### PR TITLE
Remove sudo from docker commands in docs

### DIFF
--- a/docs/hacking/install.rst
+++ b/docs/hacking/install.rst
@@ -116,15 +116,15 @@ installed on:
 
    .. code-block:: bash
 
-      sudo docker run -d --name postgres -p 5432:5432 postgres
-      sudo docker run -d --name elasticsearch -p 9200:9200 -p 9300:9300 nickstenning/elasticsearch-icu
-      sudo docker run -d --name rabbitmq -p 5672:5672 -p 15672:15672 --hostname rabbit rabbitmq:3-management
-      sudo docker run -d --name redis -p 6379:6379 redis
+      docker run -d --name postgres -p 5432:5432 postgres
+      docker run -d --name elasticsearch -p 9200:9200 -p 9300:9300 nickstenning/elasticsearch-icu
+      docker run -d --name rabbitmq -p 5672:5672 -p 15672:15672 --hostname rabbit rabbitmq:3-management
+      docker run -d --name redis -p 6379:6379 redis
 
    You'll now have four Docker containers named ``postgres``, ``elasticsearch``,
    ``rabbitmq`` and ``redis`` running and exposing their various services on the
-   ports defined above. You should be able to see them by running ``sudo docker
-   ps``. You should also be able to visit your Elasticsearch service by opening
+   ports defined above. You should be able to see them by running ``docker ps``.
+   You should also be able to visit your Elasticsearch service by opening
    http://127.0.0.1:9200/ in a browser, and connect to your PostgreSQL by
    running ``psql postgresql://postgres@localhost/postgres`` (if you have psql
    installed).
@@ -137,14 +137,14 @@ installed on:
 
       .. code-block:: bash
 
-         sudo docker start postgres elasticsearch rabbitmq redis
+         docker start postgres elasticsearch rabbitmq redis
 
 3. Create the `htest` database in the ``postgres`` container. This is needed
    to run the h tests:
 
    .. code-block:: bash
 
-      sudo docker run -it --link postgres:postgres --rm postgres sh -c 'exec psql -h "$POSTGRES_PORT_5432_TCP_ADDR" -p "$POSTGRES_PORT_5432_TCP_PORT" -U postgres -c "CREATE DATABASE htest;"'
+      docker run -it --link postgres:postgres --rm postgres sh -c 'exec psql -h "$POSTGRES_PORT_5432_TCP_ADDR" -p "$POSTGRES_PORT_5432_TCP_PORT" -U postgres -c "CREATE DATABASE htest;"'
 
 
 .. tip::
@@ -155,7 +155,7 @@ installed on:
 
    .. code-block:: bash
 
-      sudo docker run -it --link postgres:postgres --rm postgres sh -c 'exec psql -h "$POSTGRES_PORT_5432_TCP_ADDR" -p "$POSTGRES_PORT_5432_TCP_PORT" -U postgres'
+      docker run -it --link postgres:postgres --rm postgres sh -c 'exec psql -h "$POSTGRES_PORT_5432_TCP_ADDR" -p "$POSTGRES_PORT_5432_TCP_PORT" -U postgres'
 
    This runs psql in a fourth Docker container (from the same official
    PostgreSQL image, which also contains psql) and links it to your named
@@ -170,7 +170,7 @@ installed on:
 
    .. code-block:: bash
 
-      sudo docker logs rabbitmq
+      docker logs rabbitmq
 
    For more on how to use Docker see the `Docker website`_.
 
@@ -374,3 +374,27 @@ admin access rights using H's command-line tools.
 See the :doc:`../administration` documentation for information
 on how to give the initial user admin rights and access the Administration
 Dashboard.
+
+
+Troubleshooting
+---------------
+
+
+Cannot connect to the Docker daemon
+```````````````````````````````````
+
+If you get an error that looks like this when trying to run ``docker``
+commands::
+
+ Cannot connect to the Docker daemon. Is the docker daemon running on this host?
+ Error: failed to start containers: postgres
+
+it could be because you don't have permission to access the Unix socket that
+the docker daemon is bound to. On some operating systems (e.g. Linux) you need
+to either:
+
+* Take additional steps during Docker installation to give your Unix user
+  access to the Docker daemon's port (consult the installation
+  instructions for your operating system on the `Docker website`_), or
+
+* Prefix all ``docker`` commands with ``sudo``.


### PR DESCRIPTION
An awkward thing about our dev install docs is:

- On Linux you need to use sudo with all docker commands or you'll get
  an unhelpful error message.
- Unless you took additional steps during docker install to enable
  docker without sudo, in which case sudo is unnecessary but does no
  harm
- On OS X sudo docker is always unnecessary, but does no harm

Remove sudo from all docker commands, the docs now assume that linux
users took the extra steps in the docker install docs to enable no sudo,
and add the error message that they would get if they didn't to a new
troubleshooting section.

Troubleshooting sections at the bottoms of pages can be handy in docs:

- Keep lots of "if this happens then do this" details from cluttering
  the main flow of the docs

- While letting you cover as many potential problems as you like. It scales, this list at the bottom of the page can grow as long as it wants without harming the structure and flow of the rest of the docs.

- Put lots of problems in one place, each with their own subtitle, easy
  to find, easy to scan or search for

- Clear and simple docs structure. If you want to document a problem and
  solution, now you know where.

- Works well when the same problem can occur at multiple places in the
  instructions, we only need to document it in one place

- If some problem and solution is no longer relevant it can be deleted,
  but in the likely event that it does not get deleted it's not really
  doing any harm sitting at the bottom of the page where no one will
  look at it unless they get that error