### PR TITLE
Make "make clean" compatible with OSX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@ default:
 	@yes | ./bootstrap
 
 clean:
-	find h/js -iname '*.js' | xargs -r rm
-	find h/css -iname '*.css' | sed /visualsearch/d | xargs -r rm
+	find h/js  -iname '*.js' -exec rm {} \;
+	find h/css -iname '*.css' -not -iname '*visualsearch*' -exec rm {} \;
 
 test:
 	@echo -n "Checking to see if elasticsearch is running..."


### PR DESCRIPTION
Previously it used `rm -r` to skip running the command if nothing was piped in via stdin. The `-r` flag is not supported by OSX so now we just use the find command to perform the removal using `-exec`.
