### PR TITLE
Squash session and profile; auth and account

### DIFF
--- a/h/static/scripts/auth/session.coffee
+++ b/h/static/scripts/auth/session.coffee
@@ -12,6 +12,7 @@ ACTION = [
   'forgot'
   'activate'
   'edit_profile'
+  'disable_user'
 ]
 
 ACTION_OPTION =
@@ -90,36 +91,8 @@ class SessionProvider
         actions[name].transformResponse = process
 
       endpoint = documentHelpers.absoluteURI('/app')
-      $resource(endpoint, {}, actions).load()
+      $resource(endpoint, {}, actions)
   ]
-
-# Function providing a server-side user profile resource.
-#
-# This function provides an angular $resource factory
-# for manipulating server-side account-profile settings. It defines the
-# actions (such as 'login', 'register') as REST-ish actions
-profileProvider = [
-  '$q', '$resource', 'documentHelpers',
-  ($q,   $resource,   documentHelpers) ->
-    defaults =
-      email: ""
-      password: ""
-
-    actions =
-      edit_profile:
-        method: 'POST'
-        params:
-          __formid__: "edit_profile"
-        withCredentials: true
-      disable_user:
-        method: 'POST'
-        params:
-          __formid__: "disable_user"
-        withCredentials: true
-
-    endpoint = documentHelpers.absoluteURI('/app')
-    $resource(endpoint, {}, actions)
-]
 
 
 configure = ['$httpProvider', ($httpProvider) ->
@@ -143,4 +116,3 @@ configure = ['$httpProvider', ($httpProvider) ->
 
 angular.module('h.session', imports, configure)
 .provider('session', SessionProvider)
-.factory('profile', profileProvider)

--- a/h/static/scripts/controllers.coffee
+++ b/h/static/scripts/controllers.coffee
@@ -246,6 +246,8 @@ class App
       # Do not rely on the identity service to invoke callbacks within an
       # angular digest cycle.
       $scope.$evalAsync ->
+        $scope.dialog.visible = false
+
         # Update any edits in progress.
         for draft in drafts.all()
           annotator.publish 'beforeAnnotationCreated', draft
@@ -308,15 +310,12 @@ class App
       $scope.updater.then (sock) ->
         sock.send(JSON.stringify(sockmsg))
 
-    $scope.authTimeout = ->
-      flash 'info',
-        'For your security, the forms have been reset due to inactivity.'
-
     $scope.clearSelection = ->
       $scope.search.query = ''
       $scope.selectedAnnotations = null
       $scope.selectedAnnotationsCount = 0
 
+    $scope.dialog = visible: false
     $scope.id = identity
 
     $scope.model = persona: undefined

--- a/h/static/scripts/controllers/account-management.coffee
+++ b/h/static/scripts/controllers/account-management.coffee
@@ -1,9 +1,7 @@
 class AccountManagement
-  @inject = ['$scope', '$rootScope', '$filter', 'flash', 'profile',
-             'identity', 'formHelpers']
+  @inject = ['$scope', '$filter', 'flash', 'session', 'identity', 'formHelpers']
 
-  constructor: ($scope, $rootScope, $filter, flash, profile,
-                identity, formHelpers) ->
+  constructor: ($scope, $filter, flash, session, identity, formHelpers) ->
     persona_filter = $filter('persona')
 
     onSuccess = (form, response) ->
@@ -42,7 +40,7 @@ class AccountManagement
       # The extension is then removed from the page.
       # Confirmation of success is given.
       return unless form.$valid
-      username = persona_filter $scope.session.userid
+      username = persona_filter $scope.persona
       packet =
         username: username
         pwd: form.pwd.$modelValue
@@ -50,7 +48,7 @@ class AccountManagement
       successHandler = angular.bind(null, onDelete, form)
       errorHandler   = angular.bind(null, onError, form)
 
-      promise = profile.disable_user(packet)
+      promise = session.disable_user(packet)
       promise.$promise.then(successHandler, errorHandler)
 
     $scope.submit = (form) ->
@@ -58,7 +56,7 @@ class AccountManagement
       # forms. However, in the backend it is just one: edit_profile
       return unless form.$valid
 
-      username = persona_filter $scope.session.userid
+      username = persona_filter $scope.persona
       packet =
         username: username
         pwd: form.pwd.$modelValue
@@ -67,14 +65,9 @@ class AccountManagement
       successHandler = angular.bind(null, onSuccess, form)
       errorHandler   = angular.bind(null, onError, form)
 
-      promise = profile.edit_profile(packet)
+      promise = session.edit_profile(packet)
       promise.$promise.then(successHandler, errorHandler)
 
-    $rootScope.$on 'nav:account', ->
-      $scope.$apply -> $scope.sheet = true
-
-    $rootScope.$on 'logout', ->
-      $scope.sheet = false
 
 angular.module('h.controllers.AccountManagement', [])
 .controller('AccountManagement', AccountManagement)

--- a/h/static/scripts/directives.coffee
+++ b/h/static/scripts/directives.coffee
@@ -107,6 +107,24 @@ privacy = ->
   templateUrl: 'privacy.html'
 
 
+# Extend the tabbable directive from angular-bootstrap with autofocus
+tabbable = ['$timeout', ($timeout) ->
+  link: (scope, elem, attrs, ctrl) ->
+    return unless ctrl
+    render = ctrl.$render
+    ctrl.$render = ->
+      render.call(ctrl)
+      $timeout ->
+        elem
+        .find(':input')
+        .filter(':visible:first')
+        .focus()
+      , false
+  require: '?ngModel'
+  restrict: 'C'
+]
+
+
 tabReveal = ['$parse', ($parse) ->
   compile: (tElement, tAttrs, transclude) ->
     panes = []
@@ -148,15 +166,6 @@ tabReveal = ['$parse', ($parse) ->
             angular.element(tabs[i]).css 'display', 'none'
   require: ['ngModel', 'tabbable']
 ]
-
-
-# TODO: Move this behaviour to a route.
-showAccount = ->
-  restrict: 'A'
-  link: (scope, elem, attr) ->
-    elem.on 'click', (event) ->
-      event.preventDefault()
-      scope.$emit('nav:account')
 
 
 repeatAnim = ->
@@ -215,8 +224,8 @@ angular.module('h.directives', imports)
 .directive('formInput', formInput)
 .directive('formValidate', formValidate)
 .directive('privacy', privacy)
+.directive('tabbable', tabbable)
 .directive('tabReveal', tabReveal)
-.directive('showAccount', showAccount)
 .directive('repeatAnim', repeatAnim)
 .directive('whenscrolled', whenscrolled)
 .directive('match', match)

--- a/h/templates/account.html
+++ b/h/templates/account.html
@@ -1,4 +1,4 @@
-<div class="tabbable">
+<div class="tabbable" ng-controller="AccountManagement">
   <div class="tab-pane" title="Account">
     <form class="account-form form" name="changePasswordForm" ng-submit="submit(changePasswordForm)" novalidate form-validate>
       <h2 class="form-heading"><span>Change Your Password</span></h2>

--- a/h/templates/app.pt
+++ b/h/templates/app.pt
@@ -5,7 +5,7 @@
       <div class="inner" ng-switch="persona">
         <span class="pull-right" ng-switch-when="undefined">⋯</span>
         <a class="pull-right" href=""
-           ng-click="id.request()"
+           ng-click="dialog.visible = true; id.request()"
            ng-switch-when="null">Sign in</a>
         <div class="dropdown pull-right user-picker" ng-switch-default>
           <span role="button"
@@ -14,7 +14,7 @@
             --><span class="provider">/{{persona|persona:'provider'}}</span><!--
             --><i class="icon-triangle"></i></span>
           <ul class="dropdown-menu pull-right" role="menu">
-            <li show-account><a href="#">Account</a></li>
+            <li><a href="" ng-click="dialog.visible = 'true'">Account</a></li>
             <li><a href="http://hypothes.is/contact/"
                    target="_blank">Feedback</a></li>
             <li><a href="/docs/help" target="_blank">Help</a></li>
@@ -36,34 +36,17 @@
 
     <!-- Wrapper -->
     <div id="wrapper" whenscrolled="loadMore(10)">
-      <!-- Panels -->
-      <div class="panels"
-           data-settings-panel-model="auth.persona"></div>
-      <!-- / Panels -->
-
-      <!-- Account and Authentication -->
-      <div class="content ng-cloak" ng-show="!!sheet">
-        <div class="sheet">
+      <!-- Dialog -->
+      <div class="content ng-cloak" ng-if="dialog.visible">
+        <div id="dialog" class="sheet">
           <i class="close icon-cancel"
              role="button"
              title="Close"
-             ng-click="sheet = false"></i>
-          <metal:main use-macro="blocks['auth']" />
+             ng-click="dialog.visible = false"></i>
+          <metal:main use-macro="blocks['dialog']"/>
         </div>
       </div>
-      <!-- / Account and Authentication -->
-
-      <!-- Panels Nav-->
-      <div class="content ng-cloak">
-        <div class="sheet" ng-controller="AccountManagement" ng-show="!!sheet">
-          <span href="" class="close icon-cancel"
-              title="Close"
-              role="button"
-              ng-click="sheet = false"></span>
-          <div ng-include="'account.html'"></div>
-        </div>
-      </div>
-      <!-- / Panels Nav -->
+      <!-- / Dialog -->
 
       <!-- Angular view -->
       <main class="content" ng-view=""></main>
@@ -71,14 +54,8 @@
     <!-- / Wrapper -->
 
     <!-- Templates -->
-    <script type="text/ng-template" id="account.html">
-      <metal:main use-macro="load: account.html" />
-    </script>
     <script type="text/ng-template" id="annotation.html">
       <metal:main use-macro="load: h:templates/annotation.html" />
-    </script>
-    <script type="text/ng-template" id="auth.html">
-      <metal:main use-macro="load: h:templates/auth.html" />
     </script>
     <script type="text/ng-template" id="markdown.html">
       <metal:main use-macro="load: h:templates/markdown.html" />

--- a/h/templates/auth.html
+++ b/h/templates/auth.html
@@ -1,217 +1,225 @@
-<!-- Login -->
-<form data-title="Sign in"
-      data-value="login"
-      class="form tab-pane"
-      name="login"
-      form-validate
-      novalidate>
+<div class="form-vertical tabbable"
+     tab-reveal="['forgot', 'activate']"
+     ng-controller="AuthController as auth"
+     ng-form="form"
+     ng-init="tab = 'login'"
+     ng-model="tab"
+     ng-submit="auth.submit(form[tab])">
+  <!-- Login -->
+  <form data-title="Sign in"
+        data-value="login"
+        class="form tab-pane"
+        name="login"
+        form-validate
+        novalidate>
 
-  <p class="form-description form-error" ng-show="login.responseErrorMessage">
-    {{login.responseErrorMessage}}
-  </p>
+    <p class="form-description form-error" ng-show="login.responseErrorMessage">
+      {{login.responseErrorMessage}}
+    </p>
 
-  <div class="form-field">
-    <label class="form-label" for="field-login-username">Username:</label>
-    <input class="form-input" type="text" id="field-login-username"
-           name="username" value=""
-           ng-model="model.username" ng-minlength="3"
-           required autocapitalize="false" />
-    <ul class="form-error-list">
-      <li class="form-error" ng-show="login.username.$error.required"
-          >Please enter your username.</li>
-      <li class="form-error" ng-show="login.username.$error.minlength"
-          >Usernames are at least 3 characters.</li>
-      <li class="form-error" ng-show="login.username.$error.response"
-          >{{login.username.responseErrorMessage}}</li>
-    </ul>
-  </div>
-
-  <div class="form-field">
-    <label class="form-label" for="field-login-password">Password:</label>
-    <input class="form-input" id="field-login-password"
-           type="password" name="password" value=""
-           ng-model="model.password"
-           required autocapitalize="false" autocorrect="false" />
-    <ul class="form-error-list">
-      <li class="form-error" ng-show="login.password.$error.required"
-          >Please enter your password.</li>
-      <li class="form-error" ng-show="login.password.$error.response"
-          >{{login.password.responseErrorMessage}}</li>
-    </ul>
-  </div>
-
-  <div class="form-actions">
-    <div class="form-actions-message">
-      <a href="" ng-click="tab = 'forgot'">Forgotten your password</a> or
-      <a href="" ng-click="tab = 'activate'"
-         >have an activation code?</a>
+    <div class="form-field">
+      <label class="form-label" for="field-login-username">Username:</label>
+      <input class="form-input" type="text" id="field-login-username"
+             name="username" value=""
+             ng-model="model.username" ng-minlength="3"
+             required autocapitalize="false" />
+      <ul class="form-error-list">
+        <li class="form-error" ng-show="login.username.$error.required"
+            >Please enter your username.</li>
+        <li class="form-error" ng-show="login.username.$error.minlength"
+            >Usernames are at least 3 characters.</li>
+        <li class="form-error" ng-show="login.username.$error.response"
+            >{{login.username.responseErrorMessage}}</li>
+      </ul>
     </div>
-    <div class="form-actions-buttons">
-      <button class="btn btn-primary" type="submit" name="login">Sign in</button>
+
+    <div class="form-field">
+      <label class="form-label" for="field-login-password">Password:</label>
+      <input class="form-input" id="field-login-password"
+             type="password" name="password" value=""
+             ng-model="model.password"
+             required autocapitalize="false" autocorrect="false" />
+      <ul class="form-error-list">
+        <li class="form-error" ng-show="login.password.$error.required"
+            >Please enter your password.</li>
+        <li class="form-error" ng-show="login.password.$error.response"
+            >{{login.password.responseErrorMessage}}</li>
+      </ul>
     </div>
-  </div>
-</form>
-<!-- / Login -->
 
-<!-- Register -->
-<form data-title="Create an account"
-      data-value="register"
-      class="form tab-pane"
-      name="register"
-      form-validate
-      novalidate>
-
-  <p class="form-description form-error" ng-show="register.responseErrorMessage">
-    {{register.responseErrorMessage}}
-  </p>
-
-  <div class="form-field">
-    <label class="form-label" for="field-register-username">Username:
-      <span class="form-hint">(between 3 and 15 characters)</span>
-    </label>
-    <input class="form-input" id="field-register-username"
-           type="text" name="username" value=""
-           required autocapitalize="false" ng-model="model.username"
-           ng-minlength="3" ng-maxlength="15"
-           ng-pattern="/^[A-Za-z0-9._]+$/"
-           ng-model-options="{updateOn: 'blur'}" />
-    <ul class="form-error-list">
-      <li class="form-error" ng-show="register.username.$error.required"
-          >Please choose a username.</li>
-      <li class="form-error" ng-show="register.username.$error.minlength"
-          >Usernames must be at least 3 characters.</li>
-      <li class="form-error" ng-show="register.username.$error.maxlength"
-          >Usernames must be 15 characters at most.</li>
-      <li class="form-error" ng-show="register.username.$error.pattern"
-          >Only letters, numbers, underscore and dot are allowed.</li>
-      <li class="form-error" ng-show="register.username.$error.response"
-          >{{register.username.responseErrorMessage}}</li>
-    </ul>
-  </div>
-
-  <div class="form-field">
-    <label class="form-label" for="field-register-email">Email Address:</label>
-    <input class="form-input" id="field-register-email"
-           type="email" name="email" value=""
-           ng-model="model.email" required autocapitalize="false"
-           ng-model-options="{updateOn: 'blur'}" />
-    <ul class="form-error-list">
-      <li class="form-error" ng-show="register.email.$error.email"
-          >Is this an email address?</li>
-      <li class="form-error" ng-show="register.email.$error.required"
-          >Please enter your email.</li>
-      <li class="form-error" ng-show="register.email.$error.response"
-          >{{register.email.responseErrorMessage}}</li>
-    </ul>
-  </div>
-
-  <div class="form-field">
-    <label class="form-label" for="field-register-password">Password:
-      <span class="form-hint">(at least two characters)</span>
-    </label>
-    <input id="field-register-password" class="form-input"
-           type="password" name="password" value=""
-           required autocapitalize="false" autocorrect="false"
-           ng-minlength="2" ng-model="model.password"
-           ng-model-options="{updateOn: 'blur'}" />
-    <ul class="form-error-list">
-      <li class="form-error" ng-show="register.password.$error.required"
-          >Please enter a password.</li>
-      <li class="form-error" ng-show="register.password.$error.minlength"
-          >Passwords must be at least 2 characters.</li>
-      <li class="form-error" ng-show="register.password.$error.response"
-          >{{register.password.responseErrorMessage}}</li>
-    </ul>
-  </div>
-
-  <div class="form-actions">
-    <div class="form-actions-buttons">
-      <button class="btn" type="submit" name="sign_up">Sign up</button>
+    <div class="form-actions">
+      <div class="form-actions-message">
+        <a href="" ng-click="tab = 'forgot'">Forgotten your password</a> or
+        <a href="" ng-click="tab = 'activate'"
+           >have an activation code?</a>
+      </div>
+      <div class="form-actions-buttons">
+        <button class="btn btn-primary" type="submit" name="login">Sign in</button>
+      </div>
     </div>
-  </div>
+  </form>
+  <!-- / Login -->
 
-</form>
-<!-- / Register -->
+  <!-- Register -->
+  <form data-title="Create an account"
+        data-value="register"
+        class="form tab-pane"
+        name="register"
+        form-validate
+        novalidate>
 
-<!-- Forgot password -->
-<form data-title="Confirm account"
-      data-value="forgot"
-      class="form tab-pane"
-      name="forgot"
-      form-validate
-      novalidate>
+    <p class="form-description form-error" ng-show="register.responseErrorMessage">
+      {{register.responseErrorMessage}}
+    </p>
 
-  <p class="form-description form-error" ng-show="forgot.responseErrorMessage">
-    {{forgot.responseErrorMessage}}
-  </p>
-  <div class="form-field">
-    <label class="form-label" for="field-forgot-email">Please enter your email address:</label>
-    <input class="form-input" id="field-forgot-email"
-           type="email" name="email" value=""
-           required autocapitalize="false" ng-model="model.email" />
-    <ul class="form-error-list">
-      <li class="form-error" ng-show="forgot.email.$error.email">Is this an email address?</li>
-      <li class="form-error" ng-show="forgot.email.$error.required">Please enter your email.</li>
-      <li class="form-error" ng-show="forgot.email.$error.response"
-          >{{forgot.email.responseErrorMessage}}</li>
-    </ul>
-  </div>
-
-  <div class="form-actions">
-    <div class="form-actions-buttons">
-      <button class="btn" type="submit" name="forgot">Request access</button>
+    <div class="form-field">
+      <label class="form-label" for="field-register-username">Username:
+        <span class="form-hint">(between 3 and 15 characters)</span>
+      </label>
+      <input class="form-input" id="field-register-username"
+             type="text" name="username" value=""
+             required autocapitalize="false" ng-model="model.username"
+             ng-minlength="3" ng-maxlength="15"
+             ng-pattern="/^[A-Za-z0-9._]+$/"
+             ng-model-options="{updateOn: 'blur'}" />
+      <ul class="form-error-list">
+        <li class="form-error" ng-show="register.username.$error.required"
+            >Please choose a username.</li>
+        <li class="form-error" ng-show="register.username.$error.minlength"
+            >Usernames must be at least 3 characters.</li>
+        <li class="form-error" ng-show="register.username.$error.maxlength"
+            >Usernames must be 15 characters at most.</li>
+        <li class="form-error" ng-show="register.username.$error.pattern"
+            >Only letters, numbers, underscore and dot are allowed.</li>
+        <li class="form-error" ng-show="register.username.$error.response"
+            >{{register.username.responseErrorMessage}}</li>
+      </ul>
     </div>
-  </div>
-</form>
-<!-- / Forgot password -->
 
-<!-- Activate -->
-<form data-title="Activate an account"
-      data-value="activate"
-      class="form tab-pane"
-      name="activate"
-      form-validate
-      novalidate>
-
-  <p class="form-description form-error" ng-show="activate.responseErrorMessage">
-    {{activate.responseErrorMessage}}
-  </p>
-
-  <div class="form-field">
-    <label class="form-label" for="field-activate-code">Your activation code:</label>
-    <input class="form-input" id="field-activate-code"
-           type="text" name="code" value=""
-           required autocorrect="false" autocapitalize="false"
-           ng-model="model.code" />
-    <ul class="form-error-list">
-      <li class="form-error" ng-show="activate.code.$error.required">Please enter your activation code</li>
-      <li class="form-error" ng-show="activate.code.$error.response"
-          >{{activate.code.responseErrorMessage}}</li>
-    </ul>
-  </div>
-
-  <div class="form-field">
-    <label class="form-label" for="field-activate-password">Account password:
-      <span class="form-hint">(at least two characters)</span>
-    </label>
-    <input class="form-input" id="field-activate-password"
-           type="password" name="password" value=""
-           required autocapitalize="false" autocorrect="false"
-           ng-minlength="2" ng-model="model.password" />
-    <ul class="form-error-list">
-      <li class="form-error" ng-show="activate.password.$error.required"
-          >Please choose a password.</li>
-      <li class="form-error" ng-show="activate.password.$error.minlength"
-          >Passwords must be at least 2 characters.</li>
-      <li class="form-error" ng-show="activate.password.$error.response"
-          >{{activate.password.responseErrorMessage}}</li>
-    </ul>
-  </div>
-
-  <div class="form-actions">
-    <div class="form-actions-buttons">
-      <button class="btn" type="submit" name="activate">Activate</button>
+    <div class="form-field">
+      <label class="form-label" for="field-register-email">Email Address:</label>
+      <input class="form-input" id="field-register-email"
+             type="email" name="email" value=""
+             ng-model="model.email" required autocapitalize="false"
+             ng-model-options="{updateOn: 'blur'}" />
+      <ul class="form-error-list">
+        <li class="form-error" ng-show="register.email.$error.email"
+            >Is this an email address?</li>
+        <li class="form-error" ng-show="register.email.$error.required"
+            >Please enter your email.</li>
+        <li class="form-error" ng-show="register.email.$error.response"
+            >{{register.email.responseErrorMessage}}</li>
+      </ul>
     </div>
-  </div>
-</form>
-<!--/ Activate -->
+
+    <div class="form-field">
+      <label class="form-label" for="field-register-password">Password:
+        <span class="form-hint">(at least two characters)</span>
+      </label>
+      <input id="field-register-password" class="form-input"
+             type="password" name="password" value=""
+             required autocapitalize="false" autocorrect="false"
+             ng-minlength="2" ng-model="model.password"
+             ng-model-options="{updateOn: 'blur'}" />
+      <ul class="form-error-list">
+        <li class="form-error" ng-show="register.password.$error.required"
+            >Please enter a password.</li>
+        <li class="form-error" ng-show="register.password.$error.minlength"
+            >Passwords must be at least 2 characters.</li>
+        <li class="form-error" ng-show="register.password.$error.response"
+            >{{register.password.responseErrorMessage}}</li>
+      </ul>
+    </div>
+
+    <div class="form-actions">
+      <div class="form-actions-buttons">
+        <button class="btn" type="submit" name="sign_up">Sign up</button>
+      </div>
+    </div>
+
+  </form>
+  <!-- / Register -->
+
+  <!-- Forgot password -->
+  <form data-title="Confirm account"
+        data-value="forgot"
+        class="form tab-pane"
+        name="forgot"
+        form-validate
+        novalidate>
+
+    <p class="form-description form-error" ng-show="forgot.responseErrorMessage">
+      {{forgot.responseErrorMessage}}
+    </p>
+    <div class="form-field">
+      <label class="form-label" for="field-forgot-email">Please enter your email address:</label>
+      <input class="form-input" id="field-forgot-email"
+             type="email" name="email" value=""
+             required autocapitalize="false" ng-model="model.email" />
+      <ul class="form-error-list">
+        <li class="form-error" ng-show="forgot.email.$error.email">Is this an email address?</li>
+        <li class="form-error" ng-show="forgot.email.$error.required">Please enter your email.</li>
+        <li class="form-error" ng-show="forgot.email.$error.response"
+            >{{forgot.email.responseErrorMessage}}</li>
+      </ul>
+    </div>
+
+    <div class="form-actions">
+      <div class="form-actions-buttons">
+        <button class="btn" type="submit" name="forgot">Request access</button>
+      </div>
+    </div>
+  </form>
+  <!-- / Forgot password -->
+
+  <!-- Activate -->
+  <form data-title="Activate an account"
+        data-value="activate"
+        class="form tab-pane"
+        name="activate"
+        form-validate
+        novalidate>
+
+    <p class="form-description form-error" ng-show="activate.responseErrorMessage">
+      {{activate.responseErrorMessage}}
+    </p>
+
+    <div class="form-field">
+      <label class="form-label" for="field-activate-code">Your activation code:</label>
+      <input class="form-input" id="field-activate-code"
+             type="text" name="code" value=""
+             required autocorrect="false" autocapitalize="false"
+             ng-model="model.code" />
+      <ul class="form-error-list">
+        <li class="form-error" ng-show="activate.code.$error.required">Please enter your activation code</li>
+        <li class="form-error" ng-show="activate.code.$error.response"
+            >{{activate.code.responseErrorMessage}}</li>
+      </ul>
+    </div>
+
+    <div class="form-field">
+      <label class="form-label" for="field-activate-password">Account password:
+        <span class="form-hint">(at least two characters)</span>
+      </label>
+      <input class="form-input" id="field-activate-password"
+             type="password" name="password" value=""
+             required autocapitalize="false" autocorrect="false"
+             ng-minlength="2" ng-model="model.password" />
+      <ul class="form-error-list">
+        <li class="form-error" ng-show="activate.password.$error.required"
+            >Please choose a password.</li>
+        <li class="form-error" ng-show="activate.password.$error.minlength"
+            >Passwords must be at least 2 characters.</li>
+        <li class="form-error" ng-show="activate.password.$error.response"
+            >{{activate.password.responseErrorMessage}}</li>
+      </ul>
+    </div>
+
+    <div class="form-actions">
+      <div class="form-actions-buttons">
+        <button class="btn" type="submit" name="activate">Activate</button>
+      </div>
+    </div>
+  </form>
+  <!--/ Activate -->
+</div>

--- a/h/templates/blocks.pt
+++ b/h/templates/blocks.pt
@@ -1,10 +1,8 @@
-<metal:main define-macro="auth">
-  <div class="auth form-vertical tabbable"
-       data-tab-reveal="['forgot', 'activate']"
-       on-success="sheet = null"
-       on-timeout="authTimeout()"
-       ng-form="form"
-       ng-init="model = {}"
-       ng-model="sheet">
+<metal:main define-macro="dialog">
+  <div ng-if="persona">
+    <metal:main use-macro="load: h:templates/account.html">
+  </div>
+  <div ng-if="!persona">
+    <metal:main use-macro="load: h:templates/auth.html">
   </div>
 </metal:main>

--- a/tests/js/controllers/account-management-test.coffee
+++ b/tests/js/controllers/account-management-test.coffee
@@ -5,7 +5,7 @@ sandbox = sinon.sandbox.create()
 describe 'h.controllers.AccountManagement', ->
   $scope = null
   fakeFlash = null
-  fakeProfile = null
+  fakeSession = null
   fakeIdentity = null
   fakeFormHelpers = null
   editProfilePromise = null
@@ -13,7 +13,7 @@ describe 'h.controllers.AccountManagement', ->
   createController = null
 
   beforeEach module ($provide, $filterProvider) ->
-    fakeProfile = {}
+    fakeSession = {}
     fakeFlash = sandbox.spy()
     fakeIdentity =
       logout: sandbox.spy()
@@ -23,7 +23,7 @@ describe 'h.controllers.AccountManagement', ->
     $filterProvider.register 'persona', ->
       sandbox.stub().returns('STUBBED_PERSONA_FILTER')
 
-    $provide.value 'profile', fakeProfile
+    $provide.value 'session', fakeSession
     $provide.value 'flash', fakeFlash
     $provide.value 'identity', fakeIdentity
     $provide.value 'formHelpers', fakeFormHelpers
@@ -33,29 +33,18 @@ describe 'h.controllers.AccountManagement', ->
 
   beforeEach inject ($rootScope, $q, $controller) ->
     $scope = $rootScope.$new()
-    $scope.session = userid: 'egon@columbia.edu'
+    $scope.persona = 'egon@columbia.edu'
 
     disableUserPromise = {then: sandbox.stub()}
     editProfilePromise = {then: sandbox.stub()}
-    fakeProfile.edit_profile = sandbox.stub().returns($promise: editProfilePromise)
-    fakeProfile.disable_user = sandbox.stub().returns($promise: disableUserPromise)
+    fakeSession.edit_profile = sandbox.stub().returns($promise: editProfilePromise)
+    fakeSession.disable_user = sandbox.stub().returns($promise: disableUserPromise)
 
     createController = ->
       $controller('AccountManagement', {$scope: $scope})
 
   it 'hides the sheet by default', ->
       controller = createController()
-      assert.isFalse($scope.sheet)
-
-  describe 'event subscriptions', ->
-    it 'should show the sheet on "nav:account" event', ->
-      controller = createController()
-      $scope.$emit('nav:account')
-      assert.isTrue($scope.sheet)
-
-    it 'should hide the sheet on "logout" event', ->
-      controller = createController()
-      $scope.$emit('logout')
       assert.isFalse($scope.sheet)
 
   describe '.submit', ->
@@ -73,7 +62,7 @@ describe 'h.controllers.AccountManagement', ->
       controller = createController()
       $scope.submit(fakeForm)
 
-      assert.calledWith(fakeProfile.edit_profile, {
+      assert.calledWith(fakeSession.edit_profile, {
         username: 'STUBBED_PERSONA_FILTER'
         pwd: 'gozer'
         password: 'paranormal'
@@ -162,7 +151,7 @@ describe 'h.controllers.AccountManagement', ->
       controller = createController()
       $scope.delete(fakeForm)
 
-      assert.calledWith fakeProfile.disable_user,
+      assert.calledWith fakeSession.disable_user,
         username: 'STUBBED_PERSONA_FILTER'
         pwd: 'paranormal'
 

--- a/tests/js/directives-test.coffee
+++ b/tests/js/directives-test.coffee
@@ -167,15 +167,3 @@ describe 'h.directives', ->
 
       controller = $element.controller('ngModel')
       assert.isTrue(controller.$error.match)
-
-  describe '.showAccount', ->
-    $element = null
-
-    beforeEach ->
-      $element = $compile('<a show-account>Account</a>')($scope)
-      $scope.$digest()
-
-    it 'triggers the "nav:account" event when the Account item is clicked', (done) ->
-      $scope.$on 'nav:account', ->
-        done()
-      $element.click()


### PR DESCRIPTION
These resources are one resource on the backend. The pattern of
preserving object identity for the session response is unnecessary.
The identity module now listens for events on the root scope instead
of watching the session. The auth controller publishes the session
change directly and the auth directive is completely removed. Timeout
is handled in the controller.

Include the account and auth forms via a macro in the blocks template
so that all the dialogs can be overridden together and get rid of the
`show-account` directive.
