### PR TITLE
Respond with 400 for invalid XHR form submissions

### DIFF
--- a/h/form.py
+++ b/h/form.py
@@ -127,6 +127,7 @@ def handle_form_submission(request, form, on_success, on_failure):
         appstruct = form.validate(request.POST.items())
     except deform.ValidationFailure:
         result = on_failure()
+        request.response.status_int = 400
     else:
         result = on_success(appstruct)
 

--- a/tests/functional/test_accounts.py
+++ b/tests/functional/test_accounts.py
@@ -30,7 +30,7 @@ class TestAccountSettings(object):
         email_form['email_confirm'] = 'new_email@example.com'
         email_form['password'] = 'pass'
 
-        res = email_form.submit(xhr=True)
+        res = email_form.submit(xhr=True, status=200)
 
         assert res.body.startswith('<form')
 
@@ -45,6 +45,16 @@ class TestAccountSettings(object):
         res = email_form.submit(xhr=True)
 
         assert res.content_type == 'text/plain'
+
+    def test_submit_invalid_email_form_with_xhr_returns_400(self, app):
+        res = app.get('/account/settings')
+
+        email_form = res.forms['email']
+        email_form['email'] = 'new_email@example.com'
+        email_form['email_confirm'] = 'WRONG'
+        email_form['password'] = 'pass'
+
+        email_form.submit(xhr=True, status=400)
 
     def test_submit_password_form_without_xhr_returns_full_html_page(self,
                                                                      app):
@@ -83,6 +93,16 @@ class TestAccountSettings(object):
         res = password_form.submit(xhr=True)
 
         assert res.content_type == 'text/plain'
+
+    def test_submit_invalid_password_form_with_xhr_returns_400(self, app):
+        res = app.get('/account/settings')
+
+        password_form = res.forms['password']
+        password_form['password'] = 'pass'
+        password_form['new_password'] = 'new_password'
+        password_form['new_password_confirm'] = 'WRONG'
+
+        password_form.submit(xhr=True, status=400)
 
     @pytest.fixture
     def user(self, db_session, factories):

--- a/tests/h/form_test.py
+++ b/tests/h/form_test.py
@@ -191,6 +191,17 @@ class TestHandleFormSubmission(object):
         to_xhr_response.assert_called_once_with(
             pyramid_request, on_failure.return_value, form_)
 
+    def test_if_validation_fails_it_sets_response_status_to_400(self,
+                                                                invalid_form,
+                                                                pyramid_request,
+                                                                to_xhr_response):
+        form.handle_form_submission(pyramid_request,
+                                    invalid_form(),
+                                    mock.sentinel.on_success,
+                                    mock_callable())
+
+        assert to_xhr_response.call_args[0][0].response.status_int == 400
+
     def test_if_validation_fails_it_returns_to_xhr_response(self,
                                                             invalid_form,
                                                             pyramid_request,


### PR DESCRIPTION
For forms that use the handle_form_submission() helper to support
submitting forms via XHR, if the submitted form values are invalid then
set the response status to 400 rather than 200. This allows the client
to handle successful and unsuccessful form submission responses differently.