### PR TITLE
Use jsonschema formats

### DIFF
--- a/h/api/checkers.py
+++ b/h/api/checkers.py
@@ -1,0 +1,21 @@
+"""jsonschema format checker functions."""
+from pyramid import i18n
+
+from h.api import exceptions
+
+
+_ = i18n.TranslationStringFactory(__package__)
+
+
+def check_group_permissions(effective_principals, group):
+    """Check that the user has permission create an annotation in the group."""
+    if group == '__world__':
+        return True
+
+    group_principal = 'group:{}'.format(group)
+    if group_principal not in effective_principals:
+        raise exceptions.ValidationError(
+            'group: ' + _('You may not create annotations in groups you are '
+                          'not a member of!'))
+
+    return True

--- a/h/api/exceptions.py
+++ b/h/api/exceptions.py
@@ -1,0 +1,6 @@
+class APIError(Exception):
+    pass
+
+
+class ValidationError(APIError):
+    pass

--- a/h/api/storage.py
+++ b/h/api/storage.py
@@ -97,16 +97,6 @@ def create_annotation(request, data):
                     annotation_id=top_level_annotation_id)
             )
 
-    # The user must have permission to create an annotation in the group
-    # they've asked to create one in.
-    if data['groupid'] != '__world__':
-        group_principal = 'group:{}'.format(data['groupid'])
-        if group_principal not in request.effective_principals:
-            raise schemas.ValidationError('group: ' +
-                                          _('You may not create annotations '
-                                            'in groups you are not a member '
-                                            'of!'))
-
     annotation = models.Annotation(**data)
     request.db.add(annotation)
 

--- a/h/api/views.py
+++ b/h/api/views.py
@@ -23,6 +23,7 @@ from pyramid import security
 from pyramid.view import view_config
 
 from h.api import cors
+from h.api import exceptions
 from h.api.events import AnnotationEvent
 from h.api.presenters import AnnotationJSONPresenter
 from h.api.presenters import AnnotationJSONLDPresenter
@@ -80,7 +81,7 @@ def error_api(context, request):
     return {'status': 'failure', 'reason': context.message}
 
 
-@api_config(context=schemas.ValidationError)
+@api_config(context=exceptions.ValidationError)
 def error_validation(context, request):
     request.response.status_code = 400
     return {'status': 'failure', 'reason': context.message}


### PR DESCRIPTION
I was talking to a friend of mine who uses jsonschema at work and he asked why we don't just use jsonschema's format functions to do our "semantic validation" (the stuff that requires the db) since it's super easy and that's exactly what it's for.

* Validating some data with one of our schemas such as `CreateAnnotationSchema` does _all_ of the validation, as opposed to the current code where it does "structural" validation only because it doesn't have access to the db and then some further validation is done in `storage`. I don't like spreading our validation across two different places.

* As desired `h.api.schemas` still doesn't access the database or model at all, just works purely with dicts

* The new `h.api.checkers` contains all the validation functions that _do_ need to access resources like the db

* `h.api.views` plugs `checkers` into `schemas`, the single `validate()` call does all the validation. This unfortunately has to get a bit clever (use of advanced, poorly documented jsonschema format_checker feature, and also use of partial)

* No more validation going on in `storage`.

* New `exceptions` module added to avoid circular import

I've just done the group permissions rule as an example, but the group of reply rule (still in `storage`) could also be done I think.

After having given it a try I'd disagree that it's super easy (the documentation for how you're supposed to do this is very poor) or that this use case is exactly what it was meant for. jsonschema doesn't pass any arguments to a `group()` format checker function except the group value itself (e.g. `'__world__'`). It doesn't have access to things like the request, elasticsearch client, or database connection. It seems to me that they're just intended to check the "format" of things, e.g. this looks like a valid annotation ID, not this is an ID that actually exists in our database.

Nonetheless we _can_ have format functions that do have access to these resources. We could write our own `FormatChecker` subclass to do this. Or we could use the default class and pass in partials as I've done here.