### PR TITLE
Execute default search without a query

### DIFF
--- a/h/activity/query.py
+++ b/h/activity/query.py
@@ -38,10 +38,8 @@ def extract(request, parse=parser.parse):
 
     If no query is present in the passed request, returns ``None``.
     """
-    if 'q' not in request.params:
-        return None
 
-    q = parse(request.params['q'])
+    q = parse(request.params.get('q', ''))
 
     # If the query sent to a {group, user} search page includes a {group,
     # user}, we override it, because otherwise we'll display the union of the

--- a/h/activity/views.py
+++ b/h/activity/views.py
@@ -27,8 +27,6 @@ def search(request):
         raise httpexceptions.HTTPNotFound()
 
     q = query.extract(request)
-    if q is None:
-        return {}
 
     # Check whether a redirect is required
     query.check_url(request, q)
@@ -37,7 +35,6 @@ def search(request):
     result = query.execute(request, q)
 
     return {
-        'q': request.params['q'],
         'total': result.total,
         'aggregations': result.aggregations,
         'timeframes': result.timeframes,

--- a/tests/h/activity/query_test.py
+++ b/tests/h/activity/query_test.py
@@ -15,17 +15,16 @@ from h.activity.query import (
 
 
 class TestExtract(object):
-    def test_returns_none_if_q_not_in_params(self, parse, pyramid_request):
-        result = extract(pyramid_request, parse=parse)
-
-        assert result is None
-
     def test_parses_param_value_with_parser(self, parse, pyramid_request):
         pyramid_request.GET['q'] = 'giraffe'
 
         extract(pyramid_request, parse=parse)
 
         parse.assert_called_once_with('giraffe')
+
+    def test_returns_empty_results_when_q_param_is_missing(self, parse, pyramid_request):
+        result = extract(pyramid_request, parse=parse)
+        assert result == parse.return_value
 
     def test_returns_parse_results(self, parse, pyramid_request):
         parse.return_value = {'foo': 'bar'}


### PR DESCRIPTION
This has been nagging me for a bit. I don't think we have talked about it, so take it or leave it :) But I think going to `/search` should show the most recent annotations and not an empty page with a search field at the top.