### PR TITLE
Fix broken util.split_user

### DIFF
--- a/h/atom_feed.py
+++ b/h/atom_feed.py
@@ -63,7 +63,11 @@ def _feed_entry_from_annotation(
     :rtype: dict
 
     """
-    name = util.split_user(annotation["user"])[0]
+    parts = util.split_user(annotation["user"])
+    if parts is None:
+        name = annotation["user"]
+    else:
+        name = parts[0]
     document = annotation.get("document")
     if document:
         title = document.get("title", "")

--- a/h/test/util_test.py
+++ b/h/test/util_test.py
@@ -1,0 +1,11 @@
+from h import util
+
+
+def test_split_user():
+    parts = util.split_user("acct:seanh@hypothes.is")
+    assert parts == ('seanh', 'hypothes.is')
+
+
+def test_split_user_no_match():
+    parts = util.split_user("donkeys")
+    assert parts is None

--- a/h/util.py
+++ b/h/util.py
@@ -9,4 +9,8 @@ def split_user(username):
     ("seanh", "hypothes.is").
 
     """
-    return re.match(r'^acct:([^@]+)@(.*)$', username).groups()
+    match = re.match(r'^acct:([^@]+)@(.*)$', username)
+    if match:
+        return match.groups()
+    # Passed username didn't match
+    return None

--- a/h/views.py
+++ b/h/views.py
@@ -103,8 +103,8 @@ def stream(context, request):
 
     if stream_type == 'user':
         parts = util.split_user(stream_key)
-        if parts is not None and parts.groups()[1] == request.domain:
-            query = {'q': 'user:{}'.format(parts.groups()[0])}
+        if parts is not None and parts[1] == request.domain:
+            query = {'q': 'user:{}'.format(parts[0])}
         else:
             query = {'q': 'user:{}'.format(stream_key)}
     elif stream_type == 'tag':


### PR DESCRIPTION
The stream view assumed that split_user returned a re.Match object
rather then a tuple of match groups.

This commit makes split_user return None if the passed username is not
splittable, and places the responsibility on the caller to check for
this case.