### PR TITLE
Update documentation

### DIFF
--- a/docs/INSTALL.rst
+++ b/docs/INSTALL.rst
@@ -1,5 +1,5 @@
-Installation guide
-##################
+Deploying to a production environment
+#####################################
 
 This document contains instructions for deploying h to a production environment.
 If you are looking for instructions on setting up a development environment for

--- a/docs/hacking/administration.rst
+++ b/docs/hacking/administration.rst
@@ -1,0 +1,18 @@
+Administration
+--------------
+
+To access the admin interface, a user must be logged into hypothes.is and have admin permissions.
+To grant admin permissions to a user, run the following command in the virtual environment:
+
+.. code-block:: bash
+	
+	hypothesis admin <config_uri> <username>
+
+For example, to make someone an admin in the development configuration:
+	
+.. code-block:: bash
+	
+	hypothesis admin conf/development.ini usernamehere
+
+When this user signs in they can now access the adminstration panel at ``/admin``. The administration panel has basic options for managing users, as well as the ability to enable feature flags to try out features currently in development.
+

--- a/docs/hacking/documentation.rst
+++ b/docs/hacking/documentation.rst
@@ -2,10 +2,19 @@ Writing documentation
 #####################
 
 To build the documentation, ensure that Sphinx_ is installed and issue the
-```make html``` command from the docs directory::
+```make html``` command from the docs directory:
 
-    $ cd docs/
-    $ make html
+.. code-block:: bash
+
+    cd docs/
+    make html
+
+When the build finishes, you can view the documentation by running a static 
+web server in the newly generated ``_build/html/`` directory. For example:
+	
+.. code-block:: bash
+
+    pushd _build/html/; python -m SimpleHTTPServer; popd
 
 .. _Sphinx: http://sphinx-doc.org/
 

--- a/docs/hacking/index.rst
+++ b/docs/hacking/index.rst
@@ -17,3 +17,4 @@ and how to contribute code or documentation to the project.
    documentation
    customized-embedding
    ssl
+   administration

--- a/docs/hacking/install.rst
+++ b/docs/hacking/install.rst
@@ -289,3 +289,12 @@ use and configure it.
 .. _pyramid_debugtoolbar: https://github.com/Pylons/pyramid_debugtoolbar
 .. _pyramid_debugtoolbar documentation: http://docs.pylonsproject.org/projects/pyramid-debugtoolbar/en/latest/
 
+
+Feature Flags
+-------------
+
+Features flags allow admins to enable or disable features for certain groups
+of users. You can enable or disable them from the administration dashboard.
+Please consult the :doc:`administration` documentation for more information
+on accessing the admin dashboard.
+


### PR DESCRIPTION
+ Provide details on how to make a user an admin and access the admin dashboard.
+ Describe how feature flags are used and where they can be enabled
+ Clarify how to view builds of the documentation
+ Reorganize a bit

I was wanting to enable feature flags to review the groups work with @conordelahunty and realized that there was no information about them or making users an administrator in the documentation. This PR provides that info and makes a few other changes which I feel make things clearer.