### PR TITLE
Make auth.effective_principals do what it says

### DIFF
--- a/conf/development.ini
+++ b/conf/development.ini
@@ -11,7 +11,7 @@ es.host: http://localhost:9200
 
 mail.default_sender: "Annotation Daemon" <no-reply@localhost>
 
-multiauth.groupfinder: h.auth.effective_principals
+multiauth.groupfinder: h.auth.groupfinder
 multiauth.policies: remote session
 multiauth.policy.remote.use: pyramid.authentication.RemoteUserAuthenticationPolicy
 multiauth.policy.session.use: pyramid.authentication.SessionAuthenticationPolicy

--- a/conf/production.ini
+++ b/conf/production.ini
@@ -21,7 +21,7 @@ mail.default_sender: "Annotation Daemon" <no-reply@localhost>
 #mail.port: 25
 
 # Authentication configuration -- see the pyramid_multiauth documentation
-multiauth.groupfinder: h.auth.effective_principals
+multiauth.groupfinder: h.auth.groupfinder
 multiauth.policies: remote session
 multiauth.policy.remote.use: pyramid.authentication.RemoteUserAuthenticationPolicy
 multiauth.policy.session.use: pyramid.authentication.SessionAuthenticationPolicy


### PR DESCRIPTION
Previously `h.auth.effective_principals` was a "groupfinder", returning the list of groups of which a given userid is a member.

This commit renames that function to `groupfinder`, and updates the two configuration files to use it in that capacity. It also adds a new helper function to `h.auth`, which actually does return the list of effective principals for a given userid.

This is extracted from a work-in-progress branch to fix #2555 in a way that doesn't involve reimplementing the pyramid auth system in multiple places in our code.