### PR TITLE
Add tooltips on adder buttons.

### DIFF
--- a/h/static/scripts/annotator/plugin/toolbar.coffee
+++ b/h/static/scripts/annotator/plugin/toolbar.coffee
@@ -49,7 +49,7 @@ class Annotator.Plugin.Toolbar extends Annotator.Plugin
           state = not @annotator.visibleHighlights
           @annotator.setVisibleHighlights state
     ,
-      "title": "New Comment"
+      "title": "New Note"
       "class": "h-icon-insert-comment"
       "on":
         "click": (event) =>

--- a/h/static/scripts/guest.coffee
+++ b/h/static/scripts/guest.coffee
@@ -37,8 +37,8 @@ module.exports = class Annotator.Guest extends Annotator
   html: jQuery.extend {}, Annotator::html,
     adder: '''
       <div class="annotator-adder">
-        <button class="h-icon-insert-comment" data-action="comment"></button>
-        <button class="h-icon-border-color" data-action="highlight"></button>
+        <button class="h-icon-insert-comment" data-action="comment" title="New Note"></button>
+        <button class="h-icon-border-color" data-action="highlight" title="Highlight"></button>
       </div>
     '''
 


### PR DESCRIPTION
Adds tooltips on adder buttons and changes text of the toolbar button to "New Note." I should have done this during the original PR but it slipped my mind.