### PR TITLE
Unify styling of annotation quotes and quotes in annotation bodies

### DIFF
--- a/h/static/styles/annotation.scss
+++ b/h/static/styles/annotation.scss
@@ -171,18 +171,6 @@ $annotation-card-left-padding: 10px;
 
 .annotation-quote {
   @include quote;
-  @include font-normal;
-  color: $grey-4;
-  font-family: sans-serif;
-  letter-spacing: 0.1px;
-  font-size: 12px;
-
-  del {
-    background:#ffe6e6;
-  }
-  ins {
-    background:#e6ffe6;
-  }
 }
 
 .annotation-citation-domain {

--- a/h/static/styles/base.scss
+++ b/h/static/styles/base.scss
@@ -14,11 +14,15 @@
 }
 
 @mixin quote {
-  color: $gray;
-  font-family: $serif-font-family;
-  font-style: italic;
-  padding: 0 1em;
+  @include font-normal;
+
   border-left: 3px solid $gray-lighter;
+  color: $grey-4;
+  font-family: sans-serif;
+  font-size: 12px;
+  font-style: italic;
+  letter-spacing: 0.1px;
+  padding: 0 1em;
 }
 
 //Provides the grey-background


### PR DESCRIPTION
Make the styling of quoted snippets of the page consistent with the
styling of block quotes in annotation bodies.

The styling for `<del>` and `<ins>` elements in quotes has been removed
because it is not currently used.

Fixes #3435