### PR TITLE
Account settings forms: Update Email change form schema

### DIFF
--- a/h/accounts/schemas.py
+++ b/h/accounts/schemas.py
@@ -279,6 +279,24 @@ class LegacyEmailChangeSchema(CSRFSchema):
             raise exc
 
 
+class EmailChangeSchema(CSRFSchema):
+    email = email_node(title=_('Email address'))
+    # No validators: all validation is done on the email field
+    password = password_node(title=_('Confirm password'))
+
+    def validator(self, node, value):
+        super(EmailChangeSchema, self).validator(node, value)
+        exc = colander.Invalid(node)
+        request = node.bindings['request']
+        user = request.authenticated_user
+
+        if not models.User.validate_user(user, value.get('password')):
+            exc['password'] = _('Incorrect password. Please try again.')
+
+        if exc.children:
+            raise exc
+
+
 class PasswordChangeSchema(CSRFSchema):
     password = password_node(title=_('Current password'))
     new_password = password_node(title=_('New password'))

--- a/h/accounts/schemas.py
+++ b/h/accounts/schemas.py
@@ -253,7 +253,7 @@ class ResetPasswordSchema(CSRFSchema):
         widget=deform.widget.PasswordWidget(disable_autocomplete=True))
 
 
-class EmailChangeSchema(CSRFSchema):
+class LegacyEmailChangeSchema(CSRFSchema):
     email = email_node(title=_('New email address'))
     # No validators: all validation is done on the email field and we merely
     # assert that the confirmation field is the same.
@@ -264,7 +264,7 @@ class EmailChangeSchema(CSRFSchema):
     password = password_node(title=_('Current password'))
 
     def validator(self, node, value):
-        super(EmailChangeSchema, self).validator(node, value)
+        super(LegacyEmailChangeSchema, self).validator(node, value)
         exc = colander.Invalid(node)
         request = node.bindings['request']
         user = request.authenticated_user

--- a/h/accounts/views.py
+++ b/h/accounts/views.py
@@ -541,7 +541,7 @@ class AccountController(object):
     def __init__(self, request):
         self.request = request
 
-        email_schema = schemas.EmailChangeSchema().bind(request=request)
+        email_schema = schemas.LegacyEmailChangeSchema().bind(request=request)
         password_schema = schemas.PasswordChangeSchema().bind(request=request)
 
         self.forms = {

--- a/h/accounts/views.py
+++ b/h/accounts/views.py
@@ -541,7 +541,11 @@ class AccountController(object):
     def __init__(self, request):
         self.request = request
 
-        email_schema = schemas.LegacyEmailChangeSchema().bind(request=request)
+        if request.feature('activity_pages'):
+            email_schema = schemas.EmailChangeSchema().bind(request=request)
+        else:
+            email_schema = schemas.LegacyEmailChangeSchema().bind(request=request)
+
         password_schema = schemas.PasswordChangeSchema().bind(request=request)
 
         self.forms = {

--- a/tests/h/accounts/schemas_test.py
+++ b/tests/h/accounts/schemas_test.py
@@ -275,10 +275,10 @@ def test_ResetPasswordSchema_adds_user_to_appstruct(pyramid_csrf_request, user_m
     assert appstruct['user'] == user
 
 
-def test_EmailChangeSchema_rejects_non_matching_emails(pyramid_csrf_request, user_model):
+def test_LegacyEmailChangeSchema_rejects_non_matching_emails(pyramid_csrf_request, user_model):
     user = Mock()
     pyramid_csrf_request.authenticated_user = user
-    schema = schemas.EmailChangeSchema().bind(request=pyramid_csrf_request)
+    schema = schemas.LegacyEmailChangeSchema().bind(request=pyramid_csrf_request)
     # The email isn't taken
     user_model.get_by_email.return_value = None
 
@@ -290,10 +290,10 @@ def test_EmailChangeSchema_rejects_non_matching_emails(pyramid_csrf_request, use
     assert 'email_confirm' in exc.value.asdict()
 
 
-def test_EmailChangeSchema_rejects_wrong_password(pyramid_csrf_request, user_model):
+def test_LegacyEmailChangeSchema_rejects_wrong_password(pyramid_csrf_request, user_model):
     user = Mock()
     pyramid_csrf_request.authenticated_user = user
-    schema = schemas.EmailChangeSchema().bind(request=pyramid_csrf_request)
+    schema = schemas.LegacyEmailChangeSchema().bind(request=pyramid_csrf_request)
     # The email isn't taken
     user_model.get_by_email.return_value = None
     # The password does not check out


### PR DESCRIPTION
This pull request just changes the name of the older `EmailChangeSchema` to `LegacyEmailChangeSchema`, and adds a new `EmailChangeSchema` to be used in the restyled forms.