### PR TITLE
Remove deprecated session authentication

### DIFF
--- a/h/accounts/__init__.py
+++ b/h/accounts/__init__.py
@@ -36,18 +36,6 @@ def authenticated_user(request):
     user_service = request.find_service(name='user')
     user = user_service.fetch(request.authenticated_userid)
 
-    # If the authenticated user doesn't exist in the db then log them out.
-    # This happens when we delete a user account but the user still has a
-    # valid session for that account (because we don't invalidate sessions
-    # when we delete user accounts).
-    #
-    # FIXME: switch to authentication ticket based sessions so that we *can*
-    # invalidate sessions when deleting users. Throwing a 302 in the middle of
-    # an arbitrary request is NOT safe (e.g. POST requests).
-    if request.authenticated_userid and not user:
-        request.session.invalidate()
-        raise httpexceptions.HTTPFound(location=request.url)
-
     return user
 
 

--- a/h/auth/__init__.py
+++ b/h/auth/__init__.py
@@ -4,8 +4,7 @@
 
 import logging
 
-from pyramid.authentication import (RemoteUserAuthenticationPolicy,
-                                    SessionAuthenticationPolicy)
+from pyramid.authentication import RemoteUserAuthenticationPolicy
 import pyramid_authsanity
 from pyramid_multiauth import MultiAuthenticationPolicy
 
@@ -22,24 +21,12 @@ log = logging.getLogger(__name__)
 
 PROXY_POLICY = RemoteUserAuthenticationPolicy(environ_key='HTTP_X_FORWARDED_USER',
                                               callback=groupfinder)
-# We currently have three ways of authenticating a user:
-# 1. session - finds the authenticated userid in the session
-# 2. ticket - finds the authenticated user in the database through auth tickets
-# 3. token - finds the authenticated user in the database through tokens (API)
-#
-# We are currently in the progress of migrating the session policy to the ticket
-# policy, for non-API requests. This is only possible by having both of them
-# running for a certain time period. When a requests comes in that does not
-# authenticate with the ticket policy, but does with the session policy, then
-# we migrate this session over to use the new auth tickets.
-SESSION_POLICY = SessionAuthenticationPolicy(callback=groupfinder)
 TICKET_POLICY = pyramid_authsanity.AuthServicePolicy()
 TOKEN_POLICY = TokenAuthenticationPolicy(callback=groupfinder)
 
 DEFAULT_POLICY = AuthenticationPolicy(api_policy=TOKEN_POLICY,
-                                      fallback_policy=TICKET_POLICY,
-                                      migration_policy=SESSION_POLICY)
-WEBSOCKET_POLICY = MultiAuthenticationPolicy([TOKEN_POLICY, TICKET_POLICY, SESSION_POLICY])
+                                      fallback_policy=TICKET_POLICY)
+WEBSOCKET_POLICY = MultiAuthenticationPolicy([TOKEN_POLICY, TICKET_POLICY])
 
 
 def auth_domain(request):

--- a/tests/h/accounts/__init___test.py
+++ b/tests/h/accounts/__init___test.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import mock
 import pytest
-from pyramid import httpexceptions
 
 from h import accounts
 
@@ -20,20 +19,6 @@ class TestAuthenticatedUser(object):
 
         user_service.fetch.assert_called_once_with('userid')
 
-    def test_invalidates_session_if_user_does_not_exist(self,
-                                                        pyramid_config,
-                                                        pyramid_request):
-        """It should log the user out if they no longer exist in the db."""
-        pyramid_request.session.invalidate = mock.Mock()
-        pyramid_config.testing_securitypolicy('userid')
-
-        try:
-            accounts.authenticated_user(pyramid_request)
-        except Exception:
-            pass
-
-        pyramid_request.session.invalidate.assert_called_once_with()
-
     def test_does_not_invalidate_session_if_not_authenticated(self,
                                                               pyramid_config,
                                                               pyramid_request):
@@ -50,18 +35,6 @@ class TestAuthenticatedUser(object):
         accounts.authenticated_user(pyramid_request)
 
         assert not pyramid_request.session.invalidate.called
-
-    def test_redirects_if_user_does_not_exist(self,
-                                              pyramid_config,
-                                              pyramid_request):
-        pyramid_request.url = '/the/page/that/I/was/on'
-        pyramid_config.testing_securitypolicy('userid')
-
-        with pytest.raises(httpexceptions.HTTPFound) as exc:
-            accounts.authenticated_user(pyramid_request)
-
-        assert exc.value.location == '/the/page/that/I/was/on', (
-            'It should redirect to the same page that was requested')
 
     def test_returns_user(self,
                           factories,

--- a/tests/h/admin/services/user_test.py
+++ b/tests/h/admin/services/user_test.py
@@ -34,6 +34,14 @@ class TestRenameUserService(object):
 
         assert db_session.query(models.User).get(user.id).username == 'panda'
 
+    def test_rename_deletes_auth_tickets(self, service, user, db_session, factories):
+        ids = [factories.AuthTicket(user=user).id for _ in xrange(3)]
+
+        service.rename(user, 'panda')
+
+        count = db_session.query(models.AuthTicket).filter(models.AuthTicket.id.in_(ids)).count()
+        assert count == 0
+
     def test_rename_changes_the_users_annotations_userid(self, service, user, annotations, db_session):
         service.rename(user, 'panda')
 


### PR DESCRIPTION
**This should not be merged until 2016-09-28 to allow all users to migrate to the new auth system**

This PR removes the fallback to the session authentication policy and only uses the ticket policy for non-API requests. This is to remove the migration we added in #3885.