### PR TITLE
Denormalize document title

### DIFF
--- a/h/activity/query.py
+++ b/h/activity/query.py
@@ -169,8 +169,6 @@ def _execute_search(request, query, page_size):
 def _fetch_annotations(session, ids):
     return (session.query(Annotation)
             .options(subqueryload(Annotation.document)
-                     .subqueryload(Document.meta_titles),
-                     subqueryload(Annotation.document)
                      .subqueryload(Document.document_uris))
             .filter(Annotation.id.in_(ids))
             .order_by(Annotation.updated.desc()))

--- a/h/migrations/versions/58bb601c390f_fill_in_missing_denormalized_document_title.py
+++ b/h/migrations/versions/58bb601c390f_fill_in_missing_denormalized_document_title.py
@@ -1,0 +1,91 @@
+"""
+Fill in missing denormalized Document.title
+
+Revision ID: 58bb601c390f
+Revises: 3e1727613916
+Create Date: 2016-09-12 12:21:40.904620
+"""
+
+from __future__ import unicode_literals
+
+from collections import namedtuple
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import subqueryload
+
+
+revision = '58bb601c390f'
+down_revision = '3e1727613916'
+
+Base = declarative_base()
+Session = sessionmaker()
+
+
+class Window(namedtuple('Window', ['start', 'end'])):
+    pass
+
+
+class Document(Base):
+    __tablename__ = 'document'
+    id = sa.Column(sa.Integer, primary_key=True)
+    updated = sa.Column(sa.DateTime)
+    title = sa.Column(sa.UnicodeText())
+    meta_titles = sa.orm.relationship('DocumentMeta',
+                                      primaryjoin='and_(Document.id==DocumentMeta.document_id, DocumentMeta.type==u"title")',
+                                      order_by='DocumentMeta.updated.asc()',
+                                      viewonly=True)
+
+
+class DocumentMeta(Base):
+    __tablename__ = 'document_meta'
+    id = sa.Column(sa.Integer, primary_key=True)
+    updated = sa.Column(sa.DateTime)
+    type = sa.Column(sa.UnicodeText)
+    value = sa.Column(sa.UnicodeText)
+    document_id = sa.Column(sa.Integer,
+                            sa.ForeignKey('document.id'),
+                            nullable=False)
+
+
+def upgrade():
+    session = Session(bind=op.get_bind())
+
+    windows = _fetch_windows(session)
+    session.rollback()
+
+    for window in windows:
+        query = session.query(Document) \
+            .filter(Document.updated.between(window.start, window.end)) \
+            .options(subqueryload(Document.meta_titles)) \
+            .order_by(Document.updated.asc())
+
+        for doc in query:
+            doc.title = _document_title(doc)
+
+        session.commit()
+
+
+def downgrade():
+    pass
+
+
+def _document_title(document):
+    for meta in document.meta_titles:
+        if meta.value:
+            return meta.value[0]
+
+
+def _fetch_windows(session, chunksize=100):
+    updated = session.query(Document.updated). \
+        execution_options(stream_results=True). \
+        order_by(Document.updated.desc()).all()
+
+    count = len(updated)
+    windows = [Window(start=updated[min(x+chunksize, count)-1].updated,
+                      end=updated[x].updated)
+               for x in xrange(0, count, chunksize)]
+
+    return windows

--- a/src/memex/models/document.py
+++ b/src/memex/models/document.py
@@ -355,6 +355,9 @@ def create_or_update_document_meta(session,
                      "match given Document's id (%d)",
                      existing_dm.id, existing_dm.document_id, document.id)
 
+    if type == 'title' and value and not document.title:
+        document.title = value[0]
+
     try:
         session.flush()
     except sa.exc.IntegrityError:

--- a/src/memex/models/document.py
+++ b/src/memex/models/document.py
@@ -41,11 +41,6 @@ class Document(Base, mixins.Timestamps):
                                backref='document',
                                order_by='DocumentMeta.updated.desc()')
 
-    meta_titles = sa.orm.relationship('DocumentMeta',
-                                      primaryjoin='and_(Document.id==DocumentMeta.document_id, DocumentMeta.type==u"title")',
-                                      order_by='DocumentMeta.updated.asc()',
-                                      viewonly=True)
-
     def __repr__(self):
         return '<Document %s>' % self.id
 

--- a/src/memex/models/document.py
+++ b/src/memex/models/document.py
@@ -27,6 +27,9 @@ class Document(Base, mixins.Timestamps):
 
     id = sa.Column(sa.Integer, autoincrement=True, primary_key=True)
 
+    #: The denormalized value of the first DocumentMeta record with type title.
+    title = sa.Column('title', sa.UnicodeText())
+
     # FIXME: This relationship should be named `uris` again after the
     #        dependency on the annotator-store is removed, as it clashes with
     #        making the Postgres and Elasticsearch interface of a Document
@@ -45,12 +48,6 @@ class Document(Base, mixins.Timestamps):
 
     def __repr__(self):
         return '<Document %s>' % self.id
-
-    @property
-    def title(self):
-        for meta in self.meta_titles:
-            if meta.value:
-                return meta.value[0]
 
     @classmethod
     def find_by_uris(cls, session, uris):

--- a/src/memex/views.py
+++ b/src/memex/views.py
@@ -245,7 +245,7 @@ def _present_annotations(request, ids):
     """Load annotations by id from the database and present them."""
     def eager_load_documents(query):
         return query.options(
-            subqueryload(models.Annotation.document).subqueryload(models.Document.meta_titles))
+            subqueryload(models.Annotation.document))
 
     annotations = storage.fetch_ordered_annotations(request.db, ids,
                                                     query_processor=eager_load_documents)

--- a/tests/h/activity/bucketing_test.py
+++ b/tests/h/activity/bucketing_test.py
@@ -38,6 +38,7 @@ class TestDocumentBucket(object):
         title_meta = factories.DocumentMeta(type="title",
                                             value=["The Document Title"],
                                             document=document)
+        document.title = 'The Document Title'
         db_session.add(title_meta)
         db_session.flush()
 

--- a/tests/h/emails/reply_notification_test.py
+++ b/tests/h/emails/reply_notification_test.py
@@ -53,7 +53,7 @@ class TestGenerate(object):
                                                          pyramid_request,
                                                          html_renderer,
                                                          text_renderer):
-        notification.document.meta[0].value = []
+        notification.document.title = None
 
         generate(pyramid_request, notification)
 
@@ -142,9 +142,7 @@ class TestGenerate(object):
 
     @pytest.fixture
     def document(self, db_session):
-        doc = Document()
-        doc.meta.append(DocumentMeta(
-            type='title', value=['My fascinating page'], claimant='http://example.org'))
+        doc = Document(title='My fascinating page')
         db_session.add(doc)
         db_session.flush()
         return doc

--- a/tests/memex/models/document_test.py
+++ b/tests/memex/models/document_test.py
@@ -413,6 +413,72 @@ class TestCreateOrUpdateDocumentMeta(object):
         assert len(db_session.query(document.DocumentMeta).all()) == 1, (
             "It shouldn't have added any new objects to the db")
 
+    def test_it_denormalizes_title_to_document_when_none(self, db_session):
+        claimant = 'http://example.com/claimant'
+        type_ = 'title'
+        value = ['the title']
+        document_ = document.Document(title=None)
+        created = yesterday()
+        updated = now()
+        db_session.add(document_)
+
+        document.create_or_update_document_meta(
+            session=db_session,
+            claimant=claimant,
+            type=type_,
+            value=value,
+            document=document_,
+            created=created,
+            updated=updated,
+        )
+
+        document_ = db_session.query(document.Document).get(document_.id)
+        assert document_.title == value[0]
+
+    def test_it_denormalizes_title_to_document_when_empty(self, db_session):
+        claimant = 'http://example.com/claimant'
+        type_ = 'title'
+        value = ['the title']
+        document_ = document.Document(title='')
+        created = yesterday()
+        updated = now()
+        db_session.add(document_)
+
+        document.create_or_update_document_meta(
+            session=db_session,
+            claimant=claimant,
+            type=type_,
+            value=value,
+            document=document_,
+            created=created,
+            updated=updated,
+        )
+
+        document_ = db_session.query(document.Document).get(document_.id)
+        assert document_.title == value[0]
+
+    def test_it_skips_denormalizing_title_to_document_when_already_set(self, db_session):
+        claimant = 'http://example.com/claimant'
+        type_ = 'title'
+        value = ['the title']
+        document_ = document.Document(title='foobar')
+        created = yesterday()
+        updated = now()
+        db_session.add(document_)
+
+        document.create_or_update_document_meta(
+            session=db_session,
+            claimant=claimant,
+            type=type_,
+            value=value,
+            document=document_,
+            created=created,
+            updated=updated,
+        )
+
+        document_ = db_session.query(document.Document).get(document_.id)
+        assert document_.title == 'foobar'
+
     def test_it_logs_a_warning(self, log):
         """
         It should warn on document mismatches.

--- a/tests/memex/models/document_test.py
+++ b/tests/memex/models/document_test.py
@@ -12,47 +12,6 @@ from memex import models
 from memex.models import document
 
 
-class TestDocumentTitle(object):
-
-    def test_it_returns_the_value_of_the_one_title_DocumentMeta(self, db_session):
-        """When there's only one DocumentMeta it should return its title."""
-        doc = document.Document()
-        document.DocumentMeta(type='title',
-                              value=['The Title'],
-                              document=doc,
-                              claimant='http://example.com')
-        db_session.add(doc)
-        db_session.flush()
-
-        assert doc.title == 'The Title'
-
-    def test_it_returns_the_value_of_the_first_title_DocumentMeta(self, db_session):
-        doc = document.Document()
-        document.DocumentMeta(type='title',
-                              value=['The US Title'],
-                              document=doc,
-                              claimant='http://example.com')
-        document.DocumentMeta(type='title',
-                              value=['The UK Title'],
-                              document=doc,
-                              claimant='http://example.co.uk')
-        db_session.add(doc)
-        db_session.flush()
-
-        assert doc.title == 'The US Title'
-
-    def test_it_returns_None_if_there_are_no_title_DocumentMetas(self, db_session):
-        doc = document.Document()
-        document.DocumentMeta(type='other',
-                              value='something',
-                              document=doc,
-                              claimant='http://example.com')
-        db_session.add(doc)
-        db_session.flush()
-
-        assert doc.title is None
-
-
 class TestDocumentFindByURIs(object):
 
     def test_with_one_matching_Document(self, db_session):

--- a/tests/memex/presenters_test.py
+++ b/tests/memex/presenters_test.py
@@ -357,9 +357,9 @@ class TestAnnotationJSONLDPresenter(object):
 class TestDocumentJSONPresenter(object):
     def test_asdict(self, db_session):
         document = models.Document(
+            title='Foo',
             document_uris=[models.DocumentURI(uri='http://foo.com', claimant='http://foo.com'),
-                           models.DocumentURI(uri='http://foo.org', claimant='http://foo.com', type='rel-canonical')],
-            meta=[models.DocumentMeta(type='title', value=['Foo'], claimant='http://foo.com')])
+                           models.DocumentURI(uri='http://foo.org', claimant='http://foo.com', type='rel-canonical')])
         db_session.add(document)
         db_session.flush()
 
@@ -371,11 +371,11 @@ class TestDocumentJSONPresenter(object):
         assert {} == DocumentJSONPresenter(None).asdict()
 
     def test_asdict_does_not_render_other_meta_than_title(self, db_session):
-        document = models.Document(meta=[
-            models.DocumentMeta(type='title', value=['Foo'], claimant='http://foo.com'),
-            models.DocumentMeta(type='twitter.url', value=['http://foo.com'], claimant='http://foo.com'),
-            models.DocumentMeta(type='facebook.title', value=['FB Title'], claimant='http://foo.com'),
-        ])
+        document = models.Document(
+            title='Foo',
+            meta=[models.DocumentMeta(type='title', value=['Foo'], claimant='http://foo.com'),
+                  models.DocumentMeta(type='twitter.url', value=['http://foo.com'], claimant='http://foo.com'),
+                  models.DocumentMeta(type='facebook.title', value=['FB Title'], claimant='http://foo.com')])
         db_session.add(document)
         db_session.flush()
 


### PR DESCRIPTION
There are only a few document meta and document URI records that we actually need to display. So this pull request is to denormalize the document title onto the document itself when a new document gets created, or when an existing document gets updated and its missing the title. We can save  ourselves some extra queries on the document_meta table when reading from the database.