### PR TITLE
Only allow logins from users in the default authority

### DIFF
--- a/tests/functional/test_accounts.py
+++ b/tests/functional/test_accounts.py
@@ -106,7 +106,7 @@ class TestAccountSettings(object):
 
     @pytest.fixture
     def user(self, db_session, factories):
-        user = factories.User(password='pass')
+        user = factories.User(authority='localhost', password='pass')
         db_session.add(user)
         db_session.commit()
         return user

--- a/tests/functional/test_groups.py
+++ b/tests/functional/test_groups.py
@@ -63,7 +63,7 @@ def test_submit_create_group_form_with_xhr_returns_plain_text(app):
 
 @pytest.fixture
 def user(db_session, factories):
-    user = factories.User(password='pass')
+    user = factories.User(authority='localhost', password='pass')
     db_session.add(user)
     db_session.commit()
     return user


### PR DESCRIPTION
Switches the LoginSchema over to use `UserService#login`, which in turn restricts logins to users in the default authority.

This ensures that third-party accounts cannot be logged into using our login forms, and more importantly ensures that existing users' correct login credentials aren't rejected because the user query picked up a third-party row in the user table.

<del>_**N.B.** This PR depends on #3906 and will need a rebase once that has merged._</del>