### PR TITLE
Make the toolbar's note icon "New Page Note" if no selection

### DIFF
--- a/h/static/scripts/annotator/guest.coffee
+++ b/h/static/scripts/annotator/guest.coffee
@@ -265,7 +265,7 @@ module.exports = class Guest extends Annotator
     return confirm "You have selected a very short piece of text: only " + length + " chars. Are you sure you want to highlight this?"
 
   onSuccessfulSelection: (event, immediate) ->
-    document.getElementsByClassName('h-icon-insert-comment')[0].title = "New Note"
+    document.getElementsByClassName('toolbar-insert-comment')[0].title = "New Note"
     unless event?
       throw "Called onSuccessfulSelection without an event!"
     unless event.segments?
@@ -287,7 +287,7 @@ module.exports = class Guest extends Annotator
     true
 
   onFailedSelection: (event) ->
-    document.getElementsByClassName('h-icon-insert-comment')[0].title = "New Note"
+    document.getElementsByClassName('toolbar-insert-comment')[0].title = "New Page Note"
     @adder.hide()
     @selectedTargets = []
 

--- a/h/static/scripts/annotator/guest.coffee
+++ b/h/static/scripts/annotator/guest.coffee
@@ -265,6 +265,7 @@ module.exports = class Guest extends Annotator
     return confirm "You have selected a very short piece of text: only " + length + " chars. Are you sure you want to highlight this?"
 
   onSuccessfulSelection: (event, immediate) ->
+    document.getElementsByClassName('h-icon-insert-comment')[0].title = "New Note"
     unless event?
       throw "Called onSuccessfulSelection without an event!"
     unless event.segments?
@@ -286,6 +287,7 @@ module.exports = class Guest extends Annotator
     true
 
   onFailedSelection: (event) ->
+    document.getElementsByClassName('h-icon-insert-comment')[0].title = "New Note"
     @adder.hide()
     @selectedTargets = []
 

--- a/h/static/scripts/annotator/plugin/toolbar.coffee
+++ b/h/static/scripts/annotator/plugin/toolbar.coffee
@@ -49,7 +49,7 @@ class Annotator.Plugin.Toolbar extends Annotator.Plugin
           state = not @annotator.visibleHighlights
           @annotator.setVisibleHighlights state
     ,
-      "title": "New Note"
+      "title": "New Page Note"
       "class": "h-icon-insert-comment"
       "name": "insert-comment"
       "on":

--- a/h/static/scripts/annotator/plugin/toolbar.coffee
+++ b/h/static/scripts/annotator/plugin/toolbar.coffee
@@ -50,7 +50,7 @@ class Annotator.Plugin.Toolbar extends Annotator.Plugin
           @annotator.setVisibleHighlights state
     ,
       "title": "New Page Note"
-      "class": "h-icon-insert-comment"
+      "class": "h-icon-insert-comment toolbar-insert-comment"
       "name": "insert-comment"
       "on":
         "click": (event) =>

--- a/h/static/scripts/directive/annotation.coffee
+++ b/h/static/scripts/directive/annotation.coffee
@@ -142,7 +142,7 @@ AnnotationController = [
     #              if they are open.
     ###
     this.view = ->
-      window.top.document.getElementsByName('insert-comment')[0].title = "New Page Note"
+      window.top.document.getElementsByName('toolbar-insert-comment')[0].title = "New Page Note"
       @editing = false
       @action = 'view'
 

--- a/h/static/scripts/directive/annotation.coffee
+++ b/h/static/scripts/directive/annotation.coffee
@@ -142,6 +142,7 @@ AnnotationController = [
     #              if they are open.
     ###
     this.view = ->
+      window.top.document.getElementsByName('insert-comment')[0].title = "New Page Note"
       @editing = false
       @action = 'view'
 


### PR DESCRIPTION
Story: A  Hypothesis director was unaware that the toolbar's note button is the way to do page-level tagging. This aims to clarify that option.