### PR TITLE
Add "proxy" auth policy mode

### DIFF
--- a/h/config.py
+++ b/h/config.py
@@ -74,6 +74,7 @@ SETTINGS = [
     EnvSetting('h.client_secret', 'CLIENT_SECRET'),
     EnvSetting('h.db.should_create_all', 'MODEL_CREATE_ALL', type=asbool),
     EnvSetting('h.db.should_drop_all', 'MODEL_DROP_ALL', type=asbool),
+    EnvSetting('h.proxy_auth', 'PROXY_AUTH', type=asbool),
     EnvSetting('h.search.autoconfig', 'SEARCH_AUTOCONFIG', type=asbool),
     EnvSetting('h.websocket_url', 'WEBSOCKET_URL'),
     # The client Sentry DSN should be of the public kind, lacking the password


### PR DESCRIPTION
This change makes it possible to switch the `h` application into a mode where the authenticated user for a request is determined by the value of the X-Forwarded-User request header, rather than retrieved from the session.

This is useful for people who want to run h behind an authenticating reverse proxy which can be responsible for setting the header.

Unsurprisingly, turning this mode on in the wrong context would pose a major security risk, allowing anyone to impersonate anyone else simply by setting an HTTP header. As such, when `PROXY_AUTH` is set, the auth module prints a substantial warning to the logs.