### PR TITLE
Add service for exchanging RFC7523 authorization grants (OAuth Token 5/n)

### DIFF
--- a/h/auth/__init__.py
+++ b/h/auth/__init__.py
@@ -65,6 +65,9 @@ def includeme(config):
         WEBSOCKET_POLICY = MultiAuthenticationPolicy([TOKEN_POLICY,
                                                       PROXY_POLICY])
 
+    config.register_service_factory('.services.oauth_service_factory',
+                                    name='oauth')
+
     # Set the default authentication policy. This can be overridden by modules
     # that include this one.
     config.set_authentication_policy(DEFAULT_POLICY)

--- a/h/auth/services.py
+++ b/h/auth/services.py
@@ -4,12 +4,16 @@ from __future__ import unicode_literals
 
 import datetime
 
+import jwt
 from pyramid_authsanity import interfaces
 import sqlalchemy as sa
 from zope import interface
 
 from h.models import AuthTicket
+from h import models
+from h.exceptions import OAuthTokenError
 from h.auth.util import principals_for_user
+from h._compat import text_type
 
 TICKET_TTL = datetime.timedelta(days=7)
 
@@ -17,6 +21,9 @@ TICKET_TTL = datetime.timedelta(days=7)
 # least one minute smaller than the potential new value. This prevents that we
 # update the `expires` column on every single request.
 TICKET_REFRESH_INTERVAL = datetime.timedelta(minutes=1)
+
+# TTL of an OAuth token
+TOKEN_TTL = datetime.timedelta(hours=1)
 
 
 class AuthTicketNotLoadedError(Exception):
@@ -108,7 +115,118 @@ class AuthTicketService(object):
         self._userid = None
 
 
+class OAuthService(object):
+    def __init__(self, session, user_service, domain):
+        self.session = session
+        self.usersvc = user_service
+        self.domain = domain
+
+    def verify_jwt_bearer(self, assertion, grant_type):
+        """
+        Verifies a JWT bearer grant token and returns the matched user.
+
+        This adheres to RFC7523 [1] ("JSON Web Token (JWT) Profile for
+        OAuth 2.0 Client Authentication and Authorization Grants").
+
+        [1]: https://tools.ietf.org/html/rfc7523
+
+        :param assertion: the assertion param (typically from ``request.POST``).
+        :type assertion: text_type
+
+        :param grant_type: the grant type (typically from ``request.POST``).
+        :type grant_type: text_type
+
+        :raises h.exceptions.OAuthTokenError: if the given request and/or JWT claims are invalid
+
+        :returns: a tuple with the user and authclient
+        :rtype: tuple
+        """
+        if grant_type != 'urn:ietf:params:oauth:grant-type:jwt-bearer':
+            raise OAuthTokenError('specified grant type is not supported',
+                                  'unsupported_grant_type')
+
+        if not assertion or type(assertion) != text_type:
+            raise OAuthTokenError('required assertion parameter is missing',
+                                  'invalid_request')
+        token = assertion
+
+        unverified_claims = self._decode(token, verify=False)
+
+        client_id = unverified_claims.get('iss', None)
+        if not client_id:
+            raise OAuthTokenError('grant token issuer is missing', 'invalid_grant')
+        authclient = self.session.query(models.AuthClient).get(client_id)
+        if not authclient:
+            raise OAuthTokenError('given JWT issuer is invalid', 'invalid_grant')
+
+        claims = self._decode(token,
+                              algorithms=['HS256'],
+                              audience=self.domain,
+                              key=authclient.secret,
+                              leeway=10)
+
+        userid = claims.get('sub')
+        if not userid:
+            raise OAuthTokenError('JWT subject is missing', 'invalid_grant')
+
+        user = self.usersvc.fetch(userid)
+        if user is None:
+            raise OAuthTokenError('user with userid described in subject could not be found',
+                                  'invalid_grant')
+
+        return (user, authclient)
+
+    def create_token(self, user, authclient):
+        """
+        Creates a token for the passed-in user without any additional
+        verification.
+
+        It is the caller's responsibility to verify the token request, e.g. with
+        ``verify_jwt_bearer``.
+
+        :param assertion: the user for whom the token should be created.
+        :type assertion: h.models.User
+
+        :rtype: h.models.Token
+        """
+        token = models.Token(userid=user.userid,
+                             expires=(utcnow() + TOKEN_TTL),
+                             authclient=authclient)
+        self.session.add(token)
+
+        return token
+
+    def _decode(self, token, **kwargs):
+        try:
+            claims = jwt.decode(token, **kwargs)
+            return claims
+        except jwt.DecodeError:
+            raise OAuthTokenError('invalid JWT signature', 'invalid_grant')
+        except jwt.exceptions.InvalidAlgorithmError:
+            raise OAuthTokenError('invalid JWT signature algorithm', 'invalid_grant')
+        except jwt.MissingRequiredClaimError as exc:
+            raise OAuthTokenError('JWT is missing claim %s' % exc.claim, 'invalid_grant')
+        except jwt.InvalidAudienceError:
+            raise OAuthTokenError('invalid JWT audience', 'invalid_grant')
+        except jwt.ImmatureSignatureError:
+            raise OAuthTokenError('JWT not before is in the future', 'invalid_grant')
+        except jwt.ExpiredSignatureError:
+            raise OAuthTokenError('JWT token is expired', 'invalid_grant')
+        except jwt.InvalidIssuedAtError:
+            raise OAuthTokenError('JWT issued at is in the future', 'invalid_grant')
+
+
 def auth_ticket_service_factory(context, request):
     """Return a AuthTicketService instance for the passed context and request."""
     user_service = request.find_service(name='user')
     return AuthTicketService(request.db, user_service)
+
+
+def oauth_service_factory(context, request):
+    """Return a OAuthService instance for the passed context and request."""
+    user_service = request.find_service(name='user')
+    return OAuthService(request.db, user_service, request.domain)
+
+
+def utcnow():
+    return datetime.datetime.utcnow()

--- a/h/exceptions.py
+++ b/h/exceptions.py
@@ -28,3 +28,17 @@ class ClientUnauthorized(APIError):
     def __init__(self):
         message = _('Client credentials are invalid.')
         super(ClientUnauthorized, self).__init__(message, status_code=403)
+
+
+class OAuthTokenError(APIError):
+
+    """
+    Exception raised when an OAuth token request failed.
+
+    This specifically handles OAuth errors which have a type (``message``) and
+    a description (``description``).
+    """
+
+    def __init__(self, message, type_, status_code=400):
+        self.type = type_
+        super(OAuthTokenError, self).__init__(message, status_code=status_code)

--- a/tests/h/auth/services_test.py
+++ b/tests/h/auth/services_test.py
@@ -3,13 +3,17 @@
 from __future__ import unicode_literals
 
 from datetime import (datetime, timedelta)
+from calendar import timegm
 
+import jwt
 import mock
 import pytest
 
 from h import models
 from h.accounts.services import UserService
 from h.auth import services
+from h.exceptions import OAuthTokenError
+from h._compat import text_type
 
 
 class TestAuthTicketService(object):
@@ -206,9 +210,308 @@ class TestAuthTicketServiceFactory(object):
         assert svc.usersvc == user_service
 
 
+class TestOAuthServiceVerifyJWTBearer(object):
+    """ Tests for ``OAuthService.verify_jwt_bearer`` """
+
+    def test_it_returns_the_user_and_authclient_from_the_jwt_token(self, svc, claims, authclient, user):
+        expected_user = user
+        tok = self.jwt_token(claims, authclient.secret)
+
+        result = svc.verify_jwt_bearer(assertion=tok,
+                                       grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer')
+
+        assert (expected_user, authclient) == result
+
+    def test_missing_grant_type(self, svc):
+        with pytest.raises(OAuthTokenError) as exc:
+            svc.verify_jwt_bearer(assertion='jwt-token',
+                                  grant_type=None)
+
+        assert exc.value.type == 'unsupported_grant_type'
+        assert 'grant type is not supported' in exc.value.message
+
+    def test_unsupported_grant_type(self, svc):
+        with pytest.raises(OAuthTokenError) as exc:
+            svc.verify_jwt_bearer(assertion='jwt-token',
+                                  grant_type='authorization_code')
+
+        assert exc.value.type == 'unsupported_grant_type'
+        assert 'grant type is not supported' in exc.value.message
+
+    def test_missing_assertion(self, svc):
+        with pytest.raises(OAuthTokenError) as exc:
+            svc.verify_jwt_bearer(assertion=None,
+                                  grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer')
+
+        assert exc.value.type == 'invalid_request'
+        assert 'assertion parameter is missing' in exc.value.message
+
+    def test_non_jwt_assertion(self, svc):
+        with pytest.raises(OAuthTokenError) as exc:
+            svc.verify_jwt_bearer(assertion='bogus',
+                                  grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer')
+
+        assert exc.value.type == 'invalid_grant'
+        assert 'invalid JWT signature' in exc.value.message
+
+    def test_missing_jwt_issuer(self, svc, claims, authclient):
+        del claims['iss']
+        tok = self.jwt_token(claims, authclient.secret)
+
+        with pytest.raises(OAuthTokenError) as exc:
+            svc.verify_jwt_bearer(assertion=tok,
+                                  grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer')
+
+        assert exc.value.type == 'invalid_grant'
+        assert 'issuer is missing' in exc.value.message
+
+    def test_empty_jwt_issuer(self, svc, claims, authclient):
+        claims['iss'] = ''
+        tok = self.jwt_token(claims, authclient.secret)
+
+        with pytest.raises(OAuthTokenError) as exc:
+            svc.verify_jwt_bearer(assertion=tok,
+                                  grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer')
+
+        assert exc.value.type == 'invalid_grant'
+        assert 'issuer is missing' in exc.value.message
+
+    def test_missing_authclient_with_given_jwt_issuer(self, svc, claims, authclient, db_session):
+        db_session.delete(authclient)
+        db_session.flush()
+
+        tok = self.jwt_token(claims, authclient.secret)
+
+        with pytest.raises(OAuthTokenError) as exc:
+            svc.verify_jwt_bearer(assertion=tok,
+                                  grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer')
+
+        assert exc.value.type == 'invalid_grant'
+        assert 'issuer is invalid' in exc.value.message
+
+    def test_signed_with_different_secret(self, svc, claims):
+        tok = self.jwt_token(claims, 'different-secret')
+
+        with pytest.raises(OAuthTokenError) as exc:
+            svc.verify_jwt_bearer(assertion=tok,
+                                  grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer')
+
+        assert exc.value.type == 'invalid_grant'
+        assert 'invalid JWT signature' in exc.value.message
+
+    def test_signed_with_unsupported_algorithm(self, svc, claims, authclient):
+        tok = self.jwt_token(claims, authclient.secret, algorithm='HS512')
+
+        with pytest.raises(OAuthTokenError) as exc:
+            svc.verify_jwt_bearer(assertion=tok,
+                                  grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer')
+
+        assert exc.value.type == 'invalid_grant'
+        assert 'invalid JWT signature algorithm' in exc.value.message
+
+    def test_missing_jwt_audience(self, svc, claims, authclient):
+        del claims['aud']
+        tok = self.jwt_token(claims, authclient.secret)
+
+        with pytest.raises(OAuthTokenError) as exc:
+            svc.verify_jwt_bearer(assertion=tok,
+                                  grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer')
+
+        assert exc.value.type == 'invalid_grant'
+        assert 'missing claim aud' in exc.value.message
+
+    def test_invalid_jwt_audience(self, svc, claims, authclient):
+        claims['aud'] = 'foobar.org'
+        tok = self.jwt_token(claims, authclient.secret)
+
+        with pytest.raises(OAuthTokenError) as exc:
+            svc.verify_jwt_bearer(assertion=tok,
+                                  grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer')
+
+        assert exc.value.type == 'invalid_grant'
+        assert 'invalid JWT audience' in exc.value.message
+
+    def test_jwt_not_before_in_future(self, svc, claims, authclient):
+        claims['nbf'] = self.epoch(delta=timedelta(minutes=5))
+        tok = self.jwt_token(claims, authclient.secret)
+
+        with pytest.raises(OAuthTokenError) as exc:
+            svc.verify_jwt_bearer(assertion=tok,
+                                  grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer')
+
+        assert exc.value.type == 'invalid_grant'
+        assert 'not before is in the future' in exc.value.message
+
+    def test_jwt_expires_with_leeway_in_the_past(self, svc, claims, authclient):
+        claims['exp'] = self.epoch(delta=timedelta(minutes=-2))
+        tok = self.jwt_token(claims, authclient.secret)
+
+        with pytest.raises(OAuthTokenError) as exc:
+            svc.verify_jwt_bearer(assertion=tok,
+                                  grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer')
+
+        assert exc.value.type == 'invalid_grant'
+        assert 'token is expired' in exc.value.message
+
+    def test_jwt_issued_at_in_the_future(self, svc, claims, authclient):
+        claims['iat'] = self.epoch(delta=timedelta(minutes=2))
+        tok = self.jwt_token(claims, authclient.secret)
+
+        with pytest.raises(OAuthTokenError) as exc:
+            svc.verify_jwt_bearer(assertion=tok,
+                                  grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer')
+
+        assert exc.value.type == 'invalid_grant'
+        assert 'issued at is in the future' in exc.value.message
+
+    def test_missing_jwt_subject(self, svc, claims, authclient):
+        del claims['sub']
+        tok = self.jwt_token(claims, authclient.secret)
+
+        with pytest.raises(OAuthTokenError) as exc:
+            svc.verify_jwt_bearer(assertion=tok,
+                                  grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer')
+
+        assert exc.value.type == 'invalid_grant'
+        assert 'subject is missing' in exc.value.message
+
+    def test_empty_jwt_subject(self, svc, claims, authclient):
+        claims['sub'] = ''
+        tok = self.jwt_token(claims, authclient.secret)
+
+        with pytest.raises(OAuthTokenError) as exc:
+            svc.verify_jwt_bearer(assertion=tok,
+                                  grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer')
+
+        assert exc.value.type == 'invalid_grant'
+        assert 'subject is missing' in exc.value.message
+
+    def test_user_not_found(self, svc, claims, authclient, user_service):
+        user_service.fetch.return_value = None
+
+        tok = self.jwt_token(claims, authclient.secret)
+
+        with pytest.raises(OAuthTokenError) as exc:
+            svc.verify_jwt_bearer(assertion=tok,
+                                  grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer')
+
+        assert exc.value.type == 'invalid_grant'
+        assert 'user with userid described in subject could not be found' in exc.value.message
+
+    @pytest.fixture
+    def svc(self, pyramid_request, db_session, user_service):
+        return services.OAuthService(db_session, user_service, pyramid_request.domain)
+
+    @pytest.fixture
+    def claims(self, authclient, user, pyramid_request):
+        return {
+            'iss': authclient.id,
+            'sub': user.userid,
+            'aud': pyramid_request.domain,
+            'exp': self.epoch(delta=timedelta(minutes=10)),
+            'nbf': self.epoch(),
+            'iat': self.epoch(),
+        }
+
+    @pytest.fixture
+    def authclient(self, db_session):
+        client = models.AuthClient(authority='partner.org', secret='bogus')
+        db_session.add(client)
+        db_session.flush()
+        return client
+
+    @pytest.fixture
+    def user(self, factories, authclient, user_service):
+        user = factories.User(authority=authclient.authority)
+        user_service.fetch.return_value = user
+        return user
+
+    def jwt_token(self, claims, secret, algorithm='HS256'):
+        return text_type(jwt.encode(claims, secret, algorithm=algorithm))
+
+    def epoch(self, timestamp=None, delta=None):
+        if timestamp is None:
+            timestamp = datetime.utcnow()
+
+        if delta is not None:
+            timestamp = timestamp + delta
+
+        return timegm(timestamp.utctimetuple())
+
+
+class TestOAuthServiceCreateToken(object):
+    """ Tests for ``OAuthService.create_token`` """
+
+    def test_it_creates_a_token(self, svc, user, authclient, db_session):
+        query = db_session.query(models.Token).filter_by(userid=user.userid)
+
+        assert query.count() == 0
+        svc.create_token(user, authclient)
+        assert query.count() == 1
+
+    def test_it_returns_a_token(self, svc, user, authclient):
+        token = svc.create_token(user, authclient)
+        assert type(token) == models.Token
+
+    def test_new_token_expires_within_one_hour(self, svc, db_session, user, authclient, utcnow):
+        utcnow.return_value = datetime(2016, 1, 1, 3, 0, 0)
+
+        svc.create_token(user, authclient)
+
+        token = db_session.query(models.Token).filter_by(userid=user.userid).first()
+        assert token.expires == datetime(2016, 1, 1, 4, 0, 0)
+
+    def test_it_sets_the_passed_in_authclient(self, svc, user, authclient):
+        token = svc.create_token(user, authclient)
+        assert token.authclient == authclient
+
+    @pytest.fixture
+    def svc(self, pyramid_request, db_session, user_service):
+        return services.OAuthService(db_session, user_service, pyramid_request.domain)
+
+    @pytest.fixture
+    def user(self, db_session, factories):
+        user = factories.User()
+        db_session.add(user)
+        db_session.flush()
+        return user
+
+    @pytest.fixture
+    def authclient(self, db_session):
+        client = models.AuthClient(authority='partner.org', secret='bogus')
+        db_session.add(client)
+        db_session.flush()
+        return client
+
+
+@pytest.mark.usefixtures('user_service')
+class TestOAuthServiceFactory(object):
+    def test_it_returns_oauth_service(self, pyramid_request):
+        svc = services.oauth_service_factory(None, pyramid_request)
+        assert isinstance(svc, services.OAuthService)
+
+    def test_it_provides_request_db_as_session(self, pyramid_request):
+        svc = services.oauth_service_factory(None, pyramid_request)
+        assert svc.session == pyramid_request.db
+
+    def test_it_provides_user_service(self, pyramid_request, user_service):
+        svc = services.oauth_service_factory(None, pyramid_request)
+        assert svc.usersvc == user_service
+
+    def test_it_provides_request_domain(self, pyramid_request):
+        pyramid_request.domain = 'example.org'
+        svc = services.oauth_service_factory(None, pyramid_request)
+        assert svc.domain == 'example.org'
+
+
 @pytest.fixture
 def user_service(db_session, pyramid_config):
     service = mock.Mock(spec=UserService(default_authority='example.com',
                                          session=db_session))
     pyramid_config.register_service(service, name='user')
     return service
+
+
+@pytest.fixture
+def utcnow(patch):
+    return patch('h.auth.services.utcnow')


### PR DESCRIPTION
**<del>This will need rebasing once #3980 is merged</del>.** (rebased)

This service will receive an assertion JWT bearer token and a grant_type
and will exchange that for an API token.

Partners will generate JWT tokens for their users and sign them with
their client secret. They then pass that JWT token as a configuration to
the Hypothesis client (that part still needs work), and it will then
exchange the JWT authorization grant for an access token via the `POST
/api/token` endpoint, which will be implemented in the next commit.

It adheres to the behaviour described in [RFC7523], except for the
hashing algorithm. RFC7523 requires the use of the RS256 algorithm to
sign the JWT token, the implementation in this commit still uses the
HS256 algorithm. In the future, authclients would generate a
public/private keypair and share the public part with us.

[RFC7523]: https://tools.ietf.org/html/rfc7523