### PR TITLE
Add options page to extension, allow disabling badge

### DIFF
--- a/h/browser/chrome/lib/hypothesis-chrome-extension.js
+++ b/h/browser/chrome/lib/hypothesis-chrome-extension.js
@@ -41,6 +41,7 @@ var TAB_STATUS_COMPLETE = 'complete';
  */
 function HypothesisChromeExtension(dependencies) {
   var chromeTabs = dependencies.chromeTabs;
+  var chromeStorage = dependencies.chromeStorage;
   var chromeBrowserAction = dependencies.chromeBrowserAction;
   var help  = new HelpPage(chromeTabs, dependencies.extensionURL);
   var store = new TabStore(localStorage);
@@ -162,7 +163,7 @@ function HypothesisChromeExtension(dependencies) {
       annotationCount: 0,
       extensionSidebarInstalled: false,
     });
-    state.updateAnnotationCount(tabId, url);
+    updateAnnotationCountIfEnabled(tabId, url);
   }
 
   // This function will be called multiple times as the tab reloads.
@@ -200,7 +201,7 @@ function HypothesisChromeExtension(dependencies) {
     state.clearTab(removedTabId);
 
     chromeTabs.get(addedTabId, function (tab) {
-      state.updateAnnotationCount(addedTabId, tab.url);
+      updateAnnotationCountIfEnabled(addedTabId, tab.url);
     });
   }
 
@@ -261,6 +262,16 @@ function HypothesisChromeExtension(dependencies) {
         });
       });
     }
+  }
+
+  function updateAnnotationCountIfEnabled(tabId, url) {
+    chromeStorage.sync.get({
+      badge: true,
+    }, function (items) {
+      if (items.badge) {
+        state.updateAnnotationCount(tabId, url);
+      }
+    });
   }
 }
 

--- a/h/browser/chrome/lib/install.js
+++ b/h/browser/chrome/lib/install.js
@@ -5,6 +5,7 @@ var HypothesisChromeExtension = require('./hypothesis-chrome-extension');
 var browserExtension = new HypothesisChromeExtension({
   chromeTabs: chrome.tabs,
   chromeBrowserAction: chrome.browserAction,
+  chromeStorage: chrome.storage,
   extensionURL: function (path) {
     return chrome.extension.getURL(path);
   },

--- a/h/browser/chrome/lib/options.html
+++ b/h/browser/chrome/lib/options.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Hypothesis Extension Settings</title>
+  <style>
+    .hint {
+      font-size: 90%;
+    }
+  </style>
+</head>
+
+<body>
+  <main>
+    <input type="checkbox" id="badge">
+    <label for="badge">Enable extension badge</label>
+    <p class="hint">
+        By default, the extension button displays the number of annotations found
+        on the pages you visit. Disable this if you find the badge distracting or
+        if you do not wish the extension to make requests to the Hypothesis
+        service for this data.
+    </p>
+
+    <script src="options.js"></script>
+  </main>
+</body>
+</html>

--- a/h/browser/chrome/lib/options.js
+++ b/h/browser/chrome/lib/options.js
@@ -1,0 +1,18 @@
+'use strict';
+
+function saveOptions() {
+  chrome.storage.sync.set({
+    badge: document.getElementById('badge').checked,
+  });
+}
+
+function loadOptions() {
+  chrome.storage.sync.get({
+    badge: true,
+  }, function(items) {
+    document.getElementById('badge').checked = items.badge;
+  });
+}
+
+document.addEventListener('DOMContentLoaded', loadOptions);
+document.getElementById('badge').addEventListener('click', saveOptions);

--- a/h/browser/chrome/manifest.json.jinja2
+++ b/h/browser/chrome/manifest.json.jinja2
@@ -31,11 +31,17 @@
   "homepage_url": "https://hypothes.is/",
   "incognito": "split",
 
+  "options_ui": {
+    "page": "lib/options.html",
+    "chrome_style": true
+  },
+
   "offline_enabled": false,
   "permissions": [
     "<all_urls>",
 
     "contentSettings",
+    "storage",
     "tabs"
   ],
   "content_security_policy":

--- a/h/browser/chrome/test/hypothesis-chrome-extension-test.js
+++ b/h/browser/chrome/test/hypothesis-chrome-extension-test.js
@@ -36,6 +36,7 @@ describe('HypothesisChromeExtension', function () {
   var sandbox = sinon.sandbox.create();
   var HypothesisChromeExtension;
   var ext;
+  var fakeChromeStorage;
   var fakeChromeTabs;
   var fakeChromeBrowserAction;
   var fakeErrors;
@@ -47,6 +48,7 @@ describe('HypothesisChromeExtension', function () {
 
   function createExt() {
     return new HypothesisChromeExtension({
+      chromeStorage: fakeChromeStorage,
       chromeTabs: fakeChromeTabs,
       chromeBrowserAction: fakeChromeBrowserAction,
       extensionURL: sandbox.stub(),
@@ -55,6 +57,11 @@ describe('HypothesisChromeExtension', function () {
   }
 
   beforeEach(function () {
+    fakeChromeStorage = {
+      sync: {
+        get: sandbox.stub().callsArgWith(1, {badge: true})
+      }
+    };
     fakeChromeTabs = {
       onCreated: new FakeListener(),
       onUpdated: new FakeListener(),

--- a/h/buildext.py
+++ b/h/buildext.py
@@ -181,6 +181,9 @@ def build_extension(args):
         copyfilelist(src='build/scripts',
                      dst=os.path.join(build_dir, 'lib'),
                      filelist=extension_sources)
+        copyfilelist(src='h/browser/chrome/lib',
+                     dst=os.path.join(build_dir, 'lib'),
+                     filelist=['options.html', 'options.js'])
         copyfilelist(src='build',
                      dst=public_dir,
                      filelist=client_sources)


### PR DESCRIPTION
This is an experimental commit to add an options pane to the Chrome
extension, with the first available option being the ability to disable
the annotation count badge.

The settings are persisted in a dictionary using the `chrome.storage`
API, and used to disable the code responsible for updating the badge
state when a tab changes.