### PR TITLE
Implement tools to enable Chrome extension sourcemaps

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -9,6 +9,7 @@
   "strict": "global",
   "undef": true,
   "unused": true,
+  "esversion": 6,
   "globals": {
     "chrome": false,
     "h": false,

--- a/.jshintrc
+++ b/.jshintrc
@@ -10,6 +10,7 @@
   "undef": true,
   "unused": true,
   "esversion": 6,
+  "esnext": true,
   "globals": {
     "chrome": false,
     "h": false,

--- a/h/static/scripts/app.coffee
+++ b/h/static/scripts/app.coffee
@@ -1,17 +1,23 @@
 require('./polyfills')
 
-# initialize Raven. This is required at the top of this file
+# Initialize Raven. This is required at the top of this file
 # so that it happens early in the app's startup flow
 settings = require('./settings')(document)
 if settings.raven
-  require('./raven').init(settings.raven)
-
+  raven = require('./raven')
+  raven.init(settings.raven)
 
 angular = require('angular')
 
 # autofill-event relies on the existence of window.angular so
 # it must be require'd after angular is first require'd
 require('autofill-event')
+
+# Setup Angular integration for Raven
+if settings.raven
+  raven.angularModule(angular)
+else
+  angular.module('ngRaven', [])
 
 streamer = require('./streamer')
 
@@ -89,7 +95,7 @@ module.exports = angular.module('h', [
   ['ui.bootstrap', require('./vendor/ui-bootstrap-custom-tpls-0.13.4')][0]
 
   # Local addons
-  require('./raven').angularModule().name
+  'ngRaven'
 ])
 
 .controller('AppController', require('./app-controller'))

--- a/h/static/scripts/test/raven-test.js
+++ b/h/static/scripts/test/raven-test.js
@@ -1,6 +1,31 @@
+'use strict';
+
 var proxyquire = require('proxyquire');
 
+function noCallThru(stub) {
+  return Object.assign(stub, {'@noCallThru':true});
+}
+
+function fakeExceptionData(scriptURL) {
+  return {
+    exception: {
+      values: [{
+        stacktrace: {
+          frames: [{
+            filename: scriptURL,
+          }]
+        }
+      }]
+    },
+    culprit: scriptURL,
+  };
+}
+
 describe('raven', function () {
+  // A stub for the callback that the Angular plugin installs with
+  // Raven.setDataCallback()
+  var fakeAngularTransformer;
+  var fakeAngularPlugin;
   var fakeRavenJS;
   var raven;
 
@@ -9,10 +34,26 @@ describe('raven', function () {
       config: sinon.stub().returns({
         install: sinon.stub(),
       }),
+
       captureException: sinon.stub(),
+
+      setDataCallback: function (callback) {
+        this._globalOptions.dataCallback = callback;
+      },
+
+      _globalOptions: {
+        dataCallback: undefined,
+      },
     };
+
+    fakeAngularTransformer = sinon.stub();
+    fakeAngularPlugin = sinon.spy(function (Raven) {
+      Raven.setDataCallback(fakeAngularTransformer);
+    });
+
     raven = proxyquire('../raven', {
-      'raven-js': fakeRavenJS,
+      'raven-js': noCallThru(fakeRavenJS),
+      'raven-js/plugins/angular': noCallThru(fakeAngularPlugin),
     });
   });
 
@@ -29,6 +70,36 @@ describe('raven', function () {
 
       assert.calledWith(fakeRavenJS.captureException, event.reason,
         sinon.match.any);
+    });
+  });
+
+  describe('pre-submission data transformation', function () {
+    var dataCallback;
+
+    beforeEach(function () {
+      raven.init({dsn: 'dsn', release: 'release'});
+      var configOpts = fakeRavenJS.config.args[0][1];
+      dataCallback = configOpts && configOpts.dataCallback;
+    });
+
+    it('installs a transformer', function () {
+      assert.ok(dataCallback);
+    });
+
+    it('replaces non-HTTP URLs with filenames', function () {
+      var scriptURL = 'chrome-extension://1234/public/bundle.js';
+      var transformed = dataCallback(fakeExceptionData(scriptURL));
+      assert.equal(transformed.culprit, 'bundle.js');
+      var transformedStack = transformed.exception.values[0].stacktrace;
+      assert.equal(transformedStack.frames[0].filename, 'bundle.js');
+    });
+
+    it('does not modify HTTP URLs', function () {
+      var scriptURL = 'https://hypothes.is/assets/scripts/bundle.js';
+      var transformed = dataCallback(fakeExceptionData(scriptURL));
+      assert.equal(transformed.culprit, scriptURL);
+      var transformedStack = transformed.exception.values[0].stacktrace;
+      assert.equal(transformedStack.frames[0].filename, scriptURL);
     });
   });
 
@@ -51,6 +122,37 @@ describe('raven', function () {
           url: 'foobar.com',
         },
       });
+    });
+  });
+
+  describe('.angularModule()', function () {
+    var angularStub;
+
+    beforeEach(function () {
+      angularStub = {
+        module: sinon.stub(),
+      };
+    });
+
+    it('installs the Angular plugin', function () {
+      raven.init('dsn');
+      raven.angularModule(angularStub);
+      assert.calledWith(fakeAngularPlugin, fakeRavenJS, angularStub);
+    });
+
+    it('installs the data transformers', function () {
+      raven.init('dsn');
+      var originalTransformer = sinon.stub();
+      fakeRavenJS._globalOptions.dataCallback = originalTransformer;
+      raven.angularModule(angularStub);
+      fakeRavenJS._globalOptions.dataCallback(
+        fakeExceptionData('app.bundle.js')
+      );
+
+      // Check that both our data transformer and the one provided by
+      // the Angular plugin were invoked
+      assert.called(originalTransformer);
+      assert.called(fakeAngularTransformer);
     });
   });
 });

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "proxyquire": "^1.6.0",
     "proxyquire-universal": "^1.0.8",
     "proxyquireify": "^3.0.0",
+    "request": "^2.69.0",
     "sinon": "1.16.1"
   },
   "engines": {

--- a/scripts/delete-sentry-release.py
+++ b/scripts/delete-sentry-release.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+
+from argparse import ArgumentParser
+
+import requests
+
+
+def main():
+    parser = ArgumentParser(description=
+        """Delete a release and associated files from Sentry""")
+    parser.add_argument('--key', required=True)
+    parser.add_argument('--org', required=True)
+    parser.add_argument('--project', required=True)
+    parser.add_argument('--release', required=True)
+    args = parser.parse_args()
+
+    sentry_release_url = '{}/api/0/projects/{}/{}/releases/{}/'.format(
+        'https://app.getsentry.com',
+        args.org,
+        args.project,
+        args.release
+    )
+    res = requests.delete(sentry_release_url, auth=(args.key,''))
+    if res.status_code != 204:
+        print('Deleting release failed: {}: {}'.format(res.status_code,
+          res.text))
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/gulp/upload-to-sentry.js
+++ b/scripts/gulp/upload-to-sentry.js
@@ -1,0 +1,115 @@
+'use strict';
+
+var fs = require('fs');
+var gulpUtil = require('gulp-util');
+var path = require('path');
+var request = require('request');
+var through = require('through2');
+
+/**
+ * interface SentryOptions {
+ *   /// The Sentry API key
+ *   apiKey: string;
+ *   /// The release string for the release to create
+ *   release: string;
+ *   /// The organization slug to use when constructing the API URL
+ *   organization: string;
+ *   /// The project name slug to use when constructing the API URL
+ *   project: string;
+ * }
+ */
+
+/** Wrapper around request() that returns a Promise. */
+function httpRequest(opts) {
+  return new Promise(function (resolve, reject) {
+    request(opts, function (err, response, body) {
+      if (err) {
+        reject(err);
+      } else {
+        resolve({
+          status: response.statusCode,
+          body: body,
+        });
+      }
+    });
+  });
+}
+
+/**
+ * Upload a stream of Vinyl files as a Sentry release.
+ *
+ * This creates a new release in Sentry using the organization, project
+ * and release settings in @p opts and uploads the input stream of Vinyl
+ * files as artefacts for the release.
+ *
+ * @param {SentryOptions} opts
+ * @return {NodeJS.ReadWriteStream} - A stream into which Vinyl files from
+ *                                    gulp.src() etc. can be piped.
+ */
+module.exports = function uploadToSentry(opts) {
+
+  // A map of already-created release versions.
+  // Once the release has been successfully created, this is used
+  // to avoid creating it again.
+  var createdReleases = {};
+
+  return through.obj(function (file, enc, callback) {
+    enc = enc;
+
+    gulpUtil.log(`Uploading ${file.path} to Sentry`);
+
+    var sentryURL =
+      `https://app.getsentry.com/api/0/projects/${opts.organization}/${opts.project}/releases`;
+
+    var releaseCreated;
+    if (createdReleases[opts.release]) {
+      releaseCreated = Promise.resolve();
+    } else {
+      releaseCreated = httpRequest({
+          uri: `${sentryURL}/`,
+          method: 'POST',
+          auth: {
+            user: opts.apiKey,
+            password: '',
+          },
+          body: {
+            version: opts.release,
+          },
+          json: true,
+        }).then(function (result) {
+          if (result.status === 201 ||
+              (result.status === 400 &&
+               result.body.detail.match(/already exists/))) {
+            createdReleases[opts.release] = true;
+            return;
+          }
+        });
+    }
+
+    releaseCreated.then(function () {
+      return httpRequest({
+        uri: `${sentryURL}/${opts.release}/files/`,
+        method: 'POST',
+        auth: {
+          user: opts.apiKey,
+          password: '',
+        },
+        formData: {
+          file: fs.createReadStream(file.path),
+          name: path.basename(file.path),
+        },
+      });
+    }).then(function (result) {
+      if (result.status === 201) {
+        callback();
+        return;
+      }
+      var message =
+        `Uploading file failed: ${result.status}: ${result.body}`;
+      throw new Error(message);
+    }).catch(function (err) {
+      gulpUtil.log('Sentry upload failed: ', err);
+      throw err;
+    });
+  });
+};


### PR DESCRIPTION
When the H client is served from a local URL (eg.
chrome-extension://ID/scripts/foo.bundle.js), the original
source URLs and source maps are not accessible
to Sentry.

Enabling source maps for extensions is done in three steps,
the first two of which are implemented in this PR:

 1. Changes to the crash reporting to transform local URLs
    into filenames when reporting exceptions.

    This results in URLs for source files in Sentry
    reports which are independent of where the files
    are served from
    (eg. chrome-extension://ID/scripts/bundle.js -> bundle.js)

 2. A Gulp task that uploads JS bundles and their associated
    sourcemaps to Sentry using the Sentry API.

    The assets are uploaded to Sentry using just the filename as
    the URL, so the source files and source maps are correctly
    matched up with the transformed URLs produced by the changes
    in (1).

 3. Configuring CI builds to run the Gulp task from step (2).

This commit makes use of ES2015 template strings in
upload-to-sentry.js, so the JSHint file has been adjusted
accordingly.
