### PR TITLE
Add the FeatureCohort model to h.models

### DIFF
--- a/h/models.py
+++ b/h/models.py
@@ -29,6 +29,7 @@ __all__ = (
 Activation = accounts_models.Activation
 Blocklist = badge_models.Blocklist
 Feature = features_models.Feature
+FeatureCohort = features_models.FeatureCohort
 Group = groups_models.Group
 NipsaUser = nipsa_models.NipsaUser
 Token = auth_models.Token


### PR DESCRIPTION
Following my own doctrine, I've split #3330 in two atomic pull requests. This one just makes the `FeatureCohort` model accessible to the rest of the application, and should be merged in before #3330.