### PR TITLE
Tailor API response to client

### DIFF
--- a/h/api/models/document.py
+++ b/h/api/models/document.py
@@ -38,16 +38,19 @@ class Document(Base, mixins.Timestamps):
                                backref='document',
                                order_by='DocumentMeta.updated.desc()')
 
+    meta_titles = sa.orm.relationship('DocumentMeta',
+                                      primaryjoin='and_(Document.id==DocumentMeta.document_id, DocumentMeta.type==u"title")',
+                                      order_by='DocumentMeta.updated.asc()',
+                                      viewonly=True)
+
     def __repr__(self):
         return '<Document %s>' % self.id
 
     @property
     def title(self):
-        titles = [m.value for m in self.meta if m.type == 'title']
-        try:
-            return titles[0][0]
-        except IndexError:
-            return None
+        for meta in self.meta_titles:
+            if meta.value:
+                return meta.value[0]
 
     @classmethod
     def find_by_uris(cls, session, uris):

--- a/h/api/presenters.py
+++ b/h/api/presenters.py
@@ -196,22 +196,6 @@ class DocumentJSONPresenter(object):
         return d
 
 
-class DocumentMetaJSONPresenter(object):
-    def __init__(self, document_meta):
-        self.document_meta = document_meta
-
-    def asdict(self):
-        # This turns a keypath into a nested dict by first reversing the
-        # keypath and then creating the dict from inside-out. Rather than
-        # using recursion to create the dict from the outside in.
-        reversed_path = self.document_meta.type.split('.')[::-1]
-        d = self.document_meta.value
-        for nested in reversed_path:
-            d = {nested: d}
-
-        return d
-
-
 class DocumentURIJSONPresenter(object):
     def __init__(self, document_uri):
         self.document_uri = document_uri

--- a/h/api/presenters.py
+++ b/h/api/presenters.py
@@ -188,11 +188,6 @@ class DocumentJSONPresenter(object):
         if title:
             d['title'] = [title]
 
-        d['link'] = []
-        for docuri in self.document.document_uris:
-            uri_presenter = DocumentURIJSONPresenter(docuri)
-            d['link'].append(uri_presenter.asdict())
-
         return d
 
 

--- a/h/api/presenters.py
+++ b/h/api/presenters.py
@@ -191,30 +191,6 @@ class DocumentJSONPresenter(object):
         return d
 
 
-class DocumentURIJSONPresenter(object):
-    def __init__(self, document_uri):
-        self.document_uri = document_uri
-
-    def asdict(self):
-        data = {'href': self.document_uri.uri}
-
-        rel = self.rel
-        if rel:
-            data['rel'] = rel
-
-        type = self.document_uri.content_type
-        if type:
-            data['type'] = type
-
-        return data
-
-    @property
-    def rel(self):
-        type = self.document_uri.type
-        if type and type.startswith('rel-'):
-            return self.document_uri.type[4:]
-
-
 def add_annotation_link_generator(registry, name, generator):
     """
     Registers a function which generates a named link for an annotation.

--- a/h/api/presenters.py
+++ b/h/api/presenters.py
@@ -184,10 +184,9 @@ class DocumentJSONPresenter(object):
             return {}
 
         d = {}
-
-        for docmeta in self.document.meta:
-            meta_presenter = DocumentMetaJSONPresenter(docmeta)
-            deep_merge_dict(d, meta_presenter.asdict())
+        title = self.document.title
+        if title:
+            d['title'] = [title]
 
         d['link'] = []
         for docuri in self.document.document_uris:

--- a/h/api/storage.py
+++ b/h/api/storage.py
@@ -8,7 +8,6 @@ assumed to be validated.
 """
 
 from pyramid import i18n
-from sqlalchemy.orm import subqueryload
 
 from h.api import schemas
 from h.api import models
@@ -50,19 +49,37 @@ def fetch_annotation(session, id_):
         return None
 
 
-def fetch_ordered_annotations(session, ids, load_documents=False):
+def fetch_ordered_annotations(session, ids, query_processor=None):
+    """
+    Fetch all annotations with the given ids and order them based on the list
+    of ids.
+
+    The optional `query_processor` parameter allows for passing in a function
+    that can change the query before it is run, especially useful for
+    eager-loading certain data. The function will get the query as an argument
+    and has to return a query object again.
+
+    :param session: the database session
+    :type session: sqlalchemy.orm.session.Session
+
+    :param ids: the list of annotation ids
+    :type ids: list
+
+    :param query_processor: an optional function that takes the query and
+                            returns an updated query
+    :type query_processor: callable
+
+    :returns: the annotation, if found, or None.
+    :rtype: h.api.models.Annotation, NoneType
+    """
     if not ids:
         return []
 
     ordering = {x: i for i, x in enumerate(ids)}
 
     query = session.query(models.Annotation).filter(models.Annotation.id.in_(ids))
-
-    if load_documents:
-        query = query.options(
-            subqueryload(models.Annotation.document).subqueryload(models.Document.document_uris),
-            subqueryload(models.Annotation.document).subqueryload(models.Document.meta)
-        )
+    if query_processor:
+        query = query_processor(query)
 
     anns = sorted(query, key=lambda a: ordering.get(a.id))
     return anns

--- a/h/api/views.py
+++ b/h/api/views.py
@@ -139,11 +139,12 @@ def search(request):
                             separate_replies=separate_replies)
 
     # Run the results through the JSON presenter
-    out['rows'] = [_present_searchdict(request, a)
-                   for a in out['rows']]
+    ids = [r['id'] for r in out['rows']]
+    out['rows'] = _present_annotations(request, ids)
+
     if separate_replies:
-        out['replies'] = [_present_searchdict(request, a)
-                          for a in out['replies']]
+        ids = [r['id'] for r in out['replies']]
+        out['replies'] = _present_annotations(request, ids)
 
     return out
 
@@ -234,10 +235,10 @@ def _json_payload(request):
         raise PayloadError()
 
 
-def _present_searchdict(request, mapping):
-    """Run an object returned from search through a presenter."""
-    ann = storage.annotation_from_dict(mapping)
-    return AnnotationJSONPresenter(request, ann).asdict()
+def _present_annotations(request, ids):
+    """Load annotations by id from the database and present them."""
+    annotations = storage.fetch_ordered_annotations(request.db, ids, load_documents=True)
+    return [AnnotationJSONPresenter(request, ann).asdict() for ann in annotations]
 
 
 def _publish_annotation_event(request,

--- a/h/api/views.py
+++ b/h/api/views.py
@@ -241,7 +241,6 @@ def _present_annotations(request, ids):
     """Load annotations by id from the database and present them."""
     def eager_load_documents(query):
         return query.options(
-            subqueryload(models.Annotation.document).subqueryload(models.Document.document_uris),
             subqueryload(models.Annotation.document).subqueryload(models.Document.meta_titles))
 
     annotations = storage.fetch_ordered_annotations(request.db, ids,

--- a/h/api/views.py
+++ b/h/api/views.py
@@ -242,7 +242,7 @@ def _present_annotations(request, ids):
     def eager_load_documents(query):
         return query.options(
             subqueryload(models.Annotation.document).subqueryload(models.Document.document_uris),
-            subqueryload(models.Annotation.document).subqueryload(models.Document.meta))
+            subqueryload(models.Annotation.document).subqueryload(models.Document.meta_titles))
 
     annotations = storage.fetch_ordered_annotations(request.db, ids,
                                                     query_processor=eager_load_documents)

--- a/h/feeds/views.py
+++ b/h/feeds/views.py
@@ -13,7 +13,7 @@ def _annotations(request):
     """Return the annotations from the search API."""
     rows = search.search(request, request.params)['rows']
     ids = [r['id'] for r in rows]
-    return storage.fetch_ordered_annotations(request.db, ids, load_documents=True)
+    return storage.fetch_ordered_annotations(request.db, ids)
 
 
 @view_config(route_name='stream_atom')

--- a/h/static/scripts/annotation-metadata.js
+++ b/h/static/scripts/annotation-metadata.js
@@ -13,47 +13,23 @@
  *
  */
 function extractDocumentMetadata(annotation) {
-  var document_;
   var uri = annotation.uri;
   var domain = new URL(uri).hostname;
-  if (annotation.document) {
-    if (uri.indexOf('urn') === 0) {
-      var i;
-      for (i = 0; i < annotation.document.link.length; i++) {
-        var link = annotation.document.link[i];
-        if (link.href.indexOf('urn:') === 0) {
-          continue;
-        }
-        uri = link.href;
-        break;
-      }
-    }
+  var title = domain;
 
-    var documentTitle;
-    if (Array.isArray(annotation.document.title)) {
-      documentTitle = annotation.document.title[0];
-    } else {
-      documentTitle = annotation.document.title;
-    }
-
-    document_ = {
-      uri: uri,
-      domain: domain,
-      title: documentTitle || domain
-    };
-  } else {
-    document_ = {
-      uri: uri,
-      domain: domain,
-      title: domain
-    };
+  if (annotation.document && annotation.document.title) {
+    title = annotation.document.title[0];
   }
 
-  if (document_.title.length > 30) {
-    document_.title = document_.title.slice(0, 30) + '…';
+  if (title.length > 30) {
+    title = title.slice(0, 30) + '…';
   }
 
-  return document_;
+  return {
+    uri: uri,
+    domain: domain,
+    title: title,
+  };
 }
 
 /** Return `true` if the given annotation is a reply, `false` otherwise. */

--- a/h/static/scripts/test/annotation-metadata-test.js
+++ b/h/static/scripts/test/annotation-metadata-test.js
@@ -17,26 +17,6 @@ describe('annotation-metadata', function () {
         assert.equal(extractDocumentMetadata(model).domain, 'example.com');
       });
 
-      context('when model.uri starts with "urn"', function() {
-        it(
-          'uses the first document.link uri that doesn\'t start with "urn"',
-          function() {
-            var model = {
-              uri: 'urn:isbn:0451450523',
-              document: {
-                link: [
-                  {href: 'urn:isan:0000-0000-9E59-0000-O-0000-0000-2'},
-                  {href: 'http://example.com/'}
-                ]
-              }
-            };
-
-            assert.equal(
-              extractDocumentMetadata(model).uri, 'http://example.com/');
-          }
-        );
-      });
-
       context('when model.uri does not start with "urn"', function() {
         it('uses model.uri as the uri', function() {
           var model = {
@@ -49,27 +29,13 @@ describe('annotation-metadata', function () {
         });
       });
 
-      context('when document.title is a string', function() {
-        it('returns document.title as title', function() {
-          var model = {
-            uri: 'http://example.com/',
-            document: {
-              title: 'My Document'
-            }
-          };
-
-          assert.equal(
-            extractDocumentMetadata(model).title, model.document.title);
-        });
-      });
-
-      context('when document.title is an array', function() {
-        it('returns document.title[0] as title', function() {
+      context('when document.title is an available', function() {
+        it('uses the first document title as the title', function() {
           var model = {
             uri: 'http://example.com/',
             document: {
               title: ['My Document', 'My Other Document']
-            }
+            },
           };
 
           assert.equal(
@@ -114,8 +80,8 @@ describe('annotation-metadata', function () {
         var model = {
           uri: 'http://example.com/',
           document: {
-            title: 'My Really Really Long Document Title'
-          }
+            title: ['My Really Really Long Document Title'],
+          },
         };
 
         assert.equal(

--- a/tests/h/api/presenters_test.py
+++ b/tests/h/api/presenters_test.py
@@ -11,7 +11,6 @@ from h.api.presenters import AnnotationJSONPresenter
 from h.api.presenters import AnnotationSearchIndexPresenter
 from h.api.presenters import AnnotationJSONLDPresenter
 from h.api.presenters import DocumentJSONPresenter
-from h.api.presenters import DocumentMetaJSONPresenter
 from h.api.presenters import DocumentURIJSONPresenter
 from h.api.presenters import add_annotation_link_generator
 from h.api.presenters import utc_iso8601, deep_merge_dict
@@ -453,16 +452,6 @@ class TestDocumentJSONPresenter(object):
 
         presenter = DocumentJSONPresenter(document)
         assert {'link': [], 'title': ['Foo']} == presenter.asdict()
-
-
-class TestDocumentMetaJSONPresenter(object):
-    def test_asdict(self):
-        meta = mock.Mock(type='twitter.url.main_url',
-                         value='https://example.com')
-        presenter = DocumentMetaJSONPresenter(meta)
-
-        expected = {'twitter': {'url': {'main_url': 'https://example.com'}}}
-        assert expected == presenter.asdict()
 
 
 class TestDocumentURIJSONPresenter(object):

--- a/tests/h/api/presenters_test.py
+++ b/tests/h/api/presenters_test.py
@@ -11,7 +11,6 @@ from h.api.presenters import AnnotationJSONPresenter
 from h.api.presenters import AnnotationSearchIndexPresenter
 from h.api.presenters import AnnotationJSONLDPresenter
 from h.api.presenters import DocumentJSONPresenter
-from h.api.presenters import DocumentURIJSONPresenter
 from h.api.presenters import add_annotation_link_generator
 from h.api.presenters import utc_iso8601, deep_merge_dict
 
@@ -450,50 +449,6 @@ class TestDocumentJSONPresenter(object):
 
         presenter = DocumentJSONPresenter(document)
         assert {'title': ['Foo']} == presenter.asdict()
-
-
-class TestDocumentURIJSONPresenter(object):
-    def test_asdict(self):
-        docuri = mock.Mock(uri='http://example.com/site.pdf',
-                           type='rel-alternate',
-                           content_type='application/pdf')
-        presenter = DocumentURIJSONPresenter(docuri)
-
-        expected = {'href': 'http://example.com/site.pdf',
-                    'rel': 'alternate',
-                    'type': 'application/pdf'}
-
-        assert expected == presenter.asdict()
-
-    def test_asdict_empty_rel(self):
-        docuri = mock.Mock(uri='http://example.com',
-                           type='dc-doi',
-                           content_type='text/html')
-        presenter = DocumentURIJSONPresenter(docuri)
-
-        expected = {'href': 'http://example.com', 'type': 'text/html'}
-
-        assert expected == presenter.asdict()
-
-    def test_asdict_empty_type(self):
-        docuri = mock.Mock(uri='http://example.com',
-                           type='rel-canonical',
-                           content_type=None)
-        presenter = DocumentURIJSONPresenter(docuri)
-
-        expected = {'href': 'http://example.com', 'rel': 'canonical'}
-
-        assert expected == presenter.asdict()
-
-    def test_rel_with_type_rel(self):
-        docuri = mock.Mock(type='rel-canonical')
-        presenter = DocumentURIJSONPresenter(docuri)
-        assert 'canonical' == presenter.rel
-
-    def test_rel_with_non_rel_type(self):
-        docuri = mock.Mock(type='highwire-pdf')
-        presenter = DocumentURIJSONPresenter(docuri)
-        assert presenter.rel is None
 
 
 def test_utc_iso8601():

--- a/tests/h/api/presenters_test.py
+++ b/tests/h/api/presenters_test.py
@@ -433,9 +433,7 @@ class TestDocumentJSONPresenter(object):
         db_session.flush()
 
         presenter = DocumentJSONPresenter(document)
-        expected = {'link': [{'href': 'http://foo.com'},
-                             {'href': 'http://foo.org', 'rel': 'canonical'}],
-                    'title': ['Foo']}
+        expected = {'title': ['Foo']}
         assert expected == presenter.asdict()
 
     def test_asdict_when_none_document(self):
@@ -451,7 +449,7 @@ class TestDocumentJSONPresenter(object):
         db_session.flush()
 
         presenter = DocumentJSONPresenter(document)
-        assert {'link': [], 'title': ['Foo']} == presenter.asdict()
+        assert {'title': ['Foo']} == presenter.asdict()
 
 
 class TestDocumentURIJSONPresenter(object):

--- a/tests/h/api/storage_test.py
+++ b/tests/h/api/storage_test.py
@@ -40,9 +40,9 @@ class TestFetchOrderedAnnotations(object):
         assert [ann_1, ann_2] == storage.fetch_ordered_annotations(db_session,
                                                                    [ann_1.id, ann_2.id])
 
-    def test_it_allows_to_prefetch_document_data(self, db_session):
+    def test_it_allows_to_change_the_query(self, db_session):
         ann_1 = Annotation(userid='luke', target_uri='http://example.com')
-        ann_2 = Annotation(userid='luke', target_uri='http://example.com')
+        ann_2 = Annotation(userid='maria', target_uri='http://example.com')
         db_session.add_all([ann_1, ann_2])
 
         doc = Document(
@@ -53,9 +53,12 @@ class TestFetchOrderedAnnotations(object):
 
         db_session.flush()
 
-        assert [ann_2, ann_1] == storage.fetch_ordered_annotations(db_session,
-                                                                   [ann_2.id, ann_1.id],
-                                                                   load_documents=True)
+        def only_maria(query):
+            return query.filter(Annotation.userid == 'maria')
+
+        assert [ann_2] == storage.fetch_ordered_annotations(db_session,
+                                                            [ann_2.id, ann_1.id],
+                                                            query_processor=only_maria)
 
 
 class TestExpandURI(object):

--- a/tests/h/api/views_test.py
+++ b/tests/h/api/views_test.py
@@ -79,7 +79,7 @@ class TestSearch(object):
         views.search(pyramid_request)
 
         storage.fetch_ordered_annotations.assert_called_once_with(
-            pyramid_request.db, ['row-1', 'row-2'], load_documents=True)
+            pyramid_request.db, ['row-1', 'row-2'], query_processor=mock.ANY)
 
     def test_it_renders_search_results(self, pyramid_request, search_lib):
         ann1 = models.Annotation(userid='luke')
@@ -110,7 +110,7 @@ class TestSearch(object):
         views.search(pyramid_request)
 
         assert mock.call(pyramid_request.db, ['reply-1', 'reply-2'],
-                         load_documents=True) in storage.fetch_ordered_annotations.call_args_list
+                         query_processor=mock.ANY) in storage.fetch_ordered_annotations.call_args_list
 
     def test_it_renders_replies(self, pyramid_request, search_lib):
         ann = models.Annotation(userid='luke')

--- a/tests/h/emails/reply_notification_test.py
+++ b/tests/h/emails/reply_notification_test.py
@@ -5,7 +5,6 @@ import datetime
 import mock
 import pytest
 
-from h.api.models import elastic
 from h.emails.reply_notification import generate
 from h.models import Annotation
 from h.models import Document, DocumentMeta
@@ -43,13 +42,9 @@ class TestGenerate(object):
     def test_falls_back_to_target_uri_for_document_title(self,
                                                          notification,
                                                          pyramid_request,
-                                                         storage_driver,
                                                          html_renderer,
                                                          text_renderer):
-        if storage_driver == 'elastic':
-            notification.document['title'] = []
-        else:
-            notification.document.meta[0].value = []
+        notification.document.meta[0].value = []
 
         generate(pyramid_request, notification)
 
@@ -118,42 +113,30 @@ class TestGenerate(object):
         return pyramid_config.testing_add_renderer('h:templates/emails/reply_notification.txt.jinja2')
 
     @pytest.fixture
-    def document(self, storage_driver):
-        title = 'My fascinating page'
-        if storage_driver == 'elastic':
-            return elastic.Document(title=[title])
-        else:
-            doc = Document()
-            doc.meta.append(DocumentMeta(type='title', value=[title]))
-            return doc
+    def document(self):
+        doc = Document()
+        doc.meta.append(DocumentMeta(type='title', value=['My fascinating page']))
+        return doc
 
     @pytest.fixture
-    def parent(self, storage_driver):
+    def parent(self):
         common = {
             'id': 'foo123',
             'created': datetime.datetime.utcnow(),
             'updated': datetime.datetime.utcnow(),
             'text': 'Foo is true',
         }
-        uri = 'http://example.org/'
-        if storage_driver == 'elastic':
-            return elastic.Annotation(uri=uri, **common)
-        else:
-            return Annotation(target_uri=uri, **common)
+        return Annotation(target_uri='http://example.org/', **common)
 
     @pytest.fixture
-    def reply(self, storage_driver):
+    def reply(self):
         common = {
             'id': 'bar456',
             'created': datetime.datetime.utcnow(),
             'updated': datetime.datetime.utcnow(),
             'text': 'No it is not!',
         }
-        uri = 'http://example.org/'
-        if storage_driver == 'elastic':
-            return elastic.Annotation(uri=uri, **common)
-        else:
-            return Annotation(target_uri=uri, **common)
+        return Annotation(target_uri='http://example.org/', **common)
 
     @pytest.fixture
     def notification(self, reply, reply_user, parent, parent_user, document):
@@ -170,10 +153,6 @@ class TestGenerate(object):
     @pytest.fixture
     def reply_user(self):
         return User(username='ron', email='ron@thesmiths.com')
-
-    @pytest.fixture(params=['elastic', 'postgres'])
-    def storage_driver(self, request):
-        return request.param
 
     @pytest.fixture
     def token_serializer(self, pyramid_config):

--- a/tests/h/emails/reply_notification_test.py
+++ b/tests/h/emails/reply_notification_test.py
@@ -113,9 +113,11 @@ class TestGenerate(object):
         return pyramid_config.testing_add_renderer('h:templates/emails/reply_notification.txt.jinja2')
 
     @pytest.fixture
-    def document(self):
+    def document(self, db_session):
         doc = Document()
-        doc.meta.append(DocumentMeta(type='title', value=['My fascinating page']))
+        doc.meta.append(DocumentMeta(type='title', value=['My fascinating page'], claimant='http://example.org'))
+        db_session.add(doc)
+        db_session.flush()
         return doc
 
     @pytest.fixture


### PR DESCRIPTION
In order to remove the last bit of legacy code we want to load the annotations from the database after going to Elasticsearch. #3461 introduced this change, but it turned out that for annotations on certain URIs with a lot of document data this was just too slow, it got reverted in 9af5b659106885fe2be533de347afa8d5bc5711f.

We then decided to look at the client code and only render the document data the client actually needs instead of returning everything we have stored. It turned out the client only relies on the `title` property and the `document.link` for getting a non-URN URI when needed, and both of these are only used in the stream.

~~This PR introduces a new property `target.locator` which is either the annotation URI, or when that one is a URN (e.g. PDF fingerprint `urn:x-pdf:...`), then the server tries to load a non URN URI from the document data and returns that one. Which means that whenever we want to link to the source of a document, `target.locator` will always include a linkable URI, unless we don't have one, in which case `target.locator` is missing.~~
In the case of PDFs, the `target.source` (or `uri`) will now always be the best URI we know, if it is a URN then we don't have any other information and shouldn't render a link. These changes were done in #3524.