### PR TITLE
Remove unnecessary code for checking type of `annotation.references` field

### DIFF
--- a/h/static/scripts/directive/annotation.js
+++ b/h/static/scripts/directive/annotation.js
@@ -471,16 +471,7 @@ function AnnotationController(
     * Creates a new message in reply to this annotation.
     */
   vm.reply = function() {
-    var references = domainModel.references || [];
-
-    // TODO: Remove this check once we have server-side code to ensure that
-    // references is always an array of strings.
-    if (typeof references === 'string') {
-      references = [references];
-    }
-
-    references = references.concat(domainModel.id);
-
+    var references = (domainModel.references || []).concat(domainModel.id);
     var reply = annotationMapper.createAnnotation({
       references: references,
       uri: domainModel.uri


### PR DESCRIPTION
Based on my understanding of `elastic.py` and `h/api/models/annotation.py` we're now guaranteed that the references field in API responses is either null or an array of strings, so the client-side check can be be removed. Please correct me if I've got this wrong @chdorner