### PR TITLE
Server-rendered login form

### DIFF
--- a/h/accounts/schemas.py
+++ b/h/accounts/schemas.py
@@ -116,9 +116,14 @@ class CSRFSchema(colander.Schema):
 
 
 class LoginSchema(CSRFSchema):
-    username = colander.SchemaNode(colander.String())
+    username = colander.SchemaNode(
+        colander.String(),
+        title=_('Username or email address:'),
+        widget=deform.widget.TextInputWidget(autofocus=True),
+    )
     password = colander.SchemaNode(
         colander.String(),
+        title=_('Password:'),
         widget=deform.widget.PasswordWidget()
     )
 

--- a/h/templates/accounts/login.html.jinja2
+++ b/h/templates/accounts/login.html.jinja2
@@ -1,0 +1,22 @@
+{% extends "h:templates/layouts/base.html.jinja2" %}
+
+{% block page_title %}Sign in{% endblock %}
+
+{% block styles %}
+  {% assets "app_css" %}
+    <link rel="stylesheet" href="{{ ASSET_URL }}">
+  {% endassets %}
+{% endblock styles  %}
+
+{% block content %}
+  <div class="content paper">
+    {% include "h:templates/includes/header.html.jinja2" %}
+    <div class="form-vertical">
+      <ul class="nav nav-tabs">
+        <li class="active"><a href="{{ request.route_path('login') }}">Sign in</a></li>{#
+        #}<li><a href="{{ request.route_path('register') }}">Create an account</a></li>
+      </ul>
+      {{ form | safe }}
+    </div>
+  </div>
+{% endblock content %}

--- a/h/templates/deform/form.jinja2
+++ b/h/templates/deform/form.jinja2
@@ -13,6 +13,11 @@
   {% endfor -%}
 
   <div class="form-actions">
+    <div class="form-actions-message">
+      {%- for title, href in field.extra_actions -%}
+        <a href="{{ href }}">{{ title }}</a>
+      {% endfor -%}
+    </div>
     <div class="form-actions-buttons">
       {%- for button in field.buttons -%}
         <button id="{{ field.formid + button.name }}"


### PR DESCRIPTION
This PR replaces the client-side rendered login form with one rendered by deform on the server.

While it would appear that this commit just adds code, that's because it's only an incremental improvement. It actually removes dependencies on a bunch of components we want to remove, and will be able to when the rest of the account forms are rewritten in a similar way. This changeset:

- sets us on the way to a drastic simplification of the account form handling code both on the server and in the client.
- makes a couple of small improvements to user experience (e.g. there is no longer a one second pause after logging in)
- prepares the way for doing "login in a popup," which solves some difficult Same Origin Policy problems.
- makes it much easier to understand what's going on in the login/logout ajax requests sent by the client: the login/logout controller no longer uses AjaxFormViewMapper