### PR TITLE
Add a search API test

### DIFF
--- a/h/api/test/search_test.py
+++ b/h/api/test/search_test.py
@@ -354,6 +354,29 @@ def test_build_query_with_evil_arguments():
     assert query["query"] == {'bool': {'must': [{'match_all': {}}]}}
 
 
+def test_build_query_with_arbitrary_params():
+    """You can pass any ?foo=bar param to the search API.
+
+    Arbitrary parameters that aren't handled specially are simply passed to
+    Elasticsearch as match clauses. This way search queries can match against
+    any fields in the Elasticsearch object.
+
+    """
+    params = multidict.NestedMultiDict({"foo.bar": "arbitrary"})
+
+    query = search.build_query(request_params=params)
+
+    assert query["query"] == {
+        'bool': {
+            'must': [
+                {
+                    'match': {'foo.bar': 'arbitrary'}
+                }
+            ]
+        }
+    }
+
+
 @mock.patch("annotator.annotation.Annotation.search_raw")
 def test_search_with_user_object(search_raw):
     """If search() gets a user arg it passes it to search_raw().


### PR DESCRIPTION
Add a simple test for an untested search API feature.

I noticed from [thread on h-dev](https://groups.google.com/a/list.hypothes.is/forum/#!topic/dev/FnIhr8CPyHk) that our search API apparently has an (undocumented?) `uri.parts` param. This is something that I missed when adding tests for the search API before refactoring it. On investigation the way it works seems to be:

1. The search API accepts any arbitrary arguments, ?foo=bar etc, and they end up as match clauses in the Elasticsearch query. (The search API/query building code in h knows nothing about a uri.parts parameter.)

2. Some Elasticseatch mapping/analyzer stuff going on in models.py that I guess inserts a uri.parts fields into the documents so that search queries for uri.parts have something to match against. I don't fully understand what's going on here yet (involves Elasticsearch features I don't know yet).

This PR adds a test for 1 at least, which I think is the only thing I missed when writing the search API tests as far as this uri.parts param is concerned.

I'd like to understand 2 better and maybe get this uri.parts param (and any other hidden search params) documented.
