### PR TITLE
Username uniqueness

### DIFF
--- a/h/accounts/test/models_test.py
+++ b/h/accounts/test/models_test.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import pytest
+
+from sqlalchemy import exc
+from .. import models
+
+
+class TestUser(object):
+    def test_cannot_create_dot_variant_of_user(self, db_session):
+        fred = models.User(username='fredbloggs',
+                           email='fred@example.com',
+                           password='123')
+        fred2 = models.User(username='fred.bloggs',
+                            email='fred@example.org',
+                            password='456')
+
+        db_session.add(fred)
+        db_session.add(fred2)
+        with pytest.raises(exc.IntegrityError):
+            db_session.flush()
+
+    def test_cannot_create_case_variant_of_user(self, db_session):
+        bob = models.User(username='BobJones',
+                          email='bob@example.com',
+                          password='123')
+        bob2 = models.User(username='bobjones',
+                           email='bob@example.org',
+                           password='456')
+
+        db_session.add(bob)
+        db_session.add(bob2)
+        with pytest.raises(exc.IntegrityError):
+            db_session.flush()

--- a/h/conftest.py
+++ b/h/conftest.py
@@ -8,6 +8,13 @@ import pytest
 from pyramid import testing
 from pyramid.paster import get_appsettings
 
+import pyramid_basemodel
+import transaction
+
+from sqlalchemy import engine_from_config
+from sqlalchemy.orm import scoped_session, sessionmaker
+from zope.sqlalchemy import ZopeTransactionExtension
+
 
 @pytest.fixture(scope='session', autouse=True)
 def settings():
@@ -27,3 +34,24 @@ def config(request, settings):
     request.addfinalizer(destroy)
 
     return config
+
+
+@pytest.fixture()
+def db_session(request, settings):
+    """SQLAlchemy session."""
+    engine = engine_from_config(settings, 'sqlalchemy.')
+    pyramid_basemodel.Session = _make_session()
+    pyramid_basemodel.bind_engine(engine, should_create=True, should_drop=True)
+
+    def destroy():
+        transaction.commit()
+        pyramid_basemodel.Base.metadata.drop_all(engine)
+        pyramid_basemodel.Session.close()
+
+    request.addfinalizer(destroy)
+
+    return pyramid_basemodel.Session
+
+
+def _make_session():
+    return scoped_session(sessionmaker(extension=ZopeTransactionExtension()))

--- a/h/migrations/versions/4a97f680ecca_add_uid_column.py
+++ b/h/migrations/versions/4a97f680ecca_add_uid_column.py
@@ -1,0 +1,39 @@
+"""Add uid column to user table
+
+Revision ID: 4a97f680ecca
+Revises: 209c3cd1a864
+Create Date: 2015-02-05 14:27:01.109504
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '4a97f680ecca'
+down_revision = '209c3cd1a864'
+
+from alembic import op
+import sqlalchemy as sa
+
+users = sa.Table(
+    'user',
+    sa.MetaData(),
+    sa.Column('username', sa.Unicode(30)),
+    sa.Column('uid', sa.Unicode(30)),
+)
+
+
+def upgrade():
+    op.add_column('user', sa.Column('uid',
+                                    sa.Unicode(30),
+                                    unique=True))
+    op.execute(
+        users.update().where(
+            users.c.uid == None
+        ).values(
+            uid=sa.func.lower(sa.func.replace(users.c.username, '.', ''))
+        )
+    )
+    op.alter_column('user', 'uid', nullable=False)
+
+
+def downgrade():
+    op.drop_column('user', 'uid')


### PR DESCRIPTION
Both vanilla horus and our own custom user model had integrity bugs
relating to username normalisation.

Horus allows the creation of users with usernames differing only in
case. This wouldn't be a problem but for the default implementation of
`User.get_by_username`, which does case normalisation. This means that
if both "Bob" and "bob" signed up, only one of them would be able to
sign in (depending on the nature of the underlying database index).

The problem was compounded in `h` by a normalisation for the presence of
dots ('.') in usernames. It was possible to create multiple users whose
usernames differed only by dots, but it was only possible to retrieve
one of them from the database.

This commit adds a new column to the `user` table, `uid`, which contains
the normalised version of the username (lowercase, without dots) and has
a unique constraint. It is set whenever the username is set, including
at construction time.