### PR TITLE
Refactor feature caching

### DIFF
--- a/h/mailer.py
+++ b/h/mailer.py
@@ -43,6 +43,8 @@ def worker(request):
     """
     def handle_message(_, message):
         """Receive a message from nsq and send it as an email."""
+        request.feature.clear()
+
         body = json.loads(message.body)
         email = pyramid_mailer.message.Message(
             subject=body["subject"], recipients=body["recipients"],

--- a/h/nipsa/worker.py
+++ b/h/nipsa/worker.py
@@ -57,6 +57,8 @@ def worker(request):
     """
     def handle_message(_, message):
         """Handle a message on the "nipsa_users_annotations" channel."""
+        request.feature.clear()
+
         add_or_remove_nipsa(
             client=request.es.conn,
             index=request.es.index,

--- a/h/notification/worker.py
+++ b/h/notification/worker.py
@@ -18,6 +18,8 @@ def run(request):
     round-robin fashion.
     """
     def handle_message(reader, message=None):
+        request.feature.clear()
+
         if message is None:
             return
         with request.tm:

--- a/h/streamer/test/websocket_test.py
+++ b/h/streamer/test/websocket_test.py
@@ -52,6 +52,15 @@ def test_socket_enqueues_incoming_messages():
     assert result.payload == 'client data'
 
 
+def test_handle_message_clears_feature_cache():
+    socket = mock.Mock()
+    message = websocket.Message(socket=socket, payload=json.dumps({
+        'messageType': 'foo'}))
+    websocket.handle_message(message)
+
+    socket.request.feature.clear.assert_called_with()
+
+
 def test_handle_message_sets_socket_client_id_for_client_id_messages():
     socket = mock.Mock()
     socket.client_id = None

--- a/h/streamer/websocket.py
+++ b/h/streamer/websocket.py
@@ -58,6 +58,7 @@ class WebSocket(_WebSocket):
 
 def handle_message(message):
     socket = message.socket
+    socket.request.feature.clear()
 
     data = json.loads(message.payload)
 


### PR DESCRIPTION
Instead of loading all features from the database when the Client is
initialized, this will only load the features from the database when the
actual state of the flags is accessed through either `enabled` or `all`.

The reason for this refactoring is that we have long-lived requests in
the `streamer` and package, and for the workers. These requests live for
as long as the Python process does, which means that we have to manually
invalidate the cache when a new chunk of work is about to get handled.

With the old caching mechanism, this meant that the only way to
invalidate the cache is to load the state of the flags from the
database. This solution however adds more roundtrips to Postgres, since
most websocket work and worker jobs don't rely on features at the
moment, so there's no need to load them from the database. But to
prevent weird behaviour in the future, there is a need to invalidate the
cache.

This changes the caching mechanism to only load the state of the
flags from the database when the state of one particular feature is
accessed. Thus allowing us to have a `clear()` method that only resets
the internal caching variable to an empty dictionary.

The methods that rely on the cache being loaded will now first check if
the cache is already loaded, if not, they will call `load()` first, and
then access the flags through the fresh cache.