### PR TITLE
Replace node page router

### DIFF
--- a/h/static/scripts/admin-site.js
+++ b/h/static/scripts/admin-site.js
@@ -9,14 +9,10 @@ if (settings.raven) {
 window.$ = window.jQuery = require('jquery');
 require('bootstrap');
 
-var page = require('page');
+var page = require('./page');
 
 var AdminUsersController = require('./admin-users');
 
 page('/admin/users', function() {
   new AdminUsersController(document.body, window);
-});
-
-document.addEventListener('DOMContentLoaded', function () {
-  page.start();
 });

--- a/h/static/scripts/page.js
+++ b/h/static/scripts/page.js
@@ -1,0 +1,9 @@
+'use strict';
+
+function page(path, callback) {
+  if (window.location.pathname === path) {
+    document.addEventListener('DOMContentLoaded', callback, false);
+  }
+}
+
+module.exports = page;

--- a/h/static/scripts/site.js
+++ b/h/static/scripts/site.js
@@ -6,7 +6,7 @@ if (settings.raven) {
   require('./raven').init(settings.raven);
 }
 
-var page = require('page');
+var page = require('./page');
 
 var CreateGroupFormController = require('./create-group-form');
 var DropdownMenuController = require('./dropdown-menu');
@@ -37,8 +37,4 @@ page('/register', function() {
 
 page('/forgot_password', function() {
   new FormSelectOnFocusController(document.body);
-});
-
-document.addEventListener('DOMContentLoaded', function () {
-  page.start({click: false});
 });

--- a/h/static/scripts/test/page-test.js
+++ b/h/static/scripts/test/page-test.js
@@ -1,0 +1,34 @@
+'use strict';
+
+var page = require('../page');
+
+// helper to dispatch a native event to an element
+function sendEvent(element, eventType) {
+  // createEvent() used instead of Event constructor
+  // for PhantomJS compatibility
+  var event = document.createEvent('Event');
+  event.initEvent(eventType, true /* bubbles */, true /* cancelable */);
+  element.dispatchEvent(event);
+
+  return event;
+}
+
+describe('page', function () {
+  it('it adds the callback when the url path matches', function () {
+    var spy = sinon.spy();
+
+    page(document.location.pathname, spy);
+    sendEvent(document, 'DOMContentLoaded');
+
+    assert.calledOnce(spy);
+  });
+
+  it('it skips adding the callback when the url path does not match', function () {
+    var spy = sinon.spy();
+
+    page(document.location.pathname + '-foo', spy);
+    sendEvent(document, 'DOMContentLoaded');
+
+    assert.notCalled(spy);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "mkdirp": "^0.5.1",
     "ng-tags-input": "2.2.0",
     "node-uuid": "^1.4.3",
-    "page": "^1.6.4",
     "postcss": "^5.0.6",
     "query-string": "^3.0.1",
     "raf": "^3.1.0",


### PR DESCRIPTION
We've been running into a few bugs on our end because of unwanted features coming from the [page client side router](https://www.npmjs.com/package/page). Since we only use a tiny subset of its features, we should run our own implementation that fits our needs.

We don't need all the client-side routing part, we only need to be able
to selectively run certain JavaScript code depending on which site the
user is at the moment.
This implementation is not as advanced as the one from the `page`
package, or what is possible with the `url-pattern` package. But we
don't need any fancy URL matching at the moment, once we do we can
revisit and maybe introduce something like `url-pattern` instead of just
a crude `document.location.pathname === path`.