### PR TITLE
[Update annotations in Pg 3/3]: Storage and view code for updating annotations in Postgres

### DIFF
--- a/h/api/storage.py
+++ b/h/api/storage.py
@@ -127,7 +127,7 @@ def create_annotation(request, data):
     return annotation
 
 
-def update_annotation(request, id, data):
+def legacy_update_annotation(request, id, data):
     """
     Update the annotation with the given id from passed data.
 

--- a/h/api/storage.py
+++ b/h/api/storage.py
@@ -14,6 +14,7 @@ from pyramid import i18n
 from h.api import transform
 from h.api import models
 from h.api.events import AnnotationBeforeSaveEvent
+from h.api.db import types
 
 
 _ = i18n.TranslationStringFactory(__package__)
@@ -51,7 +52,10 @@ def fetch_annotation(request, id, _postgres=None):
         _postgres = _postgres_enabled(request)
 
     if _postgres:
-        return request.db.query(models.Annotation).get(id)
+        try:
+            return request.db.query(models.Annotation).get(id)
+        except types.InvalidUUID:
+            return None
 
     return models.elastic.Annotation.fetch(id)
 

--- a/h/api/storage.py
+++ b/h/api/storage.py
@@ -72,6 +72,25 @@ def update_document_metadata(session,
                              annotation,
                              document_meta_dicts,
                              document_uri_dicts):
+    """
+    Create and update document metadata from the given annotation.
+
+    Document, DocumentURI and DocumentMeta objects will be created, updated
+    and deleted in the database as required by the given annotation and
+    document meta and uri dicts.
+
+    :param annotation: the annotation that the document metadata comes from
+    :type annotation: h.api.models.Annotation
+
+    :param document_meta_dicts: the document metadata dicts that the client
+        posted with the annotation, validated
+    :type document_meta_dicts: list of dicts
+
+    :param document_uri_dicts: the document URI dicts that the client
+        posted with the annotation, validated
+    :type document_uri_dicts: list of dicts
+
+    """
     documents = models.Document.find_or_create_by_uris(
         session,
         annotation.target_uri,

--- a/h/api/storage.py
+++ b/h/api/storage.py
@@ -135,6 +135,43 @@ def create_annotation(request, data):
     return annotation
 
 
+def update_annotation(session, annotation_id, data):
+    """
+    Update an existing annotation and its associated document metadata.
+
+    Update the annotation identified by annotation_id with the given
+    data. Create, delete and update document metadata as appropriate.
+
+    :param session: the database session
+    :type session: sqlalchemy.orm.session.Session
+
+    :param annotation_id: the ID of the annotation to be updated, this is
+        assumed to be a validated ID of an annotation that does already exist
+        in the database
+    :type annotation_id: string
+
+    :param data: the validated data with which to update the annotation
+    :type data: dict
+
+    :returns: the created annotation
+    :rtype: h.api.models.Annotation
+
+    """
+    document_uri_dicts = data['document']['document_uri_dicts']
+    document_meta_dicts = data['document']['document_meta_dicts']
+    del data['document']
+
+    annotation = models.Annotation.query.get(annotation_id)
+
+    for key, value in data.items():
+        setattr(annotation, key, value)
+
+    update_document_metadata(
+        session, annotation, document_meta_dicts, document_uri_dicts)
+
+    return annotation
+
+
 def legacy_update_annotation(request, id, data):
     """
     Update the annotation with the given id from passed data.

--- a/h/api/subscribers.py
+++ b/h/api/subscribers.py
@@ -10,7 +10,7 @@ def index_annotation_event(event):
     if not event.request.feature('postgres'):
         return
 
-    if event.action == 'create':
+    if event.action in ['create', 'update']:
         index(event.request.es, event.annotation, event.request)
     elif event.action == 'delete':
         delete(event.request.es, event.annotation)

--- a/h/api/test/storage_test.py
+++ b/h/api/test/storage_test.py
@@ -561,9 +561,73 @@ class TestCreateAnnotation(object):
             }
         }
 
+
+@pytest.mark.usefixtures('models',
+                         'update_document_metadata')
+class TestUpdateAnnotation(object):
+
+    def test_it_calls_get(self, annotation_data, models):
+        storage.update_annotation(mock.sentinel.session,
+                                  'test_annotation_id',
+                                  annotation_data)
+
+        models.Annotation.query.get.assert_called_once_with(
+            'test_annotation_id')
+
+    def test_it_updates_the_annotation(self, annotation_data, models):
+        annotation = models.Annotation.query.get.return_value = mock.Mock()
+
+        storage.update_annotation(mock.sentinel.session,
+                                  'test_annotation_id',
+                                  annotation_data)
+
+        for key, value in annotation_data.items():
+            assert getattr(annotation, key) == value
+
+    def test_it_calls_update_document_metadata(self,
+                                               annotation_data,
+                                               models,
+                                               update_document_metadata):
+        annotation = models.Annotation.query.get.return_value = mock.Mock()
+        annotation_data['document']['document_meta_dicts'] = (
+            mock.sentinel.document_meta_dicts)
+        annotation_data['document']['document_uri_dicts'] = (
+            mock.sentinel.document_uri_dicts)
+
+        storage.update_annotation(mock.sentinel.session,
+                                  'test_annotation_id',
+                                  annotation_data)
+
+        update_document_metadata.assert_called_once_with(
+            mock.sentinel.session,
+            annotation,
+            mock.sentinel.document_meta_dicts,
+            mock.sentinel.document_uri_dicts
+        )
+
+    def test_it_returns_the_annotation(self, annotation_data, models):
+        annotation = storage.update_annotation(mock.sentinel.session,
+                                               'test_annotation_id',
+                                               annotation_data)
+
+        assert annotation == models.Annotation.query.get.return_value
+
     @pytest.fixture
-    def update_document_metadata(self, patch):
-        return patch('h.api.storage.update_document_metadata')
+    def annotation_data(self):
+        return {
+            'userid': 'acct:test@localhost',
+            'text': 'text',
+            'tags': ['one', 'two'],
+            'shared': False,
+            'target_uri': 'http://www.example.com/example.html',
+            'groupid': '__world__',
+            'references': [],
+            'target_selectors': ['selector_one', 'selector_two'],
+            'document': {
+                'document_uri_dicts': [],
+                'document_meta_dicts': [],
+            }
+        }
 
 
 @pytest.mark.usefixtures('fetch_annotation')
@@ -674,3 +738,7 @@ def postgres_enabled(patch):
 @pytest.fixture
 def transform(patch):
     return patch('h.api.storage.transform')
+
+@pytest.fixture
+def update_document_metadata(patch):
+    return patch('h.api.storage.update_document_metadata')

--- a/h/api/test/storage_test.py
+++ b/h/api/test/storage_test.py
@@ -63,6 +63,12 @@ class TestFetchAnnotation(object):
         models.elastic.Annotation.fetch.assert_called_once_with('123')
         assert models.elastic.Annotation.fetch.return_value == actual
 
+    def test_it_does_not_crash_if_id_is_invalid(self):
+        request = DummyRequest(db=db.Session)
+        postgres_enabled.return_value = True
+
+        assert storage.fetch_annotation(request, 'foo', _postgres=True) is None
+
 
 class TestExpandURI(object):
 

--- a/h/api/test/views_test.py
+++ b/h/api/test/views_test.py
@@ -391,68 +391,263 @@ class TestReadJSONLD(object):
 
 @pytest.mark.usefixtures('AnnotationEvent',
                          'AnnotationJSONPresenter',
+                         'elastic',
+                         'schemas',
+                         'storage')
+class TestUpdateLegacy(object):
+
+    """Tests for update() when the 'postgres' feature flag is off."""
+
+    def test_it_raises_if_json_parsing_fails(self, mock_request):
+        """It raises PayloadError if parsing of the request body fails."""
+        # Make accessing the request.json_body property raise ValueError.
+        type(mock_request).json_body = mock.PropertyMock(
+            side_effect=ValueError)
+
+        with pytest.raises(views.PayloadError):
+            views.update(mock.Mock(), mock_request)
+
+    def test_it_fetches_the_legacy_annotation(self, elastic, mock_request):
+        annotation = mock.Mock()
+
+        views.update(annotation, mock_request)
+
+        elastic.Annotation.fetch.assert_called_once_with(annotation.id)
+
+    def test_it_does_not_init_the_schema(self, mock_request, schemas):
+        views.update(mock.Mock(), mock_request)
+
+        assert not schemas.UpdateAnnotationSchema.called
+
+    def test_it_does_not_call_update_annotation(self,
+                                               mock_request,
+                                               storage,
+                                               schemas):
+        schema = schemas.UpdateAnnotationSchema.return_value
+
+        views.update(mock.Mock(), mock_request)
+
+        assert not storage.update_annotation.called
+
+    def test_it_inits_the_legacy_schema(self, elastic, mock_request, schemas):
+        legacy_annotation = elastic.Annotation.fetch.return_value = mock.Mock()
+
+        views.update(legacy_annotation, mock_request)
+
+        schemas.LegacyUpdateAnnotationSchema.assert_called_once_with(
+            mock_request, legacy_annotation)
+
+    def test_it_calls_legacy_validate(self, copy, mock_request, schemas):
+        copy.deepcopy.side_effect = lambda x: x
+        legacy_schema = schemas.LegacyUpdateAnnotationSchema.return_value
+
+        views.update(mock.Mock(), mock_request)
+
+        legacy_schema.validate.assert_called_once_with(mock_request.json_body)
+
+    def test_it_calls_legacy_update_annotation(self,
+                                               elastic,
+                                               mock_request,
+                                               schemas,
+                                               storage):
+        legacy_annotation = elastic.Annotation.fetch.return_value = mock.Mock()
+
+        views.update(mock.Mock(), mock_request)
+
+        storage.legacy_update_annotation.assert_called_once_with(
+            mock_request,
+            legacy_annotation.id,
+            schemas.LegacyUpdateAnnotationSchema.return_value.validate\
+                .return_value)
+
+    def test_it_inits_an_AnnotationEvent(self,
+                                         AnnotationEvent,
+                                         mock_request,
+                                         storage):
+        annotation = mock.Mock()
+
+        views.update(annotation, mock_request)
+
+        AnnotationEvent.assert_called_once_with(
+            mock_request,
+            storage.legacy_update_annotation.return_value,
+            'update')
+
+    def test_it_calls_notify(self, AnnotationEvent, mock_request):
+        views.update(mock.Mock(), mock_request)
+
+        mock_request.registry.notify.assert_called_once_with(
+            AnnotationEvent.return_value)
+
+    def test_it_inits_a_presenter(self,
+                                  AnnotationJSONPresenter,
+                                  mock_request,
+                                  storage):
+        views.update(mock.Mock(), mock_request)
+
+        AnnotationJSONPresenter.assert_called_once_with(
+            mock_request, storage.legacy_update_annotation.return_value)
+
+    def test_it_dictizes_the_presenter(self,
+                                       AnnotationJSONPresenter,
+                                       mock_request):
+        returned = views.update(mock.Mock(), mock_request)
+
+        AnnotationJSONPresenter.return_value.asdict.assert_called_once_with()
+
+    def test_it_returns_a_presented_dict(self,
+                                         AnnotationJSONPresenter,
+                                         mock_request):
+        returned = views.update(mock.Mock(), mock_request)
+
+        assert returned == (
+            AnnotationJSONPresenter.return_value.asdict.return_value)
+
+    @pytest.fixture
+    def elastic(self, patch):
+        return patch('h.api.views.elastic')
+
+    @pytest.fixture
+    def mock_request(self):
+        return mock.Mock(feature=mock.Mock(return_value=False))
+
+
+@pytest.mark.usefixtures('AnnotationEvent',
+                         'AnnotationJSONPresenter',
+                         'elastic',
                          'schemas',
                          'storage')
 class TestUpdate(object):
 
-    def test_it_raises_if_json_parsing_fails(self):
+    def test_it_raises_if_json_parsing_fails(self, mock_request):
         """It raises PayloadError if parsing of the request body fails."""
-        request = mock.Mock()
-
         # Make accessing the request.json_body property raise ValueError.
-        type(request).json_body = mock.PropertyMock(side_effect=ValueError)
+        type(mock_request).json_body = mock.PropertyMock(
+            side_effect=ValueError)
 
         with pytest.raises(views.PayloadError):
-            views.update(mock.Mock(), request)
+            views.update(mock.Mock(), mock_request)
 
-    def test_it_calls_validator(self, schemas):
+    def test_it_fetches_the_legacy_annotation(self, elastic, mock_request):
         annotation = mock.Mock()
-        request = mock.Mock()
-        schema = schemas.LegacyUpdateAnnotationSchema.return_value
 
-        views.update(annotation, request)
+        views.update(annotation, mock_request)
 
-        schema.validate.assert_called_once_with(request.json_body)
+        elastic.Annotation.fetch.assert_called_once_with(annotation.id)
 
-    def test_it_calls_legacy_update_annotation(self, storage, schemas):
+    def test_it_inits_the_schema(self, mock_request, schemas):
         annotation = mock.Mock()
-        request = mock.Mock()
-        schema = schemas.LegacyUpdateAnnotationSchema.return_value
-        schema.validate.return_value = {'foo': 123}
 
-        views.update(annotation, request)
+        views.update(annotation, mock_request)
 
-        storage.legacy_update_annotation.assert_called_once_with(request,
-                                                                 annotation.id,
-                                                                 {'foo': 123})
+        schemas.UpdateAnnotationSchema.assert_called_once_with(mock_request,
+                                                               annotation)
 
-    def test_it_returns_presented_annotation(self,
-                                             AnnotationJSONPresenter,
-                                             storage):
+    def test_it_calls_validate(self, copy, mock_request, schemas):
         annotation = mock.Mock()
-        request = mock.Mock()
-        presenter = mock.Mock()
-        AnnotationJSONPresenter.return_value = presenter
+        copy.deepcopy.side_effect = lambda x: x
+        schema = schemas.UpdateAnnotationSchema.return_value
 
-        result = views.update(annotation, request)
+        views.update(annotation, mock_request)
+
+        schema.validate.assert_called_once_with(mock_request.json_body)
+
+    def test_it_calls_update_annotation(self,
+                                        elastic,
+                                        mock_request,
+                                        storage,
+                                        schemas):
+        annotation = mock.Mock()
+        schema = schemas.UpdateAnnotationSchema.return_value
+        schema.validate.return_value = mock.sentinel.validated_data
+
+        views.update(annotation, mock_request)
+
+        storage.update_annotation.assert_called_once_with(
+            mock_request.db,
+            annotation.id,
+            mock.sentinel.validated_data
+        )
+
+    def test_it_inits_the_legacy_schema(self, elastic, mock_request, schemas):
+        legacy_annotation = elastic.Annotation.fetch.return_value = mock.Mock()
+
+        views.update(legacy_annotation, mock_request)
+
+        schemas.LegacyUpdateAnnotationSchema.assert_called_once_with(
+            mock_request, legacy_annotation)
+
+    def test_it_calls_legacy_validate(self, copy, mock_request, schemas):
+        copy.deepcopy.side_effect = lambda x: x
+        legacy_schema = schemas.LegacyUpdateAnnotationSchema.return_value
+
+        views.update(mock.Mock(), mock_request)
+
+        legacy_schema.validate.assert_called_once_with(mock_request.json_body)
+
+    def test_it_calls_legacy_update_annotation(self,
+                                               elastic,
+                                               mock_request,
+                                               schemas,
+                                               storage):
+        legacy_annotation = elastic.Annotation.fetch.return_value = mock.Mock()
+
+        views.update(mock.Mock(), mock_request)
+
+        storage.legacy_update_annotation.assert_called_once_with(
+            mock_request,
+            legacy_annotation.id,
+            schemas.LegacyUpdateAnnotationSchema.return_value.validate\
+                .return_value)
+
+    def test_it_inits_an_AnnotationEvent(self,
+                                         AnnotationEvent,
+                                         mock_request,
+                                         storage):
+        annotation = mock.Mock()
+
+        views.update(annotation, mock_request)
+
+        AnnotationEvent.assert_called_once_with(
+            mock_request, storage.update_annotation.return_value, 'update')
+
+    def test_it_calls_notify(self, AnnotationEvent, mock_request):
+        views.update(mock.Mock(), mock_request)
+
+        mock_request.registry.notify.assert_called_once_with(
+            AnnotationEvent.return_value)
+
+    def test_it_inits_a_presenter(self,
+                                  AnnotationJSONPresenter,
+                                  mock_request,
+                                  storage):
+        views.update(mock.Mock(), mock_request)
 
         AnnotationJSONPresenter.assert_called_once_with(
-            request,
-            storage.legacy_update_annotation.return_value)
-        assert result == presenter.asdict()
+            mock_request, storage.update_annotation.return_value)
 
-    def test_it_calls_notify_with_an_event(self, AnnotationEvent, storage):
-        annotation = mock.Mock()
-        request = mock.Mock()
-        event = AnnotationEvent.return_value
-        annotation_out = storage.legacy_update_annotation.return_value
+    def test_it_dictizes_the_presenter(self,
+                                       AnnotationJSONPresenter,
+                                       mock_request):
+        returned = views.update(mock.Mock(), mock_request)
 
-        views.update(annotation, request)
+        AnnotationJSONPresenter.return_value.asdict.assert_called_once_with()
 
-        AnnotationEvent.assert_called_once_with(request,
-                                                annotation_out,
-                                                'update')
-        request.registry.notify.assert_called_once_with(event)
+    def test_it_returns_a_presented_dict(self,
+                                         AnnotationJSONPresenter,
+                                         mock_request):
+        returned = views.update(mock.Mock(), mock_request)
+
+        assert returned == (
+            AnnotationJSONPresenter.return_value.asdict.return_value)
+
+    @pytest.fixture
+    def elastic(self, patch):
+        return patch('h.api.views.elastic')
+
+    @pytest.fixture
+    def mock_request(self):
+        return mock.Mock(feature=mock.Mock(return_value=True))
 
 
 @pytest.mark.usefixtures('AnnotationEvent',

--- a/h/api/test/views_test.py
+++ b/h/api/test/views_test.py
@@ -414,7 +414,7 @@ class TestUpdate(object):
 
         schema.validate.assert_called_once_with(request.json_body)
 
-    def test_it_calls_update_annotation(self, storage, schemas):
+    def test_it_calls_legacy_update_annotation(self, storage, schemas):
         annotation = mock.Mock()
         request = mock.Mock()
         schema = schemas.LegacyUpdateAnnotationSchema.return_value
@@ -422,9 +422,9 @@ class TestUpdate(object):
 
         views.update(annotation, request)
 
-        storage.update_annotation.assert_called_once_with(request,
-                                                          annotation.id,
-                                                          {'foo': 123})
+        storage.legacy_update_annotation.assert_called_once_with(request,
+                                                                 annotation.id,
+                                                                 {'foo': 123})
 
     def test_it_returns_presented_annotation(self,
                                              AnnotationJSONPresenter,
@@ -438,14 +438,14 @@ class TestUpdate(object):
 
         AnnotationJSONPresenter.assert_called_once_with(
             request,
-            storage.update_annotation.return_value)
+            storage.legacy_update_annotation.return_value)
         assert result == presenter.asdict()
 
     def test_it_calls_notify_with_an_event(self, AnnotationEvent, storage):
         annotation = mock.Mock()
         request = mock.Mock()
         event = AnnotationEvent.return_value
-        annotation_out = storage.update_annotation.return_value
+        annotation_out = storage.legacy_update_annotation.return_value
 
         views.update(annotation, request)
 

--- a/h/api/test/views_test.py
+++ b/h/api/test/views_test.py
@@ -252,7 +252,7 @@ class TestCreate(object):
         views.create(request)
 
         storage.create_annotation.assert_called_once_with(
-            request, schema.validate.return_value)
+            request.db, schema.validate.return_value)
 
     def test_it_inits_LegacyCreateAnnotationSchema(self, schemas):
         request = self.mock_request()

--- a/h/api/views.py
+++ b/h/api/views.py
@@ -207,7 +207,9 @@ def update(annotation, request):
     schema = schemas.LegacyUpdateAnnotationSchema(request,
                                                   annotation=annotation)
     appstruct = schema.validate(_json_payload(request))
-    annotation = storage.update_annotation(request, annotation.id, appstruct)
+    annotation = storage.legacy_update_annotation(request,
+                                                  annotation.id,
+                                                  appstruct)
 
     _publish_annotation_event(request, annotation, 'update')
 

--- a/h/api/views.py
+++ b/h/api/views.py
@@ -29,6 +29,7 @@ from h.api.presenters import AnnotationJSONLDPresenter
 from h.api import search as search_lib
 from h.api import schemas
 from h.api import storage
+from h.api.models import elastic
 
 _ = i18n.TranslationStringFactory(__package__)
 
@@ -201,20 +202,37 @@ def read_jsonld(annotation, request):
     return presenter.asdict()
 
 
-@api_config(route_name='api.annotation', request_method='PUT', permission='update')
+@api_config(route_name='api.annotation',
+            request_method='PUT',
+            permission='update')
 def update(annotation, request):
     """Update the specified annotation with data from the PUT payload."""
-    schema = schemas.LegacyUpdateAnnotationSchema(request,
-                                                  annotation=annotation)
-    appstruct = schema.validate(_json_payload(request))
-    annotation = storage.legacy_update_annotation(request,
-                                                  annotation.id,
-                                                  appstruct)
+    json_payload = _json_payload(request)
 
-    _publish_annotation_event(request, annotation, 'update')
+    legacy_annotation = elastic.Annotation.fetch(annotation.id)
 
-    presenter = AnnotationJSONPresenter(request, annotation)
-    return presenter.asdict()
+    # Validate the annotation for, and update the annotation in, PostgreSQL.
+    if request.feature('postgres'):
+        schema = schemas.UpdateAnnotationSchema(request, annotation=annotation)
+        appstruct = schema.validate(copy.deepcopy(json_payload))
+        annotation = storage.update_annotation(request.db,
+                                               annotation.id,
+                                               appstruct)
+
+    # Validate the annotation for, and update the annotation in, Elasticsearch.
+    legacy_schema = schemas.LegacyUpdateAnnotationSchema(
+        request, annotation=legacy_annotation)
+    legacy_appstruct = legacy_schema.validate(copy.deepcopy(json_payload))
+    legacy_annotation = storage.legacy_update_annotation(request,
+                                                         legacy_annotation.id,
+                                                         legacy_appstruct)
+
+    if request.feature('postgres'):
+        _publish_annotation_event(request, annotation, 'update')
+        return AnnotationJSONPresenter(request, annotation).asdict()
+    else:
+        _publish_annotation_event(request, legacy_annotation, 'update')
+        return AnnotationJSONPresenter(request, legacy_annotation).asdict()
 
 
 @api_config(route_name='api.annotation', request_method='DELETE', permission='delete')

--- a/h/api/views.py
+++ b/h/api/views.py
@@ -161,7 +161,7 @@ def create(request):
     if request.feature('postgres'):
         schema = schemas.CreateAnnotationSchema(request)
         appstruct = schema.validate(copy.deepcopy(json_payload))
-        annotation = storage.create_annotation(request, appstruct)
+        annotation = storage.create_annotation(request.db, appstruct)
 
     # Validate the annotation for, and create the annotation in, Elasticsearch.
     legacy_schema = schemas.LegacyCreateAnnotationSchema(request)


### PR DESCRIPTION
This is branched off <https://github.com/hypothesis/h/pull/3243> so the diff is wrong. You can't really use this without the (upcoming) view code for making annotations in Pg. But the tests pass, and it still works with postgres off.