### PR TITLE
Add a couple of usernames to the blacklist

### DIFF
--- a/h/accounts/blacklist
+++ b/h/accounts/blacklist
@@ -18,6 +18,7 @@ ajax
 all
 analytics
 android
+annotatorjs
 announcements
 anonymous
 anywhere
@@ -315,6 +316,7 @@ system
 talk
 task
 tasks
+team
 tech
 telnet
 terms


### PR DESCRIPTION
These are email accounts at the @hypothes.is domain that were previously registered to keep them free. Now we can add these usernames to the blacklist and remove the stub users.