### PR TITLE
Check to see if an annotation has multiple titles

### DIFF
--- a/h/static/scripts/directives/annotation.coffee
+++ b/h/static/scripts/directives/annotation.coffee
@@ -187,11 +187,15 @@ AnnotationController = [
             break
 
         domain = extractURIComponent(uri, 'hostname')
+        documentTitle = if Array.isArray(model.document.title)
+          model.document.title[0]
+        else
+          model.document.title
 
         @document =
           uri: uri
           domain: domain
-          title: model.document.title or domain
+          title: documentTitle or domain
 
         if @document.title.length > 30
           @document.title = @document.title[0..29] + '…'

--- a/tests/js/directives/annotation-test.coffee
+++ b/tests/js/directives/annotation-test.coffee
@@ -36,6 +36,12 @@ describe 'h.directives.annotation', ->
     $scope.$digest()
     assert.equal(controller.document.title, 'A special document')
 
+  it 'uses the first title when there are more than one', ->
+    annotation.document.title = ['first title', 'second title']
+    controller = createController()
+    $scope.$digest()
+    assert.equal(controller.document.title, 'first title')
+
   it 'truncates long titles', ->
     annotation.document.title = '''A very very very long title that really
     shouldn't be found on a page on the internet.'''


### PR DESCRIPTION
Fixes the issue where a document title appears in square brackets. We need to look at why the document plugin sometimes returns a title in an array and other times does not. This should be consistent.
