### PR TITLE
Remove docs about redirecting docs pages

### DIFF
--- a/docs/developing/documentation.rst
+++ b/docs/developing/documentation.rst
@@ -15,18 +15,3 @@ web server in the newly generated ``_build/dirhtml`` directory. For example:
 .. code-block:: bash
 
    cd _build/dirhtml; python -m SimpleHTTPServer; cd -
-
-
-Moving pages around in the docs
--------------------------------
-
-Be sure to create a Read the Docs `Page Redirect <http://docs.readthedocs.io/en/latest/user-defined-redirects.html#page-redirects>`_ if you move or rename a
-page or section in the docs (changing the actual URL that the page(s) get
-rendered to, not just reordering them in the table of contents).
-
-These page redirects are setup at https://readthedocs.org/dashboard/h/redirects/
-rather than in the Sphinx config file (you'll need a Read the Docs account with
-admin permissions for the h project).
-
-Page redirects should be created *after* your docs reorganization has been
-merged into master.


### PR DESCRIPTION
The Read the Docs UI for maintaining redirects is terrible.
You can't see which redirect is which when you want to remove redirects.
And there is apparently no way to tell it to redirect for only a
specific named version of the docs such as "latest", so either you break
links for old (but valid) docs.