### PR TITLE
Remove `make lint`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,10 +41,6 @@ dist/h-$(BUILD_ID): dist/h-$(BUILD_ID).tar.gz
 docker: dist/h-$(BUILD_ID)
 	docker build -t hypothesis/hypothesis:$(DOCKER_TAG) $<
 
-.PHONY: lint
-lint: h.egg-info/.uptodate
-	@prospector
-
 .PHONY: test
 test: node_modules/.uptodate
 	@pip install -q tox


### PR DESCRIPTION
Does anyone actually use this? It runs Prospector only, even though our
primary Python linter is now Flake8, and it runs it on the entire
codebase at once (and doesn't accept args to run on individual files).
It doesn't run any of the JavaScript linters that we use either.

It seems simpler just to let people run the linters on the code they're
currently editing using things like text editor plugins,
GitHub-integrated CI tools on pull requests, etc.