### PR TITLE
Remove H_ prefix from websocket URL setting

### DIFF
--- a/h/cli/commands/devserver.py
+++ b/h/cli/commands/devserver.py
@@ -46,12 +46,12 @@ def devserver(https):
     if https:
         gunicorn_args = '--certfile=.tlscert.pem --keyfile=.tlskey.pem'
         os.environ['APP_URL'] = 'https://localhost:5000'
-        os.environ['H_WEBSOCKET_URL'] = 'wss://localhost:5001/ws'
+        os.environ['WEBSOCKET_URL'] = 'wss://localhost:5001/ws'
         os.environ['ALLOWED_ORIGINS'] = 'https://localhost:5000'
     else:
         gunicorn_args = ''
         os.environ['APP_URL'] = 'http://localhost:5000'
-        os.environ['H_WEBSOCKET_URL'] = 'ws://localhost:5001/ws'
+        os.environ['WEBSOCKET_URL'] = 'ws://localhost:5001/ws'
 
     m = Manager()
     m.add_process('web',

--- a/h/config.py
+++ b/h/config.py
@@ -75,7 +75,7 @@ SETTINGS = [
     EnvSetting('h.db.should_create_all', 'MODEL_CREATE_ALL', type=asbool),
     EnvSetting('h.db.should_drop_all', 'MODEL_DROP_ALL', type=asbool),
     EnvSetting('h.search.autoconfig', 'SEARCH_AUTOCONFIG', type=asbool),
-    EnvSetting('h.websocket_url', 'H_WEBSOCKET_URL'),
+    EnvSetting('h.websocket_url', 'WEBSOCKET_URL'),
     # The client Sentry DSN should be of the public kind, lacking the password
     # component in the DSN URI.
     EnvSetting('h.client.sentry_dsn', 'SENTRY_DSN_CLIENT'),


### PR DESCRIPTION
This is well-intentioned, but inconsistent with all other settings.