### PR TITLE
Reduced space between annotation cards.

### DIFF
--- a/h/css/common.scss
+++ b/h/css/common.scss
@@ -874,7 +874,7 @@ blockquote {
 }
 
 .stream-list {
-  margin-bottom: 1.5em; 
+  margin-bottom: .75em; 
 }
 
 


### PR DESCRIPTION
Reduced space between annotation cards by 1/2. This is solves [issue 493](https://github.com/hypothesis/h/issues/493) and looks much nicer.
