### PR TITLE
Overhaul URI analysis

### DIFF
--- a/h/api/views.py
+++ b/h/api/views.py
@@ -278,7 +278,7 @@ def _add_any_field_params_into_query(search_params):
         'multi_match': {
             'query': any_terms,
             'type': 'cross_fields',
-            'fields': ['quote', 'tags', 'text', 'uri', 'user']
+            'fields': ['quote', 'tags', 'text', 'uri.parts', 'user']
         }
     }
 

--- a/h/static/scripts/query-parser.coffee
+++ b/h/static/scripts/query-parser.coffee
@@ -65,7 +65,7 @@ module.exports = class QueryParser
          query_type: 'multi_match'
          match_type: 'cross_fields'
          and_or: 'and'
-         fields:   ['quote', 'tags', 'text', 'uri', 'user']
+         fields:   ['quote', 'tags', 'text', 'uri.parts', 'user']
 
   populateFilter: (filter, query) =>
     # Populate a filter with a query object


### PR DESCRIPTION
Change the analyzers for URI fields so that they are consistently
indexing for three separate needs:

- Match anything queries
  This analysis will return matches to any piece of the URI by
  splitting it on various separators and their URL-encoded equivalents.
  When the user is typing free text without specifying a facet, this
  will match any part of a URI.

- Site / domain queries
  When the user wants to see all the annotations for a particular site,
  they will type only a domain. This analysis indexes only the domain
  part and strips a leading 'www'.

- Page queries
  This is the "standard" application query for getting annotations
  associated with a URI. It ignores the scheme, query string, fragment
  and strips any trailing slash. It is expected that this will return
  false positives for pages where the query string affects the content
  but that is probably better than the alternative, given the many
  non-content related uses of query strings (tracking variables, etc).

The new mappings are introduced under the "uri.parts" and "site" keys.