### PR TITLE
Move CSRF handling into a tween

### DIFF
--- a/h/accounts/views.py
+++ b/h/accounts/views.py
@@ -54,17 +54,8 @@ def ajax_form(request, result):
     return result
 
 
-def ensure_csrf_token(view_fn):
-    def wrapper(context, request):
-        request.add_response_callback(session.set_csrf_token)
-        return view_fn(context, request)
-
-    return wrapper
-
-
 def view_auth_defaults(fn, *args, **kwargs):
     kwargs.setdefault('accept', 'text/html')
-    kwargs.setdefault('decorator', ensure_csrf_token)
     kwargs.setdefault('layout', 'auth')
     kwargs.setdefault('renderer', 'h:templates/auth.html')
     return view_defaults(*args, **kwargs)(fn)
@@ -88,7 +79,6 @@ class AsyncFormViewMapper(object):
 
     def __call__(self, view):
         def wrapper(context, request):
-            request.add_response_callback(session.set_csrf_token)
             if request.method == 'POST':
                 data = request.json_body
                 data.update(request.params)

--- a/h/app.py
+++ b/h/app.py
@@ -52,6 +52,8 @@ def create_app(global_config, **settings):
     config.add_jinja2_renderer('.txt')
     config.add_jinja2_renderer('.html')
 
+    config.add_tween('h.tweens.csrf_tween_factory')
+
     if config.registry.feature('accounts'):
         config.set_authentication_policy(session_authn)
         config.set_authorization_policy(acl_authz)

--- a/h/session.py
+++ b/h/session.py
@@ -28,12 +28,6 @@ def pop_flash(request):
     return queues
 
 
-def set_csrf_token(request, response):
-    csrft = request.session.get_csrf_token()
-    if request.cookies.get('XSRF-TOKEN') != csrft:
-        response.set_cookie('XSRF-TOKEN', csrft)
-
-
 def includeme(config):
     registry = config.registry
     settings = registry.settings

--- a/h/tweens.py
+++ b/h/tweens.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+
+
+def csrf_tween_factory(handler, registry):
+    """A tween that sets a 'XSRF-TOKEN' cookie."""
+
+    def csrf_tween(request):
+        response = handler(request)
+        csrft = request.session.get_csrf_token()
+        if request.cookies.get('XSRF-TOKEN') != csrft:
+            response.set_cookie('XSRF-TOKEN', csrft)
+        return response
+
+    return csrf_tween

--- a/h/views.py
+++ b/h/views.py
@@ -84,7 +84,6 @@ def help_page(context, request):
 
 @view_config(accept='application/json', context=Application, renderer='json')
 def session_view(request):
-    request.add_response_callback(session.set_csrf_token)
     flash = session.pop_flash(request)
     model = session.model(request)
     return dict(status='okay', flash=flash, model=model)


### PR DESCRIPTION
This removes the need for various components to worry about whether
they have or need a fresh csrf token. With the separation of the
site and the api into different apps it's no longer a useful
useful optimization (as if it ever was, really) to try to manage
this for only some routes.