### PR TITLE
Add a test and fix a parameter for queries

### DIFF
--- a/h/api/test/uri_test.py
+++ b/h/api/test/uri_test.py
@@ -100,6 +100,10 @@ from h.api import uri
     # Query: remove empty
     ("http://example.com?", "http://example.com"),
 
+    # Query: Preserve the query string if we can't parse it
+    ("http://example.com?&", "http://example.com?&"),
+    ("http://example.com?foo=&", "http://example.com?foo=&"),
+
     # Query: ensure UNRESERVED characters are decoded
     ("http://example.com?foo%7Ebar=baz", "http://example.com?foo~bar=baz"),
     ("http://example.com?foo~bar=baz", "http://example.com?foo~bar=baz"),

--- a/h/api/uri.py
+++ b/h/api/uri.py
@@ -218,7 +218,7 @@ def _normalize_query(uri):
     query = uri.query
 
     try:
-        items = urlparse.parse_qsl(query, keep_blank_values=True)
+        items = urlparse.parse_qsl(query, keep_blank_values=True, strict_parsing=True)
     except ValueError:
         # If we can't parse the query string, we better preserve it as it was.
         return query


### PR DESCRIPTION
Added a test for when we can't parse a query. 
Also added the `strict_parsing=True` parameter to make this possible.