### PR TITLE
Proper Media Type for JS files

### DIFF
--- a/h/views.py
+++ b/h/views.py
@@ -23,6 +23,7 @@ def js(context, request):
     request.response.content_type = 'text/javascript'
     return {}
 
+
 @view_config(layout='app', name='app.html', renderer='h:templates/app.pt')
 @view_config(layout='app', name='viewer', renderer='h:templates/app.pt')
 @view_config(layout='app', name='editor', renderer='h:templates/app.pt')


### PR DESCRIPTION
I only got as far as `embed.js`...sadly.

Most `.js` files (at least) aren't getting any `Content-Type` set (nor `Content-Length`) for that matter. This is true with both the stock `.ini` files we provide.

I'm happy to dig into this more. This at least fixes `embed.js`'s media type.
