### PR TITLE
Make Makefile more dumb

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,15 +10,9 @@ export PIP_REQUIRE_VIRTUALENV
 
 default: deps
 
-h.egg-info: setup.py
-	@pip install -q --use-wheel -e .[dev,testing,YAML]
-	@touch h.egg-info
-
-node_modules: package.json
-	@npm install
-	@touch node_modules
-
-deps: h.egg-info node_modules
+deps:
+	pip install --use-wheel -e .[dev,testing,YAML]
+	npm install
 
 clean:
 	find . -type f -name "*.py[co]" -delete
@@ -31,7 +25,7 @@ clean:
 	rm -f h/static/styles/*.css
 	rm -f .coverage
 
-dev: deps
+dev:
 	@gunicorn --reload --paste conf/development.ini
 
 test:


### PR DESCRIPTION
Having a clever Makefile that tries to work out when it needs to install
updated dependencies is a minor convenience for those of us working with
`h` on an ongoing basis.

But sometimes that process goes wrong. If for whatever reason the
`h.egg-info` file ends up more recent than `setup.py`, users get
confused by the Makefile not doing what it's supposed to.

This commit removes all magic:

- `make deps` installs deps, unconditionally
- `make dev` runs gunicorn

Our [hacking guide][1] already instructs users to run these two
separately.

[1]: https://h.readthedocs.org/en/latest/hacking/install.html

Closes #2391.