### PR TITLE
CSP Violation: old homepage

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -162,6 +162,7 @@ var styleFiles = [
   './h/static/styles/front-page/main.css',
   './h/static/styles/help-page.scss',
   './h/static/styles/site.scss',
+  './h/static/styles/old-home.scss',
 
   // Vendor
   './h/static/styles/vendor/angular-csp.css',

--- a/h/assets.ini
+++ b/h/assets.ini
@@ -68,6 +68,7 @@ front_page_js =
 
 front_page_css =
   styles/main.css
+  styles/old-home.css
   styles/icomoon.css
 
 

--- a/h/static/scripts/legacy-site.js
+++ b/h/static/scripts/legacy-site.js
@@ -21,3 +21,11 @@ if (bookmarkletInstaller) {
     event.preventDefault();
   });
 }
+
+var chromeextInstaller = document.getElementById('js-chrome-extension-install');
+if (chromeextInstaller) {
+  chromeextInstaller.addEventListener('click', function (event) {
+    chrome.webstore.install();
+    event.preventDefault();
+  });
+}

--- a/h/static/scripts/legacy-site.js
+++ b/h/static/scripts/legacy-site.js
@@ -13,3 +13,11 @@ if (window.chrome !== undefined) {
     elements[i].classList.add('hidden');
   }
 }
+
+var bookmarkletInstaller = document.getElementById('js-bookmarklet-install');
+if (bookmarkletInstaller) {
+  bookmarkletInstaller.addEventListener('click', function (event) {
+    window.alert('Drag me to the bookmarks bar');
+    event.preventDefault();
+  });
+}

--- a/h/static/scripts/legacy-site.js
+++ b/h/static/scripts/legacy-site.js
@@ -1,2 +1,15 @@
+'use strict';
+
 window.$ = window.jQuery = require('jquery');
 require('bootstrap');
+
+if (window.chrome !== undefined) {
+  var elements = document.getElementsByClassName('unhide-in-chrome');
+  for (var i = 0; i < elements.length; i++) {
+    elements[i].classList.remove('hidden');
+  }
+  elements = document.getElementsByClassName('hide-in-chrome');
+  for (var i = 0; i < elements.length; i++) {
+    elements[i].classList.add('hidden');
+  }
+}

--- a/h/static/styles/old-home.scss
+++ b/h/static/styles/old-home.scss
@@ -1,0 +1,22 @@
+@at-root {
+  .press-release-banner {
+    background-color: #f7f7f7;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+  }
+
+  .press-release-banner > p {
+    font-size: 21px;
+    margin-top: 20px;
+    margin-bottom: 20px;
+    text-align: center;
+  }
+
+  /* FIXME: Remove the '!important' hack below and move
+  This to the correct stylesheet in the new homepage.
+   */
+  .social-media-link {
+    font-size: 16px !important;
+    text-decoration: none !important;
+  }
+}

--- a/h/templates/old-home.html.jinja2
+++ b/h/templates/old-home.html.jinja2
@@ -19,29 +19,6 @@
 {% endblock %}
 
 {% block content %}
-  <style>
-    .press-release-banner {
-      background-color: #f7f7f7;
-      border: 1px solid #ccc;
-      border-radius: 4px;
-    }
-
-    .press-release-banner > p {
-      font-size: 21px;
-      margin-top: 20px;
-      margin-bottom: 20px;
-      text-align: center;
-    }
-
-    /* FIXME: Remove the '!important' hack below and move
-       This to the correct stylesheet in the new homepage.
-     */
-    .social-media-link {
-      font-size: 16px !important;
-      text-decoration: none !important;
-    }
-  </style>
-
   <header class="navbar navbar-default navbar-static-top">
     <div class="container">
       <div class="navbar-header">

--- a/h/templates/old-home.html.jinja2
+++ b/h/templates/old-home.html.jinja2
@@ -166,9 +166,10 @@
                       <div>
                         <a title="Drag me to the bookmarks bar"
                             data-bookmarklet-button=""
+                            id="js-bookmarklet-install"
                             class="btn btn-primary btn-lg installer__button--draggable"
-                            href="javascript:(function(){window.hypothesisConfig=function(){return{showHighlights:true};};var d=document,s=d.createElement('script');s.setAttribute('src','{{ request.route_url("embed") }}');d.body.appendChild(s)})();"
-                            onclick="alert('Drag me to the bookmarks bar');return false;">Launch Hypothesis
+                            href="javascript:(function(){window.hypothesisConfig=function(){return{showHighlights:true};};var d=document,s=d.createElement('script');s.setAttribute('src','{{ request.route_url("embed") }}');d.body.appendChild(s)})();">
+                            Launch Hypothesis
                         </a>
                         <p><i class="h-icon-move"></i> Drag the button into
                         your bookmarks bar then click it to launch the

--- a/h/templates/old-home.html.jinja2
+++ b/h/templates/old-home.html.jinja2
@@ -102,8 +102,8 @@
 
                 <span class="hidden unhide-in-chrome">
                   <a class="btn btn-primary hidden-xs"
+                      id="js-chrome-extension-install"
                       href="{{ chrome_extension_link }}"
-                      onclick="chrome.webstore.install();return false;"
                       data-chromeext-button="">
                     <img alt="" class="installer__browser-logo--chrome"
                           src="{{ base_url }}assets/images/browser-chrome-64x64.png">

--- a/h/templates/old-home.html.jinja2
+++ b/h/templates/old-home.html.jinja2
@@ -150,20 +150,6 @@
                 <a href="#" class="" data-toggle="modal" data-target="#addtoyoursite" data-addtosite-button="">
                   add it to your website</a>.
               </p>
-              <script>
-                if (window.chrome !== undefined) {
-                  var elements = document.getElementsByClassName(
-                      "unhide-in-chrome");
-                  for (var i=0; i<elements.length; i++) {
-                    elements[i].classList.remove("hidden");
-                  }
-                  elements = document.getElementsByClassName(
-                      "hide-in-chrome");
-                  for (var i=0; i<elements.length; i++) {
-                    elements[i].classList.add("hidden");
-                  }
-                }
-              </script>
 
               <div class="modal fade" id="bookmarklet" tabindex="-1"
                     role="dialog" aria-hidden="true">


### PR DESCRIPTION
This fixes various CSP violations on the old homepage:

* We had inline styles for the press release banner
* We had inline Javascript for toggling the Chrome extension / Bookmarklet buttons
* `onclick` handler of the Chrome extension install button
* `onclick` handler of the Bookmarklet install button

Since I'm pretty much just moving existing (untested) code around, and because it is the old homepage which will hopefully not be around for much longer, I took the liberty to not write tests for the Javascript part.