### PR TITLE
Remove an unused event

### DIFF
--- a/h/static/scripts/guest.coffee
+++ b/h/static/scripts/guest.coffee
@@ -68,11 +68,6 @@ class Annotator.Guest extends Annotator
           scope: "#{scope}:provider"
           onReady: =>
             this.publish('panelReady')
-            setTimeout =>
-              event = document.createEvent "UIEvents"
-              event.initUIEvent "annotatorReady", false, false, window, 0
-              event.annotator = this
-              window.dispatchEvent event
 
     # Load plugins
     for own name, opts of @options


### PR DESCRIPTION
The original commit that introduced this (by @csillag) does not at
all describe why it was added. Nothing in this project listens
for it.
