### PR TITLE
Extract autosuggestion dropdown logic into a separate control

### DIFF
--- a/h/static/scripts/base/controller.js
+++ b/h/static/scripts/base/controller.js
@@ -34,7 +34,10 @@ class Controller {
    *        specific to that type of controller.
    */
   constructor(element, options = {}) {
-    if (!element.controllers) {
+
+    if (!element){
+      throw new Error('Controllers require an element passed to the constructor');
+    } else if (!element.controllers) {
       element.controllers = [this];
     } else {
       element.controllers.push(this);

--- a/h/static/scripts/controllers/autosuggest-dropdown-controller.js
+++ b/h/static/scripts/controllers/autosuggest-dropdown-controller.js
@@ -1,0 +1,442 @@
+'use strict';
+
+const Controller = require('../base/controller');
+const setElementState = require('../util/dom').setElementState;
+const updateHelper = require('../util/update-helpers.js');
+
+const ENTER = 13;
+const UP = 38;
+const DOWN = 40;
+
+/**
+ * Controller for adding autosuggest control to a piece of the page
+ */
+class AutosuggestDropdownController extends Controller {
+
+  /*
+   * @typedef {Object} ConfigOptions
+   * @property {Function} renderListItem - called with every item in the list
+   *   after the listFilter function is called. The return value will be the final
+   *   html that is set in the list item DOM.
+   * @property {Function} listFilter - called at initialization, focus of input,
+   *   and input changes made by user. The function will receieve the full list
+   *   and the current value of the input. This is meant to be an pure function
+   *   that will return a filtered list based on the consumer's domain needs.
+   * @properly {Function} onSelect - called once the user has made a selection of an
+   *   item in the autosuggest. It will receive the item selected as the only argument.
+   * @property {Object} [classNames] - this is the enumerated list of class name
+   *   overrides for consumers to customize the UI.
+   *   Possible values: { container, list, item, activeItem, header }
+   * @property {String} [header] - value of the header label at top of suggestions
+   */
+
+  /**
+   * @param {HTMLInputElement} inputElement that we are responding to in order to provide
+   *    suggestions. Note, we will add the suggestion container as a sibling to this
+   *    element.
+   * @param {ConfigOptions} configOptions are used to set the initial set of items and the header
+   *    as well as providing the hooks for updates and callbacks
+   *
+   */
+  constructor(inputElement, configOptions) {
+
+    super(inputElement, configOptions);
+
+    if (!configOptions.renderListItem){
+      throw new Error('Missing renderListItem callback in AutosuggestDropdownController constructor');
+    }
+
+    if (!configOptions.listFilter){
+      throw new Error('Missing listFilter function in AutosuggestDropdownController constructor');
+    }
+
+    if (!configOptions.onSelect){
+      throw new Error('Missing onSelect callback in AutosuggestDropdownController constructor');
+    }
+
+    // set up our element class attribute enum values
+    // Note, we currently are not doing anything with the default
+    // classes, but we have them if we wanted to give something for a default
+    // styling.
+    if (configOptions.classNames){
+      this.options.classNames.container = configOptions.classNames.container || 'autosuggest__container';
+      this.options.classNames.list = configOptions.classNames.list || 'autosuggest__list';
+      this.options.classNames.item = configOptions.classNames.item || 'autosuggest__list-item';
+      this.options.classNames.activeItem = configOptions.classNames.activeItem || 'autosuggest__list-item--active';
+      this.options.classNames.header = configOptions.classNames.header || 'autosuggest__header';
+    }
+
+    // renaming simply to make it more obvious what
+    // the element is in other contexts of the controller
+    this._input = this.element;
+
+    // initial state values
+    this.setState({
+      visible: false,
+      header: configOptions.header || '',
+
+      // working list that are displayed to use
+      list: [],
+
+      // rootList is the original set that the filter
+      // will receive to determine what should be shown
+      rootList: [],
+    });
+
+    this._setList(configOptions.list);
+  }
+
+  update(newState, prevState){
+
+    // if our prev state is empty then
+    // we assume that this is the first update/render call
+    if (!('visible' in prevState)){
+
+      // create the elements that make up the component
+      this._renderContentContainers();
+      this._addTopLevelEventListeners();
+    }
+
+    if (newState.visible !== prevState.visible){
+      // updates the dom to change the class which actually updates visibilty
+      setElementState(this._suggestionContainer, { open: newState.visible});
+    }
+
+    if (newState.header !== prevState.header){
+      this._header.innerHTML = newState.header;
+    }
+
+    let listChanged = updateHelper.listIsDifferent(newState.list, prevState.list);
+
+    if (listChanged){
+      this._renderListItems();
+    }
+
+    // list change detection is needed to persist the
+    // currently active elements over to the new list
+    if (newState.activeId !== prevState.activeId || listChanged){
+
+      let currentActive = this._getActiveListItemElement();
+
+      if (prevState.activeId && currentActive){
+        currentActive.classList.remove(this.options.classNames.activeItem);
+      }
+
+      if (newState.activeId && newState.list.find((item)=>item.__suggestionId === newState.activeId)){
+        this._listContainer
+          .querySelector(`[data-suggestion-id="${newState.activeId}"]`)
+          .classList.add(this.options.classNames.activeItem);
+      }
+    }
+  }
+
+  /**
+   * sets what would be the top header html
+   *  to give context of what the suggestions are for
+   *
+   * @param  {string} header Html to place in header. You can pass plain text
+   *  as well.
+   */
+  _setHeader(header){
+    this.setState({
+      header,
+    });
+  }
+
+  /**
+   * update the current list
+   *
+   * @param  {Array} list The new list.
+   */
+  _setList(list){
+
+    if (!Array.isArray(list)){
+      throw new TypeError('setList requires an array first argument');
+    }
+
+    this.setState({
+      rootList: list.map((item)=>{
+        return Object.assign({}, item, {
+          // create an id that lets us direction map
+          // selection to arbitrary item in list.
+          // This allows lists to pass more than just the required
+          // `name` property to know more about what the list item is
+          __suggestionId: Math.random().toString(36).substr(2, 5),
+        });
+      }),
+    });
+
+    this._filterListFromInput();
+  }
+
+  /**
+   * we will run the consumer's filter function
+   *  that is expected to be a pure function that will receive the
+   *  root list (the initial list or list made with setList) and
+   *  the input's current value. that function will return the array items,
+   *  filtered and sorted, that will be set the new working list state and
+   *  be rerendered.
+   */
+  _filterListFromInput(){
+    this.setState({
+      list: this.options.listFilter(this.state.rootList, this._input.value) || [],
+    });
+  }
+
+  /**
+   * hit the consumers filter function to determine
+   *   if we still have list items that need to be shown to the user.
+   */
+  _filterAndToggleVisibility(){
+    this._filterListFromInput();
+
+    this._toggleSuggestionsVisibility(/*show*/ this.state.list.length > 0);
+  }
+
+  /**
+   * lookup the active element, get item from
+   *  object from list that was passed in, and invoke the onSelect callback.
+   *  This is process to actually make a selection
+   */
+  _selectCurrentActiveItem(){
+
+    const currentActive = this._getActiveListItemElement();
+    const suggestionId = currentActive && currentActive.getAttribute('data-suggestion-id');
+    const selection = this.state.list.filter((item)=>{ return item.__suggestionId === suggestionId;})[0];
+
+    if (selection){
+      this.options.onSelect(selection);
+      this._toggleSuggestionsVisibility(/*show*/false);
+      this.setState({
+        activeId: null,
+      });
+    }
+  }
+
+  /**
+   * update the list item dom elements with
+   *  their "active" state when the user is hovering.
+   *
+   * @param  {bool} hovering are we hovering on the current element
+   * @param  {Event} event    event used to pull the list item being targeted
+   */
+  _toggleItemHoverState(hovering, event){
+
+    let currentActive = this._getActiveListItemElement();
+    let target = event.currentTarget;
+
+    if ( hovering && currentActive && currentActive.contains(target)){
+      return;
+    }
+
+    this.setState({
+      activeId: hovering ? target.getAttribute('data-suggestion-id') : null,
+    });
+  }
+
+  /**
+   * this function piggy backs on the setElementState
+   *  style of defining element state in its class. Used in combination with the
+   *  this.options.classNames.container the consumer has easy access to what the visibility state
+   *  of the container is.
+   *
+   * @param  {bool} show should we update the state to be visible or not
+   */
+  _toggleSuggestionsVisibility(show) {
+
+    // keeps the internal state synced with visibility
+    this.setState({
+      visible: !!show,
+    });
+  }
+
+  /**
+   * @returns {HTMLElement}  the active list item element
+   */
+  _getActiveListItemElement(){
+    return this._listContainer.querySelector('.' + this.options.classNames.activeItem);
+  }
+
+  /**
+   * navigate the list, toggling the active item,
+   *  based on the users arrow directions
+   *
+   * @param  {bool} down is the user navigating down the list?
+   */
+  _keyboardSelectionChange(down){
+
+    const currentActive = this._getActiveListItemElement();
+    let nextActive;
+
+    // we have a starting point, navigate on siblings of current
+    if (currentActive){
+
+      if (down){
+        nextActive = currentActive.nextSibling;
+      } else {
+        nextActive = currentActive.previousSibling;
+      }
+
+    // we have no starting point, let's navigate based on
+    // the directional expectation of what the first item would be
+    } else if (down){
+      nextActive = this._listContainer.firstChild;
+    } else {
+      nextActive = this._listContainer.lastChild;
+    }
+
+    this.setState({
+      activeId: nextActive ?  nextActive.getAttribute('data-suggestion-id') : null,
+    });
+  }
+
+  /**
+   * build the DOM structure that makes up
+   *  the suggestion box and content containers.
+   */
+  _renderContentContainers(){
+
+    // container of all suggestion elements
+    this._suggestionContainer = document.createElement('div');
+    this._suggestionContainer.classList.add(this.options.classNames.container);
+
+
+    // child elements that will be populated by consumer
+    this._header = document.createElement('h4');
+    this._header.classList.add(this.options.classNames.header);
+    this._setHeader(this.state.header);
+    this._suggestionContainer.appendChild(this._header);
+
+    this._listContainer = document.createElement('ul');
+    this._listContainer.classList.add(this.options.classNames.list);
+    this._suggestionContainer.appendChild(this._listContainer);
+
+    // put the suggestions adjacent to the input element
+    // firefox does not support insertAdjacentElement
+    if (HTMLElement.prototype.insertAdjacentElement){
+      this._input.insertAdjacentElement('afterend', this._suggestionContainer);
+    } else {
+      this._input.parentNode.insertBefore(this._suggestionContainer, this._input.nextSibling);
+    }
+  }
+
+  /**
+   * updates the content of the list container and builds
+   *  the new set of list items.
+   */
+  _renderListItems(){
+    // Create the new list items, render their contents
+    // and update the dom with the new elements.
+
+    this._listContainer.innerHTML = '';
+
+    this.state.list.forEach((listItem)=>{
+      let li = document.createElement('li');
+      li.classList.add(this.options.classNames.item);
+      li.setAttribute('data-suggestion-id', listItem.__suggestionId);
+
+      // this should use some sort of event delegation if
+      // we find we want to expand this to lists with *a lot* of items in it
+      // But for now this binding has no real affect on small list perf
+      li.addEventListener('mouseenter', this._toggleItemHoverState.bind(this, /*hovering*/true));
+      li.addEventListener('mouseleave', this._toggleItemHoverState.bind(this, /*hovering*/false));
+      li.addEventListener('mousedown', (event)=>{
+        // for situations like mobile, hovering might not be
+        // the first event to set the active state for an element
+        // so we will mimic that on mouse down and let selection happen
+        // at the top level event
+        this._toggleItemHoverState(/*hovering*/true, event);
+        this._selectCurrentActiveItem();
+      });
+
+      li.innerHTML = this.options.renderListItem(listItem);
+
+      this._listContainer.appendChild(li);
+    });
+  }
+
+  /**
+   * The events that can be set on a "global" or top
+   *  level scope, we are going to set them here.
+   */
+  _addTopLevelEventListeners(){
+
+    // we need to use mousedown instead of click
+    // so we can beat the blur event which can
+    // change visibility/target of the active event
+    document.addEventListener('mousedown', (event)=>{
+
+      const target = event.target;
+
+      // when clicking the input itself or if we are
+      // or a global click was made while we were not visible
+      // do nothing
+      if (!this.state.visible || target === this._input){
+        return;
+      }
+
+      // see if inside interaction areas
+      if (this._suggestionContainer.contains(target)){
+
+        event.preventDefault();
+        event.stopPropagation();
+      }
+
+      // not in an interaction area, so we assume they
+      // want it to go away.
+      this._toggleSuggestionsVisibility(/*show*/ false);
+    });
+
+    // Note, keydown needed here to properly prevent the default
+    // nature of navigating keystrokes - like DOWN ARROW at the end of an
+    // input takes the cursor to the beginning of the input value.
+    this._input.addEventListener('keydown', (event)=>{
+
+      const key = event.keyCode;
+
+      // only consume the ENTER event if
+      // we have an active item
+      if (key === ENTER && !this._getActiveListItemElement()){
+        return;
+      }
+
+      // these keys are going to be consumed and not propagated
+      if ([ENTER, UP, DOWN].indexOf(key) > -1){
+
+        if (key === ENTER){
+          this._selectCurrentActiveItem();
+        } else {
+          this._keyboardSelectionChange(/*down*/key === DOWN);
+        }
+
+        event.preventDefault();
+        event.stopPropagation();
+        event.stopImmediatePropagation();
+      }
+
+      // capture phase needed to beat any other listener that could
+      // stop propagation after inspecting input value
+    }, /*useCapturePhase*/ true);
+
+    this._input.addEventListener('keyup', (event)=>{
+
+      if ([ENTER, UP, DOWN].indexOf(event.keyCode) === -1){
+        this._filterAndToggleVisibility();
+      }
+
+      // capture phase needed to beat any other listener that could
+      // stop propagation after inspecting input value
+    }, /*useCapturePhase*/ true);
+
+    this._input.addEventListener('focus', ()=>{
+      this._filterAndToggleVisibility();
+    });
+
+    this._input.addEventListener('blur', ()=>{
+      this._toggleSuggestionsVisibility(/*show*/false);
+    });
+
+  }
+}
+
+module.exports = AutosuggestDropdownController;

--- a/h/static/scripts/tests/controllers/autosuggest-dropdown-controller-test.js
+++ b/h/static/scripts/tests/controllers/autosuggest-dropdown-controller-test.js
@@ -1,0 +1,415 @@
+'use strict';
+
+const syn = require('syn');
+const unroll = require('../util').unroll;
+
+
+const AutosuggestDropdownController = require('../../controllers/autosuggest-dropdown-controller');
+
+
+// syn's move functionality does not fire
+// mouseenter and mouseleave events.
+const mouseMove = (()=>{
+
+  let _lastMovePos;
+
+  return (posObj) => {
+
+    if (_lastMovePos){
+      const prevEl = document.elementFromPoint(_lastMovePos.pageX, _lastMovePos.pageY);
+      const leaveEvent = document.createEvent( 'Events' );
+      leaveEvent.initEvent( 'mouseleave', true, false );
+      prevEl.dispatchEvent( leaveEvent );
+    }
+
+    _lastMovePos = posObj;
+
+    const el = document.elementFromPoint(posObj.pageX, posObj.pageY);
+    const enterEevent = document.createEvent( 'Events' );
+    enterEevent.initEvent( 'mouseenter', true, false );
+    el.dispatchEvent( enterEevent );
+  };
+})();
+
+
+function center(element) {
+  const rect = element.getBoundingClientRect();
+  return {
+    pageX: rect.left + (rect.width / 2),
+    pageY: rect.top + (rect.height / 2),
+  };
+}
+
+
+describe('AutosuggestDropdownController', function () {
+
+  describe('provides suggestions', function(){
+    let container;
+    let input;
+    let form;
+
+    let defaultConfig = {
+      list: [
+        {
+          title: 'user:',
+          explanation: 'search by username',
+        },
+        {
+          title: 'tag:',
+          explanation: 'search for annotations with a tag',
+        },
+        {
+          title: 'url:',
+          explanation: 'see all annotations on a page',
+        },
+        {
+          title: 'group:',
+          explanation: 'show annotations created in a group you are a member of',
+        },
+      ],
+
+      header: 'Some awesome header value',
+
+      classNames: {
+        container: 'the-container',
+        header: 'the-header',
+        list: 'the-list',
+        item: 'an-item',
+        activeItem: 'an-active-item',
+      },
+
+      renderListItem: (listItem)=>{
+
+        let itemContents = `<span class="a-title"> ${listItem.title} </span>`;
+
+        if (listItem.explanation){
+          itemContents += `<span class="an-explanation"> ${listItem.explanation} </span>`;
+        }
+
+        return itemContents;
+      },
+
+      listFilter: function(list, currentInput){
+
+
+        currentInput = (currentInput || '').trim();
+
+        return list.filter((item)=>{
+
+          if (!currentInput){
+            return item;
+          }
+          return item.title.toLowerCase().indexOf(currentInput) >= 0;
+        });
+      },
+
+      onSelect: function(){},
+    };
+
+    const isSuggestionContainerVisible = ()=>{
+      const suggestionContainer = container.querySelector('.' + defaultConfig.classNames.container);
+      return suggestionContainer.classList.contains('is-open');
+    };
+
+    const getListItems = ()=>{
+      const suggestionContainer = container.querySelector('.' + defaultConfig.classNames.container);
+      return suggestionContainer.querySelectorAll('.' + defaultConfig.classNames.item);
+    };
+
+    const getCurrentActiveElements = ()=>{
+      const list = container.querySelector('.' + defaultConfig.classNames.list);
+      return list.querySelectorAll('.' + defaultConfig.classNames.activeItem);
+    };
+
+    beforeEach(function () {
+      container = document.createElement('div');
+      container.innerHTML = '<form><input id="input-el"/></form>';
+      document.body.appendChild(container);
+      input = document.getElementById('input-el');
+      form = container.querySelector('form');
+      form.onsubmit = sinon.spy();
+    });
+
+    afterEach(function () {
+      document.body.removeChild(container);
+
+      // clear up spies
+      if ('restore' in defaultConfig.listFilter){
+        defaultConfig.listFilter.restore();
+      }
+
+      if ('restore' in defaultConfig.onSelect){
+        defaultConfig.onSelect.restore();
+      }
+    });
+
+
+    it('should initialize the controller with correct dom', function(){
+
+      assert.isTrue(form.childNodes.length === 1, 'baseline');
+
+      new AutosuggestDropdownController(input, defaultConfig);
+
+      assert.isFalse(form.childNodes.length === 1, 'initializing should add container to dom');
+
+      const suggestionContainer = container.querySelector('.' + defaultConfig.classNames.container);
+
+      assert.isOk(suggestionContainer);
+      assert.isOk(suggestionContainer.querySelector('.' + defaultConfig.classNames.header));
+      assert.isOk(suggestionContainer.querySelector('.' + defaultConfig.classNames.list));
+      assert.lengthOf(getListItems(), 4);
+
+      assert.lengthOf(suggestionContainer.querySelectorAll('.a-title'), 4, 'reflects our rendering');
+      assert.lengthOf(suggestionContainer.querySelectorAll('.an-explanation'), 4, 'reflects our rendering');
+
+    });
+
+
+    it('opens and closes based on focus status', function (done) {
+
+      new AutosuggestDropdownController(input, defaultConfig);
+
+      assert.isFalse(isSuggestionContainerVisible(), 'basline is hidden');
+
+      syn
+        .click(input, () => {
+
+          assert.isTrue(isSuggestionContainerVisible(), 'focus should show');
+
+          syn
+            .click(document.body, () => {
+              assert.isFalse(isSuggestionContainerVisible(), 'blur should hide');
+              done();
+            });
+        });
+    });
+
+
+    it('changes suggestion container and item visibility on matching input', function(done){
+
+      const reduceSpy = sinon.spy(defaultConfig, 'listFilter');
+
+      assert.equal(reduceSpy.callCount, 0);
+
+      new AutosuggestDropdownController(input, defaultConfig);
+
+      assert.equal(reduceSpy.callCount, 1, 'gets initial reduced list on initialize');
+
+      assert.lengthOf(getListItems(), 4);
+
+      syn
+        .click(input, () => {
+          assert.equal(reduceSpy.callCount, 2, 'reduces on focus');
+          assert.isTrue(isSuggestionContainerVisible(), 'focus show');
+        })
+        .type('u', () => {
+
+          assert.lengthOf(getListItems(), 3);
+          assert.equal(reduceSpy.callCount, 3, 'reduces on input');
+        })
+        .type('r', () => {
+
+          assert.lengthOf(getListItems(), 1);
+          assert.equal(reduceSpy.callCount, 4, 'reduces on input');
+
+          assert.isTrue(isSuggestionContainerVisible(), 'still showing');
+        })
+        .type('x', () => {
+
+          assert.lengthOf(getListItems(), 0);
+          assert.equal(reduceSpy.callCount, 5, 'reduces on input');
+
+          assert.isFalse(isSuggestionContainerVisible(), 'no match hide');
+
+        })
+
+        // backspace
+        .type('\b', () => {
+
+          assert.lengthOf(getListItems(), 1);
+          assert.equal(reduceSpy.callCount, 6, 'reduces on input');
+
+          assert.isTrue(isSuggestionContainerVisible(), 're match show');
+
+          done();
+        });
+
+    });
+
+    it('allows click selection', function(done){
+      const onSelectSpy = sinon.spy(defaultConfig, 'onSelect');
+
+      assert.equal(onSelectSpy.callCount, 0);
+
+      new AutosuggestDropdownController(input, defaultConfig);
+
+      syn
+        .click(input)
+        .type('t', () => {
+
+          const items = getListItems();
+
+          assert.lengthOf(items, 1);
+
+          assert.isTrue(isSuggestionContainerVisible(), 'pre select show');
+
+          syn
+            .click(items[0], ()=>{
+
+              assert.equal(onSelectSpy.callCount, 1);
+
+              const selectedItem = onSelectSpy.args[0][0];
+
+              assert.propertyVal(selectedItem, 'title', 'tag:');
+              assert.propertyVal(selectedItem, 'explanation', 'search for annotations with a tag');
+
+              assert.isFalse(isSuggestionContainerVisible(), 'post select hide');
+
+              done();
+            });
+        });
+    });
+
+    var navigationExpectations = [
+      { travel: '[down]', selectedIndex: 0 },
+      { travel: '[up]', selectedIndex: 3 },
+      { travel: '[down][up]', selectedIndex: -1 },
+      { travel: '[up][down]', selectedIndex: -1 },
+      { travel: '[down][down][down][down]', selectedIndex: 3 },
+      { travel: '[down][down][down][down][down]', selectedIndex: -1 },
+      { travel: '[up][up][up][up]', selectedIndex: 0 },
+      { travel: '[up][up][up][up][up]', selectedIndex: -1 },
+      { travel: '[up][down][up][down][down][down][down][up]', selectedIndex: 1 },
+    ];
+
+    unroll('allows keyboard navigation', function(done, fixture){
+
+      new AutosuggestDropdownController(input, defaultConfig);
+
+      const list = container.querySelector('.' + defaultConfig.classNames.list);
+
+      syn
+        .click(input)
+        .type(fixture.travel, () => {
+          var active = getCurrentActiveElements();
+          if (fixture.selectedIndex === -1){
+            assert.lengthOf(active, 0);
+          } else {
+            assert.isTrue(list.childNodes[fixture.selectedIndex].classList.contains(defaultConfig.classNames.activeItem));
+            assert.lengthOf(active, 1);
+          }
+          done();
+        });
+    }, navigationExpectations);
+
+
+    it('persists active navigation through list filter', function(done){
+      new AutosuggestDropdownController(input, defaultConfig);
+
+      const list = container.querySelector('.' + defaultConfig.classNames.list);
+      syn
+        .click(input)
+        .type('[down][down]', () => {
+          assert.isTrue(list.childNodes[1].classList.contains(defaultConfig.classNames.activeItem));
+          assert.equal(list.childNodes[1].querySelector('.a-title').textContent.trim(),
+            defaultConfig.list[1].title);
+        })
+        .type('t', () => {
+
+          assert.isTrue(list.childNodes[0].classList.contains(defaultConfig.classNames.activeItem));
+          assert.equal(list.childNodes[0].querySelector('.a-title').textContent.trim(),
+            defaultConfig.list[1].title);
+          done();
+        });
+    });
+
+    it('allows keyboard selection', function(done){
+      const onSelectSpy = sinon.spy(defaultConfig, 'onSelect');
+
+      assert.equal(onSelectSpy.callCount, 0);
+
+      new AutosuggestDropdownController(input, defaultConfig);
+
+      syn
+        .click(input)
+        .type('[down][down][enter]', () => {
+
+          assert.equal(onSelectSpy.callCount, 1);
+
+          const selectedItem = onSelectSpy.args[0][0];
+
+          assert.propertyVal(selectedItem, 'title', 'tag:');
+          assert.propertyVal(selectedItem, 'explanation', 'search for annotations with a tag');
+
+          assert.isFalse(isSuggestionContainerVisible(), 'post select hide');
+
+          assert.isFalse(form.onsubmit.called, 'should not submit the form on enter');
+
+          done();
+        });
+    });
+
+    it('can hover items', function(done){
+
+      new AutosuggestDropdownController(input, defaultConfig);
+
+      const list = container.querySelector('.' + defaultConfig.classNames.list);
+
+      syn
+        .click(input, ()=>{
+
+          mouseMove(center(list.childNodes[1]));
+
+          assert.lengthOf(getCurrentActiveElements(), 1);
+          assert.isTrue(list.childNodes[1].classList.contains(defaultConfig.classNames.activeItem));
+
+
+          mouseMove(center(list.childNodes[2]));
+
+          assert.lengthOf(getCurrentActiveElements(), 1);
+          assert.isTrue(list.childNodes[2].classList.contains(defaultConfig.classNames.activeItem));
+
+          mouseMove(center(input));
+          assert.lengthOf(getCurrentActiveElements(), 0);
+
+          done();
+
+        });
+
+    });
+
+    it('correctly sets active elements when swapping between keyboard and mouse setting', function(done){
+
+      new AutosuggestDropdownController(input, defaultConfig);
+
+      const list = container.querySelector('.' + defaultConfig.classNames.list);
+
+      syn
+        .click(input, ()=>{
+
+          mouseMove(center(list.childNodes[2]));
+
+          assert.lengthOf(getCurrentActiveElements(), 1);
+          assert.isTrue(list.childNodes[2].classList.contains(defaultConfig.classNames.activeItem));
+
+        })
+        .type('[down]', ()=>{
+          assert.lengthOf(getCurrentActiveElements(), 1);
+          assert.isTrue(list.childNodes[3].classList.contains(defaultConfig.classNames.activeItem));
+        })
+        .type('[up][up][up]', ()=>{
+          assert.lengthOf(getCurrentActiveElements(), 1);
+          assert.isTrue(list.childNodes[0].classList.contains(defaultConfig.classNames.activeItem));
+
+
+          mouseMove(center(list.childNodes[2]));
+
+          assert.lengthOf(getCurrentActiveElements(), 1);
+          assert.isTrue(list.childNodes[2].classList.contains(defaultConfig.classNames.activeItem));
+
+          done();
+        });
+    });
+
+  });
+});

--- a/h/static/scripts/tests/controllers/dropdown-menu-controller-test.js
+++ b/h/static/scripts/tests/controllers/dropdown-menu-controller-test.js
@@ -4,9 +4,9 @@ var DropdownMenuController = require('../../controllers/dropdown-menu-controller
 var util = require('./util');
 
 var TEMPLATE = ['<div class="js-dropdown-menu">',
-                '<span data-ref="dropdownMenuToggle">Toggle</span>',
-                '<span data-ref="dropdownMenuContent">Menu</span>',
-                '</div>'].join('\n');
+  '<span data-ref="dropdownMenuToggle">Toggle</span>',
+  '<span data-ref="dropdownMenuContent">Menu</span>',
+  '</div>'].join('\n');
 
 describe('DropdownMenuController', function () {
   var ctrl;

--- a/h/static/scripts/tests/controllers/search-bar-controller-test.js
+++ b/h/static/scripts/tests/controllers/search-bar-controller-test.js
@@ -5,56 +5,18 @@ var util = require('./util');
 
 var SearchBarController = require('../../controllers/search-bar-controller');
 
-function center(element) {
-  let rect = element.getBoundingClientRect();
-  return {
-    pageX: rect.left + (rect.width / 2),
-    pageY: rect.top + (rect.height / 2),
-  };
-}
-
-function isActiveItem(element) {
-  return element.classList.contains('js-search-bar-dropdown-menu-item--active');
-}
 
 describe('SearchBarController', function () {
-  describe('Dropdown', function () {
+  describe('Autosuggest', function () {
     var testEl;
     var input;
     var dropdown;
-    var dropdownItems;
     var ctrl;
-    var form;
     var TEMPLATE = `
       <form data-ref="searchBarForm">
         <div class="search-bar__lozenges" data-ref="searchBarLozenges">
         </div>
         <input data-ref="searchBarInput" class="search-bar__input" name="q" />
-        <div data-ref="searchBarDropdown">
-          <div>Narrow your search</div>
-          <ul>
-            <li data-ref="searchBarDropdownItem">
-              <span data-ref="searchBarDropdownItemTitle">
-                user:
-              </span>
-            </li>
-            <li data-ref="searchBarDropdownItem">
-              <span data-ref="searchBarDropdownItemTitle">
-                tag:
-              </span>
-            </li>
-            <li data-ref="searchBarDropdownItem">
-              <span data-ref="searchBarDropdownItemTitle">
-                url:
-              </span>
-            </li>
-            <li data-ref="searchBarDropdownItem">
-              <span data-ref="searchBarDropdownItemTitle">
-                group:
-              </span>
-            </li>
-          </ul>
-        </div>
       </form>
     `;
 
@@ -66,188 +28,59 @@ describe('SearchBarController', function () {
       ctrl = new SearchBarController(testEl);
 
       input = ctrl.refs.searchBarInput;
-      dropdown = ctrl.refs.searchBarDropdown;
-      dropdownItems = testEl.querySelectorAll('[data-ref="searchBarDropdownItem"]');
-      form = testEl.querySelector('form');
-
-      form.addEventListener('submit', event => { event.preventDefault(); });
+      dropdown = input.nextSibling;
     });
 
     afterEach(function () {
       document.body.removeChild(testEl);
     });
 
-    it('dropdown appears when the input field has focus', function (done) {
+    it('uses autosuggestion for initial facets', function (done) {
+
+      assert.isFalse(dropdown.classList.contains('is-open'));
+
       syn
         .click(input, () => {
           assert.isTrue(dropdown.classList.contains('is-open'));
+
+          let titles = Array.from(document.querySelectorAll('.search-bar__dropdown-menu-title')).map((node)=>{
+            return node.textContent.trim();
+          });
+
+          assert.deepEqual(titles, ['user:', 'tag:', 'url:', 'group:']);
+
           done();
         });
     });
 
-    it('dropdown is hidden when the input field loses focus', function (done) {
+    it('it filters and updates input with autosuggested facet selection', function (done) {
       syn
-        .click(input)
-        .click(document.body, () => {
-          assert.isFalse(dropdown.classList.contains('is-open'));
-          done();
-        });
-    });
-
-    it('selects facet from dropdown on mousedown', function (done) {
-      syn
-        .click(input)
-        .click(dropdownItems[0], () => {
-          assert.equal(input.value, 'user:');
-          done();
-        });
-    });
-
-    it('highlights facet on up arrow', function (done) {
-      syn
-        .click(input)
-        .type('[up]', () => {
-          assert.isOk(isActiveItem(dropdownItems[3]));
-          done();
-        });
-    });
-
-    it('highlights facet on down arrow', function (done) {
-      syn
-        .click(input)
-        .type('[down]', () => {
-          assert.isOk(isActiveItem(dropdownItems[0]));
-          done();
-        });
-    });
-
-    it('highlights the correct facet for a combination of mouseover, up and down arrow keys', function (done) {
-      let itemThreeCenter = center(dropdownItems[2]);
-      syn
-        .click(input)
-        // Down arrow to select first item
-        .type('[down]', () => {
-          assert.isOk(isActiveItem(dropdownItems[0]));
+        .click(input, ()=>{
+          assert.notOk(input.value, 'baseline no value in input');
         })
-        // Move mouse from input to the middle of the third item.
-        .move({
-          from: center(input),
-          to: itemThreeCenter,
-          duration: 100,
-        }, () => {
-          assert.isNotOk(isActiveItem(dropdownItems[0]));
-          assert.isOk(isActiveItem(dropdownItems[2]));
-        })
-        // Up arrow to select second item.
-        .type('[up]', () => {
-          assert.isNotOk(isActiveItem(dropdownItems[2]));
-          assert.isOk(isActiveItem(dropdownItems[1]));
-        })
-        // Jiggle the mouse just a little over the third item.
-        .move({
-          from: itemThreeCenter,
-          to: {
-            pageX: itemThreeCenter.pageX + 1,
-            pageY: itemThreeCenter.pageY + 1,
-          },
-          duration: 10,
-        }, () => {
-          assert.isNotOk(isActiveItem(dropdownItems[1]));
-          assert.isOk(isActiveItem(dropdownItems[2]));
-        })
-        // Down arrow to select the fourth item.
-        .type('[down]', () => {
-          assert.isNotOk(isActiveItem(dropdownItems[2]));
-          assert.isOk(isActiveItem(dropdownItems[3]));
+        .type('r[down][enter]', ()=>{
+          assert.equal(input.value, 'url:');
           done();
         });
     });
 
-    it('selects facet on enter', function (done) {
-      syn
-        .click(input)
-        .type('[down][enter]', () => {
-          assert.equal(input.value, 'user:');
-          done();
-        });
-    });
 
-    it('dropdown stays open when clicking on a part of it that is not one of the suggestions', function (done) {
+    it('allows submitting the form dropdown is open but has no selected value', function (done) {
+      let form = testEl.querySelector('form');
+      let submit = sinon.stub(form, 'submit');
+      
       syn
         .click(input)
-        .click(dropdown.querySelector('div'), () => {
+        .type('test[space]', () => {
           assert.isTrue(dropdown.classList.contains('is-open'));
-          done();
-        });
-    });
-
-    it('search options narrow as input changes', function (done) {
-      syn
-        .click(input)
-        .type('g', () => {
-          assert.isTrue(dropdownItems[0].classList.contains('is-hidden'));
-          assert.isFalse(dropdownItems[1].classList.contains('is-hidden'));
-          assert.isTrue(dropdownItems[2].classList.contains('is-hidden'));
-          assert.isFalse(dropdownItems[3].classList.contains('is-hidden'));
-          done();
-        });
-    });
-
-    it('highlights the correct facet from narrowed dropdown items on up and down arrow keys', function (done) {
-      syn
-        .click(input)
-        .type('g[down]', () => {
-          assert.isOk(isActiveItem(dropdownItems[1]));
         })
-        .type('[up]', () => {
-          assert.isNotOk(isActiveItem(dropdownItems[1]));
-          assert.isOk(isActiveItem(dropdownItems[3]));
-          done();
-        });
-    });
-
-    it('dropdown closes when user types ":"', function (done) {
-      syn
-        .click(input)
-        .type(':', () => {
-          assert.isFalse(dropdown.classList.contains('is-open'));
-          done();
-        });
-    });
-
-    it('dropdown closes when there are no matches', function (done) {
-      syn
-        .click(input)
-        .type('x', () => {
-          assert.isFalse(dropdown.classList.contains('is-open'));
-          done();
-        });
-    });
-
-    it('does not submit the form when a dropdown element is selected', function (done) {
-      let submitted = false;
-      form.addEventListener('submit', () => {
-        submitted = true;
-      });
-
-      syn
-        .click(input)
-        .type('[down][enter]', () => {
-          assert.isFalse(submitted);
-          done();
-        });
-    });
-
-    it('allows submitting the form when query is empty and no dropdown element is selected', function (done) {
-      var submit = sinon.stub(form, 'submit');
-
-      syn
-        .click(input)
         .type('[enter]', () => {
+          assert.equal(testEl.querySelector('input[type=hidden]').value, 'test ');
           assert.isTrue(submit.calledOnce);
           done();
         });
     });
+
   });
 
   describe('Lozenges', function () {
@@ -271,7 +104,6 @@ describe('SearchBarController', function () {
         <form>
           <div class="search-bar__lozenges" data-ref="searchBarLozenges"></div>
           <input data-ref="searchBarInput" class="search-bar__input" name="q" value="${value}">
-          <div data-ref="searchBarDropdown"></div>
         </form>
       `.trim();
 

--- a/h/static/scripts/util/update-helpers.js
+++ b/h/static/scripts/util/update-helpers.js
@@ -1,0 +1,27 @@
+'use strict';
+
+module.exports = {
+
+  /**
+   * compare two list arrays and decide if they have changed
+   *
+   * @param  {Array} listA
+   * @param  {Array} listB
+   * @returns {bool}       the result of comparing if the two
+   *   arrays seem like they have changed. True if they have changed
+   */
+  listIsDifferent: function(listA, listB){
+
+    if (!(Array.isArray(listA) && Array.isArray(listB))){
+      return true;
+    }
+
+    if (listA.length !== listB.length){
+      return true;
+    }
+
+    return !listA.every((item, index)=>{
+      return item === listB[index];
+    });
+  },
+};

--- a/h/static/styles/partials-v2/_search-bar.scss
+++ b/h/static/styles/partials-v2/_search-bar.scss
@@ -6,6 +6,9 @@
   border: 1px solid $grey-3;
   border-radius: 2px;
   display: flex;
+
+  // scope absolute positioned elements
+  position: relative;
 }
 
 .search-bar__input {
@@ -60,7 +63,8 @@
   display: none;
   padding: 20px 0 0 0;
   position: absolute;
-  margin-top: 52px;
+  top: 52px;
+  left: 0;
   width: 100%;
   z-index: $zindex-dropdown-menu;
   max-width: 650px;
@@ -72,7 +76,7 @@
 
 .search-bar__dropdown-menu-item {
   padding: 6px 30px 6px 30px;
-  cursor: default;
+  cursor: pointer;
 }
 
 .search-bar__dropdown-menu-item:last-child {

--- a/h/templates/panels/navbar.html.jinja2
+++ b/h/templates/panels/navbar.html.jinja2
@@ -1,48 +1,5 @@
 {% from '../includes/dropdown_menu.html.jinja2' import dropdown_menu %}
 
-{# Dropdown displaying search facet options. #}
-{% macro search_bar_dropdown() %}
-<div class="search-bar__dropdown-menu-container" data-ref="searchBarDropdown">
-  <h4 class="search-bar__dropdown-menu-header">
-    Narrow your search
-  </h4>
-  <ul class="search-bar__dropdown-menu">
-    <li class="search-bar__dropdown-menu-item" data-ref="searchBarDropdownItem">
-      <span class="search-bar__dropdown-menu-title" data-ref="searchBarDropdownItemTitle">
-        user:
-      </span>
-      <span class="search-bar__dropdown-menu-explanation">
-        search by username
-      </span>
-    </li>
-    <li class="search-bar__dropdown-menu-item" data-ref="searchBarDropdownItem">
-      <span class="search-bar__dropdown-menu-title" data-ref="searchBarDropdownItemTitle">
-        tag:
-      </span>
-      <span class="search-bar__dropdown-menu-explanation">
-        search for annotations with a tag
-      </span>
-    </li>
-    <li class="search-bar__dropdown-menu-item" data-ref="searchBarDropdownItem">
-      <span class="search-bar__dropdown-menu-title" data-ref="searchBarDropdownItemTitle">
-        url:
-      </span>
-      <span class="search-bar__dropdown-menu-explanation">
-        see all annotations on a page
-      </span>
-    </li>
-    <li class="search-bar__dropdown-menu-item" data-ref="searchBarDropdownItem">
-      <span class="search-bar__dropdown-menu-title" data-ref="searchBarDropdownItemTitle">
-        group:
-      </span>
-      <span class="search-bar__dropdown-menu-explanation">
-        show annotations created in a group you are a member of
-      </span>
-    </li>
-  </ul>
-</div>
-{% endmacro %}
-
 {% block content %}
 {% if feature('activity_pages') %}
 <header class="nav-bar">
@@ -58,7 +15,6 @@
         {{ svg_icon('search', 'search-bar__icon') }}
         <div class="search-bar__lozenges" data-ref="searchBarLozenges"></div>
         <input class="search-bar__input" data-ref="searchBarInput" name="q" value="{{ q }}" placeholder="Search…" autocomplete="off">
-        {{ search_bar_dropdown() }}
       </form>
     </div>
 


### PR DESCRIPTION
The first commit pulls out the requirements that we need for a reusable suggestion component into its own controller and uses that component on the searchbar controller.

The thought behind the architecture is that it should be reusable for any future need of an autosuggestion feature (which is really common to need this in many places). It's worth noting that I made it reusable enough to scale well without making too many assumptions about the usage of the component. For example, the component offers a way to add the list and a way for the consumer to decide how the list should be reduced on interaction with the input. This means that there are no data structure limitations on the list items or how it can be filtered.

Also, you will see there is no default styling for the autosuggest controller elements. Once we have more than one use of the component, we can extract the reusable styles into a default set of styling for the components - once we have the pattern we want to reflect.

I tested pretty thoroughly in unit tests and in smoke tests in various browsers. You will see that I have a few fixes for regression bugs from previous master commits in here as well.

also: Fixes #3992 
