### PR TITLE
Add rel="alternate" to JSON representation

### DIFF
--- a/h/templates/layouts/base.html
+++ b/h/templates/layouts/base.html
@@ -13,7 +13,7 @@
     <title>{% block title %}Hypothesis{% endblock %}</title>
 
     {% for attrs in link_attrs -%}
-      <link {% for key, value in attrs %}key="{{value}}" {% endfor %}/>
+      <link {% for key, value in attrs.items() %}{{ key }}="{{ value }}" {% endfor %}/>
     {% endfor -%}
     {% for href in layout.css_links %}
       <link rel="stylesheet" href="{{ href }}" />

--- a/h/views.py
+++ b/h/views.py
@@ -27,14 +27,19 @@ def annotation(context, request):
     title = 'Annotation by {user} on {title}'.format(
         user=context['user'].replace('acct:', ''),
         title=context['document']['title'])
-
+    alternate = request.resource_url(request.root, 'api', 'annotations',
+            context['id'])
     return {
         'meta_attrs': (
             {'property': 'og:title', 'content': title},
             {'property': 'og:image', 'content': '/assets/images/logo.png'},
             {'property': 'og:site_name', 'content': 'Hypothes.is'},
             {'property': 'og:url', 'content': request.url},
-        )
+        ),
+        'link_attrs': (
+            {'rel': 'alternate', 'href': alternate,
+                'type': 'application/json'},
+        ),
     }
 
 

--- a/h/views.py
+++ b/h/views.py
@@ -24,11 +24,17 @@ def error(context, request):
     renderer='h:templates/app.html',
 )
 def annotation(context, request):
-    title = 'Annotation by {user} on {title}'.format(
-        user=context['user'].replace('acct:', ''),
-        title=context['document']['title'])
+    if 'title' in context['document']:
+        title = 'Annotation by {user} on {title}'.format(
+            user=context['user'].replace('acct:', ''),
+            title=context['document']['title'])
+    else:
+        title = 'Annotation by {user}'.format(
+            user=context['user'].replace('acct:', ''))
+
     alternate = request.resource_url(request.root, 'api', 'annotations',
             context['id'])
+
     return {
         'meta_attrs': (
             {'property': 'og:title', 'content': title},


### PR DESCRIPTION
This can be useful for developers wanting to discover the JSON representation from the HTML one. I intend to set another rel="alternate" going the other way...once I find where that lives...