### PR TITLE
Fix a bug introduced with visual diff support

### DIFF
--- a/h/static/scripts/directives/annotation.coffee
+++ b/h/static/scripts/directives/annotation.coffee
@@ -134,6 +134,7 @@ AnnotationController = [
     # shouldShowDiff is set to true if there are some meaningful differences
     #  - that is, more than just uppercase / lowercase
     diffFromTargets = (targets) ->
+      return {hasDiff: false, shouldShowDiff: false} unless targets?
       hasDiff = targets.some (t) ->
         t.diffHTML?
       shouldShowDiff = hasDiff and targets.some (t) ->


### PR DESCRIPTION
When creating a reply, there was an exception
on the console, because the target list is empty,
and some code was not prepared for that.

This takes care of that.
