### PR TITLE
Allow missing permissions

### DIFF
--- a/h/api/groups/auth.py
+++ b/h/api/groups/auth.py
@@ -13,7 +13,7 @@ def set_permissions(annotation):
         return
 
     group = annotation.get('group')
-    if group is None or group == '__world__':
+    if group in (None, '', '__world__'):
         # The groups feature doesn't change the permissions for annotations
         # that don't belong to a group.
         return

--- a/h/api/groups/auth.py
+++ b/h/api/groups/auth.py
@@ -3,9 +3,15 @@
 
 def set_permissions(annotation):
     """Set the given annotation's permissions according to its group."""
+    # If this annotation doesn't have a permissions field, we don't know how to
+    # handle it and should bail.
+    permissions = annotation.get('permissions')
+    if permissions is None:
+        return
+
     # For private annotations (visible only to the user who created them) the
     # client sends just the user's ID in the read permissions.
-    is_private = (annotation['permissions']['read'] == [annotation['user']])
+    is_private = (permissions.get('read') == [annotation['user']])
 
     if is_private:
         # The groups feature doesn't change the permissions for private

--- a/h/api/groups/test/auth_test.py
+++ b/h/api/groups/test/auth_test.py
@@ -9,6 +9,22 @@ def _mock_group(hashid):
     return mock.Mock(hashid=hashid)
 
 
+def test_set_permissions_does_not_modify_annotations_with_no_permissions():
+    annotations = [{
+        'user': 'acct:jack@hypothes.is',
+    },
+    {
+        'user': 'acct:jack@hypothes.is',
+        'group': 'xyzabc',
+    }]
+
+    for ann in annotations:
+        before = copy.deepcopy(ann)
+        auth.set_permissions(ann)
+
+        assert ann == before
+
+
 def test_set_permissions_does_not_modify_private_annotations():
     original_annotation = {
         'user': 'acct:jack@hypothes.is',

--- a/h/api/groups/test/auth_test.py
+++ b/h/api/groups/test/auth_test.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import copy
 import mock
 
 from h.api.groups import auth
@@ -16,7 +17,7 @@ def test_set_permissions_does_not_modify_private_annotations():
             'read': ['acct:jack@hypothes.is']
         }
     }
-    annotation_to_be_modified = original_annotation.copy()
+    annotation_to_be_modified = copy.deepcopy(original_annotation)
 
 
     auth.set_permissions(annotation_to_be_modified)
@@ -29,12 +30,12 @@ def test_set_permissions_does_not_modify_non_group_annotations():
         original_annotation = {
             'user': 'acct:jack@hypothes.is',
             'permissions': {
-                'read': ['acct:jack@hypothes.is']
+                'read': ['acct:jill@hypothes.is']
             }
         }
         if group != 'missing':
             original_annotation['group'] = group
-        annotation_to_be_modified = original_annotation.copy()
+        annotation_to_be_modified = copy.deepcopy(original_annotation)
 
         auth.set_permissions(annotation_to_be_modified)
 


### PR DESCRIPTION
We can't always guarantee the permissions field is present, as our API does not currently enforce this. Don't crash in this case.

This PR also fixes another test that was passing due to a couple of bugs in the test, rather than because the code was correct.