### PR TITLE
Enable submitting create group form via XHR

### DIFF
--- a/h/groups/views.py
+++ b/h/groups/views.py
@@ -32,7 +32,7 @@ class GroupCreateController(object):
     @view_config(request_method='GET')
     def get(self):
         """Render the form for creating a new group."""
-        return {'form': self.form.render()}
+        return self._template_data()
 
     @view_config(request_method='POST')
     def post(self):
@@ -40,7 +40,7 @@ class GroupCreateController(object):
         try:
             appstruct = self.form.validate(self.request.POST.items())
         except deform.ValidationFailure:
-            return {'form': self.form.render()}
+            return self._template_data()
 
         groups_service = self.request.find_service(name='groups')
         group = groups_service.create(name=appstruct['name'],
@@ -50,6 +50,10 @@ class GroupCreateController(object):
                                       pubid=group.pubid,
                                       slug=group.slug)
         return HTTPSeeOther(url)
+
+    def _template_data(self):
+        """Return the data needed to render this controller's page."""
+        return {'form': self.form.render()}
 
 
 @view_config(route_name='group_read',

--- a/tests/common/matchers.py
+++ b/tests/common/matchers.py
@@ -29,6 +29,14 @@ output if it fails, e.g.
 from pyramid import httpexceptions
 
 
+class any_callable(object):  # noqa: N801
+    """An object __eq__ to any callable object."""
+
+    def __eq__(self, other):
+        """Return ``True`` if ``other`` is callable, ``False`` otherwise."""
+        return callable(other)
+
+
 class instance_of(object):  # noqa: N801
     """An object __eq__ to any object which is an instance of `type_`."""
 
@@ -81,5 +89,17 @@ class redirect_302_to(object):
 
     def __eq__(self, other):
         if not isinstance(other, httpexceptions.HTTPFound):
+            return False
+        return other.location == self.location
+
+
+class redirect_303_to(object):
+    """Matches any HTTPSeeOther redirect to the given URL."""
+
+    def __init__(self, location):
+        self.location = location
+
+    def __eq__(self, other):
+        if not isinstance(other, httpexceptions.HTTPSeeOther):
             return False
         return other.location == self.location


### PR DESCRIPTION
If a `POST` request submitting the create new group form is an `XMLHttpRequest` (it has a `X-Requested-With: XMLHttpRequest` header) then return just the `<form> ... </form>` element as an HTML snippet, rather than returning the entire HTML page (in the case of an invalid form submission) or a redirect (in the case of an valid form submission).

Depends on https://github.com/hypothesis/h/pull/3700