### PR TITLE
Leave out default target selector from presented annotation

### DIFF
--- a/h/api/presenters.py
+++ b/h/api/presenters.py
@@ -65,8 +65,11 @@ class AnnotationJSONPresenter(object):
 
     @property
     def target(self):
-        return [{'source': self.annotation.target_uri,
-                 'selector': self.annotation.target_selectors or []}]
+        target = {'source': self.annotation.target_uri}
+        if self.annotation.target_selectors:
+            target['selector'] = self.annotation.target_selectors
+
+        return [target]
 
 
 class DocumentJSONPresenter(object):

--- a/h/api/test/presenters_test.py
+++ b/h/api/test/presenters_test.py
@@ -91,7 +91,7 @@ class TestAnnotationJSONPresenter(object):
         ann = mock.Mock(target_uri='http://example.com',
                         target_selectors=None)
 
-        expected = [{'source': 'http://example.com', 'selector': []}]
+        expected = [{'source': 'http://example.com'}]
         actual = AnnotationJSONPresenter(ann).target
         assert expected == actual
 


### PR DESCRIPTION
An empty list of target selectors will result in the client trying to
anchor the annotation, which will fail, so these orphaned annotations
will not be visible.
Page notes are a good example of annotations that don't have selectors
by design, but should not be filtered out.

Fixes #3060