### PR TITLE
Fix display of document buckets with no title

### DIFF
--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -46,7 +46,13 @@
     <div class="search-result-bucket__domain">
       {{ bucket.domain }}
     </div>
-    <div class="search-result-bucket__title">{{ bucket.title }}</div>
+    <div class="search-result-bucket__title">
+      {% if bucket.title %}
+        {{ bucket.title }}
+      {% else %}
+        {% trans %}Untitled document{% endtrans %}
+      {% endif %}
+    </div>
     <div class="search-result-bucket__annotations-count">
       <div class="search-result-bucket__annotations-count-container">
         {{ bucket.annotations_count }}


### PR DESCRIPTION
When a document has no title display "Untitled document"
(internationalized) on its document bucket, instead of "None".