### PR TITLE
Pin zope.interface to 4.2.0

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -36,6 +36,10 @@ wsaccel
 ws4py
 zope.sqlalchemy
 
+# Version pin until https://github.com/zopefoundation/zope.interface/issues/53
+# is resolved
+zope.interface == 4.2.0
+
 # Version pin for known bug
 # https://github.com/repoze/repoze.sendmail/issues/31
 repoze.sendmail < 4.2

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ INSTALL_REQUIRES = [
     'pyramid>=1.6,<1.7',
     'python-dateutil>=2.1',
     'transaction',
+    'zope.interface==4.2.0',
 ]
 EXTRAS_REQUIRE = {}
 ENTRY_POINTS = {}


### PR DESCRIPTION
Pin zope.interface until
https://github.com/zopefoundation/zope.interface/issues/53 is fixed