### PR TITLE
Make search page work without js

### DIFF
--- a/h/static/scripts/controllers/search-bar-controller.js
+++ b/h/static/scripts/controllers/search-bar-controller.js
@@ -207,9 +207,7 @@ class SearchBarController extends Controller {
      */
     var lozengifyInput = () => {
       var {lozengeValues, incompleteInputValue} = SearchTextParser.getLozengeValues(this._input.value);
-      lozengeValues.forEach(function(value) {
-        addLozenge(value);
-      });
+      lozengeValues.forEach(addLozenge);
       this._input.value = incompleteInputValue;
       this._input.style.visibility = 'visible';
     };

--- a/h/static/scripts/tests/controllers/search-bar-controller-test.js
+++ b/h/static/scripts/tests/controllers/search-bar-controller-test.js
@@ -26,11 +26,10 @@ describe('SearchBarController', function () {
     var ctrl;
     var form;
     var TEMPLATE = `
-      <form>
+      <form data-ref="searchBarForm">
         <div class="search-bar__lozenges" data-ref="searchBarLozenges">
         </div>
-        <input data-ref="searchBarInput" class="search-bar__input" />
-        <input data-ref="searchBarInputHidden" class="js-search-bar__input-hidden" name="q" value="foo" />
+        <input data-ref="searchBarInput" class="search-bar__input" name="q" />
         <div data-ref="searchBarDropdown">
           <div>Narrow your search</div>
           <ul>
@@ -271,8 +270,7 @@ describe('SearchBarController', function () {
       var template = `
         <form>
           <div class="search-bar__lozenges" data-ref="searchBarLozenges"></div>
-          <input data-ref="searchBarInput" class="search-bar__input">
-          <input data-ref="searchBarInputHidden" class="js-search-bar__input-hidden" name="q" value="${value}">
+          <input data-ref="searchBarInput" class="search-bar__input" name="q" value="${value}">
           <div data-ref="searchBarDropdown"></div>
         </form>
       `.trim();

--- a/h/static/scripts/util/search-text-parser.js
+++ b/h/static/scripts/util/search-text-parser.js
@@ -79,7 +79,23 @@ function shouldLozengify(phrase) {
   return true;
 }
 
-function getLozengeValuesAndIncompleteSearchTerms(queryString) {
+/**
+ * Return an array of lozenge values from the given string.
+ *
+ * @param {String} queryString A string of query terms.
+ *
+ * @returns {Object} An object with two properties: lozengeValues is an array
+ *   of values to be turned into lozenges, and incompleteInputValue is any
+ *   remaining un-lozengifiable text from the end of the input string
+ *
+ * @example
+ * // returns {
+ *   'lozengeValues': ['foo', 'key:"foo bar"', 'gar'],
+ *   'incompleteInputValue': '"unclosed',
+ * }
+ * getLozengeValues('foo key:"foo bar" gar "unclosed')
+ */
+function getLozengeValues(queryString) {
   var inputTerms = '';
   var quoted;
   var queryTerms = [];
@@ -106,39 +122,7 @@ function getLozengeValuesAndIncompleteSearchTerms(queryString) {
   };
 }
 
-/**
- * Function which returns individual lozenge from a string.
- *
- * @param {String} queryString A string of query terms.
- *
- * @returns {Array} queryTerms An array of individual query terms.
- *
- * @example
- * // returns ['foo', 'key:"foo bar"', 'gar']
- * getLozengeValues('foo key:"foo bar" gar')
- */
-function getLozengeValues(queryString) {
-  return getLozengeValuesAndIncompleteSearchTerms(queryString).lozengeValues;
-}
-
-/**
- * Function which returns an incomplete quoted sentance from a string.
- *
- * @param {String} queryString A string of query terms.
- *
- * @returns {String} inputTerms A string which starts with a quote but
- * doesnt have an end quote.
- *
- * @example
- * // returns ['"bar gar']
- * getIncompleteInputValue('foo "bar gar')
- */
-function getIncompleteInputValue(queryString) {
-  return getLozengeValuesAndIncompleteSearchTerms(queryString).incompleteInputValue;
-}
-
 module.exports = {
   shouldLozengify: shouldLozengify,
   getLozengeValues: getLozengeValues,
-  getIncompleteInputValue: getIncompleteInputValue,
 };

--- a/h/static/styles/partials-v2/_search-bar.scss
+++ b/h/static/styles/partials-v2/_search-bar.scss
@@ -18,6 +18,14 @@
   padding-top: 18px;
   padding-bottom: 18px;
   padding-right: 3px;
+
+  .env-js-capable & {
+    visibility: hidden;
+  }
+
+  .env-js-timeout & {
+    visibility: visible;
+  }
 }
 
 .search-bar__input:hover,

--- a/h/templates/panels/navbar.html.jinja2
+++ b/h/templates/panels/navbar.html.jinja2
@@ -51,11 +51,13 @@
       !--><img alt="Hypothesis logo" class="nav-bar__logo" src="/assets/images/logo.svg"></a>
 
     <div class="nav-bar__search js-search-bar" data-ref="searchBar">
-      <form class="search-bar" action="{{ search_url }}">
+      <form class="search-bar"
+            data-ref="searchBarForm"
+            id="search-bar"
+            action="{{ search_url }}">
         {{ svg_icon('search', 'search-bar__icon') }}
         <div class="search-bar__lozenges" data-ref="searchBarLozenges"></div>
-        <input class="search-bar__input" data-ref="searchBarInput" placeholder="Search…" autocomplete="off">
-        <input type="hidden" class="js-search-bar__input-hidden" data-ref="searchBarInputHidden" name="q" value="{{ q }}">
+        <input class="search-bar__input" data-ref="searchBarInput" name="q" value="{{ q }}" placeholder="Search…" autocomplete="off">
         {{ search_bar_dropdown() }}
       </form>
     </div>

--- a/tests/functional/test_search.py
+++ b/tests/functional/test_search.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+"""Functional tests for the /search page, without JavaScript."""
+
+from __future__ import unicode_literals
+
+import pytest
+
+from h import models
+
+
+@pytest.mark.functional
+def test_search_input_text_is_submitted_as_q_without_javascript(app):
+    res = app.get('/search')
+    form = res.forms['search-bar']
+    form['q'] = 'test search query'
+
+    res = res.form.submit()
+
+    assert res.forms['search-bar']['q'].value == 'test search query', (
+        "The server should have received the search text in the q parameter, "
+        "and echoed it back in the q parameter")
+
+
+@pytest.fixture(autouse=True)
+def enable_search_page_and_activity_pages_feature_flags(
+        app,  # This fixture depends on the app fixture so that the app fixture
+              # will be run before, not after, this fixture. This is necessary
+              # because the app fixture cleans the database which would delete
+              # the changes made by this fixture if it were run after this
+              # fixture.
+        db_session):
+    for feature_name in ('search_page', 'activity_pages'):
+        assert db_session.query(models.Feature).filter_by(name=feature_name).all() == []
+        db_session.add(models.Feature(name=feature_name, everyone=True))
+    db_session.commit()


### PR DESCRIPTION
Make the `/search` page work without JavaScript.

Fixes #3990.

Get the `/search` page working without JavaScript again.

Before: when JavaScript wasn't available the user's search text would not be submitted in the `q=` param in the URL, and would disappear from the search bar on form submit:

![peek 2016-10-25 13-08](https://cloud.githubusercontent.com/assets/22498/19685419/6cc94b38-9ab4-11e6-9c5a-d7fb10c12c66.gif)

After:

![peek 2016-10-25 13-09](https://cloud.githubusercontent.com/assets/22498/19685423/72e85b6c-9ab4-11e6-975f-dac1dd0bf37c.gif)

When JavaScript _is_ available the search bar should continue to work exactly as before, all searching and lozengification etc should be the same.

Previously what happened was this:

1. The server rendered the `/search` page with two `<input>`s in the search bar `<form>`: an empty, nameless but visible `<input>`, and a hidden `<input type="hidden" name="q">`. The server rendered any search text the user had submitted into the hidden input.

2. At controller initialization time, `SearchBarController` would move the text from the `<input type="hidden" name="q">` into lozenges and/or into the visible `<input>`.

3. The user would type into the visible input. Some of this text might be lozengified by `SearchBarController` and moved from the visible input into lozenges. Some might remain in the visible input. The empty `<input type="hidden" name="q">` remained empty as the user typed.

4. On form submit `SearchBarController` would read text from the lozenges and the visible `<input>` and write it into the `<input type="hidden" name="q">` and then submit the form, so this text constructed from the lozenges and the visible input would be put into the hidden input at the last second submitted as the `q` parameter.

The problem is that when JavaScript is not available, the text just remains in the visible `<input>` and the `<input type="hidden" name="q">` remains empty, so an empty string is always submitted as the `q` parameter and search doesn't work. It always submits an empty search query.

In addition, there is no JavaScript to copy the text from the `<input type="hidden" name="q">` into the visible `<input>` on page load, so the user's search query appears to disappear from the search bar on form submit as well.

What happens now:
    
1. The server renders the `/search` page with a single, visible `<input name="q">` containing any search text the user submitted. There is no hidden input.

2. The user types into the visible input. Some of this text might be lozengified by `SearchBarController` and moved from the visible input into lozenges. Some might remain in the visible input.

3. On form submit `SearchBarController` reads text from the lozenges and the visible `<input>` and writes it into a _new_ `<input type="hidden" name="q">` which it inserts into the DOM immediately before submitting the form. `SearchBarController` also moves the `name="q"` HTML attribute from the visible to the newly-inserted hidden `<input>` at the last second, before submitting the form.
    
   (The reason for inserting a hidden input like this rather than just setting the value of the visible input is so that users don't see a flash as the search text changes for a moment before the page reloads.)
    
When JavaScript is not available, this works exactly like a normal basic form would do with a single input.
    
Changes:
    
* In the server-side HTML template, the `value="{{ q }}"` is moved from the hidden `<input>` back on to the visible `<input>` where it used to be.

   This means that, when JavaScript is not available, when the search page is
reloaded after submitting the search form, the search text that the user has typed remains in the visible `<input>` (rendered there by the server) instead of disappearing (because the server was rendering it into the hidden `<input>` instead).
    
   As a result of this, `SearchBarController`'s `lozengifyHiddenInput()` becomes `lozengifyInput()`, since the search text that it needs to lozengify on controller initialization is now in the `<input>` not in the hidden `<input>`.

* In the server-side HTML template, the `name="q"` attribute is moved from the hidden `<input>` back on to the visible `<input>` (where it used to be). This means that the search bar works without JavaScript again: the user types text into the visible `<input>` and hits `Enter` to submit it as the `q` parameter.

* The hidden input is removed from the search bar form (removed from the server-side HTML template). `SearchBarController` now inserts the hidden input into the DOM at the last second when it is needed - just before submitting the form.

* `this._inputHidden` is removed from `SearchBarController`. It just creates a hidden input when it needs it, doesn't need to keep track of it in a class-level variable.

* `SearchBarController`'s `updateHiddenInputValue()` becomes `insertHiddenInput()`, a method that both creates a hidden input and inserts it into the DOM, _and_ sets the `value` of that hidden `<input>` to the search query that we want to submit according to the lozenges and any text in the visible `<input>`.

* A `submitForm()` method is added that inserts the hidden input and submits the form (called both on `Enter` and on deleting a lozenge)

* `SearchTextParser.getLozengeValues()` now returns an object containing two properties: the array of lozenge values and the "incomplete input value" (any un-lozengifiable text, e.g. an unclosed quoted phrase, that should remain in the `<input>` and not be lozengified).

   This was previously two separate functions `getLozengeValues()` and `getIncompleteInputValue()`. This pair of functions is now called in one place only - in `lozengifyInput()` - and in that place both the lozenge and the remaining text are needed so it makes sense for the one function just to return both.

Known issues:

Before this commit there was already a "flash of no lozenges". The search bar, as rendered by the server, didn't contain any lozenges (or any search text - it was empty). When `SearchBarController` runs it inserts the lozenges and search text into the DOM. This results in a flash where you can see the empty search bar for a moment before the lozenges and search text are inserted.

By moving the un-lozengified search text, as rendered initially by the server, from the hidden input into the visible input, this commit would have made this flash even worse. Instead of seeing an empty `<input>` for a moment you would see an `<input>` containing un-lozengified text, until `SearchBarController` lozengifies it.

To avoid this, some CSS involving `env-js-capable` and `env-js-timeout` has been added to hide the visible input until after lozengification has happened. This returns us to seeing an empty search bar for a moment before the lozenges appear.

`visibility: hidden` (rather than, say, `display: none`) is used to hide the `<input>` so that the input still takes up the same space that it would have taken, affecting the layout of the other still-visible elements on the page in the same way. Otherwise (e.g. with `display: none`), the search bar would shrink in height for a second until the `<input>` was displayed.