### PR TITLE
Show the annotation's group not the focused group

### DIFF
--- a/h/static/scripts/directive/annotation.js
+++ b/h/static/scripts/directive/annotation.js
@@ -398,6 +398,11 @@ function AnnotationController(
     if (vm.editing()) {
       saveToDrafts(drafts, domainModel, vm);
     }
+
+    // New annotations move to the new group, when a new group is focused.
+    if (isNew(domainModel)) {
+      domainModel.group = groups.focused().id;
+    }
   }
 
   function onUserChanged(event, args) {
@@ -527,7 +532,7 @@ function AnnotationController(
     * @returns {Object} The full group object associated with the annotation.
     */
   vm.group = function() {
-    return groups.focused();
+    return groups.get(domainModel.group);
   };
 
   /**

--- a/h/static/scripts/directive/test/annotation-test.js
+++ b/h/static/scripts/directive/test/annotation-test.js
@@ -1484,6 +1484,30 @@ describe('annotation', function() {
            assert.notCalled(fakeDrafts.update);
          }
       );
+
+      it('updates domainModel.group if the annotation is new', function () {
+        var annotation = newAnnotation();
+        annotation.group = 'old-group-id';
+        createDirective(annotation);
+        fakeGroups.focused = sandbox.stub().returns({id: 'new-group-id'});
+
+        $rootScope.$broadcast(events.GROUP_FOCUSED);
+
+        assert.equal(annotation.group, 'new-group-id');
+      });
+
+      it('does not update domainModel.group if the annotation is not new',
+        function () {
+          var annotation = oldAnnotation();
+          annotation.group = 'old-group-id';
+          createDirective(annotation);
+          fakeGroups.focused = sandbox.stub().returns({id: 'new-group-id'});
+
+          $rootScope.$broadcast(events.GROUP_FOCUSED);
+
+          assert.equal(annotation.group, 'old-group-id');
+        }
+      );
     });
   });
 


### PR DESCRIPTION
In AnnotationController use domainModel.group instead of
groups.focused() to determine which group to display on the annotation.

groups.focused() works fine as long as the group that the annotation
belongs to is always the currently focused group. This is true when in
the sidebar, but not on the stream or on individual annotation pages. On
those pages the most recently focused group the last time the sidebar
was shown is displayed on every annotation, instead of the actual groups
of the annotations.

This means that we now need to update the domainModel.group of new
annotations when the focused group changes, to support this use:

1. Create a new annotation but don't click save yet
2. Change the focused group
3. Save the annotation

The annotation is correctly saved with the currently (and not the
previously) focused group, and also after the focused group the name of
the newly focused group is displayed on the annotation before it's
saved.

Fixes #2839.