### PR TITLE
Namespaced NSQ

### DIFF
--- a/h/config.py
+++ b/h/config.py
@@ -128,6 +128,9 @@ def _setup_nsqd(settings):
         w_port = os.environ['NSQD_PORT_4151_TCP_PORT']
         settings['nsq.writer.address'] = '{}:{}'.format(w_host, w_port)
 
+    if 'NSQ_NAMESPACE' in os.environ:
+        settings['nsq.namespace'] = os.environ['NSQ_NAMESPACE']
+
 
 def _setup_redis(settings):
     if 'REDIS_PORT' in os.environ:

--- a/h/queue.py
+++ b/h/queue.py
@@ -2,6 +2,17 @@ from pyramid.settings import aslist
 import gnsq
 
 
+class NamespacedNsqd(object):
+    def __init__(self, namespace, *args, **kwargs):
+        self.client = gnsq.Nsqd(*args, **kwargs)
+        self.namespace = namespace
+
+    def publish(self, topic, data):
+        if self.namespace is not None:
+            topic = '{0}-{1}'.format(self.namespace, topic)
+        return self.client.publish(topic, data)
+
+
 def get_reader(request, topic, channel):
     """
     Get a :py:class:`gnsq.Reader` instance configured to connect to the
@@ -11,9 +22,11 @@ def get_reader(request, topic, channel):
     The caller is responsible for adding appropriate `on_message` hooks and
     starting the reader.
     """
+    ns = request.registry.settings.get('nsq.namespace')
     addrs = aslist(request.registry.settings.get('nsq.reader.addresses',
                                                  'localhost:4150'))
-    topic = _topic_name(request, topic)
+    if ns is not None:
+        topic = '{0}-{1}'.format(ns, topic)
     reader = gnsq.Reader(topic, channel, nsqd_tcp_addresses=addrs)
     return reader
 
@@ -24,18 +37,12 @@ def get_writer(request):
     writer address configured in settings. The writer communicates over the
     nsq HTTP API and does not hold a connection open to the nsq instance.
     """
-    setting = request.registry.settings.get('nsq.writer.address',
-                                            'localhost:4151')
-    hostname, port = setting.split(':', 1)
-    nsqd = gnsq.Nsqd(hostname, http_port=port)
-    return nsqd
-
-
-def _topic_name(request, name):
     ns = request.registry.settings.get('nsq.namespace')
-    if ns is None:
-        return name
-    return '{0}-{1}'.format(ns, name)
+    addr = request.registry.settings.get('nsq.writer.address',
+                                         'localhost:4151')
+    hostname, port = addr.split(':', 1)
+    nsqd = NamespacedNsqd(ns, hostname, http_port=port)
+    return nsqd
 
 
 def includeme(config):

--- a/h/queue.py
+++ b/h/queue.py
@@ -11,9 +11,9 @@ def get_reader(request, topic, channel):
     The caller is responsible for adding appropriate `on_message` hooks and
     starting the reader.
     """
-    setting = request.registry.settings.get('nsq.reader.addresses',
-                                            'localhost:4150')
-    addrs = aslist(setting)
+    addrs = aslist(request.registry.settings.get('nsq.reader.addresses',
+                                                 'localhost:4150'))
+    topic = _topic_name(request, topic)
     reader = gnsq.Reader(topic, channel, nsqd_tcp_addresses=addrs)
     return reader
 
@@ -29,6 +29,13 @@ def get_writer(request):
     hostname, port = setting.split(':', 1)
     nsqd = gnsq.Nsqd(hostname, http_port=port)
     return nsqd
+
+
+def _topic_name(request, name):
+    ns = request.registry.settings.get('nsq.namespace')
+    if ns is None:
+        return name
+    return '{0}-{1}'.format(ns, name)
 
 
 def includeme(config):

--- a/h/test/config_test.py
+++ b/h/test/config_test.py
@@ -153,6 +153,17 @@ def test_nsqd_environment():
 
 
 @patch.dict(os.environ)
+def test_nsq_namespace():
+    os.environ['NSQ_NAMESPACE'] = 'staging'
+
+    actual_config = settings_from_environment()
+    expected_config = {
+        'nsq.namespace': 'staging',
+    }
+    assert actual_config == expected_config
+
+
+@patch.dict(os.environ)
 def test_redis_database_environment():
     os.environ['REDIS_PORT'] = 'tcp://127.0.0.1:4567'
     os.environ['REDIS_PORT_6379_TCP_ADDR'] = '127.0.0.1'

--- a/h/test/queue_test.py
+++ b/h/test/queue_test.py
@@ -5,6 +5,7 @@ from mock import patch
 from h import queue
 
 
+
 @patch('gnsq.Reader')
 def test_get_reader_default(fake_reader):
     req = testing.DummyRequest()
@@ -28,6 +29,11 @@ def test_get_reader(fake_reader):
 
 @patch('gnsq.Reader')
 def test_get_reader_namespace(fake_reader):
+    """
+    When the ``nsq.namespace`` setting is provided, `get_reader` should return
+    a reader that automatically prefixes the namespace onto the name of the
+    topic being read.
+    """
     req = testing.DummyRequest()
     req.registry.settings.update({
         'nsq.namespace': "abc123"
@@ -51,3 +57,22 @@ def test_get_writer(fake_nsqd):
     req.registry.settings.update({'nsq.writer.address': 'philae:2014'})
     queue.get_writer(req)
     fake_nsqd.assert_called_with('philae', http_port='2014')
+
+
+@patch('gnsq.Nsqd')
+def test_get_writer_namespace(fake_nsqd):
+    """
+    When the ``nsq.namespace`` setting is provided, `get_writer` should return
+    a writer that automatically prefixes the namespace onto the topic names
+    given to :method:`gnsq.Nsqd.publish` or :method:`gnsq.Nsqd.mpublish`.
+    """
+    fake_client = fake_nsqd.return_value
+    req = testing.DummyRequest()
+    req.registry.settings.update({
+        'nsq.namespace': "abc123"
+    })
+
+    writer = queue.get_writer(req)
+
+    writer.publish('sometopic', 'somedata')
+    fake_client.publish.assert_called_with('abc123-sometopic', 'somedata')

--- a/h/test/queue_test.py
+++ b/h/test/queue_test.py
@@ -1,14 +1,13 @@
 from pyramid import testing
 from mock import patch
 
-from ..queue import get_reader
-from ..queue import get_writer
+from h import queue
 
 
 @patch('gnsq.Reader')
 def test_get_reader_default(fake_reader):
     req = testing.DummyRequest()
-    get_reader(req, 'ethics-in-games-journalism', 'channel4')
+    queue.get_reader(req, 'ethics-in-games-journalism', 'channel4')
     fake_reader.assert_called_with('ethics-in-games-journalism',
                                    'channel4',
                                    nsqd_tcp_addresses=['localhost:4150'])
@@ -20,7 +19,7 @@ def test_get_reader(fake_reader):
     req.registry.settings.update({
         'nsq.reader.addresses': "foo:1234\nbar:4567"
     })
-    get_reader(req, 'ethics-in-games-journalism', 'channel4')
+    queue.get_reader(req, 'ethics-in-games-journalism', 'channel4')
     fake_reader.assert_called_with('ethics-in-games-journalism',
                                    'channel4',
                                    nsqd_tcp_addresses=['foo:1234',
@@ -30,7 +29,7 @@ def test_get_reader(fake_reader):
 @patch('gnsq.Nsqd')
 def test_get_writer_default(fake_nsqd):
     req = testing.DummyRequest()
-    get_writer(req)
+    queue.get_writer(req)
     fake_nsqd.assert_called_with('localhost', http_port='4151')
 
 
@@ -38,5 +37,5 @@ def test_get_writer_default(fake_nsqd):
 def test_get_writer(fake_nsqd):
     req = testing.DummyRequest()
     req.registry.settings.update({'nsq.writer.address': 'philae:2014'})
-    get_writer(req)
+    queue.get_writer(req)
     fake_nsqd.assert_called_with('philae', http_port='2014')

--- a/h/test/queue_test.py
+++ b/h/test/queue_test.py
@@ -1,3 +1,4 @@
+import pytest
 from pyramid import testing
 from mock import patch
 
@@ -24,6 +25,17 @@ def test_get_reader(fake_reader):
                                    'channel4',
                                    nsqd_tcp_addresses=['foo:1234',
                                                        'bar:4567'])
+
+@patch('gnsq.Reader')
+def test_get_reader_namespace(fake_reader):
+    req = testing.DummyRequest()
+    req.registry.settings.update({
+        'nsq.namespace': "abc123"
+    })
+    queue.get_reader(req, 'safari', 'elephants')
+    fake_reader.assert_called_with('abc123-safari',
+                                   'elephants',
+                                   nsqd_tcp_addresses=['localhost:4150'])
 
 
 @patch('gnsq.Nsqd')


### PR DESCRIPTION
To solve the issue of different instances of `h` stomping all over one another when they share an NSQ cluster, add support for setting a "namespace" which will be prefixed to all the topic names that queue readers and writers address.

<!---
@huboard:{"order":1778.0,"milestone_order":2082,"custom_state":""}
-->
