### PR TITLE
Add .jscrc for JavaScript Code Style help

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -1,0 +1,8 @@
+{
+  "preset": "google",
+  "excludeFiles": [
+    "node_modules/**",
+    "h/static/scripts/vendor"
+  ],
+  "maxErrors": 10
+}

--- a/docs/hacking/code-style.rst
+++ b/docs/hacking/code-style.rst
@@ -38,6 +38,15 @@ spacing is followed for blank lines.
 
 .. _Google JavaScript Style Guide: https://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml
 
+We use a combination of [JSHint](http://jshint.com) and
+[JSCS](http://jscs.info) for helping confirm code style conformance.
+
+You can run both from the root of the repo specifying the directory of the
+JavaScript files to check::
+
+    $ jshint h/static/scripts/
+    $ jscs h/static/scripts/
+
 HTML and CSS
 ------------
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "uglify-js": "^2.4.14"
   },
   "devDependencies": {
+    "jscs": "^1.13.1",
     "karma": "^0.12.17",
     "karma-browserify": "^3.0.3",
     "karma-cli": "0.0.4",


### PR DESCRIPTION
JSCS is like JSHint, but specifically for Code Style.

It comes with a Google Code Style (which we use currently)
pre-set. This config file sets that and can be extended
later for any departures we make (if any) from that style
guide.

This will be more valuable as we get off CoffeScript.