### PR TITLE
Don't update annotations with contents of others

### DIFF
--- a/h/static/scripts/directive/annotation.js
+++ b/h/static/scripts/directive/annotation.js
@@ -343,7 +343,9 @@ function AnnotationController(
   }
 
   function onAnnotationUpdated(event, updatedDomainModel) {
-    updateViewModel(updatedDomainModel, vm, permissions);
+    if (updatedDomainModel.id === domainModel.id) {
+      updateViewModel(updatedDomainModel, vm, permissions);
+    }
   }
 
   function onDestroy() {

--- a/h/static/scripts/directive/test/annotation-test.js
+++ b/h/static/scripts/directive/test/annotation-test.js
@@ -1367,6 +1367,33 @@ describe('annotation.js', function() {
       });
     });
 
+    describe('onAnnotationUpdated()', function() {
+      it('updates vm.form.text', function() {
+        var parts = createDirective();
+        var updatedModel = {
+          id: parts.annotation.id,
+          text: 'new text',
+        };
+
+        $rootScope.$emit('annotationUpdated', updatedModel);
+
+        assert.equal(parts.controller.form.text, 'new text');
+      });
+
+      it('doesn\'t update if a different annotation was updated', function() {
+        var parts = createDirective();
+        parts.controller.form.text = 'original text';
+        var updatedModel = {
+          id: 'different annotation id',
+          text: 'new text',
+        };
+
+        $rootScope.$emit('annotationUpdated', updatedModel);
+
+        assert.equal(parts.controller.form.text, 'original text');
+      });
+    });
+
     describe('onGroupFocused()', function() {
       it('if the annotation is being edited it updates drafts', function() {
         var parts = createDirective();


### PR DESCRIPTION
When listening to the 'annotationUpdated' event, AnnotationController
needs to check that it's this annotation that the event refers to before
acting on it.

Fixes #2799.