### PR TITLE
Ignore known and expected errors during sidebar injection

### DIFF
--- a/h/browser/chrome/lib/errors.js
+++ b/h/browser/chrome/lib/errors.js
@@ -45,6 +45,29 @@ function isKnownError(err) {
   return err instanceof ExtensionError;
 }
 
+var IGNORED_ERRORS = [
+  /The tab was closed/,
+  /Cannot access contents of.*/,
+];
+
+/**
+ * Returns true if a given `err` is anticipated during sidebar injection, such
+ * as the tab being closed by the user, and should not be reported to Sentry.
+ *
+ * @param {{message: string}} err - The Error-like object
+ */
+function shouldIgnoreInjectionError(err) {
+  if (IGNORED_ERRORS.some(function (pattern) {
+    return err.message.match(pattern);
+  })) {
+    return true;
+  }
+  if (isKnownError(err)) {
+    return true;
+  }
+  return false;
+}
+
 /**
  * Report an error.
  *
@@ -71,4 +94,5 @@ module.exports = {
   RestrictedProtocolError: RestrictedProtocolError,
   BlockedSiteError: BlockedSiteError,
   report: report,
+  shouldIgnoreInjectionError: shouldIgnoreInjectionError,
 };

--- a/h/browser/chrome/lib/hypothesis-chrome-extension.js
+++ b/h/browser/chrome/lib/hypothesis-chrome-extension.js
@@ -246,9 +246,11 @@ function HypothesisChromeExtension(dependencies) {
             });
             return;
           }
-          errors.report(err, 'Injecting Hypothesis sidebar', {
-            url: tab.url,
-          });
+          if (!errors.shouldIgnoreInjectionError(err)) {
+            errors.report(err, 'Injecting Hypothesis sidebar', {
+              url: tab.url,
+            });
+          }
           state.errorTab(tab.id, err);
         });
     }

--- a/h/browser/chrome/test/errors-test.js
+++ b/h/browser/chrome/test/errors-test.js
@@ -20,7 +20,39 @@ describe('errors', function () {
     console.error.restore();
   });
 
-  describe('.report', function () {
+  describe('#shouldIgnoreInjectionError', function () {
+    var ignoredErrors = [
+      'The tab was closed',
+      'Cannot access contents of url "file:///C:/t/cpp.pdf". ' +
+      'Extension manifest must request permission to access this host.',
+      'Cannot access contents of page',
+    ];
+
+    var unexpectedErrors = [
+      'SyntaxError: A typo',
+    ];
+
+    it('should be true for "expected" errors', function () {
+      ignoredErrors.forEach(function (message) {
+        var error = {message: message};
+        assert.isTrue(errors.shouldIgnoreInjectionError(error));
+      });
+    });
+
+    it('should be false for unexpected errors', function () {
+      unexpectedErrors.forEach(function (message) {
+        var error = {message: message};
+        assert.isFalse(errors.shouldIgnoreInjectionError(error));
+      });
+    });
+
+    it('should be true for the extension\'s custom error classes', function () {
+      var error = new errors.LocalFileError('some message');
+      assert.isTrue(errors.shouldIgnoreInjectionError(error));
+    });
+  });
+
+  describe('#report', function () {
     it('reports unknown errors via Raven', function () {
       var error = new Error('A most unexpected error');
       errors.report(error, 'injecting the sidebar');

--- a/h/browser/chrome/test/hypothesis-chrome-extension-test.js
+++ b/h/browser/chrome/test/hypothesis-chrome-extension-test.js
@@ -98,6 +98,7 @@ describe('HypothesisChromeExtension', function () {
       removeFromTab: sandbox.stub().returns(Promise.resolve()),
     };
     fakeErrors = {
+      shouldIgnoreInjectionError: function () { return false; },
       report: sandbox.spy(),
     };
 
@@ -392,7 +393,22 @@ describe('HypothesisChromeExtension', function () {
             sinon.match.instanceOf(ErrorType));
         });
 
-        it('logs an error', function () {
+        it('does not log known errors', function () {
+          var error = new Error('Some error');
+          fakeErrors.shouldIgnoreInjectionError = function () {
+            return true;
+          };
+          var injectError = Promise.reject(error);
+          fakeSidebarInjector.injectIntoTab.returns(injectError);
+
+          triggerInstall();
+
+          return toResult(injectError).then(function () {
+            assert.notCalled(fakeErrors.report);
+          });
+        });
+
+        it('logs unexpected errors', function () {
           var error = new ErrorType('msg');
           var injectError = Promise.reject(error);
           fakeSidebarInjector.injectIntoTab.returns(injectError);


### PR DESCRIPTION
In addition to the known issues that can prevent sidebar injection which
are represented by custom Error classes in the extension, there are also
a set of expected errors which can happen, such as the tab being closed
whilst the sidebar is being injected.

Avoid logging these and reporting them to Sentry.