### PR TITLE
Minor copy and style tweaks to the logged-out message

### DIFF
--- a/h/static/styles/loggedout-message.scss
+++ b/h/static/styles/loggedout-message.scss
@@ -7,13 +7,7 @@
   flex-direction: column;
 }
 
-.loggedout-message-actions {
-  margin: auto;
-  width: 75%;
-  text-align: center;
-}
-
-.loggedout-message-actions__link {
+.loggedout-message__link {
   text-decoration: underline;
   color: $dg-3;
 

--- a/h/templates/client/viewer.html
+++ b/h/templates/client/viewer.html
@@ -41,16 +41,13 @@
       ng-show="vm.shouldShow()">
   </li>
   <li class="loggedout-message" ng-if="isSidebar && shouldShowLoggedOutMessage()" ng-cloak>
-    This is a public annotation created with Hypothes.is
-    <span class="loggedout-message-actions">
-      <a class="loggedout-message-actions__link" href="{{ register_url }}" target="_blank">
-        Sign up
-      </a>
-      for a free account or
-      <a class="loggedout-message-actions__link" href="" ng-click="login()">
-        log in
-      </a>
-      to reply or create a new annotation
+    <span>
+      This is a public annotation created with Hypothesis.
+      <br>
+      To reply or make your own annotations on this document,
+      <a class="loggedout-message__link" href="{{ register_url }}" target="_blank">create a free account</a>
+      or
+      <a class="loggedout-message__link" href="" ng-click="login()">sign in</a>.
     </span>
     <span class="loggedout-message-logo">
       <a href="https://hypothes.is">


### PR DESCRIPTION
- We prefer "Hypothesis" in prose text to "Hypothes.is"
- Remove unwanted padding at the end of anchors.
- Say "sign in" rather than "log in," as we do everywhere else in the
  sidebar.
- Slight improvement to readability of call-to-action sentence by
  separating the "X or Y" clauses.

#### Before

<img width="429" alt="screen shot 2016-03-31 at 13 01 35" src="https://cloud.githubusercontent.com/assets/3602/14173895/2aabb0ae-f741-11e5-8b7e-f2d868b89f67.png">

#### After

<img width="431" alt="screen shot 2016-03-31 at 13 18 58" src="https://cloud.githubusercontent.com/assets/3602/14174206/335c7416-f743-11e5-9baa-d513c950418b.png">

Ping @conordelahunty for review/approval/MERCILESS REJECTION.

