### PR TITLE
Fix error when pressing delete in empty tag field

### DIFF
--- a/h/static/scripts/directives/annotation.coffee
+++ b/h/static/scripts/directives/annotation.coffee
@@ -226,8 +226,9 @@ annotation = ['$filter', '$parse', 'annotator', ($filter, $parse, annotator) ->
       scope.model.tags.push(tag.text)
 
     scope.removeTag = (tag) ->
-      scope.model.tags = scope.model.tags.filter((t) -> t isnt tag.text)
-      delete scope.model.tags if scope.model.tags.length is 0
+      if tag and scope.model.tags
+        scope.model.tags = scope.model.tags.filter((t) -> t isnt tag.text)
+        delete scope.model.tags if scope.model.tags.length is 0
 
     # Watch for changes
     scope.$watch 'model', (model) ->


### PR DESCRIPTION
Pressing backspace in the tags input still calls the removeTag handler. This results in an exception when scope.model.tags was undefined. Now we check for a tag and the tags array before updating.
