### PR TITLE
Fix EBADF crash with ws4py and gevent 1.1

### DIFF
--- a/h/websocket.py
+++ b/h/websocket.py
@@ -7,6 +7,7 @@ and a stripped-down Pyramid application which exposes a single endpoint for
 serving the "streamer" over the websocket.
 """
 
+import gevent
 from gunicorn.workers.ggevent import GeventPyWSGIWorker
 from gunicorn.workers.ggevent import PyWSGIHandler
 from ws4py.server.geventserver import WSGIServer
@@ -31,6 +32,37 @@ class WSGIHandler(PyWSGIHandler, WebSocketWSGIHandler):
             self.environ.setdefault('ws4py.websocket', None)
 
         super(WSGIHandler, self).finalize_headers()
+
+    def run_application(self):
+        # Override run_application from ws4py due to the websocket server
+        # crashing with EBADF. A change in gevent (1.1) causes all sockets to be
+        # closed when a WSGI handler returns. ws4py starts a new greenlet for
+        # each new websocket connection used to return from the WSGI handler.
+        # The fix is taken from [1] and waits for the greenlet to finish before
+        # returning from the WSGI handler.
+        #
+        # [1]: https://github.com/Lawouach/WebSocket-for-Python/pull/180
+        #
+        # More information at:
+        # - https://github.com/Lawouach/WebSocket-for-Python/issues/170
+        # - https://github.com/gevent/gevent/issues/633
+
+        upgrade_header = self.environ.get('HTTP_UPGRADE', '').lower()
+        if upgrade_header:
+            # Build and start the HTTP response
+            self.environ['ws4py.socket'] = self.socket or self.environ['wsgi.input'].rfile._sock
+            self.result = self.application(self.environ, self.start_response) or []
+            self.process_result()
+            del self.environ['ws4py.socket']
+            self.socket = None
+            self.rfile.close()
+
+            ws = self.environ.pop('ws4py.websocket', None)
+            if ws:
+                ws_greenlet = self.server.pool.track(ws)
+                ws_greenlet.join()
+        else:
+            gevent.pywsgi.WSGIHandler.run_application(self)
 
 
 class Worker(GeventPyWSGIWorker):


### PR DESCRIPTION
We now override ws4py's run_application due to the websocket server
crashing with EBADF. A change in gevent (1.1) causes all sockets to be
closed when a WSGI handler returns. ws4py starts a new greenlet for
each new websocket connection used to return from the WSGI handler.
The fix is taken from [here](https://github.com/Lawouach/WebSocket-for-Python/pull/180) and waits for the greenlet to finish before
returning from the WSGI handler.

More information at:
- https://github.com/Lawouach/WebSocket-for-Python/issues/170
- https://github.com/gevent/gevent/issues/633