### PR TITLE
Use ng-csp consistently for the AppController

### DIFF
--- a/h/buildext.py
+++ b/h/buildext.py
@@ -174,7 +174,7 @@ def build_chrome(args):
     if webassets_env.url.startswith('chrome-extension:'):
         build_extension_common(env, bundle_app=True)
         with open(content_dir + '/app.html', 'w') as fp:
-            data = render_view(env['root'], env['request'], 'extension')
+            data = render_view(env['root'], env['request'], 'viewer')
             fp.write(data)
     else:
         build_extension_common(env)

--- a/h/templates/app.html.jinja2
+++ b/h/templates/app.html.jinja2
@@ -7,7 +7,7 @@
 {% endblock %}
 
 {% block body_tag %}
-<body ng-app="h" ng-controller="AppController">
+<body ng-app="h" ng-controller="AppController" ng-csp="">
 {% endblock %}
 
 {% block content %}

--- a/h/templates/extension.html.jinja2
+++ b/h/templates/extension.html.jinja2
@@ -1,7 +1,0 @@
-{% extends "app.html.jinja2" %}
-
-{# We include ng-csp in the extension template to disable Angular features that
-   can break Content-Security-Policy rules. #}
-{% block body_tag %}
-<body ng-app="h" ng-controller="AppController" ng-csp="">
-{% endblock %}

--- a/h/views.py
+++ b/h/views.py
@@ -90,7 +90,6 @@ def widget(context, request):
 @view_config(name='viewer', renderer='h:templates/app.html.jinja2')
 @view_config(name='editor', renderer='h:templates/app.html.jinja2')
 @view_config(name='page_search', renderer='h:templates/app.html.jinja2')
-@view_config(name='extension', renderer='h:templates/extension.html.jinja2')
 def page(context, request):
     return {}
 


### PR DESCRIPTION
There's no clear reason why we should enable ng-csp (which turns off
Angular's use of inline styles and JavaScript eval so as not to violate
Content-Security-Policy rules) only for the extension.

This commit removes the difference between the stream page and the
extension, so both have ng-csp enabled.