### PR TITLE
Define a default script bundle in the base layout

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,7 +7,7 @@ indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[*.{html,js,json,scss,yaml,yml}]
+[*.{html,jinja2,js,json,scss,yaml,yml}]
 indent_size = 2
 
 [*.py]

--- a/h/templates/accounts/forgot_password.html.jinja2
+++ b/h/templates/accounts/forgot_password.html.jinja2
@@ -37,9 +37,3 @@ Password reset
   </div>
 {% endif %}
 {% endblock content %}
-
-{% block scripts %}
-  {% for url in asset_urls("site_js") %}
-  <script src="{{ url }}"></script>
-  {% endfor %}
-{% endblock %}

--- a/h/templates/accounts/login.html.jinja2
+++ b/h/templates/accounts/login.html.jinja2
@@ -30,9 +30,3 @@
     </div>
   {% endif %}
 {% endblock content %}
-
-{% block scripts %}
-  {% for url in asset_urls("site_js") %}
-  <script src="{{ url }}"></script>
-  {% endfor %}
-{% endblock %}

--- a/h/templates/accounts/reset.html.jinja2
+++ b/h/templates/accounts/reset.html.jinja2
@@ -54,9 +54,3 @@ Password reset
   </div>
   {% endif %}
 {% endblock content %}
-
-{% block scripts %}
-  {% for url in asset_urls("site_js") %}
-  <script src="{{ url }}"></script>
-  {% endfor %}
-{% endblock %}

--- a/h/templates/accounts/signup.html.jinja2
+++ b/h/templates/accounts/signup.html.jinja2
@@ -36,9 +36,3 @@ Create account
   </div>
   {% endif %}
 {% endblock content %}
-
-{% block scripts %}
-  {% for url in asset_urls("site_js") %}
-  <script src="{{ url }}"></script>
-  {% endfor %}
-{% endblock %}

--- a/h/templates/groups/create.html.jinja2
+++ b/h/templates/groups/create.html.jinja2
@@ -27,9 +27,3 @@
     </div>
   </div>
 {% endblock content %}
-
-{% block scripts %}
-{% for url in asset_urls("site_js") %}
-<script src="{{url}}"></script>
-{% endfor %}
-{% endblock scripts %}

--- a/h/templates/groups/join.html.jinja2
+++ b/h/templates/groups/join.html.jinja2
@@ -30,9 +30,3 @@
     </div>
   </div>
 {% endblock content %}
-
-{% block scripts %}
-{% for url in asset_urls("site_js") %}
-<script src="{{ url }}"></script>
-{% endfor %}
-{% endblock scripts %}

--- a/h/templates/groups/share.html.jinja2
+++ b/h/templates/groups/share.html.jinja2
@@ -71,9 +71,3 @@
     </div>
   </div>
 {% endblock content %}
-
-{% block scripts %}
-{% for url in asset_urls("site_js") %}
-<script src="{{ url }}"></script>
-{% endfor %}
-{% endblock scripts %}

--- a/h/templates/layouts/base.html.jinja2
+++ b/h/templates/layouts/base.html.jinja2
@@ -86,6 +86,10 @@
   {% block body_tag %}<body class="body">{% endblock %}
     {% block content %}{% endblock %}
     {% block templates %}{% endblock %}
-    {% block scripts %}{% endblock %}
+    {% block scripts %}
+    {% for url in asset_urls("site_js") %}
+    <script src="{{ url }}"></script>
+    {% endfor %}
+    {% endblock %}
   </body>
 </html>


### PR DESCRIPTION
Remove the repeated markup for generating `<script>` tags in each page that uses the `site_js` bundle and move it to the base layout instead.

Individual pages or layouts can still override the default bundle and provide their own. Currently only the old homepage does this.

Also add `.jinja2` to `.editorconfig` so that Vim uses correct indentation for new Jinja2 templates.