### PR TITLE
Improve stream / sidebar date formatting performance

### DIFF
--- a/h/static/scripts/date-util.js
+++ b/h/static/scripts/date-util.js
@@ -1,29 +1,24 @@
-var DATE_SUPPORTS_LOCALE_OPTS = (function () {
-  try {
-    // see http://mzl.la/1YlJJpQ
-    (new Date).toLocaleDateString('i');
-  } catch (e) {
-    if (e instanceof RangeError) {
-      return true;
-    }
-  }
-  return false;
-})();
+// cached date formatting instance.
+// See https://github.com/hypothesis/h/issues/2820#issuecomment-166285361
+var formatter;
 
 /**
  * Returns a standard human-readable representation
  * of a date and time.
  */
 function format(date) {
-  if (DATE_SUPPORTS_LOCALE_OPTS) {
-    return date.toLocaleDateString(undefined, {
-      year: 'numeric',
-      month: 'short',
-      day: '2-digit',
-      weekday: 'long',
-      hour: '2-digit',
-      minute: '2-digit',
-    });
+  if (typeof Intl !== 'undefined' && Intl.DateTimeFormat) {
+    if (!formatter) {
+      formatter = new Intl.DateTimeFormat(undefined, {
+        year: 'numeric',
+        month: 'short',
+        day: '2-digit',
+        weekday: 'long',
+        hour: '2-digit',
+        minute: '2-digit',
+      });
+    }
+    return formatter.format(date);
   } else {
     // IE < 11, Safari <= 9.0.
     // In English, this generates the string most similar to

--- a/h/static/scripts/directive/annotation.js
+++ b/h/static/scripts/directive/annotation.js
@@ -177,8 +177,8 @@ function updateViewModel($scope, time, domainModel, vm, permissions) {
     domainModel.permissions, domainModel.user);
 
   function updateTimestamp() {
-    vm.timestamp = time.toFuzzyString(domainModel.updated);
-    vm.updatedString = dateUtil.format(new Date(domainModel.updated));
+    vm.relativeTimestamp = time.toFuzzyString(domainModel.updated);
+    vm.absoluteTimestamp = dateUtil.format(new Date(domainModel.updated));
   }
 
   if (domainModel.updated) {
@@ -295,15 +295,20 @@ function AnnotationController(
       * directly from scope). */
     vm.isSidebar = $scope.isSidebar;
 
-    /** A "fuzzy string" representation of the annotation's last updated time.
+    /** A fuzzy, relative (eg. '6 days ago') format of the annotation's
+     * last update timestamp
      */
-    vm.timestamp = null;
+    vm.relativeTimestamp = null;
 
-    /** A callback for resetting the automatic refresh of vm.timestamp */
+    /** A formatted version of the annotation's last update timestamp
+     * (eg. 'Tue 22nd Dec 2015, 16:00')
+     */
+    vm.absoluteTimestamp = '';
+
+    /** A callback for resetting the automatic refresh of
+     * vm.relativeTimestamp and vm.absoluteTimestamp
+     */
     vm.cancelTimestampRefresh = undefined;
-
-    /** A human-readable representation of the annotation's last updated time */
-    vm.updatedString = '';
 
     /** The domain model, contains the currently saved version of the
       * annotation from the server (or in the case of new annotations that

--- a/h/static/scripts/directive/annotation.js
+++ b/h/static/scripts/directive/annotation.js
@@ -178,6 +178,7 @@ function updateViewModel($scope, time, domainModel, vm, permissions) {
 
   function updateTimestamp() {
     vm.timestamp = time.toFuzzyString(domainModel.updated);
+    vm.updatedString = dateUtil.format(new Date(domainModel.updated));
   }
 
   if (domainModel.updated) {
@@ -300,6 +301,9 @@ function AnnotationController(
 
     /** A callback for resetting the automatic refresh of vm.timestamp */
     vm.cancelTimestampRefresh = undefined;
+
+    /** A human-readable representation of the annotation's last updated time */
+    vm.updatedString = '';
 
     /** The domain model, contains the currently saved version of the
       * annotation from the server (or in the case of new annotations that
@@ -738,14 +742,6 @@ function AnnotationController(
   vm.updated = function() {
     return domainModel.updated;
   };
-
-  vm.updatedString = function () {
-    if (!domainModel.updated) {
-      return '';
-    }
-    var date = new Date(domainModel.updated);
-    return dateUtil.format(date);
-  }
 
   vm.user = function() {
     return domainModel.user;

--- a/h/static/scripts/directive/test/annotation-test.js
+++ b/h/static/scripts/directive/test/annotation-test.js
@@ -1152,14 +1152,14 @@ describe('annotation', function() {
       });
     });
 
-    describe('#updatedString()', function () {
+    describe('#updatedString', function () {
       it('returns the current time', function () {
         var annotation = defaultAnnotation();
         var controller = createDirective(annotation).controller;
         var expectedDate = new Date(annotation.updated);
         // the exact format of the result will depend on the current locale,
         // but check that at least the current year and time are present
-        assert.match(controller.updatedString(), new RegExp('.*2015.*' +
+        assert.match(controller.updatedString, new RegExp('.*2015.*' +
           expectedDate.toLocaleTimeString()));
       });
     });

--- a/h/static/scripts/directive/test/annotation-test.js
+++ b/h/static/scripts/directive/test/annotation-test.js
@@ -1056,7 +1056,7 @@ describe('annotation', function() {
       });
     });
 
-    describe('timestamp', function() {
+    describe('relativeTimestamp', function() {
       var annotation;
       var clock;
 
@@ -1077,7 +1077,7 @@ describe('annotation', function() {
         // Unsaved annotations don't have an updated time yet so a timestamp
         // string can't be computed for them.
         $scope.$digest();
-        assert.equal(controller.timestamp, null);
+        assert.equal(controller.relativeTimestamp, null);
       });
 
       it('is updated when a new annotation is saved', function () {
@@ -1096,7 +1096,7 @@ describe('annotation', function() {
         var controller = createDirective(annotation).controller;
         controller.action = 'create';
         return controller.save().then(function () {
-          assert.equal(controller.timestamp, 'a while ago');
+          assert.equal(controller.relativeTimestamp, 'a while ago');
         });
       });
 
@@ -1118,18 +1118,18 @@ describe('annotation', function() {
           return Promise.resolve(this);
         }
         var controller = createDirective(annotation).controller;
-        assert.equal(controller.timestamp, 'ages ago');
+        assert.equal(controller.relativeTimestamp, 'ages ago');
         controller.edit();
         clock.restore();
         return controller.save().then(function () {
-          assert.equal(controller.timestamp, 'just now');
+          assert.equal(controller.relativeTimestamp, 'just now');
         });
       });
 
       it('is updated on first digest', function() {
         var controller = createDirective(annotation).controller;
         $scope.$digest();
-        assert.equal(controller.timestamp, 'a while ago');
+        assert.equal(controller.relativeTimestamp, 'a while ago');
       });
 
       it('is updated after a timeout', function() {
@@ -1140,7 +1140,7 @@ describe('annotation', function() {
         fakeTime.toFuzzyString.returns('ages ago');
         $scope.$digest();
         clock.tick(11000);
-        assert.equal(controller.timestamp, 'ages ago');
+        assert.equal(controller.relativeTimestamp, 'ages ago');
       });
 
       it('is no longer updated after the scope is destroyed', function() {
@@ -1152,14 +1152,14 @@ describe('annotation', function() {
       });
     });
 
-    describe('#updatedString', function () {
+    describe('absoluteTimestamp', function () {
       it('returns the current time', function () {
         var annotation = defaultAnnotation();
         var controller = createDirective(annotation).controller;
         var expectedDate = new Date(annotation.updated);
         // the exact format of the result will depend on the current locale,
         // but check that at least the current year and time are present
-        assert.match(controller.updatedString, new RegExp('.*2015.*' +
+        assert.match(controller.absoluteTimestamp, new RegExp('.*2015.*' +
           expectedDate.toLocaleTimeString()));
       });
     });

--- a/h/templates/client/annotation.html
+++ b/h/templates/client/annotation.html
@@ -47,7 +47,7 @@
     <!-- Timestamp -->
     <a class="annotation-timestamp"
        target="_blank"
-       title="{{vm.updatedString()}}"
+       title="{{vm.updatedString}}"
        ng-if="!vm.editing() && vm.updated()"
        ng-href="{{::vm.baseURI}}a/{{vm.id()}}"
        >{{vm.timestamp}}</a>

--- a/h/templates/client/annotation.html
+++ b/h/templates/client/annotation.html
@@ -47,10 +47,10 @@
     <!-- Timestamp -->
     <a class="annotation-timestamp"
        target="_blank"
-       title="{{vm.updatedString}}"
+       title="{{vm.absoluteTimestamp}}"
        ng-if="!vm.editing() && vm.updated()"
        ng-href="{{::vm.baseURI}}a/{{vm.id()}}"
-       >{{vm.timestamp}}</a>
+       >{{vm.relativeTimestamp}}</a>
   </header>
 
   <!-- Excerpts -->


### PR DESCRIPTION
This fixes a regression introduced by https://github.com/hypothesis/h/pull/2808 . `Date.toLocaleDateFormat` is much faster than Moment without options but much slower with. This PR follows the advice on MDN to create a single `Intl.DateTimeFormat` instance and re-use it. It also caches the resulting string.

The end result is that a digest cycle for `/stream` is now ~20ms faster than master and ~6ms faster than before the Moment.js removal on my system.

Fixes #2820

