### PR TITLE
Replace "firstRun" config option with "openSidebar" and "openLoginForm"

### DIFF
--- a/h/templates/help.html.jinja2
+++ b/h/templates/help.html.jinja2
@@ -5,7 +5,13 @@
 {% block meta %}
   <link href='//fonts.googleapis.com/css?family=Lato:400,300' rel='stylesheet' type='text/css'>
   {{ super() }}
-  <script type="application/json" class="js-hypothesis-config">{"firstRun":true}</script>
+  <script type="application/json" class="js-hypothesis-config">
+    {
+      "firstRun": true, {# TODO: remove after 2016-09-01, by which time old clients will be gone. #}
+      "openSidebar": true,
+      "openLoginForm": true
+    }
+  </script>
   {% if not is_onboarding %}
     <script async defer src="{{ embed_js_url }}"></script>
   {% endif %}


### PR DESCRIPTION
This commit deprecates the confusingly-named "firstRun" embed script
option with two which actually describe the relevant actions triggered.

I've left the "firstRun" option around for now, for old(er) clients. We
can remove this in due course, as noted in a template comment.