### PR TITLE
Fix comments (AKA "page notes") with search_normalized

### DIFF
--- a/h/api/search/test/transform_test.py
+++ b/h/api/search/test/transform_test.py
@@ -56,6 +56,40 @@ def test_prepare_adds_scope_field(_, ann_in, ann_out, uri_normalize):
 
 @mock.patch('h.api.search.transform.models')
 @mock.patch('h.api.search.transform.groups')
+@pytest.mark.usefixtures("uri_normalize")
+@pytest.mark.parametrize("ann_in,ann_out", [
+    ({"uri": "giraffe"},
+     {"uri": "giraffe",
+      "target": [{"source": "giraffe", "scope": ["*giraffe*"]}]}),
+    ({"uri": "giraffe", "target": []},
+     {"uri": "giraffe",
+      "target": [{"source": "giraffe", "scope": ["*giraffe*"]}]}),
+    ({"uri": "giraffe", "references": []},
+     {"uri": "giraffe",
+      "references": [],
+      "target": [{"source": "giraffe", "scope": ["*giraffe*"]}]}),
+    ({"uri": "giraffe", "references": [], "target": []},
+     {"uri": "giraffe",
+      "references": [],
+      "target": [{"source": "giraffe", "scope": ["*giraffe*"]}]}),
+
+    # Does nothing if either references or target is non-empty
+    ({"uri": "giraffe", "references": ['hello'], "target": []},
+     {"uri": "giraffe", "references": ['hello'], "target": []}),
+    ({"uri": "giraffe", "references": [], "target": [{'foo': 'bar'}]},
+     {"uri": "giraffe", "references": [], "target": [{'foo': 'bar'}]}),
+
+    # Does nothing when lacking a uri
+    ({"references": [], "target": []},
+     {"references": [], "target": []}),
+])
+def test_prepare_transforms_old_style_comments(models, groups, ann_in, ann_out):
+    transform.prepare(ann_in)
+    assert ann_in == ann_out
+
+
+@mock.patch('h.api.search.transform.models')
+@mock.patch('h.api.search.transform.groups')
 def test_prepare_copies_parents_scopes_into_replies(_, models):
     parent_annotation = {
         'id': 'parent_annotation_id',

--- a/h/static/scripts/annotator/guest.coffee
+++ b/h/static/scripts/annotator/guest.coffee
@@ -269,6 +269,7 @@ module.exports = class Guest extends Annotator
         cache: self.anchoringCache
         ignoreSelector: '[class^="annotator-"]'
       }
+      # Returns an array of selectors for the passed range.
       return self.anchoring.describe(root, range, options)
 
     setDocumentInfo = (info) ->
@@ -276,6 +277,8 @@ module.exports = class Guest extends Annotator
       annotation.uri = info.uri
 
     setTargets = ([info, selectors]) ->
+      # `selectors` is an array of arrays: each item is an array of selectors
+      # identifying a distinct target.
       source = info.uri
       annotation.target = ({source, selector} for selector in selectors)
 

--- a/h/static/scripts/annotator/guest.coffee
+++ b/h/static/scripts/annotator/guest.coffee
@@ -296,6 +296,22 @@ module.exports = class Guest extends Annotator
   createHighlight: ->
     return this.createAnnotation({$highlight: true})
 
+  # Create a blank comment (AKA "page note")
+  createComment: () ->
+    annotation = {}
+    self = this
+
+    prepare = (info) ->
+      annotation.document = info.metadata
+      annotation.uri = info.uri
+      annotation.target = [{source: info.uri}]
+
+    this.getDocumentInfo()
+      .then(prepare)
+      .then(-> self.publish('beforeAnnotationCreated', [annotation]))
+
+    annotation
+
   showAnnotations: (annotations) ->
     tags = (a.$$tag for a in annotations)
     @crossframe?.call('showAnnotations', tags)

--- a/h/static/scripts/annotator/guest.coffee
+++ b/h/static/scripts/annotator/guest.coffee
@@ -197,11 +197,19 @@ module.exports = class Guest extends Annotator
 
     sync = (anchors) ->
       # Store the results of anchoring.
-      annotation.$orphan = anchors.length > 0
+
+      # An annotation is considered to be an orphan if it has at least one
+      # target with selectors, and all targets with selectors failed to anchor
+      # (i.e. we didn't find it in the page and thus it has no range).
+      hasAnchorableTargets = false
+      hasAnchoredTargets = false
       for anchor in anchors
-        if anchor.range?
-          annotation.$orphan = false
-          break
+        if anchor.target.selector?
+          hasAnchorableTargets = true
+          if anchor.range?
+            hasAnchoredTargets = true
+            break
+      annotation.$orphan = hasAnchorableTargets and not hasAnchoredTargets
 
       # Add the anchors for this annotation to instance storage.
       self.anchors = self.anchors.concat(anchors)

--- a/h/static/scripts/annotator/plugin/toolbar.coffee
+++ b/h/static/scripts/annotator/plugin/toolbar.coffee
@@ -57,7 +57,7 @@ module.exports = class Toolbar extends Annotator.Plugin
         "click": (event) =>
           event.preventDefault()
           event.stopPropagation()
-          @annotator.createAnnotation()
+          @annotator.createComment()
           @annotator.show()
     ]
     @buttons = $(makeButton(item) for item in items)

--- a/h/static/scripts/annotator/test/guest-test.coffee
+++ b/h/static/scripts/annotator/test/guest-test.coffee
@@ -240,6 +240,46 @@ describe 'Guest', ->
       annotation = guest.createAnnotation(annotation)
       assert.equal(annotation.foo, 'bar')
 
+    it 'triggers a beforeAnnotationCreated event', (done) ->
+      guest = createGuest()
+      guest.subscribe('beforeAnnotationCreated', -> done())
+
+      guest.createAnnotation()
+
+  describe 'createComment()', ->
+    it 'adds metadata to the annotation object', ->
+      guest = createGuest()
+      sinon.stub(guest, 'getDocumentInfo').returns(Promise.resolve({
+        metadata: {title: 'hello'}
+        uri: 'http://example.com/'
+      }))
+
+      annotation = guest.createComment()
+
+      timeoutPromise()
+      .then ->
+        assert.equal(annotation.uri, 'http://example.com/')
+        assert.deepEqual(annotation.document, {title: 'hello'})
+
+    it 'adds a single target with a source property', ->
+      guest = createGuest()
+      sinon.stub(guest, 'getDocumentInfo').returns(Promise.resolve({
+        metadata: {title: 'hello'}
+        uri: 'http://example.com/'
+      }))
+
+      annotation = guest.createComment()
+
+      timeoutPromise()
+      .then ->
+        assert.deepEqual(annotation.target, [{source: 'http://example.com/'}])
+
+    it 'triggers a beforeAnnotationCreated event', (done) ->
+      guest = createGuest()
+      guest.subscribe('beforeAnnotationCreated', -> done())
+
+      guest.createComment()
+
   describe 'anchor()', ->
     el = null
     range = null

--- a/h/static/scripts/annotator/test/guest-test.coffee
+++ b/h/static/scripts/annotator/test/guest-test.coffee
@@ -19,6 +19,10 @@ Guest = proxyquire('../guest', {
   'scroll-into-view': scrollIntoView,
 })
 
+# A little helper which returns a promise that resolves after a timeout
+timeoutPromise = (millis = 0) ->
+  new Promise((resolve) -> setTimeout(resolve, millis))
+
 describe 'Guest', ->
   sandbox = sinon.sandbox.create()
   CrossFrame = null
@@ -215,18 +219,20 @@ describe 'Guest', ->
       assert.isTrue(event.isPropagationStopped())
 
   describe 'createAnnotation()', ->
-    it 'adds metadata to the annotation object', (done) ->
+    it 'adds metadata to the annotation object', ->
       guest = createGuest()
       sinon.stub(guest, 'getDocumentInfo').returns(Promise.resolve({
         metadata: {title: 'hello'}
         uri: 'http://example.com/'
       }))
       annotation = {}
+
       guest.createAnnotation(annotation)
-      setTimeout ->
+
+      timeoutPromise()
+      .then ->
         assert.equal(annotation.uri, 'http://example.com/')
         assert.deepEqual(annotation.document, {title: 'hello'})
-        done()
 
     it 'treats an argument as the annotation object', ->
       guest = createGuest()

--- a/h/static/scripts/directive/annotation.coffee
+++ b/h/static/scripts/directive/annotation.coffee
@@ -85,14 +85,6 @@ AnnotationController = [
 
     ###*
     # @ngdoc method
-    # @name annotation.AnnotationController#isComment.
-    # @returns {boolean} True if the annotation is a comment.
-    ###
-    this.isComment = ->
-      not (model.target?.length or model.references?.length)
-
-    ###*
-    # @ngdoc method
     # @name annotation.AnnotationController#isHighlight.
     # @returns {boolean} True if the annotation is a highlight.
     ###


### PR DESCRIPTION
The last thing blocking full rollout of the new normalized URI searches is #2484. This pull request address and closes that issue. From the commit messages:

---

In order for comments (AKA "page notes") to be discoverable with the search logic implemented in #2413 (cc4ca35), they need to have at least one target with a source field.

Previously a comment was defined as an annotation

- with a `uri`
- without any targets
- without any references (no targets but with references == a reply)

Now comments have a single target with a single field, `source`.

---

When receiving data from older clients, this commit will ensure that we rewrite old-style comments to new ones with a target with a source field.

This will also serve as a data migration to be run with `hypothesis annotool`.

---

Closes #2484.