### PR TITLE
Consolidate code paths around deciding about PDF.js

### DIFF
--- a/h/static/scripts/guest.coffee
+++ b/h/static/scripts/guest.coffee
@@ -22,8 +22,6 @@ class Annotator.Guest extends Annotator
     TextPosition: {}
     TextQuote: {}
     FuzzyTextAnchors: {}
-    PDF: {}
-    Document: {}
 
   # Internal state
   tool: 'comment'
@@ -37,8 +35,14 @@ class Annotator.Guest extends Annotator
     super
     delete @options.noScan
 
+    # Are going to be able to use the PDF plugin here?
     if window.PDFTextMapper?.applicable()
-      delete @options.Document
+      # If we can, let's load the PDF plugin.
+      @options.PDF = {}
+    else
+      # If we can't use the PDF plugin,
+      # let's load the Document plugin instead.
+      @options.Document = {}
 
     @frame = $('<div></div>')
     .appendTo(@wrapper)


### PR DESCRIPTION
Annotator's PDF.js plugin replaces the document plugin
for PDF.js, so when we are using the PDF plugin, we
don't want to load the document plugin.

For this, we are removing it from the options, in
presence of PDF.

This commit changes how we test for PDF.

Earlier, we were simply testing for the presence of the
global PDF.js object, but it's better to actually
use the test [already implemented](https://github.com/hypothesis/annotator/blob/ecc323e43bbc94313bf3a0d8b9e1fc18a94afc1f/src/plugin/pdf.coffee#L4) inside the PDF plugin.

This has two benefits:
- If the PDF plugin is not present, we won't
  mistakenly  remove the document plugin.
- If the PDF plugin decides that it can't deploy,
  for whatever reason, we won't
  mistakenly remove the document plugin.
