### PR TITLE
Implement focusing on a group

### DIFF
--- a/h/static/scripts/annotation-mapper.js
+++ b/h/static/scripts/annotation-mapper.js
@@ -18,11 +18,15 @@ function getContainer(threading, annotation) {
 
 // Wraps the annotation store to trigger events for the CRUD actions
 // @ngInject
-function annotationMapper($rootScope, threading, store) {
+function annotationMapper($rootScope, threading, store, groups) {
   function loadAnnotations(annotations) {
     var loaded = [];
 
     annotations.forEach(function (annotation) {
+      if (annotation.group !== groups.focused().id) {
+        return;
+      }
+
       var container = getContainer(threading, annotation);
       if (container !== null) {
         angular.copy(annotation, container.message);

--- a/h/static/scripts/annotation-mapper.js
+++ b/h/static/scripts/annotation-mapper.js
@@ -66,7 +66,13 @@ function annotationMapper($rootScope, threading, store) {
     loadAnnotations: loadAnnotations,
     unloadAnnotations: unloadAnnotations,
     createAnnotation: createAnnotation,
-    deleteAnnotation: deleteAnnotation
+    deleteAnnotation: deleteAnnotation,
+    threads: function() {
+      return threading.root.children;
+    },
+    thread: function(id) {
+      return threading.idTable[id];
+    }
   };
 }
 

--- a/h/static/scripts/annotation-mapper.js
+++ b/h/static/scripts/annotation-mapper.js
@@ -19,11 +19,25 @@ function getContainer(threading, annotation) {
 // Wraps the annotation store to trigger events for the CRUD actions
 // @ngInject
 function annotationMapper($rootScope, threading, store, groups) {
-  function loadAnnotations(annotations) {
-    var loaded = [];
 
-    annotations.forEach(function (annotation) {
-      if (annotation.group !== groups.focused().id) {
+  // All of the annotations that annotationMapper has received from calls to
+  // its loadAnnotations() method.
+  var received = [];
+
+  // The annotations that are currently loaded into the page context.
+  var loaded = [];
+
+  function loadAnnotations(annotations) {
+    received = received.concat(annotations);
+    loadAnnotationsFromGroup(annotations, groups.focused().id);
+  }
+
+  function loadAnnotationsFromGroup(annotations, groupId) {
+    // The annotations that we've added to the page.
+    var newlyLoaded = [];
+
+    annotations.forEach(function(annotation) {
+      if (annotation.group !== groupId) {
         return;
       }
 
@@ -34,20 +48,31 @@ function annotationMapper($rootScope, threading, store, groups) {
         return;
       }
 
-      loaded.push(new store.AnnotationResource(annotation));
+      newlyLoaded.push(new store.AnnotationResource(annotation));
     });
 
-    $rootScope.$emit('annotationsLoaded', loaded);
+    $rootScope.$emit('annotationsLoaded', newlyLoaded);
+    loaded = loaded.concat(newlyLoaded);
   }
 
+  // When the focused group changes, change what annotations are shown.
+  $rootScope.$on('groupFocused', function() {
+    unloadAnnotations(loaded);
+    loadAnnotationsFromGroup(received, groups.focused().id);
+  });
+
   function unloadAnnotations(annotations) {
-    annotations.forEach(function (annotation) {
+    annotations.forEach(function(annotation) {
       var container = getContainer(threading, annotation);
       if (container !== null && annotation !== container.message) {
         annotation = angular.copy(annotation, container.message);
       }
 
       $rootScope.$emit('annotationDeleted', annotation);
+    });
+
+    annotations.slice().forEach(function(annotation) {
+      loaded.splice(loaded.indexOf(annotation, 1));
     });
   }
 

--- a/h/static/scripts/annotation-viewer-controller.coffee
+++ b/h/static/scripts/annotation-viewer-controller.coffee
@@ -4,11 +4,11 @@ angular = require('angular')
 module.exports = class AnnotationViewerController
   this.$inject = [
     '$location', '$routeParams', '$scope',
-    'streamer', 'store', 'streamFilter', 'annotationMapper', 'threading'
+    'streamer', 'store', 'streamFilter', 'annotationMapper'
   ]
   constructor: (
      $location,   $routeParams,   $scope,
-     streamer,   store,   streamFilter,   annotationMapper,   threading
+     streamer,   store,   streamFilter,   annotationMapper
   ) ->
     id = $routeParams.id
 
@@ -26,7 +26,7 @@ module.exports = class AnnotationViewerController
 
     store.AnnotationResource.read id: id, (annotation) ->
       annotationMapper.loadAnnotations([annotation])
-      $scope.threadRoot = {children: [threading.idTable[id]]}
+      $scope.threads = -> [annotationMapper.thread(id)]
     store.SearchResource.get references: id, ({rows}) ->
       annotationMapper.loadAnnotations(rows)
 

--- a/h/static/scripts/groups.js
+++ b/h/static/scripts/groups.js
@@ -10,7 +10,7 @@
 var STORAGE_KEY = 'hypothesis.groups.focus';
 
 // @ngInject
-function groups(localStorage, session) {
+function groups(localStorage, session, $rootScope) {
   // The currently focused group. This is the group that's shown as selected in
   // the groups dropdown, the annotations displayed are filtered to only ones
   // that belong to this group, and any new annotations that the user creates
@@ -56,6 +56,7 @@ function groups(localStorage, session) {
       if (typeof g !== 'undefined') {
         focused = g;
         localStorage.setItem(STORAGE_KEY, g.id);
+        $rootScope.$emit('groupFocused', g.id);
       }
     }
   };

--- a/h/static/scripts/stream-controller.coffee
+++ b/h/static/scripts/stream-controller.coffee
@@ -6,12 +6,12 @@ module.exports = class StreamController
   this.inject = [
     '$scope', '$route', '$rootScope', '$routeParams',
     'queryParser', 'searchFilter', 'store',
-    'streamer', 'streamFilter', 'threading', 'annotationMapper'
+    'streamer', 'streamFilter', 'annotationMapper'
   ]
   constructor: (
      $scope,   $route,   $rootScope,   $routeParams
      queryParser,   searchFilter,   store,
-     streamer,   streamFilter,   threading,   annotationMapper
+     streamer,   streamFilter,   annotationMapper
   ) ->
     offset = 0
 
@@ -52,7 +52,7 @@ module.exports = class StreamController
 
     $scope.isStream = true
     $scope.sort.name = 'Newest'
-    $scope.threadRoot = threading.root
+    $scope.threads = annotationMapper.threads
 
     $scope.shouldShowThread = (container) -> true
 

--- a/h/static/scripts/test/annotation-mapper-test.js
+++ b/h/static/scripts/test/annotation-mapper-test.js
@@ -5,6 +5,7 @@ describe('annotationMapper', function() {
   var $rootScope;
   var fakeStore;
   var fakeThreading;
+  var fakeGroups;
   var annotationMapper;
 
   before(function () {
@@ -20,9 +21,13 @@ describe('annotationMapper', function() {
     fakeThreading = {
       idTable: {}
     };
+    fakeGroups = {
+      focused: function() {return {id: 'foo'};}
+    };
 
     $provide.value('store', fakeStore);
     $provide.value('threading', fakeThreading);
+    $provide.value('groups', fakeGroups);
   }));
 
   beforeEach(angular.mock.inject(function (_annotationMapper_, _$rootScope_) {
@@ -37,7 +42,10 @@ describe('annotationMapper', function() {
   describe('.loadAnnotations()', function () {
     it('triggers the annotationLoaded event', function () {
       sandbox.stub($rootScope, '$emit');
-      var annotations = [{id: 1}, {id: 2}, {id: 3}];
+      var annotations = [
+        {id: 1, group: 'foo'},
+        {id: 2, group: 'foo'},
+        {id: 3, group: 'foo'}];
       annotationMapper.loadAnnotations(annotations);
       assert.called($rootScope.$emit);
       assert.calledWith($rootScope.$emit, 'annotationsLoaded', [{}, {}, {}]);
@@ -45,7 +53,10 @@ describe('annotationMapper', function() {
 
     it('triggers the annotationUpdated event for each annotation in the threading cache', function () {
       sandbox.stub($rootScope, '$emit');
-      var annotations = [{id: 1}, {id: 2}, {id: 3}];
+      var annotations = [
+        {id: 1, group: 'foo'},
+        {id: 2, group: 'foo'},
+        {id: 3, group: 'foo'}];
       var cached = {message: {id: 1, $$tag: 'tag1'}};
       fakeThreading.idTable[1] = cached;
 
@@ -56,7 +67,7 @@ describe('annotationMapper', function() {
 
     it('replaces the properties on the cached annotation with those from the loaded one', function () {
       sandbox.stub($rootScope, '$emit');
-      var annotations = [{id: 1, url: 'http://example.com'}];
+      var annotations = [{id: 1, group: 'foo', url: 'http://example.com'}];
       var cached = {message: {id: 1, $$tag: 'tag1'}};
       fakeThreading.idTable[1] = cached;
 
@@ -64,6 +75,7 @@ describe('annotationMapper', function() {
       assert.called($rootScope.$emit);
       assert.calledWith($rootScope.$emit, 'annotationUpdated', {
         id: 1,
+        group: 'foo',
         url: 'http://example.com'
       });
     });

--- a/h/static/scripts/test/annotation-viewer-controller-test.coffee
+++ b/h/static/scripts/test/annotation-viewer-controller-test.coffee
@@ -21,7 +21,7 @@ describe "AnnotationViewerController", ->
   # Return a new AnnotationViewerController instance.
   createAnnotationViewerController = ({$location, $routeParams, $scope,
                                        streamer, store, streamFilter,
-                                       annotationMapper, threading}) ->
+                                       annotationMapper}) ->
     locals = {
       $location: $location or {}
       $routeParams: $routeParams or {id: "test_annotation_id"}
@@ -34,7 +34,6 @@ describe "AnnotationViewerController", ->
         setMatchPolicyIncludeAny: -> {addClause: -> {addClause: ->}}
         getFilter: ->
       }
-      threading: sinon.stub()
       annotationMapper: annotationMapper or {loadAnnotations: sinon.spy()}
     }
     locals["ctrl"] = getControllerService()(

--- a/h/static/scripts/test/groups-test.js
+++ b/h/static/scripts/test/groups-test.js
@@ -19,6 +19,7 @@ var sessionWithThreeGroups = function() {
 describe('groups', function() {
   var fakeSession;
   var fakeLocalStorage;
+  var fakeRootScope;
   var sandbox;
 
   beforeEach(function () {
@@ -29,6 +30,9 @@ describe('groups', function() {
       getItem: sandbox.stub(),
       setItem: sandbox.stub()
     };
+    fakeRootScope = {
+      $emit: function() {}
+    };
   });
 
   afterEach(function () {
@@ -36,7 +40,7 @@ describe('groups', function() {
   });
 
   function service() {
-    return groups(fakeLocalStorage, fakeSession);
+    return groups(fakeLocalStorage, fakeSession, fakeRootScope);
   }
 
   describe('.all()', function() {

--- a/h/static/scripts/test/stream-controller-test.coffee
+++ b/h/static/scripts/test/stream-controller-test.coffee
@@ -10,7 +10,6 @@ describe 'StreamController', ->
   fakeStore = null
   fakeStreamer = null
   fakeStreamFilter = null
-  fakeThreading = null
 
   sandbox = null
 
@@ -63,10 +62,6 @@ describe 'StreamController', ->
       getFilter: sandbox.stub()
     }
 
-    fakeThreading = {
-      root: {}
-    }
-
     $provide.value 'annotationMapper', fakeAnnotationMapper
     $provide.value '$route', fakeRoute
     $provide.value '$routeParams', fakeParams
@@ -75,7 +70,6 @@ describe 'StreamController', ->
     $provide.value 'store', fakeStore
     $provide.value 'streamer', fakeStreamer
     $provide.value 'streamFilter', fakeStreamFilter
-    $provide.value 'threading', fakeThreading
     return
 
   beforeEach inject (_$controller_, $rootScope) ->

--- a/h/static/scripts/test/widget-controller-test.coffee
+++ b/h/static/scripts/test/widget-controller-test.coffee
@@ -9,7 +9,6 @@ describe 'WidgetController', ->
   fakeStore = null
   fakeStreamer = null
   fakeStreamFilter = null
-  fakeThreading = null
   sandbox = null
   viewer = null
 
@@ -54,17 +53,12 @@ describe 'WidgetController', ->
       getFilter: sandbox.stub().returns({})
     }
 
-    fakeThreading = {
-      root: {}
-    }
-
     $provide.value 'annotationMapper', fakeAnnotationMapper
     $provide.value 'annotationUI', fakeAnnotationUI
     $provide.value 'crossframe', fakeCrossFrame
     $provide.value 'store', fakeStore
     $provide.value 'streamer', fakeStreamer
     $provide.value 'streamFilter', fakeStreamFilter
-    $provide.value 'threading', fakeThreading
     return
 
   beforeEach inject ($controller, $rootScope) ->

--- a/h/static/scripts/threading.coffee
+++ b/h/static/scripts/threading.coffee
@@ -94,10 +94,11 @@ module.exports = class Threading
         parent = this.idTable[parentRef]
       else
         parent = @root
-      for child in parent.children when child.message is annotation
-        child.message = null
-        this.pruneEmpties(@root)
-        break
+      if parent
+        for child in parent.children when child.message is annotation
+          child.message = null
+          this.pruneEmpties(@root)
+          break
 
   annotationsLoaded: (event, annotations) =>
     messages = (@root.flattenChildren() or []).concat(annotations)

--- a/h/static/scripts/widget-controller.coffee
+++ b/h/static/scripts/widget-controller.coffee
@@ -4,15 +4,15 @@ angular = require('angular')
 module.exports = class WidgetController
   this.$inject = [
     '$scope', 'annotationUI', 'crossframe', 'annotationMapper',
-    'streamer', 'streamFilter', 'store', 'threading'
+    'streamer', 'streamFilter', 'store'
   ]
   constructor:   (
      $scope,   annotationUI, crossframe, annotationMapper,
-     streamer,   streamFilter,   store,   threading
+     streamer,   streamFilter,   store
   ) ->
     $scope.isStream = true
     $scope.isSidebar = true
-    $scope.threadRoot = threading.root
+    $scope.threads = annotationMapper.threads
 
     @chunkSize = 200
     loaded = []

--- a/h/templates/client/viewer.html
+++ b/h/templates/client/viewer.html
@@ -43,7 +43,7 @@
       ng-mouseenter="focus(child.message)"
       ng-click="scrollTo(child.message)"
       ng-mouseleave="focus()"
-      ng-repeat="child in threadRoot.children | orderBy : sort.predicate"
+      ng-repeat="child in threads() | orderBy : sort.predicate"
       ng-show="shouldShowThread(child) && (count('edit') || count('match') || !threadFilter.active()) || vm.isNew()">
   </li>
 </ul>


### PR DESCRIPTION
- [ ] Don't break the stream or individual annotation pages
- [x] Change the shown annotations when the selected group changes
- [ ] Also filter annotations from other groups out from live updates
- [ ] Focus the public group on sign out