### PR TITLE
Fix race for session data on startup

### DIFF
--- a/h/static/scripts/app.coffee
+++ b/h/static/scripts/app.coffee
@@ -7,6 +7,9 @@ require('angular-jwt')
 streamer = require('./streamer')
 
 resolve =
+  # Ensure that we have available a) the current authenticated userid, and b)
+  # the list of user groups.
+  sessionState: ['session', (session) -> session.load().$promise]
   store: ['store', (store) -> store.$promise]
   streamer: streamer.connect
   threading: [

--- a/h/static/scripts/test/session-test.js
+++ b/h/static/scripts/test/session-test.js
@@ -112,5 +112,43 @@ describe('h:session', function () {
       $httpBackend.flush();
       assert.deepEqual(session.state, response.model);
     });
+
+    it('an immediately-following call to #load() should not trigger a new request', function () {
+      $httpBackend.expectPOST(url).respond({});
+      session.login();
+      $httpBackend.flush();
+
+      session.load();
+    });
+  });
+
+  describe('#load()', function () {
+    var url = 'http://foo.com/app';
+
+    it('should fetch the session data', function () {
+      $httpBackend.expectGET(url).respond({});
+      session.load();
+      $httpBackend.flush();
+    });
+
+    it('should cache the session data', function () {
+      $httpBackend.expectGET(url).respond({});
+      session.load();
+      session.load();
+      $httpBackend.flush();
+    });
+
+    it('should eventually expire the cache', function () {
+      var clock = sandbox.useFakeTimers();
+      $httpBackend.expectGET(url).respond({});
+      session.load();
+      $httpBackend.flush();
+
+      clock.tick(301 * 1000);
+
+      $httpBackend.expectGET(url).respond({});
+      session.load();
+      $httpBackend.flush();
+    });
   });
 });


### PR DESCRIPTION
Several parts of the application require access to the session data fetched from the server when rendering. On first page load we don't have this data (something we can fix in the future by inlining the data with the viewer HTML) and this resulted in a race between the session data load triggered by `checkAuthentication` (in config/identity.js) and the query sent to the server by `WidgetController`, which needs to know the current focused group id.

Fix this by ensuring that the first load of session data is complete before switching views -- achieved by adding an item to the list of dependencies passed to `$routeProvider`.

This works, but results in multiple requests for session data in quick succession, because `checkAuthentication` runs while the view is loading. To resolve this problem, we add a straightforward TTL check to the `session.load()` method, and only make a new request if the data is more than 5m old.

Session data will be overwritten as normal whenever session mutating methods (`session.login()`, `session.logout()`) etc. are called.

- [x] needs tests for the changes to the session service.

Fixes #2590.