### PR TITLE
Added missing global switch for url replacer regexp

### DIFF
--- a/h/js/filters.coffee
+++ b/h/js/filters.coffee
@@ -2,7 +2,7 @@ class Converter extends Markdown.Converter
   constructor: ->
     super
     this.hooks.chain "postConversion", (text) ->
-      text.replace /<a href=/, "<a target=\"_blank\" href="
+      text.replace /<a href=/g, "<a target=\"_blank\" href="
 
 
 fuzzyTime = (date) ->


### PR DESCRIPTION
Hotfix for the links opening in the place of the toolbar in the case of multiple links. 
