### PR TITLE
Add bundle dependency on annotation-mapper.js

### DIFF
--- a/h/assets.yaml
+++ b/h/assets.yaml
@@ -133,6 +133,7 @@ app_js:
           contents: h:static/scripts/app.coffee
           depends:
             - h:static/scripts/*.coffee
+            - h:static/scripts/annotation-mapper.js
             - h:static/scripts/auth.js
             - h:static/scripts/features.js
             - h:static/scripts/groups.js


### PR DESCRIPTION
Until the build outputs are in a separate directory from the source
modules we need to maintain the .js files here without globbing or
webassets won't re-build the bundle when annotation-mapper.js changes
during development.