### PR TITLE
Make SearchBarController tests implementation-agnostic

### DIFF
--- a/h/static/scripts/controllers/search-bar-controller.js
+++ b/h/static/scripts/controllers/search-bar-controller.js
@@ -217,7 +217,7 @@ class SearchBarController extends Controller {
 
     this._dropdownItems.forEach(function(item) {
       if(item && item.addEventListener) {
-        item.addEventListener('mouseover', handleHoverOnItem);
+        item.addEventListener('mousemove', handleHoverOnItem);
         item.addEventListener('mousedown', handleClickOnItem);
       }
     });

--- a/h/static/scripts/controllers/search-bar-controller.js
+++ b/h/static/scripts/controllers/search-bar-controller.js
@@ -81,8 +81,7 @@ class SearchBarController extends Controller {
       clearActiveDropdownItem();
       showAllDropdownItems();
       this.setState({open: false});
-      this._input.removeEventListener('keydown', setupListenerKeys,
-        true /*capture*/);
+      this._input.removeEventListener('keydown', setupListenerKeys);
     };
 
     var openDropdown = () => {
@@ -90,8 +89,7 @@ class SearchBarController extends Controller {
 
       this.setState({open: true});
 
-      this._input.addEventListener('keydown', setupListenerKeys,
-        true /*capture*/);
+      this._input.addEventListener('keydown', setupListenerKeys);
     };
 
     var getVisibleDropdownItems = () => {
@@ -217,21 +215,15 @@ class SearchBarController extends Controller {
 
     this._dropdownItems.forEach(function(item) {
       if(item && item.addEventListener) {
-        item.addEventListener('mouseover', handleHoverOnItem,
-          true);
-        item.addEventListener('mousedown', handleClickOnItem,
-          true);
+        item.addEventListener('mouseover', handleHoverOnItem);
+        item.addEventListener('mousedown', handleClickOnItem);
       }
     });
 
-    this._dropdown.addEventListener('mousedown', handleClickOnDropdown,
-      true /*capture*/);
-    this._input.addEventListener('focusout', handleFocusOutside,
-      true /*capture*/);
-    this._input.addEventListener('input', handleInputOnInput,
-      true /*capture*/);
-    this._input.addEventListener('focusin', handleFocusinOnInput,
-      true /*capture*/);
+    this._dropdown.addEventListener('mousedown', handleClickOnDropdown);
+    this._input.addEventListener('focusout', handleFocusOutside);
+    this._input.addEventListener('input', handleInputOnInput);
+    this._input.addEventListener('focusin', handleFocusinOnInput);
   }
 
   update(state) {

--- a/h/static/scripts/controllers/search-bar-controller.js
+++ b/h/static/scripts/controllers/search-bar-controller.js
@@ -78,6 +78,7 @@ class SearchBarController extends Controller {
     };
 
     var closeDropdown = () => {
+      if (!this.state.open) { return; }
       clearActiveDropdownItem();
       showAllDropdownItems();
       this.setState({open: false});
@@ -85,6 +86,7 @@ class SearchBarController extends Controller {
     };
 
     var openDropdown = () => {
+      if (this.state.open) { return; }
       clearActiveDropdownItem();
 
       this.setState({open: true});

--- a/h/static/scripts/controllers/search-bar-controller.js
+++ b/h/static/scripts/controllers/search-bar-controller.js
@@ -221,9 +221,9 @@ class SearchBarController extends Controller {
     });
 
     this._dropdown.addEventListener('mousedown', handleClickOnDropdown);
-    this._input.addEventListener('focusout', handleFocusOutside);
+    this._input.addEventListener('blur', handleFocusOutside);
     this._input.addEventListener('input', handleInputOnInput);
-    this._input.addEventListener('focusin', handleFocusinOnInput);
+    this._input.addEventListener('focus', handleFocusinOnInput);
   }
 
   update(state) {

--- a/h/static/scripts/tests/controllers/search-bar-controller-test.js
+++ b/h/static/scripts/tests/controllers/search-bar-controller-test.js
@@ -1,8 +1,22 @@
 'use strict';
 
+var syn = require('syn');
+
 var SearchBarController = require('../../controllers/search-bar-controller');
 
-describe('SearchBarController', function () {  
+function center(element) {
+  let rect = element.getBoundingClientRect();
+  return {
+    pageX: rect.left + (rect.width / 2),
+    pageY: rect.top + (rect.height / 2),
+  };
+}
+
+function isActiveItem(element) {
+  return element.classList.contains('js-search-bar-dropdown-menu-item--active');
+}
+
+describe('SearchBarController', function () {
   var template;
   var testEl;
   var input;
@@ -42,6 +56,7 @@ describe('SearchBarController', function () {
   beforeEach(function () {
     testEl = document.createElement('div');
     testEl.innerHTML = template;
+    document.body.appendChild(testEl);
 
     ctrl = new SearchBarController(testEl);
 
@@ -51,125 +66,152 @@ describe('SearchBarController', function () {
   });
 
   afterEach(function () {
-    ctrl = null;
+    document.body.removeChild(testEl);
   });
 
-  it('dropdown appears when the input field has focus', function () {
-    input.dispatchEvent(new Event('focusin'));
-    assert.isTrue(dropdown.classList.contains('is-open'));
+  it('dropdown appears when the input field has focus', function (done) {
+    syn.click(input, () => {
+      assert.isTrue(dropdown.classList.contains('is-open'));
+      done();
+    });
   });
 
-  it('dropdown is hidden when the input field loses focus', function () {
-    input.dispatchEvent(new Event('focusin'));
-    input.dispatchEvent(new Event('focusout'));
-    assert.isFalse(dropdown.classList.contains('is-open'));
+  it('dropdown is hidden when the input field loses focus', function (done) {
+    syn
+      .click(input)
+      .click(document.body, () => {
+        assert.isFalse(dropdown.classList.contains('is-open'));
+        done();
+      });
   });
 
-  it('selects facet from dropdown on mousedown', function () {
-    input.dispatchEvent(new Event('focusin'));
-    dropdownItems[0].dispatchEvent(new Event('mousedown'));
-    assert.equal(input.value, 'user:');
+  it('selects facet from dropdown on mousedown', function (done) {
+    syn
+      .click(input)
+      .click(dropdownItems[0], () => {
+        assert.equal(input.value, 'user:');
+        done();
+      });
   });
 
-  it('highlights facet on up arrow', function () {
-    var e = new Event('keydown');
-    e.keyCode = 38;
-    input.dispatchEvent(new Event('focusin'));
-    input.dispatchEvent(e);
-    assert.isTrue(dropdownItems[3].classList.contains('js-search-bar-dropdown-menu-item--active'));
+  it('highlights facet on up arrow', function (done) {
+    syn
+      .click(input)
+      .type('[up]', () => {
+        assert.isOk(isActiveItem(dropdownItems[3]));
+        done();
+      });
   });
 
-  it('highlights facet on down arrow', function () {
-    var e = new Event('keydown');
-    e.keyCode = 40;
-    input.dispatchEvent(new Event('focusin'));
-    input.dispatchEvent(e);
-    assert.isTrue(dropdownItems[0].classList.contains('js-search-bar-dropdown-menu-item--active'));
+  it('highlights facet on down arrow', function (done) {
+    syn
+      .click(input)
+      .type('[down]', () => {
+        assert.isOk(isActiveItem(dropdownItems[0]));
+        done();
+      });
   });
 
-  it('highlights the correct facet for a combination of mouseover, up and down arrow keys', function () {
-    var e = new Event('keydown');
-    // down arrow to #1
-    e.keyCode = 40;
-    input.dispatchEvent(new Event('focusin'));
-    input.dispatchEvent(e);
-    assert.isTrue(dropdownItems[0].classList.contains('js-search-bar-dropdown-menu-item--active'));
-    // mouseover #3
-    dropdownItems[2].dispatchEvent(new Event('mouseover'));
-    assert.isFalse(dropdownItems[0].classList.contains('js-search-bar-dropdown-menu-item--active'));
-    assert.isTrue(dropdownItems[2].classList.contains('js-search-bar-dropdown-menu-item--active'));
-    // up arrow to #2
-    e.keyCode = 38;
-    input.dispatchEvent(e);
-    assert.isFalse(dropdownItems[2].classList.contains('js-search-bar-dropdown-menu-item--active'));
-    assert.isTrue(dropdownItems[1].classList.contains('js-search-bar-dropdown-menu-item--active'));
-    // mouseover #3
-    dropdownItems[2].dispatchEvent(new Event('mouseover'));
-    assert.isFalse(dropdownItems[1].classList.contains('js-search-bar-dropdown-menu-item--active'));
-    assert.isTrue(dropdownItems[2].classList.contains('js-search-bar-dropdown-menu-item--active'));
-    // down arrow to #4
-    e.keyCode = 40;
-    input.dispatchEvent(e);
-    assert.isFalse(dropdownItems[2].classList.contains('js-search-bar-dropdown-menu-item--active'));
-    assert.isTrue(dropdownItems[3].classList.contains('js-search-bar-dropdown-menu-item--active'));
+  it('highlights the correct facet for a combination of mouseover, up and down arrow keys', function (done) {
+    let itemThreeCenter = center(dropdownItems[2]);
+    syn
+      .click(input)
+      // Down arrow to select first item
+      .type('[down]', () => {
+        assert.isOk(isActiveItem(dropdownItems[0]));
+      })
+      // Move mouse from input to the middle of the third item.
+      .move({
+        from: center(input),
+        to: itemThreeCenter,
+        duration: 100
+      }, () => {
+        assert.isNotOk(isActiveItem(dropdownItems[0]));
+        assert.isOk(isActiveItem(dropdownItems[2]));
+      })
+      // Up arrow to select second item.
+      .type('[up]', () => {
+        assert.isNotOk(isActiveItem(dropdownItems[2]));
+        assert.isOk(isActiveItem(dropdownItems[1]));
+      })
+      // Jiggle the mouse just a little over the third item.
+      .move({
+        from: itemThreeCenter,
+        to: {
+          pageX: itemThreeCenter.pageX + 1,
+          pageY: itemThreeCenter.pageY + 1
+        },
+        duration: 10
+      }, () => {
+        assert.isNotOk(isActiveItem(dropdownItems[1]));
+        assert.isOk(isActiveItem(dropdownItems[2]));
+      })
+      // Down arrow to select the fourth item.
+      .type('[down]', () => {
+        assert.isNotOk(isActiveItem(dropdownItems[2]));
+        assert.isOk(isActiveItem(dropdownItems[3]));
+        done();
+      });
   });
 
-  it('selects facet on enter', function () {
-    var e1 = new Event('keydown');
-    e1.keyCode = 40;
-    var e2 = new Event('keydown');
-    e2.keyCode = 13;
-    input.dispatchEvent(new Event('focusin'));
-    input.dispatchEvent(e1);
-    input.dispatchEvent(e2);
-    assert.equal(input.value, 'user:'); 
+  it('selects facet on enter', function (done) {
+    syn
+      .click(input)
+      .type('[down][enter]', () => {
+        assert.equal(input.value, 'user:');
+        done();
+      });
   });
 
-  it('dropdown stays open when clicking on a part of it that is not one of the suggestions', function () {
-    input.dispatchEvent(new Event('focusin'));
-    dropdown.querySelector('div').dispatchEvent(new Event('mousedown'));
-    assert.isTrue(dropdown.classList.contains('is-open'));
+  it('dropdown stays open when clicking on a part of it that is not one of the suggestions', function (done) {
+    syn
+      .click(input)
+      .click(dropdown.querySelector('div'), () => {
+        assert.isTrue(dropdown.classList.contains('is-open'));
+        done();
+      });
   });
 
-  it('search options narrow as input changes', function () {
-    input.dispatchEvent(new Event('focusin'));
-    input.value = 'g';
-    input.dispatchEvent(new Event('input'));
-    assert.isTrue(dropdownItems[0].classList.contains('is-hidden'));
-    assert.isFalse(dropdownItems[1].classList.contains('is-hidden'));
-    assert.isTrue(dropdownItems[2].classList.contains('is-hidden'));
-    assert.isFalse(dropdownItems[3].classList.contains('is-hidden'));
+  it('search options narrow as input changes', function (done) {
+    syn
+      .click(input)
+      .type('g', () => {
+        assert.isTrue(dropdownItems[0].classList.contains('is-hidden'));
+        assert.isFalse(dropdownItems[1].classList.contains('is-hidden'));
+        assert.isTrue(dropdownItems[2].classList.contains('is-hidden'));
+        assert.isFalse(dropdownItems[3].classList.contains('is-hidden'));
+        done();
+      });
   });
 
-  it('highlights the correct facet from narrowed dropdown items on up and down arrow keys', function () {
-    var e = new Event('keydown');
-    input.dispatchEvent(new Event('focusin'));
-    input.value = 'g';
-    input.dispatchEvent(new Event('input'));
-    // keycode for 'up'
-    e.keyCode = 40;
-    input.dispatchEvent(new Event('focusin'));
-    input.dispatchEvent(e);
-    // down arrow to first visible item
-    assert.isTrue(dropdownItems[1].classList.contains('js-search-bar-dropdown-menu-item--active'));
-    // up arrow to last visible item
-    e.keyCode = 38;
-    input.dispatchEvent(e);
-    assert.isFalse(dropdownItems[1].classList.contains('js-search-bar-dropdown-menu-item--active'));
-    assert.isTrue(dropdownItems[3].classList.contains('js-search-bar-dropdown-menu-item--active'));
+  it('highlights the correct facet from narrowed dropdown items on up and down arrow keys', function (done) {
+    syn
+      .click(input)
+      .type('g[down]', () => {
+        assert.isOk(isActiveItem(dropdownItems[1]));
+      })
+      .type('[up]', () => {
+        assert.isNotOk(isActiveItem(dropdownItems[1]));
+        assert.isOk(isActiveItem(dropdownItems[3]));
+        done();
+      });
   });
 
-  it('dropdown closes when user types ":"', function () {
-    input.dispatchEvent(new Event('focusin'));
-    input.value = ':';
-    input.dispatchEvent(new Event('input'));
-    assert.isFalse(dropdown.classList.contains('is-open'));
+  it('dropdown closes when user types ":"', function (done) {
+    syn
+      .click(input)
+      .type(':', () => {
+        assert.isFalse(dropdown.classList.contains('is-open'));
+        done();
+      });
   });
 
-  it('dropdown closes when there are no matches', function () {
-    input.dispatchEvent(new Event('focusin'));
-    input.value = 'x';
-    input.dispatchEvent(new Event('input'));
-    assert.isFalse(dropdown.classList.contains('is-open'));
+  it('dropdown closes when there are no matches', function (done) {
+    syn
+      .click(input)
+      .type('x', () => {
+        assert.isFalse(dropdown.classList.contains('is-open'));
+        done();
+      });
   });
 });

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "proxyquire-universal": "^1.0.8",
     "proxyquireify": "^3.2.1",
     "sinon": "^1.17.3",
+    "syn": "^0.2.2",
     "websocket": "^1.0.22"
   },
   "engines": {


### PR DESCRIPTION
The existing SearchBarController tests depend heavily on the specific implementation details of the SearchBarController -- that is, they assume the use of the 'input' event as opposed to other alternatives ('keyup', 'change', etc.) that would in principle also work.

Coupling tests to implementation in this way can make refactoring very difficult -- one is forced to change the tests at the same time as the code. Even more importantly, ensuring correct behaviour in response to user-triggered events is substantially more complicated than it would at first appear, because each user event (such as a click) typically triggers a predefined sequence of related events (in this case, mousedown, mouseup, focus, click) which need to be simulated as well.

To pick a pathological example to illustrate this point: adding a 'keyup' event handler to the SearchBarController which destroyed the entire component would clearly break the real controller, but would have had no effect on this test suite.

In order to address these issues, this commit rewrites the SearchBarController test suite to use `syn`, a synthetic event library, which takes care of most of these considerations.

Doing this has exposed at least one bug in the implementation, where the `handleInputOnInput` function calls `updateActiveDropdownItem` to update the "active" dropdown item in response to a keypress, and then immediately calls `maybeOpenOrCloseDropdown`, which (indirectly) calls `clearActiveDropdownItem`.

---

Subsequent commits do the following:

- Use the `focus`/`blur` events rather than `focusin`/`focusout`. This fixes the search bar in Firefox.
- Makes the `openDropdown`/`closeDropdown` functions idempotent, fixing the issue described in the last paragraph above.