### PR TITLE
Restore default view to 'Screen'

### DIFF
--- a/h/js/controllers.coffee
+++ b/h/js/controllers.coffee
@@ -180,7 +180,7 @@ class App
 
     $rootScope.viewState =
       sort: ''
-      view: 'Document'
+      view: 'Screen'
 
     # Show the sort/view control for a while.
     #
@@ -285,7 +285,7 @@ class App
     , 200  # We hope this is long enough
 
     $scope.reloadAnnotations = ->
-      $rootScope.applyView "Document"
+      $rootScope.applyView "Screen"
       return unless plugins.Store
       $scope.$root.annotations = []
       annotator.threading.thread []

--- a/h/js/plugin/heatmap.coffee
+++ b/h/js/plugin/heatmap.coffee
@@ -41,7 +41,7 @@ class Annotator.Plugin.Heatmap extends Annotator.Plugin
   index: []
 
   # whether to update the viewer as the window is scrolled
-  dynamicBucket: false
+  dynamicBucket: true
 
   constructor: (element, options) ->
     super $(@html), options


### PR DESCRIPTION
As a part of the fix for #1231 in commit https://github.com/hypothesis/h/commit/f66448fc3b2d1e07cbb491db73367b4b69e5f9a6
the default view was changed to 'Document' from 'Screen'
but the annotations were not loaded into the sidebar as supposed
for 'Document' view, because the `applyView()` was called before
the annotations were loaded.

Since it'd take effort to correctly implement Document view update
when the store loads new annotations, it is feasible to return
to the original 'Screen' view, which works well, because
views are planned to be refined, maybe redesigned.

Fix #1276
