### PR TITLE
Enable admins to activate users

### DIFF
--- a/h/accounts/models.py
+++ b/h/accounts/models.py
@@ -132,6 +132,11 @@ class User(Base):
 
         return False
 
+    def activate(self):
+        """Activate the user by deleting any activation they have."""
+        session = sa.orm.object_session(self)
+        session.delete(self.activation)
+
     # Hashed password
     _password = sa.Column('password', sa.UnicodeText(), nullable=False)
     # Password salt

--- a/h/accounts/test/models_test.py
+++ b/h/accounts/test/models_test.py
@@ -132,3 +132,17 @@ def test_staff_members_does_not_return_non_staff_users():
 
     for non_staff in non_staff:
         assert non_staff not in staff
+
+
+def test_User_activate_activates_user():
+    user = models.User(username='kiki', email='kiki@kiki.com',
+                       password='password')
+    activation = models.Activation()
+    user.activation = activation
+    db.Session.add(user)
+    db.Session.flush()
+
+    user.activate()
+    db.Session.commit()
+
+    assert user.is_activated

--- a/h/accounts/test/views_test.py
+++ b/h/accounts/test/views_test.py
@@ -691,10 +691,9 @@ class TestActivateController(object):
         with pytest.raises(httpexceptions.HTTPNotFound):
             views.ActivateController(request).get_when_not_logged_in()
 
-    def test_get_when_not_logged_in_successful_deletes_activation(
+    def test_get_when_not_logged_in_successful_activates_user(
             self,
-            user_model,
-            activation_model):
+            user_model):
         request = DummyRequest(matchdict={'id': '123', 'code': 'abc456'})
         request.db.delete = mock.create_autospec(request.db.delete,
                                                  return_value=None)
@@ -702,8 +701,7 @@ class TestActivateController(object):
 
         views.ActivateController(request).get_when_not_logged_in()
 
-        request.db.delete.assert_called_once_with(
-            activation_model.get_by_code.return_value)
+        user_model.get_by_activation.return_value.activate.assert_called_once_with()
 
     def test_get_when_not_logged_in_successful_flashes_message(self,
                                                                user_model):

--- a/h/accounts/views.py
+++ b/h/accounts/views.py
@@ -422,14 +422,14 @@ class ActivateController(object):
         if user is None or user.id != id_:
             raise httpexceptions.HTTPNotFound()
 
-        # Activate the user (by deleting the activation)
-        self.request.db.delete(activation)
+        user.activate()
 
         self.request.session.flash(jinja2.Markup(_(
             'Your account has been activated! '
             'You can now <a href="{url}">sign in</a> using the password you '
             'provided.').format(url=self.request.route_url('login'))),
             'success')
+
         self.request.registry.notify(ActivationEvent(self.request, user))
 
         return httpexceptions.HTTPFound(

--- a/h/static/styles/admin.scss
+++ b/h/static/styles/admin.scss
@@ -10,3 +10,7 @@ body {
   table-layout: auto;
   width: auto;
 }
+
+.users-activate-form {
+  display: inline;
+}

--- a/h/templates/admin/users.html.jinja2
+++ b/h/templates/admin/users.html.jinja2
@@ -27,7 +27,23 @@
           <tr><th>Last login</th><td>{{ user.last_login_date }}</td></tr>
           <tr>
             <th>Is activated?</th>
-            <td>{% if user.is_activated %}&#x2714;{% else %}&#x2718;{% endif %}</td>
+            <td>
+              {% if user.is_activated %}
+                &#x2714;
+              {% else %}
+                &#x2718;
+                <form action="{{request.route_path('admin_users_activate')}}"
+                      class="users-activate-form"
+                      method="POST">
+                  <input type="hidden"
+                         name="username"
+                         value="{{user.username}}">
+                  <button class="btn btn-primary btn-xs" type="submit">
+                    Activate
+                  </button>
+                </form>
+              {% endif %}
+            </td>
           </tr>
           <tr>
             <th>Is admin?</th>


### PR DESCRIPTION
Add an "Activate" button next to users on the /admin/users page so that
admins can activate user accounts.

Some refactoring to avoid code duplication between activating by users
clicking on an activation link and admins clicking the new activate button:
move the code that actually activates the user onto the User model where
both views can call it.