### PR TITLE
Extract API exception views

### DIFF
--- a/h/exceptions.py
+++ b/h/exceptions.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+
+"""Exceptions raised by the h application."""
+
+from __future__ import unicode_literals
+
+
+# N.B. This class **only** covers exceptions thrown by API code provided by
+# the h package. memex code has its own base APIError class.
+class APIError(Exception):
+
+    """Base exception for problems handling API requests."""
+
+    def __init__(self, message, status_code=500):
+        self.status_code = status_code
+        super(APIError, self).__init__(message)

--- a/h/util/view.py
+++ b/h/util/view.py
@@ -1,6 +1,18 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
+
 from pyramid.view import view_config
+
+
+def handle_exception(request):
+    """Handle an uncaught exception for the passed request."""
+    request.response.status_int = 500
+    request.sentry.captureException()
+    # In debug mode we should just reraise, so that the exception is caught by
+    # the debug toolbar.
+    if request.debug:
+        raise
 
 
 def json_view(**settings):

--- a/h/views/__init__.py
+++ b/h/views/__init__.py
@@ -2,7 +2,8 @@
 
 
 def includeme(config):
-    config.include('h.views.exceptions')
+    config.scan(__name__)
+
     config.include('h.views.help')
     config.include('h.views.home')
     config.include('h.views.main')

--- a/h/views/api_exceptions.py
+++ b/h/views/api_exceptions.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+
+"""
+API exception views.
+
+Views rendered by the web application in response to exceptions thrown within
+API views.
+"""
+
+from __future__ import unicode_literals
+
+from pyramid.view import forbidden_view_config
+from pyramid.view import notfound_view_config
+
+from h.i18n import TranslationString as _
+from h.exceptions import APIError
+from h.util.view import handle_exception, json_view
+
+
+# Within the API, render a JSON 403/404 message.
+@forbidden_view_config(path_info='/api/', renderer='json')
+@notfound_view_config(path_info='/api/', renderer='json')
+def api_notfound(request):
+    """Handle a request for an unknown/forbidden resource within the API."""
+    request.response.status_code = 404
+    message = _("Either the resource you requested doesn't exist, or you are "
+                "not currently authorized to see it.")
+    return {'status': 'failure', 'reason': message}
+
+
+@json_view(context=APIError)
+def api_error(context, request):
+    """Handle an expected/deliberately thrown API exception."""
+    request.response.status_code = context.status_code
+    return {'status': 'failure', 'reason': context.message}
+
+
+@json_view(context=Exception)
+def json_error(request):
+    """Handle an unexpected exception where the request asked for JSON."""
+    handle_exception(request)
+    message = _("Uh-oh, something went wrong! We're very sorry, our "
+                "application wasn't able to load this page. The team has "
+                "been notified and we'll fix it shortly. If the problem "
+                "persists or you'd like more information please email "
+                "support@hypothes.is with the subject 'Internal Server "
+                "Error'.")
+    return {'status': 'failure', 'reason': message}

--- a/tests/h/exceptions_test.py
+++ b/tests/h/exceptions_test.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from h.exceptions import APIError
+
+
+class TestAPIError(object):
+    def test_message(self):
+        exc = APIError('some message')
+
+        assert exc.message == 'some message'
+
+    def test_default_status_code(self):
+        exc = APIError('some message')
+
+        assert exc.status_code == 500
+
+    def test_custom_status_code(self):
+        exc = APIError('some message', status_code=418)
+
+        assert exc.status_code == 418

--- a/tests/h/views/api_exceptions_test.py
+++ b/tests/h/views/api_exceptions_test.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from h.exceptions import APIError
+from h.views.api_exceptions import api_notfound, api_error, json_error
+
+
+def test_api_notfound_view(pyramid_request):
+    result = api_notfound(pyramid_request)
+
+    assert pyramid_request.response.status_int == 404
+    assert result['status'] == 'failure'
+    assert result['reason']
+
+
+def test_api_error_view(pyramid_request):
+    context = APIError(message='asplosions!', status_code=418)
+
+    result = api_error(context, pyramid_request)
+
+    assert pyramid_request.response.status_code == 418
+    assert result['status'] == 'failure'
+    assert result['reason'] == 'asplosions!'
+
+
+def test_json_error_view(patch, pyramid_request):
+    handle_exception = patch('h.views.api_exceptions.handle_exception')
+
+    result = json_error(pyramid_request)
+
+    handle_exception.assert_called_once_with(pyramid_request)
+    assert result['status'] == 'failure'
+    assert result['reason']

--- a/tests/h/views/exceptions_test.py
+++ b/tests/h/views/exceptions_test.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from h.views.exceptions import notfound, error
+
+
+def test_notfound_view(pyramid_request):
+    result = notfound(pyramid_request)
+
+    assert pyramid_request.response.status_int == 404
+    assert result == {}
+
+
+def test_error_view(patch, pyramid_request):
+    handle_exception = patch('h.views.exceptions.handle_exception')
+
+    result = error(pyramid_request)
+
+    handle_exception.assert_called_once_with(pyramid_request)
+    assert result == {}


### PR DESCRIPTION
This PR extracts the exception views for the API and JSON requests into its own view module, `h/views/api_exceptions.py`.

Other changes include:

- Updating the "reason" supplied for a 403/404 to be a human-readable string rather than "not_found" as before. This makes the response consistent with other JSON error responses.
- Adding a "status" field to the response for an uncaught exception when the request specifies "Accept: application/json". This makes the response consistent with other JSON error responses.
- Adding an exception view to catch deliberately thrown APIErrors. This is not currently used.
- Tests added for both application and API exception views.
- We rely on a `config.scan(...)` of the whole `h.views` package rather than having to define an `includeme` in each view module.
- The generic handler for uncaught exceptions has been extracted into `h.util.view.handle_exception` and tests added.