### PR TITLE
Prevent double-posting of new annotations

### DIFF
--- a/h/templates/client/annotation.html
+++ b/h/templates/client/annotation.html
@@ -149,7 +149,12 @@
          when="{'0': '', 'one': '1 reply', 'other': '{} replies'}"></a>
     </div>
 
-    <div class="annotation-actions" ng-if="!vm.editing() && vm.id()">
+    <div class="annotation-actions" ng-if="vm.isSaving">
+      Saving...
+    </div>
+
+    <div class="annotation-actions" ng-if="!vm.isSaving && !vm.editing() && vm.id()">
+      <div ng-show="vm.isSaving">Saving…</div>
       <button class="small btn btn-clean"
               ng-click="vm.reply()"
               ><i class="h-icon-reply btn-icon"></i> Reply</button>
@@ -166,7 +171,7 @@
         </span>
       </span>
       <button class="small btn btn-clean"
-              ng-show="vm.authorize('update')"
+              ng-show="vm.authorize('update') && !vm.isSaving"
               ng-click="vm.edit()"
               ><i class="h-icon-edit btn-icon"></i> Edit</button>
       <button class="small btn btn-clean"


### PR DESCRIPTION
When the user clicks the 'Post' button to create an annotation,
optimistically switch the card back to View mode but display
a 'Saving...' indicator in place of the Reply/Edit/Delete links.

This makes the UI appear more responsive when the user clicks
the Post button and also prevents an issue where the user could
click 'Post' multiple times during the save and create multiple
annotations.

 * Fix a possible inconsistency between the 'Post' button's enabled
   state and whether or not the save() function can succeed.

   The hasContent() and isShared() methods also already have tests,
   so this lets us remove several redundant tests.

 * Fix inconsistency in the return type of the save() function -
   always return a promise.

 * Treat negative status values as network errors as well as 0.
   If the server is unreachable, the real status value may be -1.

Fixes #2864

----

Current Design:

![save-indicator](https://cloud.githubusercontent.com/assets/2458/12509890/cec2675c-c0fd-11e5-85fa-7e828da694e3.png)
