### PR TITLE
Fix display regression on help/first-run pages

### DIFF
--- a/h/assets.yaml
+++ b/h/assets.yaml
@@ -216,3 +216,24 @@ inject_css:
         - h:static/styles/reset.scss
         - h:static/styles/variables.scss
         - h:static/styles/mixins/icons.scss
+
+
+# Help page
+help_page:
+  contents:
+    - help_page_css
+
+help_page_css:
+  output: styles/help-page.min.css
+  filters:
+    - cleancss
+    - cssrewrite
+  contents:
+    - h:static/styles/vendor/icomoon.css
+    - output: styles/help-page.css
+      filters: compass
+      contents:
+        - h:static/styles/help-page.scss
+      depends:
+        - h:static/styles/*.scss
+        - h:static/styles/mixins/*.scss

--- a/h/assets.yaml
+++ b/h/assets.yaml
@@ -155,26 +155,8 @@ app_css:
       contents:
         - h:static/styles/app.scss
       depends:
-        - h:static/styles/base.scss
-        - h:static/styles/annotations.scss
-        - h:static/styles/mixins/forms.scss
-        - h:static/styles/mixins/icons.scss
-        - h:static/styles/mixins/responsive.scss
-        - h:static/styles/mixins/grid.scss
-        - h:static/styles/common.scss
-        - h:static/styles/grid.scss
-        - h:static/styles/threads.scss
-        - h:static/styles/forms.scss
-        - h:static/styles/markdown-editor.scss
-        - h:static/styles/reset.scss
-        - h:static/styles/spinner.scss
-        - h:static/styles/styled-text.scss
-        - h:static/styles/simple-search.scss
-        - h:static/styles/tags-input.scss
-        - h:static/styles/topbar.scss
-        - h:static/styles/page.scss
-        - h:static/styles/help-page.scss
-        - h:static/styles/variables.scss
+        - h:static/styles/*.scss
+        - h:static/styles/mixins/*.scss
 
 
 account:

--- a/h/layouts.py
+++ b/h/layouts.py
@@ -55,7 +55,7 @@ class BaseLayout(object):
 class AppLayout(BaseLayout):
     app = 'h'
     controller = 'AppController'
-    requirements = (('app', None), ('account', None), ('topbar', None))
+    requirements = (('app', None), ('account', None))
 
 
 def includeme(config):

--- a/h/layouts.py
+++ b/h/layouts.py
@@ -58,6 +58,14 @@ class AppLayout(BaseLayout):
     requirements = (('app', None), ('account', None))
 
 
+@layout_config(name='help', template='h:templates/layouts/base.html')
+class HelpPageLayout(BaseLayout):
+
+    """Layout for the help, app index, and extension first-run pages."""
+
+    requirements = (('help_page', None),)
+
+
 def includeme(config):
     config.include('pyramid_layout')
     config.scan(__name__)

--- a/h/static/styles/app.scss
+++ b/h/static/styles/app.scss
@@ -13,6 +13,11 @@ body {
   @extend .noise;
   font-family: $sans-font-family;
   font-weight: 300;
+  font-size: .8em;
+  height: 100%;
+  width: 100%;
+  padding-top: 30px;
+  position: fixed;
 }
 
 #{nest("hgroup", "#{headings()}")} {
@@ -27,8 +32,12 @@ ol {
 }
 
 #wrapper {
+  height: 100%;
   padding: .72em;
   text-align: center;
+  overflow-y: auto;
+  position: relative;
+  -webkit-overflow-scrolling: touch;
 
   @include respond-to(tablets desktops) {
     padding-bottom: 4em;

--- a/h/static/styles/common.scss
+++ b/h/static/styles/common.scss
@@ -18,7 +18,6 @@ $headings-color: $text-color;
 @import 'tags-input';
 @import 'topbar';
 @import 'page';
-@import 'help-page';
 
 //ELEMENT STYLES////////////////////////////////
 a {

--- a/h/static/styles/help-page.scss
+++ b/h/static/styles/help-page.scss
@@ -1,18 +1,38 @@
+@import 'compass';
+
+@import 'reset';
+@import 'common';
 @import "./mixins/icons";
+
+body {
+  background: #fff;
+}
 
 .help-page {
   padding-top: 2.5em;
   padding-bottom: 2.5em;
   background: $body-background;
   font-family: 'Lato', sans-serif !important;
+  font-weight: 300;
 
   @include breakpoint(920px) {
     padding-right: 460px;
   }
 
   .masthead {
-    margin-bottom: 2.5em;
-    margin-left: -1em;
+    padding: 2.5em;
+    padding-top: 0;
+
+    .masthead-heading {
+      padding-top: 4px;
+      font-size: 1.1em;
+      font-weight: 400;
+      color: $gray;
+
+      &:hover {
+        color: $gray-dark;
+      }
+    }
   }
 }
 

--- a/h/static/styles/topbar.scss
+++ b/h/static/styles/topbar.scss
@@ -1,22 +1,6 @@
 @import 'base';
 @import 'mixins/responsive';
 
-body {
-  background-color: transparent;
-  font-size: .8em;
-  height: 100%;
-  width: 100%;
-  padding-top: 30px;
-  position: fixed;
-}
-
-#wrapper {
-  height: 100%;
-  overflow-y: auto;
-  position: relative;
-  -webkit-overflow-scrolling: touch;
-}
-
 .topbar {
   background: $white;
   border: solid 1px $gray-lighter;

--- a/h/templates/help.html
+++ b/h/templates/help.html
@@ -2,10 +2,6 @@
 
 {% block meta %}
   <link href='//fonts.googleapis.com/css?family=Lato:400,300' rel='stylesheet' type='text/css'>
-  <!-- Override app body stylings for just this page -->
-  <style type="text/css">
-    body {background: #FFF !important;}
-  </style>
   {{ super() }}
   {% if is_onboarding %}
     <meta name="hypothesis-intent" content="first-run" />

--- a/h/views.py
+++ b/h/views.py
@@ -96,9 +96,15 @@ def page(context, request):
     return {}
 
 
-@view_config(renderer='h:templates/help.html', route_name='index')
-@view_config(renderer='h:templates/help.html', route_name='help')
-@view_config(renderer='h:templates/help.html', route_name='onboarding')
+@view_config(layout='help',
+             renderer='h:templates/help.html',
+             route_name='index')
+@view_config(layout='help',
+             renderer='h:templates/help.html',
+             route_name='help')
+@view_config(layout='help',
+             renderer='h:templates/help.html',
+             route_name='onboarding')
 def help_page(context, request):
     current_route = request.matched_route.name
     return {


### PR DESCRIPTION
So, once upon a time in the mists of yesteryear, the help/first-run page looked like this:

![](https://d.pr/i/1aL2b+)

Nice, innit?

Well unfortunately it now looks like this:

![](http://d.pr/i/1kFwA+)

Note, in particular:

- misaligned logotype
- text [for ants](http://i.imgur.com/EqLMD2w.jpg)
- incorrect line-height (see bookmarklet button and the help text where the sidebar should go)

Turns out, this is due to the bundling of `topbar.scss` by 1f4ac1b. For reasons that aren't clear to me, `topbar.scss` interferes with `font-size` on `body`, and commits a couple of other heinous crimes before getting on with what I assume it was supposed to be for, namely styling the top bar.

Anyway, I've fixed this by:

- moving the scope-creepy CSS from `topbar.scss` into `app.scss`
- removing `app.scss` from the included code for the help page
- turning `help-page.scss` into a new top-level stylesheet, to be used by... wait for it... the help page

And here's what it looks like now:

![](http://d.pr/i/10pqP+)

And here's a diff between the "before" image (the first in this message) and the result of this PR:

![](https://d.pr/i/1ddWY+)

You can see that the text has moved a few pixels down, but is otherwise unchanged. The movement of a few pixels is just a result of the styling of the header, which no longer relies on overriding styles from `app.scss`.