### PR TITLE
Immediately refresh viewer for live-updates

### DIFF
--- a/h/static/scripts/controllers.coffee
+++ b/h/static/scripts/controllers.coffee
@@ -77,6 +77,7 @@ class App
                     $rootScope.annotations.push annotation if not inRootScope(annotation)
                 else
                     $rootScope.annotations.push annotation if not inRootScope(annotation)
+            $scope.$digest()
         when 'update'
           plugins.Store._onLoadAnnotations data
 


### PR DESCRIPTION
Our applyUpdates() puts/deletes annotations into the viewer.
But for the stream page, because there was no scope digest cycle
it seemed that the UI was reacting very slow to show the annotations.

This one-liner just creates a digest cycle in these scenarios.
The user experience is a magnitude better with this in the stream page

Fix #1455
