### PR TITLE
Make handle_form_submission() generic

### DIFF
--- a/h/accounts/views.py
+++ b/h/accounts/views.py
@@ -11,6 +11,7 @@ from pyramid.exceptions import BadCSRFToken
 from pyramid.view import view_config, view_defaults
 
 from h import accounts
+from h import form
 from h import i18n
 from h import mailer
 from h import models
@@ -36,69 +37,6 @@ def ajax_payload(request, data):
                'model': session.model(request)}
     payload.update(data)
     return payload
-
-
-def to_xhr_response(request, non_xhr_result, form):
-    """
-    Return an XHR response for the given ``form``, or ``non_xhr_result``.
-
-    If the given ``request`` is an XMLHttpRequest then return an XHR form
-    submission response for the given form (contains only the ``<form>``
-    element as an HTML snippet, not the entire HTML page).
-
-    If ``request`` is not an XHR request then return ``non_xhr_result``, which
-    should be the result that the view callable would normally return if this
-    were not an XHR request.
-
-    :param request: the Pyramid request
-
-    :param non_xhr_result: the view callable result that should be returned if
-        ``request`` is *not* an XHR request
-
-    :param form: the form that was submitted
-    :type form: deform.form.Form
-
-    """
-    if not request.is_xhr:
-        return non_xhr_result
-
-    request.override_renderer = 'string'
-    return form.render()
-
-
-def handle_form_submission(request, form, on_success, on_failure):
-    """
-    Handle the submission of the given form in a standard way.
-
-    :param request: the Pyramid request
-
-    :param form: the form that was submitted
-    :type form: deform.form.Form
-
-    :param on_success: A callback function to be called if the form validates
-        successfully. This function should carry out the action that the form
-        submission requests. For example for a change password form, this
-        function would change the user's password.
-    :type on_success: callable
-
-    :param on_failure: A callback function that will be called if form validation
-        fails in order to get the view callable result that should be returned.
-        Note that the result returned by on_failure() will *not* be used if the
-        request is an XHR request.
-    :type on_failure: callable
-
-    """
-    try:
-        appstruct = form.validate(request.POST.items())
-    except deform.ValidationFailure:
-        result = on_failure()
-    else:
-        on_success(appstruct)
-        request.session.flash(_("Success. We've saved your changes."),
-                              'success')
-        result = httpexceptions.HTTPFound(location=request.url)
-
-    return to_xhr_response(request, result, form)
 
 
 @json_view(context=BadCSRFToken)
@@ -566,7 +504,7 @@ class AccountController(object):
                  request_param='__formid__=email')
     def post_email_form(self):
         """Called by Pyramid when the change email form is submitted."""
-        return handle_form_submission(
+        return form.handle_form_submission(
             self.request,
             self.forms['email'],
             on_success=self.update_email_address,
@@ -576,7 +514,7 @@ class AccountController(object):
                  request_param='__formid__=password')
     def post_password_form(self):
         """Called by Pyramid when the change password form is submitted."""
-        return handle_form_submission(
+        return form.handle_form_submission(
             self.request,
             self.forms['password'],
             on_success=self.update_password,

--- a/h/form.py
+++ b/h/form.py
@@ -104,16 +104,22 @@ def handle_form_submission(request, form, on_success, on_failure):
     :param form: the form that was submitted
     :type form: deform.form.Form
 
-    :param on_success: A callback function to be called if the form validates
-        successfully. This function should carry out the action that the form
-        submission requests. For example for a change password form, this
-        function would change the user's password.
+    :param on_success:
+        A callback function to be called if the form validates successfully.
+
+        This function should carry out the action that the form submission
+        requests (for example for a change password form, this function would
+        change the user's password) and return the view callable result that
+        should be returned if this is not an XHR request.
+
+        If on_success() returns ``None`` then ``handle_form_submission()``
+        will return ``HTTPFound(location=request.url)`` by default.
     :type on_success: callable
 
-    :param on_failure: A callback function that will be called if form validation
-        fails in order to get the view callable result that should be returned.
-        Note that the result returned by on_failure() will *not* be used if the
-        request is an XHR request.
+    :param on_failure:
+        A callback function that will be called if form validation fails in
+        order to get the view callable result that should be returned if this is
+        not an XHR request.
     :type on_failure: callable
 
     """
@@ -122,8 +128,11 @@ def handle_form_submission(request, form, on_success, on_failure):
     except deform.ValidationFailure:
         result = on_failure()
     else:
-        on_success(appstruct)
-        result = httpexceptions.HTTPFound(location=request.url)
+        result = on_success(appstruct)
+
+        if result is None:
+            result = httpexceptions.HTTPFound(location=request.url)
+
         request.session.flash(_("Success. We've saved your changes."),
                               'success')
 

--- a/tests/h/conftest.py
+++ b/tests/h/conftest.py
@@ -150,22 +150,27 @@ def fake_db_session():
     return DummySession()
 
 
-def form_validating_to(appstruct):
-    form = mock.MagicMock()
-    form.validate.return_value = appstruct
-    form.render.return_value = 'valid form'
-    return form
+@pytest.fixture
+def form_validating_to():
+    def form_validating_to(appstruct):
+        form = mock.MagicMock()
+        form.validate.return_value = appstruct
+        form.render.return_value = 'valid form'
+        return form
+    return form_validating_to
 
 
 @pytest.fixture
-def invalid_form(errors=None):
-    if errors is None:
-        errors = {}
-    invalid = FakeInvalid(errors)
-    form = mock.MagicMock()
-    form.validate.side_effect = deform.ValidationFailure(None, None, invalid)
-    form.render.return_value = 'invalid form'
-    return form
+def invalid_form():
+    def invalid_form(errors=None):
+        if errors is None:
+            errors = {}
+        invalid = FakeInvalid(errors)
+        form = mock.MagicMock()
+        form.validate.side_effect = deform.ValidationFailure(None, None, invalid)
+        form.render.return_value = 'invalid form'
+        return form
+    return invalid_form
 
 
 @pytest.fixture

--- a/tests/h/form_test.py
+++ b/tests/h/form_test.py
@@ -230,13 +230,38 @@ class TestHandleFormSubmission(object):
 
         form.handle_form_submission(pyramid_request,
                                     form_,
-                                    mock.Mock(),
+                                    mock.Mock(return_value=None),
                                     mock.Mock())
 
         to_xhr_response.assert_called_once_with(
             pyramid_request,
             matchers.redirect_302_to(pyramid_request.url),
             form_)
+
+    def test_if_validation_succeeds_it_passes_on_success_result_to_to_xhr_response(
+            self,
+            matchers,
+            pyramid_request,
+            to_xhr_response):
+        """
+        A result from on_success() is passed to to_xhr_response().
+
+        If on_success() returns something other than None, it passes that
+        something to to_xhr_response().
+
+        """
+        form_ = conftest.form_validating_to('anything')
+
+        form.handle_form_submission(pyramid_request,
+                                    form_,
+                                    mock.Mock(return_value=mock.sentinel.result),
+                                    mock.Mock())
+
+        to_xhr_response.assert_called_once_with(
+            pyramid_request,
+            mock.sentinel.result,
+            form_)
+        form_ = conftest.form_validating_to('anything')
 
     def test_if_validation_succeeds_it_returns_to_xhr_response(self,
                                                                pyramid_request,

--- a/tests/h/form_test.py
+++ b/tests/h/form_test.py
@@ -5,8 +5,6 @@ import pytest
 
 from h import form
 
-from tests.h import conftest
-
 
 class TestJinja2Renderer(object):
 
@@ -172,7 +170,7 @@ class TestHandleFormSubmission(object):
         on_failure = mock_callable()
 
         form.handle_form_submission(pyramid_request,
-                                    invalid_form,
+                                    invalid_form(),
                                     mock.sentinel.on_success,
                                     on_failure)
 
@@ -183,28 +181,31 @@ class TestHandleFormSubmission(object):
                                                           pyramid_request,
                                                           to_xhr_response):
         on_failure = mock_callable()
+        form_ = invalid_form()
 
         form.handle_form_submission(pyramid_request,
-                                    invalid_form,
+                                    form_,
                                     mock.sentinel.on_success,
                                     on_failure)
 
         to_xhr_response.assert_called_once_with(
-            pyramid_request, on_failure.return_value, invalid_form)
+            pyramid_request, on_failure.return_value, form_)
 
     def test_if_validation_fails_it_returns_to_xhr_response(self,
                                                             invalid_form,
                                                             pyramid_request,
                                                             to_xhr_response):
         result = form.handle_form_submission(pyramid_request,
-                                             invalid_form,
+                                             invalid_form(),
                                              mock.sentinel.on_success,
                                              mock_callable())
 
         assert result == to_xhr_response.return_value
 
-    def test_if_validation_succeeds_it_calls_on_success(self, pyramid_request):
-        form_ = conftest.form_validating_to(mock.sentinel.appstruct)
+    def test_if_validation_succeeds_it_calls_on_success(self,
+                                                        form_validating_to,
+                                                        pyramid_request):
+        form_ = form_validating_to(mock.sentinel.appstruct)
         on_success = mock_callable()
 
         form.handle_form_submission(pyramid_request,
@@ -215,19 +216,21 @@ class TestHandleFormSubmission(object):
         on_success.assert_called_once_with(mock.sentinel.appstruct)
 
     def test_if_validation_succeeds_it_shows_a_flash_message(self,
+                                                             form_validating_to,
                                                              pyramid_request):
         form.handle_form_submission(pyramid_request,
-                                    conftest.form_validating_to('anything'),
+                                    form_validating_to('anything'),
                                     mock_callable(),
                                     mock.sentinel.on_failure)
 
         assert pyramid_request.session.peek_flash('success')
 
     def test_if_validation_succeeds_it_calls_to_xhr_response(self,
+                                                             form_validating_to,
                                                              matchers,
                                                              pyramid_request,
                                                              to_xhr_response):
-        form_ = conftest.form_validating_to('anything')
+        form_ = form_validating_to('anything')
 
         form.handle_form_submission(pyramid_request,
                                     form_,
@@ -241,6 +244,7 @@ class TestHandleFormSubmission(object):
 
     def test_if_validation_succeeds_it_passes_on_success_result_to_to_xhr_response(
             self,
+            form_validating_to,
             matchers,
             pyramid_request,
             to_xhr_response):
@@ -251,7 +255,7 @@ class TestHandleFormSubmission(object):
         something to to_xhr_response().
 
         """
-        form_ = conftest.form_validating_to('anything')
+        form_ = form_validating_to('anything')
 
         form.handle_form_submission(pyramid_request,
                                     form_,
@@ -263,13 +267,13 @@ class TestHandleFormSubmission(object):
             pyramid_request,
             mock.sentinel.result,
             form_)
-        form_ = conftest.form_validating_to('anything')
 
     def test_if_validation_succeeds_it_returns_to_xhr_response(self,
+                                                               form_validating_to,
                                                                pyramid_request,
                                                                to_xhr_response):
         result = form.handle_form_submission(pyramid_request,
-                                             conftest.form_validating_to('anything'),
+                                             form_validating_to('anything'),
                                              mock_callable(),
                                              mock.sentinel.on_failure)
 

--- a/tests/h/form_test.py
+++ b/tests/h/form_test.py
@@ -129,13 +129,12 @@ class TestToXHRResponse(object):
 
         """
         pyramid_request.is_xhr = False
-        non_xhr_result = mock.Mock()
 
         result = form.to_xhr_response(pyramid_request,
-                                      non_xhr_result,
-                                      mock.Mock())
+                                      mock.sentinel.non_xhr_result,
+                                      mock.sentinel.form)
 
-        assert result == non_xhr_result
+        assert result == mock.sentinel.non_xhr_result
 
     def test_returns_form_if_xhr(self, pyramid_request):
         """
@@ -147,7 +146,9 @@ class TestToXHRResponse(object):
         pyramid_request.is_xhr = True
         form_ = mock.Mock()
 
-        result = form.to_xhr_response(pyramid_request, mock.Mock(), form_)
+        result = form.to_xhr_response(pyramid_request,
+                                      mock.sentinel.non_xhr_result,
+                                      form_)
 
         assert result == form_.render.return_value
 
@@ -161,7 +162,7 @@ class TestHandleFormSubmission(object):
         form.handle_form_submission(pyramid_request,
                                     form_,
                                     mock.Mock(),
-                                    mock.Mock())
+                                    mock.sentinel.on_failure)
 
         form_.validate.assert_called_once_with(pyramid_request.POST.items())
 
@@ -172,7 +173,7 @@ class TestHandleFormSubmission(object):
 
         form.handle_form_submission(pyramid_request,
                                     invalid_form,
-                                    mock.Mock(),
+                                    mock.sentinel.on_success,
                                     on_failure)
 
         on_failure.assert_called_once_with()
@@ -185,7 +186,7 @@ class TestHandleFormSubmission(object):
 
         form.handle_form_submission(pyramid_request,
                                     invalid_form,
-                                    mock.Mock(),
+                                    mock.sentinel.on_success,
                                     on_failure)
 
         to_xhr_response.assert_called_once_with(
@@ -197,7 +198,7 @@ class TestHandleFormSubmission(object):
                                                             to_xhr_response):
         result = form.handle_form_submission(pyramid_request,
                                              invalid_form,
-                                             mock.Mock(),
+                                             mock.sentinel.on_success,
                                              mock.Mock())
 
         assert result == to_xhr_response.return_value
@@ -209,7 +210,7 @@ class TestHandleFormSubmission(object):
         form.handle_form_submission(pyramid_request,
                                     form_,
                                     on_success,
-                                    mock.Mock())
+                                    mock.sentinel.on_failure)
 
         on_success.assert_called_once_with(mock.sentinel.appstruct)
 
@@ -218,7 +219,7 @@ class TestHandleFormSubmission(object):
         form.handle_form_submission(pyramid_request,
                                     conftest.form_validating_to('anything'),
                                     mock.Mock(),
-                                    mock.Mock())
+                                    mock.sentinel.on_failure)
 
         assert pyramid_request.session.peek_flash('success')
 
@@ -231,7 +232,7 @@ class TestHandleFormSubmission(object):
         form.handle_form_submission(pyramid_request,
                                     form_,
                                     mock.Mock(return_value=None),
-                                    mock.Mock())
+                                    mock.sentinel.on_failure)
 
         to_xhr_response.assert_called_once_with(
             pyramid_request,
@@ -255,7 +256,7 @@ class TestHandleFormSubmission(object):
         form.handle_form_submission(pyramid_request,
                                     form_,
                                     mock.Mock(return_value=mock.sentinel.result),
-                                    mock.Mock())
+                                    mock.sentinel.on_failure)
 
         to_xhr_response.assert_called_once_with(
             pyramid_request,
@@ -269,7 +270,7 @@ class TestHandleFormSubmission(object):
         result = form.handle_form_submission(pyramid_request,
                                              conftest.form_validating_to('anything'),
                                              mock.Mock(),
-                                             mock.Mock())
+                                             mock.sentinel.on_failure)
 
         assert result == to_xhr_response.return_value
 

--- a/tests/h/form_test.py
+++ b/tests/h/form_test.py
@@ -144,7 +144,7 @@ class TestToXHRResponse(object):
 
         """
         pyramid_request.is_xhr = True
-        form_ = mock.Mock()
+        form_ = mock.Mock(spec_set=['render'])
 
         result = form.to_xhr_response(pyramid_request,
                                       mock.sentinel.non_xhr_result,
@@ -157,11 +157,11 @@ class TestToXHRResponse(object):
 class TestHandleFormSubmission(object):
 
     def test_it_calls_validate(self, pyramid_request):
-        form_ = mock.Mock()
+        form_ = mock.Mock(spec_set=['validate'])
 
         form.handle_form_submission(pyramid_request,
                                     form_,
-                                    mock.Mock(),
+                                    mock.Mock(spec_set=['__call__']),
                                     mock.sentinel.on_failure)
 
         form_.validate.assert_called_once_with(pyramid_request.POST.items())
@@ -169,7 +169,7 @@ class TestHandleFormSubmission(object):
     def test_if_validation_fails_it_calls_on_failure(self,
                                                      pyramid_request,
                                                      invalid_form):
-        on_failure = mock.Mock()
+        on_failure = mock.Mock(spec_set=['__call__'])
 
         form.handle_form_submission(pyramid_request,
                                     invalid_form,
@@ -182,7 +182,7 @@ class TestHandleFormSubmission(object):
                                                           invalid_form,
                                                           pyramid_request,
                                                           to_xhr_response):
-        on_failure = mock.Mock()
+        on_failure = mock.Mock(spec_set=['__call__'])
 
         form.handle_form_submission(pyramid_request,
                                     invalid_form,
@@ -199,13 +199,13 @@ class TestHandleFormSubmission(object):
         result = form.handle_form_submission(pyramid_request,
                                              invalid_form,
                                              mock.sentinel.on_success,
-                                             mock.Mock())
+                                             mock.Mock(spec_set=['__call__']))
 
         assert result == to_xhr_response.return_value
 
     def test_if_validation_succeeds_it_calls_on_success(self, pyramid_request):
         form_ = conftest.form_validating_to(mock.sentinel.appstruct)
-        on_success = mock.Mock()
+        on_success = mock.Mock(spec_set=['__call__'])
 
         form.handle_form_submission(pyramid_request,
                                     form_,
@@ -218,7 +218,7 @@ class TestHandleFormSubmission(object):
                                                              pyramid_request):
         form.handle_form_submission(pyramid_request,
                                     conftest.form_validating_to('anything'),
-                                    mock.Mock(),
+                                    mock.Mock(spec_set=['__call__']),
                                     mock.sentinel.on_failure)
 
         assert pyramid_request.session.peek_flash('success')
@@ -231,7 +231,8 @@ class TestHandleFormSubmission(object):
 
         form.handle_form_submission(pyramid_request,
                                     form_,
-                                    mock.Mock(return_value=None),
+                                    mock.Mock(spec_set=['__call__'],
+                                              return_value=None),
                                     mock.sentinel.on_failure)
 
         to_xhr_response.assert_called_once_with(
@@ -255,7 +256,8 @@ class TestHandleFormSubmission(object):
 
         form.handle_form_submission(pyramid_request,
                                     form_,
-                                    mock.Mock(return_value=mock.sentinel.result),
+                                    mock.Mock(spec_set=['__call__'],
+                                              return_value=mock.sentinel.result),
                                     mock.sentinel.on_failure)
 
         to_xhr_response.assert_called_once_with(
@@ -269,7 +271,7 @@ class TestHandleFormSubmission(object):
                                                                to_xhr_response):
         result = form.handle_form_submission(pyramid_request,
                                              conftest.form_validating_to('anything'),
-                                             mock.Mock(),
+                                             mock.Mock(spec_set=['__call__']),
                                              mock.sentinel.on_failure)
 
         assert result == to_xhr_response.return_value

--- a/tests/h/form_test.py
+++ b/tests/h/form_test.py
@@ -161,7 +161,7 @@ class TestHandleFormSubmission(object):
 
         form.handle_form_submission(pyramid_request,
                                     form_,
-                                    mock.Mock(spec_set=['__call__']),
+                                    mock_callable(),
                                     mock.sentinel.on_failure)
 
         form_.validate.assert_called_once_with(pyramid_request.POST.items())
@@ -169,7 +169,7 @@ class TestHandleFormSubmission(object):
     def test_if_validation_fails_it_calls_on_failure(self,
                                                      pyramid_request,
                                                      invalid_form):
-        on_failure = mock.Mock(spec_set=['__call__'])
+        on_failure = mock_callable()
 
         form.handle_form_submission(pyramid_request,
                                     invalid_form,
@@ -182,7 +182,7 @@ class TestHandleFormSubmission(object):
                                                           invalid_form,
                                                           pyramid_request,
                                                           to_xhr_response):
-        on_failure = mock.Mock(spec_set=['__call__'])
+        on_failure = mock_callable()
 
         form.handle_form_submission(pyramid_request,
                                     invalid_form,
@@ -199,13 +199,13 @@ class TestHandleFormSubmission(object):
         result = form.handle_form_submission(pyramid_request,
                                              invalid_form,
                                              mock.sentinel.on_success,
-                                             mock.Mock(spec_set=['__call__']))
+                                             mock_callable())
 
         assert result == to_xhr_response.return_value
 
     def test_if_validation_succeeds_it_calls_on_success(self, pyramid_request):
         form_ = conftest.form_validating_to(mock.sentinel.appstruct)
-        on_success = mock.Mock(spec_set=['__call__'])
+        on_success = mock_callable()
 
         form.handle_form_submission(pyramid_request,
                                     form_,
@@ -218,7 +218,7 @@ class TestHandleFormSubmission(object):
                                                              pyramid_request):
         form.handle_form_submission(pyramid_request,
                                     conftest.form_validating_to('anything'),
-                                    mock.Mock(spec_set=['__call__']),
+                                    mock_callable(),
                                     mock.sentinel.on_failure)
 
         assert pyramid_request.session.peek_flash('success')
@@ -231,8 +231,7 @@ class TestHandleFormSubmission(object):
 
         form.handle_form_submission(pyramid_request,
                                     form_,
-                                    mock.Mock(spec_set=['__call__'],
-                                              return_value=None),
+                                    mock_callable(return_value=None),
                                     mock.sentinel.on_failure)
 
         to_xhr_response.assert_called_once_with(
@@ -256,8 +255,8 @@ class TestHandleFormSubmission(object):
 
         form.handle_form_submission(pyramid_request,
                                     form_,
-                                    mock.Mock(spec_set=['__call__'],
-                                              return_value=mock.sentinel.result),
+                                    mock_callable(
+                                        return_value=mock.sentinel.result),
                                     mock.sentinel.on_failure)
 
         to_xhr_response.assert_called_once_with(
@@ -271,7 +270,7 @@ class TestHandleFormSubmission(object):
                                                                to_xhr_response):
         result = form.handle_form_submission(pyramid_request,
                                              conftest.form_validating_to('anything'),
-                                             mock.Mock(spec_set=['__call__']),
+                                             mock_callable(),
                                              mock.sentinel.on_failure)
 
         assert result == to_xhr_response.return_value
@@ -279,3 +278,15 @@ class TestHandleFormSubmission(object):
     @pytest.fixture
     def to_xhr_response(self, patch):
         return patch('h.form.to_xhr_response')
+
+
+def mock_callable(**kwargs):
+    """
+    Return a mock than can be called but doesn't have any accessible properties.
+
+    The mock can be called like ``my_mock_callable()`` but trying to access any
+    other properties like ``my_mock_callable.foo`` will fail. This is a useful
+    value to use when the method under test requires a callable as an argument.
+
+    """
+    return mock.Mock(spec_set=['__call__'], **kwargs)


### PR DESCRIPTION
Move `handle_form_submission()` into `h.form` so it can be imported but multiple `views.py` files that want to use it.

Also allow passing in a callable that provides the return value when the form submission is successful and the request is not an XHR request, instead of always redirecting to `request.url`. This makes `handle_form_submission()` usable by a wider variety of form pages.

Also some improvements to the test code.