### PR TITLE
Refactor and fix scrolling

### DIFF
--- a/h/static/scripts/annotator/plugin/bucket-bar.coffee
+++ b/h/static/scripts/annotator/plugin/bucket-bar.coffee
@@ -142,7 +142,7 @@ class Annotator.Plugin.BucketBar extends Annotator.Plugin
 
     # Get an anchor from the page we want to go to
     anchor = next[0]
-    anchor.scrollTo()
+    anchor.scrollIntoView()
 
   _update: =>
     wrapper = @annotator.wrapper

--- a/h/static/scripts/annotator/plugin/bucket-bar.coffee
+++ b/h/static/scripts/annotator/plugin/bucket-bar.coffee
@@ -53,8 +53,7 @@ class Annotator.Plugin.BucketBar extends Annotator.Plugin
     $(window).on 'resize scroll', this._scheduleUpdate
     $(document.body).on 'resize scroll', '*', this._scheduleUpdate
 
-    # Event handler to finish scrolling when we have to
-    # wait for anchors to be realized
+    # Event handler to to update when new highlights have been created
     @annotator.subscribe "highlightsCreated", (highlights) =>
       # All the highlights are guaranteed to belong to one anchor,
       # so we can do this:
@@ -68,26 +67,7 @@ class Annotator.Plugin.BucketBar extends Annotator.Plugin
       if anchor.annotation.id? # Is this a finished annotation ?
         this._scheduleUpdate()
 
-      if @pendingScroll? and anchor in @pendingScroll.anchors
-        # One of the wanted anchors has been realized
-        unless --@pendingScroll.count
-          # All anchors have been realized
-          page = @pendingScroll.page
-          dir = if @pendingScroll.direction is "up" then +1 else -1
-          {next} = @pendingScroll.anchors.reduce (acc, anchor) ->
-            {start, next} = acc
-            hl = anchor.highlight[page]
-            if not next? or hl.getTop()*dir > start*dir
-              start: hl.getTop()
-              next: hl
-            else
-              acc
-          , {}
-
-          # Scroll down to the annotation from the top of the annotation's page
-          next.paddedScrollTo('down')
-          delete @pendingScroll
-
+    # Event handler to to update when highlights have been removed
     @annotator.subscribe "highlightRemoved", (highlight) =>
       if highlight.annotation.id? # Is this a finished annotation ?
         this._scheduleUpdate()
@@ -162,21 +142,7 @@ class Annotator.Plugin.BucketBar extends Annotator.Plugin
 
     # Get an anchor from the page we want to go to
     anchor = next[0]
-    startPage = anchor.startPage
-
-    # Is this rendered?
-    if @annotator.anchoring.document.isPageMapped startPage
-      # If it was rendered, then we only have one result. Go there.
-      hl = anchor.highlight[startPage]
-      hl.paddedScrollTo direction
-    else
-      # Not rendered yet. Go to the page, and see what happens.
-      @pendingScroll =
-        anchors: next
-        count: next.length
-        page: startPage
-        direction: direction
-      @annotator.anchoring.document.setPageIndex startPage
+    anchor.scrollTo()
 
   _update: =>
     wrapper = @annotator.wrapper

--- a/h/static/scripts/annotator/plugin/enhancedanchoring.coffee
+++ b/h/static/scripts/annotator/plugin/enhancedanchoring.coffee
@@ -220,18 +220,23 @@ class Annotator.Plugin.EnhancedAnchoring extends Annotator.Plugin
   # Collect all the highlights (optionally for a given set of annotations)
   getHighlights: (annotations) ->
     results = []
+    for anchor in @getAnchors(annotations)
+      for page, highlight of anchor.highlight
+        results.push highlight
+    results
+
+  # Collect all the anchors (optionally for a given set of annotations)
+  getAnchors: (annotations) ->
+    results = []
     if annotations?
       # Collect only the given set of annotations
       for annotation in annotations
-        for anchor in annotation.anchors
-          for page, hl of anchor.highlight
-            results.push hl
+        @$.merge results, annotator.anchors
     else
       # Collect from everywhere
       for page, anchors of @anchors
-        @$.merge results, (anchor.highlight[page] for anchor in anchors when anchor.highlight[page]?)
+        @$.merge results, anchors
     results
-
 
   # PUBLIC entry point 1:
   # This is called to create a target from a raw selection,

--- a/h/static/scripts/annotator/plugin/enhancedanchoring.coffee
+++ b/h/static/scripts/annotator/plugin/enhancedanchoring.coffee
@@ -83,6 +83,41 @@ class Anchor
       # Kill the list if it's empty
       delete @anchoring.anchors[index] unless anchors.length
 
+  # Scroll to this anchor
+
+  # Scroll to this anchor
+  scrollTo: ->
+    currentPage = @anchoring.document.getPageIndex()
+
+    if @startPage is @endPage and currentPage is @startPage
+      # It's all in one page. Simply scrolling
+      @highlight[@startPage].scrollTo()
+    else
+      console.log "This is a multi-page situation"
+      if currentPage < @startPage
+        # We need to go forward
+        wantedPage = @startPage
+        scrollPage = wantedPage - 1
+      else if currentPage > @endPage
+        # We need to go backwards
+        wantedPage = @endPage
+        scrollPage = wantedPage + 1
+      else
+        # We have no idea where we need to go
+        wantedPage = @startPage
+        scrollPage = wantedPage
+
+      # Is this rendered?
+      if @anchoring.document.isPageMapped wantedPage
+        # If it was rendered, we can simply go there.
+        console.log "Page rendered, scrolling directly"
+        @highlight[wantedPage].scrollTo()
+      else
+        # Not rendered yet. Go to the page, and see what happens.
+        console.log "Scrolling to page first"
+        @pendingScroll = true
+        @anchoring.document.setPageIndex scrollPage
+
 Annotator.Anchor = Anchor
 
 # This plugin contains the enhanced anchoring framework.

--- a/h/static/scripts/annotator/plugin/enhancedanchoring.coffee
+++ b/h/static/scripts/annotator/plugin/enhancedanchoring.coffee
@@ -55,6 +55,12 @@ class Anchor
     # Announce the creation of the highlights
     @anchoring.annotator.publish 'highlightsCreated', created
 
+    # If we are supposed to scroll to the highlight on a page,
+    # and it's available now, go scroll there.
+    if @pendingScroll? and (hl = @highlight[@pendingScroll])
+      hl.scrollTo()
+      delete @pendingScroll
+
   # Remove the highlights for the given set of pages
   virtualize: (pageIndex) =>
     highlight = @highlight[pageIndex]
@@ -93,7 +99,6 @@ class Anchor
       # It's all in one page. Simply scrolling
       @highlight[@startPage].scrollTo()
     else
-      console.log "This is a multi-page situation"
       if currentPage < @startPage
         # We need to go forward
         wantedPage = @startPage
@@ -103,19 +108,18 @@ class Anchor
         wantedPage = @endPage
         scrollPage = wantedPage + 1
       else
-        # We have no idea where we need to go
+        # We have no idea where we need to go.
+        # Let's just go to the start.
         wantedPage = @startPage
         scrollPage = wantedPage
 
       # Is this rendered?
       if @anchoring.document.isPageMapped wantedPage
-        # If it was rendered, we can simply go there.
-        console.log "Page rendered, scrolling directly"
+        # The wanted page is already rendered, we can simply go there
         @highlight[wantedPage].scrollTo()
       else
-        # Not rendered yet. Go to the page, and see what happens.
-        console.log "Scrolling to page first"
-        @pendingScroll = true
+        # Not rendered yet. Go to the page, we will continue from there
+        @pendingScroll = wantedPage
         @anchoring.document.setPageIndex scrollPage
 
 Annotator.Anchor = Anchor

--- a/h/static/scripts/annotator/plugin/enhancedanchoring.coffee
+++ b/h/static/scripts/annotator/plugin/enhancedanchoring.coffee
@@ -90,8 +90,6 @@ class Anchor
       delete @anchoring.anchors[index] unless anchors.length
 
   # Scroll to this anchor
-
-  # Scroll to this anchor
   scrollTo: ->
     currentPage = @anchoring.document.getPageIndex()
 

--- a/h/static/scripts/annotator/plugin/enhancedanchoring.coffee
+++ b/h/static/scripts/annotator/plugin/enhancedanchoring.coffee
@@ -57,9 +57,9 @@ class Anchor
 
     # If we are supposed to scroll to the highlight on a page,
     # and it's available now, go scroll there.
-    if @pendingScroll? and (hl = @highlight[@pendingScroll])
+    if @pendingScrollTargetPage? and (hl = @highlight[@pendingScrollTargetPage])
       hl.scrollIntoView()
-      delete @pendingScroll
+      delete @pendingScrollTargetPage
 
   # Remove the highlights for the given set of pages
   virtualize: (pageIndex) =>
@@ -117,7 +117,7 @@ class Anchor
         @highlight[wantedPage].scrollIntoView()
       else
         # Not rendered yet. Go to the page, we will continue from there
-        @pendingScroll = wantedPage
+        @pendingScrollTargetPage = wantedPage
         @anchoring.document.setPageIndex scrollPage
 
 Annotator.Anchor = Anchor

--- a/h/static/scripts/annotator/plugin/enhancedanchoring.coffee
+++ b/h/static/scripts/annotator/plugin/enhancedanchoring.coffee
@@ -58,7 +58,7 @@ class Anchor
     # If we are supposed to scroll to the highlight on a page,
     # and it's available now, go scroll there.
     if @pendingScroll? and (hl = @highlight[@pendingScroll])
-      hl.scrollTo()
+      hl.scrollIntoView()
       delete @pendingScroll
 
   # Remove the highlights for the given set of pages
@@ -90,12 +90,12 @@ class Anchor
       delete @anchoring.anchors[index] unless anchors.length
 
   # Scroll to this anchor
-  scrollTo: ->
+  scrollIntoView: ->
     currentPage = @anchoring.document.getPageIndex()
 
     if @startPage is @endPage and currentPage is @startPage
       # It's all in one page. Simply scrolling
-      @highlight[@startPage].scrollTo()
+      @highlight[@startPage].scrollIntoView()
     else
       if currentPage < @startPage
         # We need to go forward
@@ -114,7 +114,7 @@ class Anchor
       # Is this rendered?
       if @anchoring.document.isPageMapped wantedPage
         # The wanted page is already rendered, we can simply go there
-        @highlight[wantedPage].scrollTo()
+        @highlight[wantedPage].scrollIntoView()
       else
         # Not rendered yet. Go to the page, we will continue from there
         @pendingScroll = wantedPage

--- a/h/static/scripts/annotator/plugin/enhancedanchoring.coffee
+++ b/h/static/scripts/annotator/plugin/enhancedanchoring.coffee
@@ -270,7 +270,7 @@ class Annotator.Plugin.EnhancedAnchoring extends Annotator.Plugin
     if annotations?
       # Collect only the given set of annotations
       for annotation in annotations
-        @$.merge results, annotator.anchors
+        @$.merge results, annotation.anchors
     else
       # Collect from everywhere
       for page, anchors of @anchors

--- a/h/static/scripts/annotator/plugin/texthighlights.coffee
+++ b/h/static/scripts/annotator/plugin/texthighlights.coffee
@@ -86,7 +86,7 @@ class TextHighlight
   getHeight: -> $(@_highlights).outerHeight true
 
   # Scroll the highlight into view, with a comfortable margin
-  scrollTo: ->
+  scrollIntoView: ->
     wrapper = @annotator.wrapper
     defaultView = wrapper[0].ownerDocument.defaultView
     pad = defaultView.innerHeight * .2

--- a/h/static/scripts/annotator/plugin/texthighlights.coffee
+++ b/h/static/scripts/annotator/plugin/texthighlights.coffee
@@ -85,27 +85,23 @@ class TextHighlight
   # Get the height of the highlight.
   getHeight: -> $(@_highlights).outerHeight true
 
-  # Scroll the highlight into view.
-  scrollTo: -> $(@_highlights).scrollintoview()
-
-  # Scroll the highlight into view, with a comfortable margin.
-  # up should be true if we need to scroll up; false otherwise
-  paddedScrollTo: (direction) ->
-    unless direction? then throw "Direction is required"
-    dir = if direction is "up" then -1 else +1
+  # Scroll the highlight into view, with a comfortable margin
+  scrollTo: ->
     wrapper = @annotator.wrapper
     defaultView = wrapper[0].ownerDocument.defaultView
     pad = defaultView.innerHeight * .2
     $(@_highlights).scrollintoview
-      complete: ->
+      complete: (xDirStr, yDirStr) ->
+        return if yDirStr is "none"
         scrollable = if this.parentNode is this.ownerDocument
           $(this.ownerDocument.body)
         else
           $(this)
         top = scrollable.scrollTop()
-        correction = pad * dir
+        correction = pad * (if yDirStr is "up" then -1 else +1)
         scrollable.stop().animate {scrollTop: top + correction}, 300
 
+    null
 
 # Public: Wraps the DOM Nodes within the provided range with a highlight
 # element of the specified class and returns the highlight Elements.

--- a/h/static/scripts/guest.coffee
+++ b/h/static/scripts/guest.coffee
@@ -166,7 +166,7 @@ class Annotator.Guest extends Annotator
     .bind('scrollToAnnotation', (ctx, tag) =>
       for a in @anchoring.getAnchors()
         if a.annotation.$$tag is tag
-          a.scrollTo()
+          a.scrollIntoView()
           return
     )
 

--- a/h/static/scripts/guest.coffee
+++ b/h/static/scripts/guest.coffee
@@ -164,9 +164,9 @@ class Annotator.Guest extends Annotator
     )
 
     .bind('scrollToAnnotation', (ctx, tag) =>
-      for hl in @anchoring.getHighlights()
-        if hl.annotation.$$tag is tag
-          hl.scrollTo()
+      for a in @anchoring.getAnchors()
+        if a.annotation.$$tag is tag
+          a.scrollTo()
           return
     )
 

--- a/h/static/scripts/vendor/jquery.scrollintoview.js
+++ b/h/static/scripts/vendor/jquery.scrollintoview.js
@@ -109,18 +109,24 @@
 
 				var animOptions = {};
 
+				var yDir = "none";
+
 				// vertical scroll
 				if (options.direction.y === true)
 				{
 					if (rel.top < 0)
 					{
 						animOptions.scrollTop = dim.s.scroll.top + rel.top;
+						yDir = "up"
 					}
 					else if (rel.top > 0 && rel.bottom < 0)
 					{
 						animOptions.scrollTop = dim.s.scroll.top + Math.min(rel.top, -rel.bottom);
+						yDir = "down"
 					}
 				}
+
+				var xDir = "none";
 
 				// horizontal scroll
 				if (options.direction.x === true)
@@ -128,10 +134,12 @@
 					if (rel.left < 0)
 					{
 						animOptions.scrollLeft = dim.s.scroll.left + rel.left;
+						xDir = "left"
 					}
 					else if (rel.left > 0 && rel.right < 0)
 					{
 						animOptions.scrollLeft = dim.s.scroll.left + Math.min(rel.left, -rel.right);
+						xDir = "right"
 					}
 				}
 
@@ -146,14 +154,14 @@
 						.animate(animOptions, options.duration)
 						.eq(0) // we want function to be called just once (ref. "html,body")
 						.queue(function (next) {
-							$.isFunction(options.complete) && options.complete.call(scroller[0]);
+							$.isFunction(options.complete) && options.complete.call(scroller[0], xDir, yDir);
 							next();
 						});
 				}
 				else
 				{
 					// when there's nothing to scroll, just call the "complete" function
-					$.isFunction(options.complete) && options.complete.call(scroller[0]);
+					$.isFunction(options.complete) && options.complete.call(scroller[0], xDir, yDir);
 				}
 			}
 

--- a/h/static/scripts/vendor/jquery.scrollintoview.js
+++ b/h/static/scripts/vendor/jquery.scrollintoview.js
@@ -1,15 +1,16 @@
 ﻿/*!
  * jQuery scrollintoview() plugin and :scrollable selector filter
  *
- * https://github.com/hypothesis/jquery-scrollintoview
+ * Version 1.8 (14 Jul 2011)
+ * Requires jQuery 1.4 or newer
  *
- * Copyright (c) Hypothes.is Project and contributors
+ * Copyright (c) 2011 Robert Koritnik
  * Licensed under the terms of the MIT license
  * http://www.opensource.org/licenses/mit-license.php
  *
- * Forked from the version maintained by Robert Koritnik
- * https://github.com/litera/jquery-scrollintoview
- * Version 1.8 (14 Jul 2011)
+ * Modifications from the original by Hypothes.is Project and contributors:
+ * Copyright (c) Hypothes.is Project and contributors
+ * Licensed under the terms of the MIT license
  */
 
 (function ($) {

--- a/h/static/scripts/vendor/jquery.scrollintoview.js
+++ b/h/static/scripts/vendor/jquery.scrollintoview.js
@@ -1,12 +1,15 @@
 ﻿/*!
  * jQuery scrollintoview() plugin and :scrollable selector filter
  *
- * Version 1.8 (14 Jul 2011)
- * Requires jQuery 1.4 or newer
+ * https://github.com/hypothesis/jquery-scrollintoview
  *
- * Copyright (c) 2011 Robert Koritnik
+ * Copyright (c) Hypothes.is Project and contributors
  * Licensed under the terms of the MIT license
  * http://www.opensource.org/licenses/mit-license.php
+ *
+ * Forked from the version maintained by Robert Koritnik
+ * https://github.com/litera/jquery-scrollintoview
+ * Version 1.8 (14 Jul 2011)
  */
 
 (function ($) {


### PR DESCRIPTION
This is a refactoring of our scrolling code.

 * All scrolling-related code lives in the anchoring and highlight plugins; the bucket bar doesn't have to care for this any more
 * The two code-paths for triggering scrolling (bucket-bar arrows and annotation cards) have been unified.
 * Padded scrolling (when we leave some space between the highlight and the edge of the viewport) is fully supported now in all cases.
 * The whole madness of directions is gone now. (Instead, I had to fork the jquery plugin responsible for the scrolling. It's a 4yo abandonware, so I hope that doesn't hurt as too much.)
 * Scrolling in multi-page documents (ie. pdf) is fixed.

Fixes #1776.
Fixes #1873.
Fixes #1890.
