### PR TITLE
Add Hypothesis-driven property-based tests for query builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ node_modules/
 # py.test state cache
 .cache/
 .coverage
+.hypothesis/
 .tox/
 
 .eggs/

--- a/tox.ini
+++ b/tox.ini
@@ -7,11 +7,14 @@ addopts = --pyargs
 testpaths = tests
 
 [testenv]
+# N.B. "hypothesis" in the list below is the property-based-testing framework,
+#      not our own code.
 deps =
     coverage
     factory-boy
     mock
     pytest
+    hypothesis
 passenv =
     TEST_DATABASE_URL
 commands = coverage run -m pytest {posargs:tests/h/}


### PR DESCRIPTION
This has the potential to cause much confusion. I'm sorry.

But I think the payoff is worth it.

Hypothesis is the thing we're building.

But Hypothesis is also an extremely capable property-based testing library for Python: https://github.com/HypothesisWorks/hypothesis-python

Property-based testing is an approach to testing code in which you write tests which assert the invariant properties of the system under test. For example, the tests in this commit check the following invariants of the code responsible for parsing the "limit" parameter to the search query builder:

- Any input of any description (assuming it's a string) will only ever result in an output in the range 0...LIMIT_MAX.
- Any input which is a string that is an integer in the range 0...LIMIT_MAX (e.g. "24") should result in an output which is the corresponding integer.

This is a very simple example of a property-based test, but even the few lines of code below result in *much* more comprehensive testing of the component in question than the small list of examples which it replaces. This is because Hypothesis typically generates dozens to hundreds of examples with which it tries to invalidate the invariant you've set up.

For more about Hypothesis and property-based testing, see [1].

For more about how to generate the right data for a Hypothesis-based test, see [2].

[1]: http://hypothesis.works/
[2]: http://hypothesis.works/articles/generating-the-right-data/