### PR TITLE
Centralise matcher objects in tests/common/matchers.py

### DIFF
--- a/tests/common/matchers.py
+++ b/tests/common/matchers.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+
+"""
+Matchers for use in tests.
+
+This module contains objects which can be used to write tests which are easier
+to read, especially when using assertions against :py:class:`mock.Mock`
+objects. Each matcher defines an __eq__ method, allowing instances of these
+matchers to be used wherever you would usually pass a plain value.
+
+For example, imagine you wanted to ensure that the `set_value` method of the
+`foo` mock object was called exactly once with an integer. Previously you
+would have to do something like:
+
+    assert foo.set_value.call_count == 1
+    assert isinstance(foo.set_value.call_args[0][0], int)
+
+By using the `instance_of` matcher you can simply write:
+
+    foo.set_value.assert_called_once_with(matchers.instance_of(int))
+
+As a bonus, the second test will print substantially more useful debugging
+output if it fails, e.g.
+
+    E       AssertionError: Expected call: set_value(<instance of <type 'int'>>)
+    E       Actual call: set_value('a string')
+
+"""
+
+
+class instance_of(object):
+    """An object __eq__ to any object which is an instance of `type_`."""
+
+    def __init__(self, type_):
+        self.type = type_
+
+    def __eq__(self, other):
+        return isinstance(other, self.type)
+
+    def __repr__(self):
+        return '<instance of {!r}>'.format(self.type)
+
+
+class iterable_with(object):
+    """An object __eq__ to any iterable which yields `items`."""
+
+    def __init__(self, items):
+        self.items = items
+
+    def __eq__(self, other):
+        return list(other) == self.items
+
+    def __repr__(self):
+        return '<iterable with {!r}>'.format(self.items)
+
+
+class mapping_containing(object):
+    """An object __eq__ to any mapping with the passed `key`."""
+    def __init__(self, key):
+        self.key = key
+
+    def __eq__(self, other):
+        try:
+            other[self.key]
+        except (TypeError, KeyError):
+            return False
+        else:
+            return True
+
+    def __repr__(self):
+        return '<mapping containing {!r}>'.format(self.key)

--- a/tests/h/api/search/core_test.py
+++ b/tests/h/api/search/core_test.py
@@ -115,10 +115,12 @@ def test_default_querybuilder_passes_private_to_AuthFilter(private, query, pyram
     'UriFilter',
     'GroupFilter'
 ])
-def test_default_querybuilder_includes_default_filters(filter_type, pyramid_request):
+def test_default_querybuilder_includes_default_filters(filter_type, matchers, pyramid_request):
+    from h.api.search import query
     builder = core.default_querybuilder(pyramid_request)
+    type_ = getattr(query, filter_type)
 
-    assert instance_of_type(filter_type) in builder.filters
+    assert matchers.instance_of(type_) in builder.filters
 
 
 def test_default_querybuilder_includes_registered_filters(pyramid_request):
@@ -136,10 +138,12 @@ def test_default_querybuilder_includes_registered_filters(pyramid_request):
     'AnyMatcher',
     'TagsMatcher',
 ])
-def test_default_querybuilder_includes_default_matchers(matcher_type, pyramid_request):
+def test_default_querybuilder_includes_default_matchers(matchers, matcher_type, pyramid_request):
+    from h.api.search import query
     builder = core.default_querybuilder(pyramid_request)
+    type_ = getattr(query, matcher_type)
 
-    assert instance_of_type(matcher_type) in builder.matchers
+    assert matchers.instance_of(type_) in builder.matchers
 
 
 def test_default_querybuilder_includes_registered_matchers(pyramid_request):
@@ -151,17 +155,6 @@ def test_default_querybuilder_includes_registered_matchers(pyramid_request):
 
     matcher_factory.assert_called_once_with(pyramid_request)
     assert mock.sentinel.MY_MATCHER in builder.matchers
-
-
-class instance_of_type(object):
-    def __init__(self, typename):
-        self.typename = typename
-
-    def __eq__(self, other):
-        return type(other).__name__ == self.typename
-
-    def __repr__(self):
-        return '<matcher for instance of type "{}">'.format(self.typename)
 
 
 def dummy_search_results(start=1, count=0, name='annotation'):

--- a/tests/h/api/search/index_test.py
+++ b/tests/h/api/search/index_test.py
@@ -12,14 +12,6 @@ from h.api.search import client
 from h.api.search import index
 
 
-class GeneratorEquals(object):
-    def __init__(self, items):
-        self.items = items
-
-    def __eq__(self, other):
-        return list(other) == self.items
-
-
 @pytest.mark.usefixtures('presenters')
 class TestIndexAnnotation:
 
@@ -145,7 +137,7 @@ class TestBatchIndexer(object):
             mock.call(indexer, set(['id-1'])),
         ]
 
-    def test_index_indexes_all_annotations_to_es(self, db_session, indexer, streaming_bulk):
+    def test_index_indexes_all_annotations_to_es(self, db_session, indexer, matchers, streaming_bulk):
         ann_1, ann_2 = self.annotation(), self.annotation()
         db_session.add_all([ann_1, ann_2])
         db_session.flush()
@@ -153,10 +145,10 @@ class TestBatchIndexer(object):
         indexer.index()
 
         streaming_bulk.assert_called_once_with(
-            indexer.es_client.conn, GeneratorEquals([ann_1, ann_2]),
+            indexer.es_client.conn, matchers.iterable_with([ann_1, ann_2]),
             chunk_size=mock.ANY, raise_on_error=False, expand_action_callback=mock.ANY)
 
-    def test_index_indexes_filtered_annotations_to_es(self, db_session, indexer, streaming_bulk):
+    def test_index_indexes_filtered_annotations_to_es(self, db_session, indexer, matchers, streaming_bulk):
         ann_1, ann_2 = self.annotation(), self.annotation()
         db_session.add_all([ann_1, ann_2])
         db_session.flush()
@@ -164,7 +156,7 @@ class TestBatchIndexer(object):
         indexer.index([ann_2.id])
 
         streaming_bulk.assert_called_once_with(
-            indexer.es_client.conn, GeneratorEquals([ann_2]),
+            indexer.es_client.conn, matchers.iterable_with([ann_2]),
             chunk_size=mock.ANY, raise_on_error=False, expand_action_callback=mock.ANY)
 
     def test_index_correctly_presents_bulk_actions(self,

--- a/tests/h/conftest.py
+++ b/tests/h/conftest.py
@@ -148,6 +148,12 @@ def mailer(pyramid_config):
 
 
 @pytest.fixture
+def matchers():
+    from ..common import matchers
+    return matchers
+
+
+@pytest.fixture
 def notify(pyramid_config, request):
     patcher = mock.patch.object(pyramid_config.registry, 'notify', autospec=True)
     request.addfinalizer(patcher.stop)


### PR DESCRIPTION
A number of tests (including ones I'm currently working on) use matcher objects like those in this commit. Rather than writing them over and over again for every new test module, it makes sense to centralise them.