### PR TITLE
Add token.authclient_id migration (OAuth Token 3/n)

### DIFF
--- a/h/migrations/versions/c36369fe730f_add_token_client_id_column.py
+++ b/h/migrations/versions/c36369fe730f_add_token_client_id_column.py
@@ -1,0 +1,30 @@
+"""
+Add token.client_id column
+
+Revision ID: c36369fe730f
+Revises: e15e47228c43
+Create Date: 2016-10-19 15:24:13.387546
+"""
+
+from __future__ import unicode_literals
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision = 'c36369fe730f'
+down_revision = 'e15e47228c43'
+
+
+def upgrade():
+    op.add_column('token', sa.Column(
+        'authclient_id',
+        postgresql.UUID(),
+        sa.ForeignKey('authclient.id', ondelete='cascade'),
+        nullable=True,
+    ))
+
+
+def downgrade():
+    op.drop_column('token', 'authclient_id')


### PR DESCRIPTION
<del>**This will need rebasing once #3978 is merged.**</del> (rebased)

This way we can track which authclient is responsible for which tokens,
how many active users an authclient has, etc.

It is also useful for the future when everybody will be able to create
authclients, because when an authclient gets deleted all tokens need to
be removed to make sure that they can't be used anymore for making
requests.

_This is only the migration as the code depending on this new column cannot be deployed at the same time._