### PR TITLE
Fix real-time delete

### DIFF
--- a/h/static/scripts/controllers.coffee
+++ b/h/static/scripts/controllers.coffee
@@ -48,7 +48,8 @@ class AppController
           annotationMapper.loadAnnotations data
         when 'delete'
           for annotation in data
-            $scope.$emit('annotationDeleted', annotation)
+            if a = threading.idTable[annotation.id]?.message
+              $scope.$emit('annotationDeleted', a)
 
     streamer.onmessage = (data) ->
       return if !data or data.type != 'annotation-notification'


### PR DESCRIPTION
When receiving a real-time notification about the removal
of an annotation, we emit an annotationDeleted event,
so that all components can react.

Earlier, we emited this event simply with the Annotation
bject that arrived on the wire.

However, some components couldn't deal with this, because
they were expecting to see the 'real' Annotation object,
the ones they already knew about.

So now we do a lookup before emiting the event, and use
the locally found objects instead.

Fixes #1928.

   * * *

Please comment on this; I am not intimately familiar with how our custom 
cross-frame / client-server object persistence system life-cycle is supposed to work. 