### PR TITLE
Move feeds views into h.views package

### DIFF
--- a/h/app.py
+++ b/h/app.py
@@ -122,7 +122,6 @@ def includeme(config):
     config.include('h.accounts')
     config.include('h.activity')
     config.include('h.admin')
-    config.include('h.feeds')
     config.include('h.groups')
     config.include('h.links')
     config.include('h.nipsa')

--- a/h/feeds/__init__.py
+++ b/h/feeds/__init__.py
@@ -1,4 +1,9 @@
+# -*- coding: utf-8 -*-
+
 """Code for generating feeds (e.g. Atom and RSS feeds)."""
+
+from __future__ import unicode_literals
+
 from h.feeds.render import render_atom
 from h.feeds.render import render_rss
 
@@ -6,7 +11,3 @@ __all__ = (
     'render_atom',
     'render_rss',
 )
-
-
-def includeme(config):
-    config.include('.views')

--- a/h/views/feeds.py
+++ b/h/views/feeds.py
@@ -6,8 +6,8 @@ from pyramid.view import view_config
 from pyramid import i18n
 
 from memex import search
-from memex import storage
-from h import feeds
+from memex.storage import fetch_ordered_annotations
+from h.feeds import render_atom, render_rss
 
 
 _ = i18n.TranslationStringFactory(__package__)
@@ -16,13 +16,13 @@ _ = i18n.TranslationStringFactory(__package__)
 def _annotations(request):
     """Return the annotations from the search API."""
     result = search.Search(request).run(request.params)
-    return storage.fetch_ordered_annotations(request.db, result.annotation_ids)
+    return fetch_ordered_annotations(request.db, result.annotation_ids)
 
 
 @view_config(route_name='stream_atom')
 def stream_atom(request):
     """An Atom feed of the /stream page."""
-    return feeds.render_atom(
+    return render_atom(
         request=request, annotations=_annotations(request),
         atom_url=request.route_url("stream_atom"),
         html_url=request.route_url("stream"),
@@ -33,7 +33,7 @@ def stream_atom(request):
 @view_config(route_name='stream_rss')
 def stream_rss(request):
     """An RSS feed of the /stream page."""
-    return feeds.render_rss(
+    return render_rss(
         request=request, annotations=_annotations(request),
         rss_url=request.route_url("stream_rss"),
         html_url=request.route_url("stream"),

--- a/h/views/feeds.py
+++ b/h/views/feeds.py
@@ -1,3 +1,7 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
 from pyramid.view import view_config
 from pyramid import i18n
 
@@ -37,7 +41,3 @@ def stream_rss(request):
             "Hypothesis Stream"),
         description=request.registry.settings.get("h.feed.description") or _(
             "The Web. Annotated"))
-
-
-def includeme(config):
-    config.scan(__name__)

--- a/tests/h/views/feeds_test.py
+++ b/tests/h/views/feeds_test.py
@@ -1,0 +1,105 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import mock
+import pytest
+
+from h.views.feeds import stream_atom, stream_rss
+
+
+@pytest.mark.usefixtures('fetch_ordered_annotations',
+                         'render_atom',
+                         'search_run',
+                         'routes')
+class TestStreamAtom(object):
+
+    def test_renders_atom(self, pyramid_request, render_atom):
+        stream_atom(pyramid_request)
+
+        render_atom.assert_called_once_with(request=pyramid_request,
+                                            annotations=mock.sentinel.fetched_annotations,
+                                            atom_url='http://example.com/thestream.atom',
+                                            html_url='http://example.com/thestream',
+                                            title='Some feed',
+                                            subtitle='It contains stuff')
+
+    def test_returns_rendered_atom(self, pyramid_request, render_atom):
+        result = stream_atom(pyramid_request)
+
+        assert result == render_atom.return_value
+
+
+@pytest.mark.usefixtures('fetch_ordered_annotations',
+                         'render_rss',
+                         'search_run',
+                         'routes')
+class TestStreamRSS(object):
+
+    def test_renders_rss(self, pyramid_request, render_rss):
+        stream_rss(pyramid_request)
+
+        render_rss.assert_called_once_with(request=pyramid_request,
+                                           annotations=mock.sentinel.fetched_annotations,
+                                           rss_url='http://example.com/thestream.rss',
+                                           html_url='http://example.com/thestream',
+                                           title='Some feed',
+                                           description='Stuff and things')
+
+    def test_returns_rendered_rss(self, pyramid_request, render_rss):
+        result = stream_rss(pyramid_request)
+
+        assert result == render_rss.return_value
+
+
+@pytest.fixture
+def fetch_ordered_annotations(patch):
+    fetch_ordered_annotations = patch('h.views.feeds.fetch_ordered_annotations')
+    fetch_ordered_annotations.return_value = mock.sentinel.fetched_annotations
+    return fetch_ordered_annotations
+
+
+@pytest.fixture
+def pyramid_settings(pyramid_settings):
+    settings = {}
+    settings.update(pyramid_settings)
+    settings.update({
+        'h.feed.title': 'Some feed',
+        'h.feed.subtitle': 'It contains stuff',
+        'h.feed.description': 'Stuff and things',
+    })
+    return settings
+
+
+@pytest.fixture
+def render_atom(patch):
+    return patch('h.views.feeds.render_atom')
+
+
+@pytest.fixture
+def render_rss(patch):
+    return patch('h.views.feeds.render_rss')
+
+
+@pytest.fixture
+def routes(pyramid_config):
+    pyramid_config.add_route('stream_atom', '/thestream.atom')
+    pyramid_config.add_route('stream_rss', '/thestream.rss')
+    pyramid_config.add_route('stream', '/thestream')
+
+
+@pytest.fixture
+def search(patch):
+    return patch('h.views.feeds.search')
+
+
+@pytest.fixture
+def search_run(search):
+    from memex.search.core import SearchResult
+    result = SearchResult(total=123,
+                          annotation_ids=['foo', 'bar'],
+                          reply_ids=[],
+                          aggregations={})
+    search_run = search.Search.return_value.run
+    search_run.return_value = result
+    return search_run


### PR DESCRIPTION
As part of an effort to move all views into the h.views package, this moves the feeds views out of h.feeds and into h.views.

This PR also adds some missing tests for the feeds views.