### PR TITLE
Remove request dependency from presenter classes

### DIFF
--- a/h/api/links.py
+++ b/h/api/links.py
@@ -58,7 +58,9 @@ class LinksService(object):
         for name, (g, hidden) in self.registry[LINK_GENERATORS_KEY].items():
             if hidden:
                 continue
-            links[name] = g(self._request, annotation)
+            l = g(self._request, annotation)
+            if l is not None:
+                links[name] = l
         return links
 
 

--- a/h/api/links.py
+++ b/h/api/links.py
@@ -90,5 +90,15 @@ def add_annotation_link_generator(registry, name, generator, hidden=False):
     registry[LINK_GENERATORS_KEY][name] = (generator, hidden)
 
 
+def _add_annotation_link_generator(config, name, generator, hidden=False):
+    add_annotation_link_generator(config.registry,
+                                  name,
+                                  generator,
+                                  hidden=hidden)
+
+
 def includeme(config):  # pragma: no cover
     config.register_service_factory(links_factory, name='links')
+
+    config.add_directive('add_annotation_link_generator',
+                         _add_annotation_link_generator)

--- a/h/api/search/index.py
+++ b/h/api/search/index.py
@@ -38,8 +38,8 @@ def index(es, annotation, request):
     :type annotation: h.api.models.Annotation
 
     """
-    annotation_dict = presenters.AnnotationSearchIndexPresenter(
-        request, annotation).asdict()
+    presenter = presenters.AnnotationSearchIndexPresenter(annotation)
+    annotation_dict = presenter.asdict()
 
     event = AnnotationTransformEvent(request, annotation_dict)
     request.registry.notify(event)
@@ -138,7 +138,7 @@ class BatchIndexer(object):
         action = {'index': {'_index': self.es_client.index,
                             '_type': self.es_client.t.annotation,
                             '_id': annotation.id}}
-        data = presenters.AnnotationSearchIndexPresenter(self.request, annotation).asdict()
+        data = presenters.AnnotationSearchIndexPresenter(annotation).asdict()
 
         return (action, data)
 

--- a/h/streamer/messages.py
+++ b/h/streamer/messages.py
@@ -128,8 +128,11 @@ def handle_annotation_event(message, socket):
         if annotation is None:
             return None
 
-        serialized = presenters.AnnotationJSONPresenter(
-            socket.request, annotation).asdict()
+        # FIXME: This method of retrieving the links service is temporary. We
+        # will shortly not rely on `socket.request` at all.
+        links_service = socket.request.find_service(name='links')
+        serialized = presenters.AnnotationJSONPresenter(annotation,
+                                                        links_service).asdict()
 
     userid = serialized.get('user')
     nipsa_service = socket.request.find_service(name='nipsa')

--- a/h/websocket.py
+++ b/h/websocket.py
@@ -174,11 +174,27 @@ def create_app(global_config, **settings):
     config.include('h.models')
     config.include('h.db')
 
-    # We have to include search to set up the `request.es` property.
+    # We have to include parts of the `h.api` package in order to provide,
+    # among other things:
+    #
+    #   - the links service
+    #   - the default presenters (and their link registrations)
+    #   - the `request.es` property
+    config.include('h.api.links')
+    config.include('h.api.presenters')
     config.include('h.api.search')
+
+    # We include links in order to set up the alternative link registrations
+    # for annotations.
+    config.include('h.links')
 
     # We have to include nipsa to provide the NIPSA service
     config.include('h.nipsa')
+
+    # And finally we add static routes which can be used for URL generation
+    # within the websocket server.
+    config.add_route('annotation', '/a/{id}', static=True)
+    config.add_route('api.annotation', '/api/annotations/{id}', static=True)
 
     config.include('h.streamer')
 

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -8,6 +8,7 @@ from webtest import TestApp
 TEST_SETTINGS = {
     'es.host': os.environ.get('ELASTICSEARCH_HOST', 'http://localhost:9200'),
     'es.index': 'hypothesis-test',
+    'h.app_url': 'http://localhost',
     'h.db.should_create_all': True,
     'h.db.should_drop_all': True,
     'h.search.autoconfig': True,

--- a/tests/h/api/search/index_test.py
+++ b/tests/h/api/search/index_test.py
@@ -28,9 +28,7 @@ class TestIndexAnnotation:
 
         index.index(es, annotation, pyramid_request)
 
-        presenters.AnnotationSearchIndexPresenter.assert_called_once_with(
-            pyramid_request,
-            annotation)
+        presenters.AnnotationSearchIndexPresenter.assert_called_once_with(annotation)
 
     def test_it_creates_an_annotation_before_save_event(self,
                                                         AnnotationTransformEvent,
@@ -187,8 +185,7 @@ class TestBatchIndexer(object):
 
         indexer.index()
 
-        rendered = presenters.AnnotationSearchIndexPresenter(
-            pyramid_request, annotation).asdict()
+        rendered = presenters.AnnotationSearchIndexPresenter(annotation).asdict()
         rendered['target'][0]['scope'] = [annotation.target_uri_normalized]
         assert results[0] == (
             {'index': {'_type': indexer.es_client.t.annotation,
@@ -285,8 +282,7 @@ class TestBatchDeleter(object):
 
         es_scan.return_value = [
             {'_id': annotation.id,
-             '_source': presenters.AnnotationSearchIndexPresenter(pyramid_request,
-                                                                  annotation)}]
+             '_source': presenters.AnnotationSearchIndexPresenter(annotation)}]
 
         deleted_ids = deleter.deleted_annotation_ids()
         assert len(deleted_ids) == 0


### PR DESCRIPTION
This PR removes the need to pass a Pyramid request object into a presenter class, which will in turn make it possible to remove all need for a request object from the streamer message handling code.

Instead, the AnnotationJSONPresenter and AnnotationJSONLDPresenter classes accept a "links service" argument which they use to generate links.