### PR TITLE
Inline form editing

### DIFF
--- a/h/accounts/views.py
+++ b/h/accounts/views.py
@@ -543,7 +543,8 @@ class EditProfileController(object):
         self.request = request
         self.schema = schemas.EditProfileSchema().bind(request=self.request)
         self.form = request.create_form(self.schema,
-                                        buttons=(_('Save'),))
+                                        buttons=(_('Save'),),
+                                        use_inline_editing=True)
 
     @view_config(request_method='GET')
     def get(self):

--- a/h/groups/views.py
+++ b/h/groups/views.py
@@ -74,7 +74,8 @@ class GroupEditController(object):
         self.request = request
         self.schema = schemas.GroupSchema().bind(request=self.request)
         self.form = request.create_form(self.schema,
-                                        buttons=(_('Save'),))
+                                        buttons=(_('Save'),),
+                                        use_inline_editing=True)
 
     @view_config(request_method='GET')
     def get(self):

--- a/h/static/scripts/base/controller.js
+++ b/h/static/scripts/base/controller.js
@@ -1,31 +1,12 @@
 'use strict';
 
-/**
- * Search the DOM tree starting at `el` and return a map of "data-ref" attribute
- * values to elements.
- *
- * Multiple controllers may need to refer to the same element, so `data-ref`
- * supports a space-separated list of reference names.
- */
-function findRefs(el) {
-  var map = {};
+var { findRefs } = require('../util/dom');
 
-  var descendantsWithRef = el.querySelectorAll('[data-ref]');
-  for (var i=0; i < descendantsWithRef.length; i++) {
-    // Use `Element#getAttribute` rather than `Element#dataset` to support IE 10
-    // and avoid https://bugs.webkit.org/show_bug.cgi?id=161454
-    var refEl = descendantsWithRef[i];
-    var refs = (refEl.getAttribute('data-ref') || '').split(' ');
-    refs.forEach(function (ref) {
-      map[ref] = refEl;
-    });
-  }
-
-  return map;
-}
-
-/**
+/*
  * @typedef {Object} ControllerOptions
+ * @property {Function} [reload] - A function that replaces the content of
+ *           the current element with new markup (eg. returned by an XHR request
+ *           to the server) and returns the new root Element.
  */
 
 /**
@@ -85,6 +66,15 @@ class Controller {
    */
   forceUpdate() {
     this.update(this.state, this.state);
+  }
+
+  /**
+   * Listen for events dispatched to the root element passed to the controller.
+   *
+   * This a convenience wrapper around `this.element.addEventListener`.
+   */
+  on(event, listener, useCapture) {
+    this.element.addEventListener(event, listener, useCapture);
   }
 }
 

--- a/h/static/scripts/base/upgrade-elements.js
+++ b/h/static/scripts/base/upgrade-elements.js
@@ -1,6 +1,18 @@
 'use strict';
 
 /**
+ * Mark an element as having been upgraded.
+ */
+function markReady(element) {
+  var HIDE_CLASS = 'is-hidden-when-loading';
+  var hideOnLoad = Array.from(element.querySelectorAll('.' + HIDE_CLASS));
+  hideOnLoad.forEach(function (el) {
+    el.classList.remove(HIDE_CLASS);
+  });
+  element.classList.remove(HIDE_CLASS);
+}
+
+/**
  * Upgrade elements on the page with additional functionality
  *
  * Controllers attached to upgraded elements are accessible via the `controllers`
@@ -37,6 +49,7 @@ function upgradeElements(root, controllers) {
         new ControllerClass(el, {
           reload: reload.bind(null, el),
         });
+        markReady(el);
       } catch (err) {
         console.error('Failed to upgrade element %s with controller', el, ControllerClass, ':', err.toString());
 

--- a/h/static/scripts/base/upgrade-elements.js
+++ b/h/static/scripts/base/upgrade-elements.js
@@ -13,12 +13,30 @@
  *        order to upgrade it.
  */
 function upgradeElements(root, controllers) {
+  // A helper which replaces the content (including the root element) of
+  // an upgraded element with new markup and re-applies element upgrades to
+  // the new root element
+  function reload(element, html) {
+    if (typeof html !== 'string') {
+      throw new Error('Replacement markup must be a string');
+    }
+    var container = document.createElement('div');
+    container.innerHTML = html;
+    upgradeElements(container, controllers);
+
+    var newElement = container.children[0];
+    element.parentElement.replaceChild(newElement, element);
+    return newElement;
+  }
+
   Object.keys(controllers).forEach(function (selector) {
     var elements = Array.from(root.querySelectorAll(selector));
     elements.forEach(function (el) {
       var ControllerClass = controllers[selector];
       try {
-        new ControllerClass(el);
+        new ControllerClass(el, {
+          reload: reload.bind(null, el),
+        });
       } catch (err) {
         console.error('Failed to upgrade element %s with controller', el, ControllerClass, ':', err.toString());
 

--- a/h/static/scripts/controllers/form-controller.js
+++ b/h/static/scripts/controllers/form-controller.js
@@ -1,0 +1,204 @@
+'use strict';
+
+var Controller = require('../base/controller');
+var { findRefs, setElementState } = require('../util/dom');
+var submitForm = require('../util/submit-form');
+
+/**
+ * A controller which adds inline editing functionality to forms
+ */
+class FormController extends Controller {
+  constructor(element, options) {
+    super(element, options);
+
+    setElementState(this.refs.cancelBtn, {hidden: false});
+    this.refs.cancelBtn.addEventListener('click', event => {
+      event.preventDefault();
+      this.cancel();
+    });
+
+    // List of groups of controls that constitute each form field
+    this._fields = Array.from(element.querySelectorAll('.js-form-input'))
+      .map(el => {
+        var parts = findRefs(el);
+        return {container: el, input: parts.formInput};
+      });
+
+    this.on('focus', event => {
+      var field = this._fields.find(field => field.input === event.target);
+      if (!field) {
+        return;
+      }
+
+      // Enforce that the current field retains focus while it has unsaved
+      // changes
+      if (this.state.dirty &&
+          this.state.editingField &&
+          this.state.editingField !== field) {
+        this.state.editingField.input.focus();
+        return;
+      }
+
+      this.setState({editingField: field});
+    }, true /* capture - focus does not bubble */);
+
+    this.on('input', () => {
+      this.setState({dirty: true});
+    });
+
+    this.on('keydown', event => {
+      event.stopPropagation();
+      if (event.key === 'Escape') {
+        this.cancel();
+      }
+    });
+
+    // Ignore clicks outside of the active field when editing
+    this.refs.formBackdrop.addEventListener('mousedown', event => {
+      event.preventDefault();
+      event.stopPropagation();
+    });
+
+    // When the user tabs outside of the form, cancel editing
+    this.on('blur', () => {
+      // Add a timeout because `document.activeElement` is not updated until
+      // after the event is processed
+      setTimeout(() => {
+        // If the user has made changes to the active element, then keep focus
+        // on the active field, otherwise allow them to move to the previous /
+        // next fields by tabbing
+        if (this.state.dirty && !this._isEditingFieldFocused()) {
+          this.state.editingField.input.focus();
+        } else if (!this.element.contains(document.activeElement)) {
+          this.setState({editingField: null});
+        }
+      }, 0);
+    }, true /* capture - 'blur' does not bubble */);
+
+    // Setup AJAX handling for forms
+    this.on('submit', event => {
+      event.preventDefault();
+      this.submit();
+    });
+
+    this.setState({
+      // True if the user has made changes to the field they are currently
+      // editing
+      dirty: false,
+      // The group of elements (container, input) for the form field currently
+      // being edited
+      editingField: null,
+      // Markup for the original form. Used to revert the form to its original
+      // state when the user cancels editing
+      originalForm: this.element.outerHTML,
+      // Flag that indicates a save is currently in progress
+      saving: false,
+      // Error that occurred while submitting the form
+      submitError: '',
+    });
+  }
+
+  update(state, prevState) {
+    if (prevState.editingField &&
+        state.editingField !== prevState.editingField) {
+      setElementState(prevState.editingField.container, {editing: false});
+    }
+
+    if (state.editingField) {
+      // Display Save/Cancel buttons below the field that we are currently
+      // editing
+      state.editingField.container.parentElement.insertBefore(
+        this.refs.formActions,
+        state.editingField.container.nextSibling
+      );
+      setElementState(state.editingField.container, {editing: true});
+    }
+
+    var isEditing = !!state.editingField;
+    setElementState(this.element, {editing: isEditing});
+    setElementState(this.refs.formActions, {
+      hidden: !isEditing,
+      saving: state.saving,
+    });
+    setElementState(this.refs.formSubmitError, {
+      visible: state.submitError.length > 0,
+    });
+    this.refs.formSubmitErrorMessage.textContent = state.submitError;
+  }
+
+  /**
+   * Perform an AJAX submission of the form and replace it with the rendered
+   * result.
+   */
+  submit() {
+    var originalForm = this.state.originalForm;
+
+    var activeInputId;
+    if (this.state.editingField) {
+      activeInputId = this.state.editingField.input.id;
+    }
+
+    this.setState({saving: true});
+
+    return submitForm(this.element).then(response => {
+      this.options.reload(response.form);
+    }).catch(err => {
+      if (err.form) {
+        // The server processed the request but rejected the submission.
+        // Display the returned form which will contain any validation error
+        // messages.
+        var newFormEl = this.options.reload(err.form);
+        var newFormCtrl = newFormEl.controllers.find(ctrl =>
+          ctrl instanceof FormController);
+
+        // Resume editing the field where validation failed
+        var newInput = document.getElementById(activeInputId);
+        if (newInput) {
+          newInput.focus();
+        }
+
+        newFormCtrl.setState({
+          // Mark the field in the replaced form as dirty since it has unsaved
+          // changes
+          dirty: newInput !== null,
+          // If editing is canceled, revert back to the _original_ version of
+          // the form, not the version with validation errors from the server.
+          originalForm,
+        });
+      } else {
+        // If there was an error processing the request or the server could
+        // not be reached, display a helpful error
+        this.setState({
+          submitError: err.reason,
+          saving: false,
+        });
+      }
+    });
+  }
+
+  /**
+   * Return true if the field that the user last started editing currently has
+   * focus.
+   */
+  _isEditingFieldFocused() {
+    if (!this.state.editingField) {
+      return false;
+    }
+
+    var focusedEl = document.activeElement;
+    if (this.refs.formActions.contains(focusedEl)) {
+      return true;
+    }
+    return this.state.editingField.container.contains(focusedEl);
+  }
+
+  /**
+   * Cancel editing for the currently active field and revert any unsaved
+   * changes.
+   */
+  cancel() {
+    this.options.reload(this.state.originalForm);
+  }
+}
+
+module.exports = FormController;

--- a/h/static/scripts/site.js
+++ b/h/static/scripts/site.js
@@ -11,6 +11,7 @@ require('./polyfills');
 var CharacterLimitController = require('./controllers/character-limit-controller');
 var CreateGroupFormController = require('./controllers/create-group-form-controller');
 var DropdownMenuController = require('./controllers/dropdown-menu-controller');
+var FormController = require('./controllers/form-controller');
 var FormSelectOnFocusController = require('./controllers/form-select-onfocus-controller');
 var SearchBarController = require('./controllers/search-bar-controller');
 var SearchBucketController = require('./controllers/search-bucket-controller');
@@ -22,6 +23,7 @@ var controllers = {
   '.js-character-limit': CharacterLimitController,
   '.js-create-group-form': CreateGroupFormController,
   '.js-dropdown-menu': DropdownMenuController,
+  '.js-form': FormController,
   '.js-select-onfocus': FormSelectOnFocusController,
   '.js-search-bar': SearchBarController,
   '.js-search-bucket': SearchBucketController,

--- a/h/static/scripts/tests/base/controller-test.js
+++ b/h/static/scripts/tests/base/controller-test.js
@@ -3,8 +3,8 @@
 var Controller = require('../../base/controller');
 
 class TestController extends Controller {
-  constructor(element) {
-    super(element);
+  constructor(element, options) {
+    super(element, options);
     this.update = sinon.stub();
   }
 }

--- a/h/static/scripts/tests/base/upgrade-elements-test.js
+++ b/h/static/scripts/tests/base/upgrade-elements-test.js
@@ -1,18 +1,51 @@
 'use strict';
 
+var Controller = require('../../base/controller');
 var upgradeElements = require('../../base/upgrade-elements');
+
+class TestController extends Controller {
+  constructor(element, options) {
+    super(element, options);
+  }
+}
 
 describe('upgradeElements', function () {
   it('should upgrade elements matching selectors', function () {
-    var TestController = sinon.spy();
-
     var root = document.createElement('div');
-    root.classList.add('js-test');
-    document.body.appendChild(root);
+    root.innerHTML = '<div class="js-test"></div>';
 
-    upgradeElements(document.body, {'.js-test': TestController});
-    assert.calledWith(TestController, root);
+    upgradeElements(root, {'.js-test': TestController});
+    assert.instanceOf(root.children[0].controllers[0], TestController);
+  });
 
-    root.remove();
+  describe('reload function', function () {
+    var newContent = '<div class="js-test">Reloaded element</div>';
+
+    function setupAndReload() {
+      var root = document.createElement('div');
+      root.innerHTML = '<div class="js-test">Original content</div>';
+      upgradeElements(root, {'.js-test': TestController});
+
+      var reloadFn = root.children[0].controllers[0].options.reload;
+      var reloadResult = reloadFn(newContent);
+      return {root: root, reloadResult: reloadResult};
+    }
+
+    it('replaces element markup', function () {
+      var root = setupAndReload().root;
+      assert.equal(root.innerHTML, newContent);
+    });
+
+    it('returns the replaced element', function () {
+      var result = setupAndReload();
+      assert.equal(result.root.children[0], result.reloadResult);
+    });
+
+    it('re-applies element upgrades', function () {
+      var root = setupAndReload().root;
+      var replacedElement = root.children[0];
+      var ctrl = replacedElement.controllers[0];
+      assert.instanceOf(ctrl, TestController);
+    });
   });
 });

--- a/h/static/scripts/tests/base/upgrade-elements-test.js
+++ b/h/static/scripts/tests/base/upgrade-elements-test.js
@@ -15,7 +15,28 @@ describe('upgradeElements', function () {
     root.innerHTML = '<div class="js-test"></div>';
 
     upgradeElements(root, {'.js-test': TestController});
+
     assert.instanceOf(root.children[0].controllers[0], TestController);
+  });
+
+  it('should unhide elements hidden until upgrade', function () {
+    var root = document.createElement('div');
+    root.innerHTML = '<div class="js-test is-hidden-when-loading"></div>';
+
+    upgradeElements(root, {'.js-test': TestController});
+
+    assert.equal(root.querySelectorAll('.is-hidden-when-loading').length, 0);
+  });
+
+  it('should unhide child elements hidden until upgrade', function () {
+    var root = document.createElement('div');
+    root.innerHTML = '<div class="js-test">' +
+                     '<span class="is-hidden-when-loading"></span>' +
+                     '</div>';
+
+    upgradeElements(root, {'.js-test': TestController});
+
+    assert.equal(root.querySelectorAll('.is-hidden-when-loading').length, 0);
   });
 
   describe('reload function', function () {

--- a/h/static/scripts/tests/controllers/form-controller-test.js
+++ b/h/static/scripts/tests/controllers/form-controller-test.js
@@ -1,0 +1,262 @@
+'use strict';
+
+var proxyquire = require('proxyquire');
+
+var { noCallThru } = require('../util');
+var upgradeElements = require('../../base/upgrade-elements');
+
+// Simplified version of forms rendered by deform on the server
+var TEMPLATE = `
+  <form class="js-form">
+    <div data-ref="formBackdrop"></div>
+    <div class="js-form-input">
+      <input id="deformField" data-ref="formInput firstInput" value="original value">
+    </div>
+    <div class="js-form-input">
+      <input id="deformField2" data-ref="formInput secondInput" value="original value 2">
+    </div>
+    <div data-ref="formActions">
+      <button data-ref="testSaveBtn">Save</button>
+      <button data-ref="cancelBtn">Cancel</button>
+    </div>
+    <div data-ref="formSubmitError">
+      <div data-ref="formSubmitErrorMessage"></div>
+    </div>
+  </form>
+`;
+
+var UPDATED_FORM = TEMPLATE.replace('js-form', 'js-form is-updated');
+
+describe('FormController', function () {
+  var ctrl;
+  var fakeSubmitForm;
+  var reloadSpy;
+
+  beforeEach(function () {
+    fakeSubmitForm = sinon.stub();
+    var FormController = proxyquire('../../controllers/form-controller', {
+      '../util/submit-form': noCallThru(fakeSubmitForm),
+    });
+
+    var container = document.createElement('div');
+    container.innerHTML = TEMPLATE;
+    upgradeElements(container, {
+      '.js-form': FormController,
+    });
+
+    ctrl = container.querySelector('.js-form').controllers[0];
+
+    // Wrap the original `reload` function passed to the controller so we can
+    // spy on calls to it and update `ctrl` to the new controller instance
+    // when the form is reloaded
+    var reloadFn = ctrl.options.reload;
+    reloadSpy = sinon.spy(html => {
+      var newElement = reloadFn(html);
+      ctrl = newElement.controllers[0];
+      return newElement;
+    });
+    ctrl.options.reload = reloadSpy;
+
+    // Add element to document so that it can be focused
+    document.body.appendChild(ctrl.element);
+  });
+
+  afterEach(function () {
+    ctrl.element.remove();
+  });
+
+  function isEditing() {
+    return ctrl.element.classList.contains('is-editing');
+  }
+
+  function submitForm() {
+    return ctrl.submit();
+  }
+
+  function startEditing() {
+    ctrl.refs.firstInput.focus();
+  }
+
+  function isSaving() {
+    return ctrl.refs.formActions.classList.contains('is-saving');
+  }
+
+  function submitError() {
+    if (!ctrl.refs.formSubmitError.classList.contains('is-visible')) {
+      return '<hidden>';
+    }
+    return ctrl.refs.formSubmitErrorMessage.textContent;
+  }
+
+  it('begins editing when a field is focused', function () {
+    ctrl.refs.firstInput.focus();
+    ctrl.refs.firstInput.dispatchEvent(new Event('focus'));
+    assert.isTrue(isEditing());
+  });
+
+  it('reverts the form when "Cancel" is clicked', function () {
+    startEditing();
+    ctrl.refs.firstInput.value = 'new value';
+    ctrl.refs.cancelBtn.click();
+    assert.equal(ctrl.refs.firstInput.value, 'original value');
+  });
+
+  it('reverts the form when "Escape" key is pressed', function () {
+    startEditing();
+    var event = new Event('keydown', {bubbles: true});
+    event.key = 'Escape';
+    ctrl.refs.firstInput.dispatchEvent(event);
+    assert.equal(ctrl.refs.firstInput.value, 'original value');
+  });
+
+  it('submits the form when "Save" is clicked', function () {
+    fakeSubmitForm.returns(Promise.resolve({status: 200, form: UPDATED_FORM}));
+    ctrl.refs.testSaveBtn.click();
+    assert.calledWith(fakeSubmitForm, ctrl.element);
+
+    // Ensure that test does not complete until `FormController#submit` has
+    // run
+    return Promise.resolve();
+  });
+
+  context('when form is successfully submitted', function () {
+    it('updates form with new rendered version from server', function () {
+      fakeSubmitForm.returns(Promise.resolve({status: 200, form: UPDATED_FORM}));
+      return submitForm().then(function () {
+        assert.isTrue(ctrl.element.classList.contains('is-updated'));
+      });
+    });
+
+    it('stops editing the form', function () {
+      fakeSubmitForm.returns(Promise.resolve({status: 200, form: UPDATED_FORM}));
+      return submitForm().then(function () {
+        assert.isFalse(isEditing());
+      });
+    });
+  });
+
+  context('when validation fails', function () {
+    it('updates form with rendered version from server', function () {
+      startEditing();
+      fakeSubmitForm.returns(Promise.reject({status: 400, form: UPDATED_FORM}));
+      return submitForm().then(function () {
+        assert.isTrue(ctrl.element.classList.contains('is-updated'));
+      });
+    });
+
+    it('marks updated form as dirty', function () {
+      startEditing();
+      fakeSubmitForm.returns(Promise.reject({status: 400, form: UPDATED_FORM}));
+      return submitForm().then(function () {
+        assert.isTrue(ctrl.state.dirty);
+      });
+    });
+
+    it('continues editing current field', function () {
+      startEditing();
+      fakeSubmitForm.returns(Promise.reject({status: 400, form: UPDATED_FORM}));
+      return submitForm().then(function () {
+        assert.isTrue(isEditing());
+      });
+    });
+
+    it('focuses the matching input field in the re-rendered form', function () {
+      startEditing();
+      fakeSubmitForm.returns(Promise.reject({status: 400, form: UPDATED_FORM}));
+
+      // Simulate the user saving the form by clicking the 'Save' button, which
+      // changes the focus from the input field to the button
+      ctrl.refs.testSaveBtn.focus();
+
+      return submitForm().then(function () {
+        // In the re-rendered form, the input field should be focused
+        assert.equal(document.activeElement.id, 'deformField');
+      });
+    });
+  });
+
+  it('enters the "saving" state while the form is being submitted', function () {
+    fakeSubmitForm.returns(Promise.resolve({status: 200, form: UPDATED_FORM}));
+    var saved = submitForm();
+    assert.isTrue(isSaving());
+    return saved.then(function () {
+      assert.isFalse(isSaving());
+    });
+  });
+
+  it('displays an error if form submission fails without returning a new form', function () {
+    fakeSubmitForm.returns(Promise.reject({status: 500, reason: 'Internal Server Error'}));
+    return submitForm().then(function () {
+      assert.equal(submitError(), 'Internal Server Error');
+    });
+  });
+
+  it('ignores clicks outside the field being edited', function () {
+    startEditing();
+    var event = new Event('mousedown', {cancelable: true});
+    ctrl.refs.formBackdrop.dispatchEvent(event);
+    assert.isTrue(event.defaultPrevented);
+  });
+
+  it('sets form state to dirty if user modifies active field', function () {
+    startEditing();
+
+    ctrl.refs.firstInput.dispatchEvent(new Event('input', {bubbles: true}));
+
+    assert.isTrue(ctrl.state.dirty);
+  });
+
+  context('when focus moves to another input while editing', function () {
+    it('clears editing state of first input', function () {
+      startEditing();
+      var inputs = ctrl.element.querySelectorAll('.js-form-input');
+
+      // Focus second input. Although the user cannot focus the second input with
+      // the mouse while the first is focused, they can navigate to it with the
+      // tab key
+      ctrl.refs.secondInput.focus();
+
+      assert.isFalse(inputs[0].classList.contains('is-editing'));
+      assert.isTrue(inputs[1].classList.contains('is-editing'));
+    });
+
+    it('keeps focus in previous input if it has unsaved changes', function () {
+      startEditing();
+      ctrl.setState({dirty: true});
+
+      // Simulate user/browser attempting to switch to another field
+      ctrl.refs.secondInput.focus();
+
+      assert.equal(document.activeElement, ctrl.refs.firstInput);
+    });
+  });
+
+  context('when focus moves outside of form', function () {
+    it('clears editing state if field does not have unsaved changes', function (done) {
+      startEditing();
+
+      // Simulate user moving focus outside of form (eg. via tab key).
+      // This may be to either another part of the page or browser chrome
+      ctrl.refs.firstInput.blur();
+
+      setTimeout(function () {
+        assert.isFalse(isEditing());
+        done();
+      });
+    });
+
+    it('keeps current field focused if it has unsaved changes', function (done) {
+      startEditing();
+      ctrl.setState({dirty: true});
+
+      // Simulate user/browser attempting to switch focus to an element outside
+      // the form
+      ctrl.refs.firstInput.blur();
+
+      setTimeout(function () {
+        assert.equal(document.activeElement, ctrl.refs.firstInput);
+        done();
+      });
+    });
+  });
+});

--- a/h/static/scripts/tests/util/dom-test.js
+++ b/h/static/scripts/tests/util/dom-test.js
@@ -12,6 +12,32 @@ describe('util/dom', function () {
     return child;
   }
 
+  describe('findRefs', function () {
+    it('returns a map of name to DOM element', function () {
+      var root = createDOM(`
+        <div>
+          <label data-ref="label">Input label</label>
+          <input data-ref="input">
+        </div>
+      `);
+      var labelEl = root.querySelector('label');
+      var inputEl = root.querySelector('input');
+
+      assert.deepEqual(domUtil.findRefs(root), {
+        label: labelEl,
+        input: inputEl,
+      });
+    });
+
+    it('allows elements to have more than one name', function () {
+      var root = createDOM('<div><div data-ref="one two"></div></div>');
+      assert.deepEqual(domUtil.findRefs(root), {
+        one: root.firstChild,
+        two: root.firstChild,
+      });
+    });
+  });
+
   describe('setElementState', function () {
     it('adds "is-$state" classes for keys with truthy values', function () {
       var btn = createDOM('<button></button>');

--- a/h/static/scripts/util/dom.js
+++ b/h/static/scripts/util/dom.js
@@ -23,6 +23,31 @@ function setElementState(el, state) {
   });
 }
 
+/**
+ * Search the DOM tree starting at `el` and return a map of "data-ref" attribute
+ * values to elements.
+ *
+ * This provides a way to label parts of a control in markup and get a
+ * reference to them subsequently in code.
+ */
+function findRefs(el) {
+  var map = {};
+
+  var descendantsWithRef = el.querySelectorAll('[data-ref]');
+  for (var i=0; i < descendantsWithRef.length; i++) {
+    // Use `Element#getAttribute` rather than `Element#dataset` to support IE 10
+    // and avoid https://bugs.webkit.org/show_bug.cgi?id=161454
+    var refEl = descendantsWithRef[i];
+    var refs = (refEl.getAttribute('data-ref') || '').split(' ');
+    refs.forEach(function (ref) {
+      map[ref] = refEl;
+    });
+  }
+
+  return map;
+}
+
 module.exports = {
+  findRefs: findRefs,
   setElementState: setElementState,
 };

--- a/h/static/styles/partials-v2/_base.scss
+++ b/h/static/styles/partials-v2/_base.scss
@@ -32,6 +32,8 @@ $title-font-size: 19px;
 $input-font-size: 15px;
 
 // Z-index scale
+$zindex-modal-backdrop: 5; // Backdrop of a modal dialog or form
+$zindex-modal-content: 6;  // Content of a modal dialog or form
 $zindex-dropdown-menu: 10;
 $zindex-tooltip: 20;
 

--- a/h/static/styles/partials-v2/_btn.scss
+++ b/h/static/styles/partials-v2/_btn.scss
@@ -16,6 +16,14 @@
   white-space: nowrap;
 }
 
+.btn.is-hidden {
+  display: none;
+}
+
+.btn--cancel {
+  background-color: $grey-4;
+}
+
 .btn:hover {
   background-color: $brand;
 }

--- a/h/static/styles/partials-v2/_form-actions.scss
+++ b/h/static/styles/partials-v2/_form-actions.scss
@@ -6,10 +6,21 @@
 
 .form-actions {
   margin-top: 20px;
+  margin-bottom: 30px;
 
   display: flex;
   flex-direction: row-reverse;
   align-items: center;
+  position: relative;
+  z-index: $zindex-modal-content;
+
+  .env-js-capable &.is-hidden {
+    display: none;
+  }
+}
+
+.form-actions.is-saving {
+  opacity: .5;
 }
 
 .form-actions__message {

--- a/h/static/styles/partials-v2/_form-actions.scss
+++ b/h/static/styles/partials-v2/_form-actions.scss
@@ -14,7 +14,7 @@
   position: relative;
   z-index: $zindex-modal-content;
 
-  .env-js-capable &.is-hidden {
+  &.is-hidden {
     display: none;
   }
 }

--- a/h/static/styles/partials-v2/_form-input.scss
+++ b/h/static/styles/partials-v2/_form-input.scss
@@ -29,6 +29,10 @@
     background-color: $white;
   }
 
+  .form-input.is-editing {
+    z-index: $zindex-modal-content;
+  }
+
   .form-input.is-error {
     & > .form-input__label {
       color: $brand;
@@ -36,6 +40,10 @@
 
     & > .form-input__input {
       color: $brand;
+    }
+
+    & > .form-input__error-list {
+      display: initial;
     }
   }
 
@@ -161,7 +169,8 @@
     border-width: 2px;
   }
 
-  .form-input__input:focus {
+  .form-input__input:focus,
+  .form-input.is-editing > .form-input__input {
     @include thick-border;
     border-color: $grey-6;
   }
@@ -178,7 +187,12 @@
     box-shadow: none;
   }
 
-  // Validation error message
+  // Validation error messages
+  .form-input__error-list {
+    // The error list is only shown when the input is in an `error` state
+    display: none;
+  }
+
   .form-input__error-item {
     max-width: $validation-message-width;
     position: absolute;

--- a/h/static/styles/partials-v2/_form.scss
+++ b/h/static/styles/partials-v2/_form.scss
@@ -2,6 +2,39 @@
 // -------------------------
 // Specs: https://goo.gl/pEV9E1
 
+// Backdrop which appears behind forms during inline editing
+.form__backdrop {
+  display: none;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: $zindex-modal-backdrop;
+
+  background-color: $white;
+  opacity: 0.5;
+}
+
+// Error message displayed if AJAX form submission fails for reasons other than
+// a validation error. When there is a validation error, the response is updated
+// markup for the form which replaces the original.
+.form__submit-error {
+  color: $brand;
+  display: none;
+  font-weight: bold;
+  margin-top: 5px;
+  margin-bottom: 5px;
+
+  &.is-visible {
+    display: block;
+  }
+}
+
+.form.is-editing > .form__backdrop {
+  display: block;
+}
+
 .form-header {
   margin-top: 55px;
   margin-bottom: 30px;

--- a/h/static/styles/partials-v2/_search-bar.scss
+++ b/h/static/styles/partials-v2/_search-bar.scss
@@ -49,6 +49,7 @@
   padding: 20px 0 0 0;
   position: absolute;
   width: 100%;
+  z-index: $zindex-dropdown-menu;
 }
 
 .search-bar__dropdown-menu-header {

--- a/h/static/styles/partials-v2/_util.scss
+++ b/h/static/styles/partials-v2/_util.scss
@@ -5,3 +5,14 @@
 .u-stretch {
   flex-grow: 1;
 }
+
+// Utility class that hides an element during initial page load until its
+// containing element is upgraded, or JS load times out.
+//
+// This class is an exception to the rule that is-* state classes can only be
+// used with specific components.
+@include js {
+  .is-hidden-when-loading {
+    display: none !important;
+  }
+}

--- a/h/templates/deform/form.jinja2
+++ b/h/templates/deform/form.jinja2
@@ -5,20 +5,26 @@
 {% set form_buttons_class = 'form-actions-buttons' %}
 {% set form_message_class = 'form-actions-message' %}
 {% endif %}
-
 <form id="{{ field.formid }}"
       action="{{ field.action }}"
       method="{{ field.method }}"
       enctype="multipart/form-data"
       accept-charset="utf-8"
-      class="form {% if field.css_class %}{{ field.css_class }} {% endif %}">
+      class="form {{ field.css_class or '' }}
+             {%- if field.use_inline_editing %} js-form {% endif %}">
   <input type="hidden" name="__formid__" value="{{ field.formid }}" />
+
+  <div class="form__backdrop" data-ref="formBackdrop"></div>
 
   {%- for f in field.children -%}
     {{ field.renderer(field.widget.item_template, field=f, cstruct=cstruct.get(f.name, null)) }}
   {% endfor -%}
 
-  <div class="form-actions">
+  <div class="form-actions" data-ref="formActions">
+    <div class="form__submit-error" data-ref="formSubmitError">
+      <span>{% trans %}Unable to save changes: {% endtrans %}</span>
+      <span data-ref="formSubmitErrorMessage"></span>
+    </div>
     <div class="{{ form_message_class }}">
       {%- if field.footer %}{{ field.footer | safe }}{% endif -%}
     </div>
@@ -30,7 +36,7 @@
         <button id="{{ field.formid + button.name }}"
                 name="{{ button.name }}"
                 type="{{ button.type }}"
-                class="btn{% if button.css_class %} {{ button.css_class }}{% endif %}"
+                class="form-actions__btn btn{% if button.css_class %} {{ button.css_class }}{% endif %}"
                 value="{{ _(button.value) }}"
                 {%- if button.disabled -%}
                 disabled="disabled"
@@ -38,6 +44,7 @@
                 >
         {{ _(button.title) }}
         </button>
+        <button class="btn btn--cancel is-hidden" data-ref="cancelBtn">Cancel</button>
       {% endfor -%}
     </div>
   </div>

--- a/h/templates/deform/form.jinja2
+++ b/h/templates/deform/form.jinja2
@@ -20,7 +20,8 @@
     {{ field.renderer(field.widget.item_template, field=f, cstruct=cstruct.get(f.name, null)) }}
   {% endfor -%}
 
-  <div class="form-actions" data-ref="formActions">
+  <div class="form-actions {% if field.use_inline_editing %} is-hidden-when-loading {% endif %}"
+       data-ref="formActions">
     <div class="form__submit-error" data-ref="formSubmitError">
       <span>{% trans %}Unable to save changes: {% endtrans %}</span>
       <span data-ref="formSubmitErrorMessage"></span>

--- a/h/templates/deform/includes/common_attrs.jinja2
+++ b/h/templates/deform/includes/common_attrs.jinja2
@@ -11,7 +11,7 @@
 name="{{ field.name }}"
 value="{{ cstruct }}"
 id="{{ field.oid }}"
-data-ref="{{ ref }}"
+data-ref="{{ ref }} formInput"
 class="{{field_css_class}}
       {% if field.widget.css_class %} {{ field.widget.css_class }} {% endif %}
       {% if field.widget.autofocus %} js-select-onfocus{% endif %}

--- a/h/templates/deform/mapping_item.jinja2
+++ b/h/templates/deform/mapping_item.jinja2
@@ -2,7 +2,7 @@
 {% set field_class = 'form-input' %}
 {% set field_error_state_class = 'is-error' %}
 {% set field_label_class = 'form-input__label' %}
-{% set field_error_list_class = '' %}
+{% set field_error_list_class = 'form-input__error-list' %}
 {% set field_error_item_class = 'form-input__error-item' %}
 {% set show_char_counter = field.widget.template in ('textinput', 'textarea') and
                            field.widget.max_length %}
@@ -17,6 +17,7 @@
 
 {%- if not field.widget.hidden -%}
 <div class="{{ field_class }}
+            js-form-input
             {% if field.error %}{{ field_error_state_class }}{% endif %}
             {% if show_char_counter %} js-character-limit {%- endif %}"
      {%- if field.description -%}


### PR DESCRIPTION
**Depends on https://github.com/hypothesis/h/pull/3895**

----

This implements inline form editing and enables it for the Edit Profile and Edit Group forms.

**UX Notes**

* When input fields in forms with inline editing are focused, the form submission buttons are displayed below the focused field and the area outside that field is dimmed, until the user either saves changes or cancels editing.
* Keyboard focus handling changes depending on whether the current field has unsaved changes or not. If the field has no unsaved changes, the user can navigate through the fields in the form just by hitting the tab/shift+tab keys as they normally would. When a field becomes _dirty_ (by a user making changes), the current field becomes keyboard modal and focus stays in the field until the user saves or cancels changes.

**Implementation Overview**

The basic approach is to capture the initial rendered version of the form when the form is upgraded. When the user makes changes, the form is marked as dirty. When the user cancels changes, the form is replaced with the markup for the original version and upgrades to child elements are reapplied. When the user submits the form, the markup is replaced by the updated version from the server and upgrades to child elements are re-applied. If submission failed with a validation error, focus returns to the field that was being edited.

If the form submission fails with a non-validation (non-400) error, the current field remains in the editing state and an error message is displayed next to it.

**Implementation Notes**

Forms opt in to inline editing by setting the `use_inline_editing` attribute on the `deform.Form`. This results in the `js-form` class being added to the rendered form which triggers an upgrade using `FormController` on the client.

Two new features have been added to the current controller system to support the implementation:

* Support for communication between parent and child controllers (eg. forms and form inputs) via children broadcasting events upwards (`Controller#trigger`) and parents listening for them (`Controller#on`).
* Support for replacing the content of a controlled element with new markup from the server and re-applying upgrades (`Controller#reload`)