### PR TITLE
streamer: Don't send anything without a filter

### DIFF
--- a/h/streamer.py
+++ b/h/streamer.py
@@ -599,9 +599,12 @@ def should_send_event(socket, annotation, event_data):
     if not socket.request.has_permission('read', annotation):
         return False
 
-    if socket.filter is not None:
-        if not socket.filter.match(annotation, event_data['action']):
-            return False
+    # We don't send anything until we have received a filter from the client
+    if socket.filter is None:
+        return False
+
+    if not socket.filter.match(annotation, event_data['action']):
+        return False
 
     return True
 

--- a/h/test/streamer_test.py
+++ b/h/test/streamer_test.py
@@ -315,7 +315,7 @@ class TestShouldSendEvent(unittest.TestCase):
     def test_should_send_event_no_filter(self):
         self.sock_giraffe.filter = None
         data = {'action': 'update', 'src_client_id': 'pigeon'}
-        assert should_send_event(self.sock_giraffe, {}, data)
+        assert should_send_event(self.sock_giraffe, {}, data) is False
 
     def test_should_send_event_doesnt_send_reads(self):
         data = {'action': 'read', 'src_client_id': 'pigeon'}


### PR DESCRIPTION
I misinterpreted the original intent of the filter, thus introducing
issue #1840. See 9242361, which claimed to be a refactoring but was
clearly not.

Instead, we don't send anything at all to the client until we have
received and validated a filter.