### PR TITLE
Mark 'selection_tabs' as pending removal

### DIFF
--- a/h/features/models.py
+++ b/h/features/models.py
@@ -17,7 +17,6 @@ FEATURES = {
                                " updates to annotations in the client?"),
     'orphans_tab': "Show the orphans tab to separate anchored and unanchored annotations?",
     'search_page': "Show the activity pages search skeleton page?",
-    'selection_tabs': "Show the tabs to select between annotations and notes?",
 }
 
 # Once a feature has been fully deployed, we remove the flag from the codebase.
@@ -38,7 +37,9 @@ FEATURES = {
 #
 # 4. Finally, remove the feature from FEATURES_PENDING_REMOVAL.
 #
-FEATURES_PENDING_REMOVAL = {}
+FEATURES_PENDING_REMOVAL = {
+    'selection_tabs': "Show the tabs to select between annotations and notes?",
+}
 
 
 class Feature(Base):


### PR DESCRIPTION
This feature flag has been gone from the client for quite a while now. We could probably just remove it, but for the sake of safety we'll follow the standard procedure.