### PR TITLE
Use a single global Sentry client

### DIFF
--- a/h/sentry.py
+++ b/h/sentry.py
@@ -54,11 +54,16 @@ def get_client(settings):
 
 
 def _get_request_client(request):
-    client = get_client(request.registry.settings)
+    client = request.registry['sentry.client']
     client.http_context(http_context_data(request))
     client.user_context(user_context_data(request))
+    request.add_finished_callback(lambda _: client.context.clear())
     return client
 
 
 def includeme(config):
+    # Create a sentry client and store it in the registry
+    config.registry['sentry.client'] = get_client(config.registry.settings)
+
+    # Allow retrieval of the client within a request as `request.sentry`
     config.add_request_method(_get_request_client, 'sentry', reify=True)


### PR DESCRIPTION
Unfortunately, we appear to be leaking references to Sentry clients in production, which is having a noticeable performance impact on requests to the web application.

I've yet to track down why these old Sentry client instances (generated per-request) aren't being correctly cleaned up, but we can fix the memory leak by not creating them in the first place.

This commit changes the application's integration with raven so that rather than creating a brand new raven.Client for each request, we create one on boot, and store it in the application registry. Matt Robenolt, one of the Sentry developers, says[1]:

> Don't make a new Client instance on every request. That would definitely cause problems.

[1]: https://botbot.me/freenode/sentry/2016-09-05/?msg=72514569&page=1

In particular, each Sentry client spins up a thread for reporting errors when it handles its first exception. This thread is never joined to the main thread, so we're definitely leaking threads already.

---

Before this change, the reported memory usage of a single worker receiving 5 minutes of simulated production traffic grows as follows:

    app boot           71,088 KB
    after 5m traffic   86,304 KB
    ----------------------------
    change             15,216 KB (+20%)

After this change:

    app boot           71,008 KB
    after 5m traffic   79,808 KB
    ----------------------------
    change              8,788 KB (+12%)

Of course, this is far from conclusive, but experimentation shows that of this residual 12% growth, about 10% is associated with data that the application needs to load once at startup.