### PR TITLE
Fix elastic.Document initializer

### DIFF
--- a/h/api/models/elastic.py
+++ b/h/api/models/elastic.py
@@ -245,11 +245,12 @@ class Annotation(annotation.Annotation):
 class Document(document.Document):
     __analysis__ = {}
 
-    def __init__(self, d, claimant=None, created=None, updated=None):
-        super(document.Document, self).__init__(d)
-        self.claimant = claimant
-        self.created = created
-        self.updated = updated
+    def __init__(self, *args, **kwargs):
+        self.claimant = kwargs.pop('claimant', None)
+        self.created = kwargs.pop('created', None)
+        self.updated = kwargs.pop('updated', None)
+
+        super(Document, self).__init__(*args, **kwargs)
 
     @property
     def title(self):

--- a/h/api/models/test/elastic_test.py
+++ b/h/api/models/test/elastic_test.py
@@ -271,6 +271,27 @@ class TestAnnotation(object):
 
 
 class TestDocument(object):
+    def test_init(self):
+        doc = Document({'foo': 'bar'})
+        assert doc == {'foo': 'bar'}
+
+    def test_init_claimant(self):
+        doc = Document({}, claimant='http://example.com')
+        assert doc.claimant == 'http://example.com'
+
+    def test_init_created(self):
+        doc = Document({}, created='created-value')
+        assert doc.created == 'created-value'
+
+    def test_init_updated(self):
+        doc = Document({}, updated='updated-value')
+        assert doc.updated == 'updated-value'
+
+    def test_init_id(self):
+        """It passes through other keyword arguments through to super class."""
+        doc = Document({}, id='id-value')
+        assert doc['id'] == 'id-value'
+
     def test_created(self):
         doc = Document({}, created=datetime.datetime(2016, 2, 25, 16, 45, 23, 371848))
         assert doc.created == datetime.datetime(2016, 2, 25, 16, 45, 23, 371848)


### PR DESCRIPTION
Allow any number of arguments and keyword arguments, as the super class
supports an `id` keyword argument.