### PR TITLE
Add API CORS support

### DIFF
--- a/h/api/middleware.py
+++ b/h/api/middleware.py
@@ -1,0 +1,69 @@
+from webob import Response
+from webob.dec import wsgify
+from webob.exc import HTTPBadRequest
+
+
+@wsgify.middleware
+def permit_cors(req,
+                app,
+                allow_credentials=False,
+                allow_headers=None,
+                allow_methods=None,
+                expose_headers=None,
+                max_age=86400):
+    """
+    WSGI middleware that enables CORS support across an application.
+
+    CORS stands for "Cross-Origin Resource Sharing," and is a protocol
+    implemented in browsers to allow safe dispatch of XMLHttpRequests across
+    origins.
+    """
+    # If the request is anything other than an OPTIONS request, we just
+    # pass it through and add "A-C-A-O: *" to the response headers.
+    if req.method != 'OPTIONS':
+        resp = req.get_response(app)
+        resp.headers['Access-Control-Allow-Origin'] = '*'
+        return resp
+
+    # Otherwise, we're dealing with a CORS preflight request, which,
+    # according to the spec:
+    #
+    #  http://www.w3.org/TR/cors/#resource-preflight-requests
+    #
+    # ...MUST have an Origin header.
+    origin = req.headers.get('Origin')
+    if origin is None:
+        raise HTTPBadRequest('CORS preflight request lacks Origin header.')
+
+    # ...MUST have an Access-Control-Request-Method header.
+    request_method = req.headers.get('Access-Control-Request-Method')
+    if request_method is None:
+        raise HTTPBadRequest('CORS preflight request lacks '
+                             'Access-Control-Request-Method header.')
+
+    # Always explicitly allow OPTIONS requests.
+    methods = set(['OPTIONS'])
+    if allow_methods is not None:
+        methods.update(allow_methods)
+
+    # We *could* verify that the preflight Access-Control-Request-Headers and
+    # Access-Control-Request-Method match up with the allowed headers and
+    # methods, but there's no need to do this as we can simply return what is
+    # allowed and the browser will do the rest.
+    resp = Response()
+    headers = resp.headers
+    headers['Access-Control-Allow-Origin'] = origin
+    headers['Access-Control-Allow-Methods'] = ', '.join(methods)
+    headers['Access-Control-Max-Age'] = str(max_age)
+
+    if allow_credentials:
+        headers['Access-Control-Allow-Credentials'] = 'true'
+
+    if allow_headers is not None:
+        headers['Access-Control-Allow-Headers'] = ', '.join(allow_headers)
+
+    if expose_headers is not None:
+        headers['Access-Control-Expose-Headers'] = ', '.join(expose_headers)
+
+    return resp
+

--- a/h/api/test/middleware_test.py
+++ b/h/api/test/middleware_test.py
@@ -1,0 +1,175 @@
+from mock import MagicMock
+import pytest
+
+from webob import Request
+from webob.exc import HTTPBadRequest
+
+from h.api.middleware import permit_cors
+
+
+# ARGHY ARGHY ARGHSTICKS.
+#
+# BEWARE. You might think that the lovely WebOb would treat
+#
+#    resp = app(request)
+#
+# and
+#
+#    resp = request.get_response(app)
+#
+# identically. But unfortunately this isn't the case. Specifically, in
+# WebOb==1.4 additional arguments to be passed to the middleware callable are
+# lost with the first pattern, but preserved with the second. That is, if you
+# create a wrapped application with:
+#
+#    app = my_middleware(app, some_kwarg=True)
+#
+# Then when you run
+#
+#    resp = app(request)
+#
+# you will expect the underlying `my_middleware` callable to be passed
+# `some_kwarg=True`, but it won't be, and you will waste a couple of hours
+# trying to work out what you did wrong.
+#
+# Don't do that.
+#
+# - NS, 2015-06-09
+
+
+def test_permit_cors_passes_through_non_preflight():
+    request = Request.blank('/')
+    wrapped = permit_cors(wsgi_testapp)
+
+    resp = request.get_response(wrapped)
+
+    assert resp.body == 'OK'
+    assert resp.status_code == 200
+
+
+def test_permit_cors_adds_allow_origin_header_for_non_preflight():
+    request = Request.blank('/', )
+    wrapped = permit_cors(wsgi_testapp)
+
+    resp = request.get_response(wrapped)
+
+    assert resp.headers['Access-Control-Allow-Origin'] == '*'
+
+
+def test_permit_cors_400s_for_preflight_without_origin(headers):
+    del headers['Origin']
+    request = Request.blank('/', method='OPTIONS', headers=headers)
+    wrapped = permit_cors(wsgi_testapp)
+
+    resp = request.get_response(wrapped)
+
+    assert resp.status_code == 400
+
+
+def test_permit_cors_400s_for_preflight_without_reqmethod(headers):
+    del headers['Access-Control-Request-Method']
+    request = Request.blank('/', method='OPTIONS', headers=headers)
+    wrapped = permit_cors(wsgi_testapp)
+
+    resp = request.get_response(wrapped)
+
+    assert resp.status_code == 400
+
+
+def test_permit_cors_returns_empty_body_for_preflight(headers):
+    request = Request.blank('/', method='OPTIONS', headers=headers)
+    wrapped = permit_cors(wsgi_testapp)
+
+    resp = request.get_response(wrapped)
+
+    assert resp.body == ''
+
+
+def test_permit_cors_sets_allow_origin_for_preflight(headers):
+    request = Request.blank('/', method='OPTIONS', headers=headers)
+    wrapped = permit_cors(wsgi_testapp)
+
+    resp = request.get_response(wrapped)
+
+    assert resp.headers['Access-Control-Allow-Origin'] == 'http://example.com'
+
+
+def test_permit_cors_sets_allow_methods_OPTIONS_for_preflight(headers):
+    request = Request.blank('/', method='OPTIONS', headers=headers)
+    wrapped = permit_cors(wsgi_testapp)
+
+    resp = request.get_response(wrapped)
+
+    assert resp.headers['Access-Control-Allow-Methods'] == 'OPTIONS'
+
+
+def test_permit_cors_sets_allow_methods_for_preflight(headers):
+    request = Request.blank('/', method='OPTIONS', headers=headers)
+    wrapped = permit_cors(wsgi_testapp, allow_methods=('PUT', 'DELETE'))
+
+    resp = request.get_response(wrapped)
+    values = resp.headers['Access-Control-Allow-Methods'].split(', ')
+
+    assert sorted(values) == ['DELETE', 'OPTIONS', 'PUT']
+
+
+def test_permit_cors_sets_allow_credentials_for_preflight_when_set(headers):
+    request = Request.blank('/', method='OPTIONS', headers=headers)
+    wrapped = permit_cors(wsgi_testapp, allow_credentials=True)
+
+    resp = request.get_response(wrapped)
+
+    assert resp.headers['Access-Control-Allow-Credentials'] == 'true'
+
+
+def test_permit_cors_sets_allow_headers_for_preflight_when_set(headers):
+    request = Request.blank('/', method='OPTIONS', headers=headers)
+    wrapped = permit_cors(wsgi_testapp, allow_headers=('Foo', 'X-Bar'))
+
+    resp = request.get_response(wrapped)
+    values = resp.headers['Access-Control-Allow-Headers'].split(', ')
+
+    assert sorted(values) == ['Foo', 'X-Bar']
+
+
+def test_permit_cors_sets_expose_headers_for_preflight_when_set(headers):
+    request = Request.blank('/', method='OPTIONS', headers=headers)
+    wrapped = permit_cors(wsgi_testapp, expose_headers=('Foo', 'X-Bar'))
+
+    resp = request.get_response(wrapped)
+    values = resp.headers['Access-Control-Expose-Headers'].split(', ')
+
+    assert sorted(values) == ['Foo', 'X-Bar']
+
+
+def test_permit_cors_sets_max_age_default_for_preflight(headers):
+    request = Request.blank('/', method='OPTIONS', headers=headers)
+    wrapped = permit_cors(wsgi_testapp)
+
+    resp = request.get_response(wrapped)
+
+    assert resp.headers['Access-Control-Max-Age'] == '86400'
+
+
+def test_permit_cors_sets_max_age_for_preflight_when_set(headers):
+    request = Request.blank('/', method='OPTIONS', headers=headers)
+    wrapped = permit_cors(wsgi_testapp, max_age=42)
+
+    resp = request.get_response(wrapped)
+
+    assert resp.headers['Access-Control-Max-Age'] == '42'
+
+
+# A tiny WSGI application used for testing the middleware
+def wsgi_testapp(environ, start_response):
+    start_response('200 OK', [('Content-Type', 'text/plain')])
+    return ['OK']
+
+
+@pytest.fixture
+def headers():
+    return {
+        'Origin': 'http://example.com',
+        'Access-Control-Request-Method': 'PUT',
+        'Access-Control-Request-Headers': 'Authorization',
+    }

--- a/h/api/views.py
+++ b/h/api/views.py
@@ -84,6 +84,13 @@ def access_token(request):
     return request.create_token_response()
 
 
+# N.B. Like the rest of the API, this view is exposed behind WSGI middleware
+# that enables appropriate CORS headers and response to preflight request.
+#
+# However, this view requires credentials (a cookie) so is in fact not
+# currently accessible off-origin. Given that this method of authenticating to
+# the API is not intended to remain, this seems like a limitation we do not
+# need to lift any time soon.
 @api_config(context=Root, name='token', renderer='string')
 def annotator_token(request):
     """The Annotator Auth token view."""

--- a/h/app.py
+++ b/h/app.py
@@ -8,6 +8,7 @@ from pyramid.config import Configurator
 from pyramid.renderers import JSON
 from pyramid.wsgi import wsgiapp2
 
+from h.api.middleware import permit_cors
 from h.auth import acl_authz, remote_authn, session_authn
 from h.config import settings_from_environment
 from h.security import derive_key
@@ -110,7 +111,13 @@ def create_api(global_config, **settings):
         config.include('h.queue')
         config.include('h.api.queue')
 
-    return config.make_wsgi_app()
+    app = config.make_wsgi_app()
+    app = permit_cors(app,
+                      allow_headers=('Authorization',
+                                     'X-Annotator-Auth-Token'),
+                      allow_methods=('HEAD', 'GET', 'POST', 'PUT', 'DELETE'))
+
+    return app
 
 
 def get_settings(global_config, **settings):


### PR DESCRIPTION
Adds basic CORS support to the API. This is implemented as ~~a tween, but perhaps might be better as~~ plain ol' WSGI middleware.

Notable limitations:

- returned access control headers are not customisable on a per-view basis
- sending credentials in CORS requests is currently disabled -- this means that you cannot redeem a session cookie from the h application for an auth token

Fixes #2186.