### PR TITLE
Make the Via form on the homepage work as a plain HTML form

### DIFF
--- a/h/home.py
+++ b/h/home.py
@@ -1,5 +1,14 @@
 """The home/front page of the //hypothes.is/ site."""
 from pyramid import view
+from pyramid import httpexceptions
+
+
+@view.view_config(route_name='via_redirect',
+                  request_method='GET')
+def via_redirect(context, request):
+    url = request.params['url']
+    via_link = 'https://via.hypothes.is/{}'.format(url)
+    return httpexceptions.HTTPFound(location=via_link)
 
 
 @view.view_config(route_name='index',
@@ -24,4 +33,5 @@ def index(context, request):
 
 def includeme(config):
     config.add_route('index', '/')
+    config.add_route('via_redirect', '/via')
     config.scan(__name__)

--- a/h/home.py
+++ b/h/home.py
@@ -6,7 +6,12 @@ from pyramid import httpexceptions
 @view.view_config(route_name='via_redirect',
                   request_method='GET')
 def via_redirect(context, request):
-    url = request.params['url']
+    url = request.params.get('url')
+
+    if not url:
+        raise httpexceptions.HTTPBadRequest('"url" parameter missing')
+
+
     via_link = 'https://via.hypothes.is/{}'.format(url)
     return httpexceptions.HTTPFound(location=via_link)
 

--- a/h/home.py
+++ b/h/home.py
@@ -8,7 +8,7 @@ from pyramid import httpexceptions
 def via_redirect(context, request):
     url = request.params.get('url')
 
-    if not url:
+    if url is None:
         raise httpexceptions.HTTPBadRequest('"url" parameter missing')
 
 

--- a/h/static/scripts/installer-controller.js
+++ b/h/static/scripts/installer-controller.js
@@ -29,6 +29,16 @@ function showSupportedInstallers(rootElement) {
   showIf('.js-install-any', offerChromeInstall || offerBookmarkletInstall);
 }
 
-module.exports = {
-  showSupportedInstallers: showSupportedInstallers,
-};
+function InstallerController(element) {
+  showSupportedInstallers(element);
+
+  // setup Via link form
+  var proxyForm = document.querySelector('.js-proxy-form');
+  proxyForm.addEventListener('submit', function (event) {
+    event.preventDefault();
+    var url = proxyForm.elements['url'].value;
+    window.location.href = 'https://via.hypothes.is/' + url;
+  });
+}
+
+module.exports = InstallerController;

--- a/h/static/scripts/site.js
+++ b/h/static/scripts/site.js
@@ -1,8 +1,7 @@
 var CreateGroupFormController = require('./create-group-form');
 var DropdownMenuController = require('./dropdown-menu');
+var InstallerController = require('./installer-controller');
 var ShareGroupFormController = require('./share-group-form');
-
-var installerController = require('./installer-controller');
 
 // load our customized version of Bootstrap which
 // provides a few basic UI components (eg. modal dialogs)
@@ -23,7 +22,7 @@ document.addEventListener('DOMContentLoaded', function () {
   // setup route
   var route = document.location.pathname;
   if (route.match('^/(new-homepage)?$')) {
-    installerController.showSupportedInstallers(document);
+    new InstallerController(document.body);
   } else if (route.match('^/groups') === 0) {
     setupGroupsController(route);
   }

--- a/h/static/scripts/site.js
+++ b/h/static/scripts/site.js
@@ -21,7 +21,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
   // setup route
   var route = document.location.pathname;
-  if (route.match('^/(new-homepage)?$')) {
+  if (route === '/') {
     new InstallerController(document.body);
   } else if (route.match('^/groups') === 0) {
     setupGroupsController(route);

--- a/h/static/scripts/test/installer-controller-test.js
+++ b/h/static/scripts/test/installer-controller-test.js
@@ -11,7 +11,8 @@ describe('installer page', function () {
     rootElement.innerHTML =
       '<button class="extension js-install-chrome is-hidden"></button>' +
       '<button class="bookmarklet js-install-bookmarklet is-hidden"></button>' +
-      '<input class="link">';
+      '<input class="link">' +
+      '<form class="js-proxy-form"><input name="url"></form>'
     extensionBtn = rootElement.querySelector('.extension');
     bookmarkletBtn = rootElement.querySelector('.bookmarklet');
     linkField = rootElement.querySelector('.link');
@@ -23,11 +24,10 @@ describe('installer page', function () {
   });
 
   function createController(userAgentInfo) {
-    var controller = proxyquire('../installer-controller', {
+    var Controller = proxyquire('../installer-controller', {
       './ua-detect': userAgentInfo
     });
-    controller.showSupportedInstallers(rootElement);
-    return controller;
+    return new Controller(rootElement);
   }
 
   function isHidden(el) {

--- a/h/templates/home.html.jinja2
+++ b/h/templates/home.html.jinja2
@@ -50,9 +50,9 @@
 
       <form
         class="proxy-link-form"
-        onsubmit="url = document.getElementById('search').value; if (url != '') { window.location.href = 'https://via.hypothes.is/h/' + url; } return false;">
+        action="/via">
         <input id="search" class="proxy-link-form__field" type="text"
-                name="search" placeholder="Paste a link to annotate…">
+                name="url" placeholder="Paste a link to annotate…">
         <button class="proxy-link-form__submit-btn" type="submit"
          title="Annotate this page with Hypothesis"
         >

--- a/h/templates/home.html.jinja2
+++ b/h/templates/home.html.jinja2
@@ -49,7 +49,7 @@
       <em class="installer__alt is-hidden js-install-any">or</em>
 
       <form
-        class="proxy-link-form"
+        class="proxy-link-form js-proxy-form"
         action="/via">
         <input id="search" class="proxy-link-form__field" type="text"
                 name="url" placeholder="Paste a link to annotate…">


### PR DESCRIPTION
This enables the Via link to do something useful even
if the homepage JS has not loaded.

A downside is that this introduces an additional redirect on the happy path. We could remove that but I'm unsure whether it is going to matter.