### PR TITLE
Add a small hysteresis threshold for annotation quotes

### DIFF
--- a/h/templates/client/annotation.html
+++ b/h/templates/client/annotation.html
@@ -59,7 +59,8 @@
            ng-if="vm.hasQuotes()">
     <excerpt enabled="vm.feature('truncate_annotations')"
              collapsed-height="40"
-             inline-controls="true">
+             inline-controls="true"
+             overflow-hysteresis="20">
       <blockquote class="annotation-quote"
                   ng-bind-html="selector.exact"
                   ng-repeat="selector in target.selector


### PR DESCRIPTION
If an annotation quote requires 2 or 3 lines of text, it will
not be truncated, otherwise it will be truncated to 2 lines.

CC @judell 