### PR TITLE
Fix the permissions key when rendering annotations

### DIFF
--- a/h/api/presenters.py
+++ b/h/api/presenters.py
@@ -22,7 +22,7 @@ class AnnotationJSONPresenter(object):
             'text': self.annotation.text,
             'tags': self.tags,
             'group': self.annotation.groupid,
-            'permission': self.permission,
+            'permissions': self.permissions,
             'target': self.target,
             'document': docpresenter.asdict(),
         }
@@ -53,7 +53,7 @@ class AnnotationJSONPresenter(object):
             return []
 
     @property
-    def permission(self):
+    def permissions(self):
         read = self.annotation.userid
         if self.annotation.shared:
             read = 'group:{}'.format(self.annotation.groupid)

--- a/h/api/test/presenters_test.py
+++ b/h/api/test/presenters_test.py
@@ -36,7 +36,7 @@ class TestAnnotationJSONPresenter(object):
                     'text': 'It is magical!',
                     'tags': ['magic'],
                     'group': '__world__',
-                    'permission': {'read': ['group:__world__'],
+                    'permissions': {'read': ['group:__world__'],
                                    'admin': ['acct:luke'],
                                    'update': ['acct:luke'],
                                    'delete': ['acct:luke']},
@@ -75,9 +75,9 @@ class TestAnnotationJSONPresenter(object):
         (mock.Mock(userid='acct:luke'), 'update', ['acct:luke']),
         (mock.Mock(userid='acct:luke'), 'delete', ['acct:luke']),
         ])
-    def test_permission(self, annotation, action, expected):
+    def test_permissions(self, annotation, action, expected):
         presenter = AnnotationJSONPresenter(annotation)
-        assert expected == presenter.permission[action]
+        assert expected == presenter.permissions[action]
 
     def test_target(self):
         ann = mock.Mock(target_uri='http://example.com',


### PR DESCRIPTION
It used to be `permissions` (plural), the new API presenter rendered it as `permission` singular.

Fixes #3058, which showed the edit/delete button for other users' annotations, but that was a rendering bug only, it wouldn't allow anybody to delete other users' annotations.