### PR TITLE
Add a hook to disable all JS enhancements on the page

### DIFF
--- a/h/static/scripts/test/upgrade-elements-test.js
+++ b/h/static/scripts/test/upgrade-elements-test.js
@@ -15,4 +15,19 @@ describe('upgradeElements', function () {
 
     root.remove();
   });
+
+  it('does not upgrade elements if JS is disabled', function () {
+    var TestController = sinon.spy();
+    var root = {
+      querySelectorAll: function () {
+        // Array with one fake Element to upgrade
+        return [{}];
+      },
+      ownerDocument: {
+        location: { search: '?nojs=1' },
+      },
+    };
+    upgradeElements(root, {'.js-test': TestController});
+    assert.notCalled(TestController);
+  });
 });

--- a/h/static/scripts/upgrade-elements.js
+++ b/h/static/scripts/upgrade-elements.js
@@ -1,7 +1,15 @@
 'use strict';
 
+function isJSDisabled(document) {
+  return document.location.search.match(/\bnojs=1\b/);
+}
+
 /**
  * Upgrade elements on the page with additional functionality
+ *
+ * `upgradeElements()` provides a hook to test a page without JS enhancements.
+ * If `root` lives in a document whose URL contains the query string parameter
+ * `nojs=1` then `upgradeElements()` will return immediately.
  *
  * @param {Element} root - The root element to search for matching elements
  * @param {Object} controllers - Object mapping selectors to controller classes.
@@ -10,6 +18,10 @@
  *        order to upgrade it.
  */
 function upgradeElements(root, controllers) {
+  if (isJSDisabled(root.ownerDocument)) {
+    return;
+  }
+
   Object.keys(controllers).forEach(function (selector) {
     var elements = Array.from(root.querySelectorAll(selector));
     elements.forEach(function (el) {


### PR DESCRIPTION
Adding `nojs=1` to the URL's query string parameters will disable all JS
enhancements.

This is useful for testing the behavior users will see when JS is slow
to load or otherwise broken across a variety of browsers without needing
to install browser-specific addons or change global browser settings.

We alternatively put this hook in the root site bundle (`site.js`). Putting it in `upgradeElements` has the slight advantage that it will be available in any projects using it.