### PR TITLE
Fix space between document bucket title and count

### DIFF
--- a/h/static/styles/partials-v2/_search.scss
+++ b/h/static/styles/partials-v2/_search.scss
@@ -63,6 +63,7 @@
   font-weight: bold;
   flex-grow: 1;
   margin-bottom: 10px;
+  margin-right: 5px;
 }
 
 .search-result-bucket__annotations-count {


### PR DESCRIPTION
Fixes #3738.

On master:

![screenshot from 2016-09-23 16-29-46](https://cloud.githubusercontent.com/assets/22498/18791709/bf5bac00-81ab-11e6-9aa4-c4a46cd2d0cb.png)

On this branch:

![screenshot from 2016-09-23 16-33-45](https://cloud.githubusercontent.com/assets/22498/18791724/c753273a-81ab-11e6-8cac-e2eccaed2cf1.png)
