### PR TITLE
Fix vertical alignment in document bucket headers

### DIFF
--- a/h/static/styles/partials-v2/_search.scss
+++ b/h/static/styles/partials-v2/_search.scss
@@ -46,6 +46,7 @@
 .search-result-bucket__header {
   display: flex;
   flex-direction: row;
+  align-items: center;
   padding: 10px 10px;
 
   cursor: pointer;
@@ -62,7 +63,6 @@
 .search-result-bucket__title {
   font-weight: bold;
   flex-grow: 1;
-  margin-bottom: 10px;
 }
 
 .search-result-bucket__annotations-count {
@@ -72,11 +72,17 @@
 
 .search-result-bucket__annotations-count-container {
   width: 30px;
-  padding: 5px 0px;
   background-color: $grey-2;
   text-align: center;
   border-radius: 2px;
   float: right;
+}
+
+.search-result-bucket__domain,
+.search-result-bucket__title,
+.search-result-bucket__annotations-count-container {
+  padding-top: 5px;
+  padding-bottom: 5px;
 }
 
 .search-result-bucket__content {


### PR DESCRIPTION
Fixes #3722.

The design:

![document_component_-_states](https://cloud.githubusercontent.com/assets/22498/17783676/fc326cba-6570-11e6-93a8-5fa1ccc7c466.png)

On master:

![screenshot from 2016-09-23 16-26-03](https://cloud.githubusercontent.com/assets/22498/18791412/88c56cb8-81aa-11e6-86a5-a06d0a4d8222.png)

On this branch:

![screenshot from 2016-09-23 16-25-40](https://cloud.githubusercontent.com/assets/22498/18791419/90fef20a-81aa-11e6-8fec-ea594b72b799.png)

I think the vertical alignment is still messed up on small screen sizes when media queries kick in.