### PR TITLE
Do not test annotation schema

### DIFF
--- a/h/api/test/schemas_test.py
+++ b/h/api/test/schemas_test.py
@@ -39,19 +39,34 @@ class TestJSONSchema(object):
         assert message.startswith("123 is not of type 'string'")
 
 
-class TestAnnotationSchema(object):
+def create_annotation_schema_validate(data):
+    schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
+    return schema.validate(data)
 
-    def test_it_does_not_raise_for_minimal_valid_data(self):
-        schema = schemas.AnnotationSchema()
 
-        # Use only the required fields.
-        schema.validate(self.valid_input_data())
+def update_annotation_schema_validate(data,
+                                      existing_target_uri='',
+                                      groupid=''):
+    schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(),
+                                            existing_target_uri,
+                                            groupid)
+    return schema.validate(data)
 
-    def test_it_does_not_raise_for_full_valid_data(self):
-        schema = schemas.AnnotationSchema()
 
+@pytest.mark.parametrize('validate', [
+    create_annotation_schema_validate,
+    update_annotation_schema_validate,
+])
+class TestCreateUpdateAnnotationSchema(object):
+
+    """Shared tests for CreateAnnotationSchema and UpdateAnnotationSchema."""
+
+    def test_it_does_not_raise_for_minimal_valid_data(self, validate):
+        validate(self.valid_input_data())
+
+    def test_it_does_not_raise_for_full_valid_data(self, validate):
         # Use all the keys to make sure that valid data for all of them passes.
-        schema.validate({
+        validate({
             'document': {
                 'dc': {
                     'identifier': ['foo', 'bar']
@@ -167,11 +182,12 @@ class TestAnnotationSchema(object):
 
         ({'uri': False}, "uri: False is not of type 'string'"),
     ])
-    def test_it_raises_for_invalid_data(self, input_data, error_message):
-        schema = schemas.AnnotationSchema()
-
+    def test_it_raises_for_invalid_data(self,
+                                        validate,
+                                        input_data,
+                                        error_message):
         with pytest.raises(schemas.ValidationError) as err:
-            schema.validate(self.valid_input_data(**input_data))
+            validate(self.valid_input_data(**input_data))
 
         assert str(err.value) == error_message
 
@@ -182,10 +198,8 @@ class TestAnnotationSchema(object):
         'id',
         'links',
     ])
-    def test_it_removes_protected_fields(self, field):
-        schema = schemas.AnnotationSchema()
-
-        appstruct = schema.validate(
+    def test_it_removes_protected_fields(self, validate, field):
+        appstruct = validate(
             self.valid_input_data(field='something forbidden'))
 
         assert field not in appstruct
@@ -313,25 +327,7 @@ class TestLegacyCreateAnnotationSchema(object):
         return request
 
 
-@pytest.mark.usefixtures('AnnotationSchema')
 class TestCreateAnnotationSchema(object):
-
-    def test_it_passes_input_to_AnnotationSchema_validator(self):
-        schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
-
-        schema.validate(mock.sentinel.input_data)
-
-        schema.structure.validate.assert_called_once_with(
-            mock.sentinel.input_data)
-
-    def test_it_raises_if_AnnotationSchema_validate_raises(self,
-                                                           AnnotationSchema):
-        AnnotationSchema.return_value.validate.side_effect = (
-            schemas.ValidationError('asplode'))
-        schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
-
-        with pytest.raises(schemas.ValidationError):
-            schema.validate({'foo': 'bar'})
 
     def test_it_sets_userid(self, authn_policy):
         authn_policy.authenticated_userid.return_value = (
@@ -342,103 +338,88 @@ class TestCreateAnnotationSchema(object):
 
         assert appstruct['userid'] == 'acct:harriet@example.com'
 
-    def test_it_renames_uri_to_target_uri(self, AnnotationSchema):
+    def test_it_renames_uri_to_target_uri(self, input_data):
         schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
-        AnnotationSchema.return_value.validate.return_value['uri'] = (
-            'http://example.com/example')
+        input_data['uri'] = 'http://example.com/example'
 
-        appstruct = schema.validate({})
+        appstruct = schema.validate(input_data)
 
         assert appstruct['target_uri'] == 'http://example.com/example'
         assert 'uri' not in appstruct
 
-    def test_it_inserts_empty_string_if_data_has_no_uri(self,
-                                                        AnnotationSchema):
+    def test_it_inserts_empty_string_if_data_has_no_uri(self, input_data):
         schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
-        assert 'uri' not in AnnotationSchema.return_value.validate.return_value
+        assert 'uri' not in input_data
 
-        assert schema.validate({})['target_uri'] == ''
+        assert schema.validate(input_data)['target_uri'] == ''
 
-    def test_it_keeps_text(self, AnnotationSchema):
+    def test_it_keeps_text(self, input_data):
         schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
-        AnnotationSchema.return_value.validate.return_value['text'] = (
-            'some annotation text')
+        input_data['text'] = 'some annotation text'
 
-        appstruct = schema.validate({})
+        appstruct = schema.validate(input_data)
 
         assert appstruct['text'] == 'some annotation text'
 
-    def test_it_inserts_empty_string_if_data_contains_no_text(
-            self,
-            AnnotationSchema):
+    def test_it_inserts_empty_string_if_data_contains_no_text(self,
+                                                              input_data):
         schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
-        assert 'text' not in AnnotationSchema.return_value.validate.return_value
+        assert 'text' not in input_data
 
-        assert schema.validate({})['text'] == ''
+        assert schema.validate(input_data)['text'] == ''
 
-    def test_it_keeps_tags(self, AnnotationSchema):
+    def test_it_keeps_tags(self, input_data):
         schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
-        AnnotationSchema.return_value.validate.return_value['tags'] = [
-            'foo', 'bar']
+        input_data['tags'] = ['foo', 'bar']
 
-        appstruct = schema.validate({})
+        appstruct = schema.validate(input_data)
 
         assert appstruct['tags'] == ['foo', 'bar']
 
-    def test_it_inserts_empty_list_if_data_contains_no_tags(self,
-                                                            AnnotationSchema):
+    def test_it_inserts_empty_list_if_data_contains_no_tags(self, input_data):
         schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
-        assert 'tags' not in AnnotationSchema.return_value.validate.return_value
+        assert 'tags' not in input_data
 
-        assert schema.validate({})['tags'] == []
+        assert schema.validate(input_data)['tags'] == []
 
-    def test_it_replaces_private_permissions_with_shared_False(
-            self,
-            AnnotationSchema):
-        AnnotationSchema.return_value.validate.return_value['permissions'] = {
-            'read': ['acct:harriet@example.com'],
-        }
+    def test_it_replaces_private_permissions_with_shared_False(self,
+                                                               input_data):
+        input_data['permissions'] = {'read': ['acct:harriet@example.com']}
         schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
 
-        appstruct = schema.validate({})
+        appstruct = schema.validate(input_data)
 
         assert appstruct['shared'] is False
         assert 'permissions' not in appstruct
 
-    def test_it_replaces_shared_permissions_with_shared_True(self,
-                                                             AnnotationSchema):
-        AnnotationSchema.return_value.validate.return_value['permissions'] = {
-            'read': ['group:__world__'],
-        }
-        AnnotationSchema.return_value.validate.return_value['group'] = (
-            '__world__')
+    def test_it_replaces_shared_permissions_with_shared_True(self, input_data):
+        input_data['permissions'] = {'read': ['group:__world__']}
+        input_data['group'] = '__world__'
         schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
 
-        appstruct = schema.validate({})
+        appstruct = schema.validate(input_data)
 
         assert appstruct['shared'] is True
         assert 'permissions' not in appstruct
 
-    def test_it_defaults_to_private_if_no_permissions_object_sent(
-            self,
-            AnnotationSchema):
-        del AnnotationSchema.return_value.validate.return_value['permissions']
+    def test_it_defaults_to_private_if_no_permissions_object_sent(self,
+                                                                  input_data):
+        del input_data['permissions']
         schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
 
-        appstruct = schema.validate({})
+        appstruct = schema.validate(input_data)
 
         assert appstruct['shared'] is False
 
-    def test_it_does_not_crash_if_data_contains_no_target(self,
-                                                          AnnotationSchema):
+    def test_it_does_not_crash_if_data_contains_no_target(self, input_data):
         schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
-        assert 'target' not in AnnotationSchema.return_value.validate.return_value
+        assert 'target' not in input_data
 
-        schema.validate({})
+        schema.validate(input_data)
 
-    def test_it_replaces_target_with_target_selectors(self, AnnotationSchema):
+    def test_it_replaces_target_with_target_selectors(self, input_data):
         schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
-        AnnotationSchema.return_value.validate.return_value['target'] = [
+        input_data['target'] = [
             {
                 'foo': 'bar',  # This should be removed,
                 'selector': 'the selectors',
@@ -446,58 +427,55 @@ class TestCreateAnnotationSchema(object):
             'this should be removed',
         ]
 
-        appstruct = schema.validate({})
+        appstruct = schema.validate(input_data)
 
         assert appstruct['target_selectors'] == 'the selectors'
 
-    def test_it_renames_group_to_groupid(self, AnnotationSchema):
+    def test_it_renames_group_to_groupid(self, input_data):
         schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
-        AnnotationSchema.return_value.validate.return_value['group'] = 'foo'
+        input_data['group'] = 'foo'
 
-        appstruct = schema.validate({})
+        appstruct = schema.validate(input_data)
 
         assert appstruct['groupid'] == 'foo'
         assert 'group' not in appstruct
 
-    def test_it_inserts_default_groupid_if_no_group(self, AnnotationSchema):
+    def test_it_inserts_default_groupid_if_no_group(self, input_data):
         schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
-        del AnnotationSchema.return_value.validate.return_value['group']
+        del input_data['group']
 
-        appstruct = schema.validate({})
+        appstruct = schema.validate(input_data)
 
         assert appstruct['groupid'] == '__world__'
 
-    def test_it_keeps_references(self, AnnotationSchema):
+    def test_it_keeps_references(self, input_data):
         schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
-        AnnotationSchema.return_value.validate.return_value['references'] = [
-            'parent id', 'parent id 2']
+        input_data['references'] = ['parent id', 'parent id 2']
 
-        appstruct = schema.validate({})
+        appstruct = schema.validate(input_data)
 
         assert appstruct['references'] == ['parent id', 'parent id 2']
 
-    def test_it_inserts_empty_list_if_no_references(self, AnnotationSchema):
+    def test_it_inserts_empty_list_if_no_references(self, input_data):
         schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
-        assert 'references' not in AnnotationSchema.return_value.validate\
-            .return_value
+        assert 'references' not in input_data
 
-        appstruct = schema.validate({})
+        appstruct = schema.validate(input_data)
 
         assert appstruct['references'] == []
 
-    def test_it_deletes_groupid_for_replies(self, AnnotationSchema):
+    def test_it_deletes_groupid_for_replies(self, input_data):
         schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
-        AnnotationSchema.return_value.validate.return_value['group'] = 'foo'
-        AnnotationSchema.return_value.validate.return_value['references'] = [
-            'parent annotation id']
+        input_data['group'] = 'foo'
+        input_data['references'] = ['parent annotation id']
 
-        appstruct = schema.validate({})
+        appstruct = schema.validate(input_data)
 
         assert 'groupid' not in appstruct
 
-    def test_it_moves_extra_data_into_extra_sub_dict(self, AnnotationSchema):
+    def test_it_moves_extra_data_into_extra_sub_dict(self, input_data):
         schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
-        AnnotationSchema.return_value.validate.return_value = {
+        input_data = {
             # Throw in all the fields, just to make sure that none of them get
             # into extra.
             'created': 'created',
@@ -517,22 +495,20 @@ class TestCreateAnnotationSchema(object):
             'bar': 2,
         }
 
-        appstruct = schema.validate({})
+        appstruct = schema.validate(input_data)
 
         assert appstruct['extra'] == {'foo': 1, 'bar': 2}
 
     def test_it_extracts_document_uris_from_the_document(
             self,
-            AnnotationSchema,
+            input_data,
             parse_document_claims):
-        document_data = {'foo': 'bar'}
         target_uri = 'http://example.com/example'
-        AnnotationSchema.return_value.validate.return_value['document'] = (
-            document_data)
-        AnnotationSchema.return_value.validate.return_value['uri'] = target_uri
+        document_data = input_data['document'] = {'foo': 'bar'}
+        input_data['uri'] = target_uri
         schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
 
-        schema.validate({})
+        schema.validate(input_data)
 
         parse_document_claims.document_uris_from_data.assert_called_once_with(
             document_data,
@@ -549,16 +525,15 @@ class TestCreateAnnotationSchema(object):
 
     def test_it_extracts_document_metas_from_the_document(
             self,
-            AnnotationSchema,
+            input_data,
             parse_document_claims):
         schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
         document_data = {'foo': 'bar'}
         target_uri = 'http://example.com/example'
-        AnnotationSchema.return_value.validate.return_value['document'] = {
-            'foo': 'bar'}
-        AnnotationSchema.return_value.validate.return_value['uri'] = target_uri
+        input_data['document'] = {'foo': 'bar'}
+        input_data['uri'] = target_uri
 
-        schema.validate({})
+        schema.validate(input_data)
 
         parse_document_claims.document_metas_from_data.assert_called_once_with(
             document_data,
@@ -567,7 +542,7 @@ class TestCreateAnnotationSchema(object):
 
     def test_it_does_not_pass_modified_dict_to_document_metas_from_data(
             self,
-            AnnotationSchema,
+            input_data,
             parse_document_claims):
         """
 
@@ -590,10 +565,9 @@ class TestCreateAnnotationSchema(object):
         parse_document_claims.document_uris_from_data.side_effect = (
             document_uris_from_data)
         schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
-        AnnotationSchema.return_value.validate.return_value['document'] = (
-            document)
+        input_data['document'] = document
 
-        schema.validate({})
+        schema.validate(input_data)
 
         assert (
             parse_document_claims.document_metas_from_data.call_args[0][0] ==
@@ -607,7 +581,7 @@ class TestCreateAnnotationSchema(object):
         assert appstruct['document']['document_meta_dicts'] == (
             parse_document_claims.document_metas_from_data.return_value)
 
-    def test_it_clears_existing_keys_from_document(self, AnnotationSchema):
+    def test_it_clears_existing_keys_from_document(self, input_data):
         """
         Any keys in the document dict should be removed.
 
@@ -616,13 +590,24 @@ class TestCreateAnnotationSchema(object):
 
         """
         schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
-        AnnotationSchema.return_value.validate.return_value['document'] = {
+        input_data['document'] = {
             'foo': 'bar'  # This should be deleted.
         }
 
-        appstruct = schema.validate({})
+        appstruct = schema.validate(input_data)
 
         assert 'foo' not in appstruct['document']
+
+    @pytest.fixture
+    def input_data(self):
+        return {
+            'permissions': {
+                'read': ['group:__world__'],
+                'update': ['acct:testuser@hypothes.is'],
+                'delete': ['acct:testuser@hypothes.is'],
+            },
+            'group': '__world__',
+        }
 
 
 class TestLegacyUpdateAnnotationSchema(object):
@@ -739,121 +724,86 @@ class TestLegacyUpdateAnnotationSchema(object):
             assert appstruct[k] == data[k]
 
 
-@pytest.mark.usefixtures('AnnotationSchema')
 class TestUpdateAnnotationSchema(object):
 
-    def test_it_passes_input_to_AnnotationSchema_validate(self):
-        schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(), '', '')
-
-        schema.validate(mock.sentinel.input_data)
-
-        schema.structure.validate.assert_called_once_with(
-            mock.sentinel.input_data)
-
-    def test_it_raises_if_AnnotationSchema_validate_raises(self,
-                                                           AnnotationSchema):
-        AnnotationSchema.return_value.validate.side_effect = (
-            schemas.ValidationError('asplode'))
-        schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(), '', '')
-
-        with pytest.raises(schemas.ValidationError):
-            schema.validate({})
-
-    def test_you_cannot_update_protected_fields(self,
-                                                AnnotationSchema):
+    def test_you_cannot_update_protected_fields(self, input_data):
         for protected_field in ['created', 'updated', 'user', 'id', 'links']:
-            AnnotationSchema.return_value.validate\
-                .return_value[protected_field] = 'foo'
+            input_data[protected_field] = 'foo'
             schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(),
                                                     '',
                                                     '')
 
-            appstruct = schema.validate({})
+            appstruct = schema.validate(input_data)
 
             assert protected_field not in appstruct
             assert protected_field not in appstruct.get('extra', {})
 
-    def test_you_cannot_change_an_annotations_group(self,
-                                                    AnnotationSchema):
-        AnnotationSchema.return_value.validate.return_value['groupid'] = (
-            'new-group')
-        AnnotationSchema.return_value.validate.return_value['group'] = (
-            'new-group')
+    def test_you_cannot_change_an_annotations_group(self, input_data):
+        input_data['groupid'] = 'new-group'
+        input_data['group'] = 'new-group'
         schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(), '', '')
 
-        appstruct = schema.validate({})
+        appstruct = schema.validate(input_data)
 
         assert 'groupid' not in appstruct
         assert 'groupid' not in appstruct.get('extra', {})
         assert 'group' not in appstruct
         assert 'group' not in appstruct.get('extra', {})
 
-    def test_you_cannot_change_an_annotations_userid(self,
-                                                     AnnotationSchema):
-        AnnotationSchema.return_value.validate.return_value['userid'] = (
-            'new_userid')
+    def test_you_cannot_change_an_annotations_userid(self, input_data):
+        input_data['userid'] = 'new_userid'
         schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(), '', '')
 
-        appstruct = schema.validate({})
+        appstruct = schema.validate(input_data)
 
         assert 'userid' not in appstruct
         assert 'userid' not in appstruct.get('extra', {})
 
-    def test_you_cannot_change_an_annotations_references(self,
-                                                         AnnotationSchema):
-        AnnotationSchema.return_value.validate.return_value['references'] = [
-            'new_parent']
+    def test_you_cannot_change_an_annotations_references(self, input_data):
+        input_data['references'] = ['new_parent']
         schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(), '', '')
 
-        appstruct = schema.validate({})
+        appstruct = schema.validate(input_data)
 
         assert 'references' not in appstruct
         assert 'references' not in appstruct.get('extra', {})
 
-    def test_it_renames_uri_to_target_uri(self, AnnotationSchema):
+    def test_it_renames_uri_to_target_uri(self, input_data):
         schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(), '', '')
-        AnnotationSchema.return_value.validate.return_value['uri'] = (
-            'http://example.com/example')
+        input_data['uri'] = 'http://example.com/example'
 
-        appstruct = schema.validate({})
+        appstruct = schema.validate(input_data)
 
         assert appstruct['target_uri'] == 'http://example.com/example'
         assert 'uri' not in appstruct
         assert 'uri' not in appstruct.get('extras', {})
 
-    def test_it_replaces_private_permissions_with_shared_False(
-            self,
-            AnnotationSchema):
-        AnnotationSchema.return_value.validate.return_value['permissions'] = {
-            'read': ['acct:harriet@example.com'],
-        }
+    def test_it_replaces_private_permissions_with_shared_False(self,
+                                                               input_data):
+        input_data['permissions'] = {'read': ['acct:harriet@example.com']}
         schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(), '', '')
 
-        appstruct = schema.validate({})
+        appstruct = schema.validate(input_data)
 
         assert appstruct['shared'] is False
         assert 'permissions' not in appstruct
         assert 'permissions' not in appstruct.get('extras', {})
 
-    def test_it_replaces_shared_permissions_with_shared_True(self,
-                                                             AnnotationSchema):
-        AnnotationSchema.return_value.validate.return_value['permissions'] = {
-            'read': ['group:__world__'],
-        }
+    def test_it_replaces_shared_permissions_with_shared_True(self, input_data):
+        input_data['permissions'] = {'read': ['group:__world__']}
         schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(),
                                                 '',
                                                 '__world__')
 
-        appstruct = schema.validate({})
+        appstruct = schema.validate(input_data)
 
         assert appstruct['shared'] is True
         assert 'permissions' not in appstruct
         assert 'permissions' not in appstruct.get('extras', {})
 
-    def test_it_converts_target_to_target_selectors(self,
-                                                    AnnotationSchema):
+    def test_it_converts_target_to_target_selectors(self, input_data):
         schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(), '', '')
-        AnnotationSchema.return_value.validate.return_value['target'] = [
+        input_data['target'] = [
             {
                 'foo': 'bar',  # This should be removed,
                 'selector': 'the selectors',
@@ -861,40 +811,39 @@ class TestUpdateAnnotationSchema(object):
             'this should be removed',
         ]
 
-        appstruct = schema.validate({})
+        appstruct = schema.validate(input_data)
 
         assert appstruct['target_selectors'] == 'the selectors'
         assert 'target' not in appstruct
         assert 'target' not in appstruct.get('extras', {})
 
-    def test_you_can_update_text(self, AnnotationSchema):
+    def test_you_can_update_text(self, input_data):
         schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(), '', '')
-        AnnotationSchema.return_value.validate.return_value['text'] = 'new'
+        input_data['text'] = 'new'
 
-        appstruct = schema.validate({})
+        appstruct = schema.validate(input_data)
 
         assert appstruct['text'] == 'new'
 
-    def test_you_can_update_tags(self, AnnotationSchema):
+    def test_you_can_update_tags(self, input_data):
         schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(), '', '')
-        AnnotationSchema.return_value.validate.return_value['tags'] = ['new']
+        input_data['tags'] = ['new']
 
-        appstruct = schema.validate({})
+        appstruct = schema.validate(input_data)
 
         assert appstruct['tags'] == ['new']
 
     def test_it_extracts_document_uris_from_the_document(
             self,
-            AnnotationSchema,
+            input_data,
             parse_document_claims):
         document_data = {'foo': 'bar'}
         target_uri = 'http://example.com/example'
-        AnnotationSchema.return_value.validate.return_value['document'] = (
-            document_data)
-        AnnotationSchema.return_value.validate.return_value['uri'] = target_uri
+        input_data['document'] = document_data
+        input_data['uri'] = target_uri
         schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(), '', '')
 
-        schema.validate({})
+        schema.validate(input_data)
 
         parse_document_claims.document_uris_from_data.assert_called_once_with(
             document_data,
@@ -903,7 +852,7 @@ class TestUpdateAnnotationSchema(object):
 
     def test_it_passes_existing_target_uri_to_document_uris_from_data(
             self,
-            AnnotationSchema,
+            input_data,
             parse_document_claims):
         """
         If no 'uri' is given it should use the existing target_uri.
@@ -914,42 +863,40 @@ class TestUpdateAnnotationSchema(object):
 
         """
         document_data = {'foo': 'bar'}
-        AnnotationSchema.return_value.validate.return_value['document'] = (
-            document_data)
-        assert 'uri' not in AnnotationSchema.return_value.validate.return_value
+        input_data['document'] = document_data
+        assert 'uri' not in input_data
         schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(),
                                                 mock.sentinel.target_uri,
                                                 '')
 
-        schema.validate({})
+        schema.validate(input_data)
 
         parse_document_claims.document_uris_from_data.assert_called_once_with(
             document_data,
             claimant=mock.sentinel.target_uri)
 
     def test_it_puts_document_uris_in_appstruct(self,
-                                                AnnotationSchema,
+                                                input_data,
                                                 parse_document_claims):
-        AnnotationSchema.return_value.validate.return_value['document'] = {}
+        input_data['document'] = {}
         schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(), '', '')
 
-        appstruct = schema.validate({})
+        appstruct = schema.validate(input_data)
 
         assert appstruct['document']['document_uri_dicts'] == (
             parse_document_claims.document_uris_from_data.return_value)
 
     def test_it_extracts_document_metas_from_the_document(
             self,
-            AnnotationSchema,
+            input_data,
             parse_document_claims):
         schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(), '', '')
         document_data = {'foo': 'bar'}
         target_uri = 'http://example.com/example'
-        AnnotationSchema.return_value.validate.return_value['document'] = (
-            document_data)
-        AnnotationSchema.return_value.validate.return_value['uri'] = target_uri
+        input_data['document'] = document_data
+        input_data['uri'] = target_uri
 
-        schema.validate({})
+        schema.validate(input_data)
 
         parse_document_claims.document_metas_from_data.assert_called_once_with(
             document_data,
@@ -958,7 +905,7 @@ class TestUpdateAnnotationSchema(object):
 
     def test_it_passes_existing_target_uri_to_document_metas_from_data(
             self,
-            AnnotationSchema,
+            input_data,
             parse_document_claims):
         """
         If no 'uri' is given it should use the existing target_uri.
@@ -969,14 +916,13 @@ class TestUpdateAnnotationSchema(object):
 
         """
         document_data = {'foo': 'bar'}
-        AnnotationSchema.return_value.validate.return_value['document'] = (
-            document_data)
-        assert 'uri' not in AnnotationSchema.return_value.validate.return_value
+        input_data['document'] = document_data
+        assert 'uri' not in input_data
         schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(),
                                                 mock.sentinel.target_uri,
                                                 '')
 
-        schema.validate({})
+        schema.validate(input_data)
 
         parse_document_claims.document_metas_from_data.assert_called_once_with(
             document_data,
@@ -984,7 +930,7 @@ class TestUpdateAnnotationSchema(object):
 
     def test_it_does_not_pass_modified_dict_to_document_metas_from_data(
             self,
-            AnnotationSchema,
+            input_data,
             parse_document_claims):
         """
 
@@ -1007,28 +953,26 @@ class TestUpdateAnnotationSchema(object):
         parse_document_claims.document_uris_from_data.side_effect = (
             document_uris_from_data)
         schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(), '', '')
-        AnnotationSchema.return_value.validate.return_value['document'] = (
-            document)
+        input_data['document'] = document
 
-        schema.validate({})
+        schema.validate(input_data)
 
         assert (
             parse_document_claims.document_metas_from_data.call_args[0][0] ==
             document)
 
     def test_it_puts_document_metas_in_appstruct(self,
-                                                 AnnotationSchema,
+                                                 input_data,
                                                  parse_document_claims):
         schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(), '', '')
-        AnnotationSchema.return_value.validate.return_value['document'] = {}
+        input_data['document'] = {}
 
-        appstruct = schema.validate({})
+        appstruct = schema.validate(input_data)
 
         assert appstruct['document']['document_meta_dicts'] == (
             parse_document_claims.document_metas_from_data.return_value)
 
-    def test_it_clears_existing_keys_from_document(self,
-                                                   AnnotationSchema):
+    def test_it_clears_existing_keys_from_document(self, input_data):
         """
         Any keys in the document dict should be removed.
 
@@ -1037,86 +981,73 @@ class TestUpdateAnnotationSchema(object):
 
         """
         schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(), '', '')
-        AnnotationSchema.return_value.validate.return_value['document'] = {
+        input_data['document'] = {
             'foo': 'bar'  # This should be deleted.
         }
 
-        appstruct = schema.validate({})
+        appstruct = schema.validate(input_data)
 
         assert 'foo' not in appstruct['document']
 
-    def test_document_does_not_end_up_in_extra(self,
-                                               AnnotationSchema):
+    def test_document_does_not_end_up_in_extra(self, input_data):
         schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(), '', '')
-        AnnotationSchema.return_value.validate.return_value['document'] = {
-            'foo': 'bar'
-        }
+        input_data['document'] = {'foo': 'bar'}
 
-        appstruct = schema.validate({})
+        appstruct = schema.validate(input_data)
 
         assert 'document' not in appstruct.get('extra', {})
 
-    def test_it_does_not_crash_when_fields_are_missing(self,
-                                                       AnnotationSchema):
-        AnnotationSchema.return_value.validate.return_value = {}
+    def test_it_does_not_crash_when_fields_are_missing(self):
         schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(), '', '')
 
         schema.validate({})
 
-    def test_it_adds_extra_fields_into_the_extra_dict(self,
-                                                      AnnotationSchema):
-        AnnotationSchema.return_value.validate.return_value['foo'] = 'bar'
-        AnnotationSchema.return_value.validate.return_value['custom'] = 23
+    def test_it_adds_extra_fields_into_the_extra_dict(self, input_data):
+        input_data['foo'] = 'bar'
+        input_data['custom'] = 23
         schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(), '', '')
 
-        appstruct = schema.validate({})
+        appstruct = schema.validate(input_data)
 
         assert appstruct['extra'] == {'foo': 'bar', 'custom': 23}
 
-    def test_it_overwrites_extra_fields_in_the_extra_dict(self,
-                                                          AnnotationSchema):
-        AnnotationSchema.return_value.validate.return_value['foo'] = 'bar'
-        AnnotationSchema.return_value.validate.return_value['custom'] = 23
+    def test_it_overwrites_extra_fields_in_the_extra_dict(self, input_data):
+        input_data['foo'] = 'bar'
+        input_data['custom'] = 23
         schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(), '', '')
 
-        appstruct = schema.validate({})
+        appstruct = schema.validate(input_data)
 
         assert appstruct['extra'] == {'foo': 'bar', 'custom': 23}
 
-    def test_it_does_not_modify_extra_fields_that_are_not_sent(
-            self,
-            AnnotationSchema):
-        AnnotationSchema.return_value.validate.return_value['foo'] = 'bar'
+    def test_it_does_not_modify_extra_fields_that_are_not_sent(self,
+                                                               input_data):
+        input_data['foo'] = 'bar'
         schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(), '', '')
 
-        appstruct = schema.validate({})
+        appstruct = schema.validate(input_data)
 
         assert 'custom' not in appstruct['extra']
 
-    def test_it_does_not_modify_extra_fields_if_none_are_sent(
-            self,
-            AnnotationSchema):
+    def test_it_does_not_modify_extra_fields_if_none_are_sent(self,
+                                                              input_data):
         schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(), '', '')
-        assert 'extra' not in AnnotationSchema.return_value.validate\
-            .return_value
+        assert 'extra' not in input_data
 
-        appstruct = schema.validate({})
+        appstruct = schema.validate(input_data)
 
         assert not appstruct.get('extra')
 
-
-@pytest.fixture
-def AnnotationSchema(patch):
-    cls = patch('h.api.schemas.AnnotationSchema')
-    cls.return_value.validate.return_value = {
-        'permissions': {
-            'read': ['group:__world__'],
-            'update': ['acct:testuser@hypothes.is'],
-            'delete': ['acct:testuser@hypothes.is'],
-        },
-        'group': '__world__',
-    }
-    return cls
+    @pytest.fixture
+    def input_data(self):
+        return {
+            'permissions': {
+                'read': ['group:__world__'],
+                'update': ['acct:testuser@hypothes.is'],
+                'delete': ['acct:testuser@hypothes.is'],
+            },
+            'group': '__world__',
+        }
 
 
 @pytest.fixture

--- a/h/api/test/schemas_test.py
+++ b/h/api/test/schemas_test.py
@@ -596,6 +596,7 @@ class TestCreateAnnotationSchema(object):
 
         assert 'groupid' not in appstruct
 
+
 class TestLegacyUpdateAnnotationSchema(object):
 
     def test_it_passes_input_to_structure_validator(self):

--- a/h/api/test/schemas_test.py
+++ b/h/api/test/schemas_test.py
@@ -68,7 +68,7 @@ class TestCreateUpdateAnnotationSchema(object):
     """Shared tests for CreateAnnotationSchema and UpdateAnnotationSchema."""
 
     def test_it_does_not_raise_for_minimal_valid_data(self, validate):
-        validate(self.valid_input_data())
+        validate({})
 
     def test_it_does_not_raise_for_full_valid_data(self, validate):
         # Use all the keys to make sure that valid data for all of them passes.
@@ -193,7 +193,7 @@ class TestCreateUpdateAnnotationSchema(object):
                                         input_data,
                                         error_message):
         with pytest.raises(schemas.ValidationError) as err:
-            validate(self.valid_input_data(**input_data))
+            validate(input_data)
 
         assert str(err.value) == error_message
 
@@ -205,8 +205,7 @@ class TestCreateUpdateAnnotationSchema(object):
         'links',
     ])
     def test_it_removes_protected_fields(self, validate, field):
-        appstruct = validate(
-            self.valid_input_data(field='something forbidden'))
+        appstruct = validate({'field': 'something forbidden'})
 
         assert field not in appstruct
 
@@ -377,16 +376,6 @@ class TestCreateUpdateAnnotationSchema(object):
         appstruct = validate({})
 
         assert not appstruct.get('extra')
-
-    def valid_input_data(self, **kwargs):
-        """Return a minimal valid input data for AnnotationSchema."""
-        data = {
-            'permissions': {
-                'read': [],
-            },
-        }
-        data.update(kwargs)
-        return data
 
 
 class TestLegacyCreateAnnotationSchema(object):

--- a/h/api/test/schemas_test.py
+++ b/h/api/test/schemas_test.py
@@ -815,13 +815,6 @@ class TestUpdateAnnotationSchema(object):
 
         schema.validate({})
 
-    def test_it_overwrites_extra_fields_in_the_extra_dict(self):
-        schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(), '', '')
-
-        appstruct = schema.validate({'foo': 'bar', 'custom': 23})
-
-        assert appstruct['extra'] == {'foo': 'bar', 'custom': 23}
-
 
 @pytest.fixture
 def parse_document_claims(patch):

--- a/h/api/test/schemas_test.py
+++ b/h/api/test/schemas_test.py
@@ -810,11 +810,6 @@ class TestUpdateAnnotationSchema(object):
             document_data,
             claimant=mock.sentinel.target_uri)
 
-    def test_it_does_not_crash_when_fields_are_missing(self):
-        schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(), '', '')
-
-        schema.validate({})
-
 
 @pytest.fixture
 def parse_document_claims(patch):

--- a/h/api/test/schemas_test.py
+++ b/h/api/test/schemas_test.py
@@ -186,19 +186,9 @@ class TestAnnotationSchema(object):
         schema = schemas.AnnotationSchema()
 
         appstruct = schema.validate(
-            self.annotation_data(field='something forbidden'))
+            self.valid_input_data(field='something forbidden'))
 
         assert field not in appstruct
-
-    def annotation_data(self, **kwargs):
-        """Return test input data for AnnotationSchema.validate()."""
-        data = {
-            'permissions': {
-                'read': []
-            }
-        }
-        data.update(kwargs)
-        return data
 
     def valid_input_data(self, **kwargs):
         """Return a minimal valid input data for AnnotationSchema."""

--- a/h/api/test/schemas_test.py
+++ b/h/api/test/schemas_test.py
@@ -53,10 +53,16 @@ def update_annotation_schema_validate(data,
     return schema.validate(data)
 
 
-@pytest.mark.parametrize('validate', [
-    create_annotation_schema_validate,
-    update_annotation_schema_validate,
-])
+@pytest.mark.parametrize('validate',
+    [
+        create_annotation_schema_validate,
+        update_annotation_schema_validate,
+    ],
+    ids=[
+        'CreateAnnotationSchema.validate()',
+        'UpdateAnnotationSchema.validate()'
+    ]
+)
 class TestCreateUpdateAnnotationSchema(object):
 
     """Shared tests for CreateAnnotationSchema and UpdateAnnotationSchema."""

--- a/h/api/test/schemas_test.py
+++ b/h/api/test/schemas_test.py
@@ -338,144 +338,136 @@ class TestCreateAnnotationSchema(object):
 
         assert appstruct['userid'] == 'acct:harriet@example.com'
 
-    def test_it_renames_uri_to_target_uri(self, input_data):
+    def test_it_renames_uri_to_target_uri(self):
         schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
-        input_data['uri'] = 'http://example.com/example'
 
-        appstruct = schema.validate(input_data)
+        appstruct = schema.validate({'uri': 'http://example.com/example'})
 
         assert appstruct['target_uri'] == 'http://example.com/example'
         assert 'uri' not in appstruct
 
-    def test_it_inserts_empty_string_if_data_has_no_uri(self, input_data):
+    def test_it_inserts_empty_string_if_data_has_no_uri(self):
         schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
-        assert 'uri' not in input_data
 
-        assert schema.validate(input_data)['target_uri'] == ''
+        assert schema.validate({})['target_uri'] == ''
 
-    def test_it_keeps_text(self, input_data):
+    def test_it_keeps_text(self):
         schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
-        input_data['text'] = 'some annotation text'
 
-        appstruct = schema.validate(input_data)
+        appstruct = schema.validate({'text': 'some annotation text'})
 
         assert appstruct['text'] == 'some annotation text'
 
-    def test_it_inserts_empty_string_if_data_contains_no_text(self,
-                                                              input_data):
+    def test_it_inserts_empty_string_if_data_contains_no_text(self):
         schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
-        assert 'text' not in input_data
 
-        assert schema.validate(input_data)['text'] == ''
+        assert schema.validate({})['text'] == ''
 
-    def test_it_keeps_tags(self, input_data):
+    def test_it_keeps_tags(self):
         schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
-        input_data['tags'] = ['foo', 'bar']
 
-        appstruct = schema.validate(input_data)
+        appstruct = schema.validate({'tags': ['foo', 'bar']})
 
         assert appstruct['tags'] == ['foo', 'bar']
 
-    def test_it_inserts_empty_list_if_data_contains_no_tags(self, input_data):
-        schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
-        assert 'tags' not in input_data
-
-        assert schema.validate(input_data)['tags'] == []
-
-    def test_it_replaces_private_permissions_with_shared_False(self,
-                                                               input_data):
-        input_data['permissions'] = {'read': ['acct:harriet@example.com']}
+    def test_it_inserts_empty_list_if_data_contains_no_tags(self):
         schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
 
-        appstruct = schema.validate(input_data)
+        assert schema.validate({})['tags'] == []
+
+    def test_it_replaces_private_permissions_with_shared_False(self):
+        schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
+
+        appstruct = schema.validate({
+            'permissions': {'read': ['acct:harriet@example.com']}
+        })
 
         assert appstruct['shared'] is False
         assert 'permissions' not in appstruct
 
-    def test_it_replaces_shared_permissions_with_shared_True(self, input_data):
-        input_data['permissions'] = {'read': ['group:__world__']}
-        input_data['group'] = '__world__'
+    def test_it_replaces_shared_permissions_with_shared_True(self):
         schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
 
-        appstruct = schema.validate(input_data)
+        appstruct = schema.validate({
+            'permissions': {'read': ['group:__world__']},
+            'group': '__world__'
+        })
 
         assert appstruct['shared'] is True
         assert 'permissions' not in appstruct
 
-    def test_it_defaults_to_private_if_no_permissions_object_sent(self,
-                                                                  input_data):
-        del input_data['permissions']
+    def test_it_defaults_to_private_if_no_permissions_object_sent(self):
         schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
 
-        appstruct = schema.validate(input_data)
+        appstruct = schema.validate({})
 
         assert appstruct['shared'] is False
 
-    def test_it_does_not_crash_if_data_contains_no_target(self, input_data):
+    def test_it_does_not_crash_if_data_contains_no_target(self):
         schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
-        assert 'target' not in input_data
 
-        schema.validate(input_data)
+        schema.validate({})
 
-    def test_it_replaces_target_with_target_selectors(self, input_data):
+    def test_it_replaces_target_with_target_selectors(self):
         schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
-        input_data['target'] = [
-            {
-                'foo': 'bar',  # This should be removed,
-                'selector': 'the selectors',
-            },
-            'this should be removed',
-        ]
 
-        appstruct = schema.validate(input_data)
+        appstruct = schema.validate({
+            'target': [
+                {
+                    'foo': 'bar',  # This should be removed,
+                    'selector': 'the selectors',
+                },
+                'this should be removed',
+            ]
+        })
 
         assert appstruct['target_selectors'] == 'the selectors'
 
-    def test_it_renames_group_to_groupid(self, input_data):
+    def test_it_renames_group_to_groupid(self):
         schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
-        input_data['group'] = 'foo'
 
-        appstruct = schema.validate(input_data)
+        appstruct = schema.validate({'group': 'foo'})
 
         assert appstruct['groupid'] == 'foo'
         assert 'group' not in appstruct
 
-    def test_it_inserts_default_groupid_if_no_group(self, input_data):
+    def test_it_inserts_default_groupid_if_no_group(self):
         schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
-        del input_data['group']
 
-        appstruct = schema.validate(input_data)
+        appstruct = schema.validate({})
 
         assert appstruct['groupid'] == '__world__'
 
-    def test_it_keeps_references(self, input_data):
+    def test_it_keeps_references(self):
         schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
-        input_data['references'] = ['parent id', 'parent id 2']
 
-        appstruct = schema.validate(input_data)
+        appstruct = schema.validate({
+            'references': ['parent id', 'parent id 2']
+        })
 
         assert appstruct['references'] == ['parent id', 'parent id 2']
 
-    def test_it_inserts_empty_list_if_no_references(self, input_data):
+    def test_it_inserts_empty_list_if_no_references(self):
         schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
-        assert 'references' not in input_data
 
-        appstruct = schema.validate(input_data)
+        appstruct = schema.validate({})
 
         assert appstruct['references'] == []
 
-    def test_it_deletes_groupid_for_replies(self, input_data):
+    def test_it_deletes_groupid_for_replies(self):
         schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
-        input_data['group'] = 'foo'
-        input_data['references'] = ['parent annotation id']
 
-        appstruct = schema.validate(input_data)
+        appstruct = schema.validate({
+            'group': 'foo',
+            'references': ['parent annotation id']
+        })
 
         assert 'groupid' not in appstruct
 
-    def test_it_moves_extra_data_into_extra_sub_dict(self, input_data):
+    def test_it_moves_extra_data_into_extra_sub_dict(self):
         schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
-        input_data = {
+
+        appstruct = schema.validate({
             # Throw in all the fields, just to make sure that none of them get
             # into extra.
             'created': 'created',
@@ -493,22 +485,18 @@ class TestCreateAnnotationSchema(object):
             # These should end up in extra.
             'foo': 1,
             'bar': 2,
-        }
-
-        appstruct = schema.validate(input_data)
+        })
 
         assert appstruct['extra'] == {'foo': 1, 'bar': 2}
 
     def test_it_extracts_document_uris_from_the_document(
             self,
-            input_data,
             parse_document_claims):
         target_uri = 'http://example.com/example'
-        document_data = input_data['document'] = {'foo': 'bar'}
-        input_data['uri'] = target_uri
+        document_data = {'foo': 'bar'}
         schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
 
-        schema.validate(input_data)
+        schema.validate({'document': document_data, 'uri': target_uri})
 
         parse_document_claims.document_uris_from_data.assert_called_once_with(
             document_data,
@@ -525,15 +513,15 @@ class TestCreateAnnotationSchema(object):
 
     def test_it_extracts_document_metas_from_the_document(
             self,
-            input_data,
             parse_document_claims):
         schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
         document_data = {'foo': 'bar'}
         target_uri = 'http://example.com/example'
-        input_data['document'] = {'foo': 'bar'}
-        input_data['uri'] = target_uri
 
-        schema.validate(input_data)
+        schema.validate({
+            'document': {'foo': 'bar'},
+            'uri': target_uri
+            })
 
         parse_document_claims.document_metas_from_data.assert_called_once_with(
             document_data,
@@ -542,7 +530,6 @@ class TestCreateAnnotationSchema(object):
 
     def test_it_does_not_pass_modified_dict_to_document_metas_from_data(
             self,
-            input_data,
             parse_document_claims):
         """
 
@@ -565,9 +552,8 @@ class TestCreateAnnotationSchema(object):
         parse_document_claims.document_uris_from_data.side_effect = (
             document_uris_from_data)
         schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
-        input_data['document'] = document
 
-        schema.validate(input_data)
+        schema.validate({'document': document})
 
         assert (
             parse_document_claims.document_metas_from_data.call_args[0][0] ==
@@ -581,7 +567,7 @@ class TestCreateAnnotationSchema(object):
         assert appstruct['document']['document_meta_dicts'] == (
             parse_document_claims.document_metas_from_data.return_value)
 
-    def test_it_clears_existing_keys_from_document(self, input_data):
+    def test_it_clears_existing_keys_from_document(self):
         """
         Any keys in the document dict should be removed.
 
@@ -590,24 +576,14 @@ class TestCreateAnnotationSchema(object):
 
         """
         schema = schemas.CreateAnnotationSchema(testing.DummyRequest())
-        input_data['document'] = {
-            'foo': 'bar'  # This should be deleted.
-        }
 
-        appstruct = schema.validate(input_data)
+        appstruct = schema.validate({
+            'document': {
+                'foo': 'bar'  # This should be deleted.
+            }
+        })
 
         assert 'foo' not in appstruct['document']
-
-    @pytest.fixture
-    def input_data(self):
-        return {
-            'permissions': {
-                'read': ['group:__world__'],
-                'update': ['acct:testuser@hypothes.is'],
-                'delete': ['acct:testuser@hypothes.is'],
-            },
-            'group': '__world__',
-        }
 
 
 class TestLegacyUpdateAnnotationSchema(object):
@@ -726,8 +702,9 @@ class TestLegacyUpdateAnnotationSchema(object):
 
 class TestUpdateAnnotationSchema(object):
 
-    def test_you_cannot_update_protected_fields(self, input_data):
+    def test_you_cannot_update_protected_fields(self):
         for protected_field in ['created', 'updated', 'user', 'id', 'links']:
+            input_data = {}
             input_data[protected_field] = 'foo'
             schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(),
                                                     '',
@@ -738,112 +715,108 @@ class TestUpdateAnnotationSchema(object):
             assert protected_field not in appstruct
             assert protected_field not in appstruct.get('extra', {})
 
-    def test_you_cannot_change_an_annotations_group(self, input_data):
-        input_data['groupid'] = 'new-group'
-        input_data['group'] = 'new-group'
+    def test_you_cannot_change_an_annotations_group(self):
         schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(), '', '')
 
-        appstruct = schema.validate(input_data)
+        appstruct = schema.validate({
+            'groupid': 'new-group',
+            'group': 'new-group'
+        })
+
 
         assert 'groupid' not in appstruct
         assert 'groupid' not in appstruct.get('extra', {})
         assert 'group' not in appstruct
         assert 'group' not in appstruct.get('extra', {})
 
-    def test_you_cannot_change_an_annotations_userid(self, input_data):
-        input_data['userid'] = 'new_userid'
+    def test_you_cannot_change_an_annotations_userid(self):
         schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(), '', '')
 
-        appstruct = schema.validate(input_data)
+        appstruct = schema.validate({'userid': 'new_userid'})
 
         assert 'userid' not in appstruct
         assert 'userid' not in appstruct.get('extra', {})
 
-    def test_you_cannot_change_an_annotations_references(self, input_data):
-        input_data['references'] = ['new_parent']
+    def test_you_cannot_change_an_annotations_references(self):
         schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(), '', '')
 
-        appstruct = schema.validate(input_data)
+        appstruct = schema.validate({'references': ['new_parent']})
 
         assert 'references' not in appstruct
         assert 'references' not in appstruct.get('extra', {})
 
-    def test_it_renames_uri_to_target_uri(self, input_data):
+    def test_it_renames_uri_to_target_uri(self):
         schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(), '', '')
-        input_data['uri'] = 'http://example.com/example'
 
-        appstruct = schema.validate(input_data)
+        appstruct = schema.validate({'uri': 'http://example.com/example'})
 
         assert appstruct['target_uri'] == 'http://example.com/example'
         assert 'uri' not in appstruct
         assert 'uri' not in appstruct.get('extras', {})
 
-    def test_it_replaces_private_permissions_with_shared_False(self,
-                                                               input_data):
-        input_data['permissions'] = {'read': ['acct:harriet@example.com']}
+    def test_it_replaces_private_permissions_with_shared_False(self):
         schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(), '', '')
 
-        appstruct = schema.validate(input_data)
+        appstruct = schema.validate({
+            'permissions': {'read': ['acct:harriet@example.com']}
+        })
 
         assert appstruct['shared'] is False
         assert 'permissions' not in appstruct
         assert 'permissions' not in appstruct.get('extras', {})
 
-    def test_it_replaces_shared_permissions_with_shared_True(self, input_data):
-        input_data['permissions'] = {'read': ['group:__world__']}
+    def test_it_replaces_shared_permissions_with_shared_True(self):
         schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(),
                                                 '',
                                                 '__world__')
 
-        appstruct = schema.validate(input_data)
+        appstruct = schema.validate({
+            'permissions': {'read': ['group:__world__']}
+        })
 
         assert appstruct['shared'] is True
         assert 'permissions' not in appstruct
         assert 'permissions' not in appstruct.get('extras', {})
 
-    def test_it_converts_target_to_target_selectors(self, input_data):
+    def test_it_converts_target_to_target_selectors(self):
         schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(), '', '')
-        input_data['target'] = [
-            {
-                'foo': 'bar',  # This should be removed,
-                'selector': 'the selectors',
-            },
-            'this should be removed',
-        ]
 
-        appstruct = schema.validate(input_data)
+        appstruct = schema.validate({
+            'target': [
+                {
+                    'foo': 'bar',  # This should be removed,
+                    'selector': 'the selectors',
+                },
+                'this should be removed',
+            ]
+        })
 
         assert appstruct['target_selectors'] == 'the selectors'
         assert 'target' not in appstruct
         assert 'target' not in appstruct.get('extras', {})
 
-    def test_you_can_update_text(self, input_data):
+    def test_you_can_update_text(self):
         schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(), '', '')
-        input_data['text'] = 'new'
 
-        appstruct = schema.validate(input_data)
+        appstruct = schema.validate({'text': 'new'})
 
         assert appstruct['text'] == 'new'
 
-    def test_you_can_update_tags(self, input_data):
+    def test_you_can_update_tags(self):
         schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(), '', '')
-        input_data['tags'] = ['new']
 
-        appstruct = schema.validate(input_data)
+        appstruct = schema.validate({'tags': ['new']})
 
         assert appstruct['tags'] == ['new']
 
     def test_it_extracts_document_uris_from_the_document(
             self,
-            input_data,
             parse_document_claims):
         document_data = {'foo': 'bar'}
         target_uri = 'http://example.com/example'
-        input_data['document'] = document_data
-        input_data['uri'] = target_uri
         schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(), '', '')
 
-        schema.validate(input_data)
+        schema.validate({'document': document_data, 'uri': target_uri})
 
         parse_document_claims.document_uris_from_data.assert_called_once_with(
             document_data,
@@ -852,7 +825,6 @@ class TestUpdateAnnotationSchema(object):
 
     def test_it_passes_existing_target_uri_to_document_uris_from_data(
             self,
-            input_data,
             parse_document_claims):
         """
         If no 'uri' is given it should use the existing target_uri.
@@ -863,40 +835,33 @@ class TestUpdateAnnotationSchema(object):
 
         """
         document_data = {'foo': 'bar'}
-        input_data['document'] = document_data
-        assert 'uri' not in input_data
         schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(),
                                                 mock.sentinel.target_uri,
                                                 '')
 
-        schema.validate(input_data)
+        schema.validate({'document': document_data})
 
         parse_document_claims.document_uris_from_data.assert_called_once_with(
             document_data,
             claimant=mock.sentinel.target_uri)
 
     def test_it_puts_document_uris_in_appstruct(self,
-                                                input_data,
                                                 parse_document_claims):
-        input_data['document'] = {}
         schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(), '', '')
 
-        appstruct = schema.validate(input_data)
+        appstruct = schema.validate({'document': {}})
 
         assert appstruct['document']['document_uri_dicts'] == (
             parse_document_claims.document_uris_from_data.return_value)
 
     def test_it_extracts_document_metas_from_the_document(
             self,
-            input_data,
             parse_document_claims):
         schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(), '', '')
         document_data = {'foo': 'bar'}
         target_uri = 'http://example.com/example'
-        input_data['document'] = document_data
-        input_data['uri'] = target_uri
 
-        schema.validate(input_data)
+        schema.validate({'document': document_data, 'uri': target_uri})
 
         parse_document_claims.document_metas_from_data.assert_called_once_with(
             document_data,
@@ -905,7 +870,6 @@ class TestUpdateAnnotationSchema(object):
 
     def test_it_passes_existing_target_uri_to_document_metas_from_data(
             self,
-            input_data,
             parse_document_claims):
         """
         If no 'uri' is given it should use the existing target_uri.
@@ -916,13 +880,11 @@ class TestUpdateAnnotationSchema(object):
 
         """
         document_data = {'foo': 'bar'}
-        input_data['document'] = document_data
-        assert 'uri' not in input_data
         schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(),
                                                 mock.sentinel.target_uri,
                                                 '')
 
-        schema.validate(input_data)
+        schema.validate({'document': document_data})
 
         parse_document_claims.document_metas_from_data.assert_called_once_with(
             document_data,
@@ -930,7 +892,6 @@ class TestUpdateAnnotationSchema(object):
 
     def test_it_does_not_pass_modified_dict_to_document_metas_from_data(
             self,
-            input_data,
             parse_document_claims):
         """
 
@@ -953,26 +914,23 @@ class TestUpdateAnnotationSchema(object):
         parse_document_claims.document_uris_from_data.side_effect = (
             document_uris_from_data)
         schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(), '', '')
-        input_data['document'] = document
 
-        schema.validate(input_data)
+        schema.validate({'document': document})
 
         assert (
             parse_document_claims.document_metas_from_data.call_args[0][0] ==
             document)
 
     def test_it_puts_document_metas_in_appstruct(self,
-                                                 input_data,
                                                  parse_document_claims):
         schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(), '', '')
-        input_data['document'] = {}
 
-        appstruct = schema.validate(input_data)
+        appstruct = schema.validate({'document': {}})
 
         assert appstruct['document']['document_meta_dicts'] == (
             parse_document_claims.document_metas_from_data.return_value)
 
-    def test_it_clears_existing_keys_from_document(self, input_data):
+    def test_it_clears_existing_keys_from_document(self):
         """
         Any keys in the document dict should be removed.
 
@@ -981,19 +939,19 @@ class TestUpdateAnnotationSchema(object):
 
         """
         schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(), '', '')
-        input_data['document'] = {
-            'foo': 'bar'  # This should be deleted.
-        }
 
-        appstruct = schema.validate(input_data)
+        appstruct = schema.validate({
+            'document': {
+                'foo': 'bar'  # This should be deleted.
+            }
+        })
 
         assert 'foo' not in appstruct['document']
 
-    def test_document_does_not_end_up_in_extra(self, input_data):
+    def test_document_does_not_end_up_in_extra(self):
         schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(), '', '')
-        input_data['document'] = {'foo': 'bar'}
 
-        appstruct = schema.validate(input_data)
+        appstruct = schema.validate({'document': {'foo': 'bar'}})
 
         assert 'document' not in appstruct.get('extra', {})
 
@@ -1002,52 +960,33 @@ class TestUpdateAnnotationSchema(object):
 
         schema.validate({})
 
-    def test_it_adds_extra_fields_into_the_extra_dict(self, input_data):
-        input_data['foo'] = 'bar'
-        input_data['custom'] = 23
+    def test_it_adds_extra_fields_into_the_extra_dict(self):
         schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(), '', '')
 
-        appstruct = schema.validate(input_data)
+        appstruct = schema.validate({'foo': 'bar', 'custom': 23})
 
         assert appstruct['extra'] == {'foo': 'bar', 'custom': 23}
 
-    def test_it_overwrites_extra_fields_in_the_extra_dict(self, input_data):
-        input_data['foo'] = 'bar'
-        input_data['custom'] = 23
+    def test_it_overwrites_extra_fields_in_the_extra_dict(self):
         schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(), '', '')
 
-        appstruct = schema.validate(input_data)
+        appstruct = schema.validate({'foo': 'bar', 'custom': 23})
 
         assert appstruct['extra'] == {'foo': 'bar', 'custom': 23}
 
-    def test_it_does_not_modify_extra_fields_that_are_not_sent(self,
-                                                               input_data):
-        input_data['foo'] = 'bar'
+    def test_it_does_not_modify_extra_fields_that_are_not_sent(self):
         schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(), '', '')
 
-        appstruct = schema.validate(input_data)
+        appstruct = schema.validate({'foo': 'bar'})
 
         assert 'custom' not in appstruct['extra']
 
-    def test_it_does_not_modify_extra_fields_if_none_are_sent(self,
-                                                              input_data):
+    def test_it_does_not_modify_extra_fields_if_none_are_sent(self):
         schema = schemas.UpdateAnnotationSchema(testing.DummyRequest(), '', '')
-        assert 'extra' not in input_data
 
-        appstruct = schema.validate(input_data)
+        appstruct = schema.validate({})
 
         assert not appstruct.get('extra')
-
-    @pytest.fixture
-    def input_data(self):
-        return {
-            'permissions': {
-                'read': ['group:__world__'],
-                'update': ['acct:testuser@hypothes.is'],
-                'delete': ['acct:testuser@hypothes.is'],
-            },
-            'group': '__world__',
-        }
 
 
 @pytest.fixture


### PR DESCRIPTION
I think this is going to make it easier to fix <https://github.com/hypothesis/h/issues/3291>, but also it just makes the test code a lot simpler and reduces test code duplication:

* Don't test `AnnotationSchema` directly, instead only test it indirectly via `CreateAnnotationSchema` and `UpdateAnnotationSchema`.

   `AnnotationSchema` isn't part of the public API of the schemas module, it's a base class for `CreateAnnotationSchema` and `UpdateAnnotationSchema`.

* Move the tests that were testing `AnnotationSchema` directly into a new
`TestCreateUpdateAnnotationSchema` test class which is parametrized to run
all of its tests against _both_ `CreateAnnotationSchema` and
`UpdateAnnotationSchema`. This allows us to test both of the child classes
rather than just testing the base class, and also allows us to avoid
duplicating all the test code.

* `CreateAnnotationSchema` and `UpdateAnnotationSchema` each still have their
own unit tests for the behaviors that apply to only one class or the
other, but those unit tests no longer mock `AnnotationSchema`, instead
calling the real `AnnotationSchema`. This makes these tests simpler as
they can just pass input data into `validate()` instead of having to mock
`AnnotationSchema.return_value.validate.return_value`.

   This will allow us to test future code changes where, for example,
`CreateAnnotationSchema` inherits from `AnnotationSchema` and modifies
`AnnotationSchema.schema` in a way that changes the behaviour of
`AnnotationSchema.validate()`. Since the `CreateAnnotationSchema` tests no
longer mock `AnnotationSchema`, they can test behavior changes to the real
`AnnotationSchema.validate()`.

* Remove a lot of test code duplication by moving duplicate tests from `TestCreateAnnotationSchema` and `TestUpdateAnnotationSchema` into `TestCreateUpdateAnnotationSchema`.

* I also spotted and removed some no longer necessary input data fixtures, and a couple of no longer necessary tests