### PR TITLE
Dehorusify the AuthController

### DIFF
--- a/conf/development.ini
+++ b/conf/development.ini
@@ -29,8 +29,6 @@ h.feature.notification: False
 h.feature.queue: False
 h.feature.streamer: False
 
-horus.login_redirect: stream
-horus.logout_redirect: index
 horus.register_redirect: stream
 
 horus.allow_email_auth: True

--- a/conf/production.ini
+++ b/conf/production.ini
@@ -27,8 +27,6 @@ h.feature.streamer: True
 
 # User and group framework settings -- see horus documentation
 # Used by the local authentication provider
-horus.login_redirect: stream
-horus.logout_redirect: index
 horus.activate_redirect: stream
 horus.register_redirect: stream
 

--- a/h/conftest.py
+++ b/h/conftest.py
@@ -109,6 +109,15 @@ def mailer(config):
 
 
 @pytest.fixture()
+def notify(config, request):
+    from mock import patch
+
+    patcher = patch.object(config.registry, 'notify', autospec=True)
+    request.addfinalizer(patcher.stop)
+    return patcher.start()
+
+
+@pytest.fixture()
 def routes_mapper(config):
     from pyramid.interfaces import IRoutesMapper
 


### PR DESCRIPTION
Remove the AuthController's dependency on horus. Part of the ongoing process to remove our dependency on this library.

(I couldn't resist the temptation because this one looked so easy. Expect more like this tomorrow...)