### PR TITLE
Double the truncation threshold height for annotations

### DIFF
--- a/h/templates/client/annotation.html
+++ b/h/templates/client/annotation.html
@@ -77,7 +77,7 @@
              inline-controls="false"
              on-collapsible-changed="vm.setBodyCollapsible(collapsible)"
              collapse="vm.collapseBody"
-             collapsed-height="200"
+             collapsed-height="400"
              overflow-hysteresis="20">
       <markdown ng-model="vm.form.text"
                 read-only="!vm.editing()"


### PR DESCRIPTION
As per https://trello.com/c/7QtpfMB5/ increase the threshold
so that only very long annotation bodies are truncated.