### PR TITLE
Postgres to ElasticSearch reindexer

### DIFF
--- a/h/_compat.py
+++ b/h/_compat.py
@@ -25,9 +25,11 @@ PY2 = sys.version_info[0] == 2
 if not PY2:
     text_type = str
     string_types = (str,)
+    xrange = xrange
 else:
     text_type = unicode  # noqa
     string_types = (str, unicode)  # noqa
+    xrange = range
 
 try:
     import ConfigParser as configparser

--- a/h/api/_compat.py
+++ b/h/api/_compat.py
@@ -8,9 +8,11 @@ PY2 = sys.version_info[0] == 2
 if not PY2:
     text_type = str
     string_types = (str,)
+    xrange = xrange
 else:
     text_type = unicode
     string_types = (str, unicode)
+    xrange = range
 
 try:
     from urllib import parse as urlparse

--- a/h/api/models/annotation.py
+++ b/h/api/models/annotation.py
@@ -79,11 +79,10 @@ class Annotation(Base, mixins.Timestamps):
     #: Any additional serialisable data provided by the client.
     extra = sa.Column(pg.JSONB, nullable=True)
 
-    document_uris = sa.orm.relationship('DocumentURI',
-                                        viewonly=True,
-                                        foreign_keys='DocumentURI.uri_normalized',
-                                        primaryjoin='DocumentURI.uri_normalized == Annotation.target_uri_normalized')
-    documents = association_proxy('document_uris', 'document')
+    document = sa.orm.relationship('Document',
+                                   secondary='join(DocumentURI, Document, DocumentURI.document_id == Document.id)',
+                                   primaryjoin='Annotation.target_uri_normalized == DocumentURI.uri_normalized',
+                                   uselist=False)
 
     @hybrid_property
     def target_uri(self):
@@ -97,11 +96,6 @@ class Annotation(Base, mixins.Timestamps):
     @hybrid_property
     def target_uri_normalized(self):
         return self._target_uri_normalized
-
-    @hybrid_property
-    def document(self):
-        if self.documents:
-            return self.documents[0]
 
     @property
     def parent_id(self):

--- a/h/api/models/annotation.py
+++ b/h/api/models/annotation.py
@@ -28,6 +28,7 @@ class Annotation(Base, mixins.Timestamps):
         #   http://www.postgresql.org/docs/9.5/static/gin-intro.html
         #
         sa.Index('ix__annotation_tags', 'tags', postgresql_using='gin'),
+        sa.Index('ix__annotation_updated', 'updated'),
     )
 
     #: Annotation ID: these are stored as UUIDs in the database, and mapped

--- a/h/api/models/document.py
+++ b/h/api/models/document.py
@@ -26,8 +26,12 @@ class Document(Base, mixins.Timestamps):
     #        dependency on the annotator-store is removed, as it clashes with
     #        making the Postgres and Elasticsearch interface of a Document
     #        object behave the same way.
-    document_uris = sa.orm.relationship('DocumentURI', backref='document')
-    meta = sa.orm.relationship('DocumentMeta', backref='document')
+    document_uris = sa.orm.relationship('DocumentURI',
+                                        backref='document',
+                                        order_by='DocumentURI.updated.desc()')
+    meta = sa.orm.relationship('DocumentMeta',
+                               backref='document',
+                               order_by='DocumentMeta.updated.desc()')
 
     def __repr__(self):
         return '<Document %s>' % self.id

--- a/h/api/models/document.py
+++ b/h/api/models/document.py
@@ -93,6 +93,7 @@ class DocumentURI(Base, mixins.Timestamps):
                             'uri_normalized',
                             'type',
                             'content_type'),
+        sa.Index('ix__document_uri_updated', 'updated'),
     )
 
     id = sa.Column(sa.Integer, autoincrement=True, primary_key=True)
@@ -153,6 +154,7 @@ class DocumentMeta(Base, mixins.Timestamps):
     __tablename__ = 'document_meta'
     __table_args__ = (
         sa.UniqueConstraint('claimant_normalized', 'type'),
+        sa.Index('ix__document_meta_updated', 'updated'),
     )
 
     id = sa.Column(sa.Integer, autoincrement=True, primary_key=True)

--- a/h/api/models/document.py
+++ b/h/api/models/document.py
@@ -93,6 +93,7 @@ class DocumentURI(Base, mixins.Timestamps):
                             'uri_normalized',
                             'type',
                             'content_type'),
+        sa.Index('ix__document_uri_document_id', 'document_id'),
         sa.Index('ix__document_uri_updated', 'updated'),
     )
 
@@ -154,6 +155,7 @@ class DocumentMeta(Base, mixins.Timestamps):
     __tablename__ = 'document_meta'
     __table_args__ = (
         sa.UniqueConstraint('claimant_normalized', 'type'),
+        sa.Index('ix__document_meta_document_id', 'document_id'),
         sa.Index('ix__document_meta_updated', 'updated'),
     )
 

--- a/h/api/search/index.py
+++ b/h/api/search/index.py
@@ -38,6 +38,9 @@ def index(es, annotation, request):
     :type annotation: h.api.models.Annotation
 
     """
+    # FIXME: this should not use the same presenter as we use to render
+    # annotations for clients. It is useful in the mean time until we get rid of
+    # the legacy ElasticSearch annotation storage.
     annotation_dict = presenters.AnnotationJSONPresenter(
         request, annotation).asdict()
 
@@ -133,6 +136,9 @@ class BatchIndexer(object):
         action = {'index': {'_index': self.es_client.index,
                             '_type': self.es_client.t.annotation,
                             '_id': annotation.id}}
+        # FIXME: this should not use the same presenter as we use to render
+        # annotations for clients. It is useful in the mean time until we get rid of
+        # the legacy ElasticSearch annotation storage.
         data = presenters.AnnotationJSONPresenter(self.request, annotation).asdict()
 
         return (action, data)

--- a/h/api/search/index.py
+++ b/h/api/search/index.py
@@ -2,10 +2,13 @@
 """Functions for updating the search index."""
 
 from __future__ import unicode_literals
+import itertools
 import logging
 
 import elasticsearch
+from elasticsearch import helpers as es_helpers
 
+from h.api import models
 from h.api import presenters
 from h.api.events import AnnotationTransformEvent
 
@@ -69,3 +72,89 @@ def delete(es, annotation_id):
     except elasticsearch.NotFoundError:
         log.exception('Tried to delete a nonexistent annotation from the '
                       'search index, annotation id: %s', annotation_id)
+
+
+class BatchDeleter(object):
+    """
+    A convenience class for removing all annotations that are deleted from the
+    database from the search index.
+    """
+
+    def __init__(self, session, es_client):
+        self.session = session
+        self.es_client = es_client
+
+    def delete_all(self):
+        """Remove all deleted annotations, and retry failed delete operations once."""
+        ids = self.deleted_annotation_ids()
+        for _ in range(2):
+            if not ids:
+                break
+
+            ids = self.delete(ids)
+            log.debug(
+                'Failed to delete {} annotations, might retry'.format(len(ids)))
+
+    def deleted_annotation_ids(self):
+        """
+        Get a list of deleted annotation ids by comparing all ids in the search
+        index and comparing them to all ids in the database.
+
+        :returns: a set of deleted annotation ids
+        :rtype: set
+        """
+        ids = set()
+        for batch in self._batch_iter(2000, self._es_scan()):
+            ids.update({a['_id'] for a in batch})
+
+        for batch in self._batch_iter(2000, self._pg_ids()):
+            ids.difference_update({a.id for a in batch})
+        return ids
+
+    def delete(self, annotation_ids):
+        """
+        Delete annotations from the search index.
+
+        :param annotation_ids: a list of ids to delete.
+        :type annotation_ids: collection
+
+        :returns: a set of errored ids
+        :rtype: set
+        """
+        if not annotation_ids:
+            return set()
+
+        deleting = es_helpers.streaming_bulk(self.es_client.conn, annotation_ids,
+                                             chunk_size=100,
+                                             expand_action_callback=self._prepare,
+                                             raise_on_error=False)
+        errored = set()
+        for ok, item in deleting:
+            if not ok and item['delete']['status'] != 404:
+                errored.add(item['delete']['_id'])
+        return errored
+
+    def _prepare(self, id_):
+        action = {'delete': {'_index': self.es_client.index,
+                             '_type': self.es_client.t.annotation,
+                             '_id': id_}}
+        return (action, None)
+
+    def _pg_ids(self):
+        # This is using a Postgres cursor for better query performance.
+        return self.session.query(models.Annotation.id).execution_options(stream_results=True)
+
+    def _es_scan(self):
+        query = {'_source': False, 'query': {'match_all': {}}}
+        return es_helpers.scan(self.es_client.conn,
+                               index=self.es_client.index,
+                               doc_type=self.es_client.t.annotation,
+                               query=query)
+
+    def _batch_iter(self, n, iterable):
+        it = iter(iterable)
+        while True:
+            batch = list(itertools.islice(it, n))
+            if not batch:
+                return
+            yield batch

--- a/h/api/search/test/index_test.py
+++ b/h/api/search/test/index_test.py
@@ -7,6 +7,9 @@ from pyramid.testing import DummyRequest
 
 import elasticsearch
 
+from h import db
+from h.api import models
+from h.api import presenters
 from h.api.search import client
 from h.api.search import index
 
@@ -99,6 +102,148 @@ class TestDeleteAnnotation:
     @pytest.fixture
     def log(self, patch):
         return patch('h.api.search.index.log')
+
+
+class TestBatchDeleter(object):
+    def test_delete_all_fetches_deleted_annotation_ids(self, deleter, deleted_annotation_ids):
+        deleter.delete_all()
+        assert deleted_annotation_ids.call_count == 1
+
+    def test_delete_all_deletes_annotation_ids(self, deleter, deleted_annotation_ids, delete):
+        deleted_annotation_ids.return_value = set([mock.Mock()])
+        delete.return_value = set()
+
+        deleter.delete_all()
+        delete.assert_called_once_with(deleter, deleted_annotation_ids.return_value)
+
+    def test_delete_all_skips_deleting_when_no_deleted_annotation_ids(self,
+                                                                      deleter,
+                                                                      deleted_annotation_ids,
+                                                                      delete):
+        deleted_annotation_ids.return_value = set()
+
+        deleter.delete_all()
+        assert not delete.called
+
+    def test_delete_all_retries_failed_deletion_attempts_once(self,
+                                                              deleter,
+                                                              deleted_annotation_ids,
+                                                              delete):
+        deleted_annotation_ids.return_value = set(['id-1', 'id-2'])
+        delete.return_value = set(['id-1'])
+
+        deleter.delete_all()
+        assert delete.call_args_list == [
+            mock.call(deleter, set(['id-1', 'id-2'])),
+            mock.call(deleter, set(['id-1']))
+        ]
+
+    def test_deleted_annotation_ids(self, es_scan, annotation):
+        deleter = self.deleter(session=db.Session)
+
+        es_scan.return_value = [
+            {'_id': 'deleted-from-postgres-id',
+             '_source': {'uri': 'http://example.org'}}]
+
+        deleted_ids = deleter.deleted_annotation_ids()
+        assert deleted_ids == set(['deleted-from-postgres-id'])
+
+    def test_deleted_annotation_ids_no_changes(self, es_scan, annotation):
+        request = DummyRequest()
+        deleter = self.deleter(session=db.Session)
+
+        es_scan.return_value = [
+            {'_id': annotation.id,
+             '_source': presenters.AnnotationJSONPresenter(request, annotation)}]
+
+        deleted_ids = deleter.deleted_annotation_ids()
+        assert len(deleted_ids) == 0
+
+    def test_delete_deletes_from_es(self, deleter, streaming_bulk):
+        ids = set(['test-annotation-id'])
+
+        deleter.delete(ids)
+        streaming_bulk.assert_called_once_with(
+            deleter.es_client.conn, ids, chunk_size=mock.ANY,
+            raise_on_error=False, expand_action_callback=mock.ANY)
+
+    def test_delete_correctly_presents_bulk_actions(self, deleter, streaming_bulk):
+        results = []
+
+        def fake_streaming_bulk(*args, **kwargs):
+            id_ = args[1][0]
+            callback = kwargs.get('expand_action_callback')
+            results.append(callback(id_))
+            return set()
+
+        streaming_bulk.side_effect = fake_streaming_bulk
+
+        deleter.delete(['test-annotation-id'])
+        assert results[0] == (
+            {'delete': {'_type': deleter.es_client.t.annotation,
+                        '_index': deleter.es_client.index,
+                        '_id': 'test-annotation-id'}},
+            None,
+        )
+
+    def test_delete_returns_failed_bulk_actions(self, deleter, streaming_bulk):
+        def fake_streaming_bulk(*args, **kwargs):
+            ids = args[1]
+            for id_ in ids:
+                if id_.startswith('fail'):
+                    yield (False, {'delete': {'_id': id_, 'status': 504}})
+                else:
+                    yield (True, {'delete': {'_id': id_, 'status': 200}})
+
+        streaming_bulk.side_effect = fake_streaming_bulk
+
+        result = deleter.delete(['succeed-1', 'fail-1', 'fail-2', 'succeed-2'])
+        assert result == set(['fail-1', 'fail-2'])
+
+    def test_delete_does_not_return_failed_404_bulk_actions(self, deleter, streaming_bulk):
+        def fake_streaming_bulk(*args, **kwargs):
+            ids = args[1]
+            for id_ in ids:
+                if id_ == 'fail-404':
+                    yield (False, {'delete': {'_id': id_, 'status': 404}})
+                elif id_.startswith('fail-504'):
+                    yield (False, {'delete': {'_id': id_, 'status': 504}})
+                else:
+                    yield (True, {'delete': {'_id': id_, 'status': 200}})
+
+        streaming_bulk.side_effect = fake_streaming_bulk
+
+        result = deleter.delete(['succeed-1', 'fail-404', 'fail-504'])
+        assert result == set(['fail-504'])
+
+    @pytest.fixture
+    def deleter(self, session=None):
+        if session is None:
+            session = mock.MagicMock()
+        return index.BatchDeleter(session, mock.MagicMock())
+
+    @pytest.fixture
+    def deleted_annotation_ids(self, patch):
+        return patch('h.api.search.index.BatchDeleter.deleted_annotation_ids')
+
+    @pytest.fixture
+    def delete(self, patch):
+        return patch('h.api.search.index.BatchDeleter.delete')
+
+    @pytest.fixture
+    def es_scan(self, patch):
+        return patch('h.api.search.index.es_helpers.scan')
+
+    @pytest.fixture
+    def streaming_bulk(self, patch):
+        return patch('h.api.search.index.es_helpers.streaming_bulk')
+
+    @pytest.fixture
+    def annotation(self):
+        ann = models.Annotation(userid="bob", target_uri="http://example.com")
+        db.Session.add(ann)
+        db.Session.flush()
+        return ann
 
 
 @pytest.fixture

--- a/h/celery.py
+++ b/h/celery.py
@@ -43,6 +43,7 @@ celery.conf.update(
     CELERY_ROUTES={
         'h.indexer.add_annotation': 'indexer',
         'h.indexer.delete_annotation': 'indexer',
+        'h.indexer.reindex': 'indexer',
     },
     CELERY_TASK_SERIALIZER='json',
     CELERY_QUEUES=[

--- a/h/migrations/versions/77c2af032aca_add_document_uri_and_meta_docid_ix.py
+++ b/h/migrations/versions/77c2af032aca_add_document_uri_and_meta_docid_ix.py
@@ -1,0 +1,27 @@
+"""Add Document URI and Meta document_id index
+
+Revision ID: 77c2af032aca
+Revises: f3b8e76ae9f5
+Create Date: 2016-05-13 15:06:55.496502
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '77c2af032aca'
+down_revision = 'f3b8e76ae9f5'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.execute('COMMIT')
+    op.create_index(op.f('ix__document_uri_document_id'), 'document_uri', ['document_id'],
+                    postgresql_concurrently=True)
+    op.create_index(op.f('ix__document_meta_document_id'), 'document_meta', ['document_id'],
+                    postgresql_concurrently=True)
+
+
+def downgrade():
+    op.drop_index(op.f('ix__document_uri_document_id'), 'document_uri')
+    op.drop_index(op.f('ix__document_meta_document_id'), 'document_meta')

--- a/h/migrations/versions/f3b8e76ae9f5_add_document_uri_and_meta_updated_index.py
+++ b/h/migrations/versions/f3b8e76ae9f5_add_document_uri_and_meta_updated_index.py
@@ -1,0 +1,27 @@
+"""Add Document URI and Meta updated index
+
+Revision ID: f3b8e76ae9f5
+Revises: fde6cdcdd39a
+Create Date: 2016-05-13 14:58:37.679724
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'f3b8e76ae9f5'
+down_revision = 'fde6cdcdd39a'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.execute('COMMIT')
+    op.create_index(op.f('ix__document_uri_updated'), 'document_uri', ['updated'],
+                    postgresql_concurrently=True)
+    op.create_index(op.f('ix__document_meta_updated'), 'document_meta', ['updated'],
+                    postgresql_concurrently=True)
+
+
+def downgrade():
+    op.drop_index(op.f('ix__document_uri_updated'), 'document_uri')
+    op.drop_index(op.f('ix__document_meta_updated'), 'document_meta')

--- a/h/migrations/versions/fde6cdcdd39a_add_annotation_updated_index.py
+++ b/h/migrations/versions/fde6cdcdd39a_add_annotation_updated_index.py
@@ -1,0 +1,24 @@
+"""add annotation.updated index
+
+Revision ID: fde6cdcdd39a
+Revises: 3bcd62dd7260
+Create Date: 2016-04-27 13:42:14.201644
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'fde6cdcdd39a'
+down_revision = '3bcd62dd7260'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.execute('COMMIT')
+    op.create_index(op.f('ix__annotation_updated'), 'annotation', ['updated'],
+                    postgresql_concurrently=True)
+
+
+def downgrade():
+    op.drop_index(op.f('ix__annotation_updated'), 'annotation')

--- a/h/test/indexer_test.py
+++ b/h/test/indexer_test.py
@@ -50,6 +50,31 @@ class TestDeleteAnnotation(object):
         return patch('h.indexer.delete')
 
 
+@pytest.mark.usefixtures('celery', 'BatchIndexer', 'BatchDeleter')
+class TestReindex(object):
+    def test_it_indexes_all_annotations(self, celery, BatchIndexer):
+        indexer.reindex()
+
+        BatchIndexer.assert_called_once_with(
+            celery.request.db, celery.request.es, celery.request)
+        assert BatchIndexer.return_value.index_all.called
+
+    def test_it_removes_all_deleted_annotations(self, celery, BatchDeleter):
+        indexer.reindex()
+
+        BatchDeleter.assert_called_once_with(
+            celery.request.db, celery.request.es)
+        assert BatchDeleter.return_value.delete_all.called
+
+    @pytest.fixture
+    def BatchIndexer(self, patch):
+        return patch('h.indexer.BatchIndexer')
+
+    @pytest.fixture
+    def BatchDeleter(self, patch):
+        return patch('h.indexer.BatchDeleter')
+
+
 @pytest.mark.usefixtures('add_annotation', 'delete_annotation')
 class TestSubscribeAnnotationEvent(object):
 
@@ -110,6 +135,6 @@ class TestSubscribeAnnotationEvent(object):
 @pytest.fixture
 def celery(patch):
     cel = patch('h.indexer.celery')
-    cel.request = DummyRequest(es=mock.Mock(), feature=mock.Mock())
+    cel.request = DummyRequest(db=mock.Mock(), es=mock.Mock(), feature=mock.Mock())
     cel.request.feature.return_value = True
     return cel


### PR DESCRIPTION
This PR adds:

* A class for batch indexing all (or a big set of) annotations: `h.api.search.index.BatchIndexing`
* A class for batch removing deleted annotations from the search index: `h.api.search.index.BatchDeleting`
* A celery task for an easy way to run both at the same time in a worker: `hypothesis-celery call h.indexer.reindex`

I've added more detailed comments in the code, but all SQL queries, ElasticSearch queries and operations have been optimized as far as possible for causing the least amount of load on the respective Postgres/ElasticSearch servers, and for keeping the memory footprint of the Python process running these as low as possible.

I've tested it out locally and running both the indexing and deleting takes between 5 and 5:30 minutes on my local machine with approximately 350,000 annotations.