### PR TITLE
Remove past_data

### DIFF
--- a/h/static/scripts/controllers.coffee
+++ b/h/static/scripts/controllers.coffee
@@ -64,9 +64,6 @@ class AppController
       else
         $scope.dialog.visible = false
 
-      # Skip the remaining if this is the first evaluation.
-      return if oldVal is undefined
-
       # Update any edits in progress.
       for draft in drafts.all()
         annotator.publish 'beforeAnnotationCreated', draft
@@ -91,7 +88,6 @@ class AppController
       identity.logout()
 
     $scope.loadMore = (number) ->
-      unless streamfilter.getPastData().hits then return
       streamer.send({messageType: 'more_hits', moreHits: number})
 
     $scope.clearSelection = ->
@@ -146,7 +142,6 @@ class AnnotationViewerController
       annotator.loadAnnotations(rows)
 
     streamfilter
-      .setPastDataNone()
       .setMatchPolicyIncludeAny()
       .addClause('/references', 'first_of', id, true)
       .addClause('/id', 'equals', id, true)

--- a/h/static/scripts/searchfilters.coffee
+++ b/h/static/scripts/searchfilters.coffee
@@ -261,7 +261,6 @@ class QueryParser
 
 class StreamFilter
   strategies: ['include_any', 'include_all', 'exclude_any', 'exclude_all']
-  past_modes: ['none','hits','time']
 
   filter:
       match_policy :  'include_any'
@@ -270,36 +269,16 @@ class StreamFilter
         create: true
         update: true
         delete: true
-      past_data:
-        load_past: "none"
 
   constructor: ->
 
   getFilter: -> return @filter
-  getPastData: -> return @filter.past_data
   getMatchPolicy: -> return @filter.match_policy
   getClauses: -> return @filter.clauses
   getActions: -> return @filter.actions
   getActionCreate: -> return @filter.actions.create
   getActionUpdate: -> return @filter.actions.update
   getActionDelete: -> return @filter.actions.delete
-
-  setPastDataNone: ->
-    @filter.past_data =
-      load_past: 'none'
-    this
-
-  setPastDataHits: (hits) ->
-    @filter.past_data =
-      load_past: 'hits'
-      hits: hits
-    this
-
-  setPastDataTime: (time) ->
-    @filter.past_data =
-      load_past: 'hits'
-      go_back: time
-    this
 
   setMatchPolicy: (policy) ->
     @filter.match_policy = policy
@@ -355,7 +334,6 @@ class StreamFilter
     @setActionCreate(true)
     @setActionUpdate(true)
     @setActionDelete(true)
-    @setPastDataNone()
     @noClauses()
     this
 

--- a/h/static/scripts/streamsearch.coffee
+++ b/h/static/scripts/streamsearch.coffee
@@ -18,6 +18,7 @@ class StreamSearchController
     $scope.search.query = $routeParams.q
     terms = searchfilter.generateFacetedFilter $scope.search.query
     queryparser.populateFilter streamfilter, terms
+    streamer.send({filter: streamfilter.getFilter()})
 
     # Perform the search
     searchParams = searchfilter.toObject $scope.search.query

--- a/h/test/streamer_test.py
+++ b/h/test/streamer_test.py
@@ -74,55 +74,10 @@ def test_zero_clauses():
     request = DummyRequest()
     filter_json = {
         'clauses': [],
-        'past_data': {'load_past': 'none'}
     }
 
     fef = FilterToElasticFilter(filter_json, request)
     assert fef.query['query'] == {"match_all": {}}
-
-
-def test_hits():
-    """Test setting the query size limit right
-    """
-    request = DummyRequest()
-    filter_json = {
-        'match_policy': 'include_all',
-        'clauses': [{
-            'field': 'text',
-            'operator': 'equals',
-            'value': 'foo bar',
-            'options': {}
-        }],
-        'past_data': {
-            'load_past': 'hits',
-            'hits': 75
-        }
-    }
-
-    fef = FilterToElasticFilter(filter_json, request)
-    assert fef.query['size'] is 75
-
-
-def test_past_time():
-    """Test setting the time range filter right
-    """
-    request = DummyRequest()
-    filter_json = {
-        'match_policy': 'include_all',
-        'clauses': [{
-            'field': 'text',
-            'operator': 'equals',
-            'value': 'foo bar',
-            'options': {}
-        }],
-        'past_data': {
-            'load_past': 'time',
-            'go_back': 60
-        }
-    }
-
-    fef = FilterToElasticFilter(filter_json, request)
-    assert 'gte' in fef.query['filter']['range']['created']
 
 
 def test_policy_include_any():
@@ -140,7 +95,6 @@ def test_policy_include_any():
             'value': 'bar',
             'options': {}
         }],
-        'past_data': {'load_past': 'none'}
     }
 
     fef = FilterToElasticFilter(filter_json, request)
@@ -162,7 +116,6 @@ def test_policy_include_all():
             'value': 'bar',
             'options': {}
         }],
-        'past_data': {'load_past': 'none'}
     }
 
     fef = FilterToElasticFilter(filter_json, request)
@@ -184,7 +137,6 @@ def test_policy_exclude_any():
             'value': 'bar',
             'options': {}
         }],
-        'past_data': {'load_past': 'none'}
     }
 
     fef = FilterToElasticFilter(filter_json, request)
@@ -206,7 +158,6 @@ def test_policy_exclude_all():
             'value': 'bar',
             'options': {}
         }],
-        'past_data': {'load_past': 'none'}
     }
 
     fef = FilterToElasticFilter(filter_json, request)
@@ -228,10 +179,6 @@ def test_operator_call():
                 }
             }
         }],
-        'past_data': {
-            'load_past': 'time',
-            'go_back': 60
-        }
     }
 
     generated = FilterToElasticFilter(filter_json, request)


### PR DESCRIPTION
Remove past_data handling from stream-filters.
We no longer use it, and we can load annotations via the websocket with the `more_hits` messageType.
Fixes stream page too.

Last piece to close&fix #1796 