### PR TITLE
Clean up admin "admins" view and associated tests

### DIFF
--- a/h/admin/views/admins.py
+++ b/h/admin/views/admins.py
@@ -31,7 +31,8 @@ def admins_add(request):
             "error")
     else:
         user.admin = True
-    return admins_index(request)
+    index = request.route_path('admin_admins')
+    return httpexceptions.HTTPSeeOther(location=index)
 
 
 @view_config(route_name='admin_admins',
@@ -44,9 +45,10 @@ def admins_remove(request):
     if len(models.User.admins()) > 1:
         username = request.params['remove']
         user = models.User.get_by_username(username)
-        user.admin = False
-    return httpexceptions.HTTPSeeOther(
-        location=request.route_url('admin_admins'))
+        if user is not None:
+            user.admin = False
+    index = request.route_path('admin_admins')
+    return httpexceptions.HTTPSeeOther(location=index)
 
 
 def includeme(config):


### PR DESCRIPTION
This commit is mainly about cleaning up the tests for the views responsible for managing which users are admins so that they are consistent with the test changes made in #3424.

It also makes the `admins_add` and `admins_remove` views consistent in their behaviour (they now both do redirect-after-post rather than just one of them), and fixes a bug that allowed the `admins_remove` view to crash if the username provided to it was invalid.