### PR TITLE
Fix error when changing email to current email

### DIFF
--- a/h/accounts/schemas.py
+++ b/h/accounts/schemas.py
@@ -42,7 +42,7 @@ def unique_email(node, value):
     '''Colander validator that ensures no user with this email exists.'''
     request = node.bindings['request']
     user = models.User.get_by_email(request.db, value)
-    if user:
+    if user and user.userid != request.authenticated_userid:
         msg = _("Sorry, an account with this email address already exists.")
         raise colander.Invalid(node, msg)
 

--- a/tests/h/accounts/schemas_test.py
+++ b/tests/h/accounts/schemas_test.py
@@ -69,6 +69,26 @@ def test_unique_email_invalid_when_user_does_not_exist(dummy_node, user_model):
     assert schemas.unique_email(dummy_node, "foo@bar.com") is None
 
 
+def test_unique_email_valid_when_authorized_users_email(dummy_node,
+                                                        pyramid_config,
+                                                        pyramid_request,
+                                                        user_model):
+    """
+    If the given email is the authorized user's current email it's valid.
+
+    This is so that we don't get a "That email is already taken" validation
+    error when a user tries to change their email address to the same email
+    address that they already have it set to.
+
+    """
+    pyramid_config.testing_securitypolicy('acct:elliot@hypothes.is')
+    user_model.get_by_email.return_value = Mock(
+        spec_set=('userid',),
+        userid='acct:elliot@hypothes.is')
+
+    schemas.unique_email(dummy_node, "elliot@bar.com")
+
+
 def test_RegisterSchema_with_password_too_short(pyramid_request, user_model):
     schema = schemas.RegisterSchema().bind(request=pyramid_request)
 


### PR DESCRIPTION
If the user submits the change email address form with their *current*
email address as the value for the new email address field then they
would get a "That email address is already in use" error message.

Fix this to a "We've saved your changes" success message.

Of course it doesn't make sense to change your email to its existing
value. But our way of looking at it is that the user asked for their
email to be set to a value, and it is set to that value, there's no
point in bothering the user with the fact that it was already set to
that value in the first place.