### PR TITLE
Return all canonical uris when expanding a canonical uri

### DIFF
--- a/h/api/storage.py
+++ b/h/api/storage.py
@@ -222,13 +222,16 @@ def expand_uri(request, uri):
     if doc is None:
         return [uri]
 
-    # We check if the match was a "canonical" link. If so, all annotations
-    # created on that page are guaranteed to have that as their target.source
-    # field, so we don't need to expand to other URIs and risk false positives.
+    # We check if the match was a "canonical" link. If so, we return a list of
+    # all canonical uris we have stored in our database. This will surface all
+    # annotations since they are guaranteed to have the canonical uri as their
+    # target.source field.
+    # Since we return all canonical uris we have stored we also make sure that
+    # this behaviour still works when the website changes its canonical uri.
     docuris = doc.document_uris
     for docuri in docuris:
         if docuri.uri == uri and docuri.type == 'rel-canonical':
-            return [uri]
+            return [du.uri for du in docuris if du.type == 'rel-canonical']
 
     return [docuri.uri for docuri in docuris]
 

--- a/h/api/test/storage_test.py
+++ b/h/api/test/storage_test.py
@@ -80,7 +80,7 @@ class TestExpandURI(object):
         assert storage.expand_uri(request, "http://example.com/") == [
             "http://example.com/"]
 
-    def test_expand_uri_postgres_document_doesnt_expand_canonical_uris(
+    def test_expand_uri_postgres_document_returns_all_canonical_uris_when_canonical(
             self,
             postgres_enabled):
         request = DummyRequest(db=db.Session)
@@ -91,12 +91,14 @@ class TestExpandURI(object):
             DocumentURI(uri='http://bar.com/', claimant='http://example.com'),
             DocumentURI(uri='http://example.com/', type='rel-canonical',
                         claimant='http://example.com'),
+            DocumentURI(uri='https://example.com/', type='rel-canonical',
+                        claimant='https://example.com'),
         ])
         db.Session.add(document)
         db.Session.flush()
 
         assert storage.expand_uri(request, "http://example.com/") == [
-            "http://example.com/"]
+            "http://example.com/", "https://example.com/"]
 
     def test_expand_uri_elastic_document_doesnt_expand_canonical_uris(
             self,


### PR DESCRIPTION
_tldr;_ This would let us kill two birds with one stone, it allows us to surface old and new annotations 1) when the canonical uri changes, 2) a proposed fix for #3236 

_Long version:_
Before we always only returned the passed-in uri when it ended up being
a canonical uri for the stored document. This works well since all
annotations will have the canonical uri as the `target[source]`.

The only issue is that when a website changes its canonical uri, then we
can't surface the annotations that were made previously because they
won't have the same canonical uri.

This commit fixes that behavior in returning all canonical uris when we
detect that the passed-in uri is a canonical uri.