### PR TITLE
Fix client on pages that define a variable called `global`

### DIFF
--- a/scripts/gulp/create-bundle.js
+++ b/scripts/gulp/create-bundle.js
@@ -86,7 +86,18 @@ module.exports = function createBundle(config, buildOpts) {
       'querystring',
     ],
     insertGlobalVars: {
+      // The Browserify polyfill for the `Buffer` global is large and
+      // unnecessary, but can get pulled into the bundle by modules that can
+      // optionally use it if present.
       Buffer: undefined,
+      // Override the default stub for the `global` var which defaults to
+      // the `global`, `self` and `window` globals in that order.
+      //
+      // This can break on web pages which provide their own definition of
+      // `global`. See https://github.com/hypothesis/h/issues/2723
+      global: function () {
+        return 'typeof self !== "undefined" ? self : window';
+      },
     },
   };
 


### PR DESCRIPTION
Modules which assume the existence of a global variable called "global"
(which exists in Node) are wrapped by Browserify during the build which
normally results in "global" being aliased to "self" or "window" in a
browser environment.

If code on the page into which H is loaded defines a global variable
called "global" however, that gets used instead and this can break such
modules. In the case of https://www.civilsprep.com, "global" is a
reference to a DOM node for example.

This commit fixes the issue by only aliasing "global" (as seen by the
module using it) to either "window" or "self" and not to any existing
variable called "global".

Fixes #2723