### PR TITLE
CSP should default to disabled, for now

### DIFF
--- a/h/config.py
+++ b/h/config.py
@@ -67,6 +67,9 @@ SETTINGS = [
     EnvSetting('secret_key', 'SECRET_KEY', type=bytes),
 
     # Configuration for h
+    EnvSetting('csp.enabled', 'CSP_ENABLED', type=asbool),
+    EnvSetting('csp.report_uri', 'CSP_REPORT_URI'),
+    EnvSetting('csp.report_only', 'CSP_REPORT_ONLY'),
     EnvSetting('ga_tracking_id', 'GOOGLE_ANALYTICS_TRACKING_ID'),
     EnvSetting('h.auth_domain', 'AUTH_DOMAIN'),
     EnvSetting('h.client_id', 'CLIENT_ID'),
@@ -74,10 +77,6 @@ SETTINGS = [
     EnvSetting('h.db.should_create_all', 'MODEL_CREATE_ALL', type=asbool),
     EnvSetting('h.db.should_drop_all', 'MODEL_DROP_ALL', type=asbool),
     EnvSetting('h.websocket_url', 'H_WEBSOCKET_URL'),
-
-    # Content Security Policy configuration
-    EnvSetting('csp.report_uri', 'CSP_REPORT_URI'),
-    EnvSetting('csp.report_only', 'CSP_REPORT_ONLY'),
 
     # Debug/development settings
     EnvSetting('debug_query', 'DEBUG_QUERY'),

--- a/h/test/tweens_test.py
+++ b/h/test/tweens_test.py
@@ -1,11 +1,23 @@
 # -*- coding: utf-8 -*-
 
+import mock
 from pyramid.testing import DummyRequest
+
 from h import tweens
+
+
+def test_tween_csp_noop_by_default():
+    request = DummyRequest()
+    handler = mock.sentinel.HANDLER
+    result = tweens.content_security_policy_tween_factory(handler,
+                                                          request.registry)
+
+    assert result == handler
 
 
 def test_tween_csp_default_headers():
     request = DummyRequest()
+    request.registry.settings['csp.enabled'] = True
     tween = tweens.content_security_policy_tween_factory(
         lambda req: req.response,
         request.registry)
@@ -18,7 +30,10 @@ def test_tween_csp_default_headers():
 
 def test_tween_csp_report_only_headers():
     request = DummyRequest()
-    request.registry.settings = {'csp.report_only': True}
+    request.registry.settings.update({
+        'csp.enabled': True,
+        'csp.report_only': True,
+    })
     tween = tweens.content_security_policy_tween_factory(
         lambda req: req.response,
         request.registry)
@@ -31,7 +46,10 @@ def test_tween_csp_report_only_headers():
 
 def test_tween_csp_uri():
     request = DummyRequest()
-    request.registry.settings = {'csp': {'report-uri': ['localhost']}}
+    request.registry.settings.update({
+        'csp.enabled': True,
+        'csp': {'report-uri': ['localhost']},
+    })
     tween = tweens.content_security_policy_tween_factory(
         lambda req: req.response,
         request.registry)
@@ -44,14 +62,15 @@ def test_tween_csp_uri():
 
 def test_tween_csp_header():
     request = DummyRequest()
-    request.registry.settings = {
+    request.registry.settings.update({
+        "csp.enabled": True,
         "csp": {
             "font-src": ["'self'", "fonts.gstatic.com"],
             "report-uri": ['localhost'],
             "script-src": ["'self'"],
             "style-src": ["'self'", "fonts.googleapis.com"],
         },
-    }
+    })
     tween = tweens.content_security_policy_tween_factory(
         lambda req: req.response,
         request.registry)

--- a/h/tweens.py
+++ b/h/tweens.py
@@ -75,6 +75,9 @@ def csrf_tween_factory(handler, registry):
 
 
 def content_security_policy_tween_factory(handler, registry):
+    if not registry.settings.get('csp.enabled', False):
+        return handler
+
     policy = registry.settings.get('csp', {})
     policy = "; ".join([
         " ".join([k] + [v2 for v2 in v if v2 is not None])


### PR DESCRIPTION
We may eventually choose to enable CSP headers by default. For now they should definitely default to disabled.