### PR TITLE
Move groups views into h.views package

### DIFF
--- a/h/groups/__init__.py
+++ b/h/groups/__init__.py
@@ -3,5 +3,3 @@
 
 def includeme(config):
     config.register_service_factory('.services.groups_factory', name='groups')
-
-    config.include('.views')

--- a/h/views/groups.py
+++ b/h/views/groups.py
@@ -3,7 +3,7 @@
 import deform
 from pyramid import security
 from pyramid.httpexceptions import (HTTPMovedPermanently, HTTPNoContent,
-                                    HTTPSeeOther, HTTPNotFound)
+                                    HTTPSeeOther)
 from pyramid.view import view_config, view_defaults
 
 from h import form
@@ -175,7 +175,3 @@ def _check_slug(group, request):
         raise HTTPMovedPermanently(request.route_path('group_read',
                                                       pubid=group.pubid,
                                                       slug=group.slug))
-
-
-def includeme(config):
-    config.scan(__name__)  # pragma: no cover

--- a/tests/h/views/groups_test.py
+++ b/tests/h/views/groups_test.py
@@ -4,9 +4,9 @@ import deform
 import mock
 import pytest
 from pyramid.httpexceptions import (HTTPMovedPermanently, HTTPNoContent,
-                                    HTTPSeeOther, HTTPNotFound)
+                                    HTTPSeeOther)
 
-from h.groups import views
+from h.views import groups as views
 from h.models import (Group, User)
 
 
@@ -116,7 +116,7 @@ class TestGroupCreateController(object):
 
     @pytest.fixture
     def handle_form_submission(self, patch):
-        return patch('h.groups.views.form.handle_form_submission')
+        return patch('h.views.groups.form.handle_form_submission')
 
 
 @pytest.mark.usefixtures('routes')


### PR DESCRIPTION
As part of an effort to move all views into the h.views package, this moves the groups views out of h.groups and into h.views.