### PR TITLE
CSP violation: admin confirm users delete

### DIFF
--- a/h/assets.ini
+++ b/h/assets.ini
@@ -8,6 +8,7 @@ admin_css =
   styles/admin.css
 
 admin_js =
+  scripts/raven.bundle.js
   scripts/jquery.bundle.js
   scripts/bootstrap.bundle.js
   scripts/admin-site.bundle.js

--- a/h/static/scripts/admin-site.js
+++ b/h/static/scripts/admin-site.js
@@ -8,3 +8,9 @@ if (settings.raven) {
 
 window.$ = window.jQuery = require('jquery');
 require('bootstrap');
+
+var page = require('page');
+
+document.addEventListener('DOMContentLoaded', function () {
+  page.start();
+});

--- a/h/static/scripts/admin-site.js
+++ b/h/static/scripts/admin-site.js
@@ -1,2 +1,10 @@
+'use strict';
+
+// configure error reporting
+var settings = require('./settings')(document);
+if (settings.raven) {
+  require('./raven').init(settings.raven);
+}
+
 window.$ = window.jQuery = require('jquery');
 require('bootstrap');

--- a/h/static/scripts/admin-site.js
+++ b/h/static/scripts/admin-site.js
@@ -11,6 +11,12 @@ require('bootstrap');
 
 var page = require('page');
 
+var AdminUsersController = require('./admin-users');
+
+page('/admin/users', function() {
+  new AdminUsersController(document.body, window);
+});
+
 document.addEventListener('DOMContentLoaded', function () {
   page.start();
 });

--- a/h/static/scripts/admin-users.js
+++ b/h/static/scripts/admin-users.js
@@ -1,0 +1,19 @@
+'use strict';
+
+function AdminUsersController(element, window_) {
+  this._form = element.querySelector('#js-users-delete-form');
+
+  function confirmFormSubmit() {
+    return window_.confirm('This will permanently delete all the user\'s data. Are you sure?');
+  }
+
+  if (this._form) {
+    this._form.addEventListener('submit', function (event) {
+      if (!confirmFormSubmit()) {
+        event.preventDefault();
+      }
+    });
+  }
+}
+
+module.exports = AdminUsersController;

--- a/h/static/scripts/test/admin-users-test.js
+++ b/h/static/scripts/test/admin-users-test.js
@@ -1,0 +1,47 @@
+'use strict';
+
+var AdminUsersController = require('../admin-users');
+
+// helper to dispatch a native event to an element
+function sendEvent(element, eventType) {
+  // createEvent() used instead of Event constructor
+  // for PhantomJS compatibility
+  var event = document.createEvent('Event');
+  event.initEvent(eventType, true /* bubbles */, true /* cancelable */);
+  element.dispatchEvent(event);
+
+  return event;
+}
+
+describe('AdminUsersController', function () {
+  var root;
+  var form;
+
+  beforeEach(function () {
+    root = document.createElement('div');
+    root.innerHTML = '<form id="js-users-delete-form">' +
+                     '<input type="submit" id="submit-btn">';
+    form = root.querySelector('form');
+    document.body.appendChild(root);
+  });
+
+  afterEach(function () {
+    root.parentNode.removeChild(root);
+  });
+
+  it('it submits the form when confirm returns true', function () {
+    var fakeWindow = {confirm: sinon.stub().returns(true)};
+    new AdminUsersController(root, fakeWindow);
+
+    var event = sendEvent(form, 'submit');
+    assert.isFalse(event.defaultPrevented);
+  });
+
+  it('it cancels the form submission when confirm returns false', function () {
+    var fakeWindow = {confirm: sinon.stub().returns(false)};
+    new AdminUsersController(root, fakeWindow);
+
+    var event = sendEvent(form, 'submit');
+    assert.isTrue(event.defaultPrevented);
+  });
+});

--- a/h/templates/admin/users.html.jinja2
+++ b/h/templates/admin/users.html.jinja2
@@ -60,7 +60,7 @@
         </tbody>
       </table>
 
-      <form id="users-delete-form" method="POST" action="{{request.route_path('admin_users_delete')}}" class="form-inline">
+      <form id="js-users-delete-form" method="POST" action="{{request.route_path('admin_users_delete')}}" class="form-inline">
         <input type="hidden" name="username" value="{{user.username}}">
 
         {% if user_meta['annotations_count'] > 100 %}
@@ -103,16 +103,3 @@
     {% endif %}
   {% endif %}
 {% endblock %}
-
-{% block scripts %}
-  {{ super() }}
-
-  <script type="text/javascript">
-    $(document).ready(function() {
-      $('#users-delete-form').submit(function() {
-        return confirm("This will permanently delete all the user's data. Are you sure?");
-      });
-    });
-  </script>
-{% endblock %}
-

--- a/h/templates/layouts/admin.html.jinja2
+++ b/h/templates/layouts/admin.html.jinja2
@@ -26,6 +26,17 @@
   {% for url in asset_urls("admin_css") %}
 <link rel="stylesheet" href="{{ url }}">
 {% endfor %}
+
+    {% if request.sentry.get_public_dsn() %}
+      <script class="js-hypothesis-settings" type="application/json">
+        {
+          "raven": {
+            "dsn": "{{ request.sentry.get_public_dsn('https') }}",
+            "release": "{{ h_version }}"
+          }
+        }
+      </script>
+    {% endif %}
   </head>
   <body>
     <nav class="navbar navbar-inverse navbar-fixed-top">


### PR DESCRIPTION
This pull request:

* Sets up sentry for the admin JS part
* Moves the confirm dialog when deleting users into it's own JS controller

I would need some help on how to properly test this, as this is all a bit out of my depth at the moment. Any other comments appreciated as well.