### PR TITLE
Use domain as citation title if no document

### DIFF
--- a/h/static/scripts/directive/annotation.coffee
+++ b/h/static/scripts/directive/annotation.coffee
@@ -211,15 +211,15 @@ AnnotationController = [
       @annotationURI = new URL("/a/#{@annotation.id}", this.baseURI).href
 
       # Extract the document metadata.
+      uri = model.uri
+      domain = new URL(uri).hostname
       if model.document
-        uri = model.uri
         if uri.indexOf("urn") is 0
           # This URI is not clickable, see if we have something better
           for link in model.document.link when link.href.indexOf("urn")
             uri = link.href
             break
 
-        domain = new URL(uri).hostname
         documentTitle = if Array.isArray(model.document.title)
           model.document.title[0]
         else
@@ -229,11 +229,14 @@ AnnotationController = [
           uri: uri
           domain: domain
           title: documentTitle or domain
-
-        if @document.title.length > 30
-          @document.title = @document.title[0..29] + '…'
       else
-        @document = null
+        @document =
+          uri: uri
+          domain: domain
+          title: domain
+
+      if @document.title.length > 30
+        @document.title = @document.title[0..29] + '…'
 
       # Form the tags for ngTagsInput.
       @annotation.tags = ({text} for text in (model.tags or []))

--- a/h/static/scripts/directive/test/annotation-test.coffee
+++ b/h/static/scripts/directive/test/annotation-test.coffee
@@ -209,10 +209,20 @@ describe 'annotation', ->
       controller.render()
       assert.equal(controller.document.title, 'example.com')
 
-    it 'skips the document object if no document is present on the annotation', ->
+    it 'still sets the uri correctly if the annotation has no document', ->
       delete annotation.document
       controller.render()
-      assert.isNull(controller.document)
+      assert(controller.document.uri == $scope.annotation.uri)
+
+    it 'still sets the domain correctly if the annotation has no document', ->
+      delete annotation.document
+      controller.render()
+      assert(controller.document.domain == 'example.com')
+
+    it 'uses the domain for the title when the annotation has no document', ->
+      delete annotation.document
+      controller.render()
+      assert(controller.document.title == 'example.com')
 
     describe 'when there are no targets', ->
       beforeEach ->


### PR DESCRIPTION
An annotation's document.title is used as the citation when displaying
an annotation. If this is an older annotation that has no document, fall
back to using the domain as the citation title instead.

Fixes #1542