### PR TITLE
Don't return None in group.documents()

### DIFF
--- a/h/groups/models.py
+++ b/h/groups/models.py
@@ -74,7 +74,7 @@ class Group(Base, mixins.Timestamps):
             .order_by(models.Annotation.updated.desc())
             .limit(1000))
         for annotation in annotations:
-            if annotation.document not in documents:
+            if annotation.document and annotation.document not in documents:
                 documents.append(annotation.document)
                 if len(documents) >= limit:
                     break

--- a/tests/h/groups/models_test.py
+++ b/tests/h/groups/models_test.py
@@ -169,6 +169,21 @@ def test_documents_when_group_has_no_documents(group):
     assert group.documents() == []
 
 
+def test_documents_does_not_return_null_documents(group):
+    """
+    It shouldn't return None when an annotation has no document.
+
+    Some annotations have no document and annotation.document will be None.
+    In this case nothing should be added to the list of documents,
+    it should not return None in the list of documents that it returns.
+
+    """
+    db.Session.add(api.models.Annotation(
+        userid=u'fred', groupid=group.pubid, shared=True))
+
+    assert None not in group.documents()
+
+
 def annotation(document_, groupid, shared):
     """Add a new annotation of the given document to the db and return it."""
     annotation_ = api.models.Annotation(


### PR DESCRIPTION
group.documents() shouldn't return None in the list of the group's documents
when the group has an annotation that has no document.

Some annotations have no document and annotation.document will be None.
In this case nothing from this annotation should be added to the list of
documents, it should not return None in the list of documents that it
returns.