### PR TITLE
Do not change focused group when clicking 'leave' icon

### DIFF
--- a/h/static/scripts/directive/group-list.js
+++ b/h/static/scripts/directive/group-list.js
@@ -59,7 +59,7 @@ function groupList(groups, $window) {
         }
       });
     },
-    restrict: 'AE',
+    restrict: 'E',
     scope: {},
     templateUrl: 'group_list.html'
   };

--- a/h/templates/client/group_list.html
+++ b/h/templates/client/group_list.html
@@ -50,7 +50,7 @@
           </div>
         </div>
         <!-- the 'Leave group' icon !-->
-        <div class="group-cancel-icon-container">
+        <div class="group-cancel-icon-container" ng-click="$event.stopPropagation()">
           <i class="h-icon-cancel-outline btn--cancel"
              ng-if="!group.public"
              ng-click="leaveGroup(group.id)"


### PR DESCRIPTION
This PR adds a missing test that clicking 'Leave' and rejecting the dialog does not result in leaving the group and fixes an issue where leaving a group other than the one you had focused resulted in the focused group changing.

There is an issue I'm seeing locally where join/leave actions initially update the H groups list but at some point the push notifications appear to stop working.