### PR TITLE
Remove the need to specify the Chrome extension ID when building with bundled assets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,16 +74,14 @@ build/%-chrome-stage.zip:
 	@rm -rf build/chrome $@
 	hypothesis-buildext chrome \
 		--service 'https://stage.hypothes.is' \
-		--sentry-public-dsn '$(SENTRY_DSN_STAGE)' \
-		--assets 'chrome-extension://iahhmhdkmkifclacffbofcnmgkpalpoj/public'
+		--sentry-public-dsn '$(SENTRY_DSN_STAGE)'
 	@zip -qr $@ build/chrome
 
 build/%-chrome-prod.zip:
 	@rm -rf build/chrome $@
 	hypothesis-buildext chrome \
 		--service 'https://hypothes.is' \
-		--sentry-public-dsn '$(SENTRY_DSN_PROD)' \
-		--assets 'chrome-extension://bjfhmglciegochdpefhhlphglcehbmek/public'
+		--sentry-public-dsn '$(SENTRY_DSN_PROD)'
 	@zip -qr $@ build/chrome
 
 .PHONY: clean cover deps dev extensions lint test

--- a/docs/hacking/chrome-extension.rst
+++ b/docs/hacking/chrome-extension.rst
@@ -12,7 +12,7 @@ tree and install it in Chrome.
 Building the Chrome extension for development
 ---------------------------------------------
 
-To build and install a local development instance of the Chrome extension:
+To build and install the Chrome extension:
 
 1. Do an :doc:`h development install </hacking/install>`.
 
@@ -20,33 +20,20 @@ To build and install a local development instance of the Chrome extension:
 
    .. code-block:: bash
 
-      hypothesis-buildext --debug chrome --service 'http://127.0.0.1:5000'
+      hypothesis-buildext chrome --debug --service 'http://127.0.0.1:5000'
 
    .. note::
 
-      When you run the ``hypothesis-buildext`` command without a ``--assets``
-      argument (as in the command above) it builds a Chrome extension
-      configured to load its assets (JavaScript, CSS, ...) from the ``--service``
-      URL (in the command above: your local development instance of the
-      Hypothesis web app running at http://127.0.0.1:5000). That is: the web
-      app serves these JavaScript, CSS and other files and the Chrome extension
-      is configured to request them from the web app.
+      The ``--service`` URL specifies the Hypothesis service which the extension
+      should communicate with. This can either point to your local H instance,
+      if you have one set up, or the public instance at 'https://hypothes.is'.
 
-      This is the most convenient way to build the extension for development
-      because you can make changes to these source files and have your changes
-      take effect without having to re-run the ``hypothesis-buildext`` command.
+      If you want to test the extension on pages served via HTTPS, you will
+      need to configure the extension to communicate with a Hypothesis service
+      that is **also served over HTTPS**. See :doc:`Serving h over SSL </hacking/ssl>`
+      for instructions on serving a local instance of H via SSL.
 
-      But there are some issues with building the extension this way that you
-      should be aware of:
 
-      1. The extension will fail to load on ``https://`` pages and you'll see a
-         *mixed content* warning in the console. To test the extension on
-         ``https`` sites see
-         `Building an https version of the Chrome extension`_.
-
-      2. The extension will fail to load on some sites that use
-         `Content Security Policy`_. To test the extension on these sites see
-         `Building the Chrome extension for production`_.
 
 3. Go to ``chrome://extensions/`` in Chrome.
 
@@ -57,76 +44,48 @@ To build and install a local development instance of the Chrome extension:
 6. Browse to the ``h/build/chrome/`` directory where the extension was built
    and select it.
 
-Your extension should be working now! Remember that it communicates with your
-local h instance, so you need to have h running to use the extension.
+Your extension should be working now! Remember that if you set ``--service``
+to the URL of your local H instance, you need to have H running
+in order to use the extension.
 
 .. _Content Security Policy: http://en.wikipedia.org/wiki/Content_Security_Policy
 
--------------------------------------------------
-Building an https version of the Chrome extension
--------------------------------------------------
-
-To use the Chrome extension on ``https`` sites you need to serve the
-extension's assets over ``https``:
-
-1. :doc:`Run your local h instance using https </hacking/ssl>`.
-
-2. Build the extension with an ``https`` base URL:
-
-   .. code-block:: bash
-
-      hypothesis-buildext --debug chrome --service 'https://127.0.0.1:5000'
-
-3. Follow steps 3-6 from `Building the Chrome extension for development`_
-   above to install the extension in Chrome. (If you've already installed the
-   extension and you just rebuilt it for ``https`` then you don't need to do
-   anything.)
-
-Your extension should now work on ``https`` sites.
-
-
---------------------------------------------
+---------------------------------------------
 Building the Chrome extension for production
---------------------------------------------
+---------------------------------------------
 
-The production Chrome extension doesn't load its assets from a website. Instead
-we pack the asset files into the extension itself and it loads them from
-``chrome-extension://`` URLs. This makes the extension faster and means that it
-works on sites whose `Content Security Policy`_ would prevent assets from being
-loaded from another site.
+For production builds of the Chrome extension, omit the ``--debug`` flag
+and point it to a service which is served via `HTTPS`. You may also
+wish to enable client error reporting by setting the ``--sentry-public-dsn``
+argument.
 
-This method usually isn't convenient for development because you have to re-run
-the ``hypothesis-buildext`` command after changing the source files for any of
-the assets, but if you want to test the extension on a site that uses Content
-Security Policy you should follow these steps:
+.. code-block:: bash
 
-1. Install some additional dependencies needed to build a production extension:
+   hypothesis-buildext chrome --service 'https://hypothes.is'
 
-   .. code-block:: bash
+----------------------------------------------
+Serving the sidebar from your local H instance
+----------------------------------------------
 
-      pip install -r requirements.txt
+In development, you may find it convenient to configure the extension
+to load the sidebar app from the URL specified with ``--service`` instead
+of bundling it into the extension. Building the extension this way
+allows you to test changes to the sidebar code without having to re-run
+the ``hypothesis-buildext`` command.
 
-2. Follow  `Building an https version of the Chrome extension`_ above to build
-   and install an ``https`` development extension.
+To do this, run ``hypothesis-buildext`` with the ``--no-bundle-sidebar``
+flag.
 
-3. Copy your extension's ID from the ``chrome://extensions`` page.
-   Chrome generates this ID the first time you install the extension and will
-   reuse it each time your rebuild or reinstall the extension.
+There are issues with building the extension this way that you
+should be aware of:
 
-4. Rebuild the Chrome extension with packed assets, an ``https`` base URL
+1. The extension will fail to load on ``https://`` pages unless
+   the Hypothesis service specified with ``--service`` also
+   uses an `https` URL.
 
-   .. code-block:: bash
-
-      hypothesis-buildext chrome
-          --service 'https://127.0.0.1:5000'
-          --assets 'chrome-extension://<id>/public'
-
-   Replace ``<id>`` with the ID of your extension from the
-   ``chrome://extensions`` page.
-
-Your extension should now work on sites with ``https`` and Content Security
-Policy.
-
+2. The extension will fail to load on some sites that use
+   `Content Security Policy`_. To test the extension on these sites
+   you'll need to build without the ``--no-bundle-sidebar`` option.
 
 ---------------
 Troubleshooting
@@ -136,7 +95,8 @@ Mixed Content errors in the console
 ===================================
 
 The extension fails to load and you see *Mixed Content* errors in the console.
-See `Building an https version of the Chrome extension`_.
+When using the Chrome extension on sites served over HTTPS, the extension
+must be configured to use an HTTPS ``--service`` URL.
 
 
 Insecure Response errors in the console
@@ -173,9 +133,7 @@ Connection Refused errors in the console
 
 The extension fails to load and you see
 ``GET https://127.0.0.1:5000/... net::ERR_CONNECTION_REFUSED`` errors in the
-console. This happens if you built the extension with an ``https`` base URL
+console. This happens if you built the extension with an ``https`` service URL
 but you're running h on ``http``. Either run h on ``https`` (see
 :doc:`Run your local h instance using https </hacking/ssl>`)
 or rebuild the extension  with ``--service http://...``.
-
-

--- a/h/assets.yaml
+++ b/h/assets.yaml
@@ -132,7 +132,7 @@ app_js:
     - output: scripts/app.min.js
       filters: uglifyjs
       contents:
-        - output: h:static/scripts/app.js
+        - output: static/scripts/app.js
           filters: browserify
           contents: h:static/scripts/app.coffee
           depends:

--- a/h/browser/chrome/lib/sidebar-injector.js
+++ b/h/browser/chrome/lib/sidebar-injector.js
@@ -226,6 +226,10 @@ function SidebarInjector(chromeTabs, dependencies) {
    * ie. Given '{ foo : "bar" }', this function will return
    * script code to add '<meta name="foo" content="bar">' to the
    * <head> element of the page.
+   *
+   * This enables configuration data to be shared amongst content
+   * scripts which may be running in isolated worlds (see
+   * https://developer.chrome.com/extensions/content_scripts)
    */
   function generateMetaTagCode(env) {
     var envSetupCode = '';

--- a/h/buildext.py
+++ b/h/buildext.py
@@ -198,16 +198,8 @@ def build_chrome(args):
     """
     Build the Chrome extension. You can supply the base URL of an h
     installation with which this extension will communicate, such as
-    "http://localhost:5000" (the default) when developing locally or
+    "http://localhost:5000" when developing locally or
     "https://hypothes.is" to talk to the production Hypothesis application.
-
-    By default, the extension will load static assets (JavaScript/CSS/etc.)
-    from the application you specify. This can be useful when developing, but
-    when building a production extension for deployment to the Chrome Store you
-    will need to specify an assets URL that links to the built assets within
-    the Chrome Extension, such as:
-
-        chrome-extension://<extensionid>/public
     """
     service_url = args.service_url
     if not service_url.endswith('/'):

--- a/h/buildext.py
+++ b/h/buildext.py
@@ -302,7 +302,7 @@ parser.add_argument('--sentry-public-dsn',
 parser.add_argument('--service',
                     help='The URL of the Hypothesis service which the '
                     'extension should connect to',
-                    default='http://localhost:5000/',
+                    default='https://hypothes.is/',
                     dest='service_url',
                     metavar='URL')
 parser.add_argument('--no-bundle-sidebar',

--- a/h/buildext.py
+++ b/h/buildext.py
@@ -205,13 +205,8 @@ def build_chrome(args):
     if not service_url.endswith('/'):
         service_url = '{}/'.format(service_url)
 
-    if args.bundle_sidebar:
-        assets_url = '/public'
-    else:
-        assets_url = '{}assets'.format(service_url)
-
     webassets_env = get_webassets_env(base_dir='./build/chrome/public',
-                                      assets_url=assets_url,
+                                      assets_url='/public',
                                       debug=args.debug)
 
     # Prepare a fresh build.

--- a/h/static/scripts/streamer.js
+++ b/h/static/scripts/streamer.js
@@ -86,8 +86,19 @@ function connect($rootScope, annotationMapper, groups, session, settings) {
     sendClientConfig();
   });
 
-  socket.on('error', function (error) {
-    console.warn('Error connecting to H push notification service:', error);
+  socket.on('error', function (event) {
+    console.warn('Error connecting to H push notification service:', event);
+
+    // In development, warn if the connection failure might be due to
+    // the app's origin not having been whitelisted in the H service's config.
+    //
+    // Unfortunately the error event does not provide a way to get at the
+    // HTTP status code for HTTP -> WS upgrade requests.
+    var websocketHost = new URL(url).hostname;
+    if (['localhost', '127.0.0.1'].indexOf(websocketHost) !== -1) {
+      console.warn('Check that your H service is configured to allow ' +
+                   'WebSocket connections from ' + window.location.origin);
+    }
   });
 
   socket.on('message', function (event) {

--- a/h/templates/embed.js.jinja2
+++ b/h/templates/embed.js.jinja2
@@ -6,7 +6,7 @@ if (typeof(window.annotator) === 'undefined') {
     return;
 }
 
-var resourceRoot = '';
+var resourceRoot;
 var resourceRootTag =
   document.querySelector('meta[name="hypothesis-resource-root"]');
 if (resourceRootTag) {
@@ -14,6 +14,9 @@ if (resourceRootTag) {
 }
 
 function resolve(url) {
+  if (!resourceRoot) {
+    return url;
+  }
   return new URL(url, resourceRoot).href;
 }
 

--- a/h/templates/embed.js.jinja2
+++ b/h/templates/embed.js.jinja2
@@ -6,6 +6,16 @@ if (typeof(window.annotator) === 'undefined') {
     return;
 }
 
+var resourceRoot = '';
+var resourceRootTag =
+  document.querySelector('meta[name="hypothesis-resource-root"]');
+if (resourceRootTag) {
+  resourceRoot = resourceRootTag.content;
+}
+
+function resolve(url) {
+  return new URL(url, resourceRoot).href;
+}
 
 // Injects the hypothesis dependencies. These can be either js or css, the
 // file extension is used to determine the loading method. This file is
@@ -34,7 +44,7 @@ window.hypothesisInstall = function (inject) {
     var link = document.createElement('link');
     link.rel = 'stylesheet';
     link.type = 'text/css';
-    link.href = href;
+    link.href = resolve(href);
 
     document.head.appendChild(link);
     fn(null);
@@ -45,7 +55,7 @@ window.hypothesisInstall = function (inject) {
     script.type = 'text/javascript';
     script.onload = function () { fn(null) };
     script.onerror = function () { fn(new Error('Failed to load script: ' + src)) };
-    script.src = src;
+    script.src = resolve(src);
 
     document.head.appendChild(script);
   };
@@ -74,7 +84,7 @@ window.hypothesisInstall = function (inject) {
 
 var baseUrl = document.createElement('link');
 baseUrl.rel = 'sidebar';
-baseUrl.href = '{{ app_html_url }}';
+baseUrl.href = resolve('{{ app_html_url }}');
 baseUrl.type = 'application/annotator+html';
 document.head.appendChild(baseUrl);
 


### PR DESCRIPTION
This simplifies building the Chrome extension and should make things simpler when we have extensions for other browsers in future by removing the need to specify the 'chrome-extension://<ID>' URL when bundling assets.

This URL was previously used to reference scripts and styles in `app.html` and `embed.js`. In `app.html` this is no longer needed following the decoupling of the service URL from the `<base>` URL, so assets can just use root-relative paths (eg. `/public/scripts/...`)

For embed.js, the extension add a `<meta>` tag to the document containing the root URL of the Hypothesis app and embed.js constructs asset URLs relative to this. The reason for using a `<meta>` tag is that this is accessible by scripts running on the page but in isolated worlds.