### PR TITLE
Add tests for authentication policy

### DIFF
--- a/h/auth/policy.py
+++ b/h/auth/policy.py
@@ -5,7 +5,7 @@ from pyramid import interfaces
 from zope import interface
 
 from h.auth import tokens
-from h.auth.util import effective_principals
+from h.auth import util
 
 
 @interface.implementer(interfaces.IAuthenticationPolicy)
@@ -28,7 +28,7 @@ class AuthenticationPolicy(object):
         return self.session_policy.unauthenticated_userid(request)
 
     def effective_principals(self, request):
-        return effective_principals(request.authenticated_userid, request)
+        return util.effective_principals(request.authenticated_userid, request)
 
     def remember(self, request, userid, **kw):
         if _is_api_request(request):

--- a/h/auth/policy.py
+++ b/h/auth/policy.py
@@ -5,7 +5,6 @@ from pyramid import interfaces
 from zope import interface
 
 from h.auth import tokens
-from h.auth.util import bearer_token
 from h.auth.util import effective_principals
 
 
@@ -17,16 +16,15 @@ class AuthenticationPolicy(object):
 
     def authenticated_userid(self, request):
         if _is_api_request(request):
-            token = bearer_token(request)
-            return (tokens.userid_from_api_token(token) or
-                    tokens.userid_from_jwt(token, request))
+            return tokens.authenticated_userid(request)
         return self.session_policy.authenticated_userid(request)
 
     def unauthenticated_userid(self, request):
         if _is_api_request(request):
-            # We can't always get an unauthenticated userid for an API request,
-            # as some of the authentication tokens used may be opaque.
-            return self.authenticated_userid(request)
+            # We can't really get an "unauthenticated" userid for an API
+            # request. We have to actually go and decode/look up the tokens and
+            # get what is effectively an authenticated userid.
+            return tokens.authenticated_userid(request)
         return self.session_policy.unauthenticated_userid(request)
 
     def effective_principals(self, request):

--- a/h/auth/test/policy_test.py
+++ b/h/auth/test/policy_test.py
@@ -1,0 +1,102 @@
+# -*- coding: utf-8 -*-
+
+import mock
+from pyramid.authentication import SessionAuthenticationPolicy
+from pyramid.testing import DummyRequest
+import pytest
+
+from h.auth.policy import AuthenticationPolicy
+
+SESSION_AUTH_PATHS = (
+    '/login',
+    '/account/profile',
+    '/api/badge',
+    '/api/token',
+)
+
+TOKEN_AUTH_PATHS = (
+    '/api',
+    '/api/foo',
+    '/api/annotations/abc123',
+)
+
+
+class TestAuthenticationPolicy(object):
+
+    @pytest.fixture(autouse=True)
+    def policy(self):
+        self.upstream_policy = mock.Mock(spec_set=SessionAuthenticationPolicy())
+        self.policy = AuthenticationPolicy()
+        self.policy.session_policy = self.upstream_policy
+
+    # session_request and token_request are parametrized fixtures, which will
+    # take on each value in the passed `params` sequence in turn. This is a
+    # quick and easy way to generate a named fixture which takes multiple
+    # values and can be used by multiple tests.
+    @pytest.fixture(params=SESSION_AUTH_PATHS)
+    def session_request(self, request):
+        return DummyRequest(path=request.param)
+
+    @pytest.fixture(params=TOKEN_AUTH_PATHS)
+    def token_request(self, request):
+        return DummyRequest(path=request.param)
+
+    def test_authenticated_userid_delegates_for_session_auth_paths(self, session_request):
+        result = self.policy.authenticated_userid(session_request)
+
+        self.upstream_policy.authenticated_userid.assert_called_once_with(session_request)
+        assert result == self.upstream_policy.authenticated_userid.return_value
+
+    @mock.patch('h.auth.policy.tokens')
+    def test_authenticated_userid_uses_tokens_for_token_auth_paths(self, tokens, token_request):
+        result = self.policy.authenticated_userid(token_request)
+
+        tokens.authenticated_userid.assert_called_once_with(token_request)
+        assert result == tokens.authenticated_userid.return_value
+
+    def test_unauthenticated_userid_delegates_for_session_auth_paths(self, session_request):
+        result = self.policy.unauthenticated_userid(session_request)
+
+        self.upstream_policy.unauthenticated_userid.assert_called_once_with(session_request)
+        assert result == self.upstream_policy.unauthenticated_userid.return_value
+
+    @mock.patch('h.auth.policy.tokens')
+    def test_unauthenticated_userid_uses_tokens_for_token_auth_paths(self, tokens, token_request):
+        result = self.policy.unauthenticated_userid(token_request)
+
+        tokens.authenticated_userid.assert_called_once_with(token_request)
+        assert result == tokens.authenticated_userid.return_value
+
+    @mock.patch('h.auth.policy.util')
+    def test_effective_principals_calls_effective_principals_with_authenticated_userid(self, util, authn_policy):
+        authn_policy.authenticated_userid.return_value = 'acct:rami@example.com'
+        request = DummyRequest()
+
+        result = self.policy.effective_principals(request)
+
+        util.effective_principals.assert_called_once_with('acct:rami@example.com', request)
+        assert result == util.effective_principals.return_value
+
+    def test_remember_delegates_for_session_auth_paths(self, session_request):
+        result = self.policy.remember(session_request, 'foo', bar='baz')
+
+        self.upstream_policy.remember.assert_called_once_with(session_request, 'foo', bar='baz')
+        assert result == self.upstream_policy.remember.return_value
+
+    def test_remember_does_nothing_for_token_auth_paths(self, token_request):
+        result = self.policy.remember(token_request, 'foo', bar='baz')
+
+        self.upstream_policy.remember.assert_not_called()
+        assert result == []
+
+    def test_forget_delegates_for_session_auth_paths(self, session_request):
+        result = self.policy.forget(session_request)
+
+        self.upstream_policy.forget.assert_called_once_with(session_request)
+        assert result == self.upstream_policy.forget.return_value
+
+    def test_forget_does_nothing_for_token_auth_paths(self, token_request):
+        result = self.policy.forget(token_request)
+
+        self.upstream_policy.forget.assert_not_called()
+        assert result == []

--- a/h/auth/test/util_test.py
+++ b/h/auth/test/util_test.py
@@ -134,28 +134,6 @@ def test_group_principals_with_three_groups():
     ]
 
 
-def test_bearer_token_returns_token():
-    request = testing.DummyRequest(headers={
-        'Authorization': 'Bearer f00ba12'
-    })
-
-    assert util.bearer_token(request) == 'f00ba12'
-
-
-def test_bearer_token_when_no_Authorization_header():
-    request = testing.DummyRequest(headers={})
-
-    assert util.bearer_token(request) == ''
-
-
-def test_bearer_token_when_Authorization_header_does_not_contain_bearer():
-    request = testing.DummyRequest(headers={
-        'Authorization': 'f00ba12'  # No "Bearer " prefix.
-    })
-
-    assert util.bearer_token(request) == ''
-
-
 @pytest.mark.parametrize("p_in,p_out", [
     # The basics
     ([], []),

--- a/h/auth/util.py
+++ b/h/auth/util.py
@@ -3,7 +3,6 @@
 from pyramid import security
 
 from h import accounts
-from h._compat import text_type
 from h.auth import role
 
 
@@ -53,23 +52,6 @@ def group_principals(user):
 
     """
     return ['group:{group.pubid}'.format(group=group) for group in user.groups]
-
-
-def bearer_token(request):
-    """
-    Return the bearer token from the request's Authorization header.
-
-    The "Bearer " prefix will be stripped from the token.
-
-    If the request has no Authorization header or the Authorization header
-    doesn't contain a bearer token, returns ''.
-
-    :rtype: unicode
-    """
-    if request.headers.get('Authorization', '').startswith('Bearer '):
-        return text_type(request.headers['Authorization'][len('Bearer '):])
-    else:
-        return u''
 
 
 def translate_annotation_principals(principals):


### PR DESCRIPTION
I noticed that we didn't have tests for this rather important part of the application, and I had a spare moment, so I wrote some.

In order to make `AuthenticationPolicy` easier to test, I also made a small refactoring that unifies logic previously split between the authentication policy and `h.auth.util.bearer_token` into a single function: `h.auth.tokens.authenticated_userid`.