### PR TITLE
Support for server sent events

### DIFF
--- a/h/api/__init__.py
+++ b/h/api/__init__.py
@@ -1,9 +1,12 @@
 # -*- coding: utf-8 -*-
 __all__ = ('create_root', 'includeme')
+from h.api.renderers import events_renderer_factory
 from h.api.resources import create_root
 
 
 def includeme(config):
+    config.add_renderer('events', events_renderer_factory)
+
     config.add_route('api', '/', factory=create_root)
     config.add_route('access_token', '/access_token')
 

--- a/h/api/db.py
+++ b/h/api/db.py
@@ -11,6 +11,7 @@ from sqlalchemy.ext import declarative
 
 from .models import Annotation
 from .models import Document
+from .models import Percolator
 
 
 log = logging.getLogger(__name__)
@@ -54,7 +55,7 @@ def create_db():
     # Check for required plugin(s)
     _ensure_es_plugins(es.conn)
 
-    models = [Annotation, Document]
+    models = [Annotation, Document, Percolator]
     mappings = {}
     analysis = {}
 
@@ -127,6 +128,7 @@ def delete_db():
     """Delete the Annotation and Document databases."""
     Annotation.drop_all()
     Document.drop_all()
+    Percolator.drop_all()
 
 
 def use_session(session, base=Base):

--- a/h/api/queue.py
+++ b/h/api/queue.py
@@ -15,13 +15,23 @@ def annotation(event):
     if not request.feature('queue'):
         return
 
+    client_id = request.headers.get('X-Client-Id')
     queue = request.get_queue_writer()
     data = {
         'action': action,
         'annotation': annotation,
-        'src_client_id': request.headers.get('X-Client-Id'),
+        'src_client_id': client_id,
     }
     queue.publish('annotations', json.dumps(data))
+
+    percolate = annotation.percolate()
+    for percolator_id in percolate['matches']:
+        # Don't echo events back to their producer.
+        if percolator_id is client_id:
+            continue
+        topic_id = 'percolator-{}#ephemeral'.format(percolator_id)
+        message = json.dumps({'event': action, 'data': annotation})
+        queue.publish(topic_id, message)
 
 
 def includeme(config):

--- a/h/api/renderers.py
+++ b/h/api/renderers.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+def events_renderer_factory(info):
+    def _consume_events(value):
+        for event in value:
+            if event is None:
+                yield ':'
+            else:
+                if 'data' in event:
+                    yield 'data:{}\n'.format(event['data'])
+                if 'event' in event:
+                    yield 'event:{}\n'.format(event['event'])
+                if 'id' in event:
+                    yield 'id:{}\n'.format(event['id'])
+            yield '\n'
+
+    def _render(value, system):
+        request = system.get('request')
+        if request is not None:
+            response = request.response
+            ct = response.content_type
+            if ct == response.default_content_type:
+                response.content_type = 'text/event-stream'
+
+        response.app_iter = _consume_events(value)
+        return None
+
+    return _render

--- a/h/api/search/__init__.py
+++ b/h/api/search/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from h.api.search.core import search
+from h.api.search.core import percolator
 from h.api.search.transform import prepare
 from h.api.search.transform import render
 
@@ -8,4 +9,5 @@ __all__ = (
     'prepare',
     'render',
     'search',
+    'percolator',
 )

--- a/h/api/search/core.py
+++ b/h/api/search/core.py
@@ -37,3 +37,17 @@ def search(request, params):
     rows = [models.Annotation(d['_source'], id=d['_id']) for d in docs]
 
     return {"rows": rows, "total": total}
+
+
+def percolator(request, params):
+    builder = query.Builder()
+
+    builder.append_filter(query.AuthFilter(request))
+    builder.append_filter(query.UriFilter(request))
+    builder.append_filter(
+        lambda _: nipsa.nipsa_filter(request.authenticated_userid))
+
+    builder.append_matcher(query.AnyMatcher())
+
+    body = builder.build(params)
+    return models.Percolator(body)

--- a/h/models.py
+++ b/h/models.py
@@ -14,6 +14,7 @@ __all__ = (
     'Document',
     'Feature',
     'Group',
+    'Percolator',
     'NipsaUser',
     'Subscriptions',
     'User',
@@ -26,6 +27,7 @@ Document = api_models.Document
 Feature = features.Feature
 Group = groups_models.Group
 NipsaUser = nipsa_models.NipsaUser
+Percolator = api_models.Percolator
 Subscriptions = notification_models.Subscriptions
 User = accounts_models.User
 

--- a/h/server.py
+++ b/h/server.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
+from datetime import datetime
+
 from gunicorn.workers.ggevent import GeventPyWSGIWorker, PyWSGIHandler
+from gunicorn.workers.ggevent import GeventResponse
 from ws4py.server.geventserver import WSGIServer, WebSocketWSGIHandler
 
 
@@ -17,6 +20,19 @@ class WSGIHandler(PyWSGIHandler, WebSocketWSGIHandler):
             self.environ.setdefault('ws4py.websocket', None)
 
         super(WSGIHandler, self).finalize_headers()
+
+    def log_request(self):
+        start = datetime.fromtimestamp(self.time_start)
+        finish = datetime.fromtimestamp(self.time_finish)
+        response_time = finish - start
+        resp_headers = getattr(self, 'response_headers', {})
+        resp = GeventResponse(self.status, resp_headers, self.response_length)
+        if hasattr(self, 'headers'):
+            req_headers = [h.split(":", 1) for h in self.headers.headers]
+        else:
+            req_headers = []
+        self.server.log.logger.access(resp, req_headers, self.environ,
+                                      response_time)
 
 
 class Worker(GeventPyWSGIWorker):

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ INSTALL_REQUIRES = [
     'cryptography>=0.7',
     'deform>=0.9,<1.0',
     'elasticsearch>=1.1.0',
-    'gevent>=1.0.2,<1.1.0',
+    'gevent>=1.1.0b1,<1.2.0',
     'gnsq>=0.3.0,<0.4.0',
     'gunicorn>=19.2,<20',
     'hashids==1.1.0',  # hashid format may change with updated hashid package,


### PR DESCRIPTION
Add server-side support for server sent events, allowing clients to
subscribe to searches.

The implementation relies on Elasticsearch percolator documents and
ephemeral nsq topics. Each client creates an ephemeral topic and a
percolator. The percolator stores the query from the request parameters
and whenever writes occur the annotation document is percolated and
sent to all matching topics.

The TTL feature of Elasticsearch ensures that percolator documents
are cleaned up even in the event of a server fault.