### PR TITLE
Ensure all annotations have a document (2/3)

### DIFF
--- a/h/migrations/versions/bcdd81e23920_fill_in_missing_annotation_document_id.py
+++ b/h/migrations/versions/bcdd81e23920_fill_in_missing_annotation_document_id.py
@@ -1,0 +1,143 @@
+"""
+Fill in missing Annotation.document_id
+
+Revision ID: bcdd81e23920
+Revises: addee5d1686f
+Create Date: 2016-09-22 16:02:42.284670
+"""
+
+from __future__ import unicode_literals
+
+from collections import namedtuple
+import logging
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import subqueryload
+
+from memex.db import types
+from memex.uri import normalize as uri_normalize
+
+
+revision = 'bcdd81e23920'
+down_revision = 'addee5d1686f'
+
+log = logging.getLogger(__name__)
+
+Base = declarative_base()
+Session = sessionmaker()
+
+
+class Window(namedtuple('Window', ['start', 'end'])):
+    pass
+
+
+class Document(Base):
+    __tablename__ = 'document'
+    id = sa.Column(sa.Integer, primary_key=True)
+    created = sa.Column(sa.DateTime)
+    updated = sa.Column(sa.DateTime)
+    web_uri = sa.Column('web_uri', sa.UnicodeText())
+    document_uris = sa.orm.relationship('DocumentURI',
+                                        backref='document',
+                                        order_by='DocumentURI.created.asc()')
+
+
+class DocumentURI(Base):
+    __tablename__ = 'document_uri'
+    id = sa.Column(sa.Integer, primary_key=True)
+    created = sa.Column(sa.DateTime)
+    updated = sa.Column(sa.DateTime)
+    uri = sa.Column(sa.UnicodeText)
+    uri_normalized = sa.Column(sa.UnicodeText)
+    claimant = sa.Column(sa.UnicodeText)
+    claimant_normalized = sa.Column(sa.UnicodeText)
+    type = sa.Column(sa.UnicodeText)
+    document_id = sa.Column(sa.Integer,
+                            sa.ForeignKey('document.id'),
+                            nullable=False)
+
+
+class Annotation(Base):
+    __tablename__ = 'annotation'
+    id = sa.Column(types.URLSafeUUID, primary_key=True)
+    created = sa.Column(sa.DateTime)
+    updated = sa.Column(sa.DateTime)
+    target_uri = sa.Column(sa.UnicodeText)
+    target_uri_normalized = sa.Column(sa.UnicodeText)
+    document_id = sa.Column(sa.Integer,
+                            sa.ForeignKey('document.id'),
+                            nullable=True)
+    document = sa.orm.relationship('Document')
+    document_through_uri = sa.orm.relationship(
+        'Document',
+        secondary='document_uri',
+        primaryjoin='Annotation.target_uri_normalized == DocumentURI.uri_normalized',
+        secondaryjoin='DocumentURI.document_id == Document.id',
+        viewonly=True,
+        uselist=False)
+
+
+def upgrade():
+    session = Session(bind=op.get_bind())
+
+    windows = _fetch_windows(session)
+    session.rollback()
+
+    new_documents = 0
+    document_id_updated = 0
+
+    for window in windows:
+        query = session.query(Annotation) \
+            .filter(Annotation.updated.between(window.start, window.end)) \
+            .filter(Annotation.document_id.is_(None)) \
+            .order_by(Annotation.updated.asc())
+
+        for ann in query:
+            if ann.document_id:
+                continue
+
+            if ann.document_through_uri is None:
+                uri = ann.target_uri
+                uri_normalized = uri_normalize(uri)
+
+                doc = Document(created=ann.created, updated=ann.updated)
+                docuri = DocumentURI(created=ann.created,
+                                     updated=ann.updated,
+                                     claimant=uri,
+                                     claimant_normalized=uri_normalized,
+                                     uri=uri,
+                                     uri_normalized=uri_normalized,
+                                     type='self-claim',
+                                     document=doc)
+                ann.document = doc
+                session.flush()
+                new_documents += 1
+            else:
+                ann.document_id = ann.document_through_uri.id
+                document_id_updated += 1
+
+        session.commit()
+
+    log.debug('Created %d new documents' % new_documents)
+    log.debug('Filled in %d existing document ids' % document_id_updated)
+
+
+def downgrade():
+    pass
+
+
+def _fetch_windows(session, chunksize=200):
+    updated = session.query(Annotation.updated). \
+        filter_by(document_id=None). \
+        execution_options(stream_results=True). \
+        order_by(Annotation.updated.desc()).all()
+
+    count = len(updated)
+    windows = [Window(start=updated[min(x+chunksize, count)-1].updated,
+                      end=updated[x].updated)
+               for x in xrange(0, count, chunksize)]
+
+    return windows

--- a/src/memex/models/annotation.py
+++ b/src/memex/models/annotation.py
@@ -101,6 +101,10 @@ class Annotation(Base):
                       server_default=sa.func.jsonb('{}'),
                       nullable=False)
 
+    document_id = sa.Column(sa.Integer,
+                            sa.ForeignKey('document.id'),
+                            nullable=True)
+
     document = sa.orm.relationship('Document',
                                    secondary='document_uri',
                                    primaryjoin='Annotation.target_uri_normalized == DocumentURI.uri_normalized',

--- a/src/memex/models/document.py
+++ b/src/memex/models/document.py
@@ -404,9 +404,11 @@ def merge_documents(session, documents, updated=None):
 
 
 def update_document_metadata(session,
-                             annotation,
+                             target_uri,
                              document_meta_dicts,
-                             document_uri_dicts):
+                             document_uri_dicts,
+                             created=None,
+                             updated=None):
     """
     Create and update document metadata from the given annotation.
 
@@ -414,8 +416,8 @@ def update_document_metadata(session,
     and deleted in the database as required by the given annotation and
     document meta and uri dicts.
 
-    :param annotation: the annotation that the document metadata comes from
-    :type annotation: memex.models.Annotation
+    :param target_uri: the target_uri of the annotation from which the document metadata comes from
+    :type target_uri: unicode
 
     :param document_meta_dicts: the document metadata dicts that were derived
         by validation from the "document" dict that the client posted
@@ -425,35 +427,46 @@ def update_document_metadata(session,
         validation from the "document" dict that the client posted
     :type document_uri_dicts: list of dicts
 
+    :param created: Date and time value for the new document records
+    :type created: datetime.datetime
+
+    :param updated: Date and time value for the new document records
+    :type updated: datetime.datetime
+
     """
+    if created is None:
+        created = datetime.utcnow()
+    if updated is None:
+        updated = datetime.utcnow()
+
     documents = Document.find_or_create_by_uris(
         session,
-        annotation.target_uri,
+        target_uri,
         [u['uri'] for u in document_uri_dicts],
-        created=annotation.created,
-        updated=annotation.updated)
+        created=created,
+        updated=updated)
 
     if documents.count() > 1:
         document = merge_documents(session,
                                    documents,
-                                   updated=annotation.updated)
+                                   updated=updated)
     else:
         document = documents.first()
 
-    document.updated = annotation.updated
+    document.updated = updated
 
     for document_uri_dict in document_uri_dicts:
         create_or_update_document_uri(
             session=session,
             document=document,
-            created=annotation.created,
-            updated=annotation.updated,
+            created=created,
+            updated=updated,
             **document_uri_dict)
 
     for document_meta_dict in document_meta_dicts:
         create_or_update_document_meta(
             session=session,
             document=document,
-            created=annotation.created,
-            updated=annotation.updated,
+            created=created,
+            updated=updated,
             **document_meta_dict)

--- a/src/memex/models/document.py
+++ b/src/memex/models/document.py
@@ -433,6 +433,8 @@ def update_document_metadata(session,
     :param updated: Date and time value for the new document records
     :type updated: datetime.datetime
 
+    :returns: the matched or created document
+    :rtype: memex.models.Document
     """
     if created is None:
         created = datetime.utcnow()
@@ -470,3 +472,5 @@ def update_document_metadata(session,
             created=created,
             updated=updated,
             **document_meta_dict)
+
+    return document

--- a/src/memex/storage.py
+++ b/src/memex/storage.py
@@ -120,15 +120,18 @@ def create_annotation(request, data):
     annotation = models.Annotation(**data)
     annotation.created = created
     annotation.updated = updated
-    request.db.add(annotation)
 
-    models.update_document_metadata(
+    document = models.update_document_metadata(
         request.db,
         annotation.target_uri,
         document_meta_dicts,
         document_uri_dicts,
         created=created,
         updated=updated)
+    # FIXME: use `document` setter once the relationship changed to use the document_id column
+    annotation.document_id = document.id
+
+    request.db.add(annotation)
 
     return annotation
 

--- a/src/memex/storage.py
+++ b/src/memex/storage.py
@@ -175,12 +175,13 @@ def update_annotation(session, id_, data):
     if document:
         document_uri_dicts = document['document_uri_dicts']
         document_meta_dicts = document['document_meta_dicts']
-        models.update_document_metadata(
-            session,
-            annotation.target_uri,
-            document_meta_dicts,
-            document_uri_dicts,
-            updated=updated)
+        document = models.update_document_metadata(session,
+                                                   annotation.target_uri,
+                                                   document_meta_dicts,
+                                                   document_uri_dicts,
+                                                   updated=updated)
+        # FIXME: use `document` setter once the relationship changed to use the document_id column
+        annotation.document_id = document.id
 
     return annotation
 

--- a/src/memex/storage.py
+++ b/src/memex/storage.py
@@ -84,7 +84,7 @@ def create_annotation(request, data):
     :param data: a dictionary of annotation properties
     :type data: dict
 
-    :returns: the created annotation
+    :returns: the created and flushed annotation
     :rtype: dict
     """
     created = updated = datetime.utcnow()
@@ -132,6 +132,7 @@ def create_annotation(request, data):
     annotation.document_id = document.id
 
     request.db.add(annotation)
+    request.db.flush()
 
     return annotation
 

--- a/tests/common/factories.py
+++ b/tests/common/factories.py
@@ -178,9 +178,11 @@ class Annotation(ModelFactory):
 
         api_models.update_document_metadata(
             orm.object_session(self),
-            self,
+            self.target_uri,
             document_meta_dicts=document_meta_dicts,
             document_uri_dicts=document_uri_dicts,
+            created=self.created,
+            updated=self.updated,
         )
 
 

--- a/tests/memex/models/document_test.py
+++ b/tests/memex/models/document_test.py
@@ -680,9 +680,11 @@ class TestUpdateDocumentMetadata(object):
         ]
 
         document.update_document_metadata(session,
-                                          annotation,
+                                          annotation.target_uri,
                                           [],
-                                          document_uri_dicts)
+                                          document_uri_dicts,
+                                          annotation.created,
+                                          annotation.updated)
 
         Document.find_or_create_by_uris.assert_called_once_with(
             session,
@@ -706,7 +708,12 @@ class TestUpdateDocumentMetadata(object):
         Document.find_or_create_by_uris.return_value = mock.Mock(
             count=mock.Mock(return_value=3))
 
-        document.update_document_metadata(session, annotation, [], [])
+        document.update_document_metadata(session,
+                                          annotation.target_uri,
+                                          [],
+                                          [],
+                                          annotation.created,
+                                          annotation.updated)
 
         merge_documents.assert_called_once_with(
             session,
@@ -734,7 +741,12 @@ class TestUpdateDocumentMetadata(object):
         Document.find_or_create_by_uris.return_value.first.return_value = (
             document_)
 
-        document.update_document_metadata(session, annotation, [], [])
+        document.update_document_metadata(session,
+                                          annotation.target_uri,
+                                          [],
+                                          [],
+                                          annotation.created,
+                                          annotation.updated)
 
         assert document_.updated == annotation.updated
 
@@ -768,9 +780,11 @@ class TestUpdateDocumentMetadata(object):
         ]
 
         document.update_document_metadata(session,
-                                          annotation,
+                                          annotation.target_uri,
                                           [],
-                                          document_uri_dicts)
+                                          document_uri_dicts,
+                                          annotation.created,
+                                          annotation.updated)
 
         assert create_or_update_document_uri.call_count == 3
         for doc_uri_dict in document_uri_dicts:
@@ -810,9 +824,11 @@ class TestUpdateDocumentMetadata(object):
         ]
 
         document.update_document_metadata(session,
-                                          annotation,
+                                          annotation.target_uri,
                                           document_meta_dicts,
-                                          [])
+                                          [],
+                                          annotation.created,
+                                          annotation.updated)
 
         assert create_or_update_document_meta.call_count == 3
         for document_meta_dict in document_meta_dicts:

--- a/tests/memex/models/document_test.py
+++ b/tests/memex/models/document_test.py
@@ -840,6 +840,22 @@ class TestUpdateDocumentMetadata(object):
                 **document_meta_dict
             )
 
+    def test_it_returns_a_document(self,
+                                   annotation,
+                                   create_or_update_document_meta,
+                                   Document,
+                                   session):
+        Document.find_or_create_by_uris.return_value.count.return_value = 1
+
+        result = document.update_document_metadata(session,
+                                                   annotation.target_uri,
+                                                   [],
+                                                   [],
+                                                   annotation.created,
+                                                   annotation.updated)
+
+        assert result == Document.find_or_create_by_uris.return_value.first.return_value
+
     @pytest.fixture
     def annotation(self):
         return mock.Mock(spec=models.Annotation())

--- a/tests/memex/storage_test.py
+++ b/tests/memex/storage_test.py
@@ -94,8 +94,7 @@ class TestExpandURI(object):
         ]
 
 
-@pytest.mark.usefixtures('models',
-                         'update_document_metadata')
+@pytest.mark.usefixtures('models')
 class TestCreateAnnotation(object):
 
     def test_it_fetches_parent_annotation_for_replies(self,
@@ -181,8 +180,7 @@ class TestCreateAnnotation(object):
 
     def test_it_updates_the_document_metadata_from_the_annotation(self,
                                                                   models,
-                                                                  pyramid_request,
-                                                                  update_document_metadata):
+                                                                  pyramid_request):
         annotation_data = self.annotation_data()
         annotation_data['document']['document_meta_dicts'] = (
             mock.sentinel.document_meta_dicts)
@@ -191,7 +189,7 @@ class TestCreateAnnotation(object):
 
         storage.create_annotation(pyramid_request, annotation_data)
 
-        update_document_metadata.assert_called_once_with(
+        models.update_document_metadata.assert_called_once_with(
             pyramid_request.db,
             models.Annotation.return_value,
             mock.sentinel.document_meta_dicts,
@@ -235,8 +233,7 @@ class TestCreateAnnotation(object):
         }
 
 
-@pytest.mark.usefixtures('models',
-                         'update_document_metadata')
+@pytest.mark.usefixtures('models')
 class TestUpdateAnnotation(object):
 
     def test_it_gets_the_annotation_model(self,
@@ -325,7 +322,7 @@ class TestUpdateAnnotation(object):
             self,
             annotation_data,
             session,
-            update_document_metadata):
+            models):
         annotation = session.query.return_value.get.return_value
         annotation_data['document']['document_meta_dicts'] = (
             mock.sentinel.document_meta_dicts)
@@ -336,7 +333,7 @@ class TestUpdateAnnotation(object):
                                   'test_annotation_id',
                                   annotation_data)
 
-        update_document_metadata.assert_called_once_with(
+        models.update_document_metadata.assert_called_once_with(
             session,
             annotation,
             mock.sentinel.document_meta_dicts,
@@ -357,11 +354,11 @@ class TestUpdateAnnotation(object):
     def test_it_does_not_call_update_document_meta_if_no_document_in_data(
             self,
             session,
-            update_document_metadata):
+            models):
 
         storage.update_annotation(session, 'test_annotation_id', {})
 
-        assert not update_document_metadata.called
+        assert not models.update_document_metadata.called
 
     @pytest.fixture
     def annotation_data(self):
@@ -424,8 +421,3 @@ def session(db_session):
     session = mock.Mock(spec=db_session)
     session.query.return_value.get.return_value.extra = {}
     return session
-
-
-@pytest.fixture
-def update_document_metadata(patch):
-    return patch('memex.storage.models.update_document_metadata')

--- a/tests/memex/storage_test.py
+++ b/tests/memex/storage_test.py
@@ -357,6 +357,19 @@ class TestUpdateAnnotation(object):
             updated=datetime.utcnow()
         )
 
+    def test_it_updates_the_annotations_document_id(self,
+                                                    annotation_data,
+                                                    session,
+                                                    models):
+        annotation = session.query.return_value.get.return_value
+        document = mock.Mock()
+        models.update_document_metadata.return_value = document
+
+        storage.update_annotation(session,
+                                  'test_annotation_id',
+                                  annotation_data)
+        assert annotation.document_id == document.id
+
     def test_it_returns_the_annotation(self, annotation_data, session):
         annotation = storage.update_annotation(session,
                                                'test_annotation_id',

--- a/tests/memex/storage_test.py
+++ b/tests/memex/storage_test.py
@@ -199,6 +199,18 @@ class TestCreateAnnotation(object):
             updated=datetime.utcnow(),
         )
 
+    def test_it_sets_the_annotations_document_id(self,
+                                                 models,
+                                                 pyramid_request):
+        annotation_data = self.annotation_data()
+
+        document = mock.Mock()
+        models.update_document_metadata.return_value = document
+
+        ann = storage.create_annotation(pyramid_request, annotation_data)
+
+        assert ann.document_id == document.id
+
     def test_it_returns_the_annotation(self, models, pyramid_request):
         annotation = storage.create_annotation(pyramid_request,
                                                self.annotation_data())


### PR DESCRIPTION
**~~This depends on #3929 being merged and the migration being run on production.~~**

_This is part of the bigger effort of ensuring that each annotation has one document, to achieve this we introduce a new `Annotation.document_id` column with a foreign key constraint, this way we have to ensure this on the database level and will get data integrity errors when we try to unintentionally remove a document from an annotation._

This pull request makes sure we always set the `Annotation.document_id` when:

* creating annotations (`memex.storage.create_annotation`)
* updating annotations (`memex.storage.update_annotation`)
* merging documents (`memex.document.merge_documents`)

Note: I ran the data migration locally with a recent production dump and it took around 30 minutes to complete.