### PR TITLE
Display message if a direct-linked annotation is not available

### DIFF
--- a/h/static/images/icons/lock.svg
+++ b/h/static/images/icons/lock.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="48px" height="56px" viewBox="0 0 48 56" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 3.6.1 (26313) - http://www.bohemiancoding.com/sketch -->
+    <title>Group 4 Copy 3</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Group-4-Copy-3" fill="#A6A6A6">
+            <rect id="Rectangle-34" x="0" y="24" width="48" height="32"></rect>
+            <path d="M24,0 C24,0 8,0 8,16 L8,32 L16,32 L16,16.0000004 C16,8 24,8 24,8 C24,8 32,8 32,16 L32,32 L40,32 L40,16 C40,0 24,0 24,0 Z" id="Path-52"></path>
+        </g>
+    </g>
+</svg>

--- a/h/static/scripts/test/widget-controller-test.js
+++ b/h/static/scripts/test/widget-controller-test.js
@@ -65,7 +65,8 @@ describe('WidgetController', function () {
       clearSelectedAnnotations: sandbox.spy(),
       selectedAnnotationMap: {},
       hasSelectedAnnotations: function () {
-        return Object.keys(this.selectedAnnotationMap).length > 0;
+        return !!this.selectedAnnotationMap &&
+               Object.keys(this.selectedAnnotationMap).length > 0;
       },
     };
     fakeCrossFrame = {
@@ -284,6 +285,28 @@ describe('WidgetController', function () {
         references: ['parent-id']
       });
       assert.notCalled($scope.clearSelection);
+    });
+  });
+
+  describe('direct linking messages', function () {
+    it('displays a message if the selection is unavailable', function () {
+      fakeAnnotationUI.selectedAnnotationMap = {'missing': true};
+      fakeThreading.idTable = {'123': {}};
+      $scope.$digest();
+      assert.isTrue($scope.selectedAnnotationUnavailable());
+    });
+
+    it('does not show a message if the selection is available', function () {
+      fakeAnnotationUI.selectedAnnotationMap = {'123': true};
+      fakeThreading.idTable = {'123': {}};
+      $scope.$digest();
+      assert.isFalse($scope.selectedAnnotationUnavailable());
+    });
+
+    it('does not a show a message if there is no selection', function () {
+      fakeAnnotationUI.selectedAnnotationMap = null;
+      $scope.$digest();
+      assert.isFalse($scope.selectedAnnotationUnavailable());
     });
   });
 });

--- a/h/static/scripts/widget-controller.js
+++ b/h/static/scripts/widget-controller.js
@@ -3,12 +3,22 @@
 var events = require('./events');
 var SearchClient = require('./search-client');
 
+function firstKey(object) {
+  for (var k in object) {
+    if (!object.hasOwnProperty(k)) {
+      continue;
+    }
+    return k;
+  }
+  return null;
+}
+
 /**
  * Returns the group ID of the first annotation in `results` whose
  * ID is a key in `selection`.
  */
 function groupIDFromSelection(selection, results) {
-  var id = Object.keys(selection)[0];
+  var id = firstKey(selection);
   var annot = results.find(function (annot) {
     return annot.id === id;
   });
@@ -191,6 +201,12 @@ module.exports = function WidgetController(
       return false;
     }
     return annotation.$$tag in $scope.focusedAnnotations;
+  };
+
+  $scope.selectedAnnotationUnavailable = function () {
+    return searchClients.length === 0 &&
+           annotationUI.hasSelectedAnnotations() &&
+           !threading.idTable[firstKey(annotationUI.selectedAnnotationMap)];
   };
 
   $rootScope.$on(events.BEFORE_ANNOTATION_CREATED, function (event, data) {

--- a/h/static/styles/thread.scss
+++ b/h/static/styles/thread.scss
@@ -31,7 +31,10 @@ $thread-padding: $annotation-card-left-padding;
   }
 
   &__icon {
-    font-size: 50px;
+    background-image: url(../images/icons/lock.svg);
+    background-repeat: no-repeat;
+    width: 56px;
+    height: 48px;
   }
 }
 

--- a/h/static/styles/thread.scss
+++ b/h/static/styles/thread.scss
@@ -15,6 +15,26 @@ $thread-padding: $annotation-card-left-padding;
   }
 }
 
+.annotation-unavailable-message {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid $gray-lighter;
+  padding-top: 30px;
+  padding-bottom: 30px;
+  border-radius: 3px;
+  align-items: center;
+
+  &__label {
+    margin-top: 10px;
+    max-width: 160px;
+    text-align: center;
+  }
+
+  &__icon {
+    font-size: 50px;
+  }
+}
+
 .thread-replies .thread:first-child {
   margin-top: 0.5em;
 }

--- a/h/templates/client/viewer.html
+++ b/h/templates/client/viewer.html
@@ -21,6 +21,13 @@
       on-change-sort-by="sort.name = sortBy">
     </sort-dropdown>
   </li>
+  <li class="annotation-unavailable-message"
+      ng-if="selectedAnnotationUnavailable()">
+    <span class="h-icon-lock annotation-unavailable-message__icon"></span>
+    <p class="annotation-unavailable-message__label">
+      You do not have permission to see this annotation
+    </p>
+  </li>
   <li id="{{vm.id}}"
       class="annotation-card thread"
       ng-class="{'js-hover': hasFocus(child.message)}"

--- a/h/templates/client/viewer.html
+++ b/h/templates/client/viewer.html
@@ -23,7 +23,7 @@
   </li>
   <li class="annotation-unavailable-message"
       ng-if="selectedAnnotationUnavailable()">
-    <span class="h-icon-lock annotation-unavailable-message__icon"></span>
+    <div class="annotation-unavailable-message__icon"></div>
     <p class="annotation-unavailable-message__label">
       You do not have permission to see this annotation
     </p>


### PR DESCRIPTION
This is based on **#3108** and will need to be rebased and merged afterwards.

This adds a message in the sidebar which is displayed if a direct-linked annotation is selected but that annotation is not available, after fetching all annotations for the current page.