### PR TITLE
Make user unique constraints compound with authority

### DIFF
--- a/h/migrations/versions/94c989e06363_remove_old_user_constraints.py
+++ b/h/migrations/versions/94c989e06363_remove_old_user_constraints.py
@@ -1,0 +1,28 @@
+"""
+Remove old user constraints
+
+These were created in b0e1a12de5e8 in order to avoid making that migration
+irreversible. This is the irreversible part.
+
+Revision ID: 94c989e06363
+Revises: b0e1a12de5e8
+Create Date: 2016-09-08 16:21:25.444258
+"""
+
+from __future__ import unicode_literals
+
+from alembic import op
+
+
+revision = '94c989e06363'
+down_revision = 'b0e1a12de5e8'
+
+
+def upgrade():
+    op.drop_constraint('uq__user__email_old', 'user')
+    op.drop_constraint('uq__user__uid_old', 'user')
+    op.drop_constraint('uq__user__username_old', 'user')
+
+
+def downgrade():
+    pass

--- a/h/migrations/versions/b0e1a12de5e8_update_user_unique_constraints.py
+++ b/h/migrations/versions/b0e1a12de5e8_update_user_unique_constraints.py
@@ -1,0 +1,49 @@
+"""
+Update user unique constraints
+
+Revision ID: b0e1a12de5e8
+Revises: bdaa06b14557
+Create Date: 2016-09-08 16:03:59.857402
+"""
+
+from __future__ import unicode_literals
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = 'b0e1a12de5e8'
+down_revision = 'bdaa06b14557'
+
+
+def upgrade():
+    # First we move the existing unique constraint indices out of the way
+    op.execute(sa.text('ALTER TABLE "user" RENAME CONSTRAINT uq__user__email TO uq__user__email_old'))
+    op.execute(sa.text('ALTER TABLE "user" RENAME CONSTRAINT uq__user__uid TO uq__user__uid_old'))
+    op.execute(sa.text('ALTER TABLE "user" RENAME CONSTRAINT uq__user__username TO uq__user__username_old'))
+
+    # Then we can generate the new indices in the background
+    op.execute('COMMIT')
+    op.create_index(op.f('uq__user__email'), 'user', ['email', 'authority'],
+                    unique=True,
+                    postgresql_concurrently=True)
+    op.create_index(op.f('uq__user__uid'), 'user', ['uid', 'authority'],
+                    unique=True,
+                    postgresql_concurrently=True)
+    op.create_index(op.f('uq__user__username'), 'user', ['username', 'authority'],
+                    unique=True,
+                    postgresql_concurrently=True)
+
+    # Lastly, we can create the constraints using the new indices
+    op.execute(sa.text('ALTER TABLE "user" ADD CONSTRAINT uq__user__email UNIQUE USING INDEX uq__user__email'))
+    op.execute(sa.text('ALTER TABLE "user" ADD CONSTRAINT uq__user__uid UNIQUE USING INDEX uq__user__uid'))
+    op.execute(sa.text('ALTER TABLE "user" ADD CONSTRAINT uq__user__username UNIQUE USING INDEX uq__user__username'))
+
+def downgrade():
+    op.drop_constraint('uq__user__email', 'user')
+    op.drop_constraint('uq__user__uid', 'user')
+    op.drop_constraint('uq__user__username', 'user')
+
+    op.execute(sa.text('ALTER TABLE "user" RENAME CONSTRAINT uq__user__email_old TO uq__user__email'))
+    op.execute(sa.text('ALTER TABLE "user" RENAME CONSTRAINT uq__user__uid_old TO uq__user__uid'))
+    op.execute(sa.text('ALTER TABLE "user" RENAME CONSTRAINT uq__user__username_old TO uq__user__username'))

--- a/h/models/user.py
+++ b/h/models/user.py
@@ -43,16 +43,18 @@ class UserIDComparator(Comparator):
 
 class User(Base):
     __tablename__ = 'user'
+    __table_args__ = (
+        sa.UniqueConstraint('email', 'authority'),
+        sa.UniqueConstraint('uid', 'authority'),
+        sa.UniqueConstraint('username', 'authority'),
+    )
 
     id = sa.Column(sa.Integer, autoincrement=True, primary_key=True)
 
     #: Normalised user identifier
-    uid = sa.Column(sa.UnicodeText(), nullable=False, unique=True)
+    uid = sa.Column(sa.UnicodeText(), nullable=False)
     #: Username as chosen by the user on registration
-    _username = sa.Column('username',
-                          sa.UnicodeText(),
-                          nullable=False,
-                          unique=True)
+    _username = sa.Column('username', sa.UnicodeText(), nullable=False)
 
     #: The "authority" for this user. This represents the "namespace" in which
     #: this user lives. By default, all users are created in the namespace
@@ -120,7 +122,7 @@ class User(Base):
         # on the username and authority columns.
         return UserIDComparator(cls.username, cls.authority)
 
-    email = sa.Column(sa.UnicodeText(), nullable=False, unique=True)
+    email = sa.Column(sa.UnicodeText(), nullable=False)
 
     last_login_date = sa.Column(sa.TIMESTAMP(timezone=False),
                                 default=datetime.datetime.utcnow,


### PR DESCRIPTION
In order to be able to create users for other authorities with any username, we need to only enforce username uniqueness constraints per-authority.

Update the user model so that we enforce uniqueness on the

    (email, authority)
    (uid, authority)
    (username, authority)

tuples rather than simply on email, uid, and username.