### PR TITLE
Don't show permissions error before annotation

### DIFF
--- a/h/static/scripts/test/widget-controller-test.js
+++ b/h/static/scripts/test/widget-controller-test.js
@@ -344,6 +344,17 @@ describe('WidgetController', function () {
   });
 
   describe('direct linking messages', function () {
+
+    beforeEach(function () {
+      // The document has finished loading.
+      fakeCrossFrame.frames = [
+        {
+          uri: 'http://www.example.com',
+          searchUris: [],
+        }
+      ];
+    });
+
     it('displays a message if the selection is unavailable', function () {
       annotationUI.selectAnnotations(['missing']);
       $scope.$digest();
@@ -360,6 +371,18 @@ describe('WidgetController', function () {
     it('does not a show a message if there is no selection', function () {
       annotationUI.selectAnnotations([]);
       $scope.$digest();
+      assert.isFalse($scope.selectedAnnotationUnavailable());
+    });
+
+    it("doesn't show a message if the document isn't loaded yet", function () {
+      // No search requests have been sent yet.
+      searchClients = [];
+      // There is a selection but the selected annotation isn't available.
+      annotationUI.selectAnnotations(['missing']);
+      // The document hasn't finished loading.
+      fakeCrossFrame.frames = [];
+      $scope.$digest();
+
       assert.isFalse($scope.selectedAnnotationUnavailable());
     });
 

--- a/h/static/scripts/widget-controller.js
+++ b/h/static/scripts/widget-controller.js
@@ -181,7 +181,17 @@ module.exports = function WidgetController(
   }
 
   function isLoading() {
-    return searchClients.length > 0;
+    if (!crossframe.frames.some(function (frame) { return frame.uri; })) {
+      // The document's URL isn't known so the document must still be loading.
+      return true;
+    }
+
+    if (searchClients.length > 0) {
+      // We're still waiting for annotation search results from the API.
+      return true;
+    }
+
+    return false;
   }
 
   /**


### PR DESCRIPTION
Don't momentarily show a "You do not have permission to see this
annotation" card before showing the annotation when loading a
direct-linked annotation.

Fixes #3167.

When following direct links to annotations on certain documents,
for example large PDF files that take a while to load,
a "You do not have permission to see this annotation" card was being
displayed briefly in place of the annotation card, before quickly being
replaced by the correct annotation card.

Previously the logic of the WidgetController.isLoading() function was to
return true if we are currently waiting for the response to an
annotation search request that we've sent.

The theory is that this was happening:

1. Client loads, but PDF has not yet loaded, so URL is unknown.

2. Since the URL is unknown, the sidebar does not start fetching
   annotations and isLoading() returns false.

3. Since the client a) Has a selection but b) Is not in a loading state
   - it thinks that it failed to fetch the annotation and displays the
   "You do not have permission to see this annotation" message,

4. Once the PDF finishes loading, the URL is updated and that is
   reported to the sidebar which then performs a search query and
   isLoading() starts to return true until the search query response
   arrives then it returns false again.

The fix is to make isLoading() return true if _either_ we've sent an
annotation search request and are waiting on the response _or_ we're
still waiting for the document to finish loading and haven't sent the
search request yet. So instead of returning false, then true, then false
again isLoading() will just keep returning true until both the document
has loaded and the search response has been received, then it will start
returning false.