### PR TITLE
Fix Safari and IE element upgrades

### DIFF
--- a/h/static/scripts/base/controller.js
+++ b/h/static/scripts/base/controller.js
@@ -7,22 +7,18 @@
  * Multiple controllers may need to refer to the same element, so `data-ref`
  * supports a space-separated list of reference names.
  */
-function findRefs(el, map) {
-  if (!el.dataset) {
-    return map;
-  }
-  map = map || {};
+function findRefs(el) {
+  var map = {};
 
-  var refs = (el.dataset.ref || '').split(' ');
-  refs.forEach(function (ref) {
-    map[ref] = el;
-  });
-
-  for (var i=0; i < el.children.length; i++) {
-    var node = el.children[i];
-    if (node.nodeType === Node.ELEMENT_NODE) {
-      findRefs(node, map);
-    }
+  var descendantsWithRef = el.querySelectorAll('[data-ref]');
+  for (var i=0; i < descendantsWithRef.length; i++) {
+    // Use `Element#getAttribute` rather than `Element#dataset` to support IE 10
+    // and avoid https://bugs.webkit.org/show_bug.cgi?id=161454
+    var refEl = descendantsWithRef[i];
+    var refs = (refEl.getAttribute('data-ref') || '').split(' ');
+    refs.forEach(function (ref) {
+      map[ref] = refEl;
+    });
   }
 
   return map;

--- a/h/static/scripts/tests/base/controller-test.js
+++ b/h/static/scripts/tests/base/controller-test.js
@@ -16,7 +16,7 @@ describe('Controller', function () {
 
   beforeEach(function () {
     var root = document.createElement('div');
-    root.dataset.ref = 'test';
+    root.innerHTML = '<div data-ref="test"></div>';
     document.body.appendChild(root);
     ctrl = new TestController(root);
   });
@@ -31,7 +31,7 @@ describe('Controller', function () {
   });
 
   it('exposes elements with "data-ref" attributes on the `refs` property', function () {
-    assert.deepEqual(ctrl.refs, {test: ctrl.element});
+    assert.deepEqual(ctrl.refs, {test: ctrl.element.children[0]});
   });
 
   describe('#setState', function () {


### PR DESCRIPTION
In Safari 9.x, `findRefs()` ran into an issue where
`Element#dataset#name` could sporadically return `undefined` even though
the element has a `data-ref` attribute. See
https://bugs.webkit.org/show_bug.cgi?id=161454

IE 10 lacks support for `Element#dataset` and also `ParentNode#children`
for <svg> elements, so use `querySelectorAll()` to find matching descendants.

The revised implementation does not look for `data-ref` on the root node
since that is already available via `this.element` in controllers