### PR TITLE
Keep JWZ and threading idTables in sync

### DIFF
--- a/h/static/scripts/stream-controller.coffee
+++ b/h/static/scripts/stream-controller.coffee
@@ -17,7 +17,7 @@ module.exports = class StreamController
     $scope.search = {}
 
     # XXX: Reset the threading service
-    threading.createIdTable([])
+    threading.idTable = threading.createIdTable([])
     $scope.threadRoot = threading.root = mail.messageContainer()
 
     # Initialize the base filter

--- a/h/static/scripts/test/stream-controller-test.coffee
+++ b/h/static/scripts/test/stream-controller-test.coffee
@@ -63,7 +63,8 @@ describe 'StreamController', ->
     }
 
     fakeThreading = {
-      createIdTable: sandbox.spy()
+      createIdTable: sandbox.stub().returns('a')
+      idTable: null
     }
 
     $provide.value 'annotationMapper', fakeAnnotationMapper
@@ -94,3 +95,4 @@ describe 'StreamController', ->
     assert.calledWith(fakeThreading.createIdTable, [])
     assert.isObject(fakeThreading.root)
     assert.strictEqual(fakeThreading.root, $scope.threadRoot)
+    assert.equal(fakeThreading.idTable, 'a')


### PR DESCRIPTION
When StreamController creates a new idTable, it also gives this new idTable to the threading service. 
Before this fix they were out of Sync.

Fix #2182