### PR TITLE
Build production versions of the extensions on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,9 @@ script:
   - make test
   - prospector -P .prospector.yaml h
   - hypothesis extension development.ini chrome http://localhost
+  - hypothesis extension production.ini chrome https://hypothes.is chrome-extension://notarealkey/public
   - hypothesis extension development.ini firefox http://localhost
+  - hypothesis extension production.ini firefox https://hypothes.is resource://notarealkey/hypothesis/data
 notifications:
   irc:
     channels:

--- a/h/authentication.py
+++ b/h/authentication.py
@@ -55,8 +55,8 @@ def register_web_client(config):
     settings = registry.settings
 
     client_factory = registry.getUtility(IClientFactory)
-    client_id = settings['h.client_id']
-    client_secret = settings['h.client_secret']
+    client_id = settings.get('h.client_id')
+    client_secret = settings.get('h.client_secret')
 
     if client_id is None:
         client_id = base64.urlsafe_b64encode(os.urandom(18))

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ install_requires = [
     'python-statsd>=1.7.0,<1.8.0',
     'pyramid_webassets>=0.9,<1.0',
     'pyramid-jinja2>=2.3.3',
+    'pyramid_redis_sessions>=1.0a2',
     'requests>=2.2.1',
     'ws4py>=0.3,<0.4',
 


### PR DESCRIPTION
The production builds are often broken due to the infrequency of actually running the command. This should ensure they are always working.
