### PR TITLE
Decouple transaction manager from database session

### DIFF
--- a/conf/app.ini
+++ b/conf/app.ini
@@ -30,7 +30,6 @@ mail.default_sender: "Annotation Daemon" <no-reply@localhost>
 pyramid.includes:
     pyramid_mailer
     pyramid_redis_sessions
-    pyramid_tm
 
 # Redis session configuration -- See pyramid_redis_sessions documentation
 #redis.sessions.secret:

--- a/conf/development-app.ini
+++ b/conf/development-app.ini
@@ -17,7 +17,6 @@ pyramid.reload_templates: True
 pyramid.includes:
     pyramid_debugtoolbar
     pyramid_mailer
-    pyramid_tm
     h.debug
     h.session
 

--- a/conf/development-websocket.ini
+++ b/conf/development-websocket.ini
@@ -7,7 +7,6 @@ origins:
 
 # Include any deployment-specific pyramid add-ons here
 pyramid.includes:
-    pyramid_tm
     h.session
 
 # Use gevent-compatible transport for the Sentry client

--- a/conf/websocket.ini
+++ b/conf/websocket.ini
@@ -4,7 +4,6 @@ use: egg:h#websocket
 # Include any deployment-specific pyramid add-ons here
 pyramid.includes:
     pyramid_redis_sessions
-    pyramid_tm
 
 # Use gevent-compatible transport for the Sentry client
 raven.transport: gevent

--- a/h/app.py
+++ b/h/app.py
@@ -50,16 +50,6 @@ def create_app(global_config, **settings):
 def includeme(config):
     config.add_request_method(in_debug_mode, 'debug', reify=True)
 
-    config.include('h.features')
-
-    config.include('h.assets')
-    config.include('h.db')
-    config.include('h.form')
-    config.include('h.models')
-    config.include('h.views')
-    config.include('h.feeds')
-    config.include('h.sentry')
-
     config.include('pyramid_jinja2')
     config.add_jinja2_extension('h.jinja_extensions.Filters')
     config.add_jinja2_extension('h.jinja_extensions.IncludeRawExtension')
@@ -68,15 +58,27 @@ def includeme(config):
     # Jinja2 webassets extension when the configuration is committed.
     config.action(None, configure_jinja2_assets, args=(config,))
 
+    # Core site modules
+    config.include('h.assets')
+    config.include('h.auth')
+    config.include('h.db')
+    config.include('h.features')
+    config.include('h.form')
+    config.include('h.models')
+    config.include('h.queue')
+    config.include('h.sentry')
+    config.include('h.views')
+
+    # Site modules
     config.include('h.accounts')
     config.include('h.admin', route_prefix='/admin')
-    config.include('h.auth')
     config.include('h.badge')
     config.include('h.claim')
+    config.include('h.feeds')
     config.include('h.groups')
     config.include('h.notification')
-    config.include('h.queue')
 
+    # API
     config.include('h.api', route_prefix='/api')
     config.include('h.api.nipsa')
 

--- a/h/db.py
+++ b/h/db.py
@@ -20,8 +20,7 @@ from sqlalchemy import MetaData
 from sqlalchemy import engine_from_config
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import scoped_session, sessionmaker
-
-from zope.sqlalchemy import ZopeTransactionExtension
+import zope.sqlalchemy
 
 from h.api import db as api_db
 
@@ -44,7 +43,7 @@ __all__ = (
 #
 #   http://docs.pylonsproject.org/projects/pyramid-tm/en/latest/#transaction-usage
 #
-Session = scoped_session(sessionmaker(extension=ZopeTransactionExtension()))
+Session = scoped_session(sessionmaker())
 
 # Create a default metadata object with naming conventions for indexes and
 # constraints. This makes changing such constraints and indexes with alembic
@@ -93,6 +92,15 @@ def make_engine(settings):
     return engine_from_config(settings, 'sqlalchemy.')
 
 
+def _get_request_session(request):
+    # Create a session and register it with a transaction manager, if present.
+    session = Session()
+    tm = getattr(request, 'tm', None)
+    if tm is not None:
+        zope.sqlalchemy.register(session, transaction_manager=tm)
+    return session
+
+
 def includeme(config):
     settings = config.registry.settings
     should_create = asbool(settings.get('h.db.should_create_all', False))
@@ -102,7 +110,7 @@ def includeme(config):
     # Add a property to all requests for easy access to the session. This means
     # that view functions need only refer to `request.db` in order to retrieve
     # the current database session.
-    config.add_request_method(lambda req: Session(), name='db', reify=True)
+    config.add_request_method(_get_request_session, name='db', reify=True)
 
     # Register a deferred action to bind the engine when the configuration is
     # committed. Deferring the action means that this module can be included


### PR DESCRIPTION
In preparation for making some substantial changes to the websocket server...

Move the configuration of the transaction integration into `h.app` rather than the config files, while also ensuring that

- Each request gets a brand new transaction manager rather than reusing
  the transaction manager one per thread.
- The transaction integration ignores assets requests.
- The transaction manager will attempt to retry retryable exceptions.
- The transaction manager will not annotate the transaction with the
  value of request.unauthenticated_user -- we don't use this
  functionality.

The important change comes in f0c96f2, where we make it possible to use the database session without `pyramid_tm` being part of the application. For the websocket server, where there is no request/response cycle, it doesn't makes sense to have a transaction manager responsible for committing the session.