### PR TITLE
Add target[scope] when batch indexing an annotation

### DIFF
--- a/h/api/search/index.py
+++ b/h/api/search/index.py
@@ -140,6 +140,7 @@ class BatchIndexer(object):
         # annotations for clients. It is useful in the mean time until we get rid of
         # the legacy ElasticSearch annotation storage.
         data = presenters.AnnotationJSONPresenter(self.request, annotation).asdict()
+        data['target'][0]['scope'] = [annotation.target_uri_normalized]
 
         return (action, data)
 

--- a/tests/h/api/search/index_test.py
+++ b/tests/h/api/search/index_test.py
@@ -164,11 +164,14 @@ class TestBatchIndexer(object):
         streaming_bulk.side_effect = fake_streaming_bulk
 
         indexer.index()
+
+        rendered = presenters.AnnotationJSONPresenter(mock_request, annotation).asdict()
+        rendered['target'][0]['scope'] = [annotation.target_uri_normalized]
         assert results[0] == (
             {'index': {'_type': indexer.es_client.t.annotation,
                        '_index': indexer.es_client.index,
                        '_id': annotation.id}},
-            presenters.AnnotationJSONPresenter(mock_request, annotation).asdict()
+            rendered
         )
 
     def test_index_returns_failed_bulk_actions(self, db_session, streaming_bulk):


### PR DESCRIPTION
We still use this field when searching, but the batch indexer did not set it
the same way we do it for indexing individual annotations. Now we do :tada: