### PR TITLE
Move thread ng-show conditionals onto parent elements

### DIFF
--- a/h/templates/client/thread.html
+++ b/h/templates/client/thread.html
@@ -18,19 +18,17 @@
 </article>
 
 <!-- Reply count -->
-<div class="thread-reply" ng-show="vm.showReplyToggle(count('message'))">
+<div class="thread-reply" ng-show="vm.showReplyToggle(count('message')) && (!threadFilter.active() || count('message') == count('match'))">
   <a class="reply-count small"
      href=""
-     ng-if="!threadFilter.active() || count('message') == count('match')"
      ng-pluralize count="count('message') - 1"
      when="{'0': '', one: '1 reply', other: '{} replies'}"></a>
 </div>
 
-<div class="thread-load-more" ng-show="threadFilter.active()">
+<div class="thread-load-more" ng-show="vm.container.message.id && threadFilter.active()">
   <a class="load-more small"
      href=""
      ng-click="threadFilter.active(false)"
-     ng-if="vm.container.message.id"
      ng-pluralize count="count('message') - count('match')"
      when="{'0': '',
            one: 'View one more in conversation',


### PR DESCRIPTION
Rather than the thread-reply and thread-load-more elements splitting conditionals between the parent and the child we now ensure that the entire element is always shown/hidden. This fixes display issue with margin and padding on the parent element when the parent is visible but the child is hidden.

Re: http://list.hypothes.is/archive/dev/2014-12/0000003.html
