### PR TITLE
Add temporary redirects for renamed user account URLs

### DIFF
--- a/h/app.py
+++ b/h/app.py
@@ -57,6 +57,7 @@ def includeme(config):
                           'h.api.events.AnnotationEvent')
 
     config.add_tween('h.tweens.conditional_http_tween_factory', under=EXCVIEW)
+    config.add_tween('h.tweens.redirect_tween_factory')
     config.add_tween('h.tweens.csrf_tween_factory')
     config.add_tween('h.tweens.auth_token')
     config.add_tween('h.tweens.content_security_policy_tween_factory')

--- a/h/tweens.py
+++ b/h/tweens.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import collections
+from pyramid import httpexceptions
 
 
 def auth_token(handler, registry):
@@ -96,3 +97,20 @@ def content_security_policy_tween_factory(handler, registry):
         return resp
 
     return content_security_policy_tween
+
+
+def redirect_tween_factory(handler, registry):
+    redirects = {
+        '/profile': 'account',
+        '/profile/notifications': 'account_notifications',
+        '/profile/developer': 'account_developer'
+    }
+
+    def redirect_tween(request):
+        redirect = redirects.get(request.path, False)
+        if redirect:
+            return httpexceptions.HTTPMovedPermanently(location=request.route_url(redirect))
+        else:
+            return handler(request)
+
+    return redirect_tween

--- a/h/tweens.py
+++ b/h/tweens.py
@@ -99,13 +99,14 @@ def content_security_policy_tween_factory(handler, registry):
     return content_security_policy_tween
 
 
-def redirect_tween_factory(handler, registry):
-    redirects = {
-        '/profile': 'account',
-        '/profile/notifications': 'account_notifications',
-        '/profile/developer': 'account_developer'
-    }
+REDIRECTS = {
+    '/profile': 'account',
+    '/profile/notifications': 'account_notifications',
+    '/profile/developer': 'account_developer'
+}
 
+
+def redirect_tween_factory(handler, registry, redirects=REDIRECTS):
     def redirect_tween(request):
         redirect = redirects.get(request.path, False)
         if redirect:

--- a/tests/h/tweens_test.py
+++ b/tests/h/tweens_test.py
@@ -77,3 +77,36 @@ def test_tween_csp_header(pyramid_request):
         "script-src 'self'; style-src 'self' fonts.googleapis.com"
 
     assert expected == response.headers['Content-Security-Policy']
+
+
+def test_tween_redirect_non_redirected_route(pyramid_request):
+    redirects = {'/foo': 'bar'}
+
+    pyramid_request.path = '/quux'
+
+    tween = tweens.redirect_tween_factory(
+        lambda req: req.response,
+        pyramid_request.registry,
+        redirects)
+
+    response = tween(pyramid_request)
+
+    assert response.status_code == 200
+
+
+def test_tween_redirect_redirected_route(pyramid_request, pyramid_config):
+    redirects = {'/foo': 'bar'}
+
+    pyramid_config.add_route('bar', '/bar')
+
+    pyramid_request.path = '/foo'
+
+    tween = tweens.redirect_tween_factory(
+        lambda req: req.response,
+        pyramid_request.registry,
+        redirects)
+
+    response = tween(pyramid_request)
+
+    assert response.status_code == 301
+    assert response.location == 'http://example.com/bar'


### PR DESCRIPTION
This is required so that the older versions of the client do not stop
working while the extension gets updated.