### PR TITLE
Remove angular-animate dependency

### DIFF
--- a/h/static/scripts/app.coffee
+++ b/h/static/scripts/app.coffee
@@ -76,7 +76,6 @@ module.exports = angular.module('h', [
   # Angular addons which export the Angular module name
   # via module.exports
   require('angular-jwt')
-  require('angular-animate')
   require('angular-resource')
   require('angular-route')
   require('angular-sanitize')

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "description": "The Internet, peer reviewed.",
   "dependencies": {
     "angular": "1.5.0",
-    "angular-animate": "1.5.0",
     "angular-jwt": "0.0.9",
     "angular-mocks": "1.5.0",
     "angular-resource": "1.5.0",

--- a/scripts/gulp/vendor-bundles.js
+++ b/scripts/gulp/vendor-bundles.js
@@ -13,7 +13,6 @@ module.exports = {
     polyfills: [require.resolve('../../h/static/scripts/polyfills')],
     angular: [
       'angular',
-      'angular-animate',
       'angular-jwt',
       'angular-resource',
       'angular-route',


### PR DESCRIPTION
There are no references to ng-{enter, leave, move} or
the other hooks that I could find.

angular-animate was added in fdf132efe7d56de34633451c159b05460769a259
but the mentioned CSS classes no longer exist.

This reduces the Angular bundle size by about 30KB.