### PR TITLE
Insert missing sphinx dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ install_requires = [
     # Version pin for known bug
     # https://github.com/repoze/repoze.sendmail/issues/31
     'repoze.sendmail<4.2',
+    'sphinx==1.2.3'
 ]
 
 development_extras = ['pyramid_debugtoolbar>=2.1']


### PR DESCRIPTION
Sorry for the misleading number in the branch name.
I open this to discussion to be 100% sure, that we should put this dependency in our setup.py (and not in our requirements.txt)

Fix #1371
