### PR TITLE
Fix for #364

### DIFF
--- a/h/js/controllers.coffee
+++ b/h/js/controllers.coffee
@@ -171,6 +171,11 @@ class App
         delete annotator.plugins.Store
         annotator.addStore Store.options
 
+      if newValue? and annotator.ongoing_edit
+        $timeout =>
+          annotator.clickAdder()
+        , 500
+
     $scope.$watch 'frame.visible', (newValue) ->
       if newValue
         annotator.show()

--- a/h/js/host.coffee
+++ b/h/js/host.coffee
@@ -158,6 +158,10 @@ class Annotator.Host extends Annotator
           @drag.last = null
         )
 
+        .bind('adderClick', =>
+          @onAdderClick @event
+        )
+
   scanDocument: (reason = "something happened") =>
     try
       console.log "Analyzing host frame, because " + reason + "..."
@@ -264,3 +268,8 @@ class Annotator.Host extends Annotator
     @api.notify
       method: 'addToken'
       params: token
+
+  #Save the event for restarting edit
+  onAdderClick: (event) =>
+    @event = event
+    super

--- a/h/js/services.coffee
+++ b/h/js/services.coffee
@@ -42,6 +42,7 @@ class Hypothesis extends Annotator
 
   # Internal state
   dragging: false     # * To enable dragging only when we really want to
+  ongoing_edit: false # * Is there an interrupted edit by login
 
   # Here as a noop just to make the Permissions plugin happy
   # XXX: Change me when Annotator stops assuming things about viewers
@@ -267,6 +268,10 @@ class Hypothesis extends Annotator
     ]
     this
 
+  clickAdder: =>
+    @provider.notify
+      method: 'adderClick'
+
   showEditor: (annotation) =>
     this.show()
     @element.injector().invoke [
@@ -275,6 +280,8 @@ class Hypothesis extends Annotator
         unless this.plugins.Auth? and this.plugins.Auth.haveValidToken()
           $route.current.locals.$scope.$apply ->
             $route.current.locals.$scope.$emit 'showAuth', true
+          @provider.notify method: 'onEditorHide'
+          @ongoing_edit = true
           return
 
         # Set the path
@@ -282,9 +289,11 @@ class Hypothesis extends Annotator
           id: annotation.id
           action: 'create'
         $location.path('/editor').search(search)
- 
+
         # Digest the change
         $rootScope.$digest()
+
+        @ongoing_edit = false
 
         # Push the annotation into the editor scope
         if $route.current.controller is 'EditorController'


### PR DESCRIPTION
The cause of the workflow break was that the `onAdderClick()` function in the annotator.coffee subscribes to the  `onEditorSubmit` and the `onEditorHidden` events and cleans up itself after receiving either of them.

However, when we interrupted the workflow in the `showEditor()` function in the services.coffee we haven't published any of these two events, that's why it was stucked.

But this fix does more. In that interrupted case, after login, it restarts the process by calling `onAdderClick()` function again with the same event. So the user logs in and the editor window is showed, I think this is very user-friendly.

I've checked if there is a good opportunity to restart the process inside the siderbar frame, but after login all annotations are deleted and there is not a good way to smuggle back our annotation chunk.  Restart the edit process from the start is a clean way.
