### PR TITLE
setVisibleHighlights to true when making new annotation

### DIFF
--- a/h/static/scripts/annotator/guest.coffee
+++ b/h/static/scripts/annotator/guest.coffee
@@ -363,6 +363,7 @@ module.exports = class Guest extends Annotator
         this.setVisibleHighlights true
         this.setupAnnotation(this.createHighlight())
       when 'comment'
+        this.setVisibleHighlights true
         this.setupAnnotation(this.createAnnotation())
         this.triggerShowFrame()
     Annotator.Util.getGlobal().getSelection().removeAllRanges()

--- a/h/static/scripts/annotator/test/guest-test.coffee
+++ b/h/static/scripts/annotator/test/guest-test.coffee
@@ -288,6 +288,23 @@ describe 'Guest', ->
       guest.onAdderMouseup(event)
       assert.isTrue(event.isPropagationStopped())
 
+  describe 'onAdderClick', ->
+    it 'it sets visiblehighlights to true when making a highlight', () ->
+      guest = createGuest()
+      event = jQuery.Event('click')
+      guest.setVisibleHighlights = sandbox.stub()
+      guest.onAdderClick target: dataset: action: "highlight"
+      assert.called(guest.setVisibleHighlights)
+      assert.calledWith(guest.setVisibleHighlights, true)
+
+    it 'it sets visiblehighlights to true when making an annotation', () ->
+      guest = createGuest()
+      event = jQuery.Event('click')
+      guest.setVisibleHighlights = sandbox.stub()
+      guest.onAdderClick target: dataset: action: "comment"
+      assert.called(guest.setVisibleHighlights)
+      assert.calledWith(guest.setVisibleHighlights, true)
+
   describe 'annotation sync', ->
     it 'calls sync for createAnnotation', ->
       guest = createGuest()


### PR DESCRIPTION
Meant to resolve https://github.com/hypothesis/h/issues/1992: *Highlight disappears after clicking adder icon.*

This simply sets visible highlights to true when making a new annotation, like we do when making a highlight. While we could do something complicated like introducing more CSS classes to highlights, I think this is a good enough usability improvement for now.

