### PR TITLE
Sheetaluk/280 when a user replies focus on and expand that reply

### DIFF
--- a/h/static/scripts/directive/annotation.js
+++ b/h/static/scripts/directive/annotation.js
@@ -734,6 +734,12 @@ function link(scope, elem, attrs, controllers) {
         if (threadFilter) {
           threadFilter.freeze(false);
         }
+
+        // Ensure that the just-edited annotation remains visible.
+        if (thread.parent) {
+          thread.parent.toggleCollapsed(false);
+        }
+
       }
     });
 

--- a/h/static/scripts/directive/test/annotation-test.js
+++ b/h/static/scripts/directive/test/annotation-test.js
@@ -153,7 +153,10 @@ describe('annotation', function() {
       };
       mockThreadController = {
         collapsed: true,
-        toggleCollapsed: sinon.stub()
+        toggleCollapsed: sinon.stub(),
+        parent: {
+          toggleCollapsed: sinon.stub()
+        }
       };
       mockThreadFilterController = {
         active: sinon.stub(),
@@ -263,6 +266,18 @@ describe('annotation', function() {
         true,
         mockThreadFilterController.freeze.lastCall.calledWithExactly(false));
     });
+
+    it('does not collapse parent thread after edit', function() {
+      mockAnnotationController.editing.returns(true);
+      link(scope, mockElement, mockAttributes, mockControllers);
+      scope.$digest();
+
+      mockAnnotationController.editing.returns(false);
+      scope.$digest();
+
+      assert.calledWith(mockThreadController.parent.toggleCollapsed, false);
+    });
+
   });
 
   describe('AnnotationController', function() {


### PR DESCRIPTION
calling toggleCollapsed against the parent of the thread to show the replies container after a user publishes a reply to an annotation.