### PR TITLE
Set up a constraint naming convention for sqlalchemy

### DIFF
--- a/h/db.py
+++ b/h/db.py
@@ -16,6 +16,7 @@ module.
 """
 
 from pyramid.settings import asbool
+from sqlalchemy import MetaData
 from sqlalchemy import engine_from_config
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import scoped_session, sessionmaker
@@ -45,12 +46,25 @@ __all__ = (
 #
 Session = scoped_session(sessionmaker(extension=ZopeTransactionExtension()))
 
+# Create a default metadata object with naming conventions for indexes and
+# constraints. This makes changing such constraints and indexes with alembic
+# after creation much easier. See:
+#
+#   http://docs.sqlalchemy.org/en/latest/core/constraints.html#configuring-constraint-naming-conventions
+#
+metadata = MetaData(naming_convention={
+    "ix": "ix__%(column_0_label)s",
+    "uq": "uq__%(table_name)s__%(column_0_name)s",
+    "ck": "ck__%(table_name)s__%(constraint_name)s",
+    "fk": "fk__%(table_name)s__%(column_0_name)s__%(referred_table_name)s",
+    "pk": "pk__%(table_name)s"
+})
 
 # Provide a very simple base class with a dynamic query property.
 class _Base(object):
     query = Session.query_property()
 
-Base = declarative_base(cls=_Base)
+Base = declarative_base(cls=_Base, metadata=metadata)
 
 
 def bind_engine(engine,

--- a/h/migrations/versions/5aab7692b5de_rename_constraints.py
+++ b/h/migrations/versions/5aab7692b5de_rename_constraints.py
@@ -1,0 +1,92 @@
+"""Rename constraints
+
+Revision ID: 5aab7692b5de
+Revises: 571394188821
+Create Date: 2015-10-22 16:50:08.158964
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '5aab7692b5de'
+down_revision = '571394188821'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def rename_constraint(op, table, before, after):
+    op.execute(sa.text('ALTER TABLE public.{table} '
+                       'RENAME CONSTRAINT {before} '
+                       'TO {after}'.format(table=table,
+                                           before=before,
+                                           after=after)))
+
+
+def upgrade():
+    # activation
+    rename_constraint(op, 'activation', 'activation_pkey', 'pk__activation')
+    rename_constraint(op, 'activation', 'activation_code_key', 'uq__activation__code')
+
+    # blocklist
+    rename_constraint(op, 'blocklist', 'blocklist_pkey', 'pk__blocklist')
+    rename_constraint(op, 'blocklist', 'blocklist_uri_key', 'uq__blocklist__uri')
+
+    # feature
+    rename_constraint(op, 'feature', 'feature_pkey', 'pk__feature')
+    rename_constraint(op, 'feature', 'feature_name_key', 'uq__feature__name')
+
+    # group
+    rename_constraint(op, 'group', 'group_pkey', 'pk__group')
+    rename_constraint(op, 'group', 'group_creator_id_fkey', 'fk__group__creator_id__user')
+
+    # nipsa
+    rename_constraint(op, 'nipsa', 'nipsa_pkey', 'pk__nipsa')
+
+    # subscriptions
+    rename_constraint(op, 'subscriptions', 'subscriptions_pkey', 'pk__subscriptions')
+
+    # user
+    rename_constraint(op, 'user', 'user_pkey', 'pk__user')
+    rename_constraint(op, 'user', 'user_email_key', 'uq__user__email')
+    rename_constraint(op, 'user', 'user_uid_key', 'uq__user__uid')
+    rename_constraint(op, 'user', 'user_username_key', 'uq__user__username')
+    rename_constraint(op, 'user', 'user_activation_id_fkey', 'fk__user__activation_id__activation')
+
+    # user_group
+    rename_constraint(op, 'user_group', 'user_group_group_id_fkey', 'fk__user_group__group_id__group')
+    rename_constraint(op, 'user_group', 'user_group_user_id_fkey', 'fk__user_group__user_id__user')
+
+
+def downgrade():
+    # activation
+    rename_constraint(op, 'activation', 'pk__activation', 'activation_pkey')
+    rename_constraint(op, 'activation', 'uq__activation__code', 'activation_code_key')
+
+    # blocklist
+    rename_constraint(op, 'blocklist', 'pk__blocklist', 'blocklist_pkey')
+    rename_constraint(op, 'blocklist', 'uq__blocklist__uri', 'blocklist_uri_key')
+
+    # feature
+    rename_constraint(op, 'feature', 'pk__feature', 'feature_pkey')
+    rename_constraint(op, 'feature', 'uq__feature__name', 'feature_name_key')
+
+    # group
+    rename_constraint(op, 'group', 'pk__group', 'group_pkey')
+    rename_constraint(op, 'group', 'fk__group__creator_id__user', 'group_creator_id_fkey')
+
+    # nipsa
+    rename_constraint(op, 'nipsa', 'pk__nipsa', 'nipsa_pkey')
+
+    # subscriptions
+    rename_constraint(op, 'subscriptions', 'pk__subscriptions', 'subscriptions_pkey')
+
+    # user
+    rename_constraint(op, 'user', 'pk__user', 'user_pkey')
+    rename_constraint(op, 'user', 'uq__user__email', 'user_email_key')
+    rename_constraint(op, 'user', 'uq__user__uid', 'user_uid_key')
+    rename_constraint(op, 'user', 'uq__user__username', 'user_username_key')
+    rename_constraint(op, 'user', 'fk__user__activation_id__activation', 'user_activation_id_fkey')
+
+    # user_group
+    rename_constraint(op, 'user_group', 'fk__user_group__group_id__group', 'user_group_group_id_fkey')
+    rename_constraint(op, 'user_group', 'fk__user_group__user_id__user', 'user_group_user_id_fkey')


### PR DESCRIPTION
In order to be able to add and remove constraints using alembic, they must be named. Luckily for us PostgreSQL does actually have a reasonably sensible constraint naming convention, but enforcing this in sqlalchemy allows us to know what constraints are called without referring to the database in question.

In addition, the default PostgreSQL naming convention suffers from clashes: an FK constraint on the column "id" on a join table called "foo_bar" will be named "foo_bar_id_fkey", which is the same name as would be given to an FK constraint on the "bar_id" column on table "foo". The naming convention chosen here doesn't suffer from the same problem (presuming that you never use "__" in column names).

This commit includes a migration to update existing constraints to the new naming convention.