### PR TITLE
URL encode share links

### DIFF
--- a/h/static/scripts/app.js
+++ b/h/static/scripts/app.js
@@ -187,6 +187,7 @@ module.exports = angular.module('h', [
   .value('raven', require('./raven'))
   .value('settings', settings)
   .value('time', require('./time'))
+  .value('urlEncodeFilter', require('./filter/url').encode)
 
   .config(configureHttp)
   .config(configureLocation)

--- a/h/static/scripts/directive/test/annotation-share-dialog-test.js
+++ b/h/static/scripts/directive/test/annotation-share-dialog-test.js
@@ -14,7 +14,8 @@ describe('annotationShareDialog', function () {
   before(function () {
     angular.module('app', [])
       .directive('annotationShareDialog',
-        require('../annotation-share-dialog'));
+        require('../annotation-share-dialog'))
+      .value('urlEncodeFilter', function (val) { return val; });
   });
 
   beforeEach(function () {

--- a/h/static/scripts/directive/test/share-dialog-test.js
+++ b/h/static/scripts/directive/test/share-dialog-test.js
@@ -12,7 +12,8 @@ describe('shareDialog', function () {
 
     angular.module('h', [])
       .directive('shareDialog', require('../share-dialog'))
-      .value('crossframe', fakeCrossFrame);
+      .value('crossframe', fakeCrossFrame)
+      .value('urlEncodeFilter', function (val) { return val; });
     angular.mock.module('h');
   });
 

--- a/h/static/scripts/filter/test/url-test.js
+++ b/h/static/scripts/filter/test/url-test.js
@@ -1,0 +1,17 @@
+'use strict';
+
+var url = require('../url');
+
+describe('url.encode', function () {
+  it('urlencodes its input', function () {
+    var expect = 'http%3A%2F%2Ffoo.com%2Fhello%20there.pdf';
+    var result = url.encode('http://foo.com/hello there.pdf');
+
+    assert.equal(result, expect);
+  });
+
+  it('returns the empty string for null values', function () {
+    assert.equal(url.encode(null), '');
+    assert.equal(url.encode(undefined), '');
+  });
+});

--- a/h/static/scripts/filter/url.js
+++ b/h/static/scripts/filter/url.js
@@ -1,0 +1,15 @@
+'use strict';
+
+/**
+ * URL encode a string, dealing appropriately with null values.
+ */
+function encode(str) {
+  if (str) {
+    return window.encodeURIComponent(str);
+  }
+  return '';
+}
+
+module.exports = {
+  encode: encode,
+};

--- a/h/templates/client/annotation_share_dialog.html
+++ b/h/templates/client/annotation_share_dialog.html
@@ -1,15 +1,15 @@
 <div class="annotation-share-dialog" ng-class="{'is-open': vm.isOpen}">
   <div class="annotation-share-dialog-target">
     <span class="annotation-share-dialog-target__label">Share:</span>
-    <a href="https://twitter.com/intent/tweet?url={{vm.uri}}"
+    <a href="https://twitter.com/intent/tweet?url={{vm.uri | urlEncode}}"
       target="_blank"
       title="Tweet link"
       class="annotation-share-dialog-target__icon h-icon-twitter"></a>
-    <a href="https://www.facebook.com/sharer/sharer.php?u={{vm.uri}}"
+    <a href="https://www.facebook.com/sharer/sharer.php?u={{vm.uri | urlEncode}}"
       target="_blank"
       title="Share on Facebook"
       class="annotation-share-dialog-target__icon h-icon-facebook"></a>
-    <a href="https://plus.google.com/share?url={{vm.uri}}"
+    <a href="https://plus.google.com/share?url={{vm.uri | urlEncode}}"
       target="_blank"
       title="Post on Google Plus"
       class="annotation-share-dialog-target__icon h-icon-google-plus"></a>

--- a/h/templates/client/share_dialog.html
+++ b/h/templates/client/share_dialog.html
@@ -14,15 +14,15 @@
           ng-value="vm.viaPageLink"
           readonly /></p>
       <p class="share-link-icons">
-      <a href="https://twitter.com/intent/tweet?url={{vm.viaPageLink}}"
+      <a href="https://twitter.com/intent/tweet?url={{vm.viaPageLink | urlEncode}}"
          target="_blank"
          title="Tweet link"
          class="share-link-icon h-icon-twitter"></a>
-      <a href="https://www.facebook.com/sharer/sharer.php?u={{vm.viaPageLink}}"
+      <a href="https://www.facebook.com/sharer/sharer.php?u={{vm.viaPageLink | urlEncode}}"
          target="_blank"
          title="Share on Facebook"
          class="share-link-icon h-icon-facebook"></a>
-      <a href="https://plus.google.com/share?url={{vm.viaPageLink}}"
+      <a href="https://plus.google.com/share?url={{vm.viaPageLink | urlEncode}}"
          target="_blank"
          title="Post on Google Plus"
          class="share-link-icon h-icon-google-plus"></a>

--- a/h/templates/groups/share.html.jinja2
+++ b/h/templates/groups/share.html.jinja2
@@ -54,15 +54,15 @@
         <p class="group-form-footer__heading">Invite</p>
         Invite anyone to join the group using the link below:
         <input class="share-link-field" value="{{ group_url }}">
-        <a href="//twitter.com/intent/tweet?url={{ group_url }}"
+        <a href="//twitter.com/intent/tweet?url={{ group_url | urlencode }}"
            target="_blank"
            title="Tweet link"
            class="share-link-icon h-icon-twitter"></a>
-        <a href="//www.facebook.com/sharer/sharer.php?u={{ group_url }}"
+        <a href="//www.facebook.com/sharer/sharer.php?u={{ group_url | urlencode }}"
            target="_blank"
            title="Share on Facebook"
            class="share-link-icon h-icon-facebook"></a>
-        <a href="//plus.google.com/share?url={{ group_url }}"
+        <a href="//plus.google.com/share?url={{ group_url | urlencode }}"
            target="_blank"
            title="Post on Google Plus"
            class="share-link-icon h-icon-google-plus"></a>


### PR DESCRIPTION
The URL query parameter in links to sharing services needs to be URL encoded in order to guarantee that the receiving services can correctly parse the URL. Sending an incorrectly-encoded URL such as

    http://example.com/hello world.pdf

can result in the parameter being ignored (by, [for example][1], the Twitter intent endpoint).

This PR adds a "urlEncode" filter to the client application and uses that in the templates for the annotation share dialog and the page share dialog. It also makes a similar change to the server-side templates for the groups page using Jinja2's built-in urlencode filter.

[1]: https://twitter.com/intent/tweet?url=http://example.com/hello%20world.pdf