### PR TITLE
Prevent long URLs in quotes and bodies causing overflow

### DIFF
--- a/h/static/styles/annotation-thread.scss
+++ b/h/static/styles/annotation-thread.scss
@@ -39,6 +39,9 @@ li:first-child .annotation-thread--top-reply {
 
 .annotation-thread__content {
   flex-grow: 1;
+
+  // Prevent annotation content from overflowing the container
+  max-width: 100%;
 }
 
 // Darken expand/collapse toggle when an annotation is hovered. This is only

--- a/h/static/styles/annotation.scss
+++ b/h/static/styles/annotation.scss
@@ -190,6 +190,9 @@ $annotation-card-left-padding: 10px;
 
 .annotation-quote {
   @include quote;
+
+  // Prevent long URLs etc. in quote causing overflow
+  overflow-wrap: break-word;
 }
 
 .annotation-citation-domain {

--- a/h/static/styles/markdown.scss
+++ b/h/static/styles/markdown.scss
@@ -46,6 +46,9 @@
 
   cursor: text;
 
+  // Prevent long URLs etc. in body causing overflow
+  overflow-wrap: break-word;
+
   // Margin between bottom of ascent of username and top of
   // x-height of annotation-body should be ~15px.
   // Remove additional margin-top added by the first p within


### PR DESCRIPTION
Set a maximum width on the annotation content to prevent it overflowing
the card and set `overflow-wrap` on annotation quotes and bodies so that
long words without any natural breakpoints are broken in the middle if
necessary to prevent overflow.

Fixes #3421