### PR TITLE
Email notifier code improvements

### DIFF
--- a/h/templates/emails/custom_search_subject.txt
+++ b/h/templates/emails/custom_search_subject.txt
@@ -1,0 +1,1 @@
+New annotation for your query: ${document_title} (${document_path})

--- a/h/templates/emails/reply_notification_subject.txt
+++ b/h/templates/emails/reply_notification_subject.txt
@@ -1,0 +1,1 @@
+A reply to you at: ${document_title} (${document_path})


### PR DESCRIPTION
These improvements were introduced during implementing the document owner email notifications feature. So I decided to move all these improvements into a small separate PR here.

The email notifier was already using email templates for various types of email notifications but these templates had redundancies and the subject field was not generated from a txt chameleon template.

Now, the following improvements has been done:
- NotificationTemplate class is a common superclass for all our current- and future email templates.
- ReplyTemplate, and CustomSearchTemplate classes are inherited from the NotificationTemplate, thus becoming shorter
- The subject fields are also txt templates (before that they were generated from the code)
- Import ordering has been fixes for style
