### PR TITLE
Add character limit enhancement to input fields

### DIFF
--- a/h/templates/deform/includes/common_attrs.jinja2
+++ b/h/templates/deform/includes/common_attrs.jinja2
@@ -4,7 +4,7 @@
 {% set field_css_class = 'form-input' %}
 {% endif %}
 
-{% if field.widget.template == 'textarea' and field.widget.max_length %}
+{% if field.widget.template in ('textinput', 'textarea') and field.widget.max_length %}
 {% set ref = 'characterLimitInput' %}
 {% endif %}
 

--- a/h/templates/deform/mapping_item.jinja2
+++ b/h/templates/deform/mapping_item.jinja2
@@ -15,7 +15,7 @@
 {%- if not field.widget.hidden -%}
 <div class="{{ field_class }}
             {% if field.error %}{{ field_error_state_class }}{% endif %}
-            {% if field.widget.template == 'textarea' and field.widget.max_length -%}js-character-limit{% endif %}"
+            {% if field.widget.template in ('textinput', 'textarea') and field.widget.max_length -%}js-character-limit{% endif %}"
      {%- if field.description -%}
      title="{{ _(field.description) }}"
      {% endif %}

--- a/h/templates/deform/textinput.jinja2
+++ b/h/templates/deform/textinput.jinja2
@@ -1,2 +1,3 @@
 <input type="text"
 {% include "includes/common_attrs.jinja2" %}>
+{%- if field.widget.max_length -%}<span class="form-input__character-counter" data-ref="characterLimitCounter">Up to {{ field.widget.max_length }} characters</span>{% endif %}


### PR DESCRIPTION
Currently the character counter appears on Deform `<textarea>`s that have a `max_length`. This PR adds it to Deform `<input>`s with a `max_length` as well