### PR TITLE
Rename postgres_read feature flag to postgres

### DIFF
--- a/h/api/storage.py
+++ b/h/api/storage.py
@@ -177,4 +177,4 @@ def _prepare(request, annotation):
 
 
 def _postgres_enabled(request):
-    return request.feature('postgres_read')
+    return request.feature('postgres')

--- a/h/features.py
+++ b/h/features.py
@@ -17,7 +17,7 @@ log = logging.getLogger(__name__)
 FEATURES = {
     'direct_linking': "Generate direct links to annotations in context in the client?",
     'new_homepage': "Show the new homepage design?",
-    'postgres_read': 'Use postgres to fetch annotations from storage'
+    'postgres': 'Read/write annotation and document data from/to postgres'
 }
 
 # Once a feature has been fully deployed, we remove the flag from the codebase.


### PR DESCRIPTION
This one feature flag is to be used to enable both reading from and
writing to PostgreSQL.