### PR TITLE
Fix search bucket content alignment

### DIFF
--- a/h/static/styles/partials-v2/_search.scss
+++ b/h/static/styles/partials-v2/_search.scss
@@ -98,11 +98,17 @@
 
 .search-result-bucket__annotation-cards-container {
   display: flex;
-  padding-left: 130px;
 
   &.is-hidden {
     display: none;
   }
+}
+
+.search-result-bucket__left-margin {
+  flex-grow: 0;
+  flex-shrink: 0;
+  width: 120px;
+  margin-right: 10px;
 }
 
 .search-result-bucket__annotation-cards {
@@ -115,7 +121,6 @@
 // Card displaying stats about a group of annotations in search results
 .search-bucket-stats {
   @include font-normal;
-  width: 210px;
   margin-left: 30px;
   word-wrap: break-word;
 }
@@ -151,12 +156,17 @@
     margin-right: 10px;
   }
 
+  .search-result-bucket__left-margin {
+    display: none;
+  }
+
   .search-result-bucket__annotation-cards-container {
     flex-direction: column;
+    align-items: center;
   }
 
   .search-bucket-stats {
-    margin-left: 5px;
-    margin-top: 10px;
+    margin: 0;
+    padding: 0;
   }
 }

--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -63,6 +63,7 @@
   {# The content is the area that appears / disappears on expand / collapse. #}
   <div class="search-result-bucket__content">
     <div class="search-result-bucket__annotation-cards-container" data-ref="content">
+      <div class="search-result-bucket__left-margin"></div>
       <ol class="search-result-bucket__annotation-cards">
         {% for result in bucket.annotations %}
           {{ annotation_card(result.annotation, request) }}


### PR DESCRIPTION
Fix the horizontal alignment of search result bucket contents on small
screens.

There was a 130px left margin inside the search result bucket contents
which, on small screens, takes up most of the screen width and squashes
the actual contents into a small space.

Make this margin disappear on small screens.

On master:

![peek 2016-09-26 19-41](https://cloud.githubusercontent.com/assets/22498/18847233/4fbed0e8-8421-11e6-9e15-47a732a5af73.gif)

On this branch:

![peek 2016-09-26 19-39](https://cloud.githubusercontent.com/assets/22498/18847243/572bbba2-8421-11e6-89ab-d2815844e3b6.gif)

The only problem is that I think when it's this size we might want the stats to be left-aligned with the annotation card, which I can't seem to do with this flexbox approach:

![screenshot from 2016-09-26 19-42-50](https://cloud.githubusercontent.com/assets/22498/18847284/82e8f106-8421-11e6-9bef-1d69d2fa6cf9.png)

We may need to find a different approach for this reason?