### PR TITLE
Cleanup form CSS component names

### DIFF
--- a/h/static/styles/partials-v2/_form-actions.scss
+++ b/h/static/styles/partials-v2/_form-actions.scss
@@ -12,7 +12,7 @@
   align-items: center;
 }
 
-.form-actions-message {
+.form-actions__message {
   @include font-small;
 
   color: $grey-4;

--- a/h/static/styles/partials-v2/_form-container.scss
+++ b/h/static/styles/partials-v2/_form-container.scss
@@ -1,0 +1,17 @@
+// A container for forms that are centered on a page.
+// Used for pages whose primary purpose is to display a form.
+// ---------------------------------------------------------
+
+.form-container {
+  margin-left: auto;
+  margin-right: auto;
+
+  // Max width of form fields should be 500px. It is set to 530px here to
+  // account for the padding
+  max-width: 530px;
+
+  // Account form padding is set to align left edge of form with left edge of
+  // masthead
+  padding-left: 15px;
+  padding-right: 15px;
+}

--- a/h/static/styles/partials-v2/_form.scss
+++ b/h/static/styles/partials-v2/_form.scss
@@ -2,20 +2,6 @@
 // -------------------------
 // Specs: https://goo.gl/pEV9E1
 
-.form {
-  margin-left: auto;
-  margin-right: auto;
-
-  // Max width of form fields should be 500px. It is set to 530px here to
-  // account for the padding
-  max-width: 530px;
-
-  // Account form padding is set to align left edge of form with left edge of
-  // masthead
-  padding-left: 15px;
-  padding-right: 15px;
-}
-
 .form-header {
   margin-top: 55px;
   margin-bottom: 30px;

--- a/h/static/styles/site-v2.scss
+++ b/h/static/styles/site-v2.scss
@@ -10,6 +10,7 @@
 @import 'partials-v2/dropdown-menu';
 @import 'partials-v2/form-actions';
 @import 'partials-v2/form-checkbox';
+@import 'partials-v2/form-container';
 @import 'partials-v2/form-input';
 @import 'partials-v2/form';
 @import 'partials-v2/link';

--- a/h/templates/accounts/forgot_password.html.jinja2
+++ b/h/templates/accounts/forgot_password.html.jinja2
@@ -15,7 +15,7 @@ Password reset
 {% block content %}
 {%if feature('activity_pages') %}
   {% include "h:templates/includes/logo-header.html.jinja2" %}
-  <div class="form content">
+  <div class="form-container content">
     <h1 class="form-header">Reset your password</h1>
     {{ form }}
     <footer class="form-footer">

--- a/h/templates/accounts/login.html.jinja2
+++ b/h/templates/accounts/login.html.jinja2
@@ -9,7 +9,7 @@
 {% block content %}
   {%if feature('activity_pages') %}
     {% include "h:templates/includes/logo-header.html.jinja2" %}
-    <div class="form content">
+    <div class="form-container content">
       <h1 class="form-header">Log in</h1>
       {{ form }}
       <footer class="form-footer">

--- a/h/templates/accounts/reset.html.jinja2
+++ b/h/templates/accounts/reset.html.jinja2
@@ -15,7 +15,7 @@ Password reset
 {% block content %}
   {% if feature('activity_pages') %}
   {% include "h:templates/includes/logo-header.html.jinja2" %}
-  <div class="form content">
+  <div class="form-container content">
     <h1 class="form-header">New password</h1>
     {% if not has_code %}
     <div class="form-description">

--- a/h/templates/accounts/signup.html.jinja2
+++ b/h/templates/accounts/signup.html.jinja2
@@ -15,7 +15,7 @@ Create account
 {% block content %}
   {%if feature('activity_pages') %}
     {% include "h:templates/includes/logo-header.html.jinja2" %}
-    <div class="form content">
+    <div class="form-container content">
       <h1 class="form-header">Sign up for Hypothesis</h1>
       {{ form }}
       <footer class="form-footer">

--- a/h/templates/deform/form.jinja2
+++ b/h/templates/deform/form.jinja2
@@ -1,11 +1,17 @@
+{% if feature('activity_pages') %}
+{% set form_buttons_class = 'form-actions__buttons' %}
+{% set form_message_class = 'form-actions__message' %}
+{% else %}
+{% set form_buttons_class = 'form-actions-buttons' %}
+{% set form_message_class = 'form-actions-message' %}
+{% endif %}
+
 <form id="{{ field.formid }}"
       action="{{ field.action }}"
       method="{{ field.method }}"
       enctype="multipart/form-data"
       accept-charset="utf-8"
-      {% if field.css_class -%}
-      class="{{ field.css_class }}"
-      {%- endif -%}>
+      class="form {% if field.css_class %}{{ field.css_class }} {% endif %}"
   <input type="hidden" name="__formid__" value="{{ field.formid }}" />
 
   {%- for f in field.children -%}
@@ -13,13 +19,13 @@
   {% endfor -%}
 
   <div class="form-actions">
-    <div class="form-actions-message">
+    <div class="{{ form_message_class }}">
       {%- if field.footer %}{{ field.footer | safe }}{% endif -%}
     </div>
     {% if feature('activity_pages') %}
     <div class="u-stretch"></div>
     {% endif %}
-    <div class="form-actions-buttons">
+    <div class="{{ form_buttons_class }}">
       {%- for button in field.buttons -%}
         <button id="{{ field.formid + button.name }}"
                 name="{{ button.name }}"

--- a/h/templates/layouts/account.html.jinja2
+++ b/h/templates/layouts/account.html.jinja2
@@ -27,7 +27,7 @@
   {% endif %}
   <div class="content paper">
     {% if feature('activity_pages') %}
-      <div class="form">
+      <div class="form-container">
         <nav class="tabs">
           <ul>
             {% for route, title in nav_pages %}

--- a/h/templates/layouts/group.html.jinja2
+++ b/h/templates/layouts/group.html.jinja2
@@ -6,7 +6,7 @@
   {{ panel('navbar') }}
 
   <div class="content paper">
-    <div class="form">
+    <div class="form-container">
       {% if request.session.peek_flash('success') -%}
         <div class="form-flash">
           {% for message in request.session.pop_flash('success') %}


### PR DESCRIPTION
 * Rename the `form` class to `form-container` since it represents the
   container that centers a form within a page, not the form itself and
   we'll probably want to use different form containers in future for
   other forms.

 * Update form-actions sub-elements to use BEM-structured names