### PR TITLE
Write annotations to postgres

### DIFF
--- a/h/api/models/__init__.py
+++ b/h/api/models/__init__.py
@@ -13,9 +13,13 @@ functions in `h.api.storage`.
 
 from h.api.models.annotation import Annotation
 from h.api.models.document import Document, DocumentMeta, DocumentURI
+from h.api.models.document import create_or_update_document_meta
+from h.api.models.document import create_or_update_document_uri
 
 __all__ = (
     'Annotation',
+    'create_or_update_document_meta',
+    'create_or_update_document_uri',
     'Document',
     'DocumentMeta',
     'DocumentURI',

--- a/h/api/models/__init__.py
+++ b/h/api/models/__init__.py
@@ -12,9 +12,11 @@ functions in `h.api.storage`.
 """
 
 from h.api.models.annotation import Annotation
-from h.api.models.document import Document, DocumentMeta, DocumentURI
 from h.api.models.document import create_or_update_document_meta
 from h.api.models.document import create_or_update_document_uri
+from h.api.models.document import Document
+from h.api.models.document import DocumentMeta
+from h.api.models.document import DocumentURI
 
 __all__ = (
     'Annotation',

--- a/h/api/models/__init__.py
+++ b/h/api/models/__init__.py
@@ -11,6 +11,7 @@ direct to the submodules of this package, but rather through the helper
 functions in `h.api.storage`.
 """
 
+from h.api.models import elastic
 from h.api.models.annotation import Annotation
 from h.api.models.document import create_or_update_document_meta
 from h.api.models.document import create_or_update_document_uri
@@ -25,4 +26,6 @@ __all__ = (
     'Document',
     'DocumentMeta',
     'DocumentURI',
+    'elastic',
+    'merge_documents',
 )

--- a/h/api/models/__init__.py
+++ b/h/api/models/__init__.py
@@ -18,6 +18,8 @@ from h.api.models.document import create_or_update_document_uri
 from h.api.models.document import Document
 from h.api.models.document import DocumentMeta
 from h.api.models.document import DocumentURI
+from h.api.models.document import merge_documents
+
 
 __all__ = (
     'Annotation',

--- a/h/api/models/annotation.py
+++ b/h/api/models/annotation.py
@@ -104,6 +104,13 @@ class Annotation(Base, mixins.Timestamps):
         if self.documents:
             return self.documents[0]
 
+    @property
+    def is_reply(self):
+        if self.references:
+            return True
+        else:
+            return False
+
     def __acl__(self):
         """Return a Pyramid ACL for this annotation."""
         acl = []

--- a/h/api/models/elastic.py
+++ b/h/api/models/elastic.py
@@ -145,6 +145,13 @@ class Annotation(annotation.Annotation):
         return [r for r in references if len(r) in [20, 22]]
 
     @property
+    def is_reply(self):
+        if self.references:
+            return True
+        else:
+            return False
+
+    @property
     def target_selectors(self):
         targets = self.get('target', [])
         if targets and isinstance(targets[0], dict):

--- a/h/api/models/test/annotation_test.py
+++ b/h/api/models/test/annotation_test.py
@@ -33,6 +33,25 @@ def test_document_not_found(annotation):
     assert annotation.document is None
 
 
+@annotation_fixture
+def test_is_reply_when_the_annotation_is_a_reply(annotation):
+    """If self.references is non-empty it should return True."""
+    # A non-empty references list means the annotation is a reply.
+    annotation.references = ["grandparent_annotation_id",
+                             "parent_annotation_id"]
+
+    assert annotation.is_reply is True
+
+
+@annotation_fixture
+def test_is_reply_when_the_annotation_is_not_a_reply(annotation):
+    """If self.references is non-empty it should return True."""
+    # An empty references list means the annotation is not a reply.
+    annotation.references = []
+
+    assert annotation.is_reply is False
+
+
 def test_acl_private():
     ann = Annotation(shared=False, userid='saoirse')
     actual = ann.__acl__()

--- a/h/api/models/test/document_test.py
+++ b/h/api/models/test/document_test.py
@@ -1,10 +1,13 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import unicode_literals
+import datetime
 
+import mock
 import pytest
 
 from h import db
+from h.api.models import document
 from h.api.models.document import Document, DocumentURI, DocumentMeta
 from h.api.models.document import merge_documents
 
@@ -119,6 +122,416 @@ def test_document_find_or_create_by_uris_no_results():
     assert docuri.type == 'self-claim'
 
 
+create_or_update_document_uri_fixtures = pytest.mark.usefixtures(
+    'DocumentURI',
+    'log',
+)
+
+
+def mock_docuri_dict(uri=None):
+    """Return a mock docuri_dict for create_or_update_document_uri()."""
+    if uri is None:
+        uri = 'http://example.com/example_uri.html'
+
+    now = datetime.datetime.now()
+
+    return {
+        'type': 'self-claim',
+        'claimant': 'http://example.com/example_claimant.html',
+        'uri': uri,
+        'created': now,
+        'updated': now
+    }
+
+
+def mock_document():
+    """Return a mock Document object for create_or_update_document_uri()."""
+    class Document:
+        @property
+        def id(self):
+            pass
+        @property
+        def created(self):
+            pass
+        @property
+        def updated(self):
+            pass
+    return mock.Mock(spec=Document)
+
+
+def mock_db():
+    """Return a mock db session object."""
+    class DB:
+        def add(self, obj):
+            pass
+    return mock.Mock(spec=DB())
+
+
+@create_or_update_document_uri_fixtures
+def test_create_or_update_document_uri_calls_filter(DocumentURI):
+    document.create_or_update_document_uri(
+        db=mock_db(),
+        claimant='http://example.com/example_claimant.html',
+        uri='http://example.com/example_uri.html',
+        type='self-claim',
+        content_type=None,
+        document=mock_document(),
+        created=datetime.datetime.now(),
+        updated=datetime.datetime.now())
+
+    # FIXME: We need to assert that this is called with the right arguments,
+    # but that's very awkward to do with the way sqlalchemy querying works.'
+    # Move this functionality onto the model class itself where the tests can
+    # use the actual database.
+    assert DocumentURI.query.filter.call_count == 1
+
+
+@create_or_update_document_uri_fixtures
+def test_create_or_update_document_uri_calls_first(DocumentURI):
+    document.create_or_update_document_uri(
+        db=mock_db(),
+        claimant='http://example.com/example_claimant.html',
+        uri='http://example.com/example_uri.html',
+        type='self-claim',
+        content_type=None,
+        document=mock_document(),
+        created=datetime.datetime.now(),
+        updated=datetime.datetime.now())
+
+    DocumentURI.query.filter.return_value.first.assert_called_once_with()
+
+
+@create_or_update_document_uri_fixtures
+def test_create_or_update_document_uri_inits_DocumentURI(DocumentURI):
+    """If there's no matching object in the db it should init a new one."""
+    DocumentURI.query.filter.return_value.first.return_value = None
+    claimant = 'http://example.com/example_claimant.html'
+    uri = 'http://example.com/example_uri.html'
+    type_ = 'self-claim'
+    content_type = 'text/html'
+    document_ = mock_document()
+    created = datetime.datetime.now() - datetime.timedelta(days=1)
+    updated = datetime.datetime.now()
+
+    document.create_or_update_document_uri(
+        db=mock_db(),
+        claimant=claimant,
+        uri=uri,
+        type=type_,
+        content_type=content_type,
+        document=document_,
+        created=created,
+        updated=updated)
+
+    DocumentURI.assert_called_once_with(
+        claimant=claimant,
+        uri=uri,
+        type=type_,
+        content_type=content_type,
+        document=document_,
+        created=created,
+        updated=updated)
+
+
+@create_or_update_document_uri_fixtures
+def test_create_or_update_document_uri_inits_DocumentURI_when_no_content_type(
+        DocumentURI):
+    """It shouldn't crash if docuri_dict contains no content_type."""
+    DocumentURI.query.filter.return_value.first.return_value = None
+    claimant = 'http://example.com/example_claimant.html'
+    uri = 'http://example.com/example_uri.html'
+    type_ = 'self-claim'
+    content_type = None
+    document_ = mock_document()
+    created = datetime.datetime.now() - datetime.timedelta(days=1)
+    updated = datetime.datetime.now()
+
+    document.create_or_update_document_uri(
+        db=mock_db(),
+        claimant=claimant,
+        uri=uri,
+        type=type_,
+        content_type=content_type,
+        document=document_,
+        created=created,
+        updated=updated)
+
+    DocumentURI.assert_called_once_with(
+        claimant=claimant,
+        uri=uri,
+        type=type_,
+        content_type=content_type,
+        document=document_,
+        created=created,
+        updated=updated)
+
+
+@create_or_update_document_uri_fixtures
+def test_create_or_update_document_uri_adds_DocumentURI_to_db(DocumentURI):
+    DocumentURI.query.filter.return_value.first.return_value = None
+    db = mock_db()
+
+    document.create_or_update_document_uri(
+        db=db,
+        claimant='http://example.com/example_claimant.html',
+        uri='http://example.com/example_uri.html',
+        type='self-claim',
+        content_type=None,
+        document=mock_document(),
+        created=datetime.datetime.now(),
+        updated=datetime.datetime.now())
+
+    db.add.assert_called_once_with(DocumentURI.return_value)
+
+
+@create_or_update_document_uri_fixtures
+def test_create_or_update_document_uri_does_not_create_new_DocumentURI(DocumentURI):
+    """It shouldn't create a new DocumentURI if one already exists."""
+    DocumentURI.query.filter.return_value.first.return_value = mock.Mock()
+    db = mock_db()
+
+    document.create_or_update_document_uri(
+        db=db,
+        claimant='http://example.com/example_claimant.html',
+        uri='http://example.com/example_uri.html',
+        type='self-claim',
+        content_type=None,
+        document=mock_document(),
+        created=datetime.datetime.now(),
+        updated=datetime.datetime.now())
+
+    assert not DocumentURI.called
+    assert not db.add.called
+
+
+@create_or_update_document_uri_fixtures
+def test_create_or_update_document_uri_logs_warning_if_document_ids_differ(
+        log,
+        DocumentURI):
+    """
+    It should log a warning on Document objects mismatch.
+
+    If there's an existing DocumentURI and its .document property is different
+    to the given document it shoulg log a warning.
+
+    """
+    # existing_document_uri.document will not be equal to the given document'
+    existing_document_uri = mock.Mock(document=mock_document())
+    DocumentURI.query.filter.return_value.first.return_value = existing_document_uri
+
+    document.create_or_update_document_uri(
+        db=mock_db(),
+        claimant='http://example.com/example_claimant.html',
+        uri='http://example.com/example_uri.html',
+        type='self-claim',
+        content_type=None,
+        document=mock_document(),
+        created=datetime.datetime.now(),
+        updated=datetime.datetime.now())
+
+    assert log.warn.call_count == 1
+
+
+@create_or_update_document_uri_fixtures
+def test_create_or_update_document_uri_updates_updated_time(DocumentURI):
+    # existing_document_uri has an older .updated time than than the updated
+    # argument we will pass to create_or_update_document_uri().
+    now = datetime.datetime.now()
+    yesterday = now - datetime.timedelta(days=1)
+    existing_document_uri = mock.Mock(updated=yesterday)
+
+    DocumentURI.query.filter.return_value.first.return_value = (
+        existing_document_uri)
+
+    document.create_or_update_document_uri(
+        db=mock_db(),
+        claimant='http://example.com/example_claimant.html',
+        uri='http://example.com/example_uri.html',
+        type='self-claim',
+        content_type=None,
+        document=mock_document(),
+        created=now - datetime.timedelta(days=3),
+        updated=now)
+
+    assert existing_document_uri.updated == now
+
+
+@pytest.mark.usefixtures('DocumentMeta',
+                         'log')
+class TestCreateOrUpdateDocumentMeta(object):
+
+    def test_it_calls_filter(self, DocumentMeta):
+        document.create_or_update_document_meta(
+            db=mock_db(),
+            claimant='http://example.com/claimant',
+            claimant_normalized='http://example.com/claimant_normalized',
+            type='title',
+            value='Example Page',
+            document=mock.Mock(),
+            created=yesterday(),
+            updated=now(),
+        )
+
+        # FIXME: We need to assert that this is called with the right
+        # arguments, but that's very awkward to do with the way sqlalchemy
+        # querying works.' Move this functionality onto the model class itself
+        # where the tests can use the actual database.
+        assert DocumentMeta.query.filter.call_count == 1
+
+    def test_it_calls_one_or_none(self, DocumentMeta):
+        document.create_or_update_document_meta(
+            db=mock_db(),
+            claimant='http://example.com/claimant',
+            claimant_normalized='http://example.com/claimant_normalized',
+            type='title',
+            value='Example Page',
+            document=mock.Mock(),
+            created=yesterday(),
+            updated=now(),
+        )
+
+        DocumentMeta.query.filter.return_value.one_or_none\
+            .assert_called_once_with()
+
+    def test_it_creates_a_new_DocumentMeta(self, DocumentMeta):
+        """It should create a new DocumentMeta if there isn't one already."""
+        DocumentMeta.query.filter.return_value.one_or_none\
+            .return_value = None
+        claimant = 'http://example.com/claimant'
+        claimant_normalized = 'http://example.com/claimant_normalized'
+        type_ = 'title'
+        value = 'Example Page'
+        created = yesterday()
+        updated = now()
+
+        document.create_or_update_document_meta(
+            db=mock_db(),
+            claimant=claimant,
+            claimant_normalized=claimant_normalized,
+            type=type_,
+            value=value,
+            document=mock.sentinel.document,
+            created=created,
+            updated=updated,
+        )
+
+        DocumentMeta.assert_called_once_with(
+            _claimant=claimant,
+            _claimant_normalized=claimant_normalized,
+            type=type_,
+            value=value,
+            document=mock.sentinel.document,
+            created=created,
+            updated=updated,
+        )
+
+    def test_it_adds_document_meta_to_db(self, DocumentMeta):
+        """
+        It should add the new DocumentMeta to the db.
+
+        If there's no existing equivalent DocumentMeta already in the db then
+        it should add the a new one to the db
+
+        """
+        db = mock_db()
+        DocumentMeta.query.filter.return_value.one_or_none\
+            .return_value = None
+
+        document.create_or_update_document_meta(
+            db=db,
+            claimant='http://example.com/claimant',
+            claimant_normalized='http://example.com/claimant_normalized',
+            type='title',
+            value='Example Page',
+            document=mock.Mock(),
+            created=yesterday(),
+            updated=now(),
+        )
+
+        db.add.assert_called_once_with(DocumentMeta.return_value)
+
+    def test_it_sets_value(self, DocumentMeta):
+        """If there's an existing DocumentMeta it should update its value."""
+        existing_document_meta = self.mock_document_meta()
+        existing_document_meta.value = 'old value'
+        DocumentMeta.query.filter.return_value.one_or_none\
+            .return_value = existing_document_meta
+
+        document.create_or_update_document_meta(
+            db=mock_db(),
+            claimant='http://example.com/claimant',
+            claimant_normalized='http://example.com/claimant_normalized',
+            type='title',
+            value='new value',
+            document=mock.Mock(),
+            created=yesterday(),
+            updated=now(),
+        )
+
+        assert existing_document_meta.value == 'new value'
+
+    def test_sets_updated(self, DocumentMeta):
+        """If there's an existing DocumentMeta it should update its updated."""
+        existing_document_meta = self.mock_document_meta()
+        existing_document_meta.updated = yesterday()
+        DocumentMeta.query.filter.return_value.one_or_none\
+            .return_value = existing_document_meta
+        now_ = now()
+
+        document.create_or_update_document_meta(
+            db=mock_db(),
+            claimant='http://example.com/claimant',
+            claimant_normalized='http://example.com/claimant_normalized',
+            type='title',
+            value='new value',
+            document=mock.Mock(),
+            created=yesterday(),
+            updated=now_,
+        )
+
+        assert existing_document_meta.updated == now_
+
+    def test_it_logs_warning(self, DocumentMeta, log):
+        """
+        It should warn on document mismatches.
+
+        It should warn if there's an existing DocumentMeta with a different
+        Document.
+
+        """
+        document_one = mock_document()
+        document_two = mock_document()
+        existing_document_meta = self.mock_document_meta(document=document_one)
+        DocumentMeta.query.filter.return_value.one_or_none\
+            .return_value = existing_document_meta
+
+        document.create_or_update_document_meta(
+            db=mock_db(),
+            claimant='http://example.com/claimant',
+            claimant_normalized='http://example.com/claimant_normalized',
+            type='title',
+            value='new value',
+            document=document_two,
+            created=yesterday(),
+            updated=now(),
+        )
+
+        assert log.warn.call_count == 1
+
+    def mock_document_meta(self, document=None):
+        class DocumentMeta(object):
+            def __init__(self):
+                self.claimant_normalized = None
+                self.type = None
+                self.value = None
+                self.created = None
+                self.updated = None
+                self.document = document
+                self.id = None
+                self.document_id = None
+        return mock.Mock(spec=DocumentMeta())
+
+
 merge_documents_fixtures = pytest.mark.usefixtures('merge_data')
 
 
@@ -162,6 +575,30 @@ def test_merge_documents_rewires_document_meta(merge_data):
     assert len(duplicate.meta) == 0
 
 
+def now():
+    return datetime.datetime.now()
+
+
+def yesterday():
+    return now() - datetime.timedelta(days=1)
+
+
+@pytest.fixture
+def DocumentURI(config, request):
+    patcher = mock.patch('h.api.models.document.DocumentURI')
+    DocumentURI = patcher.start()
+    request.addfinalizer(patcher.stop)
+    return DocumentURI
+
+
+@pytest.fixture
+def DocumentMeta(config, request):
+    patcher = mock.patch('h.api.models.document.DocumentMeta')
+    DocumentMeta = patcher.start()
+    request.addfinalizer(patcher.stop)
+    return DocumentMeta
+
+
 @pytest.fixture
 def merge_data(request):
     master = Document(document_uris=[DocumentURI(
@@ -184,3 +621,11 @@ def merge_data(request):
     db.Session.add_all([master, duplicate])
     db.Session.flush()
     return (master, duplicate)
+
+
+@pytest.fixture
+def log(config, request):
+    patcher = mock.patch('h.api.models.document.log', autospec=True)
+    log = patcher.start()
+    request.addfinalizer(patcher.stop)
+    return log

--- a/h/api/models/test/document_test.py
+++ b/h/api/models/test/document_test.py
@@ -8,13 +8,11 @@ import pytest
 
 from h import db
 from h.api.models import document
-from h.api.models.document import Document, DocumentURI, DocumentMeta
-from h.api.models.document import merge_documents
 
 
 def test_document_title():
-    doc = Document()
-    DocumentMeta(type='title', value='The Title', document=doc, claimant='http://example.com')
+    doc = document.Document()
+    document.DocumentMeta(type='title', value='The Title', document=doc, claimant='http://example.com')
     db.Session.add(doc)
     db.Session.flush()
 
@@ -22,9 +20,9 @@ def test_document_title():
 
 
 def test_document_title_returns_first():
-    doc = Document()
-    DocumentMeta(type='title', value='The US Title', document=doc, claimant='http://example.com')
-    DocumentMeta(type='title', value='The UK Title', document=doc, claimant='http://example.co.uk')
+    doc = document.Document()
+    document.DocumentMeta(type='title', value='The US Title', document=doc, claimant='http://example.com')
+    document.DocumentMeta(type='title', value='The UK Title', document=doc, claimant='http://example.co.uk')
     db.Session.add(doc)
     db.Session.flush()
 
@@ -32,8 +30,8 @@ def test_document_title_returns_first():
 
 
 def test_document_title_meta_not_found():
-    doc = Document()
-    DocumentMeta(type='other', value='something', document=doc, claimant='http://example.com')
+    doc = document.Document()
+    document.DocumentMeta(type='other', value='something', document=doc, claimant='http://example.com')
     db.Session.add(doc)
     db.Session.flush()
 
@@ -41,20 +39,20 @@ def test_document_title_meta_not_found():
 
 
 def test_document_find_by_uris():
-    document1 = Document()
+    document1 = document.Document()
     uri1 = 'https://de.wikipedia.org/wiki/Hauptseite'
-    document1.document_uris.append(DocumentURI(claimant=uri1, uri=uri1))
+    document1.document_uris.append(document.DocumentURI(claimant=uri1, uri=uri1))
 
-    document2 = Document()
+    document2 = document.Document()
     uri2 = 'https://en.wikipedia.org/wiki/Main_Page'
-    document2.document_uris.append(DocumentURI(claimant=uri2, uri=uri2))
+    document2.document_uris.append(document.DocumentURI(claimant=uri2, uri=uri2))
     uri3 = 'https://en.wikipedia.org'
-    document2.document_uris.append(DocumentURI(claimant=uri3, uri=uri2))
+    document2.document_uris.append(document.DocumentURI(claimant=uri3, uri=uri2))
 
     db.Session.add_all([document1, document2])
     db.Session.flush()
 
-    actual = Document.find_by_uris(db.Session, [
+    actual = document.Document.find_by_uris(db.Session, [
         'https://en.wikipedia.org/wiki/Main_Page',
         'https://m.en.wikipedia.org/wiki/Main_Page'])
     assert actual.count() == 1
@@ -62,58 +60,58 @@ def test_document_find_by_uris():
 
 
 def test_document_find_by_uris_no_matches():
-    document = Document()
-    document.document_uris.append(DocumentURI(
+    document_ = document.Document()
+    document_.document_uris.append(document.DocumentURI(
         claimant='https://en.wikipedia.org/wiki/Main_Page',
         uri='https://en.wikipedia.org/wiki/Main_Page'))
-    db.Session.add(document)
+    db.Session.add(document_)
     db.Session.flush()
 
-    actual = Document.find_by_uris(db.Session, ['https://de.wikipedia.org/wiki/Hauptseite'])
+    actual = document.Document.find_by_uris(db.Session, ['https://de.wikipedia.org/wiki/Hauptseite'])
     assert actual.count() == 0
 
 
 def test_document_find_or_create_by_uris():
-    document = Document()
-    docuri1 = DocumentURI(
+    document_ = document.Document()
+    docuri1 = document.DocumentURI(
         claimant='https://en.wikipedia.org/wiki/Main_Page',
         uri='https://en.wikipedia.org/wiki/Main_Page',
-        document=document)
-    docuri2 = DocumentURI(
+        document=document_)
+    docuri2 = document.DocumentURI(
         claimant='https://en.wikipedia.org/wiki/http/en.m.wikipedia.org/wiki/Main_Page',
         uri='https://en.wikipedia.org/wiki/Main_Page',
-        document=document)
+        document=document_)
 
     db.Session.add(docuri1)
     db.Session.add(docuri2)
     db.Session.flush()
 
-    actual = Document.find_or_create_by_uris(db.Session,
+    actual = document.Document.find_or_create_by_uris(db.Session,
         'https://en.wikipedia.org/wiki/Main_Page',
         ['https://en.wikipedia.org/wiki/http/en.m.wikipedia.org/wiki/Main_Page',
          'https://m.en.wikipedia.org/wiki/Main_Page'])
     assert actual.count() == 1
-    assert actual.first() == document
+    assert actual.first() == document_
 
 
 def test_document_find_or_create_by_uris_no_results():
-    document = Document()
-    docuri = DocumentURI(
+    document_ = document.Document()
+    docuri = document.DocumentURI(
         claimant='https://en.wikipedia.org/wiki/Main_Page',
         uri='https://en.wikipedia.org/wiki/Main_Page',
-        document=document)
+        document=document_)
 
     db.Session.add(docuri)
     db.Session.flush()
 
-    documents = Document.find_or_create_by_uris(db.Session,
+    documents = document.Document.find_or_create_by_uris(db.Session,
         'https://en.wikipedia.org/wiki/Pluto',
         ['https://m.en.wikipedia.org/wiki/Pluto'])
 
     assert documents.count() == 1
 
     actual = documents.first()
-    assert isinstance(actual, Document)
+    assert isinstance(actual, document.Document)
     assert len(actual.document_uris) == 1
 
     docuri = actual.document_uris[0]
@@ -539,7 +537,7 @@ merge_documents_fixtures = pytest.mark.usefixtures('merge_data')
 def test_merge_documents_returns_master(merge_data):
     master, duplicate = merge_data
 
-    merged_master = merge_documents(db.Session, merge_data)
+    merged_master = document.merge_documents(db.Session, merge_data)
     assert merged_master == master
 
 
@@ -547,17 +545,17 @@ def test_merge_documents_returns_master(merge_data):
 def test_merge_documents_deletes_duplicate_documents(merge_data):
     master, duplicate = merge_data
 
-    merge_documents(db.Session, merge_data)
+    document.merge_documents(db.Session, merge_data)
     db.Session.flush()
 
-    assert Document.query.get(duplicate.id) is None
+    assert document.Document.query.get(duplicate.id) is None
 
 
 @merge_documents_fixtures
 def test_merge_documents_rewires_document_uris(merge_data):
     master, duplicate = merge_data
 
-    merge_documents(db.Session, merge_data)
+    document.merge_documents(db.Session, merge_data)
     db.Session.flush()
 
     assert len(master.document_uris) == 2
@@ -568,7 +566,7 @@ def test_merge_documents_rewires_document_uris(merge_data):
 def test_merge_documents_rewires_document_meta(merge_data):
     master, duplicate = merge_data
 
-    merge_documents(db.Session, merge_data)
+    document.merge_documents(db.Session, merge_data)
     db.Session.flush()
 
     assert len(master.meta) == 2
@@ -601,19 +599,19 @@ def DocumentMeta(config, request):
 
 @pytest.fixture
 def merge_data(request):
-    master = Document(document_uris=[DocumentURI(
+    master = document.Document(document_uris=[document.DocumentURI(
             claimant='https://en.wikipedia.org/wiki/Main_Page',
             uri='https://en.wikipedia.org/wiki/Main_Page',
             type='self-claim')],
-            meta=[DocumentMeta(
+            meta=[document.DocumentMeta(
                 claimant='https://en.wikipedia.org/wiki/Main_Page',
                 type='title',
                 value='Wikipedia, the free encyclopedia')])
-    duplicate = Document(document_uris=[DocumentURI(
+    duplicate = document.Document(document_uris=[document.DocumentURI(
             claimant='https://m.en.wikipedia.org/wiki/Main_Page',
             uri='https://en.wikipedia.org/wiki/Main_Page',
             type='rel-canonical')],
-            meta=[DocumentMeta(
+            meta=[document.DocumentMeta(
                 claimant='https://m.en.wikipedia.org/wiki/Main_Page',
                 type='title',
                 value='Wikipedia, the free encyclopedia')])

--- a/h/api/models/test/document_test.py
+++ b/h/api/models/test/document_test.py
@@ -168,8 +168,8 @@ class TestCreateOrUpdateDocumentURI(object):
             type='self-claim',
             content_type=None,
             document=mock_document(),
-            created=datetime.datetime.now(),
-            updated=datetime.datetime.now())
+            created=now(),
+            updated=now())
 
         # FIXME: We need to assert that this is called with the right
         # arguments, but that's very awkward to do with the way sqlalchemy
@@ -185,8 +185,8 @@ class TestCreateOrUpdateDocumentURI(object):
             type='self-claim',
             content_type=None,
             document=mock_document(),
-            created=datetime.datetime.now(),
-            updated=datetime.datetime.now())
+            created=now(),
+            updated=now())
 
         DocumentURI.query.filter.return_value.first.assert_called_once_with()
 
@@ -198,8 +198,8 @@ class TestCreateOrUpdateDocumentURI(object):
         type_ = 'self-claim'
         content_type = 'text/html'
         document_ = mock_document()
-        created = datetime.datetime.now() - datetime.timedelta(days=1)
-        updated = datetime.datetime.now()
+        created = yesterday()
+        updated = now()
 
         document.create_or_update_document_uri(
             db=mock_db(),
@@ -228,8 +228,8 @@ class TestCreateOrUpdateDocumentURI(object):
         type_ = 'self-claim'
         content_type = None
         document_ = mock_document()
-        created = datetime.datetime.now() - datetime.timedelta(days=1)
-        updated = datetime.datetime.now()
+        created = yesterday()
+        updated = now()
 
         document.create_or_update_document_uri(
             db=mock_db(),
@@ -261,8 +261,8 @@ class TestCreateOrUpdateDocumentURI(object):
             type='self-claim',
             content_type=None,
             document=mock_document(),
-            created=datetime.datetime.now(),
-            updated=datetime.datetime.now())
+            created=now(),
+            updated=now())
 
         db.add.assert_called_once_with(DocumentURI.return_value)
 
@@ -278,8 +278,8 @@ class TestCreateOrUpdateDocumentURI(object):
             type='self-claim',
             content_type=None,
             document=mock_document(),
-            created=datetime.datetime.now(),
-            updated=datetime.datetime.now())
+            created=now(),
+            updated=now())
 
         assert not DocumentURI.called
         assert not db.add.called
@@ -304,16 +304,16 @@ class TestCreateOrUpdateDocumentURI(object):
             type='self-claim',
             content_type=None,
             document=mock_document(),
-            created=datetime.datetime.now(),
-            updated=datetime.datetime.now())
+            created=now(),
+            updated=now())
 
         assert log.warn.call_count == 1
 
     def test_it_updates_updated_time(self, DocumentURI):
         # existing_document_uri has an older .updated time than than the
         # updated argument we will pass to create_or_update_document_uri().
-        now = datetime.datetime.now()
-        yesterday = now - datetime.timedelta(days=1)
+        created = yesterday()
+        updated = now()
         existing_document_uri = mock.Mock(updated=yesterday)
 
         DocumentURI.query.filter.return_value.first.return_value = (
@@ -326,24 +326,22 @@ class TestCreateOrUpdateDocumentURI(object):
             type='self-claim',
             content_type=None,
             document=mock_document(),
-            created=now - datetime.timedelta(days=3),
-            updated=now)
+            created=created,
+            updated=updated)
 
-        assert existing_document_uri.updated == now
+        assert existing_document_uri.updated == updated
 
     def mock_docuri_dict(self, uri=None):
         """Return a mock document URI dict."""
         if uri is None:
             uri = 'http://example.com/example_uri.html'
 
-        now = datetime.datetime.now()
-
         return {
             'type': 'self-claim',
             'claimant': 'http://example.com/example_claimant.html',
             'uri': uri,
-            'created': now,
-            'updated': now
+            'created': now(),
+            'updated': now()
         }
 
     @pytest.fixture

--- a/h/api/parse_document_claims.py
+++ b/h/api/parse_document_claims.py
@@ -1,0 +1,215 @@
+"""
+Functions for parsing document claims data from the client.
+
+Functions for parsing the document claims (document metadata claims and URI
+equivalence claims) that the client POSTS in the JSON "document" sub-object in
+annotation create and update requests.
+
+The data is parsed into a format suitable for storage in our database model,
+and returned.
+
+"""
+from __future__ import unicode_literals
+
+from h.api import uri
+
+
+def document_uris_from_data(document_data, claimant):
+    """
+    Return one or more document URI dicts for the given document data.
+
+    Returns one document uri dict for each document equivalence claim in
+    document_data.
+
+    Each dict can be used to init a DocumentURI object directly:
+
+        document_uri = DocumentURI(**document_uri_dict)
+
+    Always returns at least one "self-claim" document URI whose URI is the
+    claimant URI itself.
+
+    :param document_data: the "document" sub-object that was POSTed to the API
+        as part of a new or updated annotation
+    :type document_data: dict
+
+    :param claimant: the URI that the browser was at when this annotation was
+        created (the top-level "uri" field of the annotation)
+    :type claimant: unicode
+
+    :returns: a list of one or more document URI dicts
+    :rtype: list of dicts
+
+    """
+    document_uris = document_uris_from_links(document_data.get('link', []),
+                                             claimant)
+
+    document_uris.extend(
+        document_uris_from_highwire(document_data.get('highwire', {}),
+                                    claimant)
+    )
+
+    document_uris.extend(
+        document_uris_from_dc(document_data.get('dc', {}),
+                              claimant)
+    )
+
+    document_uris.append(document_uri_self_claim(claimant))
+
+    return document_uris
+
+
+def document_metas_from_data(document_data, claimant):
+    """
+    Return a list of document meta dicts for the given document data.
+
+    Returns one document meta dict for each document metadata claim in
+    document_data.
+
+    Each dict can be used to init a DocumentMeta object directly:
+
+        document_meta = DocumentMeta(**document_meta_dict)
+
+    :param document_data: the "document" sub-object that the client POSTed to
+        the API as part of a new or updated annotation
+    :type document_data: dict
+
+    :param claimant: the URI that the browser was at when this annotation was
+        created (the top-level "uri" field of the annotation)
+    :type claimant: unicode
+
+    :returns: a list of zero or more document meta dicts
+    :rtype: list of dicts
+
+    """
+    def transform_meta_(document_meta_dicts, items, path_prefix=None):
+        """Fill document_meta_dicts with document meta dicts for the items."""
+        if path_prefix is None:
+            path_prefix = []
+
+        for key, value in items.iteritems():
+            keypath = path_prefix[:]
+            keypath.append(key)
+
+            if isinstance(value, dict):
+                transform_meta_(document_meta_dicts,
+                                value,
+                                path_prefix=keypath)
+            else:
+                if not isinstance(value, list):
+                    value = [value]
+
+                document_meta_dicts.append({
+                    'type': '.'.join(keypath),
+                    'value': value,
+                    'claimant': claimant,
+                    'claimant_normalized':
+                        uri.normalize(claimant).decode('utf-8'),
+                })
+
+    items = {k: v for k, v in document_data.iteritems() if k != 'link'}
+    document_meta_dicts = []
+    transform_meta_(document_meta_dicts, items)
+    return document_meta_dicts
+
+
+def document_uris_from_links(link_dicts, claimant):
+    """
+    Return document URI dicts for the given document.link data.
+
+    Process a document.link list of dicts that the client submitted as part of
+    an annotation create or update request and return document URI dicts for
+    all of the document equivalence claims that it makes.
+
+    """
+    document_uris = []
+    for link in link_dicts:
+
+        # Disregard self-claim URLs as they're added separately later.
+        if link.keys() == ['href'] and link['href'] == claimant:
+            continue
+
+        # Disregard doi links as these are being added separately from the
+        # highwire and dc metadata later on.
+        if link.keys() == ['href'] and link['href'].startswith('doi:'):
+            continue
+
+        uri_ = link['href']
+        type_ = None
+
+        # Handle Highwire PDF links.
+        if set(link.keys()) == set(['href', 'type']):
+            if link['type'] == 'application/pdf':
+                type_ = 'highwire-pdf'
+
+        # Handle rel="..." links.
+        if type_ is None and link.get('rel') is not None:
+            type_ = 'rel-{}'.format(link['rel'])
+
+        # The "type" item in link dicts becomes content_type in DocumentURIs.
+        content_type = None
+        if link.get('type'):
+            content_type = link['type']
+
+        document_uris.append({
+            'claimant': claimant,
+            'uri': uri_,
+            'type': type_,
+            'content_type': content_type,
+        })
+
+    return document_uris
+
+
+def document_uris_from_highwire(highwire_dict, claimant):
+    """
+    Return document URI dicts for the given 'highwire' document metadata.
+
+    Process a document.highwire dict that the client submitted as part of an
+    annotation create or update request and return document URI dicts for all
+    of the document equivalence claims that it makes.
+
+    """
+    document_uris = []
+    hwdoivalues = highwire_dict.get('doi', [])
+    for doi in hwdoivalues:
+        if not doi.startswith('doi:'):
+            doi = "doi:{}".format(doi)
+
+        document_uris.append({'claimant': claimant,
+                              'uri': doi,
+                              'type': 'highwire-doi',
+                              'content_type': None})
+    return document_uris
+
+
+def document_uris_from_dc(dc_dict, claimant):
+    """
+    Return document URI dicts for the given 'dc' document metadata.
+
+    Process a document.dc dict that the client submitted as part of an
+    annotation create or update request and return document URI dicts for all
+    of the document equivalence claims that it makes.
+
+    """
+    document_uris = []
+    dcdoivalues = dc_dict.get('identifier', [])
+    for doi in dcdoivalues:
+        if not doi.startswith('doi:'):
+            doi = "doi:{}".format(doi)
+
+        document_uris.append({'claimant': claimant,
+                              'uri': doi,
+                              'type': 'dc-doi',
+                              'content_type': None})
+
+    return document_uris
+
+
+def document_uri_self_claim(claimant):
+    """Return a "self-claim" document URI dict for the given claimant."""
+    return {
+        'claimant': claimant,
+        'uri': claimant,
+        'type': u'self-claim',
+        'content_type': None,
+    }

--- a/h/api/schemas.py
+++ b/h/api/schemas.py
@@ -7,6 +7,8 @@ from jsonschema.exceptions import best_match
 from pyramid import i18n
 from pyramid import security
 
+from h.api import parse_document_claims
+
 _ = i18n.TranslationStringFactory(__package__)
 
 # These annotation fields are not to be set by the user.
@@ -113,6 +115,20 @@ class CreateAnnotationSchema(object):
                 raise ValidationError('group: ' +
                                       _('You may not create annotations in '
                                         'groups you are not a member of!'))
+
+        # Transform the "document" dict that the client posts into a convenient
+        # format for creating DocumentURI and DocumentMeta objects later.
+        document_data = appstruct.pop('document', {})
+        document_uri_dicts = parse_document_claims.document_uris_from_data(
+            document_data,
+            claimant=appstruct.get('uri', ''))
+        document_meta_dicts = parse_document_claims.document_metas_from_data(
+            document_data,
+            claimant=appstruct.get('uri', ''))
+        appstruct['document'] = {
+            'document_uri_dicts': document_uri_dicts,
+            'document_meta_dicts': document_meta_dicts
+        }
 
         return appstruct
 

--- a/h/api/storage.py
+++ b/h/api/storage.py
@@ -12,9 +12,6 @@ from functools import partial
 from h.api import transform
 from h.api import models
 from h.api.events import AnnotationBeforeSaveEvent
-from h.api.models import elastic
-from h.api.models.annotation import Annotation
-from h.api.models.document import Document
 
 
 def annotation_from_dict(data):
@@ -27,7 +24,7 @@ def annotation_from_dict(data):
     :returns: the created annotation
     :rtype: dict
     """
-    return elastic.Annotation(data)
+    return models.elastic.Annotation(data)
 
 
 def fetch_annotation(request, id):
@@ -44,13 +41,13 @@ def fetch_annotation(request, id):
     :rtype: dict, NoneType
     """
     if _postgres_enabled(request):
-        return request.db.query(Annotation).get(id)
+        return request.db.query(models.Annotation).get(id)
 
-    return elastic.Annotation.fetch(id)
+    return models.elastic.Annotation.fetch(id)
 
 
 def _legacy_create_annotation_in_elasticsearch(request, data):
-    annotation = elastic.Annotation(data)
+    annotation = models.elastic.Annotation(data)
     # FIXME: this should happen when indexing, not storing.
     _prepare(request, annotation)
     annotation.save()
@@ -134,7 +131,7 @@ def update_annotation(request, id, data):
     :returns: the updated annotation
     :rtype: dict
     """
-    annotation = elastic.Annotation.fetch(id)
+    annotation = models.elastic.Annotation.fetch(id)
     annotation.update(data)
 
     # FIXME: this should happen when indexing, not storing.
@@ -154,7 +151,7 @@ def delete_annotation(request, id):
     :param id: the annotation id
     :type id: str
     """
-    annotation = elastic.Annotation.fetch(id)
+    annotation = models.elastic.Annotation.fetch(id)
     annotation.delete()
 
 
@@ -177,9 +174,9 @@ def expand_uri(request, uri):
     """
     doc = None
     if _postgres_enabled(request):
-        doc = Document.find_by_uris(request.db, [uri]).one_or_none()
+        doc = models.Document.find_by_uris(request.db, [uri]).one_or_none()
     else:
-        doc = elastic.Document.get_by_uri(uri)
+        doc = models.elastic.Document.get_by_uri(uri)
 
     if doc is None:
         return [uri]

--- a/h/api/storage.py
+++ b/h/api/storage.py
@@ -75,8 +75,11 @@ def _create_annotation(request, data):
         if top_level_annotation:
             data['groupid'] = top_level_annotation.groupid
         else:
-            # FIXME: Fail here with a validation error.
-            pass
+            raise schemas.ValidationError(
+                'references.0: ' +
+                _('Annotation {annotation_id} does not exist').format(
+                    annotation_id=top_level_annotation_id)
+            )
 
     # The user must have permission to create an annotation in the group
     # they've asked to create one in.

--- a/h/api/storage.py
+++ b/h/api/storage.py
@@ -61,7 +61,21 @@ def _legacy_create_annotation_in_elasticsearch(request, data):
     return annotation
 
 
-def _create_annotation(request, data):
+def create_annotation(request, data):
+    """
+    Create an annotation from passed data.
+
+    :param request: the request object
+    :type request: pyramid.request.Request
+
+    :param data: a dictionary of annotation properties
+    :type data: dict
+
+    :returns: the created annotation
+    :rtype: dict
+    """
+    if not request.feature('postgres_write'):
+        return _legacy_create_annotation_in_elasticsearch(request, data)
 
     document_uri_dicts = data['document']['document_uri_dicts']
     document_meta_dicts = data['document']['document_meta_dicts']
@@ -132,25 +146,6 @@ def _create_annotation(request, data):
             **document_meta_dict)
 
     return annotation
-
-
-def create_annotation(request, data):
-    """
-    Create an annotation from passed data.
-
-    :param request: the request object
-    :type request: pyramid.request.Request
-
-    :param data: a dictionary of annotation properties
-    :type data: dict
-
-    :returns: the created annotation
-    :rtype: dict
-    """
-    if request.feature('postgres_write'):
-        return _create_annotation(request, data)
-    else:
-        return _legacy_create_annotation_in_elasticsearch(request, data)
 
 
 def update_annotation(request, id, data):

--- a/h/api/storage.py
+++ b/h/api/storage.py
@@ -151,24 +151,9 @@ def expand_uri(request, uri):
 
 
 def _prepare(request, annotation):
-    """
-    Prepare the given annotation for storage.
-
-    Scan the passed annotation for any target URIs or document metadata URIs
-    and add normalized versions of these to the document.
-    """
+    """Prepare the given annotation for storage."""
     fetcher = partial(fetch_annotation, request)
-    transform.set_group_if_reply(annotation, fetcher=fetcher)
-    transform.insert_group_if_none(annotation)
-    transform.set_group_permissions(annotation)
-
-    # FIXME: Remove this in a month or so, when all our clients have been
-    # updated. -N 2015-09-25
-    transform.fix_old_style_comments(annotation)
-
-    # FIXME: When this becomes simply part of a search indexing operation, this
-    # should probably not mutate its argument.
-    transform.normalize_annotation_target_uris(annotation)
+    transform.prepare(annotation, fetcher)
 
     # Fire an AnnotationBeforeSaveEvent so subscribers who wish to modify an
     # annotation before save can do so.

--- a/h/api/test/parse_document_claims_test.py
+++ b/h/api/test/parse_document_claims_test.py
@@ -1,0 +1,538 @@
+import mock
+import pytest
+
+from h.api import parse_document_claims
+
+
+class TestDocumentURIsFromData(object):
+
+    def test_it_ignores_href_links_that_match_the_claimant_uri(self):
+        """
+        Links containing only the claimant URI should be ignored.
+
+        If document.link contains a link dict with just an "href" and no other
+        keys, and the value of the "href" key is the same as the claimant URI,
+        then this link dict should be ignored and not produce an additional
+        document URI dict in the output (since the document URI that it would
+        generate would be the same as the "self-claim" claimant URI one that is
+        always generated anyway).
+
+        """
+        claimant = 'http://localhost:5000/docs/help'
+        link_dicts = [{'href': claimant}]
+
+        document_uris = parse_document_claims.document_uris_from_links(
+            link_dicts,
+            claimant,
+        )
+
+        assert document_uris == []
+
+    def test_it_ignores_doi_links(self):
+        """
+        Links containing only an href that starts with doi should be ignored.
+
+        If document.link contains a link dict with just an "href" and no other
+        keys, and the value of the "href" key begins with "doi:", then the link
+        dict should be ignored and not produce a document URI dict in the
+        output.
+
+        This is because document URI dicts for doi: URIs are generate
+        separately from other metadata in the document dict outside of the
+        "link" list.
+
+        """
+        link_dicts = [{'href': 'doi:10.3389/fenvs.2014.00003'}]
+
+        document_uris = parse_document_claims.document_uris_from_links(
+            link_dicts,
+            claimant='http://localhost:5000/docs/help'
+        )
+
+        assert document_uris == []
+
+    def test_it_returns_highwire_pdf_document_uris_for_application_pdf_links(
+            self):
+        pdf_url = 'http://example.com/example.pdf'
+        link_dicts = [{'href': pdf_url, 'type': 'application/pdf'}]
+
+        document_uris = parse_document_claims.document_uris_from_links(
+            link_dicts,
+            claimant='http://localhost:5000/docs/help',
+        )
+
+        highwire_document_uri = one(
+            [d for d in document_uris if d['type'] == 'highwire-pdf'])
+        assert highwire_document_uri == {
+            'type': 'highwire-pdf',
+            'claimant': 'http://localhost:5000/docs/help',
+            'content_type': 'application/pdf',
+            'uri': pdf_url,
+        }
+
+    def test_it_returns_rel_alternate_document_uris_for_rel_alternate_links(
+            self):
+        alternate_url = 'http://example.com/alternate'
+        link_dicts = [{'href': alternate_url, 'rel': 'alternate'}]
+
+        document_uris = parse_document_claims.document_uris_from_links(
+            link_dicts,
+            claimant='http://localhost:5000/docs/help',
+        )
+
+        alternate_document_uri = one(
+            [d for d in document_uris if d['type'] == 'rel-alternate'])
+        assert alternate_document_uri == {
+            'type': 'rel-alternate',
+            'claimant': 'http://localhost:5000/docs/help',
+            'content_type': None,
+            'uri': alternate_url,
+        }
+
+    def test_it_uses_link_types_as_document_uri_content_types(self):
+        """
+        Link types get converted to document URI content_types.
+
+        The value of the 'type' key in link dicts ends up as the value of the
+        'content_type' key in the returned document URI dicts.
+
+        """
+        link_dicts = [{'href': 'http://example.com/example.html',
+                       'type': 'text/html'}]
+
+        document_uris = parse_document_claims.document_uris_from_links(
+            link_dicts,
+            claimant='http://example.com/example.html',
+        )
+
+        assert one(
+            [d for d in document_uris if d.get('content_type') == 'text/html'])
+
+    def test_it_returns_multiple_document_URI_dicts(self):
+        """If there are multiple claims it should return multiple dicts."""
+        link_dicts = [
+            {
+                'href': 'http://example.com/example.html',
+                'type': 'text/html'
+            },
+            {
+                'href': 'http://example.com/alternate.html',
+                'rel': 'alternate'
+            },
+            {
+                'href': 'http://example.com/example.pdf',
+                'type': 'application/pdf'
+            }
+        ]
+
+        document_uris = parse_document_claims.document_uris_from_links(
+            link_dicts,
+            claimant='http://example.com/claimant.html',
+        )
+
+        assert len(document_uris) == 3
+
+
+@pytest.mark.usefixtures('uri')
+class TestDocumentMetasFromData(object):
+
+    @pytest.mark.parametrize("input_,output", [
+        # String values get turned into length 1 lists.
+        (
+            {
+                'foo': 'string',
+            },
+            {
+                'type': 'foo',
+                'value': ['string']
+            }
+        ),
+
+        # List values get copied over unchanged.
+        (
+            {
+                'foo': ['one', 'two'],
+            },
+            {
+                'type': 'foo',
+                'value': ['one', 'two']
+            }
+        ),
+
+        # Sub-dicts get flattened using a '.' separator in the key,
+        # and length 1 list values in sub-dicts get copied over unchanged.
+        (
+            {
+                'facebook': {
+                    'description': ['document description'],
+                }
+            },
+            {
+                'type': 'facebook.description',
+                'value': ['document description']
+            }
+        ),
+
+        # Length >1 list values in sub-dicts get copied over unchanged.
+        (
+            {
+                'facebook': {
+                    'image': [
+                        'http://example.com/image1.png',
+                        'http://example.com/image2.png',
+                        'http://example.com/image3.jpeg',
+                    ],
+                }
+            },
+            {
+                'type': 'facebook.image',
+                'value': [
+                    'http://example.com/image1.png',
+                    'http://example.com/image2.png',
+                    'http://example.com/image3.jpeg'
+                ]
+            }
+        ),
+
+        # String values in sub-dicts get turned into length 1 lists.
+        (
+            {
+                'foo': {
+                    'bar': 'string'
+                }
+            },
+            {
+                'type': 'foo.bar',
+                'value': ['string']
+            }
+        )
+    ])
+    def test_document_metas_from_data(self, input_, output, uri):
+        claimant = 'http://example.com/claimant/'
+
+        document_metas = parse_document_claims.document_metas_from_data(
+            document_data=input_,
+            claimant=claimant)
+
+        assert document_metas == [{
+            'type': output['type'],
+            'value': output['value'],
+            'claimant': claimant,
+            'claimant_normalized': uri.normalize.return_value,
+        }]
+
+    def test_document_metas_from_data_ignores_links_list(self):
+        """It should ignore the "link" list in the document_data."""
+        document_data = {
+            'link': [
+                {'href': 'http://example.com/link'},
+            ]
+        }
+
+        document_metas = parse_document_claims.document_metas_from_data(
+            document_data, 'http://example/claimant')
+
+        assert document_metas == []
+
+    def test_document_metas_from_data_with_multiple_metadata_claims(self, uri):
+        """
+        It should create one DocumentMeta for each metadata claim.
+
+        If document_data contains multiple metadata claims it should init one
+        DocumentMeta for each claim.
+
+        """
+        claimant = 'http://example/claimant'
+        document_data = {
+            'title': 'the title',
+            'description': 'the description',
+            'site_title': 'the site title'
+        }
+
+        document_metas = parse_document_claims.document_metas_from_data(
+            document_data, claimant)
+
+        assert len(document_metas) == len(document_data.items())
+        for key, value in document_data.items():
+            assert {
+                'type': key,
+                'value': [value],
+                'claimant': claimant,
+                'claimant_normalized': uri.normalize.return_value,
+                } in document_metas
+
+    @pytest.fixture
+    def uri(self, request):
+        patcher = mock.patch('h.api.parse_document_claims.uri', autospec=True)
+        uri = patcher.start()
+        uri.normalize.return_value = 'normalized'
+        request.addfinalizer(patcher.stop)
+        return uri
+
+
+class TestDocumentURIsFromHighwire(object):
+
+    def test_highwire_doi_values_produce_highwire_doi_document_uris(self):
+        highwire_dict = {
+            'doi': ['doi:10.10.1038/nphys1170', 'doi:10.1002/0470841559.ch1',
+                    'doi:10.1594/PANGAEA.726855'],
+        }
+
+        document_uris = parse_document_claims.document_uris_from_highwire(
+            highwire_dict,
+            claimant='http://example.com/example.html',
+        )
+
+        for doi in highwire_dict['doi']:
+            document_uri = one([d for d in document_uris
+                                if d.get('uri') == doi])
+            assert document_uri == {
+                'claimant': 'http://example.com/example.html',
+                'uri': doi,
+                'type': 'highwire-doi',
+                'content_type': None,
+            }
+
+    def test_doi_is_prepended_to_highwire_dois(self):
+        """If a highwire DOI doesn't begin with 'doi:' it is prepended."""
+        highwire_dict = {'doi': ['10.10.1038/nphys1170']}
+
+        document_uris = parse_document_claims.document_uris_from_highwire(
+            highwire_dict,
+            claimant='http://example.com/example.html',
+        )
+
+        expected_uri = 'doi:' + highwire_dict['doi'][0]
+        one([d for d in document_uris if d.get('uri') == expected_uri])
+
+
+class TestDocumentURIsFromDC(object):
+
+    def test_dc_identifiers_produce_dc_doi_document_uris(self):
+        """Each 'identifier' list item in the 'dc' dict becomes a doc URI."""
+        dc_dict = {
+            'identifier': [
+                'doi:10.10.1038/nphys1170',
+                'doi:10.1002/0470841559.ch1',
+                'doi:10.1594/PANGAEA.726855'
+            ]
+        }
+
+        document_uris = parse_document_claims.document_uris_from_dc(
+            dc_dict,
+            claimant='http://example.com/example.html',
+        )
+
+        for doi in dc_dict['identifier']:
+            document_uri = one([d for d in document_uris
+                                if d.get('uri') == doi])
+            assert document_uri == {
+                'claimant': 'http://example.com/example.html',
+                'uri': doi,
+                'type': 'dc-doi',
+                'content_type': None,
+            }
+
+    def test_doi_is_prepended_to_dc_identifiers(self):
+        """If a dc identifier doesn't begin with 'doi:' it is prepended."""
+        dc_dict = {'identifier': ['10.10.1038/nphys1170']}
+
+        document_uris = parse_document_claims.document_uris_from_dc(
+            dc_dict,
+            claimant='http://example.com/example.html',
+        )
+
+        expected_uri = 'doi:' + dc_dict['identifier'][0]
+        one([d for d in document_uris if d.get('uri') == expected_uri])
+
+
+class TestDocumentURISelfClaim(object):
+
+    def test_document_uri_self_claim(self):
+        claimant = 'http://localhost:5000/docs/help'
+
+        document_uri = parse_document_claims.document_uri_self_claim(
+            claimant)
+
+        assert document_uri == {
+            'claimant': claimant,
+            'uri': claimant,
+            'type': 'self-claim',
+            'content_type': None,
+        }
+
+
+@pytest.mark.usefixtures('document_uris_from_dc',
+                         'document_uris_from_highwire',
+                         'document_uris_from_links',
+                         'document_uri_self_claim')
+class TestDocumentURIsFromData(object):
+
+    def test_it_calls_document_uris_from_links(self, document_uris_from_links):
+        document_data = {
+            'link': [
+                # In production these would be link dicts not strings.
+                'link_dict_1',
+                'link_dict_2',
+                'link_dict_3',
+            ]
+
+        }
+        claimant = 'http://localhost:5000/docs/help'
+        document_uris_from_links.return_value = [
+            mock.Mock(), mock.Mock(), mock.Mock()]
+
+        document_uris = parse_document_claims.document_uris_from_data(
+            document_data=document_data,
+            claimant=claimant,
+        )
+
+        document_uris_from_links.assert_called_once_with(
+            document_data['link'], claimant)
+        for document_uri in document_uris_from_links.return_value:
+            assert document_uri in document_uris
+
+    def test_calling_document_uris_from_links_when_no_links(
+            self,
+            document_uris_from_links):
+        document_data = {}  # No 'link' key.
+        claimant = 'http://localhost:5000/docs/help'
+
+        parse_document_claims.document_uris_from_data(
+            document_data=document_data,
+            claimant=claimant,
+        )
+
+        document_uris_from_links.assert_called_once_with(
+            [], claimant)
+
+    def test_it_calls_documents_uris_from_highwire(
+            self,
+            document_uris_from_highwire):
+        document_data = {
+            'highwire': {
+                'doi': [
+                    'doi_1',
+                    'doi_2',
+                    'doi_3',
+                ]
+            }
+        }
+        claimant = 'http://localhost:5000/docs/help'
+        document_uris_from_highwire.return_value = [
+            mock.Mock(), mock.Mock(), mock.Mock()]
+
+        document_uris = parse_document_claims.document_uris_from_data(
+            document_data=document_data,
+            claimant=claimant,
+        )
+
+        document_uris_from_highwire.assert_called_once_with(
+            document_data['highwire'], claimant)
+        for document_uri in document_uris_from_highwire.return_value:
+            assert document_uri in document_uris
+
+    def test_calling_document_uris_from_highwire_when_no_highwire(
+            self,
+            document_uris_from_highwire):
+        document_data = {}  # No 'highwire' key.
+        claimant = 'http://localhost:5000/docs/help'
+
+        parse_document_claims.document_uris_from_data(
+            document_data=document_data,
+            claimant=claimant,
+        )
+
+        document_uris_from_highwire.assert_called_once_with(
+            {}, claimant)
+
+    def test_it_calls_documents_uris_from_dc(self,
+                                             document_uris_from_dc):
+        document_data = {
+            'dc': {
+                'identifier': [
+                    'doi_1',
+                    'doi_2',
+                    'doi_3',
+                ]
+            }
+        }
+        claimant = 'http://localhost:5000/docs/help'
+        document_uris_from_dc.return_value = [
+            mock.Mock(), mock.Mock(), mock.Mock()]
+
+        document_uris = parse_document_claims.document_uris_from_data(
+            document_data=document_data,
+            claimant=claimant,
+        )
+
+        document_uris_from_dc.assert_called_once_with(
+            document_data['dc'], claimant)
+        for document_uri in document_uris_from_dc.return_value:
+            assert document_uri in document_uris
+
+    def test_calling_document_uris_from_dc_when_no_dc(self,
+                                                      document_uris_from_dc):
+        document_data = {}  # No 'dc' key.
+        claimant = 'http://localhost:5000/docs/help'
+
+        parse_document_claims.document_uris_from_data(
+            document_data=document_data,
+            claimant=claimant,
+        )
+
+        document_uris_from_dc.assert_called_once_with(
+            {}, claimant)
+
+    def test_it_calls_document_uri_self_claim(self, document_uri_self_claim):
+        claimant = 'http://example.com/claimant'
+
+        document_uris = parse_document_claims.document_uris_from_data(
+            {}, claimant)
+
+        document_uri_self_claim.assert_called_once_with(claimant)
+        assert document_uri_self_claim.return_value in document_uris
+
+    @pytest.fixture
+    def document_uris_from_dc(self, request):
+        patcher = mock.patch(
+            'h.api.parse_document_claims.document_uris_from_dc',
+            autospec=True)
+        document_uris_from_dc = patcher.start()
+        document_uris_from_dc.return_value = []
+        request.addfinalizer(patcher.stop)
+        return document_uris_from_dc
+
+    @pytest.fixture
+    def document_uris_from_highwire(self, request):
+        patcher = mock.patch(
+            'h.api.parse_document_claims.document_uris_from_highwire',
+            autospec=True)
+        document_uris_from_highwire = patcher.start()
+        document_uris_from_highwire.return_value = []
+        request.addfinalizer(patcher.stop)
+        return document_uris_from_highwire
+
+    @pytest.fixture
+    def document_uris_from_links(self, request):
+        patcher = mock.patch(
+            'h.api.parse_document_claims.document_uris_from_links',
+            autospec=True)
+        document_uris_from_links = patcher.start()
+        document_uris_from_links.return_value = []
+        request.addfinalizer(patcher.stop)
+        return document_uris_from_links
+
+    @pytest.fixture
+    def document_uri_self_claim(self, request):
+        patcher = mock.patch(
+            'h.api.parse_document_claims.document_uri_self_claim',
+            autospec=True)
+        document_uri_self_claim = patcher.start()
+        request.addfinalizer(patcher.stop)
+        return document_uri_self_claim
+
+
+def one(list_):
+    assert len(list_) == 1
+    return list_[0]

--- a/h/api/test/schemas_test.py
+++ b/h/api/test/schemas_test.py
@@ -39,6 +39,368 @@ class TestJSONSchema(object):
         assert message.startswith("123 is not of type 'string'")
 
 
+class TestAnnotationSchema(object):
+
+    def test_it_does_not_raise_for_minimal_valid_data(self):
+        schema = schemas.AnnotationSchema()
+
+        # Use only the required fields.
+        schema.validate(self.valid_input_data())
+
+    def test_it_does_not_raise_for_full_valid_data(self):
+        schema = schemas.AnnotationSchema()
+
+        # Use all the keys to make sure that valid data for all of them passes.
+        schema.validate({
+            'document': {
+                'dc': {
+                    'identifier': ['foo', 'bar']
+                },
+                'highwire': {
+                    'doi': ['foo', 'bar']
+                },
+                'link': [
+                    {
+                        'href': 'foo',
+                        'type': 'foo',
+                    },
+                    {
+                        'href': 'foo',
+                        'type': 'foo',
+                    }
+                ],
+            },
+            'group': 'foo',
+            'permissions': {
+                'admin': ['acct:foo', 'group:bar'],
+                'delete': ['acct:foo', 'group:bar'],
+                'read': ['acct:foo', 'group:bar'],
+                'update': ['acct:foo', 'group:bar'],
+            },
+            'references': ['foo', 'bar'],
+            'tags': ['foo', 'bar'],
+            'target': [
+                {
+                    'selector': 'foo'
+                },
+                {
+                    'selector': 'foo'
+                },
+            ],
+            'text': 'foo',
+            'uri' : 'foo',
+        })
+
+    def test_it_raises_if_document_is_not_a_dict(self):
+        schema = schemas.AnnotationSchema()
+
+        with pytest.raises(schemas.ValidationError) as err:
+            schema.validate(self.valid_input_data(
+                document=False,
+            ))
+
+        assert str(err.value) == "document: False is not of type 'object'"
+
+    def test_it_raises_if_document_dc_is_not_a_dict(self):
+        schema = schemas.AnnotationSchema()
+
+        with pytest.raises(schemas.ValidationError) as err:
+            schema.validate(self.valid_input_data(
+                document={'dc': False}
+            ))
+
+        assert str(err.value) == "document.dc: False is not of type 'object'"
+
+    def test_it_raises_if_document_dc_identifier_is_not_a_list(self):
+        schema = schemas.AnnotationSchema()
+
+        with pytest.raises(schemas.ValidationError) as err:
+            schema.validate(self.valid_input_data(
+                document={'dc': {'identifier': False}}
+            ))
+
+        assert str(err.value) == (
+            "document.dc.identifier: False is not of type 'array'")
+
+    def test_it_raises_if_document_dc_identifier_item_is_not_a_string(self):
+        schema = schemas.AnnotationSchema()
+
+        with pytest.raises(schemas.ValidationError) as err:
+            schema.validate(self.valid_input_data(
+                document={'dc': {'identifier': [False]}}
+            ))
+
+        assert str(err.value) == (
+            "document.dc.identifier.0: False is not of type 'string'")
+
+    def test_it_raises_if_document_highwire_is_not_a_dict(self):
+        schema = schemas.AnnotationSchema()
+
+        with pytest.raises(schemas.ValidationError) as err:
+            schema.validate(self.valid_input_data(
+                document={'highwire': False}
+            ))
+
+        assert str(err.value) == (
+            "document.highwire: False is not of type 'object'")
+
+    def test_it_raises_if_document_highwire_doi_is_not_a_list(self):
+        schema = schemas.AnnotationSchema()
+
+        with pytest.raises(schemas.ValidationError) as err:
+            schema.validate(self.valid_input_data(
+                document={'highwire': {'doi': False}}
+            ))
+
+        assert str(err.value) == (
+            "document.highwire.doi: False is not of type 'array'")
+
+    def test_it_raises_if_document_highwire_doi_item_is_not_a_string(self):
+        schema = schemas.AnnotationSchema()
+
+        with pytest.raises(schemas.ValidationError) as err:
+            schema.validate(self.valid_input_data(
+                document={'highwire': {'doi': [False]}}
+            ))
+
+        assert str(err.value) == (
+            "document.highwire.doi.0: False is not of type 'string'")
+
+    def test_it_raises_if_document_link_is_not_a_list(self):
+        schema = schemas.AnnotationSchema()
+
+        with pytest.raises(schemas.ValidationError) as err:
+            schema.validate(self.valid_input_data(
+                document={'link': False}
+            ))
+
+        assert str(err.value) == "document.link: False is not of type 'array'"
+
+    def test_it_raises_if_document_link_item_is_not_a_dict(self):
+        schema = schemas.AnnotationSchema()
+
+        with pytest.raises(schemas.ValidationError) as err:
+            schema.validate(self.valid_input_data(
+                document={'link': [False]}
+            ))
+
+        assert str(err.value) == (
+            "document.link.0: False is not of type 'object'")
+
+    def test_it_raises_if_document_link_item_has_no_href(self):
+        schema = schemas.AnnotationSchema()
+
+        with pytest.raises(schemas.ValidationError) as err:
+            schema.validate(self.valid_input_data(
+                document={'link': [{}]}
+            ))
+
+        assert str(err.value) == (
+            "document.link.0: 'href' is a required property")
+
+    def test_it_raises_if_document_link_item_href_is_not_a_string(self):
+        schema = schemas.AnnotationSchema()
+
+        with pytest.raises(schemas.ValidationError) as err:
+            schema.validate(self.valid_input_data(
+                document={'link': [{'href': False}]}
+            ))
+
+        assert str(err.value) == (
+            "document.link.0.href: False is not of type 'string'")
+
+    def test_it_raises_if_document_link_item_type_is_not_a_string(self):
+        schema = schemas.AnnotationSchema()
+
+        with pytest.raises(schemas.ValidationError) as err:
+            schema.validate(self.valid_input_data(
+                document={
+                    'link': [
+                        {
+                            'href': 'http://example.com',
+                            'type': False
+                        }
+                    ]
+                }
+            ))
+
+        assert str(err.value) == (
+            "document.link.0.type: False is not of type 'string'")
+
+    def test_it_raises_if_group_is_not_a_string(self):
+        schema = schemas.AnnotationSchema()
+
+        with pytest.raises(schemas.ValidationError) as err:
+            schema.validate(self.valid_input_data(
+                group=False
+            ))
+
+        assert str(err.value) == "group: False is not of type 'string'"
+
+    def test_it_raises_if_permissions_is_missing(self):
+        schema = schemas.AnnotationSchema()
+        data = self.valid_input_data()
+        del data['permissions']
+
+        with pytest.raises(schemas.ValidationError) as err:
+            schema.validate(data)
+
+        assert str(err.value) == "'permissions' is a required property"
+
+    def test_it_raises_if_permissions_is_not_a_dict(self):
+        schema = schemas.AnnotationSchema()
+
+        with pytest.raises(schemas.ValidationError) as err:
+            schema.validate(self.valid_input_data(
+                permissions=False
+            ))
+
+        assert str(err.value) == "permissions: False is not of type 'object'"
+
+    def test_it_raises_if_permissions_has_no_read(self):
+        schema = schemas.AnnotationSchema()
+
+        with pytest.raises(schemas.ValidationError) as err:
+            schema.validate(self.valid_input_data(
+                permissions={}
+            ))
+
+        assert str(err.value) == "permissions: 'read' is a required property"
+
+    def test_it_raises_if_permissions_read_is_not_a_list(self):
+        schema = schemas.AnnotationSchema()
+
+        with pytest.raises(schemas.ValidationError) as err:
+            schema.validate(self.valid_input_data(
+                permissions={'read': False}
+            ))
+
+        assert str(err.value) == (
+            "permissions.read: False is not of type 'array'")
+
+    def test_it_raises_if_permissions_read_item_is_not_a_string(self):
+        schema = schemas.AnnotationSchema()
+
+        with pytest.raises(schemas.ValidationError) as err:
+            schema.validate(self.valid_input_data(
+                permissions={'read': [False]}
+            ))
+
+        assert str(err.value) == (
+            "permissions.read.0: False is not of type 'string'")
+
+    def test_it_raises_if_permissions_read_item_is_wrong_format(self):
+        schema = schemas.AnnotationSchema()
+
+        with pytest.raises(schemas.ValidationError) as err:
+            schema.validate(self.valid_input_data(
+                permissions={'read': ["foo"]}
+            ))
+
+        assert str(err.value) == (
+            "permissions.read.0: u'foo' does not match '^(acct:|group:).+$'")
+
+    def test_it_raises_if_references_is_not_a_list(self):
+        schema = schemas.AnnotationSchema()
+
+        with pytest.raises(schemas.ValidationError) as err:
+            schema.validate(self.valid_input_data(
+                references=False
+            ))
+
+        assert str(err.value) == "references: False is not of type 'array'"
+
+    def test_it_raises_if_references_item_is_not_a_string(self):
+        schema = schemas.AnnotationSchema()
+
+        with pytest.raises(schemas.ValidationError) as err:
+            schema.validate(self.valid_input_data(
+                references=[False]
+            ))
+
+        assert str(err.value) == "references.0: False is not of type 'string'"
+
+    def test_it_raises_if_tags_is_not_a_list(self):
+        schema = schemas.AnnotationSchema()
+
+        with pytest.raises(schemas.ValidationError) as err:
+            schema.validate(self.valid_input_data(
+                tags=False
+            ))
+
+        assert str(err.value) == "tags: False is not of type 'array'"
+
+    def test_it_raises_if_tags_item_is_not_a_string(self):
+        schema = schemas.AnnotationSchema()
+
+        with pytest.raises(schemas.ValidationError) as err:
+            schema.validate(self.valid_input_data(
+                tags=[False]
+            ))
+
+        assert str(err.value) == "tags.0: False is not of type 'string'"
+
+    def test_it_raises_if_target_is_not_a_list(self):
+        schema = schemas.AnnotationSchema()
+
+        with pytest.raises(schemas.ValidationError) as err:
+            schema.validate(self.valid_input_data(
+                target=False
+            ))
+
+        assert str(err.value) == "target: False is not of type 'array'"
+
+    def test_it_raises_if_target_item_is_not_a_dict(self):
+        schema = schemas.AnnotationSchema()
+
+        with pytest.raises(schemas.ValidationError) as err:
+            schema.validate(self.valid_input_data(
+                target=[False]
+            ))
+
+        assert str(err.value) == "target.0: False is not of type 'object'"
+
+    def test_it_raises_if_target_has_no_selector(self):
+        schema = schemas.AnnotationSchema()
+
+        with pytest.raises(schemas.ValidationError) as err:
+            schema.validate(self.valid_input_data(
+                target=[{}]
+            ))
+
+        assert str(err.value) == "target.0: 'selector' is a required property"
+
+    def test_it_raises_if_text_is_not_a_string(self):
+        schema = schemas.AnnotationSchema()
+
+        with pytest.raises(schemas.ValidationError) as err:
+            schema.validate(self.valid_input_data(
+                text=False
+            ))
+
+        assert str(err.value) == "text: False is not of type 'string'"
+
+    def test_it_raises_if_uri_is_not_a_string(self):
+        schema = schemas.AnnotationSchema()
+
+        with pytest.raises(schemas.ValidationError) as err:
+            schema.validate(self.valid_input_data(
+                uri=False
+            ))
+
+        assert str(err.value) == "uri: False is not of type 'string'"
+
+    def valid_input_data(self, **kwargs):
+        """Return a minimal valid input data for AnnotationSchema."""
+        data = {
+            'permissions': {
+                'read': [],
+            },
+        }
+        data.update(kwargs)
+        return data
+
+
 class TestCreateAnnotationSchemaLegacy(object):
 
     """Tests for CreateAnnotationSchema when postgres_write is off."""
@@ -161,7 +523,8 @@ class TestCreateAnnotationSchema(object):
 
     """Tests for CreateAnnotationSchema when postgres_write is on."""
 
-    def test_it_passes_input_to_AnnotationSchema_validator(self, AnnotationSchema):
+    def test_it_passes_input_to_AnnotationSchema_validator(self,
+                                                           AnnotationSchema):
         schema = schemas.CreateAnnotationSchema(self.mock_request())
 
         schema.validate(mock.sentinel.input_data)
@@ -169,7 +532,8 @@ class TestCreateAnnotationSchema(object):
         schema.structure.validate.assert_called_once_with(
             mock.sentinel.input_data)
 
-    def test_it_raises_if_structure_validator_raises(self, AnnotationSchema):
+    def test_it_raises_if_AnnotationSchema_validate_raises(self,
+                                                           AnnotationSchema):
         AnnotationSchema.return_value.validate.side_effect = (
             schemas.ValidationError('asplode'))
         schema = schemas.CreateAnnotationSchema(self.mock_request())
@@ -356,12 +720,12 @@ class TestCreateAnnotationSchema(object):
 
         assert 'groupid' not in result
 
-    def test_it_moves_extra_data_into_extras_sub_dict(self):
+    def test_it_moves_extra_data_into_extra_sub_dict(self):
         schema = schemas.CreateAnnotationSchema(self.mock_request())
 
         result = schema.validate({
             # Throw in all the fields, just to make sure that none of them get
-            # into extras.
+            # into extra.
             'created': 'created',
             'updated': 'updated',
             'user': 'user',
@@ -370,17 +734,17 @@ class TestCreateAnnotationSchema(object):
             'text': 'text',
             'tags': ['gar', 'har'],
             'permissions': {'read': ['group:__world__']},
-            'target': {},
+            'target': [],
             'group': '__world__',
             'references': ['parent'],
             'document': {},
 
-            # These should end up in extras.
+            # These should end up in extra.
             'foo': 1,
             'bar': 2,
         })
 
-        assert result['extras'] == {'foo': 1, 'bar': 2}
+        assert result['extra'] == {'foo': 1, 'bar': 2}
 
     def test_it_calls_document_uris_from_data(self, parse_document_claims):
         document_data = {'foo': 'bar'}

--- a/h/api/test/schemas_test.py
+++ b/h/api/test/schemas_test.py
@@ -39,8 +39,9 @@ class TestJSONSchema(object):
         assert message.startswith("123 is not of type 'string'")
 
 
-@pytest.mark.use_fixtures('parse_document_claims')
-class TestCreateAnnotationSchema(object):
+class TestCreateAnnotationSchemaLegacy(object):
+
+    """Tests for CreateAnnotationSchema when postgres_write is off."""
 
     def test_it_passes_input_to_structure_validator(self):
         request = self.mock_request()
@@ -148,56 +149,285 @@ class TestCreateAnnotationSchema(object):
         for k in data:
             assert result[k] == data[k]
 
-    def test_it_calls_document_uris_from_data(self, parse_document_claims):
-        schema = schemas.CreateAnnotationSchema(
-            self.mock_request(postgres_write=True))
-        document_data = {'foo': 'bar'}
-        uri = 'http://example.com/example'
-        data = {
-            'document': document_data,
-            'permissions': {'read': []},
-            'uri': uri,
-        }
+    def mock_request(self):
+        request = testing.DummyRequest()
+        request.feature = mock.Mock(return_value=False,
+                                    spec=lambda flag: False)
+        return request
+
+
+@pytest.mark.usefixtures('parse_document_claims')
+class TestCreateAnnotationSchema(object):
+
+    """Tests for CreateAnnotationSchema when postgres_write is on."""
+
+    def test_it_passes_input_to_AnnotationSchema_validator(self, AnnotationSchema):
+        schema = schemas.CreateAnnotationSchema(self.mock_request())
+
+        schema.validate(mock.sentinel.input_data)
+
+        schema.structure.validate.assert_called_once_with(
+            mock.sentinel.input_data)
+
+    def test_it_raises_if_structure_validator_raises(self, AnnotationSchema):
+        AnnotationSchema.return_value.validate.side_effect = (
+            schemas.ValidationError('asplode'))
+        schema = schemas.CreateAnnotationSchema(self.mock_request())
+
+        with pytest.raises(schemas.ValidationError):
+            schema.validate({'foo': 'bar'})
+
+    @pytest.mark.parametrize('field', [
+        'created',
+        'updated',
+        'user',
+        'id',
+    ])
+    def test_it_removes_protected_fields(self, field):
+        schema = schemas.CreateAnnotationSchema(self.mock_request())
+
+        result = schema.validate(
+            self.annotation_data(field='something forbidden'),
+        )
+
+        assert field not in result
+
+    def test_it_sets_userid(self, authn_policy):
+        authn_policy.authenticated_userid.return_value = (
+            'acct:harriet@example.com')
+        schema = schemas.CreateAnnotationSchema(self.mock_request())
+
+        result = schema.validate(self.annotation_data())
+
+        assert result['userid'] == 'acct:harriet@example.com'
+
+    def test_it_renames_uri_to_target_uri(self):
+        schema = schemas.CreateAnnotationSchema(self.mock_request())
+
+        result = schema.validate(
+            self.annotation_data(uri='http://example.com/example'),
+        )
+
+        assert result['target_uri'] == 'http://example.com/example'
+        assert 'uri' not in result
+
+    def test_it_inserts_empty_string_if_data_has_no_uri(self):
+        schema = schemas.CreateAnnotationSchema(self.mock_request())
+
+        data = self.annotation_data()
+        assert 'uri' not in data
+
+        assert schema.validate(data)['target_uri'] == ''
+
+    def test_it_keeps_text(self):
+        schema = schemas.CreateAnnotationSchema(self.mock_request())
+
+        result = schema.validate(
+            self.annotation_data(text='some annotation text'))
+
+        assert result['text'] == 'some annotation text'
+
+    def test_it_inserts_empty_string_if_data_contains_no_text(self):
+        schema = schemas.CreateAnnotationSchema(self.mock_request())
+
+        data = self.annotation_data()
+        assert 'text' not in data
+
+        assert schema.validate(data)['text'] == ''
+
+    def test_it_keeps_tags(self):
+        schema = schemas.CreateAnnotationSchema(self.mock_request())
+
+        result = schema.validate(
+            self.annotation_data(tags=['foo', 'bar']))
+
+        assert result['tags'] == ['foo', 'bar']
+
+    def test_it_inserts_empty_list_if_data_contains_no_tags(self):
+        schema = schemas.CreateAnnotationSchema(self.mock_request())
+
+        data = self.annotation_data()
+        assert 'tags' not in data
+
+        assert schema.validate(data)['tags'] == []
+
+    def test_it_replaces_private_permissions_with_shared_False(
+            self,
+            authn_policy):
+        authn_policy.authenticated_userid.return_value = (
+            'acct:harriet@example.com')
+        schema = schemas.CreateAnnotationSchema(self.mock_request())
+
+        result = schema.validate(
+            self.annotation_data(
+                permissions={'read': ['acct:harriet@example.com']},
+            ),
+        )
+
+        assert result['shared'] is False
+        assert 'permissions' not in result
+
+    def test_it_replaces_shared_permissions_with_shared_True(
+            self,
+            authn_policy):
+        authn_policy.authenticated_userid.return_value = (
+            'acct:harriet@example.com')
+        schema = schemas.CreateAnnotationSchema(self.mock_request())
+
+        result = schema.validate(
+            self.annotation_data(
+                permissions={'read': ['group:__world__']},
+            ),
+        )
+
+        assert result['shared'] is True
+        assert 'permissions' not in result
+
+    def test_it_does_not_crash_if_data_contains_no_target(self):
+        schema = schemas.CreateAnnotationSchema(self.mock_request())
+
+        data = self.annotation_data()
+        assert 'target' not in data
 
         schema.validate(data)
 
+    def test_it_replaces_target_with_target_selectors(self):
+        schema = schemas.CreateAnnotationSchema(self.mock_request())
+
+        result = schema.validate(
+            self.annotation_data(
+                target=[
+                    {
+                        'foo': 'bar',  # This should be removed,
+                        'selector': 'the selectors',
+                    },
+                    'this should be removed',
+                ],
+            ),
+        )
+
+        assert result['target_selectors'] == 'the selectors'
+
+    def test_it_renames_group_to_groupid(self):
+        schema = schemas.CreateAnnotationSchema(self.mock_request())
+
+        result = schema.validate(self.annotation_data(group='foo'))
+
+        assert result['groupid'] == 'foo'
+        assert 'group' not in result
+
+    def test_it_inserts_default_groupid_if_no_group(self):
+        schema = schemas.CreateAnnotationSchema(self.mock_request())
+
+        data = self.annotation_data()
+        assert 'group' not in data
+
+        result = schema.validate(data)
+
+        assert result['groupid'] == '__world__'
+
+    def test_it_keeps_references(self):
+        schema = schemas.CreateAnnotationSchema(self.mock_request())
+
+        result = schema.validate(
+            self.annotation_data(references=['parent id', 'parent id 2']))
+
+        assert result['references'] == ['parent id', 'parent id 2']
+
+    def test_it_inserts_empty_list_if_no_references(self):
+        schema = schemas.CreateAnnotationSchema(self.mock_request())
+
+        data = self.annotation_data()
+        assert 'references' not in data
+
+        result = schema.validate(data)
+
+        assert result['references'] == []
+
+    def test_it_deletes_groupid_for_replies(self):
+        schema = schemas.CreateAnnotationSchema(self.mock_request())
+
+        result = schema.validate(
+            self.annotation_data(
+                group='foo',
+                references=['parent annotation id'],
+            )
+        )
+
+        assert 'groupid' not in result
+
+    def test_it_moves_extra_data_into_extras_sub_dict(self):
+        schema = schemas.CreateAnnotationSchema(self.mock_request())
+
+        result = schema.validate({
+            # Throw in all the fields, just to make sure that none of them get
+            # into extras.
+            'created': 'created',
+            'updated': 'updated',
+            'user': 'user',
+            'id': 'id',
+            'uri': 'uri',
+            'text': 'text',
+            'tags': ['gar', 'har'],
+            'permissions': {'read': ['group:__world__']},
+            'target': {},
+            'group': '__world__',
+            'references': ['parent'],
+            'document': {},
+
+            # These should end up in extras.
+            'foo': 1,
+            'bar': 2,
+        })
+
+        assert result['extras'] == {'foo': 1, 'bar': 2}
+
+    def test_it_calls_document_uris_from_data(self, parse_document_claims):
+        document_data = {'foo': 'bar'}
+        target_uri = 'http://example.com/example'
+        schema = schemas.CreateAnnotationSchema(self.mock_request())
+
+        schema.validate(
+            self.annotation_data(
+                document=document_data,
+                uri=target_uri,
+            )
+        )
+
         parse_document_claims.document_uris_from_data.assert_called_once_with(
             document_data,
-            claimant=uri,
+            claimant=target_uri,
         )
 
     def test_it_puts_document_uris_in_appstruct(self, parse_document_claims):
-        schema = schemas.CreateAnnotationSchema(
-            self.mock_request(postgres_write=True))
+        schema = schemas.CreateAnnotationSchema(self.mock_request())
 
-        appstruct = schema.validate({'permissions': {'read': []}})
+        appstruct = schema.validate(self.annotation_data())
 
         assert appstruct['document']['document_uri_dicts'] == (
             parse_document_claims.document_uris_from_data.return_value)
 
     def test_it_calls_document_metas_from_data(self, parse_document_claims):
-        schema = schemas.CreateAnnotationSchema(
-            self.mock_request(postgres_write=True))
+        schema = schemas.CreateAnnotationSchema(self.mock_request())
         document_data = {'foo': 'bar'}
-        uri = 'http://example.com/example'
-        data = {
-            'document': document_data,
-            'permissions': {'read': []},
-            'uri': uri,
-        }
+        target_uri = 'http://example.com/example'
 
-        schema.validate(data)
+        schema.validate(
+            self.annotation_data(
+                document=document_data,
+                uri=target_uri,
+            )
+        )
 
         parse_document_claims.document_metas_from_data.assert_called_once_with(
             document_data,
-            claimant=uri,
+            claimant=target_uri,
         )
 
     def test_it_puts_document_metas_in_appstruct(self, parse_document_claims):
-        schema = schemas.CreateAnnotationSchema(
-            self.mock_request(postgres_write=True))
+        schema = schemas.CreateAnnotationSchema(self.mock_request())
 
-        appstruct = schema.validate({'permissions': {'read': []}})
+        appstruct = schema.validate(self.annotation_data())
 
         assert appstruct['document']['document_meta_dicts'] == (
             parse_document_claims.document_metas_from_data.return_value)
@@ -210,29 +440,49 @@ class TestCreateAnnotationSchema(object):
         'document_meta_dicts' keys.
 
         """
-        schema = schemas.CreateAnnotationSchema(
-            self.mock_request(postgres_write=True))
+        schema = schemas.CreateAnnotationSchema(self.mock_request())
 
-        appstruct = schema.validate({
-            'document': {
-                'foo': 'bar'  # This should be deleted.
-            },
-            'permissions': {'read': []},
-        })
+        appstruct = schema.validate(
+            self.annotation_data(
+                document={
+                    'foo': 'bar'  # This should be deleted.
+                },
+            ),
+        )
 
         assert 'foo' not in appstruct['document']
 
-    def mock_request(self, postgres_write=False):
-        request = testing.DummyRequest()
+    def mock_request(self, authenticated_userid=None):
+        request = testing.DummyRequest(
+            authenticated_userid=authenticated_userid)
 
         def feature(flag):
             if flag == 'postgres_write':
-                return postgres_write
+                return True
             return False
 
         request.feature = mock.Mock(side_effect=feature, spec=feature)
-
         return request
+
+    def annotation_data(self, **kwargs):
+        """Return test input data for CreateAnnotationSchema.validate()."""
+        data = {
+            'permissions': {
+                'read': []
+            }
+        }
+        data.update(kwargs)
+        return data
+
+    @pytest.fixture
+    def AnnotationSchema(self, request):
+        patcher = mock.patch('h.api.schemas.AnnotationSchema',
+                             autospec=True)
+        AnnotationSchema = patcher.start()
+        AnnotationSchema.return_value.validate.return_value = (
+            self.annotation_data())
+        request.addfinalizer(patcher.stop)
+        return AnnotationSchema
 
     @pytest.fixture
     def parse_document_claims(self, request):

--- a/h/api/test/schemas_test.py
+++ b/h/api/test/schemas_test.py
@@ -39,6 +39,7 @@ class TestJSONSchema(object):
         assert message.startswith("123 is not of type 'string'")
 
 
+@pytest.mark.use_fixtures('parse_document_claims')
 class TestCreateAnnotationSchema(object):
 
     def test_it_passes_input_to_structure_validator(self):
@@ -147,9 +148,6 @@ class TestCreateAnnotationSchema(object):
         for k in data:
             assert result[k] == data[k]
 
-    # FIXME: parse_document_claims needs to be patched for all tests of code
-    # that uses it.
-    @mock.patch('h.api.schemas.parse_document_claims')
     def test_it_calls_document_uris_from_data(self, parse_document_claims):
         schema = schemas.CreateAnnotationSchema(
             self.mock_request(postgres_write=True))
@@ -168,7 +166,6 @@ class TestCreateAnnotationSchema(object):
             claimant=uri,
         )
 
-    @mock.patch('h.api.schemas.parse_document_claims')
     def test_it_puts_document_uris_in_appstruct(self, parse_document_claims):
         schema = schemas.CreateAnnotationSchema(
             self.mock_request(postgres_write=True))
@@ -178,7 +175,6 @@ class TestCreateAnnotationSchema(object):
         assert appstruct['document']['document_uri_dicts'] == (
             parse_document_claims.document_uris_from_data.return_value)
 
-    @mock.patch('h.api.schemas.parse_document_claims')
     def test_it_calls_document_metas_from_data(self, parse_document_claims):
         schema = schemas.CreateAnnotationSchema(
             self.mock_request(postgres_write=True))
@@ -197,7 +193,6 @@ class TestCreateAnnotationSchema(object):
             claimant=uri,
         )
 
-    @mock.patch('h.api.schemas.parse_document_claims')
     def test_it_puts_document_metas_in_appstruct(self, parse_document_claims):
         schema = schemas.CreateAnnotationSchema(
             self.mock_request(postgres_write=True))
@@ -238,6 +233,14 @@ class TestCreateAnnotationSchema(object):
         request.feature = mock.Mock(side_effect=feature, spec=feature)
 
         return request
+
+    @pytest.fixture
+    def parse_document_claims(self, request):
+        patcher = mock.patch('h.api.schemas.parse_document_claims',
+                             autospec=True)
+        parse_document_claims = patcher.start()
+        request.addfinalizer(patcher.stop)
+        return parse_document_claims
 
 
 class TestUpdateAnnotationSchema(object):

--- a/h/api/test/schemas_test.py
+++ b/h/api/test/schemas_test.py
@@ -16,342 +16,338 @@ class ExampleSchema(schemas.JSONSchema):
     }
 
 
-def test_jsonschema_returns_data_when_valid():
-    data = "a string"
+class TestJSONSchema(object):
 
-    assert ExampleSchema().validate(data) == data
+    def test_it_returns_data_when_valid(self):
+        data = "a string"
 
+        assert ExampleSchema().validate(data) == data
 
-def test_jsonschema_raises_when_data_invalid():
-    data = 123  # not a string
+    def test_it_raises_when_data_invalid(self):
+        data = 123  # not a string
 
-    with pytest.raises(schemas.ValidationError):
-        ExampleSchema().validate(data)
+        with pytest.raises(schemas.ValidationError):
+            ExampleSchema().validate(data)
 
+    def test_it_sets_appropriate_error_message_when_data_invalid(self):
+        data = 123  # not a string
 
-def test_jsonschema_sets_appropriate_error_message_when_data_invalid():
-    data = 123  # not a string
+        with pytest.raises(schemas.ValidationError) as e:
+            ExampleSchema().validate(data)
 
-    with pytest.raises(schemas.ValidationError) as e:
-        ExampleSchema().validate(data)
-
-    message = e.value.message
-    assert message.startswith("123 is not of type 'string'")
-
-
-def test_createannotationschema_passes_input_to_structure_validator():
-    request = mock_request()
-    schema = schemas.CreateAnnotationSchema(request)
-    schema.structure = mock.Mock()
-    schema.structure.validate.return_value = {}
-
-    schema.validate({'foo': 'bar'})
-
-    schema.structure.validate.assert_called_once_with({'foo': 'bar'})
+        message = e.value.message
+        assert message.startswith("123 is not of type 'string'")
 
 
-def test_createannotationschema_raises_if_structure_validator_raises():
-    request = mock_request()
-    schema = schemas.CreateAnnotationSchema(request)
-    schema.structure = mock.Mock()
-    schema.structure.validate.side_effect = schemas.ValidationError('asplode')
+class TestCreateAnnotationSchema(object):
 
-    with pytest.raises(schemas.ValidationError):
+    def test_it_passes_input_to_structure_validator(self):
+        request = self.mock_request()
+        schema = schemas.CreateAnnotationSchema(request)
+        schema.structure = mock.Mock()
+        schema.structure.validate.return_value = {}
+
         schema.validate({'foo': 'bar'})
 
+        schema.structure.validate.assert_called_once_with({'foo': 'bar'})
 
-@pytest.mark.parametrize('field', [
-    'created',
-    'updated',
-    'id',
-])
-def test_createannotationschema_removes_protected_fields(field):
-    request = mock_request()
-    schema = schemas.CreateAnnotationSchema(request)
-    data = {}
-    data[field] = 'something forbidden'
+    def test_it_raises_if_structure_validator_raises(self):
+        request = self.mock_request()
+        schema = schemas.CreateAnnotationSchema(request)
+        schema.structure = mock.Mock()
+        schema.structure.validate.side_effect = (
+            schemas.ValidationError('asplode'))
 
-    result = schema.validate(data)
+        with pytest.raises(schemas.ValidationError):
+            schema.validate({'foo': 'bar'})
 
-    assert field not in result
+    @pytest.mark.parametrize('field', [
+        'created',
+        'updated',
+        'id',
+    ])
+    def test_it_removes_protected_fields(self, field):
+        request = self.mock_request()
+        schema = schemas.CreateAnnotationSchema(request)
+        data = {}
+        data[field] = 'something forbidden'
 
-
-@pytest.mark.parametrize('data', [
-    {},
-    {'user': None},
-    {'user': 'acct:foo@bar.com'},
-])
-def test_createannotationschema_ignores_input_user(data, authn_policy):
-    """Any user field sent in the payload should be ignored."""
-    authn_policy.authenticated_userid.return_value = 'acct:jeanie@example.com'
-    request = mock_request()
-    schema = schemas.CreateAnnotationSchema(request)
-
-    result = schema.validate(data)
-
-    assert result['user'] == 'acct:jeanie@example.com'
-
-
-@pytest.mark.parametrize('data,effective_principals,ok', [
-    # No group supplied
-    ({}, [], True),
-
-    # World group
-    ({'group': '__world__'}, [], False),
-    ({'group': '__world__'}, [security.Everyone], True),
-
-    # Other group
-    ({'group': 'abcdef'}, [], False),
-    ({'group': 'abcdef'}, [security.Everyone], False),
-    ({'group': 'abcdef'}, [security.Everyone, 'group:abcdef'], True),
-])
-def test_createannotationschema_rejects_annotations_to_other_groups(data,
-                                                                    effective_principals,
-                                                                    ok,
-                                                                    authn_policy):
-    """
-    A user cannot create an annotation in a group they're not a member of.
-
-    If a group is specified in the annotation, then reject the creation if the
-    relevant group principal is not present in the request's effective
-    principals.
-    """
-    authn_policy.effective_principals.return_value = effective_principals
-    request = mock_request()
-    schema = schemas.CreateAnnotationSchema(request)
-
-    if ok:
         result = schema.validate(data)
-        assert result.get('group') == data.get('group')
 
-    else:
+        assert field not in result
+
+    @pytest.mark.parametrize('data', [
+        {},
+        {'user': None},
+        {'user': 'acct:foo@bar.com'},
+    ])
+    def test_it_ignores_input_user(self, data, authn_policy):
+        """Any user field sent in the payload should be ignored."""
+        authn_policy.authenticated_userid.return_value = (
+            'acct:jeanie@example.com')
+        request = self.mock_request()
+        schema = schemas.CreateAnnotationSchema(request)
+
+        result = schema.validate(data)
+
+        assert result['user'] == 'acct:jeanie@example.com'
+
+    @pytest.mark.parametrize('data,effective_principals,ok', [
+        # No group supplied
+        ({}, [], True),
+
+        # World group
+        ({'group': '__world__'}, [], False),
+        ({'group': '__world__'}, [security.Everyone], True),
+
+        # Other group
+        ({'group': 'abcdef'}, [], False),
+        ({'group': 'abcdef'}, [security.Everyone], False),
+        ({'group': 'abcdef'}, [security.Everyone, 'group:abcdef'], True),
+    ])
+    def test_it_rejects_annotations_to_other_groups(self,
+                                                    data,
+                                                    effective_principals,
+                                                    ok,
+                                                    authn_policy):
+        """
+        A user cannot create an annotation in a group they're not a member of.
+
+        If a group is specified in the annotation, then reject the creation if
+        the relevant group principal is not present in the request's effective
+        principals.
+        """
+        authn_policy.effective_principals.return_value = effective_principals
+        request = self.mock_request()
+        schema = schemas.CreateAnnotationSchema(request)
+
+        if ok:
+            result = schema.validate(data)
+            assert result.get('group') == data.get('group')
+
+        else:
+            with pytest.raises(schemas.ValidationError) as exc:
+                schema.validate(data)
+            assert exc.value.message.startswith('group:')
+
+    @pytest.mark.parametrize('data', [
+        {},
+        {'foo': 'bar'},
+        {'a_list': ['of', 'important', 'things']},
+        {'an_object': {'with': 'stuff'}},
+        {'numbers': 12345},
+        {'null': None},
+    ])
+    def test_it_permits_all_other_changes(self, data):
+        request = self.mock_request()
+        schema = schemas.CreateAnnotationSchema(request)
+
+        result = schema.validate(data)
+
+        for k in data:
+            assert result[k] == data[k]
+
+    # FIXME: parse_document_claims needs to be patched for all tests of code
+    # that uses it.
+    @mock.patch('h.api.schemas.parse_document_claims')
+    def test_it_calls_document_uris_from_data(self, parse_document_claims):
+        schema = schemas.CreateAnnotationSchema(
+            self.mock_request(postgres_write=True))
+        document_data = {'foo': 'bar'}
+        uri = 'http://example.com/example'
+        data = {
+            'document': document_data,
+            'permissions': {'read': []},
+            'uri': uri,
+        }
+
+        schema.validate(data)
+
+        parse_document_claims.document_uris_from_data.assert_called_once_with(
+            document_data,
+            claimant=uri,
+        )
+
+    @mock.patch('h.api.schemas.parse_document_claims')
+    def test_it_puts_document_uris_in_appstruct(self, parse_document_claims):
+        schema = schemas.CreateAnnotationSchema(
+            self.mock_request(postgres_write=True))
+
+        appstruct = schema.validate({'permissions': {'read': []}})
+
+        assert appstruct['document']['document_uri_dicts'] == (
+            parse_document_claims.document_uris_from_data.return_value)
+
+    @mock.patch('h.api.schemas.parse_document_claims')
+    def test_it_calls_document_metas_from_data(self, parse_document_claims):
+        schema = schemas.CreateAnnotationSchema(
+            self.mock_request(postgres_write=True))
+        document_data = {'foo': 'bar'}
+        uri = 'http://example.com/example'
+        data = {
+            'document': document_data,
+            'permissions': {'read': []},
+            'uri': uri,
+        }
+
+        schema.validate(data)
+
+        parse_document_claims.document_metas_from_data.assert_called_once_with(
+            document_data,
+            claimant=uri,
+        )
+
+    @mock.patch('h.api.schemas.parse_document_claims')
+    def test_it_puts_document_metas_in_appstruct(self, parse_document_claims):
+        schema = schemas.CreateAnnotationSchema(
+            self.mock_request(postgres_write=True))
+
+        appstruct = schema.validate({'permissions': {'read': []}})
+
+        assert appstruct['document']['document_meta_dicts'] == (
+            parse_document_claims.document_metas_from_data.return_value)
+
+    def test_it_clears_existing_keys_from_document(self):
+        """
+        Any keys in the document dict should be removed.
+
+        They're replaced with the 'document_uri_dicts' and
+        'document_meta_dicts' keys.
+
+        """
+        schema = schemas.CreateAnnotationSchema(
+            self.mock_request(postgres_write=True))
+
+        appstruct = schema.validate({
+            'document': {
+                'foo': 'bar'  # This should be deleted.
+            },
+            'permissions': {'read': []},
+        })
+
+        assert 'foo' not in appstruct['document']
+
+    def mock_request(self, postgres_write=False):
+        request = testing.DummyRequest()
+
+        def feature(flag):
+            if flag == 'postgres_write':
+                return postgres_write
+            return False
+
+        request.feature = mock.Mock(side_effect=feature, spec=feature)
+
+        return request
+
+
+class TestUpdateAnnotationSchema(object):
+
+    def test_it_passes_input_to_structure_validator(self):
+        request = testing.DummyRequest()
+        schema = schemas.UpdateAnnotationSchema(request, {})
+        schema.structure = mock.Mock()
+        schema.structure.validate.return_value = {}
+
+        schema.validate({'foo': 'bar'})
+
+        schema.structure.validate.assert_called_once_with({'foo': 'bar'})
+
+    def test_it_raises_if_structure_validator_raises(self):
+        request = testing.DummyRequest()
+        schema = schemas.UpdateAnnotationSchema(request, {})
+        schema.structure = mock.Mock()
+        schema.structure.validate.side_effect = (
+            schemas.ValidationError('asplode'))
+
+        with pytest.raises(schemas.ValidationError):
+            schema.validate({'foo': 'bar'})
+
+    @pytest.mark.parametrize('field', [
+        'created',
+        'updated',
+        'user',
+        'id',
+    ])
+    def test_it_removes_protected_fields(self, field):
+        request = testing.DummyRequest()
+        annotation = {}
+        schema = schemas.UpdateAnnotationSchema(request, annotation)
+        data = {}
+        data[field] = 'something forbidden'
+
+        result = schema.validate(data)
+
+        assert field not in result
+
+    def test_it_allows_permissions_changes_if_admin(self, authn_policy):
+        """If a user is an admin on an annotation, they can change perms."""
+        authn_policy.authenticated_userid.return_value = (
+            'acct:harriet@example.com')
+        request = testing.DummyRequest()
+        annotation = {
+            'permissions': {'admin': ['acct:harriet@example.com']}
+        }
+        schema = schemas.UpdateAnnotationSchema(request, annotation)
+        data = {
+            'permissions': {'admin': ['acct:foo@example.com']}
+        }
+
+        result = schema.validate(data)
+
+        assert result == data
+
+    @pytest.mark.parametrize('annotation', [
+        {},
+        {'permissions': {}},
+        {'permissions': {'admin': []}},
+        {'permissions': {'admin': ['acct:alice@example.com']}},
+        {'permissions': {'read': ['acct:mallory@example.com']}},
+    ])
+    def test_it_denies_permissions_changes_if_not_admin(self,
+                                                        annotation,
+                                                        authn_policy):
+        """If a user isn't admin on an annotation they can't change perms."""
+        authn_policy.authenticated_userid.return_value = (
+            'acct:mallory@example.com')
+        request = testing.DummyRequest()
+        schema = schemas.UpdateAnnotationSchema(request, annotation)
+        data = {
+            'permissions': {'admin': ['acct:mallory@example.com']}
+        }
+
         with pytest.raises(schemas.ValidationError) as exc:
             schema.validate(data)
+
+        assert exc.value.message.startswith('permissions:')
+
+    def test_it_denies_group_changes(self):
+        """An annotation may not be moved between groups."""
+        request = testing.DummyRequest()
+        annotation = {'group': 'flibble'}
+        schema = schemas.UpdateAnnotationSchema(request, annotation)
+        data = {
+            'group': '__world__'
+        }
+
+        with pytest.raises(schemas.ValidationError) as exc:
+            schema.validate(data)
+
         assert exc.value.message.startswith('group:')
 
+    @pytest.mark.parametrize('data', [
+        {},
+        {'foo': 'bar'},
+        {'a_list': ['of', 'important', 'things']},
+        {'an_object': {'with': 'stuff'}},
+        {'numbers': 12345},
+        {'null': None},
+    ])
+    def test_it_permits_all_other_changes(self, data):
+        request = testing.DummyRequest()
+        annotation = {'group': 'flibble'}
+        schema = schemas.UpdateAnnotationSchema(request, annotation)
 
-@pytest.mark.parametrize('data', [
-    {},
-    {'foo': 'bar'},
-    {'a_list': ['of', 'important', 'things']},
-    {'an_object': {'with': 'stuff'}},
-    {'numbers': 12345},
-    {'null': None},
-])
-def test_createannotationschema_permits_all_other_changes(data):
-    request = mock_request()
-    schema = schemas.CreateAnnotationSchema(request)
+        result = schema.validate(data)
 
-    result = schema.validate(data)
-
-    for k in data:
-        assert result[k] == data[k]
-
-
-# FIXME: parse_document_claims needs to be patched for all tests of code that
-# uses it.
-@mock.patch('h.api.schemas.parse_document_claims')
-def test_createannotationschema_calls_document_uris_from_data(
-        parse_document_claims):
-    schema = schemas.CreateAnnotationSchema(mock_request(postgres_write=True))
-    document_data = {'foo': 'bar'}
-    uri = 'http://example.com/example'
-    data = {
-        'document': document_data,
-        'permissions': {'read': []},
-        'uri': uri,
-    }
-
-    schema.validate(data)
-
-    parse_document_claims.document_uris_from_data.assert_called_once_with(
-        document_data,
-        claimant=uri,
-    )
-
-
-@mock.patch('h.api.schemas.parse_document_claims')
-def test_createannotationschema_puts_document_uris_in_appstruct(
-        parse_document_claims):
-    schema = schemas.CreateAnnotationSchema(mock_request(postgres_write=True))
-
-    appstruct = schema.validate({'permissions': {'read': []}})
-
-    assert appstruct['document']['document_uri_dicts'] == (
-        parse_document_claims.document_uris_from_data.return_value)
-
-
-@mock.patch('h.api.schemas.parse_document_claims')
-def test_createannotationschema_calls_document_metas_from_data(
-        parse_document_claims):
-    schema = schemas.CreateAnnotationSchema(mock_request(postgres_write=True))
-    document_data = {'foo': 'bar'}
-    uri = 'http://example.com/example'
-    data = {
-        'document': document_data,
-        'permissions': {'read': []},
-        'uri': uri,
-    }
-
-    schema.validate(data)
-
-    parse_document_claims.document_metas_from_data.assert_called_once_with(
-        document_data,
-        claimant=uri,
-    )
-
-
-@mock.patch('h.api.schemas.parse_document_claims')
-def test_createannotationschema_puts_document_metas_in_appstruct(
-        parse_document_claims):
-    schema = schemas.CreateAnnotationSchema(mock_request(postgres_write=True))
-
-    appstruct = schema.validate({'permissions': {'read': []}})
-
-    assert appstruct['document']['document_meta_dicts'] == (
-        parse_document_claims.document_metas_from_data.return_value)
-
-
-def test_createannotationschema_clears_existing_keys_from_document():
-    """
-    Any keys in the document dict should be removed.
-
-    They're replaced with the 'document_uri_dicts' and 'document_meta_dicts'
-    keys.
-
-    """
-    schema = schemas.CreateAnnotationSchema(mock_request(postgres_write=True))
-
-    appstruct = schema.validate({
-        'document': {
-            'foo': 'bar'  # This should be deleted.
-        },
-        'permissions': {'read': []},
-    })
-
-    assert 'foo' not in appstruct['document']
-
-
-def test_updateannotationschema_passes_input_to_structure_validator():
-    request = testing.DummyRequest()
-    schema = schemas.UpdateAnnotationSchema(request, {})
-    schema.structure = mock.Mock()
-    schema.structure.validate.return_value = {}
-
-    schema.validate({'foo': 'bar'})
-
-    schema.structure.validate.assert_called_once_with({'foo': 'bar'})
-
-
-def test_updateannotationschema_raises_if_structure_validator_raises():
-    request = testing.DummyRequest()
-    schema = schemas.UpdateAnnotationSchema(request, {})
-    schema.structure = mock.Mock()
-    schema.structure.validate.side_effect = schemas.ValidationError('asplode')
-
-    with pytest.raises(schemas.ValidationError):
-        schema.validate({'foo': 'bar'})
-
-
-@pytest.mark.parametrize('field', [
-    'created',
-    'updated',
-    'user',
-    'id',
-])
-def test_updateannotationschema_removes_protected_fields(field):
-    request = testing.DummyRequest()
-    annotation = {}
-    schema = schemas.UpdateAnnotationSchema(request, annotation)
-    data = {}
-    data[field] = 'something forbidden'
-
-    result = schema.validate(data)
-
-    assert field not in result
-
-
-def test_updateannotationschema_allows_permissions_changes_if_admin(authn_policy):
-    """If a user is an admin on an annotation, they can change perms."""
-    authn_policy.authenticated_userid.return_value = 'acct:harriet@example.com'
-    request = testing.DummyRequest()
-    annotation = {
-        'permissions': {'admin': ['acct:harriet@example.com']}
-    }
-    schema = schemas.UpdateAnnotationSchema(request, annotation)
-    data = {
-        'permissions': {'admin': ['acct:foo@example.com']}
-    }
-
-    result = schema.validate(data)
-
-    assert result == data
-
-
-@pytest.mark.parametrize('annotation', [
-    {},
-    {'permissions': {}},
-    {'permissions': {'admin': []}},
-    {'permissions': {'admin': ['acct:alice@example.com']}},
-    {'permissions': {'read': ['acct:mallory@example.com']}},
-])
-def test_updateannotationschema_denies_permissions_changes_if_not_admin(annotation, authn_policy):
-    """If a user is not an admin on an annotation, they cannot change perms."""
-    authn_policy.authenticated_userid.return_value = 'acct:mallory@example.com'
-    request = testing.DummyRequest()
-    schema = schemas.UpdateAnnotationSchema(request, annotation)
-    data = {
-        'permissions': {'admin': ['acct:mallory@example.com']}
-    }
-
-    with pytest.raises(schemas.ValidationError) as exc:
-        schema.validate(data)
-
-    assert exc.value.message.startswith('permissions:')
-
-
-def test_updateannotationschema_denies_group_changes():
-    """An annotation may not be moved between groups."""
-    request = testing.DummyRequest()
-    annotation = {'group': 'flibble'}
-    schema = schemas.UpdateAnnotationSchema(request, annotation)
-    data = {
-        'group': '__world__'
-    }
-
-    with pytest.raises(schemas.ValidationError) as exc:
-        schema.validate(data)
-
-    assert exc.value.message.startswith('group:')
-
-
-@pytest.mark.parametrize('data', [
-    {},
-    {'foo': 'bar'},
-    {'a_list': ['of', 'important', 'things']},
-    {'an_object': {'with': 'stuff'}},
-    {'numbers': 12345},
-    {'null': None},
-])
-def test_updateannotationschema_permits_all_other_changes(data):
-    request = testing.DummyRequest()
-    annotation = {'group': 'flibble'}
-    schema = schemas.UpdateAnnotationSchema(request, annotation)
-
-    result = schema.validate(data)
-
-    for k in data:
-        assert result[k] == data[k]
-
-
-def mock_request(postgres_write=False):
-    request = testing.DummyRequest()
-
-    def feature(flag):
-        if flag == 'postgres_write':
-            return postgres_write
-        return False
-
-    request.feature = mock.Mock(side_effect=feature, spec=feature)
-
-    return request
+        for k in data:
+            assert result[k] == data[k]

--- a/h/api/test/storage_test.py
+++ b/h/api/test/storage_test.py
@@ -52,7 +52,7 @@ class TestExpandURI(object):
         request = DummyRequest()
         models.elastic.Document.get_by_uri.return_value = None
         assert storage.expand_uri(request, "http://example.com/") == [
-                "http://example.com/"]
+            "http://example.com/"]
 
     def test_expand_uri_postgres_document_doesnt_expand_canonical_uris(
             self,
@@ -70,7 +70,7 @@ class TestExpandURI(object):
         db.Session.flush()
 
         assert storage.expand_uri(request, "http://example.com/") == [
-                "http://example.com/"]
+            "http://example.com/"]
 
     def test_expand_uri_elastic_document_doesnt_expand_canonical_uris(
             self,
@@ -87,7 +87,7 @@ class TestExpandURI(object):
             mock.Mock(uri='http://example.com/', type='rel-canonical'),
         ]
         assert storage.expand_uri(request, "http://example.com/") == [
-                "http://example.com/"]
+            "http://example.com/"]
 
     def test_expand_uri_postgres_document_uris(self, postgres_enabled):
         request = DummyRequest(db=db.Session)

--- a/h/api/test/storage_test.py
+++ b/h/api/test/storage_test.py
@@ -2,6 +2,8 @@
 
 from __future__ import unicode_literals
 
+import copy
+
 import pytest
 import mock
 from mock import patch
@@ -210,12 +212,208 @@ class TestCreateAnnotation(object):
         return transform
 
 
+@pytest.mark.usefixtures('fetch_annotation',
+                         'models')
+class TestCreateAnnotationPostgres(object):
+
+    """Tests for create_annotation() when postgres_write is on."""
+
+    def test_it_inits_an_Annotation_model(self, models):
+        storage.create_annotation(self.mock_request(), self.annotation_data())
+
+        models.Annotation.assert_called_once_with()
+
+    def test_it_sets_userid_to_authenticated_userid(self, models):
+        request = self.mock_request()
+        data = self.annotation_data()
+        # request.authenticated_userid should be used even if the data contains
+        # a different userid.
+        data['user'] = 'acct:other@localhost'
+
+        storage.create_annotation(request, data)
+
+        assert models.Annotation.return_value.userid == (
+            request.authenticated_userid)
+
+    def test_it_saves_text(self, models):
+        data = self.annotation_data()
+        storage.create_annotation(self.mock_request(), copy.deepcopy(data))
+
+        assert models.Annotation.return_value.text == data['text']
+
+    def test_it_saves_tags(self, models):
+        data = self.annotation_data()
+
+        storage.create_annotation(self.mock_request(), copy.deepcopy(data))
+
+        assert models.Annotation.return_value.tags == data['tags']
+
+    def test_it_sets_shared_to_True_if_read_permissions_are_shared(self,
+                                                                   models):
+        data = self.annotation_data()
+        data['permissions'] = {'read': ['__world__']}
+
+        storage.create_annotation(self.mock_request(), data)
+
+        assert models.Annotation.return_value.shared is True
+
+    def test_it_sets_shared_to_False_if_read_permissions_are_private(self,
+                                                                     models):
+        request = self.mock_request()
+        data = self.annotation_data()
+        data['permissions'] = {'read': [request.authenticated_userid]}
+
+        storage.create_annotation(request, data)
+
+        assert models.Annotation.return_value.shared is False
+
+    def test_it_saves_selectors(self, models):
+        data = self.annotation_data()
+        storage.create_annotation(self.mock_request(), copy.deepcopy(data))
+
+        assert models.Annotation.return_value.target_selectors == (
+            data['target'][0]['selector'])
+
+    def test_it_saves_uri(self, models):
+        data = self.annotation_data()
+        storage.create_annotation(self.mock_request(), copy.deepcopy(data))
+
+        assert models.Annotation.return_value.target_uri == data['uri']
+
+    def test_it_saves_references(self, models):
+        data = self.annotation_data()
+        data['references'] = ['foo', 'bar']
+
+        storage.create_annotation(self.mock_request(), copy.deepcopy(data))
+
+        assert models.Annotation.return_value.references == data['references']
+
+    def test_it_saves_group(self, models):
+        data = self.annotation_data()
+
+        storage.create_annotation(self.mock_request(), copy.deepcopy(data))
+
+        assert models.Annotation.return_value.groupid == data['group']
+
+
+    def test_it_fetches_parent_annotation_for_replies(self,
+                                                      fetch_annotation,
+                                                      models):
+        request = self.mock_request()
+        models.Annotation.return_value.is_reply = True
+        data = self.annotation_data()
+        data['references'] = ['parent_annotation_id']
+
+        storage.create_annotation(request, data)
+
+        fetch_annotation.assert_called_once_with(request,
+                                                 'parent_annotation_id')
+
+    def test_it_overrides_group_for_replies(self, fetch_annotation, models):
+        fetch_annotation.return_value.groupid = "parent's group id"
+        models.Annotation.return_value.is_reply = True
+        data = self.annotation_data()
+        data['groupid'] = "reply's group id"
+        data['references'] = ['parent_annotation_id']
+
+        storage.create_annotation(self.mock_request(), data)
+
+        assert models.Annotation.return_value.groupid == "parent's group id"
+
+    def test_it_saves_extras(self, models):
+        data = self.annotation_data()
+        data['foo'] = 'bar'
+
+        storage.create_annotation(self.mock_request(), data)
+
+        assert models.Annotation.return_value.extras == {'foo': 'bar'}
+
+    def test_it_adds_the_annotation_to_the_database(self, models):
+        request = self.mock_request()
+
+        storage.create_annotation(request, self.annotation_data())
+
+        request.db.add.assert_called_once_with(models.Annotation.return_value)
+
+    def test_it_returns_the_annotation(self, models):
+        annotation = storage.create_annotation(self.mock_request(),
+                                               self.annotation_data())
+
+        assert annotation == models.Annotation.return_value
+
+    def test_it_does_not_crash_if_data_contains_no_target(self):
+        # Replies have no target.
+        data = self.annotation_data()
+        del data['target']
+
+        storage.create_annotation(self.mock_request(), data)
+
+    def test_it_does_not_crash_if_target_is_empty_list(self):
+        # Page notes have [] for the target.
+        data = self.annotation_data()
+        data['target'] = []
+
+        storage.create_annotation(self.mock_request(), data)
+
+    def test_it_does_not_crash_if_no_text_or_tags(self):
+        # Highlights have no text or tags.
+        data = self.annotation_data()
+        del data['text']
+        del data['tags']
+
+        storage.create_annotation(self.mock_request(), data)
+
+    def mock_request(self):
+        request = DummyRequest(
+            feature=mock.Mock(
+                side_effect=lambda flag: flag == "postgres_write"),
+            authenticated_userid='acct:test@localhost'
+        )
+
+        request.registry.notify = mock.Mock(spec=lambda event: None)
+
+        class DBSpec(object):
+            def add(self, annotation):
+                pass
+        request.db = mock.Mock(spec=DBSpec)
+
+        return request
+
+    def annotation_data(self):
+        return {
+            'user': 'acct:test@localhost',
+            'text': 'text',
+            'tags': ['one', 'two'],
+            'permissions': {'read': ['acct:test@localhost']},
+            'uri': 'http://www.example.com/example.html',
+            'group': '__world__',
+            'references': [],
+            'target': [{'selector': ['selector_one', 'selector_two']}]
+        }
+
+    @pytest.fixture
+    def fetch_annotation(self, request):
+        patcher = patch('h.api.storage.fetch_annotation', autospec=True)
+        fetch_annotation = patcher.start()
+        request.addfinalizer(patcher.stop)
+        return fetch_annotation
+
+
 @pytest.fixture
 def document_model(config, request):
     patcher = patch('h.api.models.elastic.Document', autospec=True)
     module = patcher.start()
     request.addfinalizer(patcher.stop)
     return module
+
+
+@pytest.fixture
+def models(request):
+    patcher = patch('h.api.storage.models')
+    models = patcher.start()
+    models.Annotation.return_value.is_reply = False
+    request.addfinalizer(patcher.stop)
+    return models
 
 
 @pytest.fixture

--- a/h/api/test/storage_test.py
+++ b/h/api/test/storage_test.py
@@ -259,6 +259,20 @@ class TestCreateAnnotationPostgres(object):
 
         assert models.Annotation.call_args[1]['groupid'] == 'test-group'
 
+    def test_it_raises_if_parent_annotation_does_not_exist(self,
+                                                           fetch_annotation):
+        fetch_annotation.return_value = None
+
+        data = self.annotation_data()
+
+        # The annotation is a reply.
+        data['references'] = ['parent_annotation_id']
+
+        with pytest.raises(schemas.ValidationError) as err:
+            storage.create_annotation(self.mock_request(), data)
+
+        assert str(err.value).startswith('references.0: ')
+
     def test_it_raises_if_user_does_not_have_permissions_for_group(self):
         data = self.annotation_data()
         data['groupid'] = 'foo-group'

--- a/h/api/test/storage_test.py
+++ b/h/api/test/storage_test.py
@@ -15,105 +15,109 @@ from h.api.models.annotation import Annotation
 from h.api.models.document import Document, DocumentURI
 
 
-def test_fetch_annotation_elastic(postgres_enabled, models):
-    postgres_enabled.return_value = False
-    models.elastic.Annotation.fetch.return_value = mock.Mock()
+class TestFetchAnnotation(object):
 
-    actual = storage.fetch_annotation(DummyRequest(), '123')
+    def test_elastic(self, postgres_enabled, models):
+        postgres_enabled.return_value = False
+        models.elastic.Annotation.fetch.return_value = mock.Mock()
 
-    models.elastic.Annotation.fetch.assert_called_once_with('123')
-    assert models.elastic.Annotation.fetch.return_value == actual
+        actual = storage.fetch_annotation(DummyRequest(), '123')
 
+        models.elastic.Annotation.fetch.assert_called_once_with('123')
+        assert models.elastic.Annotation.fetch.return_value == actual
 
-def test_fetch_annotation_postgres(postgres_enabled):
-    request = DummyRequest(db=db.Session)
-    postgres_enabled.return_value = True
+    def test_postgres(self, postgres_enabled):
+        request = DummyRequest(db=db.Session)
+        postgres_enabled.return_value = True
 
-    annotation = Annotation(userid='luke')
-    db.Session.add(annotation)
-    db.Session.flush()
+        annotation = Annotation(userid='luke')
+        db.Session.add(annotation)
+        db.Session.flush()
 
-    actual = storage.fetch_annotation(request, annotation.id)
-    assert annotation == actual
-
-
-def test_expand_uri_postgres_no_document(postgres_enabled):
-    request = DummyRequest(db=db.Session)
-    postgres_enabled.return_value = True
-
-    actual = storage.expand_uri(request, 'http://example.com/')
-    assert actual == ['http://example.com/']
+        actual = storage.fetch_annotation(request, annotation.id)
+        assert annotation == actual
 
 
-def test_expand_uri_elastic_no_document(postgres_enabled, models):
-    postgres_enabled.return_value = False
-    request = DummyRequest()
-    models.elastic.Document.get_by_uri.return_value = None
-    assert storage.expand_uri(request, "http://example.com/") == [
-            "http://example.com/"]
+class TestExpandURI(object):
 
+    def test_expand_uri_postgres_no_document(self, postgres_enabled):
+        request = DummyRequest(db=db.Session)
+        postgres_enabled.return_value = True
 
-def test_expand_uri_postgres_document_doesnt_expand_canonical_uris(postgres_enabled):
-    request = DummyRequest(db=db.Session)
-    postgres_enabled.return_value = True
+        actual = storage.expand_uri(request, 'http://example.com/')
+        assert actual == ['http://example.com/']
 
-    document = Document(document_uris=[
-        DocumentURI(uri='http://foo.com/', claimant='http://example.com'),
-        DocumentURI(uri='http://bar.com/', claimant='http://example.com'),
-        DocumentURI(uri='http://example.com/', type='rel-canonical', claimant='http://example.com'),
-    ])
-    db.Session.add(document)
-    db.Session.flush()
+    def test_expand_uri_elastic_no_document(self, postgres_enabled, models):
+        postgres_enabled.return_value = False
+        request = DummyRequest()
+        models.elastic.Document.get_by_uri.return_value = None
+        assert storage.expand_uri(request, "http://example.com/") == [
+                "http://example.com/"]
 
-    assert storage.expand_uri(request, "http://example.com/") == [
-            "http://example.com/"]
+    def test_expand_uri_postgres_document_doesnt_expand_canonical_uris(
+            self,
+            postgres_enabled):
+        request = DummyRequest(db=db.Session)
+        postgres_enabled.return_value = True
 
+        document = Document(document_uris=[
+            DocumentURI(uri='http://foo.com/', claimant='http://example.com'),
+            DocumentURI(uri='http://bar.com/', claimant='http://example.com'),
+            DocumentURI(uri='http://example.com/', type='rel-canonical',
+                        claimant='http://example.com'),
+        ])
+        db.Session.add(document)
+        db.Session.flush()
 
-def test_expand_uri_elastic_document_doesnt_expand_canonical_uris(postgres_enabled, models):
-    postgres_enabled.return_value = False
+        assert storage.expand_uri(request, "http://example.com/") == [
+                "http://example.com/"]
 
-    request = DummyRequest()
-    document = models.elastic.Document.get_by_uri.return_value
-    type(document).document_uris = uris = mock.PropertyMock()
-    uris.return_value = [
-        mock.Mock(uri='http://foo.com/'),
-        mock.Mock(uri='http://bar.com/'),
-        mock.Mock(uri='http://example.com/', type='rel-canonical'),
-    ]
-    assert storage.expand_uri(request, "http://example.com/") == [
-            "http://example.com/"]
+    def test_expand_uri_elastic_document_doesnt_expand_canonical_uris(
+            self,
+            postgres_enabled,
+            models):
+        postgres_enabled.return_value = False
 
+        request = DummyRequest()
+        document = models.elastic.Document.get_by_uri.return_value
+        type(document).document_uris = uris = mock.PropertyMock()
+        uris.return_value = [
+            mock.Mock(uri='http://foo.com/'),
+            mock.Mock(uri='http://bar.com/'),
+            mock.Mock(uri='http://example.com/', type='rel-canonical'),
+        ]
+        assert storage.expand_uri(request, "http://example.com/") == [
+                "http://example.com/"]
 
-def test_expand_uri_postgres_document_uris(postgres_enabled):
-    request = DummyRequest(db=db.Session)
-    postgres_enabled.return_value = True
+    def test_expand_uri_postgres_document_uris(self, postgres_enabled):
+        request = DummyRequest(db=db.Session)
+        postgres_enabled.return_value = True
 
-    document = Document(document_uris=[
-        DocumentURI(uri='http://foo.com/', claimant='http://bar.com'),
-        DocumentURI(uri='http://bar.com/', claimant='http://bar.com'),
-    ])
-    db.Session.add(document)
-    db.Session.flush()
+        document = Document(document_uris=[
+            DocumentURI(uri='http://foo.com/', claimant='http://bar.com'),
+            DocumentURI(uri='http://bar.com/', claimant='http://bar.com'),
+        ])
+        db.Session.add(document)
+        db.Session.flush()
 
-    assert storage.expand_uri(request, 'http://foo.com/') == [
-        'http://foo.com/',
-        'http://bar.com/'
-    ]
+        assert storage.expand_uri(request, 'http://foo.com/') == [
+            'http://foo.com/',
+            'http://bar.com/'
+        ]
 
-
-def test_expand_uri_elastic_document_uris(postgres_enabled, models):
-    postgres_enabled.return_value = False
-    request = DummyRequest()
-    document = models.elastic.Document.get_by_uri.return_value
-    type(document).document_uris = uris = mock.PropertyMock()
-    uris.return_value = [
-        mock.Mock(uri="http://foo.com/"),
-        mock.Mock(uri="http://bar.com/"),
-    ]
-    assert storage.expand_uri(request, "http://example.com/") == [
-        "http://foo.com/",
-        "http://bar.com/",
-    ]
+    def test_expand_uri_elastic_document_uris(self, postgres_enabled, models):
+        postgres_enabled.return_value = False
+        request = DummyRequest()
+        document = models.elastic.Document.get_by_uri.return_value
+        type(document).document_uris = uris = mock.PropertyMock()
+        uris.return_value = [
+            mock.Mock(uri="http://foo.com/"),
+            mock.Mock(uri="http://bar.com/"),
+        ]
+        assert storage.expand_uri(request, "http://example.com/") == [
+            "http://foo.com/",
+            "http://bar.com/",
+        ]
 
 
 @pytest.mark.usefixtures('AnnotationBeforeSaveEvent',

--- a/h/api/test/views_test.py
+++ b/h/api/test/views_test.py
@@ -157,29 +157,41 @@ def test_create_calls_validator(schemas):
 
 
 @create_fixtures
-def test_create_event(AnnotationEvent, storage):
+def test_create_inits_AnnotationJSONPresenter(AnnotationJSONPresenter, storage):
     request = mock.Mock()
-    annotation = storage.create_annotation.return_value
-    event = AnnotationEvent.return_value
 
     views.create(request)
 
-    AnnotationEvent.assert_called_once_with(request, annotation, 'create')
-    request.registry.notify.assert_called_once_with(event)
+    AnnotationJSONPresenter.assert_called_once_with(
+        request, storage.create_annotation.return_value)
+
+
+@create_fixtures
+def test_create_publishes_annotation_event(AnnotationEvent,
+                                           AnnotationJSONPresenter):
+    """It should publish an annotation "create" event for the annotation."""
+    request = mock.Mock()
+
+    views.create(request)
+
+    AnnotationEvent.assert_called_once_with(
+        request,
+        AnnotationJSONPresenter.return_value.asdict.return_value,
+        'create')
+    request.registry.notify.assert_called_once_with(
+        AnnotationEvent.return_value)
 
 
 @create_fixtures
 def test_create_returns_presented_annotation(AnnotationJSONPresenter, storage):
     request = mock.Mock()
-    presenter = mock.Mock()
-    AnnotationJSONPresenter.return_value = presenter
 
     result = views.create(request)
 
     AnnotationJSONPresenter.assert_called_once_with(
             request,
             storage.create_annotation.return_value)
-    assert result == presenter.asdict()
+    assert result == AnnotationJSONPresenter.return_value.asdict.return_value
 
 
 def test_read_returns_presented_annotation(AnnotationJSONPresenter):

--- a/h/api/transform.py
+++ b/h/api/transform.py
@@ -4,6 +4,21 @@ from h._compat import string_types
 from h.api import uri
 
 
+def prepare(annotation, fetcher):
+    """Prepare the given annotation for storage."""
+    set_group_if_reply(annotation, fetcher=fetcher)
+    insert_group_if_none(annotation)
+    set_group_permissions(annotation)
+
+    # FIXME: Remove this in a month or so, when all our clients have been
+    # updated. -N 2015-09-25
+    fix_old_style_comments(annotation)
+
+    # FIXME: When this becomes simply part of a search indexing operation, this
+    # should probably not mutate its argument.
+    normalize_annotation_target_uris(annotation)
+
+
 def set_group_if_reply(annotation, fetcher):
     """
     If the annotation is a reply set its group to that of its parent.

--- a/h/api/views.py
+++ b/h/api/views.py
@@ -157,10 +157,10 @@ def create(request):
     appstruct = schema.validate(_json_payload(request))
     annotation = storage.create_annotation(request, appstruct)
 
-    _publish_annotation_event(request, annotation, 'create')
+    annotation_dict = AnnotationJSONPresenter(request, annotation).asdict()
+    _publish_annotation_event(request, annotation_dict, 'create')
 
-    presenter = AnnotationJSONPresenter(request, annotation)
-    return presenter.asdict()
+    return annotation_dict
 
 
 @api_config(route_name='api.annotation', request_method='GET', permission='read')

--- a/h/features.py
+++ b/h/features.py
@@ -17,7 +17,9 @@ log = logging.getLogger(__name__)
 FEATURES = {
     'direct_linking': "Generate direct links to annotations in context in the client?",
     'new_homepage': "Show the new homepage design?",
-    'postgres_read': 'Use postgres to fetch annotations from storage'
+    'postgres_read': 'Use postgres to fetch annotations from storage',
+    'postgres_write': 'Send annotation CRUDs to <em>both</em> Postgres and the old '
+                      'Elasticsearch index',
 }
 
 # Once a feature has been fully deployed, we remove the flag from the codebase.

--- a/h/templates/admin/features.html.jinja2
+++ b/h/templates/admin/features.html.jinja2
@@ -51,7 +51,7 @@
                 {% if feat.staff %}checked{% endif %}>
             </td>
             <td>
-              {{ feat.description }}
+              {{ feat.description|safe }}
             </td>
           </tr>
           {% endfor %}


### PR DESCRIPTION
It's probably good to look at the individual commits for this one, since there's a few commits (e.g. grouping entire test modules into test classes) that create a lot of diff noise.

Ok, so what this pull request does is:

* Create annotations and create and update annotation metadata (`Document`, `DocumentURI` and `DocumentMeta` objects) in Postgres when the create annotation API is called if the postgres_write feature flag is on

* Adds some extra validation to the create annotation API (only when postgres_write is on) so that it's not easy to make it crash

What it does not do:

* Does not index annotations from Postgres into Es
* Does not do anything in Postgres when the annotation update or delete APIs are called, these still ignore the postgres_write feature flag and write to Es

In general I've tried not to change the legacy behaviour when postgres_write is off. So I've moved the existing code unmodified into `legacy_*()` functions that get called when postgres_write is off, and put the new code in place of the original functions. This involves some duplication but the legacy stuff is to be deleted.


### Parsing the annotation data from the client

Now that we have a real database we can't just throw any crap into it, either the db or our own code will crash if required fields are missing or if known fields are the wrong type. Minimal additional JSON Schema validation has been added (only to the create annotation API and only when postgres_write is on) to prevent these crashes and send proper validation errors back.

The format of annotation data that the client POSTs in annotation create and update requests is a little different from what we need to create `h.api.models.Annotation` objects in the database. Code for converting this dict from the client into a more correct/convenient format is now all in `h.api.schemas` so that when it comes out of schema validation it's in the right format. Some of this code is new, some of it has been moved from `storage` to `schemas`.

`schemas` only does "structural" validation and transformations, i.e. work that doesn't require looking in the db. Some further "semantic" validation and transformation that does require reading from the db is done in `storage`.

### Parsing the document metadata from the client

The format of the "document" sub-object that the client POSTs in annotation create and update requests is quite far from the format that we need in order to create/update the `Document`, `DocumentMeta` and `DocumentURI` objects in the database. The new `h.api.parse_document_claims` module handles transforming this dict into two lists that are in a more convenient format for `storage` to later use to create the db objects. The code in here is adapted from existing code in `migrate.py` and `elastic.py`.

`schemas` calls `parse_document_claims` to do this, so when the data comes out of schema validation it's in the right/convenient format.


### Storage / logic of creating and updating annotation data and document metadata

Storing an annotation is considerably more complicated than it is with the legacy Elasticsearch storage code in h, because of the need to create and update document equivalence data and document metadata.

`h.api.storage.create_annotation()` is really a "logic" function with some semantic validation/transformation mixed in, all the structural validation and transformation and the model handling is elsewhere. The logic of `h.api.storage.create_annotation()` is:

* Force replies to have the same group as their parent
* Fail if replying to an annotation ID that doesn't exist
* Fail if writing to a group that you don't have permission to (note this has to happen after setting the group of replies)
* Create an `Annotation` model object from the (already validated) data
* Find all existing `Document` objects referred to by any existing `DocumentURI` objects that match any of the document URI equivalence claims in the post
* If there are no such `Document`s create a new `Document` with no `DocumentURI`s or `DocumentMeta`s pointing to it (yet)
* If there is one such `Document` use it
* If there are multiple such `Documents` merge them into one (all of the `DocumentURI`s will now point to one `Document` and the other `Document`s will be deleted, this destroys information)
* Update the `.updated` time of the `Document`
* Create new `DocumentURI`s, or update existing ones, for all document URI equivalence claims in the request
* Create new `DocumentMeta`s, or update existing ones, for all document metadata claims in the request


### Creating and updating document metadata in Postgres

The logic "create an object in the db with these params, or update an equivalent one if one already exists" seems like it belongs in the model to me, so `create_or_update_document_meta()` and `create_or_update_document_uri()` are added to `models` to do this. Again these are adapted from existing code in `migrate.py`. `storage` calls them. `merge_documents()` which does similar work was already in `models`, is now called by `storage` as well.