### PR TITLE
Don't crash if no parent is found

### DIFF
--- a/h/api/groups/logic.py
+++ b/h/api/groups/logic.py
@@ -19,14 +19,21 @@ def set_group_if_reply(annotation):
         else:
             return False
 
-    if is_reply(annotation):
-        # Get the top-level annotation that this annotation is a reply
-        # (or a reply-to-a-reply etc) to.
-        top_level_annotation_id = annotation['references'][0]
-        top_level_annotation = models.Annotation.fetch(top_level_annotation_id)
+    if not is_reply(annotation):
+        return
 
-        if 'group' in top_level_annotation:
-            annotation['group'] = top_level_annotation['group']
-        else:
-            if 'group' in annotation:
-                del annotation['group']
+    # Get the top-level annotation that this annotation is a reply
+    # (or a reply-to-a-reply etc) to.
+    top_level_annotation_id = annotation['references'][0]
+    top_level_annotation = models.Annotation.fetch(top_level_annotation_id)
+
+    # If we can't find the top-level annotation, there's nothing we can do, and
+    # we should bail.
+    if top_level_annotation is None:
+        return
+
+    if 'group' in top_level_annotation:
+        annotation['group'] = top_level_annotation['group']
+    else:
+        if 'group' in annotation:
+            del annotation['group']

--- a/h/api/groups/test/logic_test.py
+++ b/h/api/groups/test/logic_test.py
@@ -47,6 +47,15 @@ def test_set_group_if_reply_calls_fetch_if_reply(models):
 
 
 @set_group_if_reply_fixtures
+def test_set_group_if_reply_does_nothing_if_parent_not_found(models):
+    annotation = _mock_annotation(references=['parent_id'])
+
+    models.Annotation.fetch.return_value = None
+
+    logic.set_group_if_reply(annotation)
+
+
+@set_group_if_reply_fixtures
 def test_set_group_if_reply_adds_group_to_replies(models):
     """If a reply has no group it gets the group of its parent annotation."""
     annotation = _mock_annotation(references=['parent_id'])


### PR DESCRIPTION
We can't always guarantee the parent's existence (its owner might delete it) so we must handle this case.