### PR TITLE
Remove automagical annotation update handling

### DIFF
--- a/h/api/models/annotation.py
+++ b/h/api/models/annotation.py
@@ -49,7 +49,6 @@ class Annotation(Base):
     updated = sa.Column(sa.DateTime,
                         server_default=sa.func.now(),
                         default=datetime.datetime.utcnow,
-                        onupdate=datetime.datetime.utcnow,
                         nullable=False)
 
     #: The full userid (e.g. 'acct:foo@example.com') of the owner of this

--- a/h/api/models/annotation.py
+++ b/h/api/models/annotation.py
@@ -2,6 +2,8 @@
 
 from __future__ import unicode_literals
 
+import datetime
+
 from pyramid import security
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql as pg
@@ -11,11 +13,10 @@ from sqlalchemy.ext.mutable import MutableDict
 
 from h.api import uri
 from h.api.db import Base
-from h.api.db import mixins
 from h.api.db import types
 
 
-class Annotation(Base, mixins.Timestamps):
+class Annotation(Base):
 
     """Model class representing a single annotation."""
 
@@ -37,6 +38,19 @@ class Annotation(Base, mixins.Timestamps):
     id = sa.Column(types.URLSafeUUID,
                    server_default=sa.func.uuid_generate_v1mc(),
                    primary_key=True)
+
+    #: The timestamp when the annotation was created.
+    created = sa.Column(sa.DateTime,
+                        default=datetime.datetime.utcnow,
+                        server_default=sa.func.now(),
+                        nullable=False)
+
+    #: The timestamp when the user edited the annotation last.
+    updated = sa.Column(sa.DateTime,
+                        server_default=sa.func.now(),
+                        default=datetime.datetime.utcnow,
+                        onupdate=datetime.datetime.utcnow,
+                        nullable=False)
 
     #: The full userid (e.g. 'acct:foo@example.com') of the owner of this
     #: annotation.

--- a/h/api/storage.py
+++ b/h/api/storage.py
@@ -7,6 +7,8 @@ for storing and retrieving annotations. Data passed to these functions is
 assumed to be validated.
 """
 
+from datetime import datetime
+
 from pyramid import i18n
 
 from h.api import schemas
@@ -152,6 +154,7 @@ def update_annotation(session, id_, data):
     document = data.pop('document', None)
 
     annotation = session.query(models.Annotation).get(id_)
+    annotation.updated = datetime.utcnow()
 
     annotation.extra.update(data.pop('extra', {}))
 

--- a/tests/h/api/storage_test.py
+++ b/tests/h/api/storage_test.py
@@ -304,6 +304,13 @@ class TestUpdateAnnotation(object):
 
         assert annotation.extra == {'one': 1, 'two': 2}
 
+    def test_it_changes_the_updated_timestamp(self, annotation_data, session, datetime):
+        annotation = storage.update_annotation(session,
+                                               'test_annotation_id',
+                                               annotation_data)
+
+        assert annotation.updated == datetime.utcnow()
+
     def test_it_updates_the_annotation(self, annotation_data, session):
         annotation = session.query.return_value.get.return_value
 
@@ -373,6 +380,10 @@ class TestUpdateAnnotation(object):
             },
             'extra': {},
         }
+
+    @pytest.fixture
+    def datetime(self, patch):
+        return patch('h.api.storage.datetime')
 
 
 class TestDeleteAnnotation(object):


### PR DESCRIPTION
We had several issues recently where we ran migrations that then
obviously touched the `updated` column, but shouldn't have. So the
solution is to get rid of automatically changing this column and to do
it explicitly in `h.api.storage.update_annotation`.