### PR TITLE
Do not clear selection and reset search when creating a reply

### DIFF
--- a/h/static/scripts/app-controller.coffee
+++ b/h/static/scripts/app-controller.coffee
@@ -125,12 +125,6 @@ module.exports = class AppController
       $scope.search.query = ''
       annotationUI.clearSelectedAnnotations()
 
-    $rootScope.$on('beforeAnnotationCreated', (event, data) ->
-      if data.$highlight
-        return
-      $scope.clearSelection()
-    )
-
     $scope.search =
       query: $location.search()['q']
 

--- a/h/static/scripts/test/app-controller-test.coffee
+++ b/h/static/scripts/test/app-controller-test.coffee
@@ -168,30 +168,6 @@ describe 'AppController', ->
     $scope.$broadcast(events.USER_CHANGED, {initialLoad: false})
     assert.calledOnce(fakeRoute.reload)
 
-  describe 'on "beforeAnnotationCreated"', ->
-
-    ###*
-    #  It should clear any selection that exists in the sidebar before
-    #  creating a new annotation. Otherwise the new annotation with its
-    #  form open for the user to type in won't be visible because it's
-    #  not part of the selection.
-    ###
-    it 'calls $scope.clearSelection()', ->
-      createController()
-      sandbox.spy($scope, 'clearSelection')
-
-      $rootScope.$emit('beforeAnnotationCreated', {})
-
-      assert.called($scope.clearSelection)
-
-    it 'doesn\'t call $scope.clearSelection() when a highlight is created', ->
-      createController()
-      sandbox.spy($scope, 'clearSelection')
-
-      $rootScope.$emit('beforeAnnotationCreated', {$highlight: true})
-
-      assert.notCalled($scope.clearSelection)
-
   describe 'logout()', ->
     it 'prompts the user if there are drafts', ->
       fakeDrafts.count.returns(1)

--- a/h/static/scripts/test/widget-controller-test.coffee
+++ b/h/static/scripts/test/widget-controller-test.coffee
@@ -162,3 +162,10 @@ describe 'WidgetController', ->
       $scope.clearSelection = sinon.stub()
       $rootScope.$emit('beforeAnnotationCreated', {$highlight: true})
       assert.notCalled($scope.clearSelection)
+
+    it 'does not clear the selection if the new annotation is a reply', ->
+      $scope.clearSelection = sinon.stub()
+      $rootScope.$emit('beforeAnnotationCreated', {
+        references: ['parent-id']
+      })
+      assert.notCalled($scope.clearSelection)

--- a/h/static/scripts/test/widget-controller-test.coffee
+++ b/h/static/scripts/test/widget-controller-test.coffee
@@ -4,6 +4,7 @@ events = require('../events')
 
 describe 'WidgetController', ->
   $scope = null
+  $rootScope = null
   fakeAnnotationMapper = null
   fakeAnnotationUI = null
   fakeAuth = null
@@ -84,7 +85,8 @@ describe 'WidgetController', ->
     $provide.value 'groups', fakeGroups
     return
 
-  beforeEach inject ($controller, $rootScope) ->
+  beforeEach inject ($controller, _$rootScope_) ->
+    $rootScope = _$rootScope_
     $scope = $rootScope.$new()
     viewer = $controller 'WidgetController', {$scope}
 
@@ -143,3 +145,20 @@ describe 'WidgetController', ->
       assert.calledWith(fakeAnnotationMapper.loadAnnotations,
         searchResult.rows)
       assert.calledWith(fakeThreading.thread, fakeDrafts.unsaved())
+
+  describe 'when a new annotation is created', ->
+    ###*
+    #  It should clear any selection that exists in the sidebar before
+    #  creating a new annotation. Otherwise the new annotation with its
+    #  form open for the user to type in won't be visible because it's
+    #  not part of the selection.
+    ###
+    it 'clears the selection', ->
+      $scope.clearSelection = sinon.stub()
+      $rootScope.$emit('beforeAnnotationCreated', {})
+      assert.called($scope.clearSelection)
+
+    it 'does not clear the selection if the new annotation is a highlight', ->
+      $scope.clearSelection = sinon.stub()
+      $rootScope.$emit('beforeAnnotationCreated', {$highlight: true})
+      assert.notCalled($scope.clearSelection)

--- a/h/static/scripts/widget-controller.coffee
+++ b/h/static/scripts/widget-controller.coffee
@@ -4,12 +4,12 @@ events = require('./events')
 
 module.exports = class WidgetController
   this.$inject = [
-    '$scope', 'annotationUI', 'crossframe', 'annotationMapper', 'drafts', 'groups',
-    'streamer', 'streamFilter', 'store', 'threading'
+    '$scope', '$rootScope', 'annotationUI', 'crossframe', 'annotationMapper',
+    'drafts', 'groups', 'streamer', 'streamFilter', 'store', 'threading'
   ]
   constructor:   (
-     $scope,   annotationUI,   crossframe,   annotationMapper,  drafts,    groups,
-     streamer,   streamFilter,   store,   threading
+     $scope,   $rootScope,   annotationUI,   crossframe,   annotationMapper,
+     drafts,    groups,  streamer,   streamFilter,   store,   threading
   ) ->
     $scope.threadRoot = threading.root
     $scope.sortOptions = ['Newest', 'Oldest', 'Location']
@@ -72,3 +72,9 @@ module.exports = class WidgetController
 
     $scope.hasFocus = (annotation) ->
       !!($scope.focusedAnnotations ? {})[annotation?.$$tag]
+
+    $rootScope.$on('beforeAnnotationCreated', (event, data) ->
+      if data.$highlight
+        return
+      $scope.clearSelection()
+    )

--- a/h/static/scripts/widget-controller.coffee
+++ b/h/static/scripts/widget-controller.coffee
@@ -74,7 +74,7 @@ module.exports = class WidgetController
       !!($scope.focusedAnnotations ? {})[annotation?.$$tag]
 
     $rootScope.$on('beforeAnnotationCreated', (event, data) ->
-      if data.$highlight
+      if data.$highlight || (data.references && data.references.length > 0)
         return
       $scope.clearSelection()
     )


### PR DESCRIPTION
This fixes the Reply action reloading the view on the stream if search is non-empty, losing the new reply in the process.

The logic for clearing the selection and search in the sidebar
when creating a new annotation was incorrectly being triggered:

1. On the stream, where creating new annotations is not possible except for replies and
2. For replies. The selection should only be cleared in the sidebar when creating a new annotation with a location on the page.

This PR fixes the issue by moving the logic for clearing the selection from the stream's controller to the sidebar's controller and also but not clearing the selection if the new annotation is a reply
