### PR TITLE
Don't emit redundant JOINs when fetching annotation document

### DIFF
--- a/h/api/models/annotation.py
+++ b/h/api/models/annotation.py
@@ -99,8 +99,9 @@ class Annotation(Base):
                       nullable=False)
 
     document = sa.orm.relationship('Document',
-                                   secondary='join(DocumentURI, Document, DocumentURI.document_id == Document.id)',
+                                   secondary='document_uri',
                                    primaryjoin='Annotation.target_uri_normalized == DocumentURI.uri_normalized',
+                                   secondaryjoin='DocumentURI.document_id == Document.id',
                                    viewonly=True,
                                    uselist=False,
                                    backref='annotations')


### PR DESCRIPTION
This commit makes a small modification to the definition of the
relationship between the Annotation and Document models in order to
avoid emitting slightly odd queries when doing joined loads of
annotation document data.

Before this patch, a query such as

   session.query(Annotation).options(sa.orm.joinedload('document')).first()

will emit SQL something like

    SELECT
      annotation.*,
      d1.*
    FROM annotation
    LEFT OUTER JOIN (
       document_uri AS du
       JOIN document AS d2 ON du.document_id = d2.id
       JOIN document AS d1 ON d1.id = du.document_id
    )
    ON annotation.target_uri_normalized = du.uri_normalized
    LIMIT 1

where the inner `document_uri JOIN document JOIN document` is completely
redundant.

After this patch, the same query emits something like:

    SELECT
      annotation.*,
      document.*
    FROM annotation
    LEFT OUTER JOIN (
      document_uri
      JOIN document
      ON document_uri.document_id = document.id
    )
    ON annotation.target_uri_normalized = document_uri.uri_normalized
    LIMIT 1

which makes more sense.