### PR TITLE
Fix Dash compatibility issue in release script

### DIFF
--- a/scripts/release
+++ b/scripts/release
@@ -101,7 +101,7 @@ make_sdist () {
 push_release () {
     local version=$1
     # Extract everything from the fourth line to the next tag from CHANGES
-    local description=$(awk 'NR==4{p=1} /^[0-9]+\.[0-9]+\.[0-9]+/{p=0} {if(p) print $0}' CHANGES)
+    local description="$(awk 'NR==4{p=1} /^[0-9]+\.[0-9]+\.[0-9]+/{p=0} {if(p) print $0}' CHANGES)"
     status "Pushing tag"
     git push --follow-tags
 


### PR DESCRIPTION
In Dash, `local var=$(expr)` fails if the output of `$(expr)` contains
whitespace. The following outputs 'one two' in bash but 'one' in Dash:

    #!/bin/sh

    func () {
        local x=$(echo one two)
        echo $x
    }

    func

Quoting the subshell capture expression fixes the problem.
I didn't modify the `local version=` line because the version should never contain whitespace.