### PR TITLE
Simplify and split up CLI package

### DIFF
--- a/docs/administration.rst
+++ b/docs/administration.rst
@@ -6,13 +6,13 @@ permissions. To grant admin permissions to a user, run the following command:
 
 .. code-block:: bash
 
-  hypothesis admin <config_uri> <username>
+  hypothesis admin <username>
 
-For example, to make someone an admin in the development environment:
+For example, to make the user 'joe' an admin in the development environment:
 
 .. code-block:: bash
 
-  hypothesis admin conf/development-app.ini usernamehere
+  hypothesis --dev admin joe
 
 When this user signs in they can now access the adminstration panel at
 ``/admin``. The administration panel has options for managing users and optional

--- a/h/cli/commands/admin.py
+++ b/h/cli/commands/admin.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+
+import click
+
+from h import accounts
+
+
+@click.command()
+@click.argument('username')
+@click.pass_context
+def admin(ctx, username):
+    """
+    Make a user an admin.
+
+    You must specify the username of a user which you wish to give
+    administrative privileges.
+    """
+    request = ctx.obj['bootstrap']()
+    accounts.make_admin(username)
+    request.tm.commit()

--- a/h/cli/commands/initdb.py
+++ b/h/cli/commands/initdb.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+
+import os
+
+import click
+
+
+@click.command()
+@click.pass_context
+def initdb(ctx):
+    """Create database tables and elasticsearch indices."""
+    # Force model creation using the MODEL_CREATE_ALL env var
+    os.environ['MODEL_CREATE_ALL'] = 'True'
+
+    # Start the application, triggering model creation
+    bootstrap = ctx.obj['bootstrap']
+    bootstrap()

--- a/h/cli/commands/reindex.py
+++ b/h/cli/commands/reindex.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+
+import click
+import elasticsearch.helpers
+
+from h.api.search import config
+
+
+@click.command()
+@click.option('-u', '--update-alias/--no-update-alias',
+              help='Whether to update the current index alias on completion.')
+@click.argument('target')
+@click.pass_context
+def reindex(ctx, target, update_alias):
+    """
+    Reindex the annotations into a new Elasticsearch index.
+
+    You must specify the name of a target index. Annotations will be indexed
+    from the current configured index into this target index name. If
+    `--update-alias` is specified, this command will assume that the current
+    configured index is an alias and when the reindex is completed will attempt
+    to update it to point to `target`.
+    """
+    request = ctx.obj['bootstrap']()
+
+    # Configure the new index
+    config.configure_index(request.legacy_es, target)
+
+    # Reindex the annotations
+    elasticsearch.helpers.reindex(client=request.legacy_es.conn,
+                                  source_index=request.legacy_es.index,
+                                  target_index=target)
+
+    if update_alias:
+        request.legacy_es.conn.indices.update_aliases(body={'actions': [
+            # Remove all existing aliases
+            {"remove": {"index": "*", "alias": request.legacy_es.index}},
+            # Alias current index name to new target
+            {"add": {"index": target, "alias": request.legacy_es.index}},
+        ]})

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ INSTALL_REQUIRES = [
     'annotator>=0.14.2,<0.15',
     'blinker>=1.3,<1.4',
     'celery>=3.1.23,<3.2',
+    'click>=6.6,<7.0',
     'cryptacular>=1.4,<1.5',
     'cryptography>=0.7',
     'deform>=0.9,<1.0',


### PR DESCRIPTION
In preparation for adding some new commands to make local development more straightforward, this commit splits the `h.cli` package up so each subcommand is defined in its own module. It also makes the following breaking changes:

- The `annotool` command is removed. It was broken anyway, and we're very soon going to have an entirely different way of making updates to the annotation data, through normal alembic data migrations.

- The `token` command is removed. This was primarily useful before we had normal user API tokens.

- The `version` command is removed: use `hypothesis --version` instead.

- All other commands no longer accept a config file path as an argument. Instead, the `hypothesis` command has a top-level `--dev` flag which switches the behaviour of subcommands into a mode suitable for local development.

This set of changes is implemented using the `click` third-party library, which is (to my knowledge) the easiest way to build command-line applications which support nested subcommands.