### PR TITLE
Fix icon fonts in production builds

### DIFF
--- a/h/static/styles/vendor/icomoon.css
+++ b/h/static/styles/vendor/icomoon.css
@@ -1,6 +1,13 @@
 @font-face {
 	font-family: 'h';
-	src: url('fonts/h.woff?e944zd') format('woff');
+	/* WARNING - the URL below was modified from the generated URL
+	 * to use an absolute instead of relative URL
+	 * because the CSS asset pipeline is not correctly rebasing
+	 * URLs when concatenating files together.
+	 *
+	 * See issue #2571
+	 */
+	src: url('/assets/styles/vendor/fonts/h.woff?e944zd') format('woff');
 	font-weight: normal;
 	font-style: normal;
 }


### PR DESCRIPTION
As described in GH #2571, URL rebasing is broken
in the CSS asset pipeline, so relative URLs in
CSS files under styles/vendor are incorrect.

Previously icomoon.css worked because one of the
font variants (TTF) was inlined as a data URL.
This broken in the previous update which had only
the relative .woff URL.

This commit patches the issue by using an absolute URL
in the icomoon.css file. It will be fixed properly in
the CSS build as part of moving that out of the Python
web app.

See #2571