### PR TITLE
Fix groups principals

### DIFF
--- a/h/api/groups/auth.py
+++ b/h/api/groups/auth.py
@@ -43,9 +43,4 @@ def group_principals(user):
     :rtype: list of strings
 
     """
-    principals = ['group:__world__']
-
-    principals.extend(['group:{pubid}'.format(pubid=group.pubid)
-                       for group in user.groups])
-
-    return principals
+    return ['group:{group.pubid}'.format(group=group) for group in user.groups]

--- a/h/api/groups/test/auth_test.py
+++ b/h/api/groups/test/auth_test.py
@@ -73,16 +73,13 @@ def test_set_permissions_sets_read_permissions_for_group_annotations():
 def test_group_principals_with_no_groups():
     user = mock.Mock(groups=[])
 
-    assert auth.group_principals(user) == ['group:__world__']
+    assert auth.group_principals(user) == []
 
 
 def test_group_principals_with_one_group():
     user = mock.Mock(groups=[_mock_group('pubid1')])
 
-    assert auth.group_principals(user) == [
-        'group:__world__',
-        'group:pubid1',
-    ]
+    assert auth.group_principals(user) == ['group:pubid1']
 
 
 def test_group_principals_with_three_groups():
@@ -93,7 +90,6 @@ def test_group_principals_with_three_groups():
     ])
 
     assert auth.group_principals(user) == [
-        'group:__world__',
         'group:pubid1',
         'group:pubid2',
         'group:pubid3',

--- a/h/streamer.py
+++ b/h/streamer.py
@@ -25,6 +25,7 @@ from ws4py.server.wsgiutils import WebSocketWSGIApplication
 
 from h import queue
 from h._compat import text_type
+from h.api import auth
 from h.api import uri
 from h.models import Annotation
 
@@ -399,7 +400,8 @@ def _authorized_to_read(request, annotation):
             })
 
     read_permissions = annotation.get('permissions', {}).get('read', [])
-    if set(read_permissions).intersection(request.effective_principals):
+    read_principals = auth.translate_annotation_principals(read_permissions)
+    if set(read_principals).intersection(request.effective_principals):
         return True
     return False
 


### PR DESCRIPTION
When logged out, the only value in `request.effective_principals` is `pyramid.security.Everyone` (AKA `system.Everyone`). At the moment, this means that world-readable annotations -- those with `group:__world__` in their read permission field -- aren't being sent to logged-out clients.

This PR:

- Ensures that `h.api.groups.auth.group_principals` doesn't include `group:__world__` in the list of group principals for a given user. This principal is already represented by the "system.Everyone" principal which Pyramid already grants to *all* requests.
- Uses `h.api.auth.translate_annotation_principals` in `h.streamer` to ensure that annotation permissions strings are correctly compared with `request.effective_principals`.

Fixes #2777.