### PR TITLE
Don't perform normalization on URLs with no hostname

### DIFF
--- a/h/api/test/uri_test.py
+++ b/h/api/test/uri_test.py
@@ -12,6 +12,10 @@ from h.api import uri
     # Should leave URNs as they are
     ("urn:doi:10.0001/12345", "urn:doi:10.0001/12345"),
 
+    # Should leave http(s) URLs with no hostname as they are
+    ("http:///path/to/page", "http:///path/to/page"),
+    ("https:///path/to/page", "https:///path/to/page"),
+
     # Should treat messed up urlencoded strings as opaque and return them as
     # is. This is not valid urlencoding and trying to deal with it is going to
     # cause more problems than solutions (for example: is "%2F" in the path

--- a/h/api/uri.py
+++ b/h/api/uri.py
@@ -123,6 +123,10 @@ def normalize(uristr):
     if uri.scheme.lower() not in URL_SCHEMES:
         return uristr
 
+    # Don't perform normalization on URLs with no hostname.
+    if uri.hostname is None:
+        return uristr
+
     scheme = uri.scheme
     netloc = _normalize_netloc(uri)
     path = _normalize_path(uri)


### PR DESCRIPTION
Fixes #2515. I'm not sure what requests are causing this crasher on staging and production or what the correct solution is, but this is one easy solution - just don't attempt to normalize URIs with no hostname.