### PR TITLE
Do not display border for ellipses in admin ages.

### DIFF
--- a/h/static/styles/admin.scss
+++ b/h/static/styles/admin.scss
@@ -14,3 +14,7 @@ body {
 .users-activate-form {
   display: inline;
 }
+
+.pager .pager__item--more {
+  border: none;
+}


### PR DESCRIPTION
Admin pages for groups and feature cohorts have the ellipses enclosed within
a border, which makes it look clickable:
https://www.dropbox.com/s/gji8qwl7sq6ifby/Screenshot%202016-08-24%2009.57.22.png?dl=0

Remove the border so that it is clear to the user that the ellipses are not
clickable:
https://www.dropbox.com/s/8wu7olwppn21hkk/Screenshot%202016-08-24%2009.56.06.png?dl=0

Trello:
https://trello.com/c/mANzbvei/418-pagination-control
https://trello.com/c/fbvVXbvF/417-backend-support-for-pagination-control