### PR TITLE
Changing user data read endpoint from /v1/profile to /v1/session/read

### DIFF
--- a/h/auth/wpd.py
+++ b/h/auth/wpd.py
@@ -19,12 +19,12 @@ def login(request):
     secret = settings['auth.wpd.client_secret']
     code = request.params.get('code')
     state = session.get('oauth_state')
-    scope = ['profile']
+    scope = ['session']
     provider = OAuth2Session(key, scope=scope, state=state)
 
     authz_endpoint = request.route_url('auth.wpd.authorize')
     token_endpoint = request.route_url('auth.wpd.token')
-    profile_endpoint = 'https://profile.accounts.webplatform.org/v1/profile'
+    profile_endpoint = 'https://profile.accounts.webplatform.org/v1/session/read'
 
     if code is not None:
         try:


### PR DESCRIPTION
As described in an email today, I changed the profile endpoint route from /v1/profile to /v1/session/read along with a different scope string replacing 'profile' to 'session'.

Note: Its now possible to retrieve user details based on a sessionToken on accounts.webplatform.org. For implementation proposal, see: [SSO and remembering, Proposal 2](http://docs.webplatform.org/wiki/WPD:Projects/SSO/How_we_implemented_it#SSO_and_remembering.2C_proposal_2)
