### PR TITLE
Dev install docs corrections

### DIFF
--- a/docs/arch/index.rst
+++ b/docs/arch/index.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 Architecture decision records
 =============================
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -76,7 +76,7 @@ release = '0.0.2'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ['_build']
+exclude_patterns = ['_build', 'hacking/services.rst']
 
 # The reST default role (used for this markup: `text`) to use for all documents.
 #default_role = None

--- a/docs/hacking/install.rst
+++ b/docs/hacking/install.rst
@@ -117,15 +117,15 @@ installed on:
 
    .. code-block:: bash
 
-      docker run -d --name nsqd -p 4150:4150 -p 4151:4151 nsqio/nsq /nsqd
-      docker run -d --name postgres -p 5432:5432 postgres
-      docker run -d --name redis -p 6379:6379 redis
-      docker run -d --name elasticsearch -p 9200:9200 -p 9300:9300 nickstenning/elasticsearch-icu
+      sudo docker run -d --name nsqd -p 4150:4150 -p 4151:4151 nsqio/nsq /nsqd
+      sudo docker run -d --name postgres -p 5432:5432 postgres
+      sudo docker run -d --name redis -p 6379:6379 redis
+      sudo docker run -d --name elasticsearch -p 9200:9200 -p 9300:9300 nickstenning/elasticsearch-icu
 
    You'll now have four Docker containers named ``nsqd``, ``postgres``,
    ``redis`` and ``elasticsearch`` running and exposing the nsqd service on
    ports 4150 and 4151, Elasticsearch on 9200 and 9300, Redis on 6379, and
-   PostgreSQL on 5432. You should be able to see them by running ``docker ps``.
+   PostgreSQL on 5432. You should be able to see them by running ``sudo docker ps``.
    You should also be able to visit your Elasticsearch service by opening
    http://127.0.0.1:9200/ in a browser, and connect to your PostgreSQL by
    running ``psql postgresql://postgres@localhost/postgres`` (if you have psql
@@ -139,14 +139,14 @@ installed on:
 
       .. code-block:: bash
 
-         docker start postgres elasticsearch nsqd redis
+         sudo docker start postgres elasticsearch nsqd redis
 
 3. Create the `htest` database in the ``postgres`` container. This is needed
    to run the h tests:
 
    .. code-block:: bash
 
-      docker run -it --link postgres:postgres --rm postgres sh -c 'exec psql -h "$POSTGRES_PORT_5432_TCP_ADDR" -p "$POSTGRES_PORT_5432_TCP_PORT" -U postgres -c "CREATE DATABASE htest;"'
+      sudo docker run -it --link postgres:postgres --rm postgres sh -c 'exec psql -h "$POSTGRES_PORT_5432_TCP_ADDR" -p "$POSTGRES_PORT_5432_TCP_PORT" -U postgres -c "CREATE DATABASE htest;"'
 
 
 .. tip::
@@ -157,7 +157,7 @@ installed on:
 
    .. code-block:: bash
 
-      docker run -it --link postgres:postgres --rm postgres sh -c 'exec psql -h "$POSTGRES_PORT_5432_TCP_ADDR" -p "$POSTGRES_PORT_5432_TCP_PORT" -U postgres'
+      sudo docker run -it --link postgres:postgres --rm postgres sh -c 'exec psql -h "$POSTGRES_PORT_5432_TCP_ADDR" -p "$POSTGRES_PORT_5432_TCP_PORT" -U postgres'
 
    This runs psql in a fourth Docker container (from the same official
    PostgreSQL image, which also contains psql) and links it to your named
@@ -172,7 +172,7 @@ installed on:
 
    .. code-block:: bash
 
-      docker logs nsqd
+      sudo docker logs nsqd
 
    For more on how to use Docker see the `Docker website`_.
 

--- a/docs/hacking/install.rst
+++ b/docs/hacking/install.rst
@@ -3,7 +3,7 @@ Installing h in a development environment
 
 This document contains instructions for setting up a development environment
 for h. If you are looking for instructions for deploying h in a production
-environment, please consult the :doc:`/INSTALL` instead.
+environment, please consult the :doc:`/INSTALL` document instead.
 
 
 Requirements

--- a/docs/hacking/install.rst
+++ b/docs/hacking/install.rst
@@ -42,7 +42,7 @@ Installing the system dependencies on Ubuntu 14.04
 ``````````````````````````````````````````````````
 
 This section describes how to install h's system dependencies on Ubuntu 14.04.
-These steps will also probably work with little or no changes on other versions
+These steps will also probably work with few or no changes on other versions
 of Ubuntu, Debian, or other Debian-based GNU/Linux distributions.
 
 Install the following packages:
@@ -245,28 +245,31 @@ Activate the virtual environment that you've created:
 Running h
 ---------
 
-Run the following command to start the Hypothesis web service. If this is a
-fresh clone of the repository, this may take some time to run, as it will need
-to install the application dependencies and build the client assets.
-
+Start the Hypothesis web service:
 
 .. code-block:: bash
 
     make dev
+
+The first time you run ``make dev`` it might take a while to start because
+it'll need to install the application dependencies and build the client assets.
 
 This will start the server on port 5000 (http://localhost:5000), reload the
 application whenever changes are made to the source code, and restart it should
 it crash for some reason.
 
 If you are making changes to the client, or the JavaScript code or styles for the
-service, you may find it useful to run `gulp watch`. This will automatically
-rebuild the assets whenever the source files change.
+service, you may find it useful to run this command from your ``h`` directory
+in a separate terminal:
 
 .. code-block:: bash
 
     gulp watch
 
-When `gulp watch` is running, you can visit http://localhost:3000
+``gulp watch`` will automatically rebuild the assets whenever the source files
+change.
+
+When ``gulp watch`` is running, you can visit http://localhost:3000
 to see a page with an embedded Hypothesis client which will automatically reload
 when styles, templates or JavaScript source files are changed.
 

--- a/docs/hacking/install.rst
+++ b/docs/hacking/install.rst
@@ -66,7 +66,7 @@ Install node by following the
 (the version of the nodejs package in the standard Ubuntu repositories is too
 old).
 
-Upgrade pip and npm:
+Upgrade pip, virtualenv and npm:
 
 .. code-block:: bash
 

--- a/docs/hacking/install.rst
+++ b/docs/hacking/install.rst
@@ -16,7 +16,7 @@ installed:
 -  Python_ v2.7
 -  Node_ v4+ and its package manager, npm
 
-You'll also need to run, at a minimum, these external services:
+You'll also need to run these external services:
 
 .. include:: services.rst
 

--- a/docs/hacking/install.rst
+++ b/docs/hacking/install.rst
@@ -51,7 +51,6 @@ This will download the code into an ``h`` directory in your current working
 directory.
 
 
-
 Installing the system dependencies
 ----------------------------------
 

--- a/docs/hacking/install.rst
+++ b/docs/hacking/install.rst
@@ -338,6 +338,7 @@ argument or mocha's `.only()`_ modifier.
 
 .. _.only(): http://jaketrent.com/post/run-single-mocha-test/
 
+
 Debugging h
 -----------
 
@@ -359,7 +360,7 @@ environment variable (to any value). Set it to the special value ``trace`` to
 turn on result set logging as well.
 
 
-Feature Flags
+Feature flags
 -------------
 
 Features flags allow admins to enable or disable features for certain groups

--- a/docs/hacking/install.rst
+++ b/docs/hacking/install.rst
@@ -210,6 +210,39 @@ process:
    cd h
 
 
+Creating a Python virtual environment
+-------------------------------------
+
+Create a Python virtual environment to install and run the h Python code and
+Python dependencies in:
+
+.. code-block:: bash
+
+   virtualenv .venv
+
+
+.. _activating_your_virtual_environment:
+
+Activating your virtual environment
+-----------------------------------
+
+Activate the virtual environment that you've created:
+
+.. code-block:: bash
+
+   source .venv/bin/activate
+
+.. tip::
+
+   You'll need to re-activate this virtualenv with the
+   ``source .venv/bin/activate`` command each time you open a new terminal,
+   before running h.
+   See the `Virtual Environments`_ section in the Hitchhiker's guide to
+   Python for an introduction to Python virtual environments.
+
+.. _Virtual Environments: http://docs.python-guide.org/en/latest/dev/virtualenvs/
+
+
 Running h
 ---------
 
@@ -217,13 +250,6 @@ Run the following command to start the Hypothesis web service. If this is a
 fresh clone of the repository, this may take some time to run, as it will need
 to install the application dependencies and build the client assets.
 
-.. note::
-    Although it is strictly optional, we highly recommend that you install h
-    inside a Python "virtualenv". Please refer to the `virtualenv environment`_
-    section featured in the Hitchhiker's guide to Python for a comprehensive
-    introduction.
-
-.. _virtualenv environment: http://docs.python-guide.org/en/latest/dev/virtualenvs/
 
 .. code-block:: bash
 

--- a/docs/hacking/install.rst
+++ b/docs/hacking/install.rst
@@ -29,19 +29,6 @@ The following sections will explain how to install these system dependencies
 and services.
 
 
-Get the h source code from GitHub
----------------------------------
-
-Use ``git`` to download the h source code:
-
-.. code-block:: bash
-
-    git clone https://github.com/hypothesis/h.git
-
-This will download the code into an ``h`` directory in your current working
-directory.
-
-
 Installing the system dependencies
 ----------------------------------
 
@@ -190,6 +177,26 @@ installed on:
 
 
 .. _Docker website: https://www.docker.com/
+
+
+Getting the h source code from GitHub
+-------------------------------------
+
+Use ``git`` to download the h source code:
+
+.. code-block:: bash
+
+    git clone https://github.com/hypothesis/h.git
+
+This will download the code into an ``h`` directory in your current working
+directory.
+
+Change into the ``h`` directory from the remainder of the installation
+process:
+
+.. code-block:: bash
+
+   cd h
 
 
 Running h

--- a/docs/hacking/install.rst
+++ b/docs/hacking/install.rst
@@ -180,6 +180,16 @@ installed on:
 .. _Docker website: https://www.docker.com/
 
 
+Installing the gulp command
+---------------------------
+
+Install ``gulp-cli`` to get the ``gulp`` command:
+
+.. code-block:: bash
+
+    sudo npm install -g gulp-cli
+
+
 Getting the h source code from GitHub
 -------------------------------------
 
@@ -229,12 +239,11 @@ it crash for some reason.
     the inclusion of non-SSL content.
 
 If you are making changes to the client, or the JavaScript code or styles for the
-service, you may find it useful to install Gulp_ and run the `watch` task. This
-will automatically rebuild the assets whenever the source files change.
+service, you may find it useful to run `gulp watch`. This will automatically
+rebuild the assets whenever the source files change.
 
 .. code-block:: bash
 
-    npm install -g gulp-cli
     gulp watch
 
 When `gulp watch` is running, you can visit http://localhost:3000
@@ -262,12 +271,11 @@ complete set of tests, run:
 
     make test
 
-To run the frontend test suite only, install Gulp_ and run the appropriate test
-task. For example:
+To run the frontend test suite only, run the appropriate test task with gulp.
+For example:
 
 .. code-block:: bash
 
-    npm install -g gulp-cli
     gulp test-app
 
 When working on the front-end code, you can run the Karma test runner in

--- a/docs/hacking/install.rst
+++ b/docs/hacking/install.rst
@@ -54,6 +54,7 @@ Install the following packages:
         git \
         libevent-dev \
         libffi-dev \
+        libfontconfig \
         libpq-dev \
         npm \
         python-dev \

--- a/docs/hacking/install.rst
+++ b/docs/hacking/install.rst
@@ -18,20 +18,11 @@ installed:
 
 You'll also need to run, at a minimum, these external services:
 
--  Elasticsearch_ v1.0+, with the `Elasticsearch ICU Analysis`_ plugin
-   installed
--  NSQ_ v0.3+
--  PostgreSQL_ 9.4+
--  Redis_ v2.4+
+.. include:: services.rst
 
 .. _Git: https://git-scm.com/
 .. _Python: http://python.org/
 .. _Node: http://nodejs.org/
-.. _Elasticsearch: http://www.elasticsearch.org/
-.. _Elasticsearch ICU Analysis: http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/analysis-icu-plugin.html
-.. _NSQ: http://nsq.io/
-.. _PostgreSQL: http://www.postgresql.org/
-.. _Redis: http://redis.io/
 
 
 The following sections will explain how to install these system dependencies
@@ -118,10 +109,13 @@ Install the following packages:
 Installing the services
 -----------------------
 
-h requires Elasticsearch_ 1.0+ with the `Elasticsearch ICU Analysis`_ plugin,
-`NSQ`_ 0.3+ and `PostgreSQL`_ 9.4+. You can install these services however you
-want, but the easiest way is by using Docker. This should work on any operating
-system that Docker can be installed on:
+h requires trhe following external services:
+
+.. include:: services.rst
+
+You can install these services however you want, but the easiest way is by
+using Docker. This should work on any operating system that Docker can be
+installed on:
 
 1. Install Docker by following the instructions on the
    `Docker website`_.

--- a/docs/hacking/install.rst
+++ b/docs/hacking/install.rst
@@ -273,12 +273,34 @@ when styles, templates or JavaScript source files are changed.
 
 .. _Gulp: http://gulpjs.com/
 
-If you are running background tasks, you must have a Celery worker running. To
-run a Celery worker in development, run:
+
+Running the WebSocket for realtime features
+-------------------------------------------
+
+To test h's realtime features (for example, seeing new or updated annotations
+from other users appear in your browser without a page reload) you need to run
+a websocket process.  Open a new terminal, ``cd`` into your ``h`` directory,
+:ref:`activate your Python virtual environment <activating_your_virtual_environment>`,
+then run:
+
+.. code-block:: bash
+
+   gunicorn --reload --paste conf/development-websocket.ini
+
+
+Running Celery for background tasks
+-----------------------------------
+
+To test h's background tasks (for example, sending emails) you need to run a
+Celery worker process.
+Open a new terminal, ``cd`` into your ``h`` directory,
+:ref:`activate your Python virtual environment <activating_your_virtual_environment>`,
+then run:
 
 .. code-block:: bash
 
     CONFIG_URI=conf/development-app.ini hypothesis-celery worker
+
 
 .. _running-the-tests:
 

--- a/docs/hacking/install.rst
+++ b/docs/hacking/install.rst
@@ -6,6 +6,37 @@ for h. If you are looking for instructions for deploying h in a production
 environment, please consult the :doc:`/INSTALL` instead.
 
 
+Requirements
+------------
+
+To run h in a development environment you'll need these system dependencies
+installed:
+
+-  Git_
+-  Python_ v2.7
+-  Node_ v4+ and its package manager, npm
+
+You'll also need to run, at a minimum, these external services:
+
+-  Elasticsearch_ v1.0+, with the `Elasticsearch ICU Analysis`_ plugin
+   installed
+-  NSQ_ v0.3+
+-  Redis_ v2.4+
+
+.. _Git: https://git-scm.com/
+.. _Python: http://python.org/
+.. _Node: http://nodejs.org/
+.. _Elasticsearch: http://www.elasticsearch.org/
+.. _Elasticsearch ICU Analysis: http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/analysis-icu-plugin.html
+.. _NSQ: http://nsq.io/
+.. _PostgreSQL: http://www.postgresql.org/
+.. _Redis: http://redis.io/
+
+
+The following sections will explain how to install these system dependencies
+and services.
+
+
 Get the h source code from GitHub
 ---------------------------------
 
@@ -19,33 +50,6 @@ This will download the code into an ``h`` directory in your current working
 directory.
 
 
-Requirements
-------------
-
-To run h in a development environment you'll need these system dependencies
-installed:
-
--  Python_ v2.7
--  Node_ v4+ and its package manager, npm
-
-You'll also need to run, at a minimum, these external services:
-
--  Elasticsearch_ v1.0+, with the `Elasticsearch ICU Analysis`_ plugin
-   installed
--  NSQ_ v0.3+
--  Redis_ v2.4+
-
-.. _Python: http://python.org/
-.. _Node: http://nodejs.org/
-.. _Elasticsearch: http://www.elasticsearch.org/
-.. _Elasticsearch ICU Analysis: http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/analysis-icu-plugin.html
-.. _NSQ: http://nsq.io/
-.. _PostgreSQL: http://www.postgresql.org/
-.. _Redis: http://redis.io/
-
-
-The following sections will explain how to install these system dependencies
-and services.
 
 Installing the system dependencies
 ----------------------------------

--- a/docs/hacking/install.rst
+++ b/docs/hacking/install.rst
@@ -259,11 +259,6 @@ This will start the server on port 5000 (http://localhost:5000), reload the
 application whenever changes are made to the source code, and restart it should
 it crash for some reason.
 
-.. note::
-    Using the bookmarklet or otherwise embedding the application may not
-    be possible on sites accessed via HTTPS due to browser policy restricting
-    the inclusion of non-SSL content.
-
 If you are making changes to the client, or the JavaScript code or styles for the
 service, you may find it useful to run `gulp watch`. This will automatically
 rebuild the assets whenever the source files change.

--- a/docs/hacking/install.rst
+++ b/docs/hacking/install.rst
@@ -56,7 +56,6 @@ Install the following packages:
         libffi-dev \
         libfontconfig \
         libpq-dev \
-        npm \
         python-dev \
         python-pip \
         python-virtualenv

--- a/docs/hacking/install.rst
+++ b/docs/hacking/install.rst
@@ -1,8 +1,8 @@
 Installing h in a development environment
 #########################################
 
-This document contains instructions on setting up a development environment for
-h. If you are looking for instructions on deploying h in a production
+This document contains instructions for setting up a development environment
+for h. If you are looking for instructions for deploying h in a production
 environment, please consult the :doc:`/INSTALL` instead.
 
 

--- a/docs/hacking/install.rst
+++ b/docs/hacking/install.rst
@@ -21,6 +21,7 @@ You'll also need to run, at a minimum, these external services:
 -  Elasticsearch_ v1.0+, with the `Elasticsearch ICU Analysis`_ plugin
    installed
 -  NSQ_ v0.3+
+-  PostgreSQL_ 9.4+
 -  Redis_ v2.4+
 
 .. _Git: https://git-scm.com/

--- a/docs/hacking/install.rst
+++ b/docs/hacking/install.rst
@@ -96,7 +96,7 @@ Install the following packages:
 Installing the services
 -----------------------
 
-h requires trhe following external services:
+h requires the following external services:
 
 .. include:: services.rst
 
@@ -276,10 +276,10 @@ when styles, templates or JavaScript source files are changed.
 .. _Gulp: http://gulpjs.com/
 
 
-Running the WebSocket for realtime features
--------------------------------------------
+Running the WebSocket for real-time features
+--------------------------------------------
 
-To test h's realtime features (for example, seeing new or updated annotations
+To test h's real-time features (for example, seeing new or updated annotations
 from other users appear in your browser without a page reload) you need to run
 a websocket process.  Open a new terminal, ``cd`` into your ``h`` directory,
 :ref:`activate your Python virtual environment <activating_your_virtual_environment>`,

--- a/docs/hacking/services.rst
+++ b/docs/hacking/services.rst
@@ -1,0 +1,11 @@
+-  Elasticsearch_ v1.0+, with the `Elasticsearch ICU Analysis`_ plugin
+   installed
+-  NSQ_ v0.3+
+-  PostgreSQL_ 9.4+
+-  Redis_ v2.4+
+
+.. _Elasticsearch: http://www.elasticsearch.org/
+.. _Elasticsearch ICU Analysis: http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/analysis-icu-plugin.html
+.. _NSQ: http://nsq.io/
+.. _PostgreSQL: http://www.postgresql.org/
+.. _Redis: http://redis.io/


### PR DESCRIPTION
I feel like it wasn't [that long ago](https://github.com/hypothesis/h/pull/3046) when I last tested these docs on a fresh Ubuntu VM and fixed them, but they've already gotten broken in several new ways :(

Anyway, this fixes the docs so that they work on a fresh Ubuntu 14.04 again (I didn't test OS X, suspect it's slightly broken too), corrects some inconsistencies, and removes some duplication, fixes Sphinx warnings and syntax mistakes etc.

It's not perfect. For one thing I think the [list of requirements](http://h.readthedocs.org/en/latest/hacking/install.html#requirements) at the top (Python and Node) is bizarre. I added git to the list. But the _Installing the system dependencies_ sections that immediately follow tell you to apt-get or brew install what looks like a completely different list of requirements. I'm not sure that the list at the top of the file is any use to anyone and would vote for removing it.

Maybe we could also cut out some of the tips and things, it looks quite cluttered I think and hinders clarity.

Otherwise I think these docs and the install process are quite good compared to many that I've been through.