### PR TITLE
Turn search query terms into lozenges as user types. 

### DIFF
--- a/h/static/scripts/controllers/lozenge-controller.js
+++ b/h/static/scripts/controllers/lozenge-controller.js
@@ -1,0 +1,37 @@
+'use strict';
+
+var Controller = require('../base/controller');
+
+/**
+ * Create a lozenge with options.content as its content and append it to containerEl.
+ *
+ * A lozenge is made of two parts - the lozenge content and
+ * the 'x' button which when clicked removes the lozenge
+ * from the container and executes the delete callback provided.
+ *
+ * var lozenge = new Lozenge(containerEl, {
+ *   content: content,
+ *   deleteCallback: deleteCallback,
+ * });
+ */
+class LozengeController extends Controller {
+  constructor(containerEl, options) {
+    super(containerEl, options);
+    var lozengeEl = document.createElement('div');
+    lozengeEl.innerHTML =
+      '<div class="js-lozenge__content lozenge__content">'+
+      options.content+
+      '</div>' +
+      '<div class="js-lozenge__close lozenge__close">x</div>';
+    lozengeEl.classList.add('lozenge');
+    lozengeEl.classList.add('js-lozenge');
+    containerEl.appendChild(lozengeEl);
+
+    lozengeEl.querySelector('.js-lozenge__close').addEventListener('mousedown', () => {
+      lozengeEl.remove();
+      options.deleteCallback();
+    });
+  }
+}
+
+module.exports = LozengeController;

--- a/h/static/scripts/controllers/search-bar-controller.js
+++ b/h/static/scripts/controllers/search-bar-controller.js
@@ -2,6 +2,8 @@
 
 var Controller = require('../base/controller');
 var setElementState = require('../util/dom').setElementState;
+var LozengeController = require('./lozenge-controller');
+var SearchTextParser = require('../util/search-text-parser');
 
 /**
  * Controller for the search bar.
@@ -10,11 +12,12 @@ class SearchBarController extends Controller {
   constructor(element) {
     super(element);
 
-    this._input = this.refs.searchBarInput;
     this._dropdown = this.refs.searchBarDropdown;
     this._dropdownItems = Array.from(
       element.querySelectorAll('[data-ref="searchBarDropdownItem"]'));
-
+    this._input = this.refs.searchBarInput;
+    this._inputHidden = this.refs.searchBarInputHidden;
+    this._lozengeContainer = this.refs.searchBarLozenges;
     var getActiveDropdownItem = () => {
       return element.querySelector('.js-search-bar-dropdown-menu-item--active');
     };
@@ -29,16 +32,6 @@ class SearchBarController extends Controller {
     var updateActiveDropdownItem = element => {
       clearActiveDropdownItem();
       element.classList.add('js-search-bar-dropdown-menu-item--active');
-    };
-
-    var selectFacet = facet => {
-      this._input.value = facet;
-
-      closeDropdown();
-
-      setTimeout(function() {
-        this._input.focus();
-      }.bind(this), 0);
     };
 
     var isHidden = element => {
@@ -82,16 +75,22 @@ class SearchBarController extends Controller {
       clearActiveDropdownItem();
       showAllDropdownItems();
       this.setState({open: false});
-      this._input.removeEventListener('keydown', setupListenerKeys);
     };
 
     var openDropdown = () => {
       if (this.state.open) { return; }
       clearActiveDropdownItem();
-
       this.setState({open: true});
+    };
 
-      this._input.addEventListener('keydown', setupListenerKeys);
+    var selectFacet = facet => {
+      this._input.value = facet;
+
+      closeDropdown();
+
+      setTimeout(function() {
+        this._input.focus();
+      }.bind(this), 0);
     };
 
     var getVisibleDropdownItems = () => {
@@ -137,15 +136,122 @@ class SearchBarController extends Controller {
       }
     };
 
-    var setupListenerKeys = event => {
+    /**
+     * Updates the hidden input field with the consolidated
+     * search terms from the lozenges.
+     */
+    var updateHiddenInputValue = () => {
+      var newValue = '';
+      Array.from(this._lozengeContainer.querySelectorAll('.js-lozenge__content'), function(loz) {
+        newValue = newValue + loz.textContent + ' ';
+      });
+      newValue = newValue + getTrimmedInputValue();
+      this._inputHidden.value = newValue;
+    };
+
+    /**
+     * Creates a lozenge and sets the content string to the
+     * content provided and executes the delete callback when
+     * the lozenge is deleted.
+     *
+     * @param {String} content The search term
+     */
+    var addLozenge = content => {
+      var deleteCallback = () => {
+        updateHiddenInputValue();
+        this._lozengeContainer.querySelectorAll('.js-lozenge').forEach(function(loz) {
+          loz.classList.add('is-disabled');
+        });
+        this.element.querySelector('form').submit();
+      };
+
+      new LozengeController(
+        this._lozengeContainer,
+        {
+          content: content,
+          deleteCallback: deleteCallback,
+        }
+      );
+    };
+
+    /**
+     * Add incomplete search query terms which start with a quote but are missing the end quote
+     * to the input field from the hidden input field on page load.
+     */
+    var addIncompleteSearchTermToInput = () => {
+      this._input.value = SearchTextParser.getIncompleteInputValue(this._inputHidden.value);
+    };
+
+    /**
+     * Create lozenges for the search query terms already in
+     * the hidden input field on page load.
+     */
+    var lozengifyHiddenInput = () => {
+      var queryTerms = SearchTextParser.getLozengeValues(this._inputHidden.value);
+      queryTerms.forEach(function(term) {
+        addLozenge(term);
+      });
+    };
+
+    /**
+     * Setup listener keys with the handlers provided for each
+     * of them.
+     *
+     * @param {Event} The event.
+     * @param {Object} The function to execute when
+     * the event fires for each listener key.
+     */
+    var setupListenerKeys = (event, handlers) => {
+      var handler = handlers[event.keyCode];
+      if (handler) {
+        handler(event);
+      }
+    };
+
+    /**
+     * Setup the space key as the  listener for
+     * creating a lozenge.
+     *
+     * @param {Event} The event to listen for.
+     */
+    var setupLozengeListenerKeys = event => {
+      const SPACE_KEY_CODE = 32;
+
+      var handleSpaceKey = () => {
+        var word = getTrimmedInputValue();
+        if (SearchTextParser.shouldLozengify(word)) {
+          addLozenge(word);
+          // Clear the input after the lozenge is created and
+          // appended to the container element.
+          event.preventDefault();
+          this._input.value = '';
+        }
+      };
+
+      var handlers = {};
+      handlers[SPACE_KEY_CODE] = handleSpaceKey;
+      setupListenerKeys(event, handlers);
+    };
+
+    /**
+     * Setup the keys to  listener for in the search dropdown.
+     *
+     * @param {Event} The event to listen for.
+     */
+    var setupDropdownListenerKeys = event => {
+      const DOWN_ARROW_KEY_CODE = 40;
       const ENTER_KEY_CODE = 13;
       const UP_ARROW_KEY_CODE = 38;
-      const DOWN_ARROW_KEY_CODE = 40;
 
       var activeItem = getActiveDropdownItem();
       var handlers = {};
 
       var visibleDropdownItems = getVisibleDropdownItems();
+
+      var handleDownArrowKey = () => {
+        updateActiveDropdownItem(getNextVisibleSiblingElement(activeItem) ||
+          visibleDropdownItems[0]);
+      };
 
       var handleEnterKey = event => {
         if (activeItem) {
@@ -155,6 +261,9 @@ class SearchBarController extends Controller {
               querySelector('[data-ref="searchBarDropdownItemTitle"]').
               innerHTML.trim();
           selectFacet(facet);
+        } else {
+          updateHiddenInputValue();
+          this.element.querySelector('form').submit();
         }
       };
 
@@ -163,19 +272,11 @@ class SearchBarController extends Controller {
           visibleDropdownItems[visibleDropdownItems.length - 1]);
       };
 
-      var handleDownArrowKey = () => {
-        updateActiveDropdownItem(getNextVisibleSiblingElement(activeItem) ||
-          visibleDropdownItems[0]);
-      };
-
+      handlers[DOWN_ARROW_KEY_CODE] = handleDownArrowKey;
       handlers[ENTER_KEY_CODE] = handleEnterKey;
       handlers[UP_ARROW_KEY_CODE] = handleUpArrowKey;
-      handlers[DOWN_ARROW_KEY_CODE] = handleDownArrowKey;
 
-      var handler = handlers[event.keyCode];
-      if (handler) {
-        handler(event);
-      }
+      setupListenerKeys(event, handlers);
     };
 
     var handleClickOnItem = event => {
@@ -202,9 +303,12 @@ class SearchBarController extends Controller {
         this.setState({open: false});
       }
       closeDropdown();
+      this._input.removeEventListener('keydown', setupDropdownListenerKeys);
+      this._input.removeEventListener('keydown', setupLozengeListenerKeys);
     };
 
     var handleFocusinOnInput = () => {
+      this._input.addEventListener('keydown', setupDropdownListenerKeys);
       maybeOpenOrCloseDropdown();
     };
 
@@ -212,6 +316,7 @@ class SearchBarController extends Controller {
       var word = getTrimmedInputValue();
       setVisibleDropdownItems(word);
       maybeOpenOrCloseDropdown();
+      this._input.addEventListener('keydown', setupLozengeListenerKeys);
     };
 
     this._dropdownItems.forEach(function(item) {
@@ -225,6 +330,9 @@ class SearchBarController extends Controller {
     this._input.addEventListener('blur', handleFocusOutside);
     this._input.addEventListener('input', handleInputOnInput);
     this._input.addEventListener('focus', handleFocusinOnInput);
+
+    lozengifyHiddenInput();
+    addIncompleteSearchTermToInput();
   }
 
   update(state) {

--- a/h/static/scripts/tests/controllers/lozenge-controller-test.js
+++ b/h/static/scripts/tests/controllers/lozenge-controller-test.js
@@ -1,0 +1,34 @@
+'use strict';
+
+var LozengeController = require('../../controllers/lozenge-controller');
+
+describe('LozengeController', function () {
+  var el;
+  var opts;
+  var lozengeEl;
+  var lozengeContentEl;
+  var lozengeDeleteEl;
+
+  beforeEach(function () {
+    el = document.createElement('div');
+    opts = {
+      content: 'foo',
+      deleteCallback: sinon.spy(),
+    };
+
+    new LozengeController(el, opts);
+    lozengeEl = el.querySelector('.js-lozenge');
+    lozengeContentEl = lozengeEl.querySelector('.js-lozenge__content');
+    lozengeDeleteEl = lozengeEl.querySelector('.js-lozenge__close');
+  });
+
+  it('creates a new lozenge inside the container provided', function () {
+    assert.equal(lozengeContentEl.textContent, opts.content);
+  });
+
+  it('removes the lozenge and executes the delete callback provided', function () {
+    lozengeDeleteEl.dispatchEvent(new Event('mousedown'));
+    assert(opts.deleteCallback.calledOnce);
+    assert.isNull(el.querySelector('.js-lozenge'));
+  });
+});

--- a/h/static/scripts/tests/controllers/search-bar-controller-test.js
+++ b/h/static/scripts/tests/controllers/search-bar-controller-test.js
@@ -17,235 +17,314 @@ function isActiveItem(element) {
 }
 
 describe('SearchBarController', function () {
-  var template;
-  var testEl;
-  var input;
-  var dropdown;
-  var dropdownItems;
-  var ctrl;
-  var form;
+  describe('Dropdown', function () {
+    var testEl;
+    var input;
+    var dropdown;
+    var dropdownItems;
+    var ctrl;
+    var form;
+    var TEMPLATE = `
+      <form>
+        <div class="search-bar__lozenges" data-ref="searchBarLozenges">
+        </div>
+        <input data-ref="searchBarInput" class="search-bar__input" />
+        <input data-ref="searchBarInputHidden" class="js-search-bar__input-hidden" name="q" value="foo" />
+        <div data-ref="searchBarDropdown">
+          <div>Narrow your search</div>
+          <ul>
+            <li data-ref="searchBarDropdownItem">
+              <span data-ref="searchBarDropdownItemTitle">
+                user:
+              </span>
+            </li>
+            <li data-ref="searchBarDropdownItem">
+              <span data-ref="searchBarDropdownItemTitle">
+                tag:
+              </span>
+            </li>
+            <li data-ref="searchBarDropdownItem">
+              <span data-ref="searchBarDropdownItemTitle">
+                url:
+              </span>
+            </li>
+            <li data-ref="searchBarDropdownItem">
+              <span data-ref="searchBarDropdownItemTitle">
+                group:
+              </span>
+            </li>
+          </ul>
+        </div>
+      </form>
+    `;
 
-  before(function () {
-    template = '<form>' +
-      '<input data-ref="searchBarInput">' +
-      '<div data-ref="searchBarDropdown">' +
-      '<div>Narrow your search</div>' +
-      '<ul>' +
-      '<li data-ref="searchBarDropdownItem">' +
-      '<span data-ref="searchBarDropdownItemTitle">' +
-      'user:' +
-      '</span>' +
-      '</li>' +
-      '<li data-ref="searchBarDropdownItem">' +
-      '<span data-ref="searchBarDropdownItemTitle">' +
-      'tag:' +
-      '</span>' +
-      '</li>' +
-      '<li data-ref="searchBarDropdownItem">' +
-      '<span data-ref="searchBarDropdownItemTitle">' +
-      'url:' +
-      '</span>' +
-      '</li>' +
-      '<li data-ref="searchBarDropdownItem">' +
-      '<span data-ref="searchBarDropdownItemTitle">' +
-      'group:' +
-      '</span>' +
-      '</li>' +
-      '</ul>' +
-      '</div>' +
-      '</form>';
-  });
+    beforeEach(function () {
+      testEl = document.createElement('div');
+      testEl.innerHTML = TEMPLATE;
+      document.body.appendChild(testEl);
 
-  beforeEach(function () {
-    testEl = document.createElement('div');
-    testEl.innerHTML = template;
-    document.body.appendChild(testEl);
+      ctrl = new SearchBarController(testEl);
 
-    ctrl = new SearchBarController(testEl);
+      input = ctrl.refs.searchBarInput;
+      dropdown = ctrl.refs.searchBarDropdown;
+      dropdownItems = testEl.querySelectorAll('[data-ref="searchBarDropdownItem"]');
+      form = testEl.querySelector('form');
 
-    input = ctrl.refs.searchBarInput;
-    dropdown = ctrl.refs.searchBarDropdown;
-    dropdownItems = testEl.querySelectorAll('[data-ref="searchBarDropdownItem"]');
-    form = testEl.querySelector('form');
+      form.addEventListener('submit', event => { event.preventDefault(); });
+    });
 
-    form.addEventListener('submit', event => { event.preventDefault() });
-  });
+    afterEach(function () {
+      document.body.removeChild(testEl);
+    });
 
-  afterEach(function () {
-    document.body.removeChild(testEl);
-  });
+    it('dropdown appears when the input field has focus', function (done) {
+      syn
+        .click(input, () => {
+          assert.isTrue(dropdown.classList.contains('is-open'));
+          done();
+        });
+    });
 
-  it('dropdown appears when the input field has focus', function (done) {
-    syn.click(input, () => {
-      assert.isTrue(dropdown.classList.contains('is-open'));
-      done();
+    it('dropdown is hidden when the input field loses focus', function (done) {
+      syn
+        .click(input)
+        .click(document.body, () => {
+          assert.isFalse(dropdown.classList.contains('is-open'));
+          done();
+        });
+    });
+
+    it('selects facet from dropdown on mousedown', function (done) {
+      syn
+        .click(input)
+        .click(dropdownItems[0], () => {
+          assert.equal(input.value, 'user:');
+          done();
+        });
+    });
+
+    it('highlights facet on up arrow', function (done) {
+      syn
+        .click(input)
+        .type('[up]', () => {
+          assert.isOk(isActiveItem(dropdownItems[3]));
+          done();
+        });
+    });
+
+    it('highlights facet on down arrow', function (done) {
+      syn
+        .click(input)
+        .type('[down]', () => {
+          assert.isOk(isActiveItem(dropdownItems[0]));
+          done();
+        });
+    });
+
+    it('highlights the correct facet for a combination of mouseover, up and down arrow keys', function (done) {
+      let itemThreeCenter = center(dropdownItems[2]);
+      syn
+        .click(input)
+        // Down arrow to select first item
+        .type('[down]', () => {
+          assert.isOk(isActiveItem(dropdownItems[0]));
+        })
+        // Move mouse from input to the middle of the third item.
+        .move({
+          from: center(input),
+          to: itemThreeCenter,
+          duration: 100,
+        }, () => {
+          assert.isNotOk(isActiveItem(dropdownItems[0]));
+          assert.isOk(isActiveItem(dropdownItems[2]));
+        })
+        // Up arrow to select second item.
+        .type('[up]', () => {
+          assert.isNotOk(isActiveItem(dropdownItems[2]));
+          assert.isOk(isActiveItem(dropdownItems[1]));
+        })
+        // Jiggle the mouse just a little over the third item.
+        .move({
+          from: itemThreeCenter,
+          to: {
+            pageX: itemThreeCenter.pageX + 1,
+            pageY: itemThreeCenter.pageY + 1,
+          },
+          duration: 10,
+        }, () => {
+          assert.isNotOk(isActiveItem(dropdownItems[1]));
+          assert.isOk(isActiveItem(dropdownItems[2]));
+        })
+        // Down arrow to select the fourth item.
+        .type('[down]', () => {
+          assert.isNotOk(isActiveItem(dropdownItems[2]));
+          assert.isOk(isActiveItem(dropdownItems[3]));
+          done();
+        });
+    });
+
+    it('selects facet on enter', function (done) {
+      syn
+        .click(input)
+        .type('[down][enter]', () => {
+          assert.equal(input.value, 'user:');
+          done();
+        });
+    });
+
+    it('dropdown stays open when clicking on a part of it that is not one of the suggestions', function (done) {
+      syn
+        .click(input)
+        .click(dropdown.querySelector('div'), () => {
+          assert.isTrue(dropdown.classList.contains('is-open'));
+          done();
+        });
+    });
+
+    it('search options narrow as input changes', function (done) {
+      syn
+        .click(input)
+        .type('g', () => {
+          assert.isTrue(dropdownItems[0].classList.contains('is-hidden'));
+          assert.isFalse(dropdownItems[1].classList.contains('is-hidden'));
+          assert.isTrue(dropdownItems[2].classList.contains('is-hidden'));
+          assert.isFalse(dropdownItems[3].classList.contains('is-hidden'));
+          done();
+        });
+    });
+
+    it('highlights the correct facet from narrowed dropdown items on up and down arrow keys', function (done) {
+      syn
+        .click(input)
+        .type('g[down]', () => {
+          assert.isOk(isActiveItem(dropdownItems[1]));
+        })
+        .type('[up]', () => {
+          assert.isNotOk(isActiveItem(dropdownItems[1]));
+          assert.isOk(isActiveItem(dropdownItems[3]));
+          done();
+        });
+    });
+
+    it('dropdown closes when user types ":"', function (done) {
+      syn
+        .click(input)
+        .type(':', () => {
+          assert.isFalse(dropdown.classList.contains('is-open'));
+          done();
+        });
+    });
+
+    it('dropdown closes when there are no matches', function (done) {
+      syn
+        .click(input)
+        .type('x', () => {
+          assert.isFalse(dropdown.classList.contains('is-open'));
+          done();
+        });
+    });
+
+    it('does not submit the form when a dropdown element is selected', function (done) {
+      let submitted = false;
+      form.addEventListener('submit', () => {
+        submitted = true;
+      });
+
+      syn
+        .click(input)
+        .type('[down][enter]', () => {
+          assert.isFalse(submitted);
+          done();
+        });
+    });
+
+    it('allows submitting the form when query is empty and no dropdown element is selected', function (done) {
+      var submit = sinon.stub(form, 'submit');
+
+      syn
+        .click(input)
+        .type('[enter]', () => {
+          assert.isTrue(submit.calledOnce);
+          done();
+        });
     });
   });
 
-  it('dropdown is hidden when the input field loses focus', function (done) {
-    syn
-      .click(input)
-      .click(document.body, () => {
-        assert.isFalse(dropdown.classList.contains('is-open'));
-        done();
-      });
-  });
+  describe('Lozenges', function () {
+    var testEl;
+    var input;
+    var inputHidden;
+    var ctrl;
+    var TEMPLATE = `
+      <form>
+        <div class="search-bar__lozenges" data-ref="searchBarLozenges">
+        </div>
+        <input data-ref="searchBarInput" class="search-bar__input" />
+        <input data-ref="searchBarInputHidden" class="js-search-bar__input-hidden" name="q" value="foo 'bar" />
+        <div data-ref="searchBarDropdown">
+        </div>
+      </form>
+    `;
 
-  it('selects facet from dropdown on mousedown', function (done) {
-    syn
-      .click(input)
-      .click(dropdownItems[0], () => {
-        assert.equal(input.value, 'user:');
-        done();
-      });
-  });
+    beforeEach(function () {
+      testEl = document.createElement('div');
+      testEl.innerHTML = TEMPLATE;
+      document.body.appendChild(testEl);
 
-  it('highlights facet on up arrow', function (done) {
-    syn
-      .click(input)
-      .type('[up]', () => {
-        assert.isOk(isActiveItem(dropdownItems[3]));
-        done();
-      });
-  });
+      ctrl = new SearchBarController(testEl);
 
-  it('highlights facet on down arrow', function (done) {
-    syn
-      .click(input)
-      .type('[down]', () => {
-        assert.isOk(isActiveItem(dropdownItems[0]));
-        done();
-      });
-  });
-
-  it('highlights the correct facet for a combination of mouseover, up and down arrow keys', function (done) {
-    let itemThreeCenter = center(dropdownItems[2]);
-    syn
-      .click(input)
-      // Down arrow to select first item
-      .type('[down]', () => {
-        assert.isOk(isActiveItem(dropdownItems[0]));
-      })
-      // Move mouse from input to the middle of the third item.
-      .move({
-        from: center(input),
-        to: itemThreeCenter,
-        duration: 100
-      }, () => {
-        assert.isNotOk(isActiveItem(dropdownItems[0]));
-        assert.isOk(isActiveItem(dropdownItems[2]));
-      })
-      // Up arrow to select second item.
-      .type('[up]', () => {
-        assert.isNotOk(isActiveItem(dropdownItems[2]));
-        assert.isOk(isActiveItem(dropdownItems[1]));
-      })
-      // Jiggle the mouse just a little over the third item.
-      .move({
-        from: itemThreeCenter,
-        to: {
-          pageX: itemThreeCenter.pageX + 1,
-          pageY: itemThreeCenter.pageY + 1
-        },
-        duration: 10
-      }, () => {
-        assert.isNotOk(isActiveItem(dropdownItems[1]));
-        assert.isOk(isActiveItem(dropdownItems[2]));
-      })
-      // Down arrow to select the fourth item.
-      .type('[down]', () => {
-        assert.isNotOk(isActiveItem(dropdownItems[2]));
-        assert.isOk(isActiveItem(dropdownItems[3]));
-        done();
-      });
-  });
-
-  it('selects facet on enter', function (done) {
-    syn
-      .click(input)
-      .type('[down][enter]', () => {
-        assert.equal(input.value, 'user:');
-        done();
-      });
-  });
-
-  it('dropdown stays open when clicking on a part of it that is not one of the suggestions', function (done) {
-    syn
-      .click(input)
-      .click(dropdown.querySelector('div'), () => {
-        assert.isTrue(dropdown.classList.contains('is-open'));
-        done();
-      });
-  });
-
-  it('search options narrow as input changes', function (done) {
-    syn
-      .click(input)
-      .type('g', () => {
-        assert.isTrue(dropdownItems[0].classList.contains('is-hidden'));
-        assert.isFalse(dropdownItems[1].classList.contains('is-hidden'));
-        assert.isTrue(dropdownItems[2].classList.contains('is-hidden'));
-        assert.isFalse(dropdownItems[3].classList.contains('is-hidden'));
-        done();
-      });
-  });
-
-  it('highlights the correct facet from narrowed dropdown items on up and down arrow keys', function (done) {
-    syn
-      .click(input)
-      .type('g[down]', () => {
-        assert.isOk(isActiveItem(dropdownItems[1]));
-      })
-      .type('[up]', () => {
-        assert.isNotOk(isActiveItem(dropdownItems[1]));
-        assert.isOk(isActiveItem(dropdownItems[3]));
-        done();
-      });
-  });
-
-  it('dropdown closes when user types ":"', function (done) {
-    syn
-      .click(input)
-      .type(':', () => {
-        assert.isFalse(dropdown.classList.contains('is-open'));
-        done();
-      });
-  });
-
-  it('dropdown closes when there are no matches', function (done) {
-    syn
-      .click(input)
-      .type('x', () => {
-        assert.isFalse(dropdown.classList.contains('is-open'));
-        done();
-      });
-  });
-
-  it('allows submitting the form when query is empty and no dropdown element is selected', function (done) {
-    let submitted = false;
-    form.addEventListener('submit', event => {
-      submitted = true;
+      input = ctrl.refs.searchBarInput;
+      inputHidden = ctrl.refs.searchBarInputHidden;
     });
 
-    syn
-      .click(input)
-      .type('[enter]', () => {
-        assert.isTrue(submitted);
-        done();
-      });
-  });
-
-  it('does not submit the form when a dropdown element is selected', function (done) {
-    let submitted = false;
-    form.addEventListener('submit', event => {
-      submitted = true;
+    afterEach(function () {
+      document.body.removeChild(testEl);
     });
 
-    syn
-      .click(input)
-      .type('[down][enter]', () => {
-        assert.isFalse(submitted);
-        done();
-      });
+    it('should create lozenges for existing query terms in the hidden input on page load', function () {
+      assert.equal(testEl.querySelectorAll('.js-lozenge__content')[0].textContent, 'foo');
+    });
+
+    it('should  not create a lozenge for incomplete query strings in the hidden input on page load', function () {
+      assert.equal(testEl.querySelectorAll('.js-lozenge__content').length, 1);
+      assert.equal(testEl.querySelectorAll('.js-lozenge__content')[0].textContent, 'foo');
+      assert.equal(testEl.querySelector('[data-ref="searchBarInput"]').value, '\'bar');
+    });
+
+    it('should create a lozenge when the user presses space and there are no incomplete query strings in the input', function (done) {
+      input.value = '';
+      inputHidden.value = '';
+      syn
+        .click(input)
+        .type('gar')
+        .type('[space]', () => {
+          assert.equal(testEl.querySelectorAll('.js-lozenge__content')[1].textContent, 'gar');
+          done();
+        });
+    });
+
+    it('should create a lozenge when the user completes a previously incomplete query string and then presses the space key', function (done) {
+      syn
+        .click(input)
+        .type(' gar\'')
+        .type('[space]', () => {
+          assert.equal(testEl.querySelectorAll('.js-lozenge__content')[1].textContent, '\'bar gar\'');
+          done();
+        });
+    });
+
+    it('should not create a lozenge when the user does not completes a previously incomplete query string and presses the space key', function (done) {
+      syn
+        .click(input)
+        .type('[space]')
+        .type('gar')
+        .type('[space]', () => {
+          var lozenges = testEl.querySelectorAll('.js-lozenge__content');
+          assert.equal(lozenges.length, 1);
+          assert.equal(lozenges[0].textContent, 'foo');
+          assert.equal(input.value, '\'bar gar ');
+          done();
+        });
+    });
   });
 });

--- a/h/static/scripts/tests/util/search-text-parser-test.js
+++ b/h/static/scripts/tests/util/search-text-parser-test.js
@@ -1,0 +1,36 @@
+'use strict';
+
+var searchTextParser = require('../../util/search-text-parser');
+var unroll = require('../util').unroll;
+
+describe('SearchTextParser', function () {
+  unroll('should create a lozenge #input', function (fixture) {
+    assert.isTrue(searchTextParser.shouldLozengify(fixture.input));
+  },[
+    {input: 'foo'},
+    {input: '    foo    '},
+    {input: '"foo bar"'},
+    {input: '\'foo bar\''},
+    {input: 'foo:"bar"'},
+    {input: 'foo:\'bar\''},
+    {input: 'foo:\'bar1 bar2\''},
+    {input: 'foo:"bar1 bar2"'},
+    {input: 'foo:'},
+    {input: '\'foo\':'},
+    {input: '"foo":'},
+    {input: 'foo"bar:'},
+    {input: 'foo\'bar:'},
+  ]);
+
+  unroll('should not create a lozenge for', function (fixture) {
+    assert.isFalse(searchTextParser.shouldLozengify(fixture.input));
+  },[
+    {input: 'foo\''},
+    {input: 'foo\"'},
+    {input: '\'foo'},
+    {input: '\"foo'},
+    {input: ''},
+    {input: 'foo:\'bar'},
+    {input: 'foo:\"bar'},
+  ]);
+});

--- a/h/static/scripts/util/search-text-parser.js
+++ b/h/static/scripts/util/search-text-parser.js
@@ -1,0 +1,144 @@
+'use strict';
+
+/**
+ * Function which determines if it is possible to lozengify a given phrase.
+ *
+ * @param {String} phrase A potential query term.
+ *
+ * @returns {Bool} True if the input phrase can be lozengified and false otherwise.
+ *
+ * @example
+ * // returns True
+ * canLozengify('foo')
+ * @example
+ * // returns False
+ * canLozengify('foo)
+ */
+function canLozengify(phrase) {
+  phrase = phrase.trim();
+  // if there is no word
+  if (!phrase) {
+    return false;
+  }
+  // if phrase starts with a double quote, it has to end with one
+  if (phrase.indexOf('"') === 0 && phrase.indexOf('"', 1) !== phrase.length - 1) {
+    return false;
+  }
+  // if phrase ends with a double quote it has to start with one
+  if (phrase.indexOf('"', 1) === phrase.length - 1 && phrase.indexOf('"') !== 0) {
+    return false;
+  }
+  // if phrase starts with a single quote, it has to end with one
+  if (phrase.indexOf("'") === 0 && phrase.indexOf("'", 1) !== phrase.length - 1) {
+    return false;
+  }
+  // if phrase ends with a single quote it has to start with one
+  if (phrase.indexOf("'", 1) === phrase.length - 1 && phrase.indexOf("'") !== 0) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Function which determines if a phrase can be lozengified as is or
+ * if it needs to be divided into a facet name and value first.
+ *
+ * @param {String} phrase A potential query term.
+ *
+ * @returns {Bool} True if the input phrase is ready to be
+ * lozengified and false otherwise.
+ *
+ * @example
+ * // returns True
+ * shouldLozengify('foo:bar')
+ * @example
+ * // returns False
+ * shouldLozengify('foo:"bar')
+ */
+function shouldLozengify(phrase) {
+  var facetName;
+  var facetValue;
+  var i;
+
+  // if the phrase has a facet and value
+  if (phrase.indexOf(':') >= 0) {
+    i = phrase.indexOf(':');
+    facetName = phrase.slice(0, i).trim();
+    facetValue = phrase.slice(i+1, phrase.length).trim();
+
+    if (!canLozengify(facetName)) {
+      return false;
+    }
+    if (facetValue.length > 0 && !canLozengify(facetValue)) {
+      return false;
+    }
+  }
+  else if (!canLozengify(phrase)) {
+    return false;
+  }
+  return true;
+}
+
+function getLozengeValuesAndIncompleteSearchTerms(queryString) {
+  var inputTerms = '';
+  var quoted;
+  var queryTerms = [];
+  queryString.split(' ').forEach(function(term) {
+    if (quoted) {
+      inputTerms = inputTerms + ' ' + term;
+      if (shouldLozengify(inputTerms)) {
+        queryTerms.push(inputTerms);
+        inputTerms = '';
+        quoted = false;
+      }
+    } else {
+      if (shouldLozengify(term)) {
+        queryTerms.push(term);
+      } else {
+        inputTerms = term;
+        quoted = true;
+      }
+    }
+  });
+  return {
+    lozengeValues: queryTerms,
+    incompleteInputValue: inputTerms,
+  };
+}
+
+/**
+ * Function which returns individual lozenge from a string.
+ *
+ * @param {String} queryString A string of query terms.
+ *
+ * @returns {Array} queryTerms An array of individual query terms.
+ *
+ * @example
+ * // returns ['foo', 'key:"foo bar"', 'gar']
+ * getLozengeValues('foo key:"foo bar" gar')
+ */
+function getLozengeValues(queryString) {
+  return getLozengeValuesAndIncompleteSearchTerms(queryString).lozengeValues;
+}
+
+/**
+ * Function which returns an incomplete quoted sentance from a string.
+ *
+ * @param {String} queryString A string of query terms.
+ *
+ * @returns {String} inputTerms A string which starts with a quote but
+ * doesnt have an end quote.
+ *
+ * @example
+ * // returns ['"bar gar']
+ * getIncompleteInputValue('foo "bar gar')
+ */
+function getIncompleteInputValue(queryString) {
+  return getLozengeValuesAndIncompleteSearchTerms(queryString).incompleteInputValue;
+}
+
+module.exports = {
+  shouldLozengify: shouldLozengify,
+  getLozengeValues: getLozengeValues,
+  getIncompleteInputValue: getIncompleteInputValue,
+};

--- a/h/static/styles/partials-v2/_lozenge.scss
+++ b/h/static/styles/partials-v2/_lozenge.scss
@@ -1,0 +1,28 @@
+.lozenge {
+  display: flex;
+  background-color: $grey-3;
+  color: $grey-6;
+  border-radius: 2px;
+  margin-left: 10px;
+  margin-top: 15px;
+  margin-bottom: 15px;
+}
+
+.lozenge__content {
+  padding: 3px 5px 3px 5px;
+  white-space: nowrap;
+}
+
+.lozenge__close {
+  font-weight: bold;
+  padding: 3px 5px 3px 5px;
+  cursor: default;
+
+  &:hover {
+    background-color: $grey-4;
+  }
+}
+
+.is-disabled {
+  pointer-events: none;
+}

--- a/h/static/styles/partials-v2/_nav-bar.scss
+++ b/h/static/styles/partials-v2/_nav-bar.scss
@@ -17,6 +17,11 @@
   flex-direction: row;
 }
 
+.nav-bar__logo-container {
+  display: flex;
+  justify-content: center;
+}
+
 .nav-bar__logo {
   margin-left: 30px;
   margin-right: 30px;
@@ -87,7 +92,7 @@
 @media screen and (max-width: $max-phone-width) {
   // Display search bar full-width underneath nav links on phone-sized screens
   .nav-bar {
-    height: 90px;
+    height: 120px;
   }
 
   .nav-bar__search {

--- a/h/static/styles/partials-v2/_search-bar.scss
+++ b/h/static/styles/partials-v2/_search-bar.scss
@@ -3,19 +3,20 @@
 // Specs: https://trello.com/c/atjT8T9p
 
 .search-bar {
-  position: relative;
+  border: 1px solid $grey-3;
+  border-radius: 2px;
+  display: flex;
 }
 
 .search-bar__input {
   width: 100%;
 
-  border: 1px solid $grey-3;
-  border-radius: 2px;
+  border: none;
 
   // Add spacing to left of input field for search icon
-  padding-left: 30px;
-  padding-top: 3px;
-  padding-bottom: 3px;
+  padding-left: 7px;
+  padding-top: 18px;
+  padding-bottom: 18px;
   padding-right: 3px;
 }
 
@@ -25,12 +26,15 @@
   outline: none;
 }
 
-.search-bar__icon {
-  height: 14px;
-  left: 7px;
-  position: absolute;
-  top: 4px;
+.search-bar__lozenges {
+  display: flex;
+}
 
+.search-bar__icon {
+  flex-shrink: 0;
+  height: 14px;
+  margin-left: 7px;
+  margin-top: 18px;
   color: $grey-5;
 }
 
@@ -48,8 +52,10 @@
   display: none;
   padding: 20px 0 0 0;
   position: absolute;
+  margin-top: 52px;
   width: 100%;
   z-index: $zindex-dropdown-menu;
+  max-width: 650px;
 }
 
 .search-bar__dropdown-menu-header {

--- a/h/static/styles/site-v2.scss
+++ b/h/static/styles/site-v2.scss
@@ -15,6 +15,7 @@
 @import 'partials-v2/form';
 @import 'partials-v2/join-group-form';
 @import 'partials-v2/link';
+@import 'partials-v2/lozenge';
 @import 'partials-v2/masthead';
 @import 'partials-v2/nav-bar';
 @import 'partials-v2/pager';

--- a/h/templates/panels/navbar.html.jinja2
+++ b/h/templates/panels/navbar.html.jinja2
@@ -47,13 +47,15 @@
 {% if feature('activity_pages') %}
 <header class="nav-bar">
   <div class="nav-bar__content">
-    <a href="/" title="Hypothesis homepage"><!--
+    <a href="/" title="Hypothesis homepage" class="nav-bar__logo-container"><!--
       !--><img alt="Hypothesis logo" class="nav-bar__logo" src="/assets/images/logo.svg"></a>
 
     <div class="nav-bar__search js-search-bar" data-ref="searchBar">
       <form class="search-bar" action="{{ search_url }}">
-        <input class="search-bar__input" data-ref="searchBarInput" name="q" value="{{ q }}" placeholder="Search…" autocomplete="off">
         {{ svg_icon('search', 'search-bar__icon') }}
+        <div class="search-bar__lozenges" data-ref="searchBarLozenges"></div>
+        <input class="search-bar__input" data-ref="searchBarInput" placeholder="Search…" autocomplete="off">
+        <input type="hidden" class="js-search-bar__input-hidden" data-ref="searchBarInputHidden" name="q" value="{{ q }}">
         {{ search_bar_dropdown() }}
       </form>
     </div>


### PR DESCRIPTION
A phrase is determined to be a valid query term if, when the user
types a space character, the phrase is of the one of the following
forms:
    sometext
    "some text with spaces"
    'some text with spaces'
    <keyword>:sometext
    <keyword>:"some text with spaces"
    <keyword>:'some text with spaces'

After a lozenge is created, pressing the enter button when there are no active
dropdown items highlighted, submits the search form with the query parameter
"q" set to the query terms represented by the lozenges and any unfinished text
within the search box joined with a space character.

A lozenge can be deleted by pressing the "X" button on the right of each lozenge.

When a search page loads any query terms already in the hdden search box are turned
into lozenges.

https://trello.com/c/Iv4mWcIs/19-turn-search-query-terms-into-lozenges-as-user-types

Things to consider for a followup PR:
max-width and max-height for each lozenge.
max-width for the lozenges after which we wrap them around to the next line.
deleting lozenges from the keyboard