### PR TITLE
Killed opacity on pen adder.

### DIFF
--- a/h/css/inject.scss
+++ b/h/css/inject.scss
@@ -44,7 +44,6 @@
     border: none;
     cursor: pointer;
     height: 100%;
-    opacity: .8;
     text-indent: -999em;
     width: 100%;
     margin: 0;
@@ -60,10 +59,6 @@
 
     &:before {
       border-color: $hoverborder;
-    }
-
-    button {
-      opacity: 1;
     }
   }
 }


### PR DESCRIPTION
This gets rid of the opacity on the pen adder as requested by @dwhly. I for one think it looks nicer.
![killopacityonpenadder](https://f.cloud.github.com/assets/521978/1064584/d0aeb28c-133f-11e3-8ac1-56e9e9c678b1.jpg)
