### PR TITLE
Centralise inclusion of model modules

### DIFF
--- a/h/accounts/__init__.py
+++ b/h/accounts/__init__.py
@@ -28,7 +28,6 @@ def make_admin(user_id):
 def includeme(config):
     """A local identity provider."""
     config.include('.layouts')
-    config.include('.models')
     config.include('.schemas')
     config.include('.subscribers')
     config.include('.views')

--- a/h/accounts/models.py
+++ b/h/accounts/models.py
@@ -268,7 +268,3 @@ def _username_to_uid(username):
     # We normalise usernames by dots and case in order to discourage attempts
     # at impersonation.
     return username.replace('.', '').lower()
-
-
-def includeme(_):
-    pass

--- a/h/accounts/test/schemas_test.py
+++ b/h/accounts/test/schemas_test.py
@@ -6,7 +6,6 @@ from mock import patch
 from pyramid.exceptions import BadCSRFToken
 from pyramid.testing import DummyRequest
 
-from h.accounts import models
 from h.accounts import schemas
 
 
@@ -21,8 +20,6 @@ def csrf_request(config):
 
 
 def test_unblacklisted_username(config):
-    config.include(models)
-
     request = DummyRequest()
     node = colander.SchemaNode(colander.String()).bind(request=request)
     blacklist = set(['admin', 'root', 'postmaster'])
@@ -135,7 +132,6 @@ def test_login_bad_csrf(config, user_model):
 
 
 def test_login_bad_username(config, user_model):
-    config.include(models)
     request = csrf_request(config)
     schema = schemas.LoginSchema().bind(request=request)
     user_model.get_by_username.return_value = None

--- a/h/app.py
+++ b/h/app.py
@@ -46,6 +46,7 @@ def create_app(global_config, **settings):
     config.include('h.features')
 
     config.include('h.db')
+    config.include('h.models')
     config.include('h.views')
     config.include('h.renderers')
     config.include('h.api_client')

--- a/h/migrations/env.py
+++ b/h/migrations/env.py
@@ -18,9 +18,7 @@ fileConfig(config.config_file_name)
 
 # Import all model modules here in order to populate the metadata
 from h import db
-from h.accounts import models
-from h.notification import models
-from h import features
+from h import models
 
 target_metadata = db.Base.metadata
 

--- a/h/models.py
+++ b/h/models.py
@@ -1,16 +1,27 @@
 # -*- coding: utf-8 -*-
 
+from h import features
+from h.accounts import models as accounts_models
 from h.api import models as api_models
+from h.notification import models as notification_models
 
 __all__ = (
+    'Activation',
     'Annotation',
-    'Document',
     'Client',
+    'Document',
+    'Feature',
+    'Subscriptions',
+    'User',
 )
 
 
+Activation = accounts_models.Activation
 Annotation = api_models.Annotation
 Document = api_models.Document
+Feature = features.Feature
+Subscriptions = notification_models.Subscriptions
+User = accounts_models.User
 
 
 class Client(object):
@@ -20,3 +31,9 @@ class Client(object):
     def __init__(self, request, client_id):
         self.client_id = client_id
         self.client_secret = None
+
+
+def includeme(_):
+    # This module is included for side-effects only. SQLAlchemy models register
+    # with the global metadata object when imported.
+    pass

--- a/h/notification/__init__.py
+++ b/h/notification/__init__.py
@@ -30,7 +30,6 @@ class FallbackSerializer(object):
 def includeme(config):
     config.include('.types')
     config.include('.gateway')
-    config.include('.models')
     config.include('.notifier')
     config.include('.reply_template')
     config.include('.views')

--- a/h/notification/models.py
+++ b/h/notification/models.py
@@ -48,7 +48,3 @@ class Subscriptions(Base):
                 'uri': self.uri,
                 'type': self.type,
                 'active': self.active}
-
-
-def includeme(_):
-    pass


### PR DESCRIPTION
Rather than having each package include its "models" module in the
pyramid module hierarchy, this commit consolidates imports for model
packages, reexposing all model objects from `h.models`.

This simplifies model modules (they no longer need a no-op "includeme"
function), and it abstracts the ultimate location of the models from
components that simply need to know that all model metadata has been
generated (e.g. `h/migrations/env.py`).

In future, it may be wise for us to standardise on importing models from
`h.models` when importing across sub-packages, i.e. `h.foo.views` can
import `h.foo.models`, but not `h.bar.models`. Instead, it should import
`h.models` and access `h.bar`'s models from there.