### PR TITLE
Recognize 'group' as a valid parameter name in search queries

### DIFF
--- a/h/static/scripts/search-filter.coffee
+++ b/h/static/scripts/search-filter.coffee
@@ -12,7 +12,8 @@ module.exports = class SearchFilter
       # The whole term is data
       return [null, term]
 
-    if filter in ['quote', 'result', 'since', 'tag', 'text', 'uri', 'user']
+    if filter in ['group', 'quote', 'result', 'since',
+                  'tag', 'text', 'uri', 'user']
       data = term[filter.length+1..]
       return [filter, data]
     else

--- a/h/static/scripts/test/search-filter-test.coffee
+++ b/h/static/scripts/test/search-filter-test.coffee
@@ -26,12 +26,13 @@ describe 'searchFilter', ->
       assert.equal(result.any[0], query)
 
     it 'uses the filters as keys in the result object', ->
-      query = 'user:john text:foo quote:bar other'
+      query = 'user:john text:foo quote:bar group:agroup other'
       result = searchFilter.toObject(query)
       assert.equal(result.any[0], 'other')
       assert.equal(result.user[0], 'john')
       assert.equal(result.text[0], 'foo')
       assert.equal(result.quote[0], 'bar')
+      assert.equal(result.group[0], 'agroup')
 
     it 'collects the same filters into a list', ->
       query = 'user:john text:foo quote:bar other user:doe text:fuu text:fii'


### PR DESCRIPTION
The backend already supports searches for 'group:hashid' but
this was not supported on the stream because 'group'
was not recognized as a valid parameter so it was passed
to the backend in the 'any' field.

This trivial PR only exposes the minimal group search functionality that the backend already had. It doesn't by any means implement group search in a friendly way - eg. allowing the user to search for "group:_part of the name_". It does make it possible to link to a stream of annotations from a particular group however.