### PR TITLE
Add infrastructure for adjusting CSS styling depending on user agent capabilities

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -95,6 +95,10 @@ var bundles = [{
   // Legacy site bundle (for old homepage)
   name: 'legacy-site',
   entry: './h/static/scripts/legacy-site',
+},{
+  // Header script inserted inline at the top of the page
+  name: 'header',
+  entry: './h/static/scripts/header',
 }];
 
 var bundleConfigs = bundles.map(function (config) {

--- a/h/assets.ini
+++ b/h/assets.ini
@@ -20,6 +20,9 @@ site_js =
   scripts/raven.bundle.js
   scripts/site.bundle.js
 
+header_js =
+  scripts/header.bundle.js
+
 site_css =
   styles/site.css
   styles/icomoon.css

--- a/h/static/scripts/base/environment-flags.js
+++ b/h/static/scripts/base/environment-flags.js
@@ -1,0 +1,75 @@
+'use strict';
+
+/**
+ * EnvironmentFlags provides a facility to modify the appearance or behavior
+ * of components on the page depending on the capabilities of the user agent.
+ *
+ * It adds `env-${flag}` classes to a top-level element in the document to
+ * indicate support for scripting, touch input etc. These classes can then be
+ * used to modify other elements in the page via descendent selectors.
+ *
+ * @param {Element} element - DOM element which environment flags will be added
+ *                  to.
+ */
+function EnvironmentFlags(element) {
+  this._element = element;
+}
+
+EnvironmentFlags.prototype.get = function (flag) {
+  var flagClass = 'env-' + flag;
+  return this._element.classList.contains(flagClass);
+};
+
+/**
+ * Set or clear an environment flag.
+ *
+ * This will add or remove the `env-${flag}` class from the element which
+ * contains environment flags.
+ */
+EnvironmentFlags.prototype.set = function (flag, on) {
+  var flagClass = 'env-' + flag;
+  if (on) {
+    this._element.classList.add(flagClass);
+  } else {
+    this._element.classList.remove(flagClass);
+  }
+};
+
+/**
+ * Detect user agent capabilities and set default flags.
+ *
+ * This sets the `js-capable` flag but clears it if `ready()` is not called
+ * within 5000ms. This can be used to hide elements of the page assuming that
+ * they can later be shown via JS but show them again if scripts fail to load.
+ */
+EnvironmentFlags.prototype.init = function () {
+  var JS_LOAD_TIMEOUT = 5000;
+  var self = this;
+
+  // Mark browser as JS capable
+  this.set('js-capable', true);
+
+  // Set a flag to indicate touch support. Useful for browsers that do not
+  // support interaction media queries.
+  // See http://caniuse.com/#feat=css-media-interaction
+  this.set('touch', 'ontouchstart' in this._element);
+
+  // Set an additional flag if scripts fail to load in a reasonable period of
+  // time
+  this._jsLoadTimeout = setTimeout(function () {
+    self.set('js-timeout', true);
+  }, JS_LOAD_TIMEOUT);
+};
+
+/**
+ * Mark the page load as successful.
+ */
+EnvironmentFlags.prototype.ready = function () {
+  if (this._jsLoadTimeout) {
+    clearTimeout(this._jsLoadTimeout);
+  }
+  this.set('js-ready', true);
+  this.set('js-timeout', false);
+};
+
+module.exports = EnvironmentFlags;

--- a/h/static/scripts/base/environment-flags.js
+++ b/h/static/scripts/base/environment-flags.js
@@ -52,7 +52,7 @@ EnvironmentFlags.prototype.init = function () {
   // Set a flag to indicate touch support. Useful for browsers that do not
   // support interaction media queries.
   // See http://caniuse.com/#feat=css-media-interaction
-  this.set('touch', 'ontouchstart' in this._element);
+  this.set('touch', this._element.ontouchstart);
 
   // Set an additional flag if scripts fail to load in a reasonable period of
   // time

--- a/h/static/scripts/header.js
+++ b/h/static/scripts/header.js
@@ -1,0 +1,11 @@
+'use strict';
+
+// Header script which is included inline at the top of every page on the site.
+//
+// This should be a small script which does things like setting up flags to
+// indicate that scripting is active, send analytics events etc.
+
+var EnvironmentFlags = require('./base/environment-flags');
+
+window.envFlags = new EnvironmentFlags(document.documentElement);
+window.envFlags.init();

--- a/h/static/scripts/site.js
+++ b/h/static/scripts/site.js
@@ -20,3 +20,7 @@ var controllers = {
 };
 
 upgradeElements(document.body, controllers);
+
+if (window.envFlags) {
+  window.envFlags.ready();
+}

--- a/h/static/scripts/tests/base/environment-flags-test.js
+++ b/h/static/scripts/tests/base/environment-flags-test.js
@@ -1,0 +1,73 @@
+'use strict';
+
+var EnvironmentFlags = require('../../base/environment-flags');
+
+var TIMEOUT_DELAY = 10000;
+
+describe('EnvironmentFlags', function () {
+  var clock;
+  var el;
+  var flags;
+
+  beforeEach(function () {
+    el = document.createElement('div');
+    flags = new EnvironmentFlags(el);
+    clock = sinon.useFakeTimers();
+  });
+
+  afterEach(function () {
+    clock.restore();
+  });
+
+  describe('#init', function () {
+    it('should mark document as JS capable on load', function () {
+      flags.init();
+      assert.isTrue(el.classList.contains('env-js-capable'));
+    });
+
+    it('should mark JS load as failed after a timeout', function () {
+      flags.init();
+      clock.tick(TIMEOUT_DELAY);
+      assert.isTrue(el.classList.contains('env-js-timeout'));
+    });
+  });
+
+  describe('#ready', function () {
+    it('should prevent JS load timeout flag from being set', function () {
+      flags.init();
+      flags.ready();
+      clock.tick(TIMEOUT_DELAY);
+      assert.isFalse(el.classList.contains('env-js-timeout'));
+    });
+
+    it('should clear timeout flag if already set', function () {
+      flags.init();
+      clock.tick(TIMEOUT_DELAY);
+      flags.ready();
+      assert.isFalse(el.classList.contains('env-js-timeout'));
+    });
+  });
+
+  describe('#set', function () {
+    it('should add a flag if `on` is true', function () {
+      flags.set('shiny-feature', true);
+      assert.isTrue(el.classList.contains('env-shiny-feature'));
+    });
+
+    it('should remove a flag if `on` is false', function () {
+      flags.set('shiny-feature', false);
+      assert.isFalse(el.classList.contains('env-shiny-feature'));
+    });
+  });
+
+  describe('#get', function () {
+    it('should return true if the flag is set', function () {
+      flags.set('shiny-feature', true);
+      assert.isTrue(flags.get('shiny-feature'));
+    });
+
+    it('should return false if the flag is set', function () {
+      assert.isFalse(flags.get('shiny-feature'));
+    });
+  });
+});

--- a/h/static/scripts/tests/base/environment-flags-test.js
+++ b/h/static/scripts/tests/base/environment-flags-test.js
@@ -30,6 +30,17 @@ describe('EnvironmentFlags', function () {
       clock.tick(TIMEOUT_DELAY);
       assert.isTrue(el.classList.contains('env-js-timeout'));
     });
+
+    it('should not add "env-touch" flag if touch events are not supported', function () {
+      flags.init();
+      assert.isFalse(el.classList.contains('env-touch'));
+    });
+
+    it('should add "env-touch" flag if touch events are available', function () {
+      el.ontouchstart = function () {};
+      flags.init();
+      assert.isTrue(el.classList.contains('env-touch'));
+    });
   });
 
   describe('#ready', function () {

--- a/h/static/styles/mixins/_all.scss
+++ b/h/static/styles/mixins/_all.scss
@@ -5,6 +5,7 @@
 
 // Core mixins: these may depend on externally defined variables & base mixins.
 @import 'mixins/icons';
+@import 'mixins/js';
 @import 'mixins/responsive';
 @import 'mixins/typography';
 

--- a/h/static/styles/mixins/_js.scss
+++ b/h/static/styles/mixins/_js.scss
@@ -1,0 +1,22 @@
+// Helpers for changing element style or behavior depending on whether scripting
+// support is available and successfully loaded
+
+/**
+ * Mixin which enables styles if the user agent is JavaScript-capable and
+ * scripts are either loading or successfully loaded.
+ *
+ * Usage:
+ *   @include js {
+ *     // If JS is enabled, hide `thing` until the user performs some action
+ *     // which sets the 'is-expanded' state on the element.
+ *     //
+ *     // If JS is not enabled or failed to load, this selector will not apply
+ *     // and the element will not be hidden in the first place.
+ *     .thing:not(.is-expanded) { display: none };
+ *   }
+ */
+@mixin js {
+  .env-js-capable:not(.env-js-timeout) {
+    @content;
+  }
+}

--- a/h/static/styles/mixins/_responsive.scss
+++ b/h/static/styles/mixins/_responsive.scss
@@ -27,3 +27,18 @@ $break-desktop: 1024px !default;
     @content;
   }
 }
+
+// Mixin for styling elements to make them more finger-friendly on touch-input
+// devices.
+//
+// Use interaction media queries where available (see
+// http://caniuse.com/#feat=css-media-interaction) or fall back to relying on a
+// JS-added class on the <html> or <body> elements otherwise.
+@mixin touch-input {
+  @media (pointer: coarse) {
+    @content;
+  }
+  .env-touch {
+    @content;
+  }
+}

--- a/h/static/styles/partials-v2/_btn.scss
+++ b/h/static/styles/partials-v2/_btn.scss
@@ -20,12 +20,7 @@
   background-color: $brand;
 }
 
-// Touch accessibility. Note: Pointer media queries are only supported by recent
-// versions of Chrome, Safari and Edge. We should provide a fallback for older
-// browsers. See http://caniuse.com/#feat=css-media-interaction and
-// http://stackoverflow.com/questions/11387805 In doing so, we should also
-// extract this styling into a helper.
-@media (pointer: coarse) {
+@include touch-input {
   .btn {
     min-height: 44px;
   }

--- a/h/templates/layouts/base.html.jinja2
+++ b/h/templates/layouts/base.html.jinja2
@@ -81,6 +81,10 @@
       </script>
     {% endif %}
 
+    <script>
+    {% include "h:../build/scripts/header.bundle.js" %}
+    </script>
+
     {% block base_tag %}{% endblock %}
   </head>
   {% block body_tag %}<body class="body">{% endblock %}

--- a/h/templates/layouts/base.html.jinja2
+++ b/h/templates/layouts/base.html.jinja2
@@ -81,9 +81,9 @@
       </script>
     {% endif %}
 
-    <script>
-    {% include "h:../build/scripts/header.bundle.js" %}
-    </script>
+    {% for url in asset_urls("header_js") %}
+    <script src="{{ url }}"></script>
+    {% endfor %}
 
     {% block base_tag %}{% endblock %}
   </head>


### PR DESCRIPTION
_This depends on https://github.com/hypothesis/h/pull/3682_

This PR implements the basic infrastructure for changing element styling depending on user agent capabilities (scripts supported, touch input available etc.). This consists of:

- A small script which is added inline to the `<head>` of each page that detects the user agent capabilities and adds `env-$flag` classes to the `<html>` element.
- `env-js-capable` and `env-touch` flags to indicate support for scripting and touch input respectively
- SASS mixins to enable selectors if these flags are set
- Changing the styling of form buttons to use the `env-touch` flag as a fallback method for enabling touch-friendly buttons in browsers that do not support CSS interaction media queries (Safari < 9.x, Firefox)

Even though the header script is pretty small, it is still built as a Browserify bundle because the overhead of that is minimal and it is convenient for testing and supporting dev/production builds.