### PR TITLE
Scrollable groups list

### DIFF
--- a/h/static/styles/app.scss
+++ b/h/static/styles/app.scss
@@ -109,6 +109,7 @@ body {
 /* The groups dropdown list. */
 
 $group-list-width: 270px;
+$group-list-spacing-below: 50px;
 
 .group-list {
   .dropdown {
@@ -117,6 +118,9 @@ $group-list-width: 270px;
 
   .dropdown-menu {
     width: $group-list-width;
+    max-height: 500px;  // fallback for browsers lacking support for vh/calc
+    max-height: calc(100vh - #{$top-bar-height} - #{$group-list-spacing-below});
+    overflow-y: auto;
 
     .group-name {
       overflow: hidden;

--- a/h/static/styles/top-bar.scss
+++ b/h/static/styles/top-bar.scss
@@ -1,8 +1,6 @@
 @import 'base';
 @import 'mixins/responsive';
 
-$top-bar-height: 40px;
-
 .top-bar {
   background: $white;
   border-bottom: solid 1px $gray-lighter;

--- a/h/static/styles/variables.scss
+++ b/h/static/styles/variables.scss
@@ -149,4 +149,5 @@ $highlight-color-third: rgba(192, 192, 49, 0.4);
 $highlight-color-focus: rgba(156, 230, 255, 0.5);
 $score-width: 40px;
 $score-height: $score-width;
+$top-bar-height: 40px;
 $input-border-radius: 2px;


### PR DESCRIPTION
This commit ensures that the groups list is scrollable when it is forced to be smaller than the viewport due to the number of groups in it.

It's not an ideal solution, as in some contexts there isn't much of a hint to the user that the widget is scrollable. It probably beats the existing behaviour, though.

Fixes #2971.

Tagging @robertknight for review.