### PR TITLE
Fix distracting 404s in karma/phantom test output

### DIFF
--- a/h/static/scripts/annotator/host.coffee
+++ b/h/static/scripts/annotator/host.coffee
@@ -6,10 +6,14 @@ Guest = require('./guest')
 
 module.exports = class Host extends Guest
   constructor: (element, options) ->
+    # Make a copy of all options except `options.app`, the app base URL.
     appOpts = queryString.stringify(
       Object.assign({}, options, {app: undefined})
     )
-    options.app += (if '?' in options.app then '&' else '?') + appOpts
+    if options.app and '?' in options.app
+      options.app += '&' + appOpts
+    else
+      options.app += '?' + appOpts
 
     # Create the iframe
     app = $('<iframe></iframe>')

--- a/h/static/scripts/annotator/test/host-test.coffee
+++ b/h/static/scripts/annotator/test/host-test.coffee
@@ -11,6 +11,7 @@ describe 'Host', ->
   fakeCrossFrame = null
 
   createHost = (options={}, element=null) ->
+    options = Object.assign({app: '/base/test/empty.html'}, options)
     if !element
       element = document.createElement('div')
     return new Host(element, options)
@@ -86,9 +87,6 @@ describe 'Host', ->
       host.publish('panelReady')
 
     it 'passes options to the sidebar iframe', ->
-      appURL = 'http://localhost:1000/app.html'
-      host = createHost({
-        app: appURL,
-        annotations: '1234'
-      })
+      appURL = new URL('/base/test/empty.html', window.location.href)
+      host = createHost({annotations: '1234'})
       assert.equal(host.frame[0].children[0].src, appURL + '?annotations=1234')

--- a/h/static/scripts/karma.config.js
+++ b/h/static/scripts/karma.config.js
@@ -23,6 +23,9 @@ module.exports = function(config) {
       // Test setup
       './test/bootstrap.js',
 
+      // Empty HTML file to assist with some tests
+      { pattern: './test/empty.html', watched: false },
+
       // Karma watching is disabled for these files because they are
       // bundled with karma-browserify which handles watching itself via
       // watchify


### PR DESCRIPTION
For the longest time our tests have spat out a couple of ugly warnings when running:

    02 06 2016 15:19:20.485:WARN [web-server]: 404: /undefined?
    02 06 2016 15:19:20.488:WARN [web-server]: 404: /undefined?

This has annoyed me for ages so I decided to work it out. Turns out the annotator Host tests were injecting an iframe with a `src` property of `/undefined?`, which resulted in the request from Phantom to the Karma server. This PR just adds a blank file which can be served by Karma for this purpose.

Running these tests also failed in a real browser (Chrome) because we were doing `.indexOf` on an object which was undefined. d664dff fixes this issue.