### PR TITLE
Better include_raw content caching

### DIFF
--- a/h/templates/app.html
+++ b/h/templates/app.html
@@ -52,16 +52,16 @@
             <div class="tabbable"
                  ng-controller="AccountController"
                  ng-model="tab">
-              {% include_raw "h:templates/client/settings/account.html" %}
+              {{ include_raw("h:templates/client/settings/account.html") }}
               {% if feature('notification') %}
-                {% include_raw "h:templates/client/settings/notifications.html" %}
+                {{ include_raw("h:templates/client/settings/notifications.html") }}
               {% endif %}
             </div>
           {% endblock %}
         </div>
         <div ng-if="!auth.user">
           {% block auth %}
-            {% include_raw "h:templates/client/auth.html" %}
+            {{ include_raw("h:templates/client/auth.html") }}
           {% endblock %}
         </div>
       </div>
@@ -76,19 +76,19 @@
 
 {% block templates %}
   <script type="text/ng-template" id="annotation.html">
-    {% include_raw "h:templates/client/annotation.html" %}
+    {{ include_raw("h:templates/client/annotation.html") }}
   </script>
   <script type="text/ng-template" id="markdown.html">
-    {% include_raw "h:templates/client/markdown.html" %}
+    {{ include_raw("h:templates/client/markdown.html") }}
   </script>
   <script type="text/ng-template" id="privacy.html">
-    {% include_raw "h:templates/client/privacy.html" %}
+    {{ include_raw("h:templates/client/privacy.html") }}
   </script>
   <script type="text/ng-template" id="viewer.html">
-    {% include_raw "h:templates/client/viewer.html" %}
+    {{ include_raw("h:templates/client/viewer.html") }}
   </script>
   <script type="text/ng-template" id="thread.html">
-    {% include_raw "h:templates/client/thread.html" %}
+    {{ include_raw("h:templates/client/thread.html") }}
   </script>
 {% endblock %}
 

--- a/h/templates/auth.html
+++ b/h/templates/auth.html
@@ -9,6 +9,6 @@
 
 {% block templates %}
   <script type="text/ng-template" id="auth.html">
-    {% include_raw "h:templates/client/auth.html" %}
+    {% include_raw("h:templates/client/auth.html") %}
   </script>
 {% endblock %}


### PR DESCRIPTION
The include_raw tag provided by the previous iteration of this
extension adds a constant value to the Jinja parse tree, but is unable
to tell Jinja that a particular file has been read in order to generate
it. This means that the pyramid autoreloader doesn't know to reread the
files in question when they change, making development that touches the
Angular templates rather tedious -- a manual server reload is required
every time a template is changed.

This commit changes the include_raw tag to an include_raw function,
which rereads the Angular templates on each rendering of app.html in
development mode, but memoizes the contents when in production.
