### PR TITLE
Remove use of 'claim' feature flag

### DIFF
--- a/h/claim/views.py
+++ b/h/claim/views.py
@@ -54,7 +54,6 @@ def _validate_request(request):
     Check that the passed request is appropriate for proceeding with account
     claim. Asserts that:
 
-    - the 'claim' feature is toggled on
     - no-one is logged in
     - the claim token is provided and authentic
     - the user referred to in the token exists
@@ -62,9 +61,6 @@ def _validate_request(request):
 
     and raises for redirect or 404 otherwise.
     """
-    if not request.feature('claim'):
-        raise exc.HTTPNotFound()
-
     # If signed in, redirect to stream
     if request.authenticated_userid is not None:
         _perform_logged_in_redirect(request)


### PR DESCRIPTION
This is toggled on for everyone so there's no need to keep it feature flagged.

The removal of the flag in `h.features` will come in a later commit.