### PR TITLE
Add automated retry with backoff for session loads

### DIFF
--- a/h/browser/chrome/test/uri-info-test.js
+++ b/h/browser/chrome/test/uri-info-test.js
@@ -1,20 +1,7 @@
 var uriInfo = require('../lib/uri-info');
 var settings = require('./settings.json');
 
-/**
- * Takes a Promise<T> and returns a Promise<Result>
- * where Result = { result: T } | { error: any }.
- *
- * This is useful for testing that promises are rejected
- * as expected in tests.
- */
-function toResult(promise) {
-  return promise.then(function (result) {
-    return { result: result };
-  }).catch(function (err) {
-    return { error: err }
-  });
-}
+var toResult = require('../../../static/scripts/test/promise-util').toResult;
 
 describe('UriInfo.query', function() {
   var server;

--- a/h/static/scripts/app.coffee
+++ b/h/static/scripts/app.coffee
@@ -13,7 +13,7 @@ streamer = require('./streamer')
 resolve =
   # Ensure that we have available a) the current authenticated userid, and b)
   # the list of user groups.
-  sessionState: ['session', (session) -> session.load().$promise]
+  sessionState: ['session', (session) -> session.load()]
   store: ['store', (store) -> store.$promise]
   streamer: streamer.connect
   threading: [

--- a/h/static/scripts/config/identity.js
+++ b/h/static/scripts/config/identity.js
@@ -74,7 +74,7 @@ function checkAuthentication($injector, $q, session) {
     var deferred = $q.defer();
     authPromise = deferred.promise;
 
-    session.load().$promise
+    session.load()
       .then(function (data) {
         if (data.userid) {
           $injector.invoke(fetchToken).then(function (token) {

--- a/h/static/scripts/retry-util.js
+++ b/h/static/scripts/retry-util.js
@@ -1,0 +1,34 @@
+'use strict';
+
+var retry = require('retry');
+var Promise = require('core-js/library/es6/promise');
+
+/**
+ * Retry a Promise-returning operation until it succeeds or
+ * fails after a set number of attempts.
+ *
+ * @param {Function} opFn - The operation to retry
+ * @param {Object} options - The options object to pass to retry.operation()
+ *
+ * @return A promise for the first successful result of the operation, if
+ *         it succeeds within the allowed number of attempts.
+ */
+function retryPromiseOperation(opFn, options) {
+  return new Promise(function (resolve, reject) {
+    var operation = retry.operation(options);
+    operation.attempt(function () {
+      opFn().then(function (result) {
+        operation.retry();
+        resolve(result);
+      }).catch(function (err) {
+        if (!operation.retry(err)) {
+          reject(err);
+        }
+      });
+    });
+  });
+}
+
+module.exports = {
+  retryPromiseOperation: retryPromiseOperation,
+};

--- a/h/static/scripts/test/promise-util.js
+++ b/h/static/scripts/test/promise-util.js
@@ -1,0 +1,18 @@
+/**
+ * Takes a Promise<T> and returns a Promise<Result>
+ * where Result = { result: T } | { error: any }.
+ *
+ * This is useful for testing that promises are rejected
+ * as expected in tests.
+ */
+function toResult(promise) {
+  return promise.then(function (result) {
+    return { result: result };
+  }).catch(function (err) {
+    return { error: err }
+  });
+}
+
+module.exports = {
+  toResult: toResult,
+};

--- a/h/static/scripts/test/retry-util-test.js
+++ b/h/static/scripts/test/retry-util-test.js
@@ -1,0 +1,48 @@
+var Promise = require('core-js/library/es6/promise');
+
+var retryUtil = require('../retry-util');
+var toResult = require('./promise-util').toResult;
+
+describe('retry-util', function () {
+  describe('.retryPromiseOperation', function () {
+    it('should return the result of the operation function', function () {
+      var operation = sinon.stub().returns(Promise.resolve(42));
+      var wrappedOperation = retryUtil.retryPromiseOperation(operation);
+      return wrappedOperation.then(function (result) {
+        assert.equal(result, 42);
+      });
+    });
+
+    it('should retry the operation if it fails', function () {
+      var results = [new Error('fail'), 'ok'];
+      var operation = sinon.spy(function () {
+        var nextResult = results.shift();
+        if (nextResult instanceof Error) {
+          return Promise.reject(nextResult);
+        } else {
+          return Promise.resolve(nextResult);
+        }
+      });
+      var wrappedOperation = retryUtil.retryPromiseOperation(operation, {
+        minTimeout: 1,
+      });
+      return wrappedOperation.then(function (result) {
+        assert.equal(result, 'ok');
+      });
+    });
+
+    it('should return the error if it repeatedly fails', function () {
+      var error = new Error('error');
+      var operation = sinon.spy(function () {
+        return Promise.reject(error);
+      });
+      var wrappedOperation = retryUtil.retryPromiseOperation(operation, {
+        minTimeout: 1,
+        maxRetries: 2,
+      });
+      return toResult(wrappedOperation).then(function (result) {
+        assert.equal(result.error, error);
+      });
+    });
+  });
+});


### PR DESCRIPTION
If a session load fails, subsequent calls to
session.load() would trigger another request immediately.
Together with feature flag checks triggering session.load(),
this could result in a cycle if no network connection was present:

 1. App loads during initial digest cycle, 'flag.featureEnabled()'
    is called to test whether to show certain UI elements
 2. session.load() is triggered
 3. session.load() fails and the HTTP response error triggers
    a digest cycle
 4. GOTO 1

This commit resolves the problem by automatically retrying
session.load() calls with an exponential backoff.

A side _benefit_ of this is that if you activate the Chrome extension when you have no
network connectivity, the app will defer loading until the network becomes available.
Previously if the `/app` request failed, the sidebar loaded but displayed in the default logged-out state.

A downside is that no error indication is currently shown to indicate why the app remains in a loading state.