### PR TITLE
Change icon size in the bucket bar

### DIFF
--- a/h/static/styles/annotator/inject.scss
+++ b/h/static/styles/annotator/inject.scss
@@ -186,7 +186,7 @@ $base-font-size: 14px;
     height: 30px;
     width: 30px;
     padding: 0;
-    font-size: 18px;
+    font-size: 16px;
     margin-bottom: 5px;
 
     &:active {


### PR DESCRIPTION
Changing the icon size from 18px to 16px to get rid of fuzzy icons.