### PR TITLE
Reimplement document bucket media query

### DIFF
--- a/h/static/styles/partials-v2/_search.scss
+++ b/h/static/styles/partials-v2/_search.scss
@@ -62,6 +62,11 @@
   word-wrap: break-word;
 }
 
+.search-result-bucket__title-and-annotations-count {
+  display: flex;
+  flex-grow: 1;
+}
+
 .search-result-bucket__title {
   font-weight: bold;
   flex-grow: 1;
@@ -127,6 +132,23 @@
 .search-bucket-stats__val {
   color: $grey-6;
   margin-bottom: 20px;
+}
+
+// On large tablets and below, display bucket contents beneath rather than
+// alongside the domain
+@media screen and (max-width: $tablet-width + 100px) {
+    .search-result-bucket__header {
+      flex-direction: column;
+      align-items: flex-start;
+    }
+
+    .search-result-bucket__domain {
+      width: 100%;
+    }
+
+    .search-result-bucket__content {
+      margin-top: 10px;
+    }
 }
 
 // On normal tablets and below, display annotation stats below annotation list

--- a/h/static/styles/partials-v2/_search.scss
+++ b/h/static/styles/partials-v2/_search.scss
@@ -138,7 +138,10 @@
 @media screen and (max-width: $tablet-width + 100px) {
     .search-result-bucket__header {
       flex-direction: column;
-      align-items: flex-start;
+
+      // Make domain and title containers stretch to the full width of the
+      // column
+      align-items: stretch;
     }
 
     .search-result-bucket__domain {

--- a/h/static/styles/partials-v2/_search.scss
+++ b/h/static/styles/partials-v2/_search.scss
@@ -46,7 +46,6 @@
 .search-result-bucket__header {
   display: flex;
   flex-direction: row;
-  align-items: center;
   padding: 10px 10px;
 
   cursor: pointer;

--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -46,17 +46,19 @@
     <div class="search-result-bucket__domain">
       {{ bucket.domain }}
     </div>
-    <div class="search-result-bucket__title">
-      {% if bucket.title %}
-        {{ bucket.title }}
-      {% else %}
-        {% trans %}Untitled document{% endtrans %}
-      {% endif %}
+    <div class="search-result-bucket__title-and-annotations-count">
+        <div class="search-result-bucket__title">
+        {% if bucket.title %}
+            {{ bucket.title }}
+        {% else %}
+            {% trans %}Untitled document{% endtrans %}
+        {% endif %}
+        </div>
+        <div class="search-result-bucket__annotations-count">
+        <div class="search-result-bucket__annotations-count-container">
+            {{ bucket.annotations_count }}
+        </div>
     </div>
-    <div class="search-result-bucket__annotations-count">
-      <div class="search-result-bucket__annotations-count-container">
-        {{ bucket.annotations_count }}
-      </div>
     </div>
   </div>
 


### PR DESCRIPTION
Depends on <https://github.com/hypothesis/h/pull/3924> and <https://github.com/hypothesis/h/pull/3925>.

On master the domain in a document bucket header remains to the left of the title and annotations count as the screen shrinks, which looks bad on small screens:

![screenshot from 2016-09-26 14-06-33](https://cloud.githubusercontent.com/assets/22498/18835326/777d05de-83f2-11e6-9a26-deee99a87b0f.png)

This is a regression. On this branch the domain moves above the title and annotations count on small screens, as it used to do:

![peek 2016-09-26 13-57](https://cloud.githubusercontent.com/assets/22498/18835201/d4d6022c-83f1-11e6-8da4-b6ee6cf5cb19.gif)

![screenshot from 2016-09-26 14-00-21](https://cloud.githubusercontent.com/assets/22498/18835206/d849a8be-83f1-11e6-9ad8-ecae4550aa10.png)

Tested in Chrome, Firefox and Safari on iOS.