### PR TITLE
Rewrite factories.Annotation to use Postgres

### DIFF
--- a/tests/factories.py
+++ b/tests/factories.py
@@ -2,135 +2,167 @@
 """Factory classes for easily generating test objects."""
 
 from __future__ import absolute_import
+from __future__ import unicode_literals
 
 import random
-import datetime
 
 import factory
+import faker
 
-from h.api import storage
+from h import db
+from h import models
 from h.accounts import models as accounts_models
+from h.api import models as api_models
 
 
-class Annotation(factory.Factory):
-
-    """A factory class that generates test annotation dicts.
-
-    Usage:
-
-        annotation_1 = Annotation()
-        annotation_2 = Annotation()
-
-    A unique "id" and "text", "created" and "updated" strings based on the
-    current time, etc. are generated for each annotation dict returned.
-
-    You can override the value of any attribute by passing in named arguments,
-    for example:
-
-        annotation = Annotation(text="My annotation text")
-
-    There are some special params that don't appear in the annotation dicts
-    themselves but influence the values that do appear in the dicts.
-
-    For example:
-
-        annotation = Annotation(username="my_user")
-
-    will create an annotation with "user": "acct:my_user@127.0.0.1".
-
-        annotation = Annotation(num_tags=3)
-
-    will create an annotation with 3 (randomly generated) tags.
-    Without this argument the number of tags is chosen at random (and may be
-    zero).
-
-    To choose the actual values of the tags do:
-
-        annotation = Annotation(tags=["foo", "bar"])
-
-    A random number is generated for each annotation and used in the URI
-    ("http://example.com/document_3"), document title ("Example Document 3"),
-    etc. To choose this number do:
-
-        annotation = Annotation(random_number=7)
+FAKER = faker.Factory.create()
 
 
-    """
+class Document(factory.alchemy.SQLAlchemyModelFactory):
 
-    class Meta:
-        model = storage.annotation_from_dict({}).__class__
-        exclude = ["username", "random_number", "num_tags", "exact_text",
-                   "document_title"]
+    class Meta:  # pylint: disable=no-init, old-style-class
+        model = models.Document
+        sqlalchemy_session = db.Session
 
-    username = "seanh"
-    random_number = factory.LazyAttribute(lambda n: random.randint(1, 10))
-    num_tags = None
-    exact_text = None
-    document_title = None
 
-    id = factory.Sequence(lambda n: "test_id_{n}".format(n=n + 1))
-    text = factory.Sequence(lambda n: "Test annotation {n}".format(n=n + 1))
-    user = factory.LazyAttribute(
-        lambda n: u"acct:{username}@127.0.0.1".format(username=n.username))
+class DocumentMeta(factory.alchemy.SQLAlchemyModelFactory):
 
-    @factory.LazyAttribute
-    def created(stub):
-        # pylint: disable=no-self-use
-        return datetime.datetime.now().isoformat()
+    class Meta:  # pylint: disable=no-init, old-style-class
+        model = models.DocumentMeta
+        sqlalchemy_session = db.Session
 
-    updated = factory.SelfAttribute('created')
+    # Trying to add two DocumentMetas with the same claimant and type to the
+    # db will crash. We use a sequence instead of something like FAKER.url()
+    # for claimant here so that never happens (unless you pass in your own
+    # claimant).
+    claimant = factory.Sequence(
+        lambda n: 'http://example.com/document_' + str(n) + '/')
 
-    @factory.LazyAttribute
-    def tags(stub):
-        num = (stub.num_tags if stub.num_tags is not None else
-               random.randint(1, 11))
-        return ["tag_{n}".format(n=n) for n in range(1, num + 1)]
+    type = factory.Iterator([
+        'title', 'twitter.url.main_url', 'twitter.title', 'favicon'])
+    document = factory.SubFactory(Document)
 
-    @factory.LazyAttribute
-    def uri(stub):
-        return "http://example.com/document_{n}".format(n=stub.random_number)
+    @factory.lazy_attribute
+    def value(self):
+        if self.type == 'twitter.url.main_url':
+            return [FAKER.url()]
+        elif self.type == 'favicon':
+            return [FAKER.image_url()]
+        else:
+            return [FAKER.bs()]
 
-    @factory.LazyAttribute
-    def target_selectors(stub):
-        return [{"type": "RangeSelector",
-                 "startContainer": "/div[1]/article[1]/",
-                 "endContainer": "/div[1]/article[1]/section[1]",
-                 "startOffset": 0,
-                 "endOffset": 43},
-                {"start": 211,
-                 "end": 254,
-                 "type": "TextPositionSelector"},
-                {"type": "TextQuoteSelector",
-                 "prefix": "text quote prefix",
-                 "exact": (stub.exact_text if stub.exact_text is not None
-                           else "The exact text that was selected"),
-                 "suffix": "text quote suffix"},
-                {"type": "FragmentSelector",
-                 "value": ""}
-            ]
 
-    @factory.LazyAttribute
-    def permissions(stub):
-        return {
-            "admin": [stub.user],
-            "read": ["group:__world__"],
-            "update": [stub.user],
-            "delete": [stub.user]
-        }
+class DocumentURI(factory.alchemy.SQLAlchemyModelFactory):
 
-    @factory.LazyAttribute
-    def document(stub):
-        return {
-            "eprints": {},
-            "title": (stub.document_title or
-                      "Example Document {n}".format(n=stub.random_number)),
-            "twitter": {},
-            "dc": {},
-            "prism": {},
-            "highwire": {},
-            "facebook": {},
-            "link": [{"href": stub.uri}]
-        }
+    class Meta:  # pylint: disable=no-init, old-style-class
+        model = models.DocumentURI
+        sqlalchemy_session = db.Session
+
+    # Trying to add two DocumentURIs with the same claimant, uri, type and
+    # content_type to the db will crash. We use a sequence instead of something
+    # like FAKER.url() for claimant here so that never happens (unless you pass
+    # in your own claimant).
+    claimant = factory.Sequence(
+        lambda n: 'http://example.com/document_' + str(n) + '/')
+
+    uri = factory.LazyAttribute(lambda obj: obj.claimant)
+    type = factory.Iterator(['rel-alternate', 'rel-canonical', 'highwire-pdf',
+                             'dc-doi'])
+    content_type = factory.Iterator(['text/html', 'application/pdf',
+                                     'text/plain'])
+    document = factory.SubFactory(Document)
+
+
+class Annotation(factory.alchemy.SQLAlchemyModelFactory):
+
+    class Meta:  # pylint: disable=no-init, old-style-class
+        model = models.Annotation
+        sqlalchemy_session = db.Session
+        force_flush = True  # Always flush the db to generate annotation.id.
+
+    tags = factory.LazyFunction(
+        lambda: FAKER.words(nb=random.randint(0, 5)))
+    target_uri = factory.Faker('uri')
+    text = factory.Faker('paragraph')
+    userid = factory.Faker('user_name')
+
+    @factory.lazy_attribute
+    def target_selectors(self):  # pylint: disable=no-self-use
+        return [
+            {
+                'endContainer': '/div[1]/article[1]/section[1]/div[1]/div[2]/div[1]',
+                'endOffset': 76,
+                'startContainer': '/div[1]/article[1]/section[1]/div[1]/div[2]/div[1]',
+                'startOffset': 0,
+                'type': 'RangeSelector'
+            },
+            {
+                'end': 362,
+                'start': 286,
+                'type': 'TextPositionSelector'
+            },
+            {
+                'exact': 'If you wish to install Hypothesis on your own site then head over to GitHub.',
+                'prefix': ' browser extension.\n            ',
+                'suffix': '\n          \n        \n      \n    ',
+                'type': 'TextQuoteSelector'
+            },
+        ]
+
+    @factory.post_generation
+    def make_metadata(self, create, extracted, **kwargs):
+        """Create associated document metadata for the annotation."""
+        # The metadata objects are going to be added to the db, so if we're not
+        # using the create strategy then simply don't make any.
+        if not create:
+            return
+
+        def document_uri_dict():
+            """
+            Return a randomly generated DocumentURI dict for this annotation.
+
+            This doesn't add anything to the database session yet.
+            """
+            document_uri = DocumentURI.build(claimant=self.target_uri,
+                                             uri=self.target_uri)
+            return dict(
+                claimant=document_uri.claimant,
+                uri=document_uri.uri,
+                type=document_uri.type,
+                content_type=document_uri.content_type,
+            )
+
+        document_uri_dicts = [document_uri_dict()
+                              for _ in range(random.randint(1, 3))]
+
+        def document_meta_dict(**kwargs):
+            """
+            Return a randomly generated DocumentMeta dict for this annotation.
+
+            This doesn't add anything to the database session yet.
+            """
+            kwargs.setdefault('claimant', self.target_uri)
+            document_meta = DocumentMeta.build(**kwargs)
+            return dict(
+                claimant=document_meta.claimant,
+                type=document_meta.type,
+                value=document_meta.value,
+            )
+
+        document_meta_dicts = [document_meta_dict()
+                               for _ in range(random.randint(1, 3))]
+
+        # Make sure that there's always at least one DocumentMeta with
+        # type='title', so that we never get annotation.document.title is None:
+        if 'title' not in [m['type'] for m in document_meta_dicts]:
+            document_meta_dicts.append(document_meta_dict(type='title'))
+
+        api_models.update_document_metadata(
+            db.Session,
+            self,
+            document_meta_dicts=document_meta_dicts,
+            document_uri_dicts=document_uri_dicts,
+        )
 
 
 class User(factory.Factory):

--- a/tests/h/factories_test.py
+++ b/tests/h/factories_test.py
@@ -3,90 +3,111 @@
 """Unit tests for h/test/factories.py."""
 import datetime
 
-from .. import factories
+from h import db
+from tests import factories
+
+
+class TestDocument(object):
+
+    def test_with_default_values(self):
+        document = factories.Document()
+
+        db.Session.flush()
+        assert document.id
+        assert isinstance(document.created, datetime.datetime)
+        assert isinstance(document.updated, datetime.datetime)
+
+
+class TestDocumentMeta(object):
+
+    def test_with_default_values(self):
+        document_meta = factories.DocumentMeta()
+
+        db.Session.flush()
+        assert document_meta.id
+        assert document_meta.claimant
+        assert document_meta.claimant_normalized
+        assert document_meta.type
+        assert document_meta.document
+        assert document_meta.value
+        assert isinstance(document_meta.created, datetime.datetime)
+        assert isinstance(document_meta.updated, datetime.datetime)
+
+    def test_with_custom_values(self):
+        kwargs = dict(
+            claimant='http://www.example.com/claimant',
+            type='test_type',
+            value='test_value',
+        )
+
+        document_meta = factories.DocumentMeta(**kwargs)
+
+        for key, value in kwargs.items():
+            assert getattr(document_meta, key) == value
+
+
+class TestDocumentURI(object):
+
+    def test_with_default_values(self):
+        document_uri = factories.DocumentURI()
+
+        db.Session.flush()
+        assert document_uri.id
+        assert document_uri.claimant
+        assert document_uri.claimant_normalized
+        assert document_uri.uri
+        assert document_uri.uri_normalized
+        assert document_uri.type
+        assert document_uri.content_type
+        assert document_uri.document
+        assert isinstance(document_uri.created, datetime.datetime)
+        assert isinstance(document_uri.updated, datetime.datetime)
+
+    def test_with_custom_values(self):
+        kwargs = dict(
+            claimant='http://example.com/claimant',
+            uri='http://example.com/uri',
+            type='test_type',
+            content_type='test_content_type',
+        )
+
+        document_uri = factories.DocumentURI(**kwargs)
+
+        for key, value in kwargs.items():
+            assert getattr(document_uri, key) == value
 
 
 class TestAnnotation(object):
 
-    """Unit tests for the Annotation factory class."""
-
-    def test_id(self):
-        """Each test annotation should be created with a unique ID."""
-        annotation_1 = factories.Annotation()
-        annotation_2 = factories.Annotation()
-
-        assert annotation_1.get("id")
-        assert annotation_2.get("id")
-        assert annotation_1["id"] != annotation_2["id"]
-
-    def test_text(self):
-        """Each annotation should have unique note text."""
-        annotation_1 = factories.Annotation()
-        annotation_2 = factories.Annotation()
-
-        assert annotation_1.get("text")
-        assert annotation_2.get("text")
-        assert annotation_1["text"] != annotation_2["text"]
-
-    def test_custom_user(self):
-        """A custom username should be used in the user field."""
-        annotation = factories.Annotation(username="bobo")
-        assert "bobo" in annotation["user"]
-        assert "username" not in annotation
-
-    def test_created_date(self):
-        """Annotations should have a created date from the current time."""
-        before = datetime.datetime.now()
-
+    def test_with_default_values(self):
         annotation = factories.Annotation()
 
-        after = datetime.datetime.now()
-        created = datetime.datetime.strptime(
-            annotation["created"], "%Y-%m-%dT%H:%M:%S.%f")
+        assert isinstance(annotation.tags, list)
+        assert annotation.target_uri
+        assert annotation.text
+        assert annotation.userid
+        assert annotation.target_selectors
+        assert annotation.document
+        assert annotation.document.title
+        assert annotation.document.document_uris
+        assert annotation.document.meta
+        assert annotation.id
+        assert isinstance(annotation.created, datetime.datetime)
+        assert isinstance(annotation.updated, datetime.datetime)
+        assert annotation.groupid
+        assert isinstance(annotation.shared, bool)
+        assert isinstance(annotation.references, list)
+        assert isinstance(annotation.extra, dict)
 
-        assert before < created < after
+    def test_with_custom_values(self):
+        kwargs = dict(
+            tags=['foo', 'bar'],
+            target_uri='http://example.com/target_uri',
+            userid='catalina',
+            target_selectors=[{'foo': 'bar'}],
+        )
 
-    def test_updated_date(self):
-        """Annotations should have an updated date from the current time."""
-        before = datetime.datetime.now()
+        annotation = factories.Annotation(**kwargs)
 
-        annotation = factories.Annotation()
-
-        after = datetime.datetime.now()
-        updated = datetime.datetime.strptime(
-            annotation["updated"], "%Y-%m-%dT%H:%M:%S.%f")
-
-        assert before < updated < after
-
-    def test_tags(self):
-        """It should be possible to choose the number of tags with num_tags."""
-        # If num_tags isn't passed the factory chooses a random number of tags.
-        # Here we choose a num_tags higher than the upper range of this random
-        # choice, so there's no chance of random false positive test passes.
-        annotation = factories.Annotation(num_tags=20)
-        assert len(annotation["tags"]) == 20
-        assert "num_tags" not in annotation
-
-    def test_custom_tags(self):
-        assert factories.Annotation(tags=["foo", "bar", "gar"])["tags"] == [
-            "foo", "bar", "gar"]
-
-    def test_uri(self):
-        annotation = factories.Annotation(random_number=3)
-        assert annotation["uri"] == "http://example.com/document_3"
-        assert "random_number" not in annotation
-
-    def test_permissions(self):
-        annotation = factories.Annotation(username="test_user")
-        assert "test_user" in annotation["permissions"]["admin"][0]
-        assert "test_user" in annotation["permissions"]["update"][0]
-        assert "test_user" in annotation["permissions"]["delete"][0]
-
-    def test_document_title(self):
-        assert factories.Annotation(random_number=30)["document"]["title"] == (
-            "Example Document 30")
-
-    def test_document_link(self):
-        annotation = factories.Annotation(random_number=30)
-        assert annotation["document"]["link"][0]["href"] == (
-            "http://example.com/document_30")
+        for key, value in kwargs.items():
+            assert getattr(annotation, key) == value

--- a/tests/h/feeds/atom_test.py
+++ b/tests/h/feeds/atom_test.py
@@ -101,7 +101,7 @@ def test_entry_id(util):
 
 def test_entry_author():
     """The authors of entries should come from the annotation usernames."""
-    annotation = factories.Annotation(user='acct:nobu@hypothes.is')
+    annotation = factories.Annotation(userid='acct:nobu@hypothes.is')
 
     feed = atom.feed_from_annotations(
         [annotation], "atom_url", lambda annotation: "annotation url")

--- a/tests/h/feeds/rss_test.py
+++ b/tests/h/feeds/rss_test.py
@@ -68,7 +68,7 @@ def test_feed_from_annotations_item_titles():
     feed = rss.feed_from_annotations(
         [annotation], _annotation_url(), mock.Mock(), '', '', '')
 
-    assert feed['entries'][0]['title'] == annotation['document']['title']
+    assert feed['entries'][0]['title'] == annotation.document.title
 
 
 def test_feed_from_annotations_item_descriptions():
@@ -85,13 +85,14 @@ def test_feed_from_annotations_item_descriptions():
 
 def test_feed_from_annotations_item_guid():
     """Feed items should use the annotation's HTML URL as their GUID."""
-    feed = rss.feed_from_annotations(
-        [factories.Annotation(
-            id='id',
-            created=datetime.datetime(year=2015, month=3, day=11).isoformat())
-         ], _annotation_url(), mock.Mock(), '', '', '')
+    annotation = factories.Annotation(
+        created=datetime.datetime(year=2015, month=3, day=11))
 
-    assert feed['entries'][0]['guid'] == 'tag:hypothes.is,2015-09:id'
+    feed = rss.feed_from_annotations(
+        [annotation], _annotation_url(), mock.Mock(), '', '', '')
+
+    assert feed['entries'][0]['guid'] == (
+        'tag:hypothes.is,2015-09:' + annotation.id)
 
 
 def test_feed_from_annotations_title():

--- a/tests/h/feeds/util_test.py
+++ b/tests/h/feeds/util_test.py
@@ -10,11 +10,10 @@ from ... import factories
 def test_tag_uri_for_annotation():
     """Entry IDs should be tag URIs based on domain, day and annotation ID."""
     annotation = factories.Annotation(
-        id="12345",
-        created=datetime.datetime(year=2015, month=3, day=19).isoformat())
+        created=datetime.datetime(year=2015, month=3, day=19))
 
     tag_uri = util.tag_uri_for_annotation(
         annotation,
         annotation_url=mock.Mock(return_value="http://example.com/a/12345"))
 
-    assert tag_uri == "tag:example.com,2015-09:12345"
+    assert tag_uri == "tag:example.com,2015-09:" + annotation.id


### PR DESCRIPTION
Rewrite factories.Annotation to generate the new h.api.models.Annotation
objects that use the new PostgreSQL annotation storage, instead of
generating legacy Elasticsearch storage objects.

In the process also add Document, DocumentURI and DocumentMeta factories that the
Annotation factory uses, these can also be used independently.

Demo:

```python
>>> a = factories.Annotation()
>>> a.tags  # Each annotation gets a random number of randomly generated tags.
[]
>>> factories.Annotation().tags
[u'quo', u'eos']
>>> factories.Annotation().tags
[u'enim', u'suscipit', u'mollitia', u'ab']
>>> a.target_uri  # Randomly generated fake URI.
u'http://www.weimann.com/faq.jsp'
>>> a.text  # Randomly generated text.
u'Commodi magnam pariatur nulla itaque repellat reprehenderit odit. Ipsum molestiae adipisci beatae totam accusantium. Incidunt beatae iste ab blanditiis pariatur voluptatibus beatae. Harum eligendi nulla nisi maxime maxime consequatur quod.'
>>> a.userid  # Randomly generated fake user ID.
u'wpfeffer'
>>> a.target_selectors  # This is hard-coded.
[{u'type': u'RangeSelector', u'startContainer': u'/div[1]/article[1]/section[1]/div[1]/div[2]/div[1]', u'endContainer': u'/div[1]/article[1]/section[1]/div[1]/div[2]/div[1]', u'startOffset': 0, u'endOffset': 76}, {u'start': 286, u'end': 362, u'type': u'TextPositionSelector'}, {u'type': u'TextQuoteSelector', u'prefix': u' browser extension.\n            ', u'exact': u'If you wish to install Hypothesis on your own site then head over to GitHub.', u'suffix': u'\n          \n        \n      \n    '}]
>>> a.document  # Either a new Document will be created and added to the db,
                # or an existing one will be used
                # (it actually just calls update_document_metadata()).
<Document 42>
>>> a.document.title  # This comes from the generated DocumentMetas.
u'revolutionize dynamic e-tailers'
>>> a.document.document_uris  # A random number of randomly generated
                              # DocumentURIs are added to the db.
[<DocumentURI 52>, <DocumentURI 53>, <DocumentURI 54>]
>>> # They all match the target_uri of the annotation:
>>> [(u.claimant, u.claimant_normalized, u.uri, u.uri_normalized) for u in a.document.document_uris]
[(u'http://www.weimann.com/faq.jsp', u'http://www.weimann.com/faq.jsp',
  u'http://www.weimann.com/faq.jsp', u'http://www.weimann.com/faq.jsp'),
 (u'http://www.weimann.com/faq.jsp', u'http://www.weimann.com/faq.jsp',
  u'http://www.weimann.com/faq.jsp', u'http://www.weimann.com/faq.jsp'),
 (u'http://www.weimann.com/faq.jsp', u'http://www.weimann.com/faq.jsp',
  u'http://www.weimann.com/faq.jsp', u'http://www.weimann.com/faq.jsp')]
>>> # Types and content types come from looping sequences of hardcoded values.
>>> # FIXME: I'm not sure why there's a None in here.
>>> [(u.type, u.content_type) for u in a.document.document_uris]
[(u'self-claim', None), (u'rel-alternate', u'text/html'),
 (u'rel-canonical', u'application/pdf')]
>>> a.document.meta # A random number of randomly generated DocumentMetas are
                    # added to the db.
[<DocumentMeta 124>]
>>> a.document.meta[0].claimant  # It matches the annotation's target_uri.
u'http://www.weimann.com/faq.jsp'
>>> # Type and value loop through lists of hardcoded values.
>>> a.document.meta[0].type
u'title'
>>> a.document.meta[0].value
[u'revolutionize dynamic e-tailers']
```

Additionally:

* `factories.Annotation.build()` will make an `Annotation()` only (no `Document`s, `DocumentURI`s and `DocumentMeta`s) and will not add it to the db session

* You can also call `factories.Document()`, `factories.DocumentURI()` and `factories.DocumentMeta()` directly. If all you do is call `factories.DocumentURI()` and `factories.DocumentMeta()` and you didn't add any `DocumentURI`s or `DocumentMeta`s into the db in any other way, it should be safe. If there's already stuff in the db it may throw `IntegrityError`. By default it just creates a new `Document` for each `DocumentURI` and `DocumentMeta` and doesn't do any merging of documents.

* You can always call `factories.DocumentURI.build()` and `factories.DocumentMeta.build()` which is safe because it doesn't add them to the db session, then you can create dicts from these unattached `DocumentURI`s and `DocumentMeta`s and pass them into `h.api.models.update_document_metadata()` which will do the right thing (this is actually what `factories.Annotation()` does).