### PR TITLE
Add userid_domain config setting

### DIFF
--- a/h/accounts/models.py
+++ b/h/accounts/models.py
@@ -200,14 +200,8 @@ class User(Base):
         return valid
 
     @classmethod
-    def get_by_userid(cls, domain, userid):
+    def get_by_userid(cls, userid):
         """Return the user with the given ID, or None.
-
-        :param domain: The domain for the current request, for example:
-            u'hypothes.is'. This must match the domain part of the userid
-            argument - you can't retrieve users who don't belong to the given
-            domain.
-        :type domain: unicode
 
         :param userid: A userid unicode string, for example:
             u'acct:kim@hypothes.is'
@@ -221,9 +215,6 @@ class User(Base):
             username, userdomain = util.split_user(userid)
         except TypeError:
             # userid didn't match the pattern that split_user() expects.
-            return None
-
-        if userdomain != domain:
             return None
 
         return cls.get_by_username(username)

--- a/h/accounts/test/models_test.py
+++ b/h/accounts/test/models_test.py
@@ -20,7 +20,7 @@ def test_get_by_userid_calls_split_user(util):
     """It should call split_user() once with the given userid."""
     util.split_user.return_value = ('fred', 'hypothes.is')
 
-    models.User.get_by_userid('hypothes.is', 'acct:fred@hypothes.is')
+    models.User.get_by_userid('acct:fred@hypothes.is')
 
     util.split_user.assert_called_once_with('acct:fred@hypothes.is')
 
@@ -30,20 +30,9 @@ def test_get_by_userid_returns_None_for_TypeError(util):
     """If split_user() raises TypeError it should return None."""
     util.split_user.side_effect = TypeError
 
-    user = models.User.get_by_userid('hypothes.is', 'acct:fred@hypothes.is')
+    user = models.User.get_by_userid('acct:fred@hypothes.is')
 
     assert user is None
-
-
-@get_by_userid_fixtures
-def test_get_by_userid_returns_None_if_domain_does_not_match(util):
-    util.split_user.return_value = ('fred', 'bizarrohypothes.is')
-
-    result = models.User.get_by_userid(
-        'hypothes.is',  # Request domain doesn't match the userid domain.
-        'acct:fred@bizarrohypothes.is')
-
-    assert result is None
 
 
 @get_by_userid_fixtures
@@ -51,7 +40,7 @@ def test_get_by_userid_calls_get_by_username(util, get_by_username):
     """It should call get_by_username() once with the username."""
     util.split_user.return_value = ('username', 'domain')
 
-    models.User.get_by_userid('domain', 'acct:username@domain')
+    models.User.get_by_userid('acct:username@domain')
 
     get_by_username.assert_called_once_with('username')
 
@@ -61,7 +50,7 @@ def test_get_by_userid_returns_user(util, get_by_username):
     """It should return the result from get_by_username()."""
     util.split_user.return_value = ('username', 'domain')
 
-    user = models.User.get_by_userid('domain', 'acct:username@domain')
+    user = models.User.get_by_userid('acct:username@domain')
 
     assert user == get_by_username.return_value
 

--- a/h/accounts/test/views_test.py
+++ b/h/accounts/test/views_test.py
@@ -841,7 +841,7 @@ def test_profile_looks_up_by_logged_in_user(authn_policy, user_model):
 
     ProfileController(request).profile()
 
-    user_model.get_by_userid.assert_called_with(request.domain, "acct:foo@bar.com")
+    user_model.get_by_userid.assert_called_with("acct:foo@bar.com")
 
 
 @pytest.mark.usefixtures('user_model')

--- a/h/accounts/views.py
+++ b/h/accounts/views.py
@@ -484,8 +484,7 @@ class ProfileController(object):
         if err is not None:
             return err
 
-        user = User.get_by_userid(
-            self.request.domain, self.request.authenticated_userid)
+        user = User.get_by_userid(self.request.authenticated_userid)
         response = {'model': {'email': user.email}}
 
         # We allow updating subscriptions without validating a password
@@ -532,8 +531,7 @@ class ProfileController(object):
         if err is not None:
             return err
 
-        user = User.get_by_userid(
-            self.request.domain, self.request.authenticated_userid)
+        user = User.get_by_userid(self.request.authenticated_userid)
 
         if User.validate_user(user, appstruct['pwd']):  # Password check.
             # TODO: maybe have an explicit disabled flag in the status
@@ -553,7 +551,7 @@ class ProfileController(object):
         userid = request.authenticated_userid
         model = {}
         if userid:
-            model["email"] = User.get_by_userid(request.domain, userid).email
+            model["email"] = User.get_by_userid(userid).email
             model['subscriptions'] = Subscriptions.get_subscriptions_for_uri(
                 userid)
         return {'model': model}

--- a/h/auth.py
+++ b/h/auth.py
@@ -136,7 +136,7 @@ def groupfinder(userid, request):
     """
     principals = set()
 
-    user = models.User.get_by_userid(request.domain, userid)
+    user = models.User.get_by_userid(userid)
     if user is None:
         return
     if user.admin:

--- a/h/claim/invite.py
+++ b/h/claim/invite.py
@@ -14,6 +14,7 @@ from pyramid import paster
 from pyramid.request import Request
 import transaction
 
+from h import util
 from h.accounts import models
 from h.claim.util import generate_claim_url
 
@@ -73,7 +74,7 @@ def get_users(session, limit=None):
 
 def get_merge_vars(request, users):
     for user in users:
-        userid = 'acct:{}@{}'.format(user.username, request.domain)
+        userid = util.userid_from_username(user.username, requeat)
         claim = generate_claim_url(request, userid)
         recipient = user.email
         merge_vars = [

--- a/h/claim/views.py
+++ b/h/claim/views.py
@@ -72,7 +72,7 @@ def _validate_request(request):
     if payload is None:
         raise exc.HTTPNotFound()
 
-    user = User.get_by_userid(request.domain, payload['userid'])
+    user = User.get_by_userid(payload['userid'])
     if user is None:
         log.warn('got claim token with invalid userid=%r', payload['userid'])
         raise exc.HTTPNotFound()

--- a/h/config.py
+++ b/h/config.py
@@ -25,6 +25,7 @@ def settings_from_environment():
     _setup_webassets(settings)
     _setup_websocket(settings)
     _setup_blocklist(settings)
+    _setup_userid_domain(settings)
 
     return settings
 
@@ -179,3 +180,8 @@ def _setup_websocket(settings):
 def _setup_blocklist(settings):
     if 'BLOCKLIST' in os.environ:
         settings['h.blocklist'] = os.environ['BLOCKLIST']
+
+
+def _setup_userid_domain(settings):
+    if 'USERID_DOMAIN' in os.environ:
+        settings['h.userid_domain'] = os.environ['USERID_DOMAIN']

--- a/h/groups/test/views_test.py
+++ b/h/groups/test/views_test.py
@@ -111,8 +111,7 @@ def test_create_gets_user_with_authenticated_id(Form, User):
 
     views.create(request)
 
-    User.get_by_userid.assert_called_once_with(
-        request.domain, request.authenticated_userid)
+    User.get_by_userid.assert_called_once_with(request.authenticated_userid)
 
 
 @create_fixtures
@@ -379,8 +378,7 @@ def test_join_gets_user_with_authenticated_userid(User):
 
     views.join(request)
 
-    User.get_by_userid.assert_called_once_with(
-        request.domain, request.authenticated_userid)
+    User.get_by_userid.assert_called_once_with(request.authenticated_userid)
 
 
 @join_fixtures

--- a/h/groups/views.py
+++ b/h/groups/views.py
@@ -59,8 +59,7 @@ def create(request):
     except deform.ValidationFailure:
         return {'form': form.render()}
 
-    user = models.User.get_by_userid(request.domain,
-                                     request.authenticated_userid)
+    user = models.User.get_by_userid(request.authenticated_userid)
     group = models.Group(name=appstruct["name"], creator=user)
     request.db.add(group)
 
@@ -137,8 +136,7 @@ def read(request):
     if not request.authenticated_userid:
         return _login_to_join(request, group)
     else:
-        user = models.User.get_by_userid(request.domain,
-                                         request.authenticated_userid)
+        user = models.User.get_by_userid(request.authenticated_userid)
         if group in user.groups:
             return _read_group(request, group)
         else:
@@ -161,8 +159,7 @@ def join(request):
     if group is None:
         raise exc.HTTPNotFound()
 
-    user = models.User.get_by_userid(request.domain,
-                                     request.authenticated_userid)
+    user = models.User.get_by_userid(request.authenticated_userid)
 
     group.members.append(user)
     _send_group_notification(request, 'group-join', group.hashid)
@@ -197,8 +194,7 @@ def leave(request):
     if group is None:
         raise exc.HTTPNotFound()
 
-    user = models.User.get_by_userid(request.domain,
-                                     request.authenticated_userid)
+    user = models.User.get_by_userid(request.authenticated_userid)
 
     if user not in group.members:
         raise exc.HTTPNotFound()

--- a/h/session.py
+++ b/h/session.py
@@ -39,7 +39,7 @@ def _current_groups(request):
     userid = request.authenticated_userid
     if userid is None:
         return groups
-    user = models.User.get_by_userid(request.domain, userid)
+    user = models.User.get_by_userid(userid)
     if user is None:
         return groups
     for group in sorted(user.groups, key=_group_sort_key):

--- a/h/test/admin_test.py
+++ b/h/test/admin_test.py
@@ -128,7 +128,11 @@ nipsa_remove_fixtures = pytest.mark.usefixtures('nipsa')
 
 @nipsa_remove_fixtures
 def test_nipsa_remove_calls_nipsa_api_with_userid(nipsa):
-    request = Mock(params={"remove": "kiki"}, domain="hypothes.is")
+    request = Mock(
+        params={"remove": "kiki"},
+        domain="hypothes.is",
+        registry=Mock(settings={})
+    )
 
     admin.nipsa_remove(request)
 

--- a/h/test/util_test.py
+++ b/h/test/util_test.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import mock
+
 from h import util
 
 
@@ -10,3 +12,24 @@ def test_split_user():
 def test_split_user_no_match():
     parts = util.split_user("donkeys")
     assert parts is None
+
+
+def test_userid_from_username_uses_userid_domain_setting():
+    """It should use the h.userid_domain setting if set."""
+    userid = util.userid_from_username(
+        'douglas',
+        mock.Mock(
+            domain='should_not_be_used.com',
+            registry=mock.Mock(
+                settings={'h.userid_domain': 'example.com'})))
+
+    assert userid == 'acct:douglas@example.com'
+
+
+def test_userid_from_username_falls_back_on_request_domain():
+    """It should use request.domain if there's no h.userid_domain setting."""
+    userid = util.userid_from_username(
+        'douglas',
+        mock.Mock(domain='example.com', registry=mock.Mock(settings={})))
+
+    assert userid == 'acct:douglas@example.com'

--- a/h/util.py
+++ b/h/util.py
@@ -25,4 +25,6 @@ def userid_from_username(username, request):
 
     """
     return u"acct:{username}@{domain}".format(
-        username=username, domain=request.domain)
+        username=username,
+        domain=request.registry.settings.get(
+            'h.userid_domain', request.domain))


### PR DESCRIPTION
Add a config setting that overrides the domain in userids like
"acct:seanh@domain.com". If no h.userid_domain config file setting or
USERID_DOMAIN environment variable is given it falls back on the old behavior:
use request.domain.

This new setting is useful for our staging and production sites.
request.domain is hypothes.is on production but stage.hypothes.is on staging.
The two sites share the same database and search index. It's actually the same
user account in the database that you're logging in to when you log in to
either staging or production, since the user accounts in the database are
keyed by just the username (eg. seanh) and don't use the domain part. But for
example the permissions access control lists in the annotations use the full
userids, acct:seanh@stage.hypothes.is or acct:seanh@hypothes.is. This means
that if you logged into your account via stage.hypothes.is you won't be able to
edit your annotations made while logged into production hypothes.is, and
vice-versa.

With this new config setting, we can override the domain on the staging site
so that you get acct:seanh@hypothes.is when you log into either site and can
always edit all of your annotations.

This commit also removes a feature from the get_by_userid() class method.
Previously you would pass it a domain like hypothes.is and a userid like
acct:seanh@hypothes.is, and if the two domains didn't match it would return
None. This could never happen because everywhere this method is called it's
passed request.domain and request.authenticated_userid so the domains always
match.

But with the new config setting, it's possible for request.authenticated_userid
to be acct:seanh@hypothes.is while request.domain is stage.hypothes.is, causing
get_by_userid() to return None, which breaks things, for example you can no
longer login.

I could change every place that calls get_by_userid() to pass in the
userid_domain setting instead of request.domain. But that's just silly:
userid_from_username() is fetching userid_domain, and the code that calls
get_by_userid() if fetching the same userid_domain setting, and then
get_by_userid() is verifying that the setting is the same as itself and
having a `return None` line that can never get called.

Instead, just remove this feature from get_by_userid().