### PR TITLE
Modify standalone page so that highligh-only annotations look better 

### DIFF
--- a/h/templates/displayer.pt
+++ b/h/templates/displayer.pt
@@ -29,7 +29,8 @@
 
         <div class="page">
           <strong>
-            <a ng-href="">{{annotation.user | userName}}</a> annotated:
+            <a ng-href="">{{annotation.user | userName}}</a>
+            {{annotation.text && "annotated" || "highlighted"}}:
           </strong>
           <div class="domain">
             <img class="favicon" ng-src="{{root.favicon_link}}"/>


### PR DESCRIPTION
Here are the pictures.

When there is body (with or without replies), there is no change.

Before:
![before_body](https://f.cloud.github.com/assets/2093792/785690/5ddde0a2-ea8b-11e2-81e6-721ee7c312ff.png)
After:
![after_body](https://f.cloud.github.com/assets/2093792/785691/6595037a-ea8b-11e2-88f3-b15421333f2c.png)

Before:
![before_body_replies](https://f.cloud.github.com/assets/2093792/785692/6ac53a7c-ea8b-11e2-9e2a-a042517a5910.png)
After:
![after_body_reply](https://f.cloud.github.com/assets/2093792/785696/711ee33c-ea8b-11e2-85d1-14b90d0abc68.png)

If there is no body, but there are replies, this is what happens:

Before:
![before_replies](https://f.cloud.github.com/assets/2093792/785698/8749fc28-ea8b-11e2-86f9-973345de0d56.png)
After:
![after_reply](https://f.cloud.github.com/assets/2093792/785699/8eea3934-ea8b-11e2-8961-05380cb26868.png)

The only change is that the name of the annotator is not repeated. (Since he did not add any content.)

And finally, if we have highlight-only annotations (ie. neither body, nor replies):

Before:
![before_quote_only](https://f.cloud.github.com/assets/2093792/785705/b919c698-ea8b-11e2-894f-e49cf2c5c228.png)
After:
![after_quote_only](https://f.cloud.github.com/assets/2093792/785706/bec34a88-ea8b-11e2-86a3-d942bd61255f.png)

In my opinion, this last version looks better.
(That was the whole point.)
