### PR TITLE
Show adder if user makes a selection and then launches the plugin.

### DIFF
--- a/h/static/scripts/annotator/adder.html
+++ b/h/static/scripts/annotator/adder.html
@@ -1,0 +1,10 @@
+<div class="annotator-adder">
+  <div class="annotator-adder-actions">
+    <button class="annotator-adder-actions__button h-icon-annotate" data-action="comment">
+      <span class="annotator-adder-actions__label" data-action="comment">Annotate</span>
+    </button>
+    <button class="annotator-adder-actions__button h-icon-highlight" data-action="highlight">
+      <span class="annotator-adder-actions__label" data-action="highlight">Highlight</span>
+    </button>
+  </div>
+</div>

--- a/h/static/scripts/annotator/adder.js
+++ b/h/static/scripts/annotator/adder.js
@@ -9,10 +9,20 @@ var classnames = require('classnames');
 var ARROW_POINTING_DOWN = 1;
 
 /**
+ * Show the adder above the selection with an arrow pointing down at the
+ * selected text.
+ */
+var ARROW_POINTING_UP = 2;
+
+/**
  * Returns the HTML template for the adder.
  */
 function template() {
   return require('./adder.html');
+}
+
+function toPx(pixels) {
+  return pixels.toString() + 'px';
 }
 
 /**
@@ -22,23 +32,103 @@ function template() {
  * @param {JQuery} element - jQuery element for the adder.
  */
 function Adder(element) {
+  this.element = element;
+
+  var ARROW_HEIGHT = 10;
+
+  // The preferred gap between the end of the text selection and the adder's
+  // arrow position.
+  var ARROW_H_MARGIN = 20;
+
+  var view = element.ownerDocument.defaultView;
+
+  // Set initial style. The adder is hidden using the `visibility`
+  // property rather than `display` so that we can compute its size in order to
+  // position it before display.
+  element.style.display = 'block';
+  element.style.visibility = 'hidden';
+
+  function width() {
+    return element.getBoundingClientRect().width;
+  }
+
+  function height() {
+    return element.getBoundingClientRect().height;
+  }
+
+  /** Hide the adder */
   this.hide = function () {
-    element.hide();
+    element.style.visibility = 'hidden';
   };
 
-  this.showAt = function (position, arrowDirection) {
-    element[0].className = classnames({
+  /**
+   * Return the best position to show the adder in order to target the
+   * selected text in `targetRect`.
+   *
+   * @param {Rect} targetRect - The rect of text to target, in document
+   *        coordinates.
+   * @param {boolean} isSelectionBackwards - True if the selection was made
+   *        backwards, such that the focus point is at the left edge of
+   *        `targetRect`.
+   */
+  this.target = function (targetRect, isSelectionBackwards) {
+    // Set position and arrow direction depending on available space
+    var arrowDirection = ARROW_POINTING_DOWN;
+    var top;
+    var left;
+
+    // Position the adder such that the arrow it is above or below the selection
+    // and close to the end.
+    var hMargin = Math.min(ARROW_H_MARGIN, targetRect.width);
+    if (isSelectionBackwards) {
+      left = targetRect.left - width() / 2 + hMargin;
+    } else {
+      left = targetRect.left + targetRect.width - width() / 2 - hMargin;
+    }
+
+    // Note: `pageYOffset` is used instead of `scrollY` here for
+    // IE compatibility
+    if (targetRect.top - height() < view.pageYOffset &&
+        arrowDirection === ARROW_POINTING_DOWN) {
+      arrowDirection = ARROW_POINTING_UP;
+    }
+
+    if (arrowDirection === ARROW_POINTING_UP) {
+      top = targetRect.top + targetRect.height + ARROW_HEIGHT;
+    } else {
+      top = targetRect.top - height() - ARROW_HEIGHT;
+    }
+
+    // Constrain the adder to the viewport
+    left = Math.max(left, view.pageXOffset);
+    left = Math.min(left, view.pageXOffset + view.innerWidth - width());
+
+    top = Math.max(top, view.pageYOffset);
+    top = Math.min(top, view.pageYOffset + view.innerHeight - height());
+
+    return {top: top, left: left, arrowDirection: arrowDirection};
+  };
+
+  /**
+   * Show the adder at the given position and with the arrow pointing in
+   * `arrowDirection`.
+   */
+  this.showAt = function (left, top, arrowDirection) {
+    element.className = classnames({
       'annotator-adder': true,
       'annotator-adder--arrow-down': arrowDirection === ARROW_POINTING_DOWN,
+      'annotator-adder--arrow-up': arrowDirection === ARROW_POINTING_UP,
     });
-    element[0].style.top = position.top;
-    element[0].style.left = position.left;
-    element.show();
+    element.style.top = toPx(top);
+    element.style.left = toPx(left);
+    element.style.visibility = 'visible';
   };
 }
 
 module.exports = {
   ARROW_POINTING_DOWN: ARROW_POINTING_DOWN,
+  ARROW_POINTING_UP: ARROW_POINTING_UP,
+
   template: template,
   Adder: Adder,
 };

--- a/h/static/scripts/annotator/adder.js
+++ b/h/static/scripts/annotator/adder.js
@@ -72,8 +72,14 @@ function Adder(element) {
    *        `targetRect`.
    */
   this.target = function (targetRect, isSelectionBackwards) {
-    // Set position and arrow direction depending on available space
-    var arrowDirection = ARROW_POINTING_DOWN;
+    // Set the initial arrow direction based on whether the selection was made
+    // upwards or downwards.
+    var arrowDirection;
+    if (isSelectionBackwards) {
+      arrowDirection = ARROW_POINTING_DOWN;
+    } else {
+      arrowDirection = ARROW_POINTING_UP;
+    }
     var top;
     var left;
 
@@ -86,11 +92,16 @@ function Adder(element) {
       left = targetRect.left + targetRect.width - width() / 2 - hMargin;
     }
 
+    // Flip arrow direction if adder would appear above the top or below
+    // the bottom of the page.
+    //
     // Note: `pageYOffset` is used instead of `scrollY` here for
     // IE compatibility
     if (targetRect.top - height() < view.pageYOffset &&
         arrowDirection === ARROW_POINTING_DOWN) {
       arrowDirection = ARROW_POINTING_UP;
+    } else if (targetRect.top + height() > view.pageYOffset + view.innerHeight) {
+      arrowDirection = ARROW_POINTING_DOWN;
     }
 
     if (arrowDirection === ARROW_POINTING_UP) {

--- a/h/static/scripts/annotator/adder.js
+++ b/h/static/scripts/annotator/adder.js
@@ -9,14 +9,12 @@ var classnames = require('classnames');
 var ARROW_POINTING_DOWN = 1;
 
 /**
- * Show the adder above the selection with an arrow pointing down at the
+ * Show the adder above the selection with an arrow pointing up at the
  * selected text.
  */
 var ARROW_POINTING_UP = 2;
 
-/**
- * Returns the HTML template for the adder.
- */
+/** Returns the HTML template for the adder. */
 function template() {
   return require('./adder.html');
 }
@@ -25,20 +23,20 @@ function toPx(pixels) {
   return pixels.toString() + 'px';
 }
 
+var ARROW_HEIGHT = 10;
+
+// The preferred gap between the end of the text selection and the adder's
+// arrow position.
+var ARROW_H_MARGIN = 20;
+
 /**
  * Controller for the 'adder' toolbar which appears next to the selection
  * and provides controls for the user to create new annotations.
  *
- * @param {JQuery} element - jQuery element for the adder.
+ * @param {Element} element - DOM element for the adder, created from template()
  */
 function Adder(element) {
   this.element = element;
-
-  var ARROW_HEIGHT = 10;
-
-  // The preferred gap between the end of the text selection and the adder's
-  // arrow position.
-  var ARROW_H_MARGIN = 20;
 
   var view = element.ownerDocument.defaultView;
 
@@ -68,12 +66,12 @@ function Adder(element) {
    * @param {Rect} targetRect - The rect of text to target, in document
    *        coordinates.
    * @param {boolean} isSelectionBackwards - True if the selection was made
-   *        backwards, such that the focus point is at the left edge of
-   *        `targetRect`.
+   *        backwards, such that the focus point is mosty likely at the top-left
+   *        edge of `targetRect`.
    */
   this.target = function (targetRect, isSelectionBackwards) {
     // Set the initial arrow direction based on whether the selection was made
-    // upwards or downwards.
+    // forwards/upwards or downwards/backwards.
     var arrowDirection;
     if (isSelectionBackwards) {
       arrowDirection = ARROW_POINTING_DOWN;
@@ -92,11 +90,11 @@ function Adder(element) {
       left = targetRect.left + targetRect.width - width() / 2 - hMargin;
     }
 
-    // Flip arrow direction if adder would appear above the top or below
-    // the bottom of the page.
+    // Flip arrow direction if adder would appear above the top or below the
+    // bottom of the viewport.
     //
-    // Note: `pageYOffset` is used instead of `scrollY` here for
-    // IE compatibility
+    // Note: `pageYOffset` is used instead of `scrollY` here for IE
+    // compatibility
     if (targetRect.top - height() < view.pageYOffset &&
         arrowDirection === ARROW_POINTING_DOWN) {
       arrowDirection = ARROW_POINTING_UP;
@@ -110,7 +108,7 @@ function Adder(element) {
       top = targetRect.top - height() - ARROW_HEIGHT;
     }
 
-    // Constrain the adder to the viewport
+    // Constrain the adder to the viewport.
     left = Math.max(left, view.pageXOffset);
     left = Math.min(left, view.pageXOffset + view.innerWidth - width());
 

--- a/h/static/scripts/annotator/adder.js
+++ b/h/static/scripts/annotator/adder.js
@@ -1,0 +1,44 @@
+'use strict';
+
+var classnames = require('classnames');
+
+/**
+ * Show the adder above the selection with an arrow pointing down at the
+ * selected text.
+ */
+var ARROW_POINTING_DOWN = 1;
+
+/**
+ * Returns the HTML template for the adder.
+ */
+function template() {
+  return require('./adder.html');
+}
+
+/**
+ * Controller for the 'adder' toolbar which appears next to the selection
+ * and provides controls for the user to create new annotations.
+ *
+ * @param {JQuery} element - jQuery element for the adder.
+ */
+function Adder(element) {
+  this.hide = function () {
+    element.hide();
+  };
+
+  this.showAt = function (position, arrowDirection) {
+    element[0].className = classnames({
+      'annotator-adder': true,
+      'annotator-adder--arrow-down': arrowDirection === ARROW_POINTING_DOWN,
+    });
+    element[0].style.top = position.top;
+    element[0].style.left = position.left;
+    element.show();
+  };
+}
+
+module.exports = {
+  ARROW_POINTING_DOWN: ARROW_POINTING_DOWN,
+  template: template,
+  Adder: Adder,
+};

--- a/h/static/scripts/annotator/guest.coffee
+++ b/h/static/scripts/annotator/guest.coffee
@@ -1,5 +1,4 @@
 baseURI = require('document-base-uri')
-classnames = require('classnames')
 extend = require('extend')
 raf = require('raf')
 scrollIntoView = require('scroll-into-view')

--- a/h/static/scripts/annotator/guest.coffee
+++ b/h/static/scripts/annotator/guest.coffee
@@ -48,7 +48,7 @@ module.exports = class Guest extends Annotator
   constructor: (element, options) ->
     super
 
-    this.adderCtrl = new adder.Adder(@adder)
+    this.adderCtrl = new adder.Adder(@adder[0])
     this.anchors = []
 
     cfOptions =
@@ -353,8 +353,10 @@ module.exports = class Guest extends Annotator
     else
       # Show the adder button
       selection = Annotator.Util.getGlobal().getSelection()
-      this.adderCtrl.showAt(rangeUtil.selectionEndPosition(selection),
-                            adder.ARROW_POINTING_DOWN)
+      isBackwards = rangeUtil.isSelectionBackwards(selection)
+      focusRect = rangeUtil.selectionFocusRect(selection)
+      {left, top, arrowDirection} = this.adderCtrl.target(focusRect, isBackwards)
+      this.adderCtrl.showAt(left, top, arrowDirection)
     true
 
   onFailedSelection: (event) ->

--- a/h/static/scripts/annotator/guest.coffee
+++ b/h/static/scripts/annotator/guest.coffee
@@ -7,7 +7,7 @@ Annotator = require('annotator')
 $ = Annotator.$
 
 highlighter = require('./highlighter')
-
+rangeUtil = require('./range-util')
 
 animationPromise = (fn) ->
   return new Promise (resolve, reject) ->
@@ -16,7 +16,6 @@ animationPromise = (fn) ->
         resolve(fn())
       catch error
         reject(error)
-
 
 module.exports = class Guest extends Annotator
   SHOW_HIGHLIGHTS_CLASS = 'annotator-highlights-always-on'
@@ -196,6 +195,7 @@ module.exports = class Guest extends Annotator
         range = Annotator.Range.sniff(anchor.range)
         normedRange = range.normalize(root)
         highlights = highlighter.highlightRange(normedRange)
+
         $(highlights).data('annotation', anchor.annotation)
         anchor.highlights = highlights
         return anchor
@@ -341,6 +341,11 @@ module.exports = class Guest extends Annotator
     tags = (a.$$tag for a in annotations)
     @crossframe?.call('focusAnnotations', tags)
 
+  showAdder: (position) ->
+    @adder
+      .css(position)
+      .show()
+
   onSuccessfulSelection: (event, immediate) ->
     unless event?
       throw "Called onSuccessfulSelection without an event!"
@@ -360,10 +365,8 @@ module.exports = class Guest extends Annotator
       @onAdderClick event
     else
       # Show the adder button
-      @adder
-        .css(Annotator.Util.mousePosition(event, @element[0]))
-        .show()
-
+      selection = Annotator.Util.getGlobal().getSelection()
+      this.showAdder(rangeUtil.selectionEndPosition(selection))
     true
 
   onFailedSelection: (event) ->

--- a/h/static/scripts/annotator/plugin/textselection.coffee
+++ b/h/static/scripts/annotator/plugin/textselection.coffee
@@ -10,6 +10,7 @@ module.exports = class TextSelection extends Annotator.Plugin
     $(document).bind({
       "touchend": @checkForEndSelection
       "mouseup": @checkForEndSelection
+      "ready": @checkForEndSelection
     })
 
     null
@@ -18,6 +19,7 @@ module.exports = class TextSelection extends Annotator.Plugin
     $(document).unbind({
       "touchend": @checkForEndSelection
       "mouseup": @checkForEndSelection
+      "ready": @checkForEndSelection
     })
     super
 

--- a/h/static/scripts/annotator/range-util.js
+++ b/h/static/scripts/annotator/range-util.js
@@ -116,12 +116,13 @@ function getTextBoundingBoxes(range) {
 }
 
 /**
- * Returns the rectangle for the line of text containing the focus point
- * of a Selection.
+ * Returns the rectangle, in document coordinates, for the line of text
+ * containing the focus point of a Selection.
+ *
+ * Returns null if the selection is empty.
  *
  * @param {Selection} selection
- * @return {Object?} A rect containing the coordinates in the document of the
- *         line of text containing the focus point of the selection.
+ * @return {Rect?}
  */
 function selectionFocusRect(selection) {
   if (selection.isCollapsed) {

--- a/h/static/scripts/annotator/range-util.js
+++ b/h/static/scripts/annotator/range-util.js
@@ -1,0 +1,143 @@
+'use strict';
+
+function translate(rect, x, y) {
+  return {
+    left: rect.left + x,
+    top: rect.top + y,
+    width: rect.width,
+    height: rect.height,
+  };
+}
+
+function mapViewportRectToDocument(window, rect) {
+  // `pageXOffset` and `pageYOffset` are used rather than `scrollX`
+  // and `scrollY` for IE 10/11 compatibility.
+  return translate(rect, window.pageXOffset, window.pageYOffset);
+}
+
+/**
+ * Returns true if the start point of a selection occurs after the end point,
+ * in document order.
+ */
+function isSelectionBackwards(selection) {
+  if (selection.focusNode === selection.anchorNode) {
+    return selection.focusOffset < selection.anchorOffset;
+  }
+
+  var range = selection.getRangeAt(0);
+  return range.startContainer === selection.focusNode;
+}
+
+/**
+ * Returns true if `node` is between the `startContainer` and `endContainer` of
+ * the given `range`, inclusive.
+ *
+ * @param {Range} range
+ * @param {Node} node
+ */
+function isNodeInRange(range, node) {
+  if (node === range.startContainer || node === range.endContainer) {
+    return true;
+  }
+
+  /* jshint -W016 */
+  var isAfterStart = range.startContainer.compareDocumentPosition(node) &
+   Node.DOCUMENT_POSITION_FOLLOWING;
+  var isBeforeEnd = range.endContainer.compareDocumentPosition(node) &
+   Node.DOCUMENT_POSITION_PRECEDING;
+
+  return isAfterStart && isBeforeEnd;
+}
+
+/**
+ * Iterate over all Node(s) in `range` in document order and invoke `callback`
+ * for each of them.
+ *
+ * @param {Range} range
+ * @param {Function} callback
+ */
+function forEachNodeInRange(range, callback) {
+  var root = range.commonAncestorContainer;
+
+  // The `whatToShow`, `filter` and `expandEntityReferences` arguments are
+  // mandatory in IE although optional according to the spec.
+  var nodeIter = root.ownerDocument.createNodeIterator(root,
+    NodeFilter.SHOW_ALL, null /* filter */, false /* expandEntityReferences */);
+
+  /* jshint -W084 */
+  var currentNode;
+  while (currentNode = nodeIter.nextNode()) {
+    if (isNodeInRange(range, currentNode)) {
+      callback(currentNode);
+    }
+  }
+}
+
+/**
+ * Returns the bounding rectangles of non-whitespace text nodes in `range`.
+ *
+ * @param {Range} range
+ * @return {Array<Rect>} Array of bounding rects in document coordinates.
+ */
+function getTextBoundingBoxes(range) {
+  var whitespaceOnly = /^\s*$/;
+  var textNodes = [];
+  forEachNodeInRange(range, function (node) {
+    if (node.nodeType === Node.TEXT_NODE &&
+        !node.textContent.match(whitespaceOnly)) {
+      textNodes.push(node);
+    }
+  });
+
+  var rects = [];
+  textNodes.forEach(function (node) {
+    var nodeRange = node.ownerDocument.createRange();
+    nodeRange.selectNodeContents(node);
+    if (node === range.startContainer) {
+      nodeRange.setStart(node, range.startOffset);
+    }
+    if (node === range.endContainer) {
+      nodeRange.setEnd(node, range.endOffset);
+    }
+    if (nodeRange.collapsed) {
+      // If the range ends at the start of this text node or starts at the end
+      // of this node then do not include it.
+      return;
+    }
+
+    // Measure the range and translate from viewport to document coordinates
+    var viewportRects = Array.from(nodeRange.getClientRects());
+    nodeRange.detach();
+    rects = rects.concat(viewportRects.map(function (rect) {
+      return mapViewportRectToDocument(node.ownerDocument.defaultView, rect);
+    }));
+  });
+  return rects;
+}
+
+/**
+ * Returns the coordinates of the end (ie. at the focus point) of the text in a
+ * selection.
+ *
+ * @param {Selection} selection
+ * @return {Object?} The X and Y coordinates of the selection.
+ */
+function selectionEndPosition(selection) {
+  if (selection.isCollapsed) {
+    return null;
+  }
+  var textBoxes = getTextBoundingBoxes(selection.getRangeAt(0));
+  if (textBoxes.length === 0) {
+    return null;
+  }
+  if (isSelectionBackwards(selection)) {
+    return {top: textBoxes[0].top, left: textBoxes[0].left};
+  } else {
+    var lastBox = textBoxes[textBoxes.length - 1];
+    return {top: lastBox.top, left: lastBox.left + lastBox.width};
+  }
+}
+
+module.exports = {
+  selectionEndPosition: selectionEndPosition,
+};

--- a/h/static/scripts/annotator/range-util.js
+++ b/h/static/scripts/annotator/range-util.js
@@ -116,13 +116,14 @@ function getTextBoundingBoxes(range) {
 }
 
 /**
- * Returns the coordinates of the end (ie. at the focus point) of the text in a
- * selection.
+ * Returns the rectangle for the line of text containing the focus point
+ * of a Selection.
  *
  * @param {Selection} selection
- * @return {Object?} The X and Y coordinates of the selection.
+ * @return {Object?} A rect containing the coordinates in the document of the
+ *         line of text containing the focus point of the selection.
  */
-function selectionEndPosition(selection) {
+function selectionFocusRect(selection) {
   if (selection.isCollapsed) {
     return null;
   }
@@ -130,14 +131,15 @@ function selectionEndPosition(selection) {
   if (textBoxes.length === 0) {
     return null;
   }
+
   if (isSelectionBackwards(selection)) {
-    return {top: textBoxes[0].top, left: textBoxes[0].left};
+    return textBoxes[0];
   } else {
-    var lastBox = textBoxes[textBoxes.length - 1];
-    return {top: lastBox.top, left: lastBox.left + lastBox.width};
+    return textBoxes[textBoxes.length - 1];
   }
 }
 
 module.exports = {
-  selectionEndPosition: selectionEndPosition,
+  isSelectionBackwards: isSelectionBackwards,
+  selectionFocusRect: selectionFocusRect,
 };

--- a/h/static/scripts/annotator/test/adder-test.js
+++ b/h/static/scripts/annotator/test/adder-test.js
@@ -1,0 +1,66 @@
+'use strict';
+
+var adder = require('../adder');
+
+function rect(left, top, width, height) {
+  return {left: left, top: top, width: width, height: height};
+}
+
+describe('adder', function () {
+  var adderCtrl;
+  beforeEach(function () {
+    var adderEl = document.createElement('div');
+    adderEl.innerHTML = adder.template();
+    adderEl = adderEl.firstChild;
+    document.body.appendChild(adderEl.firstChild);
+
+    adderCtrl = new adder.Adder(adderEl.firstChild);
+  });
+
+  afterEach(function () {
+    adderCtrl.element.parentNode.removeChild(adderCtrl.element);
+  });
+
+  function windowSize() {
+    var window = adderCtrl.element.ownerDocument.defaultView;
+    return {width: window.innerWidth, height: window.innerHeight};
+  }
+
+  function adderSize() {
+    var rect = adderCtrl.element.getBoundingClientRect();
+    return {width: rect.width, height: rect.height};
+  }
+
+  describe('#target', function () {
+    it('positions the adder above the selection', function () {
+      var target = adderCtrl.target(rect(100,200,100,20), false);
+      assert.isAbove(target.top, 100);
+      assert.isAbove(target.left, 100);
+      assert.isBelow(target.left, 200);
+      assert.equal(target.arrowDirection, adder.ARROW_POINTING_DOWN);
+    });
+
+    it('does not position the adder above the top of the viewport', function () {
+      var target = adderCtrl.target(rect(100,-100,100,20), false);
+      assert.isAtLeast(target.top, 0);
+      assert.equal(target.arrowDirection, adder.ARROW_POINTING_UP);
+    });
+
+    it('does not position the adder below the bottom of the viewport', function () {
+      var viewSize = windowSize();
+      var target = adderCtrl.target(rect(0,viewSize.height + 100,10,20), false);
+      assert.isAtMost(target.top, viewSize.height - adderSize().height);
+    });
+
+    it('does not position the adder beyond the right edge of the viewport', function () {
+      var viewSize = windowSize();
+      var target = adderCtrl.target(rect(viewSize.width + 100,100,10,20), false);
+      assert.isAtMost(target.left, viewSize.width);
+    });
+
+    it('does not positon the adder beyond the left edge of the viewport', function () {
+      var target = adderCtrl.target(rect(-100,100,10,10), false);
+      assert.isAtLeast(target.left, 0);
+    });
+  });
+});

--- a/h/static/scripts/annotator/test/adder-test.js
+++ b/h/static/scripts/annotator/test/adder-test.js
@@ -32,9 +32,17 @@ describe('adder', function () {
   }
 
   describe('#target', function () {
-    it('positions the adder above the selection', function () {
+    it('positions the adder below the selection if the selection is forwards', function () {
       var target = adderCtrl.target(rect(100,200,100,20), false);
-      assert.isAbove(target.top, 100);
+      assert.isAbove(target.top, 220);
+      assert.isAbove(target.left, 100);
+      assert.isBelow(target.left, 200);
+      assert.equal(target.arrowDirection, adder.ARROW_POINTING_UP);
+    });
+
+    it('positions the adder above the selection if the selection is backwards', function () {
+      var target = adderCtrl.target(rect(100,200,100,20), true);
+      assert.isBelow(target.top, 200);
       assert.isAbove(target.left, 100);
       assert.isBelow(target.left, 200);
       assert.equal(target.arrowDirection, adder.ARROW_POINTING_DOWN);

--- a/h/static/scripts/annotator/test/range-util-test.js
+++ b/h/static/scripts/annotator/test/range-util-test.js
@@ -11,7 +11,7 @@ describe('range-util', function () {
     selection.collapse();
 
     testNode = document.createElement('span');
-    testNode.innerHTML = 'Some text content here';
+    testNode.innerHTML = 'Some text <br>content here';
     document.body.appendChild(testNode);
   });
 
@@ -25,28 +25,30 @@ describe('range-util', function () {
     selection.addRange(range);
   }
 
-  describe('#selectionEndPosition', function () {
+  describe('#selectionFocusRect', function () {
     it('returns null if the selection is empty', function () {
-      assert.isNull(rangeUtil.selectionEndPosition(selection));
+      assert.isNull(rangeUtil.selectionFocusRect(selection));
     });
 
     it('returns a point if the selection is not empty', function () {
       selectNode(testNode);
-      assert.ok(rangeUtil.selectionEndPosition(selection));
+      assert.ok(rangeUtil.selectionFocusRect(selection));
     });
 
-    it('returns the top-left corner if the selection is backwards', function () {
+    it('returns the first line\'s rect if the selection is backwards', function () {
       selectNode(testNode);
       selection.collapseToEnd();
       selection.extend(testNode, 0);
-      var pos = rangeUtil.selectionEndPosition(selection);
-      assert.equal(pos.left, testNode.offsetLeft);
+      var rect = rangeUtil.selectionFocusRect(selection);
+      assert.equal(rect.left, testNode.offsetLeft);
+      assert.equal(rect.top, testNode.offsetTop);
     });
 
-    it('returns the bottom-right corner if the selection is forwards', function () {
+    it('returns the last line\'s rect if the selection is forwards', function () {
       selectNode(testNode);
-      var pos = rangeUtil.selectionEndPosition(selection);
-      assert.equal(pos.left, testNode.offsetLeft + testNode.offsetWidth);
+      var rect = rangeUtil.selectionFocusRect(selection);
+      assert.equal(rect.left, testNode.offsetLeft);
+      assert.equal(rect.top + rect.height, testNode.offsetTop + testNode.offsetHeight);
     });
   });
 });

--- a/h/static/scripts/annotator/test/range-util-test.js
+++ b/h/static/scripts/annotator/test/range-util-test.js
@@ -1,0 +1,52 @@
+'use strict';
+
+var rangeUtil = require('../range-util');
+
+describe('range-util', function () {
+  var selection;
+  var testNode;
+
+  beforeEach(function () {
+    selection = window.getSelection();
+    selection.collapse();
+
+    testNode = document.createElement('span');
+    testNode.innerHTML = 'Some text content here';
+    document.body.appendChild(testNode);
+  });
+
+  afterEach(function () {
+    testNode.parentElement.removeChild(testNode);
+  });
+
+  function selectNode(node) {
+    var range = testNode.ownerDocument.createRange();
+    range.selectNodeContents(node);
+    selection.addRange(range);
+  }
+
+  describe('#selectionEndPosition', function () {
+    it('returns null if the selection is empty', function () {
+      assert.isNull(rangeUtil.selectionEndPosition(selection));
+    });
+
+    it('returns a point if the selection is not empty', function () {
+      selectNode(testNode);
+      assert.ok(rangeUtil.selectionEndPosition(selection));
+    });
+
+    it('returns the top-left corner if the selection is backwards', function () {
+      selectNode(testNode);
+      selection.collapseToEnd();
+      selection.extend(testNode, 0);
+      var pos = rangeUtil.selectionEndPosition(selection);
+      assert.equal(pos.left, testNode.offsetLeft);
+    });
+
+    it('returns the bottom-right corner if the selection is forwards', function () {
+      selectNode(testNode);
+      var pos = rangeUtil.selectionEndPosition(selection);
+      assert.equal(pos.left, testNode.offsetLeft + testNode.offsetWidth);
+    });
+  });
+});

--- a/h/static/scripts/polyfills.js
+++ b/h/static/scripts/polyfills.js
@@ -4,6 +4,7 @@
 require('core-js/es6/promise');
 require('core-js/fn/array/find');
 require('core-js/fn/array/find-index');
+require('core-js/fn/array/from');
 require('core-js/fn/object/assign');
 
 // URL constructor, required by IE 10/11,

--- a/h/static/styles/annotator/adder.scss
+++ b/h/static/styles/annotator/adder.scss
@@ -1,8 +1,6 @@
 .annotator-adder {
   box-sizing: border-box;
   direction: ltr;
-  margin-top: -60px;
-  margin-left: -65px;
   position: absolute;
   background: $white;
   border: 1px solid rgba(0,0,0,0.20);
@@ -30,6 +28,11 @@
 .annotator-adder--arrow-down:before {
   @include adder-arrow(45deg);
   bottom: -5px;
+}
+
+.annotator-adder--arrow-up:before {
+  @include adder-arrow(225deg);
+  top: -5px;
 }
 
 .annotator-adder-actions {

--- a/h/static/styles/annotator/adder.scss
+++ b/h/static/styles/annotator/adder.scss
@@ -1,0 +1,75 @@
+.annotator-adder {
+  box-sizing: border-box;
+  direction: ltr;
+  margin-top: -60px;
+  margin-left: -65px;
+  position: absolute;
+  background: $white;
+  border: 1px solid rgba(0,0,0,0.20);
+  border-radius: 4px;
+  box-shadow: 0px 0px 4px 0px rgba(0,0,0,0.15);
+  z-index: 999;
+}
+
+@mixin adder-arrow($rotation) {
+  transform: rotate($rotation);
+  background: $white;
+  border-bottom: 1px solid rgba(0,0,0,0.20);
+  border-right: 1px solid rgba(0,0,0,0.20);
+  content: "";
+  display: block;
+  height: 6px;
+  left: 0;
+  margin-left: auto;
+  margin-right: auto;
+  position: absolute;
+  right: 0;
+  width: 6px;
+}
+
+.annotator-adder--arrow-down:before {
+  @include adder-arrow(45deg);
+  bottom: -5px;
+}
+
+.annotator-adder-actions {
+  display: flex;
+  flex-direction: row;
+}
+
+.annotator-adder-actions:hover .annotator-adder-actions__button {
+  color: $gray-light !important;
+}
+
+.annotator-adder-actions__button {
+  @include box-shadow(none);
+  font-family: h;
+  font-size: 18px;
+  background: transparent !important;
+  color: $gray-dark !important;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  border: none;
+  cursor: pointer;
+
+  padding-top: 7px;
+  padding-bottom: 6px;
+  padding-left: 10px;
+  padding-right: 10px;
+}
+
+.annotator-adder-actions .annotator-adder-actions__button:hover {
+  color: $gray-dark !important;
+
+  .annotator-adder-actions__label {
+    color: $gray-dark !important;
+  }
+}
+
+.annotator-adder-actions__label {
+  font-size: 11px;
+  margin: 2px 0px;
+  font-family: sans-serif;
+  color: $gray-light !important;
+}

--- a/h/static/styles/annotator/inject.scss
+++ b/h/static/styles/annotator/inject.scss
@@ -1,81 +1,9 @@
 @import '../base';
 @import '../mixins/icons';
 
+@import './adder';
+
 $base-font-size: 14px;
-
-//ADDER////////////////////////////////
-.annotator-adder {
-  box-sizing: border-box;
-  direction: ltr;
-  margin-top: -60px;
-  margin-left: -65px;
-  position: absolute;
-  background: $white;
-  border: 1px solid rgba(0,0,0,0.20);
-  border-radius: 4px;
-  box-shadow: 0px 0px 4px 0px rgba(0,0,0,0.15);
-  z-index: 999;
-}
-
-.annotator-adder:before {
-  @include rotate(45deg);
-  background: $white;
-  bottom: -5px;
-  border-bottom: 1px solid rgba(0,0,0,0.20);
-  border-right: 1px solid rgba(0,0,0,0.20);
-  content: "";
-  display: block;
-  height: 6px;
-  left: 0;
-  margin-left: auto;
-  margin-right: auto;
-  position: absolute;
-  right: 0;
-  width: 6px;
-}
-
-.annotator-adder-actions {
-  display: flex;
-  flex-direction: row;
-}
-
-.annotator-adder-actions:hover .annotator-adder-actions__button {
-  color: $gray-light !important;
-}
-
-.annotator-adder-actions__button {
-  @include box-shadow(none);
-  font-family: h;
-  font-size: 18px;
-  background: transparent !important;
-  color: $gray-dark !important;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  border: none;
-  cursor: pointer;
-
-  padding-top: 7px;
-  padding-bottom: 6px;
-  padding-left: 10px;
-  padding-right: 10px;
-}
-
-.annotator-adder-actions .annotator-adder-actions__button:hover {
-  color: $gray-dark !important;
-
-  .annotator-adder-actions__label {
-    color: $gray-dark !important;
-  }
-}
-
-.annotator-adder-actions__label {
-  font-size: 11px;
-  margin: 2px 0px;
-  font-family: sans-serif;
-  color: $gray-light !important;
-}
-
 
 //HIGHLIGHTS////////////////////////////////
 .annotator-highlights-always-on {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "browserify": "^13.0.0",
     "browserify-ngannotate": "^1.0.1",
     "browserify-shim": "^3.8.12",
+    "classnames": "^2.2.4",
     "coffeeify": "^1.0.0",
     "commander": "^2.9.0",
     "compass-mixins": "^0.12.7",


### PR DESCRIPTION
If a user selects some text, and then realises that Hypothesis isn't
active, their first reaction will probably be to activate Hypothesis.
In this scenario, we should pop up the adder near the selection on launch.

 * If there is a selection when the 'ready' event fires, show the adder
   at the focus point of the selection.

 * For consistency, show the adder at the focus point of the selection
   after a selection whilst Hypothesis is active.

 * Add 'range-util' module which provides utility functions to get
   the coordinates at the end of the selection.

   'range-util' uses the DOM Range, Selection and NodeIterator APIs directly
   rather than Annotator's Range functions for several reasons:

   1) Given that H now requires IE >= 10, all of our target browsers
      have all the APIs that we need.

   2) Using the DOM APIs directly proved easier to debug and test.