### PR TITLE
Restore functionality to toggle the sidebar

### DIFF
--- a/h/static/scripts/annotator/plugin/toolbar.coffee
+++ b/h/static/scripts/annotator/plugin/toolbar.coffee
@@ -36,9 +36,9 @@ class Annotator.Plugin.Toolbar extends Annotator.Plugin
           event.stopPropagation()
           collapsed = @annotator.frame.hasClass('annotator-collapsed')
           if collapsed
-            @annotator.showFrame()
+            @annotator.triggerShowFrame()
           else
-            @annotator.hideFrame()
+            @annotator.triggerHideFrame()
     ,
       "title": "Show Annotations"
       "class": "h-icon-visible"

--- a/h/static/scripts/guest.coffee
+++ b/h/static/scripts/guest.coffee
@@ -195,7 +195,7 @@ class Annotator.Guest extends Annotator
           # Create the annotation
           annotation = this.setupAnnotation(this.createAnnotation())
       else
-        @hideFrame()
+        @triggerHideFrame()
     this
 
   # These methods aren't used in the iframe-hosted configuration of Annotator.
@@ -379,11 +379,11 @@ class Annotator.Guest extends Annotator
     this.showEditor(this.createAnnotation())
 
   # Open the sidebar
-  showFrame: ->
+  triggerShowFrame: ->
     @crossframe?.notify method: 'open'
 
   # Close the sidebar
-  hideFrame: ->
+  triggerHideFrame: ->
     @crossframe?.notify method: 'back'
 
   addToken: (token) =>

--- a/h/static/scripts/host.coffee
+++ b/h/static/scripts/host.coffee
@@ -31,6 +31,7 @@ class Annotator.Host extends Annotator.Guest
     .attr('src', src)
 
     super element, options, dontScan: true
+    this._addCrossFrameListeners()
 
     app.appendTo(@frame)
 
@@ -62,41 +63,14 @@ class Annotator.Host extends Annotator.Guest
       @frame.addClass 'annotator-no-transition'
     @frame.removeClass 'annotator-collapsed'
 
-  _setupXDM: (options) ->
-    channel = super
-
-    channel
-
-    .bind 'showFrame', (ctx) => this.showFrame()
-
-    .bind('hideFrame', (ctx) =>
+  hideFrame: ->
       @frame.css 'margin-left': ''
       @frame.removeClass 'annotator-no-transition'
       @frame.addClass 'annotator-collapsed'
-    )
 
-    .bind('dragFrame', (ctx, screenX) => this._dragUpdate screenX)
-
-    .bind('getMaxBottom', =>
-      sel = '*' + (":not(.annotator-#{x})" for x in [
-        'adder', 'outer', 'notice', 'filter', 'frame'
-      ]).join('')
-
-      # use the maximum bottom position in the page
-      all = for el in $(document.body).find(sel)
-        p = $(el).css('position')
-        t = $(el).offset().top
-        z = $(el).css('z-index')
-        if (y = /\d+/.exec($(el).css('top'))?[0])
-          t = Math.min(Number y, t)
-        if (p == 'absolute' or p == 'fixed') and t == 0 and z != 'auto'
-          bottom = $(el).outerHeight(false)
-          # but don't go larger than 80, because this isn't bulletproof
-          if bottom > 80 then 0 else bottom
-        else
-          0
-      Math.max.apply(Math, all)
-    )
+  _addCrossFrameListeners: ->
+    @crossframe.on('showFrame', this.showFrame.bind(this, null))
+    @crossframe.on('hideFrame', this.hideFrame.bind(this, null))
 
   _setupDragEvents: ->
     el = document.createElementNS 'http://www.w3.org/1999/xhtml', 'canvas'


### PR DESCRIPTION
This was lost when `Guest` was refactored. `Host` was overriding the private `_setupXDM` method to add additional listeners, when that call was removed in the `Guest` these listeners were never bound. Now we bind the listeners in a separate setup call after the `Guest` constructor has run.