### PR TITLE
Add facility to override detected browser environment

### DIFF
--- a/h/static/scripts/base/upgrade-elements.js
+++ b/h/static/scripts/base/upgrade-elements.js
@@ -1,9 +1,5 @@
 'use strict';
 
-function isJSDisabled(document) {
-  return document.location.search.match(/\bnojs=1\b/);
-}
-
 /**
  * Upgrade elements on the page with additional functionality
  *
@@ -21,10 +17,6 @@ function isJSDisabled(document) {
  *        order to upgrade it.
  */
 function upgradeElements(root, controllers) {
-  if (isJSDisabled(root.ownerDocument)) {
-    return;
-  }
-
   Object.keys(controllers).forEach(function (selector) {
     var elements = Array.from(root.querySelectorAll(selector));
     elements.forEach(function (el) {

--- a/h/static/scripts/site.js
+++ b/h/static/scripts/site.js
@@ -21,7 +21,11 @@ var controllers = {
   '.js-search-bucket': SearchBucketController,
 };
 
-upgradeElements(document.body, controllers);
+var doUpgrade = !window.envFlags || window.envFlags.get('js-capable');
+
+if (doUpgrade) {
+  upgradeElements(document.body, controllers);
+}
 
 if (window.envFlags) {
   window.envFlags.ready();

--- a/h/static/scripts/tests/base/environment-flags-test.js
+++ b/h/static/scripts/tests/base/environment-flags-test.js
@@ -41,6 +41,22 @@ describe('EnvironmentFlags', function () {
       flags.init();
       assert.isTrue(el.classList.contains('env-touch'));
     });
+
+    it('should add flags specified in the document URL', function () {
+      flags.init('http://example.org/?__env__=touch;js-timeout');
+      assert.isTrue(el.classList.contains('env-touch'));
+      assert.isTrue(el.classList.contains('env-js-timeout'));
+    });
+
+    it('should remove flags with a "no-" prefix specified in the document URL', function () {
+      flags.init('http://example.org/?__env__=no-js-capable');
+      assert.isFalse(el.classList.contains('env-js-capable'));
+    });
+
+    it('should remove "js-capable" flag if "nojs=1" is present in URL', function () {
+      flags.init('http://example.org/?nojs=1');
+      assert.isFalse(el.classList.contains('env-js-capable'));
+    });
   });
 
   describe('#ready', function () {

--- a/h/static/scripts/tests/base/upgrade-elements-test.js
+++ b/h/static/scripts/tests/base/upgrade-elements-test.js
@@ -16,21 +16,6 @@ describe('upgradeElements', function () {
     root.remove();
   });
 
-  it('does not upgrade elements if JS is disabled', function () {
-    var TestController = sinon.spy();
-    var root = {
-      querySelectorAll: function () {
-        // Array with one fake Element to upgrade
-        return [{}];
-      },
-      ownerDocument: {
-        location: { search: '?nojs=1' },
-      },
-    };
-    upgradeElements(root, {'.js-test': TestController});
-    assert.notCalled(TestController);
-  });
-
   it('exposes controllers via the `.controllers` element property', function () {
     function TestController() {}
 


### PR DESCRIPTION
Add support for overriding the environment classes that are set on the
`<html>` element by using `__env__=$flags` in the URL, where $flags is a
semi-colon separated list of flags that indicate flags to add or remove
(if the flag starts with a "no-" prefix).

For example:

Simulate touch input:

  https://hypothes.is/signup?__env__=touch

Simulate JS load timeout:

  https://hypothes.is/signup?__env__=js-timeout

Simulate failure to run JS:

  https://hypothes.is/signup?__env__=no-js-capable
  https://hypothes.is/signup?nojs=1 (shorthand)

This replaces the earlier `nojs=1` mechanism in `upgradeElements` which
only prevented controllers from being initialized but did not alter the
environment classes applied to `<html>`.