### PR TITLE
Add a NIPSA service to replace h.nipsa.logic

### DIFF
--- a/h/app.py
+++ b/h/app.py
@@ -73,6 +73,10 @@ def includeme(config):
     # when the configuration is committed.
     config.action(None, configure_jinja2_assets, args=(config,))
 
+    # Pyramid service layer: provides infrastructure for registering and
+    # retrieving services bound to the request.
+    config.include('pyramid_services')
+
     # Configure the transaction manager to support retrying retryable
     # exceptions. We also register the session factory with the thread-local
     # transaction manager, so that all sessions it creates are registered.

--- a/h/nipsa/__init__.py
+++ b/h/nipsa/__init__.py
@@ -3,6 +3,7 @@
 from h.nipsa.logic import index
 from h.nipsa.logic import add_nipsa
 from h.nipsa.logic import remove_nipsa
+from h.nipsa import services
 from h.nipsa import search
 
 __all__ = ('index', 'add_nipsa', 'remove_nipsa')
@@ -13,6 +14,9 @@ def includeme(config):
     # written into annotations on save.
     config.add_subscriber('h.nipsa.subscribers.transform_annotation',
                           'h.api.events.AnnotationTransformEvent')
+
+    # Register the NIPSA service
+    config.register_service_factory(services.nipsa_factory, name='nipsa')
 
     # Register an additional filter with the API search module
     config.add_search_filter(search.Filter)

--- a/h/nipsa/services.py
+++ b/h/nipsa/services.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+
+from h.nipsa import models
+from h.nipsa import worker
+
+
+class NipsaService(object):
+
+    """
+    A service which provides access to the state of "not-in-public-site-areas"
+    (NIPSA) flags on userids.
+    """
+
+    def __init__(self, session):
+        self.session = session
+
+    @property
+    def flagged_userids(self):
+        """
+        A list of all the NIPSA'd user IDs.
+
+        :rtype: list of unicode strings
+        """
+        return [u.userid for u in self.session.query(models.NipsaUser)]
+
+    def is_flagged(self, userid):
+        """Return whether the given userid is flagged as "NIPSA"."""
+        return self._user_query(userid).one_or_none() is not None
+
+    def flag(self, userid):
+        """
+        Add a NIPSA flag for a userid.
+
+        Add the given user's ID to the list of NIPSA'd user IDs. If the user
+        is already NIPSA'd then nothing will happen (but an "add_nipsa"
+        message for the user will still be published to the queue).
+        """
+        nipsa_user = self._user_query(userid).one_or_none()
+        if nipsa_user is None:
+            nipsa_user = models.NipsaUser(userid)
+            self.session.add(nipsa_user)
+
+        worker.add_nipsa.delay(userid)
+
+    def unflag(self, userid):
+        """
+        Remove the NIPSA flag for a userid.
+
+        If the user isn't NIPSA'd then nothing will happen (but a
+        "remove_nipsa" message for the user will still be published to the
+        queue).
+        """
+        self._user_query(userid).delete()
+
+        worker.remove_nipsa.delay(userid)
+
+    def _user_query(self, userid):
+        return self.session.query(models.NipsaUser).filter_by(userid=userid)
+
+
+def nipsa_factory(context, request):
+    """Return a NipsaService instance for the passed context and request."""
+    return NipsaService(request.db)

--- a/h/websocket.py
+++ b/h/websocket.py
@@ -164,6 +164,8 @@ def create_app(global_config, **settings):
     ])
     config.set_authentication_policy(policy)
 
+    config.include('pyramid_services')
+
     config.include('h.auth')
     config.include('h.sentry')
     config.include('h.stats')
@@ -175,6 +177,9 @@ def create_app(global_config, **settings):
 
     # We have to include search to set up the `request.es` property.
     config.include('h.api.search')
+
+    # We have to include nipsa to provide the NIPSA service
+    config.include('h.nipsa')
 
     config.include('h.streamer')
 

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ INSTALL_REQUIRES = [
     'psycogreen>=1.0',
     'psycopg2>=2.6.1',
     'pyramid-multiauth>=0.8.0,<0.9.0',
+    'pyramid-services==0.4',
     'pyramid_mailer>=0.13',
     'pyramid_tm>=0.7',
     'python-dateutil>=2.1',

--- a/tests/h/nipsa/services_test.py
+++ b/tests/h/nipsa/services_test.py
@@ -1,0 +1,95 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import mock
+import pytest
+from pyramid.testing import DummyRequest
+
+from h.nipsa.models import NipsaUser
+from h.nipsa.services import NipsaService
+from h.nipsa.services import nipsa_factory
+
+
+@pytest.mark.usefixtures('nipsa_users', 'worker')
+class TestNipsaService(object):
+    def test_flagged_userids_returns_list_of_userids(self, db_session):
+        svc = NipsaService(db_session)
+
+        assert set(svc.flagged_userids) == set(['acct:renata@example.com',
+                                                'acct:cecilia@example.com',
+                                                'acct:dominic@example.com'])
+
+    def test_is_flagged_returns_true_for_flagged_userids(self, db_session):
+        svc = NipsaService(db_session)
+
+        assert svc.is_flagged('acct:renata@example.com')
+        assert svc.is_flagged('acct:cecilia@example.com')
+
+    def test_is_flagged_returns_false_for_unflagged_userids(self, db_session):
+        svc = NipsaService(db_session)
+
+        assert not svc.is_flagged('acct:dochia@example.com')
+        assert not svc.is_flagged('acct:romeo@example.com')
+
+    def test_flag_adds_record_to_database(self, db_session):
+        svc = NipsaService(db_session)
+
+        svc.flag('acct:ethan@example.com')
+
+        user_query = db_session.query(NipsaUser).filter_by(userid='acct:ethan@example.com')
+        assert user_query.one_or_none() is not None
+
+    def test_flag_is_idempotent(self, db_session):
+        svc = NipsaService(db_session)
+
+        svc.flag('acct:juno@example.com')
+        svc.flag('acct:juno@example.com')
+
+        user_query = db_session.query(NipsaUser).filter_by(userid='acct:juno@example.com')
+        assert user_query.one_or_none() is not None
+
+    def test_unflag_removes_record_from_database(self, db_session):
+        svc = NipsaService(db_session)
+
+        svc.unflag('acct:renata@example.com')
+
+        user_query = db_session.query(NipsaUser).filter_by(userid='acct:renata@example.com')
+        assert user_query.one_or_none() is None
+
+    def test_unflag_is_idempotent(self, db_session):
+        svc = NipsaService(db_session)
+
+        svc.unflag('acct:dominic@example.com')
+        svc.unflag('acct:dominic@example.com')
+
+        user_query = db_session.query(NipsaUser).filter_by(userid='acct:dominic@example.com')
+        assert user_query.one_or_none() is None
+
+
+def test_nipsa_factory():
+    request = DummyRequest(db=mock.sentinel.db_session)
+
+    svc = nipsa_factory(None, request)
+
+    assert isinstance(svc, NipsaService)
+    assert svc.session == mock.sentinel.db_session
+
+
+@pytest.fixture
+def nipsa_users(db_session):
+    flagged_userids = ['acct:renata@example.com',
+                       'acct:cecilia@example.com',
+                       'acct:dominic@example.com']
+    instances = []
+
+    for userid in flagged_userids:
+        instances.append(NipsaUser(userid=userid))
+
+    db_session.add_all(instances)
+    db_session.flush()
+
+
+@pytest.fixture
+def worker(patch):
+    return patch('h.nipsa.services.worker')


### PR DESCRIPTION
One approach to limiting coupling between views and the models they control is to introduce a service layer which is responsible for encapsulating business logic and dependencies of that logic on other parts of the application.

This commit uses the `pyramid_services` library, which is a small library formalising a service layer pattern, in which services are registered with the application registry by name or by interface (I've chosen to go with name here, for the sake of simplicity). These services can then be retrieved by anything which can call `request.find_service(...)`.

Crucially, one can register service factories which in turn have access to the request object and thus can extract other dependencies (such as the database session) without calling code having to pass them in. This is the key difference between this approach and the more direct "logic" module approach.