### PR TITLE
Remove separate salt when setting a new password

### DIFF
--- a/h/accounts/models.py
+++ b/h/accounts/models.py
@@ -207,6 +207,9 @@ class User(Base):
         if len(value) < PASSWORD_MIN_LENGTH:
             raise ValueError('password must be more than {min} characters '
                              'long'.format(min=PASSWORD_MIN_LENGTH))
+        # Remove any existing explicit salt (the password context salts the
+        # password automatically).
+        self.salt = None
         self._password = password_context.encrypt(value)
         self.password_updated = datetime.datetime.utcnow()
 
@@ -227,7 +230,6 @@ class User(Base):
             # If the password is correct, take this opportunity to upgrade the
             # password and remove the salt.
             if verified:
-                self.salt = None
                 self.password = value
 
             return verified

--- a/tests/h/accounts/models_test.py
+++ b/tests/h/accounts/models_test.py
@@ -178,6 +178,17 @@ def test_check_password_upgrades_new_style_passwords():
     assert not password_context.needs_update(user._password)
 
 
+def test_setting_password_unsets_salt():
+    user = models.User(username='barnet')
+    user.salt = 'somesalt'
+    user._password = 'whatever'
+
+    user.password = 'flibble'
+
+    assert user.salt is None
+    assert user.check_password('flibble')
+
+
 def test_User_activate_activates_user(db_session):
     user = models.User(authority='example.com',
                        username='kiki',


### PR DESCRIPTION
If a user with an old-style (double-salted) password walked through the
password reset process, they'd end up with a new-style password without
the `salt` column being reset and they'd be unable to login.

This fixes that issue.