### PR TITLE
Do not use query property in User.get_by_username

### DIFF
--- a/h/accounts/__init__.py
+++ b/h/accounts/__init__.py
@@ -46,7 +46,7 @@ def get_user(userid, request):
     if parts['domain'] != request.auth_domain:
         return None
 
-    return models.User.get_by_username(parts['username'])
+    return models.User.get_by_username(request.db, parts['username'])
 
 
 def authenticated_user(request):

--- a/h/accounts/models.py
+++ b/h/accounts/models.py
@@ -200,10 +200,10 @@ class User(Base):
         return valid
 
     @classmethod
-    def get_by_username(cls, username):
+    def get_by_username(cls, session, username):
         """Fetch a user by username."""
         uid = _username_to_uid(username)
-        return cls.query.filter(cls.uid == uid).first()
+        return session.query(cls).filter(cls.uid == uid).first()
 
     @classmethod
     def admins(cls):

--- a/h/accounts/schemas.py
+++ b/h/accounts/schemas.py
@@ -48,7 +48,8 @@ def unique_email(node, value):
 
 def unique_username(node, value):
     '''Colander validator that ensures the username does not exist.'''
-    user = models.User.get_by_username(value)
+    request = node.bindings['request']
+    user = models.User.get_by_username(request.db, value)
     if user:
         msg = _("Sorry, an account with this username already exists. "
                 "Please enter another one.")
@@ -126,7 +127,7 @@ class LoginSchema(CSRFSchema):
         username = value.get('username')
         password = value.get('password')
 
-        user = models.User.get_by_username(username)
+        user = models.User.get_by_username(request.db, username)
         if user is None:
             user = models.User.get_by_email(request.db, username)
 
@@ -228,7 +229,7 @@ class ResetCode(colander.SchemaType):
         except BadData:
             raise colander.Invalid(node, _('Your reset code is not valid'))
 
-        user = models.User.get_by_username(username)
+        user = models.User.get_by_username(request.db, username)
         if user is None:
             raise colander.Invalid(node, _('Your reset code is not valid'))
         if user.password_updated is not None and timestamp < user.password_updated:

--- a/h/admin/views/admins.py
+++ b/h/admin/views/admins.py
@@ -24,7 +24,7 @@ def admins_index(_):
 def admins_add(request):
     """Make a given user an admin."""
     username = request.params['add']
-    user = models.User.get_by_username(username)
+    user = models.User.get_by_username(request.db, username)
     if user is None:
         request.session.flash(
             _("User {username} doesn't exist.".format(username=username)),
@@ -44,7 +44,7 @@ def admins_remove(request):
     """Remove a user from the admins."""
     if len(models.User.admins()) > 1:
         username = request.params['remove']
-        user = models.User.get_by_username(username)
+        user = models.User.get_by_username(request.db, username)
         if user is not None:
             user.admin = False
     index = request.route_path('admin_admins')

--- a/h/admin/views/features.py
+++ b/h/admin/views/features.py
@@ -78,7 +78,7 @@ def cohorts_edit_add(request):
     member_name = request.params['add']
     cohort_id = request.matchdict['id']
 
-    member = models.User.get_by_username(member_name)
+    member = models.User.get_by_username(request.db, member_name)
     if member is None:
         request.session.flash(
             _("User {member_name} doesn't exist.".format(member_name=member_name)),

--- a/h/admin/views/staff.py
+++ b/h/admin/views/staff.py
@@ -24,7 +24,7 @@ def staff_index(_):
 def staff_add(request):
     """Make a given user a staff member."""
     username = request.params['add']
-    user = models.User.get_by_username(username)
+    user = models.User.get_by_username(request.db, username)
     if user is None:
         request.session.flash(
             _("User {username} doesn't exist.".format(username=username)),
@@ -43,7 +43,7 @@ def staff_add(request):
 def staff_remove(request):
     """Remove a user from the staff."""
     username = request.params['remove']
-    user = models.User.get_by_username(username)
+    user = models.User.get_by_username(request.db, username)
     if user is not None:
         user.staff = False
     index = request.route_path('admin_staff')

--- a/h/admin/views/users.py
+++ b/h/admin/views/users.py
@@ -26,7 +26,7 @@ def users_index(request):
     username = request.params.get('username')
 
     if username:
-        user = models.User.get_by_username(username)
+        user = models.User.get_by_username(request.db, username)
         if user is None:
             user = models.User.get_by_email(request.db, username)
 
@@ -47,7 +47,7 @@ def users_index(request):
              permission='admin_users')
 def users_activate(request):
     username = request.params['username']
-    user = models.User.get_by_username(username)
+    user = models.User.get_by_username(request.db, username)
 
     if user is None:
         request.session.flash(jinja2.Markup(_(
@@ -74,7 +74,7 @@ def users_activate(request):
              permission='admin_users')
 def users_delete(request):
     username = request.params.get('username')
-    user = models.User.get_by_username(username)
+    user = models.User.get_by_username(request.db, username)
 
     if user is None:
         request.session.flash(

--- a/h/cli/commands/admin.py
+++ b/h/cli/commands/admin.py
@@ -16,7 +16,7 @@ def admin(ctx, username):
     administrative privileges.
     """
     request = ctx.obj['bootstrap']()
-    user = models.User.get_by_username(username)
+    user = models.User.get_by_username(request.db, username)
     if user is None:
         raise click.ClickException('no user with username "{}"'.format(username))
     else:

--- a/tests/h/accounts/__init___test.py
+++ b/tests/h/accounts/__init___test.py
@@ -40,13 +40,13 @@ def test_get_user_returns_None_if_domain_does_not_match(util):
 @get_user_fixtures
 def test_get_user_calls_get_by_username(util, get_by_username):
     """It should call get_by_username() once with the username."""
-    request = mock.Mock(auth_domain='hypothes.is')
+    request = mock.Mock(auth_domain='hypothes.is', db=mock.sentinel.db_session)
     util.user.split_user.return_value = {
         'username': 'username', 'domain': 'hypothes.is'}
 
     accounts.get_user('acct:username@hypothes.is', request)
 
-    get_by_username.assert_called_once_with('username')
+    get_by_username.assert_called_once_with(mock.sentinel.db_session, 'username')
 
 
 @get_user_fixtures

--- a/tests/h/accounts/schemas_test.py
+++ b/tests/h/accounts/schemas_test.py
@@ -92,7 +92,8 @@ def test_unique_email_invalid_when_user_does_not_exist(user_model):
 
 
 def test_RegisterSchema_with_password_too_short(user_model):
-    schema = schemas.RegisterSchema().bind(request=DummyRequest())
+    request = DummyRequest(db=mock.sentinel.db_session)
+    schema = schemas.RegisterSchema().bind(request=request)
 
     with pytest.raises(colander.Invalid) as exc:
         schema.deserialize({"password": "a"})
@@ -100,7 +101,8 @@ def test_RegisterSchema_with_password_too_short(user_model):
 
 
 def test_RegisterSchema_with_username_too_short(user_model):
-    schema = schemas.RegisterSchema().bind(request=DummyRequest())
+    request = DummyRequest(db=mock.sentinel.db_session)
+    schema = schemas.RegisterSchema().bind(request=request)
 
     with pytest.raises(colander.Invalid) as exc:
         schema.deserialize({"username": "a"})
@@ -108,7 +110,8 @@ def test_RegisterSchema_with_username_too_short(user_model):
 
 
 def test_RegisterSchema_with_username_too_long(user_model):
-    schema = schemas.RegisterSchema().bind(request=DummyRequest())
+    request = DummyRequest(db=mock.sentinel.db_session)
+    schema = schemas.RegisterSchema().bind(request=request)
 
     with pytest.raises(colander.Invalid) as exc:
         schema.deserialize({"username": "a" * 500})

--- a/tests/h/admin/views/staff_test.py
+++ b/tests/h/admin/views/staff_test.py
@@ -2,7 +2,7 @@
 
 from __future__ import unicode_literals
 
-from mock import Mock
+import mock
 from pyramid import httpexceptions
 from pyramid.testing import DummyRequest
 import pytest
@@ -12,18 +12,14 @@ from h.admin.views import staff as views
 
 @pytest.mark.usefixtures('routes')
 class TestStaffIndex(object):
-    def test_when_no_staff(self):
-        request = DummyRequest()
-
-        result = views.staff_index(request)
+    def test_when_no_staff(self, req):
+        result = views.staff_index(req)
 
         assert result["staff"] == []
 
     @pytest.mark.usefixtures('users')
-    def test_context_contains_staff_usernames(self):
-        request = DummyRequest()
-
-        result = views.staff_index(request)
+    def test_context_contains_staff_usernames(self, req):
+        result = views.staff_index(req)
 
         assert set(result["staff"]) == set(["agnos", "bojan", "cristof"])
 
@@ -31,73 +27,83 @@ class TestStaffIndex(object):
 @pytest.mark.usefixtures('users', 'routes')
 class TestStaffAddRemove(object):
 
-    def test_add_makes_users_staff(self, users):
-        request = DummyRequest(params={"add": "eva"})
+    def test_add_makes_users_staff(self, req, users):
+        req.params = {"add": "eva"}
 
-        views.staff_add(request)
+        views.staff_add(req)
 
         assert users['eva'].staff
 
-    def test_add_is_idempotent(self, users):
-        request = DummyRequest(params={"add": "agnos"})
+    def test_add_is_idempotent(self, req, users):
+        req.params = {"add": "agnos"}
 
-        views.staff_add(request)
+        views.staff_add(req)
 
         assert users['agnos'].staff
 
-    def test_add_redirects_to_index(self):
-        request = DummyRequest(params={"add": "eva"})
+    def test_add_redirects_to_index(self, req):
+        req.params = {"add": "eva"}
 
-        result = views.staff_add(request)
-
-        assert isinstance(result, httpexceptions.HTTPSeeOther)
-        assert result.location == '/adm/staff'
-
-    def test_add_redirects_to_index_when_user_not_found(self):
-        request = DummyRequest(params={"add": "florp"})
-
-        result = views.staff_add(request)
+        result = views.staff_add(req)
 
         assert isinstance(result, httpexceptions.HTTPSeeOther)
         assert result.location == '/adm/staff'
 
-    def test_add_flashes_when_user_not_found(self):
-        request = DummyRequest(params={"add": "florp"})
-        request.session.flash = Mock()
+    def test_add_redirects_to_index_when_user_not_found(self, req):
+        req.params = {"add": "florp"}
 
-        views.staff_add(request)
+        result = views.staff_add(req)
 
-        assert request.session.flash.call_count == 1
+        assert isinstance(result, httpexceptions.HTTPSeeOther)
+        assert result.location == '/adm/staff'
 
-    def test_remove_makes_users_not_staff(self, users):
-        request = DummyRequest(params={"remove": "cristof"})
+    def test_add_flashes_when_user_not_found(self, req):
+        req.params = {"add": "florp"}
+        req.session.flash = mock.Mock()
 
-        views.staff_remove(request)
+        views.staff_add(req)
+
+        assert req.session.flash.call_count == 1
+
+    def test_remove_makes_users_not_staff(self, req, users):
+        req.params = {"remove": "cristof"}
+
+        views.staff_remove(req)
 
         assert not users['cristof'].staff
 
-    def test_remove_is_idempotent(self, users):
-        request = DummyRequest(params={"remove": "eva"})
+    def test_remove_is_idempotent(self, req, users):
+        req.params = {"remove": "eva"}
 
-        views.staff_remove(request)
+        views.staff_remove(req)
 
         assert not users['eva'].staff
 
-    def test_remove_redirects_to_index(self):
-        request = DummyRequest(params={"remove": "agnos"})
+    def test_remove_redirects_to_index(self, req):
+        req.params = {"remove": "agnos"}
 
-        result = views.staff_remove(request)
+        result = views.staff_remove(req)
+
+        assert isinstance(result, httpexceptions.HTTPSeeOther)
+        assert result.location == '/adm/staff'
+
+    def test_remove_redirects_to_index_when_user_not_found(self, req):
+        req.params = {"remove": "florp"}
+
+        result = views.staff_remove(req)
 
         assert isinstance(result, httpexceptions.HTTPSeeOther)
         assert result.location == '/adm/staff'
 
-    def test_remove_redirects_to_index_when_user_not_found(self):
-        request = DummyRequest(params={"remove": "florp"})
 
-        result = views.staff_remove(request)
+@pytest.fixture
+def req(db_session):
+    return DummyRequest(db=db_session)
 
-        assert isinstance(result, httpexceptions.HTTPSeeOther)
-        assert result.location == '/adm/staff'
+
+@pytest.fixture
+def routes(config):
+    config.add_route('admin_staff', '/adm/staff')
 
 
 @pytest.fixture
@@ -123,8 +129,3 @@ def users(db_session):
     db_session.flush()
 
     return users
-
-
-@pytest.fixture()
-def routes(config):
-    config.add_route('admin_staff', '/adm/staff')


### PR DESCRIPTION
The use of a "magic" query property makes testing difficult and causes confusion about which session is the correct session to use when writing new code.

This commit is part of an effort to standardise all ORM classmethods so they take a database session as their first parameter and do not rely on a thread-local query property.