### PR TITLE
Render current search query in field

### DIFF
--- a/h/activity/views.py
+++ b/h/activity/views.py
@@ -37,7 +37,6 @@ def search(request):
     result = query.execute(request, q)
 
     return {
-        'q': request.params['q'],
         'total': result.total,
         'aggregations': result.aggregations,
         'timeframes': result.timeframes,

--- a/h/views/panels.py
+++ b/h/views/panels.py
@@ -44,6 +44,7 @@ def navbar(context, request):
             {'title': _('Create new group'), 'link': request.route_url('group_create')},
         'username': username,
         'username_link': stream_url,
+        'q': request.params.get('q', ''),
     }
 
 

--- a/tests/h/views/panels_test.py
+++ b/tests/h/views/panels_test.py
@@ -43,6 +43,15 @@ def test_navbar_username_link_when_logged_in(pyramid_request, authenticated_user
     assert result['username_link'] == 'http://example.com/search?q=user:vannevar'
 
 
+@pytest.mark.usefixtures('routes')
+def test_navbar_includes_search_query(pyramid_request):
+    pyramid_request.authenticated_user = None
+    pyramid_request.params['q'] = 'tag:question'
+    result = panels.navbar({}, pyramid_request)
+
+    assert result['q'] == 'tag:question'
+
+
 @pytest.fixture
 def routes(pyramid_config):
     pyramid_config.add_route('account', '/account')


### PR DESCRIPTION
I suspect that this got lost when the search field was moved into a
navbar panel, at which point there is no `q` variable available any more
for the jinja2 templates.