### PR TITLE
Move username charset validation to models layer

### DIFF
--- a/h/accounts/models.py
+++ b/h/accounts/models.py
@@ -2,6 +2,7 @@
 import datetime
 import hashlib
 import random
+import re
 import string
 
 import cryptacular.bcrypt
@@ -15,6 +16,7 @@ from h._compat import text_type
 CRYPT = cryptacular.bcrypt.BCRYPTPasswordManager()
 USERNAME_MIN_LENGTH = 3
 USERNAME_MAX_LENGTH = 30
+USERNAME_PATTERN = '(?i)^[A-Z0-9._]+$'
 EMAIL_MAX_LENGTH = 100
 PASSWORD_MIN_LENGTH = 2
 
@@ -103,6 +105,10 @@ class User(Base):
         return self._username
 
     def _set_username(self, value):
+        if not re.match(USERNAME_PATTERN, value):
+            raise ValueError('Username can only contain letters, numbers, periods'
+                             ' and underscores.')
+
         if not USERNAME_MIN_LENGTH <= len(value) <= USERNAME_MAX_LENGTH:
             raise ValueError('username must be between {min} and {max} '
                              'characters long'.format(

--- a/h/accounts/schemas.py
+++ b/h/accounts/schemas.py
@@ -186,7 +186,7 @@ class RegisterSchema(CSRFSchema):
                 min=models.USERNAME_MIN_LENGTH,
                 max=models.USERNAME_MAX_LENGTH),
             colander.Regex(
-                '(?i)^[A-Z0-9._]+$',
+                models.USERNAME_PATTERN,
                 msg=_("Must contain only letters, numbers, periods, and "
                       "underscores")),
             unique_username,

--- a/h/accounts/views.py
+++ b/h/accounts/views.py
@@ -124,7 +124,8 @@ class AuthController(object):
     def _login(self, user):
         user.last_login_date = datetime.datetime.utcnow()
         self.request.registry.notify(LoginEvent(self.request, user))
-        userid = util.user.userid_from_username(user.username, self.request)
+        userid = util.user.userid_from_username(user.username,
+            self.request.auth_domain)
         headers = security.remember(self.request, userid)
         return headers
 

--- a/h/admin/views/nipsa.py
+++ b/h/admin/views/nipsa.py
@@ -25,7 +25,7 @@ def nipsa_add(request):
     username = request.params["add"]
 
     if username:
-        userid = util.user.userid_from_username(username, request)
+        userid = util.user.userid_from_username(username, request.auth_domain)
         nipsa_service = request.find_service(name='nipsa')
         nipsa_service.flag(userid)
     else:
@@ -43,7 +43,7 @@ def nipsa_remove(request):
     username = request.params["remove"]
 
     if username:
-        userid = util.user.userid_from_username(username, request)
+        userid = util.user.userid_from_username(username, request.auth_domain)
         nipsa_service = request.find_service(name='nipsa')
         nipsa_service.unflag(userid)
     else:

--- a/h/admin/views/users.py
+++ b/h/admin/views/users.py
@@ -114,7 +114,7 @@ def delete_user(request, user):
 
 def _all_user_annotations_query(request, user):
     """Query matching all annotations (shared and private) owned by user."""
-    userid = util.user.userid_from_username(user.username, request)
+    userid = util.user.userid_from_username(user.username, request.auth_domain)
     return {
         'filtered': {
             'filter': {'term': {'user': userid.lower()}},

--- a/h/emails/reply_notification.py
+++ b/h/emails/reply_notification.py
@@ -52,5 +52,5 @@ def generate(request, notification):
 
 def _unsubscribe_token(request, user):
     serializer = request.registry.notification_serializer
-    userid = util.user.userid_from_username(user.username, request)
+    userid = util.user.userid_from_username(user.username, request.auth_domain)
     return serializer.dumps({'type': 'reply', 'uri': userid})

--- a/h/util/user.py
+++ b/h/util/user.py
@@ -21,7 +21,7 @@ def split_user(userid):
     raise ValueError("{userid} isn't a valid userid".format(userid=userid))
 
 
-def userid_from_username(username, request):
+def userid_from_username(username, auth_domain):
     """Return the full user ID for the given username.
 
     For example for username "seanh" return "acct:seanh@hypothes.is"
@@ -29,4 +29,4 @@ def userid_from_username(username, request):
 
     """
     return u"acct:{username}@{domain}".format(username=username,
-                                              domain=request.auth_domain)
+                                              domain=auth_domain)

--- a/tests/h/accounts/models_test.py
+++ b/tests/h/accounts/models_test.py
@@ -56,6 +56,11 @@ def test_cannot_create_user_with_too_long_username():
         models.User(username='1234567890123456789012345678901')
 
 
+def test_cannot_create_user_with_invalid_chars():
+    with pytest.raises(ValueError):
+        models.User(username='foo-bar')
+
+
 def test_cannot_create_user_with_too_long_email():
     with pytest.raises(ValueError):
         models.User(email='bob@b' + 'o'*100 +'b.com')

--- a/tests/h/util/user_test.py
+++ b/tests/h/util/user_test.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
+
 import pytest
-import mock
 
 from h.util import user as user_util
 
@@ -15,11 +15,7 @@ def test_split_user_no_match():
         user_util.split_user("donkeys")
 
 
-def test_userid_from_username_uses_request_dot_auth_domain():
-    """It should use the h.auth_domain setting if set."""
-    userid = user_util.userid_from_username(
-        'douglas',
-        mock.Mock(auth_domain='example.com')
-    )
+def test_userid_from_username():
+    userid = user_util.userid_from_username('douglas', 'example.com')
 
     assert userid == 'acct:douglas@example.com'


### PR DESCRIPTION
This PR is some preparatory refactoring extracted out of https://github.com/hypothesis/h/pull/3584

* Previously the username length was validated in the models layer but the username character set was not. That was only validated as part of the sign-up form validation. In order to support changing the username from other places (eg. the admin panel), add this validation to the models layer.
* Change the username -> userid helper to accept an auth_domain rather than a request so that it can be used from services which do not have a request object. This also saves some mocking in a test.