### PR TITLE
Make model creation a script and a config option

### DIFF
--- a/h/api/store.py
+++ b/h/api/store.py
@@ -143,6 +143,47 @@ def after_request(response):
     return response
 
 
+def store_from_settings(settings):
+    app = flask.Flask('annotator')  # Create the annotator-store app
+    app.register_blueprint(store.store)  # and register the store api.
+
+    if 'ELASTICSEARCH_PORT' in os.environ:
+        app.config['ELASTICSEARCH_HOST'] = 'http%s' % (
+            os.environ['ELASTICSEARCH_PORT'][3:],
+        )
+    elif 'es.host' in settings:
+        app.config['ELASTICSEARCH_HOST'] = settings['es.host']
+
+    if 'es.index' in settings:
+        app.config['ELASTICSEARCH_INDEX'] = settings['es.index']
+
+    if 'es.compatibility' in settings:
+        compat = settings['es.compatibility']
+        app.config['ELASTICSEARCH_COMPATIBILITY_MODE'] = compat
+
+    es.init_app(app)
+    return app
+
+
+def create_db(app):
+    try:
+        with app.test_request_context():
+            # pylint: disable=no-member
+            models.Annotation.create_all()
+            models.Document.create_all()
+    except socket.error:
+        raise Exception(
+            "Can not access ElasticSearch at %s! Are you sure it's running?" %
+            (app.config["ELASTICSEARCH_HOST"],)
+        )
+    except:
+        with app.test_request_context():
+            # pylint: disable=no-member
+            models.Annotation.update_settings()
+            models.Annotation.create_all()
+            models.Document.create_all()
+
+
 def includeme(config):
     """Include the annotator-store API backend via http or route embedding.
 
@@ -160,43 +201,7 @@ def includeme(config):
 
     The default is to embed the store as a route bound to "/api".
     """
-
-    app = flask.Flask('annotator')  # Create the annotator-store app
-    app.register_blueprint(store.store)  # and register the store api.
-    settings = config.get_settings()
-
-    if 'ELASTICSEARCH_PORT' in os.environ:
-        app.config['ELASTICSEARCH_HOST'] = 'http%s' % (
-            os.environ['ELASTICSEARCH_PORT'][3:],
-        )
-    elif 'es.host' in settings:
-        app.config['ELASTICSEARCH_HOST'] = settings['es.host']
-
-    if 'es.index' in settings:
-        app.config['ELASTICSEARCH_INDEX'] = settings['es.index']
-
-    if 'es.compatibility' in settings:
-        compat = settings['es.compatibility']
-        app.config['ELASTICSEARCH_COMPATIBILITY_MODE'] = compat
-
-    es.init_app(app)
-
-    try:
-        with app.test_request_context():
-            # pylint: disable=no-member
-            models.Annotation.create_all()
-            models.Document.create_all()
-    except socket.error:
-        raise Exception(
-            "Can not access ElasticSearch at %s! Are you sure it's running?" %
-            (app.config["ELASTICSEARCH_HOST"],)
-        )
-    except:
-        with app.test_request_context():
-            # pylint: disable=no-member
-            models.Annotation.update_settings()
-            models.Annotation.create_all()
-            models.Document.create_all()
+    app = store_from_settings(config.registry.settings)
 
     # Configure authentication and authorization
     app.config['AUTHZ_ON'] = True

--- a/h/script.py
+++ b/h/script.py
@@ -18,6 +18,16 @@ command = clik.App(
     opts=pserve.PServeCommand.parser.option_list[1:],
 )
 
+@command(usage='CONFIG_FILE')
+def init_db(args):
+    """Create the database models."""
+    from h.api import store
+    from pyramid import paster
+
+    settings_dict = paster.get_appsettings(args[0])
+    app = store.store_from_settings(settings_dict)
+    store.create_db(app)
+
 
 @command(usage='CONFIG_FILE')
 def assets(args, console):

--- a/tests/functional/__init__.py
+++ b/tests/functional/__init__.py
@@ -27,6 +27,7 @@ from paste.deploy.loadwsgi import appconfig
 from sqlalchemy import engine_from_config
 from sqlalchemy.orm import sessionmaker
 
+from h.api import store
 from h.models import Base, User
 
 
@@ -71,6 +72,8 @@ class SeleniumTestCase(unittest.TestCase):
         Base.metadata.bind = self.connection
         Base.metadata.create_all(self.engine)
 
+        # Create the database.
+        store.create_db(store.store_from_settings(settings))
         self._wipe()
 
     def tearDown(self):


### PR DESCRIPTION
Add command to h.scripts for creating the databases and elasticsearch indices.
There could also be a config option for doing this automatically.

Now users can run  "hypothesis init_db development.ini" to set up their local dbs.
