### PR TITLE
Show tooltip when user hovers on the orcid help icon in the profile edit form.

### DIFF
--- a/h/accounts/schemas.py
+++ b/h/accounts/schemas.py
@@ -387,7 +387,7 @@ class EditProfileSchema(CSRFSchema):
         missing=None,
         validator=validate_orcid,
         title=_('ORCID'),
-        hint=_('ORCID provides a persistent identifier for researchers (see http://orcid.org/)'))
+        hint=_('ORCID provides a persistent identifier for researchers (see orcid.org)'))
 
 
 class NotificationsSchema(CSRFSchema):

--- a/h/static/images/icons/info_icon.svg
+++ b/h/static/images/icons/info_icon.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="12px" height="12px" viewBox="0 0 12 12" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Artboard" fill="#A6A6A6">
+            <path d="M6,12 C9.3137085,12 12,9.3137085 12,6 C12,2.6862915 9.3137085,0 6,0 C2.6862915,0 0,2.6862915 0,6 C0,9.3137085 2.6862915,12 6,12 Z M5,2 L7,2 L7,4 L5,4 L5,2 Z M5,5 L7,5 L7,10 L5,10 L5,5 Z" id="Combined-Shape"></path>
+        </g>
+    </g>
+</svg>

--- a/h/static/scripts/controllers/tooltip-controller.js
+++ b/h/static/scripts/controllers/tooltip-controller.js
@@ -1,0 +1,64 @@
+'use strict';
+
+/**
+ * A custom tooltip similar to the one used in Google Docs which appears
+ * instantly when activated on a target element.
+ *
+ * The tooltip is displayed and hidden by setting its target element.
+ *
+ *  var tooltip = new Tooltip(document.body);
+ *  tooltip.setState({target: aWidget}); // Show tooltip
+ *  tooltip.setState({target: null}); // Hide tooltip
+ *
+ * The tooltip's label is derived from the target element's 'aria-label'
+ * attribute.
+ *
+ * @param {Element} el - The container for the tooltip.
+ */
+function TooltipController(el) {
+  var self = this;
+
+  // With mouse input, show the tooltip on hover. On touch devices we rely on
+  // the browser to synthesize 'mouseover' events to make the tooltip appear
+  // when the host element is tapped and disappear when the host element loses
+  // focus.
+  // See http://www.codediesel.com/javascript/making-mouseover-event-work-on-an-ipad/
+  el.addEventListener('mouseover', function () {
+    self.setState({target: el});
+  });
+
+  el.addEventListener('mouseout', function () {
+    self.setState({target: null});
+  });
+
+  this.setState = function (state) {
+    this.state = Object.freeze(Object.assign({}, this.state, state));
+    this.render();
+  };
+
+  this.render = function () {
+    if (!this.state.target) {
+      this._el.style.visibility = 'hidden';
+      return;
+    }
+
+    var target = this.state.target;
+    var label = target.getAttribute('aria-label');
+    this._labelEl.textContent = label;
+
+    Object.assign(this._el.style, {
+      visibility: '',
+      bottom: 'calc(100% + 5px)',
+    });
+  };
+
+  this._el = el.ownerDocument.createElement('div');
+  this._el.innerHTML = '<span class="tooltip-label js-tooltip-label"></span>';
+  this._el.className = 'tooltip';
+  el.appendChild(this._el);
+  this._labelEl = this._el.querySelector('.js-tooltip-label');
+
+  this.setState({});
+}
+
+module.exports = TooltipController;

--- a/h/static/scripts/site.js
+++ b/h/static/scripts/site.js
@@ -13,6 +13,7 @@ var CreateGroupFormController = require('./controllers/create-group-form-control
 var DropdownMenuController = require('./controllers/dropdown-menu-controller');
 var FormSelectOnFocusController = require('./controllers/form-select-onfocus-controller');
 var SearchBucketController = require('./controllers/search-bucket-controller');
+var TooltipController = require('./controllers/tooltip-controller');
 var upgradeElements = require('./base/upgrade-elements');
 
 var controllers = {
@@ -21,6 +22,7 @@ var controllers = {
   '.js-dropdown-menu': DropdownMenuController,
   '.js-select-onfocus': FormSelectOnFocusController,
   '.js-search-bucket': SearchBucketController,
+  '.js-tooltip': TooltipController,
 };
 
 var doUpgrade = !window.envFlags || window.envFlags.get('js-capable');

--- a/h/static/scripts/tests/controllers/tooltip-controller-test.js
+++ b/h/static/scripts/tests/controllers/tooltip-controller-test.js
@@ -1,0 +1,41 @@
+'use strict';
+
+var TooltipController = require('../../controllers/tooltip-controller');
+
+describe('TooltipController', function () {
+  var targetEl;
+  var template;
+  var testEl;
+  var tooltipEl;
+
+  before(function () {
+    template = '<div class="form-input__hint-icon js-tooltip"' +
+     'aria-label="Test"></div>';
+  });
+
+  beforeEach(function () {
+    testEl = document.createElement('div');
+    testEl.innerHTML = template;
+
+    targetEl = testEl.querySelector('div');
+    new TooltipController(targetEl);
+
+    tooltipEl = testEl.querySelector('.tooltip');
+  });
+
+
+  it('appears when the target is hovered', function () {
+    targetEl.dispatchEvent(new Event('mouseover'));
+    assert.equal(tooltipEl.style.visibility, '');
+  });
+
+  it('sets the label from the target\'s "aria-label" attribute', function () {
+    targetEl.dispatchEvent(new Event('mouseover'));
+    assert.equal(tooltipEl.textContent, 'Test');
+  });
+
+  it('disappears when the target is unhovered', function () {
+    targetEl.dispatchEvent(new Event('mouseout'));
+    assert.equal(tooltipEl.style.visibility, 'hidden');
+  });
+});

--- a/h/static/styles/partials-v2/_base.scss
+++ b/h/static/styles/partials-v2/_base.scss
@@ -33,6 +33,7 @@ $input-font-size: 15px;
 
 // Z-index scale
 $zindex-dropdown-menu: 10;
+$zindex-tooltip: 20;
 
 // Mobile device size breakpoints
 // ------------------------------
@@ -40,6 +41,7 @@ $zindex-dropdown-menu: 10;
 
 $max-phone-width: 500px;
 $tablet-width: 768px;
+$touch-target-size: 44px;
 
 // Include all mixins, making them available to the stylesheet. N.B. Mixins
 // should *never* output CSS, so this is safe.

--- a/h/static/styles/partials-v2/_btn.scss
+++ b/h/static/styles/partials-v2/_btn.scss
@@ -22,6 +22,6 @@
 
 @include touch-input {
   .btn {
-    min-height: 44px;
+    min-height: $touch-target-size;
   }
 }

--- a/h/static/styles/partials-v2/_form-input.scss
+++ b/h/static/styles/partials-v2/_form-input.scss
@@ -48,6 +48,11 @@
     left: $h-padding;
 
     color: $grey-5;
+
+    display: flex;
+    // The label is a sibling of the <input> field. Raise it above the <input>
+    // so that the field's tooltip appears above the focus ring
+    z-index: 1;
   }
 
   .form-input__character-counter {
@@ -80,16 +85,36 @@
     right: $h-padding;
 
     color: $grey-5;
- }
+  }
+
+  .form-input__hint-icon {
+    display: none;
+    margin-left: 6px;
+    margin-top: 1px;
+    position: relative;
+
+    .env-js-capable & {
+      display: block;
+    }
+
+    .env-js-timeout & {
+      display: none;
+    }
+  }
 
   .form-input__hint {
     @include font-normal;
 
-    position: absolute;
-    top: 40px;
-    left: $h-padding;
-
     color: $grey-5;
+    margin-top: -10px;
+
+    .env-js-capable & {
+      display: none;
+    }
+
+    .env-js-timeout & {
+      display: block;
+    }
   }
 
   // The actual <input> element for the field
@@ -109,7 +134,9 @@
   }
 
   .form-input__input.has-hint {
-    padding-top: $top-padding + $hint-height;
+    .env-js-capable & {
+      padding-top: $top-padding;
+    }
   }
 
   .form-input__input:hover {
@@ -171,6 +198,14 @@
       left: $h-padding;
       right: $h-padding;
       max-width: unset;
+    }
+  }
+
+  // Make hit target for field hint icon larger on mobile
+  @include touch-input {
+    .form-input__label > .form-input__hint-icon {
+      min-height: $touch-target-size;
+      min-width: $touch-target-size;
     }
   }
 }

--- a/h/static/styles/partials-v2/_tooltip.scss
+++ b/h/static/styles/partials-v2/_tooltip.scss
@@ -1,0 +1,62 @@
+@mixin tooltip-arrow($rotation) {
+  background: $grey-7;
+  border-bottom: 1px solid rgba(0,0,0,0.20);
+  border-right: 1px solid rgba(0,0,0,0.20);
+  content: "";
+  display: none;
+  height: 6px;
+  left: 0;
+  margin-left: auto;
+  margin-right: 7px;
+  position: absolute;
+  right: 0;
+  transform: rotate($rotation);
+  width: 6px;
+
+  .env-js-capable & {
+    display: block;
+  }
+
+  .env-js-timeout & {
+    display: none;
+  }
+}
+
+.tooltip {
+  @include font-small;
+
+  border-radius: 2px;
+  background-color: $grey-7;
+  color: white;
+  display: none;
+  font-style: normal;
+  padding-left: 5px;
+  padding-right: 5px;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  position: absolute;
+  width: 220px;
+  z-index: $zindex-tooltip;
+
+  .env-js-capable & {
+    display: block;
+  }
+
+  .env-js-timeout & {
+    display: none;
+  }
+}
+
+// Arrow at the bottom of the tooltip pointing down at the target element.
+.tooltip:before {
+  @include tooltip-arrow(45deg);
+  content: "";
+  top: calc(100% - 5px);
+  right: calc(100% - 17px);
+}
+
+.tooltip-label {
+  // Make the label a positioned element so that it appears _above_ the
+  // tooltip's arrow, which partially overlaps the content of the tooltip.
+  position: relative;
+}

--- a/h/static/styles/site-v2.scss
+++ b/h/static/styles/site-v2.scss
@@ -19,6 +19,7 @@
 @import 'partials-v2/pager';
 @import 'partials-v2/search';
 @import 'partials-v2/search-bar';
+@import 'partials-v2/tooltip';
 @import 'partials-v2/tabs';
 
 body {

--- a/h/templates/deform/mapping_item.jinja2
+++ b/h/templates/deform/mapping_item.jinja2
@@ -28,16 +28,18 @@
          title="{{ _(field.description) }}"
          {% endif %}
          for="{{ field.oid }}">
-    {{ _(field.title) }}
+           {{ _(field.title) }}
+           {%- if field.schema.hint and feature('activity_pages') -%}
+             <i class="form-input__hint-icon js-tooltip"
+               aria-label="{{ field.schema.hint }}">
+               {{ svg_icon('info_icon') }}
+             </i>
+           {% endif %}
     {%- if field.schema.hint and not feature('activity_pages') %}
       <span class="form-hint" id="hint-{{ field.oid }}">({{ field.schema.hint }})</span>
     {% endif -%}
   </label>
 {% endif -%}
-
-{% if field.schema.hint and feature('activity_pages') %}
-<div class="form-input__hint" id="hint-{{ field.oid }}">{{ field.schema.hint }}</div>
-{% endif %}
 
 {{ field.serialize(cstruct) }}
 
@@ -53,4 +55,9 @@
 
 {%- if not field.widget.hidden -%}
 </div>
+
+{% if field.schema.hint and feature('activity_pages') %}
+<div class="form-input__hint" id="hint-{{ field.oid }}">{{ field.schema.hint }}</div>
+{% endif %}
+
 {% endif -%}


### PR DESCRIPTION
Show info icons on mobile and JS enabled browsers.
Do not show tooltips on non-js or JS time outs.
Instead, display a hint text.

Test:
`http://localhost:5000/account/profile`
`http://localhost:5000/account/profile (with JS disabled)`
`http://localhost:5000/account/profile?__env__=js-timeout`
`http://localhost:5000/account/profile (mobile)`

https://trello.com/c/gGtgaRg9/425-form-field-hint-enhancement