### PR TITLE
Update copy, comments from "sign in/out" to "log in/out"

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -14,7 +14,7 @@ To use these API URLs you should:
 
 1. Generate yourself an API token on your
    `Hypothesis developer page <https://hypothes.is/profile/developer>`_
-   (you must be signed in to Hypothesis to get to this page).
+   (you must be logged in to Hypothesis to get to this page).
 
 2. Put the API token in the ``Authorization`` header in your requests to the
    API.

--- a/h/accounts/views.py
+++ b/h/accounts/views.py
@@ -78,7 +78,7 @@ class AuthController(object):
         self.request = request
         self.schema = schemas.LoginSchema().bind(request=self.request)
         self.form = deform.Form(self.schema,
-                                buttons=(_('Sign in'),),
+                                buttons=(_('Log in'),),
                                 footer=form_footer)
 
         self.login_redirect = self.request.params.get(
@@ -383,7 +383,7 @@ class RegisterController(object):
         self.request.session.flash(jinja2.Markup(_(
             'Thank you for creating an account! '
             "We've sent you an email with an activation link, "
-            'before you can sign in <strong>please check your email and open '
+            'before you can log in <strong>please check your email and open '
             'the link to activate your account</strong>.')), 'success')
         self.request.registry.notify(RegistrationEvent(self.request, user))
 
@@ -416,7 +416,7 @@ class ActivateController(object):
             self.request.session.flash(jinja2.Markup(_(
                 "We didn't recognize that activation link. "
                 "Perhaps you've already activated your account? "
-                'If so, try <a href="{url}">signing in</a> using the username '
+                'If so, try <a href="{url}">logging in</a> using the username '
                 'and password that you provided.').format(
                     url=self.request.route_url('login'))),
                 'error')
@@ -431,7 +431,7 @@ class ActivateController(object):
 
         self.request.session.flash(jinja2.Markup(_(
             'Your account has been activated! '
-            'You can now <a href="{url}">sign in</a> using the password you '
+            'You can now <a href="{url}">log in</a> using the password you '
             'provided.').format(url=self.request.route_url('login'))),
             'success')
 
@@ -452,15 +452,15 @@ class ActivateController(object):
             raise httpexceptions.HTTPNotFound()
 
         if id_ == self.request.authenticated_user.id:
-            # The user is already signed in to the account (so the account
+            # The user is already logged in to the account (so the account
             # must already be activated).
             self.request.session.flash(jinja2.Markup(_(
-                "Your account has been activated and you're now signed "
+                "Your account has been activated and you're now logged "
                 "in!")), 'success')
         else:
             self.request.session.flash(jinja2.Markup(_(
-                "You're already signed in to a different account. "
-                '<a href="{url}">Sign out</a> then try opening the '
+                "You're already logged in to a different account. "
+                '<a href="{url}">Log out</a> then try opening the '
                 'activation link again.').format(
                     url=self.request.route_url('logout'))),
                 'error')

--- a/h/templates/accounts/forgot_password.html.jinja2
+++ b/h/templates/accounts/forgot_password.html.jinja2
@@ -13,7 +13,7 @@
     {% include "h:templates/includes/logo-header.html.jinja2" %}
     <div class="form-vertical">
       <ul class="nav nav-tabs">
-        <li><a href="{{ request.route_path('login') }}">Sign in</a></li>{#
+        <li><a href="{{ request.route_path('login') }}">Log in</a></li>{#
         #}<li><a href="{{ request.route_path('register') }}">Create an account</a></li>{#
         #}<li class="active"><a href="{{ request.route_path('forgot_password') }}">Password reset</a></li>
       </ul>

--- a/h/templates/accounts/login.html.jinja2
+++ b/h/templates/accounts/login.html.jinja2
@@ -1,6 +1,6 @@
 {% extends "h:templates/layouts/base.html.jinja2" %}
 
-{% block page_title %}Sign in{% endblock %}
+{% block page_title %}Log in{% endblock %}
 
 {% block styles %}
 {% for url in asset_client_urls("app_css") %}
@@ -13,7 +13,7 @@
     {% include "h:templates/includes/logo-header.html.jinja2" %}
     <div class="form-vertical">
       <ul class="nav nav-tabs">
-        <li class="active"><a href="{{ request.route_path('login') }}">Sign in</a></li>{#
+        <li class="active"><a href="{{ request.route_path('login') }}">Log in</a></li>{#
         #}<li><a href="{{ request.route_path('register') }}">Create an account</a></li>
       </ul>
       {{ form | safe }}

--- a/h/templates/accounts/register.html.jinja2
+++ b/h/templates/accounts/register.html.jinja2
@@ -13,7 +13,7 @@
     {% include "h:templates/includes/logo-header.html.jinja2" %}
     <div class="form-vertical">
       <ul class="nav nav-tabs">
-        <li><a href="{{ request.route_path('login') }}">Sign in</a></li>{#
+        <li><a href="{{ request.route_path('login') }}">Log in</a></li>{#
         #}<li class="active"><a href="{{ request.route_path('register') }}">Create an account</a></li>
       </ul>
       {{ form | safe }}

--- a/h/templates/accounts/reset_password.html.jinja2
+++ b/h/templates/accounts/reset_password.html.jinja2
@@ -13,7 +13,7 @@
     {% include "h:templates/includes/logo-header.html.jinja2" %}
     <div class="form-vertical">
       <ul class="nav nav-tabs">
-        <li><a href="{{ request.route_path('login') }}">Sign in</a></li>{#
+        <li><a href="{{ request.route_path('login') }}">Log in</a></li>{#
         #}<li><a href="{{ request.route_path('register') }}">Create an account</a></li>{#
         #}<li class="active"><a href="">New password</a></li>
       </ul>

--- a/h/templates/app.html.jinja2
+++ b/h/templates/app.html.jinja2
@@ -41,7 +41,7 @@
       <a href="{{ register_url }}" target="_blank">
         create a free account
       </a>
-      or <a href="" ng-click="login()">sign in</a>
+      or <a href="" ng-click="login()">log in</a>
     </div>
 
     <div class="content" ng-cloak>

--- a/h/templates/groups/join.html.jinja2
+++ b/h/templates/groups/join.html.jinja2
@@ -24,7 +24,7 @@
       <form method="GET" action="{{ request.route_url('login') }}">
         <input type="hidden" name="next" value="{{ request.path }}">
         <button class="primary-action-btn" type="submit">
-          Sign in to join {{ group.name }}
+          Log in to join {{ group.name }}
         </button>
       </form>
       {% endif %}

--- a/h/templates/includes/header.html.jinja2
+++ b/h/templates/includes/header.html.jinja2
@@ -79,9 +79,9 @@
           <li class="nav-bar__item nav-bar__item--login">
             {% if username %}
               <a href="{{ user_profile_link }}">{{ username }}</a>
-            / <a href="{{ request.route_url("logout") }}">Sign out</a>
+            / <a href="{{ request.route_url("logout") }}">Log out</a>
             {% else %}
-               <a href="/login" title="Sign in to Hypothesis">Login</a>
+              <a href="/login" title="Log in to Hypothesis">Log in</a>
             / <a href="/register" title="Create a new Hypothesis account">Sign up</a>
             {% endif %}
           </li>

--- a/h/templates/old-home.html.jinja2
+++ b/h/templates/old-home.html.jinja2
@@ -75,9 +75,9 @@
         <ul class="nav navbar-nav pull-right login">
           {% if username %}
             <li><a href="{{ user_profile_link }}">{{ username }}</a></li>
-            <li><a href="{{ request.route_url("logout") }}">Sign out</a></li>
+            <li><a href="{{ request.route_url("logout") }}">Log out</a></li>
           {% else %}
-            <li><a href="{{ base_url }}login">Sign in</a></li>
+            <li><a href="{{ base_url }}login">Log in</a></li>
             <li><a href="{{ base_url }}register">Create an account</a></li>
           {% endif %}
         </ul>

--- a/tests/h/accounts/views_test.py
+++ b/tests/h/accounts/views_test.py
@@ -610,7 +610,7 @@ class TestActivateController(object):
 
         If the activation code doesn't match any activation then we redirect to
         the front page and flash a message suggesting that they may already be
-        activated and can sign in.
+        activated and can log in.
 
         This happens if a user clicks on an activation link from an email after
         they've already been activated, for example.
@@ -735,7 +735,7 @@ class TestActivateController(object):
         assert isinstance(result, httpexceptions.HTTPFound)
         assert success_flash
         assert success_flash[0].startswith(
-            "Your account has been activated and you're now signed in")
+            "Your account has been activated and you're now logged in")
 
     def test_get_when_logged_in_already_logged_in_to_different_account(self, pyramid_request):
         pyramid_request.authenticated_user = mock.Mock(id=124, spec=['id'])
@@ -748,7 +748,7 @@ class TestActivateController(object):
         assert isinstance(result, httpexceptions.HTTPFound)
         assert error_flash
         assert error_flash[0].startswith(
-            "You're already signed in to a different account")
+            "You're already logged in to a different account")
 
     @pytest.fixture
     def routes(self, pyramid_config):


### PR DESCRIPTION
In coordination with hypothesis/client#18, this PR updates copy in the rest of the application to consistently use "log {in,out}" rather than "sign {in,out}".