### PR TITLE
Use config.testing_securitypolicy, not authn_policy fixture

### DIFF
--- a/h/accounts/test/__init___test.py
+++ b/h/accounts/test/__init___test.py
@@ -147,10 +147,10 @@ authenticated_user_fixtures = pytest.mark.usefixtures('get_user')
 
 
 @authenticated_user_fixtures
-def test_authenticated_user_calls_get_user(authn_policy, get_user):
+def test_authenticated_user_calls_get_user(config, get_user):
     """It should call get_user() correctly."""
     request = testing.DummyRequest()
-    authn_policy.authenticated_userid.return_value = 'userid'
+    config.testing_securitypolicy('userid')
 
     accounts.authenticated_user(request)
 
@@ -158,13 +158,12 @@ def test_authenticated_user_calls_get_user(authn_policy, get_user):
 
 
 @authenticated_user_fixtures
-def test_authenticated_user_invalidates_session_if_user_does_not_exist(
-        authn_policy, get_user):
+def test_authenticated_user_invalidates_session_if_user_does_not_exist(config, get_user):
     """It should log the user out if they no longer exist in the db."""
     request = testing.DummyRequest()
     request.current_route_url = lambda: '/'
     request.session.invalidate = mock.Mock()
-    authn_policy.authenticated_userid.return_value = 'userid'
+    config.testing_securitypolicy('userid')
     get_user.return_value = None
 
     try:
@@ -176,8 +175,7 @@ def test_authenticated_user_invalidates_session_if_user_does_not_exist(
 
 
 @authenticated_user_fixtures
-def test_authenticated_user_does_not_invalidate_session_if_not_authenticated(
-        authn_policy, get_user):
+def test_authenticated_user_does_not_invalidate_session_if_not_authenticated(config, get_user):
     """
     If authenticated_userid is None it shouldn't invalidate the session.
 
@@ -189,7 +187,7 @@ def test_authenticated_user_does_not_invalidate_session_if_not_authenticated(
     request = testing.DummyRequest()
     request.current_route_url = lambda: '/'
     request.session.invalidate = mock.Mock()
-    authn_policy.authenticated_userid.return_value = None
+    config.testing_securitypolicy()
     get_user.return_value = None
 
     accounts.authenticated_user(request)
@@ -198,11 +196,10 @@ def test_authenticated_user_does_not_invalidate_session_if_not_authenticated(
 
 
 @authenticated_user_fixtures
-def test_authenticated_user_redirects_if_user_does_not_exist(
-        authn_policy, get_user):
+def test_authenticated_user_redirects_if_user_does_not_exist(config, get_user):
     request = testing.DummyRequest()
     request.current_route_url = lambda: '/the/page/that/I/was/on'
-    authn_policy.authenticated_userid.return_value = 'userid'
+    config.testing_securitypolicy('userid')
     get_user.return_value = None
 
     with pytest.raises(httpexceptions.HTTPFound) as exc:

--- a/h/api/schemas.py
+++ b/h/api/schemas.py
@@ -256,7 +256,7 @@ class LegacyCreateAnnotationSchema(object):
         # group they've asked to create one in.
         if 'group' in appstruct:
             if appstruct['group'] == '__world__':
-                group_principal = security.Everyone
+                group_principal = security.Authenticated
             else:
                 group_principal = 'group:{}'.format(appstruct['group'])
             if group_principal not in self.request.effective_principals:

--- a/h/api/test/storage_test.py
+++ b/h/api/test/storage_test.py
@@ -306,7 +306,7 @@ class TestLegacyUpdateAnnotation(object):
 class TestCreateAnnotation(object):
 
     def test_it_fetches_parent_annotation_for_replies(self,
-                                                      authn_policy,
+                                                      config,
                                                       fetch_annotation):
         request = self.mock_request()
 
@@ -314,7 +314,7 @@ class TestCreateAnnotation(object):
         fetch_annotation.return_value.groupid = 'test-group'
 
         # The request will need permission to write to 'test-group'.
-        authn_policy.effective_principals.return_value = ['group:test-group']
+        config.testing_securitypolicy('acct:foo@example.com', groupids=['group:test-group'])
 
         data = self.annotation_data()
 
@@ -328,14 +328,14 @@ class TestCreateAnnotation(object):
                                                  _postgres=True)
 
     def test_it_sets_group_for_replies(self,
-                                       authn_policy,
+                                       config,
                                        fetch_annotation,
                                        models):
         # Make the annotation's parent belong to 'test-group'.
         fetch_annotation.return_value.groupid = 'test-group'
 
         # The request will need permission to write to 'test-group'.
-        authn_policy.effective_principals.return_value = ['group:test-group']
+        config.testing_securitypolicy('acct:foo@example.com', groupids=['group:test-group'])
 
         data = self.annotation_data()
         assert data['groupid'] != 'test-group'

--- a/h/auth/test/policy_test.py
+++ b/h/auth/test/policy_test.py
@@ -68,8 +68,8 @@ class TestAuthenticationPolicy(object):
         assert result == tokens.authenticated_userid.return_value
 
     @mock.patch('h.auth.policy.util')
-    def test_effective_principals_calls_effective_principals_with_authenticated_userid(self, util, authn_policy):
-        authn_policy.authenticated_userid.return_value = 'acct:rami@example.com'
+    def test_effective_principals_calls_effective_principals_with_authenticated_userid(self, util, config):
+        config.testing_securitypolicy('acct:rami@example.com')
         request = DummyRequest()
 
         result = self.policy.effective_principals(request)

--- a/h/conftest.py
+++ b/h/conftest.py
@@ -5,7 +5,6 @@ The `conftest` module is automatically loaded by py.test and serves as a place
 to put fixture functions that are useful application-wide.
 """
 
-import collections
 import functools
 import os
 
@@ -120,22 +119,6 @@ def config(request, settings):
 def deform():
     """Allow tests that use deform to find our custom templates."""
     form.init()
-
-
-@pytest.fixture
-def authn_policy(config):
-    from mock import MagicMock
-
-    class DummyAuthorizationPolicy(object):
-        def permits(self, *args, **kwargs):
-            return True
-
-    config.set_authorization_policy(DummyAuthorizationPolicy())
-    policy = MagicMock()
-    policy.authenticated_userid.return_value = None
-    policy.unauthenticated_userid.return_value = None
-    config.set_authentication_policy(policy)
-    return policy
 
 
 @pytest.fixture

--- a/h/features/test/client_test.py
+++ b/h/features/test/client_test.py
@@ -52,15 +52,17 @@ class TestClient(object):
     def test_enabled_false_when_admins_true_normal_request(self, client):
         assert client.enabled('on-for-admins') is False
 
-    def test_enabled_true_when_admins_true_admin_request(self, client, authn_policy):
-        authn_policy.effective_principals.return_value = [role.Admin]
+    def test_enabled_true_when_admins_true_admin_request(self, client, config):
+        config.testing_securitypolicy('acct:foo@example.com',
+                                      groupids=[role.Admin])
         assert client.enabled('on-for-admins') is True
 
     def test_enabled_false_when_staff_true_normal_request(self, client):
         assert client.enabled('on-for-staff') is False
 
-    def test_enabled_true_when_staff_true_staff_request(self, client, authn_policy):
-        authn_policy.effective_principals.return_value = [role.Staff]
+    def test_enabled_true_when_staff_true_staff_request(self, client, config):
+        config.testing_securitypolicy('acct:foo@example.com',
+                                      groupids=[role.Staff])
         assert client.enabled('on-for-staff') is True
 
     def test_call_false_if_everyone_false(self, client):
@@ -88,8 +90,9 @@ class TestClient(object):
 
         fetcher.assert_called_once_with()
 
-    def test_all_returns_feature_dictionary(self, client, authn_policy):
-        authn_policy.effective_principals.return_value = [role.Staff]
+    def test_all_returns_feature_dictionary(self, client, config):
+        config.testing_securitypolicy('acct:foo@example.com',
+                                      groupids=[role.Staff])
 
         result = client.all()
 


### PR DESCRIPTION
Changes the tests that need an authentication policy to use the Pyramid testing_securitypolicy helper, rather than our own homebrew authn_policy fixture.

This simplifies extracting the `h.api` tests to run on their own.