### PR TITLE
Fix standalone annotation page realtime updates for replies to replies

### DIFF
--- a/h/static/scripts/annotation-viewer-controller.coffee
+++ b/h/static/scripts/annotation-viewer-controller.coffee
@@ -30,7 +30,7 @@ module.exports = class AnnotationViewerController
 
     streamFilter
       .setMatchPolicyIncludeAny()
-      .addClause('/references', 'first_of', id, true)
+      .addClause('/references', 'one_of', id, true)
       .addClause('/id', 'equals', id, true)
 
     streamer.setConfig('filter', {filter: streamFilter.getFilter()})


### PR DESCRIPTION
This PR fixes a bug where a standalone annotation page only receives realtime updates for replies on that page if the top-level annotation on the page is also the root of its message thread.

The annotation `references` field contains the ids of all ancestors in the message thread, from oldest to newest -- that is, the earlier in the references field an id appears, the higher it is in the message tree.

In order to receive realtime updates for all messages in the part of the thread displayed on a standalone annotation page, we need to ask for:

- all updates in which the id in the URL matches the id in the annotation (i.e. updates to the top-most displayed annotation, which may itself be a reply).

- all updates in which the id in the URL *is contained in* the `references` field of an annotation (i.e. updates for any annotation lower in the message thread)

Previously, this code requested all updates in which the id *was the first entry* in the references field, which is only ever true for the root of a message thread, meaning that it only ever worked on standalone annotation pages for top-level annotations, and not on pages for replies.