### PR TITLE
Remove unused IncludeRawExtension

### DIFF
--- a/h/app.py
+++ b/h/app.py
@@ -93,7 +93,6 @@ def includeme(config):
 
     config.include('pyramid_jinja2')
     config.add_jinja2_extension('h.jinja_extensions.Filters')
-    config.add_jinja2_extension('h.jinja_extensions.IncludeRawExtension')
     # Register a deferred action to setup the assets environment
     # when the configuration is committed.
     config.action(None, configure_jinja2_assets, args=(config,))

--- a/h/jinja_extensions.py
+++ b/h/jinja_extensions.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from functools import wraps
 
 import datetime
 import json
@@ -21,18 +20,6 @@ class Filters(Extension):
         environment.filters['to_json'] = to_json
 
 
-class IncludeRawExtension(Extension):
-    """
-    An extension which provides a simple include_raw function to include the
-    content of a file without further processing.
-    """
-
-    def __init__(self, environment):
-        super(IncludeRawExtension, self).__init__(environment)
-
-        environment.globals['include_raw'] = _get_includer(environment)
-
-
 def human_timestamp(timestamp, now=datetime.datetime.utcnow):
     """Turn a :py:class:`datetime.datetime` into a human-friendly string."""
     fmt = '%d %B at %H:%M'
@@ -44,24 +31,3 @@ def human_timestamp(timestamp, now=datetime.datetime.utcnow):
 def to_json(value):
     """Convert a dict into a JSON string"""
     return Markup(json.dumps(value))
-
-
-def _get_includer(environment):
-    def _include(name):
-        return Markup(environment.loader.get_source(environment, name)[0])
-    # Memoize results when [jinja2.]debug_templates is false.
-    if not environment.loader.debug:
-        _include = _memoize(_include)
-    return _include
-
-
-def _memoize(f):
-    cache = {}
-
-    @wraps(f)
-    def memoizer(*args, **kwargs):
-        # NB: this memoizer ignores kwargs.
-        if args not in cache:
-            cache[args] = f(*args, **kwargs)
-        return cache[args]
-    return memoizer


### PR DESCRIPTION
This was previously used to include angular templates in `app.html` without parsing them as Jinja2 templates. These templates are now included in the script bundles directly using the `stringify` browserify transform.