### PR TITLE
Remove user status bitfield

### DIFF
--- a/h/accounts/models.py
+++ b/h/accounts/models.py
@@ -103,7 +103,6 @@ class User(Base):
                                                   self._set_username))
 
     email = sa.Column(sa.UnicodeText(), nullable=False, unique=True)
-    status = sa.Column(sa.Integer())
 
     last_login_date = sa.Column(sa.TIMESTAMP(timezone=False),
                                 default=datetime.datetime.utcnow,

--- a/h/accounts/models.py
+++ b/h/accounts/models.py
@@ -216,51 +216,6 @@ class User(Base):
         uid = _username_to_uid(username)
         return cls.query.filter(cls.uid == uid).first()
 
-    # TODO: remove all this status bitfield stuff
-    @property
-    def email_confirmed(self):
-        return bool((self.status or 0) & 0b001)
-
-    @email_confirmed.setter
-    def email_confirmed(self, value):
-        if value:
-            self.status = (self.status or 0) | 0b001
-        else:
-            self.status = (self.status or 0) & ~0b001
-
-    @property
-    def optout(self):
-        return bool((self.status or 0) & 0b010)
-
-    @optout.setter
-    def optout(self, value):
-        if value:
-            self.status = (self.status or 0) | 0b010
-        else:
-            self.status = (self.status or 0) & ~0b010
-
-    @property
-    def subscriptions(self):
-        return bool((self.status or 0) & 0b100)
-
-    @subscriptions.setter
-    def subscriptions(self, value):
-        if value:
-            self.status = (self.status or 0) | 0b100
-        else:
-            self.status = (self.status or 0) & ~0b100
-
-    @property
-    def invited(self):
-        return bool((self.status or 0) & 0b1000)
-
-    @invited.setter
-    def invited(self, value):
-        if value:
-            self.status = (self.status or 0) | 0b1000
-        else:
-            self.status = (self.status or 0) & ~0b1000
-
     @classmethod
     def admins(cls):
         """Return a list of all admin users."""

--- a/h/migrations/versions/0d4755a0d88b_remove_status_column_from_user_table.py
+++ b/h/migrations/versions/0d4755a0d88b_remove_status_column_from_user_table.py
@@ -1,0 +1,24 @@
+"""Remove status column from user table
+
+Revision ID: 0d4755a0d88b
+Revises: 2494fea98d2d
+Create Date: 2016-03-21 20:07:07.002482
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '0d4755a0d88b'
+down_revision = '2494fea98d2d'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    # Dropping a column is O(1) so this is safe to run against a production
+    # database.
+    op.drop_column('user', 'status')
+
+
+def downgrade():
+    op.add_column('user', sa.Column('status', sa.Integer()))

--- a/h/notification/reply_template.py
+++ b/h/notification/reply_template.py
@@ -173,7 +173,6 @@ def registration_subscriptions(event):
     request = event.request
     user_uri = 'acct:{}@{}'.format(event.user.username, request.domain)
     create_subscription(event.request, user_uri, True)
-    event.user.subscriptions = True
 
 
 # For backwards compatibility, generate reply notification if not exists
@@ -185,7 +184,6 @@ def check_reply_subscriptions(event):
                                                        types.REPLY_TYPE)
     if not len(res):
         create_subscription(event.request, user_uri, True)
-        event.user.subscriptions = True
 
 
 def includeme(config):


### PR DESCRIPTION
Remove a bunch of unused legacy properties from the user model. In some cases (`subscriptions`) it's not even clear that they were ever meaningfully used.

Each of `email_confirmed`, `optout`, and `invited` appear nowhere else in the code. `subscriptions` is referenced (and set) by `h.notifications` but appears to serve no purpose.

This PR also adds a schema migration to drop the `status` column from the `user` table. `ALTER TABLE ... DROP COLUMN` is an `O(1)` operation so this is safe to run against production as soon as the code updates have gone all the way out to production.