### PR TITLE
Initialize `tags` and `text` fields to expected types for new annotations

### DIFF
--- a/h/static/scripts/directive/annotation.js
+++ b/h/static/scripts/directive/annotation.js
@@ -222,6 +222,10 @@ function AnnotationController(
     if (!domainModel.permissions) {
       domainModel.permissions = permissions['default'](domainModel.group);
     }
+    domainModel.text = domainModel.text || '';
+    if (!Array.isArray(domainModel.tags)) {
+      domainModel.tags = [];
+    }
 
     // Automatically save new highlights to the server when they're created.
     // Note that this line also gets called when the user logs in (since
@@ -398,9 +402,7 @@ function AnnotationController(
     *   otherwise.
     */
   vm.hasContent = function() {
-    var textLength = (vm.form.text || '').length;
-    var tagsLength = (vm.form.tags || []).length;
-    return (textLength > 0 || tagsLength > 0);
+    return vm.form.text.length > 0 || vm.form.tags.length > 0;
   };
 
   /**

--- a/h/static/scripts/directive/test/annotation-test.js
+++ b/h/static/scripts/directive/test/annotation-test.js
@@ -293,6 +293,15 @@ describe('annotation', function() {
           'default permissions for __world__');
       });
 
+      it('sets the tags and text fields for new annotations', function () {
+        var annotation = fixtures.newAnnotation();
+        delete annotation.tags;
+        delete annotation.text;
+        createDirective(annotation);
+        assert.equal(annotation.text, '');
+        assert.deepEqual(annotation.tags, []);
+      });
+
       it('preserves the permissions of existing annotations', function() {
         var annotation = fixtures.newAnnotation();
         annotation.permissions = {
@@ -385,7 +394,7 @@ describe('annotation', function() {
       it('edits annotations with drafts on initialization', function() {
         var annotation = fixtures.oldAnnotation();
         // The drafts service has some draft changes for this annotation.
-        fakeDrafts.get.returns('foo');
+        fakeDrafts.get.returns({text: 'foo', tags: []});
 
         var controller = createDirective(annotation).controller;
 
@@ -411,7 +420,7 @@ describe('annotation', function() {
         // and then change focus to another group and back without saving the
         // highlight, in which case the highlight will have draft edits.
         // This highlight has draft edits.
-        fakeDrafts.get.returns('foo');
+        fakeDrafts.get.returns({text: '', tags: []});
 
         var controller = createDirective(annotation).controller;
 
@@ -1186,7 +1195,7 @@ describe('annotation', function() {
         assert.equal(controller.action, 'edit');
         controller.form.text = 'this should be reverted';
         controller.revert();
-        assert.equal(controller.form.text, void 0);
+        assert.equal(controller.form.text, '');
       });
 
       it('reverts to the most recently saved version',


### PR DESCRIPTION
Several places in the `<annotation>` component assumed that the `tags`
field was an array, as did `<tag-editor>`. The `tags` and `text` fields
are always set by the server for annotations received from the API but
are not set by Annotator when creating new annotations in the page.

It would be better to initialize all of the required fields for
annotations when they are loaded into the app rather than in the
`<annotation>` component. For now however keep the initialization of all
required fields in the same place.

This fixes an error when saving new annotations.