### PR TITLE
Add annotation count to admin user info page

### DIFF
--- a/h/templates/admin/users.html.jinja2
+++ b/h/templates/admin/users.html.jinja2
@@ -37,6 +37,10 @@
             <th>Is staff?</th>
             <td>{% if user.staff %}&#x2714;{% else %}&#x2718;{% endif %}</td>
           </tr>
+          <tr>
+            <th>Annotations</th>
+            <td>{{ user_meta['annotations_count'] }}</td>
+          </tr>
         </tbody>
       </table>
     {% else %}


### PR DESCRIPTION
This PR adds a total (public + shared + groups) annotation count to the user information table displayed in the admin interface. This can be useful when determining if a user is actively using Hypothesis, or to correlate with the public API when determining if a user has mistakenly make private annotations.