### PR TITLE
Eliminate the explicit account module

### DIFF
--- a/h/static/scripts/account/account-controller.coffee
+++ b/h/static/scripts/account/account-controller.coffee
@@ -87,5 +87,5 @@ class AccountController
 
 
 
-angular.module('h.account')
+angular.module('h')
 .controller('AccountController', AccountController)

--- a/h/static/scripts/account/account.coffee
+++ b/h/static/scripts/account/account.coffee
@@ -1,10 +1,3 @@
-imports = [
-  'ngRoute'
-  'h.identity'
-  'h.helpers'
-  'h.session'
-]
-
 AUTH_SESSION_ACTIONS = [
   'login'
   'logout'
@@ -126,6 +119,7 @@ configure = [
 ]
 
 
-angular.module('h.account', imports, configure)
+angular.module('h')
+.config(configure)
 .controller('AuthAppController', AuthAppController)
 .controller('AuthPageController', AuthPageController)

--- a/h/static/scripts/account/auth-controller.coffee
+++ b/h/static/scripts/account/auth-controller.coffee
@@ -53,5 +53,5 @@ class AuthController
         , 300000
 
 
-angular.module('h.account')
+angular.module('h')
 .controller('AuthController', AuthController)

--- a/h/static/scripts/app.coffee
+++ b/h/static/scripts/app.coffee
@@ -3,7 +3,6 @@ imports = [
   'ngRoute'
   'ngSanitize'
   'ngTagsInput'
-  'h.account'
   'h.helpers'
   'h.identity'
   'h.session'

--- a/tests/js/account/account-controller-test.coffee
+++ b/tests/js/account/account-controller-test.coffee
@@ -2,7 +2,7 @@ assert = chai.assert
 sinon.assert.expose assert, prefix: null
 sandbox = sinon.sandbox.create()
 
-describe 'h.account.AccountController', ->
+describe 'AccountController', ->
   $scope = null
   fakeFlash = null
   fakeSession = null
@@ -14,7 +14,7 @@ describe 'h.account.AccountController', ->
   profilePromise = null
   createController = null
 
-  beforeEach module('h.account')
+  beforeEach module('h')
 
   beforeEach module ($provide, $filterProvider) ->
     fakeSession = {}


### PR DESCRIPTION
Angular is smart enough to not instantiate the application until all
pending scripts have been loaded. That means that we can load optional
components by simply appending the script tags. We already load the
account component after the app component. By having the account
component attach its controllers and configuration functions to the
existing 'h' module, rather than defining a new angular module, the
app can avoid having a dependency on 'h.account'. This removes the
requirement that integrators define this module. Instead, they can
just attach a configuration function to the main module if they need
to configure the identity provider.

I have a mild preference for this pattern, since strictly speaking no
account module needs to be present. With a little morke tweaking, the
interface could be made to not have a sign in link and operate in an
anonymous mode by default, assuming that the server requires no
authorization to annotate.