### PR TITLE
Optimize feed annotations loading

### DIFF
--- a/h/feeds/views.py
+++ b/h/feeds/views.py
@@ -13,7 +13,7 @@ def _annotations(request):
     """Return the annotations from the search API."""
     rows = search.search(request, request.params)['rows']
     ids = [r['id'] for r in rows]
-    return storage.fetch_ordered_annotations(request.db, ids)
+    return storage.fetch_ordered_annotations(request.db, ids, load_documents=True)
 
 
 @view_config(route_name='stream_atom')


### PR DESCRIPTION
This is based on #3461 and will need rebasing once that one is merged.
It enables the eager loading of document data for the RSS/Atom feeds.