### PR TITLE
Run each alembic migration in its own transaction

### DIFF
--- a/h/migrations/env.py
+++ b/h/migrations/env.py
@@ -60,10 +60,10 @@ def run_migrations_offline():
     script output.
 
     """
-    context.configure(url=get_database_url())
+    context.configure(url=get_database_url(),
+                      transaction_per_migration=True)
 
-    with context.begin_transaction():
-        context.run_migrations()
+    context.run_migrations()
 
 
 def run_migrations_online():
@@ -85,12 +85,12 @@ def run_migrations_online():
     connection = engine.connect()
     context.configure(
         connection=connection,
-        target_metadata=target_metadata
+        target_metadata=target_metadata,
+        transaction_per_migration=True,
     )
 
     try:
-        with context.begin_transaction():
-            context.run_migrations()
+        context.run_migrations()
     finally:
         connection.close()
 


### PR DESCRIPTION
This is a config setting that we should have enabled a long time ago
(and the alembic default should be turned on).
It ensures that each migration is wrapped in its own transaction. This
is especially important when we run two migrations at the same time, the
first one adding a column, and the second one using that column.

We also don't need to wrap the `context.run_migrations()` call in a
transaction anymore since alembic takes care of that now.