### PR TITLE
(1/3) Open sidebar and set selection when '#annotations' URL fragment is present

### DIFF
--- a/h/browser/chrome/test/hypothesis-chrome-extension-test.js
+++ b/h/browser/chrome/test/hypothesis-chrome-extension-test.js
@@ -35,7 +35,6 @@ describe('HypothesisChromeExtension', function () {
   var fakeHelpPage;
   var fakeTabStore;
   var fakeTabState;
-  var fakeTabErrorCache;
   var fakeBrowserAction;
   var fakeSidebarInjector;
 
@@ -96,7 +95,7 @@ describe('HypothesisChromeExtension', function () {
     };
 
     function FakeTabState(initialState, onchange) {
-      fakeTabState.onChangeHandler = onchange
+      fakeTabState.onChangeHandler = onchange;
     }
     FakeTabState.prototype = fakeTabState;
 
@@ -206,13 +205,13 @@ describe('HypothesisChromeExtension', function () {
       }
 
       beforeEach(function () {
-        fakeTabState.clearTab = sandbox.spy()
+        fakeTabState.clearTab = sandbox.spy();
         fakeTabState.isTabActive = function (tabId) {
           return tabState[tabId].state === TabState.states.ACTIVE;
         };
         fakeTabState.isTabErrored = function (tabId) {
           return tabState[tabId].state === TabState.states.ERRORED;
-        }
+        };
         fakeTabState.getState = function (tabId) {
           return tabState[tabId];
         };
@@ -242,6 +241,13 @@ describe('HypothesisChromeExtension', function () {
       it('resets the tab state to active if errored', function () {
         var tab = createTab({state: TabState.states.ERRORED});
         fakeChromeTabs.onUpdated.listener(tab.id, {status: 'loading'}, tab);
+        assert.equal(tabState[tab.id].state, TabState.states.ACTIVE);
+      });
+
+      it('injects the sidebar if a direct link is present', function () {
+        var tab = createTab();
+        tab.url += '#annotations:456';
+        fakeChromeTabs.onUpdated.listener(tab.id, {status: 'complete'}, tab);
         assert.equal(tabState[tab.id].state, TabState.states.ACTIVE);
       });
     });

--- a/h/static/scripts/annotation-ui.js
+++ b/h/static/scripts/annotation-ui.js
@@ -2,10 +2,18 @@
 
 function value(selection) {
   if (Object.keys(selection).length) {
-    return selection;
+    return Object.freeze(selection);
   } else {
     return null;
   }
+}
+
+function initialSelection(settings) {
+  var selection = {};
+  if (settings.annotations) {
+    selection[settings.annotations] = true;
+  }
+  return value(selection);
 }
 
 /**
@@ -17,7 +25,9 @@ function value(selection) {
  * - The state of the bucket bar
  *
  */
-module.exports = function () {
+
+// @ngInject
+module.exports = function (settings) {
   return {
     visibleHighlights: false,
 
@@ -25,7 +35,7 @@ module.exports = function () {
     focusedAnnotationMap: null,
 
     // Contains a map of annotation id:true pairs.
-    selectedAnnotationMap: null,
+    selectedAnnotationMap: initialSelection(settings),
 
     /**
      * @ngdoc method
@@ -62,17 +72,19 @@ module.exports = function () {
     },
 
     /**
-     * @ngdoc method
-     * @name annotationUI.selectAnnotations
-     * @returns nothing
-     * @description Takes an array of annotation objects and uses them to
-     * set the selectedAnnotationMap property.
+     * Set the currently selected annotation IDs.
+     *
+     * @param {Array<string|{id:string}>} annotations - Annotations or IDs
+     *        of annotations to select.
      */
     selectAnnotations: function (annotations) {
       var selection = {};
-      for (var i = 0, annotation; i < annotations.length; i++) {
-        annotation = annotations[i];
-        selection[annotation.id] = true;
+      for (var i = 0; i < annotations.length; i++) {
+        if (typeof annotations[i] === 'string') {
+          selection[annotations[i]] = true;
+        } else {
+          selection[annotations[i].id] = true;
+        }
       }
       this.selectedAnnotationMap = value(selection);
     },

--- a/h/static/scripts/annotator/config.js
+++ b/h/static/scripts/annotator/config.js
@@ -1,0 +1,31 @@
+'use strict';
+
+var docs = 'https://h.readthedocs.org/en/latest/hacking/customized-embedding.html';
+
+/**
+ * Reads the Hypothesis configuration from the environment.
+ *
+ * @param {Window} window_ - The Window object to read config from.
+ */
+function config(window_) {
+  var options = {
+    app: window_.
+      document.querySelector('link[type="application/annotator+html"]').href,
+  };
+
+  if (window_.hasOwnProperty('hypothesisConfig')) {
+    if (typeof window_.hypothesisConfig === 'function') {
+      Object.assign(options, window_.hypothesisConfig());
+    } else {
+      throw new TypeError('hypothesisConfig must be a function, see: ' + docs);
+    }
+  }
+
+  var annotFragmentMatch = window_.location.hash.match(/^#annotations:(.*)/);
+  if (annotFragmentMatch) {
+    options.annotations = annotFragmentMatch[1];
+  }
+  return options;
+}
+
+module.exports = config;

--- a/h/static/scripts/annotator/host.coffee
+++ b/h/static/scripts/annotator/host.coffee
@@ -1,13 +1,15 @@
 Annotator = require('annotator')
+queryString = require('query-string')
 $ = Annotator.$
 
 Guest = require('./guest')
 
-
 module.exports = class Host extends Guest
   constructor: (element, options) ->
-    if options.firstRun
-      options.app += (if '?' in options.app then '&' else '?') + 'firstrun'
+    appOpts = queryString.stringify(
+      Object.assign({}, options, {app: undefined})
+    )
+    options.app += (if '?' in options.app then '&' else '?') + appOpts
 
     # Create the iframe
     app = $('<iframe></iframe>')

--- a/h/static/scripts/annotator/main.js
+++ b/h/static/scripts/annotator/main.js
@@ -1,6 +1,7 @@
+'use strict';
+
 require('../polyfills');
 
-var extend = require('extend');
 var Annotator = require('annotator');
 
 // Polyfills
@@ -32,23 +33,11 @@ Annotator.Plugin.CrossFrame.AnnotationSync = require('../annotation-sync');
 Annotator.Plugin.CrossFrame.Bridge = require('../bridge');
 Annotator.Plugin.CrossFrame.Discovery = require('../discovery');
 
-var docs = 'https://h.readthedocs.org/en/latest/hacking/customized-embedding.html';
 var appLinkEl =
   document.querySelector('link[type="application/annotator+html"]');
-var options = {
-  app: appLinkEl.href,
-};
-
-if (window.hasOwnProperty('hypothesisConfig')) {
-  if (typeof window.hypothesisConfig === 'function') {
-    extend(options, window.hypothesisConfig());
-  } else {
-    throw new TypeError('hypothesisConfig must be a function, see: ' + docs);
-  }
-}
+var options = require('./config')(window);
 
 Annotator.noConflict().$.noConflict(true)(function() {
-  'use strict';
   var Klass = window.PDFViewerApplication ?
       Annotator.PdfSidebar :
       Annotator.Sidebar;

--- a/h/static/scripts/annotator/sidebar.coffee
+++ b/h/static/scripts/annotator/sidebar.coffee
@@ -24,7 +24,7 @@ module.exports = class Sidebar extends Host
     super
     this.hide()
 
-    if options.firstRun
+    if options.firstRun || options.annotations
       this.on 'panelReady', => this.show()
 
     if @plugins.BucketBar?

--- a/h/static/scripts/annotator/test/config-test.js
+++ b/h/static/scripts/annotator/test/config-test.js
@@ -1,0 +1,45 @@
+'use strict';
+
+var config = require('../config');
+
+describe('annotator configuration', function () {
+  var fakeWindowBase = {
+    document: {
+      querySelector: sinon.stub().returns({href: 'app.html'}),
+    },
+    location: {hash: ''},
+  };
+
+  it('reads the app src from the link tag', function () {
+    var linkEl = document.createElement('link');
+    linkEl.type = 'application/annotator+html';
+    linkEl.href = 'https://test.hypothes.is/app.html';
+    document.head.appendChild(linkEl);
+    assert.deepEqual(config(window), {
+      app: linkEl.href,
+    });
+    document.head.removeChild(linkEl);
+  });
+
+  it('reads the #annotation query fragment', function () {
+    var fakeWindow = Object.assign({}, fakeWindowBase, {
+      location: {hash:'#annotations:456'},
+    });
+    assert.deepEqual(config(fakeWindow), {
+      app: 'app.html',
+      annotations: '456',
+    });
+  });
+
+  it('merges the config from hypothesisConfig()', function () {
+    var fakeWindow = Object.assign({}, fakeWindowBase, {
+      hypothesisConfig: function () {
+        return {firstRun: true};
+      },
+    });
+    assert.deepEqual(config(fakeWindow), {
+      app: 'app.html',
+      firstRun: true,
+    });
+  });
+});

--- a/h/static/scripts/annotator/test/host-test.coffee
+++ b/h/static/scripts/annotator/test/host-test.coffee
@@ -84,3 +84,11 @@ describe 'Host', ->
         assert.isTrue(host.visibleHighlights)
         done()
       host.publish('panelReady')
+
+    it 'passes options to the sidebar iframe', ->
+      appURL = 'http://localhost:1000/app.html'
+      host = createHost({
+        app: appURL,
+        annotations: '1234'
+      })
+      assert.equal(host.frame[0].children[0].src, appURL + '?annotations=1234')

--- a/h/static/scripts/app-controller.js
+++ b/h/static/scripts/app-controller.js
@@ -24,7 +24,7 @@ function authStateFromUserID(userid) {
 module.exports = function AppController(
   $controller, $document, $location, $rootScope, $route, $scope,
   $window, annotationUI, auth, drafts, features, groups,
-  session
+  session, settings
 ) {
   $controller('AnnotationUIController', {$scope: $scope});
 
@@ -41,8 +41,6 @@ module.exports = function AppController(
 
   // Allow all child scopes access to the session
   $scope.session = session;
-
-  var isFirstRun = $location.search().hasOwnProperty('firstrun');
 
   // App dialogs
   $scope.accountDialog = {visible: false};
@@ -73,7 +71,7 @@ module.exports = function AppController(
     // update the auth info in the top bar and show the login form
     // after first install of the extension.
     $scope.auth = authStateFromUserID(state.userid);
-    if (!state.userid && isFirstRun) {
+    if (!state.userid && settings.firstRun) {
       $scope.login();
     }
   });

--- a/h/static/scripts/app.js
+++ b/h/static/scripts/app.js
@@ -1,10 +1,12 @@
 'use strict';
 
 require('./polyfills');
+var queryString = require('query-string');
 
 // Initialize Raven. This is required at the top of this file
 // so that it happens early in the app's startup flow
 var settings = require('./settings')(document);
+Object.assign(settings, queryString.parse(window.location.search));
 if (settings.raven) {
   var raven = require('./raven');
   raven.init(settings.raven);

--- a/h/static/scripts/test/annotation-ui-test.js
+++ b/h/static/scripts/test/annotation-ui-test.js
@@ -1,10 +1,25 @@
 'use strict';
 
+var annotationUIFactory = require('../annotation-ui');
+
 describe('annotationUI', function () {
   var annotationUI;
 
   beforeEach(function () {
-    annotationUI = require('../annotation-ui')();
+    annotationUI = annotationUIFactory({});
+  });
+
+  describe('initialization', function () {
+    it('does not set a selection when settings.annotations is null', function () {
+      assert.isFalse(annotationUI.hasSelectedAnnotations());
+    });
+
+    it('sets the selection when settings.annotations is set', function () {
+      annotationUI = annotationUIFactory({annotations: 'testid'});
+      assert.deepEqual(annotationUI.selectedAnnotationMap, {
+        testid: true,
+      });
+    });
   });
 
   describe('.focusAnnotations()', function () {

--- a/h/static/scripts/test/app-controller-test.js
+++ b/h/static/scripts/test/app-controller-test.js
@@ -15,6 +15,7 @@ describe('AppController', function () {
   var fakeLocation = null;
   var fakeParams = null;
   var fakeSession = null;
+  var fakeSettings = null;
   var fakeGroups = null;
   var fakeRoute = null;
   var fakeSettings = null;

--- a/h/static/scripts/test/app-controller-test.js
+++ b/h/static/scripts/test/app-controller-test.js
@@ -15,7 +15,6 @@ describe('AppController', function () {
   var fakeLocation = null;
   var fakeParams = null;
   var fakeSession = null;
-  var fakeSettings = null;
   var fakeGroups = null;
   var fakeRoute = null;
   var fakeSettings = null;


### PR DESCRIPTION
This is the first part of adding support for '#annotations' URL fragments in the client.
This PR covers:

1. Detecting when a tab URL contains '#annotations' and automatically injecting H in the Chrome extension
2. Detecting when Annotator is loaded into a document (by the extension, bookmarklet or embedder) containing '#annotations' in the URL fragment, automatically opening the sidebar and passing the annotation ID through to the client
3. Initializing the annotation selection from the value passed through in step (2)

Subsequent PRs will cover:
 1. Switching the focused group to the one containing the annotation, if necessary
 2. Preserving the intent to select an annotation after signing in
 3. Displaying a suitable message if the user does not have permission to access the annotation