### PR TITLE
Fix flash of expanded document buckets

### DIFF
--- a/h/static/scripts/controllers/search-bucket-controller.js
+++ b/h/static/scripts/controllers/search-bucket-controller.js
@@ -38,7 +38,7 @@ class SearchBucketController extends Controller {
   }
 
   update(state, prevState) {
-    setElementState(this.refs.content, {hidden: !state.expanded});
+    setElementState(this.refs.content, {expanded: state.expanded});
     setElementState(this.element, {expanded: state.expanded});
 
     // Scroll to element when expanded, except on initial load

--- a/h/static/scripts/tests/controllers/search-bucket-controller-test.js
+++ b/h/static/scripts/tests/controllers/search-bucket-controller-test.js
@@ -33,9 +33,19 @@ describe('SearchBucketController', function () {
     ctrl.element.remove();
   });
 
-  it('toggles content hidden state when clicked', function () {
+  it('does not have the is-expanded CSS class initially', function () {
+    assert.isFalse(ctrl.refs.content.classList.contains('is-expanded'));
+  });
+
+  it('adds the is-expanded CSS class when clicked', function () {
     ctrl.refs.header.dispatchEvent(new Event('click'));
-    assert.isFalse(ctrl.refs.content.classList.contains('is-hidden'));
+    assert.isTrue(ctrl.refs.content.classList.contains('is-expanded'));
+  });
+
+  it('removes the is-expanded CSS class when clicked again', function () {
+    ctrl.refs.header.dispatchEvent(new Event('click'));
+    ctrl.refs.header.dispatchEvent(new Event('click'));
+    assert.isFalse(ctrl.refs.content.classList.contains('is-expanded'));
   });
 
   it('scrolls element into view when expanded', function () {

--- a/h/static/styles/partials-v2/_search.scss
+++ b/h/static/styles/partials-v2/_search.scss
@@ -105,11 +105,14 @@
 }
 
 .search-result-bucket__annotation-cards-container {
-  display: flex;
   padding-left: 130px;
 
-  &.is-hidden {
+  display: flex;
+  .env-js-capable & {
     display: none;
+    &.is-expanded {
+      display: flex;
+    }
   }
 }
 


### PR DESCRIPTION
Document buckets on the /search page are expanded at first (as the HTML
and CSS is delivered from the server) and then when some JavaScript
(search-bucket-controller.js) runs it collapses them all.

So the buckets are all expanded initially and then they collapse, and on
slower connections this change is noticeable:

![on-master-with-js](https://cloud.githubusercontent.com/assets/22498/19765552/ee76f97c-9c40-11e6-89d7-746b23b41dc5.gif)

To fix this, this commit changes it so that:

* Without any JavaScript at all (e.g. browser doesn't support js at all)
  the HTML and CSS delivered from the server are such that all of the
  buckets are _expanded_:

   ![no-js](https://cloud.githubusercontent.com/assets/22498/19765561/f6d27290-9c40-11e6-9bc3-598754d85a85.gif)

* If the browser _is_ JS capable then as soon as environment-flags.js
  runs (this is run by a `<script>` in the HTML's `<head>`, so it blocks
  rendering and runs _before_ the browser renders the  HTML `<body>`) it
  adds the "env-js-capable" CSS class. This class collapses all the
  buckets.

  So in a js-capable browser the buckets will be _collapsed_ when the
  document is first rendered, no flash of expanded document buckets will
  be seen, even on a slow connection:
   
   ![on-this-branch-with-js](https://cloud.githubusercontent.com/assets/22498/19765568/031560c6-9c41-11e6-8892-7644b4ab1d3a.gif)

* If the browser is js-capable and environment-flags.js runs and adds
  the env-js-capable class, but then the site.bundle.js class
  (which contains search-bucket-controller.js) fails to load, then
  environment-flags.js will add the env-js-timeout CSS class. This class
  expands the document buckets.

  So in a js-capable browser, if loading site.bundle.js failed, the
  buckets will be _expanded_.

  On slow connections when loading site.bundle.js fails, this can cause
  the buckets to be rendered as collapsed at first and then expand, so a
  "flash of collapsed document buckets":

   ![time out](https://cloud.githubusercontent.com/assets/22498/19765593/1ebca69a-9c41-11e6-9f67-e750bac687a6.gif)

* In a js-capable browser in which site.bundle.js has loaded correctly,
  clicking on a document bucket's header will add the is-expanded CSS
  class which expands the bucket (and clicking again removes the class).

  Previously this worked the other way round: clicking would _remove_
  the is-hidden class.