### PR TITLE
Fix email notifications

### DIFF
--- a/h/api/auth.py
+++ b/h/api/auth.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+from pyramid import security
+
 from annotator.auth import Consumer, User
 
 
@@ -13,3 +15,21 @@ def get_user(request):
                 consumer = Consumer(key)
                 return User(userid, consumer, False)
     return None
+
+
+def translate_annotation_principals(principals):
+    """
+    Translate a list of annotation principals to a list of pyramid principals.
+    """
+    result = set([])
+    for principal in principals:
+        # Ignore suspicious principals from annotations
+        if principal.startswith('system.'):
+            continue
+        if principal == 'group:__world__':
+            result.add(security.Everyone)
+        elif principal == 'group:__authenticated__':
+            result.add(security.Authenticated)
+        else:
+            result.add(principal)
+    return list(result)

--- a/h/api/models.py
+++ b/h/api/models.py
@@ -217,6 +217,19 @@ class Annotation(annotation.Annotation):
         return parser.parse(self["created"]).strftime("%Y-%m-%d")
 
     @property
+    def parent(self):
+        """
+        Return the thread parent of this annotation, if it exists.
+        """
+        if 'references' not in self:
+            return None
+        if not isinstance(self['references'], list):
+            return None
+        if not self['references']:
+            return None
+        return Annotation.fetch(self['references'][-1])
+
+    @property
     def target_links(self):
         """A list of the URLs to this annotation's targets."""
         links = []

--- a/h/api/test/auth_test.py
+++ b/h/api/test/auth_test.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+
+from pyramid import security
+
+from h.api import auth
+
+
+@pytest.mark.parametrize("p_in,p_out", [
+    # The basics
+    ([], []),
+    (['acct:donna@example.com'], ['acct:donna@example.com']),
+    (['group:foo'], ['group:foo']),
+
+    # Remove pyramid principals
+    (['system.Everyone'], []),
+
+    # Remap annotatator principal names
+    (['group:__world__'], [security.Everyone]),
+    (['group:__authenticated__'], [security.Authenticated]),
+
+    # Normalise multiple principals
+    (['me', 'myself', 'me', 'group:__world__', 'group:foo', 'system.Admins'],
+     ['me', 'myself', security.Everyone, 'group:foo']),
+])
+def test_translate_annotation_principals(p_in, p_out):
+    result = auth.translate_annotation_principals(p_in)
+
+    assert set(result) == set(p_out)

--- a/h/api/test/models_test.py
+++ b/h/api/test/models_test.py
@@ -5,6 +5,8 @@ import re
 import unittest
 import urllib
 
+from mock import patch
+
 from h.api import models
 
 analysis = models.Annotation.__analysis__
@@ -94,3 +96,32 @@ def test_created_day_string_from_annotation():
 def test_target_links_from_annotation():
     annotation = models.Annotation(target=[{'source': 'target link'}])
     assert annotation.target_links == ['target link']
+
+
+def test_parent_returns_none_if_no_references():
+    annotation = models.Annotation()
+    assert annotation.parent is None
+
+
+def test_parent_returns_none_if_empty_references():
+    annotation = models.Annotation(references=[])
+    assert annotation.parent is None
+
+
+def test_parent_returns_none_if_references_not_list():
+    annotation = models.Annotation(references={'foo': 'bar'})
+    assert annotation.parent is None
+
+
+@patch.object(models.Annotation, 'fetch', spec=True)
+def test_parent_fetches_thread_parent(fetch):
+    annotation = models.Annotation(references=['abc123', 'def456'])
+    annotation.parent
+    fetch.assert_called_with('def456')
+
+
+@patch.object(models.Annotation, 'fetch', spec=True)
+def test_parent_returns_thread_parent(fetch):
+    annotation = models.Annotation(references=['abc123', 'def456'])
+    parent = annotation.parent
+    assert parent == fetch.return_value

--- a/h/api/test/resources_test.py
+++ b/h/api/test/resources_test.py
@@ -25,8 +25,9 @@ class TestAnnotationPermissions(object):
         annotation['permissions'] = {
             'read': [security.Everyone],
         }
-        with raises(ValueError):
-            resource.__acl__()
+        actual = resource.__acl__()
+        expect = []
+        assert actual == expect
 
     def test_group(self):
         resource = resources.Annotation()

--- a/h/notification/reply_template.py
+++ b/h/notification/reply_template.py
@@ -106,8 +106,14 @@ def check_conditions(annotation, data):
 
 
 def generate_notifications(request, annotation, action):
-    # And for them we need only the creation action
+    # Only send notifications when new annotations are created
     if action != 'create':
+        return
+
+    # If the annotation doesn't have a parent, or we can't find its parent,
+    # then we can't send a notification email.
+    parent = annotation.parent
+    if parent is None:
         return
 
     # Check for authorization. Send notification only for public annotation
@@ -118,7 +124,7 @@ def generate_notifications(request, annotation, action):
 
     # Store the parent values as additional data
     data = {
-        'parent': parent_values(annotation)
+        'parent': parent
     }
 
     subscriptions = Subscriptions.get_active_subscriptions_for_a_type(

--- a/h/notification/test/reply_template_test.py
+++ b/h/notification/test/reply_template_test.py
@@ -107,11 +107,8 @@ def test_all_keys_are_there():
         request = _create_request()
         annotation = store_fake_data[1]
 
-        data = {
-            'parent': rt.parent_values(annotation),
-            'subscription': {'id': 1}
-        }
-        tmap = rt.create_template_map(request, annotation, data)
+        parent = rt.parent_values(annotation)
+        tmap = rt.create_template_map(request, annotation, parent)
 
         assert 'document_title' in tmap
         assert 'document_path' in tmap
@@ -135,11 +132,8 @@ def test_template_map_key_values():
         request = _create_request()
         annotation = store_fake_data[1]
 
-        data = {
-            'parent': rt.parent_values(annotation),
-            'subscription': {'id': 1}
-        }
-        tmap = rt.create_template_map(request, annotation, data)
+        parent = rt.parent_values(annotation)
+        tmap = rt.create_template_map(request, annotation, parent)
 
         parent = store_fake_data[0]
 
@@ -172,11 +166,8 @@ def test_fallback_title():
         request = _create_request()
         annotation = store_fake_data[4]
 
-        data = {
-            'parent': rt.parent_values(annotation),
-            'subscription': {'id': 1}
-        }
-        tmap = rt.create_template_map(request, annotation, data)
+        parent = rt.parent_values(annotation)
+        tmap = rt.create_template_map(request, annotation, parent)
         assert tmap['document_title'] == annotation['uri']
 
 
@@ -187,16 +178,13 @@ def test_unsubscribe_token_generation():
         request = _create_request()
         annotation = store_fake_data[4]
 
-        data = {
-            'parent': rt.parent_values(annotation),
-            'subscription': {'id': 1}
-        }
-        rt.create_template_map(request, annotation, data)
+        parent = rt.parent_values(annotation)
+        rt.create_template_map(request, annotation, parent)
 
         notification_serializer = request.registry.notification_serializer
         notification_serializer.dumps.assert_called_with({
             'type': REPLY_TYPE,
-            'uri': data['parent']['user'],
+            'uri': parent['user'],
         })
 
 
@@ -207,11 +195,8 @@ def test_unsubscribe_url_generation():
         request = _create_request()
         annotation = store_fake_data[4]
 
-        data = {
-            'parent': rt.parent_values(annotation),
-            'subscription': {'id': 1}
-        }
-        rt.create_template_map(request, annotation, data)
+        parent = rt.parent_values(annotation)
+        rt.create_template_map(request, annotation, parent)
 
         request.route_url.assert_called_with('unsubscribe', token='TOKEN')
 
@@ -227,12 +212,9 @@ def test_get_email():
             request = _create_request()
 
             annotation = store_fake_data[1]
-            data = {
-                'parent': rt.parent_values(annotation),
-                'subscription': {'id': 1}
-            }
+            parent = rt.parent_values(annotation)
 
-            email = rt.get_recipients(request, data)
+            email = rt.get_recipients(request, parent)
             assert email[0] == user.email
 
 
@@ -245,14 +227,11 @@ def test_no_email():
             request = _create_request()
 
             annotation = store_fake_data[1]
-            data = {
-                'parent': rt.parent_values(annotation),
-                'subscription': {'id': 1}
-            }
+            parent = rt.parent_values(annotation)
 
             exc = False
             try:
-                rt.get_recipients(request, data)
+                rt.get_recipients(request, parent)
             except:
                 exc = True
             assert exc


### PR DESCRIPTION
When we receive an annotation in the notification mailer, we need to perform a set of checks:

- to determine if the annotation is a reply
- to determine who the author of the thread parent is
- to determine if we should send a reply notification to that author

In particular, we only want to send a reply notification email if the author is going to be able to read the reply. Previously, this was done by checking if the principals allowed by the 'read' permission included the system principal "system.Everyone".

Unfortunately, 998347a broke this by removing normal Annotation instances' status as a pyramid "context object", meaning that no annotations were passing the test and no reply notification emails were being sent.

This commit updates that permissions check. Now we:

1. Compute the set of principals of the parent annotation's author, using `h.auth.effective_principals`.
2. Compute the set of principals that are allowed to 'read' the reply annotation.
3. Abort unless these two sets have a non-null intersection.

Fixes #2555.

----

I apologise for the size of the diff, but it was necessary to shuffle some code around in order to be able to effectively test that this change correctly solves the problem.