### PR TITLE
Don't save null permissions/tags/text to drafts store

### DIFF
--- a/h/static/scripts/directive/annotation.coffee
+++ b/h/static/scripts/directive/annotation.coffee
@@ -241,11 +241,14 @@ AnnotationController = [
       # Drafts only preserve the text, tags and permissions of the annotation
       # (i.e. only the bits that the user can edit), changes to other
       # properties are not preserved.
-      drafts.update(model, {
-        text: draft.text
-        tags: draft.tags
-        permissions: draft.permissions
-      })
+      changes = {}
+      if draft.text?
+        changes.text = draft.text
+      if draft.tags?
+        changes.tags = draft.tags
+      if draft.permissions?
+        changes.permissions = draft.permissions
+      drafts.update(model, changes)
 
     ###*
     # @ngdoc method

--- a/h/static/scripts/directive/test/annotation-test.coffee
+++ b/h/static/scripts/directive/test/annotation-test.coffee
@@ -540,11 +540,21 @@ describe 'annotation', ->
     it "creates a draft when editing an annotation", ->
       createDirective()
       controller.edit()
-      assert.calledWith(fakeDrafts.update, annotation, {
-        text: annotation.text,
-        tags: annotation.tags,
-        permissions: annotation.permissions
-      })
+      assert.calledWith(fakeDrafts.update, annotation)
+
+    it "creates a draft with only editable fields which are non-null", ->
+      # When a draft is saved, we shouldn't save any fields to the draft
+      # "changes" object that aren't actually set on the annotation. In this
+      # case, both permissions and tags are null so shouldn't be saved in the
+      # draft.
+      createDirective()
+      annotation.permissions = null
+      annotation.text = 'Hello!'
+      annotation.tags = null
+
+      controller.edit()
+
+      assert.calledWith(fakeDrafts.update, annotation, {text: 'Hello!'})
 
     it "starts editing immediately if there is a draft", ->
       fakeDrafts.get.returns({


### PR DESCRIPTION
When saving a draft to the drafts store, don't save changes for fields which aren't actually set. This prevents us from accidentally later restoring `null` to one of these fields.

Fixes an issue where creating an annotation when logged-out would result in a null permissions field.