### PR TITLE
Search aggregations (1): Return a SearchResult object when searching

### DIFF
--- a/h/activity/views.py
+++ b/h/activity/views.py
@@ -27,11 +27,11 @@ def search(request):
     if 'q' in request.params:
         query = parser.parse(request.params['q'])
 
-        out = search_lib.search(request, query)
-        total = out['total']
+        result = search_lib.search(request, query)
+        total = result.total
 
-        anns = storage.fetch_ordered_annotations(request.db,
-                                                 [r['id'] for r in out['rows']])
+        anns = storage.fetch_ordered_annotations(request.db, result.annotation_ids)
+
         for ann in anns:
             group = request.db.query(models.Group).filter(models.Group.pubid == ann.groupid).one_or_none()
             result = {

--- a/h/api/search/core.py
+++ b/h/api/search/core.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import logging
+from collections import namedtuple
 
 from h.api.search import query
 
@@ -7,6 +8,11 @@ FILTERS_KEY = 'h.api.search.filters'
 MATCHERS_KEY = 'h.api.search.matchers'
 
 log = logging.getLogger(__name__)
+
+SearchResult = namedtuple('SearchResult', [
+    'total',
+    'annotation_ids',
+    'reply_ids'])
 
 
 def search(request, params, private=True, separate_replies=False):
@@ -41,36 +47,33 @@ def search(request, params, private=True, separate_replies=False):
         builder.append_filter(query.TopLevelAnnotationsFilter())
 
     es = request.es
-    results = es.conn.search(index=es.index,
-                             doc_type=es.t.annotation,
-                             body=builder.build(params))
-    total = results['hits']['total']
-    docs = results['hits']['hits']
-    rows = [dict(d['_source'], id=d['_id']) for d in docs]
-    return_value = {"rows": rows, "total": total}
+    response = es.conn.search(index=es.index,
+                              doc_type=es.t.annotation,
+                              _source=False,
+                              body=builder.build(params))
+    total = response['hits']['total']
+    annotation_ids = [hit['_id'] for hit in response['hits']['hits']]
+    reply_ids = []
 
     if separate_replies:
         # Do a second query for all replies to the annotations from the first
         # query.
         builder = default_querybuilder(request, private=private)
-        builder.append_matcher(query.RepliesMatcher(
-            [h['_id'] for h in results['hits']['hits']]))
-        reply_results = es.conn.search(index=es.index,
-                                       doc_type=es.t.annotation,
-                                       body=builder.build({'limit': 200}))
+        builder.append_matcher(query.RepliesMatcher(annotation_ids))
+        reply_response = es.conn.search(index=es.index,
+                                        doc_type=es.t.annotation,
+                                        _source=False,
+                                        body=builder.build({'limit': 200}))
 
-        if len(reply_results['hits']['hits']) < reply_results['hits']['total']:
+        if len(reply_response['hits']['hits']) < reply_response['hits']['total']:
             log.warn("The number of reply annotations exceeded the page size "
                      "of the Elasticsearch query. We currently don't handle "
                      "this, our search API doesn't support pagination of the "
                      "reply set.")
 
-        reply_docs = reply_results['hits']['hits']
-        reply_rows = [dict(d['_source'], id=d['_id']) for d in reply_docs]
+        reply_ids = [hit['_id'] for hit in reply_response['hits']['hits']]
 
-        return_value["replies"] = reply_rows
-
-    return return_value
+    return SearchResult(total, annotation_ids, reply_ids)
 
 
 def default_querybuilder(request, private=True):

--- a/h/api/views.py
+++ b/h/api/views.py
@@ -136,17 +136,16 @@ def search(request):
     params = request.params.copy()
 
     separate_replies = params.pop('_separate_replies', False)
-    out = search_lib.search(request,
-                            params,
-                            separate_replies=separate_replies)
+    result = search_lib.search(request, params,
+                               separate_replies=separate_replies)
 
-    # Run the results through the JSON presenter
-    ids = [r['id'] for r in out['rows']]
-    out['rows'] = _present_annotations(request, ids)
+    out = {
+        'total': result.total,
+        'rows': _present_annotations(request, result.annotation_ids)
+    }
 
     if separate_replies:
-        ids = [r['id'] for r in out['replies']]
-        out['replies'] = _present_annotations(request, ids)
+        out['replies'] = _present_annotations(request, result.reply_ids)
 
     return out
 

--- a/h/badge/views.py
+++ b/h/badge/views.py
@@ -24,8 +24,9 @@ def badge(request):
     if models.Blocklist.is_blocked(request.db, uri):
         return {'total': 0}
 
-    return {
-        'total': search_lib.search(request, {'uri': uri, 'limit': 0})['total']}
+    result = search_lib.search(request, {'uri': uri, 'limit': 0})
+
+    return {'total': result.total}
 
 
 def includeme(config):

--- a/h/feeds/views.py
+++ b/h/feeds/views.py
@@ -11,9 +11,8 @@ _ = i18n.TranslationStringFactory(__package__)
 
 def _annotations(request):
     """Return the annotations from the search API."""
-    rows = search.search(request, request.params)['rows']
-    ids = [r['id'] for r in rows]
-    return storage.fetch_ordered_annotations(request.db, ids)
+    result = search.search(request, request.params)
+    return storage.fetch_ordered_annotations(request.db, result.annotation_ids)
 
 
 @view_config(route_name='stream_atom')

--- a/tests/h/api/search/core_test.py
+++ b/tests/h/api/search/core_test.py
@@ -68,11 +68,7 @@ def test_search_returns_replies(pyramid_request):
 
     result = core.search(pyramid_request, {}, separate_replies=True)
 
-    assert result['replies'] == [
-        {'name': 'reply_2', 'id': 'id_2'},
-        {'name': 'reply_3', 'id': 'id_3'},
-        {'name': 'reply_4', 'id': 'id_4'},
-    ]
+    assert result.reply_ids == ['id_2', 'id_3', 'id_4']
 
 
 @search_fixtures

--- a/tests/h/api/views_test.py
+++ b/tests/h/api/views_test.py
@@ -9,6 +9,7 @@ from h.api import models
 from h.api import presenters
 from h.api import views
 from h.api.schemas import ValidationError
+from h.api.search.core import SearchResult
 
 
 class TestError(object):
@@ -73,8 +74,7 @@ class TestSearch(object):
                                                   separate_replies=False)
 
     def test_it_loads_annotations_from_database(self, pyramid_request, search_lib, storage):
-        search_lib.search.return_value = {'total': 2,
-                                          'rows': [{'id': 'row-1'}, {'id': 'row-2'}]}
+        search_lib.search.return_value = SearchResult(2, ['row-1', 'row-2'], [])
 
         views.search(pyramid_request)
 
@@ -87,8 +87,7 @@ class TestSearch(object):
         pyramid_request.db.add_all([ann1, ann2])
         pyramid_request.db.flush()
 
-        search_lib.search.return_value = {'total': 2,
-                                          'rows': [{'id': ann1.id}, {'id': ann2.id}]}
+        search_lib.search.return_value = SearchResult(2, [ann1.id, ann2.id], [])
 
         expected = {
             'total': 2,
@@ -102,10 +101,7 @@ class TestSearch(object):
 
     def test_it_loads_replies_from_database(self, pyramid_request, search_lib, storage):
         pyramid_request.params = {'_separate_replies': '1'}
-        search_lib.search.return_value = {'total': 1,
-                                          'rows': [{'id': 'row-1'}],
-                                          'replies': [{'id': 'reply-1'},
-                                                      {'id': 'reply-2'}]}
+        search_lib.search.return_value = SearchResult(1, ['row-1'], ['reply-1', 'reply-2'])
 
         views.search(pyramid_request)
 
@@ -121,10 +117,7 @@ class TestSearch(object):
         pyramid_request.db.add_all([reply1, reply2])
         pyramid_request.db.flush()
 
-        search_lib.search.return_value = {'total': 1,
-                                          'rows': [{'id': ann.id}],
-                                          'replies': [{'id': reply1.id}, {'id': reply2.id}],
-                                          }
+        search_lib.search.return_value = SearchResult(1, [ann.id], [reply1.id, reply2.id])
 
         pyramid_request.params = {'_separate_replies': '1'}
 

--- a/tests/h/badge/views_test.py
+++ b/tests/h/badge/views_test.py
@@ -13,13 +13,13 @@ badge_fixtures = pytest.mark.usefixtures('models', 'search_lib')
 def test_badge_returns_number_from_search_lib(models, search_lib):
     request = mock.Mock(params={'uri': 'test_uri'})
     models.Blocklist.is_blocked.return_value = False
-    search_lib.search.return_value = {'total': 29}
+    search_lib.search.return_value = mock.Mock(total=29)
 
     result = views.badge(request)
 
     search_lib.search.assert_called_once_with(
         request, {'uri': 'test_uri', 'limit': 0})
-    assert result == {'total': search_lib.search.return_value['total']}
+    assert result == {'total': 29}
 
 
 @badge_fixtures


### PR DESCRIPTION
Now that we don't just blindly render what ElasticSearch returns we can
change the return value of `h.api.search.core.search` to be a value
object for easier access and sane default values. This is also done as a
preparation for aggregation support to search.