### PR TITLE
Paginate groups admin

### DIFF
--- a/h/admin.py
+++ b/h/admin.py
@@ -7,6 +7,7 @@ from h.api import nipsa
 from h.i18n import TranslationString as _
 from h import accounts
 from h import models
+from h import paginator
 from h import util
 
 
@@ -222,8 +223,9 @@ def badge_remove(request):
                   request_method='GET',
                   renderer='h:templates/admin/groups.html.jinja2',
                   permission='admin_groups')
-def groups_index(request):
-    return {"groups": models.Group.all()}
+@paginator.paginate
+def groups_index(context, request):
+    return models.Group.query.order_by(models.Group.created.desc())
 
 
 @view.view_config(route_name='admin_groups_csv',
@@ -231,7 +233,7 @@ def groups_index(request):
                   renderer='csv',
                   permission='admin_groups')
 def groups_index_csv(request):
-    groups = models.Group.all()
+    groups = models.Group.query
 
     header = ['Group name', 'Group URL', 'Creator username',
               'Creator email', 'Number of members']

--- a/h/groups/models.py
+++ b/h/groups/models.py
@@ -68,10 +68,6 @@ class Group(Base):
         return '<Group: %s>' % self.slug
 
     @classmethod
-    def all(cls):
-        return cls.query.all()
-
-    @classmethod
     def get_by_pubid(cls, pubid):
         """Return the group with the given pubid, or None."""
         return cls.query.filter(cls.pubid == pubid).first()

--- a/h/paginator.py
+++ b/h/paginator.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import division
+
+import functools
+import math
+
+PAGE_SIZE = 20
+
+
+def paginate(wrapped=None, page_size=PAGE_SIZE):
+    """
+    Decorate a view function, providing basic pagination facilities.
+
+    Wraps a view function that returns a :py:class:`sqlalchemy.orm.query.Query`
+    object in order to enable basic pagination. Returns a dictionary containing
+    the results for the current page and page metadata. For example, the simple
+    view function
+
+        @paginate
+        def my_view(context, request):
+            return User.query
+
+    will, when wrapped, return a dictionary like the following:
+
+        {
+            "results": [<user1>, <user2>, ..., <user20>],
+            "total": 135,
+            "page": {
+                "cur": 1,
+                "max": 7,
+                "next": 2,
+                "prev": None,
+            }
+        }
+
+    You can also call :py:func:`paginate` as a function which returns a
+    decorator, if you wish to modify the options used by the function:
+
+        paginate = paginator.paginate(page_size=10)
+
+        @paginate
+        def my_view(...):
+            ...
+
+    N.B. The wrapped view function must accept two arguments: the request
+    context and the current request. This decorator does not support view
+    functions which accept only a single argument.
+    """
+    if wrapped is None:
+        def decorator(wrap):
+            return paginate(wrap, page_size=page_size)
+        return decorator
+
+    @functools.wraps(wrapped)
+    def wrapper(context, request):
+        result = wrapped(context, request)
+        total = result.count()
+        page_max = int(math.ceil(total / page_size))
+        page_max = max(1, page_max)  # there's always at least one page
+
+        try:
+            page = int(request.params['page'])
+        except (KeyError, ValueError):
+            page = 1
+        page = max(1, page)
+        page = min(page, page_max)
+
+        offset = (page - 1) * page_size
+        limit = page_size
+
+        out = {
+            'results': result.offset(offset).limit(limit).all(),
+            'total': total,
+            'page': {
+                'cur': page,
+                'max': page_max,
+                'next': page + 1 if page < page_max else None,
+                'prev': page - 1 if page > 1 else None,
+            }
+        }
+        return out
+    return wrapper

--- a/h/templates/admin/groups.html.jinja2
+++ b/h/templates/admin/groups.html.jinja2
@@ -25,7 +25,7 @@
         </tr>
       </thead>
       <tbody>
-        {% for group in groups %}
+        {% for group in results %}
           <tr>
             <td>{{ group.name }}</td>
             <td>
@@ -46,4 +46,5 @@
     </table>
   </div>
 
+  {% include "h:templates/includes/paginator.html.jinja2" %}
 {% endblock %}

--- a/h/templates/includes/paginator.html.jinja2
+++ b/h/templates/includes/paginator.html.jinja2
@@ -1,0 +1,35 @@
+<nav>
+  <ul class="pagination">
+    {% if page.prev is none %}
+      <li class="disabled">
+        <span aria-hidden="true">&laquo;</span>
+      </li>
+    {% else %}
+      <li>
+        <a href="?page={{ page.prev }}" aria-label="{% trans %}Previous{% endtrans %}">
+          <span aria-hidden="true">&laquo;</span>
+        </a>
+      </li>
+    {% endif %}
+    {% for n in range(1, page.max + 1) %}
+      {% if n == page.cur %}
+        <li class="active">
+          <span>{{ n }} <span class="sr-only">({% trans %}current{% endtrans %})</span></span>
+        </li>
+      {% else %}
+        <li><a href="?page={{ n }}">{{ n }}</a></li>
+      {% endif %}
+    {% endfor %}
+    {% if page.next is none %}
+      <li class="disabled">
+        <span aria-hidden="true">&raquo;</span>
+      </li>
+    {% else %}
+      <li>
+        <a href="?page={{ page.next }}" aria-label="{% trans %}Next{% endtrans %}">
+          <span aria-hidden="true">&raquo;</span>
+        </a>
+      </li>
+    {% endif %}
+  </ul>
+</nav>

--- a/h/test/paginator_test.py
+++ b/h/test/paginator_test.py
@@ -1,0 +1,161 @@
+# -*- coding: utf-8 -*-
+
+from pyramid.testing import DummyRequest
+import pytest
+
+from h.paginator import paginate
+
+
+class FakeQuery(object):
+
+    """
+    A helper class to fake out the fluent API of a SQLAlchemy Query object.
+    """
+
+    def __init__(self, total):
+        self.total = total
+        self.offset_param = None
+        self.limit_param = None
+        self.all_called = False
+
+    def count(self):
+        return self.total
+
+    def offset(self, n):
+        self.offset_param = n
+        return self
+
+    def limit(self, n):
+        self.limit_param = n
+        return self
+
+    def all(self):
+        self.all_called = True
+        return self
+
+
+def fake_view(total):
+    """
+    Make a fake view function and a mock query object for testing.
+    """
+    query = FakeQuery(total)
+
+    def view(context, request):
+        return query
+
+    return query, view
+
+
+def test_paginate_returns_resultset():
+    request = DummyRequest()
+    query, view = fake_view(total=10)
+
+    wrapped = paginate(view)
+    result = wrapped(context=None, request=request)
+
+    assert result['results'] == query
+    # Assert that .all() has been called to turn the query into a list.
+    assert query.all_called
+
+
+@pytest.mark.parametrize('total', [10, 20, 40, 87])
+def test_paginate_includes_total(total):
+    request = DummyRequest()
+    query, view = fake_view(total=total)
+
+    wrapped = paginate(view)
+    result = wrapped(context=None, request=request)
+
+    assert result['total'] == total
+
+
+@pytest.mark.parametrize('total,param,offset', [
+    # When there are no items:
+    (0, '1', 0),
+    (0, '2', 0),
+
+    # When there are N * PAGE_SIZE items:
+    (20, '1', 0),
+    (20, '2', 0),
+    (40, '1', 0),
+    (40, '2', 20),
+    (40, '3', 20),
+
+    # When the number of items doesn't fit perfectly into N pages:
+    (25, '1', 0),
+    (25, '2', 20),
+    (25, '3', 20),
+
+    # Some extreme cases:
+    (400, '20', 380),
+
+    # Junk data should be discarded:
+    (100, '0', 0),
+    (100, '999e9', 0),
+    (100, 'fish', 0),
+    (400, '-19000', 0),
+    (400, '?????', 0),
+])
+def test_paginate_returns_offsets_and_limits_resultset(total, param, offset):
+    request = DummyRequest(params={'page': param})
+    query, view = fake_view(total)
+
+    wrapped = paginate(view)
+    result = wrapped(context=None, request=request)
+
+    assert result['results'].offset_param == offset
+    assert result['results'].limit_param == 20
+
+
+@pytest.mark.parametrize('total,param,meta', [
+    # When there are no items:
+    (0, '1', (1, 1, None, None)),
+    (0, '2', (1, 1, None, None)),
+
+    # When there are N * PAGE_SIZE items:
+    (20, '1', (1, 1, None, None)),
+    (20, '2', (1, 1, None, None)),
+    (40, '1', (1, 2, 2, None)),
+    (40, '2', (2, 2, None, 1)),
+    (40, '3', (2, 2, None, 1)),
+
+    # When the number of items doesn't fit perfectly into N pages:
+    (25, '1', (1, 2, 2, None)),
+    (25, '2', (2, 2, None, 1)),
+    (25, '3', (2, 2, None, 1)),
+
+    # Some extreme cases:
+    (400, '19', (19, 20, 20, 18)),
+
+    # Junk data should be discarded:
+    (100, '999e9', (1, 5, 2, None)),
+    (100, 'fish',  (1, 5, 2, None)),
+    (400, '-19000', (1, 20, 2, None)),
+    (400, '?????', (1, 20, 2, None)),
+])
+def test_paginate_returns_page_metadata(total, param, meta):
+    request = DummyRequest(params={'page': param})
+    query, view = fake_view(total)
+    ecur, emax, enext, eprev = meta
+
+    wrapped = paginate(view)
+    result = wrapped(context=None, request=request)
+
+    assert result['page'] == {
+        'cur': ecur,
+        'max': emax,
+        'next': enext,
+        'prev': eprev,
+    }
+
+
+def test_paginate_params():
+    request = DummyRequest(params={'page': 2})
+    query, view = fake_view(20)
+
+    decorator = paginate(page_size=5)
+    wrapped = decorator(view)
+    result = wrapped(context=None, request=request)
+
+    assert result['results'].offset_param == 5
+    assert result['results'].limit_param == 5


### PR DESCRIPTION
Just a small PR to address a minor niggle of my own.

Rather than loading and displaying all groups on one page, use a pagination decorator to provide a slightly more enjoyable experience (for both user and rendering engine).

This also sorts the groups so that the most recently created groups are displayed first.