### PR TITLE
Fixed github issues 478 and 476.

### DIFF
--- a/h/templates/annotation.html
+++ b/h/templates/annotation.html
@@ -91,7 +91,7 @@
   <!-- Share dialog -->
   <div class="share-dialog" data-ng-show="!editing">
     <div class="icon-input">
-      <input class="share-text" type="text" ng-model="shared_link" readonly/>
+      <input class="share-text" ng-blur="toggle()" type="text" ng-model="shared_link" readonly/>
     </div>
   </div>
 


### PR DESCRIPTION
Fixed issues 478 and 476. I went for the simple fix of commenting out the "more" button and adding edit and delete buttons. 

Now it looks like this:
![newannotationmenu](https://f.cloud.github.com/assets/521978/763133/701894e6-e7f8-11e2-9bae-405b7c5a71ed.jpg)
