### PR TITLE
Add Postgres UpdateAnnotationSchema

### DIFF
--- a/h/api/schemas.py
+++ b/h/api/schemas.py
@@ -307,6 +307,26 @@ class LegacyCreateAnnotationSchema(object):
 
 class UpdateAnnotationSchema(object):
 
+    """Validate the POSTed data of an update annotation request."""
+
+    def __init__(self, request, annotation):
+        self.request = request
+        self.annotation = annotation
+        self.structure = AnnotationSchema(request)
+
+    def validate(self, data):
+        appstruct = self.structure.validate(data)
+
+        if appstruct['groupid'] != self.annotation.groupid:
+            raise ValidationError('group: ' + _("You can't move annotations "
+                                                "between groups"))
+
+        return appstruct
+
+
+
+class LegacyUpdateAnnotationSchema(object):
+
     """
     Validate the payload from a user when updating an annotation.
     """

--- a/h/api/schemas.py
+++ b/h/api/schemas.py
@@ -161,6 +161,68 @@ class AnnotationSchema(JSONSchema):
         ],
     }
 
+    def __init__(self, request):
+        super(AnnotationSchema, self).__init__()
+        self.request = request
+
+    def validate(self, data):
+        appstruct = super(AnnotationSchema, self).validate(data)
+
+        new_appstruct = {}
+
+        # Some fields are not to be set by the user, ignore them.
+        for field in PROTECTED_FIELDS:
+            appstruct.pop(field, None)
+
+        new_appstruct['userid'] = self.request.authenticated_userid
+        new_appstruct['target_uri'] = appstruct.pop('uri', u'')
+        new_appstruct['text'] = appstruct.pop('text', u'')
+        new_appstruct['tags'] = appstruct.pop('tags', [])
+
+        # Replace the client's complex permissions object with a simple shared
+        # boolean.
+        if appstruct.pop('permissions')['read'] == [new_appstruct['userid']]:
+            new_appstruct['shared'] = False
+        else:
+            new_appstruct['shared'] = True
+
+        # The 'target' dict that the client sends is replaced with a single
+        # annotation.target_selectors whose value is the first selector in
+        # the client'ss target.selectors list.
+        # Anything else in the target dict, and any selectors after the first,
+        # are discarded.
+        target = appstruct.pop('target', [])
+        if target:  # Replies and page notes don't have 'target'.
+            target = target[0]  # Multiple targets are ignored.
+            new_appstruct['target_selectors'] = target['selector']
+
+        new_appstruct['groupid'] = appstruct.pop('group', u'__world__')
+        new_appstruct['references'] = appstruct.pop('references', [])
+
+        # Replies always get the same groupid as their parent. The parent's
+        # groupid is added to the reply annotation later by the storage code.
+        # Here we just delete any group sent by the client from replies.
+        if new_appstruct['references'] and 'groupid' in new_appstruct:
+            del new_appstruct['groupid']
+
+        new_appstruct['extra'] = appstruct
+
+        # Transform the "document" dict that the client posts into a convenient
+        # format for creating DocumentURI and DocumentMeta objects later.
+        document_data = appstruct.pop('document', {})
+        document_uri_dicts = parse_document_claims.document_uris_from_data(
+            copy.deepcopy(document_data),
+            claimant=new_appstruct['target_uri'])
+        document_meta_dicts = parse_document_claims.document_metas_from_data(
+            copy.deepcopy(document_data),
+            claimant=new_appstruct['target_uri'])
+        new_appstruct['document'] = {
+            'document_uri_dicts': document_uri_dicts,
+            'document_meta_dicts': document_meta_dicts
+        }
+
+        return new_appstruct
+
 
 class LegacyAnnotationSchema(JSONSchema):
 
@@ -202,68 +264,10 @@ class CreateAnnotationSchema(object):
     """Validate the POSTed data of a create annotation request."""
 
     def __init__(self, request):
-        self.request = request
-        self.structure = AnnotationSchema()
+        self.structure = AnnotationSchema(request)
 
     def validate(self, data):
-        appstruct = self.structure.validate(data)
-
-        new_appstruct = {}
-
-        # Some fields are not to be set by the user, ignore them.
-        for field in PROTECTED_FIELDS:
-            appstruct.pop(field, None)
-
-        new_appstruct['userid'] = self.request.authenticated_userid
-
-        new_appstruct['target_uri'] = appstruct.pop('uri', u'')
-        new_appstruct['text'] = appstruct.pop('text', u'')
-        new_appstruct['tags'] = appstruct.pop('tags', [])
-
-        # Replace the client's complex permissions object with a simple shared
-        # boolean.
-        if appstruct.pop('permissions')['read'] == [new_appstruct['userid']]:
-            new_appstruct['shared'] = False
-        else:
-            new_appstruct['shared'] = True
-
-        # The 'target' dict that the client sends is replaced with a single
-        # annotation.target_selectors whose value is the first selector in
-        # the client'ss target.selectors list.
-        # Anything else in the target dict, and any selectors after the first,
-        # are discarded.
-        target = appstruct.pop('target', [])
-        if target:  # Replies and page notes don't have 'target'.
-            target = target[0]  # Multiple targets are ignored.
-            new_appstruct['target_selectors'] = target['selector']
-
-        new_appstruct['groupid'] = appstruct.pop('group', u'__world__')
-
-        new_appstruct['references'] = appstruct.pop('references', [])
-
-        # Replies always get the same groupid as their parent. The parent's
-        # groupid is added to the reply annotation later by the storage code.
-        # Here we just delete any group sent by the client from replies.
-        if new_appstruct['references'] and 'groupid' in new_appstruct:
-            del new_appstruct['groupid']
-
-        new_appstruct['extra'] = appstruct
-
-        # Transform the "document" dict that the client posts into a convenient
-        # format for creating DocumentURI and DocumentMeta objects later.
-        document_data = appstruct.pop('document', {})
-        document_uri_dicts = parse_document_claims.document_uris_from_data(
-            copy.deepcopy(document_data),
-            claimant=new_appstruct['target_uri'])
-        document_meta_dicts = parse_document_claims.document_metas_from_data(
-            copy.deepcopy(document_data),
-            claimant=new_appstruct['target_uri'])
-        new_appstruct['document'] = {
-            'document_uri_dicts': document_uri_dicts,
-            'document_meta_dicts': document_meta_dicts
-        }
-
-        return new_appstruct
+        return self.structure.validate(data)
 
 
 class LegacyCreateAnnotationSchema(object):

--- a/h/api/test/schemas_test.py
+++ b/h/api/test/schemas_test.py
@@ -825,7 +825,7 @@ class TestCreateAnnotationSchema(object):
 
     def test_it_passes_input_to_AnnotationSchema_validator(self,
                                                            AnnotationSchema):
-        schema = schemas.CreateAnnotationSchema(mock.Mock())
+        schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
 
         schema.validate(mock.sentinel.input_data)
 
@@ -836,7 +836,7 @@ class TestCreateAnnotationSchema(object):
                                                            AnnotationSchema):
         AnnotationSchema.return_value.validate.side_effect = (
             schemas.ValidationError('asplode'))
-        schema = schemas.CreateAnnotationSchema(mock.Mock())
+        schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
 
         with pytest.raises(schemas.ValidationError):
             schema.validate({'foo': 'bar'})

--- a/h/api/test/schemas_test.py
+++ b/h/api/test/schemas_test.py
@@ -409,9 +409,7 @@ class TestAnnotationSchema(object):
     def test_it_removes_protected_fields(self, field):
         schema = schemas.AnnotationSchema(testing.DummyRequest())
 
-        result = schema.validate(
-            self.annotation_data(field='something forbidden'),
-        )
+        result = schema.validate(annotation_data(field='something forbidden'))
 
         assert field not in result
 
@@ -420,7 +418,7 @@ class TestAnnotationSchema(object):
             'acct:harriet@example.com')
         schema = schemas.AnnotationSchema(testing.DummyRequest())
 
-        result = schema.validate(self.annotation_data())
+        result = schema.validate(annotation_data())
 
         assert result['userid'] == 'acct:harriet@example.com'
 
@@ -428,7 +426,7 @@ class TestAnnotationSchema(object):
         schema = schemas.AnnotationSchema(testing.DummyRequest())
 
         result = schema.validate(
-            self.annotation_data(uri='http://example.com/example'),
+            annotation_data(uri='http://example.com/example'),
         )
 
         assert result['target_uri'] == 'http://example.com/example'
@@ -437,7 +435,7 @@ class TestAnnotationSchema(object):
     def test_it_inserts_empty_string_if_data_has_no_uri(self):
         schema = schemas.AnnotationSchema(testing.DummyRequest())
 
-        data = self.annotation_data()
+        data = annotation_data()
         assert 'uri' not in data
 
         assert schema.validate(data)['target_uri'] == ''
@@ -445,15 +443,14 @@ class TestAnnotationSchema(object):
     def test_it_keeps_text(self):
         schema = schemas.AnnotationSchema(testing.DummyRequest())
 
-        result = schema.validate(
-            self.annotation_data(text='some annotation text'))
+        result = schema.validate(annotation_data(text='some annotation text'))
 
         assert result['text'] == 'some annotation text'
 
     def test_it_inserts_empty_string_if_data_contains_no_text(self):
         schema = schemas.AnnotationSchema(testing.DummyRequest())
 
-        data = self.annotation_data()
+        data = annotation_data()
         assert 'text' not in data
 
         assert schema.validate(data)['text'] == ''
@@ -461,15 +458,14 @@ class TestAnnotationSchema(object):
     def test_it_keeps_tags(self):
         schema = schemas.AnnotationSchema(testing.DummyRequest())
 
-        result = schema.validate(
-            self.annotation_data(tags=['foo', 'bar']))
+        result = schema.validate(annotation_data(tags=['foo', 'bar']))
 
         assert result['tags'] == ['foo', 'bar']
 
     def test_it_inserts_empty_list_if_data_contains_no_tags(self):
         schema = schemas.AnnotationSchema(testing.DummyRequest())
 
-        data = self.annotation_data()
+        data = annotation_data()
         assert 'tags' not in data
 
         assert schema.validate(data)['tags'] == []
@@ -482,7 +478,7 @@ class TestAnnotationSchema(object):
         schema = schemas.AnnotationSchema(testing.DummyRequest())
 
         result = schema.validate(
-            self.annotation_data(
+            annotation_data(
                 permissions={'read': ['acct:harriet@example.com']},
             ),
         )
@@ -498,7 +494,7 @@ class TestAnnotationSchema(object):
         schema = schemas.AnnotationSchema(testing.DummyRequest())
 
         result = schema.validate(
-            self.annotation_data(
+            annotation_data(
                 permissions={'read': ['group:__world__']},
             ),
         )
@@ -509,7 +505,7 @@ class TestAnnotationSchema(object):
     def test_it_does_not_crash_if_data_contains_no_target(self):
         schema = schemas.AnnotationSchema(testing.DummyRequest())
 
-        data = self.annotation_data()
+        data = annotation_data()
         assert 'target' not in data
 
         schema.validate(data)
@@ -518,7 +514,7 @@ class TestAnnotationSchema(object):
         schema = schemas.AnnotationSchema(testing.DummyRequest())
 
         result = schema.validate(
-            self.annotation_data(
+            annotation_data(
                 target=[
                     {
                         'foo': 'bar',  # This should be removed,
@@ -534,7 +530,7 @@ class TestAnnotationSchema(object):
     def test_it_renames_group_to_groupid(self):
         schema = schemas.AnnotationSchema(testing.DummyRequest())
 
-        result = schema.validate(self.annotation_data(group='foo'))
+        result = schema.validate(annotation_data(group='foo'))
 
         assert result['groupid'] == 'foo'
         assert 'group' not in result
@@ -542,7 +538,7 @@ class TestAnnotationSchema(object):
     def test_it_inserts_default_groupid_if_no_group(self):
         schema = schemas.AnnotationSchema(testing.DummyRequest())
 
-        data = self.annotation_data()
+        data = annotation_data()
         assert 'group' not in data
 
         result = schema.validate(data)
@@ -553,14 +549,14 @@ class TestAnnotationSchema(object):
         schema = schemas.AnnotationSchema(testing.DummyRequest())
 
         result = schema.validate(
-            self.annotation_data(references=['parent id', 'parent id 2']))
+            annotation_data(references=['parent id', 'parent id 2']))
 
         assert result['references'] == ['parent id', 'parent id 2']
 
     def test_it_inserts_empty_list_if_no_references(self):
         schema = schemas.AnnotationSchema(testing.DummyRequest())
 
-        data = self.annotation_data()
+        data = annotation_data()
         assert 'references' not in data
 
         result = schema.validate(data)
@@ -571,7 +567,7 @@ class TestAnnotationSchema(object):
         schema = schemas.AnnotationSchema(testing.DummyRequest())
 
         result = schema.validate(
-            self.annotation_data(
+            annotation_data(
                 group='foo',
                 references=['parent annotation id'],
             )
@@ -610,7 +606,7 @@ class TestAnnotationSchema(object):
         schema = schemas.AnnotationSchema(testing.DummyRequest())
 
         schema.validate(
-            self.annotation_data(
+            annotation_data(
                 document=document_data,
                 uri=target_uri,
             )
@@ -624,7 +620,7 @@ class TestAnnotationSchema(object):
     def test_it_puts_document_uris_in_appstruct(self, parse_document_claims):
         schema = schemas.AnnotationSchema(testing.DummyRequest())
 
-        appstruct = schema.validate(self.annotation_data())
+        appstruct = schema.validate(annotation_data())
 
         assert appstruct['document']['document_uri_dicts'] == (
             parse_document_claims.document_uris_from_data.return_value)
@@ -635,7 +631,7 @@ class TestAnnotationSchema(object):
         target_uri = 'http://example.com/example'
 
         schema.validate(
-            self.annotation_data(
+            annotation_data(
                 document=document_data,
                 uri=target_uri,
             )
@@ -670,7 +666,7 @@ class TestAnnotationSchema(object):
             document_uris_from_data)
         schema = schemas.AnnotationSchema(testing.DummyRequest())
 
-        schema.validate(self.annotation_data(document=document))
+        schema.validate(annotation_data(document=document))
 
         assert (
             parse_document_claims.document_metas_from_data.call_args[0][0] ==
@@ -679,7 +675,7 @@ class TestAnnotationSchema(object):
     def test_it_puts_document_metas_in_appstruct(self, parse_document_claims):
         schema = schemas.AnnotationSchema(testing.DummyRequest())
 
-        appstruct = schema.validate(self.annotation_data())
+        appstruct = schema.validate(annotation_data())
 
         assert appstruct['document']['document_meta_dicts'] == (
             parse_document_claims.document_metas_from_data.return_value)
@@ -695,7 +691,7 @@ class TestAnnotationSchema(object):
         schema = schemas.AnnotationSchema(testing.DummyRequest())
 
         appstruct = schema.validate(
-            self.annotation_data(
+            annotation_data(
                 document={
                     'foo': 'bar'  # This should be deleted.
                 },
@@ -703,16 +699,6 @@ class TestAnnotationSchema(object):
         )
 
         assert 'foo' not in appstruct['document']
-
-    def annotation_data(self, **kwargs):
-        """Return test input data for AnnotationSchema.validate()."""
-        data = {
-            'permissions': {
-                'read': []
-            }
-        }
-        data.update(kwargs)
-        return data
 
     @pytest.fixture
     def parse_document_claims(self, patch):
@@ -858,19 +844,8 @@ class TestCreateAnnotationSchema(object):
     @pytest.fixture
     def AnnotationSchema(self, patch):
         cls = patch('h.api.schemas.AnnotationSchema')
-        cls.return_value.validate.return_value = self.annotation_data()
+        cls.return_value.validate.return_value = annotation_data()
         return cls
-
-    def annotation_data(self, **kwargs):
-        """Return test input data for AnnotationSchema.validate()."""
-        data = {
-            'permissions': {
-                'read': []
-            }
-        }
-        data.update(kwargs)
-        return data
-
 
 
 class TestUpdateAnnotationSchema(object):
@@ -984,3 +959,13 @@ class TestUpdateAnnotationSchema(object):
 
         for k in data:
             assert result[k] == data[k]
+
+def annotation_data(**kwargs):
+    """Return test input data for AnnotationSchema.validate()."""
+    data = {
+        'permissions': {
+            'read': []
+        }
+    }
+    data.update(kwargs)
+    return data

--- a/h/api/test/schemas_test.py
+++ b/h/api/test/schemas_test.py
@@ -42,13 +42,13 @@ class TestJSONSchema(object):
 class TestAnnotationSchema(object):
 
     def test_it_does_not_raise_for_minimal_valid_data(self):
-        schema = schemas.AnnotationSchema()
+        schema = schemas.AnnotationSchema(testing.DummyRequest())
 
         # Use only the required fields.
         schema.validate(self.valid_input_data())
 
     def test_it_does_not_raise_for_full_valid_data(self):
-        schema = schemas.AnnotationSchema()
+        schema = schemas.AnnotationSchema(testing.DummyRequest())
 
         # Use all the keys to make sure that valid data for all of them passes.
         schema.validate({
@@ -92,7 +92,7 @@ class TestAnnotationSchema(object):
         })
 
     def test_it_raises_if_document_is_not_a_dict(self):
-        schema = schemas.AnnotationSchema()
+        schema = schemas.AnnotationSchema(testing.DummyRequest())
 
         with pytest.raises(schemas.ValidationError) as err:
             schema.validate(self.valid_input_data(
@@ -102,7 +102,7 @@ class TestAnnotationSchema(object):
         assert str(err.value) == "document: False is not of type 'object'"
 
     def test_it_raises_if_document_dc_is_not_a_dict(self):
-        schema = schemas.AnnotationSchema()
+        schema = schemas.AnnotationSchema(testing.DummyRequest())
 
         with pytest.raises(schemas.ValidationError) as err:
             schema.validate(self.valid_input_data(
@@ -112,7 +112,7 @@ class TestAnnotationSchema(object):
         assert str(err.value) == "document.dc: False is not of type 'object'"
 
     def test_it_raises_if_document_dc_identifier_is_not_a_list(self):
-        schema = schemas.AnnotationSchema()
+        schema = schemas.AnnotationSchema(testing.DummyRequest())
 
         with pytest.raises(schemas.ValidationError) as err:
             schema.validate(self.valid_input_data(
@@ -123,7 +123,7 @@ class TestAnnotationSchema(object):
             "document.dc.identifier: False is not of type 'array'")
 
     def test_it_raises_if_document_dc_identifier_item_is_not_a_string(self):
-        schema = schemas.AnnotationSchema()
+        schema = schemas.AnnotationSchema(testing.DummyRequest())
 
         with pytest.raises(schemas.ValidationError) as err:
             schema.validate(self.valid_input_data(
@@ -134,7 +134,7 @@ class TestAnnotationSchema(object):
             "document.dc.identifier.0: False is not of type 'string'")
 
     def test_it_raises_if_document_highwire_is_not_a_dict(self):
-        schema = schemas.AnnotationSchema()
+        schema = schemas.AnnotationSchema(testing.DummyRequest())
 
         with pytest.raises(schemas.ValidationError) as err:
             schema.validate(self.valid_input_data(
@@ -145,7 +145,7 @@ class TestAnnotationSchema(object):
             "document.highwire: False is not of type 'object'")
 
     def test_it_raises_if_document_highwire_doi_is_not_a_list(self):
-        schema = schemas.AnnotationSchema()
+        schema = schemas.AnnotationSchema(testing.DummyRequest())
 
         with pytest.raises(schemas.ValidationError) as err:
             schema.validate(self.valid_input_data(
@@ -156,7 +156,7 @@ class TestAnnotationSchema(object):
             "document.highwire.doi: False is not of type 'array'")
 
     def test_it_raises_if_document_highwire_doi_item_is_not_a_string(self):
-        schema = schemas.AnnotationSchema()
+        schema = schemas.AnnotationSchema(testing.DummyRequest())
 
         with pytest.raises(schemas.ValidationError) as err:
             schema.validate(self.valid_input_data(
@@ -167,7 +167,7 @@ class TestAnnotationSchema(object):
             "document.highwire.doi.0: False is not of type 'string'")
 
     def test_it_raises_if_document_link_is_not_a_list(self):
-        schema = schemas.AnnotationSchema()
+        schema = schemas.AnnotationSchema(testing.DummyRequest())
 
         with pytest.raises(schemas.ValidationError) as err:
             schema.validate(self.valid_input_data(
@@ -177,7 +177,7 @@ class TestAnnotationSchema(object):
         assert str(err.value) == "document.link: False is not of type 'array'"
 
     def test_it_raises_if_document_link_item_is_not_a_dict(self):
-        schema = schemas.AnnotationSchema()
+        schema = schemas.AnnotationSchema(testing.DummyRequest())
 
         with pytest.raises(schemas.ValidationError) as err:
             schema.validate(self.valid_input_data(
@@ -188,7 +188,7 @@ class TestAnnotationSchema(object):
             "document.link.0: False is not of type 'object'")
 
     def test_it_raises_if_document_link_item_has_no_href(self):
-        schema = schemas.AnnotationSchema()
+        schema = schemas.AnnotationSchema(testing.DummyRequest())
 
         with pytest.raises(schemas.ValidationError) as err:
             schema.validate(self.valid_input_data(
@@ -199,7 +199,7 @@ class TestAnnotationSchema(object):
             "document.link.0: 'href' is a required property")
 
     def test_it_raises_if_document_link_item_href_is_not_a_string(self):
-        schema = schemas.AnnotationSchema()
+        schema = schemas.AnnotationSchema(testing.DummyRequest())
 
         with pytest.raises(schemas.ValidationError) as err:
             schema.validate(self.valid_input_data(
@@ -210,7 +210,7 @@ class TestAnnotationSchema(object):
             "document.link.0.href: False is not of type 'string'")
 
     def test_it_raises_if_document_link_item_type_is_not_a_string(self):
-        schema = schemas.AnnotationSchema()
+        schema = schemas.AnnotationSchema(testing.DummyRequest())
 
         with pytest.raises(schemas.ValidationError) as err:
             schema.validate(self.valid_input_data(
@@ -228,7 +228,7 @@ class TestAnnotationSchema(object):
             "document.link.0.type: False is not of type 'string'")
 
     def test_it_raises_if_group_is_not_a_string(self):
-        schema = schemas.AnnotationSchema()
+        schema = schemas.AnnotationSchema(testing.DummyRequest())
 
         with pytest.raises(schemas.ValidationError) as err:
             schema.validate(self.valid_input_data(
@@ -238,7 +238,7 @@ class TestAnnotationSchema(object):
         assert str(err.value) == "group: False is not of type 'string'"
 
     def test_it_raises_if_permissions_is_missing(self):
-        schema = schemas.AnnotationSchema()
+        schema = schemas.AnnotationSchema(testing.DummyRequest())
         data = self.valid_input_data()
         del data['permissions']
 
@@ -248,7 +248,7 @@ class TestAnnotationSchema(object):
         assert str(err.value) == "'permissions' is a required property"
 
     def test_it_raises_if_permissions_is_not_a_dict(self):
-        schema = schemas.AnnotationSchema()
+        schema = schemas.AnnotationSchema(testing.DummyRequest())
 
         with pytest.raises(schemas.ValidationError) as err:
             schema.validate(self.valid_input_data(
@@ -258,7 +258,7 @@ class TestAnnotationSchema(object):
         assert str(err.value) == "permissions: False is not of type 'object'"
 
     def test_it_raises_if_permissions_has_no_read(self):
-        schema = schemas.AnnotationSchema()
+        schema = schemas.AnnotationSchema(testing.DummyRequest())
 
         with pytest.raises(schemas.ValidationError) as err:
             schema.validate(self.valid_input_data(
@@ -268,7 +268,7 @@ class TestAnnotationSchema(object):
         assert str(err.value) == "permissions: 'read' is a required property"
 
     def test_it_raises_if_permissions_read_is_not_a_list(self):
-        schema = schemas.AnnotationSchema()
+        schema = schemas.AnnotationSchema(testing.DummyRequest())
 
         with pytest.raises(schemas.ValidationError) as err:
             schema.validate(self.valid_input_data(
@@ -279,7 +279,7 @@ class TestAnnotationSchema(object):
             "permissions.read: False is not of type 'array'")
 
     def test_it_raises_if_permissions_read_item_is_not_a_string(self):
-        schema = schemas.AnnotationSchema()
+        schema = schemas.AnnotationSchema(testing.DummyRequest())
 
         with pytest.raises(schemas.ValidationError) as err:
             schema.validate(self.valid_input_data(
@@ -290,7 +290,7 @@ class TestAnnotationSchema(object):
             "permissions.read.0: False is not of type 'string'")
 
     def test_it_raises_if_permissions_read_item_is_wrong_format(self):
-        schema = schemas.AnnotationSchema()
+        schema = schemas.AnnotationSchema(testing.DummyRequest())
 
         with pytest.raises(schemas.ValidationError) as err:
             schema.validate(self.valid_input_data(
@@ -301,7 +301,7 @@ class TestAnnotationSchema(object):
             "permissions.read.0: u'foo' does not match '^(acct:|group:).+$'")
 
     def test_it_raises_if_references_is_not_a_list(self):
-        schema = schemas.AnnotationSchema()
+        schema = schemas.AnnotationSchema(testing.DummyRequest())
 
         with pytest.raises(schemas.ValidationError) as err:
             schema.validate(self.valid_input_data(
@@ -311,7 +311,7 @@ class TestAnnotationSchema(object):
         assert str(err.value) == "references: False is not of type 'array'"
 
     def test_it_raises_if_references_item_is_not_a_string(self):
-        schema = schemas.AnnotationSchema()
+        schema = schemas.AnnotationSchema(testing.DummyRequest())
 
         with pytest.raises(schemas.ValidationError) as err:
             schema.validate(self.valid_input_data(
@@ -321,7 +321,7 @@ class TestAnnotationSchema(object):
         assert str(err.value) == "references.0: False is not of type 'string'"
 
     def test_it_raises_if_tags_is_not_a_list(self):
-        schema = schemas.AnnotationSchema()
+        schema = schemas.AnnotationSchema(testing.DummyRequest())
 
         with pytest.raises(schemas.ValidationError) as err:
             schema.validate(self.valid_input_data(
@@ -331,7 +331,7 @@ class TestAnnotationSchema(object):
         assert str(err.value) == "tags: False is not of type 'array'"
 
     def test_it_raises_if_tags_item_is_not_a_string(self):
-        schema = schemas.AnnotationSchema()
+        schema = schemas.AnnotationSchema(testing.DummyRequest())
 
         with pytest.raises(schemas.ValidationError) as err:
             schema.validate(self.valid_input_data(
@@ -341,7 +341,7 @@ class TestAnnotationSchema(object):
         assert str(err.value) == "tags.0: False is not of type 'string'"
 
     def test_it_raises_if_target_is_not_a_list(self):
-        schema = schemas.AnnotationSchema()
+        schema = schemas.AnnotationSchema(testing.DummyRequest())
 
         with pytest.raises(schemas.ValidationError) as err:
             schema.validate(self.valid_input_data(
@@ -351,7 +351,7 @@ class TestAnnotationSchema(object):
         assert str(err.value) == "target: False is not of type 'array'"
 
     def test_it_raises_if_target_item_is_not_a_dict(self):
-        schema = schemas.AnnotationSchema()
+        schema = schemas.AnnotationSchema(testing.DummyRequest())
 
         with pytest.raises(schemas.ValidationError) as err:
             schema.validate(self.valid_input_data(
@@ -361,7 +361,7 @@ class TestAnnotationSchema(object):
         assert str(err.value) == "target.0: False is not of type 'object'"
 
     def test_it_raises_if_target_has_no_selector(self):
-        schema = schemas.AnnotationSchema()
+        schema = schemas.AnnotationSchema(testing.DummyRequest())
 
         with pytest.raises(schemas.ValidationError) as err:
             schema.validate(self.valid_input_data(
@@ -371,7 +371,7 @@ class TestAnnotationSchema(object):
         assert str(err.value) == "target.0: 'selector' is a required property"
 
     def test_it_raises_if_text_is_not_a_string(self):
-        schema = schemas.AnnotationSchema()
+        schema = schemas.AnnotationSchema(testing.DummyRequest())
 
         with pytest.raises(schemas.ValidationError) as err:
             schema.validate(self.valid_input_data(
@@ -381,7 +381,7 @@ class TestAnnotationSchema(object):
         assert str(err.value) == "text: False is not of type 'string'"
 
     def test_it_raises_if_uri_is_not_a_string(self):
-        schema = schemas.AnnotationSchema()
+        schema = schemas.AnnotationSchema(testing.DummyRequest())
 
         with pytest.raises(schemas.ValidationError) as err:
             schema.validate(self.valid_input_data(
@@ -399,6 +399,324 @@ class TestAnnotationSchema(object):
         }
         data.update(kwargs)
         return data
+
+    @pytest.mark.parametrize('field', [
+        'created',
+        'updated',
+        'user',
+        'id',
+    ])
+    def test_it_removes_protected_fields(self, field):
+        schema = schemas.AnnotationSchema(testing.DummyRequest())
+
+        result = schema.validate(
+            self.annotation_data(field='something forbidden'),
+        )
+
+        assert field not in result
+
+    def test_it_sets_userid(self, authn_policy):
+        authn_policy.authenticated_userid.return_value = (
+            'acct:harriet@example.com')
+        schema = schemas.AnnotationSchema(testing.DummyRequest())
+
+        result = schema.validate(self.annotation_data())
+
+        assert result['userid'] == 'acct:harriet@example.com'
+
+    def test_it_renames_uri_to_target_uri(self):
+        schema = schemas.AnnotationSchema(testing.DummyRequest())
+
+        result = schema.validate(
+            self.annotation_data(uri='http://example.com/example'),
+        )
+
+        assert result['target_uri'] == 'http://example.com/example'
+        assert 'uri' not in result
+
+    def test_it_inserts_empty_string_if_data_has_no_uri(self):
+        schema = schemas.AnnotationSchema(testing.DummyRequest())
+
+        data = self.annotation_data()
+        assert 'uri' not in data
+
+        assert schema.validate(data)['target_uri'] == ''
+
+    def test_it_keeps_text(self):
+        schema = schemas.AnnotationSchema(testing.DummyRequest())
+
+        result = schema.validate(
+            self.annotation_data(text='some annotation text'))
+
+        assert result['text'] == 'some annotation text'
+
+    def test_it_inserts_empty_string_if_data_contains_no_text(self):
+        schema = schemas.AnnotationSchema(testing.DummyRequest())
+
+        data = self.annotation_data()
+        assert 'text' not in data
+
+        assert schema.validate(data)['text'] == ''
+
+    def test_it_keeps_tags(self):
+        schema = schemas.AnnotationSchema(testing.DummyRequest())
+
+        result = schema.validate(
+            self.annotation_data(tags=['foo', 'bar']))
+
+        assert result['tags'] == ['foo', 'bar']
+
+    def test_it_inserts_empty_list_if_data_contains_no_tags(self):
+        schema = schemas.AnnotationSchema(testing.DummyRequest())
+
+        data = self.annotation_data()
+        assert 'tags' not in data
+
+        assert schema.validate(data)['tags'] == []
+
+    def test_it_replaces_private_permissions_with_shared_False(
+            self,
+            authn_policy):
+        authn_policy.authenticated_userid.return_value = (
+            'acct:harriet@example.com')
+        schema = schemas.AnnotationSchema(testing.DummyRequest())
+
+        result = schema.validate(
+            self.annotation_data(
+                permissions={'read': ['acct:harriet@example.com']},
+            ),
+        )
+
+        assert result['shared'] is False
+        assert 'permissions' not in result
+
+    def test_it_replaces_shared_permissions_with_shared_True(
+            self,
+            authn_policy):
+        authn_policy.authenticated_userid.return_value = (
+            'acct:harriet@example.com')
+        schema = schemas.AnnotationSchema(testing.DummyRequest())
+
+        result = schema.validate(
+            self.annotation_data(
+                permissions={'read': ['group:__world__']},
+            ),
+        )
+
+        assert result['shared'] is True
+        assert 'permissions' not in result
+
+    def test_it_does_not_crash_if_data_contains_no_target(self):
+        schema = schemas.AnnotationSchema(testing.DummyRequest())
+
+        data = self.annotation_data()
+        assert 'target' not in data
+
+        schema.validate(data)
+
+    def test_it_replaces_target_with_target_selectors(self):
+        schema = schemas.AnnotationSchema(testing.DummyRequest())
+
+        result = schema.validate(
+            self.annotation_data(
+                target=[
+                    {
+                        'foo': 'bar',  # This should be removed,
+                        'selector': 'the selectors',
+                    },
+                    'this should be removed',
+                ],
+            ),
+        )
+
+        assert result['target_selectors'] == 'the selectors'
+
+    def test_it_renames_group_to_groupid(self):
+        schema = schemas.AnnotationSchema(testing.DummyRequest())
+
+        result = schema.validate(self.annotation_data(group='foo'))
+
+        assert result['groupid'] == 'foo'
+        assert 'group' not in result
+
+    def test_it_inserts_default_groupid_if_no_group(self):
+        schema = schemas.AnnotationSchema(testing.DummyRequest())
+
+        data = self.annotation_data()
+        assert 'group' not in data
+
+        result = schema.validate(data)
+
+        assert result['groupid'] == '__world__'
+
+    def test_it_keeps_references(self):
+        schema = schemas.AnnotationSchema(testing.DummyRequest())
+
+        result = schema.validate(
+            self.annotation_data(references=['parent id', 'parent id 2']))
+
+        assert result['references'] == ['parent id', 'parent id 2']
+
+    def test_it_inserts_empty_list_if_no_references(self):
+        schema = schemas.AnnotationSchema(testing.DummyRequest())
+
+        data = self.annotation_data()
+        assert 'references' not in data
+
+        result = schema.validate(data)
+
+        assert result['references'] == []
+
+    def test_it_deletes_groupid_for_replies(self):
+        schema = schemas.AnnotationSchema(testing.DummyRequest())
+
+        result = schema.validate(
+            self.annotation_data(
+                group='foo',
+                references=['parent annotation id'],
+            )
+        )
+
+        assert 'groupid' not in result
+
+    def test_it_moves_extra_data_into_extra_sub_dict(self):
+        schema = schemas.AnnotationSchema(testing.DummyRequest())
+
+        result = schema.validate({
+            # Throw in all the fields, just to make sure that none of them get
+            # into extra.
+            'created': 'created',
+            'updated': 'updated',
+            'user': 'user',
+            'id': 'id',
+            'uri': 'uri',
+            'text': 'text',
+            'tags': ['gar', 'har'],
+            'permissions': {'read': ['group:__world__']},
+            'target': [],
+            'group': '__world__',
+            'references': ['parent'],
+
+            # These should end up in extra.
+            'foo': 1,
+            'bar': 2,
+        })
+
+        assert result['extra'] == {'foo': 1, 'bar': 2}
+
+    def test_it_calls_document_uris_from_data(self, parse_document_claims):
+        document_data = {'foo': 'bar'}
+        target_uri = 'http://example.com/example'
+        schema = schemas.AnnotationSchema(testing.DummyRequest())
+
+        schema.validate(
+            self.annotation_data(
+                document=document_data,
+                uri=target_uri,
+            )
+        )
+
+        parse_document_claims.document_uris_from_data.assert_called_once_with(
+            document_data,
+            claimant=target_uri,
+        )
+
+    def test_it_puts_document_uris_in_appstruct(self, parse_document_claims):
+        schema = schemas.AnnotationSchema(testing.DummyRequest())
+
+        appstruct = schema.validate(self.annotation_data())
+
+        assert appstruct['document']['document_uri_dicts'] == (
+            parse_document_claims.document_uris_from_data.return_value)
+
+    def test_it_calls_document_metas_from_data(self, parse_document_claims):
+        schema = schemas.AnnotationSchema(testing.DummyRequest())
+        document_data = {'foo': 'bar'}
+        target_uri = 'http://example.com/example'
+
+        schema.validate(
+            self.annotation_data(
+                document=document_data,
+                uri=target_uri,
+            )
+        )
+
+        parse_document_claims.document_metas_from_data.assert_called_once_with(
+            document_data,
+            claimant=target_uri,
+        )
+
+    def test_it_does_not_pass_modified_dict_to_document_metas_from_data(
+            self,
+            parse_document_claims):
+        """
+
+        If document_uris_from_data() modifies the document dict that it's
+        given, the original dict (or one with the same values as it) should be
+        passed t document_metas_from_data(), not the modified copy.
+
+        """
+        document = {
+            'top_level_key': 'original_value',
+            'sub_dict': {
+                'key': 'original_value'
+            }
+        }
+        def document_uris_from_data(document, claimant):
+            document['new_key'] = 'new_value'
+            document['top_level_key'] = 'new_value'
+            document['sub_dict']['key'] = 'new_value'
+        parse_document_claims.document_uris_from_data.side_effect = (
+            document_uris_from_data)
+        schema = schemas.AnnotationSchema(testing.DummyRequest())
+
+        schema.validate(self.annotation_data(document=document))
+
+        assert (
+            parse_document_claims.document_metas_from_data.call_args[0][0] ==
+            document)
+
+    def test_it_puts_document_metas_in_appstruct(self, parse_document_claims):
+        schema = schemas.AnnotationSchema(testing.DummyRequest())
+
+        appstruct = schema.validate(self.annotation_data())
+
+        assert appstruct['document']['document_meta_dicts'] == (
+            parse_document_claims.document_metas_from_data.return_value)
+
+    def test_it_clears_existing_keys_from_document(self):
+        """
+        Any keys in the document dict should be removed.
+
+        They're replaced with the 'document_uri_dicts' and
+        'document_meta_dicts' keys.
+
+        """
+        schema = schemas.AnnotationSchema(testing.DummyRequest())
+
+        appstruct = schema.validate(
+            self.annotation_data(
+                document={
+                    'foo': 'bar'  # This should be deleted.
+                },
+            ),
+        )
+
+        assert 'foo' not in appstruct['document']
+
+    def annotation_data(self, **kwargs):
+        """Return test input data for AnnotationSchema.validate()."""
+        data = {
+            'permissions': {
+                'read': []
+            }
+        }
+        data.update(kwargs)
+        return data
+
+    @pytest.fixture
+    def parse_document_claims(self, patch):
+        return patch('h.api.schemas.parse_document_claims')
 
 
 class TestLegacyCreateAnnotationSchema(object):
@@ -516,12 +834,12 @@ class TestLegacyCreateAnnotationSchema(object):
         return request
 
 
-@pytest.mark.usefixtures('parse_document_claims')
+@pytest.mark.usefixtures('AnnotationSchema')
 class TestCreateAnnotationSchema(object):
 
     def test_it_passes_input_to_AnnotationSchema_validator(self,
                                                            AnnotationSchema):
-        schema = schemas.CreateAnnotationSchema(self.mock_request())
+        schema = schemas.CreateAnnotationSchema(mock.Mock())
 
         schema.validate(mock.sentinel.input_data)
 
@@ -532,329 +850,19 @@ class TestCreateAnnotationSchema(object):
                                                            AnnotationSchema):
         AnnotationSchema.return_value.validate.side_effect = (
             schemas.ValidationError('asplode'))
-        schema = schemas.CreateAnnotationSchema(self.mock_request())
+        schema = schemas.CreateAnnotationSchema(mock.Mock())
 
         with pytest.raises(schemas.ValidationError):
             schema.validate({'foo': 'bar'})
 
-    @pytest.mark.parametrize('field', [
-        'created',
-        'updated',
-        'user',
-        'id',
-    ])
-    def test_it_removes_protected_fields(self, field):
-        schema = schemas.CreateAnnotationSchema(self.mock_request())
-
-        result = schema.validate(
-            self.annotation_data(field='something forbidden'),
-        )
-
-        assert field not in result
-
-    def test_it_sets_userid(self, authn_policy):
-        authn_policy.authenticated_userid.return_value = (
-            'acct:harriet@example.com')
-        schema = schemas.CreateAnnotationSchema(self.mock_request())
-
-        result = schema.validate(self.annotation_data())
-
-        assert result['userid'] == 'acct:harriet@example.com'
-
-    def test_it_renames_uri_to_target_uri(self):
-        schema = schemas.CreateAnnotationSchema(self.mock_request())
-
-        result = schema.validate(
-            self.annotation_data(uri='http://example.com/example'),
-        )
-
-        assert result['target_uri'] == 'http://example.com/example'
-        assert 'uri' not in result
-
-    def test_it_inserts_empty_string_if_data_has_no_uri(self):
-        schema = schemas.CreateAnnotationSchema(self.mock_request())
-
-        data = self.annotation_data()
-        assert 'uri' not in data
-
-        assert schema.validate(data)['target_uri'] == ''
-
-    def test_it_keeps_text(self):
-        schema = schemas.CreateAnnotationSchema(self.mock_request())
-
-        result = schema.validate(
-            self.annotation_data(text='some annotation text'))
-
-        assert result['text'] == 'some annotation text'
-
-    def test_it_inserts_empty_string_if_data_contains_no_text(self):
-        schema = schemas.CreateAnnotationSchema(self.mock_request())
-
-        data = self.annotation_data()
-        assert 'text' not in data
-
-        assert schema.validate(data)['text'] == ''
-
-    def test_it_keeps_tags(self):
-        schema = schemas.CreateAnnotationSchema(self.mock_request())
-
-        result = schema.validate(
-            self.annotation_data(tags=['foo', 'bar']))
-
-        assert result['tags'] == ['foo', 'bar']
-
-    def test_it_inserts_empty_list_if_data_contains_no_tags(self):
-        schema = schemas.CreateAnnotationSchema(self.mock_request())
-
-        data = self.annotation_data()
-        assert 'tags' not in data
-
-        assert schema.validate(data)['tags'] == []
-
-    def test_it_replaces_private_permissions_with_shared_False(
-            self,
-            authn_policy):
-        authn_policy.authenticated_userid.return_value = (
-            'acct:harriet@example.com')
-        schema = schemas.CreateAnnotationSchema(self.mock_request())
-
-        result = schema.validate(
-            self.annotation_data(
-                permissions={'read': ['acct:harriet@example.com']},
-            ),
-        )
-
-        assert result['shared'] is False
-        assert 'permissions' not in result
-
-    def test_it_replaces_shared_permissions_with_shared_True(
-            self,
-            authn_policy):
-        authn_policy.authenticated_userid.return_value = (
-            'acct:harriet@example.com')
-        schema = schemas.CreateAnnotationSchema(self.mock_request())
-
-        result = schema.validate(
-            self.annotation_data(
-                permissions={'read': ['group:__world__']},
-            ),
-        )
-
-        assert result['shared'] is True
-        assert 'permissions' not in result
-
-    def test_it_does_not_crash_if_data_contains_no_target(self):
-        schema = schemas.CreateAnnotationSchema(self.mock_request())
-
-        data = self.annotation_data()
-        assert 'target' not in data
-
-        schema.validate(data)
-
-    def test_it_replaces_target_with_target_selectors(self):
-        schema = schemas.CreateAnnotationSchema(self.mock_request())
-
-        result = schema.validate(
-            self.annotation_data(
-                target=[
-                    {
-                        'foo': 'bar',  # This should be removed,
-                        'selector': 'the selectors',
-                    },
-                    'this should be removed',
-                ],
-            ),
-        )
-
-        assert result['target_selectors'] == 'the selectors'
-
-    def test_it_renames_group_to_groupid(self):
-        schema = schemas.CreateAnnotationSchema(self.mock_request())
-
-        result = schema.validate(self.annotation_data(group='foo'))
-
-        assert result['groupid'] == 'foo'
-        assert 'group' not in result
-
-    def test_it_inserts_default_groupid_if_no_group(self):
-        schema = schemas.CreateAnnotationSchema(self.mock_request())
-
-        data = self.annotation_data()
-        assert 'group' not in data
-
-        result = schema.validate(data)
-
-        assert result['groupid'] == '__world__'
-
-    def test_it_keeps_references(self):
-        schema = schemas.CreateAnnotationSchema(self.mock_request())
-
-        result = schema.validate(
-            self.annotation_data(references=['parent id', 'parent id 2']))
-
-        assert result['references'] == ['parent id', 'parent id 2']
-
-    def test_it_inserts_empty_list_if_no_references(self):
-        schema = schemas.CreateAnnotationSchema(self.mock_request())
-
-        data = self.annotation_data()
-        assert 'references' not in data
-
-        result = schema.validate(data)
-
-        assert result['references'] == []
-
-    def test_it_deletes_groupid_for_replies(self):
-        schema = schemas.CreateAnnotationSchema(self.mock_request())
-
-        result = schema.validate(
-            self.annotation_data(
-                group='foo',
-                references=['parent annotation id'],
-            )
-        )
-
-        assert 'groupid' not in result
-
-    def test_it_moves_extra_data_into_extra_sub_dict(self):
-        schema = schemas.CreateAnnotationSchema(self.mock_request())
-
-        result = schema.validate({
-            # Throw in all the fields, just to make sure that none of them get
-            # into extra.
-            'created': 'created',
-            'updated': 'updated',
-            'user': 'user',
-            'id': 'id',
-            'uri': 'uri',
-            'text': 'text',
-            'tags': ['gar', 'har'],
-            'permissions': {'read': ['group:__world__']},
-            'target': [],
-            'group': '__world__',
-            'references': ['parent'],
-
-            # These should end up in extra.
-            'foo': 1,
-            'bar': 2,
-        })
-
-        assert result['extra'] == {'foo': 1, 'bar': 2}
-
-    def test_it_calls_document_uris_from_data(self, parse_document_claims):
-        document_data = {'foo': 'bar'}
-        target_uri = 'http://example.com/example'
-        schema = schemas.CreateAnnotationSchema(self.mock_request())
-
-        schema.validate(
-            self.annotation_data(
-                document=document_data,
-                uri=target_uri,
-            )
-        )
-
-        parse_document_claims.document_uris_from_data.assert_called_once_with(
-            document_data,
-            claimant=target_uri,
-        )
-
-    def test_it_puts_document_uris_in_appstruct(self, parse_document_claims):
-        schema = schemas.CreateAnnotationSchema(self.mock_request())
-
-        appstruct = schema.validate(self.annotation_data())
-
-        assert appstruct['document']['document_uri_dicts'] == (
-            parse_document_claims.document_uris_from_data.return_value)
-
-    def test_it_calls_document_metas_from_data(self, parse_document_claims):
-        schema = schemas.CreateAnnotationSchema(self.mock_request())
-        document_data = {'foo': 'bar'}
-        target_uri = 'http://example.com/example'
-
-        schema.validate(
-            self.annotation_data(
-                document=document_data,
-                uri=target_uri,
-            )
-        )
-
-        parse_document_claims.document_metas_from_data.assert_called_once_with(
-            document_data,
-            claimant=target_uri,
-        )
-
-    def test_it_does_not_pass_modified_dict_to_document_metas_from_data(
-            self,
-            parse_document_claims):
-        """
-
-        If document_uris_from_data() modifies the document dict that it's
-        given, the original dict (or one with the same values as it) should be
-        passed t document_metas_from_data(), not the modified copy.
-
-        """
-        document = {
-            'top_level_key': 'original_value',
-            'sub_dict': {
-                'key': 'original_value'
-            }
-        }
-        def document_uris_from_data(document, claimant):
-            document['new_key'] = 'new_value'
-            document['top_level_key'] = 'new_value'
-            document['sub_dict']['key'] = 'new_value'
-        parse_document_claims.document_uris_from_data.side_effect = (
-            document_uris_from_data)
-        schema = schemas.CreateAnnotationSchema(self.mock_request())
-
-        schema.validate(self.annotation_data(document=document))
-
-        assert (
-            parse_document_claims.document_metas_from_data.call_args[0][0] ==
-            document)
-
-    def test_it_puts_document_metas_in_appstruct(self, parse_document_claims):
-        schema = schemas.CreateAnnotationSchema(self.mock_request())
-
-        appstruct = schema.validate(self.annotation_data())
-
-        assert appstruct['document']['document_meta_dicts'] == (
-            parse_document_claims.document_metas_from_data.return_value)
-
-    def test_it_clears_existing_keys_from_document(self):
-        """
-        Any keys in the document dict should be removed.
-
-        They're replaced with the 'document_uri_dicts' and
-        'document_meta_dicts' keys.
-
-        """
-        schema = schemas.CreateAnnotationSchema(self.mock_request())
-
-        appstruct = schema.validate(
-            self.annotation_data(
-                document={
-                    'foo': 'bar'  # This should be deleted.
-                },
-            ),
-        )
-
-        assert 'foo' not in appstruct['document']
-
-    def mock_request(self, authenticated_userid=None):
-        request = testing.DummyRequest(
-            authenticated_userid=authenticated_userid)
-
-        def feature(flag):
-            if flag == 'postgres':
-                return True
-            return False
-
-        request.feature = mock.Mock(side_effect=feature, spec=feature)
-        return request
+    @pytest.fixture
+    def AnnotationSchema(self, patch):
+        cls = patch('h.api.schemas.AnnotationSchema')
+        cls.return_value.validate.return_value = self.annotation_data()
+        return cls
 
     def annotation_data(self, **kwargs):
-        """Return test input data for CreateAnnotationSchema.validate()."""
+        """Return test input data for AnnotationSchema.validate()."""
         data = {
             'permissions': {
                 'read': []
@@ -863,15 +871,6 @@ class TestCreateAnnotationSchema(object):
         data.update(kwargs)
         return data
 
-    @pytest.fixture
-    def AnnotationSchema(self, patch):
-        cls = patch('h.api.schemas.AnnotationSchema')
-        cls.return_value.validate.return_value = self.annotation_data()
-        return cls
-
-    @pytest.fixture
-    def parse_document_claims(self, patch):
-        return patch('h.api.schemas.parse_document_claims')
 
 
 class TestUpdateAnnotationSchema(object):

--- a/h/api/test/schemas_test.py
+++ b/h/api/test/schemas_test.py
@@ -841,7 +841,13 @@ class TestCreateAnnotationSchema(object):
         with pytest.raises(schemas.ValidationError):
             schema.validate({'foo': 'bar'})
 
+    def test_it_returns_the_appstruct_from_AnnotationSchema(self,
+                                                            AnnotationSchema):
+        schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
 
+        appstruct = schema.validate(mock.sentinel.input_data)
+
+        assert appstruct == AnnotationSchema.return_value.validate.return_value
 
 
 class TestLegacyUpdateAnnotationSchema(object):

--- a/h/api/test/views_test.py
+++ b/h/api/test/views_test.py
@@ -408,7 +408,7 @@ class TestUpdate(object):
     def test_it_calls_validator(self, schemas):
         annotation = mock.Mock()
         request = mock.Mock()
-        schema = schemas.UpdateAnnotationSchema.return_value
+        schema = schemas.LegacyUpdateAnnotationSchema.return_value
 
         views.update(annotation, request)
 
@@ -417,7 +417,7 @@ class TestUpdate(object):
     def test_it_calls_update_annotation(self, storage, schemas):
         annotation = mock.Mock()
         request = mock.Mock()
-        schema = schemas.UpdateAnnotationSchema.return_value
+        schema = schemas.LegacyUpdateAnnotationSchema.return_value
         schema.validate.return_value = {'foo': 123}
 
         views.update(annotation, request)

--- a/h/api/views.py
+++ b/h/api/views.py
@@ -204,7 +204,8 @@ def read_jsonld(annotation, request):
 @api_config(route_name='api.annotation', request_method='PUT', permission='update')
 def update(annotation, request):
     """Update the specified annotation with data from the PUT payload."""
-    schema = schemas.UpdateAnnotationSchema(request, annotation=annotation)
+    schema = schemas.LegacyUpdateAnnotationSchema(request,
+                                                  annotation=annotation)
     appstruct = schema.validate(_json_payload(request))
     annotation = storage.update_annotation(request, annotation.id, appstruct)
 


### PR DESCRIPTION
* Move a bunch of validation code out of `CreateAnnotationSchema` into `AnnotationSchema`, so that `UpdateAnnotationSchema` can share it. Move the tests too.

* Add new `UpdateAnnotationSchema` intended for use when updating annotations in Postgres (view and storage code for updating annotations in Postgres not written yet)

* The legacy Elasticsearch `UpdateAnnotationSchema` becomes `LegacyUpdateAnnotationSchema`

* The view calls `LegacyUpdateAnnotationSchema`, the new `UpdateAnnotationSchema` isn't ready for use until the storage code for updating annotations in Postgres is written

* The new `UpdateAnnotationSchema` doesn't do the "user must be admin of annotation to change its permissions" test that the legacy one does. This test was always passed, I believe. But we can't implement it in terms of the new Postgres annotation model anyway.