### PR TITLE
Fix annotation tag links

### DIFF
--- a/h/static/scripts/directive/test/annotation-test.js
+++ b/h/static/scripts/directive/test/annotation-test.js
@@ -1465,5 +1465,21 @@ describe('annotation', function() {
         });
       });
     });
+
+    describe('tag display', function () {
+      it('displays annotation tags', function () {
+        var directive = createDirective({
+          id: '1234',
+          tags: ['atag']
+        });
+        var links = [].slice.apply(directive.element[0].querySelectorAll('a'));
+        var tagLinks = links.filter(function (link) {
+          return link.textContent === 'atag';
+        });
+        assert.equal(tagLinks.length, 1);
+        assert.equal(tagLinks[0].href,
+                     'https://test.hypothes.is/stream?q=tag:atag');
+      });
+    });
   });
 });

--- a/h/templates/client/annotation.html
+++ b/h/templates/client/annotation.html
@@ -104,7 +104,7 @@
        ng-if="(vm.canCollapseBody || vm.form.tags.length) && !vm.editing()">
     <ul class="tag-list">
       <li class="tag-item" ng-repeat="tag in vm.form.tags">
-        <a ng-href="vm.tagStreamURL(tag.text)" target="_blank">{{tag.text}}</a>
+        <a ng-href="{{vm.tagStreamURL(tag.text)}}" target="_blank">{{tag.text}}</a>
       </li>
     </ul>
     <div class="u-stretch"></div>


### PR DESCRIPTION
The ng-href directive does not treat its contents as
an Angular expression.

Fixes a regression introduced in e334fea0241282 and add a test.