### PR TITLE
More minor tidy of OSX docs

### DIFF
--- a/INSTALL.OSX.rst
+++ b/INSTALL.OSX.rst
@@ -39,7 +39,20 @@ Add the tools' path to the $PATH variable:
     echo "export PATH=/usr/local/share/python:/usr/local/share/npm/bin:\$PATH" >> ~/.profile
     source ~/.profile
 
-Install Elasticsearch:
+Install Elasticsearch (Optional)
+--------------------------------
+
+`Elasticsearch
+<http://www.elasticsearch.org/>`_ is required in order to store annotations 
+locally. Take care that you install a version that meets the requirements listed 
+in `<INSTALL.rst>`_. You can check what is available via Homebrew with:
+
+.. code-block:: bash
+
+    brew info elasticsearch
+
+If an appropriate version is available then follow the instructions below, 
+otherwise get a version from `<http://www.elasticsearch.org/>`_.
 
 .. code-block:: bash
 
@@ -58,5 +71,7 @@ To launch it manually without launchctl:
 
     elasticsearch -f -D es.config=/usr/local/opt/elasticsearch/config/elasticsearch.yml
 
-After installing the above, create the virtualenv, as described in the `<INSTALL.rst>`_.
+Next Steps
+----------
 
+After installing the above, create the virtualenv, as described in `<INSTALL.rst>`_.


### PR DESCRIPTION
Changes are pretty simple. 1.0.x ES not available on homebrew at present but I figure that might catch up so didn't delete the homebrew instructions, just noted to check.

Outstanding questions are where to document the setting of es.host in the .ini files and/or whether to change default to be localhost instead of dokku. I think that leaving the default to be dokku might be helpful but then there should perhaps be a note in INSTALL.rst  (as setting is platform independent) about changing the .ini to use local ES?
