### PR TITLE
Remove the gray bg from annotation cards on hover

### DIFF
--- a/h/static/styles/threads.scss
+++ b/h/static/styles/threads.scss
@@ -74,10 +74,6 @@ $threadexp-width: .6em;
   }
 
   &.thread-collapsed {
-    &:hover {
-      background-color: $gray-lightest;
-    }
-
     & > ul {
       display: none;
     }


### PR DESCRIPTION
As discussed in #1634
