### PR TITLE
Improve Chrome sidebar injection error detection and handling

### DIFF
--- a/h/browser/chrome/help/index.html
+++ b/h/browser/chrome/help/index.html
@@ -64,6 +64,12 @@
         position: relative;
         margin-top: 1.5em;
       }
+
+      .error-details {
+        padding: 10px;
+        background-color: #eaeaea;
+        border-radius: 2px;
+      }
     </style>
   </head>
   <body>
@@ -111,6 +117,16 @@
       <section id="blocked-site" class="help-item">
         <img class="help-item__icon" src="sad-annotation.svg" />
         <h1 class="help-item__heading">We’re sorry, Hypothesis doesn't work on this site yet.</h1>
+      </section>
+      <section id="other-error" class="help-item">
+        <img class="help-item__icon" src="sad-annotation.svg" />
+        <h1 class="help-item__heading">We're sorry, Hypothesis failed to load on this page.</h1>
+        <p class="center">
+          The problem has been reported to our team. If it continues, please contact
+          <a href="mailto:support@hypothes.is">support@hypothes.is</a> and provide these
+          technical details:
+          <code><pre class="error-details js-error-message"></pre></code>
+        </p>
       </section>
     </article>
     <script src="./index.js"></script>

--- a/h/browser/chrome/help/index.js
+++ b/h/browser/chrome/help/index.js
@@ -1,3 +1,17 @@
+/** Parse a query string into an object mapping param names to values. */
+function parseQuery(query) {
+  if (query.charAt(0) === '?') {
+    query = query.slice(1);
+  }
+  return query.split('&').reduce(function (map, entry) {
+    var keyValue = entry.split('=').map(function (e) {
+      return decodeURIComponent(e);
+    });
+    map[keyValue[0]] = keyValue[1];
+    return map;
+  }, {});
+}
+
 // Detect the current OS and show approprite help.
 chrome.runtime.getPlatformInfo(function (info) {
   var opts = document.querySelectorAll('[data-extension-path]');
@@ -7,3 +21,9 @@ chrome.runtime.getPlatformInfo(function (info) {
     }
   });
 });
+
+var query = parseQuery(window.location.search);
+if (query.message) {
+  var errorTextEl = document.querySelector('.js-error-message');
+  errorTextEl.textContent = query.message;
+}

--- a/h/browser/chrome/lib/help-page.js
+++ b/h/browser/chrome/lib/help-page.js
@@ -14,11 +14,9 @@ function HelpPage(chromeTabs, extensionURL) {
   /* Accepts an instance of errors.ExtensionError and displays an appropriate
    * help page if one exists.
    *
-   * tab   - The tab to display the error message in.
-   * error - An instance of errors.ExtensionError.
-   *
-   * Throws an error if no page is available for the action.
-   * Returns nothing.
+   * @param {Tab} tab   - The tab to display the error message in.
+   * @param {Error} error - The error to display, usually an instance of
+   *                        errors.ExtensionError
    */
   this.showHelpForError = function (tab, error) {
     if (error instanceof errors.LocalFileError) {
@@ -33,21 +31,32 @@ function HelpPage(chromeTabs, extensionURL) {
     else if (error instanceof errors.BlockedSiteError) {
       return this.showBlockedSitePage(tab);
     }
-
-    throw new Error('showHelpForError does not support the error: ' + error.message);
+    else {
+      return this.showOtherErrorPage(tab, error);
+    }
   };
 
   this.showLocalFileHelpPage = showHelpPage.bind(null, 'local-file');
   this.showNoFileAccessHelpPage = showHelpPage.bind(null, 'no-file-access');
   this.showRestrictedProtocolPage = showHelpPage.bind(null, 'restricted-protocol');
   this.showBlockedSitePage = showHelpPage.bind(null, 'blocked-site');
+  this.showOtherErrorPage = showHelpPage.bind(null, 'other-error');
 
-  // Render the help page. The helpSection should correspond to the id of a
-  // section within the help page.
-  function showHelpPage(helpSection, tab) {
+  /**
+   * Open a tab displaying the help page.
+   *
+   * @p helpSection should correspond to the id of a section
+   *    within the help page.
+   */
+  function showHelpPage(helpSection, tab, error) {
+    var params = '';
+    if (error) {
+      params = '?message=' + encodeURIComponent(error.message);
+    }
+
     chromeTabs.create({
       index: tab.index + 1,
-      url:  extensionURL('/help/index.html#' + helpSection),
+      url:  extensionURL('/help/index.html' + params + '#' + helpSection),
       openerTabId: tab.id,
     });
   }

--- a/h/browser/chrome/lib/help-page.js
+++ b/h/browser/chrome/lib/help-page.js
@@ -45,8 +45,9 @@ function HelpPage(chromeTabs, extensionURL) {
   /**
    * Open a tab displaying the help page.
    *
-   * @p helpSection should correspond to the id of a section
-   *    within the help page.
+   * @param {string} helpSection - ID of a <section> within the help page.
+   * @param {tabs.Tab} tab - The tab where the error occurred.
+   * @param {Error} error - The error which prompted the help page.
    */
   function showHelpPage(helpSection, tab, error) {
     var params = '';

--- a/h/browser/chrome/test/help-page-test.js
+++ b/h/browser/chrome/test/help-page-test.js
@@ -52,9 +52,13 @@ describe('HelpPage', function () {
       });
     });
 
-    it('throws an error if an unsupported error is provided', function () {
-      assert.throws(function () {
-        help.showHelpForError(new Error('Random Error'));
+    it('renders the "other-error" page for unknown errors', function () {
+      help.showHelpForError({id: 1, index: 1}, new Error('Unexpected Error'));
+      assert.called(fakeChromeTabs.create);
+      assert.calledWith(fakeChromeTabs.create, {
+        index: 2,
+        openerTabId: 1,
+        url: 'CRX_PATH/help/index.html?message=Unexpected%20Error#other-error'
       });
     });
   });


### PR DESCRIPTION
This PR fixes several aspects of sidebar injection errors in the Chrome extension:

1. If a 'known' error happened, clicking on the badge would show an explanation.
    For an unknown error, nothing happened. I've changed this to be consistent
    and open the help page.
2. In several cases async Chrome APIs were called without checking for an error
    in the callback. I've altered the code to use the `util.promisify` wrapper which
    wraps async Chrome APIs into promises and handles checking for errors properly.
3. Speculative fix for https://app.getsentry.com/hypothesis/prod/issues/111098657/ ,
    where if the content script injected into the page to determine the content type threw
    an exception, the script returned an undefined result instead of the expected
    `Array<{type: string}>`.