### PR TITLE
Load activity replies

### DIFF
--- a/h/activity/query.py
+++ b/h/activity/query.py
@@ -8,7 +8,6 @@ from memex.search import Search
 from memex.search import parser
 from memex.search.query import (
     TagsAggregation,
-    TopLevelAnnotationsFilter,
     UsersAggregation,
 )
 import newrelic.agent
@@ -141,8 +140,7 @@ def aggregations_for(query):
 
 @newrelic.agent.function_trace()
 def _execute_search(request, query, page_size):
-    search = Search(request)
-    search.append_filter(TopLevelAnnotationsFilter())
+    search = Search(request, separate_replies=True)
     for agg in aggregations_for(query):
         search.append_aggregation(agg)
 

--- a/tests/h/activity/query_test.py
+++ b/tests/h/activity/query_test.py
@@ -491,7 +491,7 @@ class TestFetchAnnotations(object):
 
         result = fetch_annotations(db_session, ids)
 
-        assert set(annotations) == set(result)
+        assert annotations == result
 
 
 @pytest.fixture

--- a/tests/h/activity/query_test.py
+++ b/tests/h/activity/query_test.py
@@ -150,7 +150,6 @@ class TestCheckURL(object):
                          'presenters',
                          'Search',
                          'TagsAggregation',
-                         'TopLevelAnnotationsFilter',
                          'UsersAggregation')
 class TestExecute(object):
 
@@ -159,17 +158,7 @@ class TestExecute(object):
     def test_it_creates_a_search_query(self, pyramid_request, Search):
         execute(pyramid_request, MultiDict(), self.PAGE_SIZE)
 
-        Search.assert_called_once_with(pyramid_request)
-
-    def test_it_only_returns_top_level_annotations(self,
-                                                   pyramid_request,
-                                                   search,
-                                                   TopLevelAnnotationsFilter):
-        execute(pyramid_request, MultiDict(), self.PAGE_SIZE)
-
-        TopLevelAnnotationsFilter.assert_called_once_with()
-        search.append_filter.assert_called_once_with(
-            TopLevelAnnotationsFilter.return_value)
+        Search.assert_called_once_with(pyramid_request, separate_replies=True)
 
     def test_it_adds_a_tags_aggregation_to_the_search_query(self,
                                                             pyramid_request,
@@ -488,10 +477,6 @@ class TestExecute(object):
     @pytest.fixture
     def TagsAggregation(self, patch):
         return patch('h.activity.query.TagsAggregation')
-
-    @pytest.fixture
-    def TopLevelAnnotationsFilter(self, patch):
-        return patch('h.activity.query.TopLevelAnnotationsFilter')
 
     @pytest.fixture
     def UsersAggregation(self, patch):


### PR DESCRIPTION
This is just searching Elasticsearch for the replies, and then loading them from the database. It isn't showing them in any way, it isn't even building up the conversation threads. Searching and loading the replies will help us figure out how fast this will be in production.