### PR TITLE
Strip via.hypothes.is from document bucket titles

### DIFF
--- a/h/activity/bucketing.py
+++ b/h/activity/bucketing.py
@@ -10,6 +10,7 @@ import newrelic.agent
 from pyramid import i18n
 
 from h._compat import urlparse
+from h import presenters
 
 
 _ = i18n.TranslationStringFactory(__package__)
@@ -24,8 +25,10 @@ class DocumentBucket(object):
 
         self.title = document.title
 
-        if document.web_uri:
-            parsed = urlparse.urlparse(document.web_uri)
+        presented_document = presenters.DocumentHTMLPresenter(document)
+
+        if presented_document.web_uri:
+            parsed = urlparse.urlparse(presented_document.web_uri)
             self.uri = parsed.geturl()
             self.domain = parsed.netloc
         else:

--- a/h/presenters.py
+++ b/h/presenters.py
@@ -367,3 +367,13 @@ class DocumentHTMLPresenter(object):
         if self.document.document_uris:
             return jinja2.escape(self.document.document_uris[0].uri)
         return ''
+
+    @property
+    def web_uri(self):
+        via_prefix = 'https://via.hypothes.is/'
+        web_uri = self.document.web_uri
+
+        if web_uri and web_uri != via_prefix and web_uri.startswith(via_prefix):
+            web_uri = web_uri[len(via_prefix):]
+
+        return web_uri


### PR DESCRIPTION
If someone uses the https://via.hypothes.is/ proxy to annotate
http://www.example.com/ then their annotation can end up saved in our db
as an annotation of https://via.hypothes.is/http://www.example.com/
(which is the URL for http://www.example.com/ proxied through
https://via.hypothes.is/) rather than saved as an annotation of
http://www.example.com/.

On the /search page, don't display via.hypothes.is as the domain for
these https://via.hypothes.is/http://www.example.com/ documents, instead
display www.example.com.

Also don't display the address on the document bucket as
https://via.hypothes.is/http://www.example.com/ but just
http://www.example.com/.