### PR TITLE
Adding page notes line to the sidebar tutorial

### DIFF
--- a/h/templates/client/sidebar_tutorial.html
+++ b/h/templates/client/sidebar_tutorial.html
@@ -11,6 +11,12 @@
     </li>
     <li class="sidebar-tutorial__list-item">
       <p class="sidebar-tutorial__list-item-content">
+        To add a note to the page you are viewing, click the
+        <i class="h-icon-insert-comment"></i>&nbsp;button.
+      </p>
+    </li>
+    <li class="sidebar-tutorial__list-item">
+      <p class="sidebar-tutorial__list-item-content">
         To create a highlight, select text and click the
         <i class="h-icon-border-color"></i>&nbsp;button.
       </p>


### PR DESCRIPTION
Adds an item about page notes to the sidebar tutorial list

![tutorial](https://cloud.githubusercontent.com/assets/6117168/14399740/88348fe8-fda4-11e5-9099-3b19dd5b4fa5.png)
