### PR TITLE
Scroll to annotation editor when opening it

### DIFF
--- a/h/static/scripts/app-controller.coffee
+++ b/h/static/scripts/app-controller.coffee
@@ -87,6 +87,9 @@ module.exports = class AppController
     $rootScope.$on 'beforeAnnotationCreated', ->
       $scope.clearSelection()
 
+    $rootScope.$on 'editorOpened', (annotation) ->
+      $rootScope.scrollTo(annotation)
+
     $scope.login = ->
       $scope.dialog.visible = true
       identity.request {oncancel}

--- a/h/static/scripts/directive/annotation.coffee
+++ b/h/static/scripts/directive/annotation.coffee
@@ -116,6 +116,7 @@ AnnotationController = [
       @action = if model.id? then 'edit' else 'create'
       @editing = true
       @preview = 'no'
+      $rootScope.$emit("editorOpened", @annotation)
 
     ###*
     # @ngdoc method


### PR DESCRIPTION
This fixes #2053:

- Go to a page that has more than a screenful of
  annotations in the sidebar
- Scroll the sidebar to the very bottom
- Scroll the page to the very top, select some text and create a new annotation
  that will appear above the other annotations in the sidebar

=> The new annotation appears in the sidebar with its edit form open,
but it's off screen. From the user's POV nothing happens.

You can get the same bug by scrolling the sidebar to the top and
annotating the bottom of the page.

This commit fixes the issue by having AnnotationController emit an
"editorOpened" event whenever it opens its editor form, and having
AppController catch this event and scroll the sidebar to the annotation
that emitted the event.