### PR TITLE
CSP Violation: form input onfocus

### DIFF
--- a/h/static/scripts/form-select-onfocus-controller.js
+++ b/h/static/scripts/form-select-onfocus-controller.js
@@ -1,0 +1,20 @@
+'use strict';
+
+function FormSelectOnFocusController(root) {
+  this._elements = root.querySelectorAll('.js-select-onfocus');
+
+  for (var i = 0; i < this._elements.length; i++) {
+    var element = this._elements[i];
+
+    // In case the `focus` event has already been fired, select the element
+    if (element === document.activeElement) {
+      element.select();
+    }
+
+    element.addEventListener('focus', function(event) {
+      event.target.select();
+    });
+  }
+}
+
+module.exports = FormSelectOnFocusController;

--- a/h/static/scripts/site.js
+++ b/h/static/scripts/site.js
@@ -1,3 +1,5 @@
+'use strict';
+
 // configure error reporting
 var settings = require('./settings')(document);
 if (settings.raven) {
@@ -9,6 +11,7 @@ var page = require('page');
 var CreateGroupFormController = require('./create-group-form');
 var DropdownMenuController = require('./dropdown-menu');
 var InstallerController = require('./installer-controller');
+var FormSelectOnFocusController = require('./form-select-onfocus-controller');
 
 // setup components
 new DropdownMenuController(document);
@@ -24,6 +27,18 @@ page('/groups/new', function () {
   new CreateGroupFormController(document.body);
 });
 
+page('/login', function() {
+  new FormSelectOnFocusController(document.body);
+});
+
+page('/register', function() {
+  new FormSelectOnFocusController(document.body);
+});
+
+page('/forgot_password', function() {
+  new FormSelectOnFocusController(document.body);
+});
+
 document.addEventListener('DOMContentLoaded', function () {
-  page.start();
+  page.start({click: false});
 });

--- a/h/static/scripts/test/form-select-onfocus-controller-test.js
+++ b/h/static/scripts/test/form-select-onfocus-controller-test.js
@@ -1,0 +1,45 @@
+'use strict';
+
+var FormSelectOnFocusController = require('../form-select-onfocus-controller');
+
+// helper to dispatch a native event to an element
+function sendEvent(element, eventType) {
+  // createEvent() used instead of Event constructor
+  // for PhantomJS compatibility
+  var event = document.createEvent('Event');
+  event.initEvent(eventType, true /* bubbles */, true /* cancelable */);
+  element.dispatchEvent(event);
+}
+
+describe('FormSelectOnFocusController', function() {
+  var root;
+
+  beforeEach(function() {
+    root = document.createElement('div');
+    root.innerHTML = '<form id="js-users-delete-form">' +
+                     '<input type="text" class="js-select-onfocus" value="some-test-value">';
+    document.body.appendChild(root);
+  });
+
+  afterEach(function() {
+    root.parentNode.removeChild(root);
+  });
+
+  it('it selects the element on focus event', function() {
+    new FormSelectOnFocusController(root);
+    var input = root.querySelector('input');
+    sendEvent(input, 'focus');
+    assert.strictEqual(input.selectionStart, 0);
+    assert.strictEqual(input.selectionEnd, input.value.length);
+  });
+
+  it('it selects the element without focus event when it is the active element', function() {
+    // Focus element before instantiating the controller
+    var input = root.querySelector('input');
+    input.focus();
+
+    new FormSelectOnFocusController(document.body);
+    assert.strictEqual(input.selectionStart, 0);
+    assert.strictEqual(input.selectionEnd, input.value.length);
+  });
+});

--- a/h/templates/accounts/forgot_password.html.jinja2
+++ b/h/templates/accounts/forgot_password.html.jinja2
@@ -21,3 +21,9 @@
     </div>
   </div>
 {% endblock content %}
+
+{% block scripts %}
+  {% for url in asset_urls("site_js") %}
+  <script src="{{ url }}"></script>
+  {% endfor %}
+{% endblock %}

--- a/h/templates/accounts/login.html.jinja2
+++ b/h/templates/accounts/login.html.jinja2
@@ -20,3 +20,9 @@
     </div>
   </div>
 {% endblock content %}
+
+{% block scripts %}
+  {% for url in asset_urls("site_js") %}
+  <script src="{{ url }}"></script>
+  {% endfor %}
+{% endblock %}

--- a/h/templates/accounts/register.html.jinja2
+++ b/h/templates/accounts/register.html.jinja2
@@ -20,3 +20,9 @@
     </div>
   </div>
 {% endblock content %}
+
+{% block scripts %}
+  {% for url in asset_urls("site_js") %}
+  <script src="{{ url }}"></script>
+  {% endfor %}
+{% endblock %}

--- a/h/templates/deform/includes/common_attrs.jinja2
+++ b/h/templates/deform/includes/common_attrs.jinja2
@@ -1,7 +1,7 @@
 name="{{ field.name }}"
 value="{{ cstruct }}"
 id="{{ field.oid }}"
-class="form-input{% if field.widget.css_class %} {{ field.widget.css_class }}{% endif %}"
+class="form-input{% if field.widget.css_class %} {{ field.widget.css_class }}{% endif %}{% if field.widget.autofocus %} js-select-onfocus{% endif %}"
 {%- if field.widget.size -%}
 size="{{ field.widget.size }}"
 {% endif -%}
@@ -12,7 +12,7 @@ aria-describedby="hint-{{ field.oid }}"
 aria-invalid="true"
 {% endif -%}
 {%- if field.widget.autofocus -%}
-autofocus onfocus="this.select()"
+autofocus
 {% endif -%}
 {%- if field.widget.disable_autocomplete -%}
 autocomplete="off"


### PR DESCRIPTION
I'm not sure if this is the correct way to handle this, so I've held off writing tests.

One thing I noticed is that this doesn't work right after a page load, presumably because the `focus` event is fired before all the JS code is loaded (as described [here](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-autofocus)).