### PR TITLE
Fix database/index autoconfiguration in dev environment

### DIFF
--- a/conf/development-app.ini
+++ b/conf/development-app.ini
@@ -4,9 +4,6 @@ pipeline: h
 [app:h]
 use: egg:h
 
-h.db.should_create_all: True
-h.search.autoconfig: True
-
 es.host: http://localhost:9200
 
 mail.default_sender: "Annotation Daemon" <no-reply@localhost>

--- a/h/cli/__init__.py
+++ b/h/cli/__init__.py
@@ -24,7 +24,7 @@ SUBCOMMANDS = (
 )
 
 
-def bootstrap(app_url, dev=False, create_db=False):
+def bootstrap(app_url, dev=False):
     """
     Bootstrap the application from the given arguments.
 
@@ -36,13 +36,6 @@ def bootstrap(app_url, dev=False, create_db=False):
     # FIXME: This is a nasty hack and should go when we no longer need to spin
     # up an entire application to build the extensions.
     os.environ['H_SCRIPT'] = 'true'
-
-    # Override other important environment variables
-    os.environ['MODEL_CREATE_ALL'] = 'True' if create_db else 'False'
-    os.environ['MODEL_DROP_ALL'] = 'False'
-
-    if dev:
-        os.environ['SECRET_KEY'] = 'notsecret'
 
     # In development, we will happily provide a default APP_URL, but it must be
     # set in production mode.

--- a/h/cli/commands/devserver.py
+++ b/h/cli/commands/devserver.py
@@ -54,7 +54,10 @@ def devserver(https):
         os.environ['H_WEBSOCKET_URL'] = 'ws://localhost:5001/ws'
 
     m = Manager()
-    m.add_process('web', 'gunicorn --reload --paste conf/development-app.ini %s' % gunicorn_args)
+    m.add_process('web',
+                  'MODEL_CREATE_ALL=true '
+                  'SEARCH_AUTOCONFIG=true '
+                  'gunicorn --reload --paste conf/development-app.ini %s' % gunicorn_args)
     m.add_process('ws', 'gunicorn --reload --paste conf/development-websocket.ini %s' % gunicorn_args)
     m.add_process('worker', 'hypothesis --dev celery worker --autoreload')
     m.add_process('assets', 'gulp watch')

--- a/h/cli/commands/initdb.py
+++ b/h/cli/commands/initdb.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+import os
+
 import click
 
 
@@ -7,6 +9,10 @@ import click
 @click.pass_context
 def initdb(ctx):
     """Create database tables and elasticsearch indices."""
-    # Start the application, triggering model creation
+    # Settings to autocreate database tables and indices
+    os.environ['MODEL_CREATE_ALL'] = 'true'
+    os.environ['SEARCH_AUTOCONFIG'] = 'true'
+
+    # Start the application
     bootstrap = ctx.obj['bootstrap']
-    bootstrap(create_db=True)
+    bootstrap()

--- a/h/config.py
+++ b/h/config.py
@@ -74,6 +74,7 @@ SETTINGS = [
     EnvSetting('h.client_secret', 'CLIENT_SECRET'),
     EnvSetting('h.db.should_create_all', 'MODEL_CREATE_ALL', type=asbool),
     EnvSetting('h.db.should_drop_all', 'MODEL_DROP_ALL', type=asbool),
+    EnvSetting('h.search.autoconfig', 'SEARCH_AUTOCONFIG', type=asbool),
     EnvSetting('h.websocket_url', 'H_WEBSOCKET_URL'),
     # The client Sentry DSN should be of the public kind, lacking the password
     # component in the DSN URI.


### PR DESCRIPTION
Database/search index autocreation was broken for `hypothesis devserver` due to the MODEL_CREATE_ALL environment variable overrides in `h.cli.bootstrap`. This commit fixes this problem by:

- adding an environment variable, SEARCH_AUTOCONFIG, to correspond to the h.search.autoconfig setting
- setting SEARCH_AUTOCONFIG and MODEL_CREATE_ALL explicitly in the `initdb` command and for the web process run by `devserver`
- removing the affected settings from development-app.ini to prevent unintended use of the autocreation feature