### PR TITLE
Instrument application with New Relic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,4 +48,4 @@ ENV PYTHONPATH /var/lib/hypothesis:$PYTHONPATH
 
 # Start the web server by default
 USER hypothesis
-CMD ["gunicorn", "--paste", "conf/app.ini"]
+CMD ["newrelic-admin", "run-program", "gunicorn", "--paste", "conf/app.ini"]

--- a/requirements.in
+++ b/requirements.in
@@ -16,6 +16,7 @@ itsdangerous
 jsonpointer == 1.0
 jsonschema
 kombu
+newrelic
 passlib
 psycogreen
 psycopg2

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,6 +40,7 @@ kombu==3.0.35
 Mako==1.0.4               # via alembic
 MarkupSafe==0.23          # via jinja2, mako, pyramid-jinja2
 mistune==0.7.3
+newrelic==2.68.0.50
 passlib==1.6.5
 PasteDeploy==1.5.2        # via pyramid
 peppercorn==0.5           # via deform


### PR DESCRIPTION
In order to get better visibility into the performance of our application, we want to run the web application instrumented with the New Relic agent.

By default, this will do nothing. In stage and prod, we will set appropriate environment variables[1] to configure the agent.

[1]: https://docs.newrelic.com/docs/agents/python-agent/installation-configuration/python-agent-configuration#environment-variables