### PR TITLE
Reintegrate annotation/document migration

### DIFF
--- a/h/migrations/versions/4c0c44605c09_create_annotation_table.py
+++ b/h/migrations/versions/4c0c44605c09_create_annotation_table.py
@@ -8,7 +8,7 @@ Create Date: 2016-01-20 12:58:16.249481
 
 # revision identifiers, used by Alembic.
 revision = '4c0c44605c09'
-down_revision = '4886d7a14074'
+down_revision = '21f87f395e26'
 
 from alembic import op
 import sqlalchemy as sa


### PR DESCRIPTION
Because we now run PostgreSQL 9.4 in production (which supports the
JSONB data type), and we are soon going to merge postgres annotation
write support behing a feature flag.