### PR TITLE
Fix mappings for tags field

### DIFF
--- a/h/models.py
+++ b/h/models.py
@@ -47,11 +47,11 @@ class Annotation(annotation.Annotation):
         'created': {'type': 'date'},
         'updated': {'type': 'date'},
         'quote': {'type': 'string'},
-        'tags': {'type': 'string', 'index_name': 'not_analyzed'},
+        'tags': {'type': 'string', 'index': 'analyzed', 'analyzer': 'lower_keyword'},
         'text': {'type': 'string'},
         'deleted': {'type': 'boolean'},
         'uri': {'type': 'string', 'index': 'not_analyzed'},
-        'user': {'type': 'string', 'index': 'analyzed', 'analyzer': 'user'},
+        'user': {'type': 'string', 'index': 'analyzed', 'analyzer': 'lower_keyword'},
         'consumer': {'type': 'string', 'index': 'not_analyzed'},
         'target': {
             'properties': {
@@ -124,7 +124,7 @@ class Annotation(annotation.Annotation):
                 'thread': {
                     'tokenizer': 'path_hierarchy'
                 },
-                'user': {
+                'lower_keyword': {
                     'type': 'custom',
                     'tokenizer': 'keyword',
                     'filter': 'lowercase'


### PR DESCRIPTION
I've opened this as a PR because this changes the ES mapping.

The tags field contained the wrong index_name: not_analyzed property
so because of this, this field was analyzed with the default analyzer
which split the search expression at hyphens.

Because we want to do case insensitive searching for this field,
the same analyzer is needed (instead of the intented not-analyzed)
as used for the user name.

Fixes #1251
