### PR TITLE
Ensure old sort control isn't shown in sidebar

### DIFF
--- a/h/static/scripts/annotation-viewer-controller.coffee
+++ b/h/static/scripts/annotation-viewer-controller.coffee
@@ -12,9 +12,6 @@ module.exports = class AnnotationViewerController
   ) ->
     id = $routeParams.id
 
-    # Set up the viewer
-    $scope.isStream = false
-
     # Provide no-ops until these methods are moved elsewere. They only apply
     # to annotations loaded into the stream.
     $scope.focus = angular.noop

--- a/h/static/scripts/widget-controller.coffee
+++ b/h/static/scripts/widget-controller.coffee
@@ -11,7 +11,6 @@ module.exports = class WidgetController
      $scope,   annotationUI,   crossframe,   annotationMapper,  drafts,    groups,
      streamer,   streamFilter,   store,   threading
   ) ->
-    $scope.isStream = true
     $scope.threadRoot = threading.root
     $scope.sortOptions = ['Newest', 'Oldest', 'Location']
 


### PR DESCRIPTION
a055f4c inadvertently re-enabled showing the old annotation sort control in the sidebar, as a result of the one remaining use of the ambiguous "isStream" variable.

This commit ensures that "isStream" is only ever set on the actual stream page, and not in the sidebar.

Fixes #2750.