### PR TITLE
Add URL params to /stream.atom

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,11 @@
+Current Development Version (master branch)
+===========================================
+
+- Added support for URL parameters to the Atom feed at ``/stream.atom``.
+  For example: ``/stream.atom?user=seanh`` or
+  ``/stream.atom?user=seanh&tags=foo,bar``.
+
+
 0.4.0 (2015-05-05)
 ==================
 

--- a/h/test/views_test.py
+++ b/h/test/views_test.py
@@ -6,10 +6,13 @@ import json
 import unittest
 import mock
 
+import pyramid
 from pyramid import testing
 import pytest
 
 from h import views
+from h import api_client
+from . import factories
 
 
 class TestAnnotationView(unittest.TestCase):
@@ -81,3 +84,178 @@ class TestValidateBlocklist(object):
         views._validate_blocklist(config)
 
         assert config.registry.settings["h.blocklist"] == {}
+
+
+class TestStreamAtomView(object):
+
+    """Unit tests for the stream_atom() view callable."""
+
+    def test_it_returns_the_annotations_from_the_search_api(self):
+        annotations = factories.Annotation.create_batch(10)
+        request = mock.MagicMock()
+        request.api_client.get.return_value = {"rows": annotations}
+
+        data = views.stream_atom(request)
+
+        assert data["annotations"] == annotations
+
+    def test_it_returns_the_atom_url(self):
+        """It returns the URL of the 'stream_atom' route as 'atom_url'.
+
+        This is the URL to the Atom version of this Atom feed.
+
+        """
+        atom_url = "https://hypothes.is/stream.atom"
+        request = mock.MagicMock()
+
+        def side_effect(arg):
+            return {"stream_atom": atom_url}.get(arg)
+
+        request.route_url.side_effect = side_effect
+
+        data = views.stream_atom(request)
+
+        assert data["atom_url"] == atom_url
+
+    def test_it_returns_the_stream_url(self):
+        """It returns the URL of the 'stream' route as 'html_url'.
+
+        This is the URL to the HTML page corresponding to this feed.
+
+        """
+        html_url = "https://hypothes.is/stream"
+        request = mock.MagicMock()
+
+        def side_effect(arg):
+            return {"stream": html_url}.get(arg)
+
+        request.route_url.side_effect = side_effect
+
+        data = views.stream_atom(request)
+
+        assert data["html_url"] == html_url
+
+    def test_it_returns_the_feed_title(self):
+        """It returns the 'h.feed.title' from the config as 'title'."""
+        title = "Hypothesis Atom Feed"
+        request = mock.MagicMock()
+
+        def side_effect(arg):
+            return {"h.feed.title": title}.get(arg)
+
+        request.registry.settings.get.side_effect = side_effect
+
+        data = views.stream_atom(request)
+
+        assert data["title"] == title
+
+    def test_it_returns_the_feed_subtitle(self):
+        """It returns the 'h.feed.subtitle' from the config as 'subtitle'."""
+        subtitle = "A feed of all our annotations"
+        request = mock.MagicMock()
+
+        def side_effect(arg):
+            return {"h.feed.subtitle": subtitle}.get(arg)
+
+        request.registry.settings.get.side_effect = side_effect
+
+        data = views.stream_atom(request)
+
+        assert data["subtitle"] == subtitle
+
+    def test_it_adds_a_limit_param_if_none_is_given(self):
+        request = mock.MagicMock()
+        request.params = {}
+
+        views.stream_atom(request)
+
+        params = request.api_client.get.call_args[1]["params"]
+        assert params["limit"] == 1000
+
+    def test_it_forwards_user_supplied_limits(self):
+        """User-supplied ``limit`` params should be forwarded.
+
+        If the user supplies a ``limit`` param < 1000 this should be forwarded
+        to the search API.
+
+        """
+        for limit in (0, 500, 1000):
+            request = mock.MagicMock()
+            request.params = {"limit": limit}
+
+            views.stream_atom(request)
+
+            params = request.api_client.get.call_args[1]["params"]
+            assert params["limit"] == limit
+
+    def test_it_ignores_limits_greater_than_1000(self):
+        """It doesn't let the user specify a ``limit`` > 1000.
+
+        It just reduces the limit to 1000.
+
+        """
+        request = mock.MagicMock()
+        request.params = {"limit": 1001}
+
+        views.stream_atom(request)
+
+        params = request.api_client.get.call_args[1]["params"]
+        assert params["limit"] == 1000
+
+    def test_it_falls_back_to_1000_if_limit_is_invalid(self):
+        """If the user gives an invalid limit value it falls back to 1000."""
+        for limit in ("not a valid integer", None, [1, 2, 3]):
+            request = mock.MagicMock()
+            request.params = {"limit": limit}
+
+            views.stream_atom(request)
+
+            params = request.api_client.get.call_args[1]["params"]
+            assert params["limit"] == 1000
+
+    def test_it_falls_back_to_1000_if_limit_is_negative(self):
+        """If given a negative number for limit it falls back to 1000."""
+        request = mock.MagicMock()
+        request.params = {"limit": -50}
+
+        views.stream_atom(request)
+
+        params = request.api_client.get.call_args[1]["params"]
+        assert params["limit"] == 1000
+
+    def test_it_forwards_url_params_to_the_api(self):
+        """Any URL params are forwarded to the search API."""
+        request = mock.MagicMock()
+        request.params = {
+            "user": "seanh",
+            "tags": "JavaScript",
+            "foo": "bar"
+        }
+
+        views.stream_atom(request)
+
+        params = request.api_client.get.call_args[1]["params"]
+        assert params["user"] == "seanh"
+        assert params["tags"] == "JavaScript"
+        assert params["foo"] == "bar"
+
+    def test_it_raises_httpserviceunavailable_for_connectionerror(self):
+        request = mock.MagicMock()
+        request.api_client.get.side_effect = api_client.ConnectionError
+
+        with pytest.raises(pyramid.httpexceptions.HTTPServiceUnavailable):
+            views.stream_atom(request)
+
+    def test_it_raises_httpgatewaytimeout_for_timeout(self):
+        request = mock.MagicMock()
+        request.api_client.get.side_effect = api_client.Timeout
+
+        with pytest.raises(pyramid.httpexceptions.HTTPGatewayTimeout):
+            views.stream_atom(request)
+
+    def test_it_raises_httpbadgateway_for_apierror(self):
+        request = mock.MagicMock()
+        request.api_client.get.side_effect = api_client.APIError
+
+        with pytest.raises(pyramid.httpexceptions.HTTPBadGateway):
+            views.stream_atom(request)

--- a/h/views.py
+++ b/h/views.py
@@ -144,9 +144,22 @@ def stream(context, request):
 
 @view_config(renderer='annotations_atom', route_name='stream_atom')
 def stream_atom(request):
+    params = dict(request.params)
+
+    # The maximum value that this function allows the limit param.
+    max_limit = 1000
+
+    try:
+        params["limit"] = int(params.get("limit", max_limit))
+    except (ValueError, TypeError):
+        params["limit"] = max_limit
+
+    if not 0 <= params["limit"] <= max_limit:
+        params["limit"] = max_limit
+
     try:
         annotations = request.api_client.get(
-            "/search", params={"limit": 1000})["rows"]
+            "/search", params=params)["rows"]
     except api_client.ConnectionError as err:
         raise httpexceptions.HTTPServiceUnavailable(err)
     except api_client.Timeout as err:


### PR DESCRIPTION
Just accepts the same URL params as /api/search.

Ensure that the params always contain a "limit" and that it's always
<= 1000.

Also add unit tests for the stream_atom() view callable (there weren't
any)