### PR TITLE
Cleanup expired authtickets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ node_modules/
 *.pyo
 
 *.log
+
+celerybeat-schedule
+celerybeat.pid

--- a/h/auth/worker.py
+++ b/h/auth/worker.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from datetime import datetime
+
+from h import models
+from h.celery import celery
+from h.celery import get_task_logger
+
+
+log = get_task_logger(__name__)
+
+
+@celery.task
+def delete_expired_auth_tickets():
+    celery.request.db.query(models.AuthTicket) \
+        .filter(models.AuthTicket.expires < datetime.utcnow()) \
+        .delete()

--- a/h/celery.py
+++ b/h/celery.py
@@ -10,6 +10,7 @@ integrates it with the Pyramid application by attaching a bootstrapped fake
 
 from __future__ import absolute_import
 
+from datetime import timedelta
 import logging
 import os
 
@@ -32,6 +33,12 @@ celery.conf.update(
     # store.
     BROKER_URL=os.environ.get('CELERY_BROKER_URL',
         os.environ.get('BROKER_URL', 'amqp://guest:guest@localhost:5672//')),
+    CELERYBEAT_SCHEDULE={
+        'delete-expired-authtickets': {
+            'task': 'h.auth.worker.delete_expired_auth_tickets',
+            'schedule': timedelta(hours=1)
+        }
+    },
     CELERY_ACCEPT_CONTENT=['json'],
     # Enable at-least-once delivery mode. This probably isn't actually what we
     # want for all of our queues, but it makes the failure-mode behaviour of
@@ -39,7 +46,7 @@ celery.conf.update(
     CELERY_ACKS_LATE=True,
     CELERY_DISABLE_RATE_LIMITS=True,
     CELERY_IGNORE_RESULT=True,
-    CELERY_IMPORTS=('h.mailer', 'h.nipsa.worker', 'h.indexer', 'h.admin.worker'),
+    CELERY_IMPORTS=('h.mailer', 'h.nipsa.worker', 'h.indexer', 'h.admin.worker', 'h.auth.worker'),
     CELERY_ROUTES={
         'h.indexer.add_annotation': 'indexer',
         'h.indexer.delete_annotation': 'indexer',

--- a/h/cli/commands/devserver.py
+++ b/h/cli/commands/devserver.py
@@ -28,7 +28,11 @@ import click
               default=True,
               help="Whether or not to run the gulp watch process "
                    "(default: --assets).")
-def devserver(https, web, ws, worker, assets):
+@click.option('--beat/--no-beat',
+              default=True,
+              help="Wheter or not to run the celery beat process "
+                   "(default: --beat).")
+def devserver(https, web, ws, worker, assets, beat):
     """
     Run a development server.
 
@@ -82,6 +86,9 @@ def devserver(https, web, ws, worker, assets):
 
     if worker:
         m.add_process('worker', 'hypothesis --dev celery worker --autoreload')
+
+    if beat:
+        m.add_process('beat', 'hypothesis --dev celery beat')
 
     if assets:
         m.add_process('assets', 'gulp watch')

--- a/tests/h/auth/worker_test.py
+++ b/tests/h/auth/worker_test.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from datetime import (datetime, timedelta)
+
+import pytest
+
+from h.auth import worker
+from h.models import AuthTicket
+
+
+@pytest.mark.usefixtures('celery')
+class TestDeleteExpiredAuthTickets(object):
+    def test_it_removes_expired_tickets(self, db_session, factories):
+        tickets = [
+            factories.AuthTicket(expires=datetime(2014, 5, 6, 7, 8, 9)),
+            factories.AuthTicket(expires=(datetime.utcnow() - timedelta(seconds=1))),
+        ]
+        db_session.add_all(tickets)
+
+        assert db_session.query(AuthTicket).count() == 2
+        worker.delete_expired_auth_tickets()
+        assert db_session.query(AuthTicket).count() == 0
+
+    def test_it_leaves_valid_tickets(self, db_session, factories):
+        tickets = [
+            factories.AuthTicket(expires=datetime(2014, 5, 6, 7, 8, 9)),
+            factories.AuthTicket(expires=(datetime.utcnow() + timedelta(hours=1))),
+        ]
+        db_session.add_all(tickets)
+
+        assert db_session.query(AuthTicket).count() == 2
+        worker.delete_expired_auth_tickets()
+        assert db_session.query(AuthTicket).count() == 1
+
+    @pytest.fixture
+    def celery(self, patch, db_session):
+        cel = patch('h.auth.worker.celery', autospec=False)
+        cel.request.db = db_session
+        return cel


### PR DESCRIPTION
**This depends on #3885 being merged and will need a rebase**

We should clean up expired auth tickets from the database, this adds a celery task that is being run periodically with `celery beat`.

This will also need some OPS work in the playbooks repo to get a celery beat (exactly one) process up and running.