### PR TITLE
Consistency fixes for SignupFormController

### DIFF
--- a/h/static/scripts/controllers/signup-form-controller.js
+++ b/h/static/scripts/controllers/signup-form-controller.js
@@ -1,14 +1,17 @@
 'use strict';
 
-function SignupFormController(element) {
-  var self = this;
-  var form = element;
+var Controller = require('../base/controller');
 
-  this._submitBtn = element.querySelector('.js-signup-btn')
+class SignupFormController extends Controller {
+  constructor(element) {
+    super(element);
 
-  form.addEventListener('submit', event => {
-    this._submitBtn.disabled = true;
-  });
+    var submitBtn = element.querySelector('.js-signup-btn');
+
+    element.addEventListener('submit', () => {
+      submitBtn.disabled = true;
+    });
+  }
 }
 
 module.exports = SignupFormController;

--- a/h/static/scripts/tests/controllers/signup-form-controller-test.js
+++ b/h/static/scripts/tests/controllers/signup-form-controller-test.js
@@ -1,39 +1,29 @@
 'use strict';
 
-var SignupFormController = require('../../controllers/signup-form-controller')
+var SignupFormController = require('../../controllers/signup-form-controller');
 
-// helper to dispatch a native event to an element
-function sendEvent(element, eventType) {
-  // createEvent() used instead of Event constructor
-  // for PhantomJS compatibility
-  var event = document.createEvent('Event');
-  event.initEvent(eventType, true /* bubbles */, true /* cancelable */);
-  element.dispatchEvent(event);
-}
+var TEMPLATE = `
+  <form class="js-signup-form">
+    <input type="submit" class="js-signup-btn">
+  </form>
+  `;
 
-describe('SignupFormController', function() {
+describe('SignupFormController', function () {
   var element;
-  var template;
   var form;
   var submitBtn;
 
-  before(function () {
-    template = '<form class="js-signup-form">' +
-               '<input type="submit" class="js-signup-btn">' +
-               '</form>'
-  });
-
   beforeEach(function () {
     element = document.createElement('div');
-    element.innerHTML = template;
+    element.innerHTML = TEMPLATE;
     form = element.querySelector('.js-signup-form');
     submitBtn = element.querySelector('.js-signup-btn');
   });
 
   it('disables the submit button on form submit', function () {
-    var controller = new SignupFormController(form);
+    new SignupFormController(form);
     assert.isFalse(submitBtn.disabled);
-    sendEvent(form, 'submit');
+    form.dispatchEvent(new Event('submit'));
     assert.isTrue(submitBtn.disabled);
   });
 });


### PR DESCRIPTION
Refactor SignupFormController to follow the pattern of other controllers
in inheriting from the Controller base class.

 * Fix lint errors about unused variables and missing semis

 * Use template string in test

 * Remove sendEvent() helper which is not required in PhantomJS 2.x

In other controllers, elements of interest are accessed via `this.refs`. That is trickier here however because of the way the submit button is defined, so I've left it as-is for the moment. One way that this could be made a little more generic would be to find all input/button elements with type "submit".