### PR TITLE
Allow either "signed-out" to "logged-out" auth status

### DIFF
--- a/h/templates/app.html.jinja2
+++ b/h/templates/app.html.jinja2
@@ -36,7 +36,13 @@
       on-change-sort-key="setSortKey(sortKey)">
     </top-bar>
 
-    <div class="create-account-banner" ng-if="isSidebar && auth.status === 'signed-out'" ng-cloak>
+    {#
+      The client is transitioning from using "signed-out" as an auth status to
+      "logged-out". For the moment we recognise either.
+
+      TODO: remove the "signed-out" option when the client no longer uses it.
+    #}
+    <div class="create-account-banner" ng-if="isSidebar && (auth.status === 'signed-out' || auth.status === 'logged-out')" ng-cloak>
       To annotate this document
       <a href="{{ register_url }}" target="_blank">
         create a free account


### PR DESCRIPTION
While the client transitions from "signed-out" to "logged-out", we simplify the deployment process by simply recognising both/either in app.html.