### PR TITLE
Renamed a few methods to be more consistent

### DIFF
--- a/h/static/scripts/controllers.coffee
+++ b/h/static/scripts/controllers.coffee
@@ -344,7 +344,7 @@ class ViewerController
       if angular.isObject annotation
         for p in annotator.providers
           p.channel.notify
-            method: 'scrollTo'
+            method: 'scrollToAnnotation'
             params: annotation.$$tag
 
     $scope.shouldShowThread = (container) ->

--- a/h/static/scripts/guest.coffee
+++ b/h/static/scripts/guest.coffee
@@ -151,7 +151,7 @@ class Annotator.Guest extends Annotator
           hl.setFocused false
     )
 
-    .bind('scrollTo', (ctx, tag) =>
+    .bind('scrollToAnnotation', (ctx, tag) =>
       for hl in @getHighlights()
         if hl.annotation.$$tag is tag
           hl.scrollTo()
@@ -228,17 +228,17 @@ class Annotator.Guest extends Annotator
     this.plugins.Bridge.sync([annotation])
     annotation
 
-  showViewer: (annotations) =>
+  showAnnotations: (annotations) =>
     @panel?.notify
       method: "showViewer"
       params: (a.$$tag for a in annotations)
 
-  toggleViewerSelection: (annotations) =>
+  toggleAnnotationSelection: (annotations) =>
     @panel?.notify
       method: "toggleViewerSelection"
       params: (a.$$tag for a in annotations)
 
-  updateViewer: (annotations) =>
+  updateAnnotations: (annotations) =>
     @panel?.notify
       method: "updateViewer"
       params: (a.$$tag for a in annotations)
@@ -290,10 +290,10 @@ class Annotator.Guest extends Annotator
 
     if toggle
       # Tell sidebar to add these annotations to the sidebar
-      this.toggleViewerSelection annotations
+      this.toggleAnnotationSelection annotations
     else
       # Tell sidebar to show the viewer for these annotations
-      this.showViewer annotations
+      this.showAnnotations annotations
 
   # When hovering on a highlight in highlighting mode,
   # tell the sidebar to hilite the relevant annotations

--- a/h/static/scripts/plugin/heatmap.coffee
+++ b/h/static/scripts/plugin/heatmap.coffee
@@ -351,7 +351,7 @@ class Annotator.Plugin.Heatmap extends Annotator.Plugin
     this._buildTabs(@tabs, @buckets)
 
     if @dynamicBucket
-      @annotator.updateViewer this._getDynamicBucket()
+      @annotator.updateAnnotations this._getDynamicBucket()
 
   _buildTabs: ->
     @tabs.each (d, el) =>
@@ -395,4 +395,4 @@ class Annotator.Plugin.Heatmap extends Annotator.Plugin
   # Simulate clicking on the comments tab
   commentClick: =>
     @dynamicBucket = false
-    annotator.showViewer @buckets[@_getCommentBucket()]
+    annotator.showAnnotations @buckets[@_getCommentBucket()]


### PR DESCRIPTION
(As previously discussed with @tilgovi [here](https://github.com/hypothesis/h/pull/1735#commitcomment-8799722).)

Sidebar -> Document RPC methods:
- Renamed `scrollTo()` to `scrollToAnnotation()` (to be consistent with `focusAnnotations()`

Guest methods:
- Renamed `showViewer()` to `showAnnotations()` (to be consistend with `focusAnnotations()`)
- Renamed `updateViewer()` to `updateAnnotations()` (same reason)
- Renamed `toggleViewerSelection()` to `toggleAnnotationSelection()` (same reason)
