### PR TITLE
Use h.api.uri in streamer filter construction

### DIFF
--- a/h/streamer.py
+++ b/h/streamer.py
@@ -23,7 +23,7 @@ from ws4py.server.wsgiutils import WebSocketWSGIApplication
 
 from .api.auth import get_user  # FIXME: should not import from .api
 from h.api import nipsa
-from annotator import document
+from h.api import uri
 from .models import Annotation
 
 log = logging.getLogger(__name__)
@@ -498,21 +498,15 @@ class WebSocket(_WebSocket):
 
     def _expand_uris(self, clause):
         uris = clause['value']
+        expanded = set()
+
         if not isinstance(uris, list):
             uris = [uris]
 
-        if len(uris) < 1:
-            return
+        for item in uris:
+            expanded.update(uri.expand(item))
 
-        available_uris = set(uris)
-        for uri in uris:
-            doc = document.Document.get_by_uri(uri)
-            if doc is None:
-                return
-            for eq_uri in doc.uris():
-                available_uris.add(eq_uri)
-
-        clause['value'] = list(available_uris)
+        clause['value'] = list(expanded)
 
     def received_message(self, msg):
         with self.request.tm:

--- a/h/test/streamer_test.py
+++ b/h/test/streamer_test.py
@@ -239,12 +239,10 @@ class TestWebSocket(unittest.TestCase):
             }
         })
 
-        with patch('annotator.document.Document.get_by_uri') as doc:
-            uris = Mock()
-            uris.return_value = ['http://example.com',
-                                 'http://example.com/alter',
-                                 'http://example.com/print']
-            doc.return_value = Mock(uris=uris)
+        with patch('h.api.uri.expand') as expand:
+            expand.return_value = ['http://example.com',
+                                   'http://example.com/alter',
+                                   'http://example.com/print']
             msg = MagicMock()
             msg.data = filter_message
 
@@ -256,30 +254,6 @@ class TestWebSocket(unittest.TestCase):
             assert 'http://example.com' in uri_values
             assert 'http://example.com/alter' in uri_values
             assert 'http://example.com/print' in uri_values
-
-    def test_filter_message_will_not_change_for_empty_doc(self):
-        filter_message = json.dumps({
-            'filter': {
-                'actions': {},
-                'match_policy': 'include_all',
-                'clauses': [{
-                    'field': '/uri',
-                    'operator': 'equals',
-                    'value': 'http://example.com',
-                }],
-            }
-        })
-
-        with patch('annotator.document.Document.get_by_uri') as doc:
-            doc.return_value = None
-            msg = MagicMock()
-            msg.data = filter_message
-
-            self.s.received_message(msg)
-
-            uri_filter = self.s.filter.filter['clauses'][0]
-            uri_values = uri_filter['value']
-            assert 'http://example.com' == uri_values
 
 
 class TestBroadcast(unittest.TestCase):


### PR DESCRIPTION
Use the 'h.api.uri.expand` abstraction rather than dealing directly with the document model.