### PR TITLE
Load annotations from DB in RSS/Atom feeds

### DIFF
--- a/h/api/storage.py
+++ b/h/api/storage.py
@@ -49,6 +49,17 @@ def fetch_annotation(session, id_):
         return None
 
 
+def fetch_ordered_annotations(session, ids):
+    if not ids:
+        return []
+
+    ordering = {x: i for i, x in enumerate(ids)}
+
+    anns = session.query(models.Annotation).filter(models.Annotation.id.in_(ids)).all()
+    anns = sorted(anns, key=lambda a: ordering.get(a.id))
+    return anns
+
+
 def create_annotation(request, data):
     """
     Create an annotation from passed data.

--- a/h/feeds/atom.py
+++ b/h/feeds/atom.py
@@ -42,9 +42,6 @@ def _feed_entry_from_annotation(
             {"rel": "alternate", "type": "application/json",
              "href": annotation_api_url(annotation.annotation)}
         )
-    # TODO
-    # entry["links"].extend(
-    #     [{"rel": "related", "href": link} for link in annotation.target_links])
 
     return entry
 

--- a/h/feeds/atom.py
+++ b/h/feeds/atom.py
@@ -20,16 +20,17 @@ def _feed_entry_from_annotation(
 
     """
     try:
-        name = util.user.split_user(annotation["user"])["username"]
+        name = util.user.split_user(annotation.userid)["username"]
     except ValueError:
-        name = annotation["user"]
+        name = annotation.userid
+
     entry = {
         "id": h.feeds.util.tag_uri_for_annotation(
             annotation.annotation, annotation_url),
         "author": {"name": name},
         "title": annotation.title,
-        "updated": annotation["updated"],
-        "published": annotation["created"],
+        "updated": _utc_iso8601_string(annotation.updated),
+        "published": _utc_iso8601_string(annotation.created),
         "content": annotation.description,
         "links": [
             {"rel": "alternate", "type": "text/html",
@@ -41,10 +42,15 @@ def _feed_entry_from_annotation(
             {"rel": "alternate", "type": "application/json",
              "href": annotation_api_url(annotation.annotation)}
         )
-    entry["links"].extend(
-        [{"rel": "related", "href": link} for link in annotation.target_links])
+    # TODO
+    # entry["links"].extend(
+    #     [{"rel": "related", "href": link} for link in annotation.target_links])
 
     return entry
+
+
+def _utc_iso8601_string(timestamp):
+    return timestamp.strftime('%Y-%m-%dT%H:%M:%S.%f+00:00')
 
 
 def feed_from_annotations(
@@ -79,6 +85,6 @@ def feed_from_annotations(
     }
 
     if annotations:
-        feed["updated"] = annotations[0]["updated"]
+        feed["updated"] = _utc_iso8601_string(annotations[0].updated)
 
     return feed

--- a/h/feeds/render.py
+++ b/h/feeds/render.py
@@ -29,11 +29,11 @@ def render_atom(request, annotations, atom_url, html_url, title, subtitle):
 
     def annotation_url(annotation):
         """Return the HTML permalink URL for the given annotation."""
-        return request.route_url('annotation', id=annotation["id"])
+        return request.route_url('annotation', id=annotation.id)
 
     def annotation_api_url(annotation):
         """Return the JSON API URL for the given annotation."""
-        return request.route_url('api.annotation', id=annotation["id"])
+        return request.route_url('api.annotation', id=annotation.id)
 
     feed = atom.feed_from_annotations(
         annotations=annotations, atom_url=atom_url,
@@ -69,7 +69,7 @@ def render_rss(request, annotations, rss_url, html_url, title, description):
 
     def annotation_url(annotation):
         """Return the HTML permalink URL for the given annotation."""
-        return request.route_url('annotation', id=annotation["id"])
+        return request.route_url('annotation', id=annotation.id)
 
     feed = rss.feed_from_annotations(
         annotations=annotations, annotation_url=annotation_url,

--- a/h/feeds/rss.py
+++ b/h/feeds/rss.py
@@ -20,8 +20,7 @@ def _pubDate_string_from_annotation(annotation):
     element of an RSS feed.
 
     """
-    if annotation.created:
-        return annotation.created.strftime('%a, %d %b %Y %H:%M:%S +0000')
+    return annotation.created.strftime('%a, %d %b %Y %H:%M:%S +0000')
 
 
 def _feed_item_from_annotation(annotation, annotation_url):
@@ -71,7 +70,7 @@ def feed_from_annotations(annotations, annotation_url, rss_url, html_url,
             for annotation in annotations]
     }
 
-    if annotations and annotations[0].updated:
+    if annotations:
         feed['pubDate'] = annotations[0].updated.strftime('%a, %d %b %Y %H:%M:%S UTC')
 
     return feed

--- a/h/feeds/rss.py
+++ b/h/feeds/rss.py
@@ -1,6 +1,5 @@
 """Functions for generating RSS feeds."""
 from pyramid import i18n
-from dateutil import parser
 
 from h import presenters
 from h import util
@@ -21,8 +20,8 @@ def _pubDate_string_from_annotation(annotation):
     element of an RSS feed.
 
     """
-    return parser.parse(annotation['created']).strftime(
-        '%a, %d %b %Y %H:%M:%S %z')
+    if annotation.created:
+        return annotation.created.strftime('%a, %d %b %Y %H:%M:%S +0000')
 
 
 def _feed_item_from_annotation(annotation, annotation_url):
@@ -35,16 +34,15 @@ def _feed_item_from_annotation(annotation, annotation_url):
 
     """
     try:
-        name = util.user.split_user(annotation["user"])["username"]
+        name = util.user.split_user(annotation.userid)["username"]
     except ValueError:
-        name = annotation["user"]
+        name = annotation.userid
     return {
         "author": {"name": name},
         "title": annotation.title,
         "description": annotation.description,
         "pubDate": _pubDate_string_from_annotation(annotation),
-        "guid": h.feeds.util.tag_uri_for_annotation(
-            annotation, annotation_url),
+        "guid": h.feeds.util.tag_uri_for_annotation(annotation, annotation_url),
         "link": annotation_url(annotation)
     }
 
@@ -73,8 +71,7 @@ def feed_from_annotations(annotations, annotation_url, rss_url, html_url,
             for annotation in annotations]
     }
 
-    if annotations:
-        feed['pubDate'] = parser.parse(annotations[0]['updated']).strftime(
-            '%a, %d %b %Y %H:%M:%S %Z')
+    if annotations and annotations[0].updated:
+        feed['pubDate'] = annotations[0].updated.strftime('%a, %d %b %Y %H:%M:%S UTC')
 
     return feed

--- a/h/feeds/util.py
+++ b/h/feeds/util.py
@@ -20,4 +20,4 @@ def tag_uri_for_annotation(annotation, annotation_url):
     domain = urlparse.urlparse(annotation_url(annotation)).hostname
     return u"tag:{domain},{date}:{id_}".format(domain=domain,
                                                date=FEED_TAG_DATE,
-                                               id_=annotation["id"])
+                                               id_=annotation.id)

--- a/h/feeds/views.py
+++ b/h/feeds/views.py
@@ -12,7 +12,8 @@ _ = i18n.TranslationStringFactory(__package__)
 def _annotations(request):
     """Return the annotations from the search API."""
     rows = search.search(request, request.params)['rows']
-    return [storage.annotation_from_dict(a) for a in rows]
+    ids = [r['id'] for r in rows]
+    return storage.fetch_ordered_annotations(request.db, ids)
 
 
 @view_config(route_name='stream_atom')

--- a/h/presenters.py
+++ b/h/presenters.py
@@ -62,9 +62,6 @@ class AnnotationHTMLPresenter(object):
     def __getattr__(self, attr):
         return getattr(self.annotation, attr)
 
-    def __getitem__(self, key):
-        return self.annotation[key]
-
     @property
     def uri(self):
         return jinja2.escape(self.annotation.target_uri)

--- a/h/presenters.py
+++ b/h/presenters.py
@@ -67,7 +67,7 @@ class AnnotationHTMLPresenter(object):
 
     @property
     def uri(self):
-        return jinja2.escape(self.annotation.uri)
+        return jinja2.escape(self.annotation.target_uri)
 
     @property
     def filename(self):
@@ -244,20 +244,10 @@ class AnnotationHTMLPresenter(object):
 
         """
         def get_selection():
-            targets = self.annotation.get("target")
-            if not isinstance(targets, list):
-                return
-            for target in targets:
-                if not isinstance(target, dict):
-                    continue
-                selectors = target.get("selector")
-                if not isinstance(selectors, list):
-                    continue
-                for selector in selectors:
-                    if not isinstance(selector, dict):
-                        continue
-                    if "exact" in selector:
-                        return selector["exact"]
+            selectors = self.annotation.target_selectors
+            for selector in selectors:
+                if "exact" in selector:
+                    return selector["exact"]
 
         description = ""
 
@@ -267,7 +257,7 @@ class AnnotationHTMLPresenter(object):
             description += "&lt;blockquote&gt;{selection}&lt;/blockquote&gt;".format(
                 selection=selection)
 
-        text = self.annotation.get("text")
+        text = self.annotation.text
         if text:
             text = jinja2.escape(text)
             description += "{text}".format(text=text)

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -91,12 +91,8 @@ class Annotation(factory.Factory):
         return "http://example.com/document_{n}".format(n=stub.random_number)
 
     @factory.LazyAttribute
-    def target(stub):
-        return [{
-            "source": stub.uri,
-            "pos": {"top": 200.00, "height": 20},
-            "selector": [
-                {"type": "RangeSelector",
+    def target_selectors(stub):
+        return [{"type": "RangeSelector",
                  "startContainer": "/div[1]/article[1]/",
                  "endContainer": "/div[1]/article[1]/section[1]",
                  "startOffset": 0,
@@ -112,7 +108,6 @@ class Annotation(factory.Factory):
                 {"type": "FragmentSelector",
                  "value": ""}
             ]
-        }]
 
     @factory.LazyAttribute
     def permissions(stub):

--- a/tests/h/api/storage_test.py
+++ b/tests/h/api/storage_test.py
@@ -28,6 +28,20 @@ class TestFetchAnnotation(object):
         assert storage.fetch_annotation(db_session, 'foo') is None
 
 
+class TestFetchOrderedAnnotations(object):
+
+    def test_it_returns_annotations_for_ids_in_the_same_order(self, db_session):
+        ann_1 = Annotation(userid='luke')
+        ann_2 = Annotation(userid='luke')
+        db_session.add_all([ann_1, ann_2])
+        db_session.flush()
+
+        assert [ann_2, ann_1] == storage.fetch_ordered_annotations(db_session,
+                                                                   [ann_2.id, ann_1.id])
+        assert [ann_1, ann_2] == storage.fetch_ordered_annotations(db_session,
+                                                                   [ann_1.id, ann_2.id])
+
+
 class TestExpandURI(object):
 
     def test_expand_uri_no_document(self, db_session):

--- a/tests/h/factories_test.py
+++ b/tests/h/factories_test.py
@@ -76,11 +76,6 @@ class TestAnnotation(object):
         assert annotation["uri"] == "http://example.com/document_3"
         assert "random_number" not in annotation
 
-    def test_source(self):
-        annotation = factories.Annotation(random_number=3)
-        assert annotation["target"][0]["source"] == (
-            "http://example.com/document_3")
-
     def test_permissions(self):
         annotation = factories.Annotation(username="test_user")
         assert "test_user" in annotation["permissions"]["admin"][0]

--- a/tests/h/feeds/atom_test.py
+++ b/tests/h/feeds/atom_test.py
@@ -190,23 +190,6 @@ def test_annotation_api_url_links(_):
     }
 
 
-def test_target_links():
-    """Entries should have links to the annotation's targets."""
-    annotation = factories.Annotation()
-    annotation['target'] = [
-        {'source': 'target href 1'},
-        {'source': 'target href 2'},
-        {'source': 'target href 3'},
-    ]
-
-    feed = atom.feed_from_annotations(
-        [annotation], "atom_url", lambda annotation: "annotation url")
-
-    hrefs = [link['href'] for link in feed['entries'][0]['links']]
-    for target in annotation['target']:
-        assert target['source'] in hrefs
-
-
 def test_feed_updated():
     annotations = [
         _annotation(updated=datetime(year=2015, month=3, day=11, hour=10, minute=45, second=54, microsecond=537626)),

--- a/tests/h/feeds/atom_test.py
+++ b/tests/h/feeds/atom_test.py
@@ -13,8 +13,8 @@ from ... import factories
 def _annotation(**kwargs):
     args = {
         'userid': 'acct:janebloggs@hypothes.is',
-        'created': datetime.now(),
-        'updated': datetime.now(),
+        'created': datetime.utcnow(),
+        'updated': datetime.utcnow(),
         'target_selectors': [],
     }
     args.update(kwargs)

--- a/tests/h/feeds/atom_test.py
+++ b/tests/h/feeds/atom_test.py
@@ -14,7 +14,8 @@ def _annotation(**kwargs):
     args = {
         'userid': 'acct:janebloggs@hypothes.is',
         'created': datetime.now(),
-        'updated': datetime.now()
+        'updated': datetime.now(),
+        'target_selectors': [],
     }
     args.update(kwargs)
     return models.Annotation(**args)

--- a/tests/h/feeds/rss_test.py
+++ b/tests/h/feeds/rss_test.py
@@ -22,6 +22,8 @@ def _annotation(**kwargs):
     args = {
         'userid': 'acct:janebloggs@hypothes.is',
         'target_selectors': [],
+        'created': datetime.datetime.utcnow(),
+        'updated': datetime.datetime.utcnow(),
     }
     args.update(**kwargs)
     return models.Annotation(**args)

--- a/tests/h/feeds/rss_test.py
+++ b/tests/h/feeds/rss_test.py
@@ -19,12 +19,17 @@ def _annotation_url():
 
 
 def _annotation(**kwargs):
-    return models.Annotation(userid='acct:janebloggs@hypothes.is', **kwargs)
+    args = {
+        'userid': 'acct:janebloggs@hypothes.is',
+        'target_selectors': [],
+    }
+    args.update(**kwargs)
+    return models.Annotation(**args)
 
 
 def test_feed_from_annotations_item_author():
     """Feed items should include the annotation's author."""
-    annotation = models.Annotation(userid='acct:janebloggs@hypothes.is')
+    annotation = _annotation()
 
     feed = rss.feed_from_annotations(
         [annotation], _annotation_url(), mock.Mock(), '', '', '')

--- a/tests/h/feeds/rss_test.py
+++ b/tests/h/feeds/rss_test.py
@@ -2,6 +2,7 @@ import datetime
 
 import mock
 
+from h import models
 from h.feeds import rss
 
 from ... import factories
@@ -17,9 +18,13 @@ def _annotation_url():
     return mock.Mock(return_value='https://hypothes.is/a/id')
 
 
+def _annotation(**kwargs):
+    return models.Annotation(userid='acct:janebloggs@hypothes.is', **kwargs)
+
+
 def test_feed_from_annotations_item_author():
     """Feed items should include the annotation's author."""
-    annotation = factories.Annotation(username="janebloggs")
+    annotation = models.Annotation(userid='acct:janebloggs@hypothes.is')
 
     feed = rss.feed_from_annotations(
         [annotation], _annotation_url(), mock.Mock(), '', '', '')
@@ -27,14 +32,12 @@ def test_feed_from_annotations_item_author():
     assert feed['entries'][0]['author'] == {'name': 'janebloggs'}
 
 
-def test_feed_from_annotations_pubDate():
+def test_feed_annotations_pubDate():
     """It should render the pubDates of annotations correctly."""
-    annotation = factories.Annotation(
-        created=datetime.datetime(year=2015, month=3, day=11, hour=10,
-                                  minute=43, seconds=54).isoformat())
+    ann = _annotation(created=datetime.datetime(year=2015, month=3, day=11, hour=10, minute=43, second=54))
 
     feed = rss.feed_from_annotations(
-        [annotation], _annotation_url(), mock.Mock(), '', '', '')
+        [ann], _annotation_url(), mock.Mock(), '', '', '')
 
     assert feed['entries'][0]['pubDate'] == 'Wed, 11 Mar 2015 10:43:54 +0000'
 
@@ -138,9 +141,9 @@ def test_feed_from_annotations_with_3_annotations():
 def test_feed_from_annotations_pubDate():
     """The pubDate should be the updated time of the most recent annotation."""
     annotations = [
-        factories.Annotation(updated='2015-03-11T10:45:54.537626+00:00'),
-        factories.Annotation(updated='2015-02-11T10:43:54.537626+00:00'),
-        factories.Annotation(updated='2015-01-11T10:43:54.537626+00:00')
+        _annotation(updated=datetime.datetime(year=2015, month=3, day=11, hour=10, minute=45, second=54, microsecond=537626)),
+        _annotation(updated=datetime.datetime(year=2015, month=2, day=11, hour=10, minute=43, second=54, microsecond=537626)),
+        _annotation(updated=datetime.datetime(year=2015, month=1, day=11, hour=10, minute=43, second=54, microsecond=537626))
     ]
 
     feed = rss.feed_from_annotations(


### PR DESCRIPTION
_#3388 and this have depend on changes in the presenters, we should review these PRs and merge them into a new "pg-cleanup" branch, and then merge that one into master_

This is the second part of removing the usage of `storage.annotation_from_dict`. We now also load the annotations from the database after we search in the index for the Atom/RSS feeds.
Over time all searching should then load the data from the database, which will let us only keep searchable data in the index instead of the whole annotation object.
Sean also did some great changes to the `AnnotationHTMLPresenter` making it work with the annotation DB model.