### PR TITLE
Fixed bug where the wrong icon would show marking an annotation as private. 

### DIFF
--- a/h/css/common.scss
+++ b/h/css/common.scss
@@ -440,7 +440,7 @@ blockquote {
 }
 
 .vis-icon {
-  @include fonticon("\e602", left);
+  @include fonticon("\e001", left);
 }
 
 .highlight-icon {


### PR DESCRIPTION
Made a slight mistake in my iconwork PR. This fixes it. On private annotations the wrong icon was showing.
