### PR TITLE
Generate a downloadable groups report in CSV format

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -10,7 +10,8 @@ Bug fixes
 Features
 --------
 
-- A report on groups is now available in the admin dashboard (#2764).
+- A report on groups is now available in the admin dashboard, which can be
+  downloaded in CSV format (#2764, #2772).
 
 Miscellanea
 -----------

--- a/h/_compat.py
+++ b/h/_compat.py
@@ -25,3 +25,8 @@ except ImportError:
     url_quote_plus = urllib.quote_plus
     url_unquote = urllib.unquote
     url_unquote_plus = urllib.unquote_plus
+
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO

--- a/h/admin.py
+++ b/h/admin.py
@@ -207,12 +207,37 @@ def badge_remove(request):
     request.db.delete(models.Blocklist.get_by_uri(uri))
     return badge_index(request)
 
+
 @view.view_config(route_name='admin_groups',
                   request_method='GET',
                   renderer='h:templates/admin/groups.html.jinja2',
                   permission='admin_groups')
 def groups_index(request):
     return {"groups": models.Group.all()}
+
+
+@view.view_config(route_name='admin_groups_csv',
+                  request_method='GET',
+                  renderer='csv',
+                  permission='admin_groups')
+def groups_index_csv(request):
+    groups = models.Group.all()
+
+    header = ['Group name', 'Group URL', 'Creator username',
+              'Creator email', 'Number of members']
+    rows = [[group.name,
+             request.route_url('group_read',
+                               pubid=group.pubid,
+                               slug=group.slug),
+             group.creator.username,
+             group.creator.email,
+             len(group.members)] for group in groups]
+
+    filename = 'groups.csv'
+    request.response.content_disposition = 'attachment;filename=' + filename
+
+    return {'header': header, 'rows': rows}
+
 
 def includeme(config):
     config.add_route('admin_index', '/admin')
@@ -222,5 +247,6 @@ def includeme(config):
     config.add_route('admin_staff', '/admin/staff')
     config.add_route('admin_users', '/admin/users')
     config.add_route('admin_groups', '/admin/groups')
+    config.add_route('admin_groups_csv', '/admin/groups.csv')
     config.add_route('admin_badge', '/admin/badge')
     config.scan(__name__)

--- a/h/app.py
+++ b/h/app.py
@@ -42,6 +42,8 @@ def create_app(global_config, **settings):
     config.add_tween('h.tweens.csrf_tween_factory')
     config.add_tween('h.tweens.auth_token')
 
+    config.add_renderer('csv', 'h.renderers.CSV')
+
     config.include(__name__)
 
     return config.make_wsgi_app()

--- a/h/renderers.py
+++ b/h/renderers.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+# Taken from:
+# https://pyramid-cookbook.readthedocs.org/en/latest/templates/customrenderers.html
+# with minor modifications
+import csv
+from h._compat import StringIO
+
+
+class CSV(object):
+    def __init__(self, info):
+        pass
+
+    def __call__(self, value, system):
+        """ Returns a plain CSV-encoded string with content-type
+        ``text/csv``. The content-type may be overridden by
+        setting ``request.response.content_type``."""
+
+        request = system.get('request')
+        if request is not None:
+            response = request.response
+            ct = response.content_type
+            if ct == response.default_content_type:
+                response.content_type = 'text/csv'
+
+        fout = StringIO()
+        writer = csv.writer(fout,
+                            delimiter=',',
+                            quotechar=',',
+                            quoting=csv.QUOTE_MINIMAL)
+
+        writer.writerow(value.get('header', []))
+        writer.writerows(value.get('rows', []))
+
+        return fout.getvalue()

--- a/h/templates/admin/groups.html.jinja2
+++ b/h/templates/admin/groups.html.jinja2
@@ -8,6 +8,12 @@
     On this page you can see a list of all the groups and their details.
   </p>
 
+  <p>
+    <a href="{{ request.route_url('admin_groups_csv') }}">
+      Download report as CSV
+    </a>
+  </p>
+
   <div class="table-responsive">
     <table class="table table-striped">
       <thead>

--- a/h/test/renderers_test.py
+++ b/h/test/renderers_test.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from pyramid.testing import DummyRequest
+
+from h import renderers
+
+
+def test_response_content_type():
+    renderer = renderers.CSV({})
+    req = DummyRequest()
+    renderer({}, {'request': req})
+    assert req.response.content_type == 'text/csv'
+
+
+def test_render_simple_csv():
+    renderer = renderers.CSV({})
+    req = DummyRequest()
+    sys = {'request': req}
+    value = {'header': ['One', 'Two'],
+             'rows': [[1, 2], [3, 4]]}
+
+    assert renderer(value, sys) == "One,Two\r\n1,2\r\n3,4\r\n"


### PR DESCRIPTION
This finishes story https://trello.com/c/iO3YJnyW/191-staff-dashboard-groups-report

The CSV renderer has been taken from the Pyramid documentation, with only very minor modifications: https://pyramid-cookbook.readthedocs.org/en/latest/templates/customrenderers.html