### PR TITLE
Add reindex CLI command

### DIFF
--- a/h/api/search/__init__.py
+++ b/h/api/search/__init__.py
@@ -76,6 +76,14 @@ def includeme(config):
         name='legacy_es',
         reify=True)
 
+    # request.new_es is always a client for the legacy Elasticsearch index,
+    # regardless of whether the 'postgres' feature flag is on.
+    # This should be used to write to the new search index.
+    config.add_request_method(
+        lambda r: _get_client(r.registry.settings),
+        name='new_es',
+        reify=True)
+
     # request.es is a client for either the new or the legacy Elasticsearch
     # index, depending on the 'postgres' feature flaf.
     # This should always be used to read from the search index.

--- a/h/api/search/__init__.py
+++ b/h/api/search/__init__.py
@@ -71,6 +71,7 @@ def includeme(config):
     # request.legacy_es is always a client for the legacy Elasticsearch index,
     # regardless of whether the 'postgres' feature flag is on.
     # This should be used to write to the legacy search index.
+    # TODO: Remove when postgres migration is done
     config.add_request_method(
         lambda r: _legacy_get_client(r.registry.settings),
         name='legacy_es',
@@ -79,6 +80,7 @@ def includeme(config):
     # request.new_es is always a client for the legacy Elasticsearch index,
     # regardless of whether the 'postgres' feature flag is on.
     # This should be used to write to the new search index.
+    # TODO: Remove when postgres migration is done
     config.add_request_method(
         lambda r: _get_client(r.registry.settings),
         name='new_es',

--- a/h/api/search/index.py
+++ b/h/api/search/index.py
@@ -84,6 +84,14 @@ def delete(es, annotation_id):
                       'search index, annotation id: %s', annotation_id)
 
 
+def reindex(session, es, request):
+    indexing = BatchIndexer(session, es, request)
+    indexing.index_all()
+
+    deleting = BatchDeleter(session, es)
+    deleting.delete_all()
+
+
 class BatchIndexer(object):
     """
     A convenience class for reindexing all annotations from the database to

--- a/h/celery.py
+++ b/h/celery.py
@@ -43,7 +43,7 @@ celery.conf.update(
     CELERY_ROUTES={
         'h.indexer.add_annotation': 'indexer',
         'h.indexer.delete_annotation': 'indexer',
-        'h.indexer.reindex': 'indexer',
+        'h.indexer.reindex_annotations': 'indexer',
     },
     CELERY_TASK_SERIALIZER='json',
     CELERY_QUEUES=[

--- a/h/cli/__init__.py
+++ b/h/cli/__init__.py
@@ -19,8 +19,8 @@ SUBCOMMANDS = (
     'h.cli.commands.celery.celery',
     'h.cli.commands.devserver.devserver',
     'h.cli.commands.initdb.initdb',
+    'h.cli.commands.legacy_reindex.legacy_reindex',
     'h.cli.commands.migrate.migrate',
-    'h.cli.commands.reindex.reindex',
 )
 
 

--- a/h/cli/__init__.py
+++ b/h/cli/__init__.py
@@ -21,6 +21,7 @@ SUBCOMMANDS = (
     'h.cli.commands.initdb.initdb',
     'h.cli.commands.legacy_reindex.legacy_reindex',
     'h.cli.commands.migrate.migrate',
+    'h.cli.commands.reindex.reindex',
 )
 
 

--- a/h/cli/commands/legacy_reindex.py
+++ b/h/cli/commands/legacy_reindex.py
@@ -11,7 +11,7 @@ from h.api.search import config
               help='Whether to update the current index alias on completion.')
 @click.argument('target')
 @click.pass_context
-def reindex(ctx, target, update_alias):
+def legacy_reindex(ctx, target, update_alias):
     """
     Reindex the annotations into a new Elasticsearch index.
 

--- a/h/cli/commands/reindex.py
+++ b/h/cli/commands/reindex.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+
+import click
+
+from h.api.search import index
+
+
+@click.command()
+@click.pass_context
+def reindex(ctx):
+    """
+    Reindex all annotations from the PostgreSQL database to the Elasticsearch index.
+    """
+
+    request = ctx.obj['bootstrap']()
+
+    index.reindex(request.db, request.new_es, request)

--- a/h/indexer.py
+++ b/h/indexer.py
@@ -7,13 +7,12 @@ from h.celery import celery
 from h.api import storage
 from h.api.search.index import index
 from h.api.search.index import delete
-from h.api.search.index import BatchIndexer
-from h.api.search.index import BatchDeleter
+from h.api.search.index import reindex
 
 __all__ = (
     'add_annotation',
     'delete_annotation',
-    'reindex',
+    'reindex_annotations',
 )
 
 
@@ -32,15 +31,11 @@ def delete_annotation(id_):
 
 
 @celery.task
-def reindex():
+def reindex_annotations():
     if not celery.request.feature('postgres'):
         return
 
-    indexing = BatchIndexer(celery.request.db, celery.request.es, celery.request)
-    indexing.index_all()
-
-    deleting = BatchDeleter(celery.request.db, celery.request.es)
-    deleting.delete_all()
+    reindex(celery.request.db, celery.request.new_es, celery.request)
 
 
 def subscribe_annotation_event(event):

--- a/tests/h/api/search/index_test.py
+++ b/tests/h/api/search/index_test.py
@@ -111,6 +111,30 @@ class TestDeleteAnnotation:
         return patch('h.api.search.index.log')
 
 
+@pytest.mark.usefixtures('BatchIndexer', 'BatchDeleter')
+class TestReindex(object):
+    def test_it_indexes_all_annotations(self, BatchIndexer):
+        index.reindex(mock.sentinel.session, mock.sentinel.es, mock.sentinel.request)
+
+        BatchIndexer.assert_called_once_with(
+            mock.sentinel.session, mock.sentinel.es, mock.sentinel.request)
+        assert BatchIndexer.return_value.index_all.called
+
+    def test_it_removes_all_deleted_annotations(self, BatchDeleter):
+        index.reindex(mock.sentinel.session, mock.sentinel.es, mock.sentinel.request)
+
+        BatchDeleter.assert_called_once_with(mock.sentinel.session, mock.sentinel.es)
+        assert BatchDeleter.return_value.delete_all.called
+
+    @pytest.fixture
+    def BatchIndexer(self, patch):
+        return patch('h.api.search.index.BatchIndexer')
+
+    @pytest.fixture
+    def BatchDeleter(self, patch):
+        return patch('h.api.search.index.BatchDeleter')
+
+
 class TestBatchIndexer(object):
     def test_index_all(self, indexer, index):
         indexer.index_all()


### PR DESCRIPTION
* Move `h.indexer.reindex` code into `h.api.search.index` (so it can be called from multiple places)
* Rename celery task to `h.indexer.reindex_annotations`
* Rename old reindex task to `legacy_reindex`
* Add new reindex task as `reindex`