### PR TITLE
Add 'authority' column to user table

### DIFF
--- a/h/migrations/versions/2e2cc6a0c521_fill_in_user_authority_column.py
+++ b/h/migrations/versions/2e2cc6a0c521_fill_in_user_authority_column.py
@@ -1,0 +1,26 @@
+"""
+Fill in user authority column
+
+Revision ID: 2e2cc6a0c521
+Revises: f48100c9af86
+Create Date: 2016-08-15 18:13:08.372479
+"""
+
+from __future__ import unicode_literals
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = '2e2cc6a0c521'
+down_revision = 'f48100c9af86'
+
+user_table = sa.table('user', sa.Column('authority', sa.UnicodeText()))
+
+
+def upgrade():
+    op.execute(user_table.update().values(authority='hypothes.is'))
+
+
+def downgrade():
+    pass
+

--- a/h/migrations/versions/f48100c9af86_add_authority_column_to_user_table.py
+++ b/h/migrations/versions/f48100c9af86_add_authority_column_to_user_table.py
@@ -1,0 +1,24 @@
+"""
+Add authority column to user table
+
+Revision ID: f48100c9af86
+Revises: 64cf31f9f721
+Create Date: 2016-08-15 18:10:23.511861
+"""
+
+from __future__ import unicode_literals
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = 'f48100c9af86'
+down_revision = '64cf31f9f721'
+
+
+def upgrade():
+    op.add_column('user', sa.Column('authority', sa.UnicodeText(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('user', 'authority')


### PR DESCRIPTION
This PR adds two migrations:

1. To add a nullable 'authority' column to the user table.

2. To fill the authority column with 'hypothes.is' for all rows in the user table.

This authority column will be used to distinguish between our own service users and the users of accounts generated by the "third-party accounts" system. In the mean time, this change actually makes handling of userids within the `h` code substantially simpler, by making it possible for a `User` object to know its own userid. Subsequent PRs will make these changes.

By deploying and running these migrations before we make the corresponding changes to the user model, we can ensure a zero-downtime rollout of that new code.