### PR TITLE
Prepare the direct_linking feature flag for removal

### DIFF
--- a/h/features/models.py
+++ b/h/features/models.py
@@ -12,7 +12,6 @@ from h.db import mixins
 log = logging.getLogger(__name__)
 
 FEATURES = {
-    'direct_linking': "Generate direct links to annotations in context in the client?",
     'new_homepage': "Show the new homepage design?",
 }
 
@@ -36,6 +35,7 @@ FEATURES = {
 #
 FEATURES_PENDING_REMOVAL = {
     'claim': "Enable 'claim your username' web views?",
+    'direct_linking': "Generate direct links to annotations in context in the client?",
     'ops_disable_streamer_uri_equivalence': "[Ops] Disable streamer URI equivalence support?",
     'postgres': 'Read/write annotation and document data from/to postgres',
 }

--- a/h/links.py
+++ b/h/links.py
@@ -16,7 +16,7 @@ def html_link(request, annotation):
 def incontext_link(request, annotation):
     """Generate a link to an annotation on the page where it was made."""
     is_reply = bool(annotation.references)
-    if not request.feature('direct_linking') or is_reply:
+    if is_reply:
         return None
 
     bouncer_url = request.registry.settings.get('h.bouncer_url')

--- a/h/static/styles/annotation.scss
+++ b/h/static/styles/annotation.scss
@@ -232,24 +232,8 @@ $annotation-card-left-padding: 10px;
   }
 }
 
-.share-dialog-wrapper {
+.annotation-share-dialog-wrapper {
   position: relative;
-
-  &.open .share-dialog--actions {
-    display: block;
-  }
-}
-
-.share-dialog--actions {
-  padding: 3px;
-  width: inherit;
-}
-
-.share-dialog__link {
-  padding: 0;
-  width: 220px;
-  border: none;
-  color: $text-color;
 }
 
 // the actions for publishing annotations and reverting changes

--- a/h/templates/client/annotation.html
+++ b/h/templates/client/annotation.html
@@ -174,23 +174,7 @@
         h-tooltip>
         <i class="h-icon-annotation-reply btn-icon "></i>
       </button>
-      <span class="share-dialog-wrapper" ng-if="!vm.feature('direct_linking')">
-        <button class="btn btn-clean annotation-action-btn"
-          ng-click="vm.showShareDialog = !vm.showShareDialog"
-          aria-label="Link"
-          h-tooltip>
-          <i class="h-icon-link btn-icon "></i>
-        </button>
-        <span class="share-dialog share-dialog--actions" ng-click="$event.stopPropagation()">
-          <a target="_blank"
-            class="h-icon-link"
-            ng-href="{{vm.annotationURI}}"
-            title="Open in new tab">
-          </a>
-          <input class="share-dialog__link" type="text" value="{{vm.annotationURI}}" readonly>
-        </span>
-      </span>
-      <span class="share-dialog-wrapper" ng-if="vm.feature('direct_linking')">
+      <span class="share-dialog-wrapper">
         <button class="btn btn-clean annotation-action-btn"
           ng-click="vm.showShareDialog = true"
           aria-label="Share"

--- a/h/templates/client/annotation.html
+++ b/h/templates/client/annotation.html
@@ -174,7 +174,7 @@
         h-tooltip>
         <i class="h-icon-annotation-reply btn-icon "></i>
       </button>
-      <span class="share-dialog-wrapper">
+      <span class="annotation-share-dialog-wrapper">
         <button class="btn btn-clean annotation-action-btn"
           ng-click="vm.showShareDialog = true"
           aria-label="Share"

--- a/tests/h/links_test.py
+++ b/tests/h/links_test.py
@@ -50,8 +50,6 @@ def test_incontext_link_appends_schemaless_uri_if_present(api_request,
 
 @pytest.fixture
 def api_request():
-    def feature(name):
-        return name == 'direct_linking'
-    request = DummyRequest(feature=feature)
+    request = DummyRequest()
     request.registry.settings = {'h.bouncer_url': 'https://hyp.is'}
     return request


### PR DESCRIPTION
This is now deployed and enabled for everyone so we can remove the flag.