### PR TITLE
Fix document bucket responsive layout bugs

### DIFF
--- a/h/static/styles/partials-v2/_search.scss
+++ b/h/static/styles/partials-v2/_search.scss
@@ -140,6 +140,11 @@
   margin-bottom: 20px;
 }
 
+.search-bucket-stats__address,
+.search-bucket-stats__username {
+  word-break: break-all;
+}
+
 // On large tablets and below, display bucket titles beneath rather than
 // alongside the domain name.
 @media screen and (max-width: $tablet-width + 100px) {

--- a/h/static/styles/partials-v2/_search.scss
+++ b/h/static/styles/partials-v2/_search.scss
@@ -182,6 +182,10 @@
     flex-direction: column;
   }
 
+  .search-result-bucket__annotation-cards {
+    width: 100%;
+  }
+
   .search-bucket-stats {
     margin-left: 5px;
     margin-top: 10px;

--- a/h/static/styles/partials-v2/_search.scss
+++ b/h/static/styles/partials-v2/_search.scss
@@ -137,8 +137,8 @@
   margin-bottom: 20px;
 }
 
-// On large tablets and below, display bucket contents beneath rather than
-// alongside the domain
+// On large tablets and below, display bucket titles beneath rather than
+// alongside the domain name.
 @media screen and (max-width: $tablet-width + 100px) {
     .search-result-bucket__header {
       flex-direction: column;

--- a/h/static/styles/partials-v2/_search.scss
+++ b/h/static/styles/partials-v2/_search.scss
@@ -124,7 +124,6 @@
 // Card displaying stats about a group of annotations in search results
 .search-bucket-stats {
   @include font-normal;
-  width: 210px;
   margin-left: 30px;
   word-wrap: break-word;
 }

--- a/h/static/styles/partials-v2/_search.scss
+++ b/h/static/styles/partials-v2/_search.scss
@@ -160,6 +160,14 @@
     }
 }
 
+// On large tablets and below left-align annotation cards in order to make more
+// space for the stats to the right of the annotation card.
+@media screen and (max-width: $tablet-width + 150px) {
+  .search-result-bucket__annotation-cards-container {
+    padding-left: 0;
+  }
+}
+
 // On normal tablets and below, display annotation stats below annotation list
 @media screen and (max-width: $tablet-width) {
 
@@ -172,7 +180,6 @@
 
   .search-result-bucket__annotation-cards-container {
     flex-direction: column;
-    padding-left: 0;
   }
 
   .search-bucket-stats {

--- a/h/static/styles/partials-v2/_search.scss
+++ b/h/static/styles/partials-v2/_search.scss
@@ -116,6 +116,7 @@
 .search-result-bucket__annotation-cards {
   flex-grow: 1;
   max-width: 500px;
+  flex-shrink: 0;
   padding-left: 0;
   padding-right: 0;
 }

--- a/h/static/styles/partials-v2/_search.scss
+++ b/h/static/styles/partials-v2/_search.scss
@@ -126,6 +126,9 @@
   @include font-normal;
   margin-left: 30px;
   word-wrap: break-word;
+  min-width: 0;  // Without this min-width stats containing really
+                 // long words won't be wrapped (word-wrap: break-word won't
+                 // work).
 }
 
 .search-bucket-stats__key {

--- a/h/static/styles/partials-v2/_search.scss
+++ b/h/static/styles/partials-v2/_search.scss
@@ -100,9 +100,6 @@
 }
 
 .search-result-bucket__content {
-  display: flex;
-  flex-direction: column;
-  flex-grow: 1;
   padding-left: 10px;
   padding-right: 10px;
 }

--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -9,7 +9,7 @@
     <div class="search-bucket-stats__key">
         Address
     </div>
-    <div class="search-bucket-stats__val">
+    <div class="search-bucket-stats__val search-bucket-stats__address">
         {{ bucket.uri }}
     </div>
   {% endif %}
@@ -28,7 +28,9 @@
   </div>
   <ul class="search-bucket-stats__val">
     {% for user in bucket.users %}
-      <li>{{ user.split(':')[1].split('@')[0] }}</li>
+      <li class="search-bucket-stats__username">
+        {{ user.split(':')[1].split('@')[0] }}
+      </li>
     {% endfor %}
   </ul>
 </div>


### PR DESCRIPTION
This pull request fixes a number of issues with the layout of document bucket bodies on different screen sizes.

Fixes https://github.com/hypothesis/h/issues/3741

# Before

Stats overrun the document bucket (this also creates a horizontal scrollbar):

![screenshot from 2016-10-13 19-02-34](https://cloud.githubusercontent.com/assets/22498/19360759/cd39ebbc-9177-11e6-91b3-39c35169352b.png)

In other cases the stats retain their width and the annotation card is shrunk thinner than we want it to be (it appears to depend on the contents of the annotation cards and/or stats, whether this or the above happens):

![screenshot from 2016-10-13 19-03-02](https://cloud.githubusercontent.com/assets/22498/19360758/cd38d542-9177-11e6-9f54-a2081f698dff.png)

Stats are wrapped unnecessarily:

![screenshot from 2016-10-13 19-02-00](https://cloud.githubusercontent.com/assets/22498/19360760/cd3e6e1c-9177-11e6-8364-95d90a0cf077.png)

![screenshot from 2016-10-13 19-01-16](https://cloud.githubusercontent.com/assets/22498/19360761/cd4d4734-9177-11e6-8eb7-0e419bedfdd6.png)

# After

![peek 2016-10-13 18-56](https://cloud.githubusercontent.com/assets/22498/19360548/f1764f58-9176-11e6-976b-c165b30fc8e6.gif)

![peek 2016-10-13 18-55](https://cloud.githubusercontent.com/assets/22498/19360549/f189dbc2-9176-11e6-85fa-c230e421ef1d.gif)

![screenshot from 2016-10-13 18-54-09](https://cloud.githubusercontent.com/assets/22498/19360553/f198427a-9176-11e6-9620-06eb0e7c6967.png)

![screenshot from 2016-10-13 18-53-47](https://cloud.githubusercontent.com/assets/22498/19360550/f1938e10-9176-11e6-9a89-32a160bbd98d.png)

![screenshot from 2016-10-13 18-53-19](https://cloud.githubusercontent.com/assets/22498/19360554/f198c4ca-9176-11e6-8811-62866bae25ab.png)

![screenshot from 2016-10-13 18-53-01](https://cloud.githubusercontent.com/assets/22498/19360552/f196828c-9176-11e6-9aea-5283656f45af.png)

![screenshot from 2016-10-13 18-52-37](https://cloud.githubusercontent.com/assets/22498/19360551/f1967990-9176-11e6-8c3a-8dd6e85e787b.png)

![screenshot from 2016-10-13 18-52-19](https://cloud.githubusercontent.com/assets/22498/19360555/f1a344f4-9176-11e6-9420-0a576b981580.png)

![screenshot from 2016-10-13 18-51-04](https://cloud.githubusercontent.com/assets/22498/19360556/f1a8052a-9176-11e6-88c3-6f68739b6264.png)

![screenshot from 2016-10-13 18-50-42](https://cloud.githubusercontent.com/assets/22498/19360557/f1adb916-9176-11e6-9755-1f415146ff09.png)
