### PR TITLE
Fix a couple of slow front-end tests and enable slow test reporting

### DIFF
--- a/h/static/scripts/karma.config.js
+++ b/h/static/scripts/karma.config.js
@@ -91,5 +91,8 @@ module.exports = function(config) {
     // Continuous Integration mode
     // if true, Karma captures browsers, runs the tests and exits
     singleRun: false,
+
+    // Log slow tests so we can fix them before they timeout
+    reportSlowerThan: 500,
   });
 };

--- a/h/static/scripts/test/bridge-test.coffee
+++ b/h/static/scripts/test/bridge-test.coffee
@@ -37,7 +37,9 @@ describe 'Bridge', ->
 
     it 'adds the channel to the .links property', ->
       channel = createChannel()
-      assert.include(bridge.links, {channel: channel, window: fakeWindow})
+      assert.isTrue(bridge.links.some((link) ->
+        link.channel == channel && link.window == fakeWindow
+      ))
 
     it 'registers any existing listeners on the channel', ->
       message1 = sandbox.spy()

--- a/h/static/scripts/test/retry-util-test.js
+++ b/h/static/scripts/test/retry-util-test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var retryUtil = require('../retry-util');
 var toResult = require('./promise-util').toResult;
 
@@ -35,8 +37,8 @@ describe('retry-util', function () {
         return Promise.reject(error);
       });
       var wrappedOperation = retryUtil.retryPromiseOperation(operation, {
-        minTimeout: 1,
-        maxRetries: 2,
+        minTimeout: 3,
+        retries: 2,
       });
       return toResult(wrappedOperation).then(function (result) {
         assert.equal(result.error, error);


### PR DESCRIPTION
This fixes a couple of front-end tests running much more slowly, relatively speaking, than they should have been. One of these, the 'Bridge' test, has flaked out on Travis a few times in the past.

I've also enabled slow test reporting in Karma with a threshold set at 500ms (vs. the test timeout of 2000ms) which should help us to spot slow tests before they cause Travis failures.