### PR TITLE
Fix app initialization race when issuing annotation search query

### DIFF
--- a/h/static/scripts/groups.js
+++ b/h/static/scripts/groups.js
@@ -31,7 +31,15 @@ function groups(localStorage, session, $rootScope, features) {
     }
   };
 
+  /** Returns a promise which resolves once the list of groups
+   * has been loaded.
+   */
+  function ready() {
+    return session.load().$promise;
+  }
+
   return {
+    ready: ready,
     all: all,
     get: get,
 

--- a/h/static/scripts/widget-controller.coffee
+++ b/h/static/scripts/widget-controller.coffee
@@ -17,21 +17,25 @@ module.exports = class WidgetController
     loaded = []
 
     _loadAnnotationsFrom = (query, offset) =>
-      queryCore =
-        limit: @chunkSize
-        offset: offset
-        sort: 'created'
-        order: 'asc'
-        group: groups.focused().id
-      q = angular.extend(queryCore, query)
+      groups.ready().then( ->
+        queryCore =
+          limit: @chunkSize
+          offset: offset
+          sort: 'created'
+          order: 'asc'
+          group: groups.focused().id
+        q = angular.extend(queryCore, query)
 
-      store.SearchResource.get q, (results) ->
-        total = results.total
-        offset += results.rows.length
-        if offset < total
-          _loadAnnotationsFrom query, offset
+        store.SearchResource.get q, (results) ->
+          total = results.total
+          offset += results.rows.length
+          if offset < total
+            _loadAnnotationsFrom query, offset
 
-        annotationMapper.loadAnnotations(results.rows)
+          annotationMapper.loadAnnotations(results.rows)
+      ).catch((e) ->
+        throw e
+      )
 
     loadAnnotations = (frames) ->
       for f in frames


### PR DESCRIPTION
If the initial annotation search query was constructed
before the user's session state had been retrieved,
the groups list was empty and groups.focused() returned null
in WidgetController._loadAnnotationsFrom

This commit resolves the issue by adding a 'groups.ready()'
function which returns a promise once the groups list is ready.

It currently just returns the session.load().$promise.

Fixes #2590