### PR TITLE
Fix broken api module: use the string versions of the client secret

### DIFF
--- a/h/api.py
+++ b/h/api.py
@@ -258,7 +258,7 @@ class Token(BearerToken):
         message = dict(consumerKey=client.client_id, ttl=client.ttl)
         message.update(request.extra_credentials or {})
         token = {
-            'access_token': auth.encode_token(message, client.secret),
+            'access_token': auth.encode_token(message, client.client_secret),
             'expires_in': client.ttl,
             'token_type': 'http://annotateit.org/api/token',
         }
@@ -276,7 +276,7 @@ class Token(BearerToken):
             return False
 
         try:
-            token = auth.decode_token(token, client.secret, client.ttl)
+            token = auth.decode_token(token, client.client_secret, client.ttl)
         except auth.TokenInvalid:
             return False
 

--- a/h/test/api_test.py
+++ b/h/test/api_test.py
@@ -2,6 +2,10 @@
 
 """Defines unit tests for h.api."""
 
+from collections import namedtuple
+import unittest
+
+from annotator import auth
 from mock import patch, MagicMock, Mock
 from pytest import fixture, raises
 from pyramid.testing import DummyRequest, DummyResource
@@ -66,6 +70,66 @@ def user(monkeypatch):
     get_user.return_value = user
     monkeypatch.setattr(api, 'get_user', get_user)
     return user
+
+
+FakeClient = namedtuple('FakeClient', 'client_id client_secret ttl')
+
+
+class TestToken(unittest.TestCase):
+
+    def setUp(self):
+        self.tok = api.Token()
+
+        self.client = FakeClient('myclientid', 'secretz!', 3600)
+        self.request = DummyRequest(client=self.client,
+                                    extra_credentials=None)
+        self.request.headers['X-Annotator-Auth-Token'] = 'foobarbaz'
+
+        self.decode_token_patcher = patch('annotator.auth.decode_token')
+        self.decode_token = self.decode_token_patcher.start()
+        self.decode_token.return_value = {'consumerKey': 'myclientid'}
+
+        self.get_consumer_patcher = patch('h.api.get_consumer')
+        self.get_consumer = self.get_consumer_patcher.start()
+        self.get_consumer.return_value = self.client
+
+    def tearDown(self):
+        self.decode_token_patcher.stop()
+        self.get_consumer_patcher.stop()
+
+    def test_created_token_has_access_token(self):
+        res = self.tok.create_token(self.request)
+        assert res['access_token'] is not None
+
+    def test_created_token_has_correct_ttl(self):
+        self.request.client = FakeClient('foo', 'bar', 1234)
+        res = self.tok.create_token(self.request)
+        assert res['expires_in'] == 1234
+
+    def test_validate_request_no_header(self):
+        del self.request.headers['X-Annotator-Auth-Token']
+        res = self.tok.validate_request(self.request)
+        assert res is False
+
+    def test_validate_request_no_client(self):
+        self.get_consumer.return_value = None
+        res = self.tok.validate_request(self.request)
+        assert res is False
+
+    def test_validate_request_invalid_token(self):
+        self.decode_token.side_effect = auth.TokenInvalid
+        res = self.tok.validate_request(self.request)
+        assert res is False
+
+    def test_validate_request_incorrect_client(self):
+        self.decode_token.return_value = {'consumerKey': 'someoneelse'}
+        res = self.tok.validate_request(self.request)
+        assert res is False
+
+    def test_validate_request_uses_header(self):
+        self.tok.validate_request(self.request)
+        self.decode_token.assert_called_once_with(
+            'foobarbaz', 'secretz!', 3600)
 
 
 def test_index():


### PR DESCRIPTION
This is ugly, but because `Consumer#secret` is a UUID, we should be using
the `Consumer#client_secret` property here which is a string (unicode)
representation of the secret.

The prior state causes 500s on the token endpoint on a fresh checkout.
