### PR TITLE
Address usability issues

### DIFF
--- a/h/static/scripts/annotator/plugin/toolbar.coffee
+++ b/h/static/scripts/annotator/plugin/toolbar.coffee
@@ -10,8 +10,6 @@ makeButton = (item) ->
   return button[0]
 
 class Annotator.Plugin.Toolbar extends Annotator.Plugin
-  PUSHED_CLASS = 'annotator-pushed'
-
   events:
     'setVisibleHighlights': 'onSetVisibleHighlights'
 

--- a/h/static/scripts/annotator/plugin/toolbar.coffee
+++ b/h/static/scripts/annotator/plugin/toolbar.coffee
@@ -13,11 +13,9 @@ class Annotator.Plugin.Toolbar extends Annotator.Plugin
   PUSHED_CLASS = 'annotator-pushed'
 
   events:
-    '.annotator-toolbar mouseenter': 'show'
-    '.annotator-toolbar mouseleave': 'hide'
     'setVisibleHighlights': 'onSetVisibleHighlights'
 
-  html: '<div class="annotator-toolbar annotator-hide"></div>'
+  html: '<div class="annotator-toolbar"></div>'
 
   pluginInit: ->
     @annotator.toolbar = @toolbar = $(@html)
@@ -39,7 +37,7 @@ class Annotator.Plugin.Toolbar extends Annotator.Plugin
           else
             @annotator.triggerHideFrame()
     ,
-      "title": "Show Annotations"
+      "title": "Hide Highlights"
       "class": "h-icon-visibility"
       "on":
         "click": (event) =>
@@ -67,16 +65,15 @@ class Annotator.Plugin.Toolbar extends Annotator.Plugin
     # psuedo-class to a clicked element.
     @toolbar.on('mouseup', 'a', (event) -> $(event.target).blur())
 
-  show: -> this.toolbar.removeClass('annotator-hide')
-
-  hide: -> this.toolbar.addClass('annotator-hide')
-
   onSetVisibleHighlights: (state) ->
     if state
-      $(@buttons[1]).addClass(PUSHED_CLASS)
+      $(@buttons[1]).children().removeClass('h-icon-visibility-off')
+      $(@buttons[1]).children().addClass('h-icon-visibility')
+      $(@buttons[1]).children().prop('title', 'Hide Highlights');
     else
-      $(@buttons[1]).removeClass(PUSHED_CLASS)
-    this._updateStickyButtons()
+      $(@buttons[1]).children().removeClass('h-icon-visibility')
+      $(@buttons[1]).children().addClass('h-icon-visibility-off')
+      $(@buttons[1]).children().prop('title', 'Show Highlights');
 
   _updateStickyButtons: ->
     count = $(@buttons).filter(-> $(this).hasClass(PUSHED_CLASS)).length

--- a/h/static/styles/inject.scss
+++ b/h/static/styles/inject.scss
@@ -152,33 +152,8 @@ $base-font-size: 14px;
   }
 }
 
-.annotator-frame .annotator-toolbar.annotator-hide {
-  display: block;
-  visibility: visible;
-
-  li {
-    @include transition-delay(.75s);
-    @include transition-timing-function(cubic-bezier(1, .1, .55, 0));
-    height: 0;
-    left: 34px;
-    margin-top: -2px;
-    &:first-child, &.annotator-pushed {
-      @include transition-delay(0);
-      left: 3px;
-      height: 30px;
-    }
-    &.annotator-pushed {
-      margin-top: 5px;
-    }
-  }
-}
-
 .annotator-frame .annotator-toolbar li {
   @include smallshadow;
-  @include transition-property(left, height, margin-top);
-  @include transition-duration(.25s);
-  @include transition-delay(0);
-  @include transition-timing-function(cubic-bezier(0, .55, .1, 1));
   background: $white;
   border: solid 1px $gray-lighter;
   border-radius: 4px;
@@ -199,16 +174,6 @@ $base-font-size: 14px;
     padding-right: 6px;
     width: 36px;
     z-index: 1;
-  }
-
-  &.annotator-pushed {
-    @include box-shadow(none);
-    left: 3px;
-    z-index: 1;
-
-    a {
-      color: $text-color;
-    }
   }
 
   a {

--- a/h/static/styles/variables.scss
+++ b/h/static/styles/variables.scss
@@ -57,7 +57,7 @@ $bucket-bar-width: 22px;
 $highlight-color: rgba(255, 255, 60, 0.3);
 $highlight-color-second: rgba(206, 206, 60, 0.4);
 $highlight-color-third: rgba(192, 192, 49, 0.4);
-$highlight-color-focus: rgb(224, 246, 254);
+$highlight-color-focus: rgba(156, 230, 255, 0.5);
 $score-width: 40px;
 $score-height: $score-width;
 $input-border-radius: 2px;


### PR DESCRIPTION
This PR address the following issues:
- https://github.com/hypothesis/h/issues/2135
- https://github.com/hypothesis/h/issues/2135
- https://github.com/hypothesis/vision/issues/187

The changes in it were recommended by Michele Ide-Smith's wonderful [Hypothes.is UX Review Doc](https://docs.google.com/a/hypothes.is/document/d/1pTsZAYUyjRT4MFqkRPo-f6XTs76rcNY5PpM9DXQD290/edit#), which you can reference for rational behind these changes.

You can see this PR in action here: https://improve-ux.dokku.hypothes.is

Changes:
- Toolbar is now always open (many people have suggested this in the past)
- Show anotations changes icon and tooltip when toggled.
- .annotator-h1-focused color darkened