### PR TITLE
Fix confirmation of user deletion in admin panel

### DIFF
--- a/h/templates/layouts/admin.html.jinja2
+++ b/h/templates/layouts/admin.html.jinja2
@@ -68,5 +68,6 @@
     {% for url in asset_urls("admin_js") %}
     <script src="{{ url }}"></script>
     {% endfor %}
+    {% block scripts %}{% endblock %}
   </body>
 </html>


### PR DESCRIPTION
83c4f48 broke this by removing the "scripts" block from the admin layout.