### PR TITLE
Denormalize document web uri

### DIFF
--- a/h/activity/bucketing.py
+++ b/h/activity/bucketing.py
@@ -24,8 +24,8 @@ class DocumentBucket(object):
 
         self.title = document.title
 
-        parsed = self._find_http_or_https_uri(document)
-        if parsed:
+        if document.web_uri:
+            parsed = urlparse.urlparse(document.web_uri)
             self.uri = parsed.geturl()
             self.domain = parsed.netloc
         else:
@@ -46,14 +46,6 @@ class DocumentBucket(object):
     def update(self, annotations):
         for annotation in annotations:
             self.append(annotation)
-
-    def _find_http_or_https_uri(self, document):
-        for docuri in document.document_uris:
-            uri = urlparse.urlparse(docuri.uri)
-            if uri.scheme in ['http', 'https']:
-                return uri
-
-        return None
 
     def __eq__(self, other):
         return (

--- a/h/activity/query.py
+++ b/h/activity/query.py
@@ -168,8 +168,7 @@ def _execute_search(request, query, page_size):
 @newrelic.agent.function_trace()
 def _fetch_annotations(session, ids):
     return (session.query(Annotation)
-            .options(subqueryload(Annotation.document)
-                     .subqueryload(Document.document_uris))
+            .options(subqueryload(Annotation.document))
             .filter(Annotation.id.in_(ids))
             .order_by(Annotation.updated.desc()))
 

--- a/h/migrations/versions/a44ef07b085a_fill_in_missing_denormalized_document_web_uri.py
+++ b/h/migrations/versions/a44ef07b085a_fill_in_missing_denormalized_document_web_uri.py
@@ -1,0 +1,92 @@
+"""
+Fill in missing denormalized Document.web_uri
+
+Revision ID: a44ef07b085a
+Revises: 58bb601c390f
+Create Date: 2016-09-12 15:31:00.597582
+"""
+
+from __future__ import unicode_literals
+
+from collections import namedtuple
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import subqueryload
+
+from memex._compat import urlparse
+
+
+revision = 'a44ef07b085a'
+down_revision = '58bb601c390f'
+
+Base = declarative_base()
+Session = sessionmaker()
+
+
+class Window(namedtuple('Window', ['start', 'end'])):
+    pass
+
+
+class Document(Base):
+    __tablename__ = 'document'
+    id = sa.Column(sa.Integer, primary_key=True)
+    updated = sa.Column(sa.DateTime)
+    web_uri = sa.Column(sa.UnicodeText())
+    document_uris = sa.orm.relationship('DocumentURI',
+                                        backref='document',
+                                        order_by='DocumentURI.updated.desc()')
+
+
+class DocumentURI(Base):
+    __tablename__ = 'document_uri'
+    id = sa.Column(sa.Integer, primary_key=True)
+    updated = sa.Column(sa.DateTime)
+    uri = sa.Column(sa.UnicodeText)
+    document_id = sa.Column(sa.Integer,
+                            sa.ForeignKey('document.id'),
+                            nullable=False)
+
+
+def upgrade():
+    session = Session(bind=op.get_bind())
+
+    windows = _fetch_windows(session)
+    session.rollback()
+
+    for window in windows:
+        query = session.query(Document) \
+            .filter(Document.updated.between(window.start, window.end)) \
+            .options(subqueryload(Document.document_uris)) \
+            .order_by(Document.updated.asc())
+
+        for doc in query:
+            doc.web_uri = _document_web_uri(doc)
+
+        session.commit()
+
+
+def downgrade():
+    pass
+
+
+def _document_web_uri(document):
+    for docuri in document.document_uris:
+        uri = urlparse.urlparse(docuri.uri)
+        if uri.scheme in ['http', 'https']:
+            return docuri.uri
+
+
+def _fetch_windows(session, chunksize=100):
+    updated = session.query(Document.updated). \
+        execution_options(stream_results=True). \
+        order_by(Document.updated.desc()).all()
+
+    count = len(updated)
+    windows = [Window(start=updated[min(x+chunksize, count)-1].updated,
+                      end=updated[x].updated)
+               for x in xrange(0, count, chunksize)]
+
+    return windows

--- a/h/migrations/versions/a44ef07b085a_fill_in_missing_denormalized_document_web_uri.py
+++ b/h/migrations/versions/a44ef07b085a_fill_in_missing_denormalized_document_web_uri.py
@@ -37,13 +37,13 @@ class Document(Base):
     web_uri = sa.Column(sa.UnicodeText())
     document_uris = sa.orm.relationship('DocumentURI',
                                         backref='document',
-                                        order_by='DocumentURI.updated.desc()')
+                                        order_by='DocumentURI.created.asc()')
 
 
 class DocumentURI(Base):
     __tablename__ = 'document_uri'
     id = sa.Column(sa.Integer, primary_key=True)
-    updated = sa.Column(sa.DateTime)
+    created = sa.Column(sa.DateTime)
     uri = sa.Column(sa.UnicodeText)
     document_id = sa.Column(sa.Integer,
                             sa.ForeignKey('document.id'),

--- a/src/memex/models/document.py
+++ b/src/memex/models/document.py
@@ -13,6 +13,7 @@ from sqlalchemy.ext.hybrid import hybrid_property
 from memex.db import Base
 from memex.db import mixins
 from memex.uri import normalize as uri_normalize
+from memex._compat import urlparse
 
 
 log = logging.getLogger(__name__)
@@ -278,6 +279,11 @@ def create_or_update_document_uri(session,
                  docuri.id, docuri.document_id, document.id)
 
     docuri.updated = updated
+
+    if not document.web_uri:
+        parsed = urlparse.urlparse(uri)
+        if parsed.scheme in ['http', 'https']:
+            document.web_uri = uri
 
     try:
         session.flush()

--- a/src/memex/models/document.py
+++ b/src/memex/models/document.py
@@ -30,6 +30,9 @@ class Document(Base, mixins.Timestamps):
     #: The denormalized value of the first DocumentMeta record with type title.
     title = sa.Column('title', sa.UnicodeText())
 
+    #: The denormalized value of the first http(s) DocumentURI
+    web_uri = sa.Column('web_uri', sa.UnicodeText())
+
     # FIXME: This relationship should be named `uris` again after the
     #        dependency on the annotator-store is removed, as it clashes with
     #        making the Postgres and Elasticsearch interface of a Document

--- a/tests/h/activity/bucketing_test.py
+++ b/tests/h/activity/bucketing_test.py
@@ -45,46 +45,20 @@ class TestDocumentBucket(object):
         bucket = bucketing.DocumentBucket(document)
         assert bucket.title == 'The Document Title'
 
-    def test_init_extracts_the_first_http_uri(self, db_session, document):
-        docuri_pdf = factories.DocumentURI(uri='urn:x-pdf:fingerprint',
-                                           updated=datetime.datetime(2016, 5, 2),
-                                           document=document)
-        docuri_http = factories.DocumentURI(uri='http://example.com',
-                                            updated=datetime.datetime(2016, 5, 1),
-                                            document=document)
-        db_session.add_all([docuri_pdf, docuri_http])
-        db_session.flush()
+    def test_init_uses_the_document_web_uri(self, db_session, document):
+        document.web_uri = 'http://example.com'
 
         bucket = bucketing.DocumentBucket(document)
         assert bucket.uri == 'http://example.com'
 
-    def test_init_extracts_the_first_https_uri(self, db_session, document):
-        docuri_pdf = factories.DocumentURI(uri='urn:x-pdf:fingerprint',
-                                           updated=datetime.datetime(2016, 5, 2),
-                                           document=document)
-        docuri_https = factories.DocumentURI(uri='https://example.com',
-                                             updated=datetime.datetime(2016, 5, 1),
-                                             document=document)
-        db_session.add_all([docuri_pdf, docuri_https])
-        db_session.flush()
-
-        bucket = bucketing.DocumentBucket(document)
-        assert bucket.uri == 'https://example.com'
-
     def test_init_sets_None_uri_when_no_http_or_https_can_be_found(self, db_session, document):
-        docuri_pdf = factories.DocumentURI(uri='urn:x-pdf:fingerprint',
-                                           document=document)
-        db_session.add(docuri_pdf)
-        db_session.flush()
+        document.web_uri = None
 
         bucket = bucketing.DocumentBucket(document)
         assert bucket.uri is None
 
     def test_init_sets_the_domain_from_the_extracted_uri(self, db_session, document):
-        docuri_https = factories.DocumentURI(uri='https://www.example.com/foobar.html',
-                                             document=document)
-        db_session.add(docuri_https)
-        db_session.flush()
+        document.web_uri = 'https://www.example.com/foobar.html'
 
         bucket = bucketing.DocumentBucket(document)
         assert bucket.domain == 'www.example.com'


### PR DESCRIPTION
There are only a few document meta and document URI records that we actually need to display. So this pull request is to denormalize the document's first `http` or `https` URI onto the document itself when a new document gets created, or when an existing document gets updated and its missing the `web_uri`. We can save ourselves some extra queries on the document_uri table when reading from the database.