### PR TITLE
Make nipsa work with Postgres feature flag

### DIFF
--- a/h/api/events.py
+++ b/h/api/events.py
@@ -15,15 +15,16 @@ class AnnotationEvent(object):
             return self.annotation_dict.get('id')
 
 
-class AnnotationBeforeSaveEvent(object):
+class AnnotationTransformEvent(object):
 
     """
-    An event fired just before an annotation is saved.
+    An event fired before an annotation is indexed or otherwise needs to be
+    transformed by third-party code.
 
     This event can be used by subscribers who wish to modify the content of an
-    annotation just before it is saved.
+    annotation just before it is indexed or in other use-cases.
     """
 
-    def __init__(self, request, annotation):
+    def __init__(self, request, annotation_dict):
         self.request = request
-        self.annotation = annotation
+        self.annotation_dict = annotation_dict

--- a/h/api/search/index.py
+++ b/h/api/search/index.py
@@ -7,7 +7,7 @@ import logging
 import elasticsearch
 
 from h.api import presenters
-from h.api.events import AnnotationBeforeSaveEvent
+from h.api.events import AnnotationTransformEvent
 
 
 log = logging.getLogger(__name__)
@@ -34,7 +34,7 @@ def index(es, annotation, request):
     annotation_dict['target'][0]['scope'] = [
         annotation.target_uri_normalized]
 
-    event = AnnotationBeforeSaveEvent(request, annotation_dict)
+    event = AnnotationTransformEvent(request, annotation_dict)
     request.registry.notify(event)
 
     es.conn.index(

--- a/h/api/search/index.py
+++ b/h/api/search/index.py
@@ -7,6 +7,7 @@ import logging
 import elasticsearch
 
 from h.api import presenters
+from h.api.events import AnnotationBeforeSaveEvent
 
 
 log = logging.getLogger(__name__)
@@ -32,6 +33,9 @@ def index(es, annotation, request):
 
     annotation_dict['target'][0]['scope'] = [
         annotation.target_uri_normalized]
+
+    event = AnnotationBeforeSaveEvent(request, annotation_dict)
+    request.registry.notify(event)
 
     es.conn.index(
         index=es.index,

--- a/h/api/search/test/index_test.py
+++ b/h/api/search/test/index_test.py
@@ -23,21 +23,21 @@ class TestIndexAnnotation:
         presenters.AnnotationJSONPresenter.assert_called_once_with(
             request, annotation)
 
-    def test_it_creates_an_annotation_before_save_event(self, es, presenters, AnnotationBeforeSaveEvent):
+    def test_it_creates_an_annotation_before_save_event(self, es, presenters, AnnotationTransformEvent):
         request = mock.Mock()
         presented = presenters.AnnotationJSONPresenter.return_value.asdict()
 
         index.index(es, mock.Mock(), request)
 
-        AnnotationBeforeSaveEvent.assert_called_once_with(request, presented)
+        AnnotationTransformEvent.assert_called_once_with(request, presented)
 
-    def test_it_notifies_before_save_event(self, es, presenters, AnnotationBeforeSaveEvent):
+    def test_it_notifies_before_save_event(self, es, presenters, AnnotationTransformEvent):
         request = DummyRequest()
         request.registry.notify = mock.Mock(spec=lambda event: None)
 
         index.index(es, mock.Mock(), request)
 
-        event = AnnotationBeforeSaveEvent.return_value
+        event = AnnotationTransformEvent.return_value
         request.registry.notify.assert_called_once_with(event)
 
     def test_it_indexes_the_annotation(self, es, presenters):
@@ -72,8 +72,8 @@ class TestIndexAnnotation:
         return presenters
 
     @pytest.fixture
-    def AnnotationBeforeSaveEvent(self, patch):
-        return patch('h.api.search.index.AnnotationBeforeSaveEvent')
+    def AnnotationTransformEvent(self, patch):
+        return patch('h.api.search.index.AnnotationTransformEvent')
 
 
 @pytest.mark.usefixtures('log')

--- a/h/api/storage.py
+++ b/h/api/storage.py
@@ -14,7 +14,7 @@ from pyramid import i18n
 from h.api import schemas
 from h.api import transform
 from h.api import models
-from h.api.events import AnnotationBeforeSaveEvent
+from h.api.events import AnnotationTransformEvent
 
 
 _ = i18n.TranslationStringFactory(__package__)
@@ -238,9 +238,9 @@ def _prepare(request, annotation):
     fetcher = partial(fetch_annotation, request, _postgres=False)
     transform.prepare(annotation, fetcher)
 
-    # Fire an AnnotationBeforeSaveEvent so subscribers who wish to modify an
+    # Fire an AnnotationTransformEvent so subscribers who wish to modify an
     # annotation before save can do so.
-    event = AnnotationBeforeSaveEvent(request, annotation)
+    event = AnnotationTransformEvent(request, annotation)
     request.registry.notify(event)
 
 

--- a/h/api/test/storage_test.py
+++ b/h/api/test/storage_test.py
@@ -146,7 +146,7 @@ class TestExpandURI(object):
         ]
 
 
-@pytest.mark.usefixtures('AnnotationBeforeSaveEvent',
+@pytest.mark.usefixtures('AnnotationTransformEvent',
                          'models',  # Don't try to talk to real Elasticsearch!
                          'partial',
                          'transform')
@@ -173,23 +173,23 @@ class TestLegacyCreateAnnotation(object):
         transform.prepare.assert_called_once_with(
             models.elastic.Annotation.return_value, partial.return_value)
 
-    def test_it_inits_AnnotationBeforeSaveEvent(self,
-                                                AnnotationBeforeSaveEvent,
-                                                models):
+    def test_it_inits_AnnotationTransformEvent(self,
+                                               AnnotationTransformEvent,
+                                               models):
         request = self.mock_request()
 
         storage.legacy_create_annotation(request, self.annotation_data())
 
-        AnnotationBeforeSaveEvent.assert_called_once_with(
+        AnnotationTransformEvent.assert_called_once_with(
             request, models.elastic.Annotation.return_value)
 
-    def test_it_calls_notify(self, AnnotationBeforeSaveEvent):
+    def test_it_calls_notify(self, AnnotationTransformEvent):
         request = self.mock_request()
 
         storage.legacy_create_annotation(request, self.annotation_data())
 
         request.registry.notify.assert_called_once_with(
-            AnnotationBeforeSaveEvent.return_value)
+            AnnotationTransformEvent.return_value)
 
     def test_it_calls_annotation_save(self, models):
         storage.legacy_create_annotation(self.mock_request(),
@@ -213,8 +213,8 @@ class TestLegacyCreateAnnotation(object):
         return {'foo': 'bar'}
 
     @pytest.fixture
-    def AnnotationBeforeSaveEvent(self, patch):
-        return patch('h.api.storage.AnnotationBeforeSaveEvent')
+    def AnnotationTransformEvent(self, patch):
+        return patch('h.api.storage.AnnotationTransformEvent')
 
     @pytest.fixture
     def partial(self, patch):

--- a/h/nipsa/__init__.py
+++ b/h/nipsa/__init__.py
@@ -12,7 +12,7 @@ def includeme(config):
     # Register the transform_annotation subscriber so that nipsa fields are
     # written into annotations on save.
     config.add_subscriber('h.nipsa.subscribers.transform_annotation',
-                          'h.api.events.AnnotationBeforeSaveEvent')
+                          'h.api.events.AnnotationTransformEvent')
 
     # Register an additional filter with the API search module
     config.add_search_filter(search.Filter)

--- a/h/nipsa/subscribers.py
+++ b/h/nipsa/subscribers.py
@@ -5,6 +5,6 @@ from h.nipsa import logic
 
 def transform_annotation(event):
     """Add a {"nipsa": True} field on annotations whose users are flagged."""
-    annotation = event.annotation
+    annotation = event.annotation_dict
     if 'user' in annotation and logic.has_nipsa(annotation['user']):
         annotation['nipsa'] = True

--- a/h/nipsa/test/subscribers_test.py
+++ b/h/nipsa/test/subscribers_test.py
@@ -8,7 +8,7 @@ import pytest
 from h.nipsa import subscribers
 
 
-FakeEvent = namedtuple('FakeEvent', ['annotation'])
+FakeEvent = namedtuple('FakeEvent', ['annotation_dict'])
 
 
 @pytest.mark.parametrize("ann,nipsa", [
@@ -17,7 +17,7 @@ FakeEvent = namedtuple('FakeEvent', ['annotation'])
     ({}, False),
 ])
 def test_transform_annotation(ann, nipsa, has_nipsa):
-    event = FakeEvent(annotation=ann)
+    event = FakeEvent(annotation_dict=ann)
     has_nipsa.return_value = nipsa
     subscribers.transform_annotation(event)
     if nipsa:

--- a/h/nipsa/worker.py
+++ b/h/nipsa/worker.py
@@ -63,6 +63,12 @@ def bulk_update_annotations(client, query, action):
 @celery.task
 def add_nipsa(userid):
     log.info("setting nipsa flag for user annotations: %s", userid)
+
+    if celery.request.feature('postgres'):
+        bulk_update_annotations(celery.request.es,
+                                search.not_nipsad_annotations(userid),
+                                add_nipsa_action)
+
     bulk_update_annotations(celery.request.legacy_es,
                             search.not_nipsad_annotations(userid),
                             add_nipsa_action)
@@ -71,6 +77,12 @@ def add_nipsa(userid):
 @celery.task
 def remove_nipsa(userid):
     log.info("clearing nipsa flag for user annotations: %s", userid)
+
+    if celery.request.feature('postgres'):
+        bulk_update_annotations(celery.request.es,
+                                search.nipsad_annotations(userid),
+                                remove_nipsa_action)
+
     bulk_update_annotations(celery.request.legacy_es,
                             search.nipsad_annotations(userid),
                             remove_nipsa_action)

--- a/h/subscribers.py
+++ b/h/subscribers.py
@@ -7,7 +7,7 @@ from h import emails
 from h import mailer
 from h.api import presenters
 from h.api import storage
-from h.api.events import AnnotationBeforeSaveEvent
+from h.api.events import AnnotationTransformEvent
 from h.notification import reply
 
 
@@ -31,8 +31,8 @@ def add_renderer_globals(event):
 def publish_annotation_event(event):
     """Publish an annotation event to the message queue."""
     annotation_dict = deepcopy(event.annotation_dict)
-    before_save_event = AnnotationBeforeSaveEvent(event.request,
-                                                  annotation_dict)
+    before_save_event = AnnotationTransformEvent(event.request,
+                                                 annotation_dict)
     event.request.registry.notify(before_save_event)
 
     data = {

--- a/h/subscribers.py
+++ b/h/subscribers.py
@@ -1,10 +1,13 @@
 # -*- coding: utf-8 -*-
 
+from copy import deepcopy
+
 from h import __version__
 from h import emails
 from h import mailer
 from h.api import presenters
 from h.api import storage
+from h.api.events import AnnotationBeforeSaveEvent
 from h.notification import reply
 
 
@@ -27,9 +30,14 @@ def add_renderer_globals(event):
 
 def publish_annotation_event(event):
     """Publish an annotation event to the message queue."""
+    annotation_dict = deepcopy(event.annotation_dict)
+    before_save_event = AnnotationBeforeSaveEvent(event.request,
+                                                  annotation_dict)
+    event.request.registry.notify(before_save_event)
+
     data = {
         'action': event.action,
-        'annotation': event.annotation_dict,
+        'annotation': annotation_dict,
         'src_client_id': event.request.headers.get('X-Client-Id'),
     }
 

--- a/h/test/subscribers_test.py
+++ b/h/test/subscribers_test.py
@@ -21,14 +21,32 @@ class FakeMailer(object):
 @pytest.mark.usefixtures('presenters')
 class TestPublishAnnotationEvent:
 
-    def test_it_publishes_the_serialized_data(self, event, presenters):
+    def test_it_initializes_a_new_before_save_event(
+        self, event, presenters, AnnotationBeforeSaveEvent, deepcopy):
+
+        subscribers.publish_annotation_event(event)
+
+        deepcopy.assert_called_once_with(event.annotation_dict)
+
+        AnnotationBeforeSaveEvent.assert_called_once_with(event.request,
+                                                          deepcopy.return_value)
+
+    def test_it_notifies_before_save_event(self, event, AnnotationBeforeSaveEvent, deepcopy):
+        event.request.registry.notify = mock.Mock(spec=lambda event: None)
+        before_save_event = AnnotationBeforeSaveEvent.return_value
+
+        subscribers.publish_annotation_event(event)
+
+        event.request.registry.notify.assert_called_once_with(before_save_event)
+
+    def test_it_publishes_the_serialized_data(self, event, presenters, deepcopy):
         event.request.headers = {'X-Client-Id': 'client_id'}
 
         subscribers.publish_annotation_event(event)
 
         event.request.realtime.publish_annotation.assert_called_once_with({
             'action': event.action,
-            'annotation': event.annotation_dict,
+            'annotation': deepcopy.return_value,
             'src_client_id': 'client_id'
         })
 
@@ -43,6 +61,14 @@ class TestPublishAnnotationEvent:
     @pytest.fixture
     def presenters(self, patch):
         return patch('h.subscribers.presenters')
+
+    @pytest.fixture
+    def AnnotationBeforeSaveEvent(self, patch):
+        return patch('h.subscribers.AnnotationBeforeSaveEvent')
+
+    @pytest.fixture
+    def deepcopy(self, patch):
+        return patch('h.subscribers.deepcopy')
 
 
 @pytest.mark.usefixtures('fetch_annotation')

--- a/h/test/subscribers_test.py
+++ b/h/test/subscribers_test.py
@@ -22,18 +22,18 @@ class FakeMailer(object):
 class TestPublishAnnotationEvent:
 
     def test_it_initializes_a_new_before_save_event(
-        self, event, presenters, AnnotationBeforeSaveEvent, deepcopy):
+        self, event, presenters, AnnotationTransformEvent, deepcopy):
 
         subscribers.publish_annotation_event(event)
 
         deepcopy.assert_called_once_with(event.annotation_dict)
 
-        AnnotationBeforeSaveEvent.assert_called_once_with(event.request,
-                                                          deepcopy.return_value)
+        AnnotationTransformEvent.assert_called_once_with(event.request,
+                                                         deepcopy.return_value)
 
-    def test_it_notifies_before_save_event(self, event, AnnotationBeforeSaveEvent, deepcopy):
+    def test_it_notifies_before_save_event(self, event, AnnotationTransformEvent, deepcopy):
         event.request.registry.notify = mock.Mock(spec=lambda event: None)
-        before_save_event = AnnotationBeforeSaveEvent.return_value
+        before_save_event = AnnotationTransformEvent.return_value
 
         subscribers.publish_annotation_event(event)
 
@@ -63,8 +63,8 @@ class TestPublishAnnotationEvent:
         return patch('h.subscribers.presenters')
 
     @pytest.fixture
-    def AnnotationBeforeSaveEvent(self, patch):
-        return patch('h.subscribers.AnnotationBeforeSaveEvent')
+    def AnnotationTransformEvent(self, patch):
+        return patch('h.subscribers.AnnotationTransformEvent')
 
     @pytest.fixture
     def deepcopy(self, patch):


### PR DESCRIPTION
This is mostly pretty straightforward:

* Emit `AnnotationBeforeSaveEvent` in `h.api.search.index` before sending the presented dictionary to Elasticsearch.
* Make sure the nipsa celery task adds/removes the `"nipsa": true` field to all indexed documents of a user
* Emit `AnnotationBeforeSaveEvent` in `h.subscribers.publish_annotation_event` before sending the real-time message so that `h.streamer` can filter out these annotations