### PR TITLE
Search aggregations (4): Users aggregation

### DIFF
--- a/h/activity/views.py
+++ b/h/activity/views.py
@@ -25,7 +25,7 @@ def search(request):
     if not request.feature('activity_pages'):
         raise httpexceptions.HTTPNotFound()
 
-    results = []
+    timeframes = []
     total = None
     tags = []
     users = []

--- a/h/activity/views.py
+++ b/h/activity/views.py
@@ -28,15 +28,19 @@ def search(request):
     results = []
     total = None
     tags = []
+    users = []
     if 'q' in request.params:
         search_query = parser.parse(request.params['q'])
 
         search_request = search_lib.Search(request)
         search_request.append_filter(query.TopLevelAnnotationsFilter())
         search_request.append_aggregation(query.TagsAggregation(limit=10))
+        if len(search_query.getall('group')) == 1:
+            search_request.append_aggregation(query.UsersAggregation(limit=10))
         result = search_request.run(search_query)
         total = result.total
         tags = result.aggregations['tags']
+        users = result.aggregations.get('users', [])
 
         def eager_load_documents(query):
             return query.options(
@@ -62,6 +66,7 @@ def search(request):
         'q': request.params.get('q', ''),
         'total': total,
         'tags': tags,
+        'users': users,
         'timeframes': timeframes,
     }
 

--- a/h/api/presenters.py
+++ b/h/api/presenters.py
@@ -100,6 +100,7 @@ class AnnotationSearchIndexPresenter(AnnotationBasePresenter):
             'created': self.created,
             'updated': self.updated,
             'user': self.annotation.userid,
+            'user_raw': self.annotation.userid,
             'uri': self.annotation.target_uri,
             'text': self.text,
             'tags': self.tags,

--- a/h/api/search/config.py
+++ b/h/api/search/config.py
@@ -40,6 +40,7 @@ ANNOTATION_MAPPING = {
             },
         },
         'user': {'type': 'string', 'index': 'analyzed', 'analyzer': 'user'},
+        'user_raw': {'type': 'string', 'index': 'not_analyzed'},
         'target': {
             'properties': {
                 'source': {

--- a/h/api/search/query.py
+++ b/h/api/search/query.py
@@ -267,3 +267,26 @@ class TagsAggregation(object):
             {'tag': b['key'], 'count': b['doc_count']}
             for b in result['buckets']
         ]
+
+
+class UsersAggregation(object):
+    def __init__(self, limit=0):
+        self.key = 'users'
+        self.limit = limit
+
+    def __call__(self, _):
+        return {
+            "terms": {
+                "field": "user_raw",
+                "size": self.limit
+            }
+        }
+
+    def parse_result(self, result):
+        if not result:
+            return {}
+
+        return [
+            {'user': b['key'], 'count': b['doc_count']}
+            for b in result['buckets']
+        ]

--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -20,6 +20,17 @@ Tags (first ten):
 </p>
 {% endif %}
 
+{% if users %}
+<p>
+Users (first ten):
+<ul>
+  {% for user in users %}
+  <li>{{ user.user }} ({{ user.count }})</li>
+  {% endfor %}
+</ul>
+</p>
+{% endif %}
+
 <ol>
   {% for timeframe in timeframes %}
     <li>

--- a/tests/h/api/presenters_test.py
+++ b/tests/h/api/presenters_test.py
@@ -212,6 +212,7 @@ class TestAnnotationSearchIndexPresenter(object):
             'created': '2016-02-24T18:03:25.000768+00:00',
             'updated': '2016-02-29T10:24:05.000564+00:00',
             'user': 'acct:luke@hypothes.is',
+            'user_raw': 'acct:luke@hypothes.is',
             'uri': 'http://example.com',
             'text': 'It is magical!',
             'tags': ['magic'],

--- a/tests/h/api/search/query_test.py
+++ b/tests/h/api/search/query_test.py
@@ -499,3 +499,42 @@ class TestTagsAggregations(object):
     def parse_result_with_empty(self):
         agg = query.TagsAggregation()
         assert agg.parse_result({}) == {}
+
+
+class TestUsersAggregation(object):
+    def test_key_is_users(self):
+        assert query.UsersAggregation().key == 'users'
+
+    def test_elasticsearch_aggregation(self):
+        agg = query.UsersAggregation()
+        assert agg({}) == {
+            'terms': {'field': 'user_raw', 'size': 0}
+        }
+
+    def test_it_allows_to_set_a_limit(self):
+        agg = query.UsersAggregation(limit=14)
+        assert agg({}) == {
+            'terms': {'field': 'user_raw', 'size': 14}
+        }
+
+    def parse_result(self):
+        agg = query.UsersAggregation()
+        elasticsearch_result = {
+            'buckets': [
+                {'key': 'alice', 'doc_count': 42},
+                {'key': 'luke', 'doc_count': 28},
+            ]
+        }
+
+        assert agg(elasticsearch_result) == [
+            {'user': 'alice', 'count': 42},
+            {'user': 'luke', 'count': 28},
+        ]
+
+    def parse_result_with_none(self):
+        agg = query.UsersAggregation()
+        assert agg.parse_result(None) == {}
+
+    def parse_result_with_empty(self):
+        agg = query.UsersAggregation()
+        assert agg.parse_result({}) == {}


### PR DESCRIPTION
_This is based on #3624 and will need rebasing once that one got merged_

The aggregation is pretty much the same as the tags aggregation. One caveat is that [analyzed fields have a big impact on how aggregations work](https://www.elastic.co/guide/en/elasticsearch/guide/1.x/aggregations-and-analysis.html). The solution for this is to add a new `user_raw` field to the search index which is not analyzed.

The activity page skeleton will automatically add the users aggregation if the search contains exactly one group.