### PR TITLE
Fix auth{entication,orization} policies for websocket server

### DIFF
--- a/conf/development-websocket.ini
+++ b/conf/development-websocket.ini
@@ -1,18 +1,12 @@
 [app:main]
 use: egg:h#websocket
 
-# Authentication configuration -- see the pyramid_multiauth documentation
-multiauth.groupfinder: h.auth.groupfinder
-multiauth.policies: session
-multiauth.policy.session.use: pyramid.authentication.SessionAuthenticationPolicy
-
 # Allowed websocket origins
 origins:
     http://localhost:5000
 
 # Include any deployment-specific pyramid add-ons here
 pyramid.includes:
-    pyramid_multiauth
     pyramid_tm
     h.session
 

--- a/conf/websocket.ini
+++ b/conf/websocket.ini
@@ -1,14 +1,8 @@
 [app:main]
 use: egg:h#websocket
 
-# Authentication configuration -- see the pyramid_multiauth documentation
-multiauth.groupfinder: h.auth.groupfinder
-multiauth.policies: session
-multiauth.policy.session.use: pyramid.authentication.SessionAuthenticationPolicy
-
 # Include any deployment-specific pyramid add-ons here
 pyramid.includes:
-    pyramid_multiauth
     pyramid_redis_sessions
     pyramid_tm
 

--- a/h/app.py
+++ b/h/app.py
@@ -3,12 +3,10 @@
 import logging
 import os
 
-from pyramid import authorization
 from pyramid.config import Configurator
 from pyramid.tweens import EXCVIEW
 from pyramid.settings import asbool
 
-from h import auth
 from h.config import settings_from_environment
 from h.security import derive_key
 
@@ -30,9 +28,6 @@ def create_app(global_config, **settings):
     settings = get_settings(global_config, **settings)
 
     config = Configurator(settings=settings)
-
-    config.set_authentication_policy(auth.AuthenticationPolicy())
-    config.set_authorization_policy(authorization.ACLAuthorizationPolicy())
 
     config.set_root_factory('h.resources.create_root')
 

--- a/h/auth.py
+++ b/h/auth.py
@@ -3,6 +3,7 @@
 import logging
 
 from pyramid import authentication
+from pyramid import authorization
 from pyramid import interfaces
 from pyramid import security
 from zope import interface
@@ -97,3 +98,11 @@ def is_api_request(request):
 def includeme(config):
     # Allow retrieval of the auth_domain from the request object.
     config.add_request_method(auth_domain, name='auth_domain', reify=True)
+
+    # Set up pyramid authentication and authorization policies. See the Pyramid
+    # documentation at:
+    #
+    #   http://docs.pylonsproject.org/projects/pyramid/en/latest/narr/security.html
+    #
+    config.set_authentication_policy(AuthenticationPolicy())
+    config.set_authorization_policy(authorization.ACLAuthorizationPolicy())


### PR DESCRIPTION
The removal of pyramid_multiauth and friends missed the websocket server. This commit:

- moves configuration of the authentication and authorization policies back into `h.auth` so it is correctly picked up by the websocket server
- removes pyramid_multiauth configuration from `conf/*websocket.ini`.

@seanh this currently blocks deployment, so if you could find a time to review this soon, that would be great!