### PR TITLE
Remove the "links" field from the search index

### DIFF
--- a/h/api/search/index.py
+++ b/h/api/search/index.py
@@ -38,14 +38,8 @@ def index(es, annotation, request):
     :type annotation: h.api.models.Annotation
 
     """
-    # FIXME: this should not use the same presenter as we use to render
-    # annotations for clients. It is useful in the mean time until we get rid of
-    # the legacy ElasticSearch annotation storage.
-    annotation_dict = presenters.AnnotationJSONPresenter(
+    annotation_dict = presenters.AnnotationSearchIndexPresenter(
         request, annotation).asdict()
-
-    annotation_dict['target'][0]['scope'] = [
-        annotation.target_uri_normalized]
 
     event = AnnotationTransformEvent(request, annotation_dict)
     request.registry.notify(event)
@@ -144,11 +138,7 @@ class BatchIndexer(object):
         action = {'index': {'_index': self.es_client.index,
                             '_type': self.es_client.t.annotation,
                             '_id': annotation.id}}
-        # FIXME: this should not use the same presenter as we use to render
-        # annotations for clients. It is useful in the mean time until we get rid of
-        # the legacy ElasticSearch annotation storage.
-        data = presenters.AnnotationJSONPresenter(self.request, annotation).asdict()
-        data['target'][0]['scope'] = [annotation.target_uri_normalized]
+        data = presenters.AnnotationSearchIndexPresenter(self.request, annotation).asdict()
 
         return (action, data)
 

--- a/tests/h/api/presenters_test.py
+++ b/tests/h/api/presenters_test.py
@@ -562,3 +562,16 @@ class Berlin(datetime.tzinfo):
 
     def dst(self, dt):
         return datetime.timedelta()
+
+
+@pytest.fixture(autouse=True)
+def clear_registry():
+    # If you call add_annotation_link_generator() as some tests in this module
+    # do it'll add stuff to the request registry that you pass to it.
+    # Then when a later test runs and creates a _new_ DummyRequest instance,
+    # that request's registry will still contain the stuff added by the
+    # previous test!
+    # DummyRequest.registry is shared across requests.
+    # So rather than requiring each test that adds to the registry to also
+    # clear it, this autouse fixture just clears the registry after every test.
+    DummyRequest().registry.clear()

--- a/tests/h/api/presenters_test.py
+++ b/tests/h/api/presenters_test.py
@@ -8,6 +8,7 @@ from pyramid.testing import DummyRequest
 
 from h.api.presenters import AnnotationBasePresenter
 from h.api.presenters import AnnotationJSONPresenter
+from h.api.presenters import AnnotationSearchIndexPresenter
 from h.api.presenters import AnnotationJSONLDPresenter
 from h.api.presenters import DocumentJSONPresenter
 from h.api.presenters import DocumentMetaJSONPresenter
@@ -259,6 +260,121 @@ class TestAnnotationJSONPresenter(object):
     @pytest.fixture
     def document_asdict(self, patch):
         return patch('h.api.presenters.DocumentJSONPresenter.asdict')
+
+
+@pytest.mark.usefixtures('DocumentJSONPresenter')
+class TestAnnotationSearchIndexPresenter(object):
+
+    def test_asdict(self, DocumentJSONPresenter):
+        request = DummyRequest()
+        annotation = mock.Mock(
+            id='xyz123',
+            created=datetime.datetime(2016, 2, 24, 18, 3, 25, 768),
+            updated=datetime.datetime(2016, 2, 29, 10, 24, 5, 564),
+            userid='acct:luke@hypothes.is',
+            target_uri='http://example.com',
+            target_uri_normalized='http://example.com/normalized',
+            text='It is magical!',
+            tags=['magic'],
+            groupid='__world__',
+            shared=True,
+            target_selectors=[{'TestSelector': 'foobar'}],
+            references=['referenced-id-1', 'referenced-id-2'],
+            extra={'extra-1': 'foo', 'extra-2': 'bar'})
+        DocumentJSONPresenter.return_value.asdict.return_value = {'foo': 'bar'}
+
+        annotation_dict = AnnotationSearchIndexPresenter(
+            request, annotation).asdict()
+
+        assert annotation_dict == {
+            'id': 'xyz123',
+            'created': '2016-02-24T18:03:25.000768+00:00',
+            'updated': '2016-02-29T10:24:05.000564+00:00',
+            'user': 'acct:luke@hypothes.is',
+            'uri': 'http://example.com',
+            'text': 'It is magical!',
+            'tags': ['magic'],
+            'group': '__world__',
+            'permissions': {'read': ['group:__world__'],
+                            'admin': ['acct:luke@hypothes.is'],
+                            'update': ['acct:luke@hypothes.is'],
+                            'delete': ['acct:luke@hypothes.is']},
+            'target': [{'scope': ['http://example.com/normalized'],
+                        'source': 'http://example.com',
+                        'selector': [{'TestSelector': 'foobar'}]}],
+            'document': {'foo': 'bar'},
+            'references': ['referenced-id-1', 'referenced-id-2'],
+            'extra-1': 'foo',
+            'extra-2': 'bar',
+        }
+
+    def test_asdict_extra_cannot_override_other_data(self):
+        request = DummyRequest()
+        annotation = mock.Mock(id='the-real-id', extra={'id': 'the-extra-id'})
+
+        annotation_dict = AnnotationSearchIndexPresenter(
+            request, annotation).asdict()
+
+        assert annotation_dict['id'] == 'the-real-id'
+
+    def test_asdict_does_not_modify_extra(self):
+        extra = {'foo': 'bar'}
+        request = DummyRequest()
+        annotation = mock.Mock(id='my-id', extra=extra)
+
+        AnnotationSearchIndexPresenter(request, annotation).asdict()
+
+        assert extra == {'foo': 'bar'}, (
+                "Presenting the annotation shouldn't change the 'extra' dict")
+
+    def test_asdict_does_not_return_links_from_link_generators(self):
+        request = DummyRequest()
+        annotation = mock.Mock(id='my-id', extra={})
+        add_annotation_link_generator(request.registry,
+                                      'giraffe',
+                                      lambda r, a: 'http://giraffe.com')
+        add_annotation_link_generator(request.registry,
+                                      'withid',
+                                      lambda r, a: 'http://withid.com/' + a.id)
+
+        annotation_dict = AnnotationSearchIndexPresenter(
+            request, annotation).asdict()
+
+        assert 'links' not in annotation_dict
+
+    @pytest.mark.parametrize('annotation,action,expected', [
+        (mock.Mock(userid='acct:luke', shared=False), 'read', ['acct:luke']),
+        (mock.Mock(groupid='__world__', shared=True), 'read',
+            ['group:__world__']),
+        (mock.Mock(groupid='lulapalooza', shared=True), 'read',
+            ['group:lulapalooza']),
+        (mock.Mock(userid='acct:luke'), 'admin', ['acct:luke']),
+        (mock.Mock(userid='acct:luke'), 'update', ['acct:luke']),
+        (mock.Mock(userid='acct:luke'), 'delete', ['acct:luke']),
+        ])
+    def test_permissions(self, annotation, action, expected):
+        request = DummyRequest()
+        presenter = AnnotationSearchIndexPresenter(request, annotation)
+
+        assert expected == presenter.permissions[action]
+
+    def test_it_copies_target_uri_normalized_to_target_scope(self):
+        request = DummyRequest()
+        annotation = mock.Mock(
+            target_uri_normalized='http://example.com/normalized',
+            extra={})
+
+        annotation_dict = AnnotationSearchIndexPresenter(
+            request, annotation).asdict()
+
+        assert annotation_dict['target'][0]['scope'] == [
+            'http://example.com/normalized']
+
+    @pytest.fixture
+    def DocumentJSONPresenter(self, patch):
+        class_ = patch('h.api.presenters.DocumentJSONPresenter')
+        class_.return_value.asdict.return_value = {}
+        return class_
 
 
 @pytest.mark.usefixtures('routes')

--- a/tests/h/api/search/index_test.py
+++ b/tests/h/api/search/index_test.py
@@ -30,12 +30,13 @@ class TestIndexAnnotation:
 
         index.index(es, annotation, request)
 
-        presenters.AnnotationJSONPresenter.assert_called_once_with(
+        presenters.AnnotationSearchIndexPresenter.assert_called_once_with(
             request, annotation)
 
     def test_it_creates_an_annotation_before_save_event(self, es, presenters, AnnotationTransformEvent):
         request = mock.Mock()
-        presented = presenters.AnnotationJSONPresenter.return_value.asdict()
+        presented = (
+            presenters.AnnotationSearchIndexPresenter.return_value.asdict())
 
         index.index(es, mock.Mock(), request)
 
@@ -56,21 +57,14 @@ class TestIndexAnnotation:
         es.conn.index.assert_called_once_with(
             index='hypothesis',
             doc_type='annotation',
-            body=presenters.AnnotationJSONPresenter.return_value.asdict.return_value,
+            body=presenters.AnnotationSearchIndexPresenter.return_value.asdict.return_value,
             id='test_annotation_id',
         )
-
-    def test_it_inserts_the_source_field(self, es):
-        annotation = mock.Mock()
-
-        index.index(es, annotation, mock.Mock())
-
-        assert es.conn.index.call_args[1]['body']['target'][0]['scope'] == [annotation.target_uri_normalized]
 
     @pytest.fixture
     def presenters(self, patch):
         presenters = patch('h.api.search.index.presenters')
-        presenter = presenters.AnnotationJSONPresenter.return_value
+        presenter = presenters.AnnotationSearchIndexPresenter.return_value
         presenter.asdict.return_value = {
             'id': 'test_annotation_id',
             'target': [
@@ -189,7 +183,8 @@ class TestBatchIndexer(object):
 
         indexer.index()
 
-        rendered = presenters.AnnotationJSONPresenter(mock_request, annotation).asdict()
+        rendered = presenters.AnnotationSearchIndexPresenter(
+            mock_request, annotation).asdict()
         rendered['target'][0]['scope'] = [annotation.target_uri_normalized]
         assert results[0] == (
             {'index': {'_type': indexer.es_client.t.annotation,
@@ -290,7 +285,8 @@ class TestBatchDeleter(object):
 
         es_scan.return_value = [
             {'_id': annotation.id,
-             '_source': presenters.AnnotationJSONPresenter(request, annotation)}]
+             '_source': presenters.AnnotationSearchIndexPresenter(request,
+                                                                  annotation)}]
 
         deleted_ids = deleter.deleted_annotation_ids()
         assert len(deleted_ids) == 0


### PR DESCRIPTION
Remove the "links" field of annotations from the search index.

This field did not exist in the search index back when we used the
legacy Elasticsearch storage, it only existed in the annotations
returned by the API, but it got accidentally added into the search index when
we moved to the new Postgres storage becayse the new search indexer uses
AnnotationJSONPresenter which is the presenter used for returning
annotations from the API.

Fundamentally we don't want the annotations returned by the API to have
to look exactly the same as the annotations in the search index - these
are two different things, and may evolve in different directions
according to different needs.

So add a new AnnotationSearchIndexPresenter and have the search indexer
use that instead of AnnotationJSONPresenter. Now the annotation formats
used by the API and search index are separated in the code and can be
modified independently.

Note that both AnnotationJSONPresenter and
AnnotationSearchIndexPresenter still use DocumentJSONPresenter for the
document sub-object of annotations - it has not been necessary to
separate out a DocumentSearchIndexPresenter yet.

Fixes https://github.com/hypothesis/h/issues/3261