### PR TITLE
Remove apparently dead code in thread.coffee

### DIFF
--- a/h/static/scripts/directives/thread.coffee
+++ b/h/static/scripts/directives/thread.coffee
@@ -97,11 +97,6 @@ thread = [
         else
           attrs.$removeClass COLLAPSED_CLASS
 
-      # Watch the thread-collapsed attribute.
-      if attrs.threadCollapsed
-        scope.$watch $parse(attrs.threadCollapsed), (collapsed) ->
-          ctrl.toggleCollapsed() if !!collapsed != ctrl.collapsed
-
     controller: 'ThreadController'
     controllerAs: 'vm'
     link: linkFn

--- a/h/templates/client/viewer.html
+++ b/h/templates/client/viewer.html
@@ -37,7 +37,6 @@
       ng-class="{'js-hover': hasFocus(child.message)}"
       deep-count="count"
       thread="child" thread-filter
-      thread-collapsed="!search.query"
       ng-include="'thread.html'"
       ng-mouseenter="focus(child.message)"
       ng-click="scrollTo(child.message)"


### PR DESCRIPTION
I can't find any behaviour difference with this code removed. Threads
are correctly collapsed and uncollapsed when the search is changed or
cleared.
