### PR TITLE
Only update stream filter when we have >0 URIs

### DIFF
--- a/h/static/scripts/widget-controller.coffee
+++ b/h/static/scripts/widget-controller.coffee
@@ -40,8 +40,9 @@ module.exports = class WidgetController
         loaded.push(f.uri)
         _loadAnnotationsFrom({uri: f.uri}, 0)
 
-      streamFilter.resetFilter().addClause('/uri', 'one_of', loaded)
-      streamer.send({filter: streamFilter.getFilter()})
+      if loaded.length > 0
+        streamFilter.resetFilter().addClause('/uri', 'one_of', loaded)
+        streamer.send({filter: streamFilter.getFilter()})
 
     $scope.$watchCollection (-> crossframe.frames), loadAnnotations
 


### PR DESCRIPTION
The backend code in `h.streamer` assumes that the arguments to "one_of"
are either a non-empty list or a single value. Passing an empty list
causes the generation of a bogus query.

So, don't update the stream filter until we have at least one URI to
stream for.

Fixes #2257.

I've considered fixing this in `h.streamer` and also writing tests for `h.streamer` or this code in `WidgetController`. I don't think costs of any of these options is justified by the benefits, given we already know `h.streamer` is a disaster and needs to die in a fire.