### PR TITLE
Resolve user authorization before view render

### DIFF
--- a/h/static/scripts/app.coffee
+++ b/h/static/scripts/app.coffee
@@ -12,6 +12,14 @@ imports = [
 
 
 resolve =
+  auth: ['$q', '$rootScope', 'auth', ($q, $rootScope, auth) ->
+    dfd = $q.defer()
+    unwatch = $rootScope.$watch (-> auth.user), (user) ->
+      return if user is undefined
+      dfd.resolve(auth)
+      unwatch()
+    dfd.promise
+  ]
   store: ['store', (store) -> store.$promise]
 
 

--- a/h/static/scripts/controllers.coffee
+++ b/h/static/scripts/controllers.coffee
@@ -36,8 +36,7 @@ class AppController
     oncancel = ->
       $scope.dialog.visible = false
 
-    $scope.$on '$routeChangeStart', (event, newRoute, oldRoute) ->
-      return if newRoute.redirectTo
+    cleanupAnnotations = ->
       # Clean up any annotations that need to be unloaded.
       for id, container of $scope.threading.idTable when container.message
         # Remove annotations not belonging to this user when highlighting.
@@ -75,6 +74,9 @@ class AppController
       # Reopen the streamer.
       streamer.close()
       streamer.open($window.WebSocket, streamerUrl)
+
+      # Clean up annotations that should be removed
+      cleanupAnnotations()
 
       # Reload the view.
       $route.reload()

--- a/h/static/scripts/streamsearch.coffee
+++ b/h/static/scripts/streamsearch.coffee
@@ -19,6 +19,11 @@ class StreamSearchController
     terms = searchfilter.generateFacetedFilter $scope.search.query
     queryparser.populateFilter streamfilter, terms
 
+    # Perform the search
+    query = angular.extend limit: 10, $scope.search.query
+    store.SearchResource.get query, ({rows}) ->
+      annotator.loadAnnotations(rows)
+
     $scope.isEmbedded = false
     $scope.isStream = true
 
@@ -28,12 +33,6 @@ class StreamSearchController
 
     $scope.$on '$destroy', ->
       $scope.search.query = ''
-
-    $scope.$watch (-> auth.user), ->
-      query = angular.extend limit: 10, $scope.search.query
-      store.SearchResource.get query, ({rows}) ->
-        annotator.loadAnnotations(rows)
-
 
 angular.module('h')
 .controller('StreamSearchController', StreamSearchController)


### PR DESCRIPTION
Avoid having to watch the user in route controllers at all by resolving
it as a prerequisite of the routes, much like the store bootstrap. The
user may still be ``null`` but it will not be ``undefined``.

For clarity, the $routeChangeStart handler is changed back to a
function, ``cleanupAnnotations``, that is called explicitly from
the user watcher in the ``AppController`` right before the route
reloads.