### PR TITLE
Don't explode on empty bodies in AsyncFormViewMapper

### DIFF
--- a/h/accounts/views.py
+++ b/h/accounts/views.py
@@ -30,7 +30,10 @@ def ajax_form(request, result):
 
     if isinstance(result, httpexceptions.HTTPRedirection):
         request.response.headers.extend(result.headers)
-        result = result.json
+        if result.body != '':
+            result = result.json
+        else:
+            result = {}
         result["status"] = "okay"
     elif isinstance(result, httpexceptions.HTTPError):
         request.response.status_code = result.code


### PR DESCRIPTION
This is a quick fix for an error currently in staging which prevents logout from working.

Obviously this should have tests, but testing this code is totally horrendous. I've nearly finished some work to improve this substantially on the `dehorusify-profilecontroller` branch, and I'll be sure to test this code path there. For now, I think we should merge this and push it to staging.