### PR TITLE
Add missing reset_password redirect

### DIFF
--- a/h/tweens.py
+++ b/h/tweens.py
@@ -105,6 +105,7 @@ REDIRECTS = [
     ('/profile', 'account'),
     ('/register', 'signup'),
     ('/forgot_password', 'forgot_password'),
+    ('/reset_password', 'account_reset'),
 ]
 
 


### PR DESCRIPTION
#3662 made it possible to redirect based on prefix matches, but was missing the actual redirect for the `/reset_password` path.