### PR TITLE
Collapse document buckets until toggled by clicking document titles 

### DIFF
--- a/h/static/scripts/base/environment-flags.js
+++ b/h/static/scripts/base/environment-flags.js
@@ -68,8 +68,6 @@ EnvironmentFlags.prototype.ready = function () {
   if (this._jsLoadTimeout) {
     clearTimeout(this._jsLoadTimeout);
   }
-  this.set('js-ready', true);
-  this.set('js-timeout', false);
 };
 
 module.exports = EnvironmentFlags;

--- a/h/static/scripts/controllers/search-bucket-controller.js
+++ b/h/static/scripts/controllers/search-bucket-controller.js
@@ -1,0 +1,13 @@
+'use strict';
+
+function SearchBucketController(element) {
+  var header = element.querySelector('.js-header');
+  var content = element.querySelector('.js-content');
+
+  header.addEventListener('click', function () {
+    element.classList.toggle('is-expanded');
+    content.classList.toggle('is-expanded');
+  });
+}
+
+module.exports = SearchBucketController;

--- a/h/static/scripts/site.js
+++ b/h/static/scripts/site.js
@@ -11,12 +11,14 @@ require('./polyfills');
 var CreateGroupFormController = require('./controllers/create-group-form-controller');
 var DropdownMenuController = require('./controllers/dropdown-menu-controller');
 var FormSelectOnFocusController = require('./controllers/form-select-onfocus-controller');
+var SearchBucketController = require('./controllers/search-bucket-controller');
 var upgradeElements = require('./base/upgrade-elements');
 
 var controllers = {
   '.js-create-group-form': CreateGroupFormController,
   '.js-dropdown-menu': DropdownMenuController,
   '.js-select-onfocus': FormSelectOnFocusController,
+  '.js-search-bucket': SearchBucketController,
 };
 
 upgradeElements(document.body, controllers);

--- a/h/static/scripts/tests/base/environment-flags-test.js
+++ b/h/static/scripts/tests/base/environment-flags-test.js
@@ -51,11 +51,11 @@ describe('EnvironmentFlags', function () {
       assert.isFalse(el.classList.contains('env-js-timeout'));
     });
 
-    it('should clear timeout flag if already set', function () {
+    it('should not clear timeout flag if already set', function () {
       flags.init();
       clock.tick(TIMEOUT_DELAY);
       flags.ready();
-      assert.isFalse(el.classList.contains('env-js-timeout'));
+      assert.isTrue(el.classList.contains('env-js-timeout'));
     });
   });
 

--- a/h/static/scripts/tests/controllers/search-bucket-controller-test.js
+++ b/h/static/scripts/tests/controllers/search-bucket-controller-test.js
@@ -1,0 +1,30 @@
+'use strict';
+
+var SearchBucketController = require('../../controllers/search-bucket-controller');
+var util = require('./util');
+
+var TEMPLATE = [
+  '<div class="js-search-bucket">',
+  '<div class="js-header"></div>',
+  '<div class="js-content"></div>',
+  '</div>',
+];
+
+describe('SearchBucketController', function () {
+  var container;
+  var headerEl;
+  var contentEl;
+
+  beforeEach(function () {
+    container = util.setupComponent(document, TEMPLATE, {
+      '.js-search-bucket': SearchBucketController,
+    });
+    headerEl = container.querySelector('.js-header');
+    contentEl = container.querySelector('.js-content');
+  });
+
+  it('toggles content expanded state when clicked', function () {
+    headerEl.dispatchEvent(new Event('click'));
+    assert.isTrue(contentEl.classList.contains('is-expanded'));
+  });
+});

--- a/h/static/styles/partials-v2/_search.scss
+++ b/h/static/styles/partials-v2/_search.scss
@@ -38,7 +38,13 @@
   background-color: $grey-2;
   border-bottom: 1px solid $grey-3;
 
-  &:hover {
+  .env-js-capable & {
+    background-color: $white;
+  }
+
+  .env-js-capable &:hover,
+  .env-js-capable &.is-expanded,
+  .env-js-timeout & {
     background-color: $grey-2;
   }
 }
@@ -57,6 +63,9 @@
 .search-result-bucket__header {
   display: flex;
   flex-direction: row;
+
+  cursor: pointer;
+  user-select: none;
 }
 
 .search-result-bucket__title {
@@ -66,6 +75,12 @@
 
 .search-result-bucket__annotation-cards-container {
   display: flex;
+  .env-js-capable & {
+    display: none;
+  }
+  .env-js-capable &.is-expanded, .env-js-timeout & {
+    display: flex;
+  }
 }
 
 .search-result-bucket__annotation-cards {

--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -36,12 +36,12 @@
   A collapsible bucket/group of annotations
 #}
 {% macro search_result_bucket(bucket) %}
-<div class="search-result-bucket">
+<div class="search-result-bucket js-search-bucket">
   <div class="search-result-bucket__domain">
     {{ bucket.domain }}
   </div>
   <div class="search-result-bucket__content">
-    <div class="search-result-bucket__header">
+    <div class="search-result-bucket__header js-header">
       <div class="search-result-bucket__title">{{ bucket.title }}</div>
       <div class="search-result-bucket__annotations-count">
         <div class="search-result-bucket__annotations-count-container">
@@ -49,7 +49,7 @@
         </div>
       </div>
     </div>
-    <div class="search-result-bucket__annotation-cards-container">
+    <div class="search-result-bucket__annotation-cards-container js-content">
       <ol class="search-result-bucket__annotation-cards">
         {% for result in bucket.annotations %}
           {{ annotation_card(result.annotation, request) }}


### PR DESCRIPTION
This implements the behavior described at https://trello.com/c/TDZE8zFu/416-document-component to collapse search result buckets until toggled by clicking the bucket titles.

~~While working on this I found it more natural to implement the 'expand by default' behavior by changing the way the environment classes on the `<html>` element work, to have an explicit `no JS` class and then style that in a selector that also covers the 'explicitly expanded' case.  The first commit in this PR makes that change and the second implements the collapsing-by-default for the search result buckets.  When testing this, you can flip between the initial states in JS/non-JS mode by setting the `<html>` element's classes to `env-js` or `env-no-js` respectively.~~ (We decided against this change in the end for the time being, see https://botbot.me/freenode/hypothes.is/msg/71520214/ )