### PR TITLE
Annotation links

### DIFF
--- a/h/api/presenters.py
+++ b/h/api/presenters.py
@@ -11,6 +11,12 @@ class AnnotationBasePresenter(object):
         self.annotation = annotation
         self.request = request
 
+    @property
+    def links(self):
+        return {
+            'json': self.request.route_url('api.annotation',
+                                           id=self.annotation.id),
+        }
 
 class AnnotationJSONPresenter(AnnotationBasePresenter):
     def asdict(self):
@@ -28,6 +34,7 @@ class AnnotationJSONPresenter(AnnotationBasePresenter):
             'permissions': self.permissions,
             'target': self.target,
             'document': docpresenter.asdict(),
+            'links': self.links,
         }
 
         if self.annotation.references:

--- a/h/api/presenters.py
+++ b/h/api/presenters.py
@@ -6,10 +6,13 @@ Presenters for API data.
 import collections
 
 
-class AnnotationJSONPresenter(object):
-    def __init__(self, annotation):
+class AnnotationBasePresenter(object):
+    def __init__(self, request, annotation):
         self.annotation = annotation
+        self.request = request
 
+
+class AnnotationJSONPresenter(AnnotationBasePresenter):
     def asdict(self):
         docpresenter = DocumentJSONPresenter(self.annotation.document)
 
@@ -139,6 +142,7 @@ class DocumentURIJSONPresenter(object):
         type = self.document_uri.type
         if type and type.startswith('rel-'):
             return self.document_uri.type[4:]
+
 
 def utc_iso8601(datetime):
     return datetime.strftime('%Y-%m-%dT%H:%M:%S.%f+00:00')

--- a/h/api/test/presenters_test.py
+++ b/h/api/test/presenters_test.py
@@ -14,6 +14,11 @@ from h.api.presenters import utc_iso8601, deep_merge_dict
 
 
 class TestAnnotationBasePresenter(object):
+
+    @pytest.fixture(autouse=True)
+    def link_routes(self, routes_mapper):
+        routes_mapper.add_route('api.annotation', '/dummy/abc123')
+
     def test_constructor_args(self):
         request = DummyRequest()
         annotation = mock.Mock()
@@ -23,8 +28,22 @@ class TestAnnotationBasePresenter(object):
         assert presenter.request == request
         assert presenter.annotation == annotation
 
+    def test_links(self):
+        request = DummyRequest()
+        annotation = mock.Mock()
+
+        links = AnnotationBasePresenter(request, annotation).links
+
+        assert 'json' in links
+        assert links['json'] == 'http://example.com/dummy/abc123'
+
 
 class TestAnnotationJSONPresenter(object):
+
+    @pytest.fixture(autouse=True)
+    def link_routes(self, routes_mapper):
+        routes_mapper.add_route('api.annotation', '/dummy/abc123')
+
     def test_asdict(self, document_asdict):
         request = DummyRequest()
         ann = mock.Mock(id='the-id',
@@ -57,6 +76,7 @@ class TestAnnotationJSONPresenter(object):
                     'target': [{'source': 'http://example.com',
                                 'selector': [{'TestSelector': 'foobar'}]}],
                     'document': {'foo': 'bar'},
+                    'links': {'json': 'http://example.com/dummy/abc123'},
                     'references': ['referenced-id-1', 'referenced-id-2'],
                     'extra-1': 'foo',
                     'extra-2': 'bar'}

--- a/h/api/test/views_test.py
+++ b/h/api/test/views_test.py
@@ -177,6 +177,7 @@ def test_create_returns_presented_annotation(AnnotationJSONPresenter, storage):
     result = views.create(request)
 
     AnnotationJSONPresenter.assert_called_once_with(
+            request,
             storage.create_annotation.return_value)
     assert result == presenter.asdict()
 
@@ -189,7 +190,7 @@ def test_read_returns_presented_annotation(AnnotationJSONPresenter):
 
     result = views.read(annotation, request)
 
-    AnnotationJSONPresenter.assert_called_once_with(annotation)
+    AnnotationJSONPresenter.assert_called_once_with(request, annotation)
     assert result == presenter.asdict()
 
 
@@ -246,6 +247,7 @@ def test_update_returns_presented_annotation(AnnotationJSONPresenter, storage):
     result = views.update(annotation, request)
 
     AnnotationJSONPresenter.assert_called_once_with(
+            request,
             storage.update_annotation.return_value)
     assert result == presenter.asdict()
 

--- a/h/api/views.py
+++ b/h/api/views.py
@@ -139,9 +139,11 @@ def search(request):
                             separate_replies=separate_replies)
 
     # Run the results through the JSON presenter
-    out['rows'] = [_present_searchdict(a) for a in out['rows']]
+    out['rows'] = [_present_searchdict(request, a)
+                   for a in out['rows']]
     if separate_replies:
-        out['replies'] = [_present_searchdict(a) for a in out['replies']]
+        out['replies'] = [_present_searchdict(request, a)
+                          for a in out['replies']]
 
     return out
 
@@ -157,14 +159,14 @@ def create(request):
 
     _publish_annotation_event(request, annotation, 'create')
 
-    presenter = AnnotationJSONPresenter(annotation)
+    presenter = AnnotationJSONPresenter(request, annotation)
     return presenter.asdict()
 
 
 @api_config(route_name='api.annotation', request_method='GET', permission='read')
 def read(annotation, request):
     """Return the annotation (simply how it was stored in the database)."""
-    presenter = AnnotationJSONPresenter(annotation)
+    presenter = AnnotationJSONPresenter(request, annotation)
     return presenter.asdict()
 
 
@@ -177,7 +179,7 @@ def update(annotation, request):
 
     _publish_annotation_event(request, annotation, 'update')
 
-    presenter = AnnotationJSONPresenter(annotation)
+    presenter = AnnotationJSONPresenter(request, annotation)
     return presenter.asdict()
 
 
@@ -208,10 +210,10 @@ def _json_payload(request):
         raise PayloadError()
 
 
-def _present_searchdict(mapping):
+def _present_searchdict(request, mapping):
     """Run an object returned from search through a presenter."""
     ann = storage.annotation_from_dict(mapping)
-    return AnnotationJSONPresenter(ann).asdict()
+    return AnnotationJSONPresenter(request, ann).asdict()
 
 
 def _publish_annotation_event(request, annotation, action):


### PR DESCRIPTION
Expose a `links` property on annotations, which can be used to store and retrieve (from the client-side) hypermedia references to other representations or related URLs for the annotation.