### PR TITLE
Postgres Write 2/4: Model code for creating new annotations in Postgres

### DIFF
--- a/h/api/models/__init__.py
+++ b/h/api/models/__init__.py
@@ -13,9 +13,13 @@ functions in `h.api.storage`.
 
 from h.api.models.annotation import Annotation
 from h.api.models.document import Document, DocumentMeta, DocumentURI
+from h.api.models.document import create_or_update_document_meta
+from h.api.models.document import create_or_update_document_uri
 
 __all__ = (
     'Annotation',
+    'create_or_update_document_meta',
+    'create_or_update_document_uri',
     'Document',
     'DocumentMeta',
     'DocumentURI',

--- a/h/api/models/__init__.py
+++ b/h/api/models/__init__.py
@@ -12,9 +12,11 @@ functions in `h.api.storage`.
 """
 
 from h.api.models.annotation import Annotation
-from h.api.models.document import Document, DocumentMeta, DocumentURI
 from h.api.models.document import create_or_update_document_meta
 from h.api.models.document import create_or_update_document_uri
+from h.api.models.document import Document
+from h.api.models.document import DocumentMeta
+from h.api.models.document import DocumentURI
 
 __all__ = (
     'Annotation',

--- a/h/api/models/document.py
+++ b/h/api/models/document.py
@@ -260,7 +260,6 @@ def create_or_update_document_uri(session,
 
 def create_or_update_document_meta(session,
                                    claimant,
-                                   claimant_normalized,
                                    type,
                                    value,
                                    document,
@@ -286,10 +285,6 @@ def create_or_update_document_meta(session,
         if a new DocumentMeta is created
     :type claimant: unicode
 
-    :param claimant_normalized: the value of the new or existing DocumentMeta's
-        claimant_normalized attribute
-    :type claimant_normalized: unicode
-
     :param type: the value of the new or existing DocumentMeta's type attribute
     :type type: unicode
 
@@ -311,19 +306,18 @@ def create_or_update_document_meta(session,
 
     """
     existing_dm = DocumentMeta.query.filter(
-        DocumentMeta.claimant_normalized == claimant_normalized,
+        DocumentMeta.claimant_normalized == uri_normalize(claimant),
         DocumentMeta.type == type).one_or_none()
 
     if existing_dm is None:
         session.add(DocumentMeta(
-                    _claimant=claimant,
-                    _claimant_normalized=claimant_normalized,
-                   type=type,
-                   value=value,
-                   document=document,
-                   created=created,
-                   updated=updated,
-        ))
+                    claimant=claimant,
+                    type=type,
+                    value=value,
+                    document=document,
+                    created=created,
+                    updated=updated,
+                    ))
     else:
         existing_dm.value = value
         existing_dm.updated = updated

--- a/h/api/models/document.py
+++ b/h/api/models/document.py
@@ -322,9 +322,9 @@ def create_or_update_document_meta(session,
         existing_dm.value = value
         existing_dm.updated = updated
         if not existing_dm.document == document:
-            log.warn('Found DocumentMeta with id %d does not match expected '
-                     'document with id %d', existing_dm.id,
-                     document.id)
+            log.warn("Found DocumentMeta (id: %d)'s document_id (%d) doesn't "
+                     "match given Document's id (%d)",
+                     existing_dm.id, existing_dm.document_id, document.id)
 
 
 def merge_documents(session, documents, updated=datetime.now()):

--- a/h/api/models/document.py
+++ b/h/api/models/document.py
@@ -251,8 +251,9 @@ def create_or_update_document_uri(session,
                              updated=updated)
         session.add(docuri)
     elif not docuri.document == document:
-        log.warn('Found DocumentURI with id %d does not match expected '
-                 'document with id %d', docuri.document_id, document.id)
+        log.warn("Found DocumentURI (id: %d)'s document_id (%d) doesn't match "
+                 "given Document's id (%d)",
+                 docuri.id, docuri.document_id, document.id)
 
     docuri.updated = updated
 

--- a/h/api/models/document.py
+++ b/h/api/models/document.py
@@ -289,7 +289,7 @@ def create_or_update_document_meta(session,
 
     :param value: the value to set the new or existing DocumentMeta's value
         attribute to
-    :type value: unicode
+    :type value: list of unicode strings
 
     :param document: the value to use for the DocumentMeta's document if a new
         DocumentMeta is created

--- a/h/api/models/document.py
+++ b/h/api/models/document.py
@@ -8,7 +8,6 @@ import logging
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql as pg
 from sqlalchemy.ext.hybrid import hybrid_property
-from sqlalchemy.orm import aliased
 
 from h.api.db import Base
 from h.api.db import mixins

--- a/h/api/models/document.py
+++ b/h/api/models/document.py
@@ -234,7 +234,7 @@ def create_or_update_document_uri(session,
     :type updated: datetime.datetime
 
     """
-    docuri = DocumentURI.query.filter(
+    docuri = session.query(DocumentURI).filter(
         DocumentURI.claimant_normalized == uri_normalize(claimant),
         DocumentURI.uri_normalized == uri_normalize(uri),
         DocumentURI.type == type,
@@ -304,7 +304,7 @@ def create_or_update_document_meta(session,
     :type updated: datetime.datetime
 
     """
-    existing_dm = DocumentMeta.query.filter(
+    existing_dm = session.query(DocumentMeta).filter(
         DocumentMeta.claimant_normalized == uri_normalize(claimant),
         DocumentMeta.type == type).one_or_none()
 

--- a/h/api/models/document.py
+++ b/h/api/models/document.py
@@ -185,7 +185,7 @@ class DocumentMeta(Base, mixins.Timestamps):
         return '<DocumentMeta %s>' % self.id
 
 
-def create_or_update_document_uri(db,
+def create_or_update_document_uri(session,
                                   claimant,
                                   uri,
                                   type,
@@ -207,8 +207,8 @@ def create_or_update_document_uri(db,
     belongs to may be different. The claimant and uri are normalized before
     comparing.
 
-    :param db: the database session
-    :type db: sqlalchemy.orm.session.Session
+    :param session: the database session
+    :type session: sqlalchemy.orm.session.Session
 
     :param claimant: the .claimant property of the DocumentURI
     :type claimant: unicode
@@ -249,7 +249,7 @@ def create_or_update_document_uri(db,
                              document=document,
                              created=created,
                              updated=updated)
-        db.add(docuri)
+        session.add(docuri)
     elif not docuri.document == document:
         log.warn('Found DocumentURI with id %d does not match expected '
                  'document with id %d', docuri.document_id, document.id)
@@ -257,7 +257,7 @@ def create_or_update_document_uri(db,
     docuri.updated = updated
 
 
-def create_or_update_document_meta(db,
+def create_or_update_document_meta(session,
                                    claimant,
                                    claimant_normalized,
                                    type,
@@ -278,8 +278,8 @@ def create_or_update_document_meta(db,
     claimant and type, but its value, document and created and updated times
     needn't match the given ones.
 
-    :param db: the database session
-    :type db: sqlalchemy.orm.session.Session
+    :param session: the database session
+    :type session: sqlalchemy.orm.session.Session
 
     :param claimant: the value to use for the DocumentMeta's claimant attribute
         if a new DocumentMeta is created
@@ -314,14 +314,14 @@ def create_or_update_document_meta(db,
         DocumentMeta.type == type).one_or_none()
 
     if existing_dm is None:
-        db.add(DocumentMeta(
-            _claimant=claimant,
-            _claimant_normalized=claimant_normalized,
-            type=type,
-            value=value,
-            document=document,
-            created=created,
-            updated=updated,
+        session.add(DocumentMeta(
+                    _claimant=claimant,
+                    _claimant_normalized=claimant_normalized,
+                   type=type,
+                   value=value,
+                   document=document,
+                   created=created,
+                   updated=updated,
         ))
     else:
         existing_dm.value = value

--- a/h/api/models/document.py
+++ b/h/api/models/document.py
@@ -3,15 +3,19 @@
 from __future__ import unicode_literals
 
 from datetime import datetime
+import logging
 
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql as pg
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import aliased
 
-from h.api import uri
 from h.api.db import Base
 from h.api.db import mixins
+from h.api.uri import normalize as uri_normalize
+
+
+log = logging.getLogger(__name__)
 
 
 class Document(Base, mixins.Timestamps):
@@ -39,7 +43,7 @@ class Document(Base, mixins.Timestamps):
     @classmethod
     def find_by_uris(cls, session, uris):
         """Find documents by a list of uris."""
-        query_uris = [uri.normalize(u) for u in uris]
+        query_uris = [uri_normalize(u) for u in uris]
 
         matching_claims = (
             session.query(DocumentURI)
@@ -118,7 +122,7 @@ class DocumentURI(Base, mixins.Timestamps):
     @claimant.setter
     def claimant(self, value):
         self._claimant = value
-        self._claimant_normalized = uri.normalize(value)
+        self._claimant_normalized = uri_normalize(value)
 
     @hybrid_property
     def claimant_normalized(self):
@@ -131,7 +135,7 @@ class DocumentURI(Base, mixins.Timestamps):
     @uri.setter
     def uri(self, value):
         self._uri = value
-        self._uri_normalized = uri.normalize(value)
+        self._uri_normalized = uri_normalize(value)
 
     @hybrid_property
     def uri_normalized(self):
@@ -171,7 +175,7 @@ class DocumentMeta(Base, mixins.Timestamps):
     @claimant.setter
     def claimant(self, value):
         self._claimant = value
-        self._claimant_normalized = uri.normalize(value)
+        self._claimant_normalized = uri_normalize(value)
 
     @hybrid_property
     def claimant_normalized(self):
@@ -179,6 +183,153 @@ class DocumentMeta(Base, mixins.Timestamps):
 
     def __repr__(self):
         return '<DocumentMeta %s>' % self.id
+
+
+def create_or_update_document_uri(db,
+                                  claimant,
+                                  uri,
+                                  type,
+                                  content_type,
+                                  document,
+                                  created,
+                                  updated):
+    """
+    Create or update a DocumentURI with the given parameters.
+
+    If an equivalent DocumentURI already exists in the database then its
+    updated time will be updated.
+
+    If no equivalent DocumentURI exists in the database then a new one will be
+    created and added to the database.
+
+    To be considered "equivalent" an existing DocumentURI must have the same
+    claimant, uri, type and content_type, but the Document object that it
+    belongs to may be different. The claimant and uri are normalized before
+    comparing.
+
+    :param db: the database session
+    :type db: sqlalchemy.orm.session.Session
+
+    :param claimant: the .claimant property of the DocumentURI
+    :type claimant: unicode
+
+    :param uri: the .uri property of the DocumentURI
+    :type uri: unicode
+
+    :param type: the .type property of the DocumentURI
+    :type type: unicode
+
+    :param content_type: the .content_type property of the DocumentURI
+    :type content_type: unicode
+
+    :param document: the Document that the new DocumentURI will belong to, if a
+        new DocumentURI is created
+    :type document: h.api.models.Document
+
+    :param created: the time that will be used as the .created time for the new
+        DocumentURI, if a new one is created
+    :type created: datetime.datetime
+
+    :param updated: the time that will be set as the .updated time for the new
+        or existing DocumentURI
+    :type updated: datetime.datetime
+
+    """
+    docuri = DocumentURI.query.filter(
+        DocumentURI.claimant_normalized == uri_normalize(claimant),
+        DocumentURI.uri_normalized == uri_normalize(uri),
+        DocumentURI.type == type,
+        DocumentURI.content_type == content_type).first()
+
+    if docuri is None:
+        docuri = DocumentURI(claimant=claimant,
+                             uri=uri,
+                             type=type,
+                             content_type=content_type,
+                             document=document,
+                             created=created,
+                             updated=updated)
+        db.add(docuri)
+    elif not docuri.document == document:
+        log.warn('Found DocumentURI with id %d does not match expected '
+                 'document with id %d', docuri.document_id, document.id)
+
+    docuri.updated = updated
+
+
+def create_or_update_document_meta(db,
+                                   claimant,
+                                   claimant_normalized,
+                                   type,
+                                   value,
+                                   document,
+                                   created,
+                                   updated):
+    """
+    Create or update a DocumentMeta with the given parameters.
+
+    If an equivalent DocumentMeta already exists in the database then its value
+    and updated time will be updated.
+
+    If no equivalent DocumentMeta exists in the database then a new one will be
+    created and added to the database.
+
+    To be considered "equivalent" an existing DocumentMeta must have the given
+    claimant and type, but its value, document and created and updated times
+    needn't match the given ones.
+
+    :param db: the database session
+    :type db: sqlalchemy.orm.session.Session
+
+    :param claimant: the value to use for the DocumentMeta's claimant attribute
+        if a new DocumentMeta is created
+    :type claimant: unicode
+
+    :param claimant_normalized: the value of the new or existing DocumentMeta's
+        claimant_normalized attribute
+    :type claimant_normalized: unicode
+
+    :param type: the value of the new or existing DocumentMeta's type attribute
+    :type type: unicode
+
+    :param value: the value to set the new or existing DocumentMeta's value
+        attribute to
+    :type value: unicode
+
+    :param document: the value to use for the DocumentMeta's document if a new
+        DocumentMeta is created
+    :type document: h.api.models.Document
+
+    :param created: the value to use for the DocumentMeta's created attribute
+        if a new DocumentMeta is created
+    :type created: datetime.datetime
+
+    :param updated: the value to set the new or existing DocumentMeta's updated
+        attribute to
+    :type updated: datetime.datetime
+
+    """
+    existing_dm = DocumentMeta.query.filter(
+        DocumentMeta.claimant_normalized == claimant_normalized,
+        DocumentMeta.type == type).one_or_none()
+
+    if existing_dm is None:
+        db.add(DocumentMeta(
+            _claimant=claimant,
+            _claimant_normalized=claimant_normalized,
+            type=type,
+            value=value,
+            document=document,
+            created=created,
+            updated=updated,
+        ))
+    else:
+        existing_dm.value = value
+        existing_dm.updated = updated
+        if not existing_dm.document == document:
+            log.warn('Found DocumentMeta with id %d does not match expected '
+                     'document with id %d', existing_dm.id,
+                     document.id)
 
 
 def merge_documents(session, documents, updated=datetime.now()):

--- a/h/api/models/test/document_test.py
+++ b/h/api/models/test/document_test.py
@@ -462,6 +462,11 @@ def mock_document():
 
 
 def mock_document_meta(document=None):
+
+    # We define a class to use as the mock spec here because we can't use the
+    # real DocumentMeta class because that class may be patched in the tests
+    # that are calling this function (so we'd end up using a mock object as a
+    # spec instead, and get completely the wrong spec).
     class DocumentMeta(object):
         def __init__(self):
             self.type = None
@@ -471,6 +476,7 @@ def mock_document_meta(document=None):
             self.document = document
             self.id = None
             self.document_id = None
+
     return mock.Mock(spec=DocumentMeta())
 
 

--- a/h/api/models/test/document_test.py
+++ b/h/api/models/test/document_test.py
@@ -458,17 +458,7 @@ def mock_db_session():
 
 def mock_document():
     """Return a mock Document object."""
-    class Document(object):
-        @property
-        def id(self):
-            pass
-        @property
-        def created(self):
-            pass
-        @property
-        def updated(self):
-            pass
-    return mock.Mock(spec=Document)
+    return mock.Mock(spec=document.Document())
 
 
 def mock_document_meta(document=None):

--- a/h/api/models/test/document_test.py
+++ b/h/api/models/test/document_test.py
@@ -178,10 +178,9 @@ class TestCreateOrUpdateDocumentURI(object):
         )
         db.Session.add(document_uri)
 
-        mock_db_session = mock.Mock()
         now_ = now()
         document.create_or_update_document_uri(
-            session=mock_db_session,
+            session=db.Session,
             claimant=claimant,
             uri=uri,
             type=type_,
@@ -193,7 +192,8 @@ class TestCreateOrUpdateDocumentURI(object):
 
         assert document_uri.created == created
         assert document_uri.updated == now_
-        assert not mock_db_session.add.called
+        assert len(db.Session.query(document.DocumentURI).all()) == 1, (
+            "It shouldn't have added any new objects to the db")
 
     def test_it_creates_a_new_DocumentURI_if_there_is_no_existing_one(self):
         claimant = 'http://example.com/example_claimant.html'
@@ -327,10 +327,9 @@ class TestCreateOrUpdateDocumentMeta(object):
         )
         db.Session.add(document_meta)
 
-        mock_db_session = mock.Mock()
         new_updated = now()
         document.create_or_update_document_meta(
-            session=mock_db_session,
+            session=db.Session,
             claimant=claimant,
             type=type_,
             value='new value',
@@ -344,7 +343,8 @@ class TestCreateOrUpdateDocumentMeta(object):
         assert document_meta.created == created, "It shouldn't update created"
         assert document_meta.document == document_, (
             "It shouldn't update document")
-        assert not mock_db_session.add.called
+        assert len(db.Session.query(document.DocumentMeta).all()) == 1, (
+            "It shouldn't have added any new objects to the db")
 
     def test_it_logs_a_warning(self, DocumentMeta, log):
         """
@@ -452,6 +452,8 @@ def mock_db_session():
     """Return a mock db session object."""
     class DB(object):
         def add(self, obj):
+            pass
+        def query(self, cls):
             pass
     return mock.Mock(spec=DB())
 

--- a/h/api/models/test/document_test.py
+++ b/h/api/models/test/document_test.py
@@ -1,10 +1,13 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import unicode_literals
+import datetime
 
+import mock
 import pytest
 
 from h import db
+from h.api.models import document
 from h.api.models.document import Document, DocumentURI, DocumentMeta
 from h.api.models.document import merge_documents
 
@@ -119,6 +122,416 @@ def test_document_find_or_create_by_uris_no_results():
     assert docuri.type == 'self-claim'
 
 
+create_or_update_document_uri_fixtures = pytest.mark.usefixtures(
+    'DocumentURI',
+    'log',
+)
+
+
+def mock_docuri_dict(uri=None):
+    """Return a mock docuri_dict for create_or_update_document_uri()."""
+    if uri is None:
+        uri = 'http://example.com/example_uri.html'
+
+    now = datetime.datetime.now()
+
+    return {
+        'type': 'self-claim',
+        'claimant': 'http://example.com/example_claimant.html',
+        'uri': uri,
+        'created': now,
+        'updated': now
+    }
+
+
+def mock_document():
+    """Return a mock Document object for create_or_update_document_uri()."""
+    class Document:
+        @property
+        def id(self):
+            pass
+        @property
+        def created(self):
+            pass
+        @property
+        def updated(self):
+            pass
+    return mock.Mock(spec=Document)
+
+
+def mock_db():
+    """Return a mock db session object."""
+    class DB:
+        def add(self, obj):
+            pass
+    return mock.Mock(spec=DB())
+
+
+@create_or_update_document_uri_fixtures
+def test_create_or_update_document_uri_calls_filter(DocumentURI):
+    document.create_or_update_document_uri(
+        db=mock_db(),
+        claimant='http://example.com/example_claimant.html',
+        uri='http://example.com/example_uri.html',
+        type='self-claim',
+        content_type=None,
+        document=mock_document(),
+        created=datetime.datetime.now(),
+        updated=datetime.datetime.now())
+
+    # FIXME: We need to assert that this is called with the right arguments,
+    # but that's very awkward to do with the way sqlalchemy querying works.'
+    # Move this functionality onto the model class itself where the tests can
+    # use the actual database.
+    assert DocumentURI.query.filter.call_count == 1
+
+
+@create_or_update_document_uri_fixtures
+def test_create_or_update_document_uri_calls_first(DocumentURI):
+    document.create_or_update_document_uri(
+        db=mock_db(),
+        claimant='http://example.com/example_claimant.html',
+        uri='http://example.com/example_uri.html',
+        type='self-claim',
+        content_type=None,
+        document=mock_document(),
+        created=datetime.datetime.now(),
+        updated=datetime.datetime.now())
+
+    DocumentURI.query.filter.return_value.first.assert_called_once_with()
+
+
+@create_or_update_document_uri_fixtures
+def test_create_or_update_document_uri_inits_DocumentURI(DocumentURI):
+    """If there's no matching object in the db it should init a new one."""
+    DocumentURI.query.filter.return_value.first.return_value = None
+    claimant = 'http://example.com/example_claimant.html'
+    uri = 'http://example.com/example_uri.html'
+    type_ = 'self-claim'
+    content_type = 'text/html'
+    document_ = mock_document()
+    created = datetime.datetime.now() - datetime.timedelta(days=1)
+    updated = datetime.datetime.now()
+
+    document.create_or_update_document_uri(
+        db=mock_db(),
+        claimant=claimant,
+        uri=uri,
+        type=type_,
+        content_type=content_type,
+        document=document_,
+        created=created,
+        updated=updated)
+
+    DocumentURI.assert_called_once_with(
+        claimant=claimant,
+        uri=uri,
+        type=type_,
+        content_type=content_type,
+        document=document_,
+        created=created,
+        updated=updated)
+
+
+@create_or_update_document_uri_fixtures
+def test_create_or_update_document_uri_inits_DocumentURI_when_no_content_type(
+        DocumentURI):
+    """It shouldn't crash if docuri_dict contains no content_type."""
+    DocumentURI.query.filter.return_value.first.return_value = None
+    claimant = 'http://example.com/example_claimant.html'
+    uri = 'http://example.com/example_uri.html'
+    type_ = 'self-claim'
+    content_type = None
+    document_ = mock_document()
+    created = datetime.datetime.now() - datetime.timedelta(days=1)
+    updated = datetime.datetime.now()
+
+    document.create_or_update_document_uri(
+        db=mock_db(),
+        claimant=claimant,
+        uri=uri,
+        type=type_,
+        content_type=content_type,
+        document=document_,
+        created=created,
+        updated=updated)
+
+    DocumentURI.assert_called_once_with(
+        claimant=claimant,
+        uri=uri,
+        type=type_,
+        content_type=content_type,
+        document=document_,
+        created=created,
+        updated=updated)
+
+
+@create_or_update_document_uri_fixtures
+def test_create_or_update_document_uri_adds_DocumentURI_to_db(DocumentURI):
+    DocumentURI.query.filter.return_value.first.return_value = None
+    db = mock_db()
+
+    document.create_or_update_document_uri(
+        db=db,
+        claimant='http://example.com/example_claimant.html',
+        uri='http://example.com/example_uri.html',
+        type='self-claim',
+        content_type=None,
+        document=mock_document(),
+        created=datetime.datetime.now(),
+        updated=datetime.datetime.now())
+
+    db.add.assert_called_once_with(DocumentURI.return_value)
+
+
+@create_or_update_document_uri_fixtures
+def test_create_or_update_document_uri_does_not_create_new_DocumentURI(DocumentURI):
+    """It shouldn't create a new DocumentURI if one already exists."""
+    DocumentURI.query.filter.return_value.first.return_value = mock.Mock()
+    db = mock_db()
+
+    document.create_or_update_document_uri(
+        db=db,
+        claimant='http://example.com/example_claimant.html',
+        uri='http://example.com/example_uri.html',
+        type='self-claim',
+        content_type=None,
+        document=mock_document(),
+        created=datetime.datetime.now(),
+        updated=datetime.datetime.now())
+
+    assert not DocumentURI.called
+    assert not db.add.called
+
+
+@create_or_update_document_uri_fixtures
+def test_create_or_update_document_uri_logs_warning_if_document_ids_differ(
+        log,
+        DocumentURI):
+    """
+    It should log a warning on Document objects mismatch.
+
+    If there's an existing DocumentURI and its .document property is different
+    to the given document it shoulg log a warning.
+
+    """
+    # existing_document_uri.document will not be equal to the given document'
+    existing_document_uri = mock.Mock(document=mock_document())
+    DocumentURI.query.filter.return_value.first.return_value = existing_document_uri
+
+    document.create_or_update_document_uri(
+        db=mock_db(),
+        claimant='http://example.com/example_claimant.html',
+        uri='http://example.com/example_uri.html',
+        type='self-claim',
+        content_type=None,
+        document=mock_document(),
+        created=datetime.datetime.now(),
+        updated=datetime.datetime.now())
+
+    assert log.warn.call_count == 1
+
+
+@create_or_update_document_uri_fixtures
+def test_create_or_update_document_uri_updates_updated_time(DocumentURI):
+    # existing_document_uri has an older .updated time than than the updated
+    # argument we will pass to create_or_update_document_uri().
+    now = datetime.datetime.now()
+    yesterday = now - datetime.timedelta(days=1)
+    existing_document_uri = mock.Mock(updated=yesterday)
+
+    DocumentURI.query.filter.return_value.first.return_value = (
+        existing_document_uri)
+
+    document.create_or_update_document_uri(
+        db=mock_db(),
+        claimant='http://example.com/example_claimant.html',
+        uri='http://example.com/example_uri.html',
+        type='self-claim',
+        content_type=None,
+        document=mock_document(),
+        created=now - datetime.timedelta(days=3),
+        updated=now)
+
+    assert existing_document_uri.updated == now
+
+
+@pytest.mark.usefixtures('DocumentMeta',
+                         'log')
+class TestCreateOrUpdateDocumentMeta(object):
+
+    def test_it_calls_filter(self, DocumentMeta):
+        document.create_or_update_document_meta(
+            db=mock_db(),
+            claimant='http://example.com/claimant',
+            claimant_normalized='http://example.com/claimant_normalized',
+            type='title',
+            value='Example Page',
+            document=mock.Mock(),
+            created=yesterday(),
+            updated=now(),
+        )
+
+        # FIXME: We need to assert that this is called with the right
+        # arguments, but that's very awkward to do with the way sqlalchemy
+        # querying works.' Move this functionality onto the model class itself
+        # where the tests can use the actual database.
+        assert DocumentMeta.query.filter.call_count == 1
+
+    def test_it_calls_one_or_none(self, DocumentMeta):
+        document.create_or_update_document_meta(
+            db=mock_db(),
+            claimant='http://example.com/claimant',
+            claimant_normalized='http://example.com/claimant_normalized',
+            type='title',
+            value='Example Page',
+            document=mock.Mock(),
+            created=yesterday(),
+            updated=now(),
+        )
+
+        DocumentMeta.query.filter.return_value.one_or_none\
+            .assert_called_once_with()
+
+    def test_it_creates_a_new_DocumentMeta(self, DocumentMeta):
+        """It should create a new DocumentMeta if there isn't one already."""
+        DocumentMeta.query.filter.return_value.one_or_none\
+            .return_value = None
+        claimant = 'http://example.com/claimant'
+        claimant_normalized = 'http://example.com/claimant_normalized'
+        type_ = 'title'
+        value = 'Example Page'
+        created = yesterday()
+        updated = now()
+
+        document.create_or_update_document_meta(
+            db=mock_db(),
+            claimant=claimant,
+            claimant_normalized=claimant_normalized,
+            type=type_,
+            value=value,
+            document=mock.sentinel.document,
+            created=created,
+            updated=updated,
+        )
+
+        DocumentMeta.assert_called_once_with(
+            _claimant=claimant,
+            _claimant_normalized=claimant_normalized,
+            type=type_,
+            value=value,
+            document=mock.sentinel.document,
+            created=created,
+            updated=updated,
+        )
+
+    def test_it_adds_document_meta_to_db(self, DocumentMeta):
+        """
+        It should add the new DocumentMeta to the db.
+
+        If there's no existing equivalent DocumentMeta already in the db then
+        it should add the a new one to the db
+
+        """
+        db = mock_db()
+        DocumentMeta.query.filter.return_value.one_or_none\
+            .return_value = None
+
+        document.create_or_update_document_meta(
+            db=db,
+            claimant='http://example.com/claimant',
+            claimant_normalized='http://example.com/claimant_normalized',
+            type='title',
+            value='Example Page',
+            document=mock.Mock(),
+            created=yesterday(),
+            updated=now(),
+        )
+
+        db.add.assert_called_once_with(DocumentMeta.return_value)
+
+    def test_it_sets_value(self, DocumentMeta):
+        """If there's an existing DocumentMeta it should update its value."""
+        existing_document_meta = self.mock_document_meta()
+        existing_document_meta.value = 'old value'
+        DocumentMeta.query.filter.return_value.one_or_none\
+            .return_value = existing_document_meta
+
+        document.create_or_update_document_meta(
+            db=mock_db(),
+            claimant='http://example.com/claimant',
+            claimant_normalized='http://example.com/claimant_normalized',
+            type='title',
+            value='new value',
+            document=mock.Mock(),
+            created=yesterday(),
+            updated=now(),
+        )
+
+        assert existing_document_meta.value == 'new value'
+
+    def test_sets_updated(self, DocumentMeta):
+        """If there's an existing DocumentMeta it should update its updated."""
+        existing_document_meta = self.mock_document_meta()
+        existing_document_meta.updated = yesterday()
+        DocumentMeta.query.filter.return_value.one_or_none\
+            .return_value = existing_document_meta
+        now_ = now()
+
+        document.create_or_update_document_meta(
+            db=mock_db(),
+            claimant='http://example.com/claimant',
+            claimant_normalized='http://example.com/claimant_normalized',
+            type='title',
+            value='new value',
+            document=mock.Mock(),
+            created=yesterday(),
+            updated=now_,
+        )
+
+        assert existing_document_meta.updated == now_
+
+    def test_it_logs_warning(self, DocumentMeta, log):
+        """
+        It should warn on document mismatches.
+
+        It should warn if there's an existing DocumentMeta with a different
+        Document.
+
+        """
+        document_one = mock_document()
+        document_two = mock_document()
+        existing_document_meta = self.mock_document_meta(document=document_one)
+        DocumentMeta.query.filter.return_value.one_or_none\
+            .return_value = existing_document_meta
+
+        document.create_or_update_document_meta(
+            db=mock_db(),
+            claimant='http://example.com/claimant',
+            claimant_normalized='http://example.com/claimant_normalized',
+            type='title',
+            value='new value',
+            document=document_two,
+            created=yesterday(),
+            updated=now(),
+        )
+
+        assert log.warn.call_count == 1
+
+    def mock_document_meta(self, document=None):
+        class DocumentMeta(object):
+            def __init__(self):
+                self.claimant_normalized = None
+                self.type = None
+                self.value = None
+                self.created = None
+                self.updated = None
+                self.document = document
+                self.id = None
+                self.document_id = None
+        return mock.Mock(spec=DocumentMeta())
+
+
 merge_documents_fixtures = pytest.mark.usefixtures('merge_data')
 
 
@@ -162,6 +575,30 @@ def test_merge_documents_rewires_document_meta(merge_data):
     assert len(duplicate.meta) == 0
 
 
+def now():
+    return datetime.datetime.now()
+
+
+def yesterday():
+    return now() - datetime.timedelta(days=1)
+
+
+@pytest.fixture
+def DocumentURI(config, request):
+    patcher = mock.patch('h.api.models.document.DocumentURI')
+    DocumentURI = patcher.start()
+    request.addfinalizer(patcher.stop)
+    return DocumentURI
+
+
+@pytest.fixture
+def DocumentMeta(config, request):
+    patcher = mock.patch('h.api.models.document.DocumentMeta')
+    DocumentMeta = patcher.start()
+    request.addfinalizer(patcher.stop)
+    return DocumentMeta
+
+
 @pytest.fixture
 def merge_data(request):
     master = Document(document_uris=[DocumentURI(
@@ -184,3 +621,11 @@ def merge_data(request):
     db.Session.add_all([master, duplicate])
     db.Session.flush()
     return (master, duplicate)
+
+
+@pytest.fixture
+def log(config, request):
+    patcher = mock.patch('h.api.models.document.log', autospec=True)
+    log = patcher.start()
+    request.addfinalizer(patcher.stop)
+    return log

--- a/h/api/models/test/document_test.py
+++ b/h/api/models/test/document_test.py
@@ -8,13 +8,11 @@ import pytest
 
 from h import db
 from h.api.models import document
-from h.api.models.document import Document, DocumentURI, DocumentMeta
-from h.api.models.document import merge_documents
 
 
 def test_document_title():
-    doc = Document()
-    DocumentMeta(type='title', value='The Title', document=doc, claimant='http://example.com')
+    doc = document.Document()
+    document.DocumentMeta(type='title', value='The Title', document=doc, claimant='http://example.com')
     db.Session.add(doc)
     db.Session.flush()
 
@@ -22,9 +20,9 @@ def test_document_title():
 
 
 def test_document_title_returns_first():
-    doc = Document()
-    DocumentMeta(type='title', value='The US Title', document=doc, claimant='http://example.com')
-    DocumentMeta(type='title', value='The UK Title', document=doc, claimant='http://example.co.uk')
+    doc = document.Document()
+    document.DocumentMeta(type='title', value='The US Title', document=doc, claimant='http://example.com')
+    document.DocumentMeta(type='title', value='The UK Title', document=doc, claimant='http://example.co.uk')
     db.Session.add(doc)
     db.Session.flush()
 
@@ -32,8 +30,8 @@ def test_document_title_returns_first():
 
 
 def test_document_title_meta_not_found():
-    doc = Document()
-    DocumentMeta(type='other', value='something', document=doc, claimant='http://example.com')
+    doc = document.Document()
+    document.DocumentMeta(type='other', value='something', document=doc, claimant='http://example.com')
     db.Session.add(doc)
     db.Session.flush()
 
@@ -41,20 +39,20 @@ def test_document_title_meta_not_found():
 
 
 def test_document_find_by_uris():
-    document1 = Document()
+    document1 = document.Document()
     uri1 = 'https://de.wikipedia.org/wiki/Hauptseite'
-    document1.document_uris.append(DocumentURI(claimant=uri1, uri=uri1))
+    document1.document_uris.append(document.DocumentURI(claimant=uri1, uri=uri1))
 
-    document2 = Document()
+    document2 = document.Document()
     uri2 = 'https://en.wikipedia.org/wiki/Main_Page'
-    document2.document_uris.append(DocumentURI(claimant=uri2, uri=uri2))
+    document2.document_uris.append(document.DocumentURI(claimant=uri2, uri=uri2))
     uri3 = 'https://en.wikipedia.org'
-    document2.document_uris.append(DocumentURI(claimant=uri3, uri=uri2))
+    document2.document_uris.append(document.DocumentURI(claimant=uri3, uri=uri2))
 
     db.Session.add_all([document1, document2])
     db.Session.flush()
 
-    actual = Document.find_by_uris(db.Session, [
+    actual = document.Document.find_by_uris(db.Session, [
         'https://en.wikipedia.org/wiki/Main_Page',
         'https://m.en.wikipedia.org/wiki/Main_Page'])
     assert actual.count() == 1
@@ -62,58 +60,58 @@ def test_document_find_by_uris():
 
 
 def test_document_find_by_uris_no_matches():
-    document = Document()
-    document.document_uris.append(DocumentURI(
+    document_ = document.Document()
+    document_.document_uris.append(document.DocumentURI(
         claimant='https://en.wikipedia.org/wiki/Main_Page',
         uri='https://en.wikipedia.org/wiki/Main_Page'))
-    db.Session.add(document)
+    db.Session.add(document_)
     db.Session.flush()
 
-    actual = Document.find_by_uris(db.Session, ['https://de.wikipedia.org/wiki/Hauptseite'])
+    actual = document.Document.find_by_uris(db.Session, ['https://de.wikipedia.org/wiki/Hauptseite'])
     assert actual.count() == 0
 
 
 def test_document_find_or_create_by_uris():
-    document = Document()
-    docuri1 = DocumentURI(
+    document_ = document.Document()
+    docuri1 = document.DocumentURI(
         claimant='https://en.wikipedia.org/wiki/Main_Page',
         uri='https://en.wikipedia.org/wiki/Main_Page',
-        document=document)
-    docuri2 = DocumentURI(
+        document=document_)
+    docuri2 = document.DocumentURI(
         claimant='https://en.wikipedia.org/wiki/http/en.m.wikipedia.org/wiki/Main_Page',
         uri='https://en.wikipedia.org/wiki/Main_Page',
-        document=document)
+        document=document_)
 
     db.Session.add(docuri1)
     db.Session.add(docuri2)
     db.Session.flush()
 
-    actual = Document.find_or_create_by_uris(db.Session,
+    actual = document.Document.find_or_create_by_uris(db.Session,
         'https://en.wikipedia.org/wiki/Main_Page',
         ['https://en.wikipedia.org/wiki/http/en.m.wikipedia.org/wiki/Main_Page',
          'https://m.en.wikipedia.org/wiki/Main_Page'])
     assert actual.count() == 1
-    assert actual.first() == document
+    assert actual.first() == document_
 
 
 def test_document_find_or_create_by_uris_no_results():
-    document = Document()
-    docuri = DocumentURI(
+    document_ = document.Document()
+    docuri = document.DocumentURI(
         claimant='https://en.wikipedia.org/wiki/Main_Page',
         uri='https://en.wikipedia.org/wiki/Main_Page',
-        document=document)
+        document=document_)
 
     db.Session.add(docuri)
     db.Session.flush()
 
-    documents = Document.find_or_create_by_uris(db.Session,
+    documents = document.Document.find_or_create_by_uris(db.Session,
         'https://en.wikipedia.org/wiki/Pluto',
         ['https://m.en.wikipedia.org/wiki/Pluto'])
 
     assert documents.count() == 1
 
     actual = documents.first()
-    assert isinstance(actual, Document)
+    assert isinstance(actual, document.Document)
     assert len(actual.document_uris) == 1
 
     docuri = actual.document_uris[0]
@@ -539,7 +537,7 @@ merge_documents_fixtures = pytest.mark.usefixtures('merge_data')
 def test_merge_documents_returns_master(merge_data):
     master, duplicate = merge_data
 
-    merged_master = merge_documents(db.Session, merge_data)
+    merged_master = document.merge_documents(db.Session, merge_data)
     assert merged_master == master
 
 
@@ -547,17 +545,17 @@ def test_merge_documents_returns_master(merge_data):
 def test_merge_documents_deletes_duplicate_documents(merge_data):
     master, duplicate = merge_data
 
-    merge_documents(db.Session, merge_data)
+    document.merge_documents(db.Session, merge_data)
     db.Session.flush()
 
-    assert Document.query.get(duplicate.id) is None
+    assert document.Document.query.get(duplicate.id) is None
 
 
 @merge_documents_fixtures
 def test_merge_documents_rewires_document_uris(merge_data):
     master, duplicate = merge_data
 
-    merge_documents(db.Session, merge_data)
+    document.merge_documents(db.Session, merge_data)
     db.Session.flush()
 
     assert len(master.document_uris) == 2
@@ -568,7 +566,7 @@ def test_merge_documents_rewires_document_uris(merge_data):
 def test_merge_documents_rewires_document_meta(merge_data):
     master, duplicate = merge_data
 
-    merge_documents(db.Session, merge_data)
+    document.merge_documents(db.Session, merge_data)
     db.Session.flush()
 
     assert len(master.meta) == 2
@@ -601,19 +599,19 @@ def DocumentMeta(config, request):
 
 @pytest.fixture
 def merge_data(request):
-    master = Document(document_uris=[DocumentURI(
+    master = document.Document(document_uris=[document.DocumentURI(
             claimant='https://en.wikipedia.org/wiki/Main_Page',
             uri='https://en.wikipedia.org/wiki/Main_Page',
             type='self-claim')],
-            meta=[DocumentMeta(
+            meta=[document.DocumentMeta(
                 claimant='https://en.wikipedia.org/wiki/Main_Page',
                 type='title',
                 value='Wikipedia, the free encyclopedia')])
-    duplicate = Document(document_uris=[DocumentURI(
+    duplicate = document.Document(document_uris=[document.DocumentURI(
             claimant='https://m.en.wikipedia.org/wiki/Main_Page',
             uri='https://en.wikipedia.org/wiki/Main_Page',
             type='rel-canonical')],
-            meta=[DocumentMeta(
+            meta=[document.DocumentMeta(
                 claimant='https://m.en.wikipedia.org/wiki/Main_Page',
                 type='title',
                 value='Wikipedia, the free encyclopedia')])

--- a/h/api/models/test/document_test.py
+++ b/h/api/models/test/document_test.py
@@ -168,8 +168,8 @@ class TestCreateOrUpdateDocumentURI(object):
             type='self-claim',
             content_type=None,
             document=mock_document(),
-            created=datetime.datetime.now(),
-            updated=datetime.datetime.now())
+            created=now(),
+            updated=now())
 
         # FIXME: We need to assert that this is called with the right
         # arguments, but that's very awkward to do with the way sqlalchemy
@@ -185,8 +185,8 @@ class TestCreateOrUpdateDocumentURI(object):
             type='self-claim',
             content_type=None,
             document=mock_document(),
-            created=datetime.datetime.now(),
-            updated=datetime.datetime.now())
+            created=now(),
+            updated=now())
 
         DocumentURI.query.filter.return_value.first.assert_called_once_with()
 
@@ -198,8 +198,8 @@ class TestCreateOrUpdateDocumentURI(object):
         type_ = 'self-claim'
         content_type = 'text/html'
         document_ = mock_document()
-        created = datetime.datetime.now() - datetime.timedelta(days=1)
-        updated = datetime.datetime.now()
+        created = yesterday()
+        updated = now()
 
         document.create_or_update_document_uri(
             db=mock_db(),
@@ -228,8 +228,8 @@ class TestCreateOrUpdateDocumentURI(object):
         type_ = 'self-claim'
         content_type = None
         document_ = mock_document()
-        created = datetime.datetime.now() - datetime.timedelta(days=1)
-        updated = datetime.datetime.now()
+        created = yesterday()
+        updated = now()
 
         document.create_or_update_document_uri(
             db=mock_db(),
@@ -261,8 +261,8 @@ class TestCreateOrUpdateDocumentURI(object):
             type='self-claim',
             content_type=None,
             document=mock_document(),
-            created=datetime.datetime.now(),
-            updated=datetime.datetime.now())
+            created=now(),
+            updated=now())
 
         db.add.assert_called_once_with(DocumentURI.return_value)
 
@@ -278,8 +278,8 @@ class TestCreateOrUpdateDocumentURI(object):
             type='self-claim',
             content_type=None,
             document=mock_document(),
-            created=datetime.datetime.now(),
-            updated=datetime.datetime.now())
+            created=now(),
+            updated=now())
 
         assert not DocumentURI.called
         assert not db.add.called
@@ -304,16 +304,16 @@ class TestCreateOrUpdateDocumentURI(object):
             type='self-claim',
             content_type=None,
             document=mock_document(),
-            created=datetime.datetime.now(),
-            updated=datetime.datetime.now())
+            created=now(),
+            updated=now())
 
         assert log.warn.call_count == 1
 
     def test_it_updates_updated_time(self, DocumentURI):
         # existing_document_uri has an older .updated time than than the
         # updated argument we will pass to create_or_update_document_uri().
-        now = datetime.datetime.now()
-        yesterday = now - datetime.timedelta(days=1)
+        created = yesterday()
+        updated = now()
         existing_document_uri = mock.Mock(updated=yesterday)
 
         DocumentURI.query.filter.return_value.first.return_value = (
@@ -326,24 +326,22 @@ class TestCreateOrUpdateDocumentURI(object):
             type='self-claim',
             content_type=None,
             document=mock_document(),
-            created=now - datetime.timedelta(days=3),
-            updated=now)
+            created=created,
+            updated=updated)
 
-        assert existing_document_uri.updated == now
+        assert existing_document_uri.updated == updated
 
     def mock_docuri_dict(self, uri=None):
         """Return a mock document URI dict."""
         if uri is None:
             uri = 'http://example.com/example_uri.html'
 
-        now = datetime.datetime.now()
-
         return {
             'type': 'self-claim',
             'claimant': 'http://example.com/example_claimant.html',
             'uri': uri,
-            'created': now,
-            'updated': now
+            'created': now(),
+            'updated': now()
         }
 
     @pytest.fixture

--- a/h/api/models/test/document_test.py
+++ b/h/api/models/test/document_test.py
@@ -178,10 +178,10 @@ class TestCreateOrUpdateDocumentURI(object):
         )
         db.Session.add(document_uri)
 
-        mock_db = mock.Mock()
+        mock_db_session = mock.Mock()
         now_ = now()
         document.create_or_update_document_uri(
-            db=mock_db,
+            session=mock_db_session,
             claimant=claimant,
             uri=uri,
             type=type_,
@@ -193,7 +193,7 @@ class TestCreateOrUpdateDocumentURI(object):
 
         assert document_uri.created == created
         assert document_uri.updated == now_
-        assert not mock_db.add.called
+        assert not mock_db_session.add.called
 
     def test_it_creates_a_new_DocumentURI_if_there_is_no_existing_one(self):
         claimant = 'http://example.com/example_claimant.html'
@@ -218,7 +218,7 @@ class TestCreateOrUpdateDocumentURI(object):
         ))
 
         document.create_or_update_document_uri(
-            db=db.Session,
+            session=db.Session,
             claimant=claimant,
             uri=uri,
             type=type_,
@@ -251,7 +251,7 @@ class TestCreateOrUpdateDocumentURI(object):
             existing_document_uri)
 
         document.create_or_update_document_uri(
-            db=mock_db(),
+            session=mock_db_session(),
             claimant='http://example.com/example_claimant.html',
             uri='http://example.com/example_uri.html',
             type='self-claim',
@@ -295,7 +295,7 @@ class TestCreateOrUpdateDocumentMeta(object):
         ))
 
         document.create_or_update_document_meta(
-            db=db.Session,
+            session=db.Session,
             claimant=claimant,
             claimant_normalized=claimant_normalized,
             type=type_,
@@ -333,10 +333,10 @@ class TestCreateOrUpdateDocumentMeta(object):
         )
         db.Session.add(document_meta)
 
-        mock_db = mock.Mock()
+        mock_db_session = mock.Mock()
         new_updated = now()
         document.create_or_update_document_meta(
-            db=mock_db,
+            session=mock_db_session,
             claimant=claimant,
             claimant_normalized=claimant_normalized,
             type=type_,
@@ -351,7 +351,7 @@ class TestCreateOrUpdateDocumentMeta(object):
         assert document_meta.created == created, "It shouldn't update created"
         assert document_meta.document == document_, (
             "It shouldn't update document")
-        assert not mock_db.add.called
+        assert not mock_db_session.add.called
 
     def test_it_logs_a_warning(self, DocumentMeta, log):
         """
@@ -368,7 +368,7 @@ class TestCreateOrUpdateDocumentMeta(object):
             .return_value = existing_document_meta
 
         document.create_or_update_document_meta(
-            db=mock_db(),
+            session=mock_db_session(),
             claimant='http://example.com/claimant',
             claimant_normalized='http://example.com/claimant_normalized',
             type='title',
@@ -456,7 +456,7 @@ def yesterday():
     return now() - datetime.timedelta(days=1)
 
 
-def mock_db():
+def mock_db_session():
     """Return a mock db session object."""
     class DB(object):
         def add(self, obj):

--- a/h/api/models/test/document_test.py
+++ b/h/api/models/test/document_test.py
@@ -274,7 +274,6 @@ class TestCreateOrUpdateDocumentMeta(object):
 
     def test_it_creates_a_new_DocumentMeta_if_there_is_no_existing_one(self):
         claimant = 'http://example.com/claimant'
-        claimant_normalized = 'http://example.com/claimant_normalized'
         type_ = 'title'
         value = 'the title'
         document_ = document.Document()
@@ -284,8 +283,7 @@ class TestCreateOrUpdateDocumentMeta(object):
         # Add one non-matching DocumentMeta to the database.
         # This should be ignored.
         db.Session.add(document.DocumentMeta(
-            _claimant=claimant,
-            _claimant_normalized=claimant_normalized,
+            claimant=claimant,
             # Different type means this should not match the query.
             type='different',
             value=value,
@@ -297,7 +295,6 @@ class TestCreateOrUpdateDocumentMeta(object):
         document.create_or_update_document_meta(
             session=db.Session,
             claimant=claimant,
-            claimant_normalized=claimant_normalized,
             type=type_,
             value=value,
             document=document_,
@@ -307,7 +304,6 @@ class TestCreateOrUpdateDocumentMeta(object):
 
         document_meta = db.Session.query(document.DocumentMeta).all()[-1]
         assert document_meta.claimant == claimant
-        assert document_meta.claimant_normalized == claimant_normalized
         assert document_meta.type == type_
         assert document_meta.value == value
         assert document_meta.document == document_
@@ -316,15 +312,13 @@ class TestCreateOrUpdateDocumentMeta(object):
 
     def test_it_updates_an_existing_DocumentMeta_if_there_is_one(self):
         claimant = 'http://example.com/claimant'
-        claimant_normalized = 'http://example.com/claimant_normalized'
         type_ = 'title'
         value = 'the title'
         document_ = document.Document()
         created = yesterday()
         updated = now()
         document_meta = document.DocumentMeta(
-            _claimant=claimant,
-            _claimant_normalized=claimant_normalized,
+            claimant=claimant,
             type=type_,
             value=value,
             document=document_,
@@ -338,7 +332,6 @@ class TestCreateOrUpdateDocumentMeta(object):
         document.create_or_update_document_meta(
             session=mock_db_session,
             claimant=claimant,
-            claimant_normalized=claimant_normalized,
             type=type_,
             value='new value',
             document=document.Document(),  # This should be ignored.
@@ -370,7 +363,6 @@ class TestCreateOrUpdateDocumentMeta(object):
         document.create_or_update_document_meta(
             session=mock_db_session(),
             claimant='http://example.com/claimant',
-            claimant_normalized='http://example.com/claimant_normalized',
             type='title',
             value='new value',
             document=document_two,
@@ -482,7 +474,6 @@ def mock_document():
 def mock_document_meta(document=None):
     class DocumentMeta(object):
         def __init__(self):
-            self.claimant_normalized = None
             self.type = None
             self.value = None
             self.created = None


### PR DESCRIPTION
This pull request adds the new model code that the `storage` module will use to create and update `DocumentMeta` and `DocumentURI` objects in the db (see <https://github.com/hypothesis/h/pull/3153>), specifically it adds two factory functions `create_or_update_document_meta()` and `create_or_update_document_uri()`.

The logic "create an object in the db with these params, or update an equivalent one if one already exists" seems like it belongs in the model to me, so `create_or_update_document_meta()` and `create_or_update_document_uri()` are added to `models` to do this.

`merge_documents()` which does similar work was already in `models`, is will be called by `storage` as well.

These are adapted from existing code in `migrate.py`. `storage` calls them. 