### PR TITLE
Wrap long words in annotation bodies

### DIFF
--- a/h/static/styles/partials-v2/_annotation-card.scss
+++ b/h/static/styles/partials-v2/_annotation-card.scss
@@ -57,4 +57,5 @@
 
 .annotation-card__text {
   @include styled-text;
+  overflow-wrap: break-word;
 }


### PR DESCRIPTION
On the /search page long words (e.g. URLs) in annotation bodies were not
wrapping and were overflowing the annotation card. Wrap these to the
width of the annotation card.

Before:

![screenshot from 2016-10-12 14-36-06](https://cloud.githubusercontent.com/assets/22498/19312300/b8509b9a-9089-11e6-8226-89a3efeb2c5a.png)

After:

![screenshot from 2016-10-12 14-38-18](https://cloud.githubusercontent.com/assets/22498/19312305/bd4892ec-9089-11e6-9f1e-843a1c79bf43.png)
