### PR TITLE
Get rid of the inAdderClick logic

### DIFF
--- a/h/static/scripts/guest.coffee
+++ b/h/static/scripts/guest.coffee
@@ -7,6 +7,7 @@ class Annotator.Guest extends Annotator
   events:
     ".annotator-adder button click":     "onAdderClick"
     ".annotator-adder button mousedown": "onAdderMousedown"
+    ".annotator-adder button mouseup":   "onAdderMouseup"
     "setTool": "onSetTool"
     "setVisibleHighlights": "onSetVisibleHighlights"
 
@@ -337,6 +338,10 @@ class Annotator.Guest extends Annotator
     @api.notify
       method: 'addToken'
       params: token
+
+  onAdderMouseup: ->
+    event.preventDefault()
+    event.stopPropagation()
 
   onAdderMousedown: ->
 


### PR DESCRIPTION
Instead of setting/resetting the inAdderClick flag,
we can just override mouseUp on the adder click,
and stop propagating.
