### PR TITLE
Warn about slow tests and add extended timeout for flakey test

### DIFF
--- a/h/static/scripts/karma.config.js
+++ b/h/static/scripts/karma.config.js
@@ -90,6 +90,13 @@ module.exports = function(config) {
     // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
     logLevel: config.LOG_INFO,
 
+    // warn about tests that take a long time to execute,
+    // in combination with per-test timeouts this can also be used
+    // to discover whether tests that intermittently timeout are merely slow,
+    // in which case they will trigger a warning,
+    // or failing to complete at all within the extended timeout
+    reportSlowerThan: 500,
+
     // enable / disable watching file and executing tests whenever any file changes
     autoWatch: true,
 

--- a/h/static/scripts/test/bridge-test.coffee
+++ b/h/static/scripts/test/bridge-test.coffee
@@ -35,7 +35,14 @@ describe 'Bridge', ->
       assert.equal(channel.dst, fakeWindow)
       assert.equal(channel.origin, 'http://example.com')
 
+
     it 'adds the channel to the .links property', ->
+      # extended timeout to assist debugging a flakey test,
+      # in combination with the 'reportSlowerThan' config option
+      # in karma.conf.js.
+      # See https://travis-ci.org/hypothesis/h/builds/82894887
+      this.timeout 30000
+
       channel = createChannel()
       assert.include(bridge.links, {channel: channel, window: fakeWindow})
 


### PR DESCRIPTION
Enable reporting of all tests that take longer than 500ms
to execute. In combination with high or disabled timeouts
for individual tests, this can be used to determine whether
tests that intermittently time out within the 2000ms threshold
are slow or hanging or failing to trigger the async callback.

Add a high timeout for the Bridge.createChannel() test which
is intermittently failing, eg. in https://travis-ci.org/hypothesis/h/builds/82894887

A few things to note about that run:
 - The overall completion time for the test suite was higher
   than average by more than 2000ms, so other tests may have
   taken a lot longer to run than normal
 - The test which timed out is pretty simple and synchronous,
   but there are a number of other async tests in the same suite so
   perhaps one of those tests is interfering with it

See #2563