### PR TITLE
Report form level errors

### DIFF
--- a/h/accounts/schemas.py
+++ b/h/accounts/schemas.py
@@ -54,8 +54,8 @@ def unblacklisted_username(node, value, blacklist=None):
 def matching_emails(node, value):
     """Colander validator that ensures email and emailAgain fields match."""
     if value.get("email") != value.get("emailAgain"):
-        exc = colander.Invalid(node, "The emails must match")
-        exc["emailAgain"] = "The emails must match."
+        exc = colander.Invalid(node)
+        exc["emailAgain"] = _("The emails must match")
         raise exc
 
 

--- a/h/accounts/test/views_test.py
+++ b/h/accounts/test/views_test.py
@@ -123,30 +123,6 @@ def test_ajax_form_includes_flash_data(pop_flash):
     assert result['flash'] == {'success': ['Well done!']}
 
 
-def test_ajax_form_sets_status_code_400_on_flash_error(pop_flash):
-    request = DummyRequest()
-    pop_flash.return_value = {'error': ['I asplode!']}
-    _ = ajax_form(request, {'some': 'data'})
-
-    assert request.response.status_code == 400
-
-
-def test_ajax_form_sets_status_failure_on_flash_error(pop_flash):
-    request = DummyRequest()
-    pop_flash.return_value = {'error': ['I asplode!']}
-    result = ajax_form(request, {'some': 'data'})
-
-    assert result['status'] == 'failure'
-
-
-def test_ajax_form_sets_reason_on_flash_error(pop_flash):
-    request = DummyRequest()
-    pop_flash.return_value = {'error': ['I asplode!']}
-    result = ajax_form(request, {'some': 'data'})
-
-    assert result['reason'] == 'I asplode!'
-
-
 def test_validate_form_passes_data_to_validate():
     form = MagicMock()
 

--- a/h/accounts/test/views_test.py
+++ b/h/accounts/test/views_test.py
@@ -45,7 +45,12 @@ def configure(config):
 
 
 # A fake version of colander.Invalid for use when testing validate_form
-FakeInvalid = namedtuple('FakeInvalid', 'children')
+class FakeInvalid(object):
+    def __init__(self, errors):
+        self.errors = errors
+
+    def asdict(self):
+        return self.errors
 
 
 def test_ajax_form_handles_http_redirect_as_success():
@@ -68,34 +73,36 @@ def test_ajax_form_handles_http_error_as_error():
 
 def test_ajax_form_sets_failure_status_on_errors():
     request = DummyRequest()
-    result = ajax_form(request, {'errors': 'data'})
+    result = ajax_form(request, {'errors': {}})
 
     assert result['status'] == 'failure'
 
 
 def test_ajax_form_sets_status_code_400_on_errors():
     request = DummyRequest()
-    _ = ajax_form(request, {'errors': 'data'})
+    _ = ajax_form(request, {'errors': {}})
 
     assert request.response.status_code == 400
 
 
 def test_ajax_form_sets_status_code_from_input_on_errors():
     request = DummyRequest()
-    _ = ajax_form(request, {'errors': 'data', 'code': 418})
+    _ = ajax_form(request, {'errors': {}, 'code': 418})
 
     assert request.response.status_code == 418
 
 
-def test_ajax_form_aggregates_errors_on_success():
+def test_ajax_form_passes_errors_through_on_errors():
     request = DummyRequest()
-    errors = [
-        {'name': 'Name is too weird'},
-        {'email': 'Email must be @hotmail.com'},
-    ]
+    errors = {
+        '': 'Top level error',
+        'name': 'Name is too weird',
+        'email': 'Email must be @hotmail.com',
+    }
     result = ajax_form(request, {'errors': errors})
 
-    assert result['errors'] == {'name': 'Name is too weird',
+    assert result['errors'] == {'': 'Top level error',
+                                'name': 'Name is too weird',
                                 'email': 'Email must be @hotmail.com'}
 
 
@@ -132,13 +139,13 @@ def test_validate_form_passes_data_to_validate():
 
 
 def test_validate_form_failure():
-    invalid = FakeInvalid(children=object())
+    invalid = FakeInvalid({'': 'Asplode!', 'email': 'No @ sign!'})
     form = MagicMock()
     form.validate.side_effect = deform.ValidationFailure(None, None, invalid)
 
     err, data = validate_form(form, {})
 
-    assert err == {'errors': invalid.children}
+    assert err == {'errors': {'': 'Asplode!', 'email': 'No @ sign!'}}
     assert data is None
 
 

--- a/h/accounts/views.py
+++ b/h/accounts/views.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import json
 
-import colander
 import deform
 import horus.events
 import horus.views
@@ -33,19 +32,9 @@ def ajax_form(request, result):
     elif isinstance(result, httpexceptions.HTTPError):
         request.response.status_code = result.code
         result = {'status': 'failure', 'reason': str(result)}
-    else:
-        errors = result.pop('errors', None)
-        if errors is not None:
-            status_code = result.pop('code', 400)
-            request.response.status_code = status_code
-            result['status'] = 'failure'
-
-            result.setdefault('errors', {})
-            for e in errors:
-                if isinstance(e, colander.Invalid):
-                    result['errors'].update(e.asdict())
-                elif isinstance(e, dict):
-                    result['errors'].update(e)
+    elif 'errors' in result:
+        request.response.status_code = result.pop('code', 400)
+        result['status'] = 'failure'
 
     result['flash'] = session.pop_flash(request)
 
@@ -57,7 +46,7 @@ def validate_form(form, data):
     try:
         appstruct = form.validate(data)
     except deform.ValidationFailure as err:
-        return {'errors': err.error.children}, None
+        return {'errors': err.error.asdict()}, None
     else:
         return None, appstruct
 
@@ -345,7 +334,7 @@ class ProfileController(object):
         #   `password` (used below) is optional, and is the new password
         #
         if not User.validate_user(user, appstruct.get('pwd')):
-            return {'errors': [{'pwd': _('Invalid password')}], 'code': 401}
+            return {'errors': {'pwd': _('Invalid password')}, 'code': 401}
 
         email = appstruct.get('email')
         if email:
@@ -354,7 +343,7 @@ class ProfileController(object):
             if email_user:
                 if email_user.id != user.id:
                     return {
-                        'errors': [{'pwd': _('That email is already used')}],
+                        'errors': {'pwd': _('That email is already used')},
                     }
 
             response['model']['email'] = user.email = email
@@ -383,7 +372,7 @@ class ProfileController(object):
             FlashMessage(self.request, _('Account disabled.'), kind='success')
             return {}
         else:
-            return dict(errors=[{'pwd': _('Invalid password')}], code=401)
+            return dict(errors={'pwd': _('Invalid password')}, code=401)
 
     def profile(self):
         """
@@ -463,7 +452,7 @@ def _update_subscription_data(request, subscription):
     sub = Subscriptions.get_by_id(request, subscription['id'])
     if sub is None:
         return {
-            'errors': [{'subscriptions': _('Subscription not found')}],
+            'errors': {'subscriptions': _('Subscription not found')},
         }
 
     # If we're trying to update a subscription for anyone other than
@@ -474,7 +463,7 @@ def _update_subscription_data(request, subscription):
     # belong to.
     if sub.uri != request.authenticated_userid:
         return {
-            'errors': [{'subscriptions': _('Subscription not found')}],
+            'errors': {'subscriptions': _('Subscription not found')},
         }
 
     sub.active = subscription.get('active', True)

--- a/h/accounts/views.py
+++ b/h/accounts/views.py
@@ -27,8 +27,6 @@ from h import session
 
 
 def ajax_form(request, result):
-    flash = session.pop_flash(request)
-
     if isinstance(result, httpexceptions.HTTPRedirection):
         request.response.headers.extend(result.headers)
         result = {'status': 'okay'}
@@ -49,14 +47,7 @@ def ajax_form(request, result):
                 elif isinstance(e, dict):
                     result['errors'].update(e)
 
-        reasons = flash.pop('error', [])
-        if reasons:
-            assert(len(reasons) == 1)
-            request.response.status_code = 400
-            result['status'] = 'failure'
-            result['reason'] = reasons[0]
-
-    result['flash'] = flash
+    result['flash'] = session.pop_flash(request)
 
     return result
 

--- a/h/static/scripts/form-respond.coffee
+++ b/h/static/scripts/form-respond.coffee
@@ -4,9 +4,17 @@
 # will contain the API error message.
 module.exports = ->
   (form, errors, reason) ->
-    for own field, error of errors
-      form[field].$setValidity('response', false)
-      form[field].responseErrorMessage = error
-
     form.$setValidity('response', !reason)
     form.responseErrorMessage = reason
+
+    for own field, error of errors
+      # If there's an empty-string field, it's a top-level form error. Set the
+      # overall form validity from this field, but only if there wasn't already
+      # a reason.
+      if !reason and field == ''
+        form.$setValidity('response', false)
+        form.responseErrorMessage = error
+        continue
+
+      form[field].$setValidity('response', false)
+      form[field].responseErrorMessage = error

--- a/h/static/scripts/test/form-respond-test.coffee
+++ b/h/static/scripts/test/form-respond-test.coffee
@@ -38,6 +38,14 @@ describe 'form-respond', ->
     assert.equal(form.username.responseErrorMessage, 'must be at least 3 characters')
     assert.equal(form.password.responseErrorMessage, 'must be present')
 
+  it 'sets the "response" error key if the form has a top-level error', ->
+    formRespond form, {'': 'Explosions!'}
+    assert.calledWith(form.$setValidity, 'response', false)
+
+  it 'adds an error message if the form has a top-level error', ->
+    formRespond form, {'': 'Explosions!'}
+    assert.equal(form.responseErrorMessage, 'Explosions!')
+
   it 'sets the "response" error key if the form has a failure reason', ->
     formRespond form, null, 'fail'
     assert.calledWith(form.$setValidity, 'response', false)


### PR DESCRIPTION
When we call `form.validate()` and the validation fails, the raised exception is a `deform.ValidationFailure`. This object has an `error` attribute which represents the underlying validation error object for the entire form.

Previously, if the validation failure were a result of top-level validation errors (such as the fact that an unactivated user is trying to log in), this error would be lost, because we only reported errors for the forms fields, or "children".

This commit changes `h.accounts.views.validate_form` so that it converts the entire `colander.Invalid` object into a dictionary using its `asdict()` instance method. By doing this, we get two immediate benefits:

- top-level validation errors are reported in the '' (empty string) field
- we avoid the need to aggregate form field errors by hand in ajax_form

In addition, we need to deal with this case on the frontend, so this commit also changes the formRespond directive so that if no overall "reason" is provided for failure, then an empty-string member of the "errors" object can set the overall validation status (and error message) for the form.

(This PR also removes support for error flash messages from `ajax_form`. We don't use them anywhere in this package and hopefully won't ever have to.)