### PR TITLE
Fix the missing threads in the stream

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -70,10 +70,6 @@ search
 
    Search for annotations.
 
-   Top-level annotations (but not replies) that match the search query are
-   returned in the "rows" field. The "total" field counts the number of these
-   top-level annotations.
-
    **Example request**::
 
       GET /api/search?limit=1000&user=gluejar@hypothes.is

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -70,6 +70,10 @@ search
 
    Search for annotations.
 
+   Top-level annotations (but not replies) that match the search query are
+   returned in the "rows" field. The "total" field counts the number of these
+   top-level annotations.
+
    **Example request**::
 
       GET /api/search?limit=1000&user=gluejar@hypothes.is

--- a/h/api/search/core.py
+++ b/h/api/search/core.py
@@ -1,7 +1,12 @@
 # -*- coding: utf-8 -*-
+import logging
+
 from h.api import models
 from h.api import nipsa
 from h.api.search import query
+
+
+log = logging.getLogger(__name__)
 
 
 def search(request, params, private=True):
@@ -22,24 +27,42 @@ def search(request, params, private=True):
         dicts) and "total" (the number of matching annotations, an int)
     :rtype: dict
     """
-    builder = query.Builder()
+    def make_builder():
+        builder = query.Builder()
+        builder.append_filter(query.AuthFilter(request, private=private))
+        builder.append_filter(query.UriFilter())
+        builder.append_filter(
+            lambda _: nipsa.nipsa_filter(request.authenticated_userid))
+        builder.append_filter(query.GroupFilter())
+        builder.append_matcher(query.AnyMatcher())
+        builder.append_matcher(query.TagsMatcher())
+        return builder
 
-    builder.append_filter(query.AuthFilter(request, private=private))
-    builder.append_filter(query.UriFilter())
-    builder.append_filter(lambda _: \
-        nipsa.nipsa_filter(request.authenticated_userid))
-    builder.append_filter(query.GroupFilter())
-
-    builder.append_matcher(query.AnyMatcher())
-    builder.append_matcher(query.TagsMatcher())
-
-    body = builder.build(params)
-    results = models.Annotation.search_raw(body,
+    builder = make_builder()
+    builder.append_filter(query.TopLevelAnnotationsFilter())
+    results = models.Annotation.search_raw(builder.build(params),
                                            raw_result=True,
                                            authorization_enabled=False)
+
+    # Do a second query for all replies to the annotations from the first
+    # query.
+    builder = make_builder()
+    builder.append_matcher(query.RepliesMatcher(
+        [h['_id'] for h in results['hits']['hits']]))
+    reply_results = models.Annotation.search_raw(builder.build({'limit': 100}),
+                                                 raw_result=True,
+                                                 authorization_enabled=False)
+
+    if len(reply_results['hits']['hits']) < reply_results['hits']['total']:
+        log.warn("The number of reply annotations exceeded the page size of "
+                 "the Elasticsearch query. We currently don't handle this, "
+                 "our search API doesn't support pagination of the reply set.")
 
     total = results['hits']['total']
     docs = results['hits']['hits']
     rows = [models.Annotation(d['_source'], id=d['_id']) for d in docs]
+    reply_docs = reply_results['hits']['hits']
+    reply_rows = [models.Annotation(d['_source'], id=d['_id'])
+                  for d in reply_docs]
 
-    return {"rows": rows, "total": total}
+    return {"rows": rows, "total": total, "replies": reply_rows}

--- a/h/api/search/query.py
+++ b/h/api/search/query.py
@@ -87,6 +87,14 @@ def extract_sort(params):
     }]
 
 
+class TopLevelAnnotationsFilter(object):
+
+    """Matches top-level annotations only, filters out replies."""
+
+    def __call__(self, _):
+        return {'missing': {'field': 'references'}}
+
+
 class AuthFilter(object):
 
     """
@@ -191,3 +199,16 @@ class TagsMatcher(object):
         matchers = [{'match': {'tags': {'query': t, 'operator': 'and'}}}
                     for t in tags]
         return {'bool': {'must': matchers}} if matchers else None
+
+
+class RepliesMatcher(object):
+
+    """Matches any replies to any of the given annotation ids."""
+
+    def __init__(self, ids):
+        self.annotation_ids = ids
+
+    def __call__(self, _):
+        return {
+            'terms': {'references': self.annotation_ids}
+        }

--- a/h/api/search/test/core_test.py
+++ b/h/api/search/test/core_test.py
@@ -4,7 +4,7 @@ import pytest
 from h.api.search import core
 
 
-search_fixtures = pytest.mark.usefixtures('query', 'models')
+search_fixtures = pytest.mark.usefixtures('query', 'nipsa', 'models', 'log')
 
 
 @search_fixtures
@@ -13,18 +13,196 @@ def test_search_passes_private_to_AuthFilter(query):
 
     core.search(request, mock.Mock(), private=True)
 
-    query.AuthFilter.assert_called_once_with(request, True)
+    assert query.AuthFilter.call_args_list == [
+        mock.call(request, private=True), mock.call(request, private=True)]
+
+
+@search_fixtures
+def test_search_queries_for_replies(query, models):
+    """It should do a second query for replies to the results of the first."""
+    # Mock the Builder objects that Builder() returns.
+    builder = mock.Mock()
+    query.Builder.side_effect = [
+        mock.Mock(),  # We don't care about the first Builder in this test.
+        builder
+    ]
+
+    # Mock the search results that search_raw() returns.
+    models.Annotation.search_raw.side_effect = [
+        # The first time search_raw() is called it returns the result of
+        # querying for the top-level annotations only.
+        {
+            'hits': {
+                'total': 3,
+                'hits': [
+                    {'_id': 'annotation_1', '_source': 'source'},
+                    {'_id': 'annotation_2', '_source': 'source'},
+                    {'_id': 'annotation_3', '_source': 'source'}
+                ]
+            }
+        },
+        # The second call returns the result of querying for all the replies to
+        # those annotations
+        {
+            'hits': {
+                'total': 3,
+                'hits': [
+                    {'_id': 'reply_1', '_source': 'source'},
+                    {'_id': 'reply_2', '_source': 'source'},
+                    {'_id': 'reply_3', '_source': 'source'}
+                ]
+            }
+        },
+    ]
+
+    core.search(mock.Mock(), mock.Mock())
+
+    # It should construct a RepliesMatcher for replies to the annotations from
+    # the first search.
+    query.RepliesMatcher.assert_called_once_with(
+        ['annotation_1', 'annotation_2', 'annotation_3'])
+
+    # It should append the RepliesMatcher to the query builder.
+    assert builder.append_matcher.call_args_list[-1] == mock.call(
+        query.RepliesMatcher.return_value)
+
+    # It should call search_raw() a second time with the body from the
+    # query builder.
+    assert models.Annotation.search_raw.call_count == 2
+    last_call = models.Annotation.search_raw.call_args_list[-1]
+    first_arg = last_call[0][0]
+    assert first_arg == builder.build.return_value
+
+
+@search_fixtures
+def test_search_returns_replies(models):
+    """It should return an Annotation for each reply from search_raw()."""
+    models.Annotation.search_raw.side_effect = [
+        # The first time search_raw() is called it returns the result of
+        # querying for the top-level annotations only.
+        {
+            'hits': {
+                'total': 1,
+                'hits': [{'_id': 'parent_annotation_id', '_source': 'source'}]
+            }
+        },
+        # The second call returns the result of querying for all the replies to
+        # those annotations
+        {
+            'hits': {
+                'total': 3,
+                'hits': [
+                    {'_id': 'reply_1', '_source': 'source'},
+                    {'_id': 'reply_2', '_source': 'source'},
+                    {'_id': 'reply_3', '_source': 'source'}
+                ]
+            }
+        },
+    ]
+    # It should call Annotation() four times: first for the parent annotation
+    # and then once for each reply.
+    models.Annotation.side_effect = [
+        mock.sentinel.parent_annotation_object,
+        mock.sentinel.reply_annotation_object_1,
+        mock.sentinel.reply_annotation_object_2,
+        mock.sentinel.reply_annotation_object_3,
+    ]
+
+    result = core.search(mock.Mock(), mock.Mock())
+
+    assert result['replies'] == [
+        mock.sentinel.reply_annotation_object_1,
+        mock.sentinel.reply_annotation_object_2,
+        mock.sentinel.reply_annotation_object_3
+    ]
+
+
+@search_fixtures
+def test_search_logs_a_warning_if_there_are_too_many_replies(models, log):
+    """It should log a warning if there's more than one page of replies."""
+    models.Annotation.search_raw.side_effect = [
+        {
+            'hits': {
+                'total': 3,
+                'hits': [
+                    {'_id': 'annotation_{n}'.format(n=n), '_source': 'source'}
+                    for n in range(0, 3)]
+            }
+        },
+        # The second call to search_raw() returns 'total': 11000 but only
+        # returns the first 100 of 11000 hits.
+        {
+            'hits': {
+                'total': 11000,
+                'hits': [
+                    {'_id': 'reply_{n}'.format(n=n), '_source': 'source'}
+                    for n in range(0, 100)]
+            }
+        },
+    ]
+
+    core.search(mock.Mock(), mock.Mock())
+
+    assert log.warn.call_count == 1
+
+
+@search_fixtures
+def test_search_does_not_log_a_warning_if_there_are_not_too_many_replies(
+        models, log):
+    """It should not log a warning if there's less than one page of replies."""
+    models.Annotation.search_raw.side_effect = [
+        {
+            'hits': {
+                'total': 3,
+                'hits': [
+                    {'_id': 'annotation_{n}'.format(n=n), '_source': 'source'}
+                    for n in range(0, 3)]
+            }
+        },
+        # The second call to search_raw() returns 'total': 100 and returns all
+        # 100 hits in the first page pf results.
+        {
+            'hits': {
+                'total': 100,
+                'hits': [
+                    {'_id': 'reply_{n}'.format(n=n), '_source': 'source'}
+                    for n in range(0, 100)]
+            }
+        },
+    ]
+
+    core.search(mock.Mock(), mock.Mock())
+
+    assert not log.warn.called
 
 
 @pytest.fixture
 def query(request):
     patcher = mock.patch('h.api.search.core.query', autospec=True)
+    result = patcher.start()
     request.addfinalizer(patcher.stop)
-    return patcher.start()
+    return result
+
+
+@pytest.fixture
+def nipsa(request):
+    patcher = mock.patch('h.api.search.core.nipsa', autospec=True)
+    result = patcher.start()
+    request.addfinalizer(patcher.stop)
+    return result
 
 
 @pytest.fixture
 def models(request):
     patcher = mock.patch('h.api.search.core.models', autospec=True)
+    result = patcher.start()
     request.addfinalizer(patcher.stop)
-    return patcher.start()
+    return result
+
+
+@pytest.fixture
+def log(request):
+    patcher = mock.patch('h.api.search.core.log', autospec=True)
+    result = patcher.start()
+    request.addfinalizer(patcher.stop)
+    return result

--- a/h/api/search/test/transform_test.py
+++ b/h/api/search/test/transform_test.py
@@ -106,39 +106,6 @@ def test_prepare_transforms_old_style_comments(models, groups, ann_in, ann_out):
 
 @mock.patch('h.api.search.transform.models')
 @mock.patch('h.api.search.transform.groups')
-def test_prepare_copies_parents_scopes_into_replies(_, models):
-    parent_annotation = {
-        'id': 'parent_annotation_id',
-        'target': [{'scope': 'https://example.com/annotated_article'}]
-    }
-    reply = {'references': [parent_annotation['id'], 'some other id']}
-    models.Annotation.fetch.return_value = parent_annotation
-
-    transform.prepare(reply)
-
-    assert reply['target'] == parent_annotation['target']
-
-
-@mock.patch('h.api.search.transform.models')
-@mock.patch('h.api.search.transform.groups')
-def test_prepare_overwrites_existing_targets_in_replies(_, models):
-    parent_annotation = {
-        'id': 'parent_annotation_id',
-        'target': [{'scope': 'https://example.com/annotated_article'}]
-    }
-    reply = {
-        'references': [parent_annotation['id'], 'some other id'],
-        'target': ['this should be overwritten']
-    }
-    models.Annotation.fetch.return_value = parent_annotation
-
-    transform.prepare(reply)
-
-    assert reply['target'] == parent_annotation['target']
-
-
-@mock.patch('h.api.search.transform.models')
-@mock.patch('h.api.search.transform.groups')
 def test_prepare_does_nothing_if_parents_target_is_not_a_list(_, models):
     """It should do nothing to replies if the parent's target isn't a list.
 
@@ -159,68 +126,6 @@ def test_prepare_does_nothing_if_parents_target_is_not_a_list(_, models):
     transform.prepare(reply)
 
     assert reply['target'] == mock.sentinel.target
-
-
-@mock.patch('h.api.search.transform.models')
-@mock.patch('h.api.search.transform.groups')
-def test_prepare_does_not_copy_other_keys_from_targets(_, models):
-    """Only the parent's scope should be copied into replies.
-
-    Not any other keys that the parent's target might have.
-
-    """
-    parent_annotation = {
-        'id': 'parent_annotation_id',
-        'target': [{
-            'scope': 'https://example.com/annotated_article',
-            'foo': 'bar',
-            'selector': {}
-        }]
-    }
-    reply = {'references': [parent_annotation['id'], 'some other id']}
-    models.Annotation.fetch.return_value = parent_annotation
-
-    transform.prepare(reply)
-
-    assert 'foo' not in reply['target']
-    assert 'selector' not in reply['target']
-
-
-@mock.patch('h.api.search.transform.models')
-@mock.patch('h.api.search.transform.groups')
-def test_prepare_does_not_copy_targets_that_are_not_dicts(_, models):
-    """Parent's targets that aren't dicts shouldn't be copied into replies."""
-    parent_annotation = {
-        'id': 'parent_annotation_id',
-        'target': ['not a dict', None, ['not', 'a', 'dict']]
-    }
-    reply = {'references': [parent_annotation['id'], 'some other id']}
-    models.Annotation.fetch.return_value = parent_annotation
-
-    transform.prepare(reply)
-
-    assert reply['target'] == []
-
-
-@mock.patch('h.api.search.transform.models')
-@mock.patch('h.api.search.transform.groups')
-def test_prepare_does_not_copy_targets_with_no_scope(_, models):
-    """Parent's targets with no 'scope' should not be copied into replies."""
-    parent_annotation = {
-        'id': 'parent_annotation_id',
-        # Target has no 'scope' key.
-        'target': [{
-            'foo': 'bar',
-            'selector': {}
-        }]
-    }
-    reply = {'references': [parent_annotation['id'], 'some other id']}
-    models.Annotation.fetch.return_value = parent_annotation
-
-    transform.prepare(reply)
-
-    assert reply['target'] == []
-
 
 
 @mock.patch('h.api.search.transform.groups')

--- a/h/api/search/transform.py
+++ b/h/api/search/transform.py
@@ -30,8 +30,6 @@ def prepare(annotation):
     # should probably not mutate its argument.
     _normalize_annotation_target_uris(annotation)
 
-    _copy_parent_scopes_into_replies(annotation)
-
     if 'user' in annotation and nipsa.has_nipsa(annotation['user']):
         annotation['nipsa'] = True
 
@@ -80,29 +78,3 @@ def _transform_old_style_comments(annotation):
 
     if has_uri and has_no_targets and has_no_references:
         annotation['target'] = [{'source': annotation.get('uri')}]
-
-
-def _copy_parent_scopes_into_replies(annotation):
-    """If this annotation is a reply then copy its parents scopes into it.
-
-    If the given annotation is a reply then we find the thread root
-    annotation and copy its targets into the reply, _but_ we only
-    copy the 'scope' key from each target and not the rest of the dict.
-    """
-    references = annotation.get('references')
-
-    if not references:
-        return  # This annotation is not a reply.
-
-    parent = models.Annotation.fetch(references[0])
-
-    if not parent:
-        return  # Nothing can be done.
-
-    targets = parent.get('target', [])
-    if not isinstance(targets, list):
-        return
-
-    # Deliberately overwrite any existing target in the reply annotation.
-    annotation['target'] = [{'scope': target['scope']} for target in targets
-                            if isinstance(target, dict) and 'scope' in target]

--- a/h/api/test/views_test.py
+++ b/h/api/test/views_test.py
@@ -52,7 +52,7 @@ def test_search_renders_results(search_lib):
     request = testing.DummyRequest()
     search_lib.search.return_value = {
         'total': 3,
-        'rows': ['a', 'b', 'c'],
+        'rows': ['a', 'b', 'c']
     }
     search_lib.render.side_effect = lambda x: x.upper()
 
@@ -61,7 +61,21 @@ def test_search_renders_results(search_lib):
     assert result == {
         'total': 3,
         'rows': ['A', 'B', 'C'],
+        'replies': []
     }
+
+
+def test_search_renders_replies(search_lib):
+    search_lib.search.return_value = {
+        'total': 3,
+        'rows': ['parent_annotation'],
+        'replies': ['a', 'b', 'c']
+    }
+    search_lib.render.side_effect = lambda x: x.upper()
+
+    result = views.search(mock.Mock())
+
+    assert result['replies'] == ['A', 'B', 'C']
 
 
 def test_access_token_returns_create_token_response():

--- a/h/api/test/views_test.py
+++ b/h/api/test/views_test.py
@@ -45,7 +45,8 @@ def test_search_searches(search_lib):
 
     views.search(request)
 
-    search_lib.search.assert_called_once_with(request, request.params)
+    search_lib.search.assert_called_once_with(
+        request, request.params, separate_replies=False)
 
 
 def test_search_renders_results(search_lib):
@@ -61,7 +62,6 @@ def test_search_renders_results(search_lib):
     assert result == {
         'total': 3,
         'rows': ['A', 'B', 'C'],
-        'replies': []
     }
 
 

--- a/h/api/views.py
+++ b/h/api/views.py
@@ -92,13 +92,22 @@ def index(context, request):
 @api_config(context=Root, name='search')
 def search(request):
     """Search the database for annotations matching with the given query."""
-    results = search_lib.search(request, request.params)
+    params = request.params.copy()
 
-    return {
+    separate_replies = params.pop('_separate_replies', False)
+    results = search_lib.search(request, params,
+                                separate_replies=separate_replies)
+
+    return_value = {
         'total': results['total'],
-        'rows': [search_lib.render(a) for a in results['rows']],
-        'replies': [search_lib.render(a) for a in results['replies']]
+        'rows': [search_lib.render(a) for a in results['rows']]
     }
+
+    if separate_replies:
+        return_value['replies'] = [
+            search_lib.render(a) for a in results['replies']]
+
+    return return_value
 
 
 @api_config(route_name='access_token')

--- a/h/api/views.py
+++ b/h/api/views.py
@@ -97,6 +97,7 @@ def search(request):
     return {
         'total': results['total'],
         'rows': [search_lib.render(a) for a in results['rows']],
+        'replies': [search_lib.render(a) for a in results['replies']]
     }
 
 

--- a/h/static/scripts/annotation-mapper.js
+++ b/h/static/scripts/annotation-mapper.js
@@ -19,7 +19,9 @@ function getContainer(threading, annotation) {
 // Wraps the annotation store to trigger events for the CRUD actions
 // @ngInject
 function annotationMapper($rootScope, threading, store) {
-  function loadAnnotations(annotations) {
+  function loadAnnotations(annotations, replies) {
+    annotations = annotations.concat(replies || []);
+
     var loaded = [];
 
     annotations.forEach(function (annotation) {

--- a/h/static/scripts/annotation-viewer-controller.coffee
+++ b/h/static/scripts/annotation-viewer-controller.coffee
@@ -22,11 +22,9 @@ module.exports = class AnnotationViewerController
     $scope.search.update = (query) ->
       $location.path('/stream').search('q', query)
 
-    store.AnnotationResource.get id: id, (annotation) ->
-      annotationMapper.loadAnnotations([annotation])
+    store.SearchResource.get _id: id, ({rows, replies}) ->
+      annotationMapper.loadAnnotations(rows.concat(replies))
       $scope.threadRoot = {children: [threading.idTable[id]]}
-    store.SearchResource.get references: id, ({rows}) ->
-      annotationMapper.loadAnnotations(rows)
 
     streamFilter
       .setMatchPolicyIncludeAny()

--- a/h/static/scripts/annotation-viewer-controller.coffee
+++ b/h/static/scripts/annotation-viewer-controller.coffee
@@ -23,7 +23,7 @@ module.exports = class AnnotationViewerController
       $location.path('/stream').search('q', query)
 
     store.SearchResource.get _id: id, ({rows, replies}) ->
-      annotationMapper.loadAnnotations(rows.concat(replies))
+      annotationMapper.loadAnnotations(rows, replies)
       $scope.threadRoot = {children: [threading.idTable[id]]}
 
     streamFilter

--- a/h/static/scripts/annotation-viewer-controller.coffee
+++ b/h/static/scripts/annotation-viewer-controller.coffee
@@ -22,9 +22,14 @@ module.exports = class AnnotationViewerController
     $scope.search.update = (query) ->
       $location.path('/stream').search('q', query)
 
-    store.SearchResource.get _id: id, ({rows, replies}) ->
+    search_params = {
+      _id: id,
+      _separate_replies: true
+    }
+    store.SearchResource.get(search_params, ({rows, replies}) ->
       annotationMapper.loadAnnotations(rows, replies)
       $scope.threadRoot = {children: [threading.idTable[id]]}
+    )
 
     streamFilter
       .setMatchPolicyIncludeAny()

--- a/h/static/scripts/stream-controller.coffee
+++ b/h/static/scripts/stream-controller.coffee
@@ -23,7 +23,7 @@ module.exports = class StreamController
 
     load = ({rows, replies}) ->
         offset += rows.length
-        annotationMapper.loadAnnotations(rows.concat(replies))
+        annotationMapper.loadAnnotations(rows, replies)
 
     # Disable the thread filter (client-side search)
     $scope.$on '$routeChangeSuccess', ->

--- a/h/static/scripts/stream-controller.coffee
+++ b/h/static/scripts/stream-controller.coffee
@@ -21,9 +21,9 @@ module.exports = class StreamController
       query = angular.extend(options, searchParams)
       store.SearchResource.get(query, load)
 
-    load = ({rows}) ->
+    load = ({rows, replies}) ->
         offset += rows.length
-        annotationMapper.loadAnnotations(rows)
+        annotationMapper.loadAnnotations(rows.concat(replies))
 
     # Disable the thread filter (client-side search)
     $scope.$on '$routeChangeSuccess', ->

--- a/h/static/scripts/stream-controller.coffee
+++ b/h/static/scripts/stream-controller.coffee
@@ -19,6 +19,7 @@ module.exports = class StreamController
       options = {offset, limit}
       searchParams = searchFilter.toObject($routeParams.q)
       query = angular.extend(options, searchParams)
+      query._separate_replies = true
       store.SearchResource.get(query, load)
 
     load = ({rows, replies}) ->

--- a/h/static/scripts/test/annotation-mapper-test.js
+++ b/h/static/scripts/test/annotation-mapper-test.js
@@ -43,6 +43,15 @@ describe('annotationMapper', function() {
       assert.calledWith($rootScope.$emit, 'annotationsLoaded', [{}, {}, {}]);
     });
 
+    it('also includes replies in the annotationLoaded event', function () {
+      sandbox.stub($rootScope, '$emit');
+      var annotations = [{id: 1}]
+      var replies = [{id: 2}, {id: 3}];
+      annotationMapper.loadAnnotations(annotations, replies);
+      assert.called($rootScope.$emit);
+      assert.calledWith($rootScope.$emit, 'annotationsLoaded', [{}, {}, {}]);
+    });
+
     it('triggers the annotationUpdated event for each annotation in the threading cache', function () {
       sandbox.stub($rootScope, '$emit');
       var annotations = [{id: 1}, {id: 2}, {id: 3}];
@@ -52,6 +61,17 @@ describe('annotationMapper', function() {
       annotationMapper.loadAnnotations(annotations);
       assert.called($rootScope.$emit);
       assert.calledWith($rootScope.$emit, 'annotationUpdated', cached.message);
+    });
+
+    it('also triggers annotationUpdated for cached replies', function () {
+      sandbox.stub($rootScope, '$emit');
+      var annotations = [{id: 1}];
+      var replies = [{id: 2}, {id: 3}, {id: 4}];
+      var cached = {message: {id: 3, $$tag: 'tag3'}};
+      fakeThreading.idTable[3] = cached;
+
+      annotationMapper.loadAnnotations(annotations, replies);
+      assert($rootScope.$emit.calledWith("annotationUpdated", {id: 3}))
     });
 
     it('replaces the properties on the cached annotation with those from the loaded one', function () {

--- a/h/static/scripts/test/annotation-viewer-controller-test.coffee
+++ b/h/static/scripts/test/annotation-viewer-controller-test.coffee
@@ -71,5 +71,5 @@ describe "AnnotationViewerController", ->
     })
 
     assert annotationMapper.loadAnnotations.calledWith(
-        ['annotation_1', 'annotation_2', 'reply_1', 'reply_2', 'reply_3']
+        ['annotation_1', 'annotation_2'], ['reply_1', 'reply_2', 'reply_3']
     ), "It should pass all the annotations and replies to loadAnnotations()"

--- a/h/static/scripts/test/annotation-viewer-controller-test.coffee
+++ b/h/static/scripts/test/annotation-viewer-controller-test.coffee
@@ -25,22 +25,51 @@ describe "AnnotationViewerController", ->
     locals = {
       $location: $location or {}
       $routeParams: $routeParams or {id: "test_annotation_id"}
-      $scope: $scope or {search: {}}
+      $scope: $scope or {
+        search: {}
+        threading: {
+          getContainer: ->
+        }
+      }
       streamer: streamer or {setConfig: ->}
       store: store or {
-        AnnotationResource: {get: sinon.spy()},
-        SearchResource: {get: ->}}
+        SearchResource: {get: sinon.spy()}}
       streamFilter: streamFilter or {
         setMatchPolicyIncludeAny: -> {addClause: -> {addClause: ->}}
         getFilter: ->
       }
-      threading: sinon.stub()
       annotationMapper: annotationMapper or {loadAnnotations: sinon.spy()}
+      threading: threading or {idTable: {}}
     }
     locals["ctrl"] = getControllerService()(
       "AnnotationViewerController", locals)
     return locals
 
-  it "calls the annotation API to get the annotation", ->
+  it "calls the search API to get the annotation and its replies", ->
     {store} = createAnnotationViewerController({})
-    assert store.AnnotationResource.get.args[0][0].id == "test_annotation_id"
+    assert store.SearchResource.get.calledOnce
+    assert store.SearchResource.get.calledWith(
+      {_id: "test_annotation_id"})
+
+  it "passes the annotations and replies from search into loadAnnotations", ->
+    {annotationMapper} = createAnnotationViewerController({
+      store: {
+        SearchResource: {
+          # SearchResource.get(id, func) takes an annotation id and a function
+          # that it should call with the search result. Our mock .get() here
+          # just immediately calls the function with some fake results.
+          get: (id, func) ->
+            func(
+              {
+                # In production these would be annotation objects, not strings.
+                rows: ['annotation_1', 'annotation_2']
+                replies: ['reply_1', 'reply_2', 'reply_3']
+              }
+            )
+        }
+      }
+    })
+
+    assert annotationMapper.loadAnnotations.calledWith(
+        ['annotation_1', 'annotation_2', 'reply_1', 'reply_2', 'reply_3']
+    ), "It should pass all the annotations and replies to loadAnnotations()"

--- a/h/static/scripts/test/annotation-viewer-controller-test.coffee
+++ b/h/static/scripts/test/annotation-viewer-controller-test.coffee
@@ -49,7 +49,7 @@ describe "AnnotationViewerController", ->
     {store} = createAnnotationViewerController({})
     assert store.SearchResource.get.calledOnce
     assert store.SearchResource.get.calledWith(
-      {_id: "test_annotation_id"})
+      {_id: "test_annotation_id", _separate_replies: true})
 
   it "passes the annotations and replies from search into loadAnnotations", ->
     {annotationMapper} = createAnnotationViewerController({

--- a/h/static/scripts/test/stream-controller-test.coffee
+++ b/h/static/scripts/test/stream-controller-test.coffee
@@ -97,7 +97,7 @@ describe 'StreamController', ->
 
     assert fakeAnnotationMapper.loadAnnotations.calledOnce
     assert fakeAnnotationMapper.loadAnnotations.calledWith(
-      ['annotation_1', 'annotation_2', 'reply_1', 'reply_2', 'reply_3']
+      ['annotation_1', 'annotation_2'], ['reply_1', 'reply_2', 'reply_3']
     )
 
 

--- a/h/static/scripts/test/stream-controller-test.coffee
+++ b/h/static/scripts/test/stream-controller-test.coffee
@@ -86,6 +86,11 @@ describe 'StreamController', ->
   afterEach ->
     sandbox.restore()
 
+  it 'calls the search API with _separate_replies: true', ->
+    createController()
+    assert.equal(
+      fakeStore.SearchResource.get.firstCall.args[0]._separate_replies, true)
+
   it 'passes the annotations and replies from search to loadAnnotations()', ->
     fakeStore.SearchResource.get = (query, func) ->
       func({

--- a/h/static/scripts/test/stream-controller-test.coffee
+++ b/h/static/scripts/test/stream-controller-test.coffee
@@ -86,6 +86,21 @@ describe 'StreamController', ->
   afterEach ->
     sandbox.restore()
 
+  it 'passes the annotations and replies from search to loadAnnotations()', ->
+    fakeStore.SearchResource.get = (query, func) ->
+      func({
+        'rows': ['annotation_1', 'annotation_2']
+        'replies': ['reply_1', 'reply_2', 'reply_3']
+      })
+
+    createController()
+
+    assert fakeAnnotationMapper.loadAnnotations.calledOnce
+    assert fakeAnnotationMapper.loadAnnotations.calledWith(
+      ['annotation_1', 'annotation_2', 'reply_1', 'reply_2', 'reply_3']
+    )
+
+
   describe 'on $routeChangeSuccess', ->
 
     it 'disables page search', ->

--- a/h/static/scripts/test/widget-controller-test.coffee
+++ b/h/static/scripts/test/widget-controller-test.coffee
@@ -104,6 +104,15 @@ describe 'WidgetController', ->
       assert.calledWith(loadSpy, [60..79])
       assert.calledWith(loadSpy, [80..99])
 
+    it 'passes _separate_replies: true to the search API', ->
+      fakeStore.SearchResource.get = sandbox.stub()
+      fakeCrossFrame.frames.push({uri: 'http://example.com'})
+
+      $scope.$digest()
+
+      assert.equal(
+        fakeStore.SearchResource.get.firstCall.args[0]._separate_replies, true)
+
     it 'passes annotations and replies from search to loadAnnotations()', ->
       fakeStore.SearchResource.get = (query, callback) ->
         callback({

--- a/h/static/scripts/test/widget-controller-test.coffee
+++ b/h/static/scripts/test/widget-controller-test.coffee
@@ -50,6 +50,7 @@ describe 'WidgetController', ->
           result =
             total: 100
             rows: [offset..offset+limit-1]
+            replies: []
           callback result
     }
 
@@ -103,11 +104,25 @@ describe 'WidgetController', ->
       assert.calledWith(loadSpy, [60..79])
       assert.calledWith(loadSpy, [80..99])
 
+    it 'passes annotations and replies from search to loadAnnotations()', ->
+      fakeStore.SearchResource.get = (query, callback) ->
+        callback({
+          rows: ['annotation_1', 'annotation_2']
+          replies: ['reply_1', 'reply_2', 'reply_3']
+        })
+      fakeCrossFrame.frames.push({uri: 'http://example.com'})
+      $scope.$digest()
+
+      assert fakeAnnotationMapper.loadAnnotations.calledOnce
+      assert fakeAnnotationMapper.loadAnnotations.calledWith(
+        ['annotation_1', 'annotation_2', 'reply_1', 'reply_2', 'reply_3']
+      )
+
   describe 'when the focused group changes', ->
     it 'should load annotations for the new group', ->
       fakeThreading.annotationList = sandbox.stub().returns([{id: '1'}])
       fakeCrossFrame.frames.push({uri: 'http://example.com'})
-      searchResult = {total: 10, rows: [0..10]}
+      searchResult = {total: 10, rows: [0..10], replies: []}
       fakeStore.SearchResource.get = (query, callback) ->
         callback(searchResult)
 

--- a/h/static/scripts/test/widget-controller-test.coffee
+++ b/h/static/scripts/test/widget-controller-test.coffee
@@ -115,7 +115,7 @@ describe 'WidgetController', ->
 
       assert fakeAnnotationMapper.loadAnnotations.calledOnce
       assert fakeAnnotationMapper.loadAnnotations.calledWith(
-        ['annotation_1', 'annotation_2', 'reply_1', 'reply_2', 'reply_3']
+        ['annotation_1', 'annotation_2'], ['reply_1', 'reply_2', 'reply_3']
       )
 
   describe 'when the focused group changes', ->

--- a/h/static/scripts/widget-controller.coffee
+++ b/h/static/scripts/widget-controller.coffee
@@ -32,6 +32,7 @@ module.exports = class WidgetController
         order: 'asc'
         group: groups.focused().id
       q = angular.extend(queryCore, query)
+      q._separate_replies = true
 
       store.SearchResource.get q, (results) ->
         total = results.total

--- a/h/static/scripts/widget-controller.coffee
+++ b/h/static/scripts/widget-controller.coffee
@@ -39,7 +39,7 @@ module.exports = class WidgetController
         if offset < total
           _loadAnnotationsFrom query, offset
 
-        annotationMapper.loadAnnotations(results.rows)
+        annotationMapper.loadAnnotations(results.rows.concat(results.replies))
 
     loadAnnotations = (frames) ->
       for f in frames

--- a/h/static/scripts/widget-controller.coffee
+++ b/h/static/scripts/widget-controller.coffee
@@ -39,7 +39,7 @@ module.exports = class WidgetController
         if offset < total
           _loadAnnotationsFrom query, offset
 
-        annotationMapper.loadAnnotations(results.rows.concat(results.replies))
+        annotationMapper.loadAnnotations(results.rows, results.replies)
 
     loadAnnotations = (frames) ->
       for f in frames

--- a/h/templates/client/viewer.html
+++ b/h/templates/client/viewer.html
@@ -26,7 +26,6 @@
       ng-class="{'js-hover': hasFocus(child.message)}"
       deep-count="count"
       thread="child" thread-filter
-      ng-if="child.message"
       ng-include="'thread.html'"
       ng-mouseenter="focus(child.message)"
       ng-click="scrollTo(child.message)"


### PR DESCRIPTION
- [x] The search API now returns top-level annotations only, not replies.
- [x] If an undocumented `_include_replies: True` argument is passed then it returns an additional `"replies"` key containing all replies to the top-level annotations in the `"rows"` key
- [x] Up to 100 replies are returned. There is not pagination of the `"replies"` list. If an annotation set has more than 100 replies, log a warning.
- [x] No longer copy `scope` from parent annotations into replies, not used anymore
- [x] Revert <https://github.com/hypothesis/h/commit/5a5b4e345c050a71e619fb5732426b2306f29e64> (which replaced the _Message not available_ cards in the stream with simply hiding the threads with missing annotations)

This just does exactly what <https://github.com/hypothesis/h/pull/2483> did except it also makes returning the replies optional and off by default. I re-did it manually because rebasing the three month old branch was too messy.

Some discussion about how we might iterate on this API later in this comment: <https://github.com/hypothesis/h/pull/2483#issuecomment-138887155>. I'd just add that when searching, we probably want search queries to be matched against annotations and their replies and if an annotation or any of its replies matches a query then return the whole thread.

Fixes #1916.