### PR TITLE
Live reload development tool for Hypothesis client

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,12 @@
+Unreleased
+==========
+
+Miscellanea
+-----------
+
+- Added a live reload facility for development of the Hypothesis
+  front-end (#3038)
+
 0.16.0 (2016-04-04)
 ===================
 

--- a/docs/hacking/install.rst
+++ b/docs/hacking/install.rst
@@ -227,6 +227,10 @@ will automatically rebuild the assets whenever the source files change.
     npm install -g gulp-cli
     gulp watch
 
+When `gulp watch` is running, you can visit http://localhost:3000
+to see a page with an embedded Hypothesis client which will automatically reload
+when styles, templates or JavaScript source files are changed.
+
 .. _Gulp: http://gulpjs.com/
 
 .. _running-the-tests:

--- a/h/static/scripts/app.js
+++ b/h/static/scripts/app.js
@@ -106,6 +106,12 @@ function setupHttp($http) {
   $http.defaults.headers.common['X-Client-Id'] = streamer.clientId;
 }
 
+function processAppOpts() {
+  if (settings.liveReloadServer) {
+    require('./live-reload-client').connect(settings.liveReloadServer);
+  }
+}
+
 module.exports = angular.module('h', [
   // Angular addons which export the Angular module name
   // via module.exports
@@ -197,3 +203,5 @@ module.exports = angular.module('h', [
 
   .run(setupCrossFrame)
   .run(setupHttp);
+
+processAppOpts();

--- a/h/static/scripts/live-reload-client.js
+++ b/h/static/scripts/live-reload-client.js
@@ -1,0 +1,100 @@
+'use strict';
+
+var queryString = require('query-string');
+
+var Socket = require('./websocket');
+
+/**
+ * Return a URL with a cache-busting query string parameter added.
+ *
+ * @param {string} url - The original asset URL
+ * @return {string} The URL with a cache-buster added.
+ */
+function cacheBustURL(url) {
+  var newUrl = url;
+  var cacheBuster = queryString.parse({timestamp: Date.now()});
+  if (url.indexOf('?') !== -1) {
+    newUrl += '&' + cacheBuster;
+  } else {
+    newUrl += '?' + cacheBuster;
+  }
+  return newUrl;
+}
+
+/**
+ * Return true if a URL matches a list of paths of modified assets.
+ *
+ * @param {string} url - The URL of the stylesheet, script or other resource.
+ * @param {Array<string>} changed - List of paths of modified assets.
+ */
+function didAssetChange(url, changed) {
+  return changed.some(function (path) {
+    return url.indexOf(path) !== -1;
+  });
+}
+
+/**
+ * Reload a stylesheet or media element if it references a file
+ * in a list of changed assets.
+ *
+ * @param {Element} element - An HTML <link> tag or media element.
+ * @param {Array<string>} changed - List of paths of modified assets.
+ */
+function maybeReloadElement(element, changed) {
+  var parentElement = element.parentNode;
+  var newElement = element.cloneNode();
+  var srcKeys = ['href', 'src'];
+  srcKeys.forEach(function (key) {
+    if (key in element && didAssetChange(element[key], changed)) {
+      newElement[key] = cacheBustURL(element[key]);
+    }
+  });
+  parentElement.replaceChild(newElement, element);
+}
+
+function reloadExternalStyleSheets(changed) {
+  var linkTags = [].slice.apply(document.querySelectorAll('link'));
+  linkTags.forEach(function (tag) {
+    maybeReloadElement(tag, changed);
+  });
+}
+
+/**
+ * Connect to the live-reload server at @p url.
+ *
+ * @param {string} url - The URL of the live reload server. If undefined,
+ *                       the 'livereloadserver' query string parameter is
+ *                       used.
+ */
+function connect(url) {
+  var conn = new Socket(url);
+  conn.on('open', function () {
+    console.log('Live reload client listening');
+  });
+  conn.on('message', function (event) {
+    var message = JSON.parse(event.data);
+    if (message.type === 'assets-changed') {
+      var scriptsOrTemplatesChanged = message.changed.some(function (path) {
+        return path.match(/\.(html|js)$/);
+      });
+      var stylesChanged = message.changed.some(function (path) {
+        return path.match(/\.css$/);
+      });
+      if (scriptsOrTemplatesChanged) {
+        // Ask the host page to reload the client (eg. by reloading itself).
+        window.top.postMessage({type:'reloadrequest'}, '*');
+        return;
+      }
+      if (stylesChanged) {
+        reloadExternalStyleSheets(message.changed);
+      }
+    }
+  });
+  conn.on('error', function (err) {
+    console.error('Error connecting to live reload server:', err);
+  });
+}
+
+module.exports = {
+  connect: connect,
+};

--- a/package.json
+++ b/package.json
@@ -83,7 +83,8 @@
     "proxyquire-universal": "^1.0.8",
     "proxyquireify": "^3.0.0",
     "request": "^2.69.0",
-    "sinon": "1.16.1"
+    "sinon": "1.16.1",
+    "websocket": "^1.0.22"
   },
   "engines": {
     "node": "0.10.x"

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "is-equal-shallow": "^0.1.3",
     "jquery": "1.11.1",
     "js-polyfills": "^0.1.16",
+    "lodash.debounce": "^4.0.3",
     "mkdirp": "^0.5.1",
     "ng-tags-input": "2.2.0",
     "node-uuid": "^1.4.3",

--- a/scripts/gulp/live-reload-server.js
+++ b/scripts/gulp/live-reload-server.js
@@ -1,0 +1,107 @@
+'use strict';
+
+var fs = require('fs');
+var gulpUtil = require('gulp-util');
+var http = require('http');
+var WebSocketServer = require('websocket').server;
+
+function changelogText() {
+  return fs.readFileSync('./CHANGES', 'utf-8');
+}
+
+/**
+ * An HTTP and WebSocket server which enables live reloading of the client.
+ *
+ * A simple HTTP and WebSocket server
+ * which serves a test page with the Hypothesis client embedded
+ * and notifies connected clients when assets are modified, enabling
+ * the client to live-reload.
+ *
+ * @param {number} port - The port that the test server should listen on.
+ * @param {string} appServer - The URL of the Hypothesis service to load
+ *                             the client from.
+ *
+ * @constructor
+ */
+function LiveReloadServer(port, appServer) {
+  var connections = [];
+
+  function listen() {
+    var log = gulpUtil.log;
+    var server = http.createServer(function (req, response) {
+      var content = `
+    <html>
+    <head>
+      <meta charset="UTF-8">
+      <title>Hypothesis Client Test</title>
+    </head>
+    <body>
+      <pre style="margin: 75px;">${changelogText()}</pre>
+      <script>
+      window.hypothesisConfig = function () {
+        return {
+          liveReloadServer: 'ws://localhost:${port}',
+
+          // Open the sidebar when the page loads
+          firstRun: true,
+        };
+      };
+
+      window.addEventListener('message', function (event) {
+        if (event.data.type && event.data.type === 'reloadrequest') {
+          window.location.reload();
+        }
+      });
+      </script>
+      <script src="${appServer}/embed.js"></script>
+    </body>
+    </html>
+      `;
+      response.end(content);
+    });
+
+    server.listen(port, function (err) {
+      if (err) {
+        log('Setting up live reload server failed', err);
+      }
+      log(`Live reload server listening at http://localhost:${port}/`);
+    });
+
+    var ws = new WebSocketServer({
+      httpServer: server,
+    });
+
+    ws.on('request', function (req) {
+      log('Live reload client connected');
+      var conn = req.accept(null, req.origin);
+      connections.push(conn);
+
+      conn.on('close', function () {
+        var closedConn = conn;
+        connections = connections.filter(function (conn) {
+          return conn !== closedConn;
+        });
+      });
+    });
+  }
+
+  /**
+   * Notify connected clients about assets that changed.
+   *
+   * @param {Array<string>} assets - A list of paths of assets that changed.
+   *                                 Paths are relative to the root asset
+   *                                 build directory.
+   */
+  this.notifyChanged = function (assets) {
+    connections.forEach(function (conn) {
+      conn.sendUTF(JSON.stringify({
+        type: 'assets-changed',
+        changed: assets,
+      }));
+    });
+  };
+
+  listen();
+}
+
+module.exports = LiveReloadServer;


### PR DESCRIPTION
This implements a live reload server and client support which enables the Hypothesis client
to automatically reload stylesheets when they change and reload the app if scripts
or templates are changed.

Live reloading when scripts change currently requires support from the hosting page, which must
respond to a `reloadrequest` message from the sidebar app.

There are existing tools such as LiveReload and BrowserSync which do this but I've opted for something custom at the moment because of the differences between Hypothesis and a normal web page. On the client, it is also quite useful that we can re-use the existing WebSocket wrapper.

There are two parts to this:

 - A server which serves test pages with the Hypothesis client embedded and notifies
   it when front-end assets (styles, scripts) are changed.

   Test pages are served at http://localhost:3000/<any path>
   by default.

 - A small client script which connects to the server and listens for notifications of asset changes.
   It will then reload style tags etc.

----
**TODO**
- [x] Only start the live reload server when running `gulp watch`
- [x] Investigate why the sidebar does not always reload when a script or template change triggers a full page reload