### PR TITLE
Rearrange groups views to take advantage of GroupsService

### DIFF
--- a/h/app.py
+++ b/h/app.py
@@ -134,7 +134,7 @@ def includeme(config):
     config.include('h.admin', route_prefix='/admin')
     config.include('h.badge')
     config.include('h.feeds')
-    config.include('h.groups')
+    config.include('h.groups', route_prefix='/groups')
     config.include('h.links')
     config.include('h.nipsa')
     config.include('h.notification')

--- a/h/groups/__init__.py
+++ b/h/groups/__init__.py
@@ -5,3 +5,20 @@ def includeme(config):
     config.register_service_factory('.services.groups_factory', name='groups')
 
     config.include('.views')
+
+    config.add_route('group_create', '/new')
+
+    config.add_route('group_leave',
+                     '/{pubid}/leave',
+                     factory='h.groups.models:GroupFactory',
+                     traverse='/{pubid}')
+
+    # Match "/<pubid>/": we redirect to the version with the slug.
+    config.add_route('group_read',
+                     '/{pubid}/{slug:[^/]*}',
+                     factory='h.groups.models:GroupFactory',
+                     traverse='/{pubid}')
+    config.add_route('group_read_noslug',
+                     '/{pubid}',
+                     factory='h.groups.models:GroupFactory',
+                     traverse='/{pubid}')

--- a/h/groups/models.py
+++ b/h/groups/models.py
@@ -100,11 +100,6 @@ class Group(Base, mixins.Timestamps):
         return '<Group: %s>' % self.slug
 
     @classmethod
-    def get_by_pubid(cls, session, pubid):
-        """Return the group with the given pubid, or None."""
-        return session.query(cls).filter(cls.pubid == pubid).first()
-
-    @classmethod
     def created_by(cls, session, user):
         """Return a query object filtering groups by creator."""
         return session.query(cls).filter(Group.creator == user)

--- a/h/groups/models.py
+++ b/h/groups/models.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import sqlalchemy as sa
+from pyramid import security
 from sqlalchemy.orm import exc
 import slugify
 
@@ -12,6 +13,17 @@ from h import pubid
 
 GROUP_NAME_MIN_LENGTH = 4
 GROUP_NAME_MAX_LENGTH = 25
+
+
+class GroupFactory(object):
+    def __init__(self, request):
+        self.request = request
+
+    def __getitem__(self, pubid):
+        try:
+            return self.request.db.query(Group).filter_by(pubid=pubid).one()
+        except exc.NoResultFound:
+            raise KeyError()
 
 
 class Group(Base, mixins.Timestamps):
@@ -56,9 +68,6 @@ class Group(Base, mixins.Timestamps):
         """A version of this group's name suitable for use in a URL."""
         return slugify.slugify(self.name)
 
-    def __repr__(self):
-        return '<Group: %s>' % self.slug
-
     def documents(self, limit=25):
         """
         Return this group's most recently annotated documents.
@@ -80,6 +89,15 @@ class Group(Base, mixins.Timestamps):
                     break
 
         return documents
+
+    def __acl__(self):
+        return [
+            (security.Allow, 'group:{}'.format(self.pubid), 'read'),
+            security.DENY_ALL,
+        ]
+
+    def __repr__(self):
+        return '<Group: %s>' % self.slug
 
     @classmethod
     def get_by_pubid(cls, session, pubid):

--- a/h/groups/services.py
+++ b/h/groups/services.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
 
+from functools import partial
+
+from h import session
 from h.accounts import get_user
 from h.models import Group
 
@@ -8,9 +11,17 @@ class GroupsService(object):
 
     """A service for manipulating groups and group membership."""
 
-    def __init__(self, session, user_fetcher):
+    def __init__(self, session, user_fetcher, publish=None):
+        """
+        Create a new groups service.
+
+        :param session: the SQLAlchemy session object
+        :param user_fetcher: a callable for fetching users by userid
+        :param publish: a callable for publishing events
+        """
         self.session = session
         self.user_fetcher = user_fetcher
+        self.publish = publish
 
     def create(self, name, userid):
         """
@@ -26,25 +37,49 @@ class GroupsService(object):
         self.session.add(group)
         self.session.flush()
 
+        if self.publish:
+            self.publish('group-join', group.pubid, userid)
+
         return group
 
     def member_join(self, group, userid):
         """Add `userid` to the member list of `group`."""
         user = self.user_fetcher(userid)
 
-        if user not in group.members:
-            group.members.append(user)
+        if user in group.members:
+            return
+
+        group.members.append(user)
+
+        if self.publish:
+            self.publish('group-join', group.pubid, userid)
 
     def member_leave(self, group, userid):
         """Remove `userid` from the member list of `group`."""
         user = self.user_fetcher(userid)
 
-        if user in group.members:
-            group.members.remove(user)
+        if user not in group.members:
+            return
+
+        group.members.remove(user)
+
+        if self.publish:
+            self.publish('group-leave', group.pubid, userid)
 
 
 def groups_factory(context, request):
     """Return a GroupsService instance for the passed context and request."""
     def user_fetcher(userid):
         return get_user(userid, request)
-    return GroupsService(session=request.db, user_fetcher=user_fetcher)
+    return GroupsService(session=request.db,
+                         user_fetcher=user_fetcher,
+                         publish=partial(_publish, request))
+
+
+def _publish(request, event_type, groupid, userid):
+    request.realtime.publish_user({
+        'type': event_type,
+        'session_model': session.model(request),
+        'userid': userid,
+        'group': groupid,
+    })

--- a/h/templates/groups/join.html.jinja2
+++ b/h/templates/groups/join.html.jinja2
@@ -14,7 +14,7 @@
       <img class="group-form__invite-icon" src="/assets/images/icons/group-invite.svg">
       <div class="group-form__name-label">You have been invited to annotate with the group</div>
       <div class="group-form__name-input">{{ group.name }}</div>
-      {% if is_logged_in %}
+      {% if request.authenticated_userid %}
         <form method="POST">
           <button class="primary-action-btn" type="submit">
             Join {{ group.name }}

--- a/h/templates/groups/share.html.jinja2
+++ b/h/templates/groups/share.html.jinja2
@@ -8,6 +8,8 @@
 {% endfor %}
 {% endblock %}
 
+{% set group_url = request.route_url('group_read', pubid=group.pubid, slug=group.slug) %}
+
 {% block content %}
   <div class="content content--narrow">
     <div class="group-form is-member-of-group">

--- a/tests/h/groups/services_test.py
+++ b/tests/h/groups/services_test.py
@@ -2,6 +2,7 @@
 
 from __future__ import unicode_literals
 
+import mock
 import pytest
 
 from h.models import Group
@@ -48,6 +49,14 @@ class TestGroupsService(object):
         assert group.id
         assert group.pubid
 
+    def test_create_publishes_join_event(self, db_session, users):
+        publish = mock.Mock(spec_set=[])
+        svc = GroupsService(db_session, users.get, publish=publish)
+
+        group = svc.create('Dishwasher disassemblers', 'theresa')
+
+        publish.assert_called_once_with('group-join', group.pubid, 'theresa')
+
     def test_member_join_adds_user_to_group(self, db_session, users):
         svc = GroupsService(db_session, users.get)
         group = Group(name='Donkey Trust', creator=users['cazimir'])
@@ -64,6 +73,16 @@ class TestGroupsService(object):
         svc.member_join(group, 'theresa')
 
         assert group.members.count(users['theresa']) == 1
+
+    def test_member_join_publishes_join_event(self, db_session, users):
+        publish = mock.Mock(spec_set=[])
+        svc = GroupsService(db_session, users.get, publish=publish)
+        group = Group(name='Donkey Trust', creator=users['cazimir'])
+        group.pubid = 'abc123'
+
+        svc.member_join(group, 'theresa')
+
+        publish.assert_called_once_with('group-join', 'abc123', 'theresa')
 
     def test_member_leave_removes_user_from_group(self, db_session, users):
         svc = GroupsService(db_session, users.get)
@@ -84,16 +103,51 @@ class TestGroupsService(object):
 
         assert users['cazimir'] not in group.members
 
+    def test_member_leave_publishes_leave_event(self, db_session, users):
+        publish = mock.Mock(spec_set=[])
+        svc = GroupsService(db_session, users.get, publish=publish)
+        group = Group(name='Donkey Trust', creator=users['theresa'])
+        group.members.append(users['cazimir'])
+        group.pubid = 'abc123'
 
-def test_groups_factory(patch, pyramid_request):
-    get_user = patch('h.groups.services.get_user')
+        svc.member_leave(group, 'cazimir')
 
-    svc = groups_factory(None, pyramid_request)
-    svc.user_fetcher('foo')
+        publish.assert_called_once_with('group-leave', 'abc123', 'cazimir')
 
-    assert isinstance(svc, GroupsService)
-    assert svc.session == pyramid_request.db
-    get_user.assert_called_once_with('foo', pyramid_request)
+
+class TestGroupsFactory(object):
+    def test_returns_groups_service(self, pyramid_request):
+        svc = groups_factory(None, pyramid_request)
+
+        assert isinstance(svc, GroupsService)
+
+    def test_provides_request_db_as_session(self, pyramid_request):
+        svc = groups_factory(None, pyramid_request)
+
+        assert svc.session == pyramid_request.db
+
+    def test_wraps_get_user_as_user_fetcher(self, patch, pyramid_request):
+        get_user = patch('h.groups.services.get_user')
+        svc = groups_factory(None, pyramid_request)
+
+        svc.user_fetcher('foo')
+
+        get_user.assert_called_once_with('foo', pyramid_request)
+
+    def test_provides_realtime_publisher_as_publish(self, patch, pyramid_request):
+        pyramid_request.realtime = mock.Mock(spec_set=['publish_user'])
+        session = patch('h.groups.services.session')
+        svc = groups_factory(None, pyramid_request)
+
+        svc.publish('group-join', 'abc123', 'theresa')
+
+        session.model.assert_called_once_with(pyramid_request)
+        pyramid_request.realtime.publish_user.assert_called_once_with({
+            'type': 'group-join',
+            'session_model': session.model.return_value,
+            'userid': 'theresa',
+            'group': 'abc123',
+        })
 
 
 @pytest.fixture

--- a/tests/h/groups/views_test.py
+++ b/tests/h/groups/views_test.py
@@ -1,594 +1,219 @@
 # -*- coding: utf-8 -*-
-import itertools
 
 import deform
 import mock
 import pytest
-from pyramid import httpexceptions
+from pyramid.httpexceptions import (HTTPMovedPermanently, HTTPNoContent,
+                                    HTTPSeeOther)
 
 from h.groups import views
 
 
-_SENTINEL = object()
+@pytest.mark.usefixtures('groups_service', 'routes')
+class TestGroupCreateController(object):
+
+    def test_get_renders_form(self, pyramid_request):
+        controller = views.GroupCreateController(pyramid_request)
+        controller.form = form_validating_to({})
+
+        result = controller.get()
+
+        assert result == {'form': 'valid form'}
+
+    def test_post_creates_group_when_form_valid(self,
+                                                groups_service,
+                                                pyramid_config,
+                                                pyramid_request):
+        pyramid_config.testing_securitypolicy('ariadna')
+        controller = views.GroupCreateController(pyramid_request)
+        controller.form = form_validating_to({'name': 'Kangaroo Tamers'})
+
+        controller.post()
+
+        assert ('Kangaroo Tamers', 'ariadna') in groups_service.created
+
+    def test_post_redirects_to_group_when_form_valid(self,
+                                                     pyramid_config,
+                                                     pyramid_request):
+        pyramid_config.testing_securitypolicy('ariadna')
+        controller = views.GroupCreateController(pyramid_request)
+        controller.form = form_validating_to({'name': 'Kangaroo Tamers'})
+
+        result = controller.post()
+
+        assert isinstance(result, HTTPSeeOther)
+        assert result.location == '/g/abc123/fake-group'
 
 
-def _mock_request(feature=None, settings=None, params=None,
-                  authenticated_userid=_SENTINEL, route_url=None, **kwargs):
-    """Return a mock Pyramid request object."""
-    params = params or {"foo": "bar"}
-    if authenticated_userid is _SENTINEL:
-        authenticated_userid = "acct:fred@hypothes.is"
-    return mock.Mock(
-        feature=feature or (lambda feature: True),
-        registry=mock.Mock(settings=settings or {}),
-        params=params, POST=params,
-        authenticated_userid=authenticated_userid,
-        route_url=route_url or mock.Mock(return_value="test-read-url"),
-        **kwargs)
+    def test_post_rerenders_form_when_form_invalid(self,
+                                                   pyramid_config,
+                                                   pyramid_request):
+        pyramid_config.testing_securitypolicy('ariadna')
+        controller = views.GroupCreateController(pyramid_request)
+        controller.form = invalid_form()
+
+        result = controller.post()
+
+        assert result == {'form': 'invalid form'}
 
 
-def _matchdict():
-    """Return a matchdict like the one the group_read route receives."""
-    return {"pubid": mock.sentinel.pubid, "slug": mock.sentinel.slug}
+@pytest.mark.usefixtures('groups_service', 'routes')
+class TestGroupRead(object):
+    def test_redirects_if_slug_incorrect(self, pyramid_request):
+        group = FakeGroup('abc123', 'some-slug')
+        pyramid_request.matchdict['slug'] = 'another-slug'
+
+        with pytest.raises(HTTPMovedPermanently) as exc:
+            views.read(group, pyramid_request)
+
+        assert exc.value.location == '/g/abc123/some-slug'
+
+    def test_returns_template_context(self, patch, pyramid_request):
+        group = FakeGroup('abc123', 'some-slug')
+        group.documents = lambda: ['d1', 'd2']
+        link = patch('h.presenters.DocumentHTMLPresenter.link',
+                     autospec=None,
+                     new_callable=mock.PropertyMock)
+        link.side_effect = ['link1', 'link2']
+        pyramid_request.matchdict['slug'] = 'some-slug'
+
+        result = views.read(group, pyramid_request)
+
+        assert result == {
+            'group': group,
+            'document_links': ['link1', 'link2'],
+        }
+
+    def test_renders_join_template_if_not_member(self,
+                                                 pyramid_config,
+                                                 pyramid_request):
+        group = FakeGroup('abc123', 'some-slug')
+        pyramid_config.testing_securitypolicy('bohus', permissive=False)
+        pyramid_request.matchdict['slug'] = 'some-slug'
+
+        result = views.read(group, pyramid_request)
+
+        assert 'join.html' in pyramid_request.override_renderer
+        assert result == {'group': group}
 
 
-# The fixtures required to mock all of create_form()'s dependencies.
-create_form_fixtures = pytest.mark.usefixtures('GroupSchema', 'Form')
+@pytest.mark.usefixtures('routes')
+class TestGroupReadUnauthenticated(object):
+    def test_redirects_if_slug_incorrect(self, pyramid_request):
+        group = FakeGroup('abc123', 'some-slug')
+        pyramid_request.matchdict['slug'] = 'another-slug'
+
+        with pytest.raises(HTTPMovedPermanently) as exc:
+            views.read_unauthenticated(group, pyramid_request)
+
+        assert exc.value.location == '/g/abc123/some-slug'
+
+    def test_returns_template_context(self, pyramid_request):
+        group = FakeGroup('abc123', 'some-slug')
+        pyramid_request.matchdict['slug'] = 'some-slug'
+
+        result = views.read_unauthenticated(group, pyramid_request)
+
+        assert result == {'group': group}
 
 
-@create_form_fixtures
-def test_create_form_creates_form_with_GroupSchema(GroupSchema, Form):
-    test_schema = mock.Mock()
-    GroupSchema.return_value = mock.Mock(
-        bind=mock.Mock(return_value=test_schema))
+@pytest.mark.usefixtures('routes')
+def test_read_noslug_redirects(pyramid_request):
+    group = FakeGroup('abc123', 'some-slug')
 
-    views.create_form(request=_mock_request())
+    with pytest.raises(HTTPMovedPermanently) as exc:
+        views.read_noslug(group, pyramid_request)
 
-    assert Form.call_args[0][0] == test_schema
-
-
-@create_form_fixtures
-def test_create_form_returns_form(Form):
-    test_form = mock.Mock()
-    Form.return_value = test_form
-
-    result = views.create_form(request=_mock_request())
-
-    assert result["form"] == test_form.render.return_value
+    assert exc.value.location == '/g/abc123/some-slug'
 
 
-# The fixtures required to mock all of create()'s dependencies.
-create_fixtures = pytest.mark.usefixtures('GroupSchema', 'Form', 'Group',
-                                          'session_model')
+@pytest.mark.usefixtures('groups_service', 'routes')
+class TestGroupJoin(object):
+    def test_joins_group(self,
+                         groups_service,
+                         pyramid_config,
+                         pyramid_request):
+        group = FakeGroup('abc123', 'some-slug')
+        pyramid_config.testing_securitypolicy('gentiana')
+
+        views.join(group, pyramid_request)
+
+        assert (group, 'gentiana') in groups_service.joined
+
+    def test_redirects_to_group_page(self, pyramid_request):
+        group = FakeGroup('abc123', 'some-slug')
+
+        result = views.join(group, pyramid_request)
+
+        assert isinstance(result, HTTPSeeOther)
+        assert result.location == '/g/abc123/some-slug'
 
 
-@create_fixtures
-def test_create_inits_form_with_schema(GroupSchema, Form):
-    schema = mock.Mock()
-    GroupSchema.return_value = mock.Mock(bind=mock.Mock(return_value=schema))
+@pytest.mark.usefixtures('groups_service', 'routes')
+class TestGroupLeave(object):
+    def test_leaves_group(self,
+                          groups_service,
+                          pyramid_config,
+                          pyramid_request):
+        group = FakeGroup('abc123', 'some-slug')
+        pyramid_config.testing_securitypolicy('marcela')
 
-    views.create(request=_mock_request())
+        views.leave(group, pyramid_request)
 
-    assert Form.call_args[0][0] == schema
+        assert (group, 'marcela') in groups_service.left
 
+    def test_returns_nocontent(self, pyramid_request):
+        group = FakeGroup('abc123', 'some-slug')
 
-@create_fixtures
-def test_create_validates_form(Form):
-    Form.return_value = form = mock.Mock()
-    form.validate.return_value = {"name": "new group"}
-    request = _mock_request()
+        result = views.leave(group, pyramid_request)
 
-    views.create(request)
-
-    form.validate.assert_called_once_with(request.params.items())
+        assert isinstance(result, HTTPNoContent)
 
 
-@create_fixtures
-def test_create_rerenders_form_on_validation_failure(Form):
-    Form.return_value = form = mock.Mock()
+class FakeGroup(object):
+    def __init__(self, pubid, slug):
+        self.pubid = pubid
+        self.slug = slug
+
+class FakeGroupsService(object):
+    def __init__(self):
+        self.created = []
+        self.joined = []
+        self.left = []
+
+    def create(self, name, userid):
+        self.created.append((name, userid))
+        return FakeGroup('abc123', 'fake-group')
+
+    def member_join(self, group, userid):
+        self.joined.append((group, userid))
+
+    def member_leave(self, group, userid):
+        self.left.append((group, userid))
+
+
+
+def form_validating_to(appstruct):
+    form = mock.Mock()
+    form.validate.return_value = appstruct
+    form.render.return_value = 'valid form'
+    return form
+
+
+def invalid_form():
+    form = mock.Mock()
     form.validate.side_effect = deform.ValidationFailure(None, None, None)
-
-    result = views.create(_mock_request())
-
-    assert result['form'] == form.render.return_value
-
-
-@create_fixtures
-def test_create_gets_user_with_authenticated_id(Form):
-    """It uses the "name" from the validated data to create a new group."""
-    Form.return_value = mock.Mock(validate=lambda data: {"name": "test-group"})
-    request = _mock_request()
-    type(request).authenticated_user = user_property = mock.PropertyMock()
-
-    views.create(request)
-
-    user_property.assert_called_once_with()
-
-
-@create_fixtures
-def test_create_uses_name_from_validated_data(Form, Group):
-    """It uses the "name" from the validated data to create a new group."""
-    Form.return_value = mock.Mock(validate=lambda data: {"name": "test-group"})
-    request = _mock_request()
-    request.authenticated_user = user = mock.Mock()
-
-    views.create(request)
-
-    Group.assert_called_once_with(name="test-group", creator=user)
-
-
-@create_fixtures
-def test_create_adds_group_to_db(Group):
-    """It should add the new group to the database session."""
-    group = mock.Mock(id=6)
-    Group.return_value = group
-    request = _mock_request()
-
-    views.create(request)
-
-    request.db.add.assert_called_once_with(group)
-
-
-@create_fixtures
-def test_create_redirects_to_group_read_page(Group):
-    """After successfully creating a new group it should redirect."""
-    group = mock.Mock(id='test-id', slug='test-slug')
-    Group.return_value = group
-    request = _mock_request()
-
-    result = views.create(request)
-
-    assert isinstance(result, httpexceptions.HTTPRedirection)
-
-
-@create_fixtures
-def test_create_with_non_ascii_name():
-    views.create(_mock_request(params={"name": u"☆ ßüper Gröup ☆"}))
-
-
-@create_fixtures
-def test_create_publishes_join_event(Group, session_model):
-    group = mock.Mock(pubid=mock.sentinel.pubid)
-    Group.return_value = group
-    request = _mock_request()
-
-    views.create(request)
-
-    request.realtime.publish_user.assert_called_once_with({
-        'type': 'group-join',
-        'userid': request.authenticated_userid,
-        'group': group.pubid,
-        'session_model': session_model(),
-    })
-
-
-# The fixtures required to mock all of read()'s dependencies.
-read_fixtures = pytest.mark.usefixtures('Group',
-                                        'renderers',
-                                        'routes',
-                                        'presenters')
-
-
-@read_fixtures
-def test_read_gets_group_by_pubid(Group):
-    request = _mock_request(matchdict={'pubid': 'abc', 'slug': 'snail'})
-    views.read(request)
-
-    Group.get_by_pubid.assert_called_once_with(request.db, 'abc')
-
-
-@read_fixtures
-def test_read_404s_when_group_does_not_exist(Group):
-    Group.get_by_pubid.return_value = None
-
-    with pytest.raises(httpexceptions.HTTPNotFound):
-        views.read(_mock_request(matchdict=_matchdict()))
-
-
-@read_fixtures
-def test_read_without_slug_redirects(Group):
-    """/groups/<pubid> should redirect to /groups/<pubid>/<slug>."""
-    group = Group.get_by_pubid.return_value = mock.Mock()
-    matchdict = {"pubid": "1"}  # No slug.
-    request = _mock_request(matchdict=matchdict)
-
-    result = views.read(request)
-
-    assert isinstance(result, httpexceptions.HTTPRedirection)
-
-
-@read_fixtures
-def test_read_with_wrong_slug_redirects(Group):
-    """/groups/<pubid>/<wrong> should redirect to /groups/<pubid>/<slug>."""
-    group = Group.get_by_pubid.return_value = mock.Mock(slug="my-group")
-    matchdict = {"pubid": "1", "slug": "my-gro"}  # Wrong slug.
-    request = _mock_request(matchdict=matchdict)
-
-    result = views.read(request)
-
-    assert isinstance(result, httpexceptions.HTTPRedirection)
-
-
-@read_fixtures
-def test_read_if_not_logged_in_renders_share_group_page(Group, renderers):
-    """If not logged in should render the "Login to join this group" page."""
-    Group.get_by_pubid.return_value = mock.Mock(slug=mock.sentinel.slug)
-    request = _mock_request(authenticated_userid=None, matchdict=_matchdict())
-
-    views.read(request)
-
-    assert renderers.render_to_response.call_args[1]['renderer_name'] == (
-        'h:templates/groups/join.html.jinja2')
-
-
-@read_fixtures
-def test_read_if_not_logged_in_passes_group(Group, renderers):
-    """It should pass the group to the template."""
-    g = Group.get_by_pubid.return_value = mock.Mock(slug=mock.sentinel.slug)
-    request = _mock_request(authenticated_userid=None, matchdict=_matchdict())
-
-    views.read(request)
-
-    assert renderers.render_to_response.call_args[1]['value']['group'] == g
-
-
-@read_fixtures
-def test_read_if_not_logged_in_returns_response(
-        Group, renderers):
-    """It should return the response from render_to_response()."""
-    Group.get_by_pubid.return_value = mock.Mock(slug=mock.sentinel.slug)
-    request = _mock_request(authenticated_userid=None, matchdict=_matchdict())
-    renderers.render_to_response.return_value = mock.sentinel.response
-
-    response = views.read(request)
-
-    assert response == mock.sentinel.response
-
-
-@read_fixtures
-def test_read_if_not_a_member_renders_template(Group, renderers):
-    """It should render the "Join this group" template."""
-    request = _mock_request(matchdict=_matchdict())
-    Group.get_by_pubid.return_value = mock.Mock(slug=mock.sentinel.slug)
-    user = request.authenticated_user = mock.Mock()
-    user.groups = []  # The user isn't a member of the group.
-
-    views.read(request)
-
-    assert renderers.render_to_response.call_args[1]['renderer_name'] == (
-        'h:templates/groups/join.html.jinja2')
-
-
-@read_fixtures
-def test_read_if_not_a_member_passes_group_to_template(Group, renderers):
-    """It should get the join URL and pass it to the template."""
-    request = _mock_request(matchdict=_matchdict())
-    g = Group.get_by_pubid.return_value = mock.Mock(slug=mock.sentinel.slug)
-    user = request.authenticated_user = mock.Mock()
-    user.groups = []  # The user isn't a member of the group.
-
-    views.read(request)
-
-    assert renderers.render_to_response.call_args[1]['value']['group'] == g
-
-
-@read_fixtures
-def test_read_if_not_a_member_passes_join_url_to_template(Group, renderers):
-    """It should get the join URL and pass it to the template."""
-    request = _mock_request(matchdict=_matchdict())
-    request.route_url.return_value = mock.sentinel.join_url
-    Group.get_by_pubid.return_value = mock.Mock(slug=mock.sentinel.slug)
-    user = request.authenticated_user = mock.Mock()
-    user.groups = []  # The user isn't a member of the group.
-
-    views.read(request)
-
-    assert renderers.render_to_response.call_args[1]['value']['join_url'] == (
-        mock.sentinel.join_url)
-
-
-@read_fixtures
-def test_read_if_not_a_member_returns_response(Group, renderers):
-    """It should return the response from render_to_response()."""
-    request = _mock_request(matchdict=_matchdict())
-    Group.get_by_pubid.return_value = mock.Mock(slug=mock.sentinel.slug)
-    user = request.authenticated_user = mock.Mock()
-    user.groups = []  # The user isn't a member of the group.
-    renderers.render_to_response.return_value = mock.sentinel.response
-
-    assert views.read(request) == mock.sentinel.response
-
-
-@read_fixtures
-def test_read_if_already_a_member_gets_groups_documents(Group,
-                                                        share_group_request):
-    views.read(share_group_request)
-
-    Group.get_by_pubid.return_value.documents.assert_called_once_with()
-
-
-@read_fixtures
-def test_read_if_already_a_member_presents_documents(Group,
-                                                     share_group_request,
-                                                     presenters):
-    """It should call DocumentHTMLPresenter with each annotation."""
-
-    document_1 = mock.Mock()
-    document_2 = mock.Mock()
-    document_3 = mock.Mock()
-    Group.get_by_pubid.return_value.documents.return_value = [
-        document_1, document_2, document_3]
-
-    views.read(share_group_request)
-
-    presenters.DocumentHTMLPresenter.assert_has_calls(
-        [mock.call(document_1), mock.call(document_2), mock.call(document_3)],
-        any_order=True
-    )
-
-
-@read_fixtures
-def test_read_if_already_a_member_renders_template(share_group_request,
-                                                   renderers):
-    """It should render the "Share this group" template."""
-    views.read(share_group_request)
-
-    assert renderers.render_to_response.call_args[1]['renderer_name'] == (
-        'h:templates/groups/share.html.jinja2')
-
-
-@read_fixtures
-def test_read_if_already_a_member_passes_group_to_template(share_group_request,
-                                                           Group,
-                                                           renderers):
-    """It passes the group to the template."""
-    views.read(share_group_request)
-
-    assert renderers.render_to_response.call_args[1]['value']['group'] == (
-        Group.get_by_pubid.return_value)
-
-
-@read_fixtures
-def test_read_if_already_a_member_gets_group_url(Group, share_group_request):
-    share_group_request.route_url = mock.Mock()
-
-    views.read(share_group_request)
-
-    share_group_request.route_url.assert_called_once_with(
-        'group_read',
-        pubid=Group.get_by_pubid.return_value.pubid,
-        slug=Group.get_by_pubid.return_value.slug)
-
-
-@read_fixtures
-def test_read_if_already_a_member_passes_group_url_to_template(
-        share_group_request,
-        renderers):
-    share_group_request.route_url = mock.Mock()
-
-    views.read(share_group_request)
-
-    assert renderers.render_to_response.call_args[1]['value']['group_url'] == (
-        share_group_request.route_url.return_value)
-
-
-@read_fixtures
-def test_read_if_already_a_member_passes_document_links_to_template(
-        Group,
-        share_group_request,
-        presenters,
-        renderers):
-    """It should pass the document links to the template."""
-    document_1 = mock.Mock()
-    document_2 = mock.Mock()
-    document_3 = mock.Mock()
-    Group.get_by_pubid.return_value.documents.return_value = [
-        document_1, document_2, document_3]
-
-    views.read(share_group_request)
-
-    assert renderers.render_to_response.call_args[1]['value']['document_links'] == [
-        'document_link_1', 'document_link_2', 'document_link_3']
-
-
-@read_fixtures
-def test_read_if_already_a_member_when_group_has_no_annotated_documents(
-        Group,
-        share_group_request,
-        presenters,
-        renderers):
-    Group.get_by_pubid.return_value.documents.return_value = []
-
-    views.read(share_group_request)
-
-    assert not presenters.DocumentHTMLPresenter.called
-    assert renderers.render_to_response.call_args[1]['value']['document_links'] == []
-
-
-@read_fixtures
-def test_read_if_already_a_member_returns_response(share_group_request,
-                                                   renderers):
-    """It should return the response from render_to_response()."""
-    renderers.render_to_response.return_value = mock.sentinel.response
-
-    assert views.read(share_group_request) == mock.sentinel.response
-
-
-# The fixtures required to mock all of join()'s dependencies.
-join_fixtures = pytest.mark.usefixtures('Group', 'session_model')
-
-
-@join_fixtures
-def test_join_gets_group_by_pubid(Group):
-    request = _mock_request(matchdict={'pubid': 'twibble', 'slug': 'snail'})
-    views.join(request)
-
-    Group.get_by_pubid.assert_called_once_with(request.db, "twibble")
-
-
-@join_fixtures
-def test_join_404s_if_group_not_found(Group):
-    Group.get_by_pubid.return_value = None
-
-    with pytest.raises(httpexceptions.HTTPNotFound):
-        views.join(_mock_request(matchdict=_matchdict()))
-
-
-@join_fixtures
-def test_join_gets_user():
-    request = _mock_request(matchdict=_matchdict())
-    type(request).authenticated_user = user_property = mock.PropertyMock()
-
-    views.join(request)
-
-    user_property.assert_called_once_with()
-
-
-@join_fixtures
-def test_join_adds_user_to_group_members(Group):
-    Group.get_by_pubid.return_value = group = mock.Mock()
-    request = _mock_request(
-        matchdict=_matchdict(), authenticated_user=mock.sentinel.user)
-
-    views.join(request)
-
-    group.members.append.assert_called_once_with(mock.sentinel.user)
-
-
-@join_fixtures
-def test_join_redirects_to_group_page(Group):
-    slug = "test-slug"
-    group = Group.get_by_pubid.return_value = mock.Mock(slug=slug)
-    request = _mock_request(matchdict=_matchdict())
-
-    result = views.join(request)
-
-    assert isinstance(result, httpexceptions.HTTPRedirection)
-
-
-@join_fixtures
-def test_join_publishes_join_event(Group, session_model):
-    group = mock.Mock(pubid = mock.sentinel.pubid)
-    Group.get_by_pubid.return_value = group
-    request = _mock_request(matchdict=_matchdict())
-
-    views.join(request)
-
-    request.realtime.publish_user.assert_called_once_with({
-        'type': 'group-join',
-        'userid': request.authenticated_userid,
-        'group': mock.sentinel.pubid,
-        'session_model': session_model(),
-    })
-
-
-leave_fixtures = pytest.mark.usefixtures('Group', 'session_model')
-
-
-@leave_fixtures
-def test_leave_removes_user_from_group_members(Group):
-    user = mock.sentinel.user
-    group = mock.Mock()
-    group.members = [user]
-    Group.get_by_pubid.return_value = group
-    request = _mock_request(
-        matchdict=_matchdict(), authenticated_user=user)
-
-    result = views.leave(request)
-
-    assert(group.members == [])
-
-
-@leave_fixtures
-def test_leave_returns_not_found_if_user_not_in_group(Group):
-    group = mock.Mock(members=[])
-    Group.get_by_pubid.return_value = group
-    request = _mock_request(matchdict=_matchdict(), user=mock.sentinel.user)
-
-    with pytest.raises(httpexceptions.HTTPNotFound):
-        result = views.leave(request)
-
-
-@leave_fixtures
-def test_leave_publishes_leave_event(Group, session_model):
-    group = mock.Mock(pubid=mock.sentinel.pubid,
-                      members=[mock.sentinel.user])
-    Group.get_by_pubid.return_value = group
-    request = _mock_request(
-        matchdict=_matchdict(), authenticated_user=mock.sentinel.user)
-
-    views.leave(request)
-
-    request.realtime.publish_user.assert_called_once_with({
-        'type': 'group-leave',
-        'userid': request.authenticated_userid,
-        'group': mock.sentinel.pubid,
-        'session_model': session_model(),
-    })
+    form.render.return_value = 'invalid form'
+    return form
 
 
 @pytest.fixture
-def share_group_request(Group, pyramid_config, pyramid_request, pubid=u'__world__'):
-    """
-    Return a logged-in, already-member request for the group read page.
-
-    The user is logged-in and is a member of the group.
-
-    """
-    pyramid_request.matchdict.update({'pubid': pubid, 'slug': 'slug'})
-
-    # The user is logged-in.
-    pyramid_config.testing_securitypolicy('userid')
-    pyramid_request.authenticated_user = mock.Mock()
-
-    # The user is a member of the group.
-    pyramid_request.authenticated_user.groups = [Group.get_by_pubid.return_value]
-
-    return pyramid_request
-
-
-@pytest.fixture
-def Form(patch):
-    return patch('h.groups.views.deform.Form')
-
-
-@pytest.fixture
-def GroupSchema(patch):
-    return patch('h.groups.views.schemas.GroupSchema')
-
-
-@pytest.fixture
-def Group(patch):
-    Group = patch('h.groups.views.models.Group')
-    Group.get_by_pubid.return_value = mock.Mock(slug='slug', pubid=u'xyz123')
-    Group.get_by_pubid.return_value.documents.return_value = []
-    return Group
-
-
-@pytest.fixture
-def session_model(patch):
-    return patch('h.session.model', autospec=False)
-
-
-@pytest.fixture
-def renderers(patch):
-    return patch('h.groups.views.renderers')
+def groups_service(pyramid_config):
+    service = FakeGroupsService()
+    pyramid_config.register_service(service, name='groups')
+    return service
 
 
 @pytest.fixture
 def routes(pyramid_config):
-    pyramid_config.add_route('group_read', '/groups/{pubid}/{slug:[^/]*}')
-
-
-@pytest.fixture
-def presenters(patch):
-    presenters = patch('h.groups.views.presenters')
-
-    # The first call to DocumentHTMLPresenter() returns
-    # mock.Mock(link='document_link_1'), the second returns
-    # mock.Mock(link='document_link_2'), and so on.
-    presenters.DocumentHTMLPresenter.side_effect = itertools.imap(
-        lambda i: mock.Mock(link="document_link_" + str(i)),
-        itertools.count(start=1))
-
-    return presenters
+    pyramid_config.add_route('group_read', '/g/{pubid}/{slug}')


### PR DESCRIPTION
Now that the business logic associated with administering groups is mostly encapsulated by the GroupsService (see #3499), we can substantially simplify the views code. This is achieved by doing the following:

- Retrieval of the group for join/leave/read views moves into a Pyramid traversal operation, so that each view simply receives the group object directly, rather than having to fetch it itself.

- Rather than each view needing to do its own `if request.authenticated_userid is None:` check, we use the Pyramid `effective_principals` predicate in the view config. This also allows us to remove a conditional from the read view, by matching different view functions dependent on the user's authentication status.

- Relieve the views of the need to do an explicit membership check by adding an ACL to the `Group` model. Only members of the group have the "read" permission, so we can then use `request.has_permission("read")`.

This results in somewhat less mock-heavy test code for views.py, as well as improved test coverage. Hopefully it will also make it easier to add and modify functionality in future, too.

_**N.B.** This PR depends on #3498 and #3499, and will need rebasing after these merge._