### PR TITLE
[WIP] Style the visual diff support

### DIFF
--- a/h/static/styles/annotations.scss
+++ b/h/static/styles/annotations.scss
@@ -46,6 +46,12 @@
 
 .annotation-quote {
   @include quote;
+  del {
+    background:#ffe6e6;
+  }
+  ins {
+    background:#e6ffe6;
+  }
 }
 
 .annotation-citation-domain {


### PR DESCRIPTION
This PR adds back the colors.

Before:

![before](https://cloud.githubusercontent.com/assets/2093792/5194771/12aaa96c-7513-11e4-8704-935029d2a9cb.png)

After:

![after](https://cloud.githubusercontent.com/assets/2093792/5194775/1bc8cfb0-7513-11e4-967a-8cf90ae47b3b.png)

The problems with the location of the checkbox still remains. See for example this:

![remaining](https://cloud.githubusercontent.com/assets/2093792/5194781/2c0931f8-7513-11e4-8dd3-35e2b2c42674.png)

(Search for the "Show differences" checkbox.)

I would appreciate if someone could take a look at the CSS, and fix it. 
