### PR TITLE
Periodically remove expired auth tokens

### DIFF
--- a/h/accounts/views.py
+++ b/h/accounts/views.py
@@ -653,7 +653,7 @@ class DeveloperController(object):
             token.regenerate()
         else:
             # The user doesn't have an API token yet, generate one for them.
-            token = models.Token(self.request.authenticated_userid)
+            token = models.Token(userid=self.request.authenticated_userid)
             self.request.db.add(token)
 
         return {'token': token.value}

--- a/h/auth/worker.py
+++ b/h/auth/worker.py
@@ -17,3 +17,10 @@ def delete_expired_auth_tickets():
     celery.request.db.query(models.AuthTicket) \
         .filter(models.AuthTicket.expires < datetime.utcnow()) \
         .delete()
+
+
+@celery.task
+def delete_expired_tokens():
+    celery.request.db.query(models.Token) \
+        .filter(models.Token.expires < datetime.utcnow()) \
+        .delete()

--- a/h/celery.py
+++ b/h/celery.py
@@ -37,7 +37,11 @@ celery.conf.update(
         'delete-expired-authtickets': {
             'task': 'h.auth.worker.delete_expired_auth_tickets',
             'schedule': timedelta(hours=1)
-        }
+        },
+        'delete-expired-tokens': {
+            'task': 'h.auth.worker.delete_expired_tokens',
+            'schedule': timedelta(hours=1)
+        },
     },
     CELERY_ACCEPT_CONTENT=['json'],
     # Enable at-least-once delivery mode. This probably isn't actually what we

--- a/h/models/token.py
+++ b/h/models/token.py
@@ -39,8 +39,8 @@ class Token(Base, mixins.Timestamps):
     #: A NULL value in this column indicates a token that does not expire.
     expires = sqlalchemy.Column(sqlalchemy.DateTime, nullable=True)
 
-    def __init__(self, userid):
-        self.userid = userid
+    def __init__(self, **kwargs):
+        super(Token, self).__init__(**kwargs)
         self.regenerate()
 
     @classmethod

--- a/tests/common/factories.py
+++ b/tests/common/factories.py
@@ -115,3 +115,12 @@ class AuthTicket(ModelFactory):
     @factory.lazy_attribute
     def user_userid(self):
         return self.user.userid
+
+
+class Token(ModelFactory):
+
+    class Meta:  # pylint: disable=no-init, old-style-class
+        model = models.Token
+        force_flush = True
+
+    userid = factory.LazyAttribute(lambda _: ('acct:' + FAKER.user_name() + '@example.com'))

--- a/tests/h/accounts/views_test.py
+++ b/tests/h/accounts/views_test.py
@@ -963,7 +963,7 @@ class TestDeveloperController(object):
 
         views.DeveloperController(pyramid_request).post()
 
-        models.Token.assert_called_once_with(pyramid_request.authenticated_userid)
+        models.Token.assert_called_once_with(userid=pyramid_request.authenticated_userid)
 
     def test_post_adds_new_token_to_db(self, models, pyramid_request):
         """If the user doesn't have a token yet it should add one to the db."""
@@ -973,7 +973,7 @@ class TestDeveloperController(object):
 
         assert models.Token.return_value in pyramid_request.db.added
 
-        models.Token.assert_called_once_with(pyramid_request.authenticated_userid)
+        models.Token.assert_called_once_with(userid=pyramid_request.authenticated_userid)
 
     def test_post_returns_token_after_regenerating(self, models, pyramid_request):
         """After regenerating a token it should return its new value."""

--- a/tests/h/auth/worker_test.py
+++ b/tests/h/auth/worker_test.py
@@ -7,7 +7,7 @@ from datetime import (datetime, timedelta)
 import pytest
 
 from h.auth import worker
-from h.models import AuthTicket
+from h.models import (AuthTicket, Token)
 
 
 @pytest.mark.usefixtures('celery')
@@ -34,8 +34,36 @@ class TestDeleteExpiredAuthTickets(object):
         worker.delete_expired_auth_tickets()
         assert db_session.query(AuthTicket).count() == 1
 
-    @pytest.fixture
-    def celery(self, patch, db_session):
-        cel = patch('h.auth.worker.celery', autospec=False)
-        cel.request.db = db_session
-        return cel
+
+@pytest.mark.usefixtures('celery')
+class TestDeleteExpiredTokens(object):
+    def test_it_removes_expired_tokens(self, db_session, factories):
+        factories.Token(expires=datetime(2014, 5, 6, 7, 8, 9))
+        factories.Token(expires=(datetime.utcnow() - timedelta(seconds=1)))
+
+        assert db_session.query(Token).count() == 2
+        worker.delete_expired_tokens()
+        assert db_session.query(Token).count() == 0
+
+    def test_it_leaves_valid_tickets(self, db_session, factories):
+        factories.Token(expires=datetime(2014, 5, 6, 7, 8, 9))
+        factories.Token(expires=(datetime.utcnow() + timedelta(hours=1)))
+
+        assert db_session.query(Token).count() == 2
+        worker.delete_expired_tokens()
+        assert db_session.query(Token).count() == 1
+
+    def test_it_leaves_tickets_without_an_expiration_date(self, db_session, factories):
+        factories.Token(expires=None)
+        factories.Token(expires=None)
+
+        assert db_session.query(Token).count() == 2
+        worker.delete_expired_tokens()
+        assert db_session.query(Token).count() == 2
+
+
+@pytest.fixture
+def celery(patch, db_session):
+    cel = patch('h.auth.worker.celery', autospec=False)
+    cel.request.db = db_session
+    return cel

--- a/tests/h/models/token_test.py
+++ b/tests/h/models/token_test.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from h.models import Token
+
+
+class TestToken(object):
+    def test_init_generates_value(self):
+        assert Token().value


### PR DESCRIPTION
Similar to the worker that removes expired auth tickets, this adds a new
worker which runs every hour and deletes expired auth tokens from the
database.