### PR TITLE
Use new Document API when expanding URIs

### DIFF
--- a/h/api/models/elastic.py
+++ b/h/api/models/elastic.py
@@ -265,6 +265,12 @@ class Document(document.Document):
 
     @property
     def uris(self):
+        """
+        Returns a list of the DocumentURIs for the document.
+
+        This overrides the inherited `uris` method from the annotator-store
+        which used to return a list of uri strings.
+        """
         return [DocumentURI(link) for link in self._transform_links()]
 
     def _transform_meta(self, meta, data, path_prefix=[]):

--- a/h/api/storage.py
+++ b/h/api/storage.py
@@ -120,11 +120,11 @@ def expand_uri(uri):
     # We check if the match was a "canonical" link. If so, all annotations
     # created on that page are guaranteed to have that as their target.source
     # field, so we don't need to expand to other URIs and risk false positives.
-    for link in doc.get('link', []):
-        if link.get('href') == uri and link.get('rel') == 'canonical':
+    for u in doc.uris:
+        if u.uri == uri and u.type == 'rel-canonical':
             return [uri]
 
-    return doc.uris()
+    return [u.uri for u in doc.uris if u.uri is not None]
 
 
 def _prepare(request, annotation):

--- a/h/api/test/storage_test.py
+++ b/h/api/test/storage_test.py
@@ -40,25 +40,20 @@ def test_expand_uri_no_document(document_model):
 
 
 def test_expand_uri_document_doesnt_expand_canonical_uris(document_model):
-    document = document_model.get_by_uri.return_value
-    document.get.return_value = [
-        {"href": "http://foo.com/"},
-        {"href": "http://bar.com/"},
-        {"href": "http://example.com/", "rel": "canonical"},
-    ]
-    document.uris.return_value = [
-        "http://foo.com/",
-        "http://bar.com/",
-        "http://example.com/",
-    ]
+    document_model.get_by_uri.return_value = mock.Mock(uris=[
+        mock.Mock(uri='http://foo.com/'),
+        mock.Mock(uri='http://bar.com'),
+        mock.Mock(uri='http://example.com/', type='rel-canonical'),
+    ])
     assert storage.expand_uri("http://example.com/") == ["http://example.com/"]
 
 
 def test_expand_uri_document_uris(document_model):
-    document_model.get_by_uri.return_value.uris.return_value = [
-        "http://foo.com/",
-        "http://bar.com/",
-    ]
+    document_model.get_by_uri.return_value = mock.Mock(uris=[
+        mock.Mock(uri="http://foo.com/"),
+        mock.Mock(uri=None),
+        mock.Mock(uri="http://bar.com/"),
+    ])
     assert storage.expand_uri("http://example.com/") == [
         "http://foo.com/",
         "http://bar.com/",


### PR DESCRIPTION
This fixes a bug we discovered on staging (https://app.getsentry.com/hypothesis/stage/issues/114915027/) that got introduced with #3011.