### PR TITLE
Re-implement collapsible excerpt overflow state checking

### DIFF
--- a/h/static/scripts/app.js
+++ b/h/static/scripts/app.js
@@ -204,6 +204,7 @@ module.exports = angular.module('h', [
   .value('AnnotationSync', require('./annotation-sync'))
   .value('AnnotationUISync', require('./annotation-ui-sync'))
   .value('Discovery', require('./discovery'))
+  .value('ExcerptOverflowMonitor', require('./directive/excerpt-overflow-monitor'))
   .value('raven', require('./raven'))
   .value('settings', settings)
   .value('time', require('./time'))

--- a/h/static/scripts/directive/annotation.js
+++ b/h/static/scripts/directive/annotation.js
@@ -698,12 +698,19 @@ function AnnotationController(
     return persona.username(domainModel.user);
   };
 
-  /** Sets whether or not the controls for
-   * expanding/collapsing the body of lengthy annotations
-   * should be shown.
+  /**
+   * Sets whether or not the controls for expanding/collapsing the body of
+   * lengthy annotations should be shown.
    */
-  vm.setBodyCollapsible = function(canCollapse) {
+  vm.setBodyCollapsible = function (canCollapse) {
+    if (canCollapse === vm.canCollapseBody) {
+      return;
+    }
     vm.canCollapseBody = canCollapse;
+
+    // This event handler is called from outside the digest cycle, so
+    // explicitly trigger a digest.
+    $scope.$digest();
   };
 
   init();
@@ -768,7 +775,7 @@ function link(scope, elem, attrs, controllers) {
   *
   */
 // @ngInject
-function annotation($document) {
+function annotation() {
   return {
     restrict: 'E',
     bindToController: true,

--- a/h/static/scripts/directive/excerpt-overflow-monitor.js
+++ b/h/static/scripts/directive/excerpt-overflow-monitor.js
@@ -1,0 +1,116 @@
+'use strict';
+
+function toPx(val) {
+  return val.toString() + 'px';
+}
+
+/**
+ * Interface used by ExcerptOverflowMonitor to retrieve the state of the
+ * <excerpt> and report when the state changes.
+ *
+ * interface Excerpt {
+ *   getState(): State;
+ *   contentHeight(): number | undefined;
+ *   onOverflowChanged(): void;
+ * }
+ */
+
+/**
+ * A helper for the <excerpt> component which handles determinination of the
+ * overflow state and content styling given the current state of the component
+ * and the height of its contents.
+ *
+ * When the state of the excerpt or its content changes, the component should
+ * call check() to schedule an async update of the overflow state.
+ *
+ * @param {Excerpt} excerpt - Interface used to query the current state of the
+ *        excerpt and notify it when the overflow state changes.
+ * @param {(callback) => number} requestAnimationFrame -
+ *        Function called to schedule an async recalculation of the overflow
+ *        state.
+ */
+function ExcerptOverflowMonitor(excerpt, requestAnimationFrame) {
+  var pendingUpdate = false;
+
+  // Last-calculated overflow state
+  var prevOverflowing;
+
+  function update() {
+    var state = excerpt.getState();
+
+    if (!pendingUpdate) {
+      return;
+    }
+
+    pendingUpdate = false;
+
+    var overflowing = false;
+    if (state.enabled) {
+      var hysteresisPx = state.overflowHysteresis || 0;
+      overflowing = excerpt.contentHeight() >
+        (state.collapsedHeight + hysteresisPx);
+    }
+    if (overflowing === prevOverflowing) {
+      return;
+    }
+
+    prevOverflowing = overflowing;
+    excerpt.onOverflowChanged(overflowing);
+  }
+
+  /**
+   * Schedule a deferred check of whether the content is collapsed.
+   */
+  function check() {
+    if (pendingUpdate) {
+      return;
+    }
+    pendingUpdate = true;
+    requestAnimationFrame(update);
+  }
+
+  /**
+   * Returns an object mapping CSS properties to values that should be applied
+   * to an excerpt's content element in order to truncate it based on the
+   * current overflow state.
+   */
+  function contentStyle() {
+    var state = excerpt.getState();
+    if (!state.enabled) {
+      return {};
+    }
+
+    var maxHeight = '';
+    if (prevOverflowing) {
+      if (state.collapse) {
+        maxHeight = toPx(state.collapsedHeight);
+      } else if (state.animate) {
+        // Animating the height change requires that the final
+        // height be specified exactly, rather than relying on
+        // auto height
+        maxHeight = toPx(excerpt.contentHeight());
+      }
+    } else if (typeof prevOverflowing === 'undefined' &&
+               state.collapse) {
+      // If the excerpt is collapsed but the overflowing state has not yet
+      // been computed then the exact max height is unknown, but it will be
+      // in the range [state.collapsedHeight, state.collapsedHeight +
+      // state.overflowHysteresis]
+      //
+      // Here we guess that the final content height is most likely to be
+      // either less than `collapsedHeight` or more than `collapsedHeight` +
+      // `overflowHysteresis`, in which case it will be truncated to
+      // `collapsedHeight`.
+      maxHeight = toPx(state.collapsedHeight);
+    }
+
+    return {
+      'max-height': maxHeight,
+    };
+  }
+
+  this.contentStyle = contentStyle;
+  this.check = check;
+}
+
+module.exports = ExcerptOverflowMonitor;

--- a/h/static/scripts/directive/excerpt.js
+++ b/h/static/scripts/directive/excerpt.js
@@ -86,6 +86,11 @@ function excerpt(ExcerptOverflowMonitor) {
           if (ctrl.onCollapsibleChanged) {
             ctrl.onCollapsibleChanged({collapsible: overflowing});
           }
+          // Even though this change happens outside the framework, we use
+          // $digest() rather than $apply() here to avoid a large number of full
+          // digest cycles if many excerpts update their overflow state at the
+          // same time. The onCollapsibleChanged() handler, if any, is
+          // responsible for triggering any necessary digests in parent scopes.
           scope.$digest();
         },
       }, window.requestAnimationFrame);
@@ -131,8 +136,12 @@ function excerpt(ExcerptOverflowMonitor) {
       inlineControls: '<',
       /** Sets whether or not the excerpt is collapsed. */
       collapse: '=?',
-      /** Called when the collapsibility of the excerpt (that is, whether or
+      /**
+       * Called when the collapsibility of the excerpt (that is, whether or
        * not the content height exceeds the collapsed height), changes.
+       *
+       * Note: This function is *not* called from inside a digest cycle,
+       * the caller is responsible for triggering any necessary digests.
        */
       onCollapsibleChanged: '&?',
       /** The height of this container in pixels when collapsed.

--- a/h/static/scripts/directive/excerpt.js
+++ b/h/static/scripts/directive/excerpt.js
@@ -64,6 +64,19 @@ function excerpt(ExcerptOverflowMonitor) {
     controller: ExcerptController,
     controllerAs: 'vm',
     link: function (scope, elem, attrs, ctrl) {
+      // Test if the element or any of its parents have been hidden by
+      // an 'ng-show' directive
+      function isElementHidden() {
+        var el = elem[0];
+        while (el) {
+          if (el.classList.contains('ng-hide')) {
+            return true;
+          }
+          el = el.parentElement;
+        }
+        return false;
+      }
+
       var overflowMonitor = new ExcerptOverflowMonitor({
         getState: function () {
           return {
@@ -103,6 +116,15 @@ function excerpt(ExcerptOverflowMonitor) {
       window.addEventListener('resize', overflowMonitor.check);
       scope.$on('$destroy', function () {
         window.removeEventListener('resize', overflowMonitor.check);
+      });
+
+      // Watch for changes to the visibility of the excerpt.
+      // Unfortunately there is no DOM API for this, so we rely on a digest
+      // being triggered after the visibility changes.
+      scope.$watch(isElementHidden, function (hidden) {
+        if (!hidden) {
+          overflowMonitor.check();
+        }
       });
 
       // Watch input properties which may affect the overflow state

--- a/h/static/scripts/directive/test/excerpt-overflow-monitor-test.js
+++ b/h/static/scripts/directive/test/excerpt-overflow-monitor-test.js
@@ -1,0 +1,95 @@
+'use strict';
+
+var ExcerptOverflowMonitor = require('../excerpt-overflow-monitor');
+
+describe('ExcerptOverflowMonitor', function () {
+  var contentHeight;
+  var ctrl;
+  var monitor;
+  var state;
+
+  beforeEach(function () {
+    contentHeight = 0;
+
+    state = {
+      enabled: true,
+      animate: true,
+      collapsedHeight: 100,
+      collapse: true,
+      overflowHysteresis: 20,
+    };
+
+    ctrl = {
+      getState: function () { return state; },
+      contentHeight: function () { return contentHeight; },
+      onOverflowChanged: sinon.stub(),
+    };
+
+    monitor = new ExcerptOverflowMonitor(ctrl, function (callback) {
+      callback();
+    });
+  });
+
+  context('when enabled', function () {
+    it('overflows if height > collaped height + hysteresis', function () {
+      contentHeight = 200;
+      monitor.check();
+      assert.calledWith(ctrl.onOverflowChanged, true);
+    });
+
+    it('does not overflow if height < collapsed height', function () {
+      contentHeight = 80;
+      monitor.check();
+      assert.calledWith(ctrl.onOverflowChanged, false);
+    });
+
+    it('does not overflow if height is in [collapsed height, collapsed height + hysteresis]', function () {
+      contentHeight = 110;
+      monitor.check();
+      assert.calledWith(ctrl.onOverflowChanged, false);
+    });
+  });
+
+  context('when not enabled', function () {
+    beforeEach(function () {
+      state.enabled = false;
+    });
+
+    it('does not overflow if height > collapsed height + hysteresis', function () {
+      contentHeight = 200;
+      monitor.check();
+      assert.calledWith(ctrl.onOverflowChanged, false);
+    });
+  });
+
+  context('#contentStyle', function () {
+    it('sets max-height if collapsed and overflowing', function () {
+      contentHeight = 200;
+      monitor.check();
+      assert.deepEqual(monitor.contentStyle(), {'max-height': '100px'});
+    });
+
+    it('sets max height to empty if not overflowing', function () {
+      contentHeight = 80;
+      monitor.check();
+      assert.deepEqual(monitor.contentStyle(), {'max-height': ''});
+    });
+
+    it('sets max-height if overflow state is unknown', function () {
+      // Before the initial overflow check, the state is unknown
+      assert.deepEqual(monitor.contentStyle(), {'max-height': '100px'});
+    });
+  });
+
+  context('#check', function () {
+    it('calls onOverflowChanged() if state changed', function () {
+      contentHeight = 200;
+      monitor.check();
+
+      ctrl.onOverflowChanged = sinon.stub();
+      contentHeight = 250;
+      monitor.check();
+      assert.notCalled(ctrl.onOverflowChanged);
+    });
+  });
+});

--- a/h/static/scripts/directive/test/excerpt-test.js
+++ b/h/static/scripts/directive/test/excerpt-test.js
@@ -41,21 +41,9 @@ describe('excerpt directive', function () {
     return el.querySelector('.excerpt').offsetHeight;
   }
 
-  var defaultRAF = window.requestAnimationFrame;
-
   before(function () {
     angular.module('app', [])
       .directive('excerpt', excerpt.directive);
-
-    // requestAnimationFrame() is used internally by <excerpt>
-    // to schedule overflow state checks
-    window.requestAnimationFrame = function (callback) {
-      setTimeout(callback, 0);
-    };
-  });
-
-  after(function () {
-    window.requestAnimationFrame = defaultRAF;
   });
 
   beforeEach(function () {

--- a/h/static/scripts/directive/test/excerpt-test.js
+++ b/h/static/scripts/directive/test/excerpt-test.js
@@ -106,6 +106,24 @@ describe('excerpt directive', function () {
     });
   });
 
+  context('visibility changes', function () {
+    it('schedules an overflow check when shown', function () {
+      var element = excerptDirective({}, '<span></span>');
+      fakeOverflowMonitor.check.reset();
+
+      // ng-hide is the class used by the ngShow and ngHide directives
+      // to show or hide elements. For now, this is the only way of hiding
+      // or showing excerpts that we need to support.
+      element[0].classList.add('ng-hide');
+      element.scope.$digest();
+      assert.notCalled(fakeOverflowMonitor.check);
+
+      element[0].classList.remove('ng-hide');
+      element.scope.$digest();
+      assert.called(fakeOverflowMonitor.check);
+    });
+  });
+
   context('excerpt content style', function () {
     it('sets the content style using ExcerptOverflowMonitor#contentStyle()', function () {
       var element = excerptDirective({}, '<span></span>');

--- a/h/static/scripts/karma-phantomjs-polyfill.js
+++ b/h/static/scripts/karma-phantomjs-polyfill.js
@@ -11,6 +11,9 @@
 // by all browsers we support (IE >= 10)
 require('core-js/es5');
 
+// PhantomJS 1.x does not support rAF.
+require('raf').polyfill();
+
 // Additional polyfills for newer features.
 // Be careful that any polyfills used here match what is used in the
 // app itself.

--- a/h/templates/client/annotation.html
+++ b/h/templates/client/annotation.html
@@ -59,7 +59,8 @@
            ng-if="vm.hasQuotes()">
     <excerpt collapsed-height="40"
              inline-controls="true"
-             overflow-hysteresis="20">
+             overflow-hysteresis="20"
+             content-data="selector.exact">
       <blockquote class="annotation-quote"
                   ng-bind-html="selector.exact"
                   ng-repeat="selector in target.selector
@@ -77,7 +78,8 @@
              on-collapsible-changed="vm.setBodyCollapsible(collapsible)"
              collapse="vm.collapseBody"
              collapsed-height="400"
-             overflow-hysteresis="20">
+             overflow-hysteresis="20"
+             content-data="vm.form.text">
       <markdown ng-model="vm.form.text"
                 read-only="!vm.editing()">
       </markdown>

--- a/h/templates/client/excerpt.html
+++ b/h/templates/client/excerpt.html
@@ -1,5 +1,5 @@
-<div ng-transclude ng-if="!vm.enabled()"></div>
-<div class="excerpt__container" ng-if="vm.enabled()">
+<div ng-transclude ng-if="!vm.enabled"></div>
+<div class="excerpt__container" ng-if="vm.enabled">
   <div class="excerpt" ng-style="vm.contentStyle()">
     <div ng-transclude></div>
     <div ng-click="vm.expand()"


### PR DESCRIPTION
This PR re-implements the way annotation bodies and quotes check whether they are collapsed and need to display the controls to expand/collapse, in order to fix performance issues with the `<excerpt>` and a problem reported via Sentry where the excerpt could get into a loop between showing the controls and not showing them.

----

The collapsible excerpts used for annotation quotes and bodies need to compute the height of their contents in order to determine:

 1. Whether to show controls for expanding and collapsing the excerpt
 2. The height of the excerpt when collapsed. If the height exceeds the maximum collapsed height by only a small amount, such as a 3-line quote, then the full content is shown and the excerpt is allowed to be taller than the collapsed height.

Previously, the height of the excerpt was calculated 'on-demand' whenever Angular needed to compute any properties of the view that depended on it, by calling the `overflowing()` function in the excerpt, which in turn used `Element.scrollHeight` to measure the height of the content.

This was problematic however because:
 1. `Element.scrollHeight` forces the browser to synchronously lay out the content of the element, which is expensive
 2. The excerpt could trigger an infinite cycle, if its content and the window height were _just right_ [1]

This PR fixes the cycle and performance problems by only computing the overflow state in response to changes in the excerpt's content (eg. annotation quote or body text) and certain events (window resize, media load).

~~Additionally, it defers calculation of the overflow state until the excerpt is actually in the viewport.~~ (_Update_: I removed this because determining whether the excerpt is in the viewport was causing exactly the same layout flush that I was originally trying to avoid)

----

[1] AIUI, the sequence of events which triggered the cycle is:

1. Excerpt overflow state is unknown, so the `max-height` property is not set. If the contents of the annotation list are tall enough, the window shows a scroll bar
2. The overflow is state is calculated, and the excerpt is found to be overflowing, so its `max-height` property is set, reducing the height of the excerpt.
3. If the annotation list is the right height, (2) may cause the content to now become shorter than the window height and the scrollbar will disappear
4. Since the vertical scrollbar has disappeared, this gives the excerpt's content more horizontal room
5. When the excerpt's overflow state is recalculated on the next digest cycle, it is no longer overflowing, because the extra horizontal space means that the content requires less height.
6. If the excerpt's height is now between the collapsed height and the collapsed height + threshold, it will now expand vertically
7. As a result of (6), this may cause the window to show a scrollbar and we go back to step 2 above.