### PR TITLE
Remove the h.accounts.make_staff helper

### DIFF
--- a/h/accounts/__init__.py
+++ b/h/accounts/__init__.py
@@ -15,13 +15,6 @@ class Error(Exception):
     pass
 
 
-class NoSuchUserError(Error):
-
-    """Exception raised when asking for a user that doesn't exist."""
-
-    pass
-
-
 class JSONError(Error):
 
     """Exception raised when there's a problem with a request's JSON body.
@@ -32,15 +25,6 @@ class JSONError(Error):
     """
 
     pass
-
-
-def make_staff(username):
-    """Make the given user a staff member."""
-    user = models.User.get_by_username(username)
-    if user:
-        user.staff = True
-    else:
-        raise NoSuchUserError
 
 
 def get_user(userid, request):

--- a/tests/h/accounts/__init___test.py
+++ b/tests/h/accounts/__init___test.py
@@ -6,48 +6,6 @@ from pyramid import testing
 
 from h import accounts
 
-
-@mock.patch("h.accounts.models.User.get_by_username")
-def test_make_staff_gets_user_by_username(get_by_username):
-    """It should pass the right value to get_by_username()."""
-    accounts.make_staff("fred")
-
-    get_by_username.assert_called_once_with("fred")
-
-
-@mock.patch("h.accounts.models.User.get_by_username")
-def test_make_staff_sets_staff_to_True_if_False(get_by_username):
-    """It should set .staff to True if it was False."""
-    fred = mock.Mock()
-    fred.staff = False
-    get_by_username.return_value = fred
-
-    accounts.make_staff("fred")
-
-    assert fred.staff is True
-
-
-@mock.patch("h.accounts.models.User.get_by_username")
-def test_make_staff_sets_staff_to_True_if_True(get_by_username):
-    """If .staff is True it should just do nothing."""
-    fred = mock.Mock()
-    fred.staff = True
-    get_by_username.return_value = fred
-
-    accounts.make_staff("fred")
-
-    assert fred.staff is True
-
-
-@mock.patch("h.accounts.models.User.get_by_username")
-def test_make_staff_raises_if_user_does_not_exist(get_by_username):
-    """It should raise NoSuchUserError if the user doesn't exist."""
-    get_by_username.return_value = None
-
-    with pytest.raises(accounts.NoSuchUserError):
-        accounts.make_staff("fred")
-
-
 # The fixtures required to mock all of get_user()'s dependencies.
 get_user_fixtures = pytest.mark.usefixtures('util', 'get_by_username')
 

--- a/tests/h/admin/views/staff_test.py
+++ b/tests/h/admin/views/staff_test.py
@@ -1,152 +1,130 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
+
 from mock import Mock
 from pyramid import httpexceptions
 from pyramid.testing import DummyRequest
 import pytest
 
-from h import accounts
 from h.admin.views import staff as views
 
 
-# The fixtures required to mock all of staff_index()'s dependencies.
-staff_index_fixtures = pytest.mark.usefixtures('User')
+@pytest.mark.usefixtures('routes')
+class TestStaffIndex(object):
+    def test_when_no_staff(self):
+        request = DummyRequest()
+
+        result = views.staff_index(request)
+
+        assert result["staff"] == []
+
+    @pytest.mark.usefixtures('users')
+    def test_context_contains_staff_usernames(self):
+        request = DummyRequest()
+
+        result = views.staff_index(request)
+
+        assert set(result["staff"]) == set(["agnos", "bojan", "cristof"])
 
 
-@staff_index_fixtures
-def test_staff_index_when_no_staff(User):
-    request = DummyRequest()
-    User.staff_members.return_value = []
+@pytest.mark.usefixtures('users', 'routes')
+class TestStaffAddRemove(object):
 
-    result = views.staff_index(request)
+    def test_add_makes_users_staff(self, users):
+        request = DummyRequest(params={"add": "eva"})
 
-    assert result["staff"] == []
+        views.staff_add(request)
 
+        assert users['eva'].staff
 
-@staff_index_fixtures
-def test_staff_index_when_one_staff(User):
-    request = DummyRequest()
-    User.staff_members.return_value = [Mock(username="fred")]
+    def test_add_is_idempotent(self, users):
+        request = DummyRequest(params={"add": "agnos"})
 
-    result = views.staff_index(request)
+        views.staff_add(request)
 
-    assert result["staff"] == ["fred"]
+        assert users['agnos'].staff
 
+    def test_add_redirects_to_index(self):
+        request = DummyRequest(params={"add": "eva"})
 
-@staff_index_fixtures
-def test_staff_index_when_multiple_staff(User):
-    request = DummyRequest()
-    User.staff_members.return_value = [Mock(username="fred"),
-                                       Mock(username="bob"),
-                                       Mock(username="frank")]
+        result = views.staff_add(request)
 
-    result = views.staff_index(request)
+        assert isinstance(result, httpexceptions.HTTPSeeOther)
+        assert result.location == '/adm/staff'
 
-    assert result["staff"] == ["fred", "bob", "frank"]
+    def test_add_redirects_to_index_when_user_not_found(self):
+        request = DummyRequest(params={"add": "florp"})
 
+        result = views.staff_add(request)
 
-# The fixtures required to mock all of staff_add()'s dependencies.
-staff_add_fixtures = pytest.mark.usefixtures('make_staff', 'staff_index')
+        assert isinstance(result, httpexceptions.HTTPSeeOther)
+        assert result.location == '/adm/staff'
 
+    def test_add_flashes_when_user_not_found(self):
+        request = DummyRequest(params={"add": "florp"})
+        request.session.flash = Mock()
 
-@staff_add_fixtures
-def test_staff_add_calls_make_staff(make_staff):
-    request = DummyRequest(params={"add": "seanh"})
+        views.staff_add(request)
 
-    views.staff_add(request)
+        assert request.session.flash.call_count == 1
 
-    make_staff.assert_called_once_with("seanh")
+    def test_remove_makes_users_not_staff(self, users):
+        request = DummyRequest(params={"remove": "cristof"})
 
+        views.staff_remove(request)
 
-@staff_add_fixtures
-def test_staff_add_returns_index_on_success(staff_index):
-    request = DummyRequest(params={"add": "seanh"})
-    staff_index.return_value = "expected data"
+        assert not users['cristof'].staff
 
-    result = views.staff_add(request)
+    def test_remove_is_idempotent(self, users):
+        request = DummyRequest(params={"remove": "eva"})
 
-    assert result == "expected data"
+        views.staff_remove(request)
 
+        assert not users['eva'].staff
 
-@staff_add_fixtures
-def test_staff_add_flashes_on_NoSuchUserError(make_staff):
-    make_staff.side_effect = accounts.NoSuchUserError
-    request = DummyRequest(params={"add": "seanh"})
-    request.session.flash = Mock()
+    def test_remove_redirects_to_index(self):
+        request = DummyRequest(params={"remove": "agnos"})
 
-    views.staff_add(request)
+        result = views.staff_remove(request)
 
-    assert request.session.flash.call_count == 1
+        assert isinstance(result, httpexceptions.HTTPSeeOther)
+        assert result.location == '/adm/staff'
 
+    def test_remove_redirects_to_index_when_user_not_found(self):
+        request = DummyRequest(params={"remove": "florp"})
 
-@staff_add_fixtures
-def test_staff_add_returns_index_on_NoSuchUserError(make_staff, staff_index):
-    make_staff.side_effect = accounts.NoSuchUserError
-    staff_index.return_value = "expected data"
-    request = DummyRequest(params={"add": "seanh"})
+        result = views.staff_remove(request)
 
-    result = views.staff_add(request)
-
-    assert result == "expected data"
+        assert isinstance(result, httpexceptions.HTTPSeeOther)
+        assert result.location == '/adm/staff'
 
 
-# The fixtures required to mock all of staff_remove()'s dependencies.
-staff_remove_fixtures = pytest.mark.usefixtures('User')
+@pytest.fixture
+def users(db_session):
+    from h import models
+
+    staff = ['agnos', 'bojan', 'cristof']
+    nonstaff = ['david', 'eva', 'flora']
+
+    users = {}
+
+    for staff in staff:
+        users[staff] = models.User(username=staff,
+                                   email=staff + '@example.com',
+                                   password='secret',
+                                   staff=True)
+    for nonstaff in nonstaff:
+        users[nonstaff] = models.User(username=nonstaff,
+                                      email=nonstaff + '@example.com',
+                                      password='secret')
+
+    db_session.add_all(list(users.values()))
+    db_session.flush()
+
+    return users
 
 
-@staff_remove_fixtures
-def test_staff_remove_calls_get_by_username(User):
-    User.staff_members.return_value = [Mock(username="fred"),
-                                       Mock(username="bob"),
-                                       Mock(username="frank")]
-    request = DummyRequest(params={"remove": "fred"})
-
-    views.staff_remove(request)
-
-    User.get_by_username.assert_called_once_with("fred")
-
-
-@staff_remove_fixtures
-def test_staff_remove_sets_staff_to_False(User):
-    User.staff_members.return_value = [Mock(username="fred"),
-                                       Mock(username="bob"),
-                                       Mock(username="frank")]
-    request = DummyRequest(params={"remove": "fred"})
-    user = Mock(staff=True)
-    User.get_by_username.return_value = user
-
-    views.staff_remove(request)
-
-    assert user.staff is False
-
-
-@staff_remove_fixtures
-def test_staff_remove_returns_redirect_on_success(User):
-    User.staff_members.return_value = [Mock(username="fred"),
-                                       Mock(username="bob"),
-                                       Mock(username="frank")]
-    request = DummyRequest(params={"remove": "fred"})
-
-    response = views.staff_remove(request)
-
-    assert isinstance(response, httpexceptions.HTTPSeeOther)
-
-
-@pytest.fixture(autouse=True)
+@pytest.fixture()
 def routes(config):
     config.add_route('admin_staff', '/adm/staff')
-
-
-@pytest.fixture
-def User(patch):
-    return patch('h.models.User')
-
-
-@pytest.fixture
-def make_staff(patch):
-    return patch('h.admin.views.staff.accounts.make_staff')
-
-
-@pytest.fixture
-def staff_index(patch):
-    return patch('h.admin.views.staff.staff_index')


### PR DESCRIPTION
This is exactly the same set of changes as made in #3424 and #3425, only for
the `make_staff` helper and views rather than for the `make_admin` helper and
views.