### PR TITLE
PR: Change when the sidebar is opened - v2

### DIFF
--- a/h/js/controllers.coffee
+++ b/h/js/controllers.coffee
@@ -32,7 +32,6 @@ class App
       $location.search('id', null).replace()
       dynamicBucket = true
       annotator.showViewer()
-      annotator.show()
       heatmap.publish 'updated'
       $scope.$digest()
 
@@ -55,7 +54,7 @@ class App
               acc.push hl.data
           acc
         , []
-        annotator.showViewer annotations
+        annotator.updateViewer annotations
 
       elem.selectAll('.heatmap-pointer')
         # Creates highlights corresponding bucket when mouse is hovered
@@ -96,7 +95,6 @@ class App
             dynamicBucket = false
             $location.search({'id' : null })
             annotator.showViewer heatmap.buckets[bucket]
-            annotator.show()
             $scope.$digest()
 
     $scope.$watch 'sheet.collapsed', (newValue) ->

--- a/h/js/host.coffee
+++ b/h/js/host.coffee
@@ -294,6 +294,7 @@ class Annotator.Host extends Annotator
       width: "#{w}px"
 
   showViewer: (annotations) => @plugins.Bridge.showViewer annotations
+  updateViewer: (annotations) => @plugins.Bridge.updateViewer annotations
   showEditor: (annotation) => @plugins.Bridge.showEditor annotation
 
   checkForStartSelection: (event) =>
@@ -338,7 +339,7 @@ class Annotator.Host extends Annotator
       @plugins.Bridge.injectAnnotation annotation
 
       # Switch view to show the new annotation
-      this.showViewer [ annotation ]
+      this.updateViewer [ annotation ]
     else
       super event
 
@@ -363,9 +364,6 @@ class Annotator.Host extends Annotator
 
     # Tell sidebar to show the viewer for these annotations
     this.showViewer annotations
-
-    # Make sure the sidebar is open
-    this.showFrame()
 
   addToken: (token) =>
     @api.notify

--- a/h/js/plugin/bridge.coffee
+++ b/h/js/plugin/bridge.coffee
@@ -128,6 +128,10 @@ class Annotator.Plugin.Bridge extends Annotator.Plugin
       @annotator.showViewer (this._parse a for a in annotations)
     )
 
+    .bind('updateViewer', (ctx, annotations) =>
+      @annotator.updateViewer (this._parse a for a in annotations)
+    )
+
     .bind('injectAnnotation', (ctx, annotation) =>
       a = this._parse annotation
 
@@ -188,6 +192,12 @@ class Annotator.Plugin.Bridge extends Annotator.Plugin
   showViewer: (annotations) ->
     @channel.notify
       method: 'showViewer'
+      params: (this._format a for a in annotations)
+    this
+
+  updateViewer: (annotations) ->
+    @channel.notify
+      method: 'updateViewer'
       params: (this._format a for a in annotations)
     this
 

--- a/h/js/services.coffee
+++ b/h/js/services.coffee
@@ -260,7 +260,7 @@ class Hypothesis extends Annotator
   # Do nothing in the app frame, let the host handle it.
   setupAnnotation: (annotation) -> annotation
 
-  showViewer: (annotations=[]) =>
+  updateViewer: (annotations=[]) =>
     @element.injector().invoke [
       '$location', '$rootScope',
       ($location, $rootScope) ->
@@ -269,6 +269,10 @@ class Hypothesis extends Annotator
         $rootScope.$digest()
     ]
     this
+
+  showViewer: (annotations=[]) =>
+    this.show()
+    this.updateViewer annotations
 
   clickAdder: =>
     @provider.notify


### PR DESCRIPTION
New iteration of my solution for #649.

This does the following things:
- Introduce the publicly accessible `showFrame()` and `hideFrame()` methods to the host frame, for opening/closing the sidebar
- Introduce a new method, named `updateViewer()`, which is almost like `showViewer()`, except that it does not actually open the sidebar, only updates the content of it
- Started to use this new method (that does not open the sidebar) in the following cases:
  - A new highlight is created
  - Heatmap is updated

Unlike the previous PR (https://github.com/hypothesis/h/pull/650), this does not change the semantics of `showViewer()`.
