### PR TITLE
Activity page skeleton: Add free-text search query parser

### DIFF
--- a/h/api/search/parser.py
+++ b/h/api/search/parser.py
@@ -1,0 +1,112 @@
+# -*- coding: utf-8 -*-
+
+"""
+The query parser which converts our subset of the Apache Lucene syntax and
+transforms it into a MultiDict structure that h.api.search understands.
+"""
+
+from __future__ import unicode_literals
+
+from collections import namedtuple
+
+import pyparsing as pp
+from webob.multidict import MultiDict
+
+# Enable memoizing of the parsing logic
+pp.ParserElement.enablePackrat()
+
+# Named fields we support when querying (e.g. `user:luke`)
+named_fields = ['user', 'tag', 'group', 'uri']
+
+whitespace = set([
+    "\u0009",  # character tabulation
+    "\u000a",  # line feed
+    "\u000b",  # line tabulation
+    "\u000c",  # form feed
+    "\u000d",  # carriage return
+    "\u0020",  # space
+    "\u0085",  # next line
+    "\u00a0",  # no-break space
+    "\u1680",  # ogham space mark
+    "\u2000",  # en quad
+    "\u2001",  # em quad
+    "\u2002",  # en space
+    "\u2003",  # em space
+    "\u2004",  # three-per-em space
+    "\u2005",  # four-per-em space
+    "\u2006",  # six-per-em space
+    "\u2007",  # figure space
+    "\u2008",  # punctuation space
+    "\u2009",  # thin space
+    "\u200a",  # hair space
+    "\u2028",  # line separator
+    "\u2029",  # paragraph separator
+    "\u202f",  # narrow no-break space
+    "\u205f",  # medium mathematical space
+    "\u3000",  # ideographic space
+])
+
+parser = None
+Match = namedtuple('Match', ['key', 'value'])
+
+
+def parse(q):
+    """Parse a free text, Lucene-like, query string into a MultiDict.
+
+    "user:luke tag:foobar tag:news hello world" is parsed into:
+    ``
+    {
+        "user": "luke",
+        "tag": "foobar",
+        "tag": "news",
+        "any": "hello",
+        "any": "world"
+    }
+    ``
+
+    Supported keys for fields are ``user``, ``group``, ``tag``, ``uri``.
+    Any other search terms will get the key ``any``.
+    """
+    parser = _get_parser()
+    parse_results = parser.parseString(q)
+
+    # The parser returns all matched strings, even the field names, we use a
+    # parse action to turn matches into a key/value pair (Match), but we need
+    # to filter out any other matches that the parser returns.
+    return MultiDict([m for m in parse_results if isinstance(m, Match)])
+
+
+def _get_parser():
+    global parser
+    if parser is None:
+        parser = _make_parser()
+    return parser
+
+
+def _make_parser():
+    word = pp.CharsNotIn(''.join(whitespace))
+    word.skipWhitespace = True
+
+    value = pp.MatchFirst([
+        pp.dblQuotedString.copy().setParseAction(pp.removeQuotes),
+        pp.sglQuotedString.copy().setParseAction(pp.removeQuotes),
+        pp.Empty() + pp.CharsNotIn(''.join(whitespace)),
+    ])
+
+    expressions = []
+
+    for field in named_fields:
+        exp = pp.Suppress(pp.CaselessLiteral(field) + ':') + \
+            value.copy().setParseAction(_decorate_match(field))
+        expressions.append(exp)
+
+    any_ = value.copy().setParseAction(_decorate_match('any'))
+    expressions.append(any_)
+
+    return pp.ZeroOrMore(pp.MatchFirst(expressions))
+
+
+def _decorate_match(key):
+    def parse_action_impl(t):
+        return Match(key, t[0])
+    return parse_action_impl

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ INSTALL_REQUIRES = [
     'python-dateutil>=2.1',
     'python-slugify>=1.1.3,<1.2.0',
     'pyramid-jinja2>=2.3.3',
+    'pyparsing>=2.1.5',
     'raven>=5.10.2,<5.11.0',
     'requests>=2.7.0',
     'statsd>=3.2.1,<3.3.0',

--- a/tests/h/api/search/parser_test.py
+++ b/tests/h/api/search/parser_test.py
@@ -1,0 +1,112 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import pytest
+from hypothesis import strategies as st
+from hypothesis import given
+from webob.multidict import MultiDict
+
+from h.api.search import parser
+
+
+@pytest.mark.parametrize("query_in,query_out", [
+    # user field
+    ('user:luke', MultiDict([('user', 'luke')])),
+    ('user:luke@hypothes.is', MultiDict([('user', 'luke@hypothes.is')])),
+    ('user:acct:luke@hypothes.is', MultiDict([('user', 'acct:luke@hypothes.is')])),
+    ('user:luke user:alice', MultiDict([('user', 'luke'), ('user', 'alice')])),
+    ('user:"luke and alice"', MultiDict([('user', 'luke and alice')])),
+    ('user:"luke"', MultiDict([('user', 'luke')])),
+    ('USER:luke', MultiDict([('user', 'luke')])),
+
+
+    # tag field
+    ('tag:foo', MultiDict([('tag', 'foo')])),
+    ('tag:foo tag:bar', MultiDict([('tag', 'foo'), ('tag', 'bar')])),
+    ('tag:\'foo bar\'', MultiDict([('tag', 'foo bar')])),
+    ('tag:"foo bar"', MultiDict([('tag', 'foo bar')])),
+    ('tag:\'foobar\'', MultiDict([('tag', 'foobar')])),
+    ('Tag:foo', MultiDict([('tag', 'foo')])),
+
+    # group field
+    ('group:__world__', MultiDict([('group', '__world__')])),
+    ('group:__world__ group:My-Group', MultiDict([('group', '__world__'), ('group', 'My-Group')])),
+    ('GrOuP:__world__', MultiDict([('group', '__world__')])),
+
+    # uri field
+    ('uri:https://example.com', MultiDict([('uri', 'https://example.com')])),
+    ('uri:urn:x-pdf:hthe-fingerprint', MultiDict([('uri', 'urn:x-pdf:hthe-fingerprint')])),
+    ('uri:https://foo.com uri:http://bar.com', MultiDict([('uri', 'https://foo.com'), ('uri', 'http://bar.com')])),
+    ('uri:https://example.com?foo=bar&baz=qux#hello', MultiDict([('uri', 'https://example.com?foo=bar&baz=qux#hello')])),
+    ('URI:https://example.com', MultiDict([('uri', 'https://example.com')])),
+
+    # any field
+    ('foo', MultiDict([('any', 'foo')])),
+    ('foo bar', MultiDict([('any', 'foo'), ('any', 'bar')])),
+    ('foo "bar baz"', MultiDict([('any', 'foo'), ('any', 'bar baz')])),
+
+    # unrecognized fields go into any
+    ('bogus:hello', MultiDict([('any', 'bogus:hello')])),
+
+    # combinations
+    ('user:luke group:__world__ tag:foobar hello world', MultiDict([
+        ('user', 'luke'),
+        ('group', '__world__'),
+        ('tag', 'foobar'),
+        ('any', 'hello'),
+        ('any', 'world'),
+    ])),
+    ('tag:foo bar gRoup:__world__ giraffe', MultiDict([
+        ('group', '__world__'),
+        ('tag', 'foo'),
+        ('any', 'bar'),
+        ('any', 'giraffe'),
+    ])),
+])
+def test_parse(query_in, query_out):
+    assert parser.parse(query_in) == query_out
+
+
+@pytest.mark.parametrize("query_in,query_out", [
+    ('""', MultiDict([('any', '')])),
+    ("''", MultiDict([('any', "")])),
+    ('tag:""', MultiDict([('tag', '')])),
+    ('tag:"""', MultiDict([('tag', '"""')])),
+    ('"""', MultiDict([('any', '"""')])),
+    ("'''", MultiDict([('any', "'''")])),
+    ('tag:""""', MultiDict([('tag', '""')])),
+    ('""""', MultiDict([('any', '""')])),
+    ("''''", MultiDict([('any', "''")])),
+    ('tag:"""""', MultiDict([('tag', '"""""')])),
+    ('"""""', MultiDict([('any', '"""""')])),
+    ("'''''", MultiDict([('any', "'''''")])),
+    ('""0', MultiDict([('any', ''), ('any', '0')])),
+    ('0""', MultiDict([('any', '0""')])),
+    ('\'\'0""', MultiDict([('any', '0""')])),
+    ('\'0"', MultiDict([('any', '\'0"')])),
+])
+def test_parse_with_odd_quotes_combinations(query_in, query_out):
+    assert parser.parse(query_in) == query_out
+
+
+@given(st.text())
+@pytest.mark.fuzz
+def test_parse_always_return_a_multidict(text):
+    """Given any string input, output should always be a MultiDict."""
+    result = parser.parse(text)
+    assert isinstance(result, MultiDict)
+
+
+# Combinations of strings containing any number of quotes are already tested
+# separately.
+char_blacklist = parser.whitespace.union(set('\'"'))
+nonwhitespace_chars = st.characters(blacklist_characters=char_blacklist)
+nonwhitespace_text = st.text(alphabet=nonwhitespace_chars, min_size=1)
+
+
+@given(kw=st.sampled_from(parser.named_fields),
+       value=nonwhitespace_text)
+def test_parse_with_any_nonwhitespace_text(kw, value):
+    result = parser.parse(kw + ':' + value)
+    assert result.get(kw) == value


### PR DESCRIPTION
_This is part two of a four-part series of pull requests that adds a new free-text search parser and a skeleton page for playing with it. This needs rebasing after #3596 is merged._

This pull request adds a free-text search parser that converts a query like `user:chdorner tag:reading atlantic` into a MultiDict that looks like what the search api expects `{'user': 'chdorner', 'tag': 'reading', 'any': 'atlantic'}`.
It supports different named fields, strings in double or single quotes, and should work with any Unicode characters. For a complete list check out the test examples.

_These changes were split out of the PR #3588_