### PR TITLE
Allow setting model creation settings from env

### DIFF
--- a/h/config.py
+++ b/h/config.py
@@ -9,6 +9,7 @@ def settings_from_environment():
     settings = {}
 
     _setup_heroku(settings)
+    _setup_db(settings)
     _setup_elasticsearch(settings)
     _setup_email(settings)
     _setup_features(settings)
@@ -38,6 +39,16 @@ def _setup_heroku(settings):
     # REDISTOGO_URL matches the Heroku environment variable for Redis To Go
     if 'REDISTOGO_URL' in os.environ:
         settings['redis.sessions.url'] = os.environ['REDISTOGO_URL'] + '0'
+
+
+def _setup_db(settings):
+    # Allow overriding the model autocreation/deletion from the environment
+    if 'MODEL_CREATE_ALL' in os.environ:
+        settings['basemodel.should_create_all'] = asbool(
+            os.environ['MODEL_CREATE_ALL'])
+    if 'MODEL_DROP_ALL' in os.environ:
+        settings['basemodel.should_drop_all'] = asbool(
+            os.environ['MODEL_DROP_ALL'])
 
 
 def _setup_elasticsearch(settings):

--- a/production.ini
+++ b/production.ini
@@ -2,9 +2,6 @@
 use: egg:h
 filter-with: proxy-prefix
 
-# Don't create/update indices and mappings by default
-basemodel.should_create_all: False
-
 # ElasticSearch configuration
 #es.host: http://localhost:9200
 #es.index: annotator


### PR DESCRIPTION
Dokku deployments are currently failing because they use production.ini,
which has disabled automatic schema setup. This change reverts that
default, as it is still sensible for single-worker production
environments, and allows the setting to be configured from the
environment.