### PR TITLE
Refactor and fix scrolling - except padding

### DIFF
--- a/h/static/scripts/annotator/plugin/texthighlights.coffee
+++ b/h/static/scripts/annotator/plugin/texthighlights.coffee
@@ -85,27 +85,11 @@ class TextHighlight
   # Get the height of the highlight.
   getHeight: -> $(@_highlights).outerHeight true
 
-  # Scroll the highlight into view.
-  scrollTo: -> $(@_highlights).scrollintoview()
-
-  # Scroll the highlight into view, with a comfortable margin.
-  # up should be true if we need to scroll up; false otherwise
-  paddedScrollTo: (direction) ->
-    unless direction? then throw "Direction is required"
-    dir = if direction is "up" then -1 else +1
-    wrapper = @annotator.wrapper
-    defaultView = wrapper[0].ownerDocument.defaultView
-    pad = defaultView.innerHeight * .2
-    $(@_highlights).scrollintoview
-      complete: ->
-        scrollable = if this.parentNode is this.ownerDocument
-          $(this.ownerDocument.body)
-        else
-          $(this)
-        top = scrollable.scrollTop()
-        correction = pad * dir
-        scrollable.stop().animate {scrollTop: top + correction}, 300
-
+  # Scroll the highlight into view
+  scrollIntoView: ->
+    new Promise (resolve, reject) ->
+      $(@_highlights).scrollintoview complete: ->
+        resolve()
 
 # Public: Wraps the DOM Nodes within the provided range with a highlight
 # element of the specified class and returns the highlight Elements.

--- a/h/static/scripts/guest.coffee
+++ b/h/static/scripts/guest.coffee
@@ -164,9 +164,9 @@ class Annotator.Guest extends Annotator
         else
           hl.setFocused false
     crossframe.on 'scrollToAnnotation', (ctx, tag) =>
-      for hl in @anchoring.getHighlights()
-        if hl.annotation.$$tag is tag
-          hl.scrollTo()
+      for a in @anchoring.getAnchors()
+        if a.annotation.$$tag is tag
+          a.scrollIntoView()
           return
     crossframe.on 'getDocumentInfo', (trans) =>
       (@plugins.PDF?.getMetaData() ? Promise.reject())

--- a/tests/js/guest-test.coffee
+++ b/tests/js/guest-test.coffee
@@ -194,14 +194,14 @@ describe 'Annotator.Guest', ->
         assert.calledWith(highlights[1].setFocused, false)
 
     describe 'on "scrollToAnnotation" event', ->
-      it 'scrolls to the highLight with the matching tag', ->
+      it 'scrolls to the anchor with the matching tag', ->
         guest = createGuest()
-        highlights = [
-          {annotation: {$$tag: 'tag1'}, scrollTo: sandbox.stub()}
+        anchors = [
+          {annotation: {$$tag: 'tag1'}, scrollIntoView: sandbox.stub()}
         ]
-        sandbox.stub(guest.anchoring, 'getHighlights').returns(highlights)
+        sandbox.stub(guest.anchoring, 'getAnchors').returns(anchors)
         emitGuestEvent('scrollToAnnotation', 'ctx', 'tag1')
-        assert.called(highlights[0].scrollTo)
+        assert.called(anchors[0].scrollIntoView)
 
     describe 'on "getDocumentInfo" event', ->
       guest = null

--- a/tests/js/plugin/enhancedanchoring-test.coffee
+++ b/tests/js/plugin/enhancedanchoring-test.coffee
@@ -60,9 +60,9 @@ describe 'Annotator.Plugin.EnhancedAnchoring', ->
         page: page
         removeFromDocument: sinon.spy()
         scrollIntoView: sinon.spy ->
-          new Promise (resolve, reject) =>
-            setTimeout =>
-              @anchor.anchoring.document.setPageIndex @page
+          new Promise (resolve, reject) ->
+            setTimeout ->
+              anchor.anchoring.document.setPageIndex page
               resolve()
 
   afterEach ->

--- a/tests/js/plugin/enhancedanchoring-test.coffee
+++ b/tests/js/plugin/enhancedanchoring-test.coffee
@@ -665,15 +665,10 @@ describe 'Annotator.Plugin.EnhancedAnchoring', ->
         ann = createTestAnnotationForPages "a1", [10]
         anchor = am.createAnchor(ann, ann.target[0]).result
         am.document.currentIndex = 5  # We start from page 5
-        am.document.setPageIndex = sinon.spy (index) ->
-          am.document.currentIndex = index
-          if index is 9
-            renderPage am.document, 9
-            renderPage am.document, 10
 
         # Now we trigger the actual action
-        anchor.scrollIntoView().then ->
-          assert.calledWith am.document.setPageIndex, 9
+        anchor.scrollIntoView()
+        assert.calledWith am.document.setPageIndex, 9
 
       it 'gets the wanted page rendered', ->
         am = createAnchoringManagerAndLazyDocument()

--- a/tests/js/plugin/enhancedanchoring-test.coffee
+++ b/tests/js/plugin/enhancedanchoring-test.coffee
@@ -660,7 +660,7 @@ describe 'Annotator.Plugin.EnhancedAnchoring', ->
 
     describe 'when scrolling to a virtual anchor', ->
 
-      it 'jumpings close to the wanted page', ->
+      it 'scrolls right next to the wanted page (to get it rendered)', ->
         am = createAnchoringManagerAndLazyDocument()
         ann = createTestAnnotationForPages "a1", [10]
         anchor = am.createAnchor(ann, ann.target[0]).result
@@ -675,7 +675,7 @@ describe 'Annotator.Plugin.EnhancedAnchoring', ->
         anchor.scrollIntoView().then ->
           assert.calledWith am.document.setPageIndex, 9
 
-      it 'has the wanted page rendered', ->
+      it 'gets the wanted page rendered', ->
         am = createAnchoringManagerAndLazyDocument()
         ann = createTestAnnotationForPages "a1", [10]
         anchor = am.createAnchor(ann, ann.target[0]).result
@@ -690,7 +690,7 @@ describe 'Annotator.Plugin.EnhancedAnchoring', ->
         anchor.scrollIntoView().then ->
           assert am.document.isPageMapped 10
 
-      it 'gets to the wanted page, eventually', ->
+      it 'scrolls to the wanted page, eventually', ->
         am = createAnchoringManagerAndLazyDocument()
         ann = createTestAnnotationForPages "a1", [10]
         anchor = am.createAnchor(ann, ann.target[0]).result

--- a/tests/js/plugin/enhancedanchoring-test.coffee
+++ b/tests/js/plugin/enhancedanchoring-test.coffee
@@ -60,10 +60,7 @@ describe 'Annotator.Plugin.EnhancedAnchoring', ->
         page: page
         removeFromDocument: sinon.spy()
         scrollIntoView: sinon.spy ->
-          new Promise (resolve, reject) ->
-            setTimeout ->
-              anchor.anchoring.document.setPageIndex page
-              resolve()
+          new Promise (resolve, reject) -> setTimeout -> resolve()
 
   afterEach ->
     sandbox.restore()
@@ -237,9 +234,6 @@ describe 'Annotator.Plugin.EnhancedAnchoring', ->
 
   describe 'two-phased anchoring', ->
 
-    # Simple lazy rendering document simulation for testing,
-    # which emulates the user movement prediction (and page rendering)
-    # behavior of PDF.js
     class DummyDocumentAccess
 
       @applicable: -> true
@@ -247,11 +241,8 @@ describe 'Annotator.Plugin.EnhancedAnchoring', ->
       isPageMapped: (index) -> index in @_rendered
       getPageIndex: -> @currentIndex
 
-      setPageIndex: sinon.spy()
-
       constructor: ->
         @_rendered = []
-        @currentIndex = -10
 
     # Helper function to trigger a page rendering
     # This is an asynchronous method; returns a promise.
@@ -665,6 +656,7 @@ describe 'Annotator.Plugin.EnhancedAnchoring', ->
         ann = createTestAnnotationForPages "a1", [10]
         anchor = am.createAnchor(ann, ann.target[0]).result
         am.document.currentIndex = 5  # We start from page 5
+        am.document.setPageIndex = sinon.spy()
 
         # Now we trigger the actual action
         anchor.scrollIntoView()
@@ -684,21 +676,6 @@ describe 'Annotator.Plugin.EnhancedAnchoring', ->
         # Now we trigger the actual action
         anchor.scrollIntoView().then ->
           assert am.document.isPageMapped 10
-
-      it 'scrolls to the wanted page, eventually', ->
-        am = createAnchoringManagerAndLazyDocument()
-        ann = createTestAnnotationForPages "a1", [10]
-        anchor = am.createAnchor(ann, ann.target[0]).result
-        am.document.currentIndex = 5  # We start from page 5
-        am.document.setPageIndex = sinon.spy (index) ->
-          am.document.currentIndex = index
-          if index is 9
-            renderPage am.document, 9
-            renderPage am.document, 10
-
-        # Now we trigger the actual action
-        anchor.scrollIntoView().then ->
-          assert.calledWith am.document.setPageIndex, 10
 
       it 'calls scrollIntoView() on the highlight', ->
         am = createAnchoringManagerAndLazyDocument()


### PR DESCRIPTION
This is a refactoring of our scrolling code.

This PR contains all the non-controversial bits of #1899. 
Padded scrolling is completely removed in this version, so forking the upstream library is unnecessary.

This takes care of the cleanup of our own code; we can discuss how to best to the padded scrolling trick independently.

Text from the original PR:

   * * *

 * All scrolling-related code lives in the anchoring and highlight plugins; the bucket bar doesn't have to care for this any more
 * The two code-paths for triggering scrolling (bucket-bar arrows and annotation cards) have been unified.
 * ~~Padded scrolling (when we leave some space between the highlight and the edge of the viewport) is fully supported now in all cases.~~ Padded scrolling is removed
 * The whole madness of directions is gone now. ~~(Instead, I had to fork the jquery plugin responsible for the scrolling. It's a 4yo abandonware, so I hope that doesn't hurt as too much.)~~ 
 * Scrolling in multi-page documents (ie. pdf) is fixed.

Fixes #1873.
Fixes #1890.