### PR TITLE
Avoid route reload on change

### DIFF
--- a/h/static/scripts/app-controller.coffee
+++ b/h/static/scripts/app-controller.coffee
@@ -46,8 +46,7 @@ module.exports = class AppController
       options: ['Newest', 'Oldest', 'Location']
     }
 
-    # Reload the view when the focused group changes or the
-    # list of groups that the user is a member of changes
+    # Reload the view when the user switches accounts
     reloadEvents = [events.USER_CHANGED];
     reloadEvents.forEach((eventName) ->
       $scope.$on(eventName, (event, data) ->

--- a/h/static/scripts/app-controller.coffee
+++ b/h/static/scripts/app-controller.coffee
@@ -48,7 +48,7 @@ module.exports = class AppController
 
     # Reload the view when the focused group changes or the
     # list of groups that the user is a member of changes
-    reloadEvents = [events.USER_CHANGED, events.GROUP_FOCUSED];
+    reloadEvents = [events.USER_CHANGED];
     reloadEvents.forEach((eventName) ->
       $scope.$on(eventName, (event, data) ->
         if !data || !data.initialLoad

--- a/h/static/scripts/app.coffee
+++ b/h/static/scripts/app.coffee
@@ -19,15 +19,13 @@ resolve =
     'annotationMapper', 'drafts', 'threading'
     (annotationMapper,   drafts,   threading) ->
       # Unload all the annotations
-      idTable = threading.idTable
-      annotations = (message for id, {message} of idTable when message)
-      annotationMapper.unloadAnnotations(annotations)
+      annotationMapper.unloadAnnotations(threading.annotationList())
 
       # Reset the threading root
       threading.createIdTable([])
       threading.root = mail.messageContainer()
 
-      # Thread all the drafts
+      # Reload all unsaved annotations
       threading.thread(drafts.all())
 
       return threading

--- a/h/static/scripts/test/app-controller-test.coffee
+++ b/h/static/scripts/test/app-controller-test.coffee
@@ -145,12 +145,6 @@ describe 'AppController', ->
     createController()
     assert.isFalse($scope.shareDialog.visible)
 
-  it 'reloads the view when the focused group changes', ->
-    createController()
-    fakeRoute.reload = sinon.spy()
-    $scope.$broadcast(events.GROUP_FOCUSED)
-    assert.calledOnce(fakeRoute.reload)
-
   it 'does not reload the view when the logged-in user changes on first load', ->
     createController()
     fakeRoute.reload = sinon.spy()

--- a/h/static/scripts/threading.coffee
+++ b/h/static/scripts/threading.coffee
@@ -1,7 +1,20 @@
 angular = require('angular')
 mail = require('./vendor/jwz')
 
-
+# The threading service provides the model for the currently loaded
+# set of annotations, structured as a tree of annotations and replies.
+#
+# The service listens for events when annotations are loaded, unloaded,
+# created or deleted and updates the tree model in response.
+#
+# The conversion of a flat list of incoming messages into a tree structure
+# with replies nested under their parents
+# uses an implementation of the `jwz` message threading algorithm
+# (see https://www.jwz.org/doc/threading.html and the JS port
+#  at https://github.com/maxogden/conversationThreading-js).
+#
+# The 'Threading' service "inherits" from 'mail.messageThread'
+#
 module.exports = class Threading
   root: null
 

--- a/h/static/scripts/threading.coffee
+++ b/h/static/scripts/threading.coffee
@@ -61,6 +61,11 @@ module.exports = class Threading
     this.pruneEmpties(@root)
     @root
 
+  # Returns a flat list of every annotation that is currently loaded
+  # in the thread
+  annotationList: ->
+    (message for id, {message} of @idTable when message)
+
   pruneEmpties: (parent) ->
     for container in parent.children
       this.pruneEmpties(container)


### PR DESCRIPTION
Avoid reloading whole view when focused group changes

When the focused group changes, instead of reloading the whole
view just unload the currently displayed annotations and then
reload the annotations for the newly selected group(s) and
any drafts of unsaved annotations.

The only immediately 'visible' effect of the change is
that switching groups now only results in a call to /search
rather than network requests to fetch session state and features.

In future this should make it easier to preserve state
for the area below the top bar when switching groups.
