### PR TITLE
Use an object for privacy level models

### DIFF
--- a/h/templates/client/privacy.html
+++ b/h/templates/client/privacy.html
@@ -3,15 +3,16 @@
         role="button"
         class="dropdown-toggle"
         data-toggle="dropdown">
-        <i class="small" ng-class="{'h-icon-earth': level == 'Public', 'h-icon-locked': level == 'Only Me'}"></i>
-        {{level}}
+        <i class="small" ng-class="{'h-icon-earth': level.name == 'public',
+                                    'h-icon-locked': level.name == 'private'}"></i>
+        {{level.text}}
         <i class="h-icon-triangle"></i>
   </span>
   <ul class="dropdown-menu" role="menu">
-    <li ng-repeat="p in levels" ng-click="setLevel(p)">
-      <i class="small" ng-class="{'h-icon-earth': p == 'Public',
-                                  'h-icon-locked': p == 'Only Me'}"></i>
-      {{p}}
+    <li ng-repeat="level in levels" ng-click="setLevel(level)">
+      <i class="small" ng-class="{'h-icon-earth': level.name == 'public',
+                                  'h-icon-locked': level.name == 'private'}"></i>
+      {{level.text}}
     </li>
   </ul>
 </div>

--- a/tests/js/directives/privacy-test.coffee
+++ b/tests/js/directives/privacy-test.coffee
@@ -42,7 +42,7 @@ describe 'h.directives.privacy', ->
         $element = $compile('<privacy ng-model="permissions">')($scope)
         $scope.$digest()
         $isolateScope = $element.isolateScope()
-        $isolateScope.setLevel('Public')
+        $isolateScope.setLevel(name: VISIBILITY_PUBLIC)
 
         $scope2.permissions = {read: []}
         $element = $compile('<privacy ng-model="permissions">')($scope2)
@@ -71,7 +71,7 @@ describe 'h.directives.privacy', ->
         $element = $compile('<privacy ng-model="permissions">')($scope)
         $scope.$digest()
         $isolateScope = $element.isolateScope()
-        $isolateScope.setLevel('Public')
+        $isolateScope.setLevel(name: VISIBILITY_PUBLIC)
 
         expected = VISIBILITY_PUBLIC
         stored = store.getItem VISIBILITY_KEY
@@ -94,14 +94,14 @@ describe 'h.directives.privacy', ->
           $isolateScope = $element.isolateScope()
 
         it 'sets the initial permissions based on the stored privacy level', ->
-          assert.equal $isolateScope.level, 'Public'
+          assert.equal $isolateScope.level.name, VISIBILITY_PUBLIC
 
         it 'does not alter the level on subsequent renderings', ->
           modelCtrl = $element.controller('ngModel')
           store.setItem VISIBILITY_KEY, VISIBILITY_PRIVATE
           $scope.permissions.read = ['acct:user@example.com']
           $scope.$digest()
-          assert.equal $isolateScope.level, 'Public'
+          assert.equal $isolateScope.level.name, VISIBILITY_PUBLIC
 
       describe 'when permissions.read is filled', ->
         it 'does not alter the level', ->
@@ -111,7 +111,7 @@ describe 'h.directives.privacy', ->
           $element = $compile('<privacy ng-model="permissions">')($scope)
           $scope.$digest()
           $isolateScope = $element.isolateScope()
-          assert.equal($isolateScope.level, 'Public')
+          assert.equal($isolateScope.level.name, VISIBILITY_PUBLIC)
 
       describe 'user attribute', ->
         beforeEach ->


### PR DESCRIPTION
This makes the association between the level key name and the display
text explicit and tight in the code.
