### PR TITLE
Make client injection robust to pages that replace the URL fragment as they load

### DIFF
--- a/h/browser/chrome/test/hypothesis-chrome-extension-test.js
+++ b/h/browser/chrome/test/hypothesis-chrome-extension-test.js
@@ -255,6 +255,21 @@ describe('HypothesisChromeExtension', function () {
       it('injects the sidebar if a direct link is present', function () {
         var tab = createTab();
         tab.url += '#annotations:456';
+        fakeChromeTabs.onUpdated.listener(tab.id, {status: 'loading'}, tab);
+        fakeChromeTabs.onUpdated.listener(tab.id, {status: 'complete'}, tab);
+        assert.equal(tabState[tab.id].state, TabState.states.ACTIVE);
+      });
+
+      it('injects the sidebar if the page rewrites the URL fragment', function () {
+        var tab = createTab();
+        var origURL = tab.url;
+        tab.url += '#annotations:456';
+        fakeChromeTabs.onUpdated.listener(tab.id, {status: 'loading'}, tab);
+
+        // Simulate client side JS rewriting the URL fragment before the sidebar
+        // is injected
+        tab.url = origURL + '#modified-fragment';
+        fakeChromeTabs.onUpdated.listener(tab.id, {status: 'loading'}, tab);
         fakeChromeTabs.onUpdated.listener(tab.id, {status: 'complete'}, tab);
         assert.equal(tabState[tab.id].state, TabState.states.ACTIVE);
       });

--- a/h/static/scripts/annotator/config.js
+++ b/h/static/scripts/annotator/config.js
@@ -33,6 +33,14 @@ function config(window_) {
     }
   }
 
+  // Extract the direct linked ID from the URL.
+  //
+  // The Chrome extension or proxy may already have provided this config
+  // via a tag injected into the DOM, which avoids the problem where the page's
+  // JS rewrites the URL before Hypothesis loads.
+  //
+  // In environments where the config has not been injected into the DOM,
+  // we try to retrieve it from the URL here.
   var directLinkedID = annotationIDs.extractIDFromURL(window_.location.href);
   if (directLinkedID) {
     options.annotations = directLinkedID;

--- a/h/static/scripts/annotator/config.js
+++ b/h/static/scripts/annotator/config.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var annotationIDs = require('../util/annotation-ids');
+var settings = require('../settings');
 
 var docs = 'https://h.readthedocs.org/en/latest/hacking/customized-embedding.html';
 
@@ -15,15 +16,12 @@ function config(window_) {
       document.querySelector('link[type="application/annotator+html"]').href,
   };
 
-  // Parse config from `<meta name="hypothesis-config" content="<JSON>">` tags
-  var configElement = window_.document
-    .querySelector('meta[name="hypothesis-config"]');
-  if (configElement) {
-    try {
-      Object.assign(options, JSON.parse(configElement.content));
-    } catch (err) {
-      console.warn('Could not parse Hypothesis config from', configElement);
-    }
+  // Parse config from `<script class="js-hypothesis-config">` tags
+  try {
+    Object.assign(options, settings(window_.document, 'js-hypothesis-config'));
+  } catch (err) {
+    console.warn('Could not parse settings from js-hypothesis-config tags',
+      err);
   }
 
   // Parse config from `window.hypothesisConfig` function

--- a/h/static/scripts/annotator/config.js
+++ b/h/static/scripts/annotator/config.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var annotationIDs = require('../util/annotation-ids');
+
 var docs = 'https://h.readthedocs.org/en/latest/hacking/customized-embedding.html';
 
 /**
@@ -13,6 +15,18 @@ function config(window_) {
       document.querySelector('link[type="application/annotator+html"]').href,
   };
 
+  // Parse config from `<meta name="hypothesis-config" content="<JSON>">` tags
+  var configElement = window_.document
+    .querySelector('meta[name="hypothesis-config"]');
+  if (configElement) {
+    try {
+      Object.assign(options, JSON.parse(configElement.content));
+    } catch (err) {
+      console.warn('Could not parse Hypothesis config from', configElement);
+    }
+  }
+
+  // Parse config from `window.hypothesisConfig` function
   if (window_.hasOwnProperty('hypothesisConfig')) {
     if (typeof window_.hypothesisConfig === 'function') {
       Object.assign(options, window_.hypothesisConfig());
@@ -21,9 +35,9 @@ function config(window_) {
     }
   }
 
-  var annotFragmentMatch = window_.location.hash.match(/^#annotations:(.*)/);
-  if (annotFragmentMatch) {
-    options.annotations = annotFragmentMatch[1];
+  var directLinkedID = annotationIDs.extractIDFromURL(window_.location.href);
+  if (directLinkedID) {
+    options.annotations = directLinkedID;
   }
   return options;
 }

--- a/h/static/scripts/annotator/test/config-test.js
+++ b/h/static/scripts/annotator/test/config-test.js
@@ -64,7 +64,7 @@ describe('annotator configuration', function () {
     });
   });
 
-  it('merges the config from the "hypothesis-config" meta tag', function () {
+  it('merges the config from the "js-hypothesis-config" <script> tag', function () {
     fakeScriptConfig = '{"annotations":"456"}';
     assert.deepEqual(config(fakeWindowBase), {
       app: 'app.html',

--- a/h/static/scripts/annotator/test/config-test.js
+++ b/h/static/scripts/annotator/test/config-test.js
@@ -3,26 +3,32 @@
 var config = require('../config');
 
 describe('annotator configuration', function () {
-  var fakeMetaConfig;
+  var fakeScriptConfig;
+
+  function fakeQuerySelector(selector) {
+    if (selector === 'link[type="application/annotator+html"]') {
+      return {href: 'app.html'};
+    } else if (selector === 'script.js-hypothesis-config' &&
+               fakeScriptConfig) {
+      return {textContent: fakeScriptConfig};
+    } else {
+      return null;
+    }
+  }
 
   var fakeWindowBase = {
     document: {
-      querySelector: sinon.spy(function (selector) {
-        if (selector === 'link[type="application/annotator+html"]') {
-          return {href: 'app.html'};
-        } else if (selector === 'meta[name="hypothesis-config"]' &&
-                   fakeMetaConfig) {
-          return {content:fakeMetaConfig};
-        } else {
-          return null;
-        }
-      }),
+      querySelector: fakeQuerySelector,
+      querySelectorAll: function (selector) {
+        var match = fakeQuerySelector(selector);
+        return match ? [match] : [];
+      },
     },
     location: {hash: ''},
   };
 
   beforeEach(function () {
-    fakeMetaConfig = '';
+    fakeScriptConfig = '';
   });
 
   it('reads the app src from the link tag', function () {
@@ -59,7 +65,7 @@ describe('annotator configuration', function () {
   });
 
   it('merges the config from the "hypothesis-config" meta tag', function () {
-    fakeMetaConfig = '{"annotations":"456"}';
+    fakeScriptConfig = '{"annotations":"456"}';
     assert.deepEqual(config(fakeWindowBase), {
       app: 'app.html',
       annotations: '456',

--- a/h/static/scripts/settings.js
+++ b/h/static/scripts/settings.js
@@ -6,16 +6,20 @@ require('core-js/fn/object/assign');
  * Return application configuration information from the host page.
  *
  * Exposes shared application settings, read from script tags with the
- * class 'js-hypothesis-settings' which contain JSON content.
+ * class `settingsClass` which contain JSON content.
  *
  * If there are multiple such tags, the configuration from each is merged.
  *
  * @param {Document|Element} document - The root element to search for
  *                                      <script> settings tags.
+ * @param {string} settingsClass - The class name to match on <script> tags.
  */
-function settings(document) {
+function settings(document, settingsClass) {
+  if (!settingsClass) {
+    settingsClass = 'js-hypothesis-settings';
+  }
   var settingsElements =
-    document.querySelectorAll('script.js-hypothesis-settings');
+    document.querySelectorAll('script.' + settingsClass);
 
   var config = {};
   for (var i=0; i < settingsElements.length; i++) {

--- a/h/static/scripts/test/settings-test.js
+++ b/h/static/scripts/test/settings-test.js
@@ -1,24 +1,42 @@
+'use strict';
+
 var settings = require('../settings');
 
-function createJSONScriptTag(obj) {
+function createJSONScriptTag(obj, className) {
   var el = document.createElement('script');
   el.type = 'application/json';
   el.textContent = JSON.stringify(obj);
-  el.classList.add('js-hypothesis-settings');
+  el.classList.add(className);
+  el.classList.add('js-settings-test');
   return el;
 }
 
+function removeJSONScriptTags() {
+  var elements = document.querySelectorAll('.js-settings-test');
+  for (var i=0; i < elements.length; i++) {
+    elements[i].parentNode.removeChild(elements[i]);
+  }
+}
+
 describe('settings', function () {
-  afterEach(function () {
-    var elements = document.querySelectorAll('.js-hypothesis-settings');
-    for (var i=0; i < elements.length; i++) {
-      elements[i].parentNode.removeChild(elements[i]);
-    }
+  afterEach(removeJSONScriptTags);
+
+  it('reads config from .js-hypothesis-settings <script> tags', function () {
+    document.body.appendChild(createJSONScriptTag({key:'value'},
+      'js-hypothesis-settings'));
+    assert.deepEqual(settings(document), {key:'value'});
   });
 
-  it('should merge settings', function () {
-    document.body.appendChild(createJSONScriptTag({ a: 1 }));
-    document.body.appendChild(createJSONScriptTag({ b: 2 }));
-    assert.deepEqual(settings(document), { a: 1, b: 2 });
+  it('reads config from <script> tags with the specified class name', function () {
+    document.body.appendChild(createJSONScriptTag({foo:'bar'},
+      'js-custom-settings'));
+    assert.deepEqual(settings(document), {});
+    assert.deepEqual(settings(document, 'js-custom-settings'), {foo:'bar'});
+  });
+
+  it('merges settings from all config <script> tags', function () {
+    document.body.appendChild(createJSONScriptTag({a: 1}, 'settings'));
+    document.body.appendChild(createJSONScriptTag({b: 2}, 'settings'));
+    assert.deepEqual(settings(document, 'settings'), {a: 1, b: 2});
   });
 });

--- a/h/static/scripts/util/annotation-ids.js
+++ b/h/static/scripts/util/annotation-ids.js
@@ -1,0 +1,18 @@
+'use strict';
+
+function extractIDFromURL(url) {
+  try {
+    var annotFragmentMatch = url.match(/#annotations:([A-Za-z0-9_-]+)$/);
+    if (annotFragmentMatch) {
+      return annotFragmentMatch[1];
+    } else {
+      return null;
+    }
+  } catch (err) {
+    return null;
+  }
+}
+
+module.exports = {
+  extractIDFromURL: extractIDFromURL,
+};

--- a/h/static/scripts/util/annotation-ids.js
+++ b/h/static/scripts/util/annotation-ids.js
@@ -1,7 +1,16 @@
 'use strict';
 
+/**
+ * Extracts a direct-linked annotation ID from the fragment of a URL.
+ *
+ * @param {string} url - The URL which may contain a '#annotations:<ID>'
+ *        fragment.
+ * @return {string?} The annotation ID if present
+ */
 function extractIDFromURL(url) {
   try {
+    // Annotation IDs are url-safe-base64 identifiers
+    // See https://tools.ietf.org/html/rfc4648#page-7
     var annotFragmentMatch = url.match(/#annotations:([A-Za-z0-9_-]+)$/);
     if (annotFragmentMatch) {
       return annotFragmentMatch[1];


### PR DESCRIPTION
This is a set of changes that make direct-linking more robust to changes in the URL fragment by the page when it loads, such as on Medium and EBSCOHost.

There are two changes here which help with this:

1. Making the parsing of the '#annotations' fragment stricter by only matching characters after '#annotations:' which are valid annotation ID chars (the URL-safe Base64 charset)
2. Capturing the ID from the '#annotations' fragment when a tab starts loading in the Chrome extension and passing that ID through to the sidebar when it is injected, so that the direct link works even if client-side JS rewrites the fragment whilst it loads, or a client-side triggered redirect causes the URL fragment to be lost.

Fixes #3137
Fixes #3122