### PR TITLE
Refine extension differentiators

### DIFF
--- a/h/views.py
+++ b/h/views.py
@@ -5,7 +5,6 @@ import re
 
 from pyramid import httpexceptions
 from pyramid.events import ContextFound
-from pyramid.settings import asbool
 from pyramid.view import forbidden_view_config, notfound_view_config
 from pyramid.view import view_config
 
@@ -56,26 +55,8 @@ def annotation(context, request):
 
 @view_config(name='embed.js', renderer='h:templates/embed.js')
 def js(context, request):
-    settings = request.registry.settings
     request.response.content_type = b'text/javascript'
-
-    appstruct = {}
-
-    # If we are building a browser extension when rendering embed.js, we may
-    # need to link to the app.html embedded within the extension rather than
-    # the one hosted by the application.
-    #
-    # FIXME: remove this hack
-    if asbool(settings.get('h.use_bundled_app_html')):
-        # A base URL of http://example.com/public means that app.html will be
-        # at http://example.com/public/app.html, so make sure we append the
-        # trailing slash as necessary.
-        base = request.webassets_env.url
-        if not base.endswith('/'):
-            base += '/'
-        appstruct['app_html'] = base + 'app.html'
-
-    return appstruct
+    return {}
 
 
 @view_config(layout='app', name='app.html', renderer='h:templates/app.html')


### PR DESCRIPTION
Improve the way the different extension builds are factored and
supported:

- Get rid of use_bundled_app_html. The buildext script uses the
  renderer directly to render the embed code with the right URL
  and the template falls back naturally to using the default.
  Views are simplified.

- Make all the subdirs of each browser that need to be copied
  explicit, rather than cleaning up after a blind copy such as was
  done with the tests.

- Ensure Firefox vendor assets are not minified.

- Avoid chdir dances.

Close #1956