### PR TITLE
Fix a pep257 warning

### DIFF
--- a/h/db.py
+++ b/h/db.py
@@ -24,12 +24,12 @@ from zope.sqlalchemy import ZopeTransactionExtension
 
 from h.api import db as api_db
 
-__all__ = [
+__all__ = (
     'Base',
     'Session',
     'bind_engine',
     'make_engine',
-]
+)
 
 # Create a thread-local session factory (which can also be used directly as a
 # session):


### PR DESCRIPTION
h/db.py WARNING: __all__ is defined as a list, this means pep257 cannot
reliably detect contents o f the __all__ variable, because it can be
mutated. Change __all__ to be an (immutable) tuple, to remove this
warning. Note, pep257 u ses __all__ to detect which definitions are
public, to warn if public definitions are missing docstrings. If __all__
is a (mutable) list, pep257 cannot reliably assume its contents. pep257
will proceed assuming __all__ is not mutated.