### PR TITLE
Consolidate API validation

### DIFF
--- a/h/api/logic.py
+++ b/h/api/logic.py
@@ -11,48 +11,18 @@ _ = i18n.TranslationString
 log = logging.getLogger(__name__)
 
 
-def create_annotation(fields, userid):
+def create_annotation(fields):
     """Create and store an annotation."""
-    # Create Annotation instance
     annotation = Annotation(fields)
-    annotation['user'] = userid
-
-    # Save it in the database
     search_lib.prepare(annotation)
     annotation.save()
-
-    log.debug('Created annotation; user: %s', annotation['user'])
 
     return annotation
 
 
-def update_annotation(annotation, fields, userid):
-    """Update the given annotation with the given new fields.
-
-    :raises RuntimeError: if the fields attempt to change the annotation's
-        permissions and has_admin_permission is False, or if they are
-        attempting to move the annotation between groups.
-
-    """
-    # If the user is changing access permissions, check if it's allowed.
-    permissions = annotation.get('permissions', {})
-    changing_permissions = (
-        'permissions' in fields and
-        fields['permissions'] != permissions
-    )
-    if changing_permissions and userid not in permissions.get('admin', []):
-        raise RuntimeError(
-            _('Not authorized to change annotation permissions.'), 401)
-
-    if 'group' in fields and 'group' in annotation:
-        if fields['group'] != annotation.get('group'):
-            raise RuntimeError(
-                _("You can't move annotations between groups."), 401)
-
-    # Update the annotation with the new data
+def update_annotation(annotation, fields):
+    """Update the given annotation with the given new fields."""
     annotation.update(fields)
-
-    # Save the annotation in the database, overwriting the old version.
     search_lib.prepare(annotation)
     annotation.save()
 

--- a/h/api/test/logic_test.py
+++ b/h/api/test/logic_test.py
@@ -25,26 +25,15 @@ create_annotation_fixtures = pytest.mark.usefixtures(
 @create_annotation_fixtures
 def test_create_annotation_calls_Annotation(Annotation):
     fields = mock.MagicMock()
-    logic.create_annotation(fields, userid='acct:joe@example.org')
+    logic.create_annotation(fields)
 
     Annotation.assert_called_once_with(fields)
 
 
 @create_annotation_fixtures
-def test_create_annotation_sets_user(Annotation):
-    """It should set the annotation's 'user' field to the userid."""
-    userid = 'acct:sofia@example.net'
-    Annotation.return_value = _mock_annotation()
-
-    annotation = logic.create_annotation({}, userid)
-
-    assert annotation['user'] == userid
-
-
-@create_annotation_fixtures
 def test_create_annotation_calls_prepare(Annotation, search_lib):
     """It should call prepare() once with the annotation."""
-    logic.create_annotation({}, userid='acct:gustave@example.com')
+    logic.create_annotation({})
 
     search_lib.prepare.assert_called_once_with(Annotation.return_value)
 
@@ -52,44 +41,15 @@ def test_create_annotation_calls_prepare(Annotation, search_lib):
 @create_annotation_fixtures
 def test_create_annotation_calls_save(Annotation):
     """It should call save() once."""
-    logic.create_annotation({}, userid='acct:francois@example.com')
+    logic.create_annotation({})
 
     Annotation.return_value.save.assert_called_once_with()
 
 
 @create_annotation_fixtures
 def test_create_annotation_returns_the_annotation(Annotation):
-    result = logic.create_annotation({}, userid='acct:satyarupa@example.org')
+    result = logic.create_annotation({})
     assert result == Annotation.return_value
-
-
-@create_annotation_fixtures
-def test_create_annotation_does_not_crash_if_annotation_has_no_group(
-        Annotation):
-    assert 'group' not in Annotation.return_value
-    fields = {}  # No group here either.
-
-    logic.create_annotation(fields, userid='acct:maya@example.net')
-
-
-@create_annotation_fixtures
-def test_create_annotation_does_not_crash_if_annotations_parent_has_no_group(
-        Annotation):
-    """It shouldn't crash if the parent annotation has no group.
-
-    It shouldn't crash if the annotation is a reply and its parent annotation
-    has no 'group' field.
-
-    """
-    # No group in the original annotation/reply itself.
-    Annotation.return_value = _mock_annotation()
-    assert 'group' not in Annotation.return_value
-    fields = {}  # No group here either.
-
-    # And no group in the parent annotation either.
-    Annotation.fetch.return_value = {}
-
-    logic.create_annotation(fields, userid='acct:filip@example.com')
 
 
 # The fixtures required to mock all of update_annotation()'s dependencies.
@@ -97,69 +57,20 @@ update_annotation_fixtures = pytest.mark.usefixtures('search_lib')
 
 
 @update_annotation_fixtures
-def test_update_annotation_raises_if_non_admin_changes_perms():
-    with pytest.raises(RuntimeError):
-        logic.update_annotation(
-            _mock_annotation(permissions={}),
-            fields={'permissions': {'read': ['someone']}},
-            userid='alice')
-
-
-@update_annotation_fixtures
-def test_update_annotation_admins_can_change_permissions():
-    annotation = _mock_annotation(
-        permissions={'admin': ['alice']},
-        user='alice')
-
-    logic.update_annotation(
-        annotation,
-        fields={'permissions': 'changed'},
-        userid='alice')
-
-    assert annotation['permissions'] == 'changed'
-
-
-@update_annotation_fixtures
-def test_update_annotation_non_admins_can_make_non_permissions_changes():
-    annotation = _mock_annotation(
-        foo='bar',
-        permissions={'admin': ['alice']},
-        user='alice')
-
-    logic.update_annotation(
-        annotation,
-        fields={
-            'foo': 'changed',
-        },
-        userid='bob')
-
-    assert annotation['foo'] == 'changed'
-
-
-@update_annotation_fixtures
 def test_update_annotation_calls_update():
     annotation = _mock_annotation()
     fields = {'foo': 'bar'}
 
-    logic.update_annotation(annotation, fields, 'foo')
+    logic.update_annotation(annotation, fields)
 
     annotation.update.assert_called_once_with(fields)
-
-
-@update_annotation_fixtures
-def test_update_annotation_user_cannot_change_group():
-    annotation = _mock_annotation(group='old')
-    fields = {'group': 'new'}
-
-    with pytest.raises(RuntimeError):
-        logic.update_annotation(annotation, fields, 'foo')
 
 
 @update_annotation_fixtures
 def test_update_annotation_calls_prepare(search_lib):
     annotation = _mock_annotation()
 
-    logic.update_annotation(annotation, {}, 'foo')
+    logic.update_annotation(annotation, {})
 
     search_lib.prepare.assert_called_once_with(annotation)
 
@@ -168,50 +79,13 @@ def test_update_annotation_calls_prepare(search_lib):
 def test_update_annotation_calls_save():
     annotation = _mock_annotation()
 
-    logic.update_annotation(annotation, {}, 'foo')
+    logic.update_annotation(annotation, {})
 
     annotation.save.assert_called_once_with()
 
 
-@update_annotation_fixtures
-def test_update_annotation_does_not_crash_if_annotation_has_no_group():
-    annotation = _mock_annotation()
-    assert 'group' not in annotation
-
-    logic.update_annotation(annotation, {}, 'foo')
-
-
-@update_annotation_fixtures
-def test_update_annotation_does_not_crash_if_annotations_parent_has_no_group(
-        Annotation):
-    """It shouldn't crash if the parent annotation has no group.
-
-    It shouldn't crash if the annotation is a reply and its parent annotation
-    has no 'group' field.
-
-    """
-    # No group in the original annotation/reply itself.
-    annotation = _mock_annotation()
-    assert 'group' not in annotation
-
-    # And no group in the parent annotation either.
-    Annotation.fetch.return_value = {}
-
-    logic.update_annotation(annotation, {}, 'foo')
-
-
 # The fixtures required to mock all of delete_annotation()'s dependencies.
 delete_annotation_fixtures = pytest.mark.usefixtures()
-
-
-@delete_annotation_fixtures
-def test_delete_does_not_crash_if_annotation_has_no_group():
-    annotation = mock.MagicMock()
-    annotation_data = {}  # No 'group' key.
-    annotation.get.side_effect = annotation_data.get
-    annotation.__getitem__.side_effect = annotation_data.__getitem__
-
-    logic.delete_annotation(annotation)
 
 
 @delete_annotation_fixtures

--- a/h/api/test/schemas_test.py
+++ b/h/api/test/schemas_test.py
@@ -1,4 +1,8 @@
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import mock
+from pyramid import testing
 import pytest
 
 from h.api import schemas
@@ -6,8 +10,8 @@ from h.api import schemas
 
 class ExampleSchema(schemas.JSONSchema):
     schema = {
-        '$schema': 'http://json-schema.org/draft-04/schema#',
-        'type': 'string',
+        b'$schema': b'http://json-schema.org/draft-04/schema#',
+        b'type': b'string',
     }
 
 
@@ -34,16 +38,184 @@ def test_jsonschema_sets_appropriate_error_message_when_data_invalid():
     assert message.startswith("123 is not of type 'string'")
 
 
+def test_createannotationschema_passes_input_to_structure_validator():
+    request = testing.DummyRequest()
+    schema = schemas.CreateAnnotationSchema(request)
+    schema.structure = mock.Mock()
+    schema.structure.validate.return_value = {}
+
+    schema.validate({'foo': 'bar'})
+
+    schema.structure.validate.assert_called_once_with({'foo': 'bar'})
+
+
+def test_createannotationschema_raises_if_structure_validator_raises():
+    request = testing.DummyRequest()
+    schema = schemas.CreateAnnotationSchema(request)
+    schema.structure = mock.Mock()
+    schema.structure.validate.side_effect = schemas.ValidationError('asplode')
+
+    with pytest.raises(schemas.ValidationError):
+        schema.validate({'foo': 'bar'})
+
+
+@pytest.mark.parametrize('field', [
+    'created',
+    'updated',
+    'id',
+])
+def test_createannotationschema_removes_protected_fields(field):
+    request = testing.DummyRequest()
+    schema = schemas.CreateAnnotationSchema(request)
+    data = {}
+    data[field] = 'something forbidden'
+
+    result = schema.validate(data)
+
+    assert field not in result
+
+
+@pytest.mark.parametrize('data', [
+    {},
+    {'user': None},
+    {'user': 'acct:foo@bar.com'},
+])
+def test_createannotationschema_ignores_input_user(data, authn_policy):
+    """Any user field sent in the payload should be ignored."""
+    authn_policy.authenticated_userid.return_value = 'acct:jeanie@example.com'
+    request = testing.DummyRequest()
+    schema = schemas.CreateAnnotationSchema(request)
+
+    result = schema.validate(data)
+
+    assert result == {'user': 'acct:jeanie@example.com'}
+
+
+@pytest.mark.parametrize('data', [
+    {},
+    {'foo': 'bar'},
+    {'a_list': ['of', 'important', 'things']},
+    {'an_object': {'with': 'stuff'}},
+    {'numbers': 12345},
+    {'null': None},
+])
+def test_createannotationschema_permits_all_other_changes(data):
+    request = testing.DummyRequest()
+    schema = schemas.CreateAnnotationSchema(request)
+
+    result = schema.validate(data)
+
+    for k in data:
+        assert result[k] == data[k]
+
+
+def test_updateannotationschema_passes_input_to_structure_validator():
+    request = testing.DummyRequest()
+    schema = schemas.UpdateAnnotationSchema(request, {})
+    schema.structure = mock.Mock()
+    schema.structure.validate.return_value = {}
+
+    schema.validate({'foo': 'bar'})
+
+    schema.structure.validate.assert_called_once_with({'foo': 'bar'})
+
+
+def test_updateannotationschema_raises_if_structure_validator_raises():
+    request = testing.DummyRequest()
+    schema = schemas.UpdateAnnotationSchema(request, {})
+    schema.structure = mock.Mock()
+    schema.structure.validate.side_effect = schemas.ValidationError('asplode')
+
+    with pytest.raises(schemas.ValidationError):
+        schema.validate({'foo': 'bar'})
+
+
 @pytest.mark.parametrize('field', [
     'created',
     'updated',
     'user',
     'id',
 ])
-def test_annotationschema_removes_protected_fields(field):
+def test_updateannotationschema_removes_protected_fields(field):
+    request = testing.DummyRequest()
+    annotation = {}
+    schema = schemas.UpdateAnnotationSchema(request, annotation)
     data = {}
     data[field] = 'something forbidden'
 
-    result = schemas.AnnotationSchema().validate(data)
+    result = schema.validate(data)
 
     assert field not in result
+
+
+def test_updateannotationschema_allows_permissions_changes_if_admin(authn_policy):
+    """If a user is an admin on an annotation, they can change perms."""
+    authn_policy.authenticated_userid.return_value = 'acct:harriet@example.com'
+    request = testing.DummyRequest()
+    annotation = {
+        'permissions': {'admin': ['acct:harriet@example.com']}
+    }
+    schema = schemas.UpdateAnnotationSchema(request, annotation)
+    data = {
+        'permissions': {'admin': ['acct:foo@example.com']}
+    }
+
+    result = schema.validate(data)
+
+    assert result == data
+
+
+@pytest.mark.parametrize('annotation', [
+    {},
+    {'permissions': {}},
+    {'permissions': {'admin': []}},
+    {'permissions': {'admin': ['acct:alice@example.com']}},
+    {'permissions': {'read': ['acct:mallory@example.com']}},
+])
+def test_updateannotationschema_denies_permissions_changes_if_not_admin(annotation, authn_policy):
+    """If a user is not an admin on an annotation, they cannot change perms."""
+    authn_policy.authenticated_userid.return_value = 'acct:mallory@example.com'
+    request = testing.DummyRequest()
+    schema = schemas.UpdateAnnotationSchema(request, annotation)
+    data = {
+        'permissions': {'admin': ['acct:mallory@example.com']}
+    }
+
+    with pytest.raises(schemas.ValidationError) as exc:
+        schema.validate(data)
+
+    assert exc.value.message.startswith('permissions:')
+
+
+def test_updateannotationschema_denies_group_changes():
+    """An annotation may not be moved between groups."""
+    request = testing.DummyRequest()
+    annotation = {'group': 'flibble'}
+    schema = schemas.UpdateAnnotationSchema(request, annotation)
+    data = {
+        'group': '__world__'
+    }
+
+    with pytest.raises(schemas.ValidationError) as exc:
+        schema.validate(data)
+
+    assert exc.value.message.startswith('group:')
+
+
+@pytest.mark.parametrize('data', [
+    {},
+    {'foo': 'bar'},
+    {'a_list': ['of', 'important', 'things']},
+    {'an_object': {'with': 'stuff'}},
+    {'numbers': 12345},
+    {'null': None},
+])
+def test_updateannotationschema_permits_all_other_changes(data):
+    request = testing.DummyRequest()
+    annotation = {'group': 'flibble'}
+    schema = schemas.UpdateAnnotationSchema(request, annotation)
+
+    result = schema.validate(data)
+
+    for k in data:
+        assert result[k] == data[k]

--- a/h/api/test/views_test.py
+++ b/h/api/test/views_test.py
@@ -215,23 +215,22 @@ def test_create_raises_if_json_parsing_fails():
 def test_create_calls_create_annotation(logic, schemas):
     """It should call logic.create_annotation() appropriately."""
     request = mock.Mock()
-    schemas.AnnotationSchema.return_value.validate.return_value = {'foo': 123}
+    schema = schemas.CreateAnnotationSchema.return_value
+    schema.validate.return_value = {'foo': 123}
 
     views.create(request)
 
-    logic.create_annotation.assert_called_once_with(
-        {'foo': 123},
-        userid=request.authenticated_userid)
+    logic.create_annotation.assert_called_once_with({'foo': 123})
 
 
 @create_fixtures
 def test_create_calls_validator(schemas):
     request = mock.Mock()
+    schema = schemas.CreateAnnotationSchema.return_value
 
     views.create(request)
 
-    schemas.AnnotationSchema.return_value.validate.assert_called_once_with(
-        request.json_body)
+    schema.validate.assert_called_once_with(request.json_body)
 
 
 @create_fixtures
@@ -330,36 +329,24 @@ def test_update_raises_if_json_parsing_fails():
 @update_fixtures
 def test_update_calls_validator(schemas):
     request = mock.Mock()
+    schema = schemas.UpdateAnnotationSchema.return_value
 
     views.update(mock.Mock(), request)
 
-    schemas.AnnotationSchema.return_value.validate.assert_called_once_with(
-        request.json_body)
+    schema.validate.assert_called_once_with(request.json_body)
 
 
 @update_fixtures
 def test_update_calls_update_annotation(logic, schemas):
     context = mock.Mock()
     request = mock.Mock()
-    schemas.AnnotationSchema.return_value.validate.return_value = {'foo': 123}
+    schema = schemas.UpdateAnnotationSchema.return_value
+    schema.validate.return_value = {'foo': 123}
 
     views.update(context, request)
 
-    logic.update_annotation.assert_called_once_with(
-        context.model,
-        {'foo': 123},
-        request.authenticated_userid)
-
-
-@update_fixtures
-def test_update_returns_error_if_update_annotation_raises(logic):
-    logic.update_annotation.side_effect = RuntimeError("Nope", 401)
-
-    with pytest.raises(views.APIError) as exc:
-        views.update(mock.Mock(), mock.Mock())
-
-    assert exc.value.message == "Nope"
-    assert exc.value.status_code == 401
+    logic.update_annotation.assert_called_once_with(context.model,
+                                                    {'foo': 123})
 
 
 @update_fixtures

--- a/h/api/views.py
+++ b/h/api/views.py
@@ -189,11 +189,11 @@ def annotations_index(request):
 @api_config(context=Annotations, request_method='POST', permission='create')
 def create(request):
     """Read the POSTed JSON-encoded annotation and persist it."""
-    schema = schemas.AnnotationSchema()
+    schema = schemas.CreateAnnotationSchema(request)
     appstruct = schema.validate(_json_payload(request))
 
-    annotation = logic.create_annotation(appstruct,
-                                         userid=request.authenticated_userid)
+    annotation = logic.create_annotation(appstruct)
+
     # Notify any subscribers
     _publish_annotation_event(request, annotation, 'create')
 
@@ -216,16 +216,11 @@ def read(context, request):
 def update(context, request):
     """Update the fields we received and store the updated version."""
     annotation = context.model
-    schema = schemas.AnnotationSchema()
+    schema = schemas.UpdateAnnotationSchema(request, annotation)
     appstruct = schema.validate(_json_payload(request))
 
     # Update and store the annotation
-    try:
-        logic.update_annotation(annotation,
-                                appstruct,
-                                userid=request.authenticated_userid)
-    except RuntimeError as err:
-        raise APIError(err.args[0], status_code=err.args[1])
+    logic.update_annotation(annotation, appstruct)
 
     # Notify any subscribers
     _publish_annotation_event(request, annotation, 'update')


### PR DESCRIPTION
With a view to turning `h.api.logic` into `h.api.storage` -- and as a result the central point of indirection for all `h.api` storage accesses, I've moved some of the annotation payload prep and validation out of `h.api.logic` and alongside the other validation logic in `h.api.schemas`.