### PR TITLE
Open Graph protocol metadata added to Annotation view

### DIFF
--- a/h/templates/layouts/base.html
+++ b/h/templates/layouts/base.html
@@ -5,6 +5,9 @@
       <meta charset="UTF-8" />
       <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
       <meta name="viewport" content="width=device-width,initial-scale=1" />
+      {% for property, content in layout.meta_properties %}
+        <meta property="{{ property }}" content="{{ content }}" />
+      {% endfor %}
       {% for name, content in layout.meta_attrs %}
         <meta name="{{ name }}" content="{{ content }}" />
       {% endfor %}

--- a/h/templates/layouts/base.html
+++ b/h/templates/layouts/base.html
@@ -5,19 +5,16 @@
       <meta charset="UTF-8" />
       <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
       <meta name="viewport" content="width=device-width,initial-scale=1" />
-      {% for property, content in layout.meta_properties %}
-        <meta property="{{ property }}" content="{{ content }}" />
-      {% endfor %}
-      {% for name, content in layout.meta_attrs %}
-        <meta name="{{ name }}" content="{{ content }}" />
-      {% endfor %}
+      {% for attrs in meta_attrs -%}
+        <meta {% for key, value in attrs.items() %}{{ key }}="{{ value }}" {% endfor %}/>
+      {% endfor -%}
     {% endblock %}
 
     <title>{% block title %}Hypothesis{% endblock %}</title>
 
-    {% for rel, href in layout.link_attrs %}
-      <link rel="{{ rel }}" href="{{ href }}" />
-    {% endfor %}
+    {% for attrs in link_attrs -%}
+      <link {% for key, value in attrs %}key="{{value}}" {% endfor %}/>
+    {% endfor -%}
     {% for href in layout.css_links %}
       <link rel="stylesheet" href="{{ href }}" />
     {% endfor %}

--- a/h/views.py
+++ b/h/views.py
@@ -17,14 +17,18 @@ log = logging.getLogger(__name__)
     renderer='h:templates/app.html',
 )
 def annotation(context, request):
-    request.layout_manager.layout.meta_properties = [
-            ('og:title', 'Annotation by {user} on {title}'.format(
-                user=context['user'].replace('acct:', ''),
-                title=context['document']['title'])),
-            ('og:image', '/assets/images/logo.png'),
-            ('og:site_name', 'Hypothes.is'),
-            ('og:url', request.url)]
-    return {}
+    title = 'Annotation by {user} on {title}'.format(
+        user=context['user'].replace('acct:', ''),
+        title=context['document']['title'])
+
+    return {
+        'meta_attrs': (
+            {'property': 'og:title', 'content': title},
+            {'property': 'og:image', 'content': '/assets/images/logo.png'},
+            {'property': 'og:site_name', 'content': 'Hypothes.is'},
+            {'property': 'og:url', 'content': request.url},
+        )
+    }
 
 
 @view_config(name='embed.js', renderer='h:templates/embed.js')

--- a/h/views.py
+++ b/h/views.py
@@ -17,6 +17,13 @@ log = logging.getLogger(__name__)
     renderer='h:templates/app.html',
 )
 def annotation(context, request):
+    request.layout_manager.layout.meta_properties = [
+            ('og:title', 'Annotation by {user} on {title}'.format(
+                user=context['user'].replace('acct:', ''),
+                title=context['document']['title'])),
+            ('og:image', '/assets/images/logo.png'),
+            ('og:site_name', 'Hypothes.is'),
+            ('og:url', request.url)]
     return {}
 
 


### PR DESCRIPTION
http://ogp.me/ basic implementation for better
display of content if shared via social network
sites that support OGP (most do).

I completely believe this could probably use some improvement. :smiley_cat: Let me know how. :wink:

For instance `layout.meta_properties` and `layout.meta_attrs` could be merged into a more complex template...this was just faster/simpler and showed of the intention.