### PR TITLE
Don't update timestamps of unsaved annotations

### DIFF
--- a/h/static/scripts/directive/annotation.coffee
+++ b/h/static/scripts/directive/annotation.coffee
@@ -361,6 +361,10 @@ AnnotationController = [
       @annotation.tags = ({text} for text in (@annotation.tags or []))
 
     updateTimestamp = (repeat=false) =>
+      if not model.updated
+        # New (not yet saved to the server) annotations don't have any .updated
+        # yet, so we can't update their timestamp.
+        return
       @timestamp = time.toFuzzyString model.updated
       fuzzyUpdate = time.nextFuzzyUpdate model.updated
       nextUpdate = (1000 * fuzzyUpdate) + 500

--- a/h/static/scripts/directive/test/annotation-test.coffee
+++ b/h/static/scripts/directive/test/annotation-test.coffee
@@ -368,15 +368,22 @@ describe 'annotation', ->
       afterEach ->
         clock.restore()
 
+      it 'is not updated for unsaved annotations', ->
+        # Unsaved annotations don't have an updated time yet so a timestamp
+        # string can't be computed for them.
+        annotation.updated = null
+        $scope.$digest()
+        assert.equal(controller.timestamp, null)
+
       it 'is updated on first digest', ->
         $scope.$digest()
         assert.equal(controller.timestamp, 'a while ago')
 
       it 'is updated after a timeout', ->
         fakeTime.nextFuzzyUpdate.returns(10)
+        fakeTime.toFuzzyString.returns('ages ago')
         $scope.$digest()
         clock.tick(11000)
-        fakeTime.toFuzzyString.returns('ages ago')
         $timeout.flush()
         assert.equal(controller.timestamp, 'ages ago')
 


### PR DESCRIPTION
Fix a bug where the updateTimestamp() function in AnnotationController would
try to update the @timestamp property of new annotations that have no
model.updated timestamp because they haven't been saved to the server yet.
This result in nonsense values being generated and updateTimestamp() being
called multiple times per second for each unsaved annotation.