### PR TITLE
Don't access the database session directly in tests

### DIFF
--- a/tests/h/accounts/models_test.py
+++ b/tests/h/accounts/models_test.py
@@ -6,22 +6,21 @@ import re
 import pytest
 from sqlalchemy import exc
 
-from h import db
 from h.accounts import models
 
 from ... import factories
 
 
-def test_activation_has_asciinumeric_code():
+def test_activation_has_asciinumeric_code(db_session):
     act = models.Activation()
 
-    db.Session.add(act)
-    db.Session.flush()
+    db_session.add(act)
+    db_session.flush()
 
     assert re.match(r'[A-Za-z0-9]{12}', act.code)
 
 
-def test_cannot_create_dot_variant_of_user():
+def test_cannot_create_dot_variant_of_user(db_session):
     fred = models.User(username='fredbloggs',
                        email='fred@example.com',
                        password='123')
@@ -29,13 +28,13 @@ def test_cannot_create_dot_variant_of_user():
                         email='fred@example.org',
                         password='456')
 
-    db.Session.add(fred)
-    db.Session.add(fred2)
+    db_session.add(fred)
+    db_session.add(fred2)
     with pytest.raises(exc.IntegrityError):
-        db.Session.flush()
+        db_session.flush()
 
 
-def test_cannot_create_case_variant_of_user():
+def test_cannot_create_case_variant_of_user(db_session):
     bob = models.User(username='BobJones',
                       email='bob@example.com',
                       password='123')
@@ -43,10 +42,10 @@ def test_cannot_create_case_variant_of_user():
                        email='bob@example.org',
                        password='456')
 
-    db.Session.add(bob)
-    db.Session.add(bob2)
+    db_session.add(bob)
+    db_session.add(bob2)
     with pytest.raises(exc.IntegrityError):
-        db.Session.flush()
+        db_session.flush()
 
 
 def test_cannot_create_user_with_too_short_username():
@@ -69,15 +68,15 @@ def test_cannot_create_user_with_too_short_password():
         models.User(password='a')
 
 
-def test_User_activate_activates_user():
+def test_User_activate_activates_user(db_session):
     user = models.User(username='kiki', email='kiki@kiki.com',
                        password='password')
     activation = models.Activation()
     user.activation = activation
-    db.Session.add(user)
-    db.Session.flush()
+    db_session.add(user)
+    db_session.flush()
 
     user.activate()
-    db.Session.commit()
+    db_session.commit()
 
     assert user.is_activated

--- a/tests/h/admin/views/features_test.py
+++ b/tests/h/admin/views/features_test.py
@@ -3,7 +3,6 @@
 import pytest
 import mock
 
-from h import db
 from h import models
 from h.admin.views import features as views
 
@@ -158,10 +157,10 @@ def test_cohorts_edit_with_users(pyramid_request):
     cohort.members.append(user1)
     cohort.members.append(user2)
 
-    db.Session.add(user1)
-    db.Session.add(user2)
-    db.Session.add(cohort)
-    db.Session.flush()
+    pyramid_request.db.add(user1)
+    pyramid_request.db.add(user2)
+    pyramid_request.db.add(cohort)
+    pyramid_request.db.flush()
 
     pyramid_request.matchdict['id'] = cohort.id
     result = views.cohorts_edit({}, pyramid_request)

--- a/tests/h/auth/tokens_test.py
+++ b/tests/h/auth/tokens_test.py
@@ -4,7 +4,6 @@ import datetime
 
 import pytest
 
-from h import db
 from h.auth import models
 from h.auth import tokens
 
@@ -119,7 +118,7 @@ def test_userid_from_api_token_returns_None_when_token_doesnt_start_with_prefix(
     """
     token = models.Token('acct:foo@example.com')
     token.value = u'abc123'
-    db.Session.add(token)
+    pyramid_request.db.add(token)
 
     result = tokens.userid_from_api_token(u'abc123', pyramid_request)
 
@@ -136,7 +135,7 @@ def test_userid_from_api_token_returns_None_for_nonexistent_tokens(pyramid_reque
 
 def test_userid_from_api_token_returns_userid_for_valid_tokens(pyramid_request):
     token = models.Token('acct:foo@example.com')
-    db.Session.add(token)
+    pyramid_request.db.add(token)
 
     result = tokens.userid_from_api_token(token.value, pyramid_request)
 

--- a/tests/h/features/models_test.py
+++ b/tests/h/features/models_test.py
@@ -3,7 +3,6 @@
 import mock
 import pytest
 
-from h import db
 from h.models import Feature
 
 
@@ -15,43 +14,41 @@ class TestFeature(object):
 
         assert feat.description == 'A test flag for testing with.'
 
-    def test_all_creates_annotations_that_dont_exist(self):
-        features = Feature.all(db.Session)
+    def test_all_creates_annotations_that_dont_exist(self, db_session):
+        features = Feature.all(db_session)
 
         assert len(features) == 1
         assert features[0].name == 'notification'
 
-    def test_all_only_returns_current_flags(self):
+    def test_all_only_returns_current_flags(self, db_session):
         """The .all() method should only return named current feature flags."""
-        session = db.Session
         new, pending, old = [Feature(name='notification'),
                              Feature(name='abouttoberemoved'),
                              Feature(name='somethingelse')]
-        session.add_all([new, pending, old])
-        session.flush()
+        db_session.add_all([new, pending, old])
+        db_session.flush()
 
-        features = Feature.all(session)
+        features = Feature.all(db_session)
 
         assert len(features) == 1
         assert features[0].name == 'notification'
 
-    def test_remove_old_flag_removes_old_flags(self):
+    def test_remove_old_flag_removes_old_flags(self, db_session):
         """
         The remove_old_flags function should remove unknown flags.
 
         New flags and flags pending removal should be left alone, but completely
         unknown flags should be removed.
         """
-        session = db.Session
         new, pending, old = [Feature(name='notification'),
                              Feature(name='abouttoberemoved'),
                              Feature(name='somethingelse')]
-        session.add_all([new, pending, old])
-        session.flush()
+        db_session.add_all([new, pending, old])
+        db_session.flush()
 
-        Feature.remove_old_flags(session)
+        Feature.remove_old_flags(db_session)
 
-        remaining = set([f.name for f in session.query(Feature).all()])
+        remaining = set([f.name for f in db_session.query(Feature).all()])
         assert remaining == {'abouttoberemoved', 'notification'}
 
     @pytest.fixture

--- a/tests/h/groups/models_test.py
+++ b/tests/h/groups/models_test.py
@@ -2,19 +2,18 @@
 import pytest
 
 from h import api
-from h import db
 from h.groups import models
 
 from ... import factories
 
 
-def test_init():
+def test_init(db_session):
     name = "My Hypothesis Group"
     user = factories.User()
 
     group = models.Group(name=name, creator=user)
-    db.Session.add(group)
-    db.Session.flush()
+    db_session.add(group)
+    db_session.flush()
 
     assert group.id
     assert group.name == name
@@ -38,29 +37,29 @@ def test_with_long_name():
                      creator=factories.User())
 
 
-def test_slug():
+def test_slug(db_session):
     name = "My Hypothesis Group"
     user = factories.User()
 
     group = models.Group(name=name, creator=user)
-    db.Session.add(group)
-    db.Session.flush()
+    db_session.add(group)
+    db_session.flush()
 
     assert group.slug == "my-hypothesis-group"
 
 
-def test_repr():
+def test_repr(db_session):
     name = "My Hypothesis Group"
     user = factories.User()
 
     group = models.Group(name=name, creator=user)
-    db.Session.add(group)
-    db.Session.flush()
+    db_session.add(group)
+    db_session.flush()
 
     assert repr(group) == "<Group: my-hypothesis-group>"
 
 
-def test_created_by():
+def test_created_by(db_session):
     name_1 = "My first group"
     name_2 = "My second group"
     user = factories.User()
@@ -68,21 +67,21 @@ def test_created_by():
     group_1 = models.Group(name=name_1, creator=user)
     group_2 = models.Group(name=name_2, creator=user)
 
-    db.Session.add(group_1, group_2)
-    db.Session.flush()
+    db_session.add(group_1, group_2)
+    db_session.flush()
 
-    assert models.Group.created_by(db.Session, user).all() == [group_1, group_2]
+    assert models.Group.created_by(db_session, user).all() == [group_1, group_2]
 
 
 @pytest.mark.usefixtures('documents')
-def test_documents_returns_groups_annotated_documents(group):
+def test_documents_returns_groups_annotated_documents(db_session, group):
     # Three different documents each with a shared annotation in the group.
-    document_1 = document('http://example.com/document_1')
-    annotation(document_1, groupid='test-group', shared=True)
-    document_2 = document('http://example.com/document_2')
-    annotation(document_2, groupid='test-group', shared=True)
-    document_3 = document('http://example.com/document_3')
-    annotation(document_3, groupid='test-group', shared=True)
+    document_1 = document(db_session, 'http://example.com/document_1')
+    annotation(db_session, document_1, groupid='test-group', shared=True)
+    document_2 = document(db_session, 'http://example.com/document_2')
+    annotation(db_session, document_2, groupid='test-group', shared=True)
+    document_3 = document(db_session, 'http://example.com/document_3')
+    annotation(db_session, document_3, groupid='test-group', shared=True)
 
     # In this test we don't care about other annotated documents that the
     # documents fixture might have created before we created our own.
@@ -123,21 +122,25 @@ def test_documents_returns_documents_annotated_by_this_group_and_another(
     assert documents['annotated_by_this_group_and_another_group'] in returned
 
 
-def test_documents_does_not_return_more_than_25_documents(group):
+def test_documents_does_not_return_more_than_25_documents(db_session, group):
     for i in range(50):
-        annotation(
-            document('http://example.com/document_' + str(i)),
-            groupid='test-group', shared=True)
+        annotation(db_session,
+                   document(db_session,
+                            'http://example.com/document_' + str(i)),
+                   groupid='test-group',
+                   shared=True)
 
     assert len(group.documents()) == 25
 
 
-def test_documents_passing_in_a_custom_limit(group):
+def test_documents_passing_in_a_custom_limit(db_session, group):
     """It should obey a custom limit if one is passed in."""
     for i in range(50):
-        annotation(
-            document('http://example.com/document_' + str(i)),
-            groupid='test-group', shared=True)
+        annotation(db_session,
+                   document(db_session,
+                            'http://example.com/document_' + str(i)),
+                   groupid='test-group',
+                   shared=True)
 
     for limit in (10, 40):
         assert len(group.documents(limit=limit)) == limit
@@ -147,7 +150,7 @@ def test_documents_when_group_has_no_documents(group):
     assert group.documents() == []
 
 
-def test_documents_does_not_return_null_documents(group):
+def test_documents_does_not_return_null_documents(db_session, group):
     """
     It shouldn't return None when an annotation has no document.
 
@@ -156,72 +159,87 @@ def test_documents_does_not_return_null_documents(group):
     it should not return None in the list of documents that it returns.
 
     """
-    db.Session.add(api.models.Annotation(
+    db_session.add(api.models.Annotation(
         userid=u'fred', groupid=group.pubid, shared=True))
 
     assert None not in group.documents()
 
 
-def annotation(document_, groupid, shared):
+def annotation(session, document_, groupid, shared):
     """Add a new annotation of the given document to the db and return it."""
     annotation_ = api.models.Annotation(
         userid=u'fred', groupid=groupid, shared=shared,
         target_uri=document_.document_uris[0].uri)
-    db.Session.add(annotation_)
+    session.add(annotation_)
     return annotation_
 
 
-def document(uri):
+def document(session, uri):
     """Add a new Document for the given uri to the db and return it."""
     document_ = api.models.Document()
-    db.Session.add(document_)
+    session.add(document_)
 
     # Flush the session so that document.id gets generated.
-    db.Session.flush()
+    session.flush()
 
-    db.Session.add(api.models.DocumentURI(
+    session.add(api.models.DocumentURI(
         claimant=uri, document_id=document_.id, uri=uri))
 
     return document_
 
 
 @pytest.fixture
-def documents():
+def documents(db_session):
     """Add diverse annotated documents to the db and return them."""
     # Document with one shared annotation.
-    one_shared_annotation = document(
-        'http://example.com/one_shared_annotation')
-    annotation(one_shared_annotation, groupid='test-group', shared=True)
+    one_shared_annotation = document(db_session,
+                                     'http://example.com/one_shared_annotation')
+    annotation(db_session,
+               one_shared_annotation,
+               groupid='test-group',
+               shared=True)
 
     # Document with multiple shared annotations.
-    multiple_shared_annotations = document(
-        'http://example.com/multiple_shared_annotations')
+    multiple_shared_annotations = document(db_session,
+                                           'http://example.com/multiple_shared_annotations')
     for _ in range(3):
-        annotation(multiple_shared_annotations, groupid='test-group',
+        annotation(db_session,
+                   multiple_shared_annotations,
+                   groupid='test-group',
                    shared=True)
 
     # Document with only private annotations.
-    only_private_annotations = document(
-        'http://example.com/only_private_annotations')
-    annotation(only_private_annotations, groupid='test-group', shared=False)
+    only_private_annotations = document(db_session,
+                                        'http://example.com/only_private_annotations')
+    annotation(db_session,
+               only_private_annotations,
+               groupid='test-group',
+               shared=False)
 
     # Document with both private and shared annotations.
-    private_and_shared_annotations = document(
-        'http://example.com/private_and_shared_annotations')
+    private_and_shared_annotations = document(db_session,
+                                              'http://example.com/private_and_shared_annotations')
     for shared in [True, False]:
-        annotation(private_and_shared_annotations, groupid='test-group',
+        annotation(db_session,
+                   private_and_shared_annotations,
+                   groupid='test-group',
                    shared=shared)
 
     # Document annotated by other group.
-    annotated_by_other_group = document(
-        'http://example.com/annotated_by_other_group')
-    annotation(annotated_by_other_group, groupid='other-group', shared=True)
+    annotated_by_other_group = document(db_session,
+                                        'http://example.com/annotated_by_other_group')
+    annotation(db_session,
+               annotated_by_other_group,
+               groupid='other-group',
+               shared=True)
 
     # Document annotated by both this group and another group.
-    annotated_by_this_group_and_another_group = document(
-        'http://example.com/annotated_by_this_group_and_another_group')
+    annotated_by_this_group_and_another_group = document(db_session,
+                                                         'http://example.com/annotated_by_this_group_and_another_group')
     for groupid in ['test-group', 'other-group']:
-        annotation(annotated_by_this_group_and_another_group, groupid=groupid,
+        annotation(db_session,
+                   annotated_by_this_group_and_another_group,
+                   groupid=groupid,
                    shared=True)
 
     return dict(
@@ -230,15 +248,14 @@ def documents():
         only_private_annotations=only_private_annotations,
         private_and_shared_annotations=private_and_shared_annotations,
         annotated_by_other_group=annotated_by_other_group,
-        annotated_by_this_group_and_another_group=
-            annotated_by_this_group_and_another_group,
+        annotated_by_this_group_and_another_group=annotated_by_this_group_and_another_group,
     )
 
 
 @pytest.fixture
-def group():
+def group(db_session):
     """Add a new group to the db and return it."""
     group_ = models.Group(name='test-group', creator=factories.User())
-    db.Session.add(group_)
+    db_session.add(group_)
     group_.pubid = 'test-group'
     return group_


### PR DESCRIPTION
All tests should access the database session using the `db_session` fixture. This will make it easier to turn `h.db.Session` into a stateless session factory in future.

This PR doesn't address the test factories or conftest.py. These will be fixed in a subsequent commit.