### PR TITLE
Fix ragged document bucket title left-alignment

### DIFF
--- a/h/static/styles/partials-v2/_search.scss
+++ b/h/static/styles/partials-v2/_search.scss
@@ -54,6 +54,8 @@
 }
 
 .search-result-bucket__domain {
+  flex-grow: 0;
+  flex-shrink: 0;
   width: 120px;
   color: $grey-4;
   margin-right: 10px;


### PR DESCRIPTION
On master:

![peek 2016-09-26 12-10](https://cloud.githubusercontent.com/assets/22498/18832360/ec86717c-83e2-11e6-8c3a-75b63380a200.gif)

On this branch:

![hy](https://cloud.githubusercontent.com/assets/22498/18832364/f215df42-83e2-11e6-99ec-0b26feb05809.gif)
