### PR TITLE
Do not put replies in the rootscope when not in document view

### DIFF
--- a/h/static/scripts/controllers.coffee
+++ b/h/static/scripts/controllers.coffee
@@ -76,7 +76,7 @@ class App
                   if annotator.isComment(annotation)
                     $rootScope.annotations.push annotation if not inRootScope(annotation)
                 else
-                    $rootScope.annotations.push annotation if not inRootScope(annotation)
+                    $rootScope.annotations.push annotation if not inRootScope(annotation) and not annotation.references?
         when 'update'
           plugins.Store._onLoadAnnotations data
 


### PR DESCRIPTION
The `applyUpdates()` (at least for now) sometimes populates the `$rootScope.annotations` to display the newly received annotation data immediately.

The error described in #1415 was coming from here, that the `$rootScope.annotations` was accidentally populated with reply annotations.

Now we do this only in Document viewstate mode, because our stream page needs this, because it can receive reply annotations whose parents do not match the search criteria but the reply itself does (i.e. search for: text:car, and the parent does not have the word car in its text)

Fix #1415
