### PR TITLE
Add thread_root_id property to Postgres annotation model

### DIFF
--- a/h/api/models/annotation.py
+++ b/h/api/models/annotation.py
@@ -107,6 +107,21 @@ class Annotation(Base, mixins.Timestamps):
         return self._target_uri_normalized
 
     @property
+    def thread_root_id(self):
+        """
+        Return the id of the root annotation of this annotation's thread.
+
+        Return the id of the root annotation of the thread to which this
+        annotation belongs. May be this annotation's own id if it is the root
+        annotation of its thread.
+
+        """
+        if self.references:
+            return self.references[0]
+        else:
+            return self.id
+
+    @property
     def parent_id(self):
         """
         Return the ID of the annotation that this annotation is a reply to.

--- a/tests/h/api/models/annotation_test.py
+++ b/tests/h/api/models/annotation_test.py
@@ -32,6 +32,31 @@ def test_document_not_found(annotation, db_session):
     assert annotation.document is None
 
 
+def test_thread_root_id_returns_id_if_no_references():
+    assert Annotation(id='test_id').thread_root_id == 'test_id'
+
+
+def test_thread_root_id_returns_id_if_references_empty():
+    assert Annotation(id='test_id', references=[]).thread_root_id == (
+        'test_id')
+
+
+def test_thread_root_id_returns_reference_if_only_one_reference():
+    annotation = Annotation(id='test_id',
+                            references=['AVMG6tocH9ZO4OKSk1WS'])
+
+    assert annotation.thread_root_id == 'AVMG6tocH9ZO4OKSk1WS'
+
+
+def test_thread_root_id_returns_first_reference_if_many_references():
+    annotation = Annotation(id='test_id',
+                            references=['AVMG6tocH9ZO4OKSk1WS',
+                                        'AVMG6tocH9ZO4OKSk1WSaa',
+                                        'Qe7fpc5ZRgWy0RSHEP9UNg'])
+
+    assert annotation.thread_root_id == 'AVMG6tocH9ZO4OKSk1WS'
+
+
 def test_parent_id_of_direct_reply():
     ann = Annotation(references=['parent_id'])
 


### PR DESCRIPTION
Copy the thread_root_id property from the Elastic to the Postgres
annotation model. Fixes a crash in incontext_link() because it now uses
Postgres not Elastic annotations.