### PR TITLE
Use consistent names in panels.py

### DIFF
--- a/h/templates/panels/navbar.html.jinja2
+++ b/h/templates/panels/navbar.html.jinja2
@@ -64,7 +64,7 @@
       {% if username %}
       <span class="nav-bar-links__item">
         <a class="nav-bar-links__link"
-           href="{{ username_link }}">
+           href="{{ username_url }}">
           {{ username }}
         </a>
       </span>

--- a/h/views/panels.py
+++ b/h/views/panels.py
@@ -48,7 +48,7 @@ def navbar(context, request):
         'create_group_item':
             {'title': _('Create new group'), 'link': request.route_url('group_create')},
         'username': username,
-        'username_link': stream_url,
+        'username_url': stream_url,
         'search_url': search_url,
         'q': request.params.get('q', ''),
     }

--- a/tests/h/views/panels_test.py
+++ b/tests/h/views/panels_test.py
@@ -32,11 +32,11 @@ class TestNavbar(object):
             {'title': titles[1], 'link': 'http://example.com/groups/id2/second'},
         ]
 
-    def test_username_link_when_logged_in(self, req, authenticated_user):
+    def test_username_url_when_logged_in(self, req, authenticated_user):
         req.authenticated_user = authenticated_user
         result = panels.navbar({}, req)
 
-        assert result['username_link'] == 'http://example.com/search?q=user:vannevar'
+        assert result['username_url'] == 'http://example.com/search?q=user:vannevar'
 
     def test_it_includes_search_query(self, req):
         req.params['q'] = 'tag:question'


### PR DESCRIPTION
For consistency with search_url, rename username_link to username_url.

This'll need rebasing after #3944 merges.