### PR TITLE
Fix broken promises in IE

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -26,6 +26,7 @@
   "phantom": true,
   "jquery": true,
   "predef": [
+    "-Promise", // We currently support IE10-11 which lack a Promise global
     "angular",
     "assert",
     "after",
@@ -37,7 +38,6 @@
     "it",
     "require",
     "sinon",
-    "Promise",
     "URL"
   ]
 }

--- a/h/static/scripts/directive/annotation.js
+++ b/h/static/scripts/directive/annotation.js
@@ -1,6 +1,8 @@
 /* jshint node: true */
 'use strict';
 
+var Promise = require('core-js/library/es6/promise');
+
 var dateUtil = require('../date-util');
 var events = require('../events');
 

--- a/h/static/scripts/directive/test/annotation-test.js
+++ b/h/static/scripts/directive/test/annotation-test.js
@@ -1,6 +1,8 @@
 /* jshint node: true */
 'use strict';
 
+var Promise = require('core-js/library/es6/promise');
+
 var events = require('../../events');
 
 var module = angular.mock.module;

--- a/h/static/scripts/session.js
+++ b/h/static/scripts/session.js
@@ -2,6 +2,7 @@
 
 var assign = require('core-js/library/fn/object/assign');
 var angular = require('angular');
+var Promise = require('core-js/library/es6/promise');
 
 var events = require('./events');
 var retryUtil = require('./retry-util');

--- a/h/static/scripts/test/annotation-mapper-test.js
+++ b/h/static/scripts/test/annotation-mapper-test.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var Promise = require('core-js/library/es6/promise');
+
 describe('annotationMapper', function() {
   var sandbox = sinon.sandbox.create();
   var $rootScope;


### PR DESCRIPTION
We support IE10/11, neither of which define Promise globals, so make jshint warn if we use Promise without explicitly defining it (by importing a polyfill), and fix the places where we currently use Promise as an implied global.