### PR TITLE
Fix error when client_id is not a UUID

### DIFF
--- a/h/auth/services.py
+++ b/h/auth/services.py
@@ -154,7 +154,15 @@ class OAuthService(object):
         client_id = unverified_claims.get('iss', None)
         if not client_id:
             raise OAuthTokenError('grant token issuer is missing', 'invalid_grant')
-        authclient = self.session.query(models.AuthClient).get(client_id)
+
+        authclient = None
+        try:
+            authclient = self.session.query(models.AuthClient).get(client_id)
+        except sa.exc.StatementError as exc:
+            if str(exc.orig) == 'badly formed hexadecimal UUID string':
+                pass
+            else:
+                raise
         if not authclient:
             raise OAuthTokenError('given JWT issuer is invalid', 'invalid_grant')
 

--- a/tests/h/auth/services_test.py
+++ b/tests/h/auth/services_test.py
@@ -284,6 +284,17 @@ class TestOAuthServiceVerifyJWTBearer(object):
         assert exc.value.type == 'invalid_grant'
         assert 'issuer is invalid' in exc.value.message
 
+    def test_non_uuid_jwt_issuer(self, svc, claims, authclient, db_session):
+        claims['iss'] = 'bogus'
+        tok = self.jwt_token(claims, authclient.secret)
+
+        with pytest.raises(OAuthTokenError) as exc:
+            svc.verify_jwt_bearer(assertion=tok,
+                                  grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer')
+
+        assert exc.value.type == 'invalid_grant'
+        assert 'issuer is invalid' in exc.value.message
+
     def test_signed_with_different_secret(self, svc, claims):
         tok = self.jwt_token(claims, 'different-secret')
 


### PR DESCRIPTION
@seanh found this bug with the code in #3981 

The solution is to recover from the SQLAlchemy Statement error, see that it is the one we're expecting and then return a proper OAuth error.

Fixes #4000.