### PR TITLE
Add a preliminary "create user" API endpoint

### DIFF
--- a/h/exceptions.py
+++ b/h/exceptions.py
@@ -4,6 +4,8 @@
 
 from __future__ import unicode_literals
 
+from h.i18n import TranslationString as _
+
 
 # N.B. This class **only** covers exceptions thrown by API code provided by
 # the h package. memex code has its own base APIError class.
@@ -14,3 +16,15 @@ class APIError(Exception):
     def __init__(self, message, status_code=500):
         self.status_code = status_code
         super(APIError, self).__init__(message)
+
+
+class ClientUnauthorized(APIError):
+
+    """
+    Exception raised if the client credentials provided for an API request
+    were missing or invalid.
+    """
+
+    def __init__(self):
+        message = _('Client credentials are invalid.')
+        super(ClientUnauthorized, self).__init__(message, status_code=403)

--- a/h/routes.py
+++ b/h/routes.py
@@ -61,6 +61,7 @@ def includeme(config):
     # API (other than those provided by memex)
     config.add_route('badge', '/api/badge')
     config.add_route('token', '/api/token')
+    config.add_route('api.users', '/api/users')
 
     # Client
     config.add_route('session', '/app')

--- a/h/views/api_users.py
+++ b/h/views/api_users.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import hmac
+
+import sqlalchemy as sa
+
+from h.auth.util import basic_auth_creds
+from h.exceptions import ClientUnauthorized
+from h.models import AuthClient
+from h.util.view import json_view
+
+
+@json_view(route_name='api.users', request_method='POST')
+def create(request):
+    """
+    Create a user.
+
+    This API endpoint allows authorised clients (those able to provide a valid
+    Client ID and Client Secret) to create users in their authority. These
+    users are created pre-activated, and are unable to log in to the web
+    service directly.
+    """
+    client = _request_client(request)
+    payload = request.json_body
+
+    user_props = {
+        'authority': client.authority,
+        'username': payload['username'],
+        'email': payload['email'],
+    }
+
+    user_signup_service = request.find_service(name='user_signup')
+    user = user_signup_service.signup(require_activation=False, **user_props)
+
+    return {
+        'authority': user.authority,
+        'email': user.email,
+        'userid': user.userid,
+        'username': user.username,
+    }
+
+
+def _request_client(request):
+    creds = basic_auth_creds(request)
+    if creds is None:
+        raise ClientUnauthorized()
+
+    # We fetch the client by its ID and then do a constant-time comparison of
+    # the secret with that provided in the request.
+    #
+    # It is important not to include the secret as part of the SQL query
+    # because the resulting code may be subject to a timing attack.
+    client_id, client_secret = creds
+    try:
+        client = request.db.query(AuthClient).get(client_id)
+    except sa.exc.StatementError:  # client_id is malformed
+        raise ClientUnauthorized()
+    if client is None:
+        raise ClientUnauthorized()
+
+    if not hmac.compare_digest(client.secret, client_secret):
+        raise ClientUnauthorized()
+
+    return client

--- a/tests/common/factories.py
+++ b/tests/common/factories.py
@@ -191,6 +191,13 @@ class Activation(ModelFactory):
         force_flush = True
 
 
+class AuthClient(ModelFactory):
+
+    class Meta(object):
+        model = models.AuthClient
+        force_flush = True
+
+
 class User(factory.Factory):
 
     """A factory class that generates h.models.User objects.

--- a/tests/h/exceptions_test.py
+++ b/tests/h/exceptions_test.py
@@ -2,7 +2,7 @@
 
 from __future__ import unicode_literals
 
-from h.exceptions import APIError
+from h.exceptions import APIError, ClientUnauthorized
 
 
 class TestAPIError(object):
@@ -20,3 +20,15 @@ class TestAPIError(object):
         exc = APIError('some message', status_code=418)
 
         assert exc.status_code == 418
+
+
+class TestClientUnauthorized(object):
+    def test_message(self):
+        exc = ClientUnauthorized()
+
+        assert 'credentials are invalid' in exc.message
+
+    def test_status_code(self):
+        exc = ClientUnauthorized()
+
+        assert exc.status_code == 403

--- a/tests/h/routes_test.py
+++ b/tests/h/routes_test.py
@@ -58,6 +58,7 @@ def test_includeme():
         call('assets', '/assets/*subpath'),
         call('badge', '/api/badge'),
         call('token', '/api/token'),
+        call('api.users', '/api/users'),
         call('session', '/app'),
         call('widget', '/app.html'),
         call('embed', '/embed.js'),

--- a/tests/h/views/api_users_test.py
+++ b/tests/h/views/api_users_test.py
@@ -1,0 +1,125 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import pytest
+from mock import Mock
+
+from h.accounts.services import UserSignupService
+from h.exceptions import ClientUnauthorized
+from h.views.api_users import create
+
+
+@pytest.mark.usefixtures('auth_client',
+                         'basic_auth_creds',
+                         'user_signup_service')
+class TestCreate(object):
+
+    def test_returns_user_object(self,
+                                 auth_client,
+                                 basic_auth_creds,
+                                 factories,
+                                 pyramid_request,
+                                 user_signup_service,
+                                 valid_payload):
+        basic_auth_creds.return_value = (auth_client.id, auth_client.secret)
+        pyramid_request.json_body = valid_payload
+        user_signup_service.signup.return_value = factories.User(**valid_payload)
+
+        result = create(pyramid_request)
+
+        assert result == {
+            'userid': 'acct:jeremy@weylandindustries.com',
+            'username': 'jeremy',
+            'email': 'jeremy@weylandtech.com',
+            'authority': 'weylandindustries.com',
+        }
+
+    def test_signs_up_user(self,
+                           auth_client,
+                           basic_auth_creds,
+                           factories,
+                           pyramid_request,
+                           user_signup_service,
+                           valid_payload):
+        basic_auth_creds.return_value = (auth_client.id, auth_client.secret)
+        pyramid_request.json_body = valid_payload
+        user_signup_service.signup.return_value = factories.User(**valid_payload)
+
+        create(pyramid_request)
+
+        user_signup_service.signup.assert_called_once_with(
+            require_activation=False,
+            authority='weylandindustries.com',
+            username='jeremy',
+            email='jeremy@weylandtech.com')
+
+    def test_raises_when_no_creds(self, pyramid_request, valid_payload):
+        pyramid_request.json_body = valid_payload
+
+        with pytest.raises(ClientUnauthorized):
+            create(pyramid_request)
+
+    def test_raises_when_malformed_client_id(self,
+                                             basic_auth_creds,
+                                             pyramid_request,
+                                             valid_payload):
+        basic_auth_creds.return_value = ('foobar', 'somerandomsecret')
+        pyramid_request.json_body = valid_payload
+
+        with pytest.raises(ClientUnauthorized):
+            create(pyramid_request)
+
+    def test_raises_when_no_client(self,
+                                   basic_auth_creds,
+                                   pyramid_request,
+                                   valid_payload):
+        basic_auth_creds.return_value = ('C69BA868-5089-4EE4-ABB6-63A1C38C395B',
+                                         'somerandomsecret')
+        pyramid_request.json_body = valid_payload
+
+        with pytest.raises(ClientUnauthorized):
+            create(pyramid_request)
+
+    def test_raises_when_client_secret_invalid(self,
+                                               auth_client,
+                                               basic_auth_creds,
+                                               pyramid_request,
+                                               valid_payload):
+        basic_auth_creds.return_value = (auth_client.id, 'incorrectsecret')
+        pyramid_request.json_body = valid_payload
+
+        with pytest.raises(ClientUnauthorized):
+            create(pyramid_request)
+
+
+@pytest.fixture
+def auth_client(factories):
+    return factories.AuthClient(authority='weylandindustries.com')
+
+
+@pytest.fixture
+def basic_auth_creds(patch):
+    basic_auth_creds = patch('h.views.api_users.basic_auth_creds')
+    basic_auth_creds.return_value = None
+    return basic_auth_creds
+
+
+@pytest.fixture
+def user_signup_service(db_session, factories, pyramid_config):
+    service = Mock(spec_set=UserSignupService(default_authority='example.com',
+                                              mailer=None,
+                                              session=None,
+                                              signup_email=None,
+                                              stats=None))
+    pyramid_config.register_service(service, name='user_signup')
+    return service
+
+
+@pytest.fixture
+def valid_payload():
+    return {
+        'authority': 'weylandindustries.com',
+        'email': 'jeremy@weylandtech.com',
+        'username': 'jeremy',
+    }


### PR DESCRIPTION
In order to allow third-party accounts clients to furnish their users with grant tokens that allow them to use our API, we need those users to first exist in our database.

This commit adds a relatively straightforward "create user" API endpoint that checks the client's credentials (which must be provided as an HTTP Basic username and password) and creates a user from provided parameters if they validate.

At this stage, I haven't hooked up any useful validation of the payload provided by the HTTP client, but that doesn't matter in production, as we have no AuthClients in the database and so all requests to the endpoint will simply get 403 responses anyway.

In a subsequent pull request I plan to hook up the JSON Schema added in eb4ee79, which will provide proper validation of the request payload and better error messages.

~~_**N.B.** This PR depends on #3923 and will need to be rebased once that has merged._~~