### PR TITLE
Add integration test for anchoring

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -265,7 +265,7 @@ create
               "read": ["group:__world__"],
               "update": ["acct:joebloggs@example.org"],
               "delete": ["acct:joebloggs@example.org"],
-              "admin": ["acct:joebloggs@example.org"],
+              "admin": ["acct:joebloggs@example.org"]
           },
           "document": { ... },
           "target": [ ... ],

--- a/h/static/scripts/annotator/test/integration/anchoring-test.js
+++ b/h/static/scripts/annotator/test/integration/anchoring-test.js
@@ -1,0 +1,128 @@
+// Tests that annotated sections of the page are correctly highlighted when
+// annotations are loaded via the bridge that connects the sidebar app and the
+// annotator guest.
+
+'use strict';
+
+var Annotator = require('annotator');
+
+var unroll = require('../../../test/util').unroll;
+var Guest = require('../../guest');
+
+function quoteSelector(quote) {
+  return {
+    type: 'TextQuoteSelector',
+    exact: quote,
+  };
+}
+
+/** Generate an annotation that matches a text quote in a page. */
+function annotateQuote(quote) {
+  return {
+    target: [{
+      selector: [quoteSelector(quote)],
+    }],
+  };
+}
+
+/**
+ * Return the text of all highlighted phrases in `container`.
+ *
+ * @param {Element} container
+ */
+function highlightedPhrases(container) {
+  return Array.from(container.querySelectorAll('.annotator-hl')).map(function (el) {
+    return el.textContent;
+  });
+}
+
+function simplifyWhitespace(quote) {
+  return quote.replace(/\s+/g, ' ');
+}
+
+function FakeCrossFrame(elem, options) {
+  var waiters = [];
+
+  this.destroy = sinon.stub();
+  this.onConnect = sinon.stub();
+  this.on = sinon.stub();
+  this.options = options;
+
+  this.sync = function () {
+    waiters.forEach(function (waiter) {
+      --waiter.count;
+      if (waiter.count === 0) {
+        waiter.resolve();
+        waiters = waiters.filter(function (w) {
+          return w !== waiter;
+        });
+      }
+    });
+  };
+
+  /** Wait for `count` annotations to be anchored. */
+  this.awaitSync = function (count) {
+    return new Promise(function (resolve) {
+      waiters.push({
+        count: count,
+        resolve: resolve,
+      });
+    });
+  };
+}
+
+describe('anchoring', function () {
+  var guest;
+  var container;
+  var crossFrame;
+
+  before(function () {
+    Annotator.Plugin.CrossFrame = FakeCrossFrame;
+  });
+
+  beforeEach(function () {
+    container = document.createElement('div');
+    container.innerHTML = require('./test-page.html');
+    document.body.appendChild(container);
+    guest = new Guest(container);
+    crossFrame = guest.crossframe;
+  });
+
+  afterEach(function () {
+    guest.destroy();
+    container.parentNode.removeChild(container);
+  });
+
+  unroll('should highlight #tag when annotations are loaded', function (testCase) {
+    var normalize = function (quotes) {
+      return quotes.map(function (q) { return simplifyWhitespace(q); });
+    };
+
+    var annotations = testCase.quotes.map(function (q) {
+      return annotateQuote(q);
+    });
+
+    // Simulate new annotations being loaded via the bridge
+    crossFrame.options.emit('annotationsLoaded', annotations);
+
+    return crossFrame.awaitSync(testCase.quotes.length).then(function () {
+      var assertFn = testCase.expectFail ? assert.notDeepEqual : assert.deepEqual;
+      assertFn(normalize(highlightedPhrases(container)),
+               normalize(testCase.quotes));
+    });
+  }, [{
+    tag: 'a simple quote',
+    quotes: ['This has not been a scientist\'s war'],
+  },{
+    // Known failure with nested annotations that are anchored via quotes
+    // or positions. See https://github.com/hypothesis/h/pull/3313 and
+    // https://github.com/hypothesis/h/issues/3278
+    tag: 'nested quotes',
+    quotes: [
+      'This has not been a scientist\'s war;' +
+        ' it has been a war in which all have had a part',
+      'scientist\'s war',
+    ],
+    expectFail: true,
+  }]);
+});

--- a/h/static/scripts/annotator/test/integration/test-page.html
+++ b/h/static/scripts/annotator/test/integration/test-page.html
@@ -1,0 +1,23 @@
+<h1>As we may think</h1>
+
+<h2>Vannevar Bush</h2>
+
+<p>This has not been a scientist's war; it has been a war in which all have had a
+part. The scientists, burying their old professional competition in the demand
+of a common cause, have shared greatly and learned much. It has been
+exhilarating to work in effective partnership. Now, for many, this appears to be
+approaching an end. What are the scientists to do next?</p>
+
+<p>For the biologists, and particularly for the medical scientists, there can be
+little indecision, for their war has hardly required them to leave the old
+paths. Many indeed have been able to carry on their war research in their
+familiar peacetime laboratories. Their objectives remain much the same.</p>
+
+<p>It is the physicists who have been thrown most violently off stride, who have
+left academic pursuits for the making of strange destructive gadgets, who have
+had to devise new methods for their unanticipated assignments. They have done
+their part on the devices that made it possible to turn back the enemy, have
+worked in combined effort with the physicists of our allies. They have felt
+within themselves the stir of achievement. They have been part of a great team.
+Now, as peace approaches, one asks where they will find objectives worthy of
+their best.</p>


### PR DESCRIPTION
This adds an integration test for anchoring of annotations loaded
into the annotator guest via the sidebar.

This was extracted from https://github.com/hypothesis/h/pull/3313

The test case for nested annotations has been marked as an expected
failure until a better resolution for #3278 has been found.