### PR TITLE
Clear selection before creating new annotation

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,15 @@
+Unreleased
+==========
+
+Features
+--------
+
+- Clear any selection that exists in the sidebar before creating a new
+  annotation. Fixes a usability issue that the new annotation with its form
+  open for the user to type in wouldn't be visible because it wasn't part of
+  the selection. (#2817)
+
+
 0.8.7 (2015-12-18)
 ==================
 

--- a/h/static/scripts/app-controller.coffee
+++ b/h/static/scripts/app-controller.coffee
@@ -125,6 +125,12 @@ module.exports = class AppController
       $scope.search.query = ''
       annotationUI.clearSelectedAnnotations()
 
+    $rootScope.$on('beforeAnnotationCreated', (event, data) ->
+      if data.$highlight
+        return
+      $scope.clearSelection()
+    )
+
     $scope.search =
       query: $location.search()['q']
 

--- a/h/static/scripts/test/app-controller-test.coffee
+++ b/h/static/scripts/test/app-controller-test.coffee
@@ -168,6 +168,30 @@ describe 'AppController', ->
     $scope.$broadcast(events.USER_CHANGED, {initialLoad: false})
     assert.calledOnce(fakeRoute.reload)
 
+  describe 'on "beforeAnnotationCreated"', ->
+
+    ###*
+    #  It should clear any selection that exists in the sidebar before
+    #  creating a new annotation. Otherwise the new annotation with its
+    #  form open for the user to type in won't be visible because it's
+    #  not part of the selection.
+    ###
+    it 'calls $scope.clearSelection()', ->
+      createController()
+      sandbox.spy($scope, 'clearSelection')
+
+      $rootScope.$emit('beforeAnnotationCreated', {})
+
+      assert.called($scope.clearSelection)
+
+    it 'doesn\'t call $scope.clearSelection() when a highlight is created', ->
+      createController()
+      sandbox.spy($scope, 'clearSelection')
+
+      $rootScope.$emit('beforeAnnotationCreated', {$highlight: true})
+
+      assert.notCalled($scope.clearSelection)
+
   describe 'logout()', ->
     it 'prompts the user if there are drafts', ->
       fakeDrafts.count.returns(1)


### PR DESCRIPTION
Clear any selection that exists in the sidebar before creating a new
annotation. Otherwise the new annotation with its form open for the user
to type in won't be visible because it's not part of the selection.

https://trello.com/c/EqRZwdZC/210-clear-selected-annotations-when-a-user-initiates-a-new-annotation