### PR TITLE
Unify dev and prod session configs

### DIFF
--- a/conf/app.ini
+++ b/conf/app.ini
@@ -28,13 +28,6 @@ mail.default_sender: "Annotation Daemon" <no-reply@localhost>
 # Include any deployment-specific pyramid add-ons here
 pyramid.includes:
     pyramid_mailer
-    pyramid_redis_sessions
-
-# Redis session configuration -- See pyramid_redis_sessions documentation
-#redis.sessions.secret:
-redis.sessions.cookie_httponly: True
-redis.sessions.cookie_max_age: 2592000
-redis.sessions.timeout: 604800
 
 # SQLAlchemy configuration -- See SQLAlchemy documentation
 sqlalchemy.url: postgresql://postgres@localhost/postgres

--- a/conf/development-app.ini
+++ b/conf/development-app.ini
@@ -14,7 +14,6 @@ pyramid.includes:
     pyramid_debugtoolbar
     pyramid_mailer
     h.debug
-    h.session
 
 # Set a default persistent secret for development. DO NOT copy this into a
 # production settings file.

--- a/conf/development-websocket.ini
+++ b/conf/development-websocket.ini
@@ -5,10 +5,6 @@ use: egg:h#websocket
 origins:
     http://localhost:5000
 
-# Include any deployment-specific pyramid add-ons here
-pyramid.includes:
-    h.session
-
 # Use gevent-compatible transport for the Sentry client
 raven.transport: gevent
 

--- a/h/app.py
+++ b/h/app.py
@@ -122,6 +122,7 @@ def includeme(config):
     config.include('h.models')
     config.include('h.realtime')
     config.include('h.sentry')
+    config.include('h.session')
     config.include('h.stats')
     config.include('h.views')
 

--- a/h/session.py
+++ b/h/session.py
@@ -1,7 +1,4 @@
 # -*- coding: utf-8 -*-
-from pyramid.session import SignedCookieSessionFactory
-
-from h.security import derive_key
 
 
 def model(request):
@@ -58,10 +55,9 @@ def _current_groups(request):
 
 
 def includeme(config):
-    registry = config.registry
-    settings = registry.settings
-
-    session_secret = derive_key(settings['secret_key'], b'h.session')
-    session_factory = SignedCookieSessionFactory(session_secret, httponly=True)
-
-    config.set_session_factory(session_factory)
+    config.add_settings({
+        "redis.sessions.cookie_httponly": True,
+        "redis.sessions.cookie_max_age": 2592000,
+        "redis.sessions.timeout": 604800,
+    })
+    config.include('pyramid_redis_sessions')

--- a/h/websocket.py
+++ b/h/websocket.py
@@ -167,6 +167,7 @@ def create_app(global_config, **settings):
     config.include('pyramid_services')
 
     config.include('h.auth')
+    config.include('h.session')
     config.include('h.sentry')
     config.include('h.stats')
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 -e .
 certifi
 cffi
-pyramid_redis_sessions
 requests[security]
 wsaccel

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ INSTALL_REQUIRES = [
     'pyramid-multiauth>=0.8.0,<0.9.0',
     'pyramid-services==0.4',
     'pyramid_mailer>=0.13',
+    'pyramid-redis-sessions>=1.0.1,<1.2.0',
     'pyramid_tm>=0.7',
     'python-dateutil>=2.1',
     'python-slugify>=1.1.3,<1.2.0',


### PR DESCRIPTION
Prior to this PR, h used a signed cookie-based session in development, while using a session-only cookie and a session persisted in Redis in production.

The development documentation already requires a user to install and configure Redis, so there is no need for this violation of dev-prod parity[1] to continue.

[1]: http://12factor.net/dev-prod-parity