### PR TITLE
Fix installation of URL polyfill with js-polyfills v0.1.16

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,12 @@
 Unreleased
 ==========
 
+Bug Fixes
+---------
+
+- Fix compatibility with IE 10, 11.0 and early versions
+  of Microsoft Edge (#3064)
+
 0.10.0 (2016-03-07)
 ===================
 

--- a/h/static/scripts/polyfills.js
+++ b/h/static/scripts/polyfills.js
@@ -9,7 +9,7 @@ require('core-js/fn/object/assign');
 try {
   new window.URL('https://hypothes.is');
 } catch (err) {
-  window.URL = require('js-polyfills/url').URL;
+  require('js-polyfills/url');
 }
 
 // document.evaluate() implementation,

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "inherits": "^2.0.1",
     "is-equal-shallow": "^0.1.3",
     "jquery": "1.11.1",
-    "js-polyfills": "^0.1.11",
+    "js-polyfills": "^0.1.16",
     "mkdirp": "^0.5.1",
     "ng-tags-input": "2.2.0",
     "node-uuid": "^1.4.3",


### PR DESCRIPTION
js-polyfills v0.1.16 was recently published with a change in how the polyfill is installed.
This version of the lib was picked up by the recent v0.10.0 release.

js-polyfills v0.1.15 used to install the polyfill on
`this.URL`, where `this` was set to module.exports in
the context of a Browserify bundle. Consequently the result
was available as `require('js-polyfills/url').URL`.

As of v0.1.16 however, it installs the polyfill on `self`,
which is the Window object in the context of the browser
and so `require('js-polyfills/url').URL` is undefined.

Fixes #3064 