### PR TITLE
Fix video embeds in Firefox < 45

### DIFF
--- a/h/static/scripts/media-embedder.js
+++ b/h/static/scripts/media-embedder.js
@@ -130,7 +130,7 @@ function embedForLink(link) {
  *
  */
 function replaceLinkWithEmbed(link) {
-  if (link.href !== link.innerText) {
+  if (link.href !== link.textContent) {
     return;
   }
 


### PR DESCRIPTION
innerText is non-standard and not supported in Firefox < 45.

Use textContent instead.