### PR TITLE
Fix user annotation query in admin panel

### DIFF
--- a/h/admin.py
+++ b/h/admin.py
@@ -255,7 +255,7 @@ def _all_user_annotations_query(userid):
     """Query matching all annotations (shared and private) owned by userid."""
     return {
         'filtered': {
-            'filter': {'term': {'user': userid}},
+            'filter': {'term': {'user': userid.lower()}},
             'query': {'match_all': {}}
         }
     }

--- a/h/test/admin_test.py
+++ b/h/test/admin_test.py
@@ -455,14 +455,20 @@ def test_users_index_looks_up_users_by_username(User):
 @users_index_fixtures
 def test_users_index_queries_annotation_count(User):
     es = MagicMock()
-    request = DummyRequest(params={"username": "bob"},
+    request = DummyRequest(params={"username": "Bob"},
                            es=es)
 
     admin.users_index(request)
 
+    expected_query = {
+        'query': {
+            'filtered': {'filter': {'term': {'user': u'acct:bob@example.com'}},
+            'query': {'match_all': {}}}
+        }
+    }
     es.conn.count.assert_called_with(index=es.index,
                                      doc_type=es.t.annotation,
-                                     body=ANY)
+                                     body=expected_query)
 
 
 @users_index_fixtures


### PR DESCRIPTION
The query that counts annotations for a given user was incorrect, failing to lowercase the userid in the query.

Ideally this would use the common query builder, but for now simply assert that the userid is forced to lowercase.