### PR TITLE
Notify AnnotationTransformEvent when bulk indexing

### DIFF
--- a/h/api/search/index.py
+++ b/h/api/search/index.py
@@ -140,6 +140,9 @@ class BatchIndexer(object):
                             '_id': annotation.id}}
         data = presenters.AnnotationSearchIndexPresenter(self.request, annotation).asdict()
 
+        event = AnnotationTransformEvent(self.request, data)
+        self.request.registry.notify(event)
+
         return (action, data)
 
     def _stream_all_annotations(self, chunksize=2000):


### PR DESCRIPTION
We did not emit this event which meant when bulk indexing (or
reindexing) we did remove the nipsa flag on annotations.

Fixes #3509