### PR TITLE
Remove bad css classes from buckets

### DIFF
--- a/h/static/scripts/plugin/heatmap.coffee
+++ b/h/static/scripts/plugin/heatmap.coffee
@@ -370,6 +370,8 @@ class Annotator.Plugin.Heatmap extends Annotator.Plugin
 
     .addClass (d) => if @isUpper(d) then 'upper' else ''
     .addClass (d) => if @isLower(d) then 'lower' else ''
+    .removeClass  (d) => unless @isUpper(d) then 'upper' else ''
+    .removeClass  (d) => unless @isLower(d) then 'lower' else ''
 
     .css 'display', (d) =>
       bucket = @buckets[d]


### PR DESCRIPTION
Once a bucket received a lower or an upper css class, it was never removed.

Once an update function is done, than the bucket with an index of last one - 2
will automatically receive a lower css class because that is the definition
of the isLower function.

The heatmap plugin reuses the already existing buckets and only adds new
ones if neeeded. So after new buckets are added a new one with will get
the lower css class, but nobody removes the lower class from the bucket
which already had it.

Fix #1620 
