### PR TITLE
Move badge views into h.views package

### DIFF
--- a/h/app.py
+++ b/h/app.py
@@ -123,7 +123,6 @@ def includeme(config):
     config.include('h.accounts.views')
     config.include('h.activity')
     config.include('h.admin')
-    config.include('h.badge')
     config.include('h.feeds')
     config.include('h.groups')
     config.include('h.links')

--- a/h/badge/__init__.py
+++ b/h/badge/__init__.py
@@ -1,5 +1,0 @@
-# -*- coding: utf-8 -*-
-
-
-def includeme(config):
-    config.include('.views')

--- a/h/views/badge.py
+++ b/h/views/badge.py
@@ -1,3 +1,7 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
 from pyramid import httpexceptions
 
 from h import models
@@ -28,7 +32,3 @@ def badge(request):
     result = search.Search(request).run(query)
 
     return {'total': result.total}
-
-
-def includeme(config):
-    config.scan(__name__)

--- a/tests/h/views/badge_test.py
+++ b/tests/h/views/badge_test.py
@@ -1,9 +1,13 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
 import pytest
 import mock
 
 from pyramid import httpexceptions
 
-from h.badge import views
+from h.views.badge import badge
 
 
 badge_fixtures = pytest.mark.usefixtures('models', 'search_lib')
@@ -15,7 +19,7 @@ def test_badge_returns_number_from_search(models, search_run):
     models.Blocklist.is_blocked.return_value = False
     search_run.return_value = mock.Mock(total=29)
 
-    result = views.badge(request)
+    result = badge(request)
 
     search_run.assert_called_once_with({'uri': 'test_uri', 'limit': 0})
     assert result == {'total': 29}
@@ -27,7 +31,7 @@ def test_badge_returns_0_if_blocked(models, search_run):
     models.Blocklist.is_blocked.return_value = True
     search_run.return_value = {'total': 29}
 
-    result = views.badge(request)
+    result = badge(request)
 
     assert not search_run.called
     assert result == {'total': 0}
@@ -36,17 +40,17 @@ def test_badge_returns_0_if_blocked(models, search_run):
 @badge_fixtures
 def test_badge_raises_if_no_uri():
     with pytest.raises(httpexceptions.HTTPBadRequest):
-        views.badge(mock.Mock(params={}))
+        badge(mock.Mock(params={}))
 
 
 @pytest.fixture
 def models(patch):
-    return patch('h.badge.views.models')
+    return patch('h.views.badge.models')
 
 
 @pytest.fixture
 def search_lib(patch):
-    return patch('h.badge.views.search')
+    return patch('h.views.badge.search')
 
 
 @pytest.fixture


### PR DESCRIPTION
As part of an effort to move all views into the h.views package, this moves the badge view out of h.badge and into h.views.