### PR TITLE
Fix #2965 (2/N) - Remove unused alternative delete button from <annotation> component

### DIFF
--- a/h/static/scripts/directive/test/annotation-test.js
+++ b/h/static/scripts/directive/test/annotation-test.js
@@ -728,7 +728,7 @@ describe('annotation', function() {
       });
     });
 
-    describe('deleteAnnotation() method', function() {
+    describe('#delete()', function() {
       beforeEach(function() {
         fakeAnnotationMapper.deleteAnnotation = sandbox.stub();
       });

--- a/h/templates/client/annotation.html
+++ b/h/templates/client/annotation.html
@@ -104,11 +104,7 @@
   <!-- / Tags -->
 
   <footer class="annotation-footer">
-    <div class="annotation-form-actions" ng-if="vm.editing()" ng-switch="vm.action">
-      <button ng-switch-when="delete"
-        ng-click="vm.save()"
-        class="dropdown-menu-btn"
-        aria-label="Delete" h-tooltip><i class="h-icon-check btn-icon"></i></button>
+    <div class="annotation-form-actions" ng-if="vm.editing()">
       <publish-annotation-btn
         class="publish-annotation-btn"
         group="vm.group()"


### PR DESCRIPTION
Remove an alternative annotation deletion button which was part of an
older UI for annotation cards and is no longer used.