### PR TITLE
Activity page skeleton: Add UserFilter to search

### DIFF
--- a/h/api/search/core.py
+++ b/h/api/search/core.py
@@ -78,6 +78,7 @@ def default_querybuilder(request, private=True):
     builder.append_filter(query.AuthFilter(request, private=private))
     builder.append_filter(query.UriFilter(request))
     builder.append_filter(query.GroupFilter())
+    builder.append_filter(query.UserFilter())
     builder.append_matcher(query.AnyMatcher())
     builder.append_matcher(query.TagsMatcher())
     for factory in request.registry.get(FILTERS_KEY, []):

--- a/h/api/search/query.py
+++ b/h/api/search/query.py
@@ -185,6 +185,22 @@ class UriFilter(object):
         return {"terms": {"target.scope": list(uris)}}
 
 
+class UserFilter(object):
+
+    """
+    A filter that selects only annotations where the 'user' parameter matches.
+    """
+
+    def __call__(self, params):
+        if 'user' not in params:
+            return None
+
+        users = [v for k, v in params.items() if k == 'user']
+        del params['user']
+
+        return {'terms': {'user': users}}
+
+
 class AnyMatcher(object):
 
     """

--- a/h/api/search/query.py
+++ b/h/api/search/query.py
@@ -213,7 +213,7 @@ class AnyMatcher(object):
         qs = ' '.join([v for k, v in params.items() if k == "any"])
         result = {
             "simple_query_string": {
-                "fields": ["quote", "tags", "text", "uri.parts", "user"],
+                "fields": ["quote", "tags", "text", "uri.parts"],
                 "query": qs,
             }
         }

--- a/tests/h/api/search/core_test.py
+++ b/tests/h/api/search/core_test.py
@@ -113,7 +113,8 @@ def test_default_querybuilder_passes_private_to_AuthFilter(private, query, pyram
 @pytest.mark.parametrize('filter_type', [
     'AuthFilter',
     'UriFilter',
-    'GroupFilter'
+    'UserFilter',
+    'GroupFilter',
 ])
 def test_default_querybuilder_includes_default_filters(filter_type, matchers, pyramid_request):
     from h.api.search import query

--- a/tests/h/api/search/query_test.py
+++ b/tests/h/api/search/query_test.py
@@ -354,6 +354,39 @@ class TestUriFilter(object):
         return uri
 
 
+class TestUserFilter(object):
+    def test_term_filters_for_user(self):
+        userfilter = query.UserFilter()
+
+        assert userfilter({"user": "luke"}) == {"terms": {"user": ["luke"]}}
+
+    def test_supports_filtering_for_multiple_users(self):
+        userfilter = query.UserFilter()
+
+        params = multidict.MultiDict()
+        params.add("user", "alice")
+        params.add("user", "luke")
+
+        assert userfilter(params) == {
+            "terms": {
+                "user": ["alice", "luke"]
+            }
+        }
+
+    def test_strips_param(self):
+        userfilter = query.UserFilter()
+        params = {"user": "luke"}
+
+        userfilter(params)
+
+        assert params == {}
+
+    def test_returns_none_when_no_param(self):
+        userfilter = query.UserFilter()
+
+        assert userfilter({}) is None
+
+
 class TestAnyMatcher():
     def test_any_query(self):
         anymatcher = query.AnyMatcher()

--- a/tests/h/api/search/query_test.py
+++ b/tests/h/api/search/query_test.py
@@ -395,7 +395,7 @@ class TestAnyMatcher():
 
         assert result == {
             "simple_query_string": {
-                "fields": ["quote", "tags", "text", "uri.parts", "user"],
+                "fields": ["quote", "tags", "text", "uri.parts"],
                 "query": "foo",
             }
         }
@@ -411,7 +411,7 @@ class TestAnyMatcher():
 
         assert result == {
             "simple_query_string": {
-                "fields": ["quote", "tags", "text", "uri.parts", "user"],
+                "fields": ["quote", "tags", "text", "uri.parts"],
                 "query": "howdy there",
             }
         }


### PR DESCRIPTION
_This is part three of a four-part series of pull requests that adds a new free-text search parser and a skeleton page for playing with it. This needs rebasing after #3597 is merged._

This pull request removes the `user` field from the `AnyMatcher` and adds a new `UserFilter` to our search query builder.
I think this should be a backwards-compatible change, but please look out for issues when reviewing.

_These changes were split out of the PR #3588_