### PR TITLE
Fix RavenJS initialization in app and stream

### DIFF
--- a/h/static/scripts/app.coffee
+++ b/h/static/scripts/app.coffee
@@ -1,7 +1,8 @@
 # initialize Raven. This is required at the top of this file
 # so that it happens early in the app's startup flow
-if window.RAVEN_CONFIG
-  require('./raven').init(window.RAVEN_CONFIG)
+settings = require('./settings')(document)
+if settings.raven
+  require('./raven').init(settings.raven)
 
 
 require('autofill-event')
@@ -143,13 +144,13 @@ module.exports = angular.module('h', [
 .service('unicode', require('./unicode'))
 .service('viewFilter', require('./view-filter'))
 
-.factory('settings', require('./settings'))
 .factory('store', require('./store'))
 
 .value('AnnotationSync', require('./annotation-sync'))
 .value('AnnotationUISync', require('./annotation-ui-sync'))
 .value('Discovery', require('./discovery'))
 .value('raven', require('./raven'))
+.value('settings', settings)
 
 .config(configureLocation)
 .config(configureRoutes)

--- a/h/static/scripts/settings.js
+++ b/h/static/scripts/settings.js
@@ -1,24 +1,27 @@
 'use strict';
 
+require('core-js/fn/object/assign');
+
 /**
- * @ngdoc factory
- * @name  settings
+ * Return application configuration information from the host page.
  *
- * @description
- * The 'settings' factory exposes shared application settings, read from a
- * script tag with type "application/json" and id "hypothesis-settings" in the
- * app page.
+ * Exposes shared application settings, read from script tags with the
+ * class 'js-hypothesis-settings' which contain JSON content.
+ *
+ * If there are multiple such tags, the configuration from each is merged.
+ *
+ * @param {Document|Element} document - The root element to search for
+ *                                      <script> settings tags.
  */
-// @ngInject
-function settings($document) {
-  var settingsElement = $document[0].querySelector(
-    'script[type="application/json"]#hypothesis-settings');
+function settings(document) {
+  var settingsElements =
+    document.querySelectorAll('script.js-hypothesis-settings');
 
-  if (settingsElement) {
-    return JSON.parse(settingsElement.textContent);
+  var config = {};
+  for (var i=0; i < settingsElements.length; i++) {
+    Object.assign(config, JSON.parse(settingsElements[i].textContent));
   }
-
-  return {};
+  return config;
 }
 
 module.exports = settings;

--- a/h/static/scripts/site.js
+++ b/h/static/scripts/site.js
@@ -1,6 +1,7 @@
 // configure error reporting
-if (window.RAVEN_CONFIG) {
-  require('./raven').init(window.RAVEN_CONFIG);
+var settings = require('./settings')(document);
+if (settings.raven) {
+  require('./raven').init(settings.raven);
 }
 
 var page = require('page');

--- a/h/static/scripts/test/settings-test.js
+++ b/h/static/scripts/test/settings-test.js
@@ -1,0 +1,24 @@
+var settings = require('../settings');
+
+function createJSONScriptTag(obj) {
+  var el = document.createElement('script');
+  el.type = 'application/json';
+  el.textContent = JSON.stringify(obj);
+  el.classList.add('js-hypothesis-settings');
+  return el;
+}
+
+describe('settings', function () {
+  afterEach(function () {
+    var elements = document.querySelectorAll('.js-hypothesis-settings');
+    for (var i=0; i < elements.length; i++) {
+      elements[i].parentNode.removeChild(elements[i]);
+    }
+  });
+
+  it('should merge settings', function () {
+    document.body.appendChild(createJSONScriptTag({ a: 1 }));
+    document.body.appendChild(createJSONScriptTag({ b: 2 }));
+    assert.deepEqual(settings(document), { a: 1, b: 2 });
+  });
+});

--- a/h/templates/app.html.jinja2
+++ b/h/templates/app.html.jinja2
@@ -60,7 +60,7 @@
     {% endfor -%}
 
     <!-- App Configuration !-->
-    <script id="hypothesis-settings" type="application/json">
+    <script class="js-hypothesis-settings" type="application/json">
       {{ app_config | safe }}
     </script>
 

--- a/h/templates/layouts/base.html.jinja2
+++ b/h/templates/layouts/base.html.jinja2
@@ -55,11 +55,13 @@
     {% endif %}
 
     {% if request.sentry.get_public_dsn() %}
-      <script>
-        var RAVEN_CONFIG = {
-          dsn: "{{ request.sentry.get_public_dsn('https') }}",
-          release: "{{ h_version }}"
-        };
+      <script class="js-hypothesis-settings" type="application/json">
+        {
+          "raven": {
+            "dsn": "{{ request.sentry.get_public_dsn('https') }}",
+            "release": "{{ h_version }}"
+          }
+        }
       </script>
     {% endif %}
 


### PR DESCRIPTION
app.coffee failed to initialize Raven because it looked for
config info in window.RAVEN_CONFIG instead of the #hypothesis-settings
<script> tag.

This commit makes the web service expose the Raven config info
to the site and the application in the same way, using JSON <script>
tags which are compatible with the strict CSP policy used by
the Chrome extension.

 * Expose and consume config info in the same way on
   the site and in the app.

 * Refactor settings.js to make it independent of Angular, for
   use on the site.

Fixes #2938