### PR TITLE
Extension build type indicator

### DIFF
--- a/h/browser/chrome/lib/browser-action.js
+++ b/h/browser/chrome/lib/browser-action.js
@@ -18,6 +18,26 @@ icons[states.INACTIVE] = {
   38: 'images/browser-icon-inactive@2x.png'
 };
 
+var buildType = '';
+settings.then(function (settings) {
+  buildType = settings.buildType;
+}).catch(function (err) {
+  console.error(err);
+});
+
+// themes to apply to the toolbar icon badge depending on the type of
+// build. Production builds use the default color and no text
+var badgeThemes = {
+  'dev': {
+    defaultText: 'DEV',
+    color: '#5BCF59', // Emerald green
+  },
+  'staging': {
+    defaultText: 'STG',
+    color: '#EDA061', // Porche orange-pink
+  }
+};
+
 // Fake localization function.
 function _(str) {
   return str;
@@ -54,6 +74,7 @@ function BrowserAction(chromeBrowserAction) {
       throw new Error('Unknown tab state');
     }
 
+    // display the annotation count on the badge
     if (state.state !== states.ERRORED && state.annotationCount) {
       var countLabel;
       var totalString = state.annotationCount.toString();
@@ -68,6 +89,18 @@ function BrowserAction(chromeBrowserAction) {
       }
       title = countLabel;
       badgeText = totalString;
+    }
+
+    // update the badge style to reflect the build type
+    var badgeTheme = badgeThemes[buildType];
+    if (badgeTheme) {
+      chromeBrowserAction.setBadgeBackgroundColor({
+        tabId: tabId,
+        color: badgeTheme.color,
+      });
+      if (!badgeText) {
+        badgeText = badgeTheme.defaultText;
+      }
     }
 
     chromeBrowserAction.setBadgeText({tabId: tabId, text: badgeText});

--- a/h/browser/chrome/test/browser-action-test.js
+++ b/h/browser/chrome/test/browser-action-test.js
@@ -1,4 +1,5 @@
 var assign = require('core-js/modules/$.assign');
+var proxyquire = require('proxyquire');
 
 describe('BrowserAction', function () {
   'use strict';
@@ -13,6 +14,7 @@ describe('BrowserAction', function () {
       annotationCount: 0,
       title: '',
       badgeText: '',
+      badgeColor: '',
 
       setIcon: function (options) {
         this.icon = options.path;
@@ -23,6 +25,9 @@ describe('BrowserAction', function () {
       setBadgeText: function (options) {
         this.badgeText = options.text;
       },
+      setBadgeBackgroundColor: function (options) {
+        this.badgeColor = options.color;
+      }
     };
     action = new BrowserAction(fakeChromeBrowserAction);
   });
@@ -138,6 +143,44 @@ describe('BrowserAction', function () {
       assert.equal(fakeChromeBrowserAction.badgeText, '999+');
       assert.equal(fakeChromeBrowserAction.title,
         'There are 999+ annotations on this page');
+    });
+  });
+
+  describe('build type', function () {
+    beforeEach(function () {
+      var fakeSettings = Promise.resolve({
+        buildType: 'staging',
+        '@noCallThru': true,
+      });
+      var BrowserAction = proxyquire('../lib/browser-action', {
+        './settings': fakeSettings,
+      });
+      action = new BrowserAction(fakeChromeBrowserAction);
+      return fakeSettings;
+    });
+
+    it('sets the text to STG when there are no annotations', function () {
+      action.update(1, {
+        state: TabState.states.INACTIVE,
+        annotationCount: 0,
+      });
+      assert.equal(fakeChromeBrowserAction.badgeText, 'STG');
+    });
+
+    it('shows the annotation count when there are annotations', function () {
+      action.update(1, {
+        state: TabState.states.INACTIVE,
+        annotationCount: 3,
+      });
+      assert.equal(fakeChromeBrowserAction.badgeText, '3');
+    });
+
+    it('sets the background color', function () {
+      action.update(1, {
+        state: TabState.states.INACTIVE,
+        annotationCount: 0,
+      });
+      assert.equal(fakeChromeBrowserAction.badgeColor, '#EDA061');
     });
   });
 });


### PR DESCRIPTION
This PR builds on top of https://github.com/hypothesis/h/pull/2638 to customize the extension badge depending on the build flavor.

 * Use a green background for dev extensions and orange for staging

 * For dev and staging extensions, set the badge's label to
   'DEV' or 'STG' if there are no annotations for the current URL

 * There are no visual changes to the production extension

![stg-active](https://cloud.githubusercontent.com/assets/2458/10604297/5b09642c-771b-11e5-8453-7a1c2c97afa7.png)

![stg-vs-dev-extension](https://cloud.githubusercontent.com/assets/2458/10604299/6022b3fa-771b-11e5-8633-c37e02c64db0.png)



