### PR TITLE
DRY in .editorconfig and add SCSS settings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,22 +2,21 @@ root = true
 
 [*]
 end_of_line = lf
+indent_style = space
 insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{html,js,scss}]
+indent_size = 2
 
 [*.{js,py}]
 charset = utf-8
 
 [*.py]
-indent_style = space
 indent_size = 4
-
-[*.js]
-indent_style = space
-indent_size = 2
 
 [Makefile]
 indent_style = tab
 
 [{package.json,.travis.yml}]
-indent_style = space
 indent_size = 2


### PR DESCRIPTION
 * Spaces are used for indents everywhere except Makefiles,
   so add that as the default.

 * Specify 2 as the indent size for SCSS files.