### PR TITLE
Add .editorconfig for (optional) code assist

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,23 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+[*.{js,py}]
+charset = utf-8
+
+[*.py]
+indent_style = space
+indent_size = 4
+
+[*.js]
+indent_style = space
+indent_size = 4
+
+[Makefile]
+indent_style = tab
+
+[{package.json,.travis.yml}]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
http://editorconfig.org/

**If** a developer is using EditorConfig, then all their future edits should be more inline with our style guides--assuming I mapped that all correctly. :grin: 

@tilgovi thoughts?