### PR TITLE
Misc styling improvements

### DIFF
--- a/h/static/styles/common.scss
+++ b/h/static/styles/common.scss
@@ -188,7 +188,7 @@ html {
     a {
       display: block;
       line-height: 1;
-      padding: 1em;
+      padding: .8em;
       white-space: nowrap;
     }
 

--- a/h/static/styles/forms.scss
+++ b/h/static/styles/forms.scss
@@ -263,7 +263,7 @@
 // Positions the icon nicely within the button.
 .btn-icon {
   font-size: 1.4em;
-  vertical-align: top;
+  vertical-align: sub;
 }
 
 // Absolutely positions a message/icon to the left of a button.

--- a/h/static/styles/topbar.scss
+++ b/h/static/styles/topbar.scss
@@ -14,7 +14,7 @@
 
   .inner {
     * {
-      font-size: 14px;
+      font-size: 13px;
       line-height: 28px;
 
       .btn-icon {

--- a/h/templates/client/annotation.html
+++ b/h/templates/client/annotation.html
@@ -1,4 +1,4 @@
-<header class="annotation-header" ng-if="!vm.annotation.user">
+<header class="annotation-header" ng-if="!vm.annotation.user" style="margin-top:.75em">
   <strong>You must be signed in to create annotations.</strong>
 </header>
 


### PR DESCRIPTION
1.) Adjust vertical alignment of save an cancel icons.

Before:
![selection_103](https://cloud.githubusercontent.com/assets/521978/8688823/7f0050ce-2a55-11e5-95a2-e9ab2da8bb72.png)

After:
![selection_101](https://cloud.githubusercontent.com/assets/521978/8688824/7f1a639c-2a55-11e5-83e2-330c4d6cb3f2.png)



2.) Add extra space at the top of the "Sign in to create annotations" message.

Before:
![selection_100](https://cloud.githubusercontent.com/assets/521978/8688836/af874036-2a55-11e5-92b6-a503fe02e1f8.png)

After:
![selection_099](https://cloud.githubusercontent.com/assets/521978/8688839/b6b9c9aa-2a55-11e5-983a-0ad7df8d1bf2.png)


3.) Adjust font-sizes to be more visually appealing, and *slightly* reduce menu padding. Requested by @dwhly. : )

Before:
![selection_105](https://cloud.githubusercontent.com/assets/521978/8688907/4cdd1c8e-2a56-11e5-833d-1d65c9cf2f86.png)

After:
![selection_104](https://cloud.githubusercontent.com/assets/521978/8688874/02436aa2-2a56-11e5-8951-b50e186a6729.png)

