### PR TITLE
Do not use query property in Blocklist model

### DIFF
--- a/h/admin/views/badge.py
+++ b/h/admin/views/badge.py
@@ -1,40 +1,53 @@
 # -*- coding: utf-8 -*-
 
+from pyramid import httpexceptions
 from pyramid.view import view_config
+from sqlalchemy.exc import IntegrityError
 
 from h import models
+from h.i18n import TranslationString as _
 
 
 @view_config(route_name='admin_badge',
              request_method='GET',
              renderer='h:templates/admin/badge.html.jinja2',
              permission='admin_badge')
-def badge_index(_):
-    return {"uris": models.Blocklist.all()}
+def badge_index(request):
+    return {"uris": request.db.query(models.Blocklist).all()}
 
 
 @view_config(route_name='admin_badge',
              request_method='POST',
              request_param='add',
-             renderer='h:templates/admin/badge.html.jinja2',
              permission='admin_badge')
 def badge_add(request):
+    uri = request.params['add']
+    item = models.Blocklist(uri=uri)
+    request.db.add(item)
+
+    # There's a uniqueness constraint on `uri`, so we flush the session,
+    # catching any IntegrityError and responding appropriately.
     try:
-        request.db.add(models.Blocklist(uri=request.params['add']))
-    except ValueError as exc:
-        request.session.flash(exc.message, 'error')
-    return badge_index(request)
+        request.db.flush()
+    except IntegrityError:
+        request.db.rollback()
+        msg = _("{uri} is already blocked.").format(uri=uri)
+        request.session.flash(msg, 'error')
+
+    index = request.route_path('admin_badge')
+    return httpexceptions.HTTPSeeOther(location=index)
 
 
 @view_config(route_name='admin_badge',
              request_method='POST',
              request_param='remove',
-             renderer='h:templates/admin/badge.html.jinja2',
              permission='admin_badge')
 def badge_remove(request):
     uri = request.params['remove']
-    request.db.delete(models.Blocklist.get_by_uri(uri))
-    return badge_index(request)
+    request.db.query(models.Blocklist).filter_by(uri=uri).delete()
+
+    index = request.route_path('admin_badge')
+    return httpexceptions.HTTPSeeOther(location=index)
 
 
 def includeme(config):

--- a/h/badge/views.py
+++ b/h/badge/views.py
@@ -21,7 +21,7 @@ def badge(request):
     if not uri:
         raise httpexceptions.HTTPBadRequest()
 
-    if models.Blocklist.is_blocked(uri):
+    if models.Blocklist.is_blocked(request.db, uri):
         return {'total': 0}
 
     return {


### PR DESCRIPTION
This commit is part of an effort to standardise all ORM classmethods so they take a database session as their first parameter and do not rely on a thread-local query property.

The Blocklist model stores a list of patterns to be matched against incoming URLs for badge requests to see if the badge count should be forced to 0 for that request.

There were a number of classmethods on the Blocklist model, most of which were there to assist the admin views for updating the blocklist, rather than for the primary badge endpoint. Most of these are now gone.

Specifically:

- The only classmethod remaining is Blocklist.is_blocked, which now takes a database session as its first parameter.
- Blocklist.all was an alias for Blocklist.query.all... now gone.
- Blocklist.get_by_uri was only used by a) a validator that wasn't concurrency-safe, and b) Blocklist.is_blocked. I've removed the validator and replaced the relevant validation with a concurrency-safe version, and moved the lookup query directly into .is_blocked.

While in this part of the code, I've made the admin POST view functions do a redirect-after-post to prevent double submission problems.

Lastly, I've rejigged the tests for the admin views in much the same way as I did in #3424 and #3425 for the admins/staff admin views.