### PR TITLE
Fix losing group / user filter when searching

### DIFF
--- a/h/templates/panels/navbar.html.jinja2
+++ b/h/templates/panels/navbar.html.jinja2
@@ -8,7 +8,7 @@
       !--><img alt="Hypothesis logo" class="nav-bar__logo" src="/assets/images/logo.svg"></a>
 
     <div class="nav-bar__search">
-      <form class="search-bar" action="{{ request.route_url("activity.search") }}">
+      <form class="search-bar" action="{{ search_url }}">
         <input class="search-bar__input" name="q" value="{{ q }}" placeholder="Search…">
         {{ svg_icon('search', 'search-bar__icon') }}
       </form>

--- a/h/views/panels.py
+++ b/h/views/panels.py
@@ -31,6 +31,11 @@ def navbar(context, request):
             "?q=user:{}".format(request.authenticated_user.username))
         username = request.authenticated_user.username
 
+    if request.matched_route.name in ['activity.group_search', 'activity.user_search']:
+        search_url = request.current_route_url()
+    else:
+        search_url = request.route_url('activity.search')
+
     return {
         'settings_menu_items': [
             {'title': _('Account details'), 'link': request.route_url('account')},
@@ -44,6 +49,7 @@ def navbar(context, request):
             {'title': _('Create new group'), 'link': request.route_url('group_create')},
         'username': username,
         'username_link': stream_url,
+        'search_link': search_url,
         'q': request.params.get('q', ''),
     }
 

--- a/tests/h/conftest.py
+++ b/tests/h/conftest.py
@@ -222,6 +222,7 @@ def pyramid_request(db_session, fake_feature, pyramid_settings):
     request = testing.DummyRequest(db=db_session, feature=fake_feature)
     request.auth_domain = request.domain
     request.create_form = mock.Mock()
+    request.matched_route = mock.Mock()
     request.registry.settings = pyramid_settings
     request.is_xhr = False
     return request


### PR DESCRIPTION
When using the search form on the group / user search page we POSTed the
form to `/search` which lost the filter on the group / user. This now
checks on which page the user is and then uses that as the form action,
defaulting to `/search`.