### PR TITLE
WIP - Group membership change push notifications

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,9 @@ clean:
 dev: deps
 	@gunicorn --reload --paste conf/development.ini
 
-test: client-test
+test: backend-test client-test
+
+backend-test:
 	@python setup.py test
 
 client-test:

--- a/h/api/events.py
+++ b/h/api/events.py
@@ -1,8 +1,33 @@
 # -*- coding: utf-8 -*-
-class AnnotationEvent(object):
+
+# Types representing events stored in the notification queue
+# (see queue.py)
+
+class Event(object):
+    def __init__(self, request):
+        self.request = request
+
+class AnnotationEvent(Event):
     """An event representing an action on an annotation."""
 
     def __init__(self, request, annotation, action):
-        self.request = request
+        Event.__init__(self, request)
         self.annotation = annotation
         self.action = action
+
+class UserStatusEvent(Event):
+    """An event representing a change in a user's status."""
+
+    def __init__(self, request, user_id, type, group_id = None):
+        assert type in ['group-joined', 'group-left']
+
+        Event.__init__(self, request)
+
+        self.user_id = user_id
+        """ The ID of the user affected by the event """
+
+        self.type = type
+        """ The type of action (eg. joined a group, left a group) """
+
+        self.group_id = group_id
+        """ Optional. For group membership events, the hash ID of the group """

--- a/h/static/scripts/app-controller.coffee
+++ b/h/static/scripts/app-controller.coffee
@@ -38,9 +38,14 @@ module.exports = class AppController
     # Default sort
     $scope.sort = name: 'Location'
 
-    $scope.$on('groupFocused', (event) ->
-      $route.reload()
-    )
+    # Reload the view when the focused group changes or the user
+    # joins or leaves a group
+    groupChangeEvents = ['groupJoined', 'groupLeft', 'groupFocused'];
+    groupChangeEvents.forEach((eventName) ->
+      $scope.$on(eventName, (event) ->
+        $route.reload()
+      )
+    );
 
     identity.watch({
       onlogin: (identity) -> $scope.auth.user = auth.userid(identity)

--- a/h/static/scripts/groups.js
+++ b/h/static/scripts/groups.js
@@ -2,8 +2,12 @@
  * @ngdoc service
  * @name  groups
  *
- * @description
- * Get and set the UI's currently focused group.
+ * @description Provides access to the list of groups that the user is currently
+ *              a member of and the currently selected group in the UI.
+ *
+ *              The list of groups is initialized from the session state
+ *              and can then later be updated using the add() and remove()
+ *              methods.
  */
 'use strict';
 
@@ -17,12 +21,12 @@ function groups(localStorage, session, $rootScope, features) {
   // will be created in this group.
   var focused;
 
-  var all = function all() {
+  function all() {
     return session.state.groups || [];
   };
 
   // Return the full object for the group with the given id.
-  var get = function get(id) {
+  function get(id) {
     var gs = all();
     for (var i = 0, max = gs.length; i < max; i++) {
       if (gs[i].id === id) {
@@ -31,35 +35,65 @@ function groups(localStorage, session, $rootScope, features) {
     }
   };
 
+  /** Update the groups list by adding a group that the user has joined. */
+  function add(group) {
+    var otherGroups = all().filter(function (existingGroup) {
+      return existingGroup.id !== group.id;
+    });
+    session.state.groups = otherGroups.concat(group);
+    $rootScope.$broadcast('groupJoined', group.id);
+  }
+
+  /** Update the groups list by removing a group that the user has left. */
+  function remove(group) {
+    var otherGroups = all().filter(function (existingGroup) {
+      return existingGroup.id !== group.id;
+    });
+    session.state.groups = otherGroups;
+
+    if (focused.id === group.id) {
+      focused = null;
+    }
+
+    $rootScope.$broadcast('groupLeft', group.id);
+  }
+
+  /** Return the currently focused group. If no group is explicitly focused we
+   * will check localStorage to see if we have persisted a focused group from
+   * a previous session. Lastly, we fall back to the first group available.
+   */
+  function focused() {
+    if (focused) {
+     return focused;
+    } else if (features.flagEnabled('groups')) {
+     var fromStorage = get(localStorage.getItem(STORAGE_KEY));
+     if (typeof fromStorage !== 'undefined') {
+       focused = fromStorage;
+       return focused;
+     }
+    }
+    return all()[0];
+  }
+
+  /** Set the group with the passed id as the currently focused group. */
+  function focus(id) {
+   var g = get(id);
+   if (typeof g !== 'undefined') {
+     focused = g;
+     localStorage.setItem(STORAGE_KEY, g.id);
+     $rootScope.$broadcast('groupFocused', g.id);
+   }
+  }
+
   return {
     all: all,
     get: get,
 
-    // Return the currently focused group. If no group is explicitly focused we
-    // will check localStorage to see if we have persisted a focused group from
-    // a previous session. Lastly, we fall back to the first group available.
-    focused: function() {
-      if (focused) {
-        return focused;
-      } else if (features.flagEnabled('groups')) {
-        var fromStorage = get(localStorage.getItem(STORAGE_KEY));
-        if (typeof fromStorage !== 'undefined') {
-          focused = fromStorage;
-          return focused;
-        }
-      }
-      return all()[0];
-    },
+    add: add,
+    remove: remove,
 
-    // Set the group with the passed id as the currently focused group.
-    focus: function(id) {
-      var g = get(id);
-      if (typeof g !== 'undefined') {
-        focused = g;
-        localStorage.setItem(STORAGE_KEY, g.id);
-        $rootScope.$broadcast('groupFocused', g.id);
-      }
-    }
+    focused: focused,
+    focus: focus,
   };
 }
 

--- a/h/static/scripts/groups.js
+++ b/h/static/scripts/groups.js
@@ -19,7 +19,7 @@ function groups(localStorage, session, $rootScope, features) {
   // the groups dropdown, the annotations displayed are filtered to only ones
   // that belong to this group, and any new annotations that the user creates
   // will be created in this group.
-  var focused;
+  var focusedGroup;
 
   function all() {
     return session.state.groups || [];
@@ -51,8 +51,8 @@ function groups(localStorage, session, $rootScope, features) {
     });
     session.state.groups = otherGroups;
 
-    if (focused.id === group.id) {
-      focused = null;
+    if (focusedGroup && focusedGroup.id === group.id) {
+      focusedGroup = null;
     }
 
     $rootScope.$broadcast('groupLeft', group.id);
@@ -63,13 +63,13 @@ function groups(localStorage, session, $rootScope, features) {
    * a previous session. Lastly, we fall back to the first group available.
    */
   function focused() {
-    if (focused) {
-     return focused;
+    if (focusedGroup) {
+     return focusedGroup;
     } else if (features.flagEnabled('groups')) {
      var fromStorage = get(localStorage.getItem(STORAGE_KEY));
      if (typeof fromStorage !== 'undefined') {
-       focused = fromStorage;
-       return focused;
+       focusedGroup = fromStorage;
+       return focusedGroup;
      }
     }
     return all()[0];
@@ -79,7 +79,7 @@ function groups(localStorage, session, $rootScope, features) {
   function focus(id) {
    var g = get(id);
    if (typeof g !== 'undefined') {
-     focused = g;
+     focusedGroup = g;
      localStorage.setItem(STORAGE_KEY, g.id);
      $rootScope.$broadcast('groupFocused', g.id);
    }

--- a/h/static/scripts/streamer.js
+++ b/h/static/scripts/streamer.js
@@ -1,0 +1,80 @@
+var baseURI = require('document-base-uri')
+var uuid = require('node-uuid')
+
+// the randomly generated session UUID
+var clientId = uuid.v4();
+
+// the singleton socket instance, only one may
+// be open at a time
+var socket;
+
+/**
+ * Open a new WebSocket connection to the Hypothesis push notification service.
+ * Only one websocket connection may exist at a time, any existing socket is
+ * closed.
+ *
+ * @param $websocket - angular-websocket constructor
+ * @param annotationMapper - The local annotation store
+ * @param groups - The local groups store
+ *
+ * @return An angular-websocket wrapper around the socket.
+ */
+// @ngInject
+function connect($websocket, annotationMapper, groups) {
+  // Get the socket URL
+  var url = new URL('/ws', baseURI);
+  url.protocol = url.protocol.replace('http', 'ws');
+
+  // Close any existing socket
+  if (socket) {
+    socket.close();
+  }
+
+  // Open the socket
+  socket = $websocket(url.href, [], {
+    reconnectIfNotNormalClose: true
+  });
+  socket.send({
+    messageType: 'client_id',
+    value: clientId
+  })
+
+  // Listen for updates
+  socket.onMessage(function (event) {
+    message = JSON.parse(event.data)
+    if (!message || message.type !== 'annotation-notification') {
+      return;
+    }
+    action = message.options.action
+    annotations = message.payload
+
+    if (annotations.length === 0) {
+      return;
+    }
+
+    // Discard annotations that aren't from the currently focused group.
+    // FIXME: Have the server only send us annotations from the focused
+    // group in the first place.
+    annotations = annotations.filter(function (ann) {
+      return ann.group == groups.focused().id
+    });
+
+    switch (action) {
+      case 'create':
+      case 'update':
+      case 'past':
+        annotationMapper.loadAnnotations(annotations);
+        break;
+      case 'delete':
+        annotationMapper.unloadAnnotations(annotations);
+        break;
+    }
+  });
+
+  return socket
+}
+
+module.exports = {
+  connect: connect,
+  clientId: clientId
+};

--- a/h/static/scripts/test/app-controller-test.coffee
+++ b/h/static/scripts/test/app-controller-test.coffee
@@ -21,7 +21,7 @@ describe 'AppController', ->
     $controller('AppController', locals)
 
   before ->
-    angular.module('h')
+    angular.module('h', [])
     .controller('AppController', require('../app-controller'))
     .controller('AnnotationUIController', angular.noop)
 
@@ -137,7 +137,11 @@ describe 'AppController', ->
     createController()
     assert.isFalse($scope.shareDialog.visible)
 
-  it 'calls $route.reload() when the focused group changes', ->
+  it 'calls $route.reload() when the groups state changes', ->
     createController()
-    $scope.$broadcast('groupFocused')
-    assert.calledOnce(fakeRoute.reload)
+    groupEvents = ['groupFocused', 'groupJoined', 'groupLeft'];
+    groupEvents.forEach((event) ->
+      fakeRoute.reload = sinon.spy()
+      $scope.$broadcast(event)
+      assert.calledOnce(fakeRoute.reload)
+    )

--- a/h/static/scripts/test/groups-test.js
+++ b/h/static/scripts/test/groups-test.js
@@ -15,7 +15,6 @@ var sessionWithThreeGroups = function() {
   };
 };
 
-
 describe('groups', function() {
   var fakeSession;
   var fakeLocalStorage;
@@ -124,6 +123,44 @@ describe('groups', function() {
       s.focus('id3');
 
       assert.calledWithMatch(fakeLocalStorage.setItem, sinon.match.any, 'id3');
+    });
+  });
+
+  describe('add()', function () {
+    it('updates the group list when add() is called', function () {
+      var s = service();
+      var prevCount = s.all().length;
+      s.add({ id: 'new-group' });
+      assert.equal(s.all().length, prevCount + 1);
+    });
+
+    it('emits a "groupJoined" notification when a group is added', function () {
+      var s = service();
+      s.add({ id: 'new-group' });
+      assert.calledWithMatch(fakeRootScope.$broadcast, 'groupJoined');
+    });
+  });
+
+  describe('remove()', function () {
+    it('updates the group list when remove() is called', function () {
+      var s = service();
+      var GROUP_ID = 'a-group';
+      s.add({ id: GROUP_ID });
+      s.focus(GROUP_ID);
+
+      var prevCount = s.all().length;
+      s.remove({ id: GROUP_ID });
+      assert.equal(s.all().length, prevCount - 1);
+
+      // the selected group should be reset if the currently focused
+      // group is removed
+      assert.notEqual(s.focused().id, GROUP_ID);
+    });
+
+    it('emits a "groupLeft" notification when a group is removed', function () {
+      var s = service();
+      s.remove({ id: 'a-group' });
+      assert.calledWithMatch(fakeRootScope.$broadcast, 'groupLeft');
     });
   });
 });

--- a/h/static/scripts/test/streamer-test.js
+++ b/h/static/scripts/test/streamer-test.js
@@ -1,0 +1,100 @@
+'use strict';
+
+var streamer = require('../streamer');
+
+function fakeSocketConstructor(url) {
+  return {
+    messages: [],
+    onMessageCallbacks: [],
+    didClose: false,
+
+    send: function (message) {
+      this.messages.push(message);
+    },
+
+    onMessage: function (callback) {
+      this.onMessageCallbacks.push(callback);
+    },
+
+    notify: function (message) {
+      this.onMessageCallbacks.forEach(function (callback) {
+        callback({
+          data: JSON.stringify(message)
+        });
+      });
+    },
+
+    close: function () {
+      this.didClose = true
+    }
+  };
+}
+
+describe('streamer', function () {
+  var fakeAnnotationMapper;
+  var fakeGroups;
+  var socket;
+
+  beforeEach(function () {
+    fakeAnnotationMapper = {
+      loadAnnotations: sinon.stub(),
+      unloadAnnotations: sinon.stub(),
+    };
+
+    fakeGroups = {
+      focused: function () {
+        return 'public';
+      },
+    };
+
+    socket = streamer.connect(
+      fakeSocketConstructor,
+      fakeAnnotationMapper,
+      fakeGroups
+    );
+  });
+
+  it('should send a client ID', function () {
+    assert.equal(socket.messages.length, 1);
+    assert.equal(socket.messages[0].messageType, 'client_id');
+    assert.equal(socket.messages[0].value, streamer.clientId);
+  });
+
+  it('should close any existing socket', function () {
+    var oldSocket = socket;
+    var newSocket = streamer.connect(fakeSocketConstructor,
+      fakeAnnotationMapper,
+      fakeGroups
+    );
+    assert.ok(oldSocket.didClose);
+    assert.ok(!newSocket.didClose);
+  });
+
+  describe('annotation notifications', function () {
+    it('should load new annotations', function () {
+      socket.notify({
+        type: 'annotation-notification',
+        options: {
+          action: 'create',
+        },
+        payload: [{
+          group: 'public'
+        }]
+      });
+      assert.ok(fakeAnnotationMapper.loadAnnotations.calledOnce);
+    });
+
+    it('should unload deleted annotations', function () {
+      socket.notify({
+        type: 'annotation-notification',
+        options: {
+          action: 'delete',
+        },
+        payload: [{
+          group: 'public'
+        }]
+      });
+      assert.ok(fakeAnnotationMapper.unloadAnnotations.calledOnce);
+    });
+  });
+});

--- a/h/static/scripts/test/streamer-test.js
+++ b/h/static/scripts/test/streamer-test.js
@@ -45,6 +45,8 @@ describe('streamer', function () {
       focused: function () {
         return 'public';
       },
+      add: sinon.stub(),
+      remove: sinon.stub(),
     };
 
     socket = streamer.connect(
@@ -95,6 +97,30 @@ describe('streamer', function () {
         }]
       });
       assert.ok(fakeAnnotationMapper.unloadAnnotations.calledOnce);
+    });
+  });
+
+  describe('user status notifications', function () {
+    it('adds a group on "group-joined" notifications', function () {
+      socket.notify({
+        type: 'user-status-notification',
+        action: 'group-joined',
+        group: {
+          id: 'new-group'
+        }
+      });
+      assert.ok(fakeGroups.add.calledOnce);
+    });
+
+    it('removes a group on "group-removed" notifications', function () {
+      socket.notify({
+        type: 'user-status-notification',
+        action: 'group-left',
+        group: {
+          id: 'a-group'
+        }
+      });
+      assert.ok(fakeGroups.remove.calledOnce);
     });
   });
 });


### PR DESCRIPTION
This implements the client and server side parts of push notifications for group membership changes for a user.

This adds a new class of push notification, 'user-status-notification',
which is broadcast to logged-in clients when changes to the user's
state, including the list of groups that they are a member of,
changes.

----

- [ ] Figure out how to get the correct URL for the group
- [ ] Avoid duplicating the logic that serializes groups into JSON in session.py and streamer.py
- [ ] Write tests for `groups.{add,remove}` on the client
- [ ] Write tests for event queuing when a user joins a group on the server
- [ ] Write tests for push notifications of group join / leave events

----

When the user creates or joins a group, a notification is
added to the event queue with an associated user ID
which is then broadcast via the web socket.

On the client side, the streamer service listens for the new
class of notification and updates the groups part of the session
state in response, firing off 'group-joined' or 'group-left'
notifications which trigger a reload of the view.

When the user leaves a group, this may trigger an implicit change
of focus if the user was a member of the group.