### PR TITLE
Consistent names for focusing on annotations

### DIFF
--- a/h/static/scripts/controllers.coffee
+++ b/h/static/scripts/controllers.coffee
@@ -305,7 +305,7 @@ class AnnotationViewerController
 
     # Provide no-ops until these methods are moved elsewere. They only apply
     # to annotations loaded into the stream.
-    $scope.activate = angular.noop
+    $scope.focus = angular.noop
 
     $scope.shouldShowThread = -> true
 
@@ -335,14 +335,14 @@ class ViewerController
     $scope.isEmbedded = true
     $scope.isStream = true
 
-    $scope.activate = (annotation) ->
+    $scope.focus = (annotation) ->
       if angular.isObject annotation
         highlights = [annotation.$$tag]
       else
         highlights = []
       for p in annotator.providers
         p.channel.notify
-          method: 'setActiveHighlights'
+          method: 'setFocusedHighlights'
           params: highlights
 
     $scope.scrollTo = (annotation) ->

--- a/h/static/scripts/guest.coffee
+++ b/h/static/scripts/guest.coffee
@@ -143,7 +143,7 @@ class Annotator.Guest extends Annotator
       if value then @plugins.Heatmap._update()
     )
 
-    .bind('setActiveHighlights', (ctx, tags=[]) =>
+    .bind('setFocusedHighlights', (ctx, tags=[]) =>
       for hl in @getHighlights()
         if hl.annotation.$$tag in tags
           hl.setActive true, true

--- a/h/templates/client/viewer.html
+++ b/h/templates/client/viewer.html
@@ -38,9 +38,9 @@
       thread="child" thread-filter
       thread-collapsed="!search.query"
       ng-include="'thread.html'"
-      ng-mouseenter="activate(child.message)"
+      ng-mouseenter="focus(child.message)"
       ng-click="scrollTo(child.message)""
-      ng-mouseleave="activate()"
+      ng-mouseleave="focus()"
       ng-repeat="child in vm.container.children | orderBy : sort.predicate"
       ng-show="vm.container && shouldShowThread(child) &&
                (count('edit') || count('match') || !threadFilter.active())">


### PR DESCRIPTION
Consistently use "focus" for describing what we do with the highlights in the document when the user hovers the mouse pointer over the corresponding annotation card.

(As per terminology recently finalized while discussing https://github.com/hypothesis/h/issues/1728 and https://github.com/hypothesis/h/issues/1729)
