### PR TITLE
Use Node v4.3 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,7 @@ addons:
       # Upload all built zipfiles (browser extensions)
       - $(ls build/*.zip | tr "\n" ":")
   postgresql: "9.4"
-language:
-  - python
+language: python
 python:
   - '2.7'
 before_install:
@@ -15,7 +14,10 @@ before_install:
   - npm install gulp-cli
 install:
   - pip install --use-wheel -e .
+  - nvm install 4.3
+  - node --version
   - npm install
+  - npm rebuild node-sass
 before_script:
   - createdb htest
 script:


### PR DESCRIPTION
Use Node v4 for consistency with what we use to
build the production assets in the Docker build
and also to enable some ES2015 goodness in Gulp scripts (eg. template strings)

Travis does not support multiple languages
in the 'language' field, so non-default Node
versions need to be installed with nvm as
part of the install process.

Rebuilding node-sass was needed to get a version
of the native binding that matched the Node version,
even when after clearing the cache for the branch. I'm not clear
at the moment on why this was necessary.