### PR TITLE
Initialize `tags` and `text` fields of all annotations loaded into the app

### DIFF
--- a/h/static/scripts/annotation-ui.js
+++ b/h/static/scripts/annotation-ui.js
@@ -84,11 +84,31 @@ function excludeAnnotations(current, annotations) {
   });
 }
 
+/**
+ * Initialize all required fields of `annot` to the expected types.
+ *
+ * Initializing these fields when annotations are added allows the rest of the
+ * app to assume their existence.
+ */
+function addRequiredFields(annot) {
+  // Modify `annot` rather than returning a copy because `annot` is currently
+  // a `store.AnnotationResource` instance rather than a plain object and has
+  // non-enumerable fields (eg. `$$tag`).
+  if (!Array.isArray(annot.tags)) {
+    annot.tags = [];
+  }
+  if (typeof annot.text === 'undefined') {
+    annot.text = '';
+  }
+  return annot;
+}
+
 function annotationsReducer(state, action) {
   switch (action.type) {
     case types.ADD_ANNOTATIONS:
+      var annots = action.annotations.map(addRequiredFields);
       return Object.assign({}, state,
-        {annotations: state.annotations.concat(action.annotations)});
+        {annotations: state.annotations.concat(annots)});
     case types.REMOVE_ANNOTATIONS:
       return Object.assign({}, state,
         {annotations: excludeAnnotations(state.annotations, action.annotations)});

--- a/h/static/scripts/test/annotation-ui-test.js
+++ b/h/static/scripts/test/annotation-ui-test.js
@@ -32,6 +32,18 @@ describe('annotationUI', function () {
       annotationUI.addAnnotations([annot]);
       assert.deepEqual(annotationUI.getState().annotations, [annot]);
     });
+
+    it('adds required fields if missing', function () {
+      var annot = {id: 'foo'};
+      annotationUI.addAnnotations([annot]);
+
+      var addedAnnot = annotationUI.getState().annotations[0];
+      assert.deepEqual(addedAnnot, {
+        id: 'foo',
+        tags: [],
+        text: '',
+      });
+    });
   });
 
   describe('#removeAnnotations()', function () {
@@ -66,7 +78,7 @@ describe('annotationUI', function () {
     it('notifies subscribers when the UI state changes', function () {
       var listener = sinon.stub();
       annotationUI.subscribe(listener);
-      annotationUI.addAnnotations(annotationFixtures.defaultAnnotation());
+      annotationUI.addAnnotations([annotationFixtures.defaultAnnotation()]);
       assert.called(listener);
     });
   });

--- a/h/static/scripts/test/integration/threading-test.js
+++ b/h/static/scripts/test/integration/threading-test.js
@@ -9,15 +9,18 @@ var fixtures = immutable({
   annotations: [{
     id: '1',
     references: [],
+    tags: [],
     text: 'first annotation',
     updated: 50,
   },{
     id: '2',
+    tags: [],
     references: [],
     text: 'second annotation',
     updated: 200,
   },{
     id: '3',
+    tags: [],
     references: ['2'],
     text: 'reply to first annotation',
     updated: 100,

--- a/h/static/scripts/test/widget-controller-test.js
+++ b/h/static/scripts/test/widget-controller-test.js
@@ -276,7 +276,9 @@ describe('WidgetController', function () {
       var loadSpy = fakeAnnotationMapper.loadAnnotations;
 
       $scope.$broadcast(events.GROUP_FOCUSED);
-      assert.calledWith(fakeAnnotationMapper.unloadAnnotations, [{id: '123'}]);
+      assert.calledWith(fakeAnnotationMapper.unloadAnnotations, [
+        sinon.match({id: '123'}),
+      ]);
       assert.calledWith(annotationUI.addAnnotations, fakeDrafts.unsaved());
       $scope.$digest();
       assert.calledWith(loadSpy, [sinon.match({id: uri + '123'})]);


### PR DESCRIPTION
Several places in the `<annotation>` component assumed that the `tags`
field was an array, as did `<tag-editor>`. The `tags` and `text` fields
are always set by the server for annotations received from the API but
are not set by Annotator when creating new annotations in the page.

Initializing these fields in the reducer, which is the only place that
the loaded set of annotations can be modified, means that the rest of
the app can rely on them having the expected type.

This fixes an error when saving new annotations.