### PR TITLE
Faster docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,25 @@
 FROM gliderlabs/alpine:3.2
 MAINTAINER Hypothes.is Project and contributors
 
-# Update the base image and install runtime dependencies.
-RUN apk-install ca-certificates libffi libpq py-pip nodejs ruby
+# Install system build and runtime dependencies.
+RUN apk add --update \
+    ca-certificates \
+    libffi \
+    libpq \
+    python \
+    py-pip \
+    nodejs \
+    ruby \
+  && apk add \
+    libffi-dev \
+    g++ \
+    make \
+    postgresql-dev \
+    python-dev \
+    ruby-dev \
+  && gem install --no-ri compass \
+  && pip install --no-cache-dir -U pip \
+  && rm -rf /var/cache/apk/*
 
 # Create the hypothesis user, group, home directory and package directory.
 RUN addgroup -S hypothesis \
@@ -11,36 +28,18 @@ WORKDIR /var/lib/hypothesis
 
 # Copy packaging
 COPY h/_version.py ./h/
-COPY package.json setup.* requirements.txt versioneer.py ./
+COPY README.rst package.json setup.* requirements.txt versioneer.py ./
 
-# These files must exist to satisfy setup.py.
-RUN touch CHANGES.txt README.rst
-
-# Install build dependencies, build, then clean up.
-RUN apk-install --virtual build-deps \
-    libffi-dev \
-    g++ \
-    make \
-    postgresql-dev \
-    python-dev \
-    ruby-dev \
-  && gem install --no-ri compass \
-  && npm install --production \
-  && pip install --no-cache-dir -U pip \
+# Install application dependencies.
+RUN npm install --production \
   && pip install --no-cache-dir -r requirements.txt \
-  && apk del build-deps postgresql-dev \
-  && npm cache clean \
-  && rm -rf /tmp/*
+  && npm cache clean
 
 # Copy the rest of the application files
 COPY Procfile gunicorn.conf.py ./
 COPY conf ./conf/
 COPY h ./h/
 COPY scripts ./scripts/
-
-# Change ownership of all the files and switch to the hypothesis user.
-RUN chown -R hypothesis:hypothesis .
-USER hypothesis
 
 # Expose the default port.
 EXPOSE 5000
@@ -55,5 +54,6 @@ RUN hypothesis assets conf/production.ini
 VOLUME ["/var/lib/hypothesis/h/static"]
 
 # Use honcho and start all the daemons by default.
+USER hypothesis
 ENTRYPOINT ["honcho"]
 CMD ["start", "-c", "all=1,assets=0,initdb=0"]

--- a/setup.py
+++ b/setup.py
@@ -80,10 +80,7 @@ setup(
     name='h',
     version=versioneer.get_version(),
     description='The Internet. Peer-reviewed.',
-    long_description='\n\n'.join([
-        open('README.rst', 'rt').read(),
-        open('CHANGES.txt', 'rt').read(),
-    ]),
+    long_description=open('README.rst', 'rt').read(),
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Environment :: Console',


### PR DESCRIPTION
This PR attempts to improve the lives of people frequently building and deploying the h docker image by increasing the proportion of the image that remains cached across multiple builds, at the cost of a somewhat larger image.

Changes include:

- Build dependencies are now installed once and left in the image, as
  opposed to installed only for the duration of the build and then
  removed. The impact of this change is analysed below.
- CHANGES.rst no longer invalidates application dependency build.
- Source files are not chowned to the hypothesis user, so source code
  doesn't take up twice the space in the image.

With this set of changes, at this commit, the total size of the image is 460 MB, compared to 282 MB for the image for v0.8.9. But when we look at the layer breakdown for each of these images we see a different story:

#### v0.8.9 image:

    LAYER                                 SIZE        CUMULATIVE
    base image                            5.249 MB    5.249 MB
    system dependencies                   73.88 MB    79.13 MB
    packaging files                       85.55 kB*   79.22 MB
    build and application dependencies    130.5 MB*   209.7 MB
    application source code               64.95 MB*   274.7 MB
    application static asset build        7.571 MB*   282.2 MB

#### This pull request:

    LAYER                                 SIZE        CUMULATIVE
    base image                            5.249 MB    5.249 MB
    build and system dependencies         308.1 MB    313.4 MB
    packaging files                       87.95 kB    313.4 MB
    application dependencies              106.2 MB    419.6 MB
    application source code               30.73 MB*   450.4 MB
    application static asset build        6.145 MB*   456.5 MB

The difference here is that a typical build (one which didn't change the python or node dependencies) would rebuild each of the starred layers, amounting to a ~203 MB diff previously, and a ~37 MB diff now. The difference is smaller but still not insignificant if a build changes the python/node dependencies (~203 MB/143 MB).

The build is now significantly faster as the system build dependencies no longer need to be downloaded and installed every time:

                  NO CACHE     WARM CACHE
    v0.8.9        7m 9s        6m 41s
    this PR       7m 15s       57s