### PR TITLE
Create user api validation

### DIFF
--- a/h/accounts/schemas.py
+++ b/h/accounts/schemas.py
@@ -17,6 +17,7 @@ from h.models.user import (
     USERNAME_MIN_LENGTH,
     USERNAME_PATTERN,
 )
+from h.schemas import JSONSchema
 
 _ = i18n.TranslationString
 log = logging.getLogger(__name__)
@@ -402,6 +403,35 @@ class NotificationsSchema(CSRFSchema):
             omit_label=True,
             values=types),
     )
+
+
+class CreateUserAPISchema(JSONSchema):
+    """Validate a user JSON object."""
+
+    schema = {
+        'type': 'object',
+        'properties': {
+            'authority': {
+                'type': 'string',
+                'format': 'hostname',
+            },
+            'username': {
+                'type': 'string',
+                'minLength': 3,
+                'maxLength': 30,
+                'pattern': '^[A-Za-z0-9._]+$',
+            },
+            'email': {
+                'type': 'string',
+                'format': 'email',
+            },
+        },
+        'required': [
+            'authority',
+            'username',
+            'email',
+        ],
+    }
 
 
 def includeme(config):

--- a/h/schemas.py
+++ b/h/schemas.py
@@ -23,7 +23,9 @@ class JSONSchema(object):
     schema = {}
 
     def __init__(self):
-        self.validator = jsonschema.Draft4Validator(self.schema)
+        format_checker = jsonschema.FormatChecker()
+        self.validator = jsonschema.Draft4Validator(self.schema,
+                                                    format_checker=format_checker)
 
     def validate(self, data):
         """

--- a/h/schemas.py
+++ b/h/schemas.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+"""Classes for validating data passed to views."""
+
+from __future__ import unicode_literals
+
+import copy
+import jsonschema
+from jsonschema.exceptions import best_match
+
+
+class ValidationError(Exception):
+    pass
+
+
+class JSONSchema(object):
+    """
+    Validate data according to a Draft 4 JSON Schema.
+
+    Inherit from this class and override the `schema` class property with a
+    valid JSON schema.
+    """
+
+    schema = {}
+
+    def __init__(self):
+        self.validator = jsonschema.Draft4Validator(self.schema)
+
+    def validate(self, data):
+        """
+        Validate `data` according to the current schema.
+
+        :param data: The data to be validated
+        :return: valid data
+        :raises ValidationError: if the data is invalid
+        """
+        # Take a copy to ensure we don't modify what we were passed.
+        appstruct = copy.deepcopy(data)
+        error = best_match(self.validator.iter_errors(appstruct))
+        if error is not None:
+            raise ValidationError(_format_jsonschema_error(error))
+        return appstruct
+
+
+def _format_jsonschema_error(error):
+    """Format a :py:class:`jsonschema.ValidationError` as a string."""
+    if error.path:
+        dotted_path = '.'.join([str(c) for c in error.path])
+        return '{path}: {message}'.format(path=dotted_path,
+                                          message=error.message)
+    return error.message

--- a/h/views/api_users.py
+++ b/h/views/api_users.py
@@ -10,6 +10,7 @@ from h import models
 from h.accounts import schemas
 from h.auth.util import basic_auth_creds
 from h.exceptions import ClientUnauthorized
+from h.schemas import ValidationError
 from h.util.view import json_view
 
 
@@ -27,6 +28,8 @@ def create(request):
 
     schema = schemas.CreateUserAPISchema()
     appstruct = schema.validate(request.json_body)
+
+    _check_authority(client, appstruct)
     appstruct['authority'] = client.authority
 
     user_signup_service = request.find_service(name='user_signup')
@@ -37,6 +40,13 @@ def create(request):
         'userid': user.userid,
         'username': user.username,
     }
+
+
+def _check_authority(client, data):
+    authority = data.get('authority')
+    if client.authority != authority:
+        msg = "'authority' does not match authenticated client"
+        raise ValidationError(msg)
 
 
 def _request_client(request):

--- a/tests/h/schemas_test.py
+++ b/tests/h/schemas_test.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import pytest
+
+from h import schemas
+
+
+class ExampleSchema(schemas.JSONSchema):
+    schema = {
+        b'$schema': b'http://json-schema.org/draft-04/schema#',
+        b'type': b'string',
+    }
+
+
+class TestJSONSchema(object):
+    def test_it_returns_data_when_valid(self):
+        data = "a string"
+
+        assert ExampleSchema().validate(data) == data
+
+    def test_it_raises_when_data_invalid(self):
+        data = 123  # not a string
+
+        with pytest.raises(schemas.ValidationError):
+            ExampleSchema().validate(data)
+
+    def test_it_sets_appropriate_error_message_when_data_invalid(self):
+        data = 123  # not a string
+
+        with pytest.raises(schemas.ValidationError) as e:
+            ExampleSchema().validate(data)
+
+        message = e.value.message
+        assert message.startswith("123 is not of type 'string'")

--- a/tests/h/views/api_users_test.py
+++ b/tests/h/views/api_users_test.py
@@ -15,14 +15,12 @@ from h.views.api_users import create
                          'user_signup_service')
 class TestCreate(object):
 
+    @pytest.mark.usefixtures('valid_auth')
     def test_returns_user_object(self,
-                                 auth_client,
-                                 basic_auth_creds,
                                  factories,
                                  pyramid_request,
                                  user_signup_service,
                                  valid_payload):
-        basic_auth_creds.return_value = (auth_client.id, auth_client.secret)
         pyramid_request.json_body = valid_payload
         user_signup_service.signup.return_value = factories.User(**valid_payload)
 
@@ -35,14 +33,12 @@ class TestCreate(object):
             'authority': 'weylandindustries.com',
         }
 
+    @pytest.mark.usefixtures('valid_auth')
     def test_signs_up_user(self,
-                           auth_client,
-                           basic_auth_creds,
                            factories,
                            pyramid_request,
                            user_signup_service,
                            valid_payload):
-        basic_auth_creds.return_value = (auth_client.id, auth_client.secret)
         pyramid_request.json_body = valid_payload
         user_signup_service.signup.return_value = factories.User(**valid_payload)
 
@@ -103,6 +99,11 @@ def basic_auth_creds(patch):
     basic_auth_creds = patch('h.views.api_users.basic_auth_creds')
     basic_auth_creds.return_value = None
     return basic_auth_creds
+
+
+@pytest.fixture
+def valid_auth(basic_auth_creds, auth_client):
+    basic_auth_creds.return_value = (auth_client.id, auth_client.secret)
 
 
 @pytest.fixture

--- a/tests/h/views/api_users_test.py
+++ b/tests/h/views/api_users_test.py
@@ -109,6 +109,17 @@ class TestCreate(object):
         with pytest.raises(ValidationError):
             create(pyramid_request)
 
+    @pytest.mark.usefixtures('valid_auth')
+    def test_raises_when_authority_doesnt_match(self, pyramid_request, valid_payload, auth_client):
+        payload = valid_payload
+        payload['authority'] = 'foo-%s' % auth_client.authority
+        pyramid_request.json_body = payload
+
+        with pytest.raises(ValidationError) as exc:
+            create(pyramid_request)
+
+        assert "'authority' does not match authenticated client" in str(exc.value)
+
     @pytest.fixture
     def schemas(self, patch):
         return patch('h.views.api_users.schemas')

--- a/tests/h/views/api_users_test.py
+++ b/tests/h/views/api_users_test.py
@@ -120,6 +120,46 @@ class TestCreate(object):
 
         assert "'authority' does not match authenticated client" in str(exc.value)
 
+    @pytest.mark.usefixtures('valid_auth')
+    def test_raises_when_username_taken(self,
+                                        pyramid_request,
+                                        valid_payload,
+                                        db_session,
+                                        factories,
+                                        auth_client):
+        existing_user = factories.User(authority=auth_client.authority)
+        db_session.add(existing_user)
+        db_session.flush()
+
+        payload = valid_payload
+        payload['username'] = existing_user.username
+        pyramid_request.json_body = payload
+
+        with pytest.raises(ValidationError) as exc:
+            create(pyramid_request)
+
+        assert ('username %s already exists' % existing_user.username) in str(exc.value)
+
+    @pytest.mark.usefixtures('valid_auth')
+    def test_raises_when_email_taken(self,
+                                     pyramid_request,
+                                     valid_payload,
+                                     db_session,
+                                     factories,
+                                     auth_client):
+        existing_user = factories.User(authority=auth_client.authority)
+        db_session.add(existing_user)
+        db_session.flush()
+
+        payload = valid_payload
+        payload['email'] = existing_user.email
+        pyramid_request.json_body = payload
+
+        with pytest.raises(ValidationError) as exc:
+            create(pyramid_request)
+
+        assert ('email address %s already exists' % existing_user.email) in str(exc.value)
+
     @pytest.fixture
     def schemas(self, patch):
         return patch('h.views.api_users.schemas')


### PR DESCRIPTION
~This depends on #4007 being merged and then needs a rebase.~

This PR adds validation of the `POST /api/users` endpoint. It first validates the structure of the JSON input according to the same schema as we publish in the documentation, that the passed-in `authority` is the same as the one of the authenticated client, and then also adds uniqueness validation (username/email within the same authority).
