### PR TITLE
Don't crash when creating DocumentMetas concurrently

### DIFF
--- a/h/api/models/__init__.py
+++ b/h/api/models/__init__.py
@@ -27,4 +27,5 @@ __all__ = (
     'DocumentURI',
     'elastic',
     'merge_documents',
+    'update_document_metadata',
 )

--- a/h/api/models/__init__.py
+++ b/h/api/models/__init__.py
@@ -13,8 +13,6 @@ functions in `h.api.storage`.
 
 from h.api.models import elastic
 from h.api.models.annotation import Annotation
-from h.api.models.document import create_or_update_document_meta
-from h.api.models.document import create_or_update_document_uri
 from h.api.models.document import Document
 from h.api.models.document import DocumentMeta
 from h.api.models.document import DocumentURI
@@ -24,8 +22,6 @@ from h.api.models.document import update_document_metadata
 
 __all__ = (
     'Annotation',
-    'create_or_update_document_meta',
-    'create_or_update_document_uri',
     'Document',
     'DocumentMeta',
     'DocumentURI',


### PR DESCRIPTION
Fixes #3465.

Creating a new annotation can crash when two concurrent requests are
trying to create new annotations of the same document:

My theory is that this can happen due to a concurrency problem when two
people simultaneously try to annotate a page that has not been annotated
before:

1. Browse to a page that:

   a. Will generate more than one `DocumentMeta` (e.g. has a title and
   favicon)

   b. Has not been annotated yet (or more accurately does not currently
   have any `DocumentMeta`s in the db)

2. Put a `set_trace()` before
   [this line](https://github.com/hypothesis/h/blob/46948765cc7e49b18b7d8030ad29b9f137e86de0/h/api/models/document.py#L413)

3. Annotate the page

4. The first time it hits your `set_trace()` hit `c` for continue,
   allowing it to create the first of two `DocumentMeta`s. I suppose the
   ordering here is undefined but for me it was always the title
   `DocumentMeta` that got created first. This creates the
   `DocumentMeta` in the `sqlalchemy` session but doesn't flush or
   commit it yet. The code should now be stopped on your `set_trace()`
   for the second (and last) time.

5. Go over to a `psql` shell for your db and insert a `DocumentMeta`
   with the same `claimant_normalized` and `type` as the one that was
   created in the previous step: `INSERT INTO document_meta
   (document_id, claimant, claimant_normalized, type, value) VALUES
   (1128, 'http://localhost:4545/', 'http://localhost:4545', 'title',
   '{"foo"}');`

6. Go back and hit `c` to continue processing the request. The query for
   existing `DocumentMeta`s on
   [this line](https://github.com/hypothesis/h/blob/46948765cc7e49b18b7d8030ad29b9f137e86de0/h/api/models/document.py#L318)
   will cause the `DocumentMeta` that was created in step 4 to be
   flushed, which will violate a database constraint because of the
   `DocumentMeta` that you added in step 5, and you will see the
   traceback.

The problem is that `create_or_update_document_meta()` has the logic:
"If there's already a DocumentMeta then return it, else create a new one" and
this cannot work because a concurrent request may create a new
DocumentMeta in-between the "if" and the "create a new one" and this
will then cause the "create a new one" to crash with an IntegrityError
from the database.

It is not possible to simply catch this IntegrityError and return the
DocumentMeta that was inserted by the concurrent request instead,
because once the IntegrityError has happened it's necessary to rollback
the transaction and this will lose any other objects that've been added
to the session outside of `create_or_update_document_meta()` but not
committed yet (e.g. `DocumentURI`s, the new `Annotation`).

So instead we raise a TransientError subclass which causes pyramid_tm to
abort the transaction and try replaying the request.

See: http://docs.pylonsproject.org/projects/pyramid_tm/en/latest/#retrying