### PR TITLE
Get username from auth not from form

### DIFF
--- a/h/accounts/schemas.py
+++ b/h/accounts/schemas.py
@@ -193,8 +193,6 @@ class ProfileSchema(CSRFSchema):
     This form is broken into multiple parts, for updating the email address,
     password, and subscriptions, so multiple fields are nullable.
     """
-
-    username = colander.SchemaNode(colander.String())
     pwd = colander.SchemaNode(
         colander.String(),
         widget=deform.widget.PasswordWidget(),

--- a/h/accounts/test/views_test.py
+++ b/h/accounts/test/views_test.py
@@ -945,8 +945,8 @@ def test_disable_user_with_invalid_password(form_validator, user_model):
     request = DummyRequest(method='POST')
     form_validator.return_value = (None, {"username": "john", "pwd": "doe"})
 
-    # With an invalid password, get_user returns None
-    user_model.get_user.return_value = None
+    # With an invalid password, validate_user() returns False.
+    user_model.validate_user.return_value = False
 
     profile = ProfileController(request)
     result = profile.disable_user()
@@ -962,7 +962,7 @@ def test_disable_user_sets_random_password(form_validator, user_model):
     form_validator.return_value = (None, {"username": "john", "pwd": "doe"})
 
     user = FakeUser(password='abc')
-    user_model.get_user.return_value = user
+    user_model.get_by_userid.return_value = user
 
     profile = ProfileController(request)
     profile.disable_user()

--- a/h/accounts/test/views_test.py
+++ b/h/accounts/test/views_test.py
@@ -942,7 +942,7 @@ def test_subscription_update(authn_policy, form_validator,
 @pytest.mark.usefixtures('activation_model')
 def test_disable_user_with_invalid_password(form_validator, user_model):
     """Make sure our disable_user call validates the user password."""
-    request = DummyRequest(method='POST')
+    request = Mock(method='POST', authenticated_userid='john')
     form_validator.return_value = (None, {"username": "john", "pwd": "doe"})
 
     # With an invalid password, validate_user() returns False.
@@ -958,7 +958,7 @@ def test_disable_user_with_invalid_password(form_validator, user_model):
 @pytest.mark.usefixtures('activation_model')
 def test_disable_user_sets_random_password(form_validator, user_model):
     """Check if the user is disabled."""
-    request = DummyRequest(method='POST')
+    request = Mock(method='POST', authenticated_userid='john')
     form_validator.return_value = (None, {"username": "john", "pwd": "doe"})
 
     user = FakeUser(password='abc')
@@ -968,6 +968,12 @@ def test_disable_user_sets_random_password(form_validator, user_model):
     profile.disable_user()
 
     assert user.password == user_model.generate_random_password.return_value
+
+
+def test_disable_user_with_no_authenticated_user():
+    exc = ProfileController(Mock(authenticated_userid=None)).disable_user()
+
+    assert isinstance(exc, httpexceptions.HTTPUnauthorized)
 
 
 @pytest.fixture

--- a/h/accounts/views.py
+++ b/h/accounts/views.py
@@ -467,12 +467,10 @@ class ProfileController(object):
         if err is not None:
             return err
 
-        username = appstruct['username']
-        pwd = appstruct['pwd']
+        user = User.get_by_userid(
+            self.request.domain, self.request.authenticated_userid)
 
-        # Password check
-        user = User.get_user(username, pwd)
-        if user:
+        if User.validate_user(user, appstruct['pwd']):  # Password check.
             # TODO: maybe have an explicit disabled flag in the status
             user.password = User.generate_random_password()
             self.request.session.flash(_('Account disabled.'), 'success')

--- a/h/accounts/views.py
+++ b/h/accounts/views.py
@@ -463,6 +463,9 @@ class ProfileController(object):
 
     def disable_user(self):
         """Disable the user by setting a random password."""
+        if self.request.authenticated_userid is None:
+            return httpexceptions.HTTPUnauthorized()
+
         err, appstruct = validate_form(self.form, self.request.POST.items())
         if err is not None:
             return err


### PR DESCRIPTION
When editing a user's profile or disabling a user, use the user from
request.authenticated_userid not the username submitted in the form.

Remove username from the schema so the form submission doesn't need to
contain it.

The change email form was getting a validation error back from the
server because it didn't submit the username in the form - now it
doesn't need to. Fixes #2441.