### PR TITLE
Use distinct database session for h.api tests

### DIFF
--- a/h/api/conftest.py
+++ b/h/api/conftest.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+
+import os
+
+import pytest
+from sqlalchemy import engine_from_config
+from sqlalchemy.orm import scoped_session, sessionmaker
+
+from h.api import db
+
+Session = scoped_session(sessionmaker())
+
+
+@pytest.fixture
+def config(request, settings):
+    """Pyramid configurator object."""
+    from pyramid import testing
+    config = testing.setUp(settings=settings)
+    request.addfinalizer(testing.tearDown)
+    return config
+
+
+@pytest.fixture(scope='session')
+def settings():
+    """Default app settings."""
+    settings = {}
+    settings['sqlalchemy.url'] = os.environ.get('TEST_DATABASE_URL',
+                                                'postgresql://postgres@localhost/htest')
+    return settings
+
+
+@pytest.fixture(autouse=True)
+def db_session(request, monkeypatch):
+    """
+    Prepare the SQLAlchemy session object.
+
+    We enable fast repeatable database tests by setting up the database only
+    once per session (see :func:`setup_database`) and then wrapping each test
+    function in a SAVEPOINT/ROLLBACK TO SAVEPOINT within the transaction.
+    """
+    Session.begin_nested()
+    request.addfinalizer(Session.rollback)
+
+    # Prevent the session from committing, but simulate the effects of a commit
+    # within our transaction. N.B. we must not only flush SQLA state to the
+    # database but also expire the persistence state of all objects.
+    def _fake_commit():
+        Session.flush()
+        Session.expire_all()
+    monkeypatch.setattr(Session, 'commit', _fake_commit)
+    # Prevent the session from closing (make it a no-op):
+    monkeypatch.setattr(Session, 'remove', lambda: None)
+    return Session
+
+
+@pytest.fixture(scope='module', autouse=True)
+def setup_database(request, settings):
+    """Set up the database connection and create tables."""
+    engine = engine_from_config(settings, 'sqlalchemy.')
+    db.bind_engine(engine, should_create=True, should_drop=True)
+    db.use_session(Session)
+    request.addfinalizer(Session.remove)

--- a/h/api/models/test/annotation_test.py
+++ b/h/api/models/test/annotation_test.py
@@ -5,7 +5,6 @@ from __future__ import unicode_literals
 from pyramid import security
 import pytest
 
-from h import db
 from h.api.models.annotation import Annotation
 from h.api.models.document import Document, DocumentURI
 
@@ -14,21 +13,21 @@ annotation_fixture = pytest.mark.usefixtures('annotation')
 
 
 @annotation_fixture
-def test_document(annotation):
+def test_document(annotation, db_session):
     document = Document(document_uris=[DocumentURI(claimant=annotation.target_uri,
                                                    uri=annotation.target_uri)])
-    db.Session.add(document)
-    db.Session.flush()
+    db_session.add(document)
+    db_session.flush()
 
     assert annotation.document == document
 
 
 @annotation_fixture
-def test_document_not_found(annotation):
+def test_document_not_found(annotation, db_session):
     document = Document(document_uris=[DocumentURI(claimant='something-else',
                                                    uri='something-else')])
-    db.Session.add(document)
-    db.Session.flush()
+    db_session.add(document)
+    db_session.flush()
 
     assert annotation.document is None
 
@@ -85,9 +84,9 @@ def test_acl_group_shared():
 
 
 @pytest.fixture
-def annotation():
+def annotation(db_session):
     ann = Annotation(userid="testuser", target_uri="http://example.com")
 
-    db.Session.add(ann)
-    db.Session.flush()
+    db_session.add(ann)
+    db_session.flush()
     return ann


### PR DESCRIPTION
The h.api tests formerly used the default scoped session in h.db when testing. This commit gives these tests their own independently managed database session, thus allowing them to be run independently of the rest of the h test suite.