### PR TITLE
Let users change their email addresses

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -14,6 +14,7 @@
 - Added support for URL parameters to the Atom feed at ``/stream.atom``.
   For example: ``/stream.atom?user=seanh`` or
   ``/stream.atom?user=seanh&tags=foo,bar``.
+- Users can now change their email addresses using the Account form (#2131)
 
 0.4.0 (2015-05-05)
 ==================

--- a/h/accounts/schemas.py
+++ b/h/accounts/schemas.py
@@ -189,6 +189,11 @@ class EditProfileSchema(CSRFSchema):
         default='',
         missing=colander.null
     )
+    emailAgain = colander.SchemaNode(
+        colander.String(),
+        default='',
+        missing=colander.null,
+    )
     password = colander.SchemaNode(
         colander.String(),
         title=_('Password'),

--- a/h/accounts/schemas.py
+++ b/h/accounts/schemas.py
@@ -186,6 +186,7 @@ class EditProfileSchema(CSRFSchema):
     )
     email = colander.SchemaNode(
         colander.String(),
+        validator=colander.All(colander.Email(), unique_email),
         default='',
         missing=colander.null
     )

--- a/h/accounts/test/views_test.py
+++ b/h/accounts/test/views_test.py
@@ -76,7 +76,7 @@ class TestProfile(object):
 
 class TestEditProfile(object):
 
-    """Unit tests for the edit_profile() function."""
+    """Unit tests for ProfileController's edit_profile() method."""
 
     @pytest.mark.usefixtures('activation_model', 'dummy_db_session')
     def test_profile_invalid_password(self, config, user_model):

--- a/h/accounts/test/views_test.py
+++ b/h/accounts/test/views_test.py
@@ -10,10 +10,13 @@ from horus.interfaces import (
 from horus.schemas import ProfileSchema
 from horus.forms import SubmitForm
 from horus.strings import UIStringsBase
+import deform
+import colander
 
 import h.accounts.views
 from h.accounts.views import RegisterController
 from h.accounts.views import ProfileController
+import h.accounts.schemas as schemas
 from h.models import _
 
 
@@ -54,6 +57,29 @@ def _get_fake_request(username, password, with_subscriptions=False, active=True)
         subs = subs.replace('activestate', str(active).lower()).replace('username', username)
         fake_request.POST['subscriptions'] = subs
     return fake_request
+
+
+class TestEmailsMustMatchValidator(object):
+
+    """Unit tests for _emails_must_match_validator()."""
+
+    def test_it_raises_invalid_if_the_emails_do_not_match(self):
+        form = deform.Form(schemas.EditProfileSchema())
+        value = {
+            "email": "foo",
+            "emailAgain": "bar"
+        }
+        with pytest.raises(colander.Invalid):
+            h.accounts.views._emails_must_match_validator(form, value)
+
+    def test_it_returns_None_if_the_emails_match(self):
+        form = deform.Form(schemas.EditProfileSchema())
+        value = {
+            "email": "foo",
+            "emailAgain": "foo"
+        }
+        assert h.accounts.views._emails_must_match_validator(form, value) == (
+            None)
 
 
 class TestProfile(object):

--- a/h/accounts/test/views_test.py
+++ b/h/accounts/test/views_test.py
@@ -56,18 +56,22 @@ def _get_fake_request(username, password, with_subscriptions=False, active=True)
     return fake_request
 
 
-@pytest.mark.usefixtures('activation_model', 'dummy_db_session')
-def test_profile_returns_email(config, user_model, authn_policy):
-    """profile() should include the user's email in the dict it returns."""
-    request = _get_fake_request("john", "doe")
-    authn_policy.authenticated_userid.return_value = "john"
-    user_model.get_by_id.return_value = FakeUser(
-        email="test_user@test_email.com")
-    configure(config)
+class TestProfile(object):
 
-    profile = ProfileController(request).profile()
+    """Unit tests for ProfileController's profile() method."""
 
-    assert profile["model"]["email"] == "test_user@test_email.com"
+    @pytest.mark.usefixtures('activation_model', 'dummy_db_session')
+    def test_profile_returns_email(self, config, user_model, authn_policy):
+        """profile() should include the user's email in the dict it returns."""
+        request = _get_fake_request("john", "doe")
+        authn_policy.authenticated_userid.return_value = "john"
+        user_model.get_by_id.return_value = FakeUser(
+            email="test_user@test_email.com")
+        configure(config)
+
+        profile = ProfileController(request).profile()
+
+        assert profile["model"]["email"] == "test_user@test_email.com"
 
 
 class TestEditProfile(object):

--- a/h/accounts/test/views_test.py
+++ b/h/accounts/test/views_test.py
@@ -56,9 +56,10 @@ def _get_fake_request(username, password, with_subscriptions=False, active=True)
 
 
 @pytest.mark.usefixtures('activation_model', 'dummy_db_session')
-def test_profile_returns_email(config, user_model):
+def test_profile_returns_email(config, user_model, authn_policy):
     """profile() should include the user's email in the dict it returns."""
     request = _get_fake_request("john", "doe")
+    authn_policy.authenticated_userid.return_value = "john"
     user_model.get_by_id.return_value = FakeUser(
         email="test_user@test_email.com")
     configure(config)

--- a/h/accounts/test/views_test.py
+++ b/h/accounts/test/views_test.py
@@ -13,10 +13,10 @@ from horus.strings import UIStringsBase
 import deform
 import colander
 
-import h.accounts.views
+from h.accounts import schemas
+from h.accounts import views
 from h.accounts.views import RegisterController
 from h.accounts.views import ProfileController
-import h.accounts.schemas as schemas
 from h.models import _
 
 
@@ -70,7 +70,7 @@ class TestEmailsMustMatchValidator(object):
             "emailAgain": "bar"
         }
         with pytest.raises(colander.Invalid):
-            h.accounts.views._emails_must_match_validator(form, value)
+            views._emails_must_match_validator(form, value)
 
     def test_it_returns_None_if_the_emails_match(self):
         form = deform.Form(schemas.EditProfileSchema())
@@ -78,8 +78,7 @@ class TestEmailsMustMatchValidator(object):
             "email": "foo",
             "emailAgain": "foo"
         }
-        assert h.accounts.views._emails_must_match_validator(form, value) == (
-            None)
+        assert views._emails_must_match_validator(form, value) is None
 
 
 class TestProfile(object):
@@ -139,8 +138,7 @@ class TestEditProfile(object):
         with patch(
                 "h.accounts.views._validate_edit_profile_request") as validate:
             validate.side_effect = (
-                h.accounts.views._InvalidEditProfileRequestError(
-                    errors=errors))
+                views._InvalidEditProfileRequestError(errors=errors))
             result = profile.edit_profile()
 
         assert result["errors"] == errors

--- a/h/accounts/views.py
+++ b/h/accounts/views.py
@@ -19,6 +19,7 @@ from h import session
 from h.models import _
 from h.notification.models import Subscriptions
 from h.resources import Application
+import h.accounts.models
 
 from . import schemas
 from .events import LoginEvent, LogoutEvent
@@ -96,8 +97,14 @@ class AsyncFormViewMapper(object):
             result = ajax_form(request, result)
             model = result.setdefault('model', {})
             model.update(session.model(request))
-            if 'email' not in model and 'email' in request.params:
-                model['email'] = request.params['email']
+
+            # Add the user's email into the model. This is needed so that the
+            # edit profile forms can show the value of the user's current
+            # email.
+            if 'email' not in model and request.authenticated_userid:
+                model['email'] = h.accounts.models.User.get_by_id(
+                    request, request.authenticated_userid).email
+
             result.pop('form', None)
             return result
         return wrapper

--- a/h/accounts/views.py
+++ b/h/accounts/views.py
@@ -231,6 +231,13 @@ class AsyncRegisterController(RegisterController):
     __view_mapper__ = AsyncFormViewMapper
 
 
+def _emails_must_match_validator(form, value):
+    if value.get("email") != value.get("emailAgain"):
+        exc = colander.Invalid(form, "The emails must match")
+        exc["emailAgain"] = "The emails must match."
+        raise exc
+
+
 @view_auth_defaults
 @view_config(attr='edit_profile', route_name='edit_profile')
 @view_config(attr='disable_user', route_name='disable_user')
@@ -238,7 +245,8 @@ class AsyncRegisterController(RegisterController):
 class ProfileController(horus.views.ProfileController):
     def edit_profile(self):
         request = self.request
-        schema = schemas.EditProfileSchema().bind(request=request)
+        schema = schemas.EditProfileSchema(
+            validator=_emails_must_match_validator).bind(request=request)
         form = deform.Form(schema)
 
         try:

--- a/h/accounts/views.py
+++ b/h/accounts/views.py
@@ -96,6 +96,8 @@ class AsyncFormViewMapper(object):
             result = ajax_form(request, result)
             model = result.setdefault('model', {})
             model.update(session.model(request))
+            if 'email' not in model and 'email' in request.params:
+                model['email'] = request.params['email']
             result.pop('form', None)
             return result
         return wrapper
@@ -303,8 +305,8 @@ class ProfileController(horus.views.ProfileController):
 
     def profile(self):
         request = self.request
-        model = {}
         userid = request.authenticated_userid
+        model = {"email": self.User.get_by_id(request, userid).email}
         if request.registry.feature('notification'):
             model['subscriptions'] = Subscriptions.get_subscriptions_for_uri(
                 request,

--- a/h/accounts/views.py
+++ b/h/accounts/views.py
@@ -314,7 +314,9 @@ class ProfileController(horus.views.ProfileController):
     def profile(self):
         request = self.request
         userid = request.authenticated_userid
-        model = {"email": self.User.get_by_id(request, userid).email}
+        model = {}
+        if userid:
+            model["email"] = self.User.get_by_id(request, userid).email
         if request.registry.feature('notification'):
             model['subscriptions'] = Subscriptions.get_subscriptions_for_uri(
                 request,

--- a/h/accounts/views.py
+++ b/h/accounts/views.py
@@ -239,6 +239,7 @@ class AsyncRegisterController(RegisterController):
 
 
 def _emails_must_match_validator(form, value):
+    """Raise colander.Invalid if "email" and "emailAgain" don't match."""
     if value.get("email") != value.get("emailAgain"):
         exc = colander.Invalid(form, "The emails must match")
         exc["emailAgain"] = "The emails must match."

--- a/h/static/scripts/account/account-controller.coffee
+++ b/h/static/scripts/account/account-controller.coffee
@@ -80,7 +80,7 @@ class AccountController
       promise = session.edit_profile(packet)
       promise.$promise.then(successHandler, errorHandler)
 
-    $scope.changeEmail = (form) ->
+    $scope.changeEmailSubmit = (form) ->
       formRespond(form)
       return unless form.$valid
 

--- a/h/static/scripts/account/account-controller.coffee
+++ b/h/static/scripts/account/account-controller.coffee
@@ -89,6 +89,7 @@ class AccountController
         username: username
         pwd: form.pwd.$modelValue
         email: form.email.$modelValue
+        emailAgain: form.emailAgain.$modelValue
 
       successHandler = angular.bind(null, onSuccess, form)
       errorHandler   = angular.bind(null, onError, form)

--- a/h/static/scripts/account/account-controller.coffee
+++ b/h/static/scripts/account/account-controller.coffee
@@ -17,6 +17,7 @@ class AccountController
       formModel = form.$name.slice(0, -4)
       $scope[formModel] = {} # Reset form fields.
       $scope.$broadcast 'formState', form.$name, 'success'  # Update status btn
+      $scope.email = response.email
 
     onDelete = (form, response) ->
       identity.logout()
@@ -39,6 +40,7 @@ class AccountController
     session.profile().$promise
       .then (result) =>
         $scope.subscriptions = result.subscriptions
+        $scope.email = result.email
 
     # Data for each of the forms
     $scope.editProfile = {}
@@ -70,6 +72,23 @@ class AccountController
         username: username
         pwd: form.pwd.$modelValue
         password: form.password.$modelValue
+
+      successHandler = angular.bind(null, onSuccess, form)
+      errorHandler   = angular.bind(null, onError, form)
+
+      $scope.$broadcast 'formState', form.$name, 'loading'  # Update status btn
+      promise = session.edit_profile(packet)
+      promise.$promise.then(successHandler, errorHandler)
+
+    $scope.changeEmail = (form) ->
+      formRespond(form)
+      return unless form.$valid
+
+      username = persona_filter auth.user
+      packet =
+        username: username
+        pwd: form.pwd.$modelValue
+        email: form.email.$modelValue
 
       successHandler = angular.bind(null, onSuccess, form)
       errorHandler   = angular.bind(null, onError, form)

--- a/h/static/scripts/account/test/account-controller-test.coffee
+++ b/h/static/scripts/account/test/account-controller-test.coffee
@@ -311,7 +311,7 @@ describe "h:AccountController", ->
       $filter: $filter or -> -> {}
       auth: auth or {}
       flash: flash or {}
-      formRespond: formRespond or {}
+      formRespond: formRespond or ->
       identity: identity or {}
       session: session or getStubSession({})
     }
@@ -347,7 +347,6 @@ describe "h:AccountController", ->
       edit_profile.returns({$promise: Promise.resolve({})})
 
       {$scope} = controller(
-        formRespond: ->
         session: getStubSession(edit_profile: edit_profile)
         # Simulate a logged-in user with username "joeuser"
         $filter: -> -> "joeuser")
@@ -374,7 +373,6 @@ describe "h:AccountController", ->
       new_email_addr = "new_email_address@test.com"
 
       {$scope} = controller(
-        formRespond: ->
         # AccountController expects session.edit_profile() to respond with the
         # newly saved email address.
         session: getStubSession(
@@ -431,7 +429,7 @@ describe "h:AccountController", ->
 
     it "broadcasts 'formState' 'changeEmailForm' 'loading' on submit", ->
       new_email_address = "new_email_address@test.com"
-      {$scope} = controller(formRespond: ->)
+      {$scope} = controller({})
 
       $scope.$broadcast = sinon.stub()
 
@@ -451,7 +449,7 @@ describe "h:AccountController", ->
     it "broadcasts 'formState' 'changeEmailForm' 'success' on success", ->
       new_email_address = "new_email_address@test.com"
 
-      {$scope} = controller(formRespond: ->)
+      {$scope} = controller({})
 
       $scope.$broadcast = sinon.stub()
 
@@ -473,7 +471,6 @@ describe "h:AccountController", ->
       new_email_address = "new_email_address@test.com"
 
       {$scope} = controller(
-        formRespond: ->
         flash: {error: ->}
         session: getStubSession(
           edit_profile: -> {$promise: Promise.reject({data: {}})}

--- a/h/static/scripts/account/test/account-controller-test.coffee
+++ b/h/static/scripts/account/test/account-controller-test.coffee
@@ -323,8 +323,8 @@ describe "h:AccountController", ->
        session = {profile: -> {$promise: ...}}
        {ctrl, $scope} = controller(session: session)
   ###
-  controller = ({$scope, $filter, auth, flash, formRespond, identity,
-                session}) ->
+  createAccountController = ({$scope, $filter, auth, flash, formRespond,
+                              identity, session}) ->
     locals = {
       $scope: $scope or getRootScope().$new()
       $filter: $filter or -> -> {}
@@ -349,7 +349,8 @@ describe "h:AccountController", ->
     profilePromise = Promise.resolve({
       email: "test_user@test_email.com"
     })
-    {$scope} = controller(session: {profile: -> {$promise: profilePromise}})
+    {$scope} = createAccountController(
+      session: {profile: -> {$promise: profilePromise}})
 
     profilePromise.then(->
       assert $scope.email == "test_user@test_email.com"
@@ -365,7 +366,7 @@ describe "h:AccountController", ->
       edit_profile = sinon.stub()
       edit_profile.returns({$promise: Promise.resolve({})})
 
-      {$scope} = controller(
+      {$scope} = createAccountController(
         session: getStubSession(edit_profile: edit_profile)
         # Simulate a logged-in user with username "joeuser"
         $filter: -> -> "joeuser")
@@ -385,7 +386,7 @@ describe "h:AccountController", ->
     it "updates placeholder after successfully changing the email address", ->
       new_email_addr = "new_email_address@test.com"
 
-      {$scope} = controller(
+      {$scope} = createAccountController(
         # AccountController expects session.edit_profile() to respond with the
         # newly saved email address.
         session: getStubSession(
@@ -411,7 +412,7 @@ describe "h:AccountController", ->
             emailAgain: "The emails must match."
       }
 
-      {$scope} = controller(
+      {$scope} = createAccountController(
         formRespond: require("../../form-respond")()
         session: getStubSession(
           edit_profile: -> {$promise: Promise.reject(server_response)}
@@ -428,7 +429,7 @@ describe "h:AccountController", ->
       )
 
     it "broadcasts 'formState' 'changeEmailForm' 'loading' on submit", ->
-      {$scope} = controller({})
+      {$scope} = createAccountController({})
 
       $scope.$broadcast = sinon.stub()
 
@@ -441,7 +442,7 @@ describe "h:AccountController", ->
         "formState", "changeEmailForm", "loading")
 
     it "broadcasts 'formState' 'changeEmailForm' 'success' on success", ->
-      {$scope} = controller({})
+      {$scope} = createAccountController({})
 
       $scope.$broadcast = sinon.stub()
 
@@ -455,7 +456,7 @@ describe "h:AccountController", ->
       )
 
     it "broadcasts 'formState' 'changeEmailForm' '' on error", ->
-      {$scope} = controller(
+      {$scope} = createAccountController(
         flash: {error: ->}
         session: getStubSession(
           edit_profile: -> {$promise: Promise.reject({data: {}})}
@@ -483,7 +484,7 @@ describe "h:AccountController", ->
         statusText: "Unauthorized"
       }
 
-      {$scope} = controller(
+      {$scope} = createAccountController(
         formRespond: require("../../form-respond")()
         session: getStubSession(
           edit_profile: -> {$promise: Promise.reject(server_response)}

--- a/h/static/scripts/account/test/account-controller-test.coffee
+++ b/h/static/scripts/account/test/account-controller-test.coffee
@@ -324,7 +324,7 @@ describe "h:AccountController", ->
       email: "test_user@test_email.com"
     })
     session = {profile: -> {$promise: profilePromise}}
-    {ctrl, $scope} = controller(session: session)
+    {$scope} = controller(session: session)
 
     profilePromise.then(->
       assert $scope.email == "test_user@test_email.com"

--- a/h/static/scripts/account/test/account-controller-test.coffee
+++ b/h/static/scripts/account/test/account-controller-test.coffee
@@ -273,6 +273,25 @@ describe "h:AccountController", ->
       edit_profile: edit_profile or -> {$promise: Promise.resolve({})}
     }
 
+  # Return a minimal stub version of the object that AccountController's
+  # changeEmail() method receives when the user submits the changeEmailForm.
+  getStubChangeEmailForm = ({email, emailAgain, password}) ->
+    return {
+      $name: "changeEmailForm"
+      email:
+        $modelValue: email
+        $setValidity: ->
+      emailAgain:
+        $modelValue: emailAgain
+        $setValidity: ->
+      pwd:
+        $modelValue: password
+        $setValidity: ->
+      $valid: true
+      $setPristine: ->
+      $setValidity: ->
+    }
+
   ###
   Return an AccountController instance and stub services.
 
@@ -340,7 +359,7 @@ describe "h:AccountController", ->
 
     it "calls sesson.edit_profile() with the right data on form submission", ->
 
-      new_email_address = "new_email_address@test.com"
+      new_email_addr = "new_email_address@test.com"
 
       # Stub the session.edit_profile() function.
       edit_profile = sinon.stub()
@@ -351,21 +370,15 @@ describe "h:AccountController", ->
         # Simulate a logged-in user with username "joeuser"
         $filter: -> -> "joeuser")
 
-      form = {
-        $name: "changeEmailForm"
-        email: $modelValue: new_email_address
-        emailAgain: $modelValue: new_email_address
-        pwd: $modelValue: "pass"
-        $valid: true
-        $setPristine: ->
-      }
+      form = getStubChangeEmailForm(
+        email: new_email_addr, emailAgain: new_email_addr, password: "pass")
 
       $scope.changeEmail(form).then(->
         assert edit_profile.calledWithExactly({
           username: "joeuser"
           pwd: "pass"
-          email: new_email_address
-          emailAgain: new_email_address
+          email: new_email_addr
+          emailAgain: new_email_addr
         })
       )
 
@@ -382,14 +395,8 @@ describe "h:AccountController", ->
           )
       )
 
-      form = {
-        $name: "changeEmailForm"
-        email: $modelValue: new_email_addr
-        emailAgain: $modelValue: new_email_addr
-        pwd: $modelValue: "pass"
-        $valid: true
-        $setPristine: ->
-      }
+      form = getStubChangeEmailForm(
+        email: new_email_addr, emailAgain: new_email_addr, password: "pass")
 
       $scope.changeEmail(form).then(->
         assert $scope.email == new_email_addr
@@ -411,56 +418,36 @@ describe "h:AccountController", ->
         )
       )
 
-      form = {
-        $name: "changeEmailForm"
-        email: $modelValue: "my_new_email_address@yahoo.com"
-        emailAgain:
-          $modelValue: "a_different_email_address@bluebottle.com"
-          $setValidity: ->
-        pwd: $modelValue: "pass"
-        $valid: true
-        $setPristine: ->
-        $setValidity: ->
-      }
+      form = getStubChangeEmailForm(
+        email: "my_new_email_address@yahoo.com"
+        emailAgain: "a_different_email_address@bluebottle.com"
+        pwd: "pass")
 
       $scope.changeEmail(form).then(->
         assert form.emailAgain.responseErrorMessage == "The emails must match."
       )
 
     it "broadcasts 'formState' 'changeEmailForm' 'loading' on submit", ->
-      new_email_address = "new_email_address@test.com"
       {$scope} = controller({})
 
       $scope.$broadcast = sinon.stub()
 
-      form = {
-        $name: "changeEmailForm"
-        email: $modelValue: new_email_address
-        emailAgain: $modelValue: new_email_address
-        pwd: $modelValue: "pass"
-        $valid: true
-        $setPristine: ->
-      }
+      form = getStubChangeEmailForm(
+        email: "new_email_address@test.com",
+        emailAgain: "new_email_address@test.com", password: "pass")
       $scope.changeEmail(form)
 
       assert $scope.$broadcast.calledWithExactly(
         "formState", "changeEmailForm", "loading")
 
     it "broadcasts 'formState' 'changeEmailForm' 'success' on success", ->
-      new_email_address = "new_email_address@test.com"
-
       {$scope} = controller({})
 
       $scope.$broadcast = sinon.stub()
 
-      form = {
-        $name: "changeEmailForm"
-        email: $modelValue: new_email_address
-        emailAgain: $modelValue: new_email_address
-        pwd: $modelValue: "pass"
-        $valid: true
-        $setPristine: ->
-      }
+      form = getStubChangeEmailForm(
+        email: "new_email_address@test.com",
+        emailAgain: "new_email_address@test.com", password: "pass")
 
       $scope.changeEmail(form).then(->
         assert $scope.$broadcast.calledWithExactly(
@@ -468,8 +455,6 @@ describe "h:AccountController", ->
       )
 
     it "broadcasts 'formState' 'changeEmailForm' '' on error", ->
-      new_email_address = "new_email_address@test.com"
-
       {$scope} = controller(
         flash: {error: ->}
         session: getStubSession(
@@ -479,14 +464,9 @@ describe "h:AccountController", ->
 
       $scope.$broadcast = sinon.stub()
 
-      form = {
-        $name: "changeEmailForm"
-        email: $modelValue: new_email_address
-        emailAgain: $modelValue: new_email_address
-        pwd: $modelValue: "pass"
-        $valid: true
-        $setPristine: ->
-      }
+      form = getStubChangeEmailForm(
+        email: "new_email_address@test.com",
+        emailAgain: "new_email_address@test.com", password: "pass")
 
       $scope.changeEmail(form).then(->
         assert $scope.$broadcast.calledWithExactly(
@@ -494,8 +474,6 @@ describe "h:AccountController", ->
       )
 
     it "shows an error if the password is wrong", ->
-      new_email_address = "new_email_address@test.com"
-
       # Mock of the server response you get when you enter the wrong password.
       server_response = {
         data:
@@ -512,17 +490,9 @@ describe "h:AccountController", ->
         )
       )
 
-      form = {
-        $name: "changeEmailForm"
-        email: $modelValue: new_email_address
-        emailAgain: $modelValue: new_email_address
-        pwd:
-          $modelValue: "pass"
-          $setValidity: ->
-        $valid: true
-        $setPristine: ->
-        $setValidity: ->
-      }
+      form = getStubChangeEmailForm(
+        email: "new_email_address@test.com",
+        emailAgain: "new_email_address@test.com", password: "pass")
 
       $scope.changeEmail(form).then(->
         assert form.pwd.responseErrorMessage == "Invalid password"

--- a/h/static/scripts/account/test/account-controller-test.coffee
+++ b/h/static/scripts/account/test/account-controller-test.coffee
@@ -287,7 +287,7 @@ describe "h:AccountController", ->
    Use CoffeeScript's destructuring assignment to pull out just the things
    you need from the returned object. For example:
 
-       {ctrl, $scope} = controller()
+       {ctrl, $scope} = controller({})
 
    By default this does the minimum amount of stubbing necessary to create an
    AccountController without it crashing. For each of the services that gets

--- a/h/static/scripts/account/test/account-controller-test.coffee
+++ b/h/static/scripts/account/test/account-controller-test.coffee
@@ -292,37 +292,7 @@ describe "h:AccountController", ->
       $setValidity: ->
     }
 
-  ###
-  Return an AccountController instance and stub services.
-
-  Returns an object containing:
-
-  * an AccountController instance with all the services it depends on
-    stubbed, and
-  * each of the stubbed services
-
-  The returned object looks like this:
-
-      {"ctrl": the AccountController instance
-       "$scope": the scope attached to ctrl
-       "$filter": the stub filter injected into ctrl
-       "auth": the stub auth service injected into ctrl
-       ... (more stubbed services here)
-      }
-
-   Use CoffeeScript's destructuring assignment to pull out just the things
-   you need from the returned object. For example:
-
-       {ctrl, $scope} = controller({})
-
-   By default this does the minimum amount of stubbing necessary to create an
-   AccountController without it crashing. For each of the services that gets
-   stubbed the caller can optionally pass in their own object to be used
-   instead of the minimal stub. For example:
-
-       session = {profile: -> {$promise: ...}}
-       {ctrl, $scope} = controller(session: session)
-  ###
+  # Return an AccountController instance and stub services.
   createAccountController = ({$scope, $filter, auth, flash, formRespond,
                               identity, session}) ->
     locals = {

--- a/h/static/scripts/account/test/account-controller-test.coffee
+++ b/h/static/scripts/account/test/account-controller-test.coffee
@@ -274,7 +274,7 @@ describe "h:AccountController", ->
     }
 
   # Return a minimal stub version of the object that AccountController's
-  # changeEmail() method receives when the user submits the changeEmailForm.
+  # changeEmailSubmit() method receives when the user submits the changeEmailForm.
   getStubChangeEmailForm = ({email, emailAgain, password}) ->
     return {
       $name: "changeEmailForm"
@@ -344,7 +344,7 @@ describe "h:AccountController", ->
       form = getStubChangeEmailForm(
         email: new_email_addr, emailAgain: new_email_addr, password: "pass")
 
-      $scope.changeEmail(form).then(->
+      $scope.changeEmailSubmit(form).then(->
         assert edit_profile.calledWithExactly({
           username: "joeuser"
           pwd: "pass"
@@ -369,7 +369,7 @@ describe "h:AccountController", ->
       form = getStubChangeEmailForm(
         email: new_email_addr, emailAgain: new_email_addr, password: "pass")
 
-      $scope.changeEmail(form).then(->
+      $scope.changeEmailSubmit(form).then(->
         assert $scope.email == new_email_addr
       )
 
@@ -394,7 +394,7 @@ describe "h:AccountController", ->
         emailAgain: "a_different_email_address@bluebottle.com"
         pwd: "pass")
 
-      $scope.changeEmail(form).then(->
+      $scope.changeEmailSubmit(form).then(->
         assert form.emailAgain.responseErrorMessage == "The emails must match."
       )
 
@@ -406,7 +406,7 @@ describe "h:AccountController", ->
       form = getStubChangeEmailForm(
         email: "new_email_address@test.com",
         emailAgain: "new_email_address@test.com", password: "pass")
-      $scope.changeEmail(form)
+      $scope.changeEmailSubmit(form)
 
       assert $scope.$broadcast.calledWithExactly(
         "formState", "changeEmailForm", "loading")
@@ -420,7 +420,7 @@ describe "h:AccountController", ->
         email: "new_email_address@test.com",
         emailAgain: "new_email_address@test.com", password: "pass")
 
-      $scope.changeEmail(form).then(->
+      $scope.changeEmailSubmit(form).then(->
         assert $scope.$broadcast.calledWithExactly(
           "formState", "changeEmailForm", "success")
       )
@@ -439,7 +439,7 @@ describe "h:AccountController", ->
         email: "new_email_address@test.com",
         emailAgain: "new_email_address@test.com", password: "pass")
 
-      $scope.changeEmail(form).then(->
+      $scope.changeEmailSubmit(form).then(->
         assert $scope.$broadcast.calledWithExactly(
           "formState", "changeEmailForm", "")
       )
@@ -465,6 +465,6 @@ describe "h:AccountController", ->
         email: "new_email_address@test.com",
         emailAgain: "new_email_address@test.com", password: "pass")
 
-      $scope.changeEmail(form).then(->
+      $scope.changeEmailSubmit(form).then(->
         assert form.pwd.responseErrorMessage == "Invalid password"
       )

--- a/h/templates/client/settings/account.html
+++ b/h/templates/client/settings/account.html
@@ -17,6 +17,16 @@
     </div>
 
     <div class="form-field">
+      <label class="form-label" for="field-emailAgain">Enter Your Email Address Again:</label>
+      <input id="field-emailAgain" class="form-input" type="email" name="emailAgain" placeholder="{{email}}" required ng-model="changeEmail.emailAgain" />
+      <ul class="form-error-list">
+        <li class="form-error" ng-show="changeEmailForm.emailAgain.$error.required">Please enter your new email address twice.</li>
+        <li class="form-error" ng-show="changeEmailForm.emailAgain.$error.email">Please enter a valid email address.</li>
+        <li class="form-error" ng-show="changeEmailForm.emailAgain.$error.response">{{changeEmailForm.emailAgain.responseErrorMessage}}</li>
+      </ul>
+    </div>
+
+    <div class="form-field">
       <label class="form-label" for="field-pwd">Password:</label>
       <input id="field-pwd" class="form-input" type="password" name="pwd" required ng-model="changeEmail.pwd" />
 

--- a/h/templates/client/settings/account.html
+++ b/h/templates/client/settings/account.html
@@ -1,5 +1,41 @@
 <div class="tab-pane" title="Account">
   <form class="account-form form"
+        name="changeEmailForm"
+        ng-submit="changeEmail(changeEmailForm)"
+        novalidate form-validate>
+
+    <h2 class="form-heading"><span>Change Your Email Address</span></h2>
+
+    <div class="form-field">
+      <label class="form-label" for="field-email">Email Address:</label>
+      <input id="field-email" class="form-input" type="email" name="email" placeholder="{{email}}" required ng-model="changeEmail.email" />
+      <ul class="form-error-list">
+        <li class="form-error" ng-show="changeEmailForm.email.$error.required">Please enter your new email address.</li>
+        <li class="form-error" ng-show="changeEmailForm.email.$error.email">Please enter a valid email address.</li>
+        <li class="form-error" ng-show="changeEmailForm.email.$error.response">{{changeEmailForm.email.responseErrorMessage}}</li>
+      </ul>
+    </div>
+
+    <div class="form-field">
+      <label class="form-label" for="field-pwd">Password:</label>
+      <input id="field-pwd" class="form-input" type="password" name="pwd" required ng-model="changeEmail.pwd" />
+
+      <ul class="form-error-list">
+        <li class="form-error" ng-show="changeEmailForm.pwd.$error.required">Please enter your password.</li>
+        <li class="form-error" ng-show="changeEmailForm.pwd.$error.minlength">Your password does not match the one we have on record.</li>
+        <li class="form-error" ng-show="changeEmailForm.pwd.$error.response">{{changeEmailForm.pwd.responseErrorMessage}}</li>
+      </ul>
+    </div>
+
+    <div class="form-actions">
+      <div class="form-actions-buttons">
+        <button class="btn" type="submit"
+                status-button="changeEmailForm">Update</button>
+      </div>
+    </div>
+  </form>
+
+  <form class="account-form form"
         name="changePasswordForm"
         ng-submit="submit(changePasswordForm)"
         novalidate form-validate>

--- a/h/templates/client/settings/account.html
+++ b/h/templates/client/settings/account.html
@@ -1,7 +1,7 @@
 <div class="tab-pane" title="Account">
   <form class="account-form form"
         name="changeEmailForm"
-        ng-submit="changeEmail(changeEmailForm)"
+        ng-submit="changeEmailSubmit(changeEmailForm)"
         novalidate form-validate>
 
     <h2 class="form-heading"><span>Change Your Email Address</span></h2>

--- a/h/templates/client/settings/account.html
+++ b/h/templates/client/settings/account.html
@@ -6,7 +6,7 @@
 
     <h2 class="form-heading"><span>Change Your Email Address</span></h2>
 
-    <p class="form-description">Your current email address is: {{email}}.</p>
+    <p class="form-description">Your current email address is: <strong>{{email}}</strong>.</p>
 
     <div class="form-field">
       <label class="form-label" for="field-email">New Email Address:</label>

--- a/h/templates/client/settings/account.html
+++ b/h/templates/client/settings/account.html
@@ -6,7 +6,7 @@
 
     <h2 class="form-heading"><span>Change Your Email Address</span></h2>
 
-    <p class="form-description">Your current email address is: <strong>{{email}}</strong>.</p>
+    <p class="form-description">Your current email address is: <strong ng-bind="email"></strong>.</p>
 
     <div class="form-field">
       <label class="form-label" for="field-email">New Email Address:</label>

--- a/h/templates/client/settings/account.html
+++ b/h/templates/client/settings/account.html
@@ -6,9 +6,11 @@
 
     <h2 class="form-heading"><span>Change Your Email Address</span></h2>
 
+    <p class="form-description">Your current email address is: {{email}}.</p>
+
     <div class="form-field">
-      <label class="form-label" for="field-email">Email Address:</label>
-      <input id="field-email" class="form-input" type="email" name="email" placeholder="{{email}}" required ng-model="changeEmail.email" />
+      <label class="form-label" for="field-email">New Email Address:</label>
+      <input id="field-email" class="form-input" type="email" name="email" required ng-model="changeEmail.email" />
       <ul class="form-error-list">
         <li class="form-error" ng-show="changeEmailForm.email.$error.required">Please enter your new email address.</li>
         <li class="form-error" ng-show="changeEmailForm.email.$error.email">Please enter a valid email address.</li>
@@ -17,8 +19,8 @@
     </div>
 
     <div class="form-field">
-      <label class="form-label" for="field-emailAgain">Enter Your Email Address Again:</label>
-      <input id="field-emailAgain" class="form-input" type="email" name="emailAgain" placeholder="{{email}}" required ng-model="changeEmail.emailAgain" />
+      <label class="form-label" for="field-emailAgain">Enter Your New Email Address Again:</label>
+      <input id="field-emailAgain" class="form-input" type="email" name="emailAgain" required ng-model="changeEmail.emailAgain" />
       <ul class="form-error-list">
         <li class="form-error" ng-show="changeEmailForm.emailAgain.$error.required">Please enter your new email address twice.</li>
         <li class="form-error" ng-show="changeEmailForm.emailAgain.$error.email">Please enter a valid email address.</li>


### PR DESCRIPTION
Fixes https://github.com/hypothesis/vision/issues/174

account.html:

- Add a new "Change Your Email Address" form

accounts/views.py:

- Add email to the user dict returned at /app?__formid__=profile (or
  session.profile() in Angular)

- When resetting the form after a successful submission, put the new (or
  unchanged) email address into the user dict returned in the response.
  AccountController needs this (see below).

account-controller.coffee:

- Add $scope.email (the user's current email address), to use for placeholder
  text in the email form field.

- After a successful form submission set $scope.email to the one from the
  response. This sets the placeholder text in the email field to the new value,
  instead of continuing to show the old email address as placeholder.

- Add changeEmail() method to receive email form submissions.