### PR TITLE
Fully isolate os.environ during config testing

### DIFF
--- a/h/test/config_test.py
+++ b/h/test/config_test.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 import os
-from mock import patch
+import pytest
+
 from h.config import settings_from_environment
 
 
-@patch.dict(os.environ)
 def test_google_analytics():
     os.environ['GOOGLE_ANALYTICS_TRACKING_ID'] = '12345-1'
 
@@ -15,7 +15,6 @@ def test_google_analytics():
     assert actual_config == expected_config
 
 
-@patch.dict(os.environ)
 def test_heroku_bonsai():
     url = 'http://ql9lsrn8:img5ndnsbtaahloy@redwood-94865.us-east-1.bonsai.io/'
     os.environ['BONSAI_URL'] = url
@@ -27,7 +26,6 @@ def test_heroku_bonsai():
     assert actual_config == expected_config
 
 
-@patch.dict(os.environ)
 def test_heroku_redistogo():
     url = 'redis://redistogo:12345@mummichog.redistogo.com:9128/'
     os.environ['REDISTOGO_URL'] = url
@@ -39,7 +37,6 @@ def test_heroku_redistogo():
     assert actual_config == expected_config
 
 
-@patch.dict(os.environ)
 def test_heroku_database_sqlite():
     os.environ['DATABASE_URL'] = 'sqlite:///tmp/database.db'
 
@@ -48,7 +45,6 @@ def test_heroku_database_sqlite():
     assert actual_config == expected_config
 
 
-@patch.dict(os.environ)
 def test_heroku_database_postgres():
     os.environ['DATABASE_URL'] = 'postgres://postgres:1234/database'
 
@@ -59,7 +55,6 @@ def test_heroku_database_postgres():
     assert actual_config == expected_config
 
 
-@patch.dict(os.environ)
 def test_es_environment():
     os.environ['ELASTICSEARCH_PORT'] = 'tcp://127.0.0.1:1234'
     os.environ['ELASTICSEARCH_PORT_9200_TCP_ADDR'] = '127.0.0.1'
@@ -74,7 +69,6 @@ def test_es_environment():
     assert actual_config == expected_config
 
 
-@patch.dict(os.environ)
 def test_mail_mailgun():
     os.environ['MAILGUN_SMTP_LOGIN'] = 'hollywood'
     os.environ['MAILGUN_SMTP_PASSWORD'] = 'wolfman'
@@ -90,7 +84,6 @@ def test_mail_mailgun():
     assert actual_config == expected_config
 
 
-@patch.dict(os.environ)
 def test_mail_mandrill():
     os.environ['MANDRILL_USERNAME'] = 'maverick'
     os.environ['MANDRILL_APIKEY'] = 'ace'
@@ -106,7 +99,6 @@ def test_mail_mandrill():
     assert actual_config == expected_config
 
 
-@patch.dict(os.environ)
 def test_mail_sendgrid():
     os.environ['SENDGRID_USERNAME'] = 'goose'
     os.environ['SENDGRID_PASSWORD'] = 'stud'
@@ -122,7 +114,6 @@ def test_mail_sendgrid():
     assert actual_config == expected_config
 
 
-@patch.dict(os.environ)
 def test_mail_sender():
     os.environ['MAIL_DEFAULT_SENDER'] = 'zardoz@vortex.org'
 
@@ -133,7 +124,6 @@ def test_mail_sender():
     assert actual_config == expected_config
 
 
-@patch.dict(os.environ)
 def test_mail_environment():
     os.environ['MAIL_PORT'] = 'tcp://127.0.0.1:4567'
     os.environ['MAIL_PORT_25_TCP_ADDR'] = '127.0.0.1'
@@ -147,7 +137,6 @@ def test_mail_environment():
     assert actual_config == expected_config
 
 
-@patch.dict(os.environ)
 def test_nsqd_environment():
     os.environ['NSQD_PORT'] = 'tcp://127.0.0.1:4150'
     os.environ['NSQD_PORT_4150_TCP_ADDR'] = 'tcp.nsqd.local'
@@ -163,7 +152,6 @@ def test_nsqd_environment():
     assert actual_config == expected_config
 
 
-@patch.dict(os.environ)
 def test_nsq_namespace():
     os.environ['NSQ_NAMESPACE'] = 'staging'
 
@@ -174,7 +162,6 @@ def test_nsq_namespace():
     assert actual_config == expected_config
 
 
-@patch.dict(os.environ)
 def test_redis_database_environment():
     os.environ['REDIS_PORT'] = 'tcp://127.0.0.1:4567'
     os.environ['REDIS_PORT_6379_TCP_ADDR'] = '127.0.0.1'
@@ -188,7 +175,6 @@ def test_redis_database_environment():
     assert actual_config == expected_config
 
 
-@patch.dict(os.environ)
 def test_client_credentials_environment():
     os.environ['CLIENT_ID'] = 'annotate'
     os.environ['CLIENT_SECRET'] = 'unsecret'
@@ -201,7 +187,6 @@ def test_client_credentials_environment():
     assert actual_config == expected_config
 
 
-@patch.dict(os.environ)
 def test_secret_key_environment():
     os.environ['SECRET_KEY'] = 's3kr1t'
 
@@ -212,7 +197,6 @@ def test_secret_key_environment():
     assert actual_config == expected_config
 
 
-@patch.dict(os.environ)
 def test_session_secret_environment():  # bw compat
     os.environ['SESSION_SECRET'] = 's3kr1t'
 
@@ -223,7 +207,6 @@ def test_session_secret_environment():  # bw compat
     assert actual_config == expected_config
 
 
-@patch.dict(os.environ)
 def test_blocklist():
     blocklist = '{"seanh.cc": {}, "twitter.com": {}, "finance.yahoo.com": {}'
     os.environ['BLOCKLIST'] = blocklist
@@ -231,3 +214,13 @@ def test_blocklist():
     actual_config = settings_from_environment()
 
     assert actual_config == {'h.blocklist': blocklist}
+
+
+@pytest.fixture(autouse=True)
+def environ(request):
+    """Clear the environment and later restore it to its original state."""
+    from mock import patch
+
+    patcher = patch.dict(os.environ, clear=True)
+    request.addfinalizer(patcher.stop)
+    return patcher.start()


### PR DESCRIPTION
This commit ensures that for each test in h.test.config_test (which tests the parsing of configuration variables from the system environment), the value of `os.environ` is cleared. This makes it impossible for environment variables set outside the test process to break these tests.