### PR TITLE
Remove "at least two characters" copy from password field

### DIFF
--- a/h/accounts/schemas.py
+++ b/h/accounts/schemas.py
@@ -181,8 +181,7 @@ class RegisterSchema(CSRFSchema):
         widget=deform.widget.TextInputWidget(autofocus=True),
     )
     email = email_node(title=_('Email address:'))
-    password = password_node(title=_('Password:'),
-                             hint=_('at least two characters'))
+    password = password_node(title=_('Password:'))
 
 
 class ResetCode(colander.SchemaType):
@@ -219,7 +218,6 @@ class ResetPasswordSchema(CSRFSchema):
         widget=deform.widget.TextInputWidget(disable_autocomplete=True))
     password = password_node(
         title=_('New password:'),
-        hint=_('at least two characters'),
         widget=deform.widget.PasswordWidget(disable_autocomplete=True))
 
 

--- a/h/claim/schemas.py
+++ b/h/claim/schemas.py
@@ -12,6 +12,5 @@ _ = i18n.TranslationString
 
 class UpdateAccountSchema(CSRFSchema):
     password = password_node(title=_('New password'),
-                             hint=_('at least two characters'),
                              widget=deform.widget.PasswordWidget(
                                  autofocus=True))


### PR DESCRIPTION
On account registration, claim, and password reset.
There are other related messages (such as the error popup warning the user for password too short) which still warn about this limit, but aren't visible except as error messages.