### PR TITLE
Deliver up-to-date groups list in groups leave/join notifications

### DIFF
--- a/h/streamer.py
+++ b/h/streamer.py
@@ -583,7 +583,7 @@ def handle_user_event(message, socket):
     return {
         'type': 'session-change',
         'action': message['type'],
-        'model': h.session.model(socket.request)
+        'model': message['session_model']
     }
 
 

--- a/h/test/streamer_test.py
+++ b/h/test/streamer_test.py
@@ -384,12 +384,13 @@ def test_handle_annotation_event_sends_if_in_group():
     assert streamer.handle_annotation_event(message, socket) is not None
 
 
-@patch('h.session.model')
-def test_handle_user_event_sends_session_change_when_joining_or_leaving_group(session_model):
+def test_handle_user_event_sends_session_change_when_joining_or_leaving_group():
+    session_model = Mock()
     message = {
         'type': 'group-join',
         'userid': 'amy',
         'group': 'groupid',
+        'session_model': session_model,
     }
 
     sock = FakeSocket('clientid')
@@ -398,7 +399,7 @@ def test_handle_user_event_sends_session_change_when_joining_or_leaving_group(se
     assert streamer.handle_user_event(message, sock) == {
         'type': 'session-change',
         'action': 'group-join',
-        'model': session_model.return_value,
+        'model': session_model,
     }
 
 


### PR DESCRIPTION
When pushing a session state change notification to clients
after joining or leaving a group, the session model could
be out of date because the groups view published the notification
prior to committing the database transaction.

If the websocket server picked up the message from NSQ and queried
the DB for the session state prior to the commit happening,
the client would receive a notification but the payload
would be out of date.

We considered two possible approaches to fix this - one
was to commit the transaction in the groups views before
publishing the notification, the other was to serialize the
session model as part of the notification.

This commit takes the latter approach for consistency with how
annotation notifications work and also as slightly more
explicit to read. We may want to reconsider in future.

Fixes #2671