### PR TITLE
Remove Moment.js

### DIFF
--- a/h/static/scripts/app.coffee
+++ b/h/static/scripts/app.coffee
@@ -126,7 +126,6 @@ module.exports = angular.module('h', [
 .directive('topBar', require('./directive/top-bar'))
 
 .filter('converter', require('./filter/converter'))
-.filter('moment', require('./filter/moment'))
 .filter('persona', require('./filter/persona').filter)
 .filter('urlencode', require('./filter/urlencode'))
 .filter('documentTitle', require('./filter/document-title'))

--- a/h/static/scripts/date-util.js
+++ b/h/static/scripts/date-util.js
@@ -1,0 +1,37 @@
+var DATE_SUPPORTS_LOCALE_OPTS = (function () {
+  try {
+    // see http://mzl.la/1YlJJpQ
+    (new Date).toLocaleDateString('i');
+  } catch (e) {
+    if (e instanceof RangeError) {
+      return true;
+    }
+  }
+  return false;
+})();
+
+/**
+ * Returns a standard human-readable representation
+ * of a date and time.
+ */
+function format(date) {
+  if (DATE_SUPPORTS_LOCALE_OPTS) {
+    return date.toLocaleDateString(undefined, {
+      year: 'numeric',
+      month: 'short',
+      day: '2-digit',
+      weekday: 'long',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  } else {
+    // IE < 11, Safari <= 9.0.
+    // In English, this generates the string most similar to
+    // the toLocaleDateString() result above.
+    return date.toDateString() + ' ' + date.toLocaleTimeString();
+  }
+}
+
+module.exports = {
+  format: format,
+};

--- a/h/static/scripts/directive/annotation.js
+++ b/h/static/scripts/directive/annotation.js
@@ -1,6 +1,7 @@
 /* jshint node: true */
 'use strict';
 
+var dateUtil = require('../date-util');
 var events = require('../events');
 
 /** Return a domainModel tags array from the given vm tags array.
@@ -744,7 +745,7 @@ function AnnotationController(
       return '';
     }
     var date = new Date(domainModel.updated);
-    return date.toDateString() + ', ' + date.toLocaleTimeString();
+    return dateUtil.format(date);
   }
 
   vm.user = function() {

--- a/h/static/scripts/directive/annotation.js
+++ b/h/static/scripts/directive/annotation.js
@@ -739,6 +739,14 @@ function AnnotationController(
     return domainModel.updated;
   };
 
+  vm.updatedString = function () {
+    if (!domainModel.updated) {
+      return '';
+    }
+    var date = new Date(domainModel.updated);
+    return date.toDateString() + ', ' + date.toLocaleTimeString();
+  }
+
   vm.user = function() {
     return domainModel.user;
   };

--- a/h/static/scripts/directive/test/annotation-test.js
+++ b/h/static/scripts/directive/test/annotation-test.js
@@ -404,7 +404,8 @@ describe('annotation.js', function() {
         },
         target: [{}],
         uri: 'http://example.com',
-        user: 'acct:bill@localhost'
+        user: 'acct:bill@localhost',
+        updated: '2015-05-10T20:18:56.613388+00:00',
       };
     }
 
@@ -1101,6 +1102,18 @@ describe('annotation.js', function() {
         $scope.$destroy();
         $timeout.flush();
         $timeout.verifyNoPendingTasks();
+      });
+    });
+
+    describe('#updatedString()', function () {
+      it('returns the current time', function () {
+        var annotation = defaultAnnotation();
+        var controller = createDirective(annotation).controller;
+        var expectedDate = new Date(annotation.updated);
+        // the exact format of the result will depend on the current locale,
+        // but check that at least the current year and time are present
+        assert.match(controller.updatedString(), new RegExp('.*2015.*' +
+          expectedDate.toLocaleTimeString()));
       });
     });
 

--- a/h/static/scripts/filter/moment.js
+++ b/h/static/scripts/filter/moment.js
@@ -1,8 +1,0 @@
-var moment = require('moment');
-
-
-module.exports = ['$window', function ($window) {
-  return function (value, format) {
-    return moment(value).format(format);
-  };
-}];

--- a/h/templates/client/annotation.html
+++ b/h/templates/client/annotation.html
@@ -47,7 +47,7 @@
     <!-- Timestamp -->
     <a class="annotation-timestamp"
        target="_blank"
-       title="{{vm.updated() | moment:'LLLL'}}"
+       title="{{vm.updatedString()}}"
        ng-if="!vm.editing() && vm.updated()"
        ng-href="{{vm.baseURI}}a/{{vm.id()}}"
        >{{vm.timestamp}}</a>

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "is-equal-shallow": "^0.1.3",
     "jquery": "1.11.1",
     "js-polyfills": "^0.1.11",
-    "moment": "^2.10.6",
     "ng-tags-input": "2.2.0",
     "node-uuid": "^1.4.3",
     "postcss": "^5.0.6",
@@ -95,8 +94,7 @@
     "annotator": "./h/static/scripts/vendor/annotator.js",
     "angular": "./node_modules/angular/angular.js",
     "hammerjs": "./node_modules/hammerjs/hammer.js",
-    "jquery": "./node_modules/jquery/dist/jquery.js",
-    "moment": "./node_modules/moment/min/moment-with-locales.js"
+    "jquery": "./node_modules/jquery/dist/jquery.js"
   },
   "browserify-shim": {
     "annotator": {


### PR DESCRIPTION
Moment.js is only used in a single place, for converting ISO8601 date-time strings
from the annotation's 'updated' field to user-friendly
date strings (eg. 'Wednesday 17 Dec, 18:59') for the tooltips
for the last-updated link in the annotation card.

Replacing this with functions from the built-in Date object saves
167KB from the generated bundle size (see
moment/min/moment-with-locales.min.js) and also speeds up the digest
cycle. For 20 annotation cards in the /stream view, generating the
date string used to take 6-7ms with Moment. It takes <2ms with
the built in functions in a current build of Chrome.

This still shows up as the most expensive watch expression, so
we might want to add caching as well.