### PR TITLE
Fix sidebar's focusing on annotation cards

### DIFF
--- a/h/static/scripts/annotation-ui-service.coffee
+++ b/h/static/scripts/annotation-ui-service.coffee
@@ -13,7 +13,7 @@ createAnnotationUI = ->
 
     visibleHighlights: false
 
-    # Contains a map of annotation id:true pairs.
+    # Contains a map of annotation tag:true pairs.
     focusedAnnotationMap: null
 
     # Contains a map of annotation id:true pairs.
@@ -28,7 +28,7 @@ createAnnotationUI = ->
     ###
     focusAnnotations: (annotations) ->
       selection = {}
-      selection[id] = true for {id} in annotations
+      selection[$$tag] = true for {$$tag} in annotations
       @focusedAnnotationMap = value(selection)
 
     ###*

--- a/h/static/scripts/controllers.coffee
+++ b/h/static/scripts/controllers.coffee
@@ -251,7 +251,7 @@ class ViewerController
         true
 
     $scope.hasFocus = (annotation) ->
-      annotation?.$$tag in ($scope.focusedAnnotations ? [])
+      !!($scope.focusedAnnotations ? {})[annotation?.$$tag]
 
 angular.module('h')
 .controller('AppController', AppController)

--- a/h/static/scripts/test/annotation-ui-service-test.coffee
+++ b/h/static/scripts/test/annotation-ui-service-test.coffee
@@ -17,25 +17,25 @@ describe 'AnnotationUI', ->
 
   describe '.focusAnnotations()', ->
     it 'adds the passed annotations to the focusedAnnotationMap', ->
-      annotationUI.focusAnnotations([{id: 1}, {id: 2}, {id: 3}])
+      annotationUI.focusAnnotations([{$$tag: 1}, {$$tag: 2}, {$$tag: 3}])
       assert.deepEqual(annotationUI.focusedAnnotationMap, {
         1: true, 2: true, 3: true
       })
 
     it 'replaces any annotations originally in the map', ->
       annotationUI.focusedAnnotationMap = {1: true}
-      annotationUI.focusAnnotations([{id: 2}, {id: 3}])
+      annotationUI.focusAnnotations([{$$tag: 2}, {$$tag: 3}])
       assert.deepEqual(annotationUI.focusedAnnotationMap, {
         2: true, 3: true
       })
 
     it 'does not modify the original map object', ->
       orig = annotationUI.focusedAnnotationMap = {1: true}
-      annotationUI.focusAnnotations([{id: 2}, {id: 3}])
+      annotationUI.focusAnnotations([{$$tag: 2}, {$$tag: 3}])
       assert.notEqual(annotationUI.focusedAnnotationMap, orig)
 
     it 'nulls the map if no annotations are focused', ->
-      orig = annotationUI.focusedAnnotationMap = {1: true}
+      orig = annotationUI.focusedAnnotationMap = {$$tag: true}
       annotationUI.focusAnnotations([])
       assert.isNull(annotationUI.focusedAnnotationMap)
 


### PR DESCRIPTION
When the user moves the mouse over a highlight in the document,
the corresponding annotation card (in the sidebar) is supposed
to be highlighted, to indicate focus.

Our mechanism for this was broken in 3 different ways:

1. AnnotationUI service's focusAnnotations() method was working
   with annotation IDs. However, annotations being created
   right now don't yet have ID, only tags. So we should be working
   with tags instead. (Like we are, in many other cases
   when cross-frame communication communication is done
   around annotations.)

   I fixed that, and also updated the corresponding tests.

2. In controllers.coffee, when we were trying to check if a given
   annotation has focus, we were using the tag value, while on
   the other hand, it was not the tag, but the id that was put
   into the map. Of course this didn't work.

   Since now we are consistently using the tag, no change
   was needed here.

3. We are putting $$tag:true pairs into the map, but when
   checking for membership, the `in` operator was used.
   That works for lists, but not for maps. For maps, we simply
   have to read out the value belonging to the given key,
   and see if it's true.

After fixing these problems, the feature works again.
Fixes #2033.