### PR TITLE
Remove ES test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ language:
   - python
 python:
   - '2.7'
-before_install:
-  - sudo /usr/share/elasticsearch/bin/plugin -install elasticsearch/elasticsearch-analysis-icu/2.4.1
-  - sudo service elasticsearch restart
 install:
   - gem install sass
   - gem install compass

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ script:
   - make test
   - make cover
   - make lint
-  - hypothesis-buildext conf/development.ini chrome --base http://localhost
-  - hypothesis-buildext conf/development.ini firefox --base http://localhost
+  - hypothesis-buildext conf/testext.ini chrome --base http://localhost
+  - hypothesis-buildext conf/testext.ini firefox --base http://localhost
   - "hypothesis-buildext conf/production.ini chrome
     --base https://hypothes.is
     --assets chrome-extension://notarealkey/public"

--- a/Makefile
+++ b/Makefile
@@ -24,9 +24,6 @@ dev:
 	@gunicorn --reload --paste conf/development.ini
 
 test:
-	@echo -n "Checking to see if elasticsearch is running..."
-	$(eval es := $(shell wget --quiet --output-document - http://localhost:9200))
-	@if [ -n '${es}' ] ; then echo "yes." ; else echo "no!"; exit 1; fi
 	@python setup.py test
 	@"$$(npm bin)"/karma start h/static/scripts/karma.config.js --single-run
 	@"$$(npm bin)"/karma start h/browser/chrome/karma.config.js --single-run

--- a/conf/test.ini
+++ b/conf/test.ini
@@ -2,7 +2,6 @@
 use: egg:h
 
 es.host: http://localhost:9200
-es.index: annotator_test
 
 sqlalchemy.url: sqlite://
 

--- a/conf/testext.ini
+++ b/conf/testext.ini
@@ -3,6 +3,12 @@ use: egg:h
 
 es.host: http://localhost:9200
 
+h.feature.accounts: True
+h.feature.api: True
+h.feature.claim: True
+h.feature.streamer: True
+h.feature.notification: True
+
 sqlalchemy.url: sqlite://
 
 webassets.base_dir: h:static

--- a/h/conftest.py
+++ b/h/conftest.py
@@ -15,9 +15,6 @@ from sqlalchemy import engine_from_config
 from sqlalchemy.orm import scoped_session, sessionmaker
 from zope.sqlalchemy import ZopeTransactionExtension
 
-from h.api.db import create_db, delete_db
-from h.api.db import store_from_settings
-
 
 @pytest.fixture(scope='session', autouse=True)
 def settings():
@@ -88,17 +85,6 @@ def dummy_db_session(config):
     sess = DummySession()
     config.registry.registerUtility(sess, IDBSession)
     return sess
-
-
-@pytest.fixture()
-def es_connection(request, settings):
-    es = store_from_settings(settings)
-    create_db()
-    # Pylint issue #258: https://bitbucket.org/logilab/pylint/issue/258
-    #
-    # pylint: disable=unexpected-keyword-arg
-    es.conn.cluster.health(wait_for_status='yellow')
-    request.addfinalizer(delete_db)
 
 
 @pytest.fixture()

--- a/h/test/models_test.py
+++ b/h/test/models_test.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import unittest
-import pytest
 
 from pytest import fixture, raises
 from pyramid import security
@@ -58,22 +57,3 @@ class TestAnnotationPermissions(unittest.TestCase):
         actual = annotation.__acl__()
         expect = [(security.Allow, security.Authenticated, 'read')]
         assert actual == expect
-
-
-@pytest.mark.usefixtures('es_connection')
-def test_uri_mapping():
-    permissions = {
-        'read': ['group:__world__'],
-    }
-    a1 = models.Annotation(uri='http://example.com/page#hashtag',
-                           permissions=permissions)
-    a1.save()
-    a2 = models.Annotation(uri='http://example.com/page',
-                           permissions=permissions)
-    a2.save()
-    a3 = models.Annotation(uri='http://totallydifferent.domain.com/',
-                           permissions=permissions)
-    a3.save()
-
-    res = models.Annotation.search(query={'uri': 'example.com/page'})
-    assert len(res) == 2


### PR DESCRIPTION
Only one test in our codebase actually depends upon a running ElasticSearch server, and it doesn't really need to (and/or is testing the wrong thing).

So, remove it!