### PR TITLE
Set default auth domain to localhost in development

### DIFF
--- a/conf/development-app.ini
+++ b/conf/development-app.ini
@@ -9,6 +9,8 @@ es.host: http://localhost:9200
 pyramid.debug_all: True
 pyramid.reload_templates: True
 
+h.auth_domain: localhost
+
 # Set a default persistent secret for development. DO NOT copy this into a
 # production settings file.
 h.client_id: nosuchid


### PR DESCRIPTION
This ensures that the default auth domain is the same for a development
instance regardless of which IP/domain the web service is accessed
through. This enables login to work if the service is accessed via its
IP from a different device on the same network or via ngrok.

The AUTH_DOMAIN environment variable still takes precedence if set.