### PR TITLE
URL changes for reset password, forgot password and register.

### DIFF
--- a/h/client.py
+++ b/h/client.py
@@ -58,7 +58,6 @@ def _app_html_context(assets_env, api_url, service_url, ga_tracking_id,
         'app_js_urls': assets_env.urls('app_js'),
         'ga_tracking_id': ga_tracking_id,
         'ga_cookie_domain': ga_cookie_domain,
-        'register_url': service_url + 'register',
     }
 
 

--- a/h/templates/accounts/forgot_password.html.jinja2
+++ b/h/templates/accounts/forgot_password.html.jinja2
@@ -29,7 +29,7 @@ Password reset
     <div class="form-vertical">
       <ul class="nav nav-tabs">
         <li><a href="{{ request.route_path('login') }}">Log in</a></li>{#
-        #}<li><a href="{{ request.route_path('register') }}">Create an account</a></li>{#
+        #}<li><a href="{{ request.route_path('signup') }}">Create an account</a></li>{#
         #}<li class="active"><a href="{{ request.route_path('forgot_password') }}">Password reset</a></li>
       </ul>
       {{ form }}

--- a/h/templates/accounts/login.html.jinja2
+++ b/h/templates/accounts/login.html.jinja2
@@ -14,7 +14,7 @@
       {{ form }}
       <footer class="form-footer">
         Don't have a Hypothesis account?
-        <a class="link" href="{{ request.route_path('register') }}">Sign up</a>
+        <a class="link" href="{{ request.route_path('signup') }}">Sign up</a>
       </footer>
     </div>
   {% else %}
@@ -23,7 +23,7 @@
       <div class="form-vertical">
         <ul class="nav nav-tabs">
           <li class="active"><a href="{{ request.route_path('login') }}">Log in</a></li>{#
-          #}<li><a href="{{ request.route_path('register') }}">Create an account</a></li>
+          #}<li><a href="{{ request.route_path('signup') }}">Create an account</a></li>
         </ul>
         {{ form }}
       </div>

--- a/h/templates/accounts/reset.html.jinja2
+++ b/h/templates/accounts/reset.html.jinja2
@@ -37,7 +37,7 @@ Password reset
     <div class="form-vertical">
       <ul class="nav nav-tabs">
         <li><a href="{{ request.route_path('login') }}">Log in</a></li>{#
-        #}<li><a href="{{ request.route_path('register') }}">Create an account</a></li>{#
+        #}<li><a href="{{ request.route_path('signup') }}">Create an account</a></li>{#
         #}<li class="active"><a href="">New password</a></li>
       </ul>
       {% if not has_code %}

--- a/h/templates/accounts/signup.html.jinja2
+++ b/h/templates/accounts/signup.html.jinja2
@@ -29,7 +29,7 @@ Create account
     <div class="form-vertical">
       <ul class="nav nav-tabs">
         <li><a href="{{ request.route_path('login') }}">Log in</a></li>{#
-        #}<li class="active"><a href="{{ request.route_path('register') }}">Create an account</a></li>
+        #}<li class="active"><a href="{{ request.route_path('signup') }}">Create an account</a></li>
       </ul>
       {{ form }}
     </div>

--- a/h/templates/home.html.jinja2
+++ b/h/templates/home.html.jinja2
@@ -73,7 +73,7 @@
             <li><a href="{{ request.route_url("logout") }}">Log out</a></li>
           {% else %}
             <li><a href="{{ base_url }}login">Log in</a></li>
-            <li><a href="{{ base_url }}register">Create an account</a></li>
+            <li><a href="{{ base_url }}signup">Create an account</a></li>
           {% endif %}
         </ul>
       </nav>

--- a/h/tweens.py
+++ b/h/tweens.py
@@ -102,7 +102,9 @@ def content_security_policy_tween_factory(handler, registry):
 REDIRECTS = {
     '/profile': 'account',
     '/profile/notifications': 'account_notifications',
-    '/profile/developer': 'account_developer'
+    '/profile/developer': 'account_developer',
+    '/register': 'signup',
+    '/forgot_password': 'forgot_password'
 }
 
 


### PR DESCRIPTION
https://trello.com/c/Yiraeqzs/408-logged-out-form-url-changes-and-redirects

Related to:
https://github.com/hypothesis/client/pull/68

Test scenarios:
- In /: create new user
- In acount/settings:
   changed email
   changed password
- In stream:
   logged out and logged in with new password, 
   forgot password and reset it

**N.B.** We will need to coordinate the deployment of this change carefully, as we may need to update our nginx configuration._​