### PR TITLE
Use the "HTML" link for the annotation timestamp

### DIFF
--- a/h/static/scripts/directive/annotation.js
+++ b/h/static/scripts/directive/annotation.js
@@ -120,11 +120,13 @@ function updateViewModel($scope, time, domainModel,
   };
 
   if (domainModel.links) {
-    vm.annotationURI = domainModel.links.incontext ||
+    vm.linkInContext = domainModel.links.incontext ||
                        domainModel.links.html ||
                        '';
+    vm.linkHTML = domainModel.links.html || '';
   } else {
-    vm.annotationURI = '';
+    vm.linkInContext = '';
+    vm.linkHTML = '';
   }
 
   vm.isPrivate = permissions.isPrivate(

--- a/h/static/scripts/directive/test/annotation-test.js
+++ b/h/static/scripts/directive/test/annotation-test.js
@@ -1424,30 +1424,54 @@ describe('annotation', function() {
       });
     });
 
-    describe('annotation metadata', function () {
-      function findLink(directive) {
-        var links = directive.element[0]
-          .querySelectorAll('header .annotation-header__timestamp');
-        return links[links.length-1];
-      }
-
-      it('displays HTML links when in-context links are not available', function () {
-        var annotation = Object.assign({}, fixtures.defaultAnnotation(), {
-          links: {html: 'https://test.hypothes.is/a/deadbeef'},
-        });
-        var directive = createDirective(annotation);
-        assert.equal(findLink(directive).href, annotation.links.html);
-      });
-
-      it('displays in-context links when available', function () {
+    describe('annotation links', function () {
+      it('linkInContext uses the in-context links when available', function () {
         var annotation = Object.assign({}, fixtures.defaultAnnotation(), {
           links: {
             html: 'https://test.hypothes.is/a/deadbeef',
             incontext: 'https://hpt.is/deadbeef'
           },
         });
-        var directive = createDirective(annotation);
-        assert.equal(findLink(directive).href, annotation.links.incontext);
+        var controller = createDirective(annotation).controller;
+
+        assert.equal(controller.linkInContext, annotation.links.incontext);
+      });
+
+      it('linkInContext falls back to the HTML link when in-context links are missing', function () {
+        var annotation = Object.assign({}, fixtures.defaultAnnotation(), {
+          links: {
+            html: 'https://test.hypothes.is/a/deadbeef',
+          },
+        });
+        var controller = createDirective(annotation).controller;
+
+        assert.equal(controller.linkInContext, annotation.links.html);
+      });
+
+      it('linkHTML uses the HTML link when available', function () {
+        var annotation = Object.assign({}, fixtures.defaultAnnotation(), {
+          links: {
+            html: 'https://test.hypothes.is/a/deadbeef',
+            incontext: 'https://hpt.is/deadbeef'
+          },
+        });
+        var controller = createDirective(annotation).controller;
+
+        assert.equal(controller.linkHTML, annotation.links.html);
+      });
+
+      it('linkInContext is blank when unknown', function () {
+        var annotation = fixtures.defaultAnnotation();
+        var controller = createDirective(annotation).controller;
+
+        assert.equal(controller.linkInContext, '');
+      });
+
+      it('linkHTML is blank when unknown', function () {
+        var annotation = fixtures.defaultAnnotation();
+        var controller = createDirective(annotation).controller;
+
+        assert.equal(controller.linkHTML, '');
       });
     });
   });

--- a/h/templates/client/annotation.html
+++ b/h/templates/client/annotation.html
@@ -45,7 +45,7 @@
        target="_blank"
        title="{{vm.absoluteTimestamp}}"
        ng-if="!vm.editing() && vm.updated()"
-       ng-href="{{vm.annotationURI}}"
+       ng-href="{{vm.linkHTML}}"
        >{{vm.relativeTimestamp}}</a>
   </header>
 
@@ -183,7 +183,7 @@
         </button>
         <annotation-share-dialog
           group="vm.group()"
-          uri="vm.annotationURI"
+          uri="vm.linkInContext"
           is-private="vm.isPrivate"
           is-open="vm.showShareDialog"
           on-close="vm.showShareDialog = false">


### PR DESCRIPTION
The timestamp wasn't originally specified to be switched to the "in-context" link, so this commit makes sure that it always points to the "HTML" representation of the annotation, if that link is available.