### PR TITLE
Fix CSP violation on new homepage

### DIFF
--- a/h/static/styles/util.scss
+++ b/h/static/styles/util.scss
@@ -22,3 +22,7 @@
 .u-strong {
   font-weight: bold;
 }
+
+.u-hidden {
+  display: none;
+}

--- a/h/templates/includes/header.html.jinja2
+++ b/h/templates/includes/header.html.jinja2
@@ -8,7 +8,7 @@
   the wordpress-theme-hypothesis repository.
 
 #}
-<svg style="display:none">
+<svg class="u-hidden">
     <symbol class="border-with-left-arrow" id="border-with-left-arrow">
         <rect class="background-rect" stroke="none" x="0" y="0" width="10" height="20"/>
         <!-- ensure a sharp outline !-->


### PR DESCRIPTION
Fixing these CSP violations is quite a good task to dabble around with some frontend code. So here is the first one.

We are not allowing inline styles in our CSP policy, this commit adds a new class `svg-symbols` to the `svg` tag containing the symbols for the hiring banner arrow and the navigation arrows, and moves the `display: none` into the `header.scss` file.

Please let me know about wrong naming, wrong CSS files, etc.

The CSP violations that are already reported are listed here: https://report-uri.io/account/csp_reports/