### PR TITLE
Inline form editing

### DIFF
--- a/h/accounts/views.py
+++ b/h/accounts/views.py
@@ -566,10 +566,11 @@ class EditProfileController(object):
             self.request,
             self.form,
             on_success=self._update_user,
-            on_failure=self._template_data)
+            on_failure=self._template_data,
+            inline_editing=True)
 
     def _template_data(self):
-        return {'form': self.form.render()}
+        return {'form': self.form.render(inline_editing=True)}
 
     def _update_user(self, appstruct):
         user = self.request.authenticated_user

--- a/h/form.py
+++ b/h/form.py
@@ -134,8 +134,9 @@ def handle_form_submission(request, form, on_success, on_failure, **kwargs):
         if result is None:
             result = httpexceptions.HTTPFound(location=request.url)
 
-        request.session.flash(_("Success. We've saved your changes."),
-                              'success')
+        if not request.is_xhr:
+            request.session.flash(_("Success. We've saved your changes."),
+                                  'success')
 
     return to_xhr_response(request, result, form, **kwargs)
 

--- a/h/form.py
+++ b/h/form.py
@@ -95,7 +95,7 @@ def configure_environment(config):  # pragma: no cover
     config.registry[ENVIRONMENT_KEY] = create_environment(base)
 
 
-def handle_form_submission(request, form, on_success, on_failure):
+def handle_form_submission(request, form, on_success, on_failure, **kwargs):
     """
     Handle the submission of the given form in a standard way.
 
@@ -137,10 +137,10 @@ def handle_form_submission(request, form, on_success, on_failure):
         request.session.flash(_("Success. We've saved your changes."),
                               'success')
 
-    return to_xhr_response(request, result, form)
+    return to_xhr_response(request, result, form, **kwargs)
 
 
-def to_xhr_response(request, non_xhr_result, form):
+def to_xhr_response(request, non_xhr_result, form, **kwargs):
     """
     Return an XHR response for the given ``form``, or ``non_xhr_result``.
 
@@ -165,7 +165,7 @@ def to_xhr_response(request, non_xhr_result, form):
         return non_xhr_result
 
     request.override_renderer = 'string'
-    return form.render()
+    return form.render(**kwargs)
 
 
 def includeme(config):  # pragma: no cover

--- a/h/groups/views.py
+++ b/h/groups/views.py
@@ -91,11 +91,12 @@ class GroupEditController(object):
                 self.request,
                 self.form,
                 on_success=self._update_group,
-                on_failure=self._template_data)
+                on_failure=self._template_data,
+                inline_editing=True)
 
     def _template_data(self):
         return {
-            'form': self.form.render(),
+            'form': self.form.render(inline_editing=True),
             'group_path': self.request.route_path('group_read',
                                                   pubid=self.group.pubid,
                                                   slug=self.group.slug)

--- a/h/static/scripts/base/controller.js
+++ b/h/static/scripts/base/controller.js
@@ -1,5 +1,19 @@
 'use strict';
 
+var dom = require('../util/dom');
+
+function addRef(map, ref, el) {
+  if (map[ref]) {
+    if (Array.isArray(map[ref])) {
+      map[ref].push(el);
+    } else {
+      map[ref] = [map[ref], el];
+    }
+  } else {
+    map[ref] = el;
+  }
+}
+
 /**
  * Search the DOM tree starting at `el` and return a map of "data-ref" attribute
  * values to elements.
@@ -10,18 +24,10 @@ function findRefs(el, map) {
   }
   map = map || {};
 
-  var ref = el.dataset.ref;
-  if (ref) {
-    if (map[ref]) {
-      if (Array.isArray(map[ref])) {
-        map[ref].push(el);
-      } else {
-        map[ref] = [map[ref], el];
-      }
-    } else {
-      map[ref] = el;
-    }
-  }
+  var refs = (el.dataset.ref || '').split(' ');
+  refs.forEach(function (ref) {
+    addRef(map, ref, el);
+  });
 
   for (var i=0; i < el.children.length; i++) {
     var node = el.children[i];
@@ -82,6 +88,19 @@ Controller.prototype.setState = function (changes) {
  */
 Controller.prototype.forceUpdate = function () {
   this.update(this.state, this.state);
+};
+
+/*
+ * Replace the HTML content of the element with an updated version from the
+ * server.
+ */
+Controller.prototype.reload = function (html) {
+  this.element.controllers = null;
+  var root = dom.replaceElement(this.element, html);
+
+  this.element = root;
+  this.refs = findRefs(root);
+  this.state = {};
 };
 
 module.exports = Controller;

--- a/h/static/scripts/base/controller.js
+++ b/h/static/scripts/base/controller.js
@@ -1,0 +1,87 @@
+'use strict';
+
+/**
+ * Search the DOM tree starting at `el` and return a map of "data-ref" attribute
+ * values to elements.
+ */
+function findRefs(el, map) {
+  if (!el.dataset) {
+    return map;
+  }
+  map = map || {};
+
+  var ref = el.dataset.ref;
+  if (ref) {
+    if (map[ref]) {
+      if (Array.isArray(map[ref])) {
+        map[ref].push(el);
+      } else {
+        map[ref] = [map[ref], el];
+      }
+    } else {
+      map[ref] = el;
+    }
+  }
+
+  for (var i=0; i < el.children.length; i++) {
+    var node = el.children[i];
+    if (node.nodeType === Node.ELEMENT_NODE) {
+      findRefs(node, map);
+    }
+  }
+
+  return map;
+}
+
+/**
+ * Base class for controllers that upgrade elements with additional
+ * functionality.
+ *
+ * - Child elements with `data-ref="$name"` attributes are exposed on the
+ *   controller as `this.refs.$name`.
+ * - The element passed to the controller is exposed via the `element` property
+ * - The controllers attached to an element are accessible via the
+ *   `element.controllers` array
+ *
+ * The controller maintains internal state in `this.state`, which can only be
+ * updated by calling (`this.setState(changes)`). Whenever the internal state of
+ * the controller changes, `this.update()` is called to sync the DOM with this
+ * state.
+ *
+ * @param {Element} element - The DOM Element to upgrade
+ */
+function Controller(element) {
+  if (!element.controllers) {
+    element.controllers = [this];
+  } else {
+    element.controllers.push(this);
+  }
+
+  this.state = {};
+  this.element = element;
+  this.refs = findRefs(element);
+}
+
+/**
+ * Set the state of the controller.
+ *
+ * This will merge `changes` into the current state and call the `update()`
+ * method provided by the subclass to update the DOM to match the current state.
+ */
+Controller.prototype.setState = function (changes) {
+  var prevState = this.state;
+  this.state = Object.freeze(Object.assign({}, this.state, changes));
+  this.update(this.state, prevState);
+};
+
+/**
+ * Calls update() with the current state.
+ *
+ * This is useful for controllers where the state is available in the DOM
+ * itself, so doesn't need to be maintained internally.
+ */
+Controller.prototype.forceUpdate = function () {
+  this.update(this.state, this.state);
+};
+
+module.exports = Controller;

--- a/h/static/scripts/base/upgrade-elements.js
+++ b/h/static/scripts/base/upgrade-elements.js
@@ -22,12 +22,7 @@ function upgradeElements(root, controllers) {
     elements.forEach(function (el) {
       var ControllerClass = controllers[selector];
       try {
-        var ctrl = new ControllerClass(el);
-        if (!el.controllers) {
-          el.controllers = [ctrl];
-        } else {
-          el.controllers.push(ctrl);
-        }
+        new ControllerClass(el);
       } catch (err) {
         console.error('Failed to upgrade element %s with controller', el, ControllerClass, ':', err.toString());
 

--- a/h/static/scripts/controllers/character-limit-controller.js
+++ b/h/static/scripts/controllers/character-limit-controller.js
@@ -1,29 +1,28 @@
 'use strict';
 
+var inherits = require('inherits');
+
+var Controller = require('../base/controller');
+var setElementState = require('../util/dom').setElementState;
+
 function CharacterLimitController(element) {
-  var counter = element.parentElement.querySelector(
-    '.js-character-limit-counter');
-  var input = element.querySelector('.js-character-limit-input');
-  var maxlength = parseInt(input.dataset.maxlength);
+  Controller.call(this, element);
 
-  counter.textContent = '';
-
-  function updateCounter() {
-    var length = input.value.length;
-
-    counter.textContent = length + '/' + maxlength;
-
-    if (length > maxlength) {
-      counter.classList.add('is-too-long');
-    } else {
-      counter.classList.remove('is-too-long');
-    }
-  }
-
-  updateCounter();
-  input.addEventListener('input', updateCounter);
-
-  counter.classList.add('is-ready');
+  var self = this;
+  this.refs.characterLimitInput.addEventListener('input', function () {
+    self.forceUpdate();
+  });
+  this.forceUpdate();
 }
+inherits(CharacterLimitController, Controller);
+
+CharacterLimitController.prototype.update = function () {
+  var input = this.refs.characterLimitInput;
+  var maxlength = parseInt(input.dataset.maxlength);
+  var counter = this.refs.characterLimitCounter;
+  counter.textContent = input.value.length + '/' + maxlength;
+  setElementState(counter, {tooLong: input.value.length > maxlength});
+  setElementState(this.refs.characterLimitCounter, {ready: true});
+};
 
 module.exports = CharacterLimitController;

--- a/h/static/scripts/controllers/dropdown-menu-controller.js
+++ b/h/static/scripts/controllers/dropdown-menu-controller.js
@@ -1,21 +1,30 @@
 'use strict';
 
+var inherits = require('inherits');
+
+var Controller = require('../base/controller');
+var setElementState = require('../util/dom').setElementState;
+
 /**
  * Controller for dropdown menus.
  */
 function DropdownMenuController(element) {
-  var toggleEl = element.querySelector('.js-dropdown-menu-toggle');
-  var contentEl = element.querySelector('.js-dropdown-menu-content');
+  Controller.call(this, element);
+
+  var self = this;
+  var toggleEl = this.refs.dropdownMenuToggle;
 
   var handleClickOutside = function (event) {
-    if (!contentEl.contains(event.target)) {
+    if (!self.refs.dropdownMenuContent.contains(event.target)) {
       // When clicking outside the menu on the toggle element, stop the event
       // so that it does not re-trigger the menu
       if (toggleEl.contains(event.target)) {
         event.stopPropagation();
         event.preventDefault();
       }
-      contentEl.classList.remove('is-open');
+
+      self.setState({open: false});
+
       element.ownerDocument.removeEventListener('click', handleClickOutside,
         true /* capture */);
     }
@@ -25,11 +34,16 @@ function DropdownMenuController(element) {
     event.preventDefault();
     event.stopPropagation();
 
-    contentEl.classList.add('is-open');
+    self.setState({open: true});
 
     element.ownerDocument.addEventListener('click', handleClickOutside,
       true /* capture */);
   });
 }
+inherits(DropdownMenuController, Controller);
+
+DropdownMenuController.prototype.update = function (state) {
+  setElementState(this.refs.dropdownMenuContent, {open: state.open});
+};
 
 module.exports = DropdownMenuController;

--- a/h/static/scripts/controllers/form-controller.js
+++ b/h/static/scripts/controllers/form-controller.js
@@ -1,0 +1,161 @@
+'use strict';
+
+var inherits = require('inherits');
+
+var Controller = require('../base/controller');
+var dom = require('../util/dom');
+var submitForm = require('../util/submit-form');
+
+var setElementState = dom.setElementState;
+
+function container(el) {
+  if (el.dataset.ref && el.dataset.ref.indexOf('formInputContainer') !== -1) {
+    return el;
+  } else {
+    return container(el.parentElement);
+  }
+}
+
+/**
+ * A controller which adds inline editing functionality to forms
+ */
+function FormController(element) {
+  Controller.call(this, element);
+
+  this._init(element);
+}
+inherits(FormController, Controller);
+
+FormController.prototype._init = function (element) {
+  var self = this;
+
+  var inlineEditingEnabled = !!element.dataset.inlineEditing;
+  if (!inlineEditingEnabled) {
+    setElementState(this.refs.formButtons, {visible: true});
+    return;
+  }
+
+  setElementState(this.refs.cancelBtn, {hidden: false});
+  this.refs.cancelBtn.addEventListener('click', function (event) {
+    event.preventDefault();
+    self.cancel();
+  });
+  element.addEventListener('keypress', function (event) {
+    if (event.key === 'Escape') {
+      self.cancel();
+    }
+  });
+
+  // Begin editing when an input field is focused
+  [].concat(this.refs.formInput).forEach(function (inputEl) {
+    inputEl.addEventListener('focus', function () {
+      if (self.state.editingField !== inputEl) {
+        self.setState({
+          editingField: inputEl,
+          initialValue: inputEl.value,
+        });
+      }
+    });
+  });
+
+  // Setup AJAX handling for forms
+  element.addEventListener('submit', function (event) {
+    event.preventDefault();
+    self.submit();
+  });
+
+  this.state = {
+    editing: false,
+    saving: false,
+  };
+  this.update(this.state, {});
+};
+
+FormController.prototype.update = function (state, prevState) {
+  if (prevState.editingField !== state.editingField) {
+    if (prevState.editingField) {
+      setElementState(container(prevState.editingField), {
+        editing: false,
+
+        // Hide validation error messages after reverting field to previous
+        // value. The `error` state may be set on the server.
+        error: false,
+      });
+      if (prevState.initialValue) {
+        prevState.editingField.value = prevState.initialValue;
+      }
+      prevState.editingField.blur();
+    }
+
+    if (state.editingField) {
+      state.editingField.focus();
+      setElementState(container(state.editingField), {editing: true});
+      state.editingField.parentElement.insertBefore(this.refs.formButtons,
+        state.editingField.nextSibling);
+    }
+  }
+
+  var isEditing = !!state.editingField;
+  this.refs.formBackdrop.style.display = isEditing ? 'block' : 'none';
+
+  setElementState(this.element, {editing: isEditing});
+  setElementState(this.refs.formButtons, {
+    visible: isEditing,
+    saving: state.saving,
+  });
+};
+
+/**
+ * Cancel editing for the currently active field.
+ */
+FormController.prototype.cancel = function () {
+  this.setState({editingField: null});
+};
+
+/**
+ * Replace the form with an updated version rendered on the server.
+ * @param {string} form
+ */
+FormController.prototype._reload = function (form) {
+  this.reload(form);
+  this._init(this.element);
+};
+
+/**
+ * Perform an AJAX submission of the form and replace it with the rendered
+ * result.
+ */
+FormController.prototype.submit = function () {
+  this.setState({saving: true});
+
+  var self = this;
+  return submitForm(this.element).then(function (rsp) {
+    self.setState({editingField: null});
+    self._reload(rsp.form);
+
+  }).catch(function (err) {
+    var activeFieldId;
+    var prevValue;
+    if (self.state.editingField) {
+      activeFieldId = self.state.editingField.id;
+      prevValue = self.state.initialValue;
+    }
+
+    self._reload(err.form);
+
+    // Resume editing the field.
+    // TODO - When the user presses escape we need to revert the form back to
+    // its saved state
+    if (activeFieldId) {
+      var failedField = document.getElementById(activeFieldId);
+      self.setState({
+        editingField: failedField,
+        initialValue: prevValue,
+      });
+    }
+  }).then(function () {
+    self.setState({saving: false});
+  });
+};
+
+module.exports = FormController;

--- a/h/static/scripts/controllers/search-bucket-controller.js
+++ b/h/static/scripts/controllers/search-bucket-controller.js
@@ -1,22 +1,30 @@
 'use strict';
 
+var inherits = require('inherits');
 var scrollIntoView = require('scroll-into-view');
 
-function SearchBucketController(element) {
-  this.scrollTo = scrollIntoView;
+var Controller = require('../base/controller');
+var setElementState = require('../util/dom').setElementState;
 
-  var header = element.querySelector('.js-header');
-  var content = element.querySelector('.js-content');
+function SearchBucketController(element) {
+  Controller.call(this, element);
+
+  this.scrollTo = scrollIntoView;
   var self = this;
 
-  header.addEventListener('click', function () {
-    element.classList.toggle('is-expanded');
-    content.classList.toggle('is-expanded');
-
-    if (element.classList.contains('is-expanded')) {
-      self.scrollTo(element);
-    }
+  this.refs.header.addEventListener('click', function () {
+    self.setState({expanded: !self.state.expanded});
   });
 }
+inherits(SearchBucketController, Controller);
+
+SearchBucketController.prototype.update = function (state) {
+  setElementState(this.refs.content, {expanded: state.expanded});
+  setElementState(this.refs.header, {expanded: state.expanded});
+
+  if (state.expanded) {
+    this.scrollTo(this.element);
+  }
+};
 
 module.exports = SearchBucketController;

--- a/h/static/scripts/controllers/tooltip-controller.js
+++ b/h/static/scripts/controllers/tooltip-controller.js
@@ -1,5 +1,9 @@
 'use strict';
 
+var inherits = require('inherits');
+
+var Controller = require('../base/controller');
+
 /**
  * A custom tooltip similar to the one used in Google Docs which appears
  * instantly when activated on a target element.
@@ -16,6 +20,8 @@
  * @param {Element} el - The container for the tooltip.
  */
 function TooltipController(el) {
+  Controller.call(this, el);
+
   var self = this;
 
   // With mouse input, show the tooltip on hover. On touch devices we rely on
@@ -31,34 +37,30 @@ function TooltipController(el) {
     self.setState({target: null});
   });
 
-  this.setState = function (state) {
-    this.state = Object.freeze(Object.assign({}, this.state, state));
-    this.render();
-  };
-
-  this.render = function () {
-    if (!this.state.target) {
-      this._el.style.visibility = 'hidden';
-      return;
-    }
-
-    var target = this.state.target;
-    var label = target.getAttribute('aria-label');
-    this._labelEl.textContent = label;
-
-    Object.assign(this._el.style, {
-      visibility: '',
-      bottom: 'calc(100% + 5px)',
-    });
-  };
-
   this._el = el.ownerDocument.createElement('div');
   this._el.innerHTML = '<span class="tooltip-label js-tooltip-label"></span>';
   this._el.className = 'tooltip';
   el.appendChild(this._el);
   this._labelEl = this._el.querySelector('.js-tooltip-label');
 
-  this.setState({});
+  this.setState({target: null});
 }
+inherits(TooltipController, Controller);
+
+TooltipController.prototype.update = function (state) {
+  if (!state.target) {
+    this._el.style.visibility = 'hidden';
+    return;
+  }
+
+  var target = state.target;
+  var label = target.getAttribute('aria-label');
+  this._labelEl.textContent = label;
+
+  Object.assign(this._el.style, {
+    visibility: '',
+    bottom: 'calc(100% + 5px)',
+  });
+};
 
 module.exports = TooltipController;

--- a/h/static/scripts/polyfills.js
+++ b/h/static/scripts/polyfills.js
@@ -6,6 +6,7 @@ require('core-js/fn/array/find');
 require('core-js/fn/array/find-index');
 require('core-js/fn/array/from');
 require('core-js/fn/object/assign');
+require('core-js/fn/string/starts-with');
 
 // URL constructor, required by IE 10/11,
 // early versions of Microsoft Edge.

--- a/h/static/scripts/polyfills.js
+++ b/h/static/scripts/polyfills.js
@@ -8,6 +8,9 @@ require('core-js/fn/array/from');
 require('core-js/fn/object/assign');
 require('core-js/fn/string/starts-with');
 
+// DOM polyfills
+require('element-closest'); // Element.closest(), Element.matches()
+
 // URL constructor, required by IE 10/11,
 // early versions of Microsoft Edge.
 try {

--- a/h/static/scripts/site.js
+++ b/h/static/scripts/site.js
@@ -12,6 +12,7 @@ var CharacterLimitController = require('./controllers/character-limit-controller
 var CreateGroupFormController = require('./controllers/create-group-form-controller');
 var DropdownMenuController = require('./controllers/dropdown-menu-controller');
 var FormSelectOnFocusController = require('./controllers/form-select-onfocus-controller');
+var FormController = require('./controllers/form-controller');
 var SearchBucketController = require('./controllers/search-bucket-controller');
 var TooltipController = require('./controllers/tooltip-controller');
 var upgradeElements = require('./base/upgrade-elements');
@@ -20,6 +21,7 @@ var controllers = {
   '.js-character-limit': CharacterLimitController,
   '.js-create-group-form': CreateGroupFormController,
   '.js-dropdown-menu': DropdownMenuController,
+  '.js-form': FormController,
   '.js-select-onfocus': FormSelectOnFocusController,
   '.js-search-bucket': SearchBucketController,
   '.js-tooltip': TooltipController,

--- a/h/static/scripts/tests/base/controller-test.js
+++ b/h/static/scripts/tests/base/controller-test.js
@@ -1,0 +1,50 @@
+'use strict';
+
+var inherits = require('inherits');
+
+var Controller = require('../../base/controller');
+
+function TestController(element) {
+  Controller.call(this, element);
+
+  this.update = sinon.stub();
+}
+inherits(TestController, Controller);
+
+describe('Controller', function () {
+  var ctrl;
+
+  beforeEach(function () {
+    var root = document.createElement('div');
+    root.dataset.ref = 'test';
+    document.body.appendChild(root);
+    ctrl = new TestController(root);
+  });
+
+  afterEach(function () {
+    ctrl.element.remove();
+  });
+
+  it('exposes controllers via the `.controllers` element property', function () {
+    assert.equal(ctrl.element.controllers.length, 1);
+    assert.instanceOf(ctrl.element.controllers[0], TestController);
+  });
+
+  it('exposes elements with "data-ref" attributes on the `refs` property', function () {
+    assert.deepEqual(ctrl.refs, {test: ctrl.element});
+  });
+
+  describe('#setState', function () {
+    it('calls update() with new and previous state', function () {
+      ctrl.setState({open: true});
+      ctrl.update = sinon.stub();
+      ctrl.setState({open: true, saving: true});
+      assert.calledWith(ctrl.update, {
+        open: true,
+        saving: true,
+      }, {
+        open: true,
+      });
+    });
+  });
+});

--- a/h/static/scripts/tests/base/controller-test.js
+++ b/h/static/scripts/tests/base/controller-test.js
@@ -47,4 +47,21 @@ describe('Controller', function () {
       });
     });
   });
+
+  describe('#reload', function () {
+    it("replaces the element's content", function () {
+      ctrl.reload('<div class="is-updated"></div>');
+      assert.isTrue(ctrl.element.classList.contains('is-updated'));
+    });
+
+    it('reinitializes refs', function () {
+      ctrl.reload('<div class="is-updated" data-ref="updated"></div>');
+      assert.deepEqual(ctrl.refs, {updated: ctrl.element});
+    });
+
+    it("resets the controller's state", function () {
+      ctrl.reload('<div class="is-updated"></div>');
+      assert.deepEqual(ctrl.state, {});
+    });
+  });
 });

--- a/h/static/scripts/tests/base/upgrade-elements-test.js
+++ b/h/static/scripts/tests/base/upgrade-elements-test.js
@@ -15,16 +15,4 @@ describe('upgradeElements', function () {
 
     root.remove();
   });
-
-  it('exposes controllers via the `.controllers` element property', function () {
-    function TestController() {}
-
-    var root = document.createElement('div');
-    root.classList.add('js-test');
-    document.body.appendChild(root);
-
-    upgradeElements(document.body, {'.js-test': TestController});
-    assert.equal(root.controllers.length, 1);
-    assert.instanceOf(root.controllers[0], TestController);
-  });
 });

--- a/h/static/scripts/tests/controllers/character-limit-controller-test.js
+++ b/h/static/scripts/tests/controllers/character-limit-controller-test.js
@@ -5,12 +5,12 @@ var util = require('./util');
 
 describe('CharacterLimitController', function () {
 
-  var containerEl;
+  var ctrl;
 
   afterEach(function () {
-    if (containerEl) {
-      containerEl.remove();
-      containerEl = null;
+    if (ctrl) {
+      ctrl.element.remove();
+      ctrl = null;
     }
   });
 
@@ -22,25 +22,18 @@ describe('CharacterLimitController', function () {
     maxlength = maxlength || 250;
 
     var template = '<div class="js-character-limit">';
-    template += '<textarea class="js-character-limit-input" data-maxlength="' + maxlength + '">';
+    template += '<textarea data-ref="characterLimitInput" data-maxlength="' + maxlength + '">';
     if (value) {
       template += value;
     }
-    template += '</textarea><span class="js-character-limit-counter">Foo</span>';
+    template += '</textarea><span data-ref="characterLimitCounter">Foo</span>';
     template += '</div>';
 
-    containerEl = util.setupComponent(document, template, {
-      '.js-character-limit': CharacterLimitController,
-    });
-    var divEl = containerEl.querySelector('.js-character-limit');
-    var counterEl = containerEl.querySelector('.js-character-limit-counter');
-    var textarea = containerEl.querySelector('textarea');
-    var ctrl = divEl.controllers[0];
+    ctrl = util.setupComponent(document, template, CharacterLimitController);
 
     return {
-      containerEl: containerEl,
-      counterEl: counterEl,
-      textarea: textarea,
+      counterEl: ctrl.refs.characterLimitCounter,
+      textarea: ctrl.refs.characterLimitInput,
       ctrl: ctrl,
     };
   }

--- a/h/static/scripts/tests/controllers/dropdown-menu-controller-test.js
+++ b/h/static/scripts/tests/controllers/dropdown-menu-controller-test.js
@@ -4,25 +4,23 @@ var DropdownMenuController = require('../../controllers/dropdown-menu-controller
 var util = require('./util');
 
 var TEMPLATE = ['<div class="js-dropdown-menu">',
-                '<span class="js-dropdown-menu-toggle">Toggle</span>',
-                '<span class="js-dropdown-menu-content">Menu</span>',
+                '<span data-ref="dropdownMenuToggle">Toggle</span>',
+                '<span data-ref="dropdownMenuContent">Menu</span>',
                 '</div>'].join('\n');
 
 describe('DropdownMenuController', function () {
-  var container;
+  var ctrl;
   var toggleEl;
   var menuEl;
 
   beforeEach(function () {
-    container = util.setupComponent(document, TEMPLATE, {
-      '.js-dropdown-menu': DropdownMenuController,
-    });
-    toggleEl = container.querySelector('.js-dropdown-menu-toggle');
-    menuEl = container.querySelector('.js-dropdown-menu-content');
+    ctrl = util.setupComponent(document, TEMPLATE, DropdownMenuController);
+    toggleEl = ctrl.refs.dropdownMenuToggle;
+    menuEl = ctrl.refs.dropdownMenuContent;
   });
 
   afterEach(function () {
-    container.remove();
+    ctrl.element.remove();
   });
 
   function isOpen() {

--- a/h/static/scripts/tests/controllers/form-controller-test.js
+++ b/h/static/scripts/tests/controllers/form-controller-test.js
@@ -1,0 +1,149 @@
+'use strict';
+
+var proxyquire = require('proxyquire');
+
+var util = require('./util');
+var noCallThru = require('../util').noCallThru;
+
+// Simplified version of forms rendered by deform, with the `js-` hooks expected
+// by the controller
+var TEMPLATE = [
+  '<form class="js-form" data-inline-editing="true">',
+  '<div data-ref="formBackdrop"></div>',
+  '<div data-ref="formInputContainer">',
+  '<input id="deformField" data-ref="formInput">',
+  '</div>',
+  '<div data-ref="formButtons">',
+  '<button data-ref="testSaveBtn">Save</button><button data-ref="cancelBtn">',
+  '</div>',
+  '</form>',
+].join('\n');
+
+var UPDATED_FORM = TEMPLATE.replace('js-form', 'js-form is-updated');
+
+describe('FormController', function () {
+  var ctrl;
+  var fakeSubmitForm;
+
+  beforeEach(function () {
+    fakeSubmitForm = sinon.stub();
+    var FormController = proxyquire('../../controllers/form-controller', {
+      '../util/submit-form': noCallThru(fakeSubmitForm),
+    });
+
+    ctrl = util.setupComponent(document, TEMPLATE, FormController);
+  });
+
+  afterEach(function () {
+    ctrl.element.remove();
+  });
+
+  function isEditing() {
+    return ctrl.element.classList.contains('is-editing');
+  }
+
+  function submitForm() {
+    return ctrl.submit();
+  }
+
+  function startEditing() {
+    ctrl.refs.formInput.focus();
+    ctrl.refs.formInput.dispatchEvent(new Event('focus'));
+  }
+
+  function isSaving() {
+    return ctrl.refs.formButtons.classList.contains('is-saving');
+  }
+
+  it('begins editing when a field is focused', function () {
+    ctrl.refs.formInput.focus();
+    ctrl.refs.formInput.dispatchEvent(new Event('focus'));
+    assert.isTrue(isEditing());
+  });
+
+  it('shows backdrop when editing a field', function () {
+    startEditing();
+    assert.equal(ctrl.refs.formBackdrop.style.display, 'block');
+  });
+
+  it('cancels editing when "Cancel" is clicked', function () {
+    startEditing();
+    ctrl.refs.cancelBtn.click();
+    assert.isFalse(isEditing());
+  });
+
+  it('cancels editing when "Escape" is pressed', function () {
+    startEditing();
+    var event = new Event('keypress');
+    event.key = 'Escape';
+    ctrl.element.dispatchEvent(event);
+    assert.isFalse(isEditing());
+  });
+
+  it('reverts a field to its previous value when editing is canceled', function () {
+    ctrl.refs.formInput.value = 'old value';
+    startEditing();
+    ctrl.refs.formInput.value = 'new value';
+    ctrl.refs.cancelBtn.click();
+    assert.equal(ctrl.refs.formInput.value, 'old value');
+  });
+
+  it('hides validation errors when editing is canceled', function () {
+    startEditing();
+
+    // Simulate `error` state being set on field, usually as a result of
+    // the server setting a validation error message
+    ctrl.refs.formInputContainer.classList.add('is-error');
+    ctrl.refs.cancelBtn.click();
+    assert.isFalse(ctrl.refs.formInputContainer.classList.contains('is-error'));
+  });
+
+  it('submits the form when "Save" is clicked', function () {
+    fakeSubmitForm.returns(Promise.resolve({status: 200, form: UPDATED_FORM}));
+    ctrl.refs.testSaveBtn.click();
+    assert.calledWith(fakeSubmitForm, ctrl.element);
+
+    // Ensure that test does not complete until `FormController#submit` has
+    // run
+    return Promise.resolve();
+  });
+
+  it('updates form with rendered version from server when the form is saved', function () {
+    fakeSubmitForm.returns(Promise.resolve({status: 200, form: UPDATED_FORM}));
+    return submitForm().then(function () {
+      assert.isTrue(ctrl.element.classList.contains('is-updated'));
+    });
+  });
+
+  it('stops editing the form when saving succeeds', function () {
+    fakeSubmitForm.returns(Promise.resolve({status: 200, form: UPDATED_FORM}));
+    return submitForm().then(function () {
+      assert.isFalse(isEditing());
+    });
+  });
+
+  it('updates form with rendered version from server when saving fails', function () {
+    startEditing();
+    fakeSubmitForm.returns(Promise.reject({status: 400, form: UPDATED_FORM}));
+    return submitForm().then(function () {
+      assert.isTrue(ctrl.element.classList.contains('is-updated'));
+    });
+  });
+
+  it('keeps editing the form when saving fails', function () {
+    startEditing();
+    fakeSubmitForm.returns(Promise.reject({status: 400, form: UPDATED_FORM}));
+    return submitForm().then(function () {
+      assert.isTrue(isEditing());
+    });
+  });
+
+  it('enters the "saving" state while the form is being submitted', function () {
+    fakeSubmitForm.returns(Promise.resolve({status: 200, form: UPDATED_FORM}));
+    var saved = submitForm();
+    assert.isTrue(isSaving());
+    return saved.then(function () {
+      assert.isFalse(isSaving());
+    });
+  });
+});

--- a/h/static/scripts/tests/controllers/search-bucket-controller-test.js
+++ b/h/static/scripts/tests/controllers/search-bucket-controller-test.js
@@ -5,34 +5,30 @@ var util = require('./util');
 
 var TEMPLATE = [
   '<div class="js-search-bucket">',
-  '<div class="js-header"></div>',
-  '<div class="js-content"></div>',
+  '<div data-ref="header"></div>',
+  '<div data-ref="content"></div>',
   '</div>',
-];
+].join('\n');
 
 describe('SearchBucketController', function () {
-  var container;
-  var headerEl;
-  var contentEl;
   var ctrl;
 
   beforeEach(function () {
-    container = util.setupComponent(document, TEMPLATE, {
-      '.js-search-bucket': SearchBucketController,
-    });
-    headerEl = container.querySelector('.js-header');
-    contentEl = container.querySelector('.js-content');
-    ctrl = container.querySelector('.js-search-bucket').controllers[0];
+    ctrl = util.setupComponent(document, TEMPLATE, SearchBucketController);
+  });
+
+  afterEach(function () {
+    ctrl.element.remove();
   });
 
   it('toggles content expanded state when clicked', function () {
-    headerEl.dispatchEvent(new Event('click'));
-    assert.isTrue(contentEl.classList.contains('is-expanded'));
+    ctrl.refs.header.dispatchEvent(new Event('click'));
+    assert.isTrue(ctrl.refs.content.classList.contains('is-expanded'));
   });
 
   it('scrolls element into view when expanded', function () {
     ctrl.scrollTo = sinon.stub();
-    headerEl.dispatchEvent(new Event('click'));
-    assert.calledWith(ctrl.scrollTo, container.querySelector('.js-search-bucket'));
+    ctrl.refs.header.dispatchEvent(new Event('click'));
+    assert.calledWith(ctrl.scrollTo, ctrl.element);
   });
 });

--- a/h/static/scripts/tests/controllers/util.js
+++ b/h/static/scripts/tests/controllers/util.js
@@ -1,24 +1,22 @@
 'use strict';
 
-var upgradeElements = require('../../base/upgrade-elements');
-
 /**
  * Helper to set up a component for a controller test
  *
  * @param {Document} document - Document to create component in
  * @param {string} template - HTML markup for the component
- * @param {object} controllers - Map of class names to controller classes used to
-                   upgrade the components using `upgradeElements()`
+ * @param {Controller} controller - The controller class
+ * @return {Controller} - The controller instance
  */
-function setupComponent(document, template, controllers) {
+function setupComponent(document, template, ControllerClass) {
   var container = document.createElement('div');
   container.innerHTML = template;
-  document.body.appendChild(container);
-  upgradeElements(container, controllers);
-  return container;
+  var root = container.firstChild;
+  document.body.appendChild(root);
+  container.remove();
+  return new ControllerClass(root);
 }
 
 module.exports = {
   setupComponent: setupComponent,
 };
-

--- a/h/static/scripts/tests/util/dom-test.js
+++ b/h/static/scripts/tests/util/dom-test.js
@@ -29,4 +29,20 @@ describe('util/dom', function () {
       assert.deepEqual(Array.from(btn.classList), []);
     });
   });
+
+  describe('replaceElement', function () {
+    it('replaces the DOM element', function () {
+      var container = createDOM('<div><button></button></div>');
+      var btn = domUtil.replaceElement(container.querySelector('button'),
+        '<button class="updated"></button>');
+      assert.equal(btn.outerHTML, '<button class="updated"></button>');
+    });
+
+    it('throws if the element does not have a parent', function () {
+      var el = document.createElement('div');
+      assert.throws(function () {
+        domUtil.replaceElement(el, '<div></div>');
+      });
+    });
+  });
 });

--- a/h/static/scripts/tests/util/dom-test.js
+++ b/h/static/scripts/tests/util/dom-test.js
@@ -1,0 +1,32 @@
+'use strict';
+
+var domUtil = require('../../util/dom');
+
+describe('util/dom', function () {
+  function createDOM(html) {
+    var el = document.createElement('div');
+    el.innerHTML = html;
+    var child = el.children[0];
+    document.body.appendChild(child);
+    el.remove();
+    return child;
+  }
+
+  describe('setElementState', function () {
+    it('adds "is-$state" classes for keys with truthy values', function () {
+      var btn = createDOM('<button></button>');
+      domUtil.setElementState(btn, {
+        visible: true,
+      });
+      assert.deepEqual(Array.from(btn.classList), ['is-visible']);
+    });
+
+    it('removes "is-$state" classes for keys with falsey values', function () {
+      var btn = createDOM('<button class="is-hidden"></button>');
+      domUtil.setElementState(btn, {
+        hidden: false,
+      });
+      assert.deepEqual(Array.from(btn.classList), []);
+    });
+  });
+});

--- a/h/static/scripts/tests/util/string-test.js
+++ b/h/static/scripts/tests/util/string-test.js
@@ -1,0 +1,21 @@
+'use strict';
+
+var stringUtil = require('../../util/string');
+
+describe('util/string', function () {
+  describe('hyphenate', function () {
+    it('converts input to kebab-case', function () {
+      assert.equal(stringUtil.hyphenate('fooBar'), 'foo-bar');
+      assert.equal(stringUtil.hyphenate('FooBar'), '-foo-bar');
+    });
+  });
+
+  describe('unhyphenate', function () {
+    it('converts input to camelCase', function () {
+      assert.equal(stringUtil.unhyphenate('foo-bar'), 'fooBar');
+      assert.equal(stringUtil.unhyphenate('foo-bar-'), 'fooBar');
+      assert.equal(stringUtil.unhyphenate('foo-bar-baz'), 'fooBarBaz');
+      assert.equal(stringUtil.unhyphenate('-foo-bar-baz'), 'FooBarBaz');
+    });
+  });
+});

--- a/h/static/scripts/tests/util/submit-form-test.js
+++ b/h/static/scripts/tests/util/submit-form-test.js
@@ -1,0 +1,49 @@
+'use strict';
+
+var submitForm = require('../../util/submit-form');
+
+var lastRequest;
+function FakeXMLHttpRequest() {
+  lastRequest = this; // eslint-disable-line consistent-this
+  this.open = sinon.stub();
+  this.setRequestHeader = sinon.stub();
+  this.send = sinon.stub();
+
+  var self = this;
+  setTimeout(function () {
+    self.readyState = XMLHttpRequest.DONE;
+    if (!self.status) {
+      self.status = 200;
+    }
+    self.responseText = 'response';
+    self.onreadystatechange();
+  }, 0);
+}
+FakeXMLHttpRequest.DONE = 4;
+
+describe('submitForm', function () {
+  function createForm() {
+    var form = document.createElement('form');
+    form.action = 'http://example.org/things';
+    form.method = 'POST';
+    form.innerHTML = '<input name="field" value="value">';
+    return form;
+  }
+
+  it('submits the form data', function () {
+    var form = createForm();
+    return submitForm(form, FakeXMLHttpRequest).then(function () {
+      var arg = lastRequest.send.getCall(0).args[0];
+      assert.instanceOf(arg, FormData);
+    });
+  });
+
+  it('returns a rejected promise if the XHR request fails', function () {
+    var form = createForm();
+    var done = submitForm(form, FakeXMLHttpRequest);
+    lastRequest.status = 400;
+    return done.catch(function (err) {
+      assert.deepEqual(err, {status: 400, form: 'response'});
+    });
+  });
+});

--- a/h/static/scripts/util/dom.js
+++ b/h/static/scripts/util/dom.js
@@ -9,6 +9,23 @@ var hyphenate = stringUtil.hyphenate;
  */
 
 /**
+ * Replace a DOM element with an HTML string and return the new DOM element.
+ *
+ * @param {Element} el - DOM Element to replace
+ * @param {string} html - HTML string that replaces the entire element
+ */
+function replaceElement(el, html) {
+  if (!el.parentElement) {
+    throw new Error('Cannot replace an element without a parent');
+  }
+  var parentEl = el.parentElement;
+  var siblings = Array.from(parentEl.children);
+  var nodeIndex = siblings.indexOf(el);
+  el.outerHTML = html;
+  return parentEl.children[nodeIndex];
+}
+
+/**
  * Set the state classes (`is-$state`) on an element.
  *
  * @param {Element} el
@@ -24,5 +41,6 @@ function setElementState(el, state) {
 }
 
 module.exports = {
+  replaceElement: replaceElement,
   setElementState: setElementState,
 };

--- a/h/static/scripts/util/dom.js
+++ b/h/static/scripts/util/dom.js
@@ -1,0 +1,28 @@
+'use strict';
+
+var stringUtil = require('./string');
+
+var hyphenate = stringUtil.hyphenate;
+
+/**
+ * Utility functions for DOM manipulation.
+ */
+
+/**
+ * Set the state classes (`is-$state`) on an element.
+ *
+ * @param {Element} el
+ * @param {Object} state - A map of state keys to boolean. For each key `k`,
+ *                 the class `is-$k` will be added to the element if the value
+ *                 is true or removed otherwise.
+ */
+function setElementState(el, state) {
+  Object.keys(state).forEach(function (key) {
+    var stateClass = 'is-' + hyphenate(key);
+    el.classList.toggle(stateClass, !!state[key]);
+  });
+}
+
+module.exports = {
+  setElementState: setElementState,
+};

--- a/h/static/scripts/util/string.js
+++ b/h/static/scripts/util/string.js
@@ -1,0 +1,25 @@
+'use strict';
+
+/**
+ * Convert a `camelCase` or `CapitalCase` string to `kebab-case`
+ */
+function hyphenate(name) {
+  var uppercasePattern = /([A-Z])/g;
+  return name.replace(uppercasePattern, '-$1').toLowerCase();
+}
+
+/** Convert a `kebab-case` string to `camelCase` */
+function unhyphenate(name) {
+  var idx = name.indexOf('-');
+  if (idx === -1) {
+    return name;
+  } else {
+    var ch = (name[idx+1] || '').toUpperCase();
+    return unhyphenate(name.slice(0,idx) + ch + name.slice(idx+2));
+  }
+}
+
+module.exports = {
+  hyphenate: hyphenate,
+  unhyphenate: unhyphenate,
+};

--- a/h/static/scripts/util/submit-form.js
+++ b/h/static/scripts/util/submit-form.js
@@ -1,0 +1,35 @@
+'use strict';
+
+/**
+ * Submit a form using XMLHttpRequest and update the rendered form with the
+ * response HTML.
+ *
+ * @param {HTMLFormElement} formEl - The `<form>` to submit
+ * @return {Promise} A promise which resolves when the form submission completes
+ */
+function submitForm(formEl, XMLHttpRequest) {
+  XMLHttpRequest = XMLHttpRequest || window.XMLHttpRequest;
+
+  var formData = new FormData(formEl);
+  var req = new XMLHttpRequest();
+  req.open('POST', formEl.action, true /* async */);
+
+  // Flag this as an XHR request so that the server can respond accordingly
+  req.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
+
+  req.send(formData);
+
+  return new Promise(function (resolve, reject) {
+    req.onreadystatechange = function () {
+      if (req.readyState === XMLHttpRequest.DONE) {
+        if (req.status === 200) {
+          resolve({status: req.status, form: req.responseText});
+        } else {
+          reject({status: req.status, form: req.responseText});
+        }
+      }
+    };
+  });
+}
+
+module.exports = submitForm;

--- a/h/static/styles/partials-v2/_base.scss
+++ b/h/static/styles/partials-v2/_base.scss
@@ -32,6 +32,8 @@ $title-font-size: 19px;
 $input-font-size: 15px;
 
 // Z-index scale
+$zindex-modal-backdrop: 5; // Backdrop of a modal dialog or form
+$zindex-modal-content: 6;  // Content of a modal dialog or form
 $zindex-dropdown-menu: 10;
 $zindex-tooltip: 20;
 

--- a/h/static/styles/partials-v2/_btn.scss
+++ b/h/static/styles/partials-v2/_btn.scss
@@ -16,6 +16,14 @@
   white-space: nowrap;
 }
 
+.btn.is-hidden {
+  display: none;
+}
+
+.btn--cancel {
+  background-color: $grey-4;
+}
+
 .btn:hover {
   background-color: $brand;
 }

--- a/h/static/styles/partials-v2/_form-actions.scss
+++ b/h/static/styles/partials-v2/_form-actions.scss
@@ -18,3 +18,21 @@
   color: $grey-4;
   padding-left: 15px;
 }
+
+.form-actions__buttons {
+  .env-js-capable & {
+    display: none;
+  }
+
+  .env-js-capable &.is-visible,
+  .env-js-timeout & {
+    display: block;
+    z-index: $zindex-modal-content;
+    margin-top: 10px;
+  }
+}
+
+.form-actions__buttons.is-saving  .form-actions__btn {
+  opacity: .5;
+}
+

--- a/h/static/styles/partials-v2/_form-input.scss
+++ b/h/static/styles/partials-v2/_form-input.scss
@@ -29,6 +29,10 @@
     background-color: $white;
   }
 
+  .form-input.is-editing {
+    z-index: $zindex-modal-content;
+  }
+
   .form-input.is-error {
     & > .form-input__label {
       color: $brand;
@@ -36,6 +40,10 @@
 
     & > .form-input__input {
       color: $brand;
+    }
+
+    & > .form-input__error-list {
+      display: initial;
     }
   }
 
@@ -157,7 +165,8 @@
     border-width: 2px;
   }
 
-  .form-input__input:focus {
+  .form-input__input:focus,
+  .form-input.is-editing > .form-input__input {
     @include thick-border;
     border-color: $grey-6;
   }
@@ -174,7 +183,12 @@
     box-shadow: none;
   }
 
-  // Validation error message
+  // Validation error messages
+  .form-input__error-list {
+    // The error list is only shown when the input is in an `error` state
+    display: none;
+  }
+
   .form-input__error-item {
     max-width: $validation-message-width;
     position: absolute;

--- a/h/static/styles/partials-v2/_form.scss
+++ b/h/static/styles/partials-v2/_form.scss
@@ -2,6 +2,20 @@
 // -------------------------
 // Specs: https://goo.gl/pEV9E1
 
+// Backdrop which appears behind forms during inline editing
+.form__backdrop {
+  display: none;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: $zindex-modal-backdrop;
+
+  background-color: $white;
+  opacity: 0.5;
+}
+
 .form-header {
   margin-top: 55px;
   margin-bottom: 30px;

--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -41,7 +41,7 @@
     {{ bucket.domain }}
   </div>
   <div class="search-result-bucket__content">
-    <div class="search-result-bucket__header js-header">
+    <div class="search-result-bucket__header" data-ref="header">
       <div class="search-result-bucket__title">{{ bucket.title }}</div>
       <div class="search-result-bucket__annotations-count">
         <div class="search-result-bucket__annotations-count-container">
@@ -49,7 +49,7 @@
         </div>
       </div>
     </div>
-    <div class="search-result-bucket__annotation-cards-container js-content">
+    <div class="search-result-bucket__annotation-cards-container" data-ref="content">
       <ol class="search-result-bucket__annotation-cards">
         {% for result in bucket.annotations %}
           {{ annotation_card(result.annotation, request) }}

--- a/h/templates/deform/form.jinja2
+++ b/h/templates/deform/form.jinja2
@@ -11,8 +11,11 @@
       method="{{ field.method }}"
       enctype="multipart/form-data"
       accept-charset="utf-8"
-      class="form {% if field.css_class %}{{ field.css_class }} {% endif %}">
+      class="form {{ field.css_class or '' }} js-form"
+      {%- if inline_editing %} data-inline-editing="true" {% endif -%}>
   <input type="hidden" name="__formid__" value="{{ field.formid }}" />
+
+  <div class="form__backdrop" data-ref="formBackdrop"></div>
 
   {%- for f in field.children -%}
     {{ field.renderer(field.widget.item_template, field=f, cstruct=cstruct.get(f.name, null)) }}
@@ -25,19 +28,21 @@
     {% if feature('activity_pages') %}
     <div class="u-stretch"></div>
     {% endif %}
-    <div class="{{ form_buttons_class }}">
+    <div class="{{ form_buttons_class }}" data-ref="formButtons">
       {%- for button in field.buttons -%}
         <button id="{{ field.formid + button.name }}"
                 name="{{ button.name }}"
                 type="{{ button.type }}"
-                class="btn{% if button.css_class %} {{ button.css_class }}{% endif %}"
+                class="form-actions__btn btn{% if button.css_class %} {{ button.css_class }}{% endif %}"
                 value="{{ _(button.value) }}"
+                data-ref="formBtn"
                 {%- if button.disabled -%}
                 disabled="disabled"
                 {% endif -%}
                 >
         {{ _(button.title) }}
         </button>
+        <button class="btn btn--cancel is-hidden" data-ref="cancelBtn">Cancel</button>
       {% endfor -%}
     </div>
   </div>

--- a/h/templates/deform/includes/common_attrs.jinja2
+++ b/h/templates/deform/includes/common_attrs.jinja2
@@ -11,7 +11,7 @@
 name="{{ field.name }}"
 value="{{ cstruct }}"
 id="{{ field.oid }}"
-data-ref="{{ ref }}"
+data-ref="{{ ref }} formInput"
 class="{{field_css_class}}
       {% if field.widget.css_class %} {{ field.widget.css_class }} {% endif %}
       {% if field.widget.autofocus %} js-select-onfocus{% endif %}

--- a/h/templates/deform/includes/common_attrs.jinja2
+++ b/h/templates/deform/includes/common_attrs.jinja2
@@ -4,14 +4,18 @@
 {% set field_css_class = 'form-input' %}
 {% endif %}
 
+{% if field.widget.template == 'textarea' and field.widget.max_length %}
+{% set ref = 'characterLimitInput' %}
+{% endif %}
+
 name="{{ field.name }}"
 value="{{ cstruct }}"
 id="{{ field.oid }}"
+data-ref="{{ ref }}"
 class="{{field_css_class}}
       {% if field.widget.css_class %} {{ field.widget.css_class }} {% endif %}
       {% if field.widget.autofocus %} js-select-onfocus{% endif %}
-      {% if field.schema.hint %} has-hint {% endif %}
-      {% if field.widget.template == 'textarea' and field.widget.max_length %}js-character-limit-input{% endif %}"
+      {% if field.schema.hint %} has-hint {% endif %}"
 {%- if field.widget.size -%}
 size="{{ field.widget.size }}"
 {% endif -%}

--- a/h/templates/deform/mapping_item.jinja2
+++ b/h/templates/deform/mapping_item.jinja2
@@ -2,7 +2,7 @@
 {% set field_class = 'form-input' %}
 {% set field_error_state_class = 'is-error' %}
 {% set field_label_class = 'form-input__label' %}
-{% set field_error_list_class = '' %}
+{% set field_error_list_class = 'form-input__error-list' %}
 {% set field_error_item_class = 'form-input__error-item' %}
 {% else %}
 {% set field_class = 'form-group form-field' %}
@@ -15,7 +15,9 @@
 {%- if not field.widget.hidden -%}
 <div class="{{ field_class }}
             {% if field.error %}{{ field_error_state_class }}{% endif %}
-            {% if field.widget.template == 'textarea' and field.widget.max_length -%}js-character-limit{% endif %}"
+            {% if field.widget.template == 'textarea' and field.widget.max_length -%}js-character-limit{% endif %}
+            js-form-input-container
+            "
      {%- if field.description -%}
      title="{{ _(field.description) }}"
      {% endif %}

--- a/h/templates/deform/textarea.jinja2
+++ b/h/templates/deform/textarea.jinja2
@@ -1,3 +1,8 @@
+
 <textarea
 {% include "includes/common_attrs.jinja2" %}>{{ cstruct }}</textarea>
-{%- if field.widget.max_length -%}<span class="form-input__character-counter js-character-limit-counter">Up to {{ field.widget.max_length }} characters</span>{% endif %}
+{% if field.widget.max_length %}
+  <span class="form-input__character-counter" data-ref="characterLimitCounter">
+    Up to {{ field.widget.max_length }} characters
+  </span>
+{% endif %}

--- a/h/templates/includes/dropdown_menu.html.jinja2
+++ b/h/templates/includes/dropdown_menu.html.jinja2
@@ -15,10 +15,10 @@
 #}
 {% macro dropdown_menu(items, title='', footer_item=None) -%}
 <div class="dropdown-menu js-dropdown-menu">
-  <span class="js-dropdown-menu-toggle">
+  <span data-ref="dropdownMenuToggle">
     {{ caller() }}
   </span>
-  <div class="dropdown-menu__menu js-dropdown-menu-content">
+  <div class="dropdown-menu__menu" data-ref="dropdownMenuContent">
     <h2 class="dropdown-menu__title">{{ title }}</h2>
     <ul>
       {% for item in items %}

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "gulp-svgmin": "^1.2.2",
     "gulp-util": "^3.0.7",
     "hypothesis": "^0.38.1",
+    "inherits": "^2.0.1",
     "is-equal-shallow": "^0.1.3",
     "jquery": "1.11.1",
     "js-polyfills": "^0.1.16",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "browserify-shim": "^3.8.12",
     "commander": "^2.9.0",
     "core-js": "^1.2.5",
+    "element-closest": "^2.0.1",
     "end-of-stream": "^1.1.0",
     "exorcist": "^0.4.0",
     "gulp": "^3.9.1",

--- a/tests/h/accounts/views_test.py
+++ b/tests/h/accounts/views_test.py
@@ -15,7 +15,7 @@ class FakeForm(object):
     def set_appstruct(self, appstruct):
         self.appstruct = appstruct
 
-    def render(self):
+    def render(self, **kwargs):
         return self.appstruct
 
 

--- a/tests/h/groups/views_test.py
+++ b/tests/h/groups/views_test.py
@@ -297,7 +297,7 @@ class FakeForm(object):
     def set_appstruct(self, appstruct):
         self.appstruct = appstruct
 
-    def render(self):
+    def render(self, **kwargs):
         return self.appstruct
 
 


### PR DESCRIPTION
**_Depends on: #3771 and #3772_**

This implements an enhancement that enables inline editing for forms (see ) and enables it for the 'Edit Profile' and 'Edit group' forms. Support for the 'Account' and 'Notifications' forms will come separately as these require some additional work.

Forms opt into inline editing by passing the `inline_editing` flag when calling `form.render()`

See https://trello.com/c/KIU3NXPe/411-inline-editing-enhancement-for-forms

----
- [x] Reset form state after user makes a change that results in a validation error and then cancels editing the form