### PR TITLE
Move nipsa setting to search prepare transform

### DIFF
--- a/h/api/logic.py
+++ b/h/api/logic.py
@@ -2,7 +2,6 @@
 import logging
 
 from h.api.models import Annotation
-from h.api import nipsa
 from h.api import search as search_lib
 
 
@@ -25,8 +24,6 @@ def create_annotation(fields, user):
     annotation['user'] = user.id
     annotation['consumer'] = user.consumer.key
 
-    if nipsa.has_nipsa(user.id):
-        annotation["nipsa"] = True
 
     # Save it in the database
     search_lib.prepare(annotation)

--- a/h/api/search/test/transform_test.py
+++ b/h/api/search/test/transform_test.py
@@ -34,6 +34,20 @@ def test_prepare_adds_source_normalized_field(ann_in, ann_out, uri_normalize):
     assert ann_in == ann_out
 
 
+@pytest.mark.parametrize("ann,nipsa", [
+    ({"user": "george"}, True),
+    ({"user": "georgia"}, False),
+    ({}, False),
+])
+def test_prepare_sets_nipsa_field(ann, nipsa, has_nipsa):
+    has_nipsa.return_value = nipsa
+    transform.prepare(ann)
+    if nipsa:
+        assert ann["nipsa"] is True
+    else:
+        assert "nipsa" not in ann
+
+
 @pytest.mark.parametrize("ann_in,ann_out", [
     # Preserves the basics
     ({}, {}),
@@ -59,6 +73,13 @@ def test_render_noop_when_nothing_to_remove(ann_in, ann_out):
 ])
 def test_render_removes_source_normalized_field(ann_in, ann_out):
     assert transform.render(ann_in) == ann_out
+
+
+@pytest.fixture
+def has_nipsa(request):
+    patcher = mock.patch('h.api.nipsa.has_nipsa', autospec=True)
+    request.addfinalizer(patcher.stop)
+    return patcher.start()
 
 
 @pytest.fixture

--- a/h/api/search/transform.py
+++ b/h/api/search/transform.py
@@ -4,6 +4,7 @@
 
 import copy
 
+from h.api import nipsa
 from h.api import uri
 
 
@@ -17,6 +18,9 @@ def prepare(annotation):
     # FIXME: When this becomes simply part of a search indexing operation, this
     # should probably not mutate its argument.
     _normalize_annotation_target_uris(annotation)
+
+    if 'user' in annotation and nipsa.has_nipsa(annotation['user']):
+        annotation['nipsa'] = True
 
 
 def render(annotation):

--- a/h/api/test/logic_test.py
+++ b/h/api/test/logic_test.py
@@ -19,7 +19,7 @@ def _mock_annotation(**kwargs):
 
 # The fixtures required to mock all of create_annotation()'s dependencies.
 create_annotation_fixtures = pytest.mark.usefixtures(
-    'Annotation', 'nipsa', 'search_lib',)
+    'Annotation', 'search_lib')
 
 
 @create_annotation_fixtures
@@ -68,39 +68,6 @@ def test_create_annotation_sets_consumer(Annotation):
     annotation = logic.create_annotation({}, user)
 
     assert annotation['consumer'] == user.consumer.key
-
-
-@create_annotation_fixtures
-def test_create_annotation_calls_nipsa(nipsa):
-    """It should call has_nipsa() once with the user's id."""
-    user = mock.Mock()
-
-    logic.create_annotation({}, user)
-
-    nipsa.has_nipsa.assert_called_once_with(user.id)
-
-
-@create_annotation_fixtures
-def test_create_annotation_sets_nipsa_if_user_is_nipsad(Annotation, nipsa):
-    Annotation.return_value = _mock_annotation()
-    # The user is nipsa'd.
-    nipsa.has_nipsa.return_value = True
-
-    annotation = logic.create_annotation({}, mock.Mock())
-
-    assert annotation['nipsa'] is True
-
-
-@create_annotation_fixtures
-def test_create_annotation_does_not_set_nipsa_if_user_is_not_nipsad(
-        Annotation, nipsa):
-    Annotation.return_value = _mock_annotation()
-    # The user is not nipsa'd.
-    nipsa.has_nipsa.return_value = False
-
-    annotation = logic.create_annotation({}, mock.Mock())
-
-    assert 'nipsa' not in annotation
 
 
 @create_annotation_fixtures
@@ -290,13 +257,6 @@ def test_update_annotation_calls_save():
 @pytest.fixture
 def Annotation(request):
     patcher = mock.patch('h.api.logic.Annotation', autospec=True)
-    request.addfinalizer(patcher.stop)
-    return patcher.start()
-
-
-@pytest.fixture
-def nipsa(request):
-    patcher = mock.patch('h.api.logic.nipsa', autospec=True)
     request.addfinalizer(patcher.stop)
     return patcher.start()
 


### PR DESCRIPTION
NIPSA is a feature of search and it should be enforced on every
index operation, not just create. Put it in the prepare function.