### PR TITLE
Fix reset password exception

### DIFF
--- a/h/accounts/events.py
+++ b/h/accounts/events.py
@@ -1,0 +1,4 @@
+class LoginEvent(object):
+    def __init__(self, request, user):
+        self.request = request
+        self.user = user

--- a/h/accounts/events.py
+++ b/h/accounts/events.py
@@ -2,3 +2,9 @@ class LoginEvent(object):
     def __init__(self, request, user):
         self.request = request
         self.user = user
+
+
+class LogoutEvent(object):
+    def __init__(self, request, user):
+        self.request = request
+        self.user = user

--- a/h/accounts/subscribers.py
+++ b/h/accounts/subscribers.py
@@ -8,7 +8,10 @@ from horus.events import (
     RegistrationActivatedEvent,
     PasswordResetEvent,
 )
-from .events import LoginEvent
+from .events import (
+    LoginEvent,
+    LogoutEvent,
+)
 
 from h.stats import get_client as stats
 
@@ -41,6 +44,11 @@ def login(event):
 
     headers = security.remember(request, userid)
     request.response.headerlist.extend(headers)
+
+
+@subscriber(LogoutEvent)
+def logout(event):
+    stats(event.request).get_counter('auth.local.logout').increment()
 
 
 class AutoLogin(object):

--- a/h/accounts/subscribers.py
+++ b/h/accounts/subscribers.py
@@ -36,6 +36,11 @@ def login(event):
 
 
 class AutoLogin(object):
+    """
+    AutoLogin is a subscriber predicate that ensures that the marked subscriber
+    will only be called if the value of the ``horus.autologin`` setting matches
+    the value provided to the predicate.
+    """
 
     def __init__(self, val, config):
         self.val = val

--- a/h/accounts/subscribers.py
+++ b/h/accounts/subscribers.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import datetime
+
 from pyramid import security
 from pyramid.events import subscriber
 from pyramid.settings import asbool
@@ -8,12 +10,39 @@ from horus.events import (
     RegistrationActivatedEvent,
     PasswordResetEvent,
 )
+
 from .events import (
     LoginEvent,
     LogoutEvent,
 )
 
 from h.stats import get_client as stats
+
+
+@subscriber(LoginEvent)
+@subscriber(NewRegistrationEvent, autologin=True)
+@subscriber(PasswordResetEvent, autologin=True)
+@subscriber(RegistrationActivatedEvent)
+def login(event):
+    request = event.request
+    user = event.user
+    userid = 'acct:{}@{}'.format(user.username, request.domain)
+
+    request.user = userid
+
+    # Record a login event
+    stats(request).get_counter('auth.local.login').increment()
+
+    # Update the user's last login date
+    user.last_login_date = datetime.datetime.utcnow()
+
+    headers = security.remember(request, userid)
+    request.response.headerlist.extend(headers)
+
+
+@subscriber(LogoutEvent)
+def logout(event):
+    stats(event.request).get_counter('auth.local.logout').increment()
 
 
 @subscriber(NewRegistrationEvent)
@@ -29,26 +58,6 @@ def password_reset(event):
 @subscriber(RegistrationActivatedEvent)
 def registration_activated(event):
     stats(event.request).get_counter('auth.local.activate').increment()
-
-
-@subscriber(LoginEvent)
-@subscriber(NewRegistrationEvent, autologin=True)
-@subscriber(PasswordResetEvent, autologin=True)
-@subscriber(RegistrationActivatedEvent)
-def login(event):
-    request = event.request
-    user = event.user
-    userid = 'acct:{}@{}'.format(user.username, request.domain)
-
-    request.user = userid
-
-    headers = security.remember(request, userid)
-    request.response.headerlist.extend(headers)
-
-
-@subscriber(LogoutEvent)
-def logout(event):
-    stats(event.request).get_counter('auth.local.logout').increment()
 
 
 class AutoLogin(object):

--- a/h/accounts/subscribers.py
+++ b/h/accounts/subscribers.py
@@ -11,8 +11,18 @@ from horus.events import (
 from h.stats import get_client as stats
 
 
+@subscriber(NewRegistrationEvent)
+def new_registration(event):
+    stats(event.request).get_counter('auth.local.register').increment()
+
+
+@subscriber(PasswordResetEvent)
+def password_reset(event):
+    stats(event.request).get_counter('auth.local.reset_password').increment()
+
+
 @subscriber(RegistrationActivatedEvent)
-def activate(event):
+def registration_activated(event):
     stats(event.request).get_counter('auth.local.activate').increment()
 
 

--- a/h/accounts/test/subscribers_test.py
+++ b/h/accounts/test/subscribers_test.py
@@ -1,0 +1,37 @@
+from mock import MagicMock
+from pytest import fixture
+
+from pyramid import testing
+
+from ..events import LoginEvent
+from ..subscribers import login
+
+
+def test_login_subscriber(authn_policy):
+    request = testing.DummyRequest(domain='example.com')
+    user = DummyUser('joe.bloggs')
+
+    event = LoginEvent(request, user)
+
+    login(event)
+
+    authn_policy.remember.assert_called_with(request,
+                                             'acct:joe.bloggs@example.com')
+
+
+class DummyUser(object):
+    def __init__(self, username):
+        self.username = username
+
+
+class DummyAuthorizationPolicy(object):
+    def permits(self, *args, **kwargs):
+        return True
+
+
+@fixture()
+def authn_policy(config):
+    authn_policy = MagicMock()
+    config.set_authorization_policy(DummyAuthorizationPolicy())
+    config.set_authentication_policy(authn_policy)
+    return authn_policy

--- a/h/accounts/views.py
+++ b/h/accounts/views.py
@@ -8,16 +8,16 @@ import horus.events
 import horus.views
 from horus.lib import FlashMessage
 from horus.resources import UserFactory
-from pyramid import httpexceptions, security
+from pyramid import httpexceptions
 from pyramid.view import view_config, view_defaults
 
 from h import session
-from h.events import LoginEvent
 from h.models import _
 from h.stats import get_client as stats
 from h.notification.models import Subscriptions
 
 from . import schemas
+from .events import LoginEvent
 
 
 def ajax_form(request, result):
@@ -53,13 +53,6 @@ def ajax_form(request, result):
     result['flash'] = flash
 
     return result
-
-
-def remember(request, user):
-    if user is not None:
-        userid = 'acct:{}@{}'.format(user.username, request.domain)
-        headers = security.remember(request, userid)
-        request.response.headerlist.extend(headers)
 
 
 def ensure_csrf_token(view_fn):
@@ -135,9 +128,7 @@ class AuthController(horus.views.AuthController):
         stats(request).get_counter('auth.local.login').increment()
         user.last_login_date = datetime.datetime.utcnow()
         self.db.add(user)
-        remember(request, user)
-        event = LoginEvent(self.request, user)
-        self.request.registry.notify(event)
+        self.request.registry.notify(LoginEvent(self.request, user))
 
         return {'status': 'okay'}
 
@@ -157,11 +148,7 @@ class AsyncAuthController(AuthController):
 @view_config(attr='forgot_password', route_name='forgot_password')
 @view_config(attr='reset_password', route_name='reset_password')
 class ForgotPasswordController(horus.views.ForgotPasswordController):
-    def reset_password(self):
-        request = self.request
-        result = super(ForgotPasswordController, self).reset_password()
-        remember(request, request.user)
-        return result
+    pass
 
 
 @view_defaults(accept='application/json', name='app', renderer='json')
@@ -186,11 +173,7 @@ class AsyncForgotPasswordController(ForgotPasswordController):
 @view_config(attr='register', route_name='register')
 @view_config(attr='activate', route_name='activate')
 class RegisterController(horus.views.RegisterController):
-    def register(self):
-        request = self.request
-        result = super(RegisterController, self).register()
-        remember(request, request.user)
-        return result
+    pass
 
 
 @view_defaults(accept='application/json', name='app', renderer='json')

--- a/h/accounts/views.py
+++ b/h/accounts/views.py
@@ -17,7 +17,7 @@ from h.stats import get_client as stats
 from h.notification.models import Subscriptions
 
 from . import schemas
-from .events import LoginEvent
+from .events import LoginEvent, LogoutEvent
 
 
 def ajax_form(request, result):
@@ -133,7 +133,8 @@ class AuthController(horus.views.AuthController):
         return {'status': 'okay'}
 
     def logout(self):
-        stats(self.request).get_counter('auth.local.logout').increment()
+        user = self.User.get_by_id(self.request, self.request.user)
+        self.request.registry.notify(LogoutEvent(self.request, user))
         return super(AuthController, self).logout()
 
 

--- a/h/accounts/views.py
+++ b/h/accounts/views.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
+import json
 import datetime
 
 import colander
 import deform
+import horus.events
 import horus.views
-import json
 from horus.lib import FlashMessage
 from horus.resources import UserFactory
 from pyramid import httpexceptions, security
@@ -159,7 +160,6 @@ class ForgotPasswordController(horus.views.ForgotPasswordController):
     def reset_password(self):
         request = self.request
         result = super(ForgotPasswordController, self).reset_password()
-        stats(request).get_counter('auth.local.reset_password').increment()
         remember(request, request.user)
         return result
 
@@ -189,7 +189,6 @@ class RegisterController(horus.views.RegisterController):
     def register(self):
         request = self.request
         result = super(RegisterController, self).register()
-        stats(request).get_counter('auth.local.register').increment()
         remember(request, request.user)
         return result
 

--- a/h/events.py
+++ b/h/events.py
@@ -8,9 +8,3 @@ class AnnotationEvent(object):
         self.request = request
         self.annotation = annotation
         self.action = action
-
-
-class LoginEvent(object):
-    def __init__(self, request, user):
-        self.request = request
-        self.user = user

--- a/h/notification/reply_template.py
+++ b/h/notification/reply_template.py
@@ -16,7 +16,8 @@ from h.notification.models import Subscriptions
 from h.notification.gateway import user_name, \
     user_profile_url, standalone_url, get_user_by_name
 from h.notification.types import ROOT_PATH, REPLY_TYPE
-from h.events import LoginEvent, AnnotationEvent
+from h.accounts.events import LoginEvent
+from h.events import AnnotationEvent
 from h.models import Annotation
 
 log = logging.getLogger(__name__)


### PR DESCRIPTION
This is mostly to fix an issue where visiting an invalid reset_password paths as a logged in user triggers an exception, but I've taken the opportunity to fix some related issues, namely:

- account events were being double counted
- autologin code was distributed around the codebase

I'm still not sure whether `request.user` is supposed to be a full user object or a userid URI. The only thing that seems to assume the former is the accounts module itself and parts of `horus` that we're not using, so I've gone ahead and assumed that `h.authentication` and `h.authorization` have it right and converted the last use of `request.user` that's a full user object into a userid URL (in `h.accounts.subscribers`).