### PR TITLE
Fix JS error checking via Hound

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -4,7 +4,7 @@ javascript:
   config_file: .jshintrc
   ignore_file: .jshintignore
 jscs:
-  enabled: true
+  enabled: false
   config_file: .jscsrc
 ruby:
   enabled: false

--- a/.jscsrc
+++ b/.jscsrc
@@ -11,7 +11,6 @@
     "h/static/styles/vendor/**",
     "node_modules/**"
   ],
-  "maxErrors": 10,
   "disallowSpacesInAnonymousFunctionExpression": null,
   "disallowSpacesInFunctionDeclaration": {
     "beforeOpeningRoundBrace": true

--- a/.jshintrc
+++ b/.jshintrc
@@ -9,7 +9,6 @@
   "strict": "global",
   "undef": true,
   "unused": true,
-  "esversion": 6,
   "esnext": true,
   "globals": {
     "chrome": false,


### PR DESCRIPTION
JS error checking via Hound has been failing to complete since JSCS was enabled. Following an email to ThoughtBot's support, I'm following their advice and disabling it.

There are a couple of other changes in this PR:

- Remove the "maxErrors" option from the JSCS config. This enables the "-x" option to be used to autofix many errors, which is especially useful when converting files from CoffeeScript to JS.
- Remove the "esversion" option from the JSHint config. "esversion" is a replacement for the legacy "esnext" option. The reason for using only the legacy option is because it is compatible with both the current stable version of JSHint (v2.9.x) and the older version (v2.8.x) which Hound is currently using. Current stable versions of JSHint do not allow both.