### PR TITLE
Handle missing permissions on annotations more gracefully

### DIFF
--- a/h/test/streamer_test.py
+++ b/h/test/streamer_test.py
@@ -32,6 +32,7 @@ class FakeSocket(object):
         self.terminated = False
         self.filter = MagicMock()
         self.request = MagicMock()
+        self.request.effective_principals = ['group:__world__']
         self.send = MagicMock()
 
 


### PR DESCRIPTION
Annotations shouldn't be missing permissions, but this commit stops the streamer code from crashing out under these circumstances. We also log some additional information to Sentry so we can understand what's going on here.

q.v. https://app.getsentry.com/hypothesis/prod/issues/97826942/