### PR TITLE
Add a base class for controllers

### DIFF
--- a/h/static/scripts/base/controller.js
+++ b/h/static/scripts/base/controller.js
@@ -1,0 +1,82 @@
+'use strict';
+
+/**
+ * Search the DOM tree starting at `el` and return a map of "data-ref" attribute
+ * values to elements.
+ *
+ * Multiple controllers may need to refer to the same element, so `data-ref`
+ * supports a space-separated list of reference names.
+ */
+function findRefs(el, map) {
+  if (!el.dataset) {
+    return map;
+  }
+  map = map || {};
+
+  var refs = (el.dataset.ref || '').split(' ');
+  refs.forEach(function (ref) {
+    map[ref] = el;
+  });
+
+  for (var i=0; i < el.children.length; i++) {
+    var node = el.children[i];
+    if (node.nodeType === Node.ELEMENT_NODE) {
+      findRefs(node, map);
+    }
+  }
+
+  return map;
+}
+
+/**
+ * Base class for controllers that upgrade elements with additional
+ * functionality.
+ *
+ * - Child elements with `data-ref="$name"` attributes are exposed on the
+ *   controller as `this.refs.$name`.
+ * - The element passed to the controller is exposed via the `element` property
+ * - The controllers attached to an element are accessible via the
+ *   `element.controllers` array
+ *
+ * The controller maintains internal state in `this.state`, which can only be
+ * updated by calling (`this.setState(changes)`). Whenever the internal state of
+ * the controller changes, `this.update()` is called to sync the DOM with this
+ * state.
+ *
+ * @param {Element} element - The DOM Element to upgrade
+ */
+function Controller(element) {
+  if (!element.controllers) {
+    element.controllers = [this];
+  } else {
+    element.controllers.push(this);
+  }
+
+  this.state = {};
+  this.element = element;
+  this.refs = findRefs(element);
+}
+
+/**
+ * Set the state of the controller.
+ *
+ * This will merge `changes` into the current state and call the `update()`
+ * method provided by the subclass to update the DOM to match the current state.
+ */
+Controller.prototype.setState = function (changes) {
+  var prevState = this.state;
+  this.state = Object.freeze(Object.assign({}, this.state, changes));
+  this.update(this.state, prevState);
+};
+
+/**
+ * Calls update() with the current state.
+ *
+ * This is useful for controllers where the state is available in the DOM
+ * itself, so doesn't need to be maintained internally.
+ */
+Controller.prototype.forceUpdate = function () {
+  this.update(this.state, this.state);
+};
+
+module.exports = Controller;

--- a/h/static/scripts/base/upgrade-elements.js
+++ b/h/static/scripts/base/upgrade-elements.js
@@ -22,12 +22,7 @@ function upgradeElements(root, controllers) {
     elements.forEach(function (el) {
       var ControllerClass = controllers[selector];
       try {
-        var ctrl = new ControllerClass(el);
-        if (!el.controllers) {
-          el.controllers = [ctrl];
-        } else {
-          el.controllers.push(ctrl);
-        }
+        new ControllerClass(el);
       } catch (err) {
         console.error('Failed to upgrade element %s with controller', el, ControllerClass, ':', err.toString());
 

--- a/h/static/scripts/controllers/character-limit-controller.js
+++ b/h/static/scripts/controllers/character-limit-controller.js
@@ -1,29 +1,28 @@
 'use strict';
 
+var inherits = require('inherits');
+
+var Controller = require('../base/controller');
+var setElementState = require('../util/dom').setElementState;
+
 function CharacterLimitController(element) {
-  var counter = element.parentElement.querySelector(
-    '.js-character-limit-counter');
-  var input = element.querySelector('.js-character-limit-input');
-  var maxlength = parseInt(input.dataset.maxlength);
+  Controller.call(this, element);
 
-  counter.textContent = '';
-
-  function updateCounter() {
-    var length = input.value.length;
-
-    counter.textContent = length + '/' + maxlength;
-
-    if (length > maxlength) {
-      counter.classList.add('is-too-long');
-    } else {
-      counter.classList.remove('is-too-long');
-    }
-  }
-
-  updateCounter();
-  input.addEventListener('input', updateCounter);
-
-  counter.classList.add('is-ready');
+  var self = this;
+  this.refs.characterLimitInput.addEventListener('input', function () {
+    self.forceUpdate();
+  });
+  this.forceUpdate();
 }
+inherits(CharacterLimitController, Controller);
+
+CharacterLimitController.prototype.update = function () {
+  var input = this.refs.characterLimitInput;
+  var maxlength = parseInt(input.dataset.maxlength);
+  var counter = this.refs.characterLimitCounter;
+  counter.textContent = input.value.length + '/' + maxlength;
+  setElementState(counter, {tooLong: input.value.length > maxlength});
+  setElementState(this.refs.characterLimitCounter, {ready: true});
+};
 
 module.exports = CharacterLimitController;

--- a/h/static/scripts/controllers/dropdown-menu-controller.js
+++ b/h/static/scripts/controllers/dropdown-menu-controller.js
@@ -1,21 +1,30 @@
 'use strict';
 
+var inherits = require('inherits');
+
+var Controller = require('../base/controller');
+var setElementState = require('../util/dom').setElementState;
+
 /**
  * Controller for dropdown menus.
  */
 function DropdownMenuController(element) {
-  var toggleEl = element.querySelector('.js-dropdown-menu-toggle');
-  var contentEl = element.querySelector('.js-dropdown-menu-content');
+  Controller.call(this, element);
+
+  var self = this;
+  var toggleEl = this.refs.dropdownMenuToggle;
 
   var handleClickOutside = function (event) {
-    if (!contentEl.contains(event.target)) {
+    if (!self.refs.dropdownMenuContent.contains(event.target)) {
       // When clicking outside the menu on the toggle element, stop the event
       // so that it does not re-trigger the menu
       if (toggleEl.contains(event.target)) {
         event.stopPropagation();
         event.preventDefault();
       }
-      contentEl.classList.remove('is-open');
+
+      self.setState({open: false});
+
       element.ownerDocument.removeEventListener('click', handleClickOutside,
         true /* capture */);
     }
@@ -25,11 +34,16 @@ function DropdownMenuController(element) {
     event.preventDefault();
     event.stopPropagation();
 
-    contentEl.classList.add('is-open');
+    self.setState({open: true});
 
     element.ownerDocument.addEventListener('click', handleClickOutside,
       true /* capture */);
   });
 }
+inherits(DropdownMenuController, Controller);
+
+DropdownMenuController.prototype.update = function (state) {
+  setElementState(this.refs.dropdownMenuContent, {open: state.open});
+};
 
 module.exports = DropdownMenuController;

--- a/h/static/scripts/controllers/search-bucket-controller.js
+++ b/h/static/scripts/controllers/search-bucket-controller.js
@@ -1,22 +1,30 @@
 'use strict';
 
+var inherits = require('inherits');
 var scrollIntoView = require('scroll-into-view');
 
-function SearchBucketController(element) {
-  this.scrollTo = scrollIntoView;
+var Controller = require('../base/controller');
+var setElementState = require('../util/dom').setElementState;
 
-  var header = element.querySelector('.js-header');
-  var content = element.querySelector('.js-content');
+function SearchBucketController(element) {
+  Controller.call(this, element);
+
+  this.scrollTo = scrollIntoView;
   var self = this;
 
-  header.addEventListener('click', function () {
-    element.classList.toggle('is-expanded');
-    content.classList.toggle('is-expanded');
-
-    if (element.classList.contains('is-expanded')) {
-      self.scrollTo(element);
-    }
+  this.refs.header.addEventListener('click', function () {
+    self.setState({expanded: !self.state.expanded});
   });
 }
+inherits(SearchBucketController, Controller);
+
+SearchBucketController.prototype.update = function (state) {
+  setElementState(this.refs.content, {expanded: state.expanded});
+  setElementState(this.refs.header, {expanded: state.expanded});
+
+  if (state.expanded) {
+    this.scrollTo(this.element);
+  }
+};
 
 module.exports = SearchBucketController;

--- a/h/static/scripts/controllers/tooltip-controller.js
+++ b/h/static/scripts/controllers/tooltip-controller.js
@@ -1,5 +1,9 @@
 'use strict';
 
+var inherits = require('inherits');
+
+var Controller = require('../base/controller');
+
 /**
  * A custom tooltip similar to the one used in Google Docs which appears
  * instantly when activated on a target element.
@@ -16,6 +20,8 @@
  * @param {Element} el - The container for the tooltip.
  */
 function TooltipController(el) {
+  Controller.call(this, el);
+
   var self = this;
 
   // With mouse input, show the tooltip on hover. On touch devices we rely on
@@ -31,34 +37,30 @@ function TooltipController(el) {
     self.setState({target: null});
   });
 
-  this.setState = function (state) {
-    this.state = Object.freeze(Object.assign({}, this.state, state));
-    this.render();
-  };
-
-  this.render = function () {
-    if (!this.state.target) {
-      this._el.style.visibility = 'hidden';
-      return;
-    }
-
-    var target = this.state.target;
-    var label = target.getAttribute('aria-label');
-    this._labelEl.textContent = label;
-
-    Object.assign(this._el.style, {
-      visibility: '',
-      bottom: 'calc(100% + 5px)',
-    });
-  };
-
   this._el = el.ownerDocument.createElement('div');
   this._el.innerHTML = '<span class="tooltip-label js-tooltip-label"></span>';
   this._el.className = 'tooltip';
   el.appendChild(this._el);
   this._labelEl = this._el.querySelector('.js-tooltip-label');
 
-  this.setState({});
+  this.setState({target: null});
 }
+inherits(TooltipController, Controller);
+
+TooltipController.prototype.update = function (state) {
+  if (!state.target) {
+    this._el.style.visibility = 'hidden';
+    return;
+  }
+
+  var target = state.target;
+  var label = target.getAttribute('aria-label');
+  this._labelEl.textContent = label;
+
+  Object.assign(this._el.style, {
+    visibility: '',
+    bottom: 'calc(100% + 5px)',
+  });
+};
 
 module.exports = TooltipController;

--- a/h/static/scripts/polyfills.js
+++ b/h/static/scripts/polyfills.js
@@ -6,6 +6,7 @@ require('core-js/fn/array/find');
 require('core-js/fn/array/find-index');
 require('core-js/fn/array/from');
 require('core-js/fn/object/assign');
+require('core-js/fn/string/starts-with');
 
 // URL constructor, required by IE 10/11,
 // early versions of Microsoft Edge.

--- a/h/static/scripts/tests/base/controller-test.js
+++ b/h/static/scripts/tests/base/controller-test.js
@@ -1,0 +1,50 @@
+'use strict';
+
+var inherits = require('inherits');
+
+var Controller = require('../../base/controller');
+
+function TestController(element) {
+  Controller.call(this, element);
+
+  this.update = sinon.stub();
+}
+inherits(TestController, Controller);
+
+describe('Controller', function () {
+  var ctrl;
+
+  beforeEach(function () {
+    var root = document.createElement('div');
+    root.dataset.ref = 'test';
+    document.body.appendChild(root);
+    ctrl = new TestController(root);
+  });
+
+  afterEach(function () {
+    ctrl.element.remove();
+  });
+
+  it('exposes controllers via the `.controllers` element property', function () {
+    assert.equal(ctrl.element.controllers.length, 1);
+    assert.instanceOf(ctrl.element.controllers[0], TestController);
+  });
+
+  it('exposes elements with "data-ref" attributes on the `refs` property', function () {
+    assert.deepEqual(ctrl.refs, {test: ctrl.element});
+  });
+
+  describe('#setState', function () {
+    it('calls update() with new and previous state', function () {
+      ctrl.setState({open: true});
+      ctrl.update = sinon.stub();
+      ctrl.setState({open: true, saving: true});
+      assert.calledWith(ctrl.update, {
+        open: true,
+        saving: true,
+      }, {
+        open: true,
+      });
+    });
+  });
+});

--- a/h/static/scripts/tests/base/upgrade-elements-test.js
+++ b/h/static/scripts/tests/base/upgrade-elements-test.js
@@ -15,16 +15,4 @@ describe('upgradeElements', function () {
 
     root.remove();
   });
-
-  it('exposes controllers via the `.controllers` element property', function () {
-    function TestController() {}
-
-    var root = document.createElement('div');
-    root.classList.add('js-test');
-    document.body.appendChild(root);
-
-    upgradeElements(document.body, {'.js-test': TestController});
-    assert.equal(root.controllers.length, 1);
-    assert.instanceOf(root.controllers[0], TestController);
-  });
 });

--- a/h/static/scripts/tests/controllers/character-limit-controller-test.js
+++ b/h/static/scripts/tests/controllers/character-limit-controller-test.js
@@ -5,12 +5,12 @@ var util = require('./util');
 
 describe('CharacterLimitController', function () {
 
-  var containerEl;
+  var ctrl;
 
   afterEach(function () {
-    if (containerEl) {
-      containerEl.remove();
-      containerEl = null;
+    if (ctrl) {
+      ctrl.element.remove();
+      ctrl = null;
     }
   });
 
@@ -22,25 +22,18 @@ describe('CharacterLimitController', function () {
     maxlength = maxlength || 250;
 
     var template = '<div class="js-character-limit">';
-    template += '<textarea class="js-character-limit-input" data-maxlength="' + maxlength + '">';
+    template += '<textarea data-ref="characterLimitInput" data-maxlength="' + maxlength + '">';
     if (value) {
       template += value;
     }
-    template += '</textarea><span class="js-character-limit-counter">Foo</span>';
+    template += '</textarea><span data-ref="characterLimitCounter">Foo</span>';
     template += '</div>';
 
-    containerEl = util.setupComponent(document, template, {
-      '.js-character-limit': CharacterLimitController,
-    });
-    var divEl = containerEl.querySelector('.js-character-limit');
-    var counterEl = containerEl.querySelector('.js-character-limit-counter');
-    var textarea = containerEl.querySelector('textarea');
-    var ctrl = divEl.controllers[0];
+    ctrl = util.setupComponent(document, template, CharacterLimitController);
 
     return {
-      containerEl: containerEl,
-      counterEl: counterEl,
-      textarea: textarea,
+      counterEl: ctrl.refs.characterLimitCounter,
+      textarea: ctrl.refs.characterLimitInput,
       ctrl: ctrl,
     };
   }

--- a/h/static/scripts/tests/controllers/dropdown-menu-controller-test.js
+++ b/h/static/scripts/tests/controllers/dropdown-menu-controller-test.js
@@ -4,25 +4,23 @@ var DropdownMenuController = require('../../controllers/dropdown-menu-controller
 var util = require('./util');
 
 var TEMPLATE = ['<div class="js-dropdown-menu">',
-                '<span class="js-dropdown-menu-toggle">Toggle</span>',
-                '<span class="js-dropdown-menu-content">Menu</span>',
+                '<span data-ref="dropdownMenuToggle">Toggle</span>',
+                '<span data-ref="dropdownMenuContent">Menu</span>',
                 '</div>'].join('\n');
 
 describe('DropdownMenuController', function () {
-  var container;
+  var ctrl;
   var toggleEl;
   var menuEl;
 
   beforeEach(function () {
-    container = util.setupComponent(document, TEMPLATE, {
-      '.js-dropdown-menu': DropdownMenuController,
-    });
-    toggleEl = container.querySelector('.js-dropdown-menu-toggle');
-    menuEl = container.querySelector('.js-dropdown-menu-content');
+    ctrl = util.setupComponent(document, TEMPLATE, DropdownMenuController);
+    toggleEl = ctrl.refs.dropdownMenuToggle;
+    menuEl = ctrl.refs.dropdownMenuContent;
   });
 
   afterEach(function () {
-    container.remove();
+    ctrl.element.remove();
   });
 
   function isOpen() {

--- a/h/static/scripts/tests/controllers/search-bucket-controller-test.js
+++ b/h/static/scripts/tests/controllers/search-bucket-controller-test.js
@@ -5,34 +5,30 @@ var util = require('./util');
 
 var TEMPLATE = [
   '<div class="js-search-bucket">',
-  '<div class="js-header"></div>',
-  '<div class="js-content"></div>',
+  '<div data-ref="header"></div>',
+  '<div data-ref="content"></div>',
   '</div>',
-];
+].join('\n');
 
 describe('SearchBucketController', function () {
-  var container;
-  var headerEl;
-  var contentEl;
   var ctrl;
 
   beforeEach(function () {
-    container = util.setupComponent(document, TEMPLATE, {
-      '.js-search-bucket': SearchBucketController,
-    });
-    headerEl = container.querySelector('.js-header');
-    contentEl = container.querySelector('.js-content');
-    ctrl = container.querySelector('.js-search-bucket').controllers[0];
+    ctrl = util.setupComponent(document, TEMPLATE, SearchBucketController);
+  });
+
+  afterEach(function () {
+    ctrl.element.remove();
   });
 
   it('toggles content expanded state when clicked', function () {
-    headerEl.dispatchEvent(new Event('click'));
-    assert.isTrue(contentEl.classList.contains('is-expanded'));
+    ctrl.refs.header.dispatchEvent(new Event('click'));
+    assert.isTrue(ctrl.refs.content.classList.contains('is-expanded'));
   });
 
   it('scrolls element into view when expanded', function () {
     ctrl.scrollTo = sinon.stub();
-    headerEl.dispatchEvent(new Event('click'));
-    assert.calledWith(ctrl.scrollTo, container.querySelector('.js-search-bucket'));
+    ctrl.refs.header.dispatchEvent(new Event('click'));
+    assert.calledWith(ctrl.scrollTo, ctrl.element);
   });
 });

--- a/h/static/scripts/tests/controllers/util.js
+++ b/h/static/scripts/tests/controllers/util.js
@@ -1,24 +1,22 @@
 'use strict';
 
-var upgradeElements = require('../../base/upgrade-elements');
-
 /**
  * Helper to set up a component for a controller test
  *
  * @param {Document} document - Document to create component in
  * @param {string} template - HTML markup for the component
- * @param {object} controllers - Map of class names to controller classes used to
-                   upgrade the components using `upgradeElements()`
+ * @param {Controller} controller - The controller class
+ * @return {Controller} - The controller instance
  */
-function setupComponent(document, template, controllers) {
+function setupComponent(document, template, ControllerClass) {
   var container = document.createElement('div');
   container.innerHTML = template;
-  document.body.appendChild(container);
-  upgradeElements(container, controllers);
-  return container;
+  var root = container.firstChild;
+  document.body.appendChild(root);
+  container.remove();
+  return new ControllerClass(root);
 }
 
 module.exports = {
   setupComponent: setupComponent,
 };
-

--- a/h/static/scripts/tests/util/dom-test.js
+++ b/h/static/scripts/tests/util/dom-test.js
@@ -1,0 +1,32 @@
+'use strict';
+
+var domUtil = require('../../util/dom');
+
+describe('util/dom', function () {
+  function createDOM(html) {
+    var el = document.createElement('div');
+    el.innerHTML = html;
+    var child = el.children[0];
+    document.body.appendChild(child);
+    el.remove();
+    return child;
+  }
+
+  describe('setElementState', function () {
+    it('adds "is-$state" classes for keys with truthy values', function () {
+      var btn = createDOM('<button></button>');
+      domUtil.setElementState(btn, {
+        visible: true,
+      });
+      assert.deepEqual(Array.from(btn.classList), ['is-visible']);
+    });
+
+    it('removes "is-$state" classes for keys with falsey values', function () {
+      var btn = createDOM('<button class="is-hidden"></button>');
+      domUtil.setElementState(btn, {
+        hidden: false,
+      });
+      assert.deepEqual(Array.from(btn.classList), []);
+    });
+  });
+});

--- a/h/static/scripts/tests/util/string-test.js
+++ b/h/static/scripts/tests/util/string-test.js
@@ -1,0 +1,21 @@
+'use strict';
+
+var stringUtil = require('../../util/string');
+
+describe('util/string', function () {
+  describe('hyphenate', function () {
+    it('converts input to kebab-case', function () {
+      assert.equal(stringUtil.hyphenate('fooBar'), 'foo-bar');
+      assert.equal(stringUtil.hyphenate('FooBar'), '-foo-bar');
+    });
+  });
+
+  describe('unhyphenate', function () {
+    it('converts input to camelCase', function () {
+      assert.equal(stringUtil.unhyphenate('foo-bar'), 'fooBar');
+      assert.equal(stringUtil.unhyphenate('foo-bar-'), 'fooBar');
+      assert.equal(stringUtil.unhyphenate('foo-bar-baz'), 'fooBarBaz');
+      assert.equal(stringUtil.unhyphenate('-foo-bar-baz'), 'FooBarBaz');
+    });
+  });
+});

--- a/h/static/scripts/util/dom.js
+++ b/h/static/scripts/util/dom.js
@@ -1,0 +1,28 @@
+'use strict';
+
+var stringUtil = require('./string');
+
+var hyphenate = stringUtil.hyphenate;
+
+/**
+ * Utility functions for DOM manipulation.
+ */
+
+/**
+ * Set the state classes (`is-$state`) on an element.
+ *
+ * @param {Element} el
+ * @param {Object} state - A map of state keys to boolean. For each key `k`,
+ *                 the class `is-$k` will be added to the element if the value
+ *                 is true or removed otherwise.
+ */
+function setElementState(el, state) {
+  Object.keys(state).forEach(function (key) {
+    var stateClass = 'is-' + hyphenate(key);
+    el.classList.toggle(stateClass, !!state[key]);
+  });
+}
+
+module.exports = {
+  setElementState: setElementState,
+};

--- a/h/static/scripts/util/string.js
+++ b/h/static/scripts/util/string.js
@@ -1,0 +1,25 @@
+'use strict';
+
+/**
+ * Convert a `camelCase` or `CapitalCase` string to `kebab-case`
+ */
+function hyphenate(name) {
+  var uppercasePattern = /([A-Z])/g;
+  return name.replace(uppercasePattern, '-$1').toLowerCase();
+}
+
+/** Convert a `kebab-case` string to `camelCase` */
+function unhyphenate(name) {
+  var idx = name.indexOf('-');
+  if (idx === -1) {
+    return name;
+  } else {
+    var ch = (name[idx+1] || '').toUpperCase();
+    return unhyphenate(name.slice(0,idx) + ch + name.slice(idx+2));
+  }
+}
+
+module.exports = {
+  hyphenate: hyphenate,
+  unhyphenate: unhyphenate,
+};

--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -41,7 +41,7 @@
     {{ bucket.domain }}
   </div>
   <div class="search-result-bucket__content">
-    <div class="search-result-bucket__header js-header">
+    <div class="search-result-bucket__header" data-ref="header">
       <div class="search-result-bucket__title">{{ bucket.title }}</div>
       <div class="search-result-bucket__annotations-count">
         <div class="search-result-bucket__annotations-count-container">
@@ -49,7 +49,7 @@
         </div>
       </div>
     </div>
-    <div class="search-result-bucket__annotation-cards-container js-content">
+    <div class="search-result-bucket__annotation-cards-container" data-ref="content">
       <ol class="search-result-bucket__annotation-cards">
         {% for result in bucket.annotations %}
           {{ annotation_card(result.annotation, request) }}

--- a/h/templates/deform/includes/common_attrs.jinja2
+++ b/h/templates/deform/includes/common_attrs.jinja2
@@ -4,14 +4,18 @@
 {% set field_css_class = 'form-input' %}
 {% endif %}
 
+{% if field.widget.template == 'textarea' and field.widget.max_length %}
+{% set ref = 'characterLimitInput' %}
+{% endif %}
+
 name="{{ field.name }}"
 value="{{ cstruct }}"
 id="{{ field.oid }}"
+data-ref="{{ ref }}"
 class="{{field_css_class}}
       {% if field.widget.css_class %} {{ field.widget.css_class }} {% endif %}
       {% if field.widget.autofocus %} js-select-onfocus{% endif %}
-      {% if field.schema.hint %} has-hint {% endif %}
-      {% if field.widget.template == 'textarea' and field.widget.max_length %}js-character-limit-input{% endif %}"
+      {% if field.schema.hint %} has-hint {% endif %}"
 {%- if field.widget.size -%}
 size="{{ field.widget.size }}"
 {% endif -%}

--- a/h/templates/deform/textarea.jinja2
+++ b/h/templates/deform/textarea.jinja2
@@ -1,3 +1,8 @@
+
 <textarea
 {% include "includes/common_attrs.jinja2" %}>{{ cstruct }}</textarea>
-{%- if field.widget.max_length -%}<span class="form-input__character-counter js-character-limit-counter">Up to {{ field.widget.max_length }} characters</span>{% endif %}
+{% if field.widget.max_length %}
+  <span class="form-input__character-counter" data-ref="characterLimitCounter">
+    Up to {{ field.widget.max_length }} characters
+  </span>
+{% endif %}

--- a/h/templates/includes/dropdown_menu.html.jinja2
+++ b/h/templates/includes/dropdown_menu.html.jinja2
@@ -15,10 +15,10 @@
 #}
 {% macro dropdown_menu(items, title='', footer_item=None) -%}
 <div class="dropdown-menu js-dropdown-menu">
-  <span class="js-dropdown-menu-toggle">
+  <span data-ref="dropdownMenuToggle">
     {{ caller() }}
   </span>
-  <div class="dropdown-menu__menu js-dropdown-menu-content">
+  <div class="dropdown-menu__menu" data-ref="dropdownMenuContent">
     <h2 class="dropdown-menu__title">{{ title }}</h2>
     <ul>
       {% for item in items %}

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "gulp-svgmin": "^1.2.2",
     "gulp-util": "^3.0.7",
     "hypothesis": "^0.38.1",
+    "inherits": "^2.0.1",
     "is-equal-shallow": "^0.1.3",
     "jquery": "1.11.1",
     "js-polyfills": "^0.1.16",


### PR DESCRIPTION
In preparation for implementing more complex controllers such as the one
that will support inline form editing, add a `Controller` base class
which provides shared functionality and helps to codify/reduce boilerplate in patterns that are common across controllers.

 - Setting the state of the controller and updating the DOM to reflect
   that

 - Replacing the controlled Element's content with a new version
   rendered on the server

 - Getting references to the various elements within the controlled
   element which the controller needs to interact with

 * Add Controller base class and rewrite DropdownMenuController and
   SearchBucketController to use it

 * Simplify tests using functionality from the Controller base class

I'm aware that there is a danger of inventing our own UI framework here, so in the meantime I'm keeping an eye open for existing solutions which are a good fit for our needs.