### PR TITLE
Introduce user multifield

### DIFF
--- a/h/models.py
+++ b/h/models.py
@@ -50,7 +50,22 @@ class Annotation(annotation.Annotation):
         'text': {'type': 'string'},
         'deleted': {'type': 'boolean'},
         'uri': {'type': 'string', 'index_analyzer': 'uri_index', 'search_analyzer': 'uri_search'},
-        'user': {'type': 'string', 'index': 'analyzed', 'analyzer': 'lower_keyword'},
+        'user': {
+            'type': 'multi_field',
+            'path': 'just_name',
+            'fields': {
+                'user': {
+                    'type': 'string',
+                    'index': 'analyzed',
+                    'analyzer': 'lower_keyword'},
+                'username': {
+                    'type': 'string',
+                    'index': 'analyzed',
+                    'index_analyzer': 'username',
+                    'search_analyzer': 'lower_keyword'
+                }
+            }
+        },
         'consumer': {'type': 'string', 'index': 'not_analyzed'},
         'target': {
             'properties': {
@@ -130,6 +145,13 @@ class Annotation(annotation.Annotation):
                     ]
                 }
             },
+            'tokenizer': {
+                'username': {
+                    'type': 'pattern',
+                    'group': 1,
+                    'pattern': '^acct:(.+)@.*$'
+                }
+            },
             'analyzer': {
                 'thread': {
                     'tokenizer': 'path_hierarchy'
@@ -145,6 +167,10 @@ class Annotation(annotation.Annotation):
                 },
                 'uri_search': {
                     'tokenizer': 'keyword',
+                },
+                'username': {
+                    'tokenizer': 'username',
+                    'filter': 'lowercase'
                 }
             }
         }

--- a/h/static/scripts/searchfilters.coffee
+++ b/h/static/scripts/searchfilters.coffee
@@ -164,9 +164,7 @@ class SearchFilter
 class QueryParser
   rules:
     user:
-      formatter: (user) ->
-        'acct:' + user + '@' + window.location.hostname
-      path: '/user'
+      path: '/username'
       exact_match: true
       case_sensitive: false
       and_or: 'or'
@@ -219,13 +217,13 @@ class QueryParser
       exact_match: false
       case_sensitive: false
       and_or: 'and'
-      path:   ['/quote', '/tags', '/text', '/uri', '/user']
+      path:   ['/quote', '/tags', '/text', '/uri', '/username']
       options:
         es:
          query_type: 'multi_match'
          match_type: 'cross_fields'
          and_or: 'and'
-         fields:   ['quote', 'tag', 'text', 'uri', 'user']
+         fields:   ['quote', 'tag', 'text', 'uri', 'username']
 
 
   parseModels: (models) ->

--- a/h/streamer.py
+++ b/h/streamer.py
@@ -528,7 +528,7 @@ class StreamerSession(Session):
 def after_action(event):
     try:
         request = event.request
-        clientID = request.headers.get('X-Client-Id')
+        clientid = request.headers.get('X-Client-Id')
 
         action = event.action
         if action == 'read':
@@ -540,7 +540,7 @@ def after_action(event):
 
         manager = request.get_sockjs_manager()
         for session in manager.active_sessions():
-            if session.clientID == clientID:
+            if session.clientID == clientid:
                 continue
 
             try:
@@ -549,6 +549,10 @@ def after_action(event):
 
                 if 'references' in annotation:
                     annotation['quote'] = annotation['parent']['text']
+
+                if 'user' in annotation:
+                    username = re.match('^acct:(.+)@.*$', annotation['user'])
+                    annotation['username'] = username.group(1) if username else ''
 
                 flt = session.filter
                 if not (flt and flt.match(annotation, action)):


### PR DESCRIPTION
In the annotation.user field we store the users in the acct:username@domain format
However when we're searching for users via stream we only use the username part
and the client has to juggle to make up the domain and the backend
cannot theoretically know the domain.

So, the user field was turned into a multi-field, to reflect both usage.
annotation.user is the same as it was and
annotation.username contains only the username part.

Now the client doesn't have to construct back the whole user format.
And without this our 'any' fields searches failed for the user field

Fix #1456
Fix #1457
