### PR TITLE
Simplify annotation key event handling

### DIFF
--- a/h/static/scripts/directive/annotation.js
+++ b/h/static/scripts/directive/annotation.js
@@ -515,7 +515,7 @@ function AnnotationController(
   };
 
   // Save on Meta + Enter or Ctrl + Enter.
-  vm.onKeydown = function(event) {
+  vm.onKeydown = function (event) {
     if (event.keyCode === 13 && (event.metaKey || event.ctrlKey)) {
       event.preventDefault();
       vm.save();
@@ -716,20 +716,6 @@ function AnnotationController(
   init();
 }
 
-function link(scope, elem, attrs, controllers) {
-  var ctrl = controllers[0];
-  elem.on('keydown', ctrl.onKeydown);
-}
-
-/**
-  * @ngdoc directive
-  * @name annotation
-  * @restrict A
-  * @description
-  * Directive that instantiates
-  * {@link annotation.AnnotationController AnnotationController}.
-  *
-  */
 // @ngInject
 function annotation() {
   return {
@@ -737,12 +723,8 @@ function annotation() {
     bindToController: true,
     controller: AnnotationController,
     controllerAs: 'vm',
-    link: link,
-    require: ['annotation'],
     scope: {
       annotation: '<',
-      // Indicates whether this is the last reply in a thread.
-      isLastReply: '<',
       showDocumentInfo: '<',
       onReplyCountClick: '&',
       replyCount: '<',
@@ -758,7 +740,6 @@ module.exports = {
   // to be unit tested.
   // FIXME: The code should be refactored to enable unit testing without having
   // to do this.
-  link: link,
   updateDomainModel: updateDomainModel,
 
   // These are meant to be the public API of this module.

--- a/h/static/scripts/directive/test/annotation-test.js
+++ b/h/static/scripts/directive/test/annotation-test.js
@@ -132,58 +132,6 @@ describe('annotation', function() {
     });
   });
 
-  describe('link', function () {
-    var link = require('../annotation').link;
-
-    var scope;
-    var mockElement;
-    var mockAttributes;
-    var mockAnnotationController;
-    var mockThreadController;
-    var mockThreadFilterController;
-    var mockDeepCountController;
-    var mockControllers;
-
-    beforeEach(function () {
-      scope = util.ngModule(inject, '$rootScope').$new();
-      mockElement = {on: sinon.stub()};
-      mockAttributes = undefined;  // Left undefined because link() doesn't use
-                                   // it.
-      mockAnnotationController = {
-        editing: sinon.stub().returns(false),
-        onKeydown: "annotationController.onKeydown"  // Sentinel value.
-      };
-      mockThreadController = {
-        collapsed: true,
-        toggleCollapsed: sinon.stub(),
-        parent: {
-          toggleCollapsed: sinon.stub()
-        }
-      };
-      mockThreadFilterController = {
-        active: sinon.stub(),
-        freeze: sinon.stub()
-      };
-      mockDeepCountController = {
-        count: sinon.stub()
-      };
-      mockControllers = [
-        mockAnnotationController, mockThreadController,
-        mockThreadFilterController, mockDeepCountController];
-    });
-
-    it('binds AnnotationController.onKeydown to "keydown"', function () {
-      link(scope, mockElement, mockAttributes, mockControllers);
-
-      assert.equal(1, mockElement.on.callCount);
-      assert.equal(
-        true,
-        mockElement.on.calledWithExactly(
-          'keydown', mockAnnotationController.onKeydown)
-      );
-    });
-  });
-
   describe('AnnotationController', function() {
     var $q;
     var $rootScope;

--- a/h/templates/client/annotation.html
+++ b/h/templates/client/annotation.html
@@ -2,7 +2,7 @@
   <strong>You must be signed in to create annotations.</strong>
 </header>
 
-<div ng-if="vm.user()">
+<div ng-keydown="vm.onKeydown($event)" ng-if="vm.user()">
   <header class="annotation-header">
     <!-- User -->
     <span ng-if="vm.user()">


### PR DESCRIPTION
Rather than imperatively adding a 'keydown' event handler in the
<annotation> link function, use `ng-keydown` to set up an event handler
instead.

With this we no longer need a link function.