### PR TITLE
Fix annotation thread collapsing

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,12 @@
+Unreleased
+==========
+
+Bug fixes
+---------
+
+- Fix a bug where threads were being shown uncollapsed instead of collapsed
+  initially, and the collapse/uncollapse buttons didn't work (#2855)
+
 0.8.9 (2016-01-11)
 ==================
 

--- a/h/static/scripts/directive/annotation.js
+++ b/h/static/scripts/directive/annotation.js
@@ -789,22 +789,26 @@ function link(scope, elem, attrs, controllers) {
 
   elem.on('keydown', ctrl.onKeydown);
 
-  // FIXME: Replace this counting code with something more sane, and
-  // something that doesn't involve so much untested logic in the link
-  // function (as opposed to unit-tested methods on the AnnotationController,
-  // for example).
-  // Keep track of edits going on in the thread.
+  // FIXME: Replace this counting code with something more sane.
   if (counter !== null) {
-    // Propagate changes through the counters.
     scope.$watch((function() {return ctrl.editing();}), function(editing, old) {
-      if (editing) {
+      if (editing) {  // The user has just started editing this annotation.
+
+        // Keep track of edits going on in the thread.
+        // This 'edit' count is for example to uncollapse a thread if one of
+        // the replies in the thread is currently being edited when the
+        // annotations are first rendered (this can happen when switching
+        // focus to a different group then back again, for example).
         counter.count('edit', 1);
-        // Disable the filter and freeze it to always match while editing.
+
+        // Always show an annotation if it is being edited, even if there's an
+        // active search filter that does not match the annotation.
         if ((thread !== null) && (threadFilter !== null)) {
           threadFilter.active(false);
           threadFilter.freeze(true);
         }
-      } else if (old) {
+
+      } else if (old) {  // The user has just finished editing this annotation.
         counter.count('edit', -1);
         if (threadFilter) {
           threadFilter.freeze(false);
@@ -812,7 +816,6 @@ function link(scope, elem, attrs, controllers) {
       }
     });
 
-    // Clean up when the thread is destroyed.
     scope.$on('$destroy', function() {
       if (ctrl.editing() && counter) {
         counter.count('edit', -1);

--- a/h/static/scripts/directive/annotation.js
+++ b/h/static/scripts/directive/annotation.js
@@ -806,15 +806,6 @@ function annotation($document) {
     // for example).
     // Keep track of edits going on in the thread.
     if (counter !== null) {
-      // Expand the thread if descendants are editing.
-      scope.$watch((function() {
-        counter.count('edit');
-      }), function(count) {
-        if (count && !ctrl.editing() && thread.collapsed) {
-          thread.toggleCollapsed();
-        }
-      });
-
       // Propagate changes through the counters.
       scope.$watch((function() {return ctrl.editing();}), function(editing, old) {
         if (editing) {

--- a/h/static/scripts/directive/annotation.js
+++ b/h/static/scripts/directive/annotation.js
@@ -810,13 +810,13 @@ function annotation($document) {
       scope.$watch((function() {
         counter.count('edit');
       }), function(count) {
-        if (count && !ctrl.editing && thread.collapsed) {
+        if (count && !ctrl.editing() && thread.collapsed) {
           thread.toggleCollapsed();
         }
       });
 
       // Propagate changes through the counters.
-      scope.$watch((function() {return ctrl.editing;}), function(editing, old) {
+      scope.$watch((function() {return ctrl.editing();}), function(editing, old) {
         if (editing) {
           counter.count('edit', 1);
           // Disable the filter and freeze it to always match while editing.
@@ -834,7 +834,7 @@ function annotation($document) {
 
       // Clean up when the thread is destroyed.
       scope.$on('$destroy', function() {
-        if (ctrl.editing && counter) {
+        if (ctrl.editing() && counter) {
           counter.count('edit', -1);
         }
       });


### PR DESCRIPTION
This was broken by all the recent annotation directive refactoring:
annotation threads are now shown uncollapsed by default (should be
collapsed) and the buttons to collapse/uncollapse them do nothing.

vm/ctrl.editing became a method vm/ctrl.editing() but some code in the
link function wasn't updated.

This fixes them to be collapsed by default and gets the
collapse/uncollapse buttons working but I'm not sure if the collapse
behaviour is correct with nested threads.

Fixes #2823.