### PR TITLE
Fix incorrect API URL in Atom feed entry link

### DIFF
--- a/h/atom_feed.py
+++ b/h/atom_feed.py
@@ -182,7 +182,7 @@ def render_annotations(
 
     def annotation_api_url(annotation):
         """Return the JSON API URL for the given annotation."""
-        return request.resource_url(request.root, "api", "annotation",
+        return request.resource_url(request.root, "api", "annotations",
                                     annotation["id"])
 
     feed = _feed_from_annotations(


### PR DESCRIPTION
Fixes #2327 

Pulled out of https://github.com/hypothesis/h/pull/2338 to unblock the bug fix.