### PR TITLE
Support filtering test suites to run using '--grep' argument to gulp

### DIFF
--- a/docs/hacking/install.rst
+++ b/docs/hacking/install.rst
@@ -257,9 +257,12 @@ source code. To start the test runner in auto-watch mode, run:
 
     gulp test-watch-app
 
-You can further speed up the testing cycle for front-end code by using
-mocha's `.only()`_ to only run a particular suite of tests or even just
-a single test.
+To run only a subset of tests for front-end code, use the ``--grep``
+argument or mocha's `.only()`_ modifier.
+
+.. code-block:: bash
+
+    gulp test-watch-app --grep <pattern>
 
 .. _.only(): http://jaketrent.com/post/run-single-mocha-test/
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "browserify-ngannotate": "^1.0.1",
     "browserify-shim": "^3.8.12",
     "coffeeify": "^1.0.0",
+    "commander": "^2.9.0",
     "compass-mixins": "^0.12.7",
     "core-js": "^1.2.5",
     "diff-match-patch": "^1.0.0",


### PR DESCRIPTION
Add support for filtering the tests that are run by Gulp test tasks
using '--grep <pattern>'.

This avoids the need to use the `(describe|it).only` test modifiers to
filter the tests that are run.

The pattern argument is a JS regex expression which is passed directly
to mocha as the 'grep' option.

eg. To start the app test suite in auto-restart mode, but only run tests
for the markdown editor, run:

  gulp test-watch-app --grep markdown