### PR TITLE
Add character limit enhancement to form fields

### DIFF
--- a/h/accounts/schemas.py
+++ b/h/accounts/schemas.py
@@ -353,7 +353,11 @@ class EditProfileSchema(CSRFSchema):
         colander.String(),
         missing=None,
         validator=colander.Length(max=250),
-        widget=deform.widget.TextAreaWidget(rows=2, cols=60),
+        widget=deform.widget.TextAreaWidget(
+            cols=60,
+            max_length=250,
+            rows=2,
+        ),
         title=_('Description'))
 
     location = colander.SchemaNode(

--- a/h/static/scripts/controllers/character-limit-controller.js
+++ b/h/static/scripts/controllers/character-limit-controller.js
@@ -1,0 +1,29 @@
+'use strict';
+
+function CharacterLimitController(element) {
+  var counter = element.parentElement.querySelector(
+    '.js-character-limit-counter');
+  var input = element.querySelector('.js-character-limit-input');
+  var maxlength = parseInt(input.dataset.maxlength);
+
+  counter.textContent = '';
+
+  function updateCounter() {
+    var length = input.value.length;
+
+    counter.textContent = length + '/' + maxlength;
+
+    if (length > maxlength) {
+      counter.classList.add('is-too-long');
+    } else {
+      counter.classList.remove('is-too-long');
+    }
+  }
+
+  updateCounter();
+  input.addEventListener('input', updateCounter);
+
+  counter.classList.add('is-ready');
+}
+
+module.exports = CharacterLimitController;

--- a/h/static/scripts/site.js
+++ b/h/static/scripts/site.js
@@ -8,6 +8,7 @@ if (settings.raven) {
 
 require('./polyfills');
 
+var CharacterLimitController = require('./controllers/character-limit-controller');
 var CreateGroupFormController = require('./controllers/create-group-form-controller');
 var DropdownMenuController = require('./controllers/dropdown-menu-controller');
 var FormSelectOnFocusController = require('./controllers/form-select-onfocus-controller');
@@ -15,6 +16,7 @@ var SearchBucketController = require('./controllers/search-bucket-controller');
 var upgradeElements = require('./base/upgrade-elements');
 
 var controllers = {
+  '.js-character-limit': CharacterLimitController,
   '.js-create-group-form': CreateGroupFormController,
   '.js-dropdown-menu': DropdownMenuController,
   '.js-select-onfocus': FormSelectOnFocusController,

--- a/h/static/scripts/tests/controllers/character-limit-controller-test.js
+++ b/h/static/scripts/tests/controllers/character-limit-controller-test.js
@@ -1,0 +1,155 @@
+'use strict';
+
+var CharacterLimitController = require('../../controllers/character-limit-controller');
+var util = require('./util');
+
+describe('CharacterLimitController', function () {
+
+  var containerEl;
+
+  afterEach(function () {
+    if (containerEl) {
+      containerEl.remove();
+      containerEl = null;
+    }
+  });
+
+  /**
+   * Make a <textarea> with the character limit controller enhancement
+   * applied and return the various parts of the component.
+   */
+  function component(value, maxlength) {
+    maxlength = maxlength || 250;
+
+    var template = '<div class="js-character-limit">';
+    template += '<textarea class="js-character-limit-input" data-maxlength="' + maxlength + '">';
+    if (value) {
+      template += value;
+    }
+    template += '</textarea><span class="js-character-limit-counter">Foo</span>';
+    template += '</div>';
+
+    containerEl = util.setupComponent(document, template, {
+      '.js-character-limit': CharacterLimitController,
+    });
+    var divEl = containerEl.querySelector('.js-character-limit');
+    var counterEl = containerEl.querySelector('.js-character-limit-counter');
+    var textarea = containerEl.querySelector('textarea');
+    var ctrl = divEl.controllers[0];
+
+    return {
+      containerEl: containerEl,
+      counterEl: counterEl,
+      textarea: textarea,
+      ctrl: ctrl,
+    };
+  }
+
+  it('adds the ready class', function () {
+    var counterEl = component().counterEl;
+
+    assert.equal(counterEl.classList.contains('is-ready'), true);
+  });
+
+  it('shows the counter initially even if textarea empty', function () {
+    var counterEl = component().counterEl;
+
+    assert.equal(counterEl.innerHTML, '0/250');
+  });
+
+  it('shows the counter if the element has pre-rendered text', function () {
+    var counterEl = component('pre-rendered').counterEl;
+
+    assert.equal(counterEl.innerHTML, '12/250');
+  });
+
+  it('continues to show the container after text deleted', function() {
+    var parts = component();
+    var counterEl = parts.counterEl;
+    var textarea = parts.textarea;
+
+    // Trigger the counter to be shown.
+    textarea.value = 'Some text';
+    textarea.dispatchEvent(new Event('input'));
+
+    // Delete all the text in the textarea,
+    textarea.value = '';
+    textarea.dispatchEvent(new Event('input'));
+
+    assert.equal(counterEl.innerHTML, '0/250');
+  });
+
+  it('reads the max length from the data-maxlength attribute', function () {
+    var counterEl = component('foo', 500).counterEl;
+
+    assert.equal(counterEl.innerHTML, '3/500');
+  });
+
+  it('updates the counter when text is added on "input" events', function () {
+    var parts = component();
+    var textarea = parts.textarea;
+    var counterEl = parts.counterEl;
+
+    textarea.value = 'testing';
+    textarea.dispatchEvent(new Event('input'));
+
+    assert.equal(counterEl.innerHTML, '7/250');
+  });
+
+  it('updates the counter when text is removed on "input" events', function () {
+    var parts = component('Testing testing');
+    var textarea = parts.textarea;
+    var counterEl = parts.counterEl;
+
+    // Make the text shorter.
+    textarea.value = 'Testing';
+    textarea.dispatchEvent(new Event('input'));
+
+    assert.equal(counterEl.innerHTML, '7/250');
+  });
+
+  it('does not add error class when no pre-rendered text', function() {
+    var counterEl = component(null, 5).counterEl;
+
+    assert.equal(counterEl.classList.contains('is-too-long'),
+                 false);
+  });
+
+  it('does not add error class when pre-rendered text short enough', function() {
+    var counterEl = component('foo', 5).counterEl;
+
+    assert.equal(counterEl.classList.contains('is-too-long'),
+                 false);
+  });
+
+  it('adds an error class to the counter when pre-rendered value too long', function() {
+    var counterEl = component('Too long', 5).counterEl;
+
+    assert.equal(counterEl.classList.contains('is-too-long'),
+                 true);
+  });
+
+  it('adds an error class to the counter when too much text entered', function() {
+    var parts = component(null, 5);
+    var counterEl = parts.counterEl;
+    var textarea = parts.textarea;
+
+    textarea.value = 'too long';
+    textarea.dispatchEvent(new Event('input'));
+
+    assert.equal(counterEl.classList.contains('is-too-long'),
+                 true);
+  });
+
+  it('removes error class from counter when text reduced', function() {
+    var parts = component('too long', 6);
+    var counterEl = parts.counterEl;
+    var textarea = parts.textarea;
+
+    textarea.value = 'short';
+    textarea.dispatchEvent(new Event('input'));
+
+    assert.equal(counterEl.classList.contains('is-too-long'),
+                 false);
+  });
+});

--- a/h/static/styles/partials-v2/_form-input.scss
+++ b/h/static/styles/partials-v2/_form-input.scss
@@ -50,6 +50,38 @@
     color: $grey-5;
   }
 
+  .form-input__character-counter {
+    @include font-normal;
+
+    // Show fallback "counter" if loading js times out.
+    .env-js-timeout & {
+      display: initial;
+    }
+
+    // Immediately hide counter if js capable - prevents momentary flash of
+    // unenhanced fallback counter before js kicks in.
+    .env-js-capable & {
+      display: none;
+    }
+
+    // The js controller adds this class when it's ready - show the now
+    // enhanced counter.
+    &.is-ready {
+      display: initial;
+    }
+
+    &.is-too-long {
+      color: $brand;
+      font-weight: bold;
+    }
+
+    position: absolute;
+    bottom: 10px;
+    right: $h-padding;
+
+    color: $grey-5;
+ }
+
   .form-input__hint {
     @include font-normal;
 

--- a/h/templates/deform/includes/common_attrs.jinja2
+++ b/h/templates/deform/includes/common_attrs.jinja2
@@ -11,7 +11,7 @@ class="{{field_css_class}}
       {% if field.widget.css_class %} {{ field.widget.css_class }} {% endif %}
       {% if field.widget.autofocus %} js-select-onfocus{% endif %}
       {% if field.schema.hint %} has-hint {% endif %}
-      "
+      {% if field.widget.template == 'textarea' and field.widget.max_length %}js-character-limit-input{% endif %}"
 {%- if field.widget.size -%}
 size="{{ field.widget.size }}"
 {% endif -%}
@@ -26,6 +26,9 @@ autofocus
 {% endif -%}
 {%- if field.widget.disable_autocomplete -%}
 autocomplete="off"
+{% endif -%}
+{%- if field.widget.max_length -%}
+data-maxlength="{{ field.widget.max_length }}"
 {% endif -%}
 {%- if field.widget.placeholder -%}
 placeholder="{{ field.widget.placeholder }}"

--- a/h/templates/deform/includes/common_attrs.jinja2
+++ b/h/templates/deform/includes/common_attrs.jinja2
@@ -27,9 +27,6 @@ autofocus
 {%- if field.widget.disable_autocomplete -%}
 autocomplete="off"
 {% endif -%}
-{%- if field.widget.max_length -%}
-maxlength="{{ field.widget.max_length }}"
-{% endif -%}
 {%- if field.widget.placeholder -%}
 placeholder="{{ field.widget.placeholder }}"
 {% endif -%}

--- a/h/templates/deform/mapping_item.jinja2
+++ b/h/templates/deform/mapping_item.jinja2
@@ -13,7 +13,9 @@
 {% endif %}
 
 {%- if not field.widget.hidden -%}
-<div class="{{ field_class }}{% if field.error %} {{ field_error_state_class }}{% endif %}"
+<div class="{{ field_class }}
+            {% if field.error %}{{ field_error_state_class }}{% endif %}
+            {% if field.widget.template == 'textarea' and field.widget.max_length -%}js-character-limit{% endif %}"
      {%- if field.description -%}
      title="{{ _(field.description) }}"
      {% endif %}

--- a/h/templates/deform/textarea.jinja2
+++ b/h/templates/deform/textarea.jinja2
@@ -1,2 +1,3 @@
 <textarea
 {% include "includes/common_attrs.jinja2" %}>{{ cstruct }}</textarea>
+{%- if field.widget.max_length -%}<span class="form-input__character-counter js-character-limit-counter">Up to {{ field.widget.max_length }} characters</span>{% endif %}


### PR DESCRIPTION
Add a character limit counter JavaScript enhancement to textareas, and
apply this enhancement to the "Description" text area on the user
profile edit form.

Any `<textarea>` whose Deform widget (defined in the textarea's deform
schema, in the `schema.py` file) has a `max_length` argument will
automatically get the character counter enhancement applied.

**Terminology**:

This enhancement is actually called the **character limit** enhancement
because its job is to enhance a textarea with UX affordances to do with
the fact that the textarea has a character limit. The UX affordances of
a character limit enhancement could include a character counter, or they
could be done some other way.

The **character counter** is a particular `<span>` element that this
particular character limit enhancement manages, that displays a count of
characters entered so far / character limit.

**Implementation**:

* In `textarea.jinja2`, when the `<textarea>` has a `max_length`, we add
  a new `<span>` to Deform `<textarea>`s. This `<span>` is actually a
  _sibling_ of the `<textarea>` not a child because child elements of
  `<textarea>`s are not displayed.

* By default this span contains a static informational message about the max
  length: **Up to 250 characters**.

  Which is the fallback, no-JavaScript behaviour. It lets users know that
  there is a character limit, but does not tell them how many characters
  they've entered so far, nor whether they're over the limit, nor does
  it prevent them from entering too many characters (this last one is
  desirable - we don't want to prevent them).

* Whether JavaScript is enabled or not, if the user submits a textarea
  with too many characters the server will respond with the error
  message **Longer than maximum length 250** so the user does get some
  feedback that they've gone over the limit (but this still does not
  tell them how far over the limit they've gone, or which portion of
  their text is over the limit).

  This server error message could perhaps be improved by telling the
  user how many characters they submitted.

  When JavaScript is enabled it's good that the character limit 250 is
  repeated in both the error message and character counter. The error
  message may trigger the user to realise what that 300/250 counter
  means, if they hadn't already.

* When the browser supports JavaScript we use the `"env-js-capable"` CSS
  class to immediately hide the `<span>` (`display: none`). This
  prevents a momentary flash of the "Up to 250 characters" message
  before the JavaScript kicks in.

  If for some reason the JavaScript fails to load then the
  `"env-js-timeout"` class gets added, and we use this to override
  `"env-js-capable"` and re-show the `<span>` containing the fallback
  static message (`display: initial`).

* The new JavaScript `CharacterLimitController` in
  `character-limit-controller.js` kicks in and replaces the text of the
  `<span>` with a **0/250** counter, then adds the `"is-ready"` class to
  the `<span>` which overrides the `"env-js-capable"` and re-shows the
  span (`display: initial`).

* The character limit from the `max_length` argument in the Python code
  is passed into the Jinja2 template by Deform, and the template passes it to
  `CharacterLimitController` as the value of a `data-maxlength`
  attribute on the `<textarea>` element.

* `CharacterLimitController` finds the character counter `<span>` using
  a `js-character-counter` CSS class that's put on the span (in the
  template) for this purpose.

* `CharacterLimitController` uses the `"input"` event which I believe is
  supported by all the browsers that we support, and that is triggered
  when the user types, deletes (with backspace or delete), selects text
  and deletes, pastes, undoes and redos in the textarea.

  When this event is fired it's just a simple case of counting the
  number of characters in the textarea and updating the contents of the
  `<span>`.

* We also add the `"form-input__character-counter--error"` CSS class
  when too many characters are entered, and this makes the character
  counter turn both red and bold. (Bold is used in additional to color
  to make the change colorblind-visible.) And we remove this class when
  the text becomes short enough again.

* Nothing prevents the user from entering too many characters into the
  form, or from submitting the form with too many characters in it.

* If the textarea is pre-rendered with some text already in it the counter is still correct (this happens for example when you enter too much text and submit the form, and the server responds by re-rendering the form with an error message and with your text still in the textarea).