### PR TITLE
Use "as exc" not "as err"

### DIFF
--- a/h/accounts/test/__init___test.py
+++ b/h/accounts/test/__init___test.py
@@ -205,10 +205,10 @@ def test_authenticated_user_redirects_if_user_does_not_exist(
     authn_policy.authenticated_userid.return_value = 'userid'
     get_user.return_value = None
 
-    with pytest.raises(httpexceptions.HTTPFound) as err:
+    with pytest.raises(httpexceptions.HTTPFound) as exc:
         accounts.authenticated_user(request)
 
-    assert err.value.location == '/the/page/that/I/was/on', (
+    assert exc.value.location == '/the/page/that/I/was/on', (
         'It should redirect to the same page that was requested')
 
 

--- a/h/accounts/test/schemas_test.py
+++ b/h/accounts/test/schemas_test.py
@@ -90,33 +90,33 @@ def test_unique_email_invalid_when_user_does_not_exist(user_model):
 def test_RegisterSchema_with_password_too_short(user_model):
     schema = schemas.RegisterSchema().bind(request=DummyRequest())
 
-    with pytest.raises(colander.Invalid) as err:
+    with pytest.raises(colander.Invalid) as exc:
         schema.deserialize({"password": "a"})
-    assert "password" in err.value.asdict()
+    assert "password" in exc.value.asdict()
 
 
 def test_RegisterSchema_with_username_too_short(user_model):
     schema = schemas.RegisterSchema().bind(request=DummyRequest())
 
-    with pytest.raises(colander.Invalid) as err:
+    with pytest.raises(colander.Invalid) as exc:
         schema.deserialize({"username": "a"})
-    assert "username" in err.value.asdict()
+    assert "username" in exc.value.asdict()
 
 
 def test_RegisterSchema_with_username_too_long(user_model):
     schema = schemas.RegisterSchema().bind(request=DummyRequest())
 
-    with pytest.raises(colander.Invalid) as err:
+    with pytest.raises(colander.Invalid) as exc:
         schema.deserialize({"username": "a" * 500})
-    assert "username" in err.value.asdict()
+    assert "username" in exc.value.asdict()
 
 
 def test_ResetPasswordSchema_with_password_too_short(config, user_model):
     schema = schemas.ResetPasswordSchema().bind(request=csrf_request(config))
 
-    with pytest.raises(colander.Invalid) as err:
+    with pytest.raises(colander.Invalid) as exc:
         schema.deserialize({"password": "a"})
-    assert "password" in err.value.asdict()
+    assert "password" in exc.value.asdict()
 
 
 def test_LoginSchema_with_bad_csrf(config, user_model):

--- a/h/accounts/views.py
+++ b/h/accounts/views.py
@@ -150,10 +150,10 @@ class AjaxAuthController(AuthController):
     def login(self):
         try:
             json_body = self.request.json_body
-        except ValueError as err:
+        except ValueError as exc:
             raise accounts.JSONError(
                 _('Could not parse request body as JSON: {message}'.format(
-                    message=err.message)))
+                    message=exc.message)))
 
         if not isinstance(json_body, dict):
             raise accounts.JSONError(

--- a/h/admin/views/badge.py
+++ b/h/admin/views/badge.py
@@ -21,8 +21,8 @@ def badge_index(_):
 def badge_add(request):
     try:
         request.db.add(models.Blocklist(uri=request.params['add']))
-    except ValueError as err:
-        request.session.flash(err.message, 'error')
+    except ValueError as exc:
+        request.session.flash(exc.message, 'error')
     return badge_index(request)
 
 

--- a/h/api/test/schemas_test.py
+++ b/h/api/test/schemas_test.py
@@ -192,10 +192,10 @@ class TestCreateUpdateAnnotationSchema(object):
                                         validate,
                                         input_data,
                                         error_message):
-        with pytest.raises(schemas.ValidationError) as err:
+        with pytest.raises(schemas.ValidationError) as exc:
             validate(input_data)
 
-        assert str(err.value) == error_message
+        assert str(exc.value) == error_message
 
     @pytest.mark.parametrize('field', [
         'created',

--- a/h/api/test/storage_test.py
+++ b/h/api/test/storage_test.py
@@ -356,19 +356,19 @@ class TestCreateAnnotation(object):
         # The annotation is a reply.
         data['references'] = ['parent_annotation_id']
 
-        with pytest.raises(schemas.ValidationError) as err:
+        with pytest.raises(schemas.ValidationError) as exc:
             storage.create_annotation(self.mock_request(), data)
 
-        assert str(err.value).startswith('references.0: ')
+        assert str(exc.value).startswith('references.0: ')
 
     def test_it_raises_if_user_does_not_have_permissions_for_group(self):
         data = self.annotation_data()
         data['groupid'] = 'foo-group'
 
-        with pytest.raises(schemas.ValidationError) as err:
+        with pytest.raises(schemas.ValidationError) as exc:
             storage.create_annotation(self.mock_request(), data)
 
-        assert str(err.value).startswith('group: ')
+        assert str(exc.value).startswith('group: ')
 
     def test_it_inits_an_Annotation_model(self, models):
         data = self.annotation_data()

--- a/h/api/test/views_test.py
+++ b/h/api/test/views_test.py
@@ -232,10 +232,10 @@ class TestCreate(object):
         schemas.CreateAnnotationSchema.return_value.validate.side_effect = (
             ValidationError('asplode'))
 
-        with pytest.raises(ValidationError) as err:
+        with pytest.raises(ValidationError) as exc:
             views.create(mock_request)
 
-        assert err.value.message == 'asplode'
+        assert exc.value.message == 'asplode'
 
     def test_it_creates_the_annotation_in_storage(self,
                                                   mock_request,
@@ -253,10 +253,10 @@ class TestCreate(object):
                                                    storage):
         storage.create_annotation.side_effect = ValidationError('asplode')
 
-        with pytest.raises(ValidationError) as err:
+        with pytest.raises(ValidationError) as exc:
             views.create(mock_request)
 
-        assert err.value.message == 'asplode'
+        assert exc.value.message == 'asplode'
 
     def test_it_inits_LegacyCreateAnnotationSchema(self,
                                                    mock_request,
@@ -281,10 +281,10 @@ class TestCreate(object):
         schemas.LegacyCreateAnnotationSchema.return_value.validate\
             .side_effect = ValidationError('asplode')
 
-        with pytest.raises(ValidationError) as err:
+        with pytest.raises(ValidationError) as exc:
             views.create(mock_request)
 
-        assert err.value.message == 'asplode'
+        assert exc.value.message == 'asplode'
 
     def test_it_creates_the_annotation_in_legacy_storage(self,
                                                          mock_request,


### PR DESCRIPTION
We had a mixture of "as exc" and "as err" when catching exceptions.

Personally I think err is a much better name for instances of classes
named things like ValueError, ValidationError, etc. But we had
(slightly) more instances of exc than err in the code.