### PR TITLE
Use require() for templates

### DIFF
--- a/h/client.py
+++ b/h/client.py
@@ -11,36 +11,6 @@ from h import __version__
 
 jinja_env = Environment(loader=PackageLoader(__package__, 'templates'))
 
-ANGULAR_DIRECTIVE_TEMPLATES = [
-    'annotation',
-    'dropdown_menu_btn',
-    'excerpt',
-    'group_list',
-    'loggedout_message',
-    'login_form',
-    'markdown',
-    'publish_annotation_btn',
-    'search_status_bar',
-    'share_dialog',
-    'sidebar_tutorial',
-    'signin_control',
-    'sort_dropdown',
-    'thread',
-    'top_bar',
-    'viewer',
-]
-
-
-def _angular_template_context(name):
-    """Return the context for rendering a 'text/ng-template' <script>
-       tag for an Angular directive.
-    """
-    angular_template_path = 'client/{}.html'.format(name)
-    content, _, _ = jinja_env.loader.get_source(jinja_env,
-                                                angular_template_path)
-    return {'name': '{}.html'.format(name), 'content': content}
-
-
 def url_with_path(url):
     if urlparse.urlparse(url).path == '':
         return '{}/'.format(url)
@@ -83,8 +53,6 @@ def _app_html_context(assets_env, api_url, service_url, ga_tracking_id,
 
     return {
         'app_config': json.dumps(app_config),
-        'angular_templates': map(_angular_template_context,
-                                 ANGULAR_DIRECTIVE_TEMPLATES),
         'app_css_urls': assets_env.urls('app_css'),
         'app_js_urls': assets_env.urls('app_js'),
         'ga_tracking_id': ga_tracking_id,

--- a/h/static/scripts/app.js
+++ b/h/static/scripts/app.js
@@ -60,25 +60,27 @@ function configureLocation($locationProvider) {
 }
 
 // @ngInject
+var VIEWER_TEMPLATE = require('../../templates/client/viewer.html');
+
 function configureRoutes($routeProvider) {
   $routeProvider.when('/a/:id',
     {
       controller: 'AnnotationViewerController',
-      templateUrl: 'viewer.html',
+      template: VIEWER_TEMPLATE,
       reloadOnSearch: false,
       resolve: resolve
     });
   $routeProvider.when('/viewer',
     {
       controller: 'WidgetController',
-      templateUrl: 'viewer.html',
+      template: VIEWER_TEMPLATE,
       reloadOnSearch: false,
       resolve: resolve
     });
   $routeProvider.when('/stream',
     {
       controller: 'StreamController',
-      templateUrl: 'viewer.html',
+      template: VIEWER_TEMPLATE,
       reloadOnSearch: false,
       resolve: resolve
     });
@@ -110,6 +112,15 @@ function processAppOpts() {
   if (settings.liveReloadServer) {
     require('./live-reload-client').connect(settings.liveReloadServer);
   }
+}
+
+// @ngInject
+function setupTemplateCache($templateCache) {
+  // 'thread.html' is used via ng-include so it needs to be added
+  // to the template cache. Other components just require() templates
+  // directly as strings.
+  $templateCache.put('thread.html',
+    require('../../templates/client/thread.html'));
 }
 
 module.exports = angular.module('h', [
@@ -202,6 +213,7 @@ module.exports = angular.module('h', [
   .config(configureRoutes)
 
   .run(setupCrossFrame)
-  .run(setupHttp);
+  .run(setupHttp)
+  .run(setupTemplateCache);
 
 processAppOpts();

--- a/h/static/scripts/directive/annotation.js
+++ b/h/static/scripts/directive/annotation.js
@@ -784,7 +784,7 @@ function annotation($document) {
       onReplyCountClick: '&',
       replyCount: '<',
     },
-    templateUrl: 'annotation.html'
+    template: require('../../../templates/client/annotation.html'),
   };
 }
 

--- a/h/static/scripts/directive/dropdown-menu-btn.js
+++ b/h/static/scripts/directive/dropdown-menu-btn.js
@@ -26,6 +26,6 @@ module.exports = function () {
       onClick: '&',
       onToggleDropdown: '&',
     },
-    templateUrl: 'dropdown_menu_btn.html'
+    template: require('../../../templates/client/dropdown_menu_btn.html'),
   };
 };

--- a/h/static/scripts/directive/excerpt.js
+++ b/h/static/scripts/directive/excerpt.js
@@ -145,7 +145,7 @@ function excerpt() {
     },
     restrict: 'E',
     transclude: true,
-    templateUrl: 'excerpt.html',
+    template: require('../../../templates/client/excerpt.html'),
   };
 }
 

--- a/h/static/scripts/directive/group-list.js
+++ b/h/static/scripts/directive/group-list.js
@@ -39,7 +39,7 @@ function groupList( $window, groups, settings) {
     scope: {
       auth: '<'
     },
-    templateUrl: 'group_list.html'
+    template: require('../../../templates/client/group_list.html'),
   };
 };
 

--- a/h/static/scripts/directive/loggedout-message.js
+++ b/h/static/scripts/directive/loggedout-message.js
@@ -15,6 +15,6 @@ module.exports = function () {
        */
       onLogin: '&',
     },
-    templateUrl: 'loggedout_message.html',
+    template: require('../../../templates/client/loggedout_message.html'),
   };
 };

--- a/h/static/scripts/directive/login-form.js
+++ b/h/static/scripts/directive/login-form.js
@@ -102,7 +102,7 @@ module.exports = {
       scope: {
         onClose: '&',
       },
-      templateUrl: 'login_form.html',
+      template: require('../../../templates/client/login_form.html'),
     };
   },
   Controller: Controller,

--- a/h/static/scripts/directive/markdown.js
+++ b/h/static/scripts/directive/markdown.js
@@ -262,6 +262,6 @@ module.exports = function($filter, $sanitize, $sce) {
       readOnly: '<',
       required: '@'
     },
-    templateUrl: 'markdown.html'
+    template: require('../../../templates/client/markdown.html'),
   };
 };

--- a/h/static/scripts/directive/publish-annotation-btn.js
+++ b/h/static/scripts/directive/publish-annotation-btn.js
@@ -36,6 +36,6 @@ module.exports = function () {
       onSave: '&',
       onSetPrivacy: '&'
     },
-    templateUrl: 'publish_annotation_btn.html'
+    template: require('../../../templates/client/publish_annotation_btn.html'),
   };
 }

--- a/h/static/scripts/directive/search-status-bar.js
+++ b/h/static/scripts/directive/search-status-bar.js
@@ -12,6 +12,6 @@ module.exports = function () {
       selectionCount: '<',
       totalCount: '<',
     },
-    templateUrl: 'search_status_bar.html',
+    template: require('../../../templates/client/search_status_bar.html'),
   };
 };

--- a/h/static/scripts/directive/share-dialog.coffee
+++ b/h/static/scripts/directive/share-dialog.coffee
@@ -31,5 +31,5 @@ module.exports = ['crossframe', (crossframe) ->
         scope.viaPageLink = 'https://via.hypothes.is/' + frames[0].uri
 
   restrict: 'E'
-  templateUrl: 'share_dialog.html'
+  template: require('../../../templates/client/share_dialog.html')
 ]

--- a/h/static/scripts/directive/sidebar-tutorial.js
+++ b/h/static/scripts/directive/sidebar-tutorial.js
@@ -33,7 +33,7 @@ module.exports = {
       controllerAs: 'vm',
       restrict: 'E',
       scope: {},
-      templateUrl: 'sidebar_tutorial.html'
+      template: require('../../../templates/client/sidebar_tutorial.html'),
     };
   },
   Controller: SidebarTutorialController

--- a/h/static/scripts/directive/signin-control.js
+++ b/h/static/scripts/directive/signin-control.js
@@ -29,6 +29,6 @@ module.exports = function () {
        */
       newStyle: '<',
     },
-    templateUrl: 'signin_control.html',
+    template: require('../../../templates/client/signin_control.html'),
   };
 };

--- a/h/static/scripts/directive/sort-dropdown.js
+++ b/h/static/scripts/directive/sort-dropdown.js
@@ -13,6 +13,6 @@ module.exports = function () {
       /** Called when the user changes the current sort criteria. */
       onChangeSortBy: '&',
     },
-    templateUrl: 'sort_dropdown.html',
+    template: require('../../../templates/client/sort_dropdown.html'),
   }
 }

--- a/h/static/scripts/directive/test/annotation-test.js
+++ b/h/static/scripts/directive/test/annotation-test.js
@@ -322,7 +322,6 @@ describe('annotation', function() {
     });
 
     beforeEach(angular.mock.module('h'));
-    beforeEach(angular.mock.module('h.templates'));
     beforeEach(angular.mock.module(function($provide) {
       sandbox = sinon.sandbox.create();
 

--- a/h/static/scripts/directive/test/annotation-test.js
+++ b/h/static/scripts/directive/test/annotation-test.js
@@ -984,7 +984,6 @@ describe('annotation', function() {
         createDirective(annotation);
         $scope.$digest();
         $scope.$destroy();
-        $timeout.flush();
         $timeout.verifyNoPendingTasks();
       });
     });

--- a/h/static/scripts/directive/test/excerpt-test.js
+++ b/h/static/scripts/directive/test/excerpt-test.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var angular = require('angular');
+
 var assign = require('core-js/modules/$.object-assign');
 var util = require('./util');
 var excerpt = require('../excerpt');
@@ -32,7 +34,6 @@ describe('excerpt directive', function () {
 
   beforeEach(function () {
     angular.mock.module('app');
-    angular.mock.module('h.templates');
   });
 
   describe('enabled state', function () {

--- a/h/static/scripts/directive/test/group-list-test.js
+++ b/h/static/scripts/directive/test/group-list-test.js
@@ -1,17 +1,9 @@
 'use strict';
 
-var events = require('../../events');
+var angular = require('angular');
+
 var groupList = require('../group-list');
 var util = require('./util');
-
-// returns true if a jQuery-like element has
-// been hidden directly via an ng-show directive.
-//
-// This does not check whether the element is a descendant
-// of a hidden element
-function isElementHidden(element) {
-  return element.hasClass('ng-hide');
-}
 
 describe('groupList', function () {
   var $rootScope;
@@ -38,7 +30,6 @@ describe('groupList', function () {
 
   beforeEach(function () {
     angular.mock.module('app');
-    angular.mock.module('h.templates');
   });
 
   beforeEach(angular.mock.inject(function (_$rootScope_, _$window_) {

--- a/h/static/scripts/directive/test/markdown-test.js
+++ b/h/static/scripts/directive/test/markdown-test.js
@@ -60,7 +60,6 @@ describe('markdown', function () {
 
   beforeEach(function () {
     angular.mock.module('app');
-    angular.mock.module('h.templates');
   });
 
   describe('read only state', function () {

--- a/h/static/scripts/directive/test/publish-annotation-btn-test.js
+++ b/h/static/scripts/directive/test/publish-annotation-btn-test.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var angular = require('angular');
+
 var util = require('./util');
 
 var fakeStorage = {};
@@ -26,7 +28,6 @@ describe('publishAnnotationBtn', function () {
 
   beforeEach(function () {
     angular.mock.module('app');
-    angular.mock.module('h.templates');
 
     // create a new instance of the directive with default
     // attributes
@@ -38,7 +39,7 @@ describe('publishAnnotationBtn', function () {
      canPost: true,
      isShared: false,
      onSave: function () {},
-     onSetPrivacy: function (level) {},
+     onSetPrivacy: function () {},
      onCancel: function () {}
    });
   });

--- a/h/static/scripts/directive/test/search-status-bar-test.js
+++ b/h/static/scripts/directive/test/search-status-bar-test.js
@@ -12,7 +12,6 @@ describe('searchStatusBar', function () {
 
   beforeEach(function () {
     angular.mock.module('app');
-    angular.mock.module('h.templates');
   });
 
   context('when there is a filter', function () {

--- a/h/static/scripts/directive/test/share-dialog-test.coffee
+++ b/h/static/scripts/directive/test/share-dialog-test.coffee
@@ -10,7 +10,6 @@ describe 'share-dialog', ->
     .directive('shareDialog', require('../share-dialog'))
 
   beforeEach module('h')
-  beforeEach module('h.templates')
 
   beforeEach module ($provide) ->
     fakeCrossFrame = {frames: []}

--- a/h/static/scripts/directive/test/sort-dropdown-test.js
+++ b/h/static/scripts/directive/test/sort-dropdown-test.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var angular = require('angular');
+
 var util = require('./util');
 
 describe('sortDropdown', function () {
@@ -10,7 +12,6 @@ describe('sortDropdown', function () {
 
   beforeEach(function () {
     angular.mock.module('app');
-    angular.mock.module('h.templates');
   });
 
   it('should update the sort mode on click', function () {

--- a/h/static/scripts/directive/top-bar.js
+++ b/h/static/scripts/directive/top-bar.js
@@ -15,6 +15,6 @@ module.exports = function () {
       sortOptions: '<',
       onChangeSortBy: '&',
     },
-    templateUrl: 'top_bar.html',
+    template: require('../../../templates/client/top_bar.html'),
   };
 };

--- a/h/static/scripts/karma.config.js
+++ b/h/static/scripts/karma.config.js
@@ -1,5 +1,8 @@
+'use strict';
+
 // Karma configuration
 var path = require('path');
+var stringify = require('stringify');
 
 module.exports = function(config) {
   config.set({
@@ -63,6 +66,11 @@ module.exports = function(config) {
       configure: function (bundle) {
         bundle
           .transform('coffeeify')
+          .transform(stringify, {
+            appliesTo: {
+              includeExtensions: ['.html'],
+            },
+          })
           .plugin('proxyquire-universal')
           // fix for Proxyquire in PhantomJS 1.x.
           // See https://github.com/bitwit/proxyquireify-phantom-menace

--- a/h/static/scripts/karma.config.js
+++ b/h/static/scripts/karma.config.js
@@ -43,12 +43,6 @@ module.exports = function(config) {
     exclude: [
     ],
 
-    // strip templates of leading path
-    ngHtml2JsPreprocessor: {
-      moduleName: 'h.templates',
-      cacheIdFromPath: path.basename
-    },
-
     // preprocess matching files before serving them to the browser
     // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
     preprocessors: {
@@ -56,7 +50,6 @@ module.exports = function(config) {
       './test/bootstrap.js': ['browserify'],
       '**/*-test.js': ['browserify'],
       '**/*-test.coffee': ['browserify'],
-      '../../templates/client/*.html': ['ng-html2js'],
     },
 
     browserify: {

--- a/h/static/scripts/karma.config.js
+++ b/h/static/scripts/karma.config.js
@@ -2,7 +2,6 @@
 
 // Karma configuration
 var path = require('path');
-var stringify = require('stringify');
 
 module.exports = function(config) {
   config.set({
@@ -59,11 +58,6 @@ module.exports = function(config) {
       configure: function (bundle) {
         bundle
           .transform('coffeeify')
-          .transform(stringify, {
-            appliesTo: {
-              includeExtensions: ['.html'],
-            },
-          })
           .plugin('proxyquire-universal')
           // fix for Proxyquire in PhantomJS 1.x.
           // See https://github.com/bitwit/proxyquireify-phantom-menace

--- a/h/static/scripts/test/login-form-test.coffee
+++ b/h/static/scripts/test/login-form-test.coffee
@@ -30,7 +30,6 @@ describe 'loginForm.Controller', ->
     .controller('loginFormController', require('../directive/login-form').Controller)
 
   beforeEach module('h')
-  beforeEach module('h.templates')
 
   beforeEach module ($provide) ->
     $provide.value '$timeout', sandbox.spy()

--- a/h/templates/app.html.jinja2
+++ b/h/templates/app.html.jinja2
@@ -52,13 +52,6 @@
       <main ng-view=""></main>
     </div>
 
-    <!-- Templates for Angular components !-->
-    {% for template in angular_templates -%}
-      <script type="text/ng-template" id="{{template.name}}">
-        {{ template.content | safe }}
-      </script>
-    {% endfor -%}
-
     <!-- App Configuration !-->
     <script class="js-hypothesis-settings" type="application/json">
       {{ app_config | safe }}

--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
     "karma-browserify": "^3.0.3",
     "karma-chai": "^0.1.0",
     "karma-mocha": "^0.1.4",
-    "karma-ng-html2js-preprocessor": "^0.1.0",
     "karma-phantomjs-launcher": "^0.1.4",
     "karma-sinon": "^1.0.4",
     "mocha": "^1.20.1",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "retry": "^0.8.0",
     "scroll-into-view": "^1.3.1",
     "showdown": "^1.2.1",
+    "stringify": "^5.1.0",
     "through2": "^2.0.1",
     "tiny-emitter": "^1.0.1",
     "uglifyify": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,10 @@
   "browserify": {
     "transform": [
       "browserify-ngannotate",
-      "browserify-shim"
+      "browserify-shim",
+      ["stringify", {
+        "appliesTo": {"includeExtensions": [".html"]}
+      }]
     ]
   },
   "browser": {

--- a/scripts/gulp/create-bundle.js
+++ b/scripts/gulp/create-bundle.js
@@ -11,7 +11,6 @@ var coffeeify = require('coffeeify');
 var exorcist = require('exorcist');
 var gulpUtil = require('gulp-util');
 var mkdirp = require('mkdirp');
-var stringify = require('stringify');
 var uglifyify = require('uglifyify');
 var watchify = require('watchify');
 
@@ -117,12 +116,6 @@ module.exports = function createBundle(config, buildOpts) {
   var sourcemapPath = bundlePath + '.map';
 
   var bundle = browserify([], bundleOpts);
-
-  bundle.transform(stringify, {
-    appliesTo: {
-      includeExtensions: ['.html'],
-    },
-  });
 
   (config.require || []).forEach(function (req) {
     // When another bundle uses 'bundle.external(<module path>)',

--- a/scripts/gulp/create-bundle.js
+++ b/scripts/gulp/create-bundle.js
@@ -11,6 +11,7 @@ var coffeeify = require('coffeeify');
 var exorcist = require('exorcist');
 var gulpUtil = require('gulp-util');
 var mkdirp = require('mkdirp');
+var stringify = require('stringify');
 var uglifyify = require('uglifyify');
 var watchify = require('watchify');
 
@@ -116,6 +117,12 @@ module.exports = function createBundle(config, buildOpts) {
   var sourcemapPath = bundlePath + '.map';
 
   var bundle = browserify([], bundleOpts);
+
+  bundle.transform(stringify, {
+    appliesTo: {
+      includeExtensions: ['.html'],
+    },
+  });
 
   (config.require || []).forEach(function (req) {
     // When another bundle uses 'bundle.external(<module path>)',


### PR DESCRIPTION
This PR changes the way UI components fetch their HTML templates to use the same `require()` mechanism that is used for importing JS imports, instead of relying on the template being added to `app.html` as a `<script>` tag with the HTML as the content. Using `require()` for .html files is done via the `stringify` Browserify transform which converts HTML into JS strings.

There are a number of general reasons for doing this, plus it also helps specifically with fixing some issues with collapsible excerpts [1]:

* It makes components more self-contained, as each pulls in its own templates
* ~~It moves my drinks cabinet a few inches closer to Berlin~~ It simplifies the app.html build a little
* It makes behavior of all components the same, because they will all resolve their templates synchronously, whereas there were some components previously using `template` (which is sync) and others using `templateUrl` (which is async).
* It is faster, because it avoids going through a bunch of machinery internally in Angular that is used for fetching templates from the network (internally `templateUrl` fetches work exactly the same as an `$http` request, except that it uses a local cache which gets pre-populated from the `<script>` tags on the page).

[1] Specifically, it makes template fetching synchronous, which means that the `<excerpt>` post-link function is called, it can rely on its content having been fully processed and thus it can measure the height of that content. Subsequently the height can change, but in response to specific known events (eg. images loading, the sidebar being resized) which we can watch for separately.
