### PR TITLE
Add new POST /api/token endpoint (OAuth Token 7/n)

### DIFF
--- a/h/views/api_auth.py
+++ b/h/views/api_auth.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from h.auth.services import TOKEN_TTL
+from h.exceptions import OAuthTokenError
+from h.util.view import json_view
+
+
+@json_view(route_name='token', request_method='POST')
+def access_token(request):
+    svc = request.find_service(name='oauth')
+
+    user, authclient = svc.verify_jwt_bearer(
+        assertion=request.POST.get('assertion'),
+        grant_type=request.POST.get('grant_type'))
+    token = svc.create_token(user, authclient)
+
+    return {
+        'access_token': token.value,
+        'token_type': 'bearer',
+        'expires_in': TOKEN_TTL.total_seconds(),
+    }
+
+
+@json_view(context=OAuthTokenError)
+def api_token_error(context, request):
+    """Handle an expected/deliberately thrown API exception."""
+    request.response.status_code = context.status_code
+    resp = {'error': context.type}
+    if context.message:
+        resp['error_description'] = context.message
+    return resp

--- a/tests/h/views/api_auth_test.py
+++ b/tests/h/views/api_auth_test.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import mock
+import pytest
+
+from h import models
+from h.accounts.services import user_service_factory
+from h.auth.services import oauth_service_factory, TOKEN_TTL
+from h.exceptions import OAuthTokenError
+from h.views import api_auth as views
+
+
+@pytest.mark.usefixtures('user_service', 'oauth_service')
+class TestAccessToken(object):
+    def test_it_verifies_the_jwt_bearer(self, pyramid_request, oauth_service):
+        pyramid_request.POST = {'assertion': 'the-assertion', 'grant_type': 'the-grant-type'}
+
+        views.access_token(pyramid_request)
+
+        oauth_service.verify_jwt_bearer.assert_called_once_with(
+            assertion='the-assertion', grant_type='the-grant-type'
+        )
+
+    def test_it_creates_a_token(self, pyramid_request, oauth_service):
+        views.access_token(pyramid_request)
+
+        oauth_service.create_token.assert_called_once_with(
+            mock.sentinel.user, mock.sentinel.authclient)
+
+    def test_it_returns_an_oauth_compliant_response(self, pyramid_request, oauth_service):
+        token = models.Token()
+        oauth_service.create_token.return_value = token
+
+        assert views.access_token(pyramid_request) == {
+            'access_token': token.value,
+            'token_type': 'bearer',
+            'expires_in': TOKEN_TTL.total_seconds(),
+        }
+
+    @pytest.fixture
+    def oauth_service(self, pyramid_config, pyramid_request):
+        svc = mock.Mock(spec_set=oauth_service_factory(None, pyramid_request))
+        svc.verify_jwt_bearer.return_value = (mock.sentinel.user, mock.sentinel.authclient)
+        pyramid_config.register_service(svc, name='oauth')
+        return svc
+
+    @pytest.fixture
+    def user_service(self, pyramid_config, pyramid_request):
+        svc = mock.Mock(spec_set=user_service_factory(None, pyramid_request))
+        pyramid_config.register_service(svc, name='user')
+        return svc
+
+
+class TestAPITokenError(object):
+    def test_it_sets_the_response_status_code(self, pyramid_request):
+        context = OAuthTokenError('the error message', 'error_type', status_code=403)
+        views.api_token_error(context, pyramid_request)
+        assert pyramid_request.response.status_code == 403
+
+    def test_it_returns_the_error(self, pyramid_request):
+        context = OAuthTokenError('', 'error_type')
+        result = views.api_token_error(context, pyramid_request)
+        assert result['error'] == 'error_type'
+
+    def test_it_returns_error_description(self, pyramid_request):
+        context = OAuthTokenError('error description', 'error_type')
+        result = views.api_token_error(context, pyramid_request)
+        assert result['error_description'] == 'error description'
+
+    def test_it_skips_description_when_missing(self, pyramid_request):
+        context = OAuthTokenError(None, 'invalid_request')
+        result = views.api_token_error(context, pyramid_request)
+        assert 'error_description' not in result
+
+    def test_it_skips_description_when_empty(self, pyramid_request):
+        context = OAuthTokenError('', 'invalid_request')
+        result = views.api_token_error(context, pyramid_request)
+        assert 'error_description' not in result


### PR DESCRIPTION
**<del>This will need rebasing once #3982 is merged</del>.** (rebased)

This implements the `POST` endpoint which exchanges an RFC7523 JWT grant token for an OAuth token by using the `OAuthService` that we introduced in #3981.

_This endpoint will need to support CORS as @nickstenning mentioned in #3971. I will do that in a follow up pull request._