### PR TITLE
Re-add jQuery output to the assets.yaml

### DIFF
--- a/h/assets.yaml
+++ b/h/assets.yaml
@@ -145,6 +145,7 @@ angular_tags_input:
 
 # jQuery
 jquery:
+  output: scripts/vendor/jquery.min.js
   contents:
     - h:static/scripts/vendor/jquery.min.js
 jquery_scrollintoview:


### PR DESCRIPTION
Otherwise the Chrome extension doesn't get the jQuery file copied into it's public folder when building a production copy.

@BigBlueHat @tilgovi could you verify this change, this fixes my issue, but it looks like the line was intentionally removed in dc507f0f67a281b03a44efd0f8b3409cf9e7093c
