### PR TITLE
Don't run prospector over test packages

### DIFF
--- a/.prospector.yaml
+++ b/.prospector.yaml
@@ -1,6 +1,5 @@
 output-format: grouped
 strictness: veryhigh
-test-warnings: true
 doc-warnings: true
 max-line-length: 79
 pep8:


### PR DESCRIPTION
My motivation for this change is to reduce noise in the Prospector messages. PR #2274 pretty clearly improves "health", in my (biased) opinion, but its Prospector score is dragged down because I added [a bunch of test functions without docstrings](https://github.com/hypothesis/h/pull/2274/files#diff-bb25916b4db2b824f06e8d65a00b2945R53).

I don't think those test functions would be improved by docstrings, and might actually be made worse -- more for the eye to scan can actually hinder understanding.

In addition, there are some patterns for `py.test` (function params shadowing global fixture functions) which PyLint complains about but for which there is no easy fix.