### PR TITLE
Convert remaining controllers to ES2015 classes

### DIFF
--- a/h/static/scripts/base/controller.js
+++ b/h/static/scripts/base/controller.js
@@ -38,41 +38,46 @@ function findRefs(el) {
  * updated by calling (`this.setState(changes)`). Whenever the internal state of
  * the controller changes, `this.update()` is called to sync the DOM with this
  * state.
- *
- * @param {Element} element - The DOM Element to upgrade
  */
-function Controller(element) {
-  if (!element.controllers) {
-    element.controllers = [this];
-  } else {
-    element.controllers.push(this);
+class Controller {
+  /**
+   * Initialize the controller.
+   *
+   * @param {Element} element - The DOM Element to upgrade
+   */
+  constructor(element) {
+    if (!element.controllers) {
+      element.controllers = [this];
+    } else {
+      element.controllers.push(this);
+    }
+
+    this.state = {};
+    this.element = element;
+    this.refs = findRefs(element);
   }
 
-  this.state = {};
-  this.element = element;
-  this.refs = findRefs(element);
+  /**
+   * Set the state of the controller.
+   *
+   * This will merge `changes` into the current state and call the `update()`
+   * method provided by the subclass to update the DOM to match the current state.
+   */
+  setState(changes) {
+    var prevState = this.state;
+    this.state = Object.freeze(Object.assign({}, this.state, changes));
+    this.update(this.state, prevState);
+  }
+
+  /**
+   * Calls update() with the current state.
+   *
+   * This is useful for controllers where the state is available in the DOM
+   * itself, so doesn't need to be maintained internally.
+   */
+  forceUpdate() {
+    this.update(this.state, this.state);
+  }
 }
-
-/**
- * Set the state of the controller.
- *
- * This will merge `changes` into the current state and call the `update()`
- * method provided by the subclass to update the DOM to match the current state.
- */
-Controller.prototype.setState = function (changes) {
-  var prevState = this.state;
-  this.state = Object.freeze(Object.assign({}, this.state, changes));
-  this.update(this.state, prevState);
-};
-
-/**
- * Calls update() with the current state.
- *
- * This is useful for controllers where the state is available in the DOM
- * itself, so doesn't need to be maintained internally.
- */
-Controller.prototype.forceUpdate = function () {
-  this.update(this.state, this.state);
-};
 
 module.exports = Controller;

--- a/h/static/scripts/controllers/admin-users-controller.js
+++ b/h/static/scripts/controllers/admin-users-controller.js
@@ -1,19 +1,21 @@
 'use strict';
 
-function AdminUsersController(element, window_) {
-  window_ = window_ || window;
+var Controller = require('../base/controller');
 
-  this._form = element;
+class AdminUsersController extends Controller {
+  constructor(element, window_ = window) {
+    super(element);
 
-  function confirmFormSubmit() {
-    return window_.confirm('This will permanently delete all the user\'s data. Are you sure?');
-  }
-
-  this._form.addEventListener('submit', function (event) {
-    if (!confirmFormSubmit()) {
-      event.preventDefault();
+    function confirmFormSubmit() {
+      return window_.confirm('This will permanently delete all the user\'s data. Are you sure?');
     }
-  });
+
+    this.element.addEventListener('submit', event => {
+      if (!confirmFormSubmit()) {
+        event.preventDefault();
+      }
+    });
+  }
 }
 
 module.exports = AdminUsersController;

--- a/h/static/scripts/controllers/character-limit-controller.js
+++ b/h/static/scripts/controllers/character-limit-controller.js
@@ -1,28 +1,26 @@
 'use strict';
 
-var inherits = require('inherits');
-
 var Controller = require('../base/controller');
-var setElementState = require('../util/dom').setElementState;
+var { setElementState } = require('../util/dom');
 
-function CharacterLimitController(element) {
-  Controller.call(this, element);
+class CharacterLimitController extends Controller {
+  constructor(element) {
+    super(element);
 
-  var self = this;
-  this.refs.characterLimitInput.addEventListener('input', function () {
-    self.forceUpdate();
-  });
-  this.forceUpdate();
+    this.refs.characterLimitInput.addEventListener('input', () => {
+      this.forceUpdate();
+    });
+    this.forceUpdate();
+  }
+
+  update() {
+    var input = this.refs.characterLimitInput;
+    var maxlength = parseInt(input.dataset.maxlength);
+    var counter = this.refs.characterLimitCounter;
+    counter.textContent = input.value.length + '/' + maxlength;
+    setElementState(counter, {tooLong: input.value.length > maxlength});
+    setElementState(this.refs.characterLimitCounter, {ready: true});
+  }
 }
-inherits(CharacterLimitController, Controller);
-
-CharacterLimitController.prototype.update = function () {
-  var input = this.refs.characterLimitInput;
-  var maxlength = parseInt(input.dataset.maxlength);
-  var counter = this.refs.characterLimitCounter;
-  counter.textContent = input.value.length + '/' + maxlength;
-  setElementState(counter, {tooLong: input.value.length > maxlength});
-  setElementState(this.refs.characterLimitCounter, {ready: true});
-};
 
 module.exports = CharacterLimitController;

--- a/h/static/scripts/controllers/form-select-onfocus-controller.js
+++ b/h/static/scripts/controllers/form-select-onfocus-controller.js
@@ -1,14 +1,20 @@
 'use strict';
 
-function FormSelectOnFocusController(element) {
-  // In case the `focus` event has already been fired, select the element
-  if (element === document.activeElement) {
-    element.select();
-  }
+var Controller = require('../base/controller');
 
-  element.addEventListener('focus', function(event) {
-    event.target.select();
-  });
+class FormSelectOnFocusController extends Controller {
+  constructor(element) {
+    super(element);
+
+    // In case the `focus` event has already been fired, select the element
+    if (element === document.activeElement) {
+      element.select();
+    }
+
+    element.addEventListener('focus', event => {
+      event.target.select();
+    });
+  }
 }
 
 module.exports = FormSelectOnFocusController;

--- a/h/static/scripts/controllers/tooltip-controller.js
+++ b/h/static/scripts/controllers/tooltip-controller.js
@@ -1,7 +1,5 @@
 'use strict';
 
-var inherits = require('inherits');
-
 var Controller = require('../base/controller');
 
 /**
@@ -16,51 +14,48 @@ var Controller = require('../base/controller');
  *
  * The tooltip's label is derived from the target element's 'aria-label'
  * attribute.
- *
- * @param {Element} el - The container for the tooltip.
  */
-function TooltipController(el) {
-  Controller.call(this, el);
+class TooltipController extends Controller {
+  constructor(el) {
+    super(el);
 
-  var self = this;
+    // With mouse input, show the tooltip on hover. On touch devices we rely on
+    // the browser to synthesize 'mouseover' events to make the tooltip appear
+    // when the host element is tapped and disappear when the host element loses
+    // focus.
+    // See http://www.codediesel.com/javascript/making-mouseover-event-work-on-an-ipad/
+    el.addEventListener('mouseover', () => {
+      this.setState({target: el});
+    });
 
-  // With mouse input, show the tooltip on hover. On touch devices we rely on
-  // the browser to synthesize 'mouseover' events to make the tooltip appear
-  // when the host element is tapped and disappear when the host element loses
-  // focus.
-  // See http://www.codediesel.com/javascript/making-mouseover-event-work-on-an-ipad/
-  el.addEventListener('mouseover', function () {
-    self.setState({target: el});
-  });
+    el.addEventListener('mouseout', () => {
+      this.setState({target: null});
+    });
 
-  el.addEventListener('mouseout', function () {
-    self.setState({target: null});
-  });
+    this._tooltipEl = el.ownerDocument.createElement('div');
+    this._tooltipEl.innerHTML = '<span class="tooltip-label js-tooltip-label"></span>';
+    this._tooltipEl.className = 'tooltip';
+    el.appendChild(this._tooltipEl);
+    this._labelEl = this._tooltipEl.querySelector('.js-tooltip-label');
 
-  this._el = el.ownerDocument.createElement('div');
-  this._el.innerHTML = '<span class="tooltip-label js-tooltip-label"></span>';
-  this._el.className = 'tooltip';
-  el.appendChild(this._el);
-  this._labelEl = this._el.querySelector('.js-tooltip-label');
-
-  this.setState({target: null});
-}
-inherits(TooltipController, Controller);
-
-TooltipController.prototype.update = function (state) {
-  if (!state.target) {
-    this._el.style.visibility = 'hidden';
-    return;
+    this.setState({target: null});
   }
 
-  var target = state.target;
-  var label = target.getAttribute('aria-label');
-  this._labelEl.textContent = label;
+  update(state) {
+    if (!state.target) {
+      this._tooltipEl.style.visibility = 'hidden';
+      return;
+    }
 
-  Object.assign(this._el.style, {
-    visibility: '',
-    bottom: 'calc(100% + 5px)',
-  });
-};
+    var target = state.target;
+    var label = target.getAttribute('aria-label');
+    this._labelEl.textContent = label;
+
+    Object.assign(this._tooltipEl.style, {
+      visibility: '',
+      bottom: 'calc(100% + 5px)',
+    });
+  }
+}
 
 module.exports = TooltipController;

--- a/h/static/scripts/tests/base/controller-test.js
+++ b/h/static/scripts/tests/base/controller-test.js
@@ -1,15 +1,13 @@
 'use strict';
 
-var inherits = require('inherits');
-
 var Controller = require('../../base/controller');
 
-function TestController(element) {
-  Controller.call(this, element);
-
-  this.update = sinon.stub();
+class TestController extends Controller {
+  constructor(element) {
+    super(element);
+    this.update = sinon.stub();
+  }
 }
-inherits(TestController, Controller);
 
 describe('Controller', function () {
   var ctrl;

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "gulp-svgmin": "^1.2.2",
     "gulp-util": "^3.0.7",
     "hypothesis": "^0.38.1",
-    "inherits": "^2.0.1",
     "is-equal-shallow": "^0.1.3",
     "jquery": "1.11.1",
     "js-polyfills": "^0.1.16",


### PR DESCRIPTION
Convert remaining controllers to ES2015 classes that extend Controller,
except for `CreateGroupFormController`, since the whole group creation
form is going to be replaced shortly by a new version which uses the
standard form layout and behavior.

 * Convert ES3/5-style classes to ES2015 syntax

 * Convert event listener callbacks to use arrow functions,
   removing the need to alias `this` to `self`

 * Remove 'inherits' dependency, since all classes that have a base
   class have now been converted to ES2015 `class X extends Y` syntax

Module imports and var declarations are still using ES5 + CommonJS
syntax, for consistency with the other controller classes. These can be
converted using an automated tool later.