### PR TITLE
Fix flash of Clear Search/Selection buttons after failed sign-in

### DIFF
--- a/h/templates/client/viewer.html
+++ b/h/templates/client/viewer.html
@@ -1,5 +1,9 @@
-<!-- Thread view -->
-<ul class="stream-list"
+<!-- Annotation thread view
+
+(See gh2642 for rationale for 'ng-show="true"')
+ -->
+<ul class="stream-list ng-hide"
+    ng-show="true"
     deep-count="count"
     thread-filter="search.query"
     window-scroll="loadMore(20)">


### PR DESCRIPTION
When an app reload occurs (which happens during Sign In, switching group focus and when joining/leaving groups), the 'Clear Search' and
'Clear Selection' buttons would sometimes flash.

This occurred due to an issue where the initial
call to the watcher registered by ng-show to hide
the buttons was invoked asynchronously in some cases.

When the app's route is loaded, the following happens:

 1) viewer.html is compiled
 2) viewer.html is linked
 3) Watchers registered by directives during (1) and (2)
    are run. For the watchers registered by 'ng-show',
    this applies the `ng-hide` CSS class that hides
    elements.

On initial app load, 1-3 all happen synchronously in the
same scope.$digest cycle. However, when logging in with
an incorrect password, 1 & 2 happened in the same cycle
but 3 happened in a separate cycle, with DOM rendering
taking place in a flash between before the directive
was fully ready.

The GitHub issue has more detail and there is some
connection to the 'deepCount' directive but I decided
not to alter that here without sufficient understanding
of the consequences.

This commit fixes the issue by applying the 'ng-hide'
class to the viewer.html initially and then letting
ng-show _remove it_ when its watcher runs. This fixes
the flash when 1-2 and 3 happen in separate digest cycles
and has no effect if they run in the same cycle.

Fixes #2642