### PR TITLE
Add autodeployer webhook to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,5 +59,3 @@ notifications:
     urls:
       - https://support.hypothes.is/travis
     on_success: always
-    on_failure: always # generate lots of noise while testing
-    on_start: always

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,3 +55,9 @@ notifications:
       - secure: SKPwtfoH32aDop6hLhQdgrUhl58gM6CMBUATMdq0KMmEwCxskPbIArqxGUKxeeiO3c3jBQ+Yuq3b4m8GbR2AJxxelO0DRLNyV1lAjfeJ/QzCc3Taxqo0yel4uAFNg/oCYWH50dv2oAgDP3CHk/tKXmsgDWOjcm6A6k35xst16xI=
     on_success: change
     on_failure: always
+  webhooks:
+    urls:
+      - https://support.hypothes.is/travis
+    on_success: always
+    on_failure: always # generate lots of noise while testing
+    on_start: always


### PR DESCRIPTION
To be merged after:
* https://github.com/hypothesis/deployer/pull/1 is merged
* https://github.com/hypothesis/playbook/pull/33 is merged, the `support` box is up and running, and the autodeployer has been deployed using the playbooks on this PR.
