### PR TITLE
Fix the /docs/help page

### DIFF
--- a/h/templates/help.html.jinja2
+++ b/h/templates/help.html.jinja2
@@ -10,9 +10,7 @@
     <script>
       function hypothesisConfig() { return {firstRun: true} }
     </script>
-    <script async defer>
-      {% include "embed.js.jinja2" %}
-    </script>
+    <script async defer src="{{ embed_js_url }}"></script>
   {% endif %}
 {% endblock %}
 

--- a/h/views.py
+++ b/h/views.py
@@ -116,6 +116,7 @@ def widget(context, request):
 def help_page(context, request):
     current_route = request.matched_route.name
     return {
+        'embed_js_url': request.route_path('embed'),
         'is_help': current_route == 'help',
         'is_onboarding': current_route == 'onboarding',
     }


### PR DESCRIPTION
The embed.js template now requires additional data which was
not provided when rendered via the /docs/help route.

Resolve the issue by including the embed in the same way
that we advise users to include it in their own pages.