### PR TITLE
Move /api/token endpoint into application

### DIFF
--- a/h/api/__init__.py
+++ b/h/api/__init__.py
@@ -2,9 +2,6 @@
 
 
 def includeme(config):
-    config.add_route('api', '/', factory='h.api.resources.create_root')
-    config.add_route('token', '/token')
-
     config.include('h.api.db')
     config.include('h.api.search')
     config.include('h.api.views')

--- a/h/api/test/views_test.py
+++ b/h/api/test/views_test.py
@@ -100,43 +100,6 @@ def test_search_returns_search_results(search_lib):
     assert result == search_lib.search.return_value
 
 
-annotator_token_fixtures = pytest.mark.usefixtures('auth', 'session')
-
-
-@annotator_token_fixtures
-def test_annotator_token_calls_check_csrf_token(session):
-    request = testing.DummyRequest()
-
-    views.annotator_token(request)
-
-    session.check_csrf_token.assert_called_once_with(request,
-                                                     token='assertion')
-
-
-@annotator_token_fixtures
-def test_annotator_token_raises_Unauthorized_if_check_csrf_token_raises(
-        session):
-    session.check_csrf_token.side_effect = exceptions.BadCSRFToken
-
-    with pytest.raises(httpexceptions.HTTPUnauthorized):
-        views.annotator_token(testing.DummyRequest())
-
-
-@annotator_token_fixtures
-def test_annotator_token_calls_generate_jwt(auth):
-    request = testing.DummyRequest()
-
-    views.annotator_token(request)
-
-    auth.generate_jwt.assert_called_once_with(request, 3600)
-
-
-@annotator_token_fixtures
-def test_annotator_token_returns_token(auth):
-    assert (views.annotator_token(testing.DummyRequest()) ==
-            auth.generate_jwt.return_value)
-
-
 def test_annotations_index_searches(search_lib):
     request = testing.DummyRequest()
 
@@ -328,15 +291,6 @@ def AnnotationEvent(request):
 
 
 @pytest.fixture
-def auth(request):
-    patcher = mock.patch('h.api.views.auth', autospec=True)
-    module = patcher.start()
-    module.generate_jwt = mock.Mock(return_value='abc123')
-    request.addfinalizer(patcher.stop)
-    return module
-
-
-@pytest.fixture
 def search_lib(request):
     patcher = mock.patch('h.api.views.search_lib', autospec=True)
     request.addfinalizer(patcher.stop)
@@ -348,14 +302,6 @@ def schemas(request):
     patcher = mock.patch('h.api.views.schemas', autospec=True)
     request.addfinalizer(patcher.stop)
     return patcher.start()
-
-
-@pytest.fixture
-def session(request):
-    patcher = mock.patch('h.api.views.session', autospec=True)
-    module = patcher.start()
-    request.addfinalizer(patcher.stop)
-    return module
 
 
 @pytest.fixture

--- a/h/api/views.py
+++ b/h/api/views.py
@@ -19,14 +19,11 @@ objects and Pyramid ACLs in :mod:`h.api.resources`.
 
 import logging
 
-from pyramid import exceptions
 from pyramid import httpexceptions
 from pyramid import i18n
-from pyramid import session
 from pyramid.view import forbidden_view_config, notfound_view_config
 from pyramid.view import view_config
 
-from h.api import auth
 from h.api import cors
 from h.api.events import AnnotationEvent
 from h.api import search as search_lib
@@ -102,7 +99,6 @@ def error_validation(context, request):
 
 
 @api_config(context=Root)
-@api_config(route_name='api')
 def index(context, request):
     """Return the API descriptor document.
 
@@ -151,30 +147,6 @@ def search(request):
     return search_lib.search(request,
                              params,
                              separate_replies=separate_replies)
-
-
-# N.B. Like the rest of the API, this view is exposed behind WSGI middleware
-# that enables appropriate CORS headers and response to preflight request.
-#
-# However, this view requires credentials (a cookie) so is in fact not
-# currently accessible off-origin. Given that this method of authenticating to
-# the API is not intended to remain, this seems like a limitation we do not
-# need to lift any time soon.
-@api_config(route_name='token', renderer='string')
-def annotator_token(request):
-    """Return a JWT access token for the given request.
-
-    The token can be used in the Authorization header in subsequent requests to
-    the API to authenticate the user identified by the
-    request.authenticated_userid of the _current_ request.
-
-    """
-    try:
-        session.check_csrf_token(request, token='assertion')
-    except exceptions.BadCSRFToken:
-        raise httpexceptions.HTTPUnauthorized()
-
-    return auth.generate_jwt(request, 3600)
 
 
 @api_config(context=Annotations, request_method='GET')

--- a/h/app.py
+++ b/h/app.py
@@ -79,16 +79,6 @@ def includeme(config):
 
     config.include('h.api', route_prefix='/api')
     config.include('h.api.nipsa')
-    config.include('h.db')
-
-    # Override the traversal path for the api index route.
-    config.add_route('api', '/api/', traverse='/api/')
-
-    # Support virtual hosting the API over the index route with X-Vhm-Root.
-    config.add_view('h.api.views.index',
-                    context='h.api.resources.Root',
-                    renderer='json',
-                    route_name='index')
 
 
 def get_settings(global_config, **settings):

--- a/h/views/__init__.py
+++ b/h/views/__init__.py
@@ -13,6 +13,7 @@ def includeme(config):
     config.add_route('via_redirect', '/via')
 
     # client
+    config.add_route('token', '/api/token')
     config.add_route('embed', '/embed.js')
     config.add_route('widget', '/app.html')
 

--- a/h/views/client.py
+++ b/h/views/client.py
@@ -8,17 +8,24 @@ Views which exist either to serve or support the JavaScript annotation client.
 
 from __future__ import unicode_literals
 
+from pyramid import exceptions
+from pyramid import httpexceptions
+from pyramid import session
 from pyramid.view import view_config
 
 from h import client
-from h import session
+from h import session as h_session
+from h.api.auth import generate_jwt
 from h.util.view import json_view
 
 
 def render_app(request, extra=None):
     """Render a page that serves a preconfigured annotation client."""
     html = client.render_app_html(
-        api_url=request.route_url('api'),
+        # FIXME: The '' here is to ensure this has a trailing slash. This seems
+        # rather messy, and is inconsistent with the rest of the application's
+        # URLs.
+        api_url=request.resource_url(request.root, 'api', ''),
         service_url=request.route_url('index'),
         ga_tracking_id=request.registry.settings.get('ga_tracking_id'),
         sentry_public_dsn=request.sentry.get_public_dsn(),
@@ -27,6 +34,27 @@ def render_app(request, extra=None):
         extra=extra)
     request.response.text = html
     return request.response
+
+
+# This view requires credentials (a cookie) so is not currently accessible
+# off-origin, unlike the rest of the API. Given that this method of
+# authenticating to the API is not intended to remain, this seems like a
+# limitation we do not need to lift any time soon.
+@view_config(route_name='token', renderer='string')
+def annotator_token(request):
+    """
+    Return a JWT access token for the given request.
+
+    The token can be used in the Authorization header in subsequent requests to
+    the API to authenticate the user identified by the
+    request.authenticated_userid of the _current_ request.
+    """
+    try:
+        session.check_csrf_token(request, token='assertion')
+    except exceptions.BadCSRFToken:
+        raise httpexceptions.HTTPUnauthorized()
+
+    return generate_jwt(request, 3600)
 
 
 @view_config(route_name='embed')
@@ -41,8 +69,8 @@ def embed(context, request):
 
 @json_view(route_name='session', http_cache=0)
 def session_view(request):
-    flash = session.pop_flash(request)
-    model = session.model(request)
+    flash = h_session.pop_flash(request)
+    model = h_session.model(request)
     return dict(status='okay', flash=flash, model=model)
 
 

--- a/h/views/test/client_test.py
+++ b/h/views/test/client_test.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import mock
+import pytest
+from pyramid import exceptions
+from pyramid import httpexceptions
+from pyramid import testing
+
+from h.views import client
+
+annotator_token_fixtures = pytest.mark.usefixtures('generate_jwt', 'session')
+
+
+@annotator_token_fixtures
+def test_annotator_token_calls_check_csrf_token(session):
+    request = testing.DummyRequest()
+
+    client.annotator_token(request)
+
+    session.check_csrf_token.assert_called_once_with(request,
+                                                     token='assertion')
+
+
+@annotator_token_fixtures
+def test_annotator_token_raises_Unauthorized_if_check_csrf_token_raises(
+        session):
+    session.check_csrf_token.side_effect = exceptions.BadCSRFToken
+
+    with pytest.raises(httpexceptions.HTTPUnauthorized):
+        client.annotator_token(testing.DummyRequest())
+
+
+@annotator_token_fixtures
+def test_annotator_token_calls_generate_jwt(generate_jwt):
+    request = testing.DummyRequest()
+
+    client.annotator_token(request)
+
+    generate_jwt.assert_called_once_with(request, 3600)
+
+
+@annotator_token_fixtures
+def test_annotator_token_returns_token(generate_jwt):
+    request = testing.DummyRequest()
+
+    result = client.annotator_token(request)
+
+    assert result == generate_jwt.return_value
+
+
+@pytest.fixture
+def generate_jwt(request):
+    patcher = mock.patch('h.views.client.generate_jwt', autospec=True)
+    func = patcher.start()
+    func.return_value = 'abc123'
+    request.addfinalizer(patcher.stop)
+    return func
+
+
+@pytest.fixture
+def session(request):
+    patcher = mock.patch('h.views.client.session', autospec=True)
+    module = patcher.start()
+    request.addfinalizer(patcher.stop)
+    return module


### PR DESCRIPTION
This starts the process of moving all auth-related code out of the `h.api` package and into the application. Token issuance is the domain of the web application, as it will eventually depend on more than just the current authenticated session.