### PR TITLE
Small ux improvements

### DIFF
--- a/h/static/styles/common.scss
+++ b/h/static/styles/common.scss
@@ -183,7 +183,7 @@ html {
     a {
       display: block;
       line-height: 1;
-      padding: .5em;
+      padding: 1em;
       white-space: nowrap;
     }
 

--- a/h/templates/client/annotation.html
+++ b/h/templates/client/annotation.html
@@ -10,7 +10,6 @@
        >{{vm.annotation.user | persona}}</a>
     <i class="h-icon-lock" ng-show="vm.isPrivate() && !vm.editing"></i>
     <i class="h-icon-border-color" ng-show="vm.isHighlight() && !vm.editing"></i>
-    <i class="h-icon-insert-comment" ng-show="vm.isComment()"></i>
     <span class="annotation-citation"
           ng-if="!vm.embedded"
           ng-show="vm.document.title">

--- a/h/templates/client/annotation.html
+++ b/h/templates/client/annotation.html
@@ -9,7 +9,7 @@
        ng-href="{{vm.baseURI}}u/{{vm.annotation.user}}"
        >{{vm.annotation.user | persona}}</a>
     <i class="h-icon-lock" ng-show="vm.isPrivate() && !vm.editing"></i>
-    <i class="h-icon-border-color" ng-show="vm.isHighlight() && !vm.editing"></i>
+    <i class="h-icon-border-color" ng-show="vm.isHighlight() && !vm.editing" title="This is a highlight. Click 'edit' to add a note or tag."></i>
     <span class="annotation-citation"
           ng-if="!vm.embedded"
           ng-show="vm.document.title">


### PR DESCRIPTION
There are 3 small things in this PR:
1. Kill note icon on card: *It was the same as the icon for make new note... which was confusing, and arguably did little to help people understand what was going on.* We obviously still need something else with regards to distinguishing page comments, but that's a separate issue.
![Comment, without note icon](https://cloud.githubusercontent.com/assets/521978/8259304/557da3ee-1670-11e5-8ba0-40bea6f399d7.png)

2. Slightly more padding on menus: *with mobile I like to have more padding on the menus so that it is easier to select things with my big fingers on a small screen.*
![More padding on menus](https://cloud.githubusercontent.com/assets/521978/8259388/f84f7796-1670-11e5-9ab1-22bc68b6844a.png)

3. Adding a tooltip to the highlight icon:
![Tooltip on card highlight icon](https://cloud.githubusercontent.com/assets/521978/8259494/cd4ccd54-1671-11e5-9812-6c9295bd6808.png)

Thoughts? Hopefully these aren't too controversial.
