### PR TITLE
Refactor WebSocket origin security

### DIFF
--- a/h/static/scripts/app.coffee
+++ b/h/static/scripts/app.coffee
@@ -57,12 +57,6 @@ configure = [
     # TODO: move all front-end templates into their own directory for safety
     basePattern = baseURI.replace /\/[^\/]*$/, '/**.html'
     $sceDelegateProvider.resourceUrlWhitelist ['self', basePattern]
-
-    streamerProvider.urlFn = ['xsrf', (xsrf) ->
-      base = baseURI.replace(/^http/, 'ws')
-      "#{base}ws?csrf_token=#{xsrf.token}"
-    ]
 ]
-
 
 angular.module('h', imports, configure)

--- a/h/static/scripts/controllers.coffee
+++ b/h/static/scripts/controllers.coffee
@@ -1,12 +1,11 @@
 class AppController
   this.$inject = [
-    '$location', '$route', '$scope', '$timeout',
+    '$location', '$route', '$scope', '$timeout', '$window',
     'annotator', 'auth', 'documentHelpers', 'drafts', 'flash', 'identity',
     'permissions', 'streamer', 'streamfilter'
-
   ]
   constructor: (
-     $location,   $route,   $scope,   $timeout,
+     $location,   $route,   $scope,   $timeout,   $window,
      annotator,   auth,   documentHelpers,   drafts,   flash,   identity,
      permissions,   streamer,   streamfilter,
 
@@ -15,6 +14,7 @@ class AppController
 
     $scope.auth = auth
     isFirstRun = $location.search().hasOwnProperty('firstrun')
+    streamerUrl = documentHelpers.baseURI.replace(/^http/, 'ws') + 'ws'
 
     applyUpdates = (action, data) ->
       # Update the application with new data from the websocket.
@@ -110,8 +110,9 @@ class AppController
 
       # Reload services
       initStore()
+
       streamer.close()
-      streamer.open()
+      streamer.open($window.WebSocket, streamerUrl)
 
     $scope.$watch 'socialView.name', (newValue, oldValue) ->
       return if newValue is oldValue


### PR DESCRIPTION
Rather than using the cross site request forgery token in the URL
for the WebSocket, check the HTTP Origin header. All spec-compliant
user agents send a proper Origin header so this is sufficient to
protect users from malicious cross-site access to the WebSocket.

As a consequence, the front-end code to bootstrap the streamer can
be simplified. The streamer no longer has any provider. Its URL and
transport are passed explicitly to the ``open`` method.

While I was here, I added support for the ``protocols`` argument to
the ``open`` method, added support for the ``onopen`` and ``onclose``
handlers, set the client identifier on the ``$http`` service default
headers, aligned the state constants with the standard ones, and
ensured that the socket cannot be closed twice.