### PR TITLE
Improve flow when joining a group from logged-out

### DIFF
--- a/h/groups/templates/join.html.jinja2
+++ b/h/groups/templates/join.html.jinja2
@@ -21,7 +21,8 @@
           </button>
         </form>
       {% else %}
-      <form method="GET" action="/login" target="_blank">
+      <form method="GET" action="{{ request.route_url('login') }}">
+        <input type="hidden" name="next" value="{{ request.path }}">
         <button class="primary-action-btn" type="submit">
           Sign in to join {{ group.name }}
         </button>


### PR DESCRIPTION
Now, when joining a group from a logged-out state, you'll first see a "Sign in to join $GROUP" button, then you'll log in, then you'll be redirected back to the group page where you'll see a "Join $GROUP" button.