### PR TITLE
Remove pep257 config from setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,9 +8,5 @@ ignore =
     node_modules
     tox.ini
 
-[pep257]
-ignore = D202
-explain = true
-
 [yapf]
 based_on_style = pep8


### PR DESCRIPTION
This tool has actually been renamed to pydocstyle now, but in any case
we don't run pep257/pydocstyle directly in h, we run it indirectly via
the prospector tool, and when run by prospector pep257 is configured
separately in the .prospector.yaml (and the pep257 config in
.prospector.yaml was in conflict with the one in setup.cfg).

I didn't copy the ignore = D202 from setup.cfg into .prospector.yaml as
I don't see why we should ignore this rule.

I also didn't copy the explain = true because it doesn't do anything,
this is a pep257/pydocstyle command line option that isn't available in
the config file.