### PR TITLE
Show flash messages on the front page

### DIFF
--- a/h/accounts/views.py
+++ b/h/accounts/views.py
@@ -5,6 +5,7 @@ import json
 
 import colander
 import deform
+import jinja2
 from pyramid import httpexceptions
 from pyramid.exceptions import BadCSRFToken
 from pyramid.view import view_config, view_defaults
@@ -282,8 +283,11 @@ class ResetPasswordController(object):
         user.password = password
         self.request.db.delete(user.activation)
 
-        self.request.session.flash(_('Your password has been reset!'),
-                                   'success')
+        self.request.session.flash(jinja2.Markup(_(
+            'Your password has been reset! '
+            'You can now <a href="{url}">login</a> using the new password you '
+            'provided.').format(url=self.request.route_url('login'))),
+            'success')
         self.request.registry.notify(PasswordResetEvent(self.request, user))
 
 
@@ -365,9 +369,11 @@ class RegisterController(object):
         # Activate the user (by deleting the activation)
         self.request.db.delete(activation)
 
-        self.request.session.flash(_("Your e-mail address has been verified. "
-                                     "Thank you!"),
-                                   'success')
+        self.request.session.flash(jinja2.Markup(_(
+            'Your account has been activated! '
+            'You can now <a href="{url}">login</a> using the password you '
+            'provided.').format(url=self.request.route_url('login'))),
+            'success')
         self.request.registry.notify(ActivationEvent(self.request, user))
 
         return httpexceptions.HTTPFound(
@@ -395,11 +401,11 @@ class RegisterController(object):
         mailer = get_mailer(self.request)
         mailer.send(message)
 
-        self.request.session.flash(_("Thank you for registering! Please check "
-                                     "your e-mail now. You can continue by "
-                                     "clicking the activation link we have "
-                                     "sent you."),
-                                   'success')
+        self.request.session.flash(jinja2.Markup(_(
+            'Thank you for creating an account! '
+            "We've sent you an email with an activation link, "
+            'before you can sign in <strong>please check your email and open '
+            'the link to activate your account</strong>.')), 'success')
         self.request.registry.notify(RegistrationEvent(self.request, user))
 
 

--- a/h/templates/home.html.jinja2
+++ b/h/templates/home.html.jinja2
@@ -75,6 +75,7 @@
           {% endif %}
         </ul>
       </nav>
+      {% include "h:templates/includes/flashbar.html.jinja2" %}
     </div>
   </header>
 


### PR DESCRIPTION
This fixes three issues with the new user account registration process:
    
1. After submitting the form at `/register` the user is redirected to the front page, but they aren't shown the flash message notifying them that we have sent them an activation email. They have no idea that their account has been created, that they need to activate it, or how to activate it.
    
2. After opening the link in an activation email the user is redirected to the front page, but they aren't shown the flash message notifying them that their account has been activated. They have no idea that they can now login, or how to login.
    
3. Instead the user would see both flash messages at the same time the next time they opened a page containing the stream or sidebar (for example: after logging in and being redirected to the stream).
    
This change fixes all three issues by popping and displaying the flash message on the front page:
    
1. After submitting the form at `/register` the user is redirected to the front page and is shown the flash message notifying them that we have sent them an activation email.
    
2. After opening the link in an activation email the user is redirected to the front page, and is shown the flash message notifying them that their account has been activated.
    
3. After logging in the user is redirected to the stream, and they are not shown any flash messages.
    
This change also fixes the same issue with the reset password process: after resetting their password the user is redirected to the front page but is not shown the "Your password has been reset!" flash message, the message is instead shown to them the next time they visit a page with the stream or sidebar on it. With this change the message is shown to them on the front page.

The flash messages shown on the front page also have better usability than those in the sidebar: they stay on the screen until the user reloads the page, closes the browser window/tab, navigates to another page, or closes the message. The flash messages in the sidebar automatically disappear after a few seconds, they can easily be missed, they can't contain links (trying to click on a link that is about to move or disappear), and they cover up important parts of the sidebar UI.

I also took the opportunity to improve the wording of the flash messages, being clear about what has happened and what the user should do now and linking to the login page.

What the flash messages on the front page look like:

![screenshot from 2015-11-28 15-52-24](https://cloud.githubusercontent.com/assets/22498/11452684/e6eee458-95e8-11e5-8300-80144cb31b60.png)

Screencast of creating an account:
 
![untitled screencast 6](https://cloud.githubusercontent.com/assets/22498/11452687/fee126a2-95e8-11e5-9610-660f367aee51.gif)

Screencast of clicking on an activation link:

![untitled screencast 7](https://cloud.githubusercontent.com/assets/22498/11452689/0493ddd8-95e9-11e5-9a28-f7ae4e162ea2.gif)

Screencast of resetting a password:

![untitled screencast 8](https://cloud.githubusercontent.com/assets/22498/11452692/0ae6e9e6-95e9-11e5-8438-ba1c67165ad7.gif)
