### PR TITLE
Search aggregations (3): Tags aggregation

### DIFF
--- a/h/activity/views.py
+++ b/h/activity/views.py
@@ -27,13 +27,16 @@ def search(request):
 
     results = []
     total = None
+    tags = []
     if 'q' in request.params:
         search_query = parser.parse(request.params['q'])
 
         search_request = search_lib.Search(request)
         search_request.append_filter(query.TopLevelAnnotationsFilter())
+        search_request.append_aggregation(query.TagsAggregation(limit=10))
         result = search_request.run(search_query)
         total = result.total
+        tags = result.aggregations['tags']
 
         def eager_load_documents(query):
             return query.options(
@@ -58,7 +61,8 @@ def search(request):
     return {
         'q': request.params.get('q', ''),
         'total': total,
-        'timeframes': timeframes
+        'tags': tags,
+        'timeframes': timeframes,
     }
 
 

--- a/h/api/search/query.py
+++ b/h/api/search/query.py
@@ -15,12 +15,16 @@ class Builder(object):
     def __init__(self):
         self.filters = []
         self.matchers = []
+        self.aggregations = []
 
     def append_filter(self, f):
         self.filters.append(f)
 
     def append_matcher(self, m):
         self.matchers.append(m)
+
+    def append_aggregation(self, a):
+        self.aggregations.append(a)
 
     def build(self, params):
         """Get the resulting query object from this query builder."""
@@ -32,6 +36,7 @@ class Builder(object):
 
         filters = [f(params) for f in self.filters]
         matchers = [m(params) for m in self.matchers]
+        aggregations = {a.key: a(params) for a in self.aggregations}
         filters = [f for f in filters if f is not None]
         matchers = [m for m in matchers if m is not None]
 
@@ -57,6 +62,7 @@ class Builder(object):
             "size": p_size,
             "sort": p_sort,
             "query": query,
+            "aggs": aggregations,
         }
 
 

--- a/h/api/search/query.py
+++ b/h/api/search/query.py
@@ -244,3 +244,26 @@ class RepliesMatcher(object):
         return {
             'terms': {'references': self.annotation_ids}
         }
+
+
+class TagsAggregation(object):
+    def __init__(self, limit=0):
+        self.key = 'tags'
+        self.limit = limit
+
+    def __call__(self, _):
+        return {
+            "terms": {
+                "field": "tags",
+                "size": self.limit
+            }
+        }
+
+    def parse_result(self, result):
+        if not result:
+            return {}
+
+        return [
+            {'tag': b['key'], 'count': b['doc_count']}
+            for b in result['buckets']
+        ]

--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -4,7 +4,20 @@
 </form>
 
 {% if total %}
-Total: {{ total }}
+<p>
+Total annotations: {{ total }}
+</p>
+{% endif %}
+
+{% if tags %}
+<p>
+Tags (first ten):
+<ul>
+  {% for tag in tags %}
+  <li>{{ tag.tag }} ({{ tag.count }})</li>
+  {% endfor %}
+</ul>
+</p>
 {% endif %}
 
 <ol>

--- a/tests/h/api/search/query_test.py
+++ b/tests/h/api/search/query_test.py
@@ -460,3 +460,42 @@ class TestAnyMatcher():
         assert len(result['bool']['must']) == 2
         assert {'match': {'tags': {'query': 'foo', 'operator': 'and'}}} in result['bool']['must']
         assert {'match': {'tags': {'query': 'bar', 'operator': 'and'}}} in result['bool']['must']
+
+
+class TestTagsAggregations(object):
+    def test_key_is_tags(self):
+        assert query.TagsAggregation().key == 'tags'
+
+    def test_elasticsearch_aggregation(self):
+        agg = query.TagsAggregation()
+        assert agg({}) == {
+            'terms': {'field': 'tags', 'size': 0}
+        }
+
+    def test_it_allows_to_set_a_limit(self):
+        agg = query.TagsAggregation(limit=14)
+        assert agg({}) == {
+            'terms': {'field': 'tags', 'size': 14}
+        }
+
+    def parse_result(self):
+        agg = query.TagsAggregation()
+        elasticsearch_result = {
+            'buckets': [
+                {'key': 'tag-4', 'doc_count': 42},
+                {'key': 'tag-2', 'doc_count': 28},
+            ]
+        }
+
+        assert agg(elasticsearch_result) == [
+            {'tag': 'tag-4', 'count': 42},
+            {'tag': 'tag-2', 'count': 28},
+        ]
+
+    def parse_result_with_none(self):
+        agg = query.TagsAggregation()
+        assert agg.parse_result(None) == {}
+
+    def parse_result_with_empty(self):
+        agg = query.TagsAggregation()
+        assert agg.parse_result({}) == {}

--- a/tests/h/api/search/query_test.py
+++ b/tests/h/api/search/query_test.py
@@ -227,6 +227,28 @@ class TestBuilder(object):
             "bool": {"must": [{"match": {"giraffe": "nose"}}]},
         }
 
+    def test_passes_params_to_aggregations(self):
+        testaggregation = mock.Mock()
+        builder = query.Builder()
+        builder.append_aggregation(testaggregation)
+
+        builder.build({"foo": "bar"})
+
+        testaggregation.assert_called_with({"foo": "bar"})
+
+    def test_adds_aggregations_to_query(self):
+        testaggregation = mock.Mock(key="foobar")
+        # testaggregation.key.return_value = "foobar"
+        testaggregation.return_value = {"terms": {"field": "foo"}}
+        builder = query.Builder()
+        builder.append_aggregation(testaggregation)
+
+        q = builder.build({})
+
+        assert q["aggs"] == {
+            "foobar": {"terms": {"field": "foo"}}
+        }
+
 
 class TestAuthFilter(object):
     def test_world_not_in_principals(self):

--- a/tests/h/api/views_test.py
+++ b/tests/h/api/views_test.py
@@ -74,7 +74,7 @@ class TestSearch(object):
         search.run.assert_called_once_with(pyramid_request.params)
 
     def test_it_loads_annotations_from_database(self, pyramid_request, search_run, storage):
-        search_run.return_value = SearchResult(2, ['row-1', 'row-2'], [])
+        search_run.return_value = SearchResult(2, ['row-1', 'row-2'], [], {})
 
         views.search(pyramid_request)
 
@@ -87,7 +87,7 @@ class TestSearch(object):
         pyramid_request.db.add_all([ann1, ann2])
         pyramid_request.db.flush()
 
-        search_run.return_value = SearchResult(2, [ann1.id, ann2.id], [])
+        search_run.return_value = SearchResult(2, [ann1.id, ann2.id], [], {})
 
         expected = {
             'total': 2,
@@ -101,7 +101,7 @@ class TestSearch(object):
 
     def test_it_loads_replies_from_database(self, pyramid_request, search_run, storage):
         pyramid_request.params = {'_separate_replies': '1'}
-        search_run.return_value = SearchResult(1, ['row-1'], ['reply-1', 'reply-2'])
+        search_run.return_value = SearchResult(1, ['row-1'], ['reply-1', 'reply-2'], {})
 
         views.search(pyramid_request)
 
@@ -117,7 +117,7 @@ class TestSearch(object):
         pyramid_request.db.add_all([reply1, reply2])
         pyramid_request.db.flush()
 
-        search_run.return_value = SearchResult(1, [ann.id], [reply1.id, reply2.id])
+        search_run.return_value = SearchResult(1, [ann.id], [reply1.id, reply2.id], {})
 
         pyramid_request.params = {'_separate_replies': '1'}
 


### PR DESCRIPTION
_This is based on #3623 and will need rebasing once that one got merged_

Aggregations can be added to search queries the same way we add filters and matchers. The interface of an aggregation is very similar (a callable), but it also needs to expose a `parse_result` method which parses the Elasticsearch result and thus allows us to decouple callers of the `Search` class to know anything about how Elasticsearch renders search results.

There is also a `TagsAggregation` which can be added to search queries, check the activity page skeleton on how it is being used.