### PR TITLE
Remove source map code from vendor files

### DIFF
--- a/h/static/scripts/vendor/annotator.auth.js
+++ b/h/static/scripts/vendor/annotator.auth.js
@@ -230,6 +230,3 @@
   })(Annotator.Plugin);
 
 }).call(this);
-
-//
-//# sourceMappingURL=annotator.auth.map

--- a/h/static/scripts/vendor/annotator.document.js
+++ b/h/static/scripts/vendor/annotator.document.js
@@ -295,6 +295,3 @@
   })(Annotator.Plugin);
 
 }).call(this);
-
-//
-//# sourceMappingURL=annotator.document.map

--- a/h/static/scripts/vendor/annotator.domtextmapper.js
+++ b/h/static/scripts/vendor/annotator.domtextmapper.js
@@ -50,6 +50,3 @@
   })(Annotator.Plugin);
 
 }).call(this);
-
-//
-//# sourceMappingURL=annotator.domtextmapper.map

--- a/h/static/scripts/vendor/annotator.fuzzytextanchors.js
+++ b/h/static/scripts/vendor/annotator.fuzzytextanchors.js
@@ -118,6 +118,3 @@
   })(Annotator.Plugin);
 
 }).call(this);
-
-//
-//# sourceMappingURL=annotator.fuzzytextanchors.map

--- a/h/static/scripts/vendor/annotator.js
+++ b/h/static/scripts/vendor/annotator.js
@@ -2419,6 +2419,3 @@
   });
 
 }).call(this);
-
-//
-//# sourceMappingURL=annotator.map

--- a/h/static/scripts/vendor/annotator.pdf.js
+++ b/h/static/scripts/vendor/annotator.pdf.js
@@ -216,6 +216,3 @@
   })(Annotator.Plugin);
 
 }).call(this);
-
-//
-//# sourceMappingURL=annotator.pdf.map

--- a/h/static/scripts/vendor/annotator.permissions.js
+++ b/h/static/scripts/vendor/annotator.permissions.js
@@ -220,6 +220,3 @@
   })(Annotator.Plugin);
 
 }).call(this);
-
-//
-//# sourceMappingURL=annotator.permissions.map

--- a/h/static/scripts/vendor/annotator.store.js
+++ b/h/static/scripts/vendor/annotator.store.js
@@ -298,6 +298,3 @@
   })(Annotator.Plugin);
 
 }).call(this);
-
-//
-//# sourceMappingURL=annotator.store.map

--- a/h/static/scripts/vendor/annotator.textanchors.js
+++ b/h/static/scripts/vendor/annotator.textanchors.js
@@ -129,6 +129,3 @@
   })(Annotator.Plugin);
 
 }).call(this);
-
-//
-//# sourceMappingURL=annotator.textanchors.map

--- a/h/static/scripts/vendor/annotator.texthighlights.js
+++ b/h/static/scripts/vendor/annotator.texthighlights.js
@@ -187,6 +187,3 @@
   })(Annotator.Plugin);
 
 }).call(this);
-
-//
-//# sourceMappingURL=annotator.texthighlights.map

--- a/h/static/scripts/vendor/annotator.textposition.js
+++ b/h/static/scripts/vendor/annotator.textposition.js
@@ -134,6 +134,3 @@
   })(Annotator.Plugin);
 
 }).call(this);
-
-//
-//# sourceMappingURL=annotator.textposition.map

--- a/h/static/scripts/vendor/annotator.textquote.js
+++ b/h/static/scripts/vendor/annotator.textquote.js
@@ -102,6 +102,3 @@
   })(Annotator.Plugin);
 
 }).call(this);
-
-//
-//# sourceMappingURL=annotator.textquote.map

--- a/h/static/scripts/vendor/annotator.textrange.js
+++ b/h/static/scripts/vendor/annotator.textrange.js
@@ -130,6 +130,3 @@
   })(Annotator.Plugin);
 
 }).call(this);
-
-//
-//# sourceMappingURL=annotator.textrange.map


### PR DESCRIPTION
This removes a huge dump of console warnings as the browser tries and fails to request the map files.
