### PR TITLE
Wait for feature flag data before loading sidebar view

### DIFF
--- a/h/static/scripts/app.coffee
+++ b/h/static/scripts/app.coffee
@@ -7,6 +7,9 @@ require('angular-jwt')
 streamer = require('./streamer')
 
 resolve =
+  # Ensure that we have feature flags available before we load the main
+  # view as features such as groups affect which annotations are loaded
+  featuresLoaded: ['features', (features) -> features.fetch()]
   # Ensure that we have available a) the current authenticated userid, and b)
   # the list of user groups.
   sessionState: ['session', (session) -> session.load().$promise]

--- a/h/static/scripts/features.js
+++ b/h/static/scripts/features.js
@@ -33,10 +33,7 @@ function features ($document, $http, $log, $rootScope) {
   var featuresUrl = new URL('/app/features', $document.prop('baseURI')).href;
   var fetchOperation;
 
-  // FIXME - This should be changed to clear the feature flag cache
-  // only in response to the USER_CHANGED event once
-  // https://github.com/hypothesis/h/pull/2674 lands
-  $rootScope.$on(events.SESSION_CHANGED, function () {
+  $rootScope.$on(events.USER_CHANGED, function () {
     cache = null;
   });
 

--- a/h/static/scripts/features.js
+++ b/h/static/scripts/features.js
@@ -21,58 +21,69 @@
  */
 'use strict';
 
-var retry = require('retry');
+var assign = require('core-js/modules/$.assign');
+
+var events = require('./events');
 
 var CACHE_TTL = 5 * 60 * 1000; // 5 minutes
 
-function features ($document, $http, $log) {
+// @ngInject
+function features ($document, $http, $log, $rootScope) {
   var cache = null;
-  var operation = null;
   var featuresUrl = new URL('/app/features', $document.prop('baseURI')).href;
+  var fetchOperation;
+
+  // FIXME - This should be changed to clear the feature flag cache
+  // only in response to the USER_CHANGED event once
+  // https://github.com/hypothesis/h/pull/2674 lands
+  $rootScope.$on(events.SESSION_CHANGED, function () {
+    cache = null;
+  });
 
   function fetch() {
-    // Short-circuit if a fetch is already in progress...
-    if (operation) {
-      return;
-    }
-    operation = retry.operation({retries: 10, randomize: true});
-
-    function success(data) {
-      cache = [Date.now(), data];
-      operation = null;
+    if (fetchOperation) {
+      // fetch already in progress
+      return fetchOperation;
     }
 
-    function failure(data, status) {
-      if (!operation.retry('failed to load - remote status was ' + status)) {
-        // All retries have failed, and we will now stop polling the endpoint.
-        $log.error('features service:', operation.mainError());
-      }
-    }
-
-    operation.attempt(function () {
-      $http.get(featuresUrl)
-        .success(success)
-        .error(failure);
+    fetchOperation = $http.get(featuresUrl).then(function (response) {
+      cache = {
+        updated: Date.now(),
+        flags: response.data,
+      };
+    }).catch(function (err) {
+      // if for any reason fetching features fails, we behave as
+      // if all flags are turned off
+      $log.warn('failed to fetch feature data', err);
+      cache = assign({}, cache, {
+        updated: Date.now(),
+      });
+    }).finally(function () {
+      fetchOperation = null;
     });
+
+    return fetchOperation;
   }
 
   function flagEnabled(name) {
     // Trigger a fetch if the cache is more than CACHE_TTL milliseconds old.
     // We don't wait for the fetch to complete, so it's not this call that
     // will see new data.
-    if (cache === null || (Date.now() - cache[0]) > CACHE_TTL) {
+    if (!cache || (Date.now() - cache.updated) > CACHE_TTL) {
       fetch();
     }
 
-    if (cache === null) {
+    if (!cache || !cache.flags) {
+      // a fetch is either in progress or fetching the feature flags
+      // failed
       return false;
     }
-    var flags = cache[1];
-    if (!flags.hasOwnProperty(name)) {
+
+    if (!cache.flags.hasOwnProperty(name)) {
       $log.warn('features service: looked up unknown feature:', name);
       return false;
     }
-    return flags[name];
+    return cache.flags[name];
   }
 
   return {
@@ -81,4 +92,4 @@ function features ($document, $http, $log) {
   };
 }
 
-module.exports = ['$document', '$http', '$log', features];
+module.exports = features;

--- a/h/static/scripts/test/features-test.js
+++ b/h/static/scripts/test/features-test.js
@@ -1,9 +1,12 @@
-"use strict";
+'use strict';
 
 var mock = angular.mock;
 
+var events = require('../events');
+
 describe('h:features', function () {
   var $httpBackend;
+  var $rootScope;
   var features;
   var sandbox;
 
@@ -26,6 +29,7 @@ describe('h:features', function () {
 
   beforeEach(mock.inject(function ($injector) {
     $httpBackend = $injector.get('$httpBackend');
+    $rootScope = $injector.get('$rootScope');
     features = $injector.get('features');
   }));
 
@@ -120,6 +124,21 @@ describe('h:features', function () {
 
       defaultHandler();
       features.flagEnabled('foo');
+      $httpBackend.flush();
+    });
+
+    it('should clear the features data when the user changes', function () {
+      // fetch features and check that the flag is set
+      defaultHandler();
+      features.fetch();
+      $httpBackend.flush();
+      assert.isTrue(features.flagEnabled('foo'));
+
+      // simulate a change of logged-in user which should clear
+      // the features cache
+      $rootScope.$broadcast(events.USER_CHANGED, {});
+      defaultHandler();
+      assert.isFalse(features.flagEnabled('foo'));
       $httpBackend.flush();
     });
   });

--- a/h/static/scripts/test/features-test.js
+++ b/h/static/scripts/test/features-test.js
@@ -41,71 +41,86 @@ describe('h:features', function () {
     return handler;
   }
 
-  it('fetch should retrieve features data', function () {
-    defaultHandler();
-    features.fetch();
-    $httpBackend.flush();
+  describe('fetch', function() {
+    it('should retrieve features data', function () {
+      defaultHandler();
+      features.fetch();
+      $httpBackend.flush();
+      assert.equal(features.flagEnabled('foo'), true);
+    });
+
+    it('should return a promise', function () {
+      defaultHandler();
+      features.fetch().then(function () {
+        assert.equal(features.flagEnabled('foo'), true);
+      });
+      $httpBackend.flush();
+    });
+
+    it('should not explode for errors fetching features data', function () {
+      defaultHandler().respond(500, "ASPLODE!");
+      var handler = sinon.stub();
+      features.fetch().then(handler);
+      $httpBackend.flush();
+      assert.calledOnce(handler);
+    });
+
+    it('should only send one request at a time', function () {
+      defaultHandler();
+      features.fetch();
+      features.fetch();
+      $httpBackend.flush();
+    });
   });
 
-  it('fetch should not explode for errors fetching features data', function () {
-    defaultHandler().respond(500, "ASPLODE!");
-    features.fetch();
-    $httpBackend.flush();
-  });
+  describe('flagEnabled', function () {
+    it('should retrieve features data', function () {
+      defaultHandler();
+      features.flagEnabled('foo');
+      $httpBackend.flush();
+    });
 
-  it('fetch should only send one request at a time', function () {
-    defaultHandler();
-    features.fetch();
-    features.fetch();
-    $httpBackend.flush();
-  });
+    it('should return false initially', function () {
+      defaultHandler();
+      var result = features.flagEnabled('foo');
+      $httpBackend.flush();
 
-  it('flagEnabled should retrieve features data', function () {
-    defaultHandler();
-    features.flagEnabled('foo');
-    $httpBackend.flush();
-  });
+      assert.isFalse(result);
+    });
 
-  it('flagEnabled should return false initially', function () {
-    defaultHandler();
-    var result = features.flagEnabled('foo');
-    $httpBackend.flush();
+    it('should return flag values when data is loaded', function () {
+      defaultHandler();
+      features.fetch();
+      $httpBackend.flush();
 
-    assert.isFalse(result);
-  });
+      var foo = features.flagEnabled('foo');
+      assert.isTrue(foo);
 
-  it('flagEnabled should return flag values when data is loaded', function () {
-    defaultHandler();
-    features.fetch();
-    $httpBackend.flush();
+      var bar = features.flagEnabled('bar');
+      assert.isFalse(bar);
+    });
 
-    var foo = features.flagEnabled('foo');
-    assert.isTrue(foo);
+    it('should return false for unknown flags', function () {
+      defaultHandler();
+      features.fetch();
+      $httpBackend.flush();
 
-    var bar = features.flagEnabled('bar');
-    assert.isFalse(bar);
-  });
+      var baz = features.flagEnabled('baz');
+      assert.isFalse(baz);
+    });
 
-  it('flagEnabled should return false for unknown flags', function () {
-    defaultHandler();
-    features.fetch();
-    $httpBackend.flush();
+    it('should trigger a new fetch after cache expiry', function () {
+      var clock = sandbox.useFakeTimers();
 
-    var baz = features.flagEnabled('baz');
-    assert.isFalse(baz);
-  });
+      defaultHandler();
+      features.flagEnabled('foo');
+      $httpBackend.flush();
 
-  it('flagEnabled should trigger a new fetch after cache expiry', function () {
-    var clock = sandbox.useFakeTimers();
+      clock.tick(301 * 1000);
 
-    defaultHandler();
-    features.flagEnabled('foo');
-    $httpBackend.flush();
-
-    clock.tick(301 * 1000);
-
-    defaultHandler();
-    features.flagEnabled('foo');
-    $httpBackend.flush();
+      defaultHandler();
+      features.flagEnabled('foo');
+      $httpBackend.flush();
+    });
   });
 });

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "node-uuid": "^1.4.3",
     "postcss": "^5.0.6",
     "raf": "^3.1.0",
-    "retry": "^0.8.0",
     "scroll-into-view": "^1.3.1",
     "showdown": "^1.2.1",
     "uglify-js": "^2.4.14",


### PR DESCRIPTION
This fixes an issue where the app could show a private group as focused in the top bar but annotations from the public group.

This happened when:
 1. The feature flag data was loaded _after_ the initial search for annotations had been performed.
 2. The user has groups enabled
 3. In the user's previous H session, they had a private group selected.

In this scenario, when the initial search queries the focused group, it will get Public because until the feature flag data is returned, private groups is disabled.

Once the feature flag data loads, the groups feature is enabled, the focused group implicitly changes to the user's last selected private group but the annotation search is not updated.

The approach taken here is to request features at the same time as session data on sidebar load and wait for both before loading the view and requesting annotations.

`features.fetch()` now returns a promise which resolves when the features are fetched or the retrieval fails. I left out the exponential retry logic for the moment. If fetching feature data fails, the client will simply behave as if all features are turned off until the cache expires. I'm happy to reconsider this if we think it is important enough to keep.

----

* [X] Update the reference to `SESSION_CHANGED` once https://github.com/hypothesis/h/pull/2674 is merged