### PR TITLE
Add NIPSA column to user table and populate it

### DIFF
--- a/h/migrations/versions/b7117b569f8b_fill_user_nipsa_column.py
+++ b/h/migrations/versions/b7117b569f8b_fill_user_nipsa_column.py
@@ -1,0 +1,48 @@
+"""
+Fill user NIPSA column
+
+Revision ID: b7117b569f8b
+Revises: ddb5f0baa429
+Create Date: 2016-09-16 17:03:25.264475
+"""
+
+from __future__ import unicode_literals
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import orm
+
+from h.util.user import split_user
+
+revision = 'b7117b569f8b'
+down_revision = 'ddb5f0baa429'
+
+Session = orm.sessionmaker()
+
+
+user = sa.table('user',
+                sa.column('username', sa.UnicodeText),
+                sa.column('authority', sa.UnicodeText),
+                sa.column('nipsa', sa.Boolean))
+nipsa = sa.table('nipsa', sa.column('userid', sa.UnicodeText))
+
+
+def upgrade():
+    bind = op.get_bind()
+    session = Session(bind=bind)
+
+    op.execute(user.update().values(nipsa=False))
+
+    # Fetch all the existing NIPSA'd userids and set the NIPSA flag on the
+    # corresponding rows in the user table, if they exist.
+    for (userid,) in session.query(nipsa):
+        val = split_user(userid)
+        op.execute(user
+                   .update()
+                   .where(sa.and_(user.c.username == val['username'],
+                                  user.c.authority == val['domain']))
+                   .values(nipsa=True))
+
+
+def downgrade():
+    pass

--- a/h/migrations/versions/ddb5f0baa429_add_nipsa_column_to_user_table.py
+++ b/h/migrations/versions/ddb5f0baa429_add_nipsa_column_to_user_table.py
@@ -1,0 +1,24 @@
+"""
+Add NIPSA column to user table
+
+Revision ID: ddb5f0baa429
+Revises: 6d9257ad610d
+Create Date: 2016-09-16 16:58:03.585538
+"""
+
+from __future__ import unicode_literals
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = 'ddb5f0baa429'
+down_revision = '6d9257ad610d'
+
+
+def upgrade():
+    op.add_column('user', sa.Column('nipsa', sa.Boolean, nullable=True))
+
+
+def downgrade():
+    op.drop_column('user', 'nipsa')


### PR DESCRIPTION
This commit adds a schema migration to add a boolean "nipsa" column to the user table, and a data migration to fill that column with values based on whether the user is already flagged as NIPSA in the existing "nipsa" table.

This is preparatory work for removing the NipsaUser model and database table entirely, and relying instead on a flag on the user table.

Now that we have the ability to create users with different authorities directly in our own user table, there is little need for a separate table.