### PR TITLE
Fix #2965 (3/N) - Match annotations by ID or tag in drafts service and when removing annotations

### DIFF
--- a/h/static/scripts/annotation-ui.js
+++ b/h/static/scripts/annotation-ui.js
@@ -77,15 +77,25 @@ var types = {
   SET_SORT_KEY: 'SET_SORT_KEY',
 };
 
+/**
+ * Return a copy of `current` with all matching annotations in `annotations`
+ * removed.
+ */
 function excludeAnnotations(current, annotations) {
-  var idsAndTags = annotations.reduce(function (map, annot) {
-    var id = annot.id || annot.$$tag;
-    map[id] = true;
-    return map;
-  }, {});
+  var ids = {};
+  var tags = {};
+  annotations.forEach(function (annot) {
+    if (annot.id) {
+      ids[annot.id] = true;
+    }
+    if (annot.$$tag) {
+      tags[annot.$$tag] = true;
+    }
+  });
   return current.filter(function (annot) {
-    var id = annot.id || annot.$$tag;
-    return !idsAndTags[id];
+    var shouldRemove = (annot.id && (annot.id in ids)) ||
+                       (annot.$$tag && (annot.$$tag in tags));
+    return !shouldRemove;
   });
 }
 

--- a/h/static/scripts/drafts.js
+++ b/h/static/scripts/drafts.js
@@ -23,11 +23,10 @@ function DraftStore() {
    * Returns true if 'draft' is a draft for a given
    * annotation.
    *
-   * Annotations are matched by ID and annotation instance (for unsaved
-   * annotations which have no ID)
+   * Annotations are matched by ID or local tag.
    */
   function match(draft, model) {
-    return draft.model === model ||
+    return (draft.model.$$tag && model.$$tag === draft.model.$$tag) ||
            (draft.model.id && model.id === draft.model.id);
   }
 

--- a/h/static/scripts/test/annotation-ui-test.js
+++ b/h/static/scripts/test/annotation-ui-test.js
@@ -1,10 +1,19 @@
 'use strict';
 
+var immutable = require('seamless-immutable');
+
 var annotationUIFactory = require('../annotation-ui');
-
 var annotationFixtures = require('./annotation-fixtures');
-
 var unroll = require('./util').unroll;
+
+var defaultAnnotation = annotationFixtures.defaultAnnotation;
+
+var fixtures = immutable({
+  pair: [
+    Object.assign(defaultAnnotation(), {id: 1, $$tag: 't1'}),
+    Object.assign(defaultAnnotation(), {id: 2, $$tag: 't2'}),
+  ],
+});
 
 describe('annotationUI', function () {
   var annotationUI;
@@ -36,7 +45,7 @@ describe('annotationUI', function () {
 
   describe('#addAnnotations()', function () {
     it('adds annotations to the current state', function () {
-      var annot = annotationFixtures.defaultAnnotation();
+      var annot = defaultAnnotation();
       annotationUI.addAnnotations([annot]);
       assert.deepEqual(annotationUI.getState().annotations, [annot]);
     });
@@ -44,16 +53,28 @@ describe('annotationUI', function () {
 
   describe('#removeAnnotations()', function () {
     it('removes annotations from the current state', function () {
-      var annot = annotationFixtures.defaultAnnotation();
+      var annot = defaultAnnotation();
       annotationUI.addAnnotations([annot]);
       annotationUI.removeAnnotations([annot]);
       assert.deepEqual(annotationUI.getState().annotations, []);
+    });
+
+    it('matches annotations to remove by ID', function () {
+      annotationUI.addAnnotations(fixtures.pair);
+      annotationUI.removeAnnotations([{id: fixtures.pair[0].id}]);
+      assert.deepEqual(annotationUI.getState().annotations, [fixtures.pair[1]]);
+    });
+
+    it('matches annotations to remove by tag', function () {
+      annotationUI.addAnnotations(fixtures.pair);
+      annotationUI.removeAnnotations([{$$tag: fixtures.pair[0].$$tag}]);
+      assert.deepEqual(annotationUI.getState().annotations, [fixtures.pair[1]]);
     });
   });
 
   describe('#clearAnnotations()', function () {
     it('removes all annotations', function () {
-      var annot = annotationFixtures.defaultAnnotation();
+      var annot = defaultAnnotation();
       annotationUI.addAnnotations([annot]);
       annotationUI.clearAnnotations();
       assert.deepEqual(annotationUI.getState().annotations, []);

--- a/h/static/scripts/test/drafts-test.js
+++ b/h/static/scripts/test/drafts-test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var draftsService = require('../drafts');
 
 describe('drafts', function () {
@@ -7,7 +9,7 @@ describe('drafts', function () {
     drafts = draftsService();
   });
 
-  describe('.update', function () {
+  describe('#update', function () {
     it('should save changes', function () {
       var model = {id: 'foo'};
       assert.notOk(drafts.get(model));
@@ -31,9 +33,17 @@ describe('drafts', function () {
       drafts.update(modelB, {isPrivate:true, tags:['foo'], text:'bar'});
       assert.equal(drafts.get(modelA).text, 'bar');
     });
+
+    it('should replace drafts with the same tag', function () {
+      var modelA = {$$tag: 'foo'};
+      var modelB = {$$tag: 'foo'};
+      drafts.update(modelA, {isPrivate:true, tags:['foo'], text:'foo'});
+      drafts.update(modelB, {isPrivate:true, tags:['foo'], text:'bar'});
+      assert.equal(drafts.get(modelA).text, 'bar');
+    });
   });
 
-  describe('.remove', function () {
+  describe('#remove', function () {
     it('should remove drafts', function () {
       var model = {id: 'foo'};
       drafts.update(model, {text: 'bar'});
@@ -42,7 +52,7 @@ describe('drafts', function () {
     });
   });
 
-  describe('.unsaved', function () {
+  describe('#unsaved', function () {
     it('should return drafts for unsaved annotations', function () {
       var model = {};
       drafts.update(model, {text: 'bar'});


### PR DESCRIPTION
This is the first in a set of PRs which fixes https://github.com/hypothesis/h/issues/2965 and simplifies `annotation.js` by storing and updating annotation objects in a way that fits the standard architecture for apps using Redux: 

1. Annotations become plain, immutable objects which reflect the saved version of the annotation on the server or the initial version of the annotation received from Annotator (for new annotations)
2. The annotation editor derives its state from only:
 - The saved/new annotation
 - The current draft for that annotation (if it is being edited) and
 - A flag that indicates whether the annotation is currently being saved.
3. When an annotation is created or updated on the server, the local instance is replaced with the newly saved version and any local-only properties (eg. whether the annotation was successfully anchored) are copied across from the previous object. The code was already partially doing step (3) but in an incomplete way.

In order to do this, we need to be able to match annotations by ID rather than instance in a few places. Annotations have two IDs - a local tag which is assigned to all annotations when they are sent across the bridge between the `<iframe>` and the page and an ID which is assigned by the server.

Previously we were matching annotations by reference equality or by server-assigned ID. Instead we need to match them by server ID or by local tag. Matching by local tag is needed for new annotations which do not have a server-assigned ID yet.