### PR TITLE
Fix notifications

### DIFF
--- a/h/app.py
+++ b/h/app.py
@@ -80,6 +80,15 @@ def create_api(settings):
     if config.registry.feature('streamer'):
         config.include('.streamer')
 
+    if config.registry.feature('notification'):
+        config.include('pyramid_jinja2')
+        config.add_jinja2_renderer('.txt')
+        config.add_jinja2_renderer('.html')
+
+        # FIXME: move subscribers into .notification.subscribers so we don't
+        # have to include the whole package
+        config.include('.notification')
+
     return config.make_wsgi_app()
 
 

--- a/h/notification/models.py
+++ b/h/notification/models.py
@@ -4,9 +4,11 @@ import sqlalchemy as sa
 from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy import func, and_
 
-from pyramid_basemodel import Base
 from hem.db import get_session
+from hem.interfaces import IDBSession
 from horus.models import BaseModel
+from pyramid_basemodel import Base
+from pyramid_basemodel import Session
 
 log = logging.getLogger(__name__)
 
@@ -69,4 +71,9 @@ class Subscriptions(SubscriptionsMixin, Base):
 
 
 def includeme(config):
+    registry = config.registry
+
+    if not registry.queryUtility(IDBSession):
+        registry.registerUtility(Session, IDBSession)
+
     config.scan(__name__)

--- a/h/notification/reply_template.py
+++ b/h/notification/reply_template.py
@@ -30,9 +30,6 @@ SUBJECT_TEMPLATE = ROOT_PATH + 'reply_notification_subject.txt'
 def parent_values(annotation):
     if 'references' in annotation:
         parent = Annotation.fetch(annotation['references'][-1])
-        if 'references' in parent:
-            grandparent = Annotation.fetch(parent['references'][-1])
-            parent['quote'] = grandparent['text']
         return parent
     else:
         return {}

--- a/h/notification/test/reply_template_test.py
+++ b/h/notification/test/reply_template_test.py
@@ -85,7 +85,6 @@ def test_parent_values_reply():
         parent = rt.parent_values(annotation)
 
         assert parent['id'] == '0'
-        assert 'quote' not in parent
 
 
 def test_parent_values_root_annotation():
@@ -96,17 +95,6 @@ def test_parent_values_root_annotation():
         parent = rt.parent_values(annotation)
 
         assert len(parent.items()) == 0
-
-
-def test_parent_values_second_level_reply():
-    """Test if it the grandparent values are filled for a second level reply"""
-    with patch('h.notification.reply_template.Annotation') as mock_annotation:
-        mock_annotation.fetch = MagicMock(side_effect=fake_fetch)
-        annotation = store_fake_data[2]
-        parent = rt.parent_values(annotation)
-
-        assert parent['id'] == '1'
-        assert parent['quote'] == store_fake_data[0]['text']
 
 
 # Tests for the create_template_map function


### PR DESCRIPTION
Email notifications are currently broken in production. This PR fixes them.

The `h.notification package` contains subscribers for `h.events.AnnotationEvent`, which send reply notification emails when new replies are created.

Because the API is now an isolated WSGI application, it does not share a registry with the main application. As such, we need to explicitly include the notification package in the API application so that its subscribers are correctly called when annotations are created through the API.

This restores email notification functionality broken by 29c1500.