### PR TITLE
Remove the h.accounts.make_admin helper

### DIFF
--- a/h/accounts/__init__.py
+++ b/h/accounts/__init__.py
@@ -34,15 +34,6 @@ class JSONError(Error):
     pass
 
 
-def make_admin(username):
-    """Make the given user an admin."""
-    user = models.User.get_by_username(username)
-    if user:
-        user.admin = True
-    else:
-        raise NoSuchUserError
-
-
 def make_staff(username):
     """Make the given user a staff member."""
     user = models.User.get_by_username(username)

--- a/h/admin/views/admins.py
+++ b/h/admin/views/admins.py
@@ -3,7 +3,6 @@
 from pyramid import httpexceptions
 from pyramid.view import view_config
 
-from h import accounts
 from h import models
 from h.i18n import TranslationString as _
 
@@ -25,12 +24,13 @@ def admins_index(_):
 def admins_add(request):
     """Make a given user an admin."""
     username = request.params['add']
-    try:
-        accounts.make_admin(username)
-    except accounts.NoSuchUserError:
+    user = models.User.get_by_username(username)
+    if user is None:
         request.session.flash(
             _("User {username} doesn't exist.".format(username=username)),
             "error")
+    else:
+        user.admin = True
     return admins_index(request)
 
 

--- a/h/cli/commands/admin.py
+++ b/h/cli/commands/admin.py
@@ -2,7 +2,7 @@
 
 import click
 
-from h import accounts
+from h import models
 
 
 @click.command()
@@ -16,5 +16,9 @@ def admin(ctx, username):
     administrative privileges.
     """
     request = ctx.obj['bootstrap']()
-    accounts.make_admin(username)
+    user = models.User.get_by_username(username)
+    if user is None:
+        raise click.ClickException('no user with username "{}"'.format(username))
+    else:
+        user.admin = True
     request.tm.commit()

--- a/tests/h/accounts/__init___test.py
+++ b/tests/h/accounts/__init___test.py
@@ -8,47 +8,6 @@ from h import accounts
 
 
 @mock.patch("h.accounts.models.User.get_by_username")
-def test_make_admin_gets_user_by_username(get_by_username):
-    """It should pass the right value to get_by_username()."""
-    accounts.make_admin("fred")
-
-    get_by_username.assert_called_once_with("fred")
-
-
-@mock.patch("h.accounts.models.User.get_by_username")
-def test_make_admin_sets_admin_to_True_if_False(get_by_username):
-    """It should set .admin to True if it was False."""
-    fred = mock.Mock()
-    fred.admin = False
-    get_by_username.return_value = fred
-
-    accounts.make_admin("fred")
-
-    assert fred.admin is True
-
-
-@mock.patch("h.accounts.models.User.get_by_username")
-def test_make_admin_sets_admin_to_True_if_True(get_by_username):
-    """If .admin is True it should just do nothing."""
-    fred = mock.Mock()
-    fred.admin = True
-    get_by_username.return_value = fred
-
-    accounts.make_admin("fred")
-
-    assert fred.admin is True
-
-
-@mock.patch("h.accounts.models.User.get_by_username")
-def test_make_admin_raises_if_user_does_not_exist(get_by_username):
-    """It should raise NoSuchUserError if the user doesn't exist."""
-    get_by_username.return_value = None
-
-    with pytest.raises(accounts.NoSuchUserError):
-        accounts.make_admin("fred")
-
-
-@mock.patch("h.accounts.models.User.get_by_username")
 def test_make_staff_gets_user_by_username(get_by_username):
     """It should pass the right value to get_by_username()."""
     accounts.make_staff("fred")

--- a/tests/h/conftest.py
+++ b/tests/h/conftest.py
@@ -85,7 +85,7 @@ def setup_database(settings):
 
 
 @pytest.fixture(autouse=True)
-def database_session(request, monkeypatch):
+def db_session(request, monkeypatch):
     """
     Prepare the SQLAlchemy session object.
 
@@ -105,6 +105,8 @@ def database_session(request, monkeypatch):
     monkeypatch.setattr(db.Session, 'commit', _fake_commit)
     # Prevent the session from closing (make it a no-op):
     monkeypatch.setattr(db.Session, 'remove', lambda: None)
+
+    return db.Session()
 
 
 @pytest.fixture


### PR DESCRIPTION
As part of the work started in #3423, I'm working up to making the `User.get_by_username` classmethod take an explicit database session rather than using the query property.

There are a couple of places that use `User.get_by_username` that don't currently have access to the request object, including these helpers (`make_admin` and `make_staff`) in `h.accounts`.

So, my options are:

1. Pass the request object into these helpers.
2. Remove the layer of indirection that the helpers represent.

I've opted here for the latter, because they don't really seem to be doing anything particularly useful. There are only two places that `make_admin` is used, namely the CLI and the admin panel. In the CLI, the NoSuchUserError is not caught and thus bubbles up to the user as a traceback, which isn't very nice. In the admin view, the code needed to handle the NoSuchUserError is almost exactly as verbose as the code needed without this helper.

Moreover, in the admin views, the helper can only be used to make a user an admin, not to remove their admin status, so the companion view (`admins_remove`) already knows about the `User` model.