### PR TITLE
Remove info notification when closing the auth window

### DIFF
--- a/h/static/scripts/controllers.coffee
+++ b/h/static/scripts/controllers.coffee
@@ -195,7 +195,6 @@ class AppController
 
     oncancel = ->
       $scope.$evalAsync ->
-        flash 'info', 'Sign in canceled.'
         $scope.dialog.visible = false
 
     reset = ->


### PR DESCRIPTION
![screen shot 2014-10-15 at 19 21 21](https://cloud.githubusercontent.com/assets/47144/4649975/b5271f44-548f-11e4-9655-780885472feb.png)

Now the login pane just disappears.
