### PR TITLE
Do not use query property in Subscriptions.get_subscriptions_for_uri

### DIFF
--- a/h/accounts/views.py
+++ b/h/accounts/views.py
@@ -567,6 +567,7 @@ class NotificationsController(object):
     def _user_notifications(self):
         """Fetch the notifications/subscriptions for the logged-in user."""
         return models.Subscriptions.get_subscriptions_for_uri(
+            self.request.db,
             self.request.authenticated_userid)
 
 

--- a/h/notification/models.py
+++ b/h/notification/models.py
@@ -15,8 +15,8 @@ class Subscriptions(Base):
     active = sa.Column(sa.Boolean, default=True, nullable=False)
 
     @classmethod
-    def get_subscriptions_for_uri(cls, uri):
-        return cls.query.filter(
+    def get_subscriptions_for_uri(cls, session, uri):
+        return session.query(cls).filter(
             func.lower(cls.uri) == func.lower(uri)
         ).all()
 


### PR DESCRIPTION
The use of a "magic" query property makes testing difficult and causes confusion about which session is the correct session to use when writing new code.

This commit is part of an effort to standardise all ORM classmethods so they take a database session as their first parameter and do not rely on a thread-local query property.