### PR TITLE
Make user description field bigger

### DIFF
--- a/h/accounts/schemas.py
+++ b/h/accounts/schemas.py
@@ -362,7 +362,6 @@ class EditProfileSchema(CSRFSchema):
         missing=None,
         validator=colander.Length(max=250),
         widget=deform.widget.TextAreaWidget(
-            cols=60,
             max_length=250,
             rows=4,
         ),

--- a/h/accounts/schemas.py
+++ b/h/accounts/schemas.py
@@ -364,7 +364,7 @@ class EditProfileSchema(CSRFSchema):
         widget=deform.widget.TextAreaWidget(
             cols=60,
             max_length=250,
-            rows=2,
+            rows=4,
         ),
         title=_('Description'))
 

--- a/h/templates/deform/textarea.jinja2
+++ b/h/templates/deform/textarea.jinja2
@@ -1,5 +1,4 @@
-
-<textarea
+<textarea {%- if field.widget.rows -%}rows="{{ field.widget.rows }}"{% endif %}
 {% include "includes/common_attrs.jinja2" %}>{{ cstruct }}</textarea>
 {% if field.widget.max_length %}
   <span class="form-input__character-counter" data-ref="characterLimitCounter">

--- a/h/templates/deform/textarea.jinja2
+++ b/h/templates/deform/textarea.jinja2
@@ -1,4 +1,4 @@
-<textarea {%- if field.widget.rows -%}rows="{{ field.widget.rows }}"{% endif %}
+<textarea {% if field.widget.rows -%}rows="{{ field.widget.rows }}"{% endif %}
 {% include "includes/common_attrs.jinja2" %}>{{ cstruct }}</textarea>
 {% if field.widget.max_length %}
   <span class="form-input__character-counter" data-ref="characterLimitCounter">


### PR DESCRIPTION
This makes it just big enough to hold the max 250 chars on desktop. It'll still be too small on smaller screens where the width is less. Fixes https://github.com/hypothesis/h/issues/3780

![screenshot from 2016-08-25 16-28-47](https://cloud.githubusercontent.com/assets/22498/17975304/1086530a-6ae1-11e6-93d6-05d0daca4560.png)
