### PR TITLE
Update the displayed annotation timestamp immediately after creation/…

### DIFF
--- a/h/static/scripts/directive/test/annotation-test.js
+++ b/h/static/scripts/directive/test/annotation-test.js
@@ -1080,6 +1080,22 @@ describe('annotation.js', function() {
         assert.equal(controller.timestamp, null);
       });
 
+      it('is updated when a new annotation is saved', function () {
+        // fake clocks are not required for this test
+        clock.restore();
+
+        annotation.updated = null;
+        annotation.$create = function () {
+          annotation.updated = (new Date).toString();
+          return Promise.resolve(annotation);
+        };
+        var controller = createDirective(annotation).controller;
+        controller.action = 'create';
+        return controller.save().then(function () {
+          assert.equal(controller.timestamp, 'a while ago');
+        });
+      });
+
       it('is updated on first digest', function() {
         var controller = createDirective(annotation).controller;
         $scope.$digest();


### PR DESCRIPTION
…update

The call to updateTimestamp() for new annotations is a no-op because
the annotation has no timestamp yet.

After saving an annotation, we first need to update the timestamp
and also trigger the periodic refresh of the timestamp.

 * Remove unnecessary 'repeat' parameter to updateTimestamp()
   since the function was always called with this set to true

 * Keep track of whether a repeat has already been scheduled
   and avoid kicking of multiple timestamp update cycles

Fixes #2819