### PR TITLE
Selector is not a required property for page notes

### DIFF
--- a/h/api/schemas.py
+++ b/h/api/schemas.py
@@ -138,9 +138,6 @@ class AnnotationSchema(JSONSchema):
                             'selector': {
                             },
                         },
-                        'required': [
-                            'selector',
-                        ],
                     },
                 ],
             },
@@ -218,7 +215,7 @@ class CreateAnnotationSchema(object):
         else:
             new_appstruct['shared'] = False
 
-        if 'target' in appstruct:  # Replies and page notes don't have targets.
+        if 'target' in appstruct:
             new_appstruct['target_selectors'] = _target_selectors(
                 appstruct.pop('target'))
 
@@ -421,7 +418,7 @@ def _target_selectors(targets):
     """
     # Any targets other than the first in the list are discarded.
     # Any fields of the target other than 'selector' are discarded.
-    if targets:
+    if targets and 'selector' in targets[0]:
         return targets[0]['selector']
     else:
         return []

--- a/tests/h/api/schemas_test.py
+++ b/tests/h/api/schemas_test.py
@@ -186,8 +186,6 @@ class TestCreateUpdateAnnotationSchema(object):
 
         ({'target': [False]}, "target.0: False is not of type 'object'"),
 
-        ({'target': [{}]}, "target.0: 'selector' is a required property"),
-
         ({'text': False}, "text: False is not of type 'string'"),
 
         ({'uri': False}, "uri: False is not of type 'string'"),


### PR DESCRIPTION
We need to accept annotation updates where the target has no selectors,
because this is a valid "page note".