### PR TITLE
Thread collapse clarity (and code clarity improvements)

### DIFF
--- a/h/static/scripts/directives/test/thread-test.coffee
+++ b/h/static/scripts/directives/test/thread-test.coffee
@@ -42,33 +42,163 @@ describe 'h:directives.thread', ->
         controller.toggleCollapsed(false)
         assert.isFalse(controller.collapsed)
 
-    describe '#shouldShowReply', ->
+    describe '#shouldShowAsReply', ->
+      controller = null
+      count = null
+
+      beforeEach ->
+        controller = createController()
+        count = sinon.stub().returns(0)
+        controller.counter = {count: count}
+
+      it 'is true by default', ->
+        assert.isTrue(controller.shouldShowAsReply())
+
+      it 'is false when the parent thread is collapsed', ->
+        controller.parent = {collapsed: true}
+        assert.isFalse(controller.shouldShowAsReply())
+
+      describe 'when the thread contains edits', ->
+        beforeEach ->
+          count.withArgs('edit').returns(1)
+
+        it 'is true when the thread has no parent', ->
+          assert.isTrue(controller.shouldShowAsReply())
+
+        it 'is true when the parent thread is not collapsed', ->
+          controller.parent = {collapsed: false}
+          assert.isTrue(controller.shouldShowAsReply())
+
+        it 'is true when the parent thread is collapsed', ->
+          controller.parent = {collapsed: true}
+          assert.isTrue(controller.shouldShowAsReply())
+
+      describe 'when the thread filter is active', ->
+        beforeEach ->
+          controller.filter = {active: -> true}
+
+        it 'is false when there are no matches in the thread', ->
+          assert.isFalse(controller.shouldShowAsReply())
+
+        it 'is true when there are matches in the thread', ->
+          count.withArgs('match').returns(1)
+          assert.isTrue(controller.shouldShowAsReply())
+
+    describe '#shouldShowNumReplies', ->
       count = null
       controller = null
+      filterActive = false
 
       beforeEach ->
         controller = createController()
         count = sinon.stub()
+        controller.counter = {count: count}
+        controller.filter = {active: -> filterActive}
 
       describe 'when not filtered', ->
         it 'shows the reply if the thread has children', ->
           count.withArgs('message').returns(1)
-          assert.isTrue(controller.shouldShowReply(count, false))
+          assert.isTrue(controller.shouldShowNumReplies())
 
         it 'does not show the reply if the thread has no children', ->
           count.withArgs('message').returns(0)
-          assert.isFalse(controller.shouldShowReply(count, false))
+          assert.isFalse(controller.shouldShowNumReplies())
 
       describe 'when filtered with children', ->
+        beforeEach ->
+          filterActive = true
+
         it 'shows the reply', ->
           count.withArgs('match').returns(1)
           count.withArgs('message').returns(1)
-          assert.isTrue(controller.shouldShowReply(count, true))
+          assert.isTrue(controller.shouldShowNumReplies())
 
         it 'does not show the reply if the message count does not match the match count', ->
           count.withArgs('match').returns(0)
           count.withArgs('message').returns(1)
-          assert.isFalse(controller.shouldShowReply(count, true))
+          assert.isFalse(controller.shouldShowNumReplies())
+
+    describe '#numReplies', ->
+      controller = null
+
+      beforeEach ->
+        controller = createController()
+
+      it 'returns zero when there is no counter', ->
+        assert.equal(controller.numReplies(), 0)
+
+      it 'returns one less than the number of messages in the thread when there is a counter', ->
+        count = sinon.stub()
+        count.withArgs('message').returns(5)
+        controller.counter = {count: count}
+
+        assert.equal(controller.numReplies(), 4)
+
+    describe '#shouldShowLoadMore', ->
+      controller = null
+
+      beforeEach ->
+        controller = createController()
+
+      describe 'when the thread filter is not active', ->
+        it 'is false with an empty container', ->
+          assert.isFalse(controller.shouldShowLoadMore())
+
+        it 'is false when the container contains an annotation', ->
+          controller.container = {message: {id: 123}}
+          assert.isFalse(controller.shouldShowLoadMore())
+
+      describe 'when the thread filter is active', ->
+        beforeEach ->
+          controller.filter = {active: -> true}
+
+        it 'is false with an empty container', ->
+          assert.isFalse(controller.shouldShowLoadMore())
+
+        it 'is true when the container contains an annotation', ->
+          controller.container = {message: {id: 123}}
+          assert.isTrue(controller.shouldShowLoadMore())
+
+    describe '#loadMore', ->
+      controller = null
+
+      beforeEach ->
+        controller = createController()
+
+      it 'uncollapses the thread', ->
+        sinon.spy(controller, 'toggleCollapsed')
+        controller.loadMore()
+        assert.calledWith(controller.toggleCollapsed, false)
+
+      it 'uncollapses all the ancestors of the thread', ->
+        grandmother = {toggleCollapsed: sinon.stub()}
+        mother = {toggleCollapsed: sinon.stub()}
+        controller.parent = mother
+        controller.parent.parent = grandmother
+        controller.loadMore()
+        assert.calledWith(mother.toggleCollapsed, false)
+        assert.calledWith(grandmother.toggleCollapsed, false)
+
+      it 'deactivates the thread filter when present', ->
+        controller.filter = {active: sinon.stub()}
+        controller.loadMore()
+        assert.calledWith(controller.filter.active, false)
+
+    describe '#matchesFilter', ->
+      controller = null
+
+      beforeEach ->
+        controller = createController()
+
+      it 'is true by default', ->
+        assert.isTrue(controller.matchesFilter())
+
+      it 'checks with the thread filter to see if the root annotation matches', ->
+        check = sinon.stub().returns(false)
+        controller.filter = {check: check}
+        controller.container = {}
+        assert.isFalse(controller.matchesFilter())
+        assert.calledWith(check, controller.container)
 
 
   describe '.thread', ->

--- a/h/static/scripts/directives/test/thread-test.coffee
+++ b/h/static/scripts/directives/test/thread-test.coffee
@@ -5,27 +5,16 @@ sinon.assert.expose assert, prefix: null
 
 
 describe 'h:directives.thread', ->
-  fakeRender = null
-  sandbox = null
 
   before ->
     angular.module('h', [])
     require('../thread')
 
-  beforeEach module('h')
-
-  beforeEach module ($provide) ->
-    sandbox = sinon.sandbox.create()
-    fakeRender = sandbox.spy()
-    $provide.value 'render', fakeRender
-    return
-
-  afterEach ->
-    sandbox.restore()
-
   describe '.ThreadController', ->
     $scope = null
     createController = null
+
+    beforeEach module('h')
 
     beforeEach inject ($controller, $rootScope) ->
       $scope = $rootScope.$new()
@@ -120,18 +109,26 @@ describe 'h:directives.thread', ->
   describe '.thread', ->
     createElement = null
     $element = null
-    $isolateScope = null
     fakePulse = null
+    fakeRender = null
+    sandbox = null
+
+    beforeEach module('h')
 
     beforeEach module ($provide) ->
+      sandbox = sinon.sandbox.create()
       fakePulse = sandbox.spy()
+      fakeRender = sandbox.spy()
       $provide.value 'pulse', fakePulse
+      $provide.value 'render', fakeRender
       return
 
     beforeEach inject ($compile, $rootScope) ->
-      createElement = (html) -> $compile(html or '<div thread></div>')($rootScope.$new())
-      $element = createElement()
-      $isolateScope = $element.scope()
+      $element = $compile('<div thread></div>')($rootScope.$new())
+      $rootScope.$digest()
+
+    afterEach ->
+      sandbox.restore()
 
     it 'sets the threadRoot on the controller to false', ->
       controller = $element.controller('thread')

--- a/h/static/scripts/directives/test/thread-test.coffee
+++ b/h/static/scripts/directives/test/thread-test.coffee
@@ -50,71 +50,25 @@ describe 'h:directives.thread', ->
         controller = createController()
         count = sinon.stub()
 
-      describe 'when root', ->
-        beforeEach -> controller.isRoot = true
+      describe 'when not filtered', ->
+        it 'shows the reply if the thread has children', ->
+          count.withArgs('message').returns(1)
+          assert.isTrue(controller.shouldShowReply(count, false))
 
-        describe 'and when not filtered', ->
-          it 'shows the reply if the thread is not collapsed and has children', ->
-            count.withArgs('message').returns(1)
-            assert.isTrue(controller.shouldShowReply(count, false))
+        it 'does not show the reply if the thread has no children', ->
+          count.withArgs('message').returns(0)
+          assert.isFalse(controller.shouldShowReply(count, false))
 
-          it 'does not show the reply if the thread is not collapsed and has no children', ->
-            count.withArgs('message').returns(0)
-            assert.isFalse(controller.shouldShowReply(count, false))
+      describe 'when filtered with children', ->
+        it 'shows the reply', ->
+          count.withArgs('match').returns(1)
+          count.withArgs('message').returns(1)
+          assert.isTrue(controller.shouldShowReply(count, true))
 
-          it 'shows the reply if the thread is collapsed and has children', ->
-            count.withArgs('message').returns(1)
-            controller.toggleCollapsed(true)
-            assert.isTrue(controller.shouldShowReply(count, false))
-
-          it 'does not show the reply if the thread is collapsed and has no children', ->
-            count.withArgs('message').returns(0)
-            controller.toggleCollapsed(true)
-            assert.isFalse(controller.shouldShowReply(count, false))
-
-        describe 'and when filtered with children', ->
-          it 'shows the reply if the thread is not collapsed', ->
-            count.withArgs('match').returns(1)
-            count.withArgs('message').returns(1)
-            assert.isTrue(controller.shouldShowReply(count, true))
-
-          it 'does not show the reply if the thread is not collapsed and the message count does not match the match count', ->
-            count.withArgs('match').returns(0)
-            count.withArgs('message').returns(1)
-            assert.isFalse(controller.shouldShowReply(count, true))
-
-      describe 'when reply', ->
-        beforeEach -> controller.isRoot = false
-
-        describe 'and when not filtered', ->
-          it 'shows the reply if the thread is not collapsed and has children', ->
-            count.withArgs('message').returns(1)
-            assert.isTrue(controller.shouldShowReply(count, false))
-
-          it 'does not show the reply if the thread is not collapsed and has no children', ->
-            count.withArgs('message').returns(0)
-            assert.isFalse(controller.shouldShowReply(count, false))
-
-          it 'does not show the reply if the thread is collapsed and has children', ->
-            count.withArgs('message').returns(1)
-            controller.toggleCollapsed(true)
-            assert.isFalse(controller.shouldShowReply(count, false))
-
-          it 'does not show the reply if the thread is collapsed and has no children', ->
-            count.withArgs('message').returns(0)
-            controller.toggleCollapsed(true)
-            assert.isFalse(controller.shouldShowReply(count, false))
-
-        describe 'and when filtered with children', ->
-          it 'shows the reply if the thread is not collapsed', ->
-            count.withArgs('match').returns(1)
-            count.withArgs('message').returns(1)
-            assert.isTrue(controller.shouldShowReply(count, true))
-
-          it 'does not show the reply if the thread is not collapsed and the message count does not match the match count', ->
-            count.withArgs('match').returns(0)
-            count.withArgs('message').returns(1)
-            assert.isFalse(controller.shouldShowReply(count, true))
+        it 'does not show the reply if the message count does not match the match count', ->
+          count.withArgs('match').returns(0)
+          count.withArgs('message').returns(1)
+          assert.isFalse(controller.shouldShowReply(count, true))
 
 
   describe '.thread', ->
@@ -140,15 +94,6 @@ describe 'h:directives.thread', ->
 
     afterEach ->
       sandbox.restore()
-
-    it 'sets the threadRoot on the controller to false', ->
-      controller = $element.controller('thread')
-      assert.isFalse(controller.isRoot)
-
-    it 'sets the threadRoot on the controller to true when the thread-root attr is set', ->
-      $element = createElement('<div thread thread-root="true"></div>')
-      controller = $element.controller('thread')
-      assert.isTrue(controller.isRoot)
 
     it 'pulses the current thread on an annotationUpdated event', ->
       $element.scope().$emit('annotationUpdate')

--- a/h/static/scripts/directives/test/thread-test.coffee
+++ b/h/static/scripts/directives/test/thread-test.coffee
@@ -24,12 +24,23 @@ describe 'h:directives.thread', ->
         controller
 
     describe '#toggleCollapsed', ->
-      it 'sets the collapsed property', ->
+      it 'toggles whether or not the thread is collapsed', ->
         controller = createController()
         before = controller.collapsed
         controller.toggleCollapsed()
         after = controller.collapsed
         assert.equal(before, !after)
+
+      it 'can accept an argument to force a particular state', ->
+        controller = createController()
+        controller.toggleCollapsed(true)
+        assert.isTrue(controller.collapsed)
+        controller.toggleCollapsed(true)
+        assert.isTrue(controller.collapsed)
+        controller.toggleCollapsed(false)
+        assert.isFalse(controller.collapsed)
+        controller.toggleCollapsed(false)
+        assert.isFalse(controller.collapsed)
 
     describe '#shouldShowReply', ->
       count = null
@@ -53,12 +64,12 @@ describe 'h:directives.thread', ->
 
           it 'shows the reply if the thread is collapsed and has children', ->
             count.withArgs('message').returns(1)
-            controller.collapsed = true
+            controller.toggleCollapsed(true)
             assert.isTrue(controller.shouldShowReply(count, false))
 
           it 'does not show the reply if the thread is collapsed and has no children', ->
             count.withArgs('message').returns(0)
-            controller.collapsed = true
+            controller.toggleCollapsed(true)
             assert.isFalse(controller.shouldShowReply(count, false))
 
         describe 'and when filtered with children', ->
@@ -86,12 +97,12 @@ describe 'h:directives.thread', ->
 
           it 'does not show the reply if the thread is collapsed and has children', ->
             count.withArgs('message').returns(1)
-            controller.collapsed = true
+            controller.toggleCollapsed(true)
             assert.isFalse(controller.shouldShowReply(count, false))
 
           it 'does not show the reply if the thread is collapsed and has no children', ->
             count.withArgs('message').returns(0)
-            controller.collapsed = true
+            controller.toggleCollapsed(true)
             assert.isFalse(controller.shouldShowReply(count, false))
 
         describe 'and when filtered with children', ->

--- a/h/static/scripts/directives/thread-filter.coffee
+++ b/h/static/scripts/directives/thread-filter.coffee
@@ -143,7 +143,7 @@ ThreadFilterController = [
 threadFilter = [
   '$parse', 'searchfilter'
   ($parse,   searchfilter) ->
-    linkFn = (scope, elem, attrs, [ctrl, thread, counter]) ->
+    linkFn = (scope, elem, attrs, [ctrl, counter]) ->
       if counter?
         scope.$watch (-> ctrl.match), (match, old) ->
           if match and not old
@@ -169,7 +169,7 @@ threadFilter = [
     controller: 'ThreadFilterController'
     controllerAs: 'threadFilter'
     link: linkFn
-    require: ['threadFilter', 'thread', '?^deepCount']
+    require: ['threadFilter', '?^deepCount']
 ]
 
 

--- a/h/static/scripts/directives/thread.coffee
+++ b/h/static/scripts/directives/thread.coffee
@@ -14,12 +14,17 @@ ThreadController = [
   ->
     @container = null
     @collapsed = true
+    @parent = null
+    @counter = null
+    @filter = null
 
     ###*
     # @ngdoc method
     # @name thread.ThreadController#toggleCollapsed
     # @description
-    # Toggle the collapsed property.
+    # Toggle whether or not the replies to this thread are hidden by default.
+    # Note that the visibility of replies is also dependent on the state of the
+    # thread filter, if present.
     ###
     this.toggleCollapsed = (value) ->
       @collapsed = if value?
@@ -29,16 +34,113 @@ ThreadController = [
 
     ###*
     # @ngdoc method
-    # @name thread.ThreadController#shouldShowReply
+    # @name thread.ThreadController#shouldShowAsReply
     # @description
-    # Determines if the reply counter should be rendered. Requires the
-    # `count` directive to be passed and a boolean that indicates whether
-    # the thread is currently filtered.
+    # Return a boolean indicating whether this thread should be shown if it is
+    # being rendered as a reply to another annotation.
     ###
-    this.shouldShowReply = (count, isFilterActive) ->
-      hasChildren = count('message') > 0
-      hasFilterMatch = !isFilterActive || count('message') == count('match')
+    this.shouldShowAsReply = ->
+      shouldShowUnfiltered = not @parent?.collapsed
+      shouldShowFiltered = this._count('match') > 0
+
+      # We always show replies that contain an editor
+      if this._count('edit') > 0
+        return true
+
+      if this._isFilterActive()
+        return shouldShowFiltered
+      else
+        return shouldShowUnfiltered
+
+    ###*
+    # @ngdoc method
+    # @name thread.ThreadController#shouldShowNumReplies
+    # @description
+    # Returns a boolean indicating whether the reply count should be rendered
+    # for the annotation at the root of this thread.
+    ###
+    this.shouldShowNumReplies = ->
+      hasChildren = this._count('message') > 0
+      allRepliesShown = this._count('message') == this._count('match')
+      hasFilterMatch = !this._isFilterActive() || allRepliesShown
       hasChildren && hasFilterMatch
+
+    ###*
+    # @ngdoc method
+    # @name thread.ThreadController#numReplies
+    # @description
+    # Returns the cumulative number of replies to the annotation at the root of
+    # this thread.
+    ###
+    this.numReplies = ->
+      if @counter
+        this._count('message') - 1
+      else
+        0
+
+    ###*
+    # @ngdoc method
+    # @name thread.ThreadController#shouldShowLoadMore
+    # @description
+    # Return a boolean indicating whether the "load more" link should be shown
+    # for the annotation at the root of this thread. The "load more" link can be
+    # shown when the thread filter is active (although it may not be visible if
+    # no replies are hidden in this thread).
+    ###
+    this.shouldShowLoadMore = ->
+      this.container?.message?.id? and this._isFilterActive()
+
+    ###*
+    # @ngdoc method
+    # @name thread.ThreadController#numLoadMore
+    # @description
+    # Returns the number of replies in this thread which are currently hidden as
+    # a result of the thread filter.
+    ###
+    this.numLoadMore = ->
+      this._count('message') - this._count('match')
+
+    ###*
+    # @ngdoc method
+    # @name thread.ThreadController#loadMore
+    # @description
+    # Makes visible any replies in this thread which have been hidden by the
+    # thread filter.
+    ###
+    this.loadMore = ->
+      # If we want to show the rest of the replies in the thread, we need to
+      # uncollapse all parent threads.
+      ctrl = this
+      while ctrl
+        ctrl.toggleCollapsed(false)
+        ctrl = ctrl.parent
+      # Deactivate the thread filter for this thread.
+      @filter?.active(false)
+
+    ###*
+    # @ngdoc method
+    # @name thread.ThreadController#matchesFilter
+    # @description
+    # Returns a boolean indicating whether the annotation at the root of this
+    # thread is marked as a match by the current thread filter. If there is no
+    # thread filter attached to this thread, it will return true.
+    ###
+    this.matchesFilter = ->
+      if not @filter
+        return true
+      return @filter.check(@container)
+
+    this._isFilterActive = ->
+      if @filter
+        @filter.active()
+      else
+        false
+
+    this._count = (name) ->
+      if @counter
+        @counter.count(name)
+      else
+        0
 
     this
 ]
@@ -85,7 +187,13 @@ isHiddenThread = (elem) ->
 thread = [
   '$parse', '$window', 'pulse', 'render',
   ($parse,   $window,   pulse,   render) ->
-    linkFn = (scope, elem, attrs, [ctrl, counter]) ->
+    linkFn = (scope, elem, attrs, [ctrl, counter, filter]) ->
+
+      # We would ideally use require for this, but searching parents only for a
+      # controller is a feature of Angular 1.3 and above only.
+      ctrl.parent = elem.parent().controller('thread')
+      ctrl.counter = counter
+      ctrl.filter = filter
 
       # Toggle collapse on click.
       elem.on 'click', (event) ->
@@ -116,8 +224,6 @@ thread = [
       if counter?
         counter.count 'message', 1
         scope.$on '$destroy', -> counter.count 'message', -1
-      else
-        scope.count = -> 1
 
       # Flash the thread when any child annotations are updated.
       scope.$on 'annotationUpdate', (event) ->
@@ -144,7 +250,7 @@ thread = [
     controller: 'ThreadController'
     controllerAs: 'vm'
     link: linkFn
-    require: ['thread', '?^deepCount']
+    require: ['thread', '?^deepCount', '?^threadFilter']
     scope: true
 ]
 

--- a/h/static/scripts/directives/thread.coffee
+++ b/h/static/scripts/directives/thread.coffee
@@ -13,7 +13,7 @@
 ThreadController = [
   ->
     @container = null
-    @collapsed = false
+    @collapsed = true
 
     ###*
     # @ngdoc method

--- a/h/static/scripts/directives/thread.coffee
+++ b/h/static/scripts/directives/thread.coffee
@@ -26,8 +26,11 @@ ThreadController = [
     # @description
     # Toggle the collapsed property.
     ###
-    this.toggleCollapsed = ->
-      @collapsed = not @collapsed
+    this.toggleCollapsed = (value) ->
+      @collapsed = if value?
+                     !!value
+                   else
+                     not @collapsed
 
     ###*
     # @ngdoc method
@@ -160,7 +163,7 @@ thread = [
       # Watch the thread-collapsed attribute.
       if attrs.threadCollapsed
         scope.$watch $parse(attrs.threadCollapsed), (collapsed) ->
-          ctrl.toggleCollapsed() if !!collapsed != ctrl.collapsed
+          ctrl.toggleCollapsed(collapsed)
 
     controller: 'ThreadController'
     controllerAs: 'vm'

--- a/h/static/scripts/directives/thread.coffee
+++ b/h/static/scripts/directives/thread.coffee
@@ -1,7 +1,3 @@
-### global -COLLAPSED_CLASS ###
-
-COLLAPSED_CLASS = 'thread-collapsed'
-
 ###*
 # @ngdoc type
 # @name thread.ThreadController
@@ -85,10 +81,6 @@ isHiddenThread = (elem) ->
 # @restrict A
 # @description
 # Directive that instantiates {@link thread.ThreadController ThreadController}.
-#
-# If the `thread-collapsed` attribute is specified, it is treated as an
-# expression to watch in the context of the current scope that controls
-# the collapsed state of the thread.
 ###
 thread = [
   '$parse', '$window', 'pulse', 'render',
@@ -136,13 +128,6 @@ thread = [
         event.stopPropagation()
         pulse(elem)
 
-      # Add and remove the collapsed class when the collapsed property changes.
-      scope.$watch (-> ctrl.collapsed), (collapsed) ->
-        if collapsed
-          attrs.$addClass COLLAPSED_CLASS
-        else
-          attrs.$removeClass COLLAPSED_CLASS
-
       # The watch is necessary because the computed value of the attribute
       # expression may change. This won't happen when we use the thread
       # directive in a repeat, since the element will be torn down whenever the
@@ -155,11 +140,6 @@ thread = [
         render ->
           ctrl.container = thread
           scope.$digest()
-
-      # Watch the thread-collapsed attribute.
-      if attrs.threadCollapsed
-        scope.$watch $parse(attrs.threadCollapsed), (collapsed) ->
-          ctrl.toggleCollapsed(collapsed)
 
     controller: 'ThreadController'
     controllerAs: 'vm'

--- a/h/static/scripts/directives/thread.coffee
+++ b/h/static/scripts/directives/thread.coffee
@@ -18,7 +18,6 @@ ThreadController = [
   ->
     @container = null
     @collapsed = false
-    @isRoot = false
 
     ###*
     # @ngdoc method
@@ -41,10 +40,9 @@ ThreadController = [
     # the thread is currently filtered.
     ###
     this.shouldShowReply = (count, isFilterActive) ->
-      isCollapsedReply = (@collapsed && !@isRoot)
       hasChildren = count('message') > 0
       hasFilterMatch = !isFilterActive || count('message') == count('match')
-      !isCollapsedReply && hasChildren && hasFilterMatch
+      hasChildren && hasFilterMatch
 
     this
 ]
@@ -96,8 +94,6 @@ thread = [
   '$parse', '$window', 'pulse', 'render',
   ($parse,   $window,   pulse,   render) ->
     linkFn = (scope, elem, attrs, [ctrl, counter]) ->
-      # Determine if this is a top level thread.
-      ctrl.isRoot = $parse(attrs.threadRoot)(scope) == true
 
       # Toggle collapse on click.
       elem.on 'click', (event) ->

--- a/h/static/scripts/directives/thread.coffee
+++ b/h/static/scripts/directives/thread.coffee
@@ -125,6 +125,8 @@ thread = [
       if counter?
         counter.count 'message', 1
         scope.$on '$destroy', -> counter.count 'message', -1
+      else
+        scope.count = -> 1
 
       # Flash the thread when any child annotations are updated.
       scope.$on 'annotationUpdate', (event) ->

--- a/h/static/styles/threads.scss
+++ b/h/static/styles/threads.scss
@@ -17,7 +17,9 @@ $threadexp-width: .6em;
 }
 
 .thread-replies {
-  margin-top: 0.5em;
+  .thread:first-child {
+    margin-top: 0.5em;
+  }
 
   .thread-collapsed {
     .tag-list, .annotation-body {display: none;}

--- a/h/static/styles/threads.scss
+++ b/h/static/styles/threads.scss
@@ -20,11 +20,6 @@ $threadexp-width: .6em;
   .thread:first-child {
     margin-top: 0.5em;
   }
-
-  .thread-collapsed {
-    .tag-list, .annotation-body {display: none;}
-    .thread-reply { margin-top: 0 }
-  }
 }
 
 .thread-reply {
@@ -62,14 +57,6 @@ $threadexp-width: .6em;
     border-left: 1px dotted $gray-light;
     padding: 0;
     padding-left: $thread-padding;
-
-    &.thread-collapsed {
-      border-color: transparent;
-
-      & > article markdown {
-        display: none;
-      }
-    }
   }
 
   .threadexp {
@@ -94,19 +81,6 @@ $threadexp-width: .6em;
         top: 0;
         left: 0;
       }
-    }
-  }
-
-  &.thread-collapsed {
-    & > ul {
-      display: none;
-    }
-
-    & > .thread-message {
-      .thread &,
-      .thread & .annotation-header,
-      .thread & .annotation-section { margin: 0 }
-      .thread & footer { display: none }
     }
   }
 }

--- a/h/static/styles/threads.scss
+++ b/h/static/styles/threads.scss
@@ -16,7 +16,7 @@ $threadexp-width: .6em;
   }
 }
 
-.thread-list {
+.thread-replies {
   margin-top: 0.5em;
 
   .thread-collapsed {

--- a/h/templates/client/thread.html
+++ b/h/templates/client/thread.html
@@ -36,7 +36,7 @@
 </div>
 
 <!-- Replies -->
-<ul class="thread-list" ng-hide="vm.collapsed">
+<ul class="thread-replies">
   <li class="thread"
       deep-count="count"
       thread="child" thread-filter

--- a/h/templates/client/thread.html
+++ b/h/templates/client/thread.html
@@ -42,6 +42,7 @@
       thread="child" thread-filter
       ng-include="'thread.html'"
       ng-init="child.message.id || threadFilter.active(false)"
+      ng-class="{'thread-collapsed': vm.collapsed}"
       ng-repeat="child in vm.container.children
                  | orderBy : 'message.updated' : true"
       ng-show="count('edit') || count('match') || !threadFilter.active()">

--- a/h/templates/client/thread.html
+++ b/h/templates/client/thread.html
@@ -36,13 +36,12 @@
 </div>
 
 <!-- Replies -->
-<ul class="thread-replies">
+<ul class="thread-replies" ng-hide="vm.collapsed">
   <li class="thread"
       deep-count="count"
       thread="child" thread-filter
       ng-include="'thread.html'"
       ng-init="child.message.id || threadFilter.active(false)"
-      ng-class="{'thread-collapsed': vm.collapsed}"
       ng-repeat="child in vm.container.children
                  | orderBy : 'message.updated' : true"
       ng-show="count('edit') || count('match') || !threadFilter.active()">

--- a/h/templates/client/thread.html
+++ b/h/templates/client/thread.html
@@ -13,22 +13,25 @@
          annotation="vm.container.message"
          annotation-embedded="{{isEmbedded}}"
          ng-if="vm.container.message"
-         ng-show="threadFilter.check(vm.container)">
+         ng-show="vm.matchesFilter()">
 </article>
 
 <!-- Reply count -->
-<div class="thread-reply" ng-show="vm.shouldShowReply(count, threadFilter.active())">
+<div class="thread-reply"
+     ng-show="vm.shouldShowNumReplies()">
   <a class="reply-count small"
      href=""
-     ng-pluralize count="count('message') - 1"
+     ng-pluralize
+     count="vm.numReplies()"
      when="{'0': '', one: '1 reply', other: '{} replies'}"></a>
 </div>
 
-<div class="thread-load-more" ng-show="vm.container.message.id && threadFilter.active()">
+<div class="thread-load-more" ng-show="vm.shouldShowLoadMore()">
   <a class="load-more small"
      href=""
-     ng-click="threadFilter.active(false)"
-     ng-pluralize count="count('message') - count('match')"
+     ng-click="vm.loadMore()"
+     ng-pluralize
+     count="vm.numLoadMore()"
      when="{'0': '',
            one: 'View one more in conversation',
            other: 'View {} more in conversation'}"
@@ -36,14 +39,13 @@
 </div>
 
 <!-- Replies -->
-<ul class="thread-replies" ng-hide="vm.collapsed">
+<ul class="thread-replies">
   <li class="thread"
       deep-count="count"
       thread="child" thread-filter
       ng-include="'thread.html'"
-      ng-init="child.message.id || threadFilter.active(false)"
       ng-repeat="child in vm.container.children
                  | orderBy : 'message.updated' : true"
-      ng-show="count('edit') || count('match') || !threadFilter.active()">
+      ng-show="vm.shouldShowAsReply()">
   </li>
 </ul>

--- a/h/templates/client/viewer.html
+++ b/h/templates/client/viewer.html
@@ -1,7 +1,6 @@
 <!-- Thread view -->
 <ul class="stream-list"
     deep-count="count"
-    thread="threadRoot"
     thread-filter="search.query">
   <li ng-show="threadFilter.active()"
       ><span ng-pluralize
@@ -43,9 +42,8 @@
       ng-mouseenter="focus(child.message)"
       ng-click="scrollTo(child.message)"
       ng-mouseleave="focus()"
-      ng-repeat="child in vm.container.children | orderBy : sort.predicate"
-      ng-show="vm.container && shouldShowThread(child) &&
-               (count('edit') || count('match') || !threadFilter.active())">
+      ng-repeat="child in threadRoot.children | orderBy : sort.predicate"
+      ng-show="shouldShowThread(child) && (count('edit') || count('match') || !threadFilter.active())">
   </li>
 </ul>
 <!-- / Thread view -->

--- a/h/templates/client/viewer.html
+++ b/h/templates/client/viewer.html
@@ -36,8 +36,6 @@
       ng-class="{'js-hover': hasFocus(child.message)}"
       deep-count="count"
       thread="child" thread-filter
-      thread-collapsed="!search.query"
-      thread-root="true"
       ng-include="'thread.html'"
       ng-mouseenter="focus(child.message)"
       ng-click="scrollTo(child.message)"

--- a/h/templates/pattern_library.html
+++ b/h/templates/pattern_library.html
@@ -790,7 +790,7 @@
             <a class="reply-count small" href="">1 reply</a>
             <a class="load-more small" href=""></a>
 
-            <ul class="thread-list">
+            <ul class="thread-replies">
               <li class="thread" deep-count="count" thread="child" thread-filter="">
                 <a href="" class="threadexp" title="Collapse"><span class="h-icon-minus"></span></a>
 
@@ -836,7 +836,7 @@
                 </article>
 
                 <a class="reply-count small" href=""></a>
-                <ul class="thread-list">
+                <ul class="thread-replies">
                 </ul>
               </li>
             </ul>


### PR DESCRIPTION
*This is #1943 without the stuff @tilgovi didn't like (the RecursionHelper and the thread-list directive).*

I've always been massively confused by the meaning of 'collapsed' in the thread directive. It meant "my replies are collapsed" for the top card, and "I and my replies are collapsed" for replies themselves. This commit changes that, so that collapsing is just about whether or not your replies are visible.

That means that you can no longer collapse individual replies one by one. I consider this an improvement to the user experience.

While doing this, it became apparent to me that working on the thread directive (and associated controller) was far too difficult. I've hopefully simplified this a little bit by moving most of the complicated logic out of the `thread.html` template and into the controller itself.
