### PR TITLE
Use new ticket auth policy

### DIFF
--- a/h/auth/__init__.py
+++ b/h/auth/__init__.py
@@ -6,10 +6,12 @@ import logging
 
 from pyramid.authentication import (RemoteUserAuthenticationPolicy,
                                     SessionAuthenticationPolicy)
+import pyramid_authsanity
 from pyramid_multiauth import MultiAuthenticationPolicy
 
 from h.auth.policy import AuthenticationPolicy, TokenAuthenticationPolicy
 from h.auth.util import groupfinder
+from h.security import derive_key
 
 __all__ = (
     'DEFAULT_POLICY',
@@ -20,7 +22,18 @@ log = logging.getLogger(__name__)
 
 PROXY_POLICY = RemoteUserAuthenticationPolicy(environ_key='HTTP_X_FORWARDED_USER',
                                               callback=groupfinder)
+# We currently have three ways of authenticating a user:
+# 1. session - finds the authenticated userid in the session
+# 2. ticket - finds the authenticated user in the database through auth tickets
+# 3. token - finds the authenticated user in the database through tokens (API)
+#
+# We are currently in the progress of migrating the session policy to the ticket
+# policy, for non-API requests. This is only possible by having both of them
+# running for a certain time period. When a requests comes in that does not
+# authenticate with the ticket policy, but does with the session policy, then
+# we migrate this session over to use the new auth tickets.
 SESSION_POLICY = SessionAuthenticationPolicy(callback=groupfinder)
+TICKET_POLICY = pyramid_authsanity.AuthServicePolicy()
 TOKEN_POLICY = TokenAuthenticationPolicy(callback=groupfinder)
 
 DEFAULT_POLICY = AuthenticationPolicy(api_policy=TOKEN_POLICY,
@@ -40,6 +53,17 @@ def auth_domain(request):
 def includeme(config):
     global DEFAULT_POLICY
     global WEBSOCKET_POLICY
+
+    # Set up authsanity
+    config.register_service_factory('.services.auth_ticket_service_factory',
+                                    iface='pyramid_authsanity.interfaces.IAuthService')
+    settings = config.registry.settings
+    settings['authsanity.source'] = 'cookie'
+    settings['authsanity.cookie.max_age'] = 2592000
+    settings['authsanity.cookie.httponly'] = True
+    settings['authsanity.secret'] = derive_key(settings['secret_key'],
+                                               b'h.auth.cookie_secret')
+    config.include('pyramid_authsanity')
 
     if config.registry.settings.get('h.proxy_auth'):
         log.warn('Enabling proxy authentication mode: you MUST ensure that '

--- a/h/auth/__init__.py
+++ b/h/auth/__init__.py
@@ -37,8 +37,9 @@ TICKET_POLICY = pyramid_authsanity.AuthServicePolicy()
 TOKEN_POLICY = TokenAuthenticationPolicy(callback=groupfinder)
 
 DEFAULT_POLICY = AuthenticationPolicy(api_policy=TOKEN_POLICY,
-                                      fallback_policy=SESSION_POLICY)
-WEBSOCKET_POLICY = MultiAuthenticationPolicy([TOKEN_POLICY, SESSION_POLICY])
+                                      fallback_policy=TICKET_POLICY,
+                                      migration_policy=SESSION_POLICY)
+WEBSOCKET_POLICY = MultiAuthenticationPolicy([TOKEN_POLICY, TICKET_POLICY, SESSION_POLICY])
 
 
 def auth_domain(request):

--- a/h/auth/policy.py
+++ b/h/auth/policy.py
@@ -7,14 +7,34 @@ from zope import interface
 
 @interface.implementer(interfaces.IAuthenticationPolicy)
 class AuthenticationPolicy(object):
-    def __init__(self, api_policy, fallback_policy):
+    def __init__(self, api_policy, fallback_policy, migration_policy=None):
         self.api_policy = api_policy
         self.fallback_policy = fallback_policy
+        self.migration_policy = migration_policy
 
     def authenticated_userid(self, request):
         if _is_api_request(request):
             return self.api_policy.authenticated_userid(request)
-        return self.fallback_policy.authenticated_userid(request)
+
+        userid = self.fallback_policy.authenticated_userid(request)
+        if userid is not None:
+            return userid
+
+        # In case we couldn't authenticate the user against the fallback policy
+        # and we're in the process of migrating from one policy to another,
+        # then we check if we can authenticate against the deprecated
+        # migration policy. If that succeeded, then we remember the user in the
+        # fallback policy and from then on this code path will not be called
+        # anymore.
+        if self.migration_policy is None:
+            return userid
+
+        userid = self.migration_policy.authenticated_userid(request)
+        if userid is not None:
+            headers = self.fallback_policy.remember(request, userid)
+            request.response.headers.extend(headers)
+
+        return userid
 
     def unauthenticated_userid(self, request):
         if _is_api_request(request):

--- a/h/auth/services.py
+++ b/h/auth/services.py
@@ -1,0 +1,109 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import datetime
+
+from pyramid_authsanity import interfaces
+import sqlalchemy as sa
+from zope import interface
+from zope.sqlalchemy import mark_changed
+
+from h.models import AuthTicket
+from h.auth.util import principals_for_user
+
+TICKET_TTL = datetime.timedelta(days=7)
+
+
+class AuthTicketNotLoadedError(Exception):
+    pass
+
+
+@interface.implementer(interfaces.IAuthService)
+class AuthTicketService(object):
+    def __init__(self, session, user_service):
+        self.session = session
+        self.usersvc = user_service
+
+        self._userid = None
+
+    def userid(self):
+        """
+        Return current userid, or None.
+
+        Raises ``AuthTicketNotLoadedError`` when auth ticket has not been
+        loaded yet, which signals the auth policy to call ``verify_ticket``.
+        """
+
+        if self._userid is None:
+            raise AuthTicketNotLoadedError('auth ticket is not loaded yet')
+
+        return self._userid
+
+    def groups(self):
+        """Returns security principals of the logged-in user."""
+
+        if self._userid is None:
+            raise AuthTicketNotLoadedError('auth ticket is not loaded yet')
+
+        user = self.usersvc.fetch(self._userid)
+        return principals_for_user(user)
+
+    def verify_ticket(self, principal, ticket_id):
+        """
+        Verifies an authentication claim (usually extracted from a cookie)
+        against the stored tickets.
+
+        This will only successfully verify a ticket when it is found in the
+        database, the principal is the same, and it hasn't expired yet.
+        """
+
+        if ticket_id is None:
+            return False
+
+        # Since we load and then update the AuthTicket.expires on every request,
+        # we optimise it with a `UPDATE ... RETURNING` query, doing both of
+        # these in one. When the returned `userid` is `None` then the
+        # authentication failed, otherwise it succeeded. Doing a query like this
+        # will not mark the session as dirty, and thus the transaction will
+        # get rolled back at the end, unless we found a userid, at which point
+        # we manually mark the session as changed.
+        ticket_query = (sa.update(AuthTicket.__table__)
+                        .where(sa.and_(AuthTicket.id == ticket_id,
+                                       AuthTicket.user_userid == principal,
+                                       AuthTicket.expires > sa.func.now()))
+                        .values(expires=(sa.func.now() + TICKET_TTL))
+                        .returning(AuthTicket.user_userid))
+        self._userid = self.session.execute(ticket_query).scalar()
+
+        if self._userid:
+            mark_changed(self.session)
+            return True
+
+        return False
+
+    def add_ticket(self, principal, ticket_id):
+        """Store a new ticket with the given id and principal in the database."""
+
+        user = self.usersvc.fetch(principal)
+        if user is None:
+            raise ValueError('Cannot find user with userid %s' % principal)
+
+        ticket = AuthTicket(id=ticket_id,
+                            user=user,
+                            user_userid=user.userid,
+                            expires=(datetime.datetime.utcnow() + TICKET_TTL))
+        self.session.add(ticket)
+
+    def remove_ticket(self, ticket_id):
+        """Delete a ticket by id from the database."""
+
+        if ticket_id:
+            self.session.query(AuthTicket).filter_by(id=ticket_id).delete()
+        self._userid = None
+
+
+def auth_ticket_service_factory(context, request):
+    """Return a AuthTicketService instance for the passed context and request."""
+    user_service = request.find_service(name='user')
+    return AuthTicketService(request.db, user_service)

--- a/h/auth/util.py
+++ b/h/auth/util.py
@@ -7,7 +7,9 @@ from h.auth import role
 
 def groupfinder(userid, request):
     """
-    Return the list of additional principals for a user, or None.
+    Return the list of additional principals for a userid, or None.
+
+    This loads the user and then calls ``principals_for_user``.
 
     If `userid` identifies a valid user in the system, this function will
     return the list of additional principals for that user. If `userid` is not
@@ -23,6 +25,12 @@ def groupfinder(userid, request):
     """
     user_service = request.find_service(name='user')
     user = user_service.fetch(userid)
+
+    return principals_for_user(user)
+
+
+def principals_for_user(user):
+    """Return the list of additional principals for a user, or None."""
     if user is None:
         return None
 

--- a/h/models/__init__.py
+++ b/h/models/__init__.py
@@ -24,6 +24,7 @@ from h.notification import models as notification_models
 
 from h.models.activation import Activation
 from h.models.auth_client import AuthClient
+from h.models.auth_ticket import AuthTicket
 from h.models.blocklist import Blocklist
 from h.models.feature import Feature
 from h.models.feature_cohort import FeatureCohort
@@ -35,6 +36,7 @@ __all__ = (
     'Activation',
     'Annotation',
     'AuthClient',
+    'AuthTicket',
     'Blocklist',
     'Document',
     'DocumentMeta',

--- a/h/models/auth_ticket.py
+++ b/h/models/auth_ticket.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import sqlalchemy as sa
+
+from h.db import Base
+from h.db.mixins import Timestamps
+
+
+class AuthTicket(Base, Timestamps):
+    """
+    An auth ticket.
+
+    An auth ticket represents an open authentication session for a logged-in
+    user. The ``id`` is typically stored in an ``auth`` cookie, provided by
+    :py:class:`pyramid_authsanity.sources.CookieAuthSource`.
+    """
+
+    __tablename__ = 'authticket'
+
+    #: The id that is typically stored in the cookie, it should be a
+    #: cryptographically random string with an appropriate amount of entropy.
+    id = sa.Column(sa.UnicodeText(), primary_key=True)
+
+    #: The datetime when this ticket expires
+    expires = sa.Column(sa.DateTime, nullable=False)
+
+    user_id = sa.Column(sa.Integer,
+                        sa.ForeignKey('user.id', ondelete='cascade'),
+                        nullable=False)
+
+    #: The user whose auth ticket it is
+    user = sa.orm.relationship('User')
+
+    #: The user's userid, denormalised onto this table to avoid the need to do
+    #: a SELECT against the user table just to find the authenticated_userid
+    #: associated with the request.
+    user_userid = sa.Column('user_userid', sa.UnicodeText(), nullable=False)

--- a/requirements.in
+++ b/requirements.in
@@ -21,6 +21,7 @@ passlib
 psycogreen
 psycopg2
 pyramid
+pyramid_authsanity
 pyramid_layout
 pyramid-jinja2
 pyramid-multiauth

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,6 +50,7 @@ pyasn1==0.1.9             # via cryptography
 pycparser==2.14           # via cffi
 PyJWT==1.4.1
 pyparsing==2.1.5
+pyramid-authsanity==0.1.0a4
 pyramid-jinja2==2.6.2
 pyramid-layout==1.0
 pyramid-mailer==0.14.1
@@ -79,7 +80,7 @@ WebOb==1.6.1              # via pyramid
 ws4py==0.3.5
 wsaccel==0.6.2
 zope.deprecation==4.1.2   # via deform, pyramid, pyramid-jinja2
-zope.interface==4.3.2     # via pyramid, pyramid-services, repoze.sendmail, transaction, zope.sqlalchemy
+zope.interface==4.3.2     # via pyramid, pyramid-authsanity, pyramid-services, repoze.sendmail, transaction, zope.sqlalchemy
 zope.sqlalchemy==0.7.7
 
 # The following packages are commented out because they are

--- a/tests/common/factories.py
+++ b/tests/common/factories.py
@@ -4,6 +4,9 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+import base64
+import os
+from datetime import (datetime, timedelta)
 import random
 
 import factory
@@ -210,3 +213,18 @@ class Group(ModelFactory):
 
     name = factory.Sequence(lambda n:'Test Group {n}'.format(n=str(n)))
     creator = factory.SubFactory(User)
+
+
+class AuthTicket(ModelFactory):
+
+    class Meta:  # pylint: disable=no-init, old-style-class
+        model = models.AuthTicket
+
+    # Simulate how pyramid_authsanity generates ticket ids
+    id = factory.LazyAttribute(lambda _: base64.urlsafe_b64encode(os.urandom(32)).rstrip(b"=").decode('ascii'))
+    user = factory.SubFactory(User)
+    expires = factory.LazyAttribute(lambda _: (datetime.utcnow() + timedelta(minutes=10)))
+
+    @factory.lazy_attribute
+    def user_userid(self):
+        return self.user.userid

--- a/tests/h/auth/policy_test.py
+++ b/tests/h/auth/policy_test.py
@@ -21,14 +21,19 @@ NONAPI_PATHS = (
     '/api/token',
 )
 
+
 class TestAuthenticationPolicy(object):
 
     @pytest.fixture(autouse=True)
     def policy(self):
         self.api_policy = mock.Mock(spec_set=list(IAuthenticationPolicy))
         self.fallback_policy = mock.Mock(spec_set=list(IAuthenticationPolicy))
+        self.migration_policy = mock.Mock(spec_set=list(IAuthenticationPolicy))
         self.policy = AuthenticationPolicy(api_policy=self.api_policy,
-                                           fallback_policy=self.fallback_policy)
+                                           fallback_policy=self.fallback_policy,
+                                           migration_policy=self.migration_policy)
+
+        self.fallback_policy.remember.return_value = [('Cookie', 'auth=foobar')]
 
     # api_request and nonapi_request are parametrized fixtures, which will
     # take on each value in the passed `params` sequence in turn. This is a
@@ -49,6 +54,31 @@ class TestAuthenticationPolicy(object):
 
         self.fallback_policy.authenticated_userid.assert_called_once_with(nonapi_request)
         assert result == self.fallback_policy.authenticated_userid.return_value
+
+    def test_authenticated_userid_uses_migration_policy_when_fallback_returns_none(self, nonapi_request):
+        self.fallback_policy.authenticated_userid.return_value = None
+
+        result = self.policy.authenticated_userid(nonapi_request)
+
+        self.migration_policy.authenticated_userid.assert_called_once_with(nonapi_request)
+        assert result == self.migration_policy.authenticated_userid.return_value
+
+    def test_authenticated_userid_remembers_value_from_migration_policy_in_fallback_policy(self, nonapi_request):
+        self.fallback_policy.authenticated_userid.return_value = None
+
+        self.policy.authenticated_userid(nonapi_request)
+
+        self.fallback_policy.remember.assert_called_once_with(
+            nonapi_request,
+            self.migration_policy.authenticated_userid.return_value)
+
+    def test_authenticated_userid_sets_cookie_when_migrating(self, nonapi_request):
+        self.fallback_policy.authenticated_userid.return_value = None
+
+        self.policy.authenticated_userid(nonapi_request)
+
+        cookies = nonapi_request.response.headers.getall('Cookie')
+        assert 'auth=foobar' in cookies
 
     def test_authenticated_userid_uses_api_policy_for_api_paths(self, api_request):
         result = self.policy.authenticated_userid(api_request)

--- a/tests/h/auth/services_test.py
+++ b/tests/h/auth/services_test.py
@@ -1,0 +1,187 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from datetime import (datetime, timedelta)
+
+import mock
+import pytest
+
+from h import models
+from h.accounts.services import UserService
+from h.auth import services
+
+
+class TestAuthTicketService(object):
+    def test_userid_raises_when_ticket_has_not_been_loaded_yet(self, svc):
+        with pytest.raises(services.AuthTicketNotLoadedError) as exc:
+            svc.userid()
+        assert str(exc.value) == 'auth ticket is not loaded yet'
+
+    def test_userid_returns_the_users_userid(self, svc, ticket):
+        svc.usersvc.fetch.return_value = ticket.user
+
+        svc.verify_ticket(ticket.user_userid, ticket.id)
+
+        userid = svc.userid()
+        assert ticket.user.userid == userid
+
+    @pytest.mark.usefixtures('principals_for_user')
+    def test_groups_loads_the_user(self, svc, ticket):
+        svc.verify_ticket(ticket.user_userid, ticket.id)
+
+        svc.groups()
+
+        assert svc.usersvc.fetch.call_count == 1
+        svc.usersvc.fetch.assert_called_once_with(ticket.user_userid)
+
+    def test_groups_returns_principals_for_user(self, svc, principals_for_user, ticket):
+        principals_for_user.return_value = ['foo', 'bar', 'baz']
+        svc.usersvc.fetch.return_value = ticket.user
+        svc.verify_ticket(ticket.user_userid, ticket.id)
+
+        result = svc.groups()
+
+        principals_for_user.assert_called_once_with(ticket.user)
+        assert ['foo', 'bar', 'baz'] == result
+
+    def test_groups_raises_when_ticket_is_not_loaded(self, svc, ticket):
+        with pytest.raises(services.AuthTicketNotLoadedError) as exc:
+            svc.groups()
+        assert str(exc.value) == 'auth ticket is not loaded yet'
+
+    def test_verify_ticket_fails_when_id_is_None(self, svc):
+        assert svc.verify_ticket(self.principal, None) is False
+
+    def test_verify_ticket_fails_when_id_is_empty(self, svc):
+        assert svc.verify_ticket(self.principal, '') is False
+
+    @pytest.mark.usefixtures('ticket')
+    def test_verify_ticket_fails_when_ticket_cannot_be_found(self, svc, db_session):
+        assert svc.verify_ticket('foobar', 'bogus') is False
+
+    def test_verify_ticket_fails_when_ticket_user_does_not_match_principal(self, svc, db_session, ticket):
+        assert svc.verify_ticket('foobar', ticket.id) is False
+
+    def test_verify_ticket_fails_when_ticket_is_expired(self, svc, db_session, factories):
+        expires = datetime.utcnow() - timedelta(hours=3)
+        ticket = factories.AuthTicket(expires=expires)
+        db_session.flush()
+
+        assert svc.verify_ticket(ticket.user_userid, ticket.id) is False
+
+    def test_verify_ticket_succeeds_when_ticket_is_valid(self, svc, db_session, ticket):
+        assert svc.verify_ticket(ticket.user_userid, ticket.id) is True
+
+    def test_verify_ticket_extends_expiry_date_when_valid(self, svc, db_session, ticket):
+        expires_before = ticket.expires
+        svc.verify_ticket(ticket.user_userid, ticket.id)
+
+        # Manually expire ticket, so that the data will be reloaded from the
+        # database.
+        db_session.expire(ticket)
+        assert expires_before < ticket.expires
+
+    def test_add_ticket_raises_when_user_cannot_be_found(self, svc):
+        svc.usersvc.fetch.return_value = None
+
+        with pytest.raises(ValueError) as exc:
+            svc.add_ticket('bogus', 'foobar')
+
+        assert str(exc.value) == 'Cannot find user with userid bogus'
+
+    def test_add_ticket_stores_ticket(self, svc, db_session, user, patched_datetime):
+        svc.usersvc.fetch.return_value = user
+
+        utcnow = datetime(2016, 1, 1, 5, 23, 54)
+        patched_datetime.utcnow.return_value = utcnow
+
+        svc.add_ticket(user.userid, 'the-ticket-id')
+
+        ticket = db_session.query(models.AuthTicket).first()
+        assert ticket.id == 'the-ticket-id'
+        assert ticket.user == user
+        assert ticket.user_userid == user.userid
+        assert ticket.expires == utcnow + services.TICKET_TTL
+
+    @pytest.mark.usefixtures('ticket')
+    def test_remove_ticket_skips_deleting_when_id_is_None(self, svc, db_session):
+        assert db_session.query(models.AuthTicket).count() == 1
+        svc.remove_ticket(None)
+        assert db_session.query(models.AuthTicket).count() == 1
+
+    @pytest.mark.usefixtures('ticket')
+    def test_remove_ticket_skips_deleting_when_id_is_empty(self, svc, db_session):
+        assert db_session.query(models.AuthTicket).count() == 1
+        svc.remove_ticket('')
+        assert db_session.query(models.AuthTicket).count() == 1
+
+    def test_remove_ticket_deletes_ticket(self, svc, ticket, factories, db_session):
+        keep = factories.AuthTicket()
+
+        assert db_session.query(models.AuthTicket).count() == 2
+        svc.remove_ticket(ticket.id)
+        assert db_session.query(models.AuthTicket).get(keep.id) is not None
+        assert db_session.query(models.AuthTicket).get(ticket.id) is None
+
+    def test_remove_ticket_clears_userid_cache(self, svc, ticket):
+        svc.verify_ticket(ticket.user_userid, ticket.id)
+
+        assert svc._userid is not None
+        svc.remove_ticket(ticket.id)
+        assert svc._userid is None
+
+    @property
+    def principal(self):
+        return 'acct:bob@example.org'
+
+    @property
+    def ticket_id(self):
+        return 'test-ticket-id'
+
+    @pytest.fixture
+    def svc(self, db_session, user_service):
+        return services.AuthTicketService(db_session, user_service)
+
+    @pytest.fixture
+    def principals_for_user(self, patch):
+        return patch('h.auth.services.principals_for_user')
+
+    @pytest.fixture
+    def patched_datetime(self, patch):
+        return patch('h.auth.services.datetime.datetime')
+
+    @pytest.fixture
+    def ticket(self, factories, user, db_session):
+        ticket = factories.AuthTicket(user=user, user_userid=user.userid)
+        db_session.flush()
+        return ticket
+
+    @pytest.fixture
+    def user(self, factories, db_session):
+        user = factories.User()
+        db_session.add(user)
+        db_session.flush()
+        return user
+
+
+@pytest.mark.usefixtures('user_service')
+class TestAuthTicketServiceFactory(object):
+    def test_it_returns_auth_ticket_service(self, pyramid_request):
+        svc = services.auth_ticket_service_factory(None, pyramid_request)
+        assert isinstance(svc, services.AuthTicketService)
+
+    def test_it_provides_request_db_as_session(self, pyramid_request):
+        svc = services.auth_ticket_service_factory(None, pyramid_request)
+        assert svc.session == pyramid_request.db
+
+    def test_it_provides_user_service(self, pyramid_request, user_service):
+        svc = services.auth_ticket_service_factory(None, pyramid_request)
+        assert svc.usersvc == user_service
+
+
+@pytest.fixture
+def user_service(db_session, pyramid_config):
+    service = mock.Mock(spec=UserService(db_session))
+    pyramid_config.register_service(service, name='user')
+    return service


### PR DESCRIPTION
**This depends on #3884 being merged and run in production [✔ · DONE]**

This is replacing the authentication state storage previously done with `pyramid_redis_sessions` with `pyramid_authsanity`. This is step 1 of removing `pyramid_redis_sessions` from our code base.

When a user logs in they will get a randomly generated ticket id, we then store this id alongside the user id in the new `authticket` table, and the ticket id will get sent back to the client via the `auth` cookie. This should speed up most requests by about 10-30ms, because `pyramid_redis_sessions` was way to chatty with Redis, setting a new TTL every single time the `authenticated_userid` was being called.

The old session storage is valid for seven days, when a logged-in user accesses the site, but doesn't have a new authentication ticket yet, we will authenticate them via the old session policy and then create an auth ticket for them. After seven days we will be able to remove this fallback code and only use the new auth ticket system. This way we ensure that no logged-in user would suddenly get logged out.