### PR TITLE
Remove pre/during httpx migration support code

### DIFF
--- a/h/api/models/document.py
+++ b/h/api/models/document.py
@@ -57,10 +57,6 @@ class Document(Base, mixins.Timestamps):
         """Find documents by a list of uris."""
         query_uris = [uri_normalize(u) for u in uris]
 
-        # FIXME: remove after httpx normalization is finished
-        query_uris.extend([uri_normalize(u, httpx_normalization=False)
-                           for u in uris])
-
         matching_claims = (
             session.query(DocumentURI)
                    .filter(DocumentURI.uri_normalized.in_(query_uris))
@@ -272,14 +268,6 @@ def create_or_update_document_uri(session,
         DocumentURI.type == type,
         DocumentURI.content_type == content_type).first()
 
-    # FIXME: remove after httpx normalization is finished
-    if docuri is None:
-        docuri = session.query(DocumentURI).filter(
-            DocumentURI.claimant_normalized == uri_normalize(claimant, httpx_normalization=False),
-            DocumentURI.uri_normalized == uri_normalize(uri, httpx_normalization=False),
-            DocumentURI.type == type,
-            DocumentURI.content_type == content_type).first()
-
     if docuri is None:
         docuri = DocumentURI(claimant=claimant,
                              uri=uri,
@@ -352,12 +340,6 @@ def create_or_update_document_meta(session,
     existing_dm = session.query(DocumentMeta).filter(
         DocumentMeta.claimant_normalized == uri_normalize(claimant),
         DocumentMeta.type == type).one_or_none()
-
-    # FIXME: remove after httpx normalization is finished
-    if existing_dm is None:
-        existing_dm = session.query(DocumentMeta).filter(
-            DocumentMeta.claimant_normalized == uri_normalize(claimant, httpx_normalization=False),
-            DocumentMeta.type == type).one_or_none()
 
     if existing_dm is None:
         session.add(DocumentMeta(

--- a/h/api/search/query.py
+++ b/h/api/search/query.py
@@ -182,11 +182,6 @@ class UriFilter(object):
             us = [uri.normalize(u) for u in expanded]
             uris.update(us)
 
-            # FIXME: remove after httpx normalization is finished
-            us = [uri.normalize(u, httpx_normalization=False)
-                  for u in expanded]
-            uris.update(us)
-
         return {"terms": {"target.scope": list(uris)}}
 
 

--- a/h/api/uri.py
+++ b/h/api/uri.py
@@ -127,7 +127,7 @@ UNRESERVED_QUERY_VALUE = "-._~:@!$'()*,="
 VIA_PREFIX = "https://via.hypothes.is/"
 
 
-def normalize(uristr, httpx_normalization=True):
+def normalize(uristr):
     """Translate the given URI into a normalized form."""
     uristr = uristr.encode('utf-8')
 
@@ -148,7 +148,7 @@ def normalize(uristr, httpx_normalization=True):
     if uri.hostname is None:
         return text_type(uristr, 'utf-8')
 
-    scheme = _normalize_scheme(uri, httpx_normalization=httpx_normalization)
+    scheme = _normalize_scheme(uri)
     netloc = _normalize_netloc(uri)
     path = _normalize_path(uri)
     query = _normalize_query(uri)
@@ -159,10 +159,10 @@ def normalize(uristr, httpx_normalization=True):
     return text_type(uri.geturl(), 'utf-8')
 
 
-def _normalize_scheme(uri, httpx_normalization=True):
+def _normalize_scheme(uri):
     scheme = uri.scheme
 
-    if httpx_normalization and scheme in URL_SCHEMES:
+    if scheme in URL_SCHEMES:
         scheme = 'httpx'
 
     return scheme

--- a/tests/h/api/models/document_test.py
+++ b/tests/h/api/models/document_test.py
@@ -95,20 +95,6 @@ class TestDocumentFindByURIs(object):
             db_session, ['https://de.wikipedia.org/wiki/Hauptseite'])
         assert actual.count() == 0
 
-    def test_finds_pre_httpx_normalized_documents(self, db_session):
-        document_ = document.Document()
-        document_.document_uris.append(document.DocumentURI(
-            _claimant='https://en.wikipedia.org/wiki/Main_Page',
-            _claimant_normalized='https://en.wikipedia.org/wiki/Main_Page',
-            _uri='https://en.wikipedia.org/wiki/Main_Page',
-            _uri_normalized='https://en.wikipedia.org/wiki/Main_Page'))
-        db_session.add(document_)
-        db_session.flush()
-
-        actual = document.Document.find_by_uris(
-            db_session, ['https://en.wikipedia.org/wiki/Main_Page'])
-        assert actual.first() == document_
-
 
 class TestDocumentFindOrCreateByURIs(object):
 
@@ -302,44 +288,6 @@ class TestCreateOrUpdateDocumentURI(object):
         assert len(db_session.query(document.DocumentURI).all()) == 1, (
             "It shouldn't have added any new objects to the db")
 
-    def test_it_updates_the_existing_DocumentURI_when_it_is_normalized_pre_httpx(self, db_session):
-        claimant = 'http://example.com/example_claimant.html'
-        uri = 'http://example.com/example_uri.html'
-        type_ = 'self-claim'
-        content_type = ''
-        document_ = document.Document()
-        created = yesterday()
-        updated = yesterday()
-        document_uri = document.DocumentURI(
-            _claimant=claimant,
-            _claimant_normalized=claimant,
-            _uri=uri,
-            _uri_normalized=uri,
-            type=type_,
-            content_type=content_type,
-            document=document_,
-            created=created,
-            updated=updated,
-        )
-        db_session.add(document_uri)
-
-        now_ = now()
-        document.create_or_update_document_uri(
-            session=db_session,
-            claimant=claimant,
-            uri=uri,
-            type=type_,
-            content_type=content_type,
-            document=document_,
-            created=now_,
-            updated=now_,
-        )
-
-        assert document_uri.created == created
-        assert document_uri.updated == now_
-        assert len(db_session.query(document.DocumentURI).all()) == 1, (
-            "It shouldn't have added any new objects to the db")
-
     def test_it_creates_a_new_DocumentURI_if_there_is_no_existing_one(self, db_session):
         claimant = 'http://example.com/example_claimant.html'
         uri = 'http://example.com/example_uri.html'
@@ -479,43 +427,6 @@ class TestCreateOrUpdateDocumentMeta(object):
         updated = now()
         document_meta = document.DocumentMeta(
             claimant=claimant,
-            type=type_,
-            value=value,
-            document=document_,
-            created=created,
-            updated=updated,
-        )
-        db_session.add(document_meta)
-
-        new_updated = now()
-        document.create_or_update_document_meta(
-            session=db_session,
-            claimant=claimant,
-            type=type_,
-            value='new value',
-            document=document.Document(),  # This should be ignored.
-            created=now(),  # This should be ignored.
-            updated=new_updated,
-        )
-
-        assert document_meta.value == 'new value'
-        assert document_meta.updated == new_updated
-        assert document_meta.created == created, "It shouldn't update created"
-        assert document_meta.document == document_, (
-            "It shouldn't update document")
-        assert len(db_session.query(document.DocumentMeta).all()) == 1, (
-            "It shouldn't have added any new objects to the db")
-
-    def test_it_updates_the_existing_DocumentMeta_when_it_is_normalized_pre_httpx(self, db_session):
-        claimant = 'http://example.com/claimant'
-        type_ = 'title'
-        value = 'the title'
-        document_ = document.Document()
-        created = yesterday()
-        updated = now()
-        document_meta = document.DocumentMeta(
-            _claimant=claimant,
-            _claimant_normalized=claimant,
             type=type_,
             value=value,
             document=document_,

--- a/tests/h/api/search/query_test.py
+++ b/tests/h/api/search/query_test.py
@@ -330,9 +330,7 @@ def test_urifilter_expands_and_normalizes_into_terms_filter(storage):
     query_uris = result["terms"]["target.scope"]
 
     storage.expand_uri.assert_called_with(request.db, "http://example.com/")
-    assert sorted(query_uris) == sorted(["http://giraffes.com",
-                                         "httpx://giraffes.com",
-                                         "https://elephants.com",
+    assert sorted(query_uris) == sorted(["httpx://giraffes.com",
                                          "httpx://elephants.com"])
 
 
@@ -359,11 +357,8 @@ def test_urifilter_queries_multiple_uris(storage):
 
     storage.expand_uri.assert_any_call(request.db, "http://example.com")
     storage.expand_uri.assert_any_call(request.db, "http://example.net")
-    assert sorted(query_uris) == sorted(["http://giraffes.com",
-                                         "httpx://giraffes.com",
-                                         "https://elephants.com",
+    assert sorted(query_uris) == sorted(["httpx://giraffes.com",
                                          "httpx://elephants.com",
-                                         "http://tigers.com",
                                          "httpx://tigers.com"])
 
 

--- a/tests/h/api/uri_test.py
+++ b/tests/h/api/uri_test.py
@@ -177,15 +177,3 @@ def test_normalize(url_in, url_out):
 @pytest.mark.parametrize("url,_", TEST_URLS)
 def test_normalize_returns_unicode(url, _):
     assert isinstance(uri.normalize(url), text_type)
-
-
-@pytest.mark.parametrize("url_in,url_out", [
-    # Should not replace http and https protocol with httpx
-    ("https://example.org", "https://example.org"),
-    ("http://example.org", "http://example.org"),
-    # or when scheme is not http or https
-    ("ftp://example.org", "ftp://example.org"),
-    ("file://example.org", "file://example.org"),
-])
-def test_normalize_with_httpx_turned_off(url_in, url_out):
-    assert uri.normalize(url_in, httpx_normalization=False) == url_out

--- a/tests/h/cli/commands/normalize_uris_test.py
+++ b/tests/h/cli/commands/normalize_uris_test.py
@@ -72,16 +72,12 @@ def test_it_deletes_duplicate_document_uri_objects(req):
 
 
 def test_it_merges_documents_when_duplicates_found(req):
-    docuri_1 = models.DocumentURI(_claimant='http://example.org/',
-                                  _claimant_normalized='http://example.org',
-                                  _uri='http://example.org/',
-                                  _uri_normalized='http://example.org',
+    docuri_1 = models.DocumentURI(claimant='http://example.org/',
+                                  uri='http://example.org/',
                                   type='self-claim')
-    docuri_2 = models.DocumentURI(_claimant='https://example.org/',
-                                  _claimant_normalized='https://example.org',
-                                  _uri='https://example.org/',
-                                  _uri_normalized='https://example.org',
-                                  type='self-claim')
+    docuri_2 = models.DocumentURI(claimant='https://example.net/',
+                                  uri='https://example.org/',
+                                  type='rel-canonical')
 
     req.db.add_all([
         models.Document(document_uris=[docuri_1]),
@@ -92,7 +88,6 @@ def test_it_merges_documents_when_duplicates_found(req):
     normalize_uris.normalize_document_uris(req)
 
     assert req.db.query(models.Document).count() == 1
-    assert req.db.query(models.DocumentURI).count() == 1
 
 
 def test_it_normalizes_document_meta_claimant(req):


### PR DESCRIPTION
Now that we migrated the database we don't need to normalise to both
httpx and non-httpx variations anymore.