### PR TITLE
Add YAPF config and docs for automatic formatting of Python source code

### DIFF
--- a/docs/hacking/code-style.rst
+++ b/docs/hacking/code-style.rst
@@ -23,10 +23,15 @@ via the ``lint`` make command::
 Python
 ------
 Strict PEP8_. The project also adheres closely to the
-`Google Python Style Guide`_.
+`Google Python Style Guide`_. To reformat code in PEP8_ style,
+you can use the YAPF_ tool::
+
+    $ pip install yapf
+    $ yapf -i <Python source file>
 
 .. _PEP8: http://www.python.org/dev/peps/pep-0008/
 .. _Google Python Style Guide: https://google-styleguide.googlecode.com/svn/trunk/pyguide.html
+.. _YAPF: https://github.com/google/yapf
 
 JavaScript
 ----------

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,3 +15,6 @@ versionfile_source = h/_version.py
 versionfile_build = h/_version.py
 tag_prefix = v
 parentdir_prefix = h-
+
+[yapf]
+based_on_style = pep8


### PR DESCRIPTION
This adds the (one-line) config setting and instructions in the documentation for using [yapf](https://github.com/google/yapf) to reformat code according to PEP8 rules.

Running `yapf -i <Python source>` will take care of all the basic formatting, although it won't reorder or group imports in PEP8 style. Relevant [upstream issue](https://github.com/google/yapf/issues/209)

From brief testing, YAPF may not eliminate all style violations but it shouldn't introduce any new ones.