### PR TITLE
Add a 'hypothesis token' command

### DIFF
--- a/conf/development.ini
+++ b/conf/development.ini
@@ -7,6 +7,11 @@ use: egg:h#api
 
 basemodel.should_create_all: True
 
+# Set a default persistent secret for development. DO NOT copy this into a
+# production settings file.
+h.client_id: nosuchid
+h.client_secret: nosuchsecret
+
 
 [app:h]
 use: egg:h


### PR DESCRIPTION
It can be convenient to generate OAuth tokens for use at the command
line. This change introduces a `token` command which can be used to
generate tokens for arbitrary users. For example:

    hypothesis token development.ini --subject userid:nick@localhost

Optionally, specify a TTL:

    hypothesis token development.ini --subject group:admin --ttl 86400