### PR TITLE
Standardise on "Hypothesis" for the name of the software

### DIFF
--- a/INSTALL.ArchLinux.rst
+++ b/INSTALL.ArchLinux.rst
@@ -1,5 +1,5 @@
-Installing Hypothes.is on ArchLinux
-###################################
+Installing Hypothesis on ArchLinux
+##################################
 
 Install the following packages:
 

--- a/INSTALL.Debian.rst
+++ b/INSTALL.Debian.rst
@@ -1,5 +1,5 @@
-Installing Hypothes.is on Debian
-################################
+Installing Hypothesis on Debian
+###############################
 
 Currently (november 2012), the required packages are not part of the stable
 distribution; you need to fetch some stuff from the unstable ditribution.

--- a/INSTALL.Fedora.rst
+++ b/INSTALL.Fedora.rst
@@ -1,5 +1,5 @@
-Installing Hypothes.is on Fedora
-################################
+Installing Hypothesis on Fedora
+###############################
 
 To install the dependencies, run these commands:
 

--- a/INSTALL.OSX.rst
+++ b/INSTALL.OSX.rst
@@ -1,5 +1,5 @@
-Installing Hypothes.is on OSX
-#############################
+Installing Hypothesis on OSX
+############################
 
 Run the following commands from the directory where you've cloned this repository.
 

--- a/INSTALL.Ubuntu.rst
+++ b/INSTALL.Ubuntu.rst
@@ -1,5 +1,5 @@
-Installing Hypothes.is on Ubuntu Server 12.04.2 LTS
-###################################################
+Installing Hypothesis on Ubuntu Server 12.04.2 LTS
+##################################################
 
 To install the dependencies, run these commands:
 

--- a/INSTALL.Vagrant.rst
+++ b/INSTALL.Vagrant.rst
@@ -1,9 +1,9 @@
-Installing Hypothes.is with Vagrant
-###################################
+Installing Hypothesis with Vagrant
+##################################
 
-Running Hypothes.is on a VM enables development on Windows machines, and also provides a "clean box"
+Running Hypothesis on a VM enables development on Windows machines, and also provides a "clean box"
 for testing dependencies.  The following instructions will use Vagrant to create and manage
-a VirtualBox Ubuntu VM with Hypothes.is and all its dependencies on it.
+a VirtualBox Ubuntu VM with Hypothesis and all its dependencies on it.
 
 Install Vagrant
 ---------------

--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
-Hypothes.is
+Hypothesis
 Copyright 2012, Hypothes.is Project and contributors
 
 This product includes software developed at

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
-Hypothes.is
-===========
+Hypothesis
+==========
 
 .. image:: https://travis-ci.org/hypothesis/h.svg?branch=master
    :target: https://travis-ci.org/hypothesis/h
@@ -8,7 +8,7 @@ Hypothes.is
 About
 -----
 
-Hypothes.is brings community peer review to The Internet. It is a web
+Hypothesis brings community peer review to The Internet. It is a web
 application which enables rich annotation of web content. The project acts as
 a community aggregator for annotations and identity provider [*]_ for
 annotators. It also serves embed code for an annotation agent designed with
@@ -183,7 +183,7 @@ To build the documentation, ensure that Sphinx_ is installed and issue the
 License
 -------
 
-Hypothes.is is released under the `2-Clause BSD License`_, sometimes referred
+Hypothesis is released under the `2-Clause BSD License`_, sometimes referred
 to as the "Simplified BSD License" or the "FreeBSD License". Some third-party
 components are included. They are subject to their own licenses. All of the
 license information can be found in the included `<LICENSE>`_ file.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -3,7 +3,7 @@ Source Documentation
 
 Reference material for the public APIs exposed is available in this section. It
 It is targeted at developers interested in integrating functionality from
-Hypothes.is into their own Python applications. ::
+Hypothesis into their own Python applications. ::
 
     {
       "message": "Annotator Store API", 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# The Hypothes.is Annotation Framework documentation build configuration file, created by
+# The Hypothesis Annotation Framework documentation build configuration file, created by
 # sphinx-quickstart on Fri Oct 12 19:21:42 2012.
 #
 # This file is execfile()d with the current directory set to its containing dir.
@@ -40,7 +40,7 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'The Hypothes.is Annotation Framework'
+project = u'The Hypothesis Annotation Framework'
 copyright = u'2012, Hypothes.is Project and contributors'
 
 # The version info for the project you're documenting, acts as replacement for
@@ -183,7 +183,7 @@ latex_elements = {
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-  ('index', 'TheHypothesisAnnotationFramework.tex', u'The Hypothes.is Annotation Framework Documentation',
+  ('index', 'TheHypothesisAnnotationFramework.tex', u'The Hypothesis Annotation Framework Documentation',
    u'Hypothes.is Project and contributors', 'manual'),
 ]
 
@@ -213,7 +213,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('index', 'thehypothesisannotationframework', u'The Hypothes.is Annotation Framework Documentation',
+    ('index', 'thehypothesisannotationframework', u'The Hypothesis Annotation Framework Documentation',
      [u'Hypothes.is Project and contributors'], 1)
 ]
 
@@ -227,7 +227,7 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  ('index', 'TheHypothesisAnnotationFramework', u'The Hypothes.is Annotation Framework Documentation',
+  ('index', 'TheHypothesisAnnotationFramework', u'The Hypothesis Annotation Framework Documentation',
    u'Hypothes.is Project and contributors', 'TheHypothesisAnnotationFramework', 'One line description of project.',
    'Miscellaneous'),
 ]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,10 +1,10 @@
-.. The Hypothes.is Annotation Framework documentation master file, created by
+.. The Hypothesis Annotation Framework documentation master file, created by
    sphinx-quickstart on Fri Oct 12 19:21:42 2012.
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Welcome to The Hypothes.is Annotation Framework's documentation!
-================================================================
+Welcome to The Hypothesis Annotation Framework's documentation!
+===============================================================
 
 Contents:
 

--- a/h/browser/chrome/help/index.html
+++ b/h/browser/chrome/help/index.html
@@ -1,7 +1,7 @@
 <html>
   <head>
     <meta charset="utf-8" />
-    <title>Hypothes.is Help</title>
+    <title>Hypothesis Help</title>
     <style>
       body {
         font-family: 'Helvetica Neue', Helvetica, Arial, 'Lucida Grande', sans-serif;
@@ -70,7 +70,7 @@
     <article class="help-container">
       <section id="no-file-access" class="help-item">
         <img class="help-item__icon" src="sad-annotation.svg" />
-        <h1 class="help-item__heading">We’re sorry, Hypothes.is couldn’t open that file…</h1>
+        <h1 class="help-item__heading">We’re sorry, Hypothesis couldn’t open that file…</h1>
         <p>If it’s a local PDF document that you’ve opened from your computer
           you’ll need to change your settings to allow us to access these files.
         </p>
@@ -93,12 +93,12 @@
       </section>
       <section id="local-file" class="help-item">
         <img class="help-item__icon" src="sad-annotation.svg" />
-        <h1 class="help-item__heading">We’re sorry, Hypothes.is couldn’t open that file…</h1>
+        <h1 class="help-item__heading">We’re sorry, Hypothesis couldn’t open that file…</h1>
         <p class="center">This extension can’t be used on local HTML documents at the moment.</p>
       </section>
       <section id="restricted-protocol" class="help-item">
         <img class="help-item__icon" src="sad-annotation.svg" />
-        <h1 class="help-item__heading">We’re sorry, Hypothes.is doesn’t work on this page…</h1>
+        <h1 class="help-item__heading">We’re sorry, Hypothesis doesn’t work on this page…</h1>
         <p class="center">This extension can only be used on pages served over HTTP/HTTPS and FTP.</p>
       </section>
     </article>

--- a/h/browser/chrome/manifest.json
+++ b/h/browser/chrome/manifest.json
@@ -1,5 +1,5 @@
 {
-  "name": "Hypothes.is",
+  "name": "Hypothesis",
   "version": "{{ version }}",
   "manifest_version": 2,
 

--- a/h/notification/templates/document_owner_notification.html
+++ b/h/notification/templates/document_owner_notification.html
@@ -10,4 +10,4 @@ From:
 On {{ timestamp }} at ({{ path }})
 About ${document_path}
 --
-This is an annotation on your document from Hypothes.is / Annotator (URL here)</p>
+This is an annotation on your document from Hypothesis / Annotator (URL here)</p>

--- a/h/notification/templates/document_owner_notification.txt
+++ b/h/notification/templates/document_owner_notification.txt
@@ -10,4 +10,4 @@ From:
 On {{ timestamp }} at ({{ path }})
 About {{ document_path }}
 --
-This is an annotation on your document from Hypothes.is / Annotator (URL here)
+This is an annotation on your document from Hypothesis / Annotator (URL here)

--- a/h/script.py
+++ b/h/script.py
@@ -30,7 +30,7 @@ def get_config(args):
 
 version = __version__
 description = """\
-The Hypothes.is Project Annotation System
+The Hypothesis Project Annotation System
 """
 
 command = App(

--- a/h/templates/bookmarklet.js
+++ b/h/templates/bookmarklet.js
@@ -8,7 +8,7 @@
   var embed;
 
   if (isLocal && !isPDF) {
-    window.alert('Sorry, Hypothes.is doesn\'t work on this type of file. Only PDF\'s can be annotated locally.');
+    window.alert('Sorry, Hypothesis doesn\'t work on this type of file. Only PDF\'s can be annotated locally.');
     return;
   }
   if (isPDF && !hasPDFjs) {

--- a/h/templates/help.html
+++ b/h/templates/help.html
@@ -118,7 +118,7 @@
         <section class="help-page-section">
           <h2 id="contributing" class="help-page-heading">Contributing</h2>
           <div class="styled-text">
-            <p>Hypothes.is is an open source effort licensed under a 2-Clause <a
+            <p>Hypothesis is an open source effort licensed under a 2-Clause <a
                 href="https://en.wikipedia.org/wiki/BSD_licenses">BSD License</a>,
               sometimes referred to as the "Simplified BSD License" or the "FreeBSD
               License".</p>

--- a/h/templates/layouts/base.html
+++ b/h/templates/layouts/base.html
@@ -10,7 +10,7 @@
       {% endfor %}
     {% endblock %}
 
-    <title>{% block title %}Hypothes.is{% endblock %}</title>
+    <title>{% block title %}Hypothesis{% endblock %}</title>
 
     {% for rel, href in layout.link_attrs %}
       <link rel="{{ rel }}" href="{{ href }}" />

--- a/h/templates/pattern_library.html
+++ b/h/templates/pattern_library.html
@@ -692,7 +692,7 @@
               </fuzzytime>
             </header>
             <section class="">
-              <blockquote class="annotation-quote">Hypothes.is is an open source effort licensed under a 2-Clause BSD License, sometimes referred to as the "Simplified BSD License" or the "FreeBSD License".</blockquote>
+              <blockquote class="annotation-quote">Hypothesis is an open source effort licensed under a 2-Clause BSD License, sometimes referred to as the "Simplified BSD License" or the "FreeBSD License".</blockquote>
             </section>
             <section name="text" markdown="" class="" readonly="readonly">
               <textarea class="form-input form-textarea ng-hide"></textarea>
@@ -752,7 +752,7 @@
               </fuzzytime>
             </header>
             <section class="">
-              <blockquote class="annotation-quote">Hypothes.is is an open source effort licensed under a 2-Clause BSD License, sometimes referred to as the "Simplified BSD License" or the "FreeBSD License".</blockquote>
+              <blockquote class="annotation-quote">Hypothesis is an open source effort licensed under a 2-Clause BSD License, sometimes referred to as the "Simplified BSD License" or the "FreeBSD License".</blockquote>
             </section>
             <section name="text" markdown="" class="" readonly="readonly">
               <textarea class="form-input form-textarea ng-hide"></textarea>


### PR DESCRIPTION
As discussed, we're going to use Hypothesis in textual references to our software.

I haven't changed instances of "Hypothes.is" where they refer to the legal entity.
