### PR TITLE
Ignore errors when attempting to inject extension on Extensions Gallery

### DIFF
--- a/h/browser/chrome/lib/errors.js
+++ b/h/browser/chrome/lib/errors.js
@@ -46,8 +46,12 @@ function isKnownError(err) {
 }
 
 var IGNORED_ERRORS = [
+  // Errors that can happen when the tab is closed during injection
   /The tab was closed/,
+  /No tab with id.*/,
+  // Attempts to access pages for which Chrome does not allow scripting
   /Cannot access contents of.*/,
+  /The extensions gallery cannot be scripted/,
 ];
 
 /**

--- a/h/browser/chrome/test/errors-test.js
+++ b/h/browser/chrome/test/errors-test.js
@@ -23,9 +23,11 @@ describe('errors', function () {
   describe('#shouldIgnoreInjectionError', function () {
     var ignoredErrors = [
       'The tab was closed',
+      'No tab with id 42',
       'Cannot access contents of url "file:///C:/t/cpp.pdf". ' +
       'Extension manifest must request permission to access this host.',
       'Cannot access contents of page',
+      'The extensions gallery cannot be scripted.',
     ];
 
     var unexpectedErrors = [


### PR DESCRIPTION
As noted at http://stackoverflow.com/a/11614440 , Chrome prevents
content scripts from being injected on the Chrome Web Store, so do not
report these errors to us.

Steps to test:

 1. Open background page for H extension in dev tools, switch to Network
    tab.

 2. Go to https://chrome.google.com/webstore

 3. Activate H extension.

Expected results:

 - Activation fails. Badge shows exclamation mark.
 - Clicking on badge a second time shows error page.
 - No network requests are made to Sentry by the H extension's
   background page.

The error page does still display a misleading message that the problem
has been reported to us, but the error message from Chrome is pretty
clear about what the issue is.

Fixes this Sentry issue: https://app.getsentry.com/hypothesis/prod-client/issues/115817620/