### PR TITLE
Add IE autodetect for dom-text-mapper Annotator plugin

### DIFF
--- a/h/layouts.py
+++ b/h/layouts.py
@@ -35,6 +35,10 @@ class BaseLayout(object):
         return self.request.webassets_env['wgxpath'].urls()
 
     @property
+    def url_polyfill_urls(self):
+        return self.request.webassets_env['url'].urls()
+
+    @property
     def app_inject_urls(self):
         return self.request.webassets_env['inject'].urls()
 

--- a/h/static/bootstrap.js
+++ b/h/static/bootstrap.js
@@ -59,6 +59,15 @@ if (window.hasOwnProperty('hypothesisRole')) {
   }
 }
 
+// Simple IE autodetect function
+// See for example https://stackoverflow.com/questions/19999388/jquery-check-if-user-is-using-ie/21712356#21712356
+var ua = window.navigator.userAgent;
+if ((ua.indexOf("MSIE ") > 0) ||     // for IE <=10
+    (ua.indexOf('Trident/') > 0) ||  // for IE 11
+    (ua.indexOf('Edge/') > 0)) {     // for IE 12
+  options["DomTextMapper"] = {"skip": true}
+}
+
 if (window.hasOwnProperty('hypothesisConfig')) {
   if (typeof window.hypothesisConfig === 'function') {
     options = jQuery.extend(options, window.hypothesisConfig());

--- a/h/templates/embed.js
+++ b/h/templates/embed.js
@@ -1,7 +1,7 @@
 (function () {
   // Injects the hypothesis dependencies. These can be either js or css, the
   // file extension is used to determine the loading method. This file is
-  // pre-processed in order to insert the wgxpath and inject scripts.
+  // pre-processed in order to insert the wgxpath, url and inject scripts.
   //
   // Custom injectors can be provided to load the scripts into a different
   // environment. Both script and stylesheet methods are provided with a url
@@ -44,6 +44,20 @@
 
     if (!window.document.evaluate) {
       resources = resources.concat(['{{ layout.xpath_polyfill_urls | map("string") | join("', '") | safe }}']);
+    }
+
+    // https://github.com/Modernizr/Modernizr/blob/master/feature-detects/url/parser.js
+    var url, urlWorks;
+    try {
+      // have to actually try use it, because Safari defines a dud constructor
+      url = new URL('http://modernizr.com/');
+      urlWorks = url.href === 'http://modernizr.com/';
+    }
+    catch (err) {
+      urlWorks = false;
+    }
+    if (!urlWorks) {
+      resources = resources.concat(['{{ layout.url_polyfill_urls | map("string") | join("', '") | safe }}']);
     }
 
     if (typeof window.Annotator === 'undefined') {


### PR DESCRIPTION
Since the current implementation of the Dom-Text-Mapper doesn't run properly under IE,
we need to disable it when running IE.

Earlier, the `DomTextMapper` Annotator plugin had a `skip` option for that purpose, and the default behavior was to enable d-t-m support.

This PR introduces the new `force` option force enabling d-t-m, and changes the default behavior to auto-detect. (Disable d-t-m for IE, enable d-t-m otherwise.)

It can detect IE versions up to IE12.

See http://ie.dokku.hypothes.is for a demo.
