### PR TITLE
Move config of auth/authz policies into h.auth/h.authz modules

### DIFF
--- a/h/app.py
+++ b/h/app.py
@@ -7,11 +7,9 @@ from __future__ import unicode_literals
 import logging
 
 import transaction
-from pyramid.authorization import ACLAuthorizationPolicy
 from pyramid.settings import asbool
 from pyramid.tweens import EXCVIEW
 
-from h.auth.policy import AuthenticationPolicy
 from h.config import configure
 
 log = logging.getLogger(__name__)
@@ -97,14 +95,6 @@ def includeme(config):
         },
     })
 
-    # Set up pyramid authentication and authorization policies. See the Pyramid
-    # documentation at:
-    #
-    #   http://docs.pylonsproject.org/projects/pyramid/en/latest/narr/security.html
-    #
-    config.set_authentication_policy(AuthenticationPolicy())
-    config.set_authorization_policy(ACLAuthorizationPolicy())
-
     # API module
     #
     # We include this first so that:
@@ -116,6 +106,7 @@ def includeme(config):
     # Core site modules
     config.include('h.assets')
     config.include('h.auth')
+    config.include('h.authz')
     config.include('h.db')
     config.include('h.features')
     config.include('h.form')

--- a/h/auth/__init__.py
+++ b/h/auth/__init__.py
@@ -2,9 +2,23 @@
 
 """Authentication configuration."""
 
-from h.auth.policy import AuthenticationPolicy
+from pyramid.authentication import SessionAuthenticationPolicy
+from pyramid_multiauth import MultiAuthenticationPolicy
 
-__all__ = ()
+from h.auth.policy import AuthenticationPolicy, TokenAuthenticationPolicy
+from h.auth.util import groupfinder
+
+__all__ = (
+    'DEFAULT_POLICY',
+    'WEBSOCKET_POLICY',
+)
+
+SESSION_POLICY = SessionAuthenticationPolicy(callback=groupfinder)
+TOKEN_POLICY = TokenAuthenticationPolicy(callback=groupfinder)
+
+DEFAULT_POLICY = AuthenticationPolicy(api_policy=TOKEN_POLICY,
+                                      fallback_policy=SESSION_POLICY)
+WEBSOCKET_POLICY = MultiAuthenticationPolicy([TOKEN_POLICY, SESSION_POLICY])
 
 
 def auth_domain(request):
@@ -22,4 +36,4 @@ def includeme(config):
 
     # Set the default authentication policy. This can be overridden by modules
     # that include this one.
-    config.set_authentication_policy(AuthenticationPolicy())
+    config.set_authentication_policy(DEFAULT_POLICY)

--- a/h/auth/__init__.py
+++ b/h/auth/__init__.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 
-"""Authentication and authorization configuration."""
+"""Authentication configuration."""
+
+from h.auth.policy import AuthenticationPolicy
 
 __all__ = ()
 
@@ -17,3 +19,7 @@ def auth_domain(request):
 def includeme(config):
     # Allow retrieval of the auth_domain from the request object.
     config.add_request_method(auth_domain, name='auth_domain', reify=True)
+
+    # Set the default authentication policy. This can be overridden by modules
+    # that include this one.
+    config.set_authentication_policy(AuthenticationPolicy())

--- a/h/authz.py
+++ b/h/authz.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+
+"""Authorization configuration."""
+
+from pyramid.authorization import ACLAuthorizationPolicy
+
+__all__ = ()
+
+
+def includeme(config):
+    config.set_authorization_policy(ACLAuthorizationPolicy())

--- a/h/websocket.py
+++ b/h/websocket.py
@@ -41,7 +41,6 @@ import logging
 from gevent.pool import Pool
 from gunicorn.workers.ggevent import (GeventPyWSGIWorker, PyWSGIHandler,
                                       PyWSGIServer)
-from pyramid.authorization import ACLAuthorizationPolicy
 from ws4py import format_addresses
 
 from h import features
@@ -153,12 +152,13 @@ def create_app(global_config, **settings):
 
     config.add_request_method(features.Client, name='feature', reify=True)
 
-    config.set_authorization_policy(ACLAuthorizationPolicy())
-    config.set_authentication_policy(WebSocketAuthenticationPolicy())
-
     config.include('pyramid_services')
 
     config.include('h.auth')
+    # Override the default authentication policy.
+    config.set_authentication_policy(WebSocketAuthenticationPolicy())
+
+    config.include('h.authz')
     config.include('h.session')
     config.include('h.sentry')
     config.include('h.stats')

--- a/h/websocket.py
+++ b/h/websocket.py
@@ -44,7 +44,6 @@ from gunicorn.workers.ggevent import (GeventPyWSGIWorker, PyWSGIHandler,
 from ws4py import format_addresses
 
 from h import features
-from h.auth.policy import WebSocketAuthenticationPolicy
 from h.config import configure
 
 log = logging.getLogger(__name__)
@@ -156,7 +155,7 @@ def create_app(global_config, **settings):
 
     config.include('h.auth')
     # Override the default authentication policy.
-    config.set_authentication_policy(WebSocketAuthenticationPolicy())
+    config.set_authentication_policy('h.auth.WEBSOCKET_POLICY')
 
     config.include('h.authz')
     config.include('h.session')

--- a/tests/h/auth/policy_test.py
+++ b/tests/h/auth/policy_test.py
@@ -1,110 +1,108 @@
 # -*- coding: utf-8 -*-
 
 import mock
-from pyramid.authentication import SessionAuthenticationPolicy
 import pytest
+
+from pyramid.interfaces import IAuthenticationPolicy
 
 from h.auth.policy import AuthenticationPolicy
 from h.auth.policy import TokenAuthenticationPolicy
-from h.auth.policy import WebSocketAuthenticationPolicy
 
-SESSION_AUTH_PATHS = (
+API_PATHS = (
+    '/api',
+    '/api/foo',
+    '/api/annotations/abc123',
+)
+
+NONAPI_PATHS = (
     '/login',
     '/account/settings',
     '/api/badge',
     '/api/token',
 )
 
-TOKEN_AUTH_PATHS = (
-    '/api',
-    '/api/foo',
-    '/api/annotations/abc123',
-)
-
-
 class TestAuthenticationPolicy(object):
 
     @pytest.fixture(autouse=True)
     def policy(self):
-        self.session_policy = mock.Mock(spec_set=SessionAuthenticationPolicy())
-        self.token_policy = mock.Mock(spec_set=TokenAuthenticationPolicy())
-        self.policy = AuthenticationPolicy()
-        self.policy.session_policy = self.session_policy
-        self.policy.token_policy = self.token_policy
+        self.api_policy = mock.Mock(spec_set=list(IAuthenticationPolicy))
+        self.fallback_policy = mock.Mock(spec_set=list(IAuthenticationPolicy))
+        self.policy = AuthenticationPolicy(api_policy=self.api_policy,
+                                           fallback_policy=self.fallback_policy)
 
-    # session_request and token_request are parametrized fixtures, which will
+    # api_request and nonapi_request are parametrized fixtures, which will
     # take on each value in the passed `params` sequence in turn. This is a
     # quick and easy way to generate a named fixture which takes multiple
     # values and can be used by multiple tests.
-    @pytest.fixture(params=SESSION_AUTH_PATHS)
-    def session_request(self, request, pyramid_request):
+    @pytest.fixture(params=API_PATHS)
+    def api_request(self, request, pyramid_request):
         pyramid_request.path = request.param
         return pyramid_request
 
-    @pytest.fixture(params=TOKEN_AUTH_PATHS)
-    def token_request(self, request, pyramid_request):
+    @pytest.fixture(params=NONAPI_PATHS)
+    def nonapi_request(self, request, pyramid_request):
         pyramid_request.path = request.param
         return pyramid_request
 
-    def test_authenticated_userid_uses_session_policy_for_session_auth_paths(self, session_request):
-        result = self.policy.authenticated_userid(session_request)
+    def test_authenticated_userid_uses_fallback_policy_for_nonapi_paths(self, nonapi_request):
+        result = self.policy.authenticated_userid(nonapi_request)
 
-        self.session_policy.authenticated_userid.assert_called_once_with(session_request)
-        assert result == self.session_policy.authenticated_userid.return_value
+        self.fallback_policy.authenticated_userid.assert_called_once_with(nonapi_request)
+        assert result == self.fallback_policy.authenticated_userid.return_value
 
-    def test_authenticated_userid_uses_token_policy_for_token_auth_paths(self, token_request):
-        result = self.policy.authenticated_userid(token_request)
+    def test_authenticated_userid_uses_api_policy_for_api_paths(self, api_request):
+        result = self.policy.authenticated_userid(api_request)
 
-        self.token_policy.authenticated_userid.assert_called_once_with(token_request)
-        assert result == self.token_policy.authenticated_userid.return_value
+        self.api_policy.authenticated_userid.assert_called_once_with(api_request)
+        assert result == self.api_policy.authenticated_userid.return_value
 
-    def test_unauthenticated_userid_uses_session_policy_for_session_auth_paths(self, session_request):
-        result = self.policy.unauthenticated_userid(session_request)
+    def test_unauthenticated_userid_uses_fallback_policy_for_nonapi_paths(self, nonapi_request):
+        result = self.policy.unauthenticated_userid(nonapi_request)
 
-        self.session_policy.unauthenticated_userid.assert_called_once_with(session_request)
-        assert result == self.session_policy.unauthenticated_userid.return_value
+        self.fallback_policy.unauthenticated_userid.assert_called_once_with(nonapi_request)
+        assert result == self.fallback_policy.unauthenticated_userid.return_value
 
-    def test_unauthenticated_userid_uses_token_policy_for_token_auth_paths(self, token_request):
-        result = self.policy.unauthenticated_userid(token_request)
+    def test_unauthenticated_userid_uses_api_policy_for_api_paths(self, api_request):
+        result = self.policy.unauthenticated_userid(api_request)
 
-        self.token_policy.unauthenticated_userid.assert_called_once_with(token_request)
-        assert result == self.token_policy.unauthenticated_userid.return_value
+        self.api_policy.unauthenticated_userid.assert_called_once_with(api_request)
+        assert result == self.api_policy.unauthenticated_userid.return_value
 
-    def test_effective_principals_uses_session_policy_for_session_auth_paths(self, session_request):
-        result = self.policy.effective_principals(session_request)
+    def test_effective_principals_uses_fallback_policy_for_nonapi_paths(self, nonapi_request):
+        result = self.policy.effective_principals(nonapi_request)
 
-        self.session_policy.effective_principals.assert_called_once_with(session_request)
-        assert result == self.session_policy.effective_principals.return_value
+        self.fallback_policy.effective_principals.assert_called_once_with(nonapi_request)
+        assert result == self.fallback_policy.effective_principals.return_value
 
-    def test_effective_principals_uses_token_policy_for_token_auth_paths(self, token_request):
-        result = self.policy.effective_principals(token_request)
+    def test_effective_principals_uses_api_policy_for_api_paths(self, api_request):
+        result = self.policy.effective_principals(api_request)
 
-        self.token_policy.effective_principals.assert_called_once_with(token_request)
-        assert result == self.token_policy.effective_principals.return_value
+        self.api_policy.effective_principals.assert_called_once_with(api_request)
+        assert result == self.api_policy.effective_principals.return_value
 
-    def test_remember_uses_session_policy_for_session_auth_paths(self, session_request):
-        result = self.policy.remember(session_request, 'foo', bar='baz')
+    def test_remember_uses_fallback_policy_for_nonapi_paths(self, nonapi_request):
+        result = self.policy.remember(nonapi_request, 'foo', bar='baz')
 
-        self.session_policy.remember.assert_called_once_with(session_request, 'foo', bar='baz')
-        assert result == self.session_policy.remember.return_value
+        self.fallback_policy.remember.assert_called_once_with(nonapi_request, 'foo', bar='baz')
+        assert result == self.fallback_policy.remember.return_value
 
-    def test_remember_uses_token_policy_for_token_auth_paths(self, token_request):
-        result = self.policy.remember(token_request, 'foo', bar='baz')
+    def test_remember_uses_api_policy_for_api_paths(self, api_request):
+        result = self.policy.remember(api_request, 'foo', bar='baz')
 
-        self.token_policy.remember.assert_called_once_with(token_request, 'foo', bar='baz')
-        assert result == self.token_policy.remember.return_value
+        self.api_policy.remember.assert_called_once_with(api_request, 'foo', bar='baz')
+        assert result == self.api_policy.remember.return_value
 
-    def test_forget_uses_session_policy_for_session_auth_paths(self, session_request):
-        result = self.policy.forget(session_request)
+    def test_forget_uses_fallback_policy_for_nonapi_paths(self, nonapi_request):
+        result = self.policy.forget(nonapi_request)
 
-        self.session_policy.forget.assert_called_once_with(session_request)
-        assert result == self.session_policy.forget.return_value
+        self.fallback_policy.forget.assert_called_once_with(nonapi_request)
+        assert result == self.fallback_policy.forget.return_value
 
-    def test_forget_uses_token_policy_for_token_auth_paths(self, token_request):
-        result = self.policy.forget(token_request)
+    def test_forget_uses_api_policy_for_api_paths(self, api_request):
+        result = self.policy.forget(api_request)
 
-        self.token_policy.forget.assert_called_once_with(token_request)
-        assert result == self.token_policy.forget.return_value
+        self.api_policy.forget.assert_called_once_with(api_request)
+        assert result == self.api_policy.forget.return_value
 
 
 @pytest.mark.usefixtures('api_token', 'jwt')
@@ -210,19 +208,3 @@ class TestTokenAuthenticationPolicy(object):
     @pytest.fixture
     def jwt(self, patch):
         return patch('h.auth.tokens.userid_from_jwt')
-
-
-class TestWebSocketAuthenticationPolicy(object):
-
-    def test_policy_is_multiauth_policy(self):
-        from pyramid_multiauth import MultiAuthenticationPolicy
-        policy = WebSocketAuthenticationPolicy()
-        assert isinstance(policy, MultiAuthenticationPolicy)
-
-    def test_policy_has_correct_policies(self, matchers, patch):
-        multi = patch('pyramid_multiauth.MultiAuthenticationPolicy.__init__')
-        policy = WebSocketAuthenticationPolicy()
-        multi.assert_called_once_with(policy, [
-            matchers.instance_of(TokenAuthenticationPolicy),
-            matchers.instance_of(SessionAuthenticationPolicy),
-        ])


### PR DESCRIPTION
Rather than relying on each app instance to manually call `set_authentication_policy` on the configurator, this commit moves the (default) authentication policy configuration into the `h.auth` and `h.authz` modules.

This will make it easier for the exact configuration of the authentication policy to depend on application settings.

_*N.B.* This depends on #3635 and will need rebasing once that has merged_