### PR TITLE
Call toggleHighlightClass on crossframe message

### DIFF
--- a/h/static/scripts/annotator/guest.coffee
+++ b/h/static/scripts/annotator/guest.coffee
@@ -46,7 +46,6 @@ module.exports = class Guest extends Annotator
 
   constructor: (element, options) ->
     super
-
     this.adderCtrl = new adder.Adder(@adder[0])
     this.anchors = []
 
@@ -118,7 +117,7 @@ module.exports = class Guest extends Annotator
       .catch((reason) -> cb(reason))
 
     crossframe.on 'setVisibleHighlights', (state) =>
-      this.setVisibleHighlights(state)
+      this.toggleHighlightClass(state)
 
   _setupWrapper: ->
     @wrapper = @element


### PR DESCRIPTION
Calling `setVisibleHighlights` cause an infinite loop, as it would send the crossframe message again.

Not sure if `this.publish 'setVisibleHighlights', shouldShowHighlights` needs to be called in the guest when `toggleHighlightClass` is called.

Fixes: https://github.com/hypothesis/h/issues/2829