### PR TITLE
Don't 404 if a user visits an activation link twice

### DIFF
--- a/h/accounts/test/views_test.py
+++ b/h/accounts/test/views_test.py
@@ -648,22 +648,6 @@ activate_fixtures = pytest.mark.usefixtures('ActivationEvent',
 
 
 @activate_fixtures
-def test_activate_404s_if_code_missing():
-    request = DummyRequest(matchdict={'id': '123'})  # No 'code' in matchdict.
-
-    with pytest.raises(httpexceptions.HTTPNotFound):
-        RegisterController(request).activate()
-
-
-@activate_fixtures
-def test_activate_404s_if_id_missing():
-    request = DummyRequest(matchdict={'code': 'abc123'})  # No 'id'.
-
-    with pytest.raises(httpexceptions.HTTPNotFound):
-        RegisterController(request).activate()
-
-
-@activate_fixtures
 def test_activate_404s_if_id_not_int():
     request = DummyRequest(matchdict={
         'id': 'abc',  # Not an int.

--- a/h/accounts/views.py
+++ b/h/accounts/views.py
@@ -402,7 +402,7 @@ class RegisterController(object):
 
         self.request.session.flash(jinja2.Markup(_(
             'Your account has been activated! '
-            'You can now <a href="{url}">login</a> using the password you '
+            'You can now <a href="{url}">sign in</a> using the password you '
             'provided.').format(url=self.request.route_url('login'))),
             'success')
         self.request.registry.notify(ActivationEvent(self.request, user))

--- a/h/accounts/views.py
+++ b/h/accounts/views.py
@@ -374,12 +374,12 @@ class RegisterController(object):
         id_ = self.request.matchdict.get('id')
 
         if code is None or id_ is None:
-            return httpexceptions.HTTPNotFound()
+            raise httpexceptions.HTTPNotFound()
 
         try:
             id_ = int(id_)
         except ValueError:
-            return httpexceptions.HTTPNotFound()
+            raise httpexceptions.HTTPNotFound()
 
         activation = Activation.get_by_code(code)
         if activation is None:
@@ -395,7 +395,7 @@ class RegisterController(object):
 
         user = User.get_by_activation(activation)
         if user is None or user.id != id_:
-            return httpexceptions.HTTPNotFound()
+            raise httpexceptions.HTTPNotFound()
 
         # Activate the user (by deleting the activation)
         self.request.db.delete(activation)

--- a/h/accounts/views.py
+++ b/h/accounts/views.py
@@ -383,7 +383,15 @@ class RegisterController(object):
 
         activation = Activation.get_by_code(code)
         if activation is None:
-            return httpexceptions.HTTPNotFound()
+            self.request.session.flash(jinja2.Markup(_(
+                "We didn't recognize that activation link. "
+                "Perhaps you've already activated your account? "
+                'If so, try <a href="{url}">signing in</a> using the username '
+                'and password that you provided.').format(
+                    url=self.request.route_url('login'))),
+                'success')
+            return httpexceptions.HTTPFound(
+                location=self.request.route_url('index'))
 
         user = User.get_by_activation(activation)
         if user is None or user.id != id_:

--- a/h/accounts/views.py
+++ b/h/accounts/views.py
@@ -375,9 +375,6 @@ class RegisterController(object):
         code = self.request.matchdict.get('code')
         id_ = self.request.matchdict.get('id')
 
-        if code is None or id_ is None:
-            raise httpexceptions.HTTPNotFound()
-
         try:
             id_ = int(id_)
         except ValueError:


### PR DESCRIPTION
When a user activates their account we delete the row from the activations
database table. If the user then tries to visit an activation link from an
activation email that we sent them, after their account has already been
activated, then we can no longer find the activation row in the db so we 404.

This confuses some users.

Instead, redirect them to the front page (as we do after a successful
activation) with a flash message suggesting that they may already be activated
and should try signing in.

Note that if the user tries to visit a genuinely wrong activation link they
will get this same redirect and suggestion - we don't distinguish between old
activation links and incorrect ones.