### PR TITLE
Insert 'group': '__world__" if none

### DIFF
--- a/h/api/groups/__init__.py
+++ b/h/api/groups/__init__.py
@@ -3,9 +3,11 @@
 from h.api.groups.auth import group_principals
 from h.api.groups.auth import set_permissions
 from h.api.groups.logic import set_group_if_reply
+from h.api.groups.logic import insert_group_if_none
 
 __all__ = (
     'group_principals',
     'set_permissions',
     'set_group_if_reply',
+    'insert_group_if_none'
 )

--- a/h/api/groups/logic.py
+++ b/h/api/groups/logic.py
@@ -37,3 +37,8 @@ def set_group_if_reply(annotation):
     else:
         if 'group' in annotation:
             del annotation['group']
+
+
+def insert_group_if_none(annotation):
+    if not annotation.get('group'):
+        annotation['group'] = '__world__'

--- a/h/api/groups/test/logic_test.py
+++ b/h/api/groups/test/logic_test.py
@@ -98,6 +98,30 @@ def test_set_group_if_reply_clears_group_if_parent_has_no_group(models):
     assert 'group' not in annotation
 
 
+def test_insert_group_if_none_inserts_group():
+    annotation = {}
+
+    logic.insert_group_if_none(annotation)
+
+    assert annotation == {'group': '__world__'}
+
+
+def test_insert_group_if_none_does_not_overwrite_group():
+    annotation = {'group': 'foo'}
+
+    logic.insert_group_if_none(annotation)
+
+    assert annotation == {'group': 'foo'}
+
+
+def test_insert_group_if_none_does_nothing_if_already_group_world():
+    annotation = {'group': '__world__'}
+
+    logic.insert_group_if_none(annotation)
+
+    assert annotation == {'group': '__world__'}
+
+
 @pytest.fixture
 def models(request):
     patcher = mock.patch('h.api.groups.logic.models', autospec=True)

--- a/h/api/search/test/transform_test.py
+++ b/h/api/search/test/transform_test.py
@@ -15,6 +15,15 @@ def test_prepare_calls_set_group_if_reply(groups):
 
 
 @mock.patch('h.api.search.transform.groups')
+def test_prepare_calls_insert_group(groups):
+    annotation = {'permissions': {'read': []}}
+
+    transform.prepare(annotation)
+
+    groups.insert_group_if_none.assert_called_once_with(annotation)
+
+
+@mock.patch('h.api.search.transform.groups')
 def test_prepare_calls_set_permissions(groups):
     annotation = {'permissions': {'read': []}}
 
@@ -243,7 +252,6 @@ def test_prepare_sets_nipsa_field(_, ann, nipsa, has_nipsa):
      {"target": [{"foo": "bar"}, {"baz": "qux"}]}),
 ])
 def test_render_noop_when_nothing_to_remove(_, ann_in, ann_out):
-    ann_out['group'] = '__world__'
     assert transform.render(ann_in) == ann_out
 
 

--- a/h/api/search/transform.py
+++ b/h/api/search/transform.py
@@ -18,6 +18,7 @@ def prepare(annotation):
     and add normalized versions of these to the document.
     """
     groups.set_group_if_reply(annotation)
+    groups.insert_group_if_none(annotation)
     groups.set_permissions(annotation)
 
     # FIXME: Remove this in a month or so, when all our clients have been
@@ -42,10 +43,6 @@ def render(annotation):
     or display in the public API.
     """
     data = copy.deepcopy(dict(annotation))
-
-    if 'group' not in data:
-        data['group'] = '__world__'
-
     return data
 
 


### PR DESCRIPTION
When creating or updating an annotation if the annotation has no 'group'
field then insert `'group': '__world__'`.

This fixes a bug where people calling our API directly can create
annotations with no group field, then for example when the sidebar
searches for annotations with `'group': '__world__'` it won't find these
annotations, but the Chrome extension badge (which doesn't put any group
filter in its searches) will find them.

This could be fixed client-side but it's better to make the annotations
in our search index consistent, than to try and always remember that
public annotations may either have `group: '__world__'` or no group at
all.

This means that it's no longer necessary for us to insert
`group: '__world__'` on the way out in render().

Annotations pre-dating this commit with no group can be migrated with:

    hypothesis annotool conf/production.ini prepare

Fixes #2589.