### PR TITLE
Rename rpc methods to be more consistent

### DIFF
--- a/h/static/scripts/guest.coffee
+++ b/h/static/scripts/guest.coffee
@@ -230,17 +230,17 @@ class Annotator.Guest extends Annotator
 
   showAnnotations: (annotations) =>
     @panel?.notify
-      method: "showViewer"
+      method: "showAnnotations"
       params: (a.$$tag for a in annotations)
 
   toggleAnnotationSelection: (annotations) =>
     @panel?.notify
-      method: "toggleViewerSelection"
+      method: "toggleAnnotationSelection"
       params: (a.$$tag for a in annotations)
 
   updateAnnotations: (annotations) =>
     @panel?.notify
-      method: "updateViewer"
+      method: "updateAnnotations"
       params: (a.$$tag for a in annotations)
 
   showEditor: (annotation) =>

--- a/h/static/scripts/services.coffee
+++ b/h/static/scripts/services.coffee
@@ -154,12 +154,12 @@ class Hypothesis extends Annotator
         this.showEditor this._getLocalAnnotation(tag)
     )
 
-    .bind('showViewer', (ctx, tags=[]) =>
+    .bind('showAnnotations', (ctx, tags=[]) =>
       @element.scope().$apply =>
         this.showViewer this._getLocalAnnotations(tags)
     )
 
-    .bind('updateViewer', (ctx, tags=[]) =>
+    .bind('updateAnnotations', (ctx, tags=[]) =>
       @element.scope().$apply =>
         this.updateViewer this._getLocalAnnotations(tags)
     )
@@ -169,7 +169,7 @@ class Hypothesis extends Annotator
         this.focusAnnotations tags
     )
 
-    .bind('toggleViewerSelection', (ctx, tags=[]) =>
+    .bind('toggleAnnotationSelection', (ctx, tags=[]) =>
       @element.scope().$apply =>
         this.toggleViewerSelection this._getLocalAnnotations(tags)
     )


### PR DESCRIPTION
Between guests <-> sidebar
- `showViewer()` to  `showAnnotations()`
- `updateViewer()` to `updateAnnotations()`
- `toggleViewerSelection()` to `toggleAnnotationSelection()`

All these renames were to enforce encapsulation and these calls
are more like APIs. To guest side really do not have to know anything
what the sidebar has or does.
