### PR TITLE
Schemas code for updating annotations in postgres

### DIFF
--- a/h/api/schemas.py
+++ b/h/api/schemas.py
@@ -48,9 +48,7 @@ class JSONSchema(object):
 
 class AnnotationSchema(JSONSchema):
 
-    """
-    Validate an annotation object.
-    """
+    """Validate an annotation object."""
 
     schema = {
         'type': 'object',
@@ -158,9 +156,7 @@ class AnnotationSchema(JSONSchema):
 
 class LegacyAnnotationSchema(JSONSchema):
 
-    """
-    Validate an annotation object.
-    """
+    """Validate an annotation object."""
 
     schema = {
         'type': 'object',
@@ -240,9 +236,7 @@ class CreateAnnotationSchema(object):
 
 class LegacyCreateAnnotationSchema(object):
 
-    """
-    Validate the payload from a user when creating an annotation.
-    """
+    """Validate the payload from a user when creating an annotation."""
 
     def __init__(self, request):
         self.request = request
@@ -323,9 +317,7 @@ class UpdateAnnotationSchema(object):
 
 class LegacyUpdateAnnotationSchema(object):
 
-    """
-    Validate the payload from a user when updating an annotation.
-    """
+    """Validate the payload from a user when updating an annotation."""
 
     def __init__(self, request, annotation):
         self.request = request

--- a/h/api/schemas.py
+++ b/h/api/schemas.py
@@ -385,7 +385,7 @@ def _format_jsonschema_error(error):
 
 def _remove_protected_fields(appstruct):
     # Some fields are not to be set by the user, ignore them.
-    for field in ['created', 'updated', 'user', 'id']:
+    for field in ['created', 'updated', 'user', 'id', 'links']:
         appstruct.pop(field, None)
 
 

--- a/h/api/schemas.py
+++ b/h/api/schemas.py
@@ -156,9 +156,6 @@ class AnnotationSchema(JSONSchema):
                 'type': 'string',
             },
         },
-        'required': [
-            'permissions',
-        ],
     }
 
 
@@ -219,9 +216,11 @@ class CreateAnnotationSchema(object):
         new_appstruct['text'] = appstruct.pop('text', u'')
         new_appstruct['tags'] = appstruct.pop('tags', [])
 
+        permissions = appstruct.pop('permissions', None)
+
         # Replace the client's complex permissions object with a simple shared
         # boolean.
-        if appstruct.pop('permissions')['read'] == [new_appstruct['userid']]:
+        if permissions and permissions['read'] == [new_appstruct['userid']]:
             new_appstruct['shared'] = False
         else:
             new_appstruct['shared'] = True

--- a/h/api/schemas.py
+++ b/h/api/schemas.py
@@ -275,9 +275,9 @@ class UpdateAnnotationSchema(object):
 
     """Validate the POSTed data of an update annotation request."""
 
-    def __init__(self, request, annotation):
+    def __init__(self, request, existing_target_uri):
         self.request = request
-        self.annotation = annotation
+        self.existing_target_uri = existing_target_uri
         self.structure = AnnotationSchema()
 
     def validate(self, data):
@@ -314,7 +314,7 @@ class UpdateAnnotationSchema(object):
         if 'document' in appstruct:
             new_appstruct['document'] = _document(
                 appstruct.pop('document'),
-                new_appstruct.get('target_uri', self.annotation.target_uri))
+                new_appstruct.get('target_uri', self.existing_target_uri))
 
         new_appstruct['extra'] = appstruct
 

--- a/h/api/schemas.py
+++ b/h/api/schemas.py
@@ -211,7 +211,7 @@ class CreateAnnotationSchema(object):
             new_appstruct['shared'] = _shared(appstruct.pop('permissions'),
                                               new_appstruct['userid'])
         else:
-            new_appstruct['shared'] = True
+            new_appstruct['shared'] = False
 
         if 'target' in appstruct:  # Replies and page notes don't have targets.
             new_appstruct['target_selectors'] = _target_selectors(

--- a/h/api/schemas.py
+++ b/h/api/schemas.py
@@ -228,7 +228,7 @@ class CreateAnnotationSchema(object):
 
         # The 'target' dict that the client sends is replaced with a single
         # annotation.target_selectors whose value is the first selector in
-        # the client'ss target.selectors list.
+        # the client's target.selectors list.
         # Anything else in the target dict, and any selectors after the first,
         # are discarded.
         target = appstruct.pop('target', [])

--- a/h/api/schemas.py
+++ b/h/api/schemas.py
@@ -317,6 +317,10 @@ class UpdateAnnotationSchema(object):
         for field in PROTECTED_FIELDS:
             appstruct.pop(field, None)
 
+        # Some fields are not allowed to be changed in annotation updates.
+        for key in ['group', 'groupid', 'userid', 'references']:
+            appstruct.pop(key, '')
+
         # Fields that are allowed to be updated and that have a different name
         # internally than in the public API.
         if 'uri' in appstruct:

--- a/h/api/schemas.py
+++ b/h/api/schemas.py
@@ -11,9 +11,6 @@ from h.api import parse_document_claims
 
 _ = i18n.TranslationStringFactory(__package__)
 
-# These annotation fields are not to be set by the user.
-PROTECTED_FIELDS = ['created', 'updated', 'user', 'id']
-
 
 class ValidationError(Exception):
     pass
@@ -207,33 +204,22 @@ class CreateAnnotationSchema(object):
 
         new_appstruct = {}
 
-        # Some fields are not to be set by the user, ignore them.
-        for field in PROTECTED_FIELDS:
-            appstruct.pop(field, None)
+        _remove_protected_fields(appstruct)
 
         new_appstruct['userid'] = self.request.authenticated_userid
         new_appstruct['target_uri'] = appstruct.pop('uri', u'')
         new_appstruct['text'] = appstruct.pop('text', u'')
         new_appstruct['tags'] = appstruct.pop('tags', [])
 
-        permissions = appstruct.pop('permissions', None)
-
-        # Replace the client's complex permissions object with a simple shared
-        # boolean.
-        if permissions and permissions['read'] == [new_appstruct['userid']]:
-            new_appstruct['shared'] = False
+        if 'permissions' in appstruct:
+            new_appstruct['shared'] = _shared(appstruct.pop('permissions'),
+                                              new_appstruct['userid'])
         else:
             new_appstruct['shared'] = True
 
-        # The 'target' dict that the client sends is replaced with a single
-        # annotation.target_selectors whose value is the first selector in
-        # the client's target.selectors list.
-        # Anything else in the target dict, and any selectors after the first,
-        # are discarded.
-        target = appstruct.pop('target', [])
-        if target:  # Replies and page notes don't have 'target'.
-            target = target[0]  # Multiple targets are ignored.
-            new_appstruct['target_selectors'] = target['selector']
+        if 'target' in appstruct:  # Replies and page notes don't have targets.
+            new_appstruct['target_selectors'] = _target_selectors(
+                appstruct.pop('target'))
 
         new_appstruct['groupid'] = appstruct.pop('group', u'__world__')
         new_appstruct['references'] = appstruct.pop('references', [])
@@ -244,19 +230,8 @@ class CreateAnnotationSchema(object):
         if new_appstruct['references'] and 'groupid' in new_appstruct:
             del new_appstruct['groupid']
 
-        # Transform the "document" dict that the client posts into a convenient
-        # format for creating DocumentURI and DocumentMeta objects later.
-        document_data = appstruct.pop('document', {})
-        document_uri_dicts = parse_document_claims.document_uris_from_data(
-            copy.deepcopy(document_data),
-            claimant=new_appstruct['target_uri'])
-        document_meta_dicts = parse_document_claims.document_metas_from_data(
-            copy.deepcopy(document_data),
-            claimant=new_appstruct['target_uri'])
-        new_appstruct['document'] = {
-            'document_uri_dicts': document_uri_dicts,
-            'document_meta_dicts': document_meta_dicts
-        }
+        new_appstruct['document'] = _document(appstruct.pop('document', {}),
+                                              new_appstruct['target_uri'])
 
         new_appstruct['extra'] = appstruct
 
@@ -276,9 +251,7 @@ class LegacyCreateAnnotationSchema(object):
     def validate(self, data):
         appstruct = self.structure.validate(data)
 
-        # Some fields are not to be set by the user, ignore them.
-        for field in PROTECTED_FIELDS:
-            appstruct.pop(field, None)
+        _remove_protected_fields(appstruct)
 
         # Set the annotation user field to the request user.
         appstruct['user'] = self.request.authenticated_userid
@@ -312,9 +285,7 @@ class UpdateAnnotationSchema(object):
 
         new_appstruct = {}
 
-        # Some fields are not to be set by the user, ignore them.
-        for field in PROTECTED_FIELDS:
-            appstruct.pop(field, None)
+        _remove_protected_fields(appstruct)
 
         # Some fields are not allowed to be changed in annotation updates.
         for key in ['group', 'groupid', 'userid', 'references']:
@@ -326,15 +297,13 @@ class UpdateAnnotationSchema(object):
             new_appstruct['target_uri'] = appstruct.pop('uri')
 
         if 'permissions' in appstruct:
-            permissions = appstruct.pop('permissions')
-            if permissions['read'] == [self.request.authenticated_userid]:
-                new_appstruct['shared'] = False
-            else:
-                new_appstruct['shared'] = True
+            new_appstruct['shared'] = _shared(
+                appstruct.pop('permissions'),
+                self.request.authenticated_userid)
 
         if 'target' in appstruct:
-            new_appstruct['target_selectors'] = (
-                appstruct.pop('target')[0]['selector'])
+            new_appstruct['target_selectors'] = _target_selectors(
+                appstruct.pop('target'))
 
         # Fields that are allowed to be updated and that have the same internal
         # and external name.
@@ -343,20 +312,9 @@ class UpdateAnnotationSchema(object):
                 new_appstruct[key] = appstruct.pop(key)
 
         if 'document' in appstruct:
-            claimant = new_appstruct.get('target_uri',
-                                         self.annotation.target_uri)
-            document_data = appstruct.pop('document')
-            document_uri_dicts = parse_document_claims.document_uris_from_data(
-                copy.deepcopy(document_data),
-                claimant=claimant)
-            document_meta_dicts = (
-                parse_document_claims.document_metas_from_data(
-                    copy.deepcopy(document_data),
-                    claimant=claimant))
-            new_appstruct['document'] = {
-                'document_uri_dicts': document_uri_dicts,
-                'document_meta_dicts': document_meta_dicts
-            }
+            new_appstruct['document'] = _document(
+                appstruct.pop('document'),
+                new_appstruct.get('target_uri', self.annotation.target_uri))
 
         new_appstruct['extra'] = appstruct
 
@@ -377,9 +335,7 @@ class LegacyUpdateAnnotationSchema(object):
     def validate(self, data):
         appstruct = self.structure.validate(data)
 
-        # Some fields are not to be set by the user, ignore them.
-        for field in PROTECTED_FIELDS:
-            appstruct.pop(field, None)
+        _remove_protected_fields(appstruct)
 
         # The user may not change the permissions of an annotation on which
         # they are lacking 'admin' rights.
@@ -405,6 +361,27 @@ class LegacyUpdateAnnotationSchema(object):
         return appstruct
 
 
+def _document(document, claimant):
+    """
+    Return document meta and document URI data from the given document dict.
+
+    Transforms the "document" dict that the client posts into a convenient
+    format for creating DocumentURI and DocumentMeta objects later.
+
+    """
+    document = document or {}
+    document_uri_dicts = parse_document_claims.document_uris_from_data(
+        copy.deepcopy(document),
+        claimant=claimant)
+    document_meta_dicts = parse_document_claims.document_metas_from_data(
+        copy.deepcopy(document),
+        claimant=claimant)
+    return {
+        'document_uri_dicts': document_uri_dicts,
+        'document_meta_dicts': document_meta_dicts
+    }
+
+
 def _format_jsonschema_error(error):
     """Format a :py:class:`jsonschema.ValidationError` as a string."""
     if error.path:
@@ -412,3 +389,44 @@ def _format_jsonschema_error(error):
         return '{path}: {message}'.format(path=dotted_path,
                                           message=error.message)
     return error.message
+
+
+def _remove_protected_fields(appstruct):
+    # Some fields are not to be set by the user, ignore them.
+    for field in ['created', 'updated', 'user', 'id']:
+        appstruct.pop(field, None)
+
+
+def _shared(permissions, userid):
+    """
+    Return True if the given permissions object represents shared permissions.
+
+    Return False otherwise.
+
+    Reduces the client's complex permissions dict to a simple shared boolean.
+
+    :param permissions: the permissions dict sent by the client in an
+        annotation create or update request
+    :type permissions: dict
+
+    :param userid: the userid of the user who created the annotation
+    :type userid: unicode
+
+    """
+    return permissions['read'] != [userid]
+
+
+def _target_selectors(targets):
+    """
+    Return the target selectors from the given target list.
+
+    Transforms the target lists that the client sends in annotation create and
+    update requests into our internal target_selectors format.
+
+    """
+    # Any targets other than the first in the list are discarded.
+    # Any fields of the target other than 'selector' are discarded.
+    if targets:
+        return targets[0]['selector']
+    else:
+        return []

--- a/h/api/test/parse_document_claims_test.py
+++ b/h/api/test/parse_document_claims_test.py
@@ -375,7 +375,7 @@ class TestDocumentURISelfClaim(object):
                          'document_uri_self_claim')
 class TestDocumentURIsFromData(object):
 
-    def test_it_calls_document_uris_from_links(self, document_uris_from_links):
+    def test_it_gets_document_uris_from_links(self, document_uris_from_links):
         document_data = {
             'link': [
                 # In production these would be link dicts not strings.
@@ -413,7 +413,7 @@ class TestDocumentURIsFromData(object):
         document_uris_from_links.assert_called_once_with(
             [], claimant)
 
-    def test_it_calls_documents_uris_from_highwire_pdf(
+    def test_it_gets_documents_uris_from_highwire_pdf(
             self,
             document_uris_from_highwire_pdf):
         document_data = {
@@ -453,7 +453,7 @@ class TestDocumentURIsFromData(object):
         document_uris_from_highwire_pdf.assert_called_once_with(
             {}, claimant)
 
-    def test_it_calls_documents_uris_from_highwire_doi(
+    def test_it_gets_documents_uris_from_highwire_doi(
             self,
             document_uris_from_highwire_doi):
         document_data = {
@@ -493,8 +493,8 @@ class TestDocumentURIsFromData(object):
         document_uris_from_highwire_doi.assert_called_once_with(
             {}, claimant)
 
-    def test_it_calls_documents_uris_from_dc(self,
-                                             document_uris_from_dc):
+    def test_it_gets_documents_uris_from_dc(self,
+                                            document_uris_from_dc):
         document_data = {
             'dc': {
                 'identifier': [
@@ -531,7 +531,7 @@ class TestDocumentURIsFromData(object):
         document_uris_from_dc.assert_called_once_with(
             {}, claimant)
 
-    def test_it_calls_document_uri_self_claim(self, document_uri_self_claim):
+    def test_it_gets_self_claim_document_uris(self, document_uri_self_claim):
         claimant = 'http://example.com/claimant'
 
         document_uris = parse_document_claims.document_uris_from_data(

--- a/h/api/test/schemas_test.py
+++ b/h/api/test/schemas_test.py
@@ -42,13 +42,13 @@ class TestJSONSchema(object):
 class TestAnnotationSchema(object):
 
     def test_it_does_not_raise_for_minimal_valid_data(self):
-        schema = schemas.AnnotationSchema(testing.DummyRequest())
+        schema = schemas.AnnotationSchema()
 
         # Use only the required fields.
         schema.validate(self.valid_input_data())
 
     def test_it_does_not_raise_for_full_valid_data(self):
-        schema = schemas.AnnotationSchema(testing.DummyRequest())
+        schema = schemas.AnnotationSchema()
 
         # Use all the keys to make sure that valid data for all of them passes.
         schema.validate({
@@ -92,7 +92,7 @@ class TestAnnotationSchema(object):
         })
 
     def test_it_raises_if_document_is_not_a_dict(self):
-        schema = schemas.AnnotationSchema(testing.DummyRequest())
+        schema = schemas.AnnotationSchema()
 
         with pytest.raises(schemas.ValidationError) as err:
             schema.validate(self.valid_input_data(
@@ -102,7 +102,7 @@ class TestAnnotationSchema(object):
         assert str(err.value) == "document: False is not of type 'object'"
 
     def test_it_raises_if_document_dc_is_not_a_dict(self):
-        schema = schemas.AnnotationSchema(testing.DummyRequest())
+        schema = schemas.AnnotationSchema()
 
         with pytest.raises(schemas.ValidationError) as err:
             schema.validate(self.valid_input_data(
@@ -112,7 +112,7 @@ class TestAnnotationSchema(object):
         assert str(err.value) == "document.dc: False is not of type 'object'"
 
     def test_it_raises_if_document_dc_identifier_is_not_a_list(self):
-        schema = schemas.AnnotationSchema(testing.DummyRequest())
+        schema = schemas.AnnotationSchema()
 
         with pytest.raises(schemas.ValidationError) as err:
             schema.validate(self.valid_input_data(
@@ -123,7 +123,7 @@ class TestAnnotationSchema(object):
             "document.dc.identifier: False is not of type 'array'")
 
     def test_it_raises_if_document_dc_identifier_item_is_not_a_string(self):
-        schema = schemas.AnnotationSchema(testing.DummyRequest())
+        schema = schemas.AnnotationSchema()
 
         with pytest.raises(schemas.ValidationError) as err:
             schema.validate(self.valid_input_data(
@@ -134,7 +134,7 @@ class TestAnnotationSchema(object):
             "document.dc.identifier.0: False is not of type 'string'")
 
     def test_it_raises_if_document_highwire_is_not_a_dict(self):
-        schema = schemas.AnnotationSchema(testing.DummyRequest())
+        schema = schemas.AnnotationSchema()
 
         with pytest.raises(schemas.ValidationError) as err:
             schema.validate(self.valid_input_data(
@@ -145,7 +145,7 @@ class TestAnnotationSchema(object):
             "document.highwire: False is not of type 'object'")
 
     def test_it_raises_if_document_highwire_doi_is_not_a_list(self):
-        schema = schemas.AnnotationSchema(testing.DummyRequest())
+        schema = schemas.AnnotationSchema()
 
         with pytest.raises(schemas.ValidationError) as err:
             schema.validate(self.valid_input_data(
@@ -156,7 +156,7 @@ class TestAnnotationSchema(object):
             "document.highwire.doi: False is not of type 'array'")
 
     def test_it_raises_if_document_highwire_doi_item_is_not_a_string(self):
-        schema = schemas.AnnotationSchema(testing.DummyRequest())
+        schema = schemas.AnnotationSchema()
 
         with pytest.raises(schemas.ValidationError) as err:
             schema.validate(self.valid_input_data(
@@ -167,7 +167,7 @@ class TestAnnotationSchema(object):
             "document.highwire.doi.0: False is not of type 'string'")
 
     def test_it_raises_if_document_link_is_not_a_list(self):
-        schema = schemas.AnnotationSchema(testing.DummyRequest())
+        schema = schemas.AnnotationSchema()
 
         with pytest.raises(schemas.ValidationError) as err:
             schema.validate(self.valid_input_data(
@@ -177,7 +177,7 @@ class TestAnnotationSchema(object):
         assert str(err.value) == "document.link: False is not of type 'array'"
 
     def test_it_raises_if_document_link_item_is_not_a_dict(self):
-        schema = schemas.AnnotationSchema(testing.DummyRequest())
+        schema = schemas.AnnotationSchema()
 
         with pytest.raises(schemas.ValidationError) as err:
             schema.validate(self.valid_input_data(
@@ -188,7 +188,7 @@ class TestAnnotationSchema(object):
             "document.link.0: False is not of type 'object'")
 
     def test_it_raises_if_document_link_item_has_no_href(self):
-        schema = schemas.AnnotationSchema(testing.DummyRequest())
+        schema = schemas.AnnotationSchema()
 
         with pytest.raises(schemas.ValidationError) as err:
             schema.validate(self.valid_input_data(
@@ -199,7 +199,7 @@ class TestAnnotationSchema(object):
             "document.link.0: 'href' is a required property")
 
     def test_it_raises_if_document_link_item_href_is_not_a_string(self):
-        schema = schemas.AnnotationSchema(testing.DummyRequest())
+        schema = schemas.AnnotationSchema()
 
         with pytest.raises(schemas.ValidationError) as err:
             schema.validate(self.valid_input_data(
@@ -210,7 +210,7 @@ class TestAnnotationSchema(object):
             "document.link.0.href: False is not of type 'string'")
 
     def test_it_raises_if_document_link_item_type_is_not_a_string(self):
-        schema = schemas.AnnotationSchema(testing.DummyRequest())
+        schema = schemas.AnnotationSchema()
 
         with pytest.raises(schemas.ValidationError) as err:
             schema.validate(self.valid_input_data(
@@ -228,7 +228,7 @@ class TestAnnotationSchema(object):
             "document.link.0.type: False is not of type 'string'")
 
     def test_it_raises_if_group_is_not_a_string(self):
-        schema = schemas.AnnotationSchema(testing.DummyRequest())
+        schema = schemas.AnnotationSchema()
 
         with pytest.raises(schemas.ValidationError) as err:
             schema.validate(self.valid_input_data(
@@ -238,7 +238,7 @@ class TestAnnotationSchema(object):
         assert str(err.value) == "group: False is not of type 'string'"
 
     def test_it_raises_if_permissions_is_missing(self):
-        schema = schemas.AnnotationSchema(testing.DummyRequest())
+        schema = schemas.AnnotationSchema()
         data = self.valid_input_data()
         del data['permissions']
 
@@ -248,7 +248,7 @@ class TestAnnotationSchema(object):
         assert str(err.value) == "'permissions' is a required property"
 
     def test_it_raises_if_permissions_is_not_a_dict(self):
-        schema = schemas.AnnotationSchema(testing.DummyRequest())
+        schema = schemas.AnnotationSchema()
 
         with pytest.raises(schemas.ValidationError) as err:
             schema.validate(self.valid_input_data(
@@ -258,7 +258,7 @@ class TestAnnotationSchema(object):
         assert str(err.value) == "permissions: False is not of type 'object'"
 
     def test_it_raises_if_permissions_has_no_read(self):
-        schema = schemas.AnnotationSchema(testing.DummyRequest())
+        schema = schemas.AnnotationSchema()
 
         with pytest.raises(schemas.ValidationError) as err:
             schema.validate(self.valid_input_data(
@@ -268,7 +268,7 @@ class TestAnnotationSchema(object):
         assert str(err.value) == "permissions: 'read' is a required property"
 
     def test_it_raises_if_permissions_read_is_not_a_list(self):
-        schema = schemas.AnnotationSchema(testing.DummyRequest())
+        schema = schemas.AnnotationSchema()
 
         with pytest.raises(schemas.ValidationError) as err:
             schema.validate(self.valid_input_data(
@@ -279,7 +279,7 @@ class TestAnnotationSchema(object):
             "permissions.read: False is not of type 'array'")
 
     def test_it_raises_if_permissions_read_item_is_not_a_string(self):
-        schema = schemas.AnnotationSchema(testing.DummyRequest())
+        schema = schemas.AnnotationSchema()
 
         with pytest.raises(schemas.ValidationError) as err:
             schema.validate(self.valid_input_data(
@@ -290,7 +290,7 @@ class TestAnnotationSchema(object):
             "permissions.read.0: False is not of type 'string'")
 
     def test_it_raises_if_permissions_read_item_is_wrong_format(self):
-        schema = schemas.AnnotationSchema(testing.DummyRequest())
+        schema = schemas.AnnotationSchema()
 
         with pytest.raises(schemas.ValidationError) as err:
             schema.validate(self.valid_input_data(
@@ -301,7 +301,7 @@ class TestAnnotationSchema(object):
             "permissions.read.0: u'foo' does not match '^(acct:|group:).+$'")
 
     def test_it_raises_if_references_is_not_a_list(self):
-        schema = schemas.AnnotationSchema(testing.DummyRequest())
+        schema = schemas.AnnotationSchema()
 
         with pytest.raises(schemas.ValidationError) as err:
             schema.validate(self.valid_input_data(
@@ -311,7 +311,7 @@ class TestAnnotationSchema(object):
         assert str(err.value) == "references: False is not of type 'array'"
 
     def test_it_raises_if_references_item_is_not_a_string(self):
-        schema = schemas.AnnotationSchema(testing.DummyRequest())
+        schema = schemas.AnnotationSchema()
 
         with pytest.raises(schemas.ValidationError) as err:
             schema.validate(self.valid_input_data(
@@ -321,7 +321,7 @@ class TestAnnotationSchema(object):
         assert str(err.value) == "references.0: False is not of type 'string'"
 
     def test_it_raises_if_tags_is_not_a_list(self):
-        schema = schemas.AnnotationSchema(testing.DummyRequest())
+        schema = schemas.AnnotationSchema()
 
         with pytest.raises(schemas.ValidationError) as err:
             schema.validate(self.valid_input_data(
@@ -331,7 +331,7 @@ class TestAnnotationSchema(object):
         assert str(err.value) == "tags: False is not of type 'array'"
 
     def test_it_raises_if_tags_item_is_not_a_string(self):
-        schema = schemas.AnnotationSchema(testing.DummyRequest())
+        schema = schemas.AnnotationSchema()
 
         with pytest.raises(schemas.ValidationError) as err:
             schema.validate(self.valid_input_data(
@@ -341,7 +341,7 @@ class TestAnnotationSchema(object):
         assert str(err.value) == "tags.0: False is not of type 'string'"
 
     def test_it_raises_if_target_is_not_a_list(self):
-        schema = schemas.AnnotationSchema(testing.DummyRequest())
+        schema = schemas.AnnotationSchema()
 
         with pytest.raises(schemas.ValidationError) as err:
             schema.validate(self.valid_input_data(
@@ -351,7 +351,7 @@ class TestAnnotationSchema(object):
         assert str(err.value) == "target: False is not of type 'array'"
 
     def test_it_raises_if_target_item_is_not_a_dict(self):
-        schema = schemas.AnnotationSchema(testing.DummyRequest())
+        schema = schemas.AnnotationSchema()
 
         with pytest.raises(schemas.ValidationError) as err:
             schema.validate(self.valid_input_data(
@@ -361,7 +361,7 @@ class TestAnnotationSchema(object):
         assert str(err.value) == "target.0: False is not of type 'object'"
 
     def test_it_raises_if_target_has_no_selector(self):
-        schema = schemas.AnnotationSchema(testing.DummyRequest())
+        schema = schemas.AnnotationSchema()
 
         with pytest.raises(schemas.ValidationError) as err:
             schema.validate(self.valid_input_data(
@@ -371,7 +371,7 @@ class TestAnnotationSchema(object):
         assert str(err.value) == "target.0: 'selector' is a required property"
 
     def test_it_raises_if_text_is_not_a_string(self):
-        schema = schemas.AnnotationSchema(testing.DummyRequest())
+        schema = schemas.AnnotationSchema()
 
         with pytest.raises(schemas.ValidationError) as err:
             schema.validate(self.valid_input_data(
@@ -381,7 +381,7 @@ class TestAnnotationSchema(object):
         assert str(err.value) == "text: False is not of type 'string'"
 
     def test_it_raises_if_uri_is_not_a_string(self):
-        schema = schemas.AnnotationSchema(testing.DummyRequest())
+        schema = schemas.AnnotationSchema()
 
         with pytest.raises(schemas.ValidationError) as err:
             schema.validate(self.valid_input_data(
@@ -407,302 +407,11 @@ class TestAnnotationSchema(object):
         'id',
     ])
     def test_it_removes_protected_fields(self, field):
-        schema = schemas.AnnotationSchema(testing.DummyRequest())
+        schema = schemas.AnnotationSchema()
 
         result = schema.validate(annotation_data(field='something forbidden'))
 
         assert field not in result
-
-    def test_it_sets_userid(self, authn_policy):
-        authn_policy.authenticated_userid.return_value = (
-            'acct:harriet@example.com')
-        schema = schemas.AnnotationSchema(testing.DummyRequest())
-
-        result = schema.validate(annotation_data())
-
-        assert result['userid'] == 'acct:harriet@example.com'
-
-    def test_it_renames_uri_to_target_uri(self):
-        schema = schemas.AnnotationSchema(testing.DummyRequest())
-
-        result = schema.validate(
-            annotation_data(uri='http://example.com/example'),
-        )
-
-        assert result['target_uri'] == 'http://example.com/example'
-        assert 'uri' not in result
-
-    def test_it_inserts_empty_string_if_data_has_no_uri(self):
-        schema = schemas.AnnotationSchema(testing.DummyRequest())
-
-        data = annotation_data()
-        assert 'uri' not in data
-
-        assert schema.validate(data)['target_uri'] == ''
-
-    def test_it_keeps_text(self):
-        schema = schemas.AnnotationSchema(testing.DummyRequest())
-
-        result = schema.validate(annotation_data(text='some annotation text'))
-
-        assert result['text'] == 'some annotation text'
-
-    def test_it_inserts_empty_string_if_data_contains_no_text(self):
-        schema = schemas.AnnotationSchema(testing.DummyRequest())
-
-        data = annotation_data()
-        assert 'text' not in data
-
-        assert schema.validate(data)['text'] == ''
-
-    def test_it_keeps_tags(self):
-        schema = schemas.AnnotationSchema(testing.DummyRequest())
-
-        result = schema.validate(annotation_data(tags=['foo', 'bar']))
-
-        assert result['tags'] == ['foo', 'bar']
-
-    def test_it_inserts_empty_list_if_data_contains_no_tags(self):
-        schema = schemas.AnnotationSchema(testing.DummyRequest())
-
-        data = annotation_data()
-        assert 'tags' not in data
-
-        assert schema.validate(data)['tags'] == []
-
-    def test_it_replaces_private_permissions_with_shared_False(
-            self,
-            authn_policy):
-        authn_policy.authenticated_userid.return_value = (
-            'acct:harriet@example.com')
-        schema = schemas.AnnotationSchema(testing.DummyRequest())
-
-        result = schema.validate(
-            annotation_data(
-                permissions={'read': ['acct:harriet@example.com']},
-            ),
-        )
-
-        assert result['shared'] is False
-        assert 'permissions' not in result
-
-    def test_it_replaces_shared_permissions_with_shared_True(
-            self,
-            authn_policy):
-        authn_policy.authenticated_userid.return_value = (
-            'acct:harriet@example.com')
-        schema = schemas.AnnotationSchema(testing.DummyRequest())
-
-        result = schema.validate(
-            annotation_data(
-                permissions={'read': ['group:__world__']},
-            ),
-        )
-
-        assert result['shared'] is True
-        assert 'permissions' not in result
-
-    def test_it_does_not_crash_if_data_contains_no_target(self):
-        schema = schemas.AnnotationSchema(testing.DummyRequest())
-
-        data = annotation_data()
-        assert 'target' not in data
-
-        schema.validate(data)
-
-    def test_it_replaces_target_with_target_selectors(self):
-        schema = schemas.AnnotationSchema(testing.DummyRequest())
-
-        result = schema.validate(
-            annotation_data(
-                target=[
-                    {
-                        'foo': 'bar',  # This should be removed,
-                        'selector': 'the selectors',
-                    },
-                    'this should be removed',
-                ],
-            ),
-        )
-
-        assert result['target_selectors'] == 'the selectors'
-
-    def test_it_renames_group_to_groupid(self):
-        schema = schemas.AnnotationSchema(testing.DummyRequest())
-
-        result = schema.validate(annotation_data(group='foo'))
-
-        assert result['groupid'] == 'foo'
-        assert 'group' not in result
-
-    def test_it_inserts_default_groupid_if_no_group(self):
-        schema = schemas.AnnotationSchema(testing.DummyRequest())
-
-        data = annotation_data()
-        assert 'group' not in data
-
-        result = schema.validate(data)
-
-        assert result['groupid'] == '__world__'
-
-    def test_it_keeps_references(self):
-        schema = schemas.AnnotationSchema(testing.DummyRequest())
-
-        result = schema.validate(
-            annotation_data(references=['parent id', 'parent id 2']))
-
-        assert result['references'] == ['parent id', 'parent id 2']
-
-    def test_it_inserts_empty_list_if_no_references(self):
-        schema = schemas.AnnotationSchema(testing.DummyRequest())
-
-        data = annotation_data()
-        assert 'references' not in data
-
-        result = schema.validate(data)
-
-        assert result['references'] == []
-
-    def test_it_deletes_groupid_for_replies(self):
-        schema = schemas.AnnotationSchema(testing.DummyRequest())
-
-        result = schema.validate(
-            annotation_data(
-                group='foo',
-                references=['parent annotation id'],
-            )
-        )
-
-        assert 'groupid' not in result
-
-    def test_it_moves_extra_data_into_extra_sub_dict(self):
-        schema = schemas.AnnotationSchema(testing.DummyRequest())
-
-        result = schema.validate({
-            # Throw in all the fields, just to make sure that none of them get
-            # into extra.
-            'created': 'created',
-            'updated': 'updated',
-            'user': 'user',
-            'id': 'id',
-            'uri': 'uri',
-            'text': 'text',
-            'tags': ['gar', 'har'],
-            'permissions': {'read': ['group:__world__']},
-            'target': [],
-            'group': '__world__',
-            'references': ['parent'],
-
-            # These should end up in extra.
-            'foo': 1,
-            'bar': 2,
-        })
-
-        assert result['extra'] == {'foo': 1, 'bar': 2}
-
-    def test_it_calls_document_uris_from_data(self, parse_document_claims):
-        document_data = {'foo': 'bar'}
-        target_uri = 'http://example.com/example'
-        schema = schemas.AnnotationSchema(testing.DummyRequest())
-
-        schema.validate(
-            annotation_data(
-                document=document_data,
-                uri=target_uri,
-            )
-        )
-
-        parse_document_claims.document_uris_from_data.assert_called_once_with(
-            document_data,
-            claimant=target_uri,
-        )
-
-    def test_it_puts_document_uris_in_appstruct(self, parse_document_claims):
-        schema = schemas.AnnotationSchema(testing.DummyRequest())
-
-        appstruct = schema.validate(annotation_data())
-
-        assert appstruct['document']['document_uri_dicts'] == (
-            parse_document_claims.document_uris_from_data.return_value)
-
-    def test_it_calls_document_metas_from_data(self, parse_document_claims):
-        schema = schemas.AnnotationSchema(testing.DummyRequest())
-        document_data = {'foo': 'bar'}
-        target_uri = 'http://example.com/example'
-
-        schema.validate(
-            annotation_data(
-                document=document_data,
-                uri=target_uri,
-            )
-        )
-
-        parse_document_claims.document_metas_from_data.assert_called_once_with(
-            document_data,
-            claimant=target_uri,
-        )
-
-    def test_it_does_not_pass_modified_dict_to_document_metas_from_data(
-            self,
-            parse_document_claims):
-        """
-
-        If document_uris_from_data() modifies the document dict that it's
-        given, the original dict (or one with the same values as it) should be
-        passed t document_metas_from_data(), not the modified copy.
-
-        """
-        document = {
-            'top_level_key': 'original_value',
-            'sub_dict': {
-                'key': 'original_value'
-            }
-        }
-        def document_uris_from_data(document, claimant):
-            document['new_key'] = 'new_value'
-            document['top_level_key'] = 'new_value'
-            document['sub_dict']['key'] = 'new_value'
-        parse_document_claims.document_uris_from_data.side_effect = (
-            document_uris_from_data)
-        schema = schemas.AnnotationSchema(testing.DummyRequest())
-
-        schema.validate(annotation_data(document=document))
-
-        assert (
-            parse_document_claims.document_metas_from_data.call_args[0][0] ==
-            document)
-
-    def test_it_puts_document_metas_in_appstruct(self, parse_document_claims):
-        schema = schemas.AnnotationSchema(testing.DummyRequest())
-
-        appstruct = schema.validate(annotation_data())
-
-        assert appstruct['document']['document_meta_dicts'] == (
-            parse_document_claims.document_metas_from_data.return_value)
-
-    def test_it_clears_existing_keys_from_document(self):
-        """
-        Any keys in the document dict should be removed.
-
-        They're replaced with the 'document_uri_dicts' and
-        'document_meta_dicts' keys.
-
-        """
-        schema = schemas.AnnotationSchema(testing.DummyRequest())
-
-        appstruct = schema.validate(
-            annotation_data(
-                document={
-                    'foo': 'bar'  # This should be deleted.
-                },
-            ),
-        )
-
-        assert 'foo' not in appstruct['document']
-
-    @pytest.fixture
-    def parse_document_claims(self, patch):
-        return patch('h.api.schemas.parse_document_claims')
 
 
 class TestLegacyCreateAnnotationSchema(object):
@@ -738,9 +447,9 @@ class TestLegacyCreateAnnotationSchema(object):
         data = {}
         data[field] = 'something forbidden'
 
-        result = schema.validate(data)
+        appstruct = schema.validate(data)
 
-        assert field not in result
+        assert field not in appstruct
 
     @pytest.mark.parametrize('data', [
         {},
@@ -754,9 +463,9 @@ class TestLegacyCreateAnnotationSchema(object):
         request = self.mock_request()
         schema = schemas.LegacyCreateAnnotationSchema(request)
 
-        result = schema.validate(data)
+        appstruct = schema.validate(data)
 
-        assert result['user'] == 'acct:jeanie@example.com'
+        assert appstruct['user'] == 'acct:jeanie@example.com'
 
     @pytest.mark.parametrize('data,effective_principals,ok', [
         # No group supplied
@@ -788,8 +497,8 @@ class TestLegacyCreateAnnotationSchema(object):
         schema = schemas.LegacyCreateAnnotationSchema(request)
 
         if ok:
-            result = schema.validate(data)
-            assert result.get('group') == data.get('group')
+            appstruct = schema.validate(data)
+            assert appstruct.get('group') == data.get('group')
 
         else:
             with pytest.raises(schemas.ValidationError) as exc:
@@ -808,10 +517,10 @@ class TestLegacyCreateAnnotationSchema(object):
         request = self.mock_request()
         schema = schemas.LegacyCreateAnnotationSchema(request)
 
-        result = schema.validate(data)
+        appstruct = schema.validate(data)
 
         for k in data:
-            assert result[k] == data[k]
+            assert appstruct[k] == data[k]
 
     def mock_request(self):
         request = testing.DummyRequest()
@@ -841,13 +550,294 @@ class TestCreateAnnotationSchema(object):
         with pytest.raises(schemas.ValidationError):
             schema.validate({'foo': 'bar'})
 
-    def test_it_returns_the_appstruct_from_AnnotationSchema(self,
-                                                            AnnotationSchema):
+    def test_it_sets_userid(self, authn_policy):
+        authn_policy.authenticated_userid.return_value = (
+            'acct:harriet@example.com')
         schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
 
-        appstruct = schema.validate(mock.sentinel.input_data)
+        result = schema.validate(annotation_data())
 
-        assert appstruct == AnnotationSchema.return_value.validate.return_value
+        assert result['userid'] == 'acct:harriet@example.com'
+
+    def test_it_renames_uri_to_target_uri(self, AnnotationSchema):
+        schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
+        AnnotationSchema.return_value.validate.return_value['uri'] = (
+            'http://example.com/example')
+
+        result = schema.validate({})
+
+        assert result['target_uri'] == 'http://example.com/example'
+        assert 'uri' not in result
+
+    def test_it_inserts_empty_string_if_data_has_no_uri(self):
+        schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
+
+        data = annotation_data()
+        assert 'uri' not in data
+
+        assert schema.validate(data)['target_uri'] == ''
+
+    def test_it_keeps_text(self, AnnotationSchema):
+        schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
+        AnnotationSchema.return_value.validate.return_value['text'] = (
+            'some annotation text')
+
+        result = schema.validate({})
+
+        assert result['text'] == 'some annotation text'
+
+    def test_it_inserts_empty_string_if_data_contains_no_text(self):
+        schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
+
+        data = annotation_data()
+        assert 'text' not in data
+
+        assert schema.validate(data)['text'] == ''
+
+    def test_it_keeps_tags(self, AnnotationSchema):
+        schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
+        AnnotationSchema.return_value.validate.return_value['tags'] = [
+            'foo', 'bar']
+
+        result = schema.validate({})
+
+        assert result['tags'] == ['foo', 'bar']
+
+    def test_it_inserts_empty_list_if_data_contains_no_tags(self):
+        schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
+
+        data = annotation_data()
+        assert 'tags' not in data
+
+        assert schema.validate(data)['tags'] == []
+
+    def test_it_replaces_private_permissions_with_shared_False(
+            self,
+            AnnotationSchema,
+            authn_policy):
+        AnnotationSchema.return_value.validate.return_value['permissions'] = {
+            'read': ['acct:harriet@example.com'],
+        }
+        authn_policy.authenticated_userid.return_value = (
+            'acct:harriet@example.com')
+        schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
+
+        result = schema.validate({})
+
+        assert result['shared'] is False
+        assert 'permissions' not in result
+
+    def test_it_replaces_shared_permissions_with_shared_True(
+            self,
+            authn_policy):
+        authn_policy.authenticated_userid.return_value = (
+            'acct:harriet@example.com')
+        schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
+
+        result = schema.validate(
+            annotation_data(
+                permissions={'read': ['group:__world__']},
+            ),
+        )
+
+        assert result['shared'] is True
+        assert 'permissions' not in result
+
+    def test_it_does_not_crash_if_data_contains_no_target(self):
+        schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
+
+        data = annotation_data()
+        assert 'target' not in data
+
+        schema.validate(data)
+
+    def test_it_replaces_target_with_target_selectors(self, AnnotationSchema):
+        schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
+        AnnotationSchema.return_value.validate.return_value['target'] = [
+            {
+                'foo': 'bar',  # This should be removed,
+                'selector': 'the selectors',
+            },
+            'this should be removed',
+        ]
+
+        result = schema.validate({})
+
+        assert result['target_selectors'] == 'the selectors'
+
+    def test_it_renames_group_to_groupid(self, AnnotationSchema):
+        schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
+        AnnotationSchema.return_value.validate.return_value['group'] = 'foo'
+
+        result = schema.validate({})
+
+        assert result['groupid'] == 'foo'
+        assert 'group' not in result
+
+    def test_it_inserts_default_groupid_if_no_group(self, AnnotationSchema):
+        schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
+        del AnnotationSchema.return_value.validate.return_value['group']
+
+        result = schema.validate({})
+
+        assert result['groupid'] == '__world__'
+
+    def test_it_keeps_references(self, AnnotationSchema):
+        schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
+        AnnotationSchema.return_value.validate.return_value['references'] = [
+            'parent id', 'parent id 2']
+
+        result = schema.validate({})
+
+        assert result['references'] == ['parent id', 'parent id 2']
+
+    def test_it_inserts_empty_list_if_no_references(self, AnnotationSchema):
+        schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
+        assert 'references' not in AnnotationSchema.return_value.validate\
+            .return_value
+
+        result = schema.validate({})
+
+        assert result['references'] == []
+
+    def test_it_deletes_groupid_for_replies(self, AnnotationSchema):
+        schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
+        AnnotationSchema.return_value.validate.return_value['group'] = 'foo'
+        AnnotationSchema.return_value.validate.return_value['references'] = [
+            'parent annotation id']
+
+        result = schema.validate({})
+
+        assert 'groupid' not in result
+
+    def test_it_moves_extra_data_into_extra_sub_dict(self, AnnotationSchema):
+        schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
+        AnnotationSchema.return_value.validate.return_value = {
+            # Throw in all the fields, just to make sure that none of them get
+            # into extra.
+            'created': 'created',
+            'updated': 'updated',
+            'user': 'user',
+            'id': 'id',
+            'uri': 'uri',
+            'text': 'text',
+            'tags': ['gar', 'har'],
+            'permissions': {'read': ['group:__world__']},
+            'target': [],
+            'group': '__world__',
+            'references': ['parent'],
+
+            # These should end up in extra.
+            'foo': 1,
+            'bar': 2,
+        }
+
+        result = schema.validate({})
+
+        assert result['extra'] == {'foo': 1, 'bar': 2}
+
+    def test_it_calls_document_uris_from_data(self,
+                                              AnnotationSchema,
+                                              parse_document_claims):
+        document_data = {'foo': 'bar'}
+        target_uri = 'http://example.com/example'
+        AnnotationSchema.return_value.validate.return_value['document'] = (
+            document_data)
+        AnnotationSchema.return_value.validate.return_value['uri'] = target_uri
+        schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
+
+        schema.validate({})
+
+        parse_document_claims.document_uris_from_data.assert_called_once_with(
+            document_data,
+            claimant=target_uri,
+        )
+
+    def test_it_puts_document_uris_in_appstruct(self, parse_document_claims):
+        schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
+
+        appstruct = schema.validate({})
+
+        assert appstruct['document']['document_uri_dicts'] == (
+            parse_document_claims.document_uris_from_data.return_value)
+
+    def test_it_calls_document_metas_from_data(self,
+                                               AnnotationSchema,
+                                               parse_document_claims):
+        schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
+        document_data = {'foo': 'bar'}
+        target_uri = 'http://example.com/example'
+        AnnotationSchema.return_value.validate.return_value['document'] = {
+            'foo': 'bar'}
+        AnnotationSchema.return_value.validate.return_value['uri'] = target_uri
+
+        schema.validate({})
+
+        parse_document_claims.document_metas_from_data.assert_called_once_with(
+            document_data,
+            claimant=target_uri,
+        )
+
+    def test_it_does_not_pass_modified_dict_to_document_metas_from_data(
+            self,
+            AnnotationSchema,
+            parse_document_claims):
+        """
+
+        If document_uris_from_data() modifies the document dict that it's
+        given, the original dict (or one with the same values as it) should be
+        passed t document_metas_from_data(), not the modified copy.
+
+        """
+        document = {
+            'top_level_key': 'original_value',
+            'sub_dict': {
+                'key': 'original_value'
+            }
+        }
+        def document_uris_from_data(document, claimant):
+            document['new_key'] = 'new_value'
+            document['top_level_key'] = 'new_value'
+            document['sub_dict']['key'] = 'new_value'
+        parse_document_claims.document_uris_from_data.side_effect = (
+            document_uris_from_data)
+        schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
+        AnnotationSchema.return_value.validate.return_value['document'] = (
+            document)
+
+        schema.validate({})
+
+        assert (
+            parse_document_claims.document_metas_from_data.call_args[0][0] ==
+            document)
+
+    def test_it_puts_document_metas_in_appstruct(self, parse_document_claims):
+        schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
+
+        appstruct = schema.validate(annotation_data())
+
+        assert appstruct['document']['document_meta_dicts'] == (
+            parse_document_claims.document_metas_from_data.return_value)
+
+    def test_it_clears_existing_keys_from_document(self):
+        """
+        Any keys in the document dict should be removed.
+
+        They're replaced with the 'document_uri_dicts' and
+        'document_meta_dicts' keys.
+
+        """
+        schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
+
+        appstruct = schema.validate(
+            annotation_data(
+                document={
+                    'foo': 'bar'  # This should be deleted.
+                },
+            ),
+        )
+
+        assert 'foo' not in appstruct['document']
 
 
 class TestLegacyUpdateAnnotationSchema(object):
@@ -966,9 +956,9 @@ class TestLegacyUpdateAnnotationSchema(object):
 @pytest.mark.usefixtures('AnnotationSchema')
 class TestUpdateAnnotationSchema(object):
 
-    def test_it_passes_input_to_AnnotationSchema_validator(self,
-                                                           annotation,
-                                                           AnnotationSchema):
+    def test_it_calls_AnnotationSchema_validate(self,
+                                                annotation,
+                                                AnnotationSchema):
         schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(),
                                                 annotation)
 
@@ -986,30 +976,306 @@ class TestUpdateAnnotationSchema(object):
                                                 annotation)
 
         with pytest.raises(schemas.ValidationError):
-            schema.validate({'foo': 'bar'})
+            schema.validate({})
 
-    def test_it_raises_if_you_try_to_change_the_group(self,
-                                                      annotation,
-                                                      AnnotationSchema):
-        annotation.groupid = 'original-group'
-        AnnotationSchema.return_value.validate.return_value['groupid'] = (
-            'new-group')
+    def test_you_cannot_update_protected_fields(self,
+                                                annotation,
+                                                AnnotationSchema):
+        for protected_field in ['created', 'updated', 'user', 'id']:
+            AnnotationSchema.return_value.validate\
+                .return_value[protected_field] = 'foo'
+            schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(),
+                                                    annotation)
+
+            appstruct = schema.validate({})
+
+            assert protected_field not in appstruct
+            assert protected_field not in appstruct.get('extra', {})
+
+    def test_it_renames_uri_to_target_uri(self, annotation, AnnotationSchema):
+        schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(),
+                                                annotation)
+        AnnotationSchema.return_value.validate.return_value['uri'] = (
+            'http://example.com/example')
+
+        appstruct = schema.validate({})
+
+        assert appstruct['target_uri'] == 'http://example.com/example'
+        assert 'uri' not in appstruct
+        assert 'uri' not in appstruct.get('extras', {})
+
+    def test_it_replaces_private_permissions_with_shared_False(
+            self,
+            annotation,
+            AnnotationSchema,
+            authn_policy):
+        AnnotationSchema.return_value.validate.return_value['permissions'] = {
+            'read': ['acct:harriet@example.com'],
+        }
+        authn_policy.authenticated_userid.return_value = (
+            'acct:harriet@example.com')
         schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(),
                                                 annotation)
 
-        with pytest.raises(schemas.ValidationError):
-            schema.validate(mock.sentinel.input_data)
+        appstruct = schema.validate({})
 
-    def test_it_returns_the_appstruct_from_AnnotationSchema(self,
-                                                            annotation,
-                                                            AnnotationSchema):
+        assert appstruct['shared'] is False
+        assert 'permissions' not in appstruct
+        assert 'permissions' not in appstruct.get('extras', {})
+
+    def test_it_replaces_shared_permissions_with_shared_True(self,
+                                                             annotation,
+                                                             AnnotationSchema,
+                                                             authn_policy):
+        AnnotationSchema.return_value.validate.return_value['permissions'] = {
+            'read': ['group:__world__'],
+        }
+        authn_policy.authenticated_userid.return_value = (
+            'acct:harriet@example.com')
         schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(),
                                                 annotation)
 
-        appstruct = schema.validate(mock.sentinel.input_data)
+        appstruct = schema.validate({})
 
-        assert appstruct == AnnotationSchema.return_value.validate.return_value
+        assert appstruct['shared'] is True
+        assert 'permissions' not in appstruct
+        assert 'permissions' not in appstruct.get('extras', {})
 
+    def test_it_converts_target_to_target_selectors(self,
+                                                    annotation,
+                                                    AnnotationSchema):
+        schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(),
+                                                annotation)
+        AnnotationSchema.return_value.validate.return_value['target'] = [
+            {
+                'foo': 'bar',  # This should be removed,
+                'selector': 'the selectors',
+            },
+            'this should be removed',
+        ]
+
+        appstruct = schema.validate({})
+
+        assert appstruct['target_selectors'] == 'the selectors'
+        assert 'target' not in appstruct
+        assert 'target' not in appstruct.get('extras', {})
+
+    def test_you_can_update_text(self, annotation, AnnotationSchema):
+        annotation.text = 'old_text'
+        schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(),
+                                                annotation)
+        AnnotationSchema.return_value.validate.return_value['text'] = 'new'
+
+        appstruct = schema.validate({})
+
+        assert appstruct['text'] == 'new'
+
+    def test_you_can_update_tags(self, annotation, AnnotationSchema):
+        annotation.tags = ['old', 'tags']
+        schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(),
+                                                annotation)
+        AnnotationSchema.return_value.validate.return_value['tags'] = ['new']
+
+        appstruct = schema.validate({})
+
+        assert appstruct['tags'] == ['new']
+
+    def test_it_calls_document_uris_from_data(self,
+                                              annotation,
+                                              AnnotationSchema,
+                                              parse_document_claims):
+        document_data = {'foo': 'bar'}
+        target_uri = 'http://example.com/example'
+        AnnotationSchema.return_value.validate.return_value['document'] = (
+            document_data)
+        AnnotationSchema.return_value.validate.return_value['uri'] = target_uri
+        schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(),
+                                                annotation)
+
+        schema.validate({})
+
+        parse_document_claims.document_uris_from_data.assert_called_once_with(
+            document_data,
+            claimant=target_uri,
+        )
+
+    def test_it_passes_existing_target_uri_to_document_uris_from_data(
+            self,
+            annotation,
+            AnnotationSchema,
+            parse_document_claims):
+        """
+        If no 'uri' is given it should use the existing target_uri.
+
+        If no 'uri' is given in the update request then
+        document_uris_from_data() should be called with the existing
+        target_uri of the annotation in the database.
+
+        """
+        document_data = {'foo': 'bar'}
+        annotation.target_uri = 'http://example.com/existing_target_uri'
+        AnnotationSchema.return_value.validate.return_value['document'] = (
+            document_data)
+        assert 'uri' not in AnnotationSchema.return_value.validate.return_value
+        schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(),
+                                                annotation)
+
+        schema.validate({})
+
+        parse_document_claims.document_uris_from_data.assert_called_once_with(
+            document_data,
+            claimant=annotation.target_uri,
+        )
+
+    def test_it_puts_document_uris_in_appstruct(self,
+                                                annotation,
+                                                AnnotationSchema,
+                                                parse_document_claims):
+        AnnotationSchema.return_value.validate.return_value['document'] = {}
+        schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(),
+                                                annotation)
+
+        appstruct = schema.validate({})
+
+        assert appstruct['document']['document_uri_dicts'] == (
+            parse_document_claims.document_uris_from_data.return_value)
+
+    def test_it_calls_document_metas_from_data(self,
+                                               annotation,
+                                               AnnotationSchema,
+                                               parse_document_claims):
+        schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(),
+                                                annotation)
+        document_data = {'foo': 'bar'}
+        target_uri = 'http://example.com/example'
+        AnnotationSchema.return_value.validate.return_value['document'] = (
+            document_data)
+        AnnotationSchema.return_value.validate.return_value['uri'] = target_uri
+
+        schema.validate({})
+
+        parse_document_claims.document_metas_from_data.assert_called_once_with(
+            document_data,
+            claimant=target_uri
+        )
+
+    def test_it_passes_existing_target_uri_to_document_metas_from_data(
+            self,
+            annotation,
+            AnnotationSchema,
+            parse_document_claims):
+        """
+        If no 'uri' is given it should use the existing target_uri.
+
+        If no 'uri' is given in the update request then
+        document_metas_from_data() should be called with the existing
+        target_uri of the annotation in the database.
+
+        """
+        document_data = {'foo': 'bar'}
+        annotation.target_uri = 'http://example.com/existing_target_uri'
+        AnnotationSchema.return_value.validate.return_value['document'] = (
+            document_data)
+        assert 'uri' not in AnnotationSchema.return_value.validate.return_value
+        schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(),
+                                                annotation)
+
+        schema.validate({})
+
+        parse_document_claims.document_metas_from_data.assert_called_once_with(
+            document_data,
+            claimant=annotation.target_uri,
+        )
+
+    def test_it_does_not_pass_modified_dict_to_document_metas_from_data(
+            self,
+            annotation,
+            AnnotationSchema,
+            parse_document_claims):
+        """
+
+        If document_uris_from_data() modifies the document dict that it's
+        given, the original dict (or one with the same values as it) should be
+        passed t document_metas_from_data(), not the modified copy.
+
+        """
+        document = {
+            'top_level_key': 'original_value',
+            'sub_dict': {
+                'key': 'original_value'
+            }
+        }
+        def document_uris_from_data(document, claimant):
+            document['new_key'] = 'new_value'
+            document['top_level_key'] = 'new_value'
+            document['sub_dict']['key'] = 'new_value'
+        parse_document_claims.document_uris_from_data.side_effect = (
+            document_uris_from_data)
+        schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(),
+                                                annotation)
+        AnnotationSchema.return_value.validate.return_value['document'] = (
+            document)
+
+        schema.validate({})
+
+        assert (
+            parse_document_claims.document_metas_from_data.call_args[0][0] ==
+            document)
+
+    def test_it_puts_document_metas_in_appstruct(self,
+                                                 annotation,
+                                                 AnnotationSchema,
+                                                 parse_document_claims):
+        schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(),
+                                                annotation)
+        AnnotationSchema.return_value.validate.return_value['document'] = {}
+
+        appstruct = schema.validate({})
+
+        assert appstruct['document']['document_meta_dicts'] == (
+            parse_document_claims.document_metas_from_data.return_value)
+
+    def test_it_clears_existing_keys_from_document(self,
+                                                   annotation,
+                                                   AnnotationSchema):
+        """
+        Any keys in the document dict should be removed.
+
+        They're replaced with the 'document_uri_dicts' and
+        'document_meta_dicts' keys.
+
+        """
+        schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(),
+                                                annotation)
+        AnnotationSchema.return_value.validate.return_value['document'] = {
+            'foo': 'bar'  # This should be deleted.
+        }
+
+        appstruct = schema.validate({})
+
+        assert 'foo' not in appstruct['document']
+
+    def test_document_does_not_end_up_in_extra(self,
+                                               annotation,
+                                               AnnotationSchema):
+        schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(),
+                                                annotation)
+        AnnotationSchema.return_value.validate.return_value['document'] = {
+            'foo': 'bar'
+        }
+
+        appstruct = schema.validate({})
+
+        assert 'document' not in appstruct.get('extra', {})
+
+    def test_it_does_not_crash_when_fields_are_missing(self,
+                                                       annotation,
+                                                       AnnotationSchema):
+        AnnotationSchema.return_value.validate.return_value = {}
+        schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(),
+                                                annotation)
+
+        appstruct = schema.validate({})
 
     @pytest.fixture
     def annotation(self):
@@ -1030,6 +1296,16 @@ def annotation_data(**kwargs):
 def AnnotationSchema(patch):
     cls = patch('h.api.schemas.AnnotationSchema')
     cls.return_value.validate.return_value = {
-        'groupid': 'foogroup',
+        'permissions': {
+            'read': ['group:__world__'],
+            'update': ['acct:testuser@hypothes.is'],
+            'delete': ['acct:testuser@hypothes.is'],
+        },
+        'group': 'foogroup',
     }
     return cls
+
+
+@pytest.fixture
+def parse_document_claims(patch):
+    return patch('h.api.schemas.parse_document_claims')

--- a/h/api/test/schemas_test.py
+++ b/h/api/test/schemas_test.py
@@ -954,10 +954,8 @@ class TestLegacyUpdateAnnotationSchema(object):
 class TestUpdateAnnotationSchema(object):
 
     def test_it_calls_AnnotationSchema_validate(self,
-                                                annotation,
                                                 AnnotationSchema):
-        schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(),
-                                                annotation)
+        schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(), '')
 
         schema.validate(mock.sentinel.input_data)
 
@@ -965,24 +963,20 @@ class TestUpdateAnnotationSchema(object):
             mock.sentinel.input_data)
 
     def test_it_raises_if_AnnotationSchema_validate_raises(self,
-                                                           annotation,
                                                            AnnotationSchema):
         AnnotationSchema.return_value.validate.side_effect = (
             schemas.ValidationError('asplode'))
-        schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(),
-                                                annotation)
+        schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(), '')
 
         with pytest.raises(schemas.ValidationError):
             schema.validate({})
 
     def test_you_cannot_update_protected_fields(self,
-                                                annotation,
                                                 AnnotationSchema):
         for protected_field in ['created', 'updated', 'user', 'id']:
             AnnotationSchema.return_value.validate\
                 .return_value[protected_field] = 'foo'
-            schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(),
-                                                    annotation)
+            schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(), '')
 
             appstruct = schema.validate({})
 
@@ -990,15 +984,12 @@ class TestUpdateAnnotationSchema(object):
             assert protected_field not in appstruct.get('extra', {})
 
     def test_you_cannot_change_an_annotations_group(self,
-                                                    annotation,
                                                     AnnotationSchema):
-        annotation.groupid = 'original-group'
         AnnotationSchema.return_value.validate.return_value['groupid'] = (
             'new-group')
         AnnotationSchema.return_value.validate.return_value['group'] = (
             'new-group')
-        schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(),
-                                                annotation)
+        schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(), '')
 
         appstruct = schema.validate({})
 
@@ -1008,13 +999,10 @@ class TestUpdateAnnotationSchema(object):
         assert 'group' not in appstruct.get('extra', {})
 
     def test_you_cannot_change_an_annotations_userid(self,
-                                                     annotation,
                                                      AnnotationSchema):
-        annotation.userid = 'original_userid'
         AnnotationSchema.return_value.validate.return_value['userid'] = (
             'new_userid')
-        schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(),
-                                                annotation)
+        schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(), '')
 
         appstruct = schema.validate({})
 
@@ -1022,22 +1010,18 @@ class TestUpdateAnnotationSchema(object):
         assert 'userid' not in appstruct.get('extra', {})
 
     def test_you_cannot_change_an_annotations_references(self,
-                                                         annotation,
                                                          AnnotationSchema):
-        annotation.references = ['original_parent']
         AnnotationSchema.return_value.validate.return_value['references'] = [
             'new_parent']
-        schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(),
-                                                annotation)
+        schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(), '')
 
         appstruct = schema.validate({})
 
         assert 'references' not in appstruct
         assert 'references' not in appstruct.get('extra', {})
 
-    def test_it_renames_uri_to_target_uri(self, annotation, AnnotationSchema):
-        schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(),
-                                                annotation)
+    def test_it_renames_uri_to_target_uri(self, AnnotationSchema):
+        schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(), '')
         AnnotationSchema.return_value.validate.return_value['uri'] = (
             'http://example.com/example')
 
@@ -1049,7 +1033,6 @@ class TestUpdateAnnotationSchema(object):
 
     def test_it_replaces_private_permissions_with_shared_False(
             self,
-            annotation,
             AnnotationSchema,
             authn_policy):
         AnnotationSchema.return_value.validate.return_value['permissions'] = {
@@ -1057,8 +1040,7 @@ class TestUpdateAnnotationSchema(object):
         }
         authn_policy.authenticated_userid.return_value = (
             'acct:harriet@example.com')
-        schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(),
-                                                annotation)
+        schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(), '')
 
         appstruct = schema.validate({})
 
@@ -1067,7 +1049,6 @@ class TestUpdateAnnotationSchema(object):
         assert 'permissions' not in appstruct.get('extras', {})
 
     def test_it_replaces_shared_permissions_with_shared_True(self,
-                                                             annotation,
                                                              AnnotationSchema,
                                                              authn_policy):
         AnnotationSchema.return_value.validate.return_value['permissions'] = {
@@ -1075,8 +1056,7 @@ class TestUpdateAnnotationSchema(object):
         }
         authn_policy.authenticated_userid.return_value = (
             'acct:harriet@example.com')
-        schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(),
-                                                annotation)
+        schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(), '')
 
         appstruct = schema.validate({})
 
@@ -1085,10 +1065,8 @@ class TestUpdateAnnotationSchema(object):
         assert 'permissions' not in appstruct.get('extras', {})
 
     def test_it_converts_target_to_target_selectors(self,
-                                                    annotation,
                                                     AnnotationSchema):
-        schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(),
-                                                annotation)
+        schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(), '')
         AnnotationSchema.return_value.validate.return_value['target'] = [
             {
                 'foo': 'bar',  # This should be removed,
@@ -1103,20 +1081,16 @@ class TestUpdateAnnotationSchema(object):
         assert 'target' not in appstruct
         assert 'target' not in appstruct.get('extras', {})
 
-    def test_you_can_update_text(self, annotation, AnnotationSchema):
-        annotation.text = 'old_text'
-        schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(),
-                                                annotation)
+    def test_you_can_update_text(self, AnnotationSchema):
+        schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(), '')
         AnnotationSchema.return_value.validate.return_value['text'] = 'new'
 
         appstruct = schema.validate({})
 
         assert appstruct['text'] == 'new'
 
-    def test_you_can_update_tags(self, annotation, AnnotationSchema):
-        annotation.tags = ['old', 'tags']
-        schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(),
-                                                annotation)
+    def test_you_can_update_tags(self, AnnotationSchema):
+        schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(), '')
         AnnotationSchema.return_value.validate.return_value['tags'] = ['new']
 
         appstruct = schema.validate({})
@@ -1124,7 +1098,6 @@ class TestUpdateAnnotationSchema(object):
         assert appstruct['tags'] == ['new']
 
     def test_it_calls_document_uris_from_data(self,
-                                              annotation,
                                               AnnotationSchema,
                                               parse_document_claims):
         document_data = {'foo': 'bar'}
@@ -1132,8 +1105,7 @@ class TestUpdateAnnotationSchema(object):
         AnnotationSchema.return_value.validate.return_value['document'] = (
             document_data)
         AnnotationSchema.return_value.validate.return_value['uri'] = target_uri
-        schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(),
-                                                annotation)
+        schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(), '')
 
         schema.validate({})
 
@@ -1144,7 +1116,6 @@ class TestUpdateAnnotationSchema(object):
 
     def test_it_passes_existing_target_uri_to_document_uris_from_data(
             self,
-            annotation,
             AnnotationSchema,
             parse_document_claims):
         """
@@ -1156,27 +1127,23 @@ class TestUpdateAnnotationSchema(object):
 
         """
         document_data = {'foo': 'bar'}
-        annotation.target_uri = 'http://example.com/existing_target_uri'
         AnnotationSchema.return_value.validate.return_value['document'] = (
             document_data)
         assert 'uri' not in AnnotationSchema.return_value.validate.return_value
         schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(),
-                                                annotation)
+                                                mock.sentinel.target_uri)
 
         schema.validate({})
 
         parse_document_claims.document_uris_from_data.assert_called_once_with(
             document_data,
-            claimant=annotation.target_uri,
-        )
+            claimant=mock.sentinel.target_uri)
 
     def test_it_puts_document_uris_in_appstruct(self,
-                                                annotation,
                                                 AnnotationSchema,
                                                 parse_document_claims):
         AnnotationSchema.return_value.validate.return_value['document'] = {}
-        schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(),
-                                                annotation)
+        schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(), '')
 
         appstruct = schema.validate({})
 
@@ -1184,11 +1151,9 @@ class TestUpdateAnnotationSchema(object):
             parse_document_claims.document_uris_from_data.return_value)
 
     def test_it_calls_document_metas_from_data(self,
-                                               annotation,
                                                AnnotationSchema,
                                                parse_document_claims):
-        schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(),
-                                                annotation)
+        schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(), '')
         document_data = {'foo': 'bar'}
         target_uri = 'http://example.com/example'
         AnnotationSchema.return_value.validate.return_value['document'] = (
@@ -1204,7 +1169,6 @@ class TestUpdateAnnotationSchema(object):
 
     def test_it_passes_existing_target_uri_to_document_metas_from_data(
             self,
-            annotation,
             AnnotationSchema,
             parse_document_claims):
         """
@@ -1216,23 +1180,20 @@ class TestUpdateAnnotationSchema(object):
 
         """
         document_data = {'foo': 'bar'}
-        annotation.target_uri = 'http://example.com/existing_target_uri'
         AnnotationSchema.return_value.validate.return_value['document'] = (
             document_data)
         assert 'uri' not in AnnotationSchema.return_value.validate.return_value
         schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(),
-                                                annotation)
+                                                mock.sentinel.target_uri)
 
         schema.validate({})
 
         parse_document_claims.document_metas_from_data.assert_called_once_with(
             document_data,
-            claimant=annotation.target_uri,
-        )
+            claimant=mock.sentinel.target_uri)
 
     def test_it_does_not_pass_modified_dict_to_document_metas_from_data(
             self,
-            annotation,
             AnnotationSchema,
             parse_document_claims):
         """
@@ -1254,8 +1215,7 @@ class TestUpdateAnnotationSchema(object):
             document['sub_dict']['key'] = 'new_value'
         parse_document_claims.document_uris_from_data.side_effect = (
             document_uris_from_data)
-        schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(),
-                                                annotation)
+        schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(), '')
         AnnotationSchema.return_value.validate.return_value['document'] = (
             document)
 
@@ -1266,11 +1226,9 @@ class TestUpdateAnnotationSchema(object):
             document)
 
     def test_it_puts_document_metas_in_appstruct(self,
-                                                 annotation,
                                                  AnnotationSchema,
                                                  parse_document_claims):
-        schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(),
-                                                annotation)
+        schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(), '')
         AnnotationSchema.return_value.validate.return_value['document'] = {}
 
         appstruct = schema.validate({})
@@ -1279,7 +1237,6 @@ class TestUpdateAnnotationSchema(object):
             parse_document_claims.document_metas_from_data.return_value)
 
     def test_it_clears_existing_keys_from_document(self,
-                                                   annotation,
                                                    AnnotationSchema):
         """
         Any keys in the document dict should be removed.
@@ -1288,8 +1245,7 @@ class TestUpdateAnnotationSchema(object):
         'document_meta_dicts' keys.
 
         """
-        schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(),
-                                                annotation)
+        schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(), '')
         AnnotationSchema.return_value.validate.return_value['document'] = {
             'foo': 'bar'  # This should be deleted.
         }
@@ -1299,10 +1255,8 @@ class TestUpdateAnnotationSchema(object):
         assert 'foo' not in appstruct['document']
 
     def test_document_does_not_end_up_in_extra(self,
-                                               annotation,
                                                AnnotationSchema):
-        schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(),
-                                                annotation)
+        schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(), '')
         AnnotationSchema.return_value.validate.return_value['document'] = {
             'foo': 'bar'
         }
@@ -1312,17 +1266,50 @@ class TestUpdateAnnotationSchema(object):
         assert 'document' not in appstruct.get('extra', {})
 
     def test_it_does_not_crash_when_fields_are_missing(self,
-                                                       annotation,
                                                        AnnotationSchema):
         AnnotationSchema.return_value.validate.return_value = {}
-        schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(),
-                                                annotation)
+        schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(), '')
 
         appstruct = schema.validate({})
 
-    @pytest.fixture
-    def annotation(self):
-        return mock.Mock(groupid='foogroup')
+    def test_it_adds_extra_fields_into_the_extra_dict(self,
+                                                      AnnotationSchema):
+        AnnotationSchema.return_value.validate.return_value['foo'] = 'bar'
+        AnnotationSchema.return_value.validate.return_value['custom'] = 23
+        schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(), '')
+
+        appstruct = schema.validate({})
+
+        assert appstruct['extra'] == {'foo': 'bar', 'custom': 23}
+
+    def test_it_overwrites_extra_fields_in_the_extra_dict(self,
+                                                          AnnotationSchema):
+        AnnotationSchema.return_value.validate.return_value['foo'] = 'bar'
+        AnnotationSchema.return_value.validate.return_value['custom'] = 23
+        schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(), '')
+
+        appstruct = schema.validate({})
+
+        assert appstruct['extra'] == {'foo': 'bar', 'custom': 23}
+
+    def test_it_does_not_modify_extra_fields_that_are_not_sent(
+            self,
+            AnnotationSchema):
+        AnnotationSchema.return_value.validate.return_value['foo'] = 'bar'
+        schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(), '')
+
+        appstruct = schema.validate({})
+
+        assert 'custom' not in appstruct['extra']
+
+    def test_it_does_not_modify_extra_fields_if_none_are_sent(
+            self,
+            AnnotationSchema):
+        schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(), '')
+
+        appstruct = schema.validate({})
+
+        assert not appstruct.get('extra')
 
 
 def annotation_data(**kwargs):

--- a/h/api/test/schemas_test.py
+++ b/h/api/test/schemas_test.py
@@ -631,7 +631,7 @@ class TestCreateAnnotationSchema(object):
         assert appstruct['shared'] is True
         assert 'permissions' not in appstruct
 
-    def test_it_defaults_to_shared_if_no_permissions_object_sent(
+    def test_it_defaults_to_private_if_no_permissions_object_sent(
             self,
             AnnotationSchema):
         del AnnotationSchema.return_value.validate.return_value['permissions']
@@ -639,7 +639,7 @@ class TestCreateAnnotationSchema(object):
 
         appstruct = schema.validate({})
 
-        assert appstruct['shared'] is True
+        assert appstruct['shared'] is False
 
     def test_it_does_not_crash_if_data_contains_no_target(self):
         schema = schemas.CreateAnnotationSchema(testing.DummyRequest())

--- a/h/api/test/schemas_test.py
+++ b/h/api/test/schemas_test.py
@@ -1324,6 +1324,7 @@ class TestUpdateAnnotationSchema(object):
     def annotation(self):
         return mock.Mock(groupid='foogroup')
 
+
 def annotation_data(**kwargs):
     """Return test input data for AnnotationSchema.validate()."""
     data = {

--- a/h/api/test/schemas_test.py
+++ b/h/api/test/schemas_test.py
@@ -993,6 +993,52 @@ class TestUpdateAnnotationSchema(object):
             assert protected_field not in appstruct
             assert protected_field not in appstruct.get('extra', {})
 
+    def test_you_cannot_change_an_annotations_group(self,
+                                                    annotation,
+                                                    AnnotationSchema):
+        annotation.groupid = 'original-group'
+        AnnotationSchema.return_value.validate.return_value['groupid'] = (
+            'new-group')
+        AnnotationSchema.return_value.validate.return_value['group'] = (
+            'new-group')
+        schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(),
+                                                annotation)
+
+        appstruct = schema.validate({})
+
+        assert 'groupid' not in appstruct
+        assert 'groupid' not in appstruct.get('extra', {})
+        assert 'group' not in appstruct
+        assert 'group' not in appstruct.get('extra', {})
+
+    def test_you_cannot_change_an_annotations_userid(self,
+                                                     annotation,
+                                                     AnnotationSchema):
+        annotation.userid = 'original_userid'
+        AnnotationSchema.return_value.validate.return_value['userid'] = (
+            'new_userid')
+        schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(),
+                                                annotation)
+
+        appstruct = schema.validate({})
+
+        assert 'userid' not in appstruct
+        assert 'userid' not in appstruct.get('extra', {})
+
+    def test_you_cannot_change_an_annotations_references(self,
+                                                         annotation,
+                                                         AnnotationSchema):
+        annotation.references = ['original_parent']
+        AnnotationSchema.return_value.validate.return_value['references'] = [
+            'new_parent']
+        schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(),
+                                                annotation)
+
+        appstruct = schema.validate({})
+
+        assert 'references' not in appstruct
+        assert 'references' not in appstruct.get('extra', {})
+
     def test_it_renames_uri_to_target_uri(self, annotation, AnnotationSchema):
         schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(),
                                                 annotation)

--- a/h/api/test/schemas_test.py
+++ b/h/api/test/schemas_test.py
@@ -88,7 +88,7 @@ class TestAnnotationSchema(object):
                 },
             ],
             'text': 'foo',
-            'uri' : 'foo',
+            'uri': 'foo',
         })
 
     def test_it_raises_if_document_is_not_a_dict(self):
@@ -792,6 +792,7 @@ class TestCreateAnnotationSchema(object):
                 'key': 'original_value'
             }
         }
+
         def document_uris_from_data(document, claimant):
             document['new_key'] = 'new_value'
             document['top_level_key'] = 'new_value'
@@ -1209,6 +1210,7 @@ class TestUpdateAnnotationSchema(object):
                 'key': 'original_value'
             }
         }
+
         def document_uris_from_data(document, claimant):
             document['new_key'] = 'new_value'
             document['top_level_key'] = 'new_value'

--- a/h/api/test/schemas_test.py
+++ b/h/api/test/schemas_test.py
@@ -734,9 +734,10 @@ class TestCreateAnnotationSchema(object):
 
         assert appstruct['extra'] == {'foo': 1, 'bar': 2}
 
-    def test_it_calls_document_uris_from_data(self,
-                                              AnnotationSchema,
-                                              parse_document_claims):
+    def test_it_extracts_document_uris_from_the_document(
+            self,
+            AnnotationSchema,
+            parse_document_claims):
         document_data = {'foo': 'bar'}
         target_uri = 'http://example.com/example'
         AnnotationSchema.return_value.validate.return_value['document'] = (
@@ -759,9 +760,10 @@ class TestCreateAnnotationSchema(object):
         assert appstruct['document']['document_uri_dicts'] == (
             parse_document_claims.document_uris_from_data.return_value)
 
-    def test_it_calls_document_metas_from_data(self,
-                                               AnnotationSchema,
-                                               parse_document_claims):
+    def test_it_extracts_document_metas_from_the_document(
+            self,
+            AnnotationSchema,
+            parse_document_claims):
         schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
         document_data = {'foo': 'bar'}
         target_uri = 'http://example.com/example'
@@ -956,7 +958,7 @@ class TestLegacyUpdateAnnotationSchema(object):
 @pytest.mark.usefixtures('AnnotationSchema')
 class TestUpdateAnnotationSchema(object):
 
-    def test_it_calls_AnnotationSchema_validate(self):
+    def test_it_passes_input_to_AnnotationSchema_validate(self):
         schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(), '')
 
         schema.validate(mock.sentinel.input_data)
@@ -1099,9 +1101,10 @@ class TestUpdateAnnotationSchema(object):
 
         assert appstruct['tags'] == ['new']
 
-    def test_it_calls_document_uris_from_data(self,
-                                              AnnotationSchema,
-                                              parse_document_claims):
+    def test_it_extracts_document_uris_from_the_document(
+            self,
+            AnnotationSchema,
+            parse_document_claims):
         document_data = {'foo': 'bar'}
         target_uri = 'http://example.com/example'
         AnnotationSchema.return_value.validate.return_value['document'] = (
@@ -1152,9 +1155,10 @@ class TestUpdateAnnotationSchema(object):
         assert appstruct['document']['document_uri_dicts'] == (
             parse_document_claims.document_uris_from_data.return_value)
 
-    def test_it_calls_document_metas_from_data(self,
-                                               AnnotationSchema,
-                                               parse_document_claims):
+    def test_it_extracts_document_metas_from_the_document(
+            self,
+            AnnotationSchema,
+            parse_document_claims):
         schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(), '')
         document_data = {'foo': 'bar'}
         target_uri = 'http://example.com/example'

--- a/h/api/test/schemas_test.py
+++ b/h/api/test/schemas_test.py
@@ -407,9 +407,8 @@ class TestAnnotationSchema(object):
 
 class TestLegacyCreateAnnotationSchema(object):
 
-    def test_it_passes_input_to_structure_validator(self):
-        request = self.mock_request()
-        schema = schemas.LegacyCreateAnnotationSchema(request)
+    def test_it_passes_input_to_structure_validator(self, mock_request):
+        schema = schemas.LegacyCreateAnnotationSchema(mock_request)
         schema.structure = mock.Mock()
         schema.structure.validate.return_value = {}
 
@@ -417,9 +416,8 @@ class TestLegacyCreateAnnotationSchema(object):
 
         schema.structure.validate.assert_called_once_with({'foo': 'bar'})
 
-    def test_it_raises_if_structure_validator_raises(self):
-        request = self.mock_request()
-        schema = schemas.LegacyCreateAnnotationSchema(request)
+    def test_it_raises_if_structure_validator_raises(self, mock_request):
+        schema = schemas.LegacyCreateAnnotationSchema(mock_request)
         schema.structure = mock.Mock()
         schema.structure.validate.side_effect = (
             schemas.ValidationError('asplode'))
@@ -432,9 +430,8 @@ class TestLegacyCreateAnnotationSchema(object):
         'updated',
         'id',
     ])
-    def test_it_removes_protected_fields(self, field):
-        request = self.mock_request()
-        schema = schemas.LegacyCreateAnnotationSchema(request)
+    def test_it_removes_protected_fields(self, field, mock_request):
+        schema = schemas.LegacyCreateAnnotationSchema(mock_request)
         data = {}
         data[field] = 'something forbidden'
 
@@ -447,12 +444,11 @@ class TestLegacyCreateAnnotationSchema(object):
         {'user': None},
         {'user': 'acct:foo@bar.com'},
     ])
-    def test_it_ignores_input_user(self, data, authn_policy):
+    def test_it_ignores_input_user(self, data, authn_policy, mock_request):
         """Any user field sent in the payload should be ignored."""
         authn_policy.authenticated_userid.return_value = (
             'acct:jeanie@example.com')
-        request = self.mock_request()
-        schema = schemas.LegacyCreateAnnotationSchema(request)
+        schema = schemas.LegacyCreateAnnotationSchema(mock_request)
 
         appstruct = schema.validate(data)
 
@@ -475,7 +471,8 @@ class TestLegacyCreateAnnotationSchema(object):
                                                     data,
                                                     effective_principals,
                                                     ok,
-                                                    authn_policy):
+                                                    authn_policy,
+                                                    mock_request):
         """
         A user cannot create an annotation in a group they're not a member of.
 
@@ -484,8 +481,7 @@ class TestLegacyCreateAnnotationSchema(object):
         principals.
         """
         authn_policy.effective_principals.return_value = effective_principals
-        request = self.mock_request()
-        schema = schemas.LegacyCreateAnnotationSchema(request)
+        schema = schemas.LegacyCreateAnnotationSchema(mock_request)
 
         if ok:
             appstruct = schema.validate(data)
@@ -504,15 +500,15 @@ class TestLegacyCreateAnnotationSchema(object):
         {'numbers': 12345},
         {'null': None},
     ])
-    def test_it_permits_all_other_changes(self, data):
-        request = self.mock_request()
-        schema = schemas.LegacyCreateAnnotationSchema(request)
+    def test_it_permits_all_other_changes(self, data, mock_request):
+        schema = schemas.LegacyCreateAnnotationSchema(mock_request)
 
         appstruct = schema.validate(data)
 
         for k in data:
             assert appstruct[k] == data[k]
 
+    @pytest.fixture
     def mock_request(self):
         request = testing.DummyRequest()
         request.feature = mock.Mock(return_value=False,

--- a/h/api/test/schemas_test.py
+++ b/h/api/test/schemas_test.py
@@ -395,6 +395,7 @@ class TestAnnotationSchema(object):
         'updated',
         'user',
         'id',
+        'links',
     ])
     def test_it_removes_protected_fields(self, field):
         schema = schemas.AnnotationSchema()
@@ -429,6 +430,7 @@ class TestLegacyCreateAnnotationSchema(object):
         'created',
         'updated',
         'id',
+        'links',
     ])
     def test_it_removes_protected_fields(self, field, mock_request):
         schema = schemas.LegacyCreateAnnotationSchema(mock_request)
@@ -864,6 +866,7 @@ class TestLegacyUpdateAnnotationSchema(object):
         'updated',
         'user',
         'id',
+        'links',
     ])
     def test_it_removes_protected_fields(self, field):
         request = testing.DummyRequest()
@@ -972,7 +975,7 @@ class TestUpdateAnnotationSchema(object):
 
     def test_you_cannot_update_protected_fields(self,
                                                 AnnotationSchema):
-        for protected_field in ['created', 'updated', 'user', 'id']:
+        for protected_field in ['created', 'updated', 'user', 'id', 'links']:
             AnnotationSchema.return_value.validate\
                 .return_value[protected_field] = 'foo'
             schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(), '')

--- a/h/api/test/schemas_test.py
+++ b/h/api/test/schemas_test.py
@@ -91,304 +91,89 @@ class TestAnnotationSchema(object):
             'uri': 'foo',
         })
 
-    def test_it_raises_if_document_is_not_a_dict(self):
-        schema = schemas.AnnotationSchema()
+    @pytest.mark.parametrize("input_data,error_message", [
+        ({'document': False}, "document: False is not of type 'object'"),
 
-        with pytest.raises(schemas.ValidationError) as err:
-            schema.validate(self.valid_input_data(
-                document=False,
-            ))
+        ({'document': {'dc': False}},
+         "document.dc: False is not of type 'object'"),
 
-        assert str(err.value) == "document: False is not of type 'object'"
+        ({'document': {'dc': {'identifier': False}}},
+         "document.dc.identifier: False is not of type 'array'"),
 
-    def test_it_raises_if_document_dc_is_not_a_dict(self):
-        schema = schemas.AnnotationSchema()
+        ({'document': {'dc': {'identifier': [False]}}},
+         "document.dc.identifier.0: False is not of type 'string'"),
 
-        with pytest.raises(schemas.ValidationError) as err:
-            schema.validate(self.valid_input_data(
-                document={'dc': False}
-            ))
+        ({'document': {'highwire': False}},
+         "document.highwire: False is not of type 'object'"),
 
-        assert str(err.value) == "document.dc: False is not of type 'object'"
+        ({'document': {'highwire': {'doi': False}}},
+         "document.highwire.doi: False is not of type 'array'"),
 
-    def test_it_raises_if_document_dc_identifier_is_not_a_list(self):
-        schema = schemas.AnnotationSchema()
+        ({'document': {'highwire': {'doi': [False]}}},
+         "document.highwire.doi.0: False is not of type 'string'"),
 
-        with pytest.raises(schemas.ValidationError) as err:
-            schema.validate(self.valid_input_data(
-                document={'dc': {'identifier': False}}
-            ))
+        ({'document': {'link': False}},
+         "document.link: False is not of type 'array'"),
 
-        assert str(err.value) == (
-            "document.dc.identifier: False is not of type 'array'")
+        ({'document': {'link': [False]}},
+         "document.link.0: False is not of type 'object'"),
 
-    def test_it_raises_if_document_dc_identifier_item_is_not_a_string(self):
-        schema = schemas.AnnotationSchema()
+        ({'document': {'link': [{}]}},
+         "document.link.0: 'href' is a required property"),
 
-        with pytest.raises(schemas.ValidationError) as err:
-            schema.validate(self.valid_input_data(
-                document={'dc': {'identifier': [False]}}
-            ))
+        ({'document': {'link': [{'href': False}]}},
+         "document.link.0.href: False is not of type 'string'"),
 
-        assert str(err.value) == (
-            "document.dc.identifier.0: False is not of type 'string'")
-
-    def test_it_raises_if_document_highwire_is_not_a_dict(self):
-        schema = schemas.AnnotationSchema()
-
-        with pytest.raises(schemas.ValidationError) as err:
-            schema.validate(self.valid_input_data(
-                document={'highwire': False}
-            ))
-
-        assert str(err.value) == (
-            "document.highwire: False is not of type 'object'")
-
-    def test_it_raises_if_document_highwire_doi_is_not_a_list(self):
-        schema = schemas.AnnotationSchema()
-
-        with pytest.raises(schemas.ValidationError) as err:
-            schema.validate(self.valid_input_data(
-                document={'highwire': {'doi': False}}
-            ))
-
-        assert str(err.value) == (
-            "document.highwire.doi: False is not of type 'array'")
-
-    def test_it_raises_if_document_highwire_doi_item_is_not_a_string(self):
-        schema = schemas.AnnotationSchema()
-
-        with pytest.raises(schemas.ValidationError) as err:
-            schema.validate(self.valid_input_data(
-                document={'highwire': {'doi': [False]}}
-            ))
-
-        assert str(err.value) == (
-            "document.highwire.doi.0: False is not of type 'string'")
-
-    def test_it_raises_if_document_link_is_not_a_list(self):
-        schema = schemas.AnnotationSchema()
-
-        with pytest.raises(schemas.ValidationError) as err:
-            schema.validate(self.valid_input_data(
-                document={'link': False}
-            ))
-
-        assert str(err.value) == "document.link: False is not of type 'array'"
-
-    def test_it_raises_if_document_link_item_is_not_a_dict(self):
-        schema = schemas.AnnotationSchema()
-
-        with pytest.raises(schemas.ValidationError) as err:
-            schema.validate(self.valid_input_data(
-                document={'link': [False]}
-            ))
-
-        assert str(err.value) == (
-            "document.link.0: False is not of type 'object'")
-
-    def test_it_raises_if_document_link_item_has_no_href(self):
-        schema = schemas.AnnotationSchema()
-
-        with pytest.raises(schemas.ValidationError) as err:
-            schema.validate(self.valid_input_data(
-                document={'link': [{}]}
-            ))
-
-        assert str(err.value) == (
-            "document.link.0: 'href' is a required property")
-
-    def test_it_raises_if_document_link_item_href_is_not_a_string(self):
-        schema = schemas.AnnotationSchema()
-
-        with pytest.raises(schemas.ValidationError) as err:
-            schema.validate(self.valid_input_data(
-                document={'link': [{'href': False}]}
-            ))
-
-        assert str(err.value) == (
-            "document.link.0.href: False is not of type 'string'")
-
-    def test_it_raises_if_document_link_item_type_is_not_a_string(self):
-        schema = schemas.AnnotationSchema()
-
-        with pytest.raises(schemas.ValidationError) as err:
-            schema.validate(self.valid_input_data(
-                document={
-                    'link': [
-                        {
-                            'href': 'http://example.com',
-                            'type': False
-                        }
-                    ]
+        ({'document': {
+            'link': [
+                {
+                    'href': 'http://example.com',
+                    'type': False
                 }
-            ))
+            ]
+        }}, "document.link.0.type: False is not of type 'string'"),
 
-        assert str(err.value) == (
-            "document.link.0.type: False is not of type 'string'")
+        ({'group': False}, "group: False is not of type 'string'"),
 
-    def test_it_raises_if_group_is_not_a_string(self):
+        ({'permissions': False}, "permissions: False is not of type 'object'"),
+
+        ({'permissions': {}}, "permissions: 'read' is a required property"),
+
+        ({'permissions': {'read': False}},
+         "permissions.read: False is not of type 'array'"),
+
+        ({'permissions': {'read': [False]}},
+         "permissions.read.0: False is not of type 'string'"),
+
+        ({'permissions': {'read': ["foo"]}},
+         "permissions.read.0: u'foo' does not match '^(acct:|group:).+$'"),
+
+        ({'references': False}, "references: False is not of type 'array'"),
+
+        ({'references': [False]},
+         "references.0: False is not of type 'string'"),
+
+        ({'tags': False}, "tags: False is not of type 'array'"),
+
+        ({'tags': [False]}, "tags.0: False is not of type 'string'"),
+
+        ({'target': False}, "target: False is not of type 'array'"),
+
+        ({'target': [False]}, "target.0: False is not of type 'object'"),
+
+        ({'target': [{}]}, "target.0: 'selector' is a required property"),
+
+        ({'text': False}, "text: False is not of type 'string'"),
+
+        ({'uri': False}, "uri: False is not of type 'string'"),
+    ])
+    def test_it_raises_for_invalid_data(self, input_data, error_message):
         schema = schemas.AnnotationSchema()
 
         with pytest.raises(schemas.ValidationError) as err:
-            schema.validate(self.valid_input_data(
-                group=False
-            ))
+            schema.validate(self.valid_input_data(**input_data))
 
-        assert str(err.value) == "group: False is not of type 'string'"
-
-    def test_it_raises_if_permissions_is_not_a_dict(self):
-        schema = schemas.AnnotationSchema()
-
-        with pytest.raises(schemas.ValidationError) as err:
-            schema.validate(self.valid_input_data(
-                permissions=False
-            ))
-
-        assert str(err.value) == "permissions: False is not of type 'object'"
-
-    def test_it_raises_if_permissions_has_no_read(self):
-        schema = schemas.AnnotationSchema()
-
-        with pytest.raises(schemas.ValidationError) as err:
-            schema.validate(self.valid_input_data(
-                permissions={}
-            ))
-
-        assert str(err.value) == "permissions: 'read' is a required property"
-
-    def test_it_raises_if_permissions_read_is_not_a_list(self):
-        schema = schemas.AnnotationSchema()
-
-        with pytest.raises(schemas.ValidationError) as err:
-            schema.validate(self.valid_input_data(
-                permissions={'read': False}
-            ))
-
-        assert str(err.value) == (
-            "permissions.read: False is not of type 'array'")
-
-    def test_it_raises_if_permissions_read_item_is_not_a_string(self):
-        schema = schemas.AnnotationSchema()
-
-        with pytest.raises(schemas.ValidationError) as err:
-            schema.validate(self.valid_input_data(
-                permissions={'read': [False]}
-            ))
-
-        assert str(err.value) == (
-            "permissions.read.0: False is not of type 'string'")
-
-    def test_it_raises_if_permissions_read_item_is_wrong_format(self):
-        schema = schemas.AnnotationSchema()
-
-        with pytest.raises(schemas.ValidationError) as err:
-            schema.validate(self.valid_input_data(
-                permissions={'read': ["foo"]}
-            ))
-
-        assert str(err.value) == (
-            "permissions.read.0: u'foo' does not match '^(acct:|group:).+$'")
-
-    def test_it_raises_if_references_is_not_a_list(self):
-        schema = schemas.AnnotationSchema()
-
-        with pytest.raises(schemas.ValidationError) as err:
-            schema.validate(self.valid_input_data(
-                references=False
-            ))
-
-        assert str(err.value) == "references: False is not of type 'array'"
-
-    def test_it_raises_if_references_item_is_not_a_string(self):
-        schema = schemas.AnnotationSchema()
-
-        with pytest.raises(schemas.ValidationError) as err:
-            schema.validate(self.valid_input_data(
-                references=[False]
-            ))
-
-        assert str(err.value) == "references.0: False is not of type 'string'"
-
-    def test_it_raises_if_tags_is_not_a_list(self):
-        schema = schemas.AnnotationSchema()
-
-        with pytest.raises(schemas.ValidationError) as err:
-            schema.validate(self.valid_input_data(
-                tags=False
-            ))
-
-        assert str(err.value) == "tags: False is not of type 'array'"
-
-    def test_it_raises_if_tags_item_is_not_a_string(self):
-        schema = schemas.AnnotationSchema()
-
-        with pytest.raises(schemas.ValidationError) as err:
-            schema.validate(self.valid_input_data(
-                tags=[False]
-            ))
-
-        assert str(err.value) == "tags.0: False is not of type 'string'"
-
-    def test_it_raises_if_target_is_not_a_list(self):
-        schema = schemas.AnnotationSchema()
-
-        with pytest.raises(schemas.ValidationError) as err:
-            schema.validate(self.valid_input_data(
-                target=False
-            ))
-
-        assert str(err.value) == "target: False is not of type 'array'"
-
-    def test_it_raises_if_target_item_is_not_a_dict(self):
-        schema = schemas.AnnotationSchema()
-
-        with pytest.raises(schemas.ValidationError) as err:
-            schema.validate(self.valid_input_data(
-                target=[False]
-            ))
-
-        assert str(err.value) == "target.0: False is not of type 'object'"
-
-    def test_it_raises_if_target_has_no_selector(self):
-        schema = schemas.AnnotationSchema()
-
-        with pytest.raises(schemas.ValidationError) as err:
-            schema.validate(self.valid_input_data(
-                target=[{}]
-            ))
-
-        assert str(err.value) == "target.0: 'selector' is a required property"
-
-    def test_it_raises_if_text_is_not_a_string(self):
-        schema = schemas.AnnotationSchema()
-
-        with pytest.raises(schemas.ValidationError) as err:
-            schema.validate(self.valid_input_data(
-                text=False
-            ))
-
-        assert str(err.value) == "text: False is not of type 'string'"
-
-    def test_it_raises_if_uri_is_not_a_string(self):
-        schema = schemas.AnnotationSchema()
-
-        with pytest.raises(schemas.ValidationError) as err:
-            schema.validate(self.valid_input_data(
-                uri=False
-            ))
-
-        assert str(err.value) == "uri: False is not of type 'string'"
-
-    def valid_input_data(self, **kwargs):
-        """Return a minimal valid input data for AnnotationSchema."""
-        data = {
-            'permissions': {
-                'read': [],
-            },
-        }
-        data.update(kwargs)
-        return data
+        assert str(err.value) == error_message
 
     @pytest.mark.parametrize('field', [
         'created',
@@ -411,6 +196,16 @@ class TestAnnotationSchema(object):
             'permissions': {
                 'read': []
             }
+        }
+        data.update(kwargs)
+        return data
+
+    def valid_input_data(self, **kwargs):
+        """Return a minimal valid input data for AnnotationSchema."""
+        data = {
+            'permissions': {
+                'read': [],
+            },
         }
         data.update(kwargs)
         return data

--- a/h/api/test/schemas_test.py
+++ b/h/api/test/schemas_test.py
@@ -401,9 +401,19 @@ class TestAnnotationSchema(object):
         schema = schemas.AnnotationSchema()
 
         appstruct = schema.validate(
-            annotation_data(field='something forbidden'))
+            self.annotation_data(field='something forbidden'))
 
         assert field not in appstruct
+
+    def annotation_data(self, **kwargs):
+        """Return test input data for AnnotationSchema.validate()."""
+        data = {
+            'permissions': {
+                'read': []
+            }
+        }
+        data.update(kwargs)
+        return data
 
 
 class TestLegacyCreateAnnotationSchema(object):
@@ -543,7 +553,7 @@ class TestCreateAnnotationSchema(object):
             'acct:harriet@example.com')
         schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
 
-        appstruct = schema.validate(annotation_data())
+        appstruct = schema.validate({})
 
         assert appstruct['userid'] == 'acct:harriet@example.com'
 
@@ -557,13 +567,12 @@ class TestCreateAnnotationSchema(object):
         assert appstruct['target_uri'] == 'http://example.com/example'
         assert 'uri' not in appstruct
 
-    def test_it_inserts_empty_string_if_data_has_no_uri(self):
+    def test_it_inserts_empty_string_if_data_has_no_uri(self,
+                                                        AnnotationSchema):
         schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
+        assert 'uri' not in AnnotationSchema.return_value.validate.return_value
 
-        data = annotation_data()
-        assert 'uri' not in data
-
-        assert schema.validate(data)['target_uri'] == ''
+        assert schema.validate({})['target_uri'] == ''
 
     def test_it_keeps_text(self, AnnotationSchema):
         schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
@@ -574,13 +583,13 @@ class TestCreateAnnotationSchema(object):
 
         assert appstruct['text'] == 'some annotation text'
 
-    def test_it_inserts_empty_string_if_data_contains_no_text(self):
+    def test_it_inserts_empty_string_if_data_contains_no_text(
+            self,
+            AnnotationSchema):
         schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
+        assert 'text' not in AnnotationSchema.return_value.validate.return_value
 
-        data = annotation_data()
-        assert 'text' not in data
-
-        assert schema.validate(data)['text'] == ''
+        assert schema.validate({})['text'] == ''
 
     def test_it_keeps_tags(self, AnnotationSchema):
         schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
@@ -591,13 +600,12 @@ class TestCreateAnnotationSchema(object):
 
         assert appstruct['tags'] == ['foo', 'bar']
 
-    def test_it_inserts_empty_list_if_data_contains_no_tags(self):
+    def test_it_inserts_empty_list_if_data_contains_no_tags(self,
+                                                            AnnotationSchema):
         schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
+        assert 'tags' not in AnnotationSchema.return_value.validate.return_value
 
-        data = annotation_data()
-        assert 'tags' not in data
-
-        assert schema.validate(data)['tags'] == []
+        assert schema.validate({})['tags'] == []
 
     def test_it_replaces_private_permissions_with_shared_False(
             self,
@@ -636,13 +644,12 @@ class TestCreateAnnotationSchema(object):
 
         assert appstruct['shared'] is False
 
-    def test_it_does_not_crash_if_data_contains_no_target(self):
+    def test_it_does_not_crash_if_data_contains_no_target(self,
+                                                          AnnotationSchema):
         schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
+        assert 'target' not in AnnotationSchema.return_value.validate.return_value
 
-        data = annotation_data()
-        assert 'target' not in data
-
-        schema.validate(data)
+        schema.validate({})
 
     def test_it_replaces_target_with_target_selectors(self, AnnotationSchema):
         schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
@@ -810,12 +817,12 @@ class TestCreateAnnotationSchema(object):
     def test_it_puts_document_metas_in_appstruct(self, parse_document_claims):
         schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
 
-        appstruct = schema.validate(annotation_data())
+        appstruct = schema.validate({})
 
         assert appstruct['document']['document_meta_dicts'] == (
             parse_document_claims.document_metas_from_data.return_value)
 
-    def test_it_clears_existing_keys_from_document(self):
+    def test_it_clears_existing_keys_from_document(self, AnnotationSchema):
         """
         Any keys in the document dict should be removed.
 
@@ -824,14 +831,11 @@ class TestCreateAnnotationSchema(object):
 
         """
         schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
+        AnnotationSchema.return_value.validate.return_value['document'] = {
+            'foo': 'bar'  # This should be deleted.
+        }
 
-        appstruct = schema.validate(
-            annotation_data(
-                document={
-                    'foo': 'bar'  # This should be deleted.
-                },
-            ),
-        )
+        appstruct = schema.validate({})
 
         assert 'foo' not in appstruct['document']
 
@@ -1314,17 +1318,6 @@ class TestUpdateAnnotationSchema(object):
         appstruct = schema.validate({})
 
         assert not appstruct.get('extra')
-
-
-def annotation_data(**kwargs):
-    """Return test input data for AnnotationSchema.validate()."""
-    data = {
-        'permissions': {
-            'read': []
-        }
-    }
-    data.update(kwargs)
-    return data
 
 
 @pytest.fixture

--- a/h/api/test/schemas_test.py
+++ b/h/api/test/schemas_test.py
@@ -519,8 +519,7 @@ class TestLegacyCreateAnnotationSchema(object):
 @pytest.mark.usefixtures('AnnotationSchema')
 class TestCreateAnnotationSchema(object):
 
-    def test_it_passes_input_to_AnnotationSchema_validator(self,
-                                                           AnnotationSchema):
+    def test_it_passes_input_to_AnnotationSchema_validator(self):
         schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
 
         schema.validate(mock.sentinel.input_data)
@@ -954,8 +953,7 @@ class TestLegacyUpdateAnnotationSchema(object):
 @pytest.mark.usefixtures('AnnotationSchema')
 class TestUpdateAnnotationSchema(object):
 
-    def test_it_calls_AnnotationSchema_validate(self,
-                                                AnnotationSchema):
+    def test_it_calls_AnnotationSchema_validate(self):
         schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(), '')
 
         schema.validate(mock.sentinel.input_data)
@@ -1272,7 +1270,7 @@ class TestUpdateAnnotationSchema(object):
         AnnotationSchema.return_value.validate.return_value = {}
         schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(), '')
 
-        appstruct = schema.validate({})
+        schema.validate({})
 
     def test_it_adds_extra_fields_into_the_extra_dict(self,
                                                       AnnotationSchema):

--- a/h/api/test/schemas_test.py
+++ b/h/api/test/schemas_test.py
@@ -409,9 +409,10 @@ class TestAnnotationSchema(object):
     def test_it_removes_protected_fields(self, field):
         schema = schemas.AnnotationSchema()
 
-        result = schema.validate(annotation_data(field='something forbidden'))
+        appstruct = schema.validate(
+            annotation_data(field='something forbidden'))
 
-        assert field not in result
+        assert field not in appstruct
 
 
 class TestLegacyCreateAnnotationSchema(object):
@@ -555,19 +556,19 @@ class TestCreateAnnotationSchema(object):
             'acct:harriet@example.com')
         schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
 
-        result = schema.validate(annotation_data())
+        appstruct = schema.validate(annotation_data())
 
-        assert result['userid'] == 'acct:harriet@example.com'
+        assert appstruct['userid'] == 'acct:harriet@example.com'
 
     def test_it_renames_uri_to_target_uri(self, AnnotationSchema):
         schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
         AnnotationSchema.return_value.validate.return_value['uri'] = (
             'http://example.com/example')
 
-        result = schema.validate({})
+        appstruct = schema.validate({})
 
-        assert result['target_uri'] == 'http://example.com/example'
-        assert 'uri' not in result
+        assert appstruct['target_uri'] == 'http://example.com/example'
+        assert 'uri' not in appstruct
 
     def test_it_inserts_empty_string_if_data_has_no_uri(self):
         schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
@@ -582,9 +583,9 @@ class TestCreateAnnotationSchema(object):
         AnnotationSchema.return_value.validate.return_value['text'] = (
             'some annotation text')
 
-        result = schema.validate({})
+        appstruct = schema.validate({})
 
-        assert result['text'] == 'some annotation text'
+        assert appstruct['text'] == 'some annotation text'
 
     def test_it_inserts_empty_string_if_data_contains_no_text(self):
         schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
@@ -599,9 +600,9 @@ class TestCreateAnnotationSchema(object):
         AnnotationSchema.return_value.validate.return_value['tags'] = [
             'foo', 'bar']
 
-        result = schema.validate({})
+        appstruct = schema.validate({})
 
-        assert result['tags'] == ['foo', 'bar']
+        assert appstruct['tags'] == ['foo', 'bar']
 
     def test_it_inserts_empty_list_if_data_contains_no_tags(self):
         schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
@@ -622,10 +623,10 @@ class TestCreateAnnotationSchema(object):
             'acct:harriet@example.com')
         schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
 
-        result = schema.validate({})
+        appstruct = schema.validate({})
 
-        assert result['shared'] is False
-        assert 'permissions' not in result
+        assert appstruct['shared'] is False
+        assert 'permissions' not in appstruct
 
     def test_it_replaces_shared_permissions_with_shared_True(
             self,
@@ -634,14 +635,14 @@ class TestCreateAnnotationSchema(object):
             'acct:harriet@example.com')
         schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
 
-        result = schema.validate(
+        appstruct = schema.validate(
             annotation_data(
                 permissions={'read': ['group:__world__']},
             ),
         )
 
-        assert result['shared'] is True
-        assert 'permissions' not in result
+        assert appstruct['shared'] is True
+        assert 'permissions' not in appstruct
 
     def test_it_does_not_crash_if_data_contains_no_target(self):
         schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
@@ -661,44 +662,44 @@ class TestCreateAnnotationSchema(object):
             'this should be removed',
         ]
 
-        result = schema.validate({})
+        appstruct = schema.validate({})
 
-        assert result['target_selectors'] == 'the selectors'
+        assert appstruct['target_selectors'] == 'the selectors'
 
     def test_it_renames_group_to_groupid(self, AnnotationSchema):
         schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
         AnnotationSchema.return_value.validate.return_value['group'] = 'foo'
 
-        result = schema.validate({})
+        appstruct = schema.validate({})
 
-        assert result['groupid'] == 'foo'
-        assert 'group' not in result
+        assert appstruct['groupid'] == 'foo'
+        assert 'group' not in appstruct
 
     def test_it_inserts_default_groupid_if_no_group(self, AnnotationSchema):
         schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
         del AnnotationSchema.return_value.validate.return_value['group']
 
-        result = schema.validate({})
+        appstruct = schema.validate({})
 
-        assert result['groupid'] == '__world__'
+        assert appstruct['groupid'] == '__world__'
 
     def test_it_keeps_references(self, AnnotationSchema):
         schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
         AnnotationSchema.return_value.validate.return_value['references'] = [
             'parent id', 'parent id 2']
 
-        result = schema.validate({})
+        appstruct = schema.validate({})
 
-        assert result['references'] == ['parent id', 'parent id 2']
+        assert appstruct['references'] == ['parent id', 'parent id 2']
 
     def test_it_inserts_empty_list_if_no_references(self, AnnotationSchema):
         schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
         assert 'references' not in AnnotationSchema.return_value.validate\
             .return_value
 
-        result = schema.validate({})
+        appstruct = schema.validate({})
 
-        assert result['references'] == []
+        assert appstruct['references'] == []
 
     def test_it_deletes_groupid_for_replies(self, AnnotationSchema):
         schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
@@ -706,9 +707,9 @@ class TestCreateAnnotationSchema(object):
         AnnotationSchema.return_value.validate.return_value['references'] = [
             'parent annotation id']
 
-        result = schema.validate({})
+        appstruct = schema.validate({})
 
-        assert 'groupid' not in result
+        assert 'groupid' not in appstruct
 
     def test_it_moves_extra_data_into_extra_sub_dict(self, AnnotationSchema):
         schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
@@ -732,9 +733,9 @@ class TestCreateAnnotationSchema(object):
             'bar': 2,
         }
 
-        result = schema.validate({})
+        appstruct = schema.validate({})
 
-        assert result['extra'] == {'foo': 1, 'bar': 2}
+        assert appstruct['extra'] == {'foo': 1, 'bar': 2}
 
     def test_it_calls_document_uris_from_data(self,
                                               AnnotationSchema,
@@ -875,9 +876,9 @@ class TestLegacyUpdateAnnotationSchema(object):
         data = {}
         data[field] = 'something forbidden'
 
-        result = schema.validate(data)
+        appstruct = schema.validate(data)
 
-        assert field not in result
+        assert field not in appstruct
 
     def test_it_allows_permissions_changes_if_admin(self, authn_policy):
         """If a user is an admin on an annotation, they can change perms."""
@@ -892,9 +893,9 @@ class TestLegacyUpdateAnnotationSchema(object):
             'permissions': {'admin': ['acct:foo@example.com']}
         }
 
-        result = schema.validate(data)
+        appstruct = schema.validate(data)
 
-        assert result == data
+        assert appstruct == data
 
     @pytest.mark.parametrize('annotation', [
         {},
@@ -947,10 +948,10 @@ class TestLegacyUpdateAnnotationSchema(object):
         annotation = {'group': 'flibble'}
         schema = schemas.LegacyUpdateAnnotationSchema(request, annotation)
 
-        result = schema.validate(data)
+        appstruct = schema.validate(data)
 
         for k in data:
-            assert result[k] == data[k]
+            assert appstruct[k] == data[k]
 
 
 @pytest.mark.usefixtures('AnnotationSchema')

--- a/h/api/test/schemas_test.py
+++ b/h/api/test/schemas_test.py
@@ -237,16 +237,6 @@ class TestAnnotationSchema(object):
 
         assert str(err.value) == "group: False is not of type 'string'"
 
-    def test_it_raises_if_permissions_is_missing(self):
-        schema = schemas.AnnotationSchema()
-        data = self.valid_input_data()
-        del data['permissions']
-
-        with pytest.raises(schemas.ValidationError) as err:
-            schema.validate(data)
-
-        assert str(err.value) == "'permissions' is a required property"
-
     def test_it_raises_if_permissions_is_not_a_dict(self):
         schema = schemas.AnnotationSchema()
 
@@ -643,6 +633,16 @@ class TestCreateAnnotationSchema(object):
 
         assert appstruct['shared'] is True
         assert 'permissions' not in appstruct
+
+    def test_it_defaults_to_shared_if_no_permissions_object_sent(
+            self,
+            AnnotationSchema):
+        del AnnotationSchema.return_value.validate.return_value['permissions']
+        schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
+
+        appstruct = schema.validate({})
+
+        assert appstruct['shared'] is True
 
     def test_it_does_not_crash_if_data_contains_no_target(self):
         schema = schemas.CreateAnnotationSchema(testing.DummyRequest())


### PR DESCRIPTION
A few changes to `h.api.schemas` related to updating annotations in Postgres:

- Do partial updates in the same way the legacy Es schemas/storage do https://github.com/hypothesis/h/pull/3280/commits/0d58f63a3f58c6d5364859acc5d3ab3bd2de4375
- Don't allow changing group or references in update, handle this in schemas so storage doesn't worry about it https://github.com/hypothesis/h/pull/3280/commits/caa4d5e4bb41a67b07d662420890f5082fb7c508
- Make permissions optional https://github.com/hypothesis/h/pull/3280/commits/127263a2c97ab7f1d2d91fa8bf517a685f55f2a8
- As well as some pep8 and lint, some bug fixes, and some changes previously requested and made on https://github.com/hypothesis/h/pull/3256

So this is a bit of a grab-bag. I could try to split this up into yet smaller PRs but hopefully this is small enough if reviewed commit by commit.