### PR TITLE
Remove special-handling of pre-groups annotations

### DIFF
--- a/h/api/groups/auth.py
+++ b/h/api/groups/auth.py
@@ -19,7 +19,7 @@ def set_permissions(annotation):
         return
 
     group = annotation.get('group')
-    if group in (None, '', '__world__'):
+    if group == '__world__':
         # The groups feature doesn't change the permissions for annotations
         # that don't belong to a group.
         return

--- a/h/api/groups/test/auth_test.py
+++ b/h/api/groups/test/auth_test.py
@@ -42,20 +42,18 @@ def test_set_permissions_does_not_modify_private_annotations():
 
 
 def test_set_permissions_does_not_modify_non_group_annotations():
-    for group in ('missing', None, '', '__world__'):
-        original_annotation = {
-            'user': 'acct:jack@hypothes.is',
-            'permissions': {
-                'read': ['acct:jill@hypothes.is']
-            }
-        }
-        if group != 'missing':
-            original_annotation['group'] = group
-        annotation_to_be_modified = copy.deepcopy(original_annotation)
+    original_annotation = {
+        'user': 'acct:jack@hypothes.is',
+        'permissions': {
+            'read': ['acct:jill@hypothes.is']
+        },
+        'group': '__world__'
+    }
+    annotation_to_be_modified = copy.deepcopy(original_annotation)
 
-        auth.set_permissions(annotation_to_be_modified)
+    auth.set_permissions(annotation_to_be_modified)
 
-        assert annotation_to_be_modified == original_annotation
+    assert annotation_to_be_modified == original_annotation
 
 
 def test_set_permissions_sets_read_permissions_for_group_annotations():

--- a/h/api/search/query.py
+++ b/h/api/search/query.py
@@ -120,7 +120,7 @@ class GroupFilter(object):
     Matches only those annotations belonging to the specified group.
 
     When the groups feature flag is off, this ensures that only annotations
-    from the public group (or those lacking a group field) are returned.
+    from the public group are returned.
     """
 
     def __init__(self, request):
@@ -131,15 +131,7 @@ class GroupFilter(object):
         group = params.pop("group", None)
 
         if not self.request.feature('groups'):
-            return {
-                "or": [
-                    # Non-group annotations created after the groups feature
-                    # has been deployed.
-                    {"term": {"group": "__world__"}},
-                    # Annotations created before the groups feature existed.
-                    {"missing": {"field": "group"}},
-                ]
-            }
+            return {"term": {"group": "__world__"}}
 
         if group is not None:
             return {"term": {"group": group}}

--- a/h/api/search/test/query_test.py
+++ b/h/api/search/test/query_test.py
@@ -269,11 +269,7 @@ def test_groupfilter_restricts_to_public_annotations_when_feature_off():
     groupfilter = query.GroupFilter(request)
 
     assert groupfilter({}) == groupfilter({"group": "foo"}) == {
-        "or": [
-            {"term": {"group": "__world__"}},
-            {"missing": {"field": "group"}},
-        ]
-    }
+        "term": {"group": "__world__"}}
 
 
 def test_groupfilter_strips_param_when_feature_off():


### PR DESCRIPTION
Now that we always insert 'group': '__world__' server side on annotation
create or update if the annotation has no group field, and we've run a
migration on staging/prod, we no longer need special-handling for
pre-groups annotations that have no groups field.