### PR TITLE
Remove the 'search_normalized' feature flag

### DIFF
--- a/h/api/search/core.py
+++ b/h/api/search/core.py
@@ -21,7 +21,7 @@ def search(request, params):
     builder = query.Builder()
 
     builder.append_filter(query.AuthFilter(request))
-    builder.append_filter(query.UriFilter(request))
+    builder.append_filter(query.UriFilter())
     builder.append_filter(lambda _: \
         nipsa.nipsa_filter(request.authenticated_userid))
     builder.append_filter(query.GroupFilter(request))

--- a/h/api/search/query.py
+++ b/h/api/search/query.py
@@ -143,29 +143,13 @@ class UriFilter(object):
     A filter that selects only annotations where the 'uri' parameter matches.
     """
 
-    def __init__(self, request):
-        self.request = request
-
     def __call__(self, params):
         uristr = params.pop('uri', None)
         if uristr is None:
             return None
 
-        if self.request.feature('search_normalized'):
-            return self.term_filter(uristr)
-        return self.match_filter(uristr)
-
-    def term_filter(self, uristr):
         scopes = [uri.normalize(u) for u in uri.expand(uristr)]
         return {"terms": {"target.scope": scopes}}
-
-    def match_filter(self, uristr):
-        uristrs = uri.expand(uristr)
-        clauses = [{"match": {"uri": u}} for u in uristrs]
-
-        if len(clauses) == 1:
-            return {"query": clauses[0]}
-        return {"query": {"bool": {"should": clauses}}}
 
 
 class AnyMatcher(object):

--- a/h/features.py
+++ b/h/features.py
@@ -11,7 +11,6 @@ FEATURES = {
     'groups': "Enable private annotation groups?",
     'notification': "Send email notifications?",
     'queue': "Enable dispatch of annotation events to NSQ?",
-    'search_normalized': "Assume all data has normalized URI fields?",
     'show_unanchored_annotations': "Show annotations that fail to anchor?",
     'truncate_annotations': "Truncate long quotes and bodies in annotations?",
 }


### PR DESCRIPTION
This is now deployed and toggled on everywhere. Removing it simplifies the relevant query code and reduces the number of possible configuration states of our application.