### PR TITLE
Allow simple usernames

### DIFF
--- a/h/models.py
+++ b/h/models.py
@@ -12,7 +12,9 @@ class Annotation(annotation.Annotation):
         # Convert annotator-store roles to pyramid principals
         for action, roles in self.get('permissions', {}).items():
             for role in roles:
-                if role.startswith('group:'):
+                if role.startswith('system.'):
+                    raise ValueError('{} is a reserved role.'.format(role))
+                elif role.startswith('group:'):
                     if role == 'group:__world__':
                         principal = Everyone
                     elif role == 'group:__authenticated__':

--- a/h/models.py
+++ b/h/models.py
@@ -21,13 +21,8 @@ class Annotation(annotation.Annotation):
                         raise NotImplementedError("API consumer groups")
                     else:
                         principal = role
-                elif role.startswith('acct:'):
-                    principal = role
                 else:
-                    raise ValueError(
-                        "Unrecognized role '%s' in annotation '%s'" %
-                        (role, self.get('id'))
-                    )
+                    principal = role
 
                 # Append the converted rule tuple to the ACL
                 rule = (Allow, principal, action)

--- a/h/static/scripts/filters.coffee
+++ b/h/static/scripts/filters.coffee
@@ -26,8 +26,12 @@ momentFilter = ->
 
 
 persona = (user, part='username') ->
-  part = ['term', 'username', 'provider'].indexOf(part)
-  (user?.match /^acct:([^@]+)@(.+)/)?[part]
+  index = ['term', 'username', 'provider'].indexOf(part)
+  groups = user?.match /^acct:([^@]+)@(.+)/
+  if groups
+    groups[index]
+  else if part != 'provider'
+    user
 
 
 angular.module('h')

--- a/h/test/models_test.py
+++ b/h/test/models_test.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+import unittest
+
+from mock import patch, MagicMock, Mock
+from pytest import fixture, raises
+from pyramid import security, testing
+
+from h import models
+
+
+class TestAnnotationPermissions(unittest.TestCase):
+    def test_principal(self):
+        annotation = models.Annotation()
+        annotation['permissions'] = {
+            'read': ['saoirse'],
+        }
+        actual = annotation.__acl__()
+        expect = [(security.Allow, 'saiorse', 'read')]
+
+    def test_admin_party(self):
+        annotation = models.Annotation()
+        actual = annotation.__acl__()
+        expect = [(security.Allow, security.Everyone, security.ALL_PERMISSIONS)]
+        assert actual == expect
+
+    def test_deny_system_role(self):
+        annotation = models.Annotation()
+        annotation['permissions'] = {
+            'read': [security.Everyone],
+        }
+        with raises(ValueError):
+            annotation.__acl__()
+
+    def test_group(self):
+        annotation = models.Annotation()
+        annotation['permissions'] = {
+            'read': ['group:lulapalooza'],
+        }
+        actual = annotation.__acl__()
+        expect = [(security.Allow, 'group:lulapalooza', 'read')]
+
+    def test_group_world(self):
+        annotation = models.Annotation()
+        annotation['permissions'] = {
+            'read': ['group:__world__'],
+        }
+        actual = annotation.__acl__()
+        expect = [(security.Allow, security.Everyone, 'read')]
+        assert actual == expect
+
+    def test_group_authenticated(self):
+        annotation = models.Annotation()
+        annotation['permissions'] = {
+            'read': ['group:__authenticated__'],
+        }
+        actual = annotation.__acl__()
+        expect = [(security.Allow, security.Authenticated, 'read')]
+        assert actual == expect

--- a/tests/js/filters-test.coffee
+++ b/tests/js/filters-test.coffee
@@ -1,0 +1,27 @@
+assert = chai.assert
+sinon.assert.expose assert, prefix: null
+
+describe 'persona', ->
+  filter = null
+  term = 'acct:hacker@example.com'
+
+  beforeEach module('h')
+  beforeEach inject ($filter) ->
+    filter = $filter('persona')
+
+  it 'should return the whole term by request', ->
+    assert.equal filter('acct:hacker@example.com', 'term'), 'acct:hacker@example.com'
+
+  it 'should return the requested part', ->
+    assert.equal filter(term), 'hacker'
+    assert.equal filter(term, 'term'), term,
+    assert.equal filter(term, 'username'), 'hacker'
+    assert.equal filter(term, 'provider'), 'example.com'
+
+  it 'should pass through unrecognized terms as username or term', ->
+    assert.equal filter('bogus'), 'bogus'
+    assert.equal filter('bogus', 'username'), 'bogus'
+
+  it 'should handle error cases', ->
+    assert.notOk filter()
+    assert.notOk filter('bogus', 'provider')


### PR DESCRIPTION
I propose this as a quick way to close #1297 right now.

Allow simple user identifiers rather than strictly enforcing the acct URIs. With this change, all the old behavior should be preserved, but deployments that are running different authentication can treat the user identifier however they need to.

Splitting the field into pieces is a whole PITA because it would need to be a separate field. Searches, mappings, etc would need to change. Migrations would happen. Etc. For now, this unblocks the last stage of the SSO epic.