### PR TITLE
Clamp allowable values for "limit" parameter

### DIFF
--- a/h/api/search/query.py
+++ b/h/api/search/query.py
@@ -2,6 +2,9 @@
 from h.api import storage
 from h.api import uri
 
+LIMIT_DEFAULT = 20
+LIMIT_MAX = 200
+
 
 class Builder(object):
 
@@ -71,10 +74,11 @@ def extract_offset(params):
 def extract_limit(params):
     try:
         val = int(params.pop("limit"))
+        val = min(val, LIMIT_MAX)
         if val < 0:
             raise ValueError
     except (ValueError, KeyError):
-        return 20
+        return LIMIT_DEFAULT
     else:
         return val
 

--- a/tests/h/api/search/query_test.py
+++ b/tests/h/api/search/query_test.py
@@ -10,6 +10,7 @@ MISSING = object()
 
 OFFSET_DEFAULT = 0
 LIMIT_DEFAULT = 20
+LIMIT_MAX = 200
 
 
 @pytest.mark.parametrize('offset,from_', [
@@ -54,6 +55,10 @@ def test_builder_offset(offset, from_):
     ("   ",  LIMIT_DEFAULT),
     ("-23",  LIMIT_DEFAULT),
     ("32.7", LIMIT_DEFAULT),
+    # values above the maximum should be clamped to the maximum value
+    (LIMIT_MAX, LIMIT_MAX),
+    (LIMIT_MAX + 1, LIMIT_MAX),
+    (LIMIT_MAX + 1000, LIMIT_MAX),
 ])
 def test_builder_limit(limit, size):
     builder = query.Builder()


### PR DESCRIPTION
We don't want users to be able to specify arbitrarily high values for the "limit" parameter to the search API.

This commit ensures that the value is clamped to 200.

_**N.B.** This PR depends on #3340 and will need rebasing once that is merged._