### PR TITLE
Don't wrap URLs unnecessarily

### DIFF
--- a/h/static/styles/partials-v2/_search.scss
+++ b/h/static/styles/partials-v2/_search.scss
@@ -106,7 +106,7 @@
 // Card displaying stats about a group of annotations in search results
 .search-bucket-stats {
   @include font-normal;
-  width: 210px;
+  width: 260px;
   margin-left: 30px;
   word-wrap: break-word;
 }


### PR DESCRIPTION
Don't unnecessarily wrap URLs shown inside document buckets - expand the
div that the URL is wrapped within to fill all of the horizontal space
available to it.

Fixes #3741.

On master:

![screenshot from 2016-09-23 16-45-13](https://cloud.githubusercontent.com/assets/22498/18792163/5661cdc2-81ad-11e6-8d22-614fcb52c002.png)

![screenshot from 2016-09-23 16-44-35](https://cloud.githubusercontent.com/assets/22498/18792164/56780ab0-81ad-11e6-87bc-82babb386167.png)

On this branch:

![screenshot from 2016-09-23 16-46-01](https://cloud.githubusercontent.com/assets/22498/18792175/5fee106c-81ad-11e6-9ac2-7014bf9323c2.png)

![screenshot from 2016-09-23 16-48-15](https://cloud.githubusercontent.com/assets/22498/18792251/9dc258da-81ad-11e6-8b08-c236bba098dd.png)
