### PR TITLE
AppController listens to 'beforeAnnotationCreated'

### DIFF
--- a/h/static/scripts/controllers.coffee
+++ b/h/static/scripts/controllers.coffee
@@ -20,13 +20,15 @@ class AnnotationUIController
 
 class AppController
   this.$inject = [
-    '$controller', '$document', '$location', '$route', '$scope', '$window',
+    '$controller', '$document', '$location', '$rootScope', '$route', '$scope',
+    '$window',
     'auth', 'drafts', 'identity',
     'permissions', 'streamer', 'annotationUI',
     'annotationMapper', 'threading'
   ]
   constructor: (
-     $controller,   $document,   $location,   $route,   $scope,   $window,
+     $controller,   $document,   $location,   $rootScope,   $route,   $scope,
+     $window,
      auth,   drafts,   identity,
      permissions,   streamer,   annotationUI,
      annotationMapper, threading
@@ -102,6 +104,9 @@ class AppController
 
       # Reload the view.
       $route.reload()
+
+    $rootScope.$on 'beforeAnnotationCreated', ->
+      $scope.clearSelection()
 
     $scope.login = ->
       $scope.dialog.visible = true


### PR DESCRIPTION
By doing that it catches newly created annotations and clear the current
selection/search result for the newly created card to be visible.

Second version of https://github.com/hypothesis/h/pull/2043
Fix #1979