### PR TITLE
Centralise style configuration in base.html layout

### DIFF
--- a/h/templates/accounts/claim_account_legacy.html.jinja2
+++ b/h/templates/accounts/claim_account_legacy.html.jinja2
@@ -1,12 +1,8 @@
 {% extends "h:templates/layouts/base.html.jinja2" %}
 
-{% block page_title %}Claim account{% endblock page_title %}
+{% set uses_legacy_styles = True %}
 
-{% block styles %}
-{% for url in asset_client_urls("app_css") %}
-<link rel="stylesheet" href="{{ url }}">
-{% endfor %}
-{% endblock %}
+{% block page_title %}Claim account{% endblock page_title %}
 
 {% block content %}
   <div id="claim" class="content paper">

--- a/h/templates/accounts/forgot_password.html.jinja2
+++ b/h/templates/accounts/forgot_password.html.jinja2
@@ -1,12 +1,8 @@
 {% extends "h:templates/layouts/base.html.jinja2" %}
 
-{% block page_title %}Password reset{% endblock %}
+{% set uses_legacy_styles = True %}
 
-{% block styles %}
-{% for url in asset_client_urls("app_css") %}
-<link rel="stylesheet" href="{{ url }}">
-{% endfor %}
-{% endblock styles  %}
+{% block page_title %}Password reset{% endblock %}
 
 {% block content %}
   <div class="content paper">

--- a/h/templates/accounts/login.html.jinja2
+++ b/h/templates/accounts/login.html.jinja2
@@ -1,12 +1,8 @@
 {% extends "h:templates/layouts/base.html.jinja2" %}
 
-{% block page_title %}Log in{% endblock %}
+{% set uses_legacy_styles = True %}
 
-{% block styles %}
-{% for url in asset_client_urls("app_css") %}
-<link rel="stylesheet" href="{{ url }}">
-{% endfor %}
-{% endblock styles  %}
+{% block page_title %}Log in{% endblock %}
 
 {% block content %}
   <div class="content paper">

--- a/h/templates/accounts/register.html.jinja2
+++ b/h/templates/accounts/register.html.jinja2
@@ -1,12 +1,8 @@
 {% extends "h:templates/layouts/base.html.jinja2" %}
 
-{% block page_title %}Create an account{% endblock %}
+{% set uses_legacy_styles = True %}
 
-{% block styles %}
-{% for url in asset_client_urls("app_css") %}
-<link rel="stylesheet" href="{{ url }}">
-{% endfor %}
-{% endblock styles  %}
+{% block page_title %}Create an account{% endblock %}
 
 {% block content %}
   <div class="content paper">

--- a/h/templates/accounts/reset_password.html.jinja2
+++ b/h/templates/accounts/reset_password.html.jinja2
@@ -1,12 +1,8 @@
 {% extends "h:templates/layouts/base.html.jinja2" %}
 
-{% block page_title %}Password reset{% endblock %}
+{% set uses_legacy_styles = True %}
 
-{% block styles %}
-{% for url in asset_client_urls("app_css") %}
-<link rel="stylesheet" href="{{ url }}">
-{% endfor %}
-{% endblock styles  %}
+{% block page_title %}Password reset{% endblock %}
 
 {% block content %}
   <div class="content paper">

--- a/h/templates/groups/create.html.jinja2
+++ b/h/templates/groups/create.html.jinja2
@@ -2,12 +2,6 @@
 
 {% block page_title %}Create a new group{% endblock page_title %}
 
-{% block styles %}
-{% for url in asset_urls("site_css") %}
-<link rel="stylesheet" href="{{url}}">
-{% endfor %}
-{% endblock %}
-
 {% block content %}
   <div class="content content--narrow">
     <div class="group-form">

--- a/h/templates/groups/join.html.jinja2
+++ b/h/templates/groups/join.html.jinja2
@@ -2,12 +2,6 @@
 
 {% block page_title %}{{ group.name }}{% endblock page_title %}
 
-{% block styles %}
-{% for url in asset_urls("site_css") %}
-<link rel="stylesheet" href="{{ url }}">
-{% endfor %}
-{% endblock %}
-
 {% block content %}
   <div class="content content--narrow">
     <div class="group-form">

--- a/h/templates/groups/share.html.jinja2
+++ b/h/templates/groups/share.html.jinja2
@@ -2,12 +2,6 @@
 
 {% block page_title %}{{ group.name }}{% endblock page_title %}
 
-{% block styles %}
-{% for url in asset_urls("site_css") %}
-<link rel="stylesheet" href="{{ url }}">
-{% endfor %}
-{% endblock %}
-
 {% set group_url = request.route_url('group_read', pubid=group.pubid, slug=group.slug) %}
 
 {% block content %}

--- a/h/templates/help.html.jinja2
+++ b/h/templates/help.html.jinja2
@@ -1,5 +1,7 @@
 {% extends "layouts/base.html.jinja2" %}
 
+{% set style_bundle = 'help_page_css' %}
+
 {% block meta %}
   <link href='//fonts.googleapis.com/css?family=Lato:400,300' rel='stylesheet' type='text/css'>
   {{ super() }}
@@ -7,12 +9,6 @@
   {% if not is_onboarding %}
     <script async defer src="{{ embed_js_url }}"></script>
   {% endif %}
-{% endblock %}
-
-{% block styles %}
-{% for url in asset_urls("help_page_css") %}
-<link rel="stylesheet" href="{{ url }}">
-{% endfor %}
 {% endblock %}
 
 {% block content %}

--- a/h/templates/home.html.jinja2
+++ b/h/templates/home.html.jinja2
@@ -1,4 +1,5 @@
 {% set rss_feed_url = base_url + "feed/" %}
+{% set style_bundle = "front_page_css" %}
 
 {% extends "h:templates/layouts/base.html.jinja2" %}
 
@@ -10,12 +11,6 @@
   <link rel="chrome-webstore-item"
         href="{{ chrome_extension_link }}">
   <link href="{{ rss_feed_url }}" rel="alternate" type="application/rss+xml">
-{% endblock %}
-
-{% block styles %}
-{% for url in asset_urls("front_page_css") %}
-<link rel="stylesheet" href="{{ url }}">
-{% endfor %}
 {% endblock %}
 
 {% block content %}

--- a/h/templates/layouts/account.html.jinja2
+++ b/h/templates/layouts/account.html.jinja2
@@ -1,5 +1,6 @@
 {% extends "h:templates/layouts/base.html.jinja2" %}
 
+{%- set uses_legacy_styles = True -%}
 {%- set nav_pages = [
     ('account', 'Account'),
     ('account_notifications', 'Notifications'),
@@ -7,12 +8,6 @@
 ] -%}
 
 {% block page_title %}{{ page_title }}{% endblock %}
-
-{% block styles %}
-{% for url in asset_client_urls("app_css") %}
-<link rel="stylesheet" href="{{ url }}">
-{% endfor %}
-{% endblock styles  %}
 
 {% block content %}
   <div class="content paper">

--- a/h/templates/layouts/base.html.jinja2
+++ b/h/templates/layouts/base.html.jinja2
@@ -1,3 +1,8 @@
+{#- NOT FOR USE by new templates, this flag controls whether the template uses
+    legacy styles provided by the client bundle. -#}
+{%- set uses_legacy_styles = uses_legacy_styles|default(False) -%}
+{#- Controls the name of the default style bundle included on the page. -#}
+{%- set style_bundle = style_bundle|default('site_css') -%}
 <!DOCTYPE html>
 <html lang="en" prefix="og: http://ogp.me/ns#">
   <head>
@@ -26,7 +31,18 @@
     {% for attrs in link_attrs -%}
       <link {% for key, value in attrs.items() %}{{ key }}="{{ value }}" {% endfor %}/>
     {% endfor -%}
-    {% block styles %}{% endblock %}
+
+    {% block styles %}
+      {% if uses_legacy_styles %}
+        {% for url in asset_client_urls("app_css") %}
+        <link rel="stylesheet" href="{{ url }}">
+        {% endfor %}
+      {% else %}
+        {% for url in asset_urls(style_bundle) %}
+        <link rel="stylesheet" href="{{ url }}">
+        {% endfor %}
+      {% endif %}
+    {% endblock %}
 
     <link rel="apple-touch-icon" sizes="152x152"
           href="{{ base_url }}assets/images/apple-touch-icon-152x152.png">

--- a/h/templates/notfound.html.jinja2
+++ b/h/templates/notfound.html.jinja2
@@ -1,12 +1,8 @@
 {% extends "layouts/base.html.jinja2" %}
 
-{% block title %}Page Not Found{% endblock %}
+{% set uses_legacy_styles = True %}
 
-{% block styles %}
-{% for url in asset_client_urls("app_css") %}
-<link rel="stylesheet" href="{{ url }}">
-{% endfor %}
-{% endblock %}
+{% block title %}Page Not Found{% endblock %}
 
 {% block content %}
   <main class="content paper styled-text page">

--- a/h/templates/unsubscribe.html.jinja2
+++ b/h/templates/unsubscribe.html.jinja2
@@ -1,12 +1,8 @@
 {% extends "layouts/base.html.jinja2" %}
 
-{% block title %}Unsubscribed{% endblock %}
+{% set uses_legacy_styles = True %}
 
-{% block styles %}
-{% for url in asset_client_urls("app_css") %}
-<link rel="stylesheet" href="{{ url }}">
-{% endfor %}
-{% endblock %}
+{% block title %}Unsubscribed{% endblock %}
 
 {% block content %}
   <main class="content paper styled-text page">


### PR DESCRIPTION
Rather than every single template getting to choose its own style bundle, it makes sense for the base layout to provide a sensible default which can be overridden by templates that extend the layout.

This commit sets things up so that:

1. By default, templates extending `base.html.jinja2` will get the `site_css` bundle included.
2. Legacy templates (those that include CSS from the client) are explicitly marked by setting a `uses_legacy_styles` flag in the template.
3. Templates which are not "legacy" but which wish to override the style bundle can set a `style_bundle` template variable to select a different style bundle.

This commit should have no user-visible side-effects.