### PR TITLE
Fix a bug where canceling changes did not reset the text

### DIFF
--- a/h/static/scripts/directive/annotation.coffee
+++ b/h/static/scripts/directive/annotation.coffee
@@ -281,7 +281,7 @@ AnnotationController = [
     this.render = ->
       # Extend the view model with a copy of the domain model.
       # Note that copy is used so that deep properties aren't shared.
-      angular.extend @annotation, angular.copy model
+      @annotation = angular.extend {}, angular.copy model
 
       # Set the URI
       @annotationURI = new URL("/a/#{@annotation.id}", this.baseURI).href

--- a/h/static/scripts/directive/test/annotation-test.coffee
+++ b/h/static/scripts/directive/test/annotation-test.coffee
@@ -719,4 +719,19 @@ describe("AnnotationController", ->
 
     # Now the original text should be restored.
     assert controller.annotation.text == original_text
+
+    # test that editing reverting changes to an annotation with
+    # no text resets the text to be empty
+    it "clears the text when reverting changes to a highlight", ->
+      {controller} = createAnnotationDirective({
+          annotation: {
+            id: "test-annotation-id",
+            user: "acct:bill@localhost"
+          }
+      })
+      controller.edit()
+      assert.equal controller.action, 'edit'
+      controller.annotation.text = "this should be reverted"
+      controller.revert()
+      assert.equal controller.annotation.text, undefined
 )


### PR DESCRIPTION
AnnotationController.revert() reverted changes to the
annotation in the editor by copying across properties
from the saved annotation to the draft.

Any properties which were _added_ in the draft but not
set in the saved version, such as the text when the text
is empty, were not reverted.

Fixes #2561