### PR TITLE
Lenient search

### DIFF
--- a/h/api/search/query.py
+++ b/h/api/search/query.py
@@ -89,10 +89,9 @@ def build(request_params, effective_principals, userid=None,
 
     if "any" in request_params:
         matches.append({
-            "multi_match": {
+            "simple_query_string": {
                 "fields": ["quote", "tags", "text", "uri.parts", "user"],
-                "query": request_params.getall("any"),
-                "type": "cross_fields"
+                "query": ' '.join(request_params.getall("any"))
             }
         })
         del request_params["any"]

--- a/h/api/search/query.py
+++ b/h/api/search/query.py
@@ -103,7 +103,7 @@ def build(request_params, effective_principals, userid=None,
     query = {"match_all": {}}
 
     if matches:
-        query = {"bool": {"must": matches}}
+        query = {"bool": {"should": matches}}
 
     if filters:
         query = {

--- a/h/api/search/test/query_test.py
+++ b/h/api/search/test/query_test.py
@@ -3,7 +3,6 @@
 import pytest
 import mock
 from webob import multidict
-from pyramid import testing
 
 from h.api.search import query
 

--- a/h/api/search/test/query_test.py
+++ b/h/api/search/test/query_test.py
@@ -278,7 +278,7 @@ def test_build_with_combined_user_and_tag_query():
 
 @build_fixtures
 def test_build_with_keyword():
-    """Keywords are returned in the query dict in a "multi_match" clause."""
+    """Keywords are returned in a "simple_query_string" clause."""
     params = multidict.MultiDict()
     params.add("any", "howdy")
 
@@ -288,11 +288,10 @@ def test_build_with_keyword():
         "bool": {
             "should": [
                 {
-                    "multi_match": {
+                    "simple_query_string": {
                         "fields": ["quote", "tags", "text", "uri.parts",
                                    "user"],
-                        "query": ["howdy"],
-                        "type": "cross_fields"
+                        "query": "howdy",
                     }
                 }
             ]
@@ -310,10 +309,9 @@ def test_build_with_multiple_keywords():
     q = query.build(params, [])
 
     assert q["query"]["filtered"]["query"] == {
-        "bool": {"should": [{"multi_match": {
+        "bool": {"should": [{"simple_query_string": {
             "fields": ["quote", "tags", "text", "uri.parts", "user"],
-            "query": ["howdy", "there"],
-            "type": "cross_fields"
+            "query": "howdy there",
         }}]}
     }
 

--- a/h/api/search/test/query_test.py
+++ b/h/api/search/test/query_test.py
@@ -213,7 +213,7 @@ def test_build_for_user():
     q = query.build(multidict.NestedMultiDict({"user": "bob"}), [])
 
     assert q["query"]["filtered"]["query"] == {
-        "bool": {"must": [{"match": {"user": "bob"}}]}}
+        "bool": {"should": [{"match": {"user": "bob"}}]}}
 
 
 @build_fixtures
@@ -227,7 +227,7 @@ def test_build_for_multiple_users():
 
     assert q["query"]["filtered"]["query"] == {
         "bool": {
-            "must": [
+            "should": [
                 {"match": {"user": "fred"}},
                 {"match": {"user": "bob"}}
             ]
@@ -241,7 +241,7 @@ def test_build_for_tag():
     q = query.build(multidict.NestedMultiDict({"tags": "foo"}), [])
 
     assert q["query"]["filtered"]["query"] == {
-        "bool": {"must": [{"match": {"tags": "foo"}}]}}
+        "bool": {"should": [{"match": {"tags": "foo"}}]}}
 
 
 @build_fixtures
@@ -255,7 +255,7 @@ def test_build_for_multiple_tags():
 
     assert q["query"]["filtered"]["query"] == {
         "bool": {
-            "must": [
+            "should": [
                 {"match": {"tags": "foo"}},
                 {"match": {"tags": "bar"}}
             ]
@@ -270,7 +270,7 @@ def test_build_with_combined_user_and_tag_query():
         multidict.NestedMultiDict({"user": "bob", "tags": "foo"}), [])
 
     assert q["query"]["filtered"]["query"] == {
-        "bool": {"must": [
+        "bool": {"should": [
             {"match": {"user": "bob"}},
             {"match": {"tags": "foo"}},
         ]}}
@@ -286,7 +286,7 @@ def test_build_with_keyword():
 
     assert q["query"]["filtered"]["query"] == {
         "bool": {
-            "must": [
+            "should": [
                 {
                     "multi_match": {
                         "fields": ["quote", "tags", "text", "uri.parts",
@@ -310,7 +310,7 @@ def test_build_with_multiple_keywords():
     q = query.build(params, [])
 
     assert q["query"]["filtered"]["query"] == {
-        "bool": {"must": [{"multi_match": {
+        "bool": {"should": [{"multi_match": {
             "fields": ["quote", "tags", "text", "uri.parts", "user"],
             "query": ["howdy", "there"],
             "type": "cross_fields"
@@ -427,7 +427,7 @@ def test_build_with_single_text_param():
     q = query.build(multidict.NestedMultiDict({"text": "foobar"}), [])
 
     assert q["query"]["filtered"]["query"] == {
-        "bool": {"must": [{"match": {"text": "foobar"}}]}}
+        "bool": {"should": [{"match": {"text": "foobar"}}]}}
 
 
 @build_fixtures
@@ -440,7 +440,7 @@ def test_build_with_multiple_text_params():
 
     assert q["query"]["filtered"]["query"] == {
         "bool": {
-            "must": [
+            "should": [
                 {"match": {"text": "foo"}},
                 {"match": {"text": "bar"}}
             ]
@@ -454,7 +454,7 @@ def test_build_with_single_quote_param():
     q = query.build(multidict.NestedMultiDict({"quote": "foobar"}), [])
 
     assert q["query"]["filtered"]["query"] == {
-        "bool": {"must": [{"match": {"quote": "foobar"}}]}}
+        "bool": {"should": [{"match": {"quote": "foobar"}}]}}
 
 
 @build_fixtures
@@ -467,7 +467,7 @@ def test_build_with_multiple_quote_params():
 
     assert q["query"]["filtered"]["query"] == {
         "bool": {
-            "must": [
+            "should": [
                 {"match": {"quote": "foo"}},
                 {"match": {"quote": "bar"}}
             ]
@@ -523,7 +523,7 @@ def test_build_with_arbitrary_params():
 
     assert q["query"]["filtered"]["query"] == {
         'bool': {
-            'must': [
+            'should': [
                 {
                     'match': {'foo.bar': 'arbitrary'}
                 }

--- a/h/api/search/test/query_test.py
+++ b/h/api/search/test/query_test.py
@@ -10,8 +10,8 @@ from h.api.search import query
 def test_auth_filter_with_not_logged_in():
     effective_principals = ['system.Everyone']
     assert query.auth_filter(effective_principals) == {
-            'terms': {
-                'permissions.read': ['group:__world__', 'system.Everyone']}}
+        'terms': {
+            'permissions.read': ['group:__world__', 'system.Everyone']}}
 
 
 def test_auth_filter_when_user_is_not_a_member_of_any_groups():


### PR DESCRIPTION
This is a set of three commits designed to enabled a slightly more relaxed search experience. Commit messages reproduced in chronological order:

commit f2c65f8eefff80b78bd1345a8a956f73a4b8ffce
Author: Randall Leeds <tilgovi@hypothes.is>
Date:   Fri Aug 14 15:50:02 2015 -0700

    Treat the URI search match clauses as a filter
    
    These were being wrapped in their own boolean "should" so that only
    one URI match was required to match, despite the other clauses being
    joined under a "must".
    
    Moving these "match" clauses to a query filter makes it possible to be
    more lenient in the future by relaxing the "must" clauses into a
    "should".

commit 49dcbef846751a22cf92c1862c12030f32480260
Author: Randall Leeds <tilgovi@hypothes.is>
Date:   Fri Aug 14 15:56:14 2015 -0700

    Use "should" instead of "must" for search queries
    
    This relaxes the search queries to be allow results that match only
    some of the query. This is hopefully more intuitive for the user,
    since partial matches are returned in the absence of full matches.

commit ce4751509233f5c9bda7f9f6cf50bd81a3922cb9
Author: Randall Leeds <tilgovi@hypothes.is>
Date:   Fri Aug 14 16:00:11 2015 -0700

    Use a simple_query_string for search remainders
    
    Specifying multiple "any" terms in a search was resulting in only the
    last term being applied, since "multi_match" takes a string. Instead,
    change to the "simple_query_string" query and join the terms. This
    allows multiple terms to be specified and enables the user to use
    some advanced, but fairly safe, constructions.