### PR TITLE
Add a TokenAuthenticationPolicy for bearer tokens

### DIFF
--- a/h/auth/policy.py
+++ b/h/auth/policy.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
 
-from pyramid import authentication
 from pyramid import interfaces
+from pyramid.authentication import (CallbackAuthenticationPolicy,
+                                    SessionAuthenticationPolicy)
 from zope import interface
 
+from h._compat import text_type
 from h.auth import tokens
 from h.auth import util
 
@@ -12,7 +14,7 @@ from h.auth import util
 class AuthenticationPolicy(object):
 
     def __init__(self):
-        self.session_policy = authentication.SessionAuthenticationPolicy()
+        self.session_policy = SessionAuthenticationPolicy()
 
     def authenticated_userid(self, request):
         if _is_api_request(request):
@@ -39,6 +41,66 @@ class AuthenticationPolicy(object):
         if _is_api_request(request):
             return []
         return self.session_policy.forget(request)
+
+
+@interface.implementer(interfaces.IAuthenticationPolicy)
+class TokenAuthenticationPolicy(CallbackAuthenticationPolicy):
+
+    """
+    A bearer token authentication policy.
+
+    This is a Pyramid authentication policy in which the user's identity is
+    provided by and authenticated by the presence of a valid bearer token in
+    the "Authorization" HTTP request header.
+
+    It uses Pyramid's CallbackAuthenticationPolicy to divide responsibility
+    between this component (which is responsible only for establishing
+    identity), and a callback function, which is responsible for providing
+    additional principals for the authenticated user.
+    """
+
+    def __init__(self, callback=None, debug=False):
+        self.callback = callback
+        self.debug = debug
+
+    def remember(self, request, userid, **kw):
+        """Not implemented for token auth policy."""
+        return []
+
+    def forget(self, request):
+        """Not implemented for token auth policy."""
+        return []
+
+    def unauthenticated_userid(self, request):
+        """
+        Return the userid implied by the token in the passed request, if any.
+
+        This function inspects the passed request for bearer tokens, and
+        attempts to interpret any found tokens as either API tokens or JWTs,
+        in that order.
+
+        :param request: a request object
+        :type request: pyramid.request.Request
+
+        :returns: the userid authenticated for the passed request or None
+        :rtype: unicode or None
+        """
+        try:
+            header = request.headers['Authorization']
+        except KeyError:
+            return None
+
+        if not header.startswith('Bearer '):
+            return None
+
+        token = text_type(header[len('Bearer '):]).strip()
+        # If the token is empty at this point, it is clearly invalid and we
+        # should reject it.
+        if not token:
+            return None
+
+        return (tokens.userid_from_api_token(token) or
+                tokens.userid_from_jwt(token, request))
 
 
 def _is_api_request(request):

--- a/tests/h/auth/policy_test.py
+++ b/tests/h/auth/policy_test.py
@@ -6,6 +6,7 @@ from pyramid.testing import DummyRequest
 import pytest
 
 from h.auth.policy import AuthenticationPolicy
+from h.auth.policy import TokenAuthenticationPolicy
 
 SESSION_AUTH_PATHS = (
     '/login',
@@ -100,3 +101,111 @@ class TestAuthenticationPolicy(object):
 
         self.upstream_policy.forget.assert_not_called()
         assert result == []
+
+
+@pytest.mark.usefixtures('api_token', 'jwt')
+class TestTokenAuthenticationPolicy(object):
+    def test_remember_does_nothing(self):
+        policy = TokenAuthenticationPolicy()
+        request = DummyRequest()
+
+        assert policy.remember(request, 'foo') == []
+
+    def test_forget_does_nothing(self):
+        policy = TokenAuthenticationPolicy()
+        request = DummyRequest()
+
+        assert policy.forget(request) == []
+
+    def test_unauthenticated_userid_is_none_if_header_missing(self):
+        policy = TokenAuthenticationPolicy()
+        request = DummyRequest()
+
+        assert policy.unauthenticated_userid(request) is None
+
+    @pytest.mark.parametrize('value', [
+        'junk header',
+        'bearer:wibble',
+        'Bearer',
+        'Bearer ',
+    ])
+    def test_unauthenticated_userid_is_none_if_header_incorrectly_formatted(self, value):
+        policy = TokenAuthenticationPolicy()
+        request = DummyRequest(headers={'Authorization': value})
+
+        assert policy.unauthenticated_userid(request) is None
+
+    def test_unauthenticated_userid_passes_token_to_extractor_functions(self, jwt, api_token):
+        policy = TokenAuthenticationPolicy()
+        api_token.return_value = None
+        jwt.return_value = None
+        request = DummyRequest(headers={'Authorization': 'Bearer f00ba12'})
+
+        policy.unauthenticated_userid(request)
+
+        api_token.assert_called_once_with('f00ba12')
+        jwt.assert_called_once_with('f00ba12', request)
+
+    def test_unauthenticated_userid_returns_userid_from_api_token_if_present(self, jwt, api_token):
+        policy = TokenAuthenticationPolicy()
+        api_token.return_value = 'acct:foo@example.com'
+        jwt.return_value = 'acct:bar@example.com'
+        request = DummyRequest(headers={'Authorization': 'Bearer f00ba12'})
+
+        result = policy.unauthenticated_userid(request)
+
+        assert result == 'acct:foo@example.com'
+
+    def test_unauthenticated_userid_returns_userid_from_jwt_as_fallback(self, jwt, api_token):
+        policy = TokenAuthenticationPolicy()
+        api_token.return_value = None
+        jwt.return_value = 'acct:bar@example.com'
+        request = DummyRequest(headers={'Authorization': 'Bearer f00ba12'})
+
+        result = policy.unauthenticated_userid(request)
+
+        assert result == 'acct:bar@example.com'
+
+    def test_unauthenticated_userid_returns_none_if_neither_token_valid(self, jwt, api_token):
+        policy = TokenAuthenticationPolicy()
+        api_token.return_value = None
+        jwt.return_value = None
+        request = DummyRequest(headers={'Authorization': 'Bearer f00ba12'})
+
+        result = policy.unauthenticated_userid(request)
+
+        assert result is None
+
+    def test_authenticated_userid_uses_callback(self, jwt, api_token):
+        def callback(userid, request):
+            return None
+        policy = TokenAuthenticationPolicy(callback=callback)
+        api_token.return_value = 'acct:foo@example.com'
+        jwt.return_value = None
+        request = DummyRequest(headers={'Authorization': 'Bearer f00ba12'})
+
+        result = policy.authenticated_userid(request)
+
+        assert result is None
+
+    def test_effective_principals_uses_callback(self, jwt, api_token):
+        def callback(userid, request):
+            return [userid + '.foo', 'group:donkeys']
+        policy = TokenAuthenticationPolicy(callback=callback)
+        api_token.return_value = 'acct:foo@example.com'
+        jwt.return_value = None
+        request = DummyRequest(headers={'Authorization': 'Bearer f00ba12'})
+
+        result = policy.effective_principals(request)
+
+        assert set(result) > set(['acct:foo@example.com',
+                                  'acct:foo@example.com.foo',
+                                  'group:donkeys'])
+
+    @pytest.fixture
+    def api_token(self, patch):
+        return patch('h.auth.tokens.userid_from_api_token')
+
+    @pytest.fixture
+    def jwt(self, patch):
+        return patch('h.auth.tokens.userid_from_jwt')


### PR DESCRIPTION
This commit adds a bearer-token based authentication policy, based on Pyramid's CallbackAuthenticationPolicy, to h.auth.policy. It is not yet used, and copies most of its functionality from h.auth.token.authenticated_userid, which it will soon replace.

By wrapping up token authentication in an object conforming to Pyramid's authentication policy interface, this will make it possible to simplify various aspects of the authentication code.