### PR TITLE
Add jshint and hound config

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,9 @@
+coffeescript:
+  enabled: false
+javascript:
+  config_file: .jshintrc
+  ignore_file: .jshintignore
+ruby:
+  enabled: false
+scss:
+  enabled: false

--- a/.jshintignore
+++ b/.jshintignore
@@ -1,0 +1,7 @@
+build/
+docs/
+node_modules/
+h/browser/chrome/content/
+h/static/scripts/vendor/
+h/templates/
+**/*.min.js

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,28 @@
+{
+    "bitwise": true,
+    "curly": true,
+    "eqeqeq": true,
+    "forin": true,
+    "freeze": true,
+    "latedef": "nofunc",
+    "maxcomplexity": 10,
+    "strict": true,
+    "undef": true,
+    "unused": true,
+    "globals": {
+        "chrome": false,
+        "h": false,
+        "Promise": false,
+        "angular": false,
+        "chai": false,
+        "moment": false,
+        "jstz": false,
+        "sinon": false,
+        "JSON": false
+    },
+    "browser": true,
+    "browserify": true,
+    "mocha": true,
+    "phantom": true,
+    "jquery": true
+}


### PR DESCRIPTION
Building on #2173 but implemented as a [Hound CI](https://houndci.com/) configuration.

Only JavaScript at the moment. We can turn on CoffeeScript later if we wish.