### PR TITLE
When trying to reply without signing in, show warning.

### DIFF
--- a/h/js/controllers.coffee
+++ b/h/js/controllers.coffee
@@ -566,7 +566,7 @@ class Annotation
     $scope.reply = ($event) ->
       $event?.stopPropagation()
       unless annotator.plugins.Auth? and annotator.plugins.Auth.haveValidToken()
-        $scope.$emit 'showAuth', true
+        $window.alert "In order to reply, you need to sign in."
         return
 
       references =


### PR DESCRIPTION
Ideally, when a user tries to reply to an annotation without logging in first,
we should have him log in, and the open the editor for the reply.

Unfortunately, this does not work yet, so as a quick workaround, we simply tell him to do so.

Closes #364.
