### PR TITLE
Update uri mapping

### DIFF
--- a/h/js/streamsearch.coffee
+++ b/h/js/streamsearch.coffee
@@ -140,7 +140,7 @@ class StreamSearch
       path: '/uri'
       exact_match: false
       case_sensitive: false
-      es_query_string: true
+      es_query_string: false
       and_or: 'or'
     since:
       formatter: (past) ->

--- a/h/models.py
+++ b/h/models.py
@@ -50,7 +50,7 @@ class Annotation(annotation.Annotation):
         'tags': {'type': 'string', 'index': 'analyzed', 'analyzer': 'lower_keyword'},
         'text': {'type': 'string'},
         'deleted': {'type': 'boolean'},
-        'uri': {'type': 'string', 'index': 'not_analyzed'},
+        'uri': {'type': 'string', 'index_analyzer': 'uri_index', 'search_analyzer': 'uri_search'},
         'user': {'type': 'string', 'index': 'analyzed', 'analyzer': 'lower_keyword'},
         'consumer': {'type': 'string', 'index': 'not_analyzed'},
         'target': {
@@ -60,7 +60,7 @@ class Annotation(annotation.Annotation):
                     'path': 'just_name',
                     'fields': {
                         'id': {'type': 'string', 'index': 'not_analyzed'},
-                        'uri': {'type': 'string', 'index': 'not_analyzed'},
+                        'uri': {'type': 'string', 'index_analyzer': 'uri_index', 'search_analyzer': 'uri_search'},
                     },
                 },
                 'source': {
@@ -68,7 +68,7 @@ class Annotation(annotation.Annotation):
                     'path': 'just_name',
                     'fields': {
                         'source': {'type': 'string', 'index': 'not_analyzed'},
-                        'uri': {'type': 'string', 'index': 'not_analyzed'},
+                        'uri': {'type': 'string', 'index_analyzer': 'uri_index', 'search_analyzer': 'uri_search'},
                     },
                 },
                 'selector': {
@@ -120,6 +120,21 @@ class Annotation(annotation.Annotation):
     }
     __settings__ = {
         'analysis': {
+            'filter': {
+                'uri': {
+                    'type': 'pattern_capture',
+                    'preserve_original': 1,
+                    'patterns': [
+                        '([^\\/\\?\\#\\.]+)',
+                        '((\\w+|\\d+)(?:\\.(\\w+|\\d+))*)'
+                    ]
+                },
+                'uri_stop': {
+                    'type': 'stop',
+                    'stopwords': ['.', 'http', 'http:', 'https', 'https:', 'www', '/', ':', '&', '?', '#', 'htm', 'html', 'php', 'asp',
+                                  'aspx', 'cgi']
+                }
+            },
             'analyzer': {
                 'thread': {
                     'tokenizer': 'path_hierarchy'
@@ -128,6 +143,14 @@ class Annotation(annotation.Annotation):
                     'type': 'custom',
                     'tokenizer': 'keyword',
                     'filter': 'lowercase'
+                },
+                'uri_index': {
+                    'tokenizer': 'uax_url_email',
+                    'filter': ['uri', 'lowercase', 'unique', 'uri_stop']
+                },
+                'uri_search': {
+                    'tokenizer': 'keyword',
+                    'filter': ['lowercase']
                 }
             }
         }


### PR DESCRIPTION
To move away from ES query_string, new mapping for the uri fields
should be introduced.

For the index_analyzer we use the pattern_capture filter to be
able to split the uri field to our desire. Some stop words were
added to remove the common not relevant tokens.

In a separate issue the three uri field mapping should be cleaned up, and if a regexp ace can suggest simpler regular expressions I'd gladly use them.

Fix for #1243 
