### PR TITLE
Optimize streamer DB access

### DIFF
--- a/h/streamer/websocket.py
+++ b/h/streamer/websocket.py
@@ -60,6 +60,10 @@ class WebSocket(_WebSocket):
         except KeyError:
             pass
 
+    def send_json(self, payload):
+        if not self.terminated:
+            self.send(json.dumps(payload))
+
 
 def handle_message(message, session=None):
     """


### PR DESCRIPTION
This was an oversight made in #3378 (specifically in 80c54e5) which had
a pretty serious impact on performance. Now that we load the annotation
from the database based on the id in the realtime message we have to
make sure that we only access the database once per message, and not
once per message per socket. Which would mean that with 1000 connected
clients we would access the database 2000 times (once for loading the
annotation, once for checking if the annotation creator is nipsa'd).

This pull requests refactors the topic handler functions to receive a
list of sockets instead of a socket. This new topic handler then loads
the necessary data from the database and then calls a private function
that returns the payload that we send back to the client.