### PR TITLE
Cached features and workers

### DIFF
--- a/h/mailer.py
+++ b/h/mailer.py
@@ -43,6 +43,8 @@ def worker(request):
     """
     def handle_message(_, message):
         """Receive a message from nsq and send it as an email."""
+        request.feature.reload()
+
         body = json.loads(message.body)
         email = pyramid_mailer.message.Message(
             subject=body["subject"], recipients=body["recipients"],

--- a/h/nipsa/worker.py
+++ b/h/nipsa/worker.py
@@ -57,6 +57,8 @@ def worker(request):
     """
     def handle_message(_, message):
         """Handle a message on the "nipsa_users_annotations" channel."""
+        request.feature.reload()
+
         add_or_remove_nipsa(
             client=request.es.conn,
             index=request.es.index,

--- a/h/notification/worker.py
+++ b/h/notification/worker.py
@@ -18,6 +18,8 @@ def run(request):
     round-robin fashion.
     """
     def handle_message(reader, message=None):
+        request.feature.reload()
+
         if message is None:
             return
         with request.tm:


### PR DESCRIPTION
We need to manually reload the feature cache when handling new messages in the workers, since the Pyramid requests we use in the workers are long-lived. In fact, they live as long as the worker python process exists.