### PR TITLE
Scroll to new annotations on creation

### DIFF
--- a/h/static/scripts/directive/test/thread-test.coffee
+++ b/h/static/scripts/directive/test/thread-test.coffee
@@ -42,6 +42,25 @@ describe 'thread', ->
 
   describe 'controller', ->
 
+    it 'returns true from isNew() for a new annotation', ->
+      createDirective()
+
+      # When the user clicks to create a new annotation in the browser, we get
+      # a ThreadController with a container with a message (the annotation)
+      # with no id.
+      controller.container = {message: {}}
+
+      assert(controller.isNew())
+
+    it 'returns false from isNew() for an old annotation', ->
+      createDirective()
+
+      # When we create a ThreadController for an old annotation, the controller
+      # has a container with a message (the annotation) with an id.
+      controller.container = {message: {id: 123}}
+
+      assert(not controller.isNew())
+
     describe '#toggleCollapsed', ->
       count = null
 

--- a/h/static/scripts/directive/thread.coffee
+++ b/h/static/scripts/directive/thread.coffee
@@ -1,3 +1,5 @@
+uuid = require('node-uuid')
+
 ###*
 # @ngdoc type
 # @name thread.ThreadController
@@ -148,6 +150,8 @@ ThreadController = [
       else
         0
 
+    this.uuid = uuid.v4()
+
     this
 ]
 
@@ -174,8 +178,8 @@ isHiddenThread = (elem) ->
 # Directive that instantiates {@link thread.ThreadController ThreadController}.
 ###
 module.exports = [
-  '$parse', '$window', 'pulse', 'render',
-  ($parse,   $window,   pulse,   render) ->
+  '$parse', '$window', '$location', '$anchorScroll', 'pulse', 'render',
+  ($parse,   $window, $location, $anchorScroll, pulse,   render) ->
     linkFn = (scope, elem, attrs, [ctrl, counter, filter]) ->
 
       # We would ideally use require for this, but searching parents only for a
@@ -183,6 +187,7 @@ module.exports = [
       ctrl.parent = elem.parent().controller('thread')
       ctrl.counter = counter
       ctrl.filter = filter
+      ctrl.id = attrs.id
 
       # Track the number of messages in the thread
       if counter?
@@ -210,6 +215,10 @@ module.exports = [
         render ->
           ctrl.container = thread
           scope.$digest()
+          if (ctrl.id and not ctrl.container?.message?.id)
+            # Scroll the sidebar to show new annotations.
+            $location.hash(ctrl.id)
+            $anchorScroll()
 
     controller: ThreadController
     controllerAs: 'vm'

--- a/h/static/scripts/directive/thread.coffee
+++ b/h/static/scripts/directive/thread.coffee
@@ -150,7 +150,7 @@ ThreadController = [
       else
         0
 
-    this.uuid = uuid.v4()
+    this.id = uuid.v4()
 
     this
 ]
@@ -187,7 +187,6 @@ module.exports = [
       ctrl.parent = elem.parent().controller('thread')
       ctrl.counter = counter
       ctrl.filter = filter
-      ctrl.id = attrs.id
 
       # Track the number of messages in the thread
       if counter?

--- a/h/static/scripts/directive/thread.coffee
+++ b/h/static/scripts/directive/thread.coffee
@@ -138,6 +138,17 @@ ThreadController = [
         return true
       return @filter.check(@container)
 
+    ###*
+    # @ngdoc method
+    # @name thread.ThreadController#isNew
+    # @description
+    # Return true if this is a newly-created annotation (e.g. the user has just
+    # created it by clicking the new annotation button in the browser),
+    # false otherwise.
+    ###
+    this.isNew = ->
+      return (this.id and not this.container?.message?.id)
+
     this._isFilterActive = ->
       if @filter
         @filter.active()
@@ -214,7 +225,7 @@ module.exports = [
         render ->
           ctrl.container = thread
           scope.$digest()
-          if (ctrl.id and not ctrl.container?.message?.id)
+          if ctrl.isNew()
             # Scroll the sidebar to show new annotations.
             $location.hash(ctrl.id)
             $anchorScroll()

--- a/h/static/scripts/directive/thread.coffee
+++ b/h/static/scripts/directive/thread.coffee
@@ -179,7 +179,7 @@ isHiddenThread = (elem) ->
 ###
 module.exports = [
   '$parse', '$window', '$location', '$anchorScroll', 'pulse', 'render',
-  ($parse,   $window, $location, $anchorScroll, pulse,   render) ->
+  ($parse,   $window,   $location,   $anchorScroll,   pulse,   render) ->
     linkFn = (scope, elem, attrs, [ctrl, counter, filter]) ->
 
       # We would ideally use require for this, but searching parents only for a

--- a/h/templates/client/viewer.html
+++ b/h/templates/client/viewer.html
@@ -32,7 +32,7 @@
       </ul>
     </span>
   </li>
-  <li id="{{vm.uuid}}"
+  <li id="{{vm.id}}"
       class="paper thread"
       ng-class="{'js-hover': hasFocus(child.message)}"
       deep-count="count"

--- a/h/templates/client/viewer.html
+++ b/h/templates/client/viewer.html
@@ -32,7 +32,8 @@
       </ul>
     </span>
   </li>
-  <li class="paper thread"
+  <li id="{{vm.uuid}}"
+      class="paper thread"
       ng-class="{'js-hover': hasFocus(child.message)}"
       deep-count="count"
       thread="child" thread-filter


### PR DESCRIPTION
If necessary scroll the sidebar to show a newly created annotation (when
the user clicks the new annotation button).

Add unique ids to the <li> elements that contain the annotations, then
on creating a new annotation set the URL fragment to #<id> and scroll to
show the element.

Fixes #2053.