### PR TITLE
Make client test page load embed from same hostname as test page

### DIFF
--- a/scripts/gulp/live-reload-server.js
+++ b/scripts/gulp/live-reload-server.js
@@ -38,9 +38,11 @@ function LiveReloadServer(port, appServer) {
     <body>
       <pre style="margin: 75px;">${changelogText()}</pre>
       <script>
+      var appHost = document.location.hostname;
+
       window.hypothesisConfig = function () {
         return {
-          liveReloadServer: 'ws://localhost:${port}',
+          liveReloadServer: 'ws://' + appHost + ':${port}',
 
           // Open the sidebar when the page loads
           firstRun: true,
@@ -52,8 +54,11 @@ function LiveReloadServer(port, appServer) {
           window.location.reload();
         }
       });
+
+      var embedScript = document.createElement('script');
+      embedScript.src = '${appServer}/embed.js'.replace('localhost', appHost);
+      document.body.appendChild(embedScript);
       </script>
-      <script src="${appServer}/embed.js"></script>
     </body>
     </html>
       `;


### PR DESCRIPTION
Previously the live reload server at http://localhost:3000 hardcoded the
embed script to 'http://localhost:5000' which would cause the embed to
fail to load if accessing the live reload server via a different IP.

This happens when accessing the server through a VirtualBox Guest when
using the default networking settings or when accessing it from a say, a
mobile device on the same WiFi network as a laptop serving the dev
environment.

Instead use the same hostname for the live reload WebSocket server
and embed script as the client test page is served from.

Steps to test:

1. Start dev server
2. Run `gulp watch`
3. Access the client test page from a browser which can access the live reload server at http://localhost:3000 but _only_ via a different IP (eg. http://10.0.2.2:3000 for a VBox guest)

Expected result: Test page appears, H client loads
