### PR TITLE
Remove display: run-in from thread indicators

### DIFF
--- a/h/static/styles/threads.scss
+++ b/h/static/styles/threads.scss
@@ -103,7 +103,6 @@ $threadexp-width: .6em;
       }
 
       .indicators {
-        display: run-in;
         margin-right: .25em;
       }
     }


### PR DESCRIPTION
This is broken in Safari and removing it doesn't appear to affect the rendering in any of the other browsers.

![screen shot 2014-08-25 at 15 47 57](https://cloud.githubusercontent.com/assets/47144/4030579/75b9e890-2c5e-11e4-8440-1b487071ba0b.png)

Note the run-in acts as `display: block` in Safari.
