### PR TITLE
Mobile support

### DIFF
--- a/h/static/scripts/annotator/guest.coffee
+++ b/h/static/scripts/annotator/guest.coffee
@@ -196,19 +196,9 @@ module.exports = class Guest extends Annotator
   _setupDynamicStyle: -> this
   _setupViewer: -> this
   _setupEditor: -> this
-  _setupDocumentEvents: ->
-    $(document).bind({
-      # omit the "mouseup" check
-      "mousedown": this.checkForStartSelection
-    })
-    this
+  _setupDocumentEvents: -> this
 
   destroy: ->
-    $(document).unbind({
-      "mouseup":   this.checkForEndSelection
-      "mousedown": this.checkForStartSelection
-    })
-
     $('#annotator-dynamic-style').remove()
 
     @adder.remove()
@@ -262,13 +252,6 @@ module.exports = class Guest extends Annotator
       params: (a.$$tag for a in annotations)
 
   onAnchorMousedown: ->
-
-  checkForStartSelection: (event) =>
-    # Override to prevent Annotator choking when this ties to access the
-    # viewer but preserve the manipulation of the attribute `mouseIsDown` which
-    # is needed for preventing the panel from closing while annotating.
-    unless event and this.isAnnotator(event.target)
-      @mouseIsDown = true
 
   # This is called to create a target from a raw selection,
   # using selectors created by the registered selector creators

--- a/h/static/scripts/annotator/host.coffee
+++ b/h/static/scripts/annotator/host.coffee
@@ -64,19 +64,19 @@ module.exports = class Host extends Guest
     @frame.removeClass 'annotator-collapsed'
 
     if @toolbar?
-      @toolbar.find('.annotator-toolbar-toggle')
+      @toolbar.find('[name=sidebar-toggle]')
       .removeClass('h-icon-chevron-left')
       .addClass('h-icon-chevron-right')
 
   hideFrame: ->
-      @frame.css 'margin-left': ''
-      @frame.removeClass 'annotator-no-transition'
-      @frame.addClass 'annotator-collapsed'
+    @frame.css 'margin-left': ''
+    @frame.removeClass 'annotator-no-transition'
+    @frame.addClass 'annotator-collapsed'
 
-      if @toolbar?
-        @toolbar.find('.annotator-toolbar-toggle')
-        .removeClass('h-icon-chevron-right')
-        .addClass('h-icon-chevron-left')
+    if @toolbar?
+      @toolbar.find('[name=sidebar-toggle]')
+      .removeClass('h-icon-chevron-right')
+      .addClass('h-icon-chevron-left')
 
 
   _addCrossFrameListeners: ->

--- a/h/static/scripts/annotator/plugin/textselection.coffee
+++ b/h/static/scripts/annotator/plugin/textselection.coffee
@@ -7,11 +7,18 @@ class Annotator.Plugin.TextSelection extends Annotator.Plugin
 
     # Register the event handlers required for creating a selection
     $(document).bind({
+      "touchend": @checkForEndSelection
       "mouseup": @checkForEndSelection
     })
 
     null
 
+  destroy: ->
+    $(document).unbind({
+      "touchend": @checkForEndSelection
+      "mouseup": @checkForEndSelection
+    })
+    super
 
   # Code used to create annotations around text ranges =====================
 
@@ -61,10 +68,9 @@ class Annotator.Plugin.TextSelection extends Annotator.Plugin
       selection.addRange(range.toRange()) if range
       range
 
-  # This is called then the mouse is released.
+  # This is called when the mouse is released.
   # Checks to see if a selection has been made on mouseup and if so,
   # calls Annotator's onSuccessfulSelection method.
-  # Also resets the @mouseIsDown property.
   #
   # event - The event triggered this. Usually it's a mouseup Event,
   #         but that's not necessary. The coordinates will be used,
@@ -74,11 +80,6 @@ class Annotator.Plugin.TextSelection extends Annotator.Plugin
   #
   # Returns nothing.
   checkForEndSelection: (event = {}) =>
-    @annotator.mouseIsDown = false
-
-    # We don't care about the adder button click
-    return if @annotator.inAdderClick
-
     # Get the currently selected ranges.
     selectedRanges = @_getSelectedRanges()
 

--- a/h/static/scripts/annotator/plugin/toolbar.coffee
+++ b/h/static/scripts/annotator/plugin/toolbar.coffee
@@ -1,15 +1,18 @@
 $ = Annotator.$
 
 makeButton = (item) ->
-  anchor = $('<a></a>')
+  anchor = $('<button></button>')
   .attr('href', '')
   .attr('title', item.title)
+  .attr('name', item.name)
   .on(item.on)
   .addClass(item.class)
   button = $('<li></li>').append(anchor)
   return button[0]
 
 class Annotator.Plugin.Toolbar extends Annotator.Plugin
+  HIDE_CLASS = 'annotator-hide'
+
   events:
     'setVisibleHighlights': 'onSetVisibleHighlights'
 
@@ -24,7 +27,8 @@ class Annotator.Plugin.Toolbar extends Annotator.Plugin
 
     items = [
       "title": "Toggle Sidebar"
-      "class": "annotator-toolbar-toggle h-icon-chevron-left"
+      "class": "h-icon-chevron-left"
+      "name": "sidebar-toggle"
       "on":
         "click": (event) =>
           event.preventDefault()
@@ -37,6 +41,7 @@ class Annotator.Plugin.Toolbar extends Annotator.Plugin
     ,
       "title": "Hide Highlights"
       "class": "h-icon-visibility"
+      "name": "highlight-visibility"
       "on":
         "click": (event) =>
           event.preventDefault()
@@ -46,6 +51,7 @@ class Annotator.Plugin.Toolbar extends Annotator.Plugin
     ,
       "title": "New Note"
       "class": "h-icon-insert-comment"
+      "name": "insert-comment"
       "on":
         "click": (event) =>
           event.preventDefault()
@@ -65,10 +71,12 @@ class Annotator.Plugin.Toolbar extends Annotator.Plugin
 
   onSetVisibleHighlights: (state) ->
     if state
-      $(@buttons[1]).children().removeClass('h-icon-visibility-off')
-      $(@buttons[1]).children().addClass('h-icon-visibility')
-      $(@buttons[1]).children().prop('title', 'Hide Highlights');
+      $('[name=highlight-visibility]')
+      .removeClass('h-icon-visibility-off')
+      .addClass('h-icon-visibility')
+      .prop('title', 'Hide Highlights');
     else
-      $(@buttons[1]).children().removeClass('h-icon-visibility')
-      $(@buttons[1]).children().addClass('h-icon-visibility-off')
-      $(@buttons[1]).children().prop('title', 'Show Highlights');
+      $('[name=highlight-visibility]')
+      .removeClass('h-icon-visibility')
+      .addClass('h-icon-visibility-off')
+      .prop('title', 'Show Highlights');

--- a/h/static/styles/inject.scss
+++ b/h/static/styles/inject.scss
@@ -176,9 +176,10 @@ $base-font-size: 14px;
     z-index: 1;
   }
 
-  a {
+  button {
     @include single-transition(background-color, .25s, .25s);
     background: $white;
+    border: none;
     color: $gray-light;
     line-height: 28px;
     text-decoration: none;
@@ -189,12 +190,12 @@ $base-font-size: 14px;
     left: 0;
   }
 
-  a:active {
+  button:active {
     @include single-transition(background-color, .25s);
     background-color: $gray-light;
   }
 
-  a:focus, a:hover {
+  button:focus, button:hover {
     outline: 0;
     color: $text-color;
   }


### PR DESCRIPTION
Android and iOS devices can now create annotations. This work derives from my previous closed PR https://github.com/hypothesis/h/pull/2087, but doesn't include the UX work (which is in a separate PR). It has been tested this on the most recent versions of iOS and Android, and you can try it for yourself at http://mobile-support.dokku.hypothes.is/

@tilgovi, I think you will be happier with the code here. The events are now bound together, and we don't do user agent sniffing (except in one case the that is *only* relevant to mobile Safari).

Closes:
#587
hypothesis/vision#167