### PR TITLE
Quote for search/filtering

### DIFF
--- a/h/js/controllers.coffee
+++ b/h/js/controllers.coffee
@@ -763,6 +763,8 @@ class Viewer
 class Search
   this.$inject = ['$filter', '$location', '$routeParams', '$scope', 'annotator']
   constructor: ($filter, $location, $routeParams, $scope, annotator) ->
+    {provider, threading} = annotator
+
     $scope.highlighter = '<span class="search-hl-active">$&</span>'
     $scope.filter_orderBy = $filter('orderBy')
     $scope.render_order = {}
@@ -810,6 +812,15 @@ class Search
         unless next in $scope.search_filter
           result = true
       result
+
+    $scope.focus = (annotation) ->
+      if angular.isArray annotation
+        highlights = (a.$$tag for a in annotation when a?)
+      else if angular.isObject annotation
+        highlights = [annotation.$$tag]
+      else
+        highlights = []
+      provider.notify method: 'setActiveHighlights', params: highlights
 
     refresh = =>
       $scope.search_filter = $routeParams.matched

--- a/h/templates/page_search.html
+++ b/h/templates/page_search.html
@@ -3,7 +3,9 @@
   <li>
     <ul>
       <li ng-repeat="thread in threads"
-        class="stream-list summary">
+          ng-mouseenter="focus(thread.message)"
+          ng-mouseleave="focus()"
+          class="stream-list summary">
         <!-- Thread view -->
         <div data-recursive="" class="paper thread"
              ng-click="toggleCollapsed($event)"


### PR DESCRIPTION
This PR introduces the well-known detail mode toggle for the search results too. So the quote is now visible (after a toggle) and enables page search for quotes too. The hits in the quotes are highlighted too the same as for text search.

Also it fixes the missing feature of highlighting the annotation's quote when hovering the mouse pointer over an annotation card. 

This is a solution for point 1,4 and 5 for issue #617 
