### PR TITLE
Publish events in response callback

### DIFF
--- a/h/api/events.py
+++ b/h/api/events.py
@@ -4,10 +4,15 @@
 class AnnotationEvent(object):
     """An event representing an action on an annotation."""
 
-    def __init__(self, request, annotation, action):
+    def __init__(self, request, annotation_dict, action):
         self.request = request
-        self.annotation = annotation
+        self.annotation_dict = annotation_dict
         self.action = action
+
+    @property
+    def annotation_id(self):
+        if self.annotation_dict:
+            return self.annotation_dict.get('id')
 
 
 class AnnotationBeforeSaveEvent(object):

--- a/h/api/search/index.py
+++ b/h/api/search/index.py
@@ -41,7 +41,7 @@ def index(es, annotation, request):
     )
 
 
-def delete(es, annotation):
+def delete(es, annotation_id):
     """
     Delete an annotation from the search index.
 
@@ -60,8 +60,8 @@ def delete(es, annotation):
         es.conn.delete(
             index=es.index,
             doc_type=es.t.annotation,
-            id=annotation.id,
+            id=annotation_id,
         )
     except elasticsearch.NotFoundError:
         log.exception('Tried to delete a nonexistent annotation from the '
-                      'search index, annotation id: %s', annotation.id)
+                      'search index, annotation id: %s', annotation_id)

--- a/h/api/search/test/index_test.py
+++ b/h/api/search/test/index_test.py
@@ -58,9 +58,7 @@ class TestIndexAnnotation:
 class TestDeleteAnnotation:
 
     def test_it_deletes_the_annotation(self, es):
-        annotation = mock.Mock(id='test_annotation_id')
-
-        index.delete(es, annotation)
+        index.delete(es, 'test_annotation_id')
 
         es.conn.delete.assert_called_once_with(
             index='hypothesis',

--- a/h/api/subscribers.py
+++ b/h/api/subscribers.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+from h.api import storage
 from h.api.search.index import index
 from h.api.search.index import delete
 
@@ -11,6 +12,7 @@ def index_annotation_event(event):
         return
 
     if event.action == 'create':
-        index(event.request.es, event.annotation, event.request)
+        annotation = storage.fetch_annotation(event.request, event.annotation_id)
+        index(event.request.es, annotation, event.request)
     elif event.action == 'delete':
-        delete(event.request.es, event.annotation)
+        delete(event.request.es, event.annotation_id)

--- a/h/api/test/events_test.py
+++ b/h/api/test/events_test.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+
+import mock
+
+from h.api import events
+
+
+class TestAnnotationEvent(object):
+    def test_annotation_id(self):
+        id_ = 'test-annotation-id'
+        event = events.AnnotationEvent(mock.Mock(), {'id': id_}, 'create')
+        assert event.annotation_id == id_
+
+    def test_annotation_id_empty(self):
+        event = events.AnnotationEvent(mock.Mock(), {}, 'create')
+        assert event.annotation_id is None

--- a/h/api/test/views_test.py
+++ b/h/api/test/views_test.py
@@ -185,7 +185,7 @@ class TestCreateLegacy(object):
             request,
             storage.legacy_create_annotation.return_value,
             'create')
-        request.registry.notify.assert_called_once_with(
+        request.notify_after_commit.assert_called_once_with(
             AnnotationEvent.return_value)
 
     def test_it_returns_presented_annotation(self,
@@ -318,7 +318,7 @@ class TestCreate(object):
             request,
             storage.create_annotation.return_value,
             'create')
-        request.registry.notify.assert_called_once_with(
+        request.notify_after_commit.assert_called_once_with(
             AnnotationEvent.return_value)
 
     def test_it_returns_presented_annotation(self,
@@ -452,7 +452,7 @@ class TestUpdate(object):
         AnnotationEvent.assert_called_once_with(request,
                                                 annotation_out,
                                                 'update')
-        request.registry.notify.assert_called_once_with(event)
+        request.notify_after_commit.assert_called_once_with(event)
 
 
 @pytest.mark.usefixtures('AnnotationEvent',
@@ -477,7 +477,7 @@ class TestDelete(object):
         views.delete(annotation, request)
 
         AnnotationEvent.assert_called_once_with(request, annotation, 'delete')
-        request.registry.notify.assert_called_once_with(event)
+        request.notify_after_commit.assert_called_once_with(event)
 
     def test_it_returns_object(self):
         annotation = mock.Mock()

--- a/h/api/test/views_test.py
+++ b/h/api/test/views_test.py
@@ -175,15 +175,21 @@ class TestCreateLegacy(object):
 
     def test_it_publishes_annotation_event(self,
                                            AnnotationEvent,
+                                           AnnotationJSONPresenter,
                                            storage):
         """It publishes an annotation "create" event for the annotation."""
         request = self.mock_request()
 
         views.create(request)
 
+        annotation = storage.legacy_create_annotation.return_value
+
+        AnnotationJSONPresenter.assert_called_once_with(request, annotation)
+        presented = AnnotationJSONPresenter.return_value.asdict()
+
         AnnotationEvent.assert_called_once_with(
             request,
-            storage.legacy_create_annotation.return_value,
+            presented,
             'create')
         request.notify_after_commit.assert_called_once_with(
             AnnotationEvent.return_value)
@@ -308,15 +314,21 @@ class TestCreate(object):
 
     def test_it_publishes_annotation_event(self,
                                            AnnotationEvent,
+                                           AnnotationJSONPresenter,
                                            storage):
         """It publishes an annotation "create" event for the annotation."""
         request = self.mock_request()
 
         views.create(request)
 
+        annotation = storage.create_annotation.return_value
+
+        AnnotationJSONPresenter.assert_called_once_with(request, annotation)
+        presented = AnnotationJSONPresenter.return_value.asdict()
+
         AnnotationEvent.assert_called_once_with(
             request,
-            storage.create_annotation.return_value,
+            presented,
             'create')
         request.notify_after_commit.assert_called_once_with(
             AnnotationEvent.return_value)
@@ -441,7 +453,7 @@ class TestUpdate(object):
             storage.update_annotation.return_value)
         assert result == presenter.asdict()
 
-    def test_it_calls_notify_with_an_event(self, AnnotationEvent, storage):
+    def test_it_calls_notify_with_an_event(self, AnnotationEvent, AnnotationJSONPresenter, storage):
         annotation = mock.Mock()
         request = mock.Mock()
         event = AnnotationEvent.return_value
@@ -449,8 +461,11 @@ class TestUpdate(object):
 
         views.update(annotation, request)
 
+        AnnotationJSONPresenter.assert_called_once_with(request, annotation_out)
+        presented = AnnotationJSONPresenter.return_value.asdict()
+
         AnnotationEvent.assert_called_once_with(request,
-                                                annotation_out,
+                                                presented,
                                                 'update')
         request.notify_after_commit.assert_called_once_with(event)
 
@@ -469,14 +484,17 @@ class TestDelete(object):
         storage.delete_annotation.assert_called_once_with(request,
                                                           annotation.id)
 
-    def test_it_calls_notify_with_an_event(self, AnnotationEvent):
+    def test_it_calls_notify_with_an_event(self, AnnotationEvent, AnnotationJSONPresenter):
         annotation = mock.Mock()
         request = mock.Mock()
         event = AnnotationEvent.return_value
 
         views.delete(annotation, request)
 
-        AnnotationEvent.assert_called_once_with(request, annotation, 'delete')
+        AnnotationJSONPresenter.assert_called_once_with(request, annotation)
+        presented = AnnotationJSONPresenter.return_value.asdict()
+
+        AnnotationEvent.assert_called_once_with(request, presented, 'delete')
         request.notify_after_commit.assert_called_once_with(event)
 
     def test_it_returns_object(self):

--- a/h/api/views.py
+++ b/h/api/views.py
@@ -254,7 +254,7 @@ def _present_searchdict(request, mapping):
 def _publish_annotation_event(request, annotation, action):
     """Publish an event to the annotations queue for this annotation action"""
     event = AnnotationEvent(request, annotation, action)
-    request.registry.notify(event)
+    request.notify_after_commit(event)
 
 
 def includeme(config):

--- a/h/app.py
+++ b/h/app.py
@@ -4,6 +4,7 @@
 
 from __future__ import unicode_literals
 
+import collections
 import logging
 
 from pyramid.tweens import EXCVIEW
@@ -44,6 +45,32 @@ def create_app(global_config, **settings):
     config = configure(settings=settings)
     config.include(__name__)
     return config.make_wsgi_app()
+
+
+class EventQueue(object):
+    def __init__(self, request):
+        self.request = request
+        self.queue = collections.deque()
+
+        request.add_response_callback(self.response_callback)
+
+    def __call__(self, event):
+        self.queue.append(event)
+
+    def publish_all(self):
+        while True:
+            try:
+                event = self.queue.popleft()
+            except IndexError:
+                break
+            self.request.registry.notify(event)
+
+    def response_callback(self, request, response):
+        if request.exception is not None:
+            return
+
+        with request.tm:
+            self.publish_all()
 
 
 def includeme(config):
@@ -93,6 +120,9 @@ def includeme(config):
             "style-src": ["'self'", "fonts.googleapis.com"],
         },
     })
+
+    # After commit events
+    config.add_request_method(EventQueue, name='notify_after_commit', reify=True)
 
     # API module
     #

--- a/h/subscribers.py
+++ b/h/subscribers.py
@@ -4,6 +4,7 @@ from h import __version__
 from h import emails
 from h import mailer
 from h.api import presenters
+from h.api import storage
 from h.notification import reply
 
 
@@ -26,12 +27,9 @@ def add_renderer_globals(event):
 
 def publish_annotation_event(event):
     """Publish an annotation event to the message queue."""
-    annotation_dict = presenters.AnnotationJSONPresenter(
-        event.request, event.annotation).asdict()
-
     data = {
         'action': event.action,
-        'annotation': annotation_dict,
+        'annotation': event.annotation_dict,
         'src_client_id': event.request.headers.get('X-Client-Id'),
     }
 
@@ -44,7 +42,7 @@ def send_reply_notifications(event,
                              send=mailer.send.delay):
     """Queue any reply notification emails triggered by an annotation event."""
     request = event.request
-    annotation = event.annotation
+    annotation = storage.fetch_annotation(event.request, event.annotation_id)
     action = event.action
     try:
         notification = get_notification(request, annotation, action)

--- a/h/test/app_test.py
+++ b/h/test/app_test.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+
+import mock
+import pytest
+
+from pyramid.testing import DummyRequest
+
+from h import app
+
+
+class TestEventQueue(object):
+    def test_init_adds_response_callback(self):
+        request = mock.Mock()
+        queue = app.EventQueue(request)
+
+        request.add_response_callback.assert_called_once_with(queue.response_callback)
+
+    def test_call_appends_event_to_queue(self):
+        queue = app.EventQueue(mock.Mock())
+
+        assert len(queue.queue) == 0
+        event = mock.Mock()
+        queue(event)
+        assert list(queue.queue) == [event]
+
+    def test_publish_all_notifies_events_in_fifo_order(self):
+        request = DummyRequest()
+        request.registry.notify = mock.Mock(spec=lambda event: None)
+        queue = app.EventQueue(request)
+        firstevent = mock.Mock()
+        queue(firstevent)
+        secondevent = mock.Mock()
+        queue(secondevent)
+
+        queue.publish_all()
+
+        assert request.registry.notify.call_args_list == [
+            mock.call(firstevent),
+            mock.call(secondevent)
+        ]
+
+    def test_response_callback_skips_publishing_events_on_exception(self, publish_all):
+        request = DummyRequest(exception=ValueError('exploded!'))
+        queue = app.EventQueue(request)
+        queue.response_callback(request, None)
+        assert not publish_all.called
+
+    def test_response_callback_publishes_events(self, publish_all):
+        request = DummyRequest(exception=None, tm=mock.MagicMock())
+        queue = app.EventQueue(request)
+        queue(mock.Mock())
+        queue.response_callback(request, None)
+        assert publish_all.called
+
+    @pytest.fixture
+    def publish_all(self, patch):
+        return patch('h.app.EventQueue.publish_all')


### PR DESCRIPTION
We now publish pyramid `AnnotationEvent` after the request's transaction has been successfully committed. This is necessary to prevent a race condition with the background indexer (#3242) where the celery task could be running before the transaction that creates the Postgres annotation is committed.
This is desirable on a more general level anyway, since many subscribers are kicking off some kind of task (sending an email, notifying websocket clients, etc.) which we don't want to run when the transaction could fail. But this PR only includes the implementation for moving the publishing of the `h.api.events.AnnotationEvent` into a pyramid [response callback](http://docs.pylonsproject.org/projects/pyramid/en/latest/narr/hooks.html#using-response-callbacks) ([here](http://docs.pylonsproject.org/projects/pyramid/en/latest/narr/router.html) a diagram that illustrates when different components are being called during a request).

It is now possible (and encouraged) to instead of publishing events immediately in the views to enqueue them with `request.after_commit_events.append()`. We have one response callback that publishes all events to the registry in one isolated transaction.
Currently, this means that we can't put mapped SQLAlchemy objects in the events, as those will be detached from the session when accessed in a different transaction. For the moment we just load the annotation from the database again (where necessary), this adds a few Postgres roundtrips which is not ideal, but good enough for now :tm:. We should find more optimized ways of dealing with reloads - mostly moving functionality of subscribers into celery tasks, and / or caching the newly mapped annotations in the event so other subscribers can re-use them.

I have manually tested 1) reply notifications, 2) synchronous ES indexing (which be removed soon anyway), and 3) real-time websockets creating/deleting annotations, and verified that all these still work.