### PR TITLE
Scroll expanded search results into view

### DIFF
--- a/h/static/scripts/base/upgrade-elements.js
+++ b/h/static/scripts/base/upgrade-elements.js
@@ -11,6 +11,9 @@ function isJSDisabled(document) {
  * If `root` lives in a document whose URL contains the query string parameter
  * `nojs=1` then `upgradeElements()` will return immediately.
  *
+ * Controllers attached to upgraded elements are accessible via the `controllers`
+ * property on the element.
+ *
  * @param {Element} root - The root element to search for matching elements
  * @param {Object} controllers - Object mapping selectors to controller classes.
  *        For each element matching a given selector, an instance of the
@@ -27,7 +30,12 @@ function upgradeElements(root, controllers) {
     elements.forEach(function (el) {
       var ControllerClass = controllers[selector];
       try {
-        new ControllerClass(el);
+        var ctrl = new ControllerClass(el);
+        if (!el.controllers) {
+          el.controllers = [ctrl];
+        } else {
+          el.controllers.push(ctrl);
+        }
       } catch (err) {
         console.error('Failed to upgrade element %s with controller', el, ControllerClass, ':', err.toString());
 

--- a/h/static/scripts/controllers/search-bucket-controller.js
+++ b/h/static/scripts/controllers/search-bucket-controller.js
@@ -1,12 +1,21 @@
 'use strict';
 
+var scrollIntoView = require('scroll-into-view');
+
 function SearchBucketController(element) {
+  this.scrollTo = scrollIntoView;
+
   var header = element.querySelector('.js-header');
   var content = element.querySelector('.js-content');
+  var self = this;
 
   header.addEventListener('click', function () {
     element.classList.toggle('is-expanded');
     content.classList.toggle('is-expanded');
+
+    if (element.classList.contains('is-expanded')) {
+      self.scrollTo(element);
+    }
   });
 }
 

--- a/h/static/scripts/tests/base/upgrade-elements-test.js
+++ b/h/static/scripts/tests/base/upgrade-elements-test.js
@@ -30,4 +30,16 @@ describe('upgradeElements', function () {
     upgradeElements(root, {'.js-test': TestController});
     assert.notCalled(TestController);
   });
+
+  it('exposes controllers via the `.controllers` element property', function () {
+    function TestController() {}
+
+    var root = document.createElement('div');
+    root.classList.add('js-test');
+    document.body.appendChild(root);
+
+    upgradeElements(document.body, {'.js-test': TestController});
+    assert.equal(root.controllers.length, 1);
+    assert.instanceOf(root.controllers[0], TestController);
+  });
 });

--- a/h/static/scripts/tests/controllers/search-bucket-controller-test.js
+++ b/h/static/scripts/tests/controllers/search-bucket-controller-test.js
@@ -14,6 +14,7 @@ describe('SearchBucketController', function () {
   var container;
   var headerEl;
   var contentEl;
+  var ctrl;
 
   beforeEach(function () {
     container = util.setupComponent(document, TEMPLATE, {
@@ -21,10 +22,17 @@ describe('SearchBucketController', function () {
     });
     headerEl = container.querySelector('.js-header');
     contentEl = container.querySelector('.js-content');
+    ctrl = container.querySelector('.js-search-bucket').controllers[0];
   });
 
   it('toggles content expanded state when clicked', function () {
     headerEl.dispatchEvent(new Event('click'));
     assert.isTrue(contentEl.classList.contains('is-expanded'));
+  });
+
+  it('scrolls element into view when expanded', function () {
+    ctrl.scrollTo = sinon.stub();
+    headerEl.dispatchEvent(new Event('click'));
+    assert.calledWith(ctrl.scrollTo, container.querySelector('.js-search-bucket'));
   });
 });

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "postcss-url": "^5.1.1",
     "query-string": "^3.0.1",
     "raven-js": "^2.0.2",
+    "scroll-into-view": "^1.7.1",
     "through2": "^2.0.1",
     "uglifyify": "^3.0.1",
     "vinyl": "^1.1.1",


### PR DESCRIPTION
When expanding search results, scroll the expanded annotation cards into
view. This fixes an issue where after expanding a bucket at the bottom
of the search result list, the user had to manually scroll the page in
order to actually read the newly exposed annotation cards.

 * Add `scroll-into-view` dependency and use it to scroll expanded
   search result buckets

 * Expose controller instances on upgraded elements for use in tests and
   debugging
