### PR TITLE
Installation docs corrections

### DIFF
--- a/docs/hacking/install.rst
+++ b/docs/hacking/install.rst
@@ -277,7 +277,13 @@ Feature Flags
 -------------
 
 Features flags allow admins to enable or disable features for certain groups
-of users. You can enable or disable them from the administration dashboard.
-Please consult the :doc:`administration` documentation for more information
-on accessing the admin dashboard.
+of users. You can enable or disable them from the Administration Dashboard.
+
+To access the Administration Dashboard, you will need to first create a
+user account in your local instance of H and then give that account
+admin access rights using H's command-line tools.
+
+See the :doc:`../administration` documentation for information
+on how to give the initial user admin rights and access the Administration
+Dashboard.
 

--- a/docs/hacking/install.rst
+++ b/docs/hacking/install.rst
@@ -211,23 +211,6 @@ dependencies into the ``h/node_modules`` directory:
 
 .. _virtualenvwrapper: https://virtualenvwrapper.readthedocs.org/en/latest/install.html
 
-
-Add Node modules to your PATH
------------------------------
-
-If you don't have your ``h/node_modules/.bin`` directory on your ``PATH`` then
-you'll get errors because the Node modules you've installed can't be found
-(for example: ``Program file not found: uglifyjs``).
-To add the Node modules to your ``PATH``:
-
-.. code-block:: bash
-
-    export PATH=./node_modules/.bin:$PATH
-
-If you add the above line to your ``~/.bashrc`` file then you won't have to
-enter it every time you start a new terminal.
-
-
 Running h
 ---------
 

--- a/docs/hacking/install.rst
+++ b/docs/hacking/install.rst
@@ -128,9 +128,13 @@ installed.
 2.  Install the ICU Analysis plugin using the `instructions provided`_. **NB:**
     ensure you install the correct version of the plugin for your version of
     ElasticSearch.
+3.  (Re-)start the ElasticSearch daemon following the steps on the ElasticSearch
+    `installation page`_. Note that the daemon needs to be restarted after installing
+    the ICU plugin.
 
 .. _installing the package on your platform: https://www.elastic.co/downloads/elasticsearch
 .. _instructions provided: https://github.com/elastic/elasticsearch-analysis-icu#icu-analysis-for-elasticsearch
+.. _installation page: https://www.elastic.co/downloads/elasticsearch
 
 
 ElasticSearch Troubleshooting

--- a/docs/hacking/ssl.rst
+++ b/docs/hacking/ssl.rst
@@ -2,11 +2,11 @@
 Serving h over SSL in development
 =================================
 
-If you want to annotate a site that's served over https then you'll need to
-serve h over https as well, otherwise the browser will refuse to launch h and
-give a mixed-content warning.
+If you want to annotate a site that's served over HTTPS then you'll need to
+serve h over HTTPS as well, since the browser will refuse to load external
+scripts (eg. H's bookmarklet) via HTTP on a page served via HTTPS.
 
-To serve your local dev instance of h over https:
+To serve your local dev instance of h over HTTPS:
 
 1. Generate a private key and certificate signing request::
 
@@ -20,6 +20,9 @@ To serve your local dev instance of h over https:
 
     gunicorn --reload --paste conf/development.ini --certfile=server.crt --keyfile=key.pem
 
+4. Since the certificate is self-signed, you will need to instruct your browser to
+   trust it explicitly by visiting https://127.0.0.1:5000 and selecting the option
+   to bypass the validation error.
 
 ---------------
 Troubleshooting
@@ -29,5 +32,5 @@ Insecure Response errors in the console
 =======================================
 
 The sidebar fails to load and you see ``net::ERR_INSECURE_RESPONSE`` errors in
-the console.  You need to open https://127.0.0.1:5000 and tell Chrome to allow
+the console.  You need to open https://127.0.0.1:5000 and tell the browser to allow
 access to the site even though the certificate isn't known.


### PR DESCRIPTION
This adds additional notes in the documentation for issues I encountered whilst setting up H for the first time.

The one major issue I haven't addressed is the upgrade to the `gevent` Python package (from 1.0.2 to the latest 1.1 beta) that was required to make H work reliably over SSL when using Python 2.7.9.