### PR TITLE
Fix display of documents without titles on activity search page

### DIFF
--- a/h/activity/bucketing.py
+++ b/h/activity/bucketing.py
@@ -10,6 +10,7 @@ import newrelic.agent
 from pyramid import i18n
 
 from h._compat import urlparse
+from h import presenters
 
 
 _ = i18n.TranslationStringFactory(__package__)
@@ -22,7 +23,9 @@ class DocumentBucket(object):
         self.users = set()
         self.uri = None
 
-        self.title = document.title
+        presented_document = presenters.DocumentHTMLPresenter(document)
+
+        self.title = presented_document.title_or_untitled
 
         if document.web_uri:
             parsed = urlparse.urlparse(document.web_uri)

--- a/h/presenters.py
+++ b/h/presenters.py
@@ -168,7 +168,7 @@ class AnnotationHTMLPresenter(object):
     def title(self):
         """Return a title for this annotation."""
         if self.document:
-            return self.document.title
+            return self.document.title_or_filename_or_uri
         else:
             return ''
 
@@ -304,7 +304,8 @@ class DocumentHTMLPresenter(object):
 
         """
         return _format_document_link(
-            self.href, self.title, self.link_text, self.hostname_or_filename)
+            self.href, self.title_or_filename_or_uri, self.link_text,
+            self.hostname_or_filename)
 
     @property
     def link_text(self):
@@ -323,11 +324,11 @@ class DocumentHTMLPresenter(object):
         Markup object so it doesn't get double-escaped.
 
         """
-        title = jinja2.escape(self.title)
+        title = jinja2.escape(self.title_or_filename_or_uri)
 
-        # Sometimes self.title is the annotated document's URI (if the document
-        # has no title). In those cases we want to remove the http(s):// from
-        # the front and unquote it for link text.
+        # Sometimes self.title_or_filename_or_uri is the annotated document's
+        # URI (if the document has no title). In those cases we want to remove
+        # the http(s):// from the front and unquote it for link text.
         lower = title.lower()
         if lower.startswith('http://') or lower.startswith('https://'):
             parts = urlparse.urlparse(title)
@@ -337,9 +338,9 @@ class DocumentHTMLPresenter(object):
             return title
 
     @property
-    def title(self):
+    def title_or_filename_or_uri(self):
         """
-        Return a title for this document.
+        Return a title for this document or fall back on filename or URI.
 
         Return the document's title or if the document has no title then return
         its filename (if it's a file:// URI) or its URI for non-file URIs.

--- a/h/presenters.py
+++ b/h/presenters.py
@@ -3,10 +3,14 @@ from __future__ import unicode_literals
 import urlparse
 import urllib2
 from dateutil import parser
+from pyramid import i18n
 
 import jinja2
 
 from h._compat import text_type
+
+
+_ = i18n.TranslationStringFactory(__package__)
 
 
 def _format_document_link(href, title, link_text, host_or_filename):
@@ -362,6 +366,11 @@ class DocumentHTMLPresenter(object):
             return jinja2.escape(urllib2.unquote(self.filename))
         else:
             return jinja2.escape(urllib2.unquote(self.uri))
+
+    @property
+    def title_or_untitled(self):
+        """Return this document's title or 'Untitled Document'."""
+        return self.document.title or  _("Untitled Document")
 
     @property
     def uri(self):

--- a/tests/h/presenters_test.py
+++ b/tests/h/presenters_test.py
@@ -173,45 +173,46 @@ class TestDocumentHTMLPresenter(object):
 
         assert isinstance(self.presenter(web_uri=web_uri).href, jinja2.Markup)
 
-    link_text_fixtures = pytest.mark.usefixtures('title')
+    link_text_fixtures = pytest.mark.usefixtures('title_or_filename_or_uri')
 
     @link_text_fixtures
-    def test_link_text_with_non_http_title(self, title):
-        """If .title doesn't start with http(s) it should just use it."""
-        title.return_value = "Example Document"
+    def test_link_text_with_non_http_title(self, title_or_filename_or_uri):
+        """If .title_or_filename_or_uri doesn't start with http(s) it should just use it."""
+        title_or_filename_or_uri.return_value = "Example Document"
 
         assert self.presenter().link_text == "Example Document"
 
     @link_text_fixtures
-    def test_link_text_with_http_title(self, title):
-        """If .title is an http URI .link_test should use it.
+    def test_link_text_with_http_title(self, title_or_filename_or_uri):
+        """If .title_or_filename_or_uri is an http URI .link_test should use it.
 
-        This happens when an annotation's document has no title, so .title
-        falls back on the URI instead.
+        This happens when an annotation's document has no title, so
+        .title_or_filename_or_uri falls back on the URI instead.
 
         """
-        title.return_value = "http://www.example.com/example.html"
+        title_or_filename_or_uri.return_value = "http://www.example.com/example.html"
 
         assert self.presenter().link_text == "www.example.com/example.html"
 
     @link_text_fixtures
-    def test_link_text_with_https_title(self, title):
-        """If .title is an https URI .link_test should use it.
+    def test_link_text_with_https_title(self, title_or_filename_or_uri):
+        """If .title_or_filename_or_uri is an https URI .link_test should use it.
 
-        This happens when an annotation's document has no title, so .title
-        falls back on the URI instead.
+        This happens when an annotation's document has no title, so
+        .title_or_filename_or_uri falls back on the URI instead.
 
         """
-        title.return_value = "https://www.example.com/example.html"
+        title_or_filename_or_uri.return_value = "https://www.example.com/example.html"
 
         assert self.presenter().link_text == "www.example.com/example.html"
 
     @link_text_fixtures
-    def test_link_text_returns_Markup_if_title_returns_Markup(self, title):
+    def test_link_text_returns_Markup_if_title_returns_Markup(
+            self, title_or_filename_or_uri):
         for title_ in (jinja2.Markup("Example Document"),
                        jinja2.Markup("http://www.example.com/example.html"),
                        jinja2.Markup("https://www.example.com/example.html")):
-            title.return_value = title_
+            title_or_filename_or_uri.return_value = title_
             assert isinstance(self.presenter().link_text, jinja2.Markup)
 
     hostname_or_filename_fixtures = pytest.mark.usefixtures('uri', 'filename')
@@ -272,65 +273,70 @@ class TestDocumentHTMLPresenter(object):
 
         assert isinstance(self.presenter().hostname_or_filename, unicode)
 
-    title_fixtures = pytest.mark.usefixtures('uri', 'filename')
+    title_or_filename_or_uri_fixtures = pytest.mark.usefixtures('uri',
+                                                                'filename')
 
-    @title_fixtures
-    def test_title_with_a_document_that_has_a_title(self):
+    @title_or_filename_or_uri_fixtures
+    def test_title_or_filename_or_uri_with_a_document_that_has_a_title(self):
         """If the document has a title it should use it."""
         title = 'document title'
 
-        assert self.presenter(title=title).title == title
+        assert self.presenter(title=title).title_or_filename_or_uri == title
 
-    @title_fixtures
-    def test_title_escapes_html_in_document_titles(self):
+    @title_or_filename_or_uri_fixtures
+    def test_title_or_filename_or_uri_escapes_html_in_document_titles(self):
         spam_link = '<a href="http://example.com/rubies">Buy rubies!!!</a>'
 
-        title = self.presenter(title=spam_link).title
+        title = self.presenter(title=spam_link).title_or_filename_or_uri
 
         assert jinja2.escape(spam_link) in title
         for char in ['<', '>', '"', "'"]:
             assert char not in title
         assert isinstance(title, jinja2.Markup)
 
-    @title_fixtures
-    def test_title_with_file_uri(self, filename):
+    @title_or_filename_or_uri_fixtures
+    def test_title_or_filename_or_uri_with_file_uri(self, filename):
         """If the document has no title and the annotation has a file:// uri
         then it should return the filename part only."""
         filename.return_value = "MyFile.pdf"
 
-        assert self.presenter(title=None).title == "MyFile.pdf"
+        assert self.presenter(title=None).title_or_filename_or_uri == "MyFile.pdf"
 
-    @title_fixtures
-    def test_title_returns_Markup_when_filename_returns_Markup(self, filename):
+    @title_or_filename_or_uri_fixtures
+    def test_title_or_filename_or_uri_returns_Markup_when_filename_returns_Markup(
+            self, filename):
         filename.return_value = jinja2.Markup("MyFile.pdf")
 
-        assert isinstance(self.presenter(title=None).title, jinja2.Markup)
+        assert isinstance(
+            self.presenter(title=None).title_or_filename_or_uri, jinja2.Markup)
 
-    @title_fixtures
-    def test_title_unquotes_uris(self, uri, filename):
+    @title_or_filename_or_uri_fixtures
+    def test_title_or_filename_or_uri_unquotes_uris(self, uri, filename):
         filename.return_value = ""  # This is not a file:// URI.
         uri.return_value = "http://example.com/example%201.html"
 
-        assert self.presenter(title=None).title == (
+        assert self.presenter(title=None).title_or_filename_or_uri == (
             "http://example.com/example 1.html")
 
-    @title_fixtures
-    def test_title_returns_Markup_when_uri_returns_Markup(self, uri, filename):
+    @title_or_filename_or_uri_fixtures
+    def test_title_or_filename_or_uri_returns_Markup_when_uri_returns_Markup(
+            self, uri, filename):
         filename.return_value = ""  # This is not a file:// URI.
         uri.return_value = jinja2.Markup("http://example.com/example.html")
 
-        assert isinstance(self.presenter(title=None).title, jinja2.Markup)
+        assert isinstance(
+            self.presenter(title=None).title_or_filename_or_uri, jinja2.Markup)
 
-    @title_fixtures
+    @title_or_filename_or_uri_fixtures
     def test_title_when_document_has_None_for_title(self, uri, filename):
         """If title is None for its title it should use the uri instead."""
         uri.return_value = "http://example.com/example.html"
         filename.return_value = ""  # This is not a file:// URI.
 
-        assert self.presenter(title=None).title == (
+        assert self.presenter(title=None).title_or_filename_or_uri == (
             "http://example.com/example.html")
 
-    @title_fixtures
+    @title_or_filename_or_uri_fixtures
     @pytest.mark.parametrize('title', [
         23, 23.7, False, {'foo': 'bar'}, [1, 2, 3]
     ])
@@ -338,13 +344,13 @@ class TestDocumentHTMLPresenter(object):
                                                        uri,
                                                        filename,
                                                        title):
-        """If title is None it should use the uri instead."""
         uri.return_value = u"http://example.com/example.html"
         filename.return_value = ""  # This is not a file:// URI.
 
-        assert isinstance(self.presenter(title=title).title, unicode)
+        assert isinstance(
+            self.presenter(title=title).title_or_filename_or_uri, unicode)
 
-    @title_fixtures
+    @title_or_filename_or_uri_fixtures
     def test_title_when_document_has_empty_string_for_title(self,
                                                             uri,
                                                             filename):
@@ -352,17 +358,17 @@ class TestDocumentHTMLPresenter(object):
         uri.return_value = "http://example.com/example.html"
         filename.return_value = ""  # This is not a file:// URI.
 
-        assert self.presenter(title="").title == (
+        assert self.presenter(title="").title_or_filename_or_uri == (
             "http://example.com/example.html")
 
-    @title_fixtures
+    @title_or_filename_or_uri_fixtures
     def test_title_when_no_document_title_no_filename_and_no_uri(self,
                                                                  uri,
                                                                  filename):
         uri.return_value = ""
         filename.return_value = ""
 
-        assert self.presenter(title=None).title == ""
+        assert self.presenter(title=None).title_or_filename_or_uri == ""
 
     def presenter(self, **kwargs):
         return presenters.DocumentHTMLPresenter(mock.Mock(**kwargs))
@@ -374,10 +380,11 @@ class TestDocumentHTMLPresenter(object):
                      new_callable=mock.PropertyMock)
 
     @pytest.fixture
-    def title(self, patch):
-        return patch('h.presenters.DocumentHTMLPresenter.title',
-                     autospec=None,
-                     new_callable=mock.PropertyMock)
+    def title_or_filename_or_uri(self, patch):
+        return patch(
+            'h.presenters.DocumentHTMLPresenter.title_or_filename_or_uri',
+            autospec=None,
+            new_callable=mock.PropertyMock)
 
     @pytest.fixture
     def uri(self, patch):

--- a/tests/h/presenters_test.py
+++ b/tests/h/presenters_test.py
@@ -370,6 +370,20 @@ class TestDocumentHTMLPresenter(object):
 
         assert self.presenter(title=None).title_or_filename_or_uri == ""
 
+    title_or_untitled_fixtures = pytest.mark.usefixtures('_')
+
+    @title_or_untitled_fixtures
+    def test_title_or_untitled_returns_title(self):
+        assert self.presenter(title="Test Title").title_or_untitled == (
+            "Test Title")
+
+    @title_or_untitled_fixtures
+    def test_title_or_untitled_returns_untitled_if_no_title(self, _):
+        title_or_untitled = self.presenter(title=None).title_or_untitled
+
+        _.assert_called_once_with("Untitled Document")
+        assert title_or_untitled == _.return_value
+
     def presenter(self, **kwargs):
         return presenters.DocumentHTMLPresenter(mock.Mock(**kwargs))
 
@@ -378,6 +392,10 @@ class TestDocumentHTMLPresenter(object):
         return patch('h.presenters.DocumentHTMLPresenter.filename',
                      autospec=None,
                      new_callable=mock.PropertyMock)
+
+    @pytest.fixture
+    def _(self, patch):
+        return patch('h.presenters._')
 
     @pytest.fixture
     def title_or_filename_or_uri(self, patch):


### PR DESCRIPTION
This will show you the problem on master:

```bash
http POST 'http://localhost:5000/api/annotations' Authorization:'Bearer 6879-***' uri='http://example'
```

Then visit `/search` and see the untitled document displayed badly. Then checkout this branch and see the fix.