### PR TITLE
Show filenames of local documents with titles

### DIFF
--- a/h/static/scripts/filter/document-domain.js
+++ b/h/static/scripts/filter/document-domain.js
@@ -13,8 +13,17 @@ module.exports = function() {
    *
    */
   function documentDomainFilter(document) {
+    var uri = escapeHtml(document.uri || '');
     var domain = escapeHtml(document.domain || '');
     var title = escapeHtml(document.title || '');
+
+    if (uri.startsWith('file://') && title) {
+      var parts = uri.split('/');
+      var filename = parts[parts.length - 1];
+      if (filename) {
+        return '(' + filename + ')';
+      }
+    }
 
     if (domain && domain !== title) {
       return '(' + domain + ')';

--- a/h/static/scripts/filter/test/document-domain-test.js
+++ b/h/static/scripts/filter/test/document-domain-test.js
@@ -29,12 +29,32 @@ describe('documentDomain', function() {
     assert(domain === '');
   });
 
+  it('returns the filename for local documents with titles', function() {
+    var domain = documentDomainFilterProvider()({
+      title: 'example.com',
+      uri: 'file:///home/seanh/MyFile.pdf'
+    });
+
+    assert(domain === '(MyFile.pdf)');
+  });
+
   it('escapes HTML in the document domain', function() {
     var spamLink = '<a href="http://example.com/rubies">Buy rubies!!!</a>';
 
     var domain = documentDomainFilterProvider()({
       title: 'title',
       domain: '</a>' + spamLink
+    });
+
+    assert(domain.indexOf(spamLink) === -1);
+  });
+
+  it('escapes HTML in the document uri', function() {
+    var spamLink = '<a href="http://example.com/rubies">Buy rubies!!!</a>';
+
+    var domain = documentDomainFilterProvider()({
+      title: 'title',
+      uri: 'file:///home/seanh/' + spamLink
     });
 
     assert(domain.indexOf(spamLink) === -1);


### PR DESCRIPTION
When the annotated document is a local (file://) document and it has a
title, then show the filename in place of the domain on the annotation
card. For example:

  seanh on "Document Title" (filename.pdf)

In cases where the document has no title then the filename would already
have been used in place of "Document Title" so don't repeat it in
(...)'s.

For remote documents the domain name is shown in (...)'s instead and the
document title is hyperlinked so the people can see the full URL by
hovering over the link.