### PR TITLE
Move features subscribers into own module, with tests

### DIFF
--- a/h/features/__init__.py
+++ b/h/features/__init__.py
@@ -2,32 +2,9 @@
 
 from __future__ import unicode_literals
 
-import os
-
-from pyramid.events import NewRequest
-
-from h import db
-from h.features import client
-from h.features import models
+from h.features.client import Client
 
 __all__ = ('Client',)
-
-Client = client.Client
-
-
-def _remove_old_flags_on_boot(event):
-    """Remove old feature flags from the database on startup."""
-    # Skip this if we're in a script, not actual app startup. See the comment
-    # in h.cli:main for an explanation.
-    if 'H_SCRIPT' in os.environ:
-        return
-
-    engine = db.make_engine(event.app.registry.settings)
-    session = db.Session(bind=engine)
-    models.Feature.remove_old_flags(session)
-    session.commit()
-    session.close()
-    engine.dispose()
 
 
 def includeme(config):
@@ -35,17 +12,9 @@ def includeme(config):
 
     config.add_request_method(Client, name='feature', reify=True)
 
-    # Load the feature flags from the database at the beginning of each request.
-    # This prevents sqlalchemy DetachedInstanceErrors that can occur if the
-    # feature flags client tries to load the feature flags later on and the
-    # database session has already been closed.
-    # This is done on NewRequest to make sure that things like
-    # request.effective_principals are already setup, so that we get the correct
-    # feature flags.
-    config.add_subscriber(lambda event: event.request.feature.load(),
-                          NewRequest)
-
-    config.add_subscriber(_remove_old_flags_on_boot,
+    config.add_subscriber('h.features.subscribers.remove_old_flags',
                           'pyramid.events.ApplicationCreated')
+    config.add_subscriber('h.features.subscribers.preload_flags',
+                          'pyramid.events.NewRequest')
 
     config.add_route('features_status', '/app/features')

--- a/h/features/subscribers.py
+++ b/h/features/subscribers.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import os
+
+from h import db
+from h.models import Feature
+
+
+def remove_old_flags(event):
+    """Remove old feature flags from the database."""
+    # Skip this if we're in a script, not actual app startup. See the comment
+    # in h.cli:main for an explanation.
+    if 'H_SCRIPT' in os.environ:
+        return
+
+    engine = db.make_engine(event.app.registry.settings)
+    session = db.Session(bind=engine)
+    Feature.remove_old_flags(session)
+    session.commit()
+    session.close()
+    engine.dispose()
+
+
+def preload_flags(event):
+    """Load all feature flags from the database for this request."""
+    # This prevents sqlalchemy DetachedInstanceErrors that can occur if the
+    # feature flags client tries to load the feature flags later on and the
+    # database session has already been closed.
+    event.request.feature.load()

--- a/tests/h/conftest.py
+++ b/tests/h/conftest.py
@@ -40,9 +40,13 @@ class DummyFeature(object):
 
     def __init__(self):
         self.flags = {}
+        self.loaded = False
 
     def __call__(self, name, *args, **kwargs):
         return self.flags.get(name, True)
+
+    def load(self):
+        self.loaded = True
 
 
 class DummySession(object):

--- a/tests/h/features/subscribers_test.py
+++ b/tests/h/features/subscribers_test.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from mock import patch
+
+from pyramid.registry import Registry
+from pyramid.events import ApplicationCreated, NewRequest
+
+from h.features.subscribers import preload_flags, remove_old_flags
+
+
+class TestPreloadFlags(object):
+    def test_preloads_feature_flags(self, pyramid_request):
+        event = NewRequest(pyramid_request)
+
+        preload_flags(event)
+
+        assert event.request.feature.loaded
+
+
+class TestRemoveOldFlags(object):
+    def test_removes_flags(self, patch):
+        db = patch('h.features.subscribers.db')
+        Feature = patch('h.features.subscribers.Feature')
+        event = ApplicationCreated(DummyApp())
+
+        remove_old_flags(event)
+
+        Feature.remove_old_flags.assert_called_once_with(db.Session.return_value)
+
+    def test_cleans_up_database_session_and_connection(self, patch):
+        db = patch('h.features.subscribers.db')
+        patch('h.features.subscribers.Feature')
+        event = ApplicationCreated(DummyApp())
+
+        remove_old_flags(event)
+
+        db.Session.return_value.close.assert_called_once_with()
+        db.make_engine.return_value.dispose.assert_called_once_with()
+
+    @patch.dict('os.environ', {'H_SCRIPT': '1'})
+    def test_does_nothing_when_in_script(self, patch):
+        patch('h.features.subscribers.db')
+        Feature = patch('h.features.subscribers.Feature')
+        event = ApplicationCreated(DummyApp())
+
+        remove_old_flags(event)
+
+        assert not Feature.remove_old_flags.called
+
+
+class DummyApp(object):
+    def __init__(self):
+        self.registry = Registry('testing')
+        self.registry.settings = {'sqlalchemy.url': 'sqlite:///:memory:'}


### PR DESCRIPTION
This commit cleans up the existing event subscribers in the `h.features` package, by:

- moving both subscribers into their own module
- adding tests for these subscribers
- using the same style for both calls to `.add_subscriber`