### PR TITLE
Sort groups server-side

### DIFF
--- a/h/session.py
+++ b/h/session.py
@@ -18,6 +18,15 @@ def pop_flash(request):
             for k in ['error', 'info', 'warning', 'success']}
 
 
+def _group_sort_key(group):
+    """Sort private groups for the session model list"""
+
+    # groups are sorted first by name but also by ID
+    # so that multiple groups with the same name are displayed
+    # in a consistent order in clients
+    return (group.name.lower(), group.hashid)
+
+
 def _current_groups(request):
     """Return a list of the groups the current user is a member of.
 
@@ -33,7 +42,7 @@ def _current_groups(request):
     user = models.User.get_by_userid(request.domain, userid)
     if user is None:
         return groups
-    for group in user.groups:
+    for group in sorted(user.groups, key=_group_sort_key):
         groups.append({
             'name': group.name,
             'id': group.hashid,

--- a/h/static/scripts/directive/group-list.js
+++ b/h/static/scripts/directive/group-list.js
@@ -16,16 +16,7 @@ function GroupListController($scope, $window) {
 
   $scope.shouldShowShareLink = function (groupId) {
     return $scope.expandedGroupId === groupId;
-  }
-
-  $scope.sortedGroups = function () {
-    return $scope.groups.all().concat().sort(function (a, b) {
-      if (a.public !== b.public) {
-        return a.public ? -1 : 1;
-      }
-      return a.name.localeCompare(b.name);
-    });
-  }
+  };
 
   $scope.leaveGroup = function (groupId) {
     var groupName = $scope.groups.get(groupId).name;

--- a/h/static/scripts/directive/test/group-list-test.js
+++ b/h/static/scripts/directive/test/group-list-test.js
@@ -31,27 +31,6 @@ describe('GroupListController', function () {
     assert.equal($scope.shouldShowShareLink('group-a'), false);
     assert.equal($scope.shouldShowShareLink('group-b'), true);
   });
-
-  it('sorts groups', function () {
-    $scope.groups = {
-      all: function () {
-        return [{
-          id: 'c',
-          name: 'Zebrafish Study Group'
-        },{
-          id: 'a',
-          name: 'Antimatter Research'
-        },{
-          public: true
-        }];
-      },
-    };
-
-    var sorted = $scope.sortedGroups();
-    assert.ok(sorted[0].public);
-    assert.equal(sorted[1].name, 'Antimatter Research');
-    assert.equal(sorted[2].name, 'Zebrafish Study Group');
-  });
 });
 
 // returns true if a jQuery-like element has

--- a/h/templates/client/group_list.html
+++ b/h/templates/client/group_list.html
@@ -11,7 +11,7 @@
     <i class="h-icon-arrow-drop-down"></i>
   </span>
   <ul class="dropdown-menu pull-right" role="menu">
-    <li ng-repeat="group in sortedGroups()">
+    <li ng-repeat="group in groups.all()">
       <div ng-class="{'group-item': true, selected: group.id == groups.focused().id}"
            ng-click="groups.focus(group.id)">
         <!-- the group icon !-->

--- a/h/test/session_test.py
+++ b/h/test/session_test.py
@@ -1,0 +1,29 @@
+import unittest
+
+from mock import Mock
+from mock import patch
+
+from h.session import model
+
+
+class FakeGroup():
+    def __init__(self, hashid, name):
+        self.hashid = hashid
+        self.name = name
+        self.slug = hashid
+
+
+@patch('h.models.User')
+def test_sorts_groups(User):
+    fake_user = Mock()
+    fake_user.groups = [
+        FakeGroup('c', 'Group A'),
+        FakeGroup('b', 'Group B'),
+        FakeGroup('a', 'Group B'),
+    ]
+    User.get_by_userid.return_value = fake_user
+    request = Mock()
+    session_model = model(request)
+
+    ids = [group['id'] for group in session_model['groups']]
+    assert ids == ['__world__', 'c', 'a', 'b']


### PR DESCRIPTION
Sort groups server-side by name, then by ID

 * Sort groups on the server in a useful order on the server
   rather than the client.

   This reduces the need for logic which is otherwise likely
   to be duplicated across clients.

 * Sort groups by name, _then by ID_. This ensures that if
   multiple groups have the same name they are sorted in
   a consistent order in the client.
