### PR TITLE
Don't endlessly re-request features on connectivity issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "node-uuid": "^1.4.3",
     "postcss": "^5.0.6",
     "raf": "^3.1.0",
+    "retry": "^0.8.0",
     "scroll-into-view": "^1.3.1",
     "showdown": "^1.2.1",
     "uglify-js": "^2.4.14",


### PR DESCRIPTION
If, for whatever reason, the request to fetch features data fails, simply retry a little later (with a randomised exponential backoff). This commit uses the [retry module](https://www.npmjs.com/package/retry) to provide the backoff logic.

N.B. If we fail 10 times (over a period spanning between ~15 and ~30 minutes, using the defaults from the retry module) then we will simply stop looking for new features data. There's no point burning client CPU forever in the hope that the server reappears.

Fixes #2547.

---

FYI:

```shell
$ browserify -r retry | uglifyjs -m | wc -c
    3315
```