### PR TITLE
Move notification views into h.views package

### DIFF
--- a/h/notification/__init__.py
+++ b/h/notification/__init__.py
@@ -6,7 +6,6 @@ from ..security import derive_key
 
 def includeme(config):
     config.include('.reply')
-    config.include('.views')
 
     secret = config.registry.settings['secret_key']
     derived = derive_key(secret, b'h.notification')

--- a/h/views/notification.py
+++ b/h/views/notification.py
@@ -23,7 +23,3 @@ def unsubscribe(request):
             s.active = False
 
     return {}
-
-
-def includeme(config):
-    config.scan(__name__)

--- a/tests/h/views/notification_test.py
+++ b/tests/h/views/notification_test.py
@@ -4,7 +4,7 @@ import mock
 import pytest
 
 from h.models import Subscriptions
-from h.notification import views
+from h.views.notification import unsubscribe
 
 
 @pytest.mark.usefixtures('subscriptions', 'token_serializer')
@@ -13,7 +13,7 @@ class TestUnsubscribe(object):
     def test_deserializes_token(self, pyramid_request, token_serializer):
         pyramid_request.matchdict = {'token': 'wibble'}
 
-        views.unsubscribe(pyramid_request)
+        unsubscribe(pyramid_request)
 
         token_serializer.loads.assert_called_once_with('wibble')
 
@@ -22,7 +22,7 @@ class TestUnsubscribe(object):
         pyramid_request.matchdict = {'token': 'wibble'}
         token_serializer.loads.return_value = {'type': 'reply', 'uri': 'acct:foo@example.com'}
 
-        views.unsubscribe(pyramid_request)
+        unsubscribe(pyramid_request)
 
         assert not sub1.active
 
@@ -31,7 +31,7 @@ class TestUnsubscribe(object):
         pyramid_request.matchdict = {'token': 'wibble'}
         token_serializer.loads.return_value = {'type': 'reply', 'uri': 'acct:foo@example.com'}
 
-        views.unsubscribe(pyramid_request)
+        unsubscribe(pyramid_request)
 
         assert sub2.active
         assert sub3.active
@@ -41,8 +41,8 @@ class TestUnsubscribe(object):
         pyramid_request.matchdict = {'token': 'wibble'}
         token_serializer.loads.return_value = {'type': 'reply', 'uri': 'acct:foo@example.com'}
 
-        views.unsubscribe(pyramid_request)
-        views.unsubscribe(pyramid_request)
+        unsubscribe(pyramid_request)
+        unsubscribe(pyramid_request)
 
         assert not sub1.active
 
@@ -52,7 +52,7 @@ class TestUnsubscribe(object):
         token_serializer.loads.side_effect = ValueError('token invalid')
 
         with pytest.raises(HTTPNotFound):
-            views.unsubscribe(pyramid_request)
+            unsubscribe(pyramid_request)
 
     @pytest.fixture
     def subscriptions(self, db_session):


### PR DESCRIPTION
As part of an effort to move all views into the h.views package, this moves the notification views out of h.notification and into h.views.