### PR TITLE
notifications: Add para about resubscribing

### DIFF
--- a/h/templates/unsubscribe.html
+++ b/h/templates/unsubscribe.html
@@ -6,5 +6,10 @@
   <div class="content paper styled-text page">
     <h1>Your unsubscribe request has been processed.</h1>
     <p>You should no longer receive further notifications of this type.</p>
+    <p>
+      If you have made a mistake and wish to resubscribe, please see the
+      <em>Notifications</em> pane in your account settings after <a
+      href="{{request.route_url('login')}}">logging in</a>.
+    </p>
   </div>
 {% endblock %}


### PR DESCRIPTION
The acceptance criteria for #1708 include advising a user what to do if
they clicked a one-click unsubscribe link by accident.