### PR TITLE
Persist in-place mutations of annotation tags and extras

### DIFF
--- a/h/api/models/annotation.py
+++ b/h/api/models/annotation.py
@@ -54,7 +54,9 @@ class Annotation(Base, mixins.Timestamps):
     #: The textual body of the annotation.
     text = sa.Column(sa.UnicodeText)
     #: The tags associated with the annotation.
-    tags = sa.Column(pg.ARRAY(sa.UnicodeText, zero_indexes=True))
+    tags = sa.Column(
+        types.MutableList.as_mutable(
+            pg.ARRAY(sa.UnicodeText, zero_indexes=True)))
 
     #: A boolean indicating whether this annotation is shared with members of
     #: the group it is published in. "Private"/"Only me" annotations have

--- a/h/api/models/annotation.py
+++ b/h/api/models/annotation.py
@@ -7,6 +7,7 @@ import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql as pg
 from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.ext.hybrid import hybrid_property
+from sqlalchemy.ext.mutable import MutableDict
 
 from h.api import uri
 from h.api.db import Base
@@ -78,7 +79,7 @@ class Annotation(Base, mixins.Timestamps):
                            server_default=sa.text('ARRAY[]::uuid[]'))
 
     #: Any additional serialisable data provided by the client.
-    extra = sa.Column(pg.JSONB,
+    extra = sa.Column(MutableDict.as_mutable(pg.JSONB),
                       default=dict,
                       server_default=sa.func.jsonb('{}'),
                       nullable=False)

--- a/h/api/storage.py
+++ b/h/api/storage.py
@@ -130,12 +130,7 @@ def update_annotation(session, id_, data):
 
     annotation = session.query(models.Annotation).get(id_)
 
-    # Just modifying the annotation.extra dict in place doesn't let sqlalchemy
-    # know that it has changed and needs to be saved to the database.
-    # Work around this for now by copying, modifying then assigning.
-    extra = dict(annotation.extra)
-    extra.update(data.pop('extra', {}))
-    annotation.extra = extra
+    annotation.extra.update(data.pop('extra', {}))
 
     for key, value in data.items():
         setattr(annotation, key, value)

--- a/tests/h/api/db/types_test.py
+++ b/tests/h/api/db/types_test.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import mock
 import pytest
 
 from sqlalchemy.dialects.postgresql import dialect
@@ -109,3 +110,51 @@ def test_annotation_selector_deserialize_missing_text_quote_selector():
         'endoffset': 1
     }]
     assert t.process_result_value(selectors, dialect) == selectors
+
+
+class TestMutableList(object):
+
+    @mock.patch.object(types.Mutable, 'changed')
+    @pytest.mark.parametrize('operation', [
+        lambda l: l.__setitem__(0, 'value'),
+        lambda l: l.__setslice__(1, 3, ['a', 'b']),
+        lambda l: l.__delitem__(0),
+        lambda l: l.__delslice__(1, 3),
+        lambda l: l.append('value'),
+        lambda l: l.insert(0, 'value'),
+        lambda l: l.extend(['value']),
+        lambda l: l.pop(),
+        lambda l: l.remove(1),
+        lambda l: l.sort(),
+        lambda l: l.reverse(),
+    ])
+    def test_it_calls_changed(self, changed, operation):
+        list_ = types.MutableList([1, 2, 3])
+        assert not changed.called
+
+        operation(list_)
+
+        changed.assert_called_once_with()
+
+    @pytest.mark.parametrize('operation,expected_result', [
+        (lambda l: l.__setitem__(0, 'value'), ['value', 3, 2]),
+        (lambda l: l.__setslice__(1, 3, ['a', 'b']), [1, 'a', 'b']),
+        (lambda l: l.__delitem__(0), [3, 2]),
+        (lambda l: l.__delslice__(1, 3), [1]),
+        (lambda l: l.append('value'), [1, 3, 2, 'value']),
+        (lambda l: l.insert(0, 'value'), ['value', 1, 3, 2]),
+        (lambda l: l.extend(['value']), [1, 3, 2, 'value']),
+        (lambda l: l.pop(), [1, 3]),
+        (lambda l: l.remove(1), [3, 2]),
+        (lambda l: l.sort(), [1, 2, 3]),
+        (lambda l: l.reverse(), [2, 3, 1]),
+    ])
+    def test_it_mutates_the_list(self, operation, expected_result):
+        list_ = types.MutableList([1, 3, 2])
+
+        operation(list_)
+
+        assert list_ == expected_result
+
+    def test_pop_returns_the_popped_value(self):
+        assert types.MutableList(['value']).pop() == 'value'

--- a/tests/h/api/models/annotation_test.py
+++ b/tests/h/api/models/annotation_test.py
@@ -135,6 +135,40 @@ def test_deleting_extras_inline_is_persisted(db_session):
     assert 'foo' not in annotation.extra
 
 
+def test_appending_tags_inline_is_persisted(db_session):
+    """
+    In-place changes to Annotation.tags should be persisted.
+
+    Changes made by Annotation.tags.append() should be persisted to the
+    database.
+
+    """
+    annotation = Annotation(userid='fred')
+    annotation.tags = []  # FIXME: Annotation should have a default value here.
+    db_session.add(annotation)
+    db_session.flush()
+
+    annotation.tags.append('foo')
+    db_session.commit()
+    annotation = Annotation.query.get(annotation.id)
+
+    assert 'foo' in annotation.tags
+
+
+def test_deleting_tags_inline_is_persisted(db_session):
+    """In-place deletions of annotation tags should be persisted."""
+    annotation = Annotation(userid='fred')
+    annotation.tags = ['foo']
+    db_session.add(annotation)
+    db_session.flush()
+
+    del annotation.tags[0]
+    db_session.commit()
+    annotation = Annotation.query.get(annotation.id)
+
+    assert 'foo' not in annotation.tags
+
+
 @pytest.fixture
 def annotation(db_session):
     ann = Annotation(userid="testuser", target_uri="http://example.com")

--- a/tests/h/api/models/annotation_test.py
+++ b/tests/h/api/models/annotation_test.py
@@ -83,6 +83,58 @@ def test_acl_group_shared():
     assert actual == expect
 
 
+def test_setting_extras_inline_is_persisted(db_session):
+    """
+    In-place changes to Annotation.extra should be persisted.
+
+    Setting an Annotation.extra value in-place:
+
+        my_annotation.extra['foo'] = 'bar'
+
+    should be persisted to the database.
+
+    """
+    annotation = Annotation(userid='fred')
+    db_session.add(annotation)
+
+    # We need to flush the db here so that the default value for
+    # annotation.extra gets persisted and out mutation of annotation.extra
+    # below happens when the previous value is already persisted, otherwise
+    # this test would never fail.
+    db_session.flush()
+
+    annotation.extra['foo'] = 'bar'
+
+    # We need to commit the db session here so that the in-place change to
+    # annotation.extra above would be lost if annotation.extra was a normal
+    # dict. Without this commit() this test would never fail.
+    db_session.commit()
+
+    annotation = Annotation.query.get(annotation.id)
+
+    assert annotation.extra == {'foo': 'bar'}
+
+
+def test_deleting_extras_inline_is_persisted(db_session):
+    """
+    In-place changes to Annotation.extra should be persisted.
+
+    Deleting an Annotation.extra value in-place should be persisted to the
+    database.
+
+    """
+    annotation = Annotation(userid='fred')
+    annotation.extra = {'foo': 'bar'}
+    db_session.add(annotation)
+    db_session.flush()
+
+    del annotation.extra['foo']
+    db_session.commit()
+    annotation = Annotation.query.get(annotation.id)
+
+    assert 'foo' not in annotation.extra
+
+
 @pytest.fixture
 def annotation(db_session):
     ann = Annotation(userid="testuser", target_uri="http://example.com")


### PR DESCRIPTION
`target_selectors` is also a mutable object mutations of which are not being persisted to the database but that one is a more difficult case. I think these fixes for tags and extras can be merged separately first.