### PR TITLE
Avoid route reload on groups list change

### DIFF
--- a/h/static/scripts/app-controller.coffee
+++ b/h/static/scripts/app-controller.coffee
@@ -48,7 +48,7 @@ module.exports = class AppController
 
     # Reload the view when the focused group changes or the
     # list of groups that the user is a member of changes
-    reloadEvents = [events.SESSION_CHANGED, events.GROUP_FOCUSED];
+    reloadEvents = [events.USER_CHANGED, events.GROUP_FOCUSED];
     reloadEvents.forEach((eventName) ->
       $scope.$on(eventName, (event) ->
         $route.reload()

--- a/h/static/scripts/app-controller.coffee
+++ b/h/static/scripts/app-controller.coffee
@@ -50,8 +50,9 @@ module.exports = class AppController
     # list of groups that the user is a member of changes
     reloadEvents = [events.USER_CHANGED, events.GROUP_FOCUSED];
     reloadEvents.forEach((eventName) ->
-      $scope.$on(eventName, (event) ->
-        $route.reload()
+      $scope.$on(eventName, (event, data) ->
+        if !data || !data.initialLoad
+          $route.reload()
       )
     );
 

--- a/h/static/scripts/directive/group-list.js
+++ b/h/static/scripts/directive/group-list.js
@@ -35,6 +35,7 @@ function GroupListController($scope, $window, groups) {
 
   $scope.allGroups = groups.all();
   $scope.$on(events.GROUPS_CHANGED, function () {
+    $scope.focusedGroup = groups.focused();
     $scope.allGroups = groups.all();
   });
 

--- a/h/static/scripts/directive/group-list.js
+++ b/h/static/scripts/directive/group-list.js
@@ -1,7 +1,9 @@
 'use strict';
 
+var events = require('../events');
+
 // @ngInject
-function GroupListController($scope, $window) {
+function GroupListController($scope, $window, groups) {
   $scope.expandedGroupId = undefined;
 
   // show the share link for the specified group or clear it if
@@ -19,13 +21,27 @@ function GroupListController($scope, $window) {
   };
 
   $scope.leaveGroup = function (groupId) {
-    var groupName = $scope.groups.get(groupId).name;
+    var groupName = groups.get(groupId).name;
     var message = 'Are you sure you want to leave the group "' +
       groupName + '"?';
     if ($window.confirm(message)) {
-      $scope.groups.leave(groupId);
+      groups.leave(groupId);
     }
   }
+
+  $scope.focusGroup = function (groupId) {
+    groups.focus(groupId);
+  }
+
+  $scope.allGroups = groups.all();
+  $scope.$on(events.GROUPS_CHANGED, function () {
+    $scope.allGroups = groups.all();
+  });
+
+  $scope.focusedGroup = groups.focused();
+  $scope.$on(events.GROUP_FOCUSED, function () {
+    $scope.focusedGroup = groups.focused();
+  });
 }
 
 /**
@@ -39,8 +55,6 @@ function groupList(groups, $window) {
   return {
     controller: GroupListController,
     link: function ($scope, elem, attrs) {
-      $scope.groups = groups;
-
       $scope.createNewGroup = function() {
         $window.open('/groups/new', '_blank');
       }

--- a/h/static/scripts/directive/group-list.js
+++ b/h/static/scripts/directive/group-list.js
@@ -33,16 +33,8 @@ function GroupListController($scope, $window, groups) {
     groups.focus(groupId);
   }
 
-  $scope.allGroups = groups.all();
-  $scope.$on(events.GROUPS_CHANGED, function () {
-    $scope.focusedGroup = groups.focused();
-    $scope.allGroups = groups.all();
-  });
-
-  $scope.focusedGroup = groups.focused();
-  $scope.$on(events.GROUP_FOCUSED, function () {
-    $scope.focusedGroup = groups.focused();
-  });
+  $scope.$on(events.GROUPS_CHANGED, $scope.$apply.bind($scope));
+  $scope.$on(events.GROUP_FOCUSED, $scope.$apply.bind($scope));
 }
 
 /**
@@ -56,6 +48,8 @@ function groupList(groups, $window) {
   return {
     controller: GroupListController,
     link: function ($scope, elem, attrs) {
+      $scope.groups = groups;
+
       $scope.createNewGroup = function() {
         $window.open('/groups/new', '_blank');
       }

--- a/h/static/scripts/directive/test/group-list-test.js
+++ b/h/static/scripts/directive/test/group-list-test.js
@@ -11,6 +11,7 @@ describe('GroupListController', function () {
   beforeEach(function () {
     $scope = {
       $on: sinon.stub(),
+      $apply: sinon.stub(),
     };
     var fakeWindow = {};
     var fakeGroups = {

--- a/h/static/scripts/events.js
+++ b/h/static/scripts/events.js
@@ -2,7 +2,6 @@
  * This module defines the set of global events that are dispatched
  * on $rootScope
  */
-
 module.exports = {
   /** Broadcast when the currently selected group changes */
   GROUP_FOCUSED: 'groupFocused',

--- a/h/static/scripts/events.js
+++ b/h/static/scripts/events.js
@@ -6,6 +6,10 @@
 module.exports = {
   /** Broadcast when the currently selected group changes */
   GROUP_FOCUSED: 'groupFocused',
+  /** Broadcast when the list of groups changes */
+  GROUPS_CHANGED: 'groupsChanged',
+  /** Broadcast when the signed-in user changes */
+  USER_CHANGED: 'userChanged',
   /** Broadcast when the session state is updated.
    * This event is NOT broadcast after the initial session load.
    */

--- a/h/static/scripts/groups.js
+++ b/h/static/scripts/groups.js
@@ -84,7 +84,7 @@ function groups(localStorage, session, $rootScope, features, $http) {
   }
 
   // reset the focused group if the user leaves it
-  $rootScope.$on(events.SESSION_CHANGED, function () {
+  $rootScope.$on(events.GROUPS_CHANGED, function () {
     if (focusedGroup) {
       focusedGroup = get(focusedGroup.id);
       if (!focusedGroup) {

--- a/h/static/scripts/session.js
+++ b/h/static/scripts/session.js
@@ -116,6 +116,9 @@ function session($document, $http, $resource, $rootScope, flash) {
   resource.update = function (model) {
     var isInitialLoad = !resource.state.csrf;
 
+    var userChanged = model.userid !== resource.state.userid;
+    var groupsChanged = !angular.equals(model.groups, resource.state.groups);
+
     // Copy the model data (including the CSRF token) into `resource.state`.
     angular.copy(model, resource.state);
 
@@ -130,6 +133,12 @@ function session($document, $http, $resource, $rootScope, flash) {
 
     if (!isInitialLoad) {
       $rootScope.$broadcast(events.SESSION_CHANGED);
+      if (userChanged) {
+        $rootScope.$broadcast(events.USER_CHANGED);
+      }
+      if (groupsChanged) {
+        $rootScope.$broadcast(events.GROUPS_CHANGED);
+      }
     }
 
     // Return the model

--- a/h/static/scripts/session.js
+++ b/h/static/scripts/session.js
@@ -131,14 +131,19 @@ function session($document, $http, $resource, $rootScope, flash) {
     lastLoad = {$promise: Promise.resolve(model), $resolved: true};
     lastLoadTime = Date.now();
 
-    if (!isInitialLoad) {
-      $rootScope.$broadcast(events.SESSION_CHANGED);
-      if (userChanged) {
-        $rootScope.$broadcast(events.USER_CHANGED);
-      }
-      if (groupsChanged) {
-        $rootScope.$broadcast(events.GROUPS_CHANGED);
-      }
+    $rootScope.$broadcast(events.SESSION_CHANGED, {
+      initialLoad: isInitialLoad,
+    });
+
+    if (userChanged) {
+      $rootScope.$broadcast(events.USER_CHANGED, {
+        initialLoad: isInitialLoad,
+      });
+    }
+    if (groupsChanged) {
+      $rootScope.$broadcast(events.GROUPS_CHANGED, {
+        initialLoad: isInitialLoad,
+      });
     }
 
     // Return the model

--- a/h/static/scripts/test/app-controller-test.coffee
+++ b/h/static/scripts/test/app-controller-test.coffee
@@ -151,8 +151,14 @@ describe 'AppController', ->
     $scope.$broadcast(events.GROUP_FOCUSED)
     assert.calledOnce(fakeRoute.reload)
 
-  it 'reloads the view when the logged-in user changes', ->
+  it 'does not reload the view when the logged-in user changes on first load', ->
     createController()
     fakeRoute.reload = sinon.spy()
-    $scope.$broadcast(events.USER_CHANGED)
+    $scope.$broadcast(events.USER_CHANGED, {initialLoad: true})
+    assert.notCalled(fakeRoute.reload)
+
+  it 'reloads the view when the logged-in user changes after first load', ->
+    createController()
+    fakeRoute.reload = sinon.spy()
+    $scope.$broadcast(events.USER_CHANGED, {initialLoad: false})
     assert.calledOnce(fakeRoute.reload)

--- a/h/static/scripts/test/app-controller-test.coffee
+++ b/h/static/scripts/test/app-controller-test.coffee
@@ -151,8 +151,8 @@ describe 'AppController', ->
     $scope.$broadcast(events.GROUP_FOCUSED)
     assert.calledOnce(fakeRoute.reload)
 
-  it 'reloads the view when the session state changes', ->
+  it 'reloads the view when the logged-in user changes', ->
     createController()
     fakeRoute.reload = sinon.spy()
-    $scope.$broadcast(events.SESSION_CHANGED)
+    $scope.$broadcast(events.USER_CHANGED)
     assert.calledOnce(fakeRoute.reload)

--- a/h/static/scripts/test/groups-test.js
+++ b/h/static/scripts/test/groups-test.js
@@ -40,7 +40,7 @@ describe('groups', function() {
       $broadcast: sandbox.stub(),
 
       $on: function(event, callback) {
-        if (event === events.SESSION_CHANGED) {
+        if (event === events.GROUPS_CHANGED) {
           this.eventCallbacks.push(callback);
         }
       }

--- a/h/static/scripts/test/session-test.js
+++ b/h/static/scripts/test/session-test.js
@@ -161,7 +161,8 @@ describe('h:session', function () {
     it('broadcasts an event when the session is updated', function () {
       var sessionChangeCallback = sinon.stub();
 
-      // the initial load should not trigger a SESSION_CHANGED event
+      // the initial load should trigger a SESSION_CHANGED event
+      // with initialLoad set
       $rootScope.$on(events.SESSION_CHANGED, sessionChangeCallback);
       session.update({
         groups: [{
@@ -169,16 +170,19 @@ describe('h:session', function () {
         }],
         csrf: 'dummytoken',
       });
+      assert.calledWith(sessionChangeCallback, sinon.match({}),
+        {initialLoad: true});
 
       // subsequent loads should trigger a SESSION_CHANGED event
-      assert.isFalse(sessionChangeCallback.called);
+      sessionChangeCallback.reset();
       session.update({
         groups: [{
           id: 'groupid2'
         }],
         csrf: 'dummytoken'
       });
-      assert.calledOnce(sessionChangeCallback);
+      assert.calledWith(sessionChangeCallback, sinon.match({}),
+        {initialLoad: false});
     });
   });
 });

--- a/h/static/scripts/test/session-test.js
+++ b/h/static/scripts/test/session-test.js
@@ -158,7 +158,7 @@ describe('h:session', function () {
   });
 
   describe('#update()', function () {
-    it('broadcasts an event when the session is updated', function () {
+    it('broadcasts SESION_CHANGED when the session changes', function () {
       var sessionChangeCallback = sinon.stub();
 
       // the initial load should trigger a SESSION_CHANGED event
@@ -183,6 +183,28 @@ describe('h:session', function () {
       });
       assert.calledWith(sessionChangeCallback, sinon.match({}),
         {initialLoad: false});
+    });
+
+    it('broadcasts GROUPS_CHANGED when the groups change', function () {
+      var groupChangeCallback = sinon.stub();
+      $rootScope.$on(events.GROUPS_CHANGED, groupChangeCallback);
+      session.update({
+        groups: [{
+          id: 'groupid'
+        }],
+        csrf: 'dummytoken'
+      });
+      assert.calledOnce(groupChangeCallback);
+    });
+
+    it('broadcasts USER_CHANGED when the user changes', function () {
+      var userChangeCallback = sinon.stub();
+      $rootScope.$on(events.USER_CHANGED, userChangeCallback);
+      session.update({
+        userid: 'fred',
+        csrf: 'dummytoken'
+      });
+      assert.calledOnce(userChangeCallback);
     });
   });
 });

--- a/h/static/scripts/test/session-test.js
+++ b/h/static/scripts/test/session-test.js
@@ -158,7 +158,7 @@ describe('h:session', function () {
   });
 
   describe('#update()', function () {
-    it('broadcasts SESION_CHANGED when the session changes', function () {
+    it('broadcasts SESSION_CHANGED when the session changes', function () {
       var sessionChangeCallback = sinon.stub();
 
       // the initial load should trigger a SESSION_CHANGED event

--- a/h/templates/client/group_list.html
+++ b/h/templates/client/group_list.html
@@ -1,8 +1,8 @@
 <span ng-if="auth.status === 'signed-out'"
-      ng-switch on="focusedGroup.public">
+      ng-switch on="groups.focused().public">
   <i class="group-list-label__icon h-icon-public" ng-switch-when="true"></i><!-- nospace
   !--><i class="group-list-label__icon h-icon-group" ng-switch-default></i>
-  <span class="group-list-label__label">{{focusedGroup.name}}</span>
+  <span class="group-list-label__label">{{groups.focused().name}}</span>
 </span>
 
 <div class="pull-right"
@@ -13,19 +13,19 @@
         dropdown-toggle
         data-toggle="dropdown"
         role="button"
-        ng-switch on="focusedGroup.public"
+        ng-switch on="groups.focused().public"
         ng-click="toggleShareLink(undefined)"
         title="Change the selected group">
     <i class="group-list-label__icon h-icon-public" ng-switch-when="true"></i><!-- nospace
     !--><i class="group-list-label__icon h-icon-group" ng-switch-default></i>
-    <span class="group-list-label__label">{{focusedGroup.name}}</span><!-- nospace
+    <span class="group-list-label__label">{{groups.focused().name}}</span><!-- nospace
     !--><i class="h-icon-arrow-drop-down"></i>
   </span>
   <div class="dropdown-menu__top-arrow"></div>
   <ul class="dropdown-menu pull-none" role="menu">
     <li class="dropdown-menu__row dropdown-menu__row--unpadded "
-        ng-repeat="group in allGroups">
-      <div ng-class="{'group-item': true, selected: group.id == focusedGroup.id}"
+        ng-repeat="group in groups.all()">
+      <div ng-class="{'group-item': true, selected: group.id == groups.focused().id}"
            ng-click="focusGroup(group.id)">
         <!-- the group icon !-->
         <div class="group-icon-container" ng-switch on="group.public">

--- a/h/templates/client/group_list.html
+++ b/h/templates/client/group_list.html
@@ -1,8 +1,8 @@
 <span ng-if="auth.status === 'signed-out'"
-      ng-switch on="groups.focused().public">
+      ng-switch on="focusedGroup.public">
   <i class="group-list-label__icon h-icon-public" ng-switch-when="true"></i><!-- nospace
   !--><i class="group-list-label__icon h-icon-group" ng-switch-default></i>
-  <span class="group-list-label__label">{{groups.focused().name}}</span>
+  <span class="group-list-label__label">{{focusedGroup.name}}</span>
 </span>
 
 <div class="pull-right"
@@ -13,20 +13,20 @@
         dropdown-toggle
         data-toggle="dropdown"
         role="button"
-        ng-switch on="groups.focused().public"
+        ng-switch on="focusedGroup.public"
         ng-click="toggleShareLink(undefined)"
         title="Change the selected group">
     <i class="group-list-label__icon h-icon-public" ng-switch-when="true"></i><!-- nospace
     !--><i class="group-list-label__icon h-icon-group" ng-switch-default></i>
-    <span class="group-list-label__label">{{groups.focused().name}}</span><!-- nospace
+    <span class="group-list-label__label">{{focusedGroup.name}}</span><!-- nospace
     !--><i class="h-icon-arrow-drop-down"></i>
   </span>
   <div class="dropdown-menu__top-arrow"></div>
   <ul class="dropdown-menu pull-none" role="menu">
     <li class="dropdown-menu__row dropdown-menu__row--unpadded "
-        ng-repeat="group in groups.all()">
-      <div ng-class="{'group-item': true, selected: group.id == groups.focused().id}"
-           ng-click="groups.focus(group.id)">
+        ng-repeat="group in allGroups">
+      <div ng-class="{'group-item': true, selected: group.id == focusedGroup.id}"
+           ng-click="focusGroup(group.id)">
         <!-- the group icon !-->
         <div class="group-icon-container" ng-switch on="group.public">
           <i class="h-icon-public" ng-switch-when="true"></i>


### PR DESCRIPTION
This builds on https://github.com/hypothesis/h/pull/2669 and fixes the issue described in https://github.com/hypothesis/h/issues/2641 where the user would lose any unsaved annotation text if they joined or left a group whilst an annotation was being created in another tab.

If the user leaves the group which is currently focused in a tab, that will still result in unsaved annotations in that tab being lost.