### PR TITLE
Retry mailer tasks on SMTP failure

### DIFF
--- a/tests/h/mailer_test.py
+++ b/tests/h/mailer_test.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+from smtplib import SMTPServerDisconnected
+
 import mock
 
 from h import mailer
@@ -51,3 +53,18 @@ def test_send_dispatches_email_using_request_mailer(pyramid_mailer, celery):
 
     pyramid_mailer.get_mailer.assert_called_once_with(mock.sentinel.request)
     request_mailer.send_immediately.assert_called_once_with(message)
+
+
+@mock.patch('h.mailer.celery', autospec=True)
+@mock.patch('h.mailer.pyramid_mailer', autospec=True)
+def test_send_retries_if_mailing_fails(pyramid_mailer, celery):
+    celery.request = mock.sentinel.request
+    request_mailer = pyramid_mailer.get_mailer.return_value
+    request_mailer.send_immediately.side_effect = SMTPServerDisconnected()
+
+    mailer.send.retry = mock.Mock(spec_set=[])
+    mailer.send(recipients=['foo@example.com'],
+                subject='My email subject',
+                body='Some text body')
+
+    assert mailer.send.retry.called


### PR DESCRIPTION
We are seeing evidence that occasionally the Mandrill SMTP server disconnects our mailer, or perhaps that the network between our application and Mandrill occasionally drops:

  https://sentry.io/hypothesis/prod/issues/152186124/

This commit adds retry logic to the mailer task to ensure that in the event of any kind of network or SMTP error, the task is requeued for another delivery attempt later.

With the current configuration we will attempt to deliver mail four times (i.e. 3 retries) over a period of approximately 20 minutes, using an exponential backoff.