### PR TITLE
Automatically convert URLs in annotation text to links

### DIFF
--- a/h/static/scripts/filter/converter.js
+++ b/h/static/scripts/filter/converter.js
@@ -8,6 +8,10 @@ function targetBlank(converter) {
 }
 
 module.exports = function () {
-  var converter = new showdown.Converter({extensions: [targetBlank]});
+  // see https://github.com/showdownjs/showdown#valid-options
+  var converter = new showdown.Converter({
+    extensions: [targetBlank],
+    simplifiedAutoLink: true
+  });
   return converter.makeHtml.bind(converter);
 };

--- a/h/static/scripts/filter/test/converter-test.js
+++ b/h/static/scripts/filter/test/converter-test.js
@@ -1,0 +1,10 @@
+var converter = require('../converter');
+
+describe('markdown converter', function () {
+  var markdownToHTML = converter();
+  it('should autolink URLs', function () {
+    assert.equal(markdownToHTML('See this link - http://arxiv.org/article'),
+      '<p>See this link - <a target="_blank" href="http://arxiv.org/article">' +
+      'http://arxiv.org/article</a></p>');
+  });
+});


### PR DESCRIPTION
I was surprised not to have autolink functionality in the markdown editor.

Only URLs with a scheme or beginning with 'www.' are processed.

Fixes #2505