### PR TITLE
List group memberships of user in admin interface

### DIFF
--- a/h/groups/models.py
+++ b/h/groups/models.py
@@ -24,7 +24,7 @@ class Group(Base, mixins.Timestamps):
                       default=pubid.generate,
                       unique=True,
                       nullable=False)
-    name = sa.Column(sa.UnicodeText(), nullable=False)
+    name = sa.Column(sa.UnicodeText(), nullable=False, index=True)
 
     # We store information about who created the group -- we don't use this
     # currently, but it seems careless to lose this information when in the

--- a/h/groups/models.py
+++ b/h/groups/models.py
@@ -34,9 +34,9 @@ class Group(Base, mixins.Timestamps):
     creator = sa.orm.relationship('User')
 
     # Group membership
-    members = sa.orm.relationship('User',
-                                  secondary='user_group',
-                                  backref='groups')
+    members = sa.orm.relationship(
+        'User', secondary='user_group', backref=sa.orm.backref(
+            'groups', order_by='Group.name'))
 
     def __init__(self, name, creator):
         self.name = name

--- a/h/migrations/versions/21f87f395e26_add_group_name_index.py
+++ b/h/migrations/versions/21f87f395e26_add_group_name_index.py
@@ -1,0 +1,25 @@
+"""Add index to group.name column
+
+Revision ID: 21f87f395e26
+Revises: 0d4755a0d88b
+Create Date: 2016-03-24 15:12:59.803179
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '21f87f395e26'
+down_revision = '0d4755a0d88b'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    # Creating a concurrent index does not work inside a transaction
+    op.execute('COMMIT')
+    op.create_index(op.f('ix__group__name'), 'group', ['name'],
+                    postgresql_concurrently=True)
+
+
+def downgrade():
+    op.drop_index(op.f('ix__group__name'), 'group')

--- a/h/templates/admin/users.html.jinja2
+++ b/h/templates/admin/users.html.jinja2
@@ -72,6 +72,32 @@
 
         <button class="btn btn-danger" type="submit">Delete user</button>
       </form>
+
+      {% if user.groups %}
+        <hr>
+
+        <h2>Groups this user belongs to</h2>
+
+        <table class="table table-auto table-striped">
+          <thead>
+            <th>Name</th>
+            <th>URL</th>
+          </thead>
+          <tbody>
+            {% for group in user.groups %}
+              <tr>
+                <td>{{group.name}}</td>
+                <td>
+                  {% set group_url = request.route_url('group_read', pubid=group.pubid, slug=group.slug) %}
+                  <a href="{{ group_url }}">
+                    {{ group_url }}
+                  </a>
+                </td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      {% endif %}
     {% else %}
       <p>No user found with username or email <em>{{ username }}</em>!</p>
     {% endif %}


### PR DESCRIPTION
This just shows a table of groups the user belongs to underneath the user data in the admin interface. The whole block is omitted when the user is not a member of any group.

![2016-03-24-105911_560x390_scrot](https://cloud.githubusercontent.com/assets/112063/14013913/7858845e-f1af-11e5-8d40-0530243ef2f2.png)
