### PR TITLE
Improve capture of sidebar injection errors

### DIFF
--- a/h/browser/chrome/lib/errors.js
+++ b/h/browser/chrome/lib/errors.js
@@ -44,13 +44,14 @@ function isKnownError(err) {
  * ie. those which are not instances of ExtensionError, are reported to
  * Sentry.
  *
- * @param {string} context - Describes the context in which the error occurred
  * @param {Error} error - The error which happened.
+ * @param {string} when - Describes the context in which the error occurred.
+ * @param {Object} context - Additional context for the error.
  */
-function report(context, error) {
-  console.error(context, error);
+function report(error, when, context) {
+  console.error(when, error);
   if (!isKnownError(error)) {
-    raven.report(context, error);
+    raven.report(error, when, context);
   }
 }
 

--- a/h/browser/chrome/lib/hypothesis-chrome-extension.js
+++ b/h/browser/chrome/lib/hypothesis-chrome-extension.js
@@ -213,7 +213,7 @@ function HypothesisChromeExtension(dependencies) {
       });
       return sidebar.injectIntoTab(tab)
         .catch(function (err) {
-          errors.report('Failed to inject Hypothesis sidebar:', err, {
+          errors.report(err, 'Injecting Hypothesis sidebar', {
             url: tab.url,
           });
           state.errorTab(tab.id, err);

--- a/h/browser/chrome/lib/hypothesis-chrome-extension.js
+++ b/h/browser/chrome/lib/hypothesis-chrome-extension.js
@@ -213,7 +213,9 @@ function HypothesisChromeExtension(dependencies) {
       });
       return sidebar.injectIntoTab(tab)
         .catch(function (err) {
-          errors.report('Failed to inject Hypothesis Sidebar:', err);
+          errors.report('Failed to inject Hypothesis sidebar:', err, {
+            url: tab.url,
+          });
           state.errorTab(tab.id, err);
         });
     }

--- a/h/browser/chrome/test/errors-test.js
+++ b/h/browser/chrome/test/errors-test.js
@@ -23,14 +23,13 @@ describe('errors', function () {
   describe('.report', function () {
     it('reports unknown errors via Raven', function () {
       var error = new Error('A most unexpected error');
-      errors.report('injecting the sidebar failed', error);
-      assert.calledWith(fakeRaven.report,
-                        'injecting the sidebar failed', error);
+      errors.report(error, 'injecting the sidebar');
+      assert.calledWith(fakeRaven.report, error, 'injecting the sidebar');
     });
 
     it('does not report known errors via Raven', function () {
       var error = new errors.LocalFileError('some message');
-      errors.report('injecting the sidebar failed', error);
+      errors.report(error, 'injecting the sidebar');
       assert.notCalled(fakeRaven.report);
     });
   });

--- a/h/browser/chrome/test/hypothesis-chrome-extension-test.js
+++ b/h/browser/chrome/test/hypothesis-chrome-extension-test.js
@@ -371,8 +371,8 @@ describe('HypothesisChromeExtension', function () {
 
           return toResult(injectError).then(function () {
             assert.calledWith(fakeErrors.report,
-              'Failed to inject Hypothesis sidebar:',
               error,
+              'Injecting Hypothesis sidebar',
               { url: 'file://foo.html' }
             );
           });

--- a/h/browser/chrome/test/hypothesis-chrome-extension-test.js
+++ b/h/browser/chrome/test/hypothesis-chrome-extension-test.js
@@ -3,6 +3,8 @@
 var assign = require('core-js/modules/$.object-assign');
 var proxyquire = require('proxyquire');
 
+var toResult = require('../../../static/scripts/test/promise-util').toResult;
+
 var errors = require('../lib/errors');
 var TabState = require('../lib/tab-state');
 
@@ -333,16 +335,15 @@ describe('HypothesisChromeExtension', function () {
 
     injectErrorCases.forEach(function (ErrorType) {
       describe('with ' + ErrorType.name, function () {
-        it('puts the tab into an errored state', function (done) {
+        it('puts the tab into an errored state', function () {
           var injectError = Promise.reject(new ErrorType('msg'));
           fakeSidebarInjector.injectIntoTab.returns(injectError);
 
           triggerInstall();
 
-          injectError.catch(function () {
+          return toResult(injectError).then(function () {
             assert.called(fakeTabState.errorTab);
             assert.calledWith(fakeTabState.errorTab, 1);
-            done();
           });
         });
 
@@ -362,13 +363,18 @@ describe('HypothesisChromeExtension', function () {
         });
 
         it('logs an error', function () {
-          var injectError = Promise.reject(new ErrorType('msg'));
+          var error = new ErrorType('msg');
+          var injectError = Promise.reject(error);
           fakeSidebarInjector.injectIntoTab.returns(injectError);
 
           triggerInstall();
 
-          injectError.catch(function () {
-            assert.called(fakeErrors.report);
+          return toResult(injectError).then(function () {
+            assert.calledWith(fakeErrors.report,
+              'Failed to inject Hypothesis sidebar:',
+              error,
+              { url: 'file://foo.html' }
+            );
           });
         });
       });

--- a/h/static/scripts/raven.js
+++ b/h/static/scripts/raven.js
@@ -10,6 +10,8 @@
  * as a dependency.
  */
 
+require('core-js/fn/object/assign')
+
 var Raven = require('raven-js')
 
 var enabled = false;
@@ -51,15 +53,14 @@ function angularModule() {
 /**
  * Report an error to Sentry.
  *
- * @param {string} context - A string describing the context in which
- *                           the error occurred.
  * @param {Error} error - An error object describing what went wrong
- *
- * @param {details} Object - A JSON-serializable object containing additional
- *                          information which may be useful when investigating
- *                          the error.
+ * @param {string} when - A string describing the context in which
+ *                        the error occurred.
+ * @param {Object} [context] - A JSON-serializable object containing additional
+ *                             information which may be useful when
+ *                             investigating the error.
  */
-function report(context, error, details) {
+function report(error, when, context) {
   if (!(error instanceof Error)) {
     // If the passed object is not an Error, raven-js
     // will serialize it using toString() which produces unhelpful results
@@ -73,12 +74,8 @@ function report(context, error, details) {
     }
   }
 
-  Raven.captureException(error, {
-    extra: {
-      context: context,
-      details: details,
-    },
-  });
+  var extra = Object.assign({ when: when }, context);
+  Raven.captureException(error, { extra: extra });
 }
 
 /**
@@ -98,7 +95,7 @@ function report(context, error, details) {
 function installUnhandledPromiseErrorHandler() {
   window.addEventListener('unhandledrejection', function (event) {
     if (event.reason) {
-      report('Unhandled Promise rejection', event.reason);
+      report(event.reason, 'Unhandled Promise rejection');
     }
   });
 }

--- a/h/static/scripts/raven.js
+++ b/h/static/scripts/raven.js
@@ -54,11 +54,29 @@ function angularModule() {
  * @param {string} context - A string describing the context in which
  *                           the error occurred.
  * @param {Error} error - An error object describing what went wrong
+ *
+ * @param {details} Object - A JSON-serializable object containing additional
+ *                          information which may be useful when investigating
+ *                          the error.
  */
-function report(context, error) {
+function report(context, error, details) {
+  if (!(error instanceof Error)) {
+    // If the passed object is not an Error, raven-js
+    // will serialize it using toString() which produces unhelpful results
+    // for objects that do not provide their own toString() implementations.
+    //
+    // If the error is a plain object or non-Error subclass with a message
+    // property, such as errors returned by chrome.extension.lastError,
+    // use that instead.
+    if (typeof error === 'object' && error.message) {
+      error = error.message;
+    }
+  }
+
   Raven.captureException(error, {
     extra: {
       context: context,
+      details: details,
     },
   });
 }

--- a/h/static/scripts/test/raven-test.js
+++ b/h/static/scripts/test/raven-test.js
@@ -34,24 +34,21 @@ describe('raven', function () {
 
   describe('.report()', function () {
     it('extracts the message property from Error-like objects', function () {
-      raven.report('context', {message: 'An error'});
+      raven.report({message: 'An error'}, 'context');
       assert.calledWith(fakeRavenJS.captureException, 'An error', {
         extra: {
-          context: 'context',
-          details: undefined,
+          when: 'context',
         },
       });
     });
 
     it('passes extra details through', function () {
       var error = new Error('an error');
-      raven.report('context', error, { url: 'foobar.com' });
+      raven.report(error, 'some operation', { url: 'foobar.com' });
       assert.calledWith(fakeRavenJS.captureException, error, {
         extra: {
-          context: 'context',
-          details: {
-            url: 'foobar.com',
-          },
+          when: 'some operation',
+          url: 'foobar.com',
         },
       });
     });


### PR DESCRIPTION
 * Capture the tab URL as context when injecting the sidebar
   fails, for use in debugging.

 * Switch tests to use the toResult() helper instead of
   Promise.catch() to handle assert errors inside
   catch blocks properly. Previously the log tests passed
   even if the assertions inside `injectError.catch()` failed.

 * Handle the Error-like objects used by chrome.extension.lastError
   better.

   When a Chrome async API fails, it sets chrome.extension.lastError
   to an Error-like object with a 'message' property. Since this
   object is not an instance of Error, RavenJS stringified it
   with .toString(), resulting in an unhelpful '[object Object]'
   message in Sentry.

   This commit adds logic to extract out the message property
   of such objects when capturing exceptions.