### PR TITLE
Add make target to run karma tests with auto-watch enabled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 SHELL := bash
 PATH := bin:${PATH}
+NPM_BIN = "$$(npm bin)"
 
 # Unless the user has specified otherwise in their environment, it's probably a
 # good idea to refuse to install unless we're in an activated virtualenv.
@@ -29,10 +30,15 @@ clean:
 dev:
 	@gunicorn --reload --paste conf/development.ini
 
-test:
+test: client-test
 	@python setup.py test
-	@"$$(npm bin)"/karma start h/static/scripts/karma.config.js --single-run
-	@"$$(npm bin)"/karma start h/browser/chrome/karma.config.js --single-run
+
+client-test:
+	@$(NPM_BIN)/karma start h/static/scripts/karma.config.js --single-run
+	@$(NPM_BIN)/karma start h/browser/chrome/karma.config.js --single-run
+
+client-test-watch:
+	@$(NPM_BIN)/karma start h/static/scripts/karma.config.js
 
 cover:
 	@python setup.py test --cov

--- a/h/static/scripts/karma.config.js
+++ b/h/static/scripts/karma.config.js
@@ -38,8 +38,12 @@ module.exports = function(config) {
       'test/bootstrap.js',
 
       // Tests
-      '**/*-test.coffee',
-      '**/*-test.js'
+      //
+      // Karma watching is disabled for these files because they are
+      // bundled with karma-browserify which handles watching itself via
+      // watchify
+      { pattern: '**/*-test.coffee', watched: false, included: true, served: true },
+      { pattern: '**/*-test.js', watched: false, included: true, served: true }
     ],
 
     // list of files to exclude

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "chai": "^3.2.0",
     "jscs": "^1.13.1",
-    "karma": "^0.12.17",
+    "karma": "^0.13.10",
     "karma-browserify": "^3.0.3",
     "karma-chai": "^0.1.0",
     "karma-cli": "0.0.4",


### PR DESCRIPTION
This provides a convenient way to start Karma tests and auto-run
them when test files are changed, shortening the test cycle by ~10s (time to do a full vs incremental Browserify build).

Because the test files are incorporated into a Browserify bundle
by karma-browserify which watches files for changes via watchify(),
we can turn off Karma's own watching of the test files.

This fixes a problem in watch mode where changing a test spec file would result
in Karma running all the tests twice, once after the test spec file
changed and then again afterwards due to the browserify bundle
being updated a second or two after the test spec file changes.