### PR TITLE
Fix debug mailer

### DIFF
--- a/conf/development-app.ini
+++ b/conf/development-app.ini
@@ -8,14 +8,13 @@ es.host: http://localhost:9200
 
 pyramid.debug_all: True
 pyramid.reload_templates: True
-pyramid.includes:
-    pyramid_debugtoolbar
-    h.debug
 
 # Set a default persistent secret for development. DO NOT copy this into a
 # production settings file.
 h.client_id: nosuchid
 h.client_secret: nosuchsecret
+
+h.debug: True
 
 secret_key: notverysecretafterall
 

--- a/h/app.py
+++ b/h/app.py
@@ -136,3 +136,8 @@ def includeme(config):
     config.include('h.links')
     config.include('h.nipsa')
     config.include('h.notification')
+
+    # Debugging assistance
+    if asbool(config.registry.settings.get('h.debug')):
+        config.include('pyramid_debugtoolbar')
+        config.include('h.debug')


### PR DESCRIPTION
By moving the mailer configuration into the application, I had accidentally broken the debug mailer because it was being overridden by the real mailer.

Avoid this problem by using a catch-all `h.debug` flag instead to trigger debug module inclusion at the end of `h.app`.