### PR TITLE
Use opaque focus highlights and tweak the rules

### DIFF
--- a/h/assets.yaml
+++ b/h/assets.yaml
@@ -391,6 +391,7 @@ inject_css:
         - h:static/styles/bucket-bar.scss
         - h:static/styles/reset.scss
         - h:static/styles/variables.scss
+        - h:static/styles/mixins/highlight.scss
         - h:static/styles/mixins/icons.scss
 
 

--- a/h/static/styles/inject.scss
+++ b/h/static/styles/inject.scss
@@ -1,4 +1,5 @@
 @import 'base';
+@import 'mixins/highlight';
 @import 'mixins/icons';
 @import 'compass/css3/user-interface';
 @import 'compass/layout/stretching';
@@ -73,33 +74,25 @@ $base-font-size: 14px;
 
 
 //HIGHLIGHTS////////////////////////////////
-.annotator-hl {
-  &::-moz-selection {
-    background: $highlight-color;
-  }
-  &::-moz-selection, &::-moz-window-inactive, &::window-inactive {
-    background: $highlight-color;
-  }
-  &::selection, &::selection:window-inactive {
-    background: $highlight-color;
-  }
-}
-
-.annotator-highlights-always-on .annotator-hl {
-  background: $highlight-color;
-
+.annotator-highlights-always-on {
   .annotator-hl {
-    background-color: $highlight-color-second;
+    @include highlight($highlight-color);
   }
 
   .annotator-hl .annotator-hl {
-    background-color: $highlight-color-third;
+    @include highlight($highlight-color-second);
+  }
+
+  .annotator-hl .annotator-hl .annotator-hl {
+    @include highlight($highlight-color-third);
   }
 }
 
-.annotator-hl-focused,
-.annotator-highlights-always-on .annotator-hl.annotator-hl-focused {
-  background-color: $highlight-color-focus;
+.annotator-hl.annotator-hl-focused {
+  @include highlight($highlight-color-focus !important);
+  .annotator-hl {
+    @include highlight(transparent !important);
+  }
 }
 
 // Sidebar

--- a/h/static/styles/mixins/highlight.scss
+++ b/h/static/styles/mixins/highlight.scss
@@ -1,0 +1,11 @@
+@import 'compass/css3/selection';
+
+@mixin highlight($color) {
+  background: $color;
+  @include selection {
+    background: $color;
+    &:window-inactive {
+      background: $color;
+    }
+  }
+}

--- a/h/static/styles/variables.scss
+++ b/h/static/styles/variables.scss
@@ -57,7 +57,7 @@ $bucket-bar-width: 22px;
 $highlight-color: rgba(255, 255, 60, 0.3);
 $highlight-color-second: rgba(206, 206, 60, 0.4);
 $highlight-color-third: rgba(192, 192, 49, 0.4);
-$highlight-color-focus: rgba(192, 236, 253, 0.5);
+$highlight-color-focus: rgb(224, 246, 254);
 $score-width: 40px;
 $score-height: $score-width;
 $input-border-radius: 2px;


### PR DESCRIPTION
It may or may not be possible to change, but the way the current
highlighter slices the DOM when highlights overlap doesn't always
produce a structure where segments of larger highlights nest outside
segments of highlights that are entirely within their bounds. For
instance, structures like this may result:

```
Spans boundaries:       [   ][[ ]][   ]
Associated annotation:  A   ABA ABA   A
```

In this example, the range of A completely spans the range of B yet the
inner-most A span is completely wrapped by the B span, with no A span
wrapping them both. If A is the highlight with focus, it is not the
case that a CSS rule can simply neutralize the background color of B.
Therefore, the background color of the inner A span blends with the
background color of B, making the focus highlight less prominent than
it should be.

In this situation, the focus highlight can be guaranteed to be shown
in a clearly visible color by making it opaque. There may be colors
on which this is too low contrast, but until we can investigate other
options this PR makes the focus highlight color opaque to address this
issue.

Additionally, factor out a highlight mixin that makes it all a bit
more readable and consistent.

Fix #1766
Fix #1816
