### PR TITLE
[Update annotations in Pg 2/3]: Do all validation in schemas

### DIFF
--- a/h/api/storage.py
+++ b/h/api/storage.py
@@ -14,6 +14,7 @@ from pyramid import i18n
 from h.api import transform
 from h.api import models
 from h.api.events import AnnotationBeforeSaveEvent
+from h.api.db import types
 
 
 _ = i18n.TranslationStringFactory(__package__)
@@ -51,7 +52,10 @@ def fetch_annotation(request, id, _postgres=None):
         _postgres = _postgres_enabled(request)
 
     if _postgres:
-        return request.db.query(models.Annotation).get(id)
+        try:
+            return request.db.query(models.Annotation).get(id)
+        except types.InvalidUUID:
+            return None
 
     return models.elastic.Annotation.fetch(id)
 

--- a/h/api/test/storage_test.py
+++ b/h/api/test/storage_test.py
@@ -63,6 +63,12 @@ class TestFetchAnnotation(object):
         models.elastic.Annotation.fetch.assert_called_once_with('123')
         assert models.elastic.Annotation.fetch.return_value == actual
 
+    def test_it_does_not_crash_if_id_is_invalid(self):
+        request = DummyRequest(db=db.Session)
+        postgres_enabled.return_value = True
+
+        assert storage.fetch_annotation(request, 'foo', _postgres=True) is None
+
 
 class TestExpandURI(object):
 


### PR DESCRIPTION
When creating new annotations a couple of validation rules were
implemented in h.api.storage.create_annotation() instead of in
h.api.schemas with the rest, because we didn't want h.api.schemas to
access the db:

1. Replies must have the same group as their parent.

   Actually this is transformation not validation - it just overwrites
   the group of a reply with that of its parent.

   This needed to be implemented in storage because it requires access
   to the db to look up the parent annotation.

2. The parent ID that a reply is in reply to must be an ID of an
   annotation that actually exists in the database.
   Requires db.

3. The user must have permission to create annotations in the group
   they're trying to create one in.

   This doesn't require db access, just effective_principals, but it has
   to happen _after_ 1 above because 1 might change the group so it had
   to be in storage for that reason.

There's a number of reasons why it's desirable to do _all_ validation in
schemas and none in storage:

a. Have all the validation code implemented in one place, and one call
   to validate() does all validation and transformation at once.

b. No validation or transformation going on in storage, keeps it simple.

c. The 3 bits of validation and transformation code above are actually needed
   by both storage.create_annotation() and the (to be implemented)
   PostgreSQL version of storage.update_annotation(). This means we'd
   have to either.

   i.   Duplicate the code and tests in create_annotation() and
        update_annotation(). But then we have duplication.
   ii.  Add a private helper function for create_annotation() and
        update_annotation() to call and unit test that function. But we
        don't like unit testing private functions.
  iii.  Make the private helper function public. But it shouldn't be
        public as it's not intended to be part of storage's public API.
   iv.  Make a new module to contain this validation code for storage to
        call and unit test that module.

   We _could_ do iv. but schemas.py already contains a place to put
   validation code that's shared between create and update
   (both CreateAnnotationSchema and UpdateAnnotationSchema inherit from
   AnnotationSchema) and putting all the validation code into schemas
   has the advantages a and b as well.

So move this validation code into schemas, which is going to make
implementing the PostgreSQL version of storage.update_annotation()
with no duplicate code or tests simpler.

Schemas is still a pure module: it takes dicts as inputs, gives dicts as
outputs, and doesn't create, update or delete anything in the db.

But it does import and read the db (via storage).

If we really don't want schemas to import storage at all then I'd
suggest [using jsonschema format functions](https://github.com/hypothesis/h/pull/3225) which would allow
schemas to declare that it depends on these validation functions, while
the validation functions themselves (which need access to storage) are
actually implemented in a different module, and then h.api.views injects
the validation functions from the separate module into schemas.
All validation declared in one place in schemas and carried out by one
call to validate(), no validation in storage, and no storage in schemas.

But for now this way is simple and direct.