### PR TITLE
Remove hover state on tabs

### DIFF
--- a/h/static/styles/common.scss
+++ b/h/static/styles/common.scss
@@ -335,10 +335,6 @@ h6 {
       padding-left: .153em;
       padding-right: .153em;
       padding-bottom: .076em;
-
-      &:hover {
-        color: $link-color-hover;
-      }
     }
 
     &:active a {


### PR DESCRIPTION
Reverts 3540eab. I'm not a fan of this change, I don't think it's necessary. If everyone else disagrees then I'd rather a solution that didn't affect the active tab or conflict with the privacy toggle which uses a grey to black hover state.
