### PR TITLE
Split out elastic.DocumentMeta type normalisation

### DIFF
--- a/h/api/models/elastic.py
+++ b/h/api/models/elastic.py
@@ -382,17 +382,26 @@ class DocumentMeta(dict):
 
     @property
     def type(self):
-        value = self.get('type')
+        return self.get('type')
+
+    @property
+    def value(self):
+        return self.get('value')
+
+    @property
+    def normalized_type(self):
+        """
+        Normalized version of the type string
+
+        This should only be used in the Postgres migration script.
+        """
+        value = self.type
         if value:
             value = value.lower().replace(':', '.')
             value = re.sub(r'\.{2,}', '.', value)
             value = re.sub(r'^og\.', 'facebook.', value)
 
         return value
-
-    @property
-    def value(self):
-        return self.get('value')
 
 
 class DocumentURI(dict):

--- a/h/api/models/test/elastic_test.py
+++ b/h/api/models/test/elastic_test.py
@@ -443,22 +443,6 @@ class TestDocumentMeta(object):
         meta = DocumentMeta({'type': 'title'})
         assert meta.type == 'title'
 
-    def test_type_normalizes_multiple_dots(self):
-        meta = DocumentMeta({'type': 'dc..description'})
-        assert meta.type == 'dc.description'
-
-    def test_type_normalizes_case(self):
-        meta = DocumentMeta({'type': 'dc.Contributor.Sponsor'})
-        assert meta.type == 'dc.contributor.sponsor'
-
-    def test_type_normalizes_colons(self):
-        meta = DocumentMeta({'type': 'facebook.book:isbn'})
-        assert meta.type == 'facebook.book.isbn'
-
-    def test_type_normalizes_og(self):
-        meta = DocumentMeta({'type': 'og.title'})
-        assert meta.type == 'facebook.title'
-
     @pytest.mark.parametrize('type', ['oga.title', 'dc.og.title'])
     def test_type_skips_og_normalisation(self, type):
         meta = DocumentMeta({'type': type})
@@ -467,6 +451,22 @@ class TestDocumentMeta(object):
     def test_value(self):
         meta = DocumentMeta({'value': 'Example Page'})
         assert meta.value == 'Example Page'
+
+    def test_normalized_type_normalizes_multiple_dots(self):
+        meta = DocumentMeta({'type': 'dc..description'})
+        assert meta.normalized_type == 'dc.description'
+
+    def test_normalized_type_normalizes_case(self):
+        meta = DocumentMeta({'type': 'dc.Contributor.Sponsor'})
+        assert meta.normalized_type == 'dc.contributor.sponsor'
+
+    def test_normalized_type_normalizes_colons(self):
+        meta = DocumentMeta({'type': 'facebook.book:isbn'})
+        assert meta.normalized_type == 'facebook.book.isbn'
+
+    def test_normalized_type_normalizes_og(self):
+        meta = DocumentMeta({'type': 'og.title'})
+        assert meta.normalized_type == 'facebook.title'
 
 
 class TestDocumentURI(object):

--- a/scripts/migrate.py
+++ b/scripts/migrate.py
@@ -277,11 +277,11 @@ def create_or_update_document_uri(es_docuri, pg_document):
 def create_or_update_document_meta(es_meta, pg_document):
     meta = DocumentMeta.query.filter(
             DocumentMeta.claimant_normalized == es_meta.claimant_normalized,
-            DocumentMeta.type == es_meta.type).one_or_none()
+            DocumentMeta.type == es_meta.normalized_type).one_or_none()
 
     if meta is None:
         meta = DocumentMeta(claimant=es_meta.claimant,
-                            type=es_meta.type,
+                            type=es_meta.normalized_type,
                             value=es_meta.value,
                             created=es_meta.created,
                             updated=es_meta.updated,


### PR DESCRIPTION
Due to Elasticsearch's dynamic mapping creation, we can't normalise the
type string of an elastic DocumentMeta. Creating an annotation would
still work since it doesn't run this code, but updating an existing
annotation fails when it tries do create or update the Document ES
document because it uses the normalised version which then clashes with
the mapping that Elasticsearch automatically created based on old data.

I've moved the normalisation part into its own method
(`normalized_type`) in order to still be able to use it in the
migration, and thus automatically clean up our document metadata when we
migrate it from Elasticsearch to Postgres.

This bug was introduced when we merged #3011 and used the new
presentation layer for rendering Elasticsearch annotations.

Fixes #3062