### PR TITLE
Lowercase search term in user filter

### DIFF
--- a/h/api/search/query.py
+++ b/h/api/search/query.py
@@ -195,7 +195,7 @@ class UserFilter(object):
         if 'user' not in params:
             return None
 
-        users = [v for k, v in params.items() if k == 'user']
+        users = [v.lower() for k, v in params.items() if k == 'user']
         del params['user']
 
         return {'terms': {'user': users}}

--- a/tests/h/api/search/query_test.py
+++ b/tests/h/api/search/query_test.py
@@ -373,6 +373,11 @@ class TestUserFilter(object):
             }
         }
 
+    def test_lowercases_value(self):
+        userfilter = query.UserFilter()
+
+        assert userfilter({"user": "LUkE"}) == {"terms": {"user": ["luke"]}}
+
     def test_strips_param(self):
         userfilter = query.UserFilter()
         params = {"user": "luke"}


### PR DESCRIPTION
The field analyzer lowercases the value without adding a search analyzer
to lowercase it as well, so we need to do that before we pass the query
to Elasticsearch.

Fixes #3608