### PR TITLE
Overhaul horus view handling

### DIFF
--- a/h/__init__.py
+++ b/h/__init__.py
@@ -26,20 +26,6 @@ def includeme(config):
     config.include('h.streamer')
     config.include('h.views')
 
-    config.include('horus')
-
-    for name in ['login', 'logout']:
-        config.add_view('horus.views.AuthController', attr=name,
-                        renderer='h:templates/auth.pt', route_name=name)
-
-    for name in ['forgot_password', 'reset_password']:
-        config.add_view('horus.views.ForgotPasswordController', attr=name,
-                        renderer='h:templates/auth.pt', route_name=name)
-
-    for name in ['register', 'activate']:
-        config.add_view('horus.views.RegisterController', attr=name,
-                        renderer='h:templates/auth.pt', route_name=name)
-
 
 def create_app(settings):
     config = Configurator(settings=settings)

--- a/h/js/flash.coffee
+++ b/h/js/flash.coffee
@@ -44,18 +44,10 @@ flashInterceptor = ['$q', 'flash', ($q, flash) ->
     if format?.match /^application\/json/
       if data.flash?
         for q, msgs of data.flash
-          # Workaround for horus returning the same error for
-          # both the username and the password field, and thus
-          # flashing the same error message twice
-          if msgs.length is 2 and
-          msgs[0] is "Invalid username or password." and
-          msgs[1] is msgs[0]
-            msgs.pop()
-            ignoreStatus = true
           flash q, msgs
 
       if data.status is 'failure'
-        flash 'error', data.reason unless ignoreStatus
+        flash 'error', data.reason
         $q.reject(data.reason)
       else if data.status is 'okay' and data.model
         response.data = data.model


### PR DESCRIPTION
Refactor the views module to limit code exposure to horus and fix
a number of outstanding issues.
- Correct the mis-registration of all auth related horus views as
  AuthController, when they each use different controllers.
- Implement a view mapper that acts on the horus class-based form
  views to coerce the result to a dictionary. This mapper pulls most
  of the request and response munging away from the horus view logic
  overrides, which are left as simple subclasses. Page views for horus
  now fire login/logout events and work around eventray/horus#43 for
  password resets.
- Improve error reporting by showing flash messages only for colander
  errors, letting horus handle the rest. Remove corresponding hack in
  client-side flash handling.
