### PR TITLE
Remove additional margin at foot of annotation card

### DIFF
--- a/h/static/styles/annotation.scss
+++ b/h/static/styles/annotation.scss
@@ -108,9 +108,6 @@ $annotation-card-left-padding: 10px;
 .annotation-footer {
   @include font-normal;
   color: $grey-5;
-  // Margin between bottom of ascent of annotation footer labels
-  // and bottom of annotation card should be ~20px.
-  margin-bottom: $layout-h-margin - 13px;
   margin-top: $layout-h-margin;
 }
 


### PR DESCRIPTION
There should be 15px, not 20px of margin at the bottom of the annotation card, just as at the top.

Removing this CSS means that the annotation footer has no bottom margin and the 15px is provided for all sizes of the card by padding on .annotation-card.

Fixes #3387.