### PR TITLE
Enable Chrome extension to detect when H is already present on page

### DIFF
--- a/h/browser/chrome/content/web/viewer.html
+++ b/h/browser/chrome/content/web/viewer.html
@@ -40,7 +40,6 @@ http://sourceforge.net/adobe/cmap/wiki/License/
 
     <script src="debugger.js"></script>
     <script src="viewer.js"></script>
-    <script src="../../public/config.js"></script>
     <script src="../../public/embed.js"></script>
 
   </head>
@@ -417,4 +416,3 @@ http://sourceforge.net/adobe/cmap/wiki/License/
 
   </body>
 </html>
-

--- a/h/browser/chrome/lib/destroy.js
+++ b/h/browser/chrome/lib/destroy.js
@@ -1,0 +1,15 @@
+// Script injected into the page to trigger removal of any existing instances
+// of the Hypothesis client.
+(function () {
+  'use strict';
+
+  var annotatorLink =
+    document.querySelector('link[type="application/annotator+html"]');
+
+  if (annotatorLink) {
+    // Dispatch a 'destroy' event which is handled by the code in
+    // annotator/main.js to remove the client.
+    var destroyEvent = new Event('destroy');
+    annotatorLink.dispatchEvent(destroyEvent);
+  }
+}());

--- a/h/browser/chrome/lib/errors.js
+++ b/h/browser/chrome/lib/errors.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var raven = require('../../../static/scripts/raven');
 
 function ExtensionError(message) {
@@ -30,6 +32,12 @@ function BlockedSiteError(message) {
 }
 BlockedSiteError.prototype = Object.create(ExtensionError.prototype);
 
+function AlreadyInjectedError(message) {
+  Error.apply(this, arguments);
+  this.message = message;
+}
+AlreadyInjectedError.prototype = Object.create(ExtensionError.prototype);
+
 /**
  * Returns true if @p err is a recognized 'expected' error.
  */
@@ -57,6 +65,7 @@ function report(error, when, context) {
 
 module.exports = {
   ExtensionError: ExtensionError,
+  AlreadyInjectedError: AlreadyInjectedError,
   LocalFileError: LocalFileError,
   NoFileAccessError: NoFileAccessError,
   RestrictedProtocolError: RestrictedProtocolError,

--- a/h/browser/chrome/lib/hypothesis-chrome-extension.js
+++ b/h/browser/chrome/lib/hypothesis-chrome-extension.js
@@ -218,6 +218,13 @@ function HypothesisChromeExtension(dependencies) {
       });
       return sidebar.injectIntoTab(tab)
         .catch(function (err) {
+          if (err instanceof errors.AlreadyInjectedError) {
+            state.setState(tab.id, {
+              state: TabState.states.INACTIVE,
+              extensionSidebarInstalled: false,
+            });
+            return;
+          }
           errors.report(err, 'Injecting Hypothesis sidebar', {
             url: tab.url,
           });

--- a/h/buildext.py
+++ b/h/buildext.py
@@ -182,9 +182,9 @@ def build_chrome(args):
         copyfilelist(src='build',
                      dst=public_dir,
                      filelist=client_sources)
-        copyfilelist(src='h/static/extension',
+        copyfilelist(src='h/browser/chrome/lib',
                      dst=public_dir,
-                     filelist=['config.js', 'destroy.js'])
+                     filelist=['destroy.js'])
     except MissingSourceFile as e:
         print("Missing source file: {:s}! Have you run `gulp build`?"
               .format(e))

--- a/h/static/extension/config.js
+++ b/h/static/extension/config.js
@@ -1,8 +1,0 @@
-function hypothesisConfig() {
-  // Pages on our site can include a meta tag to trigger specific behaviour
-  // when the extension loads.
-  var hypothesisIntent = document.querySelector('[name="hypothesis-intent"]');
-  return {
-    firstRun: hypothesisIntent && hypothesisIntent.content === 'first-run',
-  };
-}

--- a/h/static/extension/destroy.js
+++ b/h/static/extension/destroy.js
@@ -1,2 +1,0 @@
-if (window.annotator) window.annotator.destroy();
-delete window.annotator;

--- a/h/static/scripts/annotator/main.js
+++ b/h/static/scripts/annotator/main.js
@@ -33,8 +33,10 @@ Annotator.Plugin.CrossFrame.Bridge = require('../bridge');
 Annotator.Plugin.CrossFrame.Discovery = require('../discovery');
 
 var docs = 'https://h.readthedocs.org/en/latest/hacking/customized-embedding.html';
+var appLinkEl =
+  document.querySelector('link[type="application/annotator+html"]');
 var options = {
-  app: jQuery('link[type="application/annotator+html"]').attr('href')
+  app: appLinkEl.href,
 };
 
 if (window.hasOwnProperty('hypothesisConfig')) {
@@ -54,5 +56,11 @@ Annotator.noConflict().$.noConflict(true)(function() {
     Klass = options.constructor;
     delete options.constructor;
   }
+
   window.annotator = new Klass(document.body, options);
+  appLinkEl.addEventListener('destroy', function () {
+    appLinkEl.parentElement.removeChild(appLinkEl);
+    window.annotator.destroy();
+    window.annotator = undefined;
+  });
 });

--- a/h/static/scripts/test/promise-util.js
+++ b/h/static/scripts/test/promise-util.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * Takes a Promise<T> and returns a Promise<Result>
  * where Result = { result: T } | { error: any }.
@@ -9,7 +11,7 @@ function toResult(promise) {
   return promise.then(function (result) {
     return { result: result };
   }).catch(function (err) {
-    return { error: err }
+    return { error: err };
   });
 }
 

--- a/h/templates/embed.js.jinja2
+++ b/h/templates/embed.js.jinja2
@@ -1,16 +1,19 @@
 (function () {
-// Prevent double embedding
-if (typeof(window.annotator) === 'undefined') {
-    window.annotator = {};
-} else {
-    return;
+// Detect presence of Hypothesis in the page
+var appLinkEl = document.querySelector('link[type="application/annotator+html"]');
+if (appLinkEl) {
+  return {
+    installedURL: appLinkEl.href,
+  };
 }
 
+// When run from a Chrome extension, load
+// resources bundled with the extension
 var resourceRoot;
-var resourceRootTag =
-  document.querySelector('meta[name="hypothesis-resource-root"]');
-if (resourceRootTag) {
-  resourceRoot = resourceRootTag.content;
+if (window.chrome &&
+    window.chrome.extension &&
+    window.chrome.extension.getURL) {
+  resourceRoot = window.chrome.extension.getURL('/');
 }
 
 function resolve(url) {
@@ -88,4 +91,6 @@ baseUrl.type = 'application/annotator+html';
 document.head.appendChild(baseUrl);
 
 window.hypothesisInstall();
+
+return {installedURL: baseUrl.href};
 })();

--- a/h/templates/help.html.jinja2
+++ b/h/templates/help.html.jinja2
@@ -3,13 +3,10 @@
 {% block meta %}
   <link href='//fonts.googleapis.com/css?family=Lato:400,300' rel='stylesheet' type='text/css'>
   {{ super() }}
-  {% if is_onboarding %}
-    <meta name="hypothesis-intent" content="first-run" />
-  {% endif %}
+  <script>
+    function hypothesisConfig() { return {firstRun: true}; }
+  </script>
   {% if not is_onboarding %}
-    <script>
-      function hypothesisConfig() { return {firstRun: true} }
-    </script>
     <script async defer src="{{ embed_js_url }}"></script>
   {% endif %}
 {% endblock %}


### PR DESCRIPTION
This reworks the way that Hypothesis detects whether it is already present on the page in embed.js, in a way that enables it to report back the app.html URL for the existing instance to the Chrome extension.

The Chrome extension can then update its state for that tab to reflect the fact that it is not injected.

In this PR, that is done by simply setting the tab state to inactive. We could in future add an indicator that the user tried to activate H but that another instance is already active, or have the extension override the instance of H on the page.

 * Detect the <link> element added to the page by embed.js,
   rather than window.annotator. This enables detection to work
   when embed.js is run in an isolated world that shares the DOM
   but not the JS environment, as is the case for content scripts
   in Chrome and Firefox.

 * Change unloading to operate by firing an event at the <link>
   element. This enables a content script to trigger unloading
   of H from an isolated JS environment.

 * Change injection of embed.js in the Chrome extension to
   execute embed.js as a content script, rather than by
   adding it as a `<script>` tag. This enables embed.js to
   access extension APIs and also report its result back
   to the extension via the return value of the script.

   A side benefit is that it also avoids a bug in Firefox
   current WebExtensions implementation where `<script>` tags
   added to the page by a content script are not executed.