### PR TITLE
Immediately render the list of visible annotations when the side panel is opened

### DIFF
--- a/h/js/host.coffee
+++ b/h/js/host.coffee
@@ -89,6 +89,7 @@ class Annotator.Host extends Annotator
           @frame.css 'margin-left': "#{-1 * @frame.width()}px"
           @frame.removeClass 'annotator-no-transition'
           @frame.removeClass 'annotator-collapsed'
+          @panel?.notify method: 'publish', params: 'hostUpdated'
         )
 
         .bind('hideFrame', =>


### PR DESCRIPTION
Previously, when the side panel was opened, the list of visible annotations was not displayed until the user scrolled or resized the page, making it seem as if no annotations were present (#464). To fix, this patch triggers the `hostUpdated` event in the callback for the `showFrame` event on the `panel` object.

This has the desired effect, and just mimics an identical call used further down in the class in the `updateFrame` helper function inside of the `_setupDocumentEvents` method. I'm not completely confident about the semantics of this code - is this a good solution, or is there a cleaner way of doing it, perhaps tied in with the document/window event bindings down in `_setupDocumentEvents`?
