### PR TITLE
Delete annotations from PostgreSQL

### DIFF
--- a/h/api/storage.py
+++ b/h/api/storage.py
@@ -189,8 +189,12 @@ def delete_annotation(request, id):
     :param id: the annotation id
     :type id: str
     """
-    annotation = models.elastic.Annotation.fetch(id)
-    annotation.delete()
+    if _postgres_enabled(request):
+        annotation = fetch_annotation(request, id, _postgres=True)
+        request.db.delete(annotation)
+
+    legacy_annotation = fetch_annotation(request, id, _postgres=False)
+    legacy_annotation.delete()
 
 
 def expand_uri(request, uri):

--- a/h/api/test/views_test.py
+++ b/h/api/test/views_test.py
@@ -466,7 +466,9 @@ class TestUpdate(object):
         request.registry.notify.assert_called_once_with(event)
 
 
-@pytest.mark.usefixtures('AnnotationEvent', 'storage')
+@pytest.mark.usefixtures('AnnotationEvent',
+                         'AnnotationJSONPresenter',
+                         'storage')
 class TestDelete(object):
 
     def test_it_calls_delete_annotation(self, storage):
@@ -478,14 +480,21 @@ class TestDelete(object):
         storage.delete_annotation.assert_called_once_with(request,
                                                           annotation.id)
 
-    def test_it_calls_notify_with_an_event(self, AnnotationEvent):
+    def test_it_calls_notify_with_an_event(self,
+                                           AnnotationEvent,
+                                           AnnotationJSONPresenter):
         annotation = mock.Mock()
         request = mock.Mock()
         event = AnnotationEvent.return_value
 
         views.delete(annotation, request)
 
-        AnnotationEvent.assert_called_once_with(request, annotation, 'delete')
+        AnnotationJSONPresenter.assert_called_once_with(request, annotation)
+        AnnotationJSONPresenter.return_value.asdict.assert_called_once_with()
+        AnnotationEvent.assert_called_once_with(
+            request,
+            AnnotationJSONPresenter.return_value.asdict.return_value,
+            'delete')
         request.registry.notify.assert_called_once_with(event)
 
     def test_it_returns_object(self):

--- a/h/api/views.py
+++ b/h/api/views.py
@@ -228,7 +228,10 @@ def delete(annotation, request):
     # process the delete event. For example, the streamer needs to know the
     # target URLs of the deleted annotation in order to know which clients to
     # forward the delete event to.
-    _publish_annotation_event(request, annotation, 'delete')
+    _publish_annotation_event(
+        request,
+        AnnotationJSONPresenter(request, annotation).asdict(),
+        'delete')
 
     return {'id': annotation.id, 'deleted': True}
 


### PR DESCRIPTION
Delete annotations from both the legacy Elasticsearch "database" and the
new PostgreSQL database when the 'postgres' feature flag is on.