### PR TITLE
Adjust the top-most position of entries in the bucket bar

### DIFF
--- a/h/static/scripts/annotator/plugin/bucket-bar.coffee
+++ b/h/static/scripts/annotator/plugin/bucket-bar.coffee
@@ -9,7 +9,7 @@ highlighter = require('../highlighter')
 
 BUCKET_SIZE = 16                              # Regular bucket size
 BUCKET_NAV_SIZE = BUCKET_SIZE + 6             # Bucket plus arrow (up/down)
-BUCKET_TOP_THRESHOLD = 100 + BUCKET_NAV_SIZE  # Toolbar
+BUCKET_TOP_THRESHOLD = 115 + BUCKET_NAV_SIZE  # Toolbar
 
 
 # Scroll to the next closest anchor off screen in the given direction.


### PR DESCRIPTION
Adjust the top-most position of entries in the bucket bar
to accomodate the height changes in the toolbar as part
of a recent design update.

![bucket-bar-pos](https://cloud.githubusercontent.com/assets/2458/10759955/2abbebb8-7cb2-11e5-8f0e-c03dceb4488e.png)

Fixes #2646