### PR TITLE
Set permissions of new annotations on login

### DIFF
--- a/h/static/scripts/directive/annotation.coffee
+++ b/h/static/scripts/directive/annotation.coffee
@@ -61,19 +61,24 @@ AnnotationController = [
 
     model = $scope.annotationGet()
 
+    # Set model.permissions to the default permissions for new annotations,
+    # _if_ model.permissions isn't already set.
+    setDefaultPermissions = ->
+      if not model.permissions?.read
+        defaultLevel = localStorage.getItem(STORAGE_KEY);
+        if (defaultLevel != 'private') and (defaultLevel != 'shared')
+          defaultLevel = 'shared';
+        if defaultLevel == 'private'
+          model.permissions = permissions.private()
+        else
+          model.permissions = permissions.shared(model.group)
+
     # Set the group of new annotations.
     if not model.group
       model.group = groups.focused().id
 
     # Set the permissions of new annotations.
-    if not model.permissions
-      defaultLevel = localStorage.getItem(STORAGE_KEY);
-      if (defaultLevel != 'private') and (defaultLevel != 'shared')
-        defaultLevel = 'shared';
-      if defaultLevel == 'private'
-        model.permissions = permissions.private()
-      else
-        model.permissions = permissions.shared(model.group)
+    setDefaultPermissions()
 
     highlight = model.$highlight
     original = null
@@ -378,6 +383,8 @@ AnnotationController = [
           highlight = false # Prevents double highlight creation.
         else
           drafts.add model, => this.revert()
+
+      setDefaultPermissions()
 
       updateTimestamp(model is old)  # repeat on first run
       this.render()

--- a/h/static/scripts/directive/annotation.coffee
+++ b/h/static/scripts/directive/annotation.coffee
@@ -1,5 +1,7 @@
 ### global -validate ###
 
+events = require('../events')
+
 # Validate an annotation.
 # Annotations must be attributed to a user or marked as deleted.
 # A public annotation is valid only if they have a body.
@@ -58,6 +60,8 @@ AnnotationController = [
     @timestamp = null
 
     model = $scope.annotationGet()
+
+    model.user ?= session.state.userid
 
     # Set the group of new annotations.
     if not model.group
@@ -374,17 +378,15 @@ AnnotationController = [
       this.render()
     , true
 
-    # Watch the current user
-    # TODO: fire events instead since watchers are not free and auth is rare
-    $scope.$watch (-> session.state.userid), (userid) ->
-      model.user ?= userid
+    $scope.$on(events.USER_CHANGED, ->
+      model.user ?= session.state.userid
 
       # Set model.permissions on sign in, if it isn't already set.
       # This is because you can create annotations when signed out and they
       # will have model.permissions = null, then when you sign in we set the
       # permissions correctly here.
       model.permissions = model.permissions or permissions.default(model.group)
-
+    )
 
     # Start editing brand new annotations immediately
     unless model.id? or (this.isHighlight() and highlight) then this.edit()

--- a/h/static/scripts/permissions.coffee
+++ b/h/static/scripts/permissions.coffee
@@ -1,3 +1,5 @@
+STORAGE_KEY = 'hypothesis.privacy'
+
 ###*
 # @ngdoc service
 # @name  Permissions
@@ -6,7 +8,7 @@
 # This service can set default permissions to annotations properly and
 # offers some utility functions regarding those.
 ###
-module.exports = ['session', (session) ->
+module.exports = ['session', 'localStorage', (session, localStorage) ->
   ALL_PERMISSIONS = {}
   GROUP_WORLD = 'group:__world__'
   ADMIN_PARTY = [{
@@ -37,7 +39,7 @@ module.exports = ['session', (session) ->
   # Typical use: annotation.permissions = permissions.private()
   ###
   private: ->
-    if not session?.state?.userid
+    if not session.state.userid
       return null
     else
       return {
@@ -57,7 +59,7 @@ module.exports = ['session', (session) ->
   # Typical use: annotation.permissions = permissions.shared(group)
   ###
   shared: (group) ->
-    if not session?.state?.userid
+    if not session.state.userid
       return null
     if group?
       group = 'group:' + group
@@ -69,6 +71,25 @@ module.exports = ['session', (session) ->
       delete: [session.state.userid]
       admin: [session.state.userid]
     }
+
+  # Return the initial permissions for a new annotation in the given group.
+  default: (group) ->
+    defaultLevel = localStorage.getItem(STORAGE_KEY);
+    if (defaultLevel != 'private') and (defaultLevel != 'shared')
+      defaultLevel = 'shared';
+    if defaultLevel == 'private'
+      return this.private()
+    else
+      return this.shared(group)
+
+  # Set the default initial permissions for new annotations (that will be
+  # returned by default() above) to "private" or "shared" permissions.
+  #
+  # @param {string} private_or_shared "private" to make default() return the
+  #   necessary permissions for private annotations, "shared" to make it
+  #   return those for shared annotations.
+  setDefault: (private_or_shared) ->
+    localStorage.setItem(STORAGE_KEY, private_or_shared);
 
   ###*
   # @ngdoc method

--- a/h/static/scripts/permissions.coffee
+++ b/h/static/scripts/permissions.coffee
@@ -37,10 +37,15 @@ module.exports = ['session', (session) ->
   # Typical use: annotation.permissions = permissions.private()
   ###
   private: ->
-    read: [session.state.userid]
-    update: [session.state.userid]
-    delete: [session.state.userid]
-    admin: [session.state.userid]
+    if not session?.state?.userid
+      return null
+    else
+      return {
+        read: [session.state.userid]
+        update: [session.state.userid]
+        delete: [session.state.userid]
+        admin: [session.state.userid]
+      }
 
   ###*
   # @ngdoc method
@@ -52,6 +57,8 @@ module.exports = ['session', (session) ->
   # Typical use: annotation.permissions = permissions.shared(group)
   ###
   shared: (group) ->
+    if not session?.state?.userid
+      return null
     if group?
       group = 'group:' + group
     else

--- a/h/static/scripts/test/permissions-test.coffee
+++ b/h/static/scripts/test/permissions-test.coffee
@@ -31,26 +31,38 @@ describe 'h:permissions', ->
     beforeEach inject (_permissions_) ->
       permissions = _permissions_
 
-    it 'private call fills all permissions with auth.user', ->
-      perms = permissions.private()
-      assert.equal(perms.read[0], 'acct:flash@gordon')
-      assert.equal(perms.update[0], 'acct:flash@gordon')
-      assert.equal(perms.delete[0], 'acct:flash@gordon')
-      assert.equal(perms.admin[0], 'acct:flash@gordon')
+    describe 'private()', ->
 
-    it 'public call fills the read property with group:__world__', ->
-      perms = permissions.shared()
-      assert.equal(perms.read[0], 'group:__world__')
-      assert.equal(perms.update[0], 'acct:flash@gordon')
-      assert.equal(perms.delete[0], 'acct:flash@gordon')
-      assert.equal(perms.admin[0], 'acct:flash@gordon')
+      it 'fills all permissions with auth.user', ->
+        perms = permissions.private()
+        assert.equal(perms.read[0], 'acct:flash@gordon')
+        assert.equal(perms.update[0], 'acct:flash@gordon')
+        assert.equal(perms.delete[0], 'acct:flash@gordon')
+        assert.equal(perms.admin[0], 'acct:flash@gordon')
 
-    it 'public call fills the read property with group:foo if passed "foo"', ->
-      perms = permissions.shared("foo")
-      assert.equal(perms.read[0], 'group:foo')
-      assert.equal(perms.update[0], 'acct:flash@gordon')
-      assert.equal(perms.delete[0], 'acct:flash@gordon')
-      assert.equal(perms.admin[0], 'acct:flash@gordon')
+      it 'returns null if session.state.userid is falsey', ->
+        delete fakeSession.state.userid
+        assert.equal(permissions.private(), null)
+
+    describe 'shared()', ->
+
+      it 'fills the read property with group:__world__', ->
+        perms = permissions.shared()
+        assert.equal(perms.read[0], 'group:__world__')
+        assert.equal(perms.update[0], 'acct:flash@gordon')
+        assert.equal(perms.delete[0], 'acct:flash@gordon')
+        assert.equal(perms.admin[0], 'acct:flash@gordon')
+
+      it 'fills the read property with group:foo if passed "foo"', ->
+        perms = permissions.shared("foo")
+        assert.equal(perms.read[0], 'group:foo')
+        assert.equal(perms.update[0], 'acct:flash@gordon')
+        assert.equal(perms.delete[0], 'acct:flash@gordon')
+        assert.equal(perms.admin[0], 'acct:flash@gordon')
+
+      it 'returns null if session.state.userid is falsey', ->
+        delete fakeSession.state.userid
+        assert.equal(permissions.shared("foo"), null)
 
     describe 'isPublic', ->
       it 'isPublic() true if the read permission has group:__world__ in it', ->


### PR DESCRIPTION
While signed out create a new annotation. You'll see a "You must sign in
to create an annotation" card. This card is in fact an annotation
in the client-side code, but one that has no user, no permissions, etc
etc. If you sign in, you'll then see a full annotation card with editor
open in place of the previous card, you can type an annotation and save
it.

Except that this will send invalid permissions to the server, which will
happy save them (no validation) and then crash.

The fix:

On sign in, set the model.permissions and @annotation.permissions of
such annotations. This means that the Post dropdown will set itself
correctly to shared or private and on posting the annotation the correct
permissions will be sent to the server.

Also fixed permissions.coffee to return null instead of invalid
permissions when not signed in.

Fixes #2686.