### PR TITLE
Add RFC7523 compliant OAuth access token endpoint

### DIFF
--- a/h/auth/__init__.py
+++ b/h/auth/__init__.py
@@ -65,6 +65,9 @@ def includeme(config):
         WEBSOCKET_POLICY = MultiAuthenticationPolicy([TOKEN_POLICY,
                                                       PROXY_POLICY])
 
+    config.register_service_factory('.services.oauth_service_factory',
+                                    name='oauth')
+
     # Set the default authentication policy. This can be overridden by modules
     # that include this one.
     config.set_authentication_policy(DEFAULT_POLICY)

--- a/h/auth/services.py
+++ b/h/auth/services.py
@@ -4,12 +4,16 @@ from __future__ import unicode_literals
 
 import datetime
 
+import jwt
 from pyramid_authsanity import interfaces
 import sqlalchemy as sa
 from zope import interface
 
 from h.models import AuthTicket
+from h import models
+from h.exceptions import OAuthTokenError
 from h.auth.util import principals_for_user
+from h._compat import text_type
 
 TICKET_TTL = datetime.timedelta(days=7)
 
@@ -17,6 +21,9 @@ TICKET_TTL = datetime.timedelta(days=7)
 # least one minute smaller than the potential new value. This prevents that we
 # update the `expires` column on every single request.
 TICKET_REFRESH_INTERVAL = datetime.timedelta(minutes=1)
+
+# TTL of an OAuth token
+TOKEN_TTL = datetime.timedelta(hours=1)
 
 
 class AuthTicketNotLoadedError(Exception):
@@ -108,7 +115,115 @@ class AuthTicketService(object):
         self._userid = None
 
 
+class OAuthService(object):
+    def __init__(self, session, user_service, domain):
+        self.session = session
+        self.usersvc = user_service
+        self.domain = domain
+
+    def verify_jwt_bearer(self, assertion, grant_type):
+        """
+        Verifies a JWT bearer grant token and returns the matched user.
+
+        This adheres to RFC7523 [1] ("JSON Web Token (JWT) Profile for
+        OAuth 2.0 Client Authentication and Authorization Grants").
+
+        [1]: https://tools.ietf.org/html/rfc7523
+
+        :param assertion: the assertion param (typically from ``request.POST``).
+        :type assertion: text_type
+
+        :param grant_type: the grant type (typically from ``request.POST``).
+        :type grant_type: text_type
+
+        :raises h.exceptions.OAuthTokenError: if the given request and/or JWT claims are invalid
+
+        :rtype: h.models.User
+        """
+        if grant_type != 'urn:ietf:params:oauth:grant-type:jwt-bearer':
+            raise OAuthTokenError('specified grant type is not supported',
+                                  'unsupported_grant_type')
+
+        if not assertion or type(assertion) != text_type:
+            raise OAuthTokenError('required assertion parameter is missing',
+                                  'invalid_request')
+        token = assertion
+
+        unverified_claims = self._decode(token, verify=False)
+
+        client_id = unverified_claims.get('iss', None)
+        if not client_id:
+            raise OAuthTokenError('grant token issuer is missing', 'invalid_grant')
+        authclient = self.session.query(models.AuthClient).get(client_id)
+        if not authclient:
+            raise OAuthTokenError('given JWT issuer is invalid', 'invalid_grant')
+
+        claims = self._decode(token,
+                              algorithms=['HS256'],
+                              audience=self.domain,
+                              key=authclient.secret,
+                              leeway=10)
+
+        userid = claims.get('sub')
+        if not userid:
+            raise OAuthTokenError('JWT subject is missing', 'invalid_grant')
+
+        user = self.usersvc.fetch(userid)
+        if user is None:
+            raise OAuthTokenError('user with userid described in subject could not be found',
+                                  'invalid_grant')
+
+        return user
+
+    def create_token(self, user):
+        """
+        Creates a token for the passed-in user without any additional
+        verification.
+
+        It is the caller's responsibility to verify the token request, e.g. with
+        ``verify_jwt_bearer``.
+
+        :param assertion: the user for whom the token should be created.
+        :type assertion: h.models.User
+
+        :rtype: h.models.Token
+        """
+        token = models.Token(userid=user.userid, expires=(utcnow() + TOKEN_TTL))
+        self.session.add(token)
+
+        return token
+
+    def _decode(self, token, **kwargs):
+        try:
+            claims = jwt.decode(token, **kwargs)
+            return claims
+        except jwt.DecodeError:
+            raise OAuthTokenError('invalid JWT signature', 'invalid_grant')
+        except jwt.exceptions.InvalidAlgorithmError:
+            raise OAuthTokenError('invalid JWT signature algorithm', 'invalid_grant')
+        except jwt.MissingRequiredClaimError as exc:
+            raise OAuthTokenError('JWT is missing claim %s' % exc.claim, 'invalid_grant')
+        except jwt.InvalidAudienceError:
+            raise OAuthTokenError('invalid JWT audience', 'invalid_grant')
+        except jwt.ImmatureSignatureError:
+            raise OAuthTokenError('JWT not before is in the future', 'invalid_grant')
+        except jwt.ExpiredSignatureError:
+            raise OAuthTokenError('JWT token is expired', 'invalid_grant')
+        except jwt.InvalidIssuedAtError:
+            raise OAuthTokenError('JWT issued at is in the future', 'invalid_grant')
+
+
 def auth_ticket_service_factory(context, request):
     """Return a AuthTicketService instance for the passed context and request."""
     user_service = request.find_service(name='user')
     return AuthTicketService(request.db, user_service)
+
+
+def oauth_service_factory(context, request):
+    """Return a OAuthService instance for the passed context and request."""
+    user_service = request.find_service(name='user')
+    return OAuthService(request.db, user_service, request.domain)
+
+
+def utcnow():
+    return datetime.datetime.utcnow()

--- a/h/auth/services.py
+++ b/h/auth/services.py
@@ -85,8 +85,8 @@ class AuthTicketService(object):
         # We don't want to update the `expires` column of an auth ticket on
         # every single request, but only when the ticket hasn't been touched
         # within a the defined `TICKET_REFRESH_INTERVAL`.
-        if (datetime.datetime.utcnow() - ticket.updated) > TICKET_REFRESH_INTERVAL:
-            ticket.expires = datetime.datetime.utcnow() + TICKET_TTL
+        if (utcnow() - ticket.updated) > TICKET_REFRESH_INTERVAL:
+            ticket.expires = utcnow() + TICKET_TTL
 
         return True
 
@@ -100,7 +100,7 @@ class AuthTicketService(object):
         ticket = models.AuthTicket(id=ticket_id,
                                    user=user,
                                    user_userid=user.userid,
-                                   expires=(datetime.datetime.utcnow() + TICKET_TTL))
+                                   expires=(utcnow() + TICKET_TTL))
         self.session.add(ticket)
         # We cache the new userid, this will allow us to migrate the old
         # session policy to this new ticket policy.

--- a/h/auth/services.py
+++ b/h/auth/services.py
@@ -9,7 +9,6 @@ from pyramid_authsanity import interfaces
 import sqlalchemy as sa
 from zope import interface
 
-from h.models import AuthTicket
 from h import models
 from h.exceptions import OAuthTokenError
 from h.auth.util import principals_for_user
@@ -72,10 +71,10 @@ class AuthTicketService(object):
         if ticket_id is None:
             return False
 
-        ticket = self.session.query(AuthTicket) \
-            .filter(AuthTicket.id == ticket_id,
-                    AuthTicket.user_userid == principal,
-                    AuthTicket.expires > sa.func.now()) \
+        ticket = self.session.query(models.AuthTicket) \
+            .filter(models.AuthTicket.id == ticket_id,
+                    models.AuthTicket.user_userid == principal,
+                    models.AuthTicket.expires > sa.func.now()) \
             .one_or_none()
 
         if ticket is None:
@@ -98,10 +97,10 @@ class AuthTicketService(object):
         if user is None:
             raise ValueError('Cannot find user with userid %s' % principal)
 
-        ticket = AuthTicket(id=ticket_id,
-                            user=user,
-                            user_userid=user.userid,
-                            expires=(datetime.datetime.utcnow() + TICKET_TTL))
+        ticket = models.AuthTicket(id=ticket_id,
+                                   user=user,
+                                   user_userid=user.userid,
+                                   expires=(datetime.datetime.utcnow() + TICKET_TTL))
         self.session.add(ticket)
         # We cache the new userid, this will allow us to migrate the old
         # session policy to this new ticket policy.
@@ -111,7 +110,7 @@ class AuthTicketService(object):
         """Delete a ticket by id from the database."""
 
         if ticket_id:
-            self.session.query(AuthTicket).filter_by(id=ticket_id).delete()
+            self.session.query(models.AuthTicket).filter_by(id=ticket_id).delete()
         self._userid = None
 
 

--- a/h/exceptions.py
+++ b/h/exceptions.py
@@ -28,3 +28,17 @@ class ClientUnauthorized(APIError):
     def __init__(self):
         message = _('Client credentials are invalid.')
         super(ClientUnauthorized, self).__init__(message, status_code=403)
+
+
+class OAuthTokenError(APIError):
+
+    """
+    Exception raised when an OAuth token request failed.
+
+    This specifically handles OAuth errors which have a type (``message``) and
+    a description (``description``).
+    """
+
+    def __init__(self, message, type_, status_code=400):
+        self.type = type_
+        super(OAuthTokenError, self).__init__(message, status_code=status_code)

--- a/h/views/api_auth.py
+++ b/h/views/api_auth.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from h.auth.services import TOKEN_TTL
+from h.exceptions import OAuthTokenError
+from h.util.view import json_view
+
+
+@json_view(route_name='token', request_method='POST')
+def access_token(request):
+    svc = request.find_service(name='oauth')
+
+    user = svc.verify_jwt_bearer(
+        assertion=request.POST.get('assertion'),
+        grant_type=request.POST.get('grant_type'))
+    token = svc.create_token(user)
+
+    return {
+        'access_token': token.value,
+        'token_type': 'bearer',
+        'expires_in': TOKEN_TTL.total_seconds(),
+    }
+
+
+@json_view(context=OAuthTokenError)
+def api_token_error(context, request):
+    """Handle an expected/deliberately thrown API exception."""
+    request.response.status_code = context.status_code
+    resp = {'error': context.type}
+    if context.message:
+        resp['error_description'] = context.message
+    return resp

--- a/h/views/client.py
+++ b/h/views/client.py
@@ -41,7 +41,7 @@ def render_app(request, extra=None):
 # off-origin, unlike the rest of the API. Given that this method of
 # authenticating to the API is not intended to remain, this seems like a
 # limitation we do not need to lift any time soon.
-@view_config(route_name='token', renderer='string')
+@view_config(route_name='token', renderer='string', request_method='GET')
 def annotator_token(request):
     """
     Return a JWT access token for the given request.

--- a/tests/h/auth/services_test.py
+++ b/tests/h/auth/services_test.py
@@ -3,13 +3,17 @@
 from __future__ import unicode_literals
 
 from datetime import (datetime, timedelta)
+from calendar import timegm
 
+import jwt
 import mock
 import pytest
 
 from h import models
 from h.accounts.services import UserService
 from h.auth import services
+from h.exceptions import OAuthTokenError
+from h._compat import text_type
 
 
 class TestAuthTicketService(object):
@@ -206,9 +210,297 @@ class TestAuthTicketServiceFactory(object):
         assert svc.usersvc == user_service
 
 
+class TestOAuthServiceVerifyJWTBearer(object):
+    """ Tests for ``OAuthService.verify_jwt_bearer`` """
+
+    def test_it_returns_the_user_from_the_jwt_token(self, svc, claims, authclient, user):
+        expected_user = user
+        tok = self.jwt_token(claims, authclient.secret)
+
+        ret_user = svc.verify_jwt_bearer(assertion=tok,
+                                         grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer')
+
+        assert expected_user == ret_user
+
+    def test_missing_grant_type(self, svc):
+        with pytest.raises(OAuthTokenError) as exc:
+            svc.verify_jwt_bearer(assertion='jwt-token',
+                                  grant_type=None)
+
+        assert exc.value.type == 'unsupported_grant_type'
+        assert 'grant type is not supported' in exc.value.message
+
+    def test_unsupported_grant_type(self, svc):
+        with pytest.raises(OAuthTokenError) as exc:
+            svc.verify_jwt_bearer(assertion='jwt-token',
+                                  grant_type='authorization_code')
+
+        assert exc.value.type == 'unsupported_grant_type'
+        assert 'grant type is not supported' in exc.value.message
+
+    def test_missing_assertion(self, svc):
+        with pytest.raises(OAuthTokenError) as exc:
+            svc.verify_jwt_bearer(assertion=None,
+                                  grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer')
+
+        assert exc.value.type == 'invalid_request'
+        assert 'assertion parameter is missing' in exc.value.message
+
+    def test_non_jwt_assertion(self, svc):
+        with pytest.raises(OAuthTokenError) as exc:
+            svc.verify_jwt_bearer(assertion='bogus',
+                                  grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer')
+
+        assert exc.value.type == 'invalid_grant'
+        assert 'invalid JWT signature' in exc.value.message
+
+    def test_missing_jwt_issuer(self, svc, claims, authclient):
+        del claims['iss']
+        tok = self.jwt_token(claims, authclient.secret)
+
+        with pytest.raises(OAuthTokenError) as exc:
+            svc.verify_jwt_bearer(assertion=tok,
+                                  grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer')
+
+        assert exc.value.type == 'invalid_grant'
+        assert 'issuer is missing' in exc.value.message
+
+    def test_empty_jwt_issuer(self, svc, claims, authclient):
+        claims['iss'] = ''
+        tok = self.jwt_token(claims, authclient.secret)
+
+        with pytest.raises(OAuthTokenError) as exc:
+            svc.verify_jwt_bearer(assertion=tok,
+                                  grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer')
+
+        assert exc.value.type == 'invalid_grant'
+        assert 'issuer is missing' in exc.value.message
+
+    def test_missing_authclient_with_given_jwt_issuer(self, svc, claims, authclient, db_session):
+        db_session.delete(authclient)
+        db_session.flush()
+
+        tok = self.jwt_token(claims, authclient.secret)
+
+        with pytest.raises(OAuthTokenError) as exc:
+            svc.verify_jwt_bearer(assertion=tok,
+                                  grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer')
+
+        assert exc.value.type == 'invalid_grant'
+        assert 'issuer is invalid' in exc.value.message
+
+    def test_signed_with_different_secret(self, svc, claims):
+        tok = self.jwt_token(claims, 'different-secret')
+
+        with pytest.raises(OAuthTokenError) as exc:
+            svc.verify_jwt_bearer(assertion=tok,
+                                  grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer')
+
+        assert exc.value.type == 'invalid_grant'
+        assert 'invalid JWT signature' in exc.value.message
+
+    def test_signed_with_unsupported_algorithm(self, svc, claims, authclient):
+        tok = self.jwt_token(claims, authclient.secret, algorithm='HS512')
+
+        with pytest.raises(OAuthTokenError) as exc:
+            svc.verify_jwt_bearer(assertion=tok,
+                                  grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer')
+
+        assert exc.value.type == 'invalid_grant'
+        assert 'invalid JWT signature algorithm' in exc.value.message
+
+    def test_missing_jwt_audience(self, svc, claims, authclient):
+        del claims['aud']
+        tok = self.jwt_token(claims, authclient.secret)
+
+        with pytest.raises(OAuthTokenError) as exc:
+            svc.verify_jwt_bearer(assertion=tok,
+                                  grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer')
+
+        assert exc.value.type == 'invalid_grant'
+        assert 'missing claim aud' in exc.value.message
+
+    def test_invalid_jwt_audience(self, svc, claims, authclient):
+        claims['aud'] = 'foobar.org'
+        tok = self.jwt_token(claims, authclient.secret)
+
+        with pytest.raises(OAuthTokenError) as exc:
+            svc.verify_jwt_bearer(assertion=tok,
+                                  grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer')
+
+        assert exc.value.type == 'invalid_grant'
+        assert 'invalid JWT audience' in exc.value.message
+
+    def test_jwt_not_before_in_future(self, svc, claims, authclient):
+        claims['nbf'] = self.epoch(delta=timedelta(minutes=5))
+        tok = self.jwt_token(claims, authclient.secret)
+
+        with pytest.raises(OAuthTokenError) as exc:
+            svc.verify_jwt_bearer(assertion=tok,
+                                  grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer')
+
+        assert exc.value.type == 'invalid_grant'
+        assert 'not before is in the future' in exc.value.message
+
+    def test_jwt_expires_with_leeway_in_the_past(self, svc, claims, authclient):
+        claims['exp'] = self.epoch(delta=timedelta(minutes=-2))
+        tok = self.jwt_token(claims, authclient.secret)
+
+        with pytest.raises(OAuthTokenError) as exc:
+            svc.verify_jwt_bearer(assertion=tok,
+                                  grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer')
+
+        assert exc.value.type == 'invalid_grant'
+        assert 'token is expired' in exc.value.message
+
+    def test_jwt_issued_at_in_the_future(self, svc, claims, authclient):
+        claims['iat'] = self.epoch(delta=timedelta(minutes=2))
+        tok = self.jwt_token(claims, authclient.secret)
+
+        with pytest.raises(OAuthTokenError) as exc:
+            svc.verify_jwt_bearer(assertion=tok,
+                                  grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer')
+
+        assert exc.value.type == 'invalid_grant'
+        assert 'issued at is in the future' in exc.value.message
+
+    def test_missing_jwt_subject(self, svc, claims, authclient):
+        del claims['sub']
+        tok = self.jwt_token(claims, authclient.secret)
+
+        with pytest.raises(OAuthTokenError) as exc:
+            svc.verify_jwt_bearer(assertion=tok,
+                                  grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer')
+
+        assert exc.value.type == 'invalid_grant'
+        assert 'subject is missing' in exc.value.message
+
+    def test_empty_jwt_subject(self, svc, claims, authclient):
+        claims['sub'] = ''
+        tok = self.jwt_token(claims, authclient.secret)
+
+        with pytest.raises(OAuthTokenError) as exc:
+            svc.verify_jwt_bearer(assertion=tok,
+                                  grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer')
+
+        assert exc.value.type == 'invalid_grant'
+        assert 'subject is missing' in exc.value.message
+
+    def test_user_not_found(self, svc, claims, authclient, user_service):
+        user_service.fetch.return_value = None
+
+        tok = self.jwt_token(claims, authclient.secret)
+
+        with pytest.raises(OAuthTokenError) as exc:
+            svc.verify_jwt_bearer(assertion=tok,
+                                  grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer')
+
+        assert exc.value.type == 'invalid_grant'
+        assert 'user with userid described in subject could not be found' in exc.value.message
+
+    @pytest.fixture
+    def svc(self, pyramid_request, db_session, user_service):
+        return services.OAuthService(db_session, user_service, pyramid_request.domain)
+
+    @pytest.fixture
+    def claims(self, authclient, user, pyramid_request):
+        return {
+            'iss': authclient.id,
+            'sub': user.userid,
+            'aud': pyramid_request.domain,
+            'exp': self.epoch(delta=timedelta(minutes=10)),
+            'nbf': self.epoch(),
+            'iat': self.epoch(),
+        }
+
+    @pytest.fixture
+    def authclient(self, db_session):
+        client = models.AuthClient(authority='partner.org', secret='bogus')
+        db_session.add(client)
+        db_session.flush()
+        return client
+
+    @pytest.fixture
+    def user(self, factories, authclient, user_service):
+        user = factories.User(authority=authclient.authority)
+        user_service.fetch.return_value = user
+        return user
+
+    def jwt_token(self, claims, secret, algorithm='HS256'):
+        return text_type(jwt.encode(claims, secret, algorithm=algorithm))
+
+    def epoch(self, timestamp=None, delta=None):
+        if timestamp is None:
+            timestamp = datetime.utcnow()
+
+        if delta is not None:
+            timestamp = timestamp + delta
+
+        return timegm(timestamp.utctimetuple())
+
+
+class TestOAuthServiceCreateToken(object):
+    """ Tests for ``OAuthService.create_token`` """
+
+    def test_it_creates_a_token(self, svc, user, db_session):
+        query = db_session.query(models.Token).filter_by(userid=user.userid)
+
+        assert query.count() == 0
+        svc.create_token(user)
+        assert query.count() == 1
+
+    def test_it_returns_a_token(self, svc, user):
+        token = svc.create_token(user)
+        assert type(token) == models.Token
+
+    def test_new_token_expires_within_one_hour(self, svc, db_session, user, utcnow):
+        utcnow.return_value = datetime(2016, 1, 1, 3, 0, 0)
+
+        svc.create_token(user)
+
+        token = db_session.query(models.Token).filter_by(userid=user.userid).first()
+        assert token.expires == datetime(2016, 1, 1, 4, 0, 0)
+
+    @pytest.fixture
+    def svc(self, pyramid_request, db_session, user_service):
+        return services.OAuthService(db_session, user_service, pyramid_request.domain)
+
+    @pytest.fixture
+    def user(self, db_session, factories):
+        user = factories.User()
+        db_session.add(user)
+        db_session.flush()
+        return user
+
+
+@pytest.mark.usefixtures('user_service')
+class TestOAuthServiceFactory(object):
+    def test_it_returns_oauth_service(self, pyramid_request):
+        svc = services.oauth_service_factory(None, pyramid_request)
+        assert isinstance(svc, services.OAuthService)
+
+    def test_it_provides_request_db_as_session(self, pyramid_request):
+        svc = services.oauth_service_factory(None, pyramid_request)
+        assert svc.session == pyramid_request.db
+
+    def test_it_provides_user_service(self, pyramid_request, user_service):
+        svc = services.oauth_service_factory(None, pyramid_request)
+        assert svc.usersvc == user_service
+
+    def test_it_provides_request_domain(self, pyramid_request):
+        pyramid_request.domain = 'example.org'
+        svc = services.oauth_service_factory(None, pyramid_request)
+        assert svc.domain == 'example.org'
+
+
 @pytest.fixture
 def user_service(db_session, pyramid_config):
     service = mock.Mock(spec=UserService(default_authority='example.com',
                                          session=db_session))
     pyramid_config.register_service(service, name='user')
     return service
+
+
+@pytest.fixture
+def utcnow(patch):
+    return patch('h.auth.services.utcnow')

--- a/tests/h/auth/services_test.py
+++ b/tests/h/auth/services_test.py
@@ -113,11 +113,10 @@ class TestAuthTicketService(object):
 
         assert str(exc.value) == 'Cannot find user with userid bogus'
 
-    def test_add_ticket_stores_ticket(self, svc, db_session, user, patched_datetime):
+    def test_add_ticket_stores_ticket(self, svc, db_session, user, utcnow):
         svc.usersvc.fetch.return_value = user
 
-        utcnow = datetime(2016, 1, 1, 5, 23, 54)
-        patched_datetime.utcnow.return_value = utcnow
+        utcnow.return_value = datetime(2016, 1, 1, 5, 23, 54)
 
         svc.add_ticket(user.userid, 'the-ticket-id')
 
@@ -125,7 +124,7 @@ class TestAuthTicketService(object):
         assert ticket.id == 'the-ticket-id'
         assert ticket.user == user
         assert ticket.user_userid == user.userid
-        assert ticket.expires == utcnow + services.TICKET_TTL
+        assert ticket.expires == utcnow.return_value + services.TICKET_TTL
 
     def test_add_ticket_caches_the_userid(self, svc, db_session, user):
         svc.usersvc.fetch.return_value = user
@@ -176,10 +175,6 @@ class TestAuthTicketService(object):
     @pytest.fixture
     def principals_for_user(self, patch):
         return patch('h.auth.services.principals_for_user')
-
-    @pytest.fixture
-    def patched_datetime(self, patch):
-        return patch('h.auth.services.datetime.datetime')
 
     @pytest.fixture
     def ticket(self, factories, user, db_session):

--- a/tests/h/views/api_auth_test.py
+++ b/tests/h/views/api_auth_test.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import mock
+import pytest
+
+from h import models
+from h.accounts.services import user_service_factory
+from h.auth.services import oauth_service_factory, TOKEN_TTL
+from h.exceptions import OAuthTokenError
+from h.views import api_auth as views
+
+
+@pytest.mark.usefixtures('user_service', 'oauth_service')
+class TestAccessToken(object):
+    def test_it_verifies_the_jwt_bearer(self, pyramid_request, oauth_service):
+        pyramid_request.POST = {'assertion': 'the-assertion', 'grant_type': 'the-grant-type'}
+
+        views.access_token(pyramid_request)
+
+        oauth_service.verify_jwt_bearer.assert_called_once_with(
+            assertion='the-assertion', grant_type='the-grant-type'
+        )
+
+    def test_it_creates_a_token(self, pyramid_request, oauth_service):
+        user = mock.Mock()
+        oauth_service.verify_jwt_bearer.return_value = user
+
+        views.access_token(pyramid_request)
+
+        oauth_service.create_token.assert_called_once_with(user)
+
+    def test_it_returns_an_oauth_compliant_response(self, pyramid_request, oauth_service):
+        token = models.Token()
+        oauth_service.create_token.return_value = token
+
+        assert views.access_token(pyramid_request) == {
+            'access_token': token.value,
+            'token_type': 'bearer',
+            'expires_in': TOKEN_TTL.total_seconds(),
+        }
+
+    @pytest.fixture
+    def oauth_service(self, pyramid_config, pyramid_request):
+        svc = mock.Mock(spec_set=oauth_service_factory(None, pyramid_request))
+        pyramid_config.register_service(svc, name='oauth')
+        return svc
+
+    @pytest.fixture
+    def user_service(self, pyramid_config, pyramid_request):
+        svc = mock.Mock(spec_set=user_service_factory(None, pyramid_request))
+        pyramid_config.register_service(svc, name='user')
+        return svc
+
+
+class TestAPITokenError(object):
+    def test_it_sets_the_response_status_code(self, pyramid_request):
+        context = OAuthTokenError('the error message', 'error_type', status_code=403)
+        views.api_token_error(context, pyramid_request)
+        assert pyramid_request.response.status_code == 403
+
+    def test_it_returns_the_error(self, pyramid_request):
+        context = OAuthTokenError('', 'error_type')
+        result = views.api_token_error(context, pyramid_request)
+        assert result['error'] == 'error_type'
+
+    def test_it_returns_error_description(self, pyramid_request):
+        context = OAuthTokenError('error description', 'error_type')
+        result = views.api_token_error(context, pyramid_request)
+        assert result['error_description'] == 'error description'
+
+    def test_it_skips_description_when_missing(self, pyramid_request):
+        context = OAuthTokenError(None, 'invalid_request')
+        result = views.api_token_error(context, pyramid_request)
+        assert 'error_description' not in result
+
+    def test_it_skips_description_when_empty(self, pyramid_request):
+        context = OAuthTokenError('', 'invalid_request')
+        result = views.api_token_error(context, pyramid_request)
+        assert 'error_description' not in result


### PR DESCRIPTION
This endpoint handles the exchange of a JWT authorization grant to an
API access token as described in [RFC7523](https://tools.ietf.org/html/rfc7523).

According to the OAuth 2.0 ([RFC6749](https://tools.ietf.org/html/rfc6749)) spec the token endpoint needs to handle `POST` requests. We currently already have a cookie-based token exchange implemented under `/api/token`, but this one is only called via `GET`. So I made sure that the current implementation only listens to `GET` and started the new implementation in a different views file only listening to `POST`.

Partners will generate JWT tokens for their users and sign them with
their client secret. They then pass that JWT token as a configuration to
the Hypothesis client (that part still needs work), and it will then
exchange the JWT authorization grant for an access token via the `POST
/api/token` endpoint.

RFC7523 [requires the use of the RS256 algorithm](https://hyp.is/1izOopB8EeaKcHPHrD9aYw/tools.ietf.org/html/rfc7523) to sign the JWT token,
the implementation in this commit still uses thi HS256 algorithm. In the
future, authclients would generate a public/private keypair and share
the public part with us.