### PR TITLE
Add a UserSignupService

### DIFF
--- a/h/accounts/__init__.py
+++ b/h/accounts/__init__.py
@@ -73,6 +73,9 @@ def includeme(config):
     config.add_request_method(
         authenticated_user, name='authenticated_user', reify=True)
 
+    config.register_service_factory('.services.user_signup_service_factory',
+                                    name='user_signup')
+
     config.include('.schemas')
     config.include('.subscribers')
     config.include('.views')

--- a/h/accounts/events.py
+++ b/h/accounts/events.py
@@ -16,12 +16,6 @@ class LogoutEvent(object):
         self.request = request
 
 
-class RegistrationEvent(object):
-    def __init__(self, request, user):
-        self.request = request
-        self.user = user
-
-
 class PasswordResetEvent(object):
     def __init__(self, request, user):
         self.request = request

--- a/h/accounts/services.py
+++ b/h/accounts/services.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from functools import partial
+
+from h import mailer
+from h import util
+from h._compat import text_type
+from h.emails import signup
+from h.models import Activation, Subscriptions, User
+
+
+class UserSignupService(object):
+
+    """A service for registering users."""
+
+    def __init__(self,
+                 default_authority,
+                 mailer,
+                 session,
+                 signup_email,
+                 stats=None):
+        """
+        Create a new user signup service.
+
+        :param default_authority: the default authority for new users
+        :param mailer: a mailer (such as :py:mod:`h.mailer`)
+        :param session: the SQLAlchemy session object
+        :param signup_email: a function for generating a signup email
+        :param stats: the stats service
+        """
+        self.default_authority = default_authority
+        self.mailer = mailer
+        self.session = session
+        self.signup_email = signup_email
+        self.stats = stats
+
+    def signup(self, **kwargs):
+        """
+        Create a new user.
+
+        All keyword arguments are passed to the :py:class:`h.models.User`
+        constructor.
+        """
+        user = User(**kwargs)
+        self.session.add(user)
+
+        # Create a new activation for the user
+        activation = Activation()
+        self.session.add(activation)
+        user.activation = activation
+
+        # Flush the session to ensure that the user can be created and the
+        # activation is successfully wired up.
+        self.session.flush()
+
+        # Send the activation email
+        mail_params = self.signup_email(id=user.id,
+                                        email=user.email,
+                                        activation_code=user.activation.code)
+        self.mailer.send.delay(*mail_params)
+
+        # FIXME: this is horrible, but is needed until the
+        # notification/subscription system is made opt-out rather than opt-in
+        # (at least from the perspective of the database).
+        sub_userid = util.user.userid_from_username(user.username,
+                                                    self.default_authority)
+        sub = Subscriptions(uri=sub_userid, type='reply', active=True)
+        self.session.add(sub)
+
+        # Record a registration with the stats service
+        if self.stats is not None:
+            self.stats.incr('auth.local.register')
+
+        return user
+
+
+def user_signup_service_factory(context, request):
+    """Return a UserSignupService instance for the passed context and request."""
+    return UserSignupService(default_authority=text_type(request.auth_domain),
+                             mailer=mailer,
+                             session=request.db,
+                             signup_email=partial(signup.generate, request),
+                             stats=request.stats)

--- a/h/accounts/subscribers.py
+++ b/h/accounts/subscribers.py
@@ -16,11 +16,6 @@ def logout(event):
     event.request.stats.incr('auth.local.logout')
 
 
-@subscriber(events.RegistrationEvent)
-def registration(event):
-    event.request.stats.incr('auth.local.register')
-
-
 @subscriber(events.PasswordResetEvent)
 def password_reset(event):
     event.request.stats.incr('auth.local.reset_password')

--- a/h/cli/commands/user.py
+++ b/h/cli/commands/user.py
@@ -20,8 +20,12 @@ def add(ctx, username, email, password):
     """Create a new user."""
     request = ctx.obj['bootstrap']()
 
-    user = models.User(username=username, email=email, password=password)
-    request.db.add(user)
+    signup_service = request.find_service(name='user_signup')
+
+    user = signup_service.signup(username=username,
+                                 email=email,
+                                 password=password)
+    user.activate()
 
     try:
         request.tm.commit()

--- a/h/notification/reply.py
+++ b/h/notification/reply.py
@@ -3,13 +3,9 @@
 from collections import namedtuple
 import logging
 
-from pyramid.events import subscriber
-
-from h import auth
 from h import accounts
 from memex import storage
 from h.notification.models import Subscriptions
-from h.accounts.events import RegistrationEvent
 
 log = logging.getLogger(__name__)
 
@@ -108,25 +104,6 @@ def get_notification(request, annotation, action):
         return
 
     return Notification(reply, reply_user, parent, parent_user, reply.document)
-
-
-# Create a reply template for a uri
-def create_subscription(request, uri, active):
-    subs = Subscriptions(
-        uri=uri,
-        type='reply',
-        active=active
-    )
-
-    request.db.add(subs)
-    request.db.flush()
-
-
-@subscriber(RegistrationEvent)
-def registration_subscriptions(event):
-    request = event.request
-    user_uri = u'acct:{}@{}'.format(event.user.username, request.domain)
-    create_subscription(event.request, user_uri, True)
 
 
 def includeme(config):

--- a/tests/h/accounts/services_test.py
+++ b/tests/h/accounts/services_test.py
@@ -1,0 +1,122 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import mock
+import pytest
+
+from h.accounts.services import UserSignupService, user_signup_service_factory
+from h.models import Activation, Subscriptions, User
+
+
+class TestUserSignupService(object):
+    def test_signup_returns_user(self, svc):
+        user = svc.signup(username='foo', email='foo@bar.com', password='baz')
+
+        assert isinstance(user, User)
+
+    def test_signup_creates_user_in_db(self, db_session, svc):
+        svc.signup(username='foo', email='foo@bar.com', password='baz')
+
+        db_session.commit()
+        db_session.close()
+
+        user = db_session.query(User).filter_by(username='foo').one_or_none()
+
+        assert user is not None
+
+    def test_signup_creates_activation_for_user(self, svc):
+        user = svc.signup(username='foo', email='foo@bar.com', password='baz')
+
+        assert isinstance(user.activation, Activation)
+
+    def test_passes_user_info_to_signup_email(self, svc, signup_email):
+        user = svc.signup(username='foo', email='foo@bar.com', password='baz')
+
+        signup_email.assert_called_once_with(id=user.id,
+                                             email='foo@bar.com',
+                                             activation_code=user.activation.code)
+
+    def test_signup_sends_email(self, mailer, svc):
+        svc.signup(username='foo', email='foo@bar.com', password='baz')
+
+        mailer.send.delay.assert_called_once_with(['test@example.com'],
+                                                  'My subject',
+                                                  'Text',
+                                                  '<p>HTML</p>')
+
+    def test_signup_creates_reply_notification_subscription(self, db_session, svc):
+        svc.signup(username='foo', email='foo@bar.com', password='baz')
+
+        sub = (db_session.query(Subscriptions)
+               .filter_by(uri='acct:foo@example.org')
+               .one_or_none())
+
+        assert sub.active
+
+    def test_signup_records_stats_if_present(self, svc, stats):
+        svc.stats = stats
+
+        svc.signup(username='foo', email='foo@bar.com', password='baz')
+
+        stats.incr.assert_called_once_with('auth.local.register')
+
+    @pytest.fixture
+    def svc(self, db_session, mailer, signup_email):
+        return UserSignupService(default_authority='example.org',
+                                 mailer=mailer,
+                                 session=db_session,
+                                 signup_email=signup_email)
+
+    @pytest.fixture
+    def mailer(self):
+        return mock.Mock(spec_set=['send'])
+
+    @pytest.fixture
+    def signup_email(self):
+        signup_email = mock.Mock(spec_set=[])
+        signup_email.return_value = (['test@example.com'], 'My subject', 'Text', '<p>HTML</p>')
+        return signup_email
+
+    @pytest.fixture
+    def stats(self):
+        return mock.Mock(spec_set=['incr'])
+
+
+class TestUserSignupServiceFactory(object):
+    def test_returns_user_signup_service(self, pyramid_request):
+        svc = user_signup_service_factory(None, pyramid_request)
+
+        assert isinstance(svc, UserSignupService)
+
+    def test_provides_request_auth_domain_as_default_authority(self, pyramid_request):
+        svc = user_signup_service_factory(None, pyramid_request)
+
+        assert svc.default_authority == pyramid_request.auth_domain
+
+    def test_provides_request_db_as_session(self, pyramid_request):
+        svc = user_signup_service_factory(None, pyramid_request)
+
+        assert svc.session == pyramid_request.db
+
+    def test_wraps_email_module_as_signup_email(self, patch, pyramid_request):
+        signup_email = patch('h.emails.signup.generate')
+        svc = user_signup_service_factory(None, pyramid_request)
+
+        svc.signup_email(id=123, email='foo@bar.com', activation_code='abc456')
+
+        signup_email.assert_called_once_with(pyramid_request,
+                                             id=123,
+                                             email='foo@bar.com',
+                                             activation_code='abc456')
+
+    def test_provides_request_stats_as_stats(self, pyramid_request):
+        svc = user_signup_service_factory(None, pyramid_request)
+
+        assert svc.stats == pyramid_request.stats
+
+
+@pytest.fixture
+def pyramid_request(pyramid_request):
+    pyramid_request.stats = mock.Mock(spec_set=['incr'])
+    return pyramid_request


### PR DESCRIPTION
In order to support API signups, we need to be able to sign up users from places other than `h.accounts.views`.

This PR adds a `UserSignupService` which acquires the responsibility for this task, and thus greatly simplifies the corresponding views in `h.accounts`.