### PR TITLE
Fix documents without URIs on activity search page

### DIFF
--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -5,12 +5,14 @@
 {# Card displaying statistics about a bucket of annotations. #}
 {% macro search_bucket_stats(bucket) %}
 <div class="search-bucket-stats">
-  <div class="search-bucket-stats__key">
-    Address
-  </div>
-  <div class="search-bucket-stats__val">
-    {{ bucket.uri }}
-  </div>
+  {% if bucket.uri %}
+    <div class="search-bucket-stats__key">
+        Address
+    </div>
+    <div class="search-bucket-stats__val">
+        {{ bucket.uri }}
+    </div>
+  {% endif %}
   {% if bucket.tags %}
     <div class="search-bucket-stats__key">
       Tags


### PR DESCRIPTION
Not all documents have a URI (e.g. locally-annotated PDF files don't
have one). Instead of displaying "Address: None" for such documents on
the /search page, just don't display the address field at all.
(This is the same thing that the search page does for e.g. documents
with no tags.)

Fixes #3858