### PR TITLE
When making a Highlight in HL mode, switch sidebar view

### DIFF
--- a/h/js/host.coffee
+++ b/h/js/host.coffee
@@ -329,6 +329,8 @@ class Annotator.Host extends Annotator
       # Tell the sidebar about the new annotation
       @plugins.Bridge.injectAnnotation annotation
 
+      # Switch view to show the new annotation
+      this.showViewer [ annotation ]
     else
       super event
 


### PR DESCRIPTION
... to single view, showing only the newly created highlight.

Fixes #641.
