### PR TITLE
Show "Only Me" when editing a private annotation

### DIFF
--- a/h/templates/client/annotation.html
+++ b/h/templates/client/annotation.html
@@ -21,7 +21,7 @@
         </a>
       </span>
       <i class="h-icon-border-color" ng-show="vm.isHighlight() && !vm.editing" title="This is a highlight. Click 'edit' to add a note or tag."></i>
-      <span ng-show="vm.isPrivate() && !vm.editing"
+      <span ng-show="vm.isPrivate()"
             title="This annotation is visible only to you.">
         <i class="h-icon-lock"></i> Only Me
       </span>


### PR DESCRIPTION
Currently on master when you create a private annotation in a group, after saving it, the top of the annotation card looks like this:

![screenshot from 2015-10-27 12 01 25](https://cloud.githubusercontent.com/assets/22498/10757366/79b031b2-7ca2-11e5-9446-d30ae6bd9d52.png)

But when creating or editing an annotation, the _Only Me_ part is not shown even if _Only Me_ is selected in the _Post_ dropdown, I consider this a bug:

![screenshot from 2015-10-27 12 03 19](https://cloud.githubusercontent.com/assets/22498/10757400/bd020e54-7ca2-11e5-9108-1c26a269157f.png)

_Only Me_ will appear after saving it.

This pull request fixes this to dynamically show and hide the _Only Me_ part as the _Post_ dropdown changes, when creating/editing:

![untitled screencast - cropped 5](https://cloud.githubusercontent.com/assets/22498/10757445/006a2820-7ca3-11e5-922a-b7cef0c20fd4.gif)

I think this accurately reflects what is happening - an annotation is being created _in the group_ but it is _private_. For better or for worse, you can create private annotations in groups currently, so not showing the group name would be wrong.