### PR TITLE
Change the search_analyzer for uri

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language:
 python:
   - '2.7'
 before_install:
-  - sudo /usr/share/elasticsearch/bin/plugin -install elasticsearch/elasticsearch-analysis-icu/2.3.0
+  - sudo /usr/share/elasticsearch/bin/plugin -install elasticsearch/elasticsearch-analysis-icu/2.4.1
   - sudo service elasticsearch restart
 install:
   - gem install sass

--- a/h/conftest.py
+++ b/h/conftest.py
@@ -15,6 +15,9 @@ from sqlalchemy import engine_from_config
 from sqlalchemy.orm import scoped_session, sessionmaker
 from zope.sqlalchemy import ZopeTransactionExtension
 
+from h.api import create_db, delete_db
+from h.api import store_from_settings
+
 
 @pytest.fixture(scope='session', autouse=True)
 def settings():
@@ -51,6 +54,17 @@ def db_session(request, settings):
     request.addfinalizer(destroy)
 
     return pyramid_basemodel.Session
+
+
+@pytest.fixture()
+def es_connection(request, settings):
+    es = store_from_settings(settings)
+    create_db()
+    # Pylint issue #258: https://bitbucket.org/logilab/pylint/issue/258
+    #
+    # pylint: disable=unexpected-keyword-arg
+    es.conn.cluster.health(wait_for_status='yellow')
+    request.addfinalizer(delete_db)
 
 
 def _make_session():

--- a/h/models.py
+++ b/h/models.py
@@ -115,13 +115,23 @@ class Annotation(annotation.Annotation):
     }
     __analysis__ = {
         'filter': {
-            'uri': {
+            'uri_index': {
                 'type': 'pattern_capture',
                 'preserve_original': '1',
                 'patterns': [
                     '([^\\/\\?\\#\\.]+)',
                     '([a-zA-Z0-9]+)(?:\\.([a-zA-Z0-9]+))*',
                     '([a-zA-Z0-9-]+)(?:\\.([a-zA-Z0-9-]+))*',
+                    '://(.+)',
+                    '://(.+)\\#',
+                ]
+            },
+            'uri_search': {
+                'type': 'pattern_capture',
+                'preserve_original': '1',
+                'patterns': [
+                    '://(.+)',
+                    '://(.+)\\#',
                 ]
             },
             'user': {
@@ -141,10 +151,11 @@ class Annotation(annotation.Annotation):
             },
             'uri_index': {
                 'tokenizer': 'keyword',
-                'filter': ['uri', 'unique']
+                'filter': ['uri_index', 'unique', 'lowercase']
             },
             'uri_search': {
                 'tokenizer': 'keyword',
+                'filter': ['uri_search', 'unique', 'lowercase']
             },
             'user': {
                 'tokenizer': 'keyword',

--- a/h/test/models_test.py
+++ b/h/test/models_test.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import unittest
+import pytest
 
 from pytest import fixture, raises
 from pyramid import security
@@ -57,3 +58,22 @@ class TestAnnotationPermissions(unittest.TestCase):
         actual = annotation.__acl__()
         expect = [(security.Allow, security.Authenticated, 'read')]
         assert actual == expect
+
+
+@pytest.mark.usefixtures('es_connection')
+def test_uri_mapping():
+    permissions = {
+        'read': ['group:__world__'],
+    }
+    a1 = models.Annotation(uri='http://example.com/page#hashtag',
+                           permissions=permissions)
+    a1.save()
+    a2 = models.Annotation(uri='http://example.com/page',
+                           permissions=permissions)
+    a2.save()
+    a3 = models.Annotation(uri='http://totallydifferent.domain.com/',
+                           permissions=permissions)
+    a3.save()
+
+    res = models.Annotation.search(query={'uri': 'example.com/page'})
+    assert len(res) == 2

--- a/test.ini
+++ b/test.ini
@@ -2,6 +2,7 @@
 use: egg:h
 
 es.host: http://localhost:9200
+es.index: annotator_test
 
 sqlalchemy.url: sqlite://
 


### PR DESCRIPTION
This PR carries the intention to have better matches on uri searches.
It extends both the search and index analyzers with uris stripped from its protocol or query or fragment.

Fix #1537

<!---
@huboard:{"order":7.125,"milestone_order":1907,"custom_state":""}
-->
