### PR TITLE
Updated content security policy.

### DIFF
--- a/h/browser/chrome/manifest.json
+++ b/h/browser/chrome/manifest.json
@@ -21,7 +21,7 @@
     "tabs"
   ],
   "content_security_policy":
-    "script-src 'self' 'unsafe-eval' {{ src }}; object-src 'self'",
+    "script-src 'self' 'unsafe-eval' {{ src }} https://cdn.mathjax.org; object-src 'self'; font-src 'self';",
 
   "background": {
     "persistent": true,


### PR DESCRIPTION
Modified the Chrome extension content security policy to allow getting MathJax resources from `cdn.mathjax.org` and loading fonts for KaTeX math rendering. This should resolve #1771. 
