### PR TITLE
Backend support for search paginator

### DIFF
--- a/h/activity/views.py
+++ b/h/activity/views.py
@@ -10,6 +10,7 @@ from pyramid import httpexceptions
 from pyramid.view import view_config
 
 from h.activity import query
+from h.paginator import paginate
 
 
 @view_config(route_name='activity.search',
@@ -40,6 +41,7 @@ def search(request):
         'total': result.total,
         'aggregations': result.aggregations,
         'timeframes': result.timeframes,
+        'page': paginate(request, result.total),
     }
 
 

--- a/h/admin/views/features.py
+++ b/h/admin/views/features.py
@@ -50,7 +50,7 @@ def features_save(request):
              request_method='GET',
              renderer='h:templates/admin/cohorts.html.jinja2',
              permission='admin_features')
-@paginator.paginate
+@paginator.paginate_query
 def cohorts_index(context, request):
     query = request.db.query(models.FeatureCohort)
     return query.order_by(models.FeatureCohort.name)

--- a/h/admin/views/groups.py
+++ b/h/admin/views/groups.py
@@ -10,7 +10,7 @@ from h import paginator
              request_method='GET',
              renderer='h:templates/admin/groups.html.jinja2',
              permission='admin_groups')
-@paginator.paginate
+@paginator.paginate_query
 def groups_index(context, request):
     return request.db.query(models.Group).order_by(models.Group.created.desc())
 

--- a/h/paginator.py
+++ b/h/paginator.py
@@ -22,11 +22,15 @@ def paginate(request, total, page_size):
     next_ = current_page + 1 if current_page < page_max else None
     prev = current_page - 1 if current_page > 1 else None
 
+    def url_for(page):
+        return request.current_route_path(_query={'page': page})
+
     return {
         'cur': current_page,
         'max': page_max,
         'next': next_,
         'prev': prev,
+        'url_for': url_for,
     }
 
 

--- a/h/paginator.py
+++ b/h/paginator.py
@@ -8,7 +8,7 @@ import math
 PAGE_SIZE = 20
 
 
-def paginate(request, total, page_size):
+def paginate(request, total, page_size=PAGE_SIZE):
     page_max = int(math.ceil(total / page_size))
     page_max = max(1, page_max)  # There's always at least one page.
 

--- a/h/paginator.py
+++ b/h/paginator.py
@@ -8,7 +8,7 @@ import math
 PAGE_SIZE = 20
 
 
-def paginate(wrapped=None, page_size=PAGE_SIZE):
+def paginate_query(wrapped=None, page_size=PAGE_SIZE):
     """
     Decorate a view function, providing basic pagination facilities.
 
@@ -17,7 +17,7 @@ def paginate(wrapped=None, page_size=PAGE_SIZE):
     the results for the current page and page metadata. For example, the simple
     view function
 
-        @paginate
+        @paginate_query
         def my_view(context, request):
             return request.db.query(User)
 
@@ -34,12 +34,12 @@ def paginate(wrapped=None, page_size=PAGE_SIZE):
             }
         }
 
-    You can also call :py:func:`paginate` as a function which returns a
+    You can also call :py:func:`paginate_query` as a function which returns a
     decorator, if you wish to modify the options used by the function:
 
-        paginate = paginator.paginate(page_size=10)
+        paginate = paginator.paginate_query(page_size=10)
 
-        @paginate
+        @paginate_query
         def my_view(...):
             ...
 
@@ -49,7 +49,7 @@ def paginate(wrapped=None, page_size=PAGE_SIZE):
     """
     if wrapped is None:
         def decorator(wrap):
-            return paginate(wrap, page_size=page_size)
+            return paginate_query(wrap, page_size=page_size)
         return decorator
 
     @functools.wraps(wrapped)

--- a/h/paginator.py
+++ b/h/paginator.py
@@ -23,7 +23,9 @@ def paginate(request, total, page_size):
     prev = current_page - 1 if current_page > 1 else None
 
     def url_for(page):
-        return request.current_route_path(_query={'page': page})
+        query = request.params.dict_of_lists()
+        query['page'] = page
+        return request.current_route_path(_query=query)
 
     return {
         'cur': current_page,

--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -80,4 +80,7 @@
     </ol>
   </div>
 
+  {% if page %}
+    {% include "h:templates/includes/paginator.html.jinja2" %}
+  {% endif %}
 {% endblock %}

--- a/h/templates/includes/paginator.html.jinja2
+++ b/h/templates/includes/paginator.html.jinja2
@@ -6,7 +6,7 @@
       </li>
     {% else %}
       <li>
-        <a href="?page={{ page.prev }}" aria-label="{% trans %}Previous{% endtrans %}">
+        <a href="{{ page.url_for(page.prev) }}" aria-label="{% trans %}Previous{% endtrans %}">
           <span aria-hidden="true">&laquo;</span>
         </a>
       </li>
@@ -17,7 +17,7 @@
           <span>{{ n }} <span class="sr-only">({% trans %}current{% endtrans %})</span></span>
         </li>
       {% else %}
-        <li><a href="?page={{ n }}">{{ n }}</a></li>
+        <li><a href="{{ page.url_for(n) }}">{{ n }}</a></li>
       {% endif %}
     {% endfor %}
     {% if page.next is none %}
@@ -26,7 +26,7 @@
       </li>
     {% else %}
       <li>
-        <a href="?page={{ page.next }}" aria-label="{% trans %}Next{% endtrans %}">
+        <a href="{{ page.url_for(page.next) }}" aria-label="{% trans %}Next{% endtrans %}">
           <span aria-hidden="true">&raquo;</span>
         </a>
       </li>

--- a/tests/h/paginator_test.py
+++ b/tests/h/paginator_test.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from h.paginator import paginate
+from h.paginator import paginate_query
 
 
 class FakeQuery(object):
@@ -48,7 +48,7 @@ def fake_view(total):
 def test_paginate_returns_resultset(pyramid_request):
     query, view = fake_view(total=10)
 
-    wrapped = paginate(view)
+    wrapped = paginate_query(view)
     result = wrapped(context=None, request=pyramid_request)
 
     assert result['results'] == query
@@ -60,7 +60,7 @@ def test_paginate_returns_resultset(pyramid_request):
 def test_paginate_includes_total(pyramid_request, total):
     query, view = fake_view(total=total)
 
-    wrapped = paginate(view)
+    wrapped = paginate_query(view)
     result = wrapped(context=None, request=pyramid_request)
 
     assert result['total'] == total
@@ -97,7 +97,7 @@ def test_paginate_returns_offsets_and_limits_resultset(pyramid_request, total, p
     pyramid_request.params = {'page': param}
     query, view = fake_view(total)
 
-    wrapped = paginate(view)
+    wrapped = paginate_query(view)
     result = wrapped(context=None, request=pyramid_request)
 
     assert result['results'].offset_param == offset
@@ -135,7 +135,7 @@ def test_paginate_returns_page_metadata(pyramid_request, total, param, meta):
     query, view = fake_view(total)
     ecur, emax, enext, eprev = meta
 
-    wrapped = paginate(view)
+    wrapped = paginate_query(view)
     result = wrapped(context=None, request=pyramid_request)
 
     assert result['page'] == {
@@ -150,7 +150,7 @@ def test_paginate_params(pyramid_request):
     pyramid_request.params = {'page': 2}
     query, view = fake_view(20)
 
-    decorator = paginate(page_size=5)
+    decorator = paginate_query(page_size=5)
     wrapped = decorator(view)
     result = wrapped(context=None, request=pyramid_request)
 

--- a/tests/h/paginator_test.py
+++ b/tests/h/paginator_test.py
@@ -1,158 +1,201 @@
 # -*- coding: utf-8 -*-
 
+import mock
 import pytest
 
+from h.paginator import paginate
 from h.paginator import paginate_query
 
 
-class FakeQuery(object):
+class TestPaginate(object):
 
-    """
-    A helper class to fake out the fluent API of a SQLAlchemy Query object.
-    """
+    def test_current_page_defaults_to_1(self, pyramid_request):
+        """If there's no 'page' request param it defaults to 1."""
+        pyramid_request.params = {}
 
-    def __init__(self, total):
-        self.total = total
-        self.offset_param = None
-        self.limit_param = None
-        self.all_called = False
+        page = paginate(pyramid_request, 600, 10)
 
-    def count(self):
-        return self.total
+        assert page['cur'] == 1
 
-    def offset(self, n):
-        self.offset_param = n
-        return self
+    @pytest.mark.parametrize('page_param,expected', [
+        # Normally the current page just comes directly from the request's
+        # 'page' param.
+        ('32', 32),
 
-    def limit(self, n):
-        self.limit_param = n
-        return self
+        # If the 'page' param is less than 1 the current page is clipped to 1.
+        ('-3', 1),
+        ('0', 1),
 
-    def all(self):
-        self.all_called = True
-        return self
+        # If the 'page' param isn't a number the current page defaults to 1.
+        ('foo', 1),
 
+        # If the 'page' param is greater than the number of pages the current
+        # page is clipped to the number of pages.
+        ('100', 60),
 
-def fake_view(total):
-    """
-    Make a fake view function and a mock query object for testing.
-    """
-    query = FakeQuery(total)
+    ])
+    def test_current_page(self, pyramid_request, page_param, expected):
+        pyramid_request.params = {'page': page_param}
 
-    def view(context, request):
-        return query
+        page = paginate(
+            pyramid_request,
+            # With 600 items in total and 10 items per page there are 60 pages.
+            600,
+            10)
 
-    return query, view
+        assert page['cur'] == expected
 
+    @pytest.mark.parametrize('total,page_size,expected', [
+        # Normally 'max' is just total / page_size.
+        (600, 10, 60),
 
-def test_paginate_returns_resultset(pyramid_request):
-    query, view = fake_view(total=10)
+        # Total doesn't divide evenly into page_size.
+        (605, 10, 61),
 
-    wrapped = paginate_query(view)
-    result = wrapped(context=None, request=pyramid_request)
+        # If total is less than page size there should be one page.
+        (6, 10, 1),
+    ])
+    def test_max(self, pyramid_request, total, page_size, expected):
+        assert paginate(pyramid_request, total, page_size)['max'] == expected
 
-    assert result['results'] == query
-    # Assert that .all() has been called to turn the query into a list.
-    assert query.all_called
+    @pytest.mark.parametrize('page_param,expected', [
+        # Normally 'next' is simply the current page + 1.
+        ('32', 33),
 
+        # If the current page is the last page then 'next' is None.
+        ('60', None),
+    ])
+    def test_next(self, pyramid_request, page_param, expected):
+        pyramid_request.params = {'page': page_param}
+        assert paginate(pyramid_request, 600, 10)['next'] == expected
 
-@pytest.mark.parametrize('total', [10, 20, 40, 87])
-def test_paginate_includes_total(pyramid_request, total):
-    query, view = fake_view(total=total)
+    @pytest.mark.parametrize('page_param,expected', [
+        # Normally 'prev' is simply the current page - 1.
+        ('32', 31),
 
-    wrapped = paginate_query(view)
-    result = wrapped(context=None, request=pyramid_request)
-
-    assert result['total'] == total
-
-
-@pytest.mark.parametrize('total,param,offset', [
-    # When there are no items:
-    (0, '1', 0),
-    (0, '2', 0),
-
-    # When there are N * PAGE_SIZE items:
-    (20, '1', 0),
-    (20, '2', 0),
-    (40, '1', 0),
-    (40, '2', 20),
-    (40, '3', 20),
-
-    # When the number of items doesn't fit perfectly into N pages:
-    (25, '1', 0),
-    (25, '2', 20),
-    (25, '3', 20),
-
-    # Some extreme cases:
-    (400, '20', 380),
-
-    # Junk data should be discarded:
-    (100, '0', 0),
-    (100, '999e9', 0),
-    (100, 'fish', 0),
-    (400, '-19000', 0),
-    (400, '?????', 0),
-])
-def test_paginate_returns_offsets_and_limits_resultset(pyramid_request, total, param, offset):
-    pyramid_request.params = {'page': param}
-    query, view = fake_view(total)
-
-    wrapped = paginate_query(view)
-    result = wrapped(context=None, request=pyramid_request)
-
-    assert result['results'].offset_param == offset
-    assert result['results'].limit_param == 20
+        # If the current page is the first page then 'prev' is None.
+        ('1', None),
+    ])
+    def test_prev(self, pyramid_request, page_param, expected):
+        pyramid_request.params = {'page': page_param}
+        assert paginate(pyramid_request, 600, 10)['prev'] == expected
 
 
-@pytest.mark.parametrize('total,param,meta', [
-    # When there are no items:
-    (0, '1', (1, 1, None, None)),
-    (0, '2', (1, 1, None, None)),
+@pytest.mark.usefixtures('paginate')
+class TestPaginateQuery(object):
 
-    # When there are N * PAGE_SIZE items:
-    (20, '1', (1, 1, None, None)),
-    (20, '2', (1, 1, None, None)),
-    (40, '1', (1, 2, 2, None)),
-    (40, '2', (2, 2, None, 1)),
-    (40, '3', (2, 2, None, 1)),
+    # The current page that will be returned by paginate().
+    CURRENT_PAGE = 3
 
-    # When the number of items doesn't fit perfectly into N pages:
-    (25, '1', (1, 2, 2, None)),
-    (25, '2', (2, 2, None, 1)),
-    (25, '3', (2, 2, None, 1)),
+    # The page_size argument that will be passed to paginate_query().
+    PAGE_SIZE = 10
 
-    # Some extreme cases:
-    (400, '19', (19, 20, 20, 18)),
+    def test_it_calls_the_wrapped_view_callable(self,
+                                                pyramid_request,
+                                                view_callable,
+                                                wrapped):
+        """It calls the wrapped view callable to get the SQLAlchemy query."""
+        wrapped(mock.sentinel.context, pyramid_request)
 
-    # Junk data should be discarded:
-    (100, '999e9', (1, 5, 2, None)),
-    (100, 'fish',  (1, 5, 2, None)),
-    (400, '-19000', (1, 20, 2, None)),
-    (400, '?????', (1, 20, 2, None)),
-])
-def test_paginate_returns_page_metadata(pyramid_request, total, param, meta):
-    pyramid_request.params = {'page': param}
-    query, view = fake_view(total)
-    ecur, emax, enext, eprev = meta
+        view_callable.assert_called_once_with(mock.sentinel.context,
+                                              pyramid_request)
 
-    wrapped = paginate_query(view)
-    result = wrapped(context=None, request=pyramid_request)
+    def test_it_calls_paginate(self,
+                               paginate,
+                               pyramid_request,
+                               wrapped):
+        """It calls paginate() to get the paginator template data."""
+        wrapped(mock.sentinel.context, pyramid_request)
 
-    assert result['page'] == {
-        'cur': ecur,
-        'max': emax,
-        'next': enext,
-        'prev': eprev,
-    }
+        paginate.assert_called_once_with(pyramid_request,
+                                         mock.sentinel.total,
+                                         self.PAGE_SIZE)
 
+    def test_it_offsets_the_query(self,
+                                  wrapped,
+                                  pyramid_request,
+                                  query):
+        """
+        It offsets the query by the correct amount.
 
-def test_paginate_params(pyramid_request):
-    pyramid_request.params = {'page': 2}
-    query, view = fake_view(20)
+        It offsets the query so that only the results starting from the first
+        result that should be shown on the current page (as returned by
+        paginate()) are fetched from the db.
 
-    decorator = paginate_query(page_size=5)
-    wrapped = decorator(view)
-    result = wrapped(context=None, request=pyramid_request)
+        """
+        wrapped(mock.sentinel.context, pyramid_request)
 
-    assert result['results'].offset_param == 5
-    assert result['results'].limit_param == 5
+        # The current page is 3, and there are 10 results per page, so we
+        # would expect the 20 first results (the first two pages) to be offset.
+        query.offset.assert_called_once_with(20)
+
+    def test_it_limits_the_query(self,
+                                 wrapped,
+                                 pyramid_request,
+                                 query):
+        """
+        It limits the query by the correct amount.
+
+        It limits the query so that only the results up to the last result that
+        should be shown on the current page are fetched from the db.
+
+        """
+        wrapped(mock.sentinel.context, pyramid_request)
+
+        query.limit.assert_called_once_with(self.PAGE_SIZE)
+
+    def test_it_returns_the_query_results(self,
+                                          wrapped,
+                                          pyramid_request):
+        results = wrapped(mock.sentinel.context, pyramid_request)['results']
+
+        assert results == mock.sentinel.all
+
+    def test_it_returns_the_total(self,
+                                  wrapped,
+                                  pyramid_request):
+        total = wrapped(mock.sentinel.context, pyramid_request)['total']
+
+        assert total == mock.sentinel.total
+
+    def test_it_returns_the_paginator_template_data(self,
+                                                    wrapped,
+                                                    paginate,
+                                                    pyramid_request):
+        page = wrapped(mock.sentinel.context, pyramid_request)['page']
+
+        assert page == paginate.return_value
+
+    @pytest.fixture
+    def paginate(self, patch):
+        return patch(
+            'h.paginator.paginate',
+            return_value={
+                'cur': self.CURRENT_PAGE,
+            },
+        )
+
+    @pytest.fixture
+    def query(self):
+        """Return a mock SQLAlchemy Query object."""
+        mock_query = mock.Mock(spec_set=['count', 'offset', 'limit', 'all'])
+        mock_query.count.side_effect = lambda: mock.sentinel.total
+        mock_query.offset.side_effect = lambda n: mock_query
+        mock_query.limit.side_effect = lambda n: mock_query
+        mock_query.all.side_effect = lambda: mock.sentinel.all
+        return mock_query
+
+    @pytest.fixture
+    def view_callable(self, query):
+        """Return a mock view callable for paginate_query() to wrap."""
+        view_callable = mock.Mock(
+            return_value=query,
+            spec_set=['__call__', '__name__'],
+        )
+        view_callable.__name__ = 'mock_view_callable'
+        return view_callable
+
+    @pytest.fixture
+    def wrapped(self, view_callable):
+        """Return a mock view callable wrapped in paginate_query()."""
+        return paginate_query(view_callable, self.PAGE_SIZE)


### PR DESCRIPTION
This pull request refactors `h.paginate` to work with both SQLAlchemy query objects and Elasticsearch search results.

`h.paginate.paginate()` is renamed to `paginate_query()`, but otherwise has the same interface. The only change that needs to be made to the `/admin/groups` and `/admin/features/cohorts` pages that were already using `paginate()` is that they now call `paginate_query()` instead.

A new `paginate()` function containing all the logic that is _not_ specific to handling SQLAlchemy query objects is then factored out of `paginate_query()`. `paginate_query()` now calls `paginate()` for the pagination logic, and only does the SQLAlchemy query handling itself.

A new `paginate_es()` is then added that calls `paginate()` and handles Elasticsearch results.

`paginate_es()` is then used to add a (completely unstyled) paginator control to the `/search` page.

This pull request does not do the HTML and CSS work to style the paginator control on the search page.

This pr does not add the "eliding" feature to the paginator. It does not produce a paginator control that looks like this: `1 ... 149 [150] 151 ... 300`. It will list all 300 pages instead.

This pr does not actually paginate the results on the `/search` page. Pagination does continue to work on the `/admin/groups` and `/admin/features/cohorts` pages, but on the `/search` page you will see the first page's result on every page.

This pr _does_ add one new feature to the paginator (other than handling Es results as input): the page links that it generates preserve any other URL params (such as search queries) that were already in the URL.