### PR TITLE
Show all annotations as top-level cards in streamer

### DIFF
--- a/h/static/scripts/annotation-viewer-controller.coffee
+++ b/h/static/scripts/annotation-viewer-controller.coffee
@@ -4,15 +4,26 @@ angular = require('angular')
 module.exports = class AnnotationViewerController
   this.$inject = [
     '$location', '$routeParams', '$scope',
-    'streamer', 'store', 'streamFilter', 'annotationMapper'
+    'streamer', 'store', 'streamFilter', 'threading', 'annotationMapper'
   ]
   constructor: (
      $location,   $routeParams,   $scope,
-     streamer,   store,   streamFilter,   annotationMapper
+     streamer,   store,   streamFilter,   threading,   annotationMapper
   ) ->
     # Tells the view that these annotations are standalone
     $scope.isEmbedded = false
     $scope.isStream = false
+
+    $scope.threadRoot = threading?.root
+
+    $scope.lookup.hasAnnotation = (annotation) ->
+      threading.idTable[annotation.id]?.message
+
+    $scope.lookup.getAnnotationContainers = ->
+      containers = []
+      for id, container of threading.idTable when container.message
+        containers.push container
+      containers
 
     # Provide no-ops until these methods are moved elsewere. They only apply
     # to annotations loaded into the stream.
@@ -26,7 +37,7 @@ module.exports = class AnnotationViewerController
     id = $routeParams.id
     store.SearchResource.get _id: id, ({rows}) ->
       annotationMapper.loadAnnotations(rows)
-      $scope.threadRoot = children: [$scope.threading.getContainer(id)]
+      $scope.threadRoot = children: [threading.getContainer(id)]
     store.SearchResource.get references: id, ({rows}) ->
       annotationMapper.loadAnnotations(rows)
 

--- a/h/static/scripts/app-controller.coffee
+++ b/h/static/scripts/app-controller.coffee
@@ -33,7 +33,7 @@ module.exports = class AppController
           annotationMapper.loadAnnotations data
         when 'delete'
           for annotation in data
-            if a = threading.idTable[annotation.id]?.message
+            if a = $scope.threading.idTable[annotation.id]?.message
               $scope.$emit('annotationDeleted', a)
 
     streamer.onmessage = (data) ->
@@ -46,9 +46,15 @@ module.exports = class AppController
     oncancel = ->
       $scope.dialog.visible = false
 
-    cleanupAnnotations = ->
-      # Clean up any annotations that need to be unloaded.
+    $rootScope.getAnnotationContainers = ->
+      containers = []
       for id, container of $scope.threading.idTable when container.message
+        containers.push container
+      containers
+
+    $scope.cleanupAnnotations = ->
+      # Clean up any annotations that need to be unloaded.
+      for container in $rootScope.getAnnotationContainers()
         # Remove annotations the user is not authorized to view.
         if not permissions.permits 'read', container.message, auth.user
           $scope.$emit('annotationDeleted', container.message)
@@ -79,7 +85,7 @@ module.exports = class AppController
       streamer.open($window.WebSocket, streamerUrl)
 
       # Clean up annotations that should be removed
-      cleanupAnnotations()
+      $scope.cleanupAnnotations()
 
       # Reload the view.
       $route.reload()

--- a/h/static/scripts/stream-controller.coffee
+++ b/h/static/scripts/stream-controller.coffee
@@ -1,4 +1,5 @@
 angular = require('angular')
+mail = require('./vendor/jwz')
 
 
 module.exports = class StreamController
@@ -12,6 +13,34 @@ module.exports = class StreamController
      auth,   queryParser,   searchFilter,   store,
      streamer,   streamFilter, annotationMapper
   ) ->
+    # Initialize cards
+    $scope.threadRoot = mail.messageContainer()
+
+    $rootScope.$on 'beforeAnnotationCreated', (event, annotation) ->
+      container = mail.messageContainer(annotation)
+      $scope.threadRoot.addChild container
+
+    $rootScope.$on 'annotationCreated', (event, annotation) ->
+      for child in ($scope.threadRoot.children or []) \
+      when child.message is annotation
+        child.message = null
+        $scope.threadRoot.removeChild child
+        container = mail.messageContainer(annotation)
+        $scope.threadRoot.addChild container
+        break
+
+    $rootScope.$on 'annotationDeleted', (event, annotation) ->
+      for child in ($scope.threadRoot.children or []) \
+      when child.message is annotation
+        child.message = null
+        $scope.threadRoot.removeChild child
+        break
+
+    $rootScope.$on 'annotationsLoaded', (event, annotations) ->
+      for annotation in annotations
+        container = mail.messageContainer(annotation)
+        $scope.threadRoot.addChild container
+
     # Initialize the base filter
     streamFilter
       .resetFilter()

--- a/h/static/scripts/test/annotation-viewer-controller-test.coffee
+++ b/h/static/scripts/test/annotation-viewer-controller-test.coffee
@@ -5,17 +5,81 @@ sinon.assert.expose assert, prefix: null
 
 
 describe 'AnnotationViewerController', ->
-  annotationViewerController = null
+  $scope = null
+  $scope = null
+  fakeAnnotationMapper = null
+  fakeLocation = null
+  fakeParams = null
+  fakeStore = null
+  fakeStreamer = null
+  fakeStreamFilter = null
+  fakeThreading = null
+
+  sandbox = null
 
   before ->
     angular.module('h', ['ngRoute'])
     .controller('AnnotationViewerController', require('../annotation-viewer-controller'))
 
+  beforeEach module('h')
+
+  beforeEach module ($provide) ->
+    sandbox = sinon.sandbox.create()
+
+    fakeAnnotationMapper = {
+      loadAnnotations: sandbox.spy()
+    }
+
+    fakeLocation = {
+      search: sandbox.stub().returns({})
+    }
+
+    fakeParams = {id: 'test'}
+
+    fakeStore = {
+      SearchResource: {
+        get: sinon.spy()
+      }
+    }
+
+    fakeStreamer = {
+      open: sandbox.spy()
+      close: sandbox.spy()
+      send: sandbox.spy()
+    }
+
+    fakeStreamFilter = {
+      setMatchPolicyIncludeAny: sandbox.stub().returnsThis()
+      addClause: sandbox.stub().returnsThis()
+      getFilter: sandbox.stub().returns({})
+    }
+
+    fakeThreading = {
+      idTable: {}
+      register: (annotation) ->
+        @idTable[annotation.id] = message: annotation
+    }
+
+    $provide.value 'annotationMapper', fakeAnnotationMapper
+    $provide.value '$location', fakeLocation
+    $provide.value '$routeParams', fakeParams
+    $provide.value 'store', fakeStore
+    $provide.value 'streamer', fakeStreamer
+    $provide.value 'streamFilter', fakeStreamFilter
+    $provide.value 'threading', fakeThreading
+    return
+
+  afterEach ->
+    sandbox.restore()
+
+  annotationViewerController = null
+
   beforeEach inject ($controller, $rootScope) ->
     $scope = $rootScope.$new()
     $scope.search = {}
+    $scope.lookup = {}
     annotationViewerController = $controller 'AnnotationViewerController',
       $scope: $scope
 
-    it 'sets the isEmbedded property to false', ->
-      assert.isFalse($scope.isEmbedded)
+  it 'sets the isEmbedded property to false', ->
+    assert.isFalse($scope.isEmbedded)

--- a/h/static/scripts/test/app-controller-test.coffee
+++ b/h/static/scripts/test/app-controller-test.coffee
@@ -18,7 +18,6 @@ describe 'AppController', ->
   fakeStore = null
   fakeStreamer = null
   fakeStreamFilter = null
-  fakeThreading = null
 
   sandbox = null
 
@@ -87,12 +86,6 @@ describe 'AppController', ->
       getFilter: sandbox.stub().returns({})
     }
 
-    fakeThreading = {
-      idTable: {}
-      register: (annotation) ->
-        @idTable[annotation.id] = message: annotation
-    }
-
     $provide.value 'annotationMapper', fakeAnnotationMapper
     $provide.value 'annotationUI', fakeAnnotationUI
     $provide.value 'auth', fakeAuth
@@ -104,7 +97,6 @@ describe 'AppController', ->
     $provide.value 'store', fakeStore
     $provide.value 'streamer', fakeStreamer
     $provide.value 'streamfilter', fakeStreamFilter
-    $provide.value 'threading', fakeThreading
     return
 
   beforeEach inject (_$controller_, $rootScope) ->
@@ -148,7 +140,7 @@ describe 'AppController', ->
         payload: anns
       assert.calledWith fakeAnnotationMapper.loadAnnotations, anns
 
-    it 'looks up annotations at threading upon "delete" action', ->
+    it 'ask lookup.hasAnnotation "delete" action', ->
       createController()
       $scope.$emit = sinon.spy()
 
@@ -157,8 +149,9 @@ describe 'AppController', ->
         id: "fake ID"
         data: "local data"
 
-      # Introduce our annotation into threading
-      fakeThreading.register localAnnotation
+      # Register our fake hasAnnotation function
+      $scope.lookup.hasAnnotation = ->
+        return localAnnotation
 
       # Prepare the annotation that will come "from the wire"
       remoteAnnotation =

--- a/h/static/scripts/test/stream-controller-test.coffee
+++ b/h/static/scripts/test/stream-controller-test.coffee
@@ -67,9 +67,6 @@ describe 'StreamController', ->
 
     return
 
-  afterEach ->
-    sandbox.restore()
-
   createController = null
 
   beforeEach inject ($controller, $rootScope) ->
@@ -79,12 +76,22 @@ describe 'StreamController', ->
     $scope.search = {
       query: ''
     }
+    $scope.lookup = {
+      hasAnnotation: sinon.spy()
+      getAnnotationContainers: sinon.spy()
+    }
     $scope.sort = {
       name: 'Newest'
     }
 
     createController = ->
-      $controller('StreamController', {$scope: $scope})
+      controller = $controller('StreamController', {$scope: $scope})
+      controller.threadRoot.children = []
+      controller.idTable = {}
+      controller
+
+  afterEach ->
+    sandbox.restore()
 
   describe '$routeParams', ->
     it 'gets populates the search query from routeParams.q', ->

--- a/h/static/scripts/test/stream-controller-test.coffee
+++ b/h/static/scripts/test/stream-controller-test.coffee
@@ -1,0 +1,173 @@
+{module, inject} = require('angular-mock')
+
+assert = chai.assert
+sinon.assert.expose assert, prefix: null
+
+describe 'StreamController', ->
+  $scope = null
+  fakeAnnotationMapper = null
+  fakeQueryParser = null
+  fakeRouteParams = null
+  fakeSearchFilter = null
+  fakeStore = null
+  fakeStreamer = null
+  fakeStreamFilter = null
+
+  sandbox = null
+
+  before ->
+    angular.module('h', ['ngRoute'])
+    .controller('StreamController', require('../stream-controller'))
+
+  beforeEach module('h')
+
+  beforeEach module ($provide) ->
+    sandbox = sinon.sandbox.create()
+
+    fakeAnnotationMapper = {
+      loadAnnotations: sandbox.spy()
+    }
+
+    fakeQueryParser = {
+      populateFilter: sandbox.spy()
+    }
+
+    fakeRouteParams = {q: 'text:test'}
+
+    fakeSearchFilter = {
+      generateFacetedFilter: sandbox.spy()
+      toObject: sandbox.spy()
+    }
+
+    fakeStore = {
+      SearchResource: {
+        get: sinon.spy()
+      }
+    }
+
+    fakeStreamer = {
+      open: sandbox.spy()
+      close: sandbox.spy()
+      send: sandbox.spy()
+    }
+
+    fakeStreamFilter = {
+      setMatchPolicyIncludeAll: sandbox.spy()
+      resetFilter: sandbox.stub().returnsThis()
+      getFilter: sandbox.spy()
+    }
+
+    $provide.value 'annotationMapper', fakeAnnotationMapper
+    $provide.value 'queryParser', fakeQueryParser
+    $provide.value '$routeParams', fakeRouteParams
+    $provide.value 'searchFilter', fakeSearchFilter
+    $provide.value 'store', fakeStore
+    $provide.value 'streamer', fakeStreamer
+    $provide.value 'streamFilter', fakeStreamFilter
+
+    return
+
+  afterEach ->
+    sandbox.restore()
+
+  createController = null
+
+  beforeEach inject ($controller, $rootScope) ->
+    $scope = $rootScope.$new()
+    $scope.$digest = sinon.spy()
+    $scope.threading = sinon.spy()
+    $scope.search = {
+      query: ''
+    }
+    $scope.sort = {
+      name: 'Newest'
+    }
+
+    createController = ->
+      $controller('StreamController', {$scope: $scope})
+
+  describe '$routeParams', ->
+    it 'gets populates the search query from routeParams.q', ->
+      query = 'text:foo quote:bar user:john@doe'
+      fakeRouteParams.q  = query
+      createController()
+
+      assert.equal $scope.search.query, query
+
+  describe 'beforeAnnotationCreated', ->
+    it 'puts the annotation within a container into $scope.threadRoot', ->
+      annotation = {id: 'test', text: 'blabla'}
+      createController()
+      $scope.$emit 'beforeAnnotationCreated', annotation
+
+      container = $scope.threadRoot.children[0]
+      assert.isTrue container.message?
+      assert.deepEqual container.message, annotation
+
+  describe 'annotationCreated', ->
+    it 'removes and reinserts the annotation from $scope.threadRoot', ->
+      annotation1 = {id: 'test1', text: 'blabla'}
+      annotation2 = {id: 'test2', text: 'blabla'}
+
+      createController()
+      $scope.$emit 'beforeAnnotationCreated', annotation1
+      $scope.$emit 'beforeAnnotationCreated', annotation2
+
+      container1 = $scope.threadRoot.children[0]
+      container2 = $scope.threadRoot.children[1]
+
+      assert.deepEqual container1.message, annotation1
+      assert.deepEqual container2.message, annotation2
+
+      annotation1.quote = 'more blabla'
+      $scope.$emit 'annotationCreated', annotation1
+
+      container1 = $scope.threadRoot.children[0]
+      container2 = $scope.threadRoot.children[1]
+
+      assert.deepEqual container1.message, annotation2
+      assert.deepEqual container2.message, annotation1
+
+  describe 'annotationDeleted', ->
+    it 'removes the annotation container from $scope.threadRoot', ->
+      annotation1 = {id: 'test1', text: 'blabla'}
+      annotation2 = {id: 'test2', text: 'blabla'}
+
+      createController()
+      $scope.$emit 'beforeAnnotationCreated', annotation1
+      $scope.$emit 'beforeAnnotationCreated', annotation2
+
+      $scope.$emit 'annotationDeleted', annotation1
+      container = $scope.threadRoot.children[0]
+      assert.deepEqual container.message, annotation2
+
+  describe 'annotationLoaded', ->
+    it 'populates the annotations into $scope.threadRoot', ->
+      annotation1 = {id: 'test1', text: 'blabla'}
+      annotation2 = {id: 'test2', text: 'blabla'}
+
+      createController()
+      $scope.$emit 'annotationsLoaded', [annotation1, annotation2]
+
+      container1 = $scope.threadRoot.children[0]
+      container2 = $scope.threadRoot.children[1]
+
+      assert.deepEqual container1.message, annotation1
+      assert.deepEqual container2.message, annotation2
+
+    it 'appends to the children, do not delete them', ->
+      annotation1 = {id: 'test1', text: 'blabla'}
+      annotation2 = {id: 'test2', text: 'blabla'}
+      annotation3 = {id: 'test3', text: 'blabla'}
+
+      createController()
+      $scope.$emit 'beforeAnnotationCreated', annotation1
+      $scope.$emit 'annotationsLoaded', [annotation2, annotation3]
+
+      container1 = $scope.threadRoot.children[0]
+      container2 = $scope.threadRoot.children[1]
+      container3 = $scope.threadRoot.children[2]
+
+      assert.deepEqual container1.message, annotation1
+      assert.deepEqual container2.message, annotation2
+      assert.deepEqual container3.message, annotation3

--- a/h/static/scripts/test/widget-controller-test.coffee
+++ b/h/static/scripts/test/widget-controller-test.coffee
@@ -13,6 +13,7 @@ describe 'WidgetController', ->
   fakeStore = null
   fakeStreamer = null
   fakeStreamFilter = null
+  fakeThreading = null
   sandbox = null
   viewer = null
 
@@ -57,6 +58,13 @@ describe 'WidgetController', ->
       getFilter: sandbox.stub().returns({})
     }
 
+    fakeThreading = {
+      idTable: {}
+      register: (annotation) ->
+        @idTable[annotation.id] = message: annotation
+    }
+
+
     $provide.value 'annotationMapper', fakeAnnotationMapper
     $provide.value 'annotationUI', fakeAnnotationUI
     $provide.value 'auth', fakeAuth
@@ -64,10 +72,12 @@ describe 'WidgetController', ->
     $provide.value 'store', fakeStore
     $provide.value 'streamer', fakeStreamer
     $provide.value 'streamFilter', fakeStreamFilter
+    $provide.value 'threading', fakeThreading
     return
 
   beforeEach inject ($controller, $rootScope) ->
     $scope = $rootScope.$new()
+    $scope.lookup = {}
     viewer = $controller 'WidgetController', {$scope}
 
   afterEach ->

--- a/h/static/scripts/widget-controller.coffee
+++ b/h/static/scripts/widget-controller.coffee
@@ -4,15 +4,26 @@ angular = require('angular')
 module.exports = class WidgetController
   this.$inject = [
     '$scope', 'annotationUI', 'crossframe', 'annotationMapper',
-    'auth', 'streamer', 'streamFilter', 'store'
+    'auth', 'streamer', 'streamFilter', 'store', 'threading'
   ]
   constructor:   (
      $scope,   annotationUI, crossframe, annotationMapper,
-     auth,   streamer,   streamFilter,   store
+     auth,   streamer,   streamFilter,   store,   threading
   ) ->
     # Tells the view that these annotations are embedded into the owner doc
     $scope.isEmbedded = true
     $scope.isStream = true
+
+    $scope.threadRoot = threading?.root
+
+    $scope.lookup.hasAnnotation = (annotation) ->
+      threading.idTable[annotation.id]?.message
+
+    $scope.lookup.getAnnotationContainers = ->
+      containers = []
+      for id, container of threading.idTable when container.message
+        containers.push container
+      containers
 
     loaded = []
 


### PR DESCRIPTION
First step for streamer and viewer separation.
StreamSearchController generates the cards to be displayed
in the streamer, and handles the annotation events.

Stream no longer relies on the threading service.
The messageContainers from jwz are still used.
They still share the same template.

Replies in the stream are displayed as root level annotation
cards.

Fix #1916