### PR TITLE
Update standards references for 'Basic' authentication

### DIFF
--- a/docs/_extra/api/hypothesis.yaml
+++ b/docs/_extra/api/hypothesis.yaml
@@ -40,7 +40,7 @@ info:
         Client Secret: E-hReVMuRyZbyr1GikieEw4JslaM6sDpb18_9V59PFw
 
     you can compute the Authorization header [as described in
-    RFC1945](https://tools.ietf.org/html/rfc1945#section-11.1):
+    RFC7617](https://tools.ietf.org/html/rfc7617):
 
         $ echo -n '96653f8e-80be-11e6-b32b-c7bcde86613a:E-hReVMuRyZbyr1GikieEw4JslaM6sDpb18_9V59PFw' | base64
         OTY2NTNmOGUtODBiZS0xMWU2LWIzMmItYzdiY2RlODY2MTNhOkUtaFJlVk11UnlaYnlyMUdpa2llRXc0SnNsYU02c0RwYjE4XzlWNTlQRnc=


### PR DESCRIPTION
Since moaning about the state of cross-browser compatibility for Basic authentication on Twitter, I've found the correct current reference for this -- namely, RFC7617 -- which provides a justification for the curl/Chrome/any-reasonable-implementer approach of UTF-8 encoding the user-id and password.

This commit updates the API docs and the comments in the tests to reflect this.