### PR TITLE
Query tags field with a match query (use mapping analyzer)

### DIFF
--- a/h/api/search/query.py
+++ b/h/api/search/query.py
@@ -197,4 +197,6 @@ class TagsMatcher(object):
             del params['tags']
         except KeyError:
             pass
-        return {'terms': {'tags': [tag for tag in tags]}} if tags else None
+        matchers = [{'match': {'tags': {'query': t, 'operator': 'and'}}}
+                    for t in tags]
+        return {'bool': {'must': matchers}} if matchers else None

--- a/h/api/search/test/query_test.py
+++ b/h/api/search/test/query_test.py
@@ -402,7 +402,10 @@ def test_tagsmatcher_aliases_tag_to_tags():
 
     result = query.TagsMatcher()(params)
 
-    assert result == {'terms': {'tags': ['foo', 'bar']}}
+    assert result == {'bool': {'must': [
+        {'match': {'tags': {'query': 'foo', 'operator': 'and'}}},
+        {'match': {'tags': {'query': 'bar', 'operator': 'and'}}},
+    ]}}
 
 
 def test_tagsmatcher_with_both_tag_and_tags():
@@ -411,7 +414,10 @@ def test_tagsmatcher_with_both_tag_and_tags():
 
     result = query.TagsMatcher()(params)
 
-    assert result == {'terms': {'tags': ['foo', 'bar']}}
+    assert result == {'bool': {'must': [
+        {'match': {'tags': {'query': 'foo', 'operator': 'and'}}},
+        {'match': {'tags': {'query': 'bar', 'operator': 'and'}}},
+    ]}}
 
 
 @pytest.fixture


### PR DESCRIPTION
The "tags" field is stored in Elasticsearch analysed (by our custom "uni_normalizer" analyzer). This means, broadly, that in the inverted index, individual terms in a tag will be stripped of punctuation and case-normalised.  As such, we need to do the same normalisation when querying, and the easiest way to do this is with a match query.

This commit changes "tag" queries so that:

- all tag parameters must match
- multiple tokens within one tag query are all required to match

By way of example, for an annotation with tags:

    ["hello", "#THERE", "big world"]

These queries will match:

    tag=hello
    tag=HELLO
    tag=#hello
    tag=hello&tag=there
    tag=hello&tag=there&tag=big+world
    tag=hello&tag=there&tag=world+big

Whereas these will not:

    tag=he+llo
    tag=hello&tag=monkeys
    tag=hello&tag=world

Fixes #2655.