### PR TITLE
Remove the 'groups' feature flag

### DIFF
--- a/h/api/search/core.py
+++ b/h/api/search/core.py
@@ -28,7 +28,7 @@ def search(request, params, private=True):
     builder.append_filter(query.UriFilter())
     builder.append_filter(lambda _: \
         nipsa.nipsa_filter(request.authenticated_userid))
-    builder.append_filter(query.GroupFilter(request))
+    builder.append_filter(query.GroupFilter())
 
     builder.append_matcher(query.AnyMatcher())
     builder.append_matcher(query.TagsMatcher())

--- a/h/api/search/query.py
+++ b/h/api/search/query.py
@@ -132,20 +132,11 @@ class GroupFilter(object):
 
     """
     Matches only those annotations belonging to the specified group.
-
-    When the groups feature flag is off, this ensures that only annotations
-    from the public group are returned.
     """
-
-    def __init__(self, request):
-        self.request = request
 
     def __call__(self, params):
         # Remove parameter if passed, preventing fall-through to default query
         group = params.pop("group", None)
-
-        if not self.request.feature('groups'):
-            return {"term": {"group": "__world__"}}
 
         if group is not None:
             return {"term": {"group": group}}

--- a/h/api/search/test/query_test.py
+++ b/h/api/search/test/query_test.py
@@ -272,44 +272,14 @@ def test_authfilter_with_private_removed_authenticated_userid_principal():
     }
 
 
-def test_groupfilter_restricts_to_public_annotations_when_feature_off():
-    """
-    When the groups feature flag is off, the filter should ensure that only
-    public annotations are returned, regardless of the parameter value.
-    """
-    request = mock.Mock()
-    request.feature.return_value = False
-    groupfilter = query.GroupFilter(request)
-
-    assert groupfilter({}) == groupfilter({"group": "foo"}) == {
-        "term": {"group": "__world__"}}
-
-
-def test_groupfilter_strips_param_when_feature_off():
-    """
-    When the groups feature flag is off, the filter should strip the group
-    parameter.
-    """
-    request = mock.Mock()
-    request.feature.return_value = False
-    groupfilter = query.GroupFilter(request)
-    params = {"group": "wibble"}
-
-    groupfilter(params)
-
-    assert params == {}
-
-
 def test_groupfilter_term_filters_for_group():
-    request = mock.Mock()
-    groupfilter = query.GroupFilter(request)
+    groupfilter = query.GroupFilter()
 
     assert groupfilter({"group": "wibble"}) == {"term": {"group": "wibble"}}
 
 
 def test_groupfilter_strips_param():
-    request = mock.Mock()
-    groupfilter = query.GroupFilter(request)
+    groupfilter = query.GroupFilter()
     params = {"group": "wibble"}
 
     groupfilter(params)
@@ -318,8 +288,7 @@ def test_groupfilter_strips_param():
 
 
 def test_groupfilter_returns_none_when_no_param():
-    request = mock.Mock()
-    groupfilter = query.GroupFilter(request)
+    groupfilter = query.GroupFilter()
 
     assert groupfilter({}) is None
 

--- a/h/api/test/views_test.py
+++ b/h/api/test/views_test.py
@@ -219,16 +219,6 @@ def test_create_returns_render(search_lib):
 read_fixtures = pytest.mark.usefixtures('search_lib', 'AnnotationEvent')
 
 
-@ read_fixtures
-def test_read_404s_for_group_annotations_if_groups_feature_is_off():
-    context = mock.Mock(model={'group': 'foo'})
-    request = mock.Mock()
-    request.feature.return_value = False
-
-    with pytest.raises(httpexceptions.HTTPNotFound):
-        views.read(context, request)
-
-
 @read_fixtures
 def test_read_event(AnnotationEvent):
     annotation = _mock_annotation()

--- a/h/api/views.py
+++ b/h/api/views.py
@@ -167,15 +167,6 @@ def read(context, request):
     """Return the annotation (simply how it was stored in the database)."""
     annotation = context.model
 
-    # Don't show group annotations for users who don't have the groups feature
-    # enabled, even if they are members of the group (this can happen if a user
-    # joins a group and then the groups feature is later disabled for that
-    # user).
-    if not request.feature('groups'):
-        if annotation.get('group') not in (None, '__world__'):
-            raise httpexceptions.HTTPNotFound()
-
-
     # Notify any subscribers
     _publish_annotation_event(request, annotation, 'read')
 

--- a/h/features.py
+++ b/h/features.py
@@ -8,7 +8,6 @@ from h.db import Base
 
 FEATURES = {
     'claim': "Enable 'claim your username' web views?",
-    'groups': "Enable private annotation groups?",
     'show_unanchored_annotations': "Show annotations that fail to anchor?",
     'truncate_annotations': "Truncate long quotes and bodies in annotations?",
 }

--- a/h/groups/test/views_test.py
+++ b/h/groups/test/views_test.py
@@ -35,12 +35,6 @@ create_form_fixtures = pytest.mark.usefixtures('GroupSchema', 'Form')
 
 
 @create_form_fixtures
-def test_create_form_404s_if_groups_feature_is_off():
-    with pytest.raises(httpexceptions.HTTPNotFound):
-        views.create_form(_mock_request(feature=lambda feature: False))
-
-
-@create_form_fixtures
 def test_create_form_creates_form_with_GroupSchema(GroupSchema, Form):
     test_schema = mock.Mock()
     GroupSchema.return_value = mock.Mock(
@@ -64,12 +58,6 @@ def test_create_form_returns_form(Form):
 # The fixtures required to mock all of create()'s dependencies.
 create_fixtures = pytest.mark.usefixtures('GroupSchema', 'Form', 'Group',
                                           'session_model')
-
-
-@create_fixtures
-def test_create_404s_if_groups_feature_is_off():
-    with pytest.raises(httpexceptions.HTTPNotFound):
-        views.create(_mock_request(feature=lambda feature: False))
 
 
 @create_fixtures
@@ -175,12 +163,6 @@ def test_create_publishes_join_event(Group, session_model):
 # The fixtures required to mock all of read()'s dependencies.
 read_fixtures = pytest.mark.usefixtures(
     'search', 'Group', 'renderers', 'uri', 'presenters')
-
-
-@read_fixtures
-def test_read_404s_if_groups_feature_is_off():
-    with pytest.raises(httpexceptions.HTTPNotFound):
-        views.read(_mock_request(feature=lambda feature: False))
 
 
 @read_fixtures
@@ -461,12 +443,6 @@ def test_read_documents_are_truncated(Group, search, renderers, uri,
 
 # The fixtures required to mock all of join()'s dependencies.
 join_fixtures = pytest.mark.usefixtures('Group', 'session_model')
-
-
-@join_fixtures
-def test_join_404s_if_groups_feature_is_off():
-    with pytest.raises(httpexceptions.HTTPNotFound):
-        views.join(_mock_request(feature=lambda feature: False))
 
 
 @join_fixtures

--- a/h/groups/views.py
+++ b/h/groups/views.py
@@ -26,9 +26,6 @@ _ = i18n.TranslationString
              renderer='h:groups/templates/create.html.jinja2')
 def create_form(request):
     """Render the form for creating a new group."""
-    if not request.feature('groups'):
-        raise exc.HTTPNotFound()
-
     if request.authenticated_userid is None:
         raise exc.HTTPNotFound()
 
@@ -61,9 +58,6 @@ def _send_group_notification(request, event_type, pubid):
              renderer='h:groups/templates/create.html.jinja2')
 def create(request):
     """Respond to a submission of the create group form."""
-    if not request.feature('groups'):
-        raise exc.HTTPNotFound()
-
     if request.authenticated_userid is None:
         raise exc.HTTPNotFound()
 
@@ -153,9 +147,6 @@ def _join(request, group):
 @view_config(route_name='group_read_noslug', request_method='GET')
 def read(request):
     """Render the page for a group."""
-    if not request.feature('groups'):
-        raise exc.HTTPNotFound()
-
     pubid = request.matchdict["pubid"]
     slug = request.matchdict.get("slug")
 
@@ -182,9 +173,6 @@ def read(request):
              request_method='POST',
              renderer='h:groups/templates/read.html.jinja2')
 def join(request):
-    if not request.feature('groups'):
-        raise exc.HTTPNotFound()
-
     if request.authenticated_userid is None:
         raise exc.HTTPNotFound()
 
@@ -216,8 +204,6 @@ def _group_form(request):
 @view_config(route_name='group_leave',
              request_method='POST')
 def leave(request):
-    if not request.feature('groups'):
-        raise exc.HTTPNotFound()
     if request.authenticated_userid is None:
         raise exc.HTTPNotFound()
 

--- a/h/static/scripts/directive/top-bar.js
+++ b/h/static/scripts/directive/top-bar.js
@@ -5,7 +5,6 @@ module.exports = function () {
     restrict: 'E',
     scope: {
       auth: '=',
-      groupsEnabled: '=',
       isSidebar: '=',
       onLogin: '&',
       onLogout: '&',

--- a/h/static/scripts/groups.js
+++ b/h/static/scripts/groups.js
@@ -18,7 +18,7 @@ var STORAGE_KEY = 'hypothesis.groups.focus';
 var events = require('./events');
 
 // @ngInject
-function groups(localStorage, session, $rootScope, features, $http) {
+function groups(localStorage, session, $rootScope, $http) {
   // The currently focused group. This is the group that's shown as selected in
   // the groups dropdown, the annotations displayed are filtered to only ones
   // that belong to this group, and any new annotations that the user creates
@@ -62,13 +62,12 @@ function groups(localStorage, session, $rootScope, features, $http) {
    */
   function focused() {
     if (focusedGroup) {
-     return focusedGroup;
-    } else if (features.flagEnabled('groups')) {
-     var fromStorage = get(localStorage.getItem(STORAGE_KEY));
-     if (fromStorage) {
-       focusedGroup = fromStorage;
-       return focusedGroup;
-     }
+      return focusedGroup;
+    }
+    var fromStorage = get(localStorage.getItem(STORAGE_KEY));
+    if (fromStorage) {
+      focusedGroup = fromStorage;
+      return focusedGroup;
     }
     return all()[0];
   }

--- a/h/static/scripts/test/groups-test.js
+++ b/h/static/scripts/test/groups-test.js
@@ -22,7 +22,6 @@ describe('groups', function() {
   var fakeSession;
   var fakeLocalStorage;
   var fakeRootScope;
-  var fakeFeatures;
   var fakeHttp;
   var sandbox;
 
@@ -45,9 +44,6 @@ describe('groups', function() {
         }
       }
     };
-    fakeFeatures = {
-      flagEnabled: function() {return true;}
-    };
     fakeHttp = sandbox.stub()
   });
 
@@ -56,8 +52,7 @@ describe('groups', function() {
   });
 
   function service() {
-    return groups(fakeLocalStorage, fakeSession, fakeRootScope,
-                  fakeFeatures, fakeHttp);
+    return groups(fakeLocalStorage, fakeSession, fakeRootScope, fakeHttp);
   }
 
   describe('.all()', function() {

--- a/h/templates/app.html.jinja2
+++ b/h/templates/app.html.jinja2
@@ -20,7 +20,6 @@
     share-dialog="shareDialog"
     is-sidebar="isSidebar"
     search-controller="search"
-    groups-enabled="feature('groups') && isSidebar"
     sort-by="sort.name"
     sort-options="sort.options"
     on-change-sort-by="sort.name = sortBy"

--- a/h/templates/client/top_bar.html
+++ b/h/templates/client/top_bar.html
@@ -1,14 +1,8 @@
 <!-- top bar for the sidebar and the stream.
 !-->
 <div class="top-bar" ng-class="frame.visible && 'shown'" ng-cloak>
-  <!-- Legacy design for top bar !-->
-  <div class="top-bar__inner content" ng-if="!groupsEnabled">
-    <button class="top-bar__btn"
-            ng-click="shareDialog.visible = !shareDialog.visible"
-            ng-if="isSidebar"
-            title="Share this page">
-      <i class="h-icon-share"></i>
-    </button>
+  <!-- Legacy design for top bar, as used in the stream !-->
+  <div class="top-bar__inner content" ng-if="!isSidebar">
     <simple-search
       class="simple-search"
       query="searchController.query"
@@ -24,13 +18,12 @@
       on-logout="onLogout()">
     </signin-control>
   </div>
-  <!-- New design for the top bar.
-       This is part of the groups roll-out
+  <!-- New design for the top bar, as used in the sidebar.
 
        The inner div is styled with 'content' to center it in
        the stream view.
   !-->
-  <div class="top-bar__inner content" ng-if="groupsEnabled">
+  <div class="top-bar__inner content" ng-if="isSidebar">
     <group-list class="group-list" auth="auth"></group-list>
     <div class="top-bar__expander"></div>
     <simple-search
@@ -48,7 +41,6 @@
     </sort-dropdown>
     <a class="top-bar__btn"
        ng-click="shareDialog.visible = !shareDialog.visible"
-       ng-if="isSidebar"
        title="Share this page">
       <i class="h-icon-share"></i>
     </a>

--- a/h/templates/client/viewer.html
+++ b/h/templates/client/viewer.html
@@ -14,7 +14,7 @@
     selection-count="selectedAnnotationsCount"
     on-clear-selection="clearSelection()">
   </search-status-bar>
-  <li ng-if="!feature('groups') && isStream">
+  <li ng-if="isStream">
     <sort-dropdown
       sort-by="sort.name"
       sort-options="sortOptions"


### PR DESCRIPTION
This is deployed and toggled on everywhere, so we can simplify our code by removing this feature flag.

There's one small wrinkle here, which is that there are still two distinct designs for the "top bar" -- one for the sidebar and one for the stream. I've simplified this in this commit, and removed any reference to groups as a toggle for the two flavours of sidebar, but at some point we will probably want to unify the two experiences.