### PR TITLE
Eager-load document uris for activity search

### DIFF
--- a/h/activity/query.py
+++ b/h/activity/query.py
@@ -169,7 +169,9 @@ def _execute_search(request, query, page_size):
 def _fetch_annotations(session, ids):
     return (session.query(Annotation)
             .options(subqueryload(Annotation.document)
-                     .subqueryload(Document.meta_titles))
+                     .subqueryload(Document.meta_titles),
+                     subqueryload(Annotation.document)
+                     .subqueryload(Document.document_uris))
             .filter(Annotation.id.in_(ids))
             .order_by(Annotation.updated.desc()))
 


### PR DESCRIPTION
This results in less queries and could potentially speed up the response
times to a more acceptable level.

Here's some performance benchmarks:

```
# before

Running 1m test @ https://localhost:5000/search
  1 threads and 1 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   122.01ms   66.95ms 442.10ms   91.88%
    Req/Sec     9.44      1.99    20.00     90.47%
  518 requests in 1.00m, 19.65MB read
Requests/sec:      8.62
Transfer/sec:    335.03KB

Running 1m test @ https://localhost:5000/users/jeremydean/search
  1 threads and 1 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   205.35ms   81.43ms 484.79ms   88.36%
    Req/Sec     5.79      2.61    10.00     61.51%
  291 requests in 1.00m, 9.19MB read
Requests/sec:      4.84
Transfer/sec:    156.68KB

# after eager-loading document uris

Running 1m test @ https://localhost:5000/search
  1 threads and 1 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    97.89ms   57.78ms 511.55ms   92.53%
    Req/Sec    11.62      4.38    20.00     74.67%
  647 requests in 1.00m, 24.46MB read
Requests/sec:     10.77
Transfer/sec:    416.81KB

Running 1m test @ https://localhost:5000/users/jeremydean/search
  1 threads and 1 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   626.35ms   95.92ms 884.43ms   63.16%
    Req/Sec     1.31      0.46     2.00     69.47%
  95 requests in 1.00m, 3.01MB read
Requests/sec:      1.58
Transfer/sec:     51.26KB
```

It's quite clear that this will not actually get the response times low enough. But I think it's still worth to get this out to production and then do some more benchmarking there.