### PR TITLE
Workaround for bogus HTML documents, as reported in #409

### DIFF
--- a/h/lib/annotator.auth.js
+++ b/h/lib/annotator.auth.js
@@ -1,12 +1,12 @@
 /*
-** Annotator 1.2.6-dev-383514e
+** Annotator 1.2.6-dev-1545e1b
 ** https://github.com/okfn/annotator/
 **
 ** Copyright 2012 Aron Carroll, Rufus Pollock, and Nick Stenning.
 ** Dual licensed under the MIT and GPLv3 licenses.
 ** https://github.com/okfn/annotator/blob/master/LICENSE
 **
-** Built at: 2013-04-09 22:06:02Z
+** Built at: 2013-05-05 23:19:10Z
 */
 
 (function() {


### PR DESCRIPTION
Introduced manual XPath construction and evaluation to Annotator,
as a fallback for bogus HTML documents. Fixes #409
