### PR TITLE
Add a basic categorized logging facility

### DIFF
--- a/h/static/scripts/logger.js
+++ b/h/static/scripts/logger.js
@@ -1,0 +1,124 @@
+/**
+ * This module implements a very simple and basic categorized logger.
+ *
+ * If we find we need something more sophisticated, we should consider
+ * an established logging library such as Bunyan, Winston etc.
+ *
+ * Usage:
+ *   var logger = getLogger('feature');
+ *   logger.{debug, info, warn, error}(fmt, args);
+ *
+ * When debugging, the logging level for a given logger can be set using
+ * logger.setLevel(level) where 'level' is a string (eg. 'debug', 'info').
+ *
+ * In the browser, all exports of this module are exposed via
+ * window.H_DEBUG.logging for runtime adjustment of the logging levels.
+ *
+ * eg. To turn on debug logging for all loggers, use:
+ *
+ *  window.H_DEBUG.logging.setLevel('debug'),
+ *
+ * or for a specific logger:
+ *
+ *  window.H_DEBUG.logging.getLogger('feature').setLevel('debug')
+ */
+
+var assign = require('object-assign');
+var loggers = {};
+
+var levels = {
+  DEBUG: 5,
+  INFO: 10,
+  WARN: 20,
+  ERROR: 30,
+};
+
+var slice = Array.prototype.slice;
+
+var defaultLogLevel = levels.WARN;
+
+function Logger(name) {
+  this.name = name;
+  this._level = undefined;
+}
+
+Logger.prototype.level = function () {
+  return this._level || defaultLogLevel;
+}
+
+Logger.prototype.logAtLevel = function(level, consoleFn, args) {
+  if (level < this.level()) {
+    return;
+  }
+  var fmt = this.name + ': ' + args[0];
+  args[0] = fmt;
+  consoleFn.apply(console, args);
+}
+
+Logger.prototype.debug = function () {
+  this.logAtLevel(levels.DEBUG, console.debug, slice.call(arguments));
+}
+
+Logger.prototype.info = function () {
+  this.logAtLevel(levels.INFO, console.info, slice.call(arguments));
+};
+
+Logger.prototype.warn = function () {
+  this.logAtLevel(levels.WARN, console.warn, slice.call(arguments));
+};
+
+Logger.prototype.error = function () {
+  this.logAtLevel(levels.ERROR, console.error, slice.call(arguments));
+};
+
+function parseLevel(level) {
+  if (typeof level === 'string') {
+    var levelKey = level.toUpperCase();
+    if (levels.hasOwnProperty(levelKey)) {
+      level = levels[levelKey];
+    } else {
+      throw new Error('Unknown logging level', level);
+    }
+  }
+  return level;
+}
+
+/** Set the level for a given logger. This can either be
+ * the value of a key in 'levels' (eg. levels.DEBUG)
+ * or a case-insensitive key name (eg. 'debug')
+ */
+Logger.prototype.setLevel = function (level) {
+  this._level = parseLevel(level);
+};
+
+/** Create or retrieve the logger with a given name.
+ *
+ * Log levels can be customized per Logger instance.
+ */
+function getLogger(name) {
+  if (!loggers.hasOwnProperty(name)) {
+    loggers[name] = new Logger(name);
+  }
+  return loggers[name];
+}
+
+/** Set the default logging level for all loggers.
+ * This level will be used by any loggers that do not have custom
+ * logging levels set.
+ */
+function setLevel(level) {
+  defaultLogLevel = parseLevel(level);
+}
+
+module.exports = {
+  levels: levels,
+  getLogger: getLogger,
+  setLevel: setLevel,
+};
+
+/** Expose loggers on the global object
+ * for debugging in the browser
+ */
+window.H_DEBUG = assign(window.H_DEBUG || {}, {
+  logging: module.exports
+});

--- a/h/static/scripts/streamer.js
+++ b/h/static/scripts/streamer.js
@@ -7,6 +7,8 @@ var clientId = uuid.v4();
 // be open at a time
 var socket;
 
+var logger = require('./logger').getLogger('websocket');
+
 /**
  * Open a new WebSocket connection to the Hypothesis push notification service.
  * Only one websocket connection may exist at a time, any existing socket is
@@ -74,15 +76,17 @@ function connect($websocket, annotationMapper, groups, session, settings) {
   socket.onMessage(function (event) {
     message = JSON.parse(event.data);
     if (!message) {
+      logger.warn('failed to parse message', event.data);
       return;
     }
+    logger.debug('received message', message);
 
     if (message.type === 'annotation-notification') {
       handleAnnotationNotification(message)
     } else if (message.type === 'session-change') {
       handleSessionChangeNotification(message)
     } else {
-      console.warn('received unsupported notification', message.type)
+      logger.warn('received unsupported notification', message.type)
     }
   });
 


### PR DESCRIPTION
This adds a minimal categorized logging facility and
adds a facility to use it for logging web socket
messages that are received.

This serves two purposes:

 * Tagging logging messages with the component they
   relate to.

 * Setting the logging level for different parts of
   the app at runtime via `window.H_DEBUG.logging`

   eg.
     window.H_DEBUG.logging.setLevel('debug')

   Will turn on debug logging for all loggers.

 * In future we may extend this to report metrics and
   log messages etc. to the server.

At the moment, this is a minimal custom implementation.
In future if we decide we do need more features, it should
be possible to swap out an existing well known service such as
Winston or Bunyan with very few changes to the users of the logging
service.

----

**TODO**

* [ ] Tests