### PR TITLE
Fix tooltip on share icon.

### DIFF
--- a/h/templates/app.html
+++ b/h/templates/app.html
@@ -10,9 +10,10 @@
     <div class="inner content">
       <div class="pull-left">
         <button class="btn btn-clean"
-              ng-click="shareDialog.visible = !shareDialog.visible"
-              ng-show="showShareButton"
-              ><i href="" title="Share this page" class="h-icon-share btn-icon"></i></button>
+                ng-click="shareDialog.visible = !shareDialog.visible"
+                ng-show="showShareButton"
+                title="Share this page">
+                <i class="h-icon-share btn-icon"></i></button>
       </div>
 
       <div class="pull-right" ng-switch="auth.user">


### PR DESCRIPTION
On Firefox, the tool-tip for the share icon *wasn't showing* due to the title attribute being on the icon rather than the button. This resolves the issue.

