### PR TITLE
Ensure that we close transient streamer DB sessions

### DIFF
--- a/h/streamer/messages.py
+++ b/h/streamer/messages.py
@@ -84,6 +84,12 @@ def handle_message(message, topic_handlers):
         if not socket.terminated:
             socket.send(json.dumps(reply))
 
+        # Ensure that we aren't holding onto any database connections.
+        #
+        # TODO: We really shouldn't be using socket.request.db at all, but
+        # instead using the single session created by process_work_queue.
+        socket.request.db.close()
+
 
 def handle_annotation_event(message, socket):
     """

--- a/h/streamer/websocket.py
+++ b/h/streamer/websocket.py
@@ -82,7 +82,12 @@ def handle_message(message):
         log.exception("Parsing filter: %s", data)
         socket.close()
         raise
-
+    finally:
+        # Ensure that we aren't holding onto any database connections.
+        #
+        # TODO: We really shouldn't be using socket.request.db at all, but
+        # instead using the single session created by process_work_queue.
+        socket.request.db.close()
 
 def _expand_clauses(request, payload):
     for clause in payload['clauses']:

--- a/tests/h/streamer/messages_test.py
+++ b/tests/h/streamer/messages_test.py
@@ -22,7 +22,7 @@ class FakeSocket(object):
         self.send = mock.MagicMock()
         # Each fake socket needs its own request, so can't use the
         # pyramid_request fixture.
-        self.request = DummyRequest(db=mock.sentinel.db_session)
+        self.request = DummyRequest(db=mock.MagicMock())
         apply_request_extensions(self.request)
 
 


### PR DESCRIPTION
Accessing `socket.request.db` inside a streamer message handler is problematic, as the new session will grab a connection from the engine connection pool and potentially not return it.

The longer-term fix here is to ensure that all database access is mediated by the session created by `process_work_queue` in `h/streamer/streamer.py`, but this is a temporary hack to ensure that we don't exhaust the connection pool when processing lots of websocket messages.