### PR TITLE
Move accounts behind a feature flag

### DIFF
--- a/development.ini
+++ b/development.ini
@@ -11,6 +11,7 @@ es.host: http://localhost:9200
 
 h.autologin: True
 
+h.feature.accounts: True
 h.feature.api: True
 h.feature.streamer: True
 h.feature.notification: False
@@ -27,7 +28,6 @@ mail.default_sender: "Annotation Daemon" <no-reply@localhost>
 pyramid.debug_all: True
 pyramid.reload_templates: True
 pyramid.includes:
-    h.accounts
     h.session
     pyramid_basemodel
     pyramid_debugtoolbar

--- a/h/app.py
+++ b/h/app.py
@@ -21,6 +21,9 @@ def create_app(settings):
     config.include('.')
     config.include('.features')
 
+    if config.registry.feature('accounts'):
+        config.include('.accounts')
+
     if config.registry.feature('api'):
         api_app = create_api(settings)
         api_view = wsgiapp2(api_app)

--- a/production.ini
+++ b/production.ini
@@ -18,6 +18,7 @@ use: egg:h
 #h.client_secret:
 
 # Feature flags
+h.feature.accounts: True
 h.feature.api: True
 h.feature.streamer: True
 h.feature.notification: True
@@ -38,7 +39,6 @@ mail.default_sender: "Annotation Daemon" <no-reply@localhost>
 
 # Include any deployment-specific pyramid add-ons here
 pyramid.includes:
-    h.accounts
     pyramid_basemodel
     pyramid_mailer
     pyramid_redis_sessions


### PR DESCRIPTION
An unfortunate side effect of embedding the API implicitly as a
separate Pyramid app when the 'api' feature is turned on is that
we have no idea which includes to pass to this sub-app. Sidestep
the issue for the moment by just removing the one default include
we know to be totally inappropriate for inclusion in the API app:
the accounts system.