### PR TITLE
Use specified page size for pagination as well

### DIFF
--- a/h/activity/views.py
+++ b/h/activity/views.py
@@ -46,7 +46,7 @@ def search(request):
         'total': result.total,
         'aggregations': result.aggregations,
         'timeframes': result.timeframes,
-        'page': paginate(request, result.total, page_size=PAGE_SIZE),
+        'page': paginate(request, result.total, page_size=page_size),
     }
 
 

--- a/tests/h/activity/views_test.py
+++ b/tests/h/activity/views_test.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+import mock
 from pyramid import httpexceptions
 
 from h.activity import views
@@ -54,6 +55,21 @@ class TestSearch(object):
                                               query.extract.return_value,
                                               page_size=views.PAGE_SIZE)
 
+    @pytest.mark.usefixtures('query')
+    def test_is_uses_passed_in_page_size_for_pagination(self, pyramid_request, paginate):
+        pyramid_request.feature.flags['search_page'] = True
+
+        pyramid_request.params['page_size'] = 100
+        views.search(pyramid_request)
+
+        paginate.assert_called_once_with(pyramid_request,
+                                         mock.ANY,
+                                         page_size=100)
+
     @pytest.fixture
     def query(self, patch):
         return patch('h.activity.views.query')
+
+    @pytest.fixture
+    def paginate(self, patch):
+        return patch('h.activity.views.paginate')


### PR DESCRIPTION
It used to still use the default page size (20) to calculate the
pagination, which resulted in index out of bounds errors.