### PR TITLE
Fix tags autocomplete dropdown CSS

### DIFF
--- a/h/static/styles/annotation.scss
+++ b/h/static/styles/annotation.scss
@@ -17,6 +17,7 @@ $annotation-card-left-padding: 10px;
 }
 
 .annotation {
+  display: block;
   font-family: $sans-font-family;
   font-weight: 300;
   position: relative;


### PR DESCRIPTION
7fff01e changed the annotation cards from `<article>` to `<annotation>`.
This seems to break the CSS of the tags autocomplete dropdown
(particularly: the width is too short) unless the `<annotation>` has
`display: block;`

Fixes #3007.