### PR TITLE
Small tweaks to the header for re-use in the blog

### DIFF
--- a/h/static/styles/header.scss
+++ b/h/static/styles/header.scss
@@ -107,8 +107,10 @@
 
     padding-top: 2px;
     padding-bottom: 2px;
+    padding-left: 0px;
+    padding-right: 0px;
 
-    z-index: 1;
+    z-index: $zindex-dropdown-menu;
   }
 
   .nav-bar-menu.is-open {

--- a/h/static/styles/variables.scss
+++ b/h/static/styles/variables.scss
@@ -135,6 +135,11 @@ $layout-h-margin: 15px;
 $anim-duration-normal: .3s; // a good default choice for transition lengths
 
 
+// Z-Index Scale
+// -------------------------
+$zindex-dropdown-menu: 10;
+
+
 // Other Variables
 // -------------------------
 $bucket-bar-width: 22px;

--- a/h/templates/includes/footer.html.jinja2
+++ b/h/templates/includes/footer.html.jinja2
@@ -1,3 +1,12 @@
+{#
+
+  Site and blog navigation footer.
+
+  This is shared between the site and blog.
+  See comments in header.html.jinja2 about updating
+  the blog theme when changing this.
+
+#}
 <footer class="footer">
   <div class="u-align-right social-media">
     <a class="social-media-link" href="https://github.com/hypothesis">

--- a/h/templates/includes/header.html.jinja2
+++ b/h/templates/includes/header.html.jinja2
@@ -1,3 +1,13 @@
+{#
+
+  Site and blog navigation header.
+
+  Note that this component is used by both the website and the blog.
+  When updating the navigation here, the WordPress Theme will also need
+  to be updated using the 'update-hypothesis-shared.py' script in
+  the wordpress-theme-hypothesis repository.
+
+#}
 <svg style="display:none">
     <symbol class="border-with-left-arrow" id="border-with-left-arrow">
         <rect class="background-rect" stroke="none" x="0" y="0" width="10" height="20"/>


### PR DESCRIPTION
 * Add notes in the header and footer about updating the blog's
   navigation when updating the navigation on the main site.

 * Increase the Z-index for dropdown menus in the header
   to avoid a problem where the search box on the blog
   appeared over the top of the dropdown.

   Add a central place for a Z-Index scale in variables.scss
   to avoid such problems in future.

 * Set the horizontal padding explicitly for the nav dropdown
   menus. Previously the site relied on padding set by
   a compass reset which was not present on the blog which
   uses a much more minimal reset.