### PR TITLE
Don't print "None" on the group join page

### DIFF
--- a/h/templates/groups/join.html.jinja2
+++ b/h/templates/groups/join.html.jinja2
@@ -16,7 +16,7 @@
           {{ group.name }}
         </div>
         <div class="join-group-form__group-description">
-          {{ group.description }}
+          {% if group.description %}{{ group.description }}{% endif %}
         </div>
         {% if request.authenticated_userid %}
           <form method="POST">


### PR DESCRIPTION
If the group has a null description, just don't print anything.

Fixes #3954.