### PR TITLE
Use streamer session in realtime message handlers

### DIFF
--- a/h/streamer/__init__.py
+++ b/h/streamer/__init__.py
@@ -2,7 +2,6 @@
 
 
 def includeme(config):
-    config.include('h.streamer.streamer')
     config.include('h.streamer.views')
 
     config.add_route('ws', 'ws')

--- a/h/streamer/streamer.py
+++ b/h/streamer/streamer.py
@@ -90,10 +90,10 @@ def process_work_queue(settings, queue, session_factory=None):
 
             if isinstance(msg, messages.Message):
                 with s.timer('streamer.msg.handler_message'):
-                    messages.handle_message(msg, topic_handlers=topic_handlers)
+                    messages.handle_message(msg, session, topic_handlers)
             elif isinstance(msg, websocket.Message):
                 with s.timer('streamer.msg.handler_websocket'):
-                    websocket.handle_message(msg)
+                    websocket.handle_message(msg, session)
             else:
                 raise UnknownMessageType(repr(msg))
 
@@ -138,8 +138,3 @@ def supervise(greenlets):
 def _get_session(settings):
     engine = db.make_engine(settings)
     return db.Session(bind=engine)
-
-
-def includeme(config):
-    # Store a reference to the work queue on the registry for websocket clients
-    config.registry['streamer.work_queue'] = WORK_QUEUE

--- a/tests/h/streamer/streamer_test.py
+++ b/tests/h/streamer/streamer_test.py
@@ -16,6 +16,7 @@ def test_process_work_queue_sends_realtime_messages_to_messages_handle_message(s
     streamer.process_work_queue({}, queue, session_factory=lambda _: session)
 
     messages.handle_message.assert_called_once_with(message,
+                                                    session,
                                                     topic_handlers=mock.ANY)
 
 
@@ -33,6 +34,7 @@ def test_process_work_queue_uses_appropriate_topic_handlers_for_realtime_message
     }
 
     messages.handle_message.assert_called_once_with(mock.ANY,
+                                                    session,
                                                     topic_handlers=topic_handlers)
 
 
@@ -42,7 +44,7 @@ def test_process_work_queue_sends_websocket_messages_to_websocket_handle_message
 
     streamer.process_work_queue({}, queue, session_factory=lambda _: session)
 
-    websocket.handle_message.assert_called_once_with(message)
+    websocket.handle_message.assert_called_once_with(message, session)
 
 
 def test_process_work_queue_commits_after_each_message(session):
@@ -111,6 +113,7 @@ def session():
 @pytest.fixture(autouse=True)
 def websocket_handle_message(patch):
     return patch('h.streamer.websocket.handle_message')
+
 
 @pytest.fixture(autouse=True)
 def messages_handle_message(patch):

--- a/tests/h/streamer/views_test.py
+++ b/tests/h/streamer/views_test.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 
 import mock
+import pytest
 
 from h.streamer import views
+from h.streamer import streamer
 
 
 def test_websocket_view_bad_origin(pyramid_request):
@@ -21,9 +23,43 @@ def test_websocket_view_good_origin(pyramid_request):
 
 
 def test_websocket_view_same_origin(pyramid_request):
-    # example.com is the dummy request default host URL
-    pyramid_request.registry.settings.update({'origins': []})
-    pyramid_request.headers = {'Origin': 'http://example.com'}
     pyramid_request.get_response = lambda _: mock.sentinel.good_response
     res = views.websocket_view(pyramid_request)
     assert res == mock.sentinel.good_response
+
+
+def test_websocket_view_adds_auth_state_to_environ(pyramid_config, pyramid_request):
+    pyramid_config.testing_securitypolicy('ragnar', groupids=['foo', 'bar'])
+    pyramid_request.get_response = lambda _: None
+
+    views.websocket_view(pyramid_request)
+    env = pyramid_request.environ
+
+    assert env['h.ws.authenticated_userid'] == 'ragnar'
+    assert env['h.ws.effective_principals'] == pyramid_request.effective_principals
+
+
+def test_websocket_view_adds_registry_reference_to_environ(pyramid_request):
+    pyramid_request.get_response = lambda _: None
+
+    views.websocket_view(pyramid_request)
+    env = pyramid_request.environ
+
+    assert env['h.ws.registry'] == pyramid_request.registry
+
+
+def test_websocket_view_adds_work_queue_to_environ(pyramid_request):
+    pyramid_request.get_response = lambda _: None
+
+    views.websocket_view(pyramid_request)
+    env = pyramid_request.environ
+
+    assert env['h.ws.streamer_work_queue'] == streamer.WORK_QUEUE
+
+
+@pytest.fixture
+def pyramid_request(pyramid_request):
+    pyramid_request.registry.settings.update({'origins': []})
+    # example.com is the dummy request default host URL
+    pyramid_request.headers = {'Origin': 'http://example.com'}
+    return pyramid_request


### PR DESCRIPTION
This PR ensures that all database access inside

1. the realtime message handlers in `h/streamer/messages.py`, and
2. the websocket message handler in `h/streamer/websocket.py`

is done using the streamer-managed session created in `process_work_queue`.

This ensures that:

- the underlying connection is returned to the pool after handling each message...
- ...and thus we don't accidentally overflow the database connection pool when handling lots of messages (or a few messages with lots of clients)
- also, the transaction isolation level set in `streamer.py` is respected

In order to do this, the created session is now passed into the message handlers.

Further, and in order to ensure that this problem doesn't recur, I've removed the `request` property from the `h.websocket.WebSocket` instances that represent client connections to the WebSocket. This means that we can't accidentally create a new database connection by accessing `socket.request.db`. Now the socket instance is informed of its auth status through the WSGI environment. This has the nice side effect of removing our last use of `pyramid.threadlocal` from the codebase