### PR TITLE
Add nipsa flag column to user table

### DIFF
--- a/h/accounts/models.py
+++ b/h/accounts/models.py
@@ -49,6 +49,8 @@ class User(UserMixin, Base):
                           sa.Unicode(30),
                           nullable=False,
                           unique=True)
+    # Not In Public Site Areas flag
+    nipsa = sa.Column(sa.BOOLEAN, default=False, nullable=False)
 
     def _get_username(self):
         return self._username

--- a/h/migrations/versions/381f709861c1_add_nipsa_flag.py
+++ b/h/migrations/versions/381f709861c1_add_nipsa_flag.py
@@ -1,0 +1,38 @@
+"""Add nipsa flag
+
+Revision ID: 381f709861c1
+Revises: 4a97f680ecca
+Create Date: 2015-05-06 13:24:29.679068
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '381f709861c1'
+down_revision = '4a97f680ecca'
+
+from alembic import op
+import sqlalchemy as sa
+
+users = sa.Table(
+    'user',
+    sa.MetaData(),
+    sa.Column('nipsa', sa.BOOLEAN),
+)
+
+
+def upgrade():
+    op.add_column('user', sa.Column('nipsa',
+                                    sa.BOOLEAN,
+                                    default=False))
+    op.execute(
+        users.update().where(
+            users.c.nipsa == None
+        ).values(
+            nipsa=False
+        )
+    )
+    op.alter_column('user', 'nipsa', nullable=False)
+
+
+def downgrade():
+    op.drop_column('user', 'nipsa')


### PR DESCRIPTION
Trying the split tasks into small PRs, this is the first one.
This PR adds the new column to the account model and provides the migration script.

The new column is never used in this point, the next PRs will use it (behind a feature flag).

