### PR TITLE
Fail more gracefully if user tries to activate H on a page served by a Chrome extension

### DIFF
--- a/h/browser/chrome/help/index.html
+++ b/h/browser/chrome/help/index.html
@@ -99,7 +99,14 @@
       <section id="restricted-protocol" class="help-item">
         <img class="help-item__icon" src="sad-annotation.svg" />
         <h1 class="help-item__heading">We’re sorry, Hypothesis doesn’t work on this page…</h1>
-        <p class="center">This extension can only be used on pages served over HTTP/HTTPS and FTP.</p>
+        <p class="center">
+          This extension can only be used on pages served over HTTP/HTTPS and FTP.
+        </p>
+        <p class="center">
+          If you have a Chrome extension installed that provides a custom viewer
+          for PDFs or other file types, that may prevent them from being annotated
+          with Hypothesis.
+        </p>
       </section>
       <section id="blocked-site" class="help-item">
         <img class="help-item__icon" src="sad-annotation.svg" />


### PR DESCRIPTION
If a user tries to activate H on a page served by a Chrome extension, such as a custom PDF viewer, the embedded viewer was loaded and displayed an unhelpful error.

This PR restores the intended behavior where the user sees an exclamation mark in the badge and clicking on that displays a page explaining the limitations of the extension with respect to annotating non-HTTP pages. I've also added a specific mention of this case to the help text.

In the specific case of a custom PDF viewer, we could often do better by extracting the original URL from the tab URL, which is typically of the form `chrome-extension://<id>/viewer?file=<original URL>` and opening that directly in the Hypothesis PDF viewer. That will require some additional work and does not cover all cases, so I've left that as a separate task.