### PR TITLE
Trigger Angular digest cycle if necessary after Redux action dispatch

### DIFF
--- a/h/static/scripts/annotation-ui-sync.js
+++ b/h/static/scripts/annotation-ui-sync.js
@@ -49,20 +49,10 @@ function AnnotationUISync($rootScope, $window, bridge, annotationSync,
     }
   };
 
-  // Because the channel events are all outside of the angular framework we
-  // need to inform Angular that it needs to re-check it's state and re-draw
-  // any UI that may have been affected by the handlers.
-  var ensureDigest = function (fn) {
-    return function () {
-      fn.apply(this, arguments);
-      $rootScope.$digest();
-    };
-  };
-
   for (var channel in channelListeners) {
     if (Object.prototype.hasOwnProperty.call(channelListeners, channel)) {
       var listener = channelListeners[channel];
-      bridge.on(channel, ensureDigest(listener));
+      bridge.on(channel, listener);
     }
   }
 

--- a/h/static/scripts/annotation-ui.js
+++ b/h/static/scripts/annotation-ui.js
@@ -139,16 +139,43 @@ function reducer(state, action) {
 }
 
 /**
+ * Redux middleware which triggers an Angular change-detection cycle
+ * if no cycle is currently in progress.
+ *
+ * This ensures that Angular UI components are updated after the UI
+ * state changes in response to external inputs (eg. WebSocket messages,
+ * messages arriving from other frames in the page, async network responses).
+ *
+ * See http://redux.js.org/docs/advanced/Middleware.html
+ */
+function angularDigestMiddleware($rootScope) {
+  return function (next) {
+    return function (action) {
+      next(action);
+
+      // '$$phase' is set if Angular is in the middle of a digest cycle already
+      if (!$rootScope.$$phase) {
+        // $applyAsync() is similar to $apply() but provides debouncing.
+        // See http://stackoverflow.com/questions/30789177
+        $rootScope.$applyAsync(function () {});
+      }
+    };
+  };
+}
+
+/**
  * Stores the UI state of the annotator in connected clients.
  *
  * This includes:
  * - The IDs of annotations that are currently selected or focused
  * - The state of the bucket bar
- *
  */
 // @ngInject
-module.exports = function (settings) {
-  var store = redux.createStore(reducer, initialState(settings));
+module.exports = function ($rootScope, settings) {
+  var enhancer = redux.applyMiddleware(
+    angularDigestMiddleware.bind(null, $rootScope)
+  );
+  var store = redux.createStore(reducer, initialState(settings), enhancer);
 
   function select(annotations) {
     store.dispatch({

--- a/h/static/scripts/streamer.js
+++ b/h/static/scripts/streamer.js
@@ -128,9 +128,12 @@ function connect($rootScope, annotationMapper, groups, session, settings) {
   });
 
   socket.on('message', function (event) {
-    // wrap message dispatches in $rootScope.$apply() so that
+    // Wrap message dispatches in $rootScope.$apply() so that
     // scope watches on app state affected by the received message
     // are updated
+    //
+    // Note: The use of $apply() here will no longer be needed once session
+    // state is moved to the Redux store in `annotationUI`.
     $rootScope.$apply(function () {
       var message = JSON.parse(event.data);
       if (!message) {

--- a/h/static/scripts/test/annotation-mapper-test.js
+++ b/h/static/scripts/test/annotation-mapper-test.js
@@ -2,7 +2,6 @@
 
 var angular = require('angular');
 
-var annotationUIFactory = require('../annotation-ui');
 var events = require('../events');
 
 describe('annotationMapper', function() {
@@ -16,16 +15,17 @@ describe('annotationMapper', function() {
     fakeStore = {
       AnnotationResource: sandbox.stub().returns({}),
     };
-    annotationUI = annotationUIFactory({});
     angular.module('app', [])
       .service('annotationMapper', require('../annotation-mapper'))
-      .value('annotationUI', annotationUI)
+      .service('annotationUI', require('../annotation-ui'))
+      .value('settings', {})
       .value('store', fakeStore);
     angular.mock.module('app');
 
-    angular.mock.inject(function (_$rootScope_, _annotationMapper_) {
+    angular.mock.inject(function (_$rootScope_, _annotationUI_, _annotationMapper_) {
       $rootScope = _$rootScope_;
       annotationMapper = _annotationMapper_;
+      annotationUI = _annotationUI_;
     });
   });
 

--- a/h/static/scripts/test/annotation-ui-controller-test.js
+++ b/h/static/scripts/test/annotation-ui-controller-test.js
@@ -24,7 +24,7 @@ describe('AnnotationUIController', function () {
     $scope = $rootScope.$new();
     $scope.search = {};
 
-    annotationUI = annotationUIFactory({});
+    annotationUI = annotationUIFactory($rootScope, {});
 
     $controller('AnnotationUIController', {
       $scope: $scope,

--- a/h/static/scripts/test/annotation-ui-sync-test.js
+++ b/h/static/scripts/test/annotation-ui-sync-test.js
@@ -52,7 +52,7 @@ describe('AnnotationUISync', function () {
       }
     };
 
-    annotationUI = annotationUIFactory({});
+    annotationUI = annotationUIFactory($rootScope, {});
     createAnnotationUISync = function () {
       new AnnotationUISync(
         $rootScope, fakeWindow, fakeBridge, fakeAnnotationSync,

--- a/h/static/scripts/test/annotation-ui-sync-test.js
+++ b/h/static/scripts/test/annotation-ui-sync-test.js
@@ -6,7 +6,6 @@ var annotationUIFactory = require('../annotation-ui');
 
 describe('AnnotationUISync', function () {
   var sandbox = sinon.sandbox.create();
-  var $digest;
   var publish;
   var fakeBridge;
   var annotationUI;
@@ -24,7 +23,6 @@ describe('AnnotationUISync', function () {
 
   beforeEach(angular.mock.module('h'));
   beforeEach(angular.mock.inject(function (AnnotationUISync, $rootScope) {
-    $digest = sandbox.stub($rootScope, '$digest');
     var listeners = {};
     publish = function (method) {
       var args = [].slice.apply(arguments);
@@ -98,12 +96,6 @@ describe('AnnotationUISync', function () {
         3: true,
       });
     });
-
-    it('triggers a digest', function () {
-      createAnnotationUISync();
-      publish('showAnnotations', ['tag1', 'tag2', 'tag3']);
-      assert.called($digest);
-    });
   });
 
   describe('on "focusAnnotations" event', function () {
@@ -116,12 +108,6 @@ describe('AnnotationUISync', function () {
         tag3: true,
       });
     });
-
-    it('triggers a digest', function () {
-      createAnnotationUISync();
-      publish('focusAnnotations', ['tag1', 'tag2', 'tag3']);
-      assert.called($digest);
-    });
   });
 
   describe('on "toggleAnnotationSelection" event', function () {
@@ -133,12 +119,6 @@ describe('AnnotationUISync', function () {
         2: true,
         3: true,
       });
-    });
-
-    it('triggers a digest', function () {
-      createAnnotationUISync();
-      publish('toggleAnnotationSelection', ['tag1', 'tag2', 'tag3']);
-      assert.called($digest);
     });
   });
 
@@ -153,12 +133,6 @@ describe('AnnotationUISync', function () {
       createAnnotationUISync();
       publish('setVisibleHighlights', true);
       assert.calledWith(fakeBridge.call, 'setVisibleHighlights', true);
-    });
-
-    it('triggers a digest of the application state', function () {
-      createAnnotationUISync();
-      publish('setVisibleHighlights', true);
-      assert.called($digest);
     });
   });
 });

--- a/h/static/scripts/test/annotation-ui-test.js
+++ b/h/static/scripts/test/annotation-ui-test.js
@@ -8,9 +8,11 @@ var unroll = require('./util').unroll;
 
 describe('annotationUI', function () {
   var annotationUI;
+  var fakeRootScope;
 
   beforeEach(function () {
-    annotationUI = annotationUIFactory({});
+    fakeRootScope = {$applyAsync: sinon.stub()};
+    annotationUI = annotationUIFactory(fakeRootScope, {});
   });
 
   describe('initialization', function () {
@@ -20,14 +22,14 @@ describe('annotationUI', function () {
     });
 
     it('sets the selection when settings.annotations is set', function () {
-      annotationUI = annotationUIFactory({annotations: 'testid'});
+      annotationUI = annotationUIFactory(fakeRootScope, {annotations: 'testid'});
       assert.deepEqual(annotationUI.getState().selectedAnnotationMap, {
         testid: true,
       });
     });
 
     it('expands the selected annotations when settings.annotations is set', function () {
-      annotationUI = annotationUIFactory({annotations: 'testid'});
+      annotationUI = annotationUIFactory(fakeRootScope, {annotations: 'testid'});
       assert.deepEqual(annotationUI.getState().expanded, {
         testid: true,
       });

--- a/h/static/scripts/test/widget-controller-test.js
+++ b/h/static/scripts/test/widget-controller-test.js
@@ -5,7 +5,6 @@ var inherits = require('inherits');
 var proxyquire = require('proxyquire');
 var EventEmitter = require('tiny-emitter');
 
-var annotationUIFactory = require('../annotation-ui');
 var events = require('../events');
 var noCallThru = require('./util').noCallThru;
 
@@ -65,6 +64,7 @@ describe('WidgetController', function () {
 
   before(function () {
     angular.module('h', [])
+      .service('annotationUI', require('../annotation-ui'))
       .controller('WidgetController', proxyquire('../widget-controller',
         noCallThru({
           angular: angular,
@@ -83,8 +83,6 @@ describe('WidgetController', function () {
       loadAnnotations: sandbox.spy(),
       unloadAnnotations: sandbox.spy()
     };
-
-    annotationUI = annotationUIFactory({});
 
     fakeCrossFrame = {
       call: sinon.stub(),
@@ -111,9 +109,7 @@ describe('WidgetController', function () {
 
     fakeRootThread = new FakeRootThread();
 
-    fakeSettings = {
-      annotations: 'test',
-    };
+    fakeSettings = {};
 
     fakeStore = {
       SearchResource: {},
@@ -121,7 +117,6 @@ describe('WidgetController', function () {
 
     $provide.value('VirtualThreadList', FakeVirtualThreadList);
     $provide.value('annotationMapper', fakeAnnotationMapper);
-    $provide.value('annotationUI', annotationUI);
     $provide.value('crossframe', fakeCrossFrame);
     $provide.value('drafts', fakeDrafts);
     $provide.value('rootThread', fakeRootThread);
@@ -132,9 +127,10 @@ describe('WidgetController', function () {
     $provide.value('settings', fakeSettings);
   }));
 
-  beforeEach(angular.mock.inject(function ($controller, _$rootScope_) {
+  beforeEach(angular.mock.inject(function ($controller, _annotationUI_, _$rootScope_) {
     $rootScope = _$rootScope_;
     $scope = $rootScope.$new();
+    annotationUI = _annotationUI_;
     viewer = $controller('WidgetController', {$scope: $scope});
   }));
 
@@ -353,6 +349,9 @@ describe('WidgetController', function () {
           searchUris: [],
         }
       ];
+
+      // There is a direct-linked annotation
+      fakeSettings.annotations = 'test';
     });
 
     it('displays a message if the selection is unavailable', function () {


### PR DESCRIPTION
In various places where the program receives external inputs (WebSocket messages, messages from other iframes, async promises being resolved) we need to trigger an Angular digest cycle explicitly in order to sync the UI with the app state after the input is processed.

Since most app state changes, including all those relating to the set of loaded annotations and the current selection, now go through Redux, we can use its [middleware functionality](http://redux.js.org/docs/advanced/Middleware.html) for adding logic around state changes to put this in one place, saving the need to sprinkle `$apply` calls and inject `$rootScope` in places that receive external inputs.

We cannot rely on this in the WebSocket code yet because WS messages can update session state which is not yet stored in Redux, but I have added a note that we should remove the `$apply` calls there once it is.