### PR TITLE
Organize account schemas tests

### DIFF
--- a/tests/h/accounts/schemas_test.py
+++ b/tests/h/accounts/schemas_test.py
@@ -29,351 +29,394 @@ class FakeInvalidSerializer(FakeSerializer):
         raise BadData("Invalid token")
 
 
-def test_unblacklisted_username(dummy_node):
-    blacklist = set(['admin', 'root', 'postmaster'])
+class TestUnblacklistedUsername(object):
 
-    # Should not raise for valid usernames
-    schemas.unblacklisted_username(dummy_node, "john", blacklist)
-    schemas.unblacklisted_username(dummy_node, "Abigail", blacklist)
-    # Should raise for usernames in blacklist
-    pytest.raises(colander.Invalid,
-                  schemas.unblacklisted_username,
-                  dummy_node,
-                  "admin",
-                  blacklist)
-    # Should raise for case variants of usernames in blacklist
-    pytest.raises(colander.Invalid,
-                  schemas.unblacklisted_username,
-                  dummy_node,
-                  "PostMaster",
-                  blacklist)
+    def test(self, dummy_node):
+        blacklist = set(['admin', 'root', 'postmaster'])
 
-
-def test_unique_email_looks_up_user_by_email(dummy_node, pyramid_request, user_model):
-    with pytest.raises(colander.Invalid):
-        schemas.unique_email(dummy_node, "foo@bar.com")
-
-    user_model.get_by_email.assert_called_with(pyramid_request.db, "foo@bar.com")
+        # Should not raise for valid usernames
+        schemas.unblacklisted_username(dummy_node, "john", blacklist)
+        schemas.unblacklisted_username(dummy_node, "Abigail", blacklist)
+        # Should raise for usernames in blacklist
+        pytest.raises(colander.Invalid,
+                      schemas.unblacklisted_username,
+                      dummy_node,
+                      "admin",
+                      blacklist)
+        # Should raise for case variants of usernames in blacklist
+        pytest.raises(colander.Invalid,
+                      schemas.unblacklisted_username,
+                      dummy_node,
+                      "PostMaster",
+                      blacklist)
 
 
-def test_unique_email_invalid_when_user_exists(dummy_node, user_model):
-    pytest.raises(colander.Invalid,
-                  schemas.unique_email,
-                  dummy_node,
-                  "foo@bar.com")
+class TestUniqueEmail(object):
+
+    def test_it_looks_up_user_by_email(self,
+                                       dummy_node,
+                                       pyramid_request,
+                                       user_model):
+        with pytest.raises(colander.Invalid):
+            schemas.unique_email(dummy_node, "foo@bar.com")
+
+        user_model.get_by_email.assert_called_with(pyramid_request.db,
+                                                   "foo@bar.com")
+
+    def test_it_is_invalid_when_user_exists(self, dummy_node, user_model):
+        pytest.raises(colander.Invalid,
+                      schemas.unique_email,
+                      dummy_node,
+                      "foo@bar.com")
+
+    def test_it_is_invalid_when_user_does_not_exist(self,
+                                                    dummy_node,
+                                                    user_model):
+        user_model.get_by_email.return_value = None
+
+        assert schemas.unique_email(dummy_node, "foo@bar.com") is None
+
+    def test_it_is_valid_when_authorized_users_email(self,
+                                                     dummy_node,
+                                                     pyramid_config,
+                                                     pyramid_request,
+                                                     user_model):
+        """
+        If the given email is the authorized user's current email it's valid.
+
+        This is so that we don't get a "That email is already taken" validation
+        error when a user tries to change their email address to the same email
+        address that they already have it set to.
+
+        """
+        pyramid_config.testing_securitypolicy('acct:elliot@hypothes.is')
+        user_model.get_by_email.return_value = Mock(
+            spec_set=('userid',),
+            userid='acct:elliot@hypothes.is')
+
+        schemas.unique_email(dummy_node, "elliot@bar.com")
 
 
-def test_unique_email_invalid_when_user_does_not_exist(dummy_node, user_model):
-    user_model.get_by_email.return_value = None
+class TestRegisterSchema(object):
 
-    assert schemas.unique_email(dummy_node, "foo@bar.com") is None
+    def test_it_with_password_too_short(self, pyramid_request, user_model):
+        schema = schemas.RegisterSchema().bind(request=pyramid_request)
 
+        with pytest.raises(colander.Invalid) as exc:
+            schema.deserialize({"password": "a"})
+        assert exc.value.asdict()['password'] == (
+            "Shorter than minimum length 2")
 
-def test_unique_email_valid_when_authorized_users_email(dummy_node,
-                                                        pyramid_config,
-                                                        pyramid_request,
-                                                        user_model):
-    """
-    If the given email is the authorized user's current email it's valid.
+    def test_it_with_username_too_short(self, pyramid_request, user_model):
+        schema = schemas.RegisterSchema().bind(request=pyramid_request)
+        user_model.get_by_username.return_value = None
 
-    This is so that we don't get a "That email is already taken" validation
-    error when a user tries to change their email address to the same email
-    address that they already have it set to.
+        with pytest.raises(colander.Invalid) as exc:
+            schema.deserialize({"username": "a"})
+        assert exc.value.asdict()['username'] == (
+            "Shorter than minimum length 3")
 
-    """
-    pyramid_config.testing_securitypolicy('acct:elliot@hypothes.is')
-    user_model.get_by_email.return_value = Mock(
-        spec_set=('userid',),
-        userid='acct:elliot@hypothes.is')
+    def test_it_with_username_too_long(self, pyramid_request, user_model):
+        schema = schemas.RegisterSchema().bind(request=pyramid_request)
+        user_model.get_by_username.return_value = None
 
-    schemas.unique_email(dummy_node, "elliot@bar.com")
+        with pytest.raises(colander.Invalid) as exc:
+            schema.deserialize({"username": "a" * 500})
+        assert exc.value.asdict()['username'] == (
+            "Longer than maximum length 30")
 
+    def test_it_with_invalid_characters_in_username(self,
+                                                    pyramid_request,
+                                                    user_model):
+        user_model.get_by_username.return_value = None
+        schema = schemas.RegisterSchema().bind(request=pyramid_request)
 
-def test_RegisterSchema_with_password_too_short(pyramid_request, user_model):
-    schema = schemas.RegisterSchema().bind(request=pyramid_request)
-
-    with pytest.raises(colander.Invalid) as exc:
-        schema.deserialize({"password": "a"})
-    assert exc.value.asdict()['password'] == "Shorter than minimum length 2"
-
-
-def test_RegisterSchema_with_username_too_short(pyramid_request, user_model):
-    schema = schemas.RegisterSchema().bind(request=pyramid_request)
-    user_model.get_by_username.return_value = None
-
-    with pytest.raises(colander.Invalid) as exc:
-        schema.deserialize({"username": "a"})
-    assert exc.value.asdict()['username'] == "Shorter than minimum length 3"
+        with pytest.raises(colander.Invalid) as exc:
+            schema.deserialize({"username": "Fred Flintstone"})
+        assert exc.value.asdict()['username'] == ("Must contain only letters, "
+                                                  "numbers, periods, and "
+                                                  "underscores")
 
 
-def test_RegisterSchema_with_username_too_long(pyramid_request, user_model):
-    schema = schemas.RegisterSchema().bind(request=pyramid_request)
-    user_model.get_by_username.return_value = None
+class TestLoginSchema(object):
 
-    with pytest.raises(colander.Invalid) as exc:
-        schema.deserialize({"username": "a" * 500})
-    assert exc.value.asdict()['username'] == "Longer than maximum length 30"
+    def test_it_with_bad_csrf(self, pyramid_request, user_model):
+        schema = schemas.LoginSchema().bind(request=pyramid_request)
+        user = user_model.get_by_username.return_value
+        user.is_activated = True
 
+        with pytest.raises(BadCSRFToken):
+            schema.deserialize({
+                'username': 'jeannie',
+                'password': 'cake',
+            })
 
-def test_RegisterSchema_with_invalid_characters_in_username(pyramid_request,
-                                                            user_model):
-    user_model.get_by_username.return_value = None
-    schema = schemas.RegisterSchema().bind(request=pyramid_request)
+    def test_it_with_bad_username(self, pyramid_csrf_request, user_model):
+        schema = schemas.LoginSchema().bind(request=pyramid_csrf_request)
+        user_model.get_by_username.return_value = None
+        user_model.get_by_email.return_value = None
 
-    with pytest.raises(colander.Invalid) as exc:
-        schema.deserialize({"username": "Fred Flintstone"})
-    assert exc.value.asdict()['username'] == ("Must contain only letters, "
-                                              "numbers, periods, and "
-                                              "underscores")
+        with pytest.raises(colander.Invalid) as exc:
+            schema.deserialize({
+                'username': 'jeannie',
+                'password': 'cake',
+            })
 
+        assert 'username' in exc.value.asdict()
 
-def test_ResetPasswordSchema_with_password_too_short(pyramid_csrf_request, user_model):
-    schema = schemas.ResetPasswordSchema().bind(request=pyramid_csrf_request)
+    def test_it_with_bad_password(self, pyramid_csrf_request, user_model):
+        schema = schemas.LoginSchema().bind(request=pyramid_csrf_request)
+        user = user_model.get_by_username.return_value
+        user.check_password.return_value = False
 
-    with pytest.raises(colander.Invalid) as exc:
-        schema.deserialize({"password": "a"})
-    assert "password" in exc.value.asdict()
+        with pytest.raises(colander.Invalid) as exc:
+            schema.deserialize({
+                'username': 'jeannie',
+                'password': 'cake',
+            })
 
+        assert 'password' in exc.value.asdict()
 
-def test_LoginSchema_with_bad_csrf(pyramid_request, user_model):
-    schema = schemas.LoginSchema().bind(request=pyramid_request)
-    user = user_model.get_by_username.return_value
-    user.is_activated = True
+    def test_it_with_valid_request(self, pyramid_csrf_request, user_model):
+        user = user_model.get_by_username.return_value
+        user.is_activated = True
 
-    with pytest.raises(BadCSRFToken):
-        schema.deserialize({
+        schema = schemas.LoginSchema().bind(request=pyramid_csrf_request)
+
+        assert 'user' in schema.deserialize({
             'username': 'jeannie',
             'password': 'cake',
         })
 
+    def test_it_with_email_instead_of_username(self,
+                                               pyramid_csrf_request,
+                                               user_model):
+        """If get_by_username() returns None it should try get_by_email()."""
+        schema = schemas.LoginSchema().bind(request=pyramid_csrf_request)
+        user_model.get_by_username.return_value = None
+        user = user_model.get_by_email.return_value
+        user.is_activated = True
 
-def test_LoginSchema_with_bad_username(pyramid_csrf_request, user_model):
-    schema = schemas.LoginSchema().bind(request=pyramid_csrf_request)
-    user_model.get_by_username.return_value = None
-    user_model.get_by_email.return_value = None
-
-    with pytest.raises(colander.Invalid) as exc:
-        schema.deserialize({
+        assert 'user' in schema.deserialize({
             'username': 'jeannie',
             'password': 'cake',
         })
 
-    assert 'username' in exc.value.asdict()
+    def test_it_with_inactive_user_account(self,
+                                           pyramid_csrf_request,
+                                           user_model):
+        user = user_model.get_by_username.return_value
+        user.is_activated = False
+        schema = schemas.LoginSchema().bind(request=pyramid_csrf_request)
+
+        with pytest.raises(colander.Invalid) as exc:
+            schema.deserialize({
+                'username': 'jeannie',
+                'password': 'cake',
+            })
+
+        assert ("You haven't activated your account yet" in
+                exc.value.asdict().get('username', ''))
 
 
-def test_LoginSchema_with_bad_password(pyramid_csrf_request, user_model):
-    schema = schemas.LoginSchema().bind(request=pyramid_csrf_request)
-    user = user_model.get_by_username.return_value
-    user.check_password.return_value = False
+class TestForgotPasswordSchema(object):
 
-    with pytest.raises(colander.Invalid) as exc:
-        schema.deserialize({
-            'username': 'jeannie',
-            'password': 'cake',
-        })
+    def test_it_is_invalid_with_no_user(self,
+                                        pyramid_csrf_request,
+                                        user_model):
+        schema = schemas.ForgotPasswordSchema().bind(
+            request=pyramid_csrf_request)
+        user_model.get_by_email.return_value = None
 
-    assert 'password' in exc.value.asdict()
+        with pytest.raises(colander.Invalid) as exc:
+            schema.deserialize({'email': 'rapha@example.com'})
 
+        assert 'email' in exc.value.asdict()
+        assert exc.value.asdict()['email'] == 'Unknown email address'
 
-def test_LoginSchema_with_valid_request(pyramid_csrf_request, user_model):
-    user = user_model.get_by_username.return_value
-    user.is_activated = True
+    def test_it_adds_user_to_appstruct(self,
+                                       pyramid_csrf_request,
+                                       user_model):
+        schema = schemas.ForgotPasswordSchema().bind(
+            request=pyramid_csrf_request)
+        user = user_model.get_by_email.return_value
 
-    schema = schemas.LoginSchema().bind(request=pyramid_csrf_request)
+        appstruct = schema.deserialize({'email': 'rapha@example.com'})
 
-    assert 'user' in schema.deserialize({
-        'username': 'jeannie',
-        'password': 'cake',
-    })
-
-
-def test_LoginSchema_with_email_instead_of_username(pyramid_csrf_request, user_model):
-    """If get_by_username() returns None it should try get_by_email()."""
-    schema = schemas.LoginSchema().bind(request=pyramid_csrf_request)
-    user_model.get_by_username.return_value = None
-    user = user_model.get_by_email.return_value
-    user.is_activated = True
-
-    assert 'user' in schema.deserialize({
-        'username': 'jeannie',
-        'password': 'cake',
-    })
+        assert appstruct['user'] == user
 
 
-def test_LoginSchema_with_inactive_user_account(pyramid_csrf_request, user_model):
-    user = user_model.get_by_username.return_value
-    user.is_activated = False
-    schema = schemas.LoginSchema().bind(request=pyramid_csrf_request)
+class TestResetPasswordSchema(object):
 
-    with pytest.raises(colander.Invalid) as exc:
-        schema.deserialize({
-            'username': 'jeannie',
-            'password': 'cake',
-        })
+    def test_it_with_password_too_short(self,
+                                        pyramid_csrf_request,
+                                        user_model):
+        schema = schemas.ResetPasswordSchema().bind(
+            request=pyramid_csrf_request)
 
-    assert ("You haven't activated your account yet" in
-            exc.value.asdict().get('username', ''))
+        with pytest.raises(colander.Invalid) as exc:
+            schema.deserialize({"password": "a"})
+        assert "password" in exc.value.asdict()
 
+    def test_it_with_invalid_user_token(self,
+                                        pyramid_csrf_request,
+                                        user_model):
+        pyramid_csrf_request.registry.password_reset_serializer = (
+            FakeInvalidSerializer())
+        schema = schemas.ResetPasswordSchema().bind(
+            request=pyramid_csrf_request)
 
-def test_ForgotPasswordSchema_invalid_with_no_user(pyramid_csrf_request, user_model):
-    schema = schemas.ForgotPasswordSchema().bind(request=pyramid_csrf_request)
-    user_model.get_by_email.return_value = None
+        with pytest.raises(colander.Invalid) as exc:
+            schema.deserialize({
+                'user': 'abc123',
+                'password': 'secret',
+            })
 
-    with pytest.raises(colander.Invalid) as exc:
-        schema.deserialize({'email': 'rapha@example.com'})
+        assert 'user' in exc.value.asdict()
+        assert 'reset code is not valid' in exc.value.asdict()['user']
 
-    assert 'email' in exc.value.asdict()
-    assert exc.value.asdict()['email'] == 'Unknown email address'
+    def test_it_with_expired_token(self, pyramid_csrf_request, user_model):
+        pyramid_csrf_request.registry.password_reset_serializer = (
+            FakeExpiredSerializer())
+        schema = schemas.ResetPasswordSchema().bind(
+            request=pyramid_csrf_request)
 
+        with pytest.raises(colander.Invalid) as exc:
+            schema.deserialize({
+                'user': 'abc123',
+                'password': 'secret',
+            })
 
-def test_ForgotPasswordSchema_adds_user_to_appstruct(pyramid_csrf_request, user_model):
-    schema = schemas.ForgotPasswordSchema().bind(request=pyramid_csrf_request)
-    user = user_model.get_by_email.return_value
+        assert 'user' in exc.value.asdict()
+        assert 'reset code has expired' in exc.value.asdict()['user']
 
-    appstruct = schema.deserialize({'email': 'rapha@example.com'})
+    @pytest.mark.usefixtures('user_model')
+    def test_it_user_has_already_reset_their_password(self,
+                                                      pyramid_csrf_request,
+                                                      user_model):
+        pyramid_csrf_request.registry.password_reset_serializer = (
+            FakeSerializer())
+        schema = schemas.ResetPasswordSchema().bind(
+            request=pyramid_csrf_request)
+        user = user_model.get_by_username.return_value
+        user.password_updated = 2
 
-    assert appstruct['user'] == user
+        with pytest.raises(colander.Invalid) as exc:
+            schema.deserialize({
+                'user': 'abc123',
+                'password': 'secret',
+            })
 
+        assert 'user' in exc.value.asdict()
+        assert 'already reset your password' in exc.value.asdict()['user']
 
-def test_ResetPasswordSchema_with_invalid_user_token(pyramid_csrf_request, user_model):
-    pyramid_csrf_request.registry.password_reset_serializer = FakeInvalidSerializer()
-    schema = schemas.ResetPasswordSchema().bind(request=pyramid_csrf_request)
+    @pytest.mark.usefixtures('user_model')
+    def test_it_adds_user_to_appstruct(self, pyramid_csrf_request, user_model):
+        pyramid_csrf_request.registry.password_reset_serializer = (
+            FakeSerializer())
+        schema = schemas.ResetPasswordSchema().bind(
+            request=pyramid_csrf_request)
+        user = user_model.get_by_username.return_value
+        user.password_updated = 0
 
-    with pytest.raises(colander.Invalid) as exc:
-        schema.deserialize({
+        appstruct = schema.deserialize({
             'user': 'abc123',
             'password': 'secret',
         })
 
-    assert 'user' in exc.value.asdict()
-    assert 'reset code is not valid' in exc.value.asdict()['user']
+        assert appstruct['user'] == user
 
 
-def test_ResetPasswordSchema_with_expired_token(pyramid_csrf_request, user_model):
-    pyramid_csrf_request.registry.password_reset_serializer = FakeExpiredSerializer()
-    schema = schemas.ResetPasswordSchema().bind(request=pyramid_csrf_request)
+class TestLegacyEmailChangeSchema(object):
 
-    with pytest.raises(colander.Invalid) as exc:
-        schema.deserialize({
-            'user': 'abc123',
-            'password': 'secret',
-        })
+    def test_it_rejects_non_matching_emails(self,
+                                            pyramid_csrf_request,
+                                            user_model):
+        user = Mock()
+        pyramid_csrf_request.authenticated_user = user
+        schema = schemas.LegacyEmailChangeSchema().bind(
+            request=pyramid_csrf_request)
+        # The email isn't taken
+        user_model.get_by_email.return_value = None
 
-    assert 'user' in exc.value.asdict()
-    assert 'reset code has expired' in exc.value.asdict()['user']
+        with pytest.raises(colander.Invalid) as exc:
+            schema.deserialize({'email': 'foo@bar.com',
+                                'email_confirm': 'foo@baz.com',
+                                'password': 'flibble'})
 
+        assert 'email_confirm' in exc.value.asdict()
 
-@pytest.mark.usefixtures('user_model')
-def test_ResetPasswordSchema_user_has_already_reset_their_password(pyramid_csrf_request,
-                                                                   user_model):
-    pyramid_csrf_request.registry.password_reset_serializer = FakeSerializer()
-    schema = schemas.ResetPasswordSchema().bind(request=pyramid_csrf_request)
-    user = user_model.get_by_username.return_value
-    user.password_updated = 2
+    def test_it_rejects_wrong_password(self, pyramid_csrf_request, user_model):
+        user = Mock()
+        pyramid_csrf_request.authenticated_user = user
+        schema = schemas.LegacyEmailChangeSchema().bind(
+            request=pyramid_csrf_request)
+        # The email isn't taken
+        user_model.get_by_email.return_value = None
+        # The password does not check out
+        user.check_password.return_value = False
 
-    with pytest.raises(colander.Invalid) as exc:
-        schema.deserialize({
-            'user': 'abc123',
-            'password': 'secret',
-        })
+        with pytest.raises(colander.Invalid) as exc:
+            schema.deserialize({'email': 'foo@bar.com',
+                                'email_confirm': 'foo@bar.com',
+                                'password': 'flibble'})
 
-    assert 'user' in exc.value.asdict()
-    assert 'already reset your password' in exc.value.asdict()['user']
-
-
-@pytest.mark.usefixtures('user_model')
-def test_ResetPasswordSchema_adds_user_to_appstruct(pyramid_csrf_request, user_model):
-    pyramid_csrf_request.registry.password_reset_serializer = FakeSerializer()
-    schema = schemas.ResetPasswordSchema().bind(request=pyramid_csrf_request)
-    user = user_model.get_by_username.return_value
-    user.password_updated = 0
-
-    appstruct = schema.deserialize({
-        'user': 'abc123',
-        'password': 'secret',
-    })
-
-    assert appstruct['user'] == user
+        user.check_password.assert_called_once_with('flibble')
+        assert 'password' in exc.value.asdict()
 
 
-def test_LegacyEmailChangeSchema_rejects_non_matching_emails(pyramid_csrf_request, user_model):
-    user = Mock()
-    pyramid_csrf_request.authenticated_user = user
-    schema = schemas.LegacyEmailChangeSchema().bind(request=pyramid_csrf_request)
-    # The email isn't taken
-    user_model.get_by_email.return_value = None
+class TestEmailChangeSchema(object):
 
-    with pytest.raises(colander.Invalid) as exc:
-        schema.deserialize({'email': 'foo@bar.com',
-                            'email_confirm': 'foo@baz.com',
-                            'password': 'flibble'})
+    def test_it_raises_if_password_wrong(self,
+                                         db_session,
+                                         factories,
+                                         pyramid_csrf_request):
+        pyramid_csrf_request.authenticated_user = factories.User()
+        db_session.add(pyramid_csrf_request.authenticated_user)
+        schema = schemas.EmailChangeSchema().bind(request=pyramid_csrf_request)
 
-    assert 'email_confirm' in exc.value.asdict()
+        with pytest.raises(colander.Invalid) as exc:
+            schema.deserialize({
+                'email': 'foo@bar.com',
+                'email_confirm': 'foo@bar.com',
+                'password': 'flibble'  # Not the correct password!
+            })
 
-
-def test_LegacyEmailChangeSchema_rejects_wrong_password(pyramid_csrf_request, user_model):
-    user = Mock()
-    pyramid_csrf_request.authenticated_user = user
-    schema = schemas.LegacyEmailChangeSchema().bind(request=pyramid_csrf_request)
-    # The email isn't taken
-    user_model.get_by_email.return_value = None
-    # The password does not check out
-    user.check_password.return_value = False
-
-    with pytest.raises(colander.Invalid) as exc:
-        schema.deserialize({'email': 'foo@bar.com',
-                            'email_confirm': 'foo@bar.com',
-                            'password': 'flibble'})
-
-    user.check_password.assert_called_once_with('flibble')
-    assert 'password' in exc.value.asdict()
+        assert 'password' in exc.value.asdict()
 
 
-def test_EmailChangeSchema_raises_if_password_wrong(db_session,
-                                                    factories,
-                                                    pyramid_csrf_request):
-    pyramid_csrf_request.authenticated_user = factories.User()
-    db_session.add(pyramid_csrf_request.authenticated_user)
-    schema = schemas.EmailChangeSchema().bind(request=pyramid_csrf_request)
+class TestPasswordChangeSchema(object):
 
-    with pytest.raises(colander.Invalid) as exc:
-        schema.deserialize({
-            'email': 'foo@bar.com',
-            'email_confirm': 'foo@bar.com',
-            'password': 'flibble'  # Not the correct password!
-        })
+    def test_it_rejects_non_matching_passwords(self,
+                                               pyramid_csrf_request,
+                                               user_model):
+        user = Mock()
+        pyramid_csrf_request.authenticated_user = user
+        schema = schemas.PasswordChangeSchema().bind(
+            request=pyramid_csrf_request)
 
-    assert 'password' in exc.value.asdict()
+        with pytest.raises(colander.Invalid) as exc:
+            schema.deserialize({'new_password': 'wibble',
+                                'new_password_confirm': 'wibble!',
+                                'password': 'flibble'})
 
+        assert 'new_password_confirm' in exc.value.asdict()
 
-def test_PasswordChangeSchema_rejects_non_matching_passwords(pyramid_csrf_request,
-                                                             user_model):
-    user = Mock()
-    pyramid_csrf_request.authenticated_user = user
-    schema = schemas.PasswordChangeSchema().bind(request=pyramid_csrf_request)
+    def test_it_rejects_wrong_password(self, pyramid_csrf_request, user_model):
+        user = Mock()
+        pyramid_csrf_request.authenticated_user = user
+        schema = schemas.PasswordChangeSchema().bind(
+            request=pyramid_csrf_request)
+        # The password does not check out
+        user.check_password.return_value = False
 
-    with pytest.raises(colander.Invalid) as exc:
-        schema.deserialize({'new_password': 'wibble',
-                            'new_password_confirm': 'wibble!',
-                            'password': 'flibble'})
+        with pytest.raises(colander.Invalid) as exc:
+            schema.deserialize({'new_password': 'wibble',
+                                'new_password_confirm': 'wibble',
+                                'password': 'flibble'})
 
-    assert 'new_password_confirm' in exc.value.asdict()
-
-
-def test_PasswordChangeSchema_rejects_wrong_password(pyramid_csrf_request, user_model):
-    user = Mock()
-    pyramid_csrf_request.authenticated_user = user
-    schema = schemas.PasswordChangeSchema().bind(request=pyramid_csrf_request)
-    # The password does not check out
-    user.check_password.return_value = False
-
-    with pytest.raises(colander.Invalid) as exc:
-        schema.deserialize({'new_password': 'wibble',
-                            'new_password_confirm': 'wibble',
-                            'password': 'flibble'})
-
-    user.check_password.assert_called_once_with('flibble')
-    assert 'password' in exc.value.asdict()
+        user.check_password.assert_called_once_with('flibble')
+        assert 'password' in exc.value.asdict()
 
 
 @pytest.fixture

--- a/tests/h/accounts/schemas_test.py
+++ b/tests/h/accounts/schemas_test.py
@@ -388,7 +388,6 @@ class TestEmailChangeSchema(object):
         with pytest.raises(colander.Invalid) as exc:
             schema.deserialize({
                 'email': 'foo@bar.com',
-                'email_confirm': 'foo@bar.com',
                 'password': 'flibble'  # Not the correct password!
             })
 

--- a/tests/h/accounts/schemas_test.py
+++ b/tests/h/accounts/schemas_test.py
@@ -420,11 +420,6 @@ class TestPasswordChangeSchema(object):
 
 
 @pytest.fixture
-def activation_model(patch):
-    return patch('h.accounts.schemas.models.Activation')
-
-
-@pytest.fixture
 def dummy_node(pyramid_request):
     class DummyNode(object):
         def __init__(self, request):

--- a/tests/h/accounts/schemas_test.py
+++ b/tests/h/accounts/schemas_test.py
@@ -380,9 +380,15 @@ class TestEmailChangeSchema(object):
     def test_it_is_invalid_if_password_wrong(self,
                                              db_session,
                                              factories,
-                                             pyramid_csrf_request):
+                                             pyramid_csrf_request,
+                                             user_model):
+        # There isn't already an account with the email address that we're
+        # trying to change to.
+        user_model.get_by_email.return_value = None
+
         pyramid_csrf_request.authenticated_user = factories.User()
         db_session.add(pyramid_csrf_request.authenticated_user)
+
         schema = schemas.EmailChangeSchema().bind(request=pyramid_csrf_request)
 
         with pytest.raises(colander.Invalid) as exc:


### PR DESCRIPTION
I want to add tests for the new `EmailChangeSchema` but I really want to add them in a `class TestEmailChangeSchema` so I can for example have per class fixtures. So organize the existing tests into classes first so that it'll be consistent.

Also tidied up the use of fixtures in these tests (define fixtures inside test classes when they're only relevant to that class, use class-level `usefixtures()` decorators...)

Also changed the names of many of the test methods to make the naming consistent.

I think this organization separates the tests for one schema from those for another more clearly, and also clarifies what our style / approach to testing these schemas is.