### PR TITLE
T88 - Add ability to leave groups

### DIFF
--- a/h/groups/test/views_test.py
+++ b/h/groups/test/views_test.py
@@ -390,6 +390,21 @@ def test_join_redirects_to_group_page(Group):
     assert isinstance(result, httpexceptions.HTTPRedirection)
 
 
+leave_fixtures = pytest.mark.usefixtures('User', 'Group')
+
+
+@leave_fixtures
+def test_leave_removes_user_from_group_members(Group, User):
+    group = mock.Mock()
+    Group.get_by_hashid.return_value = group
+    User.get_by_userid.return_value = mock.sentinel.user
+
+    request = _mock_request(matchdict=_matchdict())
+    result = views.leave(request)
+
+    group.members.remove.assert_called_once_with(mock.sentinel.user)
+
+
 @pytest.fixture
 def Form(request):
     patcher = mock.patch('h.groups.views.deform.Form', autospec=True)

--- a/h/static/scripts/directive/group-list.js
+++ b/h/static/scripts/directive/group-list.js
@@ -1,7 +1,7 @@
 'use strict';
 
 // @ngInject
-function GroupListController($scope) {
+function GroupListController($scope, $window) {
   $scope.expandedGroupId = undefined;
 
   // show the share link for the specified group or clear it if
@@ -25,6 +25,15 @@ function GroupListController($scope) {
       }
       return a.name.localeCompare(b.name);
     });
+  }
+
+  $scope.leaveGroup = function (groupId) {
+    var groupName = $scope.groups.get(groupId).name;
+    var message = 'Are you sure you want to leave the group "' +
+      groupName + '"?';
+    if ($window.confirm(message)) {
+      $scope.groups.leave(groupId);
+    }
   }
 }
 

--- a/h/static/scripts/groups.js
+++ b/h/static/scripts/groups.js
@@ -7,10 +7,12 @@
  */
 'use strict';
 
+var baseURI = require('document-base-uri');
+
 var STORAGE_KEY = 'hypothesis.groups.focus';
 
 // @ngInject
-function groups(localStorage, session, $rootScope, features) {
+function groups(localStorage, session, $rootScope, features, $http) {
   // The currently focused group. This is the group that's shown as selected in
   // the groups dropdown, the annotations displayed are filtered to only ones
   // that belong to this group, and any new annotations that the user creates
@@ -31,9 +33,27 @@ function groups(localStorage, session, $rootScope, features) {
     }
   };
 
+  /** Leave the group with the given ID.
+   * Returns a promise which resolves when the action completes.
+   */
+  function leave(id) {
+    var response = $http({
+      method: 'POST',
+      url: baseURI + 'groups/' + id + '/leave',
+    });
+
+    // TODO - Optimistically call remove() to
+    // remove the group locally when
+    // https://github.com/hypothesis/h/pull/2587 has been merged
+
+    return response;
+  };
+
   return {
     all: all,
     get: get,
+
+    leave: leave,
 
     // Return the currently focused group. If no group is explicitly focused we
     // will check localStorage to see if we have persisted a focused group from

--- a/h/static/scripts/test/groups-test.js
+++ b/h/static/scripts/test/groups-test.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var baseURI = require('document-base-uri');
+
 var groups = require('../groups');
 
 // Return a mock session service containing three groups.
@@ -21,6 +23,7 @@ describe('groups', function() {
   var fakeLocalStorage;
   var fakeRootScope;
   var fakeFeatures;
+  var fakeHttp;
   var sandbox;
 
   beforeEach(function() {
@@ -37,6 +40,7 @@ describe('groups', function() {
     fakeFeatures = {
       flagEnabled: function() {return true;}
     };
+    fakeHttp = sandbox.stub()
   });
 
   afterEach(function () {
@@ -44,7 +48,8 @@ describe('groups', function() {
   });
 
   function service() {
-    return groups(fakeLocalStorage, fakeSession, fakeRootScope, fakeFeatures);
+    return groups(fakeLocalStorage, fakeSession, fakeRootScope,
+                  fakeFeatures, fakeHttp);
   }
 
   describe('.all()', function() {
@@ -124,6 +129,17 @@ describe('groups', function() {
       s.focus('id3');
 
       assert.calledWithMatch(fakeLocalStorage.setItem, sinon.match.any, 'id3');
+    });
+  });
+
+  describe('.leave()', function () {
+    it('should call the /groups/<id>/leave service', function () {
+      var s = service();
+      s.leave('id2');
+      assert.calledWithMatch(fakeHttp, {
+        url: baseURI + 'groups/id2/leave',
+        method: 'POST'
+      });
     });
   });
 });

--- a/h/static/styles/app.scss
+++ b/h/static/styles/app.scss
@@ -123,8 +123,17 @@ $group-list-width: 270px;
     margin-right: 10px;
   }
 
+  .group-cancel-icon-container {
+    // the 'Leave group' icon is shifted down slightly
+    // so that it lines up vertically with the 'chat heads' icon on the
+    // left-hand side of the groups list
+    padding-top: 3px;
+    margin-right: 2px;
+  }
+
   .group-details {
     margin-right: 20px;
+    flex-grow: 1;
     flex-shrink: 1;
   }
 

--- a/h/static/styles/forms.scss
+++ b/h/static/styles/forms.scss
@@ -285,6 +285,14 @@
   padding: 2px;
 }
 
+// a light grey cancel/remove button which darkens on hover
+.btn--cancel {
+  color: $color-silver;
+  &:hover {
+    color: darken($color-silver, 15%);
+  }
+}
+
 // Handles state transitions from "default" -> "loading" -> "success"
 [status-button-state] .btn-message {
   top: -999em;

--- a/h/static/styles/publish-annotation-btn.scss
+++ b/h/static/styles/publish-annotation-btn.scss
@@ -11,17 +11,12 @@
 }
 
 .publish-annotation-cancel-btn {
-  $color: #bbb;
-  margin-left: 5px;
+  @extend .btn--cancel;
 
-  color: $color;
+  margin-left: 5px;
   font-weight: normal;
 
   &__icon {
     margin-right: 3px;
-  }
-
-  &:hover {
-    color: darken($color, 15%);
   }
 }

--- a/h/static/styles/variables.scss
+++ b/h/static/styles/variables.scss
@@ -15,11 +15,12 @@ $gray-lightest: #f9f9f9 !default;
 $color-mine-shaft: #3A3A3A;
 $color-dove-gray: #626262;
 $color-silver-chalice: #a6a6a6;
+$color-silver: #bbb;
 $color-alto: #dedede;
 $color-seashell: #f1f1f1;
 $color-wild-sand: #f5f5f5;
 
-// COLORS
+//COLORS
 $brand-color: #bd1c2b !default;
 
 $button-text-color: $gray-dark !default;

--- a/h/templates/client/group_list.html
+++ b/h/templates/client/group_list.html
@@ -46,6 +46,13 @@
             </div>
           </div>
         </div>
+        <!-- the 'Leave group' icon !-->
+        <div class="group-cancel-icon-container">
+          <i class="h-icon-cancel-outline btn--cancel"
+             ng-if="!group.public"
+             ng-click="leaveGroup(group.id)"
+             title="Leave '{{group.name}}'"></i>
+        </div>
       </div>
     </li>
     <li class="new-group-btn">


### PR DESCRIPTION
This adds a 'leave' button to groups which prompts to leave when clicked. The confirmation dialog is currently a default browser confirm dialog whose aesthetic quality will depend on the platform - I think we're going to want to re-do those in future.

The groups list does not update itself after removing yourself from a group, you have to refresh the page. Automatically updating the groups list when creating, joining or leaving a group will happen as part of https://github.com/hypothesis/h/pull/2587

![t88-leave-group](https://cloud.githubusercontent.com/assets/2458/10311099/368dfca4-6c3d-11e5-8a77-5b2a38e3b4da.png)
