### PR TITLE
Postgres documents

### DIFF
--- a/h/api/models/document.py
+++ b/h/api/models/document.py
@@ -1,0 +1,125 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql as pg
+from sqlalchemy.ext.hybrid import hybrid_property
+
+from h.api import uri
+from h.api.db import Base
+from h.api.db import mixins
+
+class Document(Base, mixins.Timestamps):
+    __tablename__ = 'document'
+
+    id = sa.Column(sa.Integer, autoincrement=True, primary_key=True)
+
+    uris = sa.orm.relationship('DocumentURI', backref='document')
+    meta = sa.orm.relationship('DocumentMeta', backref='document')
+
+    def __repr__(self):
+        return '<Document %s>' % self.id
+
+
+class DocumentURI(Base, mixins.Timestamps):
+    __tablename__ = 'document_uri'
+    __table_args__ = (
+        sa.UniqueConstraint('claimant_normalized',
+                            'uri_normalized',
+                            'type',
+                            'content_type'),
+    )
+
+    id = sa.Column(sa.Integer, autoincrement=True, primary_key=True)
+
+    _claimant = sa.Column('claimant',
+                          sa.UnicodeText,
+                          nullable=False)
+    _claimant_normalized = sa.Column('claimant_normalized',
+                                     sa.UnicodeText,
+                                     nullable=False)
+
+    _uri = sa.Column('uri',
+                     sa.UnicodeText,
+                     nullable=False)
+    _uri_normalized = sa.Column('uri_normalized',
+                                sa.UnicodeText,
+                                nullable=False,
+                                index=True)
+
+    type = sa.Column(sa.UnicodeText)
+    content_type = sa.Column(sa.UnicodeText)
+
+    document_id = sa.Column(sa.Integer,
+                            sa.ForeignKey('document.id'),
+                            nullable=False)
+
+    @hybrid_property
+    def claimant(self):
+        return self._claimant
+
+    @claimant.setter
+    def claimant(self, value):
+        self._claimant = value
+        self._claimant_normalized = uri.normalize(value)
+
+    @hybrid_property
+    def claimant_normalized(self):
+        return self._claimant_normalized
+
+    @hybrid_property
+    def uri(self):
+        return self._uri
+
+    @uri.setter
+    def uri(self, value):
+        self._uri = value
+        self._uri_normalized = uri.normalize(value)
+
+    @hybrid_property
+    def uri_normalized(self):
+        return self._uri_normalized
+
+    def __repr__(self):
+        return '<DocumentURI %s>' % self.id
+
+
+class DocumentMeta(Base, mixins.Timestamps):
+    __tablename__ = 'document_meta'
+    __table_args__ = (
+        sa.UniqueConstraint('claimant_normalized', 'type'),
+    )
+
+    id = sa.Column(sa.Integer, autoincrement=True, primary_key=True)
+
+    _claimant = sa.Column('claimant',
+                          sa.UnicodeText,
+                          nullable=False)
+    _claimant_normalized = sa.Column('claimant_normalized',
+                                     sa.UnicodeText,
+                                     nullable=False)
+
+    type = sa.Column(sa.UnicodeText, nullable=False)
+    value = sa.Column(pg.ARRAY(sa.UnicodeText, zero_indexes=True),
+                      nullable=False)
+
+    document_id = sa.Column(sa.Integer,
+                            sa.ForeignKey('document.id'),
+                            nullable=False)
+
+    @hybrid_property
+    def claimant(self):
+        return self._claimant
+
+    @claimant.setter
+    def claimant(self, value):
+        self._claimant = value
+        self._claimant_normalized = text_type(uri.normalize(value), 'utf-8')
+
+    @hybrid_property
+    def claimant_normalized(self):
+        return self._claimant_normalized
+
+    def __repr__(self):
+        return '<DocumentMeta %s>' % self.id

--- a/h/api/models/test/document_test.py
+++ b/h/api/models/test/document_test.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 
+import pytest
+
 from h import db
-from h.api.models.document import Document, DocumentURI
+from h.api.models.document import Document, DocumentURI, DocumentMeta
+from h.api.models.document import merge_documents
 
 
 def test_document_find_or_create_by_uris():
@@ -51,3 +54,69 @@ def test_document_find_by_uris_no_results():
     assert docuri.claimant == u'https://en.wikipedia.org/wiki/Pluto'
     assert docuri.uri == u'https://en.wikipedia.org/wiki/Pluto'
     assert docuri.type == 'self-claim'
+
+
+merge_documents_fixtures = pytest.mark.usefixtures('merge_data')
+
+
+@merge_documents_fixtures
+def test_merge_documents_returns_master(merge_data):
+    master, duplicate = merge_data
+
+    merged_master = merge_documents(db.Session, merge_data)
+    assert merged_master == master
+
+
+@merge_documents_fixtures
+def test_merge_documents_deletes_duplicate_documents(merge_data):
+    master, duplicate = merge_data
+
+    merge_documents(db.Session, merge_data)
+    db.Session.flush()
+
+    assert Document.query.get(duplicate.id) is None
+
+
+@merge_documents_fixtures
+def test_merge_documents_rewires_document_uris(merge_data):
+    master, duplicate = merge_data
+
+    merge_documents(db.Session, merge_data)
+    db.Session.flush()
+
+    assert len(master.uris) == 2
+    assert len(duplicate.uris) == 0
+
+@merge_documents_fixtures
+def test_merge_documents_rewires_document_meta(merge_data):
+    master, duplicate = merge_data
+
+    merge_documents(db.Session, merge_data)
+    db.Session.flush()
+
+    assert len(master.meta) == 2
+    assert len(duplicate.meta) == 0
+
+
+@pytest.fixture
+def merge_data(request):
+    master = Document(uris=[DocumentURI(
+            claimant=u'https://en.wikipedia.org/wiki/Main_Page',
+            uri=u'https://en.wikipedia.org/wiki/Main_Page',
+            type=u'self-claim')],
+            meta=[DocumentMeta(
+                claimant=u'https://en.wikipedia.org/wiki/Main_Page',
+                type=u'title',
+                value=u'Wikipedia, the free encyclopedia')])
+    duplicate = Document(uris=[DocumentURI(
+            claimant=u'https://m.en.wikipedia.org/wiki/Main_Page',
+            uri=u'https://en.wikipedia.org/wiki/Main_Page',
+            type=u'rel-canonical')],
+            meta=[DocumentMeta(
+                claimant=u'https://m.en.wikipedia.org/wiki/Main_Page',
+                type=u'title',
+                value=u'Wikipedia, the free encyclopedia')])
+
+    db.Session.add_all([master, duplicate])
+    db.Session.flush()
+    return (master, duplicate)

--- a/h/api/models/test/document_test.py
+++ b/h/api/models/test/document_test.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+
+from h import db
+from h.api.models.document import Document, DocumentURI
+
+
+def test_document_find_or_create_by_uris():
+    document = Document()
+    docuri1 = DocumentURI(
+        claimant=u'https://en.wikipedia.org/wiki/Main_Page',
+        uri=u'https://en.wikipedia.org/wiki/Main_Page',
+        document=document)
+    docuri2 = DocumentURI(
+        claimant=u'https://en.wikipedia.org/wiki/http/en.m.wikipedia.org/wiki/Main_Page',
+        uri=u'https://en.wikipedia.org/wiki/Main_Page',
+        document=document)
+
+    db.Session.add(docuri1)
+    db.Session.add(docuri2)
+    db.Session.flush()
+
+    actual = Document.find_or_create_by_uris(
+        u'https://en.wikipedia.org/wiki/Main_Page',
+        [u'https://en.wikipedia.org/wiki/http/en.m.wikipedia.org/wiki/Main_Page',
+         u'https://m.en.wikipedia.org/wiki/Main_Page'])
+    assert actual.count() == 1
+    assert actual.first() == document
+
+
+def test_document_find_by_uris_no_results():
+    document = Document()
+    docuri = DocumentURI(
+        claimant=u'https://en.wikipedia.org/wiki/Main_Page',
+        uri=u'https://en.wikipedia.org/wiki/Main_Page',
+        document=document)
+
+    db.Session.add(docuri)
+    db.Session.flush()
+
+    documents = Document.find_or_create_by_uris(
+        u'https://en.wikipedia.org/wiki/Pluto',
+        [u'https://m.en.wikipedia.org/wiki/Pluto'])
+
+    assert documents.count() == 1
+
+    actual = documents.first()
+    assert isinstance(actual, Document)
+    assert len(actual.uris) == 1
+
+    docuri = actual.uris[0]
+    assert docuri.claimant == u'https://en.wikipedia.org/wiki/Pluto'
+    assert docuri.uri == u'https://en.wikipedia.org/wiki/Pluto'
+    assert docuri.type == 'self-claim'

--- a/h/migrations/versions/dfa82518915a_create_document_tables.py
+++ b/h/migrations/versions/dfa82518915a_create_document_tables.py
@@ -1,0 +1,57 @@
+"""Create document tables
+
+Revision ID: dfa82518915a
+Revises: 4c0c44605c09
+Create Date: 2016-02-10 14:52:08.236839
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'dfa82518915a'
+down_revision = '4c0c44605c09'
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+def upgrade():
+    op.create_table('document',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('created', sa.DateTime, server_default=sa.func.now(), nullable=False),
+        sa.Column('updated', sa.DateTime, server_default=sa.func.now(), nullable=False),
+    )
+
+    op.create_table('document_meta',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('created', sa.DateTime, server_default=sa.func.now(), nullable=False),
+        sa.Column('updated', sa.DateTime, server_default=sa.func.now(), nullable=False),
+        sa.Column('claimant', sa.UnicodeText, nullable=False),
+        sa.Column('claimant_normalized', sa.UnicodeText, nullable=False),
+        sa.Column('type', sa.UnicodeText, nullable=False),
+        sa.Column('value', postgresql.ARRAY(sa.UnicodeText, zero_indexes=True), nullable=False),
+        sa.Column('document_id', sa.Integer, nullable=False),
+        sa.ForeignKeyConstraint(['document_id'], [u'document.id']),
+        sa.UniqueConstraint('claimant_normalized', 'type'),
+    )
+
+    op.create_table('document_uri',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('created', sa.DateTime, server_default=sa.func.now(), nullable=False),
+        sa.Column('updated', sa.DateTime, server_default=sa.func.now(), nullable=False),
+        sa.Column('claimant', sa.UnicodeText, nullable=False),
+        sa.Column('claimant_normalized', sa.UnicodeText, nullable=False),
+        sa.Column('uri', sa.UnicodeText, nullable=False),
+        sa.Column('uri_normalized', sa.UnicodeText, nullable=False, index=True),
+        sa.Column('type', sa.UnicodeText, nullable=True),
+        sa.Column('content_type', sa.UnicodeText, nullable=True),
+        sa.Column('document_id', sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(['document_id'], [u'document.id']),
+        sa.UniqueConstraint('claimant_normalized', 'uri_normalized', 'type', 'content_type')
+    )
+
+
+def downgrade():
+    op.drop_table('document_uri')
+    op.drop_table('document_meta')
+    op.drop_table('document')

--- a/h/models.py
+++ b/h/models.py
@@ -4,6 +4,7 @@ from h import features
 from h.accounts import models as accounts_models
 from h.api.models.annotation import Annotation
 from h.api.models.token import Token
+from h.api.models.document import Document, DocumentMeta, DocumentURI
 from h.api.nipsa import models as nipsa_models
 from h.groups import models as groups_models
 from h.notification import models as notification_models
@@ -13,6 +14,9 @@ __all__ = (
     'Activation',
     'Annotation',
     'Blocklist',
+    'Document',
+    'DocumentMeta',
+    'DocumentURI',
     'Feature',
     'Group',
     'NipsaUser',

--- a/scripts/migrate.py
+++ b/scripts/migrate.py
@@ -183,7 +183,10 @@ def annotation_from_data(id, data):
     if id == '_query':
         raise Skip("not an annotation (id=_query)")
 
-    ann = Annotation(id=id)
+    ann = Annotation.query.get(id)
+    if ann is None:
+        ann = Annotation(id=id)
+
     ann.created = dateparser.parse(data.pop('created')).replace(tzinfo=None)
     ann.updated = dateparser.parse(data.pop('updated')).replace(tzinfo=None)
     ann.userid = data.pop('user')

--- a/scripts/migrate.py
+++ b/scripts/migrate.py
@@ -127,6 +127,7 @@ def scan(es_client, with_filter=None):
                         doc_type=es_client.t.annotation,
                         query=query,
                         preserve_order=True,
+                        scroll='1h',
                         sort='updated:asc')
 
 

--- a/scripts/migrate.py
+++ b/scripts/migrate.py
@@ -5,6 +5,8 @@ A script to migrate annotation data from ElasticSearch to PostgreSQL.
 from __future__ import division, print_function, unicode_literals
 
 import argparse
+import datetime
+import dateutil.parser as dateparser
 import itertools
 import os
 import logging
@@ -15,8 +17,12 @@ from pyramid.request import Request
 from sqlalchemy.orm import scoped_session, sessionmaker
 
 from h import db
+from h.api.db import Base as APIBase
 from h.api.models.annotation import Annotation
+from h.api.models.document import Document, DocumentURI, DocumentMeta
+from h.api.models.document import merge_documents
 from h.api import uri
+from h._compat import text_type
 
 BATCH_SIZE = 2000
 
@@ -55,6 +61,8 @@ def main():
     engine = db.make_engine(request.registry.settings)
     Session.configure(bind=engine)
 
+    APIBase.query = Session.query_property()
+
     if 'DEBUG_QUERY' in os.environ:
         logging.getLogger('sqlalchemy.engine').setLevel(logging.INFO)
 
@@ -70,6 +78,7 @@ def migrate_annotations(es_client):
 
     print('{:d} annotations already imported'.format(Annotation.query.count()))
 
+    start = datetime.datetime.now()
     for batch in _batch_iter(BATCH_SIZE, annotations):
         # Skip over annotations until we find the point from which we haven't
         # imported yet...
@@ -81,9 +90,13 @@ def migrate_annotations(es_client):
             started = True
 
         s, f = import_annotations(batch)
+
         success += s
         failure += f
-        print('{:d} ok, {:d} failed'.format(success, failure))
+        took = (datetime.datetime.now() - start).seconds
+        print('{:d} ok, {:d} failed, took {:d} seconds'.format(success, failure, took))
+
+        start = datetime.datetime.now()
 
     in_postgres = Annotation.query.count()
     in_elastic = es_client.conn.count(index=es_client.index,
@@ -138,14 +151,20 @@ def find_start(annotations):
 
 
 def import_annotations(annotations):
-    objs = []
+    objs = set()
 
     failure = 0
     success = 0
 
     for a in annotations:
         try:
-            objs.append(annotation_from_data(a['_id'], a['_source']))
+            document_data = a['_source'].pop('document', None)
+
+            annotation = annotation_from_data(a['_id'], a['_source'])
+            objs.add(annotation)
+
+            if document_data is not None:
+                document_objs_from_data(document_data, annotation)
         except Exception as e:
             log.warn('error importing %s: %s', a['_id'], e)
             failure += 1
@@ -164,8 +183,8 @@ def annotation_from_data(id, data):
         raise Skip("not an annotation (id=_query)")
 
     ann = Annotation(id=id)
-    ann.created = data.pop('created')
-    ann.updated = data.pop('updated')
+    ann.created = dateparser.parse(data.pop('created')).replace(tzinfo=None)
+    ann.updated = dateparser.parse(data.pop('updated')).replace(tzinfo=None)
     ann.userid = data.pop('user')
     ann.groupid = data.pop('group')
 
@@ -198,16 +217,86 @@ def annotation_from_data(id, data):
     if ann.target_uri is None:
         raise Skip("annotation is missing a target source and uri")
 
-    ann.target_uri_normalized = unicode(uri.normalize(ann.target_uri), 'utf-8')
-
-    # We are generating documents from Postgres annotations, so we can safely
-    # discard them here.
-    _ = data.pop('document', None)
+    ann.target_uri_normalized = text_type(uri.normalize(ann.target_uri))
 
     if data:
         ann.extra = data
 
     return ann
+
+
+def document_objs_from_data(data, ann):
+    links = _transfom_document_links(ann.target_uri, data)
+    uris = [link['uri'] for link in links]
+    documents = Document.find_or_create_by_uris(ann.target_uri, uris,
+                                                created=ann.created,
+                                                updated=ann.updated)
+
+    if documents.count() > 1:
+        document = merge_documents(Session, documents, updated=ann.updated)
+    else:
+        document = documents.first()
+
+    document.updated = ann.updated
+
+    document_uri_objs_from_data(document, links, ann)
+    document_meta_objs_from_data(document, data, ann)
+
+
+def document_uri_objs_from_data(document, transformed_links, ann):
+    for link in transformed_links:
+        docuri = DocumentURI.query.filter(
+                DocumentURI.claimant_normalized == text_type(uri.normalize(link.get('claimant')), 'utf-8'),
+                DocumentURI.uri_normalized == text_type(uri.normalize(link.get('uri')), 'utf-8'),
+                DocumentURI.type == link.get('type'),
+                DocumentURI.content_type == link.get('content_type')
+                ).first()
+
+        if docuri is None:
+            docuri = DocumentURI(claimant=link.get('claimant'),
+                                 uri=link.get('uri'),
+                                 type=link.get('type'),
+                                 content_type=link.get('content_type'),
+                                 document=document,
+                                 created=ann.created,
+                                 updated=ann.updated)
+            Session.add(docuri)
+            Session.flush()
+
+        docuri.updated = ann.updated
+
+
+def document_meta_objs_from_data(document, data, ann, path_prefix=[]):
+    _ = data.pop('link', None)
+
+    for key, value in data.iteritems():
+        keypath = path_prefix[:]
+        keypath.append(key)
+
+        if isinstance(value, dict):
+            return document_meta_objs_from_data(document, value, ann,
+                                                path_prefix=keypath)
+
+        if not isinstance(value, list):
+            value = [value]
+
+        type = '.'.join(keypath)
+        meta = DocumentMeta.query.filter(
+                DocumentMeta.claimant_normalized == text_type(uri.normalize(ann.target_uri)),
+                DocumentMeta.type == type).one_or_none()
+
+        if meta is None:
+            meta = DocumentMeta(claimant=ann.target_uri,
+                                type='.'.join(keypath),
+                                value=value,
+                                created=ann.created,
+                                updated=ann.updated,
+                                document=document)
+            Session.add(meta)
+            Session.flush()
+        else:
+            meta.value = value
+            meta.updated = ann.updated
 
 
 def _batch_iter(n, iterable):
@@ -319,6 +408,79 @@ def _permissions_allow_sharing(user, group, perms):
         return True
 
     return False
+
+
+def _transfom_document_links(ann_target_uri, docdata):
+    transformed = []
+    doclinks = docdata.get('link', [])
+
+    # When document link is just a string, transform it to a link object with
+    # an href, so it gets further processed as either a self-claim or another
+    # claim.
+    if isinstance(doclinks, basestring):
+        doclinks = [{"href": doclinks}]
+
+    for link in doclinks:
+        # disregard self-claim urls as they're are being added separately
+        # later on.
+        if link.keys() == ['href'] and link['href'] == ann_target_uri:
+            continue
+
+        # disregard doi links as these are being added separately from the
+        # highwire and dc metadata later on.
+        if link.keys() == ['href'] and link['href'].startswith('doi:'):
+            continue
+
+        uri_ = link['href']
+        type = None
+
+        # highwire pdf (href, type=application/pdf)
+        if set(link.keys()) == set(['href', 'type']) and len(link.keys()) == 2:
+            type = 'highwire-pdf'
+
+        if type is None and link.get('rel') is not None:
+            type = 'rel-{}'.format(link['rel'])
+
+        content_type = None
+        if link.get('type'):
+            content_type = link['type']
+
+        transformed.append({
+            'claimant': ann_target_uri,
+            'uri': uri_,
+            'type': type,
+            'content_type': content_type})
+
+    # Add highwire doi link based on metadata
+    hwdoivalues = docdata.get('highwire', {}).get('doi', [])
+    for doi in hwdoivalues:
+        if not doi.startswith('doi:'):
+            doi = "doi:{}".format(doi)
+
+        transformed.append({
+            'claimant': ann_target_uri,
+            'uri': doi,
+            'type': 'highwire-doi'})
+
+    # Add dc doi link based on metadata
+    dcdoivalues = docdata.get('dc', {}).get('identifier', [])
+    for doi in dcdoivalues:
+        if not doi.startswith('doi:'):
+            doi = "doi:{}".format(doi)
+
+        transformed.append({
+            'claimant': ann_target_uri,
+            'uri': doi,
+            'type': 'dc-doi'})
+
+    # add self claim
+    transformed.append({
+        'claimant': ann_target_uri,
+        'uri': ann_target_uri,
+        'type': 'self-claim'})
+
+    return transformed
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
_tl;dr_ This pull request adds the models and migrations for the new `Document` / `DocumentMeta` / `DocumentURI` models, and generates the data out of each annotation in the migration script.

## New SQLAlchemy models
**Document**
The Document itself that only has an `id` column and timestamps, acts as
the master model to wich both uris and metadata is attached.

**DocumentURI**
A logical document can be accessed by different URIs, all of these URIs
are stored individually as a DocumentURI. Along with other data like a
type and content type.
We use the annotation `target_uri` as the `claimant` and then store each
URI the documents lists as an equivalent URI into the `uri` field, along
with its potential type (e.g. self-claim, or rel attributes) and content type.

**DocumentMeta**
In addition to document uris, we store extra metadata of the document.
There is currently no use of that data yet except for generating
specific DocumentURI models for both dublincore and highwire doi uris.

## Migration changes

Instead of migrating Elasticsearch documents of type `document`, we
decided to simulate the way document-related data will be handled in the
future, by creating or updating Document models after each annotation
has been handled.

Things worth noting:

* Similar to the current Elasticsearch solution, existing documents
  deemed equivalent will be merged automatically without an audit
  process (this will probably change in the future).

* Document links that only have an `href` field and its value is the
  same as the annotation `target_url` are discarded in favour of a
  generated `self-claim` DocumentURI

* Document links starting with `doi:` are discarded in favour of
  generated `dc-doi` and `highwire-doi` from the respective meta data.

* Document links with only an href and a content_type of
  `application/pdf` will get a type of `highwire-pdf`.

* Document links with a `rel` value will be prefixed with `rel-` and
  used as the type.

* The type of DocumentMeta models is the path of nested keys.
    `{ "facebook": { "site_name": "..." } }` vs `facebook.site_name`