### PR TITLE
Load annotations from DB for /api/search

### DIFF
--- a/h/api/views.py
+++ b/h/api/views.py
@@ -139,11 +139,12 @@ def search(request):
                             separate_replies=separate_replies)
 
     # Run the results through the JSON presenter
-    out['rows'] = [_present_searchdict(request, a)
-                   for a in out['rows']]
+    ids = [r['id'] for r in out['rows']]
+    out['rows'] = _present_annotations(request, ids)
+
     if separate_replies:
-        out['replies'] = [_present_searchdict(request, a)
-                          for a in out['replies']]
+        ids = [r['id'] for r in out['replies']]
+        out['replies'] = _present_annotations(request, ids)
 
     return out
 
@@ -234,10 +235,10 @@ def _json_payload(request):
         raise PayloadError()
 
 
-def _present_searchdict(request, mapping):
-    """Run an object returned from search through a presenter."""
-    ann = storage.annotation_from_dict(mapping)
-    return AnnotationJSONPresenter(request, ann).asdict()
+def _present_annotations(request, ids):
+    """Load annotations by id from the database and present them."""
+    annotations = storage.fetch_ordered_annotations(request.db, ids, load_documents=True)
+    return [AnnotationJSONPresenter(request, ann).asdict() for ann in annotations]
 
 
 def _publish_annotation_event(request,

--- a/tests/h/api/views_test.py
+++ b/tests/h/api/views_test.py
@@ -5,6 +5,8 @@ import pytest
 
 from pyramid import testing
 
+from h.api import models
+from h.api import presenters
 from h.api import views
 from h.api.schemas import ValidationError
 
@@ -63,59 +65,94 @@ class TestIndex(object):
         assert links['search']['url'] == host + '/dummy/search'
 
 
-@pytest.mark.usefixtures('search_lib', 'AnnotationJSONPresenter')
+@pytest.mark.usefixtures('search_lib')
 class TestSearch(object):
 
-    def test_it_searches(self, search_lib):
-        request = testing.DummyRequest()
+    def test_it_searches(self, mock_request, search_lib):
+        views.search(mock_request)
 
-        views.search(request)
-
-        search_lib.search.assert_called_once_with(request,
-                                                  request.params,
+        search_lib.search.assert_called_once_with(mock_request,
+                                                  mock_request.params,
                                                   separate_replies=False)
 
-    def test_it_returns_search_results(self, search_lib):
-        request = testing.DummyRequest()
-        search_lib.search.return_value = {'total': 0, 'rows': []}
+    def test_it_loads_annotations_from_database(self, mock_request, search_lib, storage):
+        search_lib.search.return_value = {'total': 2,
+                                          'rows': [{'id': 'row-1'}, {'id': 'row-2'}]}
 
-        result = views.search(request)
+        views.search(mock_request)
 
-        assert result == {'total': 0, 'rows': []}
+        storage.fetch_ordered_annotations.assert_called_once_with(
+            mock_request.db, ['row-1', 'row-2'], load_documents=True)
 
-    def test_it_presents_annotations(self,
-                                     search_lib,
-                                     AnnotationJSONPresenter):
-        request = testing.DummyRequest()
-        search_lib.search.return_value = {'total': 2, 'rows': [{'foo': 'bar'},
-                                                               {'baz': 'bat'}]}
-        presenter = AnnotationJSONPresenter.return_value
-        presenter.asdict.return_value = {'giraffe': True}
+    def test_it_renders_search_results(self, mock_request, search_lib):
+        ann1 = models.Annotation(userid='luke')
+        ann2 = models.Annotation(userid='sarah')
+        mock_request.db.add_all([ann1, ann2])
+        mock_request.db.flush()
 
-        result = views.search(request)
+        search_lib.search.return_value = {'total': 2,
+                                          'rows': [{'id': ann1.id}, {'id': ann2.id}]}
 
-        assert result == {'total': 2, 'rows': [{'giraffe': True},
-                                               {'giraffe': True}]}
+        expected = {
+            'total': 2,
+            'rows': [
+                presenters.AnnotationJSONPresenter(mock_request, ann1).asdict(),
+                presenters.AnnotationJSONPresenter(mock_request, ann2).asdict(),
+            ]
+        }
 
-    def test_it_presents_replies(self, search_lib, AnnotationJSONPresenter):
-        request = testing.DummyRequest(params={'_separate_replies': '1'})
+        assert views.search(mock_request) == expected
+
+    def test_it_loads_replies_from_database(self, mock_request, search_lib, storage):
+        mock_request.params = {'_separate_replies': '1'}
         search_lib.search.return_value = {'total': 1,
-                                          'rows': [{'foo': 'bar'}],
-                                          'replies': [{'baz': 'bat'},
-                                                      {'baz': 'bat'}]}
-        presenter = AnnotationJSONPresenter.return_value
-        presenter.asdict.return_value = {'giraffe': True}
+                                          'rows': [{'id': 'row-1'}],
+                                          'replies': [{'id': 'reply-1'},
+                                                      {'id': 'reply-2'}]}
 
-        result = views.search(request)
+        views.search(mock_request)
 
-        assert result == {'total': 1,
-                          'rows': [{'giraffe': True}],
-                          'replies': [{'giraffe': True},
-                                      {'giraffe': True}]}
+        assert mock.call(mock_request.db, ['reply-1', 'reply-2'],
+                         load_documents=True) in storage.fetch_ordered_annotations.call_args_list
+
+    def test_it_renders_replies(self, mock_request, search_lib):
+        ann = models.Annotation(userid='luke')
+        mock_request.db.add(ann)
+        mock_request.db.flush()
+        reply1 = models.Annotation(userid='sarah', references=[ann.id])
+        reply2 = models.Annotation(userid='sarah', references=[ann.id])
+        mock_request.db.add_all([reply1, reply2])
+        mock_request.db.flush()
+
+        search_lib.search.return_value = {'total': 1,
+                                          'rows': [{'id': ann.id}],
+                                          'replies': [{'id': reply1.id}, {'id': reply2.id}],
+                                          }
+
+        mock_request.params = {'_separate_replies': '1'}
+
+        expected = {
+            'total': 1,
+            'rows': [presenters.AnnotationJSONPresenter(mock_request, ann).asdict()],
+            'replies': [
+                presenters.AnnotationJSONPresenter(mock_request, reply1).asdict(),
+                presenters.AnnotationJSONPresenter(mock_request, reply2).asdict(),
+            ]
+        }
+
+        assert views.search(mock_request) == expected
 
     @pytest.fixture
     def search_lib(self, patch):
         return patch('h.api.views.search_lib')
+
+    @pytest.fixture
+    def storage(self, patch):
+        return patch('h.api.views.storage')
+
+    @pytest.fixture
+    def mock_request(self, db_session):
+        return testing.DummyRequest(db=db_session)
 
 
 @pytest.mark.usefixtures('AnnotationEvent',


### PR DESCRIPTION
Similar to what we're doing with the RSS/Atom feeds. After searching in Elasticsearch, we'll load the annotations from the database.
This gets rid of the last `annotation_from_dict` usage in the code (except for the annotation test factory).

This also adds the option for `storage.fetch_ordered_annotations` to eager load the document data.