### PR TITLE
Authentication token expiry

### DIFF
--- a/h/auth/interfaces.py
+++ b/h/auth/interfaces.py
@@ -9,3 +9,6 @@ class IAuthenticationToken(Interface):
     """Represents an authentication token."""
 
     userid = Attribute("""The userid to which this token was issued.""")
+
+    def is_valid(self):
+        """Checks token validity (such as expiry date)."""

--- a/h/auth/models.py
+++ b/h/auth/models.py
@@ -36,6 +36,10 @@ class Token(Base, mixins.Timestamps):
                               nullable=False,
                               unique=True)
 
+    #: A timestamp after which this token will no longer be considered valid.
+    #: A NULL value in this column indicates a token that does not expire.
+    expires = sqlalchemy.Column(sqlalchemy.DateTime, nullable=True)
+
     def __init__(self, userid):
         self.userid = userid
         self.regenerate()

--- a/h/auth/models.py
+++ b/h/auth/models.py
@@ -3,6 +3,7 @@
 from __future__ import unicode_literals
 
 import binascii
+import datetime
 import os
 
 import sqlalchemy
@@ -43,6 +44,13 @@ class Token(Base, mixins.Timestamps):
     def __init__(self, userid):
         self.userid = userid
         self.regenerate()
+
+    def is_valid(self):
+        """Check if the token is valid (unexpired). Returns a boolean."""
+        if self.expires is None:
+            return True
+        now = datetime.datetime.utcnow()
+        return now < self.expires
 
     @classmethod
     def get_by_userid(cls, session, userid):

--- a/h/auth/policy.py
+++ b/h/auth/policy.py
@@ -81,7 +81,7 @@ class TokenAuthenticationPolicy(CallbackAuthenticationPolicy):
         :rtype: unicode or None
         """
         token = getattr(request, 'auth_token', None)
-        if token is None:
+        if token is None or not token.is_valid():
             return None
 
         return token.userid

--- a/h/auth/tokens.py
+++ b/h/auth/tokens.py
@@ -26,6 +26,12 @@ class LegacyClientJWT(object):
                                   leeway=leeway,
                                   algorithms=['HS256'])
 
+    def is_valid(self):
+        """Check if the token is valid. Always true for JWTs."""
+        # JWT validity checks happen at construction time. If an instance is
+        # successfully constructed, it is by definition valid.
+        return True
+
     @property
     def userid(self):
         return self.payload.get('sub')

--- a/tests/h/auth/models_test.py
+++ b/tests/h/auth/models_test.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import datetime
+
+from h.auth.models import Token
+
+
+class TestToken(object):
+
+    def test_token_with_no_expiry_is_valid(self):
+        token = Token(userid='acct:foo@example.com')
+
+        assert token.is_valid()
+
+    def test_token_with_future_expiry_is_valid(self):
+        token = Token(userid='acct:foo@example.com')
+        token.expires = _seconds_from_now(1800)
+
+        assert token.is_valid()
+
+    def test_token_with_past_expiry_is_not_valid(self):
+        token = Token(userid='acct:foo@example.com')
+        token.expires = _seconds_from_now(-1800)
+
+        assert not token.is_valid()
+
+
+def _seconds_from_now(seconds):
+    return datetime.datetime.utcnow() + datetime.timedelta(seconds=seconds)

--- a/tests/h/auth/policy_test.py
+++ b/tests/h/auth/policy_test.py
@@ -129,6 +129,15 @@ class TestTokenAuthenticationPolicy(object):
 
         assert result == 'acct:foo@example.com'
 
+    def test_unauthenticated_userid_returns_none_if_token_invalid(self, pyramid_request):
+        policy = TokenAuthenticationPolicy()
+        token = DummyToken(valid=False)
+        pyramid_request.auth_token = token
+
+        result = policy.unauthenticated_userid(pyramid_request)
+
+        assert result is None
+
     def test_authenticated_userid_uses_callback(self, fake_token, pyramid_request):
         def callback(userid, request):
             return None
@@ -153,4 +162,13 @@ class TestTokenAuthenticationPolicy(object):
 
     @pytest.fixture
     def fake_token(self):
-        return mock.Mock(userid='acct:foo@example.com', spec_set=['userid'])
+        return DummyToken()
+
+
+class DummyToken(object):
+    def __init__(self, userid='acct:foo@example.com', valid=True):
+        self.userid = userid
+        self._valid = valid
+
+    def is_valid(self):
+        return self._valid

--- a/tests/h/auth/tokens_test.py
+++ b/tests/h/auth/tokens_test.py
@@ -74,6 +74,18 @@ class TestLegacyClientJWT(object):
 
         assert result.payload == payload
 
+    def test_always_valid(self):
+        payload = {'aud': 'http://foo.com',
+                   'exp': _seconds_from_now(3600),
+                   'sub': 'foobar'}
+        token = jwt.encode(payload, key='s3cr37')
+
+        result = tokens.LegacyClientJWT(token,
+                                        audience='http://foo.com',
+                                        key='s3cr37')
+
+        assert result.is_valid()
+
     def test_userid_gets_payload_sub(self):
         payload = {'aud': 'http://foo.com',
                    'exp': _seconds_from_now(3600),


### PR DESCRIPTION
This PR adds the ability for auth tokens to expire. We don't actually issue
expiring auth tokens just yet, but we'll need to for third-party accounts.

In order to do this we:

- add an `expires` column to the `Token` model
- add an `is_valid()` method to the `IAuthenticationToken` interface, and
  implement it for the two token types we have currently
- check `is_valid()` in the `TokenAuthenticationPolicy`

Current "dev tokens" will have NULL token expiry dates and thus will never be
considered expired.

~~_This PR depends on code from #3695 and should not be merged until #3697 has
been merged, deployed, and the schema migration run in production._~~