### PR TITLE
Replace gnsq with nsq-py

### DIFF
--- a/h/api/views.py
+++ b/h/api/views.py
@@ -194,7 +194,7 @@ def _publish_annotation_event(request, annotation, action):
         'annotation': annotation,
         'src_client_id': request.headers.get('X-Client-Id'),
     }
-    queue.publish('annotations', json.dumps(data))
+    queue.pub('annotations', json.dumps(data))
 
 
 def _api_error(request, reason, status_code):

--- a/h/notification/worker.py
+++ b/h/notification/worker.py
@@ -16,9 +16,7 @@ def run(request):
     the same channel. NSQ will distribute messages among available workers in a
     round-robin fashion.
     """
-    def handle_message(reader, message=None):
-        if message is None:
-            return
+    for message in request.get_queue_reader('annotations', 'notification'):
         data = json.loads(message.body)
         action = data['action']
         annotation = Annotation(**data['annotation'])
@@ -28,7 +26,4 @@ def run(request):
             m = Message(subject=subject, recipients=recipients,
                         body=body, html=html)
             mailer.send_immediately(m)
-
-    reader = request.get_queue_reader('annotations', 'notification')
-    reader.on_message.connect(handle_message)
-    reader.start(block=True)
+        message.fin()

--- a/setup.py
+++ b/setup.py
@@ -46,11 +46,11 @@ install_requires = [
     'cryptography>=0.7',
     'deform>=0.9,<1.0',
     'elasticsearch>=1.1.0',
-    'gnsq>=0.2.0,<0.3.0',
     'gunicorn>=19.2,<20',
     'horus>=0.9.15',
     'jsonpointer==1.0',
     'jsonschema==1.3.0',
+    'nsq-py>=0.1.7,<0.2',
     'oauthlib==0.6.3',
     'pyramid>=1.5',
     'pyramid-basemodel>=0.2',
@@ -63,7 +63,7 @@ install_requires = [
     'pyramid_webassets>=0.9,<1.0',
     'pyramid-jinja2>=2.3.3',
     'raven>=5.1.1,<5.2.0',
-    'requests>=2.2.1',
+    'requests==2.2.1',
     'ws4py>=0.3,<0.4',
 
     # Version pin for known bug


### PR DESCRIPTION
nsq-py seems at least as well maintained, it is closer in API to
the official pynsq client, supports TCP connections to nsqd,
and supports the iteration protocol as a way to consume Reader
messages, which is simpler than the signal-based callbacks and
feels a bit more Pythonic.

Finally, it doesn't depend on gevent, and it's always nice to bake
that assumption into fewer parts of the system.