### PR TITLE
Add a service to manage group creation and membership

### DIFF
--- a/h/groups/__init__.py
+++ b/h/groups/__init__.py
@@ -2,4 +2,6 @@
 
 
 def includeme(config):
+    config.register_service_factory('.services.groups_factory', name='groups')
+
     config.include('.views')

--- a/h/groups/services.py
+++ b/h/groups/services.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+
+from h.accounts import get_user
+from h.models import Group
+
+
+class GroupsService(object):
+
+    """A service for manipulating groups and group membership."""
+
+    def __init__(self, session, user_fetcher):
+        self.session = session
+        self.user_fetcher = user_fetcher
+
+    def create(self, name, userid):
+        """
+        Create a new group.
+
+        :param name: the human-readable name of the group
+        :param userid: the userid of the group creator
+
+        :returns: the created group
+        """
+        creator = self.user_fetcher(userid)
+        group = Group(name=name, creator=creator)
+        self.session.add(group)
+        self.session.flush()
+
+        return group
+
+    def member_join(self, group, userid):
+        """Add `userid` to the member list of `group`."""
+        user = self.user_fetcher(userid)
+
+        if user not in group.members:
+            group.members.append(user)
+
+    def member_leave(self, group, userid):
+        """Remove `userid` from the member list of `group`."""
+        user = self.user_fetcher(userid)
+
+        if user in group.members:
+            group.members.remove(user)
+
+
+def groups_factory(context, request):
+    """Return a GroupsService instance for the passed context and request."""
+    def user_fetcher(userid):
+        return get_user(userid, request)
+    return GroupsService(session=request.db, user_fetcher=user_fetcher)

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -177,8 +177,10 @@ class User(factory.Factory):
     class Meta(object):
         model = accounts_models.User
 
-    uid = factory.Sequence(lambda n: "test_user_{n}".format(n=n + 1))
-    username = factory.Sequence(lambda n: "test_user_{n}".format(n=n + 1))
-    email = factory.LazyAttribute(
-        lambda n: "{username}@test_users.com".format(username=n.username))
-    password = "pass"
+    username = factory.Faker('user_name')
+    email = factory.Faker('email')
+    password = factory.Faker('password')
+
+    @factory.lazy_attribute
+    def uid(self):
+        return self.username.replace('.', '').lower()

--- a/tests/h/groups/services_test.py
+++ b/tests/h/groups/services_test.py
@@ -1,0 +1,104 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import pytest
+
+from h.models import Group
+from h.groups.services import GroupsService
+from h.groups.services import groups_factory
+
+from ... import factories
+
+
+class TestGroupsService(object):
+    def test_create_returns_group(self, db_session, users):
+        svc = GroupsService(db_session, users.get)
+
+        group = svc.create('Anteater fans', 'cazimir')
+
+        assert isinstance(group, Group)
+
+    def test_create_sets_group_name(self, db_session, users):
+        svc = GroupsService(db_session, users.get)
+
+        group = svc.create('Anteater fans', 'cazimir')
+
+        assert group.name == 'Anteater fans'
+
+    def test_create_sets_group_creator(self, db_session, users):
+        svc = GroupsService(db_session, users.get)
+
+        group = svc.create('Anteater fans', 'cazimir')
+
+        assert group.creator == users['cazimir']
+
+    def test_create_adds_group_to_session(self, db_session, users):
+        svc = GroupsService(db_session, users.get)
+
+        group = svc.create('Anteater fans', 'cazimir')
+
+        assert group in db_session
+
+    def test_create_sets_group_ids(self, db_session, users):
+        svc = GroupsService(db_session, users.get)
+
+        group = svc.create('Anteater fans', 'cazimir')
+
+        assert group.id
+        assert group.pubid
+
+    def test_member_join_adds_user_to_group(self, db_session, users):
+        svc = GroupsService(db_session, users.get)
+        group = Group(name='Donkey Trust', creator=users['cazimir'])
+
+        svc.member_join(group, 'theresa')
+
+        assert users['theresa'] in group.members
+
+    def test_member_join_is_idempotent(self, db_session, users):
+        svc = GroupsService(db_session, users.get)
+        group = Group(name='Donkey Trust', creator=users['cazimir'])
+
+        svc.member_join(group, 'theresa')
+        svc.member_join(group, 'theresa')
+
+        assert group.members.count(users['theresa']) == 1
+
+    def test_member_leave_removes_user_from_group(self, db_session, users):
+        svc = GroupsService(db_session, users.get)
+        group = Group(name='Theresa and her buddies', creator=users['theresa'])
+        group.members.append(users['cazimir'])
+
+        svc.member_leave(group, 'cazimir')
+
+        assert users['cazimir'] not in group.members
+
+    def test_member_leave_is_idempotent(self, db_session, users):
+        svc = GroupsService(db_session, users.get)
+        group = Group(name='Theresa and her buddies', creator=users['theresa'])
+        group.members.append(users['cazimir'])
+
+        svc.member_leave(group, 'cazimir')
+        svc.member_leave(group, 'cazimir')
+
+        assert users['cazimir'] not in group.members
+
+
+def test_groups_factory(patch, pyramid_request):
+    get_user = patch('h.groups.services.get_user')
+
+    svc = groups_factory(None, pyramid_request)
+    svc.user_fetcher('foo')
+
+    assert isinstance(svc, GroupsService)
+    assert svc.session == pyramid_request.db
+    get_user.assert_called_once_with('foo', pyramid_request)
+
+
+@pytest.fixture
+def users():
+    return {
+        'cazimir': factories.User(username='cazimir'),
+        'theresa': factories.User(username='theresa'),
+    }


### PR DESCRIPTION
In preparation for some substantial reorganisation of the groups views (which in turn is in preparation for changes which we'll be making to groups in the near future) this commit adds a GroupsService which hides some of the details of creating groups and managing their membership.

In this commit the service remains unused.