### PR TITLE
Inline form editing for Notifications form

### DIFF
--- a/h/accounts/views.py
+++ b/h/accounts/views.py
@@ -588,7 +588,8 @@ class NotificationsController(object):
         self.request = request
         self.schema = schemas.NotificationsSchema().bind(request=self.request)
         self.form = request.create_form(self.schema,
-                                        buttons=(_('Save changes'),))
+                                        buttons=(_('Save'),),
+                                        use_inline_editing=True)
 
     @view_config(request_method='GET')
     def get(self):
@@ -598,23 +599,23 @@ class NotificationsController(object):
                                  for n in self._user_notifications()
                                  if n.active)
         })
-        return {'form': self.form.render()}
+        return self._template_data()
 
     @view_config(request_method='POST')
     def post(self):
         """Process notifications POST data."""
-        try:
-            appstruct = self.form.validate(self.request.POST.items())
-        except deform.ValidationFailure:
-            return {'form': self.form.render()}
+        return form.handle_form_submission(
+            self.request,
+            self.form,
+            on_success=self._update_notifications,
+            on_failure=self._template_data)
 
+    def _update_notifications(self, appstruct):
         for n in self._user_notifications():
             n.active = n.type in appstruct['notifications']
 
-        self.request.session.flash(_("Success. We've saved your changes."),
-                                   'success')
-        return httpexceptions.HTTPFound(
-            location=self.request.route_url('account_notifications'))
+    def _template_data(self):
+        return {'form': self.form.render()}
 
     def _user_notifications(self):
         """Fetch the notifications/subscriptions for the logged-in user."""

--- a/h/static/scripts/tests/controllers/form-controller-test.js
+++ b/h/static/scripts/tests/controllers/form-controller-test.js
@@ -15,6 +15,9 @@ var TEMPLATE = `
     <div class="js-form-input">
       <input id="deformField2" data-ref="formInput secondInput" value="original value 2">
     </div>
+    <div class="js-form-input">
+      <input id="deformField3" data-ref="formInput checkboxInput" type="checkbox">
+    </div>
     <div data-ref="formActions">
       <button data-ref="testSaveBtn">Save</button>
       <button data-ref="cancelBtn">Cancel</button>
@@ -257,6 +260,27 @@ describe('FormController', function () {
         assert.equal(document.activeElement, ctrl.refs.firstInput);
         done();
       });
+    });
+  });
+
+  context('when a checkbox is toggled', function () {
+    beforeEach(function () {
+      fakeSubmitForm.returns(Promise.resolve({status: 200, form: UPDATED_FORM}));
+      ctrl.refs.checkboxInput.focus();
+      ctrl.refs.checkboxInput.dispatchEvent(new Event('change', {bubbles: true}));
+    });
+
+    afterEach(function () {
+      // Wait for form submission to complete
+      return Promise.resolve();
+    });
+
+    it('does not show form save buttons', function () {
+      assert.isTrue(ctrl.refs.formActions.classList.contains('is-hidden'));
+    });
+
+    it('automatically submits the form', function () {
+      assert.calledWith(fakeSubmitForm, ctrl.element);
     });
   });
 });

--- a/h/templates/deform/checkbox_choice.jinja2
+++ b/h/templates/deform/checkbox_choice.jinja2
@@ -7,11 +7,11 @@
            class="form-checkbox__label">
       <input type="checkbox"
              name="checkbox"
+             data-ref="formInput"
              value="{{ value }}"
              id="{{ field.oid }}-{{ loop.index0 }}"
-             class="form-checkbox__input {% if field.widget.css_class -%}
-               {{ field.widget.css_class }}
-             {% endif -%}"
+             class="form-checkbox__input
+             {%- if field.widget.css_class %} {{ field.widget.css_class }}{% endif -%}"
              {%- if field.error -%}
              aria-invalid="true"
              {% endif -%}


### PR DESCRIPTION
~~**_Depends on https://github.com/hypothesis/h/pull/3814_**~~

This implements inline editing for the Notifications form. The first commit implements auto-submission of forms which have inline editing enabled when a user toggles a checkbox or selects a radio item. The second commit enables XHR submission and inline editing for the Notifications settings form.