### PR TITLE
Rename Document.uris relationship to `document_uris`

### DIFF
--- a/h/api/models/document.py
+++ b/h/api/models/document.py
@@ -20,7 +20,11 @@ class Document(Base, mixins.Timestamps):
 
     id = sa.Column(sa.Integer, autoincrement=True, primary_key=True)
 
-    uris = sa.orm.relationship('DocumentURI', backref='document')
+    # FIXME: This relationship should be named `uris` again after the
+    #        dependency on the annotator-store is removed, as it clashes with
+    #        making the Postgres and Elasticsearch interface of a Document
+    #        object behave the same way.
+    document_uris = sa.orm.relationship('DocumentURI', backref='document')
     meta = sa.orm.relationship('DocumentMeta', backref='document')
 
     def __repr__(self):
@@ -190,8 +194,8 @@ def merge_documents(session, documents, updated=datetime.now()):
     duplicates = documents[1:]
 
     for doc in duplicates:
-        for _ in range(len(doc.uris)):
-            u = doc.uris.pop()
+        for _ in range(len(doc.document_uris)):
+            u = doc.document_uris.pop()
             u.document = master
             u.updated = updated
 

--- a/h/api/models/elastic.py
+++ b/h/api/models/elastic.py
@@ -264,7 +264,7 @@ class Document(document.Document):
         return meta
 
     @property
-    def uris(self):
+    def document_uris(self):
         return [DocumentURI(link) for link in self._transform_links()]
 
     def _transform_meta(self, meta, data, path_prefix=[]):

--- a/h/api/models/test/annotation_test.py
+++ b/h/api/models/test/annotation_test.py
@@ -15,8 +15,8 @@ annotation_fixture = pytest.mark.usefixtures('annotation')
 
 @annotation_fixture
 def test_document(annotation):
-    document = Document(uris=[DocumentURI(claimant=annotation.target_uri,
-                                          uri=annotation.target_uri)])
+    document = Document(document_uris=[DocumentURI(claimant=annotation.target_uri,
+                                                   uri=annotation.target_uri)])
     db.Session.add(document)
     db.Session.flush()
 
@@ -25,8 +25,8 @@ def test_document(annotation):
 
 @annotation_fixture
 def test_document_not_found(annotation):
-    document = Document(uris=[DocumentURI(claimant='something-else',
-                                          uri='something-else')])
+    document = Document(document_uris=[DocumentURI(claimant='something-else',
+                                                   uri='something-else')])
     db.Session.add(document)
     db.Session.flush()
 

--- a/h/api/models/test/document_test.py
+++ b/h/api/models/test/document_test.py
@@ -40,13 +40,13 @@ def test_document_title_meta_not_found():
 def test_document_find_by_uris():
     document1 = Document()
     uri1 = 'https://de.wikipedia.org/wiki/Hauptseite'
-    document1.uris.append(DocumentURI(claimant=uri1, uri=uri1))
+    document1.document_uris.append(DocumentURI(claimant=uri1, uri=uri1))
 
     document2 = Document()
     uri2 = 'https://en.wikipedia.org/wiki/Main_Page'
-    document2.uris.append(DocumentURI(claimant=uri2, uri=uri2))
+    document2.document_uris.append(DocumentURI(claimant=uri2, uri=uri2))
     uri3 = 'https://en.wikipedia.org'
-    document2.uris.append(DocumentURI(claimant=uri3, uri=uri2))
+    document2.document_uris.append(DocumentURI(claimant=uri3, uri=uri2))
 
     db.Session.add_all([document1, document2])
     db.Session.flush()
@@ -60,7 +60,7 @@ def test_document_find_by_uris():
 
 def test_document_find_by_uris_no_matches():
     document = Document()
-    document.uris.append(DocumentURI(
+    document.document_uris.append(DocumentURI(
         claimant='https://en.wikipedia.org/wiki/Main_Page',
         uri='https://en.wikipedia.org/wiki/Main_Page'))
     db.Session.add(document)
@@ -111,9 +111,9 @@ def test_document_find_or_create_by_uris_no_results():
 
     actual = documents.first()
     assert isinstance(actual, Document)
-    assert len(actual.uris) == 1
+    assert len(actual.document_uris) == 1
 
-    docuri = actual.uris[0]
+    docuri = actual.document_uris[0]
     assert docuri.claimant == 'https://en.wikipedia.org/wiki/Pluto'
     assert docuri.uri == 'https://en.wikipedia.org/wiki/Pluto'
     assert docuri.type == 'self-claim'
@@ -147,8 +147,8 @@ def test_merge_documents_rewires_document_uris(merge_data):
     merge_documents(db.Session, merge_data)
     db.Session.flush()
 
-    assert len(master.uris) == 2
-    assert len(duplicate.uris) == 0
+    assert len(master.document_uris) == 2
+    assert len(duplicate.document_uris) == 0
 
 
 @merge_documents_fixtures
@@ -164,7 +164,7 @@ def test_merge_documents_rewires_document_meta(merge_data):
 
 @pytest.fixture
 def merge_data(request):
-    master = Document(uris=[DocumentURI(
+    master = Document(document_uris=[DocumentURI(
             claimant='https://en.wikipedia.org/wiki/Main_Page',
             uri='https://en.wikipedia.org/wiki/Main_Page',
             type='self-claim')],
@@ -172,7 +172,7 @@ def merge_data(request):
                 claimant='https://en.wikipedia.org/wiki/Main_Page',
                 type='title',
                 value='Wikipedia, the free encyclopedia')])
-    duplicate = Document(uris=[DocumentURI(
+    duplicate = Document(document_uris=[DocumentURI(
             claimant='https://m.en.wikipedia.org/wiki/Main_Page',
             uri='https://en.wikipedia.org/wiki/Main_Page',
             type='rel-canonical')],

--- a/h/api/models/test/elastic_test.py
+++ b/h/api/models/test/elastic_test.py
@@ -333,13 +333,13 @@ class TestDocument(object):
                                  'type': 'self-claim',
                                  'created': None, 'updated': None})]
 
-        assert doc.uris == expected
+        assert doc.document_uris == expected
 
     def test_uris_disregard_doi_links(self):
         doc = Document({'link': [{'href': 'doi:foobar'}]})
         # it always includes a self-claim, not removing doi links would result
         # in a length of 2
-        assert len(doc.uris) == 1
+        assert len(doc.document_uris) == 1
 
     def test_uris_str_link(self):
         doc = Document({'link': 'http://example.com'},
@@ -353,7 +353,7 @@ class TestDocument(object):
                                  'created': datetime.datetime(2016, 2, 25, 16, 45, 23, 371848),
                                  'updated': datetime.datetime(2016, 2, 25, 16, 45, 23, 371849)})]
 
-        assert doc.uris == expected
+        assert doc.document_uris == expected
 
     def test_uris_recognize_highwire_pdf(self):
         doc = Document({'link': [{'href': 'pdf-uri', 'type': 'application/pdf'}]},
@@ -370,7 +370,7 @@ class TestDocument(object):
                                  'type': 'self-claim',
                                  'created': None, 'updated': None})]
 
-        assert sorted(doc.uris) == sorted(expected)
+        assert sorted(doc.document_uris) == sorted(expected)
 
     def test_uris_prefix_type_when_rel(self):
         doc = Document({'link': [{'href': 'https://example.com', 'rel': 'canonical'}]},
@@ -387,7 +387,7 @@ class TestDocument(object):
                                  'type': 'self-claim',
                                  'created': None, 'updated': None})]
 
-        assert sorted(doc.uris) == sorted(expected)
+        assert sorted(doc.document_uris) == sorted(expected)
 
     @pytest.mark.parametrize('doc', [
         Document({'highwire': {'doi': ['foobar']}}, claimant='http://example.com'),
@@ -403,7 +403,7 @@ class TestDocument(object):
                                  'type': 'self-claim',
                                  'created': None, 'updated': None})]
 
-        assert sorted(doc.uris) == sorted(expected)
+        assert sorted(doc.document_uris) == sorted(expected)
 
     @pytest.mark.parametrize('doc', [
         Document({'dc': {'identifier': ['foobar']}}, claimant='http://example.com'),
@@ -419,7 +419,7 @@ class TestDocument(object):
                                  'type': 'self-claim',
                                  'created': None, 'updated': None})]
 
-        assert sorted(doc.uris) == sorted(expected)
+        assert sorted(doc.document_uris) == sorted(expected)
 
 
 class TestDocumentMeta(object):

--- a/h/api/presenters.py
+++ b/h/api/presenters.py
@@ -84,7 +84,7 @@ class DocumentJSONPresenter(object):
             deep_merge_dict(d, meta_presenter.asdict())
 
         d['link'] = []
-        for docuri in self.document.uris:
+        for docuri in self.document.document_uris:
             uri_presenter = DocumentURIJSONPresenter(docuri)
             d['link'].append(uri_presenter.asdict())
 

--- a/h/api/test/presenters_test.py
+++ b/h/api/test/presenters_test.py
@@ -106,8 +106,8 @@ class TestAnnotationJSONPresenter(object):
 
 class TestDocumentJSONPresenter(object):
     def test_asdict(self):
-        document = mock.Mock(uris=[mock.Mock(uri='http://foo.com', type=None, content_type=None),
-                                   mock.Mock(uri='http://foo.org', type='rel-canonical', content_type=None)],
+        document = mock.Mock(document_uris=[mock.Mock(uri='http://foo.com', type=None, content_type=None),
+                                            mock.Mock(uri='http://foo.org', type='rel-canonical', content_type=None)],
                              meta=[mock.Mock(type='twitter.url.main_url', value='http://foo.org'),
                                    mock.Mock(type='twitter.title', value='Foo')])
         presenter = DocumentJSONPresenter(document)

--- a/scripts/migrate.py
+++ b/scripts/migrate.py
@@ -213,7 +213,7 @@ def create_or_update_document_objects(es_ann):
     if not es_doc:
         return
 
-    uris = [u.uri for u in es_doc.uris]
+    uris = [u.uri for u in es_doc.document_uris]
     documents = Document.find_or_create_by_uris(Session, es_ann.target_uri, uris,
                                                 created=es_doc.created,
                                                 updated=es_doc.updated)
@@ -225,7 +225,7 @@ def create_or_update_document_objects(es_ann):
 
     document.updated = es_doc.updated
 
-    for uri_ in es_doc.uris:
+    for uri_ in es_doc.document_uris:
         create_or_update_document_uri(uri_, document)
 
     for meta in es_doc.meta:


### PR DESCRIPTION
To not clash with the annotator-store Document.uris method. This can and
should be reverted as soon as annotator-store is no longer a dependency
anymore.

See: https://app.getsentry.com/hypothesis/stage/issues/114915027/