### PR TITLE
Don't crash if parent has no text

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,12 @@
 Unreleased
 ==========
 
+Bug fixes
+---------
+
+- Fix a crash that meant that reply notification emails would not be sent if
+  the annotation replied to had no text (#2771).
+
 Features
 --------
 

--- a/h/notification/reply_template.py
+++ b/h/notification/reply_template.py
@@ -52,7 +52,7 @@ def create_template_map(request, reply, parent):
     return {
         'document_title': document_title,
         'document_path': parent['uri'],
-        'parent_text': parent['text'],
+        'parent_text': parent.get('text', ''),
         'parent_user': parent_user,
         'parent_timestamp': format_timestamp(parent['created']),
         'parent_user_profile': user_profile_url(request, parent['user']),

--- a/h/notification/test/reply_template_test.py
+++ b/h/notification/test/reply_template_test.py
@@ -191,6 +191,28 @@ def test_template_map_key_values():
         assert tmap['unsubscribe'] == 'UNSUBSCRIBE_URL'
 
 
+def test_create_template_map_when_parent_has_no_text():
+    """It shouldn't crash if the parent annotation has no 'text' item."""
+    rt.create_template_map(
+            Mock(application_url='https://hypothes.is'),
+        reply={
+            'document': {
+                'title': 'Document Title'
+            },
+            'user': 'acct:bob@hypothes.is',
+            'text': "This is Bob's annotation",
+            'created': '2013-10-27T19:40:53.245691+00:00',
+            'id': '0'
+        },
+        # parent dict has no 'text' item.
+        parent={
+            'uri': 'http://example.com/example.html',
+            'user': 'acct:fred@hypothes.is',
+            'created': '2013-10-27T19:40:53.245691+00:00',
+            'id': '1'
+        })
+
+
 def test_fallback_title():
     """Checks that the title falls back to using the url"""
     with patch('h.notification.reply_template.Annotation') as mock_annotation:


### PR DESCRIPTION
Fix a crash in the notification worker when the parent annotation that has been
replied to has no `text` item.

Fixes #2771.