### PR TITLE
Scroll to login form when clicking sign in link

### DIFF
--- a/h/templates/app.html
+++ b/h/templates/app.html
@@ -24,7 +24,7 @@
           <li ng-show="auth.user"><a href="" ng-click="logout()">Sign out</a></li>
         </ul>
       </div>
-      <a class="pull-right" href=""
+      <a class="pull-right" href="#login-form"
          ng-click="login()"
          ng-switch-when="null">Sign in</a>
 

--- a/h/templates/client/auth.html
+++ b/h/templates/client/auth.html
@@ -5,7 +5,8 @@
      ng-model="account.tab"
      ng-submit="vm.submit(form[account.tab])">
   <!-- Login -->
-  <form data-title="Sign in"
+  <form id="login-form"
+        data-title="Sign in"
         data-value="login"
         class="form tab-pane"
         name="login"


### PR DESCRIPTION
This fixes #2052: if the login form is already shown but the
iframe is taller than the window and scrolled down so that the form is
out of view, then clicking on Sign in would do nothing. With this fix,
clicking Sign in scrolls the iframe up to the login form.

@gergely-ujvari Could you review this?