### PR TITLE
Make test for URL-ness of selection stricter

### DIFF
--- a/h/static/scripts/markdown-commands.js
+++ b/h/static/scripts/markdown-commands.js
@@ -101,7 +101,7 @@ function convertSelectionToLink(state, linkType) {
   }
 
   var newState;
-  if (selection.match(/[a-z]+:.*/)) {
+  if (selection.match(/[a-z]+:\/\/.*/)) {
     // Selection is a URL, wrap it with a link and use the selection as
     // the target.
     var dummyLabel = 'Description';

--- a/h/static/scripts/test/markdown-commands-test.js
+++ b/h/static/scripts/test/markdown-commands-test.js
@@ -104,17 +104,26 @@ describe('markdown commands', function () {
       return commands.convertSelectionToLink(parseState(text), linkType);
     };
 
-    it('converts text to links', function () {
-      var output = linkify('one <sel>two</sel> three');
+    unroll('converts text to links', function (testCase) {
+      var sel = testCase.selection;
+      var output = linkify('one <sel>' + sel + '</sel> three');
       assert.equal(formatState(output),
-        'one [two](<sel>http://insert-your-link-here.com</sel>) three');
-    });
+        'one [' + sel + '](<sel>http://insert-your-link-here.com</sel>) three');
+    },[
+      {selection: 'two'},
+      {selection: 'jim:smith'}
+    ]);
 
-    it('converts URLs to links', function () {
-      var output = linkify('one <sel>http://foobar.com</sel> three');
+    unroll('converts URLs to links', function (testCase) {
+      var sel = testCase.selection;
+      var output = linkify('one <sel>' + sel + '</sel> three');
       assert.equal(formatState(output),
-        'one [<sel>Description</sel>](http://foobar.com) three');
-    });
+        'one [<sel>Description</sel>](' + sel + ') three');
+    },[
+      {selection: 'http://foobar.com'},
+      {selection: 'https://twitter.com/username'},
+      {selection: ' http://example.com/url-with-a-leading-space'},
+    ]);
 
     it('converts URLs to image links', function () {
       var output = linkify('one <sel>http://foobar.com</sel> three',


### PR DESCRIPTION
Increase the strictness of the heuristic for whether the selection is a
URL or not in the "Convert selection to link" editor toolbar command.

Require the selection to contain something that looks like a scheme
followed by an authority, rather than just a scheme.

Fixes #3513