### PR TITLE
Activity page skeleton: Add skeleton page

### DIFF
--- a/h/activity/__init__.py
+++ b/h/activity/__init__.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+
+
+def includeme(config):
+    config.include('h.activity.views')
+
+    config.add_route('activity.search', '/search')

--- a/h/activity/views.py
+++ b/h/activity/views.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+
+"""
+Activity pages views.
+"""
+
+from __future__ import unicode_literals
+
+from pyramid import httpexceptions
+from pyramid.view import view_config
+
+from h import models
+from h.api import search as search_lib
+from h.api.search import parser
+from h.api import storage
+
+
+@view_config(route_name='activity.search',
+             request_method='GET',
+             renderer='h:templates/activity/search.html.jinja2')
+def search(request):
+    if not request.feature('activity_pages'):
+        raise httpexceptions.HTTPNotFound()
+
+    results = []
+    total = None
+    if 'q' in request.params:
+        query = parser.parse(request.params['q'])
+
+        out = search_lib.search(request, query)
+        total = out['total']
+
+        anns = storage.fetch_ordered_annotations(request.db,
+                                                 [r['id'] for r in out['rows']])
+        for ann in anns:
+            group = request.db.query(models.Group).filter(models.Group.pubid == ann.groupid).one_or_none()
+            result = {
+                'annotation': ann,
+                'group': group,
+            }
+            results.append(result)
+
+    return {
+        'q': request.params.get('q', ''),
+        'total': total,
+        'results': results
+    }
+
+
+def includeme(config):
+    config.scan(__name__)

--- a/h/app.py
+++ b/h/app.py
@@ -113,6 +113,7 @@ def includeme(config):
     config.include('h.api', route_prefix='/api')
 
     # Core site modules
+    config.include('h.activity')
     config.include('h.assets')
     config.include('h.auth')
     config.include('h.db')

--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -1,0 +1,31 @@
+<form>
+  <input name="q" value="{{ q }}" placeholder="Search query">
+  <input type="submit" value="Search">
+</form>
+
+{% if total %}
+Total: {{ total }}
+{% endif %}
+
+{% for result in results %}
+<hr>
+
+<table>
+  <tr><th>ID</th><td>{{ result.annotation.id }}</td></tr>
+  <tr><th>User</th><td>{{ result.annotation.userid }}</td></tr>
+  <tr><th>Group</th><td>{{ result.group.name }}</td></tr>
+  <tr><th>Shared</th><td>{{ result.annotation.shared }}</td></tr>
+  <tr><th>URI</th><td>{{ result.annotation.target_uri }}</td></tr>
+  <tr><th>Text</th><td>{{ result.annotation.text }}</td></tr>
+  <tr>
+    <th>Tags</th>
+    <td>
+      <ul>
+        {% for tag in result.annotation.tags %}
+        <li>{{ tag }}</li>
+        {% endfor %}
+      </ul>
+    </td>
+    </tr>
+</table>
+{% endfor %}

--- a/tests/h/activity/views_test.py
+++ b/tests/h/activity/views_test.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+
+from pyramid import httpexceptions
+
+from h.activity import views
+
+
+# The search view is just a skeleton at the moment, the only part we should
+# test at the moment is that it returns a 404 response when the feature flag
+# is turned off.
+class TestSearch(object):
+    def test_it_returns_404_when_feature_turned_off(self, pyramid_request):
+        pyramid_request.feature.flags['activity_pages'] = False
+
+        with pytest.raises(httpexceptions.HTTPNotFound):
+            views.search(pyramid_request)


### PR DESCRIPTION
_This is part foiur of a four-part series of pull requests that adds a new free-text search parser and a skeleton page for playing with it. This needs rebasing after #3598 is merged._

Finally, this pull request adds a skeleton page with a search form for playing around with the search parser. This is behind a feature flag, so the design shouldn't matter (it looks like the browser default styles).

_These changes were split out of the PR #3588_