### PR TITLE
Don't expand URIs if the search URI is a rel="canonical"

### DIFF
--- a/h/api/test/uri_test.py
+++ b/h/api/test/uri_test.py
@@ -148,6 +148,21 @@ def test_expand_no_document(document_model):
     assert uri.expand("http://example.com/") == ["http://example.com/"]
 
 
+def test_expand_document_doesnt_expand_canonical_uris(document_model):
+    document = document_model.get_by_uri.return_value
+    document.get.return_value = [
+        {"href": "http://foo.com/"},
+        {"href": "http://bar.com/"},
+        {"href": "http://example.com/", "rel": "canonical"},
+    ]
+    document.uris.return_value = [
+        "http://foo.com/",
+        "http://bar.com/",
+        "http://example.com/",
+    ]
+    assert uri.expand("http://example.com/") == ["http://example.com/"]
+
+
 def test_expand_document_uris(document_model):
     document_model.get_by_uri.return_value.uris.return_value = [
         "http://foo.com/",

--- a/h/api/uri.py
+++ b/h/api/uri.py
@@ -149,6 +149,14 @@ def expand(uri):
     doc = models.Document.get_by_uri(uri)
     if doc is None:
         return [uri]
+
+    # We check if the match was a "canonical" link. If so, all annotations
+    # created on that page are guaranteed to have that as their target.source
+    # field, so we don't need to expand to other URIs and risk false positives.
+    for link in doc.get('link', []):
+        if link.get('href') == uri and link.get('rel') == 'canonical':
+            return [uri]
+
     return doc.uris()
 
 


### PR DESCRIPTION
If the search URI is known to be a canonical URI for a document, then we can shortcut URI expansion, and minimise the risk of false positives, by only searching for the canonical URI. This works because `target.source` is guaranteed to be set to the canonical URI if one is known when an annotation is created.

The motivation for this change is the following scenario:

- We have a number of pages — such as a series of HTML pages for the chapters of a published book — which are marked up with identifying metadata.
- Each page contains a [DOI][1] and a `<link rel="canonical" ...>` tag.
- The DOI is the same on every page.
- The canonical URI is *different* on every page.

This is perfectly plausible and valid, as DOIs are typically assigned at the publication or article level, not at a page or chapter level.

Prior to this commit, searching on any of these pages (once they had been annotated) would have had the same result: all the annotations from all the pages would have been returned from the search query. Why? Because the DOI is shared between all pages and when we search for URI "X", we do so in several steps:

1. Expand X into all equivalent URIs known: [A, B, C, ..., X]
2. Normalise each URI: [A', B', C', ..., X']
3. Search for any annotation targeting at least one of these normalised URIs.

And, because for each and every page that is annotated an equivalence is created between the DOI and the canonical URI, the result is a single equivalence class containing all known URIs (including the DOI).

So, what are our options? We could just not use DOIs, but that's a change that might have some side effects that are hard to predict.

This commit addresses the problem by noticing that when an annotation is created on a page which is marked up with a `<link rel="canonical">` tag, its `target.source` property is set to that canonical URI rather than the page location. This means that we can know for sure that all annotations for that page can be found by searching for the canonical URI alone.

Luckily we also store information about whether or not a URI in the equivalence class was tagged as canonical, which allows us to check if an incoming search URI is known to be canonical. If it is, we skip step 1 from above and search only by the incoming URI.

Note that this approach does not change what happens if you search for the DOI, or even for a non-canonical URI known for one of the pages. In this case, all annotations across all pages will still be returned.

[1]: https://en.wikipedia.org/wiki/Digital_object_identifier

Fixes #2634.
Fixes #2651.