### PR TITLE
Refresh welcome page

### DIFF
--- a/h/static/styles/app.scss
+++ b/h/static/styles/app.scss
@@ -152,19 +152,12 @@ ol {
   .masthead-heading {
     margin: 0;
     padding-top: 4px;
-  }
-
-  .masthead-subheading {
-    font-size: 1.231em;
-    margin: 0;
-  }
-
-  img {
-    float: left;
-    opacity: .7;
+    font-size: 1.2em;
+    font-weight: 400;
+    color: $gray-light;
 
     &:hover {
-      opacity: 1;
+      color: $gray-dark;
     }
   }
 }

--- a/h/static/styles/app.scss
+++ b/h/static/styles/app.scss
@@ -152,9 +152,9 @@ ol {
   .masthead-heading {
     margin: 0;
     padding-top: 4px;
-    font-size: 1.2em;
+    font-size: 1.1em;
     font-weight: 400;
-    color: $gray-light;
+    color: $gray;
 
     &:hover {
       color: $gray-dark;
@@ -174,7 +174,7 @@ ol {
   }
 
   .masthead-heading {
-    font-size: 20px;
+    font-size: 1.1em;
     line-height: 1em;
   }
 

--- a/h/static/styles/help-page.scss
+++ b/h/static/styles/help-page.scss
@@ -4,6 +4,7 @@
   padding-top: 2.5em;
   padding-bottom: 2.5em;
   background: $body-background;
+  font-family: 'Lato', sans-serif !important;
 
   @include breakpoint(920px) {
     padding-right: 460px;
@@ -154,5 +155,15 @@
 
   @include icons {
     font-size: 12px;
+  }
+}
+
+/*
+  Mobile layout
+*/
+
+@media screen and (max-width: 30em) {
+  .help-page-sidebar {
+    display: none;
   }
 }

--- a/h/static/styles/help-page.scss
+++ b/h/static/styles/help-page.scss
@@ -33,7 +33,8 @@
 .help-page-heading {
   color: $gray-darker;
   margin-bottom: 1em;
-  font-size: 1.5em;
+  font-weight: 400;
+  font-size: 1.1em;
 }
 
 .help-page-lede {
@@ -131,7 +132,8 @@
 
 .feature-heading {
   color: $gray-darker;
-  font-size: 1.125em;
+  font-size: 1em;
+  font-weight: 400;
   margin-bottom: .555em;
 }
 

--- a/h/templates/help.html
+++ b/h/templates/help.html
@@ -1,6 +1,11 @@
 {% extends "layouts/base.html" %}
 
 {% block meta %}
+  <link href='http://fonts.googleapis.com/css?family=Lato:400,300' rel='stylesheet' type='text/css'>
+  <!-- Override app body stylings for just this page -->
+  <style type="text/css">
+    body {background: #FFF !important;}
+  </style>
   {{ super() }}
   {% if is_onboarding %}
     <meta name="hypothesis-intent" content="first-run" />

--- a/h/templates/help.html
+++ b/h/templates/help.html
@@ -151,6 +151,7 @@
               Additionally, please feel free to join us in <a
                 href="http://webchat.freenode.net/?channels=hypothes.is">#hypothes.is</a> on <a
                 href="http://freenode.net/">freenode</a> and subscribe to our mailing list.</p>
+              <p>Finally, we also have grant opportunities for projects related to web annotation. You can find out more about them on our <a href="https://hypothes.is/fund/">Open Annotation Grant Opportunities page</a>.</p>
           </div>
         </section>
       {% endif %}

--- a/h/templates/help.html
+++ b/h/templates/help.html
@@ -151,7 +151,7 @@
               Additionally, please feel free to join us in <a
                 href="http://webchat.freenode.net/?channels=hypothes.is">#hypothes.is</a> on <a
                 href="http://freenode.net/">freenode</a> and subscribe to our mailing list.</p>
-              <p>Finally, we also have grant opportunities for projects related to web annotation. You can find out more about them on our <a href="https://hypothes.is/fund/">Open Annotation Grant Opportunities page</a>.</p>
+              <p>Finally, we also have grant opportunities for projects related to web annotation. You can find out more about them on our <a href="http://anno.fund/">Open Annotation Grant Opportunities page</a>.</p>
           </div>
         </section>
       {% endif %}

--- a/h/templates/includes/header.html
+++ b/h/templates/includes/header.html
@@ -1,5 +1,5 @@
 <header class="masthead">
-	<hgroup>
-		<a href="https://hypothes.is" class="masthead-heading">Hypothes<span class="red">.</span>is</a>
-	</hgroup>
+  <hgroup>
+	<a href="https://hypothes.is" class="masthead-heading">Hypothes<span class="red">.</span>is</a>
+  </hgroup>
 </header>

--- a/h/templates/includes/header.html
+++ b/h/templates/includes/header.html
@@ -1,5 +1,5 @@
 <header class="masthead">
 	<hgroup>
 		<a href="https://hypothes.is" class="masthead-heading">Hypothesis</a>
-    </hgroup>
+	</hgroup>
 </header>

--- a/h/templates/includes/header.html
+++ b/h/templates/includes/header.html
@@ -1,9 +1,5 @@
 <header class="masthead">
-  <a href="{{ base_url }}">
-    <img height="72" width="72" src="{{ request.static_url('h:static/images/logo.png') }}" />
-  </a>
-  <hgroup>
-    <h1 class="masthead-heading">Hypothes<span class="red">.</span>is</h1>
-    <h2 class="masthead-subheading">The&#160;Internet, peer&#160;reviewed.</h2>
-  </hgroup>
+	<hgroup>
+		<a href="https://hypothes.is" class="masthead-heading">Hypothesis</a>
+    </hgroup>
 </header>

--- a/h/templates/includes/header.html
+++ b/h/templates/includes/header.html
@@ -1,5 +1,5 @@
 <header class="masthead">
 	<hgroup>
-		<a href="https://hypothes.is" class="masthead-heading">Hypothesis</a>
+		<a href="https://hypothes.is" class="masthead-heading">Hypothes<span class="red">.</span>is</a>
 	</hgroup>
 </header>


### PR DESCRIPTION
Our welcome page could use a bit of a refresh. This PR is where we can discuss and implement some improvements. 

For starters, I've switched the font on the welcome page to Lato to make it visually consistent with our website, and I've also hidden the `.help-page-sidebar` on mobile, because I noticed when using dokku branches on mobile that I could select any thing else besides what was in the help-page-sidebar div.