### PR TITLE
Remove model dependence from search

### DIFF
--- a/h/api/search/core.py
+++ b/h/api/search/core.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import logging
 
-from h.api import models
 from h.api import nipsa
 from h.api.search import query
 
@@ -57,7 +56,7 @@ def search(request, params, private=True, separate_replies=False):
                              body=builder.build(params))
     total = results['hits']['total']
     docs = results['hits']['hits']
-    rows = [models.Annotation(d['_source'], id=d['_id']) for d in docs]
+    rows = [dict(d['_source'], id=d['_id']) for d in docs]
     return_value = {"rows": rows, "total": total}
 
     if separate_replies:
@@ -77,8 +76,7 @@ def search(request, params, private=True, separate_replies=False):
                      "reply set.")
 
         reply_docs = reply_results['hits']['hits']
-        reply_rows = [models.Annotation(d['_source'], id=d['_id'])
-                      for d in reply_docs]
+        reply_rows = [dict(d['_source'], id=d['_id']) for d in reply_docs]
 
         return_value["replies"] = reply_rows
 

--- a/h/api/search/test/core_test.py
+++ b/h/api/search/test/core_test.py
@@ -6,15 +6,29 @@ from pyramid.testing import DummyRequest
 from h.api.search import core
 
 
+def dummy_search_results(start=1, count=0, name='annotation'):
+    """Generate some dummy search results."""
+    out = {'hits': {'total': 0, 'hits': []}}
+
+    for i in range(start, start + count):
+        out['hits']['total'] += 1
+        out['hits']['hits'].append({
+            '_id': 'id_{}'.format(i),
+            '_source': {'name': '{}_{}'.format(name, i)},
+        })
+
+    return out
+
+
 def dummy_request():
     """Return a mock request with a faked out ElasticSearch connection."""
     es = mock.Mock(spec_set=['conn', 'index', 't'])
-    es.conn.search.return_value = {'hits': {'total': 0, 'hits': []}}
+    es.conn.search.return_value = dummy_search_results(0)
 
     return DummyRequest(es=es)
 
 
-search_fixtures = pytest.mark.usefixtures('query', 'nipsa', 'models', 'log')
+search_fixtures = pytest.mark.usefixtures('query', 'nipsa', 'log')
 
 
 @search_fixtures
@@ -41,7 +55,7 @@ def test_search_does_not_exclude_replies(query):
 
 
 @search_fixtures
-def test_search_queries_for_replies(query, models):
+def test_search_queries_for_replies(query):
     """It should do a second query for replies to the results of the first."""
     request = dummy_request()
 
@@ -56,40 +70,20 @@ def test_search_queries_for_replies(query, models):
     request.es.conn.search.side_effect = [
         # The first time search() is called it returns the result of querying
         # for the top-level annotations only.
-        {
-            'hits': {
-                'total': 3,
-                'hits': [
-                    {'_id': 'annotation_1', '_source': 'source'},
-                    {'_id': 'annotation_2', '_source': 'source'},
-                    {'_id': 'annotation_3', '_source': 'source'}
-                ]
-            }
-        },
+        dummy_search_results(count=3),
         # The second call returns the result of querying for all the replies to
         # those annotations
-        {
-            'hits': {
-                'total': 3,
-                'hits': [
-                    {'_id': 'reply_1', '_source': 'source'},
-                    {'_id': 'reply_2', '_source': 'source'},
-                    {'_id': 'reply_3', '_source': 'source'}
-                ]
-            }
-        },
+        dummy_search_results(start=4, count=3, name='reply'),
     ]
 
     core.search(request, {}, separate_replies=True)
 
     # It should construct a RepliesMatcher for replies to the annotations from
     # the first search.
-    query.RepliesMatcher.assert_called_once_with(
-        ['annotation_1', 'annotation_2', 'annotation_3'])
+    query.RepliesMatcher.assert_called_once_with(['id_1', 'id_2', 'id_3'])
 
     # It should append the RepliesMatcher to the query builder.
-    assert builder.append_matcher.call_args_list[-1] == mock.call(
-        query.RepliesMatcher.return_value)
+    builder.append_matcher.assert_called_with(query.RepliesMatcher.return_value)
 
     # It should call search() a second time with the body from the
     # query builder.
@@ -99,47 +93,24 @@ def test_search_queries_for_replies(query, models):
 
 
 @search_fixtures
-def test_search_returns_replies(models):
-    """It should return an Annotation for each reply from search()."""
+def test_search_returns_replies():
+    """It should return an annotation dict for each reply from search()."""
     request = dummy_request()
     request.es.conn.search.side_effect = [
         # The first time search() is called it returns the result of querying
         # for the top-level annotations only.
-        {
-            'hits': {
-                'total': 1,
-                'hits': [{'_id': 'parent_annotation_id', '_source': 'source'}]
-            }
-        },
+        dummy_search_results(count=1),
         # The second call returns the result of querying for all the replies to
         # those annotations
-        {
-            'hits': {
-                'total': 3,
-                'hits': [
-                    {'_id': 'reply_1', '_source': 'source'},
-                    {'_id': 'reply_2', '_source': 'source'},
-                    {'_id': 'reply_3', '_source': 'source'}
-                ]
-            }
-        },
-    ]
-
-    # It should call Annotation() four times: first for the parent annotation
-    # and then once for each reply.
-    models.Annotation.side_effect = [
-        mock.sentinel.parent_annotation_object,
-        mock.sentinel.reply_annotation_object_1,
-        mock.sentinel.reply_annotation_object_2,
-        mock.sentinel.reply_annotation_object_3,
+        dummy_search_results(start=2, count=3, name='reply'),
     ]
 
     result = core.search(request, {}, separate_replies=True)
 
     assert result['replies'] == [
-        mock.sentinel.reply_annotation_object_1,
-        mock.sentinel.reply_annotation_object_2,
-        mock.sentinel.reply_annotation_object_3
+        {'name': 'reply_2', 'id': 'id_2'},
+        {'name': 'reply_3', 'id': 'id_3'},
+        {'name': 'reply_4', 'id': 'id_4'},
     ]
 
 
@@ -147,26 +118,12 @@ def test_search_returns_replies(models):
 def test_search_logs_a_warning_if_there_are_too_many_replies(log):
     """It should log a warning if there's more than one page of replies."""
     request = dummy_request()
-    request.es.conn.search.side_effect = [
-        {
-            'hits': {
-                'total': 3,
-                'hits': [
-                    {'_id': 'annotation_{n}'.format(n=n), '_source': 'source'}
-                    for n in range(0, 3)]
-            }
-        },
-        # The second call to search() returns 'total': 11000 but only returns
-        # the first 100 of 11000 hits.
-        {
-            'hits': {
-                'total': 11000,
-                'hits': [
-                    {'_id': 'reply_{n}'.format(n=n), '_source': 'source'}
-                    for n in range(0, 100)]
-            }
-        },
-    ]
+    parent_results = dummy_search_results(count=3)
+    replies_results = dummy_search_results(count=100, name='reply')
+    # The second call to search() returns 'total': 11000 but only returns
+    # the first 100 of 11000 hits.
+    replies_results['hits']['total'] = 11000
+    request.es.conn.search.side_effect = [parent_results, replies_results]
 
     core.search(request, {}, separate_replies=True)
 
@@ -178,24 +135,8 @@ def test_search_does_not_log_a_warning_if_there_are_not_too_many_replies(log):
     """It should not log a warning if there's less than one page of replies."""
     request = dummy_request()
     request.es.conn.search.side_effect = [
-        {
-            'hits': {
-                'total': 3,
-                'hits': [
-                    {'_id': 'annotation_{n}'.format(n=n), '_source': 'source'}
-                    for n in range(0, 3)]
-            }
-        },
-        # The second call to search() returns 'total': 100 and returns all 100
-        # hits in the first page of results.
-        {
-            'hits': {
-                'total': 100,
-                'hits': [
-                    {'_id': 'reply_{n}'.format(n=n), '_source': 'source'}
-                    for n in range(0, 100)]
-            }
-        },
+        dummy_search_results(count=3),
+        dummy_search_results(count=100, start=4, name='reply'),
     ]
 
     core.search(request, {}, separate_replies=True)
@@ -214,14 +155,6 @@ def query(request):
 @pytest.fixture
 def nipsa(request):
     patcher = mock.patch('h.api.search.core.nipsa', autospec=True)
-    result = patcher.start()
-    request.addfinalizer(patcher.stop)
-    return result
-
-
-@pytest.fixture
-def models(request):
-    patcher = mock.patch('h.api.search.core.models', autospec=True)
     result = patcher.start()
     request.addfinalizer(patcher.stop)
     return result

--- a/h/feeds/views.py
+++ b/h/feeds/views.py
@@ -3,6 +3,7 @@ from pyramid import i18n
 
 from h.api import search
 from h import feeds
+from h import models
 
 
 _ = i18n.TranslationStringFactory(__package__)
@@ -10,7 +11,8 @@ _ = i18n.TranslationStringFactory(__package__)
 
 def _annotations(request):
     """Return the annotations from the search API."""
-    return search.search(request, request.params)['rows']
+    rows = search.search(request, request.params)['rows']
+    return [models.Annotation(a) for a in rows]
 
 
 @view_config(route_name='stream_atom')

--- a/h/groups/test/views_test.py
+++ b/h/groups/test/views_test.py
@@ -369,9 +369,8 @@ def test_read_returns_document_links(Group, search, renderers, uri,
     g = Group.get_by_pubid.return_value = mock.Mock(slug=mock.sentinel.slug)
     user = request.authenticated_user = mock.Mock()
     user.groups = [g]  # The user is a member of the group.
-    annotations = [
-        mock.Mock(uri="uri_1"), mock.Mock(uri="uri_2"), mock.Mock(uri="uri_3")]
-    search.search.return_value = {"rows": annotations}
+    annotations = [{'uri': 'uri_1'}, {'uri': 'uri_2'}, {'uri': 'uri_3'}]
+    search.search.return_value = {'rows': annotations, 'total': 3}
     def normalize(uri):
         return uri + "_normalized"
     uri.normalize.side_effect = normalize
@@ -396,12 +395,8 @@ def test_read_duplicate_documents_are_removed(Group, search, renderers, uri,
     g = Group.get_by_pubid.return_value = mock.Mock(slug=mock.sentinel.slug)
     user = request.authenticated_user = mock.Mock()
     user.groups = [g]  # The user is a member of the group.
-    annotations = [
-        mock.Mock(uri="uri_1", document_link="document_link_1"),
-        mock.Mock(uri="uri_2", document_link="document_link_2"),
-        mock.Mock(uri="uri_3", document_link="document_link_3")
-    ]
-    search.search.return_value = {"rows": annotations}
+    annotations = [{'uri': 'uri_1'}, {'uri': 'uri_2'}, {'uri': 'uri_3'}]
+    search.search.return_value = {'rows': annotations, 'total': 3}
 
     def normalize(uri):
         # All annotations' URIs normalize to the same URI.
@@ -424,12 +419,8 @@ def test_read_documents_are_truncated(Group, search, renderers, uri,
     g = Group.get_by_pubid.return_value = mock.Mock(slug=mock.sentinel.slug)
     user = request.authenticated_user = mock.Mock()
     user.groups = [g]  # The user is a member of the group.
-    annotations = [
-        mock.Mock(uri="uri_{n}".format(n=n),
-                  document_link="document_link_{n}".format(n=n))
-        for n in range(0, 50)
-    ]
-    search.search.return_value = {"rows": annotations}
+    annotations = [{'uri': 'uri_{n}'.format(n=n)} for n in range(50)]
+    search.search.return_value = {'rows': annotations, 'total': 50}
 
     def normalize(uri):
         return uri + "_normalized"
@@ -580,6 +571,7 @@ def session_model(request):
     request.addfinalizer(patcher.stop)
     return patcher.start()
 
+
 @pytest.fixture
 def renderers(request):
     patcher = mock.patch('h.groups.views.renderers', autospec=True)
@@ -590,8 +582,10 @@ def renderers(request):
 @pytest.fixture
 def search(request):
     patcher = mock.patch('h.groups.views.search', autospec=True)
+    search = patcher.start()
+    search.search.return_value = {'rows': [], 'total': 0}
     request.addfinalizer(patcher.stop)
-    return patcher.start()
+    return search
 
 
 @pytest.fixture

--- a/h/groups/views.py
+++ b/h/groups/views.py
@@ -102,9 +102,10 @@ def _read_group(request, group):
     """
     url = request.route_url('group_read', pubid=group.pubid, slug=group.slug)
 
-    result = search.search(request, private=False, params={
-        "group": group.pubid, "limit": 1000})
-    annotations = [presenters.AnnotationHTMLPresenter(a)
+    result = search.search(request,
+                           private=False,
+                           params={"group": group.pubid, "limit": 1000})
+    annotations = [presenters.AnnotationHTMLPresenter(models.Annotation(a))
                    for a in result['rows']]
 
     # Group the annotations by URI.


### PR DESCRIPTION
This commit removes all remaining mentions of `models.Annotation` from `h.api.search`, in order that changes to `models.Annotation` do not affect the behaviour of search.

Clients of `h.api.search` are now responsible for turning the dicts returned from the search methods into `Annotation` objects if necessary.

**NB:** This branch is based on #2865 and will need to be rebased once that has merged.