### PR TITLE
Remove Dockerfile entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,5 @@ RUN pip install -r requirements.txt
 ADD ./svc /etc/service
 
 # Startup and ports
-ENTRYPOINT ["/sbin/my_init"]
-CMD []
+CMD ["/sbin/my_init"]
 EXPOSE 8000


### PR DESCRIPTION
The Dockerfile entrypoint is a nice trick, but it actually makes running
one-off commands in containers rather confusing if you're not expecting
it.

Before:

    docker run hypothesis/h --skip-runit -- hypothesis token --sub acct:foo@bar.com conf/production.ini

After

    docker run hypothesis/h hypothesis token --sub acct:foo@bar.com conf/production.ini