### PR TITLE
Implement inline editing for "Change Email" and "Change Password" forms.

### DIFF
--- a/h/accounts/schemas.py
+++ b/h/accounts/schemas.py
@@ -312,7 +312,8 @@ class EmailChangeSchema(CSRFSchema):
 
 
 class PasswordChangeSchema(CSRFSchema):
-    password = password_node(title=_('Current password'))
+    password = password_node(title=_('Current password'),
+                             inactive_label=_('Password'))
     new_password = password_node(title=_('New password'),
                                  hide_until_form_active=True)
     # No validators: all validation is done on the new_password field and we

--- a/h/accounts/schemas.py
+++ b/h/accounts/schemas.py
@@ -295,7 +295,8 @@ class LegacyEmailChangeSchema(CSRFSchema):
 class EmailChangeSchema(CSRFSchema):
     email = email_node(title=_('Email address'))
     # No validators: all validation is done on the email field
-    password = password_node(title=_('Confirm password'))
+    password = password_node(title=_('Confirm password'),
+                             hide_until_form_active=True)
 
     def validator(self, node, value):
         super(EmailChangeSchema, self).validator(node, value)
@@ -312,13 +313,15 @@ class EmailChangeSchema(CSRFSchema):
 
 class PasswordChangeSchema(CSRFSchema):
     password = password_node(title=_('Current password'))
-    new_password = password_node(title=_('New password'))
+    new_password = password_node(title=_('New password'),
+                                 hide_until_form_active=True)
     # No validators: all validation is done on the new_password field and we
     # merely assert that the confirmation field is the same.
     new_password_confirm = colander.SchemaNode(
         colander.String(),
         title=_('Confirm new password'),
-        widget=deform.widget.PasswordWidget())
+        widget=deform.widget.PasswordWidget(),
+        hide_until_form_active=True)
 
     def validator(self, node, value):
         super(PasswordChangeSchema, self).validator(node, value)

--- a/h/static/scripts/controllers/form-controller.js
+++ b/h/static/scripts/controllers/form-controller.js
@@ -108,15 +108,6 @@ class FormController extends Controller {
   }
 
   update(state, prevState) {
-    this._fields.forEach(field =>
-      setElementState(field.container, {
-        editing: state.editingFields.includes(field),
-        focused: field === state.focusedField,
-        hidden: isHiddenField(field.container) &&
-                !state.editingFields.includes(field),
-      })
-    );
-
     // In forms that support editing a single field at a time, show the
     // Save/Cancel buttons below the field that we are currently editing.
     //
@@ -146,16 +137,29 @@ class FormController extends Controller {
     });
     this.refs.formSubmitErrorMessage.textContent = state.submitError;
 
-    // Update fields depending on active/inactive state of the form
+    this._updateFields(state);
+  }
+
+  _updateFields(state) {
     this._fields.forEach(field => {
-      // Fields may specify different labels for when the form is active vs
-      // inactive.
+      setElementState(field.container, {
+        editing: state.editingFields.includes(field),
+        focused: field === state.focusedField,
+        hidden: isHiddenField(field.container) &&
+                !state.editingFields.includes(field),
+      });
+
+      // Update labels
       var activeLabel = field.container.dataset.activeLabel;
       var inactiveLabel = field.container.dataset.inactiveLabel;
+      var isEditing = state.editingFields.includes(field);
+
       if (activeLabel && inactiveLabel) {
         field.label.textContent = isEditing ? activeLabel : inactiveLabel;
       }
 
+      // Update placeholder
+      //
       // The UA may or may not autofill password fields.
       // Set a dummy password as a placeholder when the field is not being edited
       // so that it appears non-empty if the UA doesn't autofill it.

--- a/h/static/scripts/controllers/form-controller.js
+++ b/h/static/scripts/controllers/form-controller.js
@@ -11,6 +11,14 @@ function shouldAutosubmit(type) {
 }
 
 /**
+ * Return true if a form field should be hidden until the user starts
+ * editing the form.
+ */
+function isHiddenField(el) {
+  return el.getAttribute('data-hide-until-active');
+}
+
+/**
  * A controller which adds inline editing functionality to forms
  */
 class FormController extends Controller {
@@ -36,7 +44,10 @@ class FormController extends Controller {
         return;
       }
 
-      this.setState({editingField: field});
+      this.setState({
+        editingFields: this._editSet(field),
+        focusedField: field,
+      });
     }, true /* capture - focus does not bubble */);
 
     this.on('change', event => {
@@ -78,9 +89,10 @@ class FormController extends Controller {
       // True if the user has made changes to the field they are currently
       // editing
       dirty: false,
-      // The group of elements (container, input) for the form field currently
-      // being edited
-      editingField: null,
+      // The set of fields currently being edited
+      editingFields: [],
+      // The field within the `editingFields` set that was last focused
+      focusedField: null,
       // Markup for the original form. Used to revert the form to its original
       // state when the user cancels editing
       originalForm: this.element.outerHTML,
@@ -92,29 +104,39 @@ class FormController extends Controller {
   }
 
   update(state, prevState) {
-    if (prevState.editingField &&
-        state.editingField !== prevState.editingField) {
-      setElementState(prevState.editingField.container, {editing: false});
+    this._fields.forEach(field =>
+      setElementState(field.container, {
+        editing: state.editingFields.includes(field),
+        focused: field === state.focusedField,
+        hidden: isHiddenField(field.container) &&
+                !state.editingFields.includes(field),
+      })
+    );
+
+    // In forms that support editing a single field at a time, show the
+    // Save/Cancel buttons below the field that we are currently editing.
+    //
+    // In the current forms that support editing multiple fields at once,
+    // we always display the Save/Cancel buttons in their default position
+    if (state.editingFields.length === 1) {
+      state.editingFields[0].container.parentElement.insertBefore(
+        this.refs.formActions,
+        state.editingFields[0].container.nextSibling
+      );
     }
 
-    if (state.editingField) {
-      // Display Save/Cancel buttons below the field that we are currently
-      // editing
-      state.editingField.container.parentElement.insertBefore(
-        this.refs.formActions,
-        state.editingField.container.nextSibling
-      );
-      setElementState(state.editingField.container, {editing: true});
-
+    if (state.editingFields.length > 0 &&
+        state.editingFields !== prevState.editingFields) {
       this._trapFocus();
     }
 
-    var isEditing = !!state.editingField;
+    var isEditing = state.editingFields.length > 0;
     setElementState(this.element, {editing: isEditing});
     setElementState(this.refs.formActions, {
       hidden: !isEditing || shouldAutosubmit(state.editingField.input.type),
       saving: state.saving,
     });
+
     setElementState(this.refs.formSubmitError, {
       visible: state.submitError.length > 0,
     });
@@ -135,8 +157,8 @@ class FormController extends Controller {
     var originalForm = this.state.originalForm;
 
     var activeInputId;
-    if (this.state.editingField) {
-      activeInputId = this.state.editingField.input.id;
+    if (this.state.editingFields.length > 0) {
+      activeInputId = this.state.editingFields[0].input.id;
     }
 
     this.setState({saving: true});
@@ -182,11 +204,12 @@ class FormController extends Controller {
    * depending upon the field which is currently focused.
    */
   _focusGroup() {
-    if (!this.state.editingField) {
+    var fieldContainers = this.state.editingFields.map(field => field.container);
+    if (fieldContainers.length === 0) {
       return null;
     }
 
-    return [this.refs.formActions, this.state.editingField.container];
+    return [this.refs.formActions].concat(fieldContainers);
   }
 
   _trapFocus() {
@@ -195,16 +218,32 @@ class FormController extends Controller {
       // otherwise let the user focus another field in the form or move focus
       // outside the form entirely.
       if (this.state.dirty) {
-        return this.state.editingField.input;
+        return this.state.editingFields[0].input;
       }
 
       // If the user tabs out of the form, clear the editing state
       if (!this.element.contains(newFocusedElement)) {
-        this.setState({editingField: null});
+        this.setState({editingFields: []});
       }
 
       return null;
     });
+  }
+
+  /**
+   * Return the set of fields that should be displayed in the editing state
+   * when a given field is selected.
+   */
+  _editSet(field) {
+    // Currently we have two types of form:
+    // 1. Forms which only edit one field at a time
+    // 2. Forms with hidden fields (eg. the Change Email, Change Password forms)
+    //    which should enable editing all fields when any is focused
+    if (this._fields.some(field => isHiddenField(field.container))) {
+      return this._fields;
+    } else {
+      return [field];
+    }
   }
 
   /**

--- a/h/static/scripts/controllers/form-controller.js
+++ b/h/static/scripts/controllers/form-controller.js
@@ -11,15 +11,34 @@ function shouldAutosubmit(type) {
 }
 
 /**
- * Return true if a form field should be hidden until the user starts
- * editing the form.
+ * Return true if a form field should be hidden until the user starts editing
+ * the form.
+ *
+ * @param {Element} el - The container for an individual form field, which may
+ *        have a "data-hide-until-active" attribute.
  */
 function isHiddenField(el) {
   return el.dataset.hideUntilActive;
 }
 
 /**
- * A controller which adds inline editing functionality to forms
+ * @typedef {Object} Field
+ * @property {Element} container - The container element for an input field
+ * @property {HTMLInputElement} input - The <input> element for an input field
+ * @property {HTMLLabelElement} label - The <label> element for a field
+ */
+
+/**
+ * A controller which adds inline editing functionality to forms.
+ *
+ * When forms have inline editing enabled, individual fields can be edited and
+ * changes can be saved without a full page reload.
+ *
+ * Instead when the user focuses a field, Save/Cancel buttons are shown beneath
+ * the field and everything else on the page is dimmed. When the user clicks 'Save'
+ * the form is submitted to the server via a `fetch()` request and the HTML of
+ * the form is updated with the result, which may be a successfully updated form
+ * or a re-rendered version of the form with validation errors indicated.
  */
 class FormController extends Controller {
   constructor(element, options) {
@@ -140,6 +159,12 @@ class FormController extends Controller {
     this._updateFields(state);
   }
 
+  /**
+   * Update the appearance of individual form fields to match the current state
+   * of the form.
+   *
+   * @param {Object} state - The internal state of the form
+   */
   _updateFields(state) {
     this._fields.forEach(field => {
       setElementState(field.container, {
@@ -238,6 +263,9 @@ class FormController extends Controller {
     return [this.refs.formActions].concat(fieldContainers);
   }
 
+  /**
+   * Trap focus within the set of form fields currently being edited.
+   */
   _trapFocus() {
     this._releaseFocus = modalFocus.trap(this._focusGroup(), newFocusedElement => {
       // Keep focus in the current field when it has unsaved changes,
@@ -259,6 +287,9 @@ class FormController extends Controller {
   /**
    * Return the set of fields that should be displayed in the editing state
    * when a given field is selected.
+   *
+   * @param {Field} - The field that was focused
+   * @return {Field[]} - Set of fields that should be active for editing
    */
   _editSet(field) {
     // Currently we have two types of form:

--- a/h/static/scripts/polyfills.js
+++ b/h/static/scripts/polyfills.js
@@ -9,6 +9,9 @@ require('core-js/fn/array/includes');
 require('core-js/fn/object/assign');
 require('core-js/fn/string/starts-with');
 
+// Element.prototype.dataset, required by IE 10
+require('element-dataset')();
+
 // URL constructor, required by IE 10/11,
 // early versions of Microsoft Edge.
 try {

--- a/h/static/scripts/polyfills.js
+++ b/h/static/scripts/polyfills.js
@@ -5,6 +5,7 @@ require('core-js/es6/promise');
 require('core-js/fn/array/find');
 require('core-js/fn/array/find-index');
 require('core-js/fn/array/from');
+require('core-js/fn/array/includes');
 require('core-js/fn/object/assign');
 require('core-js/fn/string/starts-with');
 

--- a/h/static/styles/partials-v2/_form-input.scss
+++ b/h/static/styles/partials-v2/_form-input.scss
@@ -33,6 +33,10 @@
     z-index: $zindex-modal-content;
   }
 
+  .form-input.is-hidden {
+    display: none;
+  }
+
   .form-input.is-error {
     & > .form-input__label {
       color: $brand;
@@ -169,8 +173,11 @@
     border-width: 2px;
   }
 
+  // Show a thick border around focused input fields. When inline editing is
+  // enabled, we may also show the field as focused if its Save/Cancel buttons
+  // are focused but the <input> itself is not
   .form-input__input:focus,
-  .form-input.is-editing > .form-input__input {
+  .form-input.is-focused > .form-input__input {
     @include thick-border;
     border-color: $grey-6;
   }

--- a/h/templates/deform/mapping_item.jinja2
+++ b/h/templates/deform/mapping_item.jinja2
@@ -19,7 +19,8 @@
 <div class="{{ field_class }}
             js-form-input
             {% if field.error %}{{ field_error_state_class }}{% endif %}
-            {% if show_char_counter %} js-character-limit {%- endif %}"
+            {% if show_char_counter %} js-character-limit {%- endif %}
+            {% if field.schema.hide_until_form_active %} is-hidden-when-loading {%- endif %}"
      {%- if field.description -%}
      title="{{ _(field.description) }}"
      {% endif %}

--- a/h/templates/deform/mapping_item.jinja2
+++ b/h/templates/deform/mapping_item.jinja2
@@ -23,6 +23,9 @@
      {%- if field.description -%}
      title="{{ _(field.description) }}"
      {% endif %}
+     {%- if field.schema.hide_until_form_active -%}
+     data-hide-until-active="true"
+     {% endif %}
      id="item-{{ field.oid }}">
 {% endif -%}
 

--- a/h/templates/deform/mapping_item.jinja2
+++ b/h/templates/deform/mapping_item.jinja2
@@ -27,6 +27,10 @@
      {%- if field.schema.hide_until_form_active -%}
      data-hide-until-active="true"
      {% endif %}
+     {%- if field.schema.inactive_label -%}
+     data-active-label="{{ _(field.title) }}"
+     data-inactive-label="{{ _(field.schema.inactive_label) }}"
+     {%- endif %}
      id="item-{{ field.oid }}">
 {% endif -%}
 
@@ -38,7 +42,8 @@
          title="{{ _(field.description) }}"
          {% endif %}
          for="{{ field.oid }}">
-           {{ _(field.title) }}
+         <span class="{%- if field.schema.inactive_label %}is-hidden-when-loading{% endif %}"
+               data-ref="label">{{ _(field.title) }}</span>
     {%- if field.required and field.widget.show_required and feature('activity_pages') -%}
       <span class="form-input__required">*</span>
     {% endif -%}

--- a/h/views/accounts.py
+++ b/h/views/accounts.py
@@ -473,8 +473,13 @@ class AccountController(object):
     def __init__(self, request):
         self.request = request
 
+        save_email_label = _('Change email address')
+        save_password_label = _('Change password')
+
         if request.feature('activity_pages'):
             email_schema = schemas.EmailChangeSchema().bind(request=request)
+            save_email_label = _('Save')
+            save_password_label = _('Save')
         else:
             email_schema = schemas.LegacyEmailChangeSchema().bind(request=request)
 
@@ -486,13 +491,15 @@ class AccountController(object):
 
         self.forms = {
             'email': request.create_form(email_schema,
-                                         buttons=(_('Change email address'),),
+                                         buttons=(save_email_label,),
                                          formid='email',
-                                         counter=counter),
+                                         counter=counter,
+                                         use_inline_editing=True),
             'password': request.create_form(password_schema,
-                                            buttons=(_('Change password'),),
+                                            buttons=(save_password_label,),
                                             formid='password',
-                                            counter=counter),
+                                            counter=counter,
+                                            use_inline_editing=True),
         }
 
     @view_config(request_method='GET')

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "browserify-shim": "^3.8.12",
     "commander": "^2.9.0",
     "core-js": "^1.2.5",
+    "element-dataset": "^1.3.0",
     "end-of-stream": "^1.1.0",
     "exorcist": "^0.4.0",
     "gulp": "^3.9.1",


### PR DESCRIPTION
**~~Depends on https://github.com/hypothesis/h/pull/3814~~**
**~~Depends on https://github.com/hypothesis/h/pull/3950~~**

----

This implements inline editing for the accounts forms. Compared to the other forms with inline editing, these have a couple of differences:

1. There are a set of fields which are initially hidden, but then shown when a visible field is focused - eg. in the case of the Change Email form, the Confirm Password field.
2. When any of the fields in these forms are focused, all of the fields should be editable - that is, focusable via keyboard/mouse and raised above the backdrop

The first commit implements support for these features in forms with inline editing. The second commit enables inline editing for the Change Email/Change Password forms and hides the Confirm Password, New Password and Confirm New Password fields by default.

I also found a bug where it was possible for the page to end up in a state with focus ping-ponging continually between the two forms when tabbing from one to the other. This is fixed by the third commit which simplifies and removes asynchronicity from the logic that handles tabbing out of the form.

Compared to the mocks, I made one UX change which is that the password field is labelled "Current Password" rather than just "Password" to avoid ambiguity.

I have a reservation which is that when editing a field, I don't think there is enough contrast between the fields that are not editable _behind_ the modal backdrop and the ones that are active. I'll talk with Conor about this and address as a follow-up.