### PR TITLE
Fix exception when GROUPS_CHANGED event is broadcast during route load

### DIFF
--- a/h/static/scripts/directive/group-list.js
+++ b/h/static/scripts/directive/group-list.js
@@ -32,9 +32,6 @@ function GroupListController($scope, $window, groups) {
   $scope.focusGroup = function (groupId) {
     groups.focus(groupId);
   }
-
-  $scope.$on(events.GROUPS_CHANGED, $scope.$apply.bind($scope));
-  $scope.$on(events.GROUP_FOCUSED, $scope.$apply.bind($scope));
 }
 
 /**

--- a/h/static/scripts/directive/test/group-list-test.js
+++ b/h/static/scripts/directive/test/group-list-test.js
@@ -165,20 +165,4 @@ describe('groupList', function () {
     clickLeaveIcon(element, true);
     assert.notCalled(fakeGroups.focus);
   });
-
-  it('should update when a GROUPS_CHANGED event is received', function () {
-    var element = createGroupList();
-    var groupItems = element.find('.group-item');
-    assert.equal(groupItems.length, groups.length + 1);
-
-    groups.push({
-      id: 'new-group',
-      name: 'New Group',
-      url: GROUP_LINK
-    });
-    $rootScope.$broadcast(events.GROUPS_CHANGED);
-    element.scope.$digest();
-    groupItems = element.find('.group-item');
-    assert.equal(groupItems.length, groups.length + 1);
-  });
 });


### PR DESCRIPTION
The <group-list> directive attempted to update itself in
response to a group change notification without triggering
a full digest cycle by using `$scope.$apply`.

This was based on the incorrect understanding that $apply only
dirty-checks the current scope downwards. In fact, in dirty-checks
the root scope. Additionally, the logic was pointless since
group list/focus changes happen in response to two types of events,
both of which are triggered in the context of $apply:

 * An event handler when the user selects a group

 * A callback from angular-websocket when a WebSocket message
   is received.