### PR TITLE
Do not open a database session for asset/debug requests

### DIFF
--- a/h/app.py
+++ b/h/app.py
@@ -24,12 +24,6 @@ def in_debug_mode(request):
     return asbool(request.registry.settings.get('pyramid.debug_all'))
 
 
-def tm_activate_hook(request):
-    if request.path.startswith(('/assets/', '/_debug_toolbar/')):
-        return False
-    return True
-
-
 def create_app(global_config, **settings):
     """
     Create the h WSGI application.
@@ -84,7 +78,6 @@ def includeme(config):
     config.add_settings({
         "tm.attempts": 3,
         "tm.manager_hook": lambda request: transaction.TransactionManager(),
-        "tm.activate_hook": tm_activate_hook,
         "tm.annotate_user": False,
     })
     config.include('pyramid_tm')

--- a/h/db/__init__.py
+++ b/h/db/__init__.py
@@ -76,17 +76,6 @@ def _session(request):
     engine = request.registry['sqlalchemy.engine']
     session = Session(bind=engine)
 
-    # Work around what appears to be a consistency/synchronisation bug in
-    # zope.sqlalchemy, in which old sessions aren't correctly cleared from
-    # _SESSION_STATE, causing new sessions to not be registered with the
-    # request transaction manager.
-    #
-    # N.B. This is *only* safe as long as we use a synchronous web worker in
-    # single-threaded mode.
-    #
-    # TODO: Remove this as and when we have a fix upstream.
-    zope.sqlalchemy.datamanager._SESSION_STATE.clear()
-
     # If the request has a transaction manager, associate the session with it.
     try:
         tm = request.tm

--- a/h/features/subscribers.py
+++ b/h/features/subscribers.py
@@ -25,6 +25,8 @@ def remove_old_flags(event):
 
 def preload_flags(event):
     """Load all feature flags from the database for this request."""
+    if event.request.path.startswith(('/assets/', '/_debug_toolbar/')):
+        return
     # This prevents sqlalchemy DetachedInstanceErrors that can occur if the
     # feature flags client tries to load the feature flags later on and the
     # database session has already been closed.

--- a/tests/h/features/subscribers_test.py
+++ b/tests/h/features/subscribers_test.py
@@ -2,6 +2,7 @@
 
 from __future__ import unicode_literals
 
+import pytest
 from mock import patch
 
 from pyramid.registry import Registry
@@ -17,6 +18,18 @@ class TestPreloadFlags(object):
         preload_flags(event)
 
         assert event.request.feature.loaded
+
+    @pytest.mark.parametrize('path', [
+        '/assets/some/style.css',
+        '/_debug_toolbar/foo123',
+    ])
+    def test_does_not_preload_for_opted_out_requests(self, path, pyramid_request):
+        pyramid_request.path = path
+        event = NewRequest(pyramid_request)
+
+        preload_flags(event)
+
+        assert not event.request.feature.loaded
 
 
 class TestRemoveOldFlags(object):


### PR DESCRIPTION
Opening a database session to load feature flags for these requests is not only not necessary, it is quite problematic. It causes the leakage of references to the database session inside `zope.sqlalchemy` because these requests have been opted out of the transaction manager by an `activate_hook` (see `h.app`) -- and was the cause of our bizarre session rollback problems last week.

By using the database in these requests, we were accidentally registering a database session with a transaction manager that wasn't hooked up to the request lifecycle. This meant that zope.sqlalchemy's internal references to the session weren't properly cleaned up. In a high traffic environment -- these leaked session references would then later lead to a session (in an entirely different request) not being correctly registered with the transaction manager.

I've also opened [a pull request against `pyramid_tm`](https://github.com/pylons/pyramid_tm/pull/46) which should prevent this class of bug in the future.

This PR also removes the use of the `tm.activate_hook` entirely, and the workaround we added at the end of last week. Neither are needed.

_**N.B.** This depends on #3795, and will need to be rebased once that has merged._