### PR TITLE
Bridge: don't skip old data in the 'loadAnnotations' notifications

### DIFF
--- a/h/js/plugin/bridge.coffee
+++ b/h/js/plugin/bridge.coffee
@@ -145,6 +145,9 @@ class Annotator.Plugin.Bridge extends Annotator.Plugin
 
     ## Notifications
     .bind('loadAnnotations', (txn, annotations) =>
+      # First, parse the existing ones, for any updates
+      this._parse a for a in annotations when @cache[a.tag]
+      # Then collect the new ones
       annotations = (this._parse a for a in annotations when not @cache[a.tag])
       @annotator.loadAnnotations annotations
     )
@@ -268,7 +271,7 @@ class Annotator.Plugin.Bridge extends Annotator.Plugin
   annotationsLoaded: (annotations) =>
     this._notify
       method: 'loadAnnotations'
-      params: (this._format a for a in annotations when not a.$$tag?)
+      params: (this._format a for a in annotations)
     this
 
   beforeCreateAnnotation: (annotation, cb) ->


### PR DESCRIPTION
Earlier when a 'loadAnnotations' notification was sent on the bridge plugin,
- Only locally created annotations were included; annotations with
  existing bridge tags were never sent. This was true even if the
  'annotationsLoaded` event (which we are reacting to) contained such
  annotations.
- On the receiving end, existing annotations were dropped without being
  parsed.

This made it impossible to propagate data via this notification.
However, when we do the actual anchoring in the host document, we are
trying to use this notification to spread the data which become available
as the result of the anchoring; for example, the visual diffs.

To fix this, I have made the following changes:
- All annotations (coming from the 'annotationsLoaded' event are sent
  with the notifications
- On the receiving end, all annotations are parsed, so that the updates
  in various fields can be merged in. Of course the already existing
  annotations are not included in the subsequent `loadAnnotations()` call.

This fixes #807.
