### PR TITLE
Add direct linking feature flag

### DIFF
--- a/h/static/scripts/directive/annotation.js
+++ b/h/static/scripts/directive/annotation.js
@@ -1,8 +1,6 @@
 /* jshint node: true */
 'use strict';
 
-var Promise = require('core-js/library/es6/promise');
-
 var annotationMetadata = require('../annotation-metadata');
 var dateUtil = require('../date-util');
 var documentDomain = require('../filter/document-domain');

--- a/h/static/scripts/directive/annotation.js
+++ b/h/static/scripts/directive/annotation.js
@@ -109,13 +109,22 @@ function updateDomainModel(domainModel, vm, permissions) {
 }
 
 /** Update the view model from the domain model changes. */
-function updateViewModel($scope, time, domainModel, vm, permissions) {
+function updateViewModel($scope, time, domainModel,
+                         vm, permissions) {
 
   vm.form = {
     text: domainModel.text,
     tags: viewModelTagsFromDomainModelTags(domainModel.tags),
   };
-  vm.annotationURI = new URL('/a/' + domainModel.id, vm.serviceUrl).href;
+
+  if (domainModel.links) {
+    vm.annotationURI = domainModel.links.incontext ||
+                       domainModel.links.html ||
+                       '';
+  } else {
+    vm.annotationURI = '';
+  }
+
   vm.isPrivate = permissions.isPrivate(
     domainModel.permissions, domainModel.user);
 

--- a/h/static/scripts/directive/test/annotation-test.js
+++ b/h/static/scripts/directive/test/annotation-test.js
@@ -347,7 +347,7 @@ describe('annotation', function() {
       };
 
       var fakeFeatures = {
-        flagEnabled: sandbox.stub().returns(true)
+        flagEnabled: sandbox.stub().returns(true),
       };
 
       fakeFlash = {
@@ -1494,6 +1494,33 @@ describe('annotation', function() {
         assert.equal(tagLinks.length, 1);
         assert.equal(tagLinks[0].href,
                      'https://test.hypothes.is/stream?q=tag:atag');
+      });
+    });
+
+    describe('annotation metadata', function () {
+      function findLink(directive) {
+        var links = directive.element[0]
+          .querySelectorAll('header .annotation-link');
+        return links[links.length-1];
+      }
+
+      it('displays HTML links when in-context links are not available', function () {
+        var annotation = Object.assign({}, fixtures.defaultAnnotation(), {
+          links: {html: 'https://test.hypothes.is/a/deadbeef'},
+        });
+        var directive = createDirective(annotation);
+        assert.equal(findLink(directive).href, annotation.links.html);
+      });
+
+      it('displays in-context links when available', function () {
+        var annotation = Object.assign({}, fixtures.defaultAnnotation(), {
+          links: {
+            html: 'https://test.hypothes.is/a/deadbeef',
+            incontext: 'https://hpt.is/deadbeef'
+          },
+        });
+        var directive = createDirective(annotation);
+        assert.equal(findLink(directive).href, annotation.links.incontext);
       });
     });
   });

--- a/h/static/scripts/directive/test/annotation-test.js
+++ b/h/static/scripts/directive/test/annotation-test.js
@@ -1,20 +1,20 @@
 /* jshint node: true */
 'use strict';
 
+var angular = require('angular');
 var proxyquire = require('proxyquire');
 
 var events = require('../../events');
 var fixtures = require('../../test/annotation-fixtures');
 var util = require('./util');
 
-var module = angular.mock.module;
 var inject = angular.mock.inject;
 
 /**
  * Returns the annotation directive with helpers stubbed out.
  */
 function annotationDirective() {
-  var noop = function () { return '' };
+  var noop = function () { return ''; };
 
   var annotation = proxyquire('../annotation', {
     '../filter/document-domain': noop,
@@ -321,11 +321,9 @@ describe('annotation', function() {
         .directive('annotation', annotationDirective());
     });
 
-    beforeEach(module('h'));
-
-    beforeEach(module('h.templates'));
-
-    beforeEach(module(function($provide) {
+    beforeEach(angular.mock.module('h'));
+    beforeEach(angular.mock.module('h.templates'));
+    beforeEach(angular.mock.module(function($provide) {
       sandbox = sinon.sandbox.create();
 
       fakeAnnotationMapper = {
@@ -927,7 +925,7 @@ describe('annotation', function() {
 
         annotation.updated = null;
         annotation.$create = function () {
-          annotation.updated = (new Date).toString();
+          annotation.updated = (new Date()).toString();
           return Promise.resolve(annotation);
         };
         var controller = createDirective(annotation).controller;
@@ -952,9 +950,9 @@ describe('annotation', function() {
         clock.tick(10 * 60 * 1000);
 
         annotation.$update = function () {
-          this.updated = (new Date).toString();
+          this.updated = (new Date()).toString();
           return Promise.resolve(this);
-        }
+        };
         var controller = createDirective(annotation).controller;
         assert.equal(controller.relativeTimestamp, 'ages ago');
         controller.edit();
@@ -983,7 +981,7 @@ describe('annotation', function() {
       });
 
       it('is no longer updated after the scope is destroyed', function() {
-        var controller = createDirective(annotation).controller;
+        createDirective(annotation);
         $scope.$digest();
         $scope.$destroy();
         $timeout.flush();
@@ -1038,10 +1036,14 @@ describe('annotation', function() {
 
       it(
         'doesn\'t call annotationMapper.delete() if the delete is cancelled',
-        function() {
-          var controller = createDirective().controller;
+        function(done) {
+          var parts = createDirective();
           sandbox.stub($window, 'confirm').returns(false);
-          assert(fakeAnnotationMapper.deleteAnnotation.notCalled);
+          parts.controller['delete']().then(function() {
+            assert.notCalled(fakeAnnotationMapper.deleteAnnotation);
+            done();
+          });
+          $timeout.flush();
         }
       );
 
@@ -1194,7 +1196,7 @@ describe('annotation', function() {
         'Passes group:<id> to the server when saving a new annotation',
         function() {
           fakeGroups.focused = function () {
-            return { id: 'test-id' }
+            return { id: 'test-id' };
           };
           var annotation = {
             user: 'acct:fred@hypothes.is',

--- a/h/static/scripts/test/annotation-fixtures.js
+++ b/h/static/scripts/test/annotation-fixtures.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * Return a fake annotation with the basic properties filled in.
  */

--- a/h/templates/client/annotation.html
+++ b/h/templates/client/annotation.html
@@ -49,7 +49,7 @@
        target="_blank"
        title="{{vm.absoluteTimestamp}}"
        ng-if="!vm.editing() && vm.updated()"
-       ng-href="{{::vm.serviceUrl}}a/{{vm.id()}}"
+       ng-href="{{vm.annotationURI}}"
        >{{vm.relativeTimestamp}}</a>
   </header>
 


### PR DESCRIPTION
Add a feature flag for direct linking and generate
https://hpt.is/<ID> URLs for annotations in the feeds
and in the client when the feature flag is enabled.

Note that the second and third commits in this PR fix existing JSHint issues with annotation-test.js that are needed for the changes in the first commit to pass review.