### PR TITLE
Push document metadata from guest to panel

### DIFF
--- a/h/static/scripts/services.coffee
+++ b/h/static/scripts/services.coffee
@@ -96,16 +96,15 @@ class Hypothesis extends Annotator
         entities = []
         channel = this._setupXDM options
 
-        channel.call
-          method: 'getDocumentInfo'
-          success: (info) =>
-            entityUris = {}
-            entityUris[info.uri] = true
-            for link in info.metadata.link
-              entityUris[link.href] = true if link.href
-            for href of entityUris
-              entities.push href
-            this.plugins.Store?.loadAnnotations()
+        channel.bind('setDocumentInfo', (txn, info) =>
+          entityUris = {}
+          entityUris[info.uri] = true
+          for link in info.metadata.link
+            entityUris[link.href] = true if link.href
+          for href of entityUris
+            entities.push href
+          this.plugins.Store?.loadAnnotations()
+        )
 
         # Allow the host to define it's own state
         unless source is $window.parent


### PR DESCRIPTION
By changing which end initiates the communication of document metadata,
the guest can ensure that it has sent this basic info before continuing
with expensive operations, such as scanning the DOM text. The panel has
a chance to initiate asynchronous operations, such as API requests to
load annotations, before the guest continues.