### PR TITLE
Fix infinite digest cycle caused by feature flag client

### DIFF
--- a/h/static/scripts/features.js
+++ b/h/static/scripts/features.js
@@ -25,15 +25,24 @@ var CACHE_TTL = 5 * 60 * 1000; // 5 minutes
 
 function features ($document, $http, $log) {
   var cache = null;
+  var pending = false;
   var featuresURL = new URL('/app/features', $document.prop('baseURI'));
 
   function fetch() {
+    // Short-circuit if a fetch is already in progress...
+    if (pending) {
+      return;
+    }
+    pending = true;
     $http.get(featuresURL)
     .success(function(data) {
       cache = [Date.now(), data];
     })
     .error(function() {
       $log.warn('features service: failed to load features data');
+    })
+    .finally(function() {
+      pending = false;
     });
   }
 

--- a/h/static/scripts/test/features-test.js
+++ b/h/static/scripts/test/features-test.js
@@ -57,6 +57,13 @@ describe('h:features', function () {
     $httpBackend.flush();
   });
 
+  it('fetch should only send one request at a time', function () {
+    defaultHandler();
+    features.fetch();
+    features.fetch();
+    $httpBackend.flush();
+  });
+
   it('flagEnabled should retrieve features data', function () {
     defaultHandler();
     features.flagEnabled('foo');

--- a/h/static/scripts/test/features-test.js
+++ b/h/static/scripts/test/features-test.js
@@ -8,7 +8,6 @@ sinon.assert.expose(assert, {prefix: null});
 
 describe('h:features', function () {
   var $httpBackend;
-  var httpHandler;
   var features;
   var sandbox;
 
@@ -32,9 +31,6 @@ describe('h:features', function () {
   beforeEach(mock.inject(function ($injector) {
     $httpBackend = $injector.get('$httpBackend');
     features = $injector.get('features');
-
-    httpHandler = $httpBackend.when('GET', 'http://foo.com/app/features');
-    httpHandler.respond(200, {foo: true, bar: false});
   }));
 
   afterEach(function () {
@@ -43,25 +39,32 @@ describe('h:features', function () {
     sandbox.restore();
   });
 
+  function defaultHandler() {
+    var handler = $httpBackend.expect('GET', 'http://foo.com/app/features');
+    handler.respond(200, {foo: true, bar: false});
+    return handler;
+  }
+
   it('fetch should retrieve features data', function () {
-    $httpBackend.expect('GET', 'http://foo.com/app/features');
+    defaultHandler();
     features.fetch();
     $httpBackend.flush();
   });
 
   it('fetch should not explode for errors fetching features data', function () {
-    httpHandler.respond(500, "ASPLODE!");
+    defaultHandler().respond(500, "ASPLODE!");
     features.fetch();
     $httpBackend.flush();
   });
 
   it('flagEnabled should retrieve features data', function () {
-    $httpBackend.expect('GET', 'http://foo.com/app/features');
+    defaultHandler();
     features.flagEnabled('foo');
     $httpBackend.flush();
   });
 
   it('flagEnabled should return false initially', function () {
+    defaultHandler();
     var result = features.flagEnabled('foo');
     $httpBackend.flush();
 
@@ -69,6 +72,7 @@ describe('h:features', function () {
   });
 
   it('flagEnabled should return flag values when data is loaded', function () {
+    defaultHandler();
     features.fetch();
     $httpBackend.flush();
 
@@ -80,6 +84,7 @@ describe('h:features', function () {
   });
 
   it('flagEnabled should return false for unknown flags', function () {
+    defaultHandler();
     features.fetch();
     $httpBackend.flush();
 
@@ -90,13 +95,13 @@ describe('h:features', function () {
   it('flagEnabled should trigger a new fetch after cache expiry', function () {
     var clock = sandbox.useFakeTimers();
 
-    $httpBackend.expect('GET', 'http://foo.com/app/features');
+    defaultHandler();
     features.flagEnabled('foo');
     $httpBackend.flush();
 
     clock.tick(301 * 1000);
 
-    $httpBackend.expect('GET', 'http://foo.com/app/features');
+    defaultHandler();
     features.flagEnabled('foo');
     $httpBackend.flush();
   });


### PR DESCRIPTION
This was a fun bug. If multiple feature checks are done in rapid
succession when the features cache is empty (such as, for example,
during the first digest cycle at application boot time) then the
features client would keep kicking off HTTP requests until the first one
returned.

This would clearly be a misfeature, but wouldn't actually have caused
any problems but for the fact that the spinner in
`h/directives/simple-search.coffee` does this to determine whether to
spin:

    scope.$watch (-> $http.pendingRequests.length), (pending) ->
      scope.loading = (pending > 0)

This means that kicking off dozens of requests at a time keeps
invalidating the digest cycle (because the value of
`$http.pendingRequests.length` keeps changing), so it never ends. The
result is the ever-horrible `infdig` (infinite digest cycle) error from
Angular: https://docs.angularjs.org/error/$rootScope/infdig.