### PR TITLE
Show list of group members in the group page.

### DIFF
--- a/h/groups/views.py
+++ b/h/groups/views.py
@@ -125,7 +125,10 @@ def _read_group(request, group):
                       for annotation in annotations_by_uri.values()]
 
     template_data = {
-        'group': group, 'group_url': url, 'document_links': document_links}
+        'group': group,
+        'group_url': url,
+        'document_links': document_links
+    }
 
     return renderers.render_to_response(
         renderer_name='h:templates/groups/share.html.jinja2',

--- a/h/static/styles/group-form.scss
+++ b/h/static/styles/group-form.scss
@@ -85,18 +85,16 @@
     }
   }
 
-  .group-document-list {
-
+  .group-document-list, .group-members-list {
+    display: flex;
     justify-content: left;
     font-size: $body2-font-size;
     line-height: $body2-line-height;
     background-color: $white;
     color: $color-dove-gray;
-
-    border: $border;
-    border-top: none;
+    border-left: $border;
+    border-right: $border;
     padding-top: 20px;
-    padding-bottom: 10px;
     padding-left: 20px;
     padding-right: 20px;
 
@@ -109,6 +107,10 @@
       margin-bottom: 1.5em;
     }
 
+  }
+
+  .group-members-list {
+    border-bottom: $border;
   }
 
   .group-form-footer {

--- a/h/templates/groups/about-groups.html.jinja2
+++ b/h/templates/groups/about-groups.html.jinja2
@@ -1,2 +1,5 @@
 <p class="group-form-footer__heading">About Groups</p>
-<p>Groups let you annotate and discuss content on the web privately.</p>
+<p>
+  Groups let you annotate and discuss content on the web privately.
+  <a href="//hypothes.is/annotating-with-groups/" target="_blank">More</a>
+</p>

--- a/h/templates/groups/share.html.jinja2
+++ b/h/templates/groups/share.html.jinja2
@@ -32,17 +32,27 @@
         </ul>
     </div>
     {% endif %}
+    {% if group.members %}
+    <div class="group-members-list">
+      <ul class="group-members-list__list">
+        <p class="group-members-list__heading">Group Members:</p>
+        {% for member in group.members|sort(attribute='username')  %}
+          <li>
+            <a href="{{ request.route_url('stream') }}?q=group:{{ group.pubid }} user:{{ member.username }}"
+              target="_blank"
+              title="{{ member.username }}'s annotations in this group">
+              {{ member.username }}
+            </a>
+          </li>
+        {% endfor %}
+      </ul>
+    </div>
+    {% endif %}
     <div class="group-form-footer">
       <div class="group-form-footer__explain-text">
         {% include "about-groups.html.jinja2" %}
-
-        <p class="group-form-footer__heading">You can</p>
-        <ol class="group-form-footer__list">
-          <li>Annotate any web resource privately within the group.</li>
-          <li>Restrict the annotations shown for a web resource to only those
-              belonging to the group.</li>
-          <li>Invite anyone to join the group using the link below:</li>
-        </ol>
+        <p class="group-form-footer__heading">Invite</p>
+        Invite anyone to join the group using the link below:
         <input class="share-link-field" value="{{ group_url }}">
         <a href="//twitter.com/intent/tweet?url={{ group_url }}"
            target="_blank"


### PR DESCRIPTION
Users want to see other users in the groups they belong to
and annotations each of these users have made and shared with a
group. This will help them decide how to share annotations with
their groups.

https://trello.com/c/rSUQLuos/294-as-a-user-i-want-to-be-able-to-find-out-who-is-a-member-of-a-group-i-m-in