### PR TITLE
Revert "Use "should" instead of "must" for search queries"

### DIFF
--- a/h/api/search/query.py
+++ b/h/api/search/query.py
@@ -38,7 +38,7 @@ class Builder(object):
         query = {"match_all": {}}
 
         if matchers:
-            query = {"bool": {"should": matchers}}
+            query = {"bool": {"must": matchers}}
 
         if filters:
             query = {

--- a/h/api/search/test/query_test.py
+++ b/h/api/search/test/query_test.py
@@ -145,7 +145,7 @@ def test_builder_default_param_action():
 
     q = builder.build({"foo": "bar"})
 
-    assert q["query"] == {"bool": {"should": [{"match": {"foo": "bar"}}]}}
+    assert q["query"] == {"bool": {"must": [{"match": {"foo": "bar"}}]}}
 
 
 def test_builder_default_params_multidict():
@@ -159,7 +159,7 @@ def test_builder_default_params_multidict():
 
     assert q["query"] == {
         "bool": {
-            "should": [
+            "must": [
                 {"match": {"user": "fred"}},
                 {"match": {"user": "bob"}}
             ]
@@ -237,7 +237,7 @@ def test_builder_adds_matchers_to_query():
     q = builder.build({})
 
     assert q["query"] == {
-        "bool": {"should": [{"match": {"giraffe": "nose"}}]},
+        "bool": {"must": [{"match": {"giraffe": "nose"}}]},
     }
 
 


### PR DESCRIPTION
This reverts commit 7a9c8c7d54d109ad245047790c4de157b054141c, as discussed in #2540. At the moment the search endpoint is being used primarily as a filter endpoint, and default-AND semantics are more useful for this purpose.

Fixes #2540.