### PR TITLE
CSP violation: client config on /docs/help and /welcome

### DIFF
--- a/h/templates/help.html.jinja2
+++ b/h/templates/help.html.jinja2
@@ -3,9 +3,7 @@
 {% block meta %}
   <link href='//fonts.googleapis.com/css?family=Lato:400,300' rel='stylesheet' type='text/css'>
   {{ super() }}
-  <script>
-    function hypothesisConfig() { return {firstRun: true}; }
-  </script>
+  <script type="application/json" class="js-hypothesis-config">{"firstRun":true}</script>`
   {% if not is_onboarding %}
     <script async defer src="{{ embed_js_url }}"></script>
   {% endif %}


### PR DESCRIPTION
This fixes the CSP violation we had due to the inline script that contains the client configuration. There is a new way to configure the client which is a script tag with type `application/json` and the class `js-hypothesis-config` which does not trigger a CSP error.