### PR TITLE
Make activation created_by/valid_until fields nullable

### DIFF
--- a/h/accounts/models.py
+++ b/h/accounts/models.py
@@ -48,10 +48,8 @@ class Activation(Base):
                      default=_generate_random_string)
 
     # FIXME: remove these unused columns
-    created_by = sa.Column(sa.Unicode(30), nullable=False, default=u'web')
-    valid_until = sa.Column(sa.DateTime,
-                            nullable=False,
-                            default=datetime.utcnow() + timedelta(days=3))
+    created_by = sa.Column(sa.Unicode(30), nullable=True)
+    valid_until = sa.Column(sa.DateTime, nullable=True)
 
     @classmethod
     def get_by_code(cls, code):

--- a/h/migrations/versions/b0bf0fbf353_make_created_by_and_valid_until_nullable.py
+++ b/h/migrations/versions/b0bf0fbf353_make_created_by_and_valid_until_nullable.py
@@ -1,0 +1,35 @@
+"""Make activation.{created_by,valid_until} nullable
+
+This will make it easier to remove these columns in a later migration.
+
+Revision ID: b0bf0fbf353
+Revises: ef3059e0396
+Create Date: 2015-09-30 15:14:03.050955
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'b0bf0fbf353'
+down_revision = 'ef3059e0396'
+
+from alembic import op
+import sqlalchemy as sa
+
+def upgrade():
+    with op.batch_alter_table('activation') as batch_op:
+        batch_op.alter_column('created_by',
+                              existing_type=sa.Unicode(length=30),
+                              nullable=True)
+        batch_op.alter_column('valid_until',
+                              existing_type=sa.DateTime,
+                              nullable=True)
+
+
+def downgrade():
+    with op.batch_alter_table('activation') as batch_op:
+        batch_op.alter_column('valid_until',
+                              existing_type=sa.DateTime,
+                              nullable=False)
+        batch_op.alter_column('created_by',
+                              existing_type=sa.Unicode(length=30),
+                              nullable=False)


### PR DESCRIPTION
We don't use these fields at all -- they are a hangover from when we used horus for our accounts system -- and we'd like to remove them. Unfortunately removing them in one step isn't possible with our current stage/prod setup, because when we run the migration (in order to make stage work) prod will break, because the fields are non-nullable and thus will always be sent by sqlalchemy.

We can work around this by removing them in two stages:

1. Make the fields nullable. This code can be deployed to stage and the migration run without breaking prod. When we deploy the code to prod, it will then stop sending values to the database with every INSERT.

2. Remove the fields. Again, we can do this in stage and run the migration (to remove the columns in the database) without breaking prod.

This commit represents step 1.