### PR TITLE
Disallow empty document titles

### DIFF
--- a/h/migrations/versions/3d71ec81d18c_delete_empty_document_titles.py
+++ b/h/migrations/versions/3d71ec81d18c_delete_empty_document_titles.py
@@ -1,0 +1,57 @@
+"""
+Delete empty-string document titles.
+
+Revision ID: 3d71ec81d18c
+Revises: 6964a8237c88
+Create Date: 2016-09-14 16:03:41.490371
+"""
+from __future__ import unicode_literals
+
+import logging
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql as pg
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import sessionmaker
+
+
+revision = '3d71ec81d18c'
+down_revision = '6964a8237c88'
+
+
+log = logging.getLogger(__name__)
+
+
+Base = declarative_base()
+Session = sessionmaker()
+
+
+class DocumentMeta(Base):
+    __tablename__ = 'document_meta'
+    id = sa.Column(sa.Integer, autoincrement=True, primary_key=True)
+    type = sa.Column(sa.UnicodeText)
+    value = sa.Column(pg.ARRAY(sa.UnicodeText, zero_indexes=True))
+
+
+def upgrade():
+    session = Session(bind=op.get_bind())
+    n = 0
+    for document_meta in session.query(DocumentMeta).filter_by(type='title'):
+        new_titles = []
+        for original_title in document_meta.value:
+            if original_title == '':
+                n += 1
+                log.info(
+                    "removing empty title from document_meta {id}".format(
+                        id=document_meta.id))
+            else:
+                new_titles.append(original_title)
+        if len(new_titles) != len(document_meta.value):
+            document_meta.value = new_titles
+    session.commit()
+    log.info("deleted {n} empty-string document titles".format(n=n))
+
+
+def downgrade():
+    pass

--- a/h/migrations/versions/5e535a075f16_remove_null_document_titles.py
+++ b/h/migrations/versions/5e535a075f16_remove_null_document_titles.py
@@ -1,0 +1,57 @@
+"""
+Remove null document titles.
+
+Revision ID: 5e535a075f16
+Revises: a44ef07b085a
+Create Date: 2016-09-14 15:11:26.551596
+"""
+from __future__ import unicode_literals
+
+import logging
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql as pg
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import sessionmaker
+
+
+revision = '5e535a075f16'
+down_revision = 'a44ef07b085a'
+
+
+log = logging.getLogger(__name__)
+
+
+Base = declarative_base()
+Session = sessionmaker()
+
+
+class DocumentMeta(Base):
+    __tablename__ = 'document_meta'
+    id = sa.Column(sa.Integer, autoincrement=True, primary_key=True)
+    type = sa.Column(sa.UnicodeText)
+    value = sa.Column(pg.ARRAY(sa.UnicodeText, zero_indexes=True))
+
+
+def upgrade():
+    session = Session(bind=op.get_bind())
+    n = 0
+    for document_meta in session.query(DocumentMeta).filter_by(type='title'):
+        new_titles = []
+        for original_title in document_meta.value:
+            if original_title is None:
+                n += 1
+                log.info(
+                    "removing null title from document_meta {id}".format(
+                        id=document_meta.id))
+            else:
+                new_titles.append(original_title)
+        if len(new_titles) != len(document_meta.value):
+            document_meta.value = new_titles
+    session.commit()
+    log.info("deleted {n} null document titles".format(n=n))
+
+
+def downgrade():
+    pass

--- a/h/migrations/versions/6964a8237c88_strip_whitespace_from_document_titles.py
+++ b/h/migrations/versions/6964a8237c88_strip_whitespace_from_document_titles.py
@@ -1,0 +1,60 @@
+"""
+strip whitespace from document titles
+
+Revision ID: 6964a8237c88
+Revises: 5e535a075f16
+Create Date: 2016-09-14 15:17:23.096224
+"""
+from __future__ import unicode_literals
+
+import logging
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql as pg
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import sessionmaker
+
+
+revision = '6964a8237c88'
+down_revision = '5e535a075f16'
+
+
+log = logging.getLogger(__name__)
+
+
+Base = declarative_base()
+Session = sessionmaker()
+
+
+class DocumentMeta(Base):
+    __tablename__ = 'document_meta'
+    id = sa.Column(sa.Integer, autoincrement=True, primary_key=True)
+    type = sa.Column(sa.UnicodeText)
+    value = sa.Column(pg.ARRAY(sa.UnicodeText, zero_indexes=True))
+
+
+def upgrade():
+    session = Session(bind=op.get_bind())
+    n = 0
+    for document_meta in session.query(DocumentMeta).filter_by(type='title'):
+        new_titles = []
+        for original_title in document_meta.value:
+            stripped_title = original_title.strip()
+            if original_title != stripped_title:
+                n += 1
+                log.info(
+                    "updated '{original_title}' to '{stripped_title}'".format(
+                        original_title=original_title,
+                        stripped_title=stripped_title))
+            new_titles.append(stripped_title)
+
+        if new_titles != document_meta.value:
+            document_meta.value = new_titles
+
+    session.commit()
+    log.info("updated {n} document titles".format(n=n))
+
+
+def downgrade():
+    pass

--- a/h/migrations/versions/6d9257ad610d_delete_empty_array_document_titles.py
+++ b/h/migrations/versions/6d9257ad610d_delete_empty_array_document_titles.py
@@ -1,0 +1,51 @@
+"""
+Delete document_meta rows that have type 'title' and an empty array value.
+
+Revision ID: 6d9257ad610d
+Revises: 3d71ec81d18c
+Create Date: 2016-09-14 16:06:33.439592
+"""
+from __future__ import unicode_literals
+
+import logging
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql as pg
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import sessionmaker
+
+
+revision = '6d9257ad610d'
+down_revision = '3d71ec81d18c'
+
+
+log = logging.getLogger(__name__)
+
+
+Base = declarative_base()
+Session = sessionmaker()
+
+
+class DocumentMeta(Base):
+    __tablename__ = 'document_meta'
+    id = sa.Column(sa.Integer, autoincrement=True, primary_key=True)
+    type = sa.Column(sa.UnicodeText)
+    value = sa.Column(pg.ARRAY(sa.UnicodeText, zero_indexes=True))
+
+
+def upgrade():
+    session = Session(bind=op.get_bind())
+    to_delete = []
+    for document_meta in session.query(DocumentMeta).filter_by(type='title'):
+        if document_meta.value == []:
+            to_delete.append(document_meta)
+    for document_meta in to_delete:
+        session.delete(document_meta)
+    session.commit()
+    log.info("deleted {n} empty-array document titles".format(
+        n=len(to_delete)))
+
+
+def downgrade():
+    pass

--- a/src/memex/parse_document_claims.py
+++ b/src/memex/parse_document_claims.py
@@ -101,7 +101,10 @@ def document_metas_from_data(document_data, claimant):
                 if not isinstance(value, list):
                     value = [value]
 
-                value = [v.strip() for v in value]
+                value = [v.strip() for v in value if v and v.strip()]
+
+                if not value:
+                    continue
 
                 document_meta_dicts.append({
                     'type': '.'.join(keypath),

--- a/src/memex/parse_document_claims.py
+++ b/src/memex/parse_document_claims.py
@@ -101,6 +101,8 @@ def document_metas_from_data(document_data, claimant):
                 if not isinstance(value, list):
                     value = [value]
 
+                value = [v.strip() for v in value]
+
                 document_meta_dicts.append({
                     'type': '.'.join(keypath),
                     'value': value,

--- a/src/memex/parse_document_claims.py
+++ b/src/memex/parse_document_claims.py
@@ -101,13 +101,18 @@ def document_metas_from_data(document_data, claimant):
                 if not isinstance(value, list):
                     value = [value]
 
-                value = [v.strip() for v in value if v and v.strip()]
+                type_ = '.'.join(keypath)
 
-                if not value:
-                    continue
+                if type_ == 'title':
+                    # We don't allow None, empty strings, whitespace-only
+                    # strings, leading or trailing whitespaces, or empty arrays
+                    # in document title values.
+                    value = [v.strip() for v in value if v and v.strip()]
+                    if not value:
+                        continue
 
                 document_meta_dicts.append({
-                    'type': '.'.join(keypath),
+                    'type': type_,
                     'value': value,
                     'claimant': claimant,
                 })

--- a/tests/memex/parse_document_claims_test.py
+++ b/tests/memex/parse_document_claims_test.py
@@ -201,11 +201,15 @@ class TestDocumentMetasFromData(object):
         # Leading and trailing whitespace gets stripped from document titles.
         (
             {
-                'title': ['   My Document', 'My Document   ', ' My Document '],
+                'title': ['   My Document',
+                          'My Document   ',
+                          ' My Document ',
+                          '\nMy Document\n\n'],
             },
             {
                 'type': 'title',
-                'value': ['My Document', 'My Document', 'My Document']
+                'value': ['My Document', 'My Document', 'My Document',
+                          'My Document']
             }
         ),
     ])
@@ -260,6 +264,36 @@ class TestDocumentMetasFromData(object):
                 'value': [value],
                 'claimant': claimant,
                 } in document_metas
+
+    def test_document_metas_from_data_ignores_null_titles(self):
+        """It should ignore null document titles."""
+        for title in (None, [None, None]):
+            document_data = {'title': title}
+
+            document_metas = parse_document_claims.document_metas_from_data(
+                document_data, 'http://example/claimant')
+
+            assert document_metas == []
+
+    def test_document_metas_from_data_ignores_empty_string_titles(self):
+        """It should ignore empty document titles."""
+        for title in ('', ['', '']):
+            document_data = {'title': title}
+
+            document_metas = parse_document_claims.document_metas_from_data(
+                document_data, 'http://example/claimant')
+
+            assert document_metas == []
+
+    def test_document_metas_from_data_ignores_whitespace_only_titles(self):
+        """It should ignore whitespace-only document titles."""
+        for title in (' ', [' ', ' '], '\n\n  \n'):
+            document_data = {'title': title}
+
+            document_metas = parse_document_claims.document_metas_from_data(
+                document_data, 'http://example/claimant')
+
+            assert document_metas == []
 
 
 class TestDocumentURIsFromHighwirePDF(object):

--- a/tests/memex/parse_document_claims_test.py
+++ b/tests/memex/parse_document_claims_test.py
@@ -196,7 +196,18 @@ class TestDocumentMetasFromData(object):
                 'type': 'foo.bar',
                 'value': ['string']
             }
-        )
+        ),
+
+        # Leading and trailing whitespace gets stripped from document titles.
+        (
+            {
+                'title': ['   My Document', 'My Document   ', ' My Document '],
+            },
+            {
+                'type': 'title',
+                'value': ['My Document', 'My Document', 'My Document']
+            }
+        ),
     ])
     def test_document_metas_from_data(self, input_, output):
         claimant = 'http://example.com/claimant/'

--- a/tests/memex/parse_document_claims_test.py
+++ b/tests/memex/parse_document_claims_test.py
@@ -204,12 +204,34 @@ class TestDocumentMetasFromData(object):
                 'title': ['   My Document',
                           'My Document   ',
                           ' My Document ',
-                          '\nMy Document\n\n'],
+                          '\nMy Document\n\n',
+                          '\rMy Document\r\n',
+                          '\tMy Document \t \t '],
+
             },
             {
                 'type': 'title',
                 'value': ['My Document', 'My Document', 'My Document',
-                          'My Document']
+                          'My Document', 'My Document', 'My Document']
+            }
+        ),
+
+        # Leading and trailing whitespace does not get-stripped from non-titles.
+        (
+            {
+                'foo': ['   My Document',
+                          'My Document   ',
+                          ' My Document ',
+                          '\nMy Document\n\n',
+                          '\rMy Document\r\n',
+                          '\tMy Document \t \t '],
+
+            },
+            {
+                'type': 'foo',
+                'value': ['   My Document', 'My Document   ', ' My Document ',
+                          '\nMy Document\n\n', '\rMy Document\r\n',
+                          '\tMy Document \t \t ']
             }
         ),
     ])
@@ -275,6 +297,24 @@ class TestDocumentMetasFromData(object):
 
             assert document_metas == []
 
+    def test_document_metas_from_data_allows_null_non_titles(self):
+        """Null values are allowed if 'type' isn't 'title'."""
+        for value in (None, [None, None]):
+            document_data = {'foo': value}
+
+            document_metas = parse_document_claims.document_metas_from_data(
+                document_data, 'http://example/claimant')
+
+            if not isinstance(value, list):
+                # We expect it to turn non-lists into length-1 lists.
+                value = [value]
+
+            assert document_metas == [{
+                'type': 'foo',
+                'value': value,
+                'claimant': 'http://example/claimant',
+            }]
+
     def test_document_metas_from_data_ignores_empty_string_titles(self):
         """It should ignore empty document titles."""
         for title in ('', ['', '']):
@@ -285,6 +325,24 @@ class TestDocumentMetasFromData(object):
 
             assert document_metas == []
 
+    def test_document_metas_from_data_allows_empty_string_non_titles(self):
+        """Empty strings are allowed if 'type' isn't 'title'."""
+        for value in ('', ['', '']):
+            document_data = {'foo': value}
+
+            document_metas = parse_document_claims.document_metas_from_data(
+                document_data, 'http://example/claimant')
+
+            if not isinstance(value, list):
+                # We expect it to turn non-lists into length-1 lists.
+                value = [value]
+
+            assert document_metas == [{
+                'type': 'foo',
+                'value': value,
+                'claimant': 'http://example/claimant',
+            }]
+
     def test_document_metas_from_data_ignores_whitespace_only_titles(self):
         """It should ignore whitespace-only document titles."""
         for title in (' ', [' ', ' '], '\n\n  \n'):
@@ -294,6 +352,24 @@ class TestDocumentMetasFromData(object):
                 document_data, 'http://example/claimant')
 
             assert document_metas == []
+
+    def test_document_metas_from_data_allows_whitespace_only_non_titles(self):
+        """Whitespace-only strings are allowed if 'type' isn't 'title'."""
+        for value in (' ', [' ', ' '], '\n\n  \n'):
+            document_data = {'foo': value}
+
+            document_metas = parse_document_claims.document_metas_from_data(
+                document_data, 'http://example/claimant')
+
+            if not isinstance(value, list):
+                # We expect it to turn non-lists into length-1 lists.
+                value = [value]
+
+            assert document_metas == [{
+                'type': 'foo',
+                'value': value,
+                'claimant': 'http://example/claimant',
+            }]
 
 
 class TestDocumentURIsFromHighwirePDF(object):


### PR DESCRIPTION
This prevents creation of `None`, `''`, whitespace-only strings and strings with leading and/or trailing whitespace as document titles, and removes and fixes these kinds of document titles that are already in the db. This will make it a lot easier for activity pages and future features to display documents without lots of edge cases where the display looks wrong - a document's title is always either `None` or a non-empty string.

On master, I can create documents with whitespace-only titles:

```bash
$ http POST 'http://localhost:5000/api/annotations' Authorization:'Bearer 6879-***' uri='foo' document:='{"title": " "}' | jq .document.title
[
  " "
]
```

Or with leading and/or trailing whitespace on the document title:

```bash
http POST 'http://localhost:5000/api/annotations' Authorization:'Bearer 6879-***' uri='bar' document:='{"title": " Title "}' | jq .document.title
[
  " Title "
]
```

It doesn't actually seem to be possible to create a `None` or empty string document title by posting to this API, but instances of both do somehow exist in our production database:

```sql
postgres=# SELECT count(*) FROM document_meta WHERE type = 'title' AND '' = ANY(value);
 count 
-------
   881
(1 row)
```

```python
In [3]: len([d for d in request.db.query(models.DocumentMeta).filter_by(type=u'title') if None in d.value])
Out[3]: 335
```

There aren't any `document_meta` rows whose `value` cell is an empty array, but after deleting `None` and `''` and whitespace-only strings from the arrays there will be, so the migrations remove those as well.

I've tested the db migrations here on prod data and looked at all the deleted and changed document metas - looks as expected.

Anyway, on this branch none of these kinds of document titles will be created anymore:

```bash
http POST 'http://localhost:5000/api/annotations' Authorization:'Bearer 6879-***' uri='fi' document:='{"title": " "}' | jq .document
{}
```

```bash
http POST 'http://localhost:5000/api/annotations' Authorization:'Bearer 6879-***' uri='fy' document:='{"title": " Leading whitespace"}' | jq .document
{
  "title": [
    "Leading whitespace"
  ]
}
```

```bash
http POST 'http://localhost:5000/api/annotations' Authorization:'Bearer 6879-***' uri='fo' document:='{"title": "Trailing whitespace "}' | jq .document
{
  "title": [
    "Trailing whitespace"
  ]
}
```

```bash
http POST 'http://localhost:5000/api/annotations' Authorization:'Bearer 6879-***' uri='fumb' document:='{"title": ""}' | jq .document
{}
```

```bash
http POST 'http://localhost:5000/api/annotations' Authorization:'Bearer 6879-***' uri='fum' document:='{"title": null}' | jq .document
{}
```

The validation that achieves this is in `parse_document_claims.py` rather than in the model. I did try to add a second layer of validation to the model code as well but it was complicated by two factors: 1. I only want to filter out these kinds of values when the `type` is `'title'` and 2. `value` is an array which can be initialized, set, appended to, inserted into etc and all cases would need to be validated (but only when `type` is `'title'`).