### PR TITLE
Show adder if user makes a selection and then launches the plugin.

### DIFF
--- a/h/static/scripts/annotator/guest.coffee
+++ b/h/static/scripts/annotator/guest.coffee
@@ -341,6 +341,11 @@ module.exports = class Guest extends Annotator
     tags = (a.$$tag for a in annotations)
     @crossframe?.call('focusAnnotations', tags)
 
+  showAdder: (position) ->
+    @adder
+      .css(position)
+      .show()
+
   onSuccessfulSelection: (event, immediate) ->
     unless event?
       throw "Called onSuccessfulSelection without an event!"
@@ -360,10 +365,23 @@ module.exports = class Guest extends Annotator
       @onAdderClick event
     else
       # Show the adder button
-      @adder
-        .css(Annotator.Util.mousePosition(event, @element[0]))
-        .show()
+      adderPosition = {}
 
+      # By default adder position is where the user releases the mouse
+      # while making a text selection.
+      adderPosition = Annotator.Util.mousePosition(event, @element[0])
+
+      # If the user launches the plugin after making a selection
+      # position the adder in the top and middle of the bounding
+      # box of the selection.
+      if event.type == 'ready'
+        selection = Annotator.Util.getGlobal().getSelection()
+        if !selection.isCollapsed
+          rect = selection.getRangeAt(0).getBoundingClientRect();
+          adderPosition.top = rect.top + window.scrollY
+          adderPosition.left = (rect.width / 2) + rect.left
+
+      this.showAdder(adderPosition)
     true
 
   onFailedSelection: (event) ->

--- a/h/static/scripts/annotator/plugin/textselection.coffee
+++ b/h/static/scripts/annotator/plugin/textselection.coffee
@@ -10,6 +10,7 @@ module.exports = class TextSelection extends Annotator.Plugin
     $(document).bind({
       "touchend": @checkForEndSelection
       "mouseup": @checkForEndSelection
+      "ready": @checkForEndSelection
     })
 
     null
@@ -18,6 +19,7 @@ module.exports = class TextSelection extends Annotator.Plugin
     $(document).unbind({
       "touchend": @checkForEndSelection
       "mouseup": @checkForEndSelection
+      "ready": @checkForEndSelection
     })
     super
 


### PR DESCRIPTION
If a user selects some text, and then realises that Hypothesis isn't
active, their first reaction will probably be to activate Hypothesis.
In this scenario, we should pop up the adder near the selection on launch.

* If event type is 'ready' and there is a selection, then show adder
in the top middle of the bounding box of the selection.
* Otherwise, show the adder in the mouse position.

Trello:
https://trello.com/c/1NElt1Oc/297-show-annotation-adder-on-text-selected-before-launching-the-tool