### PR TITLE
Postgres Write 4/4: Storage code for creating new annotations in Postgres

### DIFF
--- a/h/api/models/__init__.py
+++ b/h/api/models/__init__.py
@@ -11,6 +11,7 @@ direct to the submodules of this package, but rather through the helper
 functions in `h.api.storage`.
 """
 
+from h.api.models import elastic
 from h.api.models.annotation import Annotation
 from h.api.models.document import create_or_update_document_meta
 from h.api.models.document import create_or_update_document_uri
@@ -27,5 +28,6 @@ __all__ = (
     'Document',
     'DocumentMeta',
     'DocumentURI',
+    'elastic',
     'merge_documents',
 )

--- a/h/api/models/__init__.py
+++ b/h/api/models/__init__.py
@@ -17,6 +17,8 @@ from h.api.models.document import create_or_update_document_uri
 from h.api.models.document import Document
 from h.api.models.document import DocumentMeta
 from h.api.models.document import DocumentURI
+from h.api.models.document import merge_documents
+
 
 __all__ = (
     'Annotation',
@@ -25,4 +27,5 @@ __all__ = (
     'Document',
     'DocumentMeta',
     'DocumentURI',
+    'merge_documents',
 )

--- a/h/api/parse_document_claims.py
+++ b/h/api/parse_document_claims.py
@@ -143,7 +143,6 @@ def document_uris_from_links(link_dicts, claimant):
         uri_ = link['href']
         type_ = None
 
-
         # Handle rel="..." links.
         if type_ is None and link.get('rel') is not None:
             type_ = 'rel-{}'.format(link['rel'])

--- a/h/api/schemas.py
+++ b/h/api/schemas.py
@@ -216,8 +216,8 @@ class CreateAnnotationSchema(object):
 
         new_appstruct['userid'] = self.request.authenticated_userid
 
-        new_appstruct['target_uri'] = appstruct.pop('uri', '')
-        new_appstruct['text'] = appstruct.pop('text', '')
+        new_appstruct['target_uri'] = appstruct.pop('uri', u'')
+        new_appstruct['text'] = appstruct.pop('text', u'')
         new_appstruct['tags'] = appstruct.pop('tags', [])
 
         # Replace the client's complex permissions object with a simple shared
@@ -237,7 +237,7 @@ class CreateAnnotationSchema(object):
             target = target[0]  # Multiple targets are ignored.
             new_appstruct['target_selectors'] = target['selector']
 
-        new_appstruct['groupid'] = appstruct.pop('group', '__world__')
+        new_appstruct['groupid'] = appstruct.pop('group', u'__world__')
 
         new_appstruct['references'] = appstruct.pop('references', [])
 

--- a/h/api/storage.py
+++ b/h/api/storage.py
@@ -94,14 +94,13 @@ def create_annotation(request, data):
 
     # The user must have permission to create an annotation in the group
     # they've asked to create one in.
-    if data['groupid'] == '__world__':
-        group_principal = security.Everyone
-    else:
+    if data['groupid'] != '__world__':
         group_principal = 'group:{}'.format(data['groupid'])
-    if group_principal not in request.effective_principals:
-        raise schemas.ValidationError('group: ' +
-                                      _('You may not create annotations in '
-                                        'groups you are not a member of!'))
+        if group_principal not in request.effective_principals:
+            raise schemas.ValidationError('group: ' +
+                                          _('You may not create annotations '
+                                            'in groups you are not a member '
+                                            'of!'))
 
     annotation = models.Annotation(**data)
     request.db.add(annotation)

--- a/h/api/storage.py
+++ b/h/api/storage.py
@@ -128,7 +128,7 @@ def create_annotation(request, data):
 
     for document_uri_dict in document_uri_dicts:
         models.create_or_update_document_uri(
-            db=request.db,
+            session=request.db,
             document=document,
             created=annotation.created,
             updated=annotation.updated,
@@ -136,7 +136,7 @@ def create_annotation(request, data):
 
     for document_meta_dict in document_meta_dicts:
         models.create_or_update_document_meta(
-            db=request.db,
+            session=request.db,
             document=document,
             created=annotation.created,
             updated=annotation.updated,

--- a/h/api/storage.py
+++ b/h/api/storage.py
@@ -151,24 +151,9 @@ def expand_uri(request, uri):
 
 
 def _prepare(request, annotation):
-    """
-    Prepare the given annotation for storage.
-
-    Scan the passed annotation for any target URIs or document metadata URIs
-    and add normalized versions of these to the document.
-    """
+    """Prepare the given annotation for storage."""
     fetcher = partial(fetch_annotation, request)
-    transform.set_group_if_reply(annotation, fetcher=fetcher)
-    transform.insert_group_if_none(annotation)
-    transform.set_group_permissions(annotation)
-
-    # FIXME: Remove this in a month or so, when all our clients have been
-    # updated. -N 2015-09-25
-    transform.fix_old_style_comments(annotation)
-
-    # FIXME: When this becomes simply part of a search indexing operation, this
-    # should probably not mutate its argument.
-    transform.normalize_annotation_target_uris(annotation)
+    transform.prepare(annotation, fetcher)
 
     # Fire an AnnotationBeforeSaveEvent so subscribers who wish to modify an
     # annotation before save can do so.

--- a/h/api/storage.py
+++ b/h/api/storage.py
@@ -16,9 +16,6 @@ from h.api import schemas
 from h.api import transform
 from h.api import models
 from h.api.events import AnnotationBeforeSaveEvent
-from h.api.models import elastic
-from h.api.models.annotation import Annotation
-from h.api.models.document import Document
 
 
 _ = i18n.TranslationStringFactory(__package__)
@@ -34,7 +31,7 @@ def annotation_from_dict(data):
     :returns: the created annotation
     :rtype: dict
     """
-    return elastic.Annotation(data)
+    return models.elastic.Annotation(data)
 
 
 def fetch_annotation(request, id):
@@ -51,13 +48,13 @@ def fetch_annotation(request, id):
     :rtype: dict, NoneType
     """
     if _postgres_enabled(request):
-        return request.db.query(Annotation).get(id)
+        return request.db.query(models.Annotation).get(id)
 
-    return elastic.Annotation.fetch(id)
+    return models.elastic.Annotation.fetch(id)
 
 
 def legacy_create_annotation(request, data):
-    annotation = elastic.Annotation(data)
+    annotation = models.elastic.Annotation(data)
     # FIXME: this should happen when indexing, not storing.
     _prepare(request, annotation)
     annotation.save()
@@ -167,7 +164,7 @@ def update_annotation(request, id, data):
     :returns: the updated annotation
     :rtype: dict
     """
-    annotation = elastic.Annotation.fetch(id)
+    annotation = models.elastic.Annotation.fetch(id)
     annotation.update(data)
 
     # FIXME: this should happen when indexing, not storing.
@@ -187,7 +184,7 @@ def delete_annotation(request, id):
     :param id: the annotation id
     :type id: str
     """
-    annotation = elastic.Annotation.fetch(id)
+    annotation = models.elastic.Annotation.fetch(id)
     annotation.delete()
 
 
@@ -210,9 +207,9 @@ def expand_uri(request, uri):
     """
     doc = None
     if _postgres_enabled(request):
-        doc = Document.find_by_uris(request.db, [uri]).one_or_none()
+        doc = models.Document.find_by_uris(request.db, [uri]).one_or_none()
     else:
-        doc = elastic.Document.get_by_uri(uri)
+        doc = models.elastic.Document.get_by_uri(uri)
 
     if doc is None:
         return [uri]

--- a/h/api/test/storage_test.py
+++ b/h/api/test/storage_test.py
@@ -153,7 +153,6 @@ class TestExpandURI(object):
                          'transform')
 class TestLegacyCreateAnnotation(object):
 
-
     def test_it_inits_an_elastic_annotation_model(self, models):
         data = self.annotation_data()
 

--- a/h/api/test/storage_test.py
+++ b/h/api/test/storage_test.py
@@ -404,7 +404,7 @@ class TestCreateAnnotation(object):
         assert models.create_or_update_document_uri.call_count == 3
         for doc_uri_dict in annotation_data['document']['document_uri_dicts']:
             models.create_or_update_document_uri.assert_any_call(
-                db=request.db,
+                session=request.db,
                 document=models.Document.find_or_create_by_uris.return_value.first.return_value,
                 created=annotation.created,
                 updated=annotation.updated,
@@ -450,7 +450,7 @@ class TestCreateAnnotation(object):
         for document_meta_dict in annotation_data['document'][
                 'document_meta_dicts']:
             models.create_or_update_document_meta.assert_any_call(
-                db=request.db,
+                session=request.db,
                 document=models.Document.find_or_create_by_uris.return_value.first.return_value,
                 created=annotation.created,
                 updated=annotation.updated,

--- a/h/api/test/storage_test.py
+++ b/h/api/test/storage_test.py
@@ -2,6 +2,8 @@
 
 from __future__ import unicode_literals
 
+import copy
+
 import pytest
 import mock
 from mock import patch
@@ -9,6 +11,7 @@ from pyramid.testing import DummyRequest
 
 from h import db
 from h.api import storage
+from h.api import schemas
 from h.api.models.annotation import Annotation
 from h.api.models.document import Document, DocumentURI
 
@@ -118,26 +121,25 @@ def test_expand_uri_elastic_document_uris(postgres_enabled, document_model):
                          'elastic',
                          'partial',
                          'transform')
-class TestCreateAnnotation(object):
-
-    """Tests for create_annotation() when postgres_write is off."""
+class TestLegacyCreateAnnotation(object):
 
     def test_it_inits_an_elastic_annotation_model(self, elastic):
         data = self.annotation_data()
 
-        storage.create_annotation(self.mock_request(), data)
+        storage.legacy_create_annotation(self.mock_request(), data)
 
         elastic.Annotation.assert_called_once_with(data)
 
     def test_it_calls_partial(self, partial):
         request = self.mock_request()
 
-        storage.create_annotation(request, self.annotation_data())
+        storage.legacy_create_annotation(request, self.annotation_data())
 
         partial.assert_called_once_with(storage.fetch_annotation, request)
 
     def test_it_calls_prepare(self, elastic, partial, transform):
-        storage.create_annotation(self.mock_request(), self.annotation_data())
+        storage.legacy_create_annotation(self.mock_request(),
+                                         self.annotation_data())
 
         transform.prepare.assert_called_once_with(
             elastic.Annotation.return_value, partial.return_value)
@@ -147,7 +149,7 @@ class TestCreateAnnotation(object):
                                                 elastic):
         request = self.mock_request()
 
-        storage.create_annotation(request, self.annotation_data())
+        storage.legacy_create_annotation(request, self.annotation_data())
 
         AnnotationBeforeSaveEvent.assert_called_once_with(
             request, elastic.Annotation.return_value)
@@ -155,18 +157,19 @@ class TestCreateAnnotation(object):
     def test_it_calls_notify(self, AnnotationBeforeSaveEvent):
         request = self.mock_request()
 
-        storage.create_annotation(request, self.annotation_data())
+        storage.legacy_create_annotation(request, self.annotation_data())
 
         request.registry.notify.assert_called_once_with(
             AnnotationBeforeSaveEvent.return_value)
 
     def test_it_calls_annotation_save(self, elastic):
-        storage.create_annotation(self.mock_request(), self.annotation_data())
+        storage.legacy_create_annotation(self.mock_request(),
+                                         self.annotation_data())
 
         elastic.Annotation.return_value.save.assert_called_once_with()
 
     def test_it_returns_the_annotation(self, elastic):
-        result = storage.create_annotation(self.mock_request(),
+        result = storage.legacy_create_annotation(self.mock_request(),
                                            self.annotation_data())
 
         assert result == elastic.Annotation.return_value
@@ -210,12 +213,330 @@ class TestCreateAnnotation(object):
         return transform
 
 
+@pytest.mark.usefixtures('fetch_annotation',
+                         'models')
+class TestCreateAnnotation(object):
+
+    def test_it_fetches_parent_annotation_for_replies(self,
+                                                      authn_policy,
+                                                      fetch_annotation):
+        request = self.mock_request()
+
+        # Make the annotation's parent belong to 'test-group'.
+        fetch_annotation.return_value.groupid = 'test-group'
+
+        # The request will need permission to write to 'test-group'.
+        authn_policy.effective_principals.return_value = ['group:test-group']
+
+        data = self.annotation_data()
+
+        # The annotation is a reply.
+        data['references'] = ['parent_annotation_id']
+
+        storage.create_annotation(request, data)
+
+        fetch_annotation.assert_called_once_with(request,
+                                                 'parent_annotation_id')
+
+    def test_it_sets_group_for_replies(self,
+                                       authn_policy,
+                                       fetch_annotation,
+                                       models):
+        # Make the annotation's parent belong to 'test-group'.
+        fetch_annotation.return_value.groupid = 'test-group'
+
+        # The request will need permission to write to 'test-group'.
+        authn_policy.effective_principals.return_value = ['group:test-group']
+
+        data = self.annotation_data()
+        assert data['groupid'] != 'test-group'
+
+        # The annotation is a reply.
+        data['references'] = ['parent_annotation_id']
+
+        storage.create_annotation(self.mock_request(), data)
+
+        assert models.Annotation.call_args[1]['groupid'] == 'test-group'
+
+    def test_it_raises_if_parent_annotation_does_not_exist(self,
+                                                           fetch_annotation):
+        fetch_annotation.return_value = None
+
+        data = self.annotation_data()
+
+        # The annotation is a reply.
+        data['references'] = ['parent_annotation_id']
+
+        with pytest.raises(schemas.ValidationError) as err:
+            storage.create_annotation(self.mock_request(), data)
+
+        assert str(err.value).startswith('references.0: ')
+
+    def test_it_raises_if_user_does_not_have_permissions_for_group(self):
+        data = self.annotation_data()
+        data['groupid'] = 'foo-group'
+
+        with pytest.raises(schemas.ValidationError) as err:
+            storage.create_annotation(self.mock_request(), data)
+
+        assert str(err.value).startswith('group: ')
+
+    def test_it_inits_an_Annotation_model(self, models):
+        data = self.annotation_data()
+
+        storage.create_annotation(self.mock_request(), copy.deepcopy(data))
+
+        del data['document']
+        models.Annotation.assert_called_once_with(**data)
+
+    def test_it_adds_the_annotation_to_the_database(self, models):
+        request = self.mock_request()
+
+        storage.create_annotation(request, self.annotation_data())
+
+        request.db.add.assert_called_once_with(models.Annotation.return_value)
+
+    def test_it_calls_find_or_create_by_uris(self, models):
+        request = self.mock_request()
+        annotation = models.Annotation.return_value
+        annotation_data = self.annotation_data()
+        annotation_data['document']['document_uri_dicts'] = [
+            {
+                'uri': 'http://example.com/example_1',
+                'claimant': 'http://example.com/claimant',
+                'type': 'type',
+                'content_type': None,
+            },
+            {
+                'uri': 'http://example.com/example_2',
+                'claimant': 'http://example.com/claimant',
+                'type': 'type',
+                'content_type': None,
+            },
+            {
+                'uri': 'http://example.com/example_3',
+                'claimant': 'http://example.com/claimant',
+                'type': 'type',
+                'content_type': None,
+            },
+        ]
+
+        storage.create_annotation(request, annotation_data)
+
+        models.Document.find_or_create_by_uris.assert_called_once_with(
+            request.db,
+            annotation.target_uri,
+            [
+                'http://example.com/example_1',
+                'http://example.com/example_2',
+                'http://example.com/example_3',
+            ],
+            created=annotation.created,
+            updated=annotation.updated,
+        )
+
+    def test_it_calls_merge_documents(self, models):
+        """If it finds more than one document it calls merge_documents()."""
+        models.Document.find_or_create_by_uris.return_value = mock.Mock(
+            count=mock.Mock(return_value=3))
+        request = self.mock_request()
+
+        storage.create_annotation(request, self.annotation_data())
+
+        models.merge_documents.assert_called_once_with(
+            request.db,
+            models.Document.find_or_create_by_uris.return_value,
+            updated=models.Annotation.return_value.updated,
+        )
+
+    def test_it_calls_first(self, models):
+        """If it finds only one document it calls first()."""
+        models.Document.find_or_create_by_uris.return_value = mock.Mock(
+            count=mock.Mock(return_value=1))
+
+        storage.create_annotation(self.mock_request(), self.annotation_data())
+
+        models.Document.find_or_create_by_uris.return_value\
+            .first.assert_called_once_with()
+
+    def test_it_updates_document_updated(self, models):
+        yesterday = "yesterday"
+        document = models.merge_documents.return_value = mock.Mock(
+            updated=yesterday)
+        models.Document.find_or_create_by_uris.return_value.first\
+            .return_value = document
+
+        storage.create_annotation(self.mock_request(), self.annotation_data())
+
+        assert document.updated == models.Annotation.return_value.updated
+
+    def test_it_calls_create_or_update_document_uri(
+            self,
+            models):
+        models.Document.find_or_create_by_uris.return_value.count\
+            .return_value = 1
+
+        request = self.mock_request()
+
+        annotation = models.Annotation.return_value
+
+        annotation_data = self.annotation_data()
+        annotation_data['document']['document_uri_dicts'] = [
+            {
+                'uri': 'http://example.com/example_1',
+                'claimant': 'http://example.com/claimant',
+                'type': 'type',
+                'content_type': None,
+            },
+            {
+                'uri': 'http://example.com/example_2',
+                'claimant': 'http://example.com/claimant',
+                'type': 'type',
+                'content_type': None,
+            },
+            {
+                'uri': 'http://example.com/example_3',
+                'claimant': 'http://example.com/claimant',
+                'type': 'type',
+                'content_type': None,
+            },
+        ]
+
+        storage.create_annotation(request, copy.deepcopy(annotation_data))
+
+        assert models.create_or_update_document_uri.call_count == 3
+        for doc_uri_dict in annotation_data['document']['document_uri_dicts']:
+            models.create_or_update_document_uri.assert_any_call(
+                db=request.db,
+                document=models.Document.find_or_create_by_uris.return_value.first.return_value,
+                created=annotation.created,
+                updated=annotation.updated,
+                **doc_uri_dict
+            )
+
+    def test_it_calls_create_or_update_document_meta(self, models):
+        models.Document.find_or_create_by_uris.return_value.count\
+            .return_value = 1
+
+        request = self.mock_request()
+
+        annotation = models.Annotation.return_value
+
+        annotation_data = self.annotation_data()
+        annotation_data['document']['document_meta_dicts'] = [
+            {
+                'claimant': 'http://example.com/claimant',
+                'claimant_normalized':
+                    'http://example.com/claimant_normalized',
+                'type': 'title',
+                'value': 'foo',
+            },
+            {
+                'type': 'article title',
+                'claimant_normalized':
+                    'http://example.com/claimant_normalized',
+                'value': 'bar',
+                'claimant': 'http://example.com/claimant',
+            },
+            {
+                'type': 'site title',
+                'claimant_normalized':
+                    'http://example.com/claimant_normalized',
+                'value': 'gar',
+                'claimant': 'http://example.com/claimant',
+            },
+        ]
+
+        storage.create_annotation(request, copy.deepcopy(annotation_data))
+
+        assert models.create_or_update_document_meta.call_count == 3
+        for document_meta_dict in annotation_data['document'][
+                'document_meta_dicts']:
+            models.create_or_update_document_meta.assert_any_call(
+                db=request.db,
+                document=models.Document.find_or_create_by_uris.return_value.first.return_value,
+                created=annotation.created,
+                updated=annotation.updated,
+                **document_meta_dict
+            )
+
+    def test_it_returns_the_annotation(self, models):
+        annotation = storage.create_annotation(self.mock_request(),
+                                               self.annotation_data())
+
+        assert annotation == models.Annotation.return_value
+
+    def test_it_does_not_crash_if_target_selectors_is_empty(self):
+        # Page notes have [] for target_selectors.
+        data = self.annotation_data()
+        data['target_selectors'] = []
+
+        storage.create_annotation(self.mock_request(), data)
+
+    def test_it_does_not_crash_if_no_text_or_tags(self):
+        # Highlights have no text or tags.
+        data = self.annotation_data()
+        data['text'] = data['tags'] = ''
+
+        storage.create_annotation(self.mock_request(), data)
+
+    def mock_request(self):
+        request = DummyRequest(
+            feature=mock.Mock(
+                side_effect=lambda flag: flag == "postgres_write"),
+            authenticated_userid='acct:test@localhost'
+        )
+
+        request.registry.notify = mock.Mock(spec=lambda event: None)
+
+        class DBSpec(object):
+            def add(self, annotation):
+                pass
+            def flush():
+                pass
+        request.db = mock.Mock(spec=DBSpec)
+
+        return request
+
+    def annotation_data(self):
+        return {
+            'userid': 'acct:test@localhost',
+            'text': 'text',
+            'tags': ['one', 'two'],
+            'shared': False,
+            'target_uri': 'http://www.example.com/example.html',
+            'groupid': '__world__',
+            'references': [],
+            'target_selectors': ['selector_one', 'selector_two'],
+            'document': {
+                'document_uri_dicts': [],
+                'document_meta_dicts': [],
+            }
+        }
+
+    @pytest.fixture
+    def fetch_annotation(self, request):
+        patcher = patch('h.api.storage.fetch_annotation', autospec=True)
+        fetch_annotation = patcher.start()
+        request.addfinalizer(patcher.stop)
+        return fetch_annotation
+
+
 @pytest.fixture
 def document_model(config, request):
     patcher = patch('h.api.models.elastic.Document', autospec=True)
     module = patcher.start()
     request.addfinalizer(patcher.stop)
     return module
+
+
+@pytest.fixture
+def models(request):
+    patcher = patch('h.api.storage.models')
+    models = patcher.start()
+    models.Annotation.return_value.is_reply = False
+    request.addfinalizer(patcher.stop)
+    return models
 
 
 @pytest.fixture

--- a/h/api/test/storage_test.py
+++ b/h/api/test/storage_test.py
@@ -16,14 +16,14 @@ from h.api.models.annotation import Annotation
 from h.api.models.document import Document, DocumentURI
 
 
-def test_fetch_annotation_elastic(postgres_enabled, ElasticAnnotation):
+def test_fetch_annotation_elastic(postgres_enabled, models):
     postgres_enabled.return_value = False
-    ElasticAnnotation.fetch.return_value = mock.Mock()
+    models.elastic.Annotation.fetch.return_value = mock.Mock()
 
     actual = storage.fetch_annotation(DummyRequest(), '123')
 
-    ElasticAnnotation.fetch.assert_called_once_with('123')
-    assert ElasticAnnotation.fetch.return_value == actual
+    models.elastic.Annotation.fetch.assert_called_once_with('123')
+    assert models.elastic.Annotation.fetch.return_value == actual
 
 
 def test_fetch_annotation_postgres(postgres_enabled):
@@ -46,10 +46,10 @@ def test_expand_uri_postgres_no_document(postgres_enabled):
     assert actual == ['http://example.com/']
 
 
-def test_expand_uri_elastic_no_document(postgres_enabled, document_model):
+def test_expand_uri_elastic_no_document(postgres_enabled, models):
     postgres_enabled.return_value = False
     request = DummyRequest()
-    document_model.get_by_uri.return_value = None
+    models.elastic.Document.get_by_uri.return_value = None
     assert storage.expand_uri(request, "http://example.com/") == [
             "http://example.com/"]
 
@@ -70,11 +70,11 @@ def test_expand_uri_postgres_document_doesnt_expand_canonical_uris(postgres_enab
             "http://example.com/"]
 
 
-def test_expand_uri_elastic_document_doesnt_expand_canonical_uris(postgres_enabled, document_model):
+def test_expand_uri_elastic_document_doesnt_expand_canonical_uris(postgres_enabled, models):
     postgres_enabled.return_value = False
 
     request = DummyRequest()
-    document = document_model.get_by_uri.return_value
+    document = models.elastic.Document.get_by_uri.return_value
     type(document).document_uris = uris = mock.PropertyMock()
     uris.return_value = [
         mock.Mock(uri='http://foo.com/'),
@@ -102,10 +102,10 @@ def test_expand_uri_postgres_document_uris(postgres_enabled):
     ]
 
 
-def test_expand_uri_elastic_document_uris(postgres_enabled, document_model):
+def test_expand_uri_elastic_document_uris(postgres_enabled, models):
     postgres_enabled.return_value = False
     request = DummyRequest()
-    document = document_model.get_by_uri.return_value
+    document = models.elastic.Document.get_by_uri.return_value
     type(document).document_uris = uris = mock.PropertyMock()
     uris.return_value = [
         mock.Mock(uri="http://foo.com/"),
@@ -118,17 +118,18 @@ def test_expand_uri_elastic_document_uris(postgres_enabled, document_model):
 
 
 @pytest.mark.usefixtures('AnnotationBeforeSaveEvent',
-                         'elastic',
+                         'models',  # Don't try to talk to real Elasticsearch!
                          'partial',
                          'transform')
 class TestLegacyCreateAnnotation(object):
 
-    def test_it_inits_an_elastic_annotation_model(self, elastic):
+
+    def test_it_inits_an_elastic_annotation_model(self, models):
         data = self.annotation_data()
 
         storage.legacy_create_annotation(self.mock_request(), data)
 
-        elastic.Annotation.assert_called_once_with(data)
+        models.elastic.Annotation.assert_called_once_with(data)
 
     def test_it_calls_partial(self, partial):
         request = self.mock_request()
@@ -137,22 +138,21 @@ class TestLegacyCreateAnnotation(object):
 
         partial.assert_called_once_with(storage.fetch_annotation, request)
 
-    def test_it_calls_prepare(self, elastic, partial, transform):
+    def test_it_calls_prepare(self, models, partial, transform):
         storage.legacy_create_annotation(self.mock_request(),
                                          self.annotation_data())
-
         transform.prepare.assert_called_once_with(
-            elastic.Annotation.return_value, partial.return_value)
+            models.elastic.Annotation.return_value, partial.return_value)
 
     def test_it_inits_AnnotationBeforeSaveEvent(self,
                                                 AnnotationBeforeSaveEvent,
-                                                elastic):
+                                                models):
         request = self.mock_request()
 
         storage.legacy_create_annotation(request, self.annotation_data())
 
         AnnotationBeforeSaveEvent.assert_called_once_with(
-            request, elastic.Annotation.return_value)
+            request, models.elastic.Annotation.return_value)
 
     def test_it_calls_notify(self, AnnotationBeforeSaveEvent):
         request = self.mock_request()
@@ -162,17 +162,17 @@ class TestLegacyCreateAnnotation(object):
         request.registry.notify.assert_called_once_with(
             AnnotationBeforeSaveEvent.return_value)
 
-    def test_it_calls_annotation_save(self, elastic):
+    def test_it_calls_annotation_save(self, models):
         storage.legacy_create_annotation(self.mock_request(),
                                          self.annotation_data())
 
-        elastic.Annotation.return_value.save.assert_called_once_with()
+        models.elastic.Annotation.return_value.save.assert_called_once_with()
 
-    def test_it_returns_the_annotation(self, elastic):
+    def test_it_returns_the_annotation(self, models):
         result = storage.legacy_create_annotation(self.mock_request(),
                                            self.annotation_data())
 
-        assert result == elastic.Annotation.return_value
+        assert result == models.elastic.Annotation.return_value
 
     def mock_request(self):
         request = DummyRequest(feature=mock.Mock(spec=lambda feature: False,
@@ -190,13 +190,6 @@ class TestLegacyCreateAnnotation(object):
         AnnotationBeforeSaveEvent = patcher.start()
         request.addfinalizer(patcher.stop)
         return AnnotationBeforeSaveEvent
-
-    @pytest.fixture
-    def elastic(self, request):
-        patcher = patch('h.api.storage.elastic', autospec=True)
-        elastic = patcher.start()
-        request.addfinalizer(patcher.stop)
-        return elastic
 
     @pytest.fixture
     def partial(self, request):
@@ -545,11 +538,3 @@ def postgres_enabled(request):
     func = patcher.start()
     request.addfinalizer(patcher.stop)
     return func
-
-
-@pytest.fixture
-def ElasticAnnotation(request):
-    patcher = patch('h.api.storage.elastic.Annotation', autospec=True)
-    cls = patcher.start()
-    request.addfinalizer(patcher.stop)
-    return cls

--- a/h/api/test/views_test.py
+++ b/h/api/test/views_test.py
@@ -282,12 +282,24 @@ class TestCreate(object):
         """It should call storage.create_annotation() appropriately."""
         request = self.mock_request()
         schema = schemas.LegacyCreateAnnotationSchema.return_value
+
+        views.create(request)
+
+        storage.legacy_create_annotation.assert_called_once_with(
+            request,
+            schema.validate.return_value)
+
+    def test_it_reuses_the_postgres_annotation_id_in_elasticsearch(self,
+                                                                   schemas,
+                                                                   storage):
+        request = self.mock_request()
+        schema = schemas.LegacyCreateAnnotationSchema.return_value
         schema.validate.return_value = {'foo': 123}
 
         views.create(request)
 
-        storage.legacy_create_annotation.assert_called_once_with(request,
-                                                                 {'foo': 123})
+        assert storage.legacy_create_annotation.call_args[0][1]['id'] == (
+            storage.create_annotation.return_value.id)
 
     def test_it_inits_AnnotationJSONPresenter(self,
                                               AnnotationJSONPresenter,

--- a/h/api/test/views_test.py
+++ b/h/api/test/views_test.py
@@ -143,7 +143,8 @@ def test_create_calls_create_annotation(storage, schemas):
 
     views.create(request)
 
-    storage.create_annotation.assert_called_once_with(request, {'foo': 123})
+    storage.legacy_create_annotation.assert_called_once_with(request,
+                                                             {'foo': 123})
 
 
 @create_fixtures
@@ -164,7 +165,7 @@ def test_create_inits_AnnotationJSONPresenter(AnnotationJSONPresenter, storage):
     views.create(request)
 
     AnnotationJSONPresenter.assert_called_once_with(
-        request, storage.create_annotation.return_value)
+        request, storage.legacy_create_annotation.return_value)
 
 
 @create_fixtures
@@ -191,7 +192,7 @@ def test_create_returns_presented_annotation(AnnotationJSONPresenter, storage):
 
     AnnotationJSONPresenter.assert_called_once_with(
             request,
-            storage.create_annotation.return_value)
+            storage.legacy_create_annotation.return_value)
     assert result == AnnotationJSONPresenter.return_value.asdict.return_value
 
 

--- a/h/api/test/views_test.py
+++ b/h/api/test/views_test.py
@@ -399,11 +399,3 @@ def storage(request):
     patcher = mock.patch('h.api.views.storage', autospec=True)
     request.addfinalizer(patcher.stop)
     return patcher.start()
-
-
-@pytest.fixture
-def _publish_annotation_event(request):
-    patcher = mock.patch('h.api.views._publish_annotation_event',
-                         autospec=True)
-    request.addfinalizer(patcher.stop)
-    return patcher.start()

--- a/h/api/test/views_test.py
+++ b/h/api/test/views_test.py
@@ -71,6 +71,7 @@ class TestIndex(object):
         assert links['search']['url'] == host + '/dummy/search'
 
 
+@pytest.mark.usefixtures('search_lib', 'AnnotationJSONPresenter')
 class TestSearch(object):
 
     def test_it_searches(self, search_lib):

--- a/h/api/test/views_test.py
+++ b/h/api/test/views_test.py
@@ -145,7 +145,7 @@ class TestCreateLegacy(object):
         type(request).json_body = mock.PropertyMock(side_effect=ValueError)
 
         with pytest.raises(views.PayloadError):
-            views.update(mock.Mock(), request)
+            views.create(request)
 
     def test_it_calls_legacy_create_annotation(self, storage, schemas):
         request = self.mock_request()

--- a/h/api/transform.py
+++ b/h/api/transform.py
@@ -4,6 +4,21 @@ from h.api import uri
 from h.api._compat import string_types
 
 
+def prepare(annotation, fetcher):
+    """Prepare the given annotation for storage."""
+    set_group_if_reply(annotation, fetcher=fetcher)
+    insert_group_if_none(annotation)
+    set_group_permissions(annotation)
+
+    # FIXME: Remove this in a month or so, when all our clients have been
+    # updated. -N 2015-09-25
+    fix_old_style_comments(annotation)
+
+    # FIXME: When this becomes simply part of a search indexing operation, this
+    # should probably not mutate its argument.
+    normalize_annotation_target_uris(annotation)
+
+
 def set_group_if_reply(annotation, fetcher):
     """
     If the annotation is a reply set its group to that of its parent.

--- a/h/api/views.py
+++ b/h/api/views.py
@@ -166,6 +166,13 @@ def create(request):
     # Validate the annotation for, and create the annotation in, Elasticsearch.
     legacy_schema = schemas.LegacyCreateAnnotationSchema(request)
     legacy_appstruct = legacy_schema.validate(copy.deepcopy(json_payload))
+
+    # When 'postgres' is on make sure that annotations in the legacy
+    # Elasticsearch database use the same IDs as the PostgreSQL ones.
+    if request.feature('postgres'):
+        assert annotation.id
+        legacy_appstruct['id'] = annotation.id
+
     legacy_annotation = storage.legacy_create_annotation(request,
                                                          legacy_appstruct)
 

--- a/h/api/views.py
+++ b/h/api/views.py
@@ -162,10 +162,10 @@ def create(request):
 
     annotation = storage.create_annotation(request, legacy_appstruct)
 
-    _publish_annotation_event(request, annotation, 'create')
+    annotation_dict = AnnotationJSONPresenter(request, annotation).asdict()
+    _publish_annotation_event(request, annotation_dict, 'create')
 
-    presenter = AnnotationJSONPresenter(request, annotation)
-    return presenter.asdict()
+    return annotation_dict
 
 
 @api_config(route_name='api.annotation', request_method='GET', permission='read')


### PR DESCRIPTION
This pull request depends on the model code in <https://github.com/hypothesis/h/pull/3151> and the schemas code in <https://github.com/hypothesis/h/pull/3152> (not for the tests to pass, but for the code to actually work if you turn on the postgres_write feature flag).

This pull requests makes the `h.api.storage` changes necessary to accept the newly validated and transformed data from `h.api.schemas` (see <https://github.com/hypothesis/h/pull/3152>) and do the necessary logic to create and update `Annotation`, `Document`, `DocumentMeta` and `DocumentURI` objects in the database, for some of this calling new `h.api.models` functions from <https://github.com/hypothesis/h/pull/3151>.

The new storage logic is only when the postgres_write feature flag is on and only for creating new annotations, not for updating or deleting annotations.

Storing an annotation is considerably more complicated than it is with the legacy Elasticsearch storage code in h, because of the need to create and update document equivalence data and document metadata.

`h.api.storage.create_annotation()` is really a "logic" function with some semantic validation/transformation mixed in, all the structural validation and transformation and the model handling is elsewhere. The logic of `h.api.storage.create_annotation()` is:

* Force replies to have the same group as their parent
* Fail if replying to an annotation ID that doesn't exist
* Fail if writing to a group that you don't have permission to (note this has to happen after setting the group of replies)
* Create an `Annotation` model object from the (already validated) data
* Find all existing `Document` objects referred to by any existing `DocumentURI` objects that match any of the document URI equivalence claims in the post
* If there are no such `Document`s create a new `Document` with no `DocumentURI`s or `DocumentMeta`s pointing to it (yet)
* If there is one such `Document` use it
* If there are multiple such `Documents` merge them into one (all of the `DocumentURI`s will now point to one `Document` and the other `Document`s will be deleted, this destroys information)
* Update the `.updated` time of the `Document`
* Create new `DocumentURI`s, or update existing ones, for all document URI equivalence claims in the request
* Create new `DocumentMeta`s, or update existing ones, for all document metadata claims in the request