### PR TITLE
Add context predictate to view configurations

### DIFF
--- a/h/views.py
+++ b/h/views.py
@@ -50,7 +50,8 @@ def annotation(context, request):
     }
 
 
-@view_config(accept='application/json',  name='app', renderer='json')
+@view_config(context='h.resources.RootFactory',
+             accept='application/json', name='app', renderer='json')
 def app(request):
     return dict(status='okay', flash=pop_flash(request), model=model(request))
 
@@ -67,11 +68,16 @@ def bad_csrf_token(context, request):
     }
 
 
-@view_config(name='embed.js', renderer='h:templates/embed.txt')
-@view_config(layout='app', name='app.html', renderer='h:templates/app.pt')
-@view_config(layout='app', name='viewer', renderer='h:templates/app.pt')
-@view_config(layout='app', name='editor', renderer='h:templates/app.pt')
-@view_config(layout='app', name='page_search', renderer='h:templates/app.pt')
+@view_config(context='h.resources.RootFactory',
+             name='embed.js', renderer='h:templates/embed.txt')
+@view_config(layout='app', context='h.resources.RootFactory',
+             name='app.html', renderer='h:templates/app.pt')
+@view_config(layout='app', context='h.resources.RootFactory',
+             name='viewer', renderer='h:templates/app.pt')
+@view_config(layout='app', context='h.resources.RootFactory',
+             name='editor', renderer='h:templates/app.pt')
+@view_config(layout='app', context='h.resources.RootFactory',
+             name='page_search', renderer='h:templates/app.pt')
 @view_config(renderer='h:templates/help.pt', route_name='help')
 @view_config(renderer='h:templates/home.pt', route_name='index')
 def page(context, request):


### PR DESCRIPTION
Up to now things like /stream/embed.js just worked too.

Please check if none of these are actually supposed to work under some path.
Not sure if the views in auth/local/views.py need a review too.
