### PR TITLE
Remove the drop shadow from the highlight states

### DIFF
--- a/h/static/styles/base.scss
+++ b/h/static/styles/base.scss
@@ -59,7 +59,12 @@ $neutral: #0171ba;
 
 //OTHER VARIABLES
 $highlight-color: rgba(192, 236, 253, 0.5);
+$highlight-color-second: rgba(181, 234, 255, 0.8);
+$highlight-color-third: rgba(149, 224, 253, 0.8);
 $highlight-mode-color: rgba(255, 255, 60, 0.3);
+$highlight-mode-color-second: rgba(206, 206, 60, 0.4);
+$highlight-mode-color-third: rgba(192, 192, 49, 0.4);
+$highlight-mode-active-color: rgba(255, 255, 60, 0.7);
 $thread-padding: 1em;
 $threadexp-width: .72em;
 $score-width: 40px;

--- a/h/static/styles/inject.scss
+++ b/h/static/styles/inject.scss
@@ -205,6 +205,14 @@ $base-font-size: 14px;
 .annotator-hl-active, .annotator-hl-temporary, .annotator-hl-focused {
   background: $highlight-color;
 
+  .annotator-hl {
+    background-color: $highlight-color-second;
+  }
+
+  .annotator-hl .annotator-hl {
+    background-color: $highlight-color-third;
+  }
+
   &::-moz-selection {
     background: $highlight-color;
   }
@@ -218,11 +226,19 @@ $base-font-size: 14px;
 
 .annotator-highlights-always-on .annotator-hl {
   background: $highlight-mode-color;
+
+  .annotator-hl {
+    background-color: $highlight-mode-color-second;
+  }
+
+  .annotator-hl .annotator-hl {
+    background-color: $highlight-mode-color-third;
+  }
 }
 
 .annotator-highlights-always-on .annotator-hl-active,
 .annotator-highlights-always-on .annotator-hl-focused {
-  background-color: rgba($highlight-mode-color, 0.7)
+  background-color: $highlight-mode-active-color;
 }
 
 // Sidebar

--- a/h/templates/pattern_library.pt
+++ b/h/templates/pattern_library.pt
@@ -1,6 +1,7 @@
 <html metal:use-macro="main_template">
   <head metal:fill-slot="head" tal:omit-tag>
     <title>Hypothesis</title>
+    <link rel="stylesheet" type="text/css" href="/assets/styles/hypothesis-inject.css" />
     <style>
       body {
         background: none;
@@ -221,7 +222,7 @@
           </div>
           <div class="form-field">
             <button class="btn"><i class="icon-checkmark2 btn-icon"></i> Button with Icon Inside</button>
-          </div>  
+          </div>
           <div class="form-field">
             <button class="btn btn-clean" type="submit" name="">Button Clean</button>
           </div>
@@ -356,11 +357,35 @@
       </div>
       <div class="pattern-library-example">
         <div class="pattern-library-example-header">
+          <h1>Simple Search</h1>
+        </div>
+        <div class="pattern-library-example-content">
+          <form class="simple-search-form">
+            <input class="simple-search-input" type="text" name="searchText" placeholder="Search…" />
+            <i class="simple-search-icon icon-search"></i>
+            <button class="simple-search-clear" type="reset">
+              <i class="icon-x"></i>
+            </button>
+          </form>
+        </div>
+      </div>
+      <div class="pattern-library-example">
+        <div class="pattern-library-example-header">
+          <h1>Simple Search (inactive)</h1>
+        </div>
+        <div class="pattern-library-example-content">
+          <form class="simple-search-form simple-search-inactive" name="searchBox">
+            <input class="simple-search-input" type="text" name="searchText" placeholder="Search…" />
+            <i class="simple-search-icon icon-search"></i>
+          </form>
+        </div>
+      </div>
+      <div class="pattern-library-example">
+        <div class="pattern-library-example-header">
           <h1>Tags</h1>
         </div>
         <div class="pattern-library-example-content">
           <form class="form" action="" method="">
-            
             <label class="form-label" for="">Editable Tags</label>
             <ul ng-readonly="!editing" ng-model="model.tags" name="tags" class="tags ng-valid tagit ui-widget ui-widget-content ui-corner-all ng-dirty" placeholder="Add tags…">
               <li class="tagit-choice ui-widget-content ui-state-default ui-corner-all tagit-choice-editable">
@@ -420,27 +445,52 @@
       </div>
       <div class="pattern-library-example">
         <div class="pattern-library-example-header">
-          <h1>Simple Search</h1>
+          <h1>Focused Highlight</h1>
         </div>
         <div class="pattern-library-example-content">
-          <form class="simple-search-form">
-            <input class="simple-search-input" type="text" name="searchText" placeholder="Search…" />
-            <i class="simple-search-icon icon-search"></i>
-            <button class="simple-search-clear" type="reset">
-              <i class="icon-x"></i>
-            </button>
-          </form>
+          <p>Alice was beginning to get very tired of sitting by her sister on
+          the bank, and of <span class="annotator-hl annotator-hl-focused">having
+          nothing to do: once or twice she had peeped
+          into the book her sister was reading, but
+          <span class="annotator-hl annotator-hl-focused">it had no
+          <span class="annotator-hl annotator-hl-focused">pictures or
+          conversations</span> in it</span></span>
+          <span class="annotator-hl annotator-hl-focused">, 'and what is the use
+          of a book,' thought Alice 'without pictures or conversations?'</span></p>
         </div>
       </div>
       <div class="pattern-library-example">
         <div class="pattern-library-example-header">
-          <h1>Simple Search (inactive)</h1>
+          <h1>Always On Highlight</h1>
         </div>
         <div class="pattern-library-example-content">
-          <form class="simple-search-form simple-search-inactive" name="searchBox">
-            <input class="simple-search-input" type="text" name="searchText" placeholder="Search…" />
-            <i class="simple-search-icon icon-search"></i>
-          </form>
+          <p class="annotator-highlights-always-on">Alice was beginning to
+          get very tired of sitting by her sister on
+          the bank, and of <span class="annotator-hl">having
+          nothing to do: once or twice she had peeped
+          into the book her sister was reading, but
+          <span class="annotator-hl">it had no
+          <span class="annotator-hl">pictures or
+          conversations</span> in it</span></span>
+          <span class="annotator-hl">, 'and what is the use
+          of a book,' thought Alice 'without pictures or conversations?'</span></p>
+        </div>
+      </div>
+      <div class="pattern-library-example">
+        <div class="pattern-library-example-header">
+          <h1>Focused Always On Highlight</h1>
+        </div>
+        <div class="pattern-library-example-content">
+          <p class="annotator-highlights-always-on">Alice was beginning to
+          get very tired of sitting by her sister on
+          the bank, and of <span class="annotator-hl annotator-hl-focused">having
+          nothing to do: once or twice she had peeped
+          into the book her sister was reading, but
+          <span class="annotator-hl annotator-hl-focused">it had no
+          <span class="annotator-hl annotator-hl-focused">pictures or
+          conversations</span> in it</span></span>
+          <span class="annotator-hl annotator-hl-focused">, 'and what is the use
+          of a book,' thought Alice 'without pictures or conversations?'</span></p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
This has been bugging me since I started using the app, so I thought I'd offer some alternative styles.

![napkin 24-07-14 11 17 46 am](https://cloud.githubusercontent.com/assets/47144/3686091/86cadbee-1313-11e4-8cc8-a6eb64b3de3c.png)

I'd like to be able to do something with the outline of the highlight but I don't think this is going to be possible until we move to a less invasive highlighting method. As soon as you put shadows, borders or outlines on the spans it breaks up the text in the highlights and looks broken.

@dwhly @RawKStar77 would love your feedback on this.
