### PR TITLE
Hook up search pagination

### DIFF
--- a/h/activity/query.py
+++ b/h/activity/query.py
@@ -94,12 +94,18 @@ def check_url(request, query, unparse=parser.unparse):
         raise HTTPFound(location=redirect)
 
 
-def execute(request, query):
+def execute(request, query, page_size):
     search = Search(request)
     search.append_filter(TopLevelAnnotationsFilter())
     for agg in aggregations_for(query):
         search.append_aggregation(agg)
 
+    query = query.copy()
+    page = request.params.get('page', '')
+    if not page:
+        page = '1'
+    query['limit'] = page_size
+    query['offset'] = (int(page) - 1) * page_size
     search_result = search.run(query)
     result = ActivityResults(total=search_result.total,
                              aggregations=search_result.aggregations,

--- a/h/activity/views.py
+++ b/h/activity/views.py
@@ -12,6 +12,8 @@ from pyramid.view import view_config
 from h.activity import query
 from h.paginator import paginate
 
+PAGE_SIZE = 20
+
 
 @view_config(route_name='activity.search',
              request_method='GET',
@@ -34,14 +36,14 @@ def search(request):
     query.check_url(request, q)
 
     # Fetch results
-    result = query.execute(request, q)
+    result = query.execute(request, q, page_size=PAGE_SIZE)
 
     return {
         'q': request.params['q'],
         'total': result.total,
         'aggregations': result.aggregations,
         'timeframes': result.timeframes,
-        'page': paginate(request, result.total),
+        'page': paginate(request, result.total, page_size=PAGE_SIZE),
     }
 
 


### PR DESCRIPTION
Even though we already set the `page` parameter, it didn't get passed
down to the search query. To do that we also have to convert the page
number to a pair of limit/offset. This can all be done transparently in
the `query` module, while the page size definition should stay in the
view because it's being used for the pagination as well as for the
query.

Fixes #3766 