### PR TITLE
Refactor User.get_by_(username/email)

### DIFF
--- a/h/accounts/schemas.py
+++ b/h/accounts/schemas.py
@@ -49,7 +49,7 @@ def get_blacklist():
 def unique_email(node, value):
     '''Colander validator that ensures no user with this email exists.'''
     request = node.bindings['request']
-    user = models.User.get_by_email(request.db, value)
+    user = models.User.get_by_email(request.db, value, request.auth_domain)
     if user and user.userid != request.authenticated_userid:
         msg = _("Sorry, an account with this email address already exists.")
         raise colander.Invalid(node, msg)
@@ -180,7 +180,7 @@ class ForgotPasswordSchema(CSRFSchema):
 
         request = node.bindings['request']
         email = value.get('email')
-        user = models.User.get_by_email(request.db, email)
+        user = models.User.get_by_email(request.db, email, request.auth_domain)
 
         if user is None:
             err = colander.Invalid(node)

--- a/h/accounts/schemas.py
+++ b/h/accounts/schemas.py
@@ -58,7 +58,7 @@ def unique_email(node, value):
 def unique_username(node, value):
     '''Colander validator that ensures the username does not exist.'''
     request = node.bindings['request']
-    user = models.User.get_by_username(request.db, value)
+    user = models.User.get_by_username(request.db, value, request.auth_domain)
     if user:
         msg = _("This username is already taken.")
         raise colander.Invalid(node, msg)
@@ -244,7 +244,7 @@ class ResetCode(colander.SchemaType):
         except BadData:
             raise colander.Invalid(node, _('Wrong reset code.'))
 
-        user = models.User.get_by_username(request.db, username)
+        user = models.User.get_by_username(request.db, username, request.auth_domain)
         if user is None:
             raise colander.Invalid(node, _('Your reset code is not valid'))
         if user.password_updated is not None and timestamp < user.password_updated:

--- a/h/accounts/services.py
+++ b/h/accounts/services.py
@@ -172,13 +172,13 @@ class UserSignupService(object):
 
 def user_service_factory(context, request):
     """Return a UserService instance for the passed context and request."""
-    return UserService(default_authority=text_type(request.auth_domain),
+    return UserService(default_authority=request.auth_domain,
                        session=request.db)
 
 
 def user_signup_service_factory(context, request):
     """Return a UserSignupService instance for the passed context and request."""
-    return UserSignupService(default_authority=text_type(request.auth_domain),
+    return UserSignupService(default_authority=request.auth_domain,
                              mailer=mailer,
                              session=request.db,
                              signup_email=partial(signup.generate, request),

--- a/h/admin/services/user.py
+++ b/h/admin/services/user.py
@@ -31,15 +31,15 @@ class RenameUserService(object):
         self.session = session
         self.reindex = reindex
 
-    def check(self, new_username):
-        existing_user = models.User.get_by_username(self.session, new_username)
+    def check(self, new_username, authority):
+        existing_user = models.User.get_by_username(self.session, new_username, authority)
         if existing_user:
             raise UserRenameError('Another user already has the username "%s"' % new_username)
 
         return True
 
     def rename(self, user, new_username):
-        self.check(new_username)
+        self.check(new_username, user.authority)
 
         old_userid = user.userid
 

--- a/h/admin/views/admins.py
+++ b/h/admin/views/admins.py
@@ -25,7 +25,7 @@ def admins_index(request):
 def admins_add(request):
     """Make a given user an admin."""
     username = request.params['add'].strip()
-    user = models.User.get_by_username(request.db, username)
+    user = models.User.get_by_username(request.db, username, request.auth_domain)
     if user is None:
         request.session.flash(
             _("User {username} doesn't exist.".format(username=username)),
@@ -46,7 +46,7 @@ def admins_remove(request):
     n_admins = request.db.query(models.User).filter(models.User.admin).count()
     if n_admins > 1:
         username = request.params['remove']
-        user = models.User.get_by_username(request.db, username)
+        user = models.User.get_by_username(request.db, username, request.auth_domain)
         if user is not None:
             user.admin = False
     index = request.route_path('admin_admins')

--- a/h/admin/views/admins.py
+++ b/h/admin/views/admins.py
@@ -14,7 +14,10 @@ from h.i18n import TranslationString as _
 def admins_index(request):
     """A list of all the admin users as an HTML page."""
     admins = request.db.query(models.User).filter(models.User.admin)
-    return {"admin_users": [u.username for u in admins]}
+    return {
+        "admin_users": [u.userid for u in admins],
+        "default_authority": request.auth_domain,
+    }
 
 
 @view_config(route_name='admin_admins',
@@ -25,7 +28,8 @@ def admins_index(request):
 def admins_add(request):
     """Make a given user an admin."""
     username = request.params['add'].strip()
-    user = models.User.get_by_username(request.db, username, request.auth_domain)
+    authority = request.params['authority'].strip()
+    user = models.User.get_by_username(request.db, username, authority)
     if user is None:
         request.session.flash(
             _("User {username} doesn't exist.".format(username=username)),
@@ -45,8 +49,8 @@ def admins_remove(request):
     """Remove a user from the admins."""
     n_admins = request.db.query(models.User).filter(models.User.admin).count()
     if n_admins > 1:
-        username = request.params['remove']
-        user = models.User.get_by_username(request.db, username, request.auth_domain)
+        userid = request.params['remove']
+        user = request.db.query(models.User).filter_by(userid=userid).first()
         if user is not None:
             user.admin = False
     index = request.route_path('admin_admins')

--- a/h/admin/views/features.py
+++ b/h/admin/views/features.py
@@ -90,7 +90,7 @@ def cohorts_edit_add(request):
     member_name = request.params['add'].strip()
     cohort_id = request.matchdict['id']
 
-    member = models.User.get_by_username(request.db, member_name)
+    member = models.User.get_by_username(request.db, member_name, request.auth_domain)
     if member is None:
         request.session.flash(
             _("User {member_name} doesn't exist.".format(member_name=member_name)),

--- a/h/admin/views/features.py
+++ b/h/admin/views/features.py
@@ -78,7 +78,11 @@ def cohorts_add(request):
 def cohorts_edit(context, request):
     id = request.matchdict['id']
     cohort = request.db.query(models.FeatureCohort).get(id)
-    return {'cohort': cohort, 'members': cohort.members}
+    return {
+        'cohort': cohort,
+        'members': cohort.members,
+        'default_authority': request.auth_domain
+    }
 
 
 @view_config(route_name='admin_cohorts_edit',
@@ -88,12 +92,14 @@ def cohorts_edit(context, request):
              permission='admin_features')
 def cohorts_edit_add(request):
     member_name = request.params['add'].strip()
+    member_authority = request.params['authority'].strip()
     cohort_id = request.matchdict['id']
 
-    member = models.User.get_by_username(request.db, member_name, request.auth_domain)
+    member = models.User.get_by_username(request.db, member_name, member_authority)
     if member is None:
         request.session.flash(
-            _("User {member_name} doesn't exist.".format(member_name=member_name)),
+            _("User {member_name} with authority {authority} doesn't exist.".format(
+                member_name=member_name, authority=member_authority)),
             "error")
     else:
         cohort = request.db.query(models.FeatureCohort).get(cohort_id)
@@ -109,16 +115,16 @@ def cohorts_edit_add(request):
              renderer='h:templates/admin/edit_cohort.html.jinja2',
              permission='admin_features')
 def cohorts_edit_remove(request):
-    member_name = request.params['remove']
+    member_userid = request.params['remove']
     cohort_id = request.matchdict['id']
 
     cohort = request.db.query(models.FeatureCohort).get(cohort_id)
-    member = request.db.query(models.User).filter_by(username=member_name).first()
+    member = request.db.query(models.User).filter_by(userid=member_userid).first()
     try:
         cohort.members.remove(member)
     except ValueError:
         request.session.flash(
-            _("User {member_name} doesn't exist.".format(member_name=member_name)),
+            _("User {member_userid} doesn't exist.".format(member_userid=member_userid)),
             "error")
 
     url = request.route_url('admin_cohorts_edit', id=cohort_id)

--- a/h/admin/views/nipsa.py
+++ b/h/admin/views/nipsa.py
@@ -56,7 +56,7 @@ def user_not_found(exc, request):
 
 def _form_request_user(request, param):
     username = request.params[param].strip()
-    user = models.User.get_by_username(request.db, username)
+    user = models.User.get_by_username(request.db, username, request.auth_domain)
 
     if user is None:
         raise UserNotFoundError(

--- a/h/admin/views/staff.py
+++ b/h/admin/views/staff.py
@@ -14,7 +14,10 @@ from h.i18n import TranslationString as _
 def staff_index(request):
     """A list of all the staff members as an HTML page."""
     staff = request.db.query(models.User).filter(models.User.staff)
-    return {"staff": [u.username for u in staff]}
+    return {
+        "staff": [u.userid for u in staff],
+        "default_authority": request.auth_domain,
+    }
 
 
 @view_config(route_name='admin_staff',
@@ -25,7 +28,8 @@ def staff_index(request):
 def staff_add(request):
     """Make a given user a staff member."""
     username = request.params['add'].strip()
-    user = models.User.get_by_username(request.db, username, request.auth_domain)
+    authority = request.params['authority'].strip()
+    user = models.User.get_by_username(request.db, username, authority)
     if user is None:
         request.session.flash(
             _("User {username} doesn't exist.".format(username=username)),
@@ -43,8 +47,8 @@ def staff_add(request):
              permission='admin_staff')
 def staff_remove(request):
     """Remove a user from the staff."""
-    username = request.params['remove']
-    user = models.User.get_by_username(request.db, username, request.auth_domain)
+    userid = request.params['remove']
+    user = request.db.query(models.User).filter_by(userid=userid).first()
     if user is not None:
         user.staff = False
     index = request.route_path('admin_staff')

--- a/h/admin/views/staff.py
+++ b/h/admin/views/staff.py
@@ -25,7 +25,7 @@ def staff_index(request):
 def staff_add(request):
     """Make a given user a staff member."""
     username = request.params['add'].strip()
-    user = models.User.get_by_username(request.db, username)
+    user = models.User.get_by_username(request.db, username, request.auth_domain)
     if user is None:
         request.session.flash(
             _("User {username} doesn't exist.".format(username=username)),
@@ -44,7 +44,7 @@ def staff_add(request):
 def staff_remove(request):
     """Remove a user from the staff."""
     username = request.params['remove']
-    user = models.User.get_by_username(request.db, username)
+    user = models.User.get_by_username(request.db, username, request.auth_domain)
     if user is not None:
         user.staff = False
     index = request.route_path('admin_staff')

--- a/h/admin/views/users.py
+++ b/h/admin/views/users.py
@@ -34,7 +34,7 @@ def users_index(request):
         username = username.strip()
         user = models.User.get_by_username(request.db, username)
         if user is None:
-            user = models.User.get_by_email(request.db, username)
+            user = models.User.get_by_email(request.db, username, request.auth_domain)
 
     if user is not None:
         n_annots = _all_user_annotations(request, user).count()

--- a/h/admin/views/users.py
+++ b/h/admin/views/users.py
@@ -32,7 +32,7 @@ def users_index(request):
 
     if username:
         username = username.strip()
-        user = models.User.get_by_username(request.db, username)
+        user = models.User.get_by_username(request.db, username, request.auth_domain)
         if user is None:
             user = models.User.get_by_email(request.db, username, request.auth_domain)
 
@@ -74,7 +74,7 @@ def users_rename(request):
 
     try:
         svc = request.find_service(name='rename_user')
-        svc.check(new_username)
+        svc.check(new_username, request.auth_domain)
 
         worker.rename_user.delay(user.id, new_username)
 
@@ -156,7 +156,7 @@ def _all_user_annotations(request, user):
 def _form_request_user(request):
     """Return the User which a user admin form action relates to."""
     username = request.params['username'].strip()
-    user = models.User.get_by_username(request.db, username)
+    user = models.User.get_by_username(request.db, username, request.auth_domain)
 
     if user is None:
         raise UserNotFoundError("Could not find user with username %s" % username)

--- a/h/auth/__init__.py
+++ b/h/auth/__init__.py
@@ -9,7 +9,7 @@ import pyramid_authsanity
 from pyramid_multiauth import MultiAuthenticationPolicy
 
 from h.auth.policy import AuthenticationPolicy, TokenAuthenticationPolicy
-from h.auth.util import groupfinder
+from h.auth.util import auth_domain, groupfinder
 from h.security import derive_key
 
 __all__ = (
@@ -27,15 +27,6 @@ TOKEN_POLICY = TokenAuthenticationPolicy(callback=groupfinder)
 DEFAULT_POLICY = AuthenticationPolicy(api_policy=TOKEN_POLICY,
                                       fallback_policy=TICKET_POLICY)
 WEBSOCKET_POLICY = MultiAuthenticationPolicy([TOKEN_POLICY, TICKET_POLICY])
-
-
-def auth_domain(request):
-    """Return the value of the h.auth_domain config settings.
-
-    Falls back on returning request.domain if h.auth_domain isn't set.
-
-    """
-    return request.registry.settings.get('h.auth_domain', request.domain)
 
 
 def includeme(config):

--- a/h/auth/util.py
+++ b/h/auth/util.py
@@ -5,6 +5,7 @@ import base64
 from pyramid import security
 
 from h.auth import role
+from h._compat import text_type
 
 
 def basic_auth_creds(request):
@@ -98,3 +99,11 @@ def translate_annotation_principals(principals):
             result.add(principal)
     return list(result)
 
+
+def auth_domain(request):
+    """
+    Return the value of the h.auth_domain config settings.
+
+    Falls back on returning request.domain if h.auth_domain isn't set.
+    """
+    return text_type(request.registry.settings.get('h.auth_domain', request.domain))

--- a/h/cli/commands/user.py
+++ b/h/cli/commands/user.py
@@ -51,7 +51,7 @@ def admin(ctx, username, on):
     administrative privileges.
     """
     request = ctx.obj['bootstrap']()
-    user = models.User.get_by_username(request.db, username)
+    user = models.User.get_by_username(request.db, username, request.auth_domain)
     if user is None:
         raise click.ClickException('no user with username "{}"'.format(username))
 

--- a/h/cli/commands/user.py
+++ b/h/cli/commands/user.py
@@ -41,9 +41,10 @@ def add(ctx, username, email, password):
 
 @user.command()
 @click.argument('username')
+@click.option('--authority')
 @click.option('--on/--off', default=True)
 @click.pass_context
-def admin(ctx, username, on):
+def admin(ctx, username, authority, on):
     """
     Make a user an admin.
 
@@ -51,9 +52,14 @@ def admin(ctx, username, on):
     administrative privileges.
     """
     request = ctx.obj['bootstrap']()
-    user = models.User.get_by_username(request.db, username, request.auth_domain)
+
+    if not authority:
+        authority = request.auth_domain
+
+    user = models.User.get_by_username(request.db, username, authority)
     if user is None:
-        raise click.ClickException('no user with username "{}"'.format(username))
+        msg = 'no user with username "{}" and authority "{}"'.format(username, authority)
+        raise click.ClickException(msg)
 
     user.admin = on
     request.tm.commit()

--- a/h/models/user.py
+++ b/h/models/user.py
@@ -256,10 +256,13 @@ class User(Base):
         return user
 
     @classmethod
-    def get_by_username(cls, session, username):
+    def get_by_username(cls, session, username, authority):
         """Fetch a user by username."""
         uid = _username_to_uid(username)
-        return session.query(cls).filter(cls.uid == uid).first()
+        return session.query(cls).filter(
+            cls.uid == uid,
+            cls.authority == authority,
+        ).first()
 
     def __repr__(self):
         return '<User: %s>' % self.username

--- a/h/models/user.py
+++ b/h/models/user.py
@@ -239,10 +239,11 @@ class User(Base):
         return username
 
     @classmethod
-    def get_by_email(cls, session, email):
+    def get_by_email(cls, session, email, authority):
         """Fetch a user by email address."""
         return session.query(cls).filter(
-            sa.func.lower(cls.email) == email.lower()
+            sa.func.lower(cls.email) == email.lower(),
+            cls.authority == authority,
         ).first()
 
     @classmethod

--- a/h/templates/admin/admins.html.jinja2
+++ b/h/templates/admin/admins.html.jinja2
@@ -18,6 +18,10 @@
         <div class="form-group">
           <label for="add">Username</label>
           <input type="text" class="form-control" name="add">
+        </div>
+        <div class="form-group">
+          <label for="authority">Authority</label>
+          <input type="text" class="form-control" name="authority" value="{{ default_authority }}">
           <input type="submit" class="btn btn-default" value="Add">
         </div>
       </form>

--- a/h/templates/admin/edit_cohort.html.jinja2
+++ b/h/templates/admin/edit_cohort.html.jinja2
@@ -19,10 +19,14 @@
       <form method="POST"
             class="form-inline"
             action="{{ request.route_url('admin_cohorts_edit', id=cohort.id) }}">
+        <input type="hidden" name="cohort" value="{{ cohort.id }}">
         <div class="form-group">
           <label for="add">Username</label>
-          <input type="hidden" name="cohort" value="{{ cohort.id }}">
           <input type="text" class="form-control" name="add">
+        </div>
+        <div class="form-group">
+          <label for="authority">Authority</label>
+          <input type="text" class="form-control" name="authority" value="{{ default_authority }}">
           <input type="submit" class="btn btn-default" value="Add">
         </div>
       </form>
@@ -41,9 +45,9 @@
           <ul>
             {% for user in members %}
               <li>
-                {{ user.username }}
+                {{ user.userid }}
                 <button type="submit" class="btn btn-link btn-sm"
-                        name="remove" value="{{ user.username }}">
+                        name="remove" value="{{ user.userid }}">
                   Remove
                 </button>
               </li>

--- a/h/templates/admin/groups.html.jinja2
+++ b/h/templates/admin/groups.html.jinja2
@@ -35,7 +35,7 @@
               </a>
             </td>
             <td>
-              <a href="{{ request.route_url('admin_users', _query={'username': group.creator.username}) }}">
+              <a href="{{ request.route_url('admin_users', _query={'username': group.creator.username, 'authority': group.creator.authority}) }}">
                 {{ group.creator.username }}
               </a>
             </td>

--- a/h/templates/admin/nipsa.html.jinja2
+++ b/h/templates/admin/nipsa.html.jinja2
@@ -20,6 +20,10 @@
         <div class="form-group">
           <label for="add">Username</label>
           <input type="text" class="form-control" name="add">
+        </div>
+        <div class="form-group">
+          <label for="authority">Authority</label>
+          <input type="text" class="form-control" name="authority" value="{{ default_authority }}">
           <input type="submit" class="btn btn-default" value="Add">
         </div>
       </form>
@@ -31,16 +35,16 @@
       <h3 class="panel-title">Unflag a user</h3>
     </div>
     <div class="panel-body">
-      {% if usernames %}
-      <form 
-        method="POST" 
+      {% if userids %}
+      <form
+        method="POST"
         action="{{ request.route_url('admin_nipsa') }}">
         <ul>
-          {% for username in usernames %}
+          {% for userid in userids %}
             <li>
-              {{ username }}
+              {{ userid }}
               <button type="submit" class="btn btn-link btn-sm"
-                      name="remove" value="{{ username }}">
+                      name="remove" value="{{ userid }}">
                 Remove
               </button>
             </li>

--- a/h/templates/admin/staff.html.jinja2
+++ b/h/templates/admin/staff.html.jinja2
@@ -18,6 +18,10 @@
         <div class="form-group">
           <label for="add">Username</label>
           <input type="text" class="form-control" name="add">
+        </div>
+        <div class="form-group">
+          <label for="authority">Authority</label>
+          <input type="text" class="form-control" name="authority" value="{{ default_authority }}">
           <input type="submit" class="btn btn-default" value="Add">
         </div>
       </form>
@@ -30,7 +34,7 @@
     </div>
     <div class="panel-body">
       <form
-        method="POST" 
+        method="POST"
         action="{{ request.route_url('admin_staff') }}">
         <ul>
           {% for user in staff %}

--- a/h/templates/admin/users.html.jinja2
+++ b/h/templates/admin/users.html.jinja2
@@ -12,6 +12,10 @@
     <div class="form-group">
       <label for="username">Username or email</label>
       <input type="text" class="form-control" name="username">
+    </div>
+    <div class="form-group">
+      <label for="authority">Authority</label>
+      <input type="text" class="form-control" name="authority" value="{{ authority or default_authority }}">
       <input type="submit" class="btn btn-default" value="Find">
     </div>
   </form>
@@ -21,6 +25,7 @@
       <table class="table table-auto table-striped">
         <tbody>
           <tr><th>Username</th><td>{{ user.username }}</td></tr>
+          <tr><th>Authority</th><td>{{ user.authority }}</td></tr>
           <tr><th>UID</th><td>{{ user.uid }}</td></tr>
           <tr><th>Email</th><td>{{ user.email }}</td></tr>
           <tr><th>Registered</th><td>{{ user.registered_date }}</td></tr>
@@ -36,8 +41,8 @@
                       class="users-activate-form"
                       method="POST">
                   <input type="hidden"
-                         name="username"
-                         value="{{user.username}}">
+                         name="userid"
+                         value="{{user.userid}}">
                   <button class="btn btn-primary btn-xs" type="submit">
                     Activate
                   </button>
@@ -63,7 +68,7 @@
       <h3>Please-be-careful Zone</h3>
 
       <form method="POST" action="{{request.route_path('admin_users_rename')}}" class="form-inline">
-        <input type="hidden" name="username" value="{{user.username}}">
+        <input type="hidden" name="userid" value="{{user.userid}}">
         <input type="text" name="new_username" placeholder="New Username">
         <button class="btn" type="submit">Change username</button>
       </form>
@@ -73,7 +78,7 @@
       <form method="POST"
             action="{{request.route_path('admin_users_delete')}}"
             class="form-inline js-users-delete-form">
-        <input type="hidden" name="username" value="{{user.username}}">
+        <input type="hidden" name="userid" value="{{user.userid}}">
 
         {% if user_meta['annotations_count'] > 100 %}
           <div class="alert alert-warning" role="alert">
@@ -111,7 +116,7 @@
         </table>
       {% endif %}
     {% else %}
-      <p>No user found with username or email <em>{{ username }}</em>!</p>
+      <p>No user found with username or email <em>{{ username }}</em> and authority <em>{{ authority }}</em>!</p>
     {% endif %}
   {% endif %}
 {% endblock %}

--- a/tests/h/accounts/schemas_test.py
+++ b/tests/h/accounts/schemas_test.py
@@ -42,7 +42,8 @@ class TestUniqueEmail(object):
             schemas.unique_email(dummy_node, "foo@bar.com")
 
         user_model.get_by_email.assert_called_with(pyramid_request.db,
-                                                   "foo@bar.com")
+                                                   "foo@bar.com",
+                                                   pyramid_request.auth_domain)
 
     def test_it_is_invalid_when_user_exists(self, dummy_node):
         pytest.raises(colander.Invalid,

--- a/tests/h/admin/services/user_test.py
+++ b/tests/h/admin/services/user_test.py
@@ -13,7 +13,7 @@ from h.admin.services.user import make_indexer
 
 class TestRenameUserService(object):
     def test_check_returns_true_when_new_username_does_not_exist(self, service):
-        assert service.check('panda') is True
+        assert service.check('panda', 'foobar.org') is True
 
     def test_check_raises_when_new_userid_is_already_taken(self, service, user, db_session, factories):
         user_taken = factories.User(username='panda')
@@ -21,13 +21,13 @@ class TestRenameUserService(object):
         db_session.flush()
 
         with pytest.raises(UserRenameError) as err:
-            service.check('panda')
+            service.check('panda', user_taken.authority)
         assert err.value.message == 'Another user already has the username "panda"'
 
     def test_rename_checks_first(self, service, check, user):
         service.rename(user, 'panda')
 
-        check.assert_called_once_with(service, 'panda')
+        check.assert_called_once_with(service, 'panda', user.authority)
 
     def test_rename_changes_the_username(self, service, user, db_session):
         service.rename(user, 'panda')

--- a/tests/h/admin/views/admins_test.py
+++ b/tests/h/admin/views/admins_test.py
@@ -21,35 +21,48 @@ class TestAdminsIndex(object):
     def test_context_contains_admin_usernames(self, pyramid_request):
         result = views.admins_index(pyramid_request)
 
-        assert set(result["admin_users"]) == set(["agnos", "bojan", "cristof"])
+        assert set(result["admin_users"]) == set([
+            "acct:agnos@example.com",
+            "acct:bojan@example.com",
+            "acct:cristof@foo.org"
+        ])
 
 
 @pytest.mark.usefixtures('users', 'routes')
 class TestAdminsAddRemove(object):
 
     def test_add_makes_users_admins(self, pyramid_request, users):
-        pyramid_request.params = {"add": "eva"}
+        pyramid_request.params = {
+            "add": "eva",
+            "authority": 'foo.org',
+        }
 
         views.admins_add(pyramid_request)
 
         assert users['eva'].admin
 
     def test_add_is_idempotent(self, pyramid_request, users):
-        pyramid_request.params = {"add": "agnos"}
+        pyramid_request.params = {
+            "add": "agnos",
+            "authority": pyramid_request.auth_domain,
+        }
 
         views.admins_add(pyramid_request)
 
         assert users['agnos'].admin
 
     def test_add_strips_spaces(self, pyramid_request, users):
-        pyramid_request.params = {"add": "   david   "}
+        pyramid_request.params = {"add": "   david   ", "authority": "   example.com  "}
 
         views.admins_add(pyramid_request)
 
         assert users['david'].admin
 
     def test_add_redirects_to_index(self, pyramid_request):
-        pyramid_request.params = {"add": "eva"}
+        pyramid_request.params = {
+            "add": "eva",
+            "authority": pyramid_request.auth_domain,
+        }
 
         result = views.admins_add(pyramid_request)
 
@@ -57,7 +70,10 @@ class TestAdminsAddRemove(object):
         assert result.location == '/adm/admins'
 
     def test_add_redirects_to_index_when_user_not_found(self, pyramid_request):
-        pyramid_request.params = {"add": "florp"}
+        pyramid_request.params = {
+            "add": "florp",
+            "authority": pyramid_request.auth_domain,
+        }
 
         result = views.admins_add(pyramid_request)
 
@@ -65,7 +81,10 @@ class TestAdminsAddRemove(object):
         assert result.location == '/adm/admins'
 
     def test_add_flashes_when_user_not_found(self, pyramid_request):
-        pyramid_request.params = {"add": "florp"}
+        pyramid_request.params = {
+            "add": "florp",
+            "authority": pyramid_request.auth_domain,
+        }
         pyramid_request.session.flash = mock.Mock()
 
         views.admins_add(pyramid_request)
@@ -73,31 +92,31 @@ class TestAdminsAddRemove(object):
         assert pyramid_request.session.flash.call_count == 1
 
     def test_remove_makes_users_not_admins(self, pyramid_request, users):
-        pyramid_request.params = {"remove": "cristof"}
+        pyramid_request.params = {"remove": "acct:cristof@foo.org"}
 
         views.admins_remove(pyramid_request)
 
         assert not users['cristof'].admin
 
     def test_remove_is_idempotent(self, pyramid_request, users):
-        pyramid_request.params = {"remove": "eva"}
+        pyramid_request.params = {"remove": "acct:eva@example.com"}
 
         views.admins_remove(pyramid_request)
 
         assert not users['eva'].admin
 
     def test_remove_will_not_remove_last_admin(self, pyramid_request, users):
-        pyramid_request.params = {"remove": "cristof"}
+        pyramid_request.params = {"remove": "acct:cristof@foo.org"}
         views.admins_remove(pyramid_request)
-        pyramid_request.params = {"remove": "bojan"}
+        pyramid_request.params = {"remove": "acct:bojan@example.com"}
         views.admins_remove(pyramid_request)
-        pyramid_request.params = {"remove": "agnos"}
+        pyramid_request.params = {"remove": "acct:agnos@example.com"}
         views.admins_remove(pyramid_request)
 
         assert users['agnos'].admin
 
     def test_remove_redirects_to_index(self, pyramid_request):
-        pyramid_request.params = {"remove": "agnos"}
+        pyramid_request.params = {"remove": "acct:agnos@example.com"}
 
         result = views.admins_remove(pyramid_request)
 
@@ -105,7 +124,7 @@ class TestAdminsAddRemove(object):
         assert result.location == '/adm/admins'
 
     def test_remove_redirects_to_index_when_user_not_found(self, pyramid_request):
-        pyramid_request.params = {"remove": "florp"}
+        pyramid_request.params = {"remove": "acct:florp@example.com"}
 
         result = views.admins_remove(pyramid_request)
 
@@ -120,17 +139,16 @@ def routes(pyramid_config):
 
 @pytest.fixture
 def users(db_session, factories):
-    admins = ['agnos', 'bojan', 'cristof']
-    nonadmins = ['david', 'eva', 'flora']
+    users = {
+        'agnos': factories.User(username='agnos', authority='example.com', admin=True),
+        'bojan': factories.User(username='bojan', authority='example.com', admin=True),
+        'cristof': factories.User(username='cristof', authority='foo.org', admin=True),
+        'david': factories.User(username='david', authority='example.com', admin=False),
+        'eva': factories.User(username='eva', authority='foo.org', admin=False),
+        'flora': factories.User(username='flora', authority='foo.org', admin=False),
+    }
 
-    users = {}
-
-    for admin in admins:
-        users[admin] = factories.User(username=admin, admin=True)
-    for nonadmin in nonadmins:
-        users[nonadmin] = factories.User(username=nonadmin)
-
-    db_session.add_all(list(users.values()))
+    db_session.add_all(users.values())
     db_session.flush()
 
     return users

--- a/tests/h/admin/views/features_test.py
+++ b/tests/h/admin/views/features_test.py
@@ -106,6 +106,7 @@ def test_cohorts_edit_add_user(factories, pyramid_request):
 
     pyramid_request.matchdict['id'] = cohort.id
     pyramid_request.params['add'] = user.username
+    pyramid_request.params['authority'] = user.authority
     views.cohorts_edit_add(pyramid_request)
 
     assert len(cohort.members) == 1
@@ -113,7 +114,7 @@ def test_cohorts_edit_add_user(factories, pyramid_request):
 
 
 def test_cohorts_edit_add_user_strips_spaces(factories, pyramid_request):
-    user = factories.User(username='benoit')
+    user = factories.User(username='benoit', authority='foo.org')
     cohort = models.FeatureCohort(name='FractalCohort')
 
     pyramid_request.db.add(user)
@@ -122,6 +123,7 @@ def test_cohorts_edit_add_user_strips_spaces(factories, pyramid_request):
 
     pyramid_request.matchdict['id'] = cohort.id
     pyramid_request.params['add'] = '   benoit   '
+    pyramid_request.params['authority'] = '    %s   ' % user.authority
     views.cohorts_edit_add(pyramid_request)
 
     assert len(cohort.members) == 1
@@ -129,7 +131,7 @@ def test_cohorts_edit_add_user_strips_spaces(factories, pyramid_request):
 
 
 def test_cohorts_edit_remove_user(factories, pyramid_request):
-    user = factories.User(username='benoit')
+    user = factories.User(username='benoit', authority='foo.org')
     cohort = models.FeatureCohort(name='FractalCohort')
     cohort.members.append(user)
 
@@ -140,7 +142,7 @@ def test_cohorts_edit_remove_user(factories, pyramid_request):
     assert len(cohort.members) == 1
 
     pyramid_request.matchdict['id'] = cohort.id
-    pyramid_request.params['remove'] = user.username
+    pyramid_request.params['remove'] = user.userid
     views.cohorts_edit_remove(pyramid_request)
 
     assert len(cohort.members) == 0
@@ -161,7 +163,7 @@ def test_cohorts_edit_with_no_users(pyramid_request):
 def test_cohorts_edit_with_users(factories, pyramid_request):
     cohort = models.FeatureCohort(name='FractalCohort')
     user1 = factories.User(username='benoit')
-    user2 = factories.User(username='emily')
+    user2 = factories.User(username='emily', authority='foo.org')
     cohort.members.append(user1)
     cohort.members.append(user2)
 

--- a/tests/h/admin/views/staff_test.py
+++ b/tests/h/admin/views/staff_test.py
@@ -20,35 +20,51 @@ class TestStaffIndex(object):
     def test_context_contains_staff_usernames(self, pyramid_request):
         result = views.staff_index(pyramid_request)
 
-        assert set(result["staff"]) == set(["agnos", "bojan", "cristof"])
+        assert set(result["staff"]) == set([
+            "acct:agnos@example.com",
+            "acct:bojan@example.com",
+            "acct:cristof@foo.org"
+        ])
 
 
 @pytest.mark.usefixtures('users', 'routes')
 class TestStaffAddRemove(object):
 
     def test_add_makes_users_staff(self, pyramid_request, users):
-        pyramid_request.params = {"add": "eva"}
+        pyramid_request.params = {
+            "add": "eva",
+            "authority": "foo.org"
+        }
 
         views.staff_add(pyramid_request)
 
         assert users['eva'].staff
 
     def test_add_is_idempotent(self, pyramid_request, users):
-        pyramid_request.params = {"add": "agnos"}
+        pyramid_request.params = {
+            "add": "agnos",
+            "authority": pyramid_request.auth_domain
+        }
 
         views.staff_add(pyramid_request)
 
         assert users['agnos'].staff
 
     def test_add_strips_spaces(self, pyramid_request, users):
-        pyramid_request.params = {"add": "   eva   "}
+        pyramid_request.params = {
+            "add": "   eva   ",
+            "authority": "     foo.org   "
+        }
 
         views.staff_add(pyramid_request)
 
         assert users['eva'].staff
 
     def test_add_redirects_to_index(self, pyramid_request):
-        pyramid_request.params = {"add": "eva"}
+        pyramid_request.params = {
+            "add": "eva",
+            "authority": pyramid_request.auth_domain
+        }
 
         result = views.staff_add(pyramid_request)
 
@@ -56,7 +72,10 @@ class TestStaffAddRemove(object):
         assert result.location == '/adm/staff'
 
     def test_add_redirects_to_index_when_user_not_found(self, pyramid_request):
-        pyramid_request.params = {"add": "florp"}
+        pyramid_request.params = {
+            "add": "florp",
+            "authority": pyramid_request.auth_domain
+        }
 
         result = views.staff_add(pyramid_request)
 
@@ -64,7 +83,10 @@ class TestStaffAddRemove(object):
         assert result.location == '/adm/staff'
 
     def test_add_flashes_when_user_not_found(self, pyramid_request):
-        pyramid_request.params = {"add": "florp"}
+        pyramid_request.params = {
+            "add": "florp",
+            "authority": pyramid_request.auth_domain
+        }
         pyramid_request.session.flash = mock.Mock()
 
         views.staff_add(pyramid_request)
@@ -72,21 +94,21 @@ class TestStaffAddRemove(object):
         assert pyramid_request.session.flash.call_count == 1
 
     def test_remove_makes_users_not_staff(self, pyramid_request, users):
-        pyramid_request.params = {"remove": "cristof"}
+        pyramid_request.params = {"remove": "acct:cristof@foo.org"}
 
         views.staff_remove(pyramid_request)
 
         assert not users['cristof'].staff
 
     def test_remove_is_idempotent(self, pyramid_request, users):
-        pyramid_request.params = {"remove": "eva"}
+        pyramid_request.params = {"remove": "acct:eva@example.com"}
 
         views.staff_remove(pyramid_request)
 
         assert not users['eva'].staff
 
     def test_remove_redirects_to_index(self, pyramid_request):
-        pyramid_request.params = {"remove": "agnos"}
+        pyramid_request.params = {"remove": "acct:agnos@example.com"}
 
         result = views.staff_remove(pyramid_request)
 
@@ -94,7 +116,7 @@ class TestStaffAddRemove(object):
         assert result.location == '/adm/staff'
 
     def test_remove_redirects_to_index_when_user_not_found(self, pyramid_request):
-        pyramid_request.params = {"remove": "florp"}
+        pyramid_request.params = {"remove": "acct:florp@example.com"}
 
         result = views.staff_remove(pyramid_request)
 
@@ -109,17 +131,15 @@ def routes(pyramid_config):
 
 @pytest.fixture
 def users(db_session, factories):
-    staff = ['agnos', 'bojan', 'cristof']
-    nonstaff = ['david', 'eva', 'flora']
-
-    users = {}
-
-    for staff in staff:
-        users[staff] = factories.User(username=staff, staff=True)
-    for nonstaff in nonstaff:
-        users[nonstaff] = factories.User(username=nonstaff)
-
-    db_session.add_all(list(users.values()))
+    users = {
+        'agnos': factories.User(username='agnos', authority='example.com', staff=True),
+        'bojan': factories.User(username='bojan', authority='example.com', staff=True),
+        'cristof': factories.User(username='cristof', authority='foo.org', staff=True),
+        'david': factories.User(username='david', authority='example.com', staff=False),
+        'eva': factories.User(username='eva', authority='foo.org', staff=False),
+        'flora': factories.User(username='flora', authority='foo.org', staff=False),
+    }
+    db_session.add_all(users.values())
     db_session.flush()
 
     return users

--- a/tests/h/admin/views/users_test.py
+++ b/tests/h/admin/views/users_test.py
@@ -41,7 +41,7 @@ def test_users_index_looks_up_users_by_email(models, pyramid_request):
 
     views.users_index(pyramid_request)
 
-    models.User.get_by_email.assert_called_with(pyramid_request.db, "bob@builder.com")
+    models.User.get_by_email.assert_called_with(pyramid_request.db, "bob@builder.com", pyramid_request.auth_domain)
 
 
 @users_index_fixtures

--- a/tests/h/admin/views/users_test.py
+++ b/tests/h/admin/views/users_test.py
@@ -9,6 +9,7 @@ from mock import call
 from pyramid import httpexceptions
 import pytest
 
+from h.accounts.services import UserService
 from h.admin.views import users as views
 from h.models import Annotation
 
@@ -19,115 +20,130 @@ users_index_fixtures = pytest.mark.usefixtures('models')
 def test_users_index(pyramid_request):
     result = views.users_index(pyramid_request)
 
-    assert result == {'username': None, 'user': None, 'user_meta': {}}
+    assert result == {
+        'default_authority': pyramid_request.auth_domain,
+        'username': None,
+        'authority': None,
+        'user': None,
+        'user_meta': {},
+    }
 
 
 @users_index_fixtures
 def test_users_index_looks_up_users_by_username(models, pyramid_request):
-    pyramid_request.params = {"username": "bob"}
+    pyramid_request.params = {"username": "bob", "authority": "foo.org"}
     models.User.get_by_username.return_value = None
     models.User.get_by_email.return_value = None
 
     views.users_index(pyramid_request)
 
     models.User.get_by_username.assert_called_with(
-        pyramid_request.db, "bob", pyramid_request.auth_domain)
+        pyramid_request.db, "bob", "foo.org")
 
 
 @users_index_fixtures
 def test_users_index_looks_up_users_by_email(models, pyramid_request):
-    pyramid_request.params = {"username": "bob@builder.com"}
+    pyramid_request.params = {"username": "bob@builder.com", "authority": "foo.org"}
     models.User.get_by_username.return_value = None
     models.User.get_by_email.return_value = None
 
     views.users_index(pyramid_request)
 
-    models.User.get_by_email.assert_called_with(pyramid_request.db, "bob@builder.com", pyramid_request.auth_domain)
+    models.User.get_by_email.assert_called_with(pyramid_request.db, "bob@builder.com", "foo.org")
 
 
 @users_index_fixtures
 def test_users_index_strips_spaces(models, pyramid_request):
-    pyramid_request.params = {"username": "    bob   "}
+    pyramid_request.params = {"username": "    bob   ", "authority": "   foo.org    "}
     models.User.get_by_username.return_value = None
     models.User.get_by_email.return_value = None
 
     views.users_index(pyramid_request)
 
-    models.User.get_by_username.assert_called_with(pyramid_request.db, "bob", pyramid_request.auth_domain)
+    models.User.get_by_username.assert_called_with(pyramid_request.db, "bob", "foo.org")
 
 
 @users_index_fixtures
 def test_users_index_queries_annotation_count_by_userid(models, db_session, factories, pyramid_request):
-    models.User.get_by_username.return_value = factories.User(username='bob')
+    user = factories.User(username='bob')
+    models.User.get_by_username.return_value = user
     userid = "acct:bob@{}".format(pyramid_request.auth_domain)
     for _ in xrange(8):
         db_session.add(factories.Annotation(userid=userid))
     db_session.flush()
 
-    pyramid_request.params = {"username": "bob"}
+    pyramid_request.params = {"username": "bob", "authority": user.authority}
     result = views.users_index(pyramid_request)
     assert result['user_meta']['annotations_count'] == 8
 
 
 @users_index_fixtures
 def test_users_index_no_user_found(models, pyramid_request):
-    pyramid_request.params = {"username": "bob"}
+    pyramid_request.params = {"username": "bob", "authority": "foo.org"}
     models.User.get_by_username.return_value = None
     models.User.get_by_email.return_value = None
 
     result = views.users_index(pyramid_request)
 
-    assert result == {'username': "bob", 'user': None, 'user_meta': {}}
+    assert result == {
+        'default_authority': "example.com",
+        'username': "bob",
+        'authority': "foo.org",
+        'user': None,
+        'user_meta': {}
+    }
 
 
 @users_index_fixtures
 def test_users_index_user_found(models, pyramid_request, db_session, factories):
-    pyramid_request.params = {"username": "bob"}
-    user = models.User.get_by_username.return_value = factories.User(username='bob')
+    pyramid_request.params = {"username": "bob", "authority": "foo.org"}
+    user = models.User.get_by_username.return_value = factories.User(username='bob',
+                                                                     authority='foo.org')
 
     result = views.users_index(pyramid_request)
 
     assert result == {
+        'default_authority': "example.com",
         'username': "bob",
+        'authority': "foo.org",
         'user': user,
         'user_meta': {'annotations_count': 0},
     }
 
 
-users_activate_fixtures = pytest.mark.usefixtures('models', 'ActivationEvent')
+users_activate_fixtures = pytest.mark.usefixtures('user_service', 'ActivationEvent')
 
 
 @users_activate_fixtures
-def test_users_activate_gets_user(models, pyramid_request):
-    pyramid_request.params = {"username": "bob"}
+def test_users_activate_gets_user(user_service, pyramid_request):
+    pyramid_request.params = {"userid": "acct:bob@example.org"}
 
     views.users_activate(pyramid_request)
 
-    models.User.get_by_username.assert_called_once_with(
-        pyramid_request.db, "bob", pyramid_request.auth_domain)
+    user_service.fetch.assert_called_once_with("acct:bob@example.org")
 
 
 @users_activate_fixtures
-def test_users_activate_user_not_found_error(models, pyramid_request):
-    pyramid_request.params = {"username": "bob"}
-    models.User.get_by_username.return_value = None
+def test_users_activate_user_not_found_error(user_service, pyramid_request):
+    pyramid_request.params = {"userid": "acct:bob@foo.org"}
+    user_service.fetch.return_value = None
 
     with pytest.raises(views.UserNotFoundError):
         views.users_activate(pyramid_request)
 
 
 @users_activate_fixtures
-def test_users_activate_activates_user(models, pyramid_request):
-    pyramid_request.params = {"username": "bob"}
+def test_users_activate_activates_user(user_service, pyramid_request):
+    pyramid_request.params = {"userid": "acct:bob@example.org"}
 
     views.users_activate(pyramid_request)
 
-    models.User.get_by_username.return_value.activate.assert_called_once_with()
+    user_service.fetch.return_value.activate.assert_called_once_with()
 
 
 @users_activate_fixtures
 def test_users_activate_flashes_success(pyramid_request):
-    pyramid_request.params = {"username": "bob"}
+    pyramid_request.params = {"userid": "acct:bob@example.com"}
 
     views.users_activate(pyramid_request)
     success_flash = pyramid_request.session.peek_flash('success')
@@ -136,18 +152,18 @@ def test_users_activate_flashes_success(pyramid_request):
 
 
 @users_activate_fixtures
-def test_users_activate_inits_ActivationEvent(ActivationEvent, models, pyramid_request):
-    pyramid_request.params = {"username": "bob"}
+def test_users_activate_inits_ActivationEvent(ActivationEvent, user_service, pyramid_request):
+    pyramid_request.params = {"userid": "acct:bob@example.com"}
 
     views.users_activate(pyramid_request)
 
     ActivationEvent.assert_called_once_with(pyramid_request,
-                                            models.User.get_by_username.return_value)
+                                            user_service.fetch.return_value)
 
 
 @users_activate_fixtures
 def test_users_activate_calls_notify(ActivationEvent, notify, pyramid_request):
-    pyramid_request.params = {"username": "bob"}
+    pyramid_request.params = {"userid": "acct:bob@example.com"}
 
     views.users_activate(pyramid_request)
 
@@ -156,32 +172,32 @@ def test_users_activate_calls_notify(ActivationEvent, notify, pyramid_request):
 
 @users_activate_fixtures
 def test_users_activate_redirects(pyramid_request):
-    pyramid_request.params = {"username": "bob"}
+    pyramid_request.params = {"userid": "acct:bob@example.com"}
 
     result = views.users_activate(pyramid_request)
 
     assert isinstance(result, httpexceptions.HTTPFound)
 
 
-users_delete_fixtures = pytest.mark.usefixtures('models', 'delete_user')
+users_delete_fixtures = pytest.mark.usefixtures('user_service', 'delete_user')
 
 
 @users_delete_fixtures
-def test_users_delete_user_not_found_error(models, pyramid_request):
-    pyramid_request.params = {"username": "bob"}
+def test_users_delete_user_not_found_error(user_service, pyramid_request):
+    pyramid_request.params = {"userid": "acct:bob@foo.org"}
 
-    models.User.get_by_username.return_value = None
+    user_service.fetch.return_value = None
 
     with pytest.raises(views.UserNotFoundError):
         views.users_delete(pyramid_request)
 
 
 @users_delete_fixtures
-def test_users_delete_deletes_user(models, delete_user, pyramid_request):
-    pyramid_request.params = {"username": "bob"}
+def test_users_delete_deletes_user(user_service, delete_user, pyramid_request):
+    pyramid_request.params = {"userid": "acct:bob@example.com"}
     user = MagicMock()
 
-    models.User.get_by_username.return_value = user
+    user_service.fetch.return_value = user
 
     views.users_delete(pyramid_request)
 
@@ -189,11 +205,11 @@ def test_users_delete_deletes_user(models, delete_user, pyramid_request):
 
 
 @users_delete_fixtures
-def test_users_delete_group_creator_error(models, delete_user, pyramid_request):
-    pyramid_request.params = {"username": "bob"}
+def test_users_delete_group_creator_error(user_service, delete_user, pyramid_request):
+    pyramid_request.params = {"userid": "acct:bob@example.com"}
     user = MagicMock()
 
-    models.User.get_by_username.return_value = user
+    user_service.fetch.return_value = user
     delete_user.side_effect = views.UserDeletionError('group creator error')
 
     views.users_delete(pyramid_request)
@@ -311,6 +327,15 @@ def models(patch):
     module = patch('h.admin.views.users.models')
     module.Annotation = Annotation
     return module
+
+
+@pytest.fixture
+def user_service(pyramid_config, db_session):
+    service = Mock(spec_set=UserService(default_authority='example.com',
+                                        session=db_session))
+    service.login.return_value = None
+    pyramid_config.register_service(service, name='user')
+    return service
 
 
 @pytest.fixture

--- a/tests/h/admin/views/users_test.py
+++ b/tests/h/admin/views/users_test.py
@@ -30,7 +30,8 @@ def test_users_index_looks_up_users_by_username(models, pyramid_request):
 
     views.users_index(pyramid_request)
 
-    models.User.get_by_username.assert_called_with(pyramid_request.db, "bob")
+    models.User.get_by_username.assert_called_with(
+        pyramid_request.db, "bob", pyramid_request.auth_domain)
 
 
 @users_index_fixtures
@@ -52,7 +53,7 @@ def test_users_index_strips_spaces(models, pyramid_request):
 
     views.users_index(pyramid_request)
 
-    models.User.get_by_username.assert_called_with(pyramid_request.db, "bob")
+    models.User.get_by_username.assert_called_with(pyramid_request.db, "bob", pyramid_request.auth_domain)
 
 
 @users_index_fixtures
@@ -102,7 +103,8 @@ def test_users_activate_gets_user(models, pyramid_request):
 
     views.users_activate(pyramid_request)
 
-    models.User.get_by_username.assert_called_once_with(pyramid_request.db, "bob")
+    models.User.get_by_username.assert_called_once_with(
+        pyramid_request.db, "bob", pyramid_request.auth_domain)
 
 
 @users_activate_fixtures

--- a/tests/h/auth/util_test.py
+++ b/tests/h/auth/util_test.py
@@ -12,6 +12,7 @@ from pyramid import security
 
 from h.auth import role
 from h.auth import util
+from h._compat import text_type
 
 
 FakeUser = namedtuple('FakeUser', ['admin', 'staff', 'groups'])
@@ -154,6 +155,19 @@ def test_translate_annotation_principals(p_in, p_out):
     result = util.translate_annotation_principals(p_in)
 
     assert set(result) == set(p_out)
+
+
+class TestAuthDomain(object):
+    def test_it_returns_the_request_domain(self, pyramid_request):
+        assert util.auth_domain(pyramid_request) == pyramid_request.domain
+
+    def test_it_allows_overriding_request_domain(self, pyramid_request):
+        pyramid_request.registry.settings['h.auth_domain'] = 'foo.org'
+        assert util.auth_domain(pyramid_request) == u'foo.org'
+
+    def test_it_returns_text_type(self, pyramid_request):
+        pyramid_request.domain = str(pyramid_request.domain)
+        assert type(util.auth_domain(pyramid_request)) == text_type
 
 
 @pytest.fixture

--- a/tests/h/cli/commands/user_test.py
+++ b/tests/h/cli/commands/user_test.py
@@ -10,7 +10,7 @@ from h.cli.commands import user as user_cli
 class TestAdminCommand(object):
     def test_it_adds_admin(self, cli, cliconfig, non_admin_user, db_session):
         result = cli.invoke(user_cli.admin,
-                            ['--on', non_admin_user.username],
+                            [u'--on', non_admin_user.username],
                             obj=cliconfig)
 
         assert result.exit_code == 0
@@ -28,9 +28,34 @@ class TestAdminCommand(object):
         user = db_session.query(models.User).get(non_admin_user.id)
         assert user.admin
 
+    def test_it_adds_admin_with_specific_authority(self, cli, cliconfig, non_admin_user, db_session):
+        non_admin_user.authority = u'partner.org'
+        db_session.flush()
+
+        result = cli.invoke(user_cli.admin,
+                            [u'--authority', u'partner.org', non_admin_user.username],
+                            obj=cliconfig)
+
+        assert result.exit_code == 0
+
+        user = db_session.query(models.User).get(non_admin_user.id)
+        assert user.admin
+
     def test_it_removes_admin(self, cli, cliconfig, admin_user, db_session):
         result = cli.invoke(user_cli.admin,
-                            ['--off', admin_user.username],
+                            [u'--off', admin_user.username],
+                            obj=cliconfig)
+
+        assert result.exit_code == 0
+
+        user = db_session.query(models.User).get(admin_user.id)
+        assert not user.admin
+
+    def test_it_removes_admin_with_specific_authority(self, cli, cliconfig, admin_user, db_session):
+        admin_user.authority = u'partner.org'
+
+        result = cli.invoke(user_cli.admin,
+                            [u'--off', u'--authority', u'partner.org', admin_user.username],
                             obj=cliconfig)
 
         assert result.exit_code == 0
@@ -41,6 +66,17 @@ class TestAdminCommand(object):
     def test_it_errors_when_user_could_not_be_found(self, cli, cliconfig, non_admin_user, db_session):
         result = cli.invoke(user_cli.admin,
                             ['bogus_%s' % non_admin_user.username],
+                            obj=cliconfig)
+
+        assert result.exit_code == 1
+        user = db_session.query(models.User).get(non_admin_user.id)
+        assert not user.admin
+
+    def test_it_errors_when_user_with_specific_authority_could_not_be_found(
+            self, cli, cliconfig, non_admin_user, db_session):
+
+        result = cli.invoke(user_cli.admin,
+                            ['--authority', 'foo.com', non_admin_user.username],
                             obj=cliconfig)
 
         assert result.exit_code == 1

--- a/tests/h/cli/commands/user_test.py
+++ b/tests/h/cli/commands/user_test.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+
+import mock
+import pytest
+
+from h import models
+from h.cli.commands import user as user_cli
+
+
+class TestAdminCommand(object):
+    def test_it_adds_admin(self, cli, cliconfig, non_admin_user, db_session):
+        result = cli.invoke(user_cli.admin,
+                            ['--on', non_admin_user.username],
+                            obj=cliconfig)
+
+        assert result.exit_code == 0
+
+        user = db_session.query(models.User).get(non_admin_user.id)
+        assert user.admin
+
+    def test_it_adds_admin_by_default(self, cli, cliconfig, non_admin_user, db_session):
+        result = cli.invoke(user_cli.admin,
+                            [non_admin_user.username],
+                            obj=cliconfig)
+
+        assert result.exit_code == 0
+
+        user = db_session.query(models.User).get(non_admin_user.id)
+        assert user.admin
+
+    def test_it_removes_admin(self, cli, cliconfig, admin_user, db_session):
+        result = cli.invoke(user_cli.admin,
+                            ['--off', admin_user.username],
+                            obj=cliconfig)
+
+        assert result.exit_code == 0
+
+        user = db_session.query(models.User).get(admin_user.id)
+        assert not user.admin
+
+    def test_it_errors_when_user_could_not_be_found(self, cli, cliconfig, non_admin_user, db_session):
+        result = cli.invoke(user_cli.admin,
+                            ['bogus_%s' % non_admin_user.username],
+                            obj=cliconfig)
+
+        assert result.exit_code == 1
+        user = db_session.query(models.User).get(non_admin_user.id)
+        assert not user.admin
+
+    @pytest.fixture
+    def cliconfig(self, pyramid_request):
+        pyramid_request.tm = mock.Mock()
+        return {'bootstrap': mock.Mock(return_value=pyramid_request)}
+
+    @pytest.fixture
+    def admin_user(self, db_session, factories):
+        return self._user(db_session, factories, True)
+
+    @pytest.fixture
+    def non_admin_user(self, db_session, factories):
+        return self._user(db_session, factories, False)
+
+    def _user(self, db_session, factories, admin):
+        user = factories.User(admin=admin)
+        db_session.add(user)
+        db_session.flush()
+        return user

--- a/tests/h/conftest.py
+++ b/tests/h/conftest.py
@@ -21,6 +21,7 @@ from sqlalchemy.orm import sessionmaker
 from h import db
 from h import form
 from h.settings import database_url
+from h._compat import text_type
 
 TEST_DATABASE_URL = database_url(os.environ.get('TEST_DATABASE_URL',
                                                 'postgresql://postgres@localhost/htest'))
@@ -220,7 +221,7 @@ def pyramid_config(pyramid_settings, pyramid_request):
 def pyramid_request(db_session, fake_feature, pyramid_settings):
     """Dummy Pyramid request object."""
     request = testing.DummyRequest(db=db_session, feature=fake_feature)
-    request.auth_domain = request.domain
+    request.auth_domain = text_type(request.domain)
     request.create_form = mock.Mock()
     request.matched_route = mock.Mock()
     request.registry.settings = pyramid_settings

--- a/tests/h/models/user_test.py
+++ b/tests/h/models/user_test.py
@@ -236,3 +236,27 @@ class TestUserGetByEmail(object):
         db_session.add_all(users.values())
         db_session.flush()
         return users
+
+
+class TestUserGetByUsername(object):
+    def test_it_returns_a_user(self, db_session, users):
+        user = users['meredith']
+
+        actual = models.User.get_by_username(db_session, user.username)
+        assert actual == user
+
+    def test_it_filters_by_username(self, db_session):
+        username = 'bogus'
+
+        actual = models.User.get_by_username(db_session, username)
+        assert actual is None
+
+    @pytest.fixture
+    def users(self, db_session, factories):
+        users = {
+            'emily': factories.User(username='emily', authority='example.com'),
+            'meredith': factories.User(username='meredith', authority='example.com'),
+        }
+        db_session.add_all(users.values())
+        db_session.flush()
+        return users

--- a/tests/h/models/user_test.py
+++ b/tests/h/models/user_test.py
@@ -242,19 +242,27 @@ class TestUserGetByUsername(object):
     def test_it_returns_a_user(self, db_session, users):
         user = users['meredith']
 
-        actual = models.User.get_by_username(db_session, user.username)
+        actual = models.User.get_by_username(db_session, user.username, user.authority)
         assert actual == user
 
     def test_it_filters_by_username(self, db_session):
+        authority = 'example.com'
         username = 'bogus'
 
-        actual = models.User.get_by_username(db_session, username)
+        actual = models.User.get_by_username(db_session, username, authority)
+        assert actual is None
+
+    def test_it_filters_by_authority(self, db_session, users):
+        user = users['norma']
+
+        actual = models.User.get_by_username(db_session, user.username, 'example.com')
         assert actual is None
 
     @pytest.fixture
     def users(self, db_session, factories):
         users = {
             'emily': factories.User(username='emily', authority='example.com'),
+            'norma': factories.User(username='norma', authority='foo.org'),
             'meredith': factories.User(username='meredith', authority='example.com'),
         }
         db_session.add_all(users.values())

--- a/tests/h/models/user_test.py
+++ b/tests/h/models/user_test.py
@@ -198,3 +198,33 @@ def test_User_activate_activates_user(db_session):
     db_session.commit()
 
     assert user.is_activated
+
+
+class TestUserGetByEmail(object):
+    def test_it_returns_a_user(self, db_session, users):
+        user = users['meredith']
+        actual = models.User.get_by_email(db_session, user.email)
+        assert actual == user
+
+    def test_it_filters_by_email(self, db_session, users):
+        email = 'bogus@msn.com'
+
+        actual = models.User.get_by_email(db_session, email)
+        assert actual is None
+
+    def test_it_filters_email_case_insensitive(self, db_session, users):
+        user = users['emily']
+        mixed_email = 'eMiLy@mSn.com'
+
+        actual = models.User.get_by_email(db_session, mixed_email)
+        assert actual == user
+
+    @pytest.fixture
+    def users(self, db_session, factories):
+        users = {
+            'emily': factories.User(username='emily', email='emily@msn.com', authority='example.com'),
+            'meredith': factories.User(username='meredith', email='meredith@gmail.com', authority='example.com'),
+        }
+        db_session.add_all(users.values())
+        db_session.flush()
+        return users

--- a/tests/h/models/user_test.py
+++ b/tests/h/models/user_test.py
@@ -203,26 +203,34 @@ def test_User_activate_activates_user(db_session):
 class TestUserGetByEmail(object):
     def test_it_returns_a_user(self, db_session, users):
         user = users['meredith']
-        actual = models.User.get_by_email(db_session, user.email)
+        actual = models.User.get_by_email(db_session, user.email, user.authority)
         assert actual == user
 
     def test_it_filters_by_email(self, db_session, users):
+        authority = 'example.com'
         email = 'bogus@msn.com'
 
-        actual = models.User.get_by_email(db_session, email)
+        actual = models.User.get_by_email(db_session, email, authority)
         assert actual is None
 
     def test_it_filters_email_case_insensitive(self, db_session, users):
         user = users['emily']
         mixed_email = 'eMiLy@mSn.com'
 
-        actual = models.User.get_by_email(db_session, mixed_email)
+        actual = models.User.get_by_email(db_session, mixed_email, user.authority)
         assert actual == user
+
+    def test_it_filters_by_authority(self, db_session, users):
+        user = users['norma']
+
+        actual = models.User.get_by_email(db_session, user.email, 'example.com')
+        assert actual is None
 
     @pytest.fixture
     def users(self, db_session, factories):
         users = {
             'emily': factories.User(username='emily', email='emily@msn.com', authority='example.com'),
+            'norma': factories.User(username='norma', email='norma@foo.org', authority='foo.org'),
             'meredith': factories.User(username='meredith', email='meredith@gmail.com', authority='example.com'),
         }
         db_session.add_all(users.values())

--- a/tests/memex/conftest.py
+++ b/tests/memex/conftest.py
@@ -17,6 +17,7 @@ from pyramid.request import apply_request_extensions
 from sqlalchemy.orm import sessionmaker
 
 from memex import db
+from memex._compat import text_type
 
 TEST_DATABASE_URL = os.environ.get('TEST_DATABASE_URL',
                                    'postgresql://postgres@localhost/htest')
@@ -164,7 +165,7 @@ def pyramid_config(pyramid_settings, pyramid_request):
 def pyramid_request(db_session, fake_feature, pyramid_settings):
     """Dummy Pyramid request object."""
     request = testing.DummyRequest(db=db_session, feature=fake_feature)
-    request.auth_domain = request.domain
+    request.auth_domain = text_type(request.domain)
     request.create_form = mock.Mock()
     request.registry.settings = pyramid_settings
     return request


### PR DESCRIPTION
In preparation for the validation layer of `POST /api/users`, this PR adds the necessary `authority` arguments to both `User.get_by_username` and `User.get_by_email`. In addition to this change, the admin interfaces that allow for a user's username or email input will now also have a second field for the authority (prefilled with the currently configured authentication domain, in our case `hypothes.is`).
