### PR TITLE
Do angular magic differently

### DIFF
--- a/h/static/scripts/directives/markdown.coffee
+++ b/h/static/scripts/directives/markdown.coffee
@@ -335,8 +335,7 @@ markdown = ['$filter', '$sanitize', '$sce', '$timeout', ($filter, $sanitize, $sc
 
     # React to the changes to the input
     inputEl.bind 'blur change keyup', ->
-      ctrl.$setViewValue inputEl.val()
-      scope.$digest()
+      $timeout -> ctrl.$setViewValue inputEl.val()
 
     # Reset height of output div incase it has been changed.
     # Re-render when it becomes uneditable.


### PR DESCRIPTION
This commit changes how we trigger the refreshing of the markdown previews in the editor.

It has to do with how angular apply / digest cycles interwene and crash in some cases.

The change was [suggested](https://github.com/hypothesis/h/pull/2038#discussion_r26867418) by @RawKStar77.

   * * *

This solves a problem which is currently blocking #2038.