### PR TITLE
Math support

### DIFF
--- a/h/static/scripts/directives/markdown.coffee
+++ b/h/static/scripts/directives/markdown.coffee
@@ -65,10 +65,7 @@ markdown = ['$filter', '$sanitize', '$sce', '$timeout', ($filter, $sanitize, $sc
         # Check to see if markup has already been applied before to the selection.
         slice1 = text.before.slice(text.before.length - markupL.length)
         slice2 = text.after.slice(0, markupR.length)
-        # Edge case: scope.insertMath() is called for inline and block markup, to avoid a case
-        # in which pressing the math button to remove block math markup adds inline math inside of
-        # block math $$\(LaTex or MathML\)$$ we check for $$ here.
-        if (slice1 == markupL and slice2 == markupR) or (slice1 == '$$' and slice2 == '$$')
+        if (slice1 == markupL and slice2 == markupR)
           # Remove markup 
           newtext = (
             text.before.slice(0, (text.before.length - markupL.length)) +
@@ -93,7 +90,11 @@ markdown = ['$filter', '$sanitize', '$sce', '$timeout', ($filter, $sanitize, $sc
     scope.insertMath = ->
       text = userSelection()
       index = text.before.length
-      if index == 0 or input.value[index - 1] == '\n'
+      if (
+        index == 0 or
+        input.value[index - 1] == '\n' or
+        (input.value[index - 1] == '$' and input.value[index - 2] == '$')
+      )
         applyInlineMarkup('$$', 'LaTeX or MathML')
       else
         applyInlineMarkup('\\(', 'LaTeX or MathML', '\\)')


### PR DESCRIPTION
This PR is meant to resolve #1541 and #1543. Rendering math with Matrices currently works great (thanks @tilgovi for the help there), but there are still some issues around inline math, hence the "WIP" in the PR title. 

The ctrl.$render function has been rewritten to avoid the problems that were causing #1543, namely our Markdown converter removes backslashes needed to render the math. To address this we split the input up on math delimiters, and now don't run the math through our markdown converter. 

The result works well for solving that issue, and you can see in the picture below that even inline math in a basic paragraph works (see code comments). 
![inlinemath_working](https://cloud.githubusercontent.com/assets/521978/4553472/3c67c324-4e9a-11e4-8b3d-ab165bd60573.png)

However, there are some edge cases that still need to be addressed:
1. Math in blockquotes. We have to know where to put the </blockquote>.
![blockquote problems](https://cloud.githubusercontent.com/assets/521978/4553590/d62b67a2-4e9c-11e4-8672-f9915fab7328.png)
2. Math in lists. 
![list problems](https://cloud.githubusercontent.com/assets/521978/4553586/c30457c4-4e9c-11e4-885d-0783c0815f9f.png)
3. Italics or bold formatting that contains math in it, like so: `**Bold text \( 1 + 1 \) Bold text**`
![bold problem](https://cloud.githubusercontent.com/assets/521978/4553536/6aac7bca-4e9b-11e4-9cf5-841b9f412a27.png)

All of these problems are similar in what's happening: our new process breaks up the text based on math delimiters, so our Markdown renderer doesn't know what to do with `**Bold text`

I will update this opening comment as I make progress, but I thought since this is a difficult problem, it would be good to get some early feedback. 

<!---
@huboard:{"order":12.5,"milestone_order":1558,"custom_state":""}
-->
