### PR TITLE
Add a helper for generating SVG icons for use on the website

### DIFF
--- a/h/app.py
+++ b/h/app.py
@@ -65,6 +65,7 @@ def includeme(config):
 
     config.include('pyramid_jinja2')
     config.add_jinja2_extension('h.jinja_extensions.Filters')
+    config.add_jinja2_extension('h.jinja_extensions.SvgIcon')
     # Register a deferred action to setup the assets environment
     # when the configuration is committed.
     config.action(None, configure_jinja2_assets, args=(config,))

--- a/h/jinja_extensions.py
+++ b/h/jinja_extensions.py
@@ -1,10 +1,19 @@
 # -*- coding: utf-8 -*-
 
 import datetime
+from functools import partial
 import json
+import re
+
+try:
+    from xml.etree import cElementTree as ElementTree
+except ImportError:
+    from xml.etree import ElementTree
 
 from jinja2 import Markup
 from jinja2.ext import Extension
+
+SVG_NAMESPACE_URI = 'http://www.w3.org/2000/svg'
 
 
 class Filters(Extension):
@@ -31,3 +40,51 @@ def human_timestamp(timestamp, now=datetime.datetime.utcnow):
 def to_json(value):
     """Convert a dict into a JSON string"""
     return Markup(json.dumps(value))
+
+
+class SvgIcon(Extension):
+
+    """
+    Setup helpers for rendering icons.
+    """
+
+    def __init__(self, environment):
+        super(SvgIcon, self).__init__(environment)
+
+        def read_icon(name):
+            return open('build/images/icons/{}.svg'.format(name)).read()
+
+        environment.globals['svg_icon'] = partial(svg_icon, read_icon)
+
+
+def svg_icon(loader, name, css_class=''):
+    """
+    Return inline SVG markup for an icon.
+
+    This is a helper for generating inline SVGs for rendering icons in HTML
+    that can be customized via CSS.
+    See https://github.com/blog/2112-delivering-octicons-with-svg
+
+    :param loader: Callable accepting an icon name and returning XML markup for
+                   the SVG.
+    :param name: The name of the SVG file to render
+    :param css_class: CSS class attribute for the returned `<svg>` element
+    """
+
+    # Register SVG as the default namespace. This avoids a problem where
+    # ElementTree otherwise serializes SVG elements with an 'ns0' namespace (eg.
+    # '<ns0:svg>...') and browsers will not render the result as SVG.
+    # See http://stackoverflow.com/questions/8983041
+    ElementTree.register_namespace('', SVG_NAMESPACE_URI)
+    root = ElementTree.fromstring(loader(name))
+
+    if css_class:
+        root.set('class', css_class)
+
+    # If the SVG has its own title, ignore it in favor of the title attribute
+    # of the <svg> or its containing element, which is usually a link.
+    title_el = root.find('{{{}}}title'.format(SVG_NAMESPACE_URI))
+    if title_el is not None:
+        root.remove(title_el)
+
+    return Markup(ElementTree.tostring(root))

--- a/tests/h/jinja_extension_test.py
+++ b/tests/h/jinja_extension_test.py
@@ -2,10 +2,10 @@
 
 import datetime
 
+from jinja2 import Markup
 import pytest
 
 from h import jinja_extensions as ext
-
 
 @pytest.mark.parametrize("value_in,json_out", [
     ({"foo": 42}, "{\"foo\": 42}")
@@ -29,3 +29,37 @@ def test_human_timestamp(timestamp_in, string_out):
         timestamp_in, now=lambda: datetime.datetime(2016, 4, 14))
 
     assert result == string_out
+
+
+def test_svg_icon_loads_icon():
+    def read_icon(name):
+        return '<svg id="{}"></svg>'.format(name)
+
+    result = ext.svg_icon(read_icon, 'settings')
+
+    assert result == Markup('<svg id="settings" />')
+
+
+def test_svg_icon_removes_title():
+    def read_icon(name):
+        return '<svg xmlns="http://www.w3.org/2000/svg"><title>foo</title></svg>'
+
+    assert (ext.svg_icon(read_icon, 'icon') ==
+        Markup('<svg xmlns="http://www.w3.org/2000/svg" />'))
+
+
+def test_svg_icon_strips_default_xml_namespace():
+    def read_icon(name):
+        return '<svg xmlns="http://www.w3.org/2000/svg"></svg>'
+
+    assert (ext.svg_icon(read_icon, 'icon') ==
+        Markup('<svg xmlns="http://www.w3.org/2000/svg" />'))
+
+
+def test_svg_icon_sets_css_class():
+    def read_icon(name):
+        return '<svg></svg>'
+
+    result = ext.svg_icon(read_icon, 'icon', css_class='fancy-icon')
+
+    assert result == Markup('<svg class="fancy-icon" />')


### PR DESCRIPTION
The helper generates icons using inline SVG, following an approach
described at https://github.com/blog/2112-delivering-octicons-with-svg

This gives us a nice way to do vector icons which can be customized
using CSS.

In order for icons to be colorable using CSS, they must set the 'fill'
or 'stroke' properties of paths to 'currentColor'