### PR TITLE
Stricter prospector linting

### DIFF
--- a/.prospector.yaml
+++ b/.prospector.yaml
@@ -1,14 +1,30 @@
 output-format: grouped
 inherits:
   - full_pep8
-  - strictness_low
+  - strictness_high
 pep8:
   options:
     max-line-length: 79
 pylint:
   enable:
     - relative-import
+  options:
+    # Some good names that pylint would otherwise reject:
+    #
+    # - _: placeholder
+    # - i,j,k: counters
+    # - k,v: dict iteration
+    # - db,fn: common abbreviations
+    # - fp: python idiom for file handles
+    #
+    # Some good "constant" names that pylint would otherwise reject:
+    #
+    # - log: common in "log = logging.getLogger(__name__)" pattern
+    # - parser: common in modules that use argparse
+    #
+    good-names: _,i,j,k,v,e,db,fn,fp,log,parser
 ignore-paths:
+  - gunicorn.conf.py
   - h/_version.py
   - h/migrations/
   - versioneer.py


### PR DESCRIPTION
Now that we don't fail the build on lint errors (but we do receive
feedback on pull requests) this commit ups the strictness of the
prospector run to "high".

I've special-cased some names which pylint complains about which are (in
my opinion) perfectly reasonable names.