### PR TITLE
Fix wrapping of long document bucket titles

### DIFF
--- a/h/static/styles/partials-v2/_search.scss
+++ b/h/static/styles/partials-v2/_search.scss
@@ -64,12 +64,19 @@
 .search-result-bucket__title-and-annotations-count {
   display: flex;
   flex-grow: 1;
+  min-width: 0;  // Without this min-width document titles containing really
+                 // long words won't be wrapped (overflow-wrap: break-word
+                 // won't work), see https://github.com/hypothesis/h/pull/3932
 }
 
 .search-result-bucket__title {
   font-weight: bold;
   flex-grow: 1;
   margin-right: 5px;
+  overflow-wrap: break-word;
+  min-width: 0;  // Without this min-width document titles containing really
+                 // long words won't be wrapped (overflow-wrap: break-word
+                 // won't work), see https://github.com/hypothesis/h/pull/3932
 }
 
 .search-result-bucket__annotations-count {


### PR DESCRIPTION
If a document bucket had a long word in its title, for example
Pitt_Comp_Literacy_Culture_Distant_Publics_Development_Rhetoric_and_the_Subject_of_Crisis.pdf,
this word was not being wrapped and was overflowing out of the document
bucket and expanding the width of the entire page (especially on mobile).

This commit makes browsers wrap within word if necessary to prevent
overflow.

Fixes #3927

Before:

![download](https://cloud.githubusercontent.com/assets/22498/18835615/da5297e0-83f3-11e6-94c2-d825cd4c0dc5.jpg)

After:

![screenshot from 2016-09-26 16-27-03](https://cloud.githubusercontent.com/assets/22498/18840610/0e048658-8407-11e6-8a8c-8ae19bf271ff.png)

![screenshot from 2016-09-26 16-30-57](https://cloud.githubusercontent.com/assets/22498/18840615/128b5990-8407-11e6-85d4-4f84b769e653.png)

Tested on Chrome, Firefox and iOS Safari
