### PR TITLE
Move I18N helpers into h.i18n module

### DIFF
--- a/h/accounts/schemas.py
+++ b/h/accounts/schemas.py
@@ -5,8 +5,10 @@ import colander
 import deform
 from pyramid.session import check_csrf_token
 
-from h.models import _
+from h import i18n
 from h.accounts.models import User
+
+_ = i18n.TranslationString
 
 USERNAME_BLACKLIST = None
 

--- a/h/accounts/views.py
+++ b/h/accounts/views.py
@@ -10,8 +10,8 @@ from pyramid_mailer.message import Message
 
 from h.resources import Application
 from h.notification.models import Subscriptions
-from h.models import _
 from h import accounts
+from h import i18n
 from h.accounts.models import User
 from h.accounts.models import Activation
 from h.accounts.events import ActivationEvent
@@ -21,6 +21,8 @@ from h.accounts.events import LoginEvent
 from h.accounts.events import RegistrationEvent
 from h.accounts import schemas
 from h import session
+
+_ = i18n.TranslationString
 
 
 def ajax_form(request, result):

--- a/h/claim/views.py
+++ b/h/claim/views.py
@@ -4,11 +4,12 @@ import deform
 from pyramid import httpexceptions as exc
 from pyramid.view import view_config
 
-from . import schemas
-from ..models import _
-from ..accounts.models import User
-from ..accounts.events import LoginEvent
+from h import i18n
+from h.accounts.models import User
+from h.accounts.events import LoginEvent
+from h.claim import schemas
 
+_ = i18n.TranslationString
 
 log = logging.getLogger(__name__)
 

--- a/h/i18n.py
+++ b/h/i18n.py
@@ -1,0 +1,3 @@
+from pyramid.i18n import TranslationStringFactory
+
+TranslationString = TranslationStringFactory('hypothesis')

--- a/h/models.py
+++ b/h/models.py
@@ -1,10 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 from annotator import annotation, document
-from pyramid.i18n import TranslationStringFactory
 from pyramid.security import Allow, Authenticated, Everyone, ALL_PERMISSIONS
-
-_ = TranslationStringFactory(__package__)
 
 
 class Annotation(annotation.Annotation):


### PR DESCRIPTION
Rather than living, somewhat obscurely, in `h.models`, this commit moves
the I18N TranslationString helper into its own module, `h.i18n`.