### PR TITLE
Show tracebacks when functional tests 500

### DIFF
--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -13,6 +13,7 @@ TEST_SETTINGS = {
     'h.db.should_create_all': True,
     'h.db.should_drop_all': True,
     'h.search.autoconfig': True,
+    'pyramid.debug_all': True,
     'sqlalchemy.url': os.environ.get('TEST_DATABASE_URL',
                                      'postgresql://postgres@localhost/htest')
 }


### PR DESCRIPTION
When a functional test fails with a 500 Server Error show the in-app
traceback of the exception that produced the 500, rather than just the
traceback from webtest where it received the 500.

This is useful for debugging functional test errors.