### PR TITLE
Features cleanup

### DIFF
--- a/conf/development.ini
+++ b/conf/development.ini
@@ -57,6 +57,7 @@ secret_key: notverysecretafterall
 sqlalchemy.url: sqlite:///.h.db
 
 jinja2.extensions: h.jinja_extensions:IncludeRawExtension
+jinja2.filters: json = json.dumps
 
 webassets.base_dir: h:static
 webassets.base_url: assets

--- a/conf/production.ini
+++ b/conf/production.ini
@@ -56,6 +56,7 @@ sqlalchemy.url: sqlite:///.h.db
 
 # http://docs.pylonsproject.org/projects/pyramid-jinja2/en/latest/index.html#jinja2-extensions
 jinja2.extensions: h.jinja_extensions:IncludeRawExtension
+jinja2.filters: json = json.dumps
 
 # Static asset configuration -- see webassets documentation
 # Until the next pyramid_webassets, don't change these.

--- a/h/app.py
+++ b/h/app.py
@@ -57,12 +57,12 @@ def create_app(global_config, **settings):
 
     config.add_tween('h.tweens.csrf_tween_factory')
 
-    if config.registry.feature('accounts'):
+    if config.feature('accounts'):
         config.set_authentication_policy(session_authn)
         config.set_authorization_policy(acl_authz)
         config.include('.accounts')
 
-    if config.registry.feature('api'):
+    if config.feature('api'):
         api_app = create_api(settings)
         api_view = wsgiapp2(api_app)
         config.add_view(api_view, name='api', decorator=strip_vhm)
@@ -71,13 +71,13 @@ def create_app(global_config, **settings):
         config.add_view(api_view, name='api', decorator=strip_vhm,
                         route_name='index')
 
-    if config.registry.feature('claim'):
+    if config.feature('claim'):
         config.include('.claim')
 
-    if config.registry.feature('streamer'):
+    if config.feature('streamer'):
         config.include('.streamer')
 
-    if config.registry.feature('notification'):
+    if config.feature('notification'):
         config.include('.notification')
 
     return config.make_wsgi_app()

--- a/h/assets.py
+++ b/h/assets.py
@@ -92,9 +92,23 @@ def asset_response_subscriber(event):
     event.response.headers['Access-Control-Allow-Origin'] = '*'
 
 
+def setup_jinja2_enviroment(config):
+    jinja2_env = config.get_jinja2_environment('__webassets__')
+    jinja2_env.globals['feature'] = config.feature
+    jinja2_env.variable_start_string = '"{{'
+    jinja2_env.variable_end_string = '}}"'
+
+    webassets_env = config.get_webassets_env()
+    webassets_env.config['jinja2_env'] = jinja2_env
+
+
 def includeme(config):
     config.registry.settings.setdefault('webassets.bundles', 'h:assets.yaml')
     config.include('pyramid_webassets')
+
+    config.include('pyramid_jinja2')
+    config.add_jinja2_renderer('__webassets__')
+    config.action(None, setup_jinja2_enviroment, args=(config,), order=1)
 
     # Set up a predicate and subscriber to set CORS headers on asset responses
     config.add_subscriber_predicate('asset_request', AssetRequest)

--- a/h/assets.yaml
+++ b/h/assets.yaml
@@ -101,9 +101,13 @@ config:
   filters: uglifyjs
   contents:
     - output: scripts/config.js
-      filters: browserify
+      filters:
+        - browserify
+        - jinja2
       contents:
-        - h:static/scripts/config/accounts.coffee
+        - h:static/scripts/config/features.coffee
+      depends:
+        - h:static/scripts/config/*
 
 
 # Application

--- a/h/features.py
+++ b/h/features.py
@@ -53,4 +53,6 @@ def _features_from_settings(settings, prefix=__package__ + '.feature.'):
 
 
 def includeme(config):
-    config.registry.feature = get_client(config)
+    def directive(config, name):
+        return get_client(config)(name)
+    config.add_directive('feature', directive)

--- a/h/renderers.py
+++ b/h/renderers.py
@@ -51,5 +51,6 @@ def includeme(config):
 
     config.include('pyramid_jinja2')
     for extension in JINJA2_FILE_EXTENSIONS:
+        args = (config, extension)
+        config.action(None, setup_jinja2_environment, args=args, order=1)
         config.add_jinja2_renderer(extension)
-        config.action(None, setup_jinja2_environment, (config, extension))

--- a/h/renderers.py
+++ b/h/renderers.py
@@ -1,5 +1,7 @@
 from . import atom_feed
 
+JINJA2_FILE_EXTENSIONS = ['.js', '.txt', '.html', '.xml']
+
 
 class AnnotationsAtomRendererFactory(object):
 
@@ -37,7 +39,17 @@ class AnnotationsAtomRendererFactory(object):
         return atom_feed.render_annotations(request=system["request"], **value)
 
 
+def setup_jinja2_environment(config, extension):
+    env = config.get_jinja2_environment(extension)
+    env.globals['feature'] = config.feature
+
+
 def includeme(config):
     config.add_renderer(
         name="annotations_atom",
         factory="h.renderers.AnnotationsAtomRendererFactory")
+
+    config.include('pyramid_jinja2')
+    for extension in JINJA2_FILE_EXTENSIONS:
+        config.add_jinja2_renderer(extension)
+        config.action(None, setup_jinja2_environment, (config, extension))

--- a/h/static/scripts/app.coffee
+++ b/h/static/scripts/app.coffee
@@ -78,6 +78,11 @@ setupStreamer = [
     $http.defaults.headers.common['X-Client-Id'] = clientId
 ]
 
+angular.module('h.config', [])
+.provider('identity', require('./identity'))
+.provider('session', require('./session'))
+
+
 module.exports = angular.module('h', [
   'angulartics'
   'angulartics.google.analytics'
@@ -88,6 +93,7 @@ module.exports = angular.module('h', [
   'ngSanitize'
   'ngTagsInput'
   'toastr'
+  'h.config'
 ])
 
 .controller('AppController', require('./app-controller'))
@@ -117,9 +123,6 @@ module.exports = angular.module('h', [
 .filter('moment', require('./filter/moment'))
 .filter('persona', require('./filter/persona'))
 .filter('urlencode', require('./filter/urlencode'))
-
-.provider('identity', require('./identity'))
-.provider('session', require('./session'))
 
 .service('annotator', -> new Annotator(angular.element('<div>')))
 .service('annotationMapper', require('./annotation-mapper'))

--- a/h/static/scripts/app.coffee
+++ b/h/static/scripts/app.coffee
@@ -50,6 +50,27 @@ configureRoutes = ['$routeProvider', ($routeProvider) ->
 ]
 
 
+configureStreamer = ['$provide', ($provide) ->
+  $provide.service('streamer', [
+    '$http', '$injector', '$window', 'feature'
+    ($http,   $injector,   $window,   feature) ->
+      if feature('streamer')
+        streamer = $injector.instantiate(require('./streamer'))
+        clientId = uuid.v4()
+        streamer.clientId = clientId
+        $.ajaxSetup(headers: {'X-Client-Id': clientId})
+        $http.defaults.headers.common['X-Client-Id'] = clientId
+      else
+        streamer =
+          open: angular.noop
+          close: angular.noop
+          send: angular.noop
+
+      return streamer
+  ])
+]
+
+
 configureTemplates = ['$sceDelegateProvider', ($sceDelegateProvider) ->
   # Configure CSP for templates
   # XXX: IE workaround for the lack of document.baseURI property
@@ -142,7 +163,6 @@ module.exports = angular.module('h', [
 .service('searchFilter', require('./search-filter'))
 .service('store', require('./store'))
 .service('streamFilter', require('./stream-filter'))
-.service('streamer', require('./streamer'))
 .service('tags', require('./tags'))
 .service('time', require('./time'))
 .service('threading', require('./threading'))
@@ -156,8 +176,8 @@ module.exports = angular.module('h', [
 .config(configureDocument)
 .config(configureLocation)
 .config(configureRoutes)
+.config(configureStreamer)
 .config(configureTemplates)
 
 .run(setupCrossFrame)
-.run(setupStreamer)
 .run(setupHost)

--- a/h/static/scripts/config/accounts.coffee
+++ b/h/static/scripts/config/accounts.coffee
@@ -11,14 +11,17 @@ SESSION_ACTIONS = [
 ]
 
 
-configure = [
-  '$httpProvider', 'identityProvider', 'sessionProvider'
-  ($httpProvider,   identityProvider,   sessionProvider) ->
+module.exports = [
+  '$httpProvider', '$provide', 'identityProvider', 'sessionProvider'
+  ($httpProvider,   $provide,   identityProvider,   sessionProvider) ->
     # Pending authentication check
     authCheck = null
 
     # Use the Pyramid XSRF header name
     $httpProvider.defaults.xsrfHeaderName = 'X-CSRF-Token'
+
+    # Provide an XSRF token for the session provider
+    $provide.constant('xsrf', token: null)
 
     identityProvider.checkAuthentication = [
       '$q', 'session',
@@ -70,8 +73,3 @@ configure = [
           __formid__: action
         withCredentials: true
 ]
-
-
-angular.module('h')
-.value('xsrf', token: null)
-.config(configure)

--- a/h/static/scripts/config/features.coffee
+++ b/h/static/scripts/config/features.coffee
@@ -1,0 +1,24 @@
+FEATURES = {
+  accounts: """{{ feature('accounts') | json }}""",
+  notification: """{{ feature('notification') | json }}""",
+  streamer: """{{ feature('streamer') | json }}"""
+}
+
+
+feature = (name) ->
+  value = FEATURES[name]
+  if value?
+    return !!value
+  else
+    throw new Error("unknown feature: #{name}")
+
+
+config = (fn) ->
+  module.exports.config(fn)
+
+
+angular = require('angular')
+module.exports = angular.module('h.config').value('feature', feature)
+
+if feature('accounts')
+  config(require('./accounts'))

--- a/h/subscribers.py
+++ b/h/subscribers.py
@@ -7,8 +7,6 @@ def add_renderer_globals(event):
     event['base_url'] = request.resource_url(request.root, '')
     # Set the service url to use for API discovery
     event['service_url'] = request.resource_url(request.root, 'api', '')
-    # Allow templates to check for feature flags
-    event['feature'] = request.registry.feature
 
     # Add Google Analytics
     ga_tracking_id = request.registry.settings.get('ga_tracking_id')

--- a/h/test/assets_test.py
+++ b/h/test/assets_test.py
@@ -4,8 +4,6 @@ from mock import Mock
 from pyramid.urldispatch import Route
 from pyramid.testing import DummyRequest
 
-from h import assets
-
 
 class DummyEvent(object):
     """A dummy event for testing registry events."""
@@ -20,7 +18,8 @@ def test_subscriber_predicate(config):
     It should correctly match asset requests when its value is ``True``,
     and other requests when ``False``.
     """
-    config.include(assets)
+    config.include('pyramid_webassets')
+    config.add_subscriber_predicate('asset_request', 'h.assets.AssetRequest')
 
     mock1 = Mock()
     mock2 = Mock()


### PR DESCRIPTION
This is a set of commits that cleans up the feature flag usage a bit and propagates feature flags to the frontend.

- Rather than use `request.feature` the function is available as a config directive: `config.feature('name')`. This is slightly more attractive and pyramidal to me than setting properties on the registry.

- Export the feature test function to jinja2 templates by adding it as a global for all the configured renderers during configuration time rather than during the `BeforeRender` event.

- Add jinja2 templating to the asset pipeline, including feature flags. Since browserify must be the inner-most filter, the variable substitution delimiters are surrounded with quotes so that simple templates with variable substitutions can pass through browserify before jinja2.

- Create a features configuration in the frontend as part of the config package.

- Make the `h` angular module depend on `h.config` and make the config package use the latter. By defining this package in the main app bundle but augmenting it in the config bundle we ensure a few things:
  - The application can load without a config bundle.
  - The application's providers are available to the config bundle for configuration.
  - The application will not start until the config bundle is loaded.
  - The feature service is available to all service constructors in the application.