### PR TITLE
Shorten an over-long error message

### DIFF
--- a/h/accounts/schemas.py
+++ b/h/accounts/schemas.py
@@ -169,9 +169,7 @@ class ForgotPasswordSchema(CSRFSchema):
 
         if user is None:
             err = colander.Invalid(node)
-            err['email'] = _('We have no user with the email address '
-                             '"{email}". Correct this address or try '
-                             'another.').format(email=email)
+            err['email'] = _('Unknown email address')
             raise err
 
         value['user'] = user

--- a/tests/h/accounts/schemas_test.py
+++ b/tests/h/accounts/schemas_test.py
@@ -202,7 +202,7 @@ def test_ForgotPasswordSchema_invalid_with_no_user(pyramid_csrf_request, user_mo
         schema.deserialize({'email': 'rapha@example.com'})
 
     assert 'email' in exc.value.asdict()
-    assert 'no user with the email address' in exc.value.asdict()['email']
+    assert exc.value.asdict()['email'] == 'Unknown email address'
 
 
 def test_ForgotPasswordSchema_adds_user_to_appstruct(pyramid_csrf_request, user_model):


### PR DESCRIPTION
This error message was overrunning the border of its container element
in the HTML/CSS.

Fixes #3465.