### PR TITLE
Stop two sources of dangling transactions

### DIFF
--- a/h/notification/worker.py
+++ b/h/notification/worker.py
@@ -19,6 +19,10 @@ def run(request):
     def handle_message(reader, message=None):
         if message is None:
             return
+        with request.tm:
+            send_notifications(message)
+
+    def send_notifications(message):
         # We start the reader regardless, otherwise messages will pile up in
         # the notification channel, but we only actually handle them and try
         # and mail them if the 'notification' feature is toggled on.

--- a/h/streamer.py
+++ b/h/streamer.py
@@ -17,7 +17,6 @@ from jsonschema import validate
 from pyramid.config import aslist
 from pyramid.httpexceptions import HTTPBadRequest, HTTPForbidden
 from pyramid.threadlocal import get_current_request
-import transaction
 from ws4py.exc import HandshakeError
 from ws4py.websocket import WebSocket as _WebSocket
 from ws4py.server.wsgiutils import WebSocketWSGIApplication
@@ -446,6 +445,8 @@ class WebSocket(_WebSocket):
 
     @classmethod
     def start_reader(cls, request):
+        if cls.event_queue is not None:
+            return
         cls.event_queue = gevent.queue.Queue()
         reader_id = 'stream-{}#ephemeral'.format(_random_id())
         reader = request.get_queue_reader('annotations', reader_id)
@@ -459,19 +460,19 @@ class WebSocket(_WebSocket):
             cls.event_queue.put(message)
 
     def opened(self):
-        transaction.commit()  # Release the database transaction
-
         # The websocket server runs regardless, but we don't attempt to connect
         # to NSQ unless 'streamer' is toggled on.
-        if not self.request.feature('streamer'):
-            return
-
-        if self.event_queue is None:
+        if self.request.feature('streamer'):
             self.start_reader(self.request)
 
+        # Store the user
+        self.user = get_user(self.request)
+
+        # Release the database transaction
+        self.request.tm.commit()
+
     def send_annotations(self):
-        request = self.request
-        user = get_user(request)
+        user = self.user
         annotations = Annotation.search_raw(query=self.query.query, user=user)
         self.received = len(annotations)
 
@@ -503,7 +504,10 @@ class WebSocket(_WebSocket):
         clause['value'] = list(available_uris)
 
     def received_message(self, msg):
-        transaction.begin()
+        with self.request.tm:
+            self._process_message(msg)
+
+    def _process_message(self, msg):
         try:
             data = json.loads(msg.data)
             msg_type = data.get('messageType', 'filter')
@@ -533,10 +537,7 @@ class WebSocket(_WebSocket):
                 self.client_id = data.get('value')
         except:
             log.exception("Parsing filter: %s", msg)
-            transaction.abort()
             self.close()
-        else:
-            transaction.commit()
 
 
 def _annotation_packet(annotations, action):

--- a/h/streamer.py
+++ b/h/streamer.py
@@ -538,6 +538,7 @@ class WebSocket(_WebSocket):
         except:
             log.exception("Parsing filter: %s", msg)
             self.close()
+            raise
 
 
 def _annotation_packet(annotations, action):

--- a/h/streamer.py
+++ b/h/streamer.py
@@ -536,6 +536,7 @@ class WebSocket(_WebSocket):
             elif msg_type == 'client_id':
                 self.client_id = data.get('value')
         except:
+            # TODO: clean this up, catch specific errors, narrow the scope
             log.exception("Parsing filter: %s", msg)
             self.close()
             raise

--- a/h/streamer.py
+++ b/h/streamer.py
@@ -211,7 +211,9 @@ class FilterToElasticFilter(object):
                     field.append(f[1:].replace('/', '.'))
             else:
                 field = clause['field'][1:].replace('/', '.')
-            es = clause['options']['es'] if 'es' in clause['options'] else None
+
+            options = clause.get('options', {})
+            es = options.get('es')
             if es:
                 query_type = es.get('query_type', 'simple')
             else:


### PR DESCRIPTION
Two sources of dangling transactions:

- WebSocket

Solved by releasing the transaction after checking features,
avoiding a transaction to get the user for every 'more_hits' call,
and the general hygiene of processing messages in a transaction.

- Notification worker

Process messages in a transaction.