### PR TITLE
Bump the number of annotations loaded per request to 200

### DIFF
--- a/h/static/scripts/test/widget-controller-test.coffee
+++ b/h/static/scripts/test/widget-controller-test.coffee
@@ -75,6 +75,7 @@ describe 'WidgetController', ->
 
   describe 'loadAnnotations', ->
     it 'loads all annotation for a provider', ->
+      viewer.chunkSize = 20
       fakeCrossFrame.providers.push {entities: ['http://example.com']}
       $scope.$digest()
       loadSpy = fakeAnnotationMapper.loadAnnotations

--- a/h/static/scripts/widget-controller.coffee
+++ b/h/static/scripts/widget-controller.coffee
@@ -14,11 +14,12 @@ module.exports = class WidgetController
     $scope.isEmbedded = true
     $scope.isStream = true
 
+    @chunkSize = 200
     loaded = []
 
-    _loadAnnotationsFrom = (query, offset) ->
+    _loadAnnotationsFrom = (query, offset) =>
       queryCore =
-        limit: 20
+        limit: @chunkSize
         offset: offset
         sort: 'created'
         order: 'asc'


### PR DESCRIPTION
The overhead associated with a single search call is high enough that
loading only 20 annotations at once is too little. In a naive test this
reduces the time take to request about 300 annotations from 5 seconds to
about 800ms (which, IMO, is still far too slow.)