### PR TITLE
Uri indexing - remove end hashmark

### DIFF
--- a/h/models.py
+++ b/h/models.py
@@ -124,6 +124,7 @@ class Annotation(annotation.Annotation):
                     '([a-zA-Z0-9-]+)(?:\\.([a-zA-Z0-9-]+))*',
                     '://(.+)',
                     '://(.+)\\#',
+                    '(.+)\\#',
                 ]
             },
             'uri_search': {


### PR DESCRIPTION
Adding a new pattern to capture for the uri analyzer: whole uri without the hashmark from the end

This'll fix a great deal of #2129 
Reindexing will be needed.