### PR TITLE
Do not update the group for existing annotations on edit

### DIFF
--- a/h/static/scripts/directive/annotation.js
+++ b/h/static/scripts/directive/annotation.js
@@ -154,7 +154,7 @@ function saveToDrafts(drafts, domainModel, vm) {
  * @param {object} vm The object to copy properties from
  *
  */
-function updateDomainModel(domainModel, vm, permissions, groups) {
+function updateDomainModel(domainModel, vm, permissions) {
   domainModel.text = vm.form.text;
   domainModel.tags = domainModelTagsFromViewModelTags(vm.form.tags);
   if (vm.isPrivate) {
@@ -162,7 +162,6 @@ function updateDomainModel(domainModel, vm, permissions, groups) {
   } else {
     domainModel.permissions = permissions.shared(domainModel.group);
   }
-  domainModel.group = groups.focused().id;
 }
 
 /** Update the view model from the domain model changes. */
@@ -646,7 +645,7 @@ function AnnotationController(
     var saved;
     switch (vm.action) {
       case 'create':
-        updateDomainModel(domainModel, vm, permissions, groups);
+        updateDomainModel(domainModel, vm, permissions);
         saved = domainModel.$create().then(function () {
           $rootScope.$emit('annotationCreated', domainModel);
           updateView(domainModel);
@@ -656,7 +655,7 @@ function AnnotationController(
 
       case 'edit':
         var updatedModel = angular.copy(domainModel);
-        updateDomainModel(updatedModel, vm, permissions, groups);
+        updateDomainModel(updatedModel, vm, permissions);
         saved = updatedModel.$update({
           id: updatedModel.id
         }).then(function () {

--- a/h/static/scripts/directive/test/annotation-test.js
+++ b/h/static/scripts/directive/test/annotation-test.js
@@ -249,17 +249,6 @@ describe('annotation', function() {
 
       assert.equal(domainModel.permissions, 'shared permissions');
     });
-
-    it('sets domainModel.group according to groups.focused()', function() {
-      var domainModel = {};
-      var viewModel = {form: {text: 'foo'}};
-      var groups = fakeGroups();
-      groups.focused = function() {return {id: 'focused_group_id'};};
-
-      updateDomainModel(domainModel, viewModel, fakePermissions(), groups);
-
-      assert.equal(domainModel.group, 'focused_group_id');
-    });
   });
 
   describe('link', function () {


### PR DESCRIPTION
Whenever an annotation was edited, its current group
was set to whichever group was focused in the UI.

Our current model does not allow for moving annotations
between groups however. The only time when annotations
should have their groups set is when the annotation
is newly created and when switching groups before saving
the annotation. We already have separate logic to deal
with both of these cases.

Fixes #2902