### PR TITLE
Fix og:title output; Handle list or string value

### DIFF
--- a/h/static/scripts/vendor/annotator.document.js
+++ b/h/static/scripts/vendor/annotator.document.js
@@ -156,15 +156,15 @@
       if (this.metadata.highwire.title) {
         return this.metadata.title = this.metadata.highwire.title[0];
       } else if (this.metadata.eprints.title) {
-        return this.metadata.title = this.metadata.eprints.title;
+        return this.metadata.title = this.metadata.eprints.title[0];
       } else if (this.metadata.prism.title) {
-        return this.metadata.title = this.metadata.prism.title;
+        return this.metadata.title = this.metadata.prism.title[0];
       } else if (this.metadata.facebook.title) {
-        return this.metadata.title = this.metadata.facebook.title;
+        return this.metadata.title = this.metadata.facebook.title[0];
       } else if (this.metadata.twitter.title) {
-        return this.metadata.title = this.metadata.twitter.title;
+        return this.metadata.title = this.metadata.twitter.title[0];
       } else if (this.metadata.dc.title) {
-        return this.metadata.title = this.metadata.dc.title;
+        return this.metadata.title = this.metadata.dc.title[0];
       } else {
         return this.metadata.title = $("head title").text();
       }


### PR DESCRIPTION
Not sure when this changed from one to the other
(there is evidence of both), but this handles
both scenarios.

Without this document tiles for list format come out as the stringified list: `[u'The page title']` A bit sub par for sharing on social networks...