### PR TITLE
Atom feed link tweaks

### DIFF
--- a/h/atom_feed.py
+++ b/h/atom_feed.py
@@ -113,6 +113,10 @@ def _feed_entry_from_annotation(
         entry["links"].append({"rel": "alternate", "type": "application/json",
                                "href": annotation_api_url(annotation)})
 
+    for target in annotation.get('target'):
+        entry["links"].append({"rel": "related",
+                               "href": target.get('source')})
+
     return entry
 
 

--- a/h/atom_feed.py
+++ b/h/atom_feed.py
@@ -82,12 +82,10 @@ def _feed_entry_from_annotation(
     }
 
     def get_selection(annotation):
-        targets = annotation.get("target")
-        if targets:
-            for target in targets:
-                for selector in target["selector"]:
-                    if "exact" in selector:
-                        return selector["exact"]
+        for target in annotation.get("target", []):
+            for selector in target["selector"]:
+                if "exact" in selector:
+                    return selector["exact"]
 
     content = ""
 
@@ -113,7 +111,7 @@ def _feed_entry_from_annotation(
         entry["links"].append({"rel": "alternate", "type": "application/json",
                                "href": annotation_api_url(annotation)})
 
-    for target in annotation.get('target'):
+    for target in annotation.get('target', []):
         entry["links"].append({"rel": "related",
                                "href": target.get('source')})
 

--- a/h/templates/atom.xml
+++ b/h/templates/atom.xml
@@ -13,7 +13,7 @@ render the feed to Atom XML.
   <updated>{{ feed.updated }}</updated>
 
   {% for link in feed.links %}
-  <link rel="{{ link.rel }}" type="{{ link.type }}" href="{{ link.href }}" />
+  <link rel="{{ link.rel }}" {% if link.type %}type="{{ link.type }}"{% endif %} type="{{ link.type }}" href="{{ link.href }}" />
   {% endfor %}
 
   {% for entry in feed.entries %}
@@ -26,7 +26,7 @@ render the feed to Atom XML.
       <name>{{ entry.author.name }}</name>
     </author>
     {% for link in entry.links %}
-    <link rel="{{ link.rel }}" type="{{ link.type }}" href="{{ link.href }}" />
+    <link rel="{{ link.rel }}" {% if link.type %}type="{{ link.type }}"{% endif %} href="{{ link.href }}" />
     {% endfor %}
     <content type="html">
         {# This is already HTML-escaped in Python, so we don't escape it again

--- a/h/test/atom_feed_test.py
+++ b/h/test/atom_feed_test.py
@@ -336,3 +336,23 @@ def test_annotation_with_non_unicode_characters():
     assert exact_text in entry["content"]
     assert entry["title"] == document_title
     assert text in entry["content"]
+
+
+def test_annotation_with_targets():
+    annotation = factories.Annotation()
+    annotation2 = factories.Annotation()
+
+    target1 = annotation["target"][0]
+    target2 = annotation2["target"][0]
+
+    annotation["target"] = [target1, target2]
+
+    feed = atom_feed._feed_from_annotations(
+        [annotation], atom_url=None,
+        annotation_url=_mock_annotation_url_function())
+
+    assert len(feed["entries"][0]["links"]) == 3
+    assert feed["entries"][0]["links"][1]["rel"] == "related"
+    assert feed["entries"][0]["links"][1]["href"] == target1["source"]
+    assert feed["entries"][0]["links"][2]["rel"] == "related"
+    assert feed["entries"][0]["links"][2]["href"] == target2["source"]


### PR DESCRIPTION
Hopefully fixing some `<link rel="">` issues with the Atom feed.

I chose to use the URI for `oa:hasTarget` as the `rel` value for the annotated resource. It's the most accurate link relation I could find. :smile_cat: 

If someone could give this a quick test run too, I'd appreciate it...my `h` dev environs are still a tangle...

Thanks!