### PR TITLE
Remove unused SASS variables and mixins

### DIFF
--- a/h/static/styles/mixins/_reset.scss
+++ b/h/static/styles/mixins/_reset.scss
@@ -10,23 +10,3 @@
   border: 0;
 }
 
-// Adapted from http://compass-style.org/reference/compass/reset/utilities/#mixin-nested-reset
-@mixin nested-reset {
-  div, span, applet, object, iframe,
-  h1, h2, h3, h4, h5, h6, p, blockquote, pre,
-  a, abbr, acronym, address, big, cite, code,
-  del, dfn, em, img, ins, kbd, q, s, samp,
-  small, strike, strong, sub, sup, tt, var,
-  b, u, i, center,
-  dl, dt, dd, ol, ul, li,
-  fieldset, form, label, legend,
-  table, caption, tbody, tfoot, thead, tr, th, td,
-  article, aside, canvas, details, embed,
-  figure, figcaption, footer, header, hgroup,
-  menu, nav, output, ruby, section, summary,
-  time, mark, audio, video {
-    @include reset-box-model;
-    @include reset-font;
-  }
-}
-

--- a/h/static/styles/mixins/_responsive.scss
+++ b/h/static/styles/mixins/_responsive.scss
@@ -2,38 +2,6 @@ $break-wide-handheld: 480px !default;
 $break-tablet: 768px !default;
 $break-desktop: 1024px !default;
 
-// DEPRECATED: Use mobile first mixins defined below.
-@mixin respond-to($media) {
-  @if type-of($media) == 'string' {
-    @if $media == 'handhelds' {
-      @media only screen and (max-width: $break-wide-handheld) { @content; }
-    }
-    @else if $media == 'wide-handhelds' {
-      @media only screen and (min-width: $break-wide-handheld + 1) and (max-width: $break-tablet) { @content; }
-    }
-    @else if $media == 'tablets' {
-      @media only screen and (min-width: $break-tablet + 1) and (max-width: $break-desktop) { @content; }
-    }
-    @else if $media == 'desktops' {
-      @media only screen and (min-width: $break-desktop + 1) { @content; }
-    }
-  }
-  @else if type-of($media) == 'list' {
-    @if index($media, 'handhelds') {
-      @media only screen and (max-width: $break-wide-handheld) { @content; }
-    }
-    @if index($media, 'wide-handhelds') {
-      @media only screen and (min-width: $break-wide-handheld + 1) and (max-width: $break-tablet) { @content; }
-    }
-    @if index($media, 'tablets') {
-      @media only screen and (min-width: $break-tablet + -1) and (max-width: $break-desktop){ @content; }
-    }
-    @if index($media, 'desktops') {
-      @media only screen and (min-width: $break-desktop + 1) { @content; }
-    }
-  }
-}
-
 @mixin breakpoint($min) {
   @media only screen and (min-width: $min) {
     @content;

--- a/h/static/styles/partials/_base.scss
+++ b/h/static/styles/partials/_base.scss
@@ -20,15 +20,12 @@ $color-gray: #818181;
 $color-silver-chalice: #a6a6a6;
 $color-silver: #bbb;
 $color-alto: #dedede;
-$color-mercury: #e2e2e2;
-$color-gallery: #ececec;
 $color-seashell: #f1f1f1;
 $color-wild-sand: #f5f5f5;
 
 
 // Colors
 // ---------------------
-$color-cardinal: #bd1c2b;
 $brand-color: #bd1c2b !default;
 
 $button-text-color: $gray-dark !default;
@@ -38,9 +35,6 @@ $button-background-gradient: to bottom, $button-background-start, $button-backgr
 
 $error-color: #f0480c !default;
 $success-color: #1cbd41 !default;
-
-$mask-start-color: rgba($white, 0) !default;
-$mask-end-color: $white !default;
 
 
 // Variables for the new color palette
@@ -97,16 +91,10 @@ $link-color-hover:       color-weight($brand-color, 700) !default;
 // Typography
 // -------------------------
 $sans-font-family:        "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif !default;
-$serif-font-family:       Georgia, "Bitstream Charter", "Times", "Times New Roman", serif !default;
 $mono-font-family:        Open Sans Mono, Menlo, DejaVu Sans Mono, monospace !default;
 
 $base-font-size:          16px !default;
-$base-font-family:        $sans-font-family !default;
 $base-line-height:        20px !default;
-$alt-font-family:         $serif-font-family !default;
-
-$headings-font-family:    inherit !default;
-$headings-color:          inherit !default;
 
 $body1-font-size:         12px;
 $body1-line-height:       1.4em;


### PR DESCRIPTION
Remove SASS variables and mixins that are unused following separation of the client and web service into separate repositories.

The list of unused variables and mixins was found with [sass-unused](https://github.com/robertknight/sass-unused). I have left in variables from the new color palette which are unused because they will be used very soon by new designs.