### PR TITLE
Fix extension clobbering embedded H

### DIFF
--- a/h/browser/chrome/lib/hypothesis-chrome-extension.js
+++ b/h/browser/chrome/lib/hypothesis-chrome-extension.js
@@ -107,7 +107,7 @@ function HypothesisChromeExtension(dependencies) {
     });
   };
 
-  function onTabStateChange(tabId, current, previous) {
+  function onTabStateChange(tabId, current) {
     if (current) {
       browserAction.update(tabId, current);
 
@@ -197,6 +197,8 @@ function HypothesisChromeExtension(dependencies) {
     state.clearTab(tabId);
   }
 
+  // installs or uninstalls the sidebar from a tab when the H
+  // state for a tab changes
   function updateTabDocument(tab) {
     // If the tab has not yet finished loading then just quietly return.
     if (tab.status !== TAB_STATUS_COMPLETE) {

--- a/h/browser/chrome/lib/hypothesis-chrome-extension.js
+++ b/h/browser/chrome/lib/hypothesis-chrome-extension.js
@@ -191,7 +191,7 @@ function HypothesisChromeExtension(dependencies) {
   // state for a tab changes
   function updateTabDocument(tab) {
     // If the tab has not yet finished loading then just quietly return.
-    if (tab.status !== TAB_STATUS_COMPLETE) {
+    if (!state.getState(tab.id).ready) {
       return Promise.resolve();
     }
 

--- a/h/browser/chrome/lib/tab-state.js
+++ b/h/browser/chrome/lib/tab-state.js
@@ -21,6 +21,8 @@ var DEFAULT_STATE = {
    * the extension
    */
   extensionSidebarInstalled: false,
+  /** Whether the tab is loaded and ready for the sidebar to be installed. */
+  ready: false,
 };
 
 /** TabState stores the H state for a tab. This state includes:

--- a/h/browser/chrome/lib/tab-state.js
+++ b/h/browser/chrome/lib/tab-state.js
@@ -128,8 +128,6 @@ function TabState(initialState, onchange) {
       return;
     }
 
-    console.log('h:dev TabState.setState', tabId, 'current', currentState[tabId], 'new', newState);
-
     previousState[tabId] = currentState[tabId];
     currentState[tabId] = newState;
 

--- a/h/browser/chrome/lib/tab-state.js
+++ b/h/browser/chrome/lib/tab-state.js
@@ -41,12 +41,11 @@ var DEFAULT_STATE = {
  * initialState - An Object of tabId/state keys. Used when loading state
  *   from a persisted store such as localStorage. This will be merged with
  *   the default state for a tab.
- * onchange     - A function that recieves onchange(tabId, current, prev).
+ * onchange     - A function that recieves onchange(tabId, current).
  */
 function TabState(initialState, onchange) {
   var _this = this;
   var currentState;
-  var previousState;
 
   this.onchange = onchange || null;
 
@@ -58,8 +57,6 @@ function TabState(initialState, onchange) {
    *                   state for a tab.
    */
   this.load = function (newState) {
-    previousState = currentState || {};
-
     var newCurrentState = {};
     Object.keys(newState).forEach(function (tabId) {
       newCurrentState[tabId] = assign({}, DEFAULT_STATE, newState[tabId]);
@@ -81,10 +78,6 @@ function TabState(initialState, onchange) {
 
   this.clearTab = function (tabId) {
     this.setState(tabId, null);
-  };
-
-  this.restorePreviousState = function (tabId) {
-    this.setState(tabId, previousState[tabId], this.onchange);
   };
 
   this.getState = function (tabId) {
@@ -128,11 +121,10 @@ function TabState(initialState, onchange) {
       return;
     }
 
-    previousState[tabId] = currentState[tabId];
     currentState[tabId] = newState;
 
     if (_this.onchange) {
-      _this.onchange(tabId, newState, previousState[tabId] || null);
+      _this.onchange(tabId, newState);
     }
   }
 

--- a/h/browser/chrome/lib/tab-store.js
+++ b/h/browser/chrome/lib/tab-store.js
@@ -21,7 +21,12 @@ function TabStore(storage) {
   };
 
   this.set = function (tabId, value) {
-    local[tabId] = value;
+    // copy across only the parts of the tab state that should
+    // be preserved
+    local[tabId] = {
+      state: value.state,
+      annotationCount: value.annotationCount,
+    };
     storage.setItem(key, JSON.stringify(local));
   };
 

--- a/h/browser/chrome/lib/tab-store.js
+++ b/h/browser/chrome/lib/tab-store.js
@@ -1,12 +1,11 @@
 'use strict';
 
-/* The tab store ensures that the current state of the browser action
- * is persisted between browser sessions. To do this it uses an external
- * storage object that conforms to the localStorage API.
+/** TabStore is used to persist the state of H browser tabs when
+ * the extension is re-installed or updated.
  *
- * Examples
- *
- *   var store = new TabStore(window.localStorage);
+ * Note: This could also be used to persist the state across browser sessions,
+ * for that to work however the storage key would need to be changed.
+ * The tab ID is currently used but this is valid only for a browser session.
  */
 function TabStore(storage) {
   var key = 'state';

--- a/h/browser/chrome/test/hypothesis-chrome-extension-test.js
+++ b/h/browser/chrome/test/hypothesis-chrome-extension-test.js
@@ -199,7 +199,6 @@ describe('HypothesisChromeExtension', function () {
 
       beforeEach(function () {
         fakeTabState.clearTab = sandbox.spy()
-        fakeTabState.restorePreviousState = sandbox.spy();
         fakeTabState.isTabActive = function (tabId) {
           return tabState[tabId].state === TabState.states.ACTIVE;
         };

--- a/h/browser/chrome/test/hypothesis-chrome-extension-test.js
+++ b/h/browser/chrome/test/hypothesis-chrome-extension-test.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var assign = require('core-js/modules/$.assign');
 var proxyquire = require('proxyquire');
 
 var errors = require('../lib/errors');
@@ -14,6 +15,12 @@ function createConstructor(prototype) {
   }
   Constructor.prototype = Object.create(prototype);
   return Constructor;
+}
+
+function FakeListener() {
+  this.addListener = function (callback) {
+    this.listener = callback;
+  };
 }
 
 describe('HypothesisChromeExtension', function () {
@@ -39,8 +46,15 @@ describe('HypothesisChromeExtension', function () {
   }
 
   beforeEach(function () {
-    fakeChromeTabs = {};
-    fakeChromeBrowserAction = {};
+    fakeChromeTabs = {
+      onCreated: new FakeListener(),
+      onUpdated: new FakeListener(),
+      onReplaced: new FakeListener(),
+      onRemoved: new FakeListener(),
+    };
+    fakeChromeBrowserAction = {
+      onClicked: new FakeListener(),
+    };
     fakeHelpPage = {
       showHelpForError: sandbox.spy()
     };
@@ -58,6 +72,7 @@ describe('HypothesisChromeExtension', function () {
       isTabInactive: sandbox.stub().returns(false),
       isTabErrored: sandbox.stub().returns(false),
       getState: sandbox.spy(),
+      setState: sandbox.spy(),
     };
     fakeTabState.deactivateTab = sinon.spy();
     fakeTabErrorCache = {
@@ -73,8 +88,13 @@ describe('HypothesisChromeExtension', function () {
       removeFromTab: sandbox.stub().returns(Promise.resolve()),
     };
 
+    function FakeTabState(initialState, onchange) {
+      fakeTabState.onChangeHandler = onchange
+    }
+    FakeTabState.prototype = fakeTabState;
+
     HypothesisChromeExtension = proxyquire('../lib/hypothesis-chrome-extension', {
-      './tab-state': createConstructor(fakeTabState),
+      './tab-state': FakeTabState,
       './tab-store': createConstructor(fakeTabStore),
       './help-page': createConstructor(fakeHelpPage),
       './tab-error-cache': createConstructor(fakeTabErrorCache),
@@ -136,40 +156,12 @@ describe('HypothesisChromeExtension', function () {
   });
 
   describe('.listen', function () {
-    var onClickedHandler;
-    var onCreatedHandler;
-    var onUpdatedHandler;
-    var onRemovedHandler;
-
-    beforeEach(function () {
-      fakeChromeBrowserAction.onClicked = {
-        addListener: sandbox.spy(function (fn) {
-          onClickedHandler = fn;
-        })
-      };
-      fakeChromeTabs.onCreated = {
-        addListener: sandbox.spy(function (fn) {
-          onCreatedHandler = fn;
-        })
-      };
-      fakeChromeTabs.onUpdated = {
-        addListener: sandbox.spy(function (fn) {
-          onUpdatedHandler = fn;
-        })
-      };
-      fakeChromeTabs.onRemoved = {
-        addListener: sandbox.spy(function (fn) {
-          onRemovedHandler = fn;
-        })
-      };
-    });
-
     it('sets up event listeners', function () {
       ext.listen({addEventListener: sandbox.stub()});
-      assert.called(fakeChromeBrowserAction.onClicked.addListener);
-      assert.called(fakeChromeTabs.onCreated.addListener);
-      assert.called(fakeChromeTabs.onUpdated.addListener);
-      assert.called(fakeChromeTabs.onRemoved.addListener);
+      assert.ok(fakeChromeBrowserAction.onClicked.listener);
+      assert.ok(fakeChromeTabs.onCreated.listener);
+      assert.ok(fakeChromeTabs.onUpdated.listener);
+      assert.ok(fakeChromeTabs.onRemoved.listener);
     });
 
     describe('when a tab is created', function () {
@@ -179,7 +171,7 @@ describe('HypothesisChromeExtension', function () {
       });
 
       it('clears the new tab state', function () {
-        onCreatedHandler({id: 1, url: 'http://example.com/foo.html'});
+        fakeChromeTabs.onCreated.listener({id: 1, url: 'http://example.com/foo.html'});
         assert.calledWith(fakeTabState.clearTab, 1);
       });
     });
@@ -188,10 +180,11 @@ describe('HypothesisChromeExtension', function () {
       var tabState = {};
       function createTab(initialState) {
         var tabId = 1;
-        tabState[tabId] = {
-          state: initialState,
+        tabState[tabId] = assign({
+          state: TabState.states.INACTIVE,
           annotationCount: 0,
-        };
+          ready: false,
+        }, initialState);
         return {id: tabId, url: 'http://example.com/foo.html', status: 'complete'};
       }
 
@@ -207,44 +200,33 @@ describe('HypothesisChromeExtension', function () {
         fakeTabState.getState = function (tabId) {
           return tabState[tabId];
         };
+        fakeTabState.setState = function (tabId, state) {
+          tabState[tabId] = assign(tabState[tabId], state);
+        };
         ext.listen({addEventListener: sandbox.stub()});
       });
 
-      it('injects the sidebar if the tab is active', function () {
-        var tab = createTab(TabState.states.ACTIVE);
-        onUpdatedHandler(tab.id, {status: 'complete'}, tab);
-        assert.calledWith(fakeSidebarInjector.injectIntoTab, tab);
+      it('sets the tab state to ready when loading completes', function () {
+        var tab = createTab({state: TabState.states.ACTIVE});
+        fakeChromeTabs.onUpdated.listener(tab.id, {status: 'complete'}, tab);
+        assert.equal(tabState[tab.id].ready, true);
       });
 
-      it('clears the tab state if the sidebar is not active', function () {
-        var tab = {id: 1, url: 'http://example.com/foo.html', status: 'complete'};
-        tabState[tab.id].state = TabState.states.INACTIVE;
-        onUpdatedHandler(tab.id, {status: 'complete'}, tab);
-        assert.calledWith(fakeTabState.clearTab, tab.id);
+      it('resets the tab state when loading', function () {
+        var tab = createTab({
+          state: TabState.states.ACTIVE,
+          ready: true,
+          extensionSidebarInstalled: true,
+        });
+        fakeChromeTabs.onUpdated.listener(tab.id, {status: 'loading'}, tab);
+        assert.equal(tabState[tab.id].ready, false);
+        assert.equal(tabState[tab.id].extensionSidebarInstalled, false);
       });
 
-      it('updates the browser action to the active state when active', function () {
-        var tab = createTab(TabState.states.ACTIVE);
-        onUpdatedHandler(tab.id, {status: 'complete'}, tab);
-        assert.calledWith(fakeBrowserAction.update, tab.id, tabState[tab.id]);
-      });
-
-      it('updates the browser action to the inactive state when inactive', function () {
-        var tab = createTab(TabState.states.INACTIVE);
-        onUpdatedHandler(tab.id, {status: 'complete'}, tab);
-        assert.calledWith(fakeBrowserAction.update, tab.id, tabState[tab.id]);
-      });
-
-      it('restores the tab state if errored', function () {
-        var tab = createTab(TabState.states.ERRORED);
-        onUpdatedHandler(tab.id, {status: 'complete'}, tab);
-        assert.calledWith(fakeTabState.restorePreviousState, 1);
-      });
-
-      it('does nothing until the tab status is complete', function () {
-        var tab = createTab(TabState.states.ACTIVE);
-        onUpdatedHandler(tab.id, {status: 'loading'}, tab);
-        assert.notCalled(fakeSidebarInjector.injectIntoTab);
+      it('resets the tab state to active if errored', function () {
+        var tab = createTab({state: TabState.states.ERRORED});
+        fakeChromeTabs.onUpdated.listener(tab.id, {status: 'loading'}, tab);
+        assert.equal(tabState[tab.id].state, TabState.states.ACTIVE);
       });
     });
 
@@ -255,7 +237,7 @@ describe('HypothesisChromeExtension', function () {
       });
 
       it('clears the tab', function () {
-        onRemovedHandler(1);
+        fakeChromeTabs.onRemoved.listener(1);
         assert.calledWith(fakeTabState.clearTab, 1);
       });
     });
@@ -267,99 +249,73 @@ describe('HypothesisChromeExtension', function () {
 
       it('activate the tab if the tab is inactive', function () {
         fakeTabState.isTabInactive.returns(true);
-        onClickedHandler({id: 1, url: 'http://example.com/foo.html'});
+        fakeChromeBrowserAction.onClicked.listener({id: 1, url: 'http://example.com/foo.html'});
         assert.called(fakeTabState.activateTab);
         assert.calledWith(fakeTabState.activateTab, 1);
       });
 
       it('deactivate the tab if the tab is active', function () {
         fakeTabState.isTabActive.returns(true);
-        onClickedHandler({id: 1, url: 'http://example.com/foo.html'});
+        fakeChromeBrowserAction.onClicked.listener({id: 1, url: 'http://example.com/foo.html'});
         assert.called(fakeTabState.deactivateTab);
         assert.calledWith(fakeTabState.deactivateTab, 1);
       });
+    });
+  });
 
-      describe('when a tab has a local-file error', function () {
+  describe('when injection fails', function () {
+    function triggerInstall() {
+      var tab = {id: 1, url: 'file://foo.html', status: 'complete'};
+      var tabState = {
+        state: TabState.states.ACTIVE,
+        extensionSidebarInstalled: false,
+        ready: true,
+      };
+      fakeChromeTabs.get = function (tabId, callback) {
+        callback(tab);
+      };
+      fakeTabState.isTabActive.withArgs(1).returns(true);
+      fakeTabState.getState = sandbox.stub().returns(tabState);
+      fakeTabState.onChangeHandler(tab.id, tabState, null);
+    }
+
+    beforeEach(function () {
+      ext.listen({addEventListener: sandbox.stub()});
+    });
+
+    var injectErrorCases = [
+      errors.LocalFileError,
+      errors.NoFileAccessError,
+      errors.RestrictedProtocolError
+    ];
+
+    injectErrorCases.forEach(function (ErrorType) {
+      describe('with ' + ErrorType.name, function () {
         it('puts the tab into an errored state', function (done) {
-          var tab = {id: 1, url: 'file://foo.html', status: 'complete'};
+          var injectError = Promise.reject(new ErrorType('msg'));
+          fakeSidebarInjector.injectIntoTab.returns(injectError);
 
-          fakeTabState.isTabActive.withArgs(1).returns(true);
-          fakeSidebarInjector.injectIntoTab.returns(Promise.reject(new errors.LocalFileError('msg')));
+          triggerInstall();
 
-          // Trigger failed render.
-          onUpdatedHandler(tab.id, {status: 'complete'}, tab).then(function () {
+          injectError.catch(function () {
             assert.called(fakeTabState.errorTab);
             assert.calledWith(fakeTabState.errorTab, 1);
             done();
           });
         });
 
-        it('shows the local file help page', function () {
+        it('shows the help page for ' + ErrorType.name, function () {
           var tab = {id: 1, url: 'file://foo.html'};
 
-          fakeTabErrorCache.getTabError.returns(new errors.LocalFileError('msg'));
+          fakeTabErrorCache.getTabError.returns(new ErrorType('msg'));
           fakeTabState.isTabErrored.withArgs(1).returns(true);
-          onClickedHandler(tab);
+          fakeChromeBrowserAction.onClicked.listener(tab);
 
           assert.called(fakeHelpPage.showHelpForError);
-          assert.calledWith(fakeHelpPage.showHelpForError, tab, sinon.match.instanceOf(errors.LocalFileError));
+          assert.calledWith(fakeHelpPage.showHelpForError, tab,
+            sinon.match.instanceOf(ErrorType));
         });
       });
-
-      describe('when a tab has an file-access error', function () {
-        it('puts the tab into an errored state', function (done) {
-          var tab = {id: 1, url: 'file://foo.html', status: 'complete'};
-
-          fakeTabState.isTabActive.withArgs(1).returns(true);
-          fakeSidebarInjector.injectIntoTab.returns(Promise.reject(new errors.NoFileAccessError('msg')));
-
-          // Trigger failed render.
-          onUpdatedHandler(tab.id, {status: 'complete'}, tab).then(function () {
-            assert.called(fakeTabState.errorTab);
-            assert.calledWith(fakeTabState.errorTab, 1);
-            done();
-          });
-        });
-
-        it('shows the local file help page', function () {
-          var tab = {id: 1, url: 'file://foo.html'};
-
-          fakeTabErrorCache.getTabError.returns(new errors.NoFileAccessError('msg'));
-          fakeTabState.isTabErrored.withArgs(1).returns(true);
-          onClickedHandler(tab);
-
-          assert.called(fakeHelpPage.showHelpForError);
-          assert.calledWith(fakeHelpPage.showHelpForError, tab, sinon.match.instanceOf(errors.NoFileAccessError));
-        });
-      });
-
-      describe('when a tab has an chrome error', function () {
-        it('puts the tab into an errored state', function (done) {
-          var tab = {id: 1, url: 'file://foo.html', status: 'complete'};
-
-          fakeTabState.isTabActive.withArgs(1).returns(true);
-          fakeSidebarInjector.injectIntoTab.returns(Promise.reject(new errors.RestrictedProtocolError('msg')));
-
-          // Trigger failed render.
-          onUpdatedHandler(tab.id, {status: 'complete'}, tab).then(function () {
-            assert.called(fakeTabState.errorTab);
-            assert.calledWith(fakeTabState.errorTab, 1);
-            done();
-          });
-        });
-
-        it('shows the local file help page', function () {
-          var tab = {id: 1, url: 'file://foo.html'};
-
-          fakeTabErrorCache.getTabError.returns(new errors.RestrictedProtocolError('msg'));
-          fakeTabState.isTabErrored.withArgs(1).returns(true);
-          onClickedHandler(tab);
-
-          assert.called(fakeHelpPage.showHelpForError);
-          assert.calledWith(fakeHelpPage.showHelpForError, tab, sinon.match.instanceOf(errors.RestrictedProtocolError));
-        });
-      });
-
     });
   });
 
@@ -385,6 +341,9 @@ describe('HypothesisChromeExtension', function () {
     });
 
     it('updates the browser icon', function () {
+      fakeTabState.getState = sandbox.stub().returns({
+        state: tabStates.ACTIVE,
+      });
       onTabStateChange(tabStates.ACTIVE, tabStates.INACTIVE);
       assert.calledWith(fakeBrowserAction.update, 1, {
         state: tabStates.ACTIVE,
@@ -392,6 +351,9 @@ describe('HypothesisChromeExtension', function () {
     });
 
     it('updates the TabStore if the tab has not errored', function () {
+      fakeTabState.getState = sandbox.stub().returns({
+        state: tabStates.ACTIVE,
+      });
       onTabStateChange(tabStates.ACTIVE, tabStates.INACTIVE);
       assert.calledWith(fakeTabStore.set, 1, {
         state: tabStates.ACTIVE,
@@ -405,13 +367,24 @@ describe('HypothesisChromeExtension', function () {
     });
 
     it('injects the sidebar if the tab has been activated', function () {
+      fakeTabState.getState = sandbox.stub().returns({
+        state: tabStates.ACTIVE,
+      });
       fakeTabState.isTabActive.returns(true);
       onTabStateChange(tabStates.ACTIVE, tabStates.INACTIVE);
       assert.calledWith(fakeSidebarInjector.injectIntoTab, tab);
     });
 
     it('removes the sidebar if the tab has been deactivated', function () {
+      fakeTabState.getState = sandbox.stub().returns({
+        state: tabStates.INACTIVE,
+        extensionSidebarInstalled: true,
+      });
       fakeTabState.isTabInactive.returns(true);
+      fakeChromeTabs.get = sandbox.stub().yields({
+        id: 1,
+        status: 'complete',
+      })
       onTabStateChange(tabStates.INACTIVE, tabStates.ACTIVE);
       assert.calledWith(fakeSidebarInjector.removeFromTab, tab);
     });
@@ -436,6 +409,13 @@ describe('HypothesisChromeExtension', function () {
     });
 
     describe('when a tab with an error is updated', function () {
+      beforeEach(function () {
+        fakeTabState.getState = sandbox.stub().returns({
+          state: tabStates.ERRORED,
+          extensionSidebarInstalled: false,
+        });
+      });
+
       it('resets the tab error state when no longer errored', function () {
         var tab = {id: 1, url: 'file://foo.html', status: 'complete'};
         onTabStateChange(tabStates.ACTIVE, tabStates.ERRORED);

--- a/h/browser/chrome/test/hypothesis-chrome-extension-test.js
+++ b/h/browser/chrome/test/hypothesis-chrome-extension-test.js
@@ -395,6 +395,7 @@ describe('HypothesisChromeExtension', function () {
     it('injects the sidebar if the tab has been activated', function () {
       fakeTabState.getState = sandbox.stub().returns({
         state: tabStates.ACTIVE,
+        ready: true,
       });
       fakeTabState.isTabActive.returns(true);
       onTabStateChange(tabStates.ACTIVE, tabStates.INACTIVE);
@@ -405,6 +406,7 @@ describe('HypothesisChromeExtension', function () {
       fakeTabState.getState = sandbox.stub().returns({
         state: tabStates.ACTIVE,
         extensionSidebarInstalled: true,
+        ready: true,
       });
       fakeTabState.isTabActive.returns(true);
       onTabStateChange(tabStates.ACTIVE, tabStates.ACTIVE);
@@ -415,6 +417,7 @@ describe('HypothesisChromeExtension', function () {
       fakeTabState.getState = sandbox.stub().returns({
         state: tabStates.INACTIVE,
         extensionSidebarInstalled: true,
+        ready: true,
       });
       fakeTabState.isTabInactive.returns(true);
       fakeChromeTabs.get = sandbox.stub().yields({
@@ -429,6 +432,7 @@ describe('HypothesisChromeExtension', function () {
       fakeTabState.getState = sandbox.stub().returns({
         state: tabStates.INACTIVE,
         extensionSidebarInstalled: false,
+        ready: true,
       });
       fakeTabState.isTabInactive.returns(true);
       fakeChromeTabs.get = sandbox.stub().yields({id: 1, status: 'complete'});
@@ -444,7 +448,11 @@ describe('HypothesisChromeExtension', function () {
     });
 
     it('does nothing if the tab is still loading', function () {
-      fakeChromeTabs.get = sandbox.stub().yields({id: 1, status: 'loading'});
+      fakeTabState.getState = sandbox.stub().returns({
+        state: tabStates.ACTIVE,
+        extensionSidebarInstalled: false,
+        ready: false,
+      });
       onTabStateChange(tabStates.ACTIVE, tabStates.INACTIVE);
       assert.notCalled(fakeSidebarInjector.injectIntoTab);
     });
@@ -460,6 +468,7 @@ describe('HypothesisChromeExtension', function () {
         fakeTabState.getState = sandbox.stub().returns({
           state: tabStates.ERRORED,
           extensionSidebarInstalled: false,
+          ready: true,
         });
       });
 

--- a/h/browser/chrome/test/tab-state-test.js
+++ b/h/browser/chrome/test/tab-state-test.js
@@ -44,7 +44,7 @@ describe('TabState', function () {
 
     it('triggers an onchange handler', function () {
       state.activateTab(2);
-      assert.calledWith(onChange, 2, sinon.match({state: states.ACTIVE}), null);
+      assert.calledWith(onChange, 2, sinon.match({state: states.ACTIVE}));
     });
   });
 
@@ -56,7 +56,7 @@ describe('TabState', function () {
 
     it('triggers an onchange handler', function () {
       state.deactivateTab(2);
-      assert.calledWith(onChange, 2, sinon.match({state: states.INACTIVE}), null);
+      assert.calledWith(onChange, 2, sinon.match({state: states.INACTIVE}));
     });
   });
 
@@ -68,7 +68,7 @@ describe('TabState', function () {
 
     it('triggers an onchange handler', function () {
       state.errorTab(2);
-      assert.calledWith(onChange, 2, sinon.match({state: states.ERRORED}), null);
+      assert.calledWith(onChange, 2, sinon.match({state: states.ERRORED}));
     });
   });
 
@@ -83,23 +83,6 @@ describe('TabState', function () {
     it('triggers an onchange handler', function () {
       state.clearTab(1);
       assert.calledWith(onChange, 1, undefined);
-    });
-  });
-
-  describe('.restorePreviousState', function () {
-    it('restores the state for the tab id provided', function () {
-      state.errorTab(1);
-      state.restorePreviousState(1);
-      assert.equal(state.isTabErrored(1), false);
-      assert.equal(state.isTabActive(1), true);
-    });
-
-    it('is not possible for the previous state to be the same as the current state', function () {
-      state.errorTab(1);
-      state.errorTab(1);
-      state.restorePreviousState(1);
-      assert.equal(state.isTabErrored(1), false, 'Expected isTabErrored to return false');
-      assert.equal(state.isTabActive(1), true, 'Expected isTabActive to return true');
     });
   });
 
@@ -121,15 +104,6 @@ describe('TabState', function () {
     it('returns true if the tab is errored', function () {
       state.errorTab(1);
       assert.equal(state.isTabErrored(1), true);
-    });
-  });
-
-  describe('.onchange', function () {
-    it('provides the previous value to the handler', function () {
-      state.errorTab(1);
-      state.deactivateTab(1);
-      assert.calledWith(onChange, 1, sinon.match({state: states.INACTIVE}),
-        sinon.match({state: states.ERRORED}));
     });
   });
 

--- a/h/browser/chrome/test/tab-state-test.js
+++ b/h/browser/chrome/test/tab-state-test.js
@@ -44,14 +44,7 @@ describe('TabState', function () {
 
     it('triggers an onchange handler', function () {
       state.activateTab(2);
-      assert.calledWith(onChange, 2, {state: states.ACTIVE}, null);
-    });
-
-    it('options.force can be used to re-trigger the current state', function () {
-      state.activateTab(2);
-      state.activateTab(2, {force: true});
-      assert.calledWith(onChange, 2, {state: states.ACTIVE}, null);
-      assert.calledTwice(onChange);
+      assert.calledWith(onChange, 2, sinon.match({state: states.ACTIVE}), null);
     });
   });
 
@@ -63,14 +56,7 @@ describe('TabState', function () {
 
     it('triggers an onchange handler', function () {
       state.deactivateTab(2);
-      assert.calledWith(onChange, 2, {state: states.INACTIVE}, null);
-    });
-
-    it('options.force can be used to re-trigger the current state', function () {
-      state.deactivateTab(2);
-      state.deactivateTab(2, {force: true});
-      assert.calledWith(onChange, 2, {state: states.INACTIVE}, null);
-      assert.calledTwice(onChange);
+      assert.calledWith(onChange, 2, sinon.match({state: states.INACTIVE}), null);
     });
   });
 
@@ -82,14 +68,7 @@ describe('TabState', function () {
 
     it('triggers an onchange handler', function () {
       state.errorTab(2);
-      assert.calledWith(onChange, 2, {state: states.ERRORED}, null);
-    });
-
-    it('options.force can be used to re-trigger the current state', function () {
-      state.errorTab(2);
-      state.errorTab(2, {force: true});
-      assert.calledWith(onChange, 2, {state: states.ERRORED}, null);
-      assert.calledTwice(onChange);
+      assert.calledWith(onChange, 2, sinon.match({state: states.ERRORED}), null);
     });
   });
 
@@ -122,13 +101,6 @@ describe('TabState', function () {
       assert.equal(state.isTabErrored(1), false, 'Expected isTabErrored to return false');
       assert.equal(state.isTabActive(1), true, 'Expected isTabActive to return true');
     });
-
-    it('if options.force is used to set the same value it ignores the value', function () {
-      state.errorTab(1);
-      state.deactivateTab(1);
-      state.deactivateTab(1, {force: true});
-      assert.calledWith(onChange, 1, {state: states.INACTIVE}, {state: states.ERRORED});
-    });
   });
 
   describe('.isTabActive', function () {
@@ -156,8 +128,8 @@ describe('TabState', function () {
     it('provides the previous value to the handler', function () {
       state.errorTab(1);
       state.deactivateTab(1);
-      assert.calledWith(onChange, 1, {state: states.INACTIVE},
-        {state: states.ERRORED});
+      assert.calledWith(onChange, 1, sinon.match({state: states.INACTIVE}),
+        sinon.match({state: states.ERRORED}));
     });
   });
 


### PR DESCRIPTION
This PR refactors the way that the extension determines whether or not it needs to install the sidebar into the current tab and fixes an issue where the extension would automatically remove embedded H on a page even when the user did not interact with it.

The approach is to introduce two additional pieces of per-tab state in `TabState`. `extensionSidebarInstalled` tracks whether the sidebar was installed by the extension into this tab and `ready` tracks whether the tab is ready for the extension to be loaded.

Along the way, I discovered that the documentation in `TabStore` about persisting H state across browser sessions is completely wrong because it uses tab IDs as keys and those are not persistent across sessions. The only use case for `TabStore` currently therefore is persisting H tab state across extension updates and re-installation. I have simplified it and kept it doing that for now.

Another user-visible side-effect of this refactoring is that the badge state can now be updated as soon as a new page load starts, even though the actual injection of the sidebar does not happen until the tab is fully loaded. The result is that badge numbers now appear significantly faster when opening a new page. Actual injection of the sidebar remains deferred until the tab, including _all_ external resources are fully loaded. Ideally we would inject the sidebar as soon as the page receives the 'DOMContentLoaded' event and it would show up much faster. That can wait for a separate PR however.