### PR TITLE
add configuration and docs for vagrant installation

### DIFF
--- a/INSTALL.Vagrant.rst
+++ b/INSTALL.Vagrant.rst
@@ -1,0 +1,70 @@
+Installing Hypothes.is with Vagrant
+######################
+
+Running Hypothes.is on a VM enables development on Windows machines, and also provides a "clean box"
+for testing dependencies.  The following instructions will use Vagrant to create and manage
+a VirtualBox Ubuntu VM with Hypothes.is and all its dependencies on it.
+
+Install Vagrant
+---------------
+
+Use your package manager of choice, e.g.::
+
+    $ sudo apt-get vagrant
+
+or download from http://vagrantup.com.
+
+
+Bookstrapping the VM
+--------------------
+
+From the home directory of the h project (this directory) ::
+
+    $ vagrant up
+    $ vagrant ssh
+
+The first command creates the VM and starts it running, the second shells you into it.
+From there, `cd /h` and follow the directions in ./INSTALL.rst.   That's it.
+
+Notes on Using the VM
+---------------------
+
+* The vagrant commands are very simple: `vagrant up`, `vagrant ssh`, `vagrant halt`, `vagrant destroy`
+  and a few others.  `vagrant help` for explanations.
+  
+* This vagrant configuration forwards port 5000 from the guest to the host.  This means that from your
+  host machine (and from outside), "http://<hostname>:5000" will be routed to the h server on the VM.
+
+* All the configuration is contained in `./Vagrantfile`.  In particular the exact set of software
+  dependencies are encoded there, so `./Vagrantfile` will need to be updated if those change.
+
+
+VM State
+--------
+
+VM state is normally preserved across runs (e.g. `vagrant halt` followed by `vagrant run`).
+This includes the h server state (the annotation database), installed software, etc.  
+
+In addition, the h directory (this directory) is mirrored on the VM (at `/h`).  Changes can be made to the directory
+either on the host or the guest.  For example, you can edit code and invoke git while on the VM.
+
+The command `vagrant destroy` destroys the current VM and its corresponding state, but does
+not affect this directory.
+
+The configuration
+process is run each time the VM is brought up; if this gets annoying, it is possible to make a snapshot
+of the VM and use that instead.
+
+
+Notes for Windows Development
+-----------------------------
+
+If you are working with a Windows host, you want the shared directory to use Unix line endings.
+Do that by configuring this git repository as follows::
+
+    $ git config core.eol lf
+    $ git config core.autocrlf input
+
+You will probably also need to `git reset --hard` to re-extract all files with approproate line endings.
+Do this *before* proceeding with bootstrapping.
+

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,44 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+#
+# This vagrant file will create a Ubuntu LTS VM with the H package and dependencies installed and the server
+# started and bridged to localhost:8080.
+#
+# Relevant commands (performed from this directory):
+#
+#    $vagrant up        # start the VM
+#    $vagrant ssh       # shell into the VM
+#    $vagrant halt      # bring the VM down, preserving state
+#    $vagrant destroy   # destroy the VM (and any changed state)
+#
+# See vagrantup.com for more details on vagrant
+# See the INSTALL files for an explanation of what is happening below.
+
+# Elasticsearch version.
+# Note that vagrant destroy is required to get elasticsearch to be re-downloaded
+$elversion="elasticsearch-0.20.6"
+
+$script = <<SCRIPT
+  apt-get update -qq
+  apt-get -y install python-{dev,pip,virtualenv,software-properties} git libpq-dev openjdk-7-jre
+  add-apt-repository ppa:chris-lea/node.js
+  apt-get update -qq
+  apt-get -y install nodejs
+  npm --quiet install --global coffee-script uglify-js
+  gem install -y sass compass
+  if test ! -s #{$elversion}.deb; then
+    wget -q https://download.elasticsearch.org/elasticsearch/elasticsearch/#{$elversion}.deb
+    dpkg -i #{$elversion}.deb
+  fi
+SCRIPT
+
+
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "precise32"
+  config.vm.box_url = "http://files.vagrantup.com/precise32.box"
+  config.vm.network :forwarded_port, guest: 80, host: 8080   # general purpose
+  config.vm.network :forwarded_port, guest: 5000, host: 5000 # h server
+  config.vm.synced_folder ".", "/h"
+  config.vm.provision :shell, :inline=>$script
+end


### PR DESCRIPTION
Adding vagrant support for dev environment in the simplest way possible, with
configuration that mirrors the installation instructions directly.
