### PR TITLE
Move thread-list spacing onto the contained thread

### DIFF
--- a/h/static/styles/threads.scss
+++ b/h/static/styles/threads.scss
@@ -17,7 +17,9 @@ $threadexp-width: .6em;
 }
 
 .thread-list {
-  margin-top: 0.5em;
+  .thread {
+    margin-top: 0.5em;
+  }
 
   .thread-collapsed {
     .tag-list, .annotation-body {display: none;}


### PR DESCRIPTION
If thread-list has a non-zero block height then it will seem to expand
cards with no replies. Move the spacing onto the contained thread so
that if it doesn't exist, the thread-list has zero height.