### PR TITLE
Remove via links from cards

### DIFF
--- a/h/static/scripts/directive/annotation.coffee
+++ b/h/static/scripts/directive/annotation.coffee
@@ -50,7 +50,9 @@ AnnotationController = [
     highlight = model.$highlight
     original = null
     vm = this
-
+    via =
+      url: 'https://via.hypothes.is/'
+      oldUrls: ['https://via.hypothes.is/h/']
     ###*
     # @ngdoc method
     # @name annotation.AnnotationController#tagsAutoComplete.
@@ -197,6 +199,23 @@ AnnotationController = [
         else
           reply.permissions = permissions.private()
 
+    this._extractUri = (uri) ->
+      # Strip the uri from the via url
+      extractUri = uri
+
+      # Annotations could be saved with any of these urls.
+      for url in [via.url, via.oldUrls...]
+        if uri.indexOf(url) is 0
+          try
+            viaRemovedUri = uri.substring(url.length)
+            testUri = new URL(viaRemovedUri)
+            extractUri = viaRemovedUri
+            break
+          catch
+            # viaRemovedUri was not a valid URL
+            continue
+      return extractUri
+
     ###*
     # @ngdoc method
     # @name annotation.AnnotationController#render
@@ -211,8 +230,9 @@ AnnotationController = [
       @annotationURI = new URL("/a/#{@annotation.id}", this.baseURI).href
 
       # Extract the document metadata.
-      uri = model.uri
+      uri = this._extractUri(model.uri)
       domain = new URL(uri).hostname
+
       if model.document
         if uri.indexOf("urn") is 0
           # This URI is not clickable, see if we have something better

--- a/h/static/scripts/directive/test/annotation-test.coffee
+++ b/h/static/scripts/directive/test/annotation-test.coffee
@@ -204,6 +204,11 @@ describe 'annotation', ->
       controller.render()
       assert.equal(controller.document.domain, 'example.com')
 
+    it 'removes the via link for extracting domain from the uri', ->
+      annotation.uri = 'https://via.hypothes.is/http://example.com'
+      controller.render()
+      assert.equal(controller.document.domain, 'example.com')
+
     it 'uses the domain for the title if the title is not present', ->
       delete annotation.document.title
       controller.render()


### PR DESCRIPTION
Strips the via url from the annotation uri when rendering the annotation cards.

This PR will be simplified when #2215 will be merged as it'll use the via config defined here.
It handles annotations created with both the old and the new via url.

(An example annotation created with the old via url: https://api.hypothes.is/annotations/CosfKz2ZQpq2r9i3M5b1pg )
