### PR TITLE
Don't open "welcome page" when installed by admin policy

### DIFF
--- a/h/browser/chrome/lib/hypothesis-chrome-extension.js
+++ b/h/browser/chrome/lib/hypothesis-chrome-extension.js
@@ -79,14 +79,19 @@ function HypothesisChromeExtension(dependencies) {
   };
 
   /* Opens the onboarding page */
-  this.firstRun = function (installDetails) {
+  this.firstRun = function (extensionInfo) {
     // If we've been installed because of an administrative policy, then don't
     // open the welcome page in a new tab.
     //
     // It's safe to assume that if an admin policy is responsible for installing
     // the extension, opening the welcome page is going to do more harm than
     // good, as it will appear that a tab opened without user action.
-    if (installDetails.installType === 'admin') {
+    //
+    // See:
+    //
+    //   https://developer.chrome.com/extensions/management#type-ExtensionInstallType
+    //
+    if (extensionInfo.installType === 'admin') {
       return;
     }
 

--- a/h/browser/chrome/lib/install.js
+++ b/h/browser/chrome/lib/install.js
@@ -20,8 +20,18 @@ chrome.runtime.requestUpdateCheck(function (status) {
 });
 
 function onInstalled(installDetails) {
+  // The install reason can be "install", "update", "chrome_update", or
+  // "shared_module_update", see:
+  //
+  //   https://developer.chrome.com/extensions/runtime#type-OnInstalledReason
+  //
+  // If we were installed (rather than updated) then trigger a "firstRun" event,
+  // passing in the details of the installed extension. See:
+  //
+  //   https://developer.chrome.com/extensions/management#method-getSelf
+  //
   if (installDetails.reason === 'install') {
-    browserExtension.firstRun(installDetails);
+    chrome.management.getSelf(browserExtension.firstRun);
   }
 
   // We need this so that 3rd party cookie blocking does not kill us.


### PR DESCRIPTION
This commit is a second go at fixing #2890, after the first abortive attempt: 7d3369e.

If the extension has been installed as the result of an administrative policy rather than user action, it doesn't make a lot of sense (and appears to cause some frustration) to open a tab to our "welcome page."

This commit suppresses the opening of the "welcome page" on first run if the install type is admin. Chrome documentation references:

- https://developer.chrome.com/extensions/management#event-onInstalled
- https://developer.chrome.com/extensions/management#type-ExtensionInfo
- https://developer.chrome.com/extensions/management#type-ExtensionInstallType

Fixes #2890.