### PR TITLE
Analytics

### DIFF
--- a/h/assets.yaml
+++ b/h/assets.yaml
@@ -37,6 +37,17 @@ angular_toastr:
       contents: h:static/scripts/vendor/angular-toastr/angular-toastr.css
 
 
+# Analytics
+angulartics:
+  filters: uglifyjs
+  output: scripts/vendor/angulartics.min.js
+  contents: h:static/scripts/vendor/angulartics.js
+angulartics_ga:
+  filters: uglifyjs
+  output: scripts/vendor/angulartics-ga.min.js
+  contents: h:static/scripts/vendor/angulartics-ga.js
+
+
 # jQuery
 jquery:
   filters: uglifyjs
@@ -100,6 +111,8 @@ app:
     - angular_sanitize
     - angular_tags_input
     - angular_toastr
+    - angulartics
+    - angulartics_ga
     - autofill
     - bind
     - katex

--- a/h/claim/invite.py
+++ b/h/claim/invite.py
@@ -104,15 +104,18 @@ def send_invitations(request, api_key, users):
     log.info('Collecting merge vars and recipients.')
     merge_vars = list(get_merge_vars(request, users))
     recipients = list(get_recipients(users))
+    message = {
+        'merge_vars': merge_vars,
+        'to': recipients,
+        'google_analytics_domains': [request.domain],
+        'google_analytics_campaign': 'invite',
+    }
 
     try:
         results = mandrill.Mandrill(api_key).messages.send_template(
             template_content=[],
             template_name='activation-email-to-reserved-usernames',
-            message={
-                'merge_vars': merge_vars,
-                'to': recipients,
-            }
+            message=message,
         )
     except mandrill.Error:
         log.exception('Error sending invitations.')

--- a/h/config.py
+++ b/h/config.py
@@ -11,6 +11,7 @@ log = logging.getLogger(__name__)
 def settings_from_environment():
     settings = {}
 
+    _setup_analytics(settings)
     _setup_heroku(settings)
     _setup_db(settings)
     _setup_elasticsearch(settings)
@@ -34,6 +35,11 @@ def normalise_database_url(url):
     if url.startswith('postgres://'):
         url = 'postgresql+psycopg2://' + url[len('postgres://'):]
     return url
+
+
+def _setup_analytics(settings):
+    if 'GOOGLE_ANALYTICS_TRACKING_ID' in os.environ:
+        settings['ga_tracking_id'] = os.environ['GOOGLE_ANALYTICS_TRACKING_ID']
 
 
 def _setup_heroku(settings):

--- a/h/static/scripts/app.coffee
+++ b/h/static/scripts/app.coffee
@@ -77,6 +77,8 @@ setupStreamer = [
 ]
 
 module.exports = angular.module('h', [
+  'angulartics'
+  'angulartics.google.analytics'
   'bootstrap'
   'ngAnimate'
   'ngResource'

--- a/h/static/scripts/cross-frame.coffee
+++ b/h/static/scripts/cross-frame.coffee
@@ -36,8 +36,7 @@ module.exports = class CrossFrame
           $rootScope.$apply ->
             $rootScope.$emit.call($rootScope, args...)
         on: (event, handler) ->
-          $rootScope.$apply ->
-            $rootScope.$on(event, (event, args...) -> handler.apply(this, args))
+          $rootScope.$on(event, (event, args...) -> handler.apply(this, args))
 
       new AnnotationSync(bridge, options)
 

--- a/h/static/scripts/vendor/angulartics-ga.js
+++ b/h/static/scripts/vendor/angulartics-ga.js
@@ -1,0 +1,96 @@
+/**
+ * @license Angulartics v0.17.2
+ * (c) 2013 Luis Farzati http://luisfarzati.github.io/angulartics
+ * Universal Analytics update contributed by http://github.com/willmcclellan
+ * License: MIT
+ */
+(function(angular) {
+'use strict';
+
+/**
+ * @ngdoc overview
+ * @name angulartics.google.analytics
+ * Enables analytics support for Google Analytics (http://google.com/analytics)
+ */
+angular.module('angulartics.google.analytics', ['angulartics'])
+.config(['$analyticsProvider', function ($analyticsProvider) {
+
+  // GA already supports buffered invocations so we don't need
+  // to wrap these inside angulartics.waitForVendorApi
+
+  $analyticsProvider.settings.trackRelativePath = true;
+  
+  // Set the default settings for this module
+  $analyticsProvider.settings.ga = {
+    // array of additional account names (only works for analyticsjs)
+    additionalAccountNames: undefined
+  };
+
+  $analyticsProvider.registerPageTrack(function (path) {
+    if (window._gaq) _gaq.push(['_trackPageview', path]);
+    if (window.ga) {
+      ga('send', 'pageview', path);
+      angular.forEach($analyticsProvider.settings.ga.additionalAccountNames, function (accountName){
+        ga(accountName +'.send', 'pageview', path);
+      });
+    }
+  });
+
+  /**
+   * Track Event in GA
+   * @name eventTrack
+   *
+   * @param {string} action Required 'action' (string) associated with the event
+   * @param {object} properties Comprised of the mandatory field 'category' (string) and optional  fields 'label' (string), 'value' (integer) and 'noninteraction' (boolean)
+   *
+   * @link https://developers.google.com/analytics/devguides/collection/gajs/eventTrackerGuide#SettingUpEventTracking
+   *
+   * @link https://developers.google.com/analytics/devguides/collection/analyticsjs/events
+   */
+  $analyticsProvider.registerEventTrack(function (action, properties) {
+
+    // do nothing if there is no category (it's required by GA)
+    if (!properties || !properties.category) { 
+		return; 
+	}
+    // GA requires that eventValue be an integer, see:
+    // https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#eventValue
+    // https://github.com/luisfarzati/angulartics/issues/81
+    if (properties.value) {
+      var parsed = parseInt(properties.value, 10);
+      properties.value = isNaN(parsed) ? 0 : parsed;
+    }
+
+    if (window.ga) {
+
+      var eventOptions = {
+        eventCategory: properties.category || null,
+        eventAction: action || null,
+        eventLabel: properties.label ||  null,
+        eventValue: properties.value || null,
+        nonInteraction: properties.noninteraction || null
+      };
+
+      // add custom dimensions and metrics
+      for(var idx = 1; idx<=20;idx++) {
+      if (properties['dimension' +idx.toString()]) {
+        eventOptions['dimension' +idx.toString()] = properties['dimension' +idx.toString()];
+      }
+      if (properties['metric' +idx.toString()]) {
+        eventOptions['metric' +idx.toString()] = properties['metric' +idx.toString()];
+        }
+      }
+      ga('send', 'event', eventOptions);
+      angular.forEach($analyticsProvider.settings.ga.additionalAccountNames, function (accountName){
+        ga(accountName +'.send', 'event', eventOptions);
+      });
+    }
+
+    else if (window._gaq) {
+      _gaq.push(['_trackEvent', properties.category, action, properties.label, properties.value, properties.noninteraction]);
+    }
+
+  });
+
+}]);
+})(angular);

--- a/h/static/scripts/vendor/angulartics.js
+++ b/h/static/scripts/vendor/angulartics.js
@@ -1,0 +1,266 @@
+/**
+ * @license Angulartics v0.17.2
+ * (c) 2013 Luis Farzati http://luisfarzati.github.io/angulartics
+ * License: MIT
+ */
+(function(angular, analytics) {
+'use strict';
+
+var angulartics = window.angulartics || (window.angulartics = {});
+angulartics.waitForVendorCount = 0;
+angulartics.waitForVendorApi = function (objectName, delay, containsField, registerFn, onTimeout) {
+  if (!onTimeout) { angulartics.waitForVendorCount++; }
+  if (!registerFn) { registerFn = containsField; containsField = undefined; }
+  if (!Object.prototype.hasOwnProperty.call(window, objectName) || (containsField !== undefined && window[objectName][containsField] === undefined)) {
+    setTimeout(function () { angulartics.waitForVendorApi(objectName, delay, containsField, registerFn, true); }, delay);
+  }
+  else {
+    angulartics.waitForVendorCount--;
+    registerFn(window[objectName]);
+  }
+};
+
+/**
+ * @ngdoc overview
+ * @name angulartics
+ */
+angular.module('angulartics', [])
+.provider('$analytics', function () {
+  var settings = {
+    pageTracking: {
+      autoTrackFirstPage: true,
+      autoTrackVirtualPages: true,
+      trackRelativePath: false,
+      autoBasePath: false,
+      basePath: ''
+    },
+    eventTracking: {},
+    bufferFlushDelay: 1000, // Support only one configuration for buffer flush delay to simplify buffering
+    developerMode: false // Prevent sending data in local/development environment
+  };
+
+  // List of known handlers that plugins can register themselves for
+  var knownHandlers = [
+    'pageTrack',
+    'eventTrack',
+    'setAlias',
+    'setUsername',
+    'setAlias',
+    'setUserProperties',
+    'setUserPropertiesOnce',
+    'setSuperProperties',
+    'setSuperPropertiesOnce'
+  ];
+  // Cache and handler properties will match values in 'knownHandlers' as the buffering functons are installed.
+  var cache = {};
+  var handlers = {};
+
+  // General buffering handler
+  var bufferedHandler = function(handlerName){
+    return function(){
+      if(angulartics.waitForVendorCount){
+        if(!cache[handlerName]){ cache[handlerName] = []; }
+        cache[handlerName].push(arguments);
+      }
+    };
+  };
+
+  // As handlers are installed by plugins, they get pushed into a list and invoked in order.
+  var updateHandlers = function(handlerName, fn){
+    if(!handlers[handlerName]){
+      handlers[handlerName] = [];
+    }
+    handlers[handlerName].push(fn);
+    return function(){
+      var handlerArgs = arguments;
+      angular.forEach(handlers[handlerName], function(handler){
+        handler.apply(this, handlerArgs);
+      }, this);
+    };
+  };
+
+  // The api (returned by this provider) gets populated with handlers below.
+  var api = {
+    settings: settings
+  };
+
+  // Will run setTimeout if delay is > 0
+  // Runs immediately if no delay to make sure cache/buffer is flushed before anything else.
+  // Plugins should take care to register handlers by order of precedence.
+  var onTimeout = function(fn, delay){
+    if(delay){
+      setTimeout(fn, delay);
+    } else {
+      fn();
+    }
+  };
+
+  var provider = {
+    $get: function() { return api; },
+    api: api,
+    settings: settings,
+    virtualPageviews: function (value) { this.settings.pageTracking.autoTrackVirtualPages = value; },
+    firstPageview: function (value) { this.settings.pageTracking.autoTrackFirstPage = value; },
+    withBase: function (value) { this.settings.pageTracking.basePath = (value) ? angular.element('base').attr('href').slice(0, -1) : ''; },
+    withAutoBase: function (value) { this.settings.pageTracking.autoBasePath = value; },
+    developerMode: function(value) { this.settings.developerMode = value; }
+  };
+
+  // General function to register plugin handlers. Flushes buffers immediately upon registration according to the specified delay.
+  var register = function(handlerName, fn){
+    api[handlerName] = updateHandlers(handlerName, fn);
+    var handlerSettings = settings[handlerName];
+    var handlerDelay = (handlerSettings) ? handlerSettings.bufferFlushDelay : null;
+    var delay = (handlerDelay !== null) ? handlerDelay : settings.bufferFlushDelay;
+    angular.forEach(cache[handlerName], function (args, index) {
+      onTimeout(function () { fn.apply(this, args); }, index * delay);
+    });
+  };
+
+  var capitalize = function (input) {
+      return input.replace(/^./, function (match) {
+          return match.toUpperCase();
+      });
+  };
+
+  // Adds to the provider a 'register#{handlerName}' function that manages multiple plugins and buffer flushing.
+  var installHandlerRegisterFunction = function(handlerName){
+    var registerName = 'register'+capitalize(handlerName);
+    provider[registerName] = function(fn){
+      register(handlerName, fn);
+    };
+    api[handlerName] = updateHandlers(handlerName, bufferedHandler(handlerName));
+  };
+
+  // Set up register functions for each known handler
+  angular.forEach(knownHandlers, installHandlerRegisterFunction);
+  return provider;
+})
+
+.run(['$rootScope', '$window', '$analytics', '$injector', function ($rootScope, $window, $analytics, $injector) {
+  if ($analytics.settings.pageTracking.autoTrackFirstPage) {
+    $injector.invoke(['$location', function ($location) {
+      /* Only track the 'first page' if there are no routes or states on the page */
+      var noRoutesOrStates = true;
+      if ($injector.has('$route')) {
+         var $route = $injector.get('$route');
+         for (var route in $route.routes) {
+           noRoutesOrStates = false;
+           break;
+         }
+      } else if ($injector.has('$state')) {
+        var $state = $injector.get('$state');
+        for (var state in $state.get()) {
+          noRoutesOrStates = false;
+          break;
+        }
+      }
+      if (noRoutesOrStates) {
+        if ($analytics.settings.pageTracking.autoBasePath) {
+          $analytics.settings.pageTracking.basePath = $window.location.pathname;
+        }
+        if ($analytics.settings.trackRelativePath) {
+          var url = $analytics.settings.pageTracking.basePath + $location.url();
+          $analytics.pageTrack(url, $location);
+        } else {
+          $analytics.pageTrack($location.absUrl(), $location);
+        }
+      }
+    }]);
+  }
+
+  if ($analytics.settings.pageTracking.autoTrackVirtualPages) {
+    $injector.invoke(['$location', function ($location) {
+      if ($analytics.settings.pageTracking.autoBasePath) {
+        /* Add the full route to the base. */
+        $analytics.settings.pageTracking.basePath = $window.location.pathname + "#";
+      }
+      if ($injector.has('$route')) {
+        $rootScope.$on('$routeChangeSuccess', function (event, current) {
+          if (current && (current.$$route||current).redirectTo) return;
+          var url = $analytics.settings.pageTracking.basePath + $location.url();
+          $analytics.pageTrack(url, $location);
+        });
+      }
+      if ($injector.has('$state')) {
+        $rootScope.$on('$stateChangeSuccess', function (event, current) {
+          var url = $analytics.settings.pageTracking.basePath + $location.url();
+          $analytics.pageTrack(url, $location);
+        });
+      }
+    }]);
+  }
+  if ($analytics.settings.developerMode) {
+    angular.forEach($analytics, function(attr, name) {
+      if (typeof attr === 'function') {
+        $analytics[name] = function(){};
+      }
+    });
+  }
+}])
+
+.directive('analyticsOn', ['$analytics', function ($analytics) {
+  function isCommand(element) {
+    return ['a:','button:','button:button','button:submit','input:button','input:submit'].indexOf(
+      element.tagName.toLowerCase()+':'+(element.type||'')) >= 0;
+  }
+
+  function inferEventType(element) {
+    if (isCommand(element)) return 'click';
+    return 'click';
+  }
+
+  function inferEventName(element) {
+    if (isCommand(element)) return element.innerText || element.value;
+    return element.id || element.name || element.tagName;
+  }
+
+  function isProperty(name) {
+    return name.substr(0, 9) === 'analytics' && ['On', 'Event', 'If', 'Properties', 'EventType'].indexOf(name.substr(9)) === -1;
+  }
+
+  function propertyName(name) {
+    var s = name.slice(9); // slice off the 'analytics' prefix
+    if (typeof s !== 'undefined' && s!==null && s.length > 0) {
+      return s.substring(0, 1).toLowerCase() + s.substring(1);
+    }
+    else {
+      return s;
+    }
+  }
+
+  return {
+    restrict: 'A',
+    link: function ($scope, $element, $attrs) {
+      var eventType = $attrs.analyticsOn || inferEventType($element[0]);
+      var trackingData = {};
+
+      angular.forEach($attrs.$attr, function(attr, name) {
+        if (isProperty(name)) {
+          trackingData[propertyName(name)] = $attrs[name];
+          $attrs.$observe(name, function(value){
+            trackingData[propertyName(name)] = value;
+          });
+        }
+      });
+
+      angular.element($element[0]).bind(eventType, function ($event) {
+        var eventName = $attrs.analyticsEvent || inferEventName($element[0]);
+        trackingData.eventType = $event.type;
+
+        if($attrs.analyticsIf){
+          if(! $scope.$eval($attrs.analyticsIf)){
+            return; // Cancel this event if we don't pass the analytics-if condition
+          }
+        }
+        // Allow components to pass through an expression that gets merged on to the event properties
+        // eg. analytics-properites='myComponentScope.someConfigExpression.$analyticsProperties'
+        if($attrs.analyticsProperties){
+          angular.extend(trackingData, $scope.$eval($attrs.analyticsProperties));
+        }
+        $analytics.eventTrack(eventName, trackingData);
+      });
+    }
+  };
+}]);
+})(angular);

--- a/h/subscribers.py
+++ b/h/subscribers.py
@@ -9,3 +9,12 @@ def add_renderer_globals(event):
     event['service_url'] = request.resource_url(request.root, 'api', '')
     # Allow templates to check for feature flags
     event['feature'] = request.registry.feature
+
+    # Add Google Analytics
+    ga_tracking_id = request.registry.settings.get('ga_tracking_id')
+    if ga_tracking_id is not None:
+        event['ga_tracking_id'] = ga_tracking_id
+        if 'localhost' in request.host:
+            event['ga_create_options'] = "'none'"
+        else:
+            event['ga_create_options'] = "'auto'"

--- a/h/templates/layouts/base.html
+++ b/h/templates/layouts/base.html
@@ -41,7 +41,9 @@
       <script>
        window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
        ga('create', 'UA-{{ga_tracking_id}}', {{ga_create_options|safe}});
+       {% if not layout.app -%}
        ga('send', 'pageview');
+       {%- endif -%}
       </script>
       <!-- End Google Analytics -->
     {% endif %}

--- a/h/templates/layouts/base.html
+++ b/h/templates/layouts/base.html
@@ -35,6 +35,17 @@
     {% endif %}
     {% block styles %}{% endblock %}
 
+    {% if ga_tracking_id %}
+      <!-- Google Analytics -->
+      <script async src='//www.google-analytics.com/analytics.js'></script>
+      <script>
+       window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+       ga('create', 'UA-{{ga_tracking_id}}', {{ga_create_options|safe}});
+       ga('send', 'pageview');
+      </script>
+      <!-- End Google Analytics -->
+    {% endif %}
+
     {% if base_url %}
       <base target="_top" href="{{ base_url }}" />
     {% endif %}

--- a/h/test/config_test.py
+++ b/h/test/config_test.py
@@ -5,6 +5,17 @@ from h.config import settings_from_environment
 
 
 @patch.dict(os.environ)
+def test_google_analytics():
+    os.environ['GOOGLE_ANALYTICS_TRACKING_ID'] = '12345-1'
+
+    actual_config = settings_from_environment()
+    expected_config = {
+        'ga_tracking_id': '12345-1',
+    }
+    assert actual_config == expected_config
+
+
+@patch.dict(os.environ)
 def test_heroku_bonsai():
     url = 'http://ql9lsrn8:img5ndnsbtaahloy@redwood-94865.us-east-1.bonsai.io/'
     os.environ['BONSAI_URL'] = url


### PR DESCRIPTION
This pull request adds some basic Google Analytics support.

- Server-rendered pages track page views
- Claim invitation emails send campaign code
- Single-page application tracks page views using angulartics (luisfarzati/angulartics)

Angulartics can work with any number of providers so the front-end is actually enabled for various analytics providers with a little tweaking. We can start to add support for logging analytics events from various UI actions, too, if we desire. See documentation for angulartics.