### PR TITLE
Always count annotations with the correct userid

### DIFF
--- a/h/test/admin_test.py
+++ b/h/test/admin_test.py
@@ -467,17 +467,21 @@ def test_users_index_looks_up_users_by_email(User):
 
 
 @users_index_fixtures
-def test_users_index_queries_annotation_count(User):
+def test_users_index_queries_annotation_count_by_userid(User):
     es = MagicMock()
     request = DummyRequest(params={"username": "Bob"},
                            es=es)
+
+    User.get_by_username.return_value.username = 'Robert'
 
     admin.users_index(request)
 
     expected_query = {
         'query': {
-            'filtered': {'filter': {'term': {'user': u'acct:bob@example.com'}},
-            'query': {'match_all': {}}}
+            'filtered': {
+                'filter': {'term': {'user': u'acct:robert@example.com'}},
+                'query': {'match_all': {}}
+            }
         }
     }
     es.conn.count.assert_called_with(index=es.index,


### PR DESCRIPTION
Searching by email address would result in a query of the form

   ...{'term': {'user': {'foo@gmail.com@hypothes.is'}}}...

This commit ensures that we always count annotations using the correct userid.

I nominate @chdorner for review seeing as he touched this code last.