### PR TITLE
Don't 500 when non-object JSON is POSTed to API create

### DIFF
--- a/h/api/resources.py
+++ b/h/api/resources.py
@@ -80,12 +80,18 @@ class Annotations(Collection):
 
     def __acl__(self):
         deny = (Deny, Everyone, 'create')
+        group = '__world__'  # Unless we find otherwise, assume public.
+        payload = None
+
+        # Ignore invalid JSON. It will get rejected by validation later.
         try:
             payload = self.request.json_body
         except ValueError:
-            return [deny]
+            pass
 
-        group = payload.get('group', '__world__')
+        if isinstance(payload, dict) and 'group' in payload:
+            group = payload['group']
+
         if group == '__world__':
             return [(Allow, Authenticated, 'create'), deny]
 

--- a/h/api/test/resources_test.py
+++ b/h/api/test/resources_test.py
@@ -72,6 +72,16 @@ class TestAnnotationsPermissions(object):
         annotations = resources.Annotations(request)
 
         assert annotations.__acl__() == [
+            (security.Allow, security.Authenticated, 'create'),
+            (security.Deny, security.Everyone, 'create')]
+
+    def test_when_request_has_non_object_body(self):
+        request = mock.Mock()
+        request.json_body = "flibble"
+        annotations = resources.Annotations(request)
+
+        assert annotations.__acl__() == [
+            (security.Allow, security.Authenticated, 'create'),
             (security.Deny, security.Everyone, 'create')]
 
     def test_when_request_contains_no_group(self):


### PR DESCRIPTION
Sean just discovered that POSTing data that is valid JSON but not an object to the annotation create API results in an application crash.

Fix this by simply ignoring anything we don't understand in the traversal phase and assuming that the annotation to be created is public unless we can tell otherwise.