### PR TITLE
Revert "Remove useless check"

### DIFF
--- a/h/static/scripts/controllers.coffee
+++ b/h/static/scripts/controllers.coffee
@@ -346,10 +346,11 @@ class ViewerController
           params: highlights
 
     $scope.scrollTo = (annotation) ->
-      for p in annotator.providers
-        p.channel.notify
-          method: 'scrollTo'
-          params: annotation.$$tag
+      if angular.isObject annotation
+        for p in annotator.providers
+          p.channel.notify
+            method: 'scrollTo'
+            params: annotation.$$tag
 
     $scope.shouldShowThread = (container) ->
       if $scope.selectedAnnotations? and not container.parent.parent


### PR DESCRIPTION
Reverts hypothesis/h#1723

I found a case when the test is needed: when we click on the card of a deleted annotation.
