### PR TITLE
Hide orphan annotations in the sidebar

### DIFF
--- a/h/static/scripts/annotator/monkey.coffee
+++ b/h/static/scripts/annotator/monkey.coffee
@@ -16,6 +16,7 @@ Annotator.prototype.setupAnnotation = (annotation) ->
   @selectedTargets = []
 
   annotation.anchors = []
+  hasAnchor = false
 
   for t in annotation.target ? []
     try
@@ -27,13 +28,16 @@ Annotator.prototype.setupAnnotation = (annotation) ->
       if anchor?
         t.diffHTML = anchor.diffHTML
         t.diffCaseOnly = anchor.diffCaseOnly
+        hasAnchor = true
 
     catch exception
       console.log "Error in setupAnnotation for", annotation.id,
         ":", exception.stack ? exception
 
-  annotation
+  if annotation.target?.length and not hasAnchor
+    annotation.$orphan = true
 
+  annotation
 
 # Override deleteAnnotation to deal with anchors, not highlights.
 Annotator.prototype.deleteAnnotation = (annotation) ->

--- a/h/static/scripts/annotator/monkey.coffee
+++ b/h/static/scripts/annotator/monkey.coffee
@@ -16,7 +16,6 @@ Annotator.prototype.setupAnnotation = (annotation) ->
   @selectedTargets = []
 
   annotation.anchors = []
-  hasAnchor = false
 
   for t in annotation.target ? []
     try
@@ -28,13 +27,12 @@ Annotator.prototype.setupAnnotation = (annotation) ->
       if anchor?
         t.diffHTML = anchor.diffHTML
         t.diffCaseOnly = anchor.diffCaseOnly
-        hasAnchor = true
 
     catch exception
       console.log "Error in setupAnnotation for", annotation.id,
         ":", exception.stack ? exception
 
-  if annotation.target?.length and not hasAnchor
+  if annotation.target?.length and not annotation.anchors?.length
     annotation.$orphan = true
 
   annotation

--- a/h/static/scripts/annotator/test/guest-test.coffee
+++ b/h/static/scripts/annotator/test/guest-test.coffee
@@ -32,6 +32,11 @@ describe 'Guest', ->
 
       getHighlights: sandbox.stub().returns([])
       getAnchors: sandbox.stub().returns([])
+      createAnchor: sandbox.spy (annotation, target) ->
+        anchor = "anchor for " + target
+        annotation.anchors.push anchor
+
+        result: anchor
     }
 
     Annotator.Plugin.CrossFrame = -> fakeCrossFrame
@@ -292,3 +297,24 @@ describe 'Guest', ->
       guest = createGuest()
       guest.setupAnnotation({ranges: []})
       assert.called(fakeCrossFrame.sync)
+
+  describe 'Annotator monkey patch', ->
+    describe 'setupAnnotation()', ->
+      it "doesn't declare annotation without targets as orphans", ->
+        guest = createGuest()
+        annotation = target: []
+        guest.setupAnnotation(annotation)
+        assert.isFalse !!annotation.$orphan
+
+      it "doesn't declare annotations with a working target as orphans", ->
+        guest = createGuest()
+        annotation = target: ["test target"]
+        guest.setupAnnotation(annotation)
+        assert.isFalse !!annotation.$orphan
+
+      it "declares annotations with broken targets as orphans", ->
+        guest = createGuest()
+        guest.anchoring.createAnchor = -> result: null
+        annotation = target: ["broken target"]
+        guest.setupAnnotation(annotation)
+        assert !!annotation.$orphan

--- a/h/static/scripts/annotator/test/guest-test.coffee
+++ b/h/static/scripts/annotator/test/guest-test.coffee
@@ -1,5 +1,5 @@
 Annotator = require('annotator')
-require('../annotator/monkey')
+require('../monkey')
 Guest = require('../guest')
 
 assert = chai.assert

--- a/h/static/scripts/annotator/test/guest-test.coffee
+++ b/h/static/scripts/annotator/test/guest-test.coffee
@@ -1,4 +1,5 @@
 Annotator = require('annotator')
+require('../annotator/monkey')
 Guest = require('../guest')
 
 assert = chai.assert

--- a/h/static/scripts/cross-frame.coffee
+++ b/h/static/scripts/cross-frame.coffee
@@ -20,7 +20,7 @@ module.exports = class CrossFrame
       new Discovery($window, options)
 
     createAnnotationSync = ->
-      whitelist = ['$highlight', 'target', 'document', 'uri']
+      whitelist = ['$highlight', '$orphan', 'target', 'document', 'uri']
       options =
         formatter: (annotation) ->
           formatted = {}

--- a/h/static/scripts/widget-controller.coffee
+++ b/h/static/scripts/widget-controller.coffee
@@ -70,3 +70,5 @@ module.exports = class WidgetController
 
     $scope.hasFocus = (annotation) ->
       !!($scope.focusedAnnotations ? {})[annotation?.$$tag]
+
+    $scope.notOrphan = (container) -> !container?.message?.$orphan

--- a/h/templates/client/viewer.html
+++ b/h/templates/client/viewer.html
@@ -40,7 +40,7 @@
       ng-mouseenter="focus(child.message)"
       ng-click="scrollTo(child.message)"
       ng-mouseleave="focus()"
-      ng-repeat="child in threadRoot.children | orderBy : sort.predicate"
+      ng-repeat="child in threadRoot.children | filter:notOrphan | orderBy : sort.predicate"
       ng-show="shouldShowThread(child) && (count('edit') || count('match') || !threadFilter.active())">
   </li>
 </ul>


### PR DESCRIPTION

... as described by #1612 and https://github.com/hypothesis/vision/issues/153.

   * * *

Current limitations:

1. When doing a page search on a page where we have an orphan annotation that has a reply which would match the search, even though the thread will not be shown, the displayed number of matches will contain the match belonging to the reply of the orphan annotation. (This problem does not occur if the match is the orphan annotation itself; only when it's a reply. And in any case, it's never shown.)

2. I am not 100% sure I picked the right interaction points to hide the orphans; see my questions on the dev list.

3. No tests yet.