### PR TITLE
Fix gunicorn ssl crash on Python < 2.7.9

### DIFF
--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import os
+import sys
 import urlparse
 
 # Smart detect heroku stack and assume a trusted proxy.
@@ -13,10 +14,12 @@ if 'STATSD_PORT' in os.environ:
 
 def post_fork(_server, _worker):
     # Support back-ported SSL changes on Debian / Ubuntu
-    import _ssl
-    import gevent.hub
-    if not hasattr(_ssl, '_sslwrap'):
-        gevent.hub.PYGTE279 = True
+    major, minor, micro, _, _ = sys.version_info
+    if major == 2 and minor == 7 and micro >= 9:
+        import _ssl
+        import gevent.hub
+        if not hasattr(_ssl, '_sslwrap'):
+            gevent.hub.PYGTE279 = True
 
     try:
         import psycogreen.gevent


### PR DESCRIPTION
Possible fix for #2273. I'm not sure what <https://github.com/hypothesis/h/commit/c3c99186549e6ecdae54e6743aa90b9baae78cca> is actually about (@tilgovi - more links?) but it makes gunicorn crash for me and googling it sounds like it may be because SSLContext is a Python 2.7.9 thing and I'm on Python 2.7.6 (Ubuntu 14.04). I guess this may be a gunicorn or gevent bug. This commit gets rid of the crash at least