### PR TITLE
Add some tests for TextHighlight

### DIFF
--- a/h/static/scripts/annotator/plugin/texthighlights.coffee
+++ b/h/static/scripts/annotator/plugin/texthighlights.coffee
@@ -29,6 +29,8 @@ highlightRange = (normedRange, cssClass='annotator-hl') ->
 
 class TextHighlight
 
+  @highlightRange: highlightRange
+
   @createFrom: (segment, anchor, page) ->
     return null if segment.type isnt "magic range"
 
@@ -71,7 +73,7 @@ class TextHighlight
     TextHighlight._init @annotator
 
     # Create highlights and link them with the annotation
-    @_highlights = highlightRange(normedRange)
+    @_highlights = TextHighlight.highlightRange(normedRange)
     $(@_highlights).data "annotation", @annotation
 
   # Is this a temporary hl?

--- a/h/static/scripts/annotator/plugin/texthighlights.coffee
+++ b/h/static/scripts/annotator/plugin/texthighlights.coffee
@@ -1,5 +1,32 @@
 $ = Annotator.$
 
+# Public: Wraps the DOM Nodes within the provided range with a highlight
+# element of the specified class and returns the highlight Elements.
+#
+# normedRange - A NormalizedRange to be highlighted.
+# cssClass - A CSS class to use for the highlight (default: 'annotator-hl')
+#
+# Returns an array of highlight Elements.
+highlightRange = (normedRange, cssClass='annotator-hl') ->
+  white = /^\s*$/
+
+  hl = $("<span class='#{cssClass}'></span>")
+
+  # Ignore text nodes that contain only whitespace characters. This prevents
+  # spans being injected between elements that can only contain a restricted
+  # subset of nodes such as table rows and lists. This does mean that there
+  # may be the odd abandoned whitespace node in a paragraph that is skipped
+  # but better than breaking table layouts.
+
+  nodes = $(normedRange.textNodes()).filter((i) -> not white.test @nodeValue)
+  r = nodes.wrap(hl).parent().show().toArray()
+  for node in nodes
+    event = document.createEvent "UIEvents"
+    event.initUIEvent "domChange", true, false, window, 0
+    event.reason = "created hilite"
+    node.dispatchEvent event
+  r
+
 class TextHighlight
 
   @createFrom: (segment, anchor, page) ->
@@ -90,34 +117,6 @@ class TextHighlight
     new Promise (resolve, reject) =>
       $(@_highlights).scrollintoview complete: ->
         resolve()
-
-# Public: Wraps the DOM Nodes within the provided range with a highlight
-# element of the specified class and returns the highlight Elements.
-#
-# normedRange - A NormalizedRange to be highlighted.
-# cssClass - A CSS class to use for the highlight (default: 'annotator-hl')
-#
-# Returns an array of highlight Elements.
-highlightRange = (normedRange, cssClass='annotator-hl') ->
-  white = /^\s*$/
-
-  hl = $("<span class='#{cssClass}'></span>")
-
-  # Ignore text nodes that contain only whitespace characters. This prevents
-  # spans being injected between elements that can only contain a restricted
-  # subset of nodes such as table rows and lists. This does mean that there
-  # may be the odd abandoned whitespace node in a paragraph that is skipped
-  # but better than breaking table layouts.
-
-  nodes = $(normedRange.textNodes()).filter((i) -> not white.test @nodeValue)
-  r = nodes.wrap(hl).parent().show().toArray()
-  for node in nodes
-    event = document.createEvent "UIEvents"
-    event.initUIEvent "domChange", true, false, window, 0
-    event.reason = "created hilite"
-    node.dispatchEvent event
-  r
-
 
 class Annotator.Plugin.TextHighlights extends Annotator.Plugin
 

--- a/tests/js/plugin/texthighlight-test.coffee
+++ b/tests/js/plugin/texthighlight-test.coffee
@@ -62,7 +62,7 @@ describe 'Annotator.Plugin.TextHighlight', ->
 
   describe "scrollIntoView", ->
 
-    it 'actually calls jQuery scrollintoviews', ->
+    it 'calls jQuery scrollintoview', ->
       hl = createTestHighlight()
       hl.scrollIntoView()
       assert.called jqElement.scrollintoview

--- a/tests/js/plugin/texthighlight-test.coffee
+++ b/tests/js/plugin/texthighlight-test.coffee
@@ -1,0 +1,78 @@
+assert = chai.assert
+sinon.assert.expose(assert, prefix: '')
+
+# In order to be able to create highlights,
+# the Annotator.TextHighlight class must exist.
+# This class is registered then the TextHighlights plugin
+# is initialized, so we will do that.
+th = new Annotator.Plugin.TextHighlights()
+th.pluginInit()
+
+describe 'Annotator.Plugin.TextHighlight', ->
+  sandbox = null
+  jqElement = null
+  scrollTarget = null
+
+  createTestHighlight = ->
+    anchor =
+      id: "test anchor"
+      annotation: "test annotation"
+      anchoring:
+        id: "test anchoring manager"
+        annotator:
+          id: "test annotator"
+          element:
+            delegate: sinon.spy()
+
+    new Annotator.TextHighlight anchor, "test page", "test range"
+
+  beforeEach ->
+    sandbox = sinon.sandbox.create()
+    sandbox.stub Annotator.TextHighlight, 'highlightRange',
+      (normedRange, cssClass) -> "test highlight span"
+
+    sandbox.stub Annotator.$.fn, "init", (selector, context) ->
+      jqElement =
+        selector: selector
+        data: sinon.spy()
+        scrollintoview: sinon.spy (options) ->
+          scrollTarget = this.selector
+          options?.complete?()
+
+  afterEach ->
+    sandbox.restore()
+    scrollTarget = null
+
+  describe "constructor", ->
+    it 'wraps a highlight span around the given range', ->
+      hl = createTestHighlight()
+      assert.calledWith Annotator.TextHighlight.highlightRange, "test range"
+
+    it 'stores the created highlight spans in _highlights', ->
+      hl = createTestHighlight()
+      assert.equal hl._highlights, "test highlight span"
+
+    it "wraps a jQuery element around the highlight span", ->
+      hl = createTestHighlight()
+      assert.equal jqElement.selector, "test highlight span"
+
+    it "assigns the annotation as data to the highlight span", ->
+      hl = createTestHighlight()
+      assert.calledWith jqElement.data, "annotation", "test annotation"
+
+  describe "scrollIntoView", ->
+
+    it 'actually calls jQuery scrollintoviews', ->
+      hl = createTestHighlight()
+      hl.scrollIntoView()
+      assert.called jqElement.scrollintoview
+
+    it 'scrolls to the created highlight span', ->
+      hl = createTestHighlight()
+      hl.scrollIntoView()
+      assert.equal scrollTarget, hl._highlights
+
+    it 'resolves the promise after scrolling', ->
+      hl = createTestHighlight()
+      hl.scrollIntoView().then ->
+        assert.ok scrollTarget

--- a/tests/js/plugin/texthighlight-test.coffee
+++ b/tests/js/plugin/texthighlight-test.coffee
@@ -10,7 +10,6 @@ th.pluginInit()
 
 describe 'Annotator.Plugin.TextHighlight', ->
   sandbox = null
-  jqElement = null
   scrollTarget = null
 
   createTestHighlight = ->
@@ -29,15 +28,14 @@ describe 'Annotator.Plugin.TextHighlight', ->
   beforeEach ->
     sandbox = sinon.sandbox.create()
     sandbox.stub Annotator.TextHighlight, 'highlightRange',
-      (normedRange, cssClass) -> "test highlight span"
+      (normedRange, cssClass) ->
+        hl = document.createElement "hl"
+        hl.appendChild document.createTextNode "test highlight span"
+        hl
 
-    sandbox.stub Annotator.$.fn, "init", (selector, context) ->
-      jqElement =
-        selector: selector
-        data: sinon.spy()
-        scrollintoview: sinon.spy (options) ->
-          scrollTarget = this.selector
-          options?.complete?()
+    Annotator.$.fn.scrollintoview = sinon.spy (options) ->
+      scrollTarget = this[0]
+      options?.complete?()
 
   afterEach ->
     sandbox.restore()
@@ -50,22 +48,19 @@ describe 'Annotator.Plugin.TextHighlight', ->
 
     it 'stores the created highlight spans in _highlights', ->
       hl = createTestHighlight()
-      assert.equal hl._highlights, "test highlight span"
-
-    it "wraps a jQuery element around the highlight span", ->
-      hl = createTestHighlight()
-      assert.equal jqElement.selector, "test highlight span"
+      assert.equal hl._highlights.textContent, "test highlight span"
 
     it "assigns the annotation as data to the highlight span", ->
       hl = createTestHighlight()
-      assert.calledWith jqElement.data, "annotation", "test annotation"
+      annotation = $(hl._highlights).data "annotation"
+      assert.equal annotation, "test annotation"
 
   describe "scrollIntoView", ->
 
     it 'calls jQuery scrollintoview', ->
       hl = createTestHighlight()
       hl.scrollIntoView()
-      assert.called jqElement.scrollintoview
+      assert.called Annotator.$.fn.scrollintoview
 
     it 'scrolls to the created highlight span', ->
       hl = createTestHighlight()


### PR DESCRIPTION
So, last time I fixed a bug in the TextHighlight plugin, @nickstenning's regression test alarm [went off](https://github.com/hypothesis/h/commit/30a98acc3aa1c9f39ccabc5321d32094aea2d97a#commitcomment-9741632).

In an attempt to silence that alert, I am trying to add a minimal test suite here for the TextHighlight implementation.

Feedback welcome. 

I had to do some pretty ugly mocking around jQuery, if someone can improve it, please tell me how.

