### PR TITLE
Add a 'manifest' tox env to check MANIFEST.in for correctness

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ before_script:
 script:
   # Run python tests
   - tox
+  # Check python package manifest
+  - tox -e manifest
   # Run client (app) tests
   - gulp test-app
   # Run extension tests

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include Makefile AUTHORS CHANGES LICENSE NOTICE
+include *.rst
 include Dockerfile
 include gulpfile.js
 include gunicorn.conf.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,13 @@
+[check-manifest]
+ignore =
+    */test
+    */test/*
+    .*
+    h/browser
+    h/browser/*
+    node_modules
+    tox.ini
+
 [pep257]
 ignore = D202
 explain = true

--- a/tox.ini
+++ b/tox.ini
@@ -26,3 +26,8 @@ skip_install = true
 commands =
     coverage combine
     coverage report
+
+[testenv:manifest]
+deps = check-manifest
+skip_install = true
+commands = check-manifest


### PR DESCRIPTION
Adds a test task to check that we haven't forgotten to include anything from version control in MANIFEST.in. If we do forget such things, then the Docker image will be incomplete, so we better not.