### PR TITLE
Add move_uri cli command

### DIFF
--- a/h/cli/__init__.py
+++ b/h/cli/__init__.py
@@ -20,6 +20,7 @@ SUBCOMMANDS = (
     'h.cli.commands.devserver.devserver',
     'h.cli.commands.initdb.initdb',
     'h.cli.commands.migrate.migrate',
+    'h.cli.commands.move_uri.move_uri',
     'h.cli.commands.reindex.reindex',
 )
 

--- a/h/cli/commands/move_uri.py
+++ b/h/cli/commands/move_uri.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+
+import click
+
+from h import models
+from h.api import uri
+from h.api.search.index import BatchIndexer
+
+
+@click.command('move-uri')
+@click.option('--old', required=True,
+              help='Old URI with annotations and documents.')
+@click.option('--new', required=True, confirmation_prompt=True,
+              help='New URI for matching annotations and documents.')
+@click.pass_context
+def move_uri(ctx, old, new):
+    """
+    Move annotations and document equivalence data from one URL to another.
+
+    This will **replace** the annotation's ``target_uri`` and all the
+    document uri's ``claimant``, plus the matching ``uri`` for self-claim and
+    canonical uris.
+    """
+
+    request = ctx.obj['bootstrap']()
+
+    annotations = _fetch_annotations(request.db, old)
+    docuris_claimant = _fetch_document_uri_claimants(request.db, old)
+    docuris_uri = _fetch_document_uri_canonical_self_claim(request.db, old)
+
+    prompt = ('Changing all annotations and document data matching:\n' +
+              '"{old}"\nto:\n"{new}"\n' +
+              'This will affect {ann_count} annotations, {doc_claimant} ' +
+              'document uri claimants, and {doc_uri} document uri self-claims ' +
+              'or canonical uris.\n' +
+              'Are you sure? [y/N]').format(old=old, new=new,
+                                            ann_count=len(annotations),
+                                            doc_claimant=len(docuris_claimant),
+                                            doc_uri=len(docuris_uri))
+    c = click.prompt(prompt, default='n', show_default=False)
+
+    if c != 'y':
+        print('Aborted')
+        return
+
+    for annotation in annotations:
+        annotation.target_uri = new
+
+    for docuri in docuris_claimant:
+        docuri.claimant = new
+
+    for docuri in docuris_uri:
+        docuri.uri = new
+
+    if annotations:
+        indexer = BatchIndexer(request.db, request.es, request)
+        ids = [a.id for a in annotations]
+        res = indexer.index(ids)
+
+    request.tm.commit()
+
+
+def _fetch_annotations(session, uri_):
+    return session.query(models.Annotation).filter(
+        models.Annotation.target_uri_normalized == uri.normalize(uri_)).all()
+
+
+def _fetch_document_uri_claimants(session, uri_):
+    return session.query(models.DocumentURI).filter(
+        models.DocumentURI.claimant_normalized == uri.normalize(uri_)).all()
+
+
+def _fetch_document_uri_canonical_self_claim(session, uri_):
+    return session.query(models.DocumentURI).filter(
+        models.DocumentURI.uri_normalized == uri.normalize(uri_),
+        models.DocumentURI.type.in_([u'self-claim', u'rel-canonical'])).all()
+
+
+def _fetch_documents(session, uri_):
+    return models.Document.find_by_uris(session, [uri_]).all()


### PR DESCRIPTION
Which allows for easier moving of annotations and document equivalence data
from one URL to another.

This will **replace** the annotation's ``target_uri`` and all the
document uri's ``claimant``, plus the matching ``uri`` for
self-claim and canonical uris.

I've tried and make the command as safe as possible to use, this is how it looks like:
```shell
$ hypothesis --dev move_uri \
  --old http://www.hybridpedagogy.com/announcements/when-words-go-global-a-digped-chat/ \
  --new http://www.digitalpedagogylab.com/hybridped/when-words-go-global-a-digped-chat/

Changing all annotations and document data matching:
"http://www.hybridpedagogy.com/announcements/when-words-go-global-a-digped-chat/"
to:
"http://www.digitalpedagogylab.com/hybridped/when-words-go-global-a-digped-chat/"
This will affect 1 annotations, 3 document uri claimants, and 2 document uri self-claims or canonical uris.
Are you sure? [y/N]: 
```