### PR TITLE
Remove deprecated `selection_tabs` feature flag

### DIFF
--- a/h/models/feature.py
+++ b/h/models/feature.py
@@ -36,9 +36,7 @@ FEATURES = {
 #
 # 4. Finally, remove the feature from FEATURES_PENDING_REMOVAL.
 #
-FEATURES_PENDING_REMOVAL = {
-    'selection_tabs': "Show the tabs to select between annotations and notes?",
-}
+FEATURES_PENDING_REMOVAL = {}
 
 
 class Feature(Base):


### PR DESCRIPTION
This has been removed from the client on August 5th
(https://github.com/hypothesis/client/commit/b9b099b7d8f13d089d6616f20e87c47fc4a91b26)