### PR TITLE
Clean up the welcome page

### DIFF
--- a/h/views/__init__.py
+++ b/h/views/__init__.py
@@ -19,7 +19,8 @@ def includeme(config):
 
     # help
     config.add_route('help', '/docs/help')
-    config.add_route('onboarding', '/welcome')
+    config.add_route('onboarding', '/welcome/')
+    config.add_route('custom_onboarding', '/welcome/{welcome_slug}')
 
     # main
     config.add_route('annotation',

--- a/h/views/__init__.py
+++ b/h/views/__init__.py
@@ -20,7 +20,7 @@ def includeme(config):
     # help
     config.add_route('help', '/docs/help')
     config.add_route('onboarding', '/welcome/')
-    config.add_route('custom_onboarding', '/welcome/{welcome_slug}')
+    config.add_route('custom_onboarding', '/welcome/{slug}')
 
     # main
     config.add_route('annotation',

--- a/h/views/help.py
+++ b/h/views/help.py
@@ -23,7 +23,7 @@ def custom_onboarding_page(context, request):
 @view_config(renderer='h:templates/help.html.jinja2', route_name='onboarding')
 def onboarding_page(context, request):
     return exc.HTTPFound(request.route_url('custom_onboarding',
-                                           welcome_slug=_random_word()))
+                                           slug=_random_word()))
 
 
 @view_config(renderer='h:templates/help.html.jinja2', route_name='help')

--- a/h/views/help.py
+++ b/h/views/help.py
@@ -4,18 +4,39 @@
 
 from __future__ import unicode_literals
 
+import binascii
+import os
+
+from pyramid import httpexceptions as exc
 from pyramid.view import view_config
 
 
-@view_config(renderer='h:templates/help.html.jinja2', route_name='help')
-@view_config(renderer='h:templates/help.html.jinja2', route_name='onboarding')
-def help_page(context, request):
-    current_route = request.matched_route.name
+@view_config(renderer='h:templates/help.html.jinja2', route_name='custom_onboarding')
+def custom_onboarding_page(context, request):
     return {
         'embed_js_url': request.route_path('embed'),
-        'is_help': current_route == 'help',
-        'is_onboarding': current_route == 'onboarding',
+        'is_help': False,
+        'is_onboarding': True,
     }
+
+
+@view_config(renderer='h:templates/help.html.jinja2', route_name='onboarding')
+def onboarding_page(context, request):
+    return exc.HTTPFound(request.route_url('custom_onboarding',
+                                           welcome_slug=_random_word()))
+
+
+@view_config(renderer='h:templates/help.html.jinja2', route_name='help')
+def help_page(context, request):
+    return {
+        'embed_js_url': request.route_path('embed'),
+        'is_help': True,
+        'is_onboarding': False,
+    }
+
+
+def _random_word():
+    return binascii.hexlify(os.urandom(8))
 
 
 def includeme(config):

--- a/tests/h/views/help_test.py
+++ b/tests/h/views/help_test.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import pytest
+import mock
+from pyramid import httpexceptions
+
+from h.views import help
+
+
+@pytest.mark.usefixtures('routes')
+def test_welcome_page_redirects_to_new_url(pyramid_request):
+    result = help.onboarding_page({}, pyramid_request)
+    assert isinstance(result, httpexceptions.HTTPFound)
+
+
+@pytest.mark.usefixtures('routes')
+def test_help_page_returns_is_help_true(pyramid_request):
+    result = help.help_page({}, pyramid_request)
+    assert result['is_help']
+
+
+@pytest.mark.usefixtures('routes')
+def test_custom_welcome_page(pyramid_request):
+    result = help.custom_onboarding_page({}, pyramid_request)
+    assert not result['is_help']
+    assert result['is_onboarding']
+
+
+@pytest.fixture
+def routes(pyramid_config):
+    pyramid_config.add_route('help', '/docs/help')
+    pyramid_config.add_route('onboarding', '/welcome/')
+    pyramid_config.add_route('custom_onboarding', '/welcome/{slug}')
+    pyramid_config.add_route('embed', '/embed')


### PR DESCRIPTION
The `/welcome(/)` endpoint now redirects to `/welcome/{slug}`, with a
randomly generated slug, and which renders the exact same page.
This allows for the onboarding experience to start on a page that
is clean of annotations.

See https://trello.com/c/FIiBdyTX/302-clean-up-the-welcome-page