### PR TITLE
Admin account deletion

### DIFF
--- a/h/admin.py
+++ b/h/admin.py
@@ -290,9 +290,8 @@ def delete_user(request, user):
     message.
     """
 
-    for group in user.groups:
-        if group.creator == user:
-            raise UserDeletionError('Cannot delete user who is a group creator.')
+    if models.Group.created_by(user).count() > 0:
+        raise UserDeletionError('Cannot delete user who is a group creator.')
 
     user.groups = []
 

--- a/h/admin.py
+++ b/h/admin.py
@@ -172,8 +172,10 @@ def users_index(request):
     user_meta = {}
     username = request.params.get('username')
 
-    if username is not None:
+    if username:
         user = models.User.get_by_username(username)
+        if user is None:
+            user = models.User.get_by_email(username)
 
     if user is not None:
         # Fetch information on how many annotations the user has created

--- a/h/groups/models.py
+++ b/h/groups/models.py
@@ -81,6 +81,11 @@ class Group(Base):
         except exc.NoResultFound:
             return None
 
+    @classmethod
+    def created_by(cls, user):
+        """Return a query object filtering groups by creator."""
+        return cls.query.filter(Group.creator == user)
+
 
 USER_GROUP_TABLE = sa.Table(
     'user_group', Base.metadata,

--- a/h/groups/test/models_test.py
+++ b/h/groups/test/models_test.py
@@ -78,3 +78,17 @@ def test_get_by_id_when_id_does_not_exist():
     db.Session.flush()
 
     assert models.Group.get_by_id(23) is None
+
+
+def test_created_by():
+    name_1 = "My first group"
+    name_2 = "My second group"
+    user = factories.User()
+
+    group_1 = models.Group(name=name_1, creator=user)
+    group_2 = models.Group(name=name_2, creator=user)
+
+    db.Session.add(group_1, group_2)
+    db.Session.flush()
+
+    assert models.Group.created_by(user).all() == [group_1, group_2]

--- a/h/templates/admin/users.html.jinja2
+++ b/h/templates/admin/users.html.jinja2
@@ -10,7 +10,7 @@
 
   <form method="GET" class="form-inline">
     <div class="form-group">
-      <label for="username">Username</label>
+      <label for="username">Username or email</label>
       <input type="text" class="form-control" name="username">
       <input type="submit" class="btn btn-default" value="Find">
     </div>
@@ -44,7 +44,7 @@
         </tbody>
       </table>
     {% else %}
-      <p>No user found with username <em>{{ username }}</em>!</p>
+      <p>No user found with username or email <em>{{ username }}</em>!</p>
     {% endif %}
   {% endif %}
 {% endblock %}

--- a/h/templates/admin/users.html.jinja2
+++ b/h/templates/admin/users.html.jinja2
@@ -43,8 +43,34 @@
           </tr>
         </tbody>
       </table>
+
+      <form id="users-delete-form" method="POST" action="{{request.route_path('admin_users_delete')}}" class="form-inline">
+        <input type="hidden" name="username" value="{{user.username}}">
+
+        {% if user_meta['annotations_count'] > 100 %}
+          <div class="alert alert-warning" role="alert">
+            User has a lot of annotations, it might be safer to delete this user
+            directly in a shell.
+          </div>
+        {% endif %}
+
+        <button class="btn btn-danger" type="submit">Delete user</button>
+      </form>
     {% else %}
       <p>No user found with username or email <em>{{ username }}</em>!</p>
     {% endif %}
   {% endif %}
 {% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+
+  <script type="text/javascript">
+    $(document).ready(function() {
+      $('#users-delete-form').submit(function() {
+        return confirm("This will permanently delete all the user's data. Are you sure?");
+      });
+    });
+  </script>
+{% endblock %}
+

--- a/h/test/admin_test.py
+++ b/h/test/admin_test.py
@@ -453,6 +453,19 @@ def test_users_index_looks_up_users_by_username(User):
 
 
 @users_index_fixtures
+def test_users_index_looks_up_users_by_email(User):
+    es = MagicMock()
+    request = DummyRequest(params={"username": "bob@builder.com"},
+                           es=es)
+
+    User.get_by_username.return_value = None
+
+    admin.users_index(request)
+
+    User.get_by_email.assert_called_with("bob@builder.com")
+
+
+@users_index_fixtures
 def test_users_index_queries_annotation_count(User):
     es = MagicMock()
     request = DummyRequest(params={"username": "bob"},
@@ -471,6 +484,7 @@ def test_users_index_no_user_found(User):
     request = DummyRequest(params={"username": "bob"},
                            es=es)
     User.get_by_username.return_value = None
+    User.get_by_email.return_value = None
 
     result = admin.users_index(request)
 

--- a/h/test/admin_test.py
+++ b/h/test/admin_test.py
@@ -631,14 +631,14 @@ def test_badge_remove_returns_index(badge_index):
 
 
 delete_user_fixtures = pytest.mark.usefixtures(
-    'elasticsearch_helpers', 'api_storage')
+    'elasticsearch_helpers', 'api_storage', 'Group')
 
 
 @delete_user_fixtures
-def test_delete_user_raises_when_group_creator():
+def test_delete_user_raises_when_group_creator(Group):
     request, user = Mock(), Mock()
-    group = Mock(creator=user)
-    user.groups = [group]
+
+    Group.created_by.return_value.count.return_value = 10
 
     with pytest.raises(admin.UserDeletionError):
         admin.delete_user(request, user)
@@ -746,6 +746,14 @@ def User(config, request):  # pylint:disable=unused-argument
     patcher = patch('h.admin.models.User', autospec=True)
     request.addfinalizer(patcher.stop)
     return patcher.start()
+
+
+@pytest.fixture
+def Group(request):
+    patcher = patch('h.admin.models.Group', autospec=True)
+    cls = patcher.start()
+    request.addfinalizer(patcher.stop)
+    return cls
 
 
 @pytest.fixture


### PR DESCRIPTION
As discussed with @nickstenning and @lenazun, this is the minimal viable solution for deleting a user from the admin interface.

It does not allow to delete a user that is a group creator, because of the foreign key constraint on `group.creator_id`, and there are plans on using a group creator as a group admin in the future.

This will delete the following objects in order:

1. Group memberships
2. Annotations
3. User

Since this is the minimal viable solution, we are deleting all the objects during the request and not in a background worker. This means that users with lots of annotations should still be deleted in a shell on the server.
However, to make that easier I've put the relevant logic into its own function, so you would only need to run the following:

```python
>>> from h.accounts.models import User
>>> from h import admin
>>> user = User.get_by_username(u'bobthebuilder')
>>> admin.delete_user(request, user)
>>> request.tm.commit()
```

_As I'm new to H and Python, please point out even the smallest things, as it is the best way to get used to Pythonland._