### PR TITLE
Specify the minimum Chrome version in the manifest

### DIFF
--- a/docs/hacking/chrome-extension.rst
+++ b/docs/hacking/chrome-extension.rst
@@ -87,6 +87,18 @@ should be aware of:
    `Content Security Policy`_. To test the extension on these sites
    you'll need to build without the ``--no-bundle-sidebar`` option.
 
+----------------------
+Chrome version support
+----------------------
+
+We currently support at least the last 10 stable releases of Google Chrome,
+which equates to releases in the last ~14 months.
+
+See Wikipedia's `Chrome Release History`_ page for a history of recent
+releases.
+
+.. _Chrome Release History: https://en.wikipedia.org/wiki/Google_Chrome_release_history
+
 ---------------
 Troubleshooting
 ---------------

--- a/h/browser/chrome/manifest.json.jinja2
+++ b/h/browser/chrome/manifest.json.jinja2
@@ -4,6 +4,7 @@
   "version": "{{ version }}",
   "version_name": "{{ version }} ({{ version_name }})",
   "manifest_version": 2,
+  "minimum_chrome_version": "38",
 
   "description": "Collaboratively annotate, highlight, and tag web pages and PDF documents.",
   "icons": {


### PR DESCRIPTION
We've had several reports of users who were confused by ungraceful
behavior when the extension failed to load under old versions
of Chrome.

This sets the minimum version in the manifest so that users will
get a clear indication if they try to install the extension on an unsupported
version of Chrome.

The current minimum version that our extension will actually work
on is Chrome 34 (that I've tested) but in the interests of defining a simple ongoing
support policy which maps to a clear number of regular releases
and a well-defined time frame, I've rounded that to
'the last 10 stable releases' which makes the minimum version Chrome 38.

We can revise this if necessary.

Card CXkq74c7