### PR TITLE
Enable highlights by default everywhere

### DIFF
--- a/h/static/extension/config.js
+++ b/h/static/extension/config.js
@@ -4,6 +4,5 @@ function hypothesisConfig() {
   var hypothesisIntent = document.querySelector('[name="hypothesis-intent"]');
   return {
     firstRun: hypothesisIntent && hypothesisIntent.content === 'first-run',
-    showHighlights: true
   };
 }

--- a/h/static/scripts/annotator/host.coffee
+++ b/h/static/scripts/annotator/host.coffee
@@ -26,7 +26,10 @@ module.exports = class Host extends Guest
 
     this.on 'panelReady', =>
       # Initialize tool state.
-      this.setVisibleHighlights(!!options.showHighlights)
+      if options.showHighlights == undefined
+        # Highlights are on by default.
+        options.showHighlights = true
+      this.setVisibleHighlights(options.showHighlights)
 
       # Show the UI
       @frame.css('display', '')

--- a/h/static/scripts/annotator/test/host-test.coffee
+++ b/h/static/scripts/annotator/test/host-test.coffee
@@ -42,16 +42,16 @@ describe 'Host', ->
       assert.equal(host.frame.css('display'), '')
 
   describe 'options', ->
-    it 'enables highlighting when showHighlights option is provided', (done) ->
-      host = createHost(showHighlights: true)
+    it 'disables highlighting if showHighlights: false is given', (done) ->
+      host = createHost(showHighlights: false)
       host.on 'panelReady', ->
-        assert.isTrue(host.visibleHighlights)
+        assert.isFalse(host.visibleHighlights)
         done()
       host.publish('panelReady')
 
-    it 'does not enable highlighting when no showHighlights option is provided', (done) ->
+    it 'enables highlighting when no showHighlights option is given', (done) ->
       host = createHost({})
       host.on 'panelReady', ->
-        assert.isFalse(host.visibleHighlights)
+        assert.isTrue(host.visibleHighlights)
         done()
       host.publish('panelReady')

--- a/h/templates/bookmarklet.js.jinja2
+++ b/h/templates/bookmarklet.js.jinja2
@@ -20,9 +20,6 @@
     return;
   }
 
-  window.hypothesisConfig = function () {
-    return {showHighlights: true};
-  };
   embed = document.createElement('script');
   embed.setAttribute('src', embedUrl);
   document.body.appendChild(embed);


### PR DESCRIPTION
Enable highlights by default in the Chrome extension, bookmarklet and embed.

They were already enabled by default in the Chrome extension and
bookmarklet so this only changes the embed.

Highlights are turned on by default in annotator/host.coffee if no
showHighlights option is found.

The extension and bookmarklet no longer need to set showHighlights: true as
this is now the default. The embed (which was not setting showHighlights: true
and so was getting the default setting of false) will now get the new default
setting of true.

For people embedding h into their own pages, they can turn off highlights by
default by including:

    <script>
      window.hypothesisConfig=function(){return{showHighlights:false}};
    </script>

fixes #2695