### PR TITLE
Use PDF fingerprint as primary search URI for PDFs instead of url.

### DIFF
--- a/h/static/scripts/annotator/plugin/pdf-metadata.js
+++ b/h/static/scripts/annotator/plugin/pdf-metadata.js
@@ -1,0 +1,68 @@
+'use strict';
+
+/**
+ * This PDFMetadata service extracts metadata about a loading/loaded PDF
+ * document from a PDF.js PDFViewerApplication object.
+ *
+ * This hides from users of this service the need to wait until the PDF document
+ * is loaded before extracting the relevant metadata.
+ */
+function PDFMetadata(app) {
+  this._loaded = new Promise(function (resolve) {
+    var finish = function () {
+      window.removeEventListener('documentload', finish);
+      resolve(app);
+    };
+
+    if (app.documentFingerprint) {
+      resolve(app);
+    } else {
+      window.addEventListener('documentload', finish);
+    }
+  });
+}
+
+/**
+ * Returns a promise of the URI of the loaded PDF.
+ */
+PDFMetadata.prototype.getUri = function () {
+  return this._loaded.then(function (app) {
+    return app.url;
+  });
+};
+
+/**
+ * Returns a promise of a metadata object, containing:
+ *
+ * title(string) - The document title
+ * link(array) - An array of link objects representing URIs for the document
+ * documentFingerprint(string) - The document fingerprint
+ */
+PDFMetadata.prototype.getMetadata = function () {
+  return this._loaded.then(function (app) {
+    var title = document.title;
+
+    if (app.metadata && app.metadata.has('dc:title') && app.metadata.get('dc:title') !== 'Untitled') {
+      title = app.metadata.get('dc:title');
+    } else if (app.documentInfo && app.documentInfo.Title) {
+      title = app.documentInfo.Title;
+    }
+
+    var link = [
+      {href: fingerprintToURN(app.documentFingerprint)},
+      {href: app.url}
+    ];
+
+    return {
+      title: title,
+      link: link,
+      documentFingerprint: app.documentFingerprint,
+    };
+  });
+};
+
+function fingerprintToURN(fingerprint) {
+  return 'urn:x-pdf:' + String(fingerprint);
+}
+
+module.exports = PDFMetadata;

--- a/h/static/scripts/annotator/plugin/pdf-metadata.js
+++ b/h/static/scripts/annotator/plugin/pdf-metadata.js
@@ -27,7 +27,7 @@ function PDFMetadata(app) {
  */
 PDFMetadata.prototype.getUri = function () {
   return this._loaded.then(function (app) {
-    return app.url;
+    return fingerprintToURN(app.documentFingerprint);
   });
 };
 

--- a/h/static/scripts/annotator/plugin/test/pdf-metadata-test.js
+++ b/h/static/scripts/annotator/plugin/test/pdf-metadata-test.js
@@ -1,0 +1,82 @@
+'use strict';
+
+var PDFMetadata = require('../pdf-metadata');
+
+describe('pdf-metadata', function () {
+  describe('get pdf metadata when documentload event fires', function () {
+    it('should get pdf urn', function () {
+      var fakeApp = {};
+      var pdfMetadata = new PDFMetadata(fakeApp);
+
+      var event = document.createEvent('Event');
+      event.initEvent('documentload', false, false);
+      fakeApp.url = 'http://example.com/foo.pdf';
+      window.dispatchEvent(event);
+
+      return pdfMetadata.getUri().then(function (uri) {
+        assert.equal('http://example.com/foo.pdf', uri);
+      });
+    });
+  });
+
+  describe('get pdf metadata when documentFingerprint is set', function () {
+    var pdfMetadata;
+    var fakePDFViewerApplication = {
+      documentFingerprint: 'fakeFingerprint',
+      documentInfo: {
+        Title: 'fakeTitle',
+      },
+      metadata: {
+        metadata: {
+          'dc:title': 'fakeTitle',
+        }
+      },
+      url: 'fakeUrl',
+    };
+
+    beforeEach(function () {
+      pdfMetadata = new PDFMetadata(fakePDFViewerApplication);
+    });
+
+    describe('#getUri', function () {
+      it('returns the PDF URL as its URI', function () {
+        return pdfMetadata.getUri().then(function (uri) {
+          assert.equal('fakeUrl', uri);
+        });
+      });
+    });
+
+    describe('#getMetadata', function () {
+      it('should get a metadataobject with dc:title', function () {
+        var expectedMetadata = {
+          title: 'dcTitle',
+          link: [{href: 'urn:x-pdf:' + fakePDFViewerApplication.documentFingerprint},
+            {href: fakePDFViewerApplication.url}],
+          documentFingerprint: fakePDFViewerApplication.documentFingerprint,
+        };
+
+        fakePDFViewerApplication.metadata.has = sinon.stub().returns(true);
+        fakePDFViewerApplication.metadata.get = sinon.stub().returns('dcTitle');
+
+        return pdfMetadata.getMetadata().then(function (actualMetadata) {
+          assert.deepEqual(expectedMetadata, actualMetadata);
+        });
+      });
+
+      it('should get a metadataobject with documentInfo.Title', function () {
+        var expectedMetadata = {
+          title: fakePDFViewerApplication.documentInfo.Title,
+          link: [{href: 'urn:x-pdf:' + fakePDFViewerApplication.documentFingerprint},
+            {href: fakePDFViewerApplication.url}],
+          documentFingerprint: fakePDFViewerApplication.documentFingerprint,
+        };
+
+        fakePDFViewerApplication.metadata.has = sinon.stub().returns(false);
+
+        return pdfMetadata.getMetadata().then(function (actualMetadata) {
+          assert.deepEqual(expectedMetadata, actualMetadata);
+        });
+      });
+    });
+  });
+});

--- a/h/static/scripts/annotator/plugin/test/pdf-metadata-test.js
+++ b/h/static/scripts/annotator/plugin/test/pdf-metadata-test.js
@@ -10,11 +10,11 @@ describe('pdf-metadata', function () {
 
       var event = document.createEvent('Event');
       event.initEvent('documentload', false, false);
-      fakeApp.url = 'http://example.com/foo.pdf';
+      fakeApp.documentFingerprint = 'fakeFingerprint';
       window.dispatchEvent(event);
 
       return pdfMetadata.getUri().then(function (uri) {
-        assert.equal('http://example.com/foo.pdf', uri);
+        assert.equal('urn:x-pdf:fakeFingerprint', uri);
       });
     });
   });
@@ -39,9 +39,9 @@ describe('pdf-metadata', function () {
     });
 
     describe('#getUri', function () {
-      it('returns the PDF URL as its URI', function () {
+      it('returns the URN-ified document fingerprint as its URI', function () {
         return pdfMetadata.getUri().then(function (uri) {
-          assert.equal('fakeUrl', uri);
+          assert.equal('urn:x-pdf:fakeFingerprint', uri);
         });
       });
     });


### PR DESCRIPTION
https://trello.com/c/DVUemKwi/329-use-pdf-fingerprint-as-primary-search-uri-for-pdfs