### PR TITLE
Make thread building more idiomatic by using memoization

### DIFF
--- a/h/static/scripts/annotation-viewer-controller.js
+++ b/h/static/scripts/annotation-viewer-controller.js
@@ -17,17 +17,17 @@ function AnnotationViewerController (
     $location.path('/stream').search('q', query);
   };
 
-  rootThread.on('changed', function (thread) {
+  function thread() {
+    return rootThread.thread(annotationUI.getState());
+  }
+
+  annotationUI.subscribe(function () {
     $scope.virtualThreadList = {
-      visibleThreads: thread.children,
+      visibleThreads: thread().children,
       offscreenUpperHeight: '0px',
       offscreenLowerHeight: '0px',
     };
   });
-
-  $scope.rootThread = function () {
-    return rootThread.thread();
-  };
 
   $scope.setCollapsed = function (id, collapsed) {
     annotationUI.setCollapsed(id, collapsed);

--- a/h/static/scripts/stream-controller.coffee
+++ b/h/static/scripts/stream-controller.coffee
@@ -52,9 +52,12 @@ module.exports = class StreamController
     $scope.forceVisible = (id) ->
       annotationUI.setForceVisible(id, true)
 
-    rootThread.on('changed', (thread) ->
+    thread = ->
+      rootThread.thread(annotationUI.getState())
+
+    annotationUI.subscribe( ->
       $scope.virtualThreadList = {
-        visibleThreads: thread.children,
+        visibleThreads: thread().children,
         offscreenUpperHeight: '0px',
         offscreenLowerHeight: '0px',
       };
@@ -64,6 +67,4 @@ module.exports = class StreamController
     annotationUI.setSortKey('Newest')
 
     $scope.isStream = true
-    $scope.rootThread = ->
-      return rootThread.thread()
     $scope.loadMore = fetch

--- a/h/static/scripts/test/annotation-viewer-controller-test.js
+++ b/h/static/scripts/test/annotation-viewer-controller-test.js
@@ -36,7 +36,7 @@ describe('AnnotationViewerController', function () {
       $scope: opts.$scope || {
         search: {},
       },
-      annotationUI: {},
+      annotationUI: {subscribe: sinon.stub()},
       rootThread: new FakeRootThread(),
       streamer: opts.streamer || { setConfig: function () {} },
       store: opts.store || {

--- a/h/static/scripts/test/integration/threading-test.js
+++ b/h/static/scripts/test/integration/threading-test.js
@@ -52,26 +52,26 @@ describe('annotation threading', function () {
 
   it('should display newly loaded annotations', function () {
     annotationUI.addAnnotations(fixtures.annotations);
-    assert.equal(rootThread.thread().children.length, 2);
+    assert.equal(rootThread.thread(annotationUI.getState()).children.length, 2);
   });
 
   it('should not display unloaded annotations', function () {
     annotationUI.addAnnotations(fixtures.annotations);
     annotationUI.removeAnnotations(fixtures.annotations);
-    assert.equal(rootThread.thread().children.length, 0);
+    assert.equal(rootThread.thread(annotationUI.getState()).children.length, 0);
   });
 
   it('should filter annotations when a search is set', function () {
     annotationUI.addAnnotations(fixtures.annotations);
     annotationUI.setFilterQuery('second');
-    assert.equal(rootThread.thread().children.length, 1);
-    assert.equal(rootThread.thread().children[0].id, '2');
+    assert.equal(rootThread.thread(annotationUI.getState()).children.length, 1);
+    assert.equal(rootThread.thread(annotationUI.getState()).children[0].id, '2');
   });
 
   unroll('should sort annotations by #mode', function (testCase) {
     annotationUI.addAnnotations(fixtures.annotations);
     annotationUI.setSortKey(testCase.sortKey);
-    var actualOrder = rootThread.thread().children.map(function (thread) {
+    var actualOrder = rootThread.thread(annotationUI.getState()).children.map(function (thread) {
       return thread.annotation.id;
     });
     assert.deepEqual(actualOrder, testCase.expectedOrder);

--- a/h/static/scripts/test/root-thread-test.js
+++ b/h/static/scripts/test/root-thread-test.js
@@ -77,26 +77,9 @@ describe('rootThread', function () {
     });
   });
 
-  describe('initialization', function () {
-    it('builds a thread from the current set of annotations', function () {
-      assert.equal(rootThread.thread(), fixtures.emptyThread);
-    });
-  });
-
-  function assertRebuildsThread(fn) {
-    fakeBuildThread.reset();
-    var thread = Object.assign({}, fixtures.emptyThread);
-    fakeBuildThread.returns(thread);
-    fn();
-    assert.called(fakeBuildThread);
-    assert.equal(rootThread.thread(), thread);
-  }
-
-  describe('#rebuild', function () {
-    it('rebuilds the thread', function () {
-      assertRebuildsThread(function () {
-        rootThread.rebuild();
-      });
+  describe('#thread', function () {
+    it('returns the result of buildThread()', function() {
+      assert.equal(rootThread.thread(fakeAnnotationUI.state), fixtures.emptyThread);
     });
 
     it('passes loaded annotations to buildThread()', function () {
@@ -104,7 +87,7 @@ describe('rootThread', function () {
       fakeAnnotationUI.state = Object.assign({}, fakeAnnotationUI.state, {
         annotations: [annotation],
       });
-      rootThread.rebuild();
+      rootThread.thread(fakeAnnotationUI.state);
       assert.calledWith(fakeBuildThread, sinon.match([annotation]));
     });
 
@@ -112,7 +95,7 @@ describe('rootThread', function () {
       fakeAnnotationUI.state = Object.assign({}, fakeAnnotationUI.state, {
         selectedAnnotationMap: {id1: true, id2: true},
       });
-      rootThread.rebuild();
+      rootThread.thread(fakeAnnotationUI.state);
       assert.calledWith(fakeBuildThread, [], sinon.match({
         selected: ['id1', 'id2'],
       }));
@@ -122,7 +105,7 @@ describe('rootThread', function () {
       fakeAnnotationUI.state = Object.assign({}, fakeAnnotationUI.state, {
         expanded: {id1: true, id2: true},
       });
-      rootThread.rebuild();
+      rootThread.thread(fakeAnnotationUI.state);
       assert.calledWith(fakeBuildThread, [], sinon.match({
         expanded: {id1: true, id2: true},
       }));
@@ -132,19 +115,10 @@ describe('rootThread', function () {
       fakeAnnotationUI.state = Object.assign({}, fakeAnnotationUI.state, {
         forceVisible: {id1: true, id2: true},
       });
-      rootThread.rebuild();
+      rootThread.thread(fakeAnnotationUI.state);
       assert.calledWith(fakeBuildThread, [], sinon.match({
         forceVisible: ['id1', 'id2'],
       }));
-    });
-  });
-
-  context('when the annotationUI state changes', function () {
-    it('rebuilds the root thread', function () {
-      assertRebuildsThread(function () {
-        var subscriber = fakeAnnotationUI.subscribe.args[0][0];
-        subscriber();
-      });
     });
   });
 
@@ -181,7 +155,7 @@ describe('rootThread', function () {
         sortKey: testCase.order,
         sortKeysAvailable: [testCase.order],
       });
-      rootThread.rebuild();
+      rootThread.thread(fakeAnnotationUI.state);
       var sortCompareFn = fakeBuildThread.args[0][1].sortCompareFn;
       var actualOrder = sortBy(annotations, sortCompareFn).map(function (annot) {
         return annotations.indexOf(annot);
@@ -202,7 +176,7 @@ describe('rootThread', function () {
       fakeSearchFilter.generateFacetedFilter.returns(filters);
       fakeAnnotationUI.state = Object.assign({}, fakeAnnotationUI.state,
         {filterQuery: 'queryterm'});
-      rootThread.rebuild();
+      rootThread.thread(fakeAnnotationUI.state);
       var filterFn = fakeBuildThread.args[0][1].filterFn;
 
       fakeViewFilter.filter.returns([annotation]);

--- a/h/static/scripts/test/stream-controller-test.coffee
+++ b/h/static/scripts/test/stream-controller-test.coffee
@@ -43,6 +43,7 @@ describe 'StreamController', ->
       setCollapsed: sandbox.spy()
       setForceVisible: sandbox.spy()
       setSortKey: sandbox.spy()
+      subscribe: sandbox.spy()
     }
 
     fakeParams = {id: 'test'}

--- a/h/static/scripts/virtual-thread-list.js
+++ b/h/static/scripts/virtual-thread-list.js
@@ -63,6 +63,9 @@ VirtualThreadList.prototype.detach = function () {
  * matching annotations changes.
  */
 VirtualThreadList.prototype.setRootThread = function (thread) {
+  if (thread === this._rootThread) {
+    return;
+  }
   this._rootThread = thread;
   this._updateVisibleThreads();
 };

--- a/h/static/scripts/widget-controller.js
+++ b/h/static/scripts/widget-controller.js
@@ -61,11 +61,19 @@ module.exports = function WidgetController(
     return elementHeight + marginHeight;
   }
 
+  function thread() {
+    return rootThread.thread(annotationUI.getState());
+  }
+
   // `visibleThreads` keeps track of the subset of all threads matching the
   // current filters which are in or near the viewport and the view then renders
   // only those threads, using placeholders above and below the visible threads
   // to reserve space for threads which are not actually rendered.
-  var visibleThreads = new VirtualThreadList($scope, window, rootThread.thread());
+  var visibleThreads = new VirtualThreadList($scope, window, thread());
+  annotationUI.subscribe(function () {
+    visibleThreads.setRootThread(thread());
+  });
+
   visibleThreads.on('changed', function (state) {
     $scope.virtualThreadList = {
       visibleThreads: state.visibleThreads,
@@ -83,9 +91,7 @@ module.exports = function WidgetController(
       });
     }, 50);
   });
-  rootThread.on('changed', function (thread) {
-    visibleThreads.setRootThread(thread);
-  });
+
   $scope.$on('$destroy', function () {
     visibleThreads.detach();
   });
@@ -264,10 +270,6 @@ module.exports = function WidgetController(
     annotationUI.setFilterQuery(query);
   });
 
-  $scope.rootThread = function () {
-    return rootThread.thread();
-  };
-
   $scope.setCollapsed = function (id, collapsed) {
     annotationUI.setCollapsed(id, collapsed);
   };
@@ -334,11 +336,11 @@ module.exports = function WidgetController(
   });
 
   $scope.visibleCount = function () {
-    return visibleCount(rootThread.thread());
+    return visibleCount(thread());
   };
 
   $scope.topLevelThreadCount = function () {
-    return rootThread.thread().totalChildren;
+    return thread().totalChildren;
   };
 
   /**


### PR DESCRIPTION
In Redux, the idiomatic way to transform the normalized state of the application into a form that maps closer to what the UI looks like is to do:
```
  derivedData = transform(select(store.getState()))
```
Where the `select` function extracts the relevant fields from the state and the `transform` function then computes the derived data. In our case, the input state is the list of annotations, current selection/sort etc. and the derived data is a tree-structure of annotation threads and replies that are visible according to the current UI settings.

Because the store state is immutable, both `select` and `transform` can be trivially memoized to avoid unnecessary recalculations and view updates. In other words, if `select` is called with the same object twice it can just return the previously calculated value on the second call and likewise for `transform`.

Modifying the `RootThread` class to use this pattern simplifies it by avoiding inheritance from EventEmitter. In future this will make it easier to avoid rebuilding the thread if parts of the state that do not affect the visible threads changes.