### PR TITLE
Make the entire document bucket header clickable

### DIFF
--- a/h/static/styles/partials-v2/_search.scss
+++ b/h/static/styles/partials-v2/_search.scss
@@ -32,9 +32,6 @@
 
 // A group of search results
 .search-result-bucket {
-  display: flex;
-  flex-direction: row;
-  padding: 10px 10px;
   background-color: $grey-2;
   border-bottom: 1px solid $grey-3;
 
@@ -60,11 +57,14 @@
   display: flex;
   flex-direction: column;
   flex-grow: 1;
+  padding-left: 10px;
+  padding-right: 10px;
 }
 
 .search-result-bucket__header {
   display: flex;
   flex-direction: row;
+  padding: 10px 10px;
 
   cursor: pointer;
   user-select: none;
@@ -78,6 +78,7 @@
 
 .search-result-bucket__annotation-cards-container {
   display: flex;
+  padding-left: 130px;
   .env-js-capable & {
     display: none;
   }

--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -37,18 +37,23 @@
 #}
 {% macro search_result_bucket(bucket) %}
 <div class="search-result-bucket js-search-bucket">
-  <div class="search-result-bucket__domain">
-    {{ bucket.domain }}
-  </div>
-  <div class="search-result-bucket__content">
-    <div class="search-result-bucket__header" data-ref="header">
-      <div class="search-result-bucket__title">{{ bucket.title }}</div>
-      <div class="search-result-bucket__annotations-count">
-        <div class="search-result-bucket__annotations-count-container">
-          {{ bucket.annotations_count }}
-        </div>
+
+  {# The header is the clickable area that expands/collapses the bucket when
+     clicked #}
+  <div class="search-result-bucket__header" data-ref="header">
+    <div class="search-result-bucket__domain">
+      {{ bucket.domain }}
+    </div>
+    <div class="search-result-bucket__title">{{ bucket.title }}</div>
+    <div class="search-result-bucket__annotations-count">
+      <div class="search-result-bucket__annotations-count-container">
+        {{ bucket.annotations_count }}
       </div>
     </div>
+  </div>
+
+  {# The content is the area that appears / disappears on expand / collapse. #}
+  <div class="search-result-bucket__content">
     <div class="search-result-bucket__annotation-cards-container" data-ref="content">
       <ol class="search-result-bucket__annotation-cards">
         {% for result in bucket.annotations %}


### PR DESCRIPTION
Make the entire part of a document bucket that is visible when the
bucket is collapsed (domain name, document title, and number of
annotations) clickable in order to expand/collapse the bucket, instead
of having to click on the invisible flex box containing the document
title.

Fixes #3723.