### PR TITLE
Fix 'Location' sort order for annotations

### DIFF
--- a/h/static/scripts/app-controller.js
+++ b/h/static/scripts/app-controller.js
@@ -89,7 +89,9 @@ module.exports = function AppController(
         predicateFn = ['-!!message', 'message.updated'];
         break;
       case 'Location':
-        predicateFn = annotationMetadata.location;
+        predicateFn = function (thread) {
+          return annotationMetadata.location(thread.message);
+        };
         break;
     }
     $scope.sort = {

--- a/h/static/scripts/polyfills.js
+++ b/h/static/scripts/polyfills.js
@@ -3,6 +3,7 @@
 // ES2015 polyfills
 require('core-js/es6/promise');
 require('core-js/fn/array/find');
+require('core-js/fn/array/find-index');
 require('core-js/fn/object/assign');
 
 // URL constructor, required by IE 10/11,


### PR DESCRIPTION
1398661 extracted the code for getting a location from an annotation
into a separate module. However that function expects an Annotation but
the sort predicate function was being passed a Thread.

Consequently the predicate function was returning
Number.POSITIVE_INFINITY for every thread and so sort ordering fell back
to the default 'tie-breaker' comparator - which is the original index of
the element in the list being sorted.

Fixes #3106