### PR TITLE
Fix display of <ul>, <ol> in annotations

### DIFF
--- a/h/static/styles/reset.scss
+++ b/h/static/styles/reset.scss
@@ -63,9 +63,11 @@ img::-moz-selection {
   background: transparent;
 }
 
-ul, li {
-  padding: 0;
-  margin: 0;
+ul, ol, li {
+  @include reset-box-model;
+}
+
+ul, ol {
   list-style: none;
 }
 


### PR DESCRIPTION
9be804d broke the display of `<ul>` and `<ol>` tags in annotation cards by overriding a bit more than intended -- specifically, it set `list-style: none;` on `<li>` in reset.scss when the Compass reset mixins didn't do that.

This commit fixes the issue by only setting `list-style: none;` on `<ul>` and `<ol>`, which means that the list styles in styled-text.scss can take effect as originally intended.

Fixes #3331.