### PR TITLE
Use the server_name for local id authority

### DIFF
--- a/development.ini
+++ b/development.ini
@@ -97,7 +97,7 @@ webassets.manifest: False
 
 [server:main]
 use: egg:h
-host: 0.0.0.0
+host: localhost
 port: 5000
 # Uncomment this line to test SSL deployment with a dummy certificate.
 #certfile: %(here)s/host.pem

--- a/h/api/token.py
+++ b/h/api/token.py
@@ -23,7 +23,7 @@ class TokenController(views.BaseController):
         if request.user:
             parts = {
                 'username': request.user.username,
-                'provider': request.host
+                'provider': request.server_name
             }
             message['userId'] = 'acct:%(username)s@%(provider)s' % parts
 

--- a/h/js/streamfilter.coffee
+++ b/h/js/streamfilter.coffee
@@ -44,7 +44,7 @@ class ClauseParser
             value = parts[1][operator.length..]
           operator_found = true
           if field is 'user'
-            value = 'acct:' + value + '@' + window.location.hostname + ':' + window.location.port
+            value = 'acct:' + value + '@' + window.location.hostname
           break
 
       unless operator_found

--- a/h/resources.py
+++ b/h/resources.py
@@ -90,7 +90,7 @@ class AppFactory(BaseResource):
         if request.user:
             return {
                 'username': request.user.username,
-                'provider': request.host,
+                'provider': request.server_name,
             }
 
         return None


### PR DESCRIPTION
The dev server now explicitly listens on localhost. That means that
if you wish to expose this publicly you will need to set up a public-
facing proxy server, such as nginx, or create/modify a .ini file.

The Procfile still uses 0.0.0.0, which means that pyramid will fall
back to reading the HTTP Host header for the server name. In Procfile
deployments like heroku and dokku it is assumed that this header is
trusted and fixed in upstream reverse proxies.

Fixes #497.
