### PR TITLE
Make settings loader CSP-compatible

### DIFF
--- a/h/static/scripts/settings.js
+++ b/h/static/scripts/settings.js
@@ -7,18 +7,20 @@ var angular = require('angular');
  * @name  settings
  *
  * @description
- * The 'settings' factory exposes shared application settings, read from the
- * global variable 'hypothesis.settings' in the app page.
+ * The 'settings' factory exposes shared application settings, read from a
+ * script tag with type "application/json" and id "hypothesis-settings" in the
+ * app page.
  */
 // @ngInject
-function settings($window) {
-  var data = {};
+function settings($document) {
+  var settingsElement = $document[0].querySelector(
+    'script[type="application/json"]#hypothesis-settings');
 
-  if ($window.hypothesis && $window.hypothesis.settings) {
-    angular.copy($window.hypothesis.settings, data);
+  if (settingsElement) {
+    return angular.fromJson(settingsElement.textContent);
   }
 
-  return data;
+  return {};
 }
 
 module.exports = settings;

--- a/h/templates/app.html.jinja2
+++ b/h/templates/app.html.jinja2
@@ -100,12 +100,11 @@
 {% block ga_pageview %}{% endblock %}
 
 {% block scripts %}
-  <script>
-    window.hypothesis = window.hypothesis || {};
-    window.hypothesis.settings = {
-      apiUrl: "{{ request.route_url('api') }}",
-      websocketUrl: "{{ request.route_url('ws') | websocketize }}",
-    };
+  <script id="hypothesis-settings" type="application/json">
+    {
+      "apiUrl": "{{ request.route_url('api') }}",
+      "websocketUrl": "{{ request.route_url('ws') | websocketize }}"
+    }
   </script>
   {% assets "app_js" %}
     <script src="{{ ASSET_URL }}"></script>


### PR DESCRIPTION
I forgot about CSP! We disallow inline scripts in the Chrome extension, so 18c47ba broke the extension. This commit replaces an inline script with some JSON data, parsed by the settings factory.