### PR TITLE
Claim account

### DIFF
--- a/development.ini
+++ b/development.ini
@@ -13,6 +13,7 @@ h.autologin: True
 
 h.feature.accounts: True
 h.feature.api: True
+h.feature.claim: True
 h.feature.streamer: True
 h.feature.notification: False
 

--- a/h/accounts/test/subscribers_test.py
+++ b/h/accounts/test/subscribers_test.py
@@ -1,6 +1,3 @@
-from mock import MagicMock
-from pytest import fixture
-
 from pyramid import testing
 
 from ..events import LoginEvent
@@ -22,16 +19,3 @@ def test_login_subscriber(authn_policy):
 class DummyUser(object):
     def __init__(self, username):
         self.username = username
-
-
-class DummyAuthorizationPolicy(object):
-    def permits(self, *args, **kwargs):
-        return True
-
-
-@fixture()
-def authn_policy(config):
-    authn_policy = MagicMock()
-    config.set_authorization_policy(DummyAuthorizationPolicy())
-    config.set_authentication_policy(authn_policy)
-    return authn_policy

--- a/h/accounts/test/views_test.py
+++ b/h/accounts/test/views_test.py
@@ -155,16 +155,3 @@ def activation_model(config):
     mock = MagicMock()
     config.registry.registerUtility(mock, IActivationClass)
     return mock
-
-
-@pytest.fixture
-def authn_policy(config):
-    authn_policy = MagicMock()
-
-    class DummyAuthorizationPolicy(object):
-        def permits(self, *args, **kwargs):
-            return True
-
-    config.set_authorization_policy(DummyAuthorizationPolicy())
-    config.set_authentication_policy(authn_policy)
-    return authn_policy

--- a/h/app.py
+++ b/h/app.py
@@ -58,6 +58,9 @@ def create_app(settings):
         config.add_view(api_view, name='api', decorator=strip_vhm,
                         route_name='index')
 
+    if config.registry.feature('claim'):
+        config.include('.claim')
+
     if config.registry.feature('streamer'):
         config.include('.streamer')
 

--- a/h/claim/__init__.py
+++ b/h/claim/__init__.py
@@ -1,3 +1,13 @@
+from webob.cookies import SignedSerializer
+
+
 def includeme(config):
     config.include('.views')
-    print 'pulling in claim'
+    config.include('.util')
+
+    # We use the shared session secret, but salt it with the namespace
+    # 'h.claim' -- only messages serialized with this salt will
+    # authenticate on deserialization.
+    secret = config.registry.settings['session.secret']
+    serializer = SignedSerializer(secret, 'h.claim')
+    config.registry.claim_serializer = serializer

--- a/h/claim/__init__.py
+++ b/h/claim/__init__.py
@@ -1,0 +1,3 @@
+def includeme(config):
+    config.include('.views')
+    print 'pulling in claim'

--- a/h/claim/__init__.py
+++ b/h/claim/__init__.py
@@ -1,13 +1,12 @@
 from webob.cookies import SignedSerializer
 
+from ..security import derive_key
+
 
 def includeme(config):
     config.include('.views')
     config.include('.util')
-
-    # We use the shared session secret, but salt it with the namespace
-    # 'h.claim' -- only messages serialized with this salt will
-    # authenticate on deserialization.
-    secret = config.registry.settings['session.secret']
-    serializer = SignedSerializer(secret, 'h.claim')
+    secret = config.registry.settings['secret_key']
+    derived = derive_key(secret, 'h.claim')
+    serializer = SignedSerializer(derived, None)
     config.registry.claim_serializer = serializer

--- a/h/claim/schemas.py
+++ b/h/claim/schemas.py
@@ -1,0 +1,5 @@
+from ..accounts.schemas import ResetPasswordSchema
+
+
+class UpdateAccountSchema(ResetPasswordSchema):
+    pass

--- a/h/claim/templates/claim_account.html
+++ b/h/claim/templates/claim_account.html
@@ -1,0 +1,34 @@
+{% extends "h:templates/layouts/base.html" %}
+
+{% block content %}
+  <div id="claim" class="content paper">
+    {% include "h:templates/includes/header.html" %}
+    <div class="form-vertical">
+      <form class="form">
+        <p class="form-description form-error">
+        </p>
+
+        <input type="hidden" name="code" value=""/>
+        <div class="form-field">
+          <label class="form-label" for="field-activate-password">
+            New password:
+            <span class="form-hint">(at least two characters)</span>
+          </label>
+          <input class="form-input" id="field-activate-password"
+                 type="password" name="password" value=""
+                 required autocapitalize="false" autocorrect="false" />
+          <ul class="form-error-list">
+            <li class="form-error"></li>
+          </ul>
+        </div>
+
+        <div class="form-actions">
+          <div class="form-actions-buttons">
+            <button class="btn" type="submit" name="activate"
+                    status-button="activate">Claim account</button>
+          </div>
+        </div>
+      </form>
+    </div>
+  </div>
+{% endblock content %}

--- a/h/claim/templates/claim_account.html
+++ b/h/claim/templates/claim_account.html
@@ -1,31 +1,32 @@
 {% extends "h:templates/layouts/base.html" %}
 
+{% block page_title %}Claim account{% endblock page_title %}
+
 {% block content %}
   <div id="claim" class="content paper">
     {% include "h:templates/includes/header.html" %}
     <div class="form-vertical">
-      <form class="form">
-        <p class="form-description form-error">
-        </p>
-
-        <input type="hidden" name="code" value=""/>
-        <div class="form-field">
+      <form class="form" action="{{ form.action }}" method="{{ form.method }}">
+        {{ form['csrf_token'].render() | safe }}
+        <div class="form-field{% if form['password'].error %} form-field-error{% endif %}">
           <label class="form-label" for="field-activate-password">
             New password:
             <span class="form-hint">(at least two characters)</span>
           </label>
           <input class="form-input" id="field-activate-password"
-                 type="password" name="password" value=""
-                 required autocapitalize="false" autocorrect="false" />
-          <ul class="form-error-list">
-            <li class="form-error"></li>
-          </ul>
+                 autofocus onfocus="this.select()"
+                 type="password" name="password" value="" required />
+          {% if form['password'].error %}
+            <ul class="form-error-list">
+              {% for err in form['password'].error.asdict().values() %}
+                <li class="form-error">{{ err }}</li>
+              {% endfor %}
+            </ul>
+          {% endif %}
         </div>
-
         <div class="form-actions">
           <div class="form-actions-buttons">
-            <button class="btn" type="submit" name="activate"
-                    status-button="activate">Claim account</button>
+            <button class="btn" type="submit">Claim account</button>
           </div>
         </div>
       </form>

--- a/h/claim/test/utils_test.py
+++ b/h/claim/test/utils_test.py
@@ -1,0 +1,25 @@
+import mock
+import pytest
+
+from pyramid import testing
+
+from ..util import generate_claim_url
+
+
+def test_generate_claim_url():
+    serializer = mock.Mock()
+    serializer.dumps.return_value = 'faketoken'
+
+    request = testing.DummyRequest()
+    request.registry.claim_serializer = serializer
+
+    url = generate_claim_url(request, 'acct:bob@example.com')
+
+    assert url == 'http://example.com/dummy/claim/faketoken'
+    serializer.dumps.assert_called_with({'userid': 'acct:bob@example.com'})
+
+
+@pytest.fixture(autouse=True)
+def routes(config):
+    """Add routes used by claim package"""
+    config.add_route('claim_account', '/dummy/claim/{token}')

--- a/h/claim/test/views_test.py
+++ b/h/claim/test/views_test.py
@@ -1,0 +1,209 @@
+import mock
+import pytest
+
+import deform
+from pytest import raises
+from pyramid.testing import DummyRequest
+from pyramid.httpexceptions import HTTPFound, HTTPNotFound
+
+from ..views import claim_account
+from ..views import update_account
+
+
+def test_claim_account_returns_form():
+    request = _get_request()
+
+    res = claim_account(request)
+    assert 'form' in res
+
+
+def test_claim_account_missing_token_404s():
+    request = _get_request()
+    del request.matchdict['token']
+
+    with raises(HTTPNotFound):
+        claim_account(request)
+
+
+def test_claim_account_invalid_token_404s():
+    serializer = mock.Mock(spec=FakeSerializer())
+    serializer.loads.side_effect = ValueError("Boom!")
+
+    request = _get_request()
+    request.registry.claim_serializer = serializer
+
+    with raises(HTTPNotFound):
+        claim_account(request)
+
+
+def test_claim_account_valid_token_unknown_user_404s(user_model):
+    user_model.get_by_id.return_value = None
+
+    request = _get_request()
+
+    with raises(HTTPNotFound):
+        claim_account(request)
+
+
+def test_claim_account_signed_in_redirects(authn_policy):
+    authn_policy.authenticated_userid.return_value = 'acct:billy@localhost'
+
+    request = _get_request()
+
+    with raises(HTTPFound) as exc:
+        claim_account(request)
+
+    assert exc.value.location == 'http://example.com/dummy/stream'
+
+
+def test_claim_account_already_claimed_redirects(user_model):
+    user_model.get_by_id.return_value = FakeUser(password='alreadyset')
+
+    request = _get_request()
+
+    with raises(HTTPFound) as exc:
+        claim_account(request)
+
+    assert exc.value.location == 'http://example.com/dummy/stream'
+
+
+def test_update_account_updates_password(user_model):
+    user_model.get_by_id.return_value = user = FakeUser(password='')
+
+    request = _post_request(post={'password': 'donkeys'})
+
+    update_account(request)
+
+    assert user.password == 'donkeys'
+
+
+def test_update_account_redirects_to_stream(user_model):
+    user_model.get_by_id.return_value = FakeUser(password='')
+
+    request = _post_request(post={'password': 'donkeys'})
+
+    res = update_account(request)
+
+    assert isinstance(res, HTTPFound)
+    assert res.location == 'http://example.com/dummy/stream'
+
+
+def test_update_account_rerenders_form_on_validation_error(form, user_model):
+    request = _post_request(post={'password': 'giraffes'})
+    request.registry.claim_serializer = FakeSerializer()
+    form.return_value.validate.side_effect = deform.ValidationFailure(None,
+                                                                      None,
+                                                                      None)
+    user_model.get_by_id.return_value = FakeUser(password='')
+
+    res = update_account(request)
+
+    assert 'form' in res
+
+
+def test_update_account_signed_in_redirects(authn_policy):
+    authn_policy.authenticated_userid.return_value = 'acct:billy@localhost'
+
+    request = _post_request()
+
+    with raises(HTTPFound) as excinfo:
+        update_account(request)
+
+    assert excinfo.value.location == 'http://example.com/dummy/stream'
+
+
+def test_update_account_already_claimed_redirects(user_model):
+    user_model.get_by_id.return_value = FakeUser(password='alreadyset')
+
+    request = _post_request()
+
+    with raises(HTTPFound) as exc:
+        update_account(request)
+
+    assert exc.value.location == 'http://example.com/dummy/stream'
+
+
+def test_update_account_missing_token_not_found():
+    request = _post_request()
+    del request.matchdict['token']
+
+    with raises(HTTPNotFound):
+        update_account(request)
+
+
+def test_update_account_invalid_token_not_found():
+    serializer = mock.Mock(spec=FakeSerializer())
+    serializer.loads.side_effect = ValueError("Boom!")
+
+    request = _post_request()
+    request.registry.claim_serializer = serializer
+
+    with raises(HTTPNotFound):
+        update_account(request)
+
+
+def test_update_account_redirects_when_registered(user_model):
+    request = _post_request()
+    user_model.get_by_id.return_value = FakeUser(password='alreadyset')
+
+    with raises(HTTPFound) as excinfo:
+        update_account(request)
+
+    assert excinfo.value.location == 'http://example.com/dummy/stream'
+
+
+class FakeUser(object):
+    def __init__(self, **kwargs):
+        for k in kwargs:
+            setattr(self, k, kwargs[k])
+
+
+class FakeSerializer(object):
+    def dumps(self, obj):
+        return 'faketoken'
+
+    def loads(self, token):
+        return {'userid': 'acct:foo@bar.com'}
+
+
+def _get_request():
+    request = DummyRequest()
+    request.matchdict['token'] = 'testtoken'
+    request.registry.claim_serializer = FakeSerializer()
+    return request
+
+
+def _post_request(post=None):
+    if post is None:
+        post = {}
+    post.update({'csrf_token': 'testcsrftoken'})
+
+    request = DummyRequest(post)
+    request.matchdict['token'] = 'testtoken'
+    request.registry.claim_serializer = FakeSerializer()
+
+    request.session.get_csrf_token = lambda: 'testcsrftoken'
+
+    return request
+
+
+@pytest.fixture(autouse=True)
+def routes(config):
+    """Add routes used by claim package"""
+    config.add_route('stream', '/dummy/stream')
+
+
+@pytest.fixture(autouse=True)
+def user_model(request):
+    patcher = mock.patch('h.claim.views.User', autospec=True)
+    request.addfinalizer(patcher.stop)
+    model = patcher.start()
+    model.get_by_id.return_value = FakeUser(password='')
+    return model
+
+
+@pytest.fixture
+def form(request):
+    patcher = mock.patch('h.claim.views.deform.Form', autospec=True)
+    request.addfinalizer(patcher.stop)
+    return patcher.start()

--- a/h/claim/util.py
+++ b/h/claim/util.py
@@ -1,0 +1,12 @@
+def generate_claim_token(request, userid):
+    return request.registry.claim_serializer.dumps({'userid': userid})
+
+
+def generate_claim_url(request, userid):
+    ''' Generates a url that a user can visit to claim their account. '''
+    token = generate_claim_token(request, userid)
+    return request.route_url('claim_account', token=token)
+
+
+def includeme(config):
+    pass

--- a/h/claim/views.py
+++ b/h/claim/views.py
@@ -1,0 +1,13 @@
+from pyramid.view import view_config
+
+
+@view_config(
+    route_name='claim_account',
+    renderer='h:claim/templates/claim_account.html')
+def claim_account(context, request):
+    return {}
+
+
+def includeme(config):
+    config.add_route('claim_account', '/claim_account')
+    config.scan(__name__)

--- a/h/claim/views.py
+++ b/h/claim/views.py
@@ -1,13 +1,115 @@
+import logging
+
+import deform
+from horus.lib import FlashMessage
+from pyramid import httpexceptions as exc
 from pyramid.view import view_config
 
+from . import schemas
+from ..models import _
+from ..accounts.models import User
+from ..accounts.events import LoginEvent
 
-@view_config(
-    route_name='claim_account',
-    renderer='h:claim/templates/claim_account.html')
-def claim_account(context, request):
-    return {}
+
+log = logging.getLogger(__name__)
+
+
+@view_config(route_name='claim_account',
+             request_method='GET',
+             renderer='h:claim/templates/claim_account.html')
+def claim_account(request):
+    _validate_request(request)
+
+    form = _form_for_update_account(request)
+    return {'form': form}
+
+
+@view_config(route_name='claim_account',
+             request_method='POST',
+             renderer='h:claim/templates/claim_account.html')
+def update_account(request):
+    user = _validate_request(request)
+
+    form = _form_for_update_account(request)
+    try:
+        appstruct = form.validate(request.POST.items())
+    except deform.ValidationFailure:
+        return {'form': form}
+
+    # The token is valid and the form validates, so we can go ahead and claim
+    # the account:
+    user.password = appstruct['password']
+
+    msg = _('Your account has been successfully claimed.')
+    FlashMessage(request, msg, kind='success')
+
+    request.registry.notify(LoginEvent(request, user))
+    return exc.HTTPFound(location=request.route_url('stream'))
+
+
+def _validate_request(request):
+    """
+    Check that the passed request is appropriate for proceeding with account
+    claim. Asserts that:
+
+    - no-one is logged in
+    - the claim token is provided and authentic
+    - the user referred to in the token exists
+    - the user referred to in the token has not already claimed their account
+
+    and raises for redirect or 404 otherwise.
+    """
+    # If signed in, redirect to stream
+    if request.authenticated_userid is not None:
+        _perform_logged_in_redirect(request)
+
+    payload = _validate_token(request)
+    if payload is None:
+        raise exc.HTTPNotFound()
+
+    user = User.get_by_id(request, payload['userid'])
+    if user is None:
+        log.warn('got claim token with invalid userid=%r', payload['userid'])
+        raise exc.HTTPNotFound()
+
+    # User already has a password? Claimed already.
+    if user.password:
+        _perform_already_claimed_redirect(request)
+
+    return user
+
+
+def _form_for_update_account(request):
+    schema = schemas.UpdateAccountSchema().bind(request=request)
+    return deform.Form(schema)
+
+
+def _perform_already_claimed_redirect(request):
+    msg = _('This account has already been claimed.')
+    FlashMessage(request, msg, kind='error')
+    raise exc.HTTPFound(location=request.route_url('stream'))
+
+
+def _perform_logged_in_redirect(request):
+    msg = _('You are already signed in, please log out to claim an account.')
+    FlashMessage(request, msg, kind='error')
+    raise exc.HTTPFound(location=request.route_url('stream'))
+
+
+def _validate_token(request):
+    try:
+        token = request.matchdict['token']
+    except KeyError:
+        return None
+
+    try:
+        validated = request.registry.claim_serializer.loads(token)
+    except ValueError:
+        return None
+
+    return validated
 
 
 def includeme(config):
-    config.add_route('claim_account', '/claim_account')
+    config.add_route('claim_account', '/claim_account/{token}')
     config.scan(__name__)

--- a/h/conftest.py
+++ b/h/conftest.py
@@ -40,6 +40,20 @@ def config(request, settings):
 
 
 @pytest.fixture()
+def authn_policy(config):
+    from mock import MagicMock
+
+    class DummyAuthorizationPolicy(object):
+        def permits(self, *args, **kwargs):
+            return True
+
+    config.set_authorization_policy(DummyAuthorizationPolicy())
+    policy = MagicMock()
+    config.set_authentication_policy(policy)
+    return policy
+
+
+@pytest.fixture()
 def db_session(request, settings):
     """SQLAlchemy session."""
     engine = engine_from_config(settings, 'sqlalchemy.')

--- a/h/templates/layouts/base.html
+++ b/h/templates/layouts/base.html
@@ -10,7 +10,13 @@
       {% endfor -%}
     {% endblock %}
 
-    <title>{% block title %}Hypothesis{% endblock %}</title>
+    <title>
+      {%- block title -%}
+        {%- block page_title %}{% endblock -%}
+        {%- if self.page_title() %} | {% endif -%}
+        Hypothesis
+      {%- endblock -%}
+    </title>
 
     {% for attrs in link_attrs -%}
       <link {% for key, value in attrs.items() %}{{ key }}="{{ value }}" {% endfor %}/>

--- a/h/templates/layouts/base.html
+++ b/h/templates/layouts/base.html
@@ -12,8 +12,7 @@
 
     <title>
       {%- block title -%}
-        {%- block page_title %}{% endblock -%}
-        {%- if self.page_title() %} | {% endif -%}
+        {%- if self.page_title %}{{self.page_title()}} | {% endif -%}
         Hypothesis
       {%- endblock -%}
     </title>

--- a/production.ini
+++ b/production.ini
@@ -20,6 +20,7 @@ use: egg:h
 # Feature flags
 h.feature.accounts: True
 h.feature.api: True
+h.feature.claim: False
 h.feature.streamer: True
 h.feature.notification: True
 


### PR DESCRIPTION
This adds a new `claim` module for allowing users who have registered their usernames to claim their account by providing a password. Included is:

* `h.claim.util.generate_claim_url(request, user_id)` to generate a url for mailout.
* A new view that presents a form where a password can be entered.

The following cases are also covered.

* If the account is unclaimed we present a password form. This updates the user model and logs the user in.
* If the user is logged in, it will redirect to the stream with a message.
* If the user account has already been claimed (it has a password) we redirect to the stream with an error message.