### PR TITLE
Hide lock icon next to username when editing

### DIFF
--- a/h/templates/annotation.html
+++ b/h/templates/annotation.html
@@ -8,7 +8,7 @@
        target="_blank"
        ng-href="{{baseURI}}u/{{vm.annotation.user}}"
        >{{vm.annotation.user | persona}}</a>
-    <i class="small h-icon-locked" ng-show="vm.isPrivate()"></i>
+    <i class="small h-icon-locked" ng-show="vm.isPrivate() && !vm.editing"></i>
     <i class="small h-icon-highlighter" ng-show="vm.isHighlight() && !vm.editing"></i>
     <i class="small h-icon-comment" ng-show="vm.isComment()"></i>
     <span class="annotation-citation"

--- a/h/templates/privacy.html
+++ b/h/templates/privacy.html
@@ -3,6 +3,7 @@
         role="button"
         class="dropdown-toggle"
         data-toggle="dropdown">
+        <i class="small" ng-class="{'h-icon-earth': level == 'Public', 'h-icon-locked': level == 'Only Me'}"></i>
         {{level}}
         <i class="h-icon-triangle"></i>
   </span>


### PR DESCRIPTION
Simple fix for #1538 

![fix-1538](https://cloud.githubusercontent.com/assets/521978/4570473/1b4d35b4-4f5f-11e4-85c1-391f99725441.png)
