### PR TITLE
Don't flash a message when profile is successfully edited

### DIFF
--- a/h/accounts/views.py
+++ b/h/accounts/views.py
@@ -447,7 +447,6 @@ class ProfileController(object):
         if password:
             user.password = password
 
-        FlashMessage(self.request, _('Changes saved!'), kind='success')
         return response
 
     def disable_user(self):


### PR DESCRIPTION
We already have little "Saved" spinner/status indicators on the profile forms, so an additional flash message is superfluous.