### PR TITLE
Appropriately encode the tab URL for a query string

### DIFF
--- a/h/browser/chrome/lib/tab-state.js
+++ b/h/browser/chrome/lib/tab-state.js
@@ -25,6 +25,11 @@ var DEFAULT_STATE = {
   ready: false,
 };
 
+/** encodeUriQuery encodes a string for use in a query parameter */
+function encodeUriQuery(val) {
+  return encodeURIComponent(val).replace(/%20/g, '+');
+}
+
 /** TabState stores the H state for a tab. This state includes:
  *
  * - Whether the extension has been activated on a tab
@@ -161,7 +166,7 @@ function TabState(initialState, onchange) {
       self.setState(tabId, {annotationCount: total});
     };
 
-    xhr.open('GET', apiUrl + '/badge?uri=' + tabUrl);
+    xhr.open('GET', apiUrl + '/badge?uri=' + encodeUriQuery(tabUrl));
     xhr.send();
   };
 

--- a/h/browser/chrome/test/tab-state-test.js
+++ b/h/browser/chrome/test/tab-state-test.js
@@ -136,6 +136,15 @@ describe('TabState', function () {
       assert.equal(request.url, "http://example.com/badge?uri=tabUrl");
     });
 
+    it('urlencodes the tabUrl appropriately', function() {
+      state.updateAnnotationCount("tabId", "http://foo.com?bar=baz qüx", "http://example.com");
+
+      assert.equal(server.requests.length, 1);
+      var request = server.requests[0];
+      assert.equal(request.method, "GET");
+      assert.equal(request.url, "http://example.com/badge?uri=http%3A%2F%2Ffoo.com%3Fbar%3Dbaz+q%C3%BCx");
+    });
+
     it("doesn't set the annotation count if the server's JSON is invalid", function() {
       server.respondWith(
         "GET", "http://example.com/badge?uri=tabUrl",


### PR DESCRIPTION
Tab URLs can contain all kinds of weird things, including:

- query strings (`?foo=bar`)
- percent-encoded strings that do not correspond to valid UTF-8 sequences as mandated by RFC3986 (recently seen: `/ac%FD-pul-biber`, an example of ISO-8859-9 percent-encoding)

We need to ensure that when we pass the URL to the badge endpoint we pass a valid encoded string.

Fixes #2648.