### PR TITLE
Decouple Chrome extension build from Pyramid

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ extensions: build/$(ISODATE)-$(BUILD_ID)-chrome-prod.zip
 build/%-chrome-stage.zip:
 	@rm -rf build/chrome $@
 	hypothesis-buildext chrome \
-		--base 'https://stage.hypothes.is' \
+		--service 'https://stage.hypothes.is' \
 		--sentry-dsn $(SENTRY_DSN_STAGE) \
 		--assets 'chrome-extension://iahhmhdkmkifclacffbofcnmgkpalpoj/public'
 	@zip -qr $@ build/chrome
@@ -81,7 +81,7 @@ build/%-chrome-stage.zip:
 build/%-chrome-prod.zip:
 	@rm -rf build/chrome $@
 	hypothesis-buildext chrome \
-		--base 'https://hypothes.is' \
+		--service 'https://hypothes.is' \
 		--sentry-dsn $(SENTRY_DSN_PROD) \
 		--assets 'chrome-extension://bjfhmglciegochdpefhhlphglcehbmek/public'
 	@zip -qr $@ build/chrome

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ build/%-chrome-stage.zip:
 	@rm -rf build/chrome $@
 	hypothesis-buildext chrome \
 		--service 'https://stage.hypothes.is' \
-		--sentry-dsn "$(SENTRY_DSN_STAGE)" \
+		--sentry-public-dsn '$(SENTRY_DSN_STAGE)' \
 		--assets 'chrome-extension://iahhmhdkmkifclacffbofcnmgkpalpoj/public'
 	@zip -qr $@ build/chrome
 
@@ -82,7 +82,7 @@ build/%-chrome-prod.zip:
 	@rm -rf build/chrome $@
 	hypothesis-buildext chrome \
 		--service 'https://hypothes.is' \
-		--sentry-dsn "$(SENTRY_DSN_PROD)" \
+		--sentry-public-dsn '$(SENTRY_DSN_PROD)' \
 		--assets 'chrome-extension://bjfhmglciegochdpefhhlphglcehbmek/public'
 	@zip -qr $@ build/chrome
 

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ build/%-chrome-stage.zip:
 	@rm -rf build/chrome $@
 	hypothesis-buildext chrome \
 		--service 'https://stage.hypothes.is' \
-		--sentry-dsn $(SENTRY_DSN_STAGE) \
+		--sentry-dsn "$(SENTRY_DSN_STAGE)" \
 		--assets 'chrome-extension://iahhmhdkmkifclacffbofcnmgkpalpoj/public'
 	@zip -qr $@ build/chrome
 
@@ -82,7 +82,7 @@ build/%-chrome-prod.zip:
 	@rm -rf build/chrome $@
 	hypothesis-buildext chrome \
 		--service 'https://hypothes.is' \
-		--sentry-dsn $(SENTRY_DSN_PROD) \
+		--sentry-dsn "$(SENTRY_DSN_PROD)" \
 		--assets 'chrome-extension://bjfhmglciegochdpefhhlphglcehbmek/public'
 	@zip -qr $@ build/chrome
 

--- a/Makefile
+++ b/Makefile
@@ -72,19 +72,17 @@ extensions: build/$(ISODATE)-$(BUILD_ID)-chrome-prod.zip
 
 build/%-chrome-stage.zip:
 	@rm -rf build/chrome $@
-	SENTRY_DSN=$(SENTRY_DSN_STAGE) hypothesis-buildext \
-		conf/production.ini \
-		chrome \
+	hypothesis-buildext chrome \
 		--base 'https://stage.hypothes.is' \
+		--sentry-dsn $(SENTRY_DSN_STAGE) \
 		--assets 'chrome-extension://iahhmhdkmkifclacffbofcnmgkpalpoj/public'
 	@zip -qr $@ build/chrome
 
 build/%-chrome-prod.zip:
 	@rm -rf build/chrome $@
-	SENTRY_DSN=$(SENTRY_DSN_PROD) hypothesis-buildext \
-		conf/production.ini \
-		chrome \
+	hypothesis-buildext chrome \
 		--base 'https://hypothes.is' \
+		--sentry-dsn $(SENTRY_DSN_PROD) \
 		--assets 'chrome-extension://bjfhmglciegochdpefhhlphglcehbmek/public'
 	@zip -qr $@ build/chrome
 

--- a/conf/development.ini
+++ b/conf/development.ini
@@ -42,8 +42,6 @@ webassets.cache: False
 webassets.debug: True
 webassets.manifest: False
 webassets.static_view: True
-webassets.browserify_bin: node_modules/.bin/browserify
-webassets.browserify_extra_args: --extension=.coffee --transform coffeeify
 
 ;http://docs.pylonsproject.org/projects/pyramid-debugtoolbar/en/latest/#settings
 debugtoolbar.show_on_exc_only: True

--- a/conf/production.ini
+++ b/conf/production.ini
@@ -57,10 +57,6 @@ webassets.base_dir: h:static
 webassets.base_url: assets
 webassets.cache_max_age: 31536000
 webassets.static_view: True
-webassets.browserify_bin: ./node_modules/.bin/browserify
-webassets.browserify_extra_args: --extension=.coffee --transform coffeeify
-webassets.cleancss_bin: ./node_modules/.bin/cleancss
-webassets.cleancss_extra_args: --skip-advanced --skip-rebase
 webassets.uglifyjs_bin: ./node_modules/.bin/uglifyjs
 
 

--- a/conf/testext.ini
+++ b/conf/testext.ini
@@ -11,9 +11,6 @@ webassets.debug: True
 webassets.manifest: False
 webassets.static_view: True
 webassets.uglifyjs_bin: node_modules/.bin/uglifyjs
-webassets.cleancss_bin: node_modules/.bin/cleancss
-webassets.browserify_bin: node_modules/.bin/browserify
-webassets.browserify_extra_args: --extension=.coffee --transform coffeeify
 
 
 [loggers]

--- a/docs/hacking/chrome-extension.rst
+++ b/docs/hacking/chrome-extension.rst
@@ -20,7 +20,7 @@ To build and install a local development instance of the Chrome extension:
 
    .. code-block:: bash
 
-      hypothesis-buildext --debug conf/development.ini chrome --base 'http://127.0.0.1:5000'
+      hypothesis-buildext --debug chrome --base 'http://127.0.0.1:5000'
 
    .. note::
 
@@ -75,7 +75,7 @@ extension's assets over ``https``:
 
    .. code-block:: bash
 
-      hypothesis-buildext --debug conf/development.ini chrome --base 'https://127.0.0.1:5000'
+      hypothesis-buildext --debug chrome --base 'https://127.0.0.1:5000'
 
 3. Follow steps 3-6 from `Building the Chrome extension for development`_
    above to install the extension in Chrome. (If you've already installed the
@@ -113,12 +113,11 @@ Security Policy you should follow these steps:
    Chrome generates this ID the first time you install the extension and will
    reuse it each time your rebuild or reinstall the extension.
 
-4. Rebuild the Chrome extension with packed assets, an ``https`` base URL, and
-   using ``production.ini`` instead of ``development.ini``:
+4. Rebuild the Chrome extension with packed assets, an ``https`` base URL
 
    .. code-block:: bash
 
-      hypothesis-buildext conf/production.ini chrome
+      hypothesis-buildext chrome
           --base   'https://127.0.0.1:5000'
           --assets 'chrome-extension://<id>/public'
 
@@ -180,11 +179,3 @@ but you're running h on ``http``. Either run h on ``https`` (see
 or rebuild the extension  with ``--base http://...``.
 
 
-File Not Found errors in the console
-====================================
-
-The extension fails to load and you see ``net::ERR_FILE_NOT_FOUND`` errors in
-the console. This can happen if you build the extension with
-``conf/development.ini`` and ``--assets 'chrome-extension://<id>/public'``.
-Packing assets is not supported with ``development.ini``, use
-``conf/production.ini`` instead.

--- a/docs/hacking/chrome-extension.rst
+++ b/docs/hacking/chrome-extension.rst
@@ -20,13 +20,13 @@ To build and install a local development instance of the Chrome extension:
 
    .. code-block:: bash
 
-      hypothesis-buildext --debug chrome --base 'http://127.0.0.1:5000'
+      hypothesis-buildext --debug chrome --service 'http://127.0.0.1:5000'
 
    .. note::
 
       When you run the ``hypothesis-buildext`` command without a ``--assets``
       argument (as in the command above) it builds a Chrome extension
-      configured to load its assets (JavaScript, CSS, ...) from the ``--base``
+      configured to load its assets (JavaScript, CSS, ...) from the ``--service``
       URL (in the command above: your local development instance of the
       Hypothesis web app running at http://127.0.0.1:5000). That is: the web
       app serves these JavaScript, CSS and other files and the Chrome extension
@@ -75,7 +75,7 @@ extension's assets over ``https``:
 
    .. code-block:: bash
 
-      hypothesis-buildext --debug chrome --base 'https://127.0.0.1:5000'
+      hypothesis-buildext --debug chrome --service 'https://127.0.0.1:5000'
 
 3. Follow steps 3-6 from `Building the Chrome extension for development`_
    above to install the extension in Chrome. (If you've already installed the
@@ -118,7 +118,7 @@ Security Policy you should follow these steps:
    .. code-block:: bash
 
       hypothesis-buildext chrome
-          --base   'https://127.0.0.1:5000'
+          --service 'https://127.0.0.1:5000'
           --assets 'chrome-extension://<id>/public'
 
    Replace ``<id>`` with the ID of your extension from the
@@ -144,7 +144,7 @@ Insecure Response errors in the console
 
 You've built the extension with an ``https`` base URL, the extension fails to
 load and you see ``net::ERR_INSECURE_RESPONSE`` errors in the console.
-You need to open https://127.0.0.1:5000 (or whatever ``--base`` you gave)
+You need to open https://127.0.0.1:5000 (or whatever ``--service`` you gave)
 and tell Chrome to allow access to the site even though the certificate isn't
 known.
 
@@ -165,7 +165,7 @@ The extension fails to load and you see
 ``GET http://127.0.0.:5000/... net::ERR_EMPTY_RESPONSE`` errors in the console.
 This happens if you're running h on ``https`` but you've built the Chrome
 extension with an ``http`` base URL. Either run h on ``http`` or rebuild the
-extension with ``--base https://...``.
+extension with ``--service https://...``.
 
 
 Connection Refused errors in the console
@@ -176,6 +176,6 @@ The extension fails to load and you see
 console. This happens if you built the extension with an ``https`` base URL
 but you're running h on ``http``. Either run h on ``https`` (see
 :doc:`Run your local h instance using https </hacking/ssl>`)
-or rebuild the extension  with ``--base http://...``.
+or rebuild the extension  with ``--service http://...``.
 
 

--- a/h/browser/chrome/manifest.json.jinja2
+++ b/h/browser/chrome/manifest.json.jinja2
@@ -23,7 +23,7 @@
     "tabs"
   ],
   "content_security_policy":
-    "script-src 'self' 'unsafe-eval' {{ src }} https://cdn.mathjax.org; object-src 'self'; font-src 'self' data:;",
+    "script-src 'self' 'unsafe-eval' {{ script_src }} https://cdn.mathjax.org; object-src 'self'; font-src 'self' data:;",
 
   "background": {
     "persistent": true,

--- a/h/buildext.py
+++ b/h/buildext.py
@@ -78,8 +78,8 @@ def build_extension_common(webassets_env, base_url, bundle_app=False):
         else:
             app_html_url = '{}/app.html'.format(base_url)
 
-        data = client_assets.render_embed_js(webassets_env=webassets_env,
-                                             app_html_url=app_html_url)
+        data = client.render_embed_js(webassets_env=webassets_env,
+                                      app_html_url=app_html_url)
         fp.write(data)
 
 
@@ -198,7 +198,7 @@ def build_chrome(args):
 
         chrome-extension://<extensionid>/public
     """
-    base_url = args.base
+    base_url = args.service_url
     if base_url.endswith('/'):
         base_url = base_url[:-1]
 
@@ -231,7 +231,6 @@ def build_chrome(args):
     # Render the sidebar html
     api_url = '{}/api'.format(base_url)
     websocket_url = websocketize('{}/ws'.format(base_url))
-    register_url = '{}/register'.format(base_url)
     sentry_dsn = None
 
     if args.sentry_dsn:
@@ -245,14 +244,13 @@ def build_chrome(args):
     if webassets_env.url.startswith('chrome-extension:'):
         build_extension_common(webassets_env, base_url, bundle_app=True)
         with codecs.open(content_dir + '/app.html', 'w', 'utf-8') as fp:
-            data = client_assets.render_app_html(
+            data = client.render_app_html(
                 api_url=api_url,
                 base_url=url_with_path(base_url),
 
                 # Google Analytics tracking is currently not enabled
                 # for the extension
                 ga_tracking_id=None,
-                register_url=register_url,
                 webassets_env=webassets_env,
                 websocket_url=websocket_url,
                 sentry_dsn=sentry_dsn)
@@ -283,10 +281,13 @@ parser.add_argument('--sentry-dsn',
                     default='',
                     help='Specify the Sentry DSN for crash reporting',
                     metavar='SENTRY_DSN')
-parser.add_argument('--base',
-                    help='Base URL',
-                    default='http://localhost:5000',
-                    metavar='URL')
+parser.add_argument(
+    '--service',
+    help="""The URL of the Hypothesis service which the extension
+                            should connect to""",
+    default='http://localhost:5000',
+    dest='service_url',
+    metavar='URL')
 parser.add_argument('--assets',
                     help='A path (relative to base) or URL from which '
                     'to load the static assets',

--- a/h/client.py
+++ b/h/client.py
@@ -85,10 +85,10 @@ def _app_html_context(webassets_env, api_url, base_url, ga_tracking_id,
         'websocketUrl': websocket_url,
     }
 
-    if sentry_dsn:
+    if sentry_public_dsn:
         app_config.update({
             'raven': {
-                'dsn': sentry_dsn,
+                'dsn': sentry_public_dsn,
                 'release': __version__
             }
         })
@@ -110,7 +110,7 @@ def render_app_html(webassets_env,
                     base_url,
                     api_url,
                     websocket_url,
-                    sentry_dsn,
+                    sentry_public_dsn,
                     ga_tracking_id=None,
                     extra={}):
     """
@@ -121,7 +121,8 @@ def render_app_html(webassets_env,
                      (eg. https://hypothes.is/)
     :param api_url: The root URL for the Hypothesis service API
     :param websocket_url: The WebSocket URL which the client should connect to
-    :param sentry_dsn: The _public_ Sentry DSN for client-side crash reporting
+    :param sentry_public_dsn: The _public_ Sentry DSN for client-side
+                              crash reporting
     :param ga_tracking_id: The Google Analytics tracking ID
     :param extra: A dict of optional properties specifying link tags and
                   meta attributes to be included on the page, passed through to
@@ -131,7 +132,7 @@ def render_app_html(webassets_env,
     assets_dict = _app_html_context(api_url=api_url,
                                     base_url=base_url,
                                     ga_tracking_id=ga_tracking_id,
-                                    sentry_dsn=sentry_dsn,
+                                    sentry_public_dsn=sentry_public_dsn,
                                     webassets_env=webassets_env,
                                     websocket_url=websocket_url)
     return template.render(_merge(assets_dict, extra))

--- a/h/client.py
+++ b/h/client.py
@@ -64,24 +64,24 @@ def url_with_path(url):
         return url
 
 
-def _app_html_context(webassets_env, api_url, base_url, ga_tracking_id,
-                      sentry_dsn, websocket_url):
+def _app_html_context(webassets_env, api_url, service_url, ga_tracking_id,
+                      sentry_public_dsn, websocket_url):
     """
     Returns a dict of asset URLs and contents used by the sidebar app
     HTML tempate.
     """
 
-    if urlparse(base_url).hostname == 'localhost':
+    if urlparse(service_url).hostname == 'localhost':
         ga_cookie_domain = 'none'
     else:
         ga_cookie_domain = 'auto'
 
     # the serviceUrl parameter must contain a path element
-    base_url = url_with_path(base_url)
+    service_url = url_with_path(service_url)
 
     app_config = {
         'apiUrl': api_url,
-        'serviceUrl': base_url,
+        'serviceUrl': service_url,
         'websocketUrl': websocket_url,
     }
 
@@ -99,15 +99,14 @@ def _app_html_context(webassets_env, api_url, base_url, ga_tracking_id,
                                  ANGULAR_DIRECTIVE_TEMPLATES),
         'app_css_urls': asset_urls(webassets_env, 'app_css'),
         'app_js_urls': asset_urls(webassets_env, 'app_js'),
-        'base_url': base_url,
         'ga_tracking_id': ga_tracking_id,
         'ga_cookie_domain': ga_cookie_domain,
-        'register_url': base_url + 'register',
+        'register_url': service_url + 'register',
     }
 
 
 def render_app_html(webassets_env,
-                    base_url,
+                    service_url,
                     api_url,
                     websocket_url,
                     sentry_public_dsn,
@@ -117,7 +116,7 @@ def render_app_html(webassets_env,
     Return the HTML for the Hypothesis app page,
     used by the sidebar, stream and single-annotation page.
 
-    :param base_url: The base URL of the Hypothesis service
+    :param service_url: The base URL of the Hypothesis service
                      (eg. https://hypothes.is/)
     :param api_url: The root URL for the Hypothesis service API
     :param websocket_url: The WebSocket URL which the client should connect to
@@ -130,7 +129,7 @@ def render_app_html(webassets_env,
     """
     template = jinja_env.get_template('app.html.jinja2')
     assets_dict = _app_html_context(api_url=api_url,
-                                    base_url=base_url,
+                                    service_url=service_url,
                                     ga_tracking_id=ga_tracking_id,
                                     sentry_public_dsn=sentry_public_dsn,
                                     webassets_env=webassets_env,

--- a/h/client.py
+++ b/h/client.py
@@ -57,6 +57,13 @@ def asset_urls(webassets_env, name):
     return webassets_env[name].urls()
 
 
+def url_with_path(url):
+    if urlparse(url).path == '':
+        return '{}/'.format(url)
+    else:
+        return url
+
+
 def _app_html_context(webassets_env, api_url, base_url, ga_tracking_id,
                       sentry_dsn, websocket_url):
     """
@@ -70,8 +77,7 @@ def _app_html_context(webassets_env, api_url, base_url, ga_tracking_id,
         ga_cookie_domain = 'auto'
 
     # the serviceUrl parameter must contain a path element
-    if urlparse(base_url).path == '':
-        base_url += '/'
+    base_url = url_with_path(base_url)
 
     app_config = {
         'apiUrl': api_url,

--- a/h/script.py
+++ b/h/script.py
@@ -245,8 +245,7 @@ COMMANDS = {
 
 def main():
     # Set a flag in the environment that other code can use to detect if it's
-    # running in a script rather than a full web application. See also
-    # h/buildext.py.
+    # running in a script rather than a full web application.
     #
     # FIXME: This is a nasty hack and should go when we no longer need to spin
     # up an entire application to build the extensions.

--- a/h/views.py
+++ b/h/views.py
@@ -38,7 +38,7 @@ def _render_app(request, extra={}):
         base_url=request.route_url('index'),
         extra=extra,
         ga_tracking_id=request.registry.settings.get('ga_tracking_id'),
-        sentry_dsn=request.sentry.get_public_dsn(),
+        sentry_public_dsn=request.sentry.get_public_dsn(),
         webassets_env=request.webassets_env,
         websocket_url=client.websocketize(request.route_url('ws')), )
     return request.response

--- a/h/views.py
+++ b/h/views.py
@@ -35,12 +35,12 @@ def _handle_exc(request):
 def _render_app(request, extra={}):
     request.response.text = client.render_app_html(
         api_url=request.route_url('api'),
-        base_url=request.route_url('index'),
+        service_url=request.route_url('index'),
         extra=extra,
         ga_tracking_id=request.registry.settings.get('ga_tracking_id'),
         sentry_public_dsn=request.sentry.get_public_dsn(),
         webassets_env=request.webassets_env,
-        websocket_url=client.websocketize(request.route_url('ws')), )
+        websocket_url=client.websocketize(request.route_url('ws')))
     return request.response
 
 


### PR DESCRIPTION
**This builds on https://github.com/hypothesis/h/pull/2874 and will need to be rebased once that is merged**

This PR removes all usage of Pyramid and Pylons from the Chrome extension build, except for a utility function in pyramid.path.

Instead, the script creates a minimal webassets environment, adds in the bundles defined in `assets.yaml` and uses that to generate the output resources.

To simplify creation of this webassets environment, the configuration parameters for Browserify and CleanCSS which used to be defined in the paster config file are now just listed directly in `assets.py`.

As a result, the hypothesis-buildext script no longer requires a paster config file as input. Instead it just takes the name of the browser to build for, plus --debug, --base and --assets flags.