### PR TITLE
First steps towards removing the query property

### DIFF
--- a/h/accounts/models.py
+++ b/h/accounts/models.py
@@ -178,9 +178,9 @@ class User(Base):
         ).first()
 
     @classmethod
-    def get_by_activation(cls, activation):
+    def get_by_activation(cls, session, activation):
         """Fetch a user by activation instance."""
-        user = cls.query.filter(
+        user = session.query(cls).filter(
             cls.activation_id == activation.id
         ).first()
 

--- a/h/accounts/models.py
+++ b/h/accounts/models.py
@@ -50,9 +50,9 @@ class Activation(Base):
                      default=_generate_random_string)
 
     @classmethod
-    def get_by_code(cls, code):
+    def get_by_code(cls, session, code):
         """Fetch an activation by code."""
-        return cls.query.filter(cls.code == code).first()
+        return session.query(cls).filter(cls.code == code).first()
 
 
 class User(Base):

--- a/h/accounts/models.py
+++ b/h/accounts/models.py
@@ -171,9 +171,9 @@ class User(Base):
         return text_type(CRYPT.encode(password + self.salt))
 
     @classmethod
-    def get_by_email(cls, email):
+    def get_by_email(cls, session, email):
         """Fetch a user by email address."""
-        return cls.query.filter(
+        return session.query(cls).filter(
             sa.func.lower(cls.email) == email.lower()
         ).first()
 

--- a/h/accounts/models.py
+++ b/h/accounts/models.py
@@ -187,16 +187,6 @@ class User(Base):
         return user
 
     @classmethod
-    def get_user(cls, username, password):
-        """Fetch a user by username and validate their password."""
-        user = cls.get_by_username(username)
-
-        valid = cls.validate_user(user, password)
-
-        if valid:
-            return user
-
-    @classmethod
     def validate_user(cls, user, password):
         """Validate the passed password for the specified user."""
         if not user:

--- a/h/accounts/schemas.py
+++ b/h/accounts/schemas.py
@@ -39,7 +39,8 @@ def get_blacklist():
 
 def unique_email(node, value):
     '''Colander validator that ensures no user with this email exists.'''
-    user = models.User.get_by_email(value)
+    request = node.bindings['request']
+    user = models.User.get_by_email(request.db, value)
     if user:
         msg = _("Sorry, an account with this email address already exists.")
         raise colander.Invalid(node, msg)
@@ -121,12 +122,13 @@ class LoginSchema(CSRFSchema):
     def validator(self, node, value):
         super(LoginSchema, self).validator(node, value)
 
+        request = node.bindings['request']
         username = value.get('username')
         password = value.get('password')
 
         user = models.User.get_by_username(username)
         if user is None:
-            user = models.User.get_by_email(username)
+            user = models.User.get_by_email(request.db, username)
 
         if user is None:
             err = colander.Invalid(node)
@@ -161,8 +163,9 @@ class ForgotPasswordSchema(CSRFSchema):
     def validator(self, node, value):
         super(ForgotPasswordSchema, self).validator(node, value)
 
+        request = node.bindings['request']
         email = value.get('email')
-        user = models.User.get_by_email(email)
+        user = models.User.get_by_email(request.db, email)
 
         if user is None:
             err = colander.Invalid(node)

--- a/h/accounts/views.py
+++ b/h/accounts/views.py
@@ -423,7 +423,7 @@ class ActivateController(object):
             return httpexceptions.HTTPFound(
                 location=self.request.route_url('index'))
 
-        user = User.get_by_activation(activation)
+        user = User.get_by_activation(self.request.db, activation)
         if user is None or user.id != id_:
             raise httpexceptions.HTTPNotFound()
 

--- a/h/accounts/views.py
+++ b/h/accounts/views.py
@@ -411,7 +411,7 @@ class ActivateController(object):
         except ValueError:
             raise httpexceptions.HTTPNotFound()
 
-        activation = Activation.get_by_code(code)
+        activation = Activation.get_by_code(self.request.db, code)
         if activation is None:
             self.request.session.flash(jinja2.Markup(_(
                 "We didn't recognize that activation link. "

--- a/h/admin/views/users.py
+++ b/h/admin/views/users.py
@@ -28,7 +28,7 @@ def users_index(request):
     if username:
         user = models.User.get_by_username(username)
         if user is None:
-            user = models.User.get_by_email(username)
+            user = models.User.get_by_email(request.db, username)
 
     if user is not None:
         # Fetch information on how many annotations the user has created

--- a/tests/h/accounts/views_test.py
+++ b/tests/h/accounts/views_test.py
@@ -678,12 +678,14 @@ class TestActivateController(object):
             self,
             activation_model,
             user_model):
-        request = DummyRequest(matchdict={'id': '123', 'code': 'abc456'})
+        request = DummyRequest(db=mock.sentinel.db_session,
+                               matchdict={'id': '123', 'code': 'abc456'})
         user_model.get_by_activation.return_value.id = 123
 
         views.ActivateController(request).get_when_not_logged_in()
 
         user_model.get_by_activation.assert_called_once_with(
+            mock.sentinel.db_session,
             activation_model.get_by_code.return_value)
 
     def test_get_when_not_logged_in_404s_if_user_not_found(self, user_model):

--- a/tests/h/accounts/views_test.py
+++ b/tests/h/accounts/views_test.py
@@ -639,12 +639,13 @@ class TestActivateController(object):
             self,
             activation_model,
             user_model):
-        request = DummyRequest(matchdict={'id': '123', 'code': 'abc456'})
+        request = DummyRequest(db=mock.sentinel.db_session,
+                               matchdict={'id': '123', 'code': 'abc456'})
         user_model.get_by_activation.return_value.id = 123
 
         views.ActivateController(request).get_when_not_logged_in()
 
-        activation_model.get_by_code.assert_called_with('abc456')
+        activation_model.get_by_code.assert_called_with(mock.sentinel.db_session, 'abc456')
 
     def test_get_when_not_logged_in_redirects_if_activation_not_found(
             self,

--- a/tests/h/admin/views/users_test.py
+++ b/tests/h/admin/views/users_test.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import mock
 from mock import Mock
 from mock import MagicMock
 from mock import call
@@ -41,15 +42,15 @@ def test_users_index_looks_up_users_by_username(User):
 
 @users_index_fixtures
 def test_users_index_looks_up_users_by_email(User):
-    es = MagicMock()
-    request = DummyRequest(params={"username": "bob@builder.com"},
-                           es=es)
+    request = DummyRequest(db=mock.sentinel.db_session,
+                           es=MagicMock(),
+                           params={"username": "bob@builder.com"})
 
     User.get_by_username.return_value = None
 
     views.users_index(request)
 
-    User.get_by_email.assert_called_with("bob@builder.com")
+    User.get_by_email.assert_called_with(mock.sentinel.db_session, "bob@builder.com")
 
 
 @users_index_fixtures
@@ -77,9 +78,9 @@ def test_users_index_queries_annotation_count_by_userid(User):
 
 @users_index_fixtures
 def test_users_index_no_user_found(User):
-    es = MagicMock()
-    request = DummyRequest(params={"username": "bob"},
-                           es=es)
+    request = DummyRequest(db=mock.sentinel.db_session,
+                           es=MagicMock(),
+                           params={"username": "bob"})
     User.get_by_username.return_value = None
     User.get_by_email.return_value = None
 


### PR DESCRIPTION
The use of a "magic" query property makes testing difficult and causes confusion about which session is the correct session to use when writing new code.

This PR is part of an effort to standardise all ORM classmethods so they take a database session as their first parameter and do not rely on a thread-local query property.

There is a bunch more work to do here, some of which requires unpicking of other code, but this is a start.