### PR TITLE
Add authticket table migration

### DIFF
--- a/h/migrations/versions/1e88c31d8b1a_add_authticket_table.py
+++ b/h/migrations/versions/1e88c31d8b1a_add_authticket_table.py
@@ -1,0 +1,46 @@
+"""
+Add authticket table
+
+Revision ID: 1e88c31d8b1a
+Revises: f9d3058bec5f
+Create Date: 2016-09-16 12:22:26.480404
+"""
+
+from __future__ import unicode_literals
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '1e88c31d8b1a'
+down_revision = 'f9d3058bec5f'
+
+
+def upgrade():
+    op.create_table('authticket',
+                    sa.Column('id',
+                              sa.UnicodeText(),
+                              primary_key=True),
+                    sa.Column('created',
+                              sa.DateTime,
+                              server_default=sa.func.now(),
+                              nullable=False),
+                    sa.Column('updated',
+                              sa.DateTime,
+                              server_default=sa.func.now(),
+                              nullable=False),
+                    sa.Column('expires',
+                              sa.DateTime,
+                              nullable=False),
+                    sa.Column('user_id',
+                              sa.Integer(),
+                              nullable=False),
+                    sa.Column('user_userid',
+                              sa.UnicodeText(),
+                              nullable=False),
+                    sa.ForeignKeyConstraint(['user_id'], ['user.id'],
+                                            ondelete='cascade'))
+
+
+def downgrade():
+    op.drop_table('authticket')


### PR DESCRIPTION
This is the migration for the table that will be used as the storage for the authentication tickets coming up in the next pull request.