### PR TITLE
Simplify handling of admin permissions

### DIFF
--- a/h/admin.py
+++ b/h/admin.py
@@ -1,39 +1,11 @@
 from pyramid import view
 from pyramid import httpexceptions
-from pyramid import security
 
 from h.api import nipsa
 from h.i18n import TranslationString as _
 from h import accounts
 from h import models
 from h import util
-
-
-class AdminResource(object):
-
-    """The context resource factory for the admin views.
-
-    Authorizes requests with the 'group:admin' principal to use views with the
-    'admin' permission.
-
-    To make a view accessible by admins only you should first add the 'admin'
-    permission to the view:
-
-        @view.view_config(route_name='my_route', permission='admin')
-        def my_route(request):
-            ...
-
-    Then add the AdminResource factory to the route that points to the
-    view:
-
-        config.add_route('my_route', '/my_route', factory=AdminResource)
-
-    """
-
-    __acl__ = [(security.Allow, 'group:admin', 'admin')]
-
-    def __init__(self, request):
-        pass
 
 
 @view.view_config(route_name='admin_index',
@@ -173,18 +145,11 @@ def staff_remove(request):
 
 
 def includeme(config):
-    config.add_route('admin_index', '/admin',
-                     factory=AdminResource)
-    config.add_route('admin_nipsa', '/admin/nipsa',
-                     factory=AdminResource)
-    config.add_route('admin_nipsa_remove', '/admin/nipsa/remove',
-                     factory=AdminResource)
-    config.add_route('admin_admins', '/admin/admins',
-                     factory=AdminResource)
-    config.add_route('admin_admins_remove', '/admin/admins/delete',
-                     factory=AdminResource)
-    config.add_route('admin_staff', '/admin/staff',
-                     factory=AdminResource)
-    config.add_route('admin_staff_remove', '/admin/staff/delete',
-                     factory=AdminResource)
+    config.add_route('admin_index', '/admin')
+    config.add_route('admin_nipsa', '/admin/nipsa')
+    config.add_route('admin_nipsa_remove', '/admin/nipsa/remove')
+    config.add_route('admin_admins', '/admin/admins')
+    config.add_route('admin_admins_remove', '/admin/admins/delete')
+    config.add_route('admin_staff', '/admin/staff')
+    config.add_route('admin_staff_remove', '/admin/staff/delete')
     config.scan(__name__)

--- a/h/api/resources.py
+++ b/h/api/resources.py
@@ -39,6 +39,7 @@ class Annotations(object):
 class Root(Resource):
     __acl__ = [
         (Allow, Authenticated, 'create'),
+        (Allow, 'group:admin', 'admin'),
     ]
 
 

--- a/h/resources.py
+++ b/h/resources.py
@@ -54,6 +54,7 @@ class Stream(Resource):
 class Root(Resource):
     __acl__ = [
         (security.Allow, security.Authenticated, 'authenticated'),
+        (security.Allow, 'group:admin', 'admin'),
     ]
 
 


### PR DESCRIPTION
@tilgovi I realised that https://github.com/hypothesis/h/pull/2424 was kind of silly. We don't need a custom context resource factory for admin-only views, we just need to give the 'group:admin' principal the 'admin' permission on the root resources, and add the 'admin' permission to admin views.

That is, assuming we don't already use a permission called 'admin' anywhere else.