### PR TITLE
Change wording of reply count

### DIFF
--- a/h/templates/thread.html
+++ b/h/templates/thread.html
@@ -21,7 +21,7 @@
    href=""
    ng-if="!threadFilter.active() || count('message') == count('match')"
    ng-pluralize count="count('message') - 1"
-   when="{'0': '', one: '1 reply', other: '{} replies'}"></a>
+   when="{'0': '', one: '1 comment', other: '{} comments'}"></a>
 <a class="load-more small"
    href=""
    ng-click="threadFilter.active(false)"


### PR DESCRIPTION
During the design meeting @aron raised the point that additive reply counts are confusing because replies may only be a reply to the reply and not to the top level annotation.  The number is correct but we need to change the wording to not use reply/replies. 

This was discussed in the design meeting but is so trivial I decided to make a Pull Request rather than raise an issue. 

What do people think about comment/comments? It's what Reddit uses. 
