### PR TITLE
Add `devserver` command for running a dev instance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,11 @@ node_modules/
 *.egg
 *.egg-info
 
+# development TLS cert/key
+.tlscert.pem
+.tlscsr.pem
+.tlskey.pem
+
 *.pyc
 *.pyo
 

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ clean:
 
 .PHONY: dev
 dev: build/manifest.json h.egg-info/.uptodate
-	@gunicorn --reload --paste conf/development-app.ini
+	@hypothesis devserver
 
 .PHONY: dist
 dist: dist/h-$(BUILD_ID).tar.gz

--- a/docs/hacking/install.rst
+++ b/docs/hacking/install.rst
@@ -244,7 +244,7 @@ Activate the virtual environment that you've created:
 Running h
 ---------
 
-Start the Hypothesis web service:
+Start a development server:
 
 .. code-block:: bash
 
@@ -257,50 +257,12 @@ This will start the server on port 5000 (http://localhost:5000), reload the
 application whenever changes are made to the source code, and restart it should
 it crash for some reason.
 
-If you are making changes to the client, or the JavaScript code or styles for the
-service, you may find it useful to run this command from your ``h`` directory
-in a separate terminal:
-
-.. code-block:: bash
-
-    gulp watch
-
-``gulp watch`` will automatically rebuild the assets whenever the source files
-change.
-
-When ``gulp watch`` is running, you can visit http://localhost:3000
-to see a page with an embedded Hypothesis client which will automatically reload
-when styles, templates or JavaScript source files are changed.
+This command also starts a server on port 3000 (http://localhost:3000) which
+serves a page with an embedded Hypothesis client which will automatically reload
+when styles, templates or JavaScript source files are changed. This can be
+useful when developing the frontend.
 
 .. _Gulp: http://gulpjs.com/
-
-
-Running the WebSocket for real-time features
---------------------------------------------
-
-To test h's real-time features (for example, seeing new or updated annotations
-from other users appear in your browser without a page reload) you need to run
-a websocket process.  Open a new terminal, ``cd`` into your ``h`` directory,
-:ref:`activate your Python virtual environment <activating_your_virtual_environment>`,
-then run:
-
-.. code-block:: bash
-
-   gunicorn --reload --paste conf/development-websocket.ini
-
-
-Running Celery for background tasks
------------------------------------
-
-To test h's background tasks (for example, sending emails) you need to run a
-Celery worker process.
-Open a new terminal, ``cd`` into your ``h`` directory,
-:ref:`activate your Python virtual environment <activating_your_virtual_environment>`,
-then run:
-
-.. code-block:: bash
-
-    CONFIG_URI=conf/development-app.ini hypothesis-celery worker
 
 
 .. _running-the-tests:

--- a/docs/hacking/ssl.rst
+++ b/docs/hacking/ssl.rst
@@ -10,15 +10,15 @@ To serve your local dev instance of h over HTTPS:
 
 1. Generate a private key and certificate signing request::
 
-    openssl req -newkey rsa:1024 -nodes -keyout key.pem -out req.pem
+    openssl req -newkey rsa:1024 -nodes -keyout .tlskey.pem -out .tlscsr.pem
 
 2. Generate a self-signed certificate::
 
-    openssl x509 -req -in req.pem -signkey key.pem -out server.crt
+    openssl x509 -req -in .tlscsr.pem -signkey .tlskey.pem -out .tlscert.pem
 
-3. Run ``gunicorn`` with the ``certfile`` and ``keyfile`` options::
+3. Run ``hypothesis devserver`` with the ``--https`` option::
 
-    gunicorn --reload --paste conf/development-app.ini --certfile=server.crt --keyfile=key.pem
+    hypothesis devserver --https
 
 4. Since the certificate is self-signed, you will need to instruct your browser to
    trust it explicitly by visiting https://127.0.0.1:5000 and selecting the option

--- a/h/cli/__init__.py
+++ b/h/cli/__init__.py
@@ -16,6 +16,7 @@ log = logging.getLogger('h')
 
 SUBCOMMANDS = (
     'h.cli.commands.admin.admin',
+    'h.cli.commands.devserver.devserver',
     'h.cli.commands.initdb.initdb',
     'h.cli.commands.reindex.reindex',
 )

--- a/h/cli/commands/devserver.py
+++ b/h/cli/commands/devserver.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+
+import os
+import sys
+
+import click
+
+
+@click.command()
+@click.option('--https',
+              envvar='USE_HTTPS',
+              default=False,
+              is_flag=True,
+              help='Serve HTTPS rather than plain HTTP.')
+def devserver(https):
+    """
+    Run a development server.
+
+    This command will start a development instance of h, consisting of a web
+    application, Celery worker, and websocket server. It will also start a
+    process which will watch and build the frontend assets.
+
+    By default, the webserver will be accessible at:
+
+        http://localhost:5000
+
+    You can also pass the `--https` flag, which will look for a TLS certificate
+    and key in PEM format in the current directory, in files called:
+
+        .tlscert.pem
+        .tlskey.pem
+
+    If you use this flag, the webserver will be accessible at:
+
+        https://localhost:5000
+
+    If you wish this to be the default behaviour, you can set the
+    USE_HTTPS environment variable.
+    """
+    try:
+        from honcho.manager import Manager
+    except ImportError:
+        raise click.ClickException('cannot import honcho: did you run `pip install -e .[dev]` yet?')
+
+    os.environ['PYTHONUNBUFFERED'] = 'true'
+    os.environ['CONFIG_URI'] = 'conf/development-app.ini'
+    if https:
+        gunicorn_args = '--certfile=.tlscert.pem --keyfile=.tlskey.pem'
+        os.environ['APP_URL'] = 'https://localhost:5000'
+        os.environ['H_WEBSOCKET_URL'] = 'wss://localhost:5001/ws'
+        os.environ['ALLOWED_ORIGINS'] = 'https://localhost:5000'
+    else:
+        gunicorn_args = ''
+        os.environ['APP_URL'] = 'http://localhost:5000'
+        os.environ['H_WEBSOCKET_URL'] = 'ws://localhost:5001/ws'
+
+    m = Manager()
+    m.add_process('web', 'gunicorn --reload --paste conf/development-app.ini %s' % gunicorn_args)
+    m.add_process('ws', 'gunicorn --reload --paste conf/development-websocket.ini %s' % gunicorn_args)
+    m.add_process('worker', 'hypothesis-celery worker --autoreload')
+    m.add_process('assets', 'gulp watch')
+    m.loop()
+
+    sys.exit(m.returncode)

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,7 @@ INSTALL_REQUIRES = [
 ]
 EXTRAS_REQUIRE = {
     'dev': [
+        'honcho',
         'pyramid_debugtoolbar>=2.1',
         'prospector[with_pyroma]',
         'pep257',


### PR DESCRIPTION
Spinning up the various parts of an h development instance is still far too fiddly.

This adds a `hypothesis devserver` command that runs all the various pieces of a development instance, correctly wired together, and multiplexes their output onto one screen.