### PR TITLE
Postgres convergent evolution + Annotation presentation layer

### DIFF
--- a/h/admin.py
+++ b/h/admin.py
@@ -327,7 +327,7 @@ def delete_user(request, user):
     query = _all_user_annotations_query(request, user)
     annotations = es_helpers.scan(client=request.es.conn, query={'query': query})
     for annotation in annotations:
-        storage.delete_annotation(annotation['_id'])
+        storage.delete_annotation(request, annotation['_id'])
 
     request.db.delete(user)
 

--- a/h/api/models/__init__.py
+++ b/h/api/models/__init__.py
@@ -10,3 +10,13 @@ Please note: access to these model objects should almost certainly not be
 direct to the submodules of this package, but rather through the helper
 functions in `h.api.storage`.
 """
+
+from h.api.models.annotation import Annotation
+from h.api.models.document import Document, DocumentMeta, DocumentURI
+
+__all__ = (
+    'Annotation',
+    'Document',
+    'DocumentMeta',
+    'DocumentURI',
+)

--- a/h/api/models/document.py
+++ b/h/api/models/document.py
@@ -26,6 +26,13 @@ class Document(Base, mixins.Timestamps):
     def __repr__(self):
         return '<Document %s>' % self.id
 
+    @property
+    def title(self):
+        titles = [m.value for m in self.meta if m.type == 'title']
+
+        if titles:
+            return titles[0]
+
     @classmethod
     def find_by_uris(cls, session, uris):
         """Find documents by a list of uris."""

--- a/h/api/models/elastic.py
+++ b/h/api/models/elastic.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+from dateutil import parser as dateparser
+
 from annotator import annotation
 from annotator import document
 from pyramid import security
@@ -12,6 +14,150 @@ class Annotation(annotation.Annotation):
     @property
     def id(self):
         return self.get('id')
+
+    @property
+    def created(self):
+        if not self.get('created'):
+            return None
+
+        try:
+            dt = dateparser.parse(self['created'])
+            return dt.replace(tzinfo=None)
+        except ValueError:
+            pass
+
+    @property
+    def updated(self):
+        if not self.get('updated'):
+            return None
+
+        try:
+            dt = dateparser.parse(self.get('updated'))
+            return dt.replace(tzinfo=None)
+        except ValueError:
+            pass
+
+    @property
+    def target_uri(self):
+        uri_ = self.uri
+        if uri_:
+            return uri_
+
+        target_links = self.target_links
+        if target_links:
+            return target_links[0]
+
+    @property
+    def text(self):
+        text = self.get('text', None)
+        if text:
+            return text
+
+    @property
+    def tags(self):
+        tags = self.get('tags', None)
+        if isinstance(tags, basestring):
+            return [tags]
+        elif tags:
+            return tags
+
+        return []
+
+    @property
+    def userid(self):
+        return self.get('user')
+
+    @property
+    def groupid(self):
+        return self.get('group')
+
+    @property
+    def shared(self):
+        perms = self.get('permissions', {})
+        gperm = 'group:{}'.format(self.groupid)
+
+        # Extract a (deduplicated) copy of the read perms field...
+        read_perms = list(set(perms.get('read', [])))
+
+        # We explicitly fix up some known weird scenarios with the permissions
+        # field. The idea here is to cover the ones we've investigated and know
+        # about, but throw a Skip if we see something we don't recognise. Then if
+        # necessary we can make a decision on it and add a rule to handle it here.
+        #
+        # 1. Missing 'read' permissions field. Fix: set the permissions to private.
+        if not read_perms:
+            read_perms = [self.userid]
+
+        # 2. 'read' permissions field is [None]. Fix: as in 1).
+        elif read_perms == [None]:
+            read_perms = [self.userid]
+
+        # 3. Group 'read' permissions that don't match the annotation group. I
+        #    believe this is a result of a bug where the focused group was
+        #    incorrectly restored from localStorage.
+        #
+        #    CHECK THIS ONE: example annotation ids:
+        #
+        #    - AVHVDy7M8sFu_DXLVTfR (Jon)
+        #    - AVH0xnzy8sFu_DXLVU8L (Jeremy)
+        #    - AVHvR_bC8sFu_DXLVUl2 (Jeremy)
+        #
+        #    Fix: set the permissions to be the correct permissions for the group
+        #    the annotation is actually in...
+        elif (len(read_perms) == 1 and
+              read_perms[0].startswith('group:') and
+              read_perms != [gperm]):
+            read_perms = [gperm]
+
+        # 4. Read permissions includes 'group:__world__' but also other principals.
+        #
+        #    This is equivalent to including only 'group:__world__'.
+        elif len(read_perms) > 1 and self.groupid == '__world__' and gperm in read_perms:
+            read_perms = [gperm]
+
+        if (read_perms != [gperm] and read_perms != [self.userid]):
+            # attempt to fix data when client auth state is out of sync by
+            # by overriding the permissions with the user of the annotation.
+            if read_perms[0].startswith('acct:'):
+                return False
+
+        # And, now, we ignore everything other than the read permissions. If
+        # they're a group permission the annotation is considered "shared,"
+        # otherwise not.
+        if read_perms == [gperm]:
+            return True
+
+        return False
+
+    @property
+    def references(self):
+        references = self.get('references')
+        if not isinstance(references, list):
+            return None
+
+        # Some of the values in the references fields aren't IDs (i.e. they're
+        # not base64-encoded UUIDs or base64-encoded flake IDs. Instead,
+        # they're base64-encoded random numbers between 0 and 1, in ASCII...
+        #
+        # So, we filter out things that couldn't possibly be valid IDs.
+        return [r for r in references if len(r) in [20, 22]]
+
+    @property
+    def target_selectors(self):
+        targets = self.get('target', [])
+        if targets and isinstance(targets[0], dict):
+            return targets[0].get('selector', [])
+
+        return []
+
+    @property
+    def extra(self):
+        nonextra_keys = ['id', 'created', 'updated', 'user', 'group', 'uri',
+                         'text', 'tags', 'target', 'references', 'permissions',
+                         'document']
+        extra = {k: v for k, v in self.iteritems() if k not in nonextra_keys}
+        if extra:
+            return extra
 
     @property
     def uri(self):
@@ -61,7 +207,8 @@ class Annotation(annotation.Annotation):
 
     @property
     def document(self):
-        return self.get("document", {})
+        if self.get('document') and isinstance(self['document'], dict):
+            return Document(self['document'])
 
     def __acl__(self):
         """

--- a/h/api/models/test/annotation_test.py
+++ b/h/api/models/test/annotation_test.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from pyramid import security
+
+from h.api.models.annotation import Annotation
+
+
+def test_acl_private():
+    ann = Annotation(shared=False, userid='saoirse')
+    actual = ann.__acl__()
+    expect = [(security.Allow, 'saoirse', 'read'),
+              (security.Allow, 'saoirse', 'admin'),
+              (security.Allow, 'saoirse', 'update'),
+              (security.Allow, 'saoirse', 'delete'),
+              security.DENY_ALL]
+    assert actual == expect
+
+
+def test_acl_world_shared():
+    ann = Annotation(shared=True, userid='saoirse', groupid='__world__')
+    actual = ann.__acl__()
+    expect = [(security.Allow, security.Everyone, 'read'),
+              (security.Allow, 'saoirse', 'admin'),
+              (security.Allow, 'saoirse', 'update'),
+              (security.Allow, 'saoirse', 'delete'),
+              security.DENY_ALL]
+    assert actual == expect
+
+
+def test_acl_group_shared():
+    ann = Annotation(shared=True, userid='saoirse', groupid='lulapalooza')
+    actual = ann.__acl__()
+    expect = [(security.Allow, 'group:lulapalooza', 'read'),
+              (security.Allow, 'saoirse', 'admin'),
+              (security.Allow, 'saoirse', 'update'),
+              (security.Allow, 'saoirse', 'delete'),
+              security.DENY_ALL]
+    assert actual == expect

--- a/h/api/models/test/annotation_test.py
+++ b/h/api/models/test/annotation_test.py
@@ -3,8 +3,34 @@
 from __future__ import unicode_literals
 
 from pyramid import security
+import pytest
 
+from h import db
 from h.api.models.annotation import Annotation
+from h.api.models.document import Document, DocumentURI
+
+
+annotation_fixture = pytest.mark.usefixtures('annotation')
+
+
+@annotation_fixture
+def test_document(annotation):
+    document = Document(uris=[DocumentURI(claimant=annotation.target_uri,
+                                          uri=annotation.target_uri)])
+    db.Session.add(document)
+    db.Session.flush()
+
+    assert annotation.document == document
+
+
+@annotation_fixture
+def test_document_not_found(annotation):
+    document = Document(uris=[DocumentURI(claimant='something-else',
+                                          uri='something-else')])
+    db.Session.add(document)
+    db.Session.flush()
+
+    assert annotation.document is None
 
 
 def test_acl_private():
@@ -38,3 +64,12 @@ def test_acl_group_shared():
               (security.Allow, 'saoirse', 'delete'),
               security.DENY_ALL]
     assert actual == expect
+
+
+@pytest.fixture
+def annotation():
+    ann = Annotation(userid="testuser", target_uri="http://example.com")
+
+    db.Session.add(ann)
+    db.Session.flush()
+    return ann

--- a/h/api/models/test/document_test.py
+++ b/h/api/models/test/document_test.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
+
 import pytest
 
 from h import db
@@ -7,42 +9,75 @@ from h.api.models.document import Document, DocumentURI, DocumentMeta
 from h.api.models.document import merge_documents
 
 
+def test_document_find_by_uris():
+    document1 = Document()
+    uri1 = 'https://de.wikipedia.org/wiki/Hauptseite'
+    document1.uris.append(DocumentURI(claimant=uri1, uri=uri1))
+
+    document2 = Document()
+    uri2 = 'https://en.wikipedia.org/wiki/Main_Page'
+    document2.uris.append(DocumentURI(claimant=uri2, uri=uri2))
+    uri3 = 'https://en.wikipedia.org'
+    document2.uris.append(DocumentURI(claimant=uri3, uri=uri2))
+
+    db.Session.add_all([document1, document2])
+    db.Session.flush()
+
+    actual = Document.find_by_uris(db.Session, [
+        'https://en.wikipedia.org/wiki/Main_Page',
+        'https://m.en.wikipedia.org/wiki/Main_Page'])
+    assert actual.count() == 1
+    assert actual.first() == document2
+
+
+def test_document_find_by_uris_no_matches():
+    document = Document()
+    document.uris.append(DocumentURI(
+        claimant='https://en.wikipedia.org/wiki/Main_Page',
+        uri='https://en.wikipedia.org/wiki/Main_Page'))
+    db.Session.add(document)
+    db.Session.flush()
+
+    actual = Document.find_by_uris(db.Session, ['https://de.wikipedia.org/wiki/Hauptseite'])
+    assert actual.count() == 0
+
+
 def test_document_find_or_create_by_uris():
     document = Document()
     docuri1 = DocumentURI(
-        claimant=u'https://en.wikipedia.org/wiki/Main_Page',
-        uri=u'https://en.wikipedia.org/wiki/Main_Page',
+        claimant='https://en.wikipedia.org/wiki/Main_Page',
+        uri='https://en.wikipedia.org/wiki/Main_Page',
         document=document)
     docuri2 = DocumentURI(
-        claimant=u'https://en.wikipedia.org/wiki/http/en.m.wikipedia.org/wiki/Main_Page',
-        uri=u'https://en.wikipedia.org/wiki/Main_Page',
+        claimant='https://en.wikipedia.org/wiki/http/en.m.wikipedia.org/wiki/Main_Page',
+        uri='https://en.wikipedia.org/wiki/Main_Page',
         document=document)
 
     db.Session.add(docuri1)
     db.Session.add(docuri2)
     db.Session.flush()
 
-    actual = Document.find_or_create_by_uris(
-        u'https://en.wikipedia.org/wiki/Main_Page',
-        [u'https://en.wikipedia.org/wiki/http/en.m.wikipedia.org/wiki/Main_Page',
-         u'https://m.en.wikipedia.org/wiki/Main_Page'])
+    actual = Document.find_or_create_by_uris(db.Session,
+        'https://en.wikipedia.org/wiki/Main_Page',
+        ['https://en.wikipedia.org/wiki/http/en.m.wikipedia.org/wiki/Main_Page',
+         'https://m.en.wikipedia.org/wiki/Main_Page'])
     assert actual.count() == 1
     assert actual.first() == document
 
 
-def test_document_find_by_uris_no_results():
+def test_document_find_or_create_by_uris_no_results():
     document = Document()
     docuri = DocumentURI(
-        claimant=u'https://en.wikipedia.org/wiki/Main_Page',
-        uri=u'https://en.wikipedia.org/wiki/Main_Page',
+        claimant='https://en.wikipedia.org/wiki/Main_Page',
+        uri='https://en.wikipedia.org/wiki/Main_Page',
         document=document)
 
     db.Session.add(docuri)
     db.Session.flush()
 
-    documents = Document.find_or_create_by_uris(
-        u'https://en.wikipedia.org/wiki/Pluto',
-        [u'https://m.en.wikipedia.org/wiki/Pluto'])
+    documents = Document.find_or_create_by_uris(db.Session,
+        'https://en.wikipedia.org/wiki/Pluto',
+        ['https://m.en.wikipedia.org/wiki/Pluto'])
 
     assert documents.count() == 1
 
@@ -51,8 +86,8 @@ def test_document_find_by_uris_no_results():
     assert len(actual.uris) == 1
 
     docuri = actual.uris[0]
-    assert docuri.claimant == u'https://en.wikipedia.org/wiki/Pluto'
-    assert docuri.uri == u'https://en.wikipedia.org/wiki/Pluto'
+    assert docuri.claimant == 'https://en.wikipedia.org/wiki/Pluto'
+    assert docuri.uri == 'https://en.wikipedia.org/wiki/Pluto'
     assert docuri.type == 'self-claim'
 
 
@@ -87,6 +122,7 @@ def test_merge_documents_rewires_document_uris(merge_data):
     assert len(master.uris) == 2
     assert len(duplicate.uris) == 0
 
+
 @merge_documents_fixtures
 def test_merge_documents_rewires_document_meta(merge_data):
     master, duplicate = merge_data
@@ -101,21 +137,21 @@ def test_merge_documents_rewires_document_meta(merge_data):
 @pytest.fixture
 def merge_data(request):
     master = Document(uris=[DocumentURI(
-            claimant=u'https://en.wikipedia.org/wiki/Main_Page',
-            uri=u'https://en.wikipedia.org/wiki/Main_Page',
-            type=u'self-claim')],
+            claimant='https://en.wikipedia.org/wiki/Main_Page',
+            uri='https://en.wikipedia.org/wiki/Main_Page',
+            type='self-claim')],
             meta=[DocumentMeta(
-                claimant=u'https://en.wikipedia.org/wiki/Main_Page',
-                type=u'title',
-                value=u'Wikipedia, the free encyclopedia')])
+                claimant='https://en.wikipedia.org/wiki/Main_Page',
+                type='title',
+                value='Wikipedia, the free encyclopedia')])
     duplicate = Document(uris=[DocumentURI(
-            claimant=u'https://m.en.wikipedia.org/wiki/Main_Page',
-            uri=u'https://en.wikipedia.org/wiki/Main_Page',
-            type=u'rel-canonical')],
+            claimant='https://m.en.wikipedia.org/wiki/Main_Page',
+            uri='https://en.wikipedia.org/wiki/Main_Page',
+            type='rel-canonical')],
             meta=[DocumentMeta(
-                claimant=u'https://m.en.wikipedia.org/wiki/Main_Page',
-                type=u'title',
-                value=u'Wikipedia, the free encyclopedia')])
+                claimant='https://m.en.wikipedia.org/wiki/Main_Page',
+                type='title',
+                value='Wikipedia, the free encyclopedia')])
 
     db.Session.add_all([master, duplicate])
     db.Session.flush()

--- a/h/api/models/test/document_test.py
+++ b/h/api/models/test/document_test.py
@@ -9,6 +9,34 @@ from h.api.models.document import Document, DocumentURI, DocumentMeta
 from h.api.models.document import merge_documents
 
 
+def test_document_title():
+    doc = Document()
+    DocumentMeta(type='title', value='The Title', document=doc, claimant='http://example.com')
+    db.Session.add(doc)
+    db.Session.flush()
+
+    assert doc.title == 'The Title'
+
+
+def test_document_title_returns_first():
+    doc = Document()
+    DocumentMeta(type='title', value='The US Title', document=doc, claimant='http://example.com')
+    DocumentMeta(type='title', value='The UK Title', document=doc, claimant='http://example.co.uk')
+    db.Session.add(doc)
+    db.Session.flush()
+
+    assert doc.title == 'The US Title'
+
+
+def test_document_title_meta_not_found():
+    doc = Document()
+    DocumentMeta(type='other', value='something', document=doc, claimant='http://example.com')
+    db.Session.add(doc)
+    db.Session.flush()
+
+    assert doc.title is None
+
+
 def test_document_find_by_uris():
     document1 = Document()
     uri1 = 'https://de.wikipedia.org/wiki/Hauptseite'

--- a/h/api/models/test/elastic_test.py
+++ b/h/api/models/test/elastic_test.py
@@ -1,123 +1,268 @@
 # -*- coding: utf-8 -*-
 
+import datetime
+
 import pytest
 from mock import patch
 from mock import PropertyMock
 
 from pyramid import security
 
-from h.api.models.elastic import Annotation
+from h.api.models.elastic import Annotation, Document
 
 
-def test_uri():
-    assert Annotation(uri="http://foo.com").uri == "http://foo.com"
+class TestAnnotation(object):
+    @pytest.mark.parametrize('annotation', [
+        Annotation({'created': '2016-02-25T16:45:23.371848+00:00'}),
+        Annotation({'created': '2016-02-25T16:45:23.371848'})])
+    def test_created(self, annotation):
+        assert annotation.created == datetime.datetime(2016, 2, 25, 16, 45, 23, 371848)
 
+    @pytest.mark.parametrize('annotation', [
+        Annotation({'created': 'invalid'}),
+        Annotation({'created': ''}),
+        Annotation({'created': None})])
+    def test_created_invalid(self, annotation):
+        assert annotation.created is None
 
-def test_uri_with_no_uri():
-    assert Annotation().uri == ""
+    @pytest.mark.parametrize('annotation', [
+        Annotation({'updated': '2016-02-25T16:45:23.371848+00:00'}),
+        Annotation({'updated': '2016-02-25T16:45:23.371848'})])
+    def test_updated(self, annotation):
+        assert annotation.updated == datetime.datetime(2016, 2, 25, 16, 45, 23, 371848)
 
+    @pytest.mark.parametrize('annotation', [
+        Annotation({'updated': 'invalid'}),
+        Annotation({'updated': ''}),
+        Annotation({'updated': None})])
+    def test_updated_invalid(self, annotation):
+        assert annotation.updated is None
 
-def test_uri_when_uri_is_not_a_string():
-    for uri in (True, None, 23, 23.7, {"foo": False}, [1, 2, 3]):
-        assert isinstance(Annotation(uri=uri).uri, unicode)
+    def test_target_uri_from_uri(self):
+        annotation = Annotation({'uri': 'http://example.com'})
+        assert annotation.target_uri == 'http://example.com'
 
+    @pytest.mark.parametrize('annotation', [
+        Annotation({'uri': '', 'target': [{'source': 'http://example.com'}]}),
+        Annotation({'target': [{'source': 'http://example.com'}]})])
+    def test_target_uri_from_target_source(self, annotation):
+        assert annotation.target_uri == 'http://example.com'
 
-def test_target_links_from_annotation():
-    annotation = Annotation(target=[{'source': 'target link'}])
-    assert annotation.target_links == ['target link']
+    def test_text(self):
+        annotation = Annotation({'text': 'Lorem ipsum'})
+        assert annotation.text == 'Lorem ipsum'
 
+    @pytest.mark.parametrize('annotation', [
+        Annotation({'text': ''}),
+        Annotation({'text': None}),
+        Annotation({})])
+    def test_text_empty(self, annotation):
+        assert annotation.text is None
 
-def test_parent_id_returns_none_if_no_references():
-    annotation = Annotation()
-    assert annotation.parent_id is None
+    def test_tags(self):
+        annotation = Annotation({'tags': ['foo', 'bar']})
+        assert annotation.tags == ['foo', 'bar']
 
+    def test_tags_string_type(self):
+        annotation = Annotation({'tags': 'foo'})
+        assert annotation.tags == ['foo']
 
-def test_parent_id_returns_none_if_empty_references():
-    annotation = Annotation(references=[])
-    assert annotation.parent_id is None
+    @pytest.mark.parametrize('annotation', [
+        Annotation({'tags': []}),
+        Annotation({'tags': None}),
+        Annotation({})])
+    def test_tags_empty(self, annotation):
+        assert annotation.tags == []
 
+    def test_userid(self):
+        annotation = Annotation({'user': 'luke'})
+        assert annotation.userid == 'luke'
 
-def test_parent_id_returns_none_if_references_not_list():
-    annotation = Annotation(references={'foo': 'bar'})
-    assert annotation.parent_id is None
+    def test_groupid(self):
+        annotation = Annotation({'group': '__world__'})
+        assert annotation.groupid == '__world__'
 
+    def test_references_allows_20_char_ids(self):
+        annotation = Annotation({'references': ['AVMG6tocH9ZO4OKSk1WS']})
+        assert annotation.references == ['AVMG6tocH9ZO4OKSk1WS']
 
-def test_parent_id_returns_thread_parent_id():
-    annotation = Annotation(references=['abc123', 'def456'])
-    assert annotation.parent_id == 'def456'
+    def test_references_allows_22_char_ids(self):
+        annotation = Annotation({'references': ['AVMG6tocH9ZO4OKSk1WSaa']})
+        assert annotation.references == ['AVMG6tocH9ZO4OKSk1WSaa']
 
+    @pytest.mark.parametrize('annotation', [
+        Annotation({'references': ['too short']}),
+        Annotation({'references': ['this is way too long, it cannot be an id']})])
+    def test_references_filters_out_non_ids(self, annotation):
+        assert annotation.references == []
 
-def test_acl_principal():
-    annotation = Annotation({
-        'permissions': {
-            'read': ['saoirse'],
-        }
-    })
-    actual = annotation.__acl__()
-    expect = [(security.Allow, 'saoirse', 'read'), security.DENY_ALL]
-    assert actual == expect
+    @pytest.mark.parametrize('annotation', [
+        Annotation({'permissions': {'read': ['group:__world__']}, 'user': 'luke', 'group': '__world__'}),
+        Annotation({'permissions': {'read': ['group:tatooine']}, 'user': 'luke', 'group': 'tatooine'})])
+    def test_shared_true(self, annotation):
+        assert annotation.shared is True
 
+    @pytest.mark.parametrize('annotation', [
+        Annotation({'permissions': {'read': ['luke']}, 'user': 'luke', 'group': '__world__'}),
+        Annotation({'permissions': {'read': ['luke']}, 'user': 'luke', 'group': 'tatooine'}),
+        Annotation({'permissions': {'read': ['hansolo']}, 'user': 'luke', 'group': 'tatooine'})])
+    def test_shared_false(self, annotation):
+        assert annotation.shared is False
 
-def test_acl_deny_system_role():
-    annotation = Annotation({
-        'permissions': {
-            'read': [security.Everyone],
-        }
-    })
-    actual = annotation.__acl__()
-    expect = [security.DENY_ALL]
-    assert actual == expect
+    def test_target_selectors(self):
+        annotation = Annotation({'target': [{'selector': [{'foo': 'bar'}]}]})
+        assert annotation.target_selectors == [{'foo': 'bar'}]
 
+    def test_target_selectors_empty(self):
+        annotation = Annotation({'target': {}})
+        assert annotation.target_selectors == []
 
-def test_acl_group():
-    annotation = Annotation({
-        'permissions': {
-            'read': ['group:lulapalooza'],
-        }
-    })
-    actual = annotation.__acl__()
-    expect = [(security.Allow, 'group:lulapalooza', 'read'), security.DENY_ALL]
-    assert actual == expect
+    def test_target_selectors_missing_target(self):
+        annotation = Annotation({})
+        assert annotation.target_selectors == []
 
+    def test_extra(self):
+        annotation = Annotation({
+            'id': 'AVLBpz--vTW_3w8LyzKg',
+            'created': '2016-02-08T16:11:49.576908+00:00',
+            'updated': '2016-02-08T16:11:49.576908+00:00',
+            'user': 'luke',
+            'group': '__world__',
+            'uri': 'https://example.com',
+            'text': 'My comment',
+            'tags': ['look'],
+            'target': [{'source': 'https://example.com',
+                        'selector': []}],
+            'references': ['Qe7fpc5ZRgWy0RSHEP9UNg'],
+            'permissions': {'read': ['group:__world__'],
+                            'admin': ['luke'],
+                            'update': ['luke'],
+                            'delete': ['luke']},
+            'document': {'title': 'Example'},
+            'somethingelse': 'foo',
+            'extra': {'foo': 'bar'}})
+        assert annotation.extra == {'somethingelse': 'foo', 'extra': {'foo': 'bar'}}
 
-def test_acl_group_world():
-    annotation = Annotation({
-        'permissions': {
-            'read': ['group:__world__'],
-        }
-    })
-    actual = annotation.__acl__()
-    expect = [(security.Allow, security.Everyone, 'read'), security.DENY_ALL]
-    assert actual == expect
+    def test_extra_empty(self):
+        annotation = Annotation({'id': 'Qe7fpc5ZRgWy0RSHEP9UNg'})
+        assert annotation.extra is None
 
+    def test_uri(self):
+        assert Annotation(uri="http://foo.com").uri == "http://foo.com"
 
-@pytest.fixture
-def link_text(request):
-    patcher = patch('h.api.models.elastic.Annotation.link_text',
-                    new_callable=PropertyMock)
-    request.addfinalizer(patcher.stop)
-    return patcher.start()
+    def test_uri_with_no_uri(self):
+        assert Annotation().uri == ""
 
+    def test_uri_when_uri_is_not_a_string(self):
+        for uri in (True, None, 23, 23.7, {"foo": False}, [1, 2, 3]):
+            assert isinstance(Annotation(uri=uri).uri, unicode)
 
-@pytest.fixture
-def title(request):
-    patcher = patch('h.api.models.elastic.Annotation.title',
-                    new_callable=PropertyMock)
-    request.addfinalizer(patcher.stop)
-    return patcher.start()
+    def test_target_links_from_annotation(self):
+        annotation = Annotation(target=[{'source': 'target link'}])
+        assert annotation.target_links == ['target link']
 
+    def test_parent_id_returns_none_if_no_references(self):
+        annotation = Annotation()
+        assert annotation.parent_id is None
 
-@pytest.fixture
-def href(request):
-    patcher = patch('h.api.models.elastic.Annotation.href',
-                    new_callable=PropertyMock)
-    request.addfinalizer(patcher.stop)
-    return patcher.start()
+    def test_parent_id_returns_none_if_empty_references(self):
+        annotation = Annotation(references=[])
+        assert annotation.parent_id is None
 
+    def test_parent_id_returns_none_if_references_not_list(self):
+        annotation = Annotation(references={'foo': 'bar'})
+        assert annotation.parent_id is None
 
-@pytest.fixture
-def hostname_or_filename(request):
-    patcher = patch('h.api.models.elastic.Annotation.hostname_or_filename',
-                    new_callable=PropertyMock)
-    request.addfinalizer(patcher.stop)
-    return patcher.start()
+    def test_parent_id_returns_thread_parent_id(self):
+        annotation = Annotation(references=['abc123', 'def456'])
+        assert annotation.parent_id == 'def456'
+
+    def test_document_returns_document_type(self):
+        annotation = Annotation(document={'title': 'The title'})
+        assert type(annotation.document) == Document
+
+    def test_document_returns_none_without_document(self):
+        annotation = Annotation()
+        assert annotation.document is None
+
+    def test_document_returns_none_with_empty_document(self):
+        annotation = Annotation(document={})
+        assert annotation.document is None
+
+    @pytest.mark.parametrize('document', [
+        'a string',
+        [],
+        [1, 2, 3],
+        11,
+        12.7])
+    def test_document_returns_none_with_non_dict_document(self, document):
+        annotation = Annotation(document=document)
+        assert annotation.document is None
+
+    def test_acl_principal(self):
+        annotation = Annotation({
+            'permissions': {
+                'read': ['saoirse'],
+            }
+        })
+        actual = annotation.__acl__()
+        expect = [(security.Allow, 'saoirse', 'read'), security.DENY_ALL]
+        assert actual == expect
+
+    def test_acl_deny_system_role(self):
+        annotation = Annotation({
+            'permissions': {
+                'read': [security.Everyone],
+            }
+        })
+        actual = annotation.__acl__()
+        expect = [security.DENY_ALL]
+        assert actual == expect
+
+    def test_acl_group(self):
+        annotation = Annotation({
+            'permissions': {
+                'read': ['group:lulapalooza'],
+            }
+        })
+        actual = annotation.__acl__()
+        expect = [(security.Allow, 'group:lulapalooza', 'read'), security.DENY_ALL]
+        assert actual == expect
+
+    def test_acl_group_world(self):
+        annotation = Annotation({
+            'permissions': {
+                'read': ['group:__world__'],
+            }
+        })
+        actual = annotation.__acl__()
+        expect = [(security.Allow, security.Everyone, 'read'), security.DENY_ALL]
+        assert actual == expect
+
+    @pytest.fixture
+    def link_text(self, request):
+        patcher = patch('h.api.models.elastic.Annotation.link_text',
+                        new_callable=PropertyMock)
+        request.addfinalizer(patcher.stop)
+        return patcher.start()
+
+    @pytest.fixture
+    def title(self, request):
+        patcher = patch('h.api.models.elastic.Annotation.title',
+                        new_callable=PropertyMock)
+        request.addfinalizer(patcher.stop)
+        return patcher.start()
+
+    @pytest.fixture
+    def href(self, request):
+        patcher = patch('h.api.models.elastic.Annotation.href',
+                        new_callable=PropertyMock)
+        request.addfinalizer(patcher.stop)
+        return patcher.start()
+
+    @pytest.fixture
+    def hostname_or_filename(self, request):
+        patcher = patch('h.api.models.elastic.Annotation.hostname_or_filename',
+                        new_callable=PropertyMock)
+        request.addfinalizer(patcher.stop)
+        return patcher.start()

--- a/h/api/presenters.py
+++ b/h/api/presenters.py
@@ -6,6 +6,29 @@ Presenters for API data.
 import collections
 
 
+class DocumentURIJSONPresenter(object):
+    def __init__(self, document_uri):
+        self.document_uri = document_uri
+
+    def asdict(self):
+        data = {'href': self.document_uri.uri}
+
+        rel = self.rel
+        if rel:
+            data['rel'] = rel
+
+        type = self.document_uri.content_type
+        if type:
+            data['type'] = type
+
+        return data
+
+    @property
+    def rel(self):
+        type = self.document_uri.type
+        if type and type.startswith('rel-'):
+            return self.document_uri.type[4:]
+
 def utc_iso8601(datetime):
     return datetime.strftime('%Y-%m-%dT%H:%M:%S.%f+00:00')
 

--- a/h/api/presenters.py
+++ b/h/api/presenters.py
@@ -6,6 +6,22 @@ Presenters for API data.
 import collections
 
 
+class DocumentMetaJSONPresenter(object):
+    def __init__(self, document_meta):
+        self.document_meta = document_meta
+
+    def asdict(self):
+        # This turns a keypath into a nested dict by first reversing the
+        # keypath and then creating the dict from inside-out. Rather than
+        # using recursion to create the dict from the outside in.
+        reversed_path = self.document_meta.type.split('.')[::-1]
+        d = self.document_meta.value
+        for nested in reversed_path:
+            d = {nested: d}
+
+        return d
+
+
 class DocumentURIJSONPresenter(object):
     def __init__(self, document_uri):
         self.document_uri = document_uri

--- a/h/api/presenters.py
+++ b/h/api/presenters.py
@@ -3,6 +3,20 @@
 Presenters for API data.
 """
 
+import collections
+
 
 def utc_iso8601(datetime):
     return datetime.strftime('%Y-%m-%dT%H:%M:%S.%f+00:00')
+
+
+def deep_merge_dict(a, b):
+    """Recursively merges dict `b` into dict `a`."""
+
+    for k, v in b.items():
+        if isinstance(v, collections.Mapping):
+            if k not in a or not isinstance(a[k], dict):
+                a[k] = dict()
+            deep_merge_dict(a[k], v)
+        else:
+            a[k] = v

--- a/h/api/presenters.py
+++ b/h/api/presenters.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+"""
+Presenters for API data.
+"""
+
+
+def utc_iso8601(datetime):
+    return datetime.strftime('%Y-%m-%dT%H:%M:%S.%f+00:00')

--- a/h/api/presenters.py
+++ b/h/api/presenters.py
@@ -6,6 +6,28 @@ Presenters for API data.
 import collections
 
 
+class DocumentJSONPresenter(object):
+    def __init__(self, document):
+        self.document = document
+
+    def asdict(self):
+        if not self.document:
+            return {}
+
+        d = {}
+
+        for docmeta in self.document.meta:
+            meta_presenter = DocumentMetaJSONPresenter(docmeta)
+            deep_merge_dict(d, meta_presenter.asdict())
+
+        d['link'] = []
+        for docuri in self.document.uris:
+            uri_presenter = DocumentURIJSONPresenter(docuri)
+            d['link'].append(uri_presenter.asdict())
+
+        return d
+
+
 class DocumentMetaJSONPresenter(object):
     def __init__(self, document_meta):
         self.document_meta = document_meta

--- a/h/api/presenters.py
+++ b/h/api/presenters.py
@@ -6,6 +6,69 @@ Presenters for API data.
 import collections
 
 
+class AnnotationJSONPresenter(object):
+    def __init__(self, annotation):
+        self.annotation = annotation
+
+    def asdict(self):
+        docpresenter = DocumentJSONPresenter(self.annotation.document)
+
+        base = {
+            'id': self.annotation.id,
+            'created': self.created,
+            'updated': self.updated,
+            'user': self.annotation.userid,
+            'uri': self.annotation.target_uri,
+            'text': self.annotation.text,
+            'tags': self.tags,
+            'group': self.annotation.groupid,
+            'permission': self.permission,
+            'target': self.target,
+            'document': docpresenter.asdict(),
+        }
+
+        if self.annotation.references:
+            base['references'] = self.annotation.references
+
+        annotation = self.annotation.extra or {}
+        annotation.update(base)
+
+        return annotation
+
+    @property
+    def created(self):
+        if self.annotation.created:
+            return utc_iso8601(self.annotation.created)
+
+    @property
+    def updated(self):
+        if self.annotation.updated:
+            return utc_iso8601(self.annotation.updated)
+
+    @property
+    def tags(self):
+        if self.annotation.tags:
+            return self.annotation.tags
+        else:
+            return []
+
+    @property
+    def permission(self):
+        read = self.annotation.userid
+        if self.annotation.shared:
+            read = 'group:{}'.format(self.annotation.groupid)
+
+        return {'read': [read],
+                'admin': [self.annotation.userid],
+                'update': [self.annotation.userid],
+                'delete': [self.annotation.userid]}
+
+    @property
+    def target(self):
+        return [{'source': self.annotation.target_uri,
+                 'selector': self.annotation.target_selectors or []}]
+
+
 class DocumentJSONPresenter(object):
     def __init__(self, document):
         self.document = document

--- a/h/api/resources.py
+++ b/h/api/resources.py
@@ -8,7 +8,7 @@ class AnnotationFactory(object):
         self.request = request
 
     def __getitem__(self, id):
-        annotation = storage.fetch_annotation(id)
+        annotation = storage.fetch_annotation(self.request, id)
         if annotation is None:
             raise KeyError()
         return annotation

--- a/h/api/test/presenters_test.py
+++ b/h/api/test/presenters_test.py
@@ -3,8 +3,19 @@
 import datetime
 import mock
 
+from h.api.presenters import DocumentMetaJSONPresenter
 from h.api.presenters import DocumentURIJSONPresenter
 from h.api.presenters import utc_iso8601, deep_merge_dict
+
+
+class TestDocumentMetaJSONPresenter(object):
+    def test_asdict(self):
+        meta = mock.Mock(type='twitter.url.main_url',
+                         value='https://example.com')
+        presenter = DocumentMetaJSONPresenter(meta)
+
+        expected = {'twitter': {'url': {'main_url': 'https://example.com'}}}
+        assert expected == presenter.asdict()
 
 
 class TestDocumentURIJSONPresenter(object):

--- a/h/api/test/presenters_test.py
+++ b/h/api/test/presenters_test.py
@@ -2,7 +2,7 @@
 
 import datetime
 
-from h.api.presenters import utc_iso8601
+from h.api.presenters import utc_iso8601, deep_merge_dict
 
 
 def test_utc_iso8601():
@@ -13,6 +13,21 @@ def test_utc_iso8601():
 def test_utc_iso8601_ignores_timezone():
     t = datetime.datetime(2016, 2, 24, 18, 03, 25, 7685, Berlin())
     assert utc_iso8601(t) == '2016-02-24T18:03:25.007685+00:00'
+
+
+def test_deep_merge_dict():
+    a = {'foo': 1, 'bar': 2, 'baz': {'foo': 3, 'bar': 4}}
+    b = {'bar': 8, 'baz': {'bar': 6, 'qux': 7}, 'qux': 15}
+    deep_merge_dict(a, b)
+
+    assert a == {
+        'foo': 1,
+        'bar': 8,
+        'baz': {
+            'foo': 3,
+            'bar': 6,
+            'qux': 7},
+        'qux': 15}
 
 
 class Berlin(datetime.tzinfo):

--- a/h/api/test/presenters_test.py
+++ b/h/api/test/presenters_test.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+
+import datetime
+
+from h.api.presenters import utc_iso8601
+
+
+def test_utc_iso8601():
+    t = datetime.datetime(2016, 2, 24, 18, 03, 25, 7685)
+    assert utc_iso8601(t) == '2016-02-24T18:03:25.007685+00:00'
+
+
+def test_utc_iso8601_ignores_timezone():
+    t = datetime.datetime(2016, 2, 24, 18, 03, 25, 7685, Berlin())
+    assert utc_iso8601(t) == '2016-02-24T18:03:25.007685+00:00'
+
+
+class Berlin(datetime.tzinfo):
+    """Berlin timezone, without DST support"""
+
+    def utcoffset(self, dt):
+        return datetime.timedelta(hours=1)
+
+    def tzname(self, dt):
+        return "Berlin"
+
+    def dst(self, dt):
+        return datetime.timedelta()

--- a/h/api/test/presenters_test.py
+++ b/h/api/test/presenters_test.py
@@ -3,9 +3,27 @@
 import datetime
 import mock
 
+from h.api.presenters import DocumentJSONPresenter
 from h.api.presenters import DocumentMetaJSONPresenter
 from h.api.presenters import DocumentURIJSONPresenter
 from h.api.presenters import utc_iso8601, deep_merge_dict
+
+
+class TestDocumentJSONPresenter(object):
+    def test_asdict(self):
+        document = mock.Mock(uris=[mock.Mock(uri='http://foo.com', type=None, content_type=None),
+                                   mock.Mock(uri='http://foo.org', type='rel-canonical', content_type=None)],
+                             meta=[mock.Mock(type='twitter.url.main_url', value='http://foo.org'),
+                                   mock.Mock(type='twitter.title', value='Foo')])
+        presenter = DocumentJSONPresenter(document)
+
+        expected = {'link': [{'href': 'http://foo.com'},
+                             {'href': 'http://foo.org', 'rel': 'canonical'}],
+                    'twitter': {'title': 'Foo', 'url': {'main_url': 'http://foo.org'}}}
+        assert expected == presenter.asdict()
+
+    def test_asdict_when_none_document(self):
+        assert {} == DocumentJSONPresenter(None).asdict()
 
 
 class TestDocumentMetaJSONPresenter(object):

--- a/h/api/test/presenters_test.py
+++ b/h/api/test/presenters_test.py
@@ -1,9 +1,54 @@
 # -*- coding: utf-8 -*-
 
 import datetime
+import mock
 
+from h.api.presenters import DocumentURIJSONPresenter
 from h.api.presenters import utc_iso8601, deep_merge_dict
 
+
+class TestDocumentURIJSONPresenter(object):
+    def test_asdict(self):
+        docuri = mock.Mock(uri='http://example.com/site.pdf',
+                           type='rel-alternate',
+                           content_type='application/pdf')
+        presenter = DocumentURIJSONPresenter(docuri)
+
+        expected = {'href': 'http://example.com/site.pdf',
+                    'rel': 'alternate',
+                    'type': 'application/pdf'}
+
+        assert expected == presenter.asdict()
+
+    def test_asdict_empty_rel(self):
+        docuri = mock.Mock(uri='http://example.com',
+                           type='dc-doi',
+                           content_type='text/html')
+        presenter = DocumentURIJSONPresenter(docuri)
+
+        expected = {'href': 'http://example.com', 'type': 'text/html'}
+
+        assert expected == presenter.asdict()
+
+    def test_asdict_empty_type(self):
+        docuri = mock.Mock(uri='http://example.com',
+                           type='rel-canonical',
+                           content_type=None)
+        presenter = DocumentURIJSONPresenter(docuri)
+
+        expected = {'href': 'http://example.com', 'rel': 'canonical'}
+
+        assert expected == presenter.asdict()
+
+    def test_rel_with_type_rel(self):
+        docuri = mock.Mock(type='rel-canonical')
+        presenter = DocumentURIJSONPresenter(docuri)
+        assert 'canonical' == presenter.rel
+
+    def test_rel_with_non_rel_type(self):
+        docuri = mock.Mock(type='highwire-pdf')
+        presenter = DocumentURIJSONPresenter(docuri)
+        assert presenter.rel is None
 
 def test_utc_iso8601():
     t = datetime.datetime(2016, 2, 24, 18, 03, 25, 7685)

--- a/h/api/test/resources_test.py
+++ b/h/api/test/resources_test.py
@@ -10,20 +10,23 @@ from h.api.resources import AnnotationFactory
 
 class TestAnnotationFactory(object):
     def test_get_item_fetches_annotation(self, storage):
-        factory = AnnotationFactory(DummyRequest())
+        request = DummyRequest()
+        factory = AnnotationFactory(request)
 
         factory['123']
-        storage.fetch_annotation.assert_called_once_with('123')
+        storage.fetch_annotation.assert_called_once_with(request, '123')
 
     def test_get_item_returns_annotation(self, storage):
-        factory = AnnotationFactory(DummyRequest())
+        request = DummyRequest()
+        factory = AnnotationFactory(request)
         storage.fetch_annotation.return_value = Mock()
 
         annotation = factory['123']
         assert annotation == storage.fetch_annotation.return_value
 
     def test_get_item_raises_when_annotation_is_not_found(self, storage):
-        factory = AnnotationFactory(DummyRequest())
+        request = DummyRequest()
+        factory = AnnotationFactory(request)
         storage.fetch_annotation.return_value = None
 
         with pytest.raises(KeyError):

--- a/h/api/test/resources_test.py
+++ b/h/api/test/resources_test.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+
+from mock import Mock
+from mock import patch
+from pyramid.testing import DummyRequest
+import pytest
+
+from h.api.resources import AnnotationFactory
+
+
+class TestAnnotationFactory(object):
+    def test_get_item_fetches_annotation(self, storage):
+        factory = AnnotationFactory(DummyRequest())
+
+        factory['123']
+        storage.fetch_annotation.assert_called_once_with('123')
+
+    def test_get_item_returns_annotation(self, storage):
+        factory = AnnotationFactory(DummyRequest())
+        storage.fetch_annotation.return_value = Mock()
+
+        annotation = factory['123']
+        assert annotation == storage.fetch_annotation.return_value
+
+    def test_get_item_raises_when_annotation_is_not_found(self, storage):
+        factory = AnnotationFactory(DummyRequest())
+        storage.fetch_annotation.return_value = None
+
+        with pytest.raises(KeyError):
+            factory['123']
+
+    @pytest.fixture
+    def storage(self, request):
+        patcher = patch('h.api.resources.storage', autospec=True)
+        module = patcher.start()
+        request.addfinalizer(patcher.stop)
+        return module

--- a/h/api/test/storage_test.py
+++ b/h/api/test/storage_test.py
@@ -3,9 +3,35 @@
 from __future__ import unicode_literals
 
 import pytest
+import mock
 from mock import patch
+from pyramid.testing import DummyRequest
 
+from h import db
 from h.api import storage
+from h.api.models.annotation import Annotation
+
+
+def test_fetch_annotation_elastic(postgres_enabled, ElasticAnnotation):
+    postgres_enabled.return_value = False
+    ElasticAnnotation.fetch.return_value = mock.Mock()
+
+    actual = storage.fetch_annotation(DummyRequest(), '123')
+
+    ElasticAnnotation.fetch.assert_called_once_with('123')
+    assert ElasticAnnotation.fetch.return_value == actual
+
+
+def test_fetch_annotation_postgres(postgres_enabled):
+    request = DummyRequest(db=db.Session)
+    postgres_enabled.return_value = True
+
+    annotation = Annotation(userid='luke')
+    db.Session.add(annotation)
+    db.Session.flush()
+
+    actual = storage.fetch_annotation(request, annotation.id)
+    assert annotation == actual
 
 
 def test_expand_uri_no_document(document_model):
@@ -45,3 +71,19 @@ def document_model(config, request):
     module = patcher.start()
     request.addfinalizer(patcher.stop)
     return module
+
+
+@pytest.fixture
+def postgres_enabled(request):
+    patcher = patch('h.api.storage._postgres_enabled', autospec=True)
+    func = patcher.start()
+    request.addfinalizer(patcher.stop)
+    return func
+
+
+@pytest.fixture
+def ElasticAnnotation(request):
+    patcher = patch('h.api.storage.elastic.Annotation', autospec=True)
+    cls = patcher.start()
+    request.addfinalizer(patcher.stop)
+    return cls

--- a/h/api/test/views_test.py
+++ b/h/api/test/views_test.py
@@ -111,7 +111,7 @@ def test_create_calls_create_annotation(storage, schemas):
 
     views.create(request)
 
-    storage.create_annotation.assert_called_once_with({'foo': 123})
+    storage.create_annotation.assert_called_once_with(request, {'foo': 123})
 
 
 @create_fixtures
@@ -191,7 +191,9 @@ def test_update_calls_update_annotation(storage, schemas):
 
     views.update(annotation, request)
 
-    storage.update_annotation.assert_called_once_with(annotation.id, {'foo': 123})
+    storage.update_annotation.assert_called_once_with(request,
+                                                      annotation.id,
+                                                      {'foo': 123})
 
 
 @update_fixtures
@@ -227,7 +229,7 @@ def test_delete_calls_delete_annotation(storage):
 
     views.delete(annotation, request)
 
-    storage.delete_annotation.assert_called_once_with(annotation.id)
+    storage.delete_annotation.assert_called_once_with(request, annotation.id)
 
 
 @delete_fixtures

--- a/h/api/test/views_test.py
+++ b/h/api/test/views_test.py
@@ -145,13 +145,16 @@ def test_create_returns_annotation(storage):
     assert result == storage.create_annotation.return_value
 
 
-def test_read_returns_annotation():
+def test_read_returns_presented_annotation(AnnotationJSONPresenter):
     annotation = mock.Mock()
     request = mock.Mock()
+    presenter = mock.Mock()
+    AnnotationJSONPresenter.return_value = presenter
 
     result = views.read(annotation, request)
 
-    assert result == annotation
+    AnnotationJSONPresenter.assert_called_once_with(annotation)
+    assert result == presenter.asdict()
 
 
 update_fixtures = pytest.mark.usefixtures('AnnotationEvent',
@@ -259,6 +262,14 @@ def AnnotationEvent(request):
     patcher = mock.patch('h.api.views.AnnotationEvent', autospec=True)
     request.addfinalizer(patcher.stop)
     return patcher.start()
+
+
+@pytest.fixture
+def AnnotationJSONPresenter(request):
+    patcher = mock.patch('h.api.views.AnnotationJSONPresenter', autoSpec=True)
+    cls = patcher.start()
+    request.addfinalizer(patcher.stop)
+    return cls
 
 
 @pytest.fixture

--- a/h/api/test/views_test.py
+++ b/h/api/test/views_test.py
@@ -163,6 +163,7 @@ def test_read_returns_presented_annotation(AnnotationJSONPresenter):
 
 
 update_fixtures = pytest.mark.usefixtures('AnnotationEvent',
+                                          'AnnotationJSONPresenter',
                                           'schemas',
                                           'storage')
 
@@ -205,13 +206,17 @@ def test_update_calls_update_annotation(storage, schemas):
 
 
 @update_fixtures
-def test_update_returns_annotation(storage):
+def test_update_returns_presented_annotation(AnnotationJSONPresenter, storage):
     annotation = mock.Mock()
     request = mock.Mock()
+    presenter = mock.Mock()
+    AnnotationJSONPresenter.return_value = presenter
 
     result = views.update(annotation, request)
 
-    assert result == storage.update_annotation.return_value
+    AnnotationJSONPresenter.assert_called_once_with(
+            storage.update_annotation.return_value)
+    assert result == presenter.asdict()
 
 
 @update_fixtures

--- a/h/api/test/views_test.py
+++ b/h/api/test/views_test.py
@@ -86,6 +86,7 @@ def test_search_returns_search_results(search_lib):
 
 
 create_fixtures = pytest.mark.usefixtures('AnnotationEvent',
+                                          'AnnotationJSONPresenter',
                                           'schemas',
                                           'storage')
 
@@ -137,12 +138,16 @@ def test_create_event(AnnotationEvent, storage):
 
 
 @create_fixtures
-def test_create_returns_annotation(storage):
+def test_create_returns_presented_annotation(AnnotationJSONPresenter, storage):
     request = mock.Mock()
+    presenter = mock.Mock()
+    AnnotationJSONPresenter.return_value = presenter
 
     result = views.create(request)
 
-    assert result == storage.create_annotation.return_value
+    AnnotationJSONPresenter.assert_called_once_with(
+            storage.create_annotation.return_value)
+    assert result == presenter.asdict()
 
 
 def test_read_returns_presented_annotation(AnnotationJSONPresenter):

--- a/h/api/views.py
+++ b/h/api/views.py
@@ -145,7 +145,7 @@ def create(request):
     """Create an annotation from the POST payload."""
     schema = schemas.CreateAnnotationSchema(request)
     appstruct = schema.validate(_json_payload(request))
-    annotation = storage.create_annotation(appstruct)
+    annotation = storage.create_annotation(request, appstruct)
 
     _publish_annotation_event(request, annotation, 'create')
     return annotation
@@ -162,7 +162,7 @@ def update(annotation, request):
     """Update the specified annotation with data from the PUT payload."""
     schema = schemas.UpdateAnnotationSchema(request, annotation=annotation)
     appstruct = schema.validate(_json_payload(request))
-    annotation = storage.update_annotation(annotation.id, appstruct)
+    annotation = storage.update_annotation(request, annotation.id, appstruct)
 
     _publish_annotation_event(request, annotation, 'update')
     return annotation
@@ -171,7 +171,7 @@ def update(annotation, request):
 @api_config(route_name='api.annotation', request_method='DELETE', permission='delete')
 def delete(annotation, request):
     """Delete the specified annotation."""
-    storage.delete_annotation(annotation.id)
+    storage.delete_annotation(request, annotation.id)
 
     # N.B. We publish the original model (including all the original annotation
     # fields) so that queue subscribers have context needed to decide how to

--- a/h/api/views.py
+++ b/h/api/views.py
@@ -23,6 +23,7 @@ from pyramid.view import view_config
 
 from h.api import cors
 from h.api.events import AnnotationEvent
+from h.api.presenters import AnnotationJSONPresenter
 from h.api import search as search_lib
 from h.api import schemas
 from h.api import storage
@@ -154,7 +155,8 @@ def create(request):
 @api_config(route_name='api.annotation', request_method='GET', permission='read')
 def read(annotation, request):
     """Return the annotation (simply how it was stored in the database)."""
-    return annotation
+    presenter = AnnotationJSONPresenter(annotation)
+    return presenter.asdict()
 
 
 @api_config(route_name='api.annotation', request_method='PUT', permission='update')

--- a/h/api/views.py
+++ b/h/api/views.py
@@ -149,7 +149,9 @@ def create(request):
     annotation = storage.create_annotation(request, appstruct)
 
     _publish_annotation_event(request, annotation, 'create')
-    return annotation
+
+    presenter = AnnotationJSONPresenter(annotation)
+    return presenter.asdict()
 
 
 @api_config(route_name='api.annotation', request_method='GET', permission='read')

--- a/h/api/views.py
+++ b/h/api/views.py
@@ -169,7 +169,9 @@ def update(annotation, request):
     annotation = storage.update_annotation(request, annotation.id, appstruct)
 
     _publish_annotation_event(request, annotation, 'update')
-    return annotation
+
+    presenter = AnnotationJSONPresenter(annotation)
+    return presenter.asdict()
 
 
 @api_config(route_name='api.annotation', request_method='DELETE', permission='delete')

--- a/h/features.py
+++ b/h/features.py
@@ -18,6 +18,7 @@ FEATURES = {
     'claim': "Enable 'claim your username' web views?",
     'new_homepage': "Show the new homepage design?",
     'ops_disable_streamer_uri_equivalence': "[Ops] Disable streamer URI equivalence support?",
+    'postgres_read': 'Use postgres to fetch annotations from storage'
 }
 
 # Once a feature has been fully deployed, we remove the flag from the codebase.

--- a/h/notification/reply_template.py
+++ b/h/notification/reply_template.py
@@ -105,7 +105,7 @@ def generate_notifications(request, annotation, action):
     parent_id = annotation.parent_id
     if parent_id is None:
         return
-    parent = storage.fetch_annotation(parent_id)
+    parent = storage.fetch_annotation(request, parent_id)
     if parent is None or 'user' not in parent:
         return
 

--- a/h/notification/test/reply_template_test.py
+++ b/h/notification/test/reply_template_test.py
@@ -439,6 +439,6 @@ def effective_principals(request):
 def fetch(request):
     patcher = patch.object(storage, 'fetch_annotation')
     fetch = patcher.start()
-    fetch.side_effect = _fake_anno
+    fetch.side_effect = lambda _, id: _fake_anno(id)
     request.addfinalizer(patcher.stop)
     return fetch

--- a/h/presenters.py
+++ b/h/presenters.py
@@ -127,12 +127,7 @@ class AnnotationHTMLPresenter(object):
         """
         document_ = self.annotation.document
         if document_:
-            try:
-                title = document_["title"]
-            except (KeyError, TypeError):
-                # Sometimes document_ has no "title" key or isn't a dict at
-                # all.
-                title = ""
+            title = document_.title
             if title:
                 # Convert non-string titles into strings.
                 # We're assuming that title cannot be a byte string.

--- a/h/test/admin_test.py
+++ b/h/test/admin_test.py
@@ -783,8 +783,8 @@ def test_delete_user_deletes_annotations(elasticsearch_helpers, api_storage):
     admin.delete_user(request, user)
 
     assert api_storage.delete_annotation.mock_calls == [
-        call('annotation-1'),
-        call('annotation-2')
+        call(request, 'annotation-1'),
+        call(request, 'annotation-2')
     ]
 
 

--- a/h/views/main.py
+++ b/h/views/main.py
@@ -19,15 +19,16 @@ from h.views.client import render_app
 
 @view_config(route_name='annotation', permission='read')
 def annotation_page(annotation, request):
-    if 'title' in annotation.get('document', {}):
+    document = annotation.document
+    if document and document.title:
         title = 'Annotation by {user} on {title}'.format(
-            user=annotation['user'].replace('acct:', ''),
-            title=annotation['document']['title'])
+            user=annotation.userid.replace('acct:', ''),
+            title=document.title)
     else:
         title = 'Annotation by {user}'.format(
-            user=annotation['user'].replace('acct:', ''))
+            user=annotation.userid.replace('acct:', ''))
 
-    alternate = request.route_url('api.annotation', id=annotation['id'])
+    alternate = request.route_url('api.annotation', id=annotation.id)
 
     return render_app(request, {
         'meta_attrs': (

--- a/scripts/migrate.py
+++ b/scripts/migrate.py
@@ -248,6 +248,8 @@ def create_or_update_document_uri(es_docuri, pg_document):
                              created=es_docuri.created,
                              updated=es_docuri.updated)
         Session.add(docuri)
+    elif not docuri.document == pg_document:
+        log.warn('Found DocumentURI with id {:d} does not match expected document with id {:d}', docuri.id, pg_document.id)
 
     docuri.updated = es_docuri.updated
 
@@ -268,6 +270,8 @@ def create_or_update_document_meta(es_meta, pg_document):
     else:
         meta.value = es_meta.value
         meta.updated = es_meta.updated
+        if not meta.document == pg_document:
+            log.warn('Found DocumentMeta with id {:d} does not match expected document with id {:d}', meta.id, pg_document.id)
 
 
 def _batch_iter(n, iterable):

--- a/scripts/migrate.py
+++ b/scripts/migrate.py
@@ -166,6 +166,8 @@ def import_annotations(annotations):
             objs.add(annotation)
 
             create_or_update_document_objects(es_annotation)
+
+            Session.flush()
         except Exception as e:
             log.warn('error importing %s: %s', a['_id'], e)
             failure += 1
@@ -246,7 +248,6 @@ def create_or_update_document_uri(es_docuri, pg_document):
                              created=es_docuri.created,
                              updated=es_docuri.updated)
         Session.add(docuri)
-        Session.flush()
 
     docuri.updated = es_docuri.updated
 
@@ -264,7 +265,6 @@ def create_or_update_document_meta(es_meta, pg_document):
                             updated=es_meta.updated,
                             document=pg_document)
         Session.add(meta)
-        Session.flush()
     else:
         meta.value = es_meta.value
         meta.updated = es_meta.updated

--- a/scripts/migrate.py
+++ b/scripts/migrate.py
@@ -232,7 +232,7 @@ def annotation_from_data(id, data):
 def document_objs_from_data(data, ann):
     links = _transfom_document_links(ann.target_uri, data)
     uris = [link['uri'] for link in links]
-    documents = Document.find_or_create_by_uris(ann.target_uri, uris,
+    documents = Document.find_or_create_by_uris(Session, ann.target_uri, uris,
                                                 created=ann.created,
                                                 updated=ann.updated)
 


### PR DESCRIPTION
I didn't anticipate this many changes, so the branch name doesn't really reflect the code changes anymore.

Notable changes:

## Recreate Postgres model interface in the Elasticsearch models

To be able to use models regardless whether the data originally came from Elasticsearch or Postgres, I've re-created the same class structure in the Elasticsearch models. Which means we're having in-memory-only representations of `Document` / `DocumentMeta` / `DocumentURI` classes for Elasticsearch.

An Elasticsearch annotation, which is base structure is a `dict` gets automatically parsed into the aforementioned objects as soon as these properties are accessed.

The normalisation code that used to live in he Postgres migration script (`scripts/migrate.py`) has also moved into the Elasticsearch model, with added tests now.

## API Presenter layer

There is a new module `h.api.presenters` with JSON presenters for the four model classes (`Annotation`, `Document`, `DocumentMeta`, `DocumentURI`).
These are built to return the same JSON structure as we do now (minus the few occasions where we normalise the data, see above).

**Important:** This means that regardless of feature flag, as soon as these code changes get deployed, the `/api/annotations/:id` endpoint will go through the new presentation layer.

## Feature flag for reading from Postgres

There is a feature flag that for reading from Postgres. This currently only has an effect on the `h.api.storage.fetch_annotation` function, all other places (e.g. searching, or loading the created annotation before returning it) will still go Elasticsearch.