### PR TITLE
Remove unnecessary Pyramid boilerplate

### DIFF
--- a/h/views/__init__.py
+++ b/h/views/__init__.py
@@ -3,9 +3,3 @@
 
 def includeme(config):
     config.scan(__name__)
-
-    config.include('h.views.help')
-    config.include('h.views.home')
-    config.include('h.views.main')
-    config.include('h.views.client')
-    config.include('h.views.panels')

--- a/h/views/client.py
+++ b/h/views/client.py
@@ -80,7 +80,3 @@ def session_view(request):
 @view_config(route_name='widget')
 def widget(context, request):
     return render_app(request)
-
-
-def includeme(config):
-    config.scan(__name__)

--- a/h/views/help.py
+++ b/h/views/help.py
@@ -37,7 +37,3 @@ def help_page(context, request):
 
 def _random_word():
     return binascii.hexlify(os.urandom(8))
-
-
-def includeme(config):
-    config.scan(__name__)

--- a/h/views/home.py
+++ b/h/views/home.py
@@ -37,7 +37,3 @@ def index(context, request):
         )
 
     return context
-
-
-def includeme(config):
-    config.scan(__name__)

--- a/h/views/main.py
+++ b/h/views/main.py
@@ -78,7 +78,3 @@ def stream_user_redirect(request):
     query = {'q': 'user:{}'.format(request.matchdict['user'])}
     location = request.route_url('stream', _query=query)
     raise httpexceptions.HTTPFound(location=location)
-
-
-def includeme(config):
-    config.scan(__name__)

--- a/h/views/panels.py
+++ b/h/views/panels.py
@@ -52,7 +52,3 @@ def navbar(context, request):
         'search_url': search_url,
         'q': request.params.get('q', ''),
     }
-
-
-def includeme(config):
-    config.scan(__name__)


### PR DESCRIPTION
Calling `config.scan(__name__)` at the root of the `h.views` package guarantees that all the submodules will be included and processed. See:

  http://docs.pylonsproject.org/projects/pyramid/en/latest/api/config.html#pyramid.config.Configurator.scan

As a result, there is no need to explicitly `.include(...)` views modules, and thus they don't need `includeme` functions.