### PR TITLE
Enable staff to look up user's email addresses

### DIFF
--- a/h/admin.py
+++ b/h/admin.py
@@ -13,7 +13,7 @@ from h import util
 @view.view_config(route_name='admin_index',
                   request_method='GET',
                   renderer='h:templates/admin/index.html.jinja2',
-                  permission='admin')
+                  permission='admin_index')
 def index(_):
     return {}
 
@@ -21,14 +21,14 @@ def index(_):
 @view.view_config(route_name='admin_features',
                   request_method='GET',
                   renderer='h:templates/admin/features.html.jinja2',
-                  permission='admin')
+                  permission='admin_features')
 def features_index(_):
     return {"features": models.Feature.all()}
 
 
 @view.view_config(route_name='admin_features',
                   request_method='POST',
-                  permission='admin')
+                  permission='admin_features')
 def features_save(request):
     session.check_csrf_token(request)
     for feat in models.Feature.all():
@@ -46,7 +46,7 @@ def features_save(request):
 @view.view_config(route_name='admin_nipsa',
                   request_method='GET',
                   renderer='h:templates/admin/nipsa.html.jinja2',
-                  permission='admin')
+                  permission='admin_nipsa')
 def nipsa_index(_):
     return {"usernames": [util.split_user(u)["username"]
                           for u in nipsa.index()]}
@@ -56,7 +56,7 @@ def nipsa_index(_):
                   request_method='POST',
                   request_param='add',
                   renderer='h:templates/admin/nipsa.html.jinja2',
-                  permission='admin')
+                  permission='admin_nipsa')
 def nipsa_add(request):
     username = request.params["add"]
 
@@ -72,7 +72,7 @@ def nipsa_add(request):
                   request_method='POST',
                   request_param='remove',
                   renderer='h:templates/admin/nipsa.html.jinja2',
-                  permission='admin')
+                  permission='admin_nipsa')
 def nipsa_remove(request):
     username = request.params["remove"]
     userid = util.userid_from_username(username, request)
@@ -84,7 +84,7 @@ def nipsa_remove(request):
 @view.view_config(route_name='admin_admins',
                   request_method='GET',
                   renderer='h:templates/admin/admins.html.jinja2',
-                  permission='admin')
+                  permission='admin_admins')
 def admins_index(_):
     """A list of all the admin users as an HTML page."""
     return {"admin_users": [u.username for u in models.User.admins()]}
@@ -94,7 +94,7 @@ def admins_index(_):
                   request_method='POST',
                   request_param='add',
                   renderer='h:templates/admin/admins.html.jinja2',
-                  permission='admin')
+                  permission='admin_admins')
 def admins_add(request):
     """Make a given user an admin."""
     username = request.params['add']
@@ -111,7 +111,7 @@ def admins_add(request):
                   request_method='POST',
                   request_param='remove',
                   renderer='h:templates/admin/admins.html.jinja2',
-                  permission='admin')
+                  permission='admin_admins')
 def admins_remove(request):
     """Remove a user from the admins."""
     if len(models.User.admins()) > 1:
@@ -125,7 +125,7 @@ def admins_remove(request):
 @view.view_config(route_name='admin_staff',
                   request_method='GET',
                   renderer='h:templates/admin/staff.html.jinja2',
-                  permission='admin')
+                  permission='admin_staff')
 def staff_index(_):
     """A list of all the staff members as an HTML page."""
     return {"staff": [u.username for u in models.User.staff_members()]}
@@ -135,7 +135,7 @@ def staff_index(_):
                   request_method='POST',
                   request_param='add',
                   renderer='h:templates/admin/staff.html.jinja2',
-                  permission='admin')
+                  permission='admin_staff')
 def staff_add(request):
     """Make a given user a staff member."""
     username = request.params['add']
@@ -152,7 +152,7 @@ def staff_add(request):
                   request_method='POST',
                   request_param='remove',
                   renderer='h:templates/admin/staff.html.jinja2',
-                  permission='admin')
+                  permission='admin_staff')
 def staff_remove(request):
     """Remove a user from the staff."""
     username = request.params['remove']
@@ -165,7 +165,7 @@ def staff_remove(request):
 @view.view_config(route_name='admin_users',
                   request_method='GET',
                   renderer='h:templates/admin/users.html.jinja2',
-                  permission='admin')
+                  permission='admin_users')
 def users_index(request):
     user = None
     username = request.params.get('username')
@@ -179,7 +179,7 @@ def users_index(request):
 @view.view_config(route_name='admin_badge',
                   request_method='GET',
                   renderer='h:templates/admin/badge.html.jinja2',
-                  permission='admin')
+                  permission='admin_badge')
 def badge_index(_):
     return {"uris": models.Blocklist.all()}
 
@@ -188,7 +188,7 @@ def badge_index(_):
                   request_method='POST',
                   request_param='add',
                   renderer='h:templates/admin/badge.html.jinja2',
-                  permission='admin')
+                  permission='admin_badge')
 def badge_add(request):
     try:
         request.db.add(models.Blocklist(uri=request.params['add']))
@@ -201,7 +201,7 @@ def badge_add(request):
                   request_method='POST',
                   request_param='remove',
                   renderer='h:templates/admin/badge.html.jinja2',
-                  permission='admin')
+                  permission='admin_badge')
 def badge_remove(request):
     uri = request.params['remove']
     request.db.delete(models.Blocklist.get_by_uri(uri))

--- a/h/resources.py
+++ b/h/resources.py
@@ -32,7 +32,17 @@ class Stream(Resource):
 
 
 class Root(Resource):
-    __acl__ = [(Allow, 'group:__admin__', 'admin')]
+    __acl__ = [
+        (Allow, 'group:__admin__', 'admin_index'),
+        (Allow, 'group:__staff__', 'admin_index'),
+        (Allow, 'group:__admin__', 'admin_features'),
+        (Allow, 'group:__admin__', 'admin_nipsa'),
+        (Allow, 'group:__admin__', 'admin_admins'),
+        (Allow, 'group:__admin__', 'admin_staff'),
+        (Allow, 'group:__admin__', 'admin_users'),
+        (Allow, 'group:__staff__', 'admin_users'),
+        (Allow, 'group:__admin__', 'admin_badge'),
+    ]
 
 
 def create_root(request):

--- a/h/templates/layouts/admin.html.jinja2
+++ b/h/templates/layouts/admin.html.jinja2
@@ -1,11 +1,11 @@
 {%- set nav_pages = [
-    ('index', 'Home', request.route_url('admin_index')),
-    ('features', 'Feature flags', request.route_url('admin_features')),
-    ('nipsa', 'NIPSA', request.route_url('admin_nipsa')),
-    ('admins', 'Administrators', request.route_url('admin_admins')),
-    ('staff', 'Staff', request.route_url('admin_staff')),
-    ('users', 'Users', request.route_url('admin_users')),
-    ('badge', 'Badge', request.route_url('admin_badge')),
+    ('index', 'admin_index', 'Home'),
+    ('features', 'admin_features', 'Feature flags'),
+    ('nipsa', 'admin_nipsa', 'NIPSA'),
+    ('admins', 'admin_admins', 'Administrators'),
+    ('staff', 'admin_staff', 'Staff'),
+    ('users', 'admin_users', 'Users'),
+    ('badge', 'admin_badge', 'Badge'),
 ] -%}
 
 {%- set page_id = page_id|default('home') -%}
@@ -42,10 +42,12 @@
         </div>
         <div id="navbar" class="navbar-collapse collapse">
           <ul class="nav navbar-nav">
-            {% for id, title, href in nav_pages %}
-            <li{% if id == page_id %} class="active"{% endif %}>
-              <a href="{{ href }}">{{ title }}</a>
-            </li>
+            {% for id, permission, title in nav_pages %}
+              {% if request.has_permission(permission) %}
+                <li{% if id == page_id %} class="active"{% endif %}>
+                  <a href="{{ request.route_url(permission) }}">{{ title }}</a>
+                </li>
+              {% endif %}
             {% endfor %}
           </ul>
         </div>


### PR DESCRIPTION
Allow staff to access the /admin index page and to use some of the admin pages
within (so far only the /admin/users page).

Assign a different permission to each admin page ('admin_features',
'admin_nipsa' etc) then on the root resource assign some of these permissions
to admins and some to staff (or to both admins and staff).

This enables staff users to access the admin index page and some of the admin
pages within.

Then tweak the admin template to only show links to the admin pages that the
user has permission to use.

The "admin" permission, previously assigned to admin users, is removed since
it's no longer used.