### PR TITLE
Don't set passwords when not necessary in tests

### DIFF
--- a/h/migrations/versions/504a6a4db06d_relax_password_constraints.py
+++ b/h/migrations/versions/504a6a4db06d_relax_password_constraints.py
@@ -1,0 +1,27 @@
+"""
+Relax password constraints
+
+Revision ID: 504a6a4db06d
+Revises: de42d613c18d
+Create Date: 2016-08-18 22:32:51.092582
+"""
+
+from __future__ import unicode_literals
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = '504a6a4db06d'
+down_revision = 'de42d613c18d'
+
+
+def upgrade():
+    op.alter_column('user', 'password', nullable=True)
+    op.alter_column('user', 'password_updated', nullable=True, server_default=None)
+    op.alter_column('user', 'salt', nullable=True)
+
+def downgrade():
+    op.alter_column('user', 'password', nullable=False)
+    op.alter_column('user', 'password_updated', nullable=False, server_default=sa.func.now())
+    op.alter_column('user', 'salt', nullable=False)

--- a/tests/common/factories.py
+++ b/tests/common/factories.py
@@ -197,7 +197,6 @@ class User(factory.Factory):
     authority = 'example.com'
     username = factory.Faker('user_name')
     email = factory.Faker('email')
-    password = factory.Faker('password')
 
     @factory.lazy_attribute
     def uid(self):

--- a/tests/h/accounts/models_test.py
+++ b/tests/h/accounts/models_test.py
@@ -21,12 +21,10 @@ def test_activation_has_asciinumeric_code(db_session):
 def test_cannot_create_dot_variant_of_user(db_session):
     fred = models.User(authority='example.com',
                        username='fredbloggs',
-                       email='fred@example.com',
-                       password='123')
+                       email='fred@example.com')
     fred2 = models.User(authority='example.com',
                         username='fred.bloggs',
-                        email='fred@example.org',
-                        password='456')
+                        email='fred@example.org')
 
     db_session.add(fred)
     db_session.add(fred2)
@@ -37,12 +35,10 @@ def test_cannot_create_dot_variant_of_user(db_session):
 def test_cannot_create_case_variant_of_user(db_session):
     bob = models.User(authority='example.com',
                       username='BobJones',
-                      email='bob@example.com',
-                      password='123')
+                      email='bob@example.com')
     bob2 = models.User(authority='example.com',
                        username='bobjones',
-                       email='bob@example.org',
-                       password='456')
+                       email='bob@example.org')
 
     db_session.add(bob)
     db_session.add(bob2)
@@ -53,8 +49,7 @@ def test_cannot_create_case_variant_of_user(db_session):
 def test_userid_derived_from_username_and_authority():
     fred = models.User(authority='example.net',
                        username='fredbloggs',
-                       email='fred@example.com',
-                       password='123')
+                       email='fred@example.com')
 
     assert fred.userid == 'acct:fredbloggs@example.net'
 
@@ -62,8 +57,7 @@ def test_userid_derived_from_username_and_authority():
 def test_userid_as_class_property(db_session):
     fred = models.User(authority='example.net',
                        username='fredbloggs',
-                       email='fred@example.com',
-                       password='123')
+                       email='fred@example.com')
     db_session.add(fred)
     db_session.flush()
 
@@ -116,8 +110,7 @@ def test_check_password_false_with_incorrect_password():
 def test_User_activate_activates_user(db_session):
     user = models.User(authority='example.com',
                        username='kiki',
-                       email='kiki@kiki.com',
-                       password='password')
+                       email='kiki@kiki.com')
     activation = models.Activation()
     user.activation = activation
     db_session.add(user)

--- a/tests/h/accounts/services_test.py
+++ b/tests/h/accounts/services_test.py
@@ -37,12 +37,12 @@ class TestUserService(object):
 
 class TestUserSignupService(object):
     def test_signup_returns_user(self, svc):
-        user = svc.signup(username='foo', email='foo@bar.com', password='baz')
+        user = svc.signup(username='foo', email='foo@bar.com')
 
         assert isinstance(user, User)
 
     def test_signup_creates_user_in_db(self, db_session, svc):
-        svc.signup(username='foo', email='foo@bar.com', password='baz')
+        svc.signup(username='foo', email='foo@bar.com')
 
         db_session.commit()
         db_session.close()
@@ -52,32 +52,31 @@ class TestUserSignupService(object):
         assert user is not None
 
     def test_signup_creates_activation_for_user(self, svc):
-        user = svc.signup(username='foo', email='foo@bar.com', password='baz')
+        user = svc.signup(username='foo', email='foo@bar.com')
 
         assert isinstance(user.activation, Activation)
 
     def test_signup_sets_default_authority(self, svc):
-        user = svc.signup(username='foo', email='foo@bar.com', password='baz')
+        user = svc.signup(username='foo', email='foo@bar.com')
 
         assert user.authority == 'example.org'
 
     def test_signup_allows_authority_override(self, svc):
         user = svc.signup(username='foo',
                           email='foo@bar.com',
-                          password='baz',
                           authority='bar-client.com')
 
         assert user.authority == 'bar-client.com'
 
     def test_passes_user_info_to_signup_email(self, svc, signup_email):
-        user = svc.signup(username='foo', email='foo@bar.com', password='baz')
+        user = svc.signup(username='foo', email='foo@bar.com')
 
         signup_email.assert_called_once_with(id=user.id,
                                              email='foo@bar.com',
                                              activation_code=user.activation.code)
 
     def test_signup_sends_email(self, mailer, svc):
-        svc.signup(username='foo', email='foo@bar.com', password='baz')
+        svc.signup(username='foo', email='foo@bar.com')
 
         mailer.send.delay.assert_called_once_with(['test@example.com'],
                                                   'My subject',
@@ -85,7 +84,7 @@ class TestUserSignupService(object):
                                                   '<p>HTML</p>')
 
     def test_signup_creates_reply_notification_subscription(self, db_session, svc):
-        svc.signup(username='foo', email='foo@bar.com', password='baz')
+        svc.signup(username='foo', email='foo@bar.com')
 
         sub = (db_session.query(Subscriptions)
                .filter_by(uri='acct:foo@example.org')
@@ -96,7 +95,7 @@ class TestUserSignupService(object):
     def test_signup_records_stats_if_present(self, svc, stats):
         svc.stats = stats
 
-        svc.signup(username='foo', email='foo@bar.com', password='baz')
+        svc.signup(username='foo', email='foo@bar.com')
 
         stats.incr.assert_called_once_with('auth.local.register')
 

--- a/tests/h/features/client_test.py
+++ b/tests/h/features/client_test.py
@@ -146,7 +146,7 @@ class TestClient(object):
 
     @pytest.fixture
     def user(self):
-        return User(username='foo', email='foo@example.com', password='bar')
+        return User(username='foo', email='foo@example.com')
 
     @pytest.fixture
     def cohort(self):


### PR DESCRIPTION
Setting a password on a user is necessarily a slow operation. Doing this many times for test users substantially slows down the running of the test suite.

This PR:

1. relaxes the current database constraints on the password fields (see 04c4d79)
2. removes all the places in tests where we're setting passwords for users unnecessarily

In my testing this results in a ~1.7× speedup for our current test suite:

Timings for three runs of `tox -e py27-h` before this change:

    36s, 36s, 36s

Timings for three runs of `tox -e py27-h` after this change:

    20s, 21s, 22s

Speedup = 36s/21s ≈ 1.7×