### PR TITLE
Fix search icon alignment

### DIFF
--- a/h/static/styles/partials-v2/_search-bar.scss
+++ b/h/static/styles/partials-v2/_search-bar.scss
@@ -29,7 +29,7 @@
   height: 14px;
   left: 7px;
   position: absolute;
-  top: 7px;
+  top: 4px;
 
   color: $grey-5;
 }


### PR DESCRIPTION
Fix the vertical position of the looking-glass icon in the search field
on the `/search` page.

The height of the `<input>` that contains this icon (including padding and
margin) is `23px`. The height of the icon itself is `16px`. That leaves
23 - 16 = `7px` to be evenly distributed above and below the icon. So
there should be 7/2 = `3.5px` between the top of the icon and the top of
the `<input>`s border (of course the browser will round that to 3 or 4px so it won't be perfect).

If you actually enter `3.5px` into the CSS then the icon looks slightly
too high to my eye. Perhaps Chrome rounds down to `3px`. Imo it looks
better (less noticeable) to have the thin (and diagonal) handle of the
looking glass hanging slightly too far down, than to have its large
circle too high up. So I went with `4px`.

The design mockup:

![navbar_-_mobile](https://cloud.githubusercontent.com/assets/22498/18788453/cae72804-819e-11e6-953d-dcb264e2cdad.png)

On master:

![screenshot from 2016-09-23 14-58-48](https://cloud.githubusercontent.com/assets/22498/18788332/57e952aa-819e-11e6-8512-977370f24369.png)

On this branch:

![screenshot from 2016-09-23 15-03-58](https://cloud.githubusercontent.com/assets/22498/18788500/fcd32110-819e-11e6-9245-f271fc95351c.png)

Fixes https://github.com/hypothesis/h/issues/3705