### PR TITLE
[chrome] run embed code in page context

### DIFF
--- a/h/browser/chrome/lib/hypothesis-chrome-extension.js
+++ b/h/browser/chrome/lib/hypothesis-chrome-extension.js
@@ -131,6 +131,9 @@
       if (state.isTabActive(tabId)) {
         browserAction.activate(tabId);
       } else {
+        // Clear the state to express that the user has no preference.
+        // This allows the publisher embed to persist without us destroying it.
+        state.clearTab(tabId);
         browserAction.deactivate(tabId);
       }
 
@@ -138,7 +141,8 @@
     }
 
     function onTabCreated(tab) {
-      state.deactivateTab(tab.id);
+      // Clear the state in case there is old, conflicting data in storage.
+      state.clearTab(tab.id);
     }
 
     function onTabRemoved(tabId) {

--- a/h/browser/chrome/test/hypothesis-chrome-extension-test.js
+++ b/h/browser/chrome/test/hypothesis-chrome-extension-test.js
@@ -157,13 +157,13 @@ describe('HypothesisChromeExtension', function () {
 
     describe('when a tab is created', function () {
       beforeEach(function () {
-        fakeTabState.deactivateTab = sandbox.spy();
+        fakeTabState.clearTab = sandbox.spy();
         ext.listen({addEventListener: sandbox.stub()});
       });
 
-      it('registers the new tab', function () {
+      it('clears the new tab state', function () {
         onCreatedHandler({id: 1, url: 'http://example.com/foo.html'});
-        sinon.assert.calledWith(fakeTabState.deactivateTab, 1);
+        sinon.assert.calledWith(fakeTabState.clearTab, 1);
       });
     });
 
@@ -173,6 +173,7 @@ describe('HypothesisChromeExtension', function () {
       }
 
       beforeEach(function () {
+        fakeTabState.clearTab = sandbox.spy()
         fakeTabState.restorePreviousState = sandbox.spy();
         ext.listen({addEventListener: sandbox.stub()});
       });
@@ -184,11 +185,11 @@ describe('HypothesisChromeExtension', function () {
         sinon.assert.calledWith(fakeSidebarInjector.injectIntoTab, tab);
       });
 
-      it('removes the sidebar if inactive', function () {
+      it('clears the tab state if the sidebar is not active', function () {
         var tab = {id: 1, url: 'http://example.com/foo.html', status: 'complete'};
-        fakeTabState.isTabInactive.withArgs(1).returns(true);
+        fakeTabState.isTabActive.withArgs(1).returns(false);
         onUpdatedHandler(tab.id, {status: 'complete'}, tab);
-        sinon.assert.calledWith(fakeSidebarInjector.removeFromTab, tab);
+        sinon.assert.calledWith(fakeTabState.clearTab, tab.id);
       });
 
       it('updates the browser action to the active state when active', function () {

--- a/h/browser/chrome/test/sidebar-injector-test.js
+++ b/h/browser/chrome/test/sidebar-injector-test.js
@@ -86,36 +86,13 @@ describe('SidebarInjector', function () {
         var promise = injector.injectIntoTab({id: 1, url: url});
         this.server.respond();
         return promise.then(function () {
-          sinon.assert.callCount(spy, 4);
+          sinon.assert.callCount(spy, 2);
           sinon.assert.calledWith(spy, 1, {
-            file: 'public/embed.js'
+            code: sinon.match('/public/config.js')
           });
-        });
-      });
-
-      it('sets the global annotator variable to true', function () {
-        var spy = fakeChromeTabs.executeScript;
-        var url = 'http://example.com/foo.html';
-
-        var promise = injector.injectIntoTab({id: 1, url: url});
-        this.server.respond();
-        return promise.then(function () {
-          sinon.assert.callCount(spy, 4);
           sinon.assert.calledWith(spy, 1, {
-            code: 'window.annotator = true'
+            code: sinon.match('/public/embed.js')
           });
-        });
-      });
-
-      it('is not injected twice', function () {
-        fakeChromeTabs.executeScript.withArgs(1, {code: 'window.annotator'}).yields([true]);
-        var spy = fakeChromeTabs.executeScript;
-        var url = 'http://example.com/foo.html';
-
-        var promise = injector.injectIntoTab({id: 1, url: url});
-        this.server.respond();
-        return promise.then(function () {
-          sinon.assert.calledOnce(spy);
         });
       });
     });
@@ -323,16 +300,6 @@ describe('SidebarInjector', function () {
         return injector.removeFromTab({id: 1, url: 'http://example.com/foo.html'}).then(function () {
           sinon.assert.calledWith(stub, 1, {
             code: sinon.match('/public/destroy.js')
-          });
-        });
-      });
-
-      it('does nothing if the sidebar has not been injected into the page', function () {
-        var stub = fakeChromeTabs.executeScript.yields([false]);
-        return injector.removeFromTab({id: 1, url: 'http://example.com/foo.html'}).then(function () {
-          sinon.assert.calledOnce(stub);
-          sinon.assert.calledWith(stub, 1, {
-            code: sinon.match('window.annotator')
           });
         });
       });


### PR DESCRIPTION
Rather than running the embed code in the content script context and
duplicating the double embed prevention in the extension, run the
embed code in the page context since it now handles the double embed
prevention itself.

This is also simpler to reason about because the embed code runs in
a similar way for all injection methods (boomarklet, script embed, or
extension).