### PR TITLE
Require PyJWT>=1.0.0,<2.0.0

### DIFF
--- a/h/auth.py
+++ b/h/auth.py
@@ -31,7 +31,6 @@ Limitations
 import datetime
 
 import jwt
-import jwt.api
 from jwt.compat import constant_time_compare
 from oauthlib.common import generate_client_id
 from oauthlib.oauth2 import RequestValidator as _RequestValidator
@@ -89,7 +88,7 @@ class RequestValidator(_RequestValidator):
             return False
 
         try:
-            payload, signing_input, header, signature = jwt.api.load(token)
+            payload = jwt.decode(token, verify=False)
         except jwt.InvalidTokenError:
             return False
 
@@ -102,9 +101,10 @@ class RequestValidator(_RequestValidator):
             return False
 
         try:
-            jwt.api.verify_signature(payload, signing_input, header, signature,
-                                     key=client.client_secret, audience=aud,
-                                     leeway=LEEWAY)
+            payload = jwt.decode(token, key=client.client_secret,
+                                 audience=aud, leeway=LEEWAY,
+                                 algorithms=['HS256'])
+
         except jwt.InvalidTokenError:
             return False
 

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ versioneer.tag_prefix = 'v'
 versioneer.parentdir_prefix = 'h-'
 
 install_requires = [
-    'PyJWT>=0.4.3,<0.5',
+    'PyJWT>=1.0.0,<2.0.0',
     'SQLAlchemy>=0.8.0',
     'alembic>=0.6.3',
     'annotator>=0.14.1,<0.15',


### PR DESCRIPTION
Yesterday we released PyJWT [v1.0.0](https://github.com/jpadilla/pyjwt/releases/tag/1.0.0) which fixes some reported security vulnerabilities. Although this project doesn't seem to be affected, it would still be good idea to require PyJWT>=1.0.0,<2.0.0 instead.