### PR TITLE
Fix annotations made on PDFs in non-Safari browsers not appearing in Safari

### DIFF
--- a/h/static/scripts/annotator/test/guest-test.coffee
+++ b/h/static/scripts/annotator/test/guest-test.coffee
@@ -206,6 +206,28 @@ describe 'Guest', ->
 
         emitGuestEvent('getDocumentInfo', assertComplete)
 
+  describe 'getDocumentInfo()', ->
+    guest = null
+
+    beforeEach ->
+      guest = createGuest()
+      guest.plugins.PDF =
+        uri: -> 'urn:x-pdf:001122'
+        getMetadata: sandbox.stub()
+
+    it 'preserves the components of the URI other than the fragment', ->
+      guest.plugins.PDF = null
+      guest.plugins.Document =
+        uri: -> 'http://foobar.com/things?id=42'
+        metadata: {}
+      return guest.getDocumentInfo().then ({uri}) ->
+        assert.equal uri, 'http://foobar.com/things?id=42'
+
+    it 'removes the fragment identifier from URIs', () ->
+      guest.plugins.PDF.uri = -> 'urn:x-pdf:aabbcc#'
+      return guest.getDocumentInfo().then ({uri}) ->
+        assert.equal uri, 'urn:x-pdf:aabbcc'
+
   describe 'onAdderMouseUp', ->
     it 'it prevents the default browser action when triggered', () ->
       event = jQuery.Event('mouseup')


### PR DESCRIPTION
In Safari a trailing '#' is appended to URIs extracted from web
documents and PDFs. For URLs this makes no difference as the Hypothesis
search API ignores the fragment identifier. However a URN with a
trailing '#' is considered different from a URN without a trailing '#'.
Since the URI for PDFs is now a URN of the form 'urn:x-pdf:...', when
viewing a PDF in Safari annotations made in other browsers were not
fetched and vice-versa.

The trailing '#' is caused by a bug in the `URL.hash` setter in Safari.

According to section 6.3 of the URL spec [1], setting URL.hash to an empty
string should _remove_ the fragment identifier. In Safari however, it
sets the fragment identifier to an empty string. The result is that when
the URL is serialized, the output is eg. 'urn:x-pdf:aabb#' instead of
'urn:x-pdf:aabb'.

Upstream bug: https://bugs.webkit.org/show_bug.cgi?id=158869
Fixes #3471

[1] https://url.spec.whatwg.org/#urlutils-members