### PR TITLE
Don't crash on non-JSON body

### DIFF
--- a/h/accounts/__init__.py
+++ b/h/accounts/__init__.py
@@ -17,6 +17,18 @@ class NoSuchUserError(Error):
     pass
 
 
+class JSONError(Error):
+
+    """Exception raised when there's a problem with a request's JSON body.
+
+    This is for pre-validation problems such as no JSON body, body cannot
+    be parsed as JSON, or top-level keys missing from the JSON.
+
+    """
+
+    pass
+
+
 def make_admin(username):
     """Make the given user an admin."""
     user = models.User.get_by_username(username)

--- a/h/accounts/views.py
+++ b/h/accounts/views.py
@@ -17,6 +17,7 @@ from h import i18n
 from h import models
 from h import session
 from h import util
+from h import accounts
 from h.accounts import schemas
 from h.accounts.models import User
 from h.accounts.models import Activation
@@ -47,6 +48,15 @@ def bad_csrf_token(context, request):
         'status': 'failure',
         'reason': reason,
         'model': session.model(request),
+    }
+
+
+@json_view(context=accounts.JSONError)
+def error_json(error, request):
+    request.response.status_code = 400
+    return {
+        'status': 'failure',
+        'reason': error.message
     }
 
 
@@ -132,7 +142,23 @@ class AuthController(object):
 class AjaxAuthController(AuthController):
     def login(self):
         try:
-            appstruct = self.form.validate(self.request.json_body.items())
+            json_body = self.request.json_body
+        except ValueError as err:
+            raise accounts.JSONError(
+                _('Could not parse request body as JSON: {message}'.format(
+                    message=err.message)))
+
+        if not isinstance(json_body, dict):
+            raise accounts.JSONError(
+                _('Request JSON body must have a top-level object'))
+
+        # Transform non-string usernames and password into strings.
+        # Deform crashes otherwise.
+        json_body['username'] = unicode(json_body.get('username') or '')
+        json_body['password'] = unicode(json_body.get('password') or '')
+
+        try:
+            appstruct = self.form.validate(json_body.items())
         except deform.ValidationFailure as err:
             self.request.response.status_code = 400
             return ajax_payload(self.request, {'status': 'failure',

--- a/h/accounts/views.py
+++ b/h/accounts/views.py
@@ -60,6 +60,14 @@ def error_json(error, request):
     }
 
 
+@json_view(context=deform.ValidationFailure)
+def error_validation(error, request):
+    request.response.status_code = 400
+    return ajax_payload(
+        request,
+        {'status': 'failure', 'errors': error.error.asdict()})
+
+
 @view_config(route_name='login', attr='login', request_method='POST',
              renderer='h:templates/accounts/login.html.jinja2')
 @view_config(route_name='login', attr='login_form', request_method='GET',
@@ -157,12 +165,7 @@ class AjaxAuthController(AuthController):
         json_body['username'] = unicode(json_body.get('username') or '')
         json_body['password'] = unicode(json_body.get('password') or '')
 
-        try:
-            appstruct = self.form.validate(json_body.items())
-        except deform.ValidationFailure as err:
-            self.request.response.status_code = 400
-            return ajax_payload(self.request, {'status': 'failure',
-                                               'errors': err.error.asdict()})
+        appstruct = self.form.validate(json_body.items())
 
         user = appstruct['user']
         headers = self._login(user)


### PR DESCRIPTION
Don't crash if someone makes an application/json POST request to
/app?__formid__=login that doesn't have a valid JSON body.