### PR TITLE
Add MathJax CDN

### DIFF
--- a/assets.yaml
+++ b/assets.yaml
@@ -190,9 +190,6 @@ jwz:
   output: scripts/vendor/jwz.min.js
   contents:
     - h:static/scripts/vendor/jwz.js
-mathjax:
-  contents:
-    - https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML
 momentjs:
   contents:
     - filters: uglifyjs
@@ -256,7 +253,6 @@ app:
     - annotator_threading
     - jschannel
     - jwz
-    - mathjax
     - momentjs
     - pagedown
     - autofill

--- a/h/static/scripts/controllers.coffee
+++ b/h/static/scripts/controllers.coffee
@@ -31,6 +31,9 @@ class App
     # Resolved once the API service has been discovered.
     storeReady = $q.defer()
 
+    # Whether there is MathML or LaTex on the page to be rendered by MathJax.
+    $rootScope.math = false
+
     applyUpdates = (action, data) ->
       """Update the application with new data from the websocket."""
       return unless data?.length

--- a/h/static/scripts/directives.coffee
+++ b/h/static/scripts/directives.coffee
@@ -55,18 +55,31 @@ formValidate = ->
       ctrl.submit()
 
 
-markdown = ['$filter', '$timeout', ($filter, $timeout) ->
+markdown = ['$filter', '$timeout', '$rootScope', ($filter, $timeout, $rootScope) ->
   link: (scope, elem, attr, ctrl) ->
     return unless ctrl?
 
     input = elem.find('textarea')
     output = elem.find('div')
 
+    checkforMath = (textToCheck) ->
+      scope.mathOnPage = $rootScope.math
+      # MathJax uses "$$" in its markup.
+      regEx = /\$\$/
+      return textToCheck.search regEx
+
     # Re-render the markdown when the view needs updating.
     ctrl.$render = ->
       input.val (ctrl.$viewValue or '')
       scope.rendered = ($filter 'converter') (ctrl.$viewValue or '')
-      MathJax.Hub.Queue(['Typeset', MathJax.Hub]) unless scope.readonly
+      if checkforMath(scope.rendered) != -1
+        $rootScope.math = true
+        if !scope.mathOnPage # Check to see if that we haven't loaded MathJax already.
+          $.ajax { 
+            url:"https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"
+            dataType: 'script'
+          }
+      MathJax?.Hub.Queue(['Typeset', MathJax.Hub]) unless scope.readonly
       
     # React to the changes to the text area
     input.bind 'blur change keyup', ->


### PR DESCRIPTION
This PR adds MathJax, so we can render math written in LaTex or MathML:
![hypothesis](https://cloud.githubusercontent.com/assets/521978/4208235/51973c86-385e-11e4-8f9f-747d1d0d8426.jpg)

Give it a try on: https://mathjax.dokku.hypothes.is/ 
Note: the markup for math consists of two dollar signs: `$$LaTex or MathML here$$`

This PR is an alternative to including the very large MathJax library in our vendor folder (as implemented in https://github.com/hypothesis/h/pull/1480). 
