### PR TITLE
Fix base URL not being specified for /app/dismiss_sidebar_tutorial route

### DIFF
--- a/h/static/scripts/test/session-test.js
+++ b/h/static/scripts/test/session-test.js
@@ -219,4 +219,13 @@ describe('h:session', function () {
       });
     });
   });
+
+  describe('.dismiss_sidebar_tutorial()', function () {
+    var url = 'https://test.hypothes.is/app/dismiss_sidebar_tutorial';
+    it('disables the tutorial for the user', function () {
+      $httpBackend.expectPOST(url).respond({});
+      session.dismiss_sidebar_tutorial();
+      $httpBackend.flush();
+    });
+  });
 });


### PR DESCRIPTION
The dismiss_sidebar_tutorial session action overrode the whole
URL, including replacing the base URL with just '/app'. Therefore
it would have failed when app.html's origin did not match the service
URL - as in the Chrome extension.

 * Pass the complete URL for the dismiss_sidebar_tutorial action

 * Remove several unused actions from session.js that have been
   replaced by server-rendered forms

 * Add test for dimiss_sidebar_tutorial action