### PR TITLE
Move EventQueue into h.api and sandbox event notifies

### DIFF
--- a/h/api/__init__.py
+++ b/h/api/__init__.py
@@ -3,6 +3,7 @@
 
 def includeme(config):
     config.include('h.api.db')
+    config.include('h.api.eventqueue')
     config.include('h.api.presenters')
     config.include('h.api.search')
     config.include('h.api.views')

--- a/h/api/eventqueue.py
+++ b/h/api/eventqueue.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+
+import collections
+
+
+class EventQueue(object):
+    def __init__(self, request):
+        self.request = request
+        self.queue = collections.deque()
+
+        request.add_response_callback(self.response_callback)
+
+    def __call__(self, event):
+        self.queue.append(event)
+
+    def publish_all(self):
+        while True:
+            try:
+                event = self.queue.popleft()
+            except IndexError:
+                break
+            self.request.registry.notify(event)
+
+    def response_callback(self, request, response):
+        if request.exception is not None:
+            return
+
+        with request.tm:
+            self.publish_all()
+
+
+def includeme(config):
+    config.add_request_method(EventQueue,
+                              name='notify_after_commit',
+                              reify=True)

--- a/h/api/test/eventqueue_test.py
+++ b/h/api/test/eventqueue_test.py
@@ -5,18 +5,18 @@ import pytest
 
 from pyramid.testing import DummyRequest
 
-from h import app
+from h.api import eventqueue
 
 
 class TestEventQueue(object):
     def test_init_adds_response_callback(self):
         request = mock.Mock()
-        queue = app.EventQueue(request)
+        queue = eventqueue.EventQueue(request)
 
         request.add_response_callback.assert_called_once_with(queue.response_callback)
 
     def test_call_appends_event_to_queue(self):
-        queue = app.EventQueue(mock.Mock())
+        queue = eventqueue.EventQueue(mock.Mock())
 
         assert len(queue.queue) == 0
         event = mock.Mock()
@@ -26,7 +26,7 @@ class TestEventQueue(object):
     def test_publish_all_notifies_events_in_fifo_order(self):
         request = DummyRequest()
         request.registry.notify = mock.Mock(spec=lambda event: None)
-        queue = app.EventQueue(request)
+        queue = eventqueue.EventQueue(request)
         firstevent = mock.Mock()
         queue(firstevent)
         secondevent = mock.Mock()
@@ -41,17 +41,17 @@ class TestEventQueue(object):
 
     def test_response_callback_skips_publishing_events_on_exception(self, publish_all):
         request = DummyRequest(exception=ValueError('exploded!'))
-        queue = app.EventQueue(request)
+        queue = eventqueue.EventQueue(request)
         queue.response_callback(request, None)
         assert not publish_all.called
 
     def test_response_callback_publishes_events(self, publish_all):
         request = DummyRequest(exception=None, tm=mock.MagicMock())
-        queue = app.EventQueue(request)
+        queue = eventqueue.EventQueue(request)
         queue(mock.Mock())
         queue.response_callback(request, None)
         assert publish_all.called
 
     @pytest.fixture
     def publish_all(self, patch):
-        return patch('h.app.EventQueue.publish_all')
+        return patch('h.api.eventqueue.EventQueue.publish_all')

--- a/h/api/test/eventqueue_test.py
+++ b/h/api/test/eventqueue_test.py
@@ -9,7 +9,7 @@ from h.api import eventqueue
 
 
 class TestEventQueue(object):
-    def test_init_adds_response_callback(self):
+    def test_init_adds_response_callback(self, mock_request):
         request = mock.Mock()
         queue = eventqueue.EventQueue(request)
 
@@ -23,21 +23,53 @@ class TestEventQueue(object):
         queue(event)
         assert list(queue.queue) == [event]
 
-    def test_publish_all_notifies_events_in_fifo_order(self):
-        request = DummyRequest()
-        request.registry.notify = mock.Mock(spec=lambda event: None)
-        queue = eventqueue.EventQueue(request)
-        firstevent = mock.Mock()
+    def test_publish_all_notifies_events_in_fifo_order(self, mock_request):
+        queue = eventqueue.EventQueue(mock_request)
+        firstevent = mock.Mock(request=mock_request)
         queue(firstevent)
-        secondevent = mock.Mock()
+        secondevent = mock.Mock(request=mock_request)
         queue(secondevent)
 
         queue.publish_all()
 
-        assert request.registry.notify.call_args_list == [
+        assert mock_request.registry.notify.call_args_list == [
             mock.call(firstevent),
             mock.call(secondevent)
         ]
+
+    def test_publish_all_sanboxes_each_event(self, mock_request):
+        queue = eventqueue.EventQueue(mock_request)
+        firstevent = mock.Mock(request=mock_request)
+        queue(firstevent)
+        secondevent = mock.Mock(request=mock_request)
+        queue(secondevent)
+
+        queue.publish_all()
+
+        assert mock_request.registry.notify.call_args_list == [
+            mock.call(firstevent),
+            mock.call(secondevent)
+        ]
+
+    def test_publish_all_sends_exception_to_sentry(self, mock_request):
+        mock_request.sentry = mock.Mock()
+        mock_request.registry.notify.side_effect = ValueError('exploded!')
+        queue = eventqueue.EventQueue(mock_request)
+        event = mock.Mock(request=mock_request)
+        queue(event)
+
+        queue.publish_all()
+        assert mock_request.sentry.captureException.called
+
+    def test_publish_all_logs_exception_when_sentry_is_not_available(self, mock_request, log):
+        mock_request.registry.notify.side_effect = ValueError('exploded!')
+        queue = eventqueue.EventQueue(mock_request)
+        event = mock.Mock(request=mock_request)
+        queue(event)
+
+        queue.publish_all()
+
+        assert log.exception.called
 
     def test_response_callback_skips_publishing_events_on_exception(self, publish_all):
         request = DummyRequest(exception=ValueError('exploded!'))
@@ -51,6 +83,16 @@ class TestEventQueue(object):
         queue(mock.Mock())
         queue.response_callback(request, None)
         assert publish_all.called
+
+    @pytest.fixture
+    def mock_request(self):
+        request = DummyRequest(debug=False)
+        request.registry.notify = mock.Mock()
+        return request
+
+    @pytest.fixture
+    def log(self, patch):
+        return patch('h.api.eventqueue.log')
 
     @pytest.fixture
     def publish_all(self, patch):


### PR DESCRIPTION
Currently we only use the `request.notify_after_commit()` in `h.api`, although I can see this being used in other circumstances as well, but to not add other h dependencies to `h.api` I'm moving the class into its own `h.api.eventqueue` module.

The second commit makes sure that each notifying each event will be sandboxed, we catch the exception and log it either to Sentry or the exception logger. It is worth noting that if one event has multiple subscribers, these will not be sandboxes, only different events.