### PR TITLE
Remove undocumented /api/annotations endpoint

### DIFF
--- a/h/api/test/views_test.py
+++ b/h/api/test/views_test.py
@@ -85,22 +85,6 @@ def test_search_returns_search_results(search_lib):
     assert result == search_lib.search.return_value
 
 
-def test_annotations_index_searches(search_lib):
-    request = testing.DummyRequest()
-
-    views.annotations_index(request)
-
-    search_lib.search.assert_called_once_with(request, {"limit": 20})
-
-
-def test_annotations_index_returns_search_results(search_lib):
-    request = testing.DummyRequest()
-
-    result = views.annotations_index(request)
-
-    assert result == search_lib.search.return_value
-
-
 create_fixtures = pytest.mark.usefixtures('AnnotationEvent',
                                           'schemas',
                                           'storage')

--- a/h/api/views.py
+++ b/h/api/views.py
@@ -138,16 +138,6 @@ def search(request):
                              separate_replies=separate_replies)
 
 
-@api_config(route_name='api.annotations')
-def annotations_index(request):
-    """Do a search for all annotations on anything and return results.
-
-    This will use the default limit, 20 at time of writing, and results
-    are ordered most recent first.
-    """
-    return search_lib.search(request, {"limit": 20})
-
-
 @api_config(route_name='api.annotations',
             request_method='POST',
             effective_principals=security.Authenticated)


### PR DESCRIPTION
As discussed with @nickstenning, it is not being used, nor is it documented. Plus it is pretty useless, as it only returns the first 20 search results, without any way of specifying a search term. There is a proper search endpoint for that.