### PR TITLE
Fix styling of heading on 404, 5xx and Unsubscribe pages

### DIFF
--- a/h/static/styles/common.scss
+++ b/h/static/styles/common.scss
@@ -5,8 +5,11 @@
 @import './forms';
 @import './grid';
 @import './mixins/responsive';
-@import './page';
+
+// Note: These includes are currently source-order
+// dependent.
 @import './styled-text';
+@import './page';
 
 //ELEMENT STYLES////////////////////////////////
 body {


### PR DESCRIPTION
This is a partial revert of 47bf5e8b5a123a9a5f1822e2bc84e5477aed6293

These pages use elements with both styled-text and page
classes applied and the result is currently source-order dependent.

Pending a refactoring of these styles, this reverts the @import
order change.