### PR TITLE
Remove duplicated state in `<annotation>` component

### DIFF
--- a/h/static/scripts/annotation-sync.coffee
+++ b/h/static/scripts/annotation-sync.coffee
@@ -53,11 +53,6 @@ module.exports = class AnnotationSync
       this._syncCache(channel)
     @bridge.onConnect(onConnect)
 
-  # Provide a public interface to the annotation cache so that other
-  # sync services can lookup annotations by tag.
-  getAnnotationForTag: (tag) ->
-    @cache[tag] or null
-
   sync: (annotations) ->
     annotations = (this._format a for a in annotations)
     @bridge.call 'sync', annotations, (err, annotations = []) =>

--- a/h/static/scripts/annotation-ui-controller.js
+++ b/h/static/scripts/annotation-ui-controller.js
@@ -21,7 +21,7 @@ function AnnotationUIController($rootScope, $scope, annotationUI) {
   });
 
   $rootScope.$on(events.ANNOTATION_DELETED, function (event, annotation) {
-    annotationUI.removeSelectedAnnotation(annotation);
+    annotationUI.removeSelectedAnnotation(annotation.id);
   });
 }
 

--- a/h/static/scripts/annotation-ui-sync.js
+++ b/h/static/scripts/annotation-ui-sync.js
@@ -15,28 +15,16 @@
  * that the messages are broadcast out to other frames.
  */
 // @ngInject
-function AnnotationUISync($rootScope, $window, bridge, annotationSync,
-  annotationUI) {
-  // Retrieves annotations from the annotationSync cache.
-  var getAnnotationsByTags = function (tags) {
-    return tags.map(annotationSync.getAnnotationForTag, annotationSync);
-  };
-
+function AnnotationUISync($rootScope, $window, annotationUI, bridge) {
   var channelListeners = {
     showAnnotations: function (tags) {
-      tags = tags || [];
-      var annotations = getAnnotationsByTags(tags);
-      annotationUI.selectAnnotations(annotations);
+      annotationUI.selectAnnotations(tags || []);
     },
     focusAnnotations: function (tags) {
-      tags = tags || [];
-      var annotations = getAnnotationsByTags(tags);
-      annotationUI.focusAnnotations(annotations);
+      annotationUI.focusAnnotations(tags || []);
     },
     toggleAnnotationSelection: function (tags) {
-      tags = tags || [];
-      var annotations = getAnnotationsByTags(tags);
-      annotationUI.toggleSelectedAnnotations(annotations);
+      annotationUI.toggleSelectedAnnotations(tags || []);
     },
     setVisibleHighlights: function (state) {
       if (typeof state !== 'boolean') {

--- a/h/static/scripts/annotation-ui.js
+++ b/h/static/scripts/annotation-ui.js
@@ -77,15 +77,24 @@ var types = {
   SET_SORT_KEY: 'SET_SORT_KEY',
 };
 
+/**
+ * Return a copy of `current` with all matching annotations in `annotations`
+ * removed.
+ */
 function excludeAnnotations(current, annotations) {
-  var idsAndTags = annotations.reduce(function (map, annot) {
-    var id = annot.id || annot.$$tag;
-    map[id] = true;
-    return map;
-  }, {});
+  var idsAndTags = {};
+  annotations.forEach(function (annot) {
+    if (annot.id) {
+      idsAndTags[annot.id] = true;
+    }
+    if (annot.$$tag) {
+      idsAndTags[annot.$$tag] = true;
+    }
+  });
   return current.filter(function (annot) {
-    var id = annot.id || annot.$$tag;
-    return !idsAndTags[id];
+    var shouldRemove = (annot.id && idsAndTags[annot.id]) ||
+                       (annot.$$tag && idsAndTags[annot.$$tag]);
+    return !shouldRemove;
   });
 }
 

--- a/h/static/scripts/cross-frame.coffee
+++ b/h/static/scripts/cross-frame.coffee
@@ -39,7 +39,7 @@ module.exports = class CrossFrame
       new AnnotationSync(bridge, options)
 
     createAnnotationUISync = (annotationSync) ->
-      new AnnotationUISync($rootScope, $window, bridge, annotationSync, annotationUI)
+      new AnnotationUISync($rootScope, $window, annotationUI, bridge)
 
     addFrame = (channel) =>
       channel.call 'getDocumentInfo', (err, info) =>

--- a/h/static/scripts/directive/annotation.js
+++ b/h/static/scripts/directive/annotation.js
@@ -41,8 +41,8 @@ function errorMessage(reason) {
  * If there are no draft changes to this annotation, does nothing.
  *
  */
-function restoreFromDrafts(drafts, domainModel, vm) {
-  var draft = drafts.get(domainModel);
+function restoreFromDrafts(drafts, vm) {
+  var draft = drafts.get(vm.annotation);
   if (draft) {
     vm.isPrivate = draft.isPrivate;
     vm.form.tags = draft.tags;
@@ -56,17 +56,17 @@ function restoreFromDrafts(drafts, domainModel, vm) {
   * Any existing drafts for this annotation will be overwritten.
   *
   * @param {object} drafts - The drafts service
-  * @param {object} domainModel - The full domainModel object of the
-  *   annotation to be saved. This full domainModel model is not retrieved
+  * @param {object} vm.annotation - The full vm.annotation object of the
+  *   annotation to be saved. This full vm.annotation model is not retrieved
   *   again from drafts, it's only used to identify the annotation's draft in
   *   order to retrieve the fields below.
   * @param {object} vm - The view model object containing the user's unsaved
   *   changes to the annotation.
   *
   */
-function saveToDrafts(drafts, domainModel, vm) {
+function saveToDrafts(drafts, vm) {
   drafts.update(
-    domainModel,
+    vm.annotation,
     {
       isPrivate: vm.isPrivate,
       tags: vm.form.tags,
@@ -74,48 +74,47 @@ function saveToDrafts(drafts, domainModel, vm) {
     });
 }
 
-/** Update domainModel from vm.
+/** Update `annotation` from vm.
  *
  * Copy any properties from vm that might have been modified by the user into
- * domainModel, overwriting any existing properties in domainModel.
+ * `annotation`, overwriting any existing properties in `annotation`.
  *
- * @param {object} domainModel The object to copy properties to
+ * @param {object} annotation The object to copy properties to
  * @param {object} vm The object to copy properties from
  *
  */
-function updateDomainModel(domainModel, vm, permissions) {
-  domainModel.text = vm.form.text;
-  domainModel.tags = vm.form.tags;
+function updateDomainModel(annotation, vm, permissions) {
+  annotation.text = vm.form.text;
+  annotation.tags = vm.form.tags;
   if (vm.isPrivate) {
-    domainModel.permissions = permissions.private();
+    annotation.permissions = permissions.private();
   } else {
-    domainModel.permissions = permissions.shared(domainModel.group);
+    annotation.permissions = permissions.shared(annotation.group);
   }
 }
 
 /** Update the view model from the domain model changes. */
-function updateViewModel($scope, domainModel,
-                         vm, permissions) {
+function updateViewModel($scope, vm, permissions) {
 
   vm.form = {
-    text: domainModel.text,
-    tags: domainModel.tags,
+    text: vm.annotation.text,
+    tags: vm.annotation.tags,
   };
 
-  if (domainModel.links) {
-    vm.linkInContext = domainModel.links.incontext ||
-                       domainModel.links.html ||
+  if (vm.annotation.links) {
+    vm.linkInContext = vm.annotation.links.incontext ||
+                       vm.annotation.links.html ||
                        '';
-    vm.linkHTML = domainModel.links.html || '';
+    vm.linkHTML = vm.annotation.links.html || '';
   } else {
     vm.linkInContext = '';
     vm.linkHTML = '';
   }
 
   vm.isPrivate = permissions.isPrivate(
-    domainModel.permissions, domainModel.user);
+    vm.annotation.permissions, vm.annotation.user);
 
-  var documentMetadata = extractDocumentMetadata(domainModel);
+  var documentMetadata = extractDocumentMetadata(vm.annotation);
   vm.documentTitle = documentTitle(documentMetadata);
   vm.documentDomain = documentDomain(documentMetadata);
 }
@@ -132,7 +131,6 @@ function AnnotationController(
   settings) {
 
   var vm = this;
-  var domainModel;
   var newlyCreatedByHighlightButton;
 
   /**
@@ -181,13 +179,6 @@ function AnnotationController(
     /** True if the 'Share' dialog for this annotation is currently open. */
     vm.showShareDialog = false;
 
-    /** The domain model, contains the currently saved version of the
-      * annotation from the server (or in the case of new annotations that
-      * haven't been saved yet - the data that will be saved to the server when
-      * they are saved).
-      */
-    domainModel = vm.annotation;
-
     /**
       * `true` if this AnnotationController instance was created as a result of
       * the highlight button being clicked.
@@ -196,7 +187,7 @@ function AnnotationController(
       * or annotation that was fetched from the server (as opposed to created
       * new client-side).
       */
-    newlyCreatedByHighlightButton = domainModel.$highlight || false;
+    newlyCreatedByHighlightButton = vm.annotation.$highlight || false;
 
     // Call `onAnnotationUpdated()` whenever the "annotationUpdated" event is
     // emitted. This event is emitted after changes to the annotation are
@@ -217,14 +208,14 @@ function AnnotationController(
 
     // New annotations (just created locally by the client, rather then
     // received from the server) have some fields missing. Add them.
-    domainModel.user = domainModel.user || session.state.userid;
-    domainModel.group = domainModel.group || groups.focused().id;
-    if (!domainModel.permissions) {
-      domainModel.permissions = permissions['default'](domainModel.group);
+    vm.annotation.user = vm.annotation.user || session.state.userid;
+    vm.annotation.group = vm.annotation.group || groups.focused().id;
+    if (!vm.annotation.permissions) {
+      vm.annotation.permissions = permissions['default'](vm.annotation.group);
     }
-    domainModel.text = domainModel.text || '';
-    if (!Array.isArray(domainModel.tags)) {
-      domainModel.tags = [];
+    vm.annotation.text = vm.annotation.text || '';
+    if (!Array.isArray(vm.annotation.tags)) {
+      vm.annotation.tags = [];
     }
 
     // Automatically save new highlights to the server when they're created.
@@ -234,31 +225,31 @@ function AnnotationController(
     // log in.
     saveNewHighlight();
 
-    updateView(domainModel);
+    updateView();
 
     // If this annotation is not a highlight and if it's new (has just been
     // created by the annotate button) or it has edits not yet saved to the
     // server - then open the editor on AnnotationController instantiation.
     if (!newlyCreatedByHighlightButton) {
-      if (isNew(domainModel) || drafts.get(domainModel)) {
+      if (isNew(vm.annotation) || drafts.get(vm.annotation)) {
         vm.edit();
       }
     }
   }
 
-  function updateView(domainModel) {
-    updateViewModel($scope, domainModel, vm, permissions);
+  function updateView() {
+    updateViewModel($scope, vm, permissions);
   }
 
   function onAnnotationUpdated(event, updatedDomainModel) {
-    if (updatedDomainModel.id === domainModel.id) {
-      domainModel = updatedDomainModel;
-      updateView(updatedDomainModel);
+    if (updatedDomainModel.id === vm.annotation.id) {
+      vm.annotation = updatedDomainModel;
+      updateView();
     }
   }
 
   function deleteIfNewAndEmpty() {
-    if (isNew(domainModel) && !vm.form.text && vm.form.tags.length === 0) {
+    if (isNew(vm.annotation) && !vm.form.text && vm.form.tags.length === 0) {
       vm.revert();
     }
   }
@@ -271,14 +262,14 @@ function AnnotationController(
     // The annotation component may be destroyed when switching accounts,
     // when switching groups or when the component is scrolled off-screen.
     if (vm.editing()) {
-      saveToDrafts(drafts, domainModel, vm);
+      saveToDrafts(drafts, vm);
     }
   }
 
   function onGroupFocused() {
     // New annotations move to the new group, when a new group is focused.
-    if (isNew(domainModel)) {
-      domainModel.group = groups.focused().id;
+    if (isNew(vm.annotation)) {
+      vm.annotation.group = groups.focused().id;
     }
   }
 
@@ -292,7 +283,7 @@ function AnnotationController(
    *
    */
   function saveNewHighlight() {
-    if (!isNew(domainModel)) {
+    if (!isNew(vm.annotation)) {
       // Already saved.
       return;
     }
@@ -302,17 +293,17 @@ function AnnotationController(
       return;
     }
 
-    if (domainModel.user) {
+    if (vm.annotation.user) {
       // User is logged in, save to server.
       // Highlights are always private.
-      domainModel.permissions = permissions.private();
-      domainModel.$create().then(function() {
-        $rootScope.$emit(events.ANNOTATION_CREATED, domainModel);
-        updateView(domainModel);
+      vm.annotation.permissions = permissions.private();
+      vm.annotation.$create().then(function() {
+        $rootScope.$emit(events.ANNOTATION_CREATED, vm.annotation);
+        updateView();
       });
     } else {
       // User isn't logged in, save to drafts.
-      saveToDrafts(drafts, domainModel, vm);
+      saveToDrafts(drafts, vm);
     }
   }
 
@@ -338,7 +329,7 @@ function AnnotationController(
     // performance bottleneck and we would need to get the id token into the
     // session, which we should probably do anyway (and move to opaque bearer
     // tokens for the access token).
-    return permissions.permits(action, domainModel, session.state.userid);
+    return permissions.permits(action, vm.annotation, session.state.userid);
   };
 
   /**
@@ -355,7 +346,7 @@ function AnnotationController(
             errorMessage(reason), 'Deleting annotation failed');
         };
         $scope.$apply(function() {
-          annotationMapper.deleteAnnotation(domainModel).then(
+          annotationMapper.deleteAnnotation(vm.annotation).then(
             null, onRejected);
         });
       }
@@ -368,8 +359,8 @@ function AnnotationController(
     * @description Switches the view to an editor.
     */
   vm.edit = function() {
-    restoreFromDrafts(drafts, domainModel, vm);
-    vm.action = isNew(domainModel) ? 'create' : 'edit';
+    restoreFromDrafts(drafts, vm);
+    vm.action = isNew(vm.annotation) ? 'create' : 'edit';
   };
 
   /**
@@ -392,7 +383,7 @@ function AnnotationController(
     * @returns {Object} The full group object associated with the annotation.
     */
   vm.group = function() {
-    return groups.get(domainModel.group);
+    return groups.get(vm.annotation.group);
   };
 
   /**
@@ -409,7 +400,7 @@ function AnnotationController(
     * @returns {boolean} True if this annotation has quotes
     */
   vm.hasQuotes = function() {
-    return domainModel.target.some(function(target) {
+    return vm.annotation.target.some(function(target) {
       return target.selector && target.selector.some(function(selector) {
         return selector.type === 'TextQuoteSelector';
       });
@@ -417,7 +408,7 @@ function AnnotationController(
   };
 
   vm.id = function() {
-    return domainModel.id;
+    return vm.annotation.id;
   };
 
   /**
@@ -428,16 +419,16 @@ function AnnotationController(
   vm.isHighlight = function() {
     if (newlyCreatedByHighlightButton) {
       return true;
-    } else if (isNew(domainModel)) {
+    } else if (isNew(vm.annotation)) {
       return false;
     } else {
       // Once an annotation has been saved to the server there's no longer a
       // simple property that says whether it's a highlight or not.  For
-      // example there's no domainModel.highlight: true.  Instead a highlight is
+      // example there's no vm.annotation.highlight: true.  Instead a highlight is
       // defined as an annotation that isn't a page note or a reply and that
       // has no text or tags.
-      var isPageNote = (domainModel.target || []).length === 0;
-      return (!isPageNote && !isReply(domainModel) && !vm.hasContent());
+      var isPageNote = (vm.annotation.target || []).length === 0;
+      return (!isPageNote && !isReply(vm.annotation) && !vm.hasContent());
     }
   };
 
@@ -471,12 +462,12 @@ function AnnotationController(
     * Creates a new message in reply to this annotation.
     */
   vm.reply = function() {
-    var references = (domainModel.references || []).concat(domainModel.id);
+    var references = (vm.annotation.references || []).concat(vm.annotation.id);
     var reply = annotationMapper.createAnnotation({
       references: references,
-      uri: domainModel.uri
+      uri: vm.annotation.uri
     });
-    reply.group = domainModel.group;
+    reply.group = vm.annotation.group;
 
     if (session.state.userid) {
       if (vm.isPrivate) {
@@ -493,11 +484,11 @@ function AnnotationController(
     * @description Reverts an edit in progress and returns to the viewer.
     */
   vm.revert = function() {
-    drafts.remove(domainModel);
+    drafts.remove(vm.annotation);
     if (vm.action === 'create') {
-      $rootScope.$emit(events.ANNOTATION_DELETED, domainModel);
+      $rootScope.$emit(events.ANNOTATION_DELETED, vm.annotation);
     } else {
-      updateView(domainModel);
+      updateView();
       view();
     }
   };
@@ -508,7 +499,7 @@ function AnnotationController(
     * @description Saves any edits and returns to the viewer.
     */
   vm.save = function() {
-    if (!domainModel.user) {
+    if (!vm.annotation.user) {
       flash.info('Please sign in to save your annotations.');
       return Promise.resolve();
     }
@@ -521,24 +512,24 @@ function AnnotationController(
     var saved;
     switch (vm.action) {
       case 'create':
-        updateDomainModel(domainModel, vm, permissions);
-        saved = domainModel.$create().then(function () {
-          $rootScope.$emit(events.ANNOTATION_CREATED, domainModel);
-          updateView(domainModel);
-          drafts.remove(domainModel);
+        updateDomainModel(vm.annotation, vm, permissions);
+        saved = vm.annotation.$create().then(function () {
+          $rootScope.$emit(events.ANNOTATION_CREATED, vm.annotation);
+          updateView();
+          drafts.remove(vm.annotation);
         });
         break;
 
       case 'edit':
-        var updatedModel = angular.copy(domainModel);
+        var updatedModel = angular.copy(vm.annotation);
         updateDomainModel(updatedModel, vm, permissions);
         saved = updatedModel.$update({
           id: updatedModel.id
         }).then(function () {
-          drafts.remove(domainModel);
+          drafts.remove(vm.annotation);
           // Preserve the local tag which is not copied when cloning the model
           // and performing the $update() call.
-          updatedModel.$$tag = domainModel.$$tag;
+          updatedModel.$$tag = vm.annotation.$$tag;
           $rootScope.$emit(events.ANNOTATION_UPDATED, updatedModel);
         });
         break;
@@ -578,7 +569,7 @@ function AnnotationController(
     // creating or editing, we cache that and use the same privacy level the
     // next time they create an annotation.
     // But _don't_ cache it when they change the privacy level of a reply.
-    if (!isReply(domainModel)) {
+    if (!isReply(vm.annotation)) {
       permissions.setDefault(privacy);
     }
     vm.isPrivate = (privacy === 'private');
@@ -589,23 +580,23 @@ function AnnotationController(
   };
 
   vm.target = function() {
-    return domainModel.target;
+    return vm.annotation.target;
   };
 
   vm.updated = function() {
-    return domainModel.updated;
+    return vm.annotation.updated;
   };
 
   vm.user = function() {
-    return domainModel.user;
+    return vm.annotation.user;
   };
 
   vm.username = function() {
-    return persona.username(domainModel.user);
+    return persona.username(vm.annotation.user);
   };
 
   vm.isReply = function () {
-    return isReply(domainModel);
+    return isReply(vm.annotation);
   };
 
   /**

--- a/h/static/scripts/directive/annotation.js
+++ b/h/static/scripts/directive/annotation.js
@@ -536,6 +536,9 @@ function AnnotationController(
           id: updatedModel.id
         }).then(function () {
           drafts.remove(domainModel);
+          // Preserve the local tag which is not copied when cloning the model
+          // and performing the $update() call.
+          updatedModel.$$tag = domainModel.$$tag;
           $rootScope.$emit(events.ANNOTATION_UPDATED, updatedModel);
         });
         break;

--- a/h/static/scripts/directive/markdown.js
+++ b/h/static/scripts/directive/markdown.js
@@ -22,7 +22,6 @@ module.exports = function($sanitize) {
     controller: function () {},
     link: function(scope, elem) {
       var input = elem[0].querySelector('.js-markdown-input');
-      var inputEl = angular.element(input);
       var output = elem[0].querySelector('.js-markdown-preview');
 
       /**
@@ -133,13 +132,12 @@ module.exports = function($sanitize) {
         scope.preview = !scope.preview;
       };
 
-      // React to the changes to the input
       var handleInputChange = debounce(function () {
         scope.$apply(function () {
           scope.onEditText({text: input.value});
         });
       }, 100);
-      inputEl.bind('blur change keyup', handleInputChange);
+      input.addEventListener('input', handleInputChange);
 
       // Re-render the markdown when the view needs updating.
       scope.$watch('text', function () {

--- a/h/static/scripts/directive/test/annotation-test.js
+++ b/h/static/scripts/directive/test/annotation-test.js
@@ -728,7 +728,7 @@ describe('annotation', function() {
       });
     });
 
-    describe('deleteAnnotation() method', function() {
+    describe('#delete()', function() {
       beforeEach(function() {
         fakeAnnotationMapper.deleteAnnotation = sandbox.stub();
       });

--- a/h/static/scripts/directive/test/annotation-test.js
+++ b/h/static/scripts/directive/test/annotation-test.js
@@ -409,7 +409,7 @@ describe('annotation', function() {
       });
     });
 
-    describe('.isHighlight()', function() {
+    describe('#isHighlight()', function() {
       it('returns true for new highlights', function() {
         var annotation = fixtures.newHighlight();
         // We need to define $create because it'll try to call it.
@@ -952,8 +952,8 @@ describe('annotation', function() {
       });
     });
 
-    describe('onGroupFocused()', function() {
-      it('updates domainModel.group if the annotation is new', function () {
+    describe('when the focusd group changes', function() {
+      it('moves new annotations to the focused group', function () {
         var annotation = fixtures.newAnnotation();
         annotation.group = 'old-group-id';
         createDirective(annotation);
@@ -964,7 +964,7 @@ describe('annotation', function() {
         assert.equal(annotation.group, 'new-group-id');
       });
 
-      it('does not update domainModel.group if the annotation is not new',
+      it('does not modify the group of saved annotations',
         function () {
           var annotation = fixtures.oldAnnotation();
           annotation.group = 'old-group-id';
@@ -978,7 +978,6 @@ describe('annotation', function() {
       );
     });
 
-
     describe('reverting edits', function () {
       it('removes the current draft', function() {
         var controller = createDirective(fixtures.defaultAnnotation()).controller;
@@ -989,7 +988,7 @@ describe('annotation', function() {
     });
 
     describe('tag display', function () {
-      it('displays annotation tags', function () {
+      it('displays links to tags on the stream', function () {
         var directive = createDirective({
           id: '1234',
           tags: ['atag']

--- a/h/static/scripts/directive/test/markdown-test.js
+++ b/h/static/scripts/directive/test/markdown-test.js
@@ -181,7 +181,7 @@ describe('markdown', function () {
       });
       var input = inputElement(editor);
       input.value = 'new text';
-      util.sendEvent(input, 'change');
+      util.sendEvent(input, 'input');
       assert.called(onEditText);
       assert.calledWith(onEditText, 'new text');
     });

--- a/h/static/scripts/drafts.js
+++ b/h/static/scripts/drafts.js
@@ -23,11 +23,10 @@ function DraftStore() {
    * Returns true if 'draft' is a draft for a given
    * annotation.
    *
-   * Annotations are matched by ID and annotation instance (for unsaved
-   * annotations which have no ID)
+   * Annotations are matched by ID or local tag.
    */
   function match(draft, model) {
-    return draft.model === model ||
+    return (draft.model.$$tag && model.$$tag === draft.model.$$tag) ||
            (draft.model.id && model.id === draft.model.id);
   }
 

--- a/h/static/scripts/root-thread.js
+++ b/h/static/scripts/root-thread.js
@@ -76,6 +76,7 @@ function RootThread($rootScope, annotationUI, searchFilter, viewFilter) {
   // the Redux store in annotationUI.
   var loadEvents = [events.BEFORE_ANNOTATION_CREATED,
                     events.ANNOTATION_CREATED,
+                    events.ANNOTATION_UPDATED,
                     events.ANNOTATIONS_LOADED];
   loadEvents.forEach(function (event) {
     $rootScope.$on(event, function (event, annotation) {

--- a/h/static/scripts/test/annotation-sync-test.coffee
+++ b/h/static/scripts/test/annotation-sync-test.coffee
@@ -58,20 +58,6 @@ describe 'AnnotationSync', ->
 
       assert.notCalled(channel.call)
 
-  describe '.getAnnotationForTag', ->
-    it 'returns the annotation if present in the cache', ->
-      ann = {id: 1, $$tag: 'tag1'}
-      annSync = createAnnotationSync()
-      annSync.cache['tag1'] = ann
-
-      cached = annSync.getAnnotationForTag('tag1')
-      assert.equal(cached, ann)
-
-    it 'returns null if not present in the cache', ->
-      annSync = createAnnotationSync()
-      cached = annSync.getAnnotationForTag('tag1')
-      assert.isNull(cached)
-
   describe 'channel event handlers', ->
     assertBroadcast = (channelEvent, publishEvent) ->
       it 'broadcasts the "' + publishEvent + '" event over the local event bus', ->

--- a/h/static/scripts/test/annotation-ui-controller-test.js
+++ b/h/static/scripts/test/annotation-ui-controller-test.js
@@ -53,10 +53,7 @@ describe('AnnotationUIController', function () {
   });
 
   it('updates the focused annotations when the focus map changes', function () {
-    annotationUI.focusAnnotations([
-      {$$tag: '1'},
-      {$$tag: '2'},
-    ]);
+    annotationUI.focusAnnotations(['1', '2']);
     assert.deepEqual($scope.focusedAnnotations, { 1: true, 2: true });
   });
 

--- a/h/static/scripts/test/annotation-ui-sync-test.js
+++ b/h/static/scripts/test/annotation-ui-sync-test.js
@@ -10,7 +10,6 @@ describe('AnnotationUISync', function () {
   var publish;
   var fakeBridge;
   var annotationUI;
-  var fakeAnnotationSync;
   var createAnnotationUISync;
   var createChannel = function () {
     return { call: sandbox.stub() };
@@ -43,20 +42,10 @@ describe('AnnotationUISync', function () {
       ]
     };
 
-    fakeAnnotationSync = {
-      getAnnotationForTag: function (tag) {
-        return {
-          id: Number(tag.replace('tag', '')),
-          $$tag: tag,
-        };
-      }
-    };
-
     annotationUI = annotationUIFactory({});
     createAnnotationUISync = function () {
       new AnnotationUISync(
-        $rootScope, fakeWindow, fakeBridge, fakeAnnotationSync,
-        annotationUI
+        $rootScope, fakeWindow, annotationUI, fakeBridge
       );
     };
   }));
@@ -91,12 +80,9 @@ describe('AnnotationUISync', function () {
   describe('on "showAnnotations" event', function () {
     it('updates the annotationUI to include the shown annotations', function () {
       createAnnotationUISync();
+      annotationUI.selectAnnotations = sinon.stub();
       publish('showAnnotations', ['tag1', 'tag2', 'tag3']);
-      assert.deepEqual(annotationUI.getState().selectedAnnotationMap, {
-        1: true,
-        2: true,
-        3: true,
-      });
+      assert.calledWith(annotationUI.selectAnnotations, ['tag1', 'tag2', 'tag3']);
     });
 
     it('triggers a digest', function () {
@@ -127,12 +113,9 @@ describe('AnnotationUISync', function () {
   describe('on "toggleAnnotationSelection" event', function () {
     it('updates the annotationUI to show the provided annotations', function () {
       createAnnotationUISync();
+      annotationUI.toggleSelectedAnnotations = sinon.stub();
       publish('toggleAnnotationSelection', ['tag1', 'tag2', 'tag3']);
-      assert.deepEqual(annotationUI.getState().selectedAnnotationMap, {
-        1: true,
-        2: true,
-        3: true,
-      });
+      assert.calledWith(annotationUI.toggleSelectedAnnotations, ['tag1', 'tag2', 'tag3']);
     });
 
     it('triggers a digest', function () {

--- a/h/static/scripts/test/annotation-ui-test.js
+++ b/h/static/scripts/test/annotation-ui-test.js
@@ -95,22 +95,22 @@ describe('annotationUI', function () {
 
   describe('#focusAnnotations()', function () {
     it('adds the passed annotations to the focusedAnnotationMap', function () {
-      annotationUI.focusAnnotations([{ $$tag: 1 }, { $$tag: 2 }, { $$tag: 3 }]);
+      annotationUI.focusAnnotations([1, 2, 3]);
       assert.deepEqual(annotationUI.getState().focusedAnnotationMap, {
         1: true, 2: true, 3: true
       });
     });
 
     it('replaces any annotations originally in the map', function () {
-      annotationUI.focusAnnotations([{ $$tag: 1 }]);
-      annotationUI.focusAnnotations([{ $$tag: 2 }, { $$tag: 3 }]);
+      annotationUI.focusAnnotations([1]);
+      annotationUI.focusAnnotations([2, 3]);
       assert.deepEqual(annotationUI.getState().focusedAnnotationMap, {
         2: true, 3: true
       });
     });
 
     it('nulls the map if no annotations are focused', function () {
-      annotationUI.focusAnnotations([{$$tag: 1}]);
+      annotationUI.focusAnnotations([1]);
       annotationUI.focusAnnotations([]);
       assert.isNull(annotationUI.getState().focusedAnnotationMap);
     });
@@ -118,7 +118,7 @@ describe('annotationUI', function () {
 
   describe('#hasSelectedAnnotations', function () {
     it('returns true if there are any selected annotations', function () {
-      annotationUI.selectAnnotations([{id: 1}]);
+      annotationUI.selectAnnotations([1]);
       assert.isTrue(annotationUI.hasSelectedAnnotations());
     });
 
@@ -129,12 +129,12 @@ describe('annotationUI', function () {
 
   describe('#isAnnotationSelected', function () {
     it('returns true if the id provided is selected', function () {
-      annotationUI.selectAnnotations([{id: 1}]);
+      annotationUI.selectAnnotations([1]);
       assert.isTrue(annotationUI.isAnnotationSelected(1));
     });
 
     it('returns false if the id provided is not selected', function () {
-      annotationUI.selectAnnotations([{id: 1}]);
+      annotationUI.selectAnnotations([1]);
       assert.isFalse(annotationUI.isAnnotationSelected(2));
     });
 
@@ -145,22 +145,22 @@ describe('annotationUI', function () {
 
   describe('#selectAnnotations()', function () {
     it('adds the passed annotations to the selectedAnnotationMap', function () {
-      annotationUI.selectAnnotations([{ id: 1 }, { id: 2 }, { id: 3 }]);
+      annotationUI.selectAnnotations([1, 2, 3]);
       assert.deepEqual(annotationUI.getState().selectedAnnotationMap, {
         1: true, 2: true, 3: true
       });
     });
 
     it('replaces any annotations originally in the map', function () {
-      annotationUI.selectAnnotations([{ id:1 }]);
-      annotationUI.selectAnnotations([{ id: 2 }, { id: 3 }]);
+      annotationUI.selectAnnotations([1]);
+      annotationUI.selectAnnotations([2, 3]);
       assert.deepEqual(annotationUI.getState().selectedAnnotationMap, {
         2: true, 3: true
       });
     });
 
     it('nulls the map if no annotations are selected', function () {
-      annotationUI.selectAnnotations([{id:1}]);
+      annotationUI.selectAnnotations([1]);
       annotationUI.selectAnnotations([]);
       assert.isNull(annotationUI.getState().selectedAnnotationMap);
     });
@@ -168,45 +168,45 @@ describe('annotationUI', function () {
 
   describe('#toggleSelectedAnnotations()', function () {
     it('adds annotations missing from the selectedAnnotationMap', function () {
-      annotationUI.selectAnnotations([{ id: 1 }, { id: 2}]);
-      annotationUI.toggleSelectedAnnotations([{ id: 3 }, { id: 4 }]);
+      annotationUI.selectAnnotations([1, 2]);
+      annotationUI.toggleSelectedAnnotations([3, 4]);
       assert.deepEqual(annotationUI.getState().selectedAnnotationMap, {
         1: true, 2: true, 3: true, 4: true
       });
     });
 
     it('removes annotations already in the selectedAnnotationMap', function () {
-      annotationUI.selectAnnotations([{id: 1}, {id: 3}]);
-      annotationUI.toggleSelectedAnnotations([{ id: 1 }, { id: 2 }]);
+      annotationUI.selectAnnotations([1, 3]);
+      annotationUI.toggleSelectedAnnotations([1, 2]);
       assert.deepEqual(annotationUI.getState().selectedAnnotationMap, { 2: true, 3: true });
     });
 
     it('nulls the map if no annotations are selected', function () {
-      annotationUI.selectAnnotations([{id: 1}]);
-      annotationUI.toggleSelectedAnnotations([{ id: 1 }]);
+      annotationUI.selectAnnotations([1]);
+      annotationUI.toggleSelectedAnnotations([1]);
       assert.isNull(annotationUI.getState().selectedAnnotationMap);
     });
   });
 
   describe('#removeSelectedAnnotation()', function () {
     it('removes an annotation from the selectedAnnotationMap', function () {
-      annotationUI.selectAnnotations([{id: 1}, {id: 2}, {id: 3}]);
-      annotationUI.removeSelectedAnnotation({ id: 2 });
+      annotationUI.selectAnnotations([1, 2, 3]);
+      annotationUI.removeSelectedAnnotation(2);
       assert.deepEqual(annotationUI.getState().selectedAnnotationMap, {
         1: true, 3: true
       });
     });
 
     it('nulls the map if no annotations are selected', function () {
-      annotationUI.selectAnnotations([{id: 1}]);
-      annotationUI.removeSelectedAnnotation({ id: 1 });
+      annotationUI.selectAnnotations([1]);
+      annotationUI.removeSelectedAnnotation(1);
       assert.isNull(annotationUI.getState().selectedAnnotationMap);
     });
   });
 
   describe('#clearSelectedAnnotations()', function () {
     it('removes all annotations from the selection', function () {
-      annotationUI.selectAnnotations([{id: 1}]);
+      annotationUI.selectAnnotations([1]);
       annotationUI.clearSelectedAnnotations();
       assert.isNull(annotationUI.getState().selectedAnnotationMap);
     });

--- a/h/static/scripts/test/annotation-ui-test.js
+++ b/h/static/scripts/test/annotation-ui-test.js
@@ -49,6 +49,21 @@ describe('annotationUI', function () {
       annotationUI.removeAnnotations([annot]);
       assert.deepEqual(annotationUI.getState().annotations, []);
     });
+
+    it('matches annotations to remove by ID', function () {
+      var annot = annotationFixtures.defaultAnnotation();
+      annotationUI.addAnnotations([annot]);
+      annotationUI.removeAnnotations([{id: annot.id}]);
+      assert.deepEqual(annotationUI.getState().annotations, []);
+    });
+
+    it('matches annotations to remove by tag', function () {
+      var annot = annotationFixtures.defaultAnnotation();
+      annot.$$tag = 'atag';
+      annotationUI.addAnnotations([annot]);
+      annotationUI.removeAnnotations([{$$tag: annot.$$tag}]);
+      assert.deepEqual(annotationUI.getState().annotations, []);
+    });
   });
 
   describe('#clearAnnotations()', function () {

--- a/h/static/scripts/test/drafts-test.js
+++ b/h/static/scripts/test/drafts-test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var draftsService = require('../drafts');
 
 describe('drafts', function () {
@@ -7,7 +9,7 @@ describe('drafts', function () {
     drafts = draftsService();
   });
 
-  describe('.update', function () {
+  describe('#update', function () {
     it('should save changes', function () {
       var model = {id: 'foo'};
       assert.notOk(drafts.get(model));
@@ -31,9 +33,17 @@ describe('drafts', function () {
       drafts.update(modelB, {isPrivate:true, tags:['foo'], text:'bar'});
       assert.equal(drafts.get(modelA).text, 'bar');
     });
+
+    it('should replace drafts with the same tag', function () {
+      var modelA = {$$tag: 'foo'};
+      var modelB = {$$tag: 'foo'};
+      drafts.update(modelA, {isPrivate:true, tags:['foo'], text:'foo'});
+      drafts.update(modelB, {isPrivate:true, tags:['foo'], text:'bar'});
+      assert.equal(drafts.get(modelA).text, 'bar');
+    });
   });
 
-  describe('.remove', function () {
+  describe('#remove', function () {
     it('should remove drafts', function () {
       var model = {id: 'foo'};
       drafts.update(model, {text: 'bar'});
@@ -42,7 +52,7 @@ describe('drafts', function () {
     });
   });
 
-  describe('.unsaved', function () {
+  describe('#unsaved', function () {
     it('should return drafts for unsaved annotations', function () {
       var model = {};
       drafts.update(model, {text: 'bar'});

--- a/h/static/scripts/test/root-thread-test.js
+++ b/h/static/scripts/test/root-thread-test.js
@@ -208,6 +208,7 @@ describe('rootThread', function () {
     }, [
       {event: events.BEFORE_ANNOTATION_CREATED, annotations: annot},
       {event: events.ANNOTATION_CREATED, annotations: annot},
+      {event: events.ANNOTATION_UPDATED, annotations: annot},
       {event: events.ANNOTATIONS_LOADED, annotations: [annot]},
     ]);
 

--- a/h/templates/client/annotation.html
+++ b/h/templates/client/annotation.html
@@ -22,7 +22,7 @@
           target="_blank" ng-if="vm.group() && vm.group().url" href="{{vm.group().url}}">
           <i class="h-icon-group"></i><span class="annotation-header__group-name">{{vm.group().name}}</span>
         </a>
-        <span ng-show="vm.isPrivate"
+        <span ng-show="vm.state().isPrivate"
           title="This annotation is visible only to you.">
           <i class="h-icon-lock"></i><span class="annotation-header__group-name" ng-show="!vm.group().url">Only me</span>
         </span>
@@ -73,8 +73,8 @@
       collapse="vm.collapseBody"
       collapsed-height="400"
       overflow-hysteresis="20"
-      content-data="vm.form.text">
-      <markdown text="vm.form.text"
+      content-data="vm.state().text">
+      <markdown text="vm.state().text"
         on-edit-text="vm.setText(text)"
         read-only="!vm.editing()">
       </markdown>
@@ -84,14 +84,14 @@
 
   <!-- Tags -->
   <div class="annotation-body form-field" ng-if="vm.editing()">
-    <tag-editor tags="vm.form.tags"
+    <tag-editor tags="vm.state().tags"
                 on-edit-tags="vm.setTags(tags)"></tag-editor>
   </div>
 
   <div class="annotation-body u-layout-row tags tags-read-only"
-       ng-if="(vm.canCollapseBody || vm.form.tags.length) && !vm.editing()">
+       ng-if="(vm.canCollapseBody || vm.state().tags.length) && !vm.editing()">
     <ul class="tag-list">
-      <li class="tag-item" ng-repeat="tag in vm.form.tags">
+      <li class="tag-item" ng-repeat="tag in vm.state().tags">
         <a ng-href="{{vm.tagStreamURL(tag)}}" target="_blank">{{tag}}</a>
       </li>
     </ul>
@@ -169,7 +169,7 @@
         <annotation-share-dialog
           group="vm.group()"
           uri="vm.linkInContext"
-          is-private="vm.isPrivate"
+          is-private="vm.state().isPrivate"
           is-open="vm.showShareDialog"
           on-close="vm.showShareDialog = false">
         </annotation-share-dialog>

--- a/h/templates/client/annotation.html
+++ b/h/templates/client/annotation.html
@@ -28,11 +28,11 @@
         </span>
         <i class="h-icon-border-color" ng-show="vm.isHighlight() && !vm.editing()" title="This is a highlight. Click 'edit' to add a note or tag."></i>
         <span class="annotation-citation"
-          ng-bind-html="vm.documentTitle"
+          ng-bind-html="vm.documentMeta().title"
           ng-if="::vm.showDocumentInfo">
         </span>
         <span class="annotation-citation-domain"
-          ng-bind-html="vm.documentDomain"
+          ng-bind-html="vm.documentMeta().domain"
           ng-if="::vm.showDocumentInfo">
         </span>
       </span>
@@ -43,7 +43,7 @@
     <timestamp
       class-name="'annotation-header__timestamp'"
       timestamp="vm.updated()"
-      href="vm.linkHTML"
+      href="vm.links().html"
       ng-if="!vm.editing() && vm.updated()"></timestamp>
   </header>
 
@@ -168,7 +168,7 @@
         </button>
         <annotation-share-dialog
           group="vm.group()"
-          uri="vm.linkInContext"
+          uri="vm.links().incontext"
           is-private="vm.state().isPrivate"
           is-open="vm.showShareDialog"
           on-close="vm.showShareDialog = false">

--- a/h/templates/client/annotation.html
+++ b/h/templates/client/annotation.html
@@ -104,11 +104,7 @@
   <!-- / Tags -->
 
   <footer class="annotation-footer">
-    <div class="annotation-form-actions" ng-if="vm.editing()" ng-switch="vm.action">
-      <button ng-switch-when="delete"
-        ng-click="vm.save()"
-        class="dropdown-menu-btn"
-        aria-label="Delete" h-tooltip><i class="h-icon-check btn-icon"></i></button>
+    <div class="annotation-form-actions" ng-if="vm.editing()">
       <publish-annotation-btn
         class="publish-annotation-btn"
         group="vm.group()"


### PR DESCRIPTION
A lot of state was duplicated in the `<annotation>` component, such as the current unsaved changes, the editor state, the document links and metadata and the annotation object being displayed by the annotation card.

The result of all this was several bugs (https://trello.com/c/fotxgB2S, https://trello.com/c/nRaDXSdL) when that state got out of sync.

This PR is a series of changes that:
 * Remove as much state from `<annotation>` as possible at the moment. All we need is the current saved annotation (`vm.annotation`), the current unsaved changes (stored in the `drafts` service) and whether a save is in progress. From that we can compute everything else that is displayed in the view.
 * Gets us closer towards making annotations immutable objects in the sidebar app. The benefit of this is that all the places that derive something from annotation objects (eg. the domain and title associated with an annotation) can avoid recalculation if the annotation instance has not changed.

Combined, these changes allow a lot of code to be removed from `annotation.js` and many of the tests are made redundant or greatly simplified.

This is a large PR and will make a lot more sense reviewed commit-by-commit. I also expect that we'll want to separate them out into several PRs.