### PR TITLE
Extract signup email into `h.emails`

### DIFF
--- a/h/emails/__init__.py
+++ b/h/emails/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from h.emails import reply_notification
+from h.emails import reply_notification, signup
 
-__all__ = ('reply_notification',)
+__all__ = ('reply_notification', 'signup')

--- a/h/emails/signup.py
+++ b/h/emails/signup.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from pyramid.renderers import render
+
+from h.i18n import TranslationString as _
+
+
+def generate(request, id, email, activation_code):
+    """
+    Generate an email for a user signup.
+
+    :param request: the current request
+    :type request: pyramid.request.Request
+    :param id: the new user's primary key ID
+    :type id: int
+    :param email: the new user's email address
+    :type email: text
+    :param activation_code: the activation code
+    :type activation_code: text
+
+    :returns: a 4-element tuple containing: recipients, subject, text, html
+    """
+    context = {
+        'activate_link': request.route_url('activate',
+                                           id=id,
+                                           code=activation_code),
+    }
+
+    subject = _('Please activate your account')
+
+    text = render('h:templates/emails/signup.txt.jinja2',
+                  context,
+                  request=request)
+    html = render('h:templates/emails/signup.html.jinja2',
+                  context,
+                  request=request)
+
+    return [email], subject, text, html

--- a/h/templates/emails/signup.html.jinja2
+++ b/h/templates/emails/signup.html.jinja2
@@ -1,0 +1,3 @@
+<p>Please validate your email and activate your account by visiting:</p>
+
+<p>&nbsp;&nbsp;<a href="{{activate_link}}">{{activate_link}}</a></p>

--- a/h/templates/emails/signup.txt.jinja2
+++ b/h/templates/emails/signup.txt.jinja2
@@ -1,0 +1,3 @@
+Please validate your email and activate your account by visiting:
+
+  {{activate_link}}

--- a/tests/h/emails/signup_test.py
+++ b/tests/h/emails/signup_test.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import pytest
+
+from h.emails.signup import generate
+
+
+@pytest.mark.usefixtures('routes')
+class TestGenerate(object):
+
+    def test_calls_renderers_with_appropriate_context(self,
+                                                      pyramid_request,
+                                                      html_renderer,
+                                                      text_renderer):
+        generate(pyramid_request,
+                 id=1234,
+                 email='foo@example.com',
+                 activation_code='abcd4567')
+
+        expected_context = {
+            'activate_link': 'http://example.com/activate/1234/abcd4567',
+        }
+        html_renderer.assert_(**expected_context)
+        text_renderer.assert_(**expected_context)
+
+    def test_appropriate_return_values(self,
+                                       pyramid_request,
+                                       html_renderer,
+                                       text_renderer):
+        html_renderer.string_response = 'HTML output'
+        text_renderer.string_response = 'Text output'
+
+        recipients, subject, text, html = generate(pyramid_request,
+                                                   id=1234,
+                                                   email='foo@example.com',
+                                                   activation_code='abcd4567')
+
+        assert recipients == ['foo@example.com']
+        assert subject == 'Please activate your account'
+        assert html == 'HTML output'
+        assert text == 'Text output'
+
+    def test_jinja_templates_render(self,
+                                    pyramid_config,
+                                    pyramid_request):
+        """Ensure that the jinja templates don't contain syntax errors"""
+        pyramid_config.include('pyramid_jinja2')
+        pyramid_config.add_jinja2_extension('h.jinja_extensions.Filters')
+
+        generate(pyramid_request,
+                 id=1234,
+                 email='foo@example.com',
+                 activation_code='abcd4567')
+
+    @pytest.fixture
+    def html_renderer(self, pyramid_config):
+        return pyramid_config.testing_add_renderer('h:templates/emails/signup.html.jinja2')
+
+    @pytest.fixture
+    def routes(self, pyramid_config):
+        pyramid_config.add_route('activate', '/activate/{id}/{code}')
+
+    @pytest.fixture
+    def text_renderer(self, pyramid_config):
+        return pyramid_config.testing_add_renderer('h:templates/emails/signup.txt.jinja2')


### PR DESCRIPTION
The generation of the email we send to users at signup has, until now,
been hard-coded in `h.accounts.views`. This commit extracts this into
the generic `h.emails` package, adding an HTML format as a bonus.