### PR TITLE
Do not use query property in Token.get_by_{userid,value}

### DIFF
--- a/h/accounts/views.py
+++ b/h/accounts/views.py
@@ -581,7 +581,8 @@ class DeveloperController(object):
     @view_config(request_method='GET')
     def get(self):
         """Render the developer page, including the form."""
-        token = models.Token.get_by_userid(self.request.authenticated_userid)
+        token = models.Token.get_by_userid(self.request.db,
+                                           self.request.authenticated_userid)
         if token:
             return {'token': token.value}
         else:
@@ -590,7 +591,8 @@ class DeveloperController(object):
     @view_config(request_method='POST')
     def post(self):
         """(Re-)generate the user's API token."""
-        token = models.Token.get_by_userid(self.request.authenticated_userid)
+        token = models.Token.get_by_userid(self.request.db,
+                                           self.request.authenticated_userid)
 
         if token:
             # The user already has an API token, regenerate it.

--- a/h/auth/models.py
+++ b/h/auth/models.py
@@ -38,12 +38,12 @@ class Token(Base, mixins.Timestamps):
         self.regenerate()
 
     @classmethod
-    def get_by_userid(cls, userid):
-        return cls.query.filter(cls.userid == userid).first()
+    def get_by_userid(cls, session, userid):
+        return session.query(cls).filter(cls.userid == userid).first()
 
     @classmethod
-    def get_by_value(cls, value):
-        return cls.query.filter(cls.value == value).first()
+    def get_by_value(cls, session, value):
+        return session.query(cls).filter(cls.value == value).first()
 
     def regenerate(self):
         self.value = self.prefix + _token()

--- a/h/auth/policy.py
+++ b/h/auth/policy.py
@@ -98,7 +98,7 @@ class TokenAuthenticationPolicy(CallbackAuthenticationPolicy):
         if not token:
             return None
 
-        return (tokens.userid_from_api_token(token) or
+        return (tokens.userid_from_api_token(token, request) or
                 tokens.userid_from_jwt(token, request))
 
 

--- a/h/auth/tokens.py
+++ b/h/auth/tokens.py
@@ -73,7 +73,7 @@ def userid_from_jwt(token, request):
         return None
 
 
-def userid_from_api_token(token):
+def userid_from_api_token(token, request):
     """
     Return the userid authenticated by the given API token.
 
@@ -86,13 +86,16 @@ def userid_from_api_token(token):
     :param token: the token to check
     :type token: unicode
 
+    :param request: the request object
+    :type request: pyramid.request.Request
+
     :returns: the userid authenticated by the token, or None
     :rtype: unicode or None
     """
     if not token.startswith(models.Token.prefix):
         return None
 
-    token_obj = models.Token.get_by_value(token)
+    token_obj = models.Token.get_by_value(request.db, token)
     if token_obj:
         return token_obj.userid
     else:

--- a/tests/h/auth/policy_test.py
+++ b/tests/h/auth/policy_test.py
@@ -145,7 +145,7 @@ class TestTokenAuthenticationPolicy(object):
 
         policy.unauthenticated_userid(request)
 
-        api_token.assert_called_once_with('f00ba12')
+        api_token.assert_called_once_with('f00ba12', request)
         jwt.assert_called_once_with('f00ba12', request)
 
     def test_unauthenticated_userid_returns_userid_from_api_token_if_present(self, jwt, api_token):

--- a/tests/h/auth/tokens_test.py
+++ b/tests/h/auth/tokens_test.py
@@ -2,6 +2,7 @@
 
 import datetime
 
+import mock
 import pytest
 from pyramid.testing import DummyRequest
 
@@ -122,34 +123,37 @@ def test_userid_from_api_token_returns_None_when_token_doesnt_start_with_prefix(
     As a sanity check, don't even attempt to look up tokens that don't start
     with the expected prefix.
     """
+    request = mock_request()
     token = models.Token('acct:foo@example.com')
     token.value = u'abc123'
     db.Session.add(token)
 
-    result = tokens.userid_from_api_token(u'abc123')
+    result = tokens.userid_from_api_token(u'abc123', request)
 
     assert result is None
 
 
 def test_userid_from_api_token_returns_None_for_nonexistent_tokens():
+    request = mock_request()
     madeuptoken = models.Token.prefix + '123abc'
 
-    result = tokens.userid_from_api_token(madeuptoken)
+    result = tokens.userid_from_api_token(madeuptoken, request)
 
     assert result is None
 
 
 def test_userid_from_api_token_returns_userid_for_valid_tokens():
+    request = mock_request()
     token = models.Token('acct:foo@example.com')
     db.Session.add(token)
 
-    result = tokens.userid_from_api_token(token.value)
+    result = tokens.userid_from_api_token(token.value, request)
 
     assert result == 'acct:foo@example.com'
 
 
 def mock_request():
-    request = DummyRequest()
+    request = DummyRequest(db=db.Session)
     request.registry.settings = {
         'h.client_id': 'id',
         'h.client_secret': 'secret'


### PR DESCRIPTION
The use of a "magic" query property makes testing difficult and causes
confusion about which session is the correct session to use when writing
new code.

This commit is part of an effort to standardise all ORM classmethods so
they take a database session as their first parameter and do not rely on
a thread-local query property.