### PR TITLE
Kill vertical bar left of username

### DIFF
--- a/h/templates/app.pt
+++ b/h/templates/app.pt
@@ -42,7 +42,6 @@
           <li class="controlbarbutton"><a class="alwaysonhighlights-icon" href=""></a></li>
           <li class="controlbarbutton"><a class="hightlighter-icon" href=""></a></li>
           <li class="controlbarbutton"><a class="comment-icon" href=""></a></li>
-          <li class="controlbarbutton"><a class="settings-icon" href=""></a></li>
         </ul>
       </div>
       


### PR DESCRIPTION
Deleted a line a CSS that caused the vertical bar. I think it looks better. Resolves: [issue 553](https://github.com/hypothesis/h/issues/553)
