### PR TITLE
[WIP] Show all annotations as top-level cards in streamer

### DIFF
--- a/h/static/scripts/streamsearch.coffee
+++ b/h/static/scripts/streamsearch.coffee
@@ -32,6 +32,10 @@ class StreamSearchController
     $scope.sort.name = 'Newest'
 
     $scope.shouldShowThread = (container) -> true
+    $scope.threadRoot = children: $scope.threading?.streamRoot
+
+    $scope.$watch 'threading.streamRoot', (messageRoot) ->
+      $scope.threadRoot = messageRoot
 
     $scope.$on '$destroy', ->
       $scope.search.query = ''


### PR DESCRIPTION
Second version for PR #2061 

This WIP branch aims to rework the stream display that replies will have its own top level annotations cards.
Parents/children can be added later. 

Fix #1916