### PR TITLE
Auto re-install Python, Node deps if out of date

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,15 @@ export PIP_REQUIRE_VIRTUALENV
 
 default: deps
 
-deps:
+deps: .eggs/.uptodate node_modules/.uptodate
+
+.eggs/.uptodate: setup.py requirements.txt
 	pip install --use-wheel -e .[dev,testing,YAML]
+	touch $@
+
+node_modules/.uptodate: package.json
 	npm install
+	touch $@
 
 clean:
 	find . -type f -name "*.py[co]" -delete
@@ -26,8 +32,9 @@ clean:
 	rm -f h/static/scripts/hypothesis.*js
 	rm -f h/static/styles/*.css
 	rm -f .coverage
+	rm -f node_modules/.uptodate .eggs/.uptodate
 
-dev:
+dev: deps
 	@gunicorn --reload --paste conf/development.ini
 
 test: client-test

--- a/docs/hacking/install.rst
+++ b/docs/hacking/install.rst
@@ -178,7 +178,7 @@ the h application with:
 
 .. code-block:: bash
 
-    mkvirtualenv h  
+    mkvirtualenv h
 
 You will notice that the your shell prompt changes to include a (h) symbol. That
 means that you now have your virtual environment activated. This is required for
@@ -197,21 +197,6 @@ dependencies into the ``h/node_modules`` directory:
 
     cd h
     make deps
-
-.. note::
-
-   If ``make deps`` fails for any reason re-running it may not install all the
-   dependencies because it sees the ``h.egg_info`` and ``node_modules``
-   directories that it created before it failed and assumes that because they
-   exist its work is done. You may see ``make: Nothing to be done for `deps'``
-   or you may get no output, or you may see it doing some work (e.g. installing
-   Python dependencies) but it may not do *all* the work (e.g. not installing
-   missing Node dependencies).
-
-   So to reinstall all the dependencies after a failure or crash do::
-
-       rm -rf h.egg_info node_modules
-       make deps
 
 .. _virtualenvwrapper: https://virtualenvwrapper.readthedocs.org/en/latest/install.html
 


### PR DESCRIPTION
Add a marker file in node_modules/ and .eggs/ to record
whether the installed dependencies are out of date
w.r.t. package.json or requirements.txt and auto-install them
if necessary when running 'make dev'.

The marker file is not created until node / Python deps
have been successfully installed, which avoids the problem
mentioned in install.rst

For the Python dependencies, what other files need to be considered besides 'requirements.txt'?