### PR TITLE
Remove `h.util.user.userid_from_username`

### DIFF
--- a/h/accounts/services.py
+++ b/h/accounts/services.py
@@ -5,7 +5,6 @@ from __future__ import unicode_literals
 from functools import partial
 
 from h import mailer
-from h import util
 from h._compat import text_type
 from h.emails import signup
 from h.models import Activation, Subscriptions, User
@@ -65,9 +64,7 @@ class UserSignupService(object):
         # FIXME: this is horrible, but is needed until the
         # notification/subscription system is made opt-out rather than opt-in
         # (at least from the perspective of the database).
-        sub_userid = util.user.userid_from_username(user.username,
-                                                    self.default_authority)
-        sub = Subscriptions(uri=sub_userid, type='reply', active=True)
+        sub = Subscriptions(uri=user.userid, type='reply', active=True)
         self.session.add(sub)
 
         # Record a registration with the stats service

--- a/h/accounts/views.py
+++ b/h/accounts/views.py
@@ -16,7 +16,6 @@ from h import i18n
 from h import mailer
 from h import models
 from h import session
-from h import util
 from h.accounts import schemas
 from h.accounts.models import User
 from h.accounts.models import Activation
@@ -124,9 +123,7 @@ class AuthController(object):
     def _login(self, user):
         user.last_login_date = datetime.datetime.utcnow()
         self.request.registry.notify(LoginEvent(self.request, user))
-        userid = util.user.userid_from_username(user.username,
-                                                self.request.auth_domain)
-        headers = security.remember(self.request, userid)
+        headers = security.remember(self.request, user.userid)
         return headers
 
     def _logout(self):

--- a/h/admin/services/user.py
+++ b/h/admin/services/user.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 
 from h import models
 from memex.search import index
-from h.util.user import userid_from_username
 
 
 class UserRenameError(Exception):
@@ -25,9 +24,8 @@ class RenameUserService(object):
     May raise a ValueError if the new username does not validate or
     UserRenameError if the new username is already taken by another account.
     """
-    def __init__(self, session, auth_domain, reindex):
+    def __init__(self, session, reindex):
         self.session = session
-        self.auth_domain = auth_domain
         self.reindex = reindex
 
     def check(self, new_username):
@@ -40,16 +38,17 @@ class RenameUserService(object):
     def rename(self, user, new_username):
         self.check(new_username)
 
-        old_username = user.username
+        old_userid = user.userid
 
         user.username = new_username
-        ids = self._change_annotations(old_username, new_username)
+        new_userid = user.userid
+
+        ids = self._change_annotations(old_userid, new_userid)
 
         self.reindex(ids)
 
-    def _change_annotations(self, old_username, new_username):
-        new_userid = userid_from_username(new_username, self.auth_domain)
-        annotations = self._fetch_annotations(old_username)
+    def _change_annotations(self, old_userid, new_userid):
+        annotations = self._fetch_annotations(old_userid)
 
         ids = set()
         for annotation in annotations:
@@ -58,10 +57,10 @@ class RenameUserService(object):
 
         return ids
 
-    def _fetch_annotations(self, username):
-        userid = userid_from_username(username, self.auth_domain)
-        return self.session.query(models.Annotation).filter(
-            models.Annotation.userid == userid).yield_per(100)
+    def _fetch_annotations(self, userid):
+        return (self.session.query(models.Annotation)
+                .filter(models.Annotation.userid == userid)
+                .yield_per(100))
 
 
 def make_indexer(request):
@@ -78,5 +77,4 @@ def make_indexer(request):
 def rename_user_factory(context, request):
     """Return a RenameUserService instance for the passed context and request."""
     return RenameUserService(session=request.db,
-                             auth_domain=request.auth_domain,
                              reindex=make_indexer(request))

--- a/h/emails/reply_notification.py
+++ b/h/emails/reply_notification.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 from h import links
-from h import util
 
 from pyramid.renderers import render
 
@@ -61,6 +60,4 @@ def generate(request, notification):
 
 def _unsubscribe_token(request, user):
     serializer = request.registry.notification_serializer
-    userid = util.user.userid_from_username(user.username, request.auth_domain)
-    return serializer.dumps({'type': 'reply', 'uri': userid})
-
+    return serializer.dumps({'type': 'reply', 'uri': user.userid})

--- a/h/util/user.py
+++ b/h/util/user.py
@@ -19,14 +19,3 @@ def split_user(userid):
             'domain': match.groups()[1]
         }
     raise ValueError("{userid} isn't a valid userid".format(userid=userid))
-
-
-def userid_from_username(username, auth_domain):
-    """Return the full user ID for the given username.
-
-    For example for username "seanh" return "acct:seanh@hypothes.is"
-    (if we're at domain "hypothes.is").
-
-    """
-    return u"acct:{username}@{domain}".format(username=username,
-                                              domain=auth_domain)

--- a/tests/h/emails/reply_notification_test.py
+++ b/tests/h/emails/reply_notification_test.py
@@ -8,7 +8,6 @@ import pytest
 from h.emails.reply_notification import generate
 from h.models import Annotation
 from h.models import Document, DocumentMeta
-from h.models import User
 from h.notification.reply import Notification
 
 
@@ -177,8 +176,8 @@ class TestGenerate(object):
         return Annotation(target_uri='http://example.org/', **common)
 
     @pytest.fixture
-    def parent_user(self):
-        return User(username='patricia', email='pat@ric.ia')
+    def parent_user(self, factories):
+        return factories.User(username='patricia', email='pat@ric.ia')
 
     @pytest.fixture
     def reply(self):
@@ -191,8 +190,8 @@ class TestGenerate(object):
         return Annotation(target_uri='http://example.org/', **common)
 
     @pytest.fixture
-    def reply_user(self):
-        return User(username='ron', email='ron@thesmiths.com')
+    def reply_user(self, factories):
+        return factories.User(username='ron', email='ron@thesmiths.com')
 
     @pytest.fixture
     def routes(self, pyramid_config):

--- a/tests/h/util/user_test.py
+++ b/tests/h/util/user_test.py
@@ -13,9 +13,3 @@ def test_split_user():
 def test_split_user_no_match():
     with pytest.raises(ValueError):
         user_util.split_user("donkeys")
-
-
-def test_userid_from_username():
-    userid = user_util.userid_from_username('douglas', 'example.com')
-
-    assert userid == 'acct:douglas@example.com'


### PR DESCRIPTION
This helper function is no longer needed, as the user model now has its own "userid" property.

Now that the user model has its own "userid" property, this PR removes all uses of the aforementioned helper function.

_~~This PR depends on #3714 and #3715 and should not be merged until after those two. We should also wait until the associated `User.authority` migrations have been run in production.~~_