### PR TITLE
Travis Sentry sourcemaps

### DIFF
--- a/.travis/install
+++ b/.travis/install
@@ -9,5 +9,7 @@ case "$ACTION" in
     extensions)
         pip install --use-wheel -e .
         npm install
+        # trick the Makefile into skipping npm install
+        touch node_modules/.uptodate
         ;;
 esac

--- a/.travis/script
+++ b/.travis/script
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+: ${TRAVIS_TAG:=}
+
 set -eu
 
 case "$ACTION" in
@@ -10,6 +12,10 @@ case "$ACTION" in
         gulp "$GULPTASK"
         ;;
     extensions)
+        if [ -n "$TRAVIS_TAG" ]; then
+            export SENTRY_RELEASE_VERSION=$(echo "$TRAVIS_TAG" | cut -dv -f2-)
+            gulp build upload-sourcemaps
+        fi
         make extensions
         ;;
 esac

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ test: node_modules/.uptodate
 extensions: build/$(ISODATE)-$(BUILD_ID)-chrome-stage.zip
 extensions: build/$(ISODATE)-$(BUILD_ID)-chrome-prod.zip
 
-build/%-chrome-stage.zip:
+build/%-chrome-stage.zip: build/manifest.json
 	@rm -rf build/chrome $@
 	hypothesis-buildext chrome \
 		--service 'https://stage.hypothes.is' \
@@ -67,7 +67,7 @@ build/%-chrome-stage.zip:
 		--bouncer 'https://hpt.is'
 	@zip -qr $@ build/chrome
 
-build/%-chrome-prod.zip:
+build/%-chrome-prod.zip: build/manifest.json
 	@rm -rf build/chrome $@
 	hypothesis-buildext chrome \
 		--service 'https://hypothes.is' \

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -254,7 +254,9 @@ gulp.task('test-watch-extension', function (callback) {
   }, callback).start();
 });
 
-gulp.task('upload-sourcemaps', function () {
+gulp.task('upload-sourcemaps',
+          ['build-app-js',
+           'build-extension-js'], function () {
   var uploadToSentry = require('./scripts/gulp/upload-to-sentry');
   gulp.src(['build/scripts/*.js', 'build/scripts/*.map'])
     .pipe(uploadToSentry({

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -258,11 +258,14 @@ gulp.task('upload-sourcemaps',
           ['build-app-js',
            'build-extension-js'], function () {
   var uploadToSentry = require('./scripts/gulp/upload-to-sentry');
-  gulp.src(['build/scripts/*.js', 'build/scripts/*.map'])
-    .pipe(uploadToSentry({
-      apiKey: getEnv('SENTRY_API_KEY'),
-      release: getEnv('SENTRY_RELEASE_VERSION'),
-      organization: getEnv('SENTRY_ORGANIZATION'),
-      project: getEnv('SENTRY_PROJECT'),
-    }));
+
+  var opts = {
+    key: getEnv('SENTRY_API_KEY'),
+    organization: getEnv('SENTRY_ORGANIZATION'),
+  };
+  var projects = getEnv('SENTRY_PROJECTS').split(',');
+  var release = getEnv('SENTRY_RELEASE_VERSION');
+
+  return gulp.src(['build/scripts/*.js', 'build/scripts/*.map'])
+    .pipe(uploadToSentry(opts, projects, release));
 });

--- a/scripts/gulp/upload-to-sentry.js
+++ b/scripts/gulp/upload-to-sentry.js
@@ -6,7 +6,7 @@ var gulpUtil = require('gulp-util');
 var request = require('request');
 var through = require('through2');
 
-var SENTRY_API_ROOT = 'https://app.getsentry.com/api/0'
+var SENTRY_API_ROOT = 'https://app.getsentry.com/api/0';
 
 /**
  * interface SentryOptions {
@@ -119,7 +119,7 @@ module.exports = function uploadToSentry(opts, projects, release) {
     })
     .catch(function (err) {
       gulpUtil.log('Sentry upload failed: ', err);
-      throw err;
+      callback(err);
     });
   });
 };


### PR DESCRIPTION
This PR changes the `buildext` command so that it doesn't shell out to gulp itself. Instead, it assumes that prebuilt assets are available in build, and prints an error suggesting the user run `gulp build` if it can't find a file it expects to exist. I've verified that the resulting extension is byte-for-byte identical before and after this change.

This makes it possible to run `gulp build` just once, and then build multiple extensions from the built assets, and subsequent commits set that up for Travis tag builds.