### PR TITLE
Fix account settings tab bar styling

### DIFF
--- a/h/static/styles/partials-v2/_tabs.scss
+++ b/h/static/styles/partials-v2/_tabs.scss
@@ -17,5 +17,6 @@
 }
 
 .tabs {
+  margin-top: 55px;
   padding-bottom: 30px;
 }

--- a/h/templates/layouts/account.html.jinja2
+++ b/h/templates/layouts/account.html.jinja2
@@ -18,7 +18,7 @@
   {% endif %}
   <div class="content paper">
     {% if feature('activity_pages') %}
-      <div class="form form-header">
+      <div class="form">
         <nav class="tabs">
           <ul>
             {% for route, title in nav_pages %}


### PR DESCRIPTION
The `form-header` class was being applied to the whole form. It has
been removed, since it was only being used for adding the proper spacing
before the tab bar, and a margin has been added to the `tabs` class
to correct this.