### PR TITLE
Legacy API cleanup

### DIFF
--- a/h/api/schemas.py
+++ b/h/api/schemas.py
@@ -5,7 +5,6 @@ import copy
 import jsonschema
 from jsonschema.exceptions import best_match
 from pyramid import i18n
-from pyramid import security
 
 from h.api import parse_document_claims
 

--- a/h/api/storage.py
+++ b/h/api/storage.py
@@ -43,7 +43,6 @@ def fetch_annotation(request, id_):
     :returns: the annotation, if found, or None.
     :rtype: h.api.models.Annotation, NoneType
     """
-
     try:
         return request.db.query(models.Annotation).get(id_)
     except types.InvalidUUID:

--- a/h/api/views.py
+++ b/h/api/views.py
@@ -188,7 +188,6 @@ def read_jsonld(annotation, request):
             permission='update')
 def update(annotation, request):
     """Update the specified annotation with data from the PUT payload."""
-
     schema = schemas.UpdateAnnotationSchema(request,
                                             annotation.target_uri,
                                             annotation.groupid)

--- a/tests/h/api/storage_test.py
+++ b/tests/h/api/storage_test.py
@@ -368,13 +368,16 @@ class TestUpdateAnnotation(object):
 @pytest.mark.usefixtures('fetch_annotation')
 class TestDeleteAnnotation(object):
 
-    def test_it_fetches_the_annotation(self, fetch_annotation, mock_request):
-        storage.delete_annotation(mock_request, "test_id")
+    def test_it_fetches_the_annotation(self, fetch_annotation, session):
+        request = DummyRequest(db=session)
+        storage.delete_annotation(request, "test_id")
 
-        assert fetch_annotation.call_args_list[0] == mock.call(mock_request,
+        assert fetch_annotation.call_args_list[0] == mock.call(request,
                                                                "test_id")
 
-    def test_it_deletes_the_annotation(self, fetch_annotation, mock_request):
+    def test_it_deletes_the_annotation(self, fetch_annotation, session):
+        request = DummyRequest(db=session)
+
         first_return_value = mock.Mock()
         second_return_value = mock.Mock()
         fetch_annotation.side_effect = [
@@ -382,16 +385,9 @@ class TestDeleteAnnotation(object):
             second_return_value,
         ]
 
-        storage.delete_annotation(mock_request, "test_id")
+        storage.delete_annotation(request, "test_id")
 
-        mock_request.db.delete.assert_called_once_with(first_return_value)
-
-    @pytest.fixture
-    def mock_request(self, session):
-        request = DummyRequest()
-        request.feature = mock.Mock(return_value=True)
-        request.db = session
-        return request
+        request.db.delete.assert_called_once_with(first_return_value)
 
 
 @pytest.fixture

--- a/tests/h/api/views_test.py
+++ b/tests/h/api/views_test.py
@@ -216,7 +216,9 @@ class TestCreate(object):
 
     @pytest.fixture
     def mock_request(self):
-        return mock.Mock()
+        request = testing.DummyRequest(notify_after_commit=mock.Mock())
+        type(request).json_body = mock.PropertyMock(return_value={})
+        return request
 
 
 @pytest.mark.usefixtures('AnnotationJSONPresenter')


### PR DESCRIPTION
These fixes were missing from #3357. Mainly cleaning up the features/mocks in the tests and fixing PEP 257 violations.