### PR TITLE
Don't crash when there are no matching annotations

### DIFF
--- a/h/activity/query.py
+++ b/h/activity/query.py
@@ -108,7 +108,7 @@ def execute(request, query, page_size):
     # Load all referenced annotations from the database, bucket them, and add
     # the buckets to result.timeframes.
     anns = _fetch_annotations(request.db, search_result.annotation_ids)
-    result.timeframes.extend(bucketing.bucket(anns))
+    result.timeframes.extend(bucketing.bucket(anns.all()))
 
     # Fetch all groups
     group_pubids = set([a.groupid

--- a/tests/h/activity/query_test.py
+++ b/tests/h/activity/query_test.py
@@ -310,8 +310,9 @@ class TestExecute(object):
                                         search):
         result = execute(pyramid_request, MultiDict(), self.PAGE_SIZE)
 
+        _fetch_annotations.return_value.all.assert_called_once_with()
         bucketing.bucket.assert_called_once_with(
-            _fetch_annotations.return_value)
+            _fetch_annotations.return_value.all.return_value)
         assert result.timeframes == bucketing.bucket.return_value
 
     def test_it_fetches_the_groups_from_the_database(self,


### PR DESCRIPTION
The bucketing code expects to receive a list of annotations, not a
sqlalchemy query object. Sending it a query object crashes when there
are 0 annotations that match the query, because the bucketing code's
test for this relies on an empty list being falsey (whereas a sqlalchemy
query with no results is truthy).

This could happen for example if the ?page=n argument in the query
string is larger than the number of pages of matching annotations.

Fixes #3842