### PR TITLE
Allow the sidebar to be resized thinner

### DIFF
--- a/h/static/scripts/annotator/sidebar.coffee
+++ b/h/static/scripts/annotator/sidebar.coffee
@@ -5,7 +5,7 @@ Hammer = require('hammerjs')
 Host = require('./host')
 
 # Minimum width to which the frame can be resized.
-MIN_RESIZE = 280
+MIN_RESIZE = 80
 
 
 module.exports = class Sidebar extends Host

--- a/h/static/scripts/annotator/test/sidebar-test.coffee
+++ b/h/static/scripts/annotator/test/sidebar-test.coffee
@@ -78,7 +78,7 @@ describe 'Sidebar', ->
         assert.calledOnce(show)
 
       it 'calls `hide` if the widget is not fully visible', ->
-        sidebar.gestureState = {final: -100}
+        sidebar.gestureState = {final: -50}
         hide = sandbox.stub(sidebar, 'hide')
         sidebar.onPan({type: 'panend'})
         assert.calledOnce(hide)


### PR DESCRIPTION
Reduce the MIN_RESIZE size at which the sidebar will snap shut, when the
user is resizing the width of the sidebar and making it skinnier.

This is helpful for example when trying to relate a set of annotations
in the sidebar to their highlights (or lack thereof) in a long PDF.