### PR TITLE
Fix DetachedInstanceError from h.sentry

### DIFF
--- a/h/auth/policy.py
+++ b/h/auth/policy.py
@@ -2,6 +2,7 @@
 
 from pyramid import interfaces
 from pyramid.authentication import CallbackAuthenticationPolicy
+import sqlalchemy
 from zope import interface
 
 from h._compat import text_type
@@ -81,7 +82,9 @@ class TokenAuthenticationPolicy(CallbackAuthenticationPolicy):
         :rtype: unicode or None
         """
         token = getattr(request, 'auth_token', None)
-        if token is None or not token.is_valid():
+        if token is None or sqlalchemy.inspect(token).detached:
+            return None
+        if not token.is_valid():
             return None
 
         return token.userid

--- a/tests/h/auth/policy_test.py
+++ b/tests/h/auth/policy_test.py
@@ -4,6 +4,7 @@ import mock
 import pytest
 
 from pyramid.interfaces import IAuthenticationPolicy
+from sqlalchemy.orm.exc import DetachedInstanceError
 
 from h.auth.policy import AuthenticationPolicy
 from h.auth.policy import TokenAuthenticationPolicy
@@ -105,6 +106,7 @@ class TestAuthenticationPolicy(object):
         assert result == self.api_policy.forget.return_value
 
 
+@pytest.mark.usefixtures('sqlalchemy')
 class TestTokenAuthenticationPolicy(object):
     def test_remember_does_nothing(self, pyramid_request):
         policy = TokenAuthenticationPolicy()
@@ -138,6 +140,25 @@ class TestTokenAuthenticationPolicy(object):
 
         assert result is None
 
+    def test_unauthenticated_userid_does_not_crash_on_detached_tokens(
+            self, pyramid_request, sqlalchemy):
+        policy = TokenAuthenticationPolicy()
+
+        # request.auth_token is a detached instance.
+        sqlalchemy.inspect.return_value.detached = True
+
+        # If it tried to call token.is_valid() when token was detached it would
+        # get a DetachedInstanceError from sqlalchemy.
+        token = pyramid_request.auth_token = mock.Mock()
+        token.is_valid.side_effect = DetachedInstanceError()
+
+        # This would raise if the code wasn't aware of the potential for token
+        # to be detached.
+        policy.unauthenticated_userid(pyramid_request)
+
+        # For good measure check that inspect() was called correctly.
+        sqlalchemy.inspect.assert_called_once_with(token)
+
     def test_authenticated_userid_uses_callback(self, fake_token, pyramid_request):
         def callback(userid, request):
             return None
@@ -163,6 +184,12 @@ class TestTokenAuthenticationPolicy(object):
     @pytest.fixture
     def fake_token(self):
         return DummyToken()
+
+    @pytest.fixture
+    def sqlalchemy(self, patch):
+        sqlalchemy = patch('h.auth.policy.sqlalchemy')
+        sqlalchemy.inspect.return_value.detached = False
+        return sqlalchemy
 
 
 class DummyToken(object):


### PR DESCRIPTION
It's possible for h/sentry.py to produce a sqlalchemy
DetachedInstanceError in the case of an aborted sqlalchemy transaction.

For example this HTTP POST:

    http POST 'http://localhost:5000/api/annotations' Authorization:'Bearer 6879-***' uri='http://example.com' document:='{"dclink": [{"identifier": "doi:foo"}]}'

will trigger a separate issue which causes the document model code to
crash with a ProgrammingError from sqlalchemy as it tries to insert a
dict into the document_meta.value column (which is an array of
strings). Sqlalchemy crashes, which aborts the sqlalchemy transaction.

The Sentry crash reporting code then kicks in and tries to report the
ProgrammingError but crashes with a DetachedInstanceError of its own.
Excerpt from the traceback:

    File "/home/seanh/Projects/hypothesis/h/h/views/exceptions.py", line 50, in json_error
    _handle_exc(request)
    File "/home/seanh/Projects/hypothesis/h/h/views/exceptions.py", line 65, in _handle_exc
    request.sentry.captureException()
    ...
    File "/home/seanh/Projects/hypothesis/h/h/sentry.py", line 59, in _get_request_client
    client.user_context(user_context_data(request))
    File "/home/seanh/Projects/hypothesis/h/h/sentry.py", line 37, in user_context_data
    'id': request.authenticated_userid,
    ...
    File "/home/seanh/.virtualenvs/h/local/lib/python2.7/site-packages/pyramid/security.py", line 344, in authenticated_userid
    return policy.authenticated_userid(self)
    File "/home/seanh/Projects/hypothesis/h/h/auth/policy.py", line 17, in authenticated_userid
    return self.api_policy.authenticated_userid(request)
    File "/home/seanh/.virtualenvs/h/local/lib/python2.7/site-packages/pyramid/authentication.py", line 69, in authenticated_userid
    userid = self.unauthenticated_userid(request)
    File "/home/seanh/Projects/hypothesis/h/h/auth/policy.py", line 84, in unauthenticated_userid
    if not token.is_valid():
    File "/home/seanh/Projects/hypothesis/h/h/auth/models.py", line 50, in is_valid
    if self.expires is None:
    ...
    DetachedInstanceError: Instance <Token at 0x7fc96a388190> is not bound to a Session; attribute refresh operation cannot proceed

The issue is that request.auth_token is a sqlalchemy ORM object
(an h.auth.models.Token instance) and it is added using:

    config.add_request_method(auth_token, reify=True)

reify=True means that the first time something accesses
request.auth_token the actual auth_token() function will be called to
fetch the Token object from the db, but from then on Pyramid will cache
the object and just return the cached instance for each subsequent
access of request.auth_token.

After the model code raises the ProgrammingError the sqlalchemy session
to which this cached Token ORM object belongs to is aborted, which means
that the Token object is "detached" (in sqlalchemy's terminology) and
any attempt to access its properties will raise DetachedInstanceError.

As the traceback above shows, the crash reporting code in h/sentry.py
indirectly ends up accessing this auth token and getting such a
DetachedInstanceError.

The fix is to test whether the Token object is detached, and don't try
to use it if it is.