### PR TITLE
Ensure newest annotations get reindexed first

### DIFF
--- a/h/api/search/index.py
+++ b/h/api/search/index.py
@@ -160,11 +160,11 @@ class BatchIndexer(object):
 
         updated = self.session.query(models.Annotation.updated). \
                 execution_options(stream_results=True). \
-                order_by(models.Annotation.updated.asc()).all()
+                order_by(models.Annotation.updated.desc()).all()
 
         count = len(updated)
-        windows = [Window(start=updated[x].updated,
-                          end=updated[min(x+chunksize, count)-1].updated)
+        windows = [Window(start=updated[min(x+chunksize, count)-1].updated,
+                          end=updated[x].updated)
                    for x in xrange(0, count, chunksize)]
         basequery = self._eager_loaded_query().order_by(models.Annotation.updated.asc())
 


### PR DESCRIPTION
Users are more likely to notice syncing issues with their latest annotations
rather than the old ones.
This basically just adds a `ORDER BY updated desc` at the end of the query and
shuffles the calculation of the time windows around so that the start of a window
is always before the end of the window.