### PR TITLE
Don't use target="_blank" for feedback email

### DIFF
--- a/h/templates/app.html
+++ b/h/templates/app.html
@@ -17,8 +17,7 @@
           --><i class="h-icon-triangle"></i></span>
         <ul class="dropdown-menu pull-right" role="menu">
           <li ng-show="persona"><a href="" ng-click="dialog.visible='true'">Account</a></li>
-          <li><a href="mailto:support@hypothes.is"
-                 target="_blank">Feedback</a></li>
+          <li><a href="mailto:support@hypothes.is">Feedback</a></li>
           <li><a href="/docs/help" target="_blank">Help</a></li>
           <li ng-show="persona"><a href="/stream?q=user:{% raw %}{{ persona|persona }}{% endraw %}"
                  target="_blank">My Annotations</a></li>


### PR DESCRIPTION
This opens a new empty tab unnecessarily.
