### PR TITLE
Make reply in context links link to thread root

### DIFF
--- a/h/api/models/elastic.py
+++ b/h/api/models/elastic.py
@@ -186,6 +186,21 @@ class Annotation(annotation.Annotation):
             return ""
 
     @property
+    def thread_root_id(self):
+        """
+        Return the ID of the root annotation of this annotation's thread.
+
+        Return the ID of the root annotation of the thread to which this
+        annotation belongs. May be this annotation's own ID if it is the root
+        annotation of its thread.
+
+        """
+        if self.references:
+            return self.references[0]
+        else:
+            return self.id
+
+    @property
     def parent_id(self):
         """
         Return the id of the thread parent of this annotation, if it exists.

--- a/h/links.py
+++ b/h/links.py
@@ -15,15 +15,11 @@ def html_link(request, annotation):
 
 def incontext_link(request, annotation):
     """Generate a link to an annotation on the page where it was made."""
-    is_reply = bool(annotation.references)
-    if is_reply:
-        return None
-
     bouncer_url = request.registry.settings.get('h.bouncer_url')
     if not bouncer_url:
         return None
 
-    link = urlparse.urljoin(bouncer_url, annotation.id)
+    link = urlparse.urljoin(bouncer_url, annotation.thread_root_id)
     uri = annotation.target_uri
     if uri.startswith(('http://', 'https://')):
         # We can't use urljoin here, because if it detects the second argument

--- a/tests/h/api/models/elastic_test.py
+++ b/tests/h/api/models/elastic_test.py
@@ -179,6 +179,27 @@ class TestAnnotation(object):
         annotation = Annotation(target=[{'source': 'target link'}])
         assert annotation.target_links == ['target link']
 
+    def test_thread_root_id_returns_id_if_no_references(self):
+        assert Annotation(id='test_id').thread_root_id == 'test_id'
+
+    def test_thread_root_id_returns_id_if_references_empty(self):
+        assert Annotation(id='test_id', references=[]).thread_root_id == (
+            'test_id')
+
+    def test_thread_root_id_returns_reference_if_only_one_reference(self):
+        annotation = Annotation(id='test_id',
+                                references=['AVMG6tocH9ZO4OKSk1WS'])
+
+        assert annotation.thread_root_id == 'AVMG6tocH9ZO4OKSk1WS'
+
+    def test_thread_root_id_returns_first_reference_if_many_references(self):
+        annotation = Annotation(id='test_id',
+                                references=['AVMG6tocH9ZO4OKSk1WS',
+                                            'AVMG6tocH9ZO4OKSk1WSaa',
+                                            'Qe7fpc5ZRgWy0RSHEP9UNg'])
+
+        assert annotation.thread_root_id == 'AVMG6tocH9ZO4OKSk1WS'
+
     def test_parent_id_returns_none_if_no_references(self):
         annotation = Annotation()
         assert annotation.parent_id is None

--- a/tests/h/links_test.py
+++ b/tests/h/links_test.py
@@ -7,7 +7,7 @@ from h import links
 
 class FakeAnnotation(object):
     def __init__(self):
-        self.id = '123'
+        self.thread_root_id = '123'
         self.references = None
         self.target_uri = 'http://example.com/foo/bar'
         self.document = None
@@ -29,15 +29,6 @@ def test_incontext_link(pyramid_request):
     link = links.incontext_link(pyramid_request, annotation)
 
     assert link == 'https://hyp.is/123/example.com/foo/bar'
-
-
-def test_incontext_link_is_none_for_replies(pyramid_request):
-    annotation = FakeAnnotation()
-    annotation.references = ['parent']
-
-    link = links.incontext_link(pyramid_request, annotation)
-
-    assert link is None
 
 
 @pytest.mark.parametrize('target_uri,expected', [


### PR DESCRIPTION
Make the "in context" links on reply annotation cards (the links used in
the "Share" buttons on the replies) be bouncer direct links to the
thread root annotation of the reply's thread, instead of links to the
reply's standalone page.