### PR TITLE
Silence sqlalchemy warnings caused by horus

### DIFF
--- a/h/accounts/models.py
+++ b/h/accounts/models.py
@@ -22,6 +22,22 @@ from sqlalchemy import or_
 from sqlalchemy.ext.declarative import declared_attr
 
 
+# Silence some SQLAlchemy warnings caused by the Horus library.
+import warnings
+warnings.filterwarnings("ignore", message=r".*Unmanaged access of declarative "
+                                          "attribute __tablename__ from "
+                                          "non-mapped class UserGroupMixin")
+warnings.filterwarnings("ignore", message=r".*Unmanaged access of declarative "
+                                          "attribute __tablename__ from "
+                                          "non-mapped class GroupMixin")
+warnings.filterwarnings("ignore", message=r".*Unmanaged access of declarative "
+                                          "attribute __tablename__ from "
+                                          "non-mapped class ActivationMixin")
+warnings.filterwarnings("ignore", message=r".*Unmanaged access of declarative "
+                                          "attribute __tablename__ from "
+                                          "non-mapped class UserMixin")
+
+
 class Activation(ActivationMixin, Base):
     def __init__(self, *args, **kwargs):
         super(Activation, self).__init__(*args, **kwargs)


### PR DESCRIPTION
I'm not sure how long these warnings have been in h at startup, but they were getting on my nerves. I think they're caused by horus not h. Maybe just silencing them is good enough?

```
seanh@mistakenot ~/P/h/h make dev                                                                 h master
2015-05-26 17:45:45,070 [22890] [gunicorn.error:INFO] Starting gunicorn 19.3.0
2015-05-26 17:45:45,070 [22890] [gunicorn.error:INFO] Listening at: http://127.0.0.1:5000 (22890)
2015-05-26 17:45:45,070 [22890] [gunicorn.error:INFO] Using worker: h.server.Worker
2015-05-26 17:45:45,072 [22897] [gunicorn.error:INFO] Booting worker with pid: 22897
/home/seanh/.virtualenvs/h/local/lib/python2.7/site-packages/sqlalchemy/ext/declarative/api.py:173: SAWarning: Unmanaged access of declarative attribute __tablename__ from non-mapped class UserGroupMixin
  (desc.fget.__name__, cls.__name__))
/home/seanh/.virtualenvs/h/local/lib/python2.7/site-packages/sqlalchemy/ext/declarative/api.py:173: SAWarning: Unmanaged access of declarative attribute __tablename__ from non-mapped class GroupMixin
  (desc.fget.__name__, cls.__name__))
/home/seanh/.virtualenvs/h/local/lib/python2.7/site-packages/sqlalchemy/ext/declarative/api.py:173: SAWarning: Unmanaged access of declarative attribute __tablename__ from non-mapped class ActivationMixin
  (desc.fget.__name__, cls.__name__))
/home/seanh/.virtualenvs/h/local/lib/python2.7/site-packages/sqlalchemy/ext/declarative/api.py:173: SAWarning: Unmanaged access of declarative attribute __tablename__ from non-mapped class UserMixin
  (desc.fget.__name__, cls.__name__))
```