### PR TITLE
Fix a text selection problem

### DIFF
--- a/h/static/scripts/guest.coffee
+++ b/h/static/scripts/guest.coffee
@@ -7,6 +7,7 @@ class Annotator.Guest extends Annotator
   events:
     ".annotator-adder button click":     "onAdderClick"
     ".annotator-adder button mousedown": "onAdderMousedown"
+    ".annotator-adder button mouseup":   "onAdderMouseup"
     "setTool": "onSetTool"
     "setVisibleHighlights": "onSetVisibleHighlights"
 
@@ -338,14 +339,16 @@ class Annotator.Guest extends Annotator
       method: 'addToken'
       params: token
 
+  onAdderMouseup: ->
+    event.preventDefault()
+    event.stopPropagation()
+
   onAdderMousedown: ->
-    @inAdderClick = true
 
   onAdderClick: (event) =>
     event.preventDefault()
     event.stopPropagation()
     @adder.hide()
-    @inAdderClick = false
     annotation = this.setupAnnotation(this.createAnnotation())
     this.showEditor(annotation)
     Annotator.util.getGlobal().getSelection().removeAllRanges()


### PR DESCRIPTION
Added back some code lines lost in transition earlier.
- setting the inAdderClick flag avoids running the logic
  which is intended to be run when the user creates a new text
  selection with the mouse
- clearing the selection on adder click fixes #1598.
