### PR TITLE
Build Firefox WebExtensions during Travis builds

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -12,7 +12,6 @@
   "esnext": true,
   "globals": {
     "chrome": false,
-    "h": false,
     "Promise": false,
     "chai": false,
     "sinon": false,
@@ -31,6 +30,7 @@
     "assert",
     "before",
     "beforeEach",
+    "chrome",
     "context",
     "describe",
     "it",

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,8 @@ matrix:
       addons:
         artifacts:
           paths:
-            # Upload all built zipfiles (browser extensions)
-            - $(ls build/*.zip | tr "\n" ":")
+            # Upload all built extension packages
+            - $(ls build/*.zip build/*.xpi | tr "\n" ":")
       before_install:
         # Unfortunately it seems to be impossible to call `nvm install` from an
         # external script on Travis, so we have to inline this one.

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,8 @@ test: node_modules/.uptodate
 .PHONY: extensions
 extensions: build/$(ISODATE)-$(BUILD_ID)-chrome-stage.zip
 extensions: build/$(ISODATE)-$(BUILD_ID)-chrome-prod.zip
+extensions: build/$(ISODATE)-$(BUILD_ID)-firefox-stage.xpi
+extensions: build/$(ISODATE)-$(BUILD_ID)-firefox-prod.xpi
 
 build/%-chrome-stage.zip: build/manifest.json
 	@rm -rf build/chrome $@
@@ -75,6 +77,24 @@ build/%-chrome-prod.zip: build/manifest.json
 		--sentry-public-dsn '$(SENTRY_DSN_PROD)' \
 		--bouncer 'https://hyp.is'
 	@zip -qr $@ build/chrome
+
+build/%-firefox-stage.xpi: build/manifest.json
+	@rm -rf build/firefox $@
+	hypothesis-buildext firefox \
+		--service 'https://stage.hypothes.is' \
+		--websocket 'wss://stage.hypothes.is/ws' \
+		--sentry-public-dsn '$(SENTRY_DSN_STAGE)' \
+		--bouncer 'https://bouncer-stage.hypothes.is'
+	@cd build/firefox && zip -qr $(abspath $@) .
+
+build/%-firefox-prod.xpi: build/manifest.json
+	@rm -rf build/firefox $@
+	hypothesis-buildext firefox \
+		--service 'https://hypothes.is' \
+		--websocket 'wss://hypothes.is/ws' \
+		--sentry-public-dsn '$(SENTRY_DSN_PROD)' \
+		--bouncer 'https://hyp.is'
+	@cd build/firefox && zip -qr $(abspath $@) .
 
 ################################################################################
 

--- a/h/browser/chrome/lib/install.js
+++ b/h/browser/chrome/lib/install.js
@@ -15,21 +15,27 @@ var browserExtension = new HypothesisChromeExtension({
 
 browserExtension.listen(window);
 
-chrome.runtime.onInstalled.addListener(onInstalled);
+if (chrome.runtime.onInstalled) {
+  chrome.runtime.onInstalled.addListener(onInstalled);
+}
 
 // Respond to messages sent by the JavaScript from https://hpt.is.
 // This is how it knows whether the user has this Chrome extension installed.
-chrome.runtime.onMessageExternal.addListener(
-  function (request, sender, sendResponse) {
-    if (request.type === 'ping') {
-      sendResponse({type: 'pong'});
+if (chrome.runtime.onMessageExternal) {
+  chrome.runtime.onMessageExternal.addListener(
+    function (request, sender, sendResponse) {
+      if (request.type === 'ping') {
+        sendResponse({type: 'pong'});
+      }
     }
-  }
-);
+  );
+}
 
-chrome.runtime.requestUpdateCheck(function (status) {
-  chrome.runtime.onUpdateAvailable.addListener(onUpdateAvailable);
-});
+if (chrome.runtime.requestUpdateCheck) {
+  chrome.runtime.requestUpdateCheck(function () {
+    chrome.runtime.onUpdateAvailable.addListener(onUpdateAvailable);
+  });
+}
 
 function onInstalled(installDetails) {
   // The install reason can be "install", "update", "chrome_update", or

--- a/h/browser/chrome/lib/sidebar-injector.js
+++ b/h/browser/chrome/lib/sidebar-injector.js
@@ -40,6 +40,10 @@ function addJSONScriptTagFn(name, content) {
 function extractContentScriptResult(result) {
   if (Array.isArray(result) && result.length > 0) {
     return result[0];
+  } else if (typeof result === 'object') {
+    // Firefox currently returns an object instead of
+    // an array from executeScript()
+    return result;
   } else {
     return;
   }

--- a/h/browser/chrome/manifest.json.jinja2
+++ b/h/browser/chrome/manifest.json.jinja2
@@ -4,7 +4,19 @@
   "version": "{{ version }}",
   "version_name": "{{ version }} ({{ version_name }})",
   "manifest_version": 2,
+
+  {% if browser == 'chrome' %}
   "minimum_chrome_version": "38",
+  {% endif %}
+
+  {% if browser == 'firefox' %}
+  "applications": {
+    "gecko": {
+      "id": "firefox@hypothes.is",
+      "strict_min_version": "45.0.0"
+    }
+  },
+  {% endif %}
 
   "description": "Collaboratively annotate, highlight, and tag web pages and PDF documents.",
   "icons": {
@@ -27,7 +39,9 @@
     "script-src 'self' 'unsafe-eval' {{ script_src }}; object-src 'self'; font-src 'self' data:;",
 
   "background": {
+    {% if browser == 'chrome' %}
     "persistent": true,
+    {% endif %}
     "scripts": [
       "settings-data.js",
       "public/scripts/raven.bundle.js",

--- a/h/browser/chrome/manifest.json.jinja2
+++ b/h/browser/chrome/manifest.json.jinja2
@@ -13,7 +13,10 @@
   "applications": {
     "gecko": {
       "id": "firefox@hypothes.is",
-      "strict_min_version": "45.0.0"
+
+      {# Firefox v48 is required for
+         https://bugzilla.mozilla.org/show_bug.cgi?id=1210583 #}
+      "strict_min_version": "48.0.0"
     }
   },
   {% endif %}

--- a/h/buildext.py
+++ b/h/buildext.py
@@ -141,9 +141,10 @@ def settings_dict(service_url, api_url, sentry_public_dsn):
 
 def build_extension(args):
     """
-    Build the Chrome extension. You can supply the base URL of an h
-    installation with which this extension will communicate, such as
-    "http://localhost:5000" when developing locally or
+    Build the Chrome or Firefox extensions.
+
+    You can supply the base URL of an h installation with which this extension
+    will communicate, such as "http://localhost:5000" when developing locally or
     "https://hypothes.is" to talk to the production Hypothesis application.
     """
     service_url = args.service_url

--- a/h/buildext.py
+++ b/h/buildext.py
@@ -78,7 +78,7 @@ def copyfilelist(src, dst, filelist):
         shutil.copyfile(srcpath, dstpath)
 
 
-def chrome_manifest(script_host_url, bouncer_url):
+def chrome_manifest(script_host_url, bouncer_url, browser):
     # Chrome is strict about the format of the version string
     if '+' in h.__version__:
         tag, detail = h.__version__.split('+')
@@ -95,7 +95,8 @@ def chrome_manifest(script_host_url, bouncer_url):
     context = {
         'version': version,
         'version_name': version_name,
-        'bouncer': bouncer
+        'bouncer': bouncer,
+        'browser': browser,
     }
 
     if script_host_url:
@@ -138,7 +139,7 @@ def settings_dict(service_url, api_url, sentry_public_dsn):
     return config
 
 
-def build_chrome(args):
+def build_extension(args):
     """
     Build the Chrome extension. You can supply the base URL of an h
     installation with which this extension will communicate, such as
@@ -149,7 +150,7 @@ def build_chrome(args):
     if not service_url.endswith('/'):
         service_url = '{}/'.format(service_url)
 
-    build_dir = 'build/chrome'
+    build_dir = 'build/' + args.browser
     public_dir = os.path.join(build_dir, 'public')
 
     # Prepare a fresh build.
@@ -213,7 +214,8 @@ def build_chrome(args):
     # Render the manifest.
     with codecs.open(os.path.join(build_dir, 'manifest.json'), 'w', 'utf-8') as fp:
         data = chrome_manifest(script_host_url=None,
-                               bouncer_url=args.bouncer_url)
+                               bouncer_url=args.bouncer_url,
+                               browser=args.browser)
         fp.write(data)
 
     # Write build settings to a JSON file
@@ -259,14 +261,12 @@ parser.add_argument('--websocket',
                     metavar='URL')
 parser.add_argument('browser',
                     help='Specifies the browser to build an extension for',
-                    choices=['chrome'])
-
-BROWSERS = {'chrome': build_chrome}
+                    choices=['chrome', 'firefox'])
 
 
 def main():
     args = parser.parse_args()
-    BROWSERS[args.browser](args)
+    build_extension(args)
 
 
 if __name__ == '__main__':

--- a/h/static/scripts/discovery.coffee
+++ b/h/static/scripts/discovery.coffee
@@ -92,7 +92,11 @@ module.exports = class Discovery
     #
     #   https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage
     #
-    if origin is 'null'
+    # When sending messages to or from a Firefox WebExtension, current
+    # versions of Firefox have a bug that causes the origin check to fail even
+    # though the target and actual origins of the message match.
+    if origin is 'null' || origin.match('moz-extension:') ||
+       window.location.protocol == 'moz-extension:'
       origin = '*'
 
     # Check if the message is at all related to our discovery mechanism

--- a/h/templates/embed.js.jinja2
+++ b/h/templates/embed.js.jinja2
@@ -7,13 +7,14 @@ if (appLinkEl) {
   };
 }
 
-// When run from a Chrome extension, load
-// resources bundled with the extension
+// When run from a Chrome or Firefox extension, load resources bundled with the
+// extension. Note that in Firefox, the 'chrome' object is accessible as a
+// global but not attached to the 'window' object.
 var resourceRoot;
-if (window.chrome &&
-    window.chrome.extension &&
-    window.chrome.extension.getURL) {
-  resourceRoot = window.chrome.extension.getURL('/');
+if (typeof chrome !== 'undefined' &&
+    typeof chrome.extension !== 'undefined' &&
+    typeof chrome.extension.getURL !== 'undefined') {
+  resourceRoot = chrome.extension.getURL('/');
 }
 
 function resolve(url) {


### PR DESCRIPTION
_There is no hurry on this as it isn't part of our current focus but I've been maintaining this locally because its much nicer for regular use of H in Firefox than the bookmarklet. It is a fairly small set of changes and having regular builds will make it easy for me to communicate with Firefox developers to get any issues that we find fixed._

This adds a `hypothesis-buildext firefox` command which will build a Firefox WebExtension which is compatible with the current developer edition of Firefox and builds stage and production extensions on each Travis build in the same way that Chrome stage/prod extensions are built.

**What works?**
- Installation in Firefox Developer Edition builds
- The badge count
- Activating and deactivating the extension on a page
- If the URL contains a '#annotations' fragment, the extension will auto-inject

**What is missing?**
- The extension supports '#annotations' direct link fragments but communication between Bouncer and the Firefox extension in order to make Bouncer aware that an extension is present is not yet implemented.
- The resulting extension is not currently signed using the addons.mozilla.org (AMO) APIs so it can only be used with Developer Edition builds
- The extension will not check for updates
- Activating the extension on PDFs is not working yet

**Summary of changes in this PR**
 * Modify the `hypothesis-buildext` command to accept `firefox` as a browser argument. This runs the same code as the Chrome build except for the arguments passed when rendering the JSON manifest.
 * Add a handful of small workarounds for incompatibilities between Chrome and Firefox
 * Skip some of the installation and update-checking logic in the extension under Firefox, since these APIs are not yet implemented.