### PR TITLE
Fix inline Chrome extension installation

### DIFF
--- a/h/home.py
+++ b/h/home.py
@@ -6,7 +6,10 @@ from pyramid import view
                   request_method='GET',
                   renderer='h:templates/old-home.html.jinja2')
 def index(context, request):
-    context = {}
+    context = {
+      "chrome_extension_link": ("https://chrome.google.com/webstore/detail/"
+                                "bjfhmglciegochdpefhhlphglcehbmek")
+    }
 
     if request.authenticated_user:
         username = request.authenticated_user.username

--- a/h/templates/home.html.jinja2
+++ b/h/templates/home.html.jinja2
@@ -7,6 +7,8 @@
 {% block meta %}
   {{ super() }}
   <link rel='canonical' href='{{ base_url }}'>
+  <link rel="chrome-webstore-item"
+        href="{{ chrome_extension_link }}">
   <link href="{{ rss_feed_url }}" rel="alternate" type="application/rss+xml">
 {% endblock %}
 
@@ -33,7 +35,7 @@
 
     <div class="home__section installer">
       <a class="install-btn is-hidden js-install-chrome"
-          href="https://chrome.google.com/webstore/detail/bjfhmglciegochdpefhhlphglcehbmek"
+          href="{{ chrome_extension_link }}"
           onclick="chrome.webstore.install();return false;"
           data-chromeext-button="">
         <img alt="" class="install-btn__icon"

--- a/h/templates/old-home.html.jinja2
+++ b/h/templates/old-home.html.jinja2
@@ -7,6 +7,8 @@
 {% block meta %}
   {{ super() }}
   <link rel='canonical' href='{{ base_url }}'>
+  <link rel="chrome-webstore-item"
+        href="{{ chrome_extension_link }}">
   <link href="{{ rss_feed_url }}" rel="alternate" type="application/rss+xml">
 {% endblock %}
 
@@ -128,7 +130,7 @@
 
                 <span class="hidden unhide-in-chrome">
                   <a class="btn btn-primary hidden-xs"
-                      href="https://chrome.google.com/webstore/detail/bjfhmglciegochdpefhhlphglcehbmek"
+                      href="{{ chrome_extension_link }}"
                       onclick="chrome.webstore.install();return false;"
                       data-chromeext-button="">
                     <img alt="" class="installer__browser-logo--chrome"


### PR DESCRIPTION
Add the missing <link rel="chrome-webstore-item"> link
required for inline installation of Chrome extensions.

Previously the install link JS was failing due to this
and the result was that the user got directed to the
Chrome Web Store.

Fixes #2830