### PR TITLE
Move `request.es` property to h.api.db

### DIFF
--- a/h/api/db.py
+++ b/h/api/db.py
@@ -149,7 +149,12 @@ def includeme(config):
     settings = registry.settings
 
     # Configure ElasticSearch
-    store_from_settings(settings)
+    es = store_from_settings(settings)
+
+    # Add a property to all requests for easy access to the elasticsearch
+    # client. This can be used for direct or bulk access without having to
+    # reread the settings.
+    config.add_request_method(lambda req: es, name='es', reify=True)
 
     # Maybe initialize the models
     if asbool(settings.get('h.db.should_drop_all', False)):

--- a/h/api/nipsa/test/worker_test.py
+++ b/h/api/nipsa/test/worker_test.py
@@ -4,11 +4,11 @@ from h.api.nipsa import worker
 
 
 def test_add_nipsa_action():
-    action = worker.add_nipsa_action({"_id": "test_id"})
+    action = worker.add_nipsa_action("foo", {"_id": "test_id"})
 
     assert action == {
         "_op_type": "update",
-        "_index": "annotator",
+        "_index": "foo",
         "_type": "annotation",
         "_id": "test_id",
         "doc": {"nipsa": True}
@@ -17,11 +17,11 @@ def test_add_nipsa_action():
 
 def test_remove_nipsa_action():
     annotation = {"_id": "test_id", "_source": {"nipsa": True, "foo": "bar"}}
-    action = worker.remove_nipsa_action(annotation)
+    action = worker.remove_nipsa_action("bar", annotation)
 
     assert action == {
         "_op_type": "index",
-        "_index": "annotator",
+        "_index": "bar",
         "_type": "annotation",
         "_id": "test_id",
         "_source": {"foo": "bar"},
@@ -31,7 +31,11 @@ def test_remove_nipsa_action():
 @mock.patch("h.api.nipsa.worker.helpers")
 @mock.patch("h.api.nipsa.worker.nipsa_search")
 def test_add_nipsa_gets_query(nipsa_search, _):
-    worker.add_or_remove_nipsa("test_userid", "add_nipsa", mock.Mock())
+    worker.add_or_remove_nipsa(client=mock.Mock(),
+                               index="foo",
+                               userid="test_userid",
+                               action="add_nipsa")
+
 
     nipsa_search.not_nipsad_annotations.assert_called_once_with("test_userid")
 
@@ -39,7 +43,10 @@ def test_add_nipsa_gets_query(nipsa_search, _):
 @mock.patch("h.api.nipsa.worker.helpers")
 @mock.patch("h.api.nipsa.worker.nipsa_search")
 def test_remove_nipsa_gets_query(nipsa_search, _):
-    worker.add_or_remove_nipsa("test_userid", "remove_nipsa", mock.Mock())
+    worker.add_or_remove_nipsa(client=mock.Mock(),
+                               index="foo",
+                               userid="test_userid",
+                               action="remove_nipsa")
 
     nipsa_search.nipsad_annotations.assert_called_once_with("test_userid")
 
@@ -47,21 +54,27 @@ def test_remove_nipsa_gets_query(nipsa_search, _):
 @mock.patch("h.api.nipsa.worker.helpers")
 @mock.patch("h.api.nipsa.worker.nipsa_search")
 def test_add_nipsa_passes_es_client_to_scan(_, helpers):
-    es_client = mock.Mock()
+    client = mock.Mock()
 
-    worker.add_or_remove_nipsa("test_userid", "add_nipsa", es_client)
+    worker.add_or_remove_nipsa(client=client,
+                               index="foo",
+                               userid="test_userid",
+                               action="add_nipsa")
 
-    assert helpers.scan.call_args[1]["client"] == es_client
+    assert helpers.scan.call_args[1]["client"] == client
 
 
 @mock.patch("h.api.nipsa.worker.helpers")
 @mock.patch("h.api.nipsa.worker.nipsa_search")
 def test_remove_nipsa_passes_es_client_to_scan(_, helpers):
-    es_client = mock.Mock()
+    client = mock.Mock()
 
-    worker.add_or_remove_nipsa("test_userid", "remove_nipsa", es_client)
+    worker.add_or_remove_nipsa(client=client,
+                               index="foo",
+                               userid="test_userid",
+                               action="remove_nipsa")
 
-    assert helpers.scan.call_args[1]["client"] == es_client
+    assert helpers.scan.call_args[1]["client"] == client
 
 
 @mock.patch("h.api.nipsa.worker.helpers")
@@ -70,7 +83,10 @@ def test_add_nipsa_passes_query_to_scan(nipsa_search, helpers):
     query = mock.MagicMock()
     nipsa_search.not_nipsad_annotations.return_value = query
 
-    worker.add_or_remove_nipsa("test_userid", "add_nipsa", mock.Mock())
+    worker.add_or_remove_nipsa(client=mock.Mock(),
+                               index="foo",
+                               userid="test_userid",
+                               action="add_nipsa")
 
     assert helpers.scan.call_args[1]["query"] == query
 
@@ -81,7 +97,10 @@ def test_remove_nipsa_passes_query_to_scan(nipsa_search, helpers):
     query = mock.MagicMock()
     nipsa_search.nipsad_annotations.return_value = query
 
-    worker.add_or_remove_nipsa("test_userid", "remove_nipsa", mock.Mock())
+    worker.add_or_remove_nipsa(client=mock.Mock(),
+                               index="foo",
+                               userid="test_userid",
+                               action="remove_nipsa")
 
     assert helpers.scan.call_args[1]["query"] == query
 
@@ -92,7 +111,10 @@ def test_add_nipsa_passes_actions_to_bulk(_, helpers):
     helpers.scan.return_value = [
         {"_id": "foo"}, {"_id": "bar"}, {"_id": "gar"}]
 
-    worker.add_or_remove_nipsa("test_userid", "add_nipsa", mock.Mock())
+    worker.add_or_remove_nipsa(client=mock.Mock(),
+                               index="foo",
+                               userid="test_userid",
+                               action="add_nipsa")
 
     actions = helpers.bulk.call_args[1]["actions"]
     assert [action["_id"] for action in actions] == ["foo", "bar", "gar"]
@@ -104,7 +126,10 @@ def test_remove_nipsa_passes_actions_to_bulk(_, helpers):
     helpers.scan.return_value = [
         {"_id": "foo"}, {"_id": "bar"}, {"_id": "gar"}]
 
-    worker.add_or_remove_nipsa("test_userid", "remove_nipsa", mock.Mock())
+    worker.add_or_remove_nipsa(client=mock.Mock(),
+                               index="foo",
+                               userid="test_userid",
+                               action="remove_nipsa")
 
     actions = helpers.bulk.call_args[1]["actions"]
     assert [action["_id"] for action in actions] == ["foo", "bar", "gar"]
@@ -113,18 +138,24 @@ def test_remove_nipsa_passes_actions_to_bulk(_, helpers):
 @mock.patch("h.api.nipsa.worker.helpers")
 @mock.patch("h.api.nipsa.worker.nipsa_search")
 def test_add_nipsa_passes_es_client_to_bulk(_, helpers):
-    es_client = mock.Mock()
+    client = mock.Mock()
 
-    worker.add_or_remove_nipsa("test_userid", "add_nipsa", es_client)
+    worker.add_or_remove_nipsa(client=client,
+                               index="foo",
+                               userid="test_userid",
+                               action="remove_nipsa")
 
-    assert helpers.bulk.call_args[1]["client"] == es_client
+    assert helpers.bulk.call_args[1]["client"] == client
 
 
 @mock.patch("h.api.nipsa.worker.helpers")
 @mock.patch("h.api.nipsa.worker.nipsa_search")
 def test_remove_nipsa_passes_actions_to_bulk(_, helpers):
-    es_client = mock.Mock()
+    client = mock.Mock()
 
-    worker.add_or_remove_nipsa("test_userid", "remove_nipsa", es_client)
+    worker.add_or_remove_nipsa(client=client,
+                               index="foo",
+                               userid="test_userid",
+                               action="remove_nipsa")
 
-    assert helpers.bulk.call_args[1]["client"] == es_client
+    assert helpers.bulk.call_args[1]["client"] == client

--- a/h/api/search.py
+++ b/h/api/search.py
@@ -6,7 +6,6 @@ stuff should be encapsulated in this module.
 """
 import logging
 
-import elasticsearch
 from elasticsearch import helpers
 import webob.multidict
 
@@ -151,14 +150,3 @@ def index(user=None):
 
     """
     return search(webob.multidict.NestedMultiDict({"limit": 20}), user=user)
-
-
-def includeme(config):
-    """Add a ``request.es_client`` property to the request."""
-    es_host = config.registry.settings.get('es.host')
-    if es_host:
-        es_client = elasticsearch.Elasticsearch([es_host])
-    else:
-        es_client = elasticsearch.Elasticsearch()
-    config.add_request_method(
-        lambda _: es_client, 'es_client', reify=True)

--- a/h/app.py
+++ b/h/app.py
@@ -73,9 +73,6 @@ def includeme(config):
     config.include('h.notification')
     config.include('h.queue')
     config.include('h.streamer')
-    config.include('h.api.search')   # This is needed here for now so that
-                                     # request.es_client is available t
-                                     # worker functions.
 
     config.include('h.api', route_prefix='/api')
     config.include('h.api.nipsa')

--- a/h/script.py
+++ b/h/script.py
@@ -6,7 +6,6 @@ import os
 import sys
 import textwrap
 
-from elasticsearch import Elasticsearch
 from pyramid import paster
 from pyramid.request import Request
 
@@ -95,13 +94,7 @@ def reindex(args):
     """Reindex the annotations into a new Elasticsearch index."""
     request = bootstrap(args)
 
-    if 'es.host' in request.registry.settings:
-        host = request.registry.settings['es.host']
-        conn = Elasticsearch([host])
-    else:
-        conn = Elasticsearch()
-
-    r = reindexer.Reindexer(conn, interactive=True)
+    r = reindexer.Reindexer(request.es.conn, interactive=True)
 
     r.reindex(args.old_index, args.new_index)
 


### PR DESCRIPTION
Given that `h.api.db` is already responsible for reading the settings
and configuring the ElasticSearch client, it seems sensible that this
request property is added here.

This simplifies `h.api.search` and will simplify getting access to the
ElasticSearch client from CLI tools I'm currently working on.