### PR TITLE
Make password checking an instance method

### DIFF
--- a/h/accounts/models.py
+++ b/h/accounts/models.py
@@ -164,6 +164,12 @@ class User(Base):
 
         return text_type(CRYPT.encode(password + self.salt))
 
+    def check_password(self, password):
+        """Check the passed password for this user."""
+        if self.password is None:
+            return False
+        return CRYPT.check(self.password, password + self.salt)
+
     @sa.orm.validates('email')
     def validate_email(self, key, email):
         if len(email) > EMAIL_MAX_LENGTH:
@@ -200,19 +206,6 @@ class User(Base):
         ).first()
 
         return user
-
-    @classmethod
-    def validate_user(cls, user, password):
-        """Validate the passed password for the specified user."""
-        if not user:
-            return None
-
-        if user.password is None:
-            valid = False
-        else:
-            valid = CRYPT.check(user.password, password + user.salt)
-
-        return valid
 
     @classmethod
     def get_by_username(cls, session, username):

--- a/h/accounts/schemas.py
+++ b/h/accounts/schemas.py
@@ -137,7 +137,7 @@ class LoginSchema(CSRFSchema):
             err['username'] = _('User does not exist.')
             raise err
 
-        if not models.User.validate_user(user, password):
+        if not user.check_password(password):
             err = colander.Invalid(node)
             err['password'] = _('Incorrect password. Please try again.')
             raise err
@@ -272,7 +272,7 @@ class LegacyEmailChangeSchema(CSRFSchema):
         if value.get('email') != value.get('email_confirm'):
             exc['email_confirm'] = _('The emails must match')
 
-        if not models.User.validate_user(user, value.get('password')):
+        if not user.check_password(value.get('password')):
             exc['password'] = _('Incorrect password. Please try again.')
 
         if exc.children:
@@ -316,7 +316,7 @@ class PasswordChangeSchema(CSRFSchema):
         if value.get('new_password') != value.get('new_password_confirm'):
             exc['new_password_confirm'] = _('The passwords must match')
 
-        if not models.User.validate_user(user, value.get('password')):
+        if not user.check_password(value.get('password')):
             exc['password'] = _('Incorrect password. Please try again.')
 
         if exc.children:

--- a/tests/h/accounts/models_test.py
+++ b/tests/h/accounts/models_test.py
@@ -70,6 +70,20 @@ def test_cannot_create_user_with_too_short_password():
     with pytest.raises(ValueError):
         models.User(password='a')
 
+def test_check_password_false_with_null_password():
+    user = models.User(username='barnet')
+
+    assert not user.check_password('anything')
+
+def test_check_password_true_with_matching_password():
+    user = models.User(username='barnet', password='s3cr37')
+
+    assert user.check_password('s3cr37')
+
+def test_check_password_false_with_incorrect_password():
+    user = models.User(username='barnet', password='s3cr37')
+
+    assert not user.check_password('somethingelse')
 
 def test_User_activate_activates_user(db_session):
     user = models.User(username='kiki', email='kiki@kiki.com',

--- a/tests/h/accounts/schemas_test.py
+++ b/tests/h/accounts/schemas_test.py
@@ -143,7 +143,8 @@ def test_LoginSchema_with_bad_username(pyramid_csrf_request, user_model):
 
 def test_LoginSchema_with_bad_password(pyramid_csrf_request, user_model):
     schema = schemas.LoginSchema().bind(request=pyramid_csrf_request)
-    user_model.validate_user.return_value = False
+    user = user_model.get_by_username.return_value
+    user.check_password.return_value = False
 
     with pytest.raises(colander.Invalid) as exc:
         schema.deserialize({
@@ -297,14 +298,14 @@ def test_LegacyEmailChangeSchema_rejects_wrong_password(pyramid_csrf_request, us
     # The email isn't taken
     user_model.get_by_email.return_value = None
     # The password does not check out
-    user_model.validate_user.return_value = False
+    user.check_password.return_value = False
 
     with pytest.raises(colander.Invalid) as exc:
         schema.deserialize({'email': 'foo@bar.com',
                             'email_confirm': 'foo@bar.com',
                             'password': 'flibble'})
 
-    user_model.validate_user.assert_called_once_with(user, 'flibble')
+    user.check_password.assert_called_once_with('flibble')
     assert 'password' in exc.value.asdict()
 
 
@@ -327,14 +328,14 @@ def test_PasswordChangeSchema_rejects_wrong_password(pyramid_csrf_request, user_
     pyramid_csrf_request.authenticated_user = user
     schema = schemas.PasswordChangeSchema().bind(request=pyramid_csrf_request)
     # The password does not check out
-    user_model.validate_user.return_value = False
+    user.check_password.return_value = False
 
     with pytest.raises(colander.Invalid) as exc:
         schema.deserialize({'new_password': 'wibble',
-                            'new_password_confirm': 'wibble!',
+                            'new_password_confirm': 'wibble',
                             'password': 'flibble'})
 
-    user_model.validate_user.assert_called_once_with(user, 'flibble')
+    user.check_password.assert_called_once_with('flibble')
     assert 'password' in exc.value.asdict()
 
 


### PR DESCRIPTION
It is not at all clear to me why this was implemented as a classmethod accepting an instance as its first argument, rather than an instance method.

Making this an instance method makes it substantially easier to use in tests, especially when the user object isn't mocked.