### PR TITLE
Use content rather than URL-based PDF detection where possible

### DIFF
--- a/h/browser/chrome/lib/detect-content-type.js
+++ b/h/browser/chrome/lib/detect-content-type.js
@@ -1,0 +1,28 @@
+/**
+ * Returns the type of content in the current document,
+ * currently either 'PDF' or 'HTML'.
+ *
+ * This function is injected as a content script into tabs in
+ * order to detect the type of content on the page (PDF, HTML) etc.
+ * by sniffing for viewer plugins.
+ *
+ * In future this could also be extended to support extraction of the URLs
+ * of content in embedded viewers where that differs from the tab's
+ * main URL.
+ */
+function detectContentType() {
+  // check if this is the Chrome PDF viewer
+  var chromePDFPluginSelector =
+    'embed[type="application/pdf"][name="plugin"][id="plugin"]';
+  if (document.querySelector(chromePDFPluginSelector)) {
+    return {
+      type: 'PDF',
+    };
+  } else {
+    return {
+      type: 'HTML',
+    };
+  }
+}
+
+module.exports = detectContentType;

--- a/h/browser/chrome/lib/detect-content-type.js
+++ b/h/browser/chrome/lib/detect-content-type.js
@@ -13,7 +13,7 @@
 function detectContentType() {
   // check if this is the Chrome PDF viewer
   var chromePDFPluginSelector =
-    'embed[type="application/pdf"][name="plugin"][id="plugin"]';
+    'embed[type="application/pdf"][name="plugin"]';
   if (document.querySelector(chromePDFPluginSelector)) {
     return {
       type: 'PDF',

--- a/h/browser/chrome/lib/hypothesis-chrome-extension.js
+++ b/h/browser/chrome/lib/hypothesis-chrome-extension.js
@@ -208,6 +208,7 @@ function HypothesisChromeExtension(dependencies) {
       });
       return sidebar.injectIntoTab(tab)
         .catch(function (err) {
+          console.error('Failed to inject Hypothesis Sidebar:', err);
           state.errorTab(tab.id, err);
         });
     }

--- a/h/browser/chrome/lib/sidebar-injector.js
+++ b/h/browser/chrome/lib/sidebar-injector.js
@@ -1,30 +1,13 @@
 'use strict';
 
 var blocklist = require('../../../static/scripts/blocklist');
+var detectContentType = require('./detect-content-type');
 var errors = require('./errors');
 var settings = require('./settings');
 var util = require('./util');
 
 var CONTENT_TYPE_HTML = 'HTML';
 var CONTENT_TYPE_PDF = 'PDF';
-
-// a function which is executed as a content script
-// to determine the type of content being displayed in a tab
-function detectContentType(element) {
-  // check if this is the Chrome PDF viewer
-  var element = element || document;
-  var chromePDFPluginSelector =
-    'embed[type="application/pdf"][name="plugin"][id="plugin"]';
-  if (document.querySelector(chromePDFPluginSelector)) {
-    return {
-      type: 'PDF',
-    };
-  } else {
-    return {
-      type: 'HTML',
-    };
-  }
-}
 
 function toIIFEString(fn) {
   return '(' + fn.toString() + ')()';
@@ -94,11 +77,6 @@ function SidebarInjector(chromeTabs, dependencies) {
       return removeFromHTML(tab);
     }
   };
-
-  /**
-   * Returns the type of content in a DOM element or document
-   */
-  this.detectContentType = detectContentType;
 
   function getPDFViewerURL(url) {
     var PDF_VIEWER_URL = extensionURL('/content/web/viewer.html');

--- a/h/browser/chrome/lib/sidebar-injector.js
+++ b/h/browser/chrome/lib/sidebar-injector.js
@@ -10,9 +10,12 @@ var CONTENT_TYPE_PDF = 'PDF';
 
 // a function which is executed as a content script
 // to determine the type of content being displayed in a tab
-function detectContentType() {
+function detectContentType(element) {
   // check if this is the Chrome PDF viewer
-  if (document.querySelector('embed[type="application/pdf"]')) {
+  var element = element || document;
+  var chromePDFPluginSelector =
+    'embed[type="application/pdf"][name="plugin"][id="plugin"]';
+  if (document.querySelector(chromePDFPluginSelector)) {
     return {
       type: 'PDF',
     };
@@ -91,6 +94,11 @@ function SidebarInjector(chromeTabs, dependencies) {
       return removeFromHTML(tab);
     }
   };
+
+  /**
+   * Returns the type of content in a DOM element or document
+   */
+  this.detectContentType = detectContentType;
 
   function getPDFViewerURL(url) {
     var PDF_VIEWER_URL = extensionURL('/content/web/viewer.html');

--- a/h/browser/chrome/lib/sidebar-injector.js
+++ b/h/browser/chrome/lib/sidebar-injector.js
@@ -121,6 +121,10 @@ function SidebarInjector(chromeTabs, dependencies) {
     });
   }
 
+  /**
+   * Returns true if a tab is displaying a PDF using the PDF.js-based
+   * viewer bundled with the extension.
+   */
   function isPDFViewerURL(url) {
     return url.indexOf(getPDFViewerURL('')) === 0;
   }

--- a/h/browser/chrome/lib/util.js
+++ b/h/browser/chrome/lib/util.js
@@ -1,0 +1,44 @@
+function getLastError() {
+  if (typeof chrome !== 'undefined' && chrome.extension) {
+    return chrome.extension.lastError;
+  } else {
+    return undefined;
+  }
+}
+
+/**
+ * Converts an async Chrome API into a function
+ * which returns a promise.
+ *
+ * Usage:
+ *   var apiFn = promisify(chrome.someModule.aFunction);
+ *   apiFn(arg1, arg2)
+ *     .then(function (result) { ...handle success  })
+ *     .catch(function (err) { ...handle error })
+ *
+ *
+ * @param fn A Chrome API function whose last argument is a callback
+ *           which is invoked with the result of the query. When this callback
+ *           is invoked, the promise is rejected if chrome.extension.lastError
+ *           is set or resolved with the first argument to the callback otherwise.
+ */
+function promisify(fn) {
+  return function () {
+    var args = [].slice.call(arguments);
+    var result = new Promise(function (resolve, reject) {
+      fn.apply(this, args.concat(function (result) {
+        var lastError = getLastError();
+        if (lastError) {
+          reject(lastError);
+        } else {
+          resolve(result);
+        }
+      }));
+    });
+    return result;
+  };
+}
+
+module.exports = {
+  promisify: promisify,
+};

--- a/h/browser/chrome/test/detect-content-type-test.js
+++ b/h/browser/chrome/test/detect-content-type-test.js
@@ -1,0 +1,24 @@
+var detectContentType = require('../lib/detect-content-type');
+
+describe('detectContentType()', function () {
+  var el;
+  beforeEach(function () {
+    el = document.createElement('div');
+    document.body.appendChild(el);
+  });
+
+  afterEach(function () {
+    el.parentElement.removeChild(el);
+  });
+
+  it('returns HTML by default', function () {
+    el.innerHTML = '<div></div>';
+    assert.deepEqual(detectContentType(), { type: 'HTML' } );
+  });
+
+  it('returns "PDF" if the Chrome PDF plugin is present', function () {
+    el.innerHTML =
+     '<embed name="plugin" id="plugin" type="application/pdf"></embed>';
+    assert.deepEqual(detectContentType(), { type: 'PDF' });
+  });
+});

--- a/h/browser/chrome/test/detect-content-type-test.js
+++ b/h/browser/chrome/test/detect-content-type-test.js
@@ -18,7 +18,7 @@ describe('detectContentType()', function () {
 
   it('returns "PDF" if the Chrome PDF plugin is present', function () {
     el.innerHTML =
-     '<embed name="plugin" id="plugin" type="application/pdf"></embed>';
+     '<embed name="plugin" type="application/pdf"></embed>';
     assert.deepEqual(detectContentType(), { type: 'PDF' });
   });
 });

--- a/h/browser/chrome/test/sidebar-injector-test.js
+++ b/h/browser/chrome/test/sidebar-injector-test.js
@@ -294,4 +294,27 @@ describe('SidebarInjector', function () {
       });
     });
   });
+
+  describe('.detectContentType', function () {
+    var el;
+    beforeEach(function () {
+      el = document.createElement('div');
+      document.body.appendChild(el);
+    });
+
+    afterEach(function () {
+      el.parentElement.removeChild(el);
+    });
+
+    it('matches the Chrome PDF viewer', function () {
+      el.innerHTML =
+       '<embed name="plugin" id="plugin" type="application/pdf"></embed>';
+      assert.deepEqual(injector.detectContentType(el), { type: 'PDF' });
+    });
+
+    it('reports HTML by default', function () {
+      el.innerHTML = '<div></div>';
+      assert.deepEqual(injector.detectContentType(el), { type: 'HTML' } );
+    });
+  });
 });

--- a/h/browser/chrome/test/sidebar-injector-test.js
+++ b/h/browser/chrome/test/sidebar-injector-test.js
@@ -124,6 +124,7 @@ describe('SidebarInjector', function () {
           var promise = injector.injectIntoTab({id: 1, url: url});
           return promise.then(assertReject, function (err) {
             assert.instanceOf(err, errors.NoFileAccessError);
+            assert.notCalled(fakeChromeTabs.executeScript);
           });
         });
       });

--- a/h/browser/chrome/test/sidebar-injector-test.js
+++ b/h/browser/chrome/test/sidebar-injector-test.js
@@ -294,27 +294,4 @@ describe('SidebarInjector', function () {
       });
     });
   });
-
-  describe('.detectContentType', function () {
-    var el;
-    beforeEach(function () {
-      el = document.createElement('div');
-      document.body.appendChild(el);
-    });
-
-    afterEach(function () {
-      el.parentElement.removeChild(el);
-    });
-
-    it('matches the Chrome PDF viewer', function () {
-      el.innerHTML =
-       '<embed name="plugin" id="plugin" type="application/pdf"></embed>';
-      assert.deepEqual(injector.detectContentType(el), { type: 'PDF' });
-    });
-
-    it('reports HTML by default', function () {
-      el.innerHTML = '<div></div>';
-      assert.deepEqual(injector.detectContentType(el), { type: 'HTML' } );
-    });
-  });
 });


### PR DESCRIPTION
This fixes #1900 by detecting the native Chrome PDF viewer directly where possible, rather than relying on the URL including ".pdf". This mechanism could also be extended in future as a way to add custom handling for other embedded viewers.

The Chrome PDF viewer is an HTML page consisting of a single `<embed>` tag for the native PDF viewer plugin. Third party PDF viewers such as PDF.js which redirect the PDF downloads to a chrome-extension:// URL were supported previously and are not supported now. I'm checking whether there are any 3rd-party viewers that might be affected by this approach.

An alternative approach that sean explored was to check the 'Content-Type' header of the request for the page's main resource. The downside of that is that we have to watch all incoming network requests and have permissions to do that, since the viewer cannot check after the page is received - unless it makes another network request to fetch the original resource (see related upstream issue at https://code.google.com/p/chromium/issues/detail?id=242575 )


