### PR TITLE
Fix hit area for dropdown menu items

### DIFF
--- a/h/static/styles/common.scss
+++ b/h/static/styles/common.scss
@@ -179,11 +179,14 @@ html {
   z-index: 2;
 
   li:not(.ng-hide) {
-    cursor: pointer;
-    line-height: 1;
     text-align: left;
-    padding: .5em;
-    white-space: nowrap;
+
+    a {
+      display: block;
+      line-height: 1;
+      padding: .5em;
+      white-space: nowrap;
+    }
 
     &:hover {
       color: black;

--- a/h/templates/app.html
+++ b/h/templates/app.html
@@ -21,7 +21,7 @@
           <li><a href="/docs/help" target="_blank">Help</a></li>
           <li ng-show="auth.user"><a href="/stream?q=user:{% raw %}{{ auth.user|persona }}{% endraw %}"
                  target="_blank">My Annotations</a></li>
-          <li ng-show="auth.user" ng-click="logout()">Sign out</li>
+          <li ng-show="auth.user"><a href="" ng-click="logout()">Sign out</a></li>
         </ul>
       </div>
       <a class="pull-right" href=""

--- a/h/templates/client/privacy.html
+++ b/h/templates/client/privacy.html
@@ -10,9 +10,11 @@
   </span>
   <ul class="dropdown-menu" role="menu">
     <li ng-repeat="level in levels" ng-click="setLevel(level)">
-      <i class="small" ng-class="{'h-icon-earth': isPublic(level.name),
-                                  'h-icon-locked': !isPublic(level.name)}"></i>
-      {{level.text}}
+      <a href="">
+        <i class="small" ng-class="{'h-icon-earth': isPublic(level.name),
+                                    'h-icon-locked': !isPublic(level.name)}"></i>
+        {{level.text}}
+      </a>
     </li>
   </ul>
 </div>

--- a/h/templates/client/viewer.html
+++ b/h/templates/client/viewer.html
@@ -29,7 +29,7 @@
         <li ng-click="sort.name = option"
             ng-hide="option == 'Location' && !isEmbedded"
             ng-repeat="option in ['Newest', 'Oldest', 'Location']"
-            >{{option}}</li>
+            ><a href="">{{option}}</a></li>
       </ul>
     </span>
   </li>


### PR DESCRIPTION
Now all items contain anchors which are set to `display: block` this keeps all implementations consistent and improves accessibility.