### PR TITLE
[WIP] Bring back padded scrolling

### DIFF
--- a/h/static/scripts/annotator/plugin/test/texthighlight-test.coffee
+++ b/h/static/scripts/annotator/plugin/test/texthighlight-test.coffee
@@ -8,6 +8,7 @@ sinon.assert.expose(assert, prefix: '')
 describe 'Annotator.Plugin.TextHighlight', ->
   sandbox = null
   scrollTarget = null
+  animation = null
 
   createTestHighlight = ->
     anchor =
@@ -30,9 +31,10 @@ describe 'Annotator.Plugin.TextHighlight', ->
         hl.appendChild document.createTextNode "test highlight span"
         hl
 
+    Annotator.$.fn.animate = sinon.spy (options) -> animation = options
+
     Annotator.$.fn.scrollintoview = sinon.spy (options) ->
       scrollTarget = this[0]
-      options?.complete?()
 
   afterEach ->
     sandbox.restore()
@@ -53,6 +55,8 @@ describe 'Annotator.Plugin.TextHighlight', ->
       assert.equal annotation, "test annotation"
 
   describe "scrollToView", ->
+    beforeEach ->
+      this.ownerDocument = {body: "asd"}     
 
     it 'calls jQuery scrollintoview', ->
       hl = createTestHighlight()
@@ -63,3 +67,35 @@ describe 'Annotator.Plugin.TextHighlight', ->
       hl = createTestHighlight()
       hl.scrollToView()
       assert.equal scrollTarget, hl._highlights
+
+    it 'does the rigth (padding) correction after scrolling down', ->
+      Annotator.$.fn.scrollintoview = sinon.spy (options) ->
+        context =
+          parentNode: document
+          ownerDocument: document
+        options?.complete?.call context, "fake xdir", "down"
+
+      Annotator.$.fn.scrollTop = sinon.spy -> 100
+
+      Annotator.$.fn.innerHeight = sinon.spy -> 1000
+
+      hl = createTestHighlight()
+
+      hl.scrollToView()
+      assert.deepEqual animation, scrollTop: 100 + 1000 * 0.33
+
+    it 'does the rigth (padding) correction after scrolling up', ->
+      Annotator.$.fn.scrollintoview = sinon.spy (options) ->
+        context =
+          parentNode: document
+          ownerDocument: document
+        options?.complete?.call context, "fake xdir", "up"
+
+      Annotator.$.fn.scrollTop = sinon.spy -> 2000
+
+      Annotator.$.fn.innerHeight = sinon.spy -> 1000
+
+      hl = createTestHighlight()
+
+      hl.scrollToView()
+      assert.deepEqual animation, scrollTop: 2000 - 1000 * 0.33

--- a/h/static/scripts/annotator/plugin/texthighlights.coffee
+++ b/h/static/scripts/annotator/plugin/texthighlights.coffee
@@ -118,8 +118,17 @@ class TextHighlight
 
   # Scroll the highlight into view
   scrollToView: ->
-    $(@_highlights).scrollintoview()
-    null
+    $(@_highlights).scrollintoview
+      complete: (xDirStr, yDirStr) ->
+        return if yDirStr is "none"
+        scrollable = if this.parentNode is this.ownerDocument
+          $(this.ownerDocument.body)
+        else
+          $(this)
+        top = scrollable.scrollTop()
+        pad = scrollable.innerHeight() * .33
+        correction = pad * (if yDirStr is "up" then -1 else +1)
+        scrollable.stop().animate {scrollTop: top + correction}, 300
 
 class Annotator.Plugin.TextHighlights extends Annotator.Plugin
 

--- a/h/static/scripts/annotator/plugin/texthighlights.coffee
+++ b/h/static/scripts/annotator/plugin/texthighlights.coffee
@@ -122,7 +122,13 @@ class TextHighlight
       complete: (xDirStr, yDirStr) ->
         return if yDirStr is "none"
         scrollable = if this.parentNode is this.ownerDocument
-          $(this.ownerDocument.body)
+          # Does the scrollTop method work on the body?
+          if this.ownerDocument.body.scrollTop
+            # We are all good    
+            $(this.ownerDocument.body)
+          else # With FF, it doesn't.
+            # For FF, use the html node instead.
+            $(this.ownerDocument.body.parentNode)
         else
           $(this)
         top = scrollable.scrollTop()

--- a/h/static/scripts/vendor/jquery.scrollintoview.js
+++ b/h/static/scripts/vendor/jquery.scrollintoview.js
@@ -7,6 +7,10 @@
  * Copyright (c) 2011 Robert Koritnik
  * Licensed under the terms of the MIT license
  * http://www.opensource.org/licenses/mit-license.php
+ *
+ * Modifications from the original by Hypothes.is Project and contributors:
+ * Copyright (c) Hypothes.is Project and contributors
+ * Licensed under the terms of the MIT license
  */
 
 (function ($) {
@@ -109,18 +113,24 @@
 
 				var animOptions = {};
 
+				var yDir = "none";
+
 				// vertical scroll
 				if (options.direction.y === true)
 				{
 					if (rel.top < 0)
 					{
 						animOptions.scrollTop = dim.s.scroll.top + rel.top;
+						yDir = "up"
 					}
 					else if (rel.top > 0 && rel.bottom < 0)
 					{
 						animOptions.scrollTop = dim.s.scroll.top + Math.min(rel.top, -rel.bottom);
+						yDir = "down"
 					}
 				}
+
+				var xDir = "none";
 
 				// horizontal scroll
 				if (options.direction.x === true)
@@ -128,10 +138,12 @@
 					if (rel.left < 0)
 					{
 						animOptions.scrollLeft = dim.s.scroll.left + rel.left;
+						xDir = "left"
 					}
 					else if (rel.left > 0 && rel.right < 0)
 					{
 						animOptions.scrollLeft = dim.s.scroll.left + Math.min(rel.left, -rel.right);
+						xDir = "right"
 					}
 				}
 
@@ -146,14 +158,14 @@
 						.animate(animOptions, options.duration)
 						.eq(0) // we want function to be called just once (ref. "html,body")
 						.queue(function (next) {
-							$.isFunction(options.complete) && options.complete.call(scroller[0]);
+							$.isFunction(options.complete) && options.complete.call(scroller[0], xDir, yDir);
 							next();
 						});
 				}
 				else
 				{
 					// when there's nothing to scroll, just call the "complete" function
-					$.isFunction(options.complete) && options.complete.call(scroller[0]);
+					$.isFunction(options.complete) && options.complete.call(scroller[0], xDir, yDir);
 				}
 			}
 


### PR DESCRIPTION
This resurrects the padded scrolling feature, which would make direct linking look a lot better.

This version that adds a change to the upstream (abandoned) jQuery scrollIntoView plugin.
I am just putting this here as a baseline; see the previous discussion at #1899.

Fixes #1776.
