### PR TITLE
Fix confirmation prompt when deleting users

### DIFF
--- a/h/static/scripts/controllers/admin-users-controller.js
+++ b/h/static/scripts/controllers/admin-users-controller.js
@@ -3,14 +3,15 @@
 var Controller = require('../base/controller');
 
 class AdminUsersController extends Controller {
-  constructor(element, window_ = window) {
-    super(element);
+  constructor(element, options) {
+    super(element, options);
 
+    var window_ = options.window || window;
     function confirmFormSubmit() {
       return window_.confirm('This will permanently delete all the user\'s data. Are you sure?');
     }
 
-    this.element.addEventListener('submit', event => {
+    this.on('submit', event => {
       if (!confirmFormSubmit()) {
         event.preventDefault();
       }

--- a/h/static/scripts/tests/controllers/admin-users-controller-test.js
+++ b/h/static/scripts/tests/controllers/admin-users-controller-test.js
@@ -2,15 +2,8 @@
 
 var AdminUsersController = require('../../controllers/admin-users-controller');
 
-// helper to dispatch a native event to an element
-function sendEvent(element, eventType) {
-  // createEvent() used instead of Event constructor
-  // for PhantomJS compatibility
-  var event = document.createEvent('Event');
-  event.initEvent(eventType, true /* bubbles */, true /* cancelable */);
-  element.dispatchEvent(event);
-
-  return event;
+function submitEvent() {
+  return new Event('submit', {bubbles: true, cancelable: true});
 }
 
 describe('AdminUsersController', function () {
@@ -19,29 +12,32 @@ describe('AdminUsersController', function () {
 
   beforeEach(function () {
     root = document.createElement('div');
-    root.innerHTML = '<form id="js-users-delete-form">' +
-                     '<input type="submit" id="submit-btn">';
+    root.innerHTML = '<form><input type="submit"></form>';
     form = root.querySelector('form');
     document.body.appendChild(root);
   });
 
   afterEach(function () {
-    root.parentNode.removeChild(root);
+    root.remove();
   });
 
   it('it submits the form when confirm returns true', function () {
+    var event = submitEvent();
     var fakeWindow = {confirm: sinon.stub().returns(true)};
-    new AdminUsersController(root, fakeWindow);
+    new AdminUsersController(root, {window: fakeWindow});
 
-    var event = sendEvent(form, 'submit');
+    form.dispatchEvent(event);
+
     assert.isFalse(event.defaultPrevented);
   });
 
   it('it cancels the form submission when confirm returns false', function () {
+    var event = submitEvent();
     var fakeWindow = {confirm: sinon.stub().returns(false)};
-    new AdminUsersController(root, fakeWindow);
+    new AdminUsersController(root, {window: fakeWindow});
 
-    var event = sendEvent(form, 'submit');
+    form.dispatchEvent(event);
+
     assert.isTrue(event.defaultPrevented);
   });
 });


### PR DESCRIPTION
The second argument to controller constructors should be an options
object.

This regressed in 342296c234a43063c96ede0782935d31f51d55d5 when
upgradeElements() was changed to pass an options object to all
controllers.

Fixes #3951