### PR TITLE
Configure gunicorn statsd

### DIFF
--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -1,14 +1,21 @@
 # -*- coding: utf-8 -*-
 import os
-from h._compat import urlparse
 
 # Smart detect heroku stack and assume a trusted proxy.
 # This is a convenience that should hopefully not be too surprising.
 if 'heroku' in os.environ.get('LD_LIBRARY_PATH', ''):
     forwarded_allow_ips = '*'
 
-if 'STATSD_PORT' in os.environ:
-    statsd_host = urlparse.urlparse(os.environ['STATSD_PORT_8125_UDP']).netloc
+if 'STATSD_PORT_8125_UDP_ADDR' in os.environ and \
+   'STATSD_PORT_8125_UDP_PORT' in os.environ:
+        _host = os.environ['STATSD_PORT_8125_UDP_ADDR']
+        _port = os.environ['STATSD_PORT_8125_UDP_PORT']
+        statsd_host = '{}:{}'.format(_host, _port)
+
+elif 'STATSD_HOST' in os.environ:
+    _host = os.environ['STATSD_HOST']
+    _port = os.environ.get('STATSD_PORT', '8125')
+    statsd_host = '{}:{}'.format(_host, _port)
 
 
 def post_fork(server, worker):

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -6,16 +6,17 @@ import os
 if 'heroku' in os.environ.get('LD_LIBRARY_PATH', ''):
     forwarded_allow_ips = '*'
 
-if 'STATSD_PORT_8125_UDP_ADDR' in os.environ and \
-   'STATSD_PORT_8125_UDP_PORT' in os.environ:
-        _host = os.environ['STATSD_PORT_8125_UDP_ADDR']
-        _port = os.environ['STATSD_PORT_8125_UDP_PORT']
-        statsd_host = '{}:{}'.format(_host, _port)
+if not os.environ.get('GUNICORN_STATS_DISABLE', None):
+    if 'STATSD_PORT_8125_UDP_ADDR' in os.environ and \
+       'STATSD_PORT_8125_UDP_PORT' in os.environ:
+            _host = os.environ['STATSD_PORT_8125_UDP_ADDR']
+            _port = os.environ['STATSD_PORT_8125_UDP_PORT']
+            statsd_host = '{}:{}'.format(_host, _port)
 
-elif 'STATSD_HOST' in os.environ:
-    _host = os.environ['STATSD_HOST']
-    _port = os.environ.get('STATSD_PORT', '8125')
-    statsd_host = '{}:{}'.format(_host, _port)
+    elif 'STATSD_HOST' in os.environ:
+        _host = os.environ['STATSD_HOST']
+        _port = os.environ.get('STATSD_PORT', '8125')
+        statsd_host = '{}:{}'.format(_host, _port)
 
 
 def post_fork(server, worker):

--- a/h/config.py
+++ b/h/config.py
@@ -13,6 +13,7 @@ from pyramid.settings import asbool
 from h.security import derive_key
 from h.settings import DockerSetting
 from h.settings import EnvSetting
+from h.settings import SettingError
 from h.settings import database_url
 from h.settings import mandrill_settings
 
@@ -91,7 +92,11 @@ def configure(environ=None, settings=None):
         settings = {}
 
     for s in SETTINGS:
-        result = s(environ)
+        try:
+            result = s(environ)
+        except SettingError as e:
+            log.warn(e)
+
         if result is not None:
             settings.update(result)
 


### PR DESCRIPTION
We were configuring the gunicorn statsd host/port the wrong way.

This fixes that, plus makes sure that we don't error when an environment variable setting is of the wrong type, but we emit a warning and then ignore its value.