### PR TITLE
Fix standalone reply pages

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,11 @@
+Unreleased
+==========
+
+Bug fixes
+---------
+
+- Fix broken standalone annotation pages for replies (#2786).
+
 0.8.5 (2015-12-08)
 ==================
 

--- a/h/static/scripts/annotation-viewer-controller.coffee
+++ b/h/static/scripts/annotation-viewer-controller.coffee
@@ -19,13 +19,12 @@ module.exports = class AnnotationViewerController
     $scope.search.update = (query) ->
       $location.path('/stream').search('q', query)
 
-    search_params = {
-      _id: id,
-      _separate_replies: true
-    }
-    store.SearchResource.get(search_params, ({rows, replies}) ->
-      annotationMapper.loadAnnotations(rows, replies)
+    store.AnnotationResource.get({id: id}, (annotation) ->
+      annotationMapper.loadAnnotations([annotation])
       $scope.threadRoot = {children: [threading.idTable[id]]}
+    )
+    store.SearchResource.get({references: id}, ({rows}) ->
+      annotationMapper.loadAnnotations(rows)
     )
 
     streamFilter


### PR DESCRIPTION
This commit is a partial revert of 4628b26, affecting standalone annotation pages only.

That commit changed the AnnotationViewerController (the component responsible for standalone annotation pages) to make a single request to the search API to load an annotation and all its replies, rather than two requests -- for the annotation and then for its replies.

This works just fine so long as the top-level annotation is not itself a reply. In that case, however, the search endpoint returns nothing, as the (temporary) `_separate_replies` parameter ensures that only top-level annotations are matched.

This commit switches back to making two requests to populate the client-side data structures for the standalone annotation page:

1. To fetch the annotation referenced in the URL (which may itself be a reply).
2. To fetch any replies to the annotation referenced in the URL.

Fixes #2775.