### PR TITLE
Refactor h.auth.services code (OAuth Token 6/n)

### DIFF
--- a/h/auth/services.py
+++ b/h/auth/services.py
@@ -85,8 +85,8 @@ class AuthTicketService(object):
         # We don't want to update the `expires` column of an auth ticket on
         # every single request, but only when the ticket hasn't been touched
         # within a the defined `TICKET_REFRESH_INTERVAL`.
-        if (datetime.datetime.utcnow() - ticket.updated) > TICKET_REFRESH_INTERVAL:
-            ticket.expires = datetime.datetime.utcnow() + TICKET_TTL
+        if (utcnow() - ticket.updated) > TICKET_REFRESH_INTERVAL:
+            ticket.expires = utcnow() + TICKET_TTL
 
         return True
 
@@ -100,7 +100,7 @@ class AuthTicketService(object):
         ticket = models.AuthTicket(id=ticket_id,
                                    user=user,
                                    user_userid=user.userid,
-                                   expires=(datetime.datetime.utcnow() + TICKET_TTL))
+                                   expires=(utcnow() + TICKET_TTL))
         self.session.add(ticket)
         # We cache the new userid, this will allow us to migrate the old
         # session policy to this new ticket policy.

--- a/h/auth/services.py
+++ b/h/auth/services.py
@@ -9,7 +9,6 @@ from pyramid_authsanity import interfaces
 import sqlalchemy as sa
 from zope import interface
 
-from h.models import AuthTicket
 from h import models
 from h.exceptions import OAuthTokenError
 from h.auth.util import principals_for_user
@@ -72,10 +71,10 @@ class AuthTicketService(object):
         if ticket_id is None:
             return False
 
-        ticket = self.session.query(AuthTicket) \
-            .filter(AuthTicket.id == ticket_id,
-                    AuthTicket.user_userid == principal,
-                    AuthTicket.expires > sa.func.now()) \
+        ticket = self.session.query(models.AuthTicket) \
+            .filter(models.AuthTicket.id == ticket_id,
+                    models.AuthTicket.user_userid == principal,
+                    models.AuthTicket.expires > sa.func.now()) \
             .one_or_none()
 
         if ticket is None:
@@ -98,10 +97,10 @@ class AuthTicketService(object):
         if user is None:
             raise ValueError('Cannot find user with userid %s' % principal)
 
-        ticket = AuthTicket(id=ticket_id,
-                            user=user,
-                            user_userid=user.userid,
-                            expires=(datetime.datetime.utcnow() + TICKET_TTL))
+        ticket = models.AuthTicket(id=ticket_id,
+                                   user=user,
+                                   user_userid=user.userid,
+                                   expires=(datetime.datetime.utcnow() + TICKET_TTL))
         self.session.add(ticket)
         # We cache the new userid, this will allow us to migrate the old
         # session policy to this new ticket policy.
@@ -111,7 +110,7 @@ class AuthTicketService(object):
         """Delete a ticket by id from the database."""
 
         if ticket_id:
-            self.session.query(AuthTicket).filter_by(id=ticket_id).delete()
+            self.session.query(models.AuthTicket).filter_by(id=ticket_id).delete()
         self._userid = None
 
 

--- a/tests/h/auth/services_test.py
+++ b/tests/h/auth/services_test.py
@@ -113,11 +113,10 @@ class TestAuthTicketService(object):
 
         assert str(exc.value) == 'Cannot find user with userid bogus'
 
-    def test_add_ticket_stores_ticket(self, svc, db_session, user, patched_datetime):
+    def test_add_ticket_stores_ticket(self, svc, db_session, user, utcnow):
         svc.usersvc.fetch.return_value = user
 
-        utcnow = datetime(2016, 1, 1, 5, 23, 54)
-        patched_datetime.utcnow.return_value = utcnow
+        utcnow.return_value = datetime(2016, 1, 1, 5, 23, 54)
 
         svc.add_ticket(user.userid, 'the-ticket-id')
 
@@ -125,7 +124,7 @@ class TestAuthTicketService(object):
         assert ticket.id == 'the-ticket-id'
         assert ticket.user == user
         assert ticket.user_userid == user.userid
-        assert ticket.expires == utcnow + services.TICKET_TTL
+        assert ticket.expires == utcnow.return_value + services.TICKET_TTL
 
     def test_add_ticket_caches_the_userid(self, svc, db_session, user):
         svc.usersvc.fetch.return_value = user
@@ -176,10 +175,6 @@ class TestAuthTicketService(object):
     @pytest.fixture
     def principals_for_user(self, patch):
         return patch('h.auth.services.principals_for_user')
-
-    @pytest.fixture
-    def patched_datetime(self, patch):
-        return patch('h.auth.services.datetime.datetime')
 
     @pytest.fixture
     def ticket(self, factories, user, db_session):


### PR DESCRIPTION
**<del>This will need rebasing once #3981 is merged</del>.** (rebased)

These two commits refactor some of the code in `h.auth.services` to make testing of the `AuthTicketService` a bit nicer (due to a module level `utcnow` introduced with the `OAuthService`).