### PR TITLE
A simple JSON-LD renderer for individual annotations

### DIFF
--- a/h/api/__init__.py
+++ b/h/api/__init__.py
@@ -10,7 +10,7 @@ def includeme(config):
     config.add_route('api.index', '/')
     config.add_route('api.annotations', '/annotations')
     config.add_route('api.annotation',
-                     '/annotations/{id}',
+                     '/annotations/{id:[A-Za-z0-9_-]{20,22}}',
                      factory='h.api.resources:AnnotationFactory',
                      traverse='/{id}')
     config.add_route('api.search', '/search')

--- a/h/api/__init__.py
+++ b/h/api/__init__.py
@@ -13,4 +13,8 @@ def includeme(config):
                      '/annotations/{id:[A-Za-z0-9_-]{20,22}}',
                      factory='h.api.resources:AnnotationFactory',
                      traverse='/{id}')
+    config.add_route('api.annotation.jsonld',
+                     '/annotations/{id:[A-Za-z0-9_-]{20,22}}.jsonld',
+                     factory='h.api.resources:AnnotationFactory',
+                     traverse='/{id}')
     config.add_route('api.search', '/search')

--- a/h/api/presenters.py
+++ b/h/api/presenters.py
@@ -15,6 +15,16 @@ class AnnotationBasePresenter(object):
         self.request = request
 
     @property
+    def created(self):
+        if self.annotation.created:
+            return utc_iso8601(self.annotation.created)
+
+    @property
+    def updated(self):
+        if self.annotation.updated:
+            return utc_iso8601(self.annotation.updated)
+
+    @property
     def links(self):
         """A dictionary of named hypermedia links for this annotation."""
         # Named link generators are registered elsewhere in the code. See
@@ -27,6 +37,28 @@ class AnnotationBasePresenter(object):
             if link is not None:
                 out[name] = link
         return out
+
+    @property
+    def text(self):
+        if self.annotation.text:
+            return self.annotation.text
+        else:
+            return ''
+
+    @property
+    def tags(self):
+        if self.annotation.tags:
+            return self.annotation.tags
+        else:
+            return []
+
+    @property
+    def target(self):
+        target = {'source': self.annotation.target_uri}
+        if self.annotation.target_selectors:
+            target['selector'] = self.annotation.target_selectors
+
+        return [target]
 
 
 class AnnotationJSONPresenter(AnnotationBasePresenter):
@@ -57,30 +89,6 @@ class AnnotationJSONPresenter(AnnotationBasePresenter):
         return annotation
 
     @property
-    def created(self):
-        if self.annotation.created:
-            return utc_iso8601(self.annotation.created)
-
-    @property
-    def updated(self):
-        if self.annotation.updated:
-            return utc_iso8601(self.annotation.updated)
-
-    @property
-    def text(self):
-        if self.annotation.text:
-            return self.annotation.text
-        else:
-            return ''
-
-    @property
-    def tags(self):
-        if self.annotation.tags:
-            return self.annotation.tags
-        else:
-            return []
-
-    @property
     def permissions(self):
         read = self.annotation.userid
         if self.annotation.shared:
@@ -90,14 +98,6 @@ class AnnotationJSONPresenter(AnnotationBasePresenter):
                 'admin': [self.annotation.userid],
                 'update': [self.annotation.userid],
                 'delete': [self.annotation.userid]}
-
-    @property
-    def target(self):
-        target = {'source': self.annotation.target_uri}
-        if self.annotation.target_selectors:
-            target['selector'] = self.annotation.target_selectors
-
-        return [target]
 
 
 class DocumentJSONPresenter(object):

--- a/h/api/presenters.py
+++ b/h/api/presenters.py
@@ -100,6 +100,49 @@ class AnnotationJSONPresenter(AnnotationBasePresenter):
                 'delete': [self.annotation.userid]}
 
 
+class AnnotationJSONLDPresenter(AnnotationBasePresenter):
+
+    """
+    Presenter for annotations that renders a JSON-LD format compatible with the
+    draft Web Annotation Data Model, as defined at:
+
+      https://www.w3.org/TR/annotation-model/
+    """
+
+    CONTEXT_URL = 'http://www.w3.org/ns/anno.jsonld'
+
+    def asdict(self):
+        return {
+            '@context': self.CONTEXT_URL,
+            'type': 'Annotation',
+            'id': self.id,
+            'created': self.created,
+            'modified': self.updated,
+            'creator': self.annotation.userid,
+            'body': self.bodies,
+            'target': self.target,
+        }
+
+    @property
+    def id(self):
+        return self.request.route_url('annotation', id=self.annotation.id)
+
+    @property
+    def bodies(self):
+        bodies = [{
+            'type': 'TextualBody',
+            'text': self.text,
+            'format': 'text/markdown',
+        }]
+        for t in self.tags:
+            bodies.append({
+                'type': 'TextualBody',
+                'text': t,
+                'purpose': 'tagging',
+            })
+        return bodies
+
+
 class DocumentJSONPresenter(object):
     def __init__(self, document):
         self.document = document

--- a/h/api/test/views_test.py
+++ b/h/api/test/views_test.py
@@ -195,6 +195,33 @@ def test_read_returns_presented_annotation(AnnotationJSONPresenter):
     assert result == presenter.asdict()
 
 
+def test_read_jsonld_sets_correct_content_type(AnnotationJSONLDPresenter):
+    AnnotationJSONLDPresenter.CONTEXT_URL = 'http://foo.com/context.jsonld'
+
+    annotation = mock.Mock()
+    request = testing.DummyRequest()
+
+    views.read_jsonld(annotation, request)
+
+    assert request.response.content_type == 'application/ld+json'
+    assert request.response.content_type_params == {
+        'profile': 'http://foo.com/context.jsonld'
+    }
+
+
+def test_read_jsonld_returns_presented_annotation(AnnotationJSONLDPresenter):
+    annotation = mock.Mock()
+    presenter = mock.Mock()
+    AnnotationJSONLDPresenter.return_value = presenter
+    AnnotationJSONLDPresenter.CONTEXT_URL = 'http://foo.com/context.jsonld'
+    request = testing.DummyRequest()
+
+    result = views.read_jsonld(annotation, request)
+
+    AnnotationJSONLDPresenter.assert_called_once_with(request, annotation)
+    assert result == presenter.asdict()
+
+
 update_fixtures = pytest.mark.usefixtures('AnnotationEvent',
                                           'AnnotationJSONPresenter',
                                           'schemas',
@@ -321,6 +348,14 @@ def copy(request):
     patcher = mock.patch('h.api.views.copy', autospec=True)
     request.addfinalizer(patcher.stop)
     return patcher.start()
+
+
+@pytest.fixture
+def AnnotationJSONLDPresenter(request):
+    patcher = mock.patch('h.api.views.AnnotationJSONLDPresenter', autospec=True)
+    cls = patcher.start()
+    request.addfinalizer(patcher.stop)
+    return cls
 
 
 @pytest.fixture

--- a/h/api/views.py
+++ b/h/api/views.py
@@ -25,6 +25,7 @@ from pyramid.view import view_config
 from h.api import cors
 from h.api.events import AnnotationEvent
 from h.api.presenters import AnnotationJSONPresenter
+from h.api.presenters import AnnotationJSONLDPresenter
 from h.api import search as search_lib
 from h.api import schemas
 from h.api import storage
@@ -171,6 +172,16 @@ def create(request):
 def read(annotation, request):
     """Return the annotation (simply how it was stored in the database)."""
     presenter = AnnotationJSONPresenter(request, annotation)
+    return presenter.asdict()
+
+
+@api_config(route_name='api.annotation.jsonld',
+            request_method='GET',
+            permission='read')
+def read_jsonld(annotation, request):
+    request.response.content_type = 'application/ld+json'
+    request.response.content_type_params = {'profile': AnnotationJSONLDPresenter.CONTEXT_URL}
+    presenter = AnnotationJSONLDPresenter(request, annotation)
     return presenter.asdict()
 
 


### PR DESCRIPTION
This is a simplistic but functional first pass at providing a W3C Web Annotation compatible view onto our annotation data.

It adds a second route,

    /api/annotations/<id>.jsonld

which renders the relevant annotation in a JSON-LD format which should hopefully be compatible with the format defined in https://www.w3.org/TR/annotation-model/.

Huge thanks go to @chdorner who did a lot of the work that made this an easy change.