### PR TITLE
Send up to 200 replies per search request

### DIFF
--- a/h/api/search/core.py
+++ b/h/api/search/core.py
@@ -57,7 +57,7 @@ def search(request, params, private=True, separate_replies=False):
             [h['_id'] for h in results['hits']['hits']]))
         reply_results = es.conn.search(index=es.index,
                                        doc_type=es.t.annotation,
-                                       body=builder.build({'limit': 100}))
+                                       body=builder.build({'limit': 200}))
 
         if len(reply_results['hits']['hits']) < reply_results['hits']['total']:
             log.warn("The number of reply annotations exceeded the page size "


### PR DESCRIPTION
Increase the upper limit on the number of reply annotations sent in a
single search request response with _separate_replies is True from 100
to 200.

This reduces the number of "Message not available" annotation cards seen
in the browser in place of reply annotations, on pages that have a lot
of replies.

Fixes #3251