### PR TITLE
Fix size of sidebar tutorial header

### DIFF
--- a/h/static/styles/sidebar-tutorial.scss
+++ b/h/static/styles/sidebar-tutorial.scss
@@ -1,5 +1,6 @@
 .sidebar-tutorial__header {
   color: $color-cardinal;
+  font-size: $body1-font-size;
   font-weight: $title-font-weight;
 }
 


### PR DESCRIPTION
Fix the font size of the sidebar tutorial header. This used to be
smaller, was accidentally made larger.

Fixes #3325.