### PR TITLE
Add and register the debugtoolbar package

### DIFF
--- a/development.ini
+++ b/development.ini
@@ -19,6 +19,7 @@ mail.default_sender: "Annotation Daemon" <no-reply@localhost>
 pyramid.debug_all: True
 pyramid.reload_templates: True
 pyramid.includes:
+    pyramid_debugtoolbar
     pyramid_deform
     pyramid_mailer
     h.testing

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setup(
         'jsonschema==1.3.0',
         'oauthlib>=0.6.1',
         'pyramid>=1.5',
+        'pyramid_debugtoolbar>=2.1',
         'pyramid-basemodel>=0.2',
         'pyramid_deform>=0.2',
         'pyramid_chameleon>=0.1',


### PR DESCRIPTION
This now renders stack traces in the browser rather than the vauge and unhelpful "Internal Server Error" message. This is a godsend when trying to debug issues with SCSS files as I couldn't get stack traces or anything logged to the console when running the development server.

The package is suggested in the Pyramid documentation[1](http://docs.pylonsproject.org/projects/pyramid/en/latest/quick_tour.html#easier-development-with-debugtoolbar).

Here's how it looks:

![debugtoolbar](https://cloud.githubusercontent.com/assets/47144/3524735/00c45c94-076c-11e4-8054-72065dfd50e2.png)

And before:

![servererror](https://cloud.githubusercontent.com/assets/47144/3524744/2ac3bd1e-076c-11e4-95f9-0dcd9c4a1591.png)
