### PR TITLE
Decouple the Hypothesis service URL from the app's base URI

### DIFF
--- a/h/sidebar.py
+++ b/h/sidebar.py
@@ -11,5 +11,6 @@ def app_config(request):
     """
     return {
         'apiUrl': request.route_url('api'),
+        'serviceUrl': request.route_url('index'),
         'websocketUrl': _websocketize(request.route_url('ws')),
     }

--- a/h/static/scripts/app.coffee
+++ b/h/static/scripts/app.coffee
@@ -5,7 +5,6 @@ if window.RAVEN_CONFIG
 
 
 require('autofill-event')
-baseURI = require('document-base-uri')
 angular = require('angular')
 require('angular-jwt')
 
@@ -34,13 +33,6 @@ resolve =
   ]
 
 
-configureDocument = ['$provide', ($provide) ->
-  $provide.decorator '$document', ['$delegate', ($delegate) ->
-    $delegate.prop('baseURI', baseURI)
-  ]
-]
-
-
 configureLocation = ['$locationProvider', ($locationProvider) ->
   # Use HTML5 history
   $locationProvider.html5Mode(true)
@@ -66,15 +58,6 @@ configureRoutes = ['$routeProvider', ($routeProvider) ->
   $routeProvider.otherwise
     redirectTo: '/viewer'
 ]
-
-
-configureTemplates = ['$sceDelegateProvider', ($sceDelegateProvider) ->
-  # Explicitly whitelist '.html' paths adjacent to application base URI
-  # TODO: move all front-end templates into their own directory for safety
-  basePattern = new URL('**.html', baseURI).href
-  $sceDelegateProvider.resourceUrlWhitelist ['self', basePattern]
-]
-
 
 setupCrossFrame = ['crossframe', (crossframe) -> crossframe.connect()]
 
@@ -168,10 +151,8 @@ module.exports = angular.module('h', [
 .value('Discovery', require('./discovery'))
 .value('raven', require('./raven'))
 
-.config(configureDocument)
 .config(configureLocation)
 .config(configureRoutes)
-.config(configureTemplates)
 
 .run(setupCrossFrame)
 .run(setupHttp)

--- a/h/static/scripts/directive/annotation.js
+++ b/h/static/scripts/directive/annotation.js
@@ -172,7 +172,7 @@ function updateViewModel($scope, time, domainModel, vm, permissions) {
     text: domainModel.text,
     tags: viewModelTagsFromDomainModelTags(domainModel.tags),
   };
-  vm.annotationURI = new URL('/a/' + domainModel.id, vm.baseURI).href;
+  vm.annotationURI = new URL('/a/' + domainModel.id, vm.serviceUrl).href;
   vm.isPrivate = permissions.isPrivate(
     domainModel.permissions, domainModel.user);
 
@@ -252,7 +252,7 @@ function viewModelTagsFromDomainModelTags(domainModelTags) {
 function AnnotationController(
   $document, $q, $rootScope, $scope, $timeout, $window, annotationUI,
   annotationMapper, drafts, flash, features, groups, permissions, session,
-  tags, time) {
+  settings, tags, time) {
 
   var vm = this;
   var domainModel;
@@ -281,8 +281,8 @@ function AnnotationController(
     // The remaining properties on vm are read-only properties for the
     // templates.
 
-    /** The baseURI for the website, e.g. 'https://hypothes.is/'. */
-    vm.baseURI = $document.prop('baseURI');
+    /** The URL for the Hypothesis service, e.g. 'https://hypothes.is/'. */
+    vm.serviceUrl = settings.serviceUrl;
 
     /** Give the template access to the feature flags. */
     vm.feature = features.flagEnabled;

--- a/h/static/scripts/directive/group-list.js
+++ b/h/static/scripts/directive/group-list.js
@@ -25,14 +25,14 @@ function GroupListController($scope, $window, groups) {
  * @description Displays a list of groups of which the user is a member.
  */
 // @ngInject
-function groupList(groups, $window) {
+function groupList( $window, groups, settings) {
   return {
     controller: GroupListController,
     link: function ($scope, elem, attrs) {
       $scope.groups = groups;
 
       $scope.createNewGroup = function() {
-        $window.open('/groups/new', '_blank');
+        $window.open(settings.serviceUrl + 'groups/new', '_blank');
       }
     },
     restrict: 'E',

--- a/h/static/scripts/directive/login-form.js
+++ b/h/static/scripts/directive/login-form.js
@@ -1,7 +1,7 @@
 'use strict';
 
 // @ngInject
-function Controller($scope, $timeout, flash, session, formRespond) {
+function Controller($scope, $timeout, flash, session, formRespond, settings) {
   var pendingTimeout = null;
 
   function success(data) {
@@ -49,6 +49,7 @@ function Controller($scope, $timeout, flash, session, formRespond) {
     pendingTimeout = null;
   }
 
+  this.serviceUrl = settings.serviceUrl;
 
   this.submit = function submit(form) {
     formRespond(form);

--- a/h/static/scripts/directive/signin-control.js
+++ b/h/static/scripts/directive/signin-control.js
@@ -2,6 +2,12 @@
 
 module.exports = function () {
   return {
+    bindToController: true,
+    controllerAs: 'vm',
+    //@ngInject
+    controller: function (settings) {
+      this.serviceUrl = settings.serviceUrl;
+    },
     restrict: 'E',
     scope: {
       /**

--- a/h/static/scripts/directive/test/annotation-test.js
+++ b/h/static/scripts/directive/test/annotation-test.js
@@ -517,6 +517,7 @@ describe('annotation', function() {
     var fakePermissions;
     var fakePersonaFilter;
     var fakeSession;
+    var fakeSettings;
     var fakeTags;
     var fakeTime;
     var fakeUrlEncodeFilter;
@@ -707,6 +708,10 @@ describe('annotation', function() {
         }
       };
 
+      fakeSettings = {
+        serviceUrl: 'https://test.hypothes.is/',
+      };
+
       fakeTags = {
         filter: sandbox.stub().returns('a while ago'),
         store: sandbox.stub()
@@ -739,6 +744,7 @@ describe('annotation', function() {
       $provide.value('documentTitleFilter', fakeDocumentTitleFilter);
       $provide.value('documentDomainFilter', fakeDocumentDomainFilter);
       $provide.value('session', fakeSession);
+      $provide.value('settings', fakeSettings);
       $provide.value('tags', fakeTags);
       $provide.value('time', fakeTime);
       $provide.value('urlencodeFilter', fakeUrlEncodeFilter);
@@ -1731,6 +1737,9 @@ describe('annotation', function() {
           setDefault: function() {}
         },
         session: session,
+        settings: {
+          serviceUrl: 'https://test.hypothes.is/'
+        },
         tags: args.tags || {
           store: function() {}
         },
@@ -1766,6 +1775,7 @@ describe('annotation', function() {
         $provide.value('flash', locals.flash);
         $provide.value('permissions', locals.permissions);
         $provide.value('session', locals.session);
+        $provide.value('settings', locals.settings);
         $provide.value('tags', locals.tags);
         $provide.value('time', locals.time);
         $provide.value('annotationUI', locals.annotationUI);

--- a/h/static/scripts/directive/test/group-list-test.js
+++ b/h/static/scripts/directive/test/group-list-test.js
@@ -4,25 +4,6 @@ var events = require('../../events');
 var groupList = require('../group-list');
 var util = require('./util');
 
-describe('GroupListController', function () {
-  var controller;
-  var $scope;
-
-  beforeEach(function () {
-    $scope = {
-      $on: sinon.stub(),
-      $apply: sinon.stub(),
-    };
-    var fakeWindow = {};
-    var fakeGroups = {
-      all: sinon.stub(),
-      focused: sinon.stub(),
-    };
-    controller = new groupList.Controller($scope, fakeWindow, fakeGroups);
-  });
-
-});
-
 // returns true if a jQuery-like element has
 // been hidden directly via an ng-show directive.
 //
@@ -40,12 +21,18 @@ describe('groupList', function () {
 
   var groups;
   var fakeGroups;
+  var fakeSettings = {
+    serviceUrl: 'https://test.hypothes.is/',
+  };
 
   before(function() {
     angular.module('app', [])
       .directive('groupList', groupList.directive)
       .factory('groups', function () {
         return fakeGroups;
+      })
+      .factory('settings', function () {
+        return fakeSettings;
       });
   });
 
@@ -133,5 +120,15 @@ describe('groupList', function () {
     var element = createGroupList();
     clickLeaveIcon(element, true);
     assert.notCalled(fakeGroups.focus);
+  });
+
+  it('should open a window when "New Group" is clicked', function () {
+    var element = createGroupList();
+    $window.open = sinon.stub();
+    var newGroupLink =
+      element[0].querySelector('.new-group-btn a');
+    angular.element(newGroupLink).click();
+    assert.calledWith($window.open, fakeSettings.serviceUrl + 'groups/new',
+      '_blank');
   });
 });

--- a/h/static/scripts/groups.js
+++ b/h/static/scripts/groups.js
@@ -11,14 +11,12 @@
  */
 'use strict';
 
-var baseURI = require('document-base-uri');
-
 var STORAGE_KEY = 'hypothesis.groups.focus';
 
 var events = require('./events');
 
 // @ngInject
-function groups(localStorage, session, $rootScope, $http) {
+function groups(localStorage, session, settings, $rootScope, $http) {
   // The currently focused group. This is the group that's shown as selected in
   // the groups dropdown, the annotations displayed are filtered to only ones
   // that belong to this group, and any new annotations that the user creates
@@ -45,7 +43,7 @@ function groups(localStorage, session, $rootScope, $http) {
   function leave(id) {
     var response = $http({
       method: 'POST',
-      url: baseURI + 'groups/' + id + '/leave',
+      url: settings.serviceUrl + 'groups/' + id + '/leave',
     });
 
     // the groups list will be updated in response to a session state

--- a/h/static/scripts/session.js
+++ b/h/static/scripts/session.js
@@ -62,7 +62,7 @@ function sessionActions(options) {
  *
  * @ngInject
  */
-function session($document, $http, $resource, $rootScope, flash, raven) {
+function session($http, $resource, $rootScope, flash, raven, settings) {
   // Headers sent by every request made by the session service.
   var headers = {};
   // TODO: Move accounts data management (e.g. profile, edit_profile,
@@ -72,8 +72,7 @@ function session($document, $http, $resource, $rootScope, flash, raven) {
     transformResponse: process,
     withCredentials: true
   });
-  var base = $document.prop('baseURI');
-  var endpoint = new URL('/app', base).href;
+  var endpoint = new URL('/app', settings.serviceUrl).href;
   var resource = $resource(endpoint, {}, actions);
 
   // Blank initial model state

--- a/h/static/scripts/test/groups-test.js
+++ b/h/static/scripts/test/groups-test.js
@@ -1,7 +1,5 @@
 'use strict';
 
-var baseURI = require('document-base-uri');
-
 var events = require('../events');
 var groups = require('../groups');
 
@@ -23,6 +21,9 @@ describe('groups', function() {
   var fakeLocalStorage;
   var fakeRootScope;
   var fakeHttp;
+  var fakeSettings = {
+    serviceUrl: 'https://test.hypothes.is/'
+  };
   var sandbox;
 
   beforeEach(function() {
@@ -52,7 +53,8 @@ describe('groups', function() {
   });
 
   function service() {
-    return groups(fakeLocalStorage, fakeSession, fakeRootScope, fakeHttp);
+    return groups(fakeLocalStorage, fakeSession,
+                  fakeSettings, fakeRootScope, fakeHttp);
   }
 
   describe('.all()', function() {
@@ -160,7 +162,7 @@ describe('groups', function() {
       var s = service();
       s.leave('id2');
       assert.calledWithMatch(fakeHttp, {
-        url: baseURI + 'groups/id2/leave',
+        url: fakeSettings.serviceUrl + 'groups/id2/leave',
         method: 'POST'
       });
     });

--- a/h/static/scripts/test/login-form-test.coffee
+++ b/h/static/scripts/test/login-form-test.coffee
@@ -37,6 +37,7 @@ describe 'loginForm.Controller', ->
     $provide.value 'flash', mockFlash
     $provide.value 'session', new MockSession()
     $provide.value 'formRespond', mockFormRespond
+    $provide.value 'settings', sandbox.spy()
     return
 
   beforeEach inject (_$controller_, $rootScope, _$timeout_, _session_) ->

--- a/h/static/scripts/test/session-test.js
+++ b/h/static/scripts/test/session-test.js
@@ -23,17 +23,14 @@ describe('h:session', function () {
 
   beforeEach(mock.module(function ($provide) {
     sandbox = sinon.sandbox.create();
-
-    var fakeDocument = {
-      prop: sandbox.stub()
-    };
-    fakeDocument.prop.withArgs('baseURI').returns('http://foo.com/');
     fakeFlash = {error: sandbox.spy()};
     fakeRaven = {
       setUserInfo: sandbox.spy(),
     };
 
-    $provide.value('$document', fakeDocument);
+    $provide.value('settings', {
+      serviceUrl: 'https://test.hypothes.is',
+    });
     $provide.value('flash', fakeFlash);
     $provide.value('raven', fakeRaven);
   }));
@@ -54,7 +51,7 @@ describe('h:session', function () {
   // There's little point testing every single route here, as they're
   // declarative and ultimately we'd be testing ngResource.
   describe('.login()', function () {
-    var url = 'http://foo.com/app?__formid__=login';
+    var url = 'https://test.hypothes.is/app?__formid__=login';
 
     it('should send an HTTP POST to the action', function () {
       $httpBackend.expectPOST(url, {code: 123}).respond({});
@@ -133,7 +130,7 @@ describe('h:session', function () {
   });
 
   describe('.load()', function () {
-    var url = 'http://foo.com/app';
+    var url = 'https://test.hypothes.is/app';
 
     it('should fetch the session data', function () {
       $httpBackend.expectGET(url).respond({});

--- a/h/templates/app.html.jinja2
+++ b/h/templates/app.html.jinja2
@@ -36,7 +36,7 @@
 
   <div class="create-account-banner" ng-if="isSidebar && auth.status === 'signed-out'">
     To annotate this document
-    <a href="{{ request.route_path('register') }}" target="_blank">
+    <a href="{{ request.route_url('register') }}" target="_blank">
       create a free account
     </a>
     or <a href="" ng-click="login()">sign in</a>

--- a/h/templates/app.html.jinja2
+++ b/h/templates/app.html.jinja2
@@ -1,10 +1,11 @@
 {% extends "layouts/base.html.jinja2" %}
 
 {% block base_tag %}
-  {# several parts of the app rely on document.baseURI returning the root
-     URL. They should be fixed to use a different source.
-  #}
-  <base target="_top" href="{{ base_url }}" />
+  {# the <base> tag is required by Angular JS when HTML 5 history is
+     enabled. We shouldn't really need this because a given instance of the app
+     only ever displays a single route.
+   #}
+  <base target="_top" href="/" />
 {% endblock %}
 
 {% block styles %}

--- a/h/templates/client/annotation.html
+++ b/h/templates/client/annotation.html
@@ -9,7 +9,7 @@
       <span>
         <a class="annotation-user"
            target="_blank"
-           ng-href="{{::vm.baseURI}}u/{{vm.user()}}"
+           ng-href="{{::vm.serviceUrl}}u/{{vm.user()}}"
            >{{vm.user() | persona}}</a>
       </span>
 
@@ -49,7 +49,7 @@
        target="_blank"
        title="{{vm.absoluteTimestamp}}"
        ng-if="!vm.editing() && vm.updated()"
-       ng-href="{{::vm.baseURI}}a/{{vm.id()}}"
+       ng-href="{{::vm.serviceUrl}}a/{{vm.id()}}"
        >{{vm.relativeTimestamp}}</a>
   </header>
 

--- a/h/templates/client/annotation.html
+++ b/h/templates/client/annotation.html
@@ -106,7 +106,7 @@
        ng-if="(vm.canCollapseBody || vm.form.tags.length) && !vm.editing()">
     <ul class="tag-list">
       <li class="tag-item" ng-repeat="tag in vm.form.tags">
-        <a href="/stream?q=tag:'{{tag.text|urlencode}}'" target="_blank">{{tag.text}}</a>
+        <a href="{{::vm.serviceUrl}}stream?q=tag:'{{tag.text|urlencode}}'" target="_blank">{{tag.text}}</a>
       </li>
     </ul>
     <div class="u-stretch"></div>

--- a/h/templates/client/login_form.html
+++ b/h/templates/client/login_form.html
@@ -52,7 +52,7 @@
 
         <div class="form-actions">
           <div class="form-actions-message">
-            <a href="/forgot_password" target="_blank">Forgot your password?</a>
+            <a href="{{vm.serviceUrl}}forgot_password" target="_blank">Forgot your password?</a>
           </div>
           <div class="form-actions-buttons">
             <button class="btn btn-primary" type="submit" name="login"

--- a/h/templates/client/share_dialog.html
+++ b/h/templates/client/share_dialog.html
@@ -15,15 +15,15 @@
           ng-value="viaPageLink"
           readonly /></p>
       <p class="share-link-icons">
-      <a href="//twitter.com/intent/tweet?url={{viaPageLink}}"
+      <a href="https://twitter.com/intent/tweet?url={{viaPageLink}}"
          target="_blank"
          title="Tweet link"
          class="share-link-icon h-icon-twitter"></a>
-      <a href="//www.facebook.com/sharer/sharer.php?u={{viaPageLink}}"
+      <a href="https://www.facebook.com/sharer/sharer.php?u={{viaPageLink}}"
          target="_blank"
          title="Share on Facebook"
          class="share-link-icon h-icon-facebook"></a>
-      <a href="//plus.google.com/share?url={{viaPageLink}}"
+      <a href="https://plus.google.com/share?url={{viaPageLink}}"
          target="_blank"
          title="Post on Google Plus"
          class="share-link-icon h-icon-google-plus"></a>

--- a/h/templates/client/signin_control.html
+++ b/h/templates/client/signin_control.html
@@ -1,12 +1,12 @@
 <!-- New controls -->
 <span class="signin-text"
-      ng-if="newStyle && auth.status === 'unknown'">⋯</span>
+      ng-if="vm.newStyle && vm.auth.status === 'unknown'">⋯</span>
 <span class="signin-text"
-      ng-if="newStyle && auth.status === 'signed-out'">
-  <a href="/register" target="_blank">Sign up</a>
-  / <a href="" ng-click="onLogin()">Sign in</a>
+      ng-if="vm.newStyle && vm.auth.status === 'signed-out'">
+  <a href="{{vm.serviceUrl}}register" target="_blank">Sign up</a>
+  / <a href="" ng-click="vm.onLogin()">Sign in</a>
 </span>
-<div ng-if="newStyle"
+<div ng-if="vm.newStyle"
      class="pull-right user-picker"
      dropdown
      keyboard-nav>
@@ -14,64 +14,64 @@
      class="top-bar__btn"
      data-toggle="dropdown"
      dropdown-toggle
-     title="{{auth.username}}">
-    <i class="h-icon-account" ng-if="auth.status === 'signed-in'"></i><!--
+     title="{{vm.auth.username}}">
+    <i class="h-icon-account" ng-if="vm.auth.status === 'signed-in'"></i><!--
     !--><i class="h-icon-arrow-drop-down top-bar__dropdown-arrow"></i>
   </a>
   <ul class="dropdown-menu pull-right" role="menu">
-    <li class="dropdown-menu__row" ng-if="auth.status === 'signed-in'">
-      <a href="/stream?q=user:{{auth.username}}"
+    <li class="dropdown-menu__row" ng-if="vm.auth.status === 'signed-in'">
+      <a href="{{vm.serviceUrl}}stream?q=user:{{vm.auth.username}}"
          class="dropdown-menu__link"
          title="View all your annotations"
-         target="_blank">{{auth.username}}</a>
+         target="_blank">{{vm.auth.username}}</a>
     </li>
-    <li class="dropdown-menu__row" ng-if="auth.status === 'signed-in'">
-      <a class="dropdown-menu__link" href="/profile" target="_blank">Account settings</a>
+    <li class="dropdown-menu__row" ng-if="vm.auth.status === 'signed-in'">
+      <a class="dropdown-menu__link" href="{{vm.serviceUrl}}profile" target="_blank">Account settings</a>
     </li>
     <li class="dropdown-menu__row">
-      <a class="dropdown-menu__link" href="/docs/help" target="_blank">Help</a>
+      <a class="dropdown-menu__link" href="{{vm.serviceUrl}}docs/help" target="_blank">Help</a>
     </li>
     <li class="dropdown-menu__row">
       <a class="dropdown-menu__link" href="mailto:support@hypothes.is">Feedback</a>
     </li>
-    <li class="dropdown-menu__row" ng-if="auth.status === 'signed-in'">
+    <li class="dropdown-menu__row" ng-if="vm.auth.status === 'signed-in'">
       <a class="dropdown-menu__link dropdown-menu__link--subtle"
-         href="" ng-click="onLogout()">Sign out</a>
+         href="" ng-click="vm.onLogout()">Sign out</a>
     </li>
   </ul>
 </div>
 
 <!-- Old controls -->
-<span ng-if="!newStyle && auth.status === 'unknown'">⋯</span>
-<span ng-if="!newStyle && auth.status === 'signed-out'">
-  <a href="" ng-click="onLogin()">Sign in</a>
+<span ng-if="!vm.newStyle && vm.auth.status === 'unknown'">⋯</span>
+<span ng-if="!vm.newStyle && vm.auth.status === 'signed-out'">
+  <a href="" ng-click="vm.onLogin()">Sign in</a>
 </span>
-<div ng-if="!newStyle"
+<div ng-if="!vm.newStyle"
      class="pull-right user-picker"
      dropdown
      keyboard-nav>
   <span role="button" data-toggle="dropdown" dropdown-toggle>
-    {{auth.username}}<!--
+    {{vm.auth.username}}<!--
     --><span class="provider"
-             ng-if="auth.provider">/{{auth.provider}}</span><!--
+             ng-if="vm.auth.provider">/{{vm.auth.provider}}</span><!--
     --><i class="h-icon-arrow-drop-down"></i>
   </span>
   <ul class="dropdown-menu pull-right" role="menu">
-    <li class="dropdown-menu__row" ng-if="auth.status === 'signed-in'">
-      <a class="dropdown-menu__link" href="/profile" target="_blank">Account</a>
+    <li class="dropdown-menu__row" ng-if="vm.auth.status === 'signed-in'">
+      <a class="dropdown-menu__link" href="{{vm.serviceUrl}}profile" target="_blank">Account</a>
     </li>
     <li class="dropdown-menu__row" >
       <a class="dropdown-menu__link" href="mailto:support@hypothes.is">Feedback</a>
     </li>
     <li class="dropdown-menu__row" >
-      <a class="dropdown-menu__link" href="/docs/help" target="_blank">Help</a>
+      <a class="dropdown-menu__link" href="{{vm.serviceUrl}}docs/help" target="_blank">Help</a>
     </li>
-    <li class="dropdown-menu__row" ng-if="auth.status === 'signed-in'">
-      <a class="dropdown-menu__link" href="/stream?q=user:{{auth.username}}"
+    <li class="dropdown-menu__row" ng-if="vm.auth.status === 'signed-in'">
+      <a class="dropdown-menu__link" href="{{vm.serviceUrl}}stream?q=user:{{vm.auth.username}}"
          target="_blank">My Annotations</a>
     </li>
-    <li class="dropdown-menu__row" ng-if="auth.status === 'signed-in'">
-      <a class="dropdown-menu__link" href="" ng-click="onLogout()">Sign out</a>
+    <li class="dropdown-menu__row" ng-if="vm.auth.status === 'signed-in'">
+      <a class="dropdown-menu__link" href="" ng-click="vm.onLogout()">Sign out</a>
     </li>
   </ul>
 </div>


### PR DESCRIPTION
Previously the URL set as the <base> tag was used indirectly
to specify the URL of the Hypothesis service that various
links referred to as well as for other purposes.

Make things clearer by adding an explicit 'serviceUrl' attribute
to the Hypothesis client settings and use that in place of the
baseURI. This also gets us a step closer towards making it possible
to build a development front-end which uses the production service for debugging etc.

The custom template whitelist configuration has been removed
because all of the templates are embedded in app.html, so the
default value of ['self'], allowing templates to be loaded
only from the same domain as the page, is fine - unless anyone is aware of any scenarios where this would not be the case.

---

* [x] I see a local issue with this branch where the Chrome extension fails to connect to the websocket. Need to investigate whether this is related to the changes in this branch. (_This was due to be not having whitelisted requests from the chrome-extension://$ID URL of my local extension build_)
* [x] The 'New Group' link in the Chrome extension should use the service URL explicitly.
* [x] Links in the 'Sign In' menu should use the service URL explicitly.
* [x] Forgot Password and 'Create an account' links need to include the service URL / be absolute
* [x] Share links are broken in the Chrome extension