### PR TITLE
Don't unconditionally search for http://example.com/

### DIFF
--- a/h/api/search.py
+++ b/h/api/search.py
@@ -31,7 +31,7 @@ def _match_clause_for_uri(uri):
             }
         }
     else:
-        return {"match": {"uri": "http://example.com/"}}
+        return {"match": {"uri": uri}}
 
 
 def build_query(request_params):

--- a/h/api/test/search_test.py
+++ b/h/api/test/search_test.py
@@ -242,12 +242,17 @@ def test_build_query_for_uri(models):
     """
     models.Document.get_by_uri.return_value = None
 
-    query = search.build_query(
+    query1 = search.build_query(
         request_params=multidict.NestedMultiDict(
             {"uri": "http://example.com/"}))
+    query2 = search.build_query(
+        request_params=multidict.NestedMultiDict(
+            {"uri": "http://whitehouse.gov/"}))
 
-    assert query["query"] == {
+    assert query1["query"] == {
         "bool": {"must": [{"match": {"uri": "http://example.com/"}}]}}
+    assert query2["query"] == {
+        "bool": {"must": [{"match": {"uri": "http://whitehouse.gov/"}}]}}
 
 
 @mock.patch("h.api.search.models")


### PR DESCRIPTION
When we fail to find a document for the passed URI, we should probably
fall back to a naive match query for the passed URI, rather than a naive
match query for the literal string "http://example.com/".

...!

Fixes #2326.