### PR TITLE
Introduce NIPSA

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ clean:
 	find . -type d -name "__pycache__" -delete
 	rm -f h/static/scripts/vendor/*.min.js
 	rm -f h/static/scripts/account.*js
+	rm -f h/static/scripts/admin.*js
 	rm -f h/static/scripts/app.*js
 	rm -f h/static/scripts/config.*js
 	rm -f h/static/scripts/hypothesis.*js

--- a/conf/admins
+++ b/conf/admins
@@ -1,0 +1,6 @@
+dwhly
+judell
+tilgovi
+nickstenning
+csillag
+ujvari

--- a/conf/development.ini
+++ b/conf/development.ini
@@ -27,6 +27,7 @@ h.feature.api: True
 h.feature.claim: True
 h.feature.streamer: True
 h.feature.notification: False
+h.feature.nipsa: True
 
 horus.login_redirect: stream
 horus.logout_redirect: index

--- a/conf/production.ini
+++ b/conf/production.ini
@@ -23,6 +23,7 @@ h.feature.api: True
 h.feature.claim: False
 h.feature.streamer: True
 h.feature.notification: True
+h.feature.nipsa: False
 
 # User and group framework settings -- see horus documentation
 # Used by the local authentication provider

--- a/conf/production.ini
+++ b/conf/production.ini
@@ -23,7 +23,7 @@ h.feature.api: True
 h.feature.claim: False
 h.feature.streamer: True
 h.feature.notification: True
-h.feature.nipsa: False
+h.feature.nipsa: True
 
 # User and group framework settings -- see horus documentation
 # Used by the local authentication provider

--- a/conf/testext.ini
+++ b/conf/testext.ini
@@ -6,6 +6,7 @@ h.feature.api: True
 h.feature.claim: True
 h.feature.streamer: True
 h.feature.notification: True
+h.feature.nipsa: True
 
 sqlalchemy.url: sqlite://
 

--- a/h/accounts/admin.py
+++ b/h/accounts/admin.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+import re
+from pkg_resources import resource_stream
+
+from pyramid.view import view_config
+from pyramid import httpexceptions
+from hem.db import get_session
+
+from .models import User
+
+ADMIN_LIST = None
+
+
+def get_admins():
+    global ADMIN_LIST
+    if ADMIN_LIST is None:
+        ADMIN_LIST = set(
+            l.strip().lower()
+            for l in resource_stream(__package__, '../../conf/admins')
+        )
+    return ADMIN_LIST
+
+
+def get_username(userid, domain):
+    match = re.match(r'acct:([^@]+)@{}'.format(domain), userid)
+    if match:
+        return match.group(1)
+    else:
+        return None
+
+
+def _verify_admin(request):
+    if not request.unauthenticated_userid:
+        raise httpexceptions.HTTPNotFound()
+    user = get_username(request.unauthenticated_userid, request.domain)
+
+    if user not in get_admins():
+        # User is not an admin
+        raise httpexceptions.HTTPNotFound()
+
+
+@view_config(route_name='nipsa_list',
+             renderer='json')
+def nipsa_list(request):
+    _verify_admin(request)
+
+    users = User.get_nipsa_users(request)
+    return {'users': users}
+
+
+@view_config(route_name='admin_user',
+             request_method='POST',
+             accept='application/json',
+             renderer='json')
+def update_settings(request):
+    _verify_admin(request)
+
+    # Check whether all users exist
+    # Bail out at the first non-existing user
+    for username in request.json_body.keys():
+        user = User.get_by_username(request, username)
+        if not user:
+            return {
+                'status': 'failure',
+                'errors': 'Invalid request',
+                'reason': 'User does not exist:' + username
+            }
+
+    # Only proceed if all users exist
+    for username in request.json_body.keys():
+        settings = request.json_body[username]
+        if 'nipsa' in settings:
+            user = User.get_by_username(request, username)
+            user.nipsa = settings['nipsa']
+            db = get_session(request)
+            db.add(user)
+    return {'status': 'okay'}
+
+
+def includeme(config):
+    config.add_route('nipsa_list', '/admin/nipsa.list')
+    config.add_route('admin_user', '/admin/settings')
+    config.scan(__name__)

--- a/h/accounts/models.py
+++ b/h/accounts/models.py
@@ -95,7 +95,7 @@ class User(UserMixin, Base):
     @classmethod
     def get_nipsa_users(cls, request):
         session = get_session(request)
-        users = session.query(cls).filter(cls.nipsa == True).all()
+        users = session.query(cls).filter(cls.nipsa).all()
         return [u.username for u in users]
 
     # TODO: remove all this status bitfield stuff

--- a/h/accounts/models.py
+++ b/h/accounts/models.py
@@ -92,6 +92,12 @@ class User(UserMixin, Base):
             )
         ).first()
 
+    @classmethod
+    def get_nipsa_users(cls, request):
+        session = get_session(request)
+        users = session.query(cls).filter(cls.nipsa == True).all()
+        return [u.username for u in users]
+
     # TODO: remove all this status bitfield stuff
     @property
     def email_confirmed(self):

--- a/h/api/views.py
+++ b/h/api/views.py
@@ -232,7 +232,8 @@ def filter_nipsa(request, results, user):
     # the user can see his/her own annotations
     # So remove the user from the nipsa list
     nipsa_users = [u for u in nipsa_users if user is None or u != user.id]
-    results['rows'] = [a for a in results['rows'] if a['user'] not in nipsa_users]
+    results['rows'] =\
+        [a for a in results['rows'] if a['user'] not in nipsa_users]
     # FixMe: Update total correctly
     new_total = len(results['rows'])
     results['total'] -= (total - new_total)

--- a/h/api/views.py
+++ b/h/api/views.py
@@ -12,6 +12,11 @@ from .models import Annotation
 from .resources import Root
 from .resources import Annotations
 
+# FixMe: Maybe do conditional import
+from ..accounts.models import User
+from hem.interfaces import IDBSession
+from pyramid_basemodel import Session
+
 log = logging.getLogger(__name__)
 
 
@@ -74,7 +79,13 @@ def search(request):
     """Search the database for annotations matching with the given query."""
     # The search results are filtered for the authenticated user
     user = get_user(request)
-    return _search(request.params, user)
+
+    nipsa = request.registry.feature('nipsa')
+    results = _search(request.params, user)
+    if nipsa:
+        results = filter_nipsa(request, results, user)
+
+    return results
 
 
 @api_config(context=Root, name='access_token')
@@ -204,6 +215,28 @@ def _api_error(request, reason, status_code):
         'reason': reason,
     }
     return response_info
+
+
+def get_nipsa_users(request):
+    # FIXME: Add caching
+    nipsa_users = User.get_nipsa_users(request)
+    return ['acct:' + u + '@' + request.domain for u in nipsa_users]
+
+
+def filter_nipsa(request, results, user):
+    nipsa_users = get_nipsa_users(request)
+
+    total = len(results['rows'])
+
+    # If a flagged user is logged on, then
+    # the user can see his/her own annotations
+    # So remove the user from the nipsa list
+    nipsa_users = [u for u in nipsa_users if user is None or u != user.id]
+    results['rows'] = [a for a in results['rows'] if a['user'] not in nipsa_users]
+    # FixMe: Update total correctly
+    new_total = len(results['rows'])
+    results['total'] -= (total - new_total)
+    return results
 
 
 def _search(request_params, user=None):
@@ -355,4 +388,10 @@ def _anonymize_deletes(annotation):
 
 
 def includeme(config):
+    registry = config.registry
+
+    if registry.feature('nipsa'):
+        if not registry.queryUtility(IDBSession):
+            registry.registerUtility(Session, IDBSession)
+
     config.scan(__name__)

--- a/h/app.py
+++ b/h/app.py
@@ -62,6 +62,9 @@ def create_app(global_config, **settings):
         config.set_authorization_policy(acl_authz)
         config.include('.accounts')
 
+        if config.registry.feature('nipsa'):
+            config.include('.accounts.admin')
+
     if config.registry.feature('api'):
         api_app = create_api(settings)
         api_view = wsgiapp2(api_app)
@@ -97,6 +100,7 @@ def create_api(global_config, **settings):
                           'pyramid.events.ContextFound')
     config.add_tween('h.api.tweens.auth_token')
 
+    config.include('.features')  # FixMe: Should not be included!
     config.include('.api.db')
     config.include('.api.views')
     config.include('.auth')

--- a/h/assets.yaml
+++ b/h/assets.yaml
@@ -191,6 +191,20 @@ account:
           contents: h:static/scripts/account/account.coffee
           depends: h:static/scripts/account/*
 
+admin:
+  contents:
+    - jquery
+    - angular
+    - angular_bootstrap
+    - angular_route
+    - output: scripts/admin.min.js
+      filters: uglifyjs
+      contents:
+        - output: scripts/admin.js
+          filters: browserify
+          contents: h:static/scripts/admin/admin.coffee
+          depends: h:static/scripts/admin/*
+
 # The inject bundle is intended to be loaded into pages for bootstrapping
 # the application. It sets up RPC channels for cross-domain communication
 # between frames participating in annotation by using the annotator bridge

--- a/h/auth.py
+++ b/h/auth.py
@@ -44,7 +44,7 @@ from pyramid.util import action_method
 
 from .interfaces import IClientFactory
 from .oauth import JWT_BEARER
-from .accounts.admin import get_admins, get_username  # FIXME: Conditional import
+from .accounts.admin import get_admins, get_username  # FIXME: Separation
 
 LEEWAY = 240  # allowance for clock skew in verification
 

--- a/h/auth.py
+++ b/h/auth.py
@@ -44,6 +44,7 @@ from pyramid.util import action_method
 
 from .interfaces import IClientFactory
 from .oauth import JWT_BEARER
+from .accounts.admin import get_admins, get_username  # FIXME: Conditional import
 
 LEEWAY = 240  # allowance for clock skew in verification
 
@@ -168,6 +169,11 @@ def generate_signed_token(request):
         'ttl': int(ttl.total_seconds()),
         'userId': request.user,
     })
+
+    if request.registry.feature('nipsa'):
+        user = get_username(request.user, request.domain)
+        if user in get_admins():
+            claims['admin'] = True
 
     claims.update(request.extra_credentials or {})
     return jwt.encode(claims, request.client.client_secret)

--- a/h/layouts.py
+++ b/h/layouts.py
@@ -55,7 +55,8 @@ class BaseLayout(object):
 class AppLayout(BaseLayout):
     app = 'h'
     controller = 'AppController'
-    requirements = (('app', None), ('account', None), ('admin', None), ('topbar', None))
+    requirements = (('app', None), ('account', None), ('admin', None),
+                    ('topbar', None))  # FIXME: Use nipsa flag
 
 
 def includeme(config):

--- a/h/layouts.py
+++ b/h/layouts.py
@@ -55,7 +55,7 @@ class BaseLayout(object):
 class AppLayout(BaseLayout):
     app = 'h'
     controller = 'AppController'
-    requirements = (('app', None), ('account', None), ('topbar', None))
+    requirements = (('app', None), ('account', None), ('admin', None), ('topbar', None))
 
 
 def includeme(config):

--- a/h/static/scripts/admin/admin-controller.coffee
+++ b/h/static/scripts/admin/admin-controller.coffee
@@ -1,0 +1,42 @@
+class AdminController
+  @inject = [  '$scope', '$filter',
+               'admin', 'auth', 'flash', 'formRespond', 'identity']
+  constructor: ($scope,   $filter,
+                admin,   auth,   flash,   formRespond,   identity) ->
+
+    onError = (form, response) ->
+      if response.status >= 400 and response.status < 500
+        formRespond(form, response.data.errors)
+      else
+        flash.error(response.reason ? 'Sorry, we were unable to perform your request')
+
+      $scope.$broadcast 'formState', form.$name, ''  # Update status btn
+
+    onSuccess = (form, response) ->
+      if response.errors # This is not a real success
+        onError(form, response)
+        return
+
+      form.$setPristine()
+      formModel = form.$name.slice(0, -4)
+      $scope[formModel] = {} # Reset form fields.
+      $scope.$broadcast 'formState', form.$name, 'success'  # Update status btn
+
+    $scope.submit = (form, value) ->
+      formRespond(form)
+      return unless form.$valid
+
+      username = form.username.$modelValue
+
+      packet = {}
+      packet[username] = nipsa: value
+
+      successHandler = angular.bind(null, onSuccess, form)
+      errorHandler   = angular.bind(null, onError, form)
+
+      $scope.$broadcast 'formState', form.$name, 'loading'  # Update status btn
+      promise = admin.set_nipsa(packet)
+      promise.$promise.then(successHandler, errorHandler)
+
+angular.module('h')
+.controller('AdminController', AdminController)

--- a/h/static/scripts/admin/admin-service.coffee
+++ b/h/static/scripts/admin/admin-service.coffee
@@ -1,0 +1,44 @@
+angular = require('angular')
+
+module.exports = class AdminService
+  actions: null
+  options: null
+
+  constructor: ->
+    @actions =
+      set_nipsa:
+        method: 'POST'
+        withCredentials: true
+
+    @options = {}
+
+  $get: [
+    '$document', '$http', '$q', '$resource',
+    ($document,   $http,   $q,   $resource) ->
+      actions = {}
+      provider = this
+
+      prepare = (data) ->
+        return angular.toJson data
+
+      process = (data) ->
+        # Parse as json
+        data = angular.fromJson data
+
+        # Lift response data
+        model = data.model or {}
+        model.errors = data.errors
+        model.reason = data.reason
+
+        # Return the model
+        model
+
+      for name, options of provider.actions
+        actions[name] = angular.extend {}, options, @options
+        actions[name].transformRequest = prepare
+        actions[name].transformResponse = process
+
+      base = $document.prop('baseURI')
+      endpoint = new URL('/admin/settings', base).href
+      $resource(endpoint, {}, actions)
+  ]

--- a/h/static/scripts/admin/admin.coffee
+++ b/h/static/scripts/admin/admin.coffee
@@ -1,0 +1,6 @@
+angular = require('angular')
+
+angular.module('h')
+.provider('admin', require('./admin-service'))
+
+require('./admin-controller')

--- a/h/static/scripts/auth.coffee
+++ b/h/static/scripts/auth.coffee
@@ -50,6 +50,7 @@ module.exports = [
       plugins.Auth.withToken (payload) =>
         _checkingToken = false
         auth.user = payload.userId
+        auth.isAdmin = payload.admin ? false
         token = plugins.Auth.token
         $http.defaults.headers.common['X-Annotator-Auth-Token'] = token
         $rootScope.$apply()

--- a/h/static/scripts/widget-controller.coffee
+++ b/h/static/scripts/widget-controller.coffee
@@ -28,7 +28,7 @@ module.exports = class WidgetController
       store.SearchResource.get q, (results) ->
         total = results.total
         offset += results.rows.length
-        if offset < total
+        if offset < total and results.rows.length
           _loadAnnotationsFrom query, offset
 
         annotationMapper.loadAnnotations(results.rows)

--- a/h/templates/app.html
+++ b/h/templates/app.html
@@ -56,6 +56,9 @@
               {% if feature('notification') %}
                 {{ include_raw("h:templates/client/settings/notifications.html") }}
               {% endif %}
+              {% if feature('admin') %}
+                {{ include_raw("h:templates/client/settings/admin.html") }}
+              {% endif %}
             </div>
           {% endblock %}
         </div>

--- a/h/templates/app.html
+++ b/h/templates/app.html
@@ -16,7 +16,8 @@
           --><span class="provider" ng-show="auth.user">/{% raw %}{{ auth.user|persona:'provider' }}{% endraw %}</span><!--
           --><i class="h-icon-arrow-drop-down"></i></span>
         <ul class="dropdown-menu pull-right" role="menu">
-          <li ng-show="auth.user"><a href="" ng-click="dialog.visible='true'">Account</a></li>
+          <li ng-show="auth.user"><a href="" ng-click="dialog.visible='true'; adminDialog.visible='false'">Account</a></li>
+          <li ng-show="auth.isAdmin"><a href="" ng-click="adminDialog.visible='true'; dialog.visible='false'">Admin</a></li>
           <li><a href="mailto:support@hypothes.is">Feedback</a></li>
           <li><a href="/docs/help" target="_blank">Help</a></li>
           <li ng-show="auth.user"><a href="/stream?q=user:{% raw %}{{ auth.user|persona }}{% endraw %}"
@@ -56,9 +57,6 @@
               {% if feature('notification') %}
                 {{ include_raw("h:templates/client/settings/notifications.html") }}
               {% endif %}
-              {% if feature('admin') %}
-                {{ include_raw("h:templates/client/settings/admin.html") }}
-              {% endif %}
             </div>
           {% endblock %}
         </div>
@@ -70,6 +68,28 @@
       </div>
     </div>
     <!-- / Dialog -->
+
+    <!-- NipsaAdminDialog -->
+    {% if feature('nipsa') %}
+      <div class="content ng-cloak" ng-if="adminDialog.visible">
+        <div id="adminDialog" class="sheet">
+          <i class="close h-icon-close"
+             role="button"
+             title="Close"
+             ng-click="adminDialog.visible = false"></i>
+          <div>
+            {% block adminSettings %}
+              <div class="tabbable"
+                   ng-controller="AdminController"
+                   ng-model="tab">
+                {{ include_raw("h:templates/client/settings/admin.html") }}
+              </div>
+            {% endblock %}
+          </div>
+        </div>
+      </div>
+    {% endif %}
+    <!-- / NipsaAdminDialog -->
 
     <!-- Angular view -->
     <main class="content" ng-view=""></main>

--- a/h/templates/client/settings/admin.html
+++ b/h/templates/client/settings/admin.html
@@ -1,0 +1,2 @@
+<div class="tab-pane" title="Admin">
+</div>

--- a/h/templates/client/settings/admin.html
+++ b/h/templates/client/settings/admin.html
@@ -1,2 +1,51 @@
-<div class="tab-pane" title="Admin">
+<div class="tab-pane active" title="Admin">
+  <form class="set-nipsa-form form"
+	name="setNipsaForm"
+	ng-submit="submit(setNipsaForm, true)"
+	novalidate form-validate>
+    <h2 class="form-heading"><span>NIPSA restrictions</span></h2>
+    <p class="form-description">You can use this form to inflict NIPSA restrictions on users whom you find unacceptably naughty. Use this power wisely!</p>
+    <div class="form-field">
+      <label class="form-label" for="field-username">User to hide from the public eye:</label>
+      <input id="field-username" class="form-input" name="username" required ng-model="setNipsa.username" />
+      <ul class="form-error-list">
+        <li class="form-error" ng-show="setNipsaForm.username.$error.required">Please tell me who has been saying dirty things!</li>
+      </ul>
+    </div>
+
+    <div class="form-actions">
+      <div class="form-actions-buttons">
+        <button class="btn btn-danger" type="submit"
+                status-button="setNipsaForm">Restrain!</button>
+      </div>
+    </div>
+
+  </form>
+
+  <form class="clear-nipsa-form form"
+	name="clearNipsaForm"
+	ng-submit="submit(clearNipsaForm, false)"
+	novalidate form-validate>
+    <h2 class="form-heading"><span>Lift restrictions</span></h2>
+    <div class="form-field">
+      <label class="form-label" for="field-username">User to un-hide:</label>
+      <input id="field-username" class="form-input" name="username" required ng-model="clearNipsa.username" />
+      <ul class="form-error-list">
+        <li class="form-error" ng-show="clearNipsaForm.username.$error.required">Please tell me who has received your pardon!</li>
+      </ul>
+    </div>
+
+    <div class="form-actions">
+      <div class="form-actions-buttons">
+        <button class="btn" type="submit"
+                status-button="clearNipsaForm">Release!</button>
+      </div>
+    </div>
+
+  </form>
+
+  <div>
+    Current blacklist is available <a target="_blank" href="/admin/nipsa.list">here</a>.
+  </div>
+
 </div>

--- a/h/test/streamer_test.py
+++ b/h/test/streamer_test.py
@@ -330,7 +330,7 @@ class TestShouldSendEvent(unittest.TestCase):
 
     def test_non_sending_socket_receives_event(self):
         data = {'action': 'update', 'src_client_id': 'pigeon'}
-        assert should_send_event(self.sock_giraffe, {}, data)
+        assert should_send_event(self.sock_giraffe, {'user': 'test'}, data)
 
     def test_sending_socket_does_not_receive_event(self):
         data = {'action': 'update', 'src_client_id': 'pigeon'}


### PR DESCRIPTION
This PR implements a throw-away basic functionality for handling Nipsa flag for users.
Includes:
 - Add "NIPSA" feature flag
 - Add admin package (under accounts, behind the nipsa feature flag)
 - Add "admins" list in the config directory
 - Put "admin" flag to the claim data at authentication
 - Implement nipsa filtering
   - to search api
   - to realtime update
   - to stream load_more
- Minimal UI for setting NIPSA flag (see below the accounts menu entry)

Limitations & problems:
- Important: The nipsa flag is being read is read from db for every search, this can create a performance bottleneck. The list could be cached for a few minutes and/or the nipsa flag must receive an index immediately if this goes to prod.
-  The administration of admin users is very crude, simple text file at conf/admins (the exact names should be sorted out)
- No fancy UI for listing currently flagged users (but the information is available as a simple json dump)
- The total number of results returned by nipsa-filtering might not always be accurate. (We filter the data in the backend, at version 2 it should be done as part of the ES query. But with the current architecture it'd be far from trivial to put all relevant information (currently logged in user, feature flag, nipsa flagged- users) to the place (models.py) where the elasticsearch query is generated)


General notes:
- Our current feature flag system is too closely coupled with the pyramid registry which is cumbersome to say the least, this should be changed. (But not in the scope of this PR)
- Our python module separation is currently just an illusion. (We have to import many things i.e from api, account, etc.)