### PR TITLE
[WIP] Push handling annotations to the template controllers …

### DIFF
--- a/h/static/scripts/annotation-viewer-controller.coffee
+++ b/h/static/scripts/annotation-viewer-controller.coffee
@@ -3,18 +3,23 @@ angular = require('angular')
 
 module.exports = class AnnotationViewerController
   this.$inject = [
-    '$location', '$routeParams', '$scope',
-    'streamer', 'store', 'streamFilter', 'annotationMapper'
+    '$location', '$rootScope', '$routeParams', '$scope',
+    'annotationMapper', 'drafts', 'streamer', 'store', 'streamFilter',
+    'threading'
   ]
   constructor: (
-     $location,   $routeParams,   $scope,
-     streamer,   store,   streamFilter,   annotationMapper
+     $location,   $rootScope,   $routeParams,   $scope,
+     annotationMapper,   drafts,   streamer,   store,   streamFilter,
+     threading
   ) ->
+    $scope.threading = threading
+    $scope.threadRoot = $scope.threading?.root
+
     # Tells the view that these annotations are standalone
     $scope.isEmbedded = false
     $scope.isStream = false
 
-    # Provide no-ops until these methods are moved elsewere. They only apply
+    # Provide no-ops until these methods are moved elsewhere. They only apply
     # to annotations loaded into the stream.
     $scope.focus = angular.noop
 
@@ -36,3 +41,29 @@ module.exports = class AnnotationViewerController
       .addClause('/id', 'equals', id, true)
 
     streamer.send({filter: streamFilter.getFilter()})
+
+    # Listen to updates
+    streamer.onmessage = (data) ->
+      return if !data or data.type != 'annotation-notification'
+      action = data.options.action
+      payload = data.payload
+
+      return unless payload.length
+      switch action
+        when 'create', 'update', 'past'
+          annotationMapper.loadAnnotations payload
+        when 'delete'
+          for annotation in payload
+            if a = threading.idTable[annotation.id]?.message
+              $scope.$emit('annotationDeleted', a)
+
+      $scope.$digest()
+
+    listener = $rootScope.$on 'cleanupAnnotations', (event) ->
+      # Clean up any annotations
+      for id, container of $scope.threading.idTable when container.message
+        $scope.$emit('annotationDeleted', container.message)
+        drafts.remove container.message
+
+    $scope.$on '$destroy', ->
+      listener()

--- a/h/static/scripts/stream-controller.coffee
+++ b/h/static/scripts/stream-controller.coffee
@@ -1,17 +1,24 @@
 angular = require('angular')
-
+mail = require('./vendor/jwz')
 
 module.exports = class StreamController
+# To survive reloads
+  threadRoot: mail.messageContainer()
+  idTable: {}
+
   this.inject = [
-    '$scope', '$rootScope', '$routeParams',
-    'auth', 'queryParser', 'searchFilter', 'store',
-    'streamer', 'streamFilter', 'annotationMapper'
+    '$rootScope', '$routeParams', '$scope',
+    'annotationMapper', 'drafts', 'queryParser', 'searchFilter', 'store',
+    'streamer', 'streamFilter',
   ]
   constructor: (
-     $scope,   $rootScope,   $routeParams
-     auth,   queryParser,   searchFilter,   store,
-     streamer,   streamFilter, annotationMapper
+     $rootScope,   $routeParams,   $scope,
+     annotationMapper,   drafts,   queryParser,   searchFilter,   store,
+     streamer,   streamFilter,
   ) ->
+    # Initialize streamer cards
+    $scope.threadRoot = @threadRoot
+
     # Initialize the base filter
     streamFilter
       .resetFilter()
@@ -22,6 +29,23 @@ module.exports = class StreamController
     terms = searchFilter.generateFacetedFilter $scope.search.query
     queryParser.populateFilter streamFilter, terms
     streamer.send({filter: streamFilter.getFilter()})
+
+    # Listen to updates
+    streamer.onmessage = (data) =>
+      return if !data or data.type != 'annotation-notification'
+      action = data.options.action
+      payload = data.payload
+
+      return unless payload.length
+      switch action
+        when 'create', 'update', 'past'
+          annotationMapper.loadAnnotations payload
+        when 'delete'
+          for annotation in payload
+            if a = @idTable[annotation.id]?.message
+              $scope.$emit('annotationDeleted', a)
+
+      $scope.$digest()
 
     # Perform the search
     searchParams = searchFilter.toObject $scope.search.query
@@ -38,3 +62,72 @@ module.exports = class StreamController
 
     $scope.$on '$destroy', ->
       $scope.search.query = ''
+
+    beforeAnnotationCreated =  (event, annotation) =>
+      container = mail.messageContainer(annotation)
+      $scope.threadRoot.addChild container
+      if annotation.id?
+        @idTable[annotation.id] = container
+
+
+    annotationCreated = (event, annotation) =>
+      for child in ($scope.threadRoot.children or []) \
+      when child.message is annotation
+        if child.message.id?
+          delete @idTable[child.id]
+
+        child.message = null
+        $scope.threadRoot.removeChild child
+
+        container = mail.messageContainer(annotation)
+        $scope.threadRoot.addChild container
+        if annotation.id?
+          @idTable[annotation.id] = container
+        break
+
+    annotationDeleted = (event, annotation) =>
+      for child in ($scope.threadRoot.children or []) \
+      when child.message is annotation
+        child.message = null
+        $scope.threadRoot.removeChild child
+        if annotation.id?
+          delete @idTable[annotation.id]
+        break
+
+    annotationsLoaded = (event, annotations) =>
+      for annotation in annotations
+        if @idTable[annotation.id]?.message
+          @idTable[annotation.id].message = annotation
+        else
+          container = mail.messageContainer(annotation)
+          $scope.threadRoot.addChild container
+          @idTable[annotation.id] = container
+
+    cleanupAnnotations = =>
+      # Clean up any annotations that need to be unloaded.
+      for id, container of @idTable when container.message
+        $scope.$emit('annotationDeleted', container.message)
+        drafts.remove container.message
+
+    # rootScope listeners
+    listeners = []
+
+    listeners.push(
+      $rootScope.$on('beforeAnnotationCreated', beforeAnnotationCreated)
+    )
+    listeners.push(
+      $rootScope.$on('annotationCreated', annotationCreated)
+    )
+    listeners.push(
+      $rootScope.$on('annotationDeleted', annotationDeleted)
+    )
+    listeners.push(
+      $rootScope.$on('annotationsLoaded', annotationsLoaded)
+    )
+    listeners.push(
+      $rootScope.$on('cleanupAnnotations', cleanupAnnotations)
+    )
+
+    $scope.$on '$destroy', ->
+      # Deregister listeners
+      listener() for listener in listeners

--- a/h/static/scripts/stream-controller.coffee
+++ b/h/static/scripts/stream-controller.coffee
@@ -109,25 +109,13 @@ module.exports = class StreamController
         $scope.$emit('annotationDeleted', container.message)
         drafts.remove container.message
 
-    # rootScope listeners
-    listeners = []
-
-    listeners.push(
+    listeners = [
       $rootScope.$on('beforeAnnotationCreated', beforeAnnotationCreated)
-    )
-    listeners.push(
       $rootScope.$on('annotationCreated', annotationCreated)
-    )
-    listeners.push(
       $rootScope.$on('annotationDeleted', annotationDeleted)
-    )
-    listeners.push(
       $rootScope.$on('annotationsLoaded', annotationsLoaded)
-    )
-    listeners.push(
       $rootScope.$on('cleanupAnnotations', cleanupAnnotations)
-    )
+    ]
 
     $scope.$on '$destroy', ->
-      # Deregister listeners
-      listener() for listener in listeners
+      unbind() for unbind in listeners

--- a/h/static/scripts/test/app-controller-test.coffee
+++ b/h/static/scripts/test/app-controller-test.coffee
@@ -7,7 +7,6 @@ sinon.assert.expose assert, prefix: null
 describe 'AppController', ->
   $controller = null
   $scope = null
-  fakeAnnotationMapper = null
   fakeAnnotationUI = null
   fakeAuth = null
   fakeDrafts = null
@@ -18,7 +17,6 @@ describe 'AppController', ->
   fakeStore = null
   fakeStreamer = null
   fakeStreamFilter = null
-  fakeThreading = null
 
   sandbox = null
 
@@ -34,10 +32,6 @@ describe 'AppController', ->
 
   beforeEach module ($provide) ->
     sandbox = sinon.sandbox.create()
-
-    fakeAnnotationMapper = {
-      loadAnnotations: sandbox.spy()
-    }
 
     fakeAnnotationUI = {
       tool: 'comment'
@@ -87,13 +81,6 @@ describe 'AppController', ->
       getFilter: sandbox.stub().returns({})
     }
 
-    fakeThreading = {
-      idTable: {}
-      register: (annotation) ->
-        @idTable[annotation.id] = message: annotation
-    }
-
-    $provide.value 'annotationMapper', fakeAnnotationMapper
     $provide.value 'annotationUI', fakeAnnotationUI
     $provide.value 'auth', fakeAuth
     $provide.value 'drafts', fakeDrafts
@@ -104,7 +91,6 @@ describe 'AppController', ->
     $provide.value 'store', fakeStore
     $provide.value 'streamer', fakeStreamer
     $provide.value 'streamfilter', fakeStreamFilter
-    $provide.value 'threading', fakeThreading
     return
 
   beforeEach inject (_$controller_, $rootScope) ->
@@ -118,57 +104,3 @@ describe 'AppController', ->
   it 'does not show login form for logged in users', ->
     createController()
     assert.isFalse($scope.dialog.visible)
-
-  describe 'applyUpdate', ->
-
-    it 'calls annotationMapper.loadAnnotations() upon "create" action', ->
-      createController()
-      anns = ["my", "annotations"]
-      fakeStreamer.onmessage
-        type: "annotation-notification"
-        options: action: "create"
-        payload: anns
-      assert.calledWith fakeAnnotationMapper.loadAnnotations, anns
-
-    it 'calls annotationMapper.loadAnnotations() upon "update" action', ->
-      createController()
-      anns = ["my", "annotations"]
-      fakeStreamer.onmessage
-        type: "annotation-notification"
-        options: action: "update"
-        payload: anns
-      assert.calledWith fakeAnnotationMapper.loadAnnotations, anns
-
-    it 'calls annotationMapper.loadAnnotations() upon "past" action', ->
-      createController()
-      anns = ["my", "annotations"]
-      fakeStreamer.onmessage
-        type: "annotation-notification"
-        options: action: "past"
-        payload: anns
-      assert.calledWith fakeAnnotationMapper.loadAnnotations, anns
-
-    it 'looks up annotations at threading upon "delete" action', ->
-      createController()
-      $scope.$emit = sinon.spy()
-
-      # Prepare the annotation that we have locally
-      localAnnotation =
-        id: "fake ID"
-        data: "local data"
-
-      # Introduce our annotation into threading
-      fakeThreading.register localAnnotation
-
-      # Prepare the annotation that will come "from the wire"
-      remoteAnnotation =
-        id: localAnnotation.id  # same id as locally
-        data: "remote data"     # different data
-
-      # Simulate a delete action
-      fakeStreamer.onmessage
-        type: "annotation-notification"
-        options: action: "delete"
-        payload: [ remoteAnnotation ]
-
-      assert.calledWith $scope.$emit, "annotationDeleted", localAnnotation

--- a/h/static/scripts/threading.coffee
+++ b/h/static/scripts/threading.coffee
@@ -5,7 +5,7 @@ mail = require('./vendor/jwz')
 module.exports = class Threading
   # Mix in message thread properties into the prototype. The body of the
   # class will overwrite any methods applied here. If you need inheritance
-  # assign the message thread to a local varible.
+  # assign the message thread to a local variable.
   # The mail object is exported by the jwz.js library.
   $.extend(this.prototype, mail.messageThread())
 


### PR DESCRIPTION
AppController is no longer responsible for handling streamer updates,
nor cleaning up annotations in login/logout.

Instead the three template controllers are responsible.
Widget-Controller for the sidebar.
Annotation-Viewer-Controller for the standalone page.
And Streamer-Controller for the stream.

They listen to streamer.onmessage, the annotation events and,
the 'cleanupAnnotations' event emitted at login/logout.

Fix #1916 

CleanupAnnotation has changed, no longer keeping any annotations,
just dropping everything and reloading all.