### PR TITLE
Fix replies toggle visual glitch in edit mode

### DIFF
--- a/h/static/scripts/directives/thread.coffee
+++ b/h/static/scripts/directives/thread.coffee
@@ -18,6 +18,7 @@ ThreadController = [
   ->
     @container = null
     @collapsed = false
+    @inEditMode = false
 
     ###*
     # @ngdoc method
@@ -37,6 +38,19 @@ ThreadController = [
     ###
     this.showReplyToggle = (messageCount) ->
       messageCount > 1 && !(@collapsed && @container.parent.parent)
+
+    ###*
+    # @ngdoc method
+    # @name thread.ThreadController#showReplyToggle
+    # @description
+    # Callback called when an annotation directive switches between the
+    # edit and view modes. This allows the thread to present itself
+    # differently.
+    # We need a double arrow here as the annotation directive will call this
+    # funciton under it's own scope.
+    ###
+    this.onAnnotationModeChange = (mode) =>
+      this.inEditMode = mode.value == mode.EDIT
 
     this
 ]

--- a/h/static/styles/threads.scss
+++ b/h/static/styles/threads.scss
@@ -110,8 +110,11 @@ $threadexp-width: .6em;
 }
 
 .thread-reply {
-  margin-top: -2.153em;
   margin-bottom: .8em;
+}
+
+.thread-reply-pull-up {
+  margin-top: -2.153em;
 }
 
 .thread-message:hover + .thread-reply {

--- a/h/templates/client/thread.html
+++ b/h/templates/client/thread.html
@@ -13,12 +13,15 @@
          name="annotation"
          annotation="vm.container.message"
          annotation-embedded="{{isEmbedded}}"
+         annotation-on-mode-change="vm.onAnnotationModeChange"
          ng-if="vm.container.message"
          ng-show="threadFilter.check(vm.container)">
 </article>
 
 <!-- Reply count -->
-<div class="thread-reply" ng-show="vm.showReplyToggle(count('message')) && (!threadFilter.active() || count('message') == count('match'))">
+<div class="thread-reply"
+     ng-class="{'thread-reply-pull-up': !vm.inEditMode}"
+     ng-show="vm.showReplyToggle(count('message')) && (!threadFilter.active() || count('message') == count('match'))">
   <a class="reply-count small"
      href=""
      ng-pluralize count="count('message') - 1"

--- a/tests/js/directives/annotation-test.coffee
+++ b/tests/js/directives/annotation-test.coffee
@@ -28,7 +28,8 @@ describe 'h.directives.annotation', ->
     $document = _$document_
     $timeout = _$timeout_
     $scope = $rootScope.$new()
-    $scope.annotationGet = (locals) -> annotation
+    $scope.parseAnnotationAttr = (locals) -> annotation
+    $scope.parseOnModeChangeAttr = ->
     annotator = {plugins: {}, publish: sandbox.spy()}
     annotation =
       id: 'deadbeef'

--- a/tests/js/directives/thread-test.coffee
+++ b/tests/js/directives/thread-test.coffee
@@ -23,6 +23,17 @@ describe 'h.directives.thread.ThreadController', ->
       after = controller.collapsed
       assert.equal(before, !after)
 
+  describe '#onAnnotationModeChange', ->
+    it 'sets the inEditMode property to true when editing an annotation', ->
+      controller = createController()
+      controller.onAnnotationModeChange(value: 'edit', EDIT: 'edit', VIEW: 'view')
+      assert.isTrue(controller.inEditMode)
+
+    it 'sets the inEditMode property to false when viewing an annotation', ->
+      controller = createController()
+      controller.onAnnotationModeChange(value: 'view', EDIT: 'edit', VIEW: 'view')
+      assert.isFalse(controller.inEditMode)
+
 
 describe 'h.directives.thread.thread', ->
   $element = null


### PR DESCRIPTION
This fixes an issue (#1808) where the replies button overlaps the license message when the editor is switched into edit mode. 

This is achieved by only applying the negative margin on the `thread-reply` element when the annotation is in "view" mode.

An `on-mode-change` handler is now passed to the annotation directive via an attribute which is called when the view mode changes. A class applying the negative margin is then toggled on the reply element in the thread template.
