### PR TITLE
Refactor saving highlights in AnnotationController

### DIFF
--- a/h/static/scripts/directive/annotation.js
+++ b/h/static/scripts/directive/annotation.js
@@ -218,9 +218,7 @@ function AnnotationController(
       // has no text or tags.
       var isPageNote = (model.target || []).length === 0;
       var isReply = (model.references || []).length !== 0;
-      var hasText = (model.text || '').length !== 0;
-      var hasTags = (model.tags || []).length !== 0;
-      return (!isPageNote && !isReply && !hasText && !hasTags);
+      return (!isPageNote && !isReply && !vm.hasContent());
     }
   };
 

--- a/h/static/scripts/directive/annotation.js
+++ b/h/static/scripts/directive/annotation.js
@@ -364,8 +364,8 @@ function AnnotationController(
   /**
     * @ngdoc method
     * @name annotation.AnnotaitonController#hasContent
-    * @returns {boolean} True if the currently edited annotation has
-    *          content (ie. is not just a highlight)
+    * @returns {boolean} `true` if this annotation has content, `false`
+    *   otherwise.
     */
   vm.hasContent = function() {
     var textLength = (vm.annotation.text || '').length;

--- a/h/static/scripts/directive/annotation.js
+++ b/h/static/scripts/directive/annotation.js
@@ -216,10 +216,11 @@ function AnnotationController(
       // example there's no model.highlight: true.  Instead a highlight is
       // defined as an annotation that isn't a page note or a reply and that
       // has no text or tags.
-      var targetLength = (model.target || []).length;
-      var referencesLength = (model.references || []).length;
-      var tagsLength = (model.tags || []).length;
-      return (targetLength && !referencesLength && !(model.text || tagsLength));
+      var isPageNote = (model.target || []).length === 0;
+      var isReply = (model.references || []).length !== 0;
+      var hasText = (model.text || '').length !== 0;
+      var hasTags = (model.tags || []).length !== 0;
+      return (!isPageNote && !isReply && !hasText && !hasTags);
     }
   };
 

--- a/h/static/scripts/directive/annotation.js
+++ b/h/static/scripts/directive/annotation.js
@@ -186,7 +186,82 @@ function AnnotationController(
   // Set the permissions of new annotations.
   model.permissions = model.permissions || permissions['default'](model.group);
 
-  var highlight = model.$highlight;
+  /**
+   * `true` if this AnnotationController instance was created as a result of
+   * the highlight button being clicked.
+   *
+   * `false` if the annotation button was clicked, or if this is a highlight or
+   * annotation that was fetched from the server (as opposed to created new
+   * client-side).
+   */
+  var newlyCreatedByHighlightButton = model.$highlight || false;
+
+  /**
+    * @ngdoc method
+    * @name annotation.AnnotationController#isHighlight.
+    * @returns {boolean} true if the annotation is a highlight, false otherwise
+    */
+  vm.isHighlight = function() {
+    if (newlyCreatedByHighlightButton) {
+      return true;
+    } else if (!model.id) {
+      // If an annotation has no model.id (i.e. it has not been saved to the
+      // server yet) and newlyCreatedByHighlightButton is false, then it must
+      // be an annotation not a highlight (even though it may not have any
+      // text or tags yet).
+      return false;
+    } else {
+      // Once an annotation has been saved to the server there's no longer a
+      // simple property that says whether it's a highlight or not.  For
+      // example there's no model.highlight: true.  Instead a highlight is
+      // defined as an annotation that isn't a page note or a reply and that
+      // has no text or tags.
+      var targetLength = (model.target || []).length;
+      var referencesLength = (model.references || []).length;
+      var tagsLength = (model.tags || []).length;
+      return (targetLength && !referencesLength && !(model.text || tagsLength));
+    }
+  };
+
+  /** Save this annotation if it's a new highlight.
+   *
+   * The highlight will be saved to the server if the user is logged in,
+   * saved to drafts if they aren't.
+   *
+   * If the annotation is not new (it has already been saved to the server) or
+   * is not a highlight then nothing will happen.
+   *
+   */
+  function saveNewHighlight() {
+    if (model.id) {
+      // Already saved.
+      return;
+    }
+
+    if (!vm.isHighlight()) {
+      // Not a highlight,
+      return;
+    }
+
+    if (model.user) {
+      // User is logged in, save to server.
+      // Highlights are always private.
+      model.permissions = permissions.private();
+      model.$create().then(function() {
+        $rootScope.$emit('annotationCreated', model);
+      });
+    } else {
+      // User isn't logged in, save to drafts.
+      updateDraft(model);
+    }
+  }
+
+  // Automatically save new highlights to the server when they're created.
+  // Note that this line also gets called when the user logs in (since
+  // AnnotationController instances are re-created on login) so serves to
+  // automatically save highlights that were created while logged out when you
+  // log in.
+  saveNewHighlight();
 
   /**
    * @ngdoc method
@@ -227,18 +302,6 @@ function AnnotationController(
     */
   vm.tagsAutoComplete = function(query) {
     return $q.when(tags.filter(query));
-  };
-
-  /**
-    * @ngdoc method
-    * @name annotation.AnnotationController#isHighlight.
-    * @returns {boolean} True if the annotation is a highlight.
-    */
-  vm.isHighlight = function() {
-    var targetLength = (model.target || []).length;
-    var referencesLength = (model.references || []).length;
-    var tagsLength = (model.tags || []).length;
-    return (targetLength && !referencesLength && !(model.text || tagsLength));
   };
 
   /**
@@ -573,19 +636,6 @@ function AnnotationController(
       drafts.remove(model);
     }
 
-    // Save highlights once logged in.
-    if (vm.isHighlight() && highlight) {
-      if (model.user && !model.id) {
-        model.permissions = permissions.private();
-        model.$create().then(function() {
-          $rootScope.$emit('annotationCreated', model);
-        });
-        highlight = false;  // Prevents double highlight creation.
-      } else {
-        updateDraft(model);
-      }
-    }
-
     updateTimestamp(model === old);  // Repeat on first run.
     vm.render();
   }, true);
@@ -604,11 +654,13 @@ function AnnotationController(
     }
   });
 
-  // If this is a new annotation or we have unsaved changes,
-  // then start editing immediately.
-  var isNewAnnotation = !(model.id || (vm.isHighlight() && highlight));
-  if (isNewAnnotation || drafts.get(model)) {
-    vm.edit();
+  // If this annotation is not a highlight and if it's new (has just been
+  // created by the annotate button) or it has edits not yet saved to the
+  // server - then open the editor on AnnotationController instantiation.
+  if (!newlyCreatedByHighlightButton) {
+    if (!model.id || drafts.get(model)) {
+      vm.edit();
+    }
   }
 
   // When the current group changes, persist any unsaved changes using

--- a/h/static/scripts/directive/test/annotation-test.js
+++ b/h/static/scripts/directive/test/annotation-test.js
@@ -667,7 +667,7 @@ describe('annotation.js', function() {
         annotation.id = undefined;
         annotation.$highlight = true;
         // We need to define $create because it'll try to call it.
-        annotation.$create = function() {return {then: function() {}}};
+        annotation.$create = function() {return {then: function() {}};};
 
         var vm = createDirective().controller;
 
@@ -691,8 +691,8 @@ describe('annotation.js', function() {
         annotation.references = [];
         // The annotation has no text or tags. If it weren't a page note, it'd
         // be a highlight.
-        annotation.text = ''
-        annotation.tags = []
+        annotation.text = '';
+        annotation.tags = [];
 
         var vm = createDirective().controller;
 
@@ -707,8 +707,8 @@ describe('annotation.js', function() {
         annotation.references = ['parent_annotation_id'];
         // The annotation has no text or tags. If it weren't a reply, it'd
         // be a highlight.
-        annotation.text = ''
-        annotation.tags = []
+        annotation.text = '';
+        annotation.tags = [];
 
         var vm = createDirective().controller;
 
@@ -723,7 +723,7 @@ describe('annotation.js', function() {
 
         // Has some text but no tags.
         annotation.text = 'This is my annotation';
-        annotation.tags = []
+        annotation.tags = [];
 
         var vm = createDirective().controller;
 
@@ -738,7 +738,7 @@ describe('annotation.js', function() {
 
         // Has some tags but no text.
         annotation.text = '';
-        annotation.tags = ['foo']
+        annotation.tags = ['foo'];
 
         var vm = createDirective().controller;
 
@@ -753,7 +753,7 @@ describe('annotation.js', function() {
 
         // Has no tags or text, i.e. it's a highlight.
         annotation.text = '';
-        annotation.tags = []
+        annotation.tags = [];
 
         var vm = createDirective().controller;
 

--- a/h/static/scripts/directive/test/annotation-test.js
+++ b/h/static/scripts/directive/test/annotation-test.js
@@ -661,6 +661,106 @@ describe('annotation.js', function() {
       });
     });
 
+    describe('AnnotationController.isHighlight()', function() {
+      it('returns true for new highlights', function() {
+        // New highlights have no id and have $highlight: true.
+        annotation.id = undefined;
+        annotation.$highlight = true;
+        // We need to define $create because it'll try to call it.
+        annotation.$create = function() {return {then: function() {}}};
+
+        var vm = createDirective().controller;
+
+        assert.isTrue(vm.isHighlight());
+      });
+
+      it('returns false for new annotations', function() {
+        // New annotations have no id and no $highlight.
+        annotation.id = annotation.$highlight = undefined;
+
+        var vm = createDirective().controller;
+
+        assert.isFalse(vm.isHighlight());
+      });
+
+      it('returns 0 for page notes', function() {
+        annotation.$highlight = undefined;
+        // Page notes have no targets.
+        annotation.target = [];
+        // This is not a reply.
+        annotation.references = [];
+        // The annotation has no text or tags. If it weren't a page note, it'd
+        // be a highlight.
+        annotation.text = ''
+        annotation.tags = []
+
+        var vm = createDirective().controller;
+
+        assert.equal(vm.isHighlight(), 0);
+      });
+
+      it('returns false for replies', function() {
+        annotation.$highlight = undefined;
+        // This is not a page note.
+        annotation.target = ['foo'];
+        // Replies have references.
+        annotation.references = ['parent_annotation_id'];
+        // The annotation has no text or tags. If it weren't a reply, it'd
+        // be a highlight.
+        annotation.text = ''
+        annotation.tags = []
+
+        var vm = createDirective().controller;
+
+        assert.isFalse(vm.isHighlight());
+      });
+
+      it('returns false for annotations with text', function() {
+        // Not a highlight, reply or page note.
+        annotation.$highlight = undefined;
+        annotation.target = ['foo'];
+        annotation.references = ['parent_annotation_id'];
+
+        // Has some text but no tags.
+        annotation.text = 'This is my annotation';
+        annotation.tags = []
+
+        var vm = createDirective().controller;
+
+        assert.isFalse(vm.isHighlight());
+      });
+
+      it('returns false for annotations with tags', function() {
+        // Not a highlight, reply or page note.
+        annotation.$highlight = undefined;
+        annotation.target = ['foo'];
+        annotation.references = ['parent_annotation_id'];
+
+        // Has some tags but no text.
+        annotation.text = '';
+        annotation.tags = ['foo']
+
+        var vm = createDirective().controller;
+
+        assert.isFalse(vm.isHighlight());
+      });
+
+      it('returns true for annotations with no text or tags', function() {
+        // Not a new highlight, reply or page note.
+        annotation.$highlight = undefined;
+        annotation.target = ['foo'];
+        annotation.references = [];
+
+        // Has no tags or text, i.e. it's a highlight.
+        annotation.text = '';
+        annotation.tags = []
+
+        var vm = createDirective().controller;
+
+        assert.isTrue(vm.isHighlight());
+      });
+    });
+
     describe('when the annotation is a highlight', function() {
       beforeEach(function() {
         annotation.$highlight = true;

--- a/h/static/scripts/directive/test/annotation-test.js
+++ b/h/static/scripts/directive/test/annotation-test.js
@@ -683,7 +683,7 @@ describe('annotation.js', function() {
         assert.isFalse(vm.isHighlight());
       });
 
-      it('returns 0 for page notes', function() {
+      it('returns false for page notes', function() {
         annotation.$highlight = undefined;
         // Page notes have no targets.
         annotation.target = [];
@@ -696,7 +696,7 @@ describe('annotation.js', function() {
 
         var vm = createDirective().controller;
 
-        assert.equal(vm.isHighlight(), 0);
+        assert.isFalse(vm.isHighlight());
       });
 
       it('returns false for replies', function() {

--- a/h/static/scripts/directive/test/annotation-test.js
+++ b/h/static/scripts/directive/test/annotation-test.js
@@ -566,6 +566,79 @@ describe('annotation.js', function() {
 
         assert.notCalled(annotation.$create);
       });
+
+      it('edits new annotations on initialization', function() {
+        // When the user creates a new annotation and we create a new
+        // AnnotationController instance, we automatically open the
+        // annotation's editor.
+
+        // A new annotation will have no id or $highlight.
+        annotation.id = annotation.$highlight = undefined;
+
+        // A new annotation won't have any text or tags yet.
+        annotation.text = '';
+        annotation.tags = [];
+
+        // A new annotation won't have any saved drafts yet.
+        fakeDrafts.get.returns(null);
+
+        var controller = createDirective().controller;
+
+        assert.isTrue(controller.editing());
+      });
+
+      it('edits annotations with drafts on initialization', function() {
+        // This is not a new annotation.
+        annotation.id = 'annotation_id';
+        // This is not a highlight.
+        annotation.$highlight = undefined;
+        annotation.text = 'Annotation text';
+        annotation.tags = ['tag_1', 'tag_2'];
+        // The drafts service has some draft changes for this annotation.
+        fakeDrafts.get.returns('foo');
+
+        var controller = createDirective().controller;
+
+        assert.isTrue(controller.editing());
+      });
+
+      it('does not edit new highlights on initialization', function() {
+        // This is a new annotation.
+        annotation.id = undefined;
+        fakeDrafts.get.returns(null);
+        // This is a highlight.
+        annotation.$highlight = true;
+        annotation.text = '';
+        annotation.tags = [];
+        // We have to set annotation.$create() because it'll try to call it.
+        annotation.$create = sandbox.stub().returns({
+          then: function() {}
+        });
+
+        var controller = createDirective().controller;
+
+        assert.isFalse(controller.editing());
+      });
+
+      it('edits highlights with drafts on initialization', function() {
+        // You can edit a highlight, enter some text or tags, and save it (the
+        // highlight then becomes an annotation). You can also edit a highlight
+        // and then change focus to another group and back without saving the
+        // highlight, in which case the highlight will have draft edits.
+        //
+        // This is not a new highlight.
+        annotation.id = 'annotation_id';
+        annotation.$highlight = undefined;
+        // This is a highlight.
+        annotation.text = '';
+        annotation.tags = [];
+        // This highlight has draft edits.
+        fakeDrafts.get.returns('foo');
+
+        var controller = createDirective().controller;
+
+        assert.isTrue(controller.editing());
+      });
     });
 
     describe('AnnotationController.editing()', function() {


### PR DESCRIPTION
This started out as me trying to do a small fix to `AnnotationController`, I just wanted to move the line of code that automatically saves new highlights to the server on login out of a `$watch()`  function and to remove some duplicated state (`highlight`, `model.$highlight`, `vm.isHighlight()`, `vm.hasContent()` ...). But it ended up being a can of worms.

The changes I've ended up with are mostly just refactoring the code for clarity but this does also fix at least one broken behaviour (creating highlights while logged out, then logging in). See list of use-cases below.

Code changes:

* Rename local variable `highlight` to `newlyCreatedByHighlightButton` and add
  a docstring - clarify what this piece of state actually means.

   Yes I know this is a really long variable name but this state variable has a very particular meaning and is only used in a couple of places - I think the explicitness is justified here for clarity.

* Fix `vm.isHighlight()`: It now returns `false` for new annotations that the
  user hasn't entered any text or tags for yet (instead of `true`).

* Move the code for saving new highlights to the server into a
  `saveNewHighlight()` function that's called on AnnotationController
  instantiation instead of having it in a `$watch()` function that's called
  every time the local variable `model` changes.

  Also use the presence of `model.id` to avoid re-saving highlights that have
  already been saved - instead of abusing the `highlight`
  (now `newlyCreatedByHighlightButton`) variable and confusing what it
  represents.

* Don't automatically open the annotation editor on Annotationcontroller
  instantiation if the annotation is a highlight. This fixes this bug:

  1. Create a new highlight while logged out
  2. Log in
  3. Your highlight is saved to the server, but also the annotation editor is
     open on your highlight.

  The intention is that highlights are simply saved to the server, not opened
  for editing.

  _Annotations_ created while logged out, on the other hand, are _not_ saved
  to the server on login but _are_ opened for editing on login.

Cases to test (these are all things that are either broken on master, or were broken at one point by the earlier versions of the code changes in this pull request:

* During all cases, make sure that bucket bar numbers are correct

* Create new highlights while logged out, then login. The intended behaviour is that your highlights are silently saved to the server on login. They aren't double saved, their annotation editors aren't opened.

* Create new highlights while logged in. Intended behaviour: highlight is created and saved to server straight away when highlight button is clicked. Annotation editor is never opened.

* Load highlights from the server: reload the page and/or move between groups and/or logout and in again. Highlights should reappear as they were. Should not be re-saved again creating more highlights.

* Create new _annotations_ while logged out, then login. The intended behaviour is that your annotations are _not_ automatically saved to the server on login, and their annotation editors _are_ opened.

* Create new _annotations_ while logged in. The intended behaviour is that your annotations are _not_ automatically saved to the server, and their annotation editors _are_ opened.

* Load annotations from the server: reload the page and/or move between groups and/or logout and in again.

* Create a new annotation but do not save it, change to another group, change back to original group. Intended behaviour is that the annotation moves with you between groups and any privacy, text or tag edits are preserved.

* Edit an already saved annotation but do not save it, change to another group, change back to original group. The annotation does not go with you, but when you return to the group it is still there with its editor open and any edits preserved.

* **This one is still broken** (but is broken on master too): edit an already saved annotation and set its text to empty, change to another group, change back to original group - annotations original text has re-appeared. It should be empty.

* Create a highlight while logged in. Edit the highlight. Do not type any text or tags yet and do not save it. Move to another group. Move back. Highlight should still be there with its editor opened. Now enter some text, move to another group and back again - edits should be preserved.

P.S. In my opinion most of the complexity here is caused by using one directive / controller for many things (annotations, highlights, replies, page notes).