### PR TITLE
Don't open "welcome page" when installed by admin policy

### DIFF
--- a/h/browser/chrome/lib/hypothesis-chrome-extension.js
+++ b/h/browser/chrome/lib/hypothesis-chrome-extension.js
@@ -79,7 +79,17 @@ function HypothesisChromeExtension(dependencies) {
   };
 
   /* Opens the onboarding page */
-  this.firstRun = function () {
+  this.firstRun = function (installDetails) {
+    // If we've been installed because of an administrative policy, then don't
+    // open the welcome page in a new tab.
+    //
+    // It's safe to assume that if an admin policy is responsible for installing
+    // the extension, opening the welcome page is going to do more harm than
+    // good, as it will appear that a tab opened without user action.
+    if (installDetails.installType === 'admin') {
+      return;
+    }
+
     chromeTabs.create({url: 'https://hypothes.is/welcome'}, function (tab) {
       state.activateTab(tab.id);
     });

--- a/h/browser/chrome/lib/install.js
+++ b/h/browser/chrome/lib/install.js
@@ -21,7 +21,7 @@ chrome.runtime.requestUpdateCheck(function (status) {
 
 function onInstalled(installDetails) {
   if (installDetails.reason === 'install') {
-    browserExtension.firstRun();
+    browserExtension.firstRun(installDetails);
   }
 
   // We need this so that 3rd party cookie blocking does not kill us.

--- a/h/browser/chrome/test/hypothesis-chrome-extension-test.js
+++ b/h/browser/chrome/test/hypothesis-chrome-extension-test.js
@@ -148,7 +148,7 @@ describe('HypothesisChromeExtension', function () {
     });
 
     it('opens a new tab pointing to the welcome page', function () {
-      ext.firstRun();
+      ext.firstRun({});
       assert.called(fakeChromeTabs.create);
       assert.calledWith(fakeChromeTabs.create, {
         url: 'https://hypothes.is/welcome'
@@ -156,9 +156,15 @@ describe('HypothesisChromeExtension', function () {
     });
 
     it('sets the browser state to active', function () {
-      ext.firstRun();
+      ext.firstRun({});
       assert.called(fakeTabState.activateTab);
       assert.calledWith(fakeTabState.activateTab, 1);
+    });
+
+    it('does not open a new tab for administrative installs', function () {
+      ext.firstRun({installType: 'admin'});
+      assert.notCalled(fakeChromeTabs.create);
+      assert.notCalled(fakeTabState.activateTab);
     });
   });
 


### PR DESCRIPTION
If the extension has been installed as the result of an administrative policy rather than user action, it doesn't make a lot of sense (and appears to cause some frustration) to open a tab to our "welcome page."

This PR suppresses the opening of the "welcome page" on first run if the install type is `admin`. Chrome documentation references:

- https://developer.chrome.com/extensions/management#event-onInstalled
- https://developer.chrome.com/extensions/management#type-ExtensionInfo
- https://developer.chrome.com/extensions/management#type-ExtensionInstallType

Fixes #2890.