### PR TITLE
Move the websocket auth policy into h.auth.policy

### DIFF
--- a/h/auth/policy.py
+++ b/h/auth/policy.py
@@ -3,6 +3,7 @@
 from pyramid import interfaces
 from pyramid.authentication import (CallbackAuthenticationPolicy,
                                     SessionAuthenticationPolicy)
+from pyramid_multiauth import MultiAuthenticationPolicy
 from zope import interface
 
 from h._compat import text_type
@@ -100,6 +101,24 @@ class TokenAuthenticationPolicy(CallbackAuthenticationPolicy):
 
         return (tokens.userid_from_api_token(token, request) or
                 tokens.userid_from_jwt(token, request))
+
+
+@interface.implementer(interfaces.IAuthenticationPolicy)
+class WebSocketAuthenticationPolicy(MultiAuthenticationPolicy):
+
+    """
+    An authentication policy for the websocket server.
+
+    This is a "multiauth" policy that tries a series of alternate
+    authentication policies in turn: first an API token policy, and then a
+    session authentication policy.
+    """
+
+    def __init__(self):
+        super(WebSocketAuthenticationPolicy, self).__init__([
+            TokenAuthenticationPolicy(callback=util.groupfinder),
+            SessionAuthenticationPolicy(callback=util.groupfinder),
+        ])
 
 
 def _is_api_request(request):

--- a/h/websocket.py
+++ b/h/websocket.py
@@ -41,14 +41,11 @@ import logging
 from gevent.pool import Pool
 from gunicorn.workers.ggevent import (GeventPyWSGIWorker, PyWSGIHandler,
                                       PyWSGIServer)
-from pyramid.authentication import SessionAuthenticationPolicy
 from pyramid.authorization import ACLAuthorizationPolicy
-from pyramid_multiauth import MultiAuthenticationPolicy
 from ws4py import format_addresses
 
 from h import features
-from h.auth.policy import TokenAuthenticationPolicy
-from h.auth.util import groupfinder
+from h.auth.policy import WebSocketAuthenticationPolicy
 from h.config import configure
 
 log = logging.getLogger(__name__)
@@ -157,12 +154,7 @@ def create_app(global_config, **settings):
     config.add_request_method(features.Client, name='feature', reify=True)
 
     config.set_authorization_policy(ACLAuthorizationPolicy())
-
-    policy = MultiAuthenticationPolicy([
-        TokenAuthenticationPolicy(callback=groupfinder),
-        SessionAuthenticationPolicy(callback=groupfinder),
-    ])
-    config.set_authentication_policy(policy)
+    config.set_authentication_policy(WebSocketAuthenticationPolicy())
 
     config.include('pyramid_services')
 

--- a/tests/h/auth/policy_test.py
+++ b/tests/h/auth/policy_test.py
@@ -6,6 +6,7 @@ import pytest
 
 from h.auth.policy import AuthenticationPolicy
 from h.auth.policy import TokenAuthenticationPolicy
+from h.auth.policy import WebSocketAuthenticationPolicy
 
 SESSION_AUTH_PATHS = (
     '/login',
@@ -209,3 +210,19 @@ class TestTokenAuthenticationPolicy(object):
     @pytest.fixture
     def jwt(self, patch):
         return patch('h.auth.tokens.userid_from_jwt')
+
+
+class TestWebSocketAuthenticationPolicy(object):
+
+    def test_policy_is_multiauth_policy(self):
+        from pyramid_multiauth import MultiAuthenticationPolicy
+        policy = WebSocketAuthenticationPolicy()
+        assert isinstance(policy, MultiAuthenticationPolicy)
+
+    def test_policy_has_correct_policies(self, matchers, patch):
+        multi = patch('pyramid_multiauth.MultiAuthenticationPolicy.__init__')
+        policy = WebSocketAuthenticationPolicy()
+        multi.assert_called_once_with(policy, [
+            matchers.instance_of(TokenAuthenticationPolicy),
+            matchers.instance_of(SessionAuthenticationPolicy),
+        ])


### PR DESCRIPTION
Rather than having this authentication policy defined ad-hoc in h/websocket.py, where it's easy to forget it exists, this commit gives the websocket server's authentication policy a name:

    h.auth.policy.WebSocketAuthenticationPolicy