### PR TITLE
Thread collapse clarity (and code clarity improvements)

### DIFF
--- a/h/assets.yaml
+++ b/h/assets.yaml
@@ -93,6 +93,11 @@ angular_bootstrap:
   output: scripts/vendor/angular-bootstrap.min.js
   contents:
     - h:static/scripts/vendor/angular-bootstrap.js
+angular_recursion:
+  filters: uglifyjs
+  output: scripts/vendor/angular-recursion.min.js
+  contents:
+    - h:static/scripts/vendor/angular-recursion.js
 angular_resource:
   filters: uglifyjs
   output: scripts/vendor/angular-resource.min.js
@@ -196,6 +201,7 @@ app:
     - jquery
     - angular
     - angular_animate
+    - angular_recursion
     - angular_resource
     - angular_route
     - angular_sanitize

--- a/h/static/scripts/app.coffee
+++ b/h/static/scripts/app.coffee
@@ -3,6 +3,7 @@ imports = [
   'ngRoute'
   'ngSanitize'
   'ngTagsInput'
+  'RecursionHelper'
   'h.helpers'
   'h.identity'
   'h.session'

--- a/h/static/scripts/directives/thread-filter.coffee
+++ b/h/static/scripts/directives/thread-filter.coffee
@@ -143,7 +143,7 @@ ThreadFilterController = [
 threadFilter = [
   '$parse', 'searchfilter'
   ($parse,   searchfilter) ->
-    linkFn = (scope, elem, attrs, [ctrl, thread, counter]) ->
+    linkFn = (scope, elem, attrs, [ctrl, counter]) ->
       if counter?
         scope.$watch (-> ctrl.match), (match, old) ->
           if match and not old
@@ -169,7 +169,7 @@ threadFilter = [
     controller: 'ThreadFilterController'
     controllerAs: 'threadFilter'
     link: linkFn
-    require: ['threadFilter', 'thread', '?^deepCount']
+    require: ['threadFilter', '?^deepCount']
 ]
 
 

--- a/h/static/scripts/directives/thread-list.coffee
+++ b/h/static/scripts/directives/thread-list.coffee
@@ -1,0 +1,37 @@
+###*
+# @ngdoc type
+# @name threadList.ThreadListController
+#
+# @description
+# `ThreadListController` wraps a list of {@link thread.ThreadController
+# ThreadControllers}.
+###
+ThreadListController = [
+  '$scope',
+  ($scope) ->
+    @container = $scope.getContainer()
+
+    this
+]
+
+###*
+# @ngdoc directive
+# @name thread-list
+###
+threadList = ->
+  controller: 'ThreadListController'
+  controllerAs: 'vm'
+  scope:
+    getContainer: '&threadList'
+    collapsed: '=threadListCollapsed'
+    embedded: '=threadListEmbedded'
+    orderBy: '=threadListOrderBy'
+    focus: '&threadListFocus'
+    hasFocus: '&threadListHasFocus'
+    scrollTo: '&threadListScrollTo'
+    shouldShow: '&threadListShouldShow'
+  templateUrl: 'thread-list.html'
+
+angular.module('h')
+.controller('ThreadListController', ThreadListController)
+.directive('threadList', threadList)

--- a/h/static/scripts/directives/thread.coffee
+++ b/h/static/scripts/directives/thread.coffee
@@ -90,8 +90,8 @@ isHiddenThread = (elem) ->
 # the collapsed state of the thread.
 ###
 thread = [
-  '$parse', '$window', 'pulse', 'render',
-  ($parse,   $window,   pulse,   render) ->
+  'RecursionHelper', '$parse', '$window', 'pulse', 'render',
+  (RecursionHelper,   $parse,   $window,   pulse,   render) ->
     linkFn = (scope, elem, attrs, [ctrl, counter]) ->
       # Determine if this is a top level thread.
       ctrl.isRoot = $parse(attrs.threadRoot)(scope) == true
@@ -162,9 +162,10 @@ thread = [
 
     controller: 'ThreadController'
     controllerAs: 'vm'
-    link: linkFn
+    compile: (el) -> RecursionHelper.compile(el, linkFn)
     require: ['thread', '?^deepCount']
     scope: true
+    templateUrl: 'thread.html'
 ]
 
 

--- a/h/static/scripts/directives/thread.coffee
+++ b/h/static/scripts/directives/thread.coffee
@@ -17,8 +17,6 @@ COLLAPSED_CLASS = 'thread-collapsed'
 ThreadController = [
   ->
     @container = null
-    @isRoot = false
-
     @_collapsed = false
 
     ###*
@@ -51,10 +49,9 @@ ThreadController = [
     # the thread is currently filtered.
     ###
     this.shouldShowReply = (count, isFilterActive) ->
-      isCollapsedReply = (@_collapsed && !@isRoot)
       hasChildren = count('message') > 0
       hasFilterMatch = !isFilterActive || count('message') == count('match')
-      !isCollapsedReply && hasChildren && hasFilterMatch
+      hasChildren && hasFilterMatch
 
     this
 ]
@@ -106,8 +103,6 @@ thread = [
   'RecursionHelper', '$parse', '$window', 'pulse', 'render',
   (RecursionHelper,   $parse,   $window,   pulse,   render) ->
     linkFn = (scope, elem, attrs, [ctrl, counter]) ->
-      # Determine if this is a top level thread.
-      ctrl.isRoot = $parse(attrs.threadRoot)(scope) == true
 
       # Toggle collapse on click.
       elem.on 'click', (event) ->

--- a/h/static/scripts/directives/thread.coffee
+++ b/h/static/scripts/directives/thread.coffee
@@ -13,7 +13,7 @@
 ThreadController = [
   ->
     @container = null
-    @_collapsed = false
+    @_collapsed = true
 
     ###*
     # @ngdoc method

--- a/h/static/scripts/directives/thread.coffee
+++ b/h/static/scripts/directives/thread.coffee
@@ -1,7 +1,3 @@
-### global -COLLAPSED_CLASS ###
-
-COLLAPSED_CLASS = 'thread-collapsed'
-
 ###*
 # @ngdoc type
 # @name thread.ThreadController
@@ -94,10 +90,6 @@ isHiddenThread = (elem) ->
 # @restrict A
 # @description
 # Directive that instantiates {@link thread.ThreadController ThreadController}.
-#
-# If the `thread-collapsed` attribute is specified, it is treated as an
-# expression to watch in the context of the current scope that controls
-# the collapsed state of the thread.
 ###
 thread = [
   'RecursionHelper', '$parse', '$window', 'pulse', 'render',
@@ -145,13 +137,6 @@ thread = [
         event.stopPropagation()
         pulse(elem)
 
-      # Add and remove the collapsed class when the collapsed property changes.
-      scope.$watch (-> ctrl.isCollapsed()), (collapsed) ->
-        if collapsed
-          attrs.$addClass COLLAPSED_CLASS
-        else
-          attrs.$removeClass COLLAPSED_CLASS
-
       # The watch is necessary because the computed value of the attribute
       # expression may change. This won't happen when we use the thread
       # directive in a repeat, since the element will be torn down whenever the
@@ -164,11 +149,6 @@ thread = [
         render ->
           ctrl.container = thread
           scope.$digest()
-
-      # Watch the thread-collapsed attribute.
-      if attrs.threadCollapsed
-        scope.$watch $parse(attrs.threadCollapsed), (collapsed) ->
-          ctrl.toggleCollapsed(collapsed)
 
     controller: 'ThreadController'
     controllerAs: 'vm'

--- a/h/static/scripts/directives/thread.coffee
+++ b/h/static/scripts/directives/thread.coffee
@@ -13,13 +13,18 @@
 ThreadController = [
   ->
     @container = null
+    @parent = null
+    @counter = null
+    @filter = null
     @_collapsed = true
 
     ###*
     # @ngdoc method
     # @name thread.ThreadController#isCollapsed
     # @description
-    # Return whether or not the current thread is collapsed.
+    # Returns a boolean indicating whether the replies to this thread are
+    # currently hidden by default. Note that the visibility of replies is also
+    # dependent on the state of the thread filter, if present.
     ###
     this.isCollapsed = ->
       @_collapsed
@@ -28,7 +33,9 @@ ThreadController = [
     # @ngdoc method
     # @name thread.ThreadController#toggleCollapsed
     # @description
-    # Toggle the collapsed property.
+    # Toggle whether or not the replies to this thread are hidden by default.
+    # Note that the visibility of replies is also dependent on the state of the
+    # thread filter, if present.
     ###
     this.toggleCollapsed = (value) ->
       @_collapsed = if value?
@@ -38,16 +45,113 @@ ThreadController = [
 
     ###*
     # @ngdoc method
-    # @name thread.ThreadController#shouldShowReply
+    # @name thread.ThreadController#shouldShowAsReply
     # @description
-    # Determines if the reply counter should be rendered. Requires the
-    # `count` directive to be passed and a boolean that indicates whether
-    # the thread is currently filtered.
+    # Return a boolean indicating whether this thread should be shown if it is
+    # being rendered as a reply to another annotation.
     ###
-    this.shouldShowReply = (count, isFilterActive) ->
-      hasChildren = count('message') > 0
-      hasFilterMatch = !isFilterActive || count('message') == count('match')
+    this.shouldShowAsReply = ->
+      shouldShowUnfiltered = not @parent?.isCollapsed()
+      shouldShowFiltered = this._count('match') > 0
+
+      # We always show replies that contain an editor
+      if this._count('edit') > 0
+        return true
+
+      if this._isFilterActive()
+        return shouldShowFiltered
+      else
+        return shouldShowUnfiltered
+
+    ###*
+    # @ngdoc method
+    # @name thread.ThreadController#shouldShowNumReplies
+    # @description
+    # Returns a boolean indicating whether the reply count should be rendered
+    # for the annotation at the root of this thread.
+    ###
+    this.shouldShowNumReplies = ->
+      hasChildren = this._count('message') > 0
+      allRepliesShown = this._count('message') == this._count('match')
+      hasFilterMatch = !this._isFilterActive() || allRepliesShown
       hasChildren && hasFilterMatch
+
+    ###*
+    # @ngdoc method
+    # @name thread.ThreadController#numReplies
+    # @description
+    # Returns the cumulative number of replies to the annotation at the root of
+    # this thread.
+    ###
+    this.numReplies = ->
+      if @counter
+        this._count('message') - 1
+      else
+        0
+
+    ###*
+    # @ngdoc method
+    # @name thread.ThreadController#shouldShowLoadMore
+    # @description
+    # Return a boolean indicating whether the "load more" link should be shown
+    # for the annotation at the root of this thread. The "load more" link can be
+    # shown when the thread filter is active (although it may not be visible if
+    # no replies are hidden in this thread).
+    ###
+    this.shouldShowLoadMore = ->
+      this.container?.message?.id? and this._isFilterActive()
+
+    ###*
+    # @ngdoc method
+    # @name thread.ThreadController#numLoadMore
+    # @description
+    # Returns the number of replies in this thread which are currently hidden as
+    # a result of the thread filter.
+    ###
+    this.numLoadMore = ->
+      this._count('message') - this._count('match')
+
+    ###*
+    # @ngdoc method
+    # @name thread.ThreadController#loadMore
+    # @description
+    # Makes visible any replies in this thread which have been hidden by the
+    # thread filter.
+    ###
+    this.loadMore = ->
+      # If we want to show the rest of the replies in the thread, we need to
+      # uncollapse all parent threads.
+      ctrl = this
+      while ctrl
+        ctrl.toggleCollapsed(false)
+        ctrl = ctrl.parent
+      # Deactivate the thread filter for this thread.
+      @filter?.active(false)
+
+    ###*
+    # @ngdoc method
+    # @name thread.ThreadController#matchesFilter
+    # @description
+    # Returns a boolean indicating whether the annotation at the root of this
+    # thread is marked as a match by the current thread filter. If there is no
+    # thread filter attached to this thread, it will return true.
+    ###
+    this.matchesFilter = ->
+      if not @filter
+        return true
+      return @filter.check(@container)
+
+    this._isFilterActive = ->
+      if @filter
+        @filter.active()
+      else
+        false
+
+    this._count = (name) ->
+      if @counter
+        @counter.count(name)
+      else
+        0
 
     this
 ]
@@ -94,7 +198,13 @@ isHiddenThread = (elem) ->
 thread = [
   'RecursionHelper', '$parse', '$window', 'pulse', 'render',
   (RecursionHelper,   $parse,   $window,   pulse,   render) ->
-    linkFn = (scope, elem, attrs, [ctrl, counter]) ->
+    linkFn = (scope, elem, attrs, [ctrl, counter, filter]) ->
+
+      # We would ideally use require for this, but searching parents only for a
+      # controller is a feature of Angular 1.3 and above only.
+      ctrl.parent = elem.parent().controller('thread')
+      ctrl.counter = counter
+      ctrl.filter = filter
 
       # Toggle collapse on click.
       elem.on 'click', (event) ->
@@ -125,8 +235,6 @@ thread = [
       if counter?
         counter.count 'message', 1
         scope.$on '$destroy', -> counter.count 'message', -1
-      else
-        scope.count = -> 1
 
       # Flash the thread when any child annotations are updated.
       scope.$on 'annotationUpdate', (event) ->
@@ -153,7 +261,7 @@ thread = [
     controller: 'ThreadController'
     controllerAs: 'vm'
     compile: (el) -> RecursionHelper.compile(el, linkFn)
-    require: ['thread', '?^deepCount']
+    require: ['thread', '?^deepCount', '?^threadFilter']
     scope: true
     templateUrl: 'thread.html'
 ]

--- a/h/static/scripts/directives/thread.coffee
+++ b/h/static/scripts/directives/thread.coffee
@@ -125,6 +125,8 @@ thread = [
       if counter?
         counter.count 'message', 1
         scope.$on '$destroy', -> counter.count 'message', -1
+      else
+        scope.count = -> 1
 
       # Flash the thread when any child annotations are updated.
       scope.$on 'annotationUpdate', (event) ->

--- a/h/static/scripts/directives/thread.coffee
+++ b/h/static/scripts/directives/thread.coffee
@@ -17,8 +17,18 @@ COLLAPSED_CLASS = 'thread-collapsed'
 ThreadController = [
   ->
     @container = null
-    @collapsed = false
     @isRoot = false
+
+    @_collapsed = false
+
+    ###*
+    # @ngdoc method
+    # @name thread.ThreadController#isCollapsed
+    # @description
+    # Return whether or not the current thread is collapsed.
+    ###
+    this.isCollapsed = ->
+      @_collapsed
 
     ###*
     # @ngdoc method
@@ -26,8 +36,11 @@ ThreadController = [
     # @description
     # Toggle the collapsed property.
     ###
-    this.toggleCollapsed = ->
-      @collapsed = not @collapsed
+    this.toggleCollapsed = (value) ->
+      @_collapsed = if value?
+                      !!value
+                    else
+                      not @_collapsed
 
     ###*
     # @ngdoc method
@@ -38,7 +51,7 @@ ThreadController = [
     # the thread is currently filtered.
     ###
     this.shouldShowReply = (count, isFilterActive) ->
-      isCollapsedReply = (@collapsed && !@isRoot)
+      isCollapsedReply = (@_collapsed && !@isRoot)
       hasChildren = count('message') > 0
       hasFilterMatch = !isFilterActive || count('message') == count('match')
       !isCollapsedReply && hasChildren && hasFilterMatch
@@ -75,7 +88,7 @@ isHiddenThread = (elem) ->
   parentThread = parent.controller('thread')
   if !parentThread
     return false
-  return parentThread.collapsed || isHiddenThread(parent)
+  return parentThread.isCollapsed() || isHiddenThread(parent)
 
 
 ###*
@@ -138,7 +151,7 @@ thread = [
         pulse(elem)
 
       # Add and remove the collapsed class when the collapsed property changes.
-      scope.$watch (-> ctrl.collapsed), (collapsed) ->
+      scope.$watch (-> ctrl.isCollapsed()), (collapsed) ->
         if collapsed
           attrs.$addClass COLLAPSED_CLASS
         else
@@ -160,7 +173,7 @@ thread = [
       # Watch the thread-collapsed attribute.
       if attrs.threadCollapsed
         scope.$watch $parse(attrs.threadCollapsed), (collapsed) ->
-          ctrl.toggleCollapsed() if !!collapsed != ctrl.collapsed
+          ctrl.toggleCollapsed(collapsed)
 
     controller: 'ThreadController'
     controllerAs: 'vm'

--- a/h/static/scripts/vendor/angular-recursion.js
+++ b/h/static/scripts/vendor/angular-recursion.js
@@ -1,0 +1,46 @@
+/* 
+ * An Angular service which helps with creating recursive directives.
+ * @author Mark Lagendijk
+ * @license MIT
+ */
+angular.module('RecursionHelper', []).factory('RecursionHelper', ['$compile', function($compile){
+	return {
+		/**
+		 * Manually compiles the element, fixing the recursion loop.
+		 * @param element
+		 * @param [link] A post-link function, or an object with function(s) registered via pre and post properties.
+		 * @returns An object containing the linking functions.
+		 */
+		compile: function(element, link){
+			// Normalize the link parameter
+			if(angular.isFunction(link)){
+				link = { post: link };
+			}
+
+			// Break the recursion loop by removing the contents
+			var contents = element.contents().remove();
+			var compiledContents;
+			return {
+				pre: (link && link.pre) ? link.pre : null,
+				/**
+				 * Compiles and re-adds the contents
+				 */
+				post: function(scope, element){
+					// Compile the contents
+					if(!compiledContents){
+						compiledContents = $compile(contents);
+					}
+					// Re-add the compiled contents to the element
+					compiledContents(scope, function(clone){
+						element.append(clone);
+					});
+
+					// Call the post-linking function, if any
+					if(link && link.post){
+						link.post.apply(null, arguments);
+					}
+				}
+			};
+		}
+	};
+}]);

--- a/h/static/styles/threads.scss
+++ b/h/static/styles/threads.scss
@@ -17,7 +17,9 @@ $threadexp-width: .6em;
 }
 
 .thread-replies {
-  margin-top: 0.5em;
+  .thread:first-child {
+    margin-top: 0.5em;
+  }
 
   .thread-collapsed {
     .tag-list, .annotation-body {display: none;}

--- a/h/static/styles/threads.scss
+++ b/h/static/styles/threads.scss
@@ -20,11 +20,6 @@ $threadexp-width: .6em;
   .thread:first-child {
     margin-top: 0.5em;
   }
-
-  .thread-collapsed {
-    .tag-list, .annotation-body {display: none;}
-    .thread-reply { margin-top: 0 }
-  }
 }
 
 .thread-reply {
@@ -62,14 +57,6 @@ $threadexp-width: .6em;
     border-left: 1px dotted $gray-light;
     padding: 0;
     padding-left: $thread-padding;
-
-    &.thread-collapsed {
-      border-color: transparent;
-
-      & > article markdown {
-        display: none;
-      }
-    }
   }
 
   .threadexp {
@@ -94,19 +81,6 @@ $threadexp-width: .6em;
         top: 0;
         left: 0;
       }
-    }
-  }
-
-  &.thread-collapsed {
-    & > ul {
-      display: none;
-    }
-
-    & > .thread-message {
-      .thread &,
-      .thread & .annotation-header,
-      .thread & .annotation-section { margin: 0 }
-      .thread & footer { display: none }
     }
   }
 }

--- a/h/static/styles/threads.scss
+++ b/h/static/styles/threads.scss
@@ -16,7 +16,7 @@ $threadexp-width: .6em;
   }
 }
 
-.thread-list {
+.thread-replies {
   margin-top: 0.5em;
 
   .thread-collapsed {

--- a/h/templates/app.html
+++ b/h/templates/app.html
@@ -90,6 +90,9 @@
   <script type="text/ng-template" id="thread.html">
     {{ include_raw("h:templates/client/thread.html") }}
   </script>
+  <script type="text/ng-template" id="thread-list.html">
+    {{ include_raw("h:templates/client/thread-list.html") }}
+  </script>
 {% endblock %}
 
 {% block scripts %}

--- a/h/templates/client/thread-list.html
+++ b/h/templates/client/thread-list.html
@@ -1,0 +1,16 @@
+<li class="paper thread"
+    ng-class="{'js-hover': hasFocus({annotation: child.message})}"
+
+    ng-repeat="child in vm.container.children | orderBy : orderBy"
+    thread="child"
+    thread-collapsed="collapsed"
+    thread-root="true"
+
+    deep-count="count"
+    thread-filter
+
+    ng-mouseenter="focus({annotation: child.message})"
+    ng-click="scrollTo({annotation: child.message})"
+    ng-mouseleave="focus({annotation: undefined})"
+    ng-show="shouldShow({container: child}) && (count('edit') || count('match') || !threadFilter.active())">
+</li>

--- a/h/templates/client/thread-list.html
+++ b/h/templates/client/thread-list.html
@@ -3,8 +3,6 @@
 
     ng-repeat="child in vm.container.children | orderBy : orderBy"
     thread="child"
-    thread-collapsed="collapsed"
-    thread-root="true"
 
     deep-count="count"
     thread-filter

--- a/h/templates/client/thread.html
+++ b/h/templates/client/thread.html
@@ -1,7 +1,7 @@
 <a href="" class="threadexp"
-   title="{{vm.collapsed && 'Expand' || 'Collapse'}}"
-   ><span ng-class="{'h-icon-plus': !!vm.collapsed,
-                     'h-icon-minus': !vm.collapsed}"></span></a>
+   title="{{vm.isCollapsed() && 'Expand' || 'Collapse'}}"
+   ><span ng-class="{'h-icon-plus': vm.isCollapsed(),
+                     'h-icon-minus': !vm.isCollapsed()}"></span></a>
 
 <!-- Annotation -->
 <div ng-if="vm.container && !vm.container.message" class="thread-deleted">
@@ -45,7 +45,7 @@
       thread-filter
 
       ng-init="child.message.id || threadFilter.active(false)"
-      ng-class="{'thread-collapsed': vm.collapsed}"
+      ng-class="{'thread-collapsed': vm.isCollapsed()}"
       ng-repeat="child in vm.container.children
                  | orderBy : 'message.updated' : true"
       ng-show="count('edit') || count('match') || !threadFilter.active()">

--- a/h/templates/client/thread.html
+++ b/h/templates/client/thread.html
@@ -36,7 +36,7 @@
 </div>
 
 <!-- Replies -->
-<ul class="thread-list" ng-hide="vm.collapsed">
+<ul class="thread-replies">
   <li class="thread"
 
       thread="child"

--- a/h/templates/client/thread.html
+++ b/h/templates/client/thread.html
@@ -13,22 +13,25 @@
          annotation="vm.container.message"
          annotation-embedded="{{embedded}}"
          ng-if="vm.container.message"
-         ng-show="threadFilter.check(vm.container)">
+         ng-show="vm.matchesFilter()">
 </article>
 
 <!-- Reply count -->
-<div class="thread-reply" ng-show="vm.shouldShowReply(count, threadFilter.active())">
+<div class="thread-reply"
+     ng-show="vm.shouldShowNumReplies()">
   <a class="reply-count small"
      href=""
-     ng-pluralize count="count('message') - 1"
+     ng-pluralize
+     count="vm.numReplies()"
      when="{'0': '', one: '1 reply', other: '{} replies'}"></a>
 </div>
 
-<div class="thread-load-more" ng-show="vm.container.message.id && threadFilter.active()">
+<div class="thread-load-more" ng-show="vm.shouldShowLoadMore()">
   <a class="load-more small"
      href=""
-     ng-click="threadFilter.active(false)"
-     ng-pluralize count="count('message') - count('match')"
+     ng-click="vm.loadMore()"
+     ng-pluralize
+     count="vm.numLoadMore()"
      when="{'0': '',
            one: 'View one more in conversation',
            other: 'View {} more in conversation'}"
@@ -36,7 +39,7 @@
 </div>
 
 <!-- Replies -->
-<ul class="thread-replies" ng-hide="vm.isCollapsed()">
+<ul class="thread-replies">
   <li class="thread"
 
       thread="child"
@@ -44,9 +47,8 @@
       deep-count="count"
       thread-filter
 
-      ng-init="child.message.id || threadFilter.active(false)"
       ng-repeat="child in vm.container.children
                  | orderBy : 'message.updated' : true"
-      ng-show="count('edit') || count('match') || !threadFilter.active()">
+      ng-show="vm.shouldShowAsReply()">
   </li>
 </ul>

--- a/h/templates/client/thread.html
+++ b/h/templates/client/thread.html
@@ -11,7 +11,7 @@
 <article class="annotation thread-message"
          name="annotation"
          annotation="vm.container.message"
-         annotation-embedded="{{isEmbedded}}"
+         annotation-embedded="{{embedded}}"
          ng-if="vm.container.message"
          ng-show="threadFilter.check(vm.container)">
 </article>
@@ -38,10 +38,14 @@
 <!-- Replies -->
 <ul class="thread-list" ng-hide="vm.collapsed">
   <li class="thread"
+
+      thread="child"
+
       deep-count="count"
-      thread="child" thread-filter
-      ng-include="'thread.html'"
+      thread-filter
+
       ng-init="child.message.id || threadFilter.active(false)"
+      ng-class="{'thread-collapsed': vm.collapsed}"
       ng-repeat="child in vm.container.children
                  | orderBy : 'message.updated' : true"
       ng-show="count('edit') || count('match') || !threadFilter.active()">

--- a/h/templates/client/thread.html
+++ b/h/templates/client/thread.html
@@ -36,7 +36,7 @@
 </div>
 
 <!-- Replies -->
-<ul class="thread-replies">
+<ul class="thread-replies" ng-hide="vm.isCollapsed()">
   <li class="thread"
 
       thread="child"
@@ -45,7 +45,6 @@
       thread-filter
 
       ng-init="child.message.id || threadFilter.active(false)"
-      ng-class="{'thread-collapsed': vm.isCollapsed()}"
       ng-repeat="child in vm.container.children
                  | orderBy : 'message.updated' : true"
       ng-show="count('edit') || count('match') || !threadFilter.active()">

--- a/h/templates/client/viewer.html
+++ b/h/templates/client/viewer.html
@@ -1,8 +1,5 @@
 <!-- Thread view -->
-<ul class="stream-list"
-    deep-count="count"
-    thread="threadRoot"
-    thread-filter="search.query">
+<ul class="stream-list">
   <li ng-show="threadFilter.active()"
       ><span ng-pluralize
              count="count('match')"
@@ -33,19 +30,20 @@
       </ul>
     </span>
   </li>
-  <li class="paper thread"
-      ng-class="{'js-hover': hasFocus(child.message)}"
-      deep-count="count"
-      thread="child" thread-filter
-      thread-collapsed="!search.query"
-      thread-root="true"
-      ng-include="'thread.html'"
-      ng-mouseenter="focus(child.message)"
-      ng-click="scrollTo(child.message)"
-      ng-mouseleave="focus()"
-      ng-repeat="child in vm.container.children | orderBy : sort.predicate"
-      ng-show="vm.container && shouldShowThread(child) &&
-               (count('edit') || count('match') || !threadFilter.active())">
-  </li>
+</ul>
+<ul class="stream-list"
+
+    thread-list="threadRoot"
+    thread-list-collapsed="!search.query"
+    thread-list-embedded="isEmbedded"
+    thread-list-order-by="sort.predicate"
+    thread-list-focus="focus(annotation)"
+    thread-list-has-focus="hasFocus(annotation)"
+    thread-list-scroll-to="scrollTo(annotation)"
+    thread-list-should-show="shouldShowThread(container)"
+
+    deep-count="count"
+    thread-filter="search.query"
+    >
 </ul>
 <!-- / Thread view -->

--- a/h/templates/pattern_library.html
+++ b/h/templates/pattern_library.html
@@ -790,7 +790,7 @@
             <a class="reply-count small" href="">1 reply</a>
             <a class="load-more small" href=""></a>
 
-            <ul class="thread-list">
+            <ul class="thread-replies">
               <li class="thread" deep-count="count" thread="child" thread-filter="">
                 <a href="" class="threadexp" title="Collapse"><span class="h-icon-minus"></span></a>
 
@@ -836,7 +836,7 @@
                 </article>
 
                 <a class="reply-count small" href=""></a>
-                <ul class="thread-list">
+                <ul class="thread-replies">
                 </ul>
               </li>
             </ul>

--- a/karma.config.js
+++ b/karma.config.js
@@ -41,6 +41,7 @@ module.exports = function(config) {
       'h/static/scripts/vendor/angular-mocks.js',
       'h/static/scripts/vendor/angular-animate.js',
       'h/static/scripts/vendor/angular-bootstrap.js',
+      'h/static/scripts/vendor/angular-recursion.js',
       'h/static/scripts/vendor/angular-resource.js',
       'h/static/scripts/vendor/angular-route.js',
       'h/static/scripts/vendor/angular-sanitize.js',

--- a/tests/js/directives/thread-list-test.coffee
+++ b/tests/js/directives/thread-list-test.coffee
@@ -1,0 +1,53 @@
+assert = chai.assert
+sinon.assert.expose assert, prefix: null
+
+
+describe 'h.directives.threadList.ThreadListController', ->
+  $scope = null
+  createController = null
+
+  beforeEach module('h')
+
+  beforeEach inject ($controller, $rootScope) ->
+    $scope = $rootScope.$new()
+
+    createController = ->
+      controller = $controller('ThreadListController', $scope: $scope)
+      controller
+
+  describe '.container', ->
+    it 'retrieves the container from its scope', ->
+      $scope.getContainer = sinon.stub().returns(123)
+      controller = createController()
+      assert.equal(controller.container, 123)
+
+
+describe 'h.directives.threadList.threadList', ->
+  createElement = null
+  $element = null
+  $scope = null
+  sandbox = null
+
+  beforeEach module('h')
+  beforeEach module('h.templates')
+
+  beforeEach module ($provide) ->
+    sandbox = sinon.sandbox.create()
+    return
+
+  beforeEach inject ($compile, $rootScope) ->
+    $scope = $rootScope.$new()
+
+    createElement = (html) ->
+      el = $compile(html or '<div thread-list></div>')($scope)
+      $scope.$digest()
+      return el
+
+  afterEach ->
+    sandbox.restore()
+
+  it 'uses the thread-list attribute to provide the container', ->
+    container = {}
+    $scope.myContainer = container
+    $element = createElement('<div thread-list="myContainer"></div>')
+    assert.strictEqual($element.isolateScope().getContainer(), container)

--- a/tests/js/directives/thread-test.coffee
+++ b/tests/js/directives/thread-test.coffee
@@ -34,33 +34,163 @@ describe 'h.directives.thread.ThreadController', ->
       controller.toggleCollapsed(false)
       assert.isFalse(controller.isCollapsed())
 
-  describe '#shouldShowReply', ->
+  describe '#shouldShowAsReply', ->
+    controller = null
+    count = null
+
+    beforeEach ->
+      controller = createController()
+      count = sinon.stub().returns(0)
+      controller.counter = {count: count}
+
+    it 'is true by default', ->
+      assert.isTrue(controller.shouldShowAsReply())
+
+    it 'is false when the parent thread is collapsed', ->
+      controller.parent = {isCollapsed: -> true}
+      assert.isFalse(controller.shouldShowAsReply())
+
+    describe 'when the thread contains edits', ->
+      beforeEach ->
+        count.withArgs('edit').returns(1)
+
+      it 'is true when the thread has no parent', ->
+        assert.isTrue(controller.shouldShowAsReply())
+
+      it 'is true when the parent thread is not collapsed', ->
+        controller.parent = {isCollapsed: -> false}
+        assert.isTrue(controller.shouldShowAsReply())
+
+      it 'is true when the parent thread is collapsed', ->
+        controller.parent = {isCollapsed: -> true}
+        assert.isTrue(controller.shouldShowAsReply())
+
+    describe 'when the thread filter is active', ->
+      beforeEach ->
+        controller.filter = {active: -> true}
+
+      it 'is false when there are no matches in the thread', ->
+        assert.isFalse(controller.shouldShowAsReply())
+
+      it 'is true when there are matches in the thread', ->
+        count.withArgs('match').returns(1)
+        assert.isTrue(controller.shouldShowAsReply())
+
+  describe '#shouldShowNumReplies', ->
     count = null
     controller = null
+    filterActive = false
 
     beforeEach ->
       controller = createController()
       count = sinon.stub()
+      controller.counter = {count: count}
+      controller.filter = {active: -> filterActive}
 
     describe 'when not filtered', ->
       it 'shows the reply if the thread has children', ->
         count.withArgs('message').returns(1)
-        assert.isTrue(controller.shouldShowReply(count, false))
+        assert.isTrue(controller.shouldShowNumReplies())
 
       it 'does not show the reply if the thread has no children', ->
         count.withArgs('message').returns(0)
-        assert.isFalse(controller.shouldShowReply(count, false))
+        assert.isFalse(controller.shouldShowNumReplies())
 
     describe 'when filtered with children', ->
+      beforeEach ->
+        filterActive = true
+
       it 'shows the reply', ->
         count.withArgs('match').returns(1)
         count.withArgs('message').returns(1)
-        assert.isTrue(controller.shouldShowReply(count, true))
+        assert.isTrue(controller.shouldShowNumReplies())
 
       it 'does not show the reply if the message count does not match the match count', ->
         count.withArgs('match').returns(0)
         count.withArgs('message').returns(1)
-        assert.isFalse(controller.shouldShowReply(count, true))
+        assert.isFalse(controller.shouldShowNumReplies())
+
+  describe '#numReplies', ->
+    controller = null
+
+    beforeEach ->
+      controller = createController()
+
+    it 'returns zero when there is no counter', ->
+      assert.equal(controller.numReplies(), 0)
+
+    it 'returns one less than the number of messages in the thread when there is a counter', ->
+      count = sinon.stub()
+      count.withArgs('message').returns(5)
+      controller.counter = {count: count}
+
+      assert.equal(controller.numReplies(), 4)
+
+  describe '#shouldShowLoadMore', ->
+    controller = null
+
+    beforeEach ->
+      controller = createController()
+
+    describe 'when the thread filter is not active', ->
+      it 'is false with an empty container', ->
+        assert.isFalse(controller.shouldShowLoadMore())
+
+      it 'is false when the container contains an annotation', ->
+        controller.container = {message: {id: 123}}
+        assert.isFalse(controller.shouldShowLoadMore())
+
+    describe 'when the thread filter is active', ->
+      beforeEach ->
+        controller.filter = {active: -> true}
+
+      it 'is false with an empty container', ->
+        assert.isFalse(controller.shouldShowLoadMore())
+
+      it 'is true when the container contains an annotation', ->
+        controller.container = {message: {id: 123}}
+        assert.isTrue(controller.shouldShowLoadMore())
+
+  describe '#loadMore', ->
+    controller = null
+
+    beforeEach ->
+      controller = createController()
+
+    it 'uncollapses the thread', ->
+      sinon.spy(controller, 'toggleCollapsed')
+      controller.loadMore()
+      assert.calledWith(controller.toggleCollapsed, false)
+
+    it 'uncollapses all the ancestors of the thread', ->
+      grandmother = {toggleCollapsed: sinon.stub()}
+      mother = {toggleCollapsed: sinon.stub()}
+      controller.parent = mother
+      controller.parent.parent = grandmother
+      controller.loadMore()
+      assert.calledWith(mother.toggleCollapsed, false)
+      assert.calledWith(grandmother.toggleCollapsed, false)
+
+    it 'deactivates the thread filter when present', ->
+      controller.filter = {active: sinon.stub()}
+      controller.loadMore()
+      assert.calledWith(controller.filter.active, false)
+
+  describe '#matchesFilter', ->
+    controller = null
+
+    beforeEach ->
+      controller = createController()
+
+    it 'is true by default', ->
+      assert.isTrue(controller.matchesFilter())
+
+    it 'checks with the thread filter to see if the root annotation matches', ->
+      check = sinon.stub().returns(false)
+      controller.filter = {check: check}
+      controller.container = {}
+      assert.isFalse(controller.matchesFilter())
+      assert.calledWith(check, controller.container)
 
 
 describe 'h.directives.thread.thread', ->

--- a/tests/js/directives/thread-test.coffee
+++ b/tests/js/directives/thread-test.coffee
@@ -101,11 +101,21 @@ describe 'h.directives.thread.ThreadController', ->
 describe 'h.directives.thread.thread', ->
   createElement = null
   $element = null
-  $isolateScope = null
   fakePulse = null
   sandbox = null
 
-  beforeEach module('h')
+  beforeEach module 'h', ($compileProvider) ->
+    # The thread directive instantiates the annotation directive, which in turn
+    # injects a whole bunch of other stuff (auth service, permissions service,
+    # etc.) which we really don't want to have to mock individually here. As
+    # such, it's easier to just mock out the whole annotation directive for now.
+    $compileProvider.directive 'annotation', ->
+      priority: 9999
+      terminal: true
+      template: ''
+    return
+
+  beforeEach module('h.templates')
 
   beforeEach module ($provide) ->
     sandbox = sinon.sandbox.create()
@@ -114,9 +124,11 @@ describe 'h.directives.thread.thread', ->
     return
 
   beforeEach inject ($compile, $rootScope) ->
-    createElement = (html) -> $compile(html or '<div thread></div>')($rootScope.$new())
+    createElement = (html) ->
+      el = $compile(html or '<div thread></div>')($rootScope.$new())
+      $rootScope.$digest()
+      return el
     $element = createElement()
-    $isolateScope = $element.scope()
 
   afterEach ->
     sandbox.restore()

--- a/tests/js/directives/thread-test.coffee
+++ b/tests/js/directives/thread-test.coffee
@@ -42,71 +42,25 @@ describe 'h.directives.thread.ThreadController', ->
       controller = createController()
       count = sinon.stub()
 
-    describe 'when root', ->
-      beforeEach -> controller.isRoot = true
+    describe 'when not filtered', ->
+      it 'shows the reply if the thread has children', ->
+        count.withArgs('message').returns(1)
+        assert.isTrue(controller.shouldShowReply(count, false))
 
-      describe 'and when not filtered', ->
-        it 'shows the reply if the thread is not collapsed and has children', ->
-          count.withArgs('message').returns(1)
-          assert.isTrue(controller.shouldShowReply(count, false))
+      it 'does not show the reply if the thread has no children', ->
+        count.withArgs('message').returns(0)
+        assert.isFalse(controller.shouldShowReply(count, false))
 
-        it 'does not show the reply if the thread is not collapsed and has no children', ->
-          count.withArgs('message').returns(0)
-          assert.isFalse(controller.shouldShowReply(count, false))
+    describe 'when filtered with children', ->
+      it 'shows the reply', ->
+        count.withArgs('match').returns(1)
+        count.withArgs('message').returns(1)
+        assert.isTrue(controller.shouldShowReply(count, true))
 
-        it 'shows the reply if the thread is collapsed and has children', ->
-          count.withArgs('message').returns(1)
-          controller.toggleCollapsed(true)
-          assert.isTrue(controller.shouldShowReply(count, false))
-
-        it 'does not show the reply if the thread is collapsed and has no children', ->
-          count.withArgs('message').returns(0)
-          controller.toggleCollapsed(true)
-          assert.isFalse(controller.shouldShowReply(count, false))
-
-      describe 'and when filtered with children', ->
-        it 'shows the reply if the thread is not collapsed', ->
-          count.withArgs('match').returns(1)
-          count.withArgs('message').returns(1)
-          assert.isTrue(controller.shouldShowReply(count, true))
-
-        it 'does not show the reply if the thread is not collapsed and the message count does not match the match count', ->
-          count.withArgs('match').returns(0)
-          count.withArgs('message').returns(1)
-          assert.isFalse(controller.shouldShowReply(count, true))
-
-    describe 'when reply', ->
-      beforeEach -> controller.isRoot = false
-
-      describe 'and when not filtered', ->
-        it 'shows the reply if the thread is not collapsed and has children', ->
-          count.withArgs('message').returns(1)
-          assert.isTrue(controller.shouldShowReply(count, false))
-
-        it 'does not show the reply if the thread is not collapsed and has no children', ->
-          count.withArgs('message').returns(0)
-          assert.isFalse(controller.shouldShowReply(count, false))
-
-        it 'does not show the reply if the thread is collapsed and has children', ->
-          count.withArgs('message').returns(1)
-          controller.toggleCollapsed(true)
-          assert.isFalse(controller.shouldShowReply(count, false))
-
-        it 'does not show the reply if the thread is collapsed and has no children', ->
-          count.withArgs('message').returns(0)
-          controller.toggleCollapsed(true)
-          assert.isFalse(controller.shouldShowReply(count, false))
-
-      describe 'and when filtered with children', ->
-        it 'shows the reply if the thread is not collapsed', ->
-          count.withArgs('match').returns(1)
-          count.withArgs('message').returns(1)
-          assert.isTrue(controller.shouldShowReply(count, true))
-
-        it 'does not show the reply if the thread is not collapsed and the message count does not match the match count', ->
-          count.withArgs('match').returns(0)
-          count.withArgs('message').returns(1)
-          assert.isFalse(controller.shouldShowReply(count, true))
+      it 'does not show the reply if the message count does not match the match count', ->
+        count.withArgs('match').returns(0)
+        count.withArgs('message').returns(1)
+        assert.isFalse(controller.shouldShowReply(count, true))
 
 
 describe 'h.directives.thread.thread', ->
@@ -143,15 +97,6 @@ describe 'h.directives.thread.thread', ->
 
   afterEach ->
     sandbox.restore()
-
-  it 'sets the threadRoot on the controller to false', ->
-    controller = $element.controller('thread')
-    assert.isFalse(controller.isRoot)
-
-  it 'sets the threadRoot on the controller to true when the thread-root attr is set', ->
-    $element = createElement('<div thread thread-root="true"></div>')
-    controller = $element.controller('thread')
-    assert.isTrue(controller.isRoot)
 
   it 'pulses the current thread on an annotationUpdated event', ->
     $element.scope().$emit('annotationUpdate')

--- a/tests/js/directives/thread-test.coffee
+++ b/tests/js/directives/thread-test.coffee
@@ -16,12 +16,23 @@ describe 'h.directives.thread.ThreadController', ->
       controller
 
   describe '#toggleCollapsed', ->
-    it 'sets the collapsed property', ->
+    it 'toggles whether or not the thread is collapsed', ->
       controller = createController()
-      before = controller.collapsed
+      before = controller.isCollapsed()
       controller.toggleCollapsed()
-      after = controller.collapsed
+      after = controller.isCollapsed()
       assert.equal(before, !after)
+
+    it 'can accept an argument to force a particular state', ->
+      controller = createController()
+      controller.toggleCollapsed(true)
+      assert.isTrue(controller.isCollapsed())
+      controller.toggleCollapsed(true)
+      assert.isTrue(controller.isCollapsed())
+      controller.toggleCollapsed(false)
+      assert.isFalse(controller.isCollapsed())
+      controller.toggleCollapsed(false)
+      assert.isFalse(controller.isCollapsed())
 
   describe '#shouldShowReply', ->
     count = null
@@ -45,12 +56,12 @@ describe 'h.directives.thread.ThreadController', ->
 
         it 'shows the reply if the thread is collapsed and has children', ->
           count.withArgs('message').returns(1)
-          controller.collapsed = true
+          controller.toggleCollapsed(true)
           assert.isTrue(controller.shouldShowReply(count, false))
 
         it 'does not show the reply if the thread is collapsed and has no children', ->
           count.withArgs('message').returns(0)
-          controller.collapsed = true
+          controller.toggleCollapsed(true)
           assert.isFalse(controller.shouldShowReply(count, false))
 
       describe 'and when filtered with children', ->
@@ -78,12 +89,12 @@ describe 'h.directives.thread.ThreadController', ->
 
         it 'does not show the reply if the thread is collapsed and has children', ->
           count.withArgs('message').returns(1)
-          controller.collapsed = true
+          controller.toggleCollapsed(true)
           assert.isFalse(controller.shouldShowReply(count, false))
 
         it 'does not show the reply if the thread is collapsed and has no children', ->
           count.withArgs('message').returns(0)
-          controller.collapsed = true
+          controller.toggleCollapsed(true)
           assert.isFalse(controller.shouldShowReply(count, false))
 
       describe 'and when filtered with children', ->
@@ -148,7 +159,7 @@ describe 'h.directives.thread.thread', ->
 
   it 'does not pulse the thread if it is hidden (parent collapsed)', ->
     fakeParent = {
-      controller: -> {collapsed: true}
+      controller: -> {isCollapsed: sinon.stub().returns(true)}
     }
     sandbox.stub(angular.element.prototype, 'parent').returns(fakeParent)
     $element.scope().$emit('annotationUpdate')
@@ -156,10 +167,10 @@ describe 'h.directives.thread.thread', ->
 
   it 'does not pulse the thread if it is hidden (grandparent collapsed)', ->
     fakeGrandParent = {
-      controller: -> {collapsed: true}
+      controller: -> {isCollapsed: sinon.stub().returns(true)}
     }
     fakeParent = {
-      controller: -> {collapsed: false}
+      controller: -> {isCollapsed: sinon.stub().returns(false)}
       parent: -> fakeGrandParent
     }
     sandbox.stub(angular.element.prototype, 'parent').returns(fakeParent)


### PR DESCRIPTION
This pull request builds on #1942, so **please don't merge this** until that one has been reviewed, merged, and this PR has been rebased.

I've always been massively confused by the meaning of 'collapsed' in the thread directive. It meant "my replies are collapsed" for the top card, and "I and my replies are collapsed" for replies themselves. This commit changes that, so that collapsing is just about whether or not your replies are visible.

That means that you can no longer collapse individual replies one by one. I consider this an improvement to the user experience.

While doing this, it became apparent to me that working on the thread directive (and associated controller) was *far* too difficult. I've hopefully simplified this a little bit by moving most of the complicated logic out of the `thread.html` template and into the controller itself.

Lastly, I've cleaned up a few bits and pieces (like [this one](https://github.com/hypothesis/h/pull/1942/files#diff-99315dc14140e8da3a4a1b18d9df989cR129)) from the preceding PR.