### PR TITLE
Faster api

### DIFF
--- a/h/api/search.py
+++ b/h/api/search.py
@@ -124,10 +124,13 @@ def search(request_params, user=None):
               request_params.get('uri'))
 
     query = build_query(request_params)
-    results = models.Annotation.search_raw(query, user=user)
-    count = models.Annotation.search_raw(query, {'search_type': 'count'},
-                                         raw_result=True)
-    return {"rows": results, "total": count["hits"]["total"]}
+    results = models.Annotation.search_raw(query, user=user, raw_result=True)
+
+    total = results['hits']['total']
+    docs = results['hits']['hits']
+    rows = [models.Annotation(d['_source'], id=d['_id']) for d in docs]
+
+    return {"rows": rows, "total": total}
 
 
 def index(user=None):

--- a/h/app.py
+++ b/h/app.py
@@ -5,7 +5,6 @@ import logging
 import os
 
 from pyramid.config import Configurator
-from pyramid.renderers import JSON
 from pyramid.wsgi import wsgiapp2
 
 from h.api.middleware import permit_cors
@@ -97,7 +96,6 @@ def create_api(global_config, **settings):
     config.set_authorization_policy(acl_authz)
     config.set_root_factory('h.api.resources.create_root')
 
-    config.add_renderer('json', JSON(indent=4))
     config.add_subscriber('h.api.subscribers.set_user_from_oauth',
                           'pyramid.events.ContextFound')
     config.add_tween('h.api.tweens.auth_token')

--- a/h/test/views_test.py
+++ b/h/test/views_test.py
@@ -170,16 +170,16 @@ class TestStreamAtomView(object):
         views.stream_atom(request)
 
         params = request.api_client.get.call_args[1]["params"]
-        assert params["limit"] == 1000
+        assert "limit" in params
 
     def test_it_forwards_user_supplied_limits(self):
         """User-supplied ``limit`` params should be forwarded.
 
-        If the user supplies a ``limit`` param < 1000 this should be forwarded
+        If the user supplies a ``limit`` param < 500 this should be forwarded
         to the search API.
 
         """
-        for limit in (0, 500, 1000):
+        for limit in (0, 250, 500):
             request = mock.MagicMock()
             request.params = {"limit": limit}
 
@@ -188,22 +188,22 @@ class TestStreamAtomView(object):
             params = request.api_client.get.call_args[1]["params"]
             assert params["limit"] == limit
 
-    def test_it_ignores_limits_greater_than_1000(self):
-        """It doesn't let the user specify a ``limit`` > 1000.
+    def test_it_ignores_limits_greater_than_500(self):
+        """It doesn't let the user specify a ``limit`` > 500.
 
-        It just reduces the limit to 1000.
+        It just reduces the limit to 500.
 
         """
         request = mock.MagicMock()
-        request.params = {"limit": 1001}
+        request.params = {"limit": 501}
 
         views.stream_atom(request)
 
         params = request.api_client.get.call_args[1]["params"]
-        assert params["limit"] == 1000
+        assert params["limit"] == 500
 
-    def test_it_falls_back_to_1000_if_limit_is_invalid(self):
-        """If the user gives an invalid limit value it falls back to 1000."""
+    def test_it_falls_back_to_100_if_limit_is_invalid(self):
+        """If the user gives an invalid limit value it falls back to 100."""
         for limit in ("not a valid integer", None, [1, 2, 3]):
             request = mock.MagicMock()
             request.params = {"limit": limit}
@@ -211,17 +211,17 @@ class TestStreamAtomView(object):
             views.stream_atom(request)
 
             params = request.api_client.get.call_args[1]["params"]
-            assert params["limit"] == 1000
+            assert params["limit"] == 100
 
-    def test_it_falls_back_to_1000_if_limit_is_negative(self):
-        """If given a negative number for limit it falls back to 1000."""
+    def test_it_falls_back_to_100_if_limit_is_negative(self):
+        """If given a negative number for limit it falls back to 100."""
         request = mock.MagicMock()
         request.params = {"limit": -50}
 
         views.stream_atom(request)
 
         params = request.api_client.get.call_args[1]["params"]
-        assert params["limit"] == 1000
+        assert params["limit"] == 100
 
     def test_it_forwards_url_params_to_the_api(self):
         """Any URL params are forwarded to the search API."""

--- a/h/views.py
+++ b/h/views.py
@@ -153,14 +153,17 @@ def stream_atom(request):
     params = dict(request.params)
 
     # The maximum value that this function allows the limit param.
-    max_limit = 1000
+    default_limit = 100
+    max_limit = 500
 
     try:
-        params["limit"] = int(params.get("limit", max_limit))
+        params["limit"] = int(params.get("limit", default_limit))
     except (ValueError, TypeError):
-        params["limit"] = max_limit
+        params["limit"] = default_limit
 
-    if not 0 <= params["limit"] <= max_limit:
+    if params["limit"] < 0:
+        params["limit"] = default_limit
+    if params["limit"] > max_limit:
         params["limit"] = max_limit
 
     try:


### PR DESCRIPTION
The stream atom feed is currently timing out in production. There is a bunch of different stuff going on here (including the fact that the atom feed makes requests to our API by going out to the public internet and back in rather than directly to the service running on the same host...) but benchmarking suggests that the two biggest sources of slowness are:

1. JSON serialisation (specifically "pretty" output)
2. Making two identical queries to ElasticSearch instead of one...

In addition, I think 1000 annotations in the atom feed is probably a bit much -- an atom feed approaching a megabyte seems excessive. I've dropped the default number of annotations to 100.

With these three changes we go from about 1 request per second...

```
$ wrk -c1 -d10s -t1 'http://localhost:5000/stream.atom'
Running 10s test @ http://localhost:5000/stream.atom
  1 threads and 1 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   727.94ms   31.91ms 772.22ms   53.85%
    Req/Sec     1.00      0.00     1.00    100.00%
  13 requests in 10.09s, 10.79MB read
Requests/sec:      1.29
Transfer/sec:      1.07MB
```

...to about 13:

```
$ wrk -c1 -d10s -t1 'http://localhost:5000/stream.atom'
Running 10s test @ http://localhost:5000/stream.atom
  1 threads and 1 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    71.99ms   17.25ms 159.24ms   95.10%
    Req/Sec    13.58      5.06    20.00     57.29%
  139 requests in 10.03s, 12.61MB read
Requests/sec:     13.86
Transfer/sec:      1.26MB
```