### PR TITLE
Add more usernames to blacklist

### DIFF
--- a/h/auth/local/blacklist
+++ b/h/auth/local/blacklist
@@ -173,8 +173,6 @@ ipad
 iphone
 irc
 issues
-java
-javascript
 job
 jobs
 js
@@ -219,7 +217,6 @@ network
 new
 news
 newsletter
-nick
 nickname
 notes
 notifications
@@ -243,7 +240,6 @@ partners
 password
 personal
 photos
-php
 pic
 pics
 plugin
@@ -275,7 +271,6 @@ replies
 reply
 root
 rss
-ruby
 rules
 runner
 sale


### PR DESCRIPTION
I noticed that root and postmaster were missing, one thing led to
another, and I added a bunch of names from [this list](https://programmers.stackexchange.com/questions/115425/is-there-a-list-of-common-usernames-to-reserve-in-a-new-system).
