### PR TITLE
Remove focus state when clicking on toolbar buttons

### DIFF
--- a/h/static/scripts/annotator/plugin/toolbar.coffee
+++ b/h/static/scripts/annotator/plugin/toolbar.coffee
@@ -39,10 +39,6 @@ class Annotator.Plugin.Toolbar extends Annotator.Plugin
             @annotator.showFrame()
           else
             @annotator.hideFrame()
-        # Remove focus from the anchor when clicked, this removes the focus
-        # styles intended only for keyboard navigation. IE/FF apply the focus
-        # psuedo-class to a clicked element.
-        "mouseup": (event) -> $(event.target).blur()
     ,
       "title": "Show Annotations"
       "class": "h-icon-visible"
@@ -77,6 +73,11 @@ class Annotator.Plugin.Toolbar extends Annotator.Plugin
     @buttons.appendTo(list)
     @toolbar.append(list)
 
+    # Remove focus from the anchors when clicked, this removes the focus
+    # styles intended only for keyboard navigation. IE/FF apply the focus
+    # psuedo-class to a clicked element.
+    @toolbar.on('mouseup', 'a', (event) -> $(event.target).blur())
+
   show: -> this.toolbar.removeClass('annotator-hide')
 
   hide: -> this.toolbar.addClass('annotator-hide')
@@ -104,4 +105,4 @@ class Annotator.Plugin.Toolbar extends Annotator.Plugin
       height = 35
       this.toolbar.css("min-height", "")
     this.annotator.plugins.BucketBar?.BUCKET_THRESHOLD_PAD = height
-    this.annotator.plugins.BucketBar?._update();
+    this.annotator.plugins.BucketBar?._update()

--- a/h/static/scripts/host.coffee
+++ b/h/static/scripts/host.coffee
@@ -39,9 +39,13 @@ class Annotator.Host extends Annotator.Guest
 
     # Host frame dictates the toolbar options.
     this.on 'panelReady', =>
-      this.setTool('comment')
       this.anchoring._scan() # Scan the document
-      this.setVisibleHighlights(!!options.showHighlights)
+
+      # Guest is designed to respond to events rather than direct method
+      # calls. If we call set directly the other plugins will never recieve
+      # these events and the UI will be out of sync.
+      this.publish('setTool', 'comment')
+      this.publish('setVisibleHighlights', !!options.showHighlights)
 
     if @plugins.BucketBar?
       this._setupDragEvents()


### PR DESCRIPTION
This prevents the focus style continuing to be applied after a toolbar button has been clicked.