### PR TITLE
Update PDF fingerprint searching / handling

### DIFF
--- a/h/static/scripts/annotator/plugin/pdf-metadata.js
+++ b/h/static/scripts/annotator/plugin/pdf-metadata.js
@@ -27,7 +27,11 @@ function PDFMetadata(app) {
  */
 PDFMetadata.prototype.getUri = function () {
   return this._loaded.then(function (app) {
-    return fingerprintToURN(app.documentFingerprint);
+    var uri = getPDFURL(app);
+    if (!uri) {
+      uri = fingerprintToURN(app.documentFingerprint);
+    }
+    return uri;
   });
 };
 
@@ -52,11 +56,9 @@ PDFMetadata.prototype.getMetadata = function () {
       {href: fingerprintToURN(app.documentFingerprint)}
     ];
 
-    // Local file:// URLs should not be saved in document metadata.
-    // Entries in document.link should be URIs. In the case of
-    // local files, omit the URL.
-    if (app.url.indexOf('file://') !== 0) {
-      link.push({href: app.url});
+    var url = getPDFURL(app);
+    if (url) {
+      link.push({href: url});
     }
 
     return {
@@ -69,6 +71,17 @@ PDFMetadata.prototype.getMetadata = function () {
 
 function fingerprintToURN(fingerprint) {
   return 'urn:x-pdf:' + String(fingerprint);
+}
+
+function getPDFURL(app) {
+  // Local file:// URLs should not be saved in document metadata.
+  // Entries in document.link should be URIs. In the case of
+  // local files, omit the URL.
+  if (app.url.indexOf('file://') !== 0) {
+    return app.url;
+  }
+
+  return null;
 }
 
 module.exports = PDFMetadata;

--- a/h/static/scripts/annotator/plugin/test/pdf-metadata-test.js
+++ b/h/static/scripts/annotator/plugin/test/pdf-metadata-test.js
@@ -9,19 +9,23 @@ describe('pdf-metadata', function () {
 
     var event = document.createEvent('Event');
     event.initEvent('documentload', false, false);
+    fakeApp.url = 'http://fake.com';
     fakeApp.documentFingerprint = 'fakeFingerprint';
     window.dispatchEvent(event);
 
     return pdfMetadata.getUri().then(function (uri) {
-      assert.equal(uri, 'urn:x-pdf:fakeFingerprint');
+      assert.equal(uri, 'http://fake.com');
     });
   });
 
   it('does not wait for the PDF to load if it has already loaded', function () {
-    var fakePDFViewerApplication = {documentFingerprint: 'fakeFingerprint'};
+    var fakePDFViewerApplication = {
+      url: 'http://fake.com',
+      documentFingerprint: 'fakeFingerprint',
+    };
     var pdfMetadata = new PDFMetadata(fakePDFViewerApplication);
     return pdfMetadata.getUri().then(function (uri) {
-      assert.equal(uri, 'urn:x-pdf:fakeFingerprint');
+      assert.equal(uri, 'http://fake.com');
     });
   });
 
@@ -37,7 +41,7 @@ describe('pdf-metadata', function () {
           'dc:title': 'fakeTitle',
         }
       },
-      url: 'fakeUrl',
+      url: 'http://fake.com',
     };
 
     beforeEach(function () {
@@ -45,7 +49,19 @@ describe('pdf-metadata', function () {
     });
 
     describe('#getUri', function () {
-      it('returns the URN-ified document fingerprint as its URI', function () {
+      it('returns the non-file URI', function() {
+        return pdfMetadata.getUri().then(function (uri) {
+          assert.equal(uri, 'http://fake.com');
+        });
+      });
+
+      it('returns the fingerprint as a URN when the PDF URL is a local file', function () {
+        var fakePDFViewerApplication = {
+          url: 'file:///test.pdf',
+          documentFingerprint: 'fakeFingerprint',
+        };
+        var pdfMetadata = new PDFMetadata(fakePDFViewerApplication);
+
         return pdfMetadata.getUri().then(function (uri) {
           assert.equal(uri, 'urn:x-pdf:fakeFingerprint');
         });
@@ -88,7 +104,7 @@ describe('pdf-metadata', function () {
         var pdfMetadata;
         var fakePDFViewerApplication = {
           documentFingerprint: 'fakeFingerprint',
-          url: 'file://fakeUrl',
+          url: 'file://fake.pdf',
         };
         var expectedMetadata = {
           link: [{href: 'urn:x-pdf:' + fakePDFViewerApplication.documentFingerprint}],

--- a/h/static/scripts/cross-frame.coffee
+++ b/h/static/scripts/cross-frame.coffee
@@ -46,11 +46,20 @@ module.exports = class CrossFrame
         if err
           channel.destroy()
         else
+          searchUris = [info.uri]
+
           documentFingerprint = null
           if info.metadata and info.metadata.documentFingerprint
             documentFingerprint = info.metadata.documentFingerprint
+            searchUris = info.metadata.link.map((link) -> link.href)
+
           $rootScope.$apply =>
-            @frames.push({channel: channel, uri: info.uri, documentFingerprint: documentFingerprint})
+            @frames.push({
+              channel: channel,
+              uri: info.uri,
+              searchUris: searchUris,
+              documentFingerprint: documentFingerprint
+            })
 
     this.connect = ->
       discovery = createDiscovery()

--- a/h/static/scripts/test/cross-frame-test.coffee
+++ b/h/static/scripts/test/cross-frame-test.coffee
@@ -72,5 +72,23 @@ describe 'CrossFrame', ->
       fakeBridge.onConnect.yields(channel)
       crossframe.connect()
       assert.deepEqual(crossframe.frames, [
-        {channel: channel, uri: uri, documentFingerprint: null}
+        {channel: channel, uri: uri, searchUris: [uri], documentFingerprint: null}
+      ])
+
+    it 'updates the frames array with multiple search uris when the document is a PDF', ->
+      uri = 'http://example.com/test.pdf'
+      fingerprint = 'urn:x-pdf:fingerprint'
+      channel = {
+        call: sandbox.stub().yields(null, {
+          uri: uri,
+          metadata: {
+            link: [{href: uri}, {href: fingerprint}],
+            documentFingerprint: fingerprint,
+          },
+        })
+      }
+      fakeBridge.onConnect.yields(channel)
+      crossframe.connect()
+      assert.deepEqual(crossframe.frames, [
+        {channel: channel, uri: uri, searchUris: [uri, fingerprint], documentFingerprint: fingerprint}
       ])


### PR DESCRIPTION
This PR changes the client to:

* Search by fingerprint and non-file URI when the document is a fingerprint
* Changes the `target.source` of newly created annotations back to a non-file URI (otherwise uses fingerprint)

#3517 made it possible on the backend to search for multiple uris.
#3497 needs the changes of this PR (and has to remove the new `target.locator` property again).