### PR TITLE
T93 New 'Clear selection' button design

### DIFF
--- a/h/static/scripts/app.coffee
+++ b/h/static/scripts/app.coffee
@@ -124,6 +124,7 @@ module.exports = angular.module('h', [
 .directive('windowScroll', require('./directive/window-scroll'))
 .directive('dropdownMenuBtn', require('./directive/dropdown-menu-btn'))
 .directive('publishAnnotationBtn', require('./directive/publish-annotation-btn'))
+.directive('searchStatusBar', require('./directive/search-status-bar'))
 
 .filter('converter', require('./filter/converter'))
 .filter('moment', require('./filter/moment'))

--- a/h/static/scripts/directive/search-status-bar.js
+++ b/h/static/scripts/directive/search-status-bar.js
@@ -3,11 +3,6 @@ module.exports = function () {
   return {
     restrict: 'E',
     scope: {
-      /** Specifies whether to use the new design that is part of
-       * the groups roll-out.
-       * See https://trello.com/c/GxVkM1eN/
-       */
-      newDesign: '=',
       filterActive: '=',
       filterMatchCount: '=',
       onClearSelection: '&',

--- a/h/static/scripts/directive/search-status-bar.js
+++ b/h/static/scripts/directive/search-status-bar.js
@@ -1,0 +1,13 @@
+module.exports = function () {
+  return {
+    restrict: 'E',
+    scope: {
+      filterActive: '=',
+      filterMatchCount: '=',
+      onClearSelection: '&',
+      searchQuery: '=',
+      selectionCount: '=',
+    },
+    templateUrl: 'search_status_bar.html',
+  };
+};

--- a/h/static/scripts/directive/search-status-bar.js
+++ b/h/static/scripts/directive/search-status-bar.js
@@ -1,7 +1,13 @@
+// @ngInject
 module.exports = function () {
   return {
     restrict: 'E',
     scope: {
+      /** Specifies whether to use the new design that is part of
+       * the groups roll-out.
+       * See https://trello.com/c/GxVkM1eN/
+       */
+      newDesign: '=',
       filterActive: '=',
       filterMatchCount: '=',
       onClearSelection: '&',

--- a/h/static/scripts/directive/test/search-status-bar-test.js
+++ b/h/static/scripts/directive/test/search-status-bar-test.js
@@ -1,0 +1,30 @@
+'use strict';
+
+var util = require('./util');
+
+describe('searchStatusBar', function () {
+  before(function () {
+    angular.module('app', [])
+      .directive('searchStatusBar', require('../search-status-bar'));
+  });
+
+  beforeEach(function () {
+    angular.mock.module('app');
+    angular.mock.module('h.templates');
+  });
+
+  it('should display the filter count', function () {
+    var elem = util.createDirective(document, 'searchStatusBar', {
+      filterActive: true,
+      filterMatchCount: 5
+    });
+    assert.include($(elem).text(), "Found 5 results");
+  });
+
+  it('should display the selection count', function () {
+    var elem = util.createDirective(document, 'searchStatusBar', {
+      selectionCount: 1
+    });
+    assert.include($(elem).text(), 'Showing 1 selected annotation');
+  });
+});

--- a/h/static/scripts/directive/test/search-status-bar-test.js
+++ b/h/static/scripts/directive/test/search-status-bar-test.js
@@ -13,18 +13,39 @@ describe('searchStatusBar', function () {
     angular.mock.module('h.templates');
   });
 
-  it('should display the filter count', function () {
-    var elem = util.createDirective(document, 'searchStatusBar', {
-      filterActive: true,
-      filterMatchCount: 5
+  describe('old design', function () {
+    it('should display the filter count', function () {
+      var elem = util.createDirective(document, 'searchStatusBar', {
+        filterActive: true,
+        filterMatchCount: 5
+      });
+      assert.include($(elem).text(), "Found 5 results");
     });
-    assert.include($(elem).text(), "Found 5 results");
+
+    it('should display the selection count', function () {
+      var elem = util.createDirective(document, 'searchStatusBar', {
+        selectionCount: 1
+      });
+      assert.include($(elem).text(), 'Showing 1 selected annotation');
+    });
   });
 
-  it('should display the selection count', function () {
-    var elem = util.createDirective(document, 'searchStatusBar', {
-      selectionCount: 1
+  describe('new design', function () {
+    it('should display the filter count', function () {
+      var elem = util.createDirective(document, 'searchStatusBar', {
+        newDesign: true,
+        filterActive: true,
+        filterMatchCount: 5
+      });
+      assert.include($(elem).text(), "5 search results");
     });
-    assert.include($(elem).text(), 'Showing 1 selected annotation');
+
+    it('should display the selection count', function () {
+      var elem = util.createDirective(document, 'searchStatusBar', {
+        newDesign: true,
+        selectionCount: 2
+      });
+      assert.include($(elem).text(), '2 selected annotations');
+    });
   });
 });

--- a/h/static/scripts/directive/test/search-status-bar-test.js
+++ b/h/static/scripts/directive/test/search-status-bar-test.js
@@ -13,39 +13,20 @@ describe('searchStatusBar', function () {
     angular.mock.module('h.templates');
   });
 
-  describe('old design', function () {
-    it('should display the filter count', function () {
-      var elem = util.createDirective(document, 'searchStatusBar', {
-        filterActive: true,
-        filterMatchCount: 5
-      });
-      assert.include($(elem).text(), "Found 5 results");
+  it('should display the filter count', function () {
+    var elem = util.createDirective(document, 'searchStatusBar', {
+      newDesign: true,
+      filterActive: true,
+      filterMatchCount: 5
     });
-
-    it('should display the selection count', function () {
-      var elem = util.createDirective(document, 'searchStatusBar', {
-        selectionCount: 1
-      });
-      assert.include($(elem).text(), 'Showing 1 selected annotation');
-    });
+    assert.include($(elem).text(), "5 search results");
   });
 
-  describe('new design', function () {
-    it('should display the filter count', function () {
-      var elem = util.createDirective(document, 'searchStatusBar', {
-        newDesign: true,
-        filterActive: true,
-        filterMatchCount: 5
-      });
-      assert.include($(elem).text(), "5 search results");
+  it('should display the selection count', function () {
+    var elem = util.createDirective(document, 'searchStatusBar', {
+      newDesign: true,
+      selectionCount: 2
     });
-
-    it('should display the selection count', function () {
-      var elem = util.createDirective(document, 'searchStatusBar', {
-        newDesign: true,
-        selectionCount: 2
-      });
-      assert.include($(elem).text(), '2 selected annotations');
-    });
+    assert.include($(elem).text(), '2 selected annotations');
   });
 });

--- a/h/static/styles/app.scss
+++ b/h/static/styles/app.scss
@@ -12,6 +12,7 @@ $base-line-height: 20px;
 @import './primary-action-btn';
 @import './dropdown-menu-btn';
 @import './publish-annotation-btn';
+@import './search-status-bar';
 @import './share-link';
 
 body {

--- a/h/static/styles/primary-action-btn.scss
+++ b/h/static/styles/primary-action-btn.scss
@@ -12,6 +12,9 @@
   font-weight: bold;
   font-size: $body1-font-size;
 
+  padding-left: 12px;
+  padding-right: 12px;
+
   &:disabled {
     color: $gray-light;
   }
@@ -19,4 +22,17 @@
   &:hover:enabled {
     background-color: $color-mine-shaft;
   }
+}
+
+.primary-action-btn--short {
+  height: 30px;
+}
+
+.primary-action-btn__icon {
+  color: $color-silver-chalice;
+  display: inline-block;
+  font-weight: bold;
+  margin-left: -3px;
+  margin-right: 3px;
+  transform: translateY(1px);
 }

--- a/h/static/styles/search-status-bar.scss
+++ b/h/static/styles/search-status-bar.scss
@@ -1,0 +1,7 @@
+.search-status-bar {
+  margin-bottom: 10px;
+}
+
+.search-status-bar > button {
+  margin-right: 10px;
+}

--- a/h/templates/app.html.jinja2
+++ b/h/templates/app.html.jinja2
@@ -117,6 +117,9 @@
   <script type="text/ng-template" id="publish_annotation_btn.html">
     {{ include_raw("h:templates/client/publish_annotation_btn.html") }}
   </script>
+  <script type="text/ng-template" id="search_status_bar.html">
+    {{ include_raw("h:templates/client/search_status_bar.html") }}
+  </script>
 {% endblock %}
 
 {# Override ga_pageview block to prevent a 'pageview' event from being sent to

--- a/h/templates/client/search_status_bar.html
+++ b/h/templates/client/search_status_bar.html
@@ -1,0 +1,16 @@
+<li ng-show="filterActive">
+  <span ng-pluralize
+           count="filterMatchCount"
+           when="{'0': 'No results for “{{searchQuery}}”.',
+                  'one': 'Found one result.',
+                  'other': 'Found {} results.'}"></span>
+  <a href="" ng-click="onClearSelection()">Clear search</a>.
+</li>
+<li ng-show="!filterActive && selectionCount > 0">
+  <span ng-pluralize
+           count="selectionCount"
+           when="{'0': 'No annotations selected.',
+                  'one': 'Showing 1 selected annotation.',
+                  'other': 'Showing {} selected annotations.'}"></span>
+  <a href="" ng-click="onClearSelection()">Clear selection</a>.
+</li>

--- a/h/templates/client/search_status_bar.html
+++ b/h/templates/client/search_status_bar.html
@@ -1,4 +1,4 @@
-<div ng-if="newDesign" class="search-status-bar" ng-show="filterActive">
+<div class="search-status-bar" ng-show="filterActive">
   <button class="primary-action-btn primary-action-btn--short"
           ng-click="onClearSelection()"
           title="Clear the search filter and show all annotations"
@@ -11,7 +11,7 @@
                   'one': '1 search result',
                   'other': '{} search results'}"></span>
 </div>
-<div ng-if="newDesign" class="search-status-bar" ng-show="!filterActive && selectionCount > 0">
+<div class="search-status-bar" ng-show="!filterActive && selectionCount > 0">
   <button class="primary-action-btn primary-action-btn--short"
           ng-click="onClearSelection()"
           title="Clear the selection and show all annotations"
@@ -24,20 +24,3 @@
                   'one': '1 selected annotation',
                   'other': '{} selected annotations'}"></span>
 </div>
-<div ng-if="!newDesign" class="search-status-bar" ng-show="filterActive">
-  <span ng-pluralize
-           count="filterMatchCount"
-           when="{'0': 'No results for “{{searchQuery}}”.',
-                  'one': 'Found one result.',
-                  'other': 'Found {} results.'}"></span>
-  <a href="" ng-click="onClearSelection()">Clear search</a>.
-</div>
-<div ng-if="!newDesign" class="search-status-bar"
-  ng-show="!filterActive && selectionCount > 0">
-  <span ng-pluralize
-           count="selectionCount"
-           when="{'0': 'No annotations selected.',
-                  'one': 'Showing 1 selected annotation.',
-                  'other': 'Showing {} selected annotations.'}"></span>
-  <a href="" ng-click="onClearSelection()">Clear selection</a>.
-</li>

--- a/h/templates/client/search_status_bar.html
+++ b/h/templates/client/search_status_bar.html
@@ -1,12 +1,39 @@
-<li ng-show="filterActive">
+<div ng-if="newDesign" class="search-status-bar" ng-show="filterActive">
+  <button class="primary-action-btn primary-action-btn--short"
+          ng-click="onClearSelection()"
+          title="Clear the search filter and show all annotations"
+  >
+    <i class="primary-action-btn__icon h-icon-close"></i> Clear search
+  </button>
+  <span ng-pluralize
+           count="filterMatchCount"
+           when="{'0': 'No results for “{{searchQuery}}”',
+                  'one': '1 search result',
+                  'other': '{} search results'}"></span>
+</div>
+<div ng-if="newDesign" class="search-status-bar" ng-show="!filterActive && selectionCount > 0">
+  <button class="primary-action-btn primary-action-btn--short"
+          ng-click="onClearSelection()"
+          title="Clear the selection and show all annotations"
+  >
+    <i class="primary-action-btn__icon h-icon-close"></i> Clear selection
+  </button>
+  <span ng-pluralize
+           count="selectionCount"
+           when="{'0': 'No annotations selected',
+                  'one': '1 selected annotation',
+                  'other': '{} selected annotations'}"></span>
+</div>
+<div ng-if="!newDesign" class="search-status-bar" ng-show="filterActive">
   <span ng-pluralize
            count="filterMatchCount"
            when="{'0': 'No results for “{{searchQuery}}”.',
                   'one': 'Found one result.',
                   'other': 'Found {} results.'}"></span>
   <a href="" ng-click="onClearSelection()">Clear search</a>.
-</li>
-<li ng-show="!filterActive && selectionCount > 0">
+</div>
+<div ng-if="!newDesign" class="search-status-bar"
+  ng-show="!filterActive && selectionCount > 0">
   <span ng-pluralize
            count="selectionCount"
            when="{'0': 'No annotations selected.',

--- a/h/templates/client/viewer.html
+++ b/h/templates/client/viewer.html
@@ -3,20 +3,13 @@
     deep-count="count"
     thread-filter="search.query"
     window-scroll="loadMore(20)">
-  <li ng-show="threadFilter.active()"
-      ><span ng-pluralize
-             count="count('match')"
-             when="{'0': 'No results for “{{search.query}}”.',
-                    'one': 'Found one result.',
-                    'other': 'Found {} results.'}"></span>
-      <a href="" ng-click="clearSelection()">Clear search</a>.</li>
-  <li ng-show="!threadFilter.active() && selectedAnnotations"
-      ><span ng-pluralize
-             count="selectedAnnotationsCount"
-             when="{'0': 'No annotations selected.',
-                    'one': 'Showing 1 selected annotation.',
-                    'other': 'Showing {} selected annotations.'}"></span>
-      <a href="" ng-click="clearSelection()">Clear selection</a>.</li>
+  <search-status-bar
+    filter-active="threadFilter.active()"
+    filter-match-count="count('match')"
+    search-query="search ? search.query : ''"
+    selection-count="selectedAnnotationsCount"
+    on-clear-selection="clearSelection()">
+  </search-status-bar>
   <li ng-show="isStream">
     <span class="ng-cloak" dropdown keyboard-nav>
       <span role="button"

--- a/h/templates/client/viewer.html
+++ b/h/templates/client/viewer.html
@@ -4,7 +4,6 @@
     thread-filter="search.query"
     window-scroll="loadMore(20)">
   <search-status-bar
-    new-design="feature('groups')"
     filter-active="threadFilter.active()"
     filter-match-count="count('match')"
     search-query="search ? search.query : ''"

--- a/h/templates/client/viewer.html
+++ b/h/templates/client/viewer.html
@@ -4,6 +4,7 @@
     thread-filter="search.query"
     window-scroll="loadMore(20)">
   <search-status-bar
+    new-design="feature('groups')"
     filter-active="threadFilter.active()"
     filter-match-count="count('match')"
     search-query="search ? search.query : ''"


### PR DESCRIPTION
Implement new design for search status bar

This provides a clearer design for the search status
button.

The new design is part of the groups roll-out and
is only shown when the groups feature is enabled.

![t92-new_clear_btn](https://cloud.githubusercontent.com/assets/2458/10483747/e19dd024-7278-11e5-97d4-f1c231da005a.png)

![t92-new_clear_btn_2](https://cloud.githubusercontent.com/assets/2458/10483753/e5f9f7ce-7278-11e5-84a8-1a0f71eb139c.png)

