### PR TITLE
Fix failing annotator login test on OSX

### DIFF
--- a/tests/functional/test_annotator.py
+++ b/tests/functional/test_annotator.py
@@ -29,8 +29,14 @@ class TestAnnotator(SeleniumTestCase):
             WebDriverWait(driver, 3).until(ec)
 
             picker = driver.find_element_by_class_name('user-picker')
-            dropdown = picker.find_element_by_class_name('dropdown-toggle')
-            assert dropdown.text == 'test/localhost'
+            user_element = picker.find_element_by_class_name('dropdown-toggle')
+
+            # Some systems (OSX) seem to set the SERVER_NAME request
+            # environment variable to 127.0.0.1 rather than localhost. This
+            # should be configurable but I haven't found the setting yet.
+            # In the mean time we just allow a range of valid values.
+            accepted_usernames = ('test/localhost', 'test/127.0.0.1')
+            assert user_element.text in accepted_usernames
 
     def test_annotation(self):
         driver = self.driver


### PR DESCRIPTION
The `SERVER_NAME` environment variable on OSX defaults to 127.0.0.1 where on other systems it's localhost. When a user is created the provider defaults to the request.server_name value, this caused the assertion to fail.

Ideally we'd be able to set the SERVER_NAME in the config for all platforms, but I was unable to find the correct config value for this. So in the mean time I'm just accepting both options as valid.

Does anyone have any idea how to modify the default server environment? I tried:

``` ini
;development.ini
[server:main]
use: egg:gunicorn
host: localhost
port: 5000
worker_class: gevent
env: SERVER_NAME=localhost
```
