### PR TITLE
Add uri analyzer for our uri field

### DIFF
--- a/h/models.py
+++ b/h/models.py
@@ -125,7 +125,7 @@ class Annotation(annotation.Annotation):
                     'path': 'just_name',
                     'fields': {
                         'source': {'type': 'string', 'index': 'not_analyzed'},
-                        'uri': {'type': 'string', 'index': 'not_analyzed'},
+                        'uri': {'type': 'string', 'analyzer': 'uri'},
                     },
                 },
                 'selector': {
@@ -180,6 +180,10 @@ class Annotation(annotation.Annotation):
             'analyzer': {
                 'thread': {
                     'tokenizer': 'path_hierarchy'
+                },
+                'uri': {
+                    'tokenizer': 'uax_url_email',
+                    'filter': 'lowercase'
                 }
             }
         }


### PR DESCRIPTION
Since our 'uri' field was set to not_analyzed it was not available to make a case insensitive search for ES.
This solution expands our already multi-field uri to add the uri_lowercase field which is analyzed by an uax_url_email tokenizer and a lowercase filter.

After that our streaming page will use this field when searching for an uri segment.

Fixes #1028
