### PR TITLE
Remove jQuery bundle from site JS pages

### DIFF
--- a/h/assets.ini
+++ b/h/assets.ini
@@ -16,7 +16,6 @@ admin_js =
 
 # The H website
 site_js =
-  scripts/jquery.bundle.js
   scripts/raven.bundle.js
   scripts/site.bundle.js
 


### PR DESCRIPTION
The new site JS does not use jQuery. Checked by searching for uses of `jQuery` and `$` in `h/static/scripts`

Saves ~40KB min+gzip.