### PR TITLE
Support epub integrations

### DIFF
--- a/h/static/scripts/annotator/guest.coffee
+++ b/h/static/scripts/annotator/guest.coffee
@@ -69,6 +69,13 @@ module.exports = class Guest extends Annotator
     this._connectAnnotationSync(@crossframe)
     this._connectAnnotationUISync(@crossframe)
 
+    if !@options.disableClickToClose
+      @wrapper = @element
+      .on 'click', (event) =>
+        if !@selectedTargets?.length
+          this.hideFrame()
+      this
+
     # Load plugins
     for own name, opts of @options
       if not @plugins[name] and Annotator.Plugin[name]
@@ -125,13 +132,6 @@ module.exports = class Guest extends Annotator
 
     crossframe.on 'setVisibleHighlights', (state) =>
       this.publish 'setVisibleHighlights', state
-
-  _setupWrapper: ->
-    @wrapper = @element
-    .on 'click', (event) =>
-      if !@selectedTargets?.length
-        this.hideFrame()
-    this
 
   # These methods aren't used in the iframe-hosted configuration of Annotator.
   _setupDynamicStyle: -> this

--- a/h/static/scripts/annotator/host.coffee
+++ b/h/static/scripts/annotator/host.coffee
@@ -60,8 +60,9 @@ module.exports = class Host extends Guest
 
   showFrame: (options={transition: true}) ->
     # Emit event for integrators to be able to react to sidebar.
-    showFrameEvent = new Event('hypothesisSidebarOpen')
-    window.dispatchEvent(showFrameEvent)
+    try
+      showFrameEvent = new Event('hypothesisSidebarOpen')
+      window.dispatchEvent(showFrameEvent)
 
     if options.transition
       @frame.removeClass 'annotator-no-transition'
@@ -77,8 +78,9 @@ module.exports = class Host extends Guest
 
   hideFrame: ->
     # Emit event for integrators to be able to react to sidebar.
-    hideFrameEvent = new Event('hypothesisSidebarClosed')
-    window.dispatchEvent(hideFrameEvent)
+    try
+      hideFrameEvent = new Event('hypothesisSidebarClosed')
+      window.dispatchEvent(hideFrameEvent)
 
     @frame.css 'margin-left': ''
     @frame.removeClass 'annotator-no-transition'

--- a/h/static/scripts/annotator/host.coffee
+++ b/h/static/scripts/annotator/host.coffee
@@ -59,6 +59,10 @@ module.exports = class Host extends Guest
     super
 
   showFrame: (options={transition: true}) ->
+    # Emit event for integrators to be able to react to sidebar.
+    showFrameEvent = new Event('hypothesisSidebarOpen')
+    window.dispatchEvent(showFrameEvent)
+
     if options.transition
       @frame.removeClass 'annotator-no-transition'
     else
@@ -72,6 +76,10 @@ module.exports = class Host extends Guest
       .addClass('h-icon-chevron-right')
 
   hideFrame: ->
+    # Emit event for integrators to be able to react to sidebar.
+    hideFrameEvent = new Event('hypothesisSidebarClosed')
+    window.dispatchEvent(hideFrameEvent)
+
     @frame.css 'margin-left': ''
     @frame.removeClass 'annotator-no-transition'
     @frame.addClass 'annotator-collapsed'


### PR DESCRIPTION
There are two things I absolutely need for the epub integrations (Readium and Epub.js):
1. An event that fire when the sidebar opens and closes.
2. An option to disable click to close. 

For the record I don't support killing "click to close" off entirely as suggested in #2167 (not enough data it's a problem IMHO), but for a dedicated reading app it's much nicer without it. Other integrators may also want to disable it.
