### PR TITLE
Avoid showing 'Clear Selection' or 'Clear Search' buttons whilst loading

### DIFF
--- a/h/templates/client/viewer.html
+++ b/h/templates/client/viewer.html
@@ -12,7 +12,8 @@
     filter-match-count="count('match')"
     search-query="search ? search.query : ''"
     selection-count="selectedAnnotationsCount"
-    on-clear-selection="clearSelection()">
+    on-clear-selection="clearSelection()"
+    ng-show="!isLoading()">
   </search-status-bar>
   <li ng-if="isStream">
     <sort-dropdown


### PR DESCRIPTION
When loading annotations whilst a search query is active or selection is
present, avoid showing the 'Clear Search' or 'Clear Selection' buttons
until the search has actually completed and we know whether any
annotations match the query or selection.

This fixes the flash of the 'Clear Selection' button when viewing a
direct-linked annotation.