### PR TITLE
Prevent tag input field from changing height

### DIFF
--- a/h/static/styles/tags-input.scss
+++ b/h/static/styles/tags-input.scss
@@ -11,7 +11,7 @@ tags-input {
 
   .tags {
     @include form-input;
-    @include clearfix;
+    @include pie-clearfix;
 
     &.focused {
       @include form-input-focus;
@@ -20,17 +20,22 @@ tags-input {
     // Input
     .input {
       float: left;
-      margin-top: .2667em;
-      padding: .2em 0 .2em;
+      padding: .1333em 0;
       outline: none;
       border: none !important;
       background: none;
       color: $gray;
+
+      // Firefox and Webkit render input boxes at different heights. This
+      // causes issues when the tags (which render consistentely) are inserted
+      // and cause the height of the faux input to jump.
+      height: 1.4667em;
     }
   }
 
   .tag-list {
     margin-top: -.33em; // Absorb the first row of margin-top on the tags.
+    float: left;
   }
 
   .tag-item {


### PR DESCRIPTION
Alternative fix for #1477 and remove use of px in the tag-input module. The main differences are:
- Ensures there is spacing between tags when wrapping onto a new line.
- Retains the larger hit area for the delete tag button (its fills the entire right side of the tag).
- Retains the bold "x" for deletion to distinguish it from the tag text.
- Ensures the "x" is not selected as part of the tag text.
