### PR TITLE
Fix form button background gradient

### DIFF
--- a/h/static/styles/mixins/forms.scss
+++ b/h/static/styles/mixins/forms.scss
@@ -36,9 +36,9 @@
 }
 
 @mixin btn {
-  @include background(linear-gradient($button-background-gradient...));
   @include box-shadow(0 1px 0 rgba(0, 0, 0, .15));
 
+  background: linear-gradient($button-background-gradient);
   display: inline-block;
   font-weight: bold;
   color: $button-text-color;


### PR DESCRIPTION
Remove unused '...' which were originally variable
arguments to the compass 'linear-gradient()' mixin.

Now we are just using the linear-gradient() CSS function
however so the '...' was never expanded, resulting in
invalid CSS.