### PR TITLE
Only add self-claim DocumentURI when claimant is set

### DIFF
--- a/h/api/models/elastic.py
+++ b/h/api/models/elastic.py
@@ -289,6 +289,14 @@ class Document(document.Document):
         transformed = []
         links = self.get('link', [])
 
+        # add self-claim uri when claimant is not missing
+        if self.claimant:
+            transformed.append({'claimant': self.claimant,
+                                'uri': self.claimant,
+                                'type': 'self-claim',
+                                'created': self.created,
+                                'updated': self.updated})
+
         # When document link is just a string, transform it to a link object with
         # an href, so it gets further processed as either a self-claim or another
         # claim.
@@ -296,8 +304,7 @@ class Document(document.Document):
             links = [{"href": links}]
 
         for link in links:
-            # disregard self-claim urls as they're are being added separately
-            # later on.
+            # disregard self-claim urls as they have already been added
             if link.keys() == ['href'] and link['href'] == self.claimant:
                 continue
 
@@ -350,13 +357,6 @@ class Document(document.Document):
                                 'type': 'dc-doi',
                                 'created': self.created,
                                 'updated': self.updated})
-
-        # add self claim
-        transformed.append({'claimant': self.claimant,
-                            'uri': self.claimant,
-                            'type': 'self-claim',
-                            'created': self.created,
-                            'updated': self.updated})
 
         return transformed
 

--- a/h/api/models/test/elastic_test.py
+++ b/h/api/models/test/elastic_test.py
@@ -335,11 +335,18 @@ class TestDocument(object):
 
         assert doc.document_uris == expected
 
+    def test_uris_discard_self_claim_when_claimant_is_missing(self):
+        doc = Document({'link': [{'href': 'http://example.com'}]})
+        expected = [DocumentURI({'claimant': None,
+                                 'uri': 'http://example.com',
+                                 'type': None,
+                                 'content_type': None,
+                                 'created': None, 'updated': None})]
+        assert doc.document_uris == expected
+
     def test_uris_disregard_doi_links(self):
         doc = Document({'link': [{'href': 'doi:foobar'}]})
-        # it always includes a self-claim, not removing doi links would result
-        # in a length of 2
-        assert len(doc.document_uris) == 1
+        assert len(doc.document_uris) == 0
 
     def test_uris_str_link(self):
         doc = Document({'link': 'http://example.com'},


### PR DESCRIPTION
When this is being used from a Document that has been loaded from
Elasticsearch (e.g. when expanding URIs), we don't have the claimant in
the Document, which means there is no point in adding a self-claim URI
where the `uri` field would be missing.