### PR TITLE
Center icons in toolbar buttons.

### DIFF
--- a/h/static/styles/inject.scss
+++ b/h/static/styles/inject.scss
@@ -162,7 +162,6 @@ $base-font-size: 14px;
   margin-top: 5px;
   overflow: hidden;
   position: relative;
-  text-align: center;
   height: 30px;
   width: 30px;
 
@@ -181,13 +180,10 @@ $base-font-size: 14px;
     background: $white;
     border: none;
     color: $gray-light;
-    line-height: 28px;
     text-decoration: none;
     height: 28px;
     width: 28px;
-    position: absolute;
-    top: 0;
-    left: 0;
+    padding: 0;
   }
 
   button:active {


### PR DESCRIPTION
This is a really simple PR. The icons in the toolbar were slightly off center, this centers them.

Before:
![selection_047](https://cloud.githubusercontent.com/assets/521978/7190997/feb12b5c-e43e-11e4-89d1-974c488de43d.png)

After:
![selection_048](https://cloud.githubusercontent.com/assets/521978/7191002/056fcc3c-e43f-11e4-8eff-74c2262a6652.png)

