### PR TITLE
Allow toggling features on with a query string param

### DIFF
--- a/h/features/client.py
+++ b/h/features/client.py
@@ -68,6 +68,11 @@ class Client(object):
         self._cache = {f.name: self._state(f) for f in features}
 
     def _state(self, feature):
+        # If "__feature__[<featurename>]" is in the query string, then the
+        # feature is on. This allows testing feature flags for logged-out
+        # users.
+        if '__feature__[{}]'.format(feature.name) in self.request.GET:
+            return True
         # Features that are on for everyone are on.
         if feature.everyone:
             return True

--- a/tests/h/features/client_test.py
+++ b/tests/h/features/client_test.py
@@ -42,6 +42,11 @@ class TestClient(object):
         with pytest.raises(UnknownFeatureError):
             client.enabled('wibble')
 
+    def test_enabled_true_if_feature_query_param_set(self, client, pyramid_request):
+        pyramid_request.GET['__feature__[foo]'] = ''
+
+        assert client.enabled('foo') is True
+
     def test_enabled_false_if_everyone_false(self, client):
         assert client.enabled('foo') is False
 


### PR DESCRIPTION
This small commit allows you to toggle a feature flag on by setting a
__feature__[featurename] query parameter. This can be useful for
toggling a feature flag on for requests made while logged-out.