### PR TITLE
Add MathJax config option allign left

### DIFF
--- a/h/static/scripts/directives/markdown.coffee
+++ b/h/static/scripts/directives/markdown.coffee
@@ -8,6 +8,7 @@ loadMathJax = ->
         # MathJax configuration overides.
         MathJax.Hub.Config({
           showMathMenu: false
+          displayAlign: "left"
         })
     }
 


### PR DESCRIPTION
Previously, MathJax was rendering display style math align: "center", while KaTeX rendered it align: "left". This has been addressed with a simple addition to the MathJax.Hub.Config