### PR TITLE
Remove pyramid_redis_sessions and redis

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,16 +36,10 @@ node {
     rabbit = docker.image('rabbitmq').run('-P')
     brokerUrl = "amqp://guest:guest@${hostIp}:${containerPort(rabbit, 5672)}//"
 
-    redis = docker.image('redis').run('-P')
-    redisHost = hostIp
-    redisPort = containerPort(redis, 6379)
-
     try {
         // Run our Python tests inside the built container
         img.inside("-u root " +
                    "-e BROKER_URL=${brokerUrl} " +
-                   "-e REDIS_HOST=${redisHost} " +
-                   "-e REDIS_PORT=${redisPort} " +
                    "-e ELASTICSEARCH_HOST=${elasticsearchHost} " +
                    "-e TEST_DATABASE_URL=${databaseUrl}") {
             // Test dependencies
@@ -58,7 +52,6 @@ node {
             sh 'cd /var/lib/hypothesis && tox -e functional'
         }
     } finally {
-        redis.stop()
         rabbit.stop()
         elasticsearch.stop()
         postgres.stop()

--- a/conf/websocket.ini
+++ b/conf/websocket.ini
@@ -1,18 +1,8 @@
 [app:main]
 use: call:h.websocket:create_app
 
-# Include any deployment-specific pyramid add-ons here
-pyramid.includes:
-    pyramid_redis_sessions
-
 # Use gevent-compatible transport for the Sentry client
 raven.transport: gevent
-
-# Redis session configuration -- See pyramid_redis_sessions documentation
-#redis.sessions.secret:
-redis.sessions.cookie_httponly: True
-redis.sessions.cookie_max_age: 2592000
-redis.sessions.timeout: 604800
 
 # SQLAlchemy configuration -- See SQLAlchemy documentation
 sqlalchemy.url: postgresql://postgres@localhost/postgres

--- a/docs/developing/install/website.rst
+++ b/docs/developing/install/website.rst
@@ -75,13 +75,11 @@ h requires the following external services:
 - PostgreSQL_ 9.4+
 - Elasticsearch_ v1.0+, with the `Elasticsearch ICU Analysis`_ plugin
 - RabbitMQ_ v3.5+
-- Redis_ v2.4+
 
 .. _PostgreSQL: http://www.postgresql.org/
 .. _Elasticsearch: http://www.elasticsearch.org/
 .. _Elasticsearch ICU Analysis: http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/analysis-icu-plugin.html
 .. _RabbitMQ: https://rabbitmq.com/
-.. _Redis: http://redis.io/
 
 You can install these services however you want, but the easiest way is by
 using Docker. This should work on any operating system that Docker can be
@@ -92,9 +90,8 @@ installed on:
 
 2. Download and run the
    `official RabbitMQ image <https://hub.docker.com/_/rabbitmq/>`_,
-   the `official PostgreSQL image <https://hub.docker.com/_/postgres/>`_, the
-   `official Redis image <https://hub.docker.com/_/redis/>`_,
-   and our custom
+   the `official PostgreSQL image <https://hub.docker.com/_/postgres/>`_, and
+   our custom
    `Elasticsearch with ICU image <https://hub.docker.com/r/nickstenning/elasticsearch-icu/>`_:
 
    .. code-block:: bash
@@ -102,10 +99,9 @@ installed on:
       docker run -d --name postgres -p 5432:5432 postgres
       docker run -d --name elasticsearch -p 9200:9200 -p 9300:9300 nickstenning/elasticsearch-icu
       docker run -d --name rabbitmq -p 5672:5672 -p 15672:15672 --hostname rabbit rabbitmq:3-management
-      docker run -d --name redis -p 6379:6379 redis
 
-   You'll now have four Docker containers named ``postgres``, ``elasticsearch``,
-   ``rabbitmq`` and ``redis`` running and exposing their various services on the
+   You'll now have three Docker containers named ``postgres``, ``elasticsearch``,
+   and ``rabbitmq`` running and exposing their various services on the
    ports defined above. You should be able to see them by running ``docker ps``.
    You should also be able to visit your Elasticsearch service by opening
    http://localhost:9200/ in a browser, and connect to your PostgreSQL by
@@ -120,7 +116,7 @@ installed on:
 
       .. code-block:: bash
 
-         docker start postgres elasticsearch rabbitmq redis
+         docker start postgres elasticsearch rabbitmq
 
 3. Create the `htest` database in the ``postgres`` container. This is needed
    to run the h tests:

--- a/h/config.py
+++ b/h/config.py
@@ -32,10 +32,6 @@ SETTINGS = [
     DockerSetting('mail.host', 'mail',
                   pattern='{port_25_tcp_addr}'),
     DockerSetting('mail.port', 'mail', pattern='{port_25_tcp_port}'),
-    DockerSetting('redis.sessions.host', 'redis',
-                  pattern='{port_6379_tcp_addr}'),
-    DockerSetting('redis.sessions.port', 'redis',
-                  pattern='{port_6379_tcp_port}'),
     DockerSetting('statsd.host', 'statsd', pattern='{port_8125_udp_addr}'),
     DockerSetting('statsd.port', 'statsd', pattern='{port_8125_udp_port}'),
 
@@ -53,8 +49,6 @@ SETTINGS = [
     EnvSetting('mail.host', 'MAIL_HOST'),
     EnvSetting('mail.port', 'MAIL_PORT', type=int),
     EnvSetting('origins', 'ALLOWED_ORIGINS'),
-    EnvSetting('redis.sessions.host', 'REDIS_HOST'),
-    EnvSetting('redis.sessions.port', 'REDIS_PORT', type=int),
     EnvSetting('sqlalchemy.url', 'DATABASE_URL', type=database_url),
     EnvSetting('statsd.host', 'STATSD_HOST'),
     EnvSetting('statsd.port', 'STATSD_PORT', type=int),
@@ -106,12 +100,6 @@ def configure(environ=None, settings=None):
                  'configure the secret_key setting or the SECRET_KEY '
                  'environment variable!')
         settings['secret_key'] = os.urandom(64)
-
-    # If the redis session secret hasn't been set explicitly, derive it from
-    # the global secret key.
-    if 'redis.sessions.secret' not in settings:
-        settings['redis.sessions.secret'] = derive_key(settings['secret_key'],
-                                                       b'h.session')
 
     # Set up SQLAlchemy debug logging
     if 'debug_query' in settings:

--- a/requirements.in
+++ b/requirements.in
@@ -27,7 +27,6 @@ pyramid-jinja2
 pyramid-multiauth
 pyramid-services
 pyramid_mailer
-pyramid_redis_sessions
 pyramid_tm
 python-dateutil
 python-slugify < 1.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,7 +55,6 @@ pyramid-jinja2==2.6.2
 pyramid-layout==1.0
 pyramid-mailer==0.14.1
 pyramid-multiauth==0.8.0
-pyramid-redis-sessions==1.0.1
 pyramid-services==0.4
 pyramid-tm==0.12.1
 pyramid==1.7.3
@@ -64,7 +63,6 @@ python-editor==1.0.1      # via alembic
 python-slugify==1.1.4
 pytz==2016.6.1            # via celery
 raven==5.24.3
-redis==2.10.5             # via pyramid-redis-sessions
 repoze.lru==0.6           # via pyramid
 repoze.sendmail==4.1
 six==1.10.0               # via bcrypt, bleach, cryptography, html5lib, python-dateutil

--- a/tests/h/config_test.py
+++ b/tests/h/config_test.py
@@ -13,15 +13,3 @@ def test_configure_doesnt_override_secret_key():
     config = configure(environ={}, settings={'secret_key': 'foobar'})
 
     assert config.registry.settings['secret_key'] == 'foobar'
-
-
-def test_configure_generates_redis_sessions_secret_if_missing():
-    config = configure(environ={}, settings={})
-
-    assert 'redis.sessions.secret' in config.registry.settings
-
-
-def test_missing_secrets_doesnt_override_redis_sessions_secret():
-    config = configure(environ={}, settings={'redis.sessions.secret': 'isset'})
-
-    assert config.registry.settings['redis.sessions.secret'] == 'isset'

--- a/tox.ini
+++ b/tox.ini
@@ -39,8 +39,6 @@ deps =
 passenv =
     BROKER_URL
     ELASTICSEARCH_HOST
-    REDIS_HOST
-    REDIS_PORT
     TEST_DATABASE_URL
 commands = py.test {posargs:tests/functional/}
 


### PR DESCRIPTION
**This depends on #3900 being merged and possibly deployed, and then needs to be rebased**

Now that we store the session in a cookie instead of in redis, we can remove the dependency on `pyramid_redis_sessions` and Redis itself.