### PR TITLE
Add the "authority" column to the user model

### DIFF
--- a/h/accounts/models.py
+++ b/h/accounts/models.py
@@ -68,6 +68,14 @@ class User(Base):
                           nullable=False,
                           unique=True)
 
+    #: The "authority" for this user. This represents the "namespace" in which
+    #: this user lives. By default, all users are created in the namespace
+    #: corresponding to `request.domain`, but this can be overridden with the
+    #: `AUTH_DOMAIN` environment variable.
+    authority = sa.Column('authority',
+                          sa.UnicodeText(),
+                          nullable=False)
+
     #: The display name which will be used when rendering an annotation.
     display_name = sa.Column(sa.UnicodeText())
 

--- a/h/accounts/services.py
+++ b/h/accounts/services.py
@@ -43,6 +43,7 @@ class UserSignupService(object):
         All keyword arguments are passed to the :py:class:`h.models.User`
         constructor.
         """
+        kwargs.setdefault('authority', self.default_authority)
         user = User(**kwargs)
         self.session.add(user)
 

--- a/h/migrations/versions/de42d613c18d_add_constraints_to_user_authority_column.py
+++ b/h/migrations/versions/de42d613c18d_add_constraints_to_user_authority_column.py
@@ -1,0 +1,23 @@
+"""
+Add constraints to user authority column
+
+Revision ID: de42d613c18d
+Revises: 2e2cc6a0c521
+Create Date: 2016-08-15 18:18:19.037667
+"""
+
+from __future__ import unicode_literals
+
+from alembic import op
+
+
+revision = 'de42d613c18d'
+down_revision = '2e2cc6a0c521'
+
+
+def upgrade():
+    op.alter_column('user', 'authority', nullable=False)
+
+
+def downgrade():
+    op.alter_column('user', 'authority', nullable=True)

--- a/tests/common/factories.py
+++ b/tests/common/factories.py
@@ -194,6 +194,7 @@ class User(factory.Factory):
     class Meta(object):
         model = accounts_models.User
 
+    authority = 'example.com'
     username = factory.Faker('user_name')
     email = factory.Faker('email')
     password = factory.Faker('password')

--- a/tests/h/accounts/models_test.py
+++ b/tests/h/accounts/models_test.py
@@ -19,10 +19,12 @@ def test_activation_has_asciinumeric_code(db_session):
 
 
 def test_cannot_create_dot_variant_of_user(db_session):
-    fred = models.User(username='fredbloggs',
+    fred = models.User(authority='example.com',
+                       username='fredbloggs',
                        email='fred@example.com',
                        password='123')
-    fred2 = models.User(username='fred.bloggs',
+    fred2 = models.User(authority='example.com',
+                        username='fred.bloggs',
                         email='fred@example.org',
                         password='456')
 
@@ -33,10 +35,12 @@ def test_cannot_create_dot_variant_of_user(db_session):
 
 
 def test_cannot_create_case_variant_of_user(db_session):
-    bob = models.User(username='BobJones',
+    bob = models.User(authority='example.com',
+                      username='BobJones',
                       email='bob@example.com',
                       password='123')
-    bob2 = models.User(username='bobjones',
+    bob2 = models.User(authority='example.com',
+                       username='bobjones',
                        email='bob@example.org',
                        password='456')
 
@@ -72,7 +76,9 @@ def test_cannot_create_user_with_too_short_password():
 
 
 def test_User_activate_activates_user(db_session):
-    user = models.User(username='kiki', email='kiki@kiki.com',
+    user = models.User(authority='example.com',
+                       username='kiki',
+                       email='kiki@kiki.com',
                        password='password')
     activation = models.Activation()
     user.activation = activation

--- a/tests/h/accounts/services_test.py
+++ b/tests/h/accounts/services_test.py
@@ -30,6 +30,19 @@ class TestUserSignupService(object):
 
         assert isinstance(user.activation, Activation)
 
+    def test_signup_sets_default_authority(self, svc):
+        user = svc.signup(username='foo', email='foo@bar.com', password='baz')
+
+        assert user.authority == 'example.org'
+
+    def test_signup_allows_authority_override(self, svc):
+        user = svc.signup(username='foo',
+                          email='foo@bar.com',
+                          password='baz',
+                          authority='bar-client.com')
+
+        assert user.authority == 'bar-client.com'
+
     def test_passes_user_info_to_signup_email(self, svc, signup_email):
         user = svc.signup(username='foo', email='foo@bar.com', password='baz')
 

--- a/tests/h/admin/views/admins_test.py
+++ b/tests/h/admin/views/admins_test.py
@@ -111,23 +111,16 @@ def routes(pyramid_config):
 
 
 @pytest.fixture
-def users(db_session):
-    from h import models
-
+def users(db_session, factories):
     admins = ['agnos', 'bojan', 'cristof']
     nonadmins = ['david', 'eva', 'flora']
 
     users = {}
 
     for admin in admins:
-        users[admin] = models.User(username=admin,
-                                   email=admin + '@example.com',
-                                   password='secret',
-                                   admin=True)
+        users[admin] = factories.User(username=admin, admin=True)
     for nonadmin in nonadmins:
-        users[nonadmin] = models.User(username=nonadmin,
-                                      email=nonadmin + '@example.com',
-                                      password='secret')
+        users[nonadmin] = factories.User(username=nonadmin)
 
     db_session.add_all(list(users.values()))
     db_session.flush()

--- a/tests/h/admin/views/features_test.py
+++ b/tests/h/admin/views/features_test.py
@@ -96,10 +96,8 @@ def test_cohorts_add_creates_cohort_with_no_members(pyramid_request):
     assert len(cohort.members) == 0
 
 
-def test_cohorts_edit_add_user(pyramid_request):
-    user = models.User(username='benoit',
-                       password='mandelbrot',
-                       email='benoit@example.com')
+def test_cohorts_edit_add_user(factories, pyramid_request):
+    user = factories.User(username='benoit')
     cohort = models.FeatureCohort(name='FractalCohort')
 
     pyramid_request.db.add(user)
@@ -114,10 +112,8 @@ def test_cohorts_edit_add_user(pyramid_request):
     assert cohort.members[0].username == user.username
 
 
-def test_cohorts_edit_remove_user(pyramid_request):
-    user = models.User(username='benoit',
-                       password='mandelbrot',
-                       email='benoit@example.com')
+def test_cohorts_edit_remove_user(factories, pyramid_request):
+    user = factories.User(username='benoit')
     cohort = models.FeatureCohort(name='FractalCohort')
     cohort.members.append(user)
 
@@ -146,14 +142,10 @@ def test_cohorts_edit_with_no_users(pyramid_request):
     assert len(result['cohort'].members) == 0
 
 
-def test_cohorts_edit_with_users(pyramid_request):
+def test_cohorts_edit_with_users(factories, pyramid_request):
     cohort = models.FeatureCohort(name='FractalCohort')
-    user1 = models.User(username='benoit',
-                        password='mandelbrot',
-                        email='benoit@example.com')
-    user2 = models.User(username='emily',
-                        password='noether',
-                        email='emily@example.com')
+    user1 = factories.User(username='benoit')
+    user2 = factories.User(username='emily')
     cohort.members.append(user1)
     cohort.members.append(user2)
 

--- a/tests/h/admin/views/staff_test.py
+++ b/tests/h/admin/views/staff_test.py
@@ -101,23 +101,16 @@ def routes(pyramid_config):
 
 
 @pytest.fixture
-def users(db_session):
-    from h import models
-
+def users(db_session, factories):
     staff = ['agnos', 'bojan', 'cristof']
     nonstaff = ['david', 'eva', 'flora']
 
     users = {}
 
     for staff in staff:
-        users[staff] = models.User(username=staff,
-                                   email=staff + '@example.com',
-                                   password='secret',
-                                   staff=True)
+        users[staff] = factories.User(username=staff, staff=True)
     for nonstaff in nonstaff:
-        users[nonstaff] = models.User(username=nonstaff,
-                                      email=nonstaff + '@example.com',
-                                      password='secret')
+        users[nonstaff] = factories.User(username=nonstaff)
 
     db_session.add_all(list(users.values()))
     db_session.flush()


### PR DESCRIPTION
Having now added the column directly to the database, it is safe to add reference to the authority column to the user model.

We ensure that the authority column is filled in for new users using the `default_authority` parameter to the `UserSignupService`, which defaults to `request.auth_domain`.

This means that in production, new users will be created with an authority of "hypothes.is" as expected.

This PR also includes a migration to add the NOT NULL constraint to the authority column.