### PR TITLE
Do not use query property in Feature.{all,remove_old_flags}

### DIFF
--- a/h/admin/views/features.py
+++ b/h/admin/views/features.py
@@ -13,8 +13,8 @@ from h.i18n import TranslationString as _
              request_method='GET',
              renderer='h:templates/admin/features.html.jinja2',
              permission='admin_features')
-def features_index(_):
-    return {"features": models.Feature.all()}
+def features_index(request):
+    return {"features": models.Feature.all(request.db)}
 
 
 @view_config(route_name='admin_features',
@@ -22,7 +22,7 @@ def features_index(_):
              permission='admin_features')
 def features_save(request):
     session.check_csrf_token(request)
-    for feat in models.Feature.all():
+    for feat in models.Feature.all(request.db):
         for attr in ['everyone', 'admins', 'staff']:
             val = request.POST.get('{0}[{1}]'.format(feat.name, attr))
             if val == 'on':

--- a/h/features/__init__.py
+++ b/h/features/__init__.py
@@ -21,7 +21,10 @@ def _remove_old_flags_on_boot(event):
     if 'H_SCRIPT' in os.environ:
         return
 
-    models.Feature.remove_old_flags()
+    # FIXME: This function should create its own transient session rather than
+    # relying on a scoped session.
+    from h.db import Session
+    models.Feature.remove_old_flags(Session)
     transaction.commit()
 
 

--- a/h/features/client.py
+++ b/h/features/client.py
@@ -64,7 +64,8 @@ class Client(object):
 
     def _load(self):
         """Loads the feature flag states into the internal cache."""
-        self._cache = {f.name: self._state(f) for f in self._fetcher()}
+        features = self._fetcher(self.request.db)
+        self._cache = {f.name: self._state(f) for f in features}
 
     def _state(self, feature):
         # Features that are on for everyone are on.

--- a/h/features/models.py
+++ b/h/features/models.py
@@ -68,14 +68,14 @@ class Feature(Base):
         return FEATURES[self.name]
 
     @classmethod
-    def all(cls):
+    def all(cls, session):
         """Fetch (or, if necessary, create) rows for all defined features."""
         results = []
         for name in FEATURES:
-            feat = cls.query.filter(cls.name == name).first()
+            feat = session.query(cls).filter(cls.name == name).first()
             if feat is None:
                 feat = cls(name=name)
-                cls.query.session.add(feat)
+                session.add(feat)
             results.append(feat)
         return results
 

--- a/h/features/models.py
+++ b/h/features/models.py
@@ -80,7 +80,7 @@ class Feature(Base):
         return results
 
     @classmethod
-    def remove_old_flags(cls):
+    def remove_old_flags(cls, session):
         """
         Remove old/unknown data from the feature table.
 
@@ -94,7 +94,7 @@ class Feature(Base):
         # N.B. We remove only those features we know absolutely nothing about,
         # which means that FEATURES_PENDING_REMOVAL are left alone.
         known = set(FEATURES) | set(FEATURES_PENDING_REMOVAL)
-        unknown_flags = cls.query.filter(sa.not_(cls.name.in_(known)))
+        unknown_flags = session.query(cls).filter(sa.not_(cls.name.in_(known)))
         count = unknown_flags.delete(synchronize_session=False)
         if count > 0:
             log.info('removed %d old/unknown feature flags from database', count)

--- a/tests/h/features/client_test.py
+++ b/tests/h/features/client_test.py
@@ -5,9 +5,9 @@ from pyramid.testing import DummyRequest
 import pytest
 
 from h.auth import role
+from h.models import Feature
 from h.features.client import Client
 from h.features.client import UnknownFeatureError
-from h.features.models import Feature
 
 
 class TestClient(object):
@@ -17,13 +17,13 @@ class TestClient(object):
     def test_enabled_loads_features(self, client, fetcher):
         client.enabled('foo')
 
-        fetcher.assert_called_once_with()
+        fetcher.assert_called_once_with(mock.sentinel.db_session)
 
     def test_enabled_caches_features(self, client, fetcher):
         client.enabled('foo')
         client.enabled('bar')
 
-        fetcher.assert_called_once_with()
+        fetcher.assert_called_once_with(mock.sentinel.db_session)
 
     def test_enabled_caches_empty_result_sets(self, client, fetcher):
         """Even an empty result set from the fetcher should be cached."""
@@ -37,7 +37,7 @@ class TestClient(object):
         except UnknownFeatureError:
             pass
 
-        fetcher.assert_called_once_with()
+        fetcher.assert_called_once_with(mock.sentinel.db_session)
 
     def test_enabled_raises_for_unknown_features(self, client):
         with pytest.raises(UnknownFeatureError):
@@ -74,13 +74,13 @@ class TestClient(object):
     def test_all_loads_features(self, client, fetcher):
         client.all()
 
-        fetcher.assert_called_once_with()
+        fetcher.assert_called_once_with(mock.sentinel.db_session)
 
     def test_all_caches_features(self, client, fetcher):
         client.all()
         client.all()
 
-        fetcher.assert_called_once_with()
+        fetcher.assert_called_once_with(mock.sentinel.db_session)
 
     def test_all_caches_empty_result_sets(self, client, fetcher):
         """Even an empty result set from the fetcher should be cached."""
@@ -88,7 +88,7 @@ class TestClient(object):
         client.all()
         client.all()
 
-        fetcher.assert_called_once_with()
+        fetcher.assert_called_once_with(mock.sentinel.db_session)
 
     def test_all_returns_feature_dictionary(self, client, config):
         config.testing_securitypolicy('acct:foo@example.com',

--- a/tests/h/features/models_test.py
+++ b/tests/h/features/models_test.py
@@ -49,7 +49,7 @@ class TestFeature(object):
         session.add_all([new, pending, old])
         session.flush()
 
-        Feature.remove_old_flags()
+        Feature.remove_old_flags(session)
 
         remaining = set([f.name for f in session.query(Feature).all()])
         assert remaining == {'abouttoberemoved', 'notification'}

--- a/tests/h/features/models_test.py
+++ b/tests/h/features/models_test.py
@@ -4,7 +4,7 @@ import mock
 import pytest
 
 from h import db
-from h.features.models import Feature
+from h.models import Feature
 
 
 @pytest.mark.usefixtures('features_override',
@@ -16,7 +16,7 @@ class TestFeature(object):
         assert feat.description == 'A test flag for testing with.'
 
     def test_all_creates_annotations_that_dont_exist(self):
-        features = Feature.all()
+        features = Feature.all(db.Session)
 
         assert len(features) == 1
         assert features[0].name == 'notification'
@@ -30,7 +30,7 @@ class TestFeature(object):
         session.add_all([new, pending, old])
         session.flush()
 
-        features = Feature.all()
+        features = Feature.all(session)
 
         assert len(features) == 1
         assert features[0].name == 'notification'


### PR DESCRIPTION
The use of a "magic" query property makes testing difficult and causes
confusion about which session is the correct session to use when writing
new code.

This commit is part of an effort to standardise all ORM classmethods so
they take a database session as their first parameter and do not rely on a
thread-local query property.