### PR TITLE
Provide a feedback button in the interface

### DIFF
--- a/h/static/styles/topbar.scss
+++ b/h/static/styles/topbar.scss
@@ -55,7 +55,7 @@ body {
       font-family: $sans-font-family;
     }
 
-    & > * {
+    & > *:first-child, & > *:last-child {
       line-height: 28px;
       margin: 0 .72em;
     }

--- a/h/templates/app.html
+++ b/h/templates/app.html
@@ -9,25 +9,25 @@
   <div class="ng-cloak topbar" ng-class="frame.visible && 'shown'">
     <div class="inner" ng-switch="persona">
       <span class="pull-right" ng-switch-when="undefined">⋯</span>
-      <a class="pull-right" href=""
-         ng-click="login()"
-         ng-switch-when="null">Sign in</a>
-      <div class="dropdown pull-right user-picker" ng-switch-default>
+      <div class="dropdown pull-right user-picker">
         <span role="button"
               class="dropdown-toggle"
               data-toggle="dropdown">{% raw %}{{ persona|persona }}{% endraw %}<!--
-          --><span class="provider">/{% raw %}{{ persona|persona:'provider' }}{% endraw %}</span><!--
+          --><span class="provider" ng-show="persona">/{% raw %}{{ persona|persona:'provider' }}{% endraw %}</span><!--
           --><i class="h-icon-triangle"></i></span>
         <ul class="dropdown-menu pull-right" role="menu">
-          <li><a href="" ng-click="dialog.visible='true'">Account</a></li>
-          <li><a href="http://hypothes.is/contact/"
+          <li ng-show="persona"><a href="" ng-click="dialog.visible='true'">Account</a></li>
+          <li><a href="mailto:support@hypothes.is"
                  target="_blank">Feedback</a></li>
           <li><a href="/docs/help" target="_blank">Help</a></li>
-          <li><a href="/stream?q=user:{% raw %}{{ persona|persona }}{% endraw %}"
+          <li ng-show="persona"><a href="/stream?q=user:{% raw %}{{ persona|persona }}{% endraw %}"
                  target="_blank">My Annotations</a></li>
-          <li ng-click="logout()">Sign out</li>
+          <li ng-show="persona" ng-click="logout()">Sign out</li>
         </ul>
       </div>
+      <a class="pull-right" href=""
+         ng-click="login()"
+         ng-switch-when="null">Sign in</a>
 
       <!-- Searchbar -->
       <div class="simple-search"


### PR DESCRIPTION
Meant to resolve #1653. As per @dwhly's suggestion the dropdown menu is now accessible even when not logged in. Note: items relevant to only logged in users are not shown.

It now looks like this:
![hypothesis](https://cloud.githubusercontent.com/assets/521978/5252335/897f3188-7951-11e4-94ba-f8861f6e2054.png)

The feedback link consists of `mailto:support@hypothes.is` which the hypothes.is team should now have access to. 
