### PR TITLE
Upgrade Raven.js to 3.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "postcss": "^5.0.6",
     "postcss-url": "^5.1.1",
     "query-string": "^3.0.1",
-    "raven-js": "^2.0.2",
+    "raven-js": "^3.7.0",
     "scroll-into-view": "^1.7.1",
     "through2": "^2.0.1",
     "uglifyify": "^3.0.1",


### PR DESCRIPTION
Upgrading Raven.js on h so we can keep it consistent with Raven.js in the client. 

I manually tested sending errors to the dev project. That worked fine. See: https://sentry.io/hypothesis/dev/issues/163330433/

