### PR TITLE
Show appropriate messages if an annotation is unavailable to a user.

### DIFF
--- a/h/static/styles/thread.scss
+++ b/h/static/styles/thread.scss
@@ -27,7 +27,6 @@ $thread-padding: $annotation-card-left-padding;
   align-items: center;
 
   &__label {
-    max-width: 160px;
     text-align: center;
   }
 

--- a/h/templates/client/viewer.html
+++ b/h/templates/client/viewer.html
@@ -27,7 +27,16 @@
       ng-if="selectedAnnotationUnavailable()">
     <div class="annotation-unavailable-message__icon"></div>
     <p class="annotation-unavailable-message__label">
-      You do not have permission to see this annotation
+      <span ng-if="auth.status === 'signed-out'">
+        This annotation is not available.
+        <br>
+        You may need to
+        <a class="loggedout-message__link" href="" ng-click="login()">sign in</a>
+        to see it.
+      </span>
+      <span ng-if="auth.status === 'signed-in'">
+        You do not have permission to view this annotation.
+      </span>
     </p>
   </li>
   <li class="thread-list__spacer"


### PR DESCRIPTION
If a selected annotation is unavailable to a user, prompt user to sign in
if he/she isn't signed in.
If a selected annotation is unavailable to a user and he/she is already
signed in, display a message.

Trello:
https://trello.com/c/scNGUMBk/330-improve-copy-to-clarify-direct-linking-functionality
