### PR TITLE
Allow multiple 'uri' parameters to the search query

### DIFF
--- a/h/api/search/query.py
+++ b/h/api/search/query.py
@@ -170,13 +170,18 @@ class UriFilter(object):
         self.request = request
 
     def __call__(self, params):
-        uristr = params.pop('uri', None)
-        if uristr is None:
+        if 'uri' not in params:
             return None
+        query_uris = [v for k, v in params.items() if k == 'uri']
+        del params['uri']
 
-        uris = storage.expand_uri(self.request.db, uristr)
-        scopes = [uri.normalize(u) for u in uris]
-        return {"terms": {"target.scope": scopes}}
+        uris = set()
+        for query_uri in query_uris:
+            us = [uri.normalize(u)
+                  for u in storage.expand_uri(self.request.db, query_uri)]
+            uris.update(us)
+
+        return {"terms": {"target.scope": list(uris)}}
 
 
 class AnyMatcher(object):


### PR DESCRIPTION
In order to have a better chance of retrieving all the annotations we know about for a document, it should be possible to query by all known URIs for that document.

This commit makes it possible to supply multiple 'uri' parameters to the API search endpoint. The resulting query will match annotations in which `target.scope` (i.e. the normalised target URI) matches *any* of the URIs in the set expanded from *all* of the query parameter values.

This is an entirely backwards compatible change. In the case where only one `uri` parameter is provided, the query output is identical.