### PR TITLE
Add the skeleton of a functional test suite

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -14,6 +14,7 @@ graft h/migrations
 graft h/static
 graft h/templates
 graft scripts
+prune tests
 graft vendor
 global-exclude __pycache__
 global-exclude *.py[co]

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,6 @@
+Functional and integrated tests
+===============================
+
+This directory contains functional and integrated tests for the `h` application.
+Unit tests live alongside the code they test in `test` directories, and should
+not be added here.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+
+import os
+
+import pytest
+from webtest import TestApp
+
+TEST_SETTINGS = {
+    'es.host': os.environ.get('ELASTICSEARCH_HOST', 'http://localhost:9200'),
+    'es.index': 'hypothesis-test',
+    'legacy.es.index': 'annotator-test',
+    'h.db.should_create_all': True,
+    'h.db.should_drop_all': True,
+    'h.search.autoconfig': True,
+    'pyramid.includes': 'h.session',
+    'sqlalchemy.url': os.environ.get('TEST_DATABASE_URL',
+                                     'postgresql://postgres@localhost/htest')
+}
+
+
+@pytest.fixture
+def config():
+    from h.config import configure
+    _drop_indices(settings=TEST_SETTINGS)
+    config = configure(settings=TEST_SETTINGS)
+    config.include('h.app')
+    return config
+
+
+@pytest.fixture
+def app(config):
+    return TestApp(config.make_wsgi_app())
+
+
+def _drop_indices(settings):
+    import elasticsearch
+
+    conn = elasticsearch.Elasticsearch([settings['es.host']])
+
+    for name in [settings['es.index'], settings['legacy.es.index']]:
+        if conn.indices.exists(index=name):
+            conn.indices.delete(index=name)

--- a/tests/functional/test_api.py
+++ b/tests/functional/test_api.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+
+
+@pytest.mark.functional
+class TestAPI(object):
+    def test_annotation_read(self, app, annotation):
+        """Fetch an annotation by ID."""
+        res = app.get('/api/annotations/' + annotation.id,
+                      headers={'accept': 'application/json'})
+        data = res.json
+        assert data['id'] == annotation.id
+
+    def test_annotation_read_jsonld(self, app, annotation):
+        """Fetch an annotation by ID in jsonld format."""
+        res = app.get('/api/annotations/' + annotation.id + '.jsonld')
+        data = res.json
+        assert data['@context'] == 'http://www.w3.org/ns/anno.jsonld'
+        assert data['id'] == 'http://localhost/a/' + annotation.id
+
+
+@pytest.fixture
+def annotation(config):
+    from h.api.models.elastic import Annotation
+    ann = Annotation({
+        'created': '2016-01-01T00:00:00.000000+00:00',
+        'updated': '2016-01-01T00:00:00.000000+00:00',
+        'user': 'acct:testuser@localhost',
+        'target': [{'source': 'http://foobar.com', 'selector': []}],
+        'text': 'My test annotation',
+        'permissions': {'read': ['group:__world__'],
+                        'update': ['acct:testuser@localhost'],
+                        'delete': ['acct:testuser@localhost'],
+                        'admin': ['acct:testuser@localhost']},
+    })
+    ann.save()
+    return ann

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist = py27
 [pytest]
 minversion = 2.8
 addopts = --pyargs
-testpaths = h
+testpaths = h tests
 
 [testenv]
 deps =
@@ -14,7 +14,18 @@ deps =
     pytest
 passenv =
     TEST_DATABASE_URL
+# N.B. This runs unit tests only. Functional test suites are not currently run
+# automatically.
 commands = coverage run -m pytest {posargs:h}
+
+[testenv:functional]
+deps =
+    pytest
+    webtest
+passenv =
+    ELASTICSEARCH_HOST
+    TEST_DATABASE_URL
+commands = py.test {posargs:tests/functional/}
 
 [testenv:clean]
 deps = coverage


### PR DESCRIPTION
This commit adds the basic components of a functional test suite, which tests the entire WSGI application as one unit.

These tests currently do not run on Travis. It's likely we won't want them to run on Travis long-term, as it's likely the functional test suite will end up rather slow. For now, they can be run manually with

    tox -e functional