### PR TITLE
Speed up npm dependency checking when running 'make dev'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ h.egg-info/.uptodate: setup.py requirements.txt
 	touch $@
 
 node_modules/.uptodate: package.json
-	npm install
+	$(NPM_BIN)/check-dependencies || npm install
 	touch $@
 
 clean:

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
   },
   "devDependencies": {
     "chai": "^3.2.0",
+    "check-dependencies": "^0.12.0",
     "jscs": "^1.13.1",
     "karma": "^0.13.10",
     "karma-browserify": "^3.0.3",


### PR DESCRIPTION
When package.json changes, use 'check-dependencies' to do
a lightweight offline-only check of whether the installed
packages match the version ranges specified in package.json
before running the much slower 'npm install' to actually
install any missing dependencies.