### PR TITLE
Add migration for auth token "expires" column

### DIFF
--- a/h/migrations/versions/64cf31f9f721_add_expires_column_to_token_table.py
+++ b/h/migrations/versions/64cf31f9f721_add_expires_column_to_token_table.py
@@ -1,0 +1,23 @@
+"""
+Add expires column to token table
+
+Revision ID: 64cf31f9f721
+Revises: d536d9a342f3
+Create Date: 2016-08-15 15:45:21.813078
+"""
+
+from __future__ import unicode_literals
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = '64cf31f9f721'
+down_revision = 'd536d9a342f3'
+
+
+def upgrade():
+    op.add_column('token', sa.Column('expires', sa.DateTime, nullable=True))
+
+
+def downgrade():
+    op.drop_column('token', 'expires')


### PR DESCRIPTION
This PR adds a schema migration to add an "expires" datetime column to the token table. By merging this first as a nullable column we can ensure zero-downtime for subsequently merged/deployed model changes.