### PR TITLE
Fix cursor style for annotation cards

### DIFF
--- a/h/static/styles/annotation.scss
+++ b/h/static/styles/annotation.scss
@@ -9,6 +9,7 @@ $annotation-card-left-padding: 10px;
 .annotation-card {
   box-shadow: 0px 1px 1px 0px rgba(0, 0, 0, 0.10);
   border-radius: 2px;
+  cursor: pointer;
   padding: $layout-h-margin;
   background-color: $white;
 }

--- a/h/static/styles/markdown.scss
+++ b/h/static/styles/markdown.scss
@@ -44,6 +44,8 @@
 .markdown-body {
   @include styled-text;
 
+  cursor: text;
+
   // Margin between bottom of ascent of username and top of
   // x-height of annotation-body should be ~15px.
   // Remove additional margin-top added by the first p within


### PR DESCRIPTION
Set the annotation cursor to a pointer for annotation cards to indicate
that it is clickable (it scrolls the page to that annotation) except for
the body which has a text cursor to indicate that the text is
selectable.