### PR TITLE
UI tweaks for the group creation form

### DIFF
--- a/h/groups/schemas.py
+++ b/h/groups/schemas.py
@@ -25,6 +25,7 @@ class GroupSchema(CSRFSchema):
         widget=deform.widget.TextInputWidget(
             autofocus=True,
             css_class="group-form__name-input js-group-name-input",
+            disable_autocomplete=True,
             label_css_class="group-form__name-label",
             max_length=GROUP_NAME_MAX_LENGTH,
             placeholder=_("Group Name")))

--- a/h/static/styles/group-form.scss
+++ b/h/static/styles/group-form.scss
@@ -53,6 +53,7 @@
 
     &__name-label {
       font-size: 18px;
+      margin-bottom: 10px;
     }
 
     &__name-input {
@@ -62,6 +63,7 @@
       text-align: center;
       margin-bottom: 40px;
       width: 350px;
+      outline: none;
 
       // TODO - Cyan cursor color
 


### PR DESCRIPTION

 * Increase the spacing between the label and the group name

 * Disable focus outline for the group name field, since
   the input has no border

 * Turn off autocomplete for the group name input field