### PR TITLE
Fix #2965 (1/N) - Fix redundant calls to onEditText() in markdown editor component

### DIFF
--- a/h/static/scripts/directive/markdown.js
+++ b/h/static/scripts/directive/markdown.js
@@ -22,7 +22,6 @@ module.exports = function($sanitize) {
     controller: function () {},
     link: function(scope, elem) {
       var input = elem[0].querySelector('.js-markdown-input');
-      var inputEl = angular.element(input);
       var output = elem[0].querySelector('.js-markdown-preview');
 
       /**
@@ -133,13 +132,12 @@ module.exports = function($sanitize) {
         scope.preview = !scope.preview;
       };
 
-      // React to the changes to the input
       var handleInputChange = debounce(function () {
         scope.$apply(function () {
           scope.onEditText({text: input.value});
         });
       }, 100);
-      inputEl.bind('blur change keyup', handleInputChange);
+      input.addEventListener('input', handleInputChange);
 
       // Re-render the markdown when the view needs updating.
       scope.$watch('text', function () {

--- a/h/static/scripts/directive/test/markdown-test.js
+++ b/h/static/scripts/directive/test/markdown-test.js
@@ -181,7 +181,7 @@ describe('markdown', function () {
       });
       var input = inputElement(editor);
       input.value = 'new text';
-      util.sendEvent(input, 'change');
+      util.sendEvent(input, 'input');
       assert.called(onEditText);
       assert.calledWith(onEditText, 'new text');
     });


### PR DESCRIPTION
_This is the first in a set of PRs to fix #2965 and #3380 which are ultimately caused by certain state for annotations being duplicated and getting out of sync._

This fixes an issue where onEditText() would be called unnecessarily
when the markdown editor lost focus.

Simplify the code by just listening for the 'input' event, which all our
target browsers support.