### PR TITLE
Add highlight test and change scrolling

### DIFF
--- a/h/static/scripts/annotator/plugin/bucket-bar.coffee
+++ b/h/static/scripts/annotator/plugin/bucket-bar.coffee
@@ -142,7 +142,7 @@ class Annotator.Plugin.BucketBar extends Annotator.Plugin
 
     # Get an anchor from the page we want to go to
     anchor = next[0]
-    anchor.scrollIntoView()
+    anchor.scrollToView()
 
   _update: =>
     wrapper = @annotator.wrapper

--- a/h/static/scripts/annotator/plugin/enhancedanchoring.coffee
+++ b/h/static/scripts/annotator/plugin/enhancedanchoring.coffee
@@ -60,10 +60,8 @@ class Anchor
     # If we are supposed to scroll to the highlight on a page,
     # and it's available now, go scroll there.
     if @pendingScrollTargetPage? and (hl = @highlight[@pendingScrollTargetPage])
-      hl.scrollIntoView().then =>
-        @pendingScrollResolve()
-        delete @pendingScrollTargetPage
-        delete @pendingScrollResolve
+      hl.scrollToView()
+      delete @pendingScrollTargetPage
 
   # Remove the highlights for the given set of pages
   virtualize: (pageIndex) =>
@@ -94,12 +92,12 @@ class Anchor
       delete @anchoring.anchors[index] unless anchors.length
 
   # Scroll to this anchor
-  scrollIntoView: ->
+  scrollToView: ->
     currentPage = @anchoring.document.getPageIndex()
 
     if @startPage is @endPage and currentPage is @startPage
       # It's all in one page. Simply scrolling
-      @highlight[@startPage].scrollIntoView()
+      @highlight[@startPage].scrollToView()
     else
       if currentPage < @startPage
         # We need to go forward
@@ -118,13 +116,12 @@ class Anchor
       # Is this rendered?
       if @anchoring.document.isPageMapped wantedPage
         # The wanted page is already rendered, we can simply go there
-        @highlight[wantedPage].scrollIntoView()
+        @highlight[wantedPage].scrollToView()
       else
         # Not rendered yet. Go to the page, we will continue from there
         @pendingScrollTargetPage = wantedPage
-        new Promise (resolve, reject) =>
-          @pendingScrollResolve = resolve
-          @anchoring.document.setPageIndex scrollPage
+        @anchoring.document.setPageIndex scrollPage
+        null
 
 Annotator.Anchor = Anchor
 

--- a/h/static/scripts/annotator/plugin/texthighlights.coffee
+++ b/h/static/scripts/annotator/plugin/texthighlights.coffee
@@ -29,6 +29,8 @@ highlightRange = (normedRange, cssClass='annotator-hl') ->
 
 class TextHighlight
 
+  @highlightRange: highlightRange
+
   @createFrom: (segment, anchor, page) ->
     return null if segment.type isnt "magic range"
 
@@ -71,7 +73,7 @@ class TextHighlight
     TextHighlight._init @annotator
 
     # Create highlights and link them with the annotation
-    @_highlights = highlightRange(normedRange)
+    @_highlights = TextHighlight.highlightRange(normedRange)
     $(@_highlights).data "annotation", @annotation
 
   # Is this a temporary hl?

--- a/h/static/scripts/annotator/plugin/texthighlights.coffee
+++ b/h/static/scripts/annotator/plugin/texthighlights.coffee
@@ -1,5 +1,32 @@
 $ = Annotator.$
 
+# Public: Wraps the DOM Nodes within the provided range with a highlight
+# element of the specified class and returns the highlight Elements.
+#
+# normedRange - A NormalizedRange to be highlighted.
+# cssClass - A CSS class to use for the highlight (default: 'annotator-hl')
+#
+# Returns an array of highlight Elements.
+highlightRange = (normedRange, cssClass='annotator-hl') ->
+  white = /^\s*$/
+
+  hl = $("<span class='#{cssClass}'></span>")
+
+  # Ignore text nodes that contain only whitespace characters. This prevents
+  # spans being injected between elements that can only contain a restricted
+  # subset of nodes such as table rows and lists. This does mean that there
+  # may be the odd abandoned whitespace node in a paragraph that is skipped
+  # but better than breaking table layouts.
+
+  nodes = $(normedRange.textNodes()).filter((i) -> not white.test @nodeValue)
+  r = nodes.wrap(hl).parent().show().toArray()
+  for node in nodes
+    event = document.createEvent "UIEvents"
+    event.initUIEvent "domChange", true, false, window, 0
+    event.reason = "created hilite"
+    node.dispatchEvent event
+  r
+
 class TextHighlight
 
   @createFrom: (segment, anchor, page) ->
@@ -90,34 +117,6 @@ class TextHighlight
     new Promise (resolve, reject) =>
       $(@_highlights).scrollintoview complete: ->
         resolve()
-
-# Public: Wraps the DOM Nodes within the provided range with a highlight
-# element of the specified class and returns the highlight Elements.
-#
-# normedRange - A NormalizedRange to be highlighted.
-# cssClass - A CSS class to use for the highlight (default: 'annotator-hl')
-#
-# Returns an array of highlight Elements.
-highlightRange = (normedRange, cssClass='annotator-hl') ->
-  white = /^\s*$/
-
-  hl = $("<span class='#{cssClass}'></span>")
-
-  # Ignore text nodes that contain only whitespace characters. This prevents
-  # spans being injected between elements that can only contain a restricted
-  # subset of nodes such as table rows and lists. This does mean that there
-  # may be the odd abandoned whitespace node in a paragraph that is skipped
-  # but better than breaking table layouts.
-
-  nodes = $(normedRange.textNodes()).filter((i) -> not white.test @nodeValue)
-  r = nodes.wrap(hl).parent().show().toArray()
-  for node in nodes
-    event = document.createEvent "UIEvents"
-    event.initUIEvent "domChange", true, false, window, 0
-    event.reason = "created hilite"
-    node.dispatchEvent event
-  r
-
 
 class Annotator.Plugin.TextHighlights extends Annotator.Plugin
 

--- a/h/static/scripts/annotator/plugin/texthighlights.coffee
+++ b/h/static/scripts/annotator/plugin/texthighlights.coffee
@@ -115,10 +115,9 @@ class TextHighlight
   getHeight: -> $(@_highlights).outerHeight true
 
   # Scroll the highlight into view
-  scrollIntoView: ->
-    new Promise (resolve, reject) =>
-      $(@_highlights).scrollintoview complete: ->
-        resolve()
+  scrollToView: ->
+    $(@_highlights).scrollintoview()
+    null
 
 class Annotator.Plugin.TextHighlights extends Annotator.Plugin
 

--- a/h/static/scripts/guest.coffee
+++ b/h/static/scripts/guest.coffee
@@ -166,7 +166,7 @@ class Annotator.Guest extends Annotator
     crossframe.on 'scrollToAnnotation', (ctx, tag) =>
       for a in @anchoring.getAnchors()
         if a.annotation.$$tag is tag
-          a.scrollIntoView()
+          a.scrollToView()
           return
     crossframe.on 'getDocumentInfo', (trans) =>
       (@plugins.PDF?.getMetaData() ? Promise.reject())

--- a/tests/js/guest-test.coffee
+++ b/tests/js/guest-test.coffee
@@ -197,11 +197,11 @@ describe 'Annotator.Guest', ->
       it 'scrolls to the anchor with the matching tag', ->
         guest = createGuest()
         anchors = [
-          {annotation: {$$tag: 'tag1'}, scrollIntoView: sandbox.stub()}
+          {annotation: {$$tag: 'tag1'}, scrollToView: sandbox.stub()}
         ]
         sandbox.stub(guest.anchoring, 'getAnchors').returns(anchors)
         emitGuestEvent('scrollToAnnotation', 'ctx', 'tag1')
-        assert.called(anchors[0].scrollIntoView)
+        assert.called(anchors[0].scrollToView)
 
     describe 'on "getDocumentInfo" event', ->
       guest = null

--- a/tests/js/plugin/enhancedanchoring-test.coffee
+++ b/tests/js/plugin/enhancedanchoring-test.coffee
@@ -27,6 +27,9 @@ class TestAnchor extends Annotator.Anchor
 describe 'Annotator.Plugin.EnhancedAnchoring', ->
   sandbox = null
   pendingTest = null
+  am = null
+  ann = null
+  anchor = null
 
   beforeEach ->
     sandbox = sinon.sandbox.create()
@@ -41,6 +44,9 @@ describe 'Annotator.Plugin.EnhancedAnchoring', ->
   afterEach ->
     sandbox.restore()
     pendingTest = null
+    am = null
+    ann = null
+    anchor = null
 
   describe "single-phase anchoring", ->
 
@@ -68,10 +74,16 @@ describe 'Annotator.Plugin.EnhancedAnchoring', ->
 
       am
 
+    beforeEach ->
+      am = createAnchoringManager()
+
     describe "createAnchor() - single-phase", ->
 
+      beforeEach ->
+        ann = createTestAnnotation "a1"
+        anchor = am.createAnchor(ann, ann.target[0]).result
+
       it 'adds an anchor property to the annotations', ->
-        am = createAnchoringManager()
         ann = createTestAnnotation "a1", 2
 
         anchor1 = am.createAnchor(ann, ann.target[0]).result
@@ -83,37 +95,22 @@ describe 'Annotator.Plugin.EnhancedAnchoring', ->
         assert.equal ann.anchors.length, 2
 
       it 'adds an annotation property to the created anchors', ->
-        am = createAnchoringManager()
-        ann = createTestAnnotation "a1"
-        anchor = am.createAnchor(ann, ann.target[0]).result
 
         assert.equal anchor.annotation, ann
 
       it 'adds a target property to the created anchors', ->
-        am = createAnchoringManager()
-        ann = createTestAnnotation "a1"
-        anchor = am.createAnchor(ann, ann.target[0]).result
 
         assert.equal anchor.target, ann.target[0]
 
       it 'creates the anchors from the right targets', ->
-        am = createAnchoringManager()
-        ann = createTestAnnotation "a1"
-        anchor = am.createAnchor(ann, ann.target[0]).result
 
         assert.equal anchor.id, "fake anchor for " + anchor.target.id
 
       it 'adds the created anchors to the correct per-page array', ->
-        am = createAnchoringManager()
-        ann = createTestAnnotation "a1"
-        anchor = am.createAnchor(ann, ann.target[0]).result
 
         assert.include am.anchors[anchor.startPage], anchor
 
       it 'adds the created highlights to the anchors', ->
-        am = createAnchoringManager()
-        ann = createTestAnnotation "a1"
-        anchor = am.createAnchor(ann, ann.target[0]).result
 
         assert.isObject anchor.highlight
 
@@ -124,19 +121,12 @@ describe 'Annotator.Plugin.EnhancedAnchoring', ->
         assert.equal hl.page, page
 
       it 'announces the creation of the highlights in an event', ->
-        am = createAnchoringManager()
-        ann = createTestAnnotation "a1"
-        am.annotator.publish.reset()
-        anchor = am.createAnchor(ann, ann.target[0]).result
 
         hl = anchor.highlight[anchor.startPage]
 
         assert.calledWith am.annotator.publish, 'highlightsCreated', [hl]
 
       it 'adds an anchor property to the created Highlights', ->
-        am = createAnchoringManager()
-        ann = createTestAnnotation "a1"
-        anchor = am.createAnchor(ann, ann.target[0]).result
 
         page = anchor.startPage
         hl = anchor.highlight[page]
@@ -146,14 +136,11 @@ describe 'Annotator.Plugin.EnhancedAnchoring', ->
     describe "getAnchors()", ->
 
       it 'returns an empty array by default', ->
-        am = createAnchoringManager()
         anchors = am.getAnchors()
         assert.isArray anchors
         assert.equal anchors.length, 0
 
       it 'returns all the anchors', ->
-        am = createAnchoringManager()
-
         ann1 = createTestAnnotation "a1", 2
         ann2 = createTestAnnotation "a2"
         ann3 = createTestAnnotation "a3"
@@ -171,7 +158,6 @@ describe 'Annotator.Plugin.EnhancedAnchoring', ->
         assert.include anchors, anchor3
 
       it 'returns the anchors belonging to a set of annotations', ->
-        am = createAnchoringManager()
         ann1 = createTestAnnotation "a1", 2
         ann2 = createTestAnnotation "a2"
         ann3 = createTestAnnotation "a3"
@@ -190,14 +176,12 @@ describe 'Annotator.Plugin.EnhancedAnchoring', ->
 
     describe 'getHighlights()', ->
       it 'returns an empty array by default', ->
-        am = createAnchoringManager()
         hls = am.getHighlights()
 
         assert.isArray hls
         assert.equal hls.length, 0
 
       it 'returns all the highlights', ->
-        am = createAnchoringManager()
         ann1 = createTestAnnotation "a1", 2
         ann2 = createTestAnnotation "a2"
         ann3 = createTestAnnotation "a3"
@@ -215,7 +199,6 @@ describe 'Annotator.Plugin.EnhancedAnchoring', ->
         assert.include hls, anchor3.highlight[anchor3.startPage]
 
       it 'returns the highlights belonging to a set of annotations', ->
-        am = createAnchoringManager()
         ann1 = createTestAnnotation "a1", 2
         ann2 = createTestAnnotation "a2"
         ann3 = createTestAnnotation "a3"
@@ -234,7 +217,6 @@ describe 'Annotator.Plugin.EnhancedAnchoring', ->
 
     describe 'Anchor.scrollToView() - single-phase', ->
       it 'calls scrollIntoView() on the highlight', ->
-        am = createAnchoringManager()
         ann = createTestAnnotation "a1"
         anchor = am.createAnchor(ann, ann.target[0]).result
         anchor.scrollToView()
@@ -345,28 +327,28 @@ describe 'Annotator.Plugin.EnhancedAnchoring', ->
 
       result
 
+    ann = null
+
+    beforeEach ->
+      am = createAnchoringManagerAndLazyDocument()
+      ann = createTestAnnotationForPages "a1", [1]
+
     describe "when the wanted page is already rendered", ->
 
       it 'creates real anchors', ->
-        am = createAnchoringManagerAndLazyDocument()
         renderPage(am.document, 1).then ->
-          ann = createTestAnnotationForPages "a1", [1]
           anchor = am.createAnchor(ann, ann.target[0]).result
           assert anchor.fullyRealized
 
       it 'creates highlights', ->
-        am = createAnchoringManagerAndLazyDocument()
         renderPage(am.document, 1).then ->
-          ann = createTestAnnotationForPages "a1", [1]
           anchor = am.createAnchor(ann, ann.target[0]).result
           hl = anchor.highlight[1]
           assert.ok hl
           assert.equal hl.page, 1
 
       it 'announces the highlights with the appropriate event', ->
-        am = createAnchoringManagerAndLazyDocument()
         renderPage(am.document, 1).then ->
-          ann = createTestAnnotationForPages "a1", [1]
           anchor = am.createAnchor(ann, ann.target[0]).result
           hl = anchor.highlight[1]
 
@@ -375,9 +357,7 @@ describe 'Annotator.Plugin.EnhancedAnchoring', ->
     describe 'when a page is unrendered', ->
 
       it 'calls removeFromDocument an the correct highlight', ->
-        am = createAnchoringManagerAndLazyDocument()
         renderPage(am.document, 1).then ->
-          ann = createTestAnnotationForPages "a1", [1]
           anchor = am.createAnchor(ann, ann.target[0]).result
           hl = anchor.highlight[1]
           unrenderPage(am.document, 1).then ->
@@ -385,27 +365,21 @@ describe 'Annotator.Plugin.EnhancedAnchoring', ->
             assert.called hl.removeFromDocument
 
       it 'removes highlights from the relevant page', ->
-        am = createAnchoringManagerAndLazyDocument()
         renderPage(am.document, 1).then ->
-          ann = createTestAnnotationForPages "a1", [1]
           anchor = am.createAnchor(ann, ann.target[0]).result
           unrenderPage(am.document, 1).then ->
 
             assert !anchor.fullyRealized
 
       it 'announces the removal of the highlights from the relevant page', ->
-        am = createAnchoringManagerAndLazyDocument()
         renderPage(am.document, 1).then ->
-          ann = createTestAnnotationForPages "a1", [1]
           anchor = am.createAnchor(ann, ann.target[0]).result
           hl = anchor.highlight[1]
           unrenderPage(am.document, 1).then ->
             assert.calledWith am.annotator.publish, 'highlightRemoved', hl
 
       it 'switches the anchor to virtual', ->
-        am = createAnchoringManagerAndLazyDocument()
         renderPage(am.document, 1).then ->
-          ann = createTestAnnotationForPages "a1", [1]
           anchor = am.createAnchor(ann, ann.target[0]).result
           unrenderPage(am.document, 1).then ->
             assert !anchor.fullyRealized
@@ -413,22 +387,16 @@ describe 'Annotator.Plugin.EnhancedAnchoring', ->
     describe 'when the wanted page is not rendered', ->
 
       it 'creates virtual anchors', ->
-        am = createAnchoringManagerAndLazyDocument()
-        ann = createTestAnnotationForPages "a1", [1]
         anchor = am.createAnchor(ann, ann.target[0]).result
 
         assert !anchor.fullyRealized
 
       it 'creates no highlights', ->
-        am = createAnchoringManagerAndLazyDocument()
-        ann = createTestAnnotationForPages "a1", [1]
         anchor = am.createAnchor(ann, ann.target[0]).result
 
         assert.notOk anchor.highlight[1], "Should not have a highlight on page 1"
 
       it 'announces no highlihts', ->
-        am = createAnchoringManagerAndLazyDocument()
-        ann = createTestAnnotationForPages "a1", [1]
         am.annotator.publish.reset()
         anchor = am.createAnchor(ann, ann.target[0]).result
 
@@ -437,15 +405,11 @@ describe 'Annotator.Plugin.EnhancedAnchoring', ->
       describe 'when the pages are rendered later on', ->
 
         it 'realizes the anchor', ->
-          am = createAnchoringManagerAndLazyDocument()
-          ann = createTestAnnotationForPages "a1", [1]
           anchor = am.createAnchor(ann, ann.target[0]).result
           renderPage(am.document, 1).then ->
             assert anchor.fullyRealized
 
         it 'creates the highlight', ->
-          am = createAnchoringManagerAndLazyDocument()
-          ann = createTestAnnotationForPages "a1", [1]
           anchor = am.createAnchor(ann, ann.target[0]).result
           renderPage(am.document, 1).then ->
             hl = anchor.highlight[1]
@@ -453,8 +417,6 @@ describe 'Annotator.Plugin.EnhancedAnchoring', ->
             assert.calledWith am.annotator.publish, 'highlightsCreated', [hl]
 
         it 'announces the highlight', ->
-          am = createAnchoringManagerAndLazyDocument()
-          ann = createTestAnnotationForPages "a1", [1]
           anchor = am.createAnchor(ann, ann.target[0]).result
           renderPage(am.document, 1).then ->
             hl = anchor.highlight[1]
@@ -462,34 +424,29 @@ describe 'Annotator.Plugin.EnhancedAnchoring', ->
 
     describe 'when an anchor spans several pages, some of them rendered', ->
 
+      beforeEach ->
+        ann = createTestAnnotationForPages "a1", [[2,3]]
+
       it 'creates partially realized anchors', ->
-        am = createAnchoringManagerAndLazyDocument()
         renderPage(am.document, 2).then ->
-          ann = createTestAnnotationForPages "a1", [[2,3]]
           anchor = am.createAnchor(ann, ann.target[0]).result
 
           assert !anchor.fullyRealized
 
       it 'creates the highlights for the rendered pages', ->
-        am = createAnchoringManagerAndLazyDocument()
         renderPage(am.document, 2).then ->
-          ann = createTestAnnotationForPages "a1", [[2,3]]
           anchor = am.createAnchor(ann, ann.target[0]).result
 
           assert.ok anchor.highlight[2]
 
       it 'creates no highlights for the missing pages', ->
-        am = createAnchoringManagerAndLazyDocument()
         renderPage(am.document, 2).then ->
-          ann = createTestAnnotationForPages "a1", [[2,3]]
           anchor = am.createAnchor(ann, ann.target[0]).result
 
           assert.notOk anchor.highlight[3]
 
       it 'announces the creation of highlights for the rendered pages', ->
-        am = createAnchoringManagerAndLazyDocument()
         renderPage(am.document, 2).then ->
-          ann = createTestAnnotationForPages "a1", [[2,3]]
           anchor = am.createAnchor(ann, ann.target[0]).result
 
           assert.calledWith am.annotator.publish,
@@ -498,27 +455,21 @@ describe 'Annotator.Plugin.EnhancedAnchoring', ->
       describe 'when the missing pages are rendered', ->
 
         it 'the anchor is fully realized', ->
-          am = createAnchoringManagerAndLazyDocument()
           renderPage(am.document, 2).then ->
-            ann = createTestAnnotationForPages "a1", [[2,3]]
             anchor = am.createAnchor(ann, ann.target[0]).result
             renderPage(am.document, 3).then ->
 
               assert anchor.fullyRealized
 
         it 'creates the missing highlights', ->
-          am = createAnchoringManagerAndLazyDocument()
           renderPage(am.document, 2).then ->
-            ann = createTestAnnotationForPages "a1", [[2,3]]
             anchor = am.createAnchor(ann, ann.target[0]).result
             renderPage(am.document, 3).then ->
 
               assert.ok anchor.highlight[3]
 
         it 'announces the creation of the missing highlights', ->
-          am = createAnchoringManagerAndLazyDocument()
           renderPage(am.document, 2).then ->
-            ann = createTestAnnotationForPages "a1", [[2,3]]
             anchor = am.createAnchor(ann, ann.target[0]).result
 
             renderPage(am.document, 3).then ->
@@ -526,12 +477,13 @@ describe 'Annotator.Plugin.EnhancedAnchoring', ->
               assert.calledWith am.annotator.publish,
                 'highlightsCreated', [anchor.highlight[3]]
 
-    describe 'when an achor spans several pages, and a page is unrendered', ->
+    describe 'when an anchor spans several pages, and a page is unrendered', ->
+
+      beforeEach ->
+        ann = createTestAnnotationForPages "a1", [[2,3]]
 
       it 'calls removeFromDocument() on the involved highlight', ->
-        am = createAnchoringManagerAndLazyDocument()
         renderPages(am.document, [2,3]).then ->
-          ann = createTestAnnotationForPages "a1", [[2,3]]
           anchor = am.createAnchor(ann, ann.target[0]).result
           hl = anchor.highlight[2]
           unrenderPage(am.document, 2).then ->
@@ -539,9 +491,7 @@ describe 'Annotator.Plugin.EnhancedAnchoring', ->
             assert.called hl.removeFromDocument
 
       it 'does not call removeFromDocument() on the other highlights', ->
-        am = createAnchoringManagerAndLazyDocument()
         renderPages(am.document, [2,3]).then ->
-          ann = createTestAnnotationForPages "a1", [[2,3]]
           anchor = am.createAnchor(ann, ann.target[0]).result
           hl = anchor.highlight[3]
           unrenderPage(am.document, 2).then ->
@@ -549,27 +499,21 @@ describe 'Annotator.Plugin.EnhancedAnchoring', ->
             assert.notCalled hl.removeFromDocument
 
       it 'removes the involved highlight', ->
-        am = createAnchoringManagerAndLazyDocument()
         renderPages(am.document, [2, 3]).then ->
-          ann = createTestAnnotationForPages "a1", [[2,3]]
           anchor = am.createAnchor(ann, ann.target[0]).result
           unrenderPage(am.document, 2).then ->
 
             assert.notOk anchor.highlight[2]
 
       it 'retains the other highlights', ->
-        am = createAnchoringManagerAndLazyDocument()
         renderPages(am.document, [2,3]).then ->
-          ann = createTestAnnotationForPages "a1", [[2,3]]
           anchor = am.createAnchor(ann, ann.target[0]).result
           unrenderPage(am.document, 2).then ->
 
           assert.ok anchor.highlight[3]
 
       it 'announces the removal of the involved highlight', ->
-        am = createAnchoringManagerAndLazyDocument()
         renderPages(am.document, [2, 3]).then ->
-          ann = createTestAnnotationForPages "a1", [[2,3]]
           anchor = am.createAnchor(ann, ann.target[0]).result
           hl = anchor.highlight[2]
           unrenderPage(am.document, 2).then ->
@@ -577,9 +521,7 @@ describe 'Annotator.Plugin.EnhancedAnchoring', ->
             assert.calledWith am.annotator.publish, 'highlightRemoved', hl
 
       it 'switched the anchor to virtual', ->
-        am = createAnchoringManagerAndLazyDocument()
         renderPages(am.document, [2, 3]).then ->
-          ann = createTestAnnotationForPages "a1", [[2,3]]
           anchor = am.createAnchor(ann, ann.target[0]).result
           hl = anchor.highlight[2]
           unrenderPage(am.document, 2).then ->
@@ -588,10 +530,11 @@ describe 'Annotator.Plugin.EnhancedAnchoring', ->
 
     describe 'manually virtualizing an anchor', ->
 
+      beforeEach ->
+        ann = createTestAnnotationForPages "a1", [1]
+
       it 'calls removeFromDocument() on the highlight', ->
-        am = createAnchoringManagerAndLazyDocument()
         renderPage(am.document, 1).then ->
-          ann = createTestAnnotationForPages "a1", [1]
           anchor = am.createAnchor(ann, ann.target[0]).result
           hl = anchor.highlight[1]
           anchor.virtualize 1
@@ -599,18 +542,14 @@ describe 'Annotator.Plugin.EnhancedAnchoring', ->
           assert.called hl.removeFromDocument
 
       it 'removes the highlight', ->
-        am = createAnchoringManagerAndLazyDocument()
         renderPage(am.document, 1).then ->
-          ann = createTestAnnotationForPages "a1", [1]
           anchor = am.createAnchor(ann, ann.target[0]).result
           anchor.virtualize 1
 
           assert.notOk anchor.highlight[1], "the highlight should be no more"
 
       it 'announces the removal of the highlight', ->
-        am = createAnchoringManagerAndLazyDocument()
         renderPage(am.document, 1).then ->
-          ann = createTestAnnotationForPages "a1", [1]
           anchor = am.createAnchor(ann, ann.target[0]).result
           hl = anchor.highlight[1]
           anchor.virtualize 1
@@ -618,9 +557,7 @@ describe 'Annotator.Plugin.EnhancedAnchoring', ->
           assert.calledWith am.annotator.publish, 'highlightRemoved', hl
 
       it 'switches the anchor to virtual', ->
-        am = createAnchoringManagerAndLazyDocument()
         renderPage(am.document, 1).then ->
-          ann = createTestAnnotationForPages "a1", [1]
           anchor = am.createAnchor(ann, ann.target[0]).result
           anchor.virtualize 1
 
@@ -629,9 +566,7 @@ describe 'Annotator.Plugin.EnhancedAnchoring', ->
       describe 'when re-realizing a manually virtualized anchor', ->
 
         it 're-creates the highlight', ->
-          am = createAnchoringManagerAndLazyDocument()
           renderPage(am.document, 1).then ->
-            ann = createTestAnnotationForPages "a1", [1]
             anchor = am.createAnchor(ann, ann.target[0]).result
             anchor.virtualize 1
             anchor.realize()
@@ -639,9 +574,7 @@ describe 'Annotator.Plugin.EnhancedAnchoring', ->
             assert.ok anchor.highlight[1]
 
         it 'announces the creation of the highlight', ->
-          am = createAnchoringManagerAndLazyDocument()
           renderPage(am.document, 1).then ->
-            ann = createTestAnnotationForPages "a1", [1]
             anchor = am.createAnchor(ann, ann.target[0]).result
             anchor.virtualize 1
             anchor.realize()
@@ -650,9 +583,7 @@ describe 'Annotator.Plugin.EnhancedAnchoring', ->
             assert.calledWith am.annotator.publish, 'highlightsCreated', [hl]
 
         it 'realizes the anchor', ->
-          am = createAnchoringManagerAndLazyDocument()
           renderPage(am.document, 1).then ->
-            ann = createTestAnnotationForPages "a1", [1]
             anchor = am.createAnchor(ann, ann.target[0]).result
             anchor.virtualize 1
             anchor.realize()
@@ -665,9 +596,10 @@ describe 'Annotator.Plugin.EnhancedAnchoring', ->
         new Promise (resolve, reject) ->
           pendingTest = resolve: resolve
 
-      it 'scrolls right next to the wanted page (to get it rendered)', ->
-        am = createAnchoringManagerAndLazyDocument()
+      beforeEach ->
         ann = createTestAnnotationForPages "a1", [10]
+
+      it 'scrolls right next to the wanted page (to get it rendered)', ->
         anchor = am.createAnchor(ann, ann.target[0]).result
         am.document.currentIndex = 5  # We start from page 5
         am.document.setPageIndex = sinon.spy()
@@ -676,8 +608,6 @@ describe 'Annotator.Plugin.EnhancedAnchoring', ->
         assert.calledWith am.document.setPageIndex, 9
 
       it 'gets the wanted page rendered', ->
-        am = createAnchoringManagerAndLazyDocument()
-        ann = createTestAnnotationForPages "a1", [10]
         anchor = am.createAnchor(ann, ann.target[0]).result
         am.document.currentIndex = 5  # We start from page 5
         am.document.setPageIndex = sinon.spy (index) ->
@@ -691,8 +621,6 @@ describe 'Annotator.Plugin.EnhancedAnchoring', ->
           assert am.document.isPageMapped 10
 
       it 'calls scrollToView() on the highlight', ->
-        am = createAnchoringManagerAndLazyDocument()
-        ann = createTestAnnotationForPages "a1", [10]
         anchor = am.createAnchor(ann, ann.target[0]).result
         am.document.currentIndex = 5  # We start from page 5
         am.document.setPageIndex = sinon.spy (index) ->

--- a/tests/js/plugin/enhancedanchoring-test.coffee
+++ b/tests/js/plugin/enhancedanchoring-test.coffee
@@ -125,10 +125,8 @@ describe 'Annotator.Plugin.EnhancedAnchoring', ->
 
       it 'announces the creation of the highlights in an event', ->
         am = createAnchoringManager()
-
-        assert.notCalled am.annotator.publish
-
         ann = createTestAnnotation "a1"
+        am.annotator.publish.reset()
         anchor = am.createAnchor(ann, ann.target[0]).result
 
         hl = anchor.highlight[anchor.startPage]
@@ -431,6 +429,7 @@ describe 'Annotator.Plugin.EnhancedAnchoring', ->
       it 'announces no highlihts', ->
         am = createAnchoringManagerAndLazyDocument()
         ann = createTestAnnotationForPages "a1", [1]
+        am.annotator.publish.reset()
         anchor = am.createAnchor(ann, ann.target[0]).result
 
         assert.notCalled am.annotator.publish

--- a/tests/js/plugin/texthighlight-test.coffee
+++ b/tests/js/plugin/texthighlight-test.coffee
@@ -62,7 +62,7 @@ describe 'Annotator.Plugin.TextHighlight', ->
 
   describe "scrollIntoView", ->
 
-    it 'actually calls jQuery scrollintoviews', ->
+    it 'calls jQuery scrollintoview', ->
       hl = createTestHighlight()
       hl.scrollIntoView()
       assert.called jqElement.scrollintoview

--- a/tests/js/plugin/texthighlight-test.coffee
+++ b/tests/js/plugin/texthighlight-test.coffee
@@ -1,0 +1,78 @@
+assert = chai.assert
+sinon.assert.expose(assert, prefix: '')
+
+# In order to be able to create highlights,
+# the Annotator.TextHighlight class must exist.
+# This class is registered then the TextHighlights plugin
+# is initialized, so we will do that.
+th = new Annotator.Plugin.TextHighlights()
+th.pluginInit()
+
+describe 'Annotator.Plugin.TextHighlight', ->
+  sandbox = null
+  jqElement = null
+  scrollTarget = null
+
+  createTestHighlight = ->
+    anchor =
+      id: "test anchor"
+      annotation: "test annotation"
+      anchoring:
+        id: "test anchoring manager"
+        annotator:
+          id: "test annotator"
+          element:
+            delegate: sinon.spy()
+
+    new Annotator.TextHighlight anchor, "test page", "test range"
+
+  beforeEach ->
+    sandbox = sinon.sandbox.create()
+    sandbox.stub Annotator.TextHighlight, 'highlightRange',
+      (normedRange, cssClass) -> "test highlight span"
+
+    sandbox.stub Annotator.$.fn, "init", (selector, context) ->
+      jqElement =
+        selector: selector
+        data: sinon.spy()
+        scrollintoview: sinon.spy (options) ->
+          scrollTarget = this.selector
+          options?.complete?()
+
+  afterEach ->
+    sandbox.restore()
+    scrollTarget = null
+
+  describe "constructor", ->
+    it 'wraps a highlight span around the given range', ->
+      hl = createTestHighlight()
+      assert.calledWith Annotator.TextHighlight.highlightRange, "test range"
+
+    it 'stores the created highlight spans in _highlights', ->
+      hl = createTestHighlight()
+      assert.equal hl._highlights, "test highlight span"
+
+    it "wraps a jQuery element around the highlight span", ->
+      hl = createTestHighlight()
+      assert.equal jqElement.selector, "test highlight span"
+
+    it "assigns the annotation as data to the highlight span", ->
+      hl = createTestHighlight()
+      assert.calledWith jqElement.data, "annotation", "test annotation"
+
+  describe "scrollIntoView", ->
+
+    it 'actually calls jQuery scrollintoviews', ->
+      hl = createTestHighlight()
+      hl.scrollIntoView()
+      assert.called jqElement.scrollintoview
+
+    it 'scrolls to the created highlight span', ->
+      hl = createTestHighlight()
+      hl.scrollIntoView()
+      assert.equal scrollTarget, hl._highlights
+
+    it 'resolves the promise after scrolling', ->
+      hl = createTestHighlight()
+      hl.scrollIntoView().then ->
+        assert.ok scrollTarget

--- a/tests/js/plugin/texthighlight-test.coffee
+++ b/tests/js/plugin/texthighlight-test.coffee
@@ -10,7 +10,6 @@ th.pluginInit()
 
 describe 'Annotator.Plugin.TextHighlight', ->
   sandbox = null
-  jqElement = null
   scrollTarget = null
 
   createTestHighlight = ->
@@ -29,15 +28,14 @@ describe 'Annotator.Plugin.TextHighlight', ->
   beforeEach ->
     sandbox = sinon.sandbox.create()
     sandbox.stub Annotator.TextHighlight, 'highlightRange',
-      (normedRange, cssClass) -> "test highlight span"
+      (normedRange, cssClass) ->
+        hl = document.createElement "hl"
+        hl.appendChild document.createTextNode "test highlight span"
+        hl
 
-    sandbox.stub Annotator.$.fn, "init", (selector, context) ->
-      jqElement =
-        selector: selector
-        data: sinon.spy()
-        scrollintoview: sinon.spy (options) ->
-          scrollTarget = this.selector
-          options?.complete?()
+    Annotator.$.fn.scrollintoview = sinon.spy (options) ->
+      scrollTarget = this[0]
+      options?.complete?()
 
   afterEach ->
     sandbox.restore()
@@ -50,22 +48,19 @@ describe 'Annotator.Plugin.TextHighlight', ->
 
     it 'stores the created highlight spans in _highlights', ->
       hl = createTestHighlight()
-      assert.equal hl._highlights, "test highlight span"
-
-    it "wraps a jQuery element around the highlight span", ->
-      hl = createTestHighlight()
-      assert.equal jqElement.selector, "test highlight span"
+      assert.equal hl._highlights.textContent, "test highlight span"
 
     it "assigns the annotation as data to the highlight span", ->
       hl = createTestHighlight()
-      assert.calledWith jqElement.data, "annotation", "test annotation"
+      annotation = $(hl._highlights).data "annotation"
+      assert.equal annotation, "test annotation"
 
   describe "scrollIntoView", ->
 
     it 'calls jQuery scrollintoview', ->
       hl = createTestHighlight()
       hl.scrollIntoView()
-      assert.called jqElement.scrollintoview
+      assert.called Annotator.$.fn.scrollintoview
 
     it 'scrolls to the created highlight span', ->
       hl = createTestHighlight()

--- a/tests/js/plugin/texthighlight-test.coffee
+++ b/tests/js/plugin/texthighlight-test.coffee
@@ -55,19 +55,14 @@ describe 'Annotator.Plugin.TextHighlight', ->
       annotation = $(hl._highlights).data "annotation"
       assert.equal annotation, "test annotation"
 
-  describe "scrollIntoView", ->
+  describe "scrollToView", ->
 
     it 'calls jQuery scrollintoview', ->
       hl = createTestHighlight()
-      hl.scrollIntoView()
+      hl.scrollToView()
       assert.called Annotator.$.fn.scrollintoview
 
     it 'scrolls to the created highlight span', ->
       hl = createTestHighlight()
-      hl.scrollIntoView()
+      hl.scrollToView()
       assert.equal scrollTarget, hl._highlights
-
-    it 'resolves the promise after scrolling', ->
-      hl = createTestHighlight()
-      hl.scrollIntoView().then ->
-        assert.ok scrollTarget


### PR DESCRIPTION
This PR is an updated version of of https://github.com/hypothesis/h/pull/1950.

Adding a minimal test suite here for the TextHighlight implementation.

Also changing the scrolling API according to @tilgovi's suggestions, 
in order to avoid any false appearance that we are implementing
the proposed scrollIntoView() API [1], while we clearly don't.

[1] http://dev.w3.org/csswg/cssom-view/#dom-element-scrollintoview