### PR TITLE
Move alembic logger config into env.py and allow debugging

### DIFF
--- a/conf/alembic.ini
+++ b/conf/alembic.ini
@@ -15,25 +15,3 @@ script_location = h:migrations
 
 # Edit the engine string for production.
 sqlalchemy.url: postgresql://postgres@localhost/postgres
-
-[loggers]
-keys = root, alembic
-
-[handlers]
-keys = console
-
-[formatters]
-keys =
-
-[logger_root]
-level = INFO
-handlers = console
-
-[logger_alembic]
-level = INFO
-handlers =
-qualname = alembic
-
-[handler_console]
-class = StreamHandler
-args = (sys.stderr,)


### PR DESCRIPTION
This commit moves the logging config for alembic into the env.py configuration file, and makes it possible to enable SQL debug logging by setting the DEBUG_QUERY environment variable as with the rest of the application.