### PR TITLE
Ensure request session is correctly committed in non-web contexts

### DIFF
--- a/h/notification/worker.py
+++ b/h/notification/worker.py
@@ -20,8 +20,14 @@ def run(request):
     def handle_message(reader, message=None):
         if message is None:
             return
-        with request.tm:
+        try:
             send_notifications(message)
+            request.db.commit()
+        except:
+            request.db.rollback()
+            raise
+        finally:
+            request.db.close()
 
     def send_notifications(message):
         data = json.loads(message.body)

--- a/h/script.py
+++ b/h/script.py
@@ -80,7 +80,7 @@ def admin(args):
     """Make a user an admin."""
     request = bootstrap(args)
     accounts.make_admin(args.username)
-    request.tm.commit()
+    request.db.commit()
 
 parser_admin = subparsers.add_parser('admin', help=admin.__doc__)
 _add_common_args(parser_admin)


### PR DESCRIPTION
f0c96f2 changed the relationship between the transaction manager and the SQLAlchemy session so that it became possible to fetch a session that wasn't managed by the transaction manager. (This is useful for the websocket server, which manages its own database session.)

Unfortunately, this introduced a rather unpleasant bug, whereby if during the course of a request nobody accessed the session as `request.db` (using the base model `query` property exclusively, for example) then the session would never get tied to the transaction manager and would be dropped when the request ended.

This commit fixes that by moving the code that registers the session with the transaction manager into a NewRequest subscriber, which ensures that it happens on every request. This has the downside of requiring a session be constructed for every request, but there's no easy way around this while we use the magic session query property.

Pyramid doesn't run NewRequest subscribers when creating a request manually using `Request.blank` as we currently do in `h.script` and `h.worker`, so these environments must manually commit the open database transaction.

Fixes #3002.
Fixes #3001.