### PR TITLE
Execute one query to retrieve all feature flag data

### DIFF
--- a/h/features/models.py
+++ b/h/features/models.py
@@ -73,14 +73,17 @@ class Feature(Base):
     @classmethod
     def all(cls, session):
         """Fetch (or, if necessary, create) rows for all defined features."""
-        results = []
-        for name in FEATURES:
-            feat = session.query(cls).filter(cls.name == name).first()
-            if feat is None:
-                feat = cls(name=name)
-                session.add(feat)
-            results.append(feat)
-        return results
+        features = {f.name: f
+                    for f in session.query(cls)
+                    if f.name in FEATURES}
+
+        # Add missing features
+        missing = [cls(name=n)
+                   for n in FEATURES
+                   if n not in features]
+        session.add_all(missing)
+
+        return list(features.values()) + missing
 
     @classmethod
     def remove_old_flags(cls, session):


### PR DESCRIPTION
Instead of executing N queries to retrieve data for N feature flags, this commit results in us making 1 query for the vast majority of requests.

This results in a noticeable performance improvement:

     # BEFORE
     $ wrk -c 1 -t 1 -d 60s -H 'Cookie: session=...' https://localhost:5000/app
     Running 1m test @ https://localhost:5000/app
       1 threads and 1 connections
       Thread Stats   Avg      Stdev     Max   +/- Stdev
         Latency    56.48ms   30.20ms 298.60ms   91.55%
         Req/Sec    17.33      5.45    30.00     69.89%
       1028 requests in 1.00m, 1.13MB read
     Requests/sec:     17.12
     Transfer/sec:     19.24KB

     # AFTER
     $ wrk -c 1 -t 1 -d 60s -H 'Cookie: session=...' https://localhost:5000/app
     Running 1m test @ https://localhost:5000/app
       1 threads and 1 connections
       Thread Stats   Avg      Stdev     Max   +/- Stdev
         Latency    41.27ms   22.19ms 226.68ms   95.78%
         Req/Sec    23.57      5.99    30.00     60.42%
       1398 requests in 1.00m, 1.53MB read
     Requests/sec:     23.28
     Transfer/sec:     26.17KB