### PR TITLE
Fix SyntaxError exception when injecting sidebar

### DIFF
--- a/h/browser/chrome/lib/sidebar-injector.js
+++ b/h/browser/chrome/lib/sidebar-injector.js
@@ -23,6 +23,7 @@ function addJSONScriptTagFn(name, content) {
   var scriptTag = document.createElement('script');
   scriptTag.className = name;
   scriptTag.textContent = content;
+  scriptTag.type = 'application/json';
   document.head.appendChild(scriptTag);
 }
 
@@ -325,7 +326,7 @@ function SidebarInjector(chromeTabs, dependencies) {
     var configCode =
       'var hypothesisConfig = "' + configStr + '";\n' +
       '(' + addJSONScriptTagFn.toString() + ')' +
-      '("js-hypothesis-config", hypothesisConfig)';
+      '("js-hypothesis-config", hypothesisConfig);\n';
     return executeScriptFn(tabId, {code: configCode});
   }
 }


### PR DESCRIPTION
Fix an exception when injecting the sidebar caused by not setting the
`type` property on the <script> tag that contains the sidebar's JSON
config data.

This resulted in the browser trying to execute the JSON data as a JS
script. Injection still worked because the rest of the code still ran
and was able to read the JSON data from the script tag via the
textContent accessor.