### PR TITLE
Add emphasis to selected annotations

### DIFF
--- a/h/static/scripts/annotation-ui.coffee
+++ b/h/static/scripts/annotation-ui.coffee
@@ -80,12 +80,3 @@ module.exports = ->
     if selection
       delete selection[annotation.id]
       @selectedAnnotationMap = value(selection)
-
-  ###*
-  # @ngdoc method
-  # @name annotationUI.clearSelectedAnnotations()
-  # @returns nothing
-  # @description removes all annotations from the current selection.
-  ###
-  clearSelectedAnnotations: ->
-    @selectedAnnotationMap = null

--- a/h/static/scripts/annotator/plugin/bucket-bar.coffee
+++ b/h/static/scripts/annotator/plugin/bucket-bar.coffee
@@ -309,6 +309,7 @@ class Annotator.Plugin.BucketBar extends Annotator.Plugin
           @_jumpMinMax @buckets[bucket], "down"
         else
           annotations = @buckets[bucket].slice()
+          annotator.triggerShowFrame() # Open sidebar
           annotator.selectAnnotations annotations,
             (event.ctrlKey or event.metaKey),
 

--- a/h/static/scripts/annotator/plugin/texthighlights.coffee
+++ b/h/static/scripts/annotator/plugin/texthighlights.coffee
@@ -46,7 +46,15 @@ class TextHighlight
     $(event.target)
       .parents('.annotator-hl')
       .andSelf()
-      .map(-> $(this).data("annotation"))
+      .map(-> $(this).data("highlight").annotation)
+      .toArray()
+
+  # Collect the highlight impacted by an event
+  @getHighlights: (event) ->
+    $(event.target)
+      .parents('.annotator-hl')
+      .andSelf()
+      .map(-> $(this).data("highlight"))
       .toArray()
 
   # Set up events for this annotator
@@ -76,7 +84,7 @@ class TextHighlight
 
     # Create highlights and link them with the annotation
     @_highlights = TextHighlight.highlightRange(normedRange)
-    $(@_highlights).data "annotation", @annotation
+    $(@_highlights).data "highlight", this
 
   # Is this a temporary hl?
   isTemporary: -> @_temporary
@@ -95,6 +103,20 @@ class TextHighlight
       $(@_highlights).addClass('annotator-hl-focused')
     else
       $(@_highlights).removeClass('annotator-hl-focused')
+
+  # Test the selection state
+  isSelected: -> @_selected
+
+  # Mark/unmark this hl as selected
+  setSelected: (value) ->
+    @_selected = value
+    if value
+      $(@_highlights).addClass('annotator-hl-selected')
+    else
+      $(@_highlights).removeClass('annotator-hl-selected')
+
+  # Toggle the selection state
+  toggleSelected: -> @setSelected !@isSelected()
 
   # Remove all traces of this hl from the document
   removeFromDocument: ->

--- a/h/static/scripts/annotator/test/guest-test.coffee
+++ b/h/static/scripts/annotator/test/guest-test.coffee
@@ -209,6 +209,41 @@ describe 'Guest', ->
         assert.called(highlights[1].setFocused)
         assert.calledWith(highlights[1].setFocused, false)
 
+    describe 'on "selectAnnotations" event', ->
+      it 'selects any annotations with a matching tag', ->
+        guest = createGuest()
+        highlights = [
+          {annotation: {$$tag: 'tag1'}, setSelected: sandbox.stub()}
+          {annotation: {$$tag: 'tag2'}, setSelected: sandbox.stub()}
+        ]
+        guest.anchoring.getHighlights.returns(highlights)
+        emitGuestEvent('selectAnnotations', 'ctx', ['tag1'])
+        assert.called(highlights[0].setSelected)
+        assert.calledWith(highlights[0].setSelected, true)
+
+      it 'deselects any annotations without a matching tag', ->
+        guest = createGuest()
+        highlights = [
+          {annotation: {$$tag: 'tag1'}, setSelected: sandbox.stub()}
+          {annotation: {$$tag: 'tag2'}, setSelected: sandbox.stub()}
+        ]
+        guest.anchoring.getHighlights.returns(highlights)
+        emitGuestEvent('selectAnnotations', 'ctx', ['tag1'])
+        assert.called(highlights[1].setSelected)
+        assert.calledWith(highlights[1].setSelected, false)
+
+    describe 'on "deselectAnnotations" event', ->
+      it 'deselects any annotations with a matching tag', ->
+        guest = createGuest()
+        highlights = [
+          {annotation: {$$tag: 'tag1'}, setSelected: sandbox.stub()}
+          {annotation: {$$tag: 'tag2'}, setSelected: sandbox.stub()}
+        ]
+        guest.anchoring.getHighlights.returns(highlights)
+        emitGuestEvent('deselectAnnotations', 'ctx', ['tag1'])
+        assert.called(highlights[0].setSelected)
+        assert.calledWith(highlights[0].setSelected, false)
+
     describe 'on "scrollToAnnotation" event', ->
       it 'scrolls to the anchor with the matching tag', ->
         guest = createGuest()

--- a/h/static/scripts/app-controller.coffee
+++ b/h/static/scripts/app-controller.coffee
@@ -5,14 +5,14 @@ module.exports = class AppController
   this.$inject = [
     '$controller', '$document', '$location', '$rootScope', '$route', '$scope',
     '$window',
-    'auth', 'drafts', 'identity',
+    'auth', 'crossframe', 'drafts', 'identity',
     'permissions', 'streamer', 'annotationUI',
     'annotationMapper', 'threading'
   ]
   constructor: (
      $controller,   $document,   $location,   $rootScope,   $route,   $scope,
      $window,
-     auth,   drafts,   identity,
+     auth,   crossframe,   drafts,   identity,
      permissions,   streamer,   annotationUI,
      annotationMapper, threading
   ) ->
@@ -101,7 +101,7 @@ module.exports = class AppController
 
     $scope.clearSelection = ->
       $scope.search.query = ''
-      annotationUI.clearSelectedAnnotations()
+      crossframe.notify method: 'selectAnnotations', params: []
 
     $scope.dialog = visible: false
 
@@ -114,7 +114,7 @@ module.exports = class AppController
       update: (query) ->
         unless angular.equals $location.search()['q'], query
           $location.search('q', query or null)
-          annotationUI.clearSelectedAnnotations()
+          crossframe.notify method: 'selectAnnotations', params: []
 
     $scope.sort = name: 'Location'
     $scope.threading = threading

--- a/h/static/scripts/test/app-controller-test.coffee
+++ b/h/static/scripts/test/app-controller-test.coffee
@@ -48,6 +48,8 @@ describe 'AppController', ->
       user: undefined
     }
 
+    fakeCrossFrame = {providers: []}
+
     fakeDrafts = {
       remove: sandbox.spy()
       all: sandbox.stub().returns([])
@@ -96,6 +98,7 @@ describe 'AppController', ->
     $provide.value 'annotationMapper', fakeAnnotationMapper
     $provide.value 'annotationUI', fakeAnnotationUI
     $provide.value 'auth', fakeAuth
+    $provide.value 'crossframe', fakeCrossFrame
     $provide.value 'drafts', fakeDrafts
     $provide.value 'identity', fakeIdentity
     $provide.value '$location', fakeLocation

--- a/h/static/styles/inject.scss
+++ b/h/static/styles/inject.scss
@@ -87,7 +87,7 @@ $base-font-size: 14px;
 }
 
 .annotator-hl.annotator-hl-selected {
-  background-color: $highlight-color-select;
+  background-color: $highlight-color-third;
 }
 
 // Sidebar

--- a/h/static/styles/inject.scss
+++ b/h/static/styles/inject.scss
@@ -86,6 +86,10 @@ $base-font-size: 14px;
   }
 }
 
+.annotator-hl.annotator-hl-selected {
+  background-color: $highlight-color-select;
+}
+
 // Sidebar
 .annotator-frame {
   @import 'reset';

--- a/h/static/styles/variables.scss
+++ b/h/static/styles/variables.scss
@@ -58,7 +58,6 @@ $highlight-color: rgba(255, 255, 60, 0.3);
 $highlight-color-second: rgba(206, 206, 60, 0.4);
 $highlight-color-third: rgba(192, 192, 49, 0.4);
 $highlight-color-focus: rgb(224, 246, 254);
-$highlight-color-select: rgb(192, 246, 192);
 $score-width: 40px;
 $score-height: $score-width;
 $input-border-radius: 2px;

--- a/h/static/styles/variables.scss
+++ b/h/static/styles/variables.scss
@@ -58,6 +58,7 @@ $highlight-color: rgba(255, 255, 60, 0.3);
 $highlight-color-second: rgba(206, 206, 60, 0.4);
 $highlight-color-third: rgba(192, 192, 49, 0.4);
 $highlight-color-focus: rgb(224, 246, 254);
+$highlight-color-select: rgb(192, 246, 192);
 $score-width: 40px;
 $score-height: $score-width;
 $input-border-radius: 2px;


### PR DESCRIPTION
### Current behavior:

Currently, we have the following methods for selecting a specific set of annotations:
 - Click on the highlight (when always-on mode is on)
 - Click on the bar on the bucket bar.

When a set of annotations is selected, their cards will be visible in the sidebar,
and everything else will be hidden. The contents of the sidebar doesn't change,
even if the user scrolls the document.

### Proposed change:

This PR adds the following extra behavior:

The highlights belonging to the selected annotations stays visible in the document,
even if always-on mode is off, and even if the pointer is not currently hovering
over the annotation card.

(As described in #800 )

### Todo:

 - The styling is not intended to be final. Someone who cares about colors should
   devise the best color scheme, taking into account all highlight states.
   (focus, always-on mode, and selection.)
 - Maybe this could be extended to search, too.
   (Currently, search is not impacted at all.)

  * * *

The tests have been updated, and new tests have been added to cover the new functionality.

