### PR TITLE
Fix double loading on install

### DIFF
--- a/h/browser/chrome/lib/hypothesis-chrome-extension.js
+++ b/h/browser/chrome/lib/hypothesis-chrome-extension.js
@@ -1,6 +1,8 @@
 (function (h) {
   'use strict';
 
+  var TAB_STATUS_COMPLETE = 'complete';
+
   /* The main extension application. This wires together all the smaller
    * modules. The app listens to all new created/updated/removed tab events
    * and uses the TabState object to keep track of whether the sidebar is
@@ -118,7 +120,7 @@
     function onTabUpdated(tabId, changeInfo, tab) {
       // This function will be called multiple times as the tab reloads.
       // https://developer.chrome.com/extensions/tabs#event-onUpdated
-      if (changeInfo.status !== 'complete') {
+      if (changeInfo.status !== TAB_STATUS_COMPLETE) {
         return;
       }
 
@@ -144,6 +146,11 @@
     }
 
     function updateTabDocument(tab) {
+      // If the tab has not yet finished loading then just quietly return.
+      if (tab.status !== TAB_STATUS_COMPLETE) {
+        return Promise.resolve();
+      }
+
       if (state.isTabActive(tab.id)) {
         return sidebar.injectIntoTab(tab).catch(function (err) {
           tabErrors.setTabError(tab.id, err);


### PR DESCRIPTION
This issue arises because we're not checking the status of the tab before trying to inject. So when during installation a new tab is created and the extension activated this triggers the change from 'inactive' -> 'active' in TabState which embeds the sidebar into the loading tab. Later the update function is called when the tab loading is complete injecting the sidebar a second time.

We now explicitly check the tab status in the injection handler to prevent injection into a loading tab.

Fixes #1756.
