### PR TITLE
Render annotation text as empty string when missing

### DIFF
--- a/h/api/presenters.py
+++ b/h/api/presenters.py
@@ -46,6 +46,13 @@ class AnnotationJSONPresenter(object):
             return utc_iso8601(self.annotation.updated)
 
     @property
+    def text(self):
+        if self.annotation.text:
+            return self.annotation.text
+        else:
+            return ''
+
+    @property
     def tags(self):
         if self.annotation.tags:
             return self.annotation.tags

--- a/h/api/test/presenters_test.py
+++ b/h/api/test/presenters_test.py
@@ -55,6 +55,18 @@ class TestAnnotationJSONPresenter(object):
         presented = AnnotationJSONPresenter(ann).asdict()
         assert presented['id'] == 'the-real-id'
 
+    def test_text(self):
+        ann = mock.Mock(text='It is magical!')
+        presenter = AnnotationJSONPresenter(ann)
+
+        assert 'It is magical!' == presenter.text
+
+    def test_text_missing(self):
+        ann = mock.Mock(text=None)
+        presenter = AnnotationJSONPresenter(ann)
+
+        assert '' == presenter.text
+
     def test_tags(self):
         ann = mock.Mock(tags=['interesting', 'magic'])
         presenter = AnnotationJSONPresenter(ann)


### PR DESCRIPTION
As mentioned on #3060 in addition to the fix that made the page notes appear again (#3063)