### PR TITLE
Don't wrap document bucket addresses unnecessarily

### DIFF
--- a/h/static/styles/partials-v2/_search.scss
+++ b/h/static/styles/partials-v2/_search.scss
@@ -115,9 +115,10 @@
 // Card displaying stats about a group of annotations in search results
 .search-bucket-stats {
   @include font-normal;
-  width: 210px;
   margin-left: 30px;
   word-wrap: break-word;
+  min-width: 0;  // Make sure the .search-bucket-stats element's content wraps
+                 // as its flexbox parent element is resized.
 }
 
 .search-bucket-stats__key {


### PR DESCRIPTION

![peek 2016-09-27 11-14](https://cloud.githubusercontent.com/assets/22498/18869338/d906cd74-84a3-11e6-8191-3ff14a1b5d48.gif)
(But do be sure to wrap them whenever the URL is too wide for the
document bucket, as the flexbox that is the URL's parent element is
resized.)

Fixes #3741.