### PR TITLE
Update License and Notice files

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -232,3 +232,27 @@ The MIT License (MIT)
 
 Additional licenses apply to icon graphics. See the file "license.txt"
 included with the image and font files for details.
+
+For the KaTex subcomponent:
+
+ The MIT License (MIT)
+
+ Copyright (c) 2014 Khan Academy
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.

--- a/NOTICE
+++ b/NOTICE
@@ -55,3 +55,7 @@ This product also includes the following third-party components:
  * Autofill event polyfill (https://github.com/tbosch/autofill-event)
 
    Copyright 2014 Google, Inc.
+
+ * KaTex (http://khan.github.io/KaTeX/)
+
+   Copyright (c) 2014 Khan Academy


### PR DESCRIPTION
I was poking around today and noticed our license and notice files had things in them that we weren't using anymore (d3 and yepnope), so I removed them. I also noticed that they were missing mention of KaTex, so I added that.

If you notice other things that are wrong or outdated in these files, please point them out. I'm happy to address them quickly.
