### PR TITLE
Clean up pylint annotations not being used

### DIFF
--- a/h/api.py
+++ b/h/api.py
@@ -16,7 +16,7 @@ from h import events, interfaces
 from h.models import Annotation, Document
 
 
-log = logging.getLogger(__name__)  # pylint: disable=invalid-name
+log = logging.getLogger(__name__)
 
 
 # These annotation fields are not to be set by the user.

--- a/h/assets.py
+++ b/h/assets.py
@@ -5,11 +5,10 @@ import re
 from deform.field import Field
 import pyramid
 
-log = logging.getLogger(__name__)  # pylint: disable=invalid-name
+log = logging.getLogger(__name__)
 
 
 class WebassetsResourceRegistry(object):
-    # pylint: disable=too-few-public-methods
 
     def __init__(self, env):
         self.env = env
@@ -43,7 +42,6 @@ class AssetRequest(object):
     users don't register their own views this way) and it supports all static
     view requests (not just those registered by pyramid_webassets).
     """
-    # pylint: disable=too-few-public-methods
 
     def __init__(self, val, config):
         self.val = val

--- a/h/auth/local/models.py
+++ b/h/auth/local/models.py
@@ -40,7 +40,6 @@ class GUID(TypeDecorator):
     CHAR(32), storing as stringified hex values.
 
     """
-    # pylint: disable=too-many-public-methods
     impl = CHAR
 
     def load_dialect_impl(self, dialect):
@@ -129,7 +128,6 @@ class Group(GroupMixin, Base):
 
 
 class User(UserMixin, Base):
-    # pylint: disable=too-many-public-methods
 
     @classmethod
     def get_by_id(cls, request, userid):

--- a/h/auth/local/schemas.py
+++ b/h/auth/local/schemas.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-# pylint: disable=no-init, too-few-public-methods
 from pkg_resources import resource_stream
 
 import colander
@@ -66,7 +65,7 @@ class CSRFSchema(colander.Schema):
                                      default=deferred_csrf_token,
                                      missing=None)
 
-    def validator(self, form, value):  # pylint: disable=R0201
+    def validator(self, form, value):
         request = form.bindings['request']
         check_csrf_token(request)
 

--- a/h/auth/local/subscribers.py
+++ b/h/auth/local/subscribers.py
@@ -26,7 +26,6 @@ def login(event):
 
 
 class AutoLogin(object):
-    # pylint: disable=too-few-public-methods
 
     def __init__(self, val, config):
         self.val = val

--- a/h/events.py
+++ b/h/events.py
@@ -3,7 +3,6 @@ __all__ = ['AnnotationEvent']
 
 
 class AnnotationEvent(object):
-    # pylint: disable=too-few-public-methods
 
     def __init__(self, request, annotation, action):
         self.request = request

--- a/h/interfaces.py
+++ b/h/interfaces.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-# pylint: disable=too-many-public-methods
 from zope.interface import Interface
 
 

--- a/h/migrations/versions/209c3cd1a864_change_usersubscriptions_table_to_.py
+++ b/h/migrations/versions/209c3cd1a864_change_usersubscriptions_table_to_.py
@@ -24,7 +24,6 @@ class JSONEncodedDict(TypeDecorator):
         JSONEncodedDict(255)
 
     """
-    # pylint: disable=too-many-public-methods
     impl = VARCHAR
 
     def process_bind_param(self, value, dialect):

--- a/h/models.py
+++ b/h/models.py
@@ -176,6 +176,9 @@ class Annotation(annotation.Annotation):
 
     @classmethod
     def update_settings(cls):
+        # Due to metaprogramming magic happening in the annotator library, we
+        # have to pretend to pylint that cls.es exists
+        #
         # pylint: disable=no-member
         cls.es.conn.indices.close(index=cls.es.index)
         try:

--- a/h/notification/domain_mailer.py
+++ b/h/notification/domain_mailer.py
@@ -14,7 +14,7 @@ from h.notification.gateway import user_profile_url, standalone_url
 from h.notification.notifier import send_email, TemplateRenderException
 from h.notification.types import ROOT_PATH
 
-log = logging.getLogger(__name__)  # pylint: disable=invalid-name
+log = logging.getLogger(__name__)
 
 TXT_TEMPLATE = ROOT_PATH + 'document_owner_notification.txt'
 HTML_TEMPLATE = ROOT_PATH + 'document_owner_notification.html'

--- a/h/notification/models.py
+++ b/h/notification/models.py
@@ -12,7 +12,6 @@ log = logging.getLogger(__name__)
 
 
 class SubscriptionsMixin(BaseModel):
-    # pylint: disable=no-self-use
     @declared_attr
     def __table_args__(self):
         return sa.Index('subs_uri_idx_%s' % self.__tablename__, 'uri'),

--- a/h/notification/reply_template.py
+++ b/h/notification/reply_template.py
@@ -18,7 +18,7 @@ from h.notification.types import ROOT_PATH
 from h.events import LoginEvent, AnnotationEvent
 from h.models import Annotation
 
-log = logging.getLogger(__name__)  # pylint: disable=invalid-name
+log = logging.getLogger(__name__)
 
 TXT_TEMPLATE = ROOT_PATH + 'reply_notification.txt'
 HTML_TEMPLATE = ROOT_PATH + 'reply_notification.html'

--- a/h/resources.py
+++ b/h/resources.py
@@ -8,7 +8,7 @@ from zope.interface import implementer
 from h import interfaces, security
 from h.models import Annotation
 
-log = logging.getLogger(__name__)  # pylint: disable=invalid-name
+log = logging.getLogger(__name__)
 
 
 @implementer(ILocation)
@@ -108,7 +108,7 @@ class RootFactory(Stream, InnerResource):
     api = APIResource
     stream = Stream
 
-    def __acl__(self):  # pylint: disable=no-self-use
+    def __acl__(self):
         defaultlist = [
             (Allow, 'group:admin', ALL_PERMISSIONS),
             (Allow, Authenticated, 'create'),

--- a/h/streamer.py
+++ b/h/streamer.py
@@ -17,7 +17,7 @@ from h import events
 from h.api import get_user
 from h.models import Annotation
 
-log = logging.getLogger(__name__)  # pylint: disable=invalid-name
+log = logging.getLogger(__name__)
 
 filter_schema = {
     "type": "object",
@@ -320,7 +320,6 @@ class FilterHandler(object):
             if field_value is None:
                 return False
 
-            # pylint: disable=maybe-no-member
             if clause.get('case_sensitive', True):
                 cval = clause['value']
                 fval = field_value
@@ -334,7 +333,6 @@ class FilterHandler(object):
                     fval = [x.lower() for x in field_value]
                 else:
                     fval = field_value.lower()
-            # pylint: enable=maybe-no-member
 
             reversed_order = False
             # Determining operator order

--- a/h/test/assets_test.py
+++ b/h/test/assets_test.py
@@ -11,7 +11,6 @@ from h import assets
 
 class DummyEvent(object):
     """A dummy event for testing registry events."""
-    # pylint: disable=too-few-public-methods
 
     def __init__(self, request):
         self.request = request
@@ -40,7 +39,6 @@ def test_subscriber_predicate(settings):
     mock2 = Mock()
 
     with testConfig(settings=settings) as config:
-        # pylint: disable=attribute-defined-outside-init
         config.include(assets)
         config.add_subscriber(mock1, DummyEvent, asset_request=False)
         config.add_subscriber(mock2, DummyEvent, asset_request=True)

--- a/h/testing.py
+++ b/h/testing.py
@@ -11,7 +11,7 @@ from h.layouts import BaseLayout
 from h.notification import reply_template
 
 import logging
-log = logging.getLogger(__name__)  # pylint: disable=invalid-name
+log = logging.getLogger(__name__)
 
 
 @view_config(layout='pattern_library',

--- a/h/views.py
+++ b/h/views.py
@@ -7,7 +7,7 @@ from pyramid.events import ContextFound
 from pyramid.view import view_config, notfound_view_config
 
 
-log = logging.getLogger(__name__)  # pylint: disable=invalid-name
+log = logging.getLogger(__name__)
 
 
 @view_config(


### PR DESCRIPTION
The current Prospector configuration doesn't trigger any of these warnings.
