### PR TITLE
Add description field to new group form

### DIFF
--- a/h/groups/models.py
+++ b/h/groups/models.py
@@ -13,6 +13,7 @@ from h import pubid
 
 GROUP_NAME_MIN_LENGTH = 4
 GROUP_NAME_MAX_LENGTH = 25
+GROUP_DESCRIPTION_MAX_LENGTH = 250
 
 
 class GroupFactory(object):
@@ -52,8 +53,9 @@ class Group(Base, mixins.Timestamps):
         'User', secondary='user_group', backref=sa.orm.backref(
             'groups', order_by='Group.name'))
 
-    def __init__(self, name, creator):
+    def __init__(self, name, creator, description=None):
         self.name = name
+        self.description = description
         self.creator = creator
         self.members.append(creator)
 

--- a/h/groups/schemas.py
+++ b/h/groups/schemas.py
@@ -12,9 +12,9 @@ from h.groups.models import GROUP_NAME_MAX_LENGTH
 _ = i18n.TranslationString
 
 
-class GroupSchema(CSRFSchema):
+class LegacyGroupSchema(CSRFSchema):
 
-    """The schema for the create-a-new-group form."""
+    """The legacy schema for the create-a-new-group form."""
 
     name = colander.SchemaNode(
         colander.String(),

--- a/h/groups/schemas.py
+++ b/h/groups/schemas.py
@@ -5,11 +5,45 @@ import deform
 
 from h import i18n
 from h.accounts.schemas import CSRFSchema
-from h.groups.models import GROUP_NAME_MIN_LENGTH
-from h.groups.models import GROUP_NAME_MAX_LENGTH
+from h.groups.models import (
+    GROUP_DESCRIPTION_MAX_LENGTH,
+    GROUP_NAME_MIN_LENGTH,
+    GROUP_NAME_MAX_LENGTH,
+)
 
 
 _ = i18n.TranslationString
+
+
+class GroupSchema(CSRFSchema):
+
+    """The schema for the create-a-new-group form."""
+
+    name = colander.SchemaNode(
+        colander.String(),
+        title=_("What do you want to call the group?"),
+        validator=colander.Length(
+            min=GROUP_NAME_MIN_LENGTH,
+            max=GROUP_NAME_MAX_LENGTH),
+        widget=deform.widget.TextInputWidget(
+            autofocus=True,
+            css_class="group-form__name-input js-group-name-input",
+            disable_autocomplete=True,
+            label_css_class="group-form__name-label",
+            max_length=GROUP_NAME_MAX_LENGTH,
+            placeholder=_("Group Name")))
+
+    description = colander.SchemaNode(
+        colander.String(),
+        title=_("Description:"),
+        validator=colander.Length(max=GROUP_DESCRIPTION_MAX_LENGTH),
+        missing=None,
+        widget=deform.widget.TextAreaWidget(
+            css_class="group-form__description-input",
+            label_css_class="group-form__description-label",
+            min_length=0,
+            max_length=GROUP_DESCRIPTION_MAX_LENGTH,
+            placeholder=_("Group Description")))
 
 
 class LegacyGroupSchema(CSRFSchema):

--- a/h/groups/services.py
+++ b/h/groups/services.py
@@ -22,17 +22,18 @@ class GroupsService(object):
         self.user_fetcher = user_fetcher
         self.publish = publish
 
-    def create(self, name, userid):
+    def create(self, name, userid, description=None):
         """
         Create a new group.
 
         :param name: the human-readable name of the group
         :param userid: the userid of the group creator
+        :param description: the description of the group
 
         :returns: the created group
         """
         creator = self.user_fetcher(userid)
-        group = Group(name=name, creator=creator)
+        group = Group(name=name, creator=creator, description=description)
         self.session.add(group)
         self.session.flush()
 

--- a/h/groups/views.py
+++ b/h/groups/views.py
@@ -20,7 +20,11 @@ _ = i18n.TranslationString
 class GroupCreateController(object):
     def __init__(self, request):
         self.request = request
-        self.schema = schemas.LegacyGroupSchema().bind(request=self.request)
+
+        if request.feature('activity_pages'):
+            self.schema = schemas.GroupSchema().bind(request=self.request)
+        else:
+            self.schema = schemas.LegacyGroupSchema().bind(request=self.request)
 
         submit = deform.Button(title=_('Create a new group'),
                                css_class='primary-action-btn '
@@ -42,6 +46,7 @@ class GroupCreateController(object):
             groups_service = self.request.find_service(name='groups')
             group = groups_service.create(
                 name=appstruct['name'],
+                description=appstruct.get('description'),
                 userid=self.request.authenticated_userid)
 
             url = self.request.route_path('group_read',

--- a/h/groups/views.py
+++ b/h/groups/views.py
@@ -20,7 +20,7 @@ _ = i18n.TranslationString
 class GroupCreateController(object):
     def __init__(self, request):
         self.request = request
-        self.schema = schemas.GroupSchema().bind(request=self.request)
+        self.schema = schemas.LegacyGroupSchema().bind(request=self.request)
 
         submit = deform.Button(title=_('Create a new group'),
                                css_class='primary-action-btn '

--- a/h/static/styles/partials/_group-form.scss
+++ b/h/static/styles/partials/_group-form.scss
@@ -63,9 +63,21 @@
       @include flex-center-column();
     }
 
-    &__name-label {
+    &__description-label, &__name-label {
       font-size: 18px;
       margin-bottom: 10px;
+    }
+
+    &__description-input {
+      display: block;
+      margin-bottom: 40px;
+      width: 350px;
+      height: 105px;
+      border: none;
+
+      &:placeholder {
+        color: $color-alto;
+      }
     }
 
     &__name-input {

--- a/tests/h/groups/models_test.py
+++ b/tests/h/groups/models_test.py
@@ -7,14 +7,16 @@ from h import models
 
 def test_init(db_session, factories):
     name = "My Hypothesis Group"
+    description = "This group is awesome"
     user = factories.User()
 
-    group = models.Group(name=name, creator=user)
+    group = models.Group(name=name, creator=user, description=description)
     db_session.add(group)
     db_session.flush()
 
     assert group.id
     assert group.name == name
+    assert group.description == description
     assert group.created
     assert group.updated
     assert group.creator == user

--- a/tests/h/groups/services_test.py
+++ b/tests/h/groups/services_test.py
@@ -32,6 +32,20 @@ class TestGroupsService(object):
 
         assert group.creator == users['cazimir']
 
+    def test_create_sets_description_when_present(self, db_session, users):
+        svc = GroupsService(db_session, users.get)
+
+        group = svc.create('Anteater fans', 'cazimir', 'all about ant eaters')
+
+        assert group.description == 'all about ant eaters'
+
+    def test_create_skips_setting_description_when_missing(self, db_session, users):
+        svc = GroupsService(db_session, users.get)
+
+        group = svc.create('Anteater fans', 'cazimir')
+
+        assert group.description is None
+
     def test_create_adds_group_to_session(self, db_session, users):
         svc = GroupsService(db_session, users.get)
 


### PR DESCRIPTION
This adds a new textarea input field for the group description when the `activity-pages` flag is turned on.

The card mentioned that this isn't about implementing any design, it looks like this at the moment:
![2016-08-23-173137_489x532_scrot](https://cloud.githubusercontent.com/assets/112063/17900622/d2759182-6957-11e6-9c3e-6f24d4636f46.png)
