### PR TITLE
Make "/app" endpoints relative to serviceUrl

### DIFF
--- a/h/static/scripts/session.js
+++ b/h/static/scripts/session.js
@@ -56,7 +56,7 @@ function session($http, $resource, $rootScope, flash, raven, settings) {
     transformResponse: process,
     withCredentials: true
   });
-  var endpoint = new URL('/app/:path', settings.serviceUrl).href;
+  var endpoint = new URL('app/:path', settings.serviceUrl).href;
   var resource = $resource(endpoint, {}, actions);
 
   // Blank initial model state

--- a/h/static/scripts/test/session-test.js
+++ b/h/static/scripts/test/session-test.js
@@ -30,7 +30,7 @@ describe('h:session', function () {
     };
 
     $provide.value('settings', {
-      serviceUrl: 'https://test.hypothes.is',
+      serviceUrl: 'https://test.hypothes.is/root/',
     });
     $provide.value('flash', fakeFlash);
     $provide.value('raven', fakeRaven);
@@ -52,7 +52,7 @@ describe('h:session', function () {
   // There's little point testing every single route here, as they're
   // declarative and ultimately we'd be testing ngResource.
   describe('#login()', function () {
-    var url = 'https://test.hypothes.is/app?__formid__=login';
+    var url = 'https://test.hypothes.is/root/app?__formid__=login';
 
     it('should send an HTTP POST to the action', function () {
       $httpBackend.expectPOST(url, {code: 123}).respond({});
@@ -131,7 +131,7 @@ describe('h:session', function () {
   });
 
   describe('#load()', function () {
-    var url = 'https://test.hypothes.is/app';
+    var url = 'https://test.hypothes.is/root/app';
 
     it('should fetch the session data', function () {
       $httpBackend.expectGET(url).respond({});
@@ -238,7 +238,7 @@ describe('h:session', function () {
   });
 
   describe('#dismiss_sidebar_tutorial()', function () {
-    var url = 'https://test.hypothes.is/app/dismiss_sidebar_tutorial';
+    var url = 'https://test.hypothes.is/root/app/dismiss_sidebar_tutorial';
     it('disables the tutorial for the user', function () {
       $httpBackend.expectPOST(url).respond({});
       session.dismiss_sidebar_tutorial();


### PR DESCRIPTION
As reported by Donny Donovan from EJP, requests to "/app*" related endpoints weren't correctly being constructed relative to the configured "serviceUrl", which makes the client less portable.

This change removes a leading slash from the path supplied to the URL constructor, ensuring that if "serviceUrl" is not at the root of a domain, the "/app*" paths will still be correctly constructed.