### PR TITLE
Fixed DetachedInstanceError in exception view template

### DIFF
--- a/h/features/__init__.py
+++ b/h/features/__init__.py
@@ -4,6 +4,8 @@ from __future__ import unicode_literals
 
 import os
 
+from pyramid.events import NewRequest
+
 from h import db
 from h.features import client
 from h.features import models
@@ -32,6 +34,17 @@ def includeme(config):
     config.include('h.features.views')
 
     config.add_request_method(Client, name='feature', reify=True)
+
+    # Load the feature flags from the database at the beginning of each request.
+    # This prevents sqlalchemy DetachedInstanceErrors that can occur if the
+    # feature flags client tries to load the feature flags later on and the
+    # database session has already been closed.
+    # This is done on NewRequest to make sure that things like
+    # request.effective_principals are already setup, so that we get the correct
+    # feature flags.
+    config.add_subscriber(lambda event: event.request.feature.load(),
+                          NewRequest)
+
     config.add_subscriber(_remove_old_flags_on_boot,
                           'pyramid.events.ApplicationCreated')
 

--- a/h/features/client.py
+++ b/h/features/client.py
@@ -38,7 +38,7 @@ class Client(object):
         feature flags from the database first.
         """
         if self._cache is None:
-            self._load()
+            self.load()
 
         if name not in self._cache:
             raise UnknownFeatureError(
@@ -55,15 +55,15 @@ class Client(object):
         feature flags from the database first.
         """
         if self._cache is None:
-            self._load()
+            self.load()
 
         return self._cache
 
     def clear(self):
         self._cache = None
 
-    def _load(self):
-        """Loads the feature flag states into the internal cache."""
+    def load(self):
+        """Load the feature flag states into the internal cache."""
         features = self._fetcher(self.request.db)
         self._cache = {f.name: self._state(f) for f in features}
 


### PR DESCRIPTION
Exception views are called after the request's transaction has been
aborted due to an exception. If a template rendered by the exception
view then tried to call feature() it would crash with a
DetachedInstanceError as the feature flags client tries to load its
feature flags which involves accessing lazy-loaded properties of
request.authenticated_user which can no longer be loaded because the db
transaction has been aborted.

Forcing the feature flags client to load and cache all of its feature
flags when the template environment is setup ensures that these
lazy-loaded properties have already been loaded by the time any
templates get rendered, so accessing them on a detached instance is fine
because they no longer need to be read from the db.