### PR TITLE
Decouple password reset flow from account activation

### DIFF
--- a/h/accounts/__init__.py
+++ b/h/accounts/__init__.py
@@ -1,4 +1,8 @@
 # -*- coding: utf-8 -*-
+from itsdangerous import URLSafeTimedSerializer
+
+from ..security import derive_key
+
 from h import util
 from h.accounts import models
 
@@ -96,3 +100,8 @@ def includeme(config):
     config.include('.schemas')
     config.include('.subscribers')
     config.include('.views')
+
+    secret = config.registry.settings['secret_key']
+    derived = derive_key(secret, b'h.accounts')
+    serializer = URLSafeTimedSerializer(derived)
+    config.registry.password_reset_serializer = serializer

--- a/h/accounts/__init__.py
+++ b/h/accounts/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from itsdangerous import URLSafeTimedSerializer
 
-from ..security import derive_key
+from h.security import derive_key
 
 from h import util
 from h.accounts import models

--- a/h/accounts/models.py
+++ b/h/accounts/models.py
@@ -131,10 +131,10 @@ class User(Base):
     # Password salt
     salt = sa.Column(sa.UnicodeText(), nullable=False)
     # Last password update
-    last_password_update = sa.Column(sa.DateTime(timezone=False),
+    last_password_update = sa.Column(sa.DateTime(),
                                      default=sa.sql.func.now(),
                                      server_default=sa.func.now(),
-                                     nullable=True)
+                                     nullable=False)
 
     @hybrid_property
     def password(self):

--- a/h/accounts/models.py
+++ b/h/accounts/models.py
@@ -131,10 +131,10 @@ class User(Base):
     # Password salt
     salt = sa.Column(sa.UnicodeText(), nullable=False)
     # Last password update
-    last_password_update = sa.Column(sa.DateTime(),
-                                     default=sa.sql.func.now(),
-                                     server_default=sa.func.now(),
-                                     nullable=False)
+    password_updated = sa.Column(sa.DateTime(),
+                                 default=sa.sql.func.now(),
+                                 server_default=sa.func.now(),
+                                 nullable=False)
 
     @hybrid_property
     def password(self):
@@ -152,7 +152,7 @@ class User(Base):
             raise ValueError('password must be more than {min} characters '
                              'long'.format(min=PASSWORD_MIN_LENGTH))
         self._password = self._hash_password(raw_password)
-        self.last_password_update = sa.sql.func.now()
+        self.password_updated = sa.sql.func.now()
 
     def _hash_password(self, password):
         if not self.salt:

--- a/h/accounts/models.py
+++ b/h/accounts/models.py
@@ -133,7 +133,7 @@ class User(Base):
     # Last password update
     password_updated = sa.Column(sa.DateTime(),
                                  default=sa.sql.func.now(),
-                                 server_default=sa.func.now(),
+                                 server_default=sa.sql.func.now(),
                                  nullable=False)
 
     @hybrid_property

--- a/h/accounts/models.py
+++ b/h/accounts/models.py
@@ -32,7 +32,7 @@ def _generate_random_string(length=12):
 class Activation(Base):
 
     """
-    Handles activations/password reset items for users.
+    Handles activations for users.
 
     The code should be a random hash that is valid only once.
     After the hash is used to access the site, it'll be removed.
@@ -130,6 +130,11 @@ class User(Base):
     _password = sa.Column('password', sa.UnicodeText(), nullable=False)
     # Password salt
     salt = sa.Column(sa.UnicodeText(), nullable=False)
+    # Last password update
+    last_password_update = sa.Column(sa.DateTime(timezone=False),
+                                     default=sa.sql.func.now(),
+                                     server_default=sa.func.now(),
+                                     nullable=True)
 
     @hybrid_property
     def password(self):
@@ -147,6 +152,7 @@ class User(Base):
             raise ValueError('password must be more than {min} characters '
                              'long'.format(min=PASSWORD_MIN_LENGTH))
         self._password = self._hash_password(raw_password)
+        self.last_password_update = sa.sql.func.now()
 
     def _hash_password(self, password):
         if not self.salt:

--- a/h/accounts/schemas.py
+++ b/h/accounts/schemas.py
@@ -217,7 +217,7 @@ class ResetCode(colander.SchemaType):
         user = models.User.get_by_username(username)
         if user is None:
             raise colander.Invalid(node, _('Your reset code is not valid'))
-        if timestamp < user.last_password_update:
+        if timestamp < user.password_updated:
             raise colander.Invalid(node,
                                    _('You have already reset your password'))
         return user

--- a/h/accounts/schemas.py
+++ b/h/accounts/schemas.py
@@ -193,9 +193,9 @@ class ResetCode(colander.SchemaType):
             return colander.null
         if not isinstance(appstruct, models.User):
             raise colander.Invalid(node, '%r is not a User' % appstruct)
-        if not isinstance(appstruct.activation, models.Activation):
-            raise colander.Invalid(node, '%r has no Activation' % appstruct)
-        return appstruct.activation.code
+        request = node.bindings['request']
+        serializer = request.registry.password_reset_serializer
+        return serializer.dumps(appstruct.username)
 
     def deserialize(self, node, cstruct):
         if cstruct is colander.null:

--- a/h/accounts/schemas.py
+++ b/h/accounts/schemas.py
@@ -217,7 +217,7 @@ class ResetCode(colander.SchemaType):
         user = models.User.get_by_username(username)
         if user is None:
             raise colander.Invalid(node, _('Your reset code is not valid'))
-        if timestamp < user.password_updated:
+        if user.password_updated is not None and timestamp < user.password_updated:
             raise colander.Invalid(node,
                                    _('You have already reset your password'))
         return user

--- a/h/accounts/schemas.py
+++ b/h/accounts/schemas.py
@@ -200,10 +200,12 @@ class ResetCode(colander.SchemaType):
     def deserialize(self, node, cstruct):
         if cstruct is colander.null:
             return colander.null
-        activation = models.Activation.get_by_code(cstruct)
-        if activation is not None:
-            user = models.User.get_by_activation(activation)
-        if activation is None or user is None:
+
+        request = node.bindings['request']
+        serializer = request.registry.password_reset_serializer
+        username = serializer.loads(cstruct, max_age=72*3600)
+        user = models.User.get_by_username(username)
+        if user is None:
             raise colander.Invalid(node, _('Your reset code is not valid'))
         return user
 

--- a/h/accounts/test/schemas_test.py
+++ b/h/accounts/test/schemas_test.py
@@ -265,7 +265,7 @@ def test_reset_password_user_has_already_reset_their_password(config, user_model
     request.registry.password_reset_serializer = FakeSerializer()
     schema = schemas.ResetPasswordSchema().bind(request=request)
     user = user_model.get_by_username.return_value
-    user.last_password_update = 2
+    user.password_updated = 2
 
     with pytest.raises(colander.Invalid) as exc:
         schema.deserialize({
@@ -283,7 +283,7 @@ def test_reset_password_adds_user_to_appstruct(config, user_model):
     request.registry.password_reset_serializer = FakeSerializer()
     schema = schemas.ResetPasswordSchema().bind(request=request)
     user = user_model.get_by_username.return_value
-    user.last_password_update = 0
+    user.password_updated = 0
 
     appstruct = schema.deserialize({
         'user': 'abc123',

--- a/h/accounts/test/schemas_test.py
+++ b/h/accounts/test/schemas_test.py
@@ -14,6 +14,14 @@ class DummyNode(object):
     pass
 
 
+class FakeSerializer(object):
+    def dumps(self, obj):
+        return 'faketoken'
+
+    def loads(self, token, max_age=0):
+        return {'username': 'foo@bar.com'}
+
+
 def csrf_request(config, **kwargs):
     request = DummyRequest(registry=config.registry, **kwargs)
     request.headers['X-CSRF-Token'] = request.session.get_csrf_token()
@@ -211,6 +219,7 @@ def test_forgot_password_adds_user_to_appstruct(config, user_model):
 @pytest.mark.usefixtures('user_model')
 def test_reset_password_no_activation(config, activation_model):
     request = csrf_request(config)
+    request.registry.password_reset_serializer = FakeSerializer()
     schema = schemas.ResetPasswordSchema().bind(request=request)
     activation_model.get_by_code.return_value = None
 
@@ -227,6 +236,7 @@ def test_reset_password_no_activation(config, activation_model):
 @pytest.mark.usefixtures('activation_model')
 def test_reset_password_no_user_for_activation(config, user_model):
     request = csrf_request(config)
+    request.registry.password_reset_serializer = FakeSerializer()
     schema = schemas.ResetPasswordSchema().bind(request=request)
     user_model.get_by_activation.return_value = None
 
@@ -244,6 +254,7 @@ def test_reset_password_adds_user_to_appstruct(config,
                                                activation_model,
                                                user_model):
     request = csrf_request(config)
+    request.registry.password_reset_serializer = FakeSerializer()
     schema = schemas.ResetPasswordSchema().bind(request=request)
     user = user_model.get_by_activation.return_value
 

--- a/h/accounts/test/schemas_test.py
+++ b/h/accounts/test/schemas_test.py
@@ -251,12 +251,11 @@ def test_reset_password_no_user_for_activation(config, user_model):
 
 
 def test_reset_password_adds_user_to_appstruct(config,
-                                               activation_model,
                                                user_model):
     request = csrf_request(config)
     request.registry.password_reset_serializer = FakeSerializer()
     schema = schemas.ResetPasswordSchema().bind(request=request)
-    user = user_model.get_by_activation.return_value
+    user = user_model.get_by_username.return_value
 
     appstruct = schema.deserialize({
         'user': 'abc123',

--- a/h/accounts/test/views_test.py
+++ b/h/accounts/test/views_test.py
@@ -47,6 +47,14 @@ class FakeUser(object):
             setattr(self, k, kwargs[k])
 
 
+class FakeSerializer(object):
+    def dumps(self, obj):
+        return 'faketoken'
+
+    def loads(self, token):
+        return {'username': 'foo@bar.com'}
+
+
 # A fake version of colander.Invalid
 class FakeInvalid(object):
     def __init__(self, errors):
@@ -339,37 +347,33 @@ def test_forgot_password_creates_no_activations_when_validation_fails(activation
 
 
 @forgot_password_fixtures
-def test_forgot_password_creates_activation_for_user(activation_model,
-                                                     authn_policy):
+def test_forgot_password_create_no_activation_for_user(activation_model,
+                                                       authn_policy):
     request = DummyRequest(method='POST')
+    request.registry.password_reset_serializer = FakeSerializer()
     authn_policy.authenticated_userid.return_value = None
-    activation = activation_model.return_value
     user = FakeUser(username='giraffe', email='giraffe@thezoo.org')
     controller = ForgotPasswordController(request)
     controller.form = form_validating_to({"user": user})
 
     controller.forgot_password()
 
-    activation_model.assert_called_with()
-    assert activation in request.db.added
-    assert user.activation == activation
+    assert activation_model.call_count == 0
 
 
 @patch('h.accounts.views.reset_password_link')
 @forgot_password_fixtures
-def test_forgot_password_generates_reset_link_from_activation(reset_link,
-                                                              activation_model,
-                                                              authn_policy):
+def test_forgot_password_generates_reset_link(reset_link, authn_policy):
     request = DummyRequest(method='POST')
+    request.registry.password_reset_serializer = FakeSerializer()
     authn_policy.authenticated_userid.return_value = None
     user = FakeUser(username='giraffe', email='giraffe@thezoo.org')
     controller = ForgotPasswordController(request)
     controller.form = form_validating_to({"user": user})
-    activation_model.return_value.code = "abcde12345"
 
     controller.forgot_password()
 
-    reset_link.assert_called_with(request, "abcde12345")
+    reset_link.assert_called_with(request, "faketoken")
 
 
 @patch('h.accounts.views.reset_password_email')
@@ -380,22 +384,23 @@ def test_forgot_password_generates_mail(reset_link,
                                         activation_model,
                                         authn_policy):
     request = DummyRequest(method='POST')
+    request.registry.password_reset_serializer = FakeSerializer()
     authn_policy.authenticated_userid.return_value = None
     user = FakeUser(username='giraffe', email='giraffe@thezoo.org')
     controller = ForgotPasswordController(request)
     controller.form = form_validating_to({"user": user})
-    activation_model.return_value.code = "abcde12345"
     reset_link.return_value = "http://example.com"
 
     controller.forgot_password()
 
-    reset_mail.assert_called_with(user, "abcde12345", "http://example.com")
+    reset_mail.assert_called_with(user, "faketoken", "http://example.com")
 
 
 @patch('h.accounts.views.reset_password_email')
 @forgot_password_fixtures
 def test_forgot_password_sends_mail(reset_mail, authn_policy, mailer):
     request = DummyRequest(method='POST')
+    request.registry.password_reset_serializer = FakeSerializer()
     authn_policy.authenticated_userid.return_value = None
     user = FakeUser(username='giraffe', email='giraffe@thezoo.org')
     controller = ForgotPasswordController(request)
@@ -410,6 +415,7 @@ def test_forgot_password_sends_mail(reset_mail, authn_policy, mailer):
 @forgot_password_fixtures
 def test_forgot_password_redirects_on_success(authn_policy):
     request = DummyRequest(method='POST')
+    request.registry.password_reset_serializer = FakeSerializer()
     authn_policy.authenticated_userid.return_value = None
     user = FakeUser(username='giraffe', email='giraffe@thezoo.org')
     controller = ForgotPasswordController(request)
@@ -454,20 +460,6 @@ def test_reset_password_sets_user_password_from_form():
     controller.reset_password()
 
     assert elephant.password == 's3cure!'
-
-
-@reset_password_fixtures
-def test_reset_password_deletes_activation():
-    request = DummyRequest(method='POST')
-    user = FakeUser(password='password1')
-    user.activation = mock.sentinel.activation
-    controller = ResetPasswordController(request)
-    controller.form = form_validating_to({'user': user,
-                                          'password': 's3cure!'})
-
-    controller.reset_password()
-
-    assert mock.sentinel.activation in request.db.deleted
 
 
 @patch('h.accounts.views.PasswordResetEvent', autospec=True)

--- a/h/accounts/test/views_test.py
+++ b/h/accounts/test/views_test.py
@@ -346,21 +346,6 @@ def test_forgot_password_creates_no_activations_when_validation_fails(activation
     assert activation_model.call_count == 0
 
 
-@forgot_password_fixtures
-def test_forgot_password_create_no_activation_for_user(activation_model,
-                                                       authn_policy):
-    request = DummyRequest(method='POST')
-    request.registry.password_reset_serializer = FakeSerializer()
-    authn_policy.authenticated_userid.return_value = None
-    user = FakeUser(username='giraffe', email='giraffe@thezoo.org')
-    controller = ForgotPasswordController(request)
-    controller.form = form_validating_to({"user": user})
-
-    controller.forgot_password()
-
-    assert activation_model.call_count == 0
-
-
 @patch('h.accounts.views.reset_password_link')
 @forgot_password_fixtures
 def test_forgot_password_generates_reset_link(reset_link, authn_policy):

--- a/h/accounts/views.py
+++ b/h/accounts/views.py
@@ -12,7 +12,6 @@ from pyramid.view import view_config, view_defaults
 from pyramid.security import forget, remember
 from pyramid_mailer import get_mailer
 from pyramid_mailer.message import Message
-from itsdangerous import BadSignature
 
 from h import i18n
 from h import models

--- a/h/accounts/views.py
+++ b/h/accounts/views.py
@@ -12,6 +12,7 @@ from pyramid.view import view_config, view_defaults
 from pyramid.security import forget, remember
 from pyramid_mailer import get_mailer
 from pyramid_mailer.message import Message
+from itsdangerous import BadSignature
 
 from h import i18n
 from h import models
@@ -284,8 +285,10 @@ class ResetPasswordController(object):
         # If valid, we inject the supplied it into the form as a hidden field.
         # Otherwise, we 404.
         try:
-            user = schemas.ResetCode().deserialize(None, code)
+            user = schemas.ResetCode().deserialize(self.schema, code)
         except colander.Invalid:
+            raise httpexceptions.HTTPNotFound()
+        except BadSignature:
             raise httpexceptions.HTTPNotFound()
         else:
             # N.B. the form field for the reset code is called 'user'. See the

--- a/h/accounts/views.py
+++ b/h/accounts/views.py
@@ -288,8 +288,6 @@ class ResetPasswordController(object):
             user = schemas.ResetCode().deserialize(self.schema, code)
         except colander.Invalid:
             raise httpexceptions.HTTPNotFound()
-        except BadSignature:
-            raise httpexceptions.HTTPNotFound()
         else:
             # N.B. the form field for the reset code is called 'user'. See the
             # comment in `schemas.ResetPasswordSchema` for details.

--- a/h/accounts/views.py
+++ b/h/accounts/views.py
@@ -285,7 +285,7 @@ class ResetPasswordController(object):
         # If valid, we inject the supplied it into the form as a hidden field.
         # Otherwise, we 404.
         try:
-            user = schemas.ResetCode().deserialize(self.schema, code)
+            user = schemas.ResetCode().deserialize(None, code)
         except colander.Invalid:
             raise httpexceptions.HTTPNotFound()
         else:

--- a/h/migrations/versions/42bd46b9b1ea_fill_in_missing_password_updated_fields.py
+++ b/h/migrations/versions/42bd46b9b1ea_fill_in_missing_password_updated_fields.py
@@ -1,0 +1,41 @@
+"""fill in missing password_updated fields
+
+Revision ID: 42bd46b9b1ea
+Revises: 43e7c4ed2fd7
+Create Date: 2016-01-07 14:20:44.094611
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '42bd46b9b1ea'
+down_revision = '530268a1937c'
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.orm import sessionmaker
+
+from h import pubid
+
+Session = sessionmaker()
+
+group = sa.table('user',
+                 sa.column('id', sa.Integer),
+                 sa.column('password_updated', sa.DateTime))
+
+
+def upgrade():
+    bind = op.get_bind()
+    session = Session(bind=bind)
+
+    # Add the password_updated field to each row lacking one.
+    # This is O(N) but does not lock the whole table.
+    for id_, _ in session.query(group).all():
+        op.execute(group.update().
+                   where(group.c.id == id_).
+                   where(group.c.password_updated == None).
+                   values(password_updated=sa.func.now()))
+
+
+def downgrade():
+    # Nothing to do here.
+    pass

--- a/h/migrations/versions/43e7c4ed2fd7_make_user_password_updated_non_nullable.py
+++ b/h/migrations/versions/43e7c4ed2fd7_make_user_password_updated_non_nullable.py
@@ -1,0 +1,22 @@
+"""make user password_updated non-nullable
+
+Revision ID: 43e7c4ed2fd7
+Revises: 530268a1937c
+Create Date: 2015-12-22 15:48:14.867487
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '43e7c4ed2fd7'
+down_revision = '530268a1937c'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.alter_column('user', 'password_updated', nullable=False)
+
+
+def downgrade():
+    op.alter_column('user', 'password_updated', nullable=True)

--- a/h/migrations/versions/43e7c4ed2fd7_make_user_password_updated_non_nullable.py
+++ b/h/migrations/versions/43e7c4ed2fd7_make_user_password_updated_non_nullable.py
@@ -8,7 +8,7 @@ Create Date: 2015-12-22 15:48:14.867487
 
 # revision identifiers, used by Alembic.
 revision = '43e7c4ed2fd7'
-down_revision = '530268a1937c'
+down_revision = '42bd46b9b1ea'
 
 from alembic import op
 import sqlalchemy as sa

--- a/h/migrations/versions/530268a1937c_add_password_last_updated_column_to_.py
+++ b/h/migrations/versions/530268a1937c_add_password_last_updated_column_to_.py
@@ -17,8 +17,8 @@ import sqlalchemy as sa
 def upgrade():
     op.add_column('user', sa.Column('password_updated',
                                     sa.DateTime(),
-                                    server_default=sa.func.now(),
                                     nullable=True))
+    op.alter_column('user', 'password_updated', server_default=sa.func.now())
 
 
 def downgrade():

--- a/h/migrations/versions/530268a1937c_add_password_last_updated_column_to_.py
+++ b/h/migrations/versions/530268a1937c_add_password_last_updated_column_to_.py
@@ -17,6 +17,7 @@ import sqlalchemy as sa
 def upgrade():
     op.add_column('user', sa.Column('password_updated',
                                     sa.DateTime(),
+                                    server_default=sa.func.now(),
                                     nullable=True))
 
 

--- a/h/migrations/versions/530268a1937c_add_password_last_updated_column_to_.py
+++ b/h/migrations/versions/530268a1937c_add_password_last_updated_column_to_.py
@@ -15,10 +15,10 @@ import sqlalchemy as sa
 
 
 def upgrade():
-    op.add_column('user', sa.Column('last_password_update',
+    op.add_column('user', sa.Column('password_updated',
                                     sa.DateTime(),
                                     nullable=True))
 
 
 def downgrade():
-    op.drop_column('user', 'last_password_update')
+    op.drop_column('user', 'password_updated')

--- a/h/migrations/versions/530268a1937c_add_password_last_updated_column_to_.py
+++ b/h/migrations/versions/530268a1937c_add_password_last_updated_column_to_.py
@@ -1,0 +1,26 @@
+"""Add password last updated column to accounts model
+
+Revision ID: 530268a1937c
+Revises: 43645baa68b2
+Create Date: 2015-12-14 17:07:44.757878
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '530268a1937c'
+down_revision = '43645baa68b2'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('user', sa.Column('last_password_update',
+                                    sa.DateTime(timezone=False),
+                                    default=sa.sql.func.now(),
+                                    server_default=sa.func.now(),
+                                    nullable=True))
+
+
+def downgrade():
+    op.drop_column('user', 'last_password_update')

--- a/h/migrations/versions/530268a1937c_add_password_last_updated_column_to_.py
+++ b/h/migrations/versions/530268a1937c_add_password_last_updated_column_to_.py
@@ -16,9 +16,7 @@ import sqlalchemy as sa
 
 def upgrade():
     op.add_column('user', sa.Column('last_password_update',
-                                    sa.DateTime(timezone=False),
-                                    default=sa.sql.func.now(),
-                                    server_default=sa.func.now(),
+                                    sa.DateTime(),
                                     nullable=True))
 
 

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ INSTALL_REQUIRES = [
     'gevent>=1.0.2,<1.1.0',
     'gnsq>=0.3.0,<0.4.0',
     'gunicorn>=19.2,<20',
+    'itsdangerous>=0.24',
     'jsonpointer==1.0',
     'jsonschema>=2.5.1,<2.6',
     'oauthlib==0.6.3',
@@ -64,7 +65,6 @@ INSTALL_REQUIRES = [
     'requests>=2.7.0',
     'ws4py>=0.3,<0.4',
     'zope.sqlalchemy>=0.7.6,<0.8.0',
-    'itsdangerous>=0.24',
 
     # Version pin for known bug
     # https://github.com/repoze/repoze.sendmail/issues/31

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ INSTALL_REQUIRES = [
     'requests>=2.7.0',
     'ws4py>=0.3,<0.4',
     'zope.sqlalchemy>=0.7.6,<0.8.0',
+    'itsdangerous>=0.24',
 
     # Version pin for known bug
     # https://github.com/repoze/repoze.sendmail/issues/31


### PR DESCRIPTION
# Migration notes

This pull request contains three migrations:
* The first one will add a `password_updated` column to the `user` table without a default value (to prevent locking the production database), and then adds a `server_default` which will provide a default value of `now()` for all new entries.
* The second one will fill the missing `password_updated` fields with the default value.
* The third one one will make the `password_updated` field non-nullable, and needs to be run after the pull request is deployed to production. Otherwise Bad Things Will Happen :tm: 

Migrations #1 and #2 are safe to run on the production database even if this pull request hasn't been deployed to the production environment. Migration #3 isn't.

# Implementation notes

Password reset was dealt with by re-using the account activation mechanism, and the password reset token was thus an activation token. This had the unpleasant side effect that if a user created an account, and asked for a password reset before activating the account, the password reset token would overwrite the activation token, effectively locking them out of their account.

The solution implemented here uses a capability URL, where the information needed for the password reset is encoded in the password reset token itself. In particular, a password reset token contains the username of the requestor, and it then becomes URL-safe encoded, timestamped, and signed with a secret key.

In addition, we add a new `password_updated` column to the user table in the database, which gets set to the current time every time the user's password is set.

When the user attempts to reset their password by using a password reset token, the signature of the provided token is verified against our secret key, and the timestamped is checked. If this verification succeeds, we reset the user's password, and update the `password_updated` field in the corresponding database entry.

The password reset fails if the token is invalid, older than 72h, or the user has reset their password after the token creation.