### PR TITLE
Fix small KaTeX display math.

### DIFF
--- a/h/static/scripts/directives/markdown.coffee
+++ b/h/static/scripts/directives/markdown.coffee
@@ -289,7 +289,7 @@ markdown = ['$filter', '$sanitize', '$sce', '$timeout', ($filter, $sanitize, $sc
         if startMath > endMath
           endMath = index + 2
           try
-            katex.renderToString($sanitize textToCheck.substring(startMath, index))
+            katex.renderToString($sanitize "\\displaystyle {" + textToCheck.substring(startMath, index) + "}")
           catch
             loadMathJax()
             mathJaxFallback = true

--- a/h/static/scripts/directives/markdown.coffee
+++ b/h/static/scripts/directives/markdown.coffee
@@ -289,6 +289,7 @@ markdown = ['$filter', '$sanitize', '$sce', '$timeout', ($filter, $sanitize, $sc
         if startMath > endMath
           endMath = index + 2
           try
+            # \\displaystyle tells KaTeX to render the math in display style (full sized fonts).
             katex.renderToString($sanitize "\\displaystyle {" + textToCheck.substring(startMath, index) + "}")
           catch
             loadMathJax()


### PR DESCRIPTION
KaTeX default renders math in an inline style. This was creating problems for KaTeX rendered display, and making it looked bunched up and small.

