### PR TITLE
streamer: Don't silently stop processing on exceptions

### DIFF
--- a/h/streamer.py
+++ b/h/streamer.py
@@ -11,16 +11,18 @@ import unicodedata
 import weakref
 
 import gevent
-import gevent.queue
 from jsonpointer import resolve_pointer
 from jsonschema import validate
 from pyramid.config import aslist
+from pyramid.events import ApplicationCreated
+from pyramid.events import subscriber
 from pyramid.httpexceptions import HTTPBadRequest, HTTPForbidden
 from pyramid.threadlocal import get_current_request
 from ws4py.exc import HandshakeError
 from ws4py.websocket import WebSocket as _WebSocket
 from ws4py.server.wsgiutils import WebSocketWSGIApplication
 
+from h import queue
 from h.api import nipsa
 from h.api import uri
 from h.api.search import query
@@ -443,11 +445,7 @@ USER_TOPIC = 'user'
 
 
 class WebSocket(_WebSocket):
-    # Class attributes
-
-    # Tuples of (topic, message) pulled from the message queue
-    event_queue = None
-
+    # All instances of WebSocket, allowing us to iterate over open websockets
     instances = weakref.WeakSet()
     origins = []
 
@@ -467,28 +465,7 @@ class WebSocket(_WebSocket):
         cls.instances.add(instance)
         return instance
 
-    @classmethod
-    def start_reader(cls, request):
-        if cls.event_queue is not None:
-            return
-        cls.event_queue = gevent.queue.Queue()
-        reader_id = 'stream-{}#ephemeral'.format(_random_id())
-
-        for topic in [ANNOTATIONS_TOPIC, USER_TOPIC]:
-            reader = request.get_queue_reader(topic, reader_id)
-            reader.on_message.connect(receiver=cls.on_queue_message)
-            reader.start(block=False)
-
-        gevent.spawn(broadcast_from_queue, cls.event_queue, cls.instances)
-
-    @classmethod
-    def on_queue_message(cls, reader, message=None):
-        if message is not None:
-            cls.event_queue.put((reader.topic, message))
-
     def opened(self):
-        self.start_reader(self.request)
-
         # Release the database transaction
         self.request.tm.commit()
 
@@ -555,18 +532,6 @@ def _annotation_packet(annotations, action):
         'type': 'annotation-notification',
         'options': {'action': action},
     }
-
-
-def broadcast_from_queue(queue, sockets):
-    """
-    Pulls messages from a passed queue object, and handles dispatching them to
-    appropriate active sessions.
-    """
-    for (topic, message) in queue:
-        if topic == ANNOTATIONS_TOPIC:
-            broadcast_annotation_message(message, sockets)
-        elif topic == USER_TOPIC:
-            broadcast_session_change_message(message, sockets)
 
 
 def broadcast_annotation_message(message, sockets):
@@ -655,10 +620,82 @@ def should_send_annotation_event(socket, annotation, event_data):
     return True
 
 
+def process_message(reader, message):
+    """
+    Process a message from the queue.
+
+    Distributes messages from the queue to the appropriate handler functions.
+    """
+    if reader.topic == ANNOTATIONS_TOPIC:
+        broadcast_annotation_message(message, WebSocket.instances)
+    elif reader.topic == USER_TOPIC:
+        broadcast_session_change_message(message, WebSocket.instances)
+    else:
+        log.warn("streamer: don't know how to handle message from topic '%s'",
+                 reader.topic)
+
+
+def process_queue(settings, topics):
+    """
+    Configure, start, and monitor the queue readers.
+
+    This sets up all the passed readers to route their messages to
+    `process_message`, starts them, and then enters a loop that checks that the
+    reader threads never join. If they do, this fact is logged and all readers
+    are killed.
+    """
+    channel = 'stream-{}#ephemeral'.format(_random_id())
+    readers = [queue.get_reader(settings, topic, channel)
+               for topic in topics]
+
+    # Start all the readers
+    for reader in readers:
+        reader.on_message.connect(receiver=process_message)
+        reader.start(block=False)
+
+    _wait_for_readers(readers)
+
+    # We should never get here. If we do, it's because a reader thread has
+    # prematurely quit.
+    log.error("queue reader exited: killing readers and starting again")
+    for reader in readers:
+        reader.close()
+
+
 def _random_id():
     """Generate a short random string"""
     data = struct.pack('Q', random.getrandbits(64))
     return base64.urlsafe_b64encode(data).strip(b'=')
+
+
+def _wait_for_readers(readers):
+    """Wait for one or more of the readers to exit."""
+    while True:
+        for reader in readers:
+            reader.join(timeout=1)
+            if not reader.is_running:
+                return
+
+
+def _process_queue_loop(settings, topics):
+    while True:
+        process_queue(settings, topics)
+
+
+@subscriber(ApplicationCreated)
+def start_queue_processing(event):
+    """
+    Start a greenlet to process the incoming data from NSQ.
+
+    This subscriber is called when the application is booted, and kicks off a
+    greenlet running `process_queue`. The function does not block.
+    """
+    settings = event.app.registry.settings
+    topics = [
+        ANNOTATIONS_TOPIC,
+        USER_TOPIC,
+    ]
+    gevent.spawn(_process_queue_loop, settings, topics)
 
 
 def websocket(request):

--- a/h/test/queue_test.py
+++ b/h/test/queue_test.py
@@ -9,8 +9,8 @@ from h import queue
 
 @patch('gnsq.Reader')
 def test_get_reader_default(fake_reader):
-    req = testing.DummyRequest()
-    queue.get_reader(req, 'ethics-in-games-journalism', 'channel4')
+    settings = {}
+    queue.get_reader(settings, 'ethics-in-games-journalism', 'channel4')
     fake_reader.assert_called_with('ethics-in-games-journalism',
                                    'channel4',
                                    nsqd_tcp_addresses=['localhost:4150'])
@@ -18,11 +18,10 @@ def test_get_reader_default(fake_reader):
 
 @patch('gnsq.Reader')
 def test_get_reader(fake_reader):
-    req = testing.DummyRequest()
-    req.registry.settings.update({
+    settings = {
         'nsq.reader.addresses': "foo:1234\nbar:4567"
-    })
-    queue.get_reader(req, 'ethics-in-games-journalism', 'channel4')
+    }
+    queue.get_reader(settings, 'ethics-in-games-journalism', 'channel4')
     fake_reader.assert_called_with('ethics-in-games-journalism',
                                    'channel4',
                                    nsqd_tcp_addresses=['foo:1234',
@@ -35,11 +34,10 @@ def test_get_reader_namespace(fake_reader):
     a reader that automatically prefixes the namespace onto the name of the
     topic being read.
     """
-    req = testing.DummyRequest()
-    req.registry.settings.update({
+    settings = {
         'nsq.namespace': "abc123"
-    })
-    queue.get_reader(req, 'safari', 'elephants')
+    }
+    queue.get_reader(settings, 'safari', 'elephants')
     fake_reader.assert_called_with('abc123-safari',
                                    'elephants',
                                    nsqd_tcp_addresses=['localhost:4150'])
@@ -47,16 +45,15 @@ def test_get_reader_namespace(fake_reader):
 
 @patch('gnsq.Nsqd')
 def test_get_writer_default(fake_nsqd):
-    req = testing.DummyRequest()
-    queue.get_writer(req)
+    settings = {}
+    queue.get_writer(settings)
     fake_nsqd.assert_called_with('localhost', http_port='4151')
 
 
 @patch('gnsq.Nsqd')
 def test_get_writer(fake_nsqd):
-    req = testing.DummyRequest()
-    req.registry.settings.update({'nsq.writer.address': 'philae:2014'})
-    queue.get_writer(req)
+    settings = {'nsq.writer.address': 'philae:2014'}
+    queue.get_writer(settings)
     fake_nsqd.assert_called_with('philae', http_port='2014')
 
 
@@ -68,12 +65,11 @@ def test_get_writer_namespace(fake_nsqd):
     given to :method:`gnsq.Nsqd.publish` or :method:`gnsq.Nsqd.mpublish`.
     """
     fake_client = fake_nsqd.return_value
-    req = testing.DummyRequest()
-    req.registry.settings.update({
+    settings = {
         'nsq.namespace': "abc123"
-    })
+    }
 
-    writer = queue.get_writer(req)
+    writer = queue.get_writer(settings)
 
     writer.publish('sometopic', 'somedata')
     fake_client.publish.assert_called_with('abc123-sometopic', 'somedata')
@@ -81,11 +77,10 @@ def test_get_writer_namespace(fake_nsqd):
 @patch('gnsq.Nsqd')
 def test_writer_serializes_dict(fake_nsqd):
     fake_client = fake_nsqd.return_value
-    req = testing.DummyRequest()
-    req.registry.settings.update({
+    settings = {
         'nsq.namespace': 'abc',
-    })
-    writer = queue.get_writer(req)
+    }
+    writer = queue.get_writer(settings)
     writer.publish('sometopic', {
         'key': 'value',
     })


### PR DESCRIPTION
Prior to this commit, if an exception is thrown by a message handler (i.e. `h.streamer.broadcast_annotation_message` or `h.streamer.broadcast_session_change_message`) then the worst possible combination of events will occur:

1. NSQ will not be notified, and the message will thus not be requeued.
2. The greenlet processing the internal event queue will crash. There is no support in the code for restarting this greenlet, and thus all WebSocket clients connected to this worker (or that connect subsequently) will stop receiving updates.
3. The readers connected to NSQ will continue to receive messages and push them onto the internal event queue. These messages will never be handled, and will continue to stack up in memory until, presumably, the process OOMs.

All in all, not a terribly happy situation. It's very likely that this is what was causing our realtime update server to stop working occasionally, so thank you to @robertknight for spotting that!

This commit completely alters how we handle queue messages, fixing all three issues. The main changes are as follows:

- The internal queue is gone. Instead, we spin up a greenlet on app boot which is responsible, in turn, for starting the queue reader processes.
- The handling of all messages is done synchronously in the `on_message` handlers of the readers. In the event of an exception, `gnsq` will handle requeueing the message with NSQ.
- If any reader greenlet terminates (an event which should never occur) then all reader greenlets are killed and restarted. A message is also written to the logs to indicate that this happened.

There are numerous further simplifications which can now be made to this code, but I've omitted them from this PR in the interests of making the changes as clear as possible.