### PR TITLE
Standardise and improve log output for all servers

### DIFF
--- a/conf/app.ini
+++ b/conf/app.ini
@@ -7,7 +7,6 @@ pipeline:
   raven
   h
 
-
 [app:h]
 use: egg:h
 
@@ -40,67 +39,57 @@ redis.sessions.timeout: 604800
 # SQLAlchemy configuration -- See SQLAlchemy documentation
 sqlalchemy.url: postgresql://postgres@localhost/postgres
 
-
 [filter:proxy-prefix]
 use: egg:PasteDeploy#prefix
 
-
 [filter:raven]
 use: egg:raven#raven
-
 
 [server:main]
 use: egg:gunicorn
 host: 0.0.0.0
 port: 5000
 
-
 [loggers]
-keys = root, sentry, gunicorn.error, alembic
-
+keys = root, alembic, gunicorn.error, sentry
 
 [handlers]
 keys = console, sentry
 
-
 [formatters]
 keys = generic
 
-
 [logger_root]
+level = WARNING
 handlers = console, sentry
-
-
-[logger_sentry]
-level = WARN
-handlers = console
-qualname = sentry.errors
-propagate = 0
-
-
-[logger_gunicorn.error]
-handlers =
-qualname = gunicorn.error
-
 
 [logger_alembic]
 level = INFO
 handlers =
 qualname = alembic
 
+[logger_gunicorn.error]
+level = INFO
+handlers =
+qualname = gunicorn.error
+
+[logger_sentry]
+level = WARNING
+handlers = console
+qualname = sentry.errors
+propagate = 0
 
 [handler_console]
+level = NOTSET
 class = StreamHandler
 args = ()
 formatter = generic
 
-
 [handler_sentry]
+level = WARNING
 class = raven.handlers.logging.SentryHandler
 args = ()
-level = WARN
 formatter = generic
-
 
 [formatter_generic]
 format = %(asctime)s [%(process)d] [%(name)s:%(levelname)s] %(message)s

--- a/conf/development-app.ini
+++ b/conf/development-app.ini
@@ -1,7 +1,6 @@
 [pipeline:main]
 pipeline: h
 
-
 [app:h]
 use: egg:h
 
@@ -32,7 +31,6 @@ sqlalchemy.url: postgresql://postgres@localhost/postgres
 ;http://docs.pylonsproject.org/projects/pyramid-debugtoolbar/en/latest/#settings
 debugtoolbar.show_on_exc_only: True
 
-
 [server:main]
 use: egg:gunicorn
 host: localhost
@@ -42,40 +40,40 @@ timeout: 0
 errorlog: -
 reload: True
 
-
 [loggers]
-keys = root, gunicorn.error, h
-
+keys = root, gunicorn.error, h, raven
 
 [handlers]
 keys = console
 
-
 [formatters]
 keys = generic
 
-
 [logger_root]
+level = WARNING
 handlers = console
-
 
 [logger_gunicorn.error]
 level = INFO
 handlers =
 qualname = gunicorn.error
 
-
 [logger_h]
 level = INFO
 handlers =
 qualname = h
 
+[logger_raven]
+level = WARNING
+handlers = console
+qualname = raven
+propagate = 0
 
 [handler_console]
+level = NOTSET
 class = StreamHandler
 args = ()
 formatter = generic
-
 
 [formatter_generic]
 format = %(asctime)s [%(process)d] [%(name)s:%(levelname)s] %(message)s

--- a/conf/development-websocket.ini
+++ b/conf/development-websocket.ini
@@ -25,7 +25,7 @@ worker_class: h.websocket.Worker
 graceful_timeout: 0
 
 [loggers]
-keys = root
+keys = root, gunicorn.error, h, raven
 
 [handlers]
 keys = console
@@ -34,9 +34,27 @@ keys = console
 keys = generic
 
 [logger_root]
+level = WARNING
 handlers = console
 
+[logger_gunicorn.error]
+level = INFO
+handlers =
+qualname = gunicorn.error
+
+[logger_h]
+level = INFO
+handlers =
+qualname = h
+
+[logger_raven]
+level = WARNING
+handlers = console
+qualname = raven
+propagate = 0
+
 [handler_console]
+level = NOTSET
 class = StreamHandler
 args = ()
 formatter = generic

--- a/conf/websocket.ini
+++ b/conf/websocket.ini
@@ -25,7 +25,7 @@ worker_class: h.websocket.Worker
 graceful_timeout: 0
 
 [loggers]
-keys = root, sentry
+keys = root, gunicorn.error, sentry
 
 [handlers]
 keys = console, sentry
@@ -34,23 +34,30 @@ keys = console, sentry
 keys = generic
 
 [logger_root]
+level = WARNING
 handlers = console, sentry
 
+[logger_gunicorn.error]
+level = INFO
+handlers =
+qualname = gunicorn.error
+
 [logger_sentry]
-level = WARN
+level = WARNING
 handlers = console
 qualname = sentry.errors
 propagate = 0
 
 [handler_console]
+level = NOTSET
 class = StreamHandler
 args = ()
 formatter = generic
 
 [handler_sentry]
+level = WARNING
 class = raven.handlers.logging.SentryHandler
 args = ()
-level = WARN
 formatter = generic
 
 [formatter_generic]


### PR DESCRIPTION
This commit tidies up our logging configuration and ensures the following:

- log format is the same for all loggers, for all servers
- the root log level is WARNING in all cases.
- the log level for `gunicorn.error` (which prints gunicorn
  startup/status messages) is INFO in all cases.
- production servers have a Sentry log handler configured which reports
  all messages at WARNING or above.
- development servers log `h` (our code) at INFO.
- until Raven 5.11.0 is released (which will stop Raven from
  automatically configuring its own logger) we override the `raven`
  logger explicitly and set the log level to WARNING in development