### PR TITLE
Remove `h.accounts.get_user`

### DIFF
--- a/h/accounts/__init__.py
+++ b/h/accounts/__init__.py
@@ -55,7 +55,11 @@ def authenticated_user(request):
     :rtype: h.accounts.models.User or None
 
     """
-    user = get_user(request.authenticated_userid, request)
+    if request.authenticated_userid is None:
+        return None
+
+    user_service = request.find_service(name='user')
+    user = user_service.fetch(request.authenticated_userid)
 
     # If the authenticated user doesn't exist in the db then log them out.
     # This happens when we delete a user account but the user still has a
@@ -67,10 +71,10 @@ def authenticated_user(request):
     # an arbitrary request is NOT safe (e.g. POST requests).
     if request.authenticated_userid and not user:
         request.session.invalidate()
-        raise httpexceptions.HTTPFound(
-            location=request.current_route_url())
+        raise httpexceptions.HTTPFound(location=request.url)
 
     return user
+
 
 def includeme(config):
     """A local identity provider."""

--- a/h/accounts/__init__.py
+++ b/h/accounts/__init__.py
@@ -4,9 +4,6 @@ from pyramid import httpexceptions
 
 from h.security import derive_key
 
-from h import util
-from h.accounts import models
-
 
 class Error(Exception):
 
@@ -25,28 +22,6 @@ class JSONError(Error):
     """
 
     pass
-
-
-def get_user(userid, request):
-    """Return the User object for the given userid, or None.
-
-    This will also return None if the given userid is None, if it isn't a valid
-    userid, if its domain doesn't match the site's domain, or if there's just
-    no user with that userid.
-
-    """
-    if userid is None:
-        return None
-
-    try:
-        parts = util.user.split_user(userid)
-    except ValueError:
-        return
-
-    if parts['domain'] != request.auth_domain:
-        return None
-
-    return models.User.get_by_username(request.db, parts['username'])
 
 
 def authenticated_user(request):

--- a/h/auth/util.py
+++ b/h/auth/util.py
@@ -1,9 +1,7 @@
 # -*- coding: utf-8 -*-
 
-from pyramid import authorization
 from pyramid import security
 
-from h import accounts
 from h.auth import role
 
 
@@ -23,7 +21,8 @@ def groupfinder(userid, request):
     :returns: additional principals for the user (possibly empty) or None
     :rtype: list or None
     """
-    user = accounts.get_user(userid, request)
+    user_service = request.find_service(name='user')
+    user = user_service.fetch(userid)
     if user is None:
         return None
 

--- a/h/groups/services.py
+++ b/h/groups/services.py
@@ -3,7 +3,6 @@
 from functools import partial
 
 from h import session
-from h.accounts import get_user
 from h.models import Group
 
 
@@ -69,10 +68,9 @@ class GroupsService(object):
 
 def groups_factory(context, request):
     """Return a GroupsService instance for the passed context and request."""
-    def user_fetcher(userid):
-        return get_user(userid, request)
+    user_service = request.find_service(name='user')
     return GroupsService(session=request.db,
-                         user_fetcher=user_fetcher,
+                         user_fetcher=user_service.fetch,
                          publish=partial(_publish, request))
 
 

--- a/h/notification/reply.py
+++ b/h/notification/reply.py
@@ -3,7 +3,6 @@
 from collections import namedtuple
 import logging
 
-from h import accounts
 from memex import storage
 from h.notification.models import Subscriptions
 
@@ -68,14 +67,16 @@ def get_notification(request, annotation, action):
     if parent is None:
         return
 
+    user_service = request.find_service(name='user')
+
     # If the parent user doesn't exist (anymore), we can't send an email.
-    parent_user = accounts.get_user(parent.userid, request)
+    parent_user = user_service.fetch(parent.userid)
     if parent_user is None:
         return
 
     # If the reply user doesn't exist (anymore), we can't send an email, but
     # this would be super weird, so log a warning.
-    reply_user = accounts.get_user(reply.userid, request)
+    reply_user = user_service.fetch(reply.userid)
     if reply_user is None:
         log.warn('user who just replied no longer exists: %s', reply.userid)
         return

--- a/tests/h/accounts/__init___test.py
+++ b/tests/h/accounts/__init___test.py
@@ -59,74 +59,74 @@ def test_get_user_returns_user(util, get_by_username, pyramid_request):
     assert result == get_by_username.return_value
 
 
-authenticated_user_fixtures = pytest.mark.usefixtures('get_user')
+@pytest.mark.usefixtures('user_service')
+class TestAuthenticatedUser(object):
+    def test_fetches_user_using_service(self,
+                                        factories,
+                                        pyramid_config,
+                                        pyramid_request,
+                                        user_service):
+        pyramid_config.testing_securitypolicy('userid')
+        user_service.fetch.return_value = factories.User()
 
-
-@authenticated_user_fixtures
-def test_authenticated_user_calls_get_user(get_user, pyramid_config, pyramid_request):
-    """It should call get_user() correctly."""
-    pyramid_config.testing_securitypolicy('userid')
-
-    accounts.authenticated_user(pyramid_request)
-
-    get_user.assert_called_once_with('userid', pyramid_request)
-
-
-@authenticated_user_fixtures
-def test_authenticated_user_invalidates_session_if_user_does_not_exist(get_user, pyramid_config, pyramid_request):
-    """It should log the user out if they no longer exist in the db."""
-    pyramid_request.current_route_url = lambda: '/'
-    pyramid_request.session.invalidate = mock.Mock()
-    pyramid_config.testing_securitypolicy('userid')
-    get_user.return_value = None
-
-    try:
-        accounts.authenticated_user(pyramid_request)
-    except Exception:
-        pass
-
-    pyramid_request.session.invalidate.assert_called_once_with()
-
-
-@authenticated_user_fixtures
-def test_authenticated_user_does_not_invalidate_session_if_not_authenticated(get_user, pyramid_config, pyramid_request):
-    """
-    If authenticated_userid is None it shouldn't invalidate the session.
-
-    Even though the user with id None obviously won't exist in the db.
-
-    This also tests that it doesn't raise a redirect in this case.
-
-    """
-    pyramid_request.current_route_url = lambda: '/'
-    pyramid_request.session.invalidate = mock.Mock()
-    pyramid_config.testing_securitypolicy()
-    get_user.return_value = None
-
-    accounts.authenticated_user(pyramid_request)
-
-    assert not pyramid_request.session.invalidate.called
-
-
-@authenticated_user_fixtures
-def test_authenticated_user_redirects_if_user_does_not_exist(get_user, pyramid_config, pyramid_request):
-    pyramid_request.current_route_url = lambda: '/the/page/that/I/was/on'
-    pyramid_config.testing_securitypolicy('userid')
-    get_user.return_value = None
-
-    with pytest.raises(httpexceptions.HTTPFound) as exc:
         accounts.authenticated_user(pyramid_request)
 
-    assert exc.value.location == '/the/page/that/I/was/on', (
-        'It should redirect to the same page that was requested')
+        user_service.fetch.assert_called_once_with('userid')
 
+    def test_invalidates_session_if_user_does_not_exist(self,
+                                                        pyramid_config,
+                                                        pyramid_request):
+        """It should log the user out if they no longer exist in the db."""
+        pyramid_request.session.invalidate = mock.Mock()
+        pyramid_config.testing_securitypolicy('userid')
 
-@authenticated_user_fixtures
-def test_authenticated_user_returns_user_from_get_user(get_user, pyramid_config, pyramid_request):
-    """It should return the user from get_user()."""
-    pyramid_config.testing_securitypolicy('userid')
+        try:
+            accounts.authenticated_user(pyramid_request)
+        except Exception:
+            pass
 
-    assert accounts.authenticated_user(pyramid_request) == get_user.return_value
+        pyramid_request.session.invalidate.assert_called_once_with()
+
+    def test_does_not_invalidate_session_if_not_authenticated(self,
+                                                              pyramid_config,
+                                                              pyramid_request):
+        """
+        If authenticated_userid is None it shouldn't invalidate the session.
+
+        Even though the user with id None obviously won't exist in the db.
+
+        This also tests that it doesn't raise a redirect in this case.
+
+        """
+        pyramid_request.session.invalidate = mock.Mock()
+
+        accounts.authenticated_user(pyramid_request)
+
+        assert not pyramid_request.session.invalidate.called
+
+    def test_redirects_if_user_does_not_exist(self,
+                                              pyramid_config,
+                                              pyramid_request):
+        pyramid_request.url = '/the/page/that/I/was/on'
+        pyramid_config.testing_securitypolicy('userid')
+
+        with pytest.raises(httpexceptions.HTTPFound) as exc:
+            accounts.authenticated_user(pyramid_request)
+
+        assert exc.value.location == '/the/page/that/I/was/on', (
+            'It should redirect to the same page that was requested')
+
+    def test_returns_user(self,
+                          factories,
+                          pyramid_config,
+                          pyramid_request,
+                          user_service):
+        pyramid_config.testing_securitypolicy('userid')
+        user = user_service.fetch.return_value = factories.User()
+
+        result = accounts.authenticated_user(pyramid_request)
+
+        assert result == user
 
 
 @pytest.fixture
@@ -140,5 +140,8 @@ def get_by_username(patch):
 
 
 @pytest.fixture
-def get_user(patch):
-    return patch('h.accounts.get_user')
+def user_service(pyramid_config):
+    service = mock.Mock(spec_set=['fetch'])
+    service.fetch.return_value = None
+    pyramid_config.register_service(service, name='user')
+    return service

--- a/tests/h/accounts/__init___test.py
+++ b/tests/h/accounts/__init___test.py
@@ -5,59 +5,6 @@ from pyramid import httpexceptions
 
 from h import accounts
 
-# The fixtures required to mock all of get_user()'s dependencies.
-get_user_fixtures = pytest.mark.usefixtures('util', 'get_by_username')
-
-
-@get_user_fixtures
-def test_get_user_calls_split_user(util):
-    """It should call split_user() once with the given userid."""
-    util.user.split_user.return_value = {
-        'username': 'fred', 'domain': 'hypothes.is'}
-
-    accounts.get_user('acct:fred@hypothes.is', mock.Mock())
-
-    util.user.split_user.assert_called_once_with('acct:fred@hypothes.is')
-
-
-@get_user_fixtures
-def test_get_user_returns_None_if_split_user_raises_ValueError(util):
-    util.user.split_user.side_effect = ValueError
-
-    assert accounts.get_user('userid', mock.Mock()) is None
-
-
-@get_user_fixtures
-def test_get_user_returns_None_if_domain_does_not_match(util, pyramid_request):
-    util.user.split_user.return_value = {
-        'username': 'username', 'domain': 'other'}
-
-    assert accounts.get_user('userid', pyramid_request) is None
-
-
-@get_user_fixtures
-def test_get_user_calls_get_by_username(util, get_by_username, pyramid_request):
-    """It should call get_by_username() once with the username."""
-    pyramid_request.auth_domain = 'hypothes.is'
-    util.user.split_user.return_value = {
-        'username': 'username', 'domain': 'hypothes.is'}
-
-    accounts.get_user('acct:username@hypothes.is', pyramid_request)
-
-    get_by_username.assert_called_once_with(pyramid_request.db, 'username')
-
-
-@get_user_fixtures
-def test_get_user_returns_user(util, get_by_username, pyramid_request):
-    """It should return the result from get_by_username()."""
-    pyramid_request.auth_domain = 'hypothes.is'
-    util.user.split_user.return_value = {
-        'username': 'username', 'domain': 'hypothes.is'}
-
-    result = accounts.get_user('acct:username@hypothes.is', pyramid_request)
-
-    assert result == get_by_username.return_value
-
 
 @pytest.mark.usefixtures('user_service')
 class TestAuthenticatedUser(object):
@@ -127,16 +74,6 @@ class TestAuthenticatedUser(object):
         result = accounts.authenticated_user(pyramid_request)
 
         assert result == user
-
-
-@pytest.fixture
-def util(patch):
-    return patch('h.accounts.util')
-
-
-@pytest.fixture
-def get_by_username(patch):
-    return patch('h.accounts.models.User.get_by_username', autospec=False)
 
 
 @pytest.fixture

--- a/tests/h/auth/util_test.py
+++ b/tests/h/auth/util_test.py
@@ -2,6 +2,7 @@
 
 from collections import namedtuple
 import pytest
+import mock
 
 from pyramid import security
 
@@ -35,8 +36,8 @@ FakeGroup = namedtuple('FakeGroup', ['pubid'])
     (FakeUser(admin=True, staff=True, groups=[FakeGroup('donkeys')]),
      ['group:donkeys', role.Admin, role.Staff]),
 ))
-def test_groupfinder(user, principals, accounts, pyramid_request):
-    accounts.get_user.return_value = user
+def test_groupfinder(user, principals, pyramid_request, user_service):
+    user_service.fetch.return_value = user
 
     result = util.groupfinder('acct:jiji@hypothes.is', pyramid_request)
 
@@ -69,5 +70,8 @@ def test_translate_annotation_principals(p_in, p_out):
 
 
 @pytest.fixture
-def accounts(patch):
-    return patch('h.auth.util.accounts')
+def user_service(pyramid_config):
+    service = mock.Mock(spec_set=['fetch'])
+    service.fetch.return_value = None
+    pyramid_config.register_service(service, name='user')
+    return service

--- a/tests/h/groups/services_test.py
+++ b/tests/h/groups/services_test.py
@@ -113,6 +113,7 @@ class TestGroupsService(object):
         publish.assert_called_once_with('group-leave', 'abc123', 'cazimir')
 
 
+@pytest.mark.usefixtures('user_service')
 class TestGroupsFactory(object):
     def test_returns_groups_service(self, pyramid_request):
         svc = groups_factory(None, pyramid_request)
@@ -124,13 +125,12 @@ class TestGroupsFactory(object):
 
         assert svc.session == pyramid_request.db
 
-    def test_wraps_get_user_as_user_fetcher(self, patch, pyramid_request):
-        get_user = patch('h.groups.services.get_user')
+    def test_wraps_user_service_as_user_fetcher(self, pyramid_request, user_service):
         svc = groups_factory(None, pyramid_request)
 
         svc.user_fetcher('foo')
 
-        get_user.assert_called_once_with('foo', pyramid_request)
+        user_service.fetch.assert_called_once_with('foo')
 
     def test_provides_realtime_publisher_as_publish(self, patch, pyramid_request):
         pyramid_request.realtime = mock.Mock(spec_set=['publish_user'])
@@ -146,6 +146,14 @@ class TestGroupsFactory(object):
             'userid': 'theresa',
             'group': 'abc123',
         })
+
+
+@pytest.fixture
+def user_service(pyramid_config):
+    service = mock.Mock(spec_set=['fetch'])
+    service.fetch.return_value = None
+    pyramid_config.register_service(service, name='user')
+    return service
 
 
 @pytest.fixture


### PR DESCRIPTION
This PR updates a bunch of code that used `h.accounts.get_user` to instead use the `UserService` (added in #3717) and removes `get_user`.