### PR TITLE
Extensible link and meta tags in base template

### DIFF
--- a/h/templates/base.pt
+++ b/h/templates/base.pt
@@ -4,6 +4,8 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
     <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <meta tal:attributes="attrs" tal:repeat="attrs meta | []" />
+    <link tal:attributes="attrs" tal:repeat="attrs link | []" />
     <link rel="stylesheet" type="text/css"
           tal:attributes="href href"
           tal:repeat="href layout.css_links | []" />


### PR DESCRIPTION
While reviewing old issues today I remembered the work @RawKStar77 was doing on social media integrations.

One part of that was about getting metadata into the standalone page so that annotations had proper stories in Twitter, G+, Facebook, etc.

Here's a simple preparatory step. It allows any of our views to pass a "link" or "meta" array to the renderer. The base template will loop over these arrays expecting dictionary items whose keys and values become the attributes of a link or meta tag.

For instance, we could start to add metadata to our standalone view by adding to `h.views.annotation`:

``` python
def annotation(context, request):
    return {
        'meta': [
            {'property': 'og_type', 'content': 'article'},
            {'property': 'og_url', 'content': request.current_resource_url()},
            {'property': 'og_title', 'content': 'Annotation on {}'.format(context.title)},
        ]
    }
```

etc...
