### PR TITLE
Make user.id return the user's username

### DIFF
--- a/h/accounts/models.py
+++ b/h/accounts/models.py
@@ -42,6 +42,9 @@ class Group(GroupMixin, Base):
 
 
 class User(UserMixin, Base):
+    # Database primary key
+    _id = sa.Column('id', sa.Integer, autoincrement=True, primary_key=True)
+
     # Normalised user identifier
     uid = sa.Column(sa.Unicode(30), nullable=False, unique=True)
     # Username as chosen by the user on registration
@@ -56,6 +59,12 @@ class User(UserMixin, Base):
     def _set_username(self, value):
         self._username = value
         self.uid = _username_to_uid(value)
+
+    @declared_attr
+    def id(self):
+        return sa.orm.synonym('_username',
+                              descriptor=property(self._get_username,
+                                                  self._set_username))
 
     @declared_attr
     def username(self):

--- a/h/accounts/test/models_test.py
+++ b/h/accounts/test/models_test.py
@@ -8,6 +8,13 @@ from .. import models
 
 
 class TestUser(object):
+    def test_user_id_is_username(self):
+        fred = models.User(username='fredbloggs',
+                           email='fred@example.com',
+                           password='123')
+
+        assert fred.id == 'fredbloggs'
+
     def test_cannot_create_dot_variant_of_user(self, db_session):
         fred = models.User(username='fredbloggs',
                            email='fred@example.com',


### PR DESCRIPTION
We use the username exclusively as the user identifier, while [horus uses `user.id` to autologin on registration](https://github.com/eventray/horus/blob/b77190623b16486aa8250ef19b9580fcdac695c3/horus/views/__init__.py#L425).

Fixes #1947.