### PR TITLE
Add "bouncer" support to Chrome extension

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,8 @@ build/%-chrome-stage.zip:
 	hypothesis-buildext chrome \
 		--service 'https://stage.hypothes.is' \
 		--websocket 'wss://stage.hypothes.is/ws' \
-		--sentry-public-dsn '$(SENTRY_DSN_STAGE)'
+		--sentry-public-dsn '$(SENTRY_DSN_STAGE)' \
+		--bouncer 'https://hpt.is'
 	@zip -qr $@ build/chrome
 
 build/%-chrome-prod.zip:
@@ -85,7 +86,8 @@ build/%-chrome-prod.zip:
 	hypothesis-buildext chrome \
 		--service 'https://hypothes.is' \
 		--websocket 'wss://hypothes.is/ws' \
-		--sentry-public-dsn '$(SENTRY_DSN_PROD)'
+		--sentry-public-dsn '$(SENTRY_DSN_PROD)' \
+		--bouncer 'https://hpt.is'
 	@zip -qr $@ build/chrome
 
 .PHONY: clean cover deps dev extensions lint test

--- a/docs/hacking/chrome-extension.rst
+++ b/docs/hacking/chrome-extension.rst
@@ -20,7 +20,7 @@ To build and install the Chrome extension:
 
    .. code-block:: bash
 
-      hypothesis-buildext chrome --debug --service 'http://127.0.0.1:5000'
+      hypothesis-buildext chrome --debug --service 'http://127.0.0.1:5000' --bouncer 'http://127.0.0.1:8000/*'
 
    .. note::
 

--- a/h/browser/chrome/lib/install.js
+++ b/h/browser/chrome/lib/install.js
@@ -14,7 +14,19 @@ var browserExtension = new HypothesisChromeExtension({
 });
 
 browserExtension.listen(window);
+
 chrome.runtime.onInstalled.addListener(onInstalled);
+
+// Respond to messages sent by the JavaScript from https://hpt.is.
+// This is how it knows whether the user has this Chrome extension installed.
+chrome.runtime.onMessageExternal.addListener(
+  function (request, sender, sendResponse) {
+    if (request.type === 'ping') {
+      sendResponse({type: 'pong'});
+    }
+  }
+);
+
 chrome.runtime.requestUpdateCheck(function (status) {
   chrome.runtime.onUpdateAvailable.addListener(onUpdateAvailable);
 });

--- a/h/browser/chrome/manifest.json.jinja2
+++ b/h/browser/chrome/manifest.json.jinja2
@@ -46,5 +46,9 @@
     "lib/*",
     "help/*",
     "content/web/viewer.html"
-  ]
+  ]{% if bouncer_url -%},
+  "externally_connectable": {
+    "matches": ["{{ bouncer_url }}"]
+  }
+  {%- endif %}
 }

--- a/h/buildext.py
+++ b/h/buildext.py
@@ -75,7 +75,7 @@ def copytree(src, dst):
             shutil.copyfile(s, d)
 
 
-def chrome_manifest(script_host_url):
+def chrome_manifest(script_host_url, bouncer_url):
     # Chrome is strict about the format of the version string
     if '+' in h.__version__:
         tag, detail = h.__version__.split('+')
@@ -88,7 +88,8 @@ def chrome_manifest(script_host_url):
 
     context = {
         'version': version,
-        'version_name': version_name
+        'version_name': version_name,
+        'bouncer_url': bouncer_url,
     }
 
     if script_host_url:
@@ -204,7 +205,8 @@ def build_chrome(args):
 
     # Render the manifest.
     with codecs.open('build/chrome/manifest.json', 'w', 'utf-8') as fp:
-        data = chrome_manifest(script_host_url=None)
+        data = chrome_manifest(script_host_url=None,
+                               bouncer_url=args.bouncer_url)
         fp.write(data)
 
     # Write build settings to a JSON file
@@ -226,6 +228,13 @@ parser.add_argument('--debug',
                     action='store_true',
                     default=False,
                     help='create source maps to enable debugging in browser')
+parser.add_argument('--bouncer',
+                    dest='bouncer_url',
+                    help="A Chrome extension match pattern that matches the "
+                         "direct-link URLs of the Hypothesis direct-link "
+                         "bouncer service. JavaScript from this site is "
+                         "allowed to send messages to the Chrome extension",
+                    metavar='URL')
 parser.add_argument('--sentry-public-dsn',
                     default='',
                     help='Specify the public Sentry DSN for crash reporting',


### PR DESCRIPTION
This doesn't necessarily need to be merged yet, can wait until <https://github.com/hypothesis/bouncyhouse/pull/1> is finished, but <https://github.com/hypothesis/bouncyhouse/pull/1> needs this in order to work,

* * *

Add support for "bouncyhouse", the new Hypothesis direct-link bouncer
service, to the Chrome extension.

Some JavaScript from the bouncyhouse instance that will be running at
https://hpt.is/ needs to be able to tell whether the user has our Chrome
extension installed or not. This means that our Chrome extension needs
to:

1. Declare in its manifest.json that https://hpt.is/ can send messages
   to it.
2. Listen for and reply to those messages.

Development builds of the Chrome extension will need to accept messages
from dev instances of bouncyhouse, so add an argument to the
hypothesis-buildext command so that developers can specify their dev
instance's local URL instead of https://hpt.is/.