### PR TITLE
Load all annotations

### DIFF
--- a/h/static/scripts/controllers.coffee
+++ b/h/static/scripts/controllers.coffee
@@ -188,7 +188,12 @@ class ViewerController
     loaded = []
 
     _loadAnnotationsFrom = (query, offset) ->
-      q = angular.extend({limit: 20, offset: offset}, query)
+      queryCore =
+        limit: 20
+        offset: offset
+        sort: 'created'
+        order: 'asc'
+      q = angular.extend(queryCore, query)
 
       store.SearchResource.get q, (results) ->
         total = results.total

--- a/h/static/scripts/controllers.coffee
+++ b/h/static/scripts/controllers.coffee
@@ -187,8 +187,19 @@ class ViewerController
 
     loaded = []
 
+    _loadAnnotationsFrom = (query, offset) ->
+      q = angular.extend({limit: 20, offset: offset}, query)
+
+      store.SearchResource.get q, (results) ->
+        total = results.total
+        offset += results.rows.length
+        if offset < total
+          _loadAnnotationsFrom query, offset
+
+        annotationMapper.loadAnnotations(results.rows)
+
     loadAnnotations = ->
-      query = limit: 200
+      query = {}
       if annotationUI.tool is 'highlight'
         return unless auth.user
         query.user = auth.user
@@ -196,8 +207,8 @@ class ViewerController
       for p in crossframe.providers
         for e in p.entities when e not in loaded
           loaded.push e
-          r = store.SearchResource.get angular.extend(uri: e, query), (results) ->
-            annotationMapper.loadAnnotations(results.rows)
+          q = angular.extend(uri: e, query)
+          _loadAnnotationsFrom q, 0
 
       streamfilter.resetFilter().addClause('/uri', 'one_of', loaded)
 


### PR DESCRIPTION
This PR fixes the issue of loading all annotations, by using the until now ignored total number of annotations to load (and the offset and limit query parameters) it retrieves the annotations chunks by chunks

This PR needs the new annotator-store as a prerequisite for the sort and order parameters.

Fix https://github.com/hypothesis/vision/issues/154

