### PR TITLE
Move the "admin" CLI command under a "user" command

### DIFF
--- a/docs/developing/administration.rst
+++ b/docs/developing/administration.rst
@@ -6,13 +6,13 @@ permissions. To grant admin permissions to a user, run the following command:
 
 .. code-block:: bash
 
-  hypothesis admin <username>
+  hypothesis user admin <username>
 
 For example, to make the user 'joe' an admin in the development environment:
 
 .. code-block:: bash
 
-  hypothesis --dev admin joe
+  hypothesis --dev user admin joe
 
 When this user signs in they can now access the adminstration panel at
 ``/admin``. The administration panel has options for managing users and optional

--- a/h/cli/__init__.py
+++ b/h/cli/__init__.py
@@ -15,7 +15,6 @@ from h import __version__
 log = logging.getLogger('h')
 
 SUBCOMMANDS = (
-    'h.cli.commands.admin.admin',
     'h.cli.commands.celery.celery',
     'h.cli.commands.devserver.devserver',
     'h.cli.commands.initdb.initdb',
@@ -23,6 +22,7 @@ SUBCOMMANDS = (
     'h.cli.commands.move_uri.move_uri',
     'h.cli.commands.normalize_uris.normalize_uris',
     'h.cli.commands.reindex.reindex',
+    'h.cli.commands.user.user',
 )
 
 

--- a/h/cli/commands/user.py
+++ b/h/cli/commands/user.py
@@ -5,10 +5,16 @@ import click
 from h import models
 
 
-@click.command()
+@click.group()
+def user():
+    """Manage users."""
+
+
+@user.command()
 @click.argument('username')
+@click.option('--on/--off', default=True)
 @click.pass_context
-def admin(ctx, username):
+def admin(ctx, username, on):
     """
     Make a user an admin.
 
@@ -19,6 +25,11 @@ def admin(ctx, username):
     user = models.User.get_by_username(request.db, username)
     if user is None:
         raise click.ClickException('no user with username "{}"'.format(username))
-    else:
-        user.admin = True
+
+    user.admin = on
     request.tm.commit()
+
+    click.echo("{username} is now {status}an administrator"
+               .format(username=username,
+                       status='' if on else 'NOT '),
+               err=True)


### PR DESCRIPTION
In preparation for adding a "hypothesis user add" command, this commit moves the CLI command for making a user into an admin under a "user" management command, so now one runs:

    hypothesis user admin foo

Just for fun, I've also made it possible to use this command to remove a user's admin rights, too:

    hypothesis user admin --off foo