### PR TITLE
Remove the query property!

### DIFF
--- a/h/api/db/__init__.py
+++ b/h/api/db/__init__.py
@@ -30,11 +30,6 @@ metadata = MetaData(naming_convention={
 Base = declarative.declarative_base(metadata=metadata)  # pylint: disable=invalid-name
 
 
-def use_session(session, base=Base):
-    """Configure the SQLAlchemy base class to use the given session."""
-    base.query = session.query_property()
-
-
 def bind_engine(engine, base=Base, should_create=False, should_drop=False):
     """Bind the SQLAlchemy base class to the given engine."""
     base.metadata.bind = engine

--- a/h/db/__init__.py
+++ b/h/db/__init__.py
@@ -54,12 +54,7 @@ metadata = MetaData(naming_convention={
     "pk": "pk__%(table_name)s"
 })
 
-
-# Provide a very simple base class with a dynamic query property.
-class _Base(object):
-    query = Session.query_property()
-
-Base = declarative_base(cls=_Base, metadata=metadata)
+Base = declarative_base(metadata=metadata)
 
 
 def bind_engine(engine,
@@ -102,5 +97,3 @@ def includeme(config):
         'should_create': should_create,
         'should_drop': should_drop
     }, order=10)
-
-    api_db.use_session(Session)

--- a/tests/h/admin/views/features_test.py
+++ b/tests/h/admin/views/features_test.py
@@ -183,8 +183,8 @@ def test_features_save_sets_cohorts_when_checkboxes_on(pyramid_request):
     pyramid_request.POST = {'feat[cohorts][cohort]': 'on'}
     views.features_save(pyramid_request)
 
-    feat = models.Feature.query.filter_by(name='feat').first()
-    cohort = models.FeatureCohort.query.filter_by(name='cohort').first()
+    feat = pyramid_request.db.query(models.Feature).filter_by(name='feat').first()
+    cohort = pyramid_request.db.query(models.FeatureCohort).filter_by(name='cohort').first()
 
     assert len(feat.cohorts) == 1
     assert cohort in feat.cohorts
@@ -204,8 +204,8 @@ def test_features_save_unsets_cohorts_when_checkboxes_off(pyramid_request):
     pyramid_request.POST = {'feat[cohorts][cohort]': 'off'}
     views.features_save(pyramid_request)
 
-    feat = models.Feature.query.filter_by(name='feat').first()
-    cohort = models.FeatureCohort.query.filter_by(name='cohort').first()
+    feat = pyramid_request.db.query(models.Feature).filter_by(name='feat').first()
+    cohort = pyramid_request.db.query(models.FeatureCohort).filter_by(name='cohort').first()
 
     assert len(feat.cohorts) == 0
     assert cohort not in feat.cohorts

--- a/tests/h/api/conftest.py
+++ b/tests/h/api/conftest.py
@@ -58,5 +58,4 @@ def setup_database(request, settings):
     """Set up the database connection and create tables."""
     engine = engine_from_config(settings, 'sqlalchemy.')
     db.bind_engine(engine, should_create=True, should_drop=True)
-    db.use_session(Session)
     request.addfinalizer(Session.remove)

--- a/tests/h/api/models/document_test.py
+++ b/tests/h/api/models/document_test.py
@@ -514,7 +514,7 @@ class TestMergeDocuments(object):
         document.merge_documents(db_session, merge_data)
         db_session.flush()
 
-        assert document.Document.query.get(duplicate.id) is None
+        assert db_session.query(document.Document).get(duplicate.id) is None
 
     def test_merge_documents_rewires_document_uris(self, db_session, merge_data):
         master, duplicate = merge_data

--- a/tests/h/conftest.py
+++ b/tests/h/conftest.py
@@ -76,7 +76,6 @@ def setup_database():
     """Set up the database connection and create tables."""
     engine = db.make_engine({'sqlalchemy.url': TEST_DATABASE_URL})
     db.bind_engine(engine, should_create=True, should_drop=True)
-    api_db.use_session(db.Session)
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
Finally, the day is here! Thread-local sessions need be no more! (Although
they're sticking around for the moment).

The use of a "magic" query property makes testing difficult and causes
confusion about which session is the correct session to use when writing new
code.

This commit finally removes the magical query property on the model base class.
There are now only two mechanisms by which code can get hold of a database
session:

1. be passed it explicitly, or be passed an object which holds a reference to a session (such as the request object).
2. construct one yourself

This will make it possible to fully isolate request sessions from one another and to use explicitly request-scoped sessions rather than a thread-local scoped_session registry.