### PR TITLE
Remove "show_unanchored_annotations" feature

### DIFF
--- a/h/static/scripts/directive/test/thread-test.coffee
+++ b/h/static/scripts/directive/test/thread-test.coffee
@@ -132,10 +132,6 @@ describe 'thread', ->
         it 'returns false', ->
           assert.isFalse(controller.shouldShow())
 
-        it 'returns true if show_unanchored_annotations is on', ->
-          $scope.feature = -> true
-          assert.isTrue(controller.shouldShow())
-
       describe 'when the thread filter is active', ->
         beforeEach ->
           controller.filter = {active: -> true}

--- a/h/static/scripts/directive/thread.coffee
+++ b/h/static/scripts/directive/thread.coffee
@@ -59,9 +59,7 @@ ThreadController = [
         return false
 
       if this.container?.message?.$orphan == true
-        # Hide unless show_unanchored_annotations is turned on
-        if not $scope.feature('show_unanchored_annotations')
-          return false
+        return false
 
       editing = this._count('edit') > 0
       matching = this._count('match') > 0

--- a/h/static/styles/threads.scss
+++ b/h/static/styles/threads.scss
@@ -56,11 +56,3 @@ $thread-padding: $annotation-card-left-padding;
 .thread-load-more {
   clear: both;
 }
-
-.thread-anchor-notice {
-  // XXX: negative margins here make me sad; maybe refactor container
-  background-color: lighten($gray-light, 38%);
-  border-top: solid 1px $gray-lighter;
-  margin: 0 -1em -1em -1em;
-  padding: 1em;
-}

--- a/h/templates/client/thread.html
+++ b/h/templates/client/thread.html
@@ -46,8 +46,3 @@
       ng-show="vm.shouldShowAsReply()">
   </li>
 </ul>
-
-<footer class="thread-anchor-notice"
-        ng-if="feature('show_unanchored_annotations') && isSidebar && vm.container.message.$orphan">
-  <em>We can't find the exact position of this annotation.</em>
-</footer>


### PR DESCRIPTION
We've discussed this feature and decided that it can't be turned on in its current state. This commit removes it.

Note that the feature flag in `h/features.py` remains until these changes are deployed out to production.