### PR TITLE
Add ltr direction to our top injected elements.

### DIFF
--- a/h/static/styles/base.scss
+++ b/h/static/styles/base.scss
@@ -165,6 +165,7 @@ $input-border-radius: 2px;
 .annotator-notice {
   @include box-shadow(inset 2px 1px 1px hsla(0, 0%, 0%, .1));
   @include single-transition(opacity, .2s);
+  direction: ltr;
   font-family: $sans-font-family;
   line-height: 29px;
   opacity: 0;

--- a/h/static/styles/inject.scss
+++ b/h/static/styles/inject.scss
@@ -10,6 +10,7 @@ $base-font-size: 14px;
   $border: $gray;
   $hoverborder: $gray-dark;
   @include box-sizing(border-box);
+  direction: ltr;
   height: 40px;
   margin-left: -20px;
   margin-top: -50px;
@@ -138,6 +139,7 @@ $base-font-size: 14px;
   @include reset-box-model;
   @include user-select(none);
   @extend .noise;
+  direction: ltr;
   background: none;
   font-size: $base-font-size;
   line-height: $base-line-height;
@@ -181,7 +183,6 @@ $base-font-size: 14px;
 .annotator-frame .annotator-toolbar {
   position: absolute;
   left: -($heatmap-width + 18px - 7px);
-  right: 0;
   width: 37px;
   z-index: 2;
 


### PR DESCRIPTION
Otherwise our text flow is broken at rtl pages.
Also remove a superfluous rule

Fix #1459 
