### PR TITLE
[WIP] Clear search and selection when creating a new annotation.

### DIFF
--- a/h/static/scripts/annotation-ui-sync.coffee
+++ b/h/static/scripts/annotation-ui-sync.coffee
@@ -36,6 +36,8 @@ class AnnotationUISync
         show()
         annotations = getAnnotationsByTags(tags)
         annotationUI.selectAnnotations(annotations)
+      clearSelection: (ctx) ->
+        $rootScope.$broadcast('clearSelection')
       focusAnnotations: (ctx, tags=[]) ->
         annotations = getAnnotationsByTags(tags)
         annotationUI.focusAnnotations(annotations)

--- a/h/static/scripts/controllers.coffee
+++ b/h/static/scripts/controllers.coffee
@@ -103,6 +103,9 @@ class AppController
       # Reload the view.
       $route.reload()
 
+    $scope.$on 'clearSelection', ->
+      $scope.clearSelection()
+
     $scope.login = ->
       $scope.dialog.visible = true
       identity.request {oncancel}

--- a/h/static/scripts/guest.coffee
+++ b/h/static/scripts/guest.coffee
@@ -248,6 +248,10 @@ module.exports = class Annotator.Guest extends Annotator
       method: "showAnnotations"
       params: (a.$$tag for a in annotations)
 
+  clearSelection: =>
+    @crossframe?.notify
+      method: "clearSelection"
+
   toggleAnnotationSelection: (annotations) =>
     @crossframe?.notify
       method: "toggleAnnotationSelection"
@@ -397,11 +401,14 @@ module.exports = class Annotator.Guest extends Annotator
     event.preventDefault()
     event.stopPropagation()
     @adder.hide()
-    switch event.target.dataset.action
+    this.clearSelection()
+    annotation = this.setupAnnotation(this.createAnnotation())
+    Annotator.Util.getGlobal().getSelection().removeAllRanges()
+    this.showEditor(annotation)
+
+  onSetTool: (name) ->
+    switch name
+      when 'comment'
+        this.setVisibleHighlights this.visibleHighlights
       when 'highlight'
         this.setVisibleHighlights true
-        annotation = this.setupAnnotation(this.createHighlight())
-      when 'comment'
-        annotation = this.setupAnnotation(this.createAnnotation())
-        this.showEditor(annotation)
-    Annotator.Util.getGlobal().getSelection().removeAllRanges()


### PR DESCRIPTION
First approach to fix #1979 
As discussed in the issue comments, when creating a new annotation we clear the current page search/selection. For this, this PR introduces a new message called clearSelection and channels it through from guest to the AppController.

Fix #1979


Comments?
