### PR TITLE
Normalize elastic.DocumentMeta og types

### DIFF
--- a/h/api/models/elastic.py
+++ b/h/api/models/elastic.py
@@ -386,6 +386,7 @@ class DocumentMeta(dict):
         if value:
             value = value.lower().replace(':', '.')
             value = re.sub(r'\.{2,}', '.', value)
+            value = re.sub(r'^og\.', 'facebook.', value)
 
         return value
 

--- a/h/api/models/test/elastic_test.py
+++ b/h/api/models/test/elastic_test.py
@@ -455,6 +455,15 @@ class TestDocumentMeta(object):
         meta = DocumentMeta({'type': 'facebook.book:isbn'})
         assert meta.type == 'facebook.book.isbn'
 
+    def test_type_normalizes_og(self):
+        meta = DocumentMeta({'type': 'og.title'})
+        assert meta.type == 'facebook.title'
+
+    @pytest.mark.parametrize('type', ['oga.title', 'dc.og.title'])
+    def test_type_skips_og_normalisation(self, type):
+        meta = DocumentMeta({'type': type})
+        assert meta.type == type
+
     def test_value(self):
         meta = DocumentMeta({'value': 'Example Page'})
         assert meta.value == 'Example Page'


### PR DESCRIPTION
The annotator switched the naming of Facebook meta tags from "og" to
"facebook" mid 2013. This will normalise them and always return the
current "facebook" type.

The above-mentioned commit in the client can be found [here](https://github.com/openannotation/annotator/commit/61c385da0e3ba1598ced82175c0689768b84d688).