### PR TITLE
Pin pytest to version 3.0.1

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,9 @@ skip_install =
 deps =
     coverage
     mock
-    pytest
+    # Pin pytest until https://github.com/pytest-dev/pytest/issues/1905 is
+    # resolved
+    pytest==3.0.1
     hypothesis
     h: factory-boy
     h: -rrequirements.txt
@@ -28,7 +30,9 @@ commands =
 [testenv:functional]
 skip_install = true
 deps =
-    pytest
+    # Pin pytest until https://github.com/pytest-dev/pytest/issues/1905 is
+    # resolved
+    pytest==3.0.1
     webtest
     factory-boy
     -rrequirements.txt


### PR DESCRIPTION
Pin pytest version until https://github.com/pytest-dev/pytest/issues/1905 is resolved as it
caused memex tests to fail (eg. https://travis-ci.org/hypothesis/h/jobs/157031235)