### PR TITLE
Use Angular 1.3.x+ one-time bindings

### DIFF
--- a/h/templates/app.html.jinja2
+++ b/h/templates/app.html.jinja2
@@ -25,7 +25,7 @@
     on-logout="logout()"
     account-dialog="accountDialog"
     share-dialog="shareDialog"
-    is-sidebar="isSidebar"
+    is-sidebar="::isSidebar"
     search-controller="search"
     sort-by="sort.name"
     sort-options="sort.options"

--- a/h/templates/client/annotation.html
+++ b/h/templates/client/annotation.html
@@ -9,7 +9,7 @@
       <span>
         <a class="annotation-user"
            target="_blank"
-           ng-href="{{vm.baseURI}}u/{{vm.user()}}"
+           ng-href="{{::vm.baseURI}}u/{{vm.user()}}"
            >{{vm.user() | persona}}</a>
       </span>
 
@@ -33,11 +33,11 @@
         <i class="h-icon-border-color" ng-show="vm.isHighlight() && !vm.editing()" title="This is a highlight. Click 'edit' to add a note or tag."></i>
         <span class="annotation-citation"
               ng-bind-html="vm.document() | documentTitle"
-              ng-if="!vm.isSidebar">
+              ng-if="::!vm.isSidebar">
         </span>
         <span class="annotation-citation-domain"
               ng-bind-html="vm.document() | documentDomain"
-              ng-if="!vm.isSidebar">
+              ng-if="::!vm.isSidebar">
         </span>
       </span>
     </span>
@@ -49,7 +49,7 @@
        target="_blank"
        title="{{vm.updated() | moment:'LLLL'}}"
        ng-if="!vm.editing() && vm.updated()"
-       ng-href="{{vm.baseURI}}a/{{vm.id()}}"
+       ng-href="{{::vm.baseURI}}a/{{vm.id()}}"
        >{{vm.timestamp}}</a>
   </header>
 

--- a/h/templates/client/thread.html
+++ b/h/templates/client/thread.html
@@ -15,7 +15,7 @@
          name="annotation"
          annotation="vm.container.message"
          is-last-reply="$last"
-         is-sidebar="isSidebar"
+         is-sidebar="::isSidebar"
          annotation-show-reply-count="{{vm.shouldShowNumReplies()}}"
          annotation-reply-count="{{vm.numReplies()}}"
          annotation-reply-count-click="vm.toggleCollapsed()"

--- a/h/templates/client/top_bar.html
+++ b/h/templates/client/top_bar.html
@@ -2,7 +2,7 @@
 !-->
 <div class="top-bar" ng-class="frame.visible && 'shown'" ng-cloak>
   <!-- Legacy design for top bar, as used in the stream !-->
-  <div class="top-bar__inner content" ng-if="!isSidebar">
+  <div class="top-bar__inner content" ng-if="::!isSidebar">
     <simple-search
       class="simple-search"
       query="searchController.query"
@@ -23,7 +23,7 @@
        The inner div is styled with 'content' to center it in
        the stream view.
   !-->
-  <div class="top-bar__inner content" ng-if="isSidebar">
+  <div class="top-bar__inner content" ng-if="::isSidebar">
     <group-list class="group-list" auth="auth"></group-list>
     <div class="top-bar__expander"></div>
     <simple-search


### PR DESCRIPTION
Since the upgrade to Angular 1.4.x, we have a new facility available to us to reduce the number of watches created by expressions in templates. Prefixing an expression with `::` causes it to be evaluated only once and the watch is removed thereafter.

This PR uses '::' for a bunch of expressions which do not change during the lifetime of the app (eg. `isSidebar`) or an annotation card (eg. the annotation quote).

~~In combination with https://github.com/hypothesis/h/pull/2808 this reduces the length of a typical `$digest` cycle in the default view of the `/stream` from ~30ms to ~20ms and the number of watches from ~1690 to ~1530.~~

**Update** - I revised the PR after the discussion. It is now much more conservative and only cuts the number of watchers down from 1690 to 1649 in the same scenario, but that's still a small win and I think it is also a useful record of the approach.

Longer term we could do much better by taking advantage of the fact that the majority of expressions in an annotation card can only change when the annotation data itself is modified, which never happens for the majority of annotations. This PR is a quick and easy win though.