### PR TITLE
Use our own Elasticsearch client when searching

### DIFF
--- a/h/admin.py
+++ b/h/admin.py
@@ -180,7 +180,7 @@ def users_index(request):
         userid = util.userid_from_username(username, request)
         query = _all_user_annotations_query(userid)
         result = request.es.conn.count(index=request.es.index,
-                                       doc_type='annotation',
+                                       doc_type=request.es.t.annotation,
                                        body={'query': query})
         user_meta['annotations_count'] = result['count']
 

--- a/h/api/__init__.py
+++ b/h/api/__init__.py
@@ -10,4 +10,5 @@ def includeme(config):
 
     config.include('h.features')
     config.include('h.api.db')
+    config.include('h.api.search')
     config.include('h.api.views')

--- a/h/api/db.py
+++ b/h/api/db.py
@@ -147,11 +147,6 @@ def includeme(config):
     # Configure Elasticsearch
     es = store_from_settings(settings)
 
-    # Add a property to all requests for easy access to the elasticsearch
-    # client. This can be used for direct or bulk access without having to
-    # reread the settings.
-    config.add_request_method(lambda req: es, name='es', reify=True)
-
     # Maybe initialize the models
     if asbool(settings.get('h.db.should_drop_all', False)):
         delete_db()

--- a/h/api/search/__init__.py
+++ b/h/api/search/__init__.py
@@ -1,5 +1,23 @@
 # -*- coding: utf-8 -*-
 
+from h.api.search.client import Client
 from h.api.search.core import search
 
 __all__ = ('search',)
+
+
+def _get_client(request):
+    host = request.registry.settings['es.host']
+    index = request.registry.settings['es.index']
+
+    return Client(host, index)
+
+
+def includeme(config):
+    config.registry.settings.setdefault('es.host', 'http://localhost:9200')
+    config.registry.settings.setdefault('es.index', 'annotator')
+
+    # Add a property to all requests for easy access to the elasticsearch
+    # client. This can be used for direct or bulk access without having to
+    # reread the settings.
+    config.add_request_method(_get_client, name='es', reify=True)

--- a/h/api/search/client.py
+++ b/h/api/search/client.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+
+import elasticsearch
+
+
+class Client(object):
+
+    """
+    A convenience wrapper around a connection to ElasticSearch.
+
+    Holds a connection object, an index name, and an enumeration of document
+    types stored in the index.
+
+    :param host: ElasticSearch host URL
+    :param index: index name
+    """
+
+    class t(object):
+        """Document types"""
+        annotation = 'annotation'
+        document = 'document'
+
+    def __init__(self, host, index):
+        self.index = index
+        self.conn = elasticsearch.Elasticsearch([host], verify_certs=True)

--- a/h/config.py
+++ b/h/config.py
@@ -83,6 +83,9 @@ def _setup_elasticsearch(settings):
     if 'ELASTICSEARCH_INDEX' in os.environ:
         settings['es.index'] = os.environ['ELASTICSEARCH_INDEX']
 
+    if 'ELASTICSEARCH_HOST' in os.environ:
+        settings['es.host'] = os.environ['ELASTICSEARCH_HOST']
+
     # ELASTICSEARCH_PORT and MAIL_PORT match Docker container links
     if 'ELASTICSEARCH_PORT' in os.environ:
         es_host = os.environ['ELASTICSEARCH_PORT_9200_TCP_ADDR']

--- a/h/script.py
+++ b/h/script.py
@@ -104,7 +104,7 @@ def annotool(args):
     annotations = es_helpers.scan(request.es.conn,
                                   query={'query': {'match_all': {}}},
                                   index=request.es.index,
-                                  doc_type='annotation')
+                                  doc_type=request.es.t.annotation)
 
     chunksize = 1000
     state = {'total': 0, 'pending': []}
@@ -112,7 +112,7 @@ def annotool(args):
     def _flush():
         bodies = [{
             '_index': request.es.index,
-            '_type': 'annotation',
+            '_type': request.es.t.annotation,
             '_op_type': 'update',
             '_id': x['_id'],
             'doc': x['_source'],

--- a/h/test/admin_test.py
+++ b/h/test/admin_test.py
@@ -461,7 +461,7 @@ def test_users_index_queries_annotation_count(User):
     admin.users_index(request)
 
     es.conn.count.assert_called_with(index=es.index,
-                                     doc_type='annotation',
+                                     doc_type=es.t.annotation,
                                      body=ANY)
 
 


### PR DESCRIPTION
This PR adds `h.api.search.client.Client`, which is a thin wrapper around elasticsearch-py's Elasticsearch class and is intended to have some of the same attributes as [annotator-store's ElasticSearch class][1] so it can serve as a direct replacement in our codebase.

Then, rather than using `Annotation.search_raw` to perform searches, we use the ElasticSearch client now provided as `request.es`.

The motivation here is to decouple the search code from the persistence code so that we can swap out the persistence code (which would include the Annotation model) without affecting search.

[1]: https://github.com/openannotation/annotator-store/blob/45267b0/annotator/elasticsearch.py#L18