### PR TITLE
Fix standalone annotation reply pages

### DIFF
--- a/h/static/scripts/annotation-viewer-controller.js
+++ b/h/static/scripts/annotation-viewer-controller.js
@@ -2,6 +2,28 @@
 
 var angular = require('angular');
 
+/**
+ * Fetch all annotations in the same thread as `id`.
+ *
+ * @return Promise<Array<Annotation>>
+ */
+function fetchThread(store, id) {
+  var annot;
+  return store.AnnotationResource.get({id: id}).$promise.then(function (annot) {
+    if (annot.references && annot.references.length) {
+      // This is a reply, fetch the top-level annotation
+      return store.AnnotationResource.get({id: annot.references[0]}).$promise;
+    } else {
+      return annot;
+    }
+  }).then(function (annot_) {
+    annot = annot_;
+    return store.SearchResource.get({references: annot.id}).$promise;
+  }).then(function (searchResult) {
+    return [annot].concat(searchResult.rows);
+  });
+}
+
 // @ngInject
 function AnnotationViewerController (
   $location, $routeParams, $scope,
@@ -33,20 +55,27 @@ function AnnotationViewerController (
     annotationUI.setCollapsed(id, collapsed);
   };
 
-  store.AnnotationResource.get({ id: id }, function (annotation) {
-    annotationMapper.loadAnnotations([annotation]);
+  this.ready = fetchThread(store, id).then(function (annots) {
+    annotationMapper.loadAnnotations(annots);
+
+    var topLevelID = annots.filter(function (annot) {
+      return (annot.references || []).length === 0;
+    })[0];
+
+    if (!topLevelID) {
+      return;
+    }
+
+    streamFilter
+      .setMatchPolicyIncludeAny()
+      .addClause('/references', 'one_of', topLevelID, true)
+      .addClause('/id', 'equals', topLevelID, true);
+    streamer.setConfig('filter', { filter: streamFilter.getFilter() });
+
+    annots.forEach(function (annot) {
+      annotationUI.setCollapsed(annot.id, false);
+    });
   });
-
-  store.SearchResource.get({ references: id }, function (data) {
-    annotationMapper.loadAnnotations(data.rows);
-  });
-
-  streamFilter
-    .setMatchPolicyIncludeAny()
-    .addClause('/references', 'one_of', id, true)
-    .addClause('/id', 'equals', id, true);
-
-  streamer.setConfig('filter', { filter: streamFilter.getFilter() });
 }
 
 module.exports = AnnotationViewerController;


### PR DESCRIPTION
This is a proposed fix for standalone pages for replies. Rather than just showing the reply itself, it fetches and displays the whole conversation thread. I think this provides better context for the user:

![reply-standalone-page](https://cloud.githubusercontent.com/assets/2458/16079502/bd27155e-32fb-11e6-892e-da22ee7b51b0.png)

Something that is missing from the above but I would like to include in a follow-up PR is to highlight the reply that was referenced in the URL. This is something we can then also use when direct-linking to replies.

The implementation uses the existing API. The app first fetches the annotation specified in the URL, if it is a top-level annotation it fetches the replies, otherwise it first fetches the top-level parent and then fetches the replies.

A case I'm not yet handling here is when the top-level annotation no longer exists but the reply still does. In that case the current behavior will be to display the "Message not available". What I intend to do in a separate PR is show "Message not available" but still show the replies that do exist. Likewise if a reply mid-way down the thread is missing, the missing replies will be replaced by "Message not available" but any replies to the missing reply should still be shown.