### PR TITLE
Do not show vendored PDF.js in language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
 h/_version.py export-subst
+h/browser/chrome/content/build/* linguist-vendored
+h/browser/chrome/content/web/* linguist-vendored


### PR DESCRIPTION
GitHub also marks some PDF.js files as Java because it
looks for Emacs mode lines and some files have the
following mode line:

    /* -*- Mode: Java; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */

See h/h/browser/chrome/content/build/pdf.js for example.

I use the same method at python.org: https://github.com/python/pythondotorg/blob/master/.gitattributes