### PR TITLE
CodeAuth plugin (user authentication functions for host side)

### DIFF
--- a/h/assets.py
+++ b/h/assets.py
@@ -87,6 +87,9 @@ annotator_bridge = Uglify(
 annotator_discovery = Uglify(
     Coffee('js/plugin/discovery.coffee', output='js/plugin/discovery.js')
 )
+annotator_codeauth = Uglify(
+    Coffee('js/plugin/codeauth.coffee', output='js/plugin/codeauth.js')
+)
 annotator_heatmap = Uglify(
     Coffee('js/plugin/heatmap.coffee', output='js/plugin/heatmap.js')
 )
@@ -280,6 +283,8 @@ inject = Bundle(
     annotator,
     annotator_bridge,
     annotator_document,
+    # Use this with caution! Consider security implications!
+    #annotator_codeauth,
     annotator_heatmap,
     annotator_toolbar,
     Uglify(

--- a/h/js/controllers.coffee
+++ b/h/js/controllers.coffee
@@ -31,6 +31,13 @@ class App
         authentication.persona = null
         authentication.token = null
 
+        if oldValue?
+          # Tell the providers that we have logged out
+          setTimeout ->
+            # TODO: call this after the annotation reloading has finished
+            for p in providers
+              p.channel.notify method: 'onLogout'
+
         # Leave Highlighting mode when logging out
         if annotator.tool is 'highlight'
           # Because of logging out, we must leave Highlighting Mode.
@@ -39,6 +46,14 @@ class App
           # change (caused by leaving Highlighting Mode) will trigger
           # a reload anyway.
           $scope.skipAuthChangeReload = true
+      else
+        if oldValue?
+          # Tell the providers that we have logged in
+          setTimeout ->
+            for p in providers
+              p.channel.notify
+                method: 'onLogin'
+                params: newValue[0]
 
     $scope.$watch 'auth.persona', (newValue, oldValue) =>
       if oldValue? and not newValue?

--- a/h/js/guest.coffee
+++ b/h/js/guest.coffee
@@ -13,6 +13,8 @@ class Annotator.Guest extends Annotator
   # Plugin configuration
   options:
     Document: {}
+    # Use this with caution! Consider security implications!
+    #CodeAuth: {}
 
   # Internal state
   comments: null
@@ -25,6 +27,10 @@ class Annotator.Guest extends Annotator
     options.noScan = true
     super
     delete @options.noScan
+
+    # Save this reference to the Annotator class, so it's available
+    # later, even if someone has deleted the original reference
+    @Annotator = Annotator
 
     # Create an array for holding the comments
     @comments = []
@@ -59,6 +65,7 @@ class Annotator.Guest extends Annotator
               event.initUIEvent "annotatorReady", false, false, window, 0
               event.annotator = this
               window.dispatchEvent event
+            , 1000
 
     # Load plugins
     for own name, opts of @options

--- a/h/js/host.coffee
+++ b/h/js/host.coffee
@@ -32,10 +32,6 @@ class Annotator.Host extends Annotator.Guest
         if @frame.hasClass 'annotator-collapsed'
           this.showFrame()
 
-    # Save this reference to the Annotator class, so it's available
-    # later, even if someone has deleted the original reference
-    @Annotator = Annotator
-
     # Configure notification classes
     Annotator.$.extend Annotator.Notification,
       INFO: 'info'

--- a/h/js/plugin/codeauth.coffee
+++ b/h/js/plugin/codeauth.coffee
@@ -1,0 +1,96 @@
+class Annotator.Plugin.CodeAuth extends Annotator.Plugin
+
+  # These actions will be axposed on @annotator
+  actions: [
+    'loginWithUsernameAndPassword'
+    'logout'
+    'getLoginStatus'
+    'registerUser'
+  ]
+
+  pluginInit: ->
+    for i in @actions
+      @annotator[i] = this[i]
+            
+    addEventListener "annotatorReady", => @annotator.panel
+      .bind('onLogin', (ctx, user) =>
+        if @_pendingLogin?
+          @_pendingLogin?.resolve()
+          delete @_pendingLogin
+        else
+          event = document.createEvent "UIEvents"
+          event.initUIEvent "annotatorLogin", false, false, window, 0
+          event.user = user
+          window.dispatchEvent event
+      )
+
+      .bind('onLoginFailed', (ctx, data) =>
+        @_pendingLogin?.reject data
+        delete @_pendingLogin
+      )
+
+      .bind('onLogout', =>
+        if @_pendingLogout?
+          @_pendingLogout.resolve()
+          delete @_pendingLogout
+        else
+          event = document.createEvent "UIEvents"
+          event.initUIEvent "annotatorLogout", false, false, window, 0
+          window.dispatchEvent event
+      )
+
+      .bind('onRegisterFailed', (ctx, data) =>
+        @_pendingRegister?.reject data
+        delete @_pendingRegister
+      )
+
+      .bind('onRegister', (ctx, user) =>
+        if @_pendingRegister?
+          @_pendingRegister?.resolve user
+          delete @_pendingRegister
+      )
+
+  # Public API to trigger a login
+  loginWithUsernameAndPassword: (username, password) =>
+    @_pendingLogin = @annotator.Annotator.$.Deferred()
+    if @annotator.panel?
+      @annotator.panel.notify method: "login", params:
+        username: username
+        password: password
+    else
+      @pendingLogin.reject "Panel connection is not yet available."
+    @_pendingLogin
+
+  # Public API to trigger a logout
+  logout: =>
+    @_pendingLogout = @annotator.Annotator.$.Deferred()
+    if @annotator.panel?
+      @annotator.panel.notify method: "logout"
+    else
+      @pendingLogout.reject "Panel connection is not yet available."
+    @_pendingLogout
+
+  # Public API to get login status
+  getLoginStatus: =>
+    result = @annotator.Annotator.$.Deferred()
+    if @annotator.panel?
+      @annotator.panel.call
+        method: "getLoginStatus"
+        success: (data) ->
+          result.resolve data
+        error: (problem) -> result.reject problem
+    else
+      result.reject "Panel connection is not yet available."
+    result
+
+  # Public API to register a user
+  registerUser: (username, email, password) =>
+    @_pendingRegister = @annotator.Annotator.$.Deferred()
+    if @annotator.panel?
+      @annotator.panel.notify method: "registerUser", params:
+        username: username
+        email: email
+        password: password
+    else
+      @pendingRegister.reject "Panel connection is not yet available."
+    @_pendingRegister

--- a/h/js/services.coffee
+++ b/h/js/services.coffee
@@ -235,6 +235,35 @@ class Hypothesis extends Annotator
       $rootScope.$apply => this.setVisibleHighlights state
     )
 
+    .bind('login', (ctx, params) =>
+      @auth.$login(params).catch (data) =>
+        for p in @providers
+          p.channel.notify
+            method: 'onLoginFailed'
+            params: data
+    )
+
+    .bind('logout', =>
+      @auth.$logout()
+    )
+
+    .bind('getLoginStatus', =>
+      @auth.persona
+    )
+
+    .bind('registerUser', (ctx, params) =>
+      @auth.$register params, (data) =>
+        for p in @providers
+          p.channel.notify
+            method: 'onRegister'
+            params: data.persona
+      , (data) =>
+        for p in @providers
+          p.channel.notify
+            method: 'onRegisterFailed'
+            params: data
+    )
+
   _setupWrapper: ->
     @wrapper = @element.find('#wrapper')
     .on 'mousewheel', (event, delta) ->


### PR DESCRIPTION
If you load this plugin (which is disabled by default), these methods
can be used for integrating H login mechanism with code living
on the host page:
- annotator.getLoginStatus()
- annotator.loginWithUsernameAndPassword(username, password)
- annotator.logout()
- annotator.registerUser(username, email, password)

These all return promises.

Furtheremore, the following events have been introduced:
- annotatorLogin, upon successfull login
- annototorLogout, upon log out

Note: these events are _not_ fired in cases when the events were
triggered by a call from the given host/guest-side annotator instance;
use the promises to react those events. The events only happen if
these events were triggered from the sidebar, or from other host/guest
frames.

This PR obsoletes #883.
