### PR TITLE
Enable showdown's literalMidWordUnderscores

### DIFF
--- a/h/static/scripts/filter/converter.js
+++ b/h/static/scripts/filter/converter.js
@@ -11,7 +11,12 @@ module.exports = function () {
   // see https://github.com/showdownjs/showdown#valid-options
   var converter = new showdown.Converter({
     extensions: [targetBlank],
-    simplifiedAutoLink: true
+    simplifiedAutoLink: true,
+    // Since we're using simplifiedAutoLink we also use
+    // literalMidWordUnderscores because otherwise _'s in URLs get
+    // transformed into <em>'s.
+    // See https://github.com/showdownjs/showdown/issues/211
+    literalMidWordUnderscores: true,
   });
   return converter.makeHtml.bind(converter);
 };

--- a/h/static/scripts/filter/test/converter-test.js
+++ b/h/static/scripts/filter/test/converter-test.js
@@ -2,9 +2,19 @@ var converter = require('../converter');
 
 describe('markdown converter', function () {
   var markdownToHTML = converter();
+
   it('should autolink URLs', function () {
     assert.equal(markdownToHTML('See this link - http://arxiv.org/article'),
       '<p>See this link - <a target="_blank" href="http://arxiv.org/article">' +
       'http://arxiv.org/article</a></p>');
+  });
+
+  it('should autolink URLs with _\'s in them correctly', function () {
+    assert.equal(
+      markdownToHTML(
+        'See this https://hypothes.is/stream?q=tag:group_test_needs_card'),
+      '<p>See this <a target="_blank" ' +
+      'href="https://hypothes.is/stream?q=tag:group_test_needs_card">' +
+      'https://hypothes.is/stream?q=tag:group_test_needs_card</a></p>');
   });
 });


### PR DESCRIPTION
This may be a controversial way of fixing this bug, since it changes Showdown's output in ways other than fixing underscores in link as well, but it seems to be what the showdown authors recommend: <https://github.com/showdownjs/showdown/issues/211>.

Also, I haven't looked, but I suspect it might be hard to fix the behaviour otherwise, it looks to me like by the time showdown's auto-link sub-parser runs the underscores in links have already been turned into `<em>`s by other showdown code. I'm guessing this may also happen before any showdown extension we write runs. So it _may_ not be simple to fix this in another way:

This stops showdown from interpreting underscores in the middle of words
as `<em>` and `<strong>`, instead it treats them as literal underscores.

Example:

    some text with__underscores__in middle

will be parsed as

    <p>some text with__underscores__in middle</p>

Fixes #2598 (URLs with `_`'s in them were getting `<em>` tags inserted into
them, breaking the links).