### PR TITLE
Use asset specs for all template references

### DIFF
--- a/h/templates/app.pt
+++ b/h/templates/app.pt
@@ -106,28 +106,28 @@
 
     <!-- Templates -->
     <script type="text/ng-template" id="annotation.html">
-      <metal:main use-macro="load: annotation.html" />
+      <metal:main use-macro="load: h:templates/annotation.html" />
     </script>
     <script type="text/ng-template" id="editor.html">
-      <metal:main use-macro="load: editor.html" />
+      <metal:main use-macro="load: h:templates/editor.html" />
     </script>
     <script type="text/ng-template" id="markdown.html">
-      <metal:main use-macro="load: markdown.html" />
+      <metal:main use-macro="load: h:templates/markdown.html" />
     </script>
     <script type="text/ng-template" id="privacy.html">
-      <metal:main use-macro="load: privacy.html" />
+      <metal:main use-macro="load: h:templates/privacy.html" />
     </script>
     <script type="text/ng-template" id="userPicker.html">
-      <metal:main use-macro="load: userPicker.html" />
+      <metal:main use-macro="load: h:templates/userPicker.html" />
     </script>
     <script type="text/ng-template" id="viewer.html">
-      <metal:main use-macro="load: viewer.html" />
+      <metal:main use-macro="load: h:templates/viewer.html" />
     </script>
     <script type="text/ng-template" id="page_search.html">
-      <metal:main use-macro="load: page_search.html" />
+      <metal:main use-macro="load: h:templates/page_search.html" />
     </script>
     <script type="text/ng-template" id="notification.html">
-      <metal:main use-macro="load: notification.html" />
+      <metal:main use-macro="load: h:templates/notification.html" />
     </script>
   </body>
 </html>

--- a/h/templates/auth.pt
+++ b/h/templates/auth.pt
@@ -3,7 +3,7 @@
   </head>
   <body metal:fill-slot="body" tal:omit-tag>
     <div class="content">
-      <metal:main use-macro="load: header.pt" />
+      <metal:main use-macro="load: h:templates/header.pt" />
       <div tal:condition="request.session.peek_flash()">
         <span tal:repeat="message request.session.pop_flash()" tal:omit-tag>
           ${message}<br/>

--- a/h/templates/home.pt
+++ b/h/templates/home.pt
@@ -1,13 +1,13 @@
 <html metal:use-macro="main_template">
   <head metal:fill-slot="head" tal:omit-tag>
     <script type="text/javascript" defer="defer">
-      <metal:main use-macro="load: embed.txt" />
+      <metal:main use-macro="load: h:templates/embed.txt" />
     </script>
     <title>Hypothesis</title>
   </head>
   <body metal:fill-slot="body" tal:omit-tag>
     <div id="home" class="content paper">
-      <metal:main use-macro="load: header.pt" />
+      <metal:main use-macro="load: h:templates/header.pt" />
       <p>Welcome to Hypothesis. For general information about the project, please
         visit the <a href="http://hypothes.is">home page</a> where you can
         reserve a username, sign up for our newsletter or learn how to get
@@ -26,7 +26,7 @@
         <li>Highlight any piece of text to leave an annotation of your own (try
           annotating these instructions).</li>
         <li>Use this bookmarklet to annotate any page on the Web:
-          <metal:main use-macro="load: bookmarklet.pt" /></li>
+          <metal:main use-macro="load: h:templates/bookmarklet.pt" /></li>
       </ol>
       <h2>Contributing<span class="redtext">.</span></h2>
         <p>Hypothes.is is an open source effort licensed under a 2-Clause <a href="https://en.wikipedia.org/wiki/BSD_licenses">BSD License</a>, sometimes referred to as the "Simplified BSD License" or the "FreeBSD License". Development is coordinated through <a href="https://github.com/hypothesis">our Github repository</a> utilizing the issue tracking and wiki tools provided there. Additionally, we manage a mailing list which you can subscribe to by sending an email to <a href="&#x6d;&#x61;&#x69;&#x6c;&#116;&#111;&#58;&#100;&#101;&#x76;&#x2b;&#x73;&#x75;&#x62;&#115;&#99;&#114;&#105;&#98;&#x65;&#x40;&#x6c;&#x69;&#x73;&#116;&#46;&#104;&#121;&#112;&#x6f;&#x74;&#x68;&#x65;&#x73;&#46;&#105;&#115;">&#100;&#101;&#x76;&#x2b;&#x73;&#x75;&#x62;&#115;&#99;&#114;&#105;&#98;&#x65;&#x40;&#x6c;&#x69;&#x73;&#116;&#46;&#104;&#121;&#112;&#x6f;&#x74;&#x68;&#x65;&#x73;&#46;&#105;&#115;</a> (<a href="http://list.hypothes.is/archive/dev">archive</a>).</p>

--- a/h/views.py
+++ b/h/views.py
@@ -53,11 +53,11 @@ def bad_csrf_token(context, request):
     }
 
 
-@view_config(name='embed.js', renderer='templates/embed.txt')
+@view_config(name='embed.js', renderer='h:templates/embed.txt')
 @view_config(layout='app', context='pyramid.httpexceptions.HTTPNotFound',
-             renderer='templates/app.pt')
-@view_config(renderer='templates/help.pt', route_name='help')
-@view_config(renderer='templates/home.pt', route_name='index')
+             renderer='h:templates/app.pt')
+@view_config(renderer='h:templates/help.pt', route_name='help')
+@view_config(renderer='h:templates/home.pt', route_name='index')
 def page(context, request):
     return {}
 
@@ -68,7 +68,7 @@ class AnnotationController(object):
         self.request = request
         self.Store = request.registry.getUtility(interfaces.IStoreClass)
 
-    @view_config(accept='text/html', renderer='templates/displayer.pt')
+    @view_config(accept='text/html', renderer='h:templates/displayer.pt')
     def __html__(self):
         request = self.request
         context = request.context
@@ -104,7 +104,7 @@ class AnnotationController(object):
 @view_config(
     context='h.interfaces.IStreamResource',
     layout='app',
-    renderer='templates/app.pt',
+    renderer='h:templates/app.pt',
 )
 def stream(context, request):
     stream_type = context.get('stream_type')


### PR DESCRIPTION
This makes it possible to override them using Pyramid's
`config.override_asset` API.
