### PR TITLE
Convert Chrome extension to Browserify + CommonJS modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,8 +40,12 @@ dev: deps
 test: client-test
 	@python setup.py test
 
-client-test:
+client-test: client-app-test client-extension-test
+
+client-app-test:
 	@$(NPM_BIN)/karma start h/static/scripts/karma.config.js --single-run
+
+client-extension-test:
 	@$(NPM_BIN)/karma start h/browser/chrome/karma.config.js --single-run
 
 client-test-watch:

--- a/h/browser/chrome/karma.config.js
+++ b/h/browser/chrome/karma.config.js
@@ -45,10 +45,14 @@ module.exports = function(config) {
     preprocessors: {
       '../../static/scripts/karma-phantomjs-polyfill.js': ['browserify'],
       './lib/hypothesis-chrome-extension.js': ['browserify'],
+      './test/*.js': ['browserify'],
     },
 
     browserify: {
       debug: true,
+      configure: function(bundle) {
+        bundle.plugin('proxyquire-universal');
+      },
     },
 
     // test results reporter to use

--- a/h/browser/chrome/karma.config.js
+++ b/h/browser/chrome/karma.config.js
@@ -10,32 +10,26 @@ module.exports = function(config) {
 
     // frameworks to use
     // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
-    frameworks: ['mocha', 'chai', 'sinon'],
+    frameworks: [
+      'browserify',
+      'mocha',
+      'chai',
+      'sinon'
+    ],
 
 
     // list of files / patterns to load in the browser
     files: [
       // Polyfills for PhantomJS
-      '../../../node_modules/js-polyfills/polyfill.js',
+      '../../static/scripts/karma-phantomjs-polyfill.js',
 
       {
         pattern: 'test/settings.json',
         included: false,
       },
 
-      'lib/settings.js',
-      'lib/errors.js',
-      'lib/tab-store.js',
-      'lib/tab-state.js',
-      'lib/tab-error-cache.js',
-      'lib/sidebar-injector.js',
-      'lib/browser-action.js',
-      'lib/help-page.js',
-      'lib/hypothesis-chrome-extension.js',
-      'test/bootstrap.js',
-
-      'test/*-test.js',
-      '../../static/scripts/blocklist.js'
+      './lib/hypothesis-chrome-extension.js',
+      './test/*.js',
     ],
 
     proxies: {
@@ -46,12 +40,16 @@ module.exports = function(config) {
     exclude: [
     ],
 
-
     // preprocess matching files before serving them to the browser
     // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
     preprocessors: {
+      '../../static/scripts/karma-phantomjs-polyfill.js': ['browserify'],
+      './lib/hypothesis-chrome-extension.js': ['browserify'],
     },
 
+    browserify: {
+      debug: true,
+    },
 
     // test results reporter to use
     // possible values: 'dots', 'progress'

--- a/h/browser/chrome/karma.config.js
+++ b/h/browser/chrome/karma.config.js
@@ -51,7 +51,9 @@ module.exports = function(config) {
     browserify: {
       debug: true,
       configure: function(bundle) {
-        bundle.plugin('proxyquire-universal');
+        bundle
+          .plugin('proxyquire-universal')
+          .require('phantom-ownpropertynames/implement', {entry: true});
       },
     },
 

--- a/h/browser/chrome/lib/browser-action.js
+++ b/h/browser/chrome/lib/browser-action.js
@@ -1,141 +1,139 @@
-(function (h) {
-  'use strict';
+'use strict';
 
-  // Cache the tab state constants.
-  var states = h.TabState.states;
+// Cache the tab state constants.
+var states = h.TabState.states;
 
-  // Each button state has two icons one for normal resolution (19) and one
-  // for hi-res screens (38).
-  var icons = {};
-  icons[states.ACTIVE] = {
-    19: 'images/browser-icon-active.png',
-    38: 'images/browser-icon-active@2x.png'
+// Each button state has two icons one for normal resolution (19) and one
+// for hi-res screens (38).
+var icons = {};
+icons[states.ACTIVE] = {
+  19: 'images/browser-icon-active.png',
+  38: 'images/browser-icon-active@2x.png'
+};
+icons[states.INACTIVE] = {
+  19: 'images/browser-icon-inactive.png',
+  38: 'images/browser-icon-inactive@2x.png'
+};
+
+// Fake localization function.
+function _(str) {
+  return str;
+}
+
+/* Controls the display of the browser action button setting the icon, title
+ * and badges depending on the current state of the tab. This is a stateless
+ * module and does not store the current state. A TabState instance should
+ * be used to manage which tabs are active/inactive.
+ */
+function BrowserAction(chromeBrowserAction) {
+  this.setState = function (tabId, state) {
+    switch (state) {
+      case states.ACTIVE:   this.activate(tabId); break;
+      case states.INACTIVE: this.deactivate(tabId); break;
+      case states.ERRORED:  this.error(tabId); break;
+      default: throw new TypeError('State ' + state + ' is invalid');
+    }
   };
-  icons[states.INACTIVE] = {
-    19: 'images/browser-icon-inactive.png',
-    38: 'images/browser-icon-inactive@2x.png'
-  };
 
-  // Fake localization function.
-  function _(str) {
-    return str;
+  /**
+   * Set the "title" (tooltip) of the browser action _if_ no badge is
+   * currently displayed on the browser action.
+   * @param {integer} tabId The id of the tab to set the badge title for.
+   * @param {string} title The value to set the title to.
+   */
+  function setTitleIfNoBadge(tabId, title) {
+    chromeBrowserAction.getBadgeText({tabId: tabId}, function(text) {
+      if (!text) {
+        chromeBrowserAction.setTitle({tabId: tabId, title: title});
+      }
+    });
   }
 
-  /* Controls the display of the browser action button setting the icon, title
-   * and badges depending on the current state of the tab. This is a stateless
-   * module and does not store the current state. A TabState instance should
-   * be used to manage which tabs are active/inactive.
+  /**
+   * Set the "title" (tooltip) and badge text of the browser action.
+   * @param {integer} tabId The id of the tab to set the badge title for.
+   * @param {string} title The text to show in the tooltip.
+   * @param {string} badgeText The text to show on the badge.
    */
-  function BrowserAction(chromeBrowserAction) {
-    this.setState = function (tabId, state) {
-      switch (state) {
-        case states.ACTIVE:   this.activate(tabId); break;
-        case states.INACTIVE: this.deactivate(tabId); break;
-        case states.ERRORED:  this.error(tabId); break;
-        default: throw new TypeError('State ' + state + ' is invalid');
+  function setTitleAndBadgeText(tabId, title, badgeText) {
+    chromeBrowserAction.setTitle({tabId: tabId, title: title});
+    chromeBrowserAction.setBadgeText({tabId: tabId, text: badgeText});
+  }
+
+  /* Sets the active browser action appearance for the provided tab id. */
+  this.activate = function(tabId) {
+    chromeBrowserAction.setIcon({tabId: tabId, path: icons[states.ACTIVE]});
+    setTitleIfNoBadge(tabId, _('Hypothesis is active'));
+  };
+
+  /* Sets the inactive browser action appearance for the provided tab id. */
+  this.deactivate = function(tabId) {
+    chromeBrowserAction.setIcon({tabId: tabId, path: icons[states.INACTIVE]});
+    setTitleIfNoBadge(tabId, _('Hypothesis is inactive'));
+  };
+
+  /* Sets the errored browser action appearance for the provided tab id. */
+  this.error = function(tabId) {
+    chromeBrowserAction.setIcon({tabId: tabId, path: icons[states.INACTIVE]});
+    setTitleAndBadgeText(tabId,  _('Hypothesis has failed to load'), '!');
+  };
+
+  /**
+   * Show the number of annotations of the current page in the badge.
+   *
+   * @method
+   * @param {integer} tabId The id of the current tab.
+   * @param {string} tabUrl The URL of the current tab.
+   * @param {string} serviceUrl The URL of the Hypothesis API.
+   */
+  this.updateBadge = function(tabId, tabUrl, serviceUrl) {
+    // Fetch the number of annotations of the current page from the server,
+    // and display it as a badge on the browser action button.
+    var xhr = new XMLHttpRequest();
+    xhr.onload = function() {
+      var total;
+
+      try {
+        total = JSON.parse(this.response).total;
+      } catch (e) {
+        console.error(
+          'updateBadge() received invalid JSON from the server: ' + e);
+        return;
+      }
+
+      if (typeof total !== 'number') {
+        console.error(
+          'updateBadge() received invalid total from the server: ' + total);
+        return;
+      }
+
+      if (total > 0) {
+        var totalString = total.toString();
+        if (total > 999) {
+          totalString = '999+';
+        }
+        chromeBrowserAction.getBadgeText({tabId: tabId}, function(text) {
+          // The num. annotations badge is low priority - we only set it if
+          // there's no other badge currently showing.
+          if (!text) {
+            var title;
+            if (total === 1) {
+              title = _("There's 1 annotation on this page");
+            } else {
+              title = _('There are ' + totalString + ' annotations on ' +
+                        'this page');
+            }
+            setTitleAndBadgeText(tabId, title, totalString);
+          }
+        });
       }
     };
 
-    /**
-     * Set the "title" (tooltip) of the browser action _if_ no badge is
-     * currently displayed on the browser action.
-     * @param {integer} tabId The id of the tab to set the badge title for.
-     * @param {string} title The value to set the title to.
-     */
-    function setTitleIfNoBadge(tabId, title) {
-      chromeBrowserAction.getBadgeText({tabId: tabId}, function(text) {
-        if (!text) {
-          chromeBrowserAction.setTitle({tabId: tabId, title: title});
-        }
-      });
-    }
+    xhr.open('GET', serviceUrl + '/badge?uri=' + tabUrl);
+    xhr.send();
+  };
+}
 
-    /**
-     * Set the "title" (tooltip) and badge text of the browser action.
-     * @param {integer} tabId The id of the tab to set the badge title for.
-     * @param {string} title The text to show in the tooltip.
-     * @param {string} badgeText The text to show on the badge.
-     */
-    function setTitleAndBadgeText(tabId, title, badgeText) {
-      chromeBrowserAction.setTitle({tabId: tabId, title: title});
-      chromeBrowserAction.setBadgeText({tabId: tabId, text: badgeText});
-    }
+BrowserAction.icons = icons;
 
-    /* Sets the active browser action appearance for the provided tab id. */
-    this.activate = function(tabId) {
-      chromeBrowserAction.setIcon({tabId: tabId, path: icons[states.ACTIVE]});
-      setTitleIfNoBadge(tabId, _('Hypothesis is active'));
-    };
-
-    /* Sets the inactive browser action appearance for the provided tab id. */
-    this.deactivate = function(tabId) {
-      chromeBrowserAction.setIcon({tabId: tabId, path: icons[states.INACTIVE]});
-      setTitleIfNoBadge(tabId, _('Hypothesis is inactive'));
-    };
-
-    /* Sets the errored browser action appearance for the provided tab id. */
-    this.error = function(tabId) {
-      chromeBrowserAction.setIcon({tabId: tabId, path: icons[states.INACTIVE]});
-      setTitleAndBadgeText(tabId,  _('Hypothesis has failed to load'), '!');
-    };
-
-    /**
-     * Show the number of annotations of the current page in the badge.
-     *
-     * @method
-     * @param {integer} tabId The id of the current tab.
-     * @param {string} tabUrl The URL of the current tab.
-     * @param {string} serviceUrl The URL of the Hypothesis API.
-     */
-    this.updateBadge = function(tabId, tabUrl, serviceUrl) {
-      // Fetch the number of annotations of the current page from the server,
-      // and display it as a badge on the browser action button.
-      var xhr = new XMLHttpRequest();
-      xhr.onload = function() {
-        var total;
-
-        try {
-          total = JSON.parse(this.response).total;
-        } catch (e) {
-          console.error(
-            'updateBadge() received invalid JSON from the server: ' + e);
-          return;
-        }
-
-        if (typeof total !== 'number') {
-          console.error(
-            'updateBadge() received invalid total from the server: ' + total);
-          return;
-        }
-
-        if (total > 0) {
-          var totalString = total.toString();
-          if (total > 999) {
-            totalString = '999+';
-          }
-          chromeBrowserAction.getBadgeText({tabId: tabId}, function(text) {
-            // The num. annotations badge is low priority - we only set it if
-            // there's no other badge currently showing.
-            if (!text) {
-              var title;
-              if (total === 1) {
-                title = _("There's 1 annotation on this page");
-              } else {
-                title = _('There are ' + totalString + ' annotations on ' +
-                          'this page');
-              }
-              setTitleAndBadgeText(tabId, title, totalString);
-            }
-          });
-        }
-      };
-
-      xhr.open('GET', serviceUrl + '/badge?uri=' + tabUrl);
-      xhr.send();
-    };
-  }
-
-  BrowserAction.icons = icons;
-
-  h.BrowserAction = BrowserAction;
-})(window.h || (window.h = {}));
+module.exports = BrowserAction;

--- a/h/browser/chrome/lib/browser-action.js
+++ b/h/browser/chrome/lib/browser-action.js
@@ -1,7 +1,9 @@
 'use strict';
 
+var TabState = require('./tab-state');
+
 // Cache the tab state constants.
-var states = h.TabState.states;
+var states = TabState.states;
 
 // Each button state has two icons one for normal resolution (19) and one
 // for hi-res screens (38).

--- a/h/browser/chrome/lib/errors.js
+++ b/h/browser/chrome/lib/errors.js
@@ -1,38 +1,37 @@
-(function (h) {
-  function ExtensionError(message) {
-    Error.apply(this, arguments);
-    this.message = message;
-  }
-  ExtensionError.prototype = Object.create(Error);
+function ExtensionError(message) {
+  Error.apply(this, arguments);
+  this.message = message;
+}
+ExtensionError.prototype = Object.create(Error);
 
-  function LocalFileError(message) {
-    Error.apply(this, arguments);
-    this.message = message;
-  }
-  LocalFileError.prototype = Object.create(ExtensionError);
+function LocalFileError(message) {
+  Error.apply(this, arguments);
+  this.message = message;
+}
+LocalFileError.prototype = Object.create(ExtensionError);
 
-  function NoFileAccessError(message) {
-    Error.apply(this, arguments);
-    this.message = message;
-  }
-  NoFileAccessError.prototype = Object.create(ExtensionError);
+function NoFileAccessError(message) {
+  Error.apply(this, arguments);
+  this.message = message;
+}
+NoFileAccessError.prototype = Object.create(ExtensionError);
 
-  function RestrictedProtocolError(message) {
-    Error.apply(this, arguments);
-    this.message = message;
-  }
-  RestrictedProtocolError.prototype = Object.create(ExtensionError);
+function RestrictedProtocolError(message) {
+  Error.apply(this, arguments);
+  this.message = message;
+}
+RestrictedProtocolError.prototype = Object.create(ExtensionError);
 
-  function BlockedSiteError(message) {
-    Error.apply(this, arguments);
-    this.message = message;
-  }
-  BlockedSiteError.prototype = Object.create(ExtensionError);
+function BlockedSiteError(message) {
+  Error.apply(this, arguments);
+  this.message = message;
+}
+BlockedSiteError.prototype = Object.create(ExtensionError);
 
-  h.ExtensionError = ExtensionError;
-  h.LocalFileError = LocalFileError;
-  h.NoFileAccessError = NoFileAccessError;
-  h.RestrictedProtocolError = RestrictedProtocolError;
-  h.BlockedSiteError = BlockedSiteError;
-
-})(window.h || (window.h = {}));
+module.exports = {
+  ExtensionError: ExtensionError,
+  LocalFileError: LocalFileError,
+  NoFileAccessError: NoFileAccessError,
+  RestrictedProtocolError: RestrictedProtocolError,
+  BlockedSiteError: BlockedSiteError,
+};

--- a/h/browser/chrome/lib/extension.js
+++ b/h/browser/chrome/lib/extension.js
@@ -1,0 +1,2 @@
+require('./hypothesis-chrome-extension');
+require('./install');

--- a/h/browser/chrome/lib/help-page.js
+++ b/h/browser/chrome/lib/help-page.js
@@ -11,11 +11,11 @@ var errors = require('./errors');
  *   https://developer.chrome.com/extensions/extension#method-getURL
  */
 function HelpPage(chromeTabs, extensionURL) {
-  /* Accepts an instance of h.ExtensionError and displays an appropriate
+  /* Accepts an instance of errors.ExtensionError and displays an appropriate
    * help page if one exists.
    *
    * tab   - The tab to display the error message in.
-   * error - An instance of h.ExtensionError.
+   * error - An instance of errors.ExtensionError.
    *
    * Throws an error if no page is available for the action.
    * Returns nothing.

--- a/h/browser/chrome/lib/help-page.js
+++ b/h/browser/chrome/lib/help-page.js
@@ -1,56 +1,54 @@
-(function (h) {
-  'use strict';
+'use strict';
 
-  /* A controller for displaying help pages. These are bound to extension
-   * specific errors (found in errors.js) but can also be triggered manually.
+/* A controller for displaying help pages. These are bound to extension
+ * specific errors (found in errors.js) but can also be triggered manually.
+ *
+ * chromeTabs   - An instance of chrome.tabs.
+ * extensionURL - A function that recieves a path and returns a full path
+ *   to the file inside the chrome extension. See:
+ *   https://developer.chrome.com/extensions/extension#method-getURL
+ */
+function HelpPage(chromeTabs, extensionURL) {
+  /* Accepts an instance of h.ExtensionError and displays an appropriate
+   * help page if one exists.
    *
-   * chromeTabs   - An instance of chrome.tabs.
-   * extensionURL - A function that recieves a path and returns a full path
-   *   to the file inside the chrome extension. See:
-   *   https://developer.chrome.com/extensions/extension#method-getURL
+   * tab   - The tab to display the error message in.
+   * error - An instance of h.ExtensionError.
+   *
+   * Throws an error if no page is available for the action.
+   * Returns nothing.
    */
-  function HelpPage(chromeTabs, extensionURL) {
-    /* Accepts an instance of h.ExtensionError and displays an appropriate
-     * help page if one exists.
-     *
-     * tab   - The tab to display the error message in.
-     * error - An instance of h.ExtensionError.
-     *
-     * Throws an error if no page is available for the action.
-     * Returns nothing.
-     */
-    this.showHelpForError = function (tab, error) {
-      if (error instanceof h.LocalFileError) {
-        return this.showLocalFileHelpPage(tab);
-      }
-      else if (error instanceof h.NoFileAccessError) {
-        return this.showNoFileAccessHelpPage(tab);
-      }
-      else if (error instanceof h.RestrictedProtocolError) {
-        return this.showRestrictedProtocolPage(tab);
-      }
-      else if (error instanceof h.BlockedSiteError) {
-        return this.showBlockedSitePage(tab);
-      }
-
-      throw new Error('showHelpForError does not support the error: ' + error.message);
-    };
-
-    this.showLocalFileHelpPage = showHelpPage.bind(null, 'local-file');
-    this.showNoFileAccessHelpPage = showHelpPage.bind(null, 'no-file-access');
-    this.showRestrictedProtocolPage = showHelpPage.bind(null, 'restricted-protocol');
-    this.showBlockedSitePage = showHelpPage.bind(null, 'blocked-site');
-
-    // Render the help page. The helpSection should correspond to the id of a
-    // section within the help page.
-    function showHelpPage(helpSection, tab) {
-      chromeTabs.create({
-        index: tab.index + 1,
-        url:  extensionURL('/help/index.html#' + helpSection),
-        openerTabId: tab.id,
-      });
+  this.showHelpForError = function (tab, error) {
+    if (error instanceof h.LocalFileError) {
+      return this.showLocalFileHelpPage(tab);
     }
-  }
+    else if (error instanceof h.NoFileAccessError) {
+      return this.showNoFileAccessHelpPage(tab);
+    }
+    else if (error instanceof h.RestrictedProtocolError) {
+      return this.showRestrictedProtocolPage(tab);
+    }
+    else if (error instanceof h.BlockedSiteError) {
+      return this.showBlockedSitePage(tab);
+    }
 
-  h.HelpPage = HelpPage;
-})(window.h || (window.h = {}));
+    throw new Error('showHelpForError does not support the error: ' + error.message);
+  };
+
+  this.showLocalFileHelpPage = showHelpPage.bind(null, 'local-file');
+  this.showNoFileAccessHelpPage = showHelpPage.bind(null, 'no-file-access');
+  this.showRestrictedProtocolPage = showHelpPage.bind(null, 'restricted-protocol');
+  this.showBlockedSitePage = showHelpPage.bind(null, 'blocked-site');
+
+  // Render the help page. The helpSection should correspond to the id of a
+  // section within the help page.
+  function showHelpPage(helpSection, tab) {
+    chromeTabs.create({
+      index: tab.index + 1,
+      url:  extensionURL('/help/index.html#' + helpSection),
+      openerTabId: tab.id,
+    });
+  }
+}
+
+module.exports = HelpPage;

--- a/h/browser/chrome/lib/help-page.js
+++ b/h/browser/chrome/lib/help-page.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var errors = require('./errors');
+
 /* A controller for displaying help pages. These are bound to extension
  * specific errors (found in errors.js) but can also be triggered manually.
  *
@@ -19,16 +21,16 @@ function HelpPage(chromeTabs, extensionURL) {
    * Returns nothing.
    */
   this.showHelpForError = function (tab, error) {
-    if (error instanceof h.LocalFileError) {
+    if (error instanceof errors.LocalFileError) {
       return this.showLocalFileHelpPage(tab);
     }
-    else if (error instanceof h.NoFileAccessError) {
+    else if (error instanceof errors.NoFileAccessError) {
       return this.showNoFileAccessHelpPage(tab);
     }
-    else if (error instanceof h.RestrictedProtocolError) {
+    else if (error instanceof errors.RestrictedProtocolError) {
       return this.showRestrictedProtocolPage(tab);
     }
-    else if (error instanceof h.BlockedSiteError) {
+    else if (error instanceof errors.BlockedSiteError) {
       return this.showBlockedSitePage(tab);
     }
 

--- a/h/browser/chrome/lib/hypothesis-chrome-extension.js
+++ b/h/browser/chrome/lib/hypothesis-chrome-extension.js
@@ -2,7 +2,7 @@ var h = {};
 
 require('core-js/modules/es6.object.assign');
 
-h.TabState = require('./tab-state');
+var TabState = require('./tab-state');
 h.BrowserAction = require('./browser-action');
 Object.assign(h, require('./errors'));
 h.HelpPage = require('./help-page');
@@ -49,7 +49,7 @@ h.TabStore = require('./tab-store');
     var chromeBrowserAction = dependencies.chromeBrowserAction;
     var help  = new h.HelpPage(chromeTabs, dependencies.extensionURL);
     var store = new h.TabStore(localStorage);
-    var state = new h.TabState(store.all(), onTabStateChange);
+    var state = new TabState(store.all(), onTabStateChange);
     var browserAction = new h.BrowserAction(chromeBrowserAction);
     var sidebar = new h.SidebarInjector(chromeTabs, {
       extensionURL: dependencies.extensionURL,
@@ -117,6 +117,9 @@ h.TabStore = require('./tab-store');
         tabErrors.unsetTabError(tabId);
       }
     }
+
+    // exposed for use by tests
+    this._onTabStateChange = onTabStateChange;
 
     function onBrowserActionClicked(tab) {
       var tabError = tabErrors.getTabError(tab.id);
@@ -188,4 +191,4 @@ h.TabStore = require('./tab-store');
   h.HypothesisChromeExtension = HypothesisChromeExtension;
 })(h);
 
-window.h = h;
+module.exports = h.HypothesisChromeExtension;

--- a/h/browser/chrome/lib/hypothesis-chrome-extension.js
+++ b/h/browser/chrome/lib/hypothesis-chrome-extension.js
@@ -1,3 +1,13 @@
+require('./tab-state');
+require('./browser-action');
+require('./errors');
+require('./help-page');
+require('./settings');
+require('../../../static/scripts/blocklist');
+require('./sidebar-injector');
+require('./tab-error-cache');
+require('./tab-store');
+
 (function (h) {
   'use strict';
 

--- a/h/browser/chrome/lib/hypothesis-chrome-extension.js
+++ b/h/browser/chrome/lib/hypothesis-chrome-extension.js
@@ -1,12 +1,16 @@
-require('./tab-state');
-require('./browser-action');
-require('./errors');
-require('./help-page');
-require('./settings');
+window.h = window.h || {};
+
+require('core-js/modules/es6.object.assign');
+
+h.TabState = require('./tab-state');
+h.BrowserAction = require('./browser-action');
+Object.assign(h, require('./errors'));
+h.HelpPage = require('./help-page');
+h.settings = require('./settings');
 require('../../../static/scripts/blocklist');
-require('./sidebar-injector');
-require('./tab-error-cache');
-require('./tab-store');
+h.SidebarInjector = require('./sidebar-injector');
+h.TabErrorCache = require('./tab-error-cache');
+h.TabStore = require('./tab-store');
 
 (function (h) {
   'use strict';
@@ -182,4 +186,4 @@ require('./tab-store');
   }
 
   h.HypothesisChromeExtension = HypothesisChromeExtension;
-})(window.h || (window.h = {}));
+})(h);

--- a/h/browser/chrome/lib/hypothesis-chrome-extension.js
+++ b/h/browser/chrome/lib/hypothesis-chrome-extension.js
@@ -1,4 +1,4 @@
-window.h = window.h || {};
+var h = {};
 
 require('core-js/modules/es6.object.assign');
 
@@ -187,3 +187,5 @@ h.TabStore = require('./tab-store');
 
   h.HypothesisChromeExtension = HypothesisChromeExtension;
 })(h);
+
+window.h = h;

--- a/h/browser/chrome/lib/hypothesis-chrome-extension.js
+++ b/h/browser/chrome/lib/hypothesis-chrome-extension.js
@@ -1,194 +1,184 @@
-var h = {};
-
-require('core-js/modules/es6.object.assign');
+'use strict';
 
 var TabState = require('./tab-state');
-h.BrowserAction = require('./browser-action');
-Object.assign(h, require('./errors'));
-h.HelpPage = require('./help-page');
-h.settings = require('./settings');
-require('../../../static/scripts/blocklist');
-h.SidebarInjector = require('./sidebar-injector');
-h.TabErrorCache = require('./tab-error-cache');
-h.TabStore = require('./tab-store');
+var BrowserAction = require('./browser-action');
+var HelpPage = require('./help-page');
+var settings = require('./settings');
+var SidebarInjector = require('./sidebar-injector');
+var TabErrorCache = require('./tab-error-cache');
+var TabStore = require('./tab-store');
 
-(function (h) {
-  'use strict';
+var TAB_STATUS_COMPLETE = 'complete';
 
-  var TAB_STATUS_COMPLETE = 'complete';
+/* The main extension application. This wires together all the smaller
+ * modules. The app listens to all new created/updated/removed tab events
+ * and uses the TabState object to keep track of whether the sidebar is
+ * active or inactive in the tab. The app also listens to click events on
+ * the browser action and toggles the state and uses the BrowserAction module
+ * to update the visual style of the button.
+ *
+ * The SidebarInjector handles the insertion of the Hypothesis code. If it
+ * runs into errors the tab is put into an errored state and when the
+ * browser aciton is clicked again the HelpPage module displays more
+ * information to the user.
+ *
+ * Lastly the TabStore listens to changes to the TabState module and persists
+ * the current settings to localStorage. This is then loaded into the
+ * application on startup.
+ *
+ * Relevant Chrome Extension documentation:
+ * - https://developer.chrome.com/extensions/browserAction
+ * - https://developer.chrome.com/extensions/tabs
+ * - https://developer.chrome.com/extensions/extension
+ *
+ * dependencies - An object to set up the application.
+ *   chromeTabs: An instance of chrome.tabs.
+ *   chromeBrowserAction: An instance of chrome.browserAction.
+ *   extensionURL: chrome.extension.getURL.
+ *   isAllowedFileSchemeAccess: chrome.extension.isAllowedFileSchemeAccess.
+ */
+function HypothesisChromeExtension(dependencies) {
+  var chromeTabs = dependencies.chromeTabs;
+  var chromeBrowserAction = dependencies.chromeBrowserAction;
+  var help  = new HelpPage(chromeTabs, dependencies.extensionURL);
+  var store = new TabStore(localStorage);
+  var state = new TabState(store.all(), onTabStateChange);
+  var browserAction = new BrowserAction(chromeBrowserAction);
+  var sidebar = new SidebarInjector(chromeTabs, {
+    extensionURL: dependencies.extensionURL,
+    isAllowedFileSchemeAccess: dependencies.isAllowedFileSchemeAccess,
+  });
+  var tabErrors = new TabErrorCache();
 
-  /* The main extension application. This wires together all the smaller
-   * modules. The app listens to all new created/updated/removed tab events
-   * and uses the TabState object to keep track of whether the sidebar is
-   * active or inactive in the tab. The app also listens to click events on
-   * the browser action and toggles the state and uses the BrowserAction module
-   * to update the visual style of the button.
-   *
-   * The SidebarInjector handles the insertion of the Hypothesis code. If it
-   * runs into errors the tab is put into an errored state and when the
-   * browser aciton is clicked again the HelpPage module displays more
-   * information to the user.
-   *
-   * Lastly the TabStore listens to changes to the TabState module and persists
-   * the current settings to localStorage. This is then loaded into the
-   * application on startup.
-   *
-   * Relevant Chrome Extension documentation:
-   * - https://developer.chrome.com/extensions/browserAction
-   * - https://developer.chrome.com/extensions/tabs
-   * - https://developer.chrome.com/extensions/extension
-   *
-   * dependencies - An object to set up the application.
-   *   chromeTabs: An instance of chrome.tabs.
-   *   chromeBrowserAction: An instance of chrome.browserAction.
-   *   extensionURL: chrome.extension.getURL.
-   *   isAllowedFileSchemeAccess: chrome.extension.isAllowedFileSchemeAccess.
+  /* Sets up the extension and binds event listeners. Requires a window
+   * object to be passed so that it can listen for localStorage events.
    */
-  function HypothesisChromeExtension(dependencies) {
-    var chromeTabs = dependencies.chromeTabs;
-    var chromeBrowserAction = dependencies.chromeBrowserAction;
-    var help  = new h.HelpPage(chromeTabs, dependencies.extensionURL);
-    var store = new h.TabStore(localStorage);
-    var state = new TabState(store.all(), onTabStateChange);
-    var browserAction = new h.BrowserAction(chromeBrowserAction);
-    var sidebar = new h.SidebarInjector(chromeTabs, {
-      extensionURL: dependencies.extensionURL,
-      isAllowedFileSchemeAccess: dependencies.isAllowedFileSchemeAccess,
+  this.listen = function (window) {
+    chromeBrowserAction.onClicked.addListener(onBrowserActionClicked);
+    chromeTabs.onCreated.addListener(onTabCreated);
+    chromeTabs.onUpdated.addListener(onTabUpdated);
+    chromeTabs.onRemoved.addListener(onTabRemoved);
+
+    // FIXME: Find out why we used to reload the data on every get.
+    window.addEventListener('storage', function (event) {
+      var key = 'state';
+      var isState = event.key === key;
+      var isUpdate = event.newValue !== null;
+
+      // Check the event is for the store and check that something has
+      // actually changed externally by validating the new value.
+      if (isState && isUpdate && event.newValue !== JSON.stringify(store.all())) {
+        store.reload();
+        state.load(store.all());
+      }
     });
-    var tabErrors = new h.TabErrorCache();
+  };
 
-    /* Sets up the extension and binds event listeners. Requires a window
-     * object to be passed so that it can listen for localStorage events.
-     */
-    this.listen = function (window) {
-      chromeBrowserAction.onClicked.addListener(onBrowserActionClicked);
-      chromeTabs.onCreated.addListener(onTabCreated);
-      chromeTabs.onUpdated.addListener(onTabUpdated);
-      chromeTabs.onRemoved.addListener(onTabRemoved);
-
-      // FIXME: Find out why we used to reload the data on every get.
-      window.addEventListener('storage', function (event) {
-        var key = 'state';
-        var isState = event.key === key;
-        var isUpdate = event.newValue !== null;
-
-        // Check the event is for the store and check that something has
-        // actually changed externally by validating the new value.
-        if (isState && isUpdate && event.newValue !== JSON.stringify(store.all())) {
-          store.reload();
-          state.load(store.all());
+  /* A method that can be used to setup the extension on existing tabs
+   * when the extension is installed.
+   */
+  this.install = function () {
+    chromeTabs.query({}, function (tabs) {
+      tabs.forEach(function (tab) {
+        if (state.isTabActive(tab.id)) {
+          state.activateTab(tab.id, {force: true});
+        } else {
+          state.deactivateTab(tab.id, {force: true});
         }
       });
-    };
+    });
+  };
 
-    /* A method that can be used to setup the extension on existing tabs
-     * when the extension is installed.
-     */
-    this.install = function () {
-      chromeTabs.query({}, function (tabs) {
-        tabs.forEach(function (tab) {
-          if (state.isTabActive(tab.id)) {
-            state.activateTab(tab.id, {force: true});
-          } else {
-            state.deactivateTab(tab.id, {force: true});
-          }
-        });
-      });
-    };
+  /* Opens the onboarding page */
+  this.firstRun = function () {
+    chromeTabs.create({url: 'https://hypothes.is/welcome'}, function (tab) {
+      state.activateTab(tab.id);
+    });
+  };
 
-    /* Opens the onboarding page */
-    this.firstRun = function () {
-      chromeTabs.create({url: 'https://hypothes.is/welcome'}, function (tab) {
-        state.activateTab(tab.id);
-      });
-    };
+  function onTabStateChange(tabId, current, previous) {
+    if (current) {
+      browserAction.setState(tabId, current);
 
-    function onTabStateChange(tabId, current, previous) {
-      if (current) {
-        browserAction.setState(tabId, current);
-
-        if (!state.isTabErrored(tabId)) {
-          store.set(tabId, current);
-          tabErrors.unsetTabError(tabId);
-          chromeTabs.get(tabId, updateTabDocument);
-        }
-      } else {
-        store.unset(tabId);
+      if (!state.isTabErrored(tabId)) {
+        store.set(tabId, current);
         tabErrors.unsetTabError(tabId);
+        chromeTabs.get(tabId, updateTabDocument);
       }
-    }
-
-    // exposed for use by tests
-    this._onTabStateChange = onTabStateChange;
-
-    function onBrowserActionClicked(tab) {
-      var tabError = tabErrors.getTabError(tab.id);
-      if (state.isTabErrored(tab.id) && tabError) {
-        help.showHelpForError(tab, tabError);
-      }
-      else if (state.isTabActive(tab.id)) {
-        state.deactivateTab(tab.id);
-      }
-      else {
-        state.activateTab(tab.id);
-      }
-    }
-
-    function onTabUpdated(tabId, changeInfo, tab) {
-      // This function will be called multiple times as the tab reloads.
-      // https://developer.chrome.com/extensions/tabs#event-onUpdated
-      if (changeInfo.status !== TAB_STATUS_COMPLETE) {
-        return;
-      }
-
-      if (state.isTabErrored(tabId)) {
-        state.restorePreviousState(tabId);
-      }
-
-      if (state.isTabActive(tabId)) {
-        browserAction.activate(tabId);
-      } else {
-        // Clear the state to express that the user has no preference.
-        // This allows the publisher embed to persist without us destroying it.
-        state.clearTab(tabId);
-        browserAction.deactivate(tabId);
-      }
-
-      h.settings.then(function(settings) {
-        browserAction.updateBadge(tabId, tab.url, settings.serviceUrl);
-      });
-
-      return updateTabDocument(tab);
-    }
-
-    function onTabCreated(tab) {
-      // Clear the state in case there is old, conflicting data in storage.
-      state.clearTab(tab.id);
-    }
-
-    function onTabRemoved(tabId) {
-      state.clearTab(tabId);
-    }
-
-    function updateTabDocument(tab) {
-      // If the tab has not yet finished loading then just quietly return.
-      if (tab.status !== TAB_STATUS_COMPLETE) {
-        return Promise.resolve();
-      }
-
-      if (state.isTabActive(tab.id)) {
-        return sidebar.injectIntoTab(tab).catch(function (err) {
-          tabErrors.setTabError(tab.id, err);
-          state.errorTab(tab.id);
-        });
-      }
-      else if (state.isTabInactive(tab.id)) {
-        return sidebar.removeFromTab(tab);
-      }
+    } else {
+      store.unset(tabId);
+      tabErrors.unsetTabError(tabId);
     }
   }
 
-  h.HypothesisChromeExtension = HypothesisChromeExtension;
-})(h);
+  // exposed for use by tests
+  this._onTabStateChange = onTabStateChange;
 
-module.exports = h.HypothesisChromeExtension;
+  function onBrowserActionClicked(tab) {
+    var tabError = tabErrors.getTabError(tab.id);
+    if (state.isTabErrored(tab.id) && tabError) {
+      help.showHelpForError(tab, tabError);
+    }
+    else if (state.isTabActive(tab.id)) {
+      state.deactivateTab(tab.id);
+    }
+    else {
+      state.activateTab(tab.id);
+    }
+  }
+
+  function onTabUpdated(tabId, changeInfo, tab) {
+    // This function will be called multiple times as the tab reloads.
+    // https://developer.chrome.com/extensions/tabs#event-onUpdated
+    if (changeInfo.status !== TAB_STATUS_COMPLETE) {
+      return;
+    }
+
+    if (state.isTabErrored(tabId)) {
+      state.restorePreviousState(tabId);
+    }
+
+    if (state.isTabActive(tabId)) {
+      browserAction.activate(tabId);
+    } else {
+      // Clear the state to express that the user has no preference.
+      // This allows the publisher embed to persist without us destroying it.
+      state.clearTab(tabId);
+      browserAction.deactivate(tabId);
+    }
+
+    settings.then(function(settings) {
+      browserAction.updateBadge(tabId, tab.url, settings.serviceUrl);
+    });
+
+    return updateTabDocument(tab);
+  }
+
+  function onTabCreated(tab) {
+    // Clear the state in case there is old, conflicting data in storage.
+    state.clearTab(tab.id);
+  }
+
+  function onTabRemoved(tabId) {
+    state.clearTab(tabId);
+  }
+
+  function updateTabDocument(tab) {
+    // If the tab has not yet finished loading then just quietly return.
+    if (tab.status !== TAB_STATUS_COMPLETE) {
+      return Promise.resolve();
+    }
+
+    if (state.isTabActive(tab.id)) {
+      return sidebar.injectIntoTab(tab).catch(function (err) {
+        tabErrors.setTabError(tab.id, err);
+        state.errorTab(tab.id);
+      });
+    }
+    else if (state.isTabInactive(tab.id)) {
+      return sidebar.removeFromTab(tab);
+    }
+  }
+}
+
+module.exports = HypothesisChromeExtension;

--- a/h/browser/chrome/lib/install.js
+++ b/h/browser/chrome/lib/install.js
@@ -1,43 +1,43 @@
-(function () {
-  'use strict';
+'use strict';
 
-  var browserExtension = new h.HypothesisChromeExtension({
-    chromeTabs: chrome.tabs,
-    chromeBrowserAction: chrome.browserAction,
-    extensionURL: function (path) {
-      return chrome.extension.getURL(path);
-    },
-    isAllowedFileSchemeAccess: function (fn) {
-      return chrome.extension.isAllowedFileSchemeAccess(fn);
-    },
-  });
+var HypothesisChromeExtension = require('./hypothesis-chrome-extension');
 
-  browserExtension.listen(window);
-  chrome.runtime.onInstalled.addListener(onInstalled);
-  chrome.runtime.requestUpdateCheck(function (status) {
-    chrome.runtime.onUpdateAvailable.addListener(onUpdateAvailable);
-  });
+var browserExtension = new HypothesisChromeExtension({
+  chromeTabs: chrome.tabs,
+  chromeBrowserAction: chrome.browserAction,
+  extensionURL: function (path) {
+    return chrome.extension.getURL(path);
+  },
+  isAllowedFileSchemeAccess: function (fn) {
+    return chrome.extension.isAllowedFileSchemeAccess(fn);
+  },
+});
 
-  function onInstalled(installDetails) {
-    if (installDetails.reason === 'install') {
-      browserExtension.firstRun();
-    }
+browserExtension.listen(window);
+chrome.runtime.onInstalled.addListener(onInstalled);
+chrome.runtime.requestUpdateCheck(function (status) {
+  chrome.runtime.onUpdateAvailable.addListener(onUpdateAvailable);
+});
 
-    // We need this so that 3rd party cookie blocking does not kill us.
-    // See https://github.com/hypothesis/h/issues/634 for more info.
-    // This is intended to be a temporary fix only.
-    var details = {
-      primaryPattern: 'https://hypothes.is/*',
-      setting: 'allow'
-    };
-    chrome.contentSettings.cookies.set(details);
-    chrome.contentSettings.images.set(details);
-    chrome.contentSettings.javascript.set(details);
-
-    browserExtension.install();
+function onInstalled(installDetails) {
+  if (installDetails.reason === 'install') {
+    browserExtension.firstRun();
   }
 
-  function onUpdateAvailable() {
-    chrome.runtime.reload();
-  }
-})();
+  // We need this so that 3rd party cookie blocking does not kill us.
+  // See https://github.com/hypothesis/h/issues/634 for more info.
+  // This is intended to be a temporary fix only.
+  var details = {
+    primaryPattern: 'https://hypothes.is/*',
+    setting: 'allow'
+  };
+  chrome.contentSettings.cookies.set(details);
+  chrome.contentSettings.images.set(details);
+  chrome.contentSettings.javascript.set(details);
+
+  browserExtension.install();
+}
+
+function onUpdateAvailable() {
+  chrome.runtime.reload();
+}

--- a/h/browser/chrome/lib/settings.js
+++ b/h/browser/chrome/lib/settings.js
@@ -4,43 +4,39 @@
  */
 'use strict';
 
-(function(h) {
+/**
+ * Validate and normalize the given settings data.
+ *
+ * @param {Object} settings The settings from the settings.json file.
+ */
+function normalizeSettings(settings) {
 
-  /**
-   * Validate and normalize the given settings data.
-   *
-   * @param {Object} settings The settings from the settings.json file.
-   */
-  function normalizeSettings(settings) {
-
-    // Make sure that serviceUrl does not end with a /.
-    if (settings.serviceUrl.charAt(settings.serviceUrl.length - 1) === '/') {
-      settings.serviceUrl = settings.serviceUrl.slice(0, -1);
-    }
-
+  // Make sure that serviceUrl does not end with a /.
+  if (settings.serviceUrl.charAt(settings.serviceUrl.length - 1) === '/') {
+    settings.serviceUrl = settings.serviceUrl.slice(0, -1);
   }
 
-  function getSettings() {
-    return new Promise(function(resolve, reject) {
-      var request = new XMLHttpRequest();
-      request.onload = function() {
-        var settings = JSON.parse(this.responseText);
-        normalizeSettings(settings);
-        resolve(settings);
-      };
-      request.open('GET', '/settings.json');
-      request.send(null);
-    });
-  }
+}
 
-  /**
-   * A Promise whose value is the contents of the settings.json file.
-   *
-   * @example
-   * h.settings.then(function(settings) {
-   *   // Do something with the settings object.
-   * });
-   */
-  h.settings = getSettings();
+function getSettings() {
+  return new Promise(function(resolve, reject) {
+    var request = new XMLHttpRequest();
+    request.onload = function() {
+      var settings = JSON.parse(this.responseText);
+      normalizeSettings(settings);
+      resolve(settings);
+    };
+    request.open('GET', '/settings.json');
+    request.send(null);
+  });
+}
 
-})(window.h || (window.h = {}));
+/**
+ * A Promise whose value is the contents of the settings.json file.
+ *
+ * @example
+ * h.settings.then(function(settings) {
+ *   // Do something with the settings object.
+ * });
+ */
+module.exports = getSettings();

--- a/h/browser/chrome/lib/settings.js
+++ b/h/browser/chrome/lib/settings.js
@@ -35,7 +35,7 @@ function getSettings() {
  * A Promise whose value is the contents of the settings.json file.
  *
  * @example
- * h.settings.then(function(settings) {
+ * settings.then(function(settings) {
  *   // Do something with the settings object.
  * });
  */

--- a/h/browser/chrome/lib/sidebar-injector.js
+++ b/h/browser/chrome/lib/sidebar-injector.js
@@ -1,172 +1,170 @@
-(function (h) {
-  'use strict';
+'use strict';
 
-  /* The SidebarInjector is used to deploy and remove the Hypothesis sidebar
-   * from tabs. It also deals with loading PDF documents into the PDF.js viewer
-   * when applicable.
+/* The SidebarInjector is used to deploy and remove the Hypothesis sidebar
+ * from tabs. It also deals with loading PDF documents into the PDF.js viewer
+ * when applicable.
+ *
+ * chromeTabs - An instance of chrome.tabs.
+ * dependencies - An object with additional helper methods.
+ *   isAllowedFileSchemeAccess: A function that returns true if the user
+ *   can access resources over the file:// protocol. See:
+ *   https://developer.chrome.com/extensions/extension#method-isAllowedFileSchemeAccess
+ *   extensionURL: A function that receives a path and returns an absolute
+ *   url. See: https://developer.chrome.com/extensions/extension#method-getURL
+ */
+function SidebarInjector(chromeTabs, dependencies) {
+  dependencies = dependencies || {};
+
+  var isAllowedFileSchemeAccess = dependencies.isAllowedFileSchemeAccess;
+  var extensionURL = dependencies.extensionURL;
+
+  if (typeof extensionURL !== 'function') {
+    throw new TypeError('extensionURL must be a function');
+  }
+
+  if (typeof isAllowedFileSchemeAccess !== 'function') {
+    throw new TypeError('isAllowedFileSchemeAccess must be a function');
+  }
+
+  /* Injects the Hypothesis sidebar into the tab provided.
    *
-   * chromeTabs - An instance of chrome.tabs.
-   * dependencies - An object with additional helper methods.
-   *   isAllowedFileSchemeAccess: A function that returns true if the user
-   *   can access resources over the file:// protocol. See:
-   *   https://developer.chrome.com/extensions/extension#method-isAllowedFileSchemeAccess
-   *   extensionURL: A function that receives a path and returns an absolute
-   *   url. See: https://developer.chrome.com/extensions/extension#method-getURL
+   * tab - A tab object representing the tab to insert the sidebar into.
+   *
+   * Returns a promise that will be resolved if the injection succeeded
+   * otherwise it will be rejected with an error.
    */
-  function SidebarInjector(chromeTabs, dependencies) {
-    dependencies = dependencies || {};
-
-    var isAllowedFileSchemeAccess = dependencies.isAllowedFileSchemeAccess;
-    var extensionURL = dependencies.extensionURL;
-
-    if (typeof extensionURL !== 'function') {
-      throw new TypeError('extensionURL must be a function');
-    }
-
-    if (typeof isAllowedFileSchemeAccess !== 'function') {
-      throw new TypeError('isAllowedFileSchemeAccess must be a function');
-    }
-
-    /* Injects the Hypothesis sidebar into the tab provided.
-     *
-     * tab - A tab object representing the tab to insert the sidebar into.
-     *
-     * Returns a promise that will be resolved if the injection succeeded
-     * otherwise it will be rejected with an error.
-     */
-    this.injectIntoTab = function(tab) {
-      return h.settings.then(function(settings) {
-        if (h.blocklist.isBlocked(tab.url, settings.blocklist)) {
-          return Promise.reject(new h.BlockedSiteError(
-            "Hypothesis doesn't work on this site yet."));
-        }
-
-        if (isFileURL(tab.url)) {
-          return injectIntoLocalDocument(tab);
-        } else {
-          return injectIntoRemoteDocument(tab);
-        }
-      });
-    };
-
-    /* Removes the Hypothesis sidebar from the tab provided.
-     *
-     * tab - A tab object representing the tab to remove the sidebar from.
-     *
-     * Returns a promise that will be resolved if the removal succeeded
-     * otherwise it will be rejected with an error.
-     */
-    this.removeFromTab = function (tab) {
-      if (isPDFViewerURL(tab.url)) {
-        return removeFromPDF(tab);
-      } else {
-        return removeFromHTML(tab);
+  this.injectIntoTab = function(tab) {
+    return h.settings.then(function(settings) {
+      if (h.blocklist.isBlocked(tab.url, settings.blocklist)) {
+        return Promise.reject(new h.BlockedSiteError(
+          "Hypothesis doesn't work on this site yet."));
       }
-    };
 
-    function getPDFViewerURL(url) {
-      var PDF_VIEWER_URL = extensionURL('/content/web/viewer.html');
-      return PDF_VIEWER_URL + '?file=' + encodeURIComponent(url);
-    }
-
-    function isPDFURL(url) {
-      return url.toLowerCase().indexOf('.pdf') > 0;
-    }
-
-    function isPDFViewerURL(url) {
-      return url.indexOf(getPDFViewerURL('')) === 0;
-    }
-
-    function isFileURL(url) {
-      return url.indexOf("file:") === 0;
-    }
-
-    function isSupportedURL(url) {
-      var SUPPORTED_PROTOCOLS = ['http:', 'https:', 'ftp:'];
-      return SUPPORTED_PROTOCOLS.some(function (protocol) {
-        return url.indexOf(protocol) === 0;
-      });
-    }
-
-    function injectIntoLocalDocument(tab) {
-      if (isPDFURL(tab.url)) {
-        return injectIntoLocalPDF(tab);
+      if (isFileURL(tab.url)) {
+        return injectIntoLocalDocument(tab);
       } else {
-        return Promise.reject(new h.LocalFileError('Local non-PDF files are not supported'));
+        return injectIntoRemoteDocument(tab);
       }
+    });
+  };
+
+  /* Removes the Hypothesis sidebar from the tab provided.
+   *
+   * tab - A tab object representing the tab to remove the sidebar from.
+   *
+   * Returns a promise that will be resolved if the removal succeeded
+   * otherwise it will be rejected with an error.
+   */
+  this.removeFromTab = function (tab) {
+    if (isPDFViewerURL(tab.url)) {
+      return removeFromPDF(tab);
+    } else {
+      return removeFromHTML(tab);
     }
+  };
 
-    function injectIntoRemoteDocument(tab) {
-      return isPDFURL(tab.url) ? injectIntoPDF(tab) : injectIntoHTML(tab);
-    }
+  function getPDFViewerURL(url) {
+    var PDF_VIEWER_URL = extensionURL('/content/web/viewer.html');
+    return PDF_VIEWER_URL + '?file=' + encodeURIComponent(url);
+  }
 
-    function injectIntoPDF(tab) {
-      return new Promise(function (resolve, reject) {
-        if (!isPDFViewerURL(tab.url)) {
-          chromeTabs.update(tab.id, {url: getPDFViewerURL(tab.url)}, function () {
-            resolve();
-          });
-        } else {
-          resolve();
-        }
-      });
-    }
+  function isPDFURL(url) {
+    return url.toLowerCase().indexOf('.pdf') > 0;
+  }
 
-    function injectIntoLocalPDF(tab) {
-      return new Promise(function (resolve, reject) {
-        isAllowedFileSchemeAccess(function (isAllowed) {
-          if (isAllowed) {
-            resolve(injectIntoPDF(tab));
-          } else {
-            reject(new h.NoFileAccessError('Local file scheme access denied'));
-          }
-        });
-      });
-    }
+  function isPDFViewerURL(url) {
+    return url.indexOf(getPDFViewerURL('')) === 0;
+  }
 
-    function injectIntoHTML(tab) {
-      return new Promise(function (resolve, reject) {
-        if (!isSupportedURL(tab.url)) {
-          var protocol = tab.url.split(':')[0];
-          return reject(new h.RestrictedProtocolError('Cannot load Hypothesis into ' + protocol + ' pages'));
-        }
+  function isFileURL(url) {
+    return url.indexOf("file:") === 0;
+  }
 
-        return injectScript(tab.id, '/public/config.js').then(function () {
-          injectScript(tab.id, '/public/embed.js').then(resolve);
-        });
-      });
-    }
+  function isSupportedURL(url) {
+    var SUPPORTED_PROTOCOLS = ['http:', 'https:', 'ftp:'];
+    return SUPPORTED_PROTOCOLS.some(function (protocol) {
+      return url.indexOf(protocol) === 0;
+    });
+  }
 
-    function removeFromPDF(tab) {
-      return new Promise(function (resolve) {
-        var url = tab.url.slice(getPDFViewerURL('').length).split('#')[0];
-        chromeTabs.update(tab.id, {
-          url: decodeURIComponent(url)
-        }, resolve);
-      });
-    }
-
-    function removeFromHTML(tab) {
-      return new Promise(function (resolve, reject) {
-        if (!isSupportedURL(tab.url)) {
-          return resolve();
-        }
-        injectScript(tab.id, '/public/destroy.js').then(resolve);
-      });
-    }
-
-    function injectScript(tabId, path) {
-      return new Promise(function (resolve) {
-        var src  = extensionURL(path);
-        var code = 'var script = document.createElement("script");' +
-          'script.src = "{}";' +
-          'document.body.appendChild(script);';
-        var code = code.replace('{}', src);
-
-        chromeTabs.executeScript(tabId, {code: code}, resolve);
-      });
+  function injectIntoLocalDocument(tab) {
+    if (isPDFURL(tab.url)) {
+      return injectIntoLocalPDF(tab);
+    } else {
+      return Promise.reject(new h.LocalFileError('Local non-PDF files are not supported'));
     }
   }
 
-  h.SidebarInjector = SidebarInjector;
-})(window.h || (window.h = {}));
+  function injectIntoRemoteDocument(tab) {
+    return isPDFURL(tab.url) ? injectIntoPDF(tab) : injectIntoHTML(tab);
+  }
+
+  function injectIntoPDF(tab) {
+    return new Promise(function (resolve, reject) {
+      if (!isPDFViewerURL(tab.url)) {
+        chromeTabs.update(tab.id, {url: getPDFViewerURL(tab.url)}, function () {
+          resolve();
+        });
+      } else {
+        resolve();
+      }
+    });
+  }
+
+  function injectIntoLocalPDF(tab) {
+    return new Promise(function (resolve, reject) {
+      isAllowedFileSchemeAccess(function (isAllowed) {
+        if (isAllowed) {
+          resolve(injectIntoPDF(tab));
+        } else {
+          reject(new h.NoFileAccessError('Local file scheme access denied'));
+        }
+      });
+    });
+  }
+
+  function injectIntoHTML(tab) {
+    return new Promise(function (resolve, reject) {
+      if (!isSupportedURL(tab.url)) {
+        var protocol = tab.url.split(':')[0];
+        return reject(new h.RestrictedProtocolError('Cannot load Hypothesis into ' + protocol + ' pages'));
+      }
+
+      return injectScript(tab.id, '/public/config.js').then(function () {
+        injectScript(tab.id, '/public/embed.js').then(resolve);
+      });
+    });
+  }
+
+  function removeFromPDF(tab) {
+    return new Promise(function (resolve) {
+      var url = tab.url.slice(getPDFViewerURL('').length).split('#')[0];
+      chromeTabs.update(tab.id, {
+        url: decodeURIComponent(url)
+      }, resolve);
+    });
+  }
+
+  function removeFromHTML(tab) {
+    return new Promise(function (resolve, reject) {
+      if (!isSupportedURL(tab.url)) {
+        return resolve();
+      }
+      injectScript(tab.id, '/public/destroy.js').then(resolve);
+    });
+  }
+
+  function injectScript(tabId, path) {
+    return new Promise(function (resolve) {
+      var src  = extensionURL(path);
+      var code = 'var script = document.createElement("script");' +
+        'script.src = "{}";' +
+        'document.body.appendChild(script);';
+      var code = code.replace('{}', src);
+
+      chromeTabs.executeScript(tabId, {code: code}, resolve);
+    });
+  }
+}
+
+module.exports = SidebarInjector;

--- a/h/browser/chrome/lib/tab-error-cache.js
+++ b/h/browser/chrome/lib/tab-error-cache.js
@@ -1,25 +1,23 @@
-(function (h) {
-  'use strict';
+'use strict';
 
-  /* A wrapper around an Object for storing and retrieving error objects
-   * created when trying to inject the Sidebar into the document. This
-   * primarily exists to simplify the testing of the error handling. As
-   * the setters/getters can easily be stubbed.
-   */
-  function TabErrorCache() {
-    var cache = {};
+/* A wrapper around an Object for storing and retrieving error objects
+ * created when trying to inject the Sidebar into the document. This
+ * primarily exists to simplify the testing of the error handling. As
+ * the setters/getters can easily be stubbed.
+ */
+function TabErrorCache() {
+  var cache = {};
 
-    this.getTabError = function (tabId, err) {
-      return cache[tabId] || null;
-    };
+  this.getTabError = function (tabId, err) {
+    return cache[tabId] || null;
+  };
 
-    this.setTabError = function (tabId, err) {
-      cache[tabId] = err;
-    };
+  this.setTabError = function (tabId, err) {
+    cache[tabId] = err;
+  };
 
-    this.unsetTabError = function (tabId) {
-      delete cache[tabId];
-    };
-  }
-  h.TabErrorCache = TabErrorCache;
-})(window.h || (window.h = {}));
+  this.unsetTabError = function (tabId) {
+    delete cache[tabId];
+  };
+}
+module.exports = TabErrorCache;

--- a/h/browser/chrome/lib/tab-state.js
+++ b/h/browser/chrome/lib/tab-state.js
@@ -1,96 +1,94 @@
-(function (h) {
-  'use strict';
+'use strict';
 
-  var states = {
-    ACTIVE:   'active',
-    INACTIVE: 'inactive',
-    ERRORED:  'errored',
+var states = {
+  ACTIVE:   'active',
+  INACTIVE: 'inactive',
+  ERRORED:  'errored',
+};
+
+/* Manages the state of the browser action button to ensure that it displays
+ * correctly for the currently active tab. An onchange callback will be
+ * called when the extension changes state. This will be provided
+ * with the tabId, the current and previous states.
+ *
+ * Each state has a method to enable it such as activateTab() and a method
+ * to query the current state such as isTabActive().
+ *
+ * initialState - An Object of tabId/state keys. Used when loading state
+ *   from a persisted store such as localStorage.
+ * onchange     - A function that recieves onchange(tabId, current, prev).
+ */
+function TabState(initialState, onchange) {
+  var _this = this;
+  var currentState;
+  var previousState;
+
+  this.onchange = onchange || null;
+
+  /* Replaces the entire state of the object with a new one.
+   *
+   * newState - An object of tabId/state pairs.
+   *
+   * Returns nothing.
+   */
+  this.load = function (newState) {
+    previousState = currentState || {};
+    currentState = newState;
   };
 
-  /* Manages the state of the browser action button to ensure that it displays
-   * correctly for the currently active tab. An onchange callback will be
-   * called when the extension changes state. This will be provided
-   * with the tabId, the current and previous states.
-   *
-   * Each state has a method to enable it such as activateTab() and a method
-   * to query the current state such as isTabActive().
-   *
-   * initialState - An Object of tabId/state keys. Used when loading state
-   *   from a persisted store such as localStorage.
-   * onchange     - A function that recieves onchange(tabId, current, prev).
-   */
-  function TabState(initialState, onchange) {
-    var _this = this;
-    var currentState;
-    var previousState;
+  this.activateTab = function (tabId, options) {
+    transition(tabId, states.ACTIVE, options);
+  };
 
-    this.onchange = onchange || null;
+  this.deactivateTab = function (tabId, options) {
+    transition(tabId, states.INACTIVE, options);
+  };
 
-    /* Replaces the entire state of the object with a new one.
-     *
-     * newState - An object of tabId/state pairs.
-     *
-     * Returns nothing.
-     */
-    this.load = function (newState) {
-      previousState = currentState || {};
-      currentState = newState;
-    };
+  this.errorTab = function (tabId, options) {
+    transition(tabId, states.ERRORED, options);
+  };
 
-    this.activateTab = function (tabId, options) {
-      transition(tabId, states.ACTIVE, options);
-    };
+  this.clearTab = function (tabId) {
+    transition(tabId, null);
+  };
 
-    this.deactivateTab = function (tabId, options) {
-      transition(tabId, states.INACTIVE, options);
-    };
+  this.restorePreviousState = function (tabId) {
+    transition(tabId, previousState[tabId], this.onchange);
+  };
 
-    this.errorTab = function (tabId, options) {
-      transition(tabId, states.ERRORED, options);
-    };
+  this.isTabActive = function (tabId) {
+    return currentState[tabId] === states.ACTIVE;
+  };
 
-    this.clearTab = function (tabId) {
-      transition(tabId, null);
-    };
+  this.isTabInactive = function (tabId) {
+    return currentState[tabId] === states.INACTIVE;
+  };
 
-    this.restorePreviousState = function (tabId) {
-      transition(tabId, previousState[tabId], this.onchange);
-    };
+  this.isTabErrored = function (tabId) {
+    return currentState[tabId] === states.ERRORED;
+  };
 
-    this.isTabActive = function (tabId) {
-      return currentState[tabId] === states.ACTIVE;
-    };
+  // options.force allows the caller to re-trigger an onchange event for
+  // the current state without modifying the previous state. This is useful
+  // for restoring tab state after the extension is reloaded.
+  function transition (tabId, state, options) {
+    var isForced = !!options && options.force === true;
+    var hasChanged = state !== currentState[tabId];
+    if (!isForced && !hasChanged) { return; }
 
-    this.isTabInactive = function (tabId) {
-      return currentState[tabId] === states.INACTIVE;
-    };
-
-    this.isTabErrored = function (tabId) {
-      return currentState[tabId] === states.ERRORED;
-    };
-
-    // options.force allows the caller to re-trigger an onchange event for
-    // the current state without modifying the previous state. This is useful
-    // for restoring tab state after the extension is reloaded.
-    function transition (tabId, state, options) {
-      var isForced = !!options && options.force === true;
-      var hasChanged = state !== currentState[tabId];
-      if (!isForced && !hasChanged) { return; }
-
-      if (!isForced || hasChanged) {
-        previousState[tabId] = currentState[tabId];
-        currentState[tabId] = state;
-      }
-
-      if (typeof _this.onchange === 'function') {
-        _this.onchange(tabId, state, previousState[tabId] || null);
-      }
+    if (!isForced || hasChanged) {
+      previousState[tabId] = currentState[tabId];
+      currentState[tabId] = state;
     }
 
-    this.load(initialState || {});
+    if (typeof _this.onchange === 'function') {
+      _this.onchange(tabId, state, previousState[tabId] || null);
+    }
   }
 
-  TabState.states = states;
+  this.load(initialState || {});
+}
 
-  h.TabState = TabState;
-})(window.h || (window.h = {}));
+TabState.states = states;
+
+module.exports = TabState;

--- a/h/browser/chrome/lib/tab-state.js
+++ b/h/browser/chrome/lib/tab-state.js
@@ -1,4 +1,4 @@
-//'use strict';
+'use strict';
 
 var states = {
   ACTIVE:   'active',

--- a/h/browser/chrome/lib/tab-state.js
+++ b/h/browser/chrome/lib/tab-state.js
@@ -1,4 +1,4 @@
-'use strict';
+//'use strict';
 
 var states = {
   ACTIVE:   'active',

--- a/h/browser/chrome/lib/tab-store.js
+++ b/h/browser/chrome/lib/tab-store.js
@@ -1,51 +1,49 @@
-(function (h) {
-  'use strict';
+'use strict';
 
-  /* The tab store ensures that the current state of the browser action
-   * is persisted between browser sessions. To do this it uses an external
-   * storage object that conforms to the localStorage API.
-   *
-   * Examples
-   *
-   *   var store = new TabStore(window.localStorage);
-   */
-  function TabStore(storage) {
-    var key = 'state';
-    var local;
+/* The tab store ensures that the current state of the browser action
+ * is persisted between browser sessions. To do this it uses an external
+ * storage object that conforms to the localStorage API.
+ *
+ * Examples
+ *
+ *   var store = new TabStore(window.localStorage);
+ */
+function TabStore(storage) {
+  var key = 'state';
+  var local;
 
-    this.get = function (tabId) {
-      var value = local[tabId];
-      if (!value) {
-        throw new Error('TabStateStore could not find entry for tab: ' + tabId);
-      }
-      return value;
-    };
+  this.get = function (tabId) {
+    var value = local[tabId];
+    if (!value) {
+      throw new Error('TabStateStore could not find entry for tab: ' + tabId);
+    }
+    return value;
+  };
 
-    this.set = function (tabId, value) {
-      local[tabId] = value;
-      storage.setItem(key, JSON.stringify(local));
-    };
+  this.set = function (tabId, value) {
+    local[tabId] = value;
+    storage.setItem(key, JSON.stringify(local));
+  };
 
-    this.unset = function (tabId) {
-      delete local[tabId];
-      storage.setItem(key, JSON.stringify(local));
-    };
+  this.unset = function (tabId) {
+    delete local[tabId];
+    storage.setItem(key, JSON.stringify(local));
+  };
 
-    this.all = function () {
-      return local;
-    };
+  this.all = function () {
+    return local;
+  };
 
-    this.reload = function () {
-      try {
-        local = JSON.parse(storage.getItem(key));
-      } catch (e) {
-        local = null;
-      }
-      local = local || {};
-    };
+  this.reload = function () {
+    try {
+      local = JSON.parse(storage.getItem(key));
+    } catch (e) {
+      local = null;
+    }
+    local = local || {};
+  };
 
-    this.reload();
-  }
+  this.reload();
+}
 
-  h.TabStore = TabStore;
-})(window.h || (window.h = {}));
+module.exports = TabStore;

--- a/h/browser/chrome/manifest.json.jinja2
+++ b/h/browser/chrome/manifest.json.jinja2
@@ -28,17 +28,7 @@
   "background": {
     "persistent": true,
     "scripts": [
-      "lib/settings.js",
-      "lib/tab-store.js",
-      "lib/tab-state.js",
-      "lib/tab-error-cache.js",
-      "lib/sidebar-injector.js",
-      "lib/browser-action.js",
-      "lib/help-page.js",
-      "lib/errors.js",
-      "lib/hypothesis-chrome-extension.js",
-      "lib/install.js",
-      "lib/blocklist.js"
+      "lib/extension-bundle.js"
     ]
   },
   "browser_action": {

--- a/h/browser/chrome/test/browser-action-test.js
+++ b/h/browser/chrome/test/browser-action-test.js
@@ -1,8 +1,8 @@
 describe('BrowserAction', function () {
   'use strict';
 
-  var BrowserAction = h.BrowserAction;
-  var TabState = h.TabState;
+  var BrowserAction = require('../lib/browser-action');
+  var TabState = require('../lib/tab-state');
   var action;
   var fakeChromeBrowserAction;
 

--- a/h/browser/chrome/test/help-page-test.js
+++ b/h/browser/chrome/test/help-page-test.js
@@ -1,5 +1,6 @@
 describe('HelpPage', function () {
-  var HelpPage = h.HelpPage;
+  var errors = require('../lib/errors');
+  var HelpPage = require('../lib/help-page');
   var fakeChromeTabs;
   var help;
 
@@ -12,7 +13,7 @@ describe('HelpPage', function () {
 
   describe('.showHelpForError', function () {
     it('renders the "local-file" page when passed a LocalFileError', function () {
-      help.showHelpForError({id: 1, index: 1}, new h.LocalFileError('msg'));
+      help.showHelpForError({id: 1, index: 1}, new errors.LocalFileError('msg'));
       assert.called(fakeChromeTabs.create);
       assert.calledWith(fakeChromeTabs.create, {
         index: 2,
@@ -22,7 +23,7 @@ describe('HelpPage', function () {
     });
 
     it('renders the "no-file-access" page when passed a NoFileAccessError', function () {
-      help.showHelpForError({id: 1, index: 1}, new h.NoFileAccessError('msg'));
+      help.showHelpForError({id: 1, index: 1}, new errors.NoFileAccessError('msg'));
       assert.called(fakeChromeTabs.create);
       assert.calledWith(fakeChromeTabs.create, {
         index: 2,
@@ -32,7 +33,7 @@ describe('HelpPage', function () {
     });
 
     it('renders the "no-file-access" page when passed a RestrictedProtocolError', function () {
-      help.showHelpForError({id: 1, index: 1}, new h.RestrictedProtocolError('msg'));
+      help.showHelpForError({id: 1, index: 1}, new errors.RestrictedProtocolError('msg'));
       assert.called(fakeChromeTabs.create);
       assert.calledWith(fakeChromeTabs.create, {
         index: 2,
@@ -42,7 +43,7 @@ describe('HelpPage', function () {
     });
 
     it('renders the "blocked-site" page when passed a BlockedSiteError', function () {
-      help.showHelpForError({id: 1, index: 1}, new h.BlockedSiteError('msg'));
+      help.showHelpForError({id: 1, index: 1}, new errors.BlockedSiteError('msg'));
       assert.called(fakeChromeTabs.create);
       assert.calledWith(fakeChromeTabs.create, {
         index: 2,

--- a/h/browser/chrome/test/sidebar-injector-test.js
+++ b/h/browser/chrome/test/sidebar-injector-test.js
@@ -1,7 +1,8 @@
 describe('SidebarInjector', function () {
   'use strict';
 
-  var SidebarInjector = h.SidebarInjector;
+  var errors = require('../lib/errors');
+  var SidebarInjector = require('../lib/sidebar-injector');
   var injector;
   var fakeChromeTabs;
   var fakeFileAccess;
@@ -42,7 +43,7 @@ describe('SidebarInjector', function () {
 
         return injector.injectIntoTab({id: 1, url: url}).then(
           assertReject, function (err) {
-            assert.instanceOf(err, h.RestrictedProtocolError);
+            assert.instanceOf(err, errors.RestrictedProtocolError);
             assert.notCalled(spy);
           }
         );
@@ -106,7 +107,7 @@ describe('SidebarInjector', function () {
 
           var promise = injector.injectIntoTab({id: 1, url: url});
           return promise.then(assertReject, function (err) {
-            assert.instanceOf(err, h.NoFileAccessError);
+            assert.instanceOf(err, errors.NoFileAccessError);
           });
         });
       });
@@ -116,7 +117,7 @@ describe('SidebarInjector', function () {
         var url = 'file://foo.html';
         var promise = injector.injectIntoTab({id: 1, url: url});
         return promise.then(assertReject, function (err) {
-          assert.instanceOf(err, h.LocalFileError);
+          assert.instanceOf(err, errors.LocalFileError);
         });
       });
 

--- a/h/browser/chrome/test/tab-error-cache-test.js
+++ b/h/browser/chrome/test/tab-error-cache-test.js
@@ -1,8 +1,10 @@
+var TabErrorCache = require('../lib/tab-error-cache');
+
 describe('TabErrorCache', function () {
  var cache;
 
  beforeEach(function () {
-   cache = new h.TabErrorCache();
+   cache = new TabErrorCache();
  });
 
  it('allows items to be set an retrieved', function () {

--- a/h/browser/chrome/test/tab-state-test.js
+++ b/h/browser/chrome/test/tab-state-test.js
@@ -1,7 +1,7 @@
 describe('TabState', function () {
   'use strict';
 
-  var TabState = h.TabState;
+  var TabState = require('../lib/tab-state');
   var state;
   var onChange;
 

--- a/h/browser/chrome/test/tab-store-test.js
+++ b/h/browser/chrome/test/tab-store-test.js
@@ -1,7 +1,7 @@
 describe('TabStore', function () {
   'use strict';
 
-  var TabStore = h.TabStore;
+  var TabStore = require('../lib/tab-store');
   var store;
   var fakeLocalStorage;
 

--- a/h/buildext.py
+++ b/h/buildext.py
@@ -9,6 +9,7 @@ import logging
 import os
 import os.path
 import shutil
+import subprocess
 import textwrap
 import urlparse
 import json
@@ -179,10 +180,12 @@ def build_chrome(args):
     copytree('h/browser/chrome/content', 'build/chrome/content')
     copytree('h/browser/chrome/help', 'build/chrome/help')
     copytree('h/browser/chrome/images', 'build/chrome/images')
-    copytree('h/browser/chrome/lib', 'build/chrome/lib')
     copytree('h/static/images', 'build/chrome/public/images')
-    shutil.copyfile(
-        'h/static/scripts/blocklist.js', 'build/chrome/lib/blocklist.js')
+
+    os.makedirs('build/chrome/lib')
+    subprocess.call(['node_modules/.bin/browserify',
+      'h/browser/chrome/lib/extension.js',
+      '--outfile', 'build/chrome/lib/extension-bundle.js'])
 
     # Render the sidebar html.
     if webassets_env.url.startswith('chrome-extension:'):

--- a/h/static/scripts/karma.config.js
+++ b/h/static/scripts/karma.config.js
@@ -73,6 +73,8 @@ module.exports = function(config) {
         bundle
           .transform('coffeeify')
           .plugin('proxyquire-universal')
+          // fix for Proxyquire in PhantomJS 1.x.
+          // See https://github.com/bitwit/proxyquireify-phantom-menace
           .require('phantom-ownpropertynames/implement', {entry: true});
       }
     },


### PR DESCRIPTION
This replaces the ad-hoc module system in the Chrome extension based around a `window.h` global with CommonJS + Browserify.

Rationale:

* Consistency with the main app
* Clearer dependency structure
* Simplifies the `manifest.json` and Karma config files
* A step towards sharing code between the Firefox, Chrome and Safari extensions in future

Most of the tests didn't need that much alteration because they used function arguments for dependency injection. The one test that did stub out other modules now uses proxyquire.

I suggest looking at the [diff ignoring whitespace change](https://github.com/hypothesis/h/pull/2609/files?w=1) (add '?w=1 to URL') for a clearer view of the changes.