### PR TITLE
Faster Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+# use Travis container build infrastructure
+sudo: false
 language:
   - python
 python:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,9 @@ install:
   - pip install coveralls pyramid_redis_sessions
   - make
 script:
-  - make test
+  # Run all tests, with coverage if possible
   - make cover
+  # Test building browser extensions
   - hypothesis-buildext conf/testext.ini chrome --base http://localhost
   - hypothesis-buildext conf/testext.ini firefox --base http://localhost
   - "hypothesis-buildext conf/production.ini chrome

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
 install:
   - gem install sass
   - gem install compass
+  - pip install -U pip wheel
   - pip install coveralls
   - pip install mandrill
   - pip install pyramid_redis_sessions
@@ -24,6 +25,9 @@ script:
     --assets resource://notarealkey/hypothesis/data"
 after_success:
   - coveralls
+cache:
+  directories:
+    - $HOME/.cache/pip
 notifications:
   irc:
     channels:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ install:
   - gem install compass
   - pip install -U pip wheel
   - pip install coveralls
-  - pip install mandrill
   - pip install pyramid_redis_sessions
   - make
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ after_success:
   - coveralls
 cache:
   directories:
+    - node_modules
     - $HOME/.cache/pip
 notifications:
   irc:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ language:
 python:
   - '2.7'
 install:
-  - gem install sass
   - gem install compass
   - pip install -U pip wheel
   - pip install coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,7 @@ python:
 install:
   - gem install compass
   - pip install -U pip wheel
-  - pip install coveralls
-  - pip install pyramid_redis_sessions
+  - pip install coveralls pyramid_redis_sessions
   - make
 script:
   - make test

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,8 @@ test:
 
 cover:
 	@python setup.py test --cov
+	@"$$(npm bin)"/karma start h/static/scripts/karma.config.js --single-run
+	@"$$(npm bin)"/karma start h/browser/chrome/karma.config.js --single-run
 
 lint:
 	@prospector


### PR DESCRIPTION
Currently, our builds are taking 6-12 minutes depending on load at Travis. This is really super slow. I'd like to get this down to sub-1-minute in the future, but this will have to do for now. This brings build times down to just over 3 minutes, it seems.

Large speed gains from:

- switching to [Travis container-based infrastructure](http://docs.travis-ci.com/user/workers/container-based-infrastructure/)
- upgrading to [pip 7.0.0](https://mail.python.org/pipermail/distutils-sig/2015-May/026474.html) and using [Travis caching](http://docs.travis-ci.com/user/caching/) to preserve dependencies across builds
- not running the Python tests twice

And a couple of microoptimizations:

- don't install things you don't need
- don't run pip multiple times for multiple packages (we still run pip twice so we can upgrade to pip==7.0.0 but as soon as Travis themselves upgrade, that can go too)