### PR TITLE
Move pyramid_services initialisation into conftest.py

### DIFF
--- a/tests/h/admin/views/nipsa_test.py
+++ b/tests/h/admin/views/nipsa_test.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 from pyramid import httpexceptions
-from pyramid.request import apply_request_extensions
 import pytest
 
 from h.admin.views import nipsa as views
@@ -89,14 +88,9 @@ class FakeNipsaService(object):
 
 
 @pytest.fixture
-def nipsa_service(pyramid_config, pyramid_request):
+def nipsa_service(pyramid_config):
     service = FakeNipsaService()
-
-    pyramid_config.include('pyramid_services')
     pyramid_config.register_service(service, name='nipsa')
-
-    apply_request_extensions(pyramid_request)
-
     return service
 
 

--- a/tests/h/conftest.py
+++ b/tests/h/conftest.py
@@ -12,6 +12,7 @@ import mock
 import pytest
 
 from pyramid import testing
+from pyramid.request import apply_request_extensions
 
 from h import db
 from h import form
@@ -145,6 +146,10 @@ def pyramid_config(pyramid_settings, pyramid_request):
     """Pyramid configurator object."""
     with testing.testConfig(request=pyramid_request,
                             settings=pyramid_settings) as config:
+        # Include pyramid_services so it's easy to set up fake services in tests
+        config.include('pyramid_services')
+        apply_request_extensions(pyramid_request)
+
         yield config
 
 

--- a/tests/h/nipsa/subscribers_test.py
+++ b/tests/h/nipsa/subscribers_test.py
@@ -4,7 +4,6 @@ from collections import namedtuple
 
 import mock
 import pytest
-from pyramid.request import apply_request_extensions
 
 from h.nipsa import subscribers
 
@@ -31,13 +30,8 @@ def test_transform_annotation(ann, flagged, nipsa_service, pyramid_request):
 
 
 @pytest.fixture
-def nipsa_service(pyramid_config, pyramid_request):
+def nipsa_service(pyramid_config):
     service = mock.Mock(spec_set=['is_flagged'])
     service.is_flagged.return_value = False
-
-    pyramid_config.include('pyramid_services')
     pyramid_config.register_service(service, name='nipsa')
-
-    apply_request_extensions(pyramid_request)
-
     return service

--- a/tests/h/streamer/messages_test.py
+++ b/tests/h/streamer/messages_test.py
@@ -359,10 +359,7 @@ class TestHandleAnnotationEvent(object):
     def nipsa_service(self, pyramid_config):
         service = mock.Mock(spec_set=['is_flagged'])
         service.is_flagged.return_value = False
-
-        pyramid_config.include('pyramid_services')
         pyramid_config.register_service(service, name='nipsa')
-
         return service
 
 class TestHandleUserEvent(object):


### PR DESCRIPTION
To make it easier to register fake services in tests, this commit moves the inclusion and setup of the 'pyramid_services' module into conftest so it's available to all tests without further configuration.