### PR TITLE
CSS clean up: replace gray-tags with descendant selectors.

### DIFF
--- a/h/css/common.scss
+++ b/h/css/common.scss
@@ -1063,7 +1063,7 @@ pre {outline: 1px solid #ccc; padding: 5px; margin: 5px; }
   }
 
   &[readonly] {
-    input, .tagit-close { display: none; }
+    .tagit-new, .tagit-close { display: none; }
     li { padding-right: .3em; }
   }
 }
@@ -1074,13 +1074,25 @@ pre {outline: 1px solid #ccc; padding: 5px; margin: 5px; }
   overflow: hidden;
 }
 
-// Specific rules for tags on the displayer page
-.gray-tags .tags {
-  // Make tags white (on gray bg)
-  li { background: white; }
-
-  // Don't show the stub of the editor
-  li.tagit-new { display: none; }
+// Background colors for tags, depending on environment
+body {
+  // By default, body bg is gray, so we go white
+  .tags li { background: white; }
+  .paper { // If we use a paper, then it's white, so we go gray
+    .tags li { background: #e6e6e6; }
+    .noise {
+      .tags li { background: white; }
+      .paper {
+        .tags li { background: #e6e6e6; }
+        .noise {
+          .tags li { background: white; }
+          .paper {
+            .tags li { background: #e6e6e6; }
+          }
+        }
+      }
+    }
+  }
 }
 
 h3.tagstream, h3.userstream {

--- a/h/templates/displayer.pt
+++ b/h/templates/displayer.pt
@@ -135,7 +135,7 @@
             </div>
           </div>
 
-          <div class="yui3-u-1 gray-tags">
+          <div class="yui3-u-1">
             <ul ng-model="annotation.tags"
                 ng-readonly="true"
                 name="annotator.tags"

--- a/h/templates/tagstream.pt
+++ b/h/templates/tagstream.pt
@@ -79,7 +79,7 @@
                     </div>
                   </div>
                 </div>
-                <div class="yui3-u-1 gray-tags">
+                <div class="yui3-u-1">
                   <ul ng-model="annotation.tags"
                       ng-readonly="true"
                       name="reply.tags"

--- a/h/templates/userstream.pt
+++ b/h/templates/userstream.pt
@@ -79,7 +79,7 @@
                     </div>
                   </div>
                 </div>
-                <div class="yui3-u-1 gray-tags">
+                <div class="yui3-u-1">
                   <ul ng-model="annotation.tags"
                       ng-readonly="true"
                       name="reply.tags"


### PR DESCRIPTION
Some bg: According to our CSS, body and .noise are gray,
and .paper is white. Therefore, on .noise, we want white tags,
but on .paper, we want gray tags.

To make things more interesting, .noise and .paper like to
be nested in each other, alternating the bg color ad nauseam.
Therefore I could come up with a proper descendant selector
expression (not even using the :not pseode-selector), so
I have just hard-wired the first 6 levels of recursion.

Feel free to improve.

---

Anyway, the templates are now clear; no special marking classes
are necessary for configuring tags.
