### PR TITLE
Strip spaces from username forms in admin

### DIFF
--- a/h/admin/views/admins.py
+++ b/h/admin/views/admins.py
@@ -24,7 +24,7 @@ def admins_index(request):
              permission='admin_admins')
 def admins_add(request):
     """Make a given user an admin."""
-    username = request.params['add']
+    username = request.params['add'].strip()
     user = models.User.get_by_username(request.db, username)
     if user is None:
         request.session.flash(

--- a/h/admin/views/features.py
+++ b/h/admin/views/features.py
@@ -87,7 +87,7 @@ def cohorts_edit(context, request):
              renderer='h:templates/admin/edit_cohort.html.jinja2',
              permission='admin_features')
 def cohorts_edit_add(request):
-    member_name = request.params['add']
+    member_name = request.params['add'].strip()
     cohort_id = request.matchdict['id']
 
     member = models.User.get_by_username(request.db, member_name)

--- a/h/admin/views/nipsa.py
+++ b/h/admin/views/nipsa.py
@@ -55,7 +55,7 @@ def user_not_found(exc, request):
 
 
 def _form_request_user(request, param):
-    username = request.params[param]
+    username = request.params[param].strip()
     user = models.User.get_by_username(request.db, username)
 
     if user is None:

--- a/h/admin/views/staff.py
+++ b/h/admin/views/staff.py
@@ -24,7 +24,7 @@ def staff_index(request):
              permission='admin_staff')
 def staff_add(request):
     """Make a given user a staff member."""
-    username = request.params['add']
+    username = request.params['add'].strip()
     user = models.User.get_by_username(request.db, username)
     if user is None:
         request.session.flash(

--- a/h/admin/views/users.py
+++ b/h/admin/views/users.py
@@ -31,6 +31,7 @@ def users_index(request):
     username = request.params.get('username')
 
     if username:
+        username = username.strip()
         user = models.User.get_by_username(request.db, username)
         if user is None:
             user = models.User.get_by_email(request.db, username)
@@ -69,7 +70,7 @@ def users_rename(request):
     user = _form_request_user(request)
 
     old_username = user.username
-    new_username = request.params.get('new_username')
+    new_username = request.params.get('new_username').strip()
 
     try:
         svc = request.find_service(name='rename_user')
@@ -154,7 +155,7 @@ def _all_user_annotations(request, user):
 
 def _form_request_user(request):
     """Return the User which a user admin form action relates to."""
-    username = request.params['username']
+    username = request.params['username'].strip()
     user = models.User.get_by_username(request.db, username)
 
     if user is None:

--- a/tests/h/admin/views/admins_test.py
+++ b/tests/h/admin/views/admins_test.py
@@ -11,6 +11,7 @@ from h.admin.views import admins as views
 
 @pytest.mark.usefixtures('routes')
 class TestAdminsIndex(object):
+
     def test_when_no_admins(self, pyramid_request):
         result = views.admins_index(pyramid_request)
 
@@ -39,6 +40,13 @@ class TestAdminsAddRemove(object):
         views.admins_add(pyramid_request)
 
         assert users['agnos'].admin
+
+    def test_add_strips_spaces(self, pyramid_request, users):
+        pyramid_request.params = {"add": "   david   "}
+
+        views.admins_add(pyramid_request)
+
+        assert users['david'].admin
 
     def test_add_redirects_to_index(self, pyramid_request):
         pyramid_request.params = {"add": "eva"}

--- a/tests/h/admin/views/features_test.py
+++ b/tests/h/admin/views/features_test.py
@@ -112,6 +112,22 @@ def test_cohorts_edit_add_user(factories, pyramid_request):
     assert cohort.members[0].username == user.username
 
 
+def test_cohorts_edit_add_user_strips_spaces(factories, pyramid_request):
+    user = factories.User(username='benoit')
+    cohort = models.FeatureCohort(name='FractalCohort')
+
+    pyramid_request.db.add(user)
+    pyramid_request.db.add(cohort)
+    pyramid_request.db.flush()
+
+    pyramid_request.matchdict['id'] = cohort.id
+    pyramid_request.params['add'] = '   benoit   '
+    views.cohorts_edit_add(pyramid_request)
+
+    assert len(cohort.members) == 1
+    assert cohort.members[0].username == user.username
+
+
 def test_cohorts_edit_remove_user(factories, pyramid_request):
     user = factories.User(username='benoit')
     cohort = models.FeatureCohort(name='FractalCohort')

--- a/tests/h/admin/views/nipsa_test.py
+++ b/tests/h/admin/views/nipsa_test.py
@@ -59,6 +59,13 @@ class TestNipsaAddRemove(object):
         with pytest.raises(views.UserNotFoundError):
             views.nipsa_remove(pyramid_request)
 
+    def test_form_request_user_strips_spaces(self, nipsa_service, pyramid_request, users):
+        pyramid_request.params = {"add": "    carl   "}
+
+        views.nipsa_add(pyramid_request)
+
+        assert users['carl'] in nipsa_service.flagged
+
     def test_remove_redirects_to_index(self, pyramid_request):
         pyramid_request.params = {"remove": "kiki"}
 

--- a/tests/h/admin/views/staff_test.py
+++ b/tests/h/admin/views/staff_test.py
@@ -40,6 +40,13 @@ class TestStaffAddRemove(object):
 
         assert users['agnos'].staff
 
+    def test_add_strips_spaces(self, pyramid_request, users):
+        pyramid_request.params = {"add": "   eva   "}
+
+        views.staff_add(pyramid_request)
+
+        assert users['eva'].staff
+
     def test_add_redirects_to_index(self, pyramid_request):
         pyramid_request.params = {"add": "eva"}
 

--- a/tests/h/admin/views/users_test.py
+++ b/tests/h/admin/views/users_test.py
@@ -44,6 +44,17 @@ def test_users_index_looks_up_users_by_email(User, pyramid_request):
 
 
 @users_index_fixtures
+def test_users_index_strips_spaces(User, pyramid_request):
+    pyramid_request.params = {"username": "    bob   "}
+    User.get_by_username.return_value = None
+    User.get_by_email.return_value = None
+
+    views.users_index(pyramid_request)
+
+    User.get_by_username.assert_called_with(pyramid_request.db, "bob")
+
+
+@users_index_fixtures
 def test_users_index_queries_annotation_count_by_userid(User, db_session, factories, pyramid_request):
     User.get_by_username.return_value = factories.User(username='bob')
     userid = "acct:bob@{}".format(pyramid_request.auth_domain)


### PR DESCRIPTION
Strips spaces from usernames used in different files of the admin tools.  Fixes #3627 