### PR TITLE
Fix notifications form bug

### DIFF
--- a/h/templates/deform/checkbox_choice.jinja2
+++ b/h/templates/deform/checkbox_choice.jinja2
@@ -1,6 +1,7 @@
 <input type="hidden" name="__start__" value="{{ field.name }}:sequence">
 <div class="form-checkbox-list">
   {% for value, title in field.widget.values %}
+  {% if feature('activity_pages') %}
   <div class="form-checkbox">
     <label for="{{ field.oid }}-{{ loop.index0 }}"
            class="form-checkbox__label">
@@ -8,8 +9,8 @@
              name="checkbox"
              value="{{ value }}"
              id="{{ field.oid }}-{{ loop.index0 }}"
-             class="form-checkbox__input {%- if field.widget.css_class -%}
-             {{ field.widget.css_class }}
+             class="form-checkbox__input {% if field.widget.css_class -%}
+               {{ field.widget.css_class }}
              {% endif -%}"
              {%- if field.error -%}
              aria-invalid="true"
@@ -20,6 +21,26 @@
       {{ title }}
     </label>
   </div>
+  {% else %}
+  <div class="form-checkbox-item">
+    <input type="checkbox"
+           name="checkbox"
+           value="{{ value }}"
+           id="{{ field.oid }}-{{ loop.index0 }}"
+           {% if field.widget.css_class -%}
+           class="{{ field.widget.css_class }}"
+           {% endif -%}
+           {%- if field.error -%}
+           aria-invalid="true"
+           {% endif -%}
+           {% if value in cstruct %}
+           checked="True"
+           {% endif %}>
+    <label for="{{ field.oid }}-{{ loop.index0 }}">
+      {{ title }}
+    </label>
+  </div>
+  {% endif %}
   {% endfor %}
 </div>
 <input type="hidden" name="__end__" value="{{ field.name }}:sequence">


### PR DESCRIPTION
A change in #3660 accidentally caused the legacy notifications settings
form to change. This fix reverts the accidental change while leaving the correct activity pages behaviour unchanged.