### PR TITLE
Set group and visibility of reply to that of parent

### DIFF
--- a/h/static/scripts/directive/annotation.coffee
+++ b/h/static/scripts/directive/annotation.coffee
@@ -75,7 +75,7 @@ AnnotationController = [
       if defaultLevel == 'private'
         model.permissions = permissions.private()
       else
-        model.permissions = permissions.public(model.group)
+        model.permissions = permissions.shared(model.group)
 
     highlight = model.$highlight
     original = null
@@ -122,7 +122,7 @@ AnnotationController = [
     # current group or with everyone).
     ###
     this.isShared = ->
-      permissions.isPublic @annotation.permissions, model.group
+      permissions.isShared @annotation.permissions, model.group
 
     ###*
     # @ngdoc method
@@ -147,7 +147,7 @@ AnnotationController = [
       if privacy == 'private'
         @annotation.permissions = permissions.private()
       else if privacy == 'shared'
-        @annotation.permissions = permissions.public(model.group)
+        @annotation.permissions = permissions.shared(model.group)
 
     ###*
     # @ngdoc method
@@ -301,8 +301,8 @@ AnnotationController = [
       reply.group = model.group
 
       if session.state.userid
-        if permissions.isPublic(model.permissions, model.group)
-          reply.permissions = permissions.public(reply.group)
+        if permissions.isShared(model.permissions, model.group)
+          reply.permissions = permissions.shared(reply.group)
         else
           reply.permissions = permissions.private()
 

--- a/h/static/scripts/directive/publish-annotation-btn.js
+++ b/h/static/scripts/directive/publish-annotation-btn.js
@@ -1,9 +1,7 @@
 'use strict';
 
-var STORAGE_KEY = 'hypothesis.privacy';
-
 // @ngInject
-function PublishAnnotationBtnController($scope, localStorage) {
+function PublishAnnotationBtnController($scope) {
   var vm = this;
 
   vm.group = {
@@ -24,25 +22,12 @@ function PublishAnnotationBtnController($scope, localStorage) {
   }
 
   this.setPrivacy = function (level) {
-    localStorage.setItem(STORAGE_KEY, level);
     $scope.onSetPrivacy({level: level});
   }
 
   $scope.$watch('isShared', function () {
     updatePublishActionLabel();
   });
-
-  if ($scope.isNew) {
-    // set the privacy level for new annotations.
-    // FIXME - This should be done at the time the annotation is created,
-    // not by this control
-    var defaultLevel = localStorage.getItem(STORAGE_KEY);
-    if (defaultLevel !== 'private' &&
-        defaultLevel !== 'shared') {
-      defaultLevel = 'shared';
-    }
-    this.setPrivacy(defaultLevel);
-  }
 
   function updatePublishActionLabel() {
     if ($scope.isShared) {

--- a/h/static/scripts/directive/publish-annotation-btn.js
+++ b/h/static/scripts/directive/publish-annotation-btn.js
@@ -54,7 +54,6 @@ module.exports = function () {
       group: '=',
       canPost: '=',
       isShared: '=',
-      isNew: '=',
       onCancel: '&',
       onSave: '&',
       onSetPrivacy: '&'

--- a/h/static/scripts/directive/test/annotation-test.coffee
+++ b/h/static/scripts/directive/test/annotation-test.coffee
@@ -65,10 +65,10 @@ describe 'annotation', ->
 
     fakeMomentFilter = sandbox.stub().returns('ages ago')
     fakePermissions = {
-      isPublic: sandbox.stub().returns(true)
+      isShared: sandbox.stub().returns(true)
       isPrivate: sandbox.stub().returns(false)
       permits: sandbox.stub().returns(true)
-      public: sandbox.stub().returns({read: ['everybody']})
+      shared: sandbox.stub().returns({read: ['everybody']})
       private: sandbox.stub().returns({read: ['justme']})
     }
     fakePersonaFilter = sandbox.stub().returnsArg(0)
@@ -176,10 +176,10 @@ describe 'annotation', ->
       match = sinon.match {references: [annotation.id], uri: annotation.uri}
       assert.calledWith(fakeAnnotationMapper.createAnnotation, match)
 
-    it 'makes the annotation public if the parent is public', ->
+    it 'makes the annotation shared if the parent is shared', ->
       reply = {}
       fakeAnnotationMapper.createAnnotation.returns(reply)
-      fakePermissions.isPublic.returns(true)
+      fakePermissions.isShared.returns(true)
       controller.reply()
       assert.deepEqual(reply.permissions, {read: ['everybody']})
 
@@ -188,9 +188,9 @@ describe 'annotation', ->
       $scope.annotation.permissions = {read: ["my group"]}
       reply = {}
       fakeAnnotationMapper.createAnnotation.returns(reply)
-      fakePermissions.isPublic = (permissions, group) ->
+      fakePermissions.isShared = (permissions, group) ->
         return group in permissions.read
-      fakePermissions.public = (group) ->
+      fakePermissions.shared = (group) ->
         return {read: [group]}
 
       controller.reply()
@@ -200,7 +200,7 @@ describe 'annotation', ->
     it 'does not add the world readable principal if the parent is private', ->
       reply = {}
       fakeAnnotationMapper.createAnnotation.returns(reply)
-      fakePermissions.isPublic.returns(false)
+      fakePermissions.isShared.returns(false)
       controller.reply()
       assert.deepEqual(reply.permissions, {read: ['justme']})
 
@@ -686,12 +686,12 @@ describe("AnnotationController", ->
         error: ->
       }
       permissions: permissions or {
-        isPublic: (permissions, group) ->
+        isShared: (permissions, group) ->
           return group in permissions.read
         isPrivate: (permissions, user) ->
           return user in permissions.read
         permits: -> true
-        public: (group) -> {"read": [group]}
+        shared: (group) -> {"read": [group]}
         private: -> {"read": [session.state.userid]}
       }
       session: session

--- a/h/static/scripts/directive/test/publish-annotation-btn-test.js
+++ b/h/static/scripts/directive/test/publish-annotation-btn-test.js
@@ -37,7 +37,6 @@ describe('publishAnnotationBtn', function () {
      },
      canPost: true,
      isShared: false,
-     isNew: false,
      onSave: function () {},
      onSetPrivacy: function (level) {},
      onCancel: function () {}
@@ -56,7 +55,6 @@ describe('publishAnnotationBtn', function () {
         name: 'Research Lab',
         type: 'group'
       },
-      isNew: false,
       isShared: true
     })
     var buttons = element.find('button');
@@ -78,7 +76,6 @@ describe('publishAnnotationBtn', function () {
     element.link({
       // for existing annotations, the privacy should not be changed
       // unless the user makes a choice from the list
-      isNew: false,
       onSetPrivacy: privacyChangedSpy
     });
 

--- a/h/static/scripts/directive/test/publish-annotation-btn-test.js
+++ b/h/static/scripts/directive/test/publish-annotation-btn-test.js
@@ -63,16 +63,6 @@ describe('publishAnnotationBtn', function () {
     assert.equal(buttons[0].innerHTML, 'Post to Research Lab');
   });
 
-  it('should default to "shared" as the privacy level for new annotations', function () {
-    fakeStorage = {};
-    element.link({
-      isNew: true
-    });
-    assert.deepEqual(fakeStorage, {
-      'hypothesis.privacy': 'shared'
-    });
-  });
-
   it('should save when "Post..." is clicked', function () {
     var savedSpy = sinon.spy();
     element.link({

--- a/h/static/scripts/permissions.coffee
+++ b/h/static/scripts/permissions.coffee
@@ -44,14 +44,14 @@ module.exports = ['session', (session) ->
 
   ###*
   # @ngdoc method
-  # @name permissions#public
+  # @name permissions#shared
   #
-  # @param {String} [group] Group to make annotation public in.
+  # @param {String} [group] Group to make annotation shared in.
   #
-  # Sets permissions for a public annotation
-  # Typical use: annotation.permissions = permissions.public()
+  # Sets permissions for a shared annotation
+  # Typical use: annotation.permissions = permissions.shared(group)
   ###
-  public: (group) ->
+  shared: (group) ->
     if group?
       group = 'group:' + group
     else
@@ -65,14 +65,14 @@ module.exports = ['session', (session) ->
 
   ###*
   # @ngdoc method
-  # @name permissions#isPublic
+  # @name permissions#isShared
   #
   # @param {Object} permissions
   # @param {String} [group]
   #
-  # This function determines whether the permissions allow public visibility
+  # This function determines whether the permissions allow shared visibility
   ###
-  isPublic: (permissions, group) ->
+  isShared: (permissions, group) ->
     if group?
       group = 'group:' + group
     else

--- a/h/static/scripts/test/permissions-test.coffee
+++ b/h/static/scripts/test/permissions-test.coffee
@@ -39,14 +39,14 @@ describe 'h:permissions', ->
       assert.equal(perms.admin[0], 'acct:flash@gordon')
 
     it 'public call fills the read property with group:__world__', ->
-      perms = permissions.public()
+      perms = permissions.shared()
       assert.equal(perms.read[0], 'group:__world__')
       assert.equal(perms.update[0], 'acct:flash@gordon')
       assert.equal(perms.delete[0], 'acct:flash@gordon')
       assert.equal(perms.admin[0], 'acct:flash@gordon')
 
     it 'public call fills the read property with group:foo if passed "foo"', ->
-      perms = permissions.public("foo")
+      perms = permissions.shared("foo")
       assert.equal(perms.read[0], 'group:foo')
       assert.equal(perms.update[0], 'acct:flash@gordon')
       assert.equal(perms.delete[0], 'acct:flash@gordon')
@@ -57,18 +57,18 @@ describe 'h:permissions', ->
         permission = {
             read: ['group:__world__', 'acct:angry@birds.com']
         }
-        assert.isTrue(permissions.isPublic(permission))
+        assert.isTrue(permissions.isShared(permission))
 
       it 'isPublic() false otherwise', ->
         permission = {
             read: ['acct:angry@birds.com']
         }
 
-        assert.isFalse(permissions.isPublic(permission))
+        assert.isFalse(permissions.isShared(permission))
         permission.read = []
-        assert.isFalse(permissions.isPublic(permission))
+        assert.isFalse(permissions.isShared(permission))
         permission.read = ['one', 'two', 'three']
-        assert.isFalse(permissions.isPublic(permission))
+        assert.isFalse(permissions.isShared(permission))
 
     describe 'isPrivate', ->
       it 'returns true if the given user is in the permissions', ->
@@ -97,7 +97,7 @@ describe 'h:permissions', ->
         assert.isFalse(permissions.permits(action, annotation, null))
 
       it 'returns true if user different, but permissions has group:__world__', ->
-        annotation = {permissions: permissions.public()}
+        annotation = {permissions: permissions.shared()}
         annotation.permissions.read.push 'acct:darthsidious@deathstar.emp'
         user = 'acct:darthvader@deathstar.emp'
         assert.isTrue(permissions.permits('read', annotation, user))

--- a/h/templates/client/annotation.html
+++ b/h/templates/client/annotation.html
@@ -121,7 +121,6 @@
         class="publish-annotation-btn"
         group="vm.group()"
         can-post="vm.hasContent()"
-        is-new="vm.action == 'create'"
         is-shared="vm.isShared()"
         on-cancel="vm.revert()"
         on-save="vm.save()"


### PR DESCRIPTION
Set the group and visibility of replies to that of their parents, when
replies are first created.

Also prevent the visibility setting of a reply from overwriting the
cached-in-local-storage visibility level. This prevents the following
problem:

- I'm annotating publicly (my cached-in-local-storage visibility
  setting is public)
- I reply to a private annotation
- The visibility of my reply is set to that of its parent, private
- This visibility is then cached in local storage
- I make a new top-level annotation, and now it's defaulting to private
  instead of public, even though the user never did anything to change
  the visibility from public to private, it was done automatically
  because they replied to a private annotation.

Obviously changing the mode from private to public when replying to a
public annotation was also possible.

This means that if the user _does_ change the visibility of a reply, we
_don't_ cache that either:

- I'm annotating publicly (my cached-in-local-storage visibility
  setting is public)
- I reply to a public annotation
- The visibility of my reply is set to that of its parent, public
- This visibility is not cached in local storage because it's a reply
  (and the value cached in the local storage is already the same anyway)
- I then deliberately change the visibility of my reply from public to
  private
- Again this visibility is not cached in local storage because it's a reply
- The next time I make a new top-level annotation, it will still be
  defaulting to public, will not have changed to private mode