### PR TITLE
Modify the copy on reply notification email

### DIFF
--- a/h/emails/reply_notification.py
+++ b/h/emails/reply_notification.py
@@ -22,19 +22,19 @@ def generate(request, notification):
         document_title = notification.parent.target_uri
 
     parent_user_url = request.route_url('stream.user_query',
-                                        user=notification.parent_user.username) 
+                                        user=notification.parent_user.username)
 
     reply_url = links.incontext_link(request, notification.reply)
     if not reply_url:
         reply_url = request.route_url('annotation', id=notification.reply.id)
 
     reply_user_url = request.route_url('stream.user_query',
-                                        user=notification.reply_user.username)
+                                       user=notification.reply_user.username)
 
-    unsubscribe_token=_unsubscribe_token(request, notification.parent_user)
-    unsubscribe_url=request.route_url('unsubscribe', token = unsubscribe_token)
+    unsubscribe_token = _unsubscribe_token(request, notification.parent_user)
+    unsubscribe_url = request.route_url('unsubscribe', token=unsubscribe_token)
 
-    context={
+    context = {
         'document_title': document_title,
         'document_url': notification.parent.target_uri,
         'parent': notification.parent,
@@ -48,18 +48,19 @@ def generate(request, notification):
     }
 
     subject = '{user} has replied to your annotation'.format(
-        user = notification.reply_user.username)
-    text=render('h:templates/emails/reply_notification.txt.jinja2',
+        user=notification.reply_user.username)
+    text = render('h:templates/emails/reply_notification.txt.jinja2',
                   context,
-                  request = request)
-    html=render('h:templates/emails/reply_notification.html.jinja2',
+                  request=request)
+    html = render('h:templates/emails/reply_notification.html.jinja2',
                   context,
-                  request = request)
+                  request=request)
 
     return [notification.parent_user.email], subject, text, html
 
 
 def _unsubscribe_token(request, user):
-    serializer=request.registry.notification_serializer
-    userid=util.user.userid_from_username(user.username, request.auth_domain)
+    serializer = request.registry.notification_serializer
+    userid = util.user.userid_from_username(user.username, request.auth_domain)
     return serializer.dumps({'type': 'reply', 'uri': userid})
+

--- a/h/emails/reply_notification.py
+++ b/h/emails/reply_notification.py
@@ -21,36 +21,45 @@ def generate(request, notification):
     if not document_title:
         document_title = notification.parent.target_uri
 
+    parent_user_url = request.route_url('stream.user_query',
+                                        user=notification.parent_user.username) 
+
     reply_url = links.incontext_link(request, notification.reply)
     if not reply_url:
         reply_url = request.route_url('annotation', id=notification.reply.id)
 
-    unsubscribe_token = _unsubscribe_token(request, notification.parent_user)
-    unsubscribe_url = request.route_url('unsubscribe', token=unsubscribe_token)
+    reply_user_url = request.route_url('stream.user_query',
+                                        user=notification.reply_user.username)
 
-    context = {
+    unsubscribe_token=_unsubscribe_token(request, notification.parent_user)
+    unsubscribe_url=request.route_url('unsubscribe', token = unsubscribe_token)
+
+    context={
         'document_title': document_title,
         'document_url': notification.parent.target_uri,
         'parent': notification.parent,
+        'parent_user': notification.parent_user,
+        'parent_user_url': parent_user_url,
         'reply': notification.reply,
         'reply_url': reply_url,
         'reply_user': notification.reply_user,
+        'reply_user_url': reply_user_url,
         'unsubscribe_url': unsubscribe_url,
     }
 
     subject = '{user} has replied to your annotation'.format(
-        user=notification.reply_user.username)
-    text = render('h:templates/emails/reply_notification.txt.jinja2',
+        user = notification.reply_user.username)
+    text=render('h:templates/emails/reply_notification.txt.jinja2',
                   context,
-                  request=request)
-    html = render('h:templates/emails/reply_notification.html.jinja2',
+                  request = request)
+    html=render('h:templates/emails/reply_notification.html.jinja2',
                   context,
-                  request=request)
+                  request = request)
 
     return [notification.parent_user.email], subject, text, html
 
 
 def _unsubscribe_token(request, user):
-    serializer = request.registry.notification_serializer
-    userid = util.user.userid_from_username(user.username, request.auth_domain)
+    serializer=request.registry.notification_serializer
+    userid=util.user.userid_from_username(user.username, request.auth_domain)
     return serializer.dumps({'type': 'reply', 'uri': userid})

--- a/h/jinja_extensions.py
+++ b/h/jinja_extensions.py
@@ -17,6 +17,14 @@ class Filters(Extension):
         super(Filters, self).__init__(environment)
 
         environment.filters['to_json'] = to_json
+        environment.filters['human_timestamp'] = human_timestamp
+
+def human_timestamp(timestamp, now=datetime.datetime.utcnow):
+    """Turn a :py:class:`datetime.datetime` into a human-friendly string."""
+    fmt = '%d %B at %H:%M'
+    if timestamp.year < now().year:
+        fmt = '%d %B %Y at %H:%M'
+    return timestamp.strftime(fmt)
 
 
 def to_json(value):

--- a/h/jinja_extensions.py
+++ b/h/jinja_extensions.py
@@ -19,6 +19,7 @@ class Filters(Extension):
         environment.filters['to_json'] = to_json
         environment.filters['human_timestamp'] = human_timestamp
 
+
 def human_timestamp(timestamp, now=datetime.datetime.utcnow):
     """Turn a :py:class:`datetime.datetime` into a human-friendly string."""
     fmt = '%d %B at %H:%M'

--- a/h/templates/emails/reply_notification.html.jinja2
+++ b/h/templates/emails/reply_notification.html.jinja2
@@ -1,14 +1,16 @@
-<p>{{ reply_user.username }} has
-<a href="{{ reply_url }}">left a reply to your annotation</a>
+<p><a href="{{ reply_user_url }}">{{ reply_user.username }}</a> has
+<a href="{{ reply_url }}">replied to your annotation</a>
 on <a href="{{ reply_url }}">&ldquo;{{ document_title }}&rdquo;</a>:</p>
 
-<blockquote>{{ reply.text or "" }}</blockquote>
-
-<p>This was in reply to your annotation:</p>
+<p>On <a href="{{ parent_path }}">{{ parent_timestamp }}</a> <a href="{{ parent_user_url }}">{{ parent_user }}</a> commented:</p>
 
 <blockquote>{{ parent.text or "" }}</blockquote>
 
-<p><a href="{{ reply_url }}">View the thread</a>.</p>
+<p>On <a href="{{ reply_path }}">{{ reply_timestamp }}</a> <a href="{{ reply_user_url }}">{{ reply_user }}</a> replied:</p>
+
+<blockquote>{{ reply.text or "" }}</blockquote>
+
+<p><a href="{{ reply_url }}">View the thread and respond</a>.</p>
 
 <p><small>If you'd rather not receive these notifications you can
 <a href="{{ unsubscribe_url }}">unsubscribe now</a>.</small></p>

--- a/h/templates/emails/reply_notification.txt.jinja2
+++ b/h/templates/emails/reply_notification.txt.jinja2
@@ -1,11 +1,13 @@
-{{ reply_user.username }} has left a reply to your annotation on "{{ document_title }}":
+{{ reply_user.username }} has just left a reply to your annotation on "{{ document_title }}":
 
-> {{ reply.text or "" }}
-
-This was in reply to your annotation:
+On {{ parent.created | human_timestamp }} {{ parent_user.username }} said:
 
 > {{ parent.text or "" }}
 
-View the thread: {{ reply_url }}
+On {{ reply.created | human_timestamp }} {{ reply_user.username }} replied:
+
+> {{ reply.text or "" }}
+
+View the thread and respond: {{ reply_url }}
 
 If you'd rather not receive these notifications you can unsubscribe here: {{ unsubscribe_url }}

--- a/tests/h/emails/reply_notification_test.py
+++ b/tests/h/emails/reply_notification_test.py
@@ -144,7 +144,8 @@ class TestGenerate(object):
     @pytest.fixture
     def document(self, db_session):
         doc = Document()
-        doc.meta.append(DocumentMeta(type='title', value=['My fascinating page'], claimant='http://example.org'))
+        doc.meta.append(DocumentMeta(
+            type='title', value=['My fascinating page'], claimant='http://example.org'))
         db_session.add(doc)
         db_session.flush()
         return doc

--- a/tests/h/emails/reply_notification_test.py
+++ b/tests/h/emails/reply_notification_test.py
@@ -38,9 +38,12 @@ class TestGenerate(object):
             'document_title': 'My fascinating page',
             'document_url': 'http://example.org/',
             'parent': notification.parent,
+            'parent_user': parent_user,
+            'parent_user_url': 'http://example.com/stream/user/patricia',
             'reply': notification.reply,
             'reply_url': links.incontext_link.return_value,
             'reply_user': reply_user,
+            'reply_user_url': 'http://example.com/stream/user/ron',
             'unsubscribe_url': 'http://example.com/unsub/FAKETOKEN',
         }
         html_renderer.assert_(**expected_context)
@@ -83,9 +86,12 @@ class TestGenerate(object):
             'document_title': 'My fascinating page',
             'document_url': 'http://example.org/',
             'parent': notification.parent,
+            'parent_user': parent_user,
+            'reply_user_url': 'http://example.com/stream/user/patricia',
             'reply': notification.reply,
             'reply_url': 'http://example.com/ann/bar456',
             'reply_user': reply_user,
+            'reply_user_url': 'http://example.com/stream/user/ron',
             'unsubscribe_url': 'http://example.com/unsub/FAKETOKEN',
         }
         html_renderer.assert_(**expected_context)

--- a/tests/h/jinja_extension_test.py
+++ b/tests/h/jinja_extension_test.py
@@ -8,9 +8,24 @@ from h import jinja_extensions as ext
 
 
 @pytest.mark.parametrize("value_in,json_out", [
-  ({"foo": 42}, "{\"foo\": 42}")
+    ({"foo": 42}, "{\"foo\": 42}")
 ])
 def test_to_json(value_in, json_out):
     result = str(ext.to_json(value_in))
 
     assert result == json_out
+
+
+@pytest.mark.parametrize("timestamp_in,string_out", [
+    # Basic format for recent timestamps
+    (datetime.datetime(2016, 4, 14, 16, 45, 36, 529730),
+     '14 April at 16:45'),
+    # For times more than a year ago, add the year
+    (datetime.datetime(2012, 4, 14, 16, 45, 36, 529730),
+     '14 April 2012 at 16:45'),
+])
+def test_human_timestamp(timestamp_in, string_out):
+    result = ext.human_timestamp(
+        timestamp_in, now=lambda: datetime.datetime(2016, 4, 14))
+
+    assert result == string_out


### PR DESCRIPTION
Makes the copy changes suggested here (https://trello.com/c/XalCNLCx/396-update-reply-email-copy)
Reverts some changes from previous versions of this email (adds a timestamp, brings back links to usernames)


