### PR TITLE
Don't read the parent when sending stream updates

### DIFF
--- a/h/streamer.py
+++ b/h/streamer.py
@@ -468,10 +468,6 @@ class StreamerSession(Session):
         for annotation in annotations:
             try:
                 annotation.update(url_values_from_document(annotation))
-                if 'references' in annotation:
-                    parent = store.read(annotation['references'][-1])
-                    if 'text' in parent:
-                        annotation['quote'] = parent['text']
                 send_annotations.append(annotation)
             except:
                 log.exception("Updating properties: %s", annotation)


### PR DESCRIPTION
There's no reason to do this. Not only is it technically incorrect
to insert the parent's text as the quote of the child (if we want
that we should be doing it when we create the child) it's also not
storing it as a target but in a top level 'quote' property.

Fix #1264
Related to #1207
