### PR TITLE
Index document web_uri

### DIFF
--- a/src/memex/presenters.py
+++ b/src/memex/presenters.py
@@ -93,7 +93,7 @@ class AnnotationSearchIndexPresenter(AnnotationBasePresenter):
         self.annotation = annotation
 
     def asdict(self):
-        docpresenter = DocumentJSONPresenter(self.annotation.document)
+        docpresenter = DocumentSearchIndexPresenter(self.annotation.document)
 
         base = {
             'id': self.annotation.id,

--- a/src/memex/presenters.py
+++ b/src/memex/presenters.py
@@ -190,6 +190,24 @@ class DocumentJSONPresenter(object):
         return d
 
 
+class DocumentSearchIndexPresenter(object):
+    def __init__(self, document):
+        self.document = document
+
+    def asdict(self):
+        if not self.document:
+            return {}
+
+        d = {}
+        if self.document.title:
+            d['title'] = [self.document.title]
+
+        if self.document.web_uri:
+            d['web_uri'] = self.document.web_uri
+
+        return d
+
+
 def utc_iso8601(datetime):
     return datetime.strftime('%Y-%m-%dT%H:%M:%S.%f+00:00')
 

--- a/tests/memex/presenters_test.py
+++ b/tests/memex/presenters_test.py
@@ -186,10 +186,10 @@ class TestAnnotationJSONPresenter(object):
         return patch('memex.presenters.DocumentJSONPresenter.asdict')
 
 
-@pytest.mark.usefixtures('DocumentJSONPresenter')
+@pytest.mark.usefixtures('DocumentSearchIndexPresenter')
 class TestAnnotationSearchIndexPresenter(object):
 
-    def test_asdict(self, DocumentJSONPresenter):
+    def test_asdict(self, DocumentSearchIndexPresenter):
         annotation = mock.Mock(
             id='xyz123',
             created=datetime.datetime(2016, 2, 24, 18, 3, 25, 768),
@@ -204,7 +204,7 @@ class TestAnnotationSearchIndexPresenter(object):
             target_selectors=[{'TestSelector': 'foobar'}],
             references=['referenced-id-1', 'referenced-id-2'],
             extra={'extra-1': 'foo', 'extra-2': 'bar'})
-        DocumentJSONPresenter.return_value.asdict.return_value = {'foo': 'bar'}
+        DocumentSearchIndexPresenter.return_value.asdict.return_value = {'foo': 'bar'}
 
         annotation_dict = AnnotationSearchIndexPresenter(annotation).asdict()
 
@@ -273,8 +273,8 @@ class TestAnnotationSearchIndexPresenter(object):
             'http://example.com/normalized']
 
     @pytest.fixture
-    def DocumentJSONPresenter(self, patch):
-        class_ = patch('memex.presenters.DocumentJSONPresenter')
+    def DocumentSearchIndexPresenter(self, patch):
+        class_ = patch('memex.presenters.DocumentSearchIndexPresenter')
         class_.return_value.asdict.return_value = {}
         return class_
 

--- a/tests/memex/presenters_test.py
+++ b/tests/memex/presenters_test.py
@@ -11,6 +11,7 @@ from memex.presenters import AnnotationJSONPresenter
 from memex.presenters import AnnotationSearchIndexPresenter
 from memex.presenters import AnnotationJSONLDPresenter
 from memex.presenters import DocumentJSONPresenter
+from memex.presenters import DocumentSearchIndexPresenter
 from memex.presenters import utc_iso8601, deep_merge_dict
 
 
@@ -381,6 +382,21 @@ class TestDocumentJSONPresenter(object):
 
         presenter = DocumentJSONPresenter(document)
         assert {'title': ['Foo']} == presenter.asdict()
+
+
+class TestDocumentSearchIndexPresenter(object):
+    @pytest.mark.parametrize('document,expected', [
+        (models.Document(title='Foo'), {'title': ['Foo']}),
+        (models.Document(title=''), {}),
+        (models.Document(title=None), {}),
+        (models.Document(web_uri='http://foo.org'), {'web_uri': 'http://foo.org'}),
+        (models.Document(web_uri=''), {}),
+        (models.Document(web_uri=None), {}),
+        (models.Document(title='Foo', web_uri='http://foo.org'), {'title': ['Foo'], 'web_uri': 'http://foo.org'}),
+        (None, {})
+    ])
+    def test_asdict(self, document, expected):
+        assert expected == DocumentSearchIndexPresenter(document).asdict()
 
 
 def test_utc_iso8601():


### PR DESCRIPTION
This is part one of fixing #3867. It will add the new `web_uri` value to the search index. Part two will be changing bouncer to read from that field instead of looping through the document links (that don't exist anymore).