### PR TITLE
Improve validation of document uris

### DIFF
--- a/src/memex/parse_document_claims.py
+++ b/src/memex/parse_document_claims.py
@@ -58,6 +58,13 @@ def document_uris_from_data(document_data, claimant):
 
     document_uris.append(document_uri_self_claim(claimant))
 
+    for document_uri in document_uris:
+        uri = document_uri['uri']
+        if uri:
+            document_uri['uri'] = uri.strip()
+
+    document_uris = [d for d in document_uris if d['uri']]
+
     return document_uris
 
 

--- a/src/memex/parse_document_claims.py
+++ b/src/memex/parse_document_claims.py
@@ -209,13 +209,12 @@ def document_uris_from_highwire_doi(highwire_dict, claimant):
     document_uris = []
     hwdoivalues = highwire_dict.get('doi', [])
     for doi in hwdoivalues:
-        if not doi.startswith('doi:'):
-            doi = "doi:{}".format(doi)
-
-        document_uris.append({'claimant': claimant,
-                              'uri': doi,
-                              'type': 'highwire-doi',
-                              'content_type': ''})
+        doi = doi_uri_from_string(doi)
+        if doi is not None:
+            document_uris.append({'claimant': claimant,
+                                  'uri': doi,
+                                  'type': 'highwire-doi',
+                                  'content_type': ''})
     return document_uris
 
 
@@ -231,22 +230,12 @@ def document_uris_from_dc(dc_dict, claimant):
     document_uris = []
     dcdoivalues = dc_dict.get('identifier', [])
     for doi in dcdoivalues:
-        doi = doi.strip()
-
-        if doi.startswith('doi:'):
-            doi = doi[len('doi:'):]
-
-        doi = doi.strip()
-
-        if not doi:
-            continue
-
-        doi = 'doi:{}'.format(doi)
-
-        document_uris.append({'claimant': claimant,
-                              'uri': doi,
-                              'type': 'dc-doi',
-                              'content_type': ''})
+        doi = doi_uri_from_string(doi)
+        if doi is not None:
+            document_uris.append({'claimant': claimant,
+                                  'uri': doi,
+                                  'type': 'dc-doi',
+                                  'content_type': ''})
 
     return document_uris
 
@@ -259,3 +248,32 @@ def document_uri_self_claim(claimant):
         'type': u'self-claim',
         'content_type': '',
     }
+
+
+def doi_uri_from_string(s):
+    """
+    Return the DOI URI from the given user-supplied string, or None.
+
+    Return a string of the format "doi:<id>". Leading and trailing whitespace
+    is stripped from the string as a whole and from the <id> substring.
+
+    If the given string doesn't already start with "doi:" it is prepended.
+
+    If the given string does not contain a DOI URI then None is returned.
+    Examples of strings that do not include a DOI are:
+    '', ' ', 'doi:', 'doi: ', ' doi:', ' doi: '.
+
+    """
+    s = s.strip()
+
+    if s.startswith('doi:'):
+        s = s[len('doi:'):]
+
+    s = s.strip()
+
+    if not s:
+        return None
+
+    s = 'doi:{}'.format(s)
+
+    return s

--- a/src/memex/parse_document_claims.py
+++ b/src/memex/parse_document_claims.py
@@ -231,8 +231,17 @@ def document_uris_from_dc(dc_dict, claimant):
     document_uris = []
     dcdoivalues = dc_dict.get('identifier', [])
     for doi in dcdoivalues:
-        if not doi.startswith('doi:'):
-            doi = "doi:{}".format(doi)
+        doi = doi.strip()
+
+        if doi.startswith('doi:'):
+            doi = doi[len('doi:'):]
+
+        doi = doi.strip()
+
+        if not doi:
+            continue
+
+        doi = 'doi:{}'.format(doi)
 
         document_uris.append({'claimant': claimant,
                               'uri': doi,

--- a/src/memex/schemas.py
+++ b/src/memex/schemas.py
@@ -167,15 +167,17 @@ class CreateAnnotationSchema(object):
     def validate(self, data):
         appstruct = self.structure.validate(data)
 
-        if not appstruct.get('uri', ''):
-            raise ValidationError('uri: ' + _("'uri' is a required property"))
-
         new_appstruct = {}
 
         _remove_protected_fields(appstruct)
 
         new_appstruct['userid'] = self.request.authenticated_userid
-        new_appstruct['target_uri'] = appstruct.pop('uri', u'')
+
+        uri = appstruct.pop('uri', u'').strip()
+        if not uri:
+            raise ValidationError('uri: ' + _("'uri' is a required property"))
+        new_appstruct['target_uri'] = uri
+
         new_appstruct['text'] = appstruct.pop('text', u'')
         new_appstruct['tags'] = appstruct.pop('tags', [])
         new_appstruct['groupid'] = appstruct.pop('group', u'__world__')
@@ -229,7 +231,11 @@ class UpdateAnnotationSchema(object):
         # Fields that are allowed to be updated and that have a different name
         # internally than in the public API.
         if 'uri' in appstruct:
-            new_appstruct['target_uri'] = appstruct.pop('uri')
+            new_uri = appstruct.pop('uri').strip()
+            if not new_uri:
+                raise ValidationError(
+                    'uri: ' + _("'uri' is a required property"))
+            new_appstruct['target_uri'] = new_uri
 
         if 'permissions' in appstruct:
             new_appstruct['shared'] = _shared(appstruct.pop('permissions'),

--- a/tests/common/matchers.py
+++ b/tests/common/matchers.py
@@ -118,4 +118,9 @@ class unordered_list(object):
         self.items = items
 
     def __eq__(self, other):
-        return len(self.items) == len(other) and set(self.items) == set(other)
+        if len(self.items) != len(other):
+            return False
+        for item in self.items:
+            if item not in other:
+                return False
+        return True

--- a/tests/memex/parse_document_claims_test.py
+++ b/tests/memex/parse_document_claims_test.py
@@ -432,6 +432,39 @@ class TestDocumentURIsFromHighwireDOI(object):
         expected_uri = 'doi:' + highwire_dict['doi'][0]
         one([d for d in document_uris if d.get('uri') == expected_uri])
 
+    def test_empty_string_dois_are_ignored(self):
+        for doi in ('', 'doi:'):
+            highwire_dict = {'doi': [doi]}
+
+            document_uris = parse_document_claims.document_uris_from_highwire_doi(
+                highwire_dict,
+                claimant='http://example.com/example.html',
+            )
+
+            assert document_uris == []
+
+    def test_whitespace_only_dois_are_ignored(self):
+        for doi in (' ', 'doi: '):
+            highwire_dict = {'doi': [doi]}
+
+            document_uris = parse_document_claims.document_uris_from_highwire_doi(
+                highwire_dict,
+                claimant='http://example.com/example.html',
+            )
+
+            assert document_uris == []
+
+    def test_whitespace_is_stripped_from_dois(self):
+        for doi in (' foo ', 'doi: foo ', ' doi:foo ', ' doi: foo '):
+            highwire_dict = {'doi': [doi]}
+
+            document_uris = parse_document_claims.document_uris_from_highwire_doi(
+                highwire_dict,
+                claimant='http://example.com/example.html',
+            )
+
+            assert [d['uri'] for d in document_uris] == ['doi:foo']
+
 
 class TestDocumentURIsFromDC(object):
 

--- a/tests/memex/parse_document_claims_test.py
+++ b/tests/memex/parse_document_claims_test.py
@@ -472,6 +472,39 @@ class TestDocumentURIsFromDC(object):
         expected_uri = 'doi:' + dc_dict['identifier'][0]
         one([d for d in document_uris if d.get('uri') == expected_uri])
 
+    def test_empty_string_dois_are_ignored(self):
+        for doi in ('', 'doi:'):
+            dc_dict = {'identifier': [doi]}
+
+            document_uris = parse_document_claims.document_uris_from_dc(
+                dc_dict,
+                claimant='http://example.com/example.html',
+            )
+
+            assert document_uris == []
+
+    def test_whitespace_only_dois_are_ignored(self):
+        for doi in (' ', 'doi: '):
+            dc_dict = {'identifier': [doi]}
+
+            document_uris = parse_document_claims.document_uris_from_dc(
+                dc_dict,
+                claimant='http://example.com/example.html',
+            )
+
+            assert document_uris == []
+
+    def test_whitespace_is_stripped_from_dois(self):
+        for doi in (' foo ', 'doi: foo ', ' doi:foo ', ' doi: foo '):
+            dc_dict = {'identifier': [doi]}
+
+            document_uris = parse_document_claims.document_uris_from_dc(
+                dc_dict,
+                claimant='http://example.com/example.html',
+            )
+
+            assert [d['uri'] for d in document_uris] == ['doi:foo']
+
 
 class TestDocumentURISelfClaim(object):
 

--- a/tests/memex/parse_document_claims_test.py
+++ b/tests/memex/parse_document_claims_test.py
@@ -508,7 +508,7 @@ class TestDocumentURIsFromData(object):
         }
         claimant = 'http://localhost:5000/docs/help'
         document_uris_from_links.return_value = [
-            mock.Mock(), mock.Mock(), mock.Mock()]
+            {'uri': 'uri_1'}, {'uri': 'uri_2'}, {'uri': 'uri_3'}]
 
         document_uris = parse_document_claims.document_uris_from_data(
             document_data=document_data,
@@ -548,7 +548,7 @@ class TestDocumentURIsFromData(object):
         }
         claimant = 'http://localhost:5000/docs/help'
         document_uris_from_highwire_pdf.return_value = [
-            mock.Mock(), mock.Mock(), mock.Mock()]
+            {'uri': 'uri_1'}, {'uri': 'uri_2'}, {'uri': 'uri_3'}]
 
         document_uris = parse_document_claims.document_uris_from_data(
             document_data=document_data,
@@ -588,7 +588,7 @@ class TestDocumentURIsFromData(object):
         }
         claimant = 'http://localhost:5000/docs/help'
         document_uris_from_highwire_doi.return_value = [
-            mock.Mock(), mock.Mock(), mock.Mock()]
+            {'uri': 'uri_1'}, {'uri': 'uri_2'}, {'uri': 'uri_3'}]
 
         document_uris = parse_document_claims.document_uris_from_data(
             document_data=document_data,
@@ -627,7 +627,7 @@ class TestDocumentURIsFromData(object):
         }
         claimant = 'http://localhost:5000/docs/help'
         document_uris_from_dc.return_value = [
-            mock.Mock(), mock.Mock(), mock.Mock()]
+            {'uri': 'uri_1'}, {'uri': 'uri_2'}, {'uri': 'uri_3'}]
 
         document_uris = parse_document_claims.document_uris_from_data(
             document_data=document_data,
@@ -660,6 +660,125 @@ class TestDocumentURIsFromData(object):
 
         document_uri_self_claim.assert_called_once_with(claimant)
         assert document_uri_self_claim.return_value in document_uris
+
+    def test_it_ignores_null_uris(self,
+                                  document_uris_from_links,
+                                  document_uris_from_highwire_pdf,
+                                  document_uris_from_highwire_doi,
+                                  document_uris_from_dc,
+                                  document_uri_self_claim):
+        document_uris_from_links.return_value = [{'uri': None}]
+        document_uris_from_highwire_pdf.return_value = [{'uri': None}]
+        document_uris_from_highwire_doi.return_value = [{'uri': None}]
+        document_uris_from_dc.return_value = [{'uri': None}]
+        document_uri_self_claim.return_value = {'uri': None}
+
+        document_uris = parse_document_claims.document_uris_from_data(
+            {}, 'http://example.com/claimant')
+
+        assert document_uris == []
+
+    def test_it_ignores_empty_string_uris(self,
+                                          document_uris_from_links,
+                                          document_uris_from_highwire_pdf,
+                                          document_uris_from_highwire_doi,
+                                          document_uris_from_dc,
+                                          document_uri_self_claim):
+        document_uris_from_links.return_value = [{'uri': ''}]
+        document_uris_from_highwire_pdf.return_value = [{'uri': ''}]
+        document_uris_from_highwire_doi.return_value = [{'uri': ''}]
+        document_uris_from_dc.return_value = [{'uri': ''}]
+        document_uri_self_claim.return_value = {'uri': ''}
+
+        document_uris = parse_document_claims.document_uris_from_data(
+            {}, 'http://example.com/claimant')
+
+        assert document_uris == []
+
+    def test_it_ignores_whitespace_only_self_claim_uris(
+            self, document_uri_self_claim):
+        for uri in (' ', '\n ', '\r\n', ' \t'):
+            document_uri_self_claim.return_value = {'uri': uri}
+
+            document_uris = parse_document_claims.document_uris_from_data(
+                {}, 'http://example.com/claimant')
+
+            assert document_uris == []
+
+    def test_it_ignores_whitespace_only_uris(self,
+                                             document_uris_from_links,
+                                             document_uris_from_highwire_pdf,
+                                             document_uris_from_highwire_doi,
+                                             document_uris_from_dc,
+                                             document_uri_self_claim):
+        uris = [' ', '\n ', '\r\n', ' \t']
+        document_uris_from_links.return_value = [{'uri': u} for u in uris]
+        document_uris_from_highwire_pdf.return_value = [{'uri': u} for u in uris]
+        document_uris_from_highwire_doi.return_value = [{'uri': u} for u in uris]
+        document_uris_from_dc.return_value = [{'uri': u} for u in uris]
+
+        document_uris = parse_document_claims.document_uris_from_data(
+            {}, 'http://example.com/claimant')
+
+        assert document_uris == [document_uri_self_claim.return_value]
+
+    def test_it_strips_whitespace_from_uris(self,
+                                            document_uris_from_links,
+                                            document_uris_from_highwire_pdf,
+                                            document_uris_from_highwire_doi,
+                                            document_uris_from_dc,
+                                            document_uri_self_claim,
+                                            matchers):
+        document_uris_from_links.return_value = [
+            {'uri': ' from_link_1'},
+            {'uri': 'from_link_2 '},
+            {'uri': ' from_link_3 '}
+        ]
+        document_uris_from_highwire_pdf.return_value = [
+            {'uri': ' highwire_1'},
+            {'uri': 'highwire_2 '},
+            {'uri': ' highwire_3 '}
+        ]
+        document_uris_from_highwire_doi.return_value = [
+            {'uri': ' doi_1'},
+            {'uri': 'doi_2 '},
+            {'uri': ' doi_3 '}
+        ]
+        document_uris_from_dc.return_value = [
+            {'uri': ' dc_1'},
+            {'uri': 'dc_2 '},
+            {'uri': ' dc_3 '}
+        ]
+
+        document_uris = parse_document_claims.document_uris_from_data(
+            {}, 'http://example.com/claimant')
+
+        assert document_uris == matchers.unordered_list([
+            {'uri': 'from_link_1'},
+            {'uri': 'from_link_2'},
+            {'uri': 'from_link_3'},
+            {'uri': 'highwire_1'},
+            {'uri': 'highwire_2'},
+            {'uri': 'highwire_3'},
+            {'uri': 'doi_1'},
+            {'uri': 'doi_2'},
+            {'uri': 'doi_3'},
+            {'uri': 'dc_1'},
+            {'uri': 'dc_2'},
+            {'uri': 'dc_3'},
+            document_uri_self_claim.return_value
+        ])
+
+    def test_it_strips_whitespace_from_self_claim_uris(
+            self, document_uris_from_links, document_uri_self_claim):
+        for uri in (' self_claim', 'self_claim ', ' self_claim '):
+            document_uris_from_links.return_value = []
+            document_uri_self_claim.return_value = {'uri': uri}
+
+            document_uris = parse_document_claims.document_uris_from_data(
+                {}, 'http://example.com/claimant')
+
+            assert document_uris == [{'uri': uri.strip()}]
 
     @pytest.fixture
     def document_uris_from_dc(self, patch):

--- a/tests/memex/schemas_test.py
+++ b/tests/memex/schemas_test.py
@@ -195,6 +195,10 @@ class TestCreateUpdateAnnotationSchema(object):
         ({'text': False}, "text: False is not of type 'string'"),
 
         ({'uri': False}, "uri: False is not of type 'string'"),
+
+        ({'uri': ''}, "uri: 'uri' is a required property"),
+
+        ({'uri': ' '}, "uri: 'uri' is a required property"),
     ])
     def test_it_raises_for_invalid_data(self,
                                         pyramid_request,
@@ -227,6 +231,13 @@ class TestCreateUpdateAnnotationSchema(object):
 
         assert appstruct['target_uri'] == 'http://example.com/example'
         assert 'uri' not in appstruct
+
+    def test_it_strips_leading_and_trailing_whitespace_from_uri(
+            self, pyramid_request, validate):
+        appstruct = validate(pyramid_request,
+                             {'uri': ' foo '})
+
+        assert appstruct['target_uri'] == 'foo'
 
     def test_it_keeps_text(self, pyramid_request, validate):
         appstruct = validate(pyramid_request,
@@ -397,14 +408,6 @@ class TestCreateAnnotationSchema(object):
 
         with pytest.raises(schemas.ValidationError) as exc:
             schema.validate(data)
-
-        assert exc.value.message == "uri: 'uri' is a required property"
-
-    def test_it_raises_if_uri_is_empty_string(self, pyramid_request):
-        schema = schemas.CreateAnnotationSchema(pyramid_request)
-
-        with pytest.raises(schemas.ValidationError) as exc:
-            schema.validate(self.valid_data(uri=''))
 
         assert exc.value.message == "uri: 'uri' is a required property"
 


### PR DESCRIPTION
This doesn't include a db migration to clean up URIs in the db, just validation code to prevent any more messy ones getting in.

Most of the changes here are to not create `document_uri` rows in the db when we would have created them before, or to create `annotation` or `document_uri` rows with whitespace stripped from the `target_uri` and `uri` columns when we wouldn't have stripped the whitespace before. For the most part this PR does not cause the API to reject any requests (e.g. with validation errors) that it would have accepted before. So this shouldn't prevent our client from annotating any documents that it could annotate before.

**Except** in the case of trying to create an annotation with a whitespace-only string as the value of the `uri` field (stored as `target_uri` internally).  That will now be rejected with a validation error, when previously it would have been accepted. But I don't think that should present a problem for our client.

There's a few more ways to create `document_uri` rows in the db than I realised at first (I forgot that we also parse document URIs out of various kinds of metadata about the document that the client sends in annotation create/update requests).

I think the complete list of all of the ways that `document_uri`s get created is:

1. The `annotation.uri` field in annotation create and update requests
2. The `annotation.document.link.href` field in annotation create and update requests
3. The `annotation.document.dc.identifier` field in annotation create and update requests
4. The `annotation.document.highwire.pdf_url` field in annotation create and update requests
5. The `annotation.document.highwire.doi` field in annotation create and update requests

Did I miss any?

Here are the behaviours of those fields on master and on this branch (examples using <https://httpie.org/>) (differences between this branch and master highlighted in bold):

The `annotation.uri` field:

1. `uri:=null` is rejected by `AnnotationSchema` on master (example complete
   httpie command: `http POST 'http://localhost:5000/api/annotations' Authorization:'Bearer 6879-***' uri:=null`).
   Same on this branch.

2. `uri:='""'` rejected by `AnnotationSchema` on master. Same on this branch.

3. `uri=" "` on master creates an `annotation` whose `target_uri` is `" "` and
   creates `document_uri` whose `uri` is `" "`.
   **On this branch: rejected by `AnnotationSchema`**.

4. `uri=" foo "` on master creates an `annotation` whose `target_uri` has
   leading and trailing whitespace and creates a `document_uri` whose `uri` has
   leading and trailing whitespace.
   **On this branch: leading and trailing whitespace is stripped from both
   `annotation.target_uri` and `document_uri.uri`**.

The `annotation.document.link.href` field:

1. `document:='{"link": [{"href": null}]}'` rejected by `AnnotationSchema` on
    master. Example complete httpie command (you have to supply a `uri` as well
    as the `document.link.href` because `uri` is required, this applies to all
    following examples as well):
    `http POST 'http://localhost:5000/api/annotations' Authorization:'Bearer 6879-***' uri='foo' document:='{"link": [{"href": null}]}'`
    Same on this branch.

2. `document:='{"link": [{"href": ""}]}'` on master creates a `document_uri`
   whose `uri` is an empty string. **On this branch: does not create any
   document_uri**.

3. `document:='{"link": [{"href": " "}]}'` on master creates a `document_uri`
   whose `uri` is a whitespace-only string. **On this branch: does not create
   any document_uri**.

4. `document:='{"link": [{"href": " foo "}]}'` on master creates a
   `document_uri` whose `uri` has leading and trailing whitespace.
   **On this branch: whitespace is stripped**.

The `annotation.document.dc.identifier` field:

1. `document:='{"dc": {"identifier": null}}'` is rejected by `AnnotationSchema`
  on master. Same on this branch.

2. `document:='{"dc": {"identifier": [null]}}'` is rejected by
   `AnnotationSchema` on master. Same on this branch.

3. `document:='{"dc": {"identifier": []}}'` doesn't create any
   `document_uri`s on master. Same on this branch.

4. `document:='{"dc": {"identifier": [""]}}` on master creates a `document_uri`
   whose `uri` is `"doi:"`. **On this branch: no document_uri is created**.

5. `document:='{"dc": {"identifier": [" "]}}' on master creates a
   `document_uri` whose `uri` is `"doi: "`. **On this branch: no document_uri
   is created**.

6. `document:='{"dc": {"identifier": [" foo "]}}'` on master creates a
   `document_uri` whose `uri` has leading and trailing whitespace after the
   initial `"doi:`, i.e. `"doi: foo "`. **On this branch: the uri is created
   as `"doi:foo"`** (whitespace stripped before prepending `"doi:"`).

7. `document:='{"dc": {"identifier": ["doi:"]}}'` on master creates a
   `document_uri` whose `uri` is `"doi:"` **On this branch: no `document_uri`
   is created**.

8. `document:='{"dc": {"identifier": ["doi: "]}}'` on master creates a
   `document_uri` whose `uri` is `"doi: "`. **On this branch: no `document_uri`
   is created**.

9. `document:='{"dc": {"identifier": ["doi: foo "]}}'` on master creates a
   `document_uri` whose `uri` has leading and trailing whitespace after the
   initial `"doi:`, i.e. `"doi: foo "`. **On this branch: whitespace is
   stripped**.

10. `document:='{"dc": {"identifier": [" doi:foo"]}}'` on master creates a
    `document_uri` whose `uri` is `"doi: doi:foo"`.
    **On this branch: `"doi:foo"`.

The `annotation.document.highwire.pdf_url` field:

1. `document:='{"highwire": {"pdf_url": null}}'` is rejected by
   `AnnotationSchema` on master. Same on this branch.

2. `document:='{"highwire": {"pdf_url": [null]}}'` is rejected by
   `AnnotationSchema` on master. Same on this branch.

3. `document:='{"highwire": {"pdf_url": []}}'` doesn't create any
   `document_uri`s on master. Same on this branch.

4. `document:='{"highwire": {"pdf_url": [""]}}'` creates an empty-string
   `document_uri` on master. **On this branch: no `document_uri` is created.**

5. `document:='{"highwire": {"pdf_url": [" "]}}'` creates a whitespace-only
   `document_uri` on master. **On this branch: no `document_uri` is created**.

6. `document:='{"highwire": {"pdf_url": [" foo "]}}'` creates a `document_uri`
   with leading and trailing whitespace on master.
   **On this branch: whitespace is stripped**.

The `annotation.document.highwire.doi` field:

1. `document:='{"highwire": {"doi": null}}'` is rejected by `AnnotationSchema`
   on master. Same on this branch.

2. `document:='{"highwire": {"doi": [null]}}'` is rejected by
   `AnnotationSchema` on master. Same on this branch.

3. `document:='{"highwire": {"doi": []}}'` doesn't create any `document_uri`s
   on master. Same on this branch.

4. `document:='{"highwire": {"doi": [""]}}` on master creates a `document_uri`
   whose `uri` is `"doi:"`. **On this branch: no `document_uri` is created**.

5. `document:='{"highwire": {"doi": [" "]}}' on master creates a `document_uri`
   whose `uri` is `"doi: "`. **On this branch: no `document_uri` is created**.

6. `document:='{"highwire": {"doi": [" foo "]}}'` on master creates a
   `document_uri` whose `uri` has leading and trailing whitespace after the
   initial `"doi:`, i.e. `"doi: foo "`.
   **On this branch: whitespace is stripped**.

7. `document:='{"highwire": {"doi": ["doi:"]}}'` on master creates a
   `document_uri` whose `uri` is `"doi:"`.
   **On this branch: no `document_uri` is created**.

8. `document:='{"highwire": {"doi": ["doi: "]}}'` on master creates a
   `document_uri` whose `uri` is `"doi: "`.
   **On this branch: no `document_uri` is created**.

9. `document:='{"highwire": {"doi": ["doi: foo "]}}'` on master creates a
   `document_uri` whose `uri` has leading and trailing whitespace after the
   initial `"doi:`, i.e. `"doi: foo "`.
   **On this branch: `"doi:foo"`**.

10. `document:='{"highwire": {"doi": [" doi:foo"]}}'` on master creates a
    `document_uri` whose `uri` is `"doi: doi:foo"`.
    **On this branch: `"doi:foo"`**.
