### PR TITLE
Remove routes_mapper fixture and use configurator routes

### DIFF
--- a/h/accounts/views.py
+++ b/h/accounts/views.py
@@ -141,6 +141,11 @@ class AuthController(object):
                renderer='json')
 class AjaxAuthController(AuthController):
 
+    def __init__(self, request):
+        self.request = request
+        self.schema = schemas.LoginSchema().bind(request=self.request)
+        self.form = deform.Form(self.schema)
+
     @view_config(request_param='__formid__=login')
     def login(self):
         try:

--- a/h/api/test/presenters_test.py
+++ b/h/api/test/presenters_test.py
@@ -16,11 +16,8 @@ from h.api.presenters import add_annotation_link_generator
 from h.api.presenters import utc_iso8601, deep_merge_dict
 
 
+@pytest.mark.usefixtures('routes')
 class TestAnnotationBasePresenter(object):
-
-    @pytest.fixture(autouse=True)
-    def link_routes(self, routes_mapper):
-        routes_mapper.add_route('api.annotation', '/dummy/abc123')
 
     def test_constructor_args(self):
         request = DummyRequest()
@@ -160,6 +157,11 @@ class TestAnnotationBasePresenter(object):
         actual = AnnotationJSONPresenter(request, ann).target
         assert expected == actual
 
+    @pytest.fixture
+    def routes(self, config):
+        config.add_route('api.annotation', '/dummy/:id')
+
+
 
 class TestAnnotationJSONPresenter(object):
     def test_asdict(self, document_asdict):
@@ -259,13 +261,8 @@ class TestAnnotationJSONPresenter(object):
         return patch('h.api.presenters.DocumentJSONPresenter.asdict')
 
 
+@pytest.mark.usefixtures('routes')
 class TestAnnotationJSONLDPresenter(object):
-
-    @pytest.fixture(autouse=True)
-    def routes(self, request):
-        config = testing.setUp()
-        config.add_route('annotation', '/ann/{id}')
-        request.addfinalizer(testing.tearDown)
 
     def test_asdict(self):
         request = DummyRequest()
@@ -335,6 +332,12 @@ class TestAnnotationJSONLDPresenter(object):
             'text': 'lion',
             'purpose': 'tagging',
         } in bodies
+
+    @pytest.fixture
+    def routes(self, request):
+        config = testing.setUp()
+        config.add_route('annotation', '/ann/{id}')
+        request.addfinalizer(testing.tearDown)
 
 
 class TestDocumentJSONPresenter(object):

--- a/h/api/test/views_test.py
+++ b/h/api/test/views_test.py
@@ -43,13 +43,12 @@ class TestError(object):
         assert result == {'status': 'failure', 'reason': 'it exploded'}
 
 
-@pytest.mark.usefixtures('routes_mapper')
 class TestIndex(object):
 
-    def test_it_returns_the_right_links(self, routes_mapper):
-        routes_mapper.add_route('api.search', '/dummy/search')
-        routes_mapper.add_route('api.annotations', '/dummy/annotations')
-        routes_mapper.add_route('api.annotation', '/dummy/annotations/:id')
+    def test_it_returns_the_right_links(self, config):
+        config.add_route('api.search', '/dummy/search')
+        config.add_route('api.annotations', '/dummy/annotations')
+        config.add_route('api.annotation', '/dummy/annotations/:id')
 
         result = views.index(testing.DummyResource(), testing.DummyRequest())
 

--- a/h/test/admin_test.py
+++ b/h/test/admin_test.py
@@ -27,8 +27,7 @@ class DummyRequest(_DummyRequest):
 
 
 features_save_fixtures = pytest.mark.usefixtures('Feature',
-                                                 'check_csrf_token',
-                                                 'routes_mapper')
+                                                 'check_csrf_token')
 
 
 @features_save_fixtures
@@ -131,7 +130,7 @@ def test_nipsa_add_returns_index(nipsa_index):
 
 
 # The fixtures required to mock all of nipsa_remove()'s dependencies.
-nipsa_remove_fixtures = pytest.mark.usefixtures('nipsa', 'routes_mapper')
+nipsa_remove_fixtures = pytest.mark.usefixtures('nipsa')
 
 
 @nipsa_remove_fixtures
@@ -235,7 +234,7 @@ def test_admins_add_returns_index_on_NoSuchUserError(make_admin, admins_index):
 
 
 # The fixtures required to mock all of admins_remove()'s dependencies.
-admins_remove_fixtures = pytest.mark.usefixtures('User', 'routes_mapper')
+admins_remove_fixtures = pytest.mark.usefixtures('User')
 
 
 @admins_remove_fixtures
@@ -380,7 +379,7 @@ def test_staff_add_returns_index_on_NoSuchUserError(make_staff, staff_index):
 
 
 # The fixtures required to mock all of staff_remove()'s dependencies.
-staff_remove_fixtures = pytest.mark.usefixtures('User', 'routes_mapper')
+staff_remove_fixtures = pytest.mark.usefixtures('User')
 
 
 @staff_remove_fixtures
@@ -509,9 +508,7 @@ def test_users_index_user_found(User):
     }
 
 
-users_activate_fixtures = pytest.mark.usefixtures('routes_mapper',
-                                                  'User',
-                                                  'events')
+users_activate_fixtures = pytest.mark.usefixtures('User', 'events')
 
 
 @users_activate_fixtures
@@ -595,8 +592,7 @@ def test_users_activate_redirects(User):
     assert isinstance(result, httpexceptions.HTTPFound)
 
 
-users_delete_fixtures = pytest.mark.usefixtures('routes_mapper', 'User',
-                                                'delete_user')
+users_delete_fixtures = pytest.mark.usefixtures('User', 'delete_user')
 
 
 @users_delete_fixtures
@@ -786,6 +782,15 @@ def test_delete_user_deletes_user():
     admin.delete_user(request, user)
 
     request.db.delete.assert_called_once_with(user)
+
+
+@pytest.fixture(autouse=True)
+def routes(config):
+    config.add_route('admin_admins', '/adm/admins')
+    config.add_route('admin_features', '/adm/features')
+    config.add_route('admin_nipsa', '/adm/nipsa')
+    config.add_route('admin_staff', '/adm/staff')
+    config.add_route('admin_users', '/adm/users')
 
 
 @pytest.fixture

--- a/h/test/tweens_test.py
+++ b/h/test/tweens_test.py
@@ -48,6 +48,7 @@ def test_tween_csp_uri():
     request = DummyRequest()
     request.registry.settings.update({
         'csp.enabled': True,
+        'csp.report_only': False,
         'csp': {'report-uri': ['localhost']},
     })
     tween = tweens.content_security_policy_tween_factory(
@@ -64,6 +65,7 @@ def test_tween_csp_header():
     request = DummyRequest()
     request.registry.settings.update({
         "csp.enabled": True,
+        "csp.report_only": False,
         "csp": {
             "font-src": ["'self'", "fonts.gstatic.com"],
             "report-uri": ['localhost'],


### PR DESCRIPTION
Some of our tests, mostly views tests, need the pyramid application to be configured with a routes mapper so that `request.route_path` and `request.route_url` work as expected.

We had a clunky fixture, `routes_mapper`, which provided a dummy route mapper, but it's actually cleaner and easier to use the proper Pyramid routes mapper, which is set up by `pyramid.testing.setUp`. All that is required is that tests explicitly defined the routes they expect to exist using `config.add_route`.

This commit removes `routes_mapper` and also cleans up the fixture definitions so that we're not calling `pyramid.testing.setUp` for every test unconditionally. In my testing this knocks 5-6 seconds (25-30%) off test suite runtime.