### PR TITLE
Refactor feature flag to access through Client + caching

### DIFF
--- a/h/session.py
+++ b/h/session.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from pyramid.session import SignedCookieSessionFactory
 
-from h import features
 from h import models
 from h.security import derive_key
 
@@ -11,7 +10,7 @@ def model(request):
     session['csrf'] = request.session.get_csrf_token()
     session['userid'] = request.authenticated_userid
     session['groups'] = _current_groups(request)
-    session['features'] = features.all(request)
+    session['features'] = request.feature.all()
     session['preferences'] = {}
     user = request.authenticated_user
     if user and not user.sidebar_tutorial_dismissed:

--- a/h/test/session_test.py
+++ b/h/test/session_test.py
@@ -27,14 +27,13 @@ def test_model_sorts_groups(User):
     assert ids == ['__world__', 'c', 'a', 'b']
 
 
-@mock.patch('h.session.features', autospec=True)
-def test_model_includes_features(features, fake_user):
+def test_model_includes_features(fake_user):
     feature_dict = {
         'feature_one': True,
         'feature_two': False,
     }
-    features.all = mock.Mock(return_value=feature_dict)
     request = mock.Mock(authenticated_user=fake_user)
+    request.feature.all.return_value = feature_dict
 
     assert session.model(request)['features'] == feature_dict
 


### PR DESCRIPTION
Which allows us to keep the same usage
`request.feature('new-feature-name')`, but the database access is much
more optimised.

As soon as `request.feature` is accessed, we go to the database and read
the state of all feature flags into memory, Pyramid then memoizes the
client and subsequent calls to check if a given feature flag is enabled
or not are going directly to the internal cache within the request
lifecycle.