### PR TITLE
Postgres read support for storage.expand_uri

### DIFF
--- a/h/api/search/core.py
+++ b/h/api/search/core.py
@@ -76,7 +76,7 @@ def search(request, params, private=True, separate_replies=False):
 def default_querybuilder(request, private=True):
     builder = query.Builder()
     builder.append_filter(query.AuthFilter(request, private=private))
-    builder.append_filter(query.UriFilter())
+    builder.append_filter(query.UriFilter(request))
     builder.append_filter(query.GroupFilter())
     builder.append_matcher(query.AnyMatcher())
     builder.append_matcher(query.TagsMatcher())

--- a/h/api/search/query.py
+++ b/h/api/search/query.py
@@ -157,6 +157,14 @@ class UriFilter(object):
     A filter that selects only annotations where the 'uri' parameter matches.
     """
 
+    def __init__(self, request):
+        """Initialize a new UriFilter.
+
+        :param request: the pyramid.request object
+
+        """
+        self.request = request
+
     def __call__(self, params):
         uristr = params.pop('uri', None)
         if uristr is None:

--- a/h/api/search/query.py
+++ b/h/api/search/query.py
@@ -170,7 +170,8 @@ class UriFilter(object):
         if uristr is None:
             return None
 
-        scopes = [uri.normalize(u) for u in storage.expand_uri(uristr)]
+        uris = storage.expand_uri(self.request, uristr)
+        scopes = [uri.normalize(u) for u in uris]
         return {"terms": {"target.scope": scopes}}
 
 

--- a/h/api/search/test/query_test.py
+++ b/h/api/search/test/query_test.py
@@ -315,7 +315,7 @@ def test_urifilter_expands_and_normalizes_into_terms_filter(storage, uri):
     of the expansion.
     """
     request = mock.Mock()
-    storage.expand_uri.side_effect = lambda x: [
+    storage.expand_uri.side_effect = lambda _, x: [
         "http://giraffes.com/",
         "https://elephants.com/",
     ]
@@ -324,7 +324,7 @@ def test_urifilter_expands_and_normalizes_into_terms_filter(storage, uri):
 
     result = urifilter({"uri": "http://example.com/"})
 
-    storage.expand_uri.assert_called_with("http://example.com/")
+    storage.expand_uri.assert_called_with(request, "http://example.com/")
 
     assert result == {"terms":
         {"target.scope": ["http://giraffes.com", "https://elephants.com"]}

--- a/h/api/search/test/query_test.py
+++ b/h/api/search/test/query_test.py
@@ -298,7 +298,8 @@ def test_urifilter_inactive_when_no_uri_param():
     """
     When there's no `uri` parameter, return None.
     """
-    urifilter = query.UriFilter()
+    request = mock.Mock()
+    urifilter = query.UriFilter(request)
 
     assert urifilter({"foo": "bar"}) is None
 
@@ -313,12 +314,13 @@ def test_urifilter_expands_and_normalizes_into_terms_filter(storage, uri):
     It should expand the input URI before searching, and normalize the results
     of the expansion.
     """
+    request = mock.Mock()
     storage.expand_uri.side_effect = lambda x: [
         "http://giraffes.com/",
         "https://elephants.com/",
     ]
     uri.normalize.side_effect = lambda x: x[:-1]  # Strip the trailing slash
-    urifilter = query.UriFilter()
+    urifilter = query.UriFilter(request)
 
     result = urifilter({"uri": "http://example.com/"})
 

--- a/h/api/storage.py
+++ b/h/api/storage.py
@@ -32,6 +32,9 @@ def fetch_annotation(request, id):
     """
     Fetch the annotation with the given id.
 
+    :param request: the request object
+    :type request: pyramid.request.Request
+
     :param id: the annotation id
     :type id: str
 
@@ -47,6 +50,9 @@ def fetch_annotation(request, id):
 def create_annotation(request, data):
     """
     Create an annotation from passed data.
+
+    :param request: the request object
+    :type request: pyramid.request.Request
 
     :param data: a dictionary of annotation properties
     :type data: dict
@@ -70,8 +76,12 @@ def update_annotation(request, id, data):
     This executes a partial update of the annotation identified by `id` using
     the passed data.
 
+    :param request: the request object
+    :type request: pyramid.request.Request
+
     :param id: the annotation id
     :type id: str
+
     :param data: a dictionary of annotation properties
     :type data: dict
 
@@ -92,6 +102,9 @@ def delete_annotation(request, id):
     """
     Delete the annotation with the given id.
 
+    :param request: the request object
+    :type request: pyramid.request.Request
+
     :param id: the annotation id
     :type id: str
     """
@@ -106,6 +119,9 @@ def expand_uri(request, uri):
     This function determines whether we already have "document" records for the
     passed URI, and if so returns the set of all URIs which we currently
     believe refer to the same document.
+
+    :param request: the request object
+    :type request: pyramid.request.Request
 
     :param uri: a URI associated with the document
     :type id: str

--- a/h/api/storage.py
+++ b/h/api/storage.py
@@ -99,7 +99,7 @@ def delete_annotation(request, id):
     annotation.delete()
 
 
-def expand_uri(uri):
+def expand_uri(request, uri):
     """
     Return all URIs which refer to the same underlying document as `uri`.
 

--- a/h/api/test/storage_test.py
+++ b/h/api/test/storage_test.py
@@ -35,11 +35,14 @@ def test_fetch_annotation_postgres(postgres_enabled):
 
 
 def test_expand_uri_no_document(document_model):
+    request = DummyRequest()
     document_model.get_by_uri.return_value = None
-    assert storage.expand_uri("http://example.com/") == ["http://example.com/"]
+    assert storage.expand_uri(request, "http://example.com/") == [
+            "http://example.com/"]
 
 
 def test_expand_uri_document_doesnt_expand_canonical_uris(document_model):
+    request = DummyRequest()
     document = document_model.get_by_uri.return_value
     document.get.return_value = [
         {"href": "http://foo.com/"},
@@ -51,15 +54,17 @@ def test_expand_uri_document_doesnt_expand_canonical_uris(document_model):
         "http://bar.com/",
         "http://example.com/",
     ]
-    assert storage.expand_uri("http://example.com/") == ["http://example.com/"]
+    assert storage.expand_uri(request, "http://example.com/") == [
+            "http://example.com/"]
 
 
 def test_expand_uri_document_uris(document_model):
+    request = DummyRequest()
     document_model.get_by_uri.return_value.uris.return_value = [
         "http://foo.com/",
         "http://bar.com/",
     ]
-    assert storage.expand_uri("http://example.com/") == [
+    assert storage.expand_uri(request, "http://example.com/") == [
         "http://foo.com/",
         "http://bar.com/",
     ]

--- a/h/streamer/websocket.py
+++ b/h/streamer/websocket.py
@@ -71,7 +71,7 @@ def handle_message(message):
             jsonschema.validate(payload, filter.SCHEMA)
 
             # Add backend expands for clauses
-            _expand_clauses(payload)
+            _expand_clauses(socket.request, payload)
 
             socket.filter = filter.FilterHandler(payload)
         elif msg_type == 'client_id':
@@ -83,13 +83,13 @@ def handle_message(message):
         raise
 
 
-def _expand_clauses(payload):
+def _expand_clauses(request, payload):
     for clause in payload['clauses']:
         if clause['field'] == '/uri':
-            _expand_uris(clause)
+            _expand_uris(request, clause)
 
 
-def _expand_uris(clause):
+def _expand_uris(request, clause):
     uris = clause['value']
     expanded = set()
 
@@ -97,6 +97,6 @@ def _expand_uris(clause):
         uris = [uris]
 
     for item in uris:
-        expanded.update(storage.expand_uri(item))
+        expanded.update(storage.expand_uri(request, item))
 
     clause['value'] = list(expanded)


### PR DESCRIPTION
I initially wanted to get the badge endpoint to be able to work with Postgres, later I've discovered that the badge endpoint doesn't take URI equivalence into account. The upside is that we now have Postgres support for `h.api.storage.expand_uri`.