### PR TITLE
Push notifications of group membership changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,9 @@ clean:
 dev: deps
 	@gunicorn --reload --paste conf/development.ini
 
-test: client-test
+test: backend-test client-test
+
+backend-test:
 	@python setup.py test
 
 client-test:

--- a/h/groups/test/views_test.py
+++ b/h/groups/test/views_test.py
@@ -156,7 +156,7 @@ def test_create_with_non_ascii_name():
 
 
 @create_fixtures
-def test_create_broadcasts_join_event(Group):
+def test_create_publishes_join_event(Group):
     group = mock.Mock(hashid=mock.sentinel.hashid)
     Group.return_value = group
     request = _mock_request()
@@ -164,7 +164,7 @@ def test_create_broadcasts_join_event(Group):
     views.create(request)
 
     request.get_queue_writer().publish.assert_called_once_with('user', {
-        'type': 'group-joined',
+        'type': 'group-join',
         'userid': request.authenticated_userid,
         'group': group.hashid,
     })
@@ -404,7 +404,7 @@ def test_join_redirects_to_group_page(Group):
     assert isinstance(result, httpexceptions.HTTPRedirection)
 
 @join_fixtures
-def test_join_broadcasts_join_event(Group):
+def test_join_publishes_join_event(Group):
     group = mock.Mock(hashid = mock.sentinel.hashid)
     Group.get_by_hashid.return_value = group
     request = _mock_request(matchdict=_matchdict())
@@ -412,7 +412,7 @@ def test_join_broadcasts_join_event(Group):
     views.join(request)
 
     request.get_queue_writer().publish.assert_called_once_with('user', {
-        'type': 'group-joined',
+        'type': 'group-join',
         'userid': request.authenticated_userid,
         'group': mock.sentinel.hashid,
     })
@@ -447,7 +447,7 @@ def test_leave_returns_not_found_if_user_not_in_group(Group, User):
 
 
 @leave_fixtures
-def test_leave_broadcasts_leave_event(Group, User):
+def test_leave_publishes_leave_event(Group, User):
     group = mock.Mock(hashid=mock.sentinel.hashid,
                       members=[mock.sentinel.user])
     Group.get_by_hashid.return_value = group
@@ -456,7 +456,7 @@ def test_leave_broadcasts_leave_event(Group, User):
     request = _mock_request(matchdict=_matchdict())
     views.leave(request)
     request.get_queue_writer().publish.assert_called_once_with('user', {
-        'type': 'group-left',
+        'type': 'group-leave',
         'userid': request.authenticated_userid,
         'group': mock.sentinel.hashid,
     })

--- a/h/groups/views.py
+++ b/h/groups/views.py
@@ -64,7 +64,7 @@ def create(request):
     # We need to flush the db session here so that group.id will be generated.
     request.db.flush()
 
-    _send_group_notification(request, 'group-joined', group.hashid)
+    _send_group_notification(request, 'group-join', group.hashid)
 
     url = request.route_url('group_read', hashid=group.hashid, slug=group.slug)
     return exc.HTTPSeeOther(url)
@@ -162,7 +162,7 @@ def join(request):
                                      request.authenticated_userid)
 
     group.members.append(user)
-    _send_group_notification(request, 'group-joined', group.hashid)
+    _send_group_notification(request, 'group-join', group.hashid)
 
     url = request.route_url('group_read', hashid=group.hashid, slug=group.slug)
     return exc.HTTPSeeOther(url)
@@ -201,7 +201,7 @@ def leave(request):
         raise exc.HTTPNotFound()
 
     group.members.remove(user)
-    _send_group_notification(request, 'group-left', group.hashid)
+    _send_group_notification(request, 'group-leave', group.hashid)
 
     return exc.HTTPNoContent()
 

--- a/h/groups/views.py
+++ b/h/groups/views.py
@@ -37,7 +37,7 @@ def _send_group_notification(request, type, hashid):
       'userid': request.authenticated_userid,
       'group': hashid,
     }
-    queue.publish('user', json.dumps(data))
+    queue.publish('user', data)
 
 @view_config(route_name='group_create',
              request_method='POST',

--- a/h/groups/views.py
+++ b/h/groups/views.py
@@ -30,14 +30,17 @@ def create_form(request):
 
     return {'form': form.render()}
 
-def _send_group_notification(request, type, hashid):
+
+def _send_group_notification(request, event_type, hashid):
+    """Publishes a group join/leave notification on the NSQ event queue"""
     queue = request.get_queue_writer()
     data = {
-      'type': type,
+      'type': event_type,
       'userid': request.authenticated_userid,
       'group': hashid,
     }
     queue.publish('user', data)
+
 
 @view_config(route_name='group_create',
              request_method='POST',

--- a/h/groups/views.py
+++ b/h/groups/views.py
@@ -197,8 +197,9 @@ def leave(request):
     user = models.User.get_by_userid(request.domain,
                                      request.authenticated_userid)
 
-    # FIXME - This should raise an error if the user is not
-    # a member of the group
+    if user not in group.members:
+        raise exc.HTTPNotFound()
+
     group.members.remove(user)
     _send_group_notification(request, 'group-left', group.hashid)
 

--- a/h/queue.py
+++ b/h/queue.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 from pyramid.settings import aslist
+
+import json
 import gnsq
 
 
@@ -11,6 +13,8 @@ class NamespacedNsqd(object):
     def publish(self, topic, data):
         if self.namespace is not None:
             topic = '{0}-{1}'.format(self.namespace, topic)
+        if not isinstance(data, str):
+            data = json.dumps(data)
         return self.client.publish(topic, data)
 
 

--- a/h/static/scripts/app-controller.coffee
+++ b/h/static/scripts/app-controller.coffee
@@ -42,8 +42,8 @@ module.exports = class AppController
 
     # Reload the view when the focused group changes or the
     # list of groups that the user is a member of changes
-    groupChangeEvents = [events.SESSION_CHANGED, events.GROUP_FOCUSED];
-    groupChangeEvents.forEach((eventName) ->
+    reloadEvents = [events.SESSION_CHANGED, events.GROUP_FOCUSED];
+    reloadEvents.forEach((eventName) ->
       $scope.$on(eventName, (event) ->
         $route.reload()
       )
@@ -51,14 +51,7 @@ module.exports = class AppController
 
     identity.watch({
       onlogin: (identity) -> $scope.auth.user = auth.userid(identity)
-      onlogout: ->
-        $scope.auth.user = null
-
-        # Currently all groups are private so when the user logs out they can
-        # no longer see the annotations from any group they may have had
-        # focused. Focus the public group instead, so that they see any public
-        # annotations in the sidebar.
-        groups.focus('__world__')
+      onlogout: -> $scope.auth.user = null
       onready: -> $scope.auth.user ?= null
     })
 
@@ -83,10 +76,6 @@ module.exports = class AppController
         $scope.login()
       else
         $scope.accountDialog.visible = false
-
-      # Reload the view if this is not the initial load.
-      if oldVal isnt undefined
-        $route.reload()
 
     $scope.login = ->
       $scope.accountDialog.visible = true

--- a/h/static/scripts/app-controller.coffee
+++ b/h/static/scripts/app-controller.coffee
@@ -1,5 +1,7 @@
 angular = require('angular')
 
+events = require('./events');
+
 module.exports = class AppController
   this.$inject = [
     '$controller', '$document', '$location', '$route', '$scope', '$window',
@@ -38,9 +40,14 @@ module.exports = class AppController
     # Default sort
     $scope.sort = name: 'Location'
 
-    $scope.$on('groupFocused', (event) ->
-      $route.reload()
-    )
+    # Reload the view when the focused group changes or the
+    # list of groups that the user is a member of changes
+    groupChangeEvents = [events.SESSION_CHANGED, events.GROUP_FOCUSED];
+    groupChangeEvents.forEach((eventName) ->
+      $scope.$on(eventName, (event) ->
+        $route.reload()
+      )
+    );
 
     identity.watch({
       onlogin: (identity) -> $scope.auth.user = auth.userid(identity)

--- a/h/static/scripts/events.js
+++ b/h/static/scripts/events.js
@@ -4,6 +4,10 @@
  */
 
 module.exports = {
+  /** Broadcast when the currently selected group changes */
   GROUP_FOCUSED: 'groupFocused',
+  /** Broadcast when the session state is updated.
+   * This event is NOT broadcast after the initial session load.
+   */
   SESSION_CHANGED: 'sessionChanged',
 };

--- a/h/static/scripts/events.js
+++ b/h/static/scripts/events.js
@@ -1,0 +1,9 @@
+/**
+ * This module defines the set of global events that are dispatched
+ * on $rootScope
+ */
+
+module.exports = {
+  GROUP_FOCUSED: 'groupFocused',
+  SESSION_CHANGED: 'sessionChanged',
+};

--- a/h/static/scripts/groups.js
+++ b/h/static/scripts/groups.js
@@ -2,8 +2,12 @@
  * @ngdoc service
  * @name  groups
  *
- * @description
- * Get and set the UI's currently focused group.
+ * @description Provides access to the list of groups that the user is currently
+ *              a member of and the currently selected group in the UI.
+ *
+ *              The list of groups is initialized from the session state
+ *              and can then later be updated using the add() and remove()
+ *              methods.
  */
 'use strict';
 
@@ -11,20 +15,22 @@ var baseURI = require('document-base-uri');
 
 var STORAGE_KEY = 'hypothesis.groups.focus';
 
+var events = require('./events');
+
 // @ngInject
 function groups(localStorage, session, $rootScope, features, $http) {
   // The currently focused group. This is the group that's shown as selected in
   // the groups dropdown, the annotations displayed are filtered to only ones
   // that belong to this group, and any new annotations that the user creates
   // will be created in this group.
-  var focused;
+  var focusedGroup;
 
-  var all = function all() {
+  function all() {
     return session.state.groups || [];
   };
 
   // Return the full object for the group with the given id.
-  var get = function get(id) {
+  function get(id) {
     var gs = all();
     for (var i = 0, max = gs.length; i < max; i++) {
       if (gs[i].id === id) {
@@ -45,9 +51,54 @@ function groups(localStorage, session, $rootScope, features, $http) {
     // TODO - Optimistically call remove() to
     // remove the group locally when
     // https://github.com/hypothesis/h/pull/2587 has been merged
-
     return response;
   };
+
+
+  /** Return the currently focused group. If no group is explicitly focused we
+   * will check localStorage to see if we have persisted a focused group from
+   * a previous session. Lastly, we fall back to the first group available.
+   */
+  function focused() {
+    if (focusedGroup) {
+     return focusedGroup;
+    } else if (features.flagEnabled('groups')) {
+     var fromStorage = get(localStorage.getItem(STORAGE_KEY));
+     if (fromStorage) {
+       var matches = all().filter(function (group) {
+         return group.id === fromStorage.id;
+       });
+       if (matches.length > 0) {
+         focusedGroup = matches[0];
+       }
+       return focusedGroup;
+     }
+    }
+    return all()[0];
+  }
+
+  /** Set the group with the passed id as the currently focused group. */
+  function focus(id) {
+   var g = get(id);
+   if (typeof g !== 'undefined') {
+     focusedGroup = g;
+     localStorage.setItem(STORAGE_KEY, g.id);
+     $rootScope.$broadcast(events.GROUP_FOCUSED, g.id);
+   }
+  }
+
+  // reset the focused group if the user leaves it
+  $rootScope.$on(events.SESSION_CHANGED, function () {
+    if (focusedGroup) {
+      var match = session.state.groups.filter(function (group) {
+        return group.id === focusedGroup.id;
+      });
+      if (match.length === 0) {
+        focusedGroup = null;
+        $rootScope.$broadcast(events.GROUP_FOCUSED, focused());
+      }
+    }
+  });
 
   return {
     all: all,
@@ -55,31 +106,8 @@ function groups(localStorage, session, $rootScope, features, $http) {
 
     leave: leave,
 
-    // Return the currently focused group. If no group is explicitly focused we
-    // will check localStorage to see if we have persisted a focused group from
-    // a previous session. Lastly, we fall back to the first group available.
-    focused: function() {
-      if (focused) {
-        return focused;
-      } else if (features.flagEnabled('groups')) {
-        var fromStorage = get(localStorage.getItem(STORAGE_KEY));
-        if (typeof fromStorage !== 'undefined') {
-          focused = fromStorage;
-          return focused;
-        }
-      }
-      return all()[0];
-    },
-
-    // Set the group with the passed id as the currently focused group.
-    focus: function(id) {
-      var g = get(id);
-      if (typeof g !== 'undefined') {
-        focused = g;
-        localStorage.setItem(STORAGE_KEY, g.id);
-        $rootScope.$broadcast('groupFocused', g.id);
-      }
-    }
+    focused: focused,
+    focus: focus,
   };
 }
 

--- a/h/static/scripts/session.js
+++ b/h/static/scripts/session.js
@@ -61,7 +61,7 @@ function sessionActions(options) {
  *
  * @ngInject
  */
-function session($document, $http, $resource, flash, $rootScope) {
+function session($document, $http, $resource, $rootScope, flash) {
  // TODO: Move accounts data management (e.g. profile, edit_profile,
  // disable_user, etc) into another module with another route.
   var actions = sessionActions({

--- a/h/static/scripts/session.js
+++ b/h/static/scripts/session.js
@@ -115,6 +115,8 @@ function session($document, $http, $resource, $rootScope, flash) {
    *              when new state has been pushed to it by the server.
    */
   resource.update = function (model) {
+    var isInitialLoad = !resource.state.csrf;
+
     // Copy the model data (including the CSRF token) into `resource.state`.
     angular.copy(model, resource.state);
 
@@ -122,7 +124,9 @@ function session($document, $http, $resource, $rootScope, flash) {
     lastLoad = {$promise: Promise.resolve(model), $resolved: true};
     lastLoadTime = Date.now();
 
-    $rootScope.$broadcast(events.SESSION_CHANGED);
+    if (!isInitialLoad) {
+      $rootScope.$broadcast(events.SESSION_CHANGED);
+    }
 
     // Return the model
     return model;

--- a/h/static/scripts/streamer.js
+++ b/h/static/scripts/streamer.js
@@ -73,7 +73,7 @@ function connect($websocket, annotationMapper, groups, session) {
 
   // Listen for updates
   socket.onMessage(function (event) {
-    message = JSON.parse(event.data)
+    message = JSON.parse(event.data);
     if (!message) {
       return;
     }

--- a/h/static/scripts/streamer.js
+++ b/h/static/scripts/streamer.js
@@ -16,6 +16,7 @@ var socket;
  * @param $websocket - angular-websocket constructor
  * @param annotationMapper - The local annotation store
  * @param groups - The local groups store
+ * @param session - Provides access to read and update the session state
  *
  * @return An angular-websocket wrapper around the socket.
  */

--- a/h/static/scripts/test/app-controller-test.coffee
+++ b/h/static/scripts/test/app-controller-test.coffee
@@ -132,11 +132,14 @@ describe 'AppController', ->
     createController()
     assert.isFalse($scope.shareDialog.visible)
 
-  it 'calls $route.reload() when the session state changes', ->
+  it 'reloads the view when the focused group changes', ->
     createController()
-    groupEvents = [events.SESSION_CHANGED, events.GROUP_FOCUSED];
-    groupEvents.forEach((event) ->
-      fakeRoute.reload = sinon.spy()
-      $scope.$broadcast(event)
-      assert.calledOnce(fakeRoute.reload)
-    )
+    fakeRoute.reload = sinon.spy()
+    $scope.$broadcast(events.GROUP_FOCUSED)
+    assert.calledOnce(fakeRoute.reload)
+
+  it 'reloads the view when the session state changes', ->
+    createController()
+    fakeRoute.reload = sinon.spy()
+    $scope.$broadcast(events.SESSION_CHANGED)
+    assert.calledOnce(fakeRoute.reload)

--- a/h/static/scripts/test/app-controller-test.coffee
+++ b/h/static/scripts/test/app-controller-test.coffee
@@ -1,4 +1,5 @@
 {module, inject} = angular.mock
+events = require('../events')
 
 describe 'AppController', ->
   $controller = null
@@ -21,7 +22,7 @@ describe 'AppController', ->
     $controller('AppController', locals)
 
   before ->
-    angular.module('h')
+    angular.module('h', [])
     .controller('AppController', require('../app-controller'))
     .controller('AnnotationUIController', angular.noop)
 
@@ -137,7 +138,11 @@ describe 'AppController', ->
     createController()
     assert.isFalse($scope.shareDialog.visible)
 
-  it 'calls $route.reload() when the focused group changes', ->
+  it 'calls $route.reload() when the session state changes', ->
     createController()
-    $scope.$broadcast('groupFocused')
-    assert.calledOnce(fakeRoute.reload)
+    groupEvents = [events.SESSION_CHANGED, events.GROUP_FOCUSED];
+    groupEvents.forEach((event) ->
+      fakeRoute.reload = sinon.spy()
+      $scope.$broadcast(event)
+      assert.calledOnce(fakeRoute.reload)
+    )

--- a/h/static/scripts/test/app-controller-test.coffee
+++ b/h/static/scripts/test/app-controller-test.coffee
@@ -124,12 +124,6 @@ describe 'AppController', ->
     onlogout()
     assert.strictEqual($scope.auth.user, null)
 
-  it 'focuses the default group in logout', ->
-    createController()
-    {onlogout} = fakeIdentity.watch.args[0][0]
-    onlogout()
-    assert.calledWith(fakeGroups.focus, '__world__')
-
   it 'does not show login form for logged in users', ->
     createController()
     assert.isFalse($scope.accountDialog.visible)

--- a/h/static/scripts/test/session-test.js
+++ b/h/static/scripts/test/session-test.js
@@ -160,11 +160,23 @@ describe('h:session', function () {
   describe('#update()', function () {
     it('broadcasts an event when the session is updated', function () {
       var sessionChangeCallback = sinon.stub();
+
+      // the initial load should not trigger a SESSION_CHANGED event
       $rootScope.$on(events.SESSION_CHANGED, sessionChangeCallback);
       session.update({
         groups: [{
           id: 'groupid'
-        }]
+        }],
+        csrf: 'dummytoken',
+      });
+
+      // subsequent loads should trigger a SESSION_CHANGED event
+      assert.isFalse(sessionChangeCallback.called);
+      session.update({
+        groups: [{
+          id: 'groupid2'
+        }],
+        csrf: 'dummytoken'
       });
       assert.calledOnce(sessionChangeCallback);
     });

--- a/h/static/scripts/test/session-test.js
+++ b/h/static/scripts/test/session-test.js
@@ -34,7 +34,7 @@ describe('h:session', function () {
   }));
 
 
-  beforeEach(mock.inject(function (_$httpBackend_, _session_, _$rootScope_) {
+  beforeEach(mock.inject(function (_$httpBackend_, _$rootScope_, _session_) {
     $httpBackend = _$httpBackend_;
     session = _session_;
     $rootScope = _$rootScope_;

--- a/h/static/scripts/test/session-test.js
+++ b/h/static/scripts/test/session-test.js
@@ -2,8 +2,12 @@
 
 var mock = angular.mock;
 
+var events = require('../events');
+
 describe('h:session', function () {
   var $httpBackend;
+  var $rootScope;
+
   var fakeFlash;
   var fakeXsrf;
   var sandbox;
@@ -30,9 +34,10 @@ describe('h:session', function () {
   }));
 
 
-  beforeEach(mock.inject(function (_$httpBackend_, _session_) {
+  beforeEach(mock.inject(function (_$httpBackend_, _session_, _$rootScope_) {
     $httpBackend = _$httpBackend_;
     session = _session_;
+    $rootScope = _$rootScope_;
   }));
 
   afterEach(function () {
@@ -149,6 +154,19 @@ describe('h:session', function () {
       $httpBackend.expectGET(url).respond({});
       session.load();
       $httpBackend.flush();
+    });
+  });
+
+  describe('#update()', function () {
+    it('broadcasts an event when the session is updated', function () {
+      var sessionChangeCallback = sinon.stub();
+      $rootScope.$on(events.SESSION_CHANGED, sessionChangeCallback);
+      session.update({
+        groups: [{
+          id: 'groupid'
+        }]
+      });
+      assert.calledOnce(sessionChangeCallback);
     });
   });
 });

--- a/h/static/scripts/test/streamer-test.js
+++ b/h/static/scripts/test/streamer-test.js
@@ -33,6 +33,7 @@ function fakeSocketConstructor(url) {
 describe('streamer', function () {
   var fakeAnnotationMapper;
   var fakeGroups;
+  var fakeSession;
   var socket;
 
   beforeEach(function () {
@@ -47,10 +48,15 @@ describe('streamer', function () {
       },
     };
 
+    fakeSession = {
+      update: sinon.stub(),
+    };
+
     socket = streamer.connect(
       fakeSocketConstructor,
       fakeAnnotationMapper,
-      fakeGroups
+      fakeGroups,
+      fakeSession
     );
   });
 
@@ -95,6 +101,21 @@ describe('streamer', function () {
         }]
       });
       assert.ok(fakeAnnotationMapper.unloadAnnotations.calledOnce);
+    });
+  });
+
+  describe('session change notifications', function () {
+    it('updates the session when a notification is received', function () {
+      var model = {
+        groups: [{
+          id: 'new-group'
+        }]
+      };
+      socket.notify({
+        type: 'session-change',
+        model: model,
+      });
+      assert.ok(fakeSession.update.calledWith(model));
     });
   });
 });

--- a/h/streamer.py
+++ b/h/streamer.py
@@ -12,6 +12,7 @@ import weakref
 
 import gevent
 import gevent.queue
+from functools import partial
 from jsonpointer import resolve_pointer
 from jsonschema import validate
 from pyramid.config import aslist
@@ -25,7 +26,8 @@ from h.api import nipsa
 from h.api import uri
 from h.api.search import query
 from .models import Annotation
-
+from h.groups.models import Group
+import h.session
 
 log = logging.getLogger(__name__)
 
@@ -439,6 +441,8 @@ class FilterHandler(object):
 class WebSocket(_WebSocket):
     # Class attributes
     event_queue = None
+    """ Tuples of (topic, message) pulled from the message queue """
+
     instances = weakref.WeakSet()
     origins = []
 
@@ -464,15 +468,23 @@ class WebSocket(_WebSocket):
             return
         cls.event_queue = gevent.queue.Queue()
         reader_id = 'stream-{}#ephemeral'.format(_random_id())
-        reader = request.get_queue_reader('annotations', reader_id)
-        reader.on_message.connect(cls.on_queue_message)
-        reader.start(block=False)
+
+        for topic in ['annotations', 'user']:
+            reader = request.get_queue_reader(topic, reader_id)
+            reader.on_message.connect(
+                receiver=partial(cls.on_queue_message, topic),
+                # hold a reference to the per-topic callable returned by
+                # partial()
+                weak=False
+            )
+            reader.start(block=False)
+
         gevent.spawn(broadcast_from_queue, cls.event_queue, cls.instances)
 
     @classmethod
-    def on_queue_message(cls, reader, message=None):
+    def on_queue_message(cls, topic, reader, message=None):
         if message is not None:
-            cls.event_queue.put(message)
+            cls.event_queue.put((topic, message))
 
     def opened(self):
         self.start_reader(self.request)
@@ -550,16 +562,57 @@ def broadcast_from_queue(queue, sockets):
     Pulls messages from a passed queue object, and handles dispatching them to
     appropriate active sessions.
     """
-    for message in queue:
-        data_in = json.loads(message.body)
-        action = data_in['action']
-        annotation = Annotation(**data_in['annotation'])
-        payload = _annotation_packet([annotation], action)
-        data_out = json.dumps(payload)
-        for socket in list(sockets):
-            if should_send_event(socket, annotation, data_in):
-                socket.send(data_out)
+    for (topic, message) in queue:
+        if topic == 'annotation':
+            broadcast_annotation_message(message, sockets)
+        elif topic == 'user':
+            broadcast_session_change_message(message, sockets)
 
+def broadcast_annotation_message(message, sockets):
+    """
+    Broadcast an annotation message to all appropriate active sessions.
+    """
+    data_in = json.loads(message.body)
+    action = data_in['action']
+    annotation = Annotation(**data_in['annotation'])
+    payload = _annotation_packet([annotation], action)
+    data_out = json.dumps(payload)
+    for socket in list(sockets):
+        if should_send_annotation_event(socket, annotation, data_in):
+            socket.send(data_out)
+
+def _get_group_json(hash_id):
+    # FIXME - There is an issue (race condition?) here where
+    # get_by_hashid() sometimes returns None, though the hash_id appears
+    # to be valid.
+    group = Group.get_by_hashid(hash_id)
+    return {
+        'name': group.name,
+        'id': group.hashid,
+        # TODO - Generate group URL correctly
+        'url': 'https://dummy/%s/%s' % (hash_id, group.slug)
+        #'url': request.route_url('group_read',
+        #    hashid=group.hashid,
+        #    slug=group.slug)
+    }
+
+def broadcast_session_change_message(message, sockets):
+    """ Broadcast a session change to all appropriate active sessions. """
+    data_in = json.loads(message.body)
+
+    for socket in list(sockets):
+        # TODO - This logic is duplicated in should_send_annotation_event()
+        if socket.terminated:
+            continue
+
+        if socket.request.authenticated_userid == data_in['userid']:
+            # for session state change events, the full session model is included
+            # so that clients can update themselves without further API requests
+            socket.send(json.dumps({
+                'type': 'session-change',
+                'action': data_in['type'],
+                'model': h.session.model(socket.request)
+            }))
 
 def _authorized_to_read(effective_principals, annotation):
     """Return True if effective_principals authorize reading annotation.
@@ -579,7 +632,7 @@ def _authorized_to_read(effective_principals, annotation):
     return False
 
 
-def should_send_event(socket, annotation, event_data):
+def should_send_annotation_event(socket, annotation, event_data):
     """
     Inspects the passed annotation and action and decides whether or not
     the underlying session should receive the event. If it should, the

--- a/h/streamer.py
+++ b/h/streamer.py
@@ -436,6 +436,12 @@ class FilterHandler(object):
             return False
 
 
+# NSQ message topics that the WebSocket server
+# processes messages from
+ANNOTATIONS_TOPIC = 'annotations'
+USER_TOPIC = 'user'
+
+
 class WebSocket(_WebSocket):
     # Class attributes
     event_queue = None
@@ -467,7 +473,7 @@ class WebSocket(_WebSocket):
         cls.event_queue = gevent.queue.Queue()
         reader_id = 'stream-{}#ephemeral'.format(_random_id())
 
-        for topic in ['annotations', 'user']:
+        for topic in [ANNOTATIONS_TOPIC, USER_TOPIC]:
             reader = request.get_queue_reader(topic, reader_id)
             reader.on_message.connect(receiver=cls.on_queue_message)
             reader.start(block=False)
@@ -556,10 +562,11 @@ def broadcast_from_queue(queue, sockets):
     appropriate active sessions.
     """
     for (topic, message) in queue:
-        if topic == 'annotation':
+        if topic == ANNOTATIONS_TOPIC:
             broadcast_annotation_message(message, sockets)
-        elif topic == 'user':
+        elif topic == USER_TOPIC:
             broadcast_session_change_message(message, sockets)
+
 
 def broadcast_annotation_message(message, sockets):
     """

--- a/h/streamer.py
+++ b/h/streamer.py
@@ -581,20 +581,6 @@ def broadcast_annotation_message(message, sockets):
         if should_send_annotation_event(socket, annotation, data_in):
             socket.send(data_out)
 
-def _get_group_json(hash_id):
-    # FIXME - There is an issue (race condition?) here where
-    # get_by_hashid() sometimes returns None, though the hash_id appears
-    # to be valid.
-    group = Group.get_by_hashid(hash_id)
-    return {
-        'name': group.name,
-        'id': group.hashid,
-        # TODO - Generate group URL correctly
-        'url': 'https://dummy/%s/%s' % (hash_id, group.slug)
-        #'url': request.route_url('group_read',
-        #    hashid=group.hashid,
-        #    slug=group.slug)
-    }
 
 def broadcast_session_change_message(message, sockets):
     """ Broadcast a session change to all appropriate active sessions. """

--- a/h/streamer.py
+++ b/h/streamer.py
@@ -444,8 +444,9 @@ USER_TOPIC = 'user'
 
 class WebSocket(_WebSocket):
     # Class attributes
+
+    # Tuples of (topic, message) pulled from the message queue
     event_queue = None
-    """ Tuples of (topic, message) pulled from the message queue """
 
     instances = weakref.WeakSet()
     origins = []
@@ -569,9 +570,7 @@ def broadcast_from_queue(queue, sockets):
 
 
 def broadcast_annotation_message(message, sockets):
-    """
-    Broadcast an annotation message to all appropriate active sessions.
-    """
+    """Broadcast an annotation message to all appropriate active sessions."""
     data_in = json.loads(message.body)
     action = data_in['action']
     annotation = Annotation(**data_in['annotation'])
@@ -583,13 +582,14 @@ def broadcast_annotation_message(message, sockets):
 
 
 def broadcast_session_change_message(message, sockets):
-    """ Broadcast a session change to all appropriate active sessions. """
+    """Broadcast a session change to all appropriate active sessions."""
     data_in = json.loads(message.body)
 
     for socket in list(sockets):
         if socket.request.authenticated_userid == data_in['userid']:
-            # for session state change events, the full session model is included
-            # so that clients can update themselves without further API requests
+            # for session state change events, the full session model
+            # is included so that clients can update themselves without
+            # further API requests
             _send_if_open(socket, json.dumps({
                 'type': 'session-change',
                 'action': data_in['type'],
@@ -605,6 +605,7 @@ def _send_if_open(socket, data):
     # until just before sending a message to the client
     if not socket.terminated:
         socket.send(data)
+
 
 def _authorized_to_read(effective_principals, annotation):
     """Return True if effective_principals authorize reading annotation.

--- a/h/test/queue_test.py
+++ b/h/test/queue_test.py
@@ -77,3 +77,16 @@ def test_get_writer_namespace(fake_nsqd):
 
     writer.publish('sometopic', 'somedata')
     fake_client.publish.assert_called_with('abc123-sometopic', 'somedata')
+
+@patch('gnsq.Nsqd')
+def test_writer_serializes_dict(fake_nsqd):
+    fake_client = fake_nsqd.return_value
+    req = testing.DummyRequest()
+    req.registry.settings.update({
+        'nsq.namespace': 'abc',
+    })
+    writer = queue.get_writer(req)
+    writer.publish('sometopic', {
+        'key': 'value',
+    })
+    fake_client.publish.assert_called_with('abc-sometopic', '{"key": "value"}')

--- a/h/test/streamer_test.py
+++ b/h/test/streamer_test.py
@@ -16,6 +16,7 @@ from h.streamer import WebSocket
 from h.streamer import should_send_annotation_event
 from h.streamer import broadcast_from_queue
 from h.streamer import websocket
+from h.streamer import ANNOTATIONS_TOPIC
 
 
 FakeMessage = namedtuple('FakeMessage', 'body')
@@ -270,7 +271,7 @@ class TestBroadcastAnnotationEvent(unittest.TestCase):
              'action': 'delete',
              'src_client_id': 'cat'},
         ]
-        self.messages = [('annotation', FakeMessage(json.dumps(m)))
+        self.messages = [(ANNOTATIONS_TOPIC, FakeMessage(json.dumps(m)))
             for m in self.message_data]
 
         self.queue = MagicMock()

--- a/h/test/streamer_test.py
+++ b/h/test/streamer_test.py
@@ -303,7 +303,7 @@ class TestBroadcastSessionChangeEvent(unittest.TestCase):
 
         queue = MagicMock()
         queue.__iter__.return_value = [('user', FakeMessage(json.dumps({
-            'type': 'group-joined',
+            'type': 'group-join',
             'userid': 'amy',
             'group': 'groupid',
         })))]
@@ -314,7 +314,7 @@ class TestBroadcastSessionChangeEvent(unittest.TestCase):
         broadcast_from_queue(queue, [sock])
         sock.send.assert_called_with(json.dumps({
             'type': 'session-change',
-            'action': 'group-joined',
+            'action': 'group-join',
             'model': session_model.return_value,
         }))
 

--- a/h/test/streamer_test.py
+++ b/h/test/streamer_test.py
@@ -294,6 +294,13 @@ class TestBroadcastAnnotationEvent(unittest.TestCase):
         broadcast_from_queue(self.queue, [sock])
         assert sock.send.called is False
 
+    def test_terminated_socket_does_not_recieve_event(self):
+        self.should.return_value = True
+        sock = FakeSocket('giraffe')
+        sock.terminated = True
+        broadcast_from_queue(self.queue, [sock])
+        assert sock.send.called is False
+
 
 class TestBroadcastSessionChangeEvent(unittest.TestCase):
     def test_should_send_session_change_when_joining_or_leaving_group(self):
@@ -342,9 +349,6 @@ class TestShouldSendEvent(unittest.TestCase):
         data = {'action': 'update', 'src_client_id': 'pigeon'}
         assert should_send_annotation_event(self.sock_pigeon, {}, data) is False
 
-    def test_terminated_socket_does_not_recieve_event(self):
-        data = {'action': 'update', 'src_client_id': 'pigeon'}
-        assert should_send_annotation_event(self.sock_roadkill, {}, data) is False
 
     def test_should_send_annotation_event_no_filter(self):
         self.sock_giraffe.filter = None


### PR DESCRIPTION
Implement push notifications for when a user joins or leaves a group

This adds a new class of push notification, 'session-change'
which is broadcast to logged-in clients when changes to the user's
state, including the list of groups that they are a member of,
changes.

When the user creates or joins a group, a notification is
added to the event queue with an associated user ID
which is then broadcast via the web socket.

On the client side, the streamer service listens for the new
class of notification and triggers an update of the session
state in response.

When the user leaves a group, this may trigger an implicit change
of focus if the user was a member of the group.
Implement push notifications for when a user joins or leaves a group

This adds a new class of push notification, 'session-change'
which is broadcast to logged-in clients when changes to the user's
state, including the list of groups that they are a member of,
changes.

When the user creates or joins a group, a notification is
added to the event queue with an associated user ID
which is then broadcast via the web socket.

On the client side, the streamer service listens for the new
class of notification and triggers an update of the session
state in response.

When the user leaves a group, this may trigger an implicit change
of focus if the user was a member of the group.

----
Remaining Tasks:

- [X] Write tests for event queuing when a user joins a group on the server
- [X] Write tests for push notifications of group join / leave events
