### PR TITLE
Remove incontext links for replies

### DIFF
--- a/h/app.py
+++ b/h/app.py
@@ -118,5 +118,6 @@ def includeme(config):
     config.include('h.badge')
     config.include('h.feeds')
     config.include('h.groups')
+    config.include('h.links')
     config.include('h.nipsa')
     config.include('h.notification')

--- a/h/links.py
+++ b/h/links.py
@@ -15,7 +15,8 @@ def html_link(request, annotation):
 
 def incontext_link(request, annotation):
     """Generate a link to an annotation on the page where it was made."""
-    if not request.feature('direct_linking'):
+    is_reply = bool(annotation.references)
+    if not request.feature('direct_linking') or is_reply:
         return None
 
     bouncer_url = request.registry.settings.get('h.bouncer_url')

--- a/h/links.py
+++ b/h/links.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+
+"""
+Provides links to different representations of annotations.
+"""
+
+
+from h._compat import urlparse
+
+
+def html_link(request, annotation):
+    """Generate a link to an HTML representation of an annotation."""
+    return request.route_url('annotation', id=annotation.id)
+
+
+def incontext_link(request, annotation):
+    """Generate a link to an annotation on the page where it was made."""
+    if not request.feature('direct_linking'):
+        return None
+
+    bouncer_url = request.registry.settings.get('h.bouncer_url')
+    if not bouncer_url:
+        return None
+    return urlparse.urljoin(bouncer_url, annotation.id)
+
+
+def includeme(config):
+    # Add an annotation link generator for the `annotation` view -- this adds a
+    # named link called "html" to API rendered views of annotations. See
+    # :py:mod:`h.api.presenters` for details.
+    config.add_annotation_link_generator('html', html_link)
+
+    # Add an annotation link generator for viewing annotations in context on
+    # the page on which they were made.
+    config.add_annotation_link_generator('incontext', incontext_link)

--- a/h/test/links_test.py
+++ b/h/test/links_test.py
@@ -15,6 +15,14 @@ def test_incontext_link(api_request):
     assert links.incontext_link(api_request, annotation) == 'https://hyp.is/123'
 
 
+def test_incontext_link_is_none_for_replies(api_request):
+    annotation = Mock()
+    annotation.id = '123'
+    annotation.references = ['parent']
+
+    assert links.incontext_link(api_request, annotation) == None
+
+
 @pytest.fixture
 def api_request():
     def feature(name):

--- a/h/test/links_test.py
+++ b/h/test/links_test.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+
+from pyramid.testing import DummyRequest
+from mock import Mock
+import pytest
+
+from h import links
+
+
+def test_incontext_link(api_request):
+    annotation = Mock()
+    annotation.id = '123'
+    annotation.references = None
+
+    assert links.incontext_link(api_request, annotation) == 'https://hyp.is/123'
+
+
+@pytest.fixture
+def api_request():
+    def feature(name):
+        return name == 'direct_linking'
+    request = DummyRequest(feature=feature)
+    request.registry.settings = {'h.bouncer_url': 'https://hyp.is'}
+    return request

--- a/h/views/main.py
+++ b/h/views/main.py
@@ -14,7 +14,6 @@ from pyramid import httpexceptions
 from pyramid import response
 from pyramid.view import view_config
 
-from h._compat import urlparse
 from h.views.client import render_app
 
 
@@ -80,39 +79,5 @@ def stream_user_redirect(request):
     raise httpexceptions.HTTPFound(location=location)
 
 
-def _html_link(request, annotation):
-    """Generate a link to an HTML representation of an annotation."""
-    return request.route_url('annotation', id=annotation.id)
-
-
-def _incontext_link(request, annotation):
-    """Generate a link to an annotation on the page where it was made."""
-    if not request.feature('direct_linking'):
-        return
-    try:
-        return request.route_url('annotation.incontext', id=annotation.id)
-    # A KeyError means that the 'annotation.incontext' route does not
-    # exist, which in turn means that a bouncer URL has not been set for
-    # this application.
-    except KeyError:
-        pass
-
-
 def includeme(config):
     config.scan(__name__)
-
-    # Add a static (i.e. external) route for the bouncer service if we have a
-    # URL for a bouncer service set.
-    bouncer_url = config.registry.settings.get('h.bouncer_url')
-    if bouncer_url:
-        bouncer_route = urlparse.urljoin(bouncer_url, '{id}')
-        config.add_route('annotation.incontext', bouncer_route, static=True)
-
-    # Add an annotation link generator for the `annotation` view -- this adds a
-    # named link called "html" to API rendered views of annotations. See
-    # :py:mod:`h.api.presenters` for details.
-    config.add_annotation_link_generator('html', _html_link)
-
-    # Add an annotation link generator for viewing annotations in context on
-    # the page on which they were made.
-    config.add_annotation_link_generator('incontext', _incontext_link)


### PR DESCRIPTION
We are currently not decided on how we want to support direct-linking to
replies. Removing the incontext links causes the client to show links to the standalone HTML page instead and avoids exposing incontext links to other clients.

Fixes #3127
https://trello.com/c/tWqgkw82/313-remove-direct-links-to-replies