### PR TITLE
Use passlib for managing passwords

### DIFF
--- a/h/security.py
+++ b/h/security.py
@@ -1,9 +1,28 @@
 # -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 from cryptography.hazmat.backends import default_backend
+from passlib.context import CryptContext
 
 backend = default_backend()
+
+# We use a passlib CryptContext to define acceptable hashing algorithms for
+# passwords. This allows us to easily
+#
+# - migrate to new hashing algorithms
+# - update the number of rounds used when hashing passwords
+#
+# simply by using the verify_and_update method of the CryptContext object. See
+# the passlib documentation on hash migration for more details:
+#
+#   https://pythonhosted.org/passlib/lib/passlib.context-tutorial.html#context-migration-example
+#
+password_context = CryptContext(schemes=['bcrypt'],
+                                bcrypt__ident='2b',
+                                bcrypt__min_rounds=12)
 
 
 def derive_key(key_material, info, algorithm=None, length=None):

--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,7 @@
 PyJWT
 SQLAlchemy
 alembic
+bcrypt
 celery
 certifi
 cffi
@@ -16,6 +17,7 @@ itsdangerous
 jsonpointer == 1.0
 jsonschema
 kombu
+passlib
 psycogreen
 psycopg2
 pyramid < 1.7

--- a/requirements.in
+++ b/requirements.in
@@ -6,7 +6,6 @@ celery
 certifi
 cffi
 click
-cryptacular
 cryptography
 deform < 1.0
 deform-jinja2

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@
 alembic==0.8.7
 amqp==1.4.9               # via kombu
 anyjson==0.3.3            # via kombu
+bcrypt==3.1.0
 billiard==3.3.0.23        # via celery
 bleach==1.4.3
 celery==3.1.23
@@ -40,6 +41,7 @@ kombu==3.0.35
 Mako==1.0.4               # via alembic
 MarkupSafe==0.23          # via jinja2, mako, pyramid-jinja2
 mistune==0.7.3
+passlib==1.6.5
 PasteDeploy==1.5.2        # via pyramid
 pbkdf2==1.3               # via cryptacular
 peppercorn==0.5           # via deform
@@ -65,7 +67,7 @@ raven==5.10.2
 redis==2.10.5             # via pyramid-redis-sessions
 repoze.lru==0.6           # via pyramid
 repoze.sendmail==4.1
-six==1.10.0               # via bleach, cryptography, html5lib, python-dateutil
+six==1.10.0               # via bcrypt, bleach, cryptography, html5lib, python-dateutil
 SQLAlchemy==1.0.14        # via alembic, zope.sqlalchemy
 statsd==3.2.1
 transaction==1.6.1        # via pyramid-tm, repoze.sendmail, zope.sqlalchemy

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,6 @@ Chameleon==2.24           # via deform
 click==6.6
 colander==1.3.1           # via deform
 contextlib2==0.5.3        # via raven
-cryptacular==1.4.1
 cryptography==1.4
 deform-jinja2==0.5
 deform==0.9.9
@@ -43,7 +42,6 @@ MarkupSafe==0.23          # via jinja2, mako, pyramid-jinja2
 mistune==0.7.3
 passlib==1.6.5
 PasteDeploy==1.5.2        # via pyramid
-pbkdf2==1.3               # via cryptacular
 peppercorn==0.5           # via deform
 psycogreen==1.0
 psycopg2==2.6.2
@@ -85,4 +83,4 @@ zope.sqlalchemy==0.7.7
 
 # The following packages are commented out because they are
 # considered to be unsafe in a requirements file:
-# setuptools                # via cryptacular, cryptography, pyramid, repoze.sendmail, zope.deprecation, zope.interface, zope.sqlalchemy
+# setuptools                # via cryptography, pyramid, repoze.sendmail, zope.deprecation, zope.interface, zope.sqlalchemy

--- a/tests/h/security_test.py
+++ b/tests/h/security_test.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from passlib.context import CryptContext
+
+from h.security import password_context
+
+
+def test_password_context():
+    assert isinstance(password_context, CryptContext)
+    assert len(password_context.schemes()) > 0


### PR DESCRIPTION
There are a couple of problems with our current password storage -- none of
these are obviously security problems, but they are a bit ugly and it would be
nice to fix them.

This PR replaces cryptacular -- a perfectly serviceable library but one which
hasn't been updated in 4 years and has no support for newer version of the
bcrypt algorithm -- with [passlib][1] and [bcrypt][2].

This gives us a couple of things:

- We are no longer (for new passwords) "double-salting" them -- eventually we
  should be able to remove the `user.salt` column from the database, as the
  password hashes include an automatically generated salt.

- The salt now changes whenever the password changes. This happened before, but
  it wasn't obvious that this was the case, because of the confusion around
  double-salting: only the cryptacular-generated salt changed, but User.salt
  did not.

- We can now easily change the number of rounds used by bcrypt, or even the
  entire hashing algorithm, simply by modifying the password context in
  `h.security`. No changes to the model are required.

This change includes code which will automatically handle upgrading old-style
passwords (those with a redundant salt) to newer bcrypt '2b' hashes (with 12
instead of 10 rounds of bcrypt) when users log in.

[1]: https://pythonhosted.org/passlib/
[2]: https://github.com/pyca/bcrypt/