### PR TITLE
Disable extremely slow auto-update of ancient timestamps

### DIFF
--- a/h/static/scripts/directives/annotation.coffee
+++ b/h/static/scripts/directives/annotation.coffee
@@ -237,7 +237,6 @@ AnnotationController = [
     updateTimestamp = (repeat=false) =>
       @timestamp = timeHelpers.toFuzzyString model.updated
       fuzzyUpdate = timeHelpers.nextFuzzyUpdate model.updated
-      fuzzyUpdate = 5 if fuzzyUpdate < 5  # minimum 5 seconds
       nextUpdate = (1000 * fuzzyUpdate) + 500
       return unless repeat
       $timeout =>

--- a/h/static/scripts/helpers/time-helpers.coffee
+++ b/h/static/scripts/helpers/time-helpers.coffee
@@ -49,7 +49,15 @@ createTimeHelpers = ->
     return null if not date
     {_, breakpoint} = getBreakpoint(date)
     return null unless breakpoint
-    return breakpoint[2]
+    secs = breakpoint[2]
+
+    # We don't want to refresh anything more often than 5 seconds
+    secs = Math.max secs, 5
+
+    # setTimeout limit is MAX_INT32=(2^31-1) (in ms),
+    # which is about 24.8 days. So we don't set up any timeouts
+    # longer than 24 days, that is, 2073600 seconds.
+    secs = Math.min secs, 2073600
 
 angular.module('h.helpers')
 .factory('timeHelpers', createTimeHelpers)

--- a/tests/js/helpers/time-helpers-test.coffee
+++ b/tests/js/helpers/time-helpers-test.coffee
@@ -21,16 +21,16 @@ FIXTURES_TO_FUZZY_STRING = [
 ]
 
 FIXTURES_NEXT_FUZZY_UPDATE = [
-  [10, 1]
-  [29, 1]
-  [49, 1]
+  [10, 5] # we have a minimum of 5 secs
+  [29, 5]
+  [49, 5]
   [minute + 5, minute]
   [3 * minute + 5, minute]
   [4 * hour, hour]
   [27 * hour, day]
   [3 * day + 30 * minute, day]
-  [6 * month + 2 * day, month]
-  [8 * year, year]
+  [6 * month + 2 * day, 24 * day] # longer times are not supported
+  [8 * year, 24 * day]            # by setTimout
 ]
 
 describe 'timeHelpers', ->


### PR DESCRIPTION
In theory, this removes our ability to update
timestamps that are several months old, and we leave
them around in a browser tab for weeks.

In practice, this fixes #1952.

   * * *

As suggested by @tilgovi [here](https://github.com/hypothesis/h/issues/1952#issuecomment-74747913).