### PR TITLE
Enable toggling features for admins only

### DIFF
--- a/h/features.py
+++ b/h/features.py
@@ -32,6 +32,11 @@ class Feature(Base):
                          nullable=False,
                          default=False,
                          server_default=sa.sql.expression.false())
+    # Is the feature enabled for admins?
+    admins = sa.Column(sa.Boolean,
+                       nullable=False,
+                       default=False,
+                       server_default=sa.sql.expression.false())
 
     @classmethod
     def get_by_name(cls, name):
@@ -58,6 +63,9 @@ def flag_enabled(request, name):
         return False
     # Features that are on for everyone are on.
     if feat.everyone:
+        return True
+    # Features that are on for admin are on if the current user is an admin.
+    if feat.admins and 'group:admin' in request.effective_principals:
         return True
     return False
 

--- a/h/migrations/versions/17a69c28b6c2_add_admins_column_to_feature_table.py
+++ b/h/migrations/versions/17a69c28b6c2_add_admins_column_to_feature_table.py
@@ -1,0 +1,28 @@
+"""Add admins column to feature table
+
+Revision ID: 17a69c28b6c2
+Revises: 534754b1bf54
+Create Date: 2015-07-24 20:23:04.898305
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '17a69c28b6c2'
+down_revision = '534754b1bf54'
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+def upgrade():
+    with op.batch_alter_table('feature') as batch_op:
+        batch_op.add_column(sa.Column('admins',
+                                      sa.Boolean(),
+                                      nullable=False,
+                                      default=False,
+                                      server_default=sa.sql.expression.false()))
+
+
+def downgrade():
+    with op.batch_alter_table('feature') as batch_op:
+        batch_op.drop_column('admins')


### PR DESCRIPTION
Allow toggling features on for users set as admins in our accounts system. This means we can deploy features to production and allow admin users to test them before releasing them to the general population.