### PR TITLE
Show suggestion box of search facets when the search bar is in focus.

### DIFF
--- a/h/static/scripts/controllers/search-bar-controller.js
+++ b/h/static/scripts/controllers/search-bar-controller.js
@@ -1,0 +1,180 @@
+'use strict';
+
+var Controller = require('../base/controller');
+var setElementState = require('../util/dom').setElementState;
+
+/**
+ * Controller for the search bar.
+ */
+class SearchBarController extends Controller {
+  constructor(element) {
+    super(element);
+
+    this._input = this.refs.searchBarInput;
+    this._dropdown = this.refs.searchBarDropdown;
+    this._dropdownItems = Array.from(
+      element.querySelectorAll('[data-ref="searchBarDropdownItem"]'));
+
+    var getActiveDropdownItem = () => {
+      return element.querySelector('.js-search-bar-dropdown-menu-item--active');
+    };
+
+    var clearActiveDropdownItem = () => {
+      var activeItem = getActiveDropdownItem();
+      if (activeItem) {
+        activeItem.classList.remove('js-search-bar-dropdown-menu-item--active');
+      }
+    };
+
+    var updateActiveDropdownItem = element => {
+      clearActiveDropdownItem();
+      element.classList.add('js-search-bar-dropdown-menu-item--active');
+    };
+
+    var selectFacet = facet => {
+      this._input.value = this._input.value + facet;
+
+      closeDropdown();
+
+      setTimeout(function() {
+        this._input.focus();
+      }.bind(this), 0);
+    };
+
+    var getPreviousSiblingElement = element => {
+      if (!element) {
+        return null;
+      }
+
+      do {
+        element = element.previousSibling;
+      } while (element && element.nodeType != 1);
+
+      return element;
+    };
+
+    var getNextSiblingElement = element => {
+      if (!element) {
+        return null;
+      }
+
+      do {
+        element = element.nextSibling;
+      } while (element && element.nodeType != 1);
+
+      return element;
+    };
+
+    var closeDropdown = () => {
+      clearActiveDropdownItem();
+      this.setState({open: false});
+      this._input.removeEventListener('keydown', setupListenerKeys,
+        true /*capture*/);
+    };
+
+    var openDropdown = () => {
+      this.setState({open: true});
+      this._input.addEventListener('keydown', setupListenerKeys,
+        true /*capture*/);
+    };
+
+    var setupListenerKeys = event => {
+      const ENTER_KEY_CODE = 13;
+      const UP_ARROW_KEY_CODE = 38;
+      const DOWN_ARROW_KEY_CODE = 40;
+
+      var activeItem = getActiveDropdownItem();
+      var handlers = {};
+
+      var handleEnterKey = event => {
+        event.preventDefault();
+
+        if (activeItem) {
+          var facet =
+            activeItem.
+              querySelector('[data-ref="searchBarDropdownItemTitle"]').
+              innerHTML.trim();
+          selectFacet(facet);
+        }
+      };
+
+      var handleUpArrowKey = event => {
+        updateActiveDropdownItem(getPreviousSiblingElement(activeItem) ||
+          this._dropdownItems[this._dropdownItems.length - 1]);
+      };
+
+      var handleDownArrowKey = event => {
+        updateActiveDropdownItem(getNextSiblingElement(activeItem) ||
+          this._dropdownItems[0]);
+      };
+
+      handlers[ENTER_KEY_CODE] = handleEnterKey;
+      handlers[UP_ARROW_KEY_CODE] = handleUpArrowKey;
+      handlers[DOWN_ARROW_KEY_CODE] = handleDownArrowKey;
+
+      var handler = handlers[event.keyCode];
+      if (handler) {
+        handler(event);
+      }
+    };
+
+    var handleClickOnItem = event => {
+      var facet =
+        event.currentTarget.
+          querySelector('[data-ref="searchBarDropdownItemTitle"]').
+          innerHTML.trim();
+      selectFacet(facet);
+    };
+
+    var handleHoverOnItem = event => {
+      updateActiveDropdownItem(event.currentTarget);
+    };
+
+    var handleClickOnDropdown = event => {
+      // prevent clicking on a part of the dropdown menu itself that
+      // isn't one of the suggestions from closing the menu
+      event.preventDefault();
+    };
+
+    var handleFocusOutside = event => {
+      if (!element.contains(event.target) ||
+        !element.contains(event.relatedTarget)) {
+        this.setState({open: false});
+      }
+      closeDropdown();
+    };
+
+    var handleFocusOnInput = () => {
+      if (this._input.value.trim().length > 0) {
+        closeDropdown();
+      } else {
+        openDropdown();
+      }
+    };
+
+    Object.keys(this._dropdownItems).forEach(function(key) {
+      var item = this._dropdownItems[key];
+      if(item && item.addEventListener) {
+        item.addEventListener('mouseover', handleHoverOnItem,
+          true);
+        item.addEventListener('mousedown', handleClickOnItem,
+          true);
+      }
+    }.bind(this));
+
+    this._dropdown.addEventListener('mousedown', handleClickOnDropdown,
+      true /*capture*/);
+    this._input.addEventListener('focusout', handleFocusOutside,
+      true /*capture*/);
+    this._input.addEventListener('input', handleFocusOnInput,
+      true /*capture*/);
+    this._input.addEventListener('focusin', handleFocusOnInput,
+      true /*capture*/);
+  }
+
+  update(state) {
+    setElementState(this._dropdown, {open: state.open});
+  }
+}
+
+module.exports = SearchBarController;

--- a/h/static/scripts/site.js
+++ b/h/static/scripts/site.js
@@ -12,6 +12,7 @@ var CharacterLimitController = require('./controllers/character-limit-controller
 var CreateGroupFormController = require('./controllers/create-group-form-controller');
 var DropdownMenuController = require('./controllers/dropdown-menu-controller');
 var FormSelectOnFocusController = require('./controllers/form-select-onfocus-controller');
+var SearchBarController = require('./controllers/search-bar-controller');
 var SearchBucketController = require('./controllers/search-bucket-controller');
 var SignupFormController = require('./controllers/signup-form-controller');
 var TooltipController = require('./controllers/tooltip-controller');
@@ -22,6 +23,7 @@ var controllers = {
   '.js-create-group-form': CreateGroupFormController,
   '.js-dropdown-menu': DropdownMenuController,
   '.js-select-onfocus': FormSelectOnFocusController,
+  '.js-search-bar': SearchBarController,
   '.js-search-bucket': SearchBucketController,
   '.js-signup-form': SignupFormController,
   '.js-tooltip': TooltipController,

--- a/h/static/scripts/tests/controllers/search-bar-controller-test.js
+++ b/h/static/scripts/tests/controllers/search-bar-controller-test.js
@@ -1,0 +1,133 @@
+'use strict';
+
+var SearchBarController = require('../../controllers/search-bar-controller');
+
+describe('SearchBarController', function () {  
+  var template;
+  var testEl;
+  var input;
+  var dropdown;
+  var dropdownItems;
+  var ctrl;
+
+  before(function () {
+    template = '<input data-ref="searchBarInput">' +
+      '<div data-ref="searchBarDropdown">' +
+      '<div>Narrow your search</div>' +
+      '<ul>' +
+      '<li data-ref="searchBarDropdownItem">' +
+      '<span data-ref="searchBarDropdownItemTitle">' +
+      'user:' +
+      '</span>' +
+      '</li>' +
+      '<li data-ref="searchBarDropdownItem">' +
+      '<span data-ref="searchBarDropdownItemTitle">' +
+      'tag:' +
+      '</span>' +
+      '</li>' +
+      '<li data-ref="searchBarDropdownItem">' +
+      '<span data-ref="searchBarDropdownItemTitle">' +
+      'url:' +
+      '</span>' +
+      '</li>' +
+      '<li data-ref="searchBarDropdownItem">' +
+      '<span data-ref="searchBarDropdownItemTitle">' +
+      'group:' +
+      '</span>' +
+      '</li>' +
+      '</ul>' +
+      '</div>';
+  });
+
+  beforeEach(function () {
+    testEl = document.createElement('div');
+    testEl.innerHTML = template;
+
+    ctrl = new SearchBarController(testEl);
+
+    input = ctrl.refs.searchBarInput;
+    dropdown = ctrl.refs.searchBarDropdown;
+    dropdownItems = testEl.querySelectorAll('[data-ref="searchBarDropdownItem"]');
+  });
+
+  afterEach(function () {
+    ctrl = null;
+  });
+
+  it('dropdown appears when the input field has focus', function () {
+    input.dispatchEvent(new Event('focusin'));
+    assert.isTrue(dropdown.classList.contains('is-open'));
+  });
+
+  it('dropdown is hidden when the input field loses focus', function () {
+    input.dispatchEvent(new Event('focusin'));
+    input.dispatchEvent(new Event('focusout'));
+    assert.isFalse(dropdown.classList.contains('is-open'));
+  });
+
+  it('selects facet from dropdown on mousedown', function () {
+    input.dispatchEvent(new Event('focusin'));
+    dropdownItems[0].dispatchEvent(new Event('mousedown'));
+    assert.equal(input.value, 'user:');
+  });
+
+  it('highlights facet on up arrow', function () {
+    var e = new Event('keydown');
+    e.keyCode = 38;
+    input.dispatchEvent(new Event('focusin'));
+    input.dispatchEvent(e);
+    assert.isTrue(dropdownItems[3].classList.contains('js-search-bar-dropdown-menu-item--active'));
+  });
+
+  it('highlights facet on down arrow', function () {
+    var e = new Event('keydown');
+    e.keyCode = 40;
+    input.dispatchEvent(new Event('focusin'));
+    input.dispatchEvent(e);
+    assert.isTrue(dropdownItems[0].classList.contains('js-search-bar-dropdown-menu-item--active'));
+  });
+
+  it('highlights the correct facet for a combination of mouseover, up and down arrow keys', function () {
+    var e = new Event('keydown');
+    // down arrow to #1
+    e.keyCode = 40;
+    input.dispatchEvent(new Event('focusin'));
+    input.dispatchEvent(e);
+    assert.isTrue(dropdownItems[0].classList.contains('js-search-bar-dropdown-menu-item--active'));
+    // mouseover #3
+    dropdownItems[2].dispatchEvent(new Event('mouseover'));
+    assert.isFalse(dropdownItems[0].classList.contains('js-search-bar-dropdown-menu-item--active'));
+    assert.isTrue(dropdownItems[2].classList.contains('js-search-bar-dropdown-menu-item--active'));
+    // up arrow to #2
+    e.keyCode = 38;
+    input.dispatchEvent(e);
+    assert.isFalse(dropdownItems[2].classList.contains('js-search-bar-dropdown-menu-item--active'));
+    assert.isTrue(dropdownItems[1].classList.contains('js-search-bar-dropdown-menu-item--active'));
+    // mouseover #3
+    dropdownItems[2].dispatchEvent(new Event('mouseover'));
+    assert.isFalse(dropdownItems[1].classList.contains('js-search-bar-dropdown-menu-item--active'));
+    assert.isTrue(dropdownItems[2].classList.contains('js-search-bar-dropdown-menu-item--active'));
+    // down arrow to #4
+    e.keyCode = 40;
+    input.dispatchEvent(e);
+    assert.isFalse(dropdownItems[2].classList.contains('js-search-bar-dropdown-menu-item--active'));
+    assert.isTrue(dropdownItems[3].classList.contains('js-search-bar-dropdown-menu-item--active'));
+  });
+
+  it('selects facet on enter', function () {
+    var e1 = new Event('keydown');
+    e1.keyCode = 40;
+    var e2 = new Event('keydown');
+    e2.keyCode = 13;
+    input.dispatchEvent(new Event('focusin'));
+    input.dispatchEvent(e1);
+    input.dispatchEvent(e2);
+    assert.equal(input.value, 'user:'); 
+  });
+
+  it('dropdown stays open when clicking on a part of it that is not one of the suggestions', function () {
+    input.dispatchEvent(new Event('focusin'));
+    dropdown.querySelector('div').dispatchEvent(new Event('mousedown'));
+    assert.isTrue(dropdown.classList.contains('is-open'));
+  });
+});

--- a/h/static/styles/partials-v2/_search-bar.scss
+++ b/h/static/styles/partials-v2/_search-bar.scss
@@ -22,6 +22,7 @@
 .search-bar__input:hover,
 .search-bar__input:focus {
   border-color: $grey-4;
+  outline: none;
 }
 
 .search-bar__icon {
@@ -36,4 +37,46 @@
 .search-bar__input:hover + .search-bar__icon,
 .search-bar__input:focus + .search-bar__icon {
   color: $grey-6;
+}
+
+.search-bar__dropdown-menu-container {
+  background: white;
+  border: 1px solid $grey-2;
+  border-top: none;
+  box-shadow: 0px 2px 3px 0px rgba(0, 0, 0, 0.15);
+  color: $grey-4;
+  display: none;
+  padding: 20px 0 0 0;
+  position: absolute;
+  width: 100%;
+}
+
+.search-bar__dropdown-menu-header {
+  margin: 0 30px 7px 30px;
+}
+
+.search-bar__dropdown-menu-item {
+  padding: 6px 30px 6px 30px;
+  cursor: default;
+}
+
+.search-bar__dropdown-menu-item:last-child {
+  margin-bottom: 14px;
+}
+
+.js-search-bar-dropdown-menu-item--active {
+  background-color: $grey-2;
+}
+
+.search-bar__dropdown-menu-title {
+  color: $grey-6;
+  font-weight: bold;
+}
+
+.search-bar__dropdown-menu-explanation {
+  font-style: italic;
+}
+
+.search-bar__dropdown-menu-container.is-open {
+  display: block;
 }

--- a/h/templates/panels/navbar.html.jinja2
+++ b/h/templates/panels/navbar.html.jinja2
@@ -1,5 +1,48 @@
 {% from '../includes/dropdown_menu.html.jinja2' import dropdown_menu %}
 
+{# Dropdown displaying search facet options. #}
+{% macro search_bar_dropdown() %}
+<div class="search-bar__dropdown-menu-container" data-ref="searchBarDropdown">
+  <h4 class="search-bar__dropdown-menu-header">
+    Narrow your search
+  </h4>
+  <ul class="search-bar__dropdown-menu">
+    <li class="search-bar__dropdown-menu-item" data-ref="searchBarDropdownItem">
+      <span class="search-bar__dropdown-menu-title" data-ref="searchBarDropdownItemTitle">
+        user:
+      </span>
+      <span class="search-bar__dropdown-menu-explanation">
+        search by username
+      </span>
+    </li>
+    <li class="search-bar__dropdown-menu-item" data-ref="searchBarDropdownItem">
+      <span class="search-bar__dropdown-menu-title" data-ref="searchBarDropdownItemTitle">
+        tag:
+      </span>
+      <span class="search-bar__dropdown-menu-explanation">
+        search for annotations with a tag
+      </span>
+    </li>
+    <li class="search-bar__dropdown-menu-item" data-ref="searchBarDropdownItem">
+      <span class="search-bar__dropdown-menu-title" data-ref="searchBarDropdownItemTitle">
+        url:
+      </span>
+      <span class="search-bar__dropdown-menu-explanation">
+        see all annotations on a page
+      </span>
+    </li>
+    <li class="search-bar__dropdown-menu-item" data-ref="searchBarDropdownItem">
+      <span class="search-bar__dropdown-menu-title" data-ref="searchBarDropdownItemTitle">
+        group:
+      </span>
+      <span class="search-bar__dropdown-menu-explanation">
+        show annotations created in a group you are a member of
+      </span>
+    </li>
+  </ul>
+</div>
+{% endmacro %}
+
 {% block content %}
 {% if feature('activity_pages') %}
 <header class="nav-bar">
@@ -7,10 +50,11 @@
     <a href="/" title="Hypothesis homepage"><!--
       !--><img alt="Hypothesis logo" class="nav-bar__logo" src="/assets/images/logo.svg"></a>
 
-    <div class="nav-bar__search">
+    <div class="nav-bar__search js-search-bar" data-ref="searchBar">
       <form class="search-bar" action="{{ search_url }}">
-        <input class="search-bar__input" name="q" value="{{ q }}" placeholder="Search…">
+        <input class="search-bar__input" data-ref="searchBarInput" name="q" value="{{ q }}" placeholder="Search…" autocomplete="off">
         {{ svg_icon('search', 'search-bar__icon') }}
+        {{ search_bar_dropdown() }}
       </form>
     </div>
 


### PR DESCRIPTION
When the user focuses on the activity page search box a suggestion box is shown underneath which contains possible query terms the user can enter.
When the input field loses focus the sugestion box is hidden.
The user can use the up/down arrows and the enter key to select suggestions.
The user can use the mouse to select suggestions from the dropdown box.
The user can use a combination of the up and down arrows and the mouse to
highlight a facet.

https://trello.com/c/I6s1UK1R/434-show-suggestion-box-under-search-box-on-focus