### PR TITLE
Avoid updater race conditions

### DIFF
--- a/h/js/controllers.coffee
+++ b/h/js/controllers.coffee
@@ -69,7 +69,8 @@ class App
 
     session.$promise.then (data) ->
       angular.extend $scope.model, data
-      $scope.initUpdater()
+      unless data.personas?.length
+        $scope.initUpdater()
 
     # Update scope with auto-filled form field values
     $timeout ->
@@ -359,6 +360,7 @@ class App
 
       $scope.updater = socket()
       $scope.updater.onopen = ->
+        return if this isnt $scope.updater
         $scope.updater.send(JSON.stringify({filter}))
 
       $scope.updater.onclose = =>


### PR DESCRIPTION
Don't initialize the updater twice when logged in.

When the session is first loaded, only initialize the updater if there
are no logged in users in the session. If there are, the updater will
be initialized by the watcher.

Protect against duplicate initializations by ignoring onopen callbacks
that fire on a stale updater.

Fix #1307
