### PR TITLE
Re-enable pep257's "missing docstring" messages

### DIFF
--- a/.prospector.yaml
+++ b/.prospector.yaml
@@ -19,6 +19,8 @@ pylint:
   disable:
     - line-too-long  # PEP8 checks this and doesn't complain about
                      # unavoidable long lines (such as URLs).
+    - missing-docstring  # The pep257 tool reports missing docstrings to us
+                         # so we don't need pylint to do so.
     - too-few-public-methods
   options:
     # Some good names that pylint would otherwise reject:
@@ -39,12 +41,6 @@ pylint:
     #       you're shadowing the builtin.
     #
     good-names: _,i,j,k,v,e,db,fn,fp,log,parser,id,es
-pep257:
-  disable:
-    - D100  # Missing docstring in public module
-    - D101  # Missing docstring in public class
-    - D102  # Missing docstring in public method
-    - D103  # Missing docstring in public function
 pyroma:
   run: true
 ignore-paths:


### PR DESCRIPTION
We recently added "All public modules, functions, classes, and methods
should normally have docstrings" to our code style docs, so it seems
like we should have these messages enabled.

This disabling of pep257 missing docstring warnings wasn't actually
working anyway, since pylint's missing-docstring message wasn't
disabled, and since we run both pylint and pep257 at the same time (via
prospector) pylint would still complain about all the same missing
docstrings!

So this commit also disables pylint's missing docstrings warnings. We
run both pylint and pep257 at the same time via prospector, so there's
no point in having them both complain about missing docstrings.