### PR TITLE
Fix search bucket content alignment

### DIFF
--- a/h/static/styles/partials-v2/_search.scss
+++ b/h/static/styles/partials-v2/_search.scss
@@ -165,6 +165,7 @@
 
   .search-result-bucket__annotation-cards-container {
     flex-direction: column;
+    padding-left: 0;
   }
 
   .search-bucket-stats {


### PR DESCRIPTION
Fix the horizontal alignment of search result bucket contents on small
screens.

There was a 130px left margin inside the search result bucket contents
which, on small screens, takes up most of the screen width and squashes
the actual contents into a small space.

Make this margin disappear on small screens, and also centre the search
bucket contents within the search result bucket div that contains it,
when the search result bucket contents are not as wide as the search
result bucket div.

![peek 2016-09-27 10-41](https://cloud.githubusercontent.com/assets/22498/18868134/05fa9d06-849f-11e6-98bb-b0ab8d3af88d.gif)
