### PR TITLE
Reveal annotation actions when cursor hovers over card

### DIFF
--- a/h/static/styles/annotations.scss
+++ b/h/static/styles/annotations.scss
@@ -18,7 +18,7 @@
   &:focus { outline: 0; }
 }
 
-.annotation-header { margin-bottom: .8em }
+.annotation-header, .annotation-body { margin-bottom: .8em }
 .annotation-section { margin: .8em 0 }
 .annotation-target { margin: .8em 0 }
 .annotation-footer { margin-top: .8em }
@@ -64,6 +64,7 @@ privacy {
 //MAGICONTROL////////////////////////////////
 .magicontrol {
   margin-right: .8em;
+  opacity: 0;
 
   &, a {
     color: $gray-light;
@@ -75,6 +76,7 @@ privacy {
 
   .annotation:hover &, .annotation:hover & a {
     color: $link-color;
+    opacity: 1;
   }
 }
 

--- a/h/static/styles/threads.scss
+++ b/h/static/styles/threads.scss
@@ -99,7 +99,7 @@ $threadexp-width: .6em;
 }
 
 .thread-reply {
-  margin-top: -2.153em;
+  margin-top: -2.3077em;
   margin-bottom: .8em;
 }
 


### PR DESCRIPTION
@dwhly asked me to revert the card behaviour back to having the annotation actions revealed on hover. So here I present the changes and a dokku for discussion.

Dokku: https://hide-card-actions.dokku.hypothes.is

![screen shot 2014-09-24 at 11 53 06](https://cloud.githubusercontent.com/assets/47144/4386441/99c53a58-43d0-11e4-963b-3fd028e9794d.png)
