### PR TITLE
Fix the Help panel on the stream and standalone annotation pages

### DIFF
--- a/h/templates/client/help_panel.html
+++ b/h/templates/client/help_panel.html
@@ -27,8 +27,10 @@
     <dd class="help-panel-content__val">{{ vm.version }}</dd>
     <dt class="help-panel-content__key">User agent: </dt>
     <dd class="help-panel-content__val">{{ vm.userAgent }}</dd>
-    <dt class="help-panel-content__key">URL: </dt>
-    <dd class="help-panel-content__val">{{ vm.url }}</dd>
+    <div ng-if="vm.url">
+      <dt class="help-panel-content__key">URL: </dt>
+      <dd class="help-panel-content__val">{{ vm.url }}</dd>
+    </div>
     <div ng-if="vm.documentFingerprint">
       <dt class="help-panel-content__key">PDF fingerprint: </dt>
       <dd class="help-panel-content__val">{{ vm.documentFingerprint }}</dd>

--- a/h/templates/client/top_bar.html
+++ b/h/templates/client/top_bar.html
@@ -13,7 +13,7 @@
     <signin-control
       auth="auth"
       new-style="false"
-      on-show-help-panel="vm.onShowHelpPanel()"
+      on-show-help-panel="onShowHelpPanel()"
       on-login="onLogin()"
       on-logout="onLogout()">
     </signin-control>


### PR DESCRIPTION
 - Fix incorrect reference to `onShowHelpPanel` property in <top-bar>
   template

 - Do not show URL entry in metadata display if there is no annotation
   guest connected to the sidebar, as is the case in the stream and
   permalink pages.