### PR TITLE
Disable signup button on form submit

### DIFF
--- a/h/accounts/views.py
+++ b/h/accounts/views.py
@@ -339,7 +339,9 @@ class SignupController(object):
         self.request = request
         self.schema = schemas.RegisterSchema().bind(request=self.request)
         self.form = request.create_form(self.schema,
-                                        buttons=(_('Sign up'),),
+                                        buttons=(deform.Button(title=_('Sign up'),
+                                                               css_class='js-signup-btn'),),
+                                        css_class='js-signup-form',
                                         footer=form_footer)
 
     @view_config(request_method='GET')

--- a/h/static/scripts/controllers/signup-form-controller.js
+++ b/h/static/scripts/controllers/signup-form-controller.js
@@ -1,0 +1,14 @@
+'use strict';
+
+function SignupFormController(element) {
+  var self = this;
+  var form = element;
+
+  this._submitBtn = element.querySelector('.js-signup-btn')
+
+  form.addEventListener('submit', event => {
+    this._submitBtn.disabled = true;
+  });
+}
+
+module.exports = SignupFormController;

--- a/h/static/scripts/site.js
+++ b/h/static/scripts/site.js
@@ -13,6 +13,7 @@ var CreateGroupFormController = require('./controllers/create-group-form-control
 var DropdownMenuController = require('./controllers/dropdown-menu-controller');
 var FormSelectOnFocusController = require('./controllers/form-select-onfocus-controller');
 var SearchBucketController = require('./controllers/search-bucket-controller');
+var SignupFormController = require('./controllers/signup-form-controller');
 var TooltipController = require('./controllers/tooltip-controller');
 var upgradeElements = require('./base/upgrade-elements');
 
@@ -22,6 +23,7 @@ var controllers = {
   '.js-dropdown-menu': DropdownMenuController,
   '.js-select-onfocus': FormSelectOnFocusController,
   '.js-search-bucket': SearchBucketController,
+  '.js-signup-form': SignupFormController,
   '.js-tooltip': TooltipController,
 };
 

--- a/h/static/scripts/tests/controllers/signup-form-controller-test.js
+++ b/h/static/scripts/tests/controllers/signup-form-controller-test.js
@@ -1,0 +1,39 @@
+'use strict';
+
+var SignupFormController = require('../../controllers/signup-form-controller')
+
+// helper to dispatch a native event to an element
+function sendEvent(element, eventType) {
+  // createEvent() used instead of Event constructor
+  // for PhantomJS compatibility
+  var event = document.createEvent('Event');
+  event.initEvent(eventType, true /* bubbles */, true /* cancelable */);
+  element.dispatchEvent(event);
+}
+
+describe('SignupFormController', function() {
+  var element;
+  var template;
+  var form;
+  var submitBtn;
+
+  before(function () {
+    template = '<form class="js-signup-form">' +
+               '<input type="submit" class="js-signup-btn">' +
+               '</form>'
+  });
+
+  beforeEach(function () {
+    element = document.createElement('div');
+    element.innerHTML = template;
+    form = element.querySelector('.js-signup-form');
+    submitBtn = element.querySelector('.js-signup-btn');
+  });
+
+  it('disables the submit button on form submit', function () {
+    var controller = new SignupFormController(form);
+    assert.isFalse(submitBtn.disabled);
+    sendEvent(form, 'submit');
+    assert.isTrue(submitBtn.disabled);
+  });
+});


### PR DESCRIPTION
This is to prevent users from double-clicking the signup button and thus
sending two requests in quick succession which will probably result in
a SQLAlchemy integrity error as the username/email is already being
used when trying to commit the transaction.

Fixes #3830