### PR TITLE
Add Visual Studio Code project config file for JS

### DIFF
--- a/h/static/scripts/tsconfig.json
+++ b/h/static/scripts/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "target": "ES5",
+    "module": "commonjs",
+    "allowJs": true
+  }
+}


### PR DESCRIPTION
In combination with JSDoc annotations, this enables IntelliSense,
project navigation, inline documentation, refactoring and other goodies
using Visual Studio Code and other IDEs that integrate with TypeScript's
Language Service for JavaScript (aka.  'Salsa').

See https://code.visualstudio.com/docs/languages/javascript

The project file can be named either `jsconfig.json` without 'allowJs'
or `tsconfig.json` with the 'allowJs' config option enabled. I've opted
for `tsconfig.json` because that turns up better documentation on the
web and is recognized by more tools.

The project config file lives in h/static/scripts so that Visual Studio
only tries to parse and process .js files under that directory.  The
config file does support specifying the set of files to include, but
each file currently has to be listed individually. Glob support is
planned for the future. See
https://github.com/Microsoft/TypeScript/issues/1927