### PR TITLE
Move hypothesis-celery command to h.cli

### DIFF
--- a/docs/INSTALL.rst
+++ b/docs/INSTALL.rst
@@ -150,7 +150,7 @@ a worker process::
     $ docker run --name h-worker \
                  [...additional config...] \
                  hypothesis/hypothesis \
-                 hypothesis-celery worker
+                 hypothesis celery worker
 
 And, possibly, a websocket server::
 

--- a/h/cli/__init__.py
+++ b/h/cli/__init__.py
@@ -16,32 +16,19 @@ log = logging.getLogger('h')
 
 SUBCOMMANDS = (
     'h.cli.commands.admin.admin',
+    'h.cli.commands.celery.celery',
     'h.cli.commands.devserver.devserver',
     'h.cli.commands.initdb.initdb',
     'h.cli.commands.reindex.reindex',
 )
 
 
-def bootstrap(config):
+def bootstrap(app_url, dev=False, create_db=False):
     """
     Bootstrap the application from the given arguments.
 
     Returns a bootstrapped request object.
     """
-    paster.setup_logging(config)
-    request = Request.blank('/')
-    paster.bootstrap(config, request=request)
-    return request
-
-
-@click.group()
-@click.option('--dev',
-              help="Use defaults suitable for development?",
-              default=False,
-              is_flag=True)
-@click.version_option(version=__version__)
-@click.pass_context
-def cli(ctx, dev):
     # Set a flag in the environment that other code can use to detect if it's
     # running in a script rather than a full web application.
     #
@@ -50,12 +37,42 @@ def cli(ctx, dev):
     os.environ['H_SCRIPT'] = 'true'
 
     # Override other important environment variables
-    os.environ['MODEL_CREATE_ALL'] = 'False'
+    os.environ['MODEL_CREATE_ALL'] = 'True' if create_db else 'False'
     os.environ['MODEL_DROP_ALL'] = 'False'
-    os.environ['SECRET_KEY'] = 'notsecret'
+
+    if dev:
+        os.environ['SECRET_KEY'] = 'notsecret'
+
+    # In development, we will happily provide a default APP_URL, but it must be
+    # set in production mode.
+    if not app_url:
+        if dev:
+            app_url = 'http://localhost:5000'
+        else:
+            raise click.ClickException('the app URL must be set in production mode!')
 
     config = 'conf/development-app.ini' if dev else 'conf/app.ini'
-    ctx.obj['bootstrap'] = functools.partial(bootstrap, config)
+
+    paster.setup_logging(config)
+    request = Request.blank('/', base_url=app_url)
+    env = paster.bootstrap(config, request=request)
+    request.root = env['root']
+    return request
+
+
+@click.group()
+@click.option('--app-url',
+              help="The base URL for the application",
+              envvar='APP_URL',
+              metavar='URL')
+@click.option('--dev',
+              help="Use defaults suitable for development?",
+              default=False,
+              is_flag=True)
+@click.version_option(version=__version__)
+@click.pass_context
+def cli(ctx, app_url, dev):
+    ctx.obj['bootstrap'] = functools.partial(bootstrap, app_url, dev)
 
 
 def main():

--- a/h/cli/commands/celery.py
+++ b/h/cli/commands/celery.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+
+import click
+
+from h.celery import start
+
+
+@click.command(add_help_option=False,  # --help is passed through to Celery
+               context_settings={'allow_extra_args': True,
+                                 'ignore_unknown_options': True})
+@click.pass_context
+def celery(ctx):
+    """
+    Run Celery commands.
+
+    This command delegates to the celery-worker command, giving access to the
+    full Celery CLI.
+    """
+    argv = [ctx.command_path] + list(ctx.args)
+    start(argv=argv, bootstrap=ctx.obj['bootstrap'])

--- a/h/cli/commands/devserver.py
+++ b/h/cli/commands/devserver.py
@@ -43,7 +43,6 @@ def devserver(https):
         raise click.ClickException('cannot import honcho: did you run `pip install -e .[dev]` yet?')
 
     os.environ['PYTHONUNBUFFERED'] = 'true'
-    os.environ['CONFIG_URI'] = 'conf/development-app.ini'
     if https:
         gunicorn_args = '--certfile=.tlscert.pem --keyfile=.tlskey.pem'
         os.environ['APP_URL'] = 'https://localhost:5000'
@@ -57,7 +56,7 @@ def devserver(https):
     m = Manager()
     m.add_process('web', 'gunicorn --reload --paste conf/development-app.ini %s' % gunicorn_args)
     m.add_process('ws', 'gunicorn --reload --paste conf/development-websocket.ini %s' % gunicorn_args)
-    m.add_process('worker', 'hypothesis-celery worker --autoreload')
+    m.add_process('worker', 'hypothesis --dev celery worker --autoreload')
     m.add_process('assets', 'gulp watch')
     m.loop()
 

--- a/h/cli/commands/initdb.py
+++ b/h/cli/commands/initdb.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-import os
-
 import click
 
 
@@ -9,9 +7,6 @@ import click
 @click.pass_context
 def initdb(ctx):
     """Create database tables and elasticsearch indices."""
-    # Force model creation using the MODEL_CREATE_ALL env var
-    os.environ['MODEL_CREATE_ALL'] = 'True'
-
     # Start the application, triggering model creation
     bootstrap = ctx.obj['bootstrap']
-    bootstrap()
+    bootstrap(create_db=True)

--- a/h/test/celery_test.py
+++ b/h/test/celery_test.py
@@ -3,26 +3,12 @@
 import logging
 
 import mock
-from pyramid.request import Request
 import pytest
 
 from h import celery
 
 
-def fake_bootstrap(config_uri, request=None):
-    request.sentry = mock.sentinel.sentry
-    return {
-        'root': mock.sentinel.root
-    }
-
-
 class TestCelery(object):
-
-    @pytest.fixture(autouse=True)
-    def paster(self, request):
-        paster = _patch('h.celery.paster', request)
-        paster.bootstrap.side_effect = fake_bootstrap
-        return paster
 
     @pytest.fixture(autouse=True)
     def register_signal(self, request):
@@ -32,31 +18,27 @@ class TestCelery(object):
     def register_logger_signal(self, request):
         return _patch('h.celery.register_logger_signal', request)
 
-    def test_bootstrap_worker_calls_paster_bootstrap(self, paster):
+    def test_bootstrap_worker_bootstraps_application(self):
         sender = mock.Mock(spec=['app'])
 
         celery.bootstrap_worker(sender)
 
-        assert paster.bootstrap.call_count == 1
+        sender.app.webapp_bootstrap.assert_called_once_with()
 
-    def test_bootstrap_worker_attaches_request_to_app(self, paster):
+    def test_bootstrap_worker_attaches_request_to_app(self):
         sender = mock.Mock(spec=['app'])
+        request = sender.app.webapp_bootstrap.return_value
 
         celery.bootstrap_worker(sender)
 
-        assert isinstance(sender.app.request, Request)
-
-    def test_bootstrap_worker_sets_request_root(self, paster):
-        sender = mock.Mock(spec=['app'])
-
-        celery.bootstrap_worker(sender)
-
-        assert sender.app.request.root == mock.sentinel.root
+        assert sender.app.request == request
 
     def test_bootstrap_worker_configures_sentry_reporting(self,
                                                           register_signal,
                                                           register_logger_signal):
         sender = mock.Mock(spec=['app'])
+        request = sender.app.webapp_bootstrap.return_value
+        request.sentry = mock.sentinel.sentry
 
         celery.bootstrap_worker(sender)
 

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,6 @@ ENTRY_POINTS = {
     'console_scripts': [
         'hypothesis=h.cli:main',
         'hypothesis-buildext=h.buildext:main',
-        'hypothesis-celery=h.celery:main',
     ],
     'h.annotool': [
         'prepare=h.api.transform:prepare',


### PR DESCRIPTION
This moves the previously-separate `hypothesis-celery` command into the
main h CLI as the `hypothesis celery` command.

This also allows us to fully deduplicate the application bootstrap for
command line applications. There's now only one place
(`h/cli/__init__.py`) responsible for bootstrapping the Pyramid
application.

Note that the `initdb` command also changes so that the `bootstrap`
function can become fully responsible for configuring the application
when it starts up.