### PR TITLE
Thread list

### DIFF
--- a/h/assets.yaml
+++ b/h/assets.yaml
@@ -93,6 +93,11 @@ angular_bootstrap:
   output: scripts/vendor/angular-bootstrap.min.js
   contents:
     - h:static/scripts/vendor/angular-bootstrap.js
+angular_recursion:
+  filters: uglifyjs
+  output: scripts/vendor/angular-recursion.min.js
+  contents:
+    - h:static/scripts/vendor/angular-recursion.js
 angular_resource:
   filters: uglifyjs
   output: scripts/vendor/angular-resource.min.js
@@ -196,6 +201,7 @@ app:
     - jquery
     - angular
     - angular_animate
+    - angular_recursion
     - angular_resource
     - angular_route
     - angular_sanitize

--- a/h/static/scripts/app.coffee
+++ b/h/static/scripts/app.coffee
@@ -3,6 +3,7 @@ imports = [
   'ngRoute'
   'ngSanitize'
   'ngTagsInput'
+  'RecursionHelper'
   'h.helpers'
   'h.identity'
   'h.session'

--- a/h/static/scripts/directives/thread-filter.coffee
+++ b/h/static/scripts/directives/thread-filter.coffee
@@ -143,7 +143,7 @@ ThreadFilterController = [
 threadFilter = [
   '$parse', 'searchfilter'
   ($parse,   searchfilter) ->
-    linkFn = (scope, elem, attrs, [ctrl, thread, counter]) ->
+    linkFn = (scope, elem, attrs, [ctrl, counter]) ->
       if counter?
         scope.$watch (-> ctrl.match), (match, old) ->
           if match and not old
@@ -169,7 +169,7 @@ threadFilter = [
     controller: 'ThreadFilterController'
     controllerAs: 'threadFilter'
     link: linkFn
-    require: ['threadFilter', 'thread', '?^deepCount']
+    require: ['threadFilter', '?^deepCount']
 ]
 
 

--- a/h/static/scripts/directives/thread-list.coffee
+++ b/h/static/scripts/directives/thread-list.coffee
@@ -1,0 +1,37 @@
+###*
+# @ngdoc type
+# @name threadList.ThreadListController
+#
+# @description
+# `ThreadListController` wraps a list of {@link thread.ThreadController
+# ThreadControllers}.
+###
+ThreadListController = [
+  '$scope',
+  ($scope) ->
+    @container = $scope.getContainer()
+
+    this
+]
+
+###*
+# @ngdoc directive
+# @name thread-list
+###
+threadList = ->
+  controller: 'ThreadListController'
+  controllerAs: 'vm'
+  scope:
+    getContainer: '&threadList'
+    collapsed: '=threadListCollapsed'
+    embedded: '=threadListEmbedded'
+    orderBy: '=threadListOrderBy'
+    focus: '&threadListFocus'
+    hasFocus: '&threadListHasFocus'
+    scrollTo: '&threadListScrollTo'
+    shouldShow: '&threadListShouldShow'
+  templateUrl: 'thread-list.html'
+
+angular.module('h')
+.controller('ThreadListController', ThreadListController)
+.directive('threadList', threadList)

--- a/h/static/scripts/directives/thread.coffee
+++ b/h/static/scripts/directives/thread.coffee
@@ -90,8 +90,8 @@ isHiddenThread = (elem) ->
 # the collapsed state of the thread.
 ###
 thread = [
-  '$parse', '$window', 'pulse', 'render',
-  ($parse,   $window,   pulse,   render) ->
+  'RecursionHelper', '$parse', '$window', 'pulse', 'render',
+  (RecursionHelper,   $parse,   $window,   pulse,   render) ->
     linkFn = (scope, elem, attrs, [ctrl, counter]) ->
       # Determine if this is a top level thread.
       ctrl.isRoot = $parse(attrs.threadRoot)(scope) == true
@@ -162,9 +162,10 @@ thread = [
 
     controller: 'ThreadController'
     controllerAs: 'vm'
-    link: linkFn
+    compile: (el) -> RecursionHelper.compile(el, linkFn)
     require: ['thread', '?^deepCount']
     scope: true
+    templateUrl: 'thread.html'
 ]
 
 

--- a/h/static/scripts/directives/thread.coffee
+++ b/h/static/scripts/directives/thread.coffee
@@ -125,6 +125,8 @@ thread = [
       if counter?
         counter.count 'message', 1
         scope.$on '$destroy', -> counter.count 'message', -1
+      else
+        scope.count = -> 1
 
       # Flash the thread when any child annotations are updated.
       scope.$on 'annotationUpdate', (event) ->

--- a/h/static/scripts/vendor/angular-recursion.js
+++ b/h/static/scripts/vendor/angular-recursion.js
@@ -1,0 +1,46 @@
+/* 
+ * An Angular service which helps with creating recursive directives.
+ * @author Mark Lagendijk
+ * @license MIT
+ */
+angular.module('RecursionHelper', []).factory('RecursionHelper', ['$compile', function($compile){
+	return {
+		/**
+		 * Manually compiles the element, fixing the recursion loop.
+		 * @param element
+		 * @param [link] A post-link function, or an object with function(s) registered via pre and post properties.
+		 * @returns An object containing the linking functions.
+		 */
+		compile: function(element, link){
+			// Normalize the link parameter
+			if(angular.isFunction(link)){
+				link = { post: link };
+			}
+
+			// Break the recursion loop by removing the contents
+			var contents = element.contents().remove();
+			var compiledContents;
+			return {
+				pre: (link && link.pre) ? link.pre : null,
+				/**
+				 * Compiles and re-adds the contents
+				 */
+				post: function(scope, element){
+					// Compile the contents
+					if(!compiledContents){
+						compiledContents = $compile(contents);
+					}
+					// Re-add the compiled contents to the element
+					compiledContents(scope, function(clone){
+						element.append(clone);
+					});
+
+					// Call the post-linking function, if any
+					if(link && link.post){
+						link.post.apply(null, arguments);
+					}
+				}
+			};
+		}
+	};
+}]);

--- a/h/static/styles/threads.scss
+++ b/h/static/styles/threads.scss
@@ -17,7 +17,9 @@ $threadexp-width: .6em;
 }
 
 .thread-replies {
-  margin-top: 0.5em;
+  .thread:first-child {
+    margin-top: 0.5em;
+  }
 
   .thread-collapsed {
     .tag-list, .annotation-body {display: none;}

--- a/h/static/styles/threads.scss
+++ b/h/static/styles/threads.scss
@@ -16,7 +16,7 @@ $threadexp-width: .6em;
   }
 }
 
-.thread-list {
+.thread-replies {
   margin-top: 0.5em;
 
   .thread-collapsed {

--- a/h/templates/app.html
+++ b/h/templates/app.html
@@ -90,6 +90,9 @@
   <script type="text/ng-template" id="thread.html">
     {{ include_raw("h:templates/client/thread.html") }}
   </script>
+  <script type="text/ng-template" id="thread-list.html">
+    {{ include_raw("h:templates/client/thread-list.html") }}
+  </script>
 {% endblock %}
 
 {% block scripts %}

--- a/h/templates/client/thread-list.html
+++ b/h/templates/client/thread-list.html
@@ -1,0 +1,16 @@
+<li class="paper thread"
+    ng-class="{'js-hover': hasFocus({annotation: child.message})}"
+
+    ng-repeat="child in vm.container.children | orderBy : orderBy"
+    thread="child"
+    thread-collapsed="collapsed"
+    thread-root="true"
+
+    deep-count="count"
+    thread-filter
+
+    ng-mouseenter="focus({annotation: child.message})"
+    ng-click="scrollTo({annotation: child.message})"
+    ng-mouseleave="focus({annotation: undefined})"
+    ng-show="shouldShow({container: child}) && (count('edit') || count('match') || !threadFilter.active())">
+</li>

--- a/h/templates/client/thread.html
+++ b/h/templates/client/thread.html
@@ -36,7 +36,7 @@
 </div>
 
 <!-- Replies -->
-<ul class="thread-list" ng-hide="vm.collapsed">
+<ul class="thread-replies">
   <li class="thread"
 
       thread="child"

--- a/h/templates/client/thread.html
+++ b/h/templates/client/thread.html
@@ -11,7 +11,7 @@
 <article class="annotation thread-message"
          name="annotation"
          annotation="vm.container.message"
-         annotation-embedded="{{isEmbedded}}"
+         annotation-embedded="{{embedded}}"
          ng-if="vm.container.message"
          ng-show="threadFilter.check(vm.container)">
 </article>
@@ -38,10 +38,14 @@
 <!-- Replies -->
 <ul class="thread-list" ng-hide="vm.collapsed">
   <li class="thread"
+
+      thread="child"
+
       deep-count="count"
-      thread="child" thread-filter
-      ng-include="'thread.html'"
+      thread-filter
+
       ng-init="child.message.id || threadFilter.active(false)"
+      ng-class="{'thread-collapsed': vm.collapsed}"
       ng-repeat="child in vm.container.children
                  | orderBy : 'message.updated' : true"
       ng-show="count('edit') || count('match') || !threadFilter.active()">

--- a/h/templates/client/viewer.html
+++ b/h/templates/client/viewer.html
@@ -1,8 +1,5 @@
 <!-- Thread view -->
-<ul class="stream-list"
-    deep-count="count"
-    thread="threadRoot"
-    thread-filter="search.query">
+<ul class="stream-list">
   <li ng-show="threadFilter.active()"
       ><span ng-pluralize
              count="count('match')"
@@ -33,19 +30,20 @@
       </ul>
     </span>
   </li>
-  <li class="paper thread"
-      ng-class="{'js-hover': hasFocus(child.message)}"
-      deep-count="count"
-      thread="child" thread-filter
-      thread-collapsed="!search.query"
-      thread-root="true"
-      ng-include="'thread.html'"
-      ng-mouseenter="focus(child.message)"
-      ng-click="scrollTo(child.message)"
-      ng-mouseleave="focus()"
-      ng-repeat="child in vm.container.children | orderBy : sort.predicate"
-      ng-show="vm.container && shouldShowThread(child) &&
-               (count('edit') || count('match') || !threadFilter.active())">
-  </li>
+</ul>
+<ul class="stream-list"
+
+    thread-list="threadRoot"
+    thread-list-collapsed="!search.query"
+    thread-list-embedded="isEmbedded"
+    thread-list-order-by="sort.predicate"
+    thread-list-focus="focus(annotation)"
+    thread-list-has-focus="hasFocus(annotation)"
+    thread-list-scroll-to="scrollTo(annotation)"
+    thread-list-should-show="shouldShowThread(container)"
+
+    deep-count="count"
+    thread-filter="search.query"
+    >
 </ul>
 <!-- / Thread view -->

--- a/h/templates/pattern_library.html
+++ b/h/templates/pattern_library.html
@@ -790,7 +790,7 @@
             <a class="reply-count small" href="">1 reply</a>
             <a class="load-more small" href=""></a>
 
-            <ul class="thread-list">
+            <ul class="thread-replies">
               <li class="thread" deep-count="count" thread="child" thread-filter="">
                 <a href="" class="threadexp" title="Collapse"><span class="h-icon-minus"></span></a>
 
@@ -836,7 +836,7 @@
                 </article>
 
                 <a class="reply-count small" href=""></a>
-                <ul class="thread-list">
+                <ul class="thread-replies">
                 </ul>
               </li>
             </ul>

--- a/karma.config.js
+++ b/karma.config.js
@@ -41,6 +41,7 @@ module.exports = function(config) {
       'h/static/scripts/vendor/angular-mocks.js',
       'h/static/scripts/vendor/angular-animate.js',
       'h/static/scripts/vendor/angular-bootstrap.js',
+      'h/static/scripts/vendor/angular-recursion.js',
       'h/static/scripts/vendor/angular-resource.js',
       'h/static/scripts/vendor/angular-route.js',
       'h/static/scripts/vendor/angular-sanitize.js',

--- a/tests/js/directives/thread-list-test.coffee
+++ b/tests/js/directives/thread-list-test.coffee
@@ -1,0 +1,53 @@
+assert = chai.assert
+sinon.assert.expose assert, prefix: null
+
+
+describe 'h.directives.threadList.ThreadListController', ->
+  $scope = null
+  createController = null
+
+  beforeEach module('h')
+
+  beforeEach inject ($controller, $rootScope) ->
+    $scope = $rootScope.$new()
+
+    createController = ->
+      controller = $controller('ThreadListController', $scope: $scope)
+      controller
+
+  describe '.container', ->
+    it 'retrieves the container from its scope', ->
+      $scope.getContainer = sinon.stub().returns(123)
+      controller = createController()
+      assert.equal(controller.container, 123)
+
+
+describe 'h.directives.threadList.threadList', ->
+  createElement = null
+  $element = null
+  $scope = null
+  sandbox = null
+
+  beforeEach module('h')
+  beforeEach module('h.templates')
+
+  beforeEach module ($provide) ->
+    sandbox = sinon.sandbox.create()
+    return
+
+  beforeEach inject ($compile, $rootScope) ->
+    $scope = $rootScope.$new()
+
+    createElement = (html) ->
+      el = $compile(html or '<div thread-list></div>')($scope)
+      $scope.$digest()
+      return el
+
+  afterEach ->
+    sandbox.restore()
+
+  it 'uses the thread-list attribute to provide the container', ->
+    container = {}
+    $scope.myContainer = container
+    $element = createElement('<div thread-list="myContainer"></div>')
+    assert.strictEqual($element.isolateScope().getContainer(), container)

--- a/tests/js/directives/thread-test.coffee
+++ b/tests/js/directives/thread-test.coffee
@@ -101,11 +101,21 @@ describe 'h.directives.thread.ThreadController', ->
 describe 'h.directives.thread.thread', ->
   createElement = null
   $element = null
-  $isolateScope = null
   fakePulse = null
   sandbox = null
 
-  beforeEach module('h')
+  beforeEach module 'h', ($compileProvider) ->
+    # The thread directive instantiates the annotation directive, which in turn
+    # injects a whole bunch of other stuff (auth service, permissions service,
+    # etc.) which we really don't want to have to mock individually here. As
+    # such, it's easier to just mock out the whole annotation directive for now.
+    $compileProvider.directive 'annotation', ->
+      priority: 9999
+      terminal: true
+      template: ''
+    return
+
+  beforeEach module('h.templates')
 
   beforeEach module ($provide) ->
     sandbox = sinon.sandbox.create()
@@ -114,9 +124,11 @@ describe 'h.directives.thread.thread', ->
     return
 
   beforeEach inject ($compile, $rootScope) ->
-    createElement = (html) -> $compile(html or '<div thread></div>')($rootScope.$new())
+    createElement = (html) ->
+      el = $compile(html or '<div thread></div>')($rootScope.$new())
+      $rootScope.$digest()
+      return el
     $element = createElement()
-    $isolateScope = $element.scope()
 
   afterEach ->
     sandbox.restore()


### PR DESCRIPTION
This set of changes attempts to make the thread directive easier to understand by turning it into a more normal angular directive that has a consistent template.

In order to do this, a new directive, `threadList`, is introduced, which is responsible for rendering the top-level list of cards, leaving the `thread` directive responsible solely for a single annotation and its replies.