### PR TITLE
[WIP] Analyse uri field + cleanup uri search problems

### DIFF
--- a/h/models.py
+++ b/h/models.py
@@ -44,11 +44,7 @@ class Annotation(annotation.Annotation):
         'tags': {'type': 'string', 'analyzer': 'uni_normalizer'},
         'text': {'type': 'string', 'analyzer': 'uni_normalizer'},
         'deleted': {'type': 'boolean'},
-        'uri': {
-            'type': 'string',
-            'index_analyzer': 'uri_index',
-            'search_analyzer': 'uri_search'
-        },
+        'uri': {'type': 'string', 'index': 'analyzed', 'analyzer': 'uri'},
         'user': {'type': 'string', 'index': 'analyzed', 'analyzer': 'user'},
         'consumer': {'type': 'string'},
         'target': {
@@ -59,8 +55,8 @@ class Annotation(annotation.Annotation):
                     'fields': {
                         'uri': {
                             'type': 'string',
-                            'index_analyzer': 'uri_index',
-                            'search_analyzer': 'uri_search',
+                            'index': 'analyzed',
+                            'analyzer': 'uri',
                         },
                     },
                 },
@@ -139,12 +135,9 @@ class Annotation(annotation.Annotation):
                 'tokenizer': 'keyword',
                 'filter': 'lowercase'
             },
-            'uri_index': {
+            'uri': {
                 'tokenizer': 'keyword',
                 'filter': ['uri', 'unique']
-            },
-            'uri_search': {
-                'tokenizer': 'keyword',
             },
             'user': {
                 'tokenizer': 'keyword',

--- a/h/static/scripts/searchfilters.coffee
+++ b/h/static/scripts/searchfilters.coffee
@@ -203,12 +203,7 @@ class QueryParser
       formatter: (uri) ->
         uri.toLowerCase()
       path: '/uri'
-      and_or: 'or'
-      options:
-        es:
-         query_type: 'match'
-         cutoff_frequency: 0.001
-         and_or: 'and'
+      and_or: 'and'
     since:
       formatter: (past) ->
         seconds =

--- a/h/static/scripts/services.coffee
+++ b/h/static/scripts/services.coffee
@@ -365,7 +365,7 @@ class ViewFilter
     uri:
       autofalse: (annotation) -> return not annotation.uri?
       value: (annotation) -> return annotation.uri
-      match: (term, value) -> return value is term
+      match: (term, value) -> return value.indexOf(term) > -1
     user:
       autofalse: (annotation) -> return not annotation.user?
       value: (annotation) -> return annotation.user

--- a/h/static/scripts/services.coffee
+++ b/h/static/scripts/services.coffee
@@ -373,9 +373,8 @@ class ViewFilter
     any:
       fields: ['quote', 'text', 'tag', 'user']
 
-  this.$inject = ['searchfilter','stringHelpers']
-  constructor: (searchfilter, stringHelpers) ->
-    @searchfilter = searchfilter
+  this.$inject = ['stringHelpers']
+  constructor: (stringHelpers) ->
 
     @_normalize = (e) ->
       if typeof e is 'string'

--- a/h/static/scripts/services.coffee
+++ b/h/static/scripts/services.coffee
@@ -398,10 +398,10 @@ class ViewFilter
   _arrayMatches: (filter, value, match) ->
     matches = true
     # Make copy for filtering
-    copy = value.slice()
+    copy = filter.terms.slice()
 
     copy = copy.filter (e) ->
-      match filter.terms, e
+      match value, e
 
     if (filter.operator is 'and' and copy.length < filter.terms.length) or
     (filter.operator is 'or' and not copy.length)

--- a/tests/js/services-test.coffee
+++ b/tests/js/services-test.coffee
@@ -1,0 +1,155 @@
+assert = chai.assert
+sinon.assert.expose assert, prefix: null
+
+describe 'h', ->
+  sandbox = null
+
+  beforeEach module('h')
+
+  beforeEach module ($provide) ->
+    sandbox = sinon.sandbox.create()
+    return
+
+  afterEach ->
+    sandbox.restore()
+
+  describe 'viewFilter service', ->
+    fakeStringHelpers = null
+    viewFilter = null
+
+    beforeEach module ($provide) ->
+      fakeStringHelpers = {
+        uniFold: sandbox.spy()
+      }
+
+      $provide.value 'stringHelpers', fakeStringHelpers
+      return
+
+    beforeEach inject (_viewFilter_) ->
+      viewFilter = _viewFilter_
+
+    describe '_normalize', ->
+      it 'calls stringHelpers.uniFold with a string argument', ->
+        text = 'I heard you”—here I opened wide the door;—
+               Darkness there and nothing more.'
+        viewFilter._normalize text
+        assert.calledWith fakeStringHelpers.uniFold, text
+
+      it 'returns the argument otherwise', ->
+        input = null
+        result = viewFilter._normalize input
+        assert.notCalled fakeStringHelpers.uniFold
+        assert.deepEqual result, input
+
+        input = {}
+        result = viewFilter._normalize input
+        assert.notCalled fakeStringHelpers.uniFold
+        assert.deepEqual result, input
+
+        input = 2
+        result = viewFilter._normalize input
+        assert.notCalled fakeStringHelpers.uniFold
+        assert.deepEqual result, input
+
+    describe 'match functions', ->
+      filter = {
+        terms: ['Tiger', 'burning', 'bright']
+        operator: 'and'
+      }
+
+      matchAllFn = (term, value) -> true
+      matchNoneFn = (term, value) -> false
+
+      describe '_matches', ->
+        matchFn = (term, value) -> value.indexOf(term) > -1
+
+        beforeEach ->
+          fakeStringHelpers.uniFold = (e) -> return e
+
+        it 'uses the match function to evaluate matching', ->
+          match = viewFilter._matches filter, null, matchAllFn
+          assert.isTrue match
+
+          match = viewFilter._matches filter, null, matchNoneFn
+          assert.isFalse match
+
+        it 'all terms must match for "and" operator', ->
+          value = 'Tiger! Tiger! burning bright
+                  In the forest of the night
+                  What immortal hand or eye
+                  Could frame thy fearful symmetry?'
+          match = viewFilter._matches filter, value, matchFn
+          assert.isTrue match
+
+          value = "burning bright In the forest of the night"
+          match = viewFilter._matches filter, value, matchFn
+          assert.isFalse match
+
+        it 'only one term match is enough for "or" operator', ->
+          filter.operator = 'or'
+          value = 'Tiger! Tiger!'
+          match = viewFilter._matches filter, value, matchFn
+          assert.isTrue match
+
+      describe '_arrayMatches', ->
+        matchFn = (term, value) -> value in term
+
+        it 'uses the match function to evaluate matching', ->
+          value = ['copycat']
+          match = viewFilter._arrayMatches filter, value, matchAllFn
+          assert.isTrue match
+
+          match = viewFilter._arrayMatches filter, value, matchNoneFn
+          assert.isFalse match
+
+        it 'all terms must match for "and" operator', ->
+          filter.operator = 'and'
+
+          value = ['Tiger', 'burning', 'in the forest', 'bright']
+          match = viewFilter._arrayMatches filter, value, matchFn
+          assert.isTrue match
+
+          value = ['Tiger', 'burning', 'in the forest']
+          match = viewFilter._arrayMatches filter, value, matchFn
+          assert.isFalse match
+
+        it 'only one term match is enough for "or" operator', ->
+          filter.operator = 'or'
+          value = ['Tiger', 'in the forest']
+          match = viewFilter._arrayMatches filter, value, matchFn
+          assert.isTrue match
+
+      describe '_checkMatch', ->
+        checker = {
+          autofalse: (obj) -> not obj.text?
+          value: (obj) -> obj.text
+          match: (term, value) -> value.indexOf(term) > -1
+        }
+
+        it 'returns false if autofalseFn returns false', ->
+          annotation = {}
+          result = viewFilter._checkMatch filter, annotation, checker
+          assert.isFalse result
+
+        it 'calls _matches() for scalar values', ->
+          annotation = {
+            text: 'In what distant deeps or skies
+                  Burnt the fire of thine eyes?
+                  On what wings dare he aspire?
+                  What the hand dare seize the fire?'
+          }
+
+          viewFilter._matches = sandbox.spy()
+          viewFilter._checkMatch filter, annotation, checker
+          assert.called viewFilter._matches
+
+        it 'calls _arrayMatches() for arrays', ->
+          annotation = {
+            text: ['In what distant deeps or skies',
+                  'Burnt the fire of thine eyes?']
+          }
+
+          viewFilter._arrayMatches = sandbox.spy()
+          viewFilter._checkMatch filter, annotation, checker
+          assert.called viewFilter._arrayMatches
+


### PR DESCRIPTION
This PR adds the uri analyzer to analyze our uri fields instead of the old asymmetric way, where the index analyzer and the search analyzer was different.

This simplifies some configuration stuff too client side.

The biggest part of this PR is adding test cases to our `viewFilter` service. 

Fix #1537