### PR TITLE
JWT Bearer Tokens

### DIFF
--- a/h/oauth/__init__.py
+++ b/h/oauth/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+from .grant_types import JWTBearerGrant, JWT_BEARER
+__all__ = ['JWTBearerGrant', 'JWT_BEARER']

--- a/h/oauth/grant_types/__init__.py
+++ b/h/oauth/grant_types/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+from .jwt_bearer import JWTBearerGrant, JWT_BEARER
+
+__all__ = ['JWTBearerGrant', 'JWT_BEARER']

--- a/h/oauth/grant_types/jwt_bearer.py
+++ b/h/oauth/grant_types/jwt_bearer.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+import json
+
+from oauthlib.oauth2 import RequestValidator
+from oauthlib.oauth2.rfc6749 import errors, utils
+from oauthlib.oauth2.rfc6749.grant_types.base import GrantTypeBase
+
+import logging
+log = logging.getLogger(__name__)
+
+JWT_BEARER = 'urn:ietf:params:oauth:grant-type:jwt-bearer'
+
+
+class JWTBearerGrant(GrantTypeBase):
+
+    def __init__(self, request_validator=None):
+        self.request_validator = request_validator or RequestValidator()
+
+    def create_token_response(self, request, token_handler):
+        headers = {
+            'Content-Type': 'application/json',
+            'Cache-Control': 'no-store',
+            'Pragma': 'no-cache',
+        }
+        try:
+            log.debug('Validating access token request, %r.', request)
+            self.validate_token_request(request)
+        except errors.OAuth2Error as e:
+            log.debug('Client error in token request. %s.', e)
+            return headers, e.json, e.status_code
+
+        token = token_handler.create_token(request, refresh_token=False)
+        return headers, json.dumps(token), 200
+
+    def validate_token_request(self, request):
+        if request.grant_type != JWT_BEARER:
+            raise errors.UnsupportedGrantTypeError(request=request)
+
+        if request.assertion is None:
+            raise errors.InvalidRequestError('Missing assertion parameter.',
+                                             request=request)
+
+        for param in ('grant_type', 'scope'):
+            if param in request.duplicate_params:
+                raise errors.InvalidRequestError(
+                    'Duplicate %s parameter.' % param,
+                    request=request)
+
+        # Since the JSON Web Token is signed by its issuer client
+        # authentication is not strictly required when the token is used as
+        # an authorization grant. However, if client credentials are provided
+        # they should be validated as describe in Section 3.1.
+        # https://tools.ietf.org/html/draft-ietf-oauth-jwt-bearer-12#section-3.1
+        if self.request_validator.client_authentication_required(request):
+            log.debug('Authenticating client, %r.', request)
+            if not self.request_validator.authenticate_client(request):
+                log.debug('Invalid client (%r), denying access.', request)
+                raise errors.InvalidClientError(request=request)
+
+        # REQUIRED. The web token issued by the client.
+        log.debug('Validating assertion %s.', request.assertion)
+        if not self.request_validator.validate_bearer_token(
+                request.assertion, request.scopes, request):
+            log.debug('Invalid assertion, %s, for client %r.',
+                      request.assertion, request.client)
+            raise errors.InvalidGrantError('Invalid assertion.',
+                                           request=request)
+
+        original_scopes = utils.scope_to_list(
+            self.request_validator.get_original_scopes(
+                request.assertion, request))
+
+        if request.scope:
+            request.scopes = utils.scope_to_list(request.scope)
+            if (not all((s in original_scopes for s in request.scopes)) and
+                not self.request_validator.is_within_original_scope(
+                    request.scopes, request.refresh_token, request)):
+                log.debug('Refresh token %s lack requested scopes, %r.',
+                          request.refresh_token, request.scopes)
+                raise errors.InvalidScopeError(request=request)
+        else:
+            request.scopes = original_scopes

--- a/h/oauth/grant_types/test/jwt_bearer_test.py
+++ b/h/oauth/grant_types/test/jwt_bearer_test.py
@@ -1,0 +1,133 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, unicode_literals
+import json
+import mock
+import unittest
+
+from oauthlib.common import Request
+from oauthlib.oauth2.rfc6749 import errors
+from oauthlib.oauth2.rfc6749.tokens import BearerToken
+
+from h.oauth import JWTBearerGrant, JWT_BEARER
+
+
+class JWTBearerGrantTest(unittest.TestCase):
+
+    def setUp(self):
+        mock_client = mock.MagicMock()
+        mock_client.user.return_value = 'mocked user'
+        self.request = Request('http://a.b/path')
+        self.request.assertion = 'mocked assertion'
+        self.request.grant_type = JWT_BEARER
+        self.request.client = mock_client
+        self.request.scope = 'foo'
+        self.mock_validator = mock.MagicMock()
+        self.auth = JWTBearerGrant(request_validator=self.mock_validator)
+
+    def test_create_token_response(self):
+        bearer = BearerToken(self.mock_validator)
+        headers, body, status_code = self.auth.create_token_response(
+            self.request, bearer)
+        token = json.loads(body)
+        self.assertIn('access_token', token)
+        self.assertIn('token_type', token)
+        self.assertIn('expires_in', token)
+        self.assertIn('Content-Type', headers)
+        self.assertEqual(headers['Content-Type'], 'application/json')
+        self.assertTrue(self.mock_validator.client_authentication_required.called)
+        self.assertTrue(self.mock_validator.validate_bearer_token.called)
+
+    def test_create_token_inherit_scope(self):
+        self.request.scope = None
+        self.mock_validator.get_original_scopes.return_value = ['foo', 'bar']
+        bearer = BearerToken(self.mock_validator)
+        headers, body, status_code = self.auth.create_token_response(
+            self.request, bearer)
+        token = json.loads(body)
+        self.assertIn('access_token', token)
+        self.assertIn('token_type', token)
+        self.assertIn('expires_in', token)
+        self.assertEqual(token['scope'], 'foo bar')
+
+    def test_create_token_within_original_scope(self):
+        self.mock_validator.get_original_scopes.return_value = ['baz']
+        self.mock_validator.is_within_original_scope.return_value = True
+        bearer = BearerToken(self.mock_validator)
+        headers, body, status_code = self.auth.create_token_response(
+            self.request, bearer)
+        token = json.loads(body)
+        self.assertIn('access_token', token)
+        self.assertIn('token_type', token)
+        self.assertIn('expires_in', token)
+        self.assertEqual(token['scope'], 'foo')
+
+    def test_invalid_scope(self):
+        self.mock_validator.get_original_scopes.return_value = ['baz']
+        self.mock_validator.is_within_original_scope.return_value = False
+        bearer = BearerToken(self.mock_validator)
+        headers, body, status_code = self.auth.create_token_response(
+            self.request, bearer)
+        token = json.loads(body)
+        self.assertEqual(token['error'], 'invalid_scope')
+        self.assertEqual(status_code, 401)
+
+    def test_invalid_token(self):
+        self.mock_validator.validate_bearer_token.return_value = False
+        bearer = BearerToken(self.mock_validator)
+        headers, body, status_code = self.auth.create_token_response(
+            self.request, bearer)
+        token = json.loads(body)
+        self.assertEqual(token['error'], 'invalid_grant')
+        self.assertEqual(status_code, 401)
+
+    def test_invalid_client(self):
+        self.mock_validator.authenticate_client.return_value = False
+        bearer = BearerToken(self.mock_validator)
+        headers, body, status_code = self.auth.create_token_response(
+            self.request, bearer)
+        token = json.loads(body)
+        self.assertEqual(token['error'], 'invalid_client')
+        self.assertEqual(status_code, 401)
+
+    def test_authentication_required(self):
+        """
+        ensure client_authentication_required() is properly called
+        """
+        self.mock_validator.authenticate_client.return_value = False
+        self.mock_validator.authenticate_client_id.return_value = False
+        self.request.code = 'waffles'
+        self.assertRaises(errors.InvalidClientError, self.auth.validate_token_request,
+                          self.request)
+        self.mock_validator.client_authentication_required.assert_called_once_with(self.request)
+
+    def test_invalid_grant_type(self):
+        self.request.grant_type = 'wrong type'
+        self.assertRaises(errors.UnsupportedGrantTypeError,
+                          self.auth.validate_token_request, self.request)
+
+    def test_invalid_assertion(self):
+        # invalid assertion
+        self.mock_validator.validate_bearer_token.return_value = False
+        self.assertRaises(errors.InvalidGrantError,
+                          self.auth.validate_token_request, self.request)
+        # no token provided
+        del self.request.assertion
+        self.assertRaises(errors.InvalidRequestError,
+                          self.auth.validate_token_request, self.request)
+
+    def test_invalid_scope_original_scopes_empty(self):
+        self.mock_validator.validate_bearer_token.return_value = True
+        self.mock_validator.is_within_original_scope.return_value = False
+        self.assertRaises(errors.InvalidScopeError,
+                          self.auth.validate_token_request, self.request)
+
+    def test_valid_token_request(self):
+        self.request.scope = 'foo bar'
+        self.mock_validator.get_original_scopes = mock.Mock()
+        self.mock_validator.get_original_scopes.return_value = 'foo bar baz'
+        self.auth.validate_token_request(self.request)
+        self.assertEqual(self.request.scopes, self.request.scope.split())
+        # all ok but without request.scope
+        del self.request.scope
+        self.auth.validate_token_request(self.request)
+        self.assertEqual(self.request.scopes, 'foo bar baz'.split())

--- a/h/test/auth_test.py
+++ b/h/test/auth_test.py
@@ -118,7 +118,6 @@ class TestRequestValidator(unittest.TestCase):
         assert res is True
         assert self.request.client is client
         assert self.request.user == 'citizen'
-        assert self.request.scopes is None
 
 
 def test_get_client(config):


### PR DESCRIPTION
This PR adds support for JSON Web Tokens as authorization grants as per [draft-ietf-oauth-jwt-bearer](https://tools.ietf.org/html/draft-ietf-oauth-jwt-bearer).