### PR TITLE
Rework modal focus handling for forms

### DIFF
--- a/h/static/scripts/base/controller.js
+++ b/h/static/scripts/base/controller.js
@@ -76,6 +76,14 @@ class Controller {
   on(event, listener, useCapture) {
     this.element.addEventListener(event, listener, useCapture);
   }
+
+  /**
+   * Handler which is invoked when the controller's element is about to be
+   * removed.
+   *
+   * This can be used to clean up subscriptions, timeouts etc.
+   */
+  beforeRemove() {}
 }
 
 module.exports = Controller;

--- a/h/static/scripts/base/upgrade-elements.js
+++ b/h/static/scripts/base/upgrade-elements.js
@@ -12,6 +12,28 @@ function markReady(element) {
   element.classList.remove(HIDE_CLASS);
 }
 
+// List of all elements which have had upgrades applied
+var upgradedElements = [];
+
+/**
+ * Remove all of the controllers for elements under `root`.
+ *
+ * This clears the `controllers` list for all elements under `root` and notifies
+ * the controllers that their root element is about to be removed from the
+ * document.
+ */
+function removeControllers(root) {
+  upgradedElements = upgradedElements.filter(el => {
+    if (root.contains(el)) {
+      el.controllers.forEach(ctrl => ctrl.beforeRemove());
+      el.controllers = [];
+      return false;
+    } else {
+      return true;
+    }
+  });
+}
+
 /**
  * Upgrade elements on the page with additional functionality
  *
@@ -29,6 +51,8 @@ function upgradeElements(root, controllers) {
   // an upgraded element with new markup and re-applies element upgrades to
   // the new root element
   function reload(element, html) {
+    removeControllers(element);
+
     if (typeof html !== 'string') {
       throw new Error('Replacement markup must be a string');
     }
@@ -49,6 +73,7 @@ function upgradeElements(root, controllers) {
         new ControllerClass(el, {
           reload: reload.bind(null, el),
         });
+        upgradedElements.push(el);
         markReady(el);
       } catch (err) {
         console.error('Failed to upgrade element %s with controller', el, ControllerClass, ':', err.toString());

--- a/h/static/scripts/tests/base/upgrade-elements-test.js
+++ b/h/static/scripts/tests/base/upgrade-elements-test.js
@@ -68,5 +68,18 @@ describe('upgradeElements', function () {
       var ctrl = replacedElement.controllers[0];
       assert.instanceOf(ctrl, TestController);
     });
+
+    it('calls #beforeRemove on the original controllers', function () {
+      var root = document.createElement('div');
+      root.innerHTML = '<div class="js-test">Original content</div>';
+      upgradeElements(root, {'.js-test': TestController});
+      var ctrl = root.children[0].controllers[0];
+      ctrl.beforeRemove = sinon.stub();
+      var reloadFn = ctrl.options.reload;
+
+      reloadFn(newContent);
+
+      assert.called(ctrl.beforeRemove);
+    });
   });
 });

--- a/h/static/scripts/tests/controllers/form-controller-test.js
+++ b/h/static/scripts/tests/controllers/form-controller-test.js
@@ -65,6 +65,7 @@ describe('FormController', function () {
   });
 
   afterEach(function () {
+    ctrl.beforeRemove();
     ctrl.element.remove();
   });
 
@@ -235,31 +236,35 @@ describe('FormController', function () {
   });
 
   context('when focus moves outside of form', function () {
-    it('clears editing state if field does not have unsaved changes', function (done) {
+    var outsideEl;
+
+    beforeEach(function () {
+      outsideEl = document.createElement('input');
+      document.body.appendChild(outsideEl);
+    });
+
+    afterEach(function () {
+      outsideEl.remove();
+    });
+
+    it('clears editing state if field does not have unsaved changes', function () {
       startEditing();
 
       // Simulate user moving focus outside of form (eg. via tab key).
-      // This may be to either another part of the page or browser chrome
-      ctrl.refs.firstInput.blur();
+      outsideEl.focus();
 
-      setTimeout(function () {
-        assert.isFalse(isEditing());
-        done();
-      });
+      assert.isFalse(isEditing());
     });
 
-    it('keeps current field focused if it has unsaved changes', function (done) {
+    it('keeps current field focused if it has unsaved changes', function () {
       startEditing();
       ctrl.setState({dirty: true});
 
       // Simulate user/browser attempting to switch focus to an element outside
       // the form
-      ctrl.refs.firstInput.blur();
+      outsideEl.focus();
 
-      setTimeout(function () {
-        assert.equal(document.activeElement, ctrl.refs.firstInput);
-        done();
-      });
+      assert.equal(document.activeElement, ctrl.refs.firstInput);
     });
   });
 

--- a/h/static/scripts/tests/util/modal-focus-test.js
+++ b/h/static/scripts/tests/util/modal-focus-test.js
@@ -1,0 +1,63 @@
+'use strict';
+
+var modalFocus = require('../../util/modal-focus');
+
+describe('util/modal-focus', function () {
+  // Elements inside the focus group
+  var insideEls;
+  // Element outside the focus group
+  var outsideEl;
+  var onFocusOut;
+  var releaseFocus;
+
+  beforeEach(function () {
+    insideEls = [1,2,3].map(() => document.createElement('input'));
+    insideEls.forEach(el => document.body.appendChild(el));
+
+    outsideEl = document.createElement('input');
+    document.body.appendChild(outsideEl);
+
+    onFocusOut = sinon.stub();
+    releaseFocus = modalFocus.trap(insideEls, onFocusOut);
+  });
+
+  afterEach(function () {
+    insideEls.forEach(el => el.remove());
+    releaseFocus();
+  });
+
+  describe('#trap', function () {
+    it('does not invoke the callback when an element in the group is focused', function () {
+      insideEls[0].focus();
+      insideEls[1].focus();
+      assert.notCalled(onFocusOut);
+    });
+
+    it('invokes the callback when an element outside the group is focused', function () {
+      outsideEl.focus();
+      assert.calledWith(onFocusOut, outsideEl);
+    });
+
+    it('does not prevent the focus change if the callback returns null', function () {
+      onFocusOut.returns(null);
+      outsideEl.focus();
+      assert.equal(document.activeElement, outsideEl);
+    });
+
+    it('prevents a focus change if the callback returns an element', function () {
+      onFocusOut.returns(insideEls[0]);
+      outsideEl.focus();
+      assert.equal(document.activeElement, insideEls[0]);
+    });
+
+    it('releases focus when returned function is called', function () {
+      onFocusOut.returns(insideEls[0]);
+
+      releaseFocus();
+      outsideEl.focus();
+
+      assert.notCalled(onFocusOut);
+      assert.equal(document.activeElement, outsideEl);
+    });
+  });
+});

--- a/h/static/scripts/util/modal-focus.js
+++ b/h/static/scripts/util/modal-focus.js
@@ -1,0 +1,67 @@
+'use strict';
+
+// Focus release function returned by most recent call to trap()
+var currentReleaseFn;
+
+/**
+ * Trap focus within a group of elements.
+ *
+ * Watch focus changes in a document and react to and/or prevent focus moving
+ * outside a specified group of elements.
+ *
+ * @param {Element[]} elements - Array of elements which make up the modal group
+ * @param {(Element) => Element|null} callback - Callback which is invoked when
+ *        focus tries to move outside the modal group. It is called with the
+ *        new element that will be focused. If it returns null, the focus change
+ *        will proceed, otherwise if it returns an element within the group,
+ *        that element will be focused instead.
+ * @return {Function} A function which releases the modal focus, if it has not
+ *        been changed by another call to trap() in the meantime.
+ */
+function trap(elements, callback) {
+  if (currentReleaseFn) {
+    currentReleaseFn();
+  }
+
+  // The most obvious way of detecting an element losing focus and reacting
+  // based on the new focused element is the "focusout" event and the
+  // FocusEvent#relatedTarget property.
+  //
+  // However, FocusEvent#relatedTarget is not implemented in all browsers
+  // (Firefox < 48, IE) and is null in some cases even for browsers that do
+  // support it.
+  //
+  // Instead we watch the 'focus' event on the document itself.
+
+  var onFocusChange = event => {
+    if (elements.some(el => el.contains(event.target))) {
+      // Focus remains within modal group
+      return;
+    }
+
+    // Focus is trying to move outside of the modal group, test whether to
+    // allow this
+    var newTarget = callback(event.target);
+    if (newTarget) {
+      event.preventDefault();
+      event.stopPropagation();
+      newTarget.focus();
+    } else if (currentReleaseFn) {
+      currentReleaseFn();
+    }
+  };
+  document.addEventListener('focus', onFocusChange, true /* useCapture */);
+
+  var releaseFn = () => {
+    if (currentReleaseFn === releaseFn) {
+      currentReleaseFn = null;
+      document.removeEventListener('focus', onFocusChange, true /* useCapture */);
+    }
+  };
+  currentReleaseFn = releaseFn;
+  return releaseFn;
+}
+
+module.exports = {
+  trap,
+};


### PR DESCRIPTION
The previous method of ensuring that focus remained within the field
being edited and the form's action buttons relied on asynchronously
reverting focus changes after a blur.

This had several problems:

 - There was a brief flash while focus moved to a new "disallowed"
   element and back again

 - If the page contained multiple forms, it was possible for
   the page to get into a state where focus would continually
   ping-pong back between two forms each trying to retain focus

One solution is to use `FocusEvent#relatedTarget` in the `blur` handler,
but this is not supported by Firefox < 48 or IE and `#relatedTarget` is null in some
cases in Safari. Another would be the `focusout` event, but this
is not supported by Firefox either, and `#relatedTarget` may also be null there.

This commit instead adds a helper for implementing modal UI which instead intercepts `focus` events at the document level use a `useCapture` event listener. This method is compatible with all the browsers we support.