### PR TITLE
custom tinyman template, bootstrappy dropdowns

### DIFF
--- a/h/resources.py
+++ b/h/resources.py
@@ -92,6 +92,7 @@ templates = Bundle(
 
 # CSS specific to the application
 app_css = Bundle(
+    Bundle('deform_bootstrap:static/deform_bootstrap.css'),
     Bundle(
         'h:sass/app.scss',
         debug=False,

--- a/h/sass/app.scss
+++ b/h/sass/app.scss
@@ -165,29 +165,41 @@ svg { -webkit-tap-highlight-color: rgba(255, 255, 255, 0); }
 .nav a[data-target="#password-tab"] { display: none; }
 .nav .active a[data-target="#password-tab"] { display: initial; }
 
-//This class provides the more round cornered card that comes down from under things (like a sheet drying on the line?)
+.dropdown-menu {
+  @include rotateX(90deg);
+  min-width: 0;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.open {
+  & > .dropdown-menu {
+    @include rotateX(0);
+    opacity: 1;
+    pointer-events: auto;
+  }
+}
+
 .sheet {
+  padding: 1em;
+  position: absolute;
+  width: 100%;
+}
+
+.sheet, .dropdown-menu {
   @include border-radius(0 0 .5em .5em);
   @include box-shadow(5px 5px 40px hsla(0, 0%, 0%, .1));
   @include single-transition(all, .4s, ease-in-out);
   @include transform-origin(50%, 0);
   background: white;
   border: solid 1px $grayLighter;
-  margin-top: 2.5em;
-  padding: 1em;
+  margin-top: 2em;
   z-index: 4;
-  position: absolute;
-  width: 100%;
 
   &.hyp-collapsed {
     @include rotateX(90deg);
     opacity: 0;
-  }
-
-  .close {
-    position: absolute;
-    top: 1.5em;
-    right: 1em;
+    pointer-events: none;
   }
 
   div.section {
@@ -225,7 +237,6 @@ svg { -webkit-tap-highlight-color: rgba(255, 255, 255, 0); }
 
 //H BAR
 #toolbar {
-  @include clearfix;
   @include smallshadow;
   background: white;
   border: 1px solid $grayLighter;
@@ -261,6 +272,19 @@ svg { -webkit-tap-highlight-color: rgba(255, 255, 255, 0); }
   #persona {
     float: right;
     text-align: right;
+
+    span {
+      @extend .btn-link;
+    }
+
+    .dropdown-menu {
+      @include smallshadow;
+      border-top: 0;
+      margin-top: 1px;
+      padding: .5em;
+      position: absolute;
+      top: 1.4em;
+    }
   }
 }
 

--- a/h/sass/base.scss
+++ b/h/sass/base.scss
@@ -87,6 +87,7 @@ $em: 14 / 1em !default;
   border-radius: .2em;
   font-family: "Source Sans Pro", "Open Sans", sans-serif;
   font-size: 1em;
+  height: auto !important; // bootstrap override
   padding: .33em .5em;
   &:focus {
     outline: 0;
@@ -103,7 +104,7 @@ $em: 14 / 1em !default;
     inset 0 .2em 0 rgba(255, 255, 255, .2),
     0 .05em .1em rgba(0, 0, 0, .08));
   @include plainform;
-  color: black;
+  color: $gray;
   cursor: pointer;
   display: inline-block;
   padding: .4em .9em .5em;
@@ -114,7 +115,9 @@ $em: 14 / 1em !default;
   &:hover {
     @include background-image(
       linear-gradient(top, #fefefe 0%, #f4f4f4 50%, #e2e2e2 51%, #fdfdfd 100%));
+    background-position: 0;
     border-color: $grayLight $grayLight $gray;
+    color: $gray;
   }
 
   &:active {

--- a/h/sass/common.scss
+++ b/h/sass/common.scss
@@ -99,19 +99,6 @@ label {
   &:hover { color: $linkColorHover; }
 }
 
-//This is a class that generates an x mark to close things.
-.close {
-  @include icon("delete_1.png");
-  height: .9em;
-  width: .9em;
-  opacity: .6;
-  cursor: pointer;
-
-  &:hover {
-    opacity: 1;
-  }
-}
-
 .right {
   text-align: right;
 }
@@ -125,6 +112,12 @@ label {
   color: $hypothered;
 }
 
+.form-actions {
+  @include reset-box-model;
+  border-top: solid thin $grayLighter;
+  background: 0;
+}
+
 .form-horizontal {
   display: inline-block;
   .controls, .control-group, div, fieldset,
@@ -135,6 +128,8 @@ label {
     margin: .5em 0;
   }
 }
+
+.form-inline .control-group { margin-bottom: 0; }
 
 .form-vertical {
   select, textarea, input, button {
@@ -282,9 +277,11 @@ label {
 
 .nav-tabs {
   @include pie-clearfix;
-  a {
+
+  & > li > a {
     cursor: pointer;
     float: left;
+    line-height: 1;
     padding: .5em 1em;
     padding-top: .25em;
     margin-right: -.5em;
@@ -294,7 +291,7 @@ label {
     @include tabbox;
   }
 
-  .active a {
+  & > .active > a {
     @include box-shadow(none);
     color: #333;
     font-weight: bold;
@@ -456,3 +453,5 @@ label {
   margin: -4px;
   width: 225px;
 }
+
+#persona button { @extend .btn-link; }

--- a/h/schemas.py
+++ b/h/schemas.py
@@ -10,10 +10,10 @@ class PersonaSchema(pyramid_deform.CSRFSchema):
         colander.Integer(),
         widget=colander.deferred(
             lambda node, kw: deform.widget.SelectWidget(
-                values=(
-                    api.personas(kw['request']) +
-                    [(-1, 'Sign out' if kw['request'].user else 'Sign in')]
-                )
-            )
+                values=api.personas(kw['request']),
+                css_class='dropdown pull-right',
+                template='tinyman'
+            ),
         ),
+        missing=-1
     )

--- a/h/templates/app.pt
+++ b/h/templates/app.pt
@@ -7,13 +7,13 @@
           tal:repeat="href webassets(request, 'app_css') | []" />
   </head>
   <body metal:fill-slot="body">
-    <div id="toolbar">
+    <div id="toolbar" class="form-inline">
       <div class="tri"></div>
       ${structure: persona.form}
     </div>
     <div id="gutter">
       <header class="sheet">
-        <a class="close" onclick="showAuth(false)"></a>
+        <a class="close" onclick="showAuth(false)">&times;</a>
         <ul class="nav nav-tabs">
           <li><a data-target="#auth-tab"
                  data-toggle="tab">Log in</a></li>
@@ -108,7 +108,7 @@
       var setupAuth = function (cb) {
         // TODO: use less janky cookie stuff (and below)
         if (document.cookie.indexOf('auth_tkt=') != -1) {
-          $('#persona').off('change mousedown').on('change', function () {
+          $('#persona').off('change click').on('change', function () {
             $(this).submit()
           })
           if (!plugins.Auth) {
@@ -119,10 +119,14 @@
           plugins.Auth.withToken(plugins.Permissions._setAuthFromToken)
           if (cb) cb(true)
         } else {
-          $('#persona').off('change mousedown').on('mousedown', function (e) {
-            e.preventDefault()
-            $('a[data-target="#auth-tab"]').tab('show')
-            focusFirstInput('#auth-tab')
+          $('#persona span').off('click').on('click', function (e) {
+            $('.sheet .nav a[data-target]')
+              .first()
+              .tab('show')
+              .each(function () {
+                var target = $(this).data('target')
+                focusFirstInput(target)
+              })
             showAuth(true)
           })
           plugins.Permissions.setUser(null)

--- a/h/templates/deform/tinyman.pt
+++ b/h/templates/deform/tinyman.pt
@@ -1,0 +1,26 @@
+<div name="${field.name}"
+     id="${field.oid}"
+     tal:attributes="class field.widget.css_class | 'dropdown'">
+  <input name="${field.name}" type="hidden" value="-1" />
+  <span tal:condition="not len(values)">Sign in</span>
+  <a href="#" role="button" class="dropdown-toggle" data-toggle="dropdown"
+     tal:condition="len(values)">${values[0][1]}</a>
+  <ul class="dropdown-menu" role="menu">
+    <li tal:repeat="(value, description) values"
+        ><a href="#" data-value="${value}">${description}</a></li>
+    <li><a href="#" data-value="-1" name="logout"
+           tal:condition="len(values)">Sign out</a></li>
+  </ul>
+  <script type="text/javascript">
+    deform.addCallback(
+     '${field.oid}',
+     function(oid) {
+       var $field = $('#' + oid)
+       $field.find('.dropdown-menu > li').on('click', function (event) {
+         $field.find(':input').attr('value', $(event.target).data('value'))
+         $field.change()
+       })
+     }
+    )
+  </script>
+</div>


### PR DESCRIPTION
Here's one I'd like your feedback on @jtremback.

Since we already depend on the deform_bootstrap package for its bootstrap-ready deform templates I decided to bundle the bootstrap CSS into our app. I noticed that it made some things more attractive, others different, I had to override some things to get closer to what we had in places (or change the spelling of the selector to match how bootstrap addressed the same elements).

The advantage that I see is that bootstrap provides a lot of sane defaults, especially around some of the transitional effects and things that make UI fast to prototype. We can always override them later, or replace components as we good, but I wanted to have pills, tabs, etc all available. I've overridden the tabs, already, with what you had (as you'll see).

The other thing this commit does is show how to customize a deform template nicely. Deform widgets serve two roles: templating a control (or set of controls) and validating / deserializing the form input. For an example of the latter, the `CheckedPasswordWidget` will show two password fields and ensure that they match on submit, but the return value from validation has only a single password key. It's an elegant way to separate the details of how you present your form from the logical data you care about. In other words, just because you want to show someone two password fields and check them doesn't mean that your registration code actually needs two passwords, so the form schema actually only has one password field but its `Widget` can take care of the details of presentation, consumption and validation.

Here, I've taken the `SelectWidget`, since it models a list of choices, but used a custom template, `tinyman`, to show how its display can be customized and implemented using alternative DOM. In this case, I've chosen to use bootstrap's dropdown-menu features as a quick prototype (the hover action on the dropdown menu could use some tweaking to be in line with our aesthetic). I even set it up so that the form includes a hidden input with the "selected" value and clicking on any of the choices changes this value and then triggers a "change" event, just as if it had been implemented with a real select control all along.

Also, the text field glows I didn't override. I'm not sure whether I like them or not, TBH, and wanted to let you make the call.
