### PR TITLE
Add missing semicolon to content security policy setting

### DIFF
--- a/h/browser/chrome/manifest.json.jinja2
+++ b/h/browser/chrome/manifest.json.jinja2
@@ -24,7 +24,7 @@
     "tabs"
   ],
   "content_security_policy":
-    "script-src 'self' 'unsafe-eval' {{ script_src }} object-src 'self'; font-src 'self' data:;",
+    "script-src 'self' 'unsafe-eval' {{ script_src }}; object-src 'self'; font-src 'self' data:;",
 
   "background": {
     "persistent": true,


### PR DESCRIPTION
This was accidentally removed by be28086.