### PR TITLE
Use custom element names for adder toolbar

### DIFF
--- a/h/static/scripts/annotator/adder.html
+++ b/h/static/scripts/annotator/adder.html
@@ -1,10 +1,10 @@
-<div class="annotator-adder">
-  <div class="annotator-adder-actions">
-    <button class="annotator-adder-actions__button h-icon-annotate" data-action="comment">
-      <span class="annotator-adder-actions__label" data-action="comment">Annotate</span>
-    </button>
-    <button class="annotator-adder-actions__button h-icon-highlight" data-action="highlight">
-      <span class="annotator-adder-actions__label" data-action="highlight">Highlight</span>
-    </button>
-  </div>
-</div>
+<hypothesis-adder class="annotator-adder">
+    <hypothesis-adder-actions class="annotator-adder-actions">
+      <button class="annotator-adder-actions__button h-icon-annotate" data-action="comment">
+        <span class="annotator-adder-actions__label" data-action="comment">Annotate</span>
+      </button>
+      <button class="annotator-adder-actions__button h-icon-highlight" data-action="highlight">
+        <span class="annotator-adder-actions__label" data-action="highlight">Highlight</span>
+      </button>
+    </hypothesis-adder-actions>
+</hypothesis-adder>


### PR DESCRIPTION
Using custom element names for the adder's container is a simple trick
to reduce the likelihood of the adder's styling being affected by CSS
selectors in the containing page, such as example.com's `div` selector.

FWIW Genius uses the same ~~hack~~ technique.

Other techniques we could consider in addition are same-origin iframes and Shadow DOM (when available).

Fixes #3207