### PR TITLE
Increase tooltip hover target

### DIFF
--- a/h/static/styles/partials-v2/_form-input.scss
+++ b/h/static/styles/partials-v2/_form-input.scss
@@ -200,12 +200,4 @@
       max-width: unset;
     }
   }
-
-  // Make hit target for field hint icon larger on mobile
-  @include touch-input {
-    .form-input__label > .form-input__hint-icon {
-      min-height: $touch-target-size;
-      min-width: $touch-target-size;
-    }
-  }
 }

--- a/h/static/styles/partials-v2/_tooltip.scss
+++ b/h/static/styles/partials-v2/_tooltip.scss
@@ -35,6 +35,7 @@
   padding-top: 4px;
   padding-bottom: 4px;
   position: absolute;
+  left: calc(100% - 12px);
   width: 220px;
   z-index: $zindex-tooltip;
 

--- a/h/static/styles/partials-v2/_tooltip.scss
+++ b/h/static/styles/partials-v2/_tooltip.scss
@@ -53,7 +53,7 @@
   @include tooltip-arrow(45deg);
   content: "";
   top: calc(100% - 5px);
-  right: calc(100% - 17px);
+  right: calc(100% - 16.5px);
 }
 
 .tooltip-label {

--- a/h/templates/deform/mapping_item.jinja2
+++ b/h/templates/deform/mapping_item.jinja2
@@ -26,15 +26,16 @@
 {% endif -%}
 
 {%- if not (field.widget.hidden or field.widget.omit_label or field.widget.category == 'structural') -%}
-  <label class="{{ field_label_class }} {% if field.widget.label_css_class %} {{ field.widget.label_css_class }}{% endif %}"
+  <label class="{{ field_label_class }} {% if field.widget.label_css_class %} {{ field.widget.label_css_class }}{% endif %}
+                {%- if field.schema.hint and feature('activity_pages') -%}js-tooltip{% endif %}"
+         {%- if field.schema.hint %}aria-label="{{ field.schema.hint }}"{% endif %}
          {%- if field.description -%}
          title="{{ _(field.description) }}"
          {% endif %}
          for="{{ field.oid }}">
            {{ _(field.title) }}
            {%- if field.schema.hint and feature('activity_pages') -%}
-             <i class="form-input__hint-icon js-tooltip"
-               aria-label="{{ field.schema.hint }}">
+             <i class="form-input__hint-icon">
                {{ svg_icon('info_icon') }}
              </i>
            {% endif %}


### PR DESCRIPTION
Enable hovering anywhere over the entire "ORCID (i)" label (for example) rather than having to hover over the (i) icon itself, which is a very small hover target:

![peek 2016-09-02 11-36](https://cloud.githubusercontent.com/assets/22498/18201463/4751eb52-7102-11e6-8b6e-d35f99e64a7c.gif)

This is more accessible (larger hover target is easier to hit) and also
more consistent with normal HTML title-attribute tooltips which are
usually attached to words such as <label> or <a> elements and not (just)
to icons.

You no longer need to hover over the (i) icon to reveal the tooltip, but
the icon still serves the purpose of giving the user a hint that there
is a tooltip here.

I also tweaked the positioning of the tooltip's arrow to make it closer (to my eye) to the center of the "i", although I still don't think it's exactly right.

Screenshots of all three tooltips now:

![screenshot from 2016-09-02 11-35-41](https://cloud.githubusercontent.com/assets/22498/18201561/c8e41ba4-7102-11e6-9ee5-977b72d0ccee.png)
![screenshot from 2016-09-02 11-34-58](https://cloud.githubusercontent.com/assets/22498/18201563/c8e862d6-7102-11e6-9078-2fca6e5524f9.png)
![screenshot from 2016-09-02 11-34-31](https://cloud.githubusercontent.com/assets/22498/18201562/c8e6e5e6-7102-11e6-9ec4-33c60a26ee98.png)

(The "This will be emailed to you" tooltip still has a whitespace bug but that's a [separate issue](https://github.com/hypothesis/h/issues/3813))