### PR TITLE
Only pass db session to storage methods

### DIFF
--- a/h/admin/views/users.py
+++ b/h/admin/views/users.py
@@ -107,7 +107,7 @@ def delete_user(request, user):
     query = _all_user_annotations_query(request, user)
     annotations = es_helpers.scan(client=request.es.conn, query={'query': query})
     for annotation in annotations:
-        storage.delete_annotation(request, annotation['_id'])
+        storage.delete_annotation(request.db, annotation['_id'])
 
     request.db.delete(user)
 

--- a/h/api/resources.py
+++ b/h/api/resources.py
@@ -8,7 +8,7 @@ class AnnotationFactory(object):
         self.request = request
 
     def __getitem__(self, id):
-        annotation = storage.fetch_annotation(self.request, id)
+        annotation = storage.fetch_annotation(self.request.db, id)
         if annotation is None:
             raise KeyError()
         return annotation

--- a/h/api/search/query.py
+++ b/h/api/search/query.py
@@ -174,7 +174,7 @@ class UriFilter(object):
         if uristr is None:
             return None
 
-        uris = storage.expand_uri(self.request, uristr)
+        uris = storage.expand_uri(self.request.db, uristr)
         scopes = [uri.normalize(u) for u in uris]
         return {"terms": {"target.scope": scopes}}
 

--- a/h/api/storage.py
+++ b/h/api/storage.py
@@ -163,7 +163,7 @@ def delete_annotation(request, id_):
     request.db.delete(annotation)
 
 
-def expand_uri(request, uri):
+def expand_uri(session, uri):
     """
     Return all URIs which refer to the same underlying document as `uri`.
 
@@ -171,8 +171,8 @@ def expand_uri(request, uri):
     passed URI, and if so returns the set of all URIs which we currently
     believe refer to the same document.
 
-    :param request: the request object
-    :type request: pyramid.request.Request
+    :param session: the database session
+    :type session: sqlalchemy.orm.session.Session
 
     :param uri: a URI associated with the document
     :type uri: str
@@ -180,7 +180,7 @@ def expand_uri(request, uri):
     :returns: a list of equivalent URIs
     :rtype: list
     """
-    doc = models.Document.find_by_uris(request.db, [uri]).one_or_none()
+    doc = models.Document.find_by_uris(session, [uri]).one_or_none()
 
     if doc is None:
         return [uri]

--- a/h/api/storage.py
+++ b/h/api/storage.py
@@ -30,12 +30,12 @@ def annotation_from_dict(data):
     return models.elastic.Annotation(data)
 
 
-def fetch_annotation(request, id_):
+def fetch_annotation(session, id_):
     """
     Fetch the annotation with the given id.
 
-    :param request: the request object
-    :type request: pyramid.request.Request
+    :param session: the database session
+    :type session: sqlalchemy.orm.session.Session
 
     :param id_: the annotation ID
     :type id_: str
@@ -44,7 +44,7 @@ def fetch_annotation(request, id_):
     :rtype: h.api.models.Annotation, NoneType
     """
     try:
-        return request.db.query(models.Annotation).get(id_)
+        return session.query(models.Annotation).get(id_)
     except types.InvalidUUID:
         return None
 
@@ -69,7 +69,7 @@ def create_annotation(request, data):
     # Replies must have the same group as their parent.
     if data['references']:
         top_level_annotation_id = data['references'][0]
-        top_level_annotation = fetch_annotation(request,
+        top_level_annotation = fetch_annotation(request.db,
                                                 top_level_annotation_id)
         if top_level_annotation:
             data['groupid'] = top_level_annotation.groupid

--- a/h/api/storage.py
+++ b/h/api/storage.py
@@ -149,17 +149,17 @@ def update_annotation(session, id_, data):
     return annotation
 
 
-def delete_annotation(request, id_):
+def delete_annotation(session, id_):
     """
     Delete the annotation with the given id.
 
-    :param request: the request object
-    :type request: pyramid.request.Request
+    :param session: the database session
+    :type session: sqlalchemy.orm.session.Session
 
     :param id_: the annotation ID
     :type id_: str
     """
-    request.db.query(models.Annotation).filter_by(id=id_).delete()
+    session.query(models.Annotation).filter_by(id=id_).delete()
 
 
 def expand_uri(session, uri):

--- a/h/api/storage.py
+++ b/h/api/storage.py
@@ -159,8 +159,7 @@ def delete_annotation(request, id_):
     :param id_: the annotation ID
     :type id_: str
     """
-    annotation = fetch_annotation(request, id_)
-    request.db.delete(annotation)
+    request.db.query(models.Annotation).filter_by(id=id_).delete()
 
 
 def expand_uri(session, uri):

--- a/h/api/views.py
+++ b/h/api/views.py
@@ -210,7 +210,7 @@ def update(annotation, request):
             permission='delete')
 def delete(annotation, request):
     """Delete the specified annotation."""
-    storage.delete_annotation(request, annotation.id)
+    storage.delete_annotation(request.db, annotation.id)
 
     # N.B. We publish the original model (including all the original annotation
     # fields) so that queue subscribers have context needed to decide how to

--- a/h/indexer.py
+++ b/h/indexer.py
@@ -21,7 +21,7 @@ log = logging.getLogger(__name__)
 
 @celery.task
 def add_annotation(id_):
-    annotation = storage.fetch_annotation(celery.request, id_)
+    annotation = storage.fetch_annotation(celery.request.db, id_)
     index(celery.request.es, annotation, celery.request)
 
 

--- a/h/notification/reply.py
+++ b/h/notification/reply.py
@@ -68,7 +68,7 @@ def get_notification(request, annotation, action):
     # Now we know we're dealing with a reply
     reply = annotation
 
-    parent = storage.fetch_annotation(request, parent_id)
+    parent = storage.fetch_annotation(request.db, parent_id)
     if parent is None:
         return
 

--- a/h/streamer/websocket.py
+++ b/h/streamer/websocket.py
@@ -87,10 +87,10 @@ def handle_message(message):
 def _expand_clauses(request, payload):
     for clause in payload['clauses']:
         if clause['field'] == '/uri':
-            _expand_uris(request, clause)
+            _expand_uris(request.db, clause)
 
 
-def _expand_uris(request, clause):
+def _expand_uris(session, clause):
     uris = clause['value']
     expanded = set()
 
@@ -98,6 +98,6 @@ def _expand_uris(request, clause):
         uris = [uris]
 
     for item in uris:
-        expanded.update(storage.expand_uri(request, item))
+        expanded.update(storage.expand_uri(session, item))
 
     clause['value'] = list(expanded)

--- a/h/subscribers.py
+++ b/h/subscribers.py
@@ -50,7 +50,7 @@ def send_reply_notifications(event,
                              send=mailer.send.delay):
     """Queue any reply notification emails triggered by an annotation event."""
     request = event.request
-    annotation = storage.fetch_annotation(event.request, event.annotation_id)
+    annotation = storage.fetch_annotation(event.request.db, event.annotation_id)
     action = event.action
     try:
         notification = get_notification(request, annotation, action)

--- a/tests/h/admin/views/users_test.py
+++ b/tests/h/admin/views/users_test.py
@@ -296,8 +296,8 @@ def test_delete_user_deletes_annotations(elasticsearch_helpers, api_storage):
     views.delete_user(request, user)
 
     assert api_storage.delete_annotation.mock_calls == [
-        call(request, 'annotation-1'),
-        call(request, 'annotation-2')
+        call(request.db, 'annotation-1'),
+        call(request.db, 'annotation-2')
     ]
 
 

--- a/tests/h/api/resources_test.py
+++ b/tests/h/api/resources_test.py
@@ -8,28 +8,29 @@ from h.api.resources import AnnotationFactory
 
 
 class TestAnnotationFactory(object):
-    def test_get_item_fetches_annotation(self, storage):
-        request = DummyRequest()
-        factory = AnnotationFactory(request)
+    def test_get_item_fetches_annotation(self, storage, mock_request):
+        factory = AnnotationFactory(mock_request)
 
         factory['123']
-        storage.fetch_annotation.assert_called_once_with(request, '123')
+        storage.fetch_annotation.assert_called_once_with(mock_request.db, '123')
 
-    def test_get_item_returns_annotation(self, storage):
-        request = DummyRequest()
-        factory = AnnotationFactory(request)
+    def test_get_item_returns_annotation(self, storage, mock_request):
+        factory = AnnotationFactory(mock_request)
         storage.fetch_annotation.return_value = Mock()
 
         annotation = factory['123']
         assert annotation == storage.fetch_annotation.return_value
 
-    def test_get_item_raises_when_annotation_is_not_found(self, storage):
-        request = DummyRequest()
-        factory = AnnotationFactory(request)
+    def test_get_item_raises_when_annotation_is_not_found(self, storage, mock_request):
+        factory = AnnotationFactory(mock_request)
         storage.fetch_annotation.return_value = None
 
         with pytest.raises(KeyError):
             factory['123']
+
+    @pytest.fixture
+    def mock_request(self):
+        return DummyRequest(db=Mock())
 
     @pytest.fixture
     def storage(self, patch):

--- a/tests/h/api/search/query_test.py
+++ b/tests/h/api/search/query_test.py
@@ -314,7 +314,7 @@ def test_urifilter_expands_and_normalizes_into_terms_filter(storage, uri):
 
     result = urifilter({"uri": "http://example.com/"})
 
-    storage.expand_uri.assert_called_with(request, "http://example.com/")
+    storage.expand_uri.assert_called_with(request.db, "http://example.com/")
 
     assert result == {"terms":
         {"target.scope": ["http://giraffes.com", "https://elephants.com"]}

--- a/tests/h/api/storage_test.py
+++ b/tests/h/api/storage_test.py
@@ -362,14 +362,12 @@ class TestUpdateAnnotation(object):
 class TestDeleteAnnotation(object):
 
     def test_it_deletes_the_annotation(self, db_session):
-        request = DummyRequest(db=db_session)
-
         ann_1 = Annotation(userid='luke')
         ann_2 = Annotation(userid='leia')
         db_session.add_all([ann_1, ann_2])
         db_session.flush()
 
-        storage.delete_annotation(request, ann_1.id)
+        storage.delete_annotation(db_session, ann_1.id)
         db_session.commit()
 
         assert db_session.query(Annotation).get(ann_1.id) is None

--- a/tests/h/api/storage_test.py
+++ b/tests/h/api/storage_test.py
@@ -35,14 +35,10 @@ class TestFetchAnnotation(object):
 class TestExpandURI(object):
 
     def test_expand_uri_no_document(self, db_session):
-        request = DummyRequest(db=db_session)
-
-        actual = storage.expand_uri(request, 'http://example.com/')
+        actual = storage.expand_uri(db_session, 'http://example.com/')
         assert actual == ['http://example.com/']
 
     def test_expand_uri_document_doesnt_expand_canonical_uris(self, db_session):
-        request = DummyRequest(db=db_session)
-
         document = Document(document_uris=[
             DocumentURI(uri='http://foo.com/', claimant='http://example.com'),
             DocumentURI(uri='http://bar.com/', claimant='http://example.com'),
@@ -52,12 +48,10 @@ class TestExpandURI(object):
         db_session.add(document)
         db_session.flush()
 
-        assert storage.expand_uri(request, "http://example.com/") == [
+        assert storage.expand_uri(db_session, "http://example.com/") == [
             "http://example.com/"]
 
     def test_expand_uri_document_uris(self, db_session):
-        request = DummyRequest(db=db_session)
-
         document = Document(document_uris=[
             DocumentURI(uri='http://foo.com/', claimant='http://bar.com'),
             DocumentURI(uri='http://bar.com/', claimant='http://bar.com'),
@@ -65,7 +59,7 @@ class TestExpandURI(object):
         db_session.add(document)
         db_session.flush()
 
-        assert storage.expand_uri(request, 'http://foo.com/') == [
+        assert storage.expand_uri(db_session, 'http://foo.com/') == [
             'http://foo.com/',
             'http://bar.com/'
         ]

--- a/tests/h/api/storage_test.py
+++ b/tests/h/api/storage_test.py
@@ -17,19 +17,15 @@ from h.api.models.document import Document, DocumentURI
 class TestFetchAnnotation(object):
 
     def test_it_fetches_and_returns_the_annotation(self, db_session):
-        request = DummyRequest(db=db_session)
-
         annotation = Annotation(userid='luke')
         db_session.add(annotation)
         db_session.flush()
 
-        actual = storage.fetch_annotation(request, annotation.id)
+        actual = storage.fetch_annotation(db_session, annotation.id)
         assert annotation == actual
 
     def test_it_does_not_crash_if_id_is_invalid(self, db_session):
-        request = DummyRequest(db=db_session)
-
-        assert storage.fetch_annotation(request, 'foo') is None
+        assert storage.fetch_annotation(db_session, 'foo') is None
 
 
 class TestExpandURI(object):
@@ -87,7 +83,7 @@ class TestCreateAnnotation(object):
 
         storage.create_annotation(request, data)
 
-        fetch_annotation.assert_called_once_with(request,
+        fetch_annotation.assert_called_once_with(request.db,
                                                  'parent_annotation_id')
 
     def test_it_sets_group_for_replies(self,

--- a/tests/h/api/storage_test.py
+++ b/tests/h/api/storage_test.py
@@ -359,29 +359,21 @@ class TestUpdateAnnotation(object):
         }
 
 
-@pytest.mark.usefixtures('fetch_annotation')
 class TestDeleteAnnotation(object):
 
-    def test_it_fetches_the_annotation(self, fetch_annotation, session):
-        request = DummyRequest(db=session)
-        storage.delete_annotation(request, "test_id")
+    def test_it_deletes_the_annotation(self, db_session):
+        request = DummyRequest(db=db_session)
 
-        assert fetch_annotation.call_args_list[0] == mock.call(request,
-                                                               "test_id")
+        ann_1 = Annotation(userid='luke')
+        ann_2 = Annotation(userid='leia')
+        db_session.add_all([ann_1, ann_2])
+        db_session.flush()
 
-    def test_it_deletes_the_annotation(self, fetch_annotation, session):
-        request = DummyRequest(db=session)
+        storage.delete_annotation(request, ann_1.id)
+        db_session.commit()
 
-        first_return_value = mock.Mock()
-        second_return_value = mock.Mock()
-        fetch_annotation.side_effect = [
-            first_return_value,
-            second_return_value,
-        ]
-
-        storage.delete_annotation(request, "test_id")
-
-        request.db.delete.assert_called_once_with(first_return_value)
+        assert db_session.query(Annotation).get(ann_1.id) is None
+        assert db_session.query(Annotation).get(ann_2.id) == ann_2
 
 
 @pytest.fixture

--- a/tests/h/api/views_test.py
+++ b/tests/h/api/views_test.py
@@ -390,7 +390,7 @@ class TestDelete(object):
 
         views.delete(annotation, request)
 
-        storage.delete_annotation.assert_called_once_with(request,
+        storage.delete_annotation.assert_called_once_with(request.db,
                                                           annotation.id)
 
     def test_it_inits_and_fires_an_AnnotationEvent(self,

--- a/tests/h/indexer_test.py
+++ b/tests/h/indexer_test.py
@@ -16,7 +16,7 @@ class TestAddAnnotation(object):
 
         indexer.add_annotation(id_)
 
-        fetch_annotation.assert_called_once_with(celery.request, id_)
+        fetch_annotation.assert_called_once_with(celery.request.db, id_)
 
     def test_it_calls_index_with_annotation(self, fetch_annotation, index, celery):
         id_ = 'test-annotation-id'

--- a/tests/h/subscribers_test.py
+++ b/tests/h/subscribers_test.py
@@ -80,13 +80,14 @@ class TestSendReplyNotifications(object):
         event = AnnotationEvent(mock.sentinel.request,
                                 {'id': mock.sentinel.annotation_id},
                                 mock.sentinel.action)
+        mock.sentinel.request.db = mock.Mock()
 
         subscribers.send_reply_notifications(event,
                                              get_notification=get_notification,
                                              generate_mail=generate_mail,
                                              send=send)
 
-        fetch_annotation.assert_called_once_with(mock.sentinel.request,
+        fetch_annotation.assert_called_once_with(mock.sentinel.request.db,
                                                  mock.sentinel.annotation_id)
 
         get_notification.assert_called_once_with(mock.sentinel.request,
@@ -100,6 +101,7 @@ class TestSendReplyNotifications(object):
         generate_mail = mock.Mock(spec_set=[])
         generate_mail.return_value = (['foo@example.com'], 'Your email', 'Text body', 'HTML body')
         event = AnnotationEvent(s.request, None, None)
+        s.request.db = mock.Mock()
 
         subscribers.send_reply_notifications(event,
                                              get_notification=get_notification,
@@ -113,7 +115,7 @@ class TestSendReplyNotifications(object):
         send = FakeMailer()
         get_notification = mock.Mock(spec_set=[], side_effect=RuntimeError('asplode!'))
         generate_mail = mock.Mock(spec_set=[], return_value=[])
-        request = testing.DummyRequest(sentry=mock.Mock(), debug=False)
+        request = testing.DummyRequest(sentry=mock.Mock(), db=mock.Mock(), debug=False)
         event = AnnotationEvent(request, None, None)
 
         subscribers.send_reply_notifications(event,
@@ -127,7 +129,7 @@ class TestSendReplyNotifications(object):
         send = FakeMailer()
         get_notification = mock.Mock(spec_set=[], side_effect=RuntimeError('asplode!'))
         generate_mail = mock.Mock(spec_set=[], return_value=[])
-        request = testing.DummyRequest(sentry=mock.Mock(), debug=True)
+        request = testing.DummyRequest(sentry=mock.Mock(), db=mock.Mock(), debug=True)
         event = AnnotationEvent(request, None, None)
 
         with pytest.raises(RuntimeError):


### PR DESCRIPTION
Where appropriate. This will make the change for the streamer ([Trello card](https://trello.com/c/lAAVJYKS/350-postgres-cleanup-realtime-streamer-improvement)) easier.

This touches quite a bit of code. Here's a list of what I tested manually:

* Search in stream / badge endpoint
* streamer create/update/delete
* Deleting a user (and check that annotations get deleted)
* Annotation page (`/a/:id`)
* Reply notification emails (in the console)