### PR TITLE
Run functional tests on Jenkins

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -26,10 +26,12 @@ commands =
     memex: coverage run --parallel --source memex -m pytest {posargs:tests/memex/}
 
 [testenv:functional]
+skip_install = true
 deps =
     pytest
     webtest
     factory-boy
+    -rrequirements.txt
 passenv =
     BROKER_URL
     ELASTICSEARCH_HOST

--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,10 @@ deps =
     webtest
     factory-boy
 passenv =
+    BROKER_URL
     ELASTICSEARCH_HOST
+    REDIS_HOST
+    REDIS_PORT
     TEST_DATABASE_URL
 commands = py.test {posargs:tests/functional/}
 


### PR DESCRIPTION
Does what it says on the tin. Adds config to the `Jenkinsfile` which allows the functional tests to run on Jenkins.