### PR TITLE
Replace '@p <ident>' with `ident` in JSDoc comments

### DIFF
--- a/h/browser/chrome/lib/errors.js
+++ b/h/browser/chrome/lib/errors.js
@@ -39,7 +39,7 @@ function AlreadyInjectedError(message) {
 AlreadyInjectedError.prototype = Object.create(ExtensionError.prototype);
 
 /**
- * Returns true if @p err is a recognized 'expected' error.
+ * Returns true if `err` is a recognized 'expected' error.
  */
 function isKnownError(err) {
   return err instanceof ExtensionError;

--- a/h/browser/chrome/lib/sidebar-injector.js
+++ b/h/browser/chrome/lib/sidebar-injector.js
@@ -259,7 +259,7 @@ function SidebarInjector(chromeTabs, dependencies) {
   }
 
   /**
-   * Inject the script from the source file at @p path into the
+   * Inject the script from the source file at `path` into the
    * page currently loaded in the tab at the given ID.
    */
   function injectScript(tabId, path) {

--- a/h/static/scripts/markdown-commands.js
+++ b/h/static/scripts/markdown-commands.js
@@ -34,7 +34,7 @@ var LinkType = {
  * @param {EditorState} state - The state of the input field.
  * @param {number} pos - The start position of the text to remove.
  * @param {number} length - The number of characters to remove.
- * @param {string} text - The replacement text to insert at @p pos.
+ * @param {string} text - The replacement text to insert at `pos`.
  * @return {EditorState} - The new state of the input field.
  */
 function replaceText(state, pos, length, text) {

--- a/h/static/scripts/raven.js
+++ b/h/static/scripts/raven.js
@@ -46,7 +46,7 @@ function convertLocalURLsToFilenames(url) {
 }
 
 /**
- * Return a transformed version of @p data with local URLs replaced
+ * Return a transformed version of `data` with local URLs replaced
  * with filenames.
  *
  * In environments where the client is served from a local URL,

--- a/h/static/scripts/widget-controller.js
+++ b/h/static/scripts/widget-controller.js
@@ -103,7 +103,7 @@ module.exports = function WidgetController(
   }
 
   /**
-   * Load annotations for all URLs associated with @p frames.
+   * Load annotations for all URLs associated with `frames`.
    *
    * @param {Array<{uri:string}>} frames - Hypothesis client frames
    *        to load annotations for.

--- a/scripts/gulp/upload-to-sentry.js
+++ b/scripts/gulp/upload-to-sentry.js
@@ -87,7 +87,7 @@ function uploadReleaseFile(opts, project, release, file) {
  * Upload a stream of Vinyl files as a Sentry release.
  *
  * This creates a new release in Sentry using the organization, project
- * and release settings in @p opts and uploads the input stream of Vinyl
+ * and release settings in `opts` and uploads the input stream of Vinyl
  * files as artefacts for the release.
  *
  * @param {SentryOptions} opts


### PR DESCRIPTION
Using '@p $ident' to refer to parameters in JSDoc comments is not legal
syntax. Use Markdown backticks instead, ala. Angular's docs.