### PR TITLE
Fix missing PDF highlights

### DIFF
--- a/h/static/scripts/annotator/anchoring/html.coffee
+++ b/h/static/scripts/annotator/anchoring/html.coffee
@@ -50,11 +50,6 @@ exports.anchor = (root, selectors, options = {}) ->
       when 'RangeSelector'
         range = selector
 
-  # Assert that there is a quote selector, since otherwise we cannot validate
-  # the rest of the annotation's selectors.
-  if not quote?
-    return Promise.reject(new Error('quote selector not found'))
-
   # Assert the quote matches the stored quote, if applicable
   maybeAssertQuote = (range) ->
     if quote?.exact? and range.toString() != quote.exact

--- a/h/static/scripts/annotator/guest.coffee
+++ b/h/static/scripts/annotator/guest.coffee
@@ -187,6 +187,15 @@ module.exports = class Guest extends Annotator
     annotation.target ?= []
 
     locate = (target) ->
+      # Check that the anchor has a TextQuoteSelector -- without a
+      # TextQuoteSelector we have no basis on which to verify that we have
+      # reanchored correctly and so we shouldn't even try.
+      #
+      # Returning an anchor without a range will result in this annotation being
+      # treated as an orphan (assuming no other targets anchor).
+      if not (target.selector ? []).some((s) => s.type == 'TextQuoteSelector')
+        return Promise.resolve({annotation, target})
+
       # Find a target using the anchoring module.
       options = {
         cache: self.anchoringCache

--- a/h/static/scripts/annotator/test/integration/anchoring-test.js
+++ b/h/static/scripts/annotator/test/integration/anchoring-test.js
@@ -99,22 +99,4 @@ describe('anchoring', function () {
     ],
     expectFail: true,
   }]);
-
-  unroll('should silently fail when an annotation does not have a quote selector', function (testCase) {
-    var annotation = testCase.annotation;
-    var anchored = guest.anchor(annotation);
-
-    return anchored.then(function (result) {
-      assert.deepEqual(result, []);
-    });
-  }, [{
-    annotation: [{
-      target: [{
-        selector: [{
-          type: 'FragmentSelector',
-          value: 't=30,60'
-        }]
-      }]
-    }],
-  }]);
 });


### PR DESCRIPTION
fda63b4 unfortunately broke highlighting in PDFs, because the PDF anchoring code first finds the text in the document, and then uses a TextPositionSelector and the HTML anchoring code to select a range in
the rendered page for highlighting.

This commit fixes that issue by moving the TextQuoteSelector check up a level into `Guest#anchor`.

I've added two tests for this in `guest-test.coffee` -- one tests that annotations where the target contains no TextQuoteSelector are marked as orphans, and the second tests that the low-level anchoring code is never called in this case.

I have also removed the integration test, on the basis that I don't think integration testing failure cases is a good habit to get into.

Fixes #3530.