### PR TITLE
Preserve selection when switching accounts

### DIFF
--- a/h/static/scripts/annotation-mapper.js
+++ b/h/static/scripts/annotation-mapper.js
@@ -1,5 +1,8 @@
 'use strict';
 
+var angular = require('angular');
+
+var events = require('./events');
 
 // Fetch the container object for the passed annotation from the threading
 // service, but only return it if it has an associated message.
@@ -28,14 +31,14 @@ function annotationMapper($rootScope, threading, store) {
       var container = getContainer(threading, annotation);
       if (container !== null) {
         angular.copy(annotation, container.message);
-        $rootScope.$emit('annotationUpdated', container.message);
+        $rootScope.$emit(events.ANNOTATION_UPDATED, container.message);
         return;
       }
 
       loaded.push(new store.AnnotationResource(annotation));
     });
 
-    $rootScope.$emit('annotationsLoaded', loaded);
+    $rootScope.$emit(events.ANNOTATIONS_LOADED, loaded);
   }
 
   function unloadAnnotations(annotations) {
@@ -45,13 +48,13 @@ function annotationMapper($rootScope, threading, store) {
         annotation = angular.copy(annotation, container.message);
       }
 
-      $rootScope.$emit('annotationDeleted', annotation);
+      $rootScope.$emit(events.ANNOTATION_DELETED, annotation);
     });
   }
 
   function createAnnotation(annotation) {
     annotation = new store.AnnotationResource(annotation);
-    $rootScope.$emit('beforeAnnotationCreated', annotation);
+    $rootScope.$emit(events.BEFORE_ANNOTATION_CREATED, annotation);
     return annotation;
   }
 
@@ -59,7 +62,7 @@ function annotationMapper($rootScope, threading, store) {
     return annotation.$delete({
       id: annotation.id
     }).then(function () {
-      $rootScope.$emit('annotationDeleted', annotation);
+      $rootScope.$emit(events.ANNOTATION_DELETED, annotation);
       return annotation;
     });
   }

--- a/h/static/scripts/annotation-mapper.js
+++ b/h/static/scripts/annotation-mapper.js
@@ -42,14 +42,14 @@ function annotationMapper($rootScope, threading, store) {
   }
 
   function unloadAnnotations(annotations) {
-    annotations.forEach(function (annotation) {
+    var unloaded = annotations.map(function (annotation) {
       var container = getContainer(threading, annotation);
       if (container !== null && annotation !== container.message) {
         annotation = angular.copy(annotation, container.message);
       }
-
-      $rootScope.$emit(events.ANNOTATION_DELETED, annotation);
+      return annotation;
     });
+    $rootScope.$emit(events.ANNOTATIONS_UNLOADED, unloaded);
   }
 
   function createAnnotation(annotation) {

--- a/h/static/scripts/annotation-sync.coffee
+++ b/h/static/scripts/annotation-sync.coffee
@@ -130,6 +130,15 @@ module.exports = class AnnotationSync
       return unless bodies.length
       @bridge.call('loadAnnotations', bodies)
 
+    'annotationsUnloaded': (annotations) ->
+      self = this
+      annotations.forEach (annotation) ->
+        # In the client, unloading an annotation is handled the same way as
+        # deleting an annotation. Within the app however, we handle the events
+        # differently in some cases
+        delete self.cache[annotation.$$tag]
+        self._mkCallRemotelyAndParseResults('deleteAnnotation')(annotation)
+
   _syncCache: (channel) ->
     # Synchronise (here to there) the items in our cache
     annotations = (this._format a for t, a of @cache)

--- a/h/static/scripts/annotation-ui-controller.js
+++ b/h/static/scripts/annotation-ui-controller.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var events = require('./events');
+
 /** Watch the UI state and update scope properties. */
 // @ngInject
 function AnnotationUIController($rootScope, $scope, annotationUI) {
@@ -24,7 +26,7 @@ function AnnotationUIController($rootScope, $scope, annotationUI) {
     $scope.focusedAnnotations = map;
   });
 
-  $rootScope.$on('annotationDeleted', function (event, annotation) {
+  $rootScope.$on(events.ANNOTATION_DELETED, function (event, annotation) {
     annotationUI.removeSelectedAnnotation(annotation);
   });
 }

--- a/h/static/scripts/app-controller.js
+++ b/h/static/scripts/app-controller.js
@@ -123,11 +123,9 @@ module.exports = function AppController(
     if (!promptToLogout()) {
       return;
     }
-    var iterable = drafts.unsaved();
-    for (var i = 0, draft; i < iterable.length; i++) {
-      draft = iterable[i];
-      $rootScope.$emit("annotationDeleted", draft);
-    }
+    drafts.unsaved().forEach(function (draft) {
+      $rootScope.$emit(events.ANNOTATION_DELETED, draft);
+    });
     drafts.discard();
     $scope.accountDialog.visible = false;
     return auth.logout();

--- a/h/static/scripts/drafts.js
+++ b/h/static/scripts/drafts.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * The drafts service provides temporary storage for unsaved edits to new or
  * existing annotations.

--- a/h/static/scripts/events.js
+++ b/h/static/scripts/events.js
@@ -35,6 +35,9 @@ module.exports = {
   /** An annotation was either deleted or unloaded. */
   ANNOTATION_DELETED: 'annotationDeleted',
 
+  /** An annotation has been updated. */
+  ANNOTATION_UPDATED: 'annotationUpdated',
+
   /** A set of annotations were loaded from the server. */
   ANNOTATIONS_LOADED: 'annotationsLoaded',
 };

--- a/h/static/scripts/events.js
+++ b/h/static/scripts/events.js
@@ -40,4 +40,7 @@ module.exports = {
 
   /** A set of annotations were loaded from the server. */
   ANNOTATIONS_LOADED: 'annotationsLoaded',
+
+  /** An annotation is unloaded. */
+  ANNOTATIONS_UNLOADED: 'annotationsUnloaded',
 };

--- a/h/static/scripts/test/annotation-mapper-test.js
+++ b/h/static/scripts/test/annotation-mapper-test.js
@@ -38,7 +38,7 @@ describe('annotationMapper', function() {
     sandbox.restore();
   });
 
-  describe('.loadAnnotations()', function () {
+  describe('#loadAnnotations()', function () {
     it('triggers the annotationLoaded event', function () {
       sandbox.stub($rootScope, '$emit');
       var annotations = [{id: 1}, {id: 2}, {id: 3}];
@@ -108,14 +108,13 @@ describe('annotationMapper', function() {
     });
   });
 
-  describe('.unloadAnnotations()', function () {
-    it('triggers the annotationDeleted event', function () {
+  describe('#unloadAnnotations()', function () {
+    it('triggers the annotationsUnloaded event', function () {
       sandbox.stub($rootScope, '$emit');
       var annotations = [{id: 1}, {id: 2}, {id: 3}];
       annotationMapper.unloadAnnotations(annotations);
-      annotations.forEach(function (annot) {
-        assert.calledWith($rootScope.$emit, events.ANNOTATION_DELETED, annot);
-      });
+      assert.calledWith($rootScope.$emit,
+        events.ANNOTATIONS_UNLOADED, annotations);
     });
 
     it('replaces the properties on the cached annotation with those from the deleted one', function () {
@@ -125,14 +124,14 @@ describe('annotationMapper', function() {
       fakeThreading.idTable[1] = cached;
 
       annotationMapper.unloadAnnotations(annotations);
-      assert.calledWith($rootScope.$emit, events.ANNOTATION_DELETED, {
+      assert.calledWith($rootScope.$emit, events.ANNOTATIONS_UNLOADED, [{
         id: 1,
         url: 'http://example.com'
-      });
+      }]);
     });
   });
 
-  describe('.createAnnotation()', function () {
+  describe('#createAnnotation()', function () {
     it('creates a new annotaton resource', function () {
       var ann = {};
       fakeStore.AnnotationResource.returns(ann);
@@ -157,7 +156,7 @@ describe('annotationMapper', function() {
     });
   });
 
-  describe('.deleteAnnotation()', function () {
+  describe('#deleteAnnotation()', function () {
     it('deletes the annotation on the server', function () {
       var p = Promise.resolve();
       var ann = {$delete: sandbox.stub().returns(p)};

--- a/h/static/scripts/test/annotation-mapper-test.js
+++ b/h/static/scripts/test/annotation-mapper-test.js
@@ -1,5 +1,9 @@
 'use strict';
 
+var angular = require('angular');
+
+var events = require('../events');
+
 describe('annotationMapper', function() {
   var sandbox = sinon.sandbox.create();
   var $rootScope;
@@ -40,16 +44,18 @@ describe('annotationMapper', function() {
       var annotations = [{id: 1}, {id: 2}, {id: 3}];
       annotationMapper.loadAnnotations(annotations);
       assert.called($rootScope.$emit);
-      assert.calledWith($rootScope.$emit, 'annotationsLoaded', [{}, {}, {}]);
+      assert.calledWith($rootScope.$emit, events.ANNOTATIONS_LOADED,
+        [{}, {}, {}]);
     });
 
     it('also includes replies in the annotationLoaded event', function () {
       sandbox.stub($rootScope, '$emit');
-      var annotations = [{id: 1}]
+      var annotations = [{id: 1}];
       var replies = [{id: 2}, {id: 3}];
       annotationMapper.loadAnnotations(annotations, replies);
       assert.called($rootScope.$emit);
-      assert.calledWith($rootScope.$emit, 'annotationsLoaded', [{}, {}, {}]);
+      assert.calledWith($rootScope.$emit, events.ANNOTATIONS_LOADED,
+        [{}, {}, {}]);
     });
 
     it('triggers the annotationUpdated event for each annotation in the threading cache', function () {
@@ -60,7 +66,8 @@ describe('annotationMapper', function() {
 
       annotationMapper.loadAnnotations(annotations);
       assert.called($rootScope.$emit);
-      assert.calledWith($rootScope.$emit, 'annotationUpdated', cached.message);
+      assert.calledWith($rootScope.$emit, events.ANNOTATION_UPDATED,
+        cached.message);
     });
 
     it('also triggers annotationUpdated for cached replies', function () {
@@ -71,7 +78,8 @@ describe('annotationMapper', function() {
       fakeThreading.idTable[3] = cached;
 
       annotationMapper.loadAnnotations(annotations, replies);
-      assert($rootScope.$emit.calledWith("annotationUpdated", {id: 3}))
+      assert($rootScope.$emit.calledWith(events.ANNOTATION_UPDATED,
+        {id: 3}));
     });
 
     it('replaces the properties on the cached annotation with those from the loaded one', function () {
@@ -82,7 +90,7 @@ describe('annotationMapper', function() {
 
       annotationMapper.loadAnnotations(annotations);
       assert.called($rootScope.$emit);
-      assert.calledWith($rootScope.$emit, 'annotationUpdated', {
+      assert.calledWith($rootScope.$emit, events.ANNOTATION_UPDATED, {
         id: 1,
         url: 'http://example.com'
       });
@@ -96,7 +104,7 @@ describe('annotationMapper', function() {
 
       annotationMapper.loadAnnotations(annotations);
       assert.called($rootScope.$emit);
-      assert.calledWith($rootScope.$emit, 'annotationsLoaded', []);
+      assert.calledWith($rootScope.$emit, events.ANNOTATIONS_LOADED, []);
     });
   });
 
@@ -105,10 +113,9 @@ describe('annotationMapper', function() {
       sandbox.stub($rootScope, '$emit');
       var annotations = [{id: 1}, {id: 2}, {id: 3}];
       annotationMapper.unloadAnnotations(annotations);
-      assert.called($rootScope.$emit);
-      assert.calledWith($rootScope.$emit, 'annotationDeleted', annotations[0]);
-      assert.calledWith($rootScope.$emit, 'annotationDeleted', annotations[1]);
-      assert.calledWith($rootScope.$emit, 'annotationDeleted', annotations[2]);
+      annotations.forEach(function (annot) {
+        assert.calledWith($rootScope.$emit, events.ANNOTATION_DELETED, annot);
+      });
     });
 
     it('replaces the properties on the cached annotation with those from the deleted one', function () {
@@ -118,8 +125,7 @@ describe('annotationMapper', function() {
       fakeThreading.idTable[1] = cached;
 
       annotationMapper.unloadAnnotations(annotations);
-      assert.called($rootScope.$emit);
-      assert.calledWith($rootScope.$emit, 'annotationDeleted', {
+      assert.calledWith($rootScope.$emit, events.ANNOTATION_DELETED, {
         id: 1,
         url: 'http://example.com'
       });
@@ -146,7 +152,8 @@ describe('annotationMapper', function() {
       var ann = {};
       fakeStore.AnnotationResource.returns(ann);
       annotationMapper.createAnnotation();
-      assert.calledWith($rootScope.$emit, 'beforeAnnotationCreated', ann);
+      assert.calledWith($rootScope.$emit,
+        events.BEFORE_ANNOTATION_CREATED, ann);
     });
   });
 
@@ -163,8 +170,8 @@ describe('annotationMapper', function() {
       var p = Promise.resolve();
       var ann = {$delete: sandbox.stub().returns(p)};
       annotationMapper.deleteAnnotation(ann).then(function () {
-        assert.called($rootScope.$emit);
-        assert.calledWith($rootScope.$emit, 'annotationDeleted', ann);
+        assert.calledWith($rootScope.$emit,
+          events.ANNOTATION_DELETED, ann);
       }).then(done, done);
       $rootScope.$apply();
     });

--- a/h/static/scripts/test/annotation-sync-test.coffee
+++ b/h/static/scripts/test/annotation-sync-test.coffee
@@ -300,6 +300,23 @@ describe 'AnnotationSync', ->
 
         assert.notCalled(fakeBridge.call)
 
+    describe 'the "annotationsUnloaded" event', ->
+      it 'sends calls to delete the annotations over the bridge', ->
+        ann = {id: 1, $$tag: 'tag1'}
+        annSync = createAnnotationSync()
+        annSync.cache.tag1 = ann
+        options.emit('annotationsUnloaded', [ann])
+
+        assert.calledWith(fakeBridge.call, 'deleteAnnotation',
+          {msg: ann, tag: ann.$$tag}, sinon.match.func)
+
+      it 'removes the annotations from the cache', ->
+        ann = {id: 1, $$tag: 'tag1'}
+        annSync = createAnnotationSync()
+        annSync.cache.tag1 = ann
+        options.emit('annotationsUnloaded', [ann])
+        assert.isUndefined(annSync.cache.tag1)
+
     describe 'the "annotationsLoaded" event', ->
       it 'formats the provided annotations', ->
         annotations = [{id: 1}, {id: 2}, {id: 3}]

--- a/h/static/scripts/test/threading-test.coffee
+++ b/h/static/scripts/test/threading-test.coffee
@@ -1,7 +1,11 @@
 {module, inject} = angular.mock
 
+events = require('../events')
+threading = require('../threading')
+
 describe 'Threading', ->
   instance = null
+  $rootScope = null
 
   before ->
     angular.module('h', [])
@@ -9,8 +13,16 @@ describe 'Threading', ->
 
   beforeEach module('h')
 
-  beforeEach inject (_threading_) ->
+  beforeEach inject (_threading_, _$rootScope_) ->
     instance = _threading_
+    $rootScope = _$rootScope_
+
+  describe 'when an annotation is unloaded', ->
+    it 'removes the annotation from the thread', ->
+      $rootScope.$broadcast(events.ANNOTATIONS_LOADED, [{id: 'a'}])
+      assert.equal(instance.root.children.length, 1)
+      $rootScope.$broadcast(events.ANNOTATIONS_UNLOADED, [{id: 'a'}])
+      assert.equal(instance.root.children.length, 0)
 
   describe 'pruneEmpties', ->
     it 'keeps public messages with no children', ->

--- a/h/static/scripts/threading.coffee
+++ b/h/static/scripts/threading.coffee
@@ -36,6 +36,7 @@ module.exports = class Threading
     $rootScope.$on(events.ANNOTATION_CREATED, this.annotationCreated)
     $rootScope.$on(events.ANNOTATION_DELETED, this.annotationDeleted)
     $rootScope.$on(events.ANNOTATIONS_LOADED, this.annotationsLoaded)
+    $rootScope.$on(events.ANNOTATIONS_UNLOADED, this.annotationsUnloaded)
 
   # TODO: Refactor the jwz API for progressive updates.
   # Right now the idTable is wiped when `messageThread.thread()` is called and
@@ -117,6 +118,10 @@ module.exports = class Threading
         child.message = null
         this.pruneEmpties(@root)
         break
+
+  annotationsUnloaded: (event, annotations) =>
+    for annot in annotations
+      this.annotationDeleted(event, annot)
 
   annotationsLoaded: (event, annotations) =>
     messages = (@root.flattenChildren() or []).concat(annotations)

--- a/h/static/scripts/widget-controller.js
+++ b/h/static/scripts/widget-controller.js
@@ -179,7 +179,9 @@ module.exports = function WidgetController(
     // case, searchClients.length > 0), as a result of switching to the group
     // containing the selected annotation.
     //
-    // In that case, we don't want to trigger reloading annotations again.
+    // In that case, we don't want to trigger reloading annotations again and we
+    // also want to preserve the selection if the user visits a direct link to a
+    // group annotation whilst signed out, then signs in.
     if (searchClients.length) {
       return;
     }


### PR DESCRIPTION
Preserve selection when switching accounts

When visiting a direct-linked annotation (ie. #annotations:<id> is
present in the URL) we want to preserve the selection when the user
signs in, whether the annotation was private or in a group, in which
case they will need to sign in to see it, or public, in which case they
might need to sign in to reply.

Previously public direct-linked annotations became deselected when
signing in because they were unloaded when switching accounts, and this
fired the same ANNOTATION_DELETED event as when an annotation is
removed, which results in the annotation being removed from the
selection.

This commit enables the selection to be preserved by introducing a
different event within the app when annotations are unloaded vs.
deleted. When an annotation is unloaded, it is not removed from the
selection.
