### PR TITLE
Add a blocklist of sites we don't launch on

### DIFF
--- a/h/browser/chrome/help/index.html
+++ b/h/browser/chrome/help/index.html
@@ -101,6 +101,10 @@
         <h1 class="help-item__heading">We’re sorry, Hypothesis doesn’t work on this page…</h1>
         <p class="center">This extension can only be used on pages served over HTTP/HTTPS and FTP.</p>
       </section>
+      <section id="blocked-site" class="help-item">
+        <img class="help-item__icon" src="sad-annotation.svg" />
+        <h1 class="help-item__heading">We’re sorry, Hypothesis doesn't work on this site yet.</h1>
+      </section>
     </article>
     <script src="./index.js"></script>
   </body>

--- a/h/browser/chrome/karma.config.js
+++ b/h/browser/chrome/karma.config.js
@@ -27,7 +27,8 @@ module.exports = function(config) {
       'lib/browser-action.js',
       'lib/help-page.js',
       'lib/hypothesis-chrome-extension.js',
-      'test/*-test.js'
+      'test/*-test.js',
+      '../../static/scripts/blocklist.js'
     ],
 
 

--- a/h/browser/chrome/lib/errors.js
+++ b/h/browser/chrome/lib/errors.js
@@ -23,9 +23,16 @@
   }
   RestrictedProtocolError.prototype = Object.create(ExtensionError);
 
+  function BlockedSiteError(message) {
+    Error.apply(this, arguments);
+    this.message = message;
+  }
+  BlockedSiteError.prototype = Object.create(ExtensionError);
+
   h.ExtensionError = ExtensionError;
   h.LocalFileError = LocalFileError;
   h.NoFileAccessError = NoFileAccessError;
   h.RestrictedProtocolError = RestrictedProtocolError;
+  h.BlockedSiteError = BlockedSiteError;
 
 })(window.h || (window.h = {}));

--- a/h/browser/chrome/lib/help-page.js
+++ b/h/browser/chrome/lib/help-page.js
@@ -29,6 +29,9 @@
       else if (error instanceof h.RestrictedProtocolError) {
         return this.showRestrictedProtocolPage(tab);
       }
+      else if (error instanceof h.BlockedSiteError) {
+        return this.showBlockedSitePage(tab);
+      }
 
       throw new Error('showHelpForError does not support the error: ' + error.message);
     };
@@ -36,6 +39,7 @@
     this.showLocalFileHelpPage = showHelpPage.bind(null, 'local-file');
     this.showNoFileAccessHelpPage = showHelpPage.bind(null, 'no-file-access');
     this.showRestrictedProtocolPage = showHelpPage.bind(null, 'restricted-protocol');
+    this.showBlockedSitePage = showHelpPage.bind(null, 'blocked-site');
 
     // Render the help page. The helpSection should correspond to the id of a
     // section within the help page.

--- a/h/browser/chrome/manifest.json
+++ b/h/browser/chrome/manifest.json
@@ -35,7 +35,8 @@
       "lib/help-page.js",
       "lib/errors.js",
       "lib/hypothesis-chrome-extension.js",
-      "lib/install.js"
+      "lib/install.js",
+      "lib/blocklist.js"
     ]
   },
   "browser_action": {

--- a/h/browser/chrome/test/help-page-test.js
+++ b/h/browser/chrome/test/help-page-test.js
@@ -42,6 +42,16 @@ describe('HelpPage', function () {
       });
     });
 
+    it('renders the "blocked-site" page when passed a BlockedSiteError', function () {
+      help.showHelpForError({id: 1, index: 1}, new h.BlockedSiteError('msg'));
+      sinon.assert.called(fakeChromeTabs.create);
+      sinon.assert.calledWith(fakeChromeTabs.create, {
+        index: 2,
+        openerTabId: 1,
+        url: 'CRX_PATH/help/index.html#blocked-site'
+      });
+    });
+
     it('throws an error if an unsupported error is provided', function () {
       assert.throws(function () {
         help.showHelpForError(new Error('Random Error'));

--- a/h/buildext.py
+++ b/h/buildext.py
@@ -9,6 +9,7 @@ import os.path
 import shutil
 import textwrap
 import urlparse
+import json
 
 from jinja2 import Template
 from pyramid import paster
@@ -169,6 +170,8 @@ def build_chrome(args):
     copytree('h/browser/chrome/images', 'build/chrome/images')
     copytree('h/browser/chrome/lib', 'build/chrome/lib')
     copytree('h/static/images', 'build/chrome/public/images')
+    shutil.copyfile(
+        'h/static/scripts/blocklist.js', 'build/chrome/lib/blocklist.js')
 
     # Render the sidebar html.
     if webassets_env.url.startswith('chrome-extension:'):
@@ -186,6 +189,10 @@ def build_chrome(args):
     with open('build/chrome/manifest.json', 'w') as fp:
         data = chrome_manifest(env['request'])
         fp.write(data)
+
+    # Render the blocklist as a JSON file.
+    with open('build/chrome/blocklist.json', 'w') as fp:
+        fp.write(json.dumps(env['registry'].settings['h.blocklist']))
 
 
 def build_firefox(args):

--- a/h/config.py
+++ b/h/config.py
@@ -24,6 +24,7 @@ def settings_from_environment():
     _setup_statsd(settings)
     _setup_webassets(settings)
     _setup_websocket(settings)
+    _setup_blocklist(settings)
 
     return settings
 
@@ -180,3 +181,8 @@ def _setup_webassets(settings):
 def _setup_websocket(settings):
     if 'ALLOWED_ORIGINS' in os.environ:
         settings['origins'] = os.environ['ALLOWED_ORIGINS']
+
+
+def _setup_blocklist(settings):
+    if 'BLOCKLIST' in os.environ:
+        settings['h.blocklist'] = os.environ['BLOCKLIST']

--- a/h/static/scripts/blocklist.js
+++ b/h/static/scripts/blocklist.js
@@ -1,0 +1,94 @@
+var blocklist = (function() {
+  'use strict';
+
+  /* Parse the given URL and return an object with its different components.
+  *
+  * Any or all of the components returned may be undefined.
+  * For example for the URL "http://twitter.com" port, path query and anchor
+  * will be undefined.
+  *
+  */
+  var parseUrl = function(url) {
+    // Regular expression from Douglas Crockford's book
+    // JavaScript: The Good Parts.
+    var regex = /^(?:([A-Za-z]+):)?(\/{0,3})([0-9.\-A-Za-z]+)(?::(\d+))?(?:\/([^?#]*))?(?:\?([^#]*))?(?:#(.*))?$/;
+    var result = regex.exec(url);
+
+    if (result) {
+      return {
+        scheme: result[1],
+        host: result[3],
+        port: result[4],
+        path: result[5],
+        query: result[6],
+        anchor: result[7]
+      };
+    }
+
+    return {
+      scheme: undefined,
+      host: undefined,
+      port: undefined,
+      path: undefined,
+      query: undefined,
+      anchor: undefined
+    };
+  };
+
+  /* Return true if the given url is blocked by the given blocklist. */
+  var isBlocked = function(url, blocklist) {
+    url = url || '';
+
+    // Match against the hostname only, so that a pattern like
+    // "twitter.com" matches pages like "twitter.com/tag/foo".
+    var hostname = parseUrl(url).host;
+
+    if (hostname === undefined) {
+      // This happens with things like chrome-devtools:// URLs where there's
+      // no host.
+      return false;
+    }
+
+    var regexSpecialChars = '^$.+?=|\/()[]{}'; //  '*' deliberately omitted.
+    for (var pattern in blocklist) {
+      if (blocklist.hasOwnProperty(pattern)) {
+        // Escape regular expression special characters.
+        for (var i = 0; i < regexSpecialChars.length; i++) {
+          var c = regexSpecialChars.charAt(i);
+          pattern = pattern.replace(c, '\\' + c);
+        }
+
+        // Turn * into .* to enable simple patterns like "*.google.com".
+        pattern = pattern.replace('*', '.*');
+
+        // Blocklist patterns should match from the start of the URL.
+        // This means that "google.com" will _not_ match "mail.google.com",
+        // for example. (But "*.google.com" will match it.)
+        pattern = '^' + pattern;
+
+        if (hostname.match(pattern)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  };
+
+  return {
+    parseUrl: parseUrl,
+    isBlocked: isBlocked
+  };
+})();
+
+if (typeof(window.h) !== 'undefined') {
+  // Looks like blocklist.js is being run by the Chrome extension, so add to
+  // window.h like the rest of the Chrome extension libs do.
+  window.h.blocklist = blocklist;
+} else if (typeof(module) !== 'undefined') {
+  // Looks like blocklist.js being run by the frontend tests, so export the
+  // blocklist using browserify.
+  module.exports = blocklist;
+} else {
+  // Looks like blocklist.js is being run by the bookmarklet, so we don't need
+  // to export anything because it gets inlined into embed.js by Jinja2.
+}

--- a/h/static/scripts/test/blocklist-test.js
+++ b/h/static/scripts/test/blocklist-test.js
@@ -1,0 +1,60 @@
+describe('parseUrl', function () {
+  'use strict';
+
+  var assert = chai.assert;
+  var blocklist = require('../blocklist');
+  var parseUrl = blocklist.parseUrl;
+
+  it("returns 'http' for the scheme for http:// URLs", function() {
+    assert.equal(parseUrl("http://example.com").scheme, "http");
+  });
+
+  it("returns 'https' for the scheme for https:// URLs", function() {
+    assert.equal(parseUrl("https://example.com").scheme, "https");
+  });
+
+  it("returns the host part correctly", function() {
+    var parts = parseUrl("https://example.com:23/foo/bar?oh=no#gar");
+    assert.equal(parts.host, "example.com");
+  });
+
+  it("returns the port part correctly", function() {
+    var parts = parseUrl("https://example.com:23/foo/bar?oh=no#gar");
+    assert.equal(parts.port, "23");
+  });
+
+  it("returns undefined for the port if there isn't one", function() {
+    var parts = parseUrl("https://example.com/foo/bar?oh=no#gar");
+    assert.equal(parts.port, undefined);
+  });
+
+  it("returns the path part correctly", function() {
+    var parts = parseUrl("https://example.com:23/foo/bar?oh=no#gar");
+    assert.equal(parts.path, "foo/bar");
+  });
+
+  it("returns undefined for the path if there isn't one", function() {
+    var parts = parseUrl("https://example.com?oh=no#gar");
+    assert.equal(parts.path, undefined);
+  });
+
+  it("returns the query part correctly", function() {
+    var parts = parseUrl("https://example.com:23/foo/bar?oh=no&ooh=ah#gar");
+    assert.equal(parts.query, "oh=no&ooh=ah");
+  });
+
+  it("returns undefined for the query if there isn't one", function() {
+    var parts = parseUrl("https://example.com#gar");
+    assert.equal(parts.query, undefined);
+  });
+
+  it("returns the anchor part correctly", function() {
+    var parts = parseUrl("https://example.com:23/foo/bar?oh=no&ooh=ah#gar");
+    assert.equal(parts.anchor, "gar");
+  });
+
+  it("returns undefined for the anchor if there isn't one", function() {
+    var parts = parseUrl("https://example.com:23/foo/bar?oh=no&ooh=ah");
+    assert.equal(parts.anchor, undefined);
+  });
+});

--- a/h/templates/embed.js
+++ b/h/templates/embed.js
@@ -1,3 +1,7 @@
+{% if blocklist -%}
+{% include 'h:static/scripts/blocklist.js' %}
+{% endif -%}
+
 (function () {
   // Injects the hypothesis dependencies. These can be either js or css, the
   // file extension is used to determine the loading method. This file is
@@ -41,6 +45,18 @@
 
       document.head.appendChild(script);
     };
+
+    {% if blocklist %}
+      // For certain blocklisted hostnames we bail out and don't inject
+      // Hypothesis.
+      var url = window.location.toString();
+      if (blocklist.isBlocked(url, {{ blocklist|safe }})) {
+        window.alert(
+          "We're sorry, but Hypothesis doesn't work on " +
+          window.location.hostname + " yet.");
+        return;
+      }
+    {% endif %}
 
     if (!window.document.evaluate) {
       resources = resources.concat(['{{ layout.xpath_polyfill_urls | map("string") | join("', '") | safe }}']);

--- a/h/test/config_test.py
+++ b/h/test/config_test.py
@@ -221,3 +221,13 @@ def test_session_secret_environment():  # bw compat
         'secret_key': 's3kr1t',
     }
     assert actual_config == expected_config
+
+
+@patch.dict(os.environ)
+def test_blocklist():
+    blocklist = '{"seanh.cc": {}, "twitter.com": {}, "finance.yahoo.com": {}'
+    os.environ['BLOCKLIST'] = blocklist
+
+    actual_config = settings_from_environment()
+
+    assert actual_config == {'h.blocklist': blocklist}

--- a/h/test/views_test.py
+++ b/h/test/views_test.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
+import json
 
 import unittest
 import mock
@@ -28,3 +29,54 @@ class TestAnnotationView(unittest.TestCase):
         assert isinstance(result, dict)
         test = lambda d: 'foo' in d['content']
         assert any(test(d) for d in result['meta_attrs'])
+
+
+class TestJS(object):
+    """Unit tests for the js() view callable."""
+
+    def test_blocklist(self):
+        """It should pass the blocklist as a string to embed.js."""
+        request = mock.MagicMock()
+        blocklist = {"foo": "bar"}
+        request.registry.settings = {'h.blocklist': blocklist}
+
+        data = views.js({}, request)
+
+        assert data['blocklist'] == json.dumps(blocklist)
+
+
+class TestValidateBlocklist(object):
+    """Unit tests for the _validate_blocklist() function."""
+
+    def test_valid(self):
+        """It should load the setting into a dict."""
+        blocklist = {
+            "seanh.cc": {},
+            "finance.yahoo.com": {},
+            "twitter.com": {}
+        }
+        config = mock.MagicMock()
+        config.registry.settings = {"h.blocklist": json.dumps(blocklist)}
+
+        views._validate_blocklist(config)
+
+        assert config.registry.settings["h.blocklist"] == blocklist, (
+            "_validate_blocklist() should parse the JSON and turn it into a "
+            "dict")
+
+    def test_invalid_json(self):
+        """It should raise ValueError if the setting is invalid."""
+        config = mock.MagicMock()
+        config.registry.settings = {"h.blocklist": "invalid"}
+
+        with pytest.raises(ValueError):
+            views._validate_blocklist(config)
+
+    def test_default_value(self):
+        """It should insert an empty dict if there's no setting."""
+        config = mock.MagicMock()
+        config.registry.settings = {}
+
+        views._validate_blocklist(config)
+
+        assert config.registry.settings["h.blocklist"] == {}


### PR DESCRIPTION
Add a blocklist of sites we don't launch on
The blocklist is configured in production.ini like so:

    h.blocklist = {
        "seanh.cc": {},
        "finance.yahoo.com": {},
        "twitter.com": {},
        "*.google.com"
    }

The Chrome extension handles the blocklist in the same way that it
handles other launch errors (e.g. when the user hasn't given the
extension permission to annotate file:/// URLs): it adds a (!) error
badge to the "browser action" button, if the button is clicked again it
opens a "help" page saying that the site isn't supported yet.

It doesn't seem to be possible to pass data into the Chrome extension's
help pages (as far as I can tell) so the error is just "Hypothesis
doesn't work on this page yet" and not e.g. "Hypothesis doesn't work on
twitter.com".

The bookmarklet handles the blocklist in the same way that it handles
other launch errors (e.g. trying to annotate a PDF when PDF.js isn't
available): it uses window.alert() to show an error.