### PR TITLE
Dehorusify the RegisterController

### DIFF
--- a/conf/development.ini
+++ b/conf/development.ini
@@ -29,10 +29,6 @@ h.feature.notification: False
 h.feature.queue: False
 h.feature.streamer: False
 
-horus.register_redirect: stream
-
-horus.require_activation: False
-
 mail.default_sender: "Annotation Daemon" <no-reply@localhost>
 
 pyramid.debug_all: True

--- a/conf/production.ini
+++ b/conf/production.ini
@@ -25,13 +25,6 @@ h.feature.notification: True
 h.feature.queue: True
 h.feature.streamer: True
 
-# User and group framework settings -- see horus documentation
-# Used by the local authentication provider
-horus.activate_redirect: stream
-horus.register_redirect: stream
-
-#horus.require_activation: True
-
 # Mail server configuration -- see the pyramid_mailer documentation
 mail.default_sender: "Annotation Daemon" <no-reply@localhost>
 #mail.host: localhost

--- a/h/accounts/events.py
+++ b/h/accounts/events.py
@@ -1,3 +1,9 @@
+class ActivationEvent(object):
+    def __init__(self, request, user):
+        self.request = request
+        self.user = user
+
+
 class LoginEvent(object):
     def __init__(self, request, user):
         self.request = request
@@ -7,6 +13,12 @@ class LoginEvent(object):
 class LogoutEvent(object):
     def __init__(self, request):
         self.request = request
+
+
+class RegistrationEvent(object):
+    def __init__(self, request, user):
+        self.request = request
+        self.user = user
 
 
 class PasswordResetEvent(object):

--- a/h/accounts/models.py
+++ b/h/accounts/models.py
@@ -16,7 +16,6 @@ from horus.models import (
 )
 from horus.strings import UIStringsBase
 from pyramid_basemodel import Base, Session
-from pyramid.threadlocal import get_current_request
 import sqlalchemy as sa
 from sqlalchemy import or_
 from sqlalchemy.ext.declarative import declared_attr
@@ -39,18 +38,7 @@ warnings.filterwarnings("ignore", message=r".*Unmanaged access of declarative "
 
 
 class Activation(ActivationMixin, Base):
-    def __init__(self, *args, **kwargs):
-        super(Activation, self).__init__(*args, **kwargs)
-
-        # XXX: Horus currently has a bug where the Activation model isn't
-        # flushed before the email is generated, causing the link to be
-        # broken (hypothesis/h#1156).
-        #
-        # Fixed in horus@90f838cef12be249a9e9deb5f38b37151649e801
-        request = get_current_request()
-        db = get_session(request)
-        db.add(self)
-        db.flush()
+    pass
 
 
 class Group(GroupMixin, Base):

--- a/h/accounts/subscribers.py
+++ b/h/accounts/subscribers.py
@@ -6,19 +6,13 @@ from pyramid import security
 from pyramid.events import subscriber
 from pyramid.settings import asbool
 
-from horus.events import (
-    NewRegistrationEvent,
-    RegistrationActivatedEvent,
-)
-
 from h.accounts import events
 from h.stats import get_client as stats
 
 
+@subscriber(events.ActivationEvent, autologin=True)
 @subscriber(events.LoginEvent)
-@subscriber(NewRegistrationEvent, autologin=True)
 @subscriber(events.PasswordResetEvent, autologin=True)
-@subscriber(RegistrationActivatedEvent)
 def login(event):
     request = event.request
     user = event.user
@@ -39,8 +33,8 @@ def logout(event):
     stats(event.request).get_counter('auth.local.logout').increment()
 
 
-@subscriber(NewRegistrationEvent)
-def new_registration(event):
+@subscriber(events.RegistrationEvent)
+def registration(event):
     stats(event.request).get_counter('auth.local.register').increment()
 
 
@@ -49,8 +43,8 @@ def password_reset(event):
     stats(event.request).get_counter('auth.local.reset_password').increment()
 
 
-@subscriber(RegistrationActivatedEvent)
-def registration_activated(event):
+@subscriber(events.ActivationEvent)
+def activation(event):
     stats(event.request).get_counter('auth.local.activate').increment()
 
 


### PR DESCRIPTION
Wahey! The last of the bunch. This commit removes the last major dependency on horus from our accounts controllers.

Notable changes:

- User activation is no longer optional (i.e. configurable)
- After initial registration (i.e. while waiting for an email) users are taken to the index. Previously they were taken to the stream, which doesn't make a lot of sense as they can't log in until they've activated their account.
- Users are now automatically logged in after activation, and are taken to the index page as before.
- Hitting the register endpoint as a logged-in user will redirect you to the stream page.