### PR TITLE
Add blacklist for group names

### DIFF
--- a/tests/h/groups/schemas_test.py
+++ b/tests/h/groups/schemas_test.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+
+import colander
+
+from h.groups import schemas
+
+
+class TestUnblacklistedGroupNameSlug(object):
+    @pytest.mark.parametrize('group_name', [
+        'edit',
+        'edIT-',
+        'EDit__',
+        'EDIT-------',
+        'eDiT?',
+        'leave',
+        'leAVE-',
+        'LEAve_',
+        'LEAVE---',
+        'LeAvE???',
+    ])
+    def test_blacklisted(self, dummy_node, group_name):
+        blacklist = set(['edit', 'leave'])
+
+        with pytest.raises(colander.Invalid):
+            schemas.unblacklisted_group_name_slug(dummy_node, group_name, blacklist)
+
+    @pytest.mark.parametrize('group_name', [
+        'Birdwatchers',
+        'My Book Club',
+        'Hello World',
+        'Editors',
+        'Leavers',
+    ])
+    def test_passing(self, dummy_node, group_name):
+        blacklist = set(['edit', 'leave'])
+
+        schemas.unblacklisted_group_name_slug(dummy_node, group_name, blacklist)
+
+    @pytest.fixture
+    def dummy_node(self, pyramid_request):
+        class DummyNode(object):
+            def __init__(self, request):
+                self.bindings = {
+                    'request': request
+                }
+        return DummyNode(pyramid_request)


### PR DESCRIPTION
Since the URL structure is /{pubid}/{slug}, and we have two special URLs
(/{pubid}/leave and /{pubid}/edit) we have to stop allowing group names
that end up with slugs that are "edit" or "leave".

This implements a blacklist similar to what we do for usernames, the
error message says that the chosen group name is not allowed.

Fixes #3775