### PR TITLE
Improve search bucket behavior in the JS load timeout case

### DIFF
--- a/h/static/scripts/base/controller.js
+++ b/h/static/scripts/base/controller.js
@@ -25,6 +25,10 @@ function findRefs(el) {
 }
 
 /**
+ * @typedef {Object} ControllerOptions
+ */
+
+/**
  * Base class for controllers that upgrade elements with additional
  * functionality.
  *
@@ -44,8 +48,11 @@ class Controller {
    * Initialize the controller.
    *
    * @param {Element} element - The DOM Element to upgrade
+   * @param {ControllerOptions} [options] - Configuration options for the
+   *        controller. Subclasses extend this interface to provide config
+   *        specific to that type of controller.
    */
-  constructor(element) {
+  constructor(element, options = {}) {
     if (!element.controllers) {
       element.controllers = [this];
     } else {
@@ -54,6 +61,7 @@ class Controller {
 
     this.state = {};
     this.element = element;
+    this.options = options;
     this.refs = findRefs(element);
   }
 

--- a/h/static/scripts/base/environment-flags.js
+++ b/h/static/scripts/base/environment-flags.js
@@ -7,6 +7,13 @@
  * It adds `env-${flag}` classes to a top-level element in the document to
  * indicate support for scripting, touch input etc. These classes can then be
  * used to modify other elements in the page via descendent selectors.
+ *
+ * EnvironmentFlags provides hooks to override the detected set of environment
+ * features via query-string or fragment parameters in the URL:
+ *
+ *  "__env__" -  A semi-colon list of environment flags to enable or disable
+ *               (if prefixed with "no-"). eg. "__env__=touch"
+ *  "nojs=1"  -  Shorthand for "__env__=no-js-capable"
  */
 class EnvironmentFlags {
   /**

--- a/h/static/scripts/base/upgrade-elements.js
+++ b/h/static/scripts/base/upgrade-elements.js
@@ -3,10 +3,6 @@
 /**
  * Upgrade elements on the page with additional functionality
  *
- * `upgradeElements()` provides a hook to test a page without JS enhancements.
- * If `root` lives in a document whose URL contains the query string parameter
- * `nojs=1` then `upgradeElements()` will return immediately.
- *
  * Controllers attached to upgraded elements are accessible via the `controllers`
  * property on the element.
  *

--- a/h/static/scripts/controllers/search-bucket-controller.js
+++ b/h/static/scripts/controllers/search-bucket-controller.js
@@ -5,22 +5,44 @@ var scrollIntoView = require('scroll-into-view');
 var Controller = require('../base/controller');
 var setElementState = require('../util/dom').setElementState;
 
-class SearchBucketController extends Controller {
-  constructor(element) {
-    super(element);
+/**
+ * @typedef Options
+ * @property {EnvironmentFlags} [envFlags] - Environment flags. Provided as a
+ *           test seam.
+ * @property {Function} [scrollTo] - A function that scrolls a given element
+ *           into view. Provided as a test seam.
+ */
 
-    this.scrollTo = scrollIntoView;
+/**
+ * Controller for buckets of results in the search result list
+ */
+class SearchBucketController extends Controller {
+  /**
+   * @param {Element} element
+   * @param {Options} options
+   */
+  constructor(element, options) {
+    super(element, options);
+
+    this.scrollTo = this.options.scrollTo || scrollIntoView;
 
     this.refs.header.addEventListener('click', () => {
       this.setState({expanded: !this.state.expanded});
     });
+
+    var envFlags = this.options.envFlags || window.envFlags;
+
+    this.setState({
+      expanded: !!envFlags.get('js-timeout'),
+    });
   }
 
-  update(state) {
-    setElementState(this.refs.content, {expanded: state.expanded});
-    setElementState(this.refs.header, {expanded: state.expanded});
+  update(state, prevState) {
+    setElementState(this.refs.content, {hidden: !state.expanded});
+    setElementState(this.element, {expanded: state.expanded});
 
-    if (state.expanded) {
+    // Scroll to element when expanded, except on initial load
+    if (typeof prevState.expanded !== 'undefined' && state.expanded) {
       this.scrollTo(this.element);
     }
   }

--- a/h/static/scripts/site.js
+++ b/h/static/scripts/site.js
@@ -29,12 +29,11 @@ var controllers = {
   '.js-tooltip': TooltipController,
 };
 
-var doUpgrade = !window.envFlags || window.envFlags.get('js-capable');
-
-if (doUpgrade) {
+if (window.envFlags && window.envFlags.get('js-capable')) {
   upgradeElements(document.body, controllers);
-}
-
-if (window.envFlags) {
   window.envFlags.ready();
+} else {
+  // Environment flags not initialized. The header script may have been missed
+  // in the page or may have failed to load.
+  console.warn('EnvironmentFlags not initialized. Skipping element upgrades');
 }

--- a/h/static/scripts/tests/controllers/search-bucket-controller-test.js
+++ b/h/static/scripts/tests/controllers/search-bucket-controller-test.js
@@ -10,25 +10,61 @@ var TEMPLATE = [
   '</div>',
 ].join('\n');
 
+class FakeEnvFlags {
+  constructor (flags = []) {
+    this.flags = flags;
+  }
+
+  get(flag) {
+    return this.flags.indexOf(flag) !== -1;
+  }
+}
+
 describe('SearchBucketController', function () {
   var ctrl;
 
   beforeEach(function () {
-    ctrl = util.setupComponent(document, TEMPLATE, SearchBucketController);
+    ctrl = util.setupComponent(document, TEMPLATE, SearchBucketController, {
+      envFlags: new FakeEnvFlags(),
+    });
   });
 
   afterEach(function () {
     ctrl.element.remove();
   });
 
-  it('toggles content expanded state when clicked', function () {
+  it('toggles content hidden state when clicked', function () {
     ctrl.refs.header.dispatchEvent(new Event('click'));
-    assert.isTrue(ctrl.refs.content.classList.contains('is-expanded'));
+    assert.isFalse(ctrl.refs.content.classList.contains('is-hidden'));
   });
 
   it('scrolls element into view when expanded', function () {
     ctrl.scrollTo = sinon.stub();
     ctrl.refs.header.dispatchEvent(new Event('click'));
     assert.calledWith(ctrl.scrollTo, ctrl.element);
+  });
+
+  it('collapses search results on initial load', function () {
+    assert.isFalse(ctrl.state.expanded);
+  });
+
+  context('when initial load times out', function () {
+    var scrollTo;
+
+    beforeEach(function () {
+      scrollTo = sinon.stub();
+      ctrl = util.setupComponent(document, TEMPLATE, SearchBucketController, {
+        scrollTo: scrollTo,
+        envFlags: new FakeEnvFlags(['js-timeout']),
+      });
+    });
+
+    it('does not scroll page on initial load', function () {
+      assert.notCalled(scrollTo);
+    });
+
+    it('expands bucket on initial load', function () {
+      assert.isTrue(ctrl.state.expanded);
+    });
   });
 });

--- a/h/static/scripts/tests/controllers/util.js
+++ b/h/static/scripts/tests/controllers/util.js
@@ -6,15 +6,16 @@
  * @param {Document} document - Document to create component in
  * @param {string} template - HTML markup for the component
  * @param {Controller} controller - The controller class
+ * @param {Object} [options] - Options to pass to the controller constructor
  * @return {Controller} - The controller instance
  */
-function setupComponent(document, template, ControllerClass) {
+function setupComponent(document, template, ControllerClass, options) {
   var container = document.createElement('div');
   container.innerHTML = template;
   var root = container.firstChild;
   document.body.appendChild(root);
   container.remove();
-  return new ControllerClass(root);
+  return new ControllerClass(root, options);
 }
 
 module.exports = {

--- a/h/static/styles/partials-v2/_search.scss
+++ b/h/static/styles/partials-v2/_search.scss
@@ -36,13 +36,10 @@
   border-bottom: 1px solid $grey-3;
 
   .env-js-capable & {
-    background-color: $white;
-  }
-
-  .env-js-capable &:hover,
-  .env-js-capable &.is-expanded,
-  .env-js-timeout & {
-    background-color: $grey-2;
+    background-color: white;
+    &:hover, &.is-expanded {
+      background-color: $grey-2;
+    }
   }
 }
 
@@ -93,11 +90,9 @@
 .search-result-bucket__annotation-cards-container {
   display: flex;
   padding-left: 130px;
-  .env-js-capable & {
+
+  &.is-hidden {
     display: none;
-  }
-  .env-js-capable &.is-expanded, .env-js-timeout & {
-    display: flex;
   }
 }
 


### PR DESCRIPTION
When a search result bucket is upgraded after a JS load timeout, we want
the results to remain initially expanded, but they should still toggle
when clicked. Previously the toggle functionality was broken after an
eventual load.

This commit fixes the problem by removing the static `env-js-timeout` styling
and instead passing the timeout state to the search bucket controller,
which can use it to set the initial expanded state of the results.

 * Fix search bucket toggling failing after JS load timeout

 * Fix search bucket background being white instead of grey when
   expanded if mouse was not hovered over bucket.

   The `is-expanded` state was being set on the wrong element in
   `SearchBucketController#update`
