### PR TITLE
Add message about CC0 License to Editor

### DIFF
--- a/h/templates/client/annotation.html
+++ b/h/templates/client/annotation.html
@@ -95,6 +95,13 @@
 <footer class="annotation-footer form-actions"
         ng-if="vm.editing"
         ng-switch="vm.action">
+  <div class="pull-right">
+  <span class="form-actions-message pull-right">
+    <a href="http://creativecommons.org/publicdomain/zero/1.0/" target="_blank">
+      Licensed under CC0.
+    </a>
+  </span>
+  </div>
   <div class="form-actions-buttons form-actions-left">
     <button ng-switch-when="edit"
             ng-click="vm.save()"


### PR DESCRIPTION
This is meant to resolve https://github.com/hypothesis/vision/issues/90. It now looks like so:

![Editor with CC0 License](https://cloud.githubusercontent.com/assets/521978/5405934/c83d0f64-8160-11e4-9ce2-0daafb1cf46c.png)

The link points to: http://creativecommons.org/publicdomain/zero/1.0/

After thinking about it for a while I came to the conclusion that it would be good to get more feedback on the license we've chosen, and making the license clearer is a good way to get that feedback (because as @BigBlueHat insists: _no one reads the Terms of Service_). If need be, or if it confuses people in user tests, we can easily remove this.
