### PR TITLE
Append URI from document to PDF incontext links

### DIFF
--- a/h/links.py
+++ b/h/links.py
@@ -25,10 +25,17 @@ def incontext_link(request, annotation):
 
     link = urlparse.urljoin(bouncer_url, annotation.id)
     uri = annotation.target_uri
-    if uri and uri.startswith(('http://', 'https://')):
+    if uri.startswith(('http://', 'https://')):
         # We can't use urljoin here, because if it detects the second argument
         # is a URL it will discard the base URL, breaking the link entirely.
         link += '/' + uri[uri.index('://')+3:]
+    elif uri.startswith('urn:x-pdf:') and annotation.document:
+        for docuri in annotation.document.document_uris:
+            uri = docuri.uri
+            if uri.startswith(('http://', 'https://')):
+                link += '/' + uri[uri.index('://')+3:]
+                break
+
     return link
 
 

--- a/tests/h/links_test.py
+++ b/tests/h/links_test.py
@@ -5,11 +5,23 @@ import pytest
 
 from h import links
 
+
 class FakeAnnotation(object):
     def __init__(self):
         self.id = '123'
         self.references = None
         self.target_uri = 'http://example.com/foo/bar'
+        self.document = None
+
+
+class FakeDocumentURI(object):
+    def __init__(self):
+        self.uri = 'http://example.com/foo.pdf'
+
+
+class FakeDocument(object):
+    def __init__(self):
+        self.document_uris = []
 
 
 def test_incontext_link(api_request):
@@ -30,7 +42,6 @@ def test_incontext_link_is_none_for_replies(api_request):
 
 
 @pytest.mark.parametrize('target_uri,expected', [
-    (None, 'https://hyp.is/123'),
     ('', 'https://hyp.is/123'),
     ('something_not_a_url', 'https://hyp.is/123'),
     ('ftp://not_http', 'https://hyp.is/123'),
@@ -46,6 +57,33 @@ def test_incontext_link_appends_schemaless_uri_if_present(api_request,
     link = links.incontext_link(api_request, annotation)
 
     assert link == expected
+
+
+def test_incontext_link_appends_first_schemaless_uri_for_pdfs_with_document(api_request):
+    doc = FakeDocument()
+    docuri1 = FakeDocumentURI()
+    docuri1.uri = 'http://example.com/foo.pdf'
+    docuri2 = FakeDocumentURI()
+    docuri2.uri = 'http://example.com/bar.pdf'
+
+    doc.document_uris = [docuri1, docuri2]
+
+    annotation = FakeAnnotation()
+    annotation.document = doc
+    annotation.target_uri = 'urn:x-pdf:the-fingerprint'
+
+    link = links.incontext_link(api_request, annotation)
+
+    assert link == 'https://hyp.is/123/example.com/foo.pdf'
+
+
+def test_incontext_link_skips_uri_for_pdfs_with_no_document(api_request):
+    annotation = FakeAnnotation()
+    annotation.target_uri = 'urn:x-pdf:the-fingerprint'
+
+    link = links.incontext_link(api_request, annotation)
+
+    assert link == 'https://hyp.is/123'
 
 
 @pytest.fixture


### PR DESCRIPTION
We now use the PDF fingerprint as the target_uri of the annotation. In
order to still be able to append a potential HTTP URL to the incontext
link, we are trying to load an HTTP URL from the document uris.

The same work still needs to be done in Bouncer.