### PR TITLE
Fix quirks with show/hide on the search bar

### DIFF
--- a/h/static/scripts/controllers.coffee
+++ b/h/static/scripts/controllers.coffee
@@ -49,6 +49,11 @@ class App
         socialView: annotator.socialView
         ongoingHighlightSwitch: false
         model: {}
+        search:
+          facets: SEARCH_FACETS
+          values: SEARCH_VALUES
+          query: $location.search()
+          show: not angular.equals($location.search(), {})
 
     _reset()
 
@@ -114,6 +119,12 @@ class App
             $scope.reloadAnnotations()
             $scope.initUpdater()
 
+    $scope.$watch 'search.show', (visible) ->
+      if visible
+        $timeout ->
+          $element.find('.visual-search').find('input').last().focus()
+        , 10
+
     $scope.$watch 'socialView.name', (newValue, oldValue) ->
       return if newValue is oldValue
       console.log "Social View changed to '" + newValue + "'. Reloading annotations."
@@ -144,12 +155,6 @@ class App
         .first()
         .focus()
       , 10
-
-    $scope.$watch 'show_search', (value, old) ->
-      if value and not old
-        $timeout ->
-          $element.find('.visual-search').find('input').last().focus()
-        , 10
 
     $scope.$watch 'store.entities', (entities, oldEntities) ->
       return if entities is oldEntities
@@ -248,18 +253,11 @@ class App
 
     $rootScope.applySort "Location"
 
-    $scope.query = $location.search()
-    $scope.searchFacets = SEARCH_FACETS
-    $scope.searchValues = SEARCH_VALUES
-
-    $scope.search = {}
-    $scope.search.update = angular.noop
-    $scope.search.clear = angular.noop
-
-    $scope.show_search = Object.keys($scope.query).length > 0
-
     $rootScope.$on '$routeChangeSuccess', (event, next, current) ->
       unless next.$$route? then return
+
+      $scope.search.query = $location.search()
+      $scope.search.show = not angular.equals($location.search(), {})
 
       unless next.$$route.originalPath is '/stream'
         $scope.search.update = (searchCollection) ->
@@ -290,7 +288,6 @@ class App
 
         $scope.search.clear = ->
           $location.url('/viewer')
-          $scope.show_search = false
 
     $scope.reloadAnnotations = ->
       Store = plugins.Store

--- a/h/static/scripts/streamsearch.coffee
+++ b/h/static/scripts/streamsearch.coffee
@@ -61,8 +61,6 @@ class StreamSearch
       $scope.updater.then (sock) ->
         sock.send(JSON.stringify(sockmsg))
 
-    $scope.search.query = $location.search()
-
 
 angular.module('h.streamsearch', imports, configure)
 .constant('searchFacets', SEARCH_FACETS)

--- a/h/static/styles/common.scss
+++ b/h/static/styles/common.scss
@@ -782,11 +782,9 @@ pre {outline: 1px solid #ccc; padding: 5px; margin: 5px; }
 
 //Visual Search////////////////////////////////
 //Override their css here
-.search-container {
-  overflow: hidden;
-}
-
 .VS-search {
+  overflow: hidden;
+
   * {
     @include box-sizing(content-box);
   }

--- a/h/templates/app.pt
+++ b/h/templates/app.pt
@@ -16,25 +16,20 @@
         </div>
 
         <!-- Searchbar -->
-        <div class="search-container">
-          <div ng-show="show_search"
-               class="visual-search visual-container"
-               query="search.query"
-               onsearch="search.update(this)"
-               facets="searchFacets"
-               values="searchValues"
-               onclear="search.clear()"
-               ></div>
-          <div ng-hide="show_search"
-               class="visual-container"
-               ng-click="show_search = true">
-            <div class="VS-search VS-search-collapsed">
-              <div class="VS-search-box-wrapper VS-search-box">
-                <div class="VS-icon VS-icon-search"></div>
-              </div>
-            </div>
-          </div>
-        </div>
+       <div class="visual-search"
+            query="search.query"
+            facets="search.facets"
+            values="search.values"
+            onclear="search.show = false; search.clear()"
+            onsearch="search.update(this)"
+            ng-show="search.show"></div>
+       <div ng-click="search.show = true" ng-hide="search.show">
+         <div class="VS-search VS-search-collapsed">
+           <div class="VS-search-box-wrapper VS-search-box">
+             <div class="VS-icon VS-icon-search"></div>
+           </div>
+         </div>
+       </div>
       </div>
 
       <!-- Account and Authentication -->


### PR DESCRIPTION
This is a small consistency improvement which ensures that whenever the
search is cleared the input becomes invisible. Previously, this only
worked correctly on the sidebar. Now, it works everywhere, including
when navigating using the back button to get to the unfiltered stream.
