### PR TITLE
Hide highlight icon when editing an annotation

### DIFF
--- a/h/templates/annotation.html
+++ b/h/templates/annotation.html
@@ -9,7 +9,7 @@
        ng-href="{{baseURI}}u/{{vm.annotation.user}}"
        >{{vm.annotation.user | persona}}</a>
     <i class="small icon-locked" ng-show="vm.isPrivate()"></i>
-    <i class="small icon-highlighter" ng-show="vm.isHighlight()"></i>
+    <i class="small icon-highlighter" ng-show="vm.isHighlight() && !vm.editing"></i>
     <i class="small icon-comment" ng-show="vm.isComment()"></i>
     <span class="annotation-citation"
           ng-if="!vm.embedded"


### PR DESCRIPTION
Noticed a small bug with @dwhly today. The highlighter icon should not show when creating an annotation.
![smallbug](https://cloud.githubusercontent.com/assets/521978/4428739/28d0396c-45d1-11e4-9edc-3dc33931c6b7.jpg)
