### PR TITLE
Only run tests from the h package

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,2 @@
 [easy_install]
 zip_ok = false
-
-[pytest]
-norecursedirs = .git lib src node_modules

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ import versioneer
 class PyTest(TestCommand):
     def finalize_options(self):
         TestCommand.finalize_options(self)
-        self.test_args = []
+        self.test_args = ['h']
         self.test_suite = True
 
     def run_tests(self):


### PR DESCRIPTION
By default, our bootstrap script installs the virtualenv on top of the
repository root. When we "pip install -e .", a copy of the source is
placed into the "local/" directory at the repository root[1](https://github.com/pypa/virtualenv/blob/93cfa83/virtualenv.py#L1520), which
causes tests to be discovered there, as well.

We can't simply ignore the "local/" directory, because py.test's
norecursedirs option only allows patterns to be specified[2](http://pytest.org/latest/customize.html#confval-norecursedirs), not
absolute paths, and including "local" would cause tests in
"h.auth.local" to be skipped.

This commit also removes a few other ignores from the norecursedirs
option that are no longer necessary as a result of the change to
setup.py.
