### PR TITLE
Remove a couple of unused customization points in the base template

### DIFF
--- a/h/templates/layouts/base.html.jinja2
+++ b/h/templates/layouts/base.html.jinja2
@@ -75,12 +75,9 @@
     {% for url in asset_urls("header_js") %}
     <script src="{{ url }}"></script>
     {% endfor %}
-
-    {% block base_tag %}{% endblock %}
   </head>
-  {% block body_tag %}<body class="body">{% endblock %}
+  <body class="body">
     {% block content %}{% endblock %}
-    {% block templates %}{% endblock %}
     {% block scripts %}
     {% for url in asset_urls("site_js") %}
     <script src="{{ url }}"></script>


### PR DESCRIPTION
No templates in the service are currently defining `base_tag`,
`body_tag` or `templates` blocks. The first and last of these were used
only by the Hypothesis client, which no longer uses `base.html`.
`body_tag` was used by a previous attempt at a new homepage.