### PR TITLE
Remove the 'streamer' feature flag

### DIFF
--- a/h/features.py
+++ b/h/features.py
@@ -11,7 +11,6 @@ FEATURES = {
     'groups': "Enable private annotation groups?",
     'notification': "Send email notifications?",
     'queue': "Enable dispatch of annotation events to NSQ?",
-    'streamer': "Enable 'live streaming' for annotations via the websocket?",
     'search_normalized': "Assume all data has normalized URI fields?",
     'show_unanchored_annotations': "Show annotations that fail to anchor?",
 }

--- a/h/streamer.py
+++ b/h/streamer.py
@@ -475,10 +475,7 @@ class WebSocket(_WebSocket):
             cls.event_queue.put(message)
 
     def opened(self):
-        # The websocket server runs regardless, but we don't attempt to connect
-        # to NSQ unless 'streamer' is toggled on.
-        if self.request.feature('streamer'):
-            self.start_reader(self.request)
+        self.start_reader(self.request)
 
         # Release the database transaction
         self.request.tm.commit()


### PR DESCRIPTION
This is deployed and toggled on everywhere, so we can simplify our code by removing this feature flag.