### PR TITLE
Made font on heatmap-pointer tabs slightly smaller at the request of @dwhly

### DIFF
--- a/h/css/inject.scss
+++ b/h/css/inject.scss
@@ -113,12 +113,12 @@ $baseFontSize: 14px;
     background: none;
     font-weight: bold;
     font-family: $sansFontFamily;
-    font-size: 13px;
+    font-size: 11px;
     line-height: 17.5px;
     left: 5px;
     right: 2px;
     position: absolute;
-    bottom: 1px;
+    bottom: 2px;
   }
 
   &:hover {


### PR DESCRIPTION
They now look like this. : )

![smallerfontontabs](https://f.cloud.github.com/assets/521978/1394595/106518e8-3c2c-11e3-83a2-5de9f7007831.jpg)
