### PR TITLE
Proper feature flags

### DIFF
--- a/conf/development.ini
+++ b/conf/development.ini
@@ -22,11 +22,6 @@ es.host: http://localhost:9200
 
 h.autologin: True
 
-h.feature.claim: False
-h.feature.notification: False
-h.feature.queue: False
-h.feature.streamer: False
-
 mail.default_sender: "Annotation Daemon" <no-reply@localhost>
 
 pyramid.debug_all: True

--- a/conf/development.ini
+++ b/conf/development.ini
@@ -22,8 +22,6 @@ es.host: http://localhost:9200
 
 h.autologin: True
 
-h.feature.accounts: True
-h.feature.api: True
 h.feature.claim: False
 h.feature.notification: False
 h.feature.queue: False

--- a/conf/production.ini
+++ b/conf/production.ini
@@ -18,8 +18,6 @@ use: egg:h
 #h.client_secret:
 
 # Feature flags
-h.feature.accounts: True
-h.feature.api: True
 h.feature.claim: False
 h.feature.notification: True
 h.feature.queue: True

--- a/conf/production.ini
+++ b/conf/production.ini
@@ -17,12 +17,6 @@ use: egg:h
 #h.client_id:
 #h.client_secret:
 
-# Feature flags
-h.feature.claim: False
-h.feature.notification: True
-h.feature.queue: True
-h.feature.streamer: True
-
 # Mail server configuration -- see the pyramid_mailer documentation
 mail.default_sender: "Annotation Daemon" <no-reply@localhost>
 #mail.host: localhost

--- a/conf/testext.ini
+++ b/conf/testext.ini
@@ -1,8 +1,6 @@
 [app:main]
 use: egg:h
 
-h.feature.accounts: True
-h.feature.api: True
 h.feature.claim: True
 h.feature.notification: True
 h.feature.queue: True

--- a/conf/testext.ini
+++ b/conf/testext.ini
@@ -1,11 +1,6 @@
 [app:main]
 use: egg:h
 
-h.feature.claim: True
-h.feature.notification: True
-h.feature.queue: True
-h.feature.streamer: True
-
 sqlalchemy.url: sqlite://
 
 webassets.base_dir: h:static

--- a/h/accounts/test/views_test.py
+++ b/h/accounts/test/views_test.py
@@ -8,6 +8,7 @@ import deform
 from pyramid import httpexceptions
 from pyramid.testing import DummyRequest as _DummyRequest
 
+from h.conftest import DummyFeature
 from h.conftest import DummySession
 
 from h.accounts.views import ajax_form
@@ -20,8 +21,12 @@ from h.accounts.views import ProfileController
 
 class DummyRequest(_DummyRequest):
     def __init__(self, *args, **kwargs):
-        # Add a dummy database session to the request
-        params = {'db': DummySession()}
+        params = {
+            # Add a dummy database session to the request
+            'db': DummySession(),
+            # Add a dummy feature flag querier to the request
+            'feature': DummyFeature(),
+        }
         params.update(kwargs)
         super(DummyRequest, self).__init__(*args, **params)
 
@@ -30,11 +35,6 @@ class FakeUser(object):
     def __init__(self, **kwargs):
         for k in kwargs:
             setattr(self, k, kwargs[k])
-
-
-def configure(config):
-    config.registry.feature = MagicMock()
-    config.registry.feature.return_value = None
 
 
 # A fake version of colander.Invalid for use when testing validate_form

--- a/h/accounts/views.py
+++ b/h/accounts/views.py
@@ -473,7 +473,7 @@ class ProfileController(object):
         model = {}
         if userid:
             model["email"] = User.get_by_id(request, userid).email
-        if request.registry.feature('notification'):
+        if request.feature('notification'):
             model['subscriptions'] = Subscriptions.get_subscriptions_for_uri(
                 userid)
         return {'model': model}

--- a/h/api/queue.py
+++ b/h/api/queue.py
@@ -10,6 +10,11 @@ def annotation(event):
     request = event.request
     annotation = event.annotation
     action = event.action
+
+    # We only publish these events to NSQ if the 'queue' feature is enabled.
+    if not request.feature('queue'):
+        return
+
     queue = request.get_queue_writer()
     data = {
         'action': action,

--- a/h/app.py
+++ b/h/app.py
@@ -58,19 +58,17 @@ def create_app(global_config, **settings):
 
     config.add_tween('h.tweens.csrf_tween_factory')
 
-    if config.registry.feature('accounts'):
-        config.set_authentication_policy(session_authn)
-        config.set_authorization_policy(acl_authz)
-        config.include('h.accounts')
+    config.set_authentication_policy(session_authn)
+    config.set_authorization_policy(acl_authz)
+    config.include('h.accounts')
 
-    if config.registry.feature('api'):
-        api_app = create_api(settings)
-        api_view = wsgiapp2(api_app)
-        config.add_view(api_view, name='api', decorator=strip_vhm)
-        # Add the view again with the 'index' route name, otherwise it will
-        # not take precedence over the index when a virtual root is in use.
-        config.add_view(api_view, name='api', decorator=strip_vhm,
-                        route_name='index')
+    api_app = create_api(settings)
+    api_view = wsgiapp2(api_app)
+    config.add_view(api_view, name='api', decorator=strip_vhm)
+    # Add the view again with the 'index' route name, otherwise it will
+    # not take precedence over the index when a virtual root is in use.
+    config.add_view(api_view, name='api', decorator=strip_vhm,
+                    route_name='index')
 
     if config.registry.feature('claim'):
         config.include('h.claim')

--- a/h/app.py
+++ b/h/app.py
@@ -61,6 +61,10 @@ def create_app(global_config, **settings):
     config.set_authentication_policy(session_authn)
     config.set_authorization_policy(acl_authz)
     config.include('h.accounts')
+    config.include('h.claim')
+    config.include('h.notification')
+    config.include('h.queue')
+    config.include('h.streamer')
 
     api_app = create_api(settings)
     api_view = wsgiapp2(api_app)
@@ -69,18 +73,6 @@ def create_app(global_config, **settings):
     # not take precedence over the index when a virtual root is in use.
     config.add_view(api_view, name='api', decorator=strip_vhm,
                     route_name='index')
-
-    if config.registry.feature('claim'):
-        config.include('h.claim')
-
-    if config.registry.feature('queue'):
-        config.include('h.queue')
-
-    if config.registry.feature('streamer'):
-        config.include('h.streamer')
-
-    if config.registry.feature('notification'):
-        config.include('h.notification')
 
     return config.make_wsgi_app()
 
@@ -102,11 +94,8 @@ def create_api(global_config, **settings):
 
     config.include('h.auth')
     config.include('h.api.db')
+    config.include('h.api.queue')
     config.include('h.api.views')
-
-    if config.registry.feature('queue'):
-        config.include('h.queue')
-        config.include('h.api.queue')
 
     app = config.make_wsgi_app()
     app = permit_cors(app,

--- a/h/assets.yaml
+++ b/h/assets.yaml
@@ -137,7 +137,7 @@ app_js:
       contents: h:static/scripts/app.coffee
       depends:
         - h:static/scripts/*.coffee
-        - h:static/scripts/*.js
+        - h:static/scripts/features.js
         - h:static/scripts/directive/*.coffee
         - h:static/scripts/directive/*.js
         - h:static/scripts/filter/*.coffee

--- a/h/assets.yaml
+++ b/h/assets.yaml
@@ -137,8 +137,11 @@ app_js:
       contents: h:static/scripts/app.coffee
       depends:
         - h:static/scripts/*.coffee
+        - h:static/scripts/*.js
         - h:static/scripts/directive/*.coffee
+        - h:static/scripts/directive/*.js
         - h:static/scripts/filter/*.coffee
+        - h:static/scripts/filter/*.js
     - config
 
 app_css:

--- a/h/claim/test/views_test.py
+++ b/h/claim/test/views_test.py
@@ -4,11 +4,23 @@ import pytest
 
 import deform
 from pytest import raises
-from pyramid.testing import DummyRequest
+from pyramid.testing import DummyRequest as _DummyRequest
 from pyramid.httpexceptions import HTTPFound, HTTPNotFound
+
+from h.conftest import DummyFeature
 
 from ..views import claim_account
 from ..views import update_account
+
+
+class DummyRequest(_DummyRequest):
+    def __init__(self, *args, **kwargs):
+        params = {
+            # Add a dummy feature flag querier to the request
+            'feature': DummyFeature(),
+        }
+        params.update(kwargs)
+        super(DummyRequest, self).__init__(*args, **params)
 
 
 def test_claim_account_returns_form():

--- a/h/claim/views.py
+++ b/h/claim/views.py
@@ -51,6 +51,7 @@ def _validate_request(request):
     Check that the passed request is appropriate for proceeding with account
     claim. Asserts that:
 
+    - the 'claim' feature is toggled on
     - no-one is logged in
     - the claim token is provided and authentic
     - the user referred to in the token exists
@@ -58,6 +59,9 @@ def _validate_request(request):
 
     and raises for redirect or 404 otherwise.
     """
+    if not request.feature('claim'):
+        raise exc.HTTPNotFound()
+
     # If signed in, redirect to stream
     if request.authenticated_userid is not None:
         _perform_logged_in_redirect(request)

--- a/h/config.py
+++ b/h/config.py
@@ -1,6 +1,5 @@
 import os
 import logging
-import re
 import urlparse
 
 from pyramid.settings import asbool
@@ -16,7 +15,6 @@ def settings_from_environment():
     _setup_db(settings)
     _setup_elasticsearch(settings)
     _setup_email(settings)
-    _setup_features(settings)
     _setup_nsqd(settings)
     _setup_redis(settings)
     _setup_secrets(settings)
@@ -112,18 +110,6 @@ def _setup_email(settings):
         mail_port = os.environ['MAIL_PORT_25_TCP_PORT']
         settings['mail.host'] = mail_host
         settings['mail.port'] = mail_port
-
-
-def _setup_features(settings):
-    # Allow feature flag overrides from the environment. For example, to
-    # override the 'foo_bar' feature you can set the environment variable
-    # FEATURE_FOO_BAR.
-    patt = re.compile(r'FEATURE_([A-Z_]+)')
-    keys = [k for k in os.environ.iterkeys() if patt.match(k)]
-    for k in keys:
-        name = 'h.feature.{}'.format(patt.match(k).group(1).lower())
-        value = asbool(os.environ[k])
-        settings[name] = value
 
 
 def _setup_nsqd(settings):

--- a/h/conftest.py
+++ b/h/conftest.py
@@ -13,6 +13,23 @@ import transaction
 from h import db
 
 
+class DummyFeature(object):
+
+    """
+    A dummy feature flag looker-upper.
+
+    Because we're probably testing all feature-flagged functionality, this
+    feature client defaults every flag to *True*, which is the exact opposite
+    of what happens outside of testing.
+    """
+
+    def __init__(self):
+        self.flags = {}
+
+    def __call__(self, name, *args, **kwargs):
+        return self.flags.get(name, True)
+
+
 class DummySession(object):
 
     """
@@ -81,17 +98,6 @@ def db_session(request, settings):
     request.addfinalizer(destroy)
 
     return db.Session
-
-
-@pytest.fixture(autouse=True)
-def feature_flags(config):
-    class DummyFeatureClient(object):
-        def __init__(self):
-            self.flags = {}
-        def __call__(self, name, *args, **kwargs):
-            return self.flags.get(name, True)
-
-    config.registry.feature = DummyFeatureClient()
 
 
 @pytest.fixture()

--- a/h/features.py
+++ b/h/features.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+from pyramid.view import view_config
 import sqlalchemy as sa
 
 from h.db import Base
@@ -61,5 +62,18 @@ def flag_enabled(request, name):
     return False
 
 
+@view_config(route_name='features_status',
+             request_method='GET',
+             accept='application/json',
+             renderer='json')
+def features_status(request):
+    """Report current feature flag values."""
+    return {k: flag_enabled(request, k) for k in FEATURES.keys()}
+
+
 def includeme(config):
     config.add_request_method(flag_enabled, name='feature')
+
+    config.add_route('features_status', '/app/features')
+
+    config.scan(__name__)

--- a/h/migrations/env.py
+++ b/h/migrations/env.py
@@ -16,16 +16,13 @@ config = context.config
 # This line sets up loggers basically.
 fileConfig(config.config_file_name)
 
-# add your model's MetaData object here
-# for 'autogenerate' support
-# from myapp import mymodel
-# target_metadata = mymodel.Base.metadata
-target_metadata = None
+# Import all model modules here in order to populate the metadata
+from h import db
+from h.accounts import models
+from h.notification import models
+from h import features
 
-# other values from the config, defined by the needs of env.py,
-# can be acquired:
-# my_important_option = config.get_main_option("my_important_option")
-# ... etc.
+target_metadata = db.Base.metadata
 
 
 def get_database_url():

--- a/h/migrations/versions/28eb759fccb5_add_feature_table.py
+++ b/h/migrations/versions/28eb759fccb5_add_feature_table.py
@@ -1,0 +1,40 @@
+"""Add feature table
+
+Revision ID: 28eb759fccb5
+Revises: 29d0200ba8a9
+Create Date: 2015-07-08 15:53:26.103767
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '28eb759fccb5'
+down_revision = '29d0200ba8a9'
+
+import os
+
+from alembic import op
+from pyramid.settings import asbool
+import sqlalchemy as sa
+
+
+def upgrade():
+    feature_table = op.create_table('feature',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('name', sa.Unicode(length=50), nullable=False),
+        sa.Column('everyone', sa.Boolean(), server_default=sa.text(u'0'), nullable=False),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('name'))
+
+    op.bulk_insert(feature_table, [
+        {'name': u'claim',
+         'everyone': asbool(os.environ.get('FEATURE_CLAIM'))},
+        {'name': u'notification',
+         'everyone': asbool(os.environ.get('FEATURE_NOTIFICATION'))},
+        {'name': u'queue',
+         'everyone': asbool(os.environ.get('FEATURE_QUEUE'))},
+        {'name': u'streamer',
+         'everyone': asbool(os.environ.get('FEATURE_STREAMER'))}])
+
+
+def downgrade():
+    op.drop_table('feature')

--- a/h/notification/test/notification_views_test.py
+++ b/h/notification/test/notification_views_test.py
@@ -1,7 +1,19 @@
 from mock import patch, Mock
 from pytest import raises
-from pyramid.testing import DummyRequest
+from pyramid.testing import DummyRequest as _DummyRequest
 from webob.cookies import SignedSerializer
+
+from h.conftest import DummyFeature
+
+
+class DummyRequest(_DummyRequest):
+    def __init__(self, *args, **kwargs):
+        params = {
+            # Add a dummy feature flag querier to the request
+            'feature': DummyFeature(),
+        }
+        params.update(kwargs)
+        super(DummyRequest, self).__init__(*args, **params)
 
 
 def configure(config):

--- a/h/notification/views.py
+++ b/h/notification/views.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from pyramid import httpexceptions as exc
 from pyramid.view import view_config
 
 from h.notification.models import Subscriptions
@@ -6,6 +7,9 @@ from h.notification.models import Subscriptions
 
 @view_config(route_name='unsubscribe', renderer='h:templates/unsubscribe.html')
 def unsubscribe(request):
+    if not request.feature('notification'):
+        raise exc.HTTPNotFound()
+
     token = request.matchdict['token']
     payload = request.registry.notification_serializer.loads(token)
 

--- a/h/notification/worker.py
+++ b/h/notification/worker.py
@@ -19,6 +19,11 @@ def run(request):
     def handle_message(reader, message=None):
         if message is None:
             return
+        # We start the reader regardless, otherwise messages will pile up in
+        # the notification channel, but we only actually handle them and try
+        # and mail them if the 'notification' feature is toggled on.
+        if not request.feature('notification'):
+            return
         data = json.loads(message.body)
         action = data['action']
         annotation = Annotation(**data['annotation'])

--- a/h/static/scripts/app-controller.coffee
+++ b/h/static/scripts/app-controller.coffee
@@ -5,18 +5,23 @@ module.exports = class AppController
   this.$inject = [
     '$controller', '$document', '$location', '$rootScope', '$route', '$scope',
     '$window',
-    'auth', 'drafts', 'identity',
+    'auth', 'drafts', 'features', 'identity',
     'permissions', 'streamer', 'annotationUI',
     'annotationMapper', 'threading'
   ]
   constructor: (
      $controller,   $document,   $location,   $rootScope,   $route,   $scope,
      $window,
-     auth,   drafts,   identity,
+     auth,   drafts,   features,   identity,
      permissions,   streamer,   annotationUI,
      annotationMapper, threading
   ) ->
     $controller('AnnotationUIController', {$scope})
+
+    # Allow all child scopes to look up feature flags as:
+    #
+    #     if ($scope.feature('foo')) { ... }
+    $scope.feature = features.flagEnabled
 
     $scope.auth = auth
     isFirstRun = $location.search().hasOwnProperty('firstrun')

--- a/h/static/scripts/app.coffee
+++ b/h/static/scripts/app.coffee
@@ -78,6 +78,8 @@ setupStreamer = [
     $http.defaults.headers.common['X-Client-Id'] = clientId
 ]
 
+setupFeatures = ['features', (features) -> features.fetch()]
+
 module.exports = angular.module('h', [
   'angulartics'
   'angulartics.google.analytics'
@@ -128,6 +130,7 @@ module.exports = angular.module('h', [
 .service('bridge', require('./bridge'))
 .service('crossframe', require('./cross-frame'))
 .service('drafts', require('./drafts'))
+.service('features', require('./features'))
 .service('flash', require('./flash'))
 .service('formRespond', require('./form-respond'))
 .service('host', require('./host'))
@@ -155,6 +158,7 @@ module.exports = angular.module('h', [
 .config(configureRoutes)
 .config(configureTemplates)
 
+.run(setupFeatures)
 .run(setupCrossFrame)
 .run(setupStreamer)
 .run(setupHost)

--- a/h/static/scripts/features.js
+++ b/h/static/scripts/features.js
@@ -1,0 +1,65 @@
+/**
+ * Feature flag client.
+ *
+ * This is a small utility which will periodically retrieve the application
+ * feature flags from a JSON endpoint in order to expose these to the
+ * client-side application.
+ *
+ * All feature flags implicitly start toggled off. When `flagEnabled` is first
+ * called (or alternatively when `fetch` is called explicitly) an XMLHTTPRequest
+ * will be made to retrieve the current feature flag values from the server.
+ * Once these are retrieved, `flagEnabled` will return current values.
+ *
+ * If `flagEnabled` is called and the cache is more than `CACHE_TTL`
+ * milliseconds old, then it will trigger a new fetch of the feature flag
+ * values. Note that this is again done asynchronously, so it is only later
+ * calls to `flagEnabled` that will return the updated values.
+ *
+ * Users of this service should assume that the value of any given flag can
+ * change at any time and should write code accordingly. Feature flags should
+ * not be cached, and should not be interrogated only at setup time.
+ */
+"use strict";
+
+var CACHE_TTL = 5 * 60 * 1000; // 5 minutes
+
+function features ($document, $http, $log) {
+    var cache = null;
+    var featuresURL = new URL('/app/features', $document.prop('baseURI'));
+
+    function fetch() {
+        $http.get(featuresURL)
+        .success(function(data) {
+            cache = [Date.now(), data];
+        })
+        .error(function() {
+            $log.warn('features service: failed to load features data');
+        });
+    }
+
+    function flagEnabled(name) {
+        // Trigger a fetch if the cache is more than CACHE_TTL milliseconds old.
+        // We don't wait for the fetch to complete, so it's not this call that
+        // will see new data.
+        if (cache === null || (Date.now() - cache[0]) > CACHE_TTL) {
+            fetch();
+        }
+
+        if (cache === null) {
+            return false;
+        }
+        var flags = cache[1];
+        if (!flags.hasOwnProperty(name)) {
+            $log.warn('features service: looked up unknown feature:', name);
+            return false;
+        }
+        return flags[name];
+    }
+
+    return {
+        fetch: fetch,
+        flagEnabled: flagEnabled
+    };
+}
+
+module.exports = ['$document', '$http', '$log', features];

--- a/h/static/scripts/test/app-controller-test.coffee
+++ b/h/static/scripts/test/app-controller-test.coffee
@@ -11,6 +11,7 @@ describe 'AppController', ->
   fakeAnnotationUI = null
   fakeAuth = null
   fakeDrafts = null
+  fakeFeatures = null
   fakeIdentity = null
   fakeLocation = null
   fakeParams = null
@@ -52,6 +53,11 @@ describe 'AppController', ->
       remove: sandbox.spy()
       all: sandbox.stub().returns([])
       discard: sandbox.spy()
+    }
+
+    fakeFeatures = {
+      fetch: sandbox.spy()
+      flagEnabled: sandbox.stub().returns(false)
     }
 
     fakeIdentity = {
@@ -97,6 +103,7 @@ describe 'AppController', ->
     $provide.value 'annotationUI', fakeAnnotationUI
     $provide.value 'auth', fakeAuth
     $provide.value 'drafts', fakeDrafts
+    $provide.value 'features', fakeFeatures
     $provide.value 'identity', fakeIdentity
     $provide.value '$location', fakeLocation
     $provide.value '$routeParams', fakeParams

--- a/h/static/scripts/test/features-test.js
+++ b/h/static/scripts/test/features-test.js
@@ -1,0 +1,103 @@
+"use strict";
+
+var mock = require('angular-mock');
+
+var assert = chai.assert;
+sinon.assert.expose(assert, {prefix: null});
+
+
+describe('h:features', function () {
+    var $httpBackend;
+    var httpHandler;
+    var features;
+    var sandbox;
+
+    before(function () {
+        angular.module('h', [])
+        .service('features', require('../features'));
+    });
+
+    beforeEach(mock.module('h'));
+
+    beforeEach(mock.module(function ($provide) {
+        sandbox = sinon.sandbox.create();
+
+        var fakeDocument = {
+            prop: sandbox.stub()
+        };
+        fakeDocument.prop.withArgs('baseURI').returns('http://foo.com/');
+        $provide.value('$document', fakeDocument);
+    }));
+
+    beforeEach(mock.inject(function ($injector) {
+        $httpBackend = $injector.get('$httpBackend');
+        features = $injector.get('features');
+
+        httpHandler = $httpBackend.when('GET', 'http://foo.com/app/features');
+        httpHandler.respond(200, {foo: true, bar: false});
+    }));
+
+    afterEach(function () {
+        $httpBackend.verifyNoOutstandingExpectation();
+        $httpBackend.verifyNoOutstandingRequest();
+        sandbox.restore();
+    });
+
+    it('fetch should retrieve features data', function () {
+        $httpBackend.expect('GET', 'http://foo.com/app/features');
+        features.fetch();
+        $httpBackend.flush();
+    });
+
+    it('fetch should not explode for errors fetching features data', function () {
+        httpHandler.respond(500, "ASPLODE!");
+        features.fetch();
+        $httpBackend.flush();
+    });
+
+    it('flagEnabled should retrieve features data', function () {
+        $httpBackend.expect('GET', 'http://foo.com/app/features');
+        features.flagEnabled('foo');
+        $httpBackend.flush();
+    });
+
+    it('flagEnabled should return false initially', function () {
+        var result = features.flagEnabled('foo');
+        $httpBackend.flush();
+
+        assert.isFalse(result);
+    });
+
+    it('flagEnabled should return flag values when data is loaded', function () {
+        features.fetch();
+        $httpBackend.flush();
+
+        var foo = features.flagEnabled('foo');
+        assert.isTrue(foo);
+
+        var bar = features.flagEnabled('bar');
+        assert.isFalse(bar);
+    });
+
+    it('flagEnabled should return false for unknown flags', function () {
+        features.fetch();
+        $httpBackend.flush();
+
+        var baz = features.flagEnabled('baz');
+        assert.isFalse(baz);
+    });
+
+    it('flagEnabled should trigger a new fetch after cache expiry', function () {
+        var clock = sandbox.useFakeTimers();
+
+        $httpBackend.expect('GET', 'http://foo.com/app/features');
+        features.flagEnabled('foo');
+        $httpBackend.flush();
+
+        clock.tick(301 * 1000);
+
+        $httpBackend.expect('GET', 'http://foo.com/app/features');
+        features.flagEnabled('foo');
+        $httpBackend.flush();
+    });
+});

--- a/h/streamer.py
+++ b/h/streamer.py
@@ -461,6 +461,11 @@ class WebSocket(_WebSocket):
     def opened(self):
         transaction.commit()  # Release the database transaction
 
+        # The websocket server runs regardless, but we don't attempt to connect
+        # to NSQ unless 'streamer' is toggled on.
+        if not self.request.feature('streamer'):
+            return
+
         if self.event_queue is None:
             self.start_reader(self.request)
 

--- a/h/subscribers.py
+++ b/h/subscribers.py
@@ -8,7 +8,7 @@ def add_renderer_globals(event):
     # Set the service url to use for API discovery
     event['service_url'] = request.resource_url(request.root, 'api', '')
     # Allow templates to check for feature flags
-    event['feature'] = request.registry.feature
+    event['feature'] = request.feature
 
     # Add Google Analytics
     ga_tracking_id = request.registry.settings.get('ga_tracking_id')

--- a/h/templates/app.html
+++ b/h/templates/app.html
@@ -61,9 +61,7 @@
                  ng-controller="AccountController"
                  ng-model="tab">
               {{ include_raw("h:templates/client/settings/account.html") }}
-              {% if feature('notification') %}
-                {{ include_raw("h:templates/client/settings/notifications.html") }}
-              {% endif %}
+              {{ include_raw("h:templates/client/settings/notifications.html") }}
             </div>
           {% endblock %}
         </div>

--- a/h/templates/client/settings/notifications.html
+++ b/h/templates/client/settings/notifications.html
@@ -1,4 +1,4 @@
-<div class="tab-pane" title="Notifications">
+<div ng-if="feature('notification')" class="tab-pane" title="Notifications">
   <form class="account-form form" name="notificationsForm">
     <p class="form-description">Receive notification emails when:</p>
     <div class="form-field form-checkbox-list">


### PR DESCRIPTION
The way we had implemented feature flags was pretty inflexible, and
wasn't effectively allowing us to do the one thing that feature flags
are really intended to do, namely:

> Decouple deployment (when you push code to production) from release
> (when users see new features).

A truly effective feature flag system is one which achieves the above,
and also enables more dynamic options for "releasing" such as:

- release to admin users/beta users only
- release to a randomly selected 10% of users
- release only to one specific user

This requires that the feature flag system have some knowledge of the
accounts system.

Furthermore, in order to make the feature flag system truly atomic and
reversible (i.e. shit has gone wrong, let's flip that back) we need to
be able to toggle feature flags instantly, without needing to wait for
an application redeploy.

Both of these requirements indicate a feature flag system fully
integrated with the request-response cycle of the application, and one
where flag status can be more complex than a simple boolean.

In order to make this possible, this commit puts feature flags into a
"feature" table of the main application database. This allows us to
extend the definition of flag state as and when we see fit to enable
some or all of the release options denoted above.

The initial state of all feature flags is off, but in order to
facilitate an easy migration path for us the data migration with this
commit will read the current state of the existing flags from the system
environment and write appropriate rows into the table.

--

For what it's worth, I've done this work now because it's very important to be able to make an atomic flip from one data store to another (such as a migration from elasticsearch to postgres), which is a piece of work I'm currently planning out.