### PR TITLE
Fix behavior of legacy 'Create Group' form

### DIFF
--- a/h/static/scripts/controllers/create-group-form-controller.js
+++ b/h/static/scripts/controllers/create-group-form-controller.js
@@ -15,7 +15,7 @@ function CreateGroupFormController(element) {
   self._groupNameInput.addEventListener('input', groupNameChanged);
   groupNameChanged();
 
-  this._infoLink.addEventListener('click', function () {
+  this._infoLink.addEventListener('click', function (event) {
     event.preventDefault();
     self._infoLink.classList.add('is-hidden');
     self._infoText.classList.remove('is-hidden');

--- a/h/templates/deform/mapping_item.jinja2
+++ b/h/templates/deform/mapping_item.jinja2
@@ -4,18 +4,21 @@
 {% set field_label_class = 'form-input__label' %}
 {% set field_error_list_class = '' %}
 {% set field_error_item_class = 'form-input__error-item' %}
+{% set show_char_counter = field.widget.template in ('textinput', 'textarea') and
+                           field.widget.max_length %}
 {% else %}
 {% set field_class = 'form-group form-field' %}
 {% set field_error_state_class = 'form-field-error' %}
 {% set field_label_class = 'form-label' %}
 {% set field_error_list_class = 'form-error-list' %}
 {% set field_error_item_class = 'form-error' %}
+{% set show_char_counter = False %}
 {% endif %}
 
 {%- if not field.widget.hidden -%}
 <div class="{{ field_class }}
             {% if field.error %}{{ field_error_state_class }}{% endif %}
-            {% if field.widget.template in ('textinput', 'textarea') and field.widget.max_length -%}js-character-limit{% endif %}"
+            {% if show_char_counter %} js-character-limit {%- endif %}"
      {%- if field.description -%}
      title="{{ _(field.description) }}"
      {% endif %}

--- a/h/templates/deform/textinput.jinja2
+++ b/h/templates/deform/textinput.jinja2
@@ -1,3 +1,7 @@
 <input type="text"
 {% include "includes/common_attrs.jinja2" %}>
-{%- if field.widget.max_length -%}<span class="form-input__character-counter" data-ref="characterLimitCounter">Up to {{ field.widget.max_length }} characters</span>{% endif %}
+{%- if field.widget.max_length and feature('activity_pages') -%}
+<span class="form-input__character-counter" data-ref="characterLimitCounter">
+  Up to {{ field.widget.max_length }} characters
+</span>
+{% endif %}


### PR DESCRIPTION
 - Add missing function parameter to the event listener for the
   'Tell me more about groups' link

 - Do not show the character counter on text input fields unless
   activity_pages feature flag is enabled