### PR TITLE
Only show the 'Create Account' banner in the sidebar

### DIFF
--- a/h/templates/app.html.jinja2
+++ b/h/templates/app.html.jinja2
@@ -33,7 +33,7 @@
   />
   </top-bar>
 
-  <div class="create-account-banner" ng-if="auth.status === 'signed-out'">
+  <div class="create-account-banner" ng-if="isSidebar && auth.status === 'signed-out'">
     To annotate this document
     <a href="{{ request.route_path('register') }}" target="_blank">
       create a free account


### PR DESCRIPTION
Avoid showing the 'Create Account' banner in the stream and single-annotation card views.

Fixes #2872