### PR TITLE
Account settings form styling: Change email and password

### DIFF
--- a/h/accounts/views.py
+++ b/h/accounts/views.py
@@ -593,7 +593,10 @@ class AccountController(object):
         email = self.request.authenticated_user.email
         password_form = self.forms['password'].render()
 
-        email_form = self.forms['email'].render()
+        if self.request.feature('activity_pages'):
+            email_form = self.forms['email'].render({'email': email})
+        else:
+            email_form = self.forms['email'].render()
 
         return {'email': email,
                 'email_form': email_form,

--- a/h/accounts/views.py
+++ b/h/accounts/views.py
@@ -590,9 +590,14 @@ class AccountController(object):
 
     def _template_data(self):
         """Return the data needed to render accounts.html.jinja2."""
-        return {'email': self.request.authenticated_user.email,
-                'email_form': self.forms['email'],
-                'password_form': self.forms['password']}
+        email = self.request.authenticated_user.email
+        password_form = self.forms['password'].render()
+
+        email_form = self.forms['email'].render()
+
+        return {'email': email,
+                'email_form': email_form,
+                'password_form': password_form}
 
 
 @view_defaults(route_name='account_notifications',

--- a/h/templates/accounts/account.html.jinja2
+++ b/h/templates/accounts/account.html.jinja2
@@ -30,17 +30,19 @@
     {%- endif %}
     {% if feature('activity_pages') -%}
     <footer class="form-footer">
+      {% trans %}
+        If you would like to delete your account, please email us at
+        <a class="link" href="mailto:support@hypothes.is">support@hypothes.is</a> from your
+        registered email address, and we'll take it from there.
+      {% endtrans %}
+    </footer>
     {% else %}
     <legend>
-    {%- endif %}
       {% trans %}
         If you would like to delete your account, please email us at
         <a href="mailto:support@hypothes.is">support@hypothes.is</a> from your
         registered email address, and we'll take it from there.
       {% endtrans %}
-    {% if feature('activity_pages') -%}
-    </footer>
-    {% else %}
     </legend>
     {%- endif %}
   </div>

--- a/h/templates/accounts/account.html.jinja2
+++ b/h/templates/accounts/account.html.jinja2
@@ -27,12 +27,20 @@
     <h2 class="form-heading">
       <span>{% trans %}Delete account{% endtrans %}</span>
     </h2>
+    {%- endif %}
+    {% if feature('activity_pages') -%}
+    <footer class="form-footer">
+    {% else %}
     <legend>
+    {%- endif %}
       {% trans %}
         If you would like to delete your account, please email us at
         <a href="mailto:support@hypothes.is">support@hypothes.is</a> from your
         registered email address, and we'll take it from there.
       {% endtrans %}
+    {% if feature('activity_pages') -%}
+    </footer>
+    {% else %}
     </legend>
     {%- endif %}
   </div>

--- a/h/templates/accounts/account.html.jinja2
+++ b/h/templates/accounts/account.html.jinja2
@@ -5,6 +5,7 @@
 
 {% block page_content %}
   <div class="form-vertical">
+    {% if not feature('activity_pages') -%}
     <h2 class="form-heading">
       <span>{% trans %}Change your email address{% endtrans %}</span>
     </h2>
@@ -12,13 +13,17 @@
       {% trans %}Your current email address is:{% endtrans %}
       <strong>{{ email }}</strong>.
     </legend>
+    {%- endif %}
     {{ email_form }}
 
+    {% if not feature('activity_pages') -%}
     <h2 class="form-heading">
       <span>{% trans %}Change your password{% endtrans %}</span>
     </h2>
+    {%- endif %}
     {{ password_form }}
 
+    {% if not feature('activity_pages') -%}
     <h2 class="form-heading">
       <span>{% trans %}Delete account{% endtrans %}</span>
     </h2>
@@ -29,5 +34,6 @@
         registered email address, and we'll take it from there.
       {% endtrans %}
     </legend>
+    {%- endif %}
   </div>
 {% endblock page_content %}

--- a/h/templates/accounts/account.html.jinja2
+++ b/h/templates/accounts/account.html.jinja2
@@ -12,12 +12,12 @@
       {% trans %}Your current email address is:{% endtrans %}
       <strong>{{ email }}</strong>.
     </legend>
-    {{ email_form.render() }}
+    {{ email_form }}
 
     <h2 class="form-heading">
       <span>{% trans %}Change your password{% endtrans %}</span>
     </h2>
-    {{ password_form.render() }}
+    {{ password_form }}
 
     <h2 class="form-heading">
       <span>{% trans %}Delete account{% endtrans %}</span>

--- a/h/templates/accounts/account.html.jinja2
+++ b/h/templates/accounts/account.html.jinja2
@@ -16,11 +16,11 @@
     {%- endif %}
     {{ email_form }}
 
-    {% if not feature('activity_pages') -%}
     <h2 class="form-heading">
+    {% if not feature('activity_pages') -%}
       <span>{% trans %}Change your password{% endtrans %}</span>
-    </h2>
     {%- endif %}
+    </h2>
     {{ password_form }}
 
     {% if not feature('activity_pages') -%}

--- a/h/templates/layouts/account.html.jinja2
+++ b/h/templates/layouts/account.html.jinja2
@@ -17,7 +17,6 @@
   {{ panel('navbar') }}
   {% endif %}
   <div class="content paper">
-    {% include "h:templates/includes/logo-header.html.jinja2" %}
     {% if feature('activity_pages') %}
       <div class="form">
         <nav class="tabs">
@@ -42,6 +41,7 @@
         {{ self.page_content() }}
       </div>
     {% else %}
+      {% include "h:templates/includes/logo-header.html.jinja2" %}
       <ul class="nav nav-tabs">
         {% for route, title in nav_pages %}
           <li{% if route == page_route %} class="active"{% endif %}>

--- a/h/templates/layouts/account.html.jinja2
+++ b/h/templates/layouts/account.html.jinja2
@@ -18,7 +18,7 @@
   {% endif %}
   <div class="content paper">
     {% if feature('activity_pages') %}
-      <div class="form">
+      <div class="form form-header">
         <nav class="tabs">
           <ul>
             {% for route, title in nav_pages %}

--- a/tests/h/accounts/views_test.py
+++ b/tests/h/accounts/views_test.py
@@ -929,8 +929,8 @@ class TestAccountController(object):
 
         assert result == {
             'email': pyramid_request.authenticated_user.email,
-            'email_form': controller.forms['email'],
-            'password_form': controller.forms['password'],
+            'email_form': controller.forms['email'].render(),
+            'password_form': controller.forms['password'].render(),
         }
 
     def test_post_password_form_with_valid_data_changes_password(
@@ -962,8 +962,8 @@ class TestAccountController(object):
 
         assert result == {
             'email': pyramid_request.authenticated_user.email,
-            'email_form': controller.forms['email'],
-            'password_form': controller.forms['password'],
+            'email_form': controller.forms['email'].render(),
+            'password_form': controller.forms['password'].render(),
         }
 
     @pytest.fixture


### PR DESCRIPTION
This PR contains two parts:

* A small refactoring that extracts explicit calls to `form.render()` in the templates and places them in the view controller.

* Pre-populating the email field with the user's email, by calling `#render()` with an `appstruct` parameter in the `activity_pages` form.