### PR TITLE
Avoid String.prototype.startsWith() for compatibility Safari and IE

### DIFF
--- a/h/static/scripts/filter/document-domain.js
+++ b/h/static/scripts/filter/document-domain.js
@@ -17,7 +17,7 @@ module.exports = function() {
     var domain = escapeHtml(document.domain || '');
     var title = escapeHtml(document.title || '');
 
-    if (uri.startsWith('file://') && title) {
+    if (uri.indexOf('file://') === 0 && title) {
       var parts = uri.split('/');
       var filename = parts[parts.length - 1];
       if (filename) {

--- a/h/static/scripts/filter/document-title.js
+++ b/h/static/scripts/filter/document-title.js
@@ -15,7 +15,7 @@ module.exports = function() {
     var title = escapeHtml(document.title || '');
     var uri = escapeHtml(document.uri || '');
 
-    if (uri && !(uri.startsWith('http://') || uri.startsWith('https://'))) {
+    if (uri && !(uri.indexOf('http://') === 0 || uri.indexOf('https://') === 0)) {
       // We only link to http(s) URLs.
       uri = null;
     }

--- a/h/static/scripts/karma-phantomjs-polyfill.js
+++ b/h/static/scripts/karma-phantomjs-polyfill.js
@@ -1,0 +1,16 @@
+// minimal set of polyfills for PhantomJS 1.x under Karma.
+// this Polyfills:
+//
+// - ES5
+// - ES6 Promises
+// - the DOM URL API
+
+// basic polyfills for APIs which are supported natively
+// by all browsers we support (IE >= 10)
+require('js-polyfills/es5');
+window.URL = require('js-polyfills/url').URL;
+
+// additional polyfills for newer features.
+// Be careful here that any added polyfills are consistent
+// with what is used in builds of the app itself.
+require('es6-promise');

--- a/h/static/scripts/karma.config.js
+++ b/h/static/scripts/karma.config.js
@@ -19,7 +19,7 @@ module.exports = function(config) {
     // list of files / patterns to load in the browser
     files: [
       // Polyfills for PhantomJS
-      '../../../node_modules/js-polyfills/polyfill.js',
+      './karma-phantomjs-polyfill.js',
 
       // Application external deps
       '../../../node_modules/jquery/dist/jquery.js',
@@ -59,6 +59,7 @@ module.exports = function(config) {
     // preprocess matching files before serving them to the browser
     // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
     preprocessors: {
+      './karma-phantomjs-polyfill.js': ['browserify'],
       '**/*-test.js': ['browserify'],
       '**/*-test.coffee': ['browserify'],
       '../../templates/client/*.html': ['ng-html2js'],


### PR DESCRIPTION
Links to source document URIs were broken under Safari <= 8 and
other browsers as well due to reliance on the
String.prototype.startsWith() API

This issue went unnoticed in Karma/PhantomJS tests because
Karma was primed with the complete set of polyfills from
the js-polyfills library, including many (all?) ES6 polyfills.

This same set of polyfills was_not_ used in the browser build however.

This commit fixes the original issue by using 'indexOf()' instead of
'startsWith()' and reduces the likelihood of such problems going
unnoticed during testing by using a much more minimal set of polyfills
under PhantomJS.

The alternative approach would be to go in the opposite direction
and polyfill any ES6 APIs in the browser. However, we need to be
careful about code bloat, so the approach taken here is the more
conservative option.

Fixes #2568