### PR TITLE
Better API docs

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,115 +1,318 @@
-====================
-Source Documentation
-====================
+HTTP API
+========
 
-Reference material for the public APIs exposed is available in this section. It
-It is targeted at developers interested in integrating functionality from
-Hypothesis into their own Python applications. ::
-
-    {
-        "links": {
-            "annotation": {
-                "delete": {
-                    "desc": "Delete an annotation", 
-                    "method": "DELETE", 
-                    "url": "https://hypothes.is/api/annotations/:id"
-                }, 
-                "update": {
-                    "desc": "Update an existing annotation", 
-                    "method": "PUT", 
-                    "url": "https://hypothes.is/api/annotations/:id"
-                }, 
-                "create": {
-                    "desc": "Create a new annotation", 
-                    "method": "POST", 
-                    "url": "https://hypothes.is/api/annotations"
-                }, 
-                "read": {
-                    "desc": "Get an existing annotation", 
-                    "method": "GET", 
-                    "url": "https://hypothes.is/api/annotations/:id"
-                }
-            }, 
-            "search": {
-                "desc": "Basic search API", 
-                "method": "GET", 
-                "url": "https://hypothes.is/api/search"
-            }
-        }, 
-        "message": "Annotator Store API"
-    }
+This document details the ``h`` application's public HTTP API. It is targeted at
+developers interested in integrating functionality from Hypothesis into their
+own applications.
 
 
---------------
-API Endpoints:
---------------
-
-/search
-=======
-
-Search for annotations annotations
-
-Examples:
-
-https://hypothes.is/api/search?limit=1000&uri=http%3A%2F%2Fepubjs-reader.appspot.com%2F%2Fmoby-dick%2FOPS%2Fchapter_003.xhtml&user=acct:gluejar@hypothes.is
-
-https://hypothes.is/api/search?limit=1000&user=gluejar@hypothes.is
-
-https://hypothes.is/api/search?limit=1000&quote=limber
-
-https://hypothes.is/api/search?limit=1000&text=consider
-
-params:
-
-* limit - number of results to return
-* uri - url encoded uri to get annotations for
-* user - get annotations for a particular user.
-* quote - words that the annotation is quoting.
-* text - search annotation text.
-
-/annotations
-============
-
-Read
+root
 ----
 
-https://hypothes.is/api/annotations/<annotation id>
+.. http:get:: /api
 
-method: GET
+   API root. Returns hypermedia links to the rest of the API.
 
-get an annotation
+   **Example request**:
 
-Examples:
+   .. sourcecode:: http
 
-https://hypothes.is/api/annotations/utalbWjUQZK5ifydnohjmA
+      GET /api
+      Host: hypothes.is
+      Accept: application/json
 
-Create
+
+   **Example response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Content-Type: application/json; charset=UTF-8
+
+      {
+          "links": {
+              "annotation": {
+                  "create": {
+                      "desc": "Create a new annotation",
+                      "method": "POST",
+                      "url": "https://hypothes.is/api/annotations"
+                  },
+                  "delete": {
+                      "desc": "Delete an annotation",
+                      "method": "DELETE",
+                      "url": "https://hypothes.is/api/annotations/:id"
+                  },
+                  "read": {
+                      "desc": "Get an existing annotation",
+                      "method": "GET",
+                      "url": "https://hypothes.is/api/annotations/:id"
+                  },
+                  "update": {
+                      "desc": "Update an existing annotation",
+                      "method": "PUT",
+                      "url": "https://hypothes.is/api/annotations/:id"
+                  }
+              },
+              "search": {
+                  "desc": "Basic search API",
+                  "method": "GET",
+                  "url": "https://hypothes.is/api/search"
+              }
+          },
+          "message": "Annotator Store API"
+      }
+
+   :reqheader Accept: desired response content type
+   :resheader Content-Type: response content type
+   :statuscode 200: no error
+
+
+search
 ------
 
-https://hypothes.is/api/annotations/
+.. http:get:: /api/search
 
-method: POST
+   Search for annotations.
 
-create a new annotation (needs authentication)
+   **Example request**:
 
-Update
+   .. sourcecode:: http
+
+      GET /api/search?limit=1000&user=gluejar@hypothes.is
+      Host: hypothes.is
+      Accept: application/json
+
+   **Example response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Content-Type: application/json; charset=UTF-8
+
+      {
+          "rows": [
+              {
+                  "consumer": "00000000-0000-0000-0000-000000000000",
+                  "created": "2014-01-12T18:36:15.697572+00:00",
+                  "id": "LGVKq4E4SKKro1dBBEMwsA",
+                  "permissions": { ... },
+                  "references": ["6lkzoOubSOOymDNDIgazqw"],
+                  "target": [],
+                  "text": "Peut-etre",
+                  "updated": "2014-01-12T18:36:15.697588+00:00",
+                  "uri": "http://epubjs-reader.appspot.com//moby-dick/OPS/chapter_003.xhtml",
+                  "user": "acct:gluejar@hypothes.is"
+              }
+          ],
+          "total": 1
+      }
+
+   :query limit: number of results to return
+   :query uri: limit results to annotations of `uri` (must be urlencoded)
+   :query user: limit results to annotations created by `user`
+   :query quote: limit results to annotations where quoted text contains `quote`
+   :query text: limit results to annotations where body test contains `text`
+   :reqheader Accept: desired response content type
+   :resheader Content-Type: response content type
+   :statuscode 200: no error
+   :statuscode 400: errors parsing your query
+
+
+read
+----
+
+.. http:get:: /api/annotations/(string:id)
+
+   Retrieve a single annotation.
+
+   **Example request**:
+
+   .. sourcecode:: http
+
+     GET /api/annotations/utalbWjUaZK5ifydnohjmA
+     Host: hypothes.is
+     Accept: application/json
+
+   **Example response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Content-Type: application/json; charset=UTF-8
+
+      {
+          "consumer": "00000000-0000-0000-0000-000000000000",
+          "created": "2013-08-26T13:31:49.339078+00:00",
+          "document": { ... },
+          "id": "utalbWjUQZK5ifydnohjmA",
+          "permissions": { ... },
+          "references": [
+              "ZkDZ8ZRXQkiEeG_3r7s1IA",
+              "4uUTPORmTN-0y-puAXe_sw"
+          ],
+          "target": [],
+          "text": "Dan, thanks for your team's work ...",
+          "updated": "2013-08-26T14:09:14.121339+00:00",
+          "uri": "http://example.com/foo",
+          "user": "acct:johndoe@example.org"
+      }
+
+   :reqheader Accept: desired response content type
+   :resheader Content-Type: response content type
+   :statuscode 200: no error
+   :statuscode 404: annotation with the specified `id` not found
+
+
+create
 ------
 
-method: PUT
+.. http:post:: /api/annotations
 
-update an existing annotation (needs authentication)
+   Create a new annotation. Requires a valid authentication token.
 
-Delete
+   **Example request**:
+
+   .. sourcecode:: http
+
+      POST /api/annotations
+      Host: hypothes.is
+      Accept: application/json
+      Content-Type: application/json;charset=UTF-8
+      X-Annotator-Auth-Token: eyJhbGc[...]mbl_YBM
+
+      {
+          "uri": "http://example.com/",
+          "user": "acct:joebloggs@example.org",
+          "permissions": {
+              "read": ["group:__world__"],
+              "update": ["acct:joebloggs@example.org"],
+              "delete": ["acct:joebloggs@example.org"],
+              "admin": ["acct:joebloggs@example.org"],
+          },
+          "document": { ... },
+          "target": [ ... ],
+          "tags": [],
+          "text": "This is an annotation I made."
+      }
+
+   **Example response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Content-Type: application/json; charset=UTF-8
+
+      {
+          "id": "AUxWM-HasREW1YKAwhil",
+          "uri": "http://example.com/",
+          "user": "acct:joebloggs@example.org",
+          ...
+      }
+
+   :param id: annotation's unique id
+   :reqheader Accept: desired response content type
+   :reqheader Content-Type: request body content type
+   :reqheader X-Annotator-Auth-Token: JWT authentication token
+   :resheader Content-Type: response content type
+   :>json string id: unique id of new annotation
+   :>json datetime created: created date of new annotation
+   :>json datetime updated: updated date of new annotation (same as `created`)
+   :statuscode 200: no error
+   :statuscode 400: could not create annotation from your request (bad payload)
+   :statuscode 401: no auth token was provided
+   :statuscode 403: auth token provided does not convey "create" permissions
+
+
+update
 ------
 
-https://hypothes.is/api/annotations/<annotation id>
+.. http:put:: /api/annotations/(string:id)
 
-method: DELETE
+   Update the annotation with the given `id`. Requires a valid authentication
+   token.
 
-delete an existing annotation (needs authentication)
+   **Example request**:
+
+   .. sourcecode:: http
+
+      PUT /api/annotations/AUxWM-HasREW1YKAwhil
+      Host: hypothes.is
+      Accept: application/json
+      Content-Type: application/json;charset=UTF-8
+      X-Annotator-Auth-Token: eyJhbGc[...]mbl_YBM
+
+      {
+          "uri": "http://example.com/foo",
+      }
+
+   **Example response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Content-Type: application/json; charset=UTF-8
+
+      {
+          "id": "AUxWM-HasREW1YKAwhil",
+          "updated": "2015-03-26T13:09:42.646509+00:00"
+          "uri": "http://example.com/",
+          "user": "acct:joebloggs@example.org",
+          ...
+      }
+
+   :param id: annotation's unique id
+   :reqheader Accept: desired response content type
+   :reqheader Content-Type: request body content type
+   :reqheader X-Annotator-Auth-Token: JWT authentication token
+   :resheader Content-Type: response content type
+   :>json datetime updated: updated date of annotation
+   :statuscode 200: no error
+   :statuscode 400: could not update annotation from your request (bad payload)
+   :statuscode 401: no auth token was provided
+   :statuscode 403:
+      auth token provided does not convey "update" permissions for the
+      annotation with the given `id`
+   :statuscode 404: annotation with the given `id` was not found
 
 
-.. toctree::
-   :maxdepth: 1
+delete
+------
 
-   api/resources
+.. http:delete:: /api/annotations/(string:id)
+
+   Delete the annotation with the given `id`. Requires a valid authentication
+   token.
+
+   **Example request**:
+
+   .. sourcecode:: http
+
+      DELETE /api/annotations/AUxWM-HasREW1YKAwhil
+      Host: hypothes.is
+      Accept: application/json
+      X-Annotator-Auth-Token: eyJhbGc[...]mbl_YBM
+
+   **Example response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Content-Type: application/json; charset=UTF-8
+
+      {
+          "deleted": true,
+          "id": "AUxWM-HasREW1YKAwhil"
+      }
+
+   :param id: annotation's unique id
+   :reqheader Accept: desired response content type
+   :reqheader X-Annotator-Auth-Token: JWT authentication token
+   :resheader Content-Type: response content type
+   :>json boolean deleted: whether the annotation was deleted
+   :>json string id: the unique `id` of the deleted annotation
+   :statuscode 200: no error
+   :statuscode 401: no auth token was provided
+   :statuscode 403:
+      auth token provided does not convey "update" permissions for the
+      annotation with the given `id`
+   :statuscode 404: annotation with the given `id` was not found

--- a/docs/api/resources.rst
+++ b/docs/api/resources.rst
@@ -1,7 +1,0 @@
-.. _resources_module
-
-mod:`h.resources`
-------------------
-
-.. automodule:: h.resources
-   :members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -125,7 +125,7 @@ if not on_rtd:
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+#html_static_path = ['_static']
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,6 +13,8 @@
 
 import sys, os
 
+on_rtd = os.environ.get('READTHEDOCS') == 'True'
+
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
@@ -91,7 +93,10 @@ pygments_style = 'tango'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'default'
+if not on_rtd:
+    import sphinx_rtd_theme
+    html_theme = 'sphinx_rtd_theme'
+    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,7 +27,12 @@ on_rtd = os.environ.get('READTHEDOCS') == 'True'
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.intersphinx', 'sphinx.ext.viewcode']
+extensions = [
+  'sphinx.ext.autodoc',
+  'sphinx.ext.intersphinx',
+  'sphinx.ext.viewcode',
+  'sphinxcontrib.httpdomain',
+]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,5 +16,4 @@ Indices and tables
 ==================
 
 * :ref:`genindex`
-* :ref:`modindex`
 * :ref:`search`

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,1 @@
+sphinxcontrib-httpdomain


### PR DESCRIPTION
Use `sphinxcontrib.httpdomain` to generate better API documentation. See https://h.readthedocs.org/en/docs-tweaks/api.html for what it looks like.

I suspect this probably obviates the need for #1938.