### PR TITLE
Remove path for local pdf files.

### DIFF
--- a/h/static/scripts/annotator/plugin/pdf-metadata.js
+++ b/h/static/scripts/annotator/plugin/pdf-metadata.js
@@ -49,9 +49,15 @@ PDFMetadata.prototype.getMetadata = function () {
     }
 
     var link = [
-      {href: fingerprintToURN(app.documentFingerprint)},
-      {href: app.url}
+      {href: fingerprintToURN(app.documentFingerprint)}
     ];
+
+    // Local file:// URLs should not be saved in document metadata.
+    // Entries in document.link should be URIs. In the case of
+    // local files, omit the URL.
+    if (app.url.indexOf('file://') !== 0) {
+      link.push({href: app.url});
+    }
 
     return {
       title: title,

--- a/h/static/scripts/annotator/plugin/test/pdf-metadata-test.js
+++ b/h/static/scripts/annotator/plugin/test/pdf-metadata-test.js
@@ -83,6 +83,24 @@ describe('pdf-metadata', function () {
           assert.deepEqual(actualMetadata, expectedMetadata);
         });
       });
+
+      it('does not save file:// URLs in document metadata', function () {
+        var pdfMetadata;
+        var fakePDFViewerApplication = {
+          documentFingerprint: 'fakeFingerprint',
+          url: 'file://fakeUrl',
+        };
+        var expectedMetadata = {
+          link: [{href: 'urn:x-pdf:' + fakePDFViewerApplication.documentFingerprint}],
+        };
+
+        pdfMetadata = new PDFMetadata(fakePDFViewerApplication);
+
+        return pdfMetadata.getMetadata().then(function (actualMetadata) {
+          assert.equal(actualMetadata.link.length, 1);
+          assert.equal(actualMetadata.link[0].href, expectedMetadata.link[0].href);
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
Currently, when annotating a local PDF, the `file://` URL will be submitted to the server.
It is not appropriate to submit local file paths to the server.
Since entries in document.link should be URIs, omit the URL in the case of local files.

https://trello.com/c/K8t2kl9m/331-don-t-save-file-urls-in-document-metadata
53725fd

Also, closed the PR below in favour of this one
https://github.com/hypothesis/h/pull/3405

