### PR TITLE
Set og:description to empty string

### DIFF
--- a/h/views.py
+++ b/h/views.py
@@ -44,6 +44,7 @@ def annotation(context, request):
     return {
         'meta_attrs': (
             {'property': 'og:title', 'content': title},
+            {'property': 'og:description', 'content': ''},
             {'property': 'og:image', 'content': '/assets/images/logo.png'},
             {'property': 'og:site_name', 'content': 'Hypothes.is'},
             {'property': 'og:url', 'content': request.url},


### PR DESCRIPTION
To avoid non-annotation UI text leaking
into the share cards.

Fixes #1988

This is the *much* simpler version of #1991. :smiley_cat: 