### PR TITLE
Ensure all annotations have a document (3/3)

### DIFF
--- a/h/migrations/versions/5dce9a8c42c2_disallow_null_annotation_document_id.py
+++ b/h/migrations/versions/5dce9a8c42c2_disallow_null_annotation_document_id.py
@@ -1,0 +1,23 @@
+"""
+Disallow null annotation document_id
+
+Revision ID: 5dce9a8c42c2
+Revises: bcdd81e23920
+Create Date: 2016-09-22 17:22:09.294825
+"""
+
+from __future__ import unicode_literals
+
+from alembic import op
+
+
+revision = '5dce9a8c42c2'
+down_revision = 'bcdd81e23920'
+
+
+def upgrade():
+    op.alter_column('annotation', 'document_id', nullable=False)
+
+
+def downgrade():
+    op.alter_column('annotation', 'document_id', nullable=True)

--- a/src/memex/models/annotation.py
+++ b/src/memex/models/annotation.py
@@ -103,7 +103,7 @@ class Annotation(Base):
 
     document_id = sa.Column(sa.Integer,
                             sa.ForeignKey('document.id'),
-                            nullable=True)
+                            nullable=False)
 
     document = sa.orm.relationship('Document',
                                    secondary='document_uri',

--- a/src/memex/models/annotation.py
+++ b/src/memex/models/annotation.py
@@ -105,13 +105,7 @@ class Annotation(Base):
                             sa.ForeignKey('document.id'),
                             nullable=False)
 
-    document = sa.orm.relationship('Document',
-                                   secondary='document_uri',
-                                   primaryjoin='Annotation.target_uri_normalized == DocumentURI.uri_normalized',
-                                   secondaryjoin='DocumentURI.document_id == Document.id',
-                                   viewonly=True,
-                                   uselist=False,
-                                   backref='annotations')
+    document = sa.orm.relationship('Document', backref='annotations')
 
     @hybrid_property
     def target_uri(self):

--- a/src/memex/storage.py
+++ b/src/memex/storage.py
@@ -128,8 +128,7 @@ def create_annotation(request, data):
         document_uri_dicts,
         created=created,
         updated=updated)
-    # FIXME: use `document` setter once the relationship changed to use the document_id column
-    annotation.document_id = document.id
+    annotation.document = document
 
     request.db.add(annotation)
     request.db.flush()
@@ -180,8 +179,7 @@ def update_annotation(session, id_, data):
                                                    document_meta_dicts,
                                                    document_uri_dicts,
                                                    updated=updated)
-        # FIXME: use `document` setter once the relationship changed to use the document_id column
-        annotation.document_id = document.id
+        annotation.document = document
 
     return annotation
 

--- a/tests/common/factories.py
+++ b/tests/common/factories.py
@@ -7,18 +7,29 @@ from __future__ import unicode_literals
 import base64
 import os
 from datetime import (datetime, timedelta)
-import random
 
 import factory
 import faker
-from sqlalchemy import orm
 
 from h import models
-from memex import models as api_models
+
+from ..memex import factories as memex_factories
 
 
 FAKER = faker.Factory.create()
 SESSION = None
+
+Annotation = memex_factories.Annotation
+Document = memex_factories.Document
+DocumentMeta = memex_factories.DocumentMeta
+DocumentURI = memex_factories.DocumentURI
+
+
+def set_session(value):
+    global SESSION
+
+    SESSION = value
+    memex_factories.SESSION = value
 
 
 class ModelFactory(factory.alchemy.SQLAlchemyModelFactory):
@@ -39,154 +50,6 @@ class ModelFactory(factory.alchemy.SQLAlchemyModelFactory):
         if cls._meta.force_flush:
             SESSION.flush()
         return obj
-
-
-class Document(ModelFactory):
-
-    class Meta:  # pylint: disable=no-init, old-style-class
-        model = models.Document
-
-
-class DocumentMeta(ModelFactory):
-
-    class Meta:  # pylint: disable=no-init, old-style-class
-        model = models.DocumentMeta
-
-    # Trying to add two DocumentMetas with the same claimant and type to the
-    # db will crash. We use a sequence instead of something like FAKER.url()
-    # for claimant here so that never happens (unless you pass in your own
-    # claimant).
-    claimant = factory.Sequence(
-        lambda n: 'http://example.com/document_' + str(n) + '/')
-
-    type = factory.Iterator([
-        'title', 'twitter.url.main_url', 'twitter.title', 'favicon'])
-    document = factory.SubFactory(Document)
-
-    @factory.lazy_attribute
-    def value(self):
-        if self.type == 'twitter.url.main_url':
-            return [FAKER.url()]
-        elif self.type == 'favicon':
-            return [FAKER.image_url()]
-        else:
-            return [FAKER.bs()]
-
-
-class DocumentURI(ModelFactory):
-
-    class Meta:  # pylint: disable=no-init, old-style-class
-        model = models.DocumentURI
-
-    # Trying to add two DocumentURIs with the same claimant, uri, type and
-    # content_type to the db will crash. We use a sequence instead of something
-    # like FAKER.url() for claimant here so that never happens (unless you pass
-    # in your own claimant).
-    claimant = factory.Sequence(
-        lambda n: 'http://example.com/document_' + str(n) + '/')
-
-    uri = factory.LazyAttribute(lambda obj: obj.claimant)
-    type = factory.Iterator(['rel-alternate', 'rel-canonical', 'highwire-pdf',
-                             'dc-doi'])
-    content_type = factory.Iterator(['text/html', 'application/pdf',
-                                     'text/plain'])
-    document = factory.SubFactory(Document)
-
-
-class Annotation(ModelFactory):
-
-    class Meta:  # pylint: disable=no-init, old-style-class
-        model = models.Annotation
-        force_flush = True  # Always flush the db to generate annotation.id.
-
-    tags = factory.LazyFunction(
-        lambda: FAKER.words(nb=random.randint(0, 5)))
-    target_uri = factory.Faker('uri')
-    text = factory.Faker('paragraph')
-    userid = factory.Faker('user_name')
-    document = factory.SubFactory(Document)
-
-    @factory.lazy_attribute
-    def target_selectors(self):  # pylint: disable=no-self-use
-        return [
-            {
-                'endContainer': '/div[1]/article[1]/section[1]/div[1]/div[2]/div[1]',
-                'endOffset': 76,
-                'startContainer': '/div[1]/article[1]/section[1]/div[1]/div[2]/div[1]',
-                'startOffset': 0,
-                'type': 'RangeSelector'
-            },
-            {
-                'end': 362,
-                'start': 286,
-                'type': 'TextPositionSelector'
-            },
-            {
-                'exact': 'If you wish to install Hypothesis on your own site then head over to GitHub.',
-                'prefix': ' browser extension.\n            ',
-                'suffix': '\n          \n        \n      \n    ',
-                'type': 'TextQuoteSelector'
-            },
-        ]
-
-    @factory.post_generation
-    def make_metadata(self, create, extracted, **kwargs):
-        """Create associated document metadata for the annotation."""
-        # The metadata objects are going to be added to the db, so if we're not
-        # using the create strategy then simply don't make any.
-        if not create:
-            return
-
-        def document_uri_dict():
-            """
-            Return a randomly generated DocumentURI dict for this annotation.
-
-            This doesn't add anything to the database session yet.
-            """
-            document_uri = DocumentURI.build(document=self.document,
-                                             claimant=self.target_uri,
-                                             uri=self.target_uri)
-            return dict(
-                claimant=document_uri.claimant,
-                uri=document_uri.uri,
-                type=document_uri.type,
-                content_type=document_uri.content_type,
-            )
-
-        document_uri_dicts = [document_uri_dict()
-                              for _ in range(random.randint(1, 3))]
-
-        def document_meta_dict(**kwargs):
-            """
-            Return a randomly generated DocumentMeta dict for this annotation.
-
-            This doesn't add anything to the database session yet.
-            """
-            kwargs.setdefault('document', self.document)
-            kwargs.setdefault('claimant', self.target_uri)
-            document_meta = DocumentMeta.build(**kwargs)
-            return dict(
-                claimant=document_meta.claimant,
-                type=document_meta.type,
-                value=document_meta.value,
-            )
-
-        document_meta_dicts = [document_meta_dict()
-                               for _ in range(random.randint(1, 3))]
-
-        # Make sure that there's always at least one DocumentMeta with
-        # type='title', so that we never get annotation.document.title is None:
-        if 'title' not in [m['type'] for m in document_meta_dicts]:
-            document_meta_dicts.append(document_meta_dict(type='title'))
-
-        self.document = api_models.update_document_metadata(
-            orm.object_session(self),
-            self.target_uri,
-            document_meta_dicts=document_meta_dicts,
-            document_uri_dicts=document_uri_dicts,
-            created=self.created,
-            updated=self.updated,
-        )
 
 
 class Activation(ModelFactory):

--- a/tests/common/factories.py
+++ b/tests/common/factories.py
@@ -104,6 +104,7 @@ class Annotation(ModelFactory):
     target_uri = factory.Faker('uri')
     text = factory.Faker('paragraph')
     userid = factory.Faker('user_name')
+    document = factory.SubFactory(Document)
 
     @factory.lazy_attribute
     def target_selectors(self):  # pylint: disable=no-self-use
@@ -142,7 +143,8 @@ class Annotation(ModelFactory):
 
             This doesn't add anything to the database session yet.
             """
-            document_uri = DocumentURI.build(claimant=self.target_uri,
+            document_uri = DocumentURI.build(document=self.document,
+                                             claimant=self.target_uri,
                                              uri=self.target_uri)
             return dict(
                 claimant=document_uri.claimant,
@@ -160,6 +162,7 @@ class Annotation(ModelFactory):
 
             This doesn't add anything to the database session yet.
             """
+            kwargs.setdefault('document', self.document)
             kwargs.setdefault('claimant', self.target_uri)
             document_meta = DocumentMeta.build(**kwargs)
             return dict(
@@ -176,7 +179,7 @@ class Annotation(ModelFactory):
         if 'title' not in [m['type'] for m in document_meta_dicts]:
             document_meta_dicts.append(document_meta_dict(type='title'))
 
-        api_models.update_document_metadata(
+        self.document = api_models.update_document_metadata(
             orm.object_session(self),
             self.target_uri,
             document_meta_dicts=document_meta_dicts,

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -48,9 +48,9 @@ def db_session(db_engine):
 @pytest.yield_fixture
 def factories(db_session):
     from ..common import factories
-    factories.SESSION = db_session
+    factories.set_session(db_session)
     yield factories
-    factories.SESSION = None
+    factories.set_session(None)
 
 
 @pytest.fixture(scope='session', autouse=True)

--- a/tests/h/conftest.py
+++ b/tests/h/conftest.py
@@ -139,9 +139,9 @@ def db_session(db_engine):
 @pytest.yield_fixture
 def factories(db_session):
     from ..common import factories
-    factories.SESSION = db_session
+    factories.set_session(db_session)
     yield factories
-    factories.SESSION = None
+    factories.set_session(None)
 
 
 @pytest.fixture

--- a/tests/h/feeds/rss_test.py
+++ b/tests/h/feeds/rss_test.py
@@ -61,7 +61,8 @@ def test_feed_from_annotations_html_links(factories):
 
 def test_feed_from_annotations_item_titles(factories):
     """Feed items should include the annotation's document's title."""
-    annotation = factories.Annotation()
+    document = factories.Document(title='Hello, World')
+    annotation = factories.Annotation(document=document)
 
     feed = rss.feed_from_annotations(
         [annotation], _annotation_url(), mock.Mock(), '', '', '')

--- a/tests/h/models/groups_test.py
+++ b/tests/h/models/groups_test.py
@@ -152,21 +152,6 @@ def test_documents_when_group_has_no_documents(group):
     assert group.documents() == []
 
 
-def test_documents_does_not_return_null_documents(db_session, group):
-    """
-    It shouldn't return None when an annotation has no document.
-
-    Some annotations have no document and annotation.document will be None.
-    In this case nothing should be added to the list of documents,
-    it should not return None in the list of documents that it returns.
-
-    """
-    db_session.add(memex.models.Annotation(
-        userid=u'fred', groupid=group.pubid, shared=True))
-
-    assert None not in group.documents()
-
-
 def test_acl(group, factories):
     group.pubid = 'testing-pubid'
     group.creator = factories.User(username='luke', authority='foobar.org')
@@ -182,7 +167,8 @@ def annotation(session, document_, groupid, shared):
     """Add a new annotation of the given document to the db and return it."""
     annotation_ = memex.models.Annotation(
         userid=u'fred', groupid=groupid, shared=shared,
-        target_uri=document_.document_uris[0].uri)
+        target_uri=document_.document_uris[0].uri,
+        document_id=document_.id)
     session.add(annotation_)
     return annotation_
 

--- a/tests/h/notification/reply_test.py
+++ b/tests/h/notification/reply_test.py
@@ -161,6 +161,7 @@ class TestGetNotification(object):
         reply = Annotation(**FIXTURE_DATA['reply'])
         reply.target_uri = 'http://example.net/foo'
         reply.references = [parent.id]
+        reply.document = doc
         db_session.add(reply)
         db_session.flush()
         annotations[reply.id] = reply

--- a/tests/memex/conftest.py
+++ b/tests/memex/conftest.py
@@ -114,7 +114,7 @@ def db_session(db_engine):
 
 @pytest.yield_fixture
 def factories(db_session):
-    from ..common import factories
+    from . import factories
     factories.SESSION = db_session
     yield factories
     factories.SESSION = None

--- a/tests/memex/factories.py
+++ b/tests/memex/factories.py
@@ -1,0 +1,183 @@
+# -*- coding: utf-8 -*-
+"""Factory classes for easily generating test objects."""
+
+from __future__ import unicode_literals
+
+import random
+
+import factory
+import faker
+from sqlalchemy import orm
+
+from memex import models
+
+FAKER = faker.Factory.create()
+SESSION = None
+
+
+class ModelFactory(factory.alchemy.SQLAlchemyModelFactory):
+    class Meta:  # pylint: disable=no-init, old-style-class
+        abstract = True
+
+    @classmethod
+    def _create(cls, model_class, *args, **kwargs):
+        # We override SQLAlchemyModelFactory's default _create classmethod so
+        # that rather than fetching the session from cls._meta (which is
+        # created at parse time... ugh) we fetch it from the SESSION global,
+        # which is dynamically filled out by the `factories` fixture when
+        # used.
+        if SESSION is None:
+            raise RuntimeError('no session: did you use the factories fixture?')
+        obj = model_class(*args, **kwargs)
+        SESSION.add(obj)
+        if cls._meta.force_flush:
+            SESSION.flush()
+        return obj
+
+
+class Document(ModelFactory):
+
+    class Meta:  # pylint: disable=no-init, old-style-class
+        model = models.Document
+
+
+class DocumentMeta(ModelFactory):
+
+    class Meta:  # pylint: disable=no-init, old-style-class
+        model = models.DocumentMeta
+
+    # Trying to add two DocumentMetas with the same claimant and type to the
+    # db will crash. We use a sequence instead of something like FAKER.url()
+    # for claimant here so that never happens (unless you pass in your own
+    # claimant).
+    claimant = factory.Sequence(
+        lambda n: 'http://example.com/document_' + str(n) + '/')
+
+    type = factory.Iterator([
+        'title', 'twitter.url.main_url', 'twitter.title', 'favicon'])
+    document = factory.SubFactory(Document)
+
+    @factory.lazy_attribute
+    def value(self):
+        if self.type == 'twitter.url.main_url':
+            return [FAKER.url()]
+        elif self.type == 'favicon':
+            return [FAKER.image_url()]
+        else:
+            return [FAKER.bs()]
+
+
+class DocumentURI(ModelFactory):
+
+    class Meta:  # pylint: disable=no-init, old-style-class
+        model = models.DocumentURI
+
+    # Trying to add two DocumentURIs with the same claimant, uri, type and
+    # content_type to the db will crash. We use a sequence instead of something
+    # like FAKER.url() for claimant here so that never happens (unless you pass
+    # in your own claimant).
+    claimant = factory.Sequence(
+        lambda n: 'http://example.com/document_' + str(n) + '/')
+
+    uri = factory.LazyAttribute(lambda obj: obj.claimant)
+    type = factory.Iterator(['rel-alternate', 'rel-canonical', 'highwire-pdf',
+                             'dc-doi'])
+    content_type = factory.Iterator(['text/html', 'application/pdf',
+                                     'text/plain'])
+    document = factory.SubFactory(Document)
+
+
+class Annotation(ModelFactory):
+
+    class Meta:  # pylint: disable=no-init, old-style-class
+        model = models.Annotation
+        force_flush = True  # Always flush the db to generate annotation.id.
+
+    tags = factory.LazyFunction(
+        lambda: FAKER.words(nb=random.randint(0, 5)))
+    target_uri = factory.Faker('uri')
+    text = factory.Faker('paragraph')
+    userid = factory.Faker('user_name')
+    document = factory.SubFactory(Document)
+
+    @factory.lazy_attribute
+    def target_selectors(self):  # pylint: disable=no-self-use
+        return [
+            {
+                'endContainer': '/div[1]/article[1]/section[1]/div[1]/div[2]/div[1]',
+                'endOffset': 76,
+                'startContainer': '/div[1]/article[1]/section[1]/div[1]/div[2]/div[1]',
+                'startOffset': 0,
+                'type': 'RangeSelector'
+            },
+            {
+                'end': 362,
+                'start': 286,
+                'type': 'TextPositionSelector'
+            },
+            {
+                'exact': 'If you wish to install Hypothesis on your own site then head over to GitHub.',
+                'prefix': ' browser extension.\n            ',
+                'suffix': '\n          \n        \n      \n    ',
+                'type': 'TextQuoteSelector'
+            },
+        ]
+
+    @factory.post_generation
+    def make_metadata(self, create, extracted, **kwargs):
+        """Create associated document metadata for the annotation."""
+        # The metadata objects are going to be added to the db, so if we're not
+        # using the create strategy then simply don't make any.
+        if not create:
+            return
+
+        def document_uri_dict():
+            """
+            Return a randomly generated DocumentURI dict for this annotation.
+
+            This doesn't add anything to the database session yet.
+            """
+            document_uri = DocumentURI.build(document=self.document,
+                                             claimant=self.target_uri,
+                                             uri=self.target_uri)
+            return dict(
+                claimant=document_uri.claimant,
+                uri=document_uri.uri,
+                type=document_uri.type,
+                content_type=document_uri.content_type,
+            )
+
+        document_uri_dicts = [document_uri_dict()
+                              for _ in range(random.randint(1, 3))]
+
+        def document_meta_dict(**kwargs):
+            """
+            Return a randomly generated DocumentMeta dict for this annotation.
+
+            This doesn't add anything to the database session yet.
+            """
+            kwargs.setdefault('document', self.document)
+            kwargs.setdefault('claimant', self.target_uri)
+            document_meta = DocumentMeta.build(**kwargs)
+            return dict(
+                claimant=document_meta.claimant,
+                type=document_meta.type,
+                value=document_meta.value,
+            )
+
+        document_meta_dicts = [document_meta_dict()
+                               for _ in range(random.randint(1, 3))]
+
+        # Make sure that there's always at least one DocumentMeta with
+        # type='title', so that we never get annotation.document.title is None:
+        if 'title' not in [m['type'] for m in document_meta_dicts]:
+            document_meta_dicts.append(document_meta_dict(type='title'))
+
+        self.document = models.update_document_metadata(
+            orm.object_session(self),
+            self.target_uri,
+            document_meta_dicts=document_meta_dicts,
+            document_uri_dicts=document_uri_dicts,
+            created=self.created,
+            updated=self.updated,
+        )

--- a/tests/memex/models/annotation_test.py
+++ b/tests/memex/models/annotation_test.py
@@ -6,30 +6,9 @@ from pyramid import security
 import pytest
 
 from memex.models.annotation import Annotation
-from memex.models.document import Document, DocumentURI
 
 
 annotation_fixture = pytest.mark.usefixtures('annotation')
-
-
-@annotation_fixture
-def test_document(annotation, db_session):
-    document = Document(document_uris=[DocumentURI(claimant=annotation.target_uri,
-                                                   uri=annotation.target_uri)])
-    db_session.add(document)
-    db_session.flush()
-
-    assert annotation.document == document
-
-
-@annotation_fixture
-def test_document_not_found(annotation, db_session):
-    document = Document(document_uris=[DocumentURI(claimant='something-else',
-                                                   uri='something-else')])
-    db_session.add(document)
-    db_session.flush()
-
-    assert annotation.document is None
 
 
 def test_parent_id_of_direct_reply():

--- a/tests/memex/models/annotation_test.py
+++ b/tests/memex/models/annotation_test.py
@@ -102,7 +102,7 @@ def test_acl_group_shared():
     assert actual == expect
 
 
-def test_setting_extras_inline_is_persisted(db_session):
+def test_setting_extras_inline_is_persisted(db_session, factories):
     """
     In-place changes to Annotation.extra should be persisted.
 
@@ -113,14 +113,7 @@ def test_setting_extras_inline_is_persisted(db_session):
     should be persisted to the database.
 
     """
-    annotation = Annotation(userid='fred')
-    db_session.add(annotation)
-
-    # We need to flush the db here so that the default value for
-    # annotation.extra gets persisted and out mutation of annotation.extra
-    # below happens when the previous value is already persisted, otherwise
-    # this test would never fail.
-    db_session.flush()
+    annotation = factories.Annotation(userid='fred')
 
     annotation.extra['foo'] = 'bar'
 
@@ -134,7 +127,7 @@ def test_setting_extras_inline_is_persisted(db_session):
     assert annotation.extra == {'foo': 'bar'}
 
 
-def test_deleting_extras_inline_is_persisted(db_session):
+def test_deleting_extras_inline_is_persisted(db_session, factories):
     """
     In-place changes to Annotation.extra should be persisted.
 
@@ -142,10 +135,7 @@ def test_deleting_extras_inline_is_persisted(db_session):
     database.
 
     """
-    annotation = Annotation(userid='fred')
-    annotation.extra = {'foo': 'bar'}
-    db_session.add(annotation)
-    db_session.flush()
+    annotation = factories.Annotation(userid='fred', extra={'foo': 'bar'})
 
     del annotation.extra['foo']
     db_session.commit()
@@ -154,7 +144,7 @@ def test_deleting_extras_inline_is_persisted(db_session):
     assert 'foo' not in annotation.extra
 
 
-def test_appending_tags_inline_is_persisted(db_session):
+def test_appending_tags_inline_is_persisted(db_session, factories):
     """
     In-place changes to Annotation.tags should be persisted.
 
@@ -162,24 +152,18 @@ def test_appending_tags_inline_is_persisted(db_session):
     database.
 
     """
-    annotation = Annotation(userid='fred')
-    annotation.tags = []  # FIXME: Annotation should have a default value here.
-    db_session.add(annotation)
-    db_session.flush()
+    annotation = factories.Annotation(userid='fred', tags=['foo'])
 
-    annotation.tags.append('foo')
+    annotation.tags.append('bar')
     db_session.commit()
     annotation = db_session.query(Annotation).get(annotation.id)
 
-    assert 'foo' in annotation.tags
+    assert 'bar' in annotation.tags
 
 
-def test_deleting_tags_inline_is_persisted(db_session):
+def test_deleting_tags_inline_is_persisted(db_session, factories):
     """In-place deletions of annotation tags should be persisted."""
-    annotation = Annotation(userid='fred')
-    annotation.tags = ['foo']
-    db_session.add(annotation)
-    db_session.flush()
+    annotation = factories.Annotation(userid='fred', tags=['foo'])
 
     del annotation.tags[0]
     db_session.commit()

--- a/tests/memex/storage_test.py
+++ b/tests/memex/storage_test.py
@@ -209,7 +209,7 @@ class TestCreateAnnotation(object):
 
         ann = storage.create_annotation(pyramid_request, annotation_data)
 
-        assert ann.document_id == document.id
+        assert ann.document == document
 
     def test_it_returns_the_annotation(self, models, pyramid_request):
         annotation = storage.create_annotation(pyramid_request,
@@ -368,7 +368,7 @@ class TestUpdateAnnotation(object):
         storage.update_annotation(session,
                                   'test_annotation_id',
                                   annotation_data)
-        assert annotation.document_id == document.id
+        assert annotation.document == document
 
     def test_it_returns_the_annotation(self, annotation_data, session):
         annotation = storage.update_annotation(session,

--- a/tests/memex/storage_test.py
+++ b/tests/memex/storage_test.py
@@ -15,10 +15,8 @@ from memex.models.document import Document, DocumentURI, DocumentMeta
 
 class TestFetchAnnotation(object):
 
-    def test_it_fetches_and_returns_the_annotation(self, db_session):
-        annotation = Annotation(userid='luke')
-        db_session.add(annotation)
-        db_session.flush()
+    def test_it_fetches_and_returns_the_annotation(self, db_session, factories):
+        annotation = factories.Annotation()
 
         actual = storage.fetch_annotation(db_session, annotation.id)
         assert annotation == actual
@@ -29,29 +27,18 @@ class TestFetchAnnotation(object):
 
 class TestFetchOrderedAnnotations(object):
 
-    def test_it_returns_annotations_for_ids_in_the_same_order(self, db_session):
-        ann_1 = Annotation(userid='luke')
-        ann_2 = Annotation(userid='luke')
-        db_session.add_all([ann_1, ann_2])
-        db_session.flush()
+    def test_it_returns_annotations_for_ids_in_the_same_order(self, db_session, factories):
+        ann_1 = factories.Annotation(userid='luke')
+        ann_2 = factories.Annotation(userid='luke')
 
         assert [ann_2, ann_1] == storage.fetch_ordered_annotations(db_session,
                                                                    [ann_2.id, ann_1.id])
         assert [ann_1, ann_2] == storage.fetch_ordered_annotations(db_session,
                                                                    [ann_1.id, ann_2.id])
 
-    def test_it_allows_to_change_the_query(self, db_session):
-        ann_1 = Annotation(userid='luke', target_uri='http://example.com')
-        ann_2 = Annotation(userid='maria', target_uri='http://example.com')
-        db_session.add_all([ann_1, ann_2])
-
-        doc = Document(
-            document_uris=[DocumentURI(uri='http://bar.com/', claimant='http://example.com'),
-                           DocumentURI(uri='http://example.com/', type='rel-canonical', claimant='http://example.com')],
-            meta=[DocumentMeta(claimant='http://example.com', type='title', value='Example')])
-        db_session.add(doc)
-
-        db_session.flush()
+    def test_it_allows_to_change_the_query(self, db_session, factories):
+        ann_1 = factories.Annotation(userid='luke')
+        ann_2 = factories.Annotation(userid='maria')
 
         def only_maria(query):
             return query.filter(Annotation.userid == 'maria')
@@ -411,11 +398,8 @@ class TestUpdateAnnotation(object):
 
 class TestDeleteAnnotation(object):
 
-    def test_it_deletes_the_annotation(self, db_session):
-        ann_1 = Annotation(userid='luke')
-        ann_2 = Annotation(userid='leia')
-        db_session.add_all([ann_1, ann_2])
-        db_session.flush()
+    def test_it_deletes_the_annotation(self, db_session, factories):
+        ann_1, ann_2 = (factories.Annotation(), factories.Annotation())
 
         storage.delete_annotation(db_session, ann_1.id)
         db_session.commit()

--- a/tests/memex/views_test.py
+++ b/tests/memex/views_test.py
@@ -5,7 +5,6 @@ import pytest
 
 from pyramid import testing
 
-from memex import models
 from memex import presenters
 from memex import views
 from memex.schemas import ValidationError
@@ -81,11 +80,9 @@ class TestSearch(object):
         storage.fetch_ordered_annotations.assert_called_once_with(
             pyramid_request.db, ['row-1', 'row-2'], query_processor=mock.ANY)
 
-    def test_it_renders_search_results(self, links_service, pyramid_request, search_run):
-        ann1 = models.Annotation(userid='luke')
-        ann2 = models.Annotation(userid='sarah')
-        pyramid_request.db.add_all([ann1, ann2])
-        pyramid_request.db.flush()
+    def test_it_renders_search_results(self, links_service, pyramid_request, search_run, factories):
+        ann1 = factories.Annotation(userid='luke')
+        ann2 = factories.Annotation(userid='sarah')
 
         search_run.return_value = SearchResult(2, [ann1.id, ann2.id], [], {})
 
@@ -108,14 +105,10 @@ class TestSearch(object):
         assert mock.call(pyramid_request.db, ['reply-1', 'reply-2'],
                          query_processor=mock.ANY) in storage.fetch_ordered_annotations.call_args_list
 
-    def test_it_renders_replies(self, links_service, pyramid_request, search_run):
-        ann = models.Annotation(userid='luke')
-        pyramid_request.db.add(ann)
-        pyramid_request.db.flush()
-        reply1 = models.Annotation(userid='sarah', references=[ann.id])
-        reply2 = models.Annotation(userid='sarah', references=[ann.id])
-        pyramid_request.db.add_all([reply1, reply2])
-        pyramid_request.db.flush()
+    def test_it_renders_replies(self, links_service, pyramid_request, search_run, factories):
+        ann = factories.Annotation(userid='luke')
+        reply1 = factories.Annotation(userid='sarah', references=[ann.id])
+        reply2 = factories.Annotation(userid='sarah', references=[ann.id])
 
         search_run.return_value = SearchResult(1, [ann.id], [reply1.id, reply2.id], {})
 

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ deps =
     # resolved
     pytest==3.0.1
     hypothesis
-    h: factory-boy
+    factory-boy
     h: -rrequirements.txt
 passenv =
     TEST_DATABASE_URL


### PR DESCRIPTION
~~**This depends on #3930  being merged and the migration being run on production.**~~

_This is part of the bigger effort of ensuring that each annotation has one document, to achieve this we introduce a new `Annotation.document_id` column with a foreign key constraint, this way we have to ensure this on the database level and will get data integrity errors when we try to unintentionally remove a document from an annotation._

This pull request makes sure that we don't allow `NULL` values in the `annotation.document_id` column. It also changes the `Annotation.document` relationship to use the new `document_id` column instead of the old way of joining over the `document_uri` table.