### PR TITLE
Fix warnings during client test execution

### DIFF
--- a/h/browser/chrome/lib/errors.js
+++ b/h/browser/chrome/lib/errors.js
@@ -28,10 +28,24 @@ function BlockedSiteError(message) {
 }
 BlockedSiteError.prototype = Object.create(ExtensionError);
 
+/**
+ * Report an error.
+ *
+ * This currently simply logs the error with console.error().
+ * In future we can use this as a place to insert Sentry logging etc.
+ *
+ * @param {string} context - Describes the context in which the error occurred
+ * @param {Error} error - The error which happened.
+ */
+function report(context, error) {
+  console.error(context, error);
+}
+
 module.exports = {
   ExtensionError: ExtensionError,
   LocalFileError: LocalFileError,
   NoFileAccessError: NoFileAccessError,
   RestrictedProtocolError: RestrictedProtocolError,
   BlockedSiteError: BlockedSiteError,
+  report: report,
 };

--- a/h/browser/chrome/lib/hypothesis-chrome-extension.js
+++ b/h/browser/chrome/lib/hypothesis-chrome-extension.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var errors = require('./errors');
 var TabState = require('./tab-state');
 var BrowserAction = require('./browser-action');
 var HelpPage = require('./help-page');
@@ -208,7 +209,7 @@ function HypothesisChromeExtension(dependencies) {
       });
       return sidebar.injectIntoTab(tab)
         .catch(function (err) {
-          console.error('Failed to inject Hypothesis Sidebar:', err);
+          errors.report('Failed to inject Hypothesis Sidebar:', err);
           state.errorTab(tab.id, err);
         });
     }

--- a/h/browser/chrome/test/hypothesis-chrome-extension-test.js
+++ b/h/browser/chrome/test/hypothesis-chrome-extension-test.js
@@ -87,6 +87,9 @@ describe('HypothesisChromeExtension', function () {
       injectIntoTab: sandbox.stub().returns(Promise.resolve()),
       removeFromTab: sandbox.stub().returns(Promise.resolve()),
     };
+    fakeErrors = {
+      report: sandbox.spy(),
+    };
 
     function FakeTabState(initialState, onchange) {
       fakeTabState.onChangeHandler = onchange
@@ -99,6 +102,7 @@ describe('HypothesisChromeExtension', function () {
       './help-page': createConstructor(fakeHelpPage),
       './browser-action': createConstructor(fakeBrowserAction),
       './sidebar-injector': createConstructor(fakeSidebarInjector),
+      './errors': fakeErrors
     });
 
     ext = createExt();
@@ -348,6 +352,17 @@ describe('HypothesisChromeExtension', function () {
           assert.called(fakeHelpPage.showHelpForError);
           assert.calledWith(fakeHelpPage.showHelpForError, tab,
             sinon.match.instanceOf(ErrorType));
+        });
+
+        it('logs an error', function () {
+          var injectError = Promise.reject(new ErrorType('msg'));
+          fakeSidebarInjector.injectIntoTab.returns(injectError);
+
+          triggerInstall();
+
+          injectError.catch(function () {
+            assert.called(fakeErrors.report);
+          });
         });
       });
     });

--- a/h/static/scripts/karma-phantomjs-polyfill.js
+++ b/h/static/scripts/karma-phantomjs-polyfill.js
@@ -14,3 +14,13 @@ window.URL = require('js-polyfills/url').URL;
 // Be careful here that any added polyfills are consistent
 // with what is used in builds of the app itself.
 require('es6-promise');
+
+// disallow console output during tests
+['debug', 'log', 'warn', 'error'].forEach(function (method) {
+  var realFn = window.console[method];
+  window.console[method] = function () {
+    var args = [].slice.apply(arguments);
+    realFn.apply(console, args);
+    throw new Error('Tests must not log console warnings');
+  };
+});

--- a/h/static/scripts/test/websocket-test.js
+++ b/h/static/scripts/test/websocket-test.js
@@ -16,11 +16,16 @@ describe('websocket wrapper', function () {
   beforeEach(function () {
     global.WebSocket = FakeWebSocket;
     clock = sinon.useFakeTimers();
+
+    // suppress warnings of WebSocket issues in tests for handling
+    // of abnormal disconnections
+    sinon.stub(console, 'warn');
   });
 
   afterEach(function () {
     global.WebSocket = WebSocket;
     clock.restore();
+    console.warn.restore();
   });
 
   it('should reconnect after an abnormal disconnection', function () {


### PR DESCRIPTION
 * Wrap error reporting of sidebar injection failures
   so that we can stub it during tests and in future
   get them reported back to us

 * Silence warnings about WebSocket disconnections during
   the socket test.

 * Disallow console warnings during tests. In future it is likely
   that we may end up wrapping console reporting from the main app
   in the same way as in the Chrome extension but for the moment
   it is still useful to log exceptional issues