### PR TITLE
Fix for error states on login/logout/login

### DIFF
--- a/h/static/scripts/auth/auth.coffee
+++ b/h/static/scripts/auth/auth.coffee
@@ -79,14 +79,12 @@ authDirective = ['$timeout', ($timeout) ->
       scope.onError()
 
     scope.$on 'success', (event) ->
+      form.$setPristine()
       scope.onSuccess()
 
     scope.$on 'timeout', (event) ->
+      form.$setPristine()
       scope.onTimeout()
-
-    scope.$watch 'model', (value) ->
-      if value is null
-        form.$setPristine()
 
     scope.$watch 'tab', (name) ->
       $timeout ->

--- a/h/static/scripts/directives.coffee
+++ b/h/static/scripts/directives.coffee
@@ -1,58 +1,58 @@
-formValidate = ['$timeout', ($timeout) ->
-  link: (scope, elem, attr, form) ->
-    isSubmitted = false
+formInput = ->
+  link: (scope, elem, attr, [form, model, validator]) ->
+    return unless form?.$name and model?.$name and validator
+
     fieldClassName = 'form-field'
     errorClassName = 'form-field-error'
 
-    toggleClass = (field, {addClass}) ->
-      inputEl = elem.find("[name=#{field.$name}]")
-      fieldEl = inputEl.parents(".#{fieldClassName}").first()
-      fieldEl.toggleClass(errorClassName, addClass)
+    render = model.$render
 
-    updateField = (field) ->
-      return unless field?
+    resetResponse = (value) ->
+      model.$setValidity('response', true)
+      value
 
-      if field.$valid or field.$pristine
-        toggleClass(field, addClass: false)
-      else if field.$dirty
-        toggleClass(field, addClass: true)
+    toggleClass = (addClass) ->
+      elem.toggleClass(errorClassName, addClass)
+      elem.parent().toggleClass(errorClassName, addClass)
 
-    # A custom parser for each form field that is used to reset the "response"
-    # error state whenever the $viewValue changes.
-    fieldParser = (field, value) ->
-      field.$setValidity('response', true)
-      updateField(field) if field.$valid
-      return value
+    model.$parsers.unshift(resetResponse)
+    model.$render = ->
+      toggleClass(model.$invalid and model.$dirty)
+      render()
 
-    forEachField = (fn) ->
-      fn(field) for own _, field of form when field?.$name?
+    validator.addControl(model)
+    scope.$on '$destroy', -> validator.removeControl this
 
-    forEachField (field) ->
-      parser = angular.bind(null, fieldParser, field)
-      field.$parsers.push(parser)
+    scope.$watch ->
+      if model.$modelValue? or model.$pristine
+        model.$render()
+      return
 
-    # Validate field when the content changes.
-    elem.on 'change', ':input', ->
-      forEachField(updateField)
+  require: ['^?form', '?ngModel', '^?formValidate']
+  restrict: 'C'
 
-    # Validate form on submit and set flag for error watcher.
+
+formValidate = ->
+  controller: ->
+    controls = {}
+
+    addControl: (control) ->
+      if control.$name
+        controls[control.$name] = control
+
+    removeControl: (control) ->
+      if control.$name
+        delete controls[control.$name]
+
+    submit: ->
+      # make all the controls dirty and re-render them
+      for _, control of controls
+        control.$setViewValue(control.$viewValue)
+        control.$render()
+
+  link: (scope, elem, attr, ctrl) ->
     elem.on 'submit', ->
-      isSubmitted = true
-      forEachField (field) ->
-        field.$setViewValue(field.$viewValue)
-        updateField(field)
-
-    scope.$watch form.$name + '.$error', ->
-      if isSubmitted
-        forEachField(updateField)
-        isSubmitted = false
-    , true
-
-    scope.$watch form.$name + '.$pristine', (value) ->
-      forEachField(updateField) if value is true
-
-  require: 'form'
-]
+      ctrl.submit()
 
 
 markdown = ['$filter', '$timeout', ($filter, $timeout) ->
@@ -430,7 +430,8 @@ whenscrolled = ->
 match = ->
   link: (scope, elem, attr, input) ->
     validate = ->
-      input.$setValidity('match', scope.match == input.$modelValue)
+      scope.$evalAsync ->
+        input.$setValidity('match', scope.match == input.$modelValue)
 
     elem.on('keyup', validate)
     scope.$watch('match', validate)
@@ -441,6 +442,7 @@ match = ->
 
 
 angular.module('h.directives', ['ngSanitize'])
+.directive('formInput', formInput)
 .directive('formValidate', formValidate)
 .directive('fuzzytime', fuzzytime)
 .directive('markdown', markdown)

--- a/tests/js/auth-test.coffee
+++ b/tests/js/auth-test.coffee
@@ -131,15 +131,6 @@ describe 'h.auth', ->
       assert.isTrue $scope.login.$valid
       assert.isUndefined $scope.login.responseErrorMessage
 
-    it 'should reset to pristine state when the model is reset', ->
-      $rootScope.form.$setDirty()
-      $rootScope.$digest()
-      assert.isFalse $rootScope.form.$pristine
-
-      $scope.model = null
-      $scope.$digest()
-      assert.isTrue $rootScope.form.$pristine
-
     it 'should invoke handlers set by attributes', ->
       $rootScope.stub = sandbox.stub()
       for event in ['error', 'success', 'timeout']


### PR DESCRIPTION
@tilgovi this is one potential fix for the issue you raised on #1275. There are two issues currently with this.

1) I have a failing test, I can't seem to get to pass, it's setting up the correct state and performing the same actions as the login flow but for some reason it's not passing. Any ideas?
2) This whole error validation is falling into serious hack territory and indicates that we need to take a step back and look at how we wire up our forms across login and account management otherwise this is just going to be a persistent pain point.

https://github.com/hypothesis/h/pull/1275#issuecomment-51777983
