### PR TITLE
Be slightly more defensive when processing annotations for the atom feed.

### DIFF
--- a/h/atom_feed.py
+++ b/h/atom_feed.py
@@ -82,8 +82,18 @@ def _feed_entry_from_annotation(
     }
 
     def get_selection(annotation):
-        for target in annotation.get("target", []):
-            for selector in target["selector"]:
+        targets = annotation.get("target")
+        if not isinstance(targets, list):
+            return
+        for target in targets:
+            if not isinstance(target, dict):
+                continue
+            selectors = target.get("selector")
+            if not isinstance(selectors, list):
+                continue
+            for selector in selectors:
+                if not isinstance(selector, dict):
+                    continue
                 if "exact" in selector:
                     return selector["exact"]
 
@@ -111,9 +121,15 @@ def _feed_entry_from_annotation(
         entry["links"].append({"rel": "alternate", "type": "application/json",
                                "href": annotation_api_url(annotation)})
 
-    for target in annotation.get('target', []):
-        entry["links"].append({"rel": "related",
-                               "href": target.get('source')})
+    targets = annotation.get("target")
+    if isinstance(targets, list):
+        for target in targets:
+            if not isinstance(target, dict):
+                continue
+            source = target.get("source")
+            if source is None:
+                continue
+            entry["links"].append({"rel": "related", "href": source})
 
     return entry
 

--- a/h/test/atom_feed_test.py
+++ b/h/test/atom_feed_test.py
@@ -356,3 +356,22 @@ def test_annotation_with_targets():
     assert feed["entries"][0]["links"][1]["href"] == target1["source"]
     assert feed["entries"][0]["links"][2]["rel"] == "related"
     assert feed["entries"][0]["links"][2]["href"] == target2["source"]
+
+
+def test_malformed_target():
+    # This annotation has a broken target (a dict instead of a list), but we
+    # shouldn't explode in this case.
+    annotation = factories.Annotation()
+    annotation['target'] = {
+        'selector': [
+            {'start': None, 'end': None, 'type': 'TextPositionSelector'},
+            {'exact': None, 'prefix': None, 'type': 'TextQuoteSelector', 'suffix': None}
+        ]
+    }
+
+    feed = atom_feed._feed_from_annotations(
+        [annotation],
+        atom_url=None,
+        annotation_url=_mock_annotation_url_function())
+
+    assert len(feed["entries"]) == 1


### PR DESCRIPTION
When processing annotations for the Atom feed, we need to be slightly
more defensive -- the assumptions we'd like to make about annotation
structure aren't always true.

Fixes https://app.getsentry.com/hypothesis/prod/group/68815541/.