### PR TITLE
Add migration for Document.web_uri column

### DIFF
--- a/h/migrations/versions/3e1727613916_add_document_web_uri_column.py
+++ b/h/migrations/versions/3e1727613916_add_document_web_uri_column.py
@@ -1,0 +1,24 @@
+"""
+Add document web_uri column
+
+Revision ID: 3e1727613916
+Revises: a001b7b4c78e
+Create Date: 2016-09-12 13:21:56.739838
+"""
+
+from __future__ import unicode_literals
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '3e1727613916'
+down_revision = 'a001b7b4c78e'
+
+
+def upgrade():
+    op.add_column('document', sa.Column('web_uri', sa.UnicodeText()))
+
+
+def downgrade():
+    op.drop_column('document', 'web_uri')


### PR DESCRIPTION
This represents the denormalized version of the first document uri
having the `http` or `https` scheme.

**If #3855 gets merged before this, then this needs rebasing (putting the migration into the correct timeline, otherwise vice versa.**