### PR TITLE
Update PhantomJS

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -260,6 +260,14 @@ function runKarma(baseConfig, opts, done) {
     },
   };
 
+  // Work around a bug in Karma 1.10 which causes console log messages not to
+  // be displayed when using a non-default reporter.
+  // See https://github.com/karma-runner/karma/pull/2220
+  var BaseReporter = require('karma/lib/reporters/base');
+  BaseReporter.decoratorFactory.$inject =
+    BaseReporter.decoratorFactory.$inject.map(dep =>
+        dep.replace('browserLogOptions', 'browserConsoleLogOptions'));
+
   var karma = require('karma');
   new karma.Server(Object.assign({}, {
     configFile: path.resolve(__dirname, baseConfig),

--- a/h/browser/chrome/karma.config.js
+++ b/h/browser/chrome/karma.config.js
@@ -47,12 +47,7 @@ module.exports = function(config) {
     browserify: {
       debug: true,
       configure: function(bundle) {
-        bundle
-          .plugin('proxyquire-universal')
-          // fix for Proxyquire in PhantomJS 1.x.
-          // See https://github.com/bitwit/proxyquireify-phantom-menace
-          .require(require.resolve('phantom-ownpropertynames/implement'),
-            {entry: true});
+        bundle.plugin('proxyquire-universal');
       },
     },
 

--- a/h/browser/chrome/test/sidebar-injector-test.js
+++ b/h/browser/chrome/test/sidebar-injector-test.js
@@ -179,14 +179,14 @@ describe('SidebarInjector', function () {
       describe('when file access is enabled', function () {
         it('loads the PDFjs viewer', function () {
           var spy = fakeChromeTabs.update.yields([]);
-          var url = 'file://foo.pdf';
+          var url = 'file:///foo.pdf';
           contentType = 'PDF';
 
           return injector.injectIntoTab({id: 1, url: url}).then(
             function () {
               assert.called(spy);
               assert.calledWith(spy, 1, {
-                url: PDF_VIEWER_BASE_URL + encodeURIComponent('file://foo.pdf')
+                url: PDF_VIEWER_BASE_URL + encodeURIComponent('file:///foo.pdf')
               });
             }
           );

--- a/h/static/scripts/karma-phantomjs-polyfill.js
+++ b/h/static/scripts/karma-phantomjs-polyfill.js
@@ -16,3 +16,7 @@ require('core-js/es5');
 // app itself.
 require('./polyfills');
 
+// Include URL polyfill because PhantomJS 2.x has a broken URL
+// constructor. See https://github.com/hypothesis/client/pull/16
+require('js-polyfills/url');
+

--- a/h/static/scripts/karma-phantomjs-polyfill.js
+++ b/h/static/scripts/karma-phantomjs-polyfill.js
@@ -16,12 +16,3 @@ require('core-js/es5');
 // app itself.
 require('./polyfills');
 
-// disallow console output during tests
-['debug', 'log', 'warn', 'error'].forEach(function (method) {
-  var realFn = window.console[method];
-  window.console[method] = function () {
-    var args = [].slice.apply(arguments);
-    realFn.apply(console, args);
-    throw new Error('Tests must not log console warnings');
-  };
-});

--- a/h/static/scripts/karma.config.js
+++ b/h/static/scripts/karma.config.js
@@ -44,12 +44,7 @@ module.exports = function(config) {
     browserify: {
       debug: true,
       configure: function (bundle) {
-        bundle
-          .plugin('proxyquire-universal')
-          // fix for Proxyquire in PhantomJS 1.x.
-          // See https://github.com/bitwit/proxyquireify-phantom-menace
-          .require(require.resolve('phantom-ownpropertynames/implement'),
-            {entry: true});
+        bundle.plugin('proxyquire-universal');
       }
     },
 

--- a/package.json
+++ b/package.json
@@ -40,16 +40,14 @@
     "check-dependencies": "^0.12.0",
     "diff": "^2.2.2",
     "jscs": "^3.0.2",
-    "karma": "^0.13.22",
-    "karma-browserify": "^5.0.3",
+    "karma": "^1.1.0",
+    "karma-browserify": "^5.0.5",
     "karma-chai": "^0.1.0",
-    "karma-mocha": "^0.2.2",
-    "karma-mocha-reporter": "^2.0.0",
-    "karma-phantomjs-launcher": "^0.2.3",
-    "karma-sinon": "^1.0.4",
+    "karma-mocha": "^1.1.1",
+    "karma-mocha-reporter": "^2.0.4",
+    "karma-phantomjs-launcher": "^1.0.1",
+    "karma-sinon": "^1.0.5",
     "mocha": "^2.4.5",
-    "phantom-ownpropertynames": "^1.0.0",
-    "phantomjs": "^1.9.7",
     "proxyquire": "^1.7.4",
     "proxyquire-universal": "^1.0.8",
     "proxyquireify": "^3.1.1",
@@ -70,7 +68,9 @@
   },
   "homepage": "https://github.com/hypothesis/h",
   "browserify": {
-    "transform": ["browserify-shim"]
+    "transform": [
+      "browserify-shim"
+    ]
   },
   "browserify-shim": {
     "jquery": "$"


### PR DESCRIPTION
This PR updates PhantomJS and other JS test infrastructure to current versions and removes the `console.log()` ban in tests which was also recently removed from the client repository.

See hypothesis/client#16, hypothesis/client#17, hypothesis/client#23