### PR TITLE
Displaying local file names in the Groups document list

### DIFF
--- a/h/api/models/elastic.py
+++ b/h/api/models/elastic.py
@@ -254,7 +254,14 @@ class Document(document.Document):
 
     @property
     def title(self):
-        return self.get('title')
+        value = self.get('title')
+        if isinstance(value, list):
+            try:
+                return value[0]
+            except IndexError:
+                return None
+
+        return value
 
     @property
     def meta(self):

--- a/h/api/models/test/elastic_test.py
+++ b/h/api/models/test/elastic_test.py
@@ -300,6 +300,18 @@ class TestDocument(object):
         doc = Document({}, updated=datetime.datetime(2016, 2, 25, 16, 45, 23, 371848))
         assert doc.updated == datetime.datetime(2016, 2, 25, 16, 45, 23, 371848)
 
+    def test_title(self):
+        doc = Document({'title': 'Example Page'})
+        assert doc.title == 'Example Page'
+
+    def test_title_array(self):
+        doc = Document({'title': ['Example Page']})
+        assert doc.title == 'Example Page'
+
+    def test_title_empty_array(seld):
+        doc = Document({'title': []})
+        assert doc.title is None
+
     def test_meta(self):
         doc = Document({'og': {'title': ['Example Page'], 'url': ['http://example.com']},
                         'title': ['Example Page'],

--- a/h/static/styles/group-form.scss
+++ b/h/static/styles/group-form.scss
@@ -105,6 +105,11 @@
 
     &__list li {
       margin-bottom: 1.5em;
+
+      em {
+        font-style: italic;
+        color: $color-silver-chalice;
+      }
     }
 
   }


### PR DESCRIPTION
Changes how local files are being displayed to:
![2016-04-11-183100_481x438_scrot](https://cloud.githubusercontent.com/assets/112063/14434533/92ae8444-0013-11e6-996b-7d5d43b50000.png)

1. Local file without a title
1. Link with no title
1. Local file with a title
1. ...