### PR TITLE
Add a "v2" site CSS bundle and make it the default

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -140,6 +140,7 @@ var styleFiles = [
   './h/static/styles/front-page/main.css',
   './h/static/styles/help-page.scss',
   './h/static/styles/site.scss',
+  './h/static/styles/site-v2.scss',
   './h/static/styles/old-home.scss',
 
   // Vendor

--- a/h/assets.ini
+++ b/h/assets.ini
@@ -24,6 +24,8 @@ site_css =
   styles/site.css
   styles/icomoon.css
 
+site_v2_css =
+  styles/site-v2.css
 
 front_page_js =
   scripts/jquery.bundle.js

--- a/h/templates/groups/create.html.jinja2
+++ b/h/templates/groups/create.html.jinja2
@@ -1,5 +1,7 @@
 {% extends "h:templates/layouts/base.html.jinja2" %}
 
+{% set style_bundle = 'site_css' %}
+
 {% block page_title %}Create a new group{% endblock page_title %}
 
 {% block content %}

--- a/h/templates/groups/join.html.jinja2
+++ b/h/templates/groups/join.html.jinja2
@@ -1,5 +1,7 @@
 {% extends "h:templates/layouts/base.html.jinja2" %}
 
+{% set style_bundle = 'site_css' %}
+
 {% block page_title %}{{ group.name }}{% endblock page_title %}
 
 {% block content %}

--- a/h/templates/groups/share.html.jinja2
+++ b/h/templates/groups/share.html.jinja2
@@ -1,5 +1,7 @@
 {% extends "h:templates/layouts/base.html.jinja2" %}
 
+{% set style_bundle = 'site_css' %}
+
 {% block page_title %}{{ group.name }}{% endblock page_title %}
 
 {% set group_url = request.route_url('group_read', pubid=group.pubid, slug=group.slug) %}

--- a/h/templates/layouts/base.html.jinja2
+++ b/h/templates/layouts/base.html.jinja2
@@ -2,7 +2,7 @@
     legacy styles provided by the client bundle. -#}
 {%- set uses_legacy_styles = uses_legacy_styles|default(False) -%}
 {#- Controls the name of the default style bundle included on the page. -#}
-{%- set style_bundle = style_bundle|default('site_css') -%}
+{%- set style_bundle = style_bundle|default('site_v2_css') -%}
 <!DOCTYPE html>
 <html lang="en" prefix="og: http://ogp.me/ns#">
   <head>


### PR DESCRIPTION
This PR adds a `site-v2` CSS bundle, which is currently completely empty, and
makes it the default for all templates which extend from `base.html.jinja2`.

We add opt-outs for those pages (basically just group pages) which don't already explicitly opt-out of the default bundle.

This might seem a counterintuitive approach, as this commit means that the base layout "default bundle" is now not being used by *any* of the templates that extend the layout. But by making the default bundle `site_v2_css` we make it much easier to grep for templates which need updating to use the default bundle, and once fixed we simply *remove overrides* from those templates.