### PR TITLE
Support PDFs in Firefox WebExtension and add clarifying comments about Chrome PDF detection

### DIFF
--- a/h/browser/chrome/lib/detect-content-type.js
+++ b/h/browser/chrome/lib/detect-content-type.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * Returns the type of content in the current document,
  * currently either 'PDF' or 'HTML'.
@@ -10,19 +12,48 @@
  * of content in embedded viewers where that differs from the tab's
  * main URL.
  */
-function detectContentType() {
-  // check if this is the Chrome PDF viewer
-  var chromePDFPluginSelector =
-    'embed[type="application/pdf"][name="plugin"]';
-  if (document.querySelector(chromePDFPluginSelector)) {
-    return {
-      type: 'PDF',
-    };
-  } else {
-    return {
-      type: 'HTML',
-    };
+function detectContentType(document_) {
+  document_ = document_ || document;
+
+  function detectChromePDFViewer() {
+    // When viewing a PDF in Chrome, the viewer consists of a top-level
+    // document with an <embed> tag, which in turn instantiates an inner HTML
+    // document providing the PDF viewer UI plus another <embed> tag which
+    // instantiates the native PDF renderer.
+    //
+    // The selector below matches the <embed> tag in the top-level document. To
+    // see this document, open the inspector on a PDF viewer tab with
+    // Ctrl+Shift+I rather than right-clicking on the viewport and selecting the
+    // 'Inspect' option which will instead show the _inner_ document.
+    if (!!document_.querySelector('embed[type="application/pdf"][name="plugin"]')) {
+      return {type: 'PDF'};
+    }
   }
+
+  function detectFirefoxPDFViewer() {
+    // The Firefox PDF viewer is an instance of PDF.js.
+    //
+    // The Firefox PDF plugin specifically can be detected via the <base>
+    // tag it includes, which can be done from a content script (which runs
+    // in an isolated JS world from the page's own scripts).
+    //
+    // Generic PDF.js detection can be done by looking for the
+    // `window.PDFViewerApplication` object. This however requires running JS
+    // code in the same JS context as the page's own code.
+    if (document_.baseURI.indexOf('resource://pdf.js') === 0) {
+      return {type: 'PDF'};
+    }
+  }
+
+  var detectFns = [detectChromePDFViewer, detectFirefoxPDFViewer];
+  for (var i = 0; i < detectFns.length; i++) {
+    var typeInfo = detectFns[i]();
+    if (typeInfo) {
+      return typeInfo;
+    }
+  }
+
+  return {type: 'HTML'};
 }
 
 module.exports = detectContentType;

--- a/h/browser/chrome/test/detect-content-type-test.js
+++ b/h/browser/chrome/test/detect-content-type-test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var detectContentType = require('../lib/detect-content-type');
 
 describe('detectContentType()', function () {
@@ -16,9 +18,16 @@ describe('detectContentType()', function () {
     assert.deepEqual(detectContentType(), { type: 'HTML' } );
   });
 
-  it('returns "PDF" if the Chrome PDF plugin is present', function () {
-    el.innerHTML =
-     '<embed name="plugin" type="application/pdf"></embed>';
+  it('returns "PDF" if Google Chrome PDF viewer is present', function () {
+    el.innerHTML = '<embed name="plugin" type="application/pdf"></embed>';
     assert.deepEqual(detectContentType(), { type: 'PDF' });
+  });
+
+  it('returns "PDF" if Firefox PDF viewer is present', function () {
+    var fakeDocument = {
+      querySelector: function () { return null; },
+      baseURI: 'resource://pdf.js',
+    };
+    assert.deepEqual(detectContentType(fakeDocument), { type: 'PDF' });
   });
 });


### PR DESCRIPTION
This adds support for detecting the PDF.js-based viewer in the Firefox
extension and loading the Hypothesis PDF viewer instead, as we do in the Chrome extension.

After getting thoroughly confused investigating an issue with the Chrome PDF viewer, I added some comments about how the Chrome viewer works as a reference for future. See https://github.com/hypothesis/h/issues/3293 for context.