### PR TITLE
Share a group

### DIFF
--- a/h/groups/logic.py
+++ b/h/groups/logic.py
@@ -1,0 +1,7 @@
+from h import hashids
+
+
+def url_for_group(request, group):
+    """Return the URL for the given group's page."""
+    hashid = hashids.encode(request, "h.groups", number=group.id)
+    return request.route_url('group_read', hashid=hashid, slug=group.slug)

--- a/h/groups/templates/join.html.jinja2
+++ b/h/groups/templates/join.html.jinja2
@@ -10,15 +10,12 @@
 
 {% block content %}
   <div class="content paper">
-    {% for message in request.session.pop_flash('success') %}
-      {{ message }}
-    {% endfor %}
-
     {% include "h:templates/includes/header.html.jinja2" %}
-
     This is group {{ group.name }}.
-    You're a member of this group.
-    You can invite other people to join this group by sending them the link
-    to this page: {{ group_url }}
+    <form method="POST">
+      <button type="submit">
+        Join this group
+      </button>
+    </form>
   </div>
 {% endblock content %}

--- a/h/groups/templates/login_to_join.html.jinja2
+++ b/h/groups/templates/login_to_join.html.jinja2
@@ -10,15 +10,10 @@
 
 {% block content %}
   <div class="content paper">
-    {% for message in request.session.pop_flash('success') %}
-      {{ message }}
-    {% endfor %}
-
     {% include "h:templates/includes/header.html.jinja2" %}
-
     This is group {{ group.name }}.
-    You're a member of this group.
-    You can invite other people to join this group by sending them the link
-    to this page: {{ group_url }}
+    <a href="{{ request.route_url('login') }}" target="_blank">
+      Login to join this group.
+    </a>
   </div>
 {% endblock content %}

--- a/h/groups/test/logic_test.py
+++ b/h/groups/test/logic_test.py
@@ -1,0 +1,31 @@
+import mock
+
+from h.groups import logic
+
+
+@mock.patch('h.groups.logic.hashids')
+def test_url_for_group_encodes_groupid(hashids):
+    """It should encode the groupid to get the hashid.
+
+    And then pass the hashid to route_url().
+
+    """
+    hashids.encode.return_value = mock.sentinel.hashid
+    request = mock.Mock()
+    group = mock.Mock()
+
+    logic.url_for_group(request, group)
+
+    assert hashids.encode.call_args[1]['number'] == group.id
+    assert request.route_url.call_args[1]['hashid'] == mock.sentinel.hashid
+
+
+@mock.patch('h.groups.logic.hashids')
+def test_url_for_group_returns_url(_):
+    """It should return the URL from request.route_url()."""
+    request = mock.Mock()
+    request.route_url.return_value = mock.sentinel.group_url
+
+    url = logic.url_for_group(request, mock.Mock())
+
+    assert url == mock.sentinel.group_url

--- a/h/groups/test/views_test.py
+++ b/h/groups/test/views_test.py
@@ -7,18 +7,29 @@ from pyramid import httpexceptions
 from h.groups import views
 
 
+_SENTINEL = object()
+
+
 def _mock_request(feature=None, settings=None, params=None,
-                  authenticated_userid=None, route_url=None, **kwargs):
+                  authenticated_userid=_SENTINEL, route_url=None, **kwargs):
     """Return a mock Pyramid request object."""
     params = params or {"foo": "bar"}
+    if authenticated_userid is _SENTINEL:
+        authenticated_userid = "acct:fred@hypothes.is"
     return mock.Mock(
         feature=feature or (lambda feature: True),
         registry=mock.Mock(settings=settings or {
             "h.hashids.salt": "test salt"}),
         params=params, POST=params,
-        authenticated_userid=authenticated_userid or "acct:fred@hypothes.is",
+        authenticated_userid=authenticated_userid,
         route_url=route_url or mock.Mock(return_value="test-read-url"),
         **kwargs)
+
+
+def _matchdict():
+    """Return a matchdict like the one the group_read route receives."""
+    return {"hashid": mock.sentinel.hashid, "slug": mock.sentinel.slug}
+
 
 # The fixtures required to mock all of create_form()'s dependencies.
 create_form_fixtures = pytest.mark.usefixtures('GroupSchema', 'Form')
@@ -63,7 +74,7 @@ def test_create_form_returns_empty_form_data(Form):
 
 # The fixtures required to mock all of create()'s dependencies.
 create_fixtures = pytest.mark.usefixtures(
-    'GroupSchema', 'Form', 'Group', 'User', 'hashids')
+    'GroupSchema', 'Form', 'Group', 'User', 'logic')
 
 
 @create_fixtures
@@ -141,17 +152,16 @@ def test_create_adds_group_to_db(Group):
 
 
 @create_fixtures
-def test_create_redirects_to_group_read_page(Group, hashids):
+def test_create_redirects_to_group_read_page(Group, logic):
     """After successfully creating a new group it should redirect."""
     group = mock.Mock(id='test-id', slug='test-slug')
     Group.return_value = group
     request = _mock_request()
-    hashids.encode.return_value = "testhashid"
+    logic.url_for_group.return_value = "test-read-url"
 
     redirect = views.create(request)
 
-    request.route_url.assert_called_once_with(
-        "group_read", hashid="testhashid", slug="test-slug")
+    logic.url_for_group.assert_called_once_with(request, group)
     assert redirect.status_int == 303
     assert redirect.location == "test-read-url"
 
@@ -162,7 +172,8 @@ def test_create_with_non_ascii_name():
 
 
 # The fixtures required to mock all of read()'s dependencies.
-read_fixtures = pytest.mark.usefixtures('Group', 'hashids')
+read_fixtures = pytest.mark.usefixtures(
+    'Group', 'hashids', 'User', 'renderers', 'logic')
 
 
 @read_fixtures
@@ -173,32 +184,22 @@ def test_read_404s_if_groups_feature_is_off():
 
 @read_fixtures
 def test_read_decodes_hashid(hashids):
-    request = _mock_request(matchdict={"hashid": "abc", "slug": "slug"})
+    matchdict = _matchdict()
+    request = _mock_request(matchdict=matchdict)
 
     views.read(request)
 
     hashids.decode.assert_called_once_with(
-        request, "h.groups", "abc")
+        request, "h.groups", matchdict["hashid"])
 
 
 @read_fixtures
 def test_read_gets_group_by_id(Group, hashids):
     hashids.decode.return_value = 1
 
-    views.read(_mock_request(matchdict={"hashid": "1", "slug": "slug"}))
+    views.read(_mock_request(matchdict=_matchdict()))
 
     Group.get_by_id.assert_called_once_with(1)
-
-
-@read_fixtures
-def test_read_returns_the_group(Group):
-    group = Group.get_by_id.return_value
-    group.slug = 'slug'
-
-    template_data = views.read(_mock_request(
-        matchdict={"hashid": "1", "slug": "slug"}))
-
-    assert template_data["group"] == group
 
 
 @read_fixtures
@@ -206,40 +207,280 @@ def test_read_404s_when_group_does_not_exist(Group):
     Group.get_by_id.return_value = None
 
     with pytest.raises(httpexceptions.HTTPNotFound):
-        views.read(_mock_request(
-            matchdict={"hashid": "1", "slug": "slug"}))
+        views.read(_mock_request(matchdict=_matchdict()))
 
 
 @read_fixtures
-def test_read_without_slug_redirects(Group):
+def test_read_without_slug_redirects(Group, logic):
     """/groups/<hashid> should redirect to /groups/<hashid>/<slug>."""
-    Group.return_value = mock.Mock(slug="my-group")
+    group = Group.get_by_id.return_value = mock.Mock()
     matchdict = {"hashid": "1"}  # No slug.
-    request = _mock_request(
-        matchdict=matchdict,
-        route_url=mock.Mock(return_value="/1/my-group"))
+    request = _mock_request(matchdict=matchdict)
+    logic.url_for_group.return_value = "/1/my-group"
 
     redirect = views.read(request)
 
-    assert request.route_url.called_with(
-        "group_read", hashid="1", slug="my-group")
+    logic.url_for_group.assert_called_once_with(request, group)
     assert redirect.location == "/1/my-group"
 
 
 @read_fixtures
-def test_read_with_wrong_slug_redirects(Group):
+def test_read_with_wrong_slug_redirects(Group, logic):
     """/groups/<hashid>/<wrong> should redirect to /groups/<hashid>/<slug>."""
-    Group.return_value = mock.Mock(slug="my-group")
-    matchdict = {"hashid": "1", "slug": "my-gro"}
-    request = _mock_request(
-        matchdict=matchdict,
-        route_url=mock.Mock(return_value="/1/my-group"))
+    group = Group.get_by_id.return_value = mock.Mock(slug="my-group")
+    matchdict = {"hashid": "1", "slug": "my-gro"}  # Wrong slug.
+    request = _mock_request(matchdict=matchdict)
+    logic.url_for_group.return_value = "/1/my-group"
 
     redirect = views.read(request)
 
-    assert request.route_url.called_with(
-        "group_read", hashid="1", slug="my-group")
+    logic.url_for_group.assert_called_once_with(request, group)
     assert redirect.location == "/1/my-group"
+
+
+@read_fixtures
+def test_read_if_not_logged_in_renders_share_group_page(
+        Group, renderers):
+    """If not logged in should render the "Login to join this group" page."""
+    Group.get_by_id.return_value = mock.Mock(slug=mock.sentinel.slug)
+    request = _mock_request(authenticated_userid=None, matchdict=_matchdict())
+
+    views.read(request)
+
+    assert renderers.render_to_response.call_args[1]['renderer_name'] == (
+        'h:groups/templates/login_to_join.html.jinja2')
+
+
+@read_fixtures
+def test_read_if_not_logged_in_passes_group(Group, renderers):
+    """It should pass the group to the template."""
+    group = Group.get_by_id.return_value = mock.Mock(slug=mock.sentinel.slug)
+    request = _mock_request(authenticated_userid=None, matchdict=_matchdict())
+
+    views.read(request)
+
+    assert renderers.render_to_response.call_args[1]['value']['group'] == (
+        group)
+
+
+@read_fixtures
+def test_read_if_not_logged_in_returns_response(
+        Group, renderers):
+    """It should return the response from render_to_response()."""
+    Group.get_by_id.return_value = mock.Mock(slug=mock.sentinel.slug)
+    request = _mock_request(authenticated_userid=None, matchdict=_matchdict())
+    renderers.render_to_response.return_value = mock.sentinel.response
+
+    response = views.read(request)
+
+    assert response == mock.sentinel.response
+
+
+@read_fixtures
+def test_read_if_not_a_member_encodes_hashid_from_groupid(
+        Group, User, hashids):
+    """It should encode the hashid from the groupid.
+
+    And use it to get the join URL from route_url().
+
+    """
+    request = _mock_request(matchdict=_matchdict())
+    group = Group.get_by_id.return_value = mock.Mock(slug=mock.sentinel.slug)
+    user = User.get_by_id.return_value = mock.Mock()
+    user.groups = []  # The user isn't a member of the group.
+    hashids.encode.return_value = mock.sentinel.hashid
+
+    views.read(request)
+
+    assert hashids.encode.call_args[1]['number'] == group.id
+    assert request.route_url.call_args[1]['hashid'] == mock.sentinel.hashid
+
+
+@read_fixtures
+def test_read_if_not_a_member_renders_template(
+        Group, User, renderers):
+    """It should render the "Join this group" template."""
+    request = _mock_request(matchdict=_matchdict())
+    Group.get_by_id.return_value = mock.Mock(slug=mock.sentinel.slug)
+    user = User.get_by_id.return_value = mock.Mock()
+    user.groups = []  # The user isn't a member of the group.
+
+    views.read(request)
+
+    assert renderers.render_to_response.call_args[1]['renderer_name'] == (
+        'h:groups/templates/join.html.jinja2')
+
+
+@read_fixtures
+def test_read_if_not_a_member_passes_group_to_template(
+        Group, User, renderers):
+    """It should get the join URL and pass it to the template."""
+    request = _mock_request(matchdict=_matchdict())
+    group = Group.get_by_id.return_value = mock.Mock(slug=mock.sentinel.slug)
+    user = User.get_by_id.return_value = mock.Mock()
+    user.groups = []  # The user isn't a member of the group.
+
+    views.read(request)
+
+    assert renderers.render_to_response.call_args[1]['value']['group'] == group
+
+
+@read_fixtures
+def test_read_if_not_a_member_passes_join_url_to_template(
+        Group, User, renderers):
+    """It should get the join URL and pass it to the template."""
+    request = _mock_request(matchdict=_matchdict())
+    request.route_url.return_value = mock.sentinel.join_url
+    Group.get_by_id.return_value = mock.Mock(slug=mock.sentinel.slug)
+    user = User.get_by_id.return_value = mock.Mock()
+    user.groups = []  # The user isn't a member of the group.
+
+    views.read(request)
+
+    assert renderers.render_to_response.call_args[1]['value']['join_url'] == (
+        mock.sentinel.join_url)
+
+
+@read_fixtures
+def test_read_if_not_a_member_returns_response(Group, User, renderers):
+    """It should return the response from render_to_response()."""
+    request = _mock_request(matchdict=_matchdict())
+    Group.get_by_id.return_value = mock.Mock(slug=mock.sentinel.slug)
+    user = User.get_by_id.return_value = mock.Mock()
+    user.groups = []  # The user isn't a member of the group.
+    renderers.render_to_response.return_value = mock.sentinel.response
+
+    assert views.read(request) == mock.sentinel.response
+
+
+@read_fixtures
+def test_read_if_already_a_member_renders_template(
+        Group, User, renderers):
+    """It should render the "Share this group" template."""
+    request = _mock_request(matchdict=_matchdict())
+    group = Group.get_by_id.return_value = mock.Mock(slug=mock.sentinel.slug)
+    user = User.get_by_id.return_value = mock.Mock()
+    user.groups = [group]  # The user is a member of the group.
+
+    views.read(request)
+    assert renderers.render_to_response.call_args[1]['renderer_name'] == (
+        'h:groups/templates/read.html.jinja2')
+
+
+@read_fixtures
+def test_read_if_already_a_member_passes_group(Group, User, renderers):
+    """It passes the group to the template."""
+    request = _mock_request(matchdict=_matchdict())
+    group = Group.get_by_id.return_value = mock.Mock(slug=mock.sentinel.slug)
+    user = User.get_by_id.return_value = mock.Mock()
+    user.groups = [group]  # The user is a member of the group.
+
+    views.read(request)
+
+    assert renderers.render_to_response.call_args[1]['value']['group'] == group
+
+
+@read_fixtures
+def test_read_if_already_a_member_passes_group_url(
+        Group, User, logic, renderers):
+    """It gets the url from url_for_group() and passes it to the template."""
+    request = _mock_request(matchdict=_matchdict())
+    group = Group.get_by_id.return_value = mock.Mock(slug=mock.sentinel.slug)
+    user = User.get_by_id.return_value = mock.Mock()
+    user.groups = [group]  # The user is a member of the group.
+    logic.url_for_group.return_value = mock.sentinel.group_url
+
+    views.read(request)
+
+    logic.url_for_group.assert_called_once_with(request, group)
+    assert renderers.render_to_response.call_args[1]['value']['group_url'] == (
+        mock.sentinel.group_url)
+
+
+@read_fixtures
+def test_read_if_already_a_member_returns_response(
+        Group, User, renderers):
+    """It should return the response from render_to_response()."""
+    request = _mock_request(matchdict=_matchdict())
+    group = Group.get_by_id.return_value = mock.Mock(slug=mock.sentinel.slug)
+    user = User.get_by_id.return_value = mock.Mock()
+    user.groups = [group]  # The user is a member of the group.
+    renderers.render_to_response.return_value = mock.sentinel.response
+
+    assert views.read(request) == mock.sentinel.response
+
+
+# The fixtures required to mock all of join()'s dependencies.
+join_fixtures = pytest.mark.usefixtures(
+    'User', 'hashids', 'Group', 'logic')
+
+
+@join_fixtures
+def test_join_404s_if_groups_feature_is_off():
+    with pytest.raises(httpexceptions.HTTPNotFound):
+        views.join(_mock_request(feature=lambda feature: False))
+
+
+@join_fixtures
+def test_join_uses_hashid_from_matchdict_to_get_groupid(hashids):
+    matchdict = _matchdict()
+    request = _mock_request(matchdict=matchdict)
+
+    views.join(request)
+
+    hashids.decode.assert_called_once_with(
+        request, "h.groups", matchdict["hashid"])
+
+
+@join_fixtures
+def test_join_gets_group_by_id(hashids, Group):
+    hashids.decode.return_value = "test-group-id"
+
+    views.join(_mock_request(matchdict=_matchdict()))
+
+    Group.get_by_id.assert_called_once_with("test-group-id")
+
+
+@join_fixtures
+def test_join_404s_if_group_not_found(Group):
+    Group.get_by_id.return_value = None
+
+    with pytest.raises(httpexceptions.HTTPNotFound):
+        views.join(_mock_request(matchdict=_matchdict()))
+
+
+@join_fixtures
+def test_join_gets_user_with_authenticated_userid(User):
+    request = _mock_request(matchdict=_matchdict())
+
+    views.join(request)
+
+    User.get_by_id.assert_called_once_with(
+        request, request.authenticated_userid)
+
+
+@join_fixtures
+def test_join_adds_user_to_group_members(Group, User):
+    Group.get_by_id.return_value = group = mock.Mock()
+    User.get_by_id.return_value = mock.sentinel.user
+
+    views.join(_mock_request(matchdict=_matchdict()))
+
+    group.members.append.assert_called_once_with(mock.sentinel.user)
+
+
+@join_fixtures
+def test_join_redirects_to_group_page(Group, logic):
+    slug = "test-slug"
+    group = Group.get_by_id.return_value = mock.Mock(slug=slug)
+    request = _mock_request(matchdict=_matchdict())
+    logic.url_for_group.return_value = mock.sentinel.group_url
+
+    redirect = views.join(request)
+
+    logic.url_for_group.assert_called_once_with(request, group)
+    assert redirect.status_int == 303
+    assert redirect.location == mock.sentinel.group_url
 
 
 @pytest.fixture
@@ -273,5 +514,19 @@ def User(request):
 @pytest.fixture
 def hashids(request):
     patcher = mock.patch('h.groups.views.hashids', autospec=True)
+    request.addfinalizer(patcher.stop)
+    return patcher.start()
+
+
+@pytest.fixture
+def logic(request):
+    patcher = mock.patch('h.groups.views.logic', autospec=True)
+    request.addfinalizer(patcher.stop)
+    return patcher.start()
+
+
+@pytest.fixture
+def renderers(request):
+    patcher = mock.patch('h.groups.views.renderers', autospec=True)
     request.addfinalizer(patcher.stop)
     return patcher.start()

--- a/h/groups/views.py
+++ b/h/groups/views.py
@@ -3,11 +3,17 @@
 import deform
 from pyramid import httpexceptions as exc
 from pyramid.view import view_config
+from pyramid import renderers
 
 from h.groups import schemas
 from h.groups import models
+from h.groups import logic
 from h.accounts import models as accounts_models
 from h import hashids
+from h import i18n
+
+
+_ = i18n.TranslationString
 
 
 @view_config(route_name='group_create',
@@ -48,15 +54,52 @@ def create(request):
     # We need to flush the db session here so that group.id will be generated.
     request.db.flush()
 
-    hashid = hashids.encode(request, "h.groups", group.id)
-    return exc.HTTPSeeOther(
-        location=request.route_url(
-            'group_read', hashid=hashid, slug=group.slug))
+    return exc.HTTPSeeOther(logic.url_for_group(request, group))
 
 
-@view_config(route_name='group_read',
-             request_method='GET',
-             renderer='h:groups/templates/read.html.jinja2')
+def _login_to_join(request, group):
+    """Return the rendered "Login to join this group" page.
+
+    This is the page that's shown when a user who isn't logged in visits a
+    group's URL.
+
+    """
+    template_data = {'group': group}
+    return renderers.render_to_response(
+        renderer_name='h:groups/templates/login_to_join.html.jinja2',
+        value=template_data, request=request)
+
+
+def _read_group(request, group):
+    """Return the rendered "Share this group" page.
+
+    This is the page that's shown when a user who is already a member of a
+    group visits the group's URL.
+
+    """
+    template_data = {
+        'group': group, 'group_url': logic.url_for_group(request, group)}
+    return renderers.render_to_response(
+        renderer_name='h:groups/templates/read.html.jinja2',
+        value=template_data, request=request)
+
+
+def _join(request, group):
+    """Return the rendered "Join this group" page.
+
+    This is the page that's shown when a user who is not a member of a group
+    visits the group's URL.
+
+    """
+    hashid = hashids.encode(request, 'h.groups', number=group.id)
+    join_url = request.route_url('group_read', hashid=hashid, slug=group.slug)
+    template_data = {'group': group, 'join_url': join_url}
+    return renderers.render_to_response(
+        renderer_name='h:groups/templates/join.html.jinja2',
+        value=template_data, request=request)
+
+
+@view_config(route_name='group_read', request_method='GET')
 @view_config(route_name='group_read_noslug', request_method='GET')
 def read(request):
     """Render the page for a group."""
@@ -65,19 +108,52 @@ def read(request):
 
     hashid = request.matchdict["hashid"]
     slug = request.matchdict.get("slug")
-    group_id = hashids.decode(request, "h.groups", hashid)
+    group_id = hashids.decode(request, 'h.groups', hashid)
 
     group = models.Group.get_by_id(group_id)
     if group is None:
         raise exc.HTTPNotFound()
 
     if slug is None or slug != group.slug:
-        canonical = request.route_url('group_read',
-                                      hashid=hashid,
-                                      slug=group.slug)
-        return exc.HTTPMovedPermanently(location=canonical)
+        return exc.HTTPMovedPermanently(
+            location=logic.url_for_group(request, group))
 
-    return {"group": group}
+    if not request.authenticated_userid:
+        return _login_to_join(request, group)
+    else:
+        user = accounts_models.User.get_by_id(
+            request, request.authenticated_userid)
+        if group in user.groups:
+            return _read_group(request, group)
+        else:
+            return _join(request, group)
+
+
+@view_config(route_name='group_read',
+             request_method='POST',
+             renderer='h:groups/templates/read.html.jinja2',
+             permission='authenticated')
+def join(request):
+    if not request.feature('groups'):
+        raise exc.HTTPNotFound()
+
+    hashid = request.matchdict["hashid"]
+    group_id = hashids.decode(request, "h.groups", hashid)
+    group = models.Group.get_by_id(group_id)
+
+    if group is None:
+        raise exc.HTTPNotFound()
+
+    user = accounts_models.User.get_by_id(
+        request, request.authenticated_userid)
+
+    group.members.append(user)
+
+    request.session.flash(_(
+        "You've joined the {name} group.").format(name=group.name),
+        'success')
+
+    return exc.HTTPSeeOther(logic.url_for_group(request, group))
 
 
 def includeme(config):

--- a/h/static/styles/app.scss
+++ b/h/static/styles/app.scss
@@ -129,8 +129,23 @@ ol {
   }
 }
 
+
+/* The groups dropdown list. */
+
 .group-list {
   margin-right: 0.5em;
+}
+
+$group-list-width: 225px;
+
+.group-list .dropdown-menu {
+  width: $group-list-width;
+}
+
+.group-list .dropdown-menu .group-name {
+  max-width: $group-list-width - 45px;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .user-picker {

--- a/h/templates/client/group_list.html
+++ b/h/templates/client/group_list.html
@@ -4,9 +4,13 @@
 </span>
 <ul class="dropdown-menu pull-right" role="menu">
   <li ng-repeat="group in groups">
-    <a ng-href="{{group.url}}" ng-bind="group.name" target="_blank"></a>
+    <a ng-href="{{group.url}}" ng-bind="group.name" target="_blank"
+       class="group-name pull-left"></a>
+    <a ng-href="{{group.url}}" target="_blank" class="h-icon-link pull-right"
+       title="Share this group"></a>
+    <div style="clear:both;"></div>
   </li>
   <li>
-    <a href="/groups/new" target="_blank"><i class="h-icon-add"></i> Create a group</a>
+    <a href="/groups/new" target="_blank"><i class="h-icon-add"></i> New Group</a>
   </li>
 </ul>


### PR DESCRIPTION
This is the second pull request for the groups feature.

What's in here:

* If you visit a group's page when you're not logged-in it tells you what group this is and gives you a link to login in order to join
* If you are logged-in it gives you a button to join the group. Clicking this button adds you to the group in the db and reloads the page.
* If you are already a member it tells you so and gives you a link to copy and share with others in order to invite them
* "You've joined" flash message
* Needless to say some design polish is needed for these pages.
* The login link just opens `/login` in a new tab. After logging in or registering and activating you have to go back to the original tab and refresh it. It doesn't attempt to take you to the login page within the one tab and then have it redirect back to the group's page after login, because that doesn't work for people who need to register, activate, possibly install the extension. More onboarding flow design work is needed here.
* There are two links to the group's page in the groups dropdown in the sidebar: both the group's name and the "link" icon link to it. This is because in the future the group's name will become a button for focusing the sidebar on that group instead.