### PR TITLE
Add a login method to the UserService

### DIFF
--- a/h/accounts/services.py
+++ b/h/accounts/services.py
@@ -16,12 +16,14 @@ class UserService(object):
 
     """A service for retrieving and performing common operations on users."""
 
-    def __init__(self, session):
+    def __init__(self, default_authority, session):
         """
         Create a new user service.
 
+        :param default_authority: the default authority for users
         :param session: the SQLAlchemy session object
         """
+        self.default_authority = default_authority
         self.session = session
 
         # Local cache of fetched users.
@@ -114,7 +116,8 @@ class UserSignupService(object):
 
 def user_service_factory(context, request):
     """Return a UserService instance for the passed context and request."""
-    return UserService(session=request.db)
+    return UserService(default_authority=text_type(request.auth_domain),
+                       session=request.db)
 
 
 def user_signup_service_factory(context, request):

--- a/tests/common/factories.py
+++ b/tests/common/factories.py
@@ -184,6 +184,13 @@ class Annotation(ModelFactory):
         )
 
 
+class Activation(ModelFactory):
+
+    class Meta(object):
+        model = models.Activation
+        force_flush = True
+
+
 class User(factory.Factory):
 
     """A factory class that generates h.models.User objects.
@@ -195,6 +202,11 @@ class User(factory.Factory):
 
     class Meta(object):
         model = models.User
+
+    class Params(object):
+        inactive = factory.Trait(
+            activation=factory.SubFactory(Activation),
+        )
 
     authority = 'example.com'
     username = factory.Faker('user_name')

--- a/tests/h/accounts/services_test.py
+++ b/tests/h/accounts/services_test.py
@@ -6,6 +6,8 @@ import mock
 import pytest
 
 from h.accounts.services import (
+    UserNotActivated,
+    UserNotKnown,
     UserService,
     UserSignupService,
     user_service_factory,
@@ -23,7 +25,7 @@ class TestUserService(object):
         assert isinstance(result, User)
 
     def test_fetch_caches_fetched_users(self, db_session, svc, users):
-        jacqui, _ = users
+        jacqui, _, _ = users
 
         svc.fetch('acct:jacqui@foo.com')
         db_session.delete(jacqui)
@@ -34,7 +36,7 @@ class TestUserService(object):
         assert user.username == 'jacqui'
 
     def test_flushes_cache_on_session_commit(self, db_session, svc, users):
-        jacqui, _ = users
+        jacqui, _, _ = users
 
         svc.fetch('acct:jacqui@foo.com')
         db_session.delete(jacqui)
@@ -43,14 +45,53 @@ class TestUserService(object):
 
         assert user is None
 
+    def test_login_by_username(self, svc, users):
+        _, steve, _ = users
+        assert svc.login('steve', 'stevespassword') is steve
+
+    def test_login_by_email(self, svc, users):
+        _, steve, _ = users
+        assert svc.login('steve@steveo.com', 'stevespassword') is steve
+
+    def test_login_bad_password(self, svc):
+        assert svc.login('steve', 'incorrect') is None
+        assert svc.login('steve@steveo.com', 'incorrect') is None
+
+    def test_login_by_username_wrong_authority(self, svc):
+        with pytest.raises(UserNotKnown):
+            svc.login('jacqui', 'jacquispassword')
+
+    def test_login_by_email_wrong_authority(self, svc):
+        with pytest.raises(UserNotKnown):
+            svc.login('jacqui@jj.com', 'jacquispassword')
+
+    def test_login_by_username_not_activated(self, svc):
+        with pytest.raises(UserNotActivated):
+            svc.login('mirthe', 'mirthespassword')
+
+    def test_login_by_email_not_activated(self, svc, users):
+        with pytest.raises(UserNotActivated):
+            svc.login('mirthe@deboer.com', 'mirthespassword')
+
     @pytest.fixture
     def svc(self, db_session):
         return UserService(default_authority='example.com', session=db_session)
 
     @pytest.fixture
     def users(self, db_session, factories):
-        users = [factories.User(username='jacqui', authority='foo.com'),
-                 factories.User(username='steve', authority='example.com')]
+        users = [factories.User(username='jacqui',
+                                email='jacqui@jj.com',
+                                authority='foo.com',
+                                password='jacquispassword'),
+                 factories.User(username='steve',
+                                email='steve@steveo.com',
+                                authority='example.com',
+                                password='stevespassword'),
+                 factories.User(username='mirthe',
+                                email='mirthe@deboer.com',
+                                authority='example.com',
+                                password='mirthespassword',
+                                inactive=True)]
         db_session.add_all(users)
         db_session.flush()
         return users

--- a/tests/h/accounts/services_test.py
+++ b/tests/h/accounts/services_test.py
@@ -45,7 +45,7 @@ class TestUserService(object):
 
     @pytest.fixture
     def svc(self, db_session):
-        return UserService(session=db_session)
+        return UserService(default_authority='example.com', session=db_session)
 
     @pytest.fixture
     def users(self, db_session, factories):
@@ -147,6 +147,11 @@ class TestUserServiceFactory(object):
         svc = user_service_factory(None, pyramid_request)
 
         assert isinstance(svc, UserService)
+
+    def test_provides_request_auth_domain_as_default_authority(self, pyramid_request):
+        svc = user_service_factory(None, pyramid_request)
+
+        assert svc.default_authority == pyramid_request.auth_domain
 
     def test_provides_request_db_as_session(self, pyramid_request):
         svc = user_service_factory(None, pyramid_request)

--- a/tests/h/auth/services_test.py
+++ b/tests/h/auth/services_test.py
@@ -189,6 +189,7 @@ class TestAuthTicketServiceFactory(object):
 
 @pytest.fixture
 def user_service(db_session, pyramid_config):
-    service = mock.Mock(spec=UserService(db_session))
+    service = mock.Mock(spec=UserService(default_authority='example.com',
+                                         session=db_session))
     pyramid_config.register_service(service, name='user')
     return service


### PR DESCRIPTION
This commit adds an as-yet-unused `login` method to the `UserService` which refines our existing login logic by only allowing users with the correct authority (i.e. `request.auth_domain`) to log in.

A followup pull request will modify `h.accounts.schemas.LoginSchema` to use this method rather than implementing its own login logic.