### PR TITLE
Fix a failing functional test

### DIFF
--- a/tests/functional/test_api.py
+++ b/tests/functional/test_api.py
@@ -23,11 +23,9 @@ class TestAPI(object):
 
 
 @pytest.fixture
-def annotation(db_session):
-    from h.models import Annotation
-    ann = Annotation(userid='acct:testuser@localhost',
-                     groupid='__world__',
-                     shared=True)
-    db_session.add(ann)
+def annotation(db_session, factories):
+    ann =  factories.Annotation(userid='acct:testuser@localhost',
+                                groupid='__world__',
+                                shared=True)
     db_session.commit()
     return ann


### PR DESCRIPTION
The test was accessing the model directly and creating annotations with no `target_uri`. This can't happen in production because [CreateAnnotationSchema won't allow it](https://github.com/hypothesis/h/blob/9105875105f4d29fa380442ce7dfd73846533547/src/memex/schemas.py#L178) ([update doesn't allow it either](https://github.com/hypothesis/h/blob/9105875105f4d29fa380442ce7dfd73846533547/src/memex/schemas.py#L237)).

Possibly the db column should also be `NOT NULL`