### PR TITLE
Don't crash on null document.highwire.pdf_url

### DIFF
--- a/src/memex/schemas.py
+++ b/src/memex/schemas.py
@@ -75,6 +75,12 @@ class AnnotationSchema(JSONSchema):
                                     'type': 'string',
                                 },
                             },
+                            'pdf_url': {
+                                'type': 'array',
+                                'items': {
+                                    'type': 'string',
+                                },
+                            },
                         },
                     },
                     'link': {

--- a/tests/memex/schemas_test.py
+++ b/tests/memex/schemas_test.py
@@ -81,7 +81,8 @@ class TestCreateUpdateAnnotationSchema(object):
                     'identifier': ['foo', 'bar']
                 },
                 'highwire': {
-                    'doi': ['foo', 'bar']
+                    'doi': ['foo', 'bar'],
+                    'pdf_url': ['foo', 'bar'],
                 },
                 'link': [
                     {

--- a/tests/memex/schemas_test.py
+++ b/tests/memex/schemas_test.py
@@ -136,6 +136,12 @@ class TestCreateUpdateAnnotationSchema(object):
         ({'document': {'highwire': {'doi': [False]}}},
          "document.highwire.doi.0: False is not of type 'string'"),
 
+        ({'document': {'highwire': {'pdf_url': False}}},
+         "document.highwire.pdf_url: False is not of type 'array'"),
+
+        ({'document': {'highwire': {'pdf_url': [False]}}},
+         "document.highwire.pdf_url.0: False is not of type 'string'"),
+
         ({'document': {'link': False}},
          "document.link: False is not of type 'array'"),
 


### PR DESCRIPTION
A POST like this to the create or update annotation API would cause
parse_document_claims to crash:

    http POST 'http://localhost:5000/api/annotations'
      Authorization:'Bearer 6879-***'
      uri='http://example.com'
      document:='{"highwire": {"pdf_url": null}}'

And this would cause a different crash:

    http POST 'http://localhost:5000/api/annotations'
      Authorization:'Bearer 6879-***'
      uri='http://example.com'
      document:='{"highwire": {"pdf_url": [null]}}'

The problem is that parse_document_claims assumes that
annotation.document.highwire.pdf_url is a list of strings.

Fix both crashes by having AnnotationSchema reject the field if
it's not a list of strings, so it never even gets to
parse_document_claims. (This is the same way that we handle other
document metadata fields: AnnotationSchema makes sure they're the right
type, parse_document_claims can then safely assume this.)