### PR TITLE
Refactor Pyramid routing and view configuration

### DIFF
--- a/h/api/__init__.py
+++ b/h/api/__init__.py
@@ -5,8 +5,11 @@ from h.api.logic import search_annotations
 
 
 def includeme(config):
-    config.set_root_factory(create_root)
-    config.add_route('api', '/')
+    config.add_route('api', '/', factory=create_root)
+    config.add_route('access_token', '/access_token')
+
+    # XXX: Client should be using /access_token, isn't yet.
+    config.add_route('token', '/token')
 
     config.include('h.features')
     config.include('h.api.db')

--- a/h/api/models.py
+++ b/h/api/models.py
@@ -2,45 +2,12 @@
 from __future__ import unicode_literals
 
 import cgi
-from pyramid import security
 from dateutil import parser
-
 from annotator import annotation
 from annotator import document
 
 
 class Annotation(annotation.Annotation):
-    def __acl__(self):
-        acl = []
-        # Convert annotator-store roles to pyramid principals
-        for action, roles in self.get('permissions', {}).items():
-            for role in roles:
-                if role.startswith('system.'):
-                    raise ValueError('{} is a reserved role.'.format(role))
-                elif role.startswith('group:'):
-                    if role == 'group:__world__':
-                        principal = security.Everyone
-                    elif role == 'group:__authenticated__':
-                        principal = security.Authenticated
-                    elif role == 'group:__consumer__':
-                        raise NotImplementedError("API consumer groups")
-                    else:
-                        principal = role
-                else:
-                    principal = role
-
-                # Append the converted rule tuple to the ACL
-                rule = (security.Allow, principal, action)
-                acl.append(rule)
-
-        if acl:
-            return acl
-        else:
-            # If there is no acl, it's an admin party!
-            return [(security.Allow,
-                     security.Everyone,
-                     security.ALL_PERMISSIONS)]
-
     __mapping__ = {
         'annotator_schema_version': {'type': 'string'},
         'created': {'type': 'date'},

--- a/h/api/resources.py
+++ b/h/api/resources.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 
-from pyramid.security import Allow, Deny, Authenticated, Everyone
+from pyramid.decorator import reify
+from pyramid.security import Allow, Deny
+from pyramid.security import Authenticated, Everyone
 
-from .models import Annotation
+from h.api import models
 
 
 class Resource(dict):
@@ -22,12 +24,69 @@ class Resource(dict):
         self[name] = obj
 
 
-class Annotations(object):
+class Collection(Resource):
     """
-    Annotations is a container resource that exposes annotations as its
-    children in the tree.
+    A collection of other resources.
     """
-    def __init__(self, request):
+
+    def __getitem__(self, key):
+        if key not in self and callable(self.factory):
+            self.add(key, self.factory(key))
+        return super(Collection, self).__getitem__(key)
+
+    def factory(self, key):
+        raise NotImplementedError
+
+
+class Annotation(Resource):
+    """
+    A Resource representing an annotation.
+    """
+
+    def __acl__(self):
+        acl = []
+
+        model = self.model
+
+        # Convert annotator-store roles to pyramid principals
+        for action, roles in model.get('permissions', {}).items():
+            for role in roles:
+                if role.startswith('system.'):
+                    raise ValueError('{} is a reserved role.'.format(role))
+                elif role.startswith('group:'):
+                    if role == 'group:__world__':
+                        principal = Everyone
+                    elif role == 'group:__authenticated__':
+                        principal = Authenticated
+                    elif role == 'group:__consumer__':
+                        raise NotImplementedError("API consumer groups")
+                    else:
+                        principal = role
+                else:
+                    principal = role
+
+                # Append the converted rule tuple to the ACL
+                rule = (Allow, principal, action)
+                acl.append(rule)
+
+        return acl
+
+    @reify
+    def model(self):
+        if 'id' in self:
+            instance = models.Annotation.fetch(self['id'])
+            return instance or models.Annotation(id=self['id'])
+        else:
+            return models.Annotation()
+
+
+class Annotations(Collection):
+    """
+    A collection of Annotation resources.
+    """
+
+    def __init__(self, request, **kwargs):
+        super(Annotations, self).__init__(**kwargs)
         self.request = request
 
     def __acl__(self):
@@ -40,20 +99,12 @@ class Annotations(object):
             aces.append((Allow, 'group:' + group, 'create'))
         return aces + [(Deny, Everyone, 'create')]
 
-    def __getitem__(self, key):
-        instance = Annotation.fetch(key)
-        if instance is None:
-            raise KeyError(key)
-        instance.__name__ = key
-        instance.__parent__ = self
-        return instance
+    def factory(self, key):
+        return Annotation(id=key)
 
 
 class Root(Resource):
-    __acl__ = [
-        (Allow, Authenticated, 'create'),
-        (Allow, 'group:__admin__', 'admin'),
-    ]
+    pass
 
 
 def create_root(request):

--- a/h/api/test/models_test.py
+++ b/h/api/test/models_test.py
@@ -5,63 +5,7 @@ import re
 import unittest
 import urllib
 
-from pytest import raises
-from pyramid import security
-
 from h.api import models
-
-
-class TestAnnotationPermissions(unittest.TestCase):
-    def test_principal(self):
-        annotation = models.Annotation()
-        annotation['permissions'] = {
-            'read': ['saoirse'],
-        }
-        actual = annotation.__acl__()
-        expect = [(security.Allow, 'saoirse', 'read')]
-        assert actual == expect
-
-    def test_admin_party(self):
-        annotation = models.Annotation()
-        actual = annotation.__acl__()
-        expect = [(security.Allow, security.Everyone, security.ALL_PERMISSIONS)]
-        assert actual == expect
-
-    def test_deny_system_role(self):
-        annotation = models.Annotation()
-        annotation['permissions'] = {
-            'read': [security.Everyone],
-        }
-        with raises(ValueError):
-            annotation.__acl__()
-
-    def test_group(self):
-        annotation = models.Annotation()
-        annotation['permissions'] = {
-            'read': ['group:lulapalooza'],
-        }
-        actual = annotation.__acl__()
-        expect = [(security.Allow, 'group:lulapalooza', 'read')]
-        assert actual == expect
-
-    def test_group_world(self):
-        annotation = models.Annotation()
-        annotation['permissions'] = {
-            'read': ['group:__world__'],
-        }
-        actual = annotation.__acl__()
-        expect = [(security.Allow, security.Everyone, 'read')]
-        assert actual == expect
-
-    def test_group_authenticated(self):
-        annotation = models.Annotation()
-        annotation['permissions'] = {
-            'read': ['group:__authenticated__'],
-        }
-        actual = annotation.__acl__()
-        expect = [(security.Allow, security.Authenticated, 'read')]
-        assert actual == expect
-
 
 analysis = models.Annotation.__analysis__
 

--- a/h/api/test/resources_test.py
+++ b/h/api/test/resources_test.py
@@ -1,12 +1,70 @@
 import mock
+from pytest import raises
 from pyramid import security
 
 from h.api import resources
 
 
-class TestAnnotations(object):
+class TestAnnotationPermissions(object):
 
-    def test__acl__when_request_has_no_json_body(self):
+    def test_principal(self):
+        resource = resources.Annotation()
+        resource.__name__ = 'foo'
+        annotation = resource.model
+        annotation['permissions'] = {
+            'read': ['saoirse'],
+        }
+        actual = resource.__acl__()
+        expect = [(security.Allow, 'saoirse', 'read')]
+        assert actual == expect
+
+    def test_deny_system_role(self):
+        resource = resources.Annotation()
+        resource.__name__ = 'foo'
+        annotation = resource.model
+        annotation['permissions'] = {
+            'read': [security.Everyone],
+        }
+        with raises(ValueError):
+            resource.__acl__()
+
+    def test_group(self):
+        resource = resources.Annotation()
+        resource.__name__ = 'foo'
+        annotation = resource.model
+        annotation['permissions'] = {
+            'read': ['group:lulapalooza'],
+        }
+        actual = resource.__acl__()
+        expect = [(security.Allow, 'group:lulapalooza', 'read')]
+        assert actual == expect
+
+    def test_group_world(self):
+        resource = resources.Annotation()
+        resource.__name__ = 'foo'
+        annotation = resource.model
+        annotation['permissions'] = {
+            'read': ['group:__world__'],
+        }
+        actual = resource.__acl__()
+        expect = [(security.Allow, security.Everyone, 'read')]
+        assert actual == expect
+
+    def test_group_authenticated(self):
+        resource = resources.Annotation()
+        resource.__name__ = 'foo'
+        annotation = resource.model
+        annotation['permissions'] = {
+            'read': ['group:__authenticated__'],
+        }
+        actual = resource.__acl__()
+        expect = [(security.Allow, security.Authenticated, 'read')]
+        assert actual == expect
+
+
+class TestAnnotationsPermissions(object):
+
+    def test_when_request_has_no_json_body(self):
         request = mock.Mock()
         # Make request.json_body raise ValueError.
         type(request).json_body = mock.PropertyMock(side_effect=ValueError)
@@ -15,7 +73,7 @@ class TestAnnotations(object):
         assert annotations.__acl__() == [
             (security.Deny, security.Everyone, 'create')]
 
-    def test__acl__when_request_contains_no_group(self):
+    def test_when_request_contains_no_group(self):
         request = mock.Mock()
         request.json_body = {}
         annotations = resources.Annotations(request)
@@ -24,7 +82,7 @@ class TestAnnotations(object):
             (security.Allow, 'group:__world__', 'create'),
             (security.Deny, security.Everyone, 'create')]
 
-    def test__acl__when_request_has_a_group(self):
+    def test_when_request_has_a_group(self):
         request = mock.Mock()
         request.json_body = {'group': 'xyzabc'}
         annotations = resources.Annotations(request)

--- a/h/buildext.py
+++ b/h/buildext.py
@@ -52,7 +52,7 @@ def build_extension_common(env, bundle_app=False):
         if bundle_app:
             app_uri = request.webassets_env.url + '/app.html'
         else:
-            app_uri = request.resource_url(request.root, 'app.html')
+            app_uri = request.route_url('widget')
         value = {'app_uri': app_uri}
         data = render('h:templates/embed.js.jinja2', value, request=request)
         fp.write(data)

--- a/h/test/views_test.py
+++ b/h/test/views_test.py
@@ -6,19 +6,18 @@ import json
 import unittest
 import mock
 
-import pyramid
 from pyramid import testing
 import pytest
 
 from h import views
-from . import factories
 
 
 class TestAnnotationView(unittest.TestCase):
 
     def test_og_document(self):
-        context = {'id': '123', 'user': 'foo'}
-        context['document'] = {'title': 'WikiHow — How to Make a  ☆Starmap☆'}
+        annotation = {'id': '123', 'user': 'foo'}
+        annotation['document'] = {'title': 'WikiHow — How to Make a  ☆Starmap☆'}
+        context = mock.MagicMock(model=annotation)
         request = testing.DummyRequest()
         result = views.annotation(context, request)
         assert isinstance(result, dict)
@@ -26,7 +25,8 @@ class TestAnnotationView(unittest.TestCase):
         assert any(test(d) for d in result['meta_attrs'])
 
     def test_og_no_document(self):
-        context = {'id': '123', 'user': 'foo'}
+        annotation = {'id': '123', 'user': 'foo'}
+        context = mock.MagicMock(model=annotation)
         request = testing.DummyRequest()
         result = views.annotation(context, request)
         assert isinstance(result, dict)
@@ -43,7 +43,7 @@ class TestJS(object):
         blocklist = {"foo": "bar"}
         request.registry.settings = {'h.blocklist': blocklist}
 
-        data = views.js({}, request)
+        data = views.embed({}, request)
 
         assert data['blocklist'] == json.dumps(blocklist)
 


### PR DESCRIPTION
When resources are backed by database models, keep the two separate
to improve extensibility and package isolation. By separating the
resource tree from the persistence models, the resource tree can be
extended without dealing dealing with database models and mappers.
With sub-classing of the resource tree, explicit containment of the API
is no longer needed for any view other than the exception views. The
annotation model also becomes simpler, no longer containing Pyramid
permissions details. In this manner, more details about groups and
users are lifted out of the annotation API package.

Remove the "admin party" mode for annotations since otherwise this
would introduce "upsert" operations using PUT for anyone in any group.
Simply removing this unused functionality allows the annotation resource
to be behave as if its model always exists, even if empty and not
persisted, which avoids having to deal with that case within the acl code
and the view callables.

Factor out a generic Collection resource and implement the stream and the
search in terms of that. Remove most of the logic from the stream view
by making the tag and user search shortcuts implemented as a collection of
collections of annotations so that the view itself need only inspect its
context for the presence of a query. Future work can remove the need for
a redirect by teaching the client about these routes, thereby beautifying
the stream URLs for real user and tag pages.

Make all the view configuration decorators and helpers more concise and
consistent.