### PR TITLE
Fix display of local PDF domain name on search page

### DIFF
--- a/h/activity/bucketing.py
+++ b/h/activity/bucketing.py
@@ -20,7 +20,6 @@ class DocumentBucket(object):
         self.tags = set()
         self.users = set()
         self.uri = None
-        self.domain = None
 
         self.title = document.title
 
@@ -28,6 +27,8 @@ class DocumentBucket(object):
         if parsed:
             self.uri = parsed.geturl()
             self.domain = parsed.netloc
+        else:
+            self.domain = _('Local file')
 
         if annotations:
             self.update(annotations)

--- a/tests/h/activity/bucketing_test.py
+++ b/tests/h/activity/bucketing_test.py
@@ -88,14 +88,16 @@ class TestDocumentBucket(object):
         bucket = bucketing.DocumentBucket(document)
         assert bucket.domain == 'www.example.com'
 
-    def test_init_sets_None_domain_when_no_uri_is_set(self, db_session, document):
+    def test_init_sets_domain_to_local_file_when_no_uri_is_set(self,
+                                                               db_session,
+                                                               document):
         docuri_pdf = factories.DocumentURI(uri='urn:x-pdf:fingerprint',
                                            document=document)
         db_session.add(docuri_pdf)
         db_session.flush()
 
         bucket = bucketing.DocumentBucket(document)
-        assert bucket.domain is None
+        assert bucket.domain == 'Local file'
 
     def test_annotations_count_returns_count_of_annotations(self, db_session, document):
         bucket = bucketing.DocumentBucket(document)


### PR DESCRIPTION
When the annotated document has no domain name because it was a
locally-annotated PDF file, just display nothing rather than displaying
the word "None".

Fixes https://github.com/hypothesis/h/issues/3742

This replaces "None" with just an empty space:

![screenshot from 2016-08-26 12-25-57](https://cloud.githubusercontent.com/assets/22498/18003843/4b31fa20-6b88-11e6-8776-977696cc2ede.png)
