### PR TITLE
Add Token.authclient and refactor dev tokens (OAuth Token 4/n)

### DIFF
--- a/h/models/token.py
+++ b/h/models/token.py
@@ -53,9 +53,9 @@ class Token(Base, mixins.Timestamps):
         self.regenerate()
 
     @classmethod
-    def get_by_userid(cls, session, userid):
+    def get_dev_token_by_userid(cls, session, userid):
         return (session.query(cls)
-                .filter_by(userid=userid)
+                .filter_by(userid=userid, authclient=None)
                 .order_by(cls.created.desc())
                 .first())
 

--- a/h/models/token.py
+++ b/h/models/token.py
@@ -7,6 +7,7 @@ import datetime
 import os
 
 import sqlalchemy
+from sqlalchemy.dialects import postgresql
 
 from h.auth.interfaces import IAuthenticationToken
 from h.db import Base
@@ -37,6 +38,15 @@ class Token(Base, mixins.Timestamps):
     #: A timestamp after which this token will no longer be considered valid.
     #: A NULL value in this column indicates a token that does not expire.
     expires = sqlalchemy.Column(sqlalchemy.DateTime, nullable=True)
+
+    _authclient_id = sqlalchemy.Column('authclient_id',
+                                       postgresql.UUID(),
+                                       sqlalchemy.ForeignKey('authclient.id', ondelete='cascade'),
+                                       nullable=True)
+
+    #: The authclient which created the token.
+    #: A NULL value means it is a developer token.
+    authclient = sqlalchemy.orm.relationship('AuthClient')
 
     def __init__(self, **kwargs):
         super(Token, self).__init__(**kwargs)

--- a/h/views/accounts.py
+++ b/h/views/accounts.py
@@ -642,8 +642,10 @@ class DeveloperController(object):
     @view_config(request_method='GET')
     def get(self):
         """Render the developer page, including the form."""
-        token = models.Token.get_by_userid(self.request.db,
-                                           self.request.authenticated_userid)
+        token = models.Token.get_dev_token_by_userid(
+            self.request.db,
+            self.request.authenticated_userid
+        )
         if token:
             return {'token': token.value}
         else:
@@ -652,8 +654,10 @@ class DeveloperController(object):
     @view_config(request_method='POST')
     def post(self):
         """(Re-)generate the user's API token."""
-        token = models.Token.get_by_userid(self.request.db,
-                                           self.request.authenticated_userid)
+        token = models.Token.get_dev_token_by_userid(
+            self.request.db,
+            self.request.authenticated_userid
+        )
 
         if token:
             # The user already has an API token, regenerate it.

--- a/tests/common/factories.py
+++ b/tests/common/factories.py
@@ -65,6 +65,9 @@ class AuthClient(ModelFactory):
         model = models.AuthClient
         force_flush = True
 
+    authority = 'example.com'
+    secret = factory.LazyAttribute(lambda _: unicode(FAKER.sha256()))
+
 
 class User(factory.Factory):
 

--- a/tests/h/models/token_test.py
+++ b/tests/h/models/token_test.py
@@ -9,14 +9,19 @@ class TestToken(object):
     def test_init_generates_value(self):
         assert Token().value
 
-    def test_get_by_userid_filters_by_userid(self, db_session, factories):
-        token_1 = factories.Token(userid='acct:vanessa@example.org')
-        token_2 = factories.Token(userid='acct:david@example.org')
+    def test_get_dev_token_by_userid_filters_by_userid(self, db_session, factories):
+        token_1 = factories.Token(userid='acct:vanessa@example.org', authclient=None)
+        token_2 = factories.Token(userid='acct:david@example.org', authclient=None)
 
-        assert Token.get_by_userid(db_session, token_2.userid) == token_2
+        assert Token.get_dev_token_by_userid(db_session, token_2.userid) == token_2
 
-    def test_get_by_userid_only_returns_the_latest_token(self, db_session, factories):
-        token_1 = factories.Token()
-        token_2 = factories.Token(userid=token_1.userid)
+    def test_get_dev_token_by_userid_only_returns_the_latest_token(self, db_session, factories):
+        token_1 = factories.Token(authclient=None)
+        token_2 = factories.Token(userid=token_1.userid, authclient=None)
 
-        assert Token.get_by_userid(db_session, token_1.userid) == token_2
+        assert Token.get_dev_token_by_userid(db_session, token_1.userid) == token_2
+
+    def test_get_dev_token_by_userid_filters_out_non_dev_tokens(self, db_session, factories):
+        token = factories.Token(authclient=factories.AuthClient())
+
+        assert Token.get_dev_token_by_userid(db_session, token.userid) is None

--- a/tests/h/views/accounts_test.py
+++ b/tests/h/views/accounts_test.py
@@ -926,19 +926,19 @@ class TestDeveloperController(object):
     def test_get_gets_token_for_authenticated_userid(self, models, pyramid_request):
         views.DeveloperController(pyramid_request).get()
 
-        models.Token.get_by_userid.assert_called_once_with(
+        models.Token.get_dev_token_by_userid.assert_called_once_with(
             pyramid_request.db,
             pyramid_request.authenticated_userid)
 
     def test_get_returns_token(self, models, pyramid_request):
-        models.Token.get_by_userid.return_value.value = u'abc123'
+        models.Token.get_dev_token_by_userid.return_value.value = u'abc123'
 
         data = views.DeveloperController(pyramid_request).get()
 
         assert data.get('token') == u'abc123'
 
     def test_get_with_no_token(self, models, pyramid_request):
-        models.Token.get_by_userid.return_value = None
+        models.Token.get_dev_token_by_userid.return_value = None
 
         result = views.DeveloperController(pyramid_request).get()
 
@@ -947,7 +947,7 @@ class TestDeveloperController(object):
     def test_post_gets_token_for_authenticated_userid(self, models, pyramid_request):
         views.DeveloperController(pyramid_request).post()
 
-        models.Token.get_by_userid.assert_called_once_with(
+        models.Token.get_dev_token_by_userid.assert_called_once_with(
             pyramid_request.db,
             pyramid_request.authenticated_userid)
 
@@ -955,11 +955,11 @@ class TestDeveloperController(object):
         """If the user already has a token it should regenerate it."""
         views.DeveloperController(pyramid_request).post()
 
-        models.Token.get_by_userid.return_value.regenerate.assert_called_with()
+        models.Token.get_dev_token_by_userid.return_value.regenerate.assert_called_with()
 
     def test_post_inits_new_token_for_authenticated_userid(self, models, pyramid_request):
         """If the user doesn't have a token yet it should generate one."""
-        models.Token.get_by_userid.return_value = None
+        models.Token.get_dev_token_by_userid.return_value = None
 
         views.DeveloperController(pyramid_request).post()
 
@@ -967,7 +967,7 @@ class TestDeveloperController(object):
 
     def test_post_adds_new_token_to_db(self, models, pyramid_request):
         """If the user doesn't have a token yet it should add one to the db."""
-        models.Token.get_by_userid.return_value = None
+        models.Token.get_dev_token_by_userid.return_value = None
 
         views.DeveloperController(pyramid_request).post()
 
@@ -979,11 +979,11 @@ class TestDeveloperController(object):
         """After regenerating a token it should return its new value."""
         data = views.DeveloperController(pyramid_request).post()
 
-        assert data['token'] == models.Token.get_by_userid.return_value.value
+        assert data['token'] == models.Token.get_dev_token_by_userid.return_value.value
 
     def test_post_returns_token_after_generating(self, models, pyramid_request):
         """After generating a new token it should return its value."""
-        models.Token.get_by_userid.return_value = None
+        models.Token.get_dev_token_by_userid.return_value = None
 
         data = views.DeveloperController(pyramid_request).post()
 


### PR DESCRIPTION
**<del>This will need rebasing once #3979 is merged</del>** (rebased) - **this should also not be merged before #3979 is deployed and the migration has been run!**

This adds the relationship between tokens and authclients. At the same time, this will change how we identify a developer token to when the `authclient_id` column is `NULL`. The second commit in this pull request reflects that change.