### PR TITLE
Markdown editor input refactor and additional tests

### DIFF
--- a/h/static/scripts/directive/annotation.js
+++ b/h/static/scripts/directive/annotation.js
@@ -713,6 +713,10 @@ function AnnotationController(
     $scope.$digest();
   };
 
+  vm.setText = function (text) {
+    vm.form.text = text;
+  };
+
   init();
 }
 

--- a/h/static/scripts/directive/markdown.js
+++ b/h/static/scripts/directive/markdown.js
@@ -251,7 +251,6 @@ module.exports = function($filter, $sanitize) {
       readOnly: '<',
       text: '<?',
       onEditText: '&',
-      required: '@',
     },
     template: require('../../../templates/client/markdown.html'),
   };

--- a/h/static/scripts/directive/test/util.js
+++ b/h/static/scripts/directive/test/util.js
@@ -96,8 +96,8 @@ function createDirective(document, name, attrs, initialScope, initialHtml, opts)
   opts = opts || {};
   opts.parentElement = opts.parentElement || document.body;
 
-  // create a template consisting of a single element, the directive
-  // we want to create and compile it
+  // Create a template consisting of a single element, the directive
+  // we want to create and compile it.
   var $compile;
   var $scope;
   angular.mock.inject(function (_$compile_, _$rootScope_) {
@@ -109,15 +109,20 @@ function createDirective(document, name, attrs, initialScope, initialHtml, opts)
     var attrName = hyphenate(key);
     var attrKey = key;
     if (typeof attrs[key] === 'function') {
+      // If the input property is a function, generate a function expression,
+      // eg. `<my-component on-event="onEvent()">`
       attrKey += '()';
     } else if (attrs[key].callback) {
+      // If the input property is a function which accepts arguments,
+      // generate the argument list.
+      // eg. `<my-component on-change="onChange(newValue)">`
       attrKey += '(' + attrs[key].args.join(',') + ')';
     }
     templateElement.setAttribute(attrName, attrKey);
   });
   templateElement.innerHTML = initialHtml;
 
-  // add the element to the document's body so that
+  // Add the element to the document's body so that
   // it responds to events, becomes visible, reports correct
   // values for its dimensions etc.
   opts.parentElement.appendChild(templateElement);

--- a/h/templates/client/annotation.html
+++ b/h/templates/client/annotation.html
@@ -80,7 +80,8 @@
              collapsed-height="400"
              overflow-hysteresis="20"
              content-data="vm.form.text">
-      <markdown ng-model="vm.form.text"
+      <markdown text="vm.form.text"
+                on-edit-text="vm.setText(text)"
                 read-only="!vm.editing()">
       </markdown>
     </excerpt>

--- a/h/templates/client/markdown.html
+++ b/h/templates/client/markdown.html
@@ -15,8 +15,7 @@
 </div>
 <textarea class="form-input form-textarea js-markdown-input"
           ng-show="showEditor()"
-          ng-click="$event.stopPropagation()"
-          ng-required="required"></textarea>
+          ng-click="$event.stopPropagation()"></textarea>
 <div class="styled-text js-markdown-preview"
      ng-class="preview && 'markdown-preview'"
      ng-dblclick="togglePreview()"

--- a/h/templates/client/markdown.html
+++ b/h/templates/client/markdown.html
@@ -1,4 +1,4 @@
-<div ng-hide="readOnly" class="markdown-tools" ng-class="preview && 'disable'">
+<div ng-if="!readOnly" class="markdown-tools" ng-class="preview && 'disable'">
   <span class="markdown-preview-toggle">
     <a class="markdown-tools-badge h-icon-markdown" href="https://help.github.com/articles/markdown-basics" title="Parsed as Markdown" target="_blank"></a>
     <a href="" class="markdown-tools-toggle" ng-click="togglePreview()" ng-show="!preview">Preview</a>
@@ -14,7 +14,10 @@
   <i class="h-icon-format-list-bulleted markdown-tools-button" ng-click="insertList()" title="Insert list"></i>
 </div>
 <textarea class="form-input form-textarea js-markdown-input"
-          ng-hide="readOnly || preview"
+          ng-show="showEditor()"
           ng-click="$event.stopPropagation()"
           ng-required="required"></textarea>
-<div class="styled-text js-markdown-preview" ng-class="preview && 'markdown-preview'" ng-dblclick="togglePreview()" ng-show="readOnly || preview"></div>
+<div class="styled-text js-markdown-preview"
+     ng-class="preview && 'markdown-preview'"
+     ng-dblclick="togglePreview()"
+     ng-show="!showEditor()"></div>


### PR DESCRIPTION
This is some cleanup of the markdown editor and additional tests:

- Change the `<markdown>` component to use the same data-in/events-out pattern as other recently written components by replacing the `ng-model` input with a `text` input property and `on-edit-text` output. This simplifies the implementation as well, which was effectively bypassing `ng-model`'s two-way binding in any case.
- Add tests for the previewing state
- Add tests for what is rendered when the annotation has no body
- Remove the unused 'required' input