### PR TITLE
Append target URIs to "in context" links in the API

### DIFF
--- a/h/links.py
+++ b/h/links.py
@@ -22,7 +22,14 @@ def incontext_link(request, annotation):
     bouncer_url = request.registry.settings.get('h.bouncer_url')
     if not bouncer_url:
         return None
-    return urlparse.urljoin(bouncer_url, annotation.id)
+
+    link = urlparse.urljoin(bouncer_url, annotation.id)
+    uri = annotation.target_uri
+    if uri and uri.startswith(('http://', 'https://')):
+        # We can't use urljoin here, because if it detects the second argument
+        # is a URL it will discard the base URL, breaking the link entirely.
+        link += '/' + uri[uri.index('://')+3:]
+    return link
 
 
 def includeme(config):

--- a/h/test/links_test.py
+++ b/h/test/links_test.py
@@ -6,21 +6,47 @@ import pytest
 
 from h import links
 
+class FakeAnnotation(object):
+    def __init__(self):
+        self.id = '123'
+        self.references = None
+        self.target_uri = 'http://example.com/foo/bar'
+
 
 def test_incontext_link(api_request):
-    annotation = Mock()
-    annotation.id = '123'
-    annotation.references = None
+    annotation = FakeAnnotation()
 
-    assert links.incontext_link(api_request, annotation) == 'https://hyp.is/123'
+    link = links.incontext_link(api_request, annotation)
+
+    assert link == 'https://hyp.is/123/example.com/foo/bar'
 
 
 def test_incontext_link_is_none_for_replies(api_request):
-    annotation = Mock()
-    annotation.id = '123'
+    annotation = FakeAnnotation()
     annotation.references = ['parent']
 
-    assert links.incontext_link(api_request, annotation) == None
+    link = links.incontext_link(api_request, annotation)
+
+    assert link is None
+
+
+@pytest.mark.parametrize('target_uri,expected', [
+    (None, 'https://hyp.is/123'),
+    ('', 'https://hyp.is/123'),
+    ('something_not_a_url', 'https://hyp.is/123'),
+    ('ftp://not_http', 'https://hyp.is/123'),
+    ('http://example.com/foo/bar', 'https://hyp.is/123/example.com/foo/bar'),
+    ('https://safari.org/giraffes', 'https://hyp.is/123/safari.org/giraffes'),
+])
+def test_incontext_link_appends_schemaless_uri_if_present(api_request,
+                                                          target_uri,
+                                                          expected):
+    annotation = FakeAnnotation()
+    annotation.target_uri = target_uri
+
+    link = links.incontext_link(api_request, annotation)
+
+    assert link == expected
 
 
 @pytest.fixture


### PR DESCRIPTION
As originally agreed, these links should have "schemaless" versions of the annotation target URI appended to the end.