### PR TITLE
Anchor annotations sequentially

### DIFF
--- a/h/static/scripts/annotator/task-queue.js
+++ b/h/static/scripts/annotator/task-queue.js
@@ -1,0 +1,43 @@
+'use strict';
+
+/**
+ * A queue which executes a series of Promise-yielding tasks sequentially.
+ *
+ * Call push() to enqueue a new task. All tasks are executed in serial.
+ *
+ * If we end up with more sophisticated needs, we might want to look at
+ * a package such as bottleneck.
+ */
+function TaskQueue() {
+  this._queue = [];
+  this._activeTask = null;
+}
+
+TaskQueue.prototype._runNext = function () {
+  var self = this;
+  if (this._activeTask || !this._queue.length) {
+    return;
+  }
+  var fn = this._queue.shift();
+  this._activeTask = fn();
+  this._activeTask.then(function () {
+    self._activeTask = null;
+    self._runNext();
+  }).catch(function () {
+    self._activeTask = null;
+    self._runNext();
+  });
+};
+
+/**
+ * Schedule a task.
+ *
+ * @param {Function} fn - A function that when executed, returns a Promise
+ *        for completion of the task.
+ */
+TaskQueue.prototype.push = function (fn) {
+  this._queue.push(fn);
+  this._runNext();
+};
+
+module.exports = TaskQueue;

--- a/h/static/scripts/annotator/test/create-task.js
+++ b/h/static/scripts/annotator/test/create-task.js
@@ -1,0 +1,21 @@
+'use strict';
+
+/**
+ * A helper for creating fake async tasks in tests.
+ *
+ * The returned object has a `taskFn` to run the task and a `done` Promise
+ * that resolves when the task is executed.
+ */
+function createTask(id) {
+  var resolve;
+  var done = new Promise(function (resolve_) {
+    resolve = resolve_;
+  });
+  var taskFn = function () {
+    resolve();
+    return done;
+  };
+  return {id: id, taskFn: taskFn, done: done};
+}
+
+module.exports = createTask;

--- a/h/static/scripts/annotator/test/integration/anchoring-test.js
+++ b/h/static/scripts/annotator/test/integration/anchoring-test.js
@@ -1,0 +1,124 @@
+'use strict';
+
+var Annotator = require('annotator');
+
+var unroll = require('../../../test/util').unroll;
+var Guest = require('../../guest');
+
+function targetWithSelectors(selectors) {
+  return [{ selector: selectors }];
+}
+
+function quoteSelector(quote) {
+  return {
+    type: 'TextQuoteSelector',
+    exact: quote,
+  };
+}
+
+/** Generate an annotation that matches a text quote in a page. */
+function annotateQuote(quote) {
+  return {
+    target: targetWithSelectors([quoteSelector(quote)]),
+  };
+}
+
+/**
+ * Return the text of all highlighted phrases in `container`.
+ *
+ * @param {Element} container
+ */
+function highlightedPhrases(container) {
+  return Array.from(container.querySelectorAll('.annotator-hl')).map(function (el) {
+    return el.textContent;
+  });
+}
+
+function simplifyWhitespace(quote) {
+  return quote.replace(/\s+/g, ' ');
+}
+
+function FakeCrossFrame(elem, options) {
+  var waiters = [];
+
+  this.destroy = sinon.stub();
+  this.onConnect = sinon.stub();
+  this.on = sinon.stub();
+  this.options = options;
+
+  this.sync = function () {
+    waiters.forEach(function (waiter) {
+      --waiter.count;
+      if (waiter.count === 0) {
+        waiter.resolve();
+        waiters = waiters.filter(function (w) {
+          return w !== waiter;
+        });
+      }
+    });
+  };
+
+  /** Wait for `count` annotations to be anchored. */
+  this.awaitSync = function (count) {
+    return new Promise(function (resolve) {
+      waiters.push({
+        count: count,
+        resolve: resolve,
+      });
+    });
+  };
+}
+
+describe('anchoring', function () {
+  var guest;
+  var container;
+  var crossFrame;
+
+  before(function () {
+    Annotator.Plugin.CrossFrame = FakeCrossFrame;
+  });
+
+  beforeEach(function () {
+    container = document.createElement('div');
+    container.innerHTML = require('./test-page.html');
+    document.body.appendChild(container);
+    guest = new Guest(container);
+    crossFrame = guest.crossframe;
+  });
+
+  afterEach(function () {
+    guest.destroy();
+    container.parentNode.removeChild(container);
+  });
+
+  unroll('should highlight #tag when annotations are loaded', function (testCase) {
+    var normalize = function (quotes) {
+      return quotes.map(function (q) { return simplifyWhitespace(q); });
+    };
+
+    var annotations = testCase.quotes.map(function (q) {
+      return annotateQuote(q);
+    });
+
+    // Simulate new annotations being loaded via the bridge
+    crossFrame.options.emit('annotationsLoaded', annotations);
+
+    return crossFrame.awaitSync(testCase.quotes.length).then(function () {
+      assert.deepEqual(normalize(highlightedPhrases(container)),
+                       normalize(testCase.quotes));
+    });
+  }, [{
+    tag: 'a simple quote',
+    quotes: ['This has not been a scientist\'s war'],
+  },{
+    // Currently failing due to an issue with concurrently anchoring nested
+    // annotations.
+    // See https://github.com/hypothesis/h/issues/3278#issuecomment-218421956
+    tag: 'nested quotes',
+    quotes: [
+      'This has not been a scientist\'s war;' +
+        ' it has been a war in which all have had a part',
+      'scientist\'s war',
+    ],
+  }]);
+});

--- a/h/static/scripts/annotator/test/integration/anchoring-test.js
+++ b/h/static/scripts/annotator/test/integration/anchoring-test.js
@@ -111,9 +111,6 @@ describe('anchoring', function () {
     tag: 'a simple quote',
     quotes: ['This has not been a scientist\'s war'],
   },{
-    // Currently failing due to an issue with concurrently anchoring nested
-    // annotations.
-    // See https://github.com/hypothesis/h/issues/3278#issuecomment-218421956
     tag: 'nested quotes',
     quotes: [
       'This has not been a scientist\'s war;' +

--- a/h/static/scripts/annotator/test/integration/test-page.html
+++ b/h/static/scripts/annotator/test/integration/test-page.html
@@ -1,0 +1,23 @@
+<h1>As we may think</h1>
+
+<h2>Vannevar Bush</h2>
+
+<p>This has not been a scientist's war; it has been a war in which all have had a
+part. The scientists, burying their old professional competition in the demand
+of a common cause, have shared greatly and learned much. It has been
+exhilarating to work in effective partnership. Now, for many, this appears to be
+approaching an end. What are the scientists to do next?</p>
+
+<p>For the biologists, and particularly for the medical scientists, there can be
+little indecision, for their war has hardly required them to leave the old
+paths. Many indeed have been able to carry on their war research in their
+familiar peacetime laboratories. Their objectives remain much the same.</p>
+
+<p>It is the physicists who have been thrown most violently off stride, who have
+left academic pursuits for the making of strange destructive gadgets, who have
+had to devise new methods for their unanticipated assignments. They have done
+their part on the devices that made it possible to turn back the enemy, have
+worked in combined effort with the physicists of our allies. They have felt
+within themselves the stir of achievement. They have been part of a great team.
+Now, as peace approaches, one asks where they will find objectives worthy of
+their best.</p>

--- a/h/static/scripts/annotator/test/task-queue-test.js
+++ b/h/static/scripts/annotator/test/task-queue-test.js
@@ -1,0 +1,23 @@
+'use strict';
+
+var createTask = require('./create-task');
+var TaskQueue = require('../task-queue');
+
+describe('TaskQueue', function () {
+  it('executes each task in order', function () {
+    var resolveOrder = [];
+    var queue = new TaskQueue();
+
+    var tasks = [createTask(0), createTask(1)];
+    tasks.forEach(function (task) {
+      task.done.then(function () { resolveOrder.push(task.id); });
+    });
+
+    queue.push(tasks[1].taskFn);
+    queue.push(tasks[0].taskFn);
+
+    return Promise.all([tasks[0].done, tasks[1].done]).then(function () {
+      assert.deepEqual(resolveOrder, [1,0]);
+    });
+  });
+});


### PR DESCRIPTION
When anchoring annotations which overlap, inserting the highlight
for an annotation could fail if the DOM was mutated in-between the
annotation's location being resolved to a DOM Range and that DOM Range
being highlighted.

Given two annotations, #1 and #2 where #2's range is contained within #1
(eg. #1 annotates a sentence and #2 annotates a phrase within that
sentence), the following could happen:

 1. Guest#anchor() (the function that anchors annotations) called with annotation #1
 2. Guest#anchor() called with annotation #2
 3. Annotation #1 resolved to range R1
 4. Annotation #2 resolved to range R2
 5. Range R1 highlighted. This wraps the first annotation in a `<span class="annotator-hl">` tag
    and makes R2 invalid in the process.
 6. Range R2 highlighting attempted. This fails because R2 is now invalid. Consequently annotation #2 appears in the sidebar but is not highlighted in the document.

This commit resolves the issue by anchoring annotations sequentially, so
the sequence would now be:

 1. Guest#anchor() called with annotation #1
 2. Annotation #1 resolved to range R1
 3. Range R1 highlighted
 4. Guest #anchor() called with annotation #2
 5. Annotation #2 resolved to range R2
 6. Range R2 highlighted

It might be possible to optimize the process by only anchoring
annotations which overlap sequentially. This commit takes the simplest
approach and just anchors all annotations sequentially.

Fixes #3278
