### PR TITLE
Two front-end fixes

### DIFF
--- a/h/static/styles/annotations.scss
+++ b/h/static/styles/annotations.scss
@@ -184,6 +184,7 @@ privacy {
 
     .annotation-collapsed-replies {
       display: inline;
+      margin-left: .25em;
     }
   }
 }

--- a/h/static/styles/threads.scss
+++ b/h/static/styles/threads.scss
@@ -63,12 +63,9 @@ $thread-padding: 1em;
   }
 }
 
-.thread-message {
-  margin-bottom: .5em;
-}
-
+.thread-message,
 .thread-deleted {
-  margin: .8em 0;
+  margin: .5em 0;
 }
 
 .thread-load-more {

--- a/h/templates/client/annotation.html
+++ b/h/templates/client/annotation.html
@@ -103,7 +103,7 @@
     </tags-input>
   </div>
 
-  <div class="annotation-section tags tags-read-only"
+  <div class="annotation-body tags tags-read-only"
        ng-if="vm.annotation.tags.length && !vm.editing">
     <ul class="tag-list">
       <li class="tag-item" ng-repeat="tag in vm.annotation.tags">


### PR DESCRIPTION
#### Add extra space at the top of the "Sign in to create annotations" message.

Before:
![selection_100](https://cloud.githubusercontent.com/assets/521978/8837138/afaa711c-3079-11e5-8a86-c0aee9072639.png)

After:
![selection_099](https://cloud.githubusercontent.com/assets/521978/8837145/b82af762-3079-11e5-8930-45ef53389266.png)

#### Hide tags when a thread is collapsed.
Tags weren't being collapsed and now everything collapses neatly to one line.
