### PR TITLE
Install the same version of Node we use in production

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,10 @@ matrix:
     # Test web application frontend
     - env: ACTION=gulp
       language: node_js
-      node_js: '4.3'
+      # We currently build production against Alpine v3.4:
+      #
+      #   https://pkgs.alpinelinux.org/packages?name=nodejs&branch=v3.4
+      node_js: '6.2'
       before_install: npm install gulp-cli
       script: gulp test
 cache:


### PR DESCRIPTION
This should also[1] fix the issues we've been seeing with intermittent build failures on Travis.

[1]: https://github.com/npm/registry/issues/10#issuecomment-216959451