### PR TITLE
Deleted line that caused the sign in section of the topbar to be abnormally large

### DIFF
--- a/h/css/common.scss
+++ b/h/css/common.scss
@@ -585,7 +585,6 @@ blockquote {
   border: solid 1px $grayLighter;
   border-style: solid none;
   height: 30px;
-  font-size: 1.3em;
   line-height: 28px;
   position: fixed;
   left: 0;


### PR DESCRIPTION
Live on https://develop.dokku.hypothes.is/ click sign in and you'll see all the tabs are crowded like this:
![hypothesis](https://f.cloud.github.com/assets/521978/2285984/a04cdc08-9fdb-11e3-9b12-e201119ab8d6.jpg)

The font-size is set too large, I deleted the line that caused this and everything is back to it's normal size. 
