### PR TITLE
Remove the canAnnotate flag

### DIFF
--- a/h/static/scripts/guest.coffee
+++ b/h/static/scripts/guest.coffee
@@ -260,7 +260,6 @@ class Annotator.Guest extends Annotator
     return confirm "You have selected a very short piece of text: only " + length + " chars. Are you sure you want to highlight this?"
 
   onSuccessfulSelection: (event, immediate) ->
-    return unless @canAnnotate
     if @tool is 'highlight'
       # Do we really want to make this selection?
       return false unless this.confirmSelection()


### PR DESCRIPTION
Already removed from Annotator here: https://github.com/hypothesis/annotator/pull/98
, so we shouldn't rely on it any more.