### PR TITLE
Don't bust the Docker build cache with CHANGES.txt

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+.git/
+MANIFEST
+build/
+dist/
+docs/_build/
+node_modules/
+
+*.egg
+*.egg-info
+
+*.db
+*.db-journal
+
+*.pyc
+*.pyo
+
+*.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,10 +35,12 @@ ENV PATH=/srv/h/bin:/src/h/node_modules/.bin:$PATH
 WORKDIR /src/h
 
 # Python dependencies
-ADD CHANGES.txt README.rst       /src/h/
 ADD setup.* requirements.txt     /src/h/
 ADD versioneer.py                /src/h/
 ADD h/_version.py                /src/h/h/
+# These files aren't needed in the container, but setup.py gets upset if they
+# are missing:
+RUN touch CHANGES.txt README.rst
 RUN pip install -r requirements.txt
 
 # Node dependencies


### PR DESCRIPTION
Every time we update this file we're currently busting the Docker build cache and rebuilding all the Python deps. This isn't at all necessary in the container so this commit removes it and creates stub versions of CHANGES.txt/README.rst so that setup.py doesn't get upset.

Also adds a `.dockerignore` file which speeds up the uploading of build context.