### PR TITLE
Sync annotation state after anchoring

### DIFF
--- a/h/static/scripts/guest.coffee
+++ b/h/static/scripts/guest.coffee
@@ -233,6 +233,11 @@ module.exports = class Annotator.Guest extends Annotator
 
     this.removeEvents()
 
+  setupAnnotation: ->
+    annotation = super
+    this.plugins.CrossFrame.sync([annotation])
+    annotation
+
   createAnnotation: ->
     annotation = super
     this.plugins.CrossFrame.sync([annotation])


### PR DESCRIPTION
It was never called when the anchoring was finished.
This code adds the missing sync.
It is required for show diff to work.

Fix #2041