### PR TITLE
Extract timestamp out into its own component

### DIFF
--- a/h/static/scripts/app.js
+++ b/h/static/scripts/app.js
@@ -152,6 +152,7 @@ module.exports = angular.module('h', [
   .directive('sortDropdown', require('./directive/sort-dropdown'))
   .directive('spinner', require('./directive/spinner'))
   .directive('statusButton', require('./directive/status-button'))
+  .directive('timestamp', require('./directive/timestamp'))
   .directive('topBar', require('./directive/top-bar'))
   .directive('windowScroll', require('./directive/window-scroll'))
 

--- a/h/static/scripts/directive/search-status-bar.js
+++ b/h/static/scripts/directive/search-status-bar.js
@@ -3,6 +3,7 @@
 // @ngInject
 module.exports = function () {
   return {
+    controller: function () {},
     restrict: 'E',
     scope: {
       filterActive: '<',

--- a/h/static/scripts/directive/sort-dropdown.js
+++ b/h/static/scripts/directive/sort-dropdown.js
@@ -2,6 +2,7 @@
 
 module.exports = function () {
   return {
+    controller: function () {},
     restrict: 'E',
     scope: {
       /** The name of the currently selected sort key. */
@@ -12,5 +13,5 @@ module.exports = function () {
       onChangeSortKey: '&',
     },
     template: require('../../../templates/client/sort_dropdown.html'),
-  }
+  };
 };

--- a/h/static/scripts/directive/test/h-tooltip-test.js
+++ b/h/static/scripts/directive/test/h-tooltip-test.js
@@ -6,6 +6,7 @@ var util = require('./util');
 
 function testComponent() {
   return {
+    controller: function () {},
     restrict: 'E',
     template: '<div aria-label="Share" h-tooltip>Label</div>',
   };

--- a/h/static/scripts/directive/test/timestamp-test.js
+++ b/h/static/scripts/directive/test/timestamp-test.js
@@ -1,0 +1,89 @@
+'use strict';
+
+var angular = require('angular');
+
+var util = require('./util');
+
+describe('timestamp', function () {
+  var clock;
+  var fakeTime;
+
+  before(function () {
+    angular.module('app',[])
+      .directive('timestamp', require('../timestamp'));
+  });
+
+  beforeEach(function () {
+    clock = sinon.useFakeTimers();
+    fakeTime = {
+      toFuzzyString: sinon.stub().returns('a while ago'),
+      decayingInterval: function () {},
+    };
+
+    angular.mock.module('app', {
+      time: fakeTime,
+    });
+  });
+
+  afterEach(function() {
+    clock.restore();
+  });
+
+  describe('#relativeTimestamp', function() {
+    it('displays a relative time string', function() {
+      var element = util.createDirective(document, 'timestamp', {
+        timestamp: '2016-06-10T10:04:04.939Z',
+      });
+      assert.equal(element.ctrl.relativeTimestamp, 'a while ago');
+    });
+
+    it('is updated when the timestamp changes', function () {
+      var element = util.createDirective(document, 'timestamp', {
+        timestamp: '1776-07-04T10:04:04.939Z',
+      });
+      element.scope.timestamp = '1863-11-19T12:00:00.939Z';
+      fakeTime.toFuzzyString.returns('four score and seven years ago');
+      element.scope.$digest();
+      assert.equal(element.ctrl.relativeTimestamp, 'four score and seven years ago');
+    });
+
+    it('is updated after time passes', function() {
+      fakeTime.decayingInterval = function (date, callback) {
+        setTimeout(callback, 10);
+      };
+      var element = util.createDirective(document, 'timestamp', {
+        timestamp: '2016-06-10T10:04:04.939Z',
+      });
+      fakeTime.toFuzzyString.returns('60 jiffies');
+      element.scope.$digest();
+      clock.tick(1000);
+      assert.equal(element.ctrl.relativeTimestamp, '60 jiffies');
+    });
+
+    it('is no longer updated after the component is destroyed', function() {
+      var cancelRefresh = sinon.stub();
+      fakeTime.decayingInterval = function () {
+        return cancelRefresh;
+      };
+      var element = util.createDirective(document, 'timestamp', {
+        timestamp: '2016-06-10T10:04:04.939Z',
+      });
+      element.ctrl.$onDestroy();
+      assert.called(cancelRefresh);
+    });
+  });
+
+  describe('#absoluteTimestamp', function () {
+    it('displays the current time', function () {
+      var expectedDate = new Date('2016-06-10T10:04:04.939Z');
+      var element = util.createDirective(document, 'timestamp', {
+        timestamp: expectedDate.toISOString(),
+      });
+
+      // The exact format of the result will depend on the current locale,
+      // but check that at least the current year and time are present
+      assert.match(element.ctrl.absoluteTimestamp, new RegExp('.*2016.*' +
+        expectedDate.toLocaleTimeString()));
+    });
+  });
+});

--- a/h/static/scripts/directive/test/util.js
+++ b/h/static/scripts/directive/test/util.js
@@ -151,6 +151,12 @@ function createDirective(document, name, attrs, initialScope, initialHtml, opts)
     element.scope = childScope;
     childScope.$digest();
     element.ctrl = element.controller(name);
+
+    if (!element.ctrl) {
+      throw new Error('Failed to create "' + name + '" directive in test.' +
+        'Did you forget to register it with angular.module(...).directive() ?');
+    }
+
     return element;
   };
 

--- a/h/static/scripts/directive/timestamp.js
+++ b/h/static/scripts/directive/timestamp.js
@@ -1,0 +1,60 @@
+'use strict';
+
+var dateUtil = require('../date-util');
+
+// @ngInject
+function TimestampController($scope, time) {
+  var vm = this;
+
+  // A fuzzy, relative (eg. '6 days ago') format of the timestamp.
+  vm.relativeTimestamp = null;
+
+  // A formatted version of the timestamp (eg. 'Tue 22nd Dec 2015, 16:00')
+  vm.absoluteTimestamp = '';
+
+  var cancelTimestampRefresh;
+
+  function updateTimestamp() {
+    vm.relativeTimestamp = time.toFuzzyString(vm.timestamp);
+    vm.absoluteTimestamp = dateUtil.format(new Date(vm.timestamp));
+
+    if (vm.timestamp) {
+      if (cancelTimestampRefresh) {
+        cancelTimestampRefresh();
+      }
+      cancelTimestampRefresh = time.decayingInterval(vm.timestamp, function () {
+        updateTimestamp();
+        $scope.$digest();
+      });
+    }
+  }
+
+  this.$onChanges = function (changes) {
+    if (changes.timestamp) {
+      updateTimestamp();
+    }
+  };
+
+  this.$onDestroy = function () {
+    if (cancelTimestampRefresh) {
+      cancelTimestampRefresh();
+    }
+  };
+}
+
+module.exports = function () {
+  return {
+    bindToController: true,
+    controller: TimestampController,
+    controllerAs: 'vm',
+    restrict: 'E',
+    scope: {
+      className: '<',
+      href: '<',
+      timestamp: '<',
+    },
+    template: ['<a class="{{vm.className}}" target="_blank" ng-title="vm.absoluteTimestamp"',
+               ' href="{{vm.href}}"',
+               '>{{vm.relativeTimestamp}}</a>'].join(''),
+  };
+};

--- a/h/templates/client/annotation.html
+++ b/h/templates/client/annotation.html
@@ -40,13 +40,11 @@
 
     <span class="u-flex-spacer"></span>
 
-    <!-- Timestamp -->
-    <a class="annotation-header__timestamp"
-       target="_blank"
-       title="{{vm.absoluteTimestamp}}"
-       ng-if="!vm.editing() && vm.updated()"
-       ng-href="{{vm.linkHTML}}"
-       >{{vm.relativeTimestamp}}</a>
+    <timestamp
+      class-name="'annotation-header__timestamp'"
+      timestamp="vm.updated()"
+      href="vm.linkHTML"
+      ng-if="!vm.editing() && vm.updated()"></timestamp>
   </header>
 
   <!-- Excerpts -->


### PR DESCRIPTION
This makes it easier to test the refresh logic directly and decouples it
from the rest of the annotation display.