### PR TITLE
Remove bogus permissions check from streamer

### DIFF
--- a/h/streamer.py
+++ b/h/streamer.py
@@ -601,9 +601,6 @@ def should_send_event(socket, annotation, event_data):
     if event_data['src_client_id'] == socket.client_id:
         return False
 
-    if not socket.request.has_permission('read', annotation):
-        return False
-
     if annotation.get('nipsa') and (
             socket.request.authenticated_userid != annotation.get('user', '')):
         return False

--- a/h/test/streamer_test.py
+++ b/h/test/streamer_test.py
@@ -338,19 +338,10 @@ class TestShouldSendEvent(unittest.TestCase):
             {'permissions': {'read': ['group:__world__']}},
             data) is False
 
-    def test_should_send_event_check_permissions(self):
-        self.sock_giraffe.request.has_permission.return_value = False
-        anno = object()
-        data = {'action': 'update', 'src_client_id': 'pigeon'}
-        sock = self.sock_giraffe
-        assert should_send_event(sock, anno, data) is False
-        assert sock.request.has_permission.called_with('read', anno)
-
     def test_should_send_event_does_not_send_nipsad_annotations(self):
         """Users should not see annotations from NIPSA'd users."""
         annotation = {'user': 'fred', 'nipsa': True}
         socket = Mock(terminated=False, client_id='foo')
-        socket.request.has_permission.return_value = True
         event_data = {'action': 'create', 'src_client_id': 'bar'}
 
         assert not should_send_event(socket, annotation, event_data)
@@ -359,7 +350,6 @@ class TestShouldSendEvent(unittest.TestCase):
         """NIPSA'd users should see their own annotations."""
         annotation = {'user': 'fred', 'nipsa': True}
         socket = Mock(terminated=False, client_id='foo')
-        socket.request.has_permission.return_value = True
         socket.request.authenticated_userid = 'fred'  # The annotation creator.
         event_data = {'action': 'create', 'src_client_id': 'bar'}
 
@@ -373,7 +363,6 @@ class TestShouldSendEvent(unittest.TestCase):
         }
         socket = Mock(terminated=False, client_id='foo')
         socket.request.effective_principals = []  # No 'group:private-group'.
-        socket.request.has_permission.return_value = True
         event_data = {'action': 'create', 'src_client_id': 'bar'}
 
         assert not should_send_event(socket, annotation, event_data)
@@ -386,7 +375,6 @@ class TestShouldSendEvent(unittest.TestCase):
             'permissions': {'read': ['group:private-group']}
         }
         socket = Mock(terminated=False, client_id='foo')
-        socket.request.has_permission.return_value = True
         socket.request.effective_principals = ['group:private-group']
         event_data = {'action': 'create', 'src_client_id': 'bar'}
 
@@ -399,8 +387,7 @@ class TestShouldSendEvent(unittest.TestCase):
             'permissions': {'read': ['group:__world__']}
         }
         socket = Mock(terminated=False, client_id='foo')
-        socket.request.has_permission.return_value = True
         socket.request.effective_principals = ['group:private-group']
         event_data = {'action': 'create', 'src_client_id': 'bar'}
 
-        should_send_event(socket, annotation, event_data)
+        assert should_send_event(socket, annotation, event_data)


### PR DESCRIPTION
The streamer was checking if the authenticated user had permissions to see each annotation by calling `request.has_permission('read', annotation)`. Since 998347a, `Annotation` model instances are no longer valid contexts for such checks.

Given that a few lines later the annotation permissions are checked exhaustively against `request.effective_principals`, this check is unnecessary and can simply be removed.