### PR TITLE
Fix SASS watch & rebuild (take 2)

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -165,10 +165,12 @@ gulp.task('build-css', ['build-vendor-css'], function () {
   return Promise.all(styleBundleEntryFiles.map(buildStyleBundle));
 });
 
-gulp.task('watch-css', ['build-vendor-css'], function () {
-  styleBundleEntryFiles.forEach(function (input) {
-    buildStyleBundle(input, {watch: true});
-  });
+gulp.task('watch-css', function () {
+  // Build initial CSS bundles. This is done rather than adding 'build-css' as
+  // a dependency of this task so that the process continues in the event of an
+  // error.
+  Promise.all(styleBundleEntryFiles.map(buildStyleBundle)).catch(gulpUtil.log);
+  gulp.watch('h/static/styles/**/*.scss', ['build-css']);
 });
 
 var fontFiles = 'h/static/styles/vendor/fonts/*.woff';

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -13,6 +13,7 @@ var endOfStream = require('end-of-stream');
 var gulp = require('gulp');
 var gulpIf = require('gulp-if');
 var gulpUtil = require('gulp-util');
+var newer = require('gulp-newer');
 var postcss = require('gulp-postcss');
 var postcssURL = require('postcss-url');
 var svgmin = require('gulp-svgmin');
@@ -139,6 +140,7 @@ gulp.task('build-vendor-css', function () {
   });
 
   return gulp.src(vendorCSSFiles)
+    .pipe(newer(STYLE_DIR))
     .pipe(postcss([cssURLRewriter]))
     .pipe(gulp.dest(STYLE_DIR));
 });

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "gulp-batch": "^1.0.5",
     "gulp-changed": "^1.3.0",
     "gulp-if": "^2.0.0",
+    "gulp-newer": "^1.2.0",
     "gulp-postcss": "^6.1.0",
     "gulp-svgmin": "^1.2.2",
     "gulp-util": "^3.0.7",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   "devDependencies": {
     "chai": "^3.5.0",
     "check-dependencies": "^0.12.0",
-    "chokidar": "^1.6.0",
     "diff": "^2.2.2",
     "eslint": "^3.1.1",
     "eslint-config-hypothesis": "^1.0.0",

--- a/scripts/gulp/create-style-bundle.js
+++ b/scripts/gulp/create-style-bundle.js
@@ -60,6 +60,9 @@ function compileSass(options) {
   }).then(result => {
     fs.writeFileSync(options.output, result.css);
     fs.writeFileSync(sourcemapPath, result.map.toString());
+  }).catch(srcErr => {
+    // Rewrite error so that the message property contains the file path
+    throw new Error(`SASS build error in ${srcErr.file}: ${srcErr.message}`);
   });
 }
 

--- a/scripts/gulp/create-style-bundle.js
+++ b/scripts/gulp/create-style-bundle.js
@@ -2,8 +2,6 @@
 
 /* eslint-disable no-console */
 
-/* global Set */
-
 var fs = require('fs');
 var path = require('path');
 
@@ -33,7 +31,6 @@ function compileSass(options) {
     }));
   }
 
-  var start = Date.now();
   var sassBuild = new Promise((resolve, reject) => {
     sass.render({
       file: options.input,
@@ -63,105 +60,7 @@ function compileSass(options) {
   }).then(result => {
     fs.writeFileSync(options.output, result.css);
     fs.writeFileSync(sourcemapPath, result.map.toString());
-
-    return {
-      stats: {
-        duration: Date.now() - start,
-      },
-    };
   });
 }
 
-function logError(err) {
-  log(`SASS build error: ${err.message}`);
-}
-
-/**
- * Update the set of files watched by a chokidar file watcher.
- *
- * @param {FSWatcher} watcher - chokidar file watcher
- * @param {Set.<string>} currentPaths - Current set of watched files
- * @param {Set.<string>} newPaths - New set of files to watch
- */
-function updateWatchedFiles(watcher, currentPaths, newPaths) {
-  newPaths.forEach(path => {
-    if (!currentPaths.has(path)) {
-      watcher.add(path);
-    }
-  });
-  currentPaths.forEach(path => {
-    if (!newPaths.has(path)) {
-      watcher.unwatch(path);
-    }
-  });
-}
-
-/**
- * Compile a SASS file and rebuild when any of the included files changes.
- *
- * This is similar to `watchify` for Browserify JS bundles, in that it makes
- * use of the dependency information (in the form of `@import` statements) in
- * the root SCSS file to know which files to watch. As a result, it will
- * automatically start watching newly added imports.
- *
- * See `compileSass()` for a description of the `options` parameter.
- */
-function compileSassAndWatchForChanges(options) {
-  // chokidar dependency is loaded lazily so that it is not required in Docker
-  // image builds
-  var chokidar = require('chokidar');
-
-  var watcher = chokidar.watch(options.input);
-  var watchedFiles = new Set();
-
-  var isBuilding = false;
-  var pendingBuild = false;
-
-  function rebuild() {
-    pendingBuild = false;
-    isBuilding = true;
-
-    compileSass(options)
-      .then(result => {
-        log(`Built ${options.output} (${result.stats.duration}ms)`);
-        var includedFiles = new Set(result.stats.includedFiles);
-        updateWatchedFiles(watcher, watchedFiles, includedFiles);
-        watchedFiles = includedFiles;
-      })
-      .catch(logError)
-      .then(() => {
-        isBuilding = false;
-        if (pendingBuild) {
-          rebuild();
-        }
-      });
-  }
-
-  watcher.on('change', path => {
-    log(`${path} changed. Rebuilding ${options.output}`);
-
-    if (!isBuilding) {
-      rebuild();
-    } else {
-      pendingBuild = true;
-    }
-  });
-
-  rebuild();
-}
-
-/**
- * Create a CSS bundle from a SASS input file.
- */
-function createStyleBundle(options) {
-  if (options.watch) {
-    compileSassAndWatchForChanges(options);
-
-    // A `watch` build never terminates
-    return new Promise(() => {});
-  } else {
-    return compileSass(options);
-  }
-}
-
-module.exports = createStyleBundle;
+module.exports = compileSass;


### PR DESCRIPTION
This fixes CSS rebuilding in the `gulp watch` task while preserving the behavior change from before to avoid killing the asset build process if the SASS build fails.

The actual problem was that the `compileSass()` function was not returning the list of imported files after some last-minute refactoring, so only the root files in the bundle ever got watched. This PR fixes the problem by switching back to just using a dumb glob watch and rebuilding all style bundles whenever any `.scss` file changes, with a small optimization to avoid reprocessing vendor CSS when nothing changed (see second commit).

`watchify`-like smartness where a rebuild only happens when a bundle dependency changes is nice, but we can get away without that for the time being.

----

Testing:
  1. Run `make dev`
  2. Add, edit or remove style files in `h/static/styles` and check that `build-css` task runs
  3. Make changes with errors in style files (eg. Add an a new line with `{}` to any imported file) and check that asset build continues running