### PR TITLE
Allow submitting an empty search form

### DIFF
--- a/h/static/scripts/controllers/search-bar-controller.js
+++ b/h/static/scripts/controllers/search-bar-controller.js
@@ -148,9 +148,8 @@ class SearchBarController extends Controller {
       var visibleDropdownItems = getVisibleDropdownItems();
 
       var handleEnterKey = event => {
-        event.preventDefault();
-
         if (activeItem) {
+          event.preventDefault();
           var facet =
             activeItem.
               querySelector('[data-ref="searchBarDropdownItemTitle"]').

--- a/h/static/scripts/tests/controllers/search-bar-controller-test.js
+++ b/h/static/scripts/tests/controllers/search-bar-controller-test.js
@@ -23,9 +23,11 @@ describe('SearchBarController', function () {
   var dropdown;
   var dropdownItems;
   var ctrl;
+  var form;
 
   before(function () {
-    template = '<input data-ref="searchBarInput">' +
+    template = '<form>' +
+      '<input data-ref="searchBarInput">' +
       '<div data-ref="searchBarDropdown">' +
       '<div>Narrow your search</div>' +
       '<ul>' +
@@ -50,7 +52,8 @@ describe('SearchBarController', function () {
       '</span>' +
       '</li>' +
       '</ul>' +
-      '</div>';
+      '</div>' +
+      '</form>';
   });
 
   beforeEach(function () {
@@ -63,6 +66,9 @@ describe('SearchBarController', function () {
     input = ctrl.refs.searchBarInput;
     dropdown = ctrl.refs.searchBarDropdown;
     dropdownItems = testEl.querySelectorAll('[data-ref="searchBarDropdownItem"]');
+    form = testEl.querySelector('form');
+
+    form.addEventListener('submit', event => { event.preventDefault() });
   });
 
   afterEach(function () {
@@ -211,6 +217,34 @@ describe('SearchBarController', function () {
       .click(input)
       .type('x', () => {
         assert.isFalse(dropdown.classList.contains('is-open'));
+        done();
+      });
+  });
+
+  it('allows submitting the form when query is empty and no dropdown element is selected', function (done) {
+    let submitted = false;
+    form.addEventListener('submit', event => {
+      submitted = true;
+    });
+
+    syn
+      .click(input)
+      .type('[enter]', () => {
+        assert.isTrue(submitted);
+        done();
+      });
+  });
+
+  it('does not submit the form when a dropdown element is selected', function (done) {
+    let submitted = false;
+    form.addEventListener('submit', event => {
+      submitted = true;
+    });
+
+    syn
+      .click(input)
+      .type('[down][enter]', () => {
+        assert.isFalse(submitted);
         done();
       });
   });


### PR DESCRIPTION
**This depends on #3956 being merged, and will need a rebase after that.**

We handle key events differently when the search suggestions dropdown is
open. It used to always prevent the default event behaviour, even when
no suggestion from the dropdown was selected, this prevented a user from
submitting an empty form, which can be useful to return to a "search
all" query.

This change only prevents the default key event behaviour if a
suggestion is selected, otherwise it lets the event bubble up and thus
submit the form.

Fixes #3903.