### PR TITLE
Hide activation code input on forgotten password form

### DIFF
--- a/h/static/scripts/account/account.coffee
+++ b/h/static/scripts/account/account.coffee
@@ -36,7 +36,8 @@ class AuthAppController
 class AuthPageController
   this.$inject = ['$routeParams', '$scope']
   constructor:   ( $routeParams,   $scope ) ->
-    angular.extend $scope.model, $routeParams
+    $scope.model.code = $routeParams.code
+    $scope.hasActivationCode = !!$routeParams.code
 
 
 configure = [

--- a/h/templates/client/auth.html
+++ b/h/templates/client/auth.html
@@ -216,7 +216,9 @@
       {{reset_password.responseErrorMessage}}
     </p>
 
-    <div class="form-field">
+    <input type="hidden" name="code" value="{{model.code}}" ng-if="hasActivationCode"/>
+
+    <div class="form-field" ng-if="!hasActivationCode">
       <label class="form-label" for="field-activate-code"
              >Your activation code:</label>
       <input class="form-input" id="field-activate-code"


### PR DESCRIPTION
This field is an implementation detail and of no use to the user while choosing a new password. This change hides the field when the url contains the activation code.