### PR TITLE
Decouple search bar lozenge tests

### DIFF
--- a/h/static/scripts/tests/controllers/search-bar-controller-test.js
+++ b/h/static/scripts/tests/controllers/search-bar-controller-test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var syn = require('syn');
+var util = require('./util');
 
 var SearchBarController = require('../../controllers/search-bar-controller');
 
@@ -251,75 +252,96 @@ describe('SearchBarController', function () {
   });
 
   describe('Lozenges', function () {
-    var testEl;
-    var input;
-    var inputHidden;
     var ctrl;
-    var TEMPLATE = `
-      <form>
-        <div class="search-bar__lozenges" data-ref="searchBarLozenges">
-        </div>
-        <input data-ref="searchBarInput" class="search-bar__input" />
-        <input data-ref="searchBarInputHidden" class="js-search-bar__input-hidden" name="q" value="foo 'bar" />
-        <div data-ref="searchBarDropdown">
-        </div>
-      </form>
-    `;
-
-    beforeEach(function () {
-      testEl = document.createElement('div');
-      testEl.innerHTML = TEMPLATE;
-      document.body.appendChild(testEl);
-
-      ctrl = new SearchBarController(testEl);
-
-      input = ctrl.refs.searchBarInput;
-      inputHidden = ctrl.refs.searchBarInputHidden;
-    });
 
     afterEach(function () {
-      document.body.removeChild(testEl);
+      if (ctrl) {
+        ctrl.element.remove();
+        ctrl = null;
+      }
     });
+
+    /**
+     * Make a <form> with the SearchBarController enhancement applied and
+     * return the various parts of the component.
+     *
+     */
+    function component() {
+      var template = `
+        <form>
+          <div class="search-bar__lozenges" data-ref="searchBarLozenges"></div>
+          <input data-ref="searchBarInput" class="search-bar__input">
+          <input data-ref="searchBarInputHidden" class="js-search-bar__input-hidden" name="q" value="foo 'bar">
+          <div data-ref="searchBarDropdown"></div>
+        </form>
+      `.trim();
+
+      ctrl = util.setupComponent(document, template, SearchBarController);
+
+      return {
+        ctrl: ctrl,
+        input: ctrl.refs.searchBarInput,
+        hiddenInput: ctrl.refs.searchBarInputHidden,
+      };
+    }
+
+    /**
+     * Return all of the given controller's lozenge elements (if any).
+     *
+     */
+    function getLozenges(ctrl) {
+      return ctrl.refs.searchBarLozenges.querySelectorAll('.js-lozenge__content');
+    }
 
     it('should create lozenges for existing query terms in the hidden input on page load', function () {
-      assert.equal(testEl.querySelectorAll('.js-lozenge__content')[0].textContent, 'foo');
+      var {ctrl} = component();
+
+      assert.equal(getLozenges(ctrl)[0].textContent, 'foo');
     });
 
-    it('should  not create a lozenge for incomplete query strings in the hidden input on page load', function () {
-      assert.equal(testEl.querySelectorAll('.js-lozenge__content').length, 1);
-      assert.equal(testEl.querySelectorAll('.js-lozenge__content')[0].textContent, 'foo');
-      assert.equal(testEl.querySelector('[data-ref="searchBarInput"]').value, '\'bar');
+    it('should not create a lozenge for incomplete query strings in the hidden input on page load', function () {
+      var {ctrl, input} = component();
+
+      assert.equal(getLozenges(ctrl).length, 1);
+      assert.equal(getLozenges(ctrl)[0].textContent, 'foo');
+      assert.equal(input.value, '\'bar');
     });
 
     it('should create a lozenge when the user presses space and there are no incomplete query strings in the input', function (done) {
+      var {ctrl, input, hiddenInput} = component();
       input.value = '';
-      inputHidden.value = '';
+      hiddenInput.value = '';
+
       syn
         .click(input)
         .type('gar')
         .type('[space]', () => {
-          assert.equal(testEl.querySelectorAll('.js-lozenge__content')[1].textContent, 'gar');
+          assert.equal(getLozenges(ctrl)[1].textContent, 'gar');
           done();
         });
     });
 
     it('should create a lozenge when the user completes a previously incomplete query string and then presses the space key', function (done) {
+      var {ctrl, input} = component();
+
       syn
         .click(input)
         .type(' gar\'')
         .type('[space]', () => {
-          assert.equal(testEl.querySelectorAll('.js-lozenge__content')[1].textContent, '\'bar gar\'');
+          assert.equal(getLozenges(ctrl)[1].textContent, '\'bar gar\'');
           done();
         });
     });
 
     it('should not create a lozenge when the user does not completes a previously incomplete query string and presses the space key', function (done) {
+      var {ctrl, input} = component();
+
       syn
         .click(input)
         .type('[space]')
         .type('gar')
         .type('[space]', () => {
-          var lozenges = testEl.querySelectorAll('.js-lozenge__content');
+          var lozenges = getLozenges(ctrl);
           assert.equal(lozenges.length, 1);
           assert.equal(lozenges[0].textContent, 'foo');
           assert.equal(input.value, '\'bar gar ');

--- a/h/static/scripts/tests/controllers/search-bar-controller-test.js
+++ b/h/static/scripts/tests/controllers/search-bar-controller-test.js
@@ -282,7 +282,6 @@ describe('SearchBarController', function () {
       return {
         ctrl: ctrl,
         input: ctrl.refs.searchBarInput,
-        hiddenInput: ctrl.refs.searchBarInputHidden,
       };
     }
 
@@ -308,7 +307,7 @@ describe('SearchBarController', function () {
     });
 
     it('should create a lozenge when the user presses space and there are no incomplete query strings in the input', function (done) {
-      var {ctrl, input, hiddenInput} = component('foo');
+      var {ctrl, input} = component('foo');
 
       syn
         .click(input)

--- a/h/static/scripts/tests/controllers/search-bar-controller-test.js
+++ b/h/static/scripts/tests/controllers/search-bar-controller-test.js
@@ -266,12 +266,13 @@ describe('SearchBarController', function () {
      * return the various parts of the component.
      *
      */
-    function component() {
+    function component(value) {
+      value = value || '';
       var template = `
         <form>
           <div class="search-bar__lozenges" data-ref="searchBarLozenges"></div>
           <input data-ref="searchBarInput" class="search-bar__input">
-          <input data-ref="searchBarInputHidden" class="js-search-bar__input-hidden" name="q" value="foo 'bar">
+          <input data-ref="searchBarInputHidden" class="js-search-bar__input-hidden" name="q" value="${value}">
           <div data-ref="searchBarDropdown"></div>
         </form>
       `.trim();
@@ -294,21 +295,20 @@ describe('SearchBarController', function () {
     }
 
     it('should create lozenges for existing query terms in the hidden input on page load', function () {
-      var {ctrl} = component();
+      var {ctrl} = component('foo');
 
       assert.equal(getLozenges(ctrl)[0].textContent, 'foo');
     });
 
     it('should not create a lozenge for incomplete query strings in the hidden input on page load', function () {
-      var {ctrl, input} = component();
+      var {ctrl, input} = component("'bar");
 
-      assert.equal(getLozenges(ctrl).length, 1);
-      assert.equal(getLozenges(ctrl)[0].textContent, 'foo');
-      assert.equal(input.value, '\'bar');
+      assert.equal(getLozenges(ctrl).length, 0);
+      assert.equal(input.value, "'bar");
     });
 
     it('should create a lozenge when the user presses space and there are no incomplete query strings in the input', function (done) {
-      var {ctrl, input, hiddenInput} = component();
+      var {ctrl, input, hiddenInput} = component('foo');
       input.value = '';
       hiddenInput.value = '';
 
@@ -322,19 +322,19 @@ describe('SearchBarController', function () {
     });
 
     it('should create a lozenge when the user completes a previously incomplete query string and then presses the space key', function (done) {
-      var {ctrl, input} = component();
+      var {ctrl, input} = component("'bar gar'");
 
       syn
         .click(input)
         .type(' gar\'')
         .type('[space]', () => {
-          assert.equal(getLozenges(ctrl)[1].textContent, '\'bar gar\'');
+          assert.equal(getLozenges(ctrl)[0].textContent, "'bar gar'");
           done();
         });
     });
 
     it('should not create a lozenge when the user does not completes a previously incomplete query string and presses the space key', function (done) {
-      var {ctrl, input} = component();
+      var {ctrl, input} = component("'bar");
 
       syn
         .click(input)
@@ -342,9 +342,8 @@ describe('SearchBarController', function () {
         .type('gar')
         .type('[space]', () => {
           var lozenges = getLozenges(ctrl);
-          assert.equal(lozenges.length, 1);
-          assert.equal(lozenges[0].textContent, 'foo');
-          assert.equal(input.value, '\'bar gar ');
+          assert.equal(lozenges.length, 0);
+          assert.equal(input.value, "'bar gar ");
           done();
         });
     });

--- a/h/static/scripts/tests/controllers/search-bar-controller-test.js
+++ b/h/static/scripts/tests/controllers/search-bar-controller-test.js
@@ -309,8 +309,6 @@ describe('SearchBarController', function () {
 
     it('should create a lozenge when the user presses space and there are no incomplete query strings in the input', function (done) {
       var {ctrl, input, hiddenInput} = component('foo');
-      input.value = '';
-      hiddenInput.value = '';
 
       syn
         .click(input)


### PR DESCRIPTION
Decouple `SearchBarController`'s lozenge tests.

A big part of what we want to test when testing `SearchBarController` is what it does on controller initialization. For example, it should split any text in the search bar into lozenges, creating lozenges divs in the DOM. Any lozengified search terms should be removed from the input. It should leave any unfinished search terms in the search input (for example, strings with unclosed quotes in them). This all needs to be tested with lots of different initial values from the server in the `<input>`: empty, simple string, multiple lozenges, different types of lozengez unclosed lozenge (different types), and combinations of these.

This is not compatible with a `beforeEach()` function that creates an `<input>` with one value, the same for every test, and initializes the controller on it before the test's code is executed.

So replace that with a helper function that each test calls instead, as has been done in several places elsewhere.

(This pattern should be used in all JavaScript controller tests imo, in Python decoupling test fixtures is best practice and done throughout our code.)

This will pave the way for adding lots more `SearchBarController` tests for what it does when initialized on lots of different values.

I think this also makes the tests simpler and easier to read.