### PR TITLE
[WIP] Restore feature to scroll for annotations

### DIFF
--- a/h/static/scripts/controllers.coffee
+++ b/h/static/scripts/controllers.coffee
@@ -345,7 +345,7 @@ class ViewerController
           method: 'setActiveHighlights'
           params: highlights
 
-    $scope.scrollto = (annotation) ->
+    $scope.scrollTo = (annotation) ->
       if angular.isObject annotation
         for p in annotator.providers
           p.channel.notify

--- a/h/templates/client/viewer.html
+++ b/h/templates/client/viewer.html
@@ -39,7 +39,7 @@
       thread-collapsed="!search.query"
       ng-include="'thread.html'"
       ng-mouseenter="activate(child.message)"
-      ng-click="scrollto(child.message)""
+      ng-click="scrollTo(child.message)""
       ng-mouseleave="activate()"
       ng-repeat="child in vm.container.children | orderBy : sort.predicate"
       ng-show="vm.container && shouldShowThread(child) &&


### PR DESCRIPTION
Clicking on an annotation card will bring (one of the) highlights belonging to that annotation into the view in the document.
