### PR TITLE
Extension badge refactor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,11 +47,14 @@ client-test: client-app-test client-extension-test
 client-app-test: deps
 	@$(NPM_BIN)/karma start h/static/scripts/karma.config.js --single-run
 
+client-app-test-watch: deps
+	@$(NPM_BIN)/karma start h/static/scripts/karma.config.js
+
 client-extension-test: deps
 	@$(NPM_BIN)/karma start h/browser/chrome/karma.config.js --single-run
 
-client-test-watch: deps
-	@$(NPM_BIN)/karma start h/static/scripts/karma.config.js
+client-extension-test-watch: deps
+	@$(NPM_BIN)/karma start h/browser/chrome/karma.config.js
 
 cover:
 	@python setup.py test --cov

--- a/h/browser/chrome/karma.config.js
+++ b/h/browser/chrome/karma.config.js
@@ -77,7 +77,7 @@ module.exports = function(config) {
 
 
     // enable / disable watching file and executing tests whenever any file changes
-    autoWatch: false,
+    autoWatch: true,
 
 
     // start these browsers
@@ -87,6 +87,6 @@ module.exports = function(config) {
 
     // Continuous Integration mode
     // if true, Karma captures browsers, runs the tests and exits
-    singleRun: true
+    singleRun: false
   });
 };

--- a/h/browser/chrome/lib/browser-action.js
+++ b/h/browser/chrome/lib/browser-action.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var settings = require('./settings');
 var TabState = require('./tab-state');
 
 // Cache the tab state constants.
@@ -23,117 +24,56 @@ function _(str) {
 }
 
 /* Controls the display of the browser action button setting the icon, title
- * and badges depending on the current state of the tab. This is a stateless
- * module and does not store the current state. A TabState instance should
- * be used to manage which tabs are active/inactive.
+ * and badges depending on the current state of the tab.
+ *
+ * BrowserAction is responsible for mapping the logical H state of
+ * a tab (whether the extension is active, annotation count) to
+ * the badge state.
  */
 function BrowserAction(chromeBrowserAction) {
-  this.setState = function (tabId, state) {
-    switch (state) {
-      case states.ACTIVE:   this.activate(tabId); break;
-      case states.INACTIVE: this.deactivate(tabId); break;
-      case states.ERRORED:  this.error(tabId); break;
-      default: throw new TypeError('State ' + state + ' is invalid');
-    }
-  };
-
   /**
-   * Set the "title" (tooltip) of the browser action _if_ no badge is
-   * currently displayed on the browser action.
-   * @param {integer} tabId The id of the tab to set the badge title for.
-   * @param {string} title The value to set the title to.
-   */
-  function setTitleIfNoBadge(tabId, title) {
-    chromeBrowserAction.getBadgeText({tabId: tabId}, function(text) {
-      if (!text) {
-        chromeBrowserAction.setTitle({tabId: tabId, title: title});
-      }
-    });
-  }
-
-  /**
-   * Set the "title" (tooltip) and badge text of the browser action.
-   * @param {integer} tabId The id of the tab to set the badge title for.
-   * @param {string} title The text to show in the tooltip.
-   * @param {string} badgeText The text to show on the badge.
-   */
-  function setTitleAndBadgeText(tabId, title, badgeText) {
-    chromeBrowserAction.setTitle({tabId: tabId, title: title});
-    chromeBrowserAction.setBadgeText({tabId: tabId, text: badgeText});
-  }
-
-  /* Sets the active browser action appearance for the provided tab id. */
-  this.activate = function(tabId) {
-    chromeBrowserAction.setIcon({tabId: tabId, path: icons[states.ACTIVE]});
-    setTitleIfNoBadge(tabId, _('Hypothesis is active'));
-  };
-
-  /* Sets the inactive browser action appearance for the provided tab id. */
-  this.deactivate = function(tabId) {
-    chromeBrowserAction.setIcon({tabId: tabId, path: icons[states.INACTIVE]});
-    setTitleIfNoBadge(tabId, _('Hypothesis is inactive'));
-  };
-
-  /* Sets the errored browser action appearance for the provided tab id. */
-  this.error = function(tabId) {
-    chromeBrowserAction.setIcon({tabId: tabId, path: icons[states.INACTIVE]});
-    setTitleAndBadgeText(tabId,  _('Hypothesis has failed to load'), '!');
-  };
-
-  /**
-   * Show the number of annotations of the current page in the badge.
+   * Updates the state of the browser action to reflect the logical
+   * H state of a tab.
    *
-   * @method
-   * @param {integer} tabId The id of the current tab.
-   * @param {string} tabUrl The URL of the current tab.
-   * @param {string} apiUrl The URL of the Hypothesis API.
+   * @param state - The H state of a tab. See the 'tab-state' module.
    */
-  this.updateBadge = function(tabId, tabUrl, apiUrl) {
-    // Fetch the number of annotations of the current page from the server,
-    // and display it as a badge on the browser action button.
-    var xhr = new XMLHttpRequest();
-    xhr.onload = function() {
-      var total;
+  this.update = function(tabId, state) {
+    var activeIcon = icons[states.INACTIVE];
+    var title = '';
+    var badgeText = '';
 
-      try {
-        total = JSON.parse(this.response).total;
-      } catch (e) {
-        console.error(
-          'updateBadge() received invalid JSON from the server: ' + e);
-        return;
+    if (state.state === states.ACTIVE) {
+      activeIcon = icons[states.ACTIVE];
+      title = 'Hypothesis is active';
+    } else if (state.state === states.INACTIVE) {
+      title = 'Hypothesis is inactive';
+    } else if (state.state === states.ERRORED) {
+      title = 'Hypothesis failed to load';
+      badgeText = '!';
+    } else {
+      throw new Error('Unknown tab state');
+    }
+
+    if (state.state !== states.ERRORED && state.annotationCount) {
+      var countLabel;
+      var totalString = state.annotationCount.toString();
+      if (state.annotationCount > 999) {
+        totalString = '999+';
       }
-
-      if (typeof total !== 'number') {
-        console.error(
-          'updateBadge() received invalid total from the server: ' + total);
-        return;
+      if (state.annotationCount === 1) {
+        countLabel = _("There's 1 annotation on this page");
+      } else {
+        countLabel = _('There are ' + totalString + ' annotations on ' +
+                  'this page');
       }
+      title = countLabel;
+      badgeText = totalString;
+    }
 
-      if (total > 0) {
-        var totalString = total.toString();
-        if (total > 999) {
-          totalString = '999+';
-        }
-        chromeBrowserAction.getBadgeText({tabId: tabId}, function(text) {
-          // The num. annotations badge is low priority - we only set it if
-          // there's no other badge currently showing.
-          if (!text) {
-            var title;
-            if (total === 1) {
-              title = _("There's 1 annotation on this page");
-            } else {
-              title = _('There are ' + totalString + ' annotations on ' +
-                        'this page');
-            }
-            setTitleAndBadgeText(tabId, title, totalString);
-          }
-        });
-      }
-    };
-
-    xhr.open('GET', apiUrl + '/badge?uri=' + tabUrl);
-    xhr.send();
-  };
+    chromeBrowserAction.setBadgeText({tabId: tabId, text: badgeText});
+    chromeBrowserAction.setIcon({tabId: tabId, path: activeIcon});
+    chromeBrowserAction.setTitle({tabId: tabId, title: title});
+  }
 }
 
 BrowserAction.icons = icons;

--- a/h/browser/chrome/lib/hypothesis-chrome-extension.js
+++ b/h/browser/chrome/lib/hypothesis-chrome-extension.js
@@ -98,7 +98,7 @@ function HypothesisChromeExtension(dependencies) {
 
   function onTabStateChange(tabId, current, previous) {
     if (current) {
-      browserAction.setState(tabId, current);
+      browserAction.update(tabId, current);
 
       if (!state.isTabErrored(tabId)) {
         store.set(tabId, current);
@@ -138,17 +138,16 @@ function HypothesisChromeExtension(dependencies) {
       state.restorePreviousState(tabId);
     }
 
-    if (state.isTabActive(tabId)) {
-      browserAction.activate(tabId);
-    } else {
+    if (!state.isTabActive(tabId)) {
       // Clear the state to express that the user has no preference.
       // This allows the publisher embed to persist without us destroying it.
       state.clearTab(tabId);
-      browserAction.deactivate(tabId);
     }
 
+    browserAction.update(tabId, state.getState(tabId));
+
     settings.then(function(settings) {
-      browserAction.updateBadge(tabId, tab.url, settings.apiUrl);
+      state.updateAnnotationCount(tabId, tab.url, settings.apiUrl);
     });
 
     return updateTabDocument(tab);

--- a/h/browser/chrome/lib/tab-store.js
+++ b/h/browser/chrome/lib/tab-store.js
@@ -36,7 +36,18 @@ function TabStore(storage) {
 
   this.reload = function () {
     try {
-      local = JSON.parse(storage.getItem(key));
+      local = {};
+      var loaded = JSON.parse(storage.getItem(key));
+      Object.keys(loaded).forEach(function (key) {
+        // ignore tab state saved by earlier versions of
+        // the extension which saved the state as a {key: <state string>}
+        // dict rather than {key: <state object>}
+        if (typeof loaded[key] === 'string') {
+          local[key] = {state: loaded[key]};
+        } else {
+          local[key] = loaded[key];
+        }
+      });
     } catch (e) {
       local = null;
     }

--- a/h/browser/chrome/test/browser-action-test.js
+++ b/h/browser/chrome/test/browser-action-test.js
@@ -1,3 +1,5 @@
+var assign = require('core-js/modules/$.assign');
+
 describe('BrowserAction', function () {
   'use strict';
 
@@ -8,341 +10,134 @@ describe('BrowserAction', function () {
 
   beforeEach(function () {
     fakeChromeBrowserAction = {
-      setIcon: sinon.spy(),
-      setTitle: sinon.spy(),
-      getBadgeText: function(args, func) {
-        func('');
+      annotationCount: 0,
+      title: '',
+      badgeText: '',
+
+      setIcon: function (options) {
+        this.icon = options.path;
       },
-      setBadgeText: sinon.spy()
+      setTitle: function (options) {
+        this.title = options.title;
+      },
+      setBadgeText: function (options) {
+        this.badgeText = options.text;
+      },
     };
     action = new BrowserAction(fakeChromeBrowserAction);
   });
 
-  describe('.activate', function () {
+  describe('active state', function () {
     it('sets the active browser icon', function () {
-      var spy = fakeChromeBrowserAction.setIcon;
-      action.activate(1);
-      assert.calledWith(spy, {
-        tabId: 1,
-        path: BrowserAction.icons[TabState.states.ACTIVE],
-      });
+      action.update(1, {state: TabState.states.ACTIVE});
+      assert.equal(fakeChromeBrowserAction.icon, BrowserAction.icons[TabState.states.ACTIVE]);
     });
 
     it('sets the title of the browser icon', function () {
-      var spy = fakeChromeBrowserAction.setTitle;
-      action.activate(1);
-      assert.calledWith(spy, {
-        tabId: 1,
-        title: 'Hypothesis is active'
-      });
+      action.update(1, {state: TabState.states.ACTIVE});
+      assert.equal(fakeChromeBrowserAction.title, 'Hypothesis is active');
     });
 
     it('does not set the title if there is badge text showing', function () {
-      var originalGetBadgeTextFunc = fakeChromeBrowserAction.getBadgeText;
-      fakeChromeBrowserAction.getBadgeText = function(args, func) {
-        func('9');  // The number of annotations is showing on the badge.
+      var state = {
+        state: TabState.states.INACTIVE,
+        annotationCount: 9,
       };
-
-      action.activate(1);
-
-      assert.notCalled(fakeChromeBrowserAction.setTitle);
-      fakeChromeBrowserAction.getBadgeText = originalGetBadgeTextFunc;
+      action.update(1, state);
+      var prevTitle = fakeChromeBrowserAction.title;
+      action.update(1, assign(state, {state: TabState.states.ACTIVE}));
+      assert.equal(fakeChromeBrowserAction.title, prevTitle);
     });
   });
 
-  describe('.deactivate', function () {
-    it('sets the inactive browser icon', function () {
-      var spy = fakeChromeBrowserAction.setIcon;
-      action.deactivate(1);
-      assert.calledWith(spy, {
-        tabId: 1,
-        path: BrowserAction.icons[TabState.states.INACTIVE],
-      });
-    });
-
-    it('sets the title of the browser icon', function () {
-      var spy = fakeChromeBrowserAction.setTitle;
-      action.deactivate(1);
-      assert.calledWith(spy, {
-        tabId: 1,
-        title: 'Hypothesis is inactive'
-      });
-    });
-
-    it('does not set the title if there is badge text showing', function () {
-      var originalGetBadgeTextFunc = fakeChromeBrowserAction.getBadgeText;
-      fakeChromeBrowserAction.getBadgeText = function(args, func) {
-        func('9');  // The number of annotations is showing on the badge.
-      };
-
-      action.deactivate(1);
-
-      assert.notCalled(fakeChromeBrowserAction.setTitle);
-      fakeChromeBrowserAction.getBadgeText = originalGetBadgeTextFunc;
+  describe('inactive state', function () {
+    it('sets the inactive browser icon and title', function () {
+      action.update(1, {state: TabState.states.INACTIVE});
+      assert.equal(fakeChromeBrowserAction.icon, BrowserAction.icons[TabState.states.INACTIVE]);
+      assert.equal(fakeChromeBrowserAction.title, 'Hypothesis is inactive');
     });
   });
 
-  describe('.error', function () {
+  describe('error state', function () {
     it('sets the inactive browser icon', function () {
-      var spy = fakeChromeBrowserAction.setIcon;
-      action.error(1);
-      assert.calledWith(spy, {
-        tabId: 1,
-        path: BrowserAction.icons[TabState.states.INACTIVE],
-      });
+      action.update(1, {state: TabState.states.ERRORED});
+      assert.equal(fakeChromeBrowserAction.icon, BrowserAction.icons[TabState.states.INACTIVE]);
     });
 
     it('sets the title of the browser icon', function () {
-      var spy = fakeChromeBrowserAction.setTitle;
-      action.error(1);
-      assert.calledWith(spy, {
-        tabId: 1,
-        title: 'Hypothesis has failed to load'
-      });
+      action.update(1, {state: TabState.states.ERRORED});
+      assert.equal(fakeChromeBrowserAction.title, 'Hypothesis failed to load');
     });
 
     it('still sets the title even there is badge text showing', function () {
-      var originalGetBadgeTextFunc = fakeChromeBrowserAction.getBadgeText;
-      fakeChromeBrowserAction.getBadgeText = function(args, func) {
-        func('9');  // The number of annotations is showing on the badge.
-      };
-
-      action.error(1);
-
-      assert.calledWith(fakeChromeBrowserAction.setTitle, {
-        tabId: 1,
-        title: 'Hypothesis has failed to load'
+      action.update(1, {
+        state: TabState.states.ERRORED,
+        annotationCount: 9,
       });
-      fakeChromeBrowserAction.getBadgeText = originalGetBadgeTextFunc;
+      assert.equal(fakeChromeBrowserAction.title, 'Hypothesis failed to load');
     });
 
     it('shows a badge', function () {
-      var spy = fakeChromeBrowserAction.setBadgeText;
-      action.error(1);
-      assert.calledWith(spy, {
-        tabId: 1,
-        text: '!'
+      action.update(1, {
+        state: TabState.states.ERRORED,
       });
+      assert.equal(fakeChromeBrowserAction.badgeText, '!');
     });
   });
 
-  describe('.setState', function () {
-    it('allows the state to be set via a constant', function () {
-      var spy = fakeChromeBrowserAction.setIcon;
-      action.setState(1, TabState.states.ACTIVE);
-      assert.calledWith(spy, {
-        tabId: 1,
-        path: BrowserAction.icons[TabState.states.ACTIVE],
+  describe('annotation counts', function () {
+    it("sets the badge text", function() {
+      action.update(1, {
+        state: TabState.states.INACTIVE,
+        annotationCount: 23,
       });
+      assert.equal(fakeChromeBrowserAction.badgeText, '23');
     });
-  });
 
-  describe('.updateBadge()', function() {
-    var server;
-
-    beforeEach(function() {
-      server = sinon.fakeServer.create({
-        autoRespond: true,
-        respondImmediately: true
+    it("sets the badge title when there's 1 annotation",
+      function () {
+      action.update(1, {
+        state: TabState.states.INACTIVE,
+        annotationCount: 1,
       });
-      server.respondWith(
-        "GET", "http://example.com/badge?uri=tabUrl",
-        [200, {}, '{"total": 1}']
-      );
-      sinon.stub(console, 'error');
+      assert.equal(fakeChromeBrowserAction.title,
+        "There's 1 annotation on this page");
     });
 
-    afterEach(function() {
-      server.restore();
-      console.error.restore();
-    });
-
-    it('sends the correct XMLHttpRequest to the server', function() {
-      action.updateBadge("tabId", "tabUrl", "http://example.com");
-
-      assert(server.requests.length === 1);
-      var request = server.requests[0];
-      assert(request.method === "GET");
-      assert(request.url === "http://example.com/badge?uri=tabUrl");
-    });
-
-    it("doesn't set the badge if the server's JSON is invalid", function() {
-      server.respondWith(
-        "GET", "http://example.com/badge?uri=tabUrl",
-        [200, {}, 'this is not valid json']
-      );
-
-      action.updateBadge("tabId", "tabUrl", "http://example.com");
-
-      assert(fakeChromeBrowserAction.setBadgeText.notCalled);
-      assert(fakeChromeBrowserAction.setTitle.notCalled);
-    });
-
-    it("logs an error if the server's JSON is invalid", function() {
-      server.respondWith(
-        "GET", "http://example.com/badge?uri=tabUrl",
-        [200, {}, 'this is not valid json']
-      );
-
-      action.updateBadge("tabId", "tabUrl", "http://example.com");
-
-      assert(console.error.called);
-    });
-
-    it("doesn't set the badge if the server's total is invalid", function() {
-      server.respondWith(
-        "GET", "http://example.com/badge?uri=tabUrl",
-        [200, {}, '{"total": "not a valid number"}']
-      );
-
-      action.updateBadge("tabId", "tabUrl", "http://example.com");
-
-      assert(fakeChromeBrowserAction.setBadgeText.notCalled);
-      assert(fakeChromeBrowserAction.setTitle.notCalled);
-    });
-
-    it("logs an error if the server's total is invalid", function() {
-      server.respondWith(
-        "GET", "http://example.com/badge?uri=tabUrl",
-        [200, {}, '{"total": "not a valid number"}']
-      );
-
-      action.updateBadge("tabId", "tabUrl", "http://example.com");
-
-      assert(console.error.called);
-    });
-
-    it("doesn't set the badge if server response has no total", function() {
-      server.respondWith(
-        "GET", "http://example.com/badge?uri=tabUrl",
-        [200, {}, '{"rows": []}']
-      );
-
-      action.updateBadge("tabId", "tabUrl", "http://example.com");
-
-      assert(fakeChromeBrowserAction.setBadgeText.notCalled);
-      assert(fakeChromeBrowserAction.setTitle.notCalled);
-    });
-
-    it("logs an error if the server response has no total", function() {
-      server.respondWith(
-        "GET", "http://example.com/badge?uri=tabUrl",
-        [200, {}, '{"rows": []}']
-      );
-
-      action.updateBadge("tabId", "tabUrl", "http://example.com");
-
-      assert(console.error.called);
-    });
-
-    it("sets the browserAction's badge text", function() {
-      server.respondWith(
-        "GET", "http://example.com/badge?uri=tabUrl",
-        [200, {}, '{"total": 23}']
-      );
-
-      action.updateBadge("tabId", "tabUrl", "http://example.com");
-
-      assert(fakeChromeBrowserAction.setBadgeText.calledOnce);
-      assert(fakeChromeBrowserAction.setBadgeText.calledWithExactly(
-        {tabId: "tabId", text: "23"}));
-    });
-
-    it("sets the browserAction's title badge text when there's 1 annotation",
+    it("sets the badge title when there's >1 annotation",
         function() {
-      server.respondWith(
-        "GET", "http://example.com/badge?uri=tabUrl",
-        [200, {}, '{"total": 1}']
-      );
-
-      action.updateBadge("tabId", "tabUrl", "http://example.com");
-
-      assert(fakeChromeBrowserAction.setTitle.calledOnce);
-      assert(fakeChromeBrowserAction.setTitle.calledWithExactly(
-        {tabId: "tabId", title: "There's 1 annotation on this page"}));
-    });
-
-    it("sets the browserAction's title badge text when there's >1 annotation",
-        function() {
-      server.respondWith(
-        "GET", "http://example.com/badge?uri=tabUrl",
-        [200, {}, '{"total": 23}']
-      );
-
-      action.updateBadge("tabId", "tabUrl", "http://example.com");
-
-      assert(fakeChromeBrowserAction.setTitle.calledOnce);
-      assert(fakeChromeBrowserAction.setTitle.calledWithExactly(
-        {tabId: "tabId", title: "There are 23 annotations on this page"}));
+      action.update(1, {
+        state: TabState.states.INACTIVE,
+        annotationCount: 23,
+      });
+      assert.equal(fakeChromeBrowserAction.title,
+        "There are 23 annotations on this page");
     });
 
     it("does not set the badge text if there are 0 annotations", function() {
-      server.respondWith(
-        "GET", "http://example.com/badge?uri=tabUrl",
-        [200, {}, '{"total": 0}']
-      );
-
-      action.updateBadge("tabId", "tabUrl", "http://example.com");
-
-      assert(fakeChromeBrowserAction.setBadgeText.notCalled);
+      action.update(1, {
+        state: TabState.states.INACTIVE,
+        annotationCount: 0,
+      });
+      assert.equal(fakeChromeBrowserAction.badgeText, '');
     });
 
     it("does not set the badge title if there are 0 annotations", function() {
-      server.respondWith(
-        "GET", "http://example.com/badge?uri=tabUrl",
-        [200, {}, '{"total": 0}']
-      );
-
-      action.updateBadge("tabId", "tabUrl", "http://example.com");
-
-      assert(fakeChromeBrowserAction.setTitle.notCalled);
+      action.update(1, {
+        state: TabState.states.INACTIVE,
+        annotationCount: 0,
+      });
+      assert.equal(fakeChromeBrowserAction.title, 'Hypothesis is inactive');
     });
 
     it("truncates numbers greater than 999 to '999+'", function() {
-      server.respondWith(
-        "GET", "http://example.com/badge?uri=tabUrl",
-        [200, {}, '{"total": 1001}']
-      );
-
-      action.updateBadge("tabId", "tabUrl", "http://example.com");
-
-      assert(fakeChromeBrowserAction.setBadgeText.calledOnce);
-      assert(fakeChromeBrowserAction.setBadgeText.calledWithExactly(
-        {tabId: "tabId", text: "999+"}));
-      assert(fakeChromeBrowserAction.setTitle.calledWithExactly(
-        {tabId: "tabId", title: "There are 999+ annotations on this page"}));
-    });
-
-    it("does not set the badge text if there is existing text", function() {
-      server.respondWith(
-        "GET", "http://example.com/badge?uri=tabUrl",
-        [200, {}, '{"total": 23}']
-      );
-      var originalGetBadgeTextFunc = fakeChromeBrowserAction.getBadgeText;
-
-      fakeChromeBrowserAction.getBadgeText = function(args, func) {
-        func('some badge text that is already showing');
-      };
-      action.updateBadge("tabId", "tabUrl", "http://example.com");
-      fakeChromeBrowserAction.getBadgeText = originalGetBadgeTextFunc;
-
-      assert(fakeChromeBrowserAction.setBadgeText.notCalled);
-    });
-
-    it("does not set the badge title if there is existing text", function() {
-      server.respondWith(
-        "GET", "http://example.com/badge?uri=tabUrl",
-        [200, {}, '{"total": 23}']
-      );
-      var originalGetBadgeTextFunc = fakeChromeBrowserAction.getBadgeText;
-
-      fakeChromeBrowserAction.getBadgeText = function(args, func) {
-        func('some badge text that is already showing');
-      };
-      action.updateBadge("tabId", "tabUrl", "http://example.com");
-      fakeChromeBrowserAction.getBadgeText = originalGetBadgeTextFunc;
-
-      assert(fakeChromeBrowserAction.setTitle.notCalled);
+      action.update(1, {
+        state: TabState.states.INACTIVE,
+        annotationCount: 1001,
+      });
+      assert.equal(fakeChromeBrowserAction.badgeText, '999+');
+      assert.equal(fakeChromeBrowserAction.title,
+        'There are 999+ annotations on this page');
     });
   });
 });

--- a/h/browser/chrome/test/tab-store-test.js
+++ b/h/browser/chrome/test/tab-store-test.js
@@ -17,13 +17,15 @@ describe('TabStore', function () {
 
   describe('.get', function () {
     beforeEach(function () {
-      fakeLocalStorage.data.state = JSON.stringify({1: 'active'});
+      fakeLocalStorage.data.state = JSON.stringify({
+        1: {state: 'active'}
+      });
       store.reload();
     });
 
     it('retrieves a key from the cache', function () {
       var value = store.get(1);
-      assert.equal(value, 'active');
+      assert.equal(value.state, 'active');
     });
 
     it('raises an error if the key cannot be found', function () {
@@ -31,26 +33,41 @@ describe('TabStore', function () {
         store.get(100);
       });
     });
+
+    it('converts state-string keys to objects', function () {
+      fakeLocalStorage.data.state = JSON.stringify({
+        1: 'active'
+      });
+      store.reload();
+      assert.deepEqual(store.get(1), { state: 'active' });
+    });
   });
 
   describe('.set', function () {
     it('inserts a JSON string into the store for the tab id', function () {
-      var expected = JSON.stringify({1: 'active'});
-      store.set(1, 'active');
+      var expected = JSON.stringify({
+        1: { state: 'active' }
+      });
+      store.set(1, { state: 'active' });
       assert.calledWith(fakeLocalStorage.setItem, 'state', expected);
     });
 
     it('adds new properties to the serialized object with each new call', function () {
-      var expected = JSON.stringify({1: 'active', 2: 'inactive'});
-      store.set(1, 'active');
-      store.set(2, 'inactive');
+      var expected = JSON.stringify({
+        1: { state: 'active' },
+        2: { state: 'inactive'},
+      });
+      store.set(1, { state: 'active' });
+      store.set(2, { state: 'inactive' });
       assert.calledWith(fakeLocalStorage.setItem, 'state', expected);
     });
 
     it('overrides existing properties on the serialized object', function () {
-      var expected = JSON.stringify({1: 'inactive'});
-      store.set(1, 'active');
-      store.set(1, 'inactive');
+      var expected = JSON.stringify({
+        1: {state: 'inactive'}
+      });
+      store.set(1, { state: 'active' });
+      store.set(1, { state: 'inactive' });
       assert.calledWith(fakeLocalStorage.setItem, 'state', expected);
     });
   });
@@ -69,13 +86,13 @@ describe('TabStore', function () {
 
   describe('.all', function () {
     beforeEach(function () {
-      fakeLocalStorage.data.state = JSON.stringify({1: 'active'});
+      fakeLocalStorage.data.state = JSON.stringify({1: { state: 'active' }});
       store.reload();
     });
 
     it('returns all items as an Object', function () {
       var all = store.all();
-      assert.deepEqual(all, {1: 'active'});
+      assert.deepEqual(all, {1: { state: 'active' }});
     });
   });
 });

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "extend": "^2.0.0",
     "frame-rpc": "^1.3.1",
     "hammerjs": "^2.0.4",
+    "is-equal-shallow": "^0.1.3",
     "jquery": "1.11.1",
     "js-polyfills": "^0.1.11",
     "moment": "^2.10.6",


### PR DESCRIPTION
This PR refactors and simplifies the BrowserAction class in two ways, in preparation for a future PR to customize the badge depending on the extension build type (dev, staging, production).

* Makes it actually stateless (as the documentation claims it should be). Its responsibility is just to take the logical H state of a tab (active/inactive/errored, annotation count) and update the badge's label, tooltip and text. Previously it didn't actually store any state directly in BrowserAction but it used to instead read state by querying the Chrome browser action API, which made it effectively stateful. Having state flow only in one direction (H model -> badge) will make it easier to add new things which might affect the badge's ultimate appearance and also re-use the code across extensions which use different APIs to update the badge.

* Separates out the logic for querying the badge count and updating the model state from the logic that updates the presentation of the badge. This simplifies a bunch of tests.