### PR TITLE
Update annotation timestamp when creating and editing annotations

### DIFF
--- a/h/static/scripts/directive/annotation.js
+++ b/h/static/scripts/directive/annotation.js
@@ -349,7 +349,7 @@ function AnnotationController(
     // log in.
     saveNewHighlight();
 
-    updateViewModel($scope, time, domainModel, vm, permissions);
+    updateView(domainModel);
 
     // If this annotation is not a highlight and if it's new (has just been
     // created by the annotate button) or it has edits not yet saved to the
@@ -361,9 +361,13 @@ function AnnotationController(
     }
   }
 
+  function updateView(domainModel) {
+    updateViewModel($scope, time, domainModel, vm, permissions);
+  }
+
   function onAnnotationUpdated(event, updatedDomainModel) {
     if (updatedDomainModel.id === domainModel.id) {
-      updateViewModel($scope, time, updatedDomainModel, vm, permissions);
+      updateView(updatedDomainModel);
     }
   }
 
@@ -417,7 +421,7 @@ function AnnotationController(
       domainModel.permissions = permissions.private();
       domainModel.$create().then(function() {
         $rootScope.$emit('annotationCreated', domainModel);
-        updateViewModel($scope, time, domainModel, vm, permissions);
+        updateView(domainModel);
       });
     } else {
       // User isn't logged in, save to drafts.
@@ -617,7 +621,7 @@ function AnnotationController(
     if (vm.action === 'create') {
       $rootScope.$emit('annotationDeleted', domainModel);
     } else {
-      updateViewModel($scope, time, domainModel, vm, permissions);
+      updateView(domainModel);
       view();
     }
   };
@@ -649,7 +653,7 @@ function AnnotationController(
 
         var onFulfilled = function() {
           $rootScope.$emit('annotationCreated', domainModel);
-          updateViewModel($scope, time, domainModel, vm, permissions);
+          updateView(domainModel);
           view();
           drafts.remove(domainModel);
         };

--- a/h/static/scripts/directive/annotation.js
+++ b/h/static/scripts/directive/annotation.js
@@ -417,6 +417,7 @@ function AnnotationController(
       domainModel.permissions = permissions.private();
       domainModel.$create().then(function() {
         $rootScope.$emit('annotationCreated', domainModel);
+        updateViewModel($scope, time, domainModel, vm, permissions);
       });
     } else {
       // User isn't logged in, save to drafts.

--- a/h/static/scripts/directive/annotation.js
+++ b/h/static/scripts/directive/annotation.js
@@ -166,7 +166,8 @@ function updateDomainModel(domainModel, vm, permissions, groups) {
 }
 
 /** Update the view model from the domain model changes. */
-function updateViewModel(domainModel, vm, permissions) {
+function updateViewModel($scope, time, domainModel, vm, permissions) {
+
   vm.form = {
     text: domainModel.text,
     tags: viewModelTagsFromDomainModelTags(domainModel.tags),
@@ -174,6 +175,21 @@ function updateViewModel(domainModel, vm, permissions) {
   vm.annotationURI = new URL('/a/' + domainModel.id, vm.baseURI).href;
   vm.isPrivate = permissions.isPrivate(
     domainModel.permissions, domainModel.user);
+
+  function updateTimestamp() {
+    vm.timestamp = time.toFuzzyString(domainModel.updated);
+  }
+
+  if (domainModel.updated) {
+    if (vm.cancelTimestampRefresh) {
+      vm.cancelTimestampRefresh();
+    }
+    vm.cancelTimestampRefresh =
+     time.decayingInterval(domainModel.updated, function () {
+       $scope.$apply(updateTimestamp);
+     });
+    updateTimestamp();
+  }
 }
 
 /** Return truthy if the given annotation is valid, falsy otherwise.
@@ -282,6 +298,9 @@ function AnnotationController(
      */
     vm.timestamp = null;
 
+    /** A callback for resetting the automatic refresh of vm.timestamp */
+    vm.cancelTimestampRefresh = undefined;
+
     /** The domain model, contains the currently saved version of the
       * annotation from the server (or in the case of new annotations that
       * haven't been saved yet - the data that will be saved to the server when
@@ -330,8 +349,7 @@ function AnnotationController(
     // log in.
     saveNewHighlight();
 
-    updateTimestamp(true);
-    updateViewModel(domainModel, vm, permissions);
+    updateViewModel($scope, time, domainModel, vm, permissions);
 
     // If this annotation is not a highlight and if it's new (has just been
     // created by the annotate button) or it has edits not yet saved to the
@@ -345,12 +363,14 @@ function AnnotationController(
 
   function onAnnotationUpdated(event, updatedDomainModel) {
     if (updatedDomainModel.id === domainModel.id) {
-      updateViewModel(updatedDomainModel, vm, permissions);
+      updateViewModel($scope, time, updatedDomainModel, vm, permissions);
     }
   }
 
   function onDestroy() {
-    updateTimestamp = angular.noop;
+    if (vm.cancelTimestampRefresh) {
+      vm.cancelTimestampRefresh();
+    }
   }
 
   function onGroupFocused() {
@@ -403,32 +423,6 @@ function AnnotationController(
       saveToDrafts(drafts, domainModel, vm);
     }
   }
-
-  // We use `var foo = function() {...}` here instead of `function foo() {...}`
-  // because updateTimestamp gets redefined later on.
-  var updateTimestamp = function(repeat) {
-    repeat = repeat || false;
-
-    // New (not yet saved to the server) annotations don't have any .updated
-    // yet, so we can't update their timestamp.
-    if (!domainModel.updated) {
-      return;
-    }
-
-    vm.timestamp = time.toFuzzyString(domainModel.updated);
-
-    if (!repeat) {
-      return;
-    }
-
-    var fuzzyUpdate = time.nextFuzzyUpdate(domainModel.updated);
-    var nextUpdate = (1000 * fuzzyUpdate) + 500;
-
-    $timeout(function() {
-      updateTimestamp(true);
-      $scope.$digest();
-    }, nextUpdate, false);
-  };
 
   /** Switches the view to a viewer, closing the editor controls if they're
    *  open.
@@ -622,7 +616,7 @@ function AnnotationController(
     if (vm.action === 'create') {
       $rootScope.$emit('annotationDeleted', domainModel);
     } else {
-      updateViewModel(domainModel, vm, permissions);
+      updateViewModel($scope, time, domainModel, vm, permissions);
       view();
     }
   };
@@ -654,7 +648,7 @@ function AnnotationController(
 
         var onFulfilled = function() {
           $rootScope.$emit('annotationCreated', domainModel);
-          updateViewModel(domainModel, vm, permissions);
+          updateViewModel($scope, time, domainModel, vm, permissions);
           view();
           drafts.remove(domainModel);
         };


### PR DESCRIPTION
This is a revised approach to https://github.com/hypothesis/h/pull/2821 after discovery of two related bugs and following the comments in that PR.

This PR fixes three recent issues:

 * The timestamp for an annotation card did not appear after saving a new annotation
 * Timestamps did not appear on cards for newly added highlights
 * Timestamps did not update when editing an existing annotation

The root cause of the issue is that the function which updates the timestamp and triggers a periodic refresh depending on its age was not invoked in these three cases.

This PR fixes the issue by:

 * Extracting out the logic for managing the decaying interval (ie. an interval whose refresh rate depends on the age of an input date) into a separate function in `time.coffee`
 * Triggering a refresh of the timestamp and periodic timer in `updateViewModel()` which is the central function that handles updates to the view model when the domain model changes
 * Triggering an update of the view model when a new highlight is successfully saved to the server

