### PR TITLE
Handle exceptions broadcasting WS messages gracefully

### DIFF
--- a/h/test/queue_test.py
+++ b/h/test/queue_test.py
@@ -9,8 +9,8 @@ from h import queue
 
 @patch('gnsq.Reader')
 def test_get_reader_default(fake_reader):
-    req = testing.DummyRequest()
-    queue.get_reader(req, 'ethics-in-games-journalism', 'channel4')
+    settings = {}
+    queue.get_reader(settings, 'ethics-in-games-journalism', 'channel4')
     fake_reader.assert_called_with('ethics-in-games-journalism',
                                    'channel4',
                                    nsqd_tcp_addresses=['localhost:4150'])
@@ -18,11 +18,10 @@ def test_get_reader_default(fake_reader):
 
 @patch('gnsq.Reader')
 def test_get_reader(fake_reader):
-    req = testing.DummyRequest()
-    req.registry.settings.update({
+    settings = {
         'nsq.reader.addresses': "foo:1234\nbar:4567"
-    })
-    queue.get_reader(req, 'ethics-in-games-journalism', 'channel4')
+    }
+    queue.get_reader(settings, 'ethics-in-games-journalism', 'channel4')
     fake_reader.assert_called_with('ethics-in-games-journalism',
                                    'channel4',
                                    nsqd_tcp_addresses=['foo:1234',
@@ -35,11 +34,10 @@ def test_get_reader_namespace(fake_reader):
     a reader that automatically prefixes the namespace onto the name of the
     topic being read.
     """
-    req = testing.DummyRequest()
-    req.registry.settings.update({
+    settings = {
         'nsq.namespace': "abc123"
-    })
-    queue.get_reader(req, 'safari', 'elephants')
+    }
+    queue.get_reader(settings, 'safari', 'elephants')
     fake_reader.assert_called_with('abc123-safari',
                                    'elephants',
                                    nsqd_tcp_addresses=['localhost:4150'])
@@ -47,16 +45,15 @@ def test_get_reader_namespace(fake_reader):
 
 @patch('gnsq.Nsqd')
 def test_get_writer_default(fake_nsqd):
-    req = testing.DummyRequest()
-    queue.get_writer(req)
+    settings = {}
+    queue.get_writer(settings)
     fake_nsqd.assert_called_with('localhost', http_port='4151')
 
 
 @patch('gnsq.Nsqd')
 def test_get_writer(fake_nsqd):
-    req = testing.DummyRequest()
-    req.registry.settings.update({'nsq.writer.address': 'philae:2014'})
-    queue.get_writer(req)
+    settings = {'nsq.writer.address': 'philae:2014'}
+    queue.get_writer(settings)
     fake_nsqd.assert_called_with('philae', http_port='2014')
 
 
@@ -68,12 +65,11 @@ def test_get_writer_namespace(fake_nsqd):
     given to :method:`gnsq.Nsqd.publish` or :method:`gnsq.Nsqd.mpublish`.
     """
     fake_client = fake_nsqd.return_value
-    req = testing.DummyRequest()
-    req.registry.settings.update({
+    settings = {
         'nsq.namespace': "abc123"
-    })
+    }
 
-    writer = queue.get_writer(req)
+    writer = queue.get_writer(settings)
 
     writer.publish('sometopic', 'somedata')
     fake_client.publish.assert_called_with('abc123-sometopic', 'somedata')
@@ -81,11 +77,10 @@ def test_get_writer_namespace(fake_nsqd):
 @patch('gnsq.Nsqd')
 def test_writer_serializes_dict(fake_nsqd):
     fake_client = fake_nsqd.return_value
-    req = testing.DummyRequest()
-    req.registry.settings.update({
+    settings = {
         'nsq.namespace': 'abc',
-    })
-    writer = queue.get_writer(req)
+    }
+    writer = queue.get_writer(settings)
     writer.publish('sometopic', {
         'key': 'value',
     })

--- a/h/test/streamer_test.py
+++ b/h/test/streamer_test.py
@@ -6,15 +6,16 @@ import unittest
 from collections import namedtuple
 import json
 
+import pytest
 from mock import ANY
-from mock import MagicMock, Mock
+from mock import MagicMock, Mock, PropertyMock
 from mock import patch
 from pyramid.testing import DummyRequest
 
+from h import streamer
 from h.streamer import FilterToElasticFilter
 from h.streamer import WebSocket
 from h.streamer import should_send_annotation_event
-from h.streamer import broadcast_from_queue
 from h.streamer import websocket
 from h.streamer import ANNOTATIONS_TOPIC
 
@@ -223,11 +224,6 @@ class TestWebSocket(unittest.TestCase):
         self.s = WebSocket(fake_socket)
         self.s.request = fake_request
 
-    def test_opened_starts_reader(self):
-        self.s.opened()
-        for topic in ['annotations', 'user']:
-            self.s.request.get_queue_reader.assert_any_call(topic, ANY)
-
     def test_filter_message_with_uri_gets_expanded(self):
         filter_message = json.dumps({
             'filter': {
@@ -260,22 +256,11 @@ class TestWebSocket(unittest.TestCase):
 
 class TestBroadcastAnnotationEvent(unittest.TestCase):
     def setUp(self):
-        self.message_data = [
-            {'annotation': {'id': 1},
-             'action': 'delete',
-             'src_client_id': 'pigeon'},
-            {'annotation': {'id': 2},
-             'action': 'update',
-             'src_client_id': 'pigeon'},
-            {'annotation': {'id': 3},
-             'action': 'delete',
-             'src_client_id': 'cat'},
-        ]
-        self.messages = [(ANNOTATIONS_TOPIC, FakeMessage(json.dumps(m)))
-            for m in self.message_data]
-
-        self.queue = MagicMock()
-        self.queue.__iter__.return_value = self.messages
+        self.message = FakeMessage(json.dumps({
+            'annotation': {'id': 1},
+            'action': 'delete',
+            'src_client_id': 'pigeon',
+        }))
 
         self.should_patcher = patch('h.streamer.should_send_annotation_event')
         self.should = self.should_patcher.start()
@@ -283,23 +268,26 @@ class TestBroadcastAnnotationEvent(unittest.TestCase):
     def tearDown(self):
         self.should_patcher.stop()
 
+    def msg(self, n):
+        return FakeMessage(json.dumps(self.messages[n]))
+
     def test_send_when_socket_should_receive_event(self):
         self.should.return_value = True
         sock = FakeSocket('giraffe')
-        broadcast_from_queue(self.queue, [sock])
+        streamer.broadcast_annotation_message(self.message, [sock])
         assert sock.send.called
 
     def test_no_send_when_socket_should_not_receive_event(self):
         self.should.return_value = False
-        sock = FakeSocket('pidgeon')
-        broadcast_from_queue(self.queue, [sock])
+        sock = FakeSocket('pigeon')
+        streamer.broadcast_annotation_message(self.message, [sock])
         assert sock.send.called is False
 
-    def test_terminated_socket_does_not_recieve_event(self):
+    def test_terminated_socket_does_not_receive_event(self):
         self.should.return_value = True
         sock = FakeSocket('giraffe')
         sock.terminated = True
-        broadcast_from_queue(self.queue, [sock])
+        streamer.broadcast_annotation_message(self.message, [sock])
         assert sock.send.called is False
 
 
@@ -309,17 +297,16 @@ class TestBroadcastSessionChangeEvent(unittest.TestCase):
         session_model = session_model_patcher.start()
         session_model.return_value = {'groups': [{'id': 'someid'}]}
 
-        queue = MagicMock()
-        queue.__iter__.return_value = [('user', FakeMessage(json.dumps({
+        message = FakeMessage(json.dumps({
             'type': 'group-join',
             'userid': 'amy',
             'group': 'groupid',
-        })))]
+        }))
 
         sock = FakeSocket('clientid')
         sock.request.authenticated_userid = 'amy'
 
-        broadcast_from_queue(queue, [sock])
+        streamer.broadcast_session_change_message(message, [sock])
         sock.send.assert_called_with(json.dumps({
             'type': 'session-change',
             'action': 'group-join',
@@ -424,3 +411,88 @@ class TestShouldSendEvent(unittest.TestCase):
         event_data = {'action': 'create', 'src_client_id': 'bar'}
 
         assert should_send_annotation_event(socket, annotation, event_data)
+
+
+@patch('h.streamer.broadcast_annotation_message')
+def test_process_message_sends_messages_from_annotations_topic_to_annotation_handler(handler):
+    reader = Mock(topic='annotations')
+
+    streamer.process_message(reader, '{"name": "bob"}')
+
+    handler.assert_called_once_with('{"name": "bob"}',
+                                    streamer.WebSocket.instances)
+
+
+@patch('h.streamer.broadcast_session_change_message')
+def test_process_message_sends_messages_from_user_topic_to_session_change_handler(handler):
+    reader = Mock(topic='user')
+
+    streamer.process_message(reader, '{"name": "bob"}')
+
+    handler.assert_called_once_with('{"name": "bob"}',
+                                    streamer.WebSocket.instances)
+
+
+def test_process_message_ignores_messages_from_other_topics():
+    reader = Mock(topic='wibble')
+
+    streamer.process_message(reader, '{"name": "bob"}')
+
+
+def test_process_queue_creates_readers_for_each_topic(get_reader):
+    settings = {'foo': 'bar'}
+    get_reader.return_value.is_running = False  # Allow the function to exit
+
+    streamer.process_queue(settings, ['donkeys', 'gorillas'])
+
+    get_reader.assert_any_call(settings, 'donkeys', ANY)
+    get_reader.assert_any_call(settings, 'gorillas', ANY)
+
+
+def test_process_queue_connects_reader_on_message_to_process_message(get_reader):
+    settings = {'foo': 'bar'}
+    reader = get_reader.return_value
+    reader.is_running = False  # Allow the function to exit
+
+    streamer.process_queue(settings, ['donkeys'])
+
+    reader.on_message.connect.assert_called_once_with(
+        receiver=streamer.process_message)
+
+
+def test_process_queue_starts_readers(get_reader):
+    settings = {'foo': 'bar'}
+    reader = get_reader.return_value
+    reader.is_running = False  # Allow the function to exit
+
+    streamer.process_queue(settings, ['donkeys'])
+
+    reader.start.assert_called_once_with(block=False)
+
+
+def test_process_queue_waits_for_reader_join(get_reader):
+    settings = {'foo': 'bar'}
+    reader = get_reader.return_value
+    reader.is_running = False  # Allow the function to exit
+
+    streamer.process_queue(settings, ['donkeys'])
+
+    reader.join.assert_called_once_with(timeout=1)
+
+
+def test_process_queue_closes_all_readers_if_one_stops(get_reader):
+    settings = {'foo': 'bar'}
+    reader = get_reader.return_value
+    type(reader).is_running = PropertyMock(side_effect=[True, False])
+
+    streamer.process_queue(settings, ['donkeys', 'gorillas'])
+
+    assert reader.close.call_count == 2
+
+
+@pytest.fixture
+def get_reader(request):
+    patcher = patch('h.queue.get_reader')
+    mock = patcher.start()
+    request.addfinalizer(patcher.stop)
+    return mock


### PR DESCRIPTION
If an exception occurs whilst processing an NSQ message
in the WebSocket server, log the exception and continue
on to the next message.

Since there is a single greenlet iterating over all
NSQ messages that might result in a WebSocket broadcast,
an error processing one message would previously cause all
subsequent WS broadcasts to cease.