### PR TITLE
Fix form "required" indicator display issues

### DIFF
--- a/h/groups/schemas.py
+++ b/h/groups/schemas.py
@@ -39,6 +39,7 @@ class GroupSchema(CSRFSchema):
             unblacklisted_group_name_slug),
         widget=deform.widget.TextInputWidget(
             autofocus=True,
+            show_required=True,
             css_class="group-form__name-input js-group-name-input",
             disable_autocomplete=True,
             label_css_class="group-form__name-label",

--- a/h/templates/deform/mapping_item.jinja2
+++ b/h/templates/deform/mapping_item.jinja2
@@ -34,7 +34,7 @@
          {% endif %}
          for="{{ field.oid }}">
            {{ _(field.title) }}
-    {%- if field.required and feature('activity_pages') -%}
+    {%- if field.required and field.widget.show_required and feature('activity_pages') -%}
       <span class="form-input__required">*</span>
     {% endif -%}
     {%- if field.schema.hint and feature('activity_pages') -%}

--- a/h/templates/deform/mapping_item.jinja2
+++ b/h/templates/deform/mapping_item.jinja2
@@ -34,16 +34,16 @@
          {% endif %}
          for="{{ field.oid }}">
            {{ _(field.title) }}
-           {%- if field.schema.hint and feature('activity_pages') -%}
-             <i class="form-input__hint-icon">
-               {{ svg_icon('info_icon') }}
-             </i>
-           {% endif %}
-    {%- if field.schema.hint and not feature('activity_pages') %}
-      <span class="form-hint" id="hint-{{ field.oid }}">({{ field.schema.hint }})</span>
-    {% endif -%}
     {%- if field.required and feature('activity_pages') -%}
       <span class="form-input__required">*</span>
+    {% endif -%}
+    {%- if field.schema.hint and feature('activity_pages') -%}
+      <i class="form-input__hint-icon">
+        {{ svg_icon('info_icon') }}
+      </i>
+    {% endif -%}
+    {%- if field.schema.hint and not feature('activity_pages') %}
+      <span class="form-hint" id="hint-{{ field.oid }}">({{ field.schema.hint }})</span>
     {% endif -%}
   </label>
 {% endif -%}


### PR DESCRIPTION
Fixes #3848 by moving the required indicator before form hints, and only showing it on the new group form.