### PR TITLE
If sidebar is closed, display flash messages in the host frame

### DIFF
--- a/h/css/base.scss
+++ b/h/css/base.scss
@@ -218,3 +218,45 @@ $input-border-radius: 2px;
 .dark-noise {
   background: url("../images/dark_noise_1.png");
 }
+
+//FLASH/TOAST/ALERTS///////////////////////////////
+.annotator-notice {
+  @include border-radius(.1em);
+  @include smallshadow;
+  @include single-transition(opacity, .2s);
+  padding: .3em;
+  font-family: $sansFontFamily;
+  border: solid 1px;
+  bottom: 18%;
+  left: 50%;
+  margin-left: -15%;
+  opacity: 0;
+  pointer-events: none;
+  position: fixed;
+  text-align: center;
+  width: 30%;
+  z-index: 2000;
+
+  &.show, &.annotator-notice-show {
+    opacity: .8;
+    pointer-events: initial;
+  }
+}
+
+.annotator-notice-info {
+  color: #3a87ad;
+  background-color: #d9edf7;
+  border-color: #98BED1;
+}
+
+.annotator-notice-success {
+  color: #468847;
+  background-color: #dff0d8;
+  border-color: #8DC98E;
+}
+
+.annotator-notice-error {
+  color: #b94a48;
+  background-color: #f2dede;
+  border-color: #F5A1A0;
+}

--- a/h/css/common.scss
+++ b/h/css/common.scss
@@ -172,48 +172,6 @@ button, input[type=submit], .btn {
 
 }
 
-//FLASH/TOAST/ALERTS///////////////////////////////
-.toast, .annotator-notice {
-  @include border-radius(.1em);
-  @include smallshadow;
-  @include single-transition(opacity, .2s);
-  padding: .3em;
-  font-family: $sansFontFamily;
-  border: solid 1px;
-  bottom: 18%;
-  left: 50%;
-  margin-left: -15%;
-  opacity: 0;
-  pointer-events: none;
-  position: fixed;
-  text-align: center;
-  width: 30%;
-  z-index: 2000;
-
-  &.show, &.annotator-notice-show {
-    opacity: .8;
-    pointer-events: initial;
-  }
-}
-
-.info, .annotator-notice-info {
-  color: #3a87ad;
-  background-color: #d9edf7;
-  border-color: #98BED1;
-}
-
-.success, .annotator-notice-success {
-  color: #468847;
-  background-color: #dff0d8;
-  border-color: #8DC98E;
-}
-
-.error, .annotator-notice-error {
-  color: #b94a48;
-  background-color: #f2dede;
-  border-color: #F5A1A0;
-}
-
 
 //CLOSER////////////////////////////////
 .close {

--- a/h/css/inject.scss
+++ b/h/css/inject.scss
@@ -219,11 +219,6 @@ $baseFontSize: 14px;
   box-shadow:3px 3px 4px 3px #999999;
 }
 
-.annotator-notice {
-  display: none;
-}
-
-
 // Sidebar
 .annotator-frame {
   @include reset-box-model;

--- a/h/js/controllers.coffee
+++ b/h/js/controllers.coffee
@@ -9,11 +9,11 @@ class App
 
   this.$inject = [
     '$element', '$filter', '$http', '$location', '$rootScope', '$scope', '$timeout',
-    'annotator', 'authentication', 'flash', 'streamfilter'
+    'annotator', 'authentication', 'streamfilter'
   ]
   constructor: (
     $element, $filter, $http, $location, $rootScope, $scope, $timeout
-    annotator, authentication, flash, streamfilter
+    annotator, authentication, streamfilter
   ) ->
     # Get the base URL from the base tag or the app location
     baseUrl = angular.element('head base')[0]?.href

--- a/h/js/host.coffee
+++ b/h/js/host.coffee
@@ -32,6 +32,16 @@ class Annotator.Host extends Annotator.Guest
         if @frame.hasClass 'annotator-collapsed'
           this.showFrame()
 
+    # Save this reference to the Annotator class, so it's available
+    # later, even if someone has deleted the original reference
+    @Annotator = Annotator
+
+    # Configure notification classes
+    Annotator.$.extend Annotator.Notification,
+      INFO: 'info'
+      ERROR: 'error'
+      SUCCESS: 'success'
+
   _setupXDM: (options) ->
     channel = super
 
@@ -87,6 +97,18 @@ class Annotator.Host extends Annotator.Guest
 
     .bind('updateNotificationCounter', (ctx, count) =>
       this.publish 'updateNotificationCounter', count
+    )
+
+    .bind('showNotification', (ctx, n) =>
+      @_pendingNotice = @Annotator.showNotification n.message, n.type
+    )
+
+    .bind('removeNotification', =>
+      # work around Annotator.Notification not removing classes
+      return unless @_pendingNotice?
+      for _, klass of @_pendingNotice.options.classes
+        @_pendingNotice.element.removeClass klass
+      delete @_pendingNotice
     )
 
   _setupDragEvents: ->

--- a/h/js/services.coffee
+++ b/h/js/services.coffee
@@ -67,6 +67,8 @@ class Hypothesis extends Annotator
     Gettext.prototype.parse_locale_data annotator_locale_data
     super ($document.find 'body')
 
+    window.annotator = this
+
     # Generate client ID
     buffer = new Array(16)
     uuid.v4 null, buffer, 0
@@ -355,6 +357,9 @@ class Hypothesis extends Annotator
 
   hide: =>
     @element.scope().frame.visible = false
+
+  isOpen: =>
+    @element.scope().frame.visible
 
   patch_store: ->
     $location = @element.injector().get '$location'


### PR DESCRIPTION
In sidebar:
- Save our H instance as window.annotator
- Add isOpen() method to test if the sidebar is open
- Removed unused draft dependency from controller

In host document:
- Add support for showing the flash messages
- Save the Annotator class as @Annotator
- Redefine the notification level constants in Annotator.Notification
  so that they are consistent with the ones used in the sidebar

Flash message service:
- Add workaround for duplicate "invalid uname or pw" error message,
  and also swallow the "your submission was invalid" in this case.
- When the sidebar is closed, pass the message to the host frame
  instead.

Fixes #886.

This PR obsoletes #887.
