### PR TITLE
Improve input field styling on iOS

### DIFF
--- a/h/static/styles/partials-v2/_base.scss
+++ b/h/static/styles/partials-v2/_base.scss
@@ -21,6 +21,7 @@ $highlight: #58cef4;
 $sans-font-family: "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif !default;
 $mono-font-family: Open Sans Mono, Menlo, DejaVu Sans Mono, monospace !default;
 
+// Standard font sizes
 $normal-font-size: 13px;
 $normal-line-height: 15px;
 
@@ -29,9 +30,15 @@ $small-line-height: 12px;
 
 $title-font-size: 19px;
 
+// Font sizes for specific categories of control
 $input-font-size: 15px;
 
+// Minimum font size for <input> fields on iOS. If the font size is smaller than
+// this, iOS will zoom into the field when focused.
+$touch-input-font-size: 16px;
+
 // Z-index scale
+// -------------
 $zindex-modal-backdrop: 5; // Backdrop of a modal dialog or form
 $zindex-modal-content: 6;  // Content of a modal dialog or form
 $zindex-dropdown-menu: 10;

--- a/h/static/styles/partials-v2/_elements.scss
+++ b/h/static/styles/partials-v2/_elements.scss
@@ -12,3 +12,14 @@ ol {
 svg {
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
 }
+
+// Remove browser default styling for text input fields, such as the drop shadow
+// inside the field on iOS.
+// See http://stackoverflow.com/questions/23211656/remove-ios-input-shadow
+input:not([type]),
+input[type=email],
+input[type=password],
+input[type=text],
+textarea {
+  appearance: none;
+}

--- a/h/static/styles/partials-v2/_form-input.scss
+++ b/h/static/styles/partials-v2/_form-input.scss
@@ -202,6 +202,12 @@
     color: $brand;
   }
 
+  @include touch-input {
+    .form-input__input {
+      font-size: $touch-input-font-size;
+    }
+  }
+
   // On narrow screens, display validation error messages underneath the
   // input field.
   @media screen and (max-width: $max-phone-width) {

--- a/h/static/styles/partials-v2/_search-bar.scss
+++ b/h/static/styles/partials-v2/_search-bar.scss
@@ -85,3 +85,9 @@
 .search-bar__dropdown-menu-item.is-hidden {
   display: none;
 }
+
+@include touch-input {
+  .search-bar__input {
+    font-size: $touch-input-font-size;
+  }
+}


### PR DESCRIPTION
 * Use `appearance: none` on text input controls to remove the
   drop shadow which iOS adds by default

 * Set font size to 16px on touch devices. This makes the text more
   comfortable to read but also avoids iOS zooming into the field when
   selected

Fixes #3740