### PR TITLE
Allow token authentication to websocket, Mk. 2

### DIFF
--- a/h/app.py
+++ b/h/app.py
@@ -7,12 +7,14 @@ from __future__ import unicode_literals
 import collections
 import logging
 
-from pyramid.tweens import EXCVIEW
+from pyramid.authorization import ACLAuthorizationPolicy
 from pyramid.settings import asbool
+from pyramid.tweens import EXCVIEW
 import zope.sqlalchemy
 
 from h import assets
 from h import db
+from h.auth.policy import AuthenticationPolicy
 from h.config import configure
 
 log = logging.getLogger(__name__)
@@ -93,6 +95,14 @@ def includeme(config):
             "style-src": ["'self'", "fonts.googleapis.com"],
         },
     })
+
+    # Set up pyramid authentication and authorization policies. See the Pyramid
+    # documentation at:
+    #
+    #   http://docs.pylonsproject.org/projects/pyramid/en/latest/narr/security.html
+    #
+    config.set_authentication_policy(AuthenticationPolicy())
+    config.set_authorization_policy(ACLAuthorizationPolicy())
 
     # API module
     #

--- a/h/auth/__init__.py
+++ b/h/auth/__init__.py
@@ -17,13 +17,3 @@ def auth_domain(request):
 def includeme(config):
     # Allow retrieval of the auth_domain from the request object.
     config.add_request_method(auth_domain, name='auth_domain', reify=True)
-
-    # Set up pyramid authentication and authorization policies. See the Pyramid
-    # documentation at:
-    #
-    #   http://docs.pylonsproject.org/projects/pyramid/en/latest/narr/security.html
-    #
-    from h.auth.policy import AuthenticationPolicy
-    from pyramid.authorization import ACLAuthorizationPolicy
-    config.set_authentication_policy(AuthenticationPolicy())
-    config.set_authorization_policy(ACLAuthorizationPolicy())

--- a/h/websocket.py
+++ b/h/websocket.py
@@ -41,9 +41,14 @@ import logging
 from gevent.pool import Pool
 from gunicorn.workers.ggevent import (GeventPyWSGIWorker, PyWSGIHandler,
                                       PyWSGIServer)
+from pyramid.authentication import SessionAuthenticationPolicy
+from pyramid.authorization import ACLAuthorizationPolicy
+from pyramid_multiauth import MultiAuthenticationPolicy
 from ws4py import format_addresses
 
 from h import features
+from h.auth.policy import TokenAuthenticationPolicy
+from h.auth.util import groupfinder
 from h.config import configure
 
 log = logging.getLogger(__name__)
@@ -150,6 +155,14 @@ def create_app(global_config, **settings):
     config = configure(settings=settings)
 
     config.add_request_method(features.Client, name='feature', reify=True)
+
+    config.set_authorization_policy(ACLAuthorizationPolicy())
+
+    policy = MultiAuthenticationPolicy([
+        TokenAuthenticationPolicy(callback=groupfinder),
+        SessionAuthenticationPolicy(callback=groupfinder),
+    ])
+    config.set_authentication_policy(policy)
 
     config.include('h.auth')
     config.include('h.sentry')

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ INSTALL_REQUIRES = [
     'pyramid>=1.6,<1.7',
     'psycogreen>=1.0',
     'psycopg2>=2.6.1',
+    'pyramid-multiauth>=0.8.0,<0.9.0',
     'pyramid_mailer>=0.13',
     'pyramid_tm>=0.7',
     'python-dateutil>=2.1',


### PR DESCRIPTION
This is attempt number 2 at #3345, which I screwed up first time round by accidentally disabling session authentication to the WebSocket.

This uses `pyramid-multiauth` from Mozilla to "stack" the newly-added TokenAuthenticationPolicy and Pyramid's existing SessionAuthenticationPolicy. In the words of the `pyramid-multiauth` documentation, stacking auth policies means that "the results from the stacked authentication policies are combined as follows":

- authenticated_userid: return userid from first successful policy
- unauthenticated_userid: return userid from first successful policy
- effective_principals: return union of principals from all policies
- remember: return headers from all policies
- forget: return headers from all policies

This means that it is possible to authenticate to the websocket with either (or both) an API token and a valid session cookie, preserving the behaviour the client depends on, while making 3rd-party integration with the websocket easier.