### PR TITLE
Group page update

### DIFF
--- a/h/static/styles/group-form.scss
+++ b/h/static/styles/group-form.scss
@@ -19,7 +19,6 @@
     @include flex-center-column();
 
     font-size: $body2-font-size;
-    min-height: 280px;
     background-color: $white;
     border: $border;
     color: $color-dove-gray;
@@ -50,6 +49,16 @@
       margin-bottom: 40px;
     }
 
+    &__heading--short {
+      font-size: $title-font-size;
+      font-weight: $title-font-weight;
+      margin-bottom: 5px;
+    }
+
+    &__nocontent-text {
+      padding-top: 10px;
+    }
+
     .form-field {
       @include flex-center-column();
     }
@@ -76,12 +85,30 @@
     }
   }
 
-  .group-form-document-list {
-    text-align:center;
-  }
+  .group-document-list {
 
-  .group-form-document-list li {
-    margin-top: 1em;
+    justify-content: left;
+    font-size: $body2-font-size;
+    line-height: $body2-line-height;
+    background-color: $white;
+    color: $color-dove-gray;
+
+    border: $border;
+    border-top: none;
+    padding-top: 20px;
+    padding-bottom: 10px;
+    padding-left: 20px;
+    padding-right: 20px;
+
+    &__heading {
+      font-weight: bold;
+      margin-bottom: 1em;
+    }
+
+    &__list li {
+      margin-bottom: 1.5em;
+    }
+
   }
 
   .group-form-footer {

--- a/h/templates/groups/share.html.jinja2
+++ b/h/templates/groups/share.html.jinja2
@@ -12,20 +12,26 @@
   <div class="content content--narrow">
     <div class="group-form is-member-of-group">
       <i class="h-icon-group group-form__heading-icon"></i>
-      <div class="group-form__heading">{{ group.name }}</div>
-
+      <div class="group-form__heading--short">{{ group.name }}</div>
       {% if document_links %}
-        Recently annotated documents:
-        <ul class="group-form-document-list">
+        <a href="{{ request.route_url('stream') }}?q=group:{{ group.pubid }}"
+           target="_blank"
+           title="Recent annotations in this group">
+           View recent group annotations</a>
+      {% else %}
+        <p class="group-form__nocontent-text">This group has not shared any annotations yet.</p>
+      {% endif %}
+    </div>
+    {% if document_links %}
+    <div class="group-document-list">
+        <ul class="group-document-list__list">
+        <p class="group-document-list__heading">Group documents:</p>
           {% for document_link in document_links %}
             <li>{{ document_link }}</li>
           {% endfor %}
         </ul>
-      {% else %}
-        <p>This group has not shared any annotations yet.</p>
-      {% endif %}
-
     </div>
+    {% endif %}
     <div class="group-form-footer">
       <div class="group-form-footer__explain-text">
         {% include "about-groups.html.jinja2" %}


### PR DESCRIPTION
This includes:
- Adding a link to a search by group ID under the group name
- Creating a new div to display the document list, aligned to the left
- Style changes to do all of that.

![screenshot from 2016-02-02 17 36 13](https://cloud.githubusercontent.com/assets/6117168/12770227/96a79a8e-c9d3-11e5-80a0-48a5a283b5a7.png)

![screenshot from 2016-02-02 17 36 45](https://cloud.githubusercontent.com/assets/6117168/12770235/9f89f96c-c9d3-11e5-972b-8159f2c528d4.png)

