### PR TITLE
Don't log 404s to Sentry

### DIFF
--- a/h/views.py
+++ b/h/views.py
@@ -135,7 +135,6 @@ def stream(context, request):
 @forbidden_view_config(renderer='h:templates/notfound.html.jinja2')
 @notfound_view_config(renderer='h:templates/notfound.html.jinja2')
 def notfound(context, request):
-    request.sentry.captureMessage('404: %s' % request.path, level='info')
     request.response.status_int = 404
     return {}
 


### PR DESCRIPTION
This is just too noisy to be useful at the moment. In future we can set this up to distinguish between 404s raised by the application (i.e. a 403 that doesn't reveal the presence of a resource) and genuine 404s -- then it might be useful.