### PR TITLE
Remove an unused CSS media query

### DIFF
--- a/h/static/styles/partials-v2/_search.scss
+++ b/h/static/styles/partials-v2/_search.scss
@@ -127,18 +127,6 @@
   margin-bottom: 20px;
 }
 
-// On large tablets and below, display bucket contents beneath rather than
-// alongside the domain
-@media screen and (max-width: $tablet-width + 100px) {
-    .search-result-bucket {
-      flex-direction: column;
-    }
-
-    .search-result-bucket__content {
-      margin-top: 10px;
-    }
-}
-
 // On normal tablets and below, display annotation stats below annotation list
 @media screen and (max-width: $tablet-width) {
 


### PR DESCRIPTION
What this media query used to do (before <https://github.com/hypothesis/h/commit/ec8c98593ea0e4276d4b714949e4356cfc8e5c3e> broke it):

![peek 2016-09-26 12-38](https://cloud.githubusercontent.com/assets/22498/18832958/38aff34a-83e6-11e6-93be-f8ea7bc6fc4f.gif)

Now on master it only adds 10px of vertical margin, which is pointless:

![peek 2016-09-26 13-04](https://cloud.githubusercontent.com/assets/22498/18833877/cfdbcf92-83ea-11e6-892f-8f75b1415216.gif)

On this branch it's gone completely:

![peek 2016-09-26 13-07](https://cloud.githubusercontent.com/assets/22498/18833890/de858326-83ea-11e6-9bf1-2cf4f753d108.gif)

A follow-up PR will be needed to re-implement what this media query did but make it work fully again.