### PR TITLE
Remove use of horus models in h.accounts

### DIFF
--- a/h/accounts/models.py
+++ b/h/accounts/models.py
@@ -1,51 +1,60 @@
 # -*- coding: utf-8 -*-
+from datetime import datetime
+from datetime import timedelta
 import re
 
-from hem.interfaces import IDBSession
+import cryptacular.bcrypt
 from hem.db import get_session
-from horus.interfaces import (
-    IActivationClass,
-    IUserClass,
-    IUIStrings,
-)
-from horus.models import (
-    ActivationMixin,
-    GroupMixin,
-    UserMixin,
-    UserGroupMixin,
-)
-from horus.strings import UIStringsBase
-from pyramid_basemodel import Base, Session
+from hem.interfaces import IDBSession
+from hem.text import generate_random_string
+from pyramid_basemodel import Base
+from pyramid_basemodel import Session
 import sqlalchemy as sa
 from sqlalchemy import or_
 from sqlalchemy.ext.declarative import declared_attr
+from sqlalchemy.ext.hybrid import hybrid_property
 
 
-# Silence some SQLAlchemy warnings caused by the Horus library.
-import warnings
-warnings.filterwarnings("ignore", message=r".*Unmanaged access of declarative "
-                                          "attribute __tablename__ from "
-                                          "non-mapped class UserGroupMixin")
-warnings.filterwarnings("ignore", message=r".*Unmanaged access of declarative "
-                                          "attribute __tablename__ from "
-                                          "non-mapped class GroupMixin")
-warnings.filterwarnings("ignore", message=r".*Unmanaged access of declarative "
-                                          "attribute __tablename__ from "
-                                          "non-mapped class ActivationMixin")
-warnings.filterwarnings("ignore", message=r".*Unmanaged access of declarative "
-                                          "attribute __tablename__ from "
-                                          "non-mapped class UserMixin")
+CRYPT = cryptacular.bcrypt.BCRYPTPasswordManager()
 
 
-class Activation(ActivationMixin, Base):
-    pass
+class Activation(Base):
+
+    """
+    Handles activations/password reset items for users.
+
+    The code should be a random hash that is valid only once.
+    After the hash is used to access the site, it'll be removed.
+    """
+
+    __tablename__ = 'activation'
+
+    id = sa.Column(sa.Integer, autoincrement=True, primary_key=True)
+
+    # A random hash that is valid only once.
+    code = sa.Column(sa.Unicode(30),
+                     nullable=False,
+                     unique=True,
+                     default=generate_random_string)
+
+    # FIXME: remove these unused columns
+    created_by = sa.Column(sa.Unicode(30), nullable=False, default=u'web')
+    valid_until = sa.Column(sa.DateTime,
+                            nullable=False,
+                            default=datetime.utcnow() + timedelta(days=3))
+
+    @classmethod
+    def get_by_code(cls, request, code):
+        """Fetch an activation by code."""
+        session = get_session(request)
+        return session.query(cls).filter(cls.code == code).first()
 
 
-class Group(GroupMixin, Base):
-    pass
+class User(Base):
+    __tablename__ = 'user'
 
+    id = sa.Column(sa.Integer, autoincrement=True, primary_key=True)
 
-class User(UserMixin, Base):
     # Normalised user identifier
     uid = sa.Column(sa.Unicode(30), nullable=False, unique=True)
     # Username as chosen by the user on registration
@@ -73,13 +82,128 @@ class User(UserMixin, Base):
                               descriptor=property(self._get_username,
                                                   self._set_username))
 
+    email = sa.Column(sa.Unicode(100), nullable=False, unique=True)
+    status = sa.Column(sa.Integer())
+
+    last_login_date = sa.Column(sa.TIMESTAMP(timezone=False),
+                                default=sa.func.now(),
+                                server_default=sa.func.now(),
+                                nullable=False)
+    registered_date = sa.Column(sa.TIMESTAMP(timezone=False),
+                                default=sa.sql.func.now(),
+                                server_default=sa.func.now(),
+                                nullable=False)
+
+    # Activation foreign key
+    activation_id = sa.Column(sa.Integer, sa.ForeignKey(Activation.id))
+    activation = sa.orm.relationship('Activation', backref='user')
+
+    @property
+    def is_activated(self):
+        if self.activation_id is None:
+            return True
+
+        return False
+
+    # Hashed password
+    _password = sa.Column('password', sa.Unicode(256), nullable=False)
+    # Password salt
+    salt = sa.Column(sa.Unicode(256), nullable=False)
+
+    @hybrid_property
+    def password(self):
+        return self._password
+
+    @password.setter
+    def password(self, value):
+        self._set_password(value)
+
+    def _get_password(self):
+        return self._password
+
+    def _set_password(self, raw_password):
+        self._password = self._hash_password(raw_password)
+
+    def _hash_password(self, password):
+        if not self.salt:
+            self.salt = generate_random_string(24)
+
+        return unicode(CRYPT.encode(password + self.salt))
+
+    @classmethod
+    def generate_random_password(cls, chars=12):
+        """Generate a random string of fixed length."""
+        return generate_random_string(chars)
+
+    @classmethod
+    def get_by_email(cls, request, email):
+        """Fetch a user by email address."""
+        session = get_session(request)
+
+        return session.query(cls).filter(
+            sa.func.lower(cls.email) == email.lower()
+        ).first()
+
+    @classmethod
+    def get_by_email_password(cls, request, email, password):
+        """Fetch a user by email address and validate their password."""
+        user = cls.get_by_email(request, email)
+
+        if user:
+            valid = cls.validate_user(user, password)
+
+            if valid:
+                return user
+
+    @classmethod
+    def get_by_activation(cls, request, activation):
+        """Fetch a user by activation instance."""
+        session = get_session(request)
+
+        user = session.query(cls).filter(
+            cls.activation_id == activation.id_value
+        ).first()
+
+        return user
+
+    @classmethod
+    def get_user(cls, request, username, password):
+        """Fetch a user by username and validate their password."""
+        user = cls.get_by_username(request, username)
+
+        valid = cls.validate_user(user, password)
+
+        if valid:
+            return user
+
+    @classmethod
+    def validate_user(cls, user, password):
+        """Validate the passed password for the specified user."""
+        if not user:
+            return None
+
+        if user.password is None:
+            valid = False
+        else:
+            valid = CRYPT.check(user.password, password + user.salt)
+
+        return valid
+
     @classmethod
     def get_by_id(cls, request, userid):
+        """
+        Fetch a user by integer id or by full `userid`.
+
+        If `userid` is a string of the form "acct:name@domain.tld" and
+        "domain.tld" is the app's current domain, then fetch the user with
+        username "name". Otherwise, lookup the user with integer primary key
+        `userid`.
+        """
         match = re.match(r'acct:([^@]+)@{}'.format(request.domain), userid)
         if match:
             return cls.get_by_username(request, match.group(1))
-        else:
-            return super(User, cls).get_by_id(request, userid)
+        session = get_session(request)
+        return session.query(cls).filter(cls.id == userid).first()
 
     @classmethod
     def get_by_username(cls, request, username):
@@ -145,6 +269,9 @@ class User(UserMixin, Base):
         else:
             self.status = (self.status or 0) & ~0b1000
 
+    def __repr__(self):
+        return '<User: %s>' % self.username
+
 
 def _username_to_uid(username):
     # We normalise usernames by dots and case in order to discourage attempts
@@ -152,20 +279,8 @@ def _username_to_uid(username):
     return username.replace('.', '').lower()
 
 
-class UserGroup(UserGroupMixin, Base):
-    pass
-
-
 def includeme(config):
     registry = config.registry
 
-    models = [
-        (IActivationClass, Activation),
-        (IUserClass, User),
-        (IUIStrings, UIStringsBase),
-        (IDBSession, Session),
-    ]
-
-    for iface, imp in models:
-        if not registry.queryUtility(iface):
-            registry.registerUtility(imp, iface)
+    if not registry.queryUtility(IDBSession):
+        registry.registerUtility(Session, IDBSession)

--- a/h/accounts/test/views_test.py
+++ b/h/accounts/test/views_test.py
@@ -7,18 +7,6 @@ import pytest
 import deform
 from pyramid import httpexceptions
 from pyramid.testing import DummyRequest
-from horus.interfaces import (
-    IActivationClass,
-    IProfileForm,
-    IProfileSchema,
-    IRegisterForm,
-    IRegisterSchema,
-    IUIStrings,
-    IUserClass,
-)
-from horus.schemas import ProfileSchema
-from horus.forms import SubmitForm
-from horus.strings import UIStringsBase
 
 from h.accounts.views import ajax_form
 from h.accounts.views import validate_form
@@ -35,11 +23,6 @@ class FakeUser(object):
 
 
 def configure(config):
-    config.registry.registerUtility(UIStringsBase, IUIStrings)
-    config.registry.registerUtility(ProfileSchema, IProfileSchema)
-    config.registry.registerUtility(SubmitForm, IProfileForm)
-    config.registry.registerUtility(MagicMock(), IRegisterSchema)
-    config.registry.registerUtility(MagicMock(), IRegisterForm)
     config.registry.feature = MagicMock()
     config.registry.feature.return_value = None
 
@@ -1006,18 +989,14 @@ def subscriptions_model(request):
 def user_model(config, request):
     patcher = patch('h.accounts.views.User', autospec=True)
     request.addfinalizer(patcher.stop)
-    user = patcher.start()
-    config.registry.registerUtility(user, IUserClass)
-    return user
+    return patcher.start()
 
 
 @pytest.fixture
 def activation_model(config, request):
     patcher = patch('h.accounts.views.Activation', autospec=True)
     request.addfinalizer(patcher.stop)
-    activation = patcher.start()
-    config.registry.registerUtility(activation, IActivationClass)
-    return activation
+    return patcher.start()
 
 
 @pytest.fixture


### PR DESCRIPTION
This PR:

- removes all trace of the horus model mixins from `h.accounts.models`, adding the needed attributes and classmethods into our existing User and Activation models.
- removes all trace of horus from `h.accounts.schemas`.
- removes the unused Group and UserGroup models.
- *does not* include a migration to:
  + remove the User.security_code field (which is unused and luckily nullable)
  + remove the group and user_group tables

The lack of a migration is because we're going to need to do this in multiple stages in order to not break production:

1. migration: make any columns that are unused nullable
2. deploy and run the migration
3. remove any python model code that references those columns
4. deploy
5. migration: remove any unused columns
6. deploy and run the migration