### PR TITLE
Strip Via prefixes in URL normalization

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -10,6 +10,9 @@ Bug fixes
 - Fix a bug where threads were being shown uncollapsed instead of collapsed
   initially, and the collapse/uncollapse buttons didn't work (#2855)
 
+- Strip the proxy prefixes from URLs we know to be proxied (through our "via"
+  service) when normalising (#2861).
+
 0.8.9 (2016-01-11)
 ==================
 

--- a/h/api/test/uri_test.py
+++ b/h/api/test/uri_test.py
@@ -8,6 +8,13 @@ from h.api import uri
 
 
 @pytest.mark.parametrize("url_in,url_out", [
+    # Should strip https://via.hypothes.is/ from the start of URIs
+    ("https://via.hypothes.is/https://example.com", "https://example.com"),
+    ("https://via.hypothes.is/http://foo.com/bar/", "http://foo.com/bar"),
+    # but not when the URI isn't a proxied one
+    ("https://via.hypothes.is", "https://via.hypothes.is"),
+    ("https://via.hypothes.is/sample", "https://via.hypothes.is/sample"),
+
     # Should leave URNs as they are
     ("urn:doi:10.0001/12345", "urn:doi:10.0001/12345"),
 

--- a/h/api/uri.py
+++ b/h/api/uri.py
@@ -115,10 +115,21 @@ UNRESERVED_PATHSEGMENT = "-._~:@!$&'()*+,;="
 UNRESERVED_QUERY_NAME = "-._~:@!$'()*,"
 UNRESERVED_QUERY_VALUE = "-._~:@!$'()*,="
 
+# The string that gets prefixed onto a URI if you paste the URI into our Via
+# form. For example pasting https://example.com would
+# redirect your browser to https://via.hypothes.is/https://example.com.
+VIA_PREFIX = "https://via.hypothes.is/"
+
 
 def normalize(uristr):
     """Translate the given URI into a normalized form."""
     uristr = uristr.encode('utf-8')
+
+    # Strip proxy prefix for proxied URLs
+    for scheme in URL_SCHEMES:
+        if uristr.startswith(VIA_PREFIX + scheme + ':'):
+            uristr = uristr[len(VIA_PREFIX):]
+            break
 
     # Try to extract the scheme
     uri = urlparse.urlsplit(uristr)


### PR DESCRIPTION
https://trello.com/c/xwyKzlwp/223-strip-via-as-part-of-normalization