### PR TITLE
Reorder adder icons

### DIFF
--- a/h/static/scripts/annotator/guest.coffee
+++ b/h/static/scripts/annotator/guest.coffee
@@ -29,8 +29,8 @@ module.exports = class Guest extends Annotator
   html: jQuery.extend {}, Annotator::html,
     adder: '''
       <div class="annotator-adder">
-        <button class="h-icon-insert-comment" data-action="comment" title="New Note"></button>
         <button class="h-icon-border-color" data-action="highlight" title="Highlight"></button>
+        <button class="h-icon-insert-comment" data-action="comment" title="New Note"></button>
       </div>
     '''
 


### PR DESCRIPTION
Switches the order of the adder icons as recommended by @JackDougherty in https://github.com/hypothesis/h/issues/2130

Now looks like this:
![selection_033](https://cloud.githubusercontent.com/assets/521978/6990426/a10f8e8a-da20-11e4-92d5-3dc232e708fa.png)
