### PR TITLE
Add Jenkinsfile to configure build pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,3 @@ notifications:
       - secure: SKPwtfoH32aDop6hLhQdgrUhl58gM6CMBUATMdq0KMmEwCxskPbIArqxGUKxeeiO3c3jBQ+Yuq3b4m8GbR2AJxxelO0DRLNyV1lAjfeJ/QzCc3Taxqo0yel4uAFNg/oCYWH50dv2oAgDP3CHk/tKXmsgDWOjcm6A6k35xst16xI=
     on_success: change
     on_failure: always
-  webhooks:
-    urls:
-      - https://support.hypothes.is/travis
-    on_success: always

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,34 @@
+#!groovy
+
+node {
+    stage 'Build'
+    checkout scm
+
+    // Store the short commit id for use tagging images
+    sh 'git rev-parse --short HEAD > GIT_SHA'
+    gitSha = readFile('GIT_SHA').trim()
+
+    sh "make docker DOCKER_TAG=${gitSha}"
+    img = docker.image "hypothesis/hypothesis:${gitSha}"
+
+    stage 'Test'
+    docker.image('postgres:9.4').withRun('-P -e POSTGRES_DB=htest') {c ->
+        sh "echo postgresql://postgres@\$(facter ipaddress_eth0):\$(docker port ${c.id} 5432 | cut -d: -f2)/htest > DATABASE_URL"
+        databaseUrl = readFile('DATABASE_URL').trim()
+
+        // Run our Python tests inside the built container
+        img.inside("-u root -e TEST_DATABASE_URL=${databaseUrl}") {
+            sh 'pip install -q tox'
+            sh 'tox'
+        }
+    }
+
+    // We only push the image to the Docker Hub if we're on master
+    if (env.BRANCH_NAME != 'master') {
+        return
+    }
+    stage 'Push'
+    docker.withRegistry('', 'docker-hub-build') {
+        img.push('auto')
+    }
+}

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,6 +5,7 @@ include gulpfile.js
 include gunicorn.conf.py
 include package.json
 include requirements.txt
+exclude Jenkinsfile
 graft conf
 graft docs
 prune docs/_build

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ PATH := bin:${PATH}
 NPM_BIN := $(shell npm bin)
 ISODATE := $(shell TZ=UTC date '+%Y%m%d')
 BUILD_ID := $(shell python -c 'import h; print(h.__version__)')
+DOCKER_TAG = dev
 
 # Unless the user has specified otherwise in their environment, it's probably a
 # good idea to refuse to install unless we're in an activated virtualenv.
@@ -38,7 +39,7 @@ dist/h-$(BUILD_ID): dist/h-$(BUILD_ID).tar.gz
 
 .PHONY: docker
 docker: dist/h-$(BUILD_ID)
-	docker build -t hypothesis/hypothesis:dev $<
+	docker build -t hypothesis/hypothesis:$(DOCKER_TAG) $<
 
 .PHONY: lint
 lint: h.egg-info/.uptodate


### PR DESCRIPTION
This adds a Jenkinsfile, which is a Groovy script interpreted by the Jenkins Pipeline plugin in order to schedule our build.

Adding it to the source code repository means we can have Travis-like branch builds which we can configure to behave differently to master branch builds.

Here, we configure three build steps:

2. Build: builds the Docker image and tags it with the git revision
2. Test: runs the backend tests -- frontend tests will come in due course
3. Push: if we're on the master branch, we push the image (tagged as "auto") up to the Docker Hub