### PR TITLE
Sort orphan placeholders to bottom of stream

### DIFF
--- a/h/static/scripts/controllers.coffee
+++ b/h/static/scripts/controllers.coffee
@@ -224,11 +224,11 @@ class AppController
 
     $scope.$watch 'sort.name', (name) ->
       return unless name
-      [predicate, reverse] = switch name
-        when 'Newest' then ['message.updated', true]
-        when 'Oldest' then ['message.updated', false]
-        when 'Location' then ['message.target[0].pos.top', false]
-      $scope.sort = {name, predicate, reverse}
+      predicate = switch name
+        when 'Newest' then ['-!!message', '-message.updated']
+        when 'Oldest' then ['-!!message',  'message.updated']
+        when 'Location' then ['-!!message', 'message.target[0].pos.top']
+      $scope.sort = {name, predicate}
 
     $scope.$watch 'store.entities', (entities, oldEntities) ->
       return if entities is oldEntities

--- a/h/templates/viewer.html
+++ b/h/templates/viewer.html
@@ -40,8 +40,7 @@
       ng-include="'thread.html'"
       ng-mouseenter="activate(child.message)"
       ng-mouseleave="activate()"
-      ng-repeat="child in vm.container.children
-                 | orderBy : sort.predicate : sort.reverse"
+      ng-repeat="child in vm.container.children | orderBy : sort.predicate"
       ng-show="vm.container && shouldShowThread(child) &&
                (count('edit') || count('match') || !threadFilter.active())">
   </li>


### PR DESCRIPTION
This should minimize the issue we have where there are lots of top-level orphans at the top of the stream. Often, it's because the infinite scroll loads the parent later (since they are, of course, older). Now, they should sit at the bottom of the stream until their parent loads. In the sidebar, they are always at the bottom.

Hopefully, this is at least a better, though still not great, incremental improvement over what we've got.

Compare: https://stream-orphan-sort.dokku.hypothes.is/stream to https://develop.dokku.hypothes.is/stream
