### PR TITLE
Use filtering to show direct-linked annotations instead of selection (and thereby support direct links to replies)

### DIFF
--- a/h/session.py
+++ b/h/session.py
@@ -51,6 +51,7 @@ def _current_groups(request):
         groups.append({
             'name': group.name,
             'id': group.pubid,
+            'public': False,
             'url': request.route_url('group_read',
                                      pubid=group.pubid,
                                      slug=group.slug),

--- a/h/static/scripts/annotation-ui.js
+++ b/h/static/scripts/annotation-ui.js
@@ -8,14 +8,6 @@ function value(selection) {
   }
 }
 
-function initialSelection(settings) {
-  var selection = {};
-  if (settings.annotations) {
-    selection[settings.annotations] = true;
-  }
-  return value(selection);
-}
-
 /**
  * Stores the UI state of the annotator in connected clients.
  *
@@ -27,7 +19,7 @@ function initialSelection(settings) {
  */
 
 // @ngInject
-module.exports = function (settings) {
+module.exports = function () {
   return {
     visibleHighlights: false,
 
@@ -35,7 +27,7 @@ module.exports = function (settings) {
     focusedAnnotationMap: null,
 
     // Contains a map of annotation id:true pairs.
-    selectedAnnotationMap: initialSelection(settings),
+    selectedAnnotationMap: null,
 
     /**
      * @ngdoc method

--- a/h/static/scripts/app-controller.js
+++ b/h/static/scripts/app-controller.js
@@ -136,8 +136,13 @@ module.exports = function AppController(
     annotationUI.clearSelectedAnnotations();
   };
 
+  var initialQuery = $location.search().q || '';
+  if (settings.annotations) {
+    initialQuery = 'id:' + settings.annotations;
+  }
+
   $scope.search = {
-    query: $location.search().q,
+    query: initialQuery,
     clear: function () {
       $location.search('q', null);
     },

--- a/h/static/scripts/directive/search-status-bar.js
+++ b/h/static/scripts/directive/search-status-bar.js
@@ -1,3 +1,5 @@
+'use strict';
+
 // @ngInject
 module.exports = function () {
   return {
@@ -8,6 +10,8 @@ module.exports = function () {
       onClearSelection: '&',
       searchQuery: '<',
       selectionCount: '<',
+      showTotalCountMessage: '<',
+      totalCount: '<',
     },
     templateUrl: 'search_status_bar.html',
   };

--- a/h/static/scripts/directive/thread.coffee
+++ b/h/static/scripts/directive/thread.coffee
@@ -196,8 +196,8 @@ isHiddenThread = (elem) ->
 # Directive that instantiates {@link thread.ThreadController ThreadController}.
 ###
 module.exports = [
-  '$parse', '$window', '$location', '$anchorScroll', 'render',
-  ($parse,   $window,   $location,   $anchorScroll,   render) ->
+  '$parse', 'render',
+  ($parse, render) ->
     linkFn = (scope, elem, attrs, [ctrl, counter, filter]) ->
 
       # We would ideally use require for this, but searching parents only for a

--- a/h/static/scripts/groups.js
+++ b/h/static/scripts/groups.js
@@ -37,7 +37,8 @@ function groups(localStorage, session, settings, $rootScope, $http) {
     }
   }
 
-  /** Leave the group with the given ID.
+  /**
+   * Leave the group with the given ID.
    * Returns a promise which resolves when the action completes.
    */
   function leave(id) {

--- a/h/static/scripts/search-filter.coffee
+++ b/h/static/scripts/search-filter.coffee
@@ -13,7 +13,7 @@ module.exports = class SearchFilter
       return [null, term]
 
     if filter in ['group', 'quote', 'result', 'since',
-                  'tag', 'text', 'uri', 'user']
+                  'tag', 'text', 'uri', 'user', 'id']
       data = term[filter.length+1..]
       return [filter, data]
     else
@@ -106,6 +106,7 @@ module.exports = class SearchFilter
     text = []
     uri = []
     user = []
+    id = []
 
     if searchtext
       terms = @_tokenize(searchtext)
@@ -153,6 +154,7 @@ module.exports = class SearchFilter
           when 'text' then text.push term[5..]
           when 'uri' then uri.push term[4..]
           when 'user' then user.push term[5..]
+          when 'id' then id.push term[3..]
           else any.push term
 
     any:
@@ -178,4 +180,7 @@ module.exports = class SearchFilter
       operator: 'or'
     user:
       terms: user
+      operator: 'or'
+    id:
+      terms: id
       operator: 'or'

--- a/h/static/scripts/test/annotation-ui-test.js
+++ b/h/static/scripts/test/annotation-ui-test.js
@@ -6,20 +6,7 @@ describe('annotationUI', function () {
   var annotationUI;
 
   beforeEach(function () {
-    annotationUI = annotationUIFactory({});
-  });
-
-  describe('initialization', function () {
-    it('does not set a selection when settings.annotations is null', function () {
-      assert.isFalse(annotationUI.hasSelectedAnnotations());
-    });
-
-    it('sets the selection when settings.annotations is set', function () {
-      annotationUI = annotationUIFactory({annotations: 'testid'});
-      assert.deepEqual(annotationUI.selectedAnnotationMap, {
-        testid: true,
-      });
-    });
+    annotationUI = annotationUIFactory();
   });
 
   describe('.focusAnnotations()', function () {

--- a/h/static/scripts/test/app-controller-test.js
+++ b/h/static/scripts/test/app-controller-test.js
@@ -197,6 +197,17 @@ describe('AppController', function () {
     assert.calledOnce(fakeRoute.reload);
   });
 
+  it('initializes search.query to an empty string if there is no direct-linked annotation ID', function () {
+    createController();
+    assert.equal($scope.search.query, '');
+  });
+
+  it('initializes search.query from the direct-linked annotation ID', function () {
+    fakeSettings.annotations = 'someid';
+    createController();
+    assert.equal($scope.search.query, 'id:someid');
+  });
+
   describe('logout()', function () {
     it('prompts the user if there are drafts', function () {
       fakeDrafts.count.returns(1);

--- a/h/static/scripts/test/widget-controller-test.js
+++ b/h/static/scripts/test/widget-controller-test.js
@@ -124,6 +124,7 @@ describe('WidgetController', function () {
   beforeEach(angular.mock.inject(function ($controller, _$rootScope_) {
     $rootScope = _$rootScope_;
     $scope = $rootScope.$new();
+    $scope.search = {query: ''};
     viewer = $controller('WidgetController', {$scope: $scope});
   }));
 
@@ -166,13 +167,13 @@ describe('WidgetController', function () {
       assert.calledWith(loadSpy, [sinon.match({id: uris[1] + '456'})]);
     });
 
-    context('when there is a selection', function () {
+    context('when there is a direct-linked annotation', function () {
       var uri = 'http://example.com';
       var id = uri + '123';
 
       beforeEach(function () {
         fakeCrossFrame.frames = [{uri: uri}];
-        fakeAnnotationUI.selectedAnnotationMap[id] = true;
+        $scope.search.query = 'id:' + id;
         $scope.$digest();
       });
 
@@ -217,7 +218,7 @@ describe('WidgetController', function () {
 
       beforeEach(function () {
         fakeCrossFrame.frames = [{uri: uri}];
-        fakeAnnotationUI.selectedAnnotationMap[id] = true;
+        $scope.search.query = 'id:' + id;
         fakeGroups.focused = function () { return { id: 'private-group' }; };
         $scope.$digest();
       });
@@ -231,9 +232,9 @@ describe('WidgetController', function () {
   });
 
   describe('when an annotation is anchored', function () {
-    it('focuses and scrolls to the annotation if already selected', function () {
+    it('focuses and scrolls to the annotation if direct-linked', function () {
       var uri = 'http://example.com';
-      fakeAnnotationUI.selectedAnnotationMap = {'123': true};
+      $scope.search.query = 'id:123';
       fakeCrossFrame.frames.push({uri: uri});
       var annot = {
         $$tag: 'atag',
@@ -295,51 +296,49 @@ describe('WidgetController', function () {
   });
 
   describe('direct linking messages', function () {
-    it('displays a message if the selection is unavailable', function () {
-      fakeAnnotationUI.selectedAnnotationMap = {'missing': true};
+    it('displays a message if the annotation is unavailable', function () {
+      $scope.search.query = 'id:missing';
       fakeThreading.idTable = {'123': {}};
       $scope.$digest();
-      assert.isTrue($scope.selectedAnnotationUnavailable());
+      assert.isTrue($scope.annotationUnavailable());
     });
 
-    it('does not show a message if the selection is available', function () {
-      fakeAnnotationUI.selectedAnnotationMap = {'123': true};
+    it('does not show a message if the annotation is available', function () {
+      $scope.search.query = 'id:123';
       fakeThreading.idTable = {'123': {}};
       $scope.$digest();
-      assert.isFalse($scope.selectedAnnotationUnavailable());
+      assert.isFalse($scope.annotationUnavailable());
     });
 
-    it('does not a show a message if there is no selection', function () {
-      fakeAnnotationUI.selectedAnnotationMap = null;
+    it('does not a show a message if there is no direct-linked annotation', function () {
       $scope.$digest();
-      assert.isFalse($scope.selectedAnnotationUnavailable());
+      assert.isFalse($scope.annotationUnavailable());
     });
 
-    it('shows logged out message if selection is available', function () {
+    it('shows logged out message if annotation is available', function () {
       $scope.auth = {
         status: 'signed-out'
       };
-      fakeAnnotationUI.selectedAnnotationMap = {'123': true};
+      $scope.search.query = 'id:123';
       fakeThreading.idTable = {'123': {}};
       $scope.$digest();
       assert.isTrue($scope.shouldShowLoggedOutMessage());
     });
 
-    it('does not show loggedout message if selection is unavailable', function () {
+    it('does not show loggedout message if annotation is unavailable', function () {
       $scope.auth = {
         status: 'signed-out'
       };
-      fakeAnnotationUI.selectedAnnotationMap = {'missing': true};
+      $scope.search.query = 'id:missing';
       fakeThreading.idTable = {'123': {}};
       $scope.$digest();
       assert.isFalse($scope.shouldShowLoggedOutMessage());
     });
 
-    it('does not show loggedout message if there is no selection', function () {
+    it('does not show loggedout message if there is no annotation', function () {
       $scope.auth = {
         status: 'signed-out'
       };
-      fakeAnnotationUI.selectedAnnotationMap = null;
       $scope.$digest();
       assert.isFalse($scope.shouldShowLoggedOutMessage());
     });
@@ -348,18 +347,7 @@ describe('WidgetController', function () {
       $scope.auth = {
         status: 'signed-in'
       };
-      fakeAnnotationUI.selectedAnnotationMap = {'123': true};
-      fakeThreading.idTable = {'123': {}};
-      $scope.$digest();
-      assert.isFalse($scope.shouldShowLoggedOutMessage());
-    });
-
-    it('does not show loggedout message if not a direct link', function () {
-      $scope.auth = {
-        status: 'signed-out'
-      };
-      delete fakeSettings.annotations;
-      fakeAnnotationUI.selectedAnnotationMap = {'123': true};
+      $scope.search.query = 'id:123';
       fakeThreading.idTable = {'123': {}};
       $scope.$digest();
       assert.isFalse($scope.shouldShowLoggedOutMessage());

--- a/h/static/scripts/test/widget-controller-test.js
+++ b/h/static/scripts/test/widget-controller-test.js
@@ -8,6 +8,8 @@ var EventEmitter = require('tiny-emitter');
 var events = require('../events');
 var noCallThru = require('./util').noCallThru;
 
+var publicGroup = {id: '__world__', public: true};
+
 var searchClients;
 function FakeSearchClient(resource, opts) {
   assert.ok(resource);
@@ -97,7 +99,7 @@ describe('WidgetController', function () {
     };
 
     fakeGroups = {
-      focused: function () { return {id: 'foo'}; },
+      focused: function () { return {id: 'foo', public: false}; },
       focus: sinon.stub(),
     };
 
@@ -351,6 +353,31 @@ describe('WidgetController', function () {
       fakeThreading.idTable = {'123': {}};
       $scope.$digest();
       assert.isFalse($scope.shouldShowLoggedOutMessage());
+    });
+  });
+
+  describe('#shouldShowTotalCount', function () {
+    it('is true when there is a direct-linked annotation and the public group is selected', function () {
+      fakeGroups.focused = function () {
+        return publicGroup;
+      };
+      $scope.search.query = 'id:123';
+      $scope.$digest();
+      assert.isTrue($scope.shouldShowTotalCount());
+    });
+
+    it('is false when there is no direct-linked annotation', function () {
+      fakeGroups.focused = function () {
+        return publicGroup;
+      };
+      $scope.$digest();
+      assert.isFalse($scope.shouldShowTotalCount());
+    });
+
+    it('is false when a private group is selected', function () {
+      $scope.search.query = 'id:123';
+      $scope.$digest();
+      assert.isFalse($scope.shouldShowTotalCount());
     });
   });
 });

--- a/h/static/scripts/view-filter.coffee
+++ b/h/static/scripts/view-filter.coffee
@@ -86,6 +86,10 @@ module.exports = ['unicode', (unicode) ->
       autofalse: (annotation) -> return not annotation.user?
       value: (annotation) -> return annotation.user
       match: (term, value) -> return value.indexOf(term) > -1
+    id:
+      autofalse: (annotation) -> return not annotation.id?
+      value: (annotation) -> return annotation.id
+      match: (term, value) -> return value == term
     any:
       fields: ['quote', 'text', 'tag', 'user']
 

--- a/h/static/scripts/widget-controller.js
+++ b/h/static/scripts/widget-controller.js
@@ -253,6 +253,14 @@ module.exports = function WidgetController(
            !!threading.idTable[directLinkedAnnotationID()];
   };
 
+  $scope.topLevelThreadCount = function () {
+    return threading.root.children.length;
+  };
+
+  $scope.shouldShowTotalCount = function () {
+    return groups.focused().public && !!directLinkedAnnotationID();
+  };
+
   $scope.isLoading = isLoading;
 
   $rootScope.$on(events.BEFORE_ANNOTATION_CREATED, function (event, data) {

--- a/h/static/scripts/widget-controller.js
+++ b/h/static/scripts/widget-controller.js
@@ -138,6 +138,10 @@ module.exports = function WidgetController(
     searchClient.get({uri: uri, group: group});
   }
 
+  function isLoading() {
+    return searchClients.length > 0;
+  }
+
   /**
    * Load annotations for all URLs associated with `frames`.
    *
@@ -202,12 +206,11 @@ module.exports = function WidgetController(
   });
 
   $scope.$on(events.GROUP_FOCUSED, function () {
-    // The focused group may be changed during loading annotations (in which
-    // case, searchClients.length > 0), as a result of switching to the group
-    // containing a direct-linked annotation.
+    // The focused group may be changed during loading annotations as a result
+    // of switching to the group containing a direct-linked annotation.
     //
     // In that case, we don't want to trigger reloading annotations again.
-    if (searchClients.length) {
+    if (isLoading()) {
       return;
     }
 
@@ -231,7 +234,7 @@ module.exports = function WidgetController(
   };
 
   $scope.annotationUnavailable = function () {
-    return searchClients.length === 0 &&
+    return !isLoading() &&
            !!directLinkedAnnotationID() &&
            !threading.idTable[directLinkedAnnotationID()];
   };
@@ -245,10 +248,12 @@ module.exports = function WidgetController(
     // The user is logged out and has landed on a direct linked
     // annotation, and that annotation is available to the user,
     // show the CTA
-    return searchClients.length === 0 &&
+    return !isLoading() &&
            !!directLinkedAnnotationID() &&
            !!threading.idTable[directLinkedAnnotationID()];
   };
+
+  $scope.isLoading = isLoading;
 
   $rootScope.$on(events.BEFORE_ANNOTATION_CREATED, function (event, data) {
     if (data.$highlight || (data.references && data.references.length > 0)) {

--- a/h/static/scripts/widget-controller.js
+++ b/h/static/scripts/widget-controller.js
@@ -3,22 +3,14 @@
 var events = require('./events');
 var SearchClient = require('./search-client');
 
-function firstKey(object) {
-  for (var k in object) {
-    if (!object.hasOwnProperty(k)) {
-      continue;
-    }
-    return k;
-  }
-  return null;
-}
-
 /**
  * Returns the group ID of the first annotation in `results` whose
- * ID is a key in `selection`.
+ * ID matches `id`
+ *
+ * @param {string} id
+ * @param {Array<Annotation>} results
  */
-function groupIDFromSelection(selection, results) {
-  var id = firstKey(selection);
+function groupIDFromAnnotation(id, results) {
   var annot = results.find(function (annot) {
     return annot.id === id;
   });
@@ -26,6 +18,28 @@ function groupIDFromSelection(selection, results) {
     return;
   }
   return annot.group;
+}
+
+/**
+ * Return the parent annotation of `annot` which may be either an annotation
+ * or a reply.
+ *
+ * @param {Threading} threading - Threading service
+ * @param {Annotation} annot
+ */
+function rootAncestorOf(threading, annot) {
+  if (!annot.references ||
+       annot.references.length === 0) {
+    return annot;
+  }
+
+  // Replies can be nested, we're only interested in the root ancestor
+  // which is an annotation rather than a reply.
+  var root = threading.idTable[annot.references[0]].message;
+  if (!root) {
+    return annot;
+  }
+  return root;
 }
 
 // @ngInject
@@ -52,18 +66,30 @@ module.exports = function WidgetController(
   }
 
   /**
+   * Returns the ID of the direct-linked annotation (if any).
+   * This ID is passed to the app via an 'id:<annotation ID>' search query
+   */
+  function directLinkedAnnotationID() {
+    var idMatch = $scope.search.query.match(/^id:(.*)$/);
+    if (idMatch) {
+      return idMatch[1];
+    } else {
+      return null;
+    }
+  }
+
+  /**
    * Returns the Annotation object for the first annotation in the
    * selected annotation set. Note that 'first' refers to the order
    * of annotations passed to annotationUI when selecting annotations,
    * not the order in which they appear in the document.
    */
-  function firstSelectedAnnotation() {
-    if (annotationUI.selectedAnnotationMap) {
-      var id = Object.keys(annotationUI.selectedAnnotationMap)[0];
-      return threading.idTable[id] && threading.idTable[id].message;
-    } else {
+  function directLinkedAnnotation() {
+    var id = directLinkedAnnotationID();
+    if (!id) {
       return null;
     }
+    return threading.idTable[id] && threading.idTable[id].message;
   }
 
   function _resetAnnotations() {
@@ -78,17 +104,17 @@ module.exports = function WidgetController(
   function _loadAnnotationsFor(uri, group) {
     var searchClient = new SearchClient(store.SearchResource, {
       // If no group is specified, we are fetching annotations from
-      // all groups in order to find out which group contains the selected
+      // all groups in order to find out which group contains the direct-linked
       // annotation, therefore we need to load all chunks before processing
       // the results
       incremental: !!group,
     });
     searchClients.push(searchClient);
     searchClient.on('results', function (results) {
-      if (annotationUI.hasSelectedAnnotations()) {
-        // Focus the group containing the selected annotation and filter
+      if (directLinkedAnnotationID()) {
+        // Focus the group containing the annotation and filter
         // annotations to those from this group
-        var groupID = groupIDFromSelection(annotationUI.selectedAnnotationMap,
+        var groupID = groupIDFromAnnotation(directLinkedAnnotationID(),
           results);
         if (!groupID) {
           // If the selected annotation is not available, fall back to
@@ -133,18 +159,16 @@ module.exports = function WidgetController(
       }
     }, []);
 
-    // If there is no selection, load annotations only for the focused group.
+    // If there is no direct-linked annotation, load annotations only for the
+    // focused group, otherwise we load annotations for all groups, find out
+    // which group that annotation is in and then filter the results on the
+    // client by that group.
     //
-    // If there is a selection, we load annotations for all groups, find out
-    // which group the first selected annotation is in and then filter the
-    // results on the client by that group.
-    //
-    // In the common case where the total number of annotations on
-    // a page that are visible to the user is not greater than
-    // the batch size, this saves an extra roundtrip to the server
-    // to fetch the selected annotation in order to determine which group
-    // it is in before fetching the remaining annotations.
-    var group = annotationUI.hasSelectedAnnotations() ?
+    // In the common case where the total number of annotations on a page that
+    // are visible to the user is not greater than the batch size, this saves an
+    // extra roundtrip to the server to fetch the annotation in order to
+    // determine which group it is in before fetching the remaining annotations.
+    var group = directLinkedAnnotationID() ?
       null : groups.focused().id;
 
     for (var i=0; i < urls.length; i++) {
@@ -160,28 +184,29 @@ module.exports = function WidgetController(
   // When a direct-linked annotation is successfully anchored in the page,
   // focus and scroll to it
   $rootScope.$on(events.ANNOTATIONS_SYNCED, function (event, tags) {
-    var selectedAnnot = firstSelectedAnnotation();
-    if (!selectedAnnot) {
+    var annot = directLinkedAnnotation();
+    if (!annot) {
       return;
     }
-    var matchesSelection = tags.some(function (tag) {
-      return tag.tag === selectedAnnot.$$tag;
-    });
-    if (!matchesSelection) {
+
+    if (!tags.some(function (tag) { return tag.tag === annot.$$tag; })) {
       return;
     }
-    focusAnnotation(selectedAnnot);
-    scrollToAnnotation(selectedAnnot);
+
+    // Only annotations (not replies) can be scrolled to and focused, so
+    // we need to find the parent of the direct-linked annotation
+    // and focus/scroll to that.
+    var parent = rootAncestorOf(threading, annot);
+    focusAnnotation(parent);
+    scrollToAnnotation(parent);
   });
 
   $scope.$on(events.GROUP_FOCUSED, function () {
     // The focused group may be changed during loading annotations (in which
     // case, searchClients.length > 0), as a result of switching to the group
-    // containing the selected annotation.
+    // containing a direct-linked annotation.
     //
-    // In that case, we don't want to trigger reloading annotations again and we
-    // also want to preserve the selection if the user visits a direct link to a
-    // group annotation whilst signed out, then signs in.
+    // In that case, we don't want to trigger reloading annotations again.
     if (searchClients.length) {
       return;
     }
@@ -205,10 +230,10 @@ module.exports = function WidgetController(
     return annotation.$$tag in $scope.focusedAnnotations;
   };
 
-  $scope.selectedAnnotationUnavailable = function () {
+  $scope.annotationUnavailable = function () {
     return searchClients.length === 0 &&
-           annotationUI.hasSelectedAnnotations() &&
-           !threading.idTable[firstKey(annotationUI.selectedAnnotationMap)];
+           !!directLinkedAnnotationID() &&
+           !threading.idTable[directLinkedAnnotationID()];
   };
 
   $scope.shouldShowLoggedOutMessage = function () {
@@ -217,18 +242,12 @@ module.exports = function WidgetController(
       return false;
     }
 
-    // If user has not landed on a direct linked annotation
-    // don't show the CTA.
-    if (!settings.annotations) {
-      return false;
-    }
-
     // The user is logged out and has landed on a direct linked
-    // annotation. If there is an annotation selection and that
-    // selection is available to the user, show the CTA.
+    // annotation, and that annotation is available to the user,
+    // show the CTA
     return searchClients.length === 0 &&
-           annotationUI.hasSelectedAnnotations() &&
-           !!threading.idTable[firstKey(annotationUI.selectedAnnotationMap)];
+           !!directLinkedAnnotationID() &&
+           !!threading.idTable[directLinkedAnnotationID()];
   };
 
   $rootScope.$on(events.BEFORE_ANNOTATION_CREATED, function (event, data) {

--- a/h/static/styles/util.scss
+++ b/h/static/styles/util.scss
@@ -3,6 +3,10 @@
   flex-grow: 1;
 }
 
+.u-fixed-size {
+  flex-shrink: 0;
+}
+
 .u-layout-row {
   display: flex;
   flex-direction: row;

--- a/h/templates/client/search_status_bar.html
+++ b/h/templates/client/search_status_bar.html
@@ -1,4 +1,12 @@
-<div class="search-status-bar" ng-show="filterActive">
+<div class="search-status-bar" ng-if="filterActive && showTotalCountMessage">
+  <button class="primary-action-btn primary-action-btn--short"
+          ng-click="onClearSelection()"
+          title="Show all {{totalCount}} public annotations on this page"
+  >
+    See all {{totalCount}} public annotations
+  </button>
+</div>
+<div class="search-status-bar" ng-if="filterActive && !showTotalCountMessage">
   <button class="primary-action-btn primary-action-btn--short"
           ng-click="onClearSelection()"
           title="Clear the search filter and show all annotations"
@@ -11,7 +19,7 @@
                   'one': '1 search result',
                   'other': '{} search results'}"></span>
 </div>
-<div class="search-status-bar" ng-show="!filterActive && selectionCount > 0">
+<div class="search-status-bar" ng-if="!filterActive && selectionCount > 0">
   <button class="primary-action-btn primary-action-btn--short"
           ng-click="onClearSelection()"
           title="Clear the selection and show all annotations"

--- a/h/templates/client/top_bar.html
+++ b/h/templates/client/top_bar.html
@@ -24,7 +24,7 @@
        the stream view.
   !-->
   <div class="top-bar__inner content" ng-if="::isSidebar">
-    <group-list class="group-list" auth="auth"></group-list>
+    <group-list class="group-list u-fixed-size" auth="auth"></group-list>
     <div class="top-bar__expander"></div>
     <simple-search
       class="simple-search"
@@ -45,6 +45,7 @@
       <i class="h-icon-annotation-share"></i>
     </a>
     <signin-control
+      class="u-fixed-size"
       auth="auth"
       new-style="true"
       on-login="onLogin()"

--- a/h/templates/client/viewer.html
+++ b/h/templates/client/viewer.html
@@ -12,7 +12,8 @@
     filter-match-count="count('match')"
     search-query="search ? search.query : ''"
     selection-count="selectedAnnotationsCount"
-    on-clear-selection="clearSelection()">
+    on-clear-selection="clearSelection()"
+    ng-show="!isLoading()">
   </search-status-bar>
   <li ng-if="isStream">
     <sort-dropdown

--- a/h/templates/client/viewer.html
+++ b/h/templates/client/viewer.html
@@ -22,7 +22,7 @@
     </sort-dropdown>
   </li>
   <li class="annotation-unavailable-message"
-      ng-if="selectedAnnotationUnavailable()">
+      ng-if="annotationUnavailable()">
     <div class="annotation-unavailable-message__icon"></div>
     <p class="annotation-unavailable-message__label">
       You do not have permission to see this annotation

--- a/h/templates/client/viewer.html
+++ b/h/templates/client/viewer.html
@@ -13,6 +13,8 @@
     search-query="search ? search.query : ''"
     selection-count="selectedAnnotationsCount"
     on-clear-selection="clearSelection()"
+    total-count="topLevelThreadCount()"
+    show-total-count-message="shouldShowTotalCount()"
     ng-show="!isLoading()">
   </search-status-bar>
   <li ng-if="isStream">


### PR DESCRIPTION
**Background**

The sidebar has two different mechanisms for filtering the list of displayed annotations, filters and selection. Filters are used when you enter a query via search in the top bar, selection is used when you click on an annotation in the page and it filters the sidebar to show only that annotation.

**Overview**

This PR changes direct linking to filter the sidebar to show only direct-linked annotations using the filtering system, via an "id:<annotation ID>" query, rather than using the selection mechanism.

The reason for this is that the filtering mechanism works with both top-level annotations and replies, whereas the selection mechanism only works with top-level annotations, something I hadn't originally considered.

The alternative approach I could have taken would have been to implement support for selecting replies, but this would have involved re-implementing the system that hides parts of the conversation that do not match the search filter. I explored this approach but not too surprisingly it ended up being cleaner and simpler to re-use the existing system.

**UX Issues**

Some UX issues to note:
* The search field is now populated with an "id:<ID>" query automatically when following a direct link, IMO this looks a little ugly, I could perhaps not display the actual search query in the top bar in this case?
* When direct linking to a non-top level annotation, you'll now see a "View N more in this conversation" link below the annotation body, matching the behavior when using the search tool
