### PR TITLE
Allow the creation of explicit cohorts for feature flags

### DIFF
--- a/h/migrations/versions/3bcd62dd7260_add_cohort_table.py
+++ b/h/migrations/versions/3bcd62dd7260_add_cohort_table.py
@@ -1,0 +1,35 @@
+"""add cohort table
+
+Revision ID: 3bcd62dd7260
+Revises: dfa82518915a
+Create Date: 2016-05-10 17:01:02.704596
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '3bcd62dd7260'
+down_revision = 'dfa82518915a'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.create_table('cohort',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('name', sa.Unicode(length=100), nullable=False),
+        sa.Column('created', sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.Column('updated', sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_table('user_cohort',
+        sa.Column('user_id', sa.Integer(), nullable=False),
+        sa.Column('cohort_id', sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(['cohort_id'], ['cohort.id']),
+        sa.ForeignKeyConstraint(['user_id'], ['user.id'])
+    )
+
+
+def downgrade():
+    op.drop_table('user_cohort')
+    op.drop_table('cohort')


### PR DESCRIPTION
This PR is meant to keep track of the work done on the card:
https://trello.com/c/qn2cteEe/332-allow-the-creation-of-explicit-cohorts-for-feature-flags

The rough plan for this piece of work is as follows:
- [x] Add the `FeatureCohort` model in `h.features` (see PR #3309)
- [x] Database migration to create `featurecohort` and `featurecohort_user` tables (see PR #3317)
- [ ] Admin panel to create/delete cohorts (see PR #3344, #3330)
- [ ] Admin panel to edit cohorts (add/remove users)
- [ ] Link cohort list items to each respective edit cohort page.
- [ ] Add logic to `h.features.client` to handle feature cohorts (validation in `Client._state` method).
