### PR TITLE
Fix group link not being focused in dropdown menu if group hash IDs started with a number

### DIFF
--- a/h/static/scripts/directive/group-list.js
+++ b/h/static/scripts/directive/group-list.js
@@ -50,7 +50,9 @@ function groupList(groups, $window) {
           // wait for the share link field to be revealed and then select
           // the link's text
           setTimeout(function() {
-            var activeShareLinkField = elem[0].querySelector('.share-link-field[data-group-id=' + activeGroupId + ']');
+            var shareLinkSelector = '.share-link-field[data-group-id="' +
+                                    activeGroupId + '"]';
+            var activeShareLinkField = elem[0].querySelector(shareLinkSelector);
             activeShareLinkField.focus();
             activeShareLinkField.select();
           }, 0);


### PR DESCRIPTION
The hash ID was not quoted when constructing the selector
used to find the group's link field in order to focus it,
resulting in an error depending on the chars in the hash ID.