### PR TITLE
Ensure the streamer works when NSQ is namespaced

### DIFF
--- a/h/streamer/nsq.py
+++ b/h/streamer/nsq.py
@@ -16,10 +16,6 @@ from h.streamer import websocket
 
 log = logging.getLogger(__name__)
 
-# NSQ message topics that the WebSocket server
-# processes messages from
-ANNOTATIONS_TOPIC = 'annotations'
-USER_TOPIC = 'user'
 
 # An incoming message from a subscribed NSQ topic
 Message = namedtuple('Message', ['topic', 'payload'])
@@ -67,7 +63,7 @@ def process_nsq_topic(settings, topic, work_queue, raise_error=True):
         raise RuntimeError('Queue reader quit unexpectedly!')
 
 
-def handle_message(message, topic_handlers=None):
+def handle_message(message, topic_handlers):
     """
     Deserialize and process a message from the reader.
 
@@ -78,12 +74,6 @@ def handle_message(message, topic_handlers=None):
     object. It is assumed that there is a 1:1 request-reply mapping between
     incoming messages and messages to be sent out over the websockets.
     """
-    if topic_handlers is None:
-        topic_handlers = {
-            ANNOTATIONS_TOPIC: handle_annotation_event,
-            USER_TOPIC: handle_user_event,
-        }
-
     data = json.loads(message.payload)
 
     try:

--- a/h/streamer/test/streamer_test.py
+++ b/h/streamer/test/streamer_test.py
@@ -13,16 +13,34 @@ def test_process_work_queue_sends_nsq_messages_to_nsq_handle_message(session):
     message = nsq.Message(topic='foo', payload='bar')
     queue = [message]
 
-    streamer.process_work_queue(queue, session_factory=lambda: session)
+    streamer.process_work_queue({}, queue, session_factory=lambda: session)
 
-    nsq.handle_message.assert_called_once_with(message)
+    nsq.handle_message.assert_called_once_with(message,
+                                               topic_handlers=mock.ANY)
+
+
+def test_process_work_queue_uses_appropriate_topic_handlers_for_nsq_messages(session):
+    message = nsq.Message(topic='foo', payload='bar')
+    queue = [message]
+
+    streamer.process_work_queue({'nsq.namespace': 'wibble'},
+                                queue,
+                                session_factory=lambda: session)
+
+    topic_handlers = {
+        'wibble-annotations': nsq.handle_annotation_event,
+        'wibble-user': nsq.handle_user_event,
+    }
+
+    nsq.handle_message.assert_called_once_with(mock.ANY,
+                                               topic_handlers=topic_handlers)
 
 
 def test_process_work_queue_sends_websocket_messages_to_websocket_handle_message(session):
     message = websocket.Message(socket=mock.sentinel.SOCKET, payload='bar')
     queue = [message]
 
-    streamer.process_work_queue(queue, session_factory=lambda: session)
+    streamer.process_work_queue({}, queue, session_factory=lambda: session)
 
     websocket.handle_message.assert_called_once_with(message)
 
@@ -32,7 +50,7 @@ def test_process_work_queue_commits_after_each_message(session):
     message2 = nsq.Message(topic='foo', payload='bar')
     queue = [message1, message2]
 
-    streamer.process_work_queue(queue, session_factory=lambda: session)
+    streamer.process_work_queue({}, queue, session_factory=lambda: session)
 
     assert session.commit.call_count == 2
 
@@ -43,7 +61,7 @@ def test_process_work_queue_rolls_back_on_handler_exception(session):
 
     nsq.handle_message.side_effect = RuntimeError('explosion')
 
-    streamer.process_work_queue(queue, session_factory=lambda: session)
+    streamer.process_work_queue({}, queue, session_factory=lambda: session)
 
     session.commit.assert_not_called()
     session.rollback.assert_called_once_with()
@@ -53,7 +71,7 @@ def test_process_work_queue_rolls_back_on_unknown_message_type(session):
     message = 'something that is not a message'
     queue = [message]
 
-    streamer.process_work_queue(queue, session_factory=lambda: session)
+    streamer.process_work_queue({}, queue, session_factory=lambda: session)
 
     session.commit.assert_not_called()
     session.rollback.assert_called_once_with()
@@ -63,7 +81,7 @@ def test_process_work_queue_calls_close_after_commit(session):
     message = nsq.Message(topic='foo', payload='bar')
     queue = [message]
 
-    streamer.process_work_queue(queue, session_factory=lambda: session)
+    streamer.process_work_queue({}, queue, session_factory=lambda: session)
 
     assert session.method_calls[-2:] == [
         call.commit(),
@@ -77,7 +95,7 @@ def test_process_work_queue_calls_close_after_rollback(session):
 
     nsq.handle_message.side_effect = RuntimeError('explosion')
 
-    streamer.process_work_queue(queue, session_factory=lambda: session)
+    streamer.process_work_queue({}, queue, session_factory=lambda: session)
 
     assert session.method_calls[-2:] == [
         call.rollback(),


### PR DESCRIPTION
This is a bit of a nasty hack to ensure that we correctly process messages which have come from a namespaced NSQ topic (such as in stage, where all topic names are prefixed with 'stage-').