### PR TITLE
Don't run Prospector on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,11 @@ install:
   - gem install compass
   - pip install coveralls
   - pip install mandrill
-  - pip install prospector
   - pip install pyramid_redis_sessions
   - make
 script:
   - make test
   - make cover
-  - make lint
   - hypothesis-buildext conf/testext.ini chrome --base http://localhost
   - hypothesis-buildext conf/testext.ini firefox --base http://localhost
   - "hypothesis-buildext conf/production.ini chrome


### PR DESCRIPTION
This may seem like I'm reverting a good thing -- controls on Python code quality -- but actually running Prospector as part of our build has a number of problems:

- we can't quickly distinguish between a real test failure and a lint error from the GitHub status API
- we can't easily increase the strictness of our linting without also doing a bulk fix (which would be undesirable due to the risk of breaking things)
- as a result of the previous item, Landscape currently shows us at 100% health -- this is entirely artificial, and the result of relatively lax linting rules

So, I propose we don't run Prospector on Travis (bonus: faster builds) and instead turn on Landscape's [Pull Request Comparisons feature](https://blog.landscape.io/pull-request-comparisons-merge-with-confidence.html).

*See also the conversation in #2173.*