### PR TITLE
Change citation text to 'on'

### DIFF
--- a/h/templates/annotation.html
+++ b/h/templates/annotation.html
@@ -24,7 +24,7 @@
       <i class="small icon-comment3"
          ng-hide="model.target.length || model.references || editing"></i>
       <span class="annotation-citation" ng-show="!editing && !embedded && document.title">
-        left an annotation on &ldquo;<a href="{{document.uri}}" target="_blank">{{document.title}}</a>&rdquo;
+         on &ldquo;<a href="{{document.uri}}" target="_blank">{{document.title}}</a>&rdquo;
         <span class="annotation-citation-domain" ng-show="document.domain != document.title">({{document.domain}})</span>
       </span>
     </span>


### PR DESCRIPTION
@dwhly and I were going over the application today and both thought the citation text _user_ "left an annotation on" _url_ was a bit wordy. We thought about shorting it to "annotated," but then decided "on" also sounded nice.

Thoughts on this? Other suggestions? Perhaps this language could be dropped all together?
