### PR TITLE
Clean up patch boilerplate

### DIFF
--- a/h/accounts/test/__init___test.py
+++ b/h/accounts/test/__init___test.py
@@ -152,15 +152,10 @@ def test_authenticated_user_calls_get_user(get_user):
 
 
 @pytest.fixture
-def util(request):
-    patcher = mock.patch('h.accounts.util')
-    module = patcher.start()
-    request.addfinalizer(patcher.stop)
-    return module
+def util(patch):
+    return patch('h.accounts.util')
 
 
 @pytest.fixture
-def get_by_username(request):
-    patcher = mock.patch('h.accounts.models.User.get_by_username')
-    request.addfinalizer(patcher.stop)
-    return patcher.start()
+def get_by_username(patch):
+    return patch('h.accounts.models.User.get_by_username', autospec=False)

--- a/h/accounts/test/schemas_test.py
+++ b/h/accounts/test/schemas_test.py
@@ -2,7 +2,6 @@
 import colander
 import pytest
 from mock import Mock
-from mock import patch
 from pyramid.exceptions import BadCSRFToken
 from pyramid.testing import DummyRequest
 from itsdangerous import BadData, SignatureExpired
@@ -356,14 +355,10 @@ def test_PasswordChangeSchema_rejects_wrong_password(config, user_model):
 
 
 @pytest.fixture
-def activation_model(config, request):
-    patcher = patch('h.accounts.schemas.models.Activation', autospec=True)
-    request.addfinalizer(patcher.stop)
-    return patcher.start()
+def activation_model(patch):
+    return patch('h.accounts.schemas.models.Activation')
 
 
 @pytest.fixture
-def user_model(config, request):
-    patcher = patch('h.accounts.schemas.models.User', autospec=True)
-    request.addfinalizer(patcher.stop)
-    return patcher.start()
+def user_model(patch):
+    return patch('h.accounts.schemas.models.User')

--- a/h/accounts/test/views_test.py
+++ b/h/accounts/test/views_test.py
@@ -1028,64 +1028,35 @@ class TestDeveloperController(object):
 
 
 @pytest.fixture
-def pop_flash(request):
-    patcher = mock.patch('h.accounts.views.session.pop_flash', autospec=True)
-    func = patcher.start()
-    request.addfinalizer(patcher.stop)
-    return func
+def session(patch):
+    return patch('h.accounts.views.session')
 
 
 @pytest.fixture
-def session(request):
-    patcher = mock.patch('h.accounts.views.session', autospec=True)
-    session = patcher.start()
-    request.addfinalizer(patcher.stop)
-    return session
+def subscriptions_model(patch):
+    return patch('h.models.Subscriptions')
 
 
 @pytest.fixture
-def subscriptions_model(request):
-    patcher = mock.patch('h.models.Subscriptions', autospec=True)
-    model = patcher.start()
-    request.addfinalizer(patcher.stop)
-    return model
+def user_model(patch):
+    return patch('h.accounts.views.User')
 
 
 @pytest.fixture
-def user_model(request):
-    patcher = mock.patch('h.accounts.views.User', autospec=True)
-    model = patcher.start()
-    request.addfinalizer(patcher.stop)
-    return model
+def activation_model(patch):
+    return patch('h.accounts.views.Activation')
 
 
 @pytest.fixture
-def activation_model(request):
-    patcher = mock.patch('h.accounts.views.Activation', autospec=True)
-    model = patcher.start()
-    request.addfinalizer(patcher.stop)
-    return model
+def ActivationEvent(patch):
+    return patch('h.accounts.views.ActivationEvent')
 
 
 @pytest.fixture
-def ActivationEvent(request):
-    patcher = mock.patch('h.accounts.views.ActivationEvent', autospec=True)
-    model = patcher.start()
-    request.addfinalizer(patcher.stop)
-    return model
+def mailer(patch):
+    return patch('h.accounts.views.mailer')
 
 
 @pytest.fixture
-def mailer(request):
-    patcher = mock.patch('h.accounts.views.mailer', autospec=True)
-    module = patcher.start()
-    request.addfinalizer(patcher.stop)
-    return module
-
-
-@pytest.fixture
-def models(request):
-    patcher = mock.patch('h.accounts.views.models', autospec=True)
-    module = patcher.start()
-    request.addfinalizer(patcher.stop)
-    return module
+def models(patch):
+    return patch('h.accounts.views.models')

--- a/h/api/models/test/document_test.py
+++ b/h/api/models/test/document_test.py
@@ -263,11 +263,8 @@ class TestCreateOrUpdateDocumentURI(object):
         assert log.warn.call_count == 1
 
     @pytest.fixture
-    def DocumentURI(self, request):
-        patcher = mock.patch('h.api.models.document.DocumentURI')
-        DocumentURI = patcher.start()
-        request.addfinalizer(patcher.stop)
-        return DocumentURI
+    def DocumentURI(self, patch):
+        return patch('h.api.models.document.DocumentURI')
 
 
 class TestCreateOrUpdateDocumentMeta(object):
@@ -373,11 +370,8 @@ class TestCreateOrUpdateDocumentMeta(object):
         assert log.warn.call_count == 1
 
     @pytest.fixture
-    def DocumentMeta(self, request):
-        patcher = mock.patch('h.api.models.document.DocumentMeta')
-        DocumentMeta = patcher.start()
-        request.addfinalizer(patcher.stop)
-        return DocumentMeta
+    def DocumentMeta(self, patch):
+        return patch('h.api.models.document.DocumentMeta')
 
 
 @pytest.mark.usefixtures('merge_data')
@@ -483,8 +477,5 @@ def mock_document_meta(document=None):
 
 
 @pytest.fixture
-def log(config, request):
-    patcher = mock.patch('h.api.models.document.log', autospec=True)
-    log = patcher.start()
-    request.addfinalizer(patcher.stop)
-    return log
+def log(patch):
+    return patch('h.api.models.document.log')

--- a/h/api/models/test/elastic_test.py
+++ b/h/api/models/test/elastic_test.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 import datetime
 
 import pytest
-from mock import patch
 from mock import PropertyMock
 
 from pyramid import security
@@ -242,32 +241,28 @@ class TestAnnotation(object):
         assert actual == expect
 
     @pytest.fixture
-    def link_text(self, request):
-        patcher = patch('h.api.models.elastic.Annotation.link_text',
-                        new_callable=PropertyMock)
-        request.addfinalizer(patcher.stop)
-        return patcher.start()
+    def link_text(self, patch):
+        return patch('h.api.models.elastic.Annotation.link_text',
+                     autospec=None,
+                     new_callable=PropertyMock)
 
     @pytest.fixture
-    def title(self, request):
-        patcher = patch('h.api.models.elastic.Annotation.title',
-                        new_callable=PropertyMock)
-        request.addfinalizer(patcher.stop)
-        return patcher.start()
+    def title(self, patch):
+        return patch('h.api.models.elastic.Annotation.title',
+                     autospec=None,
+                     new_callable=PropertyMock)
 
     @pytest.fixture
-    def href(self, request):
-        patcher = patch('h.api.models.elastic.Annotation.href',
-                        new_callable=PropertyMock)
-        request.addfinalizer(patcher.stop)
-        return patcher.start()
+    def href(self, patch):
+        return patch('h.api.models.elastic.Annotation.href',
+                     autospec=None,
+                     new_callable=PropertyMock)
 
     @pytest.fixture
-    def hostname_or_filename(self, request):
-        patcher = patch('h.api.models.elastic.Annotation.hostname_or_filename',
-                        new_callable=PropertyMock)
-        request.addfinalizer(patcher.stop)
-        return patcher.start()
+    def hostname_or_filename(self, patch):
+        return patch('h.api.models.elastic.Annotation.hostname_or_filename',
+                     autospec=None,
+                     new_callable=PropertyMock)
 
 
 class TestDocument(object):

--- a/h/api/search/test/core_test.py
+++ b/h/api/search/test/core_test.py
@@ -205,16 +205,10 @@ class instance_of_type(object):
 
 
 @pytest.fixture
-def query(request):
-    patcher = mock.patch('h.api.search.core.query', autospec=True)
-    result = patcher.start()
-    request.addfinalizer(patcher.stop)
-    return result
+def query(patch):
+    return patch('h.api.search.core.query')
 
 
 @pytest.fixture
-def log(request):
-    patcher = mock.patch('h.api.search.core.log', autospec=True)
-    result = patcher.start()
-    request.addfinalizer(patcher.stop)
-    return result
+def log(patch):
+    return patch('h.api.search.core.log')

--- a/h/api/search/test/query_test.py
+++ b/h/api/search/test/query_test.py
@@ -394,18 +394,14 @@ def test_tagsmatcher_with_both_tag_and_tags():
 
 
 @pytest.fixture
-def storage(request):
-    patcher = mock.patch('h.api.search.query.storage', autospec=True)
-    storage = patcher.start()
+def storage(patch):
+    storage = patch('h.api.search.query.storage')
     storage.expand_uri.side_effect = lambda x: [x]
-    request.addfinalizer(patcher.stop)
     return storage
 
 
 @pytest.fixture
-def uri(request):
-    patcher = mock.patch('h.api.search.query.uri', autospec=True)
-    uri = patcher.start()
+def uri(patch):
+    uri = patch('h.api.search.query.uri')
     uri.normalize.side_effect = lambda x: x
-    request.addfinalizer(patcher.stop)
     return uri

--- a/h/api/test/parse_document_claims_test.py
+++ b/h/api/test/parse_document_claims_test.py
@@ -541,53 +541,24 @@ class TestDocumentURIsFromData(object):
         assert document_uri_self_claim.return_value in document_uris
 
     @pytest.fixture
-    def document_uris_from_dc(self, request):
-        patcher = mock.patch(
-            'h.api.parse_document_claims.document_uris_from_dc',
-            autospec=True)
-        document_uris_from_dc = patcher.start()
-        document_uris_from_dc.return_value = []
-        request.addfinalizer(patcher.stop)
-        return document_uris_from_dc
+    def document_uris_from_dc(self, patch):
+        return patch('h.api.parse_document_claims.document_uris_from_dc', return_value=[])
 
     @pytest.fixture
-    def document_uris_from_highwire_pdf(self, request):
-        patcher = mock.patch(
-            'h.api.parse_document_claims.document_uris_from_highwire_pdf',
-            autospec=True)
-        document_uris_from_highwire_pdf = patcher.start()
-        document_uris_from_highwire_pdf.return_value = []
-        request.addfinalizer(patcher.stop)
-        return document_uris_from_highwire_pdf
+    def document_uris_from_highwire_pdf(self, patch):
+        return patch('h.api.parse_document_claims.document_uris_from_highwire_pdf', return_value=[])
 
     @pytest.fixture
-    def document_uris_from_highwire_doi(self, request):
-        patcher = mock.patch(
-            'h.api.parse_document_claims.document_uris_from_highwire_doi',
-            autospec=True)
-        document_uris_from_highwire_doi = patcher.start()
-        document_uris_from_highwire_doi.return_value = []
-        request.addfinalizer(patcher.stop)
-        return document_uris_from_highwire_doi
+    def document_uris_from_highwire_doi(self, patch):
+        return patch('h.api.parse_document_claims.document_uris_from_highwire_doi', return_value=[])
 
     @pytest.fixture
-    def document_uris_from_links(self, request):
-        patcher = mock.patch(
-            'h.api.parse_document_claims.document_uris_from_links',
-            autospec=True)
-        document_uris_from_links = patcher.start()
-        document_uris_from_links.return_value = []
-        request.addfinalizer(patcher.stop)
-        return document_uris_from_links
+    def document_uris_from_links(self, patch):
+        return patch('h.api.parse_document_claims.document_uris_from_links', return_value=[])
 
     @pytest.fixture
-    def document_uri_self_claim(self, request):
-        patcher = mock.patch(
-            'h.api.parse_document_claims.document_uri_self_claim',
-            autospec=True)
-        document_uri_self_claim = patcher.start()
-        request.addfinalizer(patcher.stop)
-        return document_uri_self_claim
+    def document_uri_self_claim(self, patch):
+        return patch('h.api.parse_document_claims.document_uri_self_claim')
 
 
 def one(list_):

--- a/h/api/test/presenters_test.py
+++ b/h/api/test/presenters_test.py
@@ -255,12 +255,8 @@ class TestAnnotationJSONPresenter(object):
         assert expected == presenter.permissions[action]
 
     @pytest.fixture
-    def document_asdict(self, request):
-        patcher = mock.patch('h.api.presenters.DocumentJSONPresenter.asdict',
-                             autospec=True)
-        method = patcher.start()
-        request.addfinalizer(patcher.stop)
-        return method
+    def document_asdict(self, patch):
+        return patch('h.api.presenters.DocumentJSONPresenter.asdict')
 
 
 class TestAnnotationJSONLDPresenter(object):

--- a/h/api/test/resources_test.py
+++ b/h/api/test/resources_test.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 from mock import Mock
-from mock import patch
 from pyramid.testing import DummyRequest
 import pytest
 
@@ -33,8 +32,5 @@ class TestAnnotationFactory(object):
             factory['123']
 
     @pytest.fixture
-    def storage(self, request):
-        patcher = patch('h.api.resources.storage', autospec=True)
-        module = patcher.start()
-        request.addfinalizer(patcher.stop)
-        return module
+    def storage(self, patch):
+        return patch('h.api.resources.storage')

--- a/h/api/test/schemas_test.py
+++ b/h/api/test/schemas_test.py
@@ -864,22 +864,14 @@ class TestCreateAnnotationSchema(object):
         return data
 
     @pytest.fixture
-    def AnnotationSchema(self, request):
-        patcher = mock.patch('h.api.schemas.AnnotationSchema',
-                             autospec=True)
-        AnnotationSchema = patcher.start()
-        AnnotationSchema.return_value.validate.return_value = (
-            self.annotation_data())
-        request.addfinalizer(patcher.stop)
-        return AnnotationSchema
+    def AnnotationSchema(self, patch):
+        cls = patch('h.api.schemas.AnnotationSchema')
+        cls.return_value.validate.return_value = self.annotation_data()
+        return cls
 
     @pytest.fixture
-    def parse_document_claims(self, request):
-        patcher = mock.patch('h.api.schemas.parse_document_claims',
-                             autospec=True)
-        parse_document_claims = patcher.start()
-        request.addfinalizer(patcher.stop)
-        return parse_document_claims
+    def parse_document_claims(self, patch):
+        return patch('h.api.schemas.parse_document_claims')
 
 
 class TestUpdateAnnotationSchema(object):

--- a/h/api/test/storage_test.py
+++ b/h/api/test/storage_test.py
@@ -6,7 +6,6 @@ import copy
 
 import pytest
 import mock
-from mock import patch
 from pyramid.testing import DummyRequest
 
 from h import db
@@ -214,26 +213,16 @@ class TestLegacyCreateAnnotation(object):
         return {'foo': 'bar'}
 
     @pytest.fixture
-    def AnnotationBeforeSaveEvent(self, request):
-        patcher = patch('h.api.storage.AnnotationBeforeSaveEvent',
-                        autospec=True)
-        AnnotationBeforeSaveEvent = patcher.start()
-        request.addfinalizer(patcher.stop)
-        return AnnotationBeforeSaveEvent
+    def AnnotationBeforeSaveEvent(self, patch):
+        return patch('h.api.storage.AnnotationBeforeSaveEvent')
 
     @pytest.fixture
-    def partial(self, request):
-        patcher = patch('h.api.storage.partial', autospec=True)
-        partial = patcher.start()
-        request.addfinalizer(patcher.stop)
-        return partial
+    def partial(self, patch):
+        return patch('h.api.storage.partial')
 
     @pytest.fixture
-    def transform(self, request):
-        patcher = patch('h.api.storage.transform', autospec=True)
-        transform = patcher.start()
-        request.addfinalizer(patcher.stop)
-        return transform
+    def transform(self, patch):
+        return patch('h.api.storage.transform')
 
 
 @pytest.mark.usefixtures('fetch_annotation',
@@ -618,33 +607,17 @@ class TestDeleteAnnotation(object):
 
 
 @pytest.fixture
-def document_model(config, request):
-    patcher = patch('h.api.models.elastic.Document', autospec=True)
-    module = patcher.start()
-    request.addfinalizer(patcher.stop)
-    return module
+def fetch_annotation(patch):
+    return patch('h.api.storage.fetch_annotation')
 
 
 @pytest.fixture
-def fetch_annotation(request):
-    patcher = patch('h.api.storage.fetch_annotation', autospec=True)
-    fetch_annotation = patcher.start()
-    request.addfinalizer(patcher.stop)
-    return fetch_annotation
-
-
-@pytest.fixture
-def models(request):
-    patcher = patch('h.api.storage.models')
-    models = patcher.start()
+def models(patch):
+    models = patch('h.api.storage.models', autospec=False)
     models.Annotation.return_value.is_reply = False
-    request.addfinalizer(patcher.stop)
     return models
 
 
 @pytest.fixture
-def postgres_enabled(request):
-    patcher = patch('h.api.storage._postgres_enabled', autospec=True)
-    func = patcher.start()
-    request.addfinalizer(patcher.stop)
-    return func
+def postgres_enabled(patch):
+    return patch('h.api.storage._postgres_enabled')

--- a/h/api/test/transform_test.py
+++ b/h/api/test/transform_test.py
@@ -212,9 +212,7 @@ def test_fix_old_style_comments(ann_in, ann_out):
 
 
 @pytest.fixture
-def uri_normalize(request):
-    patcher = mock.patch('h.api.uri.normalize', autospec=True)
-    func = patcher.start()
+def uri_normalize(patch):
+    func = patch('h.api.uri.normalize')
     func.side_effect = lambda x: "*%s*" % x
-    request.addfinalizer(patcher.stop)
     return func

--- a/h/api/test/views_test.py
+++ b/h/api/test/views_test.py
@@ -122,10 +122,8 @@ class TestSearch(object):
                                       {'giraffe': True}]}
 
     @pytest.fixture
-    def search_lib(self, request):
-        patcher = mock.patch('h.api.views.search_lib', autospec=True)
-        request.addfinalizer(patcher.stop)
-        return patcher.start()
+    def search_lib(self, patch):
+        return patch('h.api.views.search_lib')
 
 
 @pytest.mark.usefixtures('AnnotationEvent',
@@ -208,10 +206,8 @@ class TestCreateLegacy(object):
         return mock.Mock(feature=mock.Mock(return_value=False))
 
     @pytest.fixture
-    def copy(self, request):
-        patcher = mock.patch('h.api.views.copy', autospec=True)
-        request.addfinalizer(patcher.stop)
-        return patcher.start()
+    def copy(self, patch):
+        return patch('h.api.views.copy')
 
 
 @pytest.mark.usefixtures('AnnotationEvent',
@@ -341,10 +337,8 @@ class TestCreate(object):
         return mock.Mock(feature=mock.Mock(return_value=True))
 
     @pytest.fixture
-    def copy(self, request):
-        patcher = mock.patch('h.api.views.copy', autospec=True)
-        request.addfinalizer(patcher.stop)
-        return patcher.start()
+    def copy(self, patch):
+        return patch('h.api.views.copy')
 
 
 @pytest.mark.usefixtures('AnnotationJSONPresenter')
@@ -392,12 +386,8 @@ class TestReadJSONLD(object):
         assert result == presenter.asdict()
 
     @pytest.fixture
-    def AnnotationJSONLDPresenter(self, request):
-        patcher = mock.patch('h.api.views.AnnotationJSONLDPresenter',
-                             autospec=True)
-        cls = patcher.start()
-        request.addfinalizer(patcher.stop)
-        return cls
+    def AnnotationJSONLDPresenter(self, patch):
+        return patch('h.api.views.AnnotationJSONLDPresenter')
 
 
 @pytest.mark.usefixtures('AnnotationEvent',
@@ -507,43 +497,30 @@ class TestDelete(object):
 
 
 @pytest.fixture
-def AnnotationEvent(request):
-    patcher = mock.patch('h.api.views.AnnotationEvent', autospec=True)
-    request.addfinalizer(patcher.stop)
-    return patcher.start()
+def AnnotationEvent(patch):
+    return patch('h.api.views.AnnotationEvent')
 
 
 @pytest.fixture
-def AnnotationJSONPresenter(request):
-    patcher = mock.patch('h.api.views.AnnotationJSONPresenter', autospec=True)
-    cls = patcher.start()
-    request.addfinalizer(patcher.stop)
-    return cls
+def AnnotationJSONPresenter(patch):
+    return patch('h.api.views.AnnotationJSONPresenter')
 
 
 @pytest.fixture
-def copy(request):
-    patcher = mock.patch('h.api.views.copy', autospec=True)
-    request.addfinalizer(patcher.stop)
-    return patcher.start()
+def copy(patch):
+    return patch('h.api.views.copy')
 
 
 @pytest.fixture
-def search_lib(request):
-    patcher = mock.patch('h.api.views.search_lib', autospec=True)
-    request.addfinalizer(patcher.stop)
-    return patcher.start()
+def search_lib(patch):
+    return patch('h.api.views.search_lib')
 
 
 @pytest.fixture
-def schemas(request):
-    patcher = mock.patch('h.api.views.schemas', autospec=True)
-    request.addfinalizer(patcher.stop)
-    return patcher.start()
+def schemas(patch):
+    return patch('h.api.views.schemas')
 
 
 @pytest.fixture
-def storage(request):
-    patcher = mock.patch('h.api.views.storage', autospec=True)
-    request.addfinalizer(patcher.stop)
-    return patcher.start()
+def storage(patch):
+    return patch('h.api.views.storage')

--- a/h/auth/test/tokens_test.py
+++ b/h/auth/test/tokens_test.py
@@ -228,8 +228,5 @@ def mock_request(token=None):
 
 
 @pytest.fixture
-def jwt(request):
-    patcher = mock.patch('h.auth.tokens.jwt', autospec=True)
-    module = patcher.start()
-    request.addfinalizer(patcher.stop)
-    return module
+def jwt(patch):
+    return patch('h.auth.tokens.jwt')

--- a/h/auth/test/util_test.py
+++ b/h/auth/test/util_test.py
@@ -157,14 +157,10 @@ def test_translate_annotation_principals(p_in, p_out):
 
 
 @pytest.fixture
-def accounts(request):
-    patcher = mock.patch('h.auth.util.accounts', autospec=True)
-    request.addfinalizer(patcher.stop)
-    return patcher.start()
+def accounts(patch):
+    return patch('h.auth.util.accounts')
 
 
 @pytest.fixture
-def group_principals(request):
-    patcher = mock.patch('h.auth.util.group_principals', autospec=True)
-    request.addfinalizer(patcher.stop)
-    return patcher.start()
+def group_principals(patch):
+    return patch('h.auth.util.group_principals')

--- a/h/badge/test/views_test.py
+++ b/h/badge/test/views_test.py
@@ -41,14 +41,10 @@ def test_badge_raises_if_no_uri():
 
 
 @pytest.fixture
-def models(config, request):  # pylint:disable=unused-argument
-    patcher = mock.patch('h.badge.views.models', autospec=True)
-    request.addfinalizer(patcher.stop)
-    return patcher.start()
+def models(patch):
+    return patch('h.badge.views.models')
 
 
 @pytest.fixture
-def search_lib(config, request):  # pylint:disable=unused-argument
-    patcher = mock.patch('h.badge.views.search_lib', autospec=True)
-    request.addfinalizer(patcher.stop)
-    return patcher.start()
+def search_lib(patch):
+    return patch('h.badge.views.search_lib')

--- a/h/groups/test/views_test.py
+++ b/h/groups/test/views_test.py
@@ -545,58 +545,42 @@ def test_leave_publishes_leave_event(Group, session_model):
 
 
 @pytest.fixture
-def Form(request):
-    patcher = mock.patch('h.groups.views.deform.Form', autospec=True)
-    request.addfinalizer(patcher.stop)
-    return patcher.start()
+def Form(patch):
+    return patch('h.groups.views.deform.Form')
 
 
 @pytest.fixture
-def GroupSchema(request):
-    patcher = mock.patch('h.groups.views.schemas.GroupSchema', autospec=True)
-    request.addfinalizer(patcher.stop)
-    return patcher.start()
+def GroupSchema(patch):
+    return patch('h.groups.views.schemas.GroupSchema')
 
 
 @pytest.fixture
-def Group(request):
-    patcher = mock.patch('h.groups.views.models.Group', autospec=True)
-    request.addfinalizer(patcher.stop)
-    return patcher.start()
+def Group(patch):
+    return patch('h.groups.views.models.Group')
 
 
 @pytest.fixture
-def session_model(request):
-    patcher = mock.patch('h.session.model')
-    request.addfinalizer(patcher.stop)
-    return patcher.start()
+def session_model(patch):
+    return patch('h.session.model', autospec=False)
 
 
 @pytest.fixture
-def renderers(request):
-    patcher = mock.patch('h.groups.views.renderers', autospec=True)
-    request.addfinalizer(patcher.stop)
-    return patcher.start()
+def renderers(patch):
+    return patch('h.groups.views.renderers')
 
 
 @pytest.fixture
-def search(request):
-    patcher = mock.patch('h.groups.views.search', autospec=True)
-    search = patcher.start()
-    search.search.return_value = {'rows': [], 'total': 0}
-    request.addfinalizer(patcher.stop)
-    return search
+def search(patch):
+    mod = patch('h.groups.views.search')
+    mod.search.return_value = {'rows': [], 'total': 0}
+    return mod
 
 
 @pytest.fixture
-def uri(request):
-    patcher = mock.patch('h.groups.views.uri', autospec=True)
-    request.addfinalizer(patcher.stop)
-    return patcher.start()
+def uri(patch):
+    return patch('h.groups.views.uri')
 
 
 @pytest.fixture
-def presenters(request):
-    patcher = mock.patch('h.groups.views.presenters', autospec=True)
-    request.addfinalizer(patcher.stop)
-    return patcher.start()
+def presenters(patch):
+    return patch('h.groups.views.presenters')

--- a/h/nipsa/test/subscribers_test.py
+++ b/h/nipsa/test/subscribers_test.py
@@ -27,8 +27,5 @@ def test_transform_annotation(ann, nipsa, has_nipsa):
 
 
 @pytest.fixture
-def has_nipsa(request):
-    patcher = mock.patch('h.nipsa.logic.has_nipsa', autospec=True)
-    func = patcher.start()
-    request.addfinalizer(patcher.stop)
-    return func
+def has_nipsa(patch):
+    return patch('h.nipsa.logic.has_nipsa')

--- a/h/notification/test/reply_template_test.py
+++ b/h/notification/test/reply_template_test.py
@@ -427,12 +427,8 @@ def test_send_if_everything_is_okay():
 
 
 @pytest.fixture
-def effective_principals(request):
-    patcher = patch('h.auth.effective_principals')
-    func = patcher.start()
-    func.return_value = [security.Everyone]
-    request.addfinalizer(patcher.stop)
-    return func
+def effective_principals(patch):
+    return patch('h.auth.effective_principals', return_value=[security.Everyone])
 
 
 @pytest.fixture(autouse=True)

--- a/h/streamer/test/nsq_test.py
+++ b/h/streamer/test/nsq_test.py
@@ -330,8 +330,5 @@ def test_process_nsq_topic_raises_if_reader_exits_early(get_reader):
 
 
 @pytest.fixture
-def get_reader(request):
-    patcher = mock.patch('h.queue.get_reader')
-    func = patcher.start()
-    request.addfinalizer(patcher.stop)
-    return func
+def get_reader(patch):
+    return patch('h.queue.get_reader')

--- a/h/streamer/test/streamer_test.py
+++ b/h/streamer/test/streamer_test.py
@@ -109,14 +109,10 @@ def session():
 
 
 @pytest.fixture(autouse=True)
-def nsq_handle_message(request):
-    patcher = mock.patch('h.streamer.nsq.handle_message')
-    patcher.start()
-    request.addfinalizer(patcher.stop)
+def nsq_handle_message(patch):
+    return patch('h.streamer.nsq.handle_message')
 
 
 @pytest.fixture(autouse=True)
-def websocket_handle_message(request):
-    patcher = mock.patch('h.streamer.websocket.handle_message')
-    patcher.start()
-    request.addfinalizer(patcher.stop)
+def websocket_handle_message(patch):
+    return patch('h.streamer.websocket.handle_message')

--- a/h/test/admin_test.py
+++ b/h/test/admin_test.py
@@ -789,96 +789,68 @@ def test_delete_user_deletes_user():
 
 
 @pytest.fixture
-def models(request):
-    patcher = patch('h.admin.models', autospec=True)
-    request.addfinalizer(patcher.stop)
-    return patcher.start()
+def models(patch):
+    return patch('h.admin.models')
 
 
 @pytest.fixture
-def badge_index(request):
-    patcher = patch('h.admin.badge_index', autospec=True)
-    request.addfinalizer(patcher.stop)
-    return patcher.start()
+def badge_index(patch):
+    return patch('h.admin.badge_index')
 
 
 @pytest.fixture
-def Feature(request):
-    patcher = patch('h.models.Feature', autospec=True)
-    request.addfinalizer(patcher.stop)
-    return patcher.start()
+def Feature(patch):
+    return patch('h.models.Feature')
 
 
 @pytest.fixture
-def check_csrf_token(request):
-    patcher = patch('pyramid.session.check_csrf_token', autospec=True)
-    request.addfinalizer(patcher.stop)
-    return patcher.start()
+def check_csrf_token(patch):
+    return patch('pyramid.session.check_csrf_token')
 
 
 @pytest.fixture
-def nipsa(config, request):  # pylint:disable=unused-argument
-    patcher = patch('h.admin.nipsa', autospec=True)
-    request.addfinalizer(patcher.stop)
-    return patcher.start()
+def nipsa(patch):
+    return patch('h.admin.nipsa')
 
 
 @pytest.fixture
-def nipsa_index(config, request):  # pylint:disable=unused-argument
-    patcher = patch('h.admin.nipsa_index', autospec=True)
-    request.addfinalizer(patcher.stop)
-    return patcher.start()
+def nipsa_index(patch):
+    return patch('h.admin.nipsa_index')
 
 
 @pytest.fixture
-def User(config, request):  # pylint:disable=unused-argument
-    patcher = patch('h.admin.models.User', autospec=True)
-    request.addfinalizer(patcher.stop)
-    return patcher.start()
+def User(patch):
+    return patch('h.admin.models.User')
 
 
 @pytest.fixture
-def make_admin(config, request):  # pylint:disable=unused-argument
-    patcher = patch('h.admin.accounts.make_admin', autospec=True)
-    request.addfinalizer(patcher.stop)
-    return patcher.start()
+def make_admin(patch):
+    return patch('h.admin.accounts.make_admin')
 
 
 @pytest.fixture
-def make_staff(config, request):  # pylint:disable=unused-argument
-    patcher = patch('h.admin.accounts.make_staff', autospec=True)
-    request.addfinalizer(patcher.stop)
-    return patcher.start()
+def make_staff(patch):
+    return patch('h.admin.accounts.make_staff')
 
 
 @pytest.fixture
-def admins_index(config, request):  # pylint:disable=unused-argument
-    patcher = patch('h.admin.admins_index', autospec=True)
-    request.addfinalizer(patcher.stop)
-    return patcher.start()
+def admins_index(patch):
+    return patch('h.admin.admins_index')
 
 
 @pytest.fixture
-def staff_index(config, request):  # pylint:disable=unused-argument
-    patcher = patch('h.admin.staff_index', autospec=True)
-    request.addfinalizer(patcher.stop)
-    return patcher.start()
+def staff_index(patch):
+    return patch('h.admin.staff_index')
 
 
 @pytest.fixture
-def elasticsearch_helpers(request):
-    patcher = patch('h.admin.es_helpers', autospec=True)
-    module = patcher.start()
-    request.addfinalizer(patcher.stop)
-    return module
+def elasticsearch_helpers(patch):
+    return patch('h.admin.es_helpers')
 
 
 @pytest.fixture
-def api_storage(request):
-    patcher = patch('h.admin.storage', autospec=True)
-    module = patcher.start()
-    request.addfinalizer(patcher.stop)
-    return module
+def api_storage(patch):
+    return patch('h.admin.storage')
 
 
 @pytest.fixture
@@ -888,16 +860,10 @@ def user_created_no_groups(models):
 
 
 @pytest.fixture
-def delete_user(request):
-    patcher = patch('h.admin.delete_user')
-    function = patcher.start()
-    request.addfinalizer(patcher.stop)
-    return function
+def delete_user(patch):
+    return patch('h.admin.delete_user')
 
 
 @pytest.fixture
-def events(request):
-    patcher = patch('h.admin.events', autospec=True)
-    module = patcher.start()
-    request.addfinalizer(patcher.stop)
-    return module
+def events(patch):
+    return patch('h.admin.events')

--- a/h/test/features_test.py
+++ b/h/test/features_test.py
@@ -81,13 +81,13 @@ class TestClient(object):
                                             client,
                                             client_load):
 
-        def test_load():
-            client._cache = {'notification': True}
+        def test_load(self):
+            self._cache = {'notification': True}
         client_load.side_effect = test_load
 
         client._cache = {}
         client.enabled('notification')
-        client_load.assert_called_with()
+        client_load.assert_called_with(client)
 
     def test_enabled_false_if_not_in_database(self, client):
         assert client.enabled('notification') is False
@@ -139,7 +139,7 @@ class TestClient(object):
     def test_all_loads_cache_when_empty(self, client, client_load):
         client._cache = {}
         client.all()
-        client_load.assert_called_with()
+        client_load.assert_called_with(client)
 
     def test_all_returns_cache(self, client):
         cache = mock.Mock()
@@ -156,18 +156,12 @@ class TestClient(object):
         return features.Client(DummyRequest(db=db.Session))
 
     @pytest.fixture
-    def client_load(self, request, client):
-        patcher = mock.patch('h.features.Client.load')
-        method = patcher.start()
-        request.addfinalizer(patcher.stop)
-        return method
+    def client_load(self, patch):
+        return patch('h.features.Client.load')
 
     @pytest.fixture
-    def fetcher(self, request, client):
-        patcher = mock.patch('h.features.Client._fetch_features')
-        method = patcher.start()
-        request.addfinalizer(patcher.stop)
-        return method
+    def fetcher(self, patch):
+        return patch('h.features.Client._fetch_features')
 
 
 def test_remove_old_flag_removes_old_flags():
@@ -190,10 +184,8 @@ def test_remove_old_flag_removes_old_flags():
 
 
 @pytest.fixture
-def feature_model(request):
-    patcher = mock.patch('h.features.Feature', autospec=True)
-    request.addfinalizer(patcher.stop)
-    model = patcher.start()
+def feature_model(patch):
+    model = patch('h.features.Feature')
     model.get_by_name.return_value.everyone = False
     model.get_by_name.return_value.admins = False
     return model

--- a/h/test/presenters_test.py
+++ b/h/test/presenters_test.py
@@ -517,60 +517,42 @@ def test_created_day_string_from_annotation():
 
 
 @pytest.fixture
-def uri(request):
-    patcher = mock.patch(
-        'h.presenters.AnnotationHTMLPresenter.uri',
-        new_callable=mock.PropertyMock)
-    result = patcher.start()
-    request.addfinalizer(patcher.stop)
-    return result
+def uri(patch):
+    return patch('h.presenters.AnnotationHTMLPresenter.uri',
+                 autospec=None,
+                 new_callable=mock.PropertyMock)
 
 
 @pytest.fixture
-def filename(request):
-    patcher = mock.patch(
-        'h.presenters.AnnotationHTMLPresenter.filename',
-        new_callable=mock.PropertyMock)
-    result = patcher.start()
-    request.addfinalizer(patcher.stop)
-    return result
+def filename(patch):
+    return patch('h.presenters.AnnotationHTMLPresenter.filename',
+                 autospec=None,
+                 new_callable=mock.PropertyMock)
 
 
 @pytest.fixture
-def title(request):
-    patcher = mock.patch(
-        'h.presenters.AnnotationHTMLPresenter.title',
-        new_callable=mock.PropertyMock)
-    result = patcher.start()
-    request.addfinalizer(patcher.stop)
-    return result
+def title(patch):
+    return patch('h.presenters.AnnotationHTMLPresenter.title',
+                 autospec=None,
+                 new_callable=mock.PropertyMock)
 
 
 @pytest.fixture
-def link_text(request):
-    patcher = mock.patch(
-        'h.presenters.AnnotationHTMLPresenter.link_text',
-        new_callable=mock.PropertyMock)
-    result = patcher.start()
-    request.addfinalizer(patcher.stop)
-    return result
+def link_text(patch):
+    return patch('h.presenters.AnnotationHTMLPresenter.link_text',
+                 autospec=None,
+                 new_callable=mock.PropertyMock)
 
 
 @pytest.fixture
-def href(request):
-    patcher = mock.patch(
-        'h.presenters.AnnotationHTMLPresenter.href',
-        new_callable=mock.PropertyMock)
-    result = patcher.start()
-    request.addfinalizer(patcher.stop)
-    return result
+def href(patch):
+    return patch('h.presenters.AnnotationHTMLPresenter.href',
+                 autospec=None,
+                 new_callable=mock.PropertyMock)
 
 
 @pytest.fixture
-def hostname_or_filename(request):
-    patcher = mock.patch(
-        'h.presenters.AnnotationHTMLPresenter.hostname_or_filename',
-        new_callable=mock.PropertyMock)
-    result = patcher.start()
-    request.addfinalizer(patcher.stop)
-    return result
+def hostname_or_filename(patch):
+    return patch('h.presenters.AnnotationHTMLPresenter.hostname_or_filename',
+                 autospec=None,
+                 new_callable=mock.PropertyMock)

--- a/h/test/queue_test.py
+++ b/h/test/queue_test.py
@@ -203,9 +203,6 @@ def test_resolve_topic_raises_if_namespace_and_topic_both_given():
                             settings={'nsq.namespace': 'prefix'})
 
 
-@pytest.fixture(scope='module', autouse=True)
-def fake_reader(request):
-    patcher = patch('gnsq.Reader', new_callable=lambda: FakeReader)
-    klass = patcher.start()
-    request.addfinalizer(patcher.stop)
-    return klass
+@pytest.fixture(autouse=True)
+def fake_reader(patch):
+    return patch('gnsq.Reader', autospec=None, new_callable=lambda: FakeReader)

--- a/h/views/test/client_test.py
+++ b/h/views/test/client_test.py
@@ -51,17 +51,12 @@ def test_annotator_token_returns_token(generate_jwt):
 
 
 @pytest.fixture
-def generate_jwt(request):
-    patcher = mock.patch('h.views.client.generate_jwt', autospec=True)
-    func = patcher.start()
+def generate_jwt(patch):
+    func = patch('h.views.client.generate_jwt')
     func.return_value = 'abc123'
-    request.addfinalizer(patcher.stop)
     return func
 
 
 @pytest.fixture
-def session(request):
-    patcher = mock.patch('h.views.client.session', autospec=True)
-    module = patcher.start()
-    request.addfinalizer(patcher.stop)
-    return module
+def session(patch):
+    return patch('h.views.client.session')

--- a/h/views/test/main_test.py
+++ b/h/views/test/main_test.py
@@ -48,18 +48,14 @@ def test_og_no_document(render_app_html):
 
 
 @pytest.fixture
-def annotation_document(request):
-    patcher = patch('h.api.models.annotation.Annotation.document',
-                    new_callable=PropertyMock)
-    prop = patcher.start()
-    request.addfinalizer(patcher.stop)
-    return prop
+def annotation_document(patch):
+    return patch('h.api.models.annotation.Annotation.document',
+                 autospec=None,
+                 new_callable=PropertyMock)
 
 
 @pytest.fixture
-def document_title(request):
-    patcher = patch('h.api.models.document.Document.title',
-                    new_callable=PropertyMock)
-    prop = patcher.start()
-    request.addfinalizer(patcher.stop)
-    return prop
+def document_title(patch):
+    return patch('h.api.models.document.Document.title',
+                 autospec=None,
+                 new_callable=PropertyMock)


### PR DESCRIPTION
So... Sean made a comment in Slack the other day about [monkeypatch](https://pytest.org/latest/monkeypatch.html), which caused me to look into our tests...  and *boy* had things gotten out of hand.

The same boilerplate has ended up replicated in many, MANY, places in our test code.

This PR extracts the common usecase into a helper called `patch`, which usually reduces the amount of boilerplate needed by a factor of 5 or so.

There are probably more places where we need to examine why we're patching SO MANY THINGS in order to write tests (because that's usually a sign of poor factoring), but at least this stops the madness.