### PR TITLE
Only index annotation in worker when it was found

### DIFF
--- a/h/indexer.py
+++ b/h/indexer.py
@@ -22,7 +22,8 @@ log = logging.getLogger(__name__)
 @celery.task
 def add_annotation(id_):
     annotation = storage.fetch_annotation(celery.request.db, id_)
-    index(celery.request.es, annotation, celery.request)
+    if annotation:
+        index(celery.request.es, annotation, celery.request)
 
 
 @celery.task

--- a/tests/h/indexer_test.py
+++ b/tests/h/indexer_test.py
@@ -26,6 +26,13 @@ class TestAddAnnotation(object):
 
         index.assert_called_once_with(celery.request.es, annotation, celery.request)
 
+    def test_it_skips_indexing_when_annotation_cannot_be_loaded(self, fetch_annotation, index, celery):
+        fetch_annotation.return_value = None
+
+        indexer.add_annotation('test-annotation-id')
+
+        assert index.called is False
+
     @pytest.fixture
     def index(self, patch):
         return patch('h.indexer.index')


### PR DESCRIPTION
If the `add_index` worker is executed after the newly-created annotation
has already been deleted, then there is no point in indexing it anymore.

This fixes a [Sentry issue](https://app.getsentry.com/hypothesis/prod/issues/138182278/) we're seeing where we pass `None` as the
annotation into h.api.search.index.index