### PR TITLE
Build and upload Chrome extensions as build artifacts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 # use Travis container build infrastructure
 sudo: false
 addons:
+  artifacts:
+    paths:
+      # Upload all built zipfiles (browser extensions)
+      - $(ls build/*.zip | tr "\n" ":")
   postgresql: "9.4"
 language:
   - python
@@ -17,15 +21,8 @@ before_script:
 script:
   # Run all tests, with coverage if possible
   - make cover
-  # Test building browser extensions
-  - hypothesis-buildext conf/testext.ini chrome --base http://localhost
-  - hypothesis-buildext conf/testext.ini firefox --base http://localhost
-  - "hypothesis-buildext conf/production.ini chrome
-    --base https://hypothes.is
-    --assets chrome-extension://notarealkey/public"
-  - "hypothesis-buildext conf/production.ini firefox
-    --base https://hypothes.is
-    --assets resource://notarealkey/hypothesis/data"
+  # Build browser extensions
+  - make extensions
 after_success:
   - coveralls
 cache:


### PR DESCRIPTION
Travis supports uploading named files as "build artifacts" after the tests have run.

This commit adds tasks to the Makefile specifically to build our stage and production extensions (the extension IDs are public data) and sets up Travis to upload zipped extension bundles as artifacts.

At the same time it:

a) removes the development builds of the extension from testing to save
   time, as it seems unlikely that we will break the development
   extension and not the production extensions.

b) removes the build of the Firefox extension from testing, as it seems
   very likely that this iteration of the Firefox extension will soon be
   discarded in its entirety in favour of one built on the WebExtensions
   API.