### PR TITLE
Preserve page query string when rendering feed URLs

### DIFF
--- a/h/views/main.py
+++ b/h/views/main.py
@@ -55,8 +55,8 @@ def robots(context, request):
 
 @view_config(route_name='stream')
 def stream(context, request):
-    atom = request.route_url('stream_atom')
-    rss = request.route_url('stream_rss')
+    atom = request.route_url('stream_atom', _query=request.query_string)
+    rss = request.route_url('stream_rss', _query=request.query_string)
     return render_app(request, {
         'link_tags': [
             {'rel': 'alternate', 'href': atom, 'type': 'application/atom+xml'},


### PR DESCRIPTION
The Atom and RSS feed URLs were always to the unfiltered stream. This makes sure that the query string used for the request to the stream page is also used in the URL to the feeds.

Fixes #3003.