### PR TITLE
Allow disabling URI equivalence lookups in the streamer

### DIFF
--- a/h/features.py
+++ b/h/features.py
@@ -17,6 +17,7 @@ log = logging.getLogger(__name__)
 FEATURES = {
     'claim': "Enable 'claim your username' web views?",
     'new_homepage': "Show the new homepage design?",
+    'ops_disable_streamer_uri_equivalence': "[Ops] Disable streamer URI equivalence support?",
 }
 
 # Once a feature has been fully deployed, we remove the flag from the codebase.

--- a/h/streamer.py
+++ b/h/streamer.py
@@ -285,8 +285,15 @@ class WebSocket(_WebSocket):
         if not isinstance(uris, list):
             uris = [uris]
 
-        for item in uris:
-            expanded.update(storage.expand_uri(item))
+        # FIXME: this is a temporary hack to allow us to disable URI
+        # equivalence support on the streamer while we debug a number of
+        # issues related to connection pool exhaustion for the websocket
+        # server.  -NS 2016-02-19
+        if self.request.feature('ops_disable_streamer_uri_equivalence'):
+            expanded.update(uris)
+        else:
+            for item in uris:
+                expanded.update(storage.expand_uri(item))
 
         clause['value'] = list(expanded)
 

--- a/h/test/streamer_test.py
+++ b/h/test/streamer_test.py
@@ -72,6 +72,10 @@ class TestWebSocket(unittest.TestCase):
         self.s.request = fake_request
 
     def test_filter_message_with_uri_gets_expanded(self):
+        # FIXME: remove this when you remove the
+        # 'ops_disable_streamer_uri_equivalence' feature.
+        self.s.request.feature.return_value = False
+
         filter_message = json.dumps({
             'filter': {
                 'actions': {},


### PR DESCRIPTION
This is a distasteful temporary hack to allow us, under heavy load, to prevent the websocket server from spewing errors due to connection pool exhaustion.

Longer-term fixes for the root cause of the problem are in the works, but having this tool available to us in production will be very useful.