### PR TITLE
Disable PEP257 missing docstring warnings

### DIFF
--- a/.prospector.yaml
+++ b/.prospector.yaml
@@ -15,6 +15,14 @@ pep257:
     - D203 # "1 blank line required before class docstring" conflicts with
            # another pep257 rule D211 "No blank lines allowed before class
            # docstring"!
+
+    # "Missing docstring" warnings:
+    - D100
+    - D101
+    - D102
+    - D103
+    - D104
+    - D105
 pyflakes:
   run: false
 


### PR DESCRIPTION
Although our coding standards claim that we follow PEP8 and PEP257, the
fact is that we don't put docstrings on everything, not even in new code
that we write, and these "missing docstring" warnings are creating a lot
of noise that's drowning out other, more interesting linter warnings.