### PR TITLE
Extract tag editor into separate component and update ng-tags-input

### DIFF
--- a/h/static/scripts/app.js
+++ b/h/static/scripts/app.js
@@ -152,6 +152,7 @@ module.exports = angular.module('h', [
   .directive('sortDropdown', require('./directive/sort-dropdown'))
   .directive('spinner', require('./directive/spinner'))
   .directive('statusButton', require('./directive/status-button'))
+  .directive('tagEditor', require('./directive/tag-editor'))
   .directive('timestamp', require('./directive/timestamp'))
   .directive('topBar', require('./directive/top-bar'))
   .directive('windowScroll', require('./directive/window-scroll'))

--- a/h/static/scripts/directive/tag-editor.js
+++ b/h/static/scripts/directive/tag-editor.js
@@ -1,0 +1,37 @@
+'use strict';
+
+// @ngInject
+function TagEditorController(tags) {
+  this.onTagsChanged = function () {
+    tags.store(this.tagList);
+
+    var newTags = this.tagList.map(function (item) { return item.text; });
+    this.onEditTags({tags: newTags});
+  };
+
+  this.autocomplete = function (query) {
+    return Promise.resolve(tags.filter(query));
+  };
+
+  this.$onChanges = function (changes) {
+    if (changes.tags) {
+      this.tagList = changes.tags.currentValue.map(function (tag) {
+        return {text: tag};
+      });
+    }
+  };
+}
+
+module.exports = function () {
+  return {
+    bindToController: true,
+    controller: TagEditorController,
+    controllerAs: 'vm',
+    restrict: 'E',
+    scope: {
+      tags: '<',
+      onEditTags: '&',
+    },
+    template: require('../../../templates/client/tag_editor.html'),
+  };
+};

--- a/h/static/scripts/directive/test/annotation-test.js
+++ b/h/static/scripts/directive/test/annotation-test.js
@@ -83,20 +83,14 @@ describe('annotation', function() {
       var domainModel = {};
       var viewModel = {
         form: {
-          tags: [
-            {text: 'foo'},
-            {text: 'bar'}
-          ]
+          tags: ['foo', 'bar'],
         }
       };
 
       updateDomainModel(domainModel, viewModel, fakePermissions(),
                         fakeGroups());
 
-      assert.deepEqual(
-        domainModel.tags, ['foo', 'bar'],
-        'The array of {tag: "text"} objects in  viewModel becomes an array ' +
-        'of "text" strings in domainModel');
+      assert.deepEqual(domainModel.tags, ['foo', 'bar']);
     });
 
     it('sets domainModel.permissions to private if vm.isPrivate', function() {
@@ -230,11 +224,6 @@ describe('annotation', function() {
         serviceUrl: 'https://test.hypothes.is/',
       };
 
-      var fakeTags = {
-        filter: sandbox.stub().returns('a while ago'),
-        store: sandbox.stub()
-      };
-
       fakeGroups = {
         focused: function() {
           return {};
@@ -250,7 +239,6 @@ describe('annotation', function() {
       $provide.value('permissions', fakePermissions);
       $provide.value('session', fakeSession);
       $provide.value('settings', fakeSettings);
-      $provide.value('tags', fakeTags);
       $provide.value('groups', fakeGroups);
     }));
 
@@ -700,11 +688,7 @@ describe('annotation', function() {
         controller.form.text = 'bar';
         assert.ok(controller.hasContent());
         controller.form.text = '';
-        controller.form.tags = [
-          {
-            text: 'foo'
-          }
-        ];
+        controller.form.tags = ['foo'];
         assert.ok(controller.hasContent());
       });
     });
@@ -995,11 +979,7 @@ describe('annotation', function() {
     describe('drafts', function() {
       it('starts editing immediately if there is a draft', function() {
         fakeDrafts.get.returns({
-          tags: [
-            {
-              text: 'unsaved'
-            }
-          ],
+          tags: ['unsaved'],
           text: 'unsaved-text'
         });
         var controller = createDirective().controller;
@@ -1008,15 +988,11 @@ describe('annotation', function() {
 
       it('uses the text and tags from the draft if present', function() {
         fakeDrafts.get.returns({
-          tags: [{text: 'unsaved-tag'}],
+          tags: ['unsaved-tag'],
           text: 'unsaved-text'
         });
         var controller = createDirective().controller;
-        assert.deepEqual(controller.form.tags, [
-          {
-            text: 'unsaved-tag'
-          }
-        ]);
+        assert.deepEqual(controller.form.tags, ['unsaved-tag']);
         assert.equal(controller.form.text, 'unsaved-text');
       });
 
@@ -1096,7 +1072,7 @@ describe('annotation', function() {
       it('does not remove the current annotation if it has tags', function () {
         var annotation = fixtures.newAnnotation();
         var parts = createDirective(annotation);
-        parts.controller.form.tags = [{text: 'a-tag'}];
+        parts.controller.form.tags = ['a-tag'];
         $rootScope.$emit(events.BEFORE_ANNOTATION_CREATED,
           fixtures.newAnnotation());
         assert.notCalled(fakeDrafts.remove);

--- a/h/static/scripts/directive/test/tag-editor-test.js
+++ b/h/static/scripts/directive/test/tag-editor-test.js
@@ -1,0 +1,62 @@
+'use strict';
+
+var angular = require('angular');
+
+var util = require('./util');
+
+describe('tagEditor', function () {
+  var fakeTags;
+
+  before(function () {
+    angular.module('app',[])
+      .directive('tagEditor', require('../tag-editor'));
+  });
+
+  beforeEach(function () {
+    fakeTags = {
+      filter: sinon.stub(),
+      store: sinon.stub(),
+    };
+
+    angular.mock.module('app', {
+      tags: fakeTags,
+    });
+  });
+
+  it('converts tags to the form expected by ng-tags-input', function () {
+    var element = util.createDirective(document, 'tag-editor', {
+      tags: ['foo', 'bar']
+    });
+    assert.deepEqual(element.ctrl.tagList, [{text: 'foo'}, {text: 'bar'}]);
+  });
+
+  describe('when tags are changed', function () {
+    var element;
+    var onEditTags;
+
+    beforeEach(function () {
+      onEditTags = sinon.stub();
+      element = util.createDirective(document, 'tag-editor', {
+        onEditTags: {args: ['tags'], callback: onEditTags},
+        tags: ['foo'],
+      });
+      element.ctrl.onTagsChanged();
+    });
+
+    it('calls onEditTags handler', function () {
+      assert.calledWith(onEditTags, sinon.match(['foo']));
+    });
+
+    it('saves tags to the store', function () {
+      assert.calledWith(fakeTags.store, sinon.match([{text: 'foo'}]));
+    });
+  });
+
+  describe('#autocomplete', function () {
+    it('suggests tags using the `tags` service', function () {
+      var element = util.createDirective(document, 'tag-editor', {tags: []});
+      element.ctrl.autocomplete('query');
+      assert.calledWith(fakeTags.filter, 'query');
+    });
+  });
+});

--- a/h/templates/client/annotation.html
+++ b/h/templates/client/annotation.html
@@ -84,24 +84,15 @@
 
   <!-- Tags -->
   <div class="annotation-body form-field" ng-if="vm.editing()">
-    <tags-input ng-model="vm.form.tags"
-      name="tags"
-      class="tags"
-      placeholder="Add tags…"
-      min-length="1"
-      replace-spaces-with-dashes="false"
-      enable-editing-last-tag="true">
-      <auto-complete source="vm.tagsAutoComplete($query)"
-        min-length="1"
-        max-results-to-show="10"></auto-complete>
-    </tags-input>
+    <tag-editor tags="vm.form.tags"
+                on-edit-tags="vm.setTags(tags)"></tag-editor>
   </div>
 
   <div class="annotation-body u-layout-row tags tags-read-only"
        ng-if="(vm.canCollapseBody || vm.form.tags.length) && !vm.editing()">
     <ul class="tag-list">
       <li class="tag-item" ng-repeat="tag in vm.form.tags">
-        <a ng-href="{{vm.tagStreamURL(tag.text)}}" target="_blank">{{tag.text}}</a>
+        <a ng-href="{{vm.tagStreamURL(tag)}}" target="_blank">{{tag}}</a>
       </li>
     </ul>
     <div class="u-stretch"></div>

--- a/h/templates/client/tag_editor.html
+++ b/h/templates/client/tag_editor.html
@@ -1,0 +1,13 @@
+<tags-input ng-model="vm.tagList"
+  name="tags"
+  class="tags"
+  placeholder="Add tags…"
+  min-length="1"
+  replace-spaces-with-dashes="false"
+  enable-editing-last-tag="true"
+  on-tag-added="vm.onTagsChanged()"
+  on-tag-removed="vm.onTagsChanged()">
+  <auto-complete source="vm.autocomplete($query)"
+    min-length="1"
+    max-results-to-show="10"></auto-complete>
+</tags-input>

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "js-polyfills": "^0.1.16",
     "lodash.debounce": "^4.0.3",
     "mkdirp": "^0.5.1",
-    "ng-tags-input": "2.2.0",
+    "ng-tags-input": "^3.1.1",
     "node-uuid": "^1.4.3",
     "postcss": "^5.0.6",
     "postcss-url": "^5.1.1",


### PR DESCRIPTION
This makes it easier to test the editor and removes a bunch of code from `<annotation>` that was coupled to implementation details of `ng-tags-input` (eg. the way it represented tags as `{text: 'foo'}` objects rather than just an array of strings).

The ng-tags-input update fixes #3324 which was an issue since the Angular 1.5.x upgrade.