### PR TITLE
Test cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 /*.db-journal
 /*.egg
 /*.egg-info
-/*.ini
 /MANIFEST
 /bin
 /build

--- a/h/accounts/test/views_test.py
+++ b/h/accounts/test/views_test.py
@@ -1,6 +1,6 @@
 from mock import patch, Mock, MagicMock
 
-from pyramid.testing import DummyRequest, testConfig
+from pyramid.testing import DummyRequest
 from horus.interfaces import IUserClass, IActivationClass, IUIStrings, IProfileSchema, IProfileForm
 from horus.schemas import ProfileSchema
 from horus.forms import SubmitForm
@@ -64,91 +64,86 @@ def _bad_password(request, username, password):
 
 
 # Tests for edit_profile calls
-def test_profile_invalid_password():
+def test_profile_invalid_password(config):
     """ Make sure our edit_profile call validates the user password
     """
     request = _get_fake_request('john', 'doe')
 
-    with testConfig() as config:
-        configure(config)
-        with patch('horus.models.UserMixin') as mock_user:
-            with patch('horus.lib.FlashMessage') as mock_flash:
-                mock_user.get_user = MagicMock(side_effect=_bad_password)
-                profile = ProfileController(request)
-                profile.User = mock_user
-                profile.edit_profile()
-                assert mock_flash.called_with(request, _('Invalid password.'), kind='error')
+    configure(config)
+    with patch('horus.models.UserMixin') as mock_user:
+        with patch('horus.lib.FlashMessage') as mock_flash:
+            mock_user.get_user = MagicMock(side_effect=_bad_password)
+            profile = ProfileController(request)
+            profile.User = mock_user
+            profile.edit_profile()
+            assert mock_flash.called_with(request, _('Invalid password.'), kind='error')
 
 
-def test_profile_calls_super():
+def test_profile_calls_super(config):
     """Make sure our method calls the superclasses edit_profile
        if the validations are successful
     """
     request = _get_fake_request('john', 'smith')
-    with testConfig() as config:
-        configure(config)
-        with patch('horus.models.UserMixin') as mock_user:
-            with patch('horus.views.ProfileController.edit_profile') as mock_super_profile:
-                mock_user.get_user = MagicMock(side_effect=_good_password_simple)
-                profile = ProfileController(request)
-                profile.User = mock_user
-                profile.edit_profile()
-                assert profile.request.context is True
-                assert mock_super_profile.called
+    configure(config)
+    with patch('horus.models.UserMixin') as mock_user:
+        with patch('horus.views.ProfileController.edit_profile') as mock_super_profile:
+            mock_user.get_user = MagicMock(side_effect=_good_password_simple)
+            profile = ProfileController(request)
+            profile.User = mock_user
+            profile.edit_profile()
+            assert profile.request.context is True
+            assert mock_super_profile.called
 
 
 # Tests for changing the subscription state
-def test_subscription_update():
+def test_subscription_update(config):
     """Make sure that the new status is written into the DB
     """
     request = _get_fake_request('acct:john@doe', 'smith', True, True)
     print "request", request.POST
-    with testConfig() as config:
-        configure(config)
-        with patch('h.accounts.views.Subscriptions') as mock_subs:
-            mock_subs.get_by_id = MagicMock()
-            mock_subs.get_by_id.return_value = Mock(active=True)
-            profile = ProfileController(request)
-            profile.db = Mock()
-            profile.db.add = MagicMock(name='add')
-            profile.edit_profile()
-            assert profile.db.add.called
+    configure(config)
+    with patch('h.accounts.views.Subscriptions') as mock_subs:
+        mock_subs.get_by_id = MagicMock()
+        mock_subs.get_by_id.return_value = Mock(active=True)
+        profile = ProfileController(request)
+        profile.db = Mock()
+        profile.db.add = MagicMock(name='add')
+        profile.edit_profile()
+        assert profile.db.add.called
 
 
 # Tests for disable_user calls
-def test_disable_invalid_password():
+def test_disable_invalid_password(config):
     """ Make sure our disable_user call validates the user password
     """
     request = _get_fake_request('john', 'doe')
 
-    with testConfig() as config:
-        configure(config)
-        with patch('horus.models.UserMixin') as mock_user:
-            with patch('horus.lib.FlashMessage') as mock_flash:
-                with patch('h.accounts.schemas.EditProfileSchema') as mock_schema:
-                    mock_schema.validator = MagicMock(name='validator')
-                    mock_user.get_user = MagicMock(side_effect=_bad_password)
-                    profile = ProfileController(request)
-                    profile.User = mock_user
-                    profile.disable_user()
-                    assert mock_flash.called_with(request, _('Invalid password.'), kind='error')
+    configure(config)
+    with patch('horus.models.UserMixin') as mock_user:
+        with patch('horus.lib.FlashMessage') as mock_flash:
+            with patch('h.accounts.schemas.EditProfileSchema') as mock_schema:
+                mock_schema.validator = MagicMock(name='validator')
+                mock_user.get_user = MagicMock(side_effect=_bad_password)
+                profile = ProfileController(request)
+                profile.User = mock_user
+                profile.disable_user()
+                assert mock_flash.called_with(request, _('Invalid password.'), kind='error')
 
 
-def test_user_disabled():
+def test_user_disabled(config):
     """Check if the disabled user flag is set
     """
     request = _get_fake_request('john', 'doe')
 
-    with testConfig() as config:
-        configure(config)
-        with patch('horus.models.UserMixin') as mock_user:
-            with patch('horus.lib.FlashMessage') as mock_flash:
-                with patch('h.accounts.schemas.EditProfileSchema') as mock_schema:
-                    mock_schema.validator = MagicMock(name='validator')
-                    mock_user.get_user = MagicMock(side_effect=_good_password)
-                    profile = ProfileController(request)
-                    profile.User = mock_user
-                    profile.db = FakeDB()
-                    profile.db.add = MagicMock(name='add')
-                    profile.disable_user()
-                    assert profile.db.add.called
+    configure(config)
+    with patch('horus.models.UserMixin') as mock_user:
+        with patch('horus.lib.FlashMessage') as mock_flash:
+            with patch('h.accounts.schemas.EditProfileSchema') as mock_schema:
+                mock_schema.validator = MagicMock(name='validator')
+                mock_user.get_user = MagicMock(side_effect=_good_password)
+                profile = ProfileController(request)
+                profile.User = mock_user
+                profile.db = FakeDB()
+                profile.db.add = MagicMock(name='add')
+                profile.disable_user()
+                assert profile.db.add.called

--- a/h/conftest.py
+++ b/h/conftest.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+"""
+The `conftest` module is automatically loaded by py.test and serves as a place
+to put fixture functions that are useful application-wide.
+"""
+import pytest
+
+from pyramid import testing
+from pyramid.paster import get_appsettings
+
+
+@pytest.fixture(scope='session', autouse=True)
+def settings():
+    """Default app settings (test.ini)."""
+    return get_appsettings('test.ini')
+
+
+@pytest.fixture(autouse=True)
+def config(request, settings):
+    """Pyramid configurator object."""
+    req = testing.DummyRequest()
+    config = testing.setUp(request=req, settings=settings)
+
+    def destroy():
+        testing.tearDown()
+
+    request.addfinalizer(destroy)
+
+    return config

--- a/h/oauth/test/lib_test.py
+++ b/h/oauth/test/lib_test.py
@@ -5,23 +5,20 @@ from pyramid import testing
 from h.oauth import interfaces, lib
 
 
-def test_get_client_ok():
+def test_get_client_ok(config):
     mock_factory = MagicMock()
-    settings = {'h.client_id': '1234'}
-    with testing.testConfig(settings=settings) as config:
-        registry = config.registry
-        registry.registerUtility(mock_factory, interfaces.IClientFactory)
-        request = testing.DummyRequest(registry=config.registry)
-        lib.get_client(request, '4321')
-        mock_factory.assert_called_with('4321')
+    registry = config.registry
+    registry.registerUtility(mock_factory, interfaces.IClientFactory)
+    request = testing.DummyRequest(registry=config.registry)
+    lib.get_client(request, '4321')
+    mock_factory.assert_called_with('4321')
 
 
-def test_get_client_not_ok():
+def test_get_client_not_ok(config):
+    config.registry.settings.update({'h.client_id': '1234'})
     mock_factory = MagicMock()
     mock_factory.return_value = None
-    settings = {'h.client_id': '1234'}
-    with testing.testConfig(settings=settings) as config:
-        registry = config.registry
-        registry.registerUtility(mock_factory, interfaces.IClientFactory)
-        request = testing.DummyRequest(registry=config.registry)
-        assert lib.get_client(request, '9876') is None
+    registry = config.registry
+    registry.registerUtility(mock_factory, interfaces.IClientFactory)
+    request = testing.DummyRequest(registry=config.registry)
+    assert lib.get_client(request, '9876') is None

--- a/h/streamer.py
+++ b/h/streamer.py
@@ -11,6 +11,7 @@ import unicodedata
 import weakref
 
 import gevent
+import gevent.queue
 from jsonpointer import resolve_pointer
 from jsonschema import validate
 from pyramid.config import aslist

--- a/h/test/assets_test.py
+++ b/h/test/assets_test.py
@@ -1,10 +1,8 @@
 # -*- coding: utf-8 -*-
 """Defines unit tests for h.assets."""
 from mock import Mock
-from pyramid.paster import get_appsettings
 from pyramid.urldispatch import Route
-from pyramid.testing import DummyRequest, testConfig
-import pytest
+from pyramid.testing import DummyRequest
 
 from h import assets
 
@@ -16,45 +14,32 @@ class DummyEvent(object):
         self.request = request
 
 
-@pytest.fixture
-def settings():
-    settings = get_appsettings('development.ini')
-    settings['bind'] = 'localhost:4000'
-    settings['es.index'] = 'annotator-test'
-    settings['sqlalchemy.url'] = 'sqlite:///test.db'
-    settings.update({
-        'basemodel.should_create_all': 'True',
-        'basemodel.should_drop_all': 'True',
-    })
-    return settings
-
-
-def test_subscriber_predicate(settings):
+def test_subscriber_predicate(config):
     """Test that the ``asset_request`` subscriber predicate.
 
     It should correctly match asset requests when its value is ``True``,
     and other requests when ``False``.
     """
+    config.include(assets)
+
     mock1 = Mock()
     mock2 = Mock()
 
-    with testConfig(settings=settings) as config:
-        config.include(assets)
-        config.add_subscriber(mock1, DummyEvent, asset_request=False)
-        config.add_subscriber(mock2, DummyEvent, asset_request=True)
+    config.add_subscriber(mock1, DummyEvent, asset_request=False)
+    config.add_subscriber(mock2, DummyEvent, asset_request=True)
 
-        request1 = DummyRequest('/')
-        request1.matched_route = None
+    request1 = DummyRequest('/')
+    request1.matched_route = None
 
-        pattern = config.get_webassets_env().url + '*subpath'
-        request2 = DummyRequest(config.get_webassets_env().url + '/t.png')
-        request2.matched_route = Route('__' + pattern, pattern)
+    pattern = config.get_webassets_env().url + '*subpath'
+    request2 = DummyRequest(config.get_webassets_env().url + '/t.png')
+    request2.matched_route = Route('__' + pattern, pattern)
 
-        event1 = DummyEvent(request1)
-        event2 = DummyEvent(request2)
+    event1 = DummyEvent(request1)
+    event2 = DummyEvent(request2)
 
-        config.registry.notify(event1)
-        config.registry.notify(event2)
+    config.registry.notify(event1)
+    config.registry.notify(event2)
 
-        mock1.assert_called_onceventwith(event1)
-        mock2.assert_called_onceventwith(event2)
+    mock1.assert_called_onceventwith(event1)
+    mock2.assert_called_onceventwith(event2)

--- a/h/test/features_test.py
+++ b/h/test/features_test.py
@@ -1,7 +1,7 @@
 import unittest
 
 from mock import patch
-from pyramid.testing import DummyRequest, testConfig
+from pyramid.testing import DummyRequest
 import pytest
 
 from h.features import Client
@@ -30,19 +30,17 @@ class TestClient(unittest.TestCase):
 
 
 @patch('h.features.Client')
-def test_get_client(client_mock):
-    settings = {
+def test_get_client(client_mock, config):
+    config.registry.settings.update({
         'h.feature.enabled_feature': 'on',
         'h.feature.disabled_feature': False,
         'unrelated_feature': 123,
-    }
+    })
 
-    with testConfig(settings=settings) as config:
-        request = DummyRequest(registry=config.registry)
+    request = DummyRequest(registry=config.registry)
+    get_client(request)
 
-        get_client(request)
-
-        client_mock.assert_called_with({
-            'enabled_feature': True,
-            'disabled_feature': False
-        })
+    client_mock.assert_called_with({
+        'enabled_feature': True,
+        'disabled_feature': False
+    })

--- a/h/test/streamer_test.py
+++ b/h/test/streamer_test.py
@@ -10,7 +10,6 @@ from mock import ANY
 from mock import MagicMock
 from mock import patch
 from pyramid.testing import DummyRequest
-from pyramid.testing import testConfig
 
 from h.streamer import FilterToElasticFilter
 from h.streamer import WebSocket
@@ -188,33 +187,30 @@ def test_operator_call():
     assert query['term']['text'] == expected
 
 
-def test_websocket_bad_origin():
-    settings = {'origins': 'http://good'}
-    with testConfig(settings=settings) as config:
-        config.include('h.streamer')
-        req = DummyRequest(headers={'Origin': 'http://bad'})
-        res = websocket(req)
-        assert res.code == 403
+def test_websocket_bad_origin(config):
+    config.registry.settings.update({'origins': 'http://good'})
+    config.include('h.streamer')
+    req = DummyRequest(headers={'Origin': 'http://bad'})
+    res = websocket(req)
+    assert res.code == 403
 
 
-def test_websocket_good_origin():
-    settings = {'origins': 'http://good'}
-    with testConfig(settings=settings) as config:
-        config.include('h.streamer')
-        req = DummyRequest(headers={'Origin': 'http://good'})
-        req.get_response = MagicMock()
-        res = websocket(req)
-        assert res.code != 403
+def test_websocket_good_origin(config):
+    config.registry.settings.update({'origins': 'http://good'})
+    config.include('h.streamer')
+    req = DummyRequest(headers={'Origin': 'http://good'})
+    req.get_response = MagicMock()
+    res = websocket(req)
+    assert res.code != 403
 
 
-def test_websocket_same_origin():
-    with testConfig() as config:
-        config.include('h.streamer')
-        # example.com is the dummy request default host URL
-        req = DummyRequest(headers={'Origin': 'http://example.com'})
-        req.get_response = MagicMock()
-        res = websocket(req)
-        assert res.code != 403
+def test_websocket_same_origin(config):
+    config.include('h.streamer')
+    # example.com is the dummy request default host URL
+    req = DummyRequest(headers={'Origin': 'http://example.com'})
+    req.get_response = MagicMock()
+    res = websocket(req)
+    assert res.code != 403
 
 
 class TestWebSocket(unittest.TestCase):

--- a/test.ini
+++ b/test.ini
@@ -1,0 +1,47 @@
+[app:main]
+use: egg:h
+
+es.host: http://localhost:9200
+
+sqlalchemy.url: sqlite://
+
+webassets.base_dir: h:static
+webassets.base_url: assets
+webassets.coffee_no_bare: True
+webassets.debug: True
+webassets.manifest: False
+webassets.static_view: True
+webassets.uglifyjs_bin: %(here)s/node_modules/.bin/uglifyjs
+webassets.cleancss_bin: %(here)s/node_modules/.bin/cleancss
+webassets.coffee_bin: %(here)s/node_modules/.bin/coffee
+
+[loggers]
+keys = root, h
+
+
+[handlers]
+keys = console
+
+
+[formatters]
+keys = generic
+
+
+[logger_root]
+handlers = console
+
+
+[logger_h]
+level = INFO
+handlers =
+qualname = h
+
+
+[handler_console]
+class = StreamHandler
+args = ()
+formatter = generic
+
+
+[formatter_generic]
+format = %(asctime)s [%(process)d] [%(name)s:%(levelname)s] %(message)s


### PR DESCRIPTION
Rather than using `pyramid.testing.testConfig` context managers in every single test, leading to
<pre>
    tests
        that
            look
                like
                    this,
</pre>
this commit adds a global `config` fixture in `h/conftest.py` which can be used across the project.