### PR TITLE
Show correct hostname in 'Add to your site' instructions

### DIFF
--- a/h/templates/includes/install_modals.html.jinja2
+++ b/h/templates/includes/install_modals.html.jinja2
@@ -34,7 +34,7 @@
         <div class="installer__section--addtosite">
           <p>
             <input class="installer__embed-script" type="text"
-                    value='&lt;script async defer src="//hypothes.is/embed.js"&gt;&lt;/script&gt;'>
+                    value="<script async defer src=&quot;{{request.resource_url(context, 'embed.js')}}&quot;></script>">
           </p>
           <p>Add the above script tag to your web site's HTML to load
           the Hypothesis sidebar on your site.</p>

--- a/h/templates/old-home.html.jinja2
+++ b/h/templates/old-home.html.jinja2
@@ -242,16 +242,10 @@
                     <div class="installer__section--addtosite">
                       <p>
                         <input class="form-control" type="text"
-                                value='&lt;script async defer src="//hypothes.is/embed.js"&gt;&lt;/script&gt;'>
+                               value="<script async defer src=&quot;{{request.resource_url(context, 'embed.js')}}&quot;></script>">
                       </p>
                       <p>Add the above script tag to your web site's HTML to load
                       the Hypothesis sidebar on your site.</p>
-
-                      <p>To show highlights by default, also add:</p>
-                      <p>
-                        <input class="form-control" type="text"
-                                value='&lt;script&gt;window.hypothesisConfig=function(){return{showHighlights:true};&lt;/script&gt;'>
-                      </p>
 
                       <p>Alternatively, if you use WordPress, checkout the
                       <a href="https://wordpress.org/plugins/hypothesis/">


### PR DESCRIPTION
Instead of hardcoding the hypothes.is domain in the instructions
for adding Hypothes.is to a site, use request.resource_url() to
get the correct host and scheme for the host serving embed.js

Also remove the instructions for adding 'showHighlights: true'
since this is no longer needed as highlights are shown by default.

(This follows up from a support request where a user was confused about how to use the embed from a private instance of H)