### PR TITLE
Enable video embeds to be shown fullscreen

### DIFF
--- a/h/static/scripts/annotator/host.coffee
+++ b/h/static/scripts/annotator/host.coffee
@@ -12,6 +12,8 @@ module.exports = class Host extends Guest
     # Create the iframe
     app = $('<iframe></iframe>')
     .attr('name', 'hyp_sidebar_frame')
+    # enable media in annotations to be shown fullscreen
+    .attr('allowfullscreen', '')
     .attr('seamless', '')
     .attr('src', options.app)
 

--- a/h/static/scripts/media-embedder.js
+++ b/h/static/scripts/media-embedder.js
@@ -8,6 +8,7 @@ function iframe(src) {
   iframe_.src = src;
   iframe_.classList.add('annotation-media-embed');
   iframe_.setAttribute('frameborder', '0');
+  iframe_.setAttribute('allowfullscreen', '');
   return iframe_;
 }
 


### PR DESCRIPTION
The 'allowfullscreen' attribute must be set on both
the embed's <iframe> and the parent sidebar <iframe>
when the embed's main script is loaded to enable
fullscreen support.