### PR TITLE
Visually truncate long bodies and quotes

### DIFF
--- a/h/static/scripts/app.coffee
+++ b/h/static/scripts/app.coffee
@@ -98,6 +98,7 @@ module.exports = angular.module('h', [
 
 .directive('annotation', require('./directive/annotation'))
 .directive('deepCount', require('./directive/deep-count'))
+.directive('excerpt', require('./directive/excerpt'))
 .directive('formInput', require('./directive/form-input'))
 .directive('formValidate', require('./directive/form-validate'))
 .directive('markdown', require('./directive/markdown'))

--- a/h/static/scripts/directive/annotation.coffee
+++ b/h/static/scripts/directive/annotation.coffee
@@ -393,12 +393,14 @@ module.exports = [
         # Propagate changes through the counters.
         scope.$watch (-> ctrl.editing), (editing, old) ->
           if editing
+            elem.addClass('editing')
             counter.count 'edit', 1
             # Disable the filter and freeze it to always match while editing.
             if thread? and threadFilter?
               threadFilter.active(false)
               threadFilter.freeze(true)
           else if old
+            elem.removeClass('editing')
             counter.count 'edit', -1
             threadFilter?.freeze(false)
 

--- a/h/static/scripts/directive/annotation.coffee
+++ b/h/static/scripts/directive/annotation.coffee
@@ -198,6 +198,7 @@ AnnotationController = [
         when 'create'
           updateDomainModel(model, @annotation)
           onFulfilled = =>
+            $scope.$broadcast('annotationCreated')
             $rootScope.$emit('annotationCreated', model)
             @view()
           onRejected = (reason) =>
@@ -208,6 +209,7 @@ AnnotationController = [
           updateDomainModel(updatedModel, @annotation)
           onFulfilled = =>
             angular.copy(updatedModel, model)
+            $scope.$broadcast('annotationUpdated')
             $rootScope.$emit('annotationUpdated', model)
             @view()
           onRejected = (reason) =>

--- a/h/static/scripts/directive/excerpt.coffee
+++ b/h/static/scripts/directive/excerpt.coffee
@@ -1,0 +1,28 @@
+###*
+# @ngdoc directive
+# @name excerpt
+# @restrict C
+# @description Checks to see if text is overflowing its container.
+# If so, it prepends/appends expanders/collapsers.
+###
+module.exports = ->
+  link: (scope, elem, attr, ctrl) ->
+    scope.$evalAsync ->
+      if elem[0].scrollHeight > elem[0].clientHeight
+        elem.prepend angular.element '<span class="more"> More...</span>'
+        if elem.hasClass('annotation-quote')
+          offset = 6
+        else if elem.hasClass('annotation-body')
+          offset = 9
+        else offset = 0
+        elem.find('.more').css({
+            top: elem[0].clientHeight + offset
+        })
+        elem.append angular.element '<span class="less"> Less ^</span>'
+        elem.find('.more').on 'click', ->
+          $(this).hide()
+          elem.addClass('show-full-excerpt')
+        elem.find('.less').on 'click', ->
+          elem.find('.more').show()
+          elem.removeClass('show-full-excerpt')
+  restrict: 'C'

--- a/h/static/scripts/directive/excerpt.coffee
+++ b/h/static/scripts/directive/excerpt.coffee
@@ -5,10 +5,22 @@
 # @description Checks to see if text is overflowing its container.
 # If so, it prepends/appends expanders/collapsers.
 ###
-module.exports = ->
+module.exports = [ '$timeout', ($timeout) ->
   link: (scope, elem, attr, ctrl) ->
-    scope.$watch (-> elem[0].scrollHeight), (scrollHeight) ->
-      scope.$evalAsync ->
+    # Check for excerpts when annotations are created.
+    scope.$on 'annotationCreated', (event) ->
+      scope.excerpt()
+
+    # Check for excerpts when annotations are updated.
+    scope.$on 'annotationUpdated', (event) ->
+      scope.excerpt()
+
+    # Check for excerpts on thread collapse toggle.
+    scope.$on 'threadToggleCollapse', (value) ->
+      scope.excerpt()
+
+    do scope.excerpt = ->
+      $timeout ->
         if elem.find('.more').length == 0
           if elem[0].scrollHeight > elem[0].clientHeight
             elem.prepend angular.element '<span class="more"> More...</span>'
@@ -28,3 +40,4 @@ module.exports = ->
               elem.find('.more').show()
               elem.removeClass('show-full-excerpt')
   restrict: 'C'
+]

--- a/h/static/scripts/directive/excerpt.coffee
+++ b/h/static/scripts/directive/excerpt.coffee
@@ -7,22 +7,24 @@
 ###
 module.exports = ->
   link: (scope, elem, attr, ctrl) ->
-    scope.$evalAsync ->
-      if elem[0].scrollHeight > elem[0].clientHeight
-        elem.prepend angular.element '<span class="more"> More...</span>'
-        if elem.hasClass('annotation-quote')
-          offset = 6
-        else if elem.hasClass('annotation-body')
-          offset = 9
-        else offset = 0
-        elem.find('.more').css({
-            top: elem[0].clientHeight + offset
-        })
-        elem.append angular.element '<span class="less"> Less ^</span>'
-        elem.find('.more').on 'click', ->
-          $(this).hide()
-          elem.addClass('show-full-excerpt')
-        elem.find('.less').on 'click', ->
-          elem.find('.more').show()
-          elem.removeClass('show-full-excerpt')
+    scope.$watch (-> elem[0].scrollHeight), (scrollHeight) ->
+      scope.$evalAsync ->
+        if elem.find('.more').length == 0
+          if elem[0].scrollHeight > elem[0].clientHeight
+            elem.prepend angular.element '<span class="more"> More...</span>'
+            if elem.hasClass('annotation-quote')
+              offset = 6
+            else if elem.hasClass('annotation-body')
+              offset = 9
+            else offset = 0
+            elem.find('.more').css({
+                top: elem[0].clientHeight + offset
+            })
+            elem.append angular.element '<span class="less"> Less ^</span>'
+            elem.find('.more').on 'click', ->
+              $(this).hide()
+              elem.addClass('show-full-excerpt')
+            elem.find('.less').on 'click', ->
+              elem.find('.more').show()
+              elem.removeClass('show-full-excerpt')
   restrict: 'C'

--- a/h/static/scripts/directive/thread.coffee
+++ b/h/static/scripts/directive/thread.coffee
@@ -13,7 +13,8 @@ uuid = require('node-uuid')
 # the collapsing behavior.
 ###
 ThreadController = [
-  ->
+  '$scope',
+  ($scope) ->
     @container = null
     @collapsed = true
     @parent = null
@@ -33,6 +34,7 @@ ThreadController = [
                  !!value
                else
                  not @collapsed
+      $scope.$broadcast('threadToggleCollapse', value)
       @collapsed = newval
 
     ###*

--- a/h/static/styles/annotations.scss
+++ b/h/static/styles/annotations.scss
@@ -66,12 +66,20 @@
 
 .annotation-quote {
   @include quote;
+  max-height: 2.9em;
+  overflow: hidden;
+
   del {
     background:#ffe6e6;
   }
   ins {
     background:#e6ffe6;
   }
+}
+
+.annotation-body {
+  max-height: 13.5em;
+  overflow: hidden;
 }
 
 .annotation-citation-domain {

--- a/h/static/styles/common.scss
+++ b/h/static/styles/common.scss
@@ -9,6 +9,7 @@ $headings-color: $text-color;
 @import 'mixins/responsive';
 @import 'grid';
 @import 'annotations';
+@import 'excerpt';
 @import 'forms';
 @import 'markdown-editor';
 @import 'spinner';

--- a/h/static/styles/excerpt.scss
+++ b/h/static/styles/excerpt.scss
@@ -1,0 +1,50 @@
+.excerpt {
+  position: relative;
+
+  &.show-full-excerpt {
+    max-height: 100% !important;
+  }
+
+  .more, .less {
+    color: rgba(189, 28, 43, 0.5);
+    background: #fff;
+    font-style: italic;
+    font-family: Georgia,"Bitstream Charter","Times","Times New Roman",serif;
+
+    &:hover {
+      color: #BD1C2B;
+    }
+  }
+
+  .more {
+    position: relative;
+    float: right;
+    margin-top: -1.99em;
+    -webkit-margin-end: -2em;
+
+    &:before {
+      opacity: .8;
+      content: " ";
+      margin-left: -3em;
+      padding-right: 40px;
+      background: -webkit-gradient(linear, left top, right top, from(rgba(255, 255, 255, 0)), to(white), color-stop(50%, white));
+      background: -moz-linear-gradient(to right, rgba(255, 255, 255, 0), white 50%, white);
+      background: -o-linear-gradient(to right, rgba(255, 255, 255, 0), white 50%, white);
+      background: -ms-linear-gradient(to right, rgba(255, 255, 255, 0), white 50%, white);
+      background: linear-gradient(to right, rgba(255, 255, 255, 0), white 50%, white);
+    }
+  }
+}
+
+// Hide excerpts when editing annotation.
+.editing {
+  .annotation-body {
+    .more {
+      display: none;
+    }
+    .less {
+      display: none;
+    }
+  }
+}
+

--- a/h/templates/client/annotation.html
+++ b/h/templates/client/annotation.html
@@ -56,7 +56,7 @@
 <!-- Excerpts -->
 <section class="annotation-section"
          ng-repeat="target in vm.annotation.target track by $index">
-  <blockquote class="annotation-quote"
+  <blockquote class="annotation-quote excerpt"
               ng-hide="target.diffHTML && vm.showDiff"
               ng-bind-html="selector.exact"
               ng-repeat="selector in target.selector
@@ -77,7 +77,7 @@
 
 <!-- Body -->
 <section name="text"
-         class="annotation-body"
+         class="annotation-body excerpt"
          ng-model="vm.annotation.text"
          ng-readonly="!vm.editing"
          markdown>


### PR DESCRIPTION
- Introduce collapsing bodies and quotes which expand when you click more.
- Meant to resolve #487 
- Uses CSS only to truncate the quotes.

Dokku here: http://more-less.dokku.hypothes.is/

Notes:
While implementing this, I attempted to follow the approach laid out in #487 (mostly succeeding). However, I ran into a problem with excerpts in the annotation body: *sometimes* overflow hidden will cause text to be cut in half. This is because we support stylized text (and thus have varying lineheights, font sizes, etc). 

To address this in this first attempt, I implemented a small gradient at the bottom of long bodies where the "More..." text appears like so:
![Annotation with long quote and long body](https://cloud.githubusercontent.com/assets/521978/8137778/9c753a30-10fa-11e5-8310-661e1ec70068.png)

I'm open to other ideas and suggestions.

We still need to determine how long we want the annotation bodies to be. I think there is general agreement that we want them to be longer than the quotes. I'm curious as to how people feel about card length after playing around with the dokku. 