### PR TITLE
Our 404 error response should have a 404 status code.

### DIFF
--- a/h/views.py
+++ b/h/views.py
@@ -178,6 +178,7 @@ def stream_atom(request):
 @forbidden_view_config(renderer='h:templates/notfound.html.jinja2')
 @notfound_view_config(renderer='h:templates/notfound.html.jinja2')
 def notfound(context, request):
+    request.response.status_int = 404
     return {}
 
 


### PR DESCRIPTION
Before:

    $ curl -sD- https://hypothes.is/app/i/dont/exist | head -n1
    HTTP/1.1 200 OK

After:

    $ curl -sD- https://localhost:5000/app/i/dont/exist | head -n1
    HTTP/1.1 404 Not Found