### PR TITLE
Add an AuthClient model for third-party accounts

### DIFF
--- a/h/db/__init__.py
+++ b/h/db/__init__.py
@@ -63,6 +63,9 @@ def init(engine, base=Base, should_create=False, should_drop=False):
         base.metadata.reflect(engine)
         base.metadata.drop_all(engine)
     if should_create:
+        # In order to be able to generate UUIDs, we load the uuid-ossp
+        # extension.
+        engine.execute('CREATE EXTENSION IF NOT EXISTS "uuid-ossp";')
         base.metadata.create_all(engine)
     api_db.init(engine, should_create=should_create, should_drop=should_drop)
 

--- a/h/migrations/versions/bdaa06b14557_add_authclient_table.py
+++ b/h/migrations/versions/bdaa06b14557_add_authclient_table.py
@@ -1,0 +1,32 @@
+"""
+Add AuthClient table
+
+Revision ID: bdaa06b14557
+Revises: afd433075707
+Create Date: 2016-09-08 14:00:17.363281
+"""
+
+from __future__ import unicode_literals
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = 'bdaa06b14557'
+down_revision = 'afd433075707'
+
+
+def upgrade():
+    op.create_table('authclient',
+    sa.Column('id', postgresql.UUID(), server_default=sa.func.uuid_generate_v1mc(), nullable=False),
+    sa.Column('created', sa.DateTime(), server_default=sa.func.now(), nullable=False),
+    sa.Column('updated', sa.DateTime(), server_default=sa.func.now(), nullable=False),
+    sa.Column('name', sa.UnicodeText(), nullable=True),
+    sa.Column('secret', sa.UnicodeText(), nullable=False),
+    sa.Column('authority', sa.UnicodeText(), nullable=False),
+    sa.PrimaryKeyConstraint('id', name=op.f('pk__authclient'))
+    )
+
+
+def downgrade():
+    op.drop_table('authclient')

--- a/h/models/__init__.py
+++ b/h/models/__init__.py
@@ -31,11 +31,13 @@ from h.notification import models as notification_models
 from h.badge import models as badge_models
 
 from h.models.activation import Activation
+from h.models.auth_client import AuthClient
 from h.models.user import User
 
 __all__ = (
     'Activation',
     'Annotation',
+    'AuthClient',
     'Blocklist',
     'Document',
     'DocumentMeta',

--- a/h/models/auth_client.py
+++ b/h/models/auth_client.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from h.db import Base
+from h.db.mixins import Timestamps
+from h.security import token_urlsafe
+
+
+class AuthClient(Base, Timestamps):
+    """
+    An OAuth client.
+
+    An AuthClient represents an OAuth client, an entity which can access
+    protected resources (such as annotations) on behalf of a user.
+
+    The first type of OAuth client we have is a very special one, which can
+    access protected resources for *any* user within its *authority*. These
+    are "publisher" accounts, which can create users in our database, and
+    subsequently issue grant authorization tokens for any of those users.
+    """
+
+    __tablename__ = 'authclient'
+
+    #: Public client identifier
+    id = sa.Column(postgresql.UUID,
+                   server_default=sa.func.uuid_generate_v1mc(),
+                   primary_key=True)
+
+    #: Human-readable name for reference.
+    name = sa.Column(sa.UnicodeText, nullable=True)
+
+    #: Client secret
+    secret = sa.Column(sa.UnicodeText, default=token_urlsafe, nullable=False)
+
+    #: Authority for which this client is allowed to authorize users.
+    authority = sa.Column(sa.UnicodeText, nullable=False)
+
+    def __repr__(self):
+        return 'AuthClient(id={self.id!r})'.format(self=self)

--- a/h/security.py
+++ b/h/security.py
@@ -2,10 +2,15 @@
 
 from __future__ import unicode_literals
 
+import base64
+import os
+
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 from cryptography.hazmat.backends import default_backend
 from passlib.context import CryptContext
+
+DEFAULT_ENTROPY = 32
 
 backend = default_backend()
 
@@ -32,3 +37,12 @@ def derive_key(key_material, info, algorithm=None, length=None):
         length = algorithm.digest_size
     hkdf = HKDF(algorithm, length, b'h.security', info, backend)
     return hkdf.derive(key_material)
+
+
+# Implementation modeled on `secrets.token_urlsafe`, new in Python 3.6.
+def token_urlsafe(nbytes=None):
+    """Return a random URL-safe string composed of *nbytes* random bytes."""
+    if nbytes is None:
+        nbytes = DEFAULT_ENTROPY
+    tok = os.urandom(nbytes)
+    return base64.urlsafe_b64encode(tok).rstrip(b'=').decode('ascii')

--- a/tests/h/models/auth_client_test.py
+++ b/tests/h/models/auth_client_test.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import pytest
+
+from h.models import AuthClient
+
+
+class TestAuthClient(object):
+
+    def test_has_id(self, client):
+        assert client.id
+
+    def test_has_secret(self, client):
+        assert client.secret
+
+    @pytest.fixture
+    def client(self, db_session):
+        client = AuthClient(authority='example.com')
+        db_session.add(client)
+        db_session.flush()
+        return client

--- a/tests/h/security_test.py
+++ b/tests/h/security_test.py
@@ -3,10 +3,31 @@
 from __future__ import unicode_literals
 
 from passlib.context import CryptContext
+from hypothesis import strategies as st
+from hypothesis import given
 
+from h._compat import text_type
 from h.security import password_context
+from h.security import token_urlsafe
 
 
 def test_password_context():
     assert isinstance(password_context, CryptContext)
     assert len(password_context.schemes()) > 0
+
+
+@given(nbytes=st.integers(min_value=1, max_value=64))
+def test_token_urlsafe(nbytes):
+    tok = token_urlsafe(nbytes)
+
+    # Should be text
+    assert isinstance(tok, text_type)
+    # Always at least nbytes of data
+    assert len(tok) > nbytes
+
+
+def test_token_urlsafe_no_args():
+    tok = token_urlsafe()
+
+    assert isinstance(tok, text_type)
+    assert len(tok) > 32


### PR DESCRIPTION
This PR adds an AuthClient model/table, which holds the ids and secrets
associated with publisher accounts, which are -- more generally -- a kind of
OAuth client.