### PR TITLE
Explicitly disallow implicit relative imports

### DIFF
--- a/.prospector.yaml
+++ b/.prospector.yaml
@@ -5,6 +5,9 @@ inherits:
 pep8:
   options:
     max-line-length: 79
+pylint:
+  enable:
+    - relative-import
 ignore-paths:
   - h/_version.py
   - h/migrations/


### PR DESCRIPTION
Rather than having to have

    from __future__ import absolute_imports

at the top of every file, we just enable the pylint warning for implicit
relative imports.