### PR TITLE
Change $anchored -> $orphan

### DIFF
--- a/h/static/scripts/annotator/guest.coffee
+++ b/h/static/scripts/annotator/guest.coffee
@@ -197,10 +197,10 @@ module.exports = class Guest extends Annotator
 
     sync = (anchors) ->
       # Store the results of anchoring.
-      annotation.$anchored = anchors.length is 0
+      annotation.$orphan = anchors.length > 0
       for anchor in anchors
         if anchor.range?
-          annotation.$anchored = true
+          annotation.$orphan = false
           break
 
       # Add the anchors for this annotation to instance storage.

--- a/h/static/scripts/annotator/test/guest-test.coffee
+++ b/h/static/scripts/annotator/test/guest-test.coffee
@@ -249,27 +249,27 @@ describe 'Guest', ->
     afterEach ->
       document.body.removeChild(el)
 
-    it "declares annotations without targets as anchored", (done) ->
+    it "doesn't declare annotations without targets as orphans", (done) ->
       guest = createGuest()
       annotation = target: []
       guest.anchor(annotation).then ->
-        assert.isTrue(annotation.$anchored)
+        assert.isFalse(annotation.$orphan)
       .then(done, done)
 
-    it "declares annotations with a working target anchored", (done) ->
+    it "doesn't declare annotations with a working target orphans", (done) ->
       guest = createGuest()
       annotation = target: [{selector: "test"}]
       sandbox.stub(anchoring, 'anchor').returns(Promise.resolve(range))
       guest.anchor(annotation).then ->
-        assert.isTrue(annotation.$anchored)
+        assert.isFalse(annotation.$orphan)
       .then(done, done)
 
-    it "declares annotations with broken targets not anchored", (done) ->
+    it "declares annotations with broken targets as orphans", (done) ->
       guest = createGuest()
       annotation = target: [{selector: 'broken selector'}]
       sandbox.stub(anchoring, 'anchor').returns(Promise.reject())
       guest.anchor(annotation).then ->
-        assert.isFalse(annotation.$anchored)
+        assert.isTrue(annotation.$orphan)
       .then(done, done)
 
     it 'updates the cross frame and bucket bar plugins', (done) ->

--- a/h/static/scripts/cross-frame.coffee
+++ b/h/static/scripts/cross-frame.coffee
@@ -18,7 +18,7 @@ module.exports = class CrossFrame
       new Discovery($window, options)
 
     createAnnotationSync = ->
-      whitelist = ['$anchored', '$highlight', 'target', 'document', 'uri']
+      whitelist = ['$orphan', '$highlight', 'target', 'document', 'uri']
       options =
         formatter: (annotation) ->
           formatted = {}

--- a/h/static/scripts/test/widget-controller-test.coffee
+++ b/h/static/scripts/test/widget-controller-test.coffee
@@ -86,3 +86,34 @@ describe 'WidgetController', ->
       assert.calledWith(loadSpy, [40..59])
       assert.calledWith(loadSpy, [60..79])
       assert.calledWith(loadSpy, [80..99])
+
+  describe 'shouldShowThread()', ->
+    it 'returns false for orphan annotations', ->
+      # Turn the 'show_unanchored_annotations' feature off.
+      $scope.feature = -> false
+
+      container =
+        message:
+          $orphan: true
+
+      assert($scope.shouldShowThread(container) is false)
+
+    it 'returns true for non-orphan annotations', ->
+      # Turn the 'show_unanchored_annotations' feature off.
+      $scope.feature = -> false
+
+      container =
+        message:
+          $orphan: false
+
+      assert($scope.shouldShowThread(container) is true)
+
+    it 'returns true for orphan annotations if show_unanchored_annotations is on', ->
+      # Turn the 'show_unanchored_annotations' feature on.
+      $scope.feature = -> true
+
+      container =
+        message:
+          $orphan: true
+
+      assert($scope.shouldShowThread(container) is true)

--- a/h/static/scripts/widget-controller.coffee
+++ b/h/static/scripts/widget-controller.coffee
@@ -58,27 +58,14 @@ module.exports = class WidgetController
         crossframe.call('scrollToAnnotation', annotation.$$tag)
 
     $scope.shouldShowThread = (container) ->
-      # Show stubs
-      if not container?.message?
-        return true
-
-      # Show replies
-      if container.message.references?.length
-        return true
-
-      # Show selected threads
-      if annotationUI.hasSelectedAnnotations()
-        return annotationUI.isAnnotationSelected(container.message.id)
-
-      # Show regardless of $anchored if that feature is turned on
+      # Show regardless of $orphan if that feature is turned on
       if $scope.feature('show_unanchored_annotations')
         return true
 
-      # Show anchored threads
-      if container.message.$anchored
-        return true
+      if container?.message?.$orphan == true
+        return false
 
-      return false
+      return true
 
     $scope.hasFocus = (annotation) ->
       !!($scope.focusedAnnotations ? {})[annotation?.$$tag]

--- a/h/templates/client/thread.html
+++ b/h/templates/client/thread.html
@@ -47,6 +47,6 @@
 </ul>
 
 <footer class="thread-anchor-notice"
-        ng-if="feature('show_unanchored_annotations') && isSidebar && !vm.container.message.$anchored">
+        ng-if="feature('show_unanchored_annotations') && isSidebar && vm.container.message.$orphan">
   <em>We can't find the exact position of this annotation.</em>
 </footer>


### PR DESCRIPTION
Instead of setting $anchored=true on anchored annotations, set
$orphan=true on orphaned (i.e. unanchored) ones as we used to do.

Orphaned annotations are the exception: we don't show them, or if
show_unanchored_annotations is one then we show them with a warning.
It's simpler and less buggy to add $orphan=true onto the exceptional
annotations than to try to add $anchored=true onto all of the
unexceptional ones.

Fixes #2525.
Fixes #2541.