### PR TITLE
Move activity page core logic into `h.activity.query`

### DIFF
--- a/h/activity/query.py
+++ b/h/activity/query.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from collections import namedtuple
+
+from memex.search import Search
+from memex.search.query import (
+    TagsAggregation,
+    TopLevelAnnotationsFilter,
+    UsersAggregation,
+)
+from sqlalchemy.orm import subqueryload
+
+from h import presenters
+from h.activity import bucketing
+from h.models import Annotation, Document, Group
+
+
+class ActivityResults(namedtuple('ActivityResults', [
+    'total',
+    'aggregations',
+    'timeframes',
+])):
+    pass
+
+
+def execute(request, query):
+    search = Search(request)
+    search.append_filter(TopLevelAnnotationsFilter())
+    for agg in aggregations_for(query):
+        search.append_aggregation(agg)
+
+    search_result = search.run(query)
+    result = ActivityResults(total=search_result.total,
+                             aggregations=search_result.aggregations,
+                             timeframes=[])
+
+    if result.total == 0:
+        return result
+
+    # Load all referenced annotations from the database, bucket them, and add
+    # the buckets to result.timeframes.
+    anns = _fetch_annotations(request.db, search_result.annotation_ids)
+    result.timeframes.extend(bucketing.bucket(anns))
+
+    # Fetch all groups
+    group_pubids = set([a.groupid
+                        for t in result.timeframes
+                        for b in t.document_buckets.values()
+                        for a in b.annotations])
+    groups = {g.pubid: g for g in _fetch_groups(request.db, group_pubids)}
+
+    # Add group information to buckets and present annotations
+    for timeframe in result.timeframes:
+        for bucket in timeframe.document_buckets.values():
+            for index, annotation in enumerate(bucket.annotations):
+                bucket.annotations[index] = {
+                    'annotation': presenters.AnnotationHTMLPresenter(annotation),
+                    'group': groups.get(annotation.groupid)
+                }
+
+    return result
+
+
+def aggregations_for(query):
+    aggregations = [TagsAggregation(limit=10)]
+
+    # Should we aggregate by user?
+    include_users_aggregation = len(query.getall('group')) == 1
+    if include_users_aggregation:
+        aggregations.append(UsersAggregation(limit=10))
+
+    return aggregations
+
+
+def _fetch_annotations(session, ids):
+    return (session.query(Annotation)
+            .options(subqueryload(Annotation.document)
+                     .subqueryload(Document.meta_titles))
+            .filter(Annotation.id.in_(ids))
+            .order_by(Annotation.updated.desc()))
+
+
+def _fetch_groups(session, pubids):
+    return session.query(Group).filter(Group.pubid.in_(pubids))

--- a/h/activity/views.py
+++ b/h/activity/views.py
@@ -8,15 +8,10 @@ from __future__ import unicode_literals
 
 from pyramid import httpexceptions
 from pyramid.view import view_config
-from sqlalchemy.orm import subqueryload
 
-from h import models
-from h import presenters
-from h.activity import bucketing
-from memex import search as search_lib
 from memex.search import parser
-from memex.search import query
-from memex import storage
+
+from h.activity import query
 
 
 @view_config(route_name='activity.search',
@@ -26,47 +21,17 @@ def search(request):
     if not request.feature('search_page'):
         raise httpexceptions.HTTPNotFound()
 
-    timeframes = []
-    total = None
-    tags = []
-    users = []
-    if 'q' in request.params:
-        search_query = parser.parse(request.params['q'])
+    if 'q' not in request.params:
+        return {}
 
-        search_request = search_lib.Search(request)
-        search_request.append_filter(query.TopLevelAnnotationsFilter())
-        search_request.append_aggregation(query.TagsAggregation(limit=10))
-        if len(search_query.getall('group')) == 1:
-            search_request.append_aggregation(query.UsersAggregation(limit=10))
-        result = search_request.run(search_query)
-        total = result.total
-        tags = result.aggregations['tags']
-        users = result.aggregations.get('users', [])
-
-        def eager_load_documents(query):
-            return query.options(
-                subqueryload(models.Annotation.document)
-                .subqueryload(models.Document.meta_titles))
-
-        anns = storage.fetch_ordered_annotations(
-            request.db, result.annotation_ids,
-            query_processor=eager_load_documents)
-
-        timeframes = bucketing.bucket(anns)
-
-        for timeframe in timeframes:
-            for document, bucket in timeframe.document_buckets.items():
-                for index, annotation in enumerate(bucket.annotations):
-                    group = request.db.query(models.Group).filter(
-                        models.Group.pubid == annotation.groupid).one_or_none()
-                    bucket.annotations[index] = {'annotation': presenters.AnnotationHTMLPresenter(annotation), 'group': group}
+    q = parser.parse(request.params['q'])
+    result = query.execute(request, q)
 
     return {
-        'q': request.params.get('q', ''),
-        'total': total,
-        'tags': tags,
-        'users': users,
-        'timeframes': timeframes,
+        'q': request.params['q'],
+        'total': result.total,
+        'aggregations': result.aggregations,
+        'timeframes': result.timeframes,
     }
 
 


### PR DESCRIPTION
This is still pre-production code, but this PR:

1. Moves the core data retrieval for activity pages into its own module.
2. Improves the efficiency of retrieving group information.