### PR TITLE
Upgrade to Pyramid 1.7

### DIFF
--- a/h/views/client.py
+++ b/h/views/client.py
@@ -51,7 +51,9 @@ def annotator_token(request):
     request.authenticated_userid of the _current_ request.
     """
     try:
-        session.check_csrf_token(request, token='assertion')
+        # The client must supply the CSRF token in the X-CSRF-Token request
+        # header.
+        session.check_csrf_token(request)
     except exceptions.BadCSRFToken:
         raise httpexceptions.HTTPUnauthorized()
 

--- a/requirements.in
+++ b/requirements.in
@@ -20,7 +20,7 @@ newrelic
 passlib
 psycogreen
 psycopg2
-pyramid < 1.7
+pyramid
 pyramid_layout
 pyramid-jinja2
 pyramid-multiauth

--- a/requirements.txt
+++ b/requirements.txt
@@ -57,7 +57,7 @@ pyramid-multiauth==0.8.0
 pyramid-redis-sessions==1.0.1
 pyramid-services==0.4
 pyramid-tm==0.12.1
-pyramid==1.6.1
+pyramid==1.7.3
 python-dateutil==2.5.3
 python-editor==1.0.1      # via alembic
 python-slugify==1.1.4

--- a/tests/h/views/client_test.py
+++ b/tests/h/views/client_test.py
@@ -15,8 +15,7 @@ annotator_token_fixtures = pytest.mark.usefixtures('generate_jwt', 'session')
 def test_annotator_token_calls_check_csrf_token(pyramid_request, session):
     client.annotator_token(pyramid_request)
 
-    session.check_csrf_token.assert_called_once_with(pyramid_request,
-                                                     token='assertion')
+    session.check_csrf_token.assert_called_once_with(pyramid_request)
 
 
 @annotator_token_fixtures


### PR DESCRIPTION
This PR upgrades us to the latest version of Pyramid.

As of Pyramid 1.7, checking a CSRF token supplied in a GET parameter is not supported[1]. This is fine, as the client already supplies the CSRF token in the X-CSRF-Token request header anyway.

See also: https://github.com/hypothesis/client/pull/89

[1]: http://docs.pylonsproject.org/projects/pyramid/en/latest/whatsnew-1.7.html#backwards-incompatibilities