### PR TITLE
Refactor User.get_by_id()

### DIFF
--- a/h/accounts/test/models_test.py
+++ b/h/accounts/test/models_test.py
@@ -4,10 +4,66 @@ from __future__ import unicode_literals
 import re
 
 import pytest
+import mock
 from sqlalchemy import exc
 
 from h.accounts import models
 from h.test import factories
+
+
+# The fixtures required to mock all of get_by_id()'s dependencies.
+get_by_id_fixtures = pytest.mark.usefixtures('util', 'get_by_username')
+
+
+@get_by_id_fixtures
+def test_get_by_id_calls_split_user(util):
+    """It should call split_user() once with the given userid."""
+    util.split_user.return_value = ('fred', 'hypothes.is')
+
+    models.User.get_by_id('hypothes.is', 'acct:fred@hypothes.is')
+
+    util.split_user.assert_called_once_with('acct:fred@hypothes.is')
+
+
+@get_by_id_fixtures
+def test_get_by_id_returns_None_for_TypeError(util):
+    """If split_user() raises TypeError it should return None."""
+    util.split_user.side_effect = TypeError
+
+    user = models.User.get_by_id('hypothes.is', 'acct:fred@hypothes.is')
+
+    assert user is None
+
+
+@get_by_id_fixtures
+def test_get_by_id_returns_None_if_domain_does_not_match(util):
+    util.split_user.return_value = ('fred', 'bizarrohypothes.is')
+
+    result = models.User.get_by_id(
+        'hypothes.is',  # Request domain doesn't match the userid domain.
+        'acct:fred@bizarrohypothes.is')
+
+    assert result is None
+
+
+@get_by_id_fixtures
+def test_get_by_id_calls_get_by_username(util, get_by_username):
+    """It should call get_by_username() once with the username."""
+    util.split_user.return_value = ('username', 'domain')
+
+    models.User.get_by_id('domain', 'acct:username@domain')
+
+    get_by_username.assert_called_once_with('username')
+
+
+@get_by_id_fixtures
+def test_get_by_id_returns_user(util, get_by_username):
+    """It should return the result from get_by_username()."""
+    util.split_user.return_value = ('username', 'domain')
+
+    user = models.User.get_by_id('domain', 'acct:username@domain')
+
+    assert user == get_by_username.return_value
 
 
 def test_activation_has_asciinumeric_code(db_session):
@@ -111,3 +167,17 @@ def test_staff_members_does_not_return_non_staff_users(db_session):
 
     for non_staff in non_staff:
         assert non_staff not in staff
+
+
+@pytest.fixture
+def util(request):
+    patcher = mock.patch('h.accounts.models.util')
+    request.addfinalizer(patcher.stop)
+    return patcher.start()
+
+
+@pytest.fixture
+def get_by_username(request):
+    patcher = mock.patch('h.accounts.models.User.get_by_username')
+    request.addfinalizer(patcher.stop)
+    return patcher.start()

--- a/h/accounts/test/views_test.py
+++ b/h/accounts/test/views_test.py
@@ -823,7 +823,7 @@ def test_profile_looks_up_by_logged_in_user(authn_policy, user_model):
 
     ProfileController(request).profile()
 
-    user_model.get_by_id.assert_called_with(request, "acct:foo@bar.com")
+    user_model.get_by_id.assert_called_with(request.domain, "acct:foo@bar.com")
 
 
 @pytest.mark.usefixtures('user_model')

--- a/h/accounts/views.py
+++ b/h/accounts/views.py
@@ -422,7 +422,8 @@ class ProfileController(object):
         if err is not None:
             return err
 
-        user = User.get_by_id(self.request, self.request.authenticated_userid)
+        user = User.get_by_id(
+            self.request.domain, self.request.authenticated_userid)
         response = {'model': {'email': user.email}}
 
         # We allow updating subscriptions without validating a password
@@ -489,7 +490,7 @@ class ProfileController(object):
         userid = request.authenticated_userid
         model = {}
         if userid:
-            model["email"] = User.get_by_id(request, userid).email
+            model["email"] = User.get_by_id(request.domain, userid).email
         if request.feature('notification'):
             model['subscriptions'] = Subscriptions.get_subscriptions_for_uri(
                 userid)

--- a/h/auth.py
+++ b/h/auth.py
@@ -139,7 +139,7 @@ def effective_principals(userid, request):
         consumer_group = 'consumer:{}'.format(request.client.client_id)
         additional_principals.append(consumer_group)
 
-    primary_user = models.User.get_by_id(request, userid)
+    primary_user = models.User.get_by_id(request.domain, userid)
 
     if primary_user is not None:
         if primary_user.admin:

--- a/h/claim/views.py
+++ b/h/claim/views.py
@@ -71,7 +71,7 @@ def _validate_request(request):
     if payload is None:
         raise exc.HTTPNotFound()
 
-    user = User.get_by_id(request, payload['userid'])
+    user = User.get_by_id(request.domain, payload['userid'])
     if user is None:
         log.warn('got claim token with invalid userid=%r', payload['userid'])
         raise exc.HTTPNotFound()

--- a/h/groups/test/views_test.py
+++ b/h/groups/test/views_test.py
@@ -125,7 +125,7 @@ def test_create_gets_user_with_authenticated_id(Form, User):
     views.create(request)
 
     User.get_by_id.assert_called_once_with(
-        request, request.authenticated_userid)
+        request.domain, request.authenticated_userid)
 
 
 @create_fixtures
@@ -456,7 +456,7 @@ def test_join_gets_user_with_authenticated_userid(User):
     views.join(request)
 
     User.get_by_id.assert_called_once_with(
-        request, request.authenticated_userid)
+        request.domain, request.authenticated_userid)
 
 
 @join_fixtures

--- a/h/groups/views.py
+++ b/h/groups/views.py
@@ -47,7 +47,7 @@ def create(request):
         return {'form': form, 'data': request.params}
 
     user = accounts_models.User.get_by_id(
-        request, request.authenticated_userid)
+        request.domain, request.authenticated_userid)
     group = models.Group(name=appstruct["name"], creator=user)
     request.db.add(group)
 
@@ -122,7 +122,7 @@ def read(request):
         return _login_to_join(request, group)
     else:
         user = accounts_models.User.get_by_id(
-            request, request.authenticated_userid)
+            request.domain, request.authenticated_userid)
         if group in user.groups:
             return _read_group(request, group)
         else:
@@ -145,7 +145,7 @@ def join(request):
         raise exc.HTTPNotFound()
 
     user = accounts_models.User.get_by_id(
-        request, request.authenticated_userid)
+        request.domain, request.authenticated_userid)
 
     group.members.append(user)
 

--- a/h/session.py
+++ b/h/session.py
@@ -29,7 +29,7 @@ def _current_groups(request):
     userid = request.authenticated_userid
     if userid is None:
         return groups
-    user = models.User.get_by_id(request, userid)
+    user = models.User.get_by_id(request.domain, userid)
     if user is None:
         return groups
     for group in user.groups:

--- a/h/util.py
+++ b/h/util.py
@@ -2,14 +2,14 @@
 import re
 
 
-def split_user(username):
-    """Return the user and domain parts from the given user account name.
+def split_user(userid):
+    """Return the user and domain parts from the given user id.
 
-    For example if username is "acct:seanh@hypothes.is" then return
-    ("seanh", "hypothes.is").
+    For example if userid is u'acct:seanh@hypothes.is' then return
+    (u'seanh', u'hypothes.is').
 
     """
-    match = re.match(r'^acct:([^@]+)@(.*)$', username)
+    match = re.match(r'^acct:([^@]+)@(.*)$', userid)
     if match:
         return match.groups()
     # Passed username didn't match


### PR DESCRIPTION
- Take domain arg instead of request
- Use util.split_user(), remove code duplication
- Remove unused capability to get a user by integer primary key
- Also fix some variable names in split_user()