### PR TITLE
Re-implement filtering of annotations based on the current selection

### DIFF
--- a/h/static/scripts/directive/test/thread-test.coffee
+++ b/h/static/scripts/directive/test/thread-test.coffee
@@ -8,7 +8,9 @@ describe 'thread', ->
   fakeGroups = null
   fakePulse = null
   fakeRender = null
+  fakeAnnotationUI = null
   sandbox = null
+  selectedAnnotations = []
 
   createDirective = ->
     $element = angular.element('<div thread>')
@@ -29,9 +31,16 @@ describe 'thread', ->
     }
     fakePulse = sandbox.spy()
     fakeRender = sandbox.spy()
+    fakeAnnotationUI = {
+      hasSelectedAnnotations: ->
+        selectedAnnotations.length > 0
+      isAnnotationSelected: (id) ->
+        selectedAnnotations.indexOf(id) != -1
+    }
     $provide.value 'groups', fakeGroups
     $provide.value 'pulse', fakePulse
     $provide.value 'render', fakeRender
+    $provide.value 'annotationUI', fakeAnnotationUI
     return
 
   beforeEach inject (_$compile_, $rootScope) ->
@@ -170,6 +179,25 @@ describe 'thread', ->
 
         it 'is true when the focused group does match', ->
           fakeGroups.focused.returns({id: 'wibble'})
+          assert.isTrue(controller.shouldShow())
+
+      describe 'filters messages based on the selection', ->
+        messageID = 456
+
+        beforeEach ->
+          controller.container =
+            message:
+              id: messageID
+
+        it 'shows all annotations when there is no selection', ->
+          assert.isTrue(controller.shouldShow())
+
+        it 'hides annotations that are not selected', ->
+          selectedAnnotations = ['some-other-message-id']
+          assert.isFalse(controller.shouldShow())
+
+        it 'shows annotations that are selected', ->
+          selectedAnnotations = [messageID]
           assert.isTrue(controller.shouldShow())
 
     describe '#shouldShowAsReply', ->

--- a/h/static/scripts/directive/thread.coffee
+++ b/h/static/scripts/directive/thread.coffee
@@ -13,8 +13,8 @@ uuid = require('node-uuid')
 # the collapsing behavior.
 ###
 ThreadController = [
-  '$scope', 'groups',
-  ($scope,   groups) ->
+  '$scope', 'groups', 'annotationUI'
+  ($scope,   groups,   annotationUI) ->
     @container = null
     @collapsed = true
     @parent = null
@@ -50,6 +50,12 @@ ThreadController = [
       # here.
       group = this.container?.message?.group
       if this.isNew() and group and group != groups.focused().id
+        return false
+
+      # when there is a selection, hide unselected annotations
+      annotationID = this.container?.message?.id
+      if annotationUI.hasSelectedAnnotations() &&
+         !annotationUI.isAnnotationSelected(annotationID)
         return false
 
       if this.container?.message?.$orphan == true


### PR DESCRIPTION
44edb50b18f5cd1a78aae32384551c74e6c19304 removed filtering
of annotations when there was a selection alongside other changes.

This re-introduces the check to see whether there is a
selection and if so whether an annotation is in the selected
set when determining whether to show a thread.

Fixes #2553