### PR TITLE
Fix detection of PDF URIs

### DIFF
--- a/h/static/scripts/annotator/main.js
+++ b/h/static/scripts/annotator/main.js
@@ -18,7 +18,7 @@ Annotator.Plugin.BucketBar = require('./plugin/bucket-bar');
 Annotator.Plugin.Toolbar = require('./plugin/toolbar');
 
 // Document type plugins
-Annotator.Plugin.Pdf = require('./plugin/pdf');
+Annotator.Plugin.PDF = require('./plugin/pdf');
 require('../vendor/annotator.document');  // Does not export the plugin :(
 
 // Selection plugins

--- a/h/static/scripts/annotator/pdf-sidebar.coffee
+++ b/h/static/scripts/annotator/pdf-sidebar.coffee
@@ -4,7 +4,7 @@ Sidebar = require('./sidebar')
 module.exports = class PdfSidebar extends Sidebar
   options:
     TextSelection: {}
-    Pdf: {}
+    PDF: {}
     BucketBar:
       container: '.annotator-frame'
       scrollables: ['#viewerContainer']

--- a/h/static/scripts/annotator/plugin/pdf.coffee
+++ b/h/static/scripts/annotator/plugin/pdf.coffee
@@ -2,7 +2,7 @@ extend = require('extend')
 Annotator = require('annotator')
 
 
-module.exports = class Pdf extends Annotator.Plugin
+module.exports = class PDF extends Annotator.Plugin
   documentLoaded: null
   observer: null
   pdfViewer: null


### PR DESCRIPTION
70c9b9b broke a number of features of the h client that were toggled on for PDF documents, by renaming the Annotator PDF plugin from `Annotator.Plugin.PDF` to `Annotator.Plugin.Pdf`.

While it's certainly an ugly side-effect of a straightforward rename, the problem is that `Guest#getDocumentInfo` (to pick one example) used `@plugins.PDF?` to determine whether to use the PDF metadata (provided by the PDF.js `PDFViewerApplication`).

In the absence of PDF metadata, `getDocumentInfo` falls back to using `window.location.href`, which explains the behaviour identified in #2506.

Fixes #2506.