### PR TITLE
Fix syntax error in gulpfile.js

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -30,7 +30,7 @@ function isSASSFile(file) {
 
 function getEnv(key) {
   if (!process.env.hasOwnProperty(key)) {
-    throw new Error(`Environment variable ${key} is not set`);
+    throw new Error('Environment variable ${key} is not set');
   }
   return process.env[key];
 }


### PR DESCRIPTION
It looks like backticks ` were used instead of ', resulting in:

    /.../h/gulpfile.js:33
        throw new Error(`Environment variable ${key} is not set`);
                        ^
    SyntaxError: Unexpected token ILLEGAL