### PR TITLE
[WIP] Do not show parents on the standalone annotation

### DIFF
--- a/h/static/scripts/controllers.coffee
+++ b/h/static/scripts/controllers.coffee
@@ -312,7 +312,14 @@ class AnnotationViewerController
         updater.then (sock) ->
           if $routeParams.id?
             _id = $routeParams.id
-            annotator.plugins.Store?.loadAnnotationsFromSearch({_id}).then ->
+            annotator.plugins.Store?.loadAnnotationsFromSearch({_id}).then (results) ->
+              # Remove references to parent annotations before loading children.
+              ann = results.rows[0]
+              ann.references = []
+
+              # Update the current thread.
+              $scope.threading.thread([ann])
+
               annotator.plugins.Store?.loadAnnotationsFromSearch({references: _id})
 
             filter = streamfilter


### PR DESCRIPTION
When an annotation is loaded we now only show the annotation and it's children. We do this by removing the references to the parents when the annotation is loaded. This prevents the Threading plugin rendering holes.

This is one potential solution to this problem, which was introduced with changes to the `Threading` plugin in  847fba989d2493763ae48b3aba9813ae7617171d. To me this fix makes sense as we want the primary annotation referenced by the url to be rendered as a card not as a reply in a tree.

However I'm not sure that the original behaviour in the Threading plugin needs to also be restored? Should `pruneEmpties` also be removing placeholders for parents when a child is passed into `thread`? 
