### PR TITLE
Add invalid session HTML error

### DIFF
--- a/h/accounts/views.py
+++ b/h/accounts/views.py
@@ -38,7 +38,7 @@ def ajax_payload(request, data):
 
 
 @json_view(context=BadCSRFToken)
-def bad_csrf_token(context, request):
+def bad_csrf_token_json(context, request):
     request.response.status_code = 403
     reason = _('Session is invalid. Please try again.')
     return {

--- a/h/accounts/views.py
+++ b/h/accounts/views.py
@@ -24,6 +24,7 @@ from h.accounts.events import PasswordResetEvent
 from h.accounts.events import LogoutEvent
 from h.accounts.events import LoginEvent
 from h.util.view import json_view
+from h._compat import urlparse
 
 _ = i18n.TranslationString
 
@@ -35,6 +36,21 @@ def ajax_payload(request, data):
                'model': session.model(request)}
     payload.update(data)
     return payload
+
+
+@view_config(context=BadCSRFToken,
+             accept='text/html',
+             renderer='h:templates/accounts/session_invalid.html.jinja2')
+def bad_csrf_token_html(context, request):
+    request.response.status_code = 403
+
+    next_path = '/'
+    referer = urlparse.urlparse(request.referer or '')
+    if referer.hostname == request.domain:
+        next_path = referer.path
+
+    login_path = request.route_path('login', _query={'next': next_path})
+    return {'login_path': login_path}
 
 
 @json_view(context=BadCSRFToken)

--- a/h/templates/accounts/session_invalid.html.jinja2
+++ b/h/templates/accounts/session_invalid.html.jinja2
@@ -1,0 +1,8 @@
+{% extends "h:templates/layouts/base.html.jinja2" %}
+
+{% block page_title %}Invalid Session{% endblock %}
+
+{% block content %}
+Sorry, but your session has expired.
+Please <a href="{{ login_path }}">go back</a> and try again.
+{% endblock content %}

--- a/tests/h/accounts/views_test.py
+++ b/tests/h/accounts/views_test.py
@@ -26,6 +26,36 @@ class FakeSerializer(object):
 
 
 @pytest.mark.usefixtures('routes')
+class TestBadCSRFTokenHTML(object):
+    def test_it_returns_login_with_root_next_as_default(self, pyramid_request):
+        pyramid_request.referer = None
+        result = views.bad_csrf_token_html(None, pyramid_request)
+
+        assert result['login_path'] == '/login?next=%2F'
+
+    def test_it_returns_login_with_referer_path_as_next(self, pyramid_request):
+        pyramid_request.referer = 'http://' + \
+                                  pyramid_request.domain + \
+                                  '/account/settings'
+
+        result = views.bad_csrf_token_html(None, pyramid_request)
+
+        assert result['login_path'] == '/login?next=%2Faccount%2Fsettings'
+
+    def test_it_returns_login_with_root_when_hostnames_are_different(self, pyramid_request):
+        pyramid_request.domain = 'example.org'
+        pyramid_request.referer = 'http://example.com/account/settings'
+
+        result = views.bad_csrf_token_html(None, pyramid_request)
+
+        assert result['login_path'] == '/login?next=%2F'
+
+    @pytest.fixture
+    def routes(self, pyramid_config):
+        pyramid_config.add_route('login', '/login')
+
+
+@pytest.mark.usefixtures('routes')
 class TestAuthController(object):
 
     def test_post_redirects_when_logged_in(self, pyramid_config, pyramid_request):


### PR DESCRIPTION
We used to render the JSON error response, even for non-XHR requests, this adds a very basic error page with a link to login (which then redirects to the most likely place the user came from).

For testing (and checking that the "design" looks good enough):

1. Login
2. Go to `/account/settings`
3. Open a second tab
4. Log out in the second tab
5. Log back in in the second tab
6. Submit the password reset form in the first tab
7. tada

Fixes #3751 