### PR TITLE
Fix escaped HTML in login error message

### DIFF
--- a/h/templates/client/login_form.html
+++ b/h/templates/client/login_form.html
@@ -30,7 +30,8 @@
                 >Please enter your username or email address.</li>
             <li class="form-error"
                 ng-show="login.username.$error.response"
-                >{{login.username.responseErrorMessage}}</li>
+                ng-bind-html="login.username.responseErrorMessage">
+            </li>
           </ul>
         </div>
 


### PR DESCRIPTION
If you try to login to an unactivated account the error message that the
server returns contains HTML:

You haven't activated your account yet. <strong>Please check your email and
open the link to activate your account</strong>.

Render this client-side as HTML rather than escaping the tags.

Fixes #3501.