### PR TITLE
Be careful syncing $location.search and queries

### DIFF
--- a/h/static/scripts/controllers.coffee
+++ b/h/static/scripts/controllers.coffee
@@ -256,9 +256,6 @@ class App
     $rootScope.$on '$routeChangeSuccess', (event, next, current) ->
       unless next.$$route? then return
 
-      $scope.search.query = $location.search()
-      $scope.search.show = not angular.equals($location.search(), {})
-
       unless next.$$route.originalPath is '/stream'
         $scope.search.update = (searchCollection) ->
           return unless annotator.discardDrafts()
@@ -813,6 +810,7 @@ class Search
     $scope.filter_orderBy = $filter('orderBy')
     $scope.matches = []
     $scope.search.query = $location.search()
+    $scope.search.show = true
     $scope.render_order = {}
     $scope.render_pos = {}
     $scope.ann_info =

--- a/h/static/scripts/streamsearch.coffee
+++ b/h/static/scripts/streamsearch.coffee
@@ -41,6 +41,9 @@ class StreamSearch
     $rootScope.applyView "Document"  # Non-sensical, but best for the moment
     $rootScope.applySort "Newest"
 
+    $scope.search.query = $location.search()
+    $scope.search.show = not angular.equals($location.search(), {})
+
     $scope.search.update = (searchCollection) ->
       # Update the query parameters
       query = queryparser.parseModels searchCollection.models


### PR DESCRIPTION
We shouldn't sync the URL bar with the search query on every route
update because some routes may have query parameters that are
irrelevant for search, such as the editor.

Instead, sync them whenever the StreamSearch or (Page)Search route
controllers initialize.

Fix #1339
