### PR TITLE
Use specific Sentry DSN for the client part of H

### DIFF
--- a/h/config.py
+++ b/h/config.py
@@ -79,6 +79,9 @@ SETTINGS = [
     EnvSetting('h.db.should_create_all', 'MODEL_CREATE_ALL', type=asbool),
     EnvSetting('h.db.should_drop_all', 'MODEL_DROP_ALL', type=asbool),
     EnvSetting('h.websocket_url', 'H_WEBSOCKET_URL'),
+    # The client Sentry DSN should be of the public kind, lacking the password
+    # component in the DSN URI.
+    EnvSetting('h.client.sentry_dsn', 'SENTRY_DSN_CLIENT'),
 
     # Debug/development settings
     EnvSetting('debug_query', 'DEBUG_QUERY'),

--- a/h/views/client.py
+++ b/h/views/client.py
@@ -21,6 +21,7 @@ from h.util.view import json_view
 
 def render_app(request, extra=None):
     """Render a page that serves a preconfigured annotation client."""
+    client_sentry_dsn = request.registry.settings.get('h.client.sentry_dsn')
     html = client.render_app_html(
         assets_env=request.assets_env,
         # FIXME: The '' here is to ensure this has a trailing slash. This seems
@@ -29,7 +30,7 @@ def render_app(request, extra=None):
         api_url=request.route_url('api.index'),
         service_url=request.route_url('index'),
         ga_tracking_id=request.registry.settings.get('ga_tracking_id'),
-        sentry_public_dsn=request.sentry.get_public_dsn(),
+        sentry_public_dsn=client_sentry_dsn,
         websocket_url=request.registry.settings.get('h.websocket_url'),
         extra=extra)
     request.response.text = html


### PR DESCRIPTION
Which lets us use the `prod-client`/`stage-client` Sentry projects for both the extension and the client part of hosted H.