### PR TITLE
Remove Token.userid uniqueness constraint (OAuth Token 2/n)

### DIFF
--- a/h/migrations/versions/e15e47228c43_remove_token_userid_uniqueness.py
+++ b/h/migrations/versions/e15e47228c43_remove_token_userid_uniqueness.py
@@ -1,0 +1,24 @@
+"""
+Remove uniqueness constraint on token.userid
+
+Revision ID: e15e47228c43
+Revises: 5dce9a8c42c2
+Create Date: 2016-10-19 16:17:06.067310
+"""
+
+from __future__ import unicode_literals
+
+from alembic import op
+
+
+revision = 'e15e47228c43'
+down_revision = '5dce9a8c42c2'
+
+
+def upgrade():
+    op.drop_constraint('uq__token__userid', 'token')
+
+
+def downgrade():
+    op.create_unique_constraint(
+        'uq__token__userid', 'token', ['userid'])

--- a/h/models/token.py
+++ b/h/models/token.py
@@ -28,8 +28,7 @@ class Token(Base, mixins.Timestamps):
                            primary_key=True)
 
     userid = sqlalchemy.Column(sqlalchemy.UnicodeText(),
-                               nullable=False,
-                               unique=True)
+                               nullable=False)
 
     value = sqlalchemy.Column(sqlalchemy.UnicodeText(),
                               nullable=False,
@@ -45,7 +44,10 @@ class Token(Base, mixins.Timestamps):
 
     @classmethod
     def get_by_userid(cls, session, userid):
-        return session.query(cls).filter(cls.userid == userid).first()
+        return (session.query(cls)
+                .filter_by(userid=userid)
+                .order_by(cls.created.desc())
+                .first())
 
     def regenerate(self):
         self.value = self.prefix + _token()

--- a/tests/h/models/token_test.py
+++ b/tests/h/models/token_test.py
@@ -8,3 +8,15 @@ from h.models import Token
 class TestToken(object):
     def test_init_generates_value(self):
         assert Token().value
+
+    def test_get_by_userid_filters_by_userid(self, db_session, factories):
+        token_1 = factories.Token(userid='acct:vanessa@example.org')
+        token_2 = factories.Token(userid='acct:david@example.org')
+
+        assert Token.get_by_userid(db_session, token_2.userid) == token_2
+
+    def test_get_by_userid_only_returns_the_latest_token(self, db_session, factories):
+        token_1 = factories.Token()
+        token_2 = factories.Token(userid=token_1.userid)
+
+        assert Token.get_by_userid(db_session, token_1.userid) == token_2


### PR DESCRIPTION
<del>**This will need rebasing once #3977 is merged.**</del> (rebased)

We will have OAuth tokens soon which means that a user can and
definitely will have more than one token at a time.

Also ensure that `Token.get_by_userid` always returns the most recent
token.

_The migration and code changes can be deployed at the same time here since we're just removing the uniqueness constraint._