### PR TITLE
Add self-documenting 'help' target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ default: test
 build/manifest.json: node_modules/.uptodate
 	$(NPM_BIN)/gulp build
 
+## Clean up runtime artifacts (needed after a version update)
 .PHONY: clean
 clean:
 	find . -type f -name "*.py[co]" -delete
@@ -24,6 +25,7 @@ clean:
 	rm -f node_modules/.uptodate h.egg-info/.uptodate
 	rm -rf build dist
 
+## Run the development H server locally
 .PHONY: dev
 dev: build/manifest.json h.egg-info/.uptodate
 	@hypothesis devserver
@@ -37,10 +39,12 @@ dist/h-$(BUILD_ID).tar.gz:
 dist/h-$(BUILD_ID): dist/h-$(BUILD_ID).tar.gz
 	tar -C dist -zxf $<
 
+## Build hypothesis/hypothesis docker image
 .PHONY: docker
 docker: dist/h-$(BUILD_ID)
 	docker build -t hypothesis/hypothesis:$(DOCKER_TAG) $<
 
+## Run test suite
 .PHONY: test
 test: node_modules/.uptodate
 	@pip install -q tox
@@ -105,3 +109,13 @@ node_modules/.uptodate: package.json
 	@echo installing javascript dependencies
 	@$(NPM_BIN)/check-dependencies 2>/dev/null || npm install
 	@touch $@
+
+# Self documenting Makefile
+.PHONY: help
+help:
+	@echo "The following targets are available:"
+	@echo " clean      Clean up runtime artifacts (needed after a version update)"
+	@echo " dev        Run the development H server locally"
+	@echo " docker     Build hypothesis/hypothesis docker image"
+	@echo " extensions Build the browser extensions"
+	@echo " test       Run the test suite (default)"


### PR DESCRIPTION
This is just a small "niceness" taken from:

http://marmelab.com/blog/2016/02/29/auto-documented-makefile.html

I've opted for leaving the default make rule as it is (run the tests), but if people like this help option it can be made the default rule.