### PR TITLE
Deform form rendering

### DIFF
--- a/h/accounts/schemas.py
+++ b/h/accounts/schemas.py
@@ -90,10 +90,10 @@ def matching_emails(node, value):
 
 def password_node(**kwargs):
     """Return a Colander schema node for a user password."""
+    kwargs.setdefault('widget', deform.widget.PasswordWidget())
     return colander.SchemaNode(
         colander.String(),
         validator=colander.Length(min=models.PASSWORD_MIN_LENGTH),
-        widget=deform.widget.PasswordWidget(),
         **kwargs)
 
 

--- a/h/app.py
+++ b/h/app.py
@@ -43,6 +43,7 @@ def includeme(config):
     config.include('h.features')
 
     config.include('h.db')
+    config.include('h.form')
     config.include('h.hashids')
     config.include('h.models')
     config.include('h.views')

--- a/h/claim/schemas.py
+++ b/h/claim/schemas.py
@@ -1,6 +1,13 @@
 # -*- coding: utf-8 -*-
-from ..accounts.schemas import ResetPasswordSchema
+
+from h import i18n
+from h.accounts.schemas import CSRFSchema
+from h.accounts.schemas import password_node
 
 
-class UpdateAccountSchema(ResetPasswordSchema):
-    pass
+_ = i18n.TranslationString
+
+
+class UpdateAccountSchema(CSRFSchema):
+    password = password_node(title=_('New password'),
+                             hint=_('at least two characters'))

--- a/h/claim/schemas.py
+++ b/h/claim/schemas.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+import deform
+
 from h import i18n
 from h.accounts.schemas import CSRFSchema
 from h.accounts.schemas import password_node
@@ -10,4 +12,6 @@ _ = i18n.TranslationString
 
 class UpdateAccountSchema(CSRFSchema):
     password = password_node(title=_('New password'),
-                             hint=_('at least two characters'))
+                             hint=_('at least two characters'),
+                             widget=deform.widget.PasswordWidget(
+                                 autofocus=True))

--- a/h/claim/templates/claim_account.html.jinja2
+++ b/h/claim/templates/claim_account.html.jinja2
@@ -12,30 +12,7 @@
   <div id="claim" class="content paper">
     {% include "h:templates/includes/header.html.jinja2" %}
     <div class="form-vertical">
-      <form class="form" action="{{ form.action }}" method="{{ form.method }}">
-        {{ form['csrf_token'].render() | safe }}
-        <div class="form-field{% if form['password'].error %} form-field-error{% endif %}">
-          <label class="form-label" for="field-activate-password">
-            New password:
-            <span class="form-hint">(at least two characters)</span>
-          </label>
-          <input class="form-input" id="field-activate-password"
-                 autofocus onfocus="this.select()"
-                 type="password" name="password" value="" required />
-          {% if form['password'].error %}
-            <ul class="form-error-list">
-              {% for err in form['password'].error.asdict().values() %}
-                <li class="form-error">{{ err }}</li>
-              {% endfor %}
-            </ul>
-          {% endif %}
-        </div>
-        <div class="form-actions">
-          <div class="form-actions-buttons">
-            <button class="btn" type="submit">Claim account</button>
-          </div>
-        </div>
-      </form>
+      {{ form | safe }}
     </div>
   </div>
 {% endblock content %}

--- a/h/claim/views.py
+++ b/h/claim/views.py
@@ -22,7 +22,7 @@ def claim_account(request):
     _validate_request(request)
 
     form = _form_for_update_account(request)
-    return {'form': form}
+    return {'form': form.render()}
 
 
 @view_config(route_name='claim_account',
@@ -35,7 +35,7 @@ def update_account(request):
     try:
         appstruct = form.validate(request.POST.items())
     except deform.ValidationFailure:
-        return {'form': form}
+        return {'form': form.render()}
 
     # The token is valid and the form validates, so we can go ahead and claim
     # the account:
@@ -86,7 +86,8 @@ def _validate_request(request):
 
 def _form_for_update_account(request):
     schema = schemas.UpdateAccountSchema().bind(request=request)
-    return deform.Form(schema)
+    form = deform.Form(schema, buttons=(_('Claim account'),))
+    return form
 
 
 def _perform_already_claimed_redirect(request):

--- a/h/form.py
+++ b/h/form.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+"""
+Configure deform to use custom templates.
+
+Sets up the form handling and rendering library, deform, to use our own custom
+form templates in preference to the defaults. Uses `deform_jinja2` to provide
+the fallback templates in Jinja2 format, which we can then extend and modify as
+necessary.
+"""
+
+
+SEARCH_PATHS = (
+    'h:templates/deform/',
+    'deform_jinja2:bootstrap_templates/',
+)
+
+
+def includeme(_):
+    from deform import Form
+    from deform_jinja2 import jinja2_renderer_factory
+    from deform_jinja2.translator import PyramidTranslator
+
+    renderer = jinja2_renderer_factory(search_paths=SEARCH_PATHS,
+                                       translator=PyramidTranslator())
+
+    Form.set_default_renderer(renderer)

--- a/h/groups/schemas.py
+++ b/h/groups/schemas.py
@@ -23,6 +23,7 @@ class GroupSchema(CSRFSchema):
             min=GROUP_NAME_MIN_LENGTH,
             max=GROUP_NAME_MAX_LENGTH),
         widget=deform.widget.TextInputWidget(
+            autofocus=True,
             css_class="group-form__name-input js-group-name-input",
             label_css_class="group-form__name-label",
             max_length=GROUP_NAME_MAX_LENGTH,

--- a/h/groups/schemas.py
+++ b/h/groups/schemas.py
@@ -1,10 +1,15 @@
 # -*- coding: utf-8 -*-
 
 import colander
+import deform
 
+from h import i18n
 from h.accounts.schemas import CSRFSchema
 from h.groups.models import GROUP_NAME_MIN_LENGTH
 from h.groups.models import GROUP_NAME_MAX_LENGTH
+
+
+_ = i18n.TranslationString
 
 
 class GroupSchema(CSRFSchema):
@@ -13,6 +18,12 @@ class GroupSchema(CSRFSchema):
 
     name = colander.SchemaNode(
         colander.String(),
+        title=_("What do you want to call the group?"),
         validator=colander.Length(
             min=GROUP_NAME_MIN_LENGTH,
-            max=GROUP_NAME_MAX_LENGTH))
+            max=GROUP_NAME_MAX_LENGTH),
+        widget=deform.widget.TextInputWidget(
+            css_class="group-form__name-input js-group-name-input",
+            label_css_class="group-form__name-label",
+            max_length=GROUP_NAME_MAX_LENGTH,
+            placeholder=_("Group Name")))

--- a/h/groups/templates/create.html.jinja2
+++ b/h/groups/templates/create.html.jinja2
@@ -13,25 +13,7 @@
     <div class="group-form">
       <i class="h-icon-group group-form__heading-icon"></i>
       <div class="group-form__heading">Create a new group</div>
-      <form class="group-form__form" action="{{ form.action }}" method="{{ form.method }}" novalidate>
-        {{ form['csrf_token'].render() | safe }}
-        <div class="form-field{% if form['name'].error %} form-field-error{% endif %}">
-          <label class="group-form__name-label" for="group-form__name-input">
-            What do you want to call the group?
-          </label>
-          <input class="group-form__name-input js-group-name-input" id="group-form__name-input"
-                 type="text" name="name" placeholder="Group Name" value="{{ data.name }}"
-                 autofocus required maxlength="25" />
-          {% if form['name'].error %}
-            <ul class="form-error-list">
-              {% for err in form['name'].error.asdict().values() %}
-                <li class="form-error">{{ err }}</li>
-              {% endfor %}
-            </ul>
-          {% endif %}
-        </div>
-        <button class="primary-action-btn group-form__submit-btn js-create-group-create-btn" type="submit">Create new group</button>
-      </form>
+      {{ form | safe }}
     </div>
     <div class="group-form-footer">
       <a href="" class="group-form-footer__explain-link js-group-info-link">Tell me more about groups</a>

--- a/h/groups/test/views_test.py
+++ b/h/groups/test/views_test.py
@@ -48,7 +48,7 @@ def test_create_form_creates_form_with_GroupSchema(GroupSchema, Form):
 
     views.create_form(request=_mock_request())
 
-    Form.assert_called_once_with(test_schema)
+    assert Form.call_args[0][0] == test_schema
 
 
 @create_form_fixtures
@@ -56,19 +56,9 @@ def test_create_form_returns_form(Form):
     test_form = mock.Mock()
     Form.return_value = test_form
 
-    template_data = views.create_form(request=_mock_request())
+    result = views.create_form(request=_mock_request())
 
-    assert template_data["form"] == test_form
-
-
-@create_form_fixtures
-def test_create_form_returns_empty_form_data(Form):
-    test_form = mock.Mock()
-    Form.return_value = test_form
-
-    template_data = views.create_form(request=_mock_request())
-
-    assert template_data["data"] == {}
+    assert result["form"] == test_form.render.return_value
 
 
 # The fixtures required to mock all of create()'s dependencies.
@@ -89,7 +79,7 @@ def test_create_inits_form_with_schema(GroupSchema, Form):
 
     views.create(request=_mock_request())
 
-    Form.assert_called_once_with(schema)
+    assert Form.call_args[0][0] == schema
 
 
 @create_fixtures
@@ -107,12 +97,10 @@ def test_create_validates_form(Form):
 def test_create_rerenders_form_on_validation_failure(Form):
     Form.return_value = form = mock.Mock()
     form.validate.side_effect = deform.ValidationFailure(None, None, None)
-    params = {"foo": "bar"}
 
-    template_data = views.create(_mock_request())
+    result = views.create(_mock_request())
 
-    assert template_data['form'] == form
-    assert template_data['data'] == params
+    assert result['form'] == form.render.return_value
 
 
 @create_fixtures

--- a/h/templates/deform/form.jinja2
+++ b/h/templates/deform/form.jinja2
@@ -1,0 +1,38 @@
+<form id="{{ field.formid }}"
+      action="{{ field.action }}"
+      method="{{ field.method }}"
+      enctype="multipart/form-data"
+      accept-charset="utf-8"
+      {% if field.css_class -%}
+      class="{{ field.css_class }}"
+      {%- endif -%}>
+  <input type="hidden" name="__formid__" value="{{ field.formid }}" />
+
+  {%- for f in field.children -%}
+    {{ field.renderer(field.widget.item_template, field=f, cstruct=cstruct.get(f.name, null)) }}
+  {% endfor -%}
+
+  <div class="form-actions">
+    <div class="form-actions-buttons">
+      {%- for button in field.buttons -%}
+        <button id="{{ field.formid + button.name }}"
+                name="{{ button.name }}"
+                type="{{ button.type }}"
+                class="btn"
+                value="{{ _(button.value) }}"
+                {%- if button.disabled -%}
+                disabled="disabled"
+                {% endif -%}
+                >
+        <span>{{ _(button.title) }}</span>
+        </button>
+      {% endfor -%}
+    </div>
+  </div>
+
+  {#
+    The default deform templates are ajax capable. I've removed that code here
+    for the sake of clarity. If we need to put it back it can be found in
+    deform_jinja2:bootstrap_templates/form.jinja2.
+  #}
+</form>

--- a/h/templates/deform/form.jinja2
+++ b/h/templates/deform/form.jinja2
@@ -18,7 +18,7 @@
         <button id="{{ field.formid + button.name }}"
                 name="{{ button.name }}"
                 type="{{ button.type }}"
-                class="btn"
+                class="btn{% if button.css_class %} {{ button.css_class }}{% endif %}"
                 value="{{ _(button.value) }}"
                 {%- if button.disabled -%}
                 disabled="disabled"

--- a/h/templates/deform/includes/common_attrs.jinja2
+++ b/h/templates/deform/includes/common_attrs.jinja2
@@ -1,6 +1,9 @@
 {% if field.schema.hint -%}
 aria-describedby="hint-{{ field.oid }}"
 {% endif -%}
+{%- if field.error %}
+aria-invalid="true"
+{% endif -%}
 {%- if field.widget.autofocus -%}
 autofocus onfocus="this.select()"
 {% endif -%}

--- a/h/templates/deform/includes/common_attrs.jinja2
+++ b/h/templates/deform/includes/common_attrs.jinja2
@@ -1,0 +1,12 @@
+{% if field.schema.hint -%}
+aria-describedby="hint-{{ field.oid }}"
+{% endif -%}
+{%- if field.widget.max_length -%}
+maxlength="{{ field.widget.max_length }}"
+{% endif -%}
+{%- if field.widget.placeholder -%}
+placeholder="{{ field.widget.placeholder }}"
+{% endif -%}
+{%- if field.required -%}
+required
+{% endif %}

--- a/h/templates/deform/includes/common_attrs.jinja2
+++ b/h/templates/deform/includes/common_attrs.jinja2
@@ -1,6 +1,9 @@
 {% if field.schema.hint -%}
 aria-describedby="hint-{{ field.oid }}"
 {% endif -%}
+{%- if field.widget.autofocus -%}
+autofocus onfocus="this.select()"
+{% endif -%}
 {%- if field.widget.max_length -%}
 maxlength="{{ field.widget.max_length }}"
 {% endif -%}

--- a/h/templates/deform/mapping_item.jinja2
+++ b/h/templates/deform/mapping_item.jinja2
@@ -1,0 +1,36 @@
+{%- if not field.widget.hidden -%}
+<div class="form-group form-field{% if field.error %} form-field-error{% endif %}"
+     {%- if field.description -%}
+     title="{{ _(field.description) }}"
+     {% endif %}
+     id="item-{{ field.oid }}">
+{% endif -%}
+
+{%- if not (field.widget.hidden or field.widget.category == 'structural') -%}
+  <label class="form-label"
+         {%- if field.description -%}
+         title="{{ _(field.description) }}"
+         {% endif %}
+         for="{{ field.oid }}">
+    {{ _(field.title) }}:
+    {%- if field.schema.hint -%}
+      <span class="form-hint" id="hint-{{ field.oid }}">({{ field.schema.hint }})</span>
+    {% endif -%}
+  </label>
+{% endif -%}
+
+{{ field.serialize(cstruct) }}
+
+{%- if field.error and not field.widget.hidden -%}
+  <ul class="form-error-list">
+  {% for msg in field.error.messages() -%}
+    {%- set errstr = 'error-%s' % field.oid -%}
+    {%- set pid = (loop.index0==0 and errstr) or ('%s-%s' % (errstr, loop.index0)) -%}
+    <li class="form-error" id="{{ pid }}">{{ _(msg) }}</li>
+  {% endfor -%}
+  </ul>
+{% endif -%}
+
+{%- if not field.widget.hidden -%}
+</div>
+{% endif -%}

--- a/h/templates/deform/mapping_item.jinja2
+++ b/h/templates/deform/mapping_item.jinja2
@@ -7,12 +7,12 @@
 {% endif -%}
 
 {%- if not (field.widget.hidden or field.widget.category == 'structural') -%}
-  <label class="form-label"
+  <label class="form-label{% if field.widget.label_css_class %} {{ field.widget.label_css_class }}{% endif %}"
          {%- if field.description -%}
          title="{{ _(field.description) }}"
          {% endif %}
          for="{{ field.oid }}">
-    {{ _(field.title) }}:
+    {{ _(field.title) }}
     {%- if field.schema.hint -%}
       <span class="form-hint" id="hint-{{ field.oid }}">({{ field.schema.hint }})</span>
     {% endif -%}

--- a/h/templates/deform/password.jinja2
+++ b/h/templates/deform/password.jinja2
@@ -3,12 +3,7 @@
        value="{{ cstruct }}"
        {%- if field.widget.size %}
        size="{{ field.widget.size }}"
-       {% endif -%}
-       {%- if field.schema.hint %}
-       aria-describedby="hint-{{ field.oid }}"
-       {% endif -%}
-       {%- if field.required %}
-       required
-       {% endif -%}
+       {% endif %}
+       {% include "includes/common_attrs.jinja2" -%}
        class="form-input{% if field.widget.css_class %} {{ field.widget.css_class }}{% endif %}"
        id="{{ field.oid }}"/>

--- a/h/templates/deform/password.jinja2
+++ b/h/templates/deform/password.jinja2
@@ -1,0 +1,14 @@
+<input type="password"
+       name="{{ field.name }}"
+       value="{{ cstruct }}"
+       {%- if field.widget.size %}
+       size="{{ field.widget.size }}"
+       {% endif -%}
+       {%- if field.schema.hint %}
+       aria-describedby="hint-{{ field.oid }}"
+       {% endif -%}
+       {%- if field.required %}
+       required
+       {% endif -%}
+       class="form-input{% if field.widget.css_class %} {{ field.widget.css_class }}{% endif %}"
+       id="{{ field.oid }}"/>

--- a/h/templates/deform/textinput.jinja2
+++ b/h/templates/deform/textinput.jinja2
@@ -2,13 +2,8 @@
        name="{{ field.name }}"
        value="{{ cstruct }}"
        {%- if field.widget.size %}
-       size="{{field.widget.size}}"
-       {% endif -%}
-       {%- if field.schema.hint %}
-       aria-describedby="hint-{{ field.oid }}"
-       {% endif -%}
-       {%- if field.required %}
-       required
-       {% endif -%}
+       size="{{ field.widget.size }}"
+       {% endif %}
+       {% include "includes/common_attrs.jinja2" -%}
        class="form-input{% if field.widget.css_class %} {{ field.widget.css_class }}{% endif %}"
        id="{{ field.oid }}"/>

--- a/h/templates/deform/textinput.jinja2
+++ b/h/templates/deform/textinput.jinja2
@@ -1,0 +1,14 @@
+<input type="text"
+       name="{{ field.name }}"
+       value="{{ cstruct }}"
+       {%- if field.widget.size %}
+       size="{{field.widget.size}}"
+       {% endif -%}
+       {%- if field.schema.hint %}
+       aria-describedby="hint-{{ field.oid }}"
+       {% endif -%}
+       {%- if field.required %}
+       required
+       {% endif -%}
+       class="form-input{% if field.widget.css_class %} {{ field.widget.css_class }}{% endif %}"
+       id="{{ field.oid }}"/>

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ INSTALL_REQUIRES = [
     'cryptacular>=1.4,<1.5',
     'cryptography>=0.7',
     'deform>=0.9,<1.0',
+    'deform-jinja2>=0.5,<0.6',
     'elasticsearch>=1.1.0',
     'gevent>=1.0.2,<1.1.0',
     'gnsq>=0.3.0,<0.4.0',


### PR DESCRIPTION
So, this is (half of) what I got up to on the train.

----

This PR removes custom form code from the templates for account claim and groups packages, in favour of using generated form code from deform.

The resulting templates *should* be pixel-for-pixel identical with the ones they replace, with the added bonus of some ARIA annotations on form fields, to help navigating forms with a screenreader.