### PR TITLE
Disable caching for features/ AJAX responses

### DIFF
--- a/h/features.py
+++ b/h/features.py
@@ -100,7 +100,8 @@ def flag_enabled(request, name):
 @view_config(route_name='features_status',
              request_method='GET',
              accept='application/json',
-             renderer='json')
+             renderer='json',
+             http_cache=0)
 def features_status(request):
     """Report current feature flag values."""
     return {k: flag_enabled(request, k) for k in FEATURES.keys()}


### PR DESCRIPTION
This fixes an issue where the response for /app/features would
be cached by IE 10, 11 resulting in the groups features not
appearing after signing in to a groups-enabled account
and refreshing the page.

I've verified that this fixes the problem I saw but haven't evaluated where other calls might be affected in the same way yet and if so, is there a more generic configuration to disable caching for AJAX responses.

Fixes #2658