### PR TITLE
Make de-selected tab color darker

### DIFF
--- a/h/static/styles/partials-v2/_tabs.scss
+++ b/h/static/styles/partials-v2/_tabs.scss
@@ -4,7 +4,7 @@
 
 .tabs__item {
   display: inline;
-  color: $grey-3;
+  color: $grey-4;
   font-size: $title-font-size;
 
   &:not(:last-of-type)::after {


### PR DESCRIPTION
Make the color of deselected tabs in the Account settings pages one shade darker.

This better matches the mocks (eg. https://trello-attachments.s3.amazonaws.com/5797dfacd60d76f1536f1c63/1440x800/8453d1566e7b00a9770814989c1faa26/settings_-_edit_profile_with_notes.png)