### PR TITLE
Postgres Write 3/4: Schema validation and transformation for creating new annotations in Postgres

### DIFF
--- a/h/api/parse_document_claims.py
+++ b/h/api/parse_document_claims.py
@@ -1,0 +1,237 @@
+"""
+Functions for parsing document claims data from the client.
+
+Functions for parsing the document claims (document metadata claims and URI
+equivalence claims) that the client POSTS in the JSON "document" sub-object in
+annotation create and update requests.
+
+The data is parsed into a format suitable for storage in our database model,
+and returned.
+
+"""
+from __future__ import unicode_literals
+
+
+def document_uris_from_data(document_data, claimant):
+    """
+    Return one or more document URI dicts for the given document data.
+
+    Returns one document uri dict for each document equivalence claim in
+    document_data.
+
+    Each dict can be used to init a DocumentURI object directly:
+
+        document_uri = DocumentURI(**document_uri_dict)
+
+    Always returns at least one "self-claim" document URI whose URI is the
+    claimant URI itself.
+
+    :param document_data: the "document" sub-object that was POSTed to the API
+        as part of a new or updated annotation
+    :type document_data: dict
+
+    :param claimant: the URI that the browser was at when this annotation was
+        created (the top-level "uri" field of the annotation)
+    :type claimant: unicode
+
+    :returns: a list of one or more document URI dicts
+    :rtype: list of dicts
+
+    """
+    document_uris = document_uris_from_links(document_data.get('link', []),
+                                             claimant)
+
+    document_uris.extend(
+        document_uris_from_highwire_pdf(document_data.get('highwire', {}),
+                                        claimant)
+    )
+
+    document_uris.extend(
+        document_uris_from_highwire_doi(document_data.get('highwire', {}),
+                                        claimant)
+    )
+
+    document_uris.extend(
+        document_uris_from_dc(document_data.get('dc', {}),
+                              claimant)
+    )
+
+    document_uris.append(document_uri_self_claim(claimant))
+
+    return document_uris
+
+
+def document_metas_from_data(document_data, claimant):
+    """
+    Return a list of document meta dicts for the given document data.
+
+    Returns one document meta dict for each document metadata claim in
+    document_data.
+
+    Each dict can be used to init a DocumentMeta object directly:
+
+        document_meta = DocumentMeta(**document_meta_dict)
+
+    :param document_data: the "document" sub-object that the client POSTed to
+        the API as part of a new or updated annotation
+    :type document_data: dict
+
+    :param claimant: the URI that the browser was at when this annotation was
+        created (the top-level "uri" field of the annotation)
+    :type claimant: unicode
+
+    :returns: a list of zero or more document meta dicts
+    :rtype: list of dicts
+
+    """
+    def transform_meta_(document_meta_dicts, items, path_prefix=None):
+        """Fill document_meta_dicts with document meta dicts for the items."""
+        if path_prefix is None:
+            path_prefix = []
+
+        for key, value in items.iteritems():
+            keypath = path_prefix[:]
+            keypath.append(key)
+
+            if isinstance(value, dict):
+                transform_meta_(document_meta_dicts,
+                                value,
+                                path_prefix=keypath)
+            else:
+                if not isinstance(value, list):
+                    value = [value]
+
+                document_meta_dicts.append({
+                    'type': '.'.join(keypath),
+                    'value': value,
+                    'claimant': claimant,
+                })
+
+    items = {k: v for k, v in document_data.iteritems() if k != 'link'}
+    document_meta_dicts = []
+    transform_meta_(document_meta_dicts, items)
+    return document_meta_dicts
+
+
+def document_uris_from_links(link_dicts, claimant):
+    """
+    Return document URI dicts for the given document.link data.
+
+    Process a document.link list of dicts that the client submitted as part of
+    an annotation create or update request and return document URI dicts for
+    all of the document equivalence claims that it makes.
+
+    """
+    document_uris = []
+    for link in link_dicts:
+
+        # Disregard self-claim URLs as they're added separately later.
+        if link.keys() == ['href'] and link['href'] == claimant:
+            continue
+
+        # Disregard doi links as these are being added separately from the
+        # highwire and dc metadata later on.
+        if link.keys() == ['href'] and link['href'].startswith('doi:'):
+            continue
+
+        # Disregard Highwire PDF links as these are being added separately from
+        # the highwire metadata later on.
+        if set(link.keys()) == set(['href', 'type']):
+            if link['type'] == 'application/pdf':
+                continue
+
+        uri_ = link['href']
+        type_ = None
+
+
+        # Handle rel="..." links.
+        if type_ is None and link.get('rel') is not None:
+            type_ = 'rel-{}'.format(link['rel'])
+
+        # The "type" item in link dicts becomes content_type in DocumentURIs.
+        content_type = None
+        if link.get('type'):
+            content_type = link['type']
+
+        document_uris.append({
+            'claimant': claimant,
+            'uri': uri_,
+            'type': type_,
+            'content_type': content_type,
+        })
+
+    return document_uris
+
+
+def document_uris_from_highwire_pdf(highwire_dict, claimant):
+    """
+    Return PDF document URI dicts for the given 'highwire' document metadata.
+
+    Process a document.highwire dict that the client submitted as part of an
+    annotation create or update request and return document URI dicts for all
+    of the PDF document equivalence claims that it makes.
+
+    """
+    document_uris = []
+    hwpdfvalues = highwire_dict.get('pdf_url', [])
+    for pdf in hwpdfvalues:
+        document_uris.append({'claimant': claimant,
+                              'uri': pdf,
+                              'type': 'highwire-pdf',
+                              'content_type': 'application/pdf'})
+    return document_uris
+
+
+def document_uris_from_highwire_doi(highwire_dict, claimant):
+    """
+    Return DOI document URI dicts for the given 'highwire' document metadata.
+
+    Process a document.highwire dict that the client submitted as part of an
+    annotation create or update request and return document URI dicts for all
+    of the 'doi:' document equivalence claims that it makes.
+
+    """
+    document_uris = []
+    hwdoivalues = highwire_dict.get('doi', [])
+    for doi in hwdoivalues:
+        if not doi.startswith('doi:'):
+            doi = "doi:{}".format(doi)
+
+        document_uris.append({'claimant': claimant,
+                              'uri': doi,
+                              'type': 'highwire-doi',
+                              'content_type': None})
+    return document_uris
+
+
+def document_uris_from_dc(dc_dict, claimant):
+    """
+    Return document URI dicts for the given 'dc' document metadata.
+
+    Process a document.dc dict that the client submitted as part of an
+    annotation create or update request and return document URI dicts for all
+    of the document equivalence claims that it makes.
+
+    """
+    document_uris = []
+    dcdoivalues = dc_dict.get('identifier', [])
+    for doi in dcdoivalues:
+        if not doi.startswith('doi:'):
+            doi = "doi:{}".format(doi)
+
+        document_uris.append({'claimant': claimant,
+                              'uri': doi,
+                              'type': 'dc-doi',
+                              'content_type': None})
+
+    return document_uris
+
+
+def document_uri_self_claim(claimant):
+    """Return a "self-claim" document URI dict for the given claimant."""
+    return {
+        'claimant': claimant,
+        'uri': claimant,
+        'type': u'self-claim',
+        'content_type': None,
+    }

--- a/h/api/schemas.py
+++ b/h/api/schemas.py
@@ -61,6 +61,119 @@ class AnnotationSchema(JSONSchema):
             'document': {
                 'type': 'object',
                 'properties': {
+                    'dc': {
+                        'type': 'object',
+                        'properties': {
+                            'identifier': {
+                                'type': 'array',
+                                'items': {
+                                    'type': 'string',
+                                },
+                            },
+                        },
+                    },
+                    'highwire': {
+                        'type': 'object',
+                        'properties': {
+                            'doi': {
+                                'type': 'array',
+                                'items': {
+                                    'type': 'string',
+                                },
+                            },
+                        },
+                    },
+                    'link': {
+                        'type': 'array',
+                        'items': {
+                            'type': 'object',
+                            'properties': {
+                                'href': {
+                                    'type': 'string',
+                                },
+                                'type': {
+                                    'type': 'string',
+                                },
+                            },
+                            'required': [
+                                'href',
+                            ],
+                        },
+                    },
+                },
+            },
+            'group': {
+                'type': 'string',
+            },
+            'permissions': {
+                'title': 'Permissions',
+                'description': 'Annotation action access control list',
+                'type': 'object',
+                'patternProperties': {
+                    '^(admin|delete|read|update)$': {
+                        'type': 'array',
+                        'items': {
+                            'type': 'string',
+                            'pattern': '^(acct:|group:).+$',
+                        },
+                    }
+                },
+                'required': [
+                    'read',
+                ],
+            },
+            'references': {
+                'type': 'array',
+                'items': {
+                    'type': 'string',
+                },
+            },
+            'tags': {
+                'type': 'array',
+                'items': {
+                    'type': 'string',
+                },
+            },
+            'target': {
+                'type': 'array',
+                'items': [
+                    {
+                        'type': 'object',
+                        'properties': {
+                            'selector': {
+                            },
+                        },
+                        'required': [
+                            'selector',
+                        ],
+                    },
+                ],
+            },
+            'text': {
+                'type': 'string',
+            },
+            'uri': {
+                'type': 'string',
+            },
+        },
+        'required': [
+            'permissions',
+        ],
+    }
+
+
+class LegacyAnnotationSchema(JSONSchema):
+
+    """
+    Validate an annotation object.
+    """
+
+    schema = {
+        'type': 'object',
+        'properties': {
+            'document': {
+                'type': 'object',
+                'properties': {
                     'link': {
                         'type': 'array',
                     },
@@ -161,7 +274,7 @@ class LegacyCreateAnnotationSchema(object):
 
     def __init__(self, request):
         self.request = request
-        self.structure = AnnotationSchema()
+        self.structure = LegacyAnnotationSchema()
 
     def validate(self, data):
         appstruct = self.structure.validate(data)
@@ -197,7 +310,7 @@ class UpdateAnnotationSchema(object):
     def __init__(self, request, annotation):
         self.request = request
         self.annotation = annotation
-        self.structure = AnnotationSchema()
+        self.structure = LegacyAnnotationSchema()
 
     def validate(self, data):
         appstruct = self.structure.validate(data)

--- a/h/api/schemas.py
+++ b/h/api/schemas.py
@@ -7,6 +7,8 @@ from jsonschema.exceptions import best_match
 from pyramid import i18n
 from pyramid import security
 
+from h.api import parse_document_claims
+
 _ = i18n.TranslationStringFactory(__package__)
 
 # These annotation fields are not to be set by the user.
@@ -133,6 +135,20 @@ class CreateAnnotationSchema(object):
             del new_appstruct['groupid']
 
         new_appstruct['extra'] = appstruct
+
+        # Transform the "document" dict that the client posts into a convenient
+        # format for creating DocumentURI and DocumentMeta objects later.
+        document_data = appstruct.pop('document', {})
+        document_uri_dicts = parse_document_claims.document_uris_from_data(
+            copy.deepcopy(document_data),
+            claimant=new_appstruct['target_uri'])
+        document_meta_dicts = parse_document_claims.document_metas_from_data(
+            copy.deepcopy(document_data),
+            claimant=new_appstruct['target_uri'])
+        new_appstruct['document'] = {
+            'document_uri_dicts': document_uri_dicts,
+            'document_meta_dicts': document_meta_dicts
+        }
 
         return new_appstruct
 

--- a/h/api/test/parse_document_claims_test.py
+++ b/h/api/test/parse_document_claims_test.py
@@ -1,0 +1,595 @@
+import mock
+import pytest
+
+from h.api import parse_document_claims
+
+
+class TestDocumentURIsFromLinks(object):
+
+    def test_it_ignores_href_links_that_match_the_claimant_uri(self):
+        """
+        Links containing only the claimant URI should be ignored.
+
+        If document.link contains a link dict with just an "href" and no other
+        keys, and the value of the "href" key is the same as the claimant URI,
+        then this link dict should be ignored and not produce an additional
+        document URI dict in the output (since the document URI that it would
+        generate would be the same as the "self-claim" claimant URI one that is
+        always generated anyway).
+
+        """
+        claimant = 'http://localhost:5000/docs/help'
+        link_dicts = [{'href': claimant}]
+
+        document_uris = parse_document_claims.document_uris_from_links(
+            link_dicts,
+            claimant,
+        )
+
+        assert document_uris == []
+
+    def test_it_ignores_doi_links(self):
+        """
+        Links containing only an href that starts with doi should be ignored.
+
+        If document.link contains a link dict with just an "href" and no other
+        keys, and the value of the "href" key begins with "doi:", then the link
+        dict should be ignored and not produce a document URI dict in the
+        output.
+
+        This is because document URI dicts for doi: URIs are generate
+        separately from other metadata in the document dict outside of the
+        "link" list.
+
+        """
+        link_dicts = [{'href': 'doi:10.3389/fenvs.2014.00003'}]
+
+        document_uris = parse_document_claims.document_uris_from_links(
+            link_dicts,
+            claimant='http://localhost:5000/docs/help'
+        )
+
+        assert document_uris == []
+
+    def test_it_ignores_highwire_pdf_links(self):
+        pdf_url = 'http://example.com/example.pdf'
+        link_dicts = [{'href': pdf_url, 'type': 'application/pdf'}]
+
+        document_uris = parse_document_claims.document_uris_from_links(
+            link_dicts,
+            claimant='http://localhost:5000/docs/help',
+        )
+
+        assert document_uris == []
+
+    def test_it_returns_rel_alternate_document_uris_for_rel_alternate_links(
+            self):
+        alternate_url = 'http://example.com/alternate'
+        link_dicts = [{'href': alternate_url, 'rel': 'alternate'}]
+
+        document_uris = parse_document_claims.document_uris_from_links(
+            link_dicts,
+            claimant='http://localhost:5000/docs/help',
+        )
+
+        alternate_document_uri = one(
+            [d for d in document_uris if d['type'] == 'rel-alternate'])
+        assert alternate_document_uri == {
+            'type': 'rel-alternate',
+            'claimant': 'http://localhost:5000/docs/help',
+            'content_type': None,
+            'uri': alternate_url,
+        }
+
+    def test_it_uses_link_types_as_document_uri_content_types(self):
+        """
+        Link types get converted to document URI content_types.
+
+        The value of the 'type' key in link dicts ends up as the value of the
+        'content_type' key in the returned document URI dicts.
+
+        """
+        link_dicts = [{'href': 'http://example.com/example.html',
+                       'type': 'text/html'}]
+
+        document_uris = parse_document_claims.document_uris_from_links(
+            link_dicts,
+            claimant='http://example.com/example.html',
+        )
+
+        assert one(
+            [d for d in document_uris if d.get('content_type') == 'text/html'])
+
+    def test_it_returns_multiple_document_URI_dicts(self):
+        """If there are multiple claims it should return multiple dicts."""
+        link_dicts = [
+            {
+                'href': 'http://example.com/example.html',
+                'type': 'text/html'
+            },
+            {
+                'href': 'http://example.com/alternate.html',
+                'rel': 'alternate'
+            },
+            {
+                'href': 'http://example.com/example2.html',
+                'type': 'text/html'
+            },
+        ]
+
+        document_uris = parse_document_claims.document_uris_from_links(
+            link_dicts,
+            claimant='http://example.com/claimant.html',
+        )
+
+        assert len(document_uris) == 3
+
+
+class TestDocumentMetasFromData(object):
+
+    @pytest.mark.parametrize("input_,output", [
+        # String values get turned into length 1 lists.
+        (
+            {
+                'foo': 'string',
+            },
+            {
+                'type': 'foo',
+                'value': ['string']
+            }
+        ),
+
+        # List values get copied over unchanged.
+        (
+            {
+                'foo': ['one', 'two'],
+            },
+            {
+                'type': 'foo',
+                'value': ['one', 'two']
+            }
+        ),
+
+        # Sub-dicts get flattened using a '.' separator in the key,
+        # and length 1 list values in sub-dicts get copied over unchanged.
+        (
+            {
+                'facebook': {
+                    'description': ['document description'],
+                }
+            },
+            {
+                'type': 'facebook.description',
+                'value': ['document description']
+            }
+        ),
+
+        # Length >1 list values in sub-dicts get copied over unchanged.
+        (
+            {
+                'facebook': {
+                    'image': [
+                        'http://example.com/image1.png',
+                        'http://example.com/image2.png',
+                        'http://example.com/image3.jpeg',
+                    ],
+                }
+            },
+            {
+                'type': 'facebook.image',
+                'value': [
+                    'http://example.com/image1.png',
+                    'http://example.com/image2.png',
+                    'http://example.com/image3.jpeg'
+                ]
+            }
+        ),
+
+        # String values in sub-dicts get turned into length 1 lists.
+        (
+            {
+                'foo': {
+                    'bar': 'string'
+                }
+            },
+            {
+                'type': 'foo.bar',
+                'value': ['string']
+            }
+        )
+    ])
+    def test_document_metas_from_data(self, input_, output):
+        claimant = 'http://example.com/claimant/'
+
+        document_metas = parse_document_claims.document_metas_from_data(
+            document_data=input_,
+            claimant=claimant)
+
+        assert document_metas == [{
+            'type': output['type'],
+            'value': output['value'],
+            'claimant': claimant,
+        }]
+
+    def test_document_metas_from_data_ignores_links_list(self):
+        """It should ignore the "link" list in the document_data."""
+        document_data = {
+            'link': [
+                {'href': 'http://example.com/link'},
+            ]
+        }
+
+        document_metas = parse_document_claims.document_metas_from_data(
+            document_data, 'http://example/claimant')
+
+        assert document_metas == []
+
+    def test_document_metas_from_data_with_multiple_metadata_claims(self):
+        """
+        It should create one DocumentMeta for each metadata claim.
+
+        If document_data contains multiple metadata claims it should init one
+        DocumentMeta for each claim.
+
+        """
+        claimant = 'http://example/claimant'
+        document_data = {
+            'title': 'the title',
+            'description': 'the description',
+            'site_title': 'the site title'
+        }
+
+        document_metas = parse_document_claims.document_metas_from_data(
+            document_data, claimant)
+
+        assert len(document_metas) == len(document_data.items())
+        for key, value in document_data.items():
+            assert {
+                'type': key,
+                'value': [value],
+                'claimant': claimant,
+                } in document_metas
+
+
+class TestDocumentURIsFromHighwirePDF(object):
+
+    def test_highwire_pdf_values_produce_highwire_pdf_document_uris(self):
+        highwire_dict = {
+                'pdf_url': ['http://example.com/1.pdf',
+                            'http://example.com/2.pdf',
+                            'http://example.com/3.pdf'],
+        }
+
+        document_uris = parse_document_claims.document_uris_from_highwire_pdf(
+            highwire_dict,
+            claimant='http://example.com/example.html',
+        )
+
+        for pdf in highwire_dict['pdf_url']:
+            document_uri = one([d for d in document_uris
+                                if d.get('uri') == pdf])
+            assert document_uri == {
+                'claimant': 'http://example.com/example.html',
+                'uri': pdf,
+                'type': 'highwire-pdf',
+                'content_type': 'application/pdf',
+            }
+
+
+class TestDocumentURIsFromHighwireDOI(object):
+
+    def test_highwire_doi_values_produce_highwire_doi_document_uris(self):
+        highwire_dict = {
+            'doi': ['doi:10.10.1038/nphys1170', 'doi:10.1002/0470841559.ch1',
+                    'doi:10.1594/PANGAEA.726855'],
+        }
+
+        document_uris = parse_document_claims.document_uris_from_highwire_doi(
+            highwire_dict,
+            claimant='http://example.com/example.html',
+        )
+
+        for doi in highwire_dict['doi']:
+            document_uri = one([d for d in document_uris
+                                if d.get('uri') == doi])
+            assert document_uri == {
+                'claimant': 'http://example.com/example.html',
+                'uri': doi,
+                'type': 'highwire-doi',
+                'content_type': None,
+            }
+
+    def test_doi_is_prepended_to_highwire_dois(self):
+        """If a highwire DOI doesn't begin with 'doi:' it is prepended."""
+        highwire_dict = {'doi': ['10.10.1038/nphys1170']}
+
+        document_uris = parse_document_claims.document_uris_from_highwire_doi(
+            highwire_dict,
+            claimant='http://example.com/example.html',
+        )
+
+        expected_uri = 'doi:' + highwire_dict['doi'][0]
+        one([d for d in document_uris if d.get('uri') == expected_uri])
+
+
+class TestDocumentURIsFromDC(object):
+
+    def test_dc_identifiers_produce_dc_doi_document_uris(self):
+        """Each 'identifier' list item in the 'dc' dict becomes a doc URI."""
+        dc_dict = {
+            'identifier': [
+                'doi:10.10.1038/nphys1170',
+                'doi:10.1002/0470841559.ch1',
+                'doi:10.1594/PANGAEA.726855'
+            ]
+        }
+
+        document_uris = parse_document_claims.document_uris_from_dc(
+            dc_dict,
+            claimant='http://example.com/example.html',
+        )
+
+        for doi in dc_dict['identifier']:
+            document_uri = one([d for d in document_uris
+                                if d.get('uri') == doi])
+            assert document_uri == {
+                'claimant': 'http://example.com/example.html',
+                'uri': doi,
+                'type': 'dc-doi',
+                'content_type': None,
+            }
+
+    def test_doi_is_prepended_to_dc_identifiers(self):
+        """If a dc identifier doesn't begin with 'doi:' it is prepended."""
+        dc_dict = {'identifier': ['10.10.1038/nphys1170']}
+
+        document_uris = parse_document_claims.document_uris_from_dc(
+            dc_dict,
+            claimant='http://example.com/example.html',
+        )
+
+        expected_uri = 'doi:' + dc_dict['identifier'][0]
+        one([d for d in document_uris if d.get('uri') == expected_uri])
+
+
+class TestDocumentURISelfClaim(object):
+
+    def test_document_uri_self_claim(self):
+        claimant = 'http://localhost:5000/docs/help'
+
+        document_uri = parse_document_claims.document_uri_self_claim(
+            claimant)
+
+        assert document_uri == {
+            'claimant': claimant,
+            'uri': claimant,
+            'type': 'self-claim',
+            'content_type': None,
+        }
+
+
+@pytest.mark.usefixtures('document_uris_from_dc',
+                         'document_uris_from_highwire_doi',
+                         'document_uris_from_highwire_pdf',
+                         'document_uris_from_links',
+                         'document_uri_self_claim')
+class TestDocumentURIsFromData(object):
+
+    def test_it_calls_document_uris_from_links(self, document_uris_from_links):
+        document_data = {
+            'link': [
+                # In production these would be link dicts not strings.
+                'link_dict_1',
+                'link_dict_2',
+                'link_dict_3',
+            ]
+
+        }
+        claimant = 'http://localhost:5000/docs/help'
+        document_uris_from_links.return_value = [
+            mock.Mock(), mock.Mock(), mock.Mock()]
+
+        document_uris = parse_document_claims.document_uris_from_data(
+            document_data=document_data,
+            claimant=claimant,
+        )
+
+        document_uris_from_links.assert_called_once_with(
+            document_data['link'], claimant)
+        for document_uri in document_uris_from_links.return_value:
+            assert document_uri in document_uris
+
+    def test_calling_document_uris_from_links_when_no_links(
+            self,
+            document_uris_from_links):
+        document_data = {}  # No 'link' key.
+        claimant = 'http://localhost:5000/docs/help'
+
+        parse_document_claims.document_uris_from_data(
+            document_data=document_data,
+            claimant=claimant,
+        )
+
+        document_uris_from_links.assert_called_once_with(
+            [], claimant)
+
+    def test_it_calls_documents_uris_from_highwire_pdf(
+            self,
+            document_uris_from_highwire_pdf):
+        document_data = {
+            'highwire': {
+                'pdf': [
+                    'pdf_1',
+                    'pdf_2',
+                    'pdf_3',
+                ]
+            }
+        }
+        claimant = 'http://localhost:5000/docs/help'
+        document_uris_from_highwire_pdf.return_value = [
+            mock.Mock(), mock.Mock(), mock.Mock()]
+
+        document_uris = parse_document_claims.document_uris_from_data(
+            document_data=document_data,
+            claimant=claimant,
+        )
+
+        document_uris_from_highwire_pdf.assert_called_once_with(
+            document_data['highwire'], claimant)
+        for document_uri in document_uris_from_highwire_pdf.return_value:
+            assert document_uri in document_uris
+
+    def test_calling_document_uris_from_highwire_pdf_when_no_highwire(
+            self,
+            document_uris_from_highwire_pdf):
+        document_data = {}  # No 'highwire' key.
+        claimant = 'http://localhost:5000/docs/help'
+
+        parse_document_claims.document_uris_from_data(
+            document_data=document_data,
+            claimant=claimant,
+        )
+
+        document_uris_from_highwire_pdf.assert_called_once_with(
+            {}, claimant)
+
+    def test_it_calls_documents_uris_from_highwire_doi(
+            self,
+            document_uris_from_highwire_doi):
+        document_data = {
+            'highwire': {
+                'doi': [
+                    'doi_1',
+                    'doi_2',
+                    'doi_3',
+                ]
+            }
+        }
+        claimant = 'http://localhost:5000/docs/help'
+        document_uris_from_highwire_doi.return_value = [
+            mock.Mock(), mock.Mock(), mock.Mock()]
+
+        document_uris = parse_document_claims.document_uris_from_data(
+            document_data=document_data,
+            claimant=claimant,
+        )
+
+        document_uris_from_highwire_doi.assert_called_once_with(
+            document_data['highwire'], claimant)
+        for document_uri in document_uris_from_highwire_doi.return_value:
+            assert document_uri in document_uris
+
+    def test_calling_document_uris_from_highwire_doi_when_no_highwire(
+            self,
+            document_uris_from_highwire_doi):
+        document_data = {}  # No 'highwire' key.
+        claimant = 'http://localhost:5000/docs/help'
+
+        parse_document_claims.document_uris_from_data(
+            document_data=document_data,
+            claimant=claimant,
+        )
+
+        document_uris_from_highwire_doi.assert_called_once_with(
+            {}, claimant)
+
+    def test_it_calls_documents_uris_from_dc(self,
+                                             document_uris_from_dc):
+        document_data = {
+            'dc': {
+                'identifier': [
+                    'doi_1',
+                    'doi_2',
+                    'doi_3',
+                ]
+            }
+        }
+        claimant = 'http://localhost:5000/docs/help'
+        document_uris_from_dc.return_value = [
+            mock.Mock(), mock.Mock(), mock.Mock()]
+
+        document_uris = parse_document_claims.document_uris_from_data(
+            document_data=document_data,
+            claimant=claimant,
+        )
+
+        document_uris_from_dc.assert_called_once_with(
+            document_data['dc'], claimant)
+        for document_uri in document_uris_from_dc.return_value:
+            assert document_uri in document_uris
+
+    def test_calling_document_uris_from_dc_when_no_dc(self,
+                                                      document_uris_from_dc):
+        document_data = {}  # No 'dc' key.
+        claimant = 'http://localhost:5000/docs/help'
+
+        parse_document_claims.document_uris_from_data(
+            document_data=document_data,
+            claimant=claimant,
+        )
+
+        document_uris_from_dc.assert_called_once_with(
+            {}, claimant)
+
+    def test_it_calls_document_uri_self_claim(self, document_uri_self_claim):
+        claimant = 'http://example.com/claimant'
+
+        document_uris = parse_document_claims.document_uris_from_data(
+            {}, claimant)
+
+        document_uri_self_claim.assert_called_once_with(claimant)
+        assert document_uri_self_claim.return_value in document_uris
+
+    @pytest.fixture
+    def document_uris_from_dc(self, request):
+        patcher = mock.patch(
+            'h.api.parse_document_claims.document_uris_from_dc',
+            autospec=True)
+        document_uris_from_dc = patcher.start()
+        document_uris_from_dc.return_value = []
+        request.addfinalizer(patcher.stop)
+        return document_uris_from_dc
+
+    @pytest.fixture
+    def document_uris_from_highwire_pdf(self, request):
+        patcher = mock.patch(
+            'h.api.parse_document_claims.document_uris_from_highwire_pdf',
+            autospec=True)
+        document_uris_from_highwire_pdf = patcher.start()
+        document_uris_from_highwire_pdf.return_value = []
+        request.addfinalizer(patcher.stop)
+        return document_uris_from_highwire_pdf
+
+    @pytest.fixture
+    def document_uris_from_highwire_doi(self, request):
+        patcher = mock.patch(
+            'h.api.parse_document_claims.document_uris_from_highwire_doi',
+            autospec=True)
+        document_uris_from_highwire_doi = patcher.start()
+        document_uris_from_highwire_doi.return_value = []
+        request.addfinalizer(patcher.stop)
+        return document_uris_from_highwire_doi
+
+    @pytest.fixture
+    def document_uris_from_links(self, request):
+        patcher = mock.patch(
+            'h.api.parse_document_claims.document_uris_from_links',
+            autospec=True)
+        document_uris_from_links = patcher.start()
+        document_uris_from_links.return_value = []
+        request.addfinalizer(patcher.stop)
+        return document_uris_from_links
+
+    @pytest.fixture
+    def document_uri_self_claim(self, request):
+        patcher = mock.patch(
+            'h.api.parse_document_claims.document_uri_self_claim',
+            autospec=True)
+        document_uri_self_claim = patcher.start()
+        request.addfinalizer(patcher.stop)
+        return document_uri_self_claim
+
+
+def one(list_):
+    assert len(list_) == 1
+    return list_[0]

--- a/h/api/test/schemas_test.py
+++ b/h/api/test/schemas_test.py
@@ -16,245 +16,246 @@ class ExampleSchema(schemas.JSONSchema):
     }
 
 
-def test_jsonschema_returns_data_when_valid():
-    data = "a string"
+class TestJSONSchema(object):
 
-    assert ExampleSchema().validate(data) == data
+    def test_it_returns_data_when_valid(self):
+        data = "a string"
 
+        assert ExampleSchema().validate(data) == data
 
-def test_jsonschema_raises_when_data_invalid():
-    data = 123  # not a string
+    def test_it_raises_when_data_invalid(self):
+        data = 123  # not a string
 
-    with pytest.raises(schemas.ValidationError):
-        ExampleSchema().validate(data)
+        with pytest.raises(schemas.ValidationError):
+            ExampleSchema().validate(data)
 
+    def test_it_sets_appropriate_error_message_when_data_invalid(self):
+        data = 123  # not a string
 
-def test_jsonschema_sets_appropriate_error_message_when_data_invalid():
-    data = 123  # not a string
+        with pytest.raises(schemas.ValidationError) as e:
+            ExampleSchema().validate(data)
 
-    with pytest.raises(schemas.ValidationError) as e:
-        ExampleSchema().validate(data)
-
-    message = e.value.message
-    assert message.startswith("123 is not of type 'string'")
-
-
-def test_createannotationschema_passes_input_to_structure_validator():
-    request = testing.DummyRequest()
-    schema = schemas.CreateAnnotationSchema(request)
-    schema.structure = mock.Mock()
-    schema.structure.validate.return_value = {}
-
-    schema.validate({'foo': 'bar'})
-
-    schema.structure.validate.assert_called_once_with({'foo': 'bar'})
+        message = e.value.message
+        assert message.startswith("123 is not of type 'string'")
 
 
-def test_createannotationschema_raises_if_structure_validator_raises():
-    request = testing.DummyRequest()
-    schema = schemas.CreateAnnotationSchema(request)
-    schema.structure = mock.Mock()
-    schema.structure.validate.side_effect = schemas.ValidationError('asplode')
+class TestCreateAnnotationSchema(object):
 
-    with pytest.raises(schemas.ValidationError):
+    def test_it_passes_input_to_structure_validator(self):
+        request = testing.DummyRequest()
+        schema = schemas.CreateAnnotationSchema(request)
+        schema.structure = mock.Mock()
+        schema.structure.validate.return_value = {}
+
         schema.validate({'foo': 'bar'})
 
+        schema.structure.validate.assert_called_once_with({'foo': 'bar'})
 
-@pytest.mark.parametrize('field', [
-    'created',
-    'updated',
-    'id',
-])
-def test_createannotationschema_removes_protected_fields(field):
-    request = testing.DummyRequest()
-    schema = schemas.CreateAnnotationSchema(request)
-    data = {}
-    data[field] = 'something forbidden'
+    def test_it_raises_if_structure_validator_raises(self):
+        request = testing.DummyRequest()
+        schema = schemas.CreateAnnotationSchema(request)
+        schema.structure = mock.Mock()
+        schema.structure.validate.side_effect = schemas.ValidationError(
+            'asplode')
 
-    result = schema.validate(data)
+        with pytest.raises(schemas.ValidationError):
+            schema.validate({'foo': 'bar'})
 
-    assert field not in result
+    @pytest.mark.parametrize('field', [
+        'created',
+        'updated',
+        'id',
+    ])
+    def test_it_removes_protected_fields(self, field):
+        request = testing.DummyRequest()
+        schema = schemas.CreateAnnotationSchema(request)
+        data = {}
+        data[field] = 'something forbidden'
 
-
-@pytest.mark.parametrize('data', [
-    {},
-    {'user': None},
-    {'user': 'acct:foo@bar.com'},
-])
-def test_createannotationschema_ignores_input_user(data, authn_policy):
-    """Any user field sent in the payload should be ignored."""
-    authn_policy.authenticated_userid.return_value = 'acct:jeanie@example.com'
-    request = testing.DummyRequest()
-    schema = schemas.CreateAnnotationSchema(request)
-
-    result = schema.validate(data)
-
-    assert result == {'user': 'acct:jeanie@example.com'}
-
-
-@pytest.mark.parametrize('data,effective_principals,ok', [
-    # No group supplied
-    ({}, [], True),
-
-    # World group
-    ({'group': '__world__'}, [], False),
-    ({'group': '__world__'}, [security.Everyone], True),
-
-    # Other group
-    ({'group': 'abcdef'}, [], False),
-    ({'group': 'abcdef'}, [security.Everyone], False),
-    ({'group': 'abcdef'}, [security.Everyone, 'group:abcdef'], True),
-])
-def test_createannotationschema_rejects_annotations_to_other_groups(data,
-                                                                    effective_principals,
-                                                                    ok,
-                                                                    authn_policy):
-    """
-    A user cannot create an annotation in a group they're not a member of.
-
-    If a group is specified in the annotation, then reject the creation if the
-    relevant group principal is not present in the request's effective
-    principals.
-    """
-    authn_policy.effective_principals.return_value = effective_principals
-    request = testing.DummyRequest()
-    schema = schemas.CreateAnnotationSchema(request)
-
-    if ok:
         result = schema.validate(data)
-        assert result.get('group') == data.get('group')
 
-    else:
+        assert field not in result
+
+    @pytest.mark.parametrize('data', [
+        {},
+        {'user': None},
+        {'user': 'acct:foo@bar.com'},
+    ])
+    def test_it_ignores_input_user(self, data, authn_policy):
+        """Any user field sent in the payload should be ignored."""
+        authn_policy.authenticated_userid.return_value = (
+            'acct:jeanie@example.com')
+        request = testing.DummyRequest()
+        schema = schemas.CreateAnnotationSchema(request)
+
+        result = schema.validate(data)
+
+        assert result == {'user': 'acct:jeanie@example.com'}
+
+    @pytest.mark.parametrize('data,effective_principals,ok', [
+        # No group supplied
+        ({}, [], True),
+
+        # World group
+        ({'group': '__world__'}, [], False),
+        ({'group': '__world__'}, [security.Everyone], True),
+
+        # Other group
+        ({'group': 'abcdef'}, [], False),
+        ({'group': 'abcdef'}, [security.Everyone], False),
+        ({'group': 'abcdef'}, [security.Everyone, 'group:abcdef'], True),
+    ])
+    def test_it_rejects_annotations_to_other_groups(self,
+                                                    data,
+                                                    effective_principals,
+                                                    ok,
+                                                    authn_policy):
+        """
+        A user cannot create an annotation in a group they're not a member of.
+
+        If a group is specified in the annotation, then reject the creation if
+        the relevant group principal is not present in the request's effective
+        principals.
+        """
+        authn_policy.effective_principals.return_value = effective_principals
+        request = testing.DummyRequest()
+        schema = schemas.CreateAnnotationSchema(request)
+
+        if ok:
+            result = schema.validate(data)
+            assert result.get('group') == data.get('group')
+
+        else:
+            with pytest.raises(schemas.ValidationError) as exc:
+                schema.validate(data)
+            assert exc.value.message.startswith('group:')
+
+    @pytest.mark.parametrize('data', [
+        {},
+        {'foo': 'bar'},
+        {'a_list': ['of', 'important', 'things']},
+        {'an_object': {'with': 'stuff'}},
+        {'numbers': 12345},
+        {'null': None},
+    ])
+    def test_it_permits_all_other_changes(self, data):
+        request = testing.DummyRequest()
+        schema = schemas.CreateAnnotationSchema(request)
+
+        result = schema.validate(data)
+
+        for k in data:
+            assert result[k] == data[k]
+
+
+class TestUpdateAnnotationSchema(object):
+
+    def test_it_passes_input_to_structure_validator(self):
+        request = testing.DummyRequest()
+        schema = schemas.UpdateAnnotationSchema(request, {})
+        schema.structure = mock.Mock()
+        schema.structure.validate.return_value = {}
+
+        schema.validate({'foo': 'bar'})
+
+        schema.structure.validate.assert_called_once_with({'foo': 'bar'})
+
+    def test_it_raises_if_structure_validator_raises(self):
+        request = testing.DummyRequest()
+        schema = schemas.UpdateAnnotationSchema(request, {})
+        schema.structure = mock.Mock()
+        schema.structure.validate.side_effect = (
+            schemas.ValidationError('asplode'))
+
+        with pytest.raises(schemas.ValidationError):
+            schema.validate({'foo': 'bar'})
+
+    @pytest.mark.parametrize('field', [
+        'created',
+        'updated',
+        'user',
+        'id',
+    ])
+    def test_it_removes_protected_fields(self, field):
+        request = testing.DummyRequest()
+        annotation = {}
+        schema = schemas.UpdateAnnotationSchema(request, annotation)
+        data = {}
+        data[field] = 'something forbidden'
+
+        result = schema.validate(data)
+
+        assert field not in result
+
+    def test_it_allows_permissions_changes_if_admin(self, authn_policy):
+        """If a user is an admin on an annotation, they can change perms."""
+        authn_policy.authenticated_userid.return_value = (
+            'acct:harriet@example.com')
+        request = testing.DummyRequest()
+        annotation = {
+            'permissions': {'admin': ['acct:harriet@example.com']}
+        }
+        schema = schemas.UpdateAnnotationSchema(request, annotation)
+        data = {
+            'permissions': {'admin': ['acct:foo@example.com']}
+        }
+
+        result = schema.validate(data)
+
+        assert result == data
+
+    @pytest.mark.parametrize('annotation', [
+        {},
+        {'permissions': {}},
+        {'permissions': {'admin': []}},
+        {'permissions': {'admin': ['acct:alice@example.com']}},
+        {'permissions': {'read': ['acct:mallory@example.com']}},
+    ])
+    def test_it_denies_permissions_changes_if_not_admin(self,
+                                                        annotation,
+                                                        authn_policy):
+        """If a user isn't admin on an annotation they can't change perms."""
+        authn_policy.authenticated_userid.return_value = (
+            'acct:mallory@example.com')
+        request = testing.DummyRequest()
+        schema = schemas.UpdateAnnotationSchema(request, annotation)
+        data = {
+            'permissions': {'admin': ['acct:mallory@example.com']}
+        }
+
         with pytest.raises(schemas.ValidationError) as exc:
             schema.validate(data)
+
+        assert exc.value.message.startswith('permissions:')
+
+    def test_it_denies_group_changes(self):
+        """An annotation may not be moved between groups."""
+        request = testing.DummyRequest()
+        annotation = {'group': 'flibble'}
+        schema = schemas.UpdateAnnotationSchema(request, annotation)
+        data = {
+            'group': '__world__'
+        }
+
+        with pytest.raises(schemas.ValidationError) as exc:
+            schema.validate(data)
+
         assert exc.value.message.startswith('group:')
 
+    @pytest.mark.parametrize('data', [
+        {},
+        {'foo': 'bar'},
+        {'a_list': ['of', 'important', 'things']},
+        {'an_object': {'with': 'stuff'}},
+        {'numbers': 12345},
+        {'null': None},
+    ])
+    def test_it_permits_all_other_changes(self, data):
+        request = testing.DummyRequest()
+        annotation = {'group': 'flibble'}
+        schema = schemas.UpdateAnnotationSchema(request, annotation)
 
-@pytest.mark.parametrize('data', [
-    {},
-    {'foo': 'bar'},
-    {'a_list': ['of', 'important', 'things']},
-    {'an_object': {'with': 'stuff'}},
-    {'numbers': 12345},
-    {'null': None},
-])
-def test_createannotationschema_permits_all_other_changes(data):
-    request = testing.DummyRequest()
-    schema = schemas.CreateAnnotationSchema(request)
+        result = schema.validate(data)
 
-    result = schema.validate(data)
-
-    for k in data:
-        assert result[k] == data[k]
-
-
-def test_updateannotationschema_passes_input_to_structure_validator():
-    request = testing.DummyRequest()
-    schema = schemas.UpdateAnnotationSchema(request, {})
-    schema.structure = mock.Mock()
-    schema.structure.validate.return_value = {}
-
-    schema.validate({'foo': 'bar'})
-
-    schema.structure.validate.assert_called_once_with({'foo': 'bar'})
-
-
-def test_updateannotationschema_raises_if_structure_validator_raises():
-    request = testing.DummyRequest()
-    schema = schemas.UpdateAnnotationSchema(request, {})
-    schema.structure = mock.Mock()
-    schema.structure.validate.side_effect = schemas.ValidationError('asplode')
-
-    with pytest.raises(schemas.ValidationError):
-        schema.validate({'foo': 'bar'})
-
-
-@pytest.mark.parametrize('field', [
-    'created',
-    'updated',
-    'user',
-    'id',
-])
-def test_updateannotationschema_removes_protected_fields(field):
-    request = testing.DummyRequest()
-    annotation = {}
-    schema = schemas.UpdateAnnotationSchema(request, annotation)
-    data = {}
-    data[field] = 'something forbidden'
-
-    result = schema.validate(data)
-
-    assert field not in result
-
-
-def test_updateannotationschema_allows_permissions_changes_if_admin(authn_policy):
-    """If a user is an admin on an annotation, they can change perms."""
-    authn_policy.authenticated_userid.return_value = 'acct:harriet@example.com'
-    request = testing.DummyRequest()
-    annotation = {
-        'permissions': {'admin': ['acct:harriet@example.com']}
-    }
-    schema = schemas.UpdateAnnotationSchema(request, annotation)
-    data = {
-        'permissions': {'admin': ['acct:foo@example.com']}
-    }
-
-    result = schema.validate(data)
-
-    assert result == data
-
-
-@pytest.mark.parametrize('annotation', [
-    {},
-    {'permissions': {}},
-    {'permissions': {'admin': []}},
-    {'permissions': {'admin': ['acct:alice@example.com']}},
-    {'permissions': {'read': ['acct:mallory@example.com']}},
-])
-def test_updateannotationschema_denies_permissions_changes_if_not_admin(annotation, authn_policy):
-    """If a user is not an admin on an annotation, they cannot change perms."""
-    authn_policy.authenticated_userid.return_value = 'acct:mallory@example.com'
-    request = testing.DummyRequest()
-    schema = schemas.UpdateAnnotationSchema(request, annotation)
-    data = {
-        'permissions': {'admin': ['acct:mallory@example.com']}
-    }
-
-    with pytest.raises(schemas.ValidationError) as exc:
-        schema.validate(data)
-
-    assert exc.value.message.startswith('permissions:')
-
-
-def test_updateannotationschema_denies_group_changes():
-    """An annotation may not be moved between groups."""
-    request = testing.DummyRequest()
-    annotation = {'group': 'flibble'}
-    schema = schemas.UpdateAnnotationSchema(request, annotation)
-    data = {
-        'group': '__world__'
-    }
-
-    with pytest.raises(schemas.ValidationError) as exc:
-        schema.validate(data)
-
-    assert exc.value.message.startswith('group:')
-
-
-@pytest.mark.parametrize('data', [
-    {},
-    {'foo': 'bar'},
-    {'a_list': ['of', 'important', 'things']},
-    {'an_object': {'with': 'stuff'}},
-    {'numbers': 12345},
-    {'null': None},
-])
-def test_updateannotationschema_permits_all_other_changes(data):
-    request = testing.DummyRequest()
-    annotation = {'group': 'flibble'}
-    schema = schemas.UpdateAnnotationSchema(request, annotation)
-
-    result = schema.validate(data)
-
-    for k in data:
-        assert result[k] == data[k]
+        for k in data:
+            assert result[k] == data[k]

--- a/h/api/test/schemas_test.py
+++ b/h/api/test/schemas_test.py
@@ -39,6 +39,368 @@ class TestJSONSchema(object):
         assert message.startswith("123 is not of type 'string'")
 
 
+class TestAnnotationSchema(object):
+
+    def test_it_does_not_raise_for_minimal_valid_data(self):
+        schema = schemas.AnnotationSchema()
+
+        # Use only the required fields.
+        schema.validate(self.valid_input_data())
+
+    def test_it_does_not_raise_for_full_valid_data(self):
+        schema = schemas.AnnotationSchema()
+
+        # Use all the keys to make sure that valid data for all of them passes.
+        schema.validate({
+            'document': {
+                'dc': {
+                    'identifier': ['foo', 'bar']
+                },
+                'highwire': {
+                    'doi': ['foo', 'bar']
+                },
+                'link': [
+                    {
+                        'href': 'foo',
+                        'type': 'foo',
+                    },
+                    {
+                        'href': 'foo',
+                        'type': 'foo',
+                    }
+                ],
+            },
+            'group': 'foo',
+            'permissions': {
+                'admin': ['acct:foo', 'group:bar'],
+                'delete': ['acct:foo', 'group:bar'],
+                'read': ['acct:foo', 'group:bar'],
+                'update': ['acct:foo', 'group:bar'],
+            },
+            'references': ['foo', 'bar'],
+            'tags': ['foo', 'bar'],
+            'target': [
+                {
+                    'selector': 'foo'
+                },
+                {
+                    'selector': 'foo'
+                },
+            ],
+            'text': 'foo',
+            'uri' : 'foo',
+        })
+
+    def test_it_raises_if_document_is_not_a_dict(self):
+        schema = schemas.AnnotationSchema()
+
+        with pytest.raises(schemas.ValidationError) as err:
+            schema.validate(self.valid_input_data(
+                document=False,
+            ))
+
+        assert str(err.value) == "document: False is not of type 'object'"
+
+    def test_it_raises_if_document_dc_is_not_a_dict(self):
+        schema = schemas.AnnotationSchema()
+
+        with pytest.raises(schemas.ValidationError) as err:
+            schema.validate(self.valid_input_data(
+                document={'dc': False}
+            ))
+
+        assert str(err.value) == "document.dc: False is not of type 'object'"
+
+    def test_it_raises_if_document_dc_identifier_is_not_a_list(self):
+        schema = schemas.AnnotationSchema()
+
+        with pytest.raises(schemas.ValidationError) as err:
+            schema.validate(self.valid_input_data(
+                document={'dc': {'identifier': False}}
+            ))
+
+        assert str(err.value) == (
+            "document.dc.identifier: False is not of type 'array'")
+
+    def test_it_raises_if_document_dc_identifier_item_is_not_a_string(self):
+        schema = schemas.AnnotationSchema()
+
+        with pytest.raises(schemas.ValidationError) as err:
+            schema.validate(self.valid_input_data(
+                document={'dc': {'identifier': [False]}}
+            ))
+
+        assert str(err.value) == (
+            "document.dc.identifier.0: False is not of type 'string'")
+
+    def test_it_raises_if_document_highwire_is_not_a_dict(self):
+        schema = schemas.AnnotationSchema()
+
+        with pytest.raises(schemas.ValidationError) as err:
+            schema.validate(self.valid_input_data(
+                document={'highwire': False}
+            ))
+
+        assert str(err.value) == (
+            "document.highwire: False is not of type 'object'")
+
+    def test_it_raises_if_document_highwire_doi_is_not_a_list(self):
+        schema = schemas.AnnotationSchema()
+
+        with pytest.raises(schemas.ValidationError) as err:
+            schema.validate(self.valid_input_data(
+                document={'highwire': {'doi': False}}
+            ))
+
+        assert str(err.value) == (
+            "document.highwire.doi: False is not of type 'array'")
+
+    def test_it_raises_if_document_highwire_doi_item_is_not_a_string(self):
+        schema = schemas.AnnotationSchema()
+
+        with pytest.raises(schemas.ValidationError) as err:
+            schema.validate(self.valid_input_data(
+                document={'highwire': {'doi': [False]}}
+            ))
+
+        assert str(err.value) == (
+            "document.highwire.doi.0: False is not of type 'string'")
+
+    def test_it_raises_if_document_link_is_not_a_list(self):
+        schema = schemas.AnnotationSchema()
+
+        with pytest.raises(schemas.ValidationError) as err:
+            schema.validate(self.valid_input_data(
+                document={'link': False}
+            ))
+
+        assert str(err.value) == "document.link: False is not of type 'array'"
+
+    def test_it_raises_if_document_link_item_is_not_a_dict(self):
+        schema = schemas.AnnotationSchema()
+
+        with pytest.raises(schemas.ValidationError) as err:
+            schema.validate(self.valid_input_data(
+                document={'link': [False]}
+            ))
+
+        assert str(err.value) == (
+            "document.link.0: False is not of type 'object'")
+
+    def test_it_raises_if_document_link_item_has_no_href(self):
+        schema = schemas.AnnotationSchema()
+
+        with pytest.raises(schemas.ValidationError) as err:
+            schema.validate(self.valid_input_data(
+                document={'link': [{}]}
+            ))
+
+        assert str(err.value) == (
+            "document.link.0: 'href' is a required property")
+
+    def test_it_raises_if_document_link_item_href_is_not_a_string(self):
+        schema = schemas.AnnotationSchema()
+
+        with pytest.raises(schemas.ValidationError) as err:
+            schema.validate(self.valid_input_data(
+                document={'link': [{'href': False}]}
+            ))
+
+        assert str(err.value) == (
+            "document.link.0.href: False is not of type 'string'")
+
+    def test_it_raises_if_document_link_item_type_is_not_a_string(self):
+        schema = schemas.AnnotationSchema()
+
+        with pytest.raises(schemas.ValidationError) as err:
+            schema.validate(self.valid_input_data(
+                document={
+                    'link': [
+                        {
+                            'href': 'http://example.com',
+                            'type': False
+                        }
+                    ]
+                }
+            ))
+
+        assert str(err.value) == (
+            "document.link.0.type: False is not of type 'string'")
+
+    def test_it_raises_if_group_is_not_a_string(self):
+        schema = schemas.AnnotationSchema()
+
+        with pytest.raises(schemas.ValidationError) as err:
+            schema.validate(self.valid_input_data(
+                group=False
+            ))
+
+        assert str(err.value) == "group: False is not of type 'string'"
+
+    def test_it_raises_if_permissions_is_missing(self):
+        schema = schemas.AnnotationSchema()
+        data = self.valid_input_data()
+        del data['permissions']
+
+        with pytest.raises(schemas.ValidationError) as err:
+            schema.validate(data)
+
+        assert str(err.value) == "'permissions' is a required property"
+
+    def test_it_raises_if_permissions_is_not_a_dict(self):
+        schema = schemas.AnnotationSchema()
+
+        with pytest.raises(schemas.ValidationError) as err:
+            schema.validate(self.valid_input_data(
+                permissions=False
+            ))
+
+        assert str(err.value) == "permissions: False is not of type 'object'"
+
+    def test_it_raises_if_permissions_has_no_read(self):
+        schema = schemas.AnnotationSchema()
+
+        with pytest.raises(schemas.ValidationError) as err:
+            schema.validate(self.valid_input_data(
+                permissions={}
+            ))
+
+        assert str(err.value) == "permissions: 'read' is a required property"
+
+    def test_it_raises_if_permissions_read_is_not_a_list(self):
+        schema = schemas.AnnotationSchema()
+
+        with pytest.raises(schemas.ValidationError) as err:
+            schema.validate(self.valid_input_data(
+                permissions={'read': False}
+            ))
+
+        assert str(err.value) == (
+            "permissions.read: False is not of type 'array'")
+
+    def test_it_raises_if_permissions_read_item_is_not_a_string(self):
+        schema = schemas.AnnotationSchema()
+
+        with pytest.raises(schemas.ValidationError) as err:
+            schema.validate(self.valid_input_data(
+                permissions={'read': [False]}
+            ))
+
+        assert str(err.value) == (
+            "permissions.read.0: False is not of type 'string'")
+
+    def test_it_raises_if_permissions_read_item_is_wrong_format(self):
+        schema = schemas.AnnotationSchema()
+
+        with pytest.raises(schemas.ValidationError) as err:
+            schema.validate(self.valid_input_data(
+                permissions={'read': ["foo"]}
+            ))
+
+        assert str(err.value) == (
+            "permissions.read.0: u'foo' does not match '^(acct:|group:).+$'")
+
+    def test_it_raises_if_references_is_not_a_list(self):
+        schema = schemas.AnnotationSchema()
+
+        with pytest.raises(schemas.ValidationError) as err:
+            schema.validate(self.valid_input_data(
+                references=False
+            ))
+
+        assert str(err.value) == "references: False is not of type 'array'"
+
+    def test_it_raises_if_references_item_is_not_a_string(self):
+        schema = schemas.AnnotationSchema()
+
+        with pytest.raises(schemas.ValidationError) as err:
+            schema.validate(self.valid_input_data(
+                references=[False]
+            ))
+
+        assert str(err.value) == "references.0: False is not of type 'string'"
+
+    def test_it_raises_if_tags_is_not_a_list(self):
+        schema = schemas.AnnotationSchema()
+
+        with pytest.raises(schemas.ValidationError) as err:
+            schema.validate(self.valid_input_data(
+                tags=False
+            ))
+
+        assert str(err.value) == "tags: False is not of type 'array'"
+
+    def test_it_raises_if_tags_item_is_not_a_string(self):
+        schema = schemas.AnnotationSchema()
+
+        with pytest.raises(schemas.ValidationError) as err:
+            schema.validate(self.valid_input_data(
+                tags=[False]
+            ))
+
+        assert str(err.value) == "tags.0: False is not of type 'string'"
+
+    def test_it_raises_if_target_is_not_a_list(self):
+        schema = schemas.AnnotationSchema()
+
+        with pytest.raises(schemas.ValidationError) as err:
+            schema.validate(self.valid_input_data(
+                target=False
+            ))
+
+        assert str(err.value) == "target: False is not of type 'array'"
+
+    def test_it_raises_if_target_item_is_not_a_dict(self):
+        schema = schemas.AnnotationSchema()
+
+        with pytest.raises(schemas.ValidationError) as err:
+            schema.validate(self.valid_input_data(
+                target=[False]
+            ))
+
+        assert str(err.value) == "target.0: False is not of type 'object'"
+
+    def test_it_raises_if_target_has_no_selector(self):
+        schema = schemas.AnnotationSchema()
+
+        with pytest.raises(schemas.ValidationError) as err:
+            schema.validate(self.valid_input_data(
+                target=[{}]
+            ))
+
+        assert str(err.value) == "target.0: 'selector' is a required property"
+
+    def test_it_raises_if_text_is_not_a_string(self):
+        schema = schemas.AnnotationSchema()
+
+        with pytest.raises(schemas.ValidationError) as err:
+            schema.validate(self.valid_input_data(
+                text=False
+            ))
+
+        assert str(err.value) == "text: False is not of type 'string'"
+
+    def test_it_raises_if_uri_is_not_a_string(self):
+        schema = schemas.AnnotationSchema()
+
+        with pytest.raises(schemas.ValidationError) as err:
+            schema.validate(self.valid_input_data(
+                uri=False
+            ))
+
+        assert str(err.value) == "uri: False is not of type 'string'"
+
+    def valid_input_data(self, **kwargs):
+        """Return a minimal valid input data for AnnotationSchema."""
+        data = {
+            'permissions': {
+                'read': [],
+            },
+        }
+        data.update(kwargs)
+        return data
+
+
 class TestLegacyCreateAnnotationSchema(object):
 
     def test_it_passes_input_to_structure_validator(self):

--- a/h/api/test/views_test.py
+++ b/h/api/test/views_test.py
@@ -138,7 +138,7 @@ def test_create_raises_if_json_parsing_fails():
 def test_create_calls_create_annotation(storage, schemas):
     """It should call storage.create_annotation() appropriately."""
     request = mock.Mock()
-    schema = schemas.CreateAnnotationSchema.return_value
+    schema = schemas.LegacyCreateAnnotationSchema.return_value
     schema.validate.return_value = {'foo': 123}
 
     views.create(request)
@@ -147,9 +147,10 @@ def test_create_calls_create_annotation(storage, schemas):
 
 
 @create_fixtures
-def test_create_calls_validator(schemas):
+def test_create_calls_validator(schemas, copy):
     request = mock.Mock()
-    schema = schemas.CreateAnnotationSchema.return_value
+    copy.deepcopy.side_effect = lambda x: x
+    schema = schemas.LegacyCreateAnnotationSchema.return_value
 
     views.create(request)
 
@@ -313,6 +314,13 @@ def AnnotationJSONPresenter(request):
     cls = patcher.start()
     request.addfinalizer(patcher.stop)
     return cls
+
+
+@pytest.fixture
+def copy(request):
+    patcher = mock.patch('h.api.views.copy', autospec=True)
+    request.addfinalizer(patcher.stop)
+    return patcher.start()
 
 
 @pytest.fixture

--- a/h/api/views.py
+++ b/h/api/views.py
@@ -16,6 +16,7 @@ particular, requests to the CRUD API endpoints are protected by the Pyramid
 authorization system. You can find the mapping between annotation "permissions"
 objects and Pyramid ACLs in :mod:`h.api.resources`.
 """
+import copy
 
 from pyramid import i18n
 from pyramid import security
@@ -153,9 +154,12 @@ def search(request):
             effective_principals=security.Authenticated)
 def create(request):
     """Create an annotation from the POST payload."""
-    schema = schemas.CreateAnnotationSchema(request)
-    appstruct = schema.validate(_json_payload(request))
-    annotation = storage.create_annotation(request, appstruct)
+    json_payload = _json_payload(request)
+
+    legacy_schema = schemas.LegacyCreateAnnotationSchema(request)
+    legacy_appstruct = legacy_schema.validate(copy.deepcopy(json_payload))
+
+    annotation = storage.create_annotation(request, legacy_appstruct)
 
     _publish_annotation_event(request, annotation, 'create')
 


### PR DESCRIPTION
This pull request adds:

1. Transformation of annotation data and document metadata from the client into the format that the `storage` module will need it in (see <https://github.com/hypothesis/h/pull/3153>)

   The format of the "document" sub-object that the client POSTs in annotation create and update requests is quite far from the format that we need in order to create/update the `Document`, `DocumentMeta` and `DocumentURI` objects in the database. The new `h.api.parse_document_claims` module handles transforming this dict into two lists that are in a more convenient format for `storage` to later use to create the db objects. The code in here is adapted from existing code in `migrate.py` and `elastic.py`.

   `schemas` calls `parse_document_claims` to do this, so when the data comes out of schema validation it's in the right/convenient format.

2. Additional validation of the data from the client so that `storage` and the db don't crash.

   Now that we have a real database we can't just throw any crap into it, either the db or our own code will crash if required fields are missing or if known fields are the wrong type. Minimal additional JSON Schema validation has been added (only to the create annotation API and only when postgres_write is on) to prevent these crashes and send proper validation errors back.

`schemas` only does "structural" validation and transformations, i.e. work that doesn't require looking in the db. Some further "semantic" validation and transformation that does require reading from the will be done in `storage`.
