### PR TITLE
Remove old feature flag data

### DIFF
--- a/h/buildext.py
+++ b/h/buildext.py
@@ -332,6 +332,13 @@ BROWSERS = {
 
 
 def main():
+    # Set a flag in the environment that other code can use to detect if it's
+    # running under buildext.
+    #
+    # FIXME: This is a nasty hack and should go when we no longer need to spin
+    # up an entire application to build the extensions.
+    os.environ['H_BUILDEXT'] = 'true'
+
     args = parser.parse_args()
     BROWSERS[args.browser](args)
 

--- a/h/db.py
+++ b/h/db.py
@@ -106,6 +106,6 @@ def includeme(config):
     config.action(None, bind_engine, (engine,), {
         'should_create': should_create,
         'should_drop': should_drop
-    })
+    }, order=10)
 
     api_db.use_session(Session)

--- a/h/features.py
+++ b/h/features.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 
 import logging
+import os
 
 from pyramid.view import view_config
 import sqlalchemy as sa
@@ -117,6 +118,11 @@ def remove_old_flags():
     This function removes unknown feature flags from the database, and is run
     once at application startup.
     """
+    # Skip this if we're only in buildext, not actual app startup. See the
+    # comment in h.buildext:main for an explanation.
+    if 'H_BUILDEXT' in os.environ:
+        return
+
     unknown_flags = Feature.query.filter(
         sa.not_(Feature.name.in_(FEATURES.keys())))
     count = unknown_flags.delete(synchronize_session=False)

--- a/h/test/features_test.py
+++ b/h/test/features_test.py
@@ -104,6 +104,18 @@ def test_flag_enabled_true_when_staff_true_staff_request(authn_policy,
     assert features.flag_enabled(request, 'notification') is True
 
 
+def test_remove_old_flag_removes_old_flags(db_session):
+    new_feature = features.Feature(name='notification')
+    old_feature = features.Feature(name='somethingelse')
+    db_session.add(new_feature, old_feature)
+    db_session.flush()
+
+    features.remove_old_flags()
+
+    remaining = [f.name for f in features.Feature.query.all()]
+    assert remaining == ['notification']
+
+
 @pytest.fixture
 def feature_model(request):
     patcher = mock.patch('h.features.Feature', autospec=True)


### PR DESCRIPTION
When a feature flag is removed from the codebase, it will remain in the database. This could potentially cause very surprising issues in the event that a feature flag with the same name (but a different meaning) is added at some point in the future.

This commit adds a function which removes unknown feature flags from the database, and configures it to run at application startup.