### PR TITLE
Added link to contact page in username menu so that users could more easily submit feedback.

### DIFF
--- a/h/templates/userPicker.html
+++ b/h/templates/userPicker.html
@@ -13,6 +13,7 @@
       <li ng-repeat="option in options"
           ng-click="model = options[$index]"
           >{{option.username}}/{{option.provider}}</li>
+      <li><a href="http://hypothes.is/contact/" target="_blank">Feedback</a></li>
       <li><a href="/docs/help" target="_blank">Help</a></li>
       <li ng-click="model = null">Sign out</li>
     </ul>


### PR DESCRIPTION
Fairly straight forward. Wanted to make it as easy as possible for the user to submit feedback. Right now it links to the Wordpress [Contact us](http://hypothes.is/contact/) page.
