### PR TITLE
Fix crash for users with empty passwords

### DIFF
--- a/h/accounts/models.py
+++ b/h/accounts/models.py
@@ -215,7 +215,7 @@ class User(Base):
 
     def check_password(self, value):
         """Check the passed password for this user."""
-        if self.password is None:
+        if not self.password:
             return False
 
         # Old-style separate salt.

--- a/tests/h/accounts/models_test.py
+++ b/tests/h/accounts/models_test.py
@@ -111,6 +111,13 @@ def test_check_password_false_with_null_password():
     assert not user.check_password('anything')
 
 
+def test_check_password_false_with_empty_password():
+    user = models.User(username='barnet')
+    user._password = ''
+
+    assert not user.check_password('')
+
+
 def test_check_password_true_with_matching_password():
     user = models.User(username='barnet', password='s3cr37')
 


### PR DESCRIPTION
Some users (those who originally registered usernames before we had a
proper accounts system) have empty strings in the password field. We
need to not crash when checking these users' passwords.

https://app.getsentry.com/hypothesis/prod/issues/152802006/

Fixes #3799.