### PR TITLE
Don't swallow exceptions when scanning the document

### DIFF
--- a/h/static/scripts/guest.coffee
+++ b/h/static/scripts/guest.coffee
@@ -71,7 +71,7 @@ class Annotator.Guest extends Annotator
 
     unless config.dontScan
       # Scan the document text with the DOM Text libraries
-      this.scanDocument "Guest initialized"
+      this._scan()
 
     # Watch for newly rendered highlights, and update positions in sidebar
     this.subscribe "highlightsCreated", (highlights) =>
@@ -196,14 +196,6 @@ class Annotator.Guest extends Annotator
     .bind('updateHeatmap', =>
       @plugins.Heatmap._scheduleUpdate()
     )
-
-  scanDocument: (reason = "something happened") =>
-    try
-      console.log "Analyzing host frame, because " + reason + "..."
-      this._scan()
-    catch e
-      console.log e.message
-      console.log e.stack
 
   _setupWrapper: ->
     @wrapper = @element

--- a/h/static/scripts/host.coffee
+++ b/h/static/scripts/host.coffee
@@ -36,7 +36,7 @@ class Annotator.Host extends Annotator.Guest
           this.showFrame()
 
     # Scan the document
-    this.scanDocument "Host initialized"
+    this._scan()
 
   _setupXDM: (options) ->
     channel = super


### PR DESCRIPTION
According to @csillag, there are no good (i.e. non-exceptional) reasons
why `this._scan()` should throw an error. As such, should not be
catching and swallowing the error, as this will make it much less likely
that we receive bug reports about brokenness in dom-text-mapper.

Inspired by conversation in #1596.
