### PR TITLE
T158 - Update truncated annotation card design

### DIFF
--- a/h/static/scripts/directive/annotation.js
+++ b/h/static/scripts/directive/annotation.js
@@ -587,6 +587,11 @@ function AnnotationController(
     }
   };
 
+  vm.toggleCollapseBody = function(event) {
+    event.stopPropagation();
+    vm.collapseBody = !vm.collapseBody;
+  };
+
   /**
     * @ngdoc method
     * @name annotation.AnnotationController#reply

--- a/h/static/scripts/directive/annotation.js
+++ b/h/static/scripts/directive/annotation.js
@@ -304,7 +304,7 @@ function AnnotationController(
     /** Determines whether controls to expand/collapse the annotation body
      * are displayed adjacent to the tags field.
      */
-    vm.canCollapseBody = true;
+    vm.canCollapseBody = false;
 
     /** Determines whether the annotation body should be collapsed. */
     vm.collapseBody = true;

--- a/h/static/scripts/directive/annotation.js
+++ b/h/static/scripts/directive/annotation.js
@@ -301,6 +301,14 @@ function AnnotationController(
     /** A callback for resetting the automatic refresh of vm.timestamp */
     vm.cancelTimestampRefresh = undefined;
 
+    /** Determines whether controls to expand/collapse the annotation body
+     * are displayed adjacent to the tags field.
+     */
+    vm.canCollapseBody = true;
+
+    /** Determines whether the annotation body should be collapsed. */
+    vm.collapseBody = true;
+
     /** The domain model, contains the currently saved version of the
       * annotation from the server (or in the case of new annotations that
       * haven't been saved yet - the data that will be saved to the server when
@@ -749,6 +757,14 @@ function AnnotationController(
 
   vm.user = function() {
     return domainModel.user;
+  }
+
+  /** Sets whether or not the controls for
+   * expanding/collapsing the body of lengthy annotations
+   * should be shown.
+   */
+  vm.setBodyCollapsible = function(canCollapse) {
+    vm.canCollapseBody = canCollapse;
   };
 
   init();

--- a/h/static/scripts/directive/excerpt.js
+++ b/h/static/scripts/directive/excerpt.js
@@ -28,6 +28,14 @@ function ExcerptController() {
   this.showInlineControls = function () {
     return this.overflowing() && this.inlineControls;
   }
+
+  this.bottomShadowStyles = function () {
+    return {
+      'excerpt__shadow': true,
+      'excerpt__shadow--transparent': this.inlineControls,
+      'is-hidden': !this.isExpandable(),
+    };
+  }
 }
 
 function toPx(val) {

--- a/h/static/scripts/directive/excerpt.js
+++ b/h/static/scripts/directive/excerpt.js
@@ -72,9 +72,24 @@ function excerpt($timeout) {
           }
         });
 
-        if (ctrl.onCollapsibleChanged) {
-          ctrl.onCollapsibleChanged({collapsible: ctrl.overflowing()});
+        scope.$watch('vm.overflowing()', function () {
+          if (ctrl.onCollapsibleChanged) {
+            ctrl.onCollapsibleChanged({collapsible: ctrl.overflowing()});
+          }
+        });
+
+        function checkForOverflowChange() {
+          scope.$digest();
         }
+
+        // trigger a recalculation of ctrl.overflowing() and properties
+        // which depend upon it when embedded media loads.
+        //
+        // In future we might wish to trigger checking for other events
+        // outside of Angular's knowledge as well, eg. loading of embedded
+        // media
+        contentElem.addEventListener('load', checkForOverflowChange,
+          true /* capture. 'load' events do not bubble */);
       });
     },
     scope: {

--- a/h/static/scripts/directive/excerpt.js
+++ b/h/static/scripts/directive/excerpt.js
@@ -69,38 +69,36 @@ function excerpt($timeout) {
         return contentElem.scrollHeight > ctrl.collapsedHeight;
       };
 
-      scope.$evalAsync(function () {
-        scope.$watch('vm.enabled()', function (isEnabled) {
-          if (isEnabled) {
-            contentElem = elem[0].querySelector('.excerpt');
+      scope.$watch('vm.enabled()', function (isEnabled) {
+        if (isEnabled) {
+          contentElem = elem[0].querySelector('.excerpt');
 
-            // trigger a recalculation of ctrl.overflowing() and properties
-            // which depend upon it when embedded media loads.
-            //
-            // In future we might wish to trigger checking for other events
-            // outside of Angular's knowledge as well, eg. loading of embedded
-            // media
-            contentElem.addEventListener('load', checkForOverflowChange,
-              true /* capture. 'load' events do not bubble */);
+          // trigger a recalculation of ctrl.overflowing() and properties
+          // which depend upon it when embedded media loads.
+          //
+          // In future we might wish to trigger checking for other events
+          // outside of Angular's knowledge as well, eg. loading of embedded
+          // media
+          contentElem.addEventListener('load', checkForOverflowChange,
+            true /* capture. 'load' events do not bubble */);
 
-            updateContentMaxHeight();
-          } else {
-            contentElem = undefined;
-          }
-        });
-
-        scope.$watch('vm.collapse', function (isCollapsed) {
-          if (!contentElem) {
-            return;
-          }
           updateContentMaxHeight();
-        });
+        } else {
+          contentElem = undefined;
+        }
+      });
 
-        scope.$watch('vm.overflowing()', function () {
-          if (ctrl.onCollapsibleChanged) {
-            ctrl.onCollapsibleChanged({collapsible: ctrl.overflowing()});
-          }
-        });
+      scope.$watch('vm.collapse', function (isCollapsed) {
+        if (!contentElem) {
+          return;
+        }
+        updateContentMaxHeight();
+      });
+
+      scope.$watch('vm.overflowing()', function () {
+        if (ctrl.onCollapsibleChanged) {
+          ctrl.onCollapsibleChanged({collapsible: ctrl.overflowing()});
+        }
       });
     },
     scope: {

--- a/h/static/scripts/directive/excerpt.js
+++ b/h/static/scripts/directive/excerpt.js
@@ -21,7 +21,8 @@ function ExcerptController() {
     return this.overflowing() && !this.collapse;
   };
 
-  this.toggle = function () {
+  this.toggle = function (event) {
+    event.stopPropagation();
     this.collapse = !this.collapse;
   };
 

--- a/h/static/scripts/directive/test/excerpt-test.js
+++ b/h/static/scripts/directive/test/excerpt-test.js
@@ -21,6 +21,10 @@ describe('excerpt directive', function () {
     return util.createDirective(document, 'excerpt', attrs, {}, content);
   }
 
+  function height(el) {
+    return el.querySelector('.excerpt').offsetHeight;
+  }
+
   before(function () {
     angular.module('app', [])
       .directive('excerpt', excerpt.directive);
@@ -49,6 +53,13 @@ describe('excerpt directive', function () {
 
       assert.equal(element.find('.excerpt #foo').length, 0);
       assert.equal(element.find('#foo').length, 1);
+    });
+
+    it('truncates long contents when enabled', function () {
+      var element = excerptDirective({enabled: false}, TALL_DIV);
+      element.scope.enabled = true;
+      element.scope.$digest();
+      assert.isBelow(height(element[0]), 100);
     });
   });
 
@@ -100,10 +111,6 @@ describe('excerpt directive', function () {
   });
 
   describe('.collapse', function () {
-    function height(el) {
-      return el.querySelector('.excerpt').offsetHeight;
-    }
-
     it('collapses the body if collapse is true', function () {
       var element = excerptDirective({collapse: true}, TALL_DIV);
       assert.isBelow(height(element[0]), 100);

--- a/h/static/scripts/directive/test/excerpt-test.js
+++ b/h/static/scripts/directive/test/excerpt-test.js
@@ -1,57 +1,23 @@
 'use strict';
 
+var assign = require('core-js/modules/$.object-assign');
 var util = require('./util');
 var excerpt = require('../excerpt');
 
+describe('excerpt directive', function () {
+  var SHORT_DIV = '<div id="foo" style="height:5px;"></div>';
+  var TALL_DIV =  '<div id="foo" style="height:200px;">foo bar</div>';
 
-describe('excerpt.Controller', function () {
-  var ctrl;
-
-  beforeEach(function() {
-    ctrl = new excerpt.Controller();
-    ctrl.overflowing = function () { return false; };
-  });
-
-  it('starts collapsed if the element is overflowing', function () {
-    ctrl.overflowing = function () { return true; };
-
-    assert.isTrue(ctrl.collapsed());
-  });
-
-  it('does not start collapsed if the element is not overflowing', function () {
-    assert.isFalse(ctrl.collapsed());
-  });
-
-  it('is not initially uncollapsed if the element is overflowing', function () {
-    assert.isFalse(ctrl.uncollapsed());
-  });
-
-  it('is not initially uncollapsed if the element is not overflowing', function () {
-    assert.isFalse(ctrl.uncollapsed());
-  });
-
-  describe('.toggle()', function () {
-    beforeEach(function () {
-      ctrl.overflowing = function () { return true; };
-    });
-
-    it('toggles the collapsed state', function () {
-      var a = ctrl.collapsed();
-      ctrl.toggle();
-      var b = ctrl.collapsed();
-      ctrl.toggle();
-      var c = ctrl.collapsed();
-
-      assert.notEqual(a, b);
-      assert.notEqual(b, c);
-      assert.equal(a, c);
-    });
-  });
-});
-
-
-describe('excerpt.excerpt', function () {
   function excerptDirective(attrs, content) {
+    var defaultAttrs = {
+      // disable animation so that expansion/collapse happens immediately
+      // when the controls are toggled in tests
+      animate: false,
+      enabled: true,
+      collapsedHeight: 40,
+      inlineControls: false,
+    };
+    attrs = assign(defaultAttrs, attrs);
     return util.createDirective(document, 'excerpt', attrs, {}, content);
   }
 
@@ -65,22 +31,111 @@ describe('excerpt.excerpt', function () {
     angular.mock.module('h.templates');
   });
 
-  it('renders its contents in a .excerpt element by default', function () {
-    var element = excerptDirective({}, '<span id="foo"></span>');
+  describe('enabled state', function () {
+    it('renders its contents in a .excerpt element by default', function () {
+      var element = excerptDirective({}, '<span id="foo"></span>');
 
-    assert.equal(element.find('.excerpt #foo').length, 1);
+      assert.equal(element.find('.excerpt #foo').length, 1);
+    });
+
+    it('when enabled, renders its contents in a .excerpt element', function () {
+      var element = excerptDirective({enabled: true}, '<span id="foo"></span>');
+
+      assert.equal(element.find('.excerpt #foo').length, 1);
+    });
+
+    it('when disabled, renders its contents but not in a .excerpt element', function () {
+      var element = excerptDirective({enabled: false}, '<span id="foo"></span>');
+
+      assert.equal(element.find('.excerpt #foo').length, 0);
+      assert.equal(element.find('#foo').length, 1);
+    });
   });
 
-  it('when enabled, renders its contents in a .excerpt element', function () {
-    var element = excerptDirective({enabled: true}, '<span id="foo"></span>');
+  function isHidden(el) {
+    return !el.offsetParent || el.classList.contains('ng-hide');
+  }
 
-    assert.equal(element.find('.excerpt #foo').length, 1);
+  function findVisible(el, selector) {
+    var elements = el.querySelectorAll(selector);
+    for (var i=0; i < elements.length; i++) {
+      if (!isHidden(elements[i])) {
+        return elements[i];
+      }
+    }
+    return undefined;
+  }
+
+  describe('inline controls', function () {
+    function findInlineControl(el) {
+      return findVisible(el, '.excerpt__toggle-link');
+    }
+
+    it('displays inline controls if collapsed', function () {
+      var element = excerptDirective({inlineControls: true},
+        TALL_DIV);
+      element.scope.$digest();
+      var expandLink = findInlineControl(element[0]);
+      assert.ok(expandLink);
+      assert.equal(expandLink.querySelector('a').textContent, 'More');
+    });
+
+    it('does not display inline controls if not collapsed', function () {
+      var element = excerptDirective({inlineControls: true},
+        SHORT_DIV);
+      var expandLink = findInlineControl(element[0]);
+      assert.notOk(expandLink);
+    });
+
+    it('toggles the expanded state when clicked', function () {
+      var element = excerptDirective({inlineControls: true},
+        TALL_DIV);
+      element.scope.$digest();
+      var expandLink = findInlineControl(element[0]);
+      angular.element(expandLink.querySelector('a')).click();
+      element.scope.$digest();
+      var collapseLink = findInlineControl(element[0]);
+      assert.equal(collapseLink.querySelector('a').textContent, 'Less');
+    });
   });
 
-  it('when disabled, renders its contents but not in a .excerpt element', function () {
-    var element = excerptDirective({enabled: false}, '<span id="foo"></span>');
+  describe('.collapse', function () {
+    function height(el) {
+      return el.querySelector('.excerpt').offsetHeight;
+    }
 
-    assert.equal(element.find('.excerpt #foo').length, 0);
-    assert.equal(element.find('#foo').length, 1);
+    it('collapses the body if collapse is true', function () {
+      var element = excerptDirective({collapse: true}, TALL_DIV);
+      assert.isBelow(height(element[0]), 100);
+    });
+
+    it('does not collapse the body if collapse is false', function () {
+      var element = excerptDirective({collapse: false}, TALL_DIV);
+      assert.isAbove(height(element[0]), 100);
+    });
+  });
+
+  describe('.onCollapsibleChanged', function () {
+    it('reports true if excerpt is tall', function () {
+      var callback = sinon.stub();
+      var element = excerptDirective({
+        onCollapsibleChanged: {
+          args: ['collapsible'],
+          callback: callback,
+        }
+      }, TALL_DIV);
+      assert.calledWith(callback, true);
+    });
+
+    it('reports false if excerpt is short', function () {
+      var callback = sinon.stub();
+      var element = excerptDirective({
+        onCollapsibleChanged: {
+          args: ['collapsible'],
+          callback: callback,
+        }
+      }, SHORT_DIV);
+      assert.calledWith(callback, false);
+    });
   });
 });

--- a/h/static/scripts/directive/test/util.js
+++ b/h/static/scripts/directive/test/util.js
@@ -51,15 +51,21 @@ function hyphenate(name) {
  *                                  scope when the element is linked
  * @param {string} [initialHtml] - Initial inner HTML content for the directive
  *                                 element.
+ * @param {Object} [opts] - Object specifying options for creating the
+ *                          directive:
+ *                          'parentElement' - The parent element for the new
+ *                                            directive. Defaults to document.body
  *
  * @return {DOMElement} The Angular jqLite-wrapped DOM element for the component.
  *                      The returned object has a link(scope) method which will
  *                      re-link the component with new properties.
  */
-function createDirective(document, name, attrs, initialScope, initialHtml) {
+function createDirective(document, name, attrs, initialScope, initialHtml, opts) {
   attrs = attrs || {};
   initialScope = initialScope || {};
   initialHtml = initialHtml || '';
+  opts = opts || {};
+  opts.parentElement = opts.parentElement || document.body;
 
   // create a template consisting of a single element, the directive
   // we want to create and compile it
@@ -81,6 +87,11 @@ function createDirective(document, name, attrs, initialScope, initialHtml) {
     templateElement.setAttribute(attrName, attrKey);
   });
   templateElement.innerHTML = initialHtml;
+
+  // add the element to the document's body so that
+  // it responds to events, becomes visible, reports correct
+  // values for its dimensions etc.
+  opts.parentElement.appendChild(templateElement);
 
   // setup initial scope
   Object.keys(attrs).forEach(function (key) {
@@ -105,6 +116,7 @@ function createDirective(document, name, attrs, initialScope, initialHtml) {
     element.link = linkDirective;
     element.scope = childScope;
     childScope.$digest();
+    element.ctrl = element.controller(name);
     return element;
   }
 

--- a/h/static/styles/annotations.scss
+++ b/h/static/styles/annotations.scss
@@ -78,25 +78,6 @@ $annotation-card-left-padding: 10px;
 .annotation-quote-list {
   margin-top: 14px;
   margin-bottom: 14px;
-
-  .excerpt { max-height: 4.8em; }
-  .excerpt-control a {
-    font-style: italic;
-    font-family: $serif-font-family;
-    font-weight: normal;
-  }
-  .excerpt--collapsed:after {
-    height: $base-line-height;
-    @include background(linear-gradient(
-      to right,
-      $mask-start-color,
-      $mask-end-color
-    ));
-  }
-}
-
-.annotation-body {
-  .excerpt { max-height: 16.2em; }
 }
 
 .annotation-media-embed {
@@ -167,7 +148,6 @@ $annotation-card-left-padding: 10px;
     margin-right: 1px;
   }
 }
-
 
 //PRIVACY CONTROL////////////////////////////
 privacy {

--- a/h/static/styles/annotations.scss
+++ b/h/static/styles/annotations.scss
@@ -20,22 +20,16 @@ $annotation-card-left-padding: 10px;
   font-family: $sans-font-family;
   font-weight: 300;
   position: relative;
-
-  .reply-count {
-    color: $gray-light;
-    &:focus { outline: 0; }
-  }
-
-  &:hover .annotation-timestamp, &:hover .reply-count  {
-    color: $link-color;
-  }
 }
 
-.annotation-timestamp {
+.annotation-link {
   font-size: $body1-font-size;
   color: $color-gray;
-  &:hover { color: $link-color-hover; }
   &:focus { outline: 0; }
+
+  .annotation:hover & {
+    color: $link-color;
+  }
 }
 
 .annotation-quote-list,

--- a/h/static/styles/excerpt.scss
+++ b/h/static/styles/excerpt.scss
@@ -1,31 +1,42 @@
-@import "compass/css3/images";
-
 .excerpt {
+  transition: max-height .3s ease-in;
   position: relative;
   overflow: hidden;
 }
 
-.excerpt--collapsed:after {
-  position: absolute;
-  bottom: 0;
-  height: $base-line-height * 2; // This controls the apparent height of the gradient.
-  width: 100%;
-  content: "";
-  pointer-events: none;
-  @include background(linear-gradient(
-    to bottom,
-    $mask-start-color,
-    $mask-end-color
-  ));
-}
-
-.excerpt--uncollapsed {
-  max-height: 100% !important;
-}
-
-.excerpt-control a {
+.excerpt__inline-controls {
   display: block;
-  text-align: right;
-  font-weight: bold;
-  width: 100%;
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  pointer-events: none;
+}
+
+.excerpt__toggle-link {
+  pointer-events: auto;
+  padding-left: 15px;
+  background-image: linear-gradient(to right, transparent 0px, white 12px);
+}
+
+.excerpt__toggle-link > a {
+  color: $text-color;
+  font-style: italic;
+  font-weight: normal;
+}
+
+// a shadow displayed at the bottom of an <excerpt>s with inline controls
+// disabled, which provides a hint that the excerpt is collapsed
+.excerpt__shadow {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 20px;
+  background-image: linear-gradient(to bottom,
+    transparent 0%, rgba(0,0,0,0.10) 90%, rgba(0,0,0,0.15) 100%);
+  transition: opacity .3s linear;
+}
+
+.excerpt__shadow.is-hidden {
+  opacity: 0;
 }

--- a/h/static/styles/excerpt.scss
+++ b/h/static/styles/excerpt.scss
@@ -1,42 +1,66 @@
-.excerpt {
-  transition: max-height .3s ease-in;
-  position: relative;
-  overflow: hidden;
-}
+@at-root {
+  $expand-duration: .15s;
 
-.excerpt__inline-controls {
-  display: block;
-  position: absolute;
-  right: 0;
-  bottom: 0;
-  pointer-events: none;
-}
+  // the truncated body of the <excerpt>
+  .excerpt {
+    transition: max-height $expand-duration ease-in;
+    overflow: hidden;
+  }
 
-.excerpt__toggle-link {
-  pointer-events: auto;
-  padding-left: 15px;
-  background-image: linear-gradient(to right, transparent 0px, white 12px);
-}
+  // a container which wraps the <excerpt> and contains the excerpt
+  // itself plus the shadow at the bottom that can be clicked to expand or
+  // collapse it
+  .excerpt__container {
+    position: relative;
+  }
 
-.excerpt__toggle-link > a {
-  color: $text-color;
-  font-style: italic;
-  font-weight: normal;
-}
+  // inline controls for expanding and collapsing
+  // the <excerpt>
+  // -------------
+  .excerpt__inline-controls {
+    display: block;
+    position: absolute;
+    right: 0;
+    bottom: 0;
+    pointer-events: none;
+  }
 
-// a shadow displayed at the bottom of an <excerpt>s with inline controls
-// disabled, which provides a hint that the excerpt is collapsed
-.excerpt__shadow {
-  position: absolute;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  height: 20px;
-  background-image: linear-gradient(to bottom,
-    transparent 0%, rgba(0,0,0,0.10) 90%, rgba(0,0,0,0.15) 100%);
-  transition: opacity .3s linear;
-}
+  .excerpt__toggle-link {
+    pointer-events: auto;
+    padding-left: 15px;
+    background-image: linear-gradient(to right, transparent 0px, white 12px);
+  }
 
-.excerpt__shadow.is-hidden {
-  opacity: 0;
+  .excerpt__toggle-link > a {
+    color: $text-color;
+    font-style: italic;
+    font-weight: normal;
+  }
+
+
+  // a shadow displayed at the bottom of an <excerpt>s with inline controls
+  // disabled, which provides a hint that the excerpt is collapsed
+  // -------------
+
+  // the distance by which the shadow indicating a collapsed
+  // annotation expands beyond the left/right edges of the card.
+  // This value is chosen such that the shadow expands to the full width of
+  // the card
+  $shadow-h-offset: -12px;
+
+  .excerpt__shadow {
+    position: absolute;
+    left: $shadow-h-offset;
+    right: $shadow-h-offset;
+    bottom: 0;
+    height: 40px;
+    background-image: linear-gradient(to bottom,
+      transparent 50%, rgba(0,0,0,0.08) 95%, rgba(0,0,0,0.13) 100%);
+    transition: opacity $expand-duration linear;
+  }
+
+  .excerpt__shadow.is-hidden {
+    opacity: 0;
+    pointer-events: none;
+  }
 }

--- a/h/static/styles/excerpt.scss
+++ b/h/static/styles/excerpt.scss
@@ -57,6 +57,10 @@
     transition: opacity $expand-duration linear;
   }
 
+  .excerpt__shadow--transparent {
+    background-image: none;
+  }
+
   .excerpt__shadow.is-hidden {
     opacity: 0;
     pointer-events: none;

--- a/h/static/styles/excerpt.scss
+++ b/h/static/styles/excerpt.scss
@@ -22,11 +22,9 @@
     position: absolute;
     right: 0;
     bottom: 0;
-    pointer-events: none;
   }
 
   .excerpt__toggle-link {
-    pointer-events: auto;
     padding-left: 15px;
     background-image: linear-gradient(to right, transparent 0px, white 12px);
   }

--- a/h/static/styles/util.scss
+++ b/h/static/styles/util.scss
@@ -3,6 +3,11 @@
   flex-grow: 1;
 }
 
+.u-layout-row {
+  display: flex;
+  flex-direction: row;
+}
+
 .u-center {
   margin-left: auto;
   margin-right: auto;
@@ -12,4 +17,8 @@
   display: flex;
   flex-direction: row;
   justify-content: flex-end;
+}
+
+.u-strong {
+  font-weight: bold;
 }

--- a/h/templates/client/annotation.html
+++ b/h/templates/client/annotation.html
@@ -14,7 +14,7 @@
       </span>
 
       <span class="annotation-collapsed-replies">
-        <a class="reply-count small" href=""
+        <a class="annotation-link" href=""
           ng-click="replyCountClick()"
           ng-pluralize count="replyCount"
           when="{'0': '', 'one': '1 reply', 'other': '{} replies'}"></a>
@@ -45,7 +45,7 @@
     <span class="u-flex-spacer"></span>
 
     <!-- Timestamp -->
-    <a class="annotation-timestamp"
+    <a class="annotation-link"
        target="_blank"
        title="{{vm.updatedString()}}"
        ng-if="!vm.editing() && vm.updated()"
@@ -108,7 +108,7 @@
       </li>
     </ul>
     <div class="u-stretch"></div>
-    <a class="u-strong" ng-show="vm.canCollapseBody"
+    <a class="annotation-link u-strong" ng-show="vm.canCollapseBody"
        ng-click="vm.collapseBody = !vm.collapseBody"
        ng-title="vm.collapseBody ? 'Show the full annotation text' : 'Show the first few lines only'"
        ng-bind="vm.collapseBody ? 'More' : 'Less'"></a>
@@ -141,7 +141,7 @@
     </div>
 
     <div class="annotation-replies" ng-if="replyCount > 0">
-      <a class="reply-count small" href=""
+      <a class="annotation-link" href=""
          ng-click="replyCountClick()"
          ng-pluralize count="replyCount"
          when="{'0': '', 'one': '1 reply', 'other': '{} replies'}"></a>

--- a/h/templates/client/annotation.html
+++ b/h/templates/client/annotation.html
@@ -109,7 +109,7 @@
     </ul>
     <div class="u-stretch"></div>
     <a class="annotation-link u-strong" ng-show="vm.canCollapseBody"
-       ng-click="vm.collapseBody = !vm.collapseBody"
+       ng-click="vm.toggleCollapseBody($event)"
        ng-title="vm.collapseBody ? 'Show the full annotation text' : 'Show the first few lines only'"
        ng-bind="vm.collapseBody ? 'More' : 'Less'"></a>
   </div>

--- a/h/templates/client/annotation.html
+++ b/h/templates/client/annotation.html
@@ -110,6 +110,7 @@
     <div class="u-stretch"></div>
     <a class="u-strong" ng-show="vm.canCollapseBody"
        ng-click="vm.collapseBody = !vm.collapseBody"
+       ng-title="vm.collapseBody ? 'Show the full annotation text' : 'Show the first few lines only'"
        ng-bind="vm.collapseBody ? 'More' : 'Less'"></a>
   </div>
   <!-- / Tags -->

--- a/h/templates/client/annotation.html
+++ b/h/templates/client/annotation.html
@@ -57,7 +57,9 @@
   <section class="annotation-quote-list"
            ng-repeat="target in vm.target() track by $index"
            ng-if="vm.hasQuotes()">
-    <excerpt enabled="vm.feature('truncate_annotations')">
+    <excerpt enabled="vm.feature('truncate_annotations')"
+             collapsed-height="40"
+             inline-controls="true">
       <blockquote class="annotation-quote"
                   ng-bind-html="selector.exact"
                   ng-repeat="selector in target.selector
@@ -70,7 +72,11 @@
 
   <!-- Body -->
   <section name="text" class="annotation-body">
-    <excerpt enabled="vm.feature('truncate_annotations') && !vm.editing()">
+    <excerpt enabled="vm.feature('truncate_annotations') && !vm.editing()"
+             inline-controls="false"
+             on-collapsible-changed="vm.setBodyCollapsible(collapsible)"
+             collapse="vm.collapseBody"
+             collapsed-height="200">
       <markdown ng-model="vm.form.text"
                 read-only="!vm.editing()"
                 embeds-enabled="vm.feature('embed_media')">
@@ -94,13 +100,17 @@
     </tags-input>
   </div>
 
-  <div class="annotation-body tags tags-read-only"
-       ng-if="vm.form.tags.length && !vm.editing()">
+  <div class="annotation-body u-layout-row tags tags-read-only"
+       ng-if="(vm.canCollapseBody || vm.form.tags.length) && !vm.editing()">
     <ul class="tag-list">
       <li class="tag-item" ng-repeat="tag in vm.form.tags">
         <a href="/stream?q=tag:'{{tag.text|urlencode}}'" target="_blank">{{tag.text}}</a>
       </li>
     </ul>
+    <div class="u-stretch"></div>
+    <a class="u-strong" ng-show="vm.canCollapseBody"
+       ng-click="vm.collapseBody = !vm.collapseBody"
+       ng-bind="vm.collapseBody ? 'More' : 'Less'"></a>
   </div>
   <!-- / Tags -->
 

--- a/h/templates/client/excerpt.html
+++ b/h/templates/client/excerpt.html
@@ -9,12 +9,12 @@
             title="Show the full excerpt">More</a>
       </span>
       <span class="excerpt__toggle-link" ng-show="vm.isCollapsible()">
-        <a ng-click="vm.toggle()"
+        <a ng-click="vm.toggle($event)"
             title="Show the first few lines only">Less</a>
       </span>
     </div>
   </div>
-  <div ng-click="vm.toggle()"
+  <div ng-click="vm.toggle($event)"
        ng-class="vm.bottomShadowStyles()"
        title="Show the full excerpt"></div>
 </div>

--- a/h/templates/client/excerpt.html
+++ b/h/templates/client/excerpt.html
@@ -1,12 +1,18 @@
 <div ng-transclude ng-if="!vm.enabled()"></div>
-<div ng-if="vm.enabled()">
-  <div class="excerpt"
-       ng-class="{'excerpt--uncollapsed': vm.uncollapsed(),
-                  'excerpt--collapsed': vm.collapsed()}"
-       ng-transclude></div>
-
-  <div class="excerpt-control">
-    <a ng-if="vm.collapsed()" ng-click="vm.toggle()">More</a>
-    <a ng-if="vm.uncollapsed()" ng-click="vm.toggle()">Less</a>
+<div class="excerpt" ng-if="vm.enabled()">
+  <div ng-transclude></div>
+  <div class="excerpt__inline-controls"
+       ng-show="vm.showInlineControls()">
+    <span class="excerpt__toggle-link" ng-show="vm.isExpandable()">
+      … <a ng-click="vm.toggle()"
+          title="Show the full excerpt">More</a>
+    </span>
+    <span class="excerpt__toggle-link" ng-show="vm.isCollapsible()">
+      <a ng-click="vm.toggle()"
+          title="Show the first few lines only">Less</a>
+    </span>
   </div>
+  <div class="excerpt__shadow"
+       ng-class="{'is-hidden' : !vm.isExpandable()}"
+       ng-if="!vm.inlineControls"></div>
 </div>

--- a/h/templates/client/excerpt.html
+++ b/h/templates/client/excerpt.html
@@ -14,9 +14,7 @@
       </span>
     </div>
   </div>
-  <div class="excerpt__shadow"
-       ng-click="vm.toggle()"
-       ng-class="{'is-hidden' : !vm.isExpandable()}"
-       ng-if="!vm.inlineControls"
+  <div ng-click="vm.toggle()"
+       ng-class="vm.bottomShadowStyles()"
        title="Show the full excerpt"></div>
 </div>

--- a/h/templates/client/excerpt.html
+++ b/h/templates/client/excerpt.html
@@ -1,18 +1,22 @@
 <div ng-transclude ng-if="!vm.enabled()"></div>
-<div class="excerpt" ng-if="vm.enabled()">
-  <div ng-transclude></div>
-  <div class="excerpt__inline-controls"
-       ng-show="vm.showInlineControls()">
-    <span class="excerpt__toggle-link" ng-show="vm.isExpandable()">
-      … <a ng-click="vm.toggle()"
-          title="Show the full excerpt">More</a>
-    </span>
-    <span class="excerpt__toggle-link" ng-show="vm.isCollapsible()">
-      <a ng-click="vm.toggle()"
-          title="Show the first few lines only">Less</a>
-    </span>
+<div class="excerpt__container" ng-if="vm.enabled()">
+  <div class="excerpt">
+    <div ng-transclude></div>
+    <div class="excerpt__inline-controls"
+         ng-show="vm.showInlineControls()">
+      <span class="excerpt__toggle-link" ng-show="vm.isExpandable()">
+        … <a ng-click="vm.toggle()"
+            title="Show the full excerpt">More</a>
+      </span>
+      <span class="excerpt__toggle-link" ng-show="vm.isCollapsible()">
+        <a ng-click="vm.toggle()"
+            title="Show the first few lines only">Less</a>
+      </span>
+    </div>
   </div>
   <div class="excerpt__shadow"
+       ng-click="vm.toggle()"
        ng-class="{'is-hidden' : !vm.isExpandable()}"
-       ng-if="!vm.inlineControls"></div>
+       ng-if="!vm.inlineControls"
+       title="Show the full excerpt"></div>
 </div>

--- a/h/templates/client/excerpt.html
+++ b/h/templates/client/excerpt.html
@@ -1,6 +1,6 @@
 <div ng-transclude ng-if="!vm.enabled()"></div>
 <div class="excerpt__container" ng-if="vm.enabled()">
-  <div class="excerpt">
+  <div class="excerpt" ng-style="vm.contentStyle()">
     <div ng-transclude></div>
     <div class="excerpt__inline-controls"
          ng-show="vm.showInlineControls()">

--- a/h/templates/client/excerpt.html
+++ b/h/templates/client/excerpt.html
@@ -5,7 +5,7 @@
     <div class="excerpt__inline-controls"
          ng-show="vm.showInlineControls()">
       <span class="excerpt__toggle-link" ng-show="vm.isExpandable()">
-        … <a ng-click="vm.toggle()"
+        … <a ng-click="vm.toggle($event)"
             title="Show the full excerpt">More</a>
       </span>
       <span class="excerpt__toggle-link" ng-show="vm.isCollapsible()">


### PR DESCRIPTION
This updates the design of truncated annotation cards following https://trello.com/c/Jg0NWyF3/158-update-design-for-truncated-annotations and discussion with Conor.

**User-visible changes**

 * The card has been made more compact by moving the expansion controls for quotes inline with
   the last line of the quote itself, showing only two lines of the quote when collapsed and
   moving the expansion control for the body into the tags line
 * Added an animation when expanding and collapsing the card
 * Make expanding annotation bodies easier by providing a large clickable area at the bottom
   of the card which expands the body when clicked

![t158-updated-trunc-design](https://cloud.githubusercontent.com/assets/2458/11840417/aa637b08-a3ed-11e5-9c95-917b10839c1f.png)

**Implementation changes**
 * The changes to the `<excerpt>` component are to give it two modes - one which provide inline controls to handle expansion/collapse and another which allows the containing directive to provide
those controls.
 * I've removed the controller tests and intend to only implement tests at the directive level,
   based on the fact that I went through about 3 different approaches to the implementation
   which had almost the same external interface but changed the internals completely.

---

**TODO**
- [x] Make expanding the quote easier but adding a hit target across the whole of the bottom of the quote, for ease of use and consistency with how the annotation body behaves.
- [x] 'More' link for annotation body should be grey when the card lacks focus
- [x] 'More' / 'Less' link state for annotation body not correct immediately after switching from edit to view mode
- [x] Fix cut-off when excerpt expands from one height to another and results in the document gaining a vertical scrollbar as a result (_Fixed in the sense that the height will be corrected after the next digest cycle after the scrollbar appears_)

**Needs additional testing**
(These issues I haven't yet been able to reproduce exactly as in https://github.com/hypothesis/h/pull/2802#issuecomment-165434711 , but a couple of the above issues were due to not using data-binding properly, and the second/third of these might be related to that)
- Investigate drop shadow not spanning full width in [Nick's screenshot](https://cloud.githubusercontent.com/assets/3602/11869132/48838c36-a4bd-11e5-85a8-7652b797756b.png)
- Investigate 'More' link being shown redundantly on a body that didn't need collapsing
- Investigate body not being collapsed (even though it should have been) and 'More' link still showing

