### PR TITLE
Faster database tests

### DIFF
--- a/h/accounts/test/models_test.py
+++ b/h/accounts/test/models_test.py
@@ -6,20 +6,21 @@ import re
 import pytest
 from sqlalchemy import exc
 
+from h import db
 from h.accounts import models
 from h.test import factories
 
 
-def test_activation_has_asciinumeric_code(db_session):
+def test_activation_has_asciinumeric_code():
     act = models.Activation()
 
-    db_session.add(act)
-    db_session.flush()
+    db.Session.add(act)
+    db.Session.flush()
 
     assert re.match(r'[A-Za-z0-9]{12}', act.code)
 
 
-def test_cannot_create_dot_variant_of_user(db_session):
+def test_cannot_create_dot_variant_of_user():
     fred = models.User(username='fredbloggs',
                        email='fred@example.com',
                        password='123')
@@ -27,13 +28,13 @@ def test_cannot_create_dot_variant_of_user(db_session):
                         email='fred@example.org',
                         password='456')
 
-    db_session.add(fred)
-    db_session.add(fred2)
+    db.Session.add(fred)
+    db.Session.add(fred2)
     with pytest.raises(exc.IntegrityError):
-        db_session.flush()
+        db.Session.flush()
 
 
-def test_cannot_create_case_variant_of_user(db_session):
+def test_cannot_create_case_variant_of_user():
     bob = models.User(username='BobJones',
                       email='bob@example.com',
                       password='123')
@@ -41,28 +42,28 @@ def test_cannot_create_case_variant_of_user(db_session):
                        email='bob@example.org',
                        password='456')
 
-    db_session.add(bob)
-    db_session.add(bob2)
+    db.Session.add(bob)
+    db.Session.add(bob2)
     with pytest.raises(exc.IntegrityError):
-        db_session.flush()
+        db.Session.flush()
 
 
-def test_cannot_create_user_with_too_short_username(db_session):
+def test_cannot_create_user_with_too_short_username():
     with pytest.raises(ValueError):
         models.User(username='aa')
 
 
-def test_cannot_create_user_with_too_long_username(db_session):
+def test_cannot_create_user_with_too_long_username():
     with pytest.raises(ValueError):
         models.User(username='1234567890123456789012345678901')
 
 
-def test_cannot_create_user_with_too_long_email(db_session):
+def test_cannot_create_user_with_too_long_email():
     with pytest.raises(ValueError):
         models.User(email='bob@b' + 'o'*100 +'b.com')
 
 
-def test_cannot_create_user_with_too_short_password(db_session):
+def test_cannot_create_user_with_too_short_password():
     with pytest.raises(ValueError):
         models.User(password='a')
 
@@ -71,28 +72,28 @@ def test_admins_when_no_admins():
     assert models.User.admins() == []
 
 
-def test_admins_when_one_admin(db_session):
+def test_admins_when_one_admin():
     admin = factories.User(admin=True)
-    db_session.add(admin)
+    db.Session.add(admin)
 
     admins = models.User.admins()
 
     assert admins == [admin]
 
 
-def test_admins_when_multiple_admins(db_session):
+def test_admins_when_multiple_admins():
     admins = [factories.User(admin=True) for _ in range(0, 2)]
-    db_session.add_all(admins)
+    db.Session.add_all(admins)
 
     result = models.User.admins()
 
     assert result == admins
 
 
-def test_admins_does_not_return_non_admin_users(db_session):
+def test_admins_does_not_return_non_admin_users():
     non_admins = [factories.User(admin=False) for _ in range(0, 2)]
-    db_session.add_all(non_admins)
-    db_session.add_all([factories.User(admin=True) for _ in range(0, 2)])
+    db.Session.add_all(non_admins)
+    db.Session.add_all([factories.User(admin=True) for _ in range(0, 2)])
 
     admins = models.User.admins()
 
@@ -104,28 +105,28 @@ def test_staff_members_when_no_staff():
     assert models.User.staff_members() == []
 
 
-def test_staff_members_when_one_staff_member(db_session):
+def test_staff_members_when_one_staff_member():
     staff_member = factories.User(staff=True)
-    db_session.add(staff_member)
+    db.Session.add(staff_member)
 
     staff_members = models.User.staff_members()
 
     assert staff_members == [staff_member]
 
 
-def test_staff_members_when_multiple_staff_members(db_session):
+def test_staff_members_when_multiple_staff_members():
     staff_members = [factories.User(staff=True) for _ in range(0, 2)]
-    db_session.add_all(staff_members)
+    db.Session.add_all(staff_members)
 
     result = models.User.staff_members()
 
     assert result == staff_members
 
 
-def test_staff_members_does_not_return_non_staff_users(db_session):
+def test_staff_members_does_not_return_non_staff_users():
     non_staff = [factories.User(staff=False) for _ in range(0, 2)]
-    db_session.add_all(non_staff)
-    db_session.add_all([factories.User(staff=True) for _ in range(0, 2)])
+    db.Session.add_all(non_staff)
+    db.Session.add_all([factories.User(staff=True) for _ in range(0, 2)])
 
     staff = models.User.staff_members()
 

--- a/h/api/nipsa/test/models_test.py
+++ b/h/api/nipsa/test/models_test.py
@@ -2,58 +2,56 @@
 import pytest
 from sqlalchemy import exc
 
+from h import db
 from h.api.nipsa import models
 
 
-@pytest.mark.usefixtures("db_session")
 def test_init():
     nipsa_user = models.NipsaUser("test_id")
     assert nipsa_user.userid == "test_id"
 
 
-def test_get_by_userid_with_matching_user(db_session):
+def test_get_by_userid_with_matching_user():
     nipsa_user = models.NipsaUser("test_id")
-    db_session.add(nipsa_user)
+    db.Session.add(nipsa_user)
 
     assert models.NipsaUser.get_by_userid("test_id") == nipsa_user
 
 
-@pytest.mark.usefixtures("db_session")
 def test_get_by_userid_not_found():
     assert models.NipsaUser.get_by_userid("does not exist") is None
 
 
-@pytest.mark.usefixtures("db_session")
 def test_all_with_no_rows():
     assert models.NipsaUser.all() == []
 
 
-def test_all_with_one_row(db_session):
+def test_all_with_one_row():
     nipsa_user = models.NipsaUser("test_id")
-    db_session.add(nipsa_user)
+    db.Session.add(nipsa_user)
 
     assert models.NipsaUser.all() == [nipsa_user]
 
 
-def test_all_with_multiple_rows(db_session):
+def test_all_with_multiple_rows():
     nipsa_user1 = models.NipsaUser("test_id1")
-    db_session.add(nipsa_user1)
+    db.Session.add(nipsa_user1)
     nipsa_user2 = models.NipsaUser("test_id2")
-    db_session.add(nipsa_user2)
+    db.Session.add(nipsa_user2)
     nipsa_user3 = models.NipsaUser("test_id3")
-    db_session.add(nipsa_user3)
+    db.Session.add(nipsa_user3)
 
     assert models.NipsaUser.all() == [nipsa_user1, nipsa_user2, nipsa_user3]
 
 
-def test_two_rows_with_same_id(db_session):
-    db_session.add(models.NipsaUser("test_id"))
+def test_two_rows_with_same_id():
+    db.Session.add(models.NipsaUser("test_id"))
     with pytest.raises(exc.IntegrityError):
-        db_session.add(models.NipsaUser("test_id"))
-        db_session.flush()
+        db.Session.add(models.NipsaUser("test_id"))
+        db.Session.flush()
 
 
-def test_null_id(db_session):
+def test_null_id():
     with pytest.raises(exc.IntegrityError):
-        db_session.add(models.NipsaUser(None))
-        db_session.flush()
+        db.Session.add(models.NipsaUser(None))
+        db.Session.flush()

--- a/h/badge/test/models_test.py
+++ b/h/badge/test/models_test.py
@@ -1,60 +1,60 @@
 # -*- coding: utf-8 -*-
 import pytest
-import mock
 
+from h import db
 from h.badge import models
 
 
-def test_cannot_add_same_uri_twice(db_session):
-    db_session.add(models.Blocklist(uri="test_uri"))
-    db_session.flush()
+def test_cannot_add_same_uri_twice():
+    db.Session.add(models.Blocklist(uri="test_uri"))
+    db.Session.flush()
 
     with pytest.raises(ValueError):
         models.Blocklist(uri="test_uri")
 
 
-def test_get_by_uri_returns_model(db_session):
+def test_get_by_uri_returns_model():
     model = models.Blocklist(uri="test_uri")
-    db_session.add(model)
-    db_session.flush()
+    db.Session.add(model)
+    db.Session.flush()
 
     assert models.Blocklist.get_by_uri("test_uri") == model
 
 
-def test_get_by_uri_returns_None_if_no_match(db_session):
+def test_get_by_uri_returns_None_if_no_match():
     model = models.Blocklist(uri="test_uri")
-    db_session.add(model)
-    db_session.flush()
+    db.Session.add(model)
+    db.Session.flush()
 
     assert models.Blocklist.get_by_uri("another_uri") is None
 
 
-def test_all(db_session):
+def test_all():
     uris = [
         models.Blocklist(uri="first"),
         models.Blocklist(uri="second"),
         models.Blocklist(uri="third")
     ]
     for uri in uris:
-        db_session.add(uri)
-    db_session.flush()
+        db.Session.add(uri)
+    db.Session.flush()
 
     assert models.Blocklist.all() == uris
 
 
-def test_is_blocked(db_session):
-    db_session.add(models.Blocklist(uri=u"http://example.com"))
-    db_session.add(models.Blocklist(uri=u"http://example.com/bar"))
-    db_session.flush()
+def test_is_blocked():
+    db.Session.add(models.Blocklist(uri=u"http://example.com"))
+    db.Session.add(models.Blocklist(uri=u"http://example.com/bar"))
+    db.Session.flush()
 
     assert models.Blocklist.is_blocked(u"http://example.com")
     assert models.Blocklist.is_blocked(u"http://example.com/bar")
     assert not models.Blocklist.is_blocked(u"http://example.com/foo")
 
 
-def test_is_blocked_with_wildcards(db_session):
-    db_session.add(models.Blocklist(uri="%//example.com%"))
-    db_session.flush()
+def test_is_blocked_with_wildcards():
+    db.Session.add(models.Blocklist(uri="%//example.com%"))
+    db.Session.flush()
 
     assert models.Blocklist.is_blocked("http://example.com/")
     assert models.Blocklist.is_blocked("http://example.com/bar")

--- a/h/groups/test/models_test.py
+++ b/h/groups/test/models_test.py
@@ -1,17 +1,18 @@
 # -*- coding: utf-8 -*-
 import pytest
 
+from h import db
 from h.groups import models
 from h.test import factories
 
 
-def test_init(db_session):
+def test_init():
     name = "My Hypothesis Group"
     user = factories.User()
 
     group = models.Group(name=name, creator=user)
-    db_session.add(group)
-    db_session.flush()
+    db.Session.add(group)
+    db.Session.flush()
 
     assert group.id
     assert group.name == name
@@ -22,58 +23,58 @@ def test_init(db_session):
     assert group.members == [user]
 
 
-def test_with_short_name(db_session):
+def test_with_short_name():
     """Should raise ValueError if name shorter than 4 characters."""
     with pytest.raises(ValueError):
         models.Group(name="abc", creator=factories.User())
 
 
-def test_with_long_name(db_session):
+def test_with_long_name():
     """Should raise ValueError if name longer than 25 characters."""
     with pytest.raises(ValueError):
         models.Group(name="abcdefghijklmnopqrstuvwxyz",
                      creator=factories.User())
 
 
-def test_slug(db_session):
+def test_slug():
     name = "My Hypothesis Group"
     user = factories.User()
 
     group = models.Group(name=name, creator=user)
-    db_session.add(group)
-    db_session.flush()
+    db.Session.add(group)
+    db.Session.flush()
 
     assert group.slug == "my-hypothesis-group"
 
 
-def test_repr(db_session):
+def test_repr():
     name = "My Hypothesis Group"
     user = factories.User()
 
     group = models.Group(name=name, creator=user)
-    db_session.add(group)
-    db_session.flush()
+    db.Session.add(group)
+    db.Session.flush()
 
     assert repr(group) == "<Group: my-hypothesis-group>"
 
 
-def test_get_by_id_when_id_does_exist(db_session):
+def test_get_by_id_when_id_does_exist():
     name = "My Hypothesis Group"
     user = factories.User()
 
     group = models.Group(name=name, creator=user)
-    db_session.add(group)
-    db_session.flush()
+    db.Session.add(group)
+    db.Session.flush()
 
     assert models.Group.get_by_id(group.id) == group
 
 
-def test_get_by_id_when_id_does_not_exist(db_session):
+def test_get_by_id_when_id_does_not_exist():
     name = "My Hypothesis Group"
     user = factories.User()
 
     group = models.Group(name=name, creator=user)
-    db_session.add(group)
-    db_session.flush()
+    db.Session.add(group)
+    db.Session.flush()
 
     assert models.Group.get_by_id(23) is None


### PR DESCRIPTION
Tests that touched the database were doing a full drop and recreation of the entire schema on every test. This meant that even a no-op test took an appreciable fraction of a second to run.

Slow tests mean sad developers, so this commit changes how we run such tests: the database schema is dropped and recreated only once -- at the start of the test session -- and test isolation is instead guaranteed using PostgreSQL's SAVEPOINT feature.

For each test function, we run the following in the database:

1. BEGIN; -- Open a new transaction. This is implicit.
2. SAVEPOINT some_savepoint_name; -- Establish a savepoint within the current transaction. For more on savepoints, see [the PostgreSQL docs][1].
3. Run the test function.
4. ROLLBACK TO SAVEPOINT some_savepoint_name; -- Roll the state of the database back to that at the savepoint.

This results in database tests that are between 5 and 10x faster, and our overall test suite runs in less than half the time. (On my machine a full `py.test` run is down to 11-12s from 30-35s).

[1]: http://www.postgresql.org/docs/current/static/sql-savepoint.html