### PR TITLE
Fix a font size on the front page

### DIFF
--- a/h/templates/home.html.jinja2
+++ b/h/templates/home.html.jinja2
@@ -134,7 +134,7 @@
                 </form>
               </section>
 
-              <p class="hide-in-chrome">
+              <p class="hide-in-chrome installer__section--bookmarklet">
                 There's also a
                 <a href="https://chrome.google.com/webstore/detail/bjfhmglciegochdpefhhlphglcehbmek">
                   Chrome extension
@@ -143,7 +143,7 @@
                 <a href="#" class="" data-toggle="modal" data-target="#addtoyoursite" data-addtosite-button="">
                   add it to your website</a>.
               </p>
-              <p class="hidden unhide-in-chrome">
+              <p class="hidden unhide-in-chrome installer__section--bookmarklet">
                 There's also a
                 <a href="#" class="" data-toggle="modal" data-target="#bookmarklet">
                   bookmarklet


### PR DESCRIPTION
Fix the font size of the "There's also a bookmarklet|Chrome extension..."
paragraphs on the front page.

The install__section--bookmarklet CSS class is not semantic here - this
fix is a quick hack because we're expecting to completely rewrite the
CSS for this page soon.