### PR TITLE
Fix a unicode warning

### DIFF
--- a/h/notification/reply_template.py
+++ b/h/notification/reply_template.py
@@ -171,7 +171,7 @@ def create_subscription(request, uri, active):
 @subscriber(RegistrationEvent)
 def registration_subscriptions(event):
     request = event.request
-    user_uri = 'acct:{}@{}'.format(event.user.username, request.domain)
+    user_uri = u'acct:{}@{}'.format(event.user.username, request.domain)
     create_subscription(event.request, user_uri, True)
 
 


### PR DESCRIPTION
We're getting this:

    Unicode type received non-unicode bind param value 'acct:fred@localhost'`

when registering new user accounts. This commit fixes it.