### PR TITLE
Search aggregations (2): Refactor search function into a class

### DIFF
--- a/h/activity/views.py
+++ b/h/activity/views.py
@@ -12,6 +12,7 @@ from pyramid.view import view_config
 from h import models
 from h.api import search as search_lib
 from h.api.search import parser
+from h.api.search import query
 from h.api import storage
 
 
@@ -25,9 +26,11 @@ def search(request):
     results = []
     total = None
     if 'q' in request.params:
-        query = parser.parse(request.params['q'])
+        search_query = parser.parse(request.params['q'])
 
-        result = search_lib.Search(request).run(query)
+        search_request = search_lib.Search(request)
+        search_request.append_filter(query.TopLevelAnnotationsFilter())
+        result = search_request.run(search_query)
         total = result.total
 
         anns = storage.fetch_ordered_annotations(request.db, result.annotation_ids)

--- a/h/activity/views.py
+++ b/h/activity/views.py
@@ -27,7 +27,7 @@ def search(request):
     if 'q' in request.params:
         query = parser.parse(request.params['q'])
 
-        result = search_lib.search(request, query)
+        result = search_lib.Search(request).run(query)
         total = result.total
 
         anns = storage.fetch_ordered_annotations(request.db, result.annotation_ids)

--- a/h/api/search/__init__.py
+++ b/h/api/search/__init__.py
@@ -4,11 +4,11 @@ from pyramid.settings import asbool
 
 from h.api.search.client import Client
 from h.api.search.config import configure_index
-from h.api.search.core import search
+from h.api.search.core import Search
 from h.api.search.core import FILTERS_KEY
 from h.api.search.core import MATCHERS_KEY
 
-__all__ = ('search',)
+__all__ = ('Search',)
 
 
 def _get_client(settings):

--- a/h/api/search/core.py
+++ b/h/api/search/core.py
@@ -50,6 +50,16 @@ class Search(object):
 
         return SearchResult(total, annotation_ids, reply_ids)
 
+    def append_filter(self, filter_):
+        """Append a search filter to the annotation and reply query."""
+        self.builder.append_filter(filter_)
+        self.reply_builder.append_filter(filter_)
+
+    def append_matcher(self, matcher):
+        """Append a search matcher to the annotation and reply query."""
+        self.builder.append_matcher(matcher)
+        self.reply_builder.append_matcher(matcher)
+
     def search_annotations(self, params):
         if self.separate_replies:
             self.builder.append_filter(query.TopLevelAnnotationsFilter())

--- a/h/api/search/core.py
+++ b/h/api/search/core.py
@@ -15,61 +15,70 @@ SearchResult = namedtuple('SearchResult', [
     'reply_ids'])
 
 
-def search(request, params, separate_replies=False):
+class Search(object):
     """
-    Search with the given params and return the matching annotations.
+    Search is the primary way to initiate a search on the annotation index.
 
     :param request: the request object
     :type request: pyramid.request.Request
 
-    :param params: the search parameters
-    :type params: dict-like
-
-    :param separate_replies: Whether or not to include a "replies" key in the
-        result containing a list of all replies to the annotations in the
-        "rows" key. If this is True then the "rows" key will include only
-        top-level annotations, not replies.
+    :param separate_replies: Wheter or not to return all replies to the
+        annotations returned by this search. If this is True then the
+        resulting annotations will only include top-leve annotations, not replies.
     :type separate_replies: bool
-
-    :returns: A dict with keys:
-      "rows" (the list of matching annotations, as dicts)
-      "total" (the number of matching annotations, an int)
-      "replies": (the list of all replies to the annotations in "rows", if
-        separate_replies=True was passed)
-    :rtype: dict
     """
-    builder = default_querybuilder(request)
-    if separate_replies:
-        builder.append_filter(query.TopLevelAnnotationsFilter())
+    def __init__(self, request, separate_replies=False):
+        self.request = request
+        self.es = request.es
+        self.separate_replies = separate_replies
 
-    es = request.es
-    response = es.conn.search(index=es.index,
-                              doc_type=es.t.annotation,
-                              _source=False,
-                              body=builder.build(params))
-    total = response['hits']['total']
-    annotation_ids = [hit['_id'] for hit in response['hits']['hits']]
-    reply_ids = []
+        self.builder = default_querybuilder(request)
+        self.reply_builder = default_querybuilder(request)
 
-    if separate_replies:
-        # Do a second query for all replies to the annotations from the first
-        # query.
-        builder = default_querybuilder(request)
-        builder.append_matcher(query.RepliesMatcher(annotation_ids))
-        reply_response = es.conn.search(index=es.index,
-                                        doc_type=es.t.annotation,
-                                        _source=False,
-                                        body=builder.build({'limit': 200}))
+    def run(self, params):
+        """
+        Execute the search query
 
-        if len(reply_response['hits']['hits']) < reply_response['hits']['total']:
+        :param params: the search parameters
+        :type params: dict-like
+
+        :returns: The search results
+        :rtype: SearchResult
+        """
+        total, annotation_ids = self.search_annotations(params)
+        reply_ids = self.search_replies(annotation_ids)
+
+        return SearchResult(total, annotation_ids, reply_ids)
+
+    def search_annotations(self, params):
+        if self.separate_replies:
+            self.builder.append_filter(query.TopLevelAnnotationsFilter())
+
+        response = self.es.conn.search(index=self.es.index,
+                                       doc_type=self.es.t.annotation,
+                                       _source=False,
+                                       body=self.builder.build(params))
+        total = response['hits']['total']
+        annotation_ids = [hit['_id'] for hit in response['hits']['hits']]
+        return (total, annotation_ids)
+
+    def search_replies(self, annotation_ids):
+        if not self.separate_replies:
+            return []
+
+        self.reply_builder.append_matcher(query.RepliesMatcher(annotation_ids))
+        response = self.es.conn.search(index=self.es.index,
+                                       doc_type=self.es.t.annotation,
+                                       _source=False,
+                                       body=self.reply_builder.build({'limit': 200}))
+
+        if len(response['hits']['hits']) < response['hits']['total']:
             log.warn("The number of reply annotations exceeded the page size "
                      "of the Elasticsearch query. We currently don't handle "
                      "this, our search API doesn't support pagination of the "
                      "reply set.")
 
-        reply_ids = [hit['_id'] for hit in reply_response['hits']['hits']]
-
-    return SearchResult(total, annotation_ids, reply_ids)
+        return [hit['_id'] for hit in response['hits']['hits']]
 
 
 def default_querybuilder(request):

--- a/h/api/search/core.py
+++ b/h/api/search/core.py
@@ -15,7 +15,7 @@ SearchResult = namedtuple('SearchResult', [
     'reply_ids'])
 
 
-def search(request, params, private=True, separate_replies=False):
+def search(request, params, separate_replies=False):
     """
     Search with the given params and return the matching annotations.
 
@@ -25,15 +25,11 @@ def search(request, params, private=True, separate_replies=False):
     :param params: the search parameters
     :type params: dict-like
 
-    :param private: whether or not to include private annotations in the search
-        results
-    :type private: bool
-
     :param separate_replies: Whether or not to include a "replies" key in the
         result containing a list of all replies to the annotations in the
         "rows" key. If this is True then the "rows" key will include only
         top-level annotations, not replies.
-    :type private: bool
+    :type separate_replies: bool
 
     :returns: A dict with keys:
       "rows" (the list of matching annotations, as dicts)
@@ -42,7 +38,7 @@ def search(request, params, private=True, separate_replies=False):
         separate_replies=True was passed)
     :rtype: dict
     """
-    builder = default_querybuilder(request, private=private)
+    builder = default_querybuilder(request)
     if separate_replies:
         builder.append_filter(query.TopLevelAnnotationsFilter())
 
@@ -58,7 +54,7 @@ def search(request, params, private=True, separate_replies=False):
     if separate_replies:
         # Do a second query for all replies to the annotations from the first
         # query.
-        builder = default_querybuilder(request, private=private)
+        builder = default_querybuilder(request)
         builder.append_matcher(query.RepliesMatcher(annotation_ids))
         reply_response = es.conn.search(index=es.index,
                                         doc_type=es.t.annotation,
@@ -76,9 +72,9 @@ def search(request, params, private=True, separate_replies=False):
     return SearchResult(total, annotation_ids, reply_ids)
 
 
-def default_querybuilder(request, private=True):
+def default_querybuilder(request):
     builder = query.Builder()
-    builder.append_filter(query.AuthFilter(request, private=private))
+    builder.append_filter(query.AuthFilter(request))
     builder.append_filter(query.UriFilter(request))
     builder.append_filter(query.GroupFilter())
     builder.append_filter(query.UserFilter())

--- a/h/api/search/query.py
+++ b/h/api/search/query.py
@@ -109,18 +109,12 @@ class AuthFilter(object):
     user's effective principals will pass through this filter.
     """
 
-    def __init__(self, request, private=True):
+    def __init__(self, request):
         """Initialize a new AuthFilter.
 
         :param request: the pyramid.request object
-
-        :param private: whether or not to include private annotations in the
-            search results
-        :type private: bool
-
         """
         self.request = request
-        self.private = private
 
     def __call__(self, params):
         principals = list(self.request.effective_principals)
@@ -133,10 +127,6 @@ class AuthFilter(object):
         # instead of 'group:__world__' we wouldn't have to do this.
         if 'group:__world__' not in principals:
             principals.insert(0, 'group:__world__')
-
-        if not self.private:
-            principals = [p for p in principals
-                          if p != self.request.authenticated_userid]
 
         return {'terms': {'permissions.read': principals}}
 

--- a/h/api/views.py
+++ b/h/api/views.py
@@ -136,8 +136,8 @@ def search(request):
     params = request.params.copy()
 
     separate_replies = params.pop('_separate_replies', False)
-    result = search_lib.search(request, params,
-                               separate_replies=separate_replies)
+    result = search_lib.Search(request, separate_replies=separate_replies) \
+        .run(params)
 
     out = {
         'total': result.total,

--- a/h/badge/views.py
+++ b/h/badge/views.py
@@ -2,7 +2,7 @@ from pyramid import httpexceptions
 
 from h import models
 from h.util.view import json_view
-from h.api import search as search_lib
+from h.api import search
 
 
 @json_view(route_name='badge')
@@ -24,7 +24,8 @@ def badge(request):
     if models.Blocklist.is_blocked(request.db, uri):
         return {'total': 0}
 
-    result = search_lib.search(request, {'uri': uri, 'limit': 0})
+    query = {'uri': uri, 'limit': 0}
+    result = search.Search(request).run(query)
 
     return {'total': result.total}
 

--- a/h/feeds/views.py
+++ b/h/feeds/views.py
@@ -11,7 +11,7 @@ _ = i18n.TranslationStringFactory(__package__)
 
 def _annotations(request):
     """Return the annotations from the search API."""
-    result = search.search(request, request.params)
+    result = search.Search(request).run(request.params)
     return storage.fetch_ordered_annotations(request.db, result.annotation_ids)
 
 

--- a/tests/h/api/search/core_test.py
+++ b/tests/h/api/search/core_test.py
@@ -99,13 +99,6 @@ def test_search_does_not_log_a_warning_if_there_are_not_too_many_replies(log, py
     assert not log.warn.called
 
 
-@pytest.mark.parametrize('private', [True, False])
-def test_default_querybuilder_passes_private_to_AuthFilter(private, query, pyramid_request):
-    core.default_querybuilder(pyramid_request, private=private)
-
-    query.AuthFilter.assert_called_once_with(pyramid_request, private=private)
-
-
 @pytest.mark.parametrize('filter_type', [
     'AuthFilter',
     'UriFilter',

--- a/tests/h/api/search/core_test.py
+++ b/tests/h/api/search/core_test.py
@@ -97,6 +97,42 @@ class TestSearch(object):
         search.search_replies(['id-1'])
         assert log.warn.call_count == 1
 
+    def test_append_filter_appends_to_annotation_builder(self, pyramid_request):
+        filter_ = mock.Mock()
+        search = core.Search(pyramid_request)
+        search.builder = mock.Mock()
+
+        search.append_filter(filter_)
+
+        search.builder.append_filter.assert_called_once_with(filter_)
+
+    def test_append_filter_appends_to_reply_builder(self, pyramid_request):
+        filter_ = mock.Mock()
+        search = core.Search(pyramid_request)
+        search.reply_builder = mock.Mock()
+
+        search.append_filter(filter_)
+
+        search.reply_builder.append_filter.assert_called_once_with(filter_)
+
+    def test_append_matcher_appends_to_annotation_builder(self, pyramid_request):
+        matcher = mock.Mock()
+
+        search = core.Search(pyramid_request)
+        search.builder = mock.Mock()
+        search.append_matcher(matcher)
+
+        search.builder.append_matcher.assert_called_once_with(matcher)
+
+    def test_append_matcher_appends_to_reply_builder(self, pyramid_request):
+        matcher = mock.Mock()
+        search = core.Search(pyramid_request)
+        search.reply_builder = mock.Mock()
+
+        search.append_matcher(matcher)
+
+        search.reply_builder.append_matcher.assert_called_once_with(matcher)
+
     @pytest.fixture
     def search_annotations(self, patch):
         return patch('h.api.search.core.Search.search_annotations')

--- a/tests/h/api/search/query_test.py
+++ b/tests/h/api/search/query_test.py
@@ -245,18 +245,6 @@ class TestAuthFilter(object):
             'terms': {'permissions.read': ['group:__world__', 'foo']}
         }
 
-    def test_with_private_removed_authenticated_userid_principal(self):
-        request = mock.Mock(
-            effective_principals=[
-                'group:__world__', 'group:foo', 'acct:thom@hypothes.is'],
-            authenticated_userid='acct:thom@hypothes.is'
-        )
-        authfilter = query.AuthFilter(request, private=False)
-
-        assert authfilter({}) == {
-            'terms': {'permissions.read': ['group:__world__', 'group:foo']}
-        }
-
 
 class TestGroupFilter(object):
     def test_term_filters_for_group(self):

--- a/tests/h/api/views_test.py
+++ b/tests/h/api/views_test.py
@@ -69,25 +69,25 @@ class TestSearch(object):
     def test_it_searches(self, pyramid_request, search_lib):
         views.search(pyramid_request)
 
-        search_lib.search.assert_called_once_with(pyramid_request,
-                                                  pyramid_request.params,
-                                                  separate_replies=False)
+        search = search_lib.Search.return_value
+        search_lib.Search.assert_called_with(pyramid_request, separate_replies=False)
+        search.run.assert_called_once_with(pyramid_request.params)
 
-    def test_it_loads_annotations_from_database(self, pyramid_request, search_lib, storage):
-        search_lib.search.return_value = SearchResult(2, ['row-1', 'row-2'], [])
+    def test_it_loads_annotations_from_database(self, pyramid_request, search_run, storage):
+        search_run.return_value = SearchResult(2, ['row-1', 'row-2'], [])
 
         views.search(pyramid_request)
 
         storage.fetch_ordered_annotations.assert_called_once_with(
             pyramid_request.db, ['row-1', 'row-2'], query_processor=mock.ANY)
 
-    def test_it_renders_search_results(self, links_service, pyramid_request, search_lib):
+    def test_it_renders_search_results(self, links_service, pyramid_request, search_run):
         ann1 = models.Annotation(userid='luke')
         ann2 = models.Annotation(userid='sarah')
         pyramid_request.db.add_all([ann1, ann2])
         pyramid_request.db.flush()
 
-        search_lib.search.return_value = SearchResult(2, [ann1.id, ann2.id], [])
+        search_run.return_value = SearchResult(2, [ann1.id, ann2.id], [])
 
         expected = {
             'total': 2,
@@ -99,16 +99,16 @@ class TestSearch(object):
 
         assert views.search(pyramid_request) == expected
 
-    def test_it_loads_replies_from_database(self, pyramid_request, search_lib, storage):
+    def test_it_loads_replies_from_database(self, pyramid_request, search_run, storage):
         pyramid_request.params = {'_separate_replies': '1'}
-        search_lib.search.return_value = SearchResult(1, ['row-1'], ['reply-1', 'reply-2'])
+        search_run.return_value = SearchResult(1, ['row-1'], ['reply-1', 'reply-2'])
 
         views.search(pyramid_request)
 
         assert mock.call(pyramid_request.db, ['reply-1', 'reply-2'],
                          query_processor=mock.ANY) in storage.fetch_ordered_annotations.call_args_list
 
-    def test_it_renders_replies(self, links_service, pyramid_request, search_lib):
+    def test_it_renders_replies(self, links_service, pyramid_request, search_run):
         ann = models.Annotation(userid='luke')
         pyramid_request.db.add(ann)
         pyramid_request.db.flush()
@@ -117,7 +117,7 @@ class TestSearch(object):
         pyramid_request.db.add_all([reply1, reply2])
         pyramid_request.db.flush()
 
-        search_lib.search.return_value = SearchResult(1, [ann.id], [reply1.id, reply2.id])
+        search_run.return_value = SearchResult(1, [ann.id], [reply1.id, reply2.id])
 
         pyramid_request.params = {'_separate_replies': '1'}
 
@@ -137,8 +137,13 @@ class TestSearch(object):
         return patch('h.api.views.search_lib')
 
     @pytest.fixture
+    def search_run(self, search_lib):
+        return search_lib.Search.return_value.run
+
+    @pytest.fixture
     def storage(self, patch):
         return patch('h.api.views.storage')
+
 
 @pytest.mark.usefixtures('AnnotationEvent',
                          'AnnotationJSONPresenter',

--- a/tests/h/badge/views_test.py
+++ b/tests/h/badge/views_test.py
@@ -10,27 +10,26 @@ badge_fixtures = pytest.mark.usefixtures('models', 'search_lib')
 
 
 @badge_fixtures
-def test_badge_returns_number_from_search_lib(models, search_lib):
+def test_badge_returns_number_from_search(models, search_run):
     request = mock.Mock(params={'uri': 'test_uri'})
     models.Blocklist.is_blocked.return_value = False
-    search_lib.search.return_value = mock.Mock(total=29)
+    search_run.return_value = mock.Mock(total=29)
 
     result = views.badge(request)
 
-    search_lib.search.assert_called_once_with(
-        request, {'uri': 'test_uri', 'limit': 0})
+    search_run.assert_called_once_with({'uri': 'test_uri', 'limit': 0})
     assert result == {'total': 29}
 
 
 @badge_fixtures
-def test_badge_returns_0_if_blocked(models, search_lib):
+def test_badge_returns_0_if_blocked(models, search_run):
     request = mock.Mock(params={'uri': 'test_uri'})
     models.Blocklist.is_blocked.return_value = True
-    search_lib.search.return_value = {'total': 29}
+    search_run.return_value = {'total': 29}
 
     result = views.badge(request)
 
-    assert not search_lib.search.called
+    assert not search_run.called
     assert result == {'total': 0}
 
 
@@ -47,4 +46,9 @@ def models(patch):
 
 @pytest.fixture
 def search_lib(patch):
-    return patch('h.badge.views.search_lib')
+    return patch('h.badge.views.search')
+
+
+@pytest.fixture
+def search_run(search_lib):
+    return search_lib.Search.return_value.run


### PR DESCRIPTION
_This is based on #3622 and will need rebasing once that one got merged_

This allows us to easily configure special filters and matchers on a per-query basis (see the last commit where we use that feature). This is also in preparation to the next PR which will add aggregation support.