### PR TITLE
Execute query in _fetch_annotations

### DIFF
--- a/h/activity/query.py
+++ b/h/activity/query.py
@@ -108,7 +108,7 @@ def execute(request, query, page_size):
     # Load all referenced annotations from the database, bucket them, and add
     # the buckets to result.timeframes.
     anns = _fetch_annotations(request.db, search_result.annotation_ids)
-    result.timeframes.extend(bucketing.bucket(anns.all()))
+    result.timeframes.extend(bucketing.bucket(anns))
 
     # Fetch all groups
     group_pubids = set([a.groupid
@@ -170,7 +170,7 @@ def _fetch_annotations(session, ids):
     return (session.query(Annotation)
             .options(subqueryload(Annotation.document))
             .filter(Annotation.id.in_(ids))
-            .order_by(Annotation.updated.desc()))
+            .order_by(Annotation.updated.desc()).all())
 
 
 @newrelic.agent.function_trace()

--- a/tests/h/activity/query_test.py
+++ b/tests/h/activity/query_test.py
@@ -310,9 +310,8 @@ class TestExecute(object):
                                         search):
         result = execute(pyramid_request, MultiDict(), self.PAGE_SIZE)
 
-        _fetch_annotations.return_value.all.assert_called_once_with()
         bucketing.bucket.assert_called_once_with(
-            _fetch_annotations.return_value.all.return_value)
+            _fetch_annotations.return_value)
         assert result.timeframes == bucketing.bucket.return_value
 
     def test_it_fetches_the_groups_from_the_database(self,


### PR DESCRIPTION
This way we get a more accurate breakout in New Relic of where time is
spent.