### PR TITLE
Generalise H_BUILDEXT to H_SCRIPT

### DIFF
--- a/h/buildext.py
+++ b/h/buildext.py
@@ -333,11 +333,12 @@ BROWSERS = {
 
 def main():
     # Set a flag in the environment that other code can use to detect if it's
-    # running under buildext.
+    # running in a script rather than a full web application. See also
+    # h/script.py.
     #
     # FIXME: This is a nasty hack and should go when we no longer need to spin
     # up an entire application to build the extensions.
-    os.environ['H_BUILDEXT'] = 'true'
+    os.environ['H_SCRIPT'] = 'true'
 
     args = parser.parse_args()
     BROWSERS[args.browser](args)

--- a/h/script.py
+++ b/h/script.py
@@ -235,6 +235,14 @@ COMMANDS = {
 
 
 def main():
+    # Set a flag in the environment that other code can use to detect if it's
+    # running in a script rather than a full web application. See also
+    # h/buildext.py.
+    #
+    # FIXME: This is a nasty hack and should go when we no longer need to spin
+    # up an entire application to build the extensions.
+    os.environ['H_SCRIPT'] = 'true'
+
     args = parser.parse_args()
     COMMANDS[args.command](args)
 

--- a/h/streamer.py
+++ b/h/streamer.py
@@ -5,6 +5,7 @@ import functools
 import json
 import logging
 import operator
+import os
 import random
 import struct
 import unicodedata
@@ -462,6 +463,10 @@ def start_queue_processing(event):
     greenlets running `process_queue` for each NSQ topic we subscribe to. The
     function does not block.
     """
+    # Skip this if we're in a script, not actual app startup. See the comment
+    # in h.script:main for an explanation.
+    if 'H_SCRIPT' in os.environ:
+        return
     def _loop(settings, topic, handler):
         while True:
             process_queue(settings, topic, handler)


### PR DESCRIPTION
We need the ability to turn off particular parts of application startup in the general case that a script is bootstrapping the application rather than a WSGI server.

This commit renames the H_BUILDEXT environment variable to H_SCRIPT and ensures that it's set in h/script.py as well as h/buildext.py.

In addition, we move the code to remove old feature flags into a NewApplication event subscriber rather than a configuration action, as it is not "configuration" and needs a fully-configured application to run.