### PR TITLE
viewer.html edited to use thread instead of reply_list closes #1017

### DIFF
--- a/h/js/directives.coffee
+++ b/h/js/directives.coffee
@@ -225,6 +225,12 @@ thread = ->
       scope.collapsed = !scope.collapsed
       scope.openDetails scope.annotation unless scope.collapsed
 
+    scope.repliesList = (annotation) ->
+      results = []
+      for thread in annotation.thread.children
+        results.push thread.message
+      results
+
     scope.toggleReplies = (event) ->
       event.stopPropagation()
       scope.collapseReplies = !scope.collapseReplies

--- a/h/templates/viewer.html
+++ b/h/templates/viewer.html
@@ -42,7 +42,7 @@
             <li class="thread"
                 ng-class="collapsed && 'collapsedreplies' || ''"
                 ng-click="toggleCollapsed($event)"
-                ng-repeat="annotation in annotation.reply_list"
+                ng-repeat="annotation in repliesList(annotation)"
                 ng-transclude
                 />
           </ul>


### PR DESCRIPTION
This may not be optimal code, as I added a repliesList function to directives
that returns messages from the thread.children array.  The other
solution I could think of would be less elegant, but also less
time-complex.  This would be to simply set the variable annotation
to hold the message property (e.g. {{annotation = annotation.message}}).
