### PR TITLE
Use $route.reload() instead of refresh events

### DIFF
--- a/h/js/app.coffee
+++ b/h/js/app.coffee
@@ -43,15 +43,12 @@ configure = [
       templateUrl: 'editor.html'
     $routeProvider.when '/viewer',
       controller: 'ViewerController'
-      reloadOnSearch: false
       templateUrl: 'viewer.html'
     $routeProvider.when '/page_search',
       controller: 'SearchController'
-      reloadOnSearch: false
       templateUrl: 'page_search.html'
     $routeProvider.when '/stream',
       controller: 'StreamSearchController'
-      reloadOnSearch: false
       templateUrl: 'viewer.html'
     $routeProvider.otherwise
       redirectTo: '/viewer'

--- a/h/js/controllers.coffee
+++ b/h/js/controllers.coffee
@@ -33,11 +33,11 @@ class App
     ]
 
   this.$inject = [
-    '$element', '$location', '$q', '$rootScope', '$scope', '$timeout',
+    '$element', '$location', '$q', '$rootScope', '$route', '$scope', '$timeout',
     'annotator', 'session', 'socket', 'streamfilter'
   ]
   constructor: (
-     $element,   $location,   $q,   $rootScope,   $scope,   $timeout
+     $element,   $location,   $q,   $rootScope,   $route,   $scope,   $timeout
      annotator,   session,   socket,   streamfilter
   ) ->
     {plugins, host, providers} = annotator
@@ -238,7 +238,6 @@ class App
     $scope.search = {}
     $scope.search.update = angular.noop
     $scope.search.clear = angular.noop
-    $scope.search.query = -> $scope.query
 
     $rootScope.$on '$routeChangeSuccess', (event, next, current) ->
       unless next.$$route? then return
@@ -275,7 +274,8 @@ class App
               when category == 'quote'
                 query.quote = query.quote.concat(value.split(/\s+/))
 
-          $location.path('/page_search').search(query)
+          unless angular.equals $location.search(), query
+            $location.path('/page_search').search(query)
 
         $scope.search.clear = ->
           $location.url('/viewer')
@@ -342,7 +342,7 @@ class App
           annotations = (a for a in annotations when a not in deleted)
           if annotations.length is 0
             annotator.unsubscribe 'annotationsLoaded', cleanup
-            $scope.$broadcast 'RefreshSearch'
+            $route.reload()
         , 10
       cleanup (a for a in annotations when a.thread)
       annotator.subscribe 'annotationsLoaded', cleanup
@@ -468,8 +468,8 @@ class App
               plugins.Store.annotations[index..index] = [] if index > -1
               annotator.deleteAnnotation container.message
 
-      # Refresh page_search
-      $rootScope.$broadcast 'RefreshSearch' if $location.path() is '/page_search' and data.length
+      # Refresh page search
+      $route.reload() if $location.path() is '/page_search' and data.length
 
       # Finally blink the changed tabs
       $timeout =>
@@ -792,6 +792,7 @@ class Search
     $scope.highlighter = '<span class="search-hl-active">$&</span>'
     $scope.filter_orderBy = $filter('orderBy')
     $scope.matches = []
+    $scope.search.query = $location.search()
     $scope.render_order = {}
     $scope.render_pos = {}
     $scope.ann_info =
@@ -978,7 +979,6 @@ class Search
       for thread in threads
         $rootScope.focus thread.message, true
 
-    $scope.$on 'RefreshSearch', refresh
     $scope.$on '$routeUpdate', refresh
 
     $scope.getThreadId = (id) ->

--- a/h/js/directives.coffee
+++ b/h/js/directives.coffee
@@ -415,9 +415,6 @@ visualSearch = ['$parse', ($parse) ->
           values = _values(scope)?[facet]
           callback(values or [], preserveOrder: true)
 
-    scope.$on 'VSSearch', ->
-      _search(scope, {"this": _vs.searchQuery})
-
     scope.$watch attr.query, (query) ->
       terms =
         for k, v of query

--- a/h/js/streamfilter.coffee
+++ b/h/js/streamfilter.coffee
@@ -71,15 +71,15 @@ class QueryParser
       and_or: 'and'
       operator: 'ge'
 
-  populateFilter: (filter, models) =>
-    # First cluster the different facets into categories
+  parseModels: (models) ->
+    # Cluster facets together
     categories = {}
     for searchItem in models
       category = searchItem.attributes.category
       value = searchItem.attributes.value
 
-      limit = 50
-      if category is 'results' then limit = value
+      if category is 'results'
+        categories['results'] = [value]
       else
         if category is 'text'
           # Visualsearch sickly automatically cluster the text field
@@ -90,9 +90,11 @@ class QueryParser
         else
           if category of categories then categories[category].push value
           else categories[category] = [value]
+    categories
 
-    # Now for the categories
-    for category, values of categories
+  populateFilter: (filter, query) =>
+    # Populate a filter with a query object
+    for category, values of query
       unless @rules[category]? then continue
       unless values.length then continue
       rule = @rules[category]
@@ -128,10 +130,6 @@ class QueryParser
           for val in values
             value_part = if rule.formatter then rule.formatter val else val
             filter.addClause mapped_field, oper_part, value_part, case_sensitive, rule.options
-
-    categories['results'] = [limit]
-
-    categories
 
 
 class StreamFilter

--- a/h/templates/app.pt
+++ b/h/templates/app.pt
@@ -19,7 +19,7 @@
         <div class="search-container">
           <div ng-show="show_search"
                class="visual-search visual-container"
-               query="search.query()"
+               query="search.query"
                onsearch="search.update(this)"
                facets="searchFacets"
                values="searchValues"


### PR DESCRIPTION
Rather than using extra events to trigger a round trip through the
visual search directive callbacks and query parsing, simply rely on
$location.search() at the time the route controller is instantiated
and stop using `reloadOnSearch: false` in the route definitions so
that changes to the search trigger a refresh of the view.

The QueryParser now splits `populateFilter` into `parseModels` and
`populateFilter` so that the models can be parsed when the visual
search callback fires and the filter can be populated separately
from the query string after the route reload.

Summary of improvements:
- Drop the VSSearch and RefreshSearch events.
- Make the search.query scope property a simple value instead of a
  function. This reduces the work required for the watcher and is
  possible because we no longer update the query string unless the
  query changes and the route will reload if it does.
- Clearing the stream is no longer necessary, since it starts clear
  on each route reload.
