### PR TITLE
Remove the MathJax math rendering fallback

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,13 @@
 Unreleased
 ==========
 
+Bug fixes
+---------
+
+- Fixed error when rendering invalid LaTeX markup. As a side effect,
+  the fallback to MathJax rendering for markup that is not supported
+  by KaTeX has been removed for the time being (#3042).
+
 0.10.0 (2016-03-07)
 ===================
 

--- a/h/browser/chrome/manifest.json.jinja2
+++ b/h/browser/chrome/manifest.json.jinja2
@@ -24,7 +24,7 @@
     "tabs"
   ],
   "content_security_policy":
-    "script-src 'self' 'unsafe-eval' {{ script_src }} https://cdn.mathjax.org; object-src 'self'; font-src 'self' data:;",
+    "script-src 'self' 'unsafe-eval' {{ script_src }} object-src 'self'; font-src 'self' data:;",
 
   "background": {
     "persistent": true,

--- a/h/static/scripts/directive/markdown.js
+++ b/h/static/scripts/directive/markdown.js
@@ -1,29 +1,10 @@
 'use strict';
 
-/* globals MathJax */
-
 var angular = require('angular');
 var katex = require('katex');
 
 var commands = require('../markdown-commands');
 var mediaEmbedder = require('../media-embedder');
-
-var loadMathJax = function() {
-  if (!(typeof MathJax !== "undefined" && MathJax !== null)) {
-    return $.ajax({
-      url: "https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML-full",
-      dataType: 'script',
-      cache: true,
-      complete: function () {
-        // MathJax configuration overides.
-        return MathJax.Hub.Config({
-          showMathMenu: false,
-          displayAlign: "left"
-        });
-      }
-    });
-  }
-};
 
 /**
  * @ngdoc directive
@@ -160,7 +141,6 @@ module.exports = function($filter, $sanitize, $sce) {
         }
       };
 
-      var mathJaxFallback = false;
       var renderInlineMath = function(textToCheck) {
         var re = /\\?\\\(|\\?\\\)/g;
         var startMath = null;
@@ -188,8 +168,6 @@ module.exports = function($filter, $sanitize, $sce) {
               endMath = null;
               return renderInlineMath(textToCheck);
             } catch (error) {
-              loadMathJax();
-              mathJaxFallback = true;
               $sanitize(textToCheck.substring(startMath, endMath));
             }
           }
@@ -228,8 +206,6 @@ module.exports = function($filter, $sanitize, $sce) {
                   // \\displaystyle tells KaTeX to render the math in display style (full sized fonts).
                   return katex.renderToString($sanitize("\\displaystyle {" + textToCheck.substring(startMath, index) + "}"));
                 } catch (error) {
-                  loadMathJax();
-                  mathJaxFallback = true;
                   return $sanitize(textToCheck.substring(startMath, index));
                 }
               } else {
@@ -260,11 +236,6 @@ module.exports = function($filter, $sanitize, $sce) {
         }
         var value = ctrl.$viewValue || '';
         output.innerHTML = renderMathAndMarkdown(value);
-        if (mathJaxFallback) {
-          return $timeout((function() {
-            return ((typeof MathJax !== "undefined" && MathJax !== null) ? MathJax.Hub : undefined).Queue(['Typeset', MathJax.Hub, output]);
-          }), 0, false);
-        }
       };
 
       // React to the changes to the input


### PR DESCRIPTION
The MathJax fallback was inadvertently broken during recent
refactoring of the <markdown> component and has long been untested.

This removes the fallback for the moment and in doing so
provides a clearer definition of what math we support -
the subset supported by KaTeX.

Looking at our public annotations, there is very little use
of complex math currently.

When we find a clear use case for it, we can revisit supporting
additional math beyond what KaTeX supports.

See https://trello.com/c/9KkjsO6v/66-remove-the-mathjax-fallback
for more background.