### PR TITLE
Add a userid property to the User model

### DIFF
--- a/h/accounts/models.py
+++ b/h/accounts/models.py
@@ -117,6 +117,10 @@ class User(Base):
         self._username = value
         self.uid = _username_to_uid(value)
 
+    @hybrid_property
+    def userid(self):
+        return u'acct:' + self.username + u'@' + self.authority
+
     email = sa.Column(sa.UnicodeText(), nullable=False, unique=True)
 
     last_login_date = sa.Column(sa.TIMESTAMP(timezone=False),

--- a/tests/h/accounts/models_test.py
+++ b/tests/h/accounts/models_test.py
@@ -50,6 +50,30 @@ def test_cannot_create_case_variant_of_user(db_session):
         db_session.flush()
 
 
+def test_userid_derived_from_username_and_authority():
+    fred = models.User(authority='example.net',
+                       username='fredbloggs',
+                       email='fred@example.com',
+                       password='123')
+
+    assert fred.userid == 'acct:fredbloggs@example.net'
+
+
+def test_userid_as_class_property(db_session):
+    fred = models.User(authority='example.net',
+                       username='fredbloggs',
+                       email='fred@example.com',
+                       password='123')
+    db_session.add(fred)
+    db_session.flush()
+
+    result = (db_session.query(models.User)
+              .filter_by(userid='acct:fredbloggs@example.net')
+              .one())
+
+    assert result == fred
+
+
 def test_cannot_create_user_with_too_short_username():
     with pytest.raises(ValueError):
         models.User(username='aa')


### PR DESCRIPTION
Now that we store the authority part of the userid in the database, we can simply have this as a property of the model instances rather than requiring helper functions all over the place.