### PR TITLE
Enable annotations on H documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -98,6 +98,11 @@ pygments_style = 'tango'
 # A list of ignored prefixes for module index sorting.
 #modindex_common_prefix = []
 
+# Hypothes.is customizations using extension API
+# see http://sphinx-doc.org/latest/extdev/index.html
+def setup(app):
+    # Add annotation to docs pages
+    app.add_javascript('https://hypothes.is/embed.js')
 
 # -- Options for HTML output ---------------------------------------------------
 


### PR DESCRIPTION
Add Hypothes.is to H's documentation pages so
users can provide feedback or ask questions
on issues when deploying or hacking H.