### PR TITLE
Refactor navbar tests

### DIFF
--- a/tests/h/views/panels_test.py
+++ b/tests/h/views/panels_test.py
@@ -8,98 +8,83 @@ import pytest
 
 from h.views import panels
 
-@pytest.mark.usefixtures('routes')
-def test_navbar_sets_null_username_when_logged_out(req):
-    result = panels.navbar({}, req)
-    assert result['username'] == None
-
 
 @pytest.mark.usefixtures('routes')
-def test_navbar_sets_username_when_logged_in(req, authenticated_user):
-    req.authenticated_user = authenticated_user
-    result = panels.navbar({}, req)
+class TestNavbar(object):
+    def test_it_sets_null_username_when_logged_out(self, req):
+        result = panels.navbar({}, req)
+        assert result['username'] == None
 
-    assert result['username'] == 'vannevar'
+    def test_it_sets_username_when_logged_in(self, req, authenticated_user):
+        req.authenticated_user = authenticated_user
+        result = panels.navbar({}, req)
 
+        assert result['username'] == 'vannevar'
 
-@pytest.mark.usefixtures('routes')
-def test_navbar_lists_groups_when_logged_in(req, authenticated_user):
-    req.authenticated_user = authenticated_user
-    result = panels.navbar({}, req)
+    def test_it_lists_groups_when_logged_in(self, req, authenticated_user):
+        req.authenticated_user = authenticated_user
+        result = panels.navbar({}, req)
 
-    titles = [group.name for group in authenticated_user.groups]
+        titles = [group.name for group in authenticated_user.groups]
 
-    assert result['groups_menu_items'] == [
-        {'title': titles[0], 'link': 'http://example.com/groups/id1/first'},
-        {'title': titles[1], 'link': 'http://example.com/groups/id2/second'},
-    ]
+        assert result['groups_menu_items'] == [
+            {'title': titles[0], 'link': 'http://example.com/groups/id1/first'},
+            {'title': titles[1], 'link': 'http://example.com/groups/id2/second'},
+        ]
 
+    def test_username_link_when_logged_in(self, req, authenticated_user):
+        req.authenticated_user = authenticated_user
+        result = panels.navbar({}, req)
 
-@pytest.mark.usefixtures('routes')
-def test_navbar_username_link_when_logged_in(req, authenticated_user):
-    req.authenticated_user = authenticated_user
-    result = panels.navbar({}, req)
+        assert result['username_link'] == 'http://example.com/search?q=user:vannevar'
 
-    assert result['username_link'] == 'http://example.com/search?q=user:vannevar'
+    def test_it_includes_search_query(self, req):
+        req.params['q'] = 'tag:question'
+        result = panels.navbar({}, req)
 
+        assert result['q'] == 'tag:question'
 
-@pytest.mark.usefixtures('routes')
-def test_navbar_includes_search_query(req):
-    req.params['q'] = 'tag:question'
-    result = panels.navbar({}, req)
+    def test_it_includes_search_url_when_on_user_search(self, req):
+        type(req.matched_route).name = PropertyMock(return_value='activity.user_search')
+        req.matchdict = {'username': 'luke'}
 
-    assert result['q'] == 'tag:question'
+        result = panels.navbar({}, req)
+        assert result['search_link'] == 'http://example.com/users/luke/search'
 
+    def test_it_includes_search_url_when_on_group_search(self, req):
+        type(req.matched_route).name = PropertyMock(return_value='activity.group_search')
+        req.matchdict = {'pubid': 'foobar'}
 
-@pytest.mark.usefixtures('routes')
-def test_navbar_includes_search_url_when_on_user_search(req):
-    type(req.matched_route).name = PropertyMock(return_value='activity.user_search')
-    req.matchdict = {'username': 'luke'}
+        result = panels.navbar({}, req)
+        assert result['search_link'] == 'http://example.com/groups/foobar/search'
 
-    result = panels.navbar({}, req)
-    assert result['search_link'] == 'http://example.com/users/luke/search'
+    def test_it_includes_default_search_url(self, req):
+        result = panels.navbar({}, req)
+        assert result['search_link'] == 'http://example.com/search'
 
+    @pytest.fixture
+    def routes(self, pyramid_config):
+        pyramid_config.add_route('account', '/account')
+        pyramid_config.add_route('account_profile', '/account/profile')
+        pyramid_config.add_route('account_notifications', '/account/notifications')
+        pyramid_config.add_route('account_developer', '/account/developer')
+        pyramid_config.add_route('activity.search', '/search')
+        pyramid_config.add_route('activity.user_search', '/users/{username}/search')
+        pyramid_config.add_route('activity.group_search', '/groups/{pubid}/search')
+        pyramid_config.add_route('group_create', '/groups/new')
+        pyramid_config.add_route('group_read', '/groups/:pubid/:slug')
+        pyramid_config.add_route('logout', '/logout')
 
-@pytest.mark.usefixtures('routes')
-def test_navbar_includes_search_url_when_on_group_search(req):
-    type(req.matched_route).name = PropertyMock(return_value='activity.group_search')
-    req.matchdict = {'pubid': 'foobar'}
+    @pytest.fixture
+    def authenticated_user(self):
+        groups = [
+            Mock(pubid='id1', slug='first'),
+            Mock(pubid='id2', slug='second'),
+        ]
+        authenticated_user = Mock(username='vannevar', groups=groups)
+        return authenticated_user
 
-    result = panels.navbar({}, req)
-    assert result['search_link'] == 'http://example.com/groups/foobar/search'
-
-
-@pytest.mark.usefixtures('routes')
-def test_navbar_includes_default_search_url(req):
-    result = panels.navbar({}, req)
-    assert result['search_link'] == 'http://example.com/search'
-
-
-@pytest.fixture
-def routes(pyramid_config):
-    pyramid_config.add_route('account', '/account')
-    pyramid_config.add_route('account_profile', '/account/profile')
-    pyramid_config.add_route('account_notifications', '/account/notifications')
-    pyramid_config.add_route('account_developer', '/account/developer')
-    pyramid_config.add_route('activity.search', '/search')
-    pyramid_config.add_route('activity.user_search', '/users/{username}/search')
-    pyramid_config.add_route('activity.group_search', '/groups/{pubid}/search')
-    pyramid_config.add_route('group_create', '/groups/new')
-    pyramid_config.add_route('group_read', '/groups/:pubid/:slug')
-    pyramid_config.add_route('logout', '/logout')
-
-
-@pytest.fixture
-def authenticated_user():
-    groups = [
-        Mock(pubid='id1', slug='first'),
-        Mock(pubid='id2', slug='second'),
-    ]
-    authenticated_user = Mock(username='vannevar', groups=groups)
-    return authenticated_user
-
-
-@pytest.fixture
-def req(pyramid_request):
-    pyramid_request.authenticated_user = None
-    return pyramid_request
+    @pytest.fixture
+    def req(self, pyramid_request):
+        pyramid_request.authenticated_user = None
+        return pyramid_request

--- a/tests/h/views/panels_test.py
+++ b/tests/h/views/panels_test.py
@@ -9,24 +9,23 @@ import pytest
 from h.views import panels
 
 @pytest.mark.usefixtures('routes')
-def test_navbar_sets_null_username_when_logged_out(pyramid_request):
-    pyramid_request.authenticated_user = None
-    result = panels.navbar({}, pyramid_request)
+def test_navbar_sets_null_username_when_logged_out(req):
+    result = panels.navbar({}, req)
     assert result['username'] == None
 
 
 @pytest.mark.usefixtures('routes')
-def test_navbar_sets_username_when_logged_in(pyramid_request, authenticated_user):
-    pyramid_request.authenticated_user = authenticated_user
-    result = panels.navbar({}, pyramid_request)
+def test_navbar_sets_username_when_logged_in(req, authenticated_user):
+    req.authenticated_user = authenticated_user
+    result = panels.navbar({}, req)
 
     assert result['username'] == 'vannevar'
 
 
 @pytest.mark.usefixtures('routes')
-def test_navbar_lists_groups_when_logged_in(pyramid_request, authenticated_user):
-    pyramid_request.authenticated_user = authenticated_user
-    result = panels.navbar({}, pyramid_request)
+def test_navbar_lists_groups_when_logged_in(req, authenticated_user):
+    req.authenticated_user = authenticated_user
+    result = panels.navbar({}, req)
 
     titles = [group.name for group in authenticated_user.groups]
 
@@ -37,49 +36,42 @@ def test_navbar_lists_groups_when_logged_in(pyramid_request, authenticated_user)
 
 
 @pytest.mark.usefixtures('routes')
-def test_navbar_username_link_when_logged_in(pyramid_request, authenticated_user):
-    pyramid_request.authenticated_user = authenticated_user
-    result = panels.navbar({}, pyramid_request)
+def test_navbar_username_link_when_logged_in(req, authenticated_user):
+    req.authenticated_user = authenticated_user
+    result = panels.navbar({}, req)
 
     assert result['username_link'] == 'http://example.com/search?q=user:vannevar'
 
 
 @pytest.mark.usefixtures('routes')
-def test_navbar_includes_search_query(pyramid_request):
-    pyramid_request.authenticated_user = None
-    pyramid_request.params['q'] = 'tag:question'
-    result = panels.navbar({}, pyramid_request)
+def test_navbar_includes_search_query(req):
+    req.params['q'] = 'tag:question'
+    result = panels.navbar({}, req)
 
     assert result['q'] == 'tag:question'
 
 
 @pytest.mark.usefixtures('routes')
-def test_navbar_includes_search_url_when_on_user_search(pyramid_request):
-    pyramid_request.authenticated_user = None
+def test_navbar_includes_search_url_when_on_user_search(req):
+    type(req.matched_route).name = PropertyMock(return_value='activity.user_search')
+    req.matchdict = {'username': 'luke'}
 
-    type(pyramid_request.matched_route).name = PropertyMock(return_value='activity.user_search')
-    pyramid_request.matchdict = {'username': 'luke'}
-
-    result = panels.navbar({}, pyramid_request)
+    result = panels.navbar({}, req)
     assert result['search_link'] == 'http://example.com/users/luke/search'
 
 
 @pytest.mark.usefixtures('routes')
-def test_navbar_includes_search_url_when_on_group_search(pyramid_request):
-    pyramid_request.authenticated_user = None
+def test_navbar_includes_search_url_when_on_group_search(req):
+    type(req.matched_route).name = PropertyMock(return_value='activity.group_search')
+    req.matchdict = {'pubid': 'foobar'}
 
-    type(pyramid_request.matched_route).name = PropertyMock(return_value='activity.group_search')
-    pyramid_request.matchdict = {'pubid': 'foobar'}
-
-    result = panels.navbar({}, pyramid_request)
+    result = panels.navbar({}, req)
     assert result['search_link'] == 'http://example.com/groups/foobar/search'
 
 
 @pytest.mark.usefixtures('routes')
-def test_navbar_includes_default_search_url(pyramid_request):
-    pyramid_request.authenticated_user = None
-
-    result = panels.navbar({}, pyramid_request)
+def test_navbar_includes_default_search_url(req):
+    result = panels.navbar({}, req)
     assert result['search_link'] == 'http://example.com/search'
 
 
@@ -105,3 +97,9 @@ def authenticated_user():
     ]
     authenticated_user = Mock(username='vannevar', groups=groups)
     return authenticated_user
+
+
+@pytest.fixture
+def req(pyramid_request):
+    pyramid_request.authenticated_user = None
+    return pyramid_request

--- a/tests/h/views/panels_test.py
+++ b/tests/h/views/panels_test.py
@@ -13,7 +13,7 @@ from h.views import panels
 class TestNavbar(object):
     def test_it_sets_null_username_when_logged_out(self, req):
         result = panels.navbar({}, req)
-        assert result['username'] == None
+        assert result['username'] is None
 
     def test_it_sets_username_when_logged_in(self, req, authenticated_user):
         req.authenticated_user = authenticated_user


### PR DESCRIPTION
**Depends on #3833**

Refactoring the tests to use a test class, a special request fixture with the `authenticated_user` property, and fixing a PEP warning about asserting `None`.