### PR TITLE
Limit current /api/token view to GET only (OAuth Token 1/n)

### DIFF
--- a/h/views/client.py
+++ b/h/views/client.py
@@ -41,7 +41,7 @@ def render_app(request, extra=None):
 # off-origin, unlike the rest of the API. Given that this method of
 # authenticating to the API is not intended to remain, this seems like a
 # limitation we do not need to lift any time soon.
-@view_config(route_name='token', renderer='string')
+@view_config(route_name='token', renderer='string', request_method='GET')
 def annotator_token(request):
     """
     Return a JWT access token for the given request.


### PR DESCRIPTION
The current token endpoint is only called via [HTTP GET]. Specifying
this in the view config will allow us to implement the new JWT OAuth
token exchange view as a separate view and after some time remove the
old cookie-based token exchange handling.

[HTTP GET]: https://github.com/hypothesis/client/blob/22181c80ce08319ac646eb35a82873dc85992cdb/h/static/scripts/auth.js#L40