### PR TITLE
Add a links service, to allow generating links to annotations

### DIFF
--- a/h/api/__init__.py
+++ b/h/api/__init__.py
@@ -3,6 +3,7 @@
 
 def includeme(config):
     config.include('h.api.eventqueue')
+    config.include('h.api.links')
     config.include('h.api.presenters')
     config.include('h.api.search')
     config.include('h.api.views')

--- a/h/api/links.py
+++ b/h/api/links.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+"""
+Tools for generating links to domain objects.
+"""
+
+from __future__ import unicode_literals
+
+from pyramid.request import Request
+
+LINK_GENERATORS_KEY = 'h.api.links.link_generators'
+
+
+class LinksService(object):
+
+    """A service for generating links to annotations."""
+
+    def __init__(self, base_url, registry):
+        """
+        Create a new links service.
+
+        :param base_url: the base URL for link construction
+        :param registry: the registry in which to look up routes
+        :type registry: pyramid.registry.Registry
+        """
+        self.base_url = base_url
+        self.registry = registry
+
+        # It would be absolutely fair if at this point you asked yourself any
+        # of the following questions:
+        #
+        # - Why are we constructing a fake request here?
+        # - Didn't we have a request and then discard it in the service
+        #   factory?
+        # - This looks really janky!
+        #
+        # Well, apart from the fact that the last one there isn't a question,
+        # those are good questions. The reason for doing this is that we need
+        # to be able to generate links to annotations in situations where we
+        # don't necessarily have a request object around, such as in the
+        # WebSocket server, or in a CLI command.
+        #
+        # In these situations, it should suffice to have an application
+        # registry (for the routing table) and a base URL. The reason we
+        # generate a request object is that this is the simplest and least
+        # error-prone way to get access to the route_url function, which can
+        # be used by link generators.
+        self._request = Request.blank('/', base_url=base_url)
+        self._request.registry = registry
+
+    def get(self, annotation, name):
+        """Get the link named `name` for the passed `annotation`."""
+        g, _ = self.registry[LINK_GENERATORS_KEY][name]
+        return g(self._request, annotation)
+
+    def get_all(self, annotation):
+        """Get all (non-hidden) links for the passed `annotation`."""
+        links = {}
+        for name, (g, hidden) in self.registry[LINK_GENERATORS_KEY].items():
+            if hidden:
+                continue
+            links[name] = g(self._request, annotation)
+        return links
+
+
+def links_factory(context, request):
+    """Return a LinksService instance for the passed context and request."""
+    base_url = request.registry.settings.get('h.app_url',
+                                             'http://localhost:5000')
+    return LinksService(base_url=base_url,
+                        registry=request.registry)
+
+
+def add_annotation_link_generator(registry, name, generator, hidden=False):
+    """
+    Registers a function which generates a named link for an annotation.
+
+    Annotation hypermedia links are added to the rendered annotations in a
+    `links` property or similar. `name` is the unique identifier for the link
+    type, and `generator` is a callable which accepts two arguments -- the
+    current request, and the annotation for which to generate a link -- and
+    returns a string.
+
+    If `hidden` is True, then the link generator will not be included in the
+    default links output when rendering annotations.
+    """
+    if LINK_GENERATORS_KEY not in registry:
+        registry[LINK_GENERATORS_KEY] = {}
+    registry[LINK_GENERATORS_KEY][name] = (generator, hidden)
+
+
+def includeme(config):  # pragma: no cover
+    config.register_service_factory(links_factory, name='links')

--- a/h/config.py
+++ b/h/config.py
@@ -67,6 +67,7 @@ SETTINGS = [
     EnvSetting('csp.report_uri', 'CSP_REPORT_URI'),
     EnvSetting('csp.report_only', 'CSP_REPORT_ONLY'),
     EnvSetting('ga_tracking_id', 'GOOGLE_ANALYTICS_TRACKING_ID'),
+    EnvSetting('h.app_url', 'APP_URL'),
     EnvSetting('h.auth_domain', 'AUTH_DOMAIN'),
     EnvSetting('h.bouncer_url', 'BOUNCER_URL'),
     EnvSetting('h.client_id', 'CLIENT_ID'),

--- a/tests/h/api/links_test.py
+++ b/tests/h/api/links_test.py
@@ -1,0 +1,104 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import mock
+import pytest
+
+from h.api.links import LinksService
+from h.api.links import add_annotation_link_generator
+from h.api.links import links_factory
+
+
+class TestLinksService(object):
+    def test_get_returns_link_text(self, registry):
+        svc = LinksService(base_url='http://example.com', registry=registry)
+
+        result = svc.get(mock.sentinel.annotation, 'giraffe')
+
+        assert result == 'http://giraffes.com'
+
+    def test_get_returns_link_text_for_hidden_links(self, registry):
+        svc = LinksService(base_url='http://example.com', registry=registry)
+
+        result = svc.get(mock.sentinel.annotation, 'kiwi')
+
+        assert result == 'http://kiwi.net'
+
+    def test_get_passes_generators_request_with_base_url(self, registry):
+        svc = LinksService(base_url='http://donkeys.com', registry=registry)
+
+        result = svc.get(mock.sentinel.annotation, 'namedroute')
+
+        assert result == 'http://donkeys.com/some/path'
+
+    def test_get_passes_generators_annotation(self, registry):
+        annotation = mock.Mock(id=12345)
+        svc = LinksService(base_url='http://example.com', registry=registry)
+
+        result = svc.get(annotation, 'paramroute')
+
+        assert result == 'http://example.com/annotations/12345'
+
+    def test_get_all_returns_nonhidden_links(self, registry):
+        svc = LinksService(base_url='http://example.com', registry=registry)
+
+        result = svc.get_all(mock.sentinel.annotation)
+
+        assert result == {
+            'giraffe': 'http://giraffes.com',
+            'elephant': 'https://elephant.org',
+        }
+
+
+class TestLinksFactory(object):
+    def test_returns_links_service(self, pyramid_request):
+        svc = links_factory(None, pyramid_request)
+
+        assert isinstance(svc, LinksService)
+
+    def test_base_url_is_development_base_if_not_set(self, pyramid_request):
+        svc = links_factory(None, pyramid_request)
+
+        assert svc.base_url == 'http://localhost:5000'
+
+    def test_base_url_is_app_url_setting_if_set(self, pyramid_request):
+        pyramid_request.registry.settings['h.app_url'] = 'https://hypothes.is'
+
+        svc = links_factory(None, pyramid_request)
+
+        assert svc.base_url == 'https://hypothes.is'
+
+    def test_registry_is_request_registry(self, pyramid_request):
+        svc = links_factory(None, pyramid_request)
+
+        assert svc.registry == pyramid_request.registry
+
+
+@pytest.fixture
+def registry(pyramid_config):
+    pyramid_config.add_route('some.named.route', '/some/path')
+    pyramid_config.add_route('param.route', '/annotations/{id}')
+
+    registry = pyramid_config.registry
+
+    add_annotation_link_generator(registry,
+                                  'giraffe',
+                                  lambda r, a: 'http://giraffes.com')
+    add_annotation_link_generator(registry,
+                                  'elephant',
+                                  lambda r, a: 'https://elephant.org')
+    add_annotation_link_generator(registry,
+                                  'kiwi',
+                                  lambda r, a: 'http://kiwi.net',
+                                  hidden=True)
+    add_annotation_link_generator(registry,
+                                  'namedroute',
+                                  lambda r, a: r.route_url('some.named.route'),
+                                  hidden=True)
+    add_annotation_link_generator(registry,
+                                  'paramroute',
+                                  lambda r, a: r.route_url('param.route', id=a.id),
+                                  hidden=True)
+
+    return registry


### PR DESCRIPTION
Generating links to annotations is currently a responsibility of the `h.api.presenters` module, which uses a passed-in Pyramid request object to do much of the heavy lifting.

This commit adds a links service (currently unused) which will replace this functionality which will allow us to remove the need to pass a request object into the presenters.

This, in turn, will allow us to entirely remove the use of a request object from the streamer code -- thus eliminating the possibility that we accidentally use `request.db` (as we currently do), thus opening unintended connections to the database server.