### PR TITLE
Simplify streamer

### DIFF
--- a/h/test/streamer_test.py
+++ b/h/test/streamer_test.py
@@ -256,11 +256,11 @@ class TestWebSocket(unittest.TestCase):
 
 class TestBroadcastAnnotationEvent(unittest.TestCase):
     def setUp(self):
-        self.message = FakeMessage(json.dumps({
+        self.message = {
             'annotation': {'id': 1},
             'action': 'delete',
             'src_client_id': 'pigeon',
-        }))
+        }
 
         self.should_patcher = patch('h.streamer.should_send_annotation_event')
         self.should = self.should_patcher.start()
@@ -294,11 +294,11 @@ class TestBroadcastSessionChangeEvent(unittest.TestCase):
         session_model = session_model_patcher.start()
         session_model.return_value = {'groups': [{'id': 'someid'}]}
 
-        message = FakeMessage(json.dumps({
+        message = {
             'type': 'group-join',
             'userid': 'amy',
             'group': 'groupid',
-        }))
+        }
 
         sock = FakeSocket('clientid')
         sock.request.authenticated_userid = 'amy'
@@ -412,11 +412,20 @@ class TestShouldSendEvent(unittest.TestCase):
 
 def test_process_message_calls_handler_with_sockets():
     handler = Mock()
-    message = '{"foo": "bar"}'
+    message = FakeMessage('{"foo": "bar"}')
 
     streamer.process_message(handler, Mock(), message)
 
-    handler.assert_called_once_with(message, WebSocket.instances)
+    handler.assert_called_once_with(ANY, WebSocket.instances)
+
+
+def test_process_message_deserializes_messages():
+    handler = Mock()
+    message = FakeMessage('{"foo": "bar"}')
+
+    streamer.process_message(handler, Mock(), message)
+
+    handler.assert_called_once_with({'foo': 'bar'}, ANY)
 
 
 def test_process_queue_creates_reader_for_topic(get_reader):

--- a/h/test/streamer_test.py
+++ b/h/test/streamer_test.py
@@ -7,6 +7,7 @@ from collections import namedtuple
 import json
 
 import pytest
+import mock
 from mock import ANY
 from mock import MagicMock, Mock
 from mock import patch
@@ -15,9 +16,7 @@ from pyramid.testing import DummyRequest
 from h import streamer
 from h.streamer import FilterToElasticFilter
 from h.streamer import WebSocket
-from h.streamer import should_send_annotation_event
 from h.streamer import websocket
-from h.streamer import ANNOTATIONS_TOPIC
 
 
 FakeMessage = namedtuple('FakeMessage', 'body')
@@ -254,178 +253,222 @@ class TestWebSocket(unittest.TestCase):
             assert 'http://example.com/print' in uri_values
 
 
-class TestBroadcastAnnotationEvent(unittest.TestCase):
-    def setUp(self):
-        self.message = {
-            'annotation': {'id': 1},
-            'action': 'delete',
-            'src_client_id': 'pigeon',
-        }
+def test_handle_annotation_event_annotation_notification_format():
+    """Check the format of the returned notification in the happy case."""
+    message = {
+        'annotation': {'permissions': {'read': ['group:__world__']}},
+        'action': 'update',
+        'src_client_id': 'pigeon'
+    }
+    socket = FakeSocket('giraffe')
 
-        self.should_patcher = patch('h.streamer.should_send_annotation_event')
-        self.should = self.should_patcher.start()
-
-    def tearDown(self):
-        self.should_patcher.stop()
-
-    def test_send_when_socket_should_receive_event(self):
-        self.should.return_value = True
-        sock = FakeSocket('giraffe')
-        streamer.broadcast_annotation_message(self.message, [sock])
-        assert sock.send.called
-
-    def test_no_send_when_socket_should_not_receive_event(self):
-        self.should.return_value = False
-        sock = FakeSocket('pigeon')
-        streamer.broadcast_annotation_message(self.message, [sock])
-        assert sock.send.called is False
-
-    def test_terminated_socket_does_not_receive_event(self):
-        self.should.return_value = True
-        sock = FakeSocket('giraffe')
-        sock.terminated = True
-        streamer.broadcast_annotation_message(self.message, [sock])
-        assert sock.send.called is False
+    assert streamer.handle_annotation_event(message, socket) == {
+        'payload': [message['annotation']],
+        'type': 'annotation-notification',
+        'options': {'action': 'update'},
+    }
 
 
-class TestBroadcastSessionChangeEvent(unittest.TestCase):
-    def test_should_send_session_change_when_joining_or_leaving_group(self):
-        session_model_patcher = patch('h.session.model')
-        session_model = session_model_patcher.start()
-        session_model.return_value = {'groups': [{'id': 'someid'}]}
+def test_handle_annotation_event_none_for_sender_socket():
+    """Should return None if the socket's client_id matches the message's."""
+    message = {
+        'annotation': {'permissions': {'read': ['group:__world__']}},
+        'action': 'update',
+        'src_client_id': 'pigeon'
+    }
+    socket = FakeSocket('pigeon')
 
-        message = {
-            'type': 'group-join',
-            'userid': 'amy',
-            'group': 'groupid',
-        }
-
-        sock = FakeSocket('clientid')
-        sock.request.authenticated_userid = 'amy'
-
-        streamer.broadcast_session_change_message(message, [sock])
-        sock.send.assert_called_with(json.dumps({
-            'type': 'session-change',
-            'action': 'group-join',
-            'model': session_model.return_value,
-        }))
-
-        session_model_patcher.stop()
+    assert streamer.handle_annotation_event(message, socket) is None
 
 
-class TestShouldSendEvent(unittest.TestCase):
-    def setUp(self):
-        self.sock_giraffe = FakeSocket('giraffe')
-        self.sock_giraffe.filter.match.return_value = True
+def test_handle_annotation_event_none_if_no_socket_filter():
+    """Should return None if the socket has no filter."""
+    message = {
+        'annotation': {'permissions': {'read': ['group:__world__']}},
+        'action': 'update',
+        'src_client_id': 'pigeon'
+    }
+    socket = FakeSocket('giraffe')
+    socket.filter = None
 
-        self.sock_pigeon = FakeSocket('pigeon')
-
-        self.sock_roadkill = FakeSocket('roadkill')
-        self.sock_roadkill.terminated = True
-
-    def test_non_sending_socket_receives_event(self):
-        data = {'action': 'update', 'src_client_id': 'pigeon'}
-        assert should_send_annotation_event(
-            self.sock_giraffe,
-            {'permissions': {'read': ['group:__world__']}},
-            data)
-
-    def test_sending_socket_does_not_receive_event(self):
-        data = {'action': 'update', 'src_client_id': 'pigeon'}
-        assert should_send_annotation_event(self.sock_pigeon, {}, data) is False
+    assert streamer.handle_annotation_event(message, socket) is None
 
 
-    def test_should_send_annotation_event_no_filter(self):
-        self.sock_giraffe.filter = None
-        data = {'action': 'update', 'src_client_id': 'pigeon'}
-        assert should_send_annotation_event(
-            self.sock_giraffe,
-            {'permissions': {'read': ['group:__world__']}},
-            data) is False
+def test_handle_annotation_event_none_if_action_is_read():
+    """Should return None if the message action is 'read'."""
+    message = {
+        'annotation': {'permissions': {'read': ['group:__world__']}},
+        'action': 'read',
+        'src_client_id': 'pigeon'
+    }
+    socket = FakeSocket('giraffe')
 
-    def test_should_send_annotation_event_doesnt_send_reads(self):
-        data = {'action': 'read', 'src_client_id': 'pigeon'}
-        assert should_send_annotation_event(self.sock_giraffe, {}, data) is False
+    assert streamer.handle_annotation_event(message, socket) is None
 
-    def test_should_send_annotation_event_filtered(self):
-        self.sock_pigeon.filter.match.return_value = False
-        data = {'action': 'update', 'src_client_id': 'giraffe'}
-        assert should_send_annotation_event(
-            self.sock_pigeon,
-            {'permissions': {'read': ['group:__world__']}},
-            data) is False
 
-    def test_should_send_annotation_event_does_not_send_nipsad_annotations(self):
-        """Users should not see annotations from NIPSA'd users."""
-        annotation = {'user': 'fred', 'nipsa': True}
-        socket = Mock(terminated=False, client_id='foo')
-        event_data = {'action': 'create', 'src_client_id': 'bar'}
+def test_handle_annotation_event_none_if_filter_does_not_match():
+    """Should return None if the socket filter doesn't match the message."""
+    message = {
+        'annotation': {'permissions': {'read': ['group:__world__']}},
+        'action': 'update',
+        'src_client_id': 'pigeon'
+    }
+    socket = FakeSocket('giraffe')
+    socket.filter.match.return_value = False
 
-        assert not should_send_annotation_event(socket, annotation, event_data)
+    assert streamer.handle_annotation_event(message, socket) is None
 
-    def test_should_send_annotation_event_does_send_nipsad_annotations(self):
-        """NIPSA'd users should see their own annotations."""
-        annotation = {'user': 'fred', 'nipsa': True}
-        socket = Mock(terminated=False, client_id='foo')
-        socket.request.authenticated_userid = 'fred'  # The annotation creator.
-        event_data = {'action': 'create', 'src_client_id': 'bar'}
 
-        assert should_send_annotation_event(socket, annotation, event_data)
-
-    def test_should_send_annotation_event_does_not_send_group_annotations(self):
-        """Users shouldn't see annotations in groups they aren't members of."""
-        annotation = {
+def test_handle_annotation_event_none_if_annotation_nipsad():
+    """Should return None if the annotation is from a NIPSA'd user."""
+    message = {
+        'annotation': {
             'user': 'fred',
-            'permissions': {'read': ['group:private-group']}
-        }
-        socket = Mock(terminated=False, client_id='foo')
-        socket.request.effective_principals = []  # No 'group:private-group'.
-        event_data = {'action': 'create', 'src_client_id': 'bar'}
-
-        assert not should_send_annotation_event(socket, annotation, event_data)
-
-    def test_should_send_annotation_event_does_send_nipsad_annotations(self):
-        """Users should see annotations from groups they are members of."""
-        annotation = {
-            'user': 'fred',
-            'group': 'private-group',
-            'permissions': {'read': ['group:private-group']}
-        }
-        socket = Mock(terminated=False, client_id='foo')
-        socket.request.effective_principals = ['group:private-group']
-        event_data = {'action': 'create', 'src_client_id': 'bar'}
-
-        assert should_send_annotation_event(socket, annotation, event_data)
-
-    def test_should_send_annotation_event_does_not_crash_if_no_group(self):
-        """Users should see annotations from groups they are members of."""
-        annotation = {
-            'user': 'fred',
+            'nipsa': True,
             'permissions': {'read': ['group:__world__']}
-        }
-        socket = Mock(terminated=False, client_id='foo')
-        socket.request.effective_principals = ['group:private-group']
-        event_data = {'action': 'create', 'src_client_id': 'bar'}
+        },
+        'action': 'update',
+        'src_client_id': 'pigeon'
+    }
+    socket = FakeSocket('giraffe')
 
-        assert should_send_annotation_event(socket, annotation, event_data)
+    assert streamer.handle_annotation_event(message, socket) is None
 
 
-def test_process_message_calls_handler_with_sockets():
+def test_handle_annotation_event_sends_nipsad_annotations_to_owners():
+    """NIPSA'd users should see their own annotations."""
+    message = {
+        'annotation': {
+            'user': 'fred',
+            'nipsa': True,
+            'permissions': {'read': ['group:__world__']}
+        },
+        'action': 'update',
+        'src_client_id': 'pigeon'
+    }
+    socket = FakeSocket('giraffe')
+    socket.request.authenticated_userid = 'fred'
+
+    assert streamer.handle_annotation_event(message, socket) is not None
+
+
+def test_handle_annotation_event_none_if_not_in_group():
+    """Users shouldn't see annotations in groups they aren't members of."""
+    message = {
+        'annotation': {
+            'user': 'fred',
+            'permissions': {'read': ['group:private-group']}
+        },
+        'action': 'update',
+        'src_client_id': 'pigeon'
+    }
+    socket = FakeSocket('giraffe')
+    socket.request.effective_principals = ['fred']  # No 'group:private-group'.
+
+    assert streamer.handle_annotation_event(message, socket) is None
+
+
+def test_handle_annotation_event_sends_if_in_group():
+    """Users should see annotations in groups they are members of."""
+    message = {
+        'annotation': {
+            'user': 'fred',
+            'permissions': {'read': ['group:private-group']}
+        },
+        'action': 'update',
+        'src_client_id': 'pigeon'
+    }
+    socket = FakeSocket('giraffe')
+    socket.request.effective_principals = ['fred', 'group:private-group']
+
+    assert streamer.handle_annotation_event(message, socket) is not None
+
+
+@patch('h.session.model')
+def test_handle_user_event_sends_session_change_when_joining_or_leaving_group(session_model):
+    message = {
+        'type': 'group-join',
+        'userid': 'amy',
+        'group': 'groupid',
+    }
+
+    sock = FakeSocket('clientid')
+    sock.request.authenticated_userid = 'amy'
+
+    assert streamer.handle_user_event(message, sock) == {
+        'type': 'session-change',
+        'action': 'group-join',
+        'model': session_model.return_value,
+    }
+
+
+def test_handle_user_event_none_when_socket_is_not_event_users():
+    """Don't send session-change events if the event user is not the socket user."""
+    message = {
+        'type': 'group-join',
+        'userid': 'amy',
+        'group': 'groupid',
+    }
+
+    sock = FakeSocket('clientid')
+    sock.request.authenticated_userid = 'bob'
+
+    assert streamer.handle_user_event(message, sock) is None
+
+
+@patch('h.streamer.WebSocket')
+def test_process_message_calls_handler_once_per_socket_with_deserialized_message(websocket):
     handler = Mock()
+    handler.return_value = None
     message = FakeMessage('{"foo": "bar"}')
+    websocket.instances = [FakeSocket('a'), FakeSocket('b')]
 
     streamer.process_message(handler, Mock(), message)
 
-    handler.assert_called_once_with(ANY, WebSocket.instances)
+    assert handler.mock_calls == [
+        mock.call({'foo': 'bar'}, websocket.instances[0]),
+        mock.call({'foo': 'bar'}, websocket.instances[1]),
+    ]
 
 
-def test_process_message_deserializes_messages():
+@patch('h.streamer.WebSocket')
+def test_process_message_sends_serialized_messages_down_websocket(websocket):
     handler = Mock()
+    handler.return_value = {'just': 'some message'}
     message = FakeMessage('{"foo": "bar"}')
+    socket = FakeSocket('a')
+    websocket.instances = [socket]
 
     streamer.process_message(handler, Mock(), message)
 
-    handler.assert_called_once_with({'foo': 'bar'}, ANY)
+    socket.send.assert_called_once_with('{"just": "some message"}')
+
+
+@patch('h.streamer.WebSocket')
+def test_process_message_does_not_send_messages_down_websocket_if_handler_response_is_none(websocket):
+    handler = Mock()
+    handler.return_value = None
+    message = FakeMessage('{"foo": "bar"}')
+    socket = FakeSocket('a')
+    websocket.instances = [socket]
+
+    streamer.process_message(handler, Mock(), message)
+
+    assert socket.send.call_count == 0
+
+
+@patch('h.streamer.WebSocket')
+def test_process_message_does_not_send_messages_down_websocket_if_socket_terminated(websocket):
+    handler = Mock()
+    handler.return_value = {'just': 'some message'}
+    message = FakeMessage('{"foo": "bar"}')
+    socket = FakeSocket('a')
+    socket.terminated = True
+    websocket.instances = [socket]
+
+    streamer.process_message(handler, Mock(), message)
+
+    assert socket.send.call_count == 0
 
 
 def test_process_queue_creates_reader_for_topic(get_reader):


### PR DESCRIPTION
Some more simplifications for `h.streamer`. These changes shouldn't change any functionality, and they don't fix any bugs, but they do make the code easier to read and easier to test. Specifically, our per-topic message handlers are no longer responsible for:

- serialisation/deserialisation
- writing to the websocket
- iterating over open websockets

All these responsibilities are now in one place, in `h.streamer.process_message`.