### PR TITLE
Don't memoize the `request.authenticated_user`

### DIFF
--- a/h/accounts/__init__.py
+++ b/h/accounts/__init__.py
@@ -53,8 +53,17 @@ def authenticated_user(request):
 
 def includeme(config):
     """A local identity provider."""
-    config.add_request_method(
-        authenticated_user, name='authenticated_user', reify=True)
+
+    # Add a `request.authenticated_user` property.
+    #
+    # N.B. we use `property=True` and not `reify=True` here because it is
+    # important that responsibility for caching user lookups is left to the
+    # UserService and not duplicated here.
+    #
+    # This prevents retried requests (those that raise
+    # `transaction.interfaces.TransientError`) gaining access to a stale
+    # `User` instance.
+    config.add_request_method(authenticated_user, property=True)
 
     config.register_service_factory('.services.user_service_factory',
                                     name='user')


### PR DESCRIPTION
This fixes an issue we've seen in production[1] where retrying annotation creations (because of unavoidable document data races) fails.

These request retries currently fail because of 274350a, which ensures that feature flags are preloaded on every request. Loading feature flags requires accessing the `request.authenticated_user` property, but this is problematic in the case of a retry because a memoized `User` object will be associated with a database session that has been rolled back (hence the retry).

The straightforward solution is to rely on the `UserService` to manage caching (see dfa0ca5) and invalidation (see 87ef989) of user lookups, and thus not memoize this request property.

[1]: https://app.getsentry.com/hypothesis/prod/issues/151279937/