### PR TITLE
Put search bucket CSS in markup order

### DIFF
--- a/h/static/styles/partials-v2/_search.scss
+++ b/h/static/styles/partials-v2/_search.scss
@@ -46,21 +46,6 @@
   }
 }
 
-.search-result-bucket__domain {
-  width: 120px;
-  color: $grey-4;
-  margin-right: 10px;
-  word-wrap: break-word;
-}
-
-.search-result-bucket__content {
-  display: flex;
-  flex-direction: column;
-  flex-grow: 1;
-  padding-left: 10px;
-  padding-right: 10px;
-}
-
 .search-result-bucket__header {
   display: flex;
   flex-direction: row;
@@ -70,10 +55,39 @@
   user-select: none;
 }
 
+.search-result-bucket__domain {
+  width: 120px;
+  color: $grey-4;
+  margin-right: 10px;
+  word-wrap: break-word;
+}
+
 .search-result-bucket__title {
   font-weight: bold;
   flex-grow: 1;
   margin-bottom: 10px;
+}
+
+.search-result-bucket__annotations-count {
+  font-weight: bold;
+  width: 75px;
+}
+
+.search-result-bucket__annotations-count-container {
+  width: 30px;
+  padding: 5px 0px;
+  background-color: $grey-2;
+  text-align: center;
+  border-radius: 2px;
+  float: right;
+}
+
+.search-result-bucket__content {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  padding-left: 10px;
+  padding-right: 10px;
 }
 
 .search-result-bucket__annotation-cards-container {
@@ -89,23 +103,6 @@
 
 .search-result-bucket__annotation-cards {
   flex-grow: 1;
-}
-
-.search-result-bucket__annotations-count-container {
-  width: 30px;
-  padding: 5px 0px;
-  background-color: $grey-2;
-  text-align: center;
-  border-radius: 2px;
-  float: right;
-}
-
-.search-result-bucket__annotations-count {
-  font-weight: bold;
-  width: 75px;
-}
-
-.search-result-bucket__annotation-cards {
   max-width: 500px;
   padding-left: 0;
   padding-right: 0;


### PR DESCRIPTION
This commit was extracted from #3790 and makes it easier to edit CSS and markup side-by-side by putting the classes in the order in which they are used.