### PR TITLE
Use timestamps from Python where possible

### DIFF
--- a/h/accounts/models.py
+++ b/h/accounts/models.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import datetime
 import hashlib
 import random
 import string
@@ -100,11 +101,11 @@ class User(Base):
     status = sa.Column(sa.Integer())
 
     last_login_date = sa.Column(sa.TIMESTAMP(timezone=False),
-                                default=sa.func.now(),
+                                default=datetime.datetime.utcnow,
                                 server_default=sa.func.now(),
                                 nullable=False)
     registered_date = sa.Column(sa.TIMESTAMP(timezone=False),
-                                default=sa.func.now(),
+                                default=datetime.datetime.utcnow,
                                 server_default=sa.func.now(),
                                 nullable=False)
 
@@ -132,7 +133,7 @@ class User(Base):
     salt = sa.Column(sa.UnicodeText(), nullable=False)
     # Last password update
     password_updated = sa.Column(sa.DateTime(),
-                                 default=sa.func.now(),
+                                 default=datetime.datetime.utcnow,
                                  server_default=sa.func.now(),
                                  nullable=False)
 
@@ -152,7 +153,7 @@ class User(Base):
             raise ValueError('password must be more than {min} characters '
                              'long'.format(min=PASSWORD_MIN_LENGTH))
         self._password = self._hash_password(raw_password)
-        self.password_updated = sa.func.now()
+        self.password_updated = datetime.datetime.utcnow()
 
     def _hash_password(self, password):
         if not self.salt:

--- a/h/groups/models.py
+++ b/h/groups/models.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import datetime
+
 import sqlalchemy as sa
 from sqlalchemy.orm import exc
 import slugify
@@ -23,11 +25,13 @@ class Group(Base):
                       nullable=False)
     name = sa.Column(sa.UnicodeText(), nullable=False)
     created = sa.Column(sa.DateTime,
+                        default=datetime.datetime.utcnow,
                         server_default=sa.func.now(),
                         nullable=False)
     updated = sa.Column(sa.DateTime,
                         server_default=sa.func.now(),
-                        onupdate=sa.func.now(),
+                        default=datetime.datetime.utcnow,
+                        onupdate=datetime.datetime.utcnow,
                         nullable=False)
 
     # We store information about who created the group -- we don't use this

--- a/h/migrations/versions/42bd46b9b1ea_fill_in_missing_password_updated_fields.py
+++ b/h/migrations/versions/42bd46b9b1ea_fill_in_missing_password_updated_fields.py
@@ -10,6 +10,8 @@ Create Date: 2016-01-07 14:20:44.094611
 revision = '42bd46b9b1ea'
 down_revision = '530268a1937c'
 
+import datetime
+
 from alembic import op
 import sqlalchemy as sa
 from sqlalchemy.orm import sessionmaker
@@ -31,7 +33,7 @@ def upgrade():
         op.execute(user.update().
                    where(user.c.id == id_).
                    where(user.c.password_updated == None).
-                   values(password_updated=sa.func.now()))
+                   values(password_updated=datetime.datetime.utcnow()))
 
 
 def downgrade():


### PR DESCRIPTION
A number of database fields record timestamps. To minimise the likelihood that a synchronisation mismatch between application and database servers will cause problems, this commit changes such code to use timestamps supplied by the Python application where possible.