### PR TITLE
Annotation links round 2

### DIFF
--- a/h/api/__init__.py
+++ b/h/api/__init__.py
@@ -3,6 +3,7 @@
 
 def includeme(config):
     config.include('h.api.db')
+    config.include('h.api.presenters')
     config.include('h.api.search')
     config.include('h.api.views')
 

--- a/h/api/presenters.py
+++ b/h/api/presenters.py
@@ -189,7 +189,14 @@ def deep_merge_dict(a, b):
             a[k] = v
 
 
+def _json_link(request, annotation):
+    return request.route_url('api.annotation', id=annotation.id)
+
+
 def includeme(config):
     config.add_directive(
         'add_annotation_link_generator',
         lambda c, n, g: add_annotation_link_generator(c.registry, n, g))
+
+    # Add a default 'json' link type
+    config.add_annotation_link_generator('json', _json_link)

--- a/h/api/presenters.py
+++ b/h/api/presenters.py
@@ -21,8 +21,12 @@ class AnnotationBasePresenter(object):
         # :py:func:`h.api.presenters.add_annotation_link_generator` for
         # details.
         link_generators = self.request.registry.get(LINK_GENERATORS_KEY, {})
-        return {name: generator(self.request, self.annotation)
-                for name, generator in link_generators.items()}
+        out = {}
+        for name, generator in link_generators.items():
+            link = generator(self.request, self.annotation)
+            if link is not None:
+                out[name] = link
+        return out
 
 
 class AnnotationJSONPresenter(AnnotationBasePresenter):

--- a/h/api/presenters.py
+++ b/h/api/presenters.py
@@ -6,6 +6,8 @@ Presenters for API data.
 import collections
 import copy
 
+LINK_GENERATORS_KEY = 'h.api.presenters.link_generators'
+
 
 class AnnotationBasePresenter(object):
     def __init__(self, request, annotation):
@@ -14,10 +16,14 @@ class AnnotationBasePresenter(object):
 
     @property
     def links(self):
-        return {
-            'json': self.request.route_url('api.annotation',
-                                           id=self.annotation.id),
-        }
+        """A dictionary of named hypermedia links for this annotation."""
+        # Named link generators are registered elsewhere in the code. See
+        # :py:func:`h.api.presenters.add_annotation_link_generator` for
+        # details.
+        link_generators = self.request.registry.get(LINK_GENERATORS_KEY, {})
+        return {name: generator(self.request, self.annotation)
+                for name, generator in link_generators.items()}
+
 
 class AnnotationJSONPresenter(AnnotationBasePresenter):
     def asdict(self):
@@ -152,6 +158,21 @@ class DocumentURIJSONPresenter(object):
             return self.document_uri.type[4:]
 
 
+def add_annotation_link_generator(registry, name, generator):
+    """
+    Registers a function which generates a named link for an annotation.
+
+    Annotation hypermedia links are added to the rendered annotations in a
+    `links` property or similar. `name` is the unique identifier for the link
+    type, and `generator` is a callable which accepts two arguments -- the
+    current request, and the annotation for which to generate a link -- and
+    returns a string.
+    """
+    if LINK_GENERATORS_KEY not in registry:
+        registry[LINK_GENERATORS_KEY] = {}
+    registry[LINK_GENERATORS_KEY][name] = generator
+
+
 def utc_iso8601(datetime):
     return datetime.strftime('%Y-%m-%dT%H:%M:%S.%f+00:00')
 
@@ -166,3 +187,9 @@ def deep_merge_dict(a, b):
             deep_merge_dict(a[k], v)
         else:
             a[k] = v
+
+
+def includeme(config):
+    config.add_directive(
+        'add_annotation_link_generator',
+        lambda c, n, g: add_annotation_link_generator(c.registry, n, g))

--- a/h/api/presenters.py
+++ b/h/api/presenters.py
@@ -4,6 +4,7 @@ Presenters for API data.
 """
 
 import collections
+import copy
 
 
 class AnnotationBasePresenter(object):
@@ -40,7 +41,7 @@ class AnnotationJSONPresenter(AnnotationBasePresenter):
         if self.annotation.references:
             base['references'] = self.annotation.references
 
-        annotation = self.annotation.extra or {}
+        annotation = copy.copy(self.annotation.extra) or {}
         annotation.update(base)
 
         return annotation

--- a/h/api/test/presenters_test.py
+++ b/h/api/test/presenters_test.py
@@ -40,12 +40,25 @@ class TestAnnotationBasePresenter(object):
     def test_links_includes_registered_links(self):
         request = DummyRequest()
         annotation = mock.Mock()
-        dummy_link_generator = mock.Mock()
-        dummy_link_generator.return_value = 'http://foo.com/bar/123'
-
         add_annotation_link_generator(request.registry,
                                       'giraffe',
-                                      dummy_link_generator)
+                                      lambda r, a: 'http://foo.com/bar/123')
+
+        links = AnnotationBasePresenter(request, annotation).links
+
+        assert links == {
+            'giraffe': 'http://foo.com/bar/123'
+        }
+
+    def test_links_omits_link_generators_that_return_none(self):
+        request = DummyRequest()
+        annotation = mock.Mock()
+        add_annotation_link_generator(request.registry,
+                                      'giraffe',
+                                      lambda r, a: 'http://foo.com/bar/123')
+        add_annotation_link_generator(request.registry,
+                                      'donkey',
+                                      lambda r, a: None)
 
         links = AnnotationBasePresenter(request, annotation).links
 
@@ -57,7 +70,6 @@ class TestAnnotationBasePresenter(object):
         request = DummyRequest()
         annotation = mock.Mock()
         dummy_link_generator = mock.Mock(return_value='')
-
         add_annotation_link_generator(request.registry,
                                       'giraffe',
                                       dummy_link_generator)

--- a/h/api/test/presenters_test.py
+++ b/h/api/test/presenters_test.py
@@ -93,6 +93,17 @@ class TestAnnotationJSONPresenter(object):
         presented = AnnotationJSONPresenter(request, ann).asdict()
         assert presented['id'] == 'the-real-id'
 
+    def test_asdict_extra_uses_copy_of_extra(self, document_asdict):
+        extra = {'foo': 'bar'}
+        request = DummyRequest()
+        ann = mock.Mock(id='my-id', extra=extra)
+        document_asdict.return_value = {}
+
+        presented = AnnotationJSONPresenter(request, ann).asdict()
+
+        # Presenting the annotation shouldn't change the "extra" dict.
+        assert extra == {'foo': 'bar'}
+
     def test_text(self):
         request = DummyRequest()
         ann = mock.Mock(text='It is magical!')

--- a/h/api/test/presenters_test.py
+++ b/h/api/test/presenters_test.py
@@ -10,6 +10,7 @@ from h.api.presenters import AnnotationJSONPresenter
 from h.api.presenters import DocumentJSONPresenter
 from h.api.presenters import DocumentMetaJSONPresenter
 from h.api.presenters import DocumentURIJSONPresenter
+from h.api.presenters import add_annotation_link_generator
 from h.api.presenters import utc_iso8601, deep_merge_dict
 
 
@@ -28,22 +29,45 @@ class TestAnnotationBasePresenter(object):
         assert presenter.request == request
         assert presenter.annotation == annotation
 
-    def test_links(self):
+    def test_links_empty(self):
         request = DummyRequest()
         annotation = mock.Mock()
 
         links = AnnotationBasePresenter(request, annotation).links
 
-        assert 'json' in links
-        assert links['json'] == 'http://example.com/dummy/abc123'
+        assert links == {}
+
+    def test_links_includes_registered_links(self):
+        request = DummyRequest()
+        annotation = mock.Mock()
+        dummy_link_generator = mock.Mock()
+        dummy_link_generator.return_value = 'http://foo.com/bar/123'
+
+        add_annotation_link_generator(request.registry,
+                                      'giraffe',
+                                      dummy_link_generator)
+
+        links = AnnotationBasePresenter(request, annotation).links
+
+        assert links == {
+            'giraffe': 'http://foo.com/bar/123'
+        }
+
+    def test_link_generators_called_with_request_and_annotation(self):
+        request = DummyRequest()
+        annotation = mock.Mock()
+        dummy_link_generator = mock.Mock(return_value='')
+
+        add_annotation_link_generator(request.registry,
+                                      'giraffe',
+                                      dummy_link_generator)
+
+        links = AnnotationBasePresenter(request, annotation).links
+
+        dummy_link_generator.assert_called_once_with(request, annotation)
 
 
 class TestAnnotationJSONPresenter(object):
-
-    @pytest.fixture(autouse=True)
-    def link_routes(self, routes_mapper):
-        routes_mapper.add_route('api.annotation', '/dummy/abc123')
-
     def test_asdict(self, document_asdict):
         request = DummyRequest()
         ann = mock.Mock(id='the-id',
@@ -76,7 +100,7 @@ class TestAnnotationJSONPresenter(object):
                     'target': [{'source': 'http://example.com',
                                 'selector': [{'TestSelector': 'foobar'}]}],
                     'document': {'foo': 'bar'},
-                    'links': {'json': 'http://example.com/dummy/abc123'},
+                    'links': {},
                     'references': ['referenced-id-1', 'referenced-id-2'],
                     'extra-1': 'foo',
                     'extra-2': 'bar'}
@@ -103,6 +127,25 @@ class TestAnnotationJSONPresenter(object):
 
         # Presenting the annotation shouldn't change the "extra" dict.
         assert extra == {'foo': 'bar'}
+
+    def test_asdict_with_link_generators(self, document_asdict):
+        request = DummyRequest()
+        ann = mock.Mock(id='my-id', extra={})
+        document_asdict.return_value = {}
+
+        add_annotation_link_generator(request.registry,
+                                      'giraffe',
+                                      lambda r, a: 'http://giraffe.com')
+        add_annotation_link_generator(request.registry,
+                                      'withid',
+                                      lambda r, a: 'http://withid.com/' + a.id)
+
+        presented = AnnotationJSONPresenter(request, ann).asdict()
+
+        assert presented['links'] == {
+            'giraffe': 'http://giraffe.com',
+            'withid': 'http://withid.com/my-id',
+        }
 
     def test_text(self):
         request = DummyRequest()

--- a/h/app.py
+++ b/h/app.py
@@ -92,6 +92,14 @@ def includeme(config):
         },
     })
 
+    # API module
+    #
+    # We include this first so that:
+    # - configuration directives provided by modules in `h.api` are available
+    #   to the rest of the application at startup.
+    # - we can override behaviour from `h.api` if necessary.
+    config.include('h.api', route_prefix='/api')
+
     # Core site modules
     config.include('h.assets')
     config.include('h.auth')
@@ -105,7 +113,6 @@ def includeme(config):
     config.include('h.views')
 
     # Site modules
-    config.include('h.api', route_prefix='/api')
     config.include('h.accounts')
     config.include('h.admin', route_prefix='/admin')
     config.include('h.badge')

--- a/h/config.py
+++ b/h/config.py
@@ -73,6 +73,7 @@ SETTINGS = [
     EnvSetting('csp.report_only', 'CSP_REPORT_ONLY'),
     EnvSetting('ga_tracking_id', 'GOOGLE_ANALYTICS_TRACKING_ID'),
     EnvSetting('h.auth_domain', 'AUTH_DOMAIN'),
+    EnvSetting('h.bouncer_url', 'BOUNCER_URL'),
     EnvSetting('h.client_id', 'CLIENT_ID'),
     EnvSetting('h.client_secret', 'CLIENT_SECRET'),
     EnvSetting('h.db.should_create_all', 'MODEL_CREATE_ALL', type=asbool),

--- a/h/features.py
+++ b/h/features.py
@@ -16,6 +16,7 @@ log = logging.getLogger(__name__)
 
 FEATURES = {
     'claim': "Enable 'claim your username' web views?",
+    'direct_linking': "Generate direct links to annotations in context in the client?",
     'new_homepage': "Show the new homepage design?",
     'ops_disable_streamer_uri_equivalence': "[Ops] Disable streamer URI equivalence support?",
     'postgres_read': 'Use postgres to fetch annotations from storage'

--- a/h/views/main.py
+++ b/h/views/main.py
@@ -79,5 +79,15 @@ def stream_user_redirect(request):
     raise httpexceptions.HTTPFound(location=location)
 
 
+def _html_link(request, annotation):
+    """Generate a link to an HTML representation of an annotation."""
+    return request.route_url('annotation', id=annotation.id)
+
+
 def includeme(config):
     config.scan(__name__)
+
+    # Add an annotation link generator for the `annotation` view -- this adds a
+    # named link called "html" to API rendered views of annotations. See
+    # :py:mod:`h.api.presenters` for details.
+    config.add_annotation_link_generator('html', _html_link)


### PR DESCRIPTION
This PR makes it possible for us to generate `incontext` links on rendered annotations for direct linking. See previous discussion in #3049.

It's split into a series of commits that probably make most sense to review one by one. In order, they do the following:

1. Fixes a bug in the annotation presenter class.
2. Makes the generation of annotation `links` properties extensible, so that we don't have to hard-code Hypothesis-specific links in the `h.api` module.
3. Makes the default `json` link use this "link generator" functionality.
4. Ensures the "link generator" configurator hooks are available to the rest of the application.
5. Adds an `html` link type that points to the "standalone annotation page" -- this can replace the manual construction of such URLs client-side.
6. Makes it possible for a link generator to opt out of generating a link (needed so that direct linking can be toggled using a feature flag).
7. Adds the `direct_linking` feature flag.
8. Adds `incontext` links to annotations if a) the `direct_linking` flag is toggled on and b) `BOUNCER_URL` is set in the application environment.