### PR TITLE
Don't crash when annotation has no document

### DIFF
--- a/h/presenters.py
+++ b/h/presenters.py
@@ -58,7 +58,10 @@ class AnnotationHTMLPresenter(object):
 
     def __init__(self, annotation):
         self.annotation = annotation
-        self.document = DocumentHTMLPresenter(self.annotation.document)
+        if self.annotation.document:
+            self.document = DocumentHTMLPresenter(self.annotation.document)
+        else:
+            self.document = None
 
     @property
     def uri(self):
@@ -108,32 +111,50 @@ class AnnotationHTMLPresenter(object):
     @property
     def document_link(self):
         """Return a link to this annotation's document."""
-        return self.document.link
+        if self.document:
+            return self.document.link
+        else:
+            return ''
 
     @property
     def filename(self):
         """Return the filename of this annotation's document."""
-        return self.document.filename
+        if self.document:
+            return self.document.filename
+        else:
+            return ''
 
     @property
     def hostname_or_filename(self):
         """Return the hostname of this annotation's document."""
-        return self.document.hostname_or_filename
+        if self.document:
+            return self.document.hostname_or_filename
+        else:
+            return ''
 
     @property
     def href(self):
         """Return an href for this annotation's document, or ""."""
-        return self.document.href
+        if self.document:
+            return self.document.href
+        else:
+            return ''
 
     @property
     def link_text(self):
         """Return some link text for this annotation's document."""
-        return self.document.link_text
+        if self.document:
+            return self.document.link_text
+        else:
+            return ''
 
     @property
     def title(self):
         """Return a title for this annotation."""
-        return self.document.title
+        if self.document:
+            return self.document.title
+        else:
+            return ''
 
     # Explicitly forward some annotation properties for convenient access.
     @property

--- a/tests/h/presenters_test.py
+++ b/tests/h/presenters_test.py
@@ -50,6 +50,44 @@ class TestAnnotationHTMLPresenter(object):
             )
         assert annotation.created_day_string == '2015-09-04'
 
+    def test_it_does_not_crash_when_annotation_has_no_document(self):
+        annotation = mock.Mock(document=None)
+        presenter = presenters.AnnotationHTMLPresenter(annotation)
+
+        # Some AnnotationHTMLPresenter properties rely on the annotation's
+        # document. Call them all to make sure that none of them crash when
+        # the document is None.
+        # pylint: disable=pointless-statement
+        presenter.document_link
+        presenter.hostname_or_filename
+        presenter.href
+        presenter.link_text
+        presenter.title
+
+    @mock.patch('h.presenters.DocumentHTMLPresenter')
+    def test_it_does_not_init_DocumentHTMLPresenter_if_no_document(
+            self, DocumentHTMLPresenter):
+        """
+        It shouldn't init DocumentHTMLPresenter if document is None.
+
+        We don't want DocumentHTMLPresenter to be initialized with None for
+        a document, so make sure that AnnotationHTMLPresenter doesn't do so.
+
+        """
+        annotation = mock.Mock(document=None)
+        presenter = presenters.AnnotationHTMLPresenter(annotation)
+
+        # Call all these as well to make sure that none of them cause a
+        # DocumentHTMLPresenter to be initialized.
+        # pylint: disable=pointless-statement
+        presenter.document_link
+        presenter.hostname_or_filename
+        presenter.href
+        presenter.link_text
+        presenter.title
+
+        assert not DocumentHTMLPresenter.called
+
 
 class TestDocumentHTMLPresenter(object):
 


### PR DESCRIPTION
AnnotationHTMLPresenter hadn't been written to handle the case when an
annotation has no document, and it crashes.

It's not clear what AnnotationHTMLPresenter properties such as
.document_link etc should return in this case. But for now just make
them return empty strings - at least it's better than crashing.