### PR TITLE
Fix client-side router on site

### DIFF
--- a/h/static/scripts/share-group-form.js
+++ b/h/static/scripts/share-group-form.js
@@ -1,4 +1,7 @@
 function ShareGroupFormController(element) {
+  if (!element.querySelector('.is-member-of-group')) {
+    return;
+  }
   var shareLink = element.querySelector('.js-share-link');
   shareLink.focus();
   shareLink.select();

--- a/h/static/scripts/site.js
+++ b/h/static/scripts/site.js
@@ -3,32 +3,31 @@ if (window.RAVEN_CONFIG) {
   require('./raven').init(window.RAVEN_CONFIG);
 }
 
+var page = require('page');
+
 var CreateGroupFormController = require('./create-group-form');
 var DropdownMenuController = require('./dropdown-menu');
 var InstallerController = require('./installer-controller');
 var ShareGroupFormController = require('./share-group-form');
 
-// load our customized version of Bootstrap which
-// provides a few basic UI components (eg. modal dialogs)
-require('../styles/vendor/bootstrap/bootstrap');
+// setup components
+new DropdownMenuController(document);
 
-function setupGroupsController(path) {
-  if (path === '/groups/new') {
-    new CreateGroupFormController(document.body);
-  } else if (document.querySelector('.is-member-of-group')) {
-    new ShareGroupFormController(document.body);
-  }
-}
+page('/', function () {
+  // load our customized version of Bootstrap which
+  // provides a few basic UI components (eg. modal dialogs)
+  require('../styles/vendor/bootstrap/bootstrap');
+  new InstallerController(document.body);
+});
+
+page('/groups/new', function () {
+  new CreateGroupFormController(document.body);
+});
+
+page('/groups/:id/:name', function () {
+  new ShareGroupFormController(document.body);
+});
 
 document.addEventListener('DOMContentLoaded', function () {
-  // setup components
-  new DropdownMenuController(document);
-
-  // setup route
-  var route = document.location.pathname;
-  if (route === '/') {
-    new InstallerController(document.body);
-  } else if (route.match('^/groups') === 0) {
-    setupGroupsController(route);
-  }
+  page.start();
 });

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "js-polyfills": "^0.1.11",
     "ng-tags-input": "2.2.0",
     "node-uuid": "^1.4.3",
+    "page": "^1.6.4",
     "postcss": "^5.0.6",
     "raf": "^3.1.0",
     "raven-js": "^2.0.2",


### PR DESCRIPTION
The JS for the group share page failed to load
because of an incorrect comparison of the result
of String.match() against a number and also
because of an attempt to load Bootstrap
unnecessarily on this pages.

This commit fixes the issue and prepares us for
adding new pages in future by:

 * Adding a client-side micro-router to simplify running
   page-specific JS

 * Only loading the Bootstrap components on pages that
   actually need it.

Fixes #2867