### PR TITLE
Search results pager styling

### DIFF
--- a/h/static/styles/partials-v2/_pager.scss
+++ b/h/static/styles/partials-v2/_pager.scss
@@ -1,0 +1,45 @@
+.pager {
+  display: flex;
+  flex-direction: row;
+  margin-top: 50px;
+  font-weight: bold;
+  justify-content: center;
+}
+
+.pager__item {
+  border-radius: 2px;
+  color: $grey-6;
+  padding: 7px 10px 7px 10px;
+}
+
+.pager__item:hover {
+  background-color: $grey-3;
+}
+
+.pager__item--begin {
+  background-color: $grey-3;
+  margin-right: 10px;
+}
+
+.pager__item--end {
+  background-color: $grey-3;
+  margin-left: 10px;
+}
+
+.pager__item--end:not(.is-disabled):hover,
+.pager__item--begin:not(.is-disabled):hover {
+  background-color: $brand;
+  color: $white;
+}
+
+.pager__item--link {
+  color: inherit;
+}
+
+.pager__item.is-highlighted {
+  background-color: $grey-3;
+}
+
+.pager__item.is-disabled {
+  color: $grey-4;
+}

--- a/h/static/styles/site-v2.scss
+++ b/h/static/styles/site-v2.scss
@@ -15,6 +15,7 @@
 @import 'partials-v2/link';
 @import 'partials-v2/masthead';
 @import 'partials-v2/nav-bar';
+@import 'partials-v2/pager';
 @import 'partials-v2/search';
 @import 'partials-v2/search-bar';
 @import 'partials-v2/tabs';

--- a/h/templates/includes/paginator.html.jinja2
+++ b/h/templates/includes/paginator.html.jinja2
@@ -1,33 +1,56 @@
 <nav>
-  <ul class="pagination">
+  <ul class="pager">
     {% if page.prev is none %}
-      <li class="disabled">
-        <span aria-hidden="true">&laquo;</span>
+      <li>
+        <span class="pager__item pager__item--begin is-disabled"
+          aria-hidden="true">
+          &#x3c;
+        </span>
       </li>
     {% else %}
       <li>
-        <a href="{{ page.url_for(page.prev) }}" aria-label="{% trans %}Previous{% endtrans %}">
-          <span aria-hidden="true">&laquo;</span>
+        <a class="pager__item pager__item--begin pager__item--link"
+          href="{{ page.url_for(page.prev) }}"
+          aria-label="{% trans %}Go to previous page{% endtrans %}">
+          <span aria-hidden="true">&#x3c;</span>
         </a>
       </li>
     {% endif %}
     {% for n in range(1, page.max + 1) %}
       {% if n == page.cur %}
-        <li class="active">
-          <span>{{ n }} <span class="sr-only">({% trans %}current{% endtrans %})</span></span>
+        <li>
+          <span class="pager__item is-highlighted"
+            aria-label="Page {{ n }}">
+            {{ n }}
+          </span>
+        </li>
+      {% elif n == '...' %}
+        <li>
+          <span class="pager__item pager__item--link">
+            &#133;
+          </span>
         </li>
       {% else %}
-        <li><a href="{{ page.url_for(n) }}">{{ n }}</a></li>
+        <li>
+          <a class="pager__item pager__item--link"
+            href="{{ page.url_for(n) }}"
+            aria-label="Go to page {{ n }}">
+            {{ n }}
+          </a>
+        </li>
       {% endif %}
     {% endfor %}
     {% if page.next is none %}
-      <li class="disabled">
-        <span aria-hidden="true">&raquo;</span>
+      <li>
+        <span class="pager__item pager__item--end is-disabled "
+          aria-hidden="true">&#x3e;</span>
       </li>
     {% else %}
       <li>
-        <a href="{{ page.url_for(page.next) }}" aria-label="{% trans %}Next{% endtrans %}">
-          <span aria-hidden="true">&raquo;</span>
+        <a class="pager__item pager__item--end pager__item--link"
+          href="{{ page.url_for(page.next) }}"
+          aria-label="{% trans %}Go to next page{% endtrans %}">
+          <span aria-hidden="true">&#x3e;</span>
         </a>
       </li>
     {% endif %}


### PR DESCRIPTION
Initial styling for search results pagination.
https://trello.com/c/mANzbvei/418-pagination-control

I split the original branch branch `search-results-pager` into 2, to create 2 separate PRs - this one for the style related changes and the other one (https://github.com/hypothesis/h/pull/3749) for pagination states.