### PR TITLE
Ensure all annotations have a document (1/3)

### DIFF
--- a/h/migrations/versions/addee5d1686f_add_annotation_document_id_column.py
+++ b/h/migrations/versions/addee5d1686f_add_annotation_document_id_column.py
@@ -1,0 +1,28 @@
+"""
+Add annotation document_id column
+
+Revision ID: addee5d1686f
+Revises: 63e8b1fe1d4b
+Create Date: 2016-09-22 15:55:06.069829
+"""
+
+from __future__ import unicode_literals
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = 'addee5d1686f'
+down_revision = '63e8b1fe1d4b'
+
+
+def upgrade():
+    op.add_column('annotation', sa.Column('document_id',
+                                          sa.Integer,
+                                          sa.ForeignKey('document.id'),
+                                          nullable=True,
+                                          index=True))
+
+
+def downgrade():
+    op.drop_column('annotation', 'document_id')


### PR DESCRIPTION
_This is part of the bigger effort of ensuring that each annotation has one document, to achieve this we introduce a new `Annotation.document_id` column with a foreign key constraint, this way we have to ensure this on the database level and will get data integrity errors when we try to unintentionally remove a document from an annotation._

We add the new `document_id` column on the `annotation` table, note that at this moment we still allow `NULL` values because we still need to run the data migration. And there needs to be code that sets the `document_id` under normal circumstances.