### PR TITLE
Escape user input in Deform forms

### DIFF
--- a/h/form.py
+++ b/h/form.py
@@ -7,6 +7,10 @@ form templates in preference to the defaults. Uses `deform_jinja2` to provide
 the fallback templates in Jinja2 format, which we can then extend and modify as
 necessary.
 """
+import deform
+import jinja2
+import pyramid_jinja2
+from pyramid.path import AssetResolver
 
 
 SEARCH_PATHS = (
@@ -15,16 +19,53 @@ SEARCH_PATHS = (
 )
 
 
-def init():
-    from deform import Form
-    from deform_jinja2 import jinja2_renderer_factory
-    from deform_jinja2.translator import PyramidTranslator
+class Jinja2Renderer(object):
+    """
+    An alternate Deform renderer that uses Jinja2 to render templates.
 
-    renderer = jinja2_renderer_factory(search_paths=SEARCH_PATHS,
-                                       translator=PyramidTranslator())
+    We supply our own Jinja2 renderer because deform_jinja2's one doesn't
+    support autoescaping.
+    """
 
-    Form.set_default_renderer(renderer)
+    def __init__(self, base_env):
+        """
+        Return a new callable Jinja2Renderer object.
+
+        :param base_env: the initial Jinja2 environment that this renderer's
+            Jinja2 environment will be created as an overlay of
+        :type base_env: :py:class:`jinja2.Environment`
+        """
+        self._base_env = base_env
+        self._env = None
+
+    def _get_env(self):
+        """
+        Return this renderer's Jinja2 environment.
+
+        Initialize the environment if it hasn't been initialized already.
+        """
+        if not self._env:
+            resolver = AssetResolver()
+            searchpath = [resolver.resolve(path).abspath()
+                          for path in SEARCH_PATHS]
+            loader = pyramid_jinja2.SmartAssetSpecLoader(searchpath)
+            self._env = self._base_env.overlay(loader=loader)
+        return self._env
+
+    def __call__(self, template_name, **kwargs):
+        """Return the given template rendered with the given keyword args."""
+        if not template_name.endswith('.jinja2'):
+            template_name += '.jinja2'
+
+        template = self._get_env().get_template(template_name)
+
+        return jinja2.Markup(template.render(**kwargs))
 
 
-def includeme(_):
-    init()
+def initialize_deform_renderer(config):
+    deform.Form.set_default_renderer(
+        Jinja2Renderer(config.get_jinja2_environment()))
+
+
+def includeme(config):
+    config.action(None, initialize_deform_renderer, args=[config])

--- a/h/form.py
+++ b/h/form.py
@@ -49,7 +49,7 @@ class Jinja2Renderer(object):
             searchpath = [resolver.resolve(path).abspath()
                           for path in SEARCH_PATHS]
             loader = pyramid_jinja2.SmartAssetSpecLoader(searchpath)
-            self._env = self._base_env.overlay(loader=loader)
+            self._env = self._base_env.overlay(autoescape=True, loader=loader)
         return self._env
 
     def __call__(self, template_name, **kwargs):

--- a/h/templates/accounts/forgot_password.html.jinja2
+++ b/h/templates/accounts/forgot_password.html.jinja2
@@ -17,7 +17,7 @@
         #}<li><a href="{{ request.route_path('register') }}">Create an account</a></li>{#
         #}<li class="active"><a href="{{ request.route_path('forgot_password') }}">Password reset</a></li>
       </ul>
-      {{ form | safe }}
+      {{ form }}
     </div>
   </div>
 {% endblock content %}

--- a/h/templates/accounts/login.html.jinja2
+++ b/h/templates/accounts/login.html.jinja2
@@ -16,7 +16,7 @@
         <li class="active"><a href="{{ request.route_path('login') }}">Log in</a></li>{#
         #}<li><a href="{{ request.route_path('register') }}">Create an account</a></li>
       </ul>
-      {{ form | safe }}
+      {{ form }}
     </div>
   </div>
 {% endblock content %}

--- a/h/templates/accounts/notifications.html.jinja2
+++ b/h/templates/accounts/notifications.html.jinja2
@@ -8,6 +8,6 @@
     <h2 class="form-heading">
       <span>{% trans %}Update your notification settings{% endtrans %}</span>
     </h2>
-    {{ form | safe }}
+    {{ form }}
   </div>
 {% endblock page_content %}

--- a/h/templates/accounts/profile.html.jinja2
+++ b/h/templates/accounts/profile.html.jinja2
@@ -12,12 +12,12 @@
       {% trans %}Your current email address is:{% endtrans %}
       <strong>{{ email }}</strong>.
     </legend>
-    {{ email_form | safe }}
+    {{ email_form }}
 
     <h2 class="form-heading">
       <span>{% trans %}Change your password{% endtrans %}</span>
     </h2>
-    {{ password_form | safe }}
+    {{ password_form }}
 
     <h2 class="form-heading">
       <span>{% trans %}Delete account{% endtrans %}</span>

--- a/h/templates/accounts/register.html.jinja2
+++ b/h/templates/accounts/register.html.jinja2
@@ -16,7 +16,7 @@
         <li><a href="{{ request.route_path('login') }}">Log in</a></li>{#
         #}<li class="active"><a href="{{ request.route_path('register') }}">Create an account</a></li>
       </ul>
-      {{ form | safe }}
+      {{ form }}
     </div>
   </div>
 {% endblock content %}

--- a/h/templates/accounts/reset_password.html.jinja2
+++ b/h/templates/accounts/reset_password.html.jinja2
@@ -26,7 +26,7 @@
         {% endtrans %}
       </legend>
       {% endif %}
-      {{ form | safe }}
+      {{ form }}
     </div>
   </div>
 {% endblock content %}

--- a/tests/h/conftest.py
+++ b/tests/h/conftest.py
@@ -116,8 +116,8 @@ def db_session(db_engine):
 
 @pytest.fixture(scope='session', autouse=True)
 def deform():
-    """Allow tests that use deform to find our custom templates."""
-    form.init()
+    """Use our custom Deform renderer instead of Deform's default one."""
+    form.initialize_deform_renderer(config=mock.Mock())
 
 
 @pytest.yield_fixture

--- a/tests/h/form_test.py
+++ b/tests/h/form_test.py
@@ -44,3 +44,16 @@ class TestJinja2Renderer(object):
         html = renderer('textinput', cstruct='', field=mock.Mock())
 
         assert isinstance(html, jinja2.Markup)
+
+    def test_it_escapes_user_text(self):
+        """It should escape user text even if the base jinja2 env doesn't."""
+        base_env = jinja2.Environment()  # This base env doesn't have
+                                         # autoescape enabled.
+        renderer = form.Jinja2Renderer(base_env)
+
+        html = renderer(
+            'textinput',
+            cstruct='I am hacking you"><script>foo</script>',
+            field=mock.Mock())
+
+        assert '<script>foo</script>' not in html

--- a/tests/h/form_test.py
+++ b/tests/h/form_test.py
@@ -1,0 +1,46 @@
+import jinja2
+import mock
+
+from h import form
+
+
+class TestJinja2Renderer(object):
+
+    def test_it_initializes_an_overlay_environment_once(self):
+        """It should call overlay() just once even if called more than once."""
+        base_env = mock.Mock()
+        renderer = form.Jinja2Renderer(base_env)
+
+        # Call the renderer multiple times to render multiple templates.
+        renderer('template_1')
+        renderer('template_2')
+        renderer('template_3')
+
+        assert base_env.overlay.call_count == 1
+
+    def test_it_passes_kwargs_to_render(self):
+        template = mock.Mock()
+        env = mock.Mock()
+        env.get_template.return_value = template
+        base_env = mock.Mock()
+        base_env.overlay.return_value = env
+        renderer = form.Jinja2Renderer(base_env)
+
+        renderer('textinput', foo='foo', bar='bar')
+
+        template.render.assert_called_once_with(foo='foo', bar='bar')
+
+    def test_it_returns_the_rendered_template(self):
+        renderer = form.Jinja2Renderer(jinja2.Environment())
+
+        html = renderer('textinput', cstruct='', field=mock.Mock())
+
+        assert html.startswith('<input')
+
+    def test_it_returns_a_Markup_object(self):
+        """It should return a Markup so the HTML will not get escaped later."""
+        renderer = form.Jinja2Renderer(jinja2.Environment())
+
+        html = renderer('textinput', cstruct='', field=mock.Mock())
+
+        assert isinstance(html, jinja2.Markup)


### PR DESCRIPTION
Replace deform_jinja2.jinja2_renderer_factory() with our own Deform
Jinja2 renderer function which uses our existing Jinja2 environment
(which escapes user input because it has auto-escaping enabled).'

deform_jinja2.jinja2_renderer_factory() does not escape user text
rendered in form fields - it doesn't turn on Jinja2's autoescaping, and
there's no way for a caller of this function to turn on autoescaping.

Rather than manually escape every instance of user text in our Deform
Jinja2 templates, replace deform_jinja2.jinja2_renderer_factory() with
our own renderer function that uses our existing Jinja2 environment that
has autoescaping enabled.