### PR TITLE
Add link to terms of service on create account form.

### DIFF
--- a/h/templates/auth.html
+++ b/h/templates/auth.html
@@ -151,8 +151,8 @@
 
     <div class="form-actions">
       <div class="form-actions-message">
-        <a href="terms-of-service" target="_blank"
-           >Terms of Service</a>
+        You are agreeing to be bound by our <a href="terms-of-service" target="_blank"
+           >Terms of Service</a>.
       </div>
       <div class="form-actions-buttons">
         <button class="btn" type="submit" name="sign_up"


### PR DESCRIPTION
Meant to resolve https://github.com/hypothesis/vision/issues/94. Here's what it looks like:

![hypothesis](https://cloud.githubusercontent.com/assets/521978/4776217/a285496a-5bbf-11e4-9a6a-0ea466826829.png)

Maybe an open question:
- Do we want a checkbox next to the terms of service?
