### PR TITLE
Hide unanchored warnings when not sidebar

### DIFF
--- a/h/static/scripts/widget-controller.coffee
+++ b/h/static/scripts/widget-controller.coffee
@@ -11,6 +11,7 @@ module.exports = class WidgetController
      streamer,   streamFilter,   store,   threading
   ) ->
     $scope.isStream = true
+    $scope.isSidebar = true
     $scope.threadRoot = threading.root
 
     @chunkSize = 200

--- a/h/templates/client/thread.html
+++ b/h/templates/client/thread.html
@@ -47,6 +47,6 @@
 </ul>
 
 <footer class="thread-anchor-notice"
-        ng-if="feature('show_unanchored_annotations') && !vm.container.message.$anchored">
+        ng-if="feature('show_unanchored_annotations') && isSidebar && !vm.container.message.$anchored">
   <em>We can't find the exact position of this annotation.</em>
 </footer>


### PR DESCRIPTION
Don't show the "We can't find the exact position of this annotation"
warnings on unanchored annotations when on the stream or individual
annotation pages - only show them in the sidebar.

Fixes #2521 