### PR TITLE
Fix adder not being shown if there is a selection when the plugin is activated

### DIFF
--- a/h/static/scripts/util/observable.js
+++ b/h/static/scripts/util/observable.js
@@ -88,8 +88,18 @@ var Observable = require('zen-observable');
    });
  }
 
+/** Drop the first `n` events from the `src` Observable. */
+function drop(src, n) {
+  var count = 0;
+  return src.filter(function () {
+    ++count;
+    return count > n;
+  });
+}
+
 module.exports = {
   buffer: buffer,
+  drop: drop,
   listen: listen,
   merge: merge,
   Observable: Observable,


### PR DESCRIPTION
`selections()` tried to listen for a 'ready' event on the DOM Document
object. The 'ready' event however is jQuery-specific however so that
never gets triggered.

Instead change the `selections()` function to perform an initial check
for a selection on the next tick and emit a null|DOMRange.

Fixes #3452