### PR TITLE
Always return parent annotations of replies

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -84,6 +84,11 @@ search
 
    **Example response**:
 
+   Top-level annotations (but not replies) that match the search query are
+   returned in the "rows" field. The "total" field counts the number of these
+   top-level annotations. The "replies" field always contains all of the reply
+   annotations to the top-level annotations in "rows".
+
    .. sourcecode:: http
 
       HTTP/1.1 200 OK
@@ -104,25 +109,28 @@ search
                   "user": "acct:gluejar@hypothes.is"
               }
           ],
-          "total": 1
+          "total": 1,
+          "replies": [
+              {...}
+          ]
       }
 
-   :query limit: The maximum number of annotations to return, for example:
-       ``/api/search?limit=30``. (Default: 20)
+   :query limit: The maximum number of top-level annotations to return in
+       "rows", for example: ``/api/search?limit=30``. (Default: 20)
 
-   :query offset: The minimum number of initial annotations to skip. This is
-       used for pagination. For example if there are 65 annotations matching
-       our search query and we're retrieving up to 30 annotations at a time,
-       then to retrieve the last 5 do: ``/api/search?limit=30&offset=60``.
-       (Default: 0)
+   :query offset: The minimum number of initial top-level annotations to skip.
+       This is used for pagination. For example if there are 65 annotations
+       matching our search query and we're retrieving up to 30 annotations at a
+       time, then to retrieve the last 5 do:
+       ``/api/search?limit=30&offset=60``.  (Default: 0)
 
-   :query sort: Specify which field the annotations should be sorted by. For
-       example to sort annotations by the name of the user that created them,
-       do: ``/api/search?sort=user`` (default: updated)
+   :query sort: Specify which field the top-level annotations should be sorted
+       by. For example to sort annotations by the name of the user that created
+       them, do: ``/api/search?sort=user`` (default: updated)
 
-   :query order: Specify which order (ascending or descending) the annotations
-       should be sorted in. For example to sort annotations in ascending
-       order of created time (i.e. oldest annotations first) do:
+   :query order: Specify which order (ascending or descending) the top-level
+       annotations should be sorted in. For example to sort annotations in
+       ascending order of created time (i.e. oldest annotations first) do:
        ``/api/search?sort=created&order=asc``. (Default: desc)
 
    :query uri: Search for annotations of a particular URI, for example

--- a/h/api/search/query.py
+++ b/h/api/search/query.py
@@ -10,6 +10,9 @@ def build(request_params, userid=None, search_normalized_uris=False):
     Translates the HTTP request params accepted by the h search API into an
     Elasticsearch query dict.
 
+    Always inserts a filter so that only top-level annotations will be returned
+    by Elasticsearch, never reply annotations.
+
     :param request_params: the HTTP request params that were posted to the
         h search API
     :type request_params: webob.multidict.NestedMultiDict
@@ -24,6 +27,7 @@ def build(request_params, userid=None, search_normalized_uris=False):
     :returns: an Elasticsearch query dict corresponding to the given h search
         API params
     :rtype: dict
+
     """
     # NestedMultiDict objects are read-only, so we need to copy to make it
     # modifiable.
@@ -50,7 +54,7 @@ def build(request_params, userid=None, search_normalized_uris=False):
         }
     }]
 
-    filters = []
+    filters = [{'missing': {'field': 'references'}}]
     matches = []
 
     uri_param = request_params.pop("uri", None)

--- a/h/api/search/test/core_test.py
+++ b/h/api/search/test/core_test.py
@@ -41,6 +41,91 @@ def test_search_does_pass_userid_to_build(build, _):
     assert build.call_args[1]["userid"] == "test_id"
 
 
+@mock.patch("h.api.search.core.models.Annotation")
+@mock.patch("h.api.search.core.query.build")
+def test_search_queries_for_replies(_, Annotation):
+    """It does a second Es query for replies to the results of the first."""
+    ids = ['foo', 'bar', 'gar']
+    Annotation.search_raw.side_effect = [
+        # The first time search_raw() is called it returns the result of
+        # querying for the top-level annotations only.
+        {
+            'hits': {
+                'total': 3,
+                'hits': [
+                    {'_id': ids[0], '_source': 'source'},
+                    {'_id': ids[1], '_source': 'source'},
+                    {'_id': ids[2], '_source': 'source'}
+                ]
+            }
+        },
+        # The second call returns the result of querying for all the replies to
+        # those annotations
+        {
+            'hits': {
+                'total': 3,
+                'hits': [
+                    {'_id': 'reply_1', '_source': 'source'},
+                    {'_id': 'reply_2', '_source': 'source'},
+                    {'_id': 'reply_3', '_source': 'source'}
+                ]
+            }
+        },
+    ]
+    user = mock.Mock()
+
+    core.search(mock.Mock(), user=user)
+
+    assert Annotation.search_raw.call_count == 2
+    Annotation.search_raw.assert_called_with(
+        {'query': {'terms': {'references': ids}}, 'size': 10000},
+        user=user, raw_result=True)
+
+
+@mock.patch("h.api.search.core.models.Annotation")
+@mock.patch("h.api.search.core.query.build")
+def test_search_returns_replies(_, Annotation):
+    """It should return an Annotation for each reply from search_raw()."""
+    Annotation.search_raw.side_effect = [
+        # The first time search_raw() is called it returns the result of
+        # querying for the top-level annotations only.
+        {
+            'hits': {
+                'total': 1,
+                'hits': [{'_id': 'parent_annotation_id', '_source': 'source'}]
+            }
+        },
+        # The second call returns the result of querying for all the replies to
+        # those annotations
+        {
+            'hits': {
+                'total': 3,
+                'hits': [
+                    {'_id': 'reply_1', '_source': 'source'},
+                    {'_id': 'reply_2', '_source': 'source'},
+                    {'_id': 'reply_3', '_source': 'source'}
+                ]
+            }
+        },
+    ]
+    # It should call Annotation() four times: first for the parent annotation
+    # and then once for each reply.
+    Annotation.side_effect = [
+        mock.sentinel.parent_annotation_object,
+        mock.sentinel.reply_annotation_object_1,
+        mock.sentinel.reply_annotation_object_2,
+        mock.sentinel.reply_annotation_object_3,
+    ]
+
+    result = core.search(mock.Mock())
+
+    assert result['replies'] == [
+        mock.sentinel.reply_annotation_object_1,
+        mock.sentinel.reply_annotation_object_2,
+        mock.sentinel.reply_annotation_object_3
+    ]
+
+
 @mock.patch("h.api.search.core.search")
 def test_index_limit_is_20(search_func):
     """index() calls search with "limit": 20."""

--- a/h/api/search/test/query_test.py
+++ b/h/api/search/test/query_test.py
@@ -378,13 +378,23 @@ def test_build_with_evil_arguments():
 
 
 @mock.patch("h.api.nipsa.nipsa_filter")
+def test_build_returns_replies_filter(_):
+    """The query should inclue a filter for top-level annotations only."""
+    q = query.build(multidict.NestedMultiDict())
+
+    assert q["query"]["filtered"]["filter"]["and"][0] == {
+        'missing': {'field': 'references'}
+    }
+
+
+@mock.patch("h.api.nipsa.nipsa_filter")
 def test_build_returns_nipsa_filter(nipsa_filter):
     """_build() returns a nipsa-filtered query."""
     nipsa_filter.return_value = "foobar!"
 
     q = query.build(multidict.NestedMultiDict())
 
-    assert q["query"]["filtered"]["filter"] == {"and": ["foobar!"]}
+    assert "foobar!" in q["query"]["filtered"]["filter"]["and"]
 
 
 @mock.patch("h.api.nipsa.nipsa_filter")

--- a/h/api/search/test/transform_test.py
+++ b/h/api/search/test/transform_test.py
@@ -35,37 +35,6 @@ def test_prepare_adds_scope_field(ann_in, ann_out, uri_normalize):
 
 
 @mock.patch('h.api.search.transform.models')
-def test_prepare_copies_parents_scopes_into_replies(models):
-    parent_annotation = {
-        'id': 'parent_annotation_id',
-        'target': [{'scope': 'https://example.com/annotated_article'}]
-    }
-    reply = {'references': [parent_annotation['id'], 'some other id']}
-    models.Annotation.fetch.return_value = parent_annotation
-
-    transform.prepare(reply)
-
-    assert reply['target'] == parent_annotation['target']
-
-
-@mock.patch('h.api.search.transform.models')
-def test_prepare_overwrites_existing_targets_in_replies(models):
-    parent_annotation = {
-        'id': 'parent_annotation_id',
-        'target': [{'scope': 'https://example.com/annotated_article'}]
-    }
-    reply = {
-        'references': [parent_annotation['id'], 'some other id'],
-        'target': ['this should be overwritten']
-    }
-    models.Annotation.fetch.return_value = parent_annotation
-
-    transform.prepare(reply)
-
-    assert reply['target'] == parent_annotation['target']
-
-
-@mock.patch('h.api.search.transform.models')
 def test_prepare_does_nothing_if_parents_target_is_not_a_list(models):
     """It should do nothing to replies if the parent's target isn't a list.
 
@@ -86,65 +55,6 @@ def test_prepare_does_nothing_if_parents_target_is_not_a_list(models):
     transform.prepare(reply)
 
     assert reply['target'] == mock.sentinel.target
-
-
-@mock.patch('h.api.search.transform.models')
-def test_prepare_does_not_copy_other_keys_from_targets(models):
-    """Only the parent's scope should be copied into replies.
-
-    Not any other keys that the parent's target might have.
-
-    """
-    parent_annotation = {
-        'id': 'parent_annotation_id',
-        'target': [{
-            'scope': 'https://example.com/annotated_article',
-            'foo': 'bar',
-            'selector': {}
-        }]
-    }
-    reply = {'references': [parent_annotation['id'], 'some other id']}
-    models.Annotation.fetch.return_value = parent_annotation
-
-    transform.prepare(reply)
-
-    assert 'foo' not in reply['target']
-    assert 'selector' not in reply['target']
-
-
-@mock.patch('h.api.search.transform.models')
-def test_prepare_does_not_copy_targets_that_are_not_dicts(models):
-    """Parent's targets that aren't dicts shouldn't be copied into replies."""
-    parent_annotation = {
-        'id': 'parent_annotation_id',
-        'target': ['not a dict', None, ['not', 'a', 'dict']]
-    }
-    reply = {'references': [parent_annotation['id'], 'some other id']}
-    models.Annotation.fetch.return_value = parent_annotation
-
-    transform.prepare(reply)
-
-    assert reply['target'] == []
-
-
-@mock.patch('h.api.search.transform.models')
-def test_prepare_does_not_copy_targets_with_no_scope(models):
-    """Parent's targets with no 'scope' should not be copied into replies."""
-    parent_annotation = {
-        'id': 'parent_annotation_id',
-        # Target has no 'scope' key.
-        'target': [{
-            'foo': 'bar',
-            'selector': {}
-        }]
-    }
-    reply = {'references': [parent_annotation['id'], 'some other id']}
-    models.Annotation.fetch.return_value = parent_annotation
-
-    transform.prepare(reply)
-
-    assert reply['target'] == []
-
 
 
 @pytest.mark.parametrize("ann,nipsa", [

--- a/h/api/search/transform.py
+++ b/h/api/search/transform.py
@@ -20,8 +20,6 @@ def prepare(annotation):
     # should probably not mutate its argument.
     _normalize_annotation_target_uris(annotation)
 
-    _copy_parent_scopes_into_replies(annotation)
-
     if 'user' in annotation and nipsa.has_nipsa(annotation['user']):
         annotation['nipsa'] = True
 
@@ -50,29 +48,3 @@ def _normalize_annotation_target_uris(annotation):
         if not isinstance(target['source'], basestring):
             continue
         target['scope'] = [uri.normalize(target['source'])]
-
-
-def _copy_parent_scopes_into_replies(annotation):
-    """If this annotation is a reply then copy its parents scopes into it.
-
-    If the given annotation is a reply then we find the thread root
-    annotation and copy its targets into the reply, _but_ we only
-    copy the 'scope' key from each target and not the rest of the dict.
-    """
-    references = annotation.get('references')
-
-    if not references:
-        return  # This annotation is not a reply.
-
-    parent = models.Annotation.fetch(references[0])
-
-    if not parent:
-        return  # Nothing can be done.
-
-    targets = parent.get('target', [])
-    if not isinstance(targets, list):
-        return
-
-    # Deliberately overwrite any existing target in the reply annotation.
-    annotation['target'] = [{'scope': target['scope']} for target in targets
-                            if isinstance(target, dict) and 'scope' in target]

--- a/h/api/test/views_test.py
+++ b/h/api/test/views_test.py
@@ -102,7 +102,8 @@ def test_search_returns_total(search_lib):
     search_lib.search.return_value = {
         'total': 3,
         # In production these would be annotation dicts, not strings.
-        'rows': ['annotation_1', 'annotation_2', 'annotation_3']
+        'rows': ['annotation_1', 'annotation_2', 'annotation_3'],
+        'replies': []
     }
 
     response_data = views.search(mock.Mock())
@@ -121,7 +122,8 @@ def test_search_returns_rendered_annotations(search_lib):
     search_lib.search.return_value = {
         'total': 3,
         # In production these would be annotation dicts, not strings.
-        'rows': ['annotation_1', 'annotation_2', 'annotation_3']
+        'rows': ['annotation_1', 'annotation_2', 'annotation_3'],
+        'replies': []
     }
     # Our mock render function just appends '_rendered' onto our mock
     # annotation strings.
@@ -132,6 +134,30 @@ def test_search_returns_rendered_annotations(search_lib):
     assert response_data['rows'] == [
         'annotation_1_rendered', 'annotation_2_rendered',
         'annotation_3_rendered']
+
+
+@search_fixtures
+def test_search_returns_rendered_replies(search_lib):
+    """It should return the rendered reply annotations.
+
+    It should pass the reply annotations from search_lib.search() through
+    search_lib.render() and return the results.
+
+    """
+    search_lib.search.return_value = {
+        'total': 3,
+        # In production these would be annotation dicts, not strings.
+        'rows': [],
+        'replies': ['reply_1', 'reply_2', 'reply_3']
+    }
+    # Our mock render function just appends '_rendered' onto our mock
+    # annotation strings.
+    search_lib.render.side_effect = lambda annotation: annotation + '_rendered'
+
+    response_data = views.search(mock.Mock())
+
+    assert response_data['replies'] == [
+        'reply_1_rendered', 'reply_2_rendered', 'reply_3_rendered']
 
 
 def test_access_token_returns_create_token_response():

--- a/h/api/views.py
+++ b/h/api/views.py
@@ -96,6 +96,7 @@ def search(request):
     return {
         'total': results['total'],
         'rows': [search_lib.render(a) for a in results['rows']],
+        'replies': [search_lib.render(a) for a in results['replies']],
     }
 
 

--- a/h/static/scripts/annotation-mapper.coffee
+++ b/h/static/scripts/annotation-mapper.coffee
@@ -4,7 +4,26 @@ module.exports = [
   ($rootScope, threading, store) ->
     setupAnnotation: (ann) -> ann
 
-    loadAnnotations: (annotations) ->
+    ###*
+    # @ngdoc function
+    #
+    # @name annotationMapper.loadAnnotations
+    #
+    # @description Load some annotations and replies into the current page
+    #   context.
+    #
+    # @param {array} annotations The array of annotation objects to load.
+    # @param {array} replies An array of all replies to the given annotations.
+    #
+    # @returns nothing
+    #
+    ###
+    loadAnnotations: (annotations, replies=[]) ->
+      # Pass both the annotations and all of the replies to those annotations
+      # into the threading code as one concatenated list. The threading code
+      # will arrange these into nested threads for display.
+      annotations = annotations.concat(replies)
+
       annotations = for annotation in annotations
         container = threading.idTable[annotation.id]
         if container?.message

--- a/h/static/scripts/annotation-viewer-controller.coffee
+++ b/h/static/scripts/annotation-viewer-controller.coffee
@@ -24,7 +24,7 @@ module.exports = class AnnotationViewerController
 
     id = $routeParams.id
     store.SearchResource.get _id: id, ({rows, replies}) ->
-      annotationMapper.loadAnnotations(rows.concat(replies))
+      annotationMapper.loadAnnotations(rows, replies)
       $scope.threadRoot = children: [$scope.threading.getContainer(id)]
 
     streamFilter

--- a/h/static/scripts/annotation-viewer-controller.coffee
+++ b/h/static/scripts/annotation-viewer-controller.coffee
@@ -23,11 +23,9 @@ module.exports = class AnnotationViewerController
       $location.path('/stream').search('q', query)
 
     id = $routeParams.id
-    store.AnnotationResource.read id: id, (annotation) ->
-      annotationMapper.loadAnnotations([annotation])
+    store.SearchResource.get _id: id, ({rows, replies}) ->
+      annotationMapper.loadAnnotations(rows.concat(replies))
       $scope.threadRoot = children: [$scope.threading.getContainer(id)]
-    store.SearchResource.get references: id, ({rows}) ->
-      annotationMapper.loadAnnotations(rows)
 
     streamFilter
       .setMatchPolicyIncludeAny()

--- a/h/static/scripts/stream-controller.coffee
+++ b/h/static/scripts/stream-controller.coffee
@@ -23,7 +23,7 @@ module.exports = class StreamController
 
     load = ({rows, replies}) ->
         offset += rows.length
-        annotationMapper.loadAnnotations(rows.concat(replies))
+        annotationMapper.loadAnnotations(rows, replies)
 
     # Disable the thread filter (client-side search)
     $scope.$on '$routeChangeSuccess', ->

--- a/h/static/scripts/stream-controller.coffee
+++ b/h/static/scripts/stream-controller.coffee
@@ -21,9 +21,9 @@ module.exports = class StreamController
       query = angular.extend(options, searchParams)
       store.SearchResource.get(query, load)
 
-    load = ({rows}) ->
+    load = ({rows, replies}) ->
         offset += rows.length
-        annotationMapper.loadAnnotations(rows)
+        annotationMapper.loadAnnotations(rows.concat(replies))
 
     # Disable the thread filter (client-side search)
     $scope.$on '$routeChangeSuccess', ->

--- a/h/static/scripts/test/annotation-viewer-controller-test.coffee
+++ b/h/static/scripts/test/annotation-viewer-controller-test.coffee
@@ -25,11 +25,15 @@ describe "AnnotationViewerController", ->
     locals = {
       $location: $location or {}
       $routeParams: $routeParams or {id: "test_annotation_id"}
-      $scope: $scope or {search: {}}
+      $scope: $scope or {
+        search: {}
+        threading: {
+          getContainer: ->
+        }
+      }
       streamer: streamer or {send: ->}
       store: store or {
-        AnnotationResource: {read: sinon.spy()},
-        SearchResource: {get: ->}}
+        SearchResource: {get: sinon.spy()}}
       streamFilter: streamFilter or {
         setMatchPolicyIncludeAny: -> {addClause: -> {addClause: ->}}
         getFilter: ->
@@ -40,6 +44,31 @@ describe "AnnotationViewerController", ->
       "AnnotationViewerController", locals)
     return locals
 
-  it "calls the annotation API to get the annotation", ->
+  it "calls the search API to get the annotation and its replies", ->
     {store} = createAnnotationViewerController({})
-    assert store.AnnotationResource.read.args[0][0].id == "test_annotation_id"
+    assert store.SearchResource.get.calledOnce
+    assert store.SearchResource.get.calledWith(
+      {_id: "test_annotation_id"})
+
+  it "passes the annotations and replies from search into loadAnnotations", ->
+    {annotationMapper} = createAnnotationViewerController({
+      store: {
+        SearchResource: {
+          # SearchResource.get(id, func) takes an annotation id and a function
+          # that it should call with the search result. Our mock .get() here
+          # just immediately calls the function with some fake results.
+          get: (id, func) ->
+            func(
+              {
+                # In production these would be annotation objects, not strings.
+                rows: ['annotation_1', 'annotation_2']
+                replies: ['reply_1', 'reply_2', 'reply_3']
+              }
+            )
+        }
+      }
+    })
+
+    assert annotationMapper.loadAnnotations.calledWith(
+        ['annotation_1', 'annotation_2', 'reply_1', 'reply_2', 'reply_3']
+    ), "It should pass all the annotations and replies to loadAnnotations()"

--- a/h/static/scripts/test/annotation-viewer-controller-test.coffee
+++ b/h/static/scripts/test/annotation-viewer-controller-test.coffee
@@ -70,5 +70,5 @@ describe "AnnotationViewerController", ->
     })
 
     assert annotationMapper.loadAnnotations.calledWith(
-        ['annotation_1', 'annotation_2', 'reply_1', 'reply_2', 'reply_3']
+        ['annotation_1', 'annotation_2'], ['reply_1', 'reply_2', 'reply_3']
     ), "It should pass all the annotations and replies to loadAnnotations()"

--- a/h/static/scripts/test/stream-controller-test.coffee
+++ b/h/static/scripts/test/stream-controller-test.coffee
@@ -93,6 +93,20 @@ describe 'StreamController', ->
     assert.isObject(fakeThreading.root)
     assert.strictEqual(fakeThreading.root, $scope.threadRoot)
 
+  it 'passes the annotations and replies from search to loadAnnotations()', ->
+    fakeStore.SearchResource.get = (query, func) ->
+      func({
+        'rows': ['annotation_1', 'annotation_2']
+        'replies': ['reply_1', 'reply_2', 'reply_3']
+      })
+
+    createController()
+
+    assert fakeAnnotationMapper.loadAnnotations.calledOnce
+    assert fakeAnnotationMapper.loadAnnotations.calledWith(
+      ['annotation_1', 'annotation_2', 'reply_1', 'reply_2', 'reply_3']
+    )
+
   describe 'on $routeChangeSuccess', ->
 
     it 'disables page search', ->

--- a/h/static/scripts/test/stream-controller-test.coffee
+++ b/h/static/scripts/test/stream-controller-test.coffee
@@ -104,7 +104,7 @@ describe 'StreamController', ->
 
     assert fakeAnnotationMapper.loadAnnotations.calledOnce
     assert fakeAnnotationMapper.loadAnnotations.calledWith(
-      ['annotation_1', 'annotation_2', 'reply_1', 'reply_2', 'reply_3']
+      ['annotation_1', 'annotation_2'], ['reply_1', 'reply_2', 'reply_3']
     )
 
   describe 'on $routeChangeSuccess', ->

--- a/h/static/scripts/test/widget-controller-test.coffee
+++ b/h/static/scripts/test/widget-controller-test.coffee
@@ -93,5 +93,5 @@ describe 'WidgetController', ->
 
       assert fakeAnnotationMapper.loadAnnotations.calledOnce
       assert fakeAnnotationMapper.loadAnnotations.calledWith(
-        ['annotation_1', 'annotation_2', 'reply_1', 'reply_2', 'reply_3']
+        ['annotation_1', 'annotation_2'], ['reply_1', 'reply_2', 'reply_3']
       )

--- a/h/static/scripts/test/widget-controller-test.coffee
+++ b/h/static/scripts/test/widget-controller-test.coffee
@@ -37,6 +37,7 @@ describe 'WidgetController', ->
           result =
             total: 100
             rows: [offset..offset+limit-1]
+            replies: []
 
           callback result
     }
@@ -80,3 +81,17 @@ describe 'WidgetController', ->
       assert.calledWith(loadSpy, [40..59])
       assert.calledWith(loadSpy, [60..79])
       assert.calledWith(loadSpy, [80..99])
+
+    it 'passes annotations and replies from search to loadAnnotations()', ->
+      fakeStore.SearchResource.get = (query, callback) ->
+        callback({
+          rows: ['annotation_1', 'annotation_2']
+          replies: ['reply_1', 'reply_2', 'reply_3']
+        })
+      fakeCrossFrame.frames.push({uri: 'http://example.com'})
+      $scope.$digest()
+
+      assert fakeAnnotationMapper.loadAnnotations.calledOnce
+      assert fakeAnnotationMapper.loadAnnotations.calledWith(
+        ['annotation_1', 'annotation_2', 'reply_1', 'reply_2', 'reply_3']
+      )

--- a/h/static/scripts/widget-controller.coffee
+++ b/h/static/scripts/widget-controller.coffee
@@ -29,7 +29,7 @@ module.exports = class WidgetController
         if offset < total
           _loadAnnotationsFrom query, offset
 
-        annotationMapper.loadAnnotations(results.rows)
+        annotationMapper.loadAnnotations(results.rows.concat(results.replies))
 
     loadAnnotations = (frames) ->
       for f in frames

--- a/h/static/scripts/widget-controller.coffee
+++ b/h/static/scripts/widget-controller.coffee
@@ -29,7 +29,7 @@ module.exports = class WidgetController
         if offset < total
           _loadAnnotationsFrom query, offset
 
-        annotationMapper.loadAnnotations(results.rows.concat(results.replies))
+        annotationMapper.loadAnnotations(results.rows, results.replies)
 
     loadAnnotations = (frames) ->
       for f in frames


### PR DESCRIPTION
Problem:

The search API sometimes returns reply annotations without their
corresponding parent annotations being in the same query results.

This happens when it's returning, say, the 20 most recent annotations
and there are some reply annotations in those 20 but the parent annotations of
those replies are not among the 20 most recent annotations.

This means the client receives some reply annotations but can't display
them properly (as a threaded discussion) because it doesn't have their
parent annotations.

Solution:

Make sure that the search API always returns all of the parent
annotations, for any reply annotations that it returns.

This is done by splitting the search API's Elasticsearch query into two
queries:

1. The original query, but with an additional filter so that it returns
only top level annotations and not replies.

2. An additional query for all of the replies to the annotations from
the first query.

Then merge the results of the two queries and return them to the
client.

This fixes the "Message not available" cards that are appearing on our
/stream page in the frontend. These occur when the client receives
replies from the search API but does not receive the parent annotations
of those replies in the same query.

Fixes #1916.