### PR TITLE
Server-side annotation text markdown rendering

### DIFF
--- a/h/migrations/versions/d536d9a342f3_fill_in_annotation_text_rendered_column.py
+++ b/h/migrations/versions/d536d9a342f3_fill_in_annotation_text_rendered_column.py
@@ -1,0 +1,85 @@
+"""
+Fill in annotation text_rendered column
+
+Revision ID: d536d9a342f3
+Revises: 39b1935d9e7b
+Create Date: 2016-08-10 14:09:01.787927
+"""
+
+from __future__ import unicode_literals
+from __future__ import print_function
+
+import sys
+from collections import namedtuple
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import sessionmaker
+
+from memex import markdown
+
+
+revision = 'd536d9a342f3'
+down_revision = '39b1935d9e7b'
+
+Base = declarative_base()
+Session = sessionmaker()
+
+
+class Window(namedtuple('Window', ['start', 'end'])):
+    pass
+
+
+class Annotation(Base):
+    __tablename__ = 'annotation'
+
+    id = sa.Column(sa.Integer, autoincrement=True, primary_key=True)
+    updated = sa.Column(sa.DateTime)
+
+    text = sa.Column(sa.UnicodeText)
+    text_rendered = sa.Column(sa.UnicodeText)
+
+
+def upgrade():
+    session = Session(bind=op.get_bind())
+
+    fill_annotations_text_rendered(session)
+
+
+def downgrade():
+    pass
+
+
+def fill_annotations_text_rendered(session):
+    windows = _fetch_windows(session)
+    session.rollback()
+
+    for window in windows:
+        _fill_annotation_window_text_rendered(session, window)
+        session.commit()
+
+        print('.', end='')
+        sys.stdout.flush()
+
+
+def _fill_annotation_window_text_rendered(session, window):
+    query = session.query(Annotation) \
+        .filter(Annotation.updated.between(window.start, window.end)) \
+        .order_by(Annotation.updated.asc())
+
+    for a in query:
+        a.text_rendered = markdown.render(a.text)
+
+
+def _fetch_windows(session, chunksize=100):
+    updated = session.query(Annotation.updated). \
+        execution_options(stream_results=True). \
+        order_by(Annotation.updated.desc()).all()
+
+    count = len(updated)
+    windows = [Window(start=updated[min(x+chunksize, count)-1].updated,
+                      end=updated[x].updated)
+               for x in xrange(0, count, chunksize)]
+
+    return windows

--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -55,8 +55,8 @@ Users (first ten):
                   <p>Group: {{ result.group.name }}</p>
                   <p>Shared: {{ result.annotation.shared }}</p>
                   <p>URI: {{ result.annotation.target_uri }}</p>
-                  <p>Text: {{ result.annotation.text }}</p>
                   <p>Tags: {{ ','.join(result.annotation.tags) }}</p>
+                  <p>Text:<br>{{ result.annotation.text_rendered|safe }}</p>
                 </li>
               {% endfor %}
             </ol>

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ alembic==0.8.7
 amqp==1.4.9               # via kombu
 anyjson==0.3.3            # via kombu
 billiard==3.3.0.23        # via celery
+bleach==1.4.3
 blinker==1.3
 celery==3.1.23
 certifi==2016.2.28
@@ -28,6 +29,7 @@ functools32==3.2.3.post2  # via jsonschema
 gevent==1.1.2
 greenlet==0.4.10          # via gevent
 gunicorn==19.6.0
+html5lib==0.9999999       # via bleach
 idna==2.1                 # via cryptography
 ipaddress==1.0.16         # via cryptography
 iso8601==0.1.11           # via colander
@@ -64,7 +66,7 @@ redis==2.10.5             # via pyramid-redis-sessions
 repoze.lru==0.6           # via pyramid
 repoze.sendmail==4.1
 requests==2.10.0
-six==1.10.0               # via cryptography, python-dateutil
+six==1.10.0               # via bleach, cryptography, html5lib, python-dateutil
 SQLAlchemy==1.0.14        # via alembic, zope.sqlalchemy
 statsd==3.2.1
 transaction==1.6.1        # via pyramid-tm, repoze.sendmail, zope.sqlalchemy

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,6 +38,7 @@ jsonschema==2.5.1
 kombu==3.0.35
 Mako==1.0.4               # via alembic
 MarkupSafe==0.23          # via jinja2, mako, pyramid-jinja2
+mistune==0.7.3
 PasteDeploy==1.5.2        # via pyramid
 pbkdf2==1.3               # via cryptacular
 peppercorn==0.5           # via deform

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ CLASSIFIERS = [
 ]
 INSTALL_REQUIRES = [
     'SQLAlchemy>=1.0.13',
+    'bleach>=1.4.3,<1.5',
     'elasticsearch>=1.1.0,<2.0.0',
     'jsonschema>=2.5.1,<2.6',
     'mistune>=0.7.3,<0.8',

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ INSTALL_REQUIRES = [
     'SQLAlchemy>=1.0.13',
     'elasticsearch>=1.1.0,<2.0.0',
     'jsonschema>=2.5.1,<2.6',
+    'mistune>=0.7.3,<0.8',
     'psycopg2>=2.6.1,<2.7',
     'pyparsing>=2.1.5,<2.2',
     'pyramid-services==0.4',

--- a/src/memex/markdown.py
+++ b/src/memex/markdown.py
@@ -4,7 +4,20 @@ from __future__ import unicode_literals
 
 import re
 
+import bleach
 import mistune
+
+MARKDOWN_TAGS = [
+    'a', 'blockquote', 'code', 'em', 'hr', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+    'img', 'li', 'ol', 'p', 'pre', 'strong', 'ul',
+]
+ALLOWED_TAGS = set(bleach.ALLOWED_TAGS + MARKDOWN_TAGS)
+
+MARKDOWN_ATTRIBUTES = {
+    'a': ['href', 'title'],
+    'img': ['alt', 'src', 'title'],
+}
+ALLOWED_ATTRIBUTES = dict(bleach.ALLOWED_ATTRIBUTES.items() + MARKDOWN_ATTRIBUTES.items())
 
 # Singleton instance of the Markdown instance
 markdown = None
@@ -52,8 +65,14 @@ class MathRenderer(mistune.Renderer):
 def render(text):
     if text is not None:
         render = _get_markdown()
-        return render(text)
+        return sanitize(render(text))
     return None
+
+
+def sanitize(text):
+    return bleach.clean(text,
+                        tags=ALLOWED_TAGS,
+                        attributes=ALLOWED_ATTRIBUTES)
 
 
 def _get_markdown():

--- a/src/memex/markdown.py
+++ b/src/memex/markdown.py
@@ -8,6 +8,8 @@ import bleach
 from bleach import callbacks as linkify_callbacks
 import mistune
 
+LINK_REL = 'nofollow noopener'
+
 MARKDOWN_TAGS = [
     'a', 'blockquote', 'code', 'em', 'hr', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
     'img', 'li', 'ol', 'p', 'pre', 'strong', 'ul',
@@ -20,6 +22,9 @@ def _filter_link_attributes(name, value):
         return True
 
     if name == 'target' and value == '_blank':
+        return True
+
+    if name == 'rel' and value == LINK_REL:
         return True
 
     return False
@@ -82,12 +87,22 @@ def render(text):
 
 def sanitize(text):
     linkified = bleach.linkify(text, callbacks=[
-        linkify_callbacks.target_blank
+        linkify_callbacks.target_blank,
+        linkify_rel,
     ])
 
     return bleach.clean(linkified,
                         tags=ALLOWED_TAGS,
                         attributes=ALLOWED_ATTRIBUTES)
+
+
+def linkify_rel(attrs, new=False):
+    if attrs['href'].startswith('mailto:'):
+        return attrs
+
+    attrs['rel'] = LINK_REL
+
+    return attrs
 
 
 def _get_markdown():

--- a/src/memex/markdown.py
+++ b/src/memex/markdown.py
@@ -10,6 +10,45 @@ import mistune
 markdown = None
 
 
+class MathMarkdown(mistune.Markdown):
+    def output_block_math(self):
+        return self.renderer.block_math(self.token['text'])
+
+
+class MathInlineLexer(mistune.InlineLexer):
+    def __init__(self, *args, **kwargs):
+        super(MathInlineLexer, self).__init__(*args, **kwargs)
+        self.rules.inline_math = re.compile(r'\\\((.*?)\\\)', re.DOTALL)
+        self.default_rules.insert(0, 'inline_math')
+
+    def output_inline_math(self, m):
+        return self.renderer.inline_math(m.group(1))
+
+
+class MathBlockLexer(mistune.BlockLexer):
+    def __init__(self, *args, **kwargs):
+        super(MathBlockLexer, self).__init__(*args, **kwargs)
+        self.rules.block_math = re.compile(r'^\$\$(.*?)\$\$', re.DOTALL)
+        self.default_rules.insert(0, 'block_math')
+
+    def parse_block_math(self, m):
+        self.tokens.append({
+            'type': 'block_math',
+            'text': m.group(1)
+        })
+
+
+class MathRenderer(mistune.Renderer):
+    def __init__(self, **kwargs):
+        super(MathRenderer, self).__init__(**kwargs)
+
+    def block_math(self, text):
+        return '<p>$$%s$$</p>\n' % text
+
+    def inline_math(self, text):
+        return '\\(%s\\)' % text
+
+
 def render(text):
     if text is not None:
         render = _get_markdown()
@@ -20,5 +59,8 @@ def render(text):
 def _get_markdown():
     global markdown
     if markdown is None:
-        markdown = mistune.Markdown(escape=True)
+        markdown = MathMarkdown(renderer=MathRenderer(),
+                                inline=MathInlineLexer,
+                                block=MathBlockLexer,
+                                escape=True)
     return markdown

--- a/src/memex/markdown.py
+++ b/src/memex/markdown.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import re
+
+import mistune
+
+# Singleton instance of the Markdown instance
+markdown = None
+
+
+def render(text):
+    if text is not None:
+        render = _get_markdown()
+        return render(text)
+    return None
+
+
+def _get_markdown():
+    global markdown
+    if markdown is None:
+        markdown = mistune.Markdown(escape=True)
+    return markdown

--- a/src/memex/models/annotation.py
+++ b/src/memex/models/annotation.py
@@ -10,6 +10,7 @@ from sqlalchemy.dialects import postgresql as pg
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.ext.mutable import MutableDict
 
+from memex import markdown
 from memex import uri
 from memex.db import Base
 from memex.db import types
@@ -144,6 +145,10 @@ class Annotation(Base):
             return self.references[0]
         else:
             return self.id
+
+    @property
+    def text_rendered(self):
+        return markdown.render(self.text)
 
     def __acl__(self):
         """Return a Pyramid ACL for this annotation."""

--- a/src/memex/models/annotation.py
+++ b/src/memex/models/annotation.py
@@ -65,9 +65,9 @@ class Annotation(Base):
                         index=True)
 
     #: The textual body of the annotation.
-    text = sa.Column(sa.UnicodeText)
+    _text = sa.Column('text', sa.UnicodeText)
     #: The Markdown-rendered and HTML-sanitized textual body of the annotation.
-    text_rendered = sa.Column(sa.UnicodeText)
+    _text_rendered = sa.Column('text_rendered', sa.UnicodeText)
     #: The tags associated with the annotation.
     tags = sa.Column(
         types.MutableList.as_mutable(
@@ -121,6 +121,19 @@ class Annotation(Base):
     @hybrid_property
     def target_uri_normalized(self):
         return self._target_uri_normalized
+
+    @hybrid_property
+    def text(self):
+        return self._text
+
+    @text.setter
+    def text(self, value):
+        self._text = value
+        self._text_rendered = markdown.render(value)
+
+    @hybrid_property
+    def text_rendered(self):
+        return self._text_rendered
 
     @property
     def parent_id(self):

--- a/src/memex/models/annotation.py
+++ b/src/memex/models/annotation.py
@@ -66,6 +66,8 @@ class Annotation(Base):
 
     #: The textual body of the annotation.
     text = sa.Column(sa.UnicodeText)
+    #: The Markdown-rendered and HTML-sanitized textual body of the annotation.
+    text_rendered = sa.Column(sa.UnicodeText)
     #: The tags associated with the annotation.
     tags = sa.Column(
         types.MutableList.as_mutable(
@@ -145,10 +147,6 @@ class Annotation(Base):
             return self.references[0]
         else:
             return self.id
-
-    @property
-    def text_rendered(self):
-        return markdown.render(self.text)
 
     def __acl__(self):
         """Return a Pyramid ACL for this annotation."""

--- a/tests/memex/markdown_test.py
+++ b/tests/memex/markdown_test.py
@@ -34,38 +34,41 @@ class TestRender(object):
 
 
 class TestSanitize(object):
-    @pytest.mark.parametrize("text", [
-        '<a href="https://example.org">example</a>',
-        '<a title="foobar">example</a>',
-        '<a href="https://example.org" title="foobar">example</a>',
-        '<blockquote>Foobar</blockquote>',
-        '<code>foobar</code>',
-        '<em>foobar</em>',
-        '<hr>',
-        '<h1>foobar</h1>'
-        '<h2>foobar</h2>'
-        '<h3>foobar</h3>'
-        '<h4>foobar</h4>',
-        '<h5>foobar</h5>',
-        '<h6>foobar</h6>',
-        '<img src="http://example.com/img.jpg">',
-        '<img src="/img.jpg">',
-        '<img alt="foobar" src="/img.jpg">',
-        '<img src="/img.jpg" title="foobar">',
-        '<img alt="hello" src="/img.jpg" title="foobar">',
-        '<ol><li>foobar</li></ol>',
-        '<p>foobar</p>'
-        '<pre>foobar</pre>',
-        '<strong>foobar</strong>',
-        '<ul><li>foobar</li></ul>',
+    @pytest.mark.parametrize("text,expected", [
+        ('<a href="https://example.org">example</a>', '<a href="https://example.org" rel="nofollow noopener" target="_blank">example</a>'),
+        ('<a title="foobar">example</a>', None),
+        ('<a href="https://example.org" rel="nofollow noopener" target="_blank" title="foobar">example</a>', None),
+        ('<blockquote>Foobar</blockquote>', None),
+        ('<code>foobar</code>', None),
+        ('<em>foobar</em>', None),
+        ('<hr>', None),
+        ('<h1>foobar</h1>', None),
+        ('<h2>foobar</h2>', None),
+        ('<h3>foobar</h3>', None),
+        ('<h4>foobar</h4>', None),
+        ('<h5>foobar</h5>', None),
+        ('<h6>foobar</h6>', None),
+        ('<img src="http://example.com/img.jpg">', None),
+        ('<img src="/img.jpg">', None),
+        ('<img alt="foobar" src="/img.jpg">', None),
+        ('<img src="/img.jpg" title="foobar">', None),
+        ('<img alt="hello" src="/img.jpg" title="foobar">', None),
+        ('<ol><li>foobar</li></ol>', None),
+        ('<p>foobar</p>', None),
+        ('<pre>foobar</pre>', None),
+        ('<strong>foobar</strong>', None),
+        ('<ul><li>foobar</li></ul>', None),
     ])
-    def test_it_allows_markdown_html(self, text):
-        assert markdown.sanitize(text) == text
+    def test_it_allows_markdown_html(self, text, expected):
+        if expected is None:
+            expected = text
+
+        assert markdown.sanitize(text) == expected
 
     @pytest.mark.parametrize("text,expected", [
         ('<script>evil()</script>', '&lt;script&gt;evil()&lt;/script&gt;'),
-        ('<a href="#" onclick="evil()">foobar</a>', '<a href="#">foobar</a>'),
-        ('<a href="#" onclick=evil()>foobar</a>', '<a href="#">foobar</a>'),
+        ('<a href="#" onclick="evil()">foobar</a>', '<a href="#" rel="nofollow noopener" target="_blank">foobar</a>'),
+        ('<a href="#" onclick=evil()>foobar</a>', '<a href="#" rel="nofollow noopener" target="_blank">foobar</a>'),
         ('<a href="javascript:alert(\'evil\')">foobar</a>', '<a>foobar</a>'),
         ('<img src="/evil.jpg" onclick="evil()">', '<img src="/evil.jpg">'),
         ('<img src="javascript:alert(\'evil\')">', '<img>'),
@@ -73,7 +76,8 @@ class TestSanitize(object):
     def test_it_escapes_evil_html(self, text, expected):
         assert markdown.sanitize(text) == expected
 
-    def test_it_adds_target_blank_to_links(self):
+    def test_it_adds_target_blank_and_rel_nofollow_to_links(self):
         actual = markdown.sanitize('<a href="https://example.org">Hello</a>')
+        expected = '<a href="https://example.org" rel="nofollow noopener" target="_blank">Hello</a>'
 
-        assert actual == '<a href="https://example.org" target="_blank">Hello</a>'
+        assert actual == expected

--- a/tests/memex/markdown_test.py
+++ b/tests/memex/markdown_test.py
@@ -8,3 +8,13 @@ from memex import markdown
 def test_render_renders_markdown():
     actual = markdown.render('_emphasis_ **bold**')
     assert '<p><em>emphasis</em> <strong>bold</strong></p>\n' == actual
+
+
+def test_render_ignores_math_block():
+    actual = markdown.render('$$1 + 1 = 2$$')
+    assert '<p>$$1 + 1 = 2$$</p>\n' == actual
+
+
+def test_render_ignores_inline_match():
+    actual = markdown.render('Foobar \(1 + 1 = 2\)')
+    assert '<p>Foobar \(1 + 1 = 2\)</p>\n' == actual

--- a/tests/memex/markdown_test.py
+++ b/tests/memex/markdown_test.py
@@ -2,19 +2,73 @@
 
 from __future__ import unicode_literals
 
+import pytest
+
 from memex import markdown
 
 
-def test_render_renders_markdown():
-    actual = markdown.render('_emphasis_ **bold**')
-    assert '<p><em>emphasis</em> <strong>bold</strong></p>\n' == actual
+class TestRender(object):
+    def test_it_renders_markdown(self):
+        actual = markdown.render('_emphasis_ **bold**')
+        assert '<p><em>emphasis</em> <strong>bold</strong></p>\n' == actual
+
+    def test_it_ignores_math_block(self):
+        actual = markdown.render('$$1 + 1 = 2$$')
+        assert '<p>$$1 + 1 = 2$$</p>\n' == actual
+
+    def test_it_ignores_inline_match(self):
+        actual = markdown.render('Foobar \(1 + 1 = 2\)')
+        assert '<p>Foobar \(1 + 1 = 2\)</p>\n' == actual
+
+    def test_it_sanitizes_the_output(self, markdown_render, sanitize):
+        markdown.render('foobar')
+        sanitize.assert_called_once_with(markdown_render.return_value)
+
+    @pytest.fixture
+    def markdown_render(self, patch):
+        return patch('memex.markdown.markdown')
+
+    @pytest.fixture
+    def sanitize(self, patch):
+        return patch('memex.markdown.sanitize')
 
 
-def test_render_ignores_math_block():
-    actual = markdown.render('$$1 + 1 = 2$$')
-    assert '<p>$$1 + 1 = 2$$</p>\n' == actual
+class TestSanitize(object):
+    @pytest.mark.parametrize("text", [
+        '<a href="https://example.org">example</a>',
+        '<a title="foobar">example</a>',
+        '<a href="https://example.org" title="foobar">example</a>',
+        '<blockquote>Foobar</blockquote>',
+        '<code>foobar</code>',
+        '<em>foobar</em>',
+        '<hr>',
+        '<h1>foobar</h1>'
+        '<h2>foobar</h2>'
+        '<h3>foobar</h3>'
+        '<h4>foobar</h4>',
+        '<h5>foobar</h5>',
+        '<h6>foobar</h6>',
+        '<img src="http://example.com/img.jpg">',
+        '<img src="/img.jpg">',
+        '<img alt="foobar" src="/img.jpg">',
+        '<img src="/img.jpg" title="foobar">',
+        '<img alt="hello" src="/img.jpg" title="foobar">',
+        '<ol><li>foobar</li></ol>',
+        '<p>foobar</p>'
+        '<pre>foobar</pre>',
+        '<strong>foobar</strong>',
+        '<ul><li>foobar</li></ul>',
+    ])
+    def test_it_allows_markdown_html(self, text):
+        assert markdown.sanitize(text) == text
 
-
-def test_render_ignores_inline_match():
-    actual = markdown.render('Foobar \(1 + 1 = 2\)')
-    assert '<p>Foobar \(1 + 1 = 2\)</p>\n' == actual
+    @pytest.mark.parametrize("text,expected", [
+        ('<script>evil()</script>', '&lt;script&gt;evil()&lt;/script&gt;'),
+        ('<a href="#" onclick="evil()">foobar</a>', '<a href="#">foobar</a>'),
+        ('<a href="#" onclick=evil()>foobar</a>', '<a href="#">foobar</a>'),
+        ('<a href="javascript:alert(\'evil\')">foobar</a>', '<a>foobar</a>'),
+        ('<img src="/evil.jpg" onclick="evil()">', '<img src="/evil.jpg">'),
+        ('<img src="javascript:alert(\'evil\')">', '<img>'),
+    ])
+    def test_it_escapes_evil_html(self, text, expected):
+        assert markdown.sanitize(text) == expected

--- a/tests/memex/markdown_test.py
+++ b/tests/memex/markdown_test.py
@@ -72,3 +72,8 @@ class TestSanitize(object):
     ])
     def test_it_escapes_evil_html(self, text, expected):
         assert markdown.sanitize(text) == expected
+
+    def test_it_adds_target_blank_to_links(self):
+        actual = markdown.sanitize('<a href="https://example.org">Hello</a>')
+
+        assert actual == '<a href="https://example.org" target="_blank">Hello</a>'

--- a/tests/memex/markdown_test.py
+++ b/tests/memex/markdown_test.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from memex import markdown
+
+
+def test_render_renders_markdown():
+    actual = markdown.render('_emphasis_ **bold**')
+    assert '<p><em>emphasis</em> <strong>bold</strong></p>\n' == actual

--- a/tests/memex/models/annotation_test.py
+++ b/tests/memex/models/annotation_test.py
@@ -79,10 +79,15 @@ def test_thread_root_id_returns_first_reference_if_many_references():
     assert annotation.thread_root_id == '1Ife3DoHEea6hpv8vWujdQ'
 
 
-def test_text_rendered(markdown):
-    annotation = Annotation(text='foobar')
-    annotation.text_rendered
+def test_text_setter_renders_markdown(markdown):
+    markdown.render.return_value = '<p>foobar</p>'
+
+    annotation = Annotation()
+    annotation.text = 'foobar'
+
     markdown.render.assert_called_once_with('foobar')
+
+    annotation.text_rendered == markdown.render.return_value
 
 
 def test_acl_private():

--- a/tests/memex/models/annotation_test.py
+++ b/tests/memex/models/annotation_test.py
@@ -79,6 +79,12 @@ def test_thread_root_id_returns_first_reference_if_many_references():
     assert annotation.thread_root_id == '1Ife3DoHEea6hpv8vWujdQ'
 
 
+def test_text_rendered(markdown):
+    annotation = Annotation(text='foobar')
+    annotation.text_rendered
+    markdown.render.assert_called_once_with('foobar')
+
+
 def test_acl_private():
     ann = Annotation(shared=False, userid='saoirse')
     actual = ann.__acl__()
@@ -205,3 +211,8 @@ def annotation(db_session):
     db_session.add(ann)
     db_session.flush()
     return ann
+
+
+@pytest.fixture
+def markdown(patch):
+    return patch('memex.models.annotation.markdown')


### PR DESCRIPTION
This adds server-side annotation text markdown rendering capabilities.

We use [mistune](https://pypi.python.org/pypi/mistune) for Markdown rendering, and for now make it ignore inline math and math blocks (see `MathMarkdown`, `MathInlineLexer`, `MathBlockLexer`, and `MathRenderer` in `h.api.markdown`).

After converting Markdown to HTML we run the text through [bleach](https://pypi.python.org/pypi/bleach) to sanitize the HTML. We bleach's default list of [allowed tags](https://github.com/mozilla/bleach/blob/v1.4.3/bleach/__init__.py#L23-L36) and [allowed attributes](https://github.com/mozilla/bleach/blob/v1.4.3/bleach/__init__.py#L38-L42), plus add anything that Markdown generates (`h.api.markdown.MARKDOWN_TAGS`, `h.api.markdown.MARKDOWN_ATTRIBUTES`).

For testing purposes, I've created an annotation with the [this text](https://gist.github.com/chdorner/c4ac4d0d8d21cfd00eeb1a5962e51425) which should include all Markdown features plus an oEmbed link (Youtube), and the inline and block math we support.