### PR TITLE
Ensure that API token exchange happens within the same authority

### DIFF
--- a/h/auth/services.py
+++ b/h/auth/services.py
@@ -181,6 +181,10 @@ class OAuthService(object):
             raise OAuthTokenError('user with userid described in subject could not be found',
                                   'invalid_grant')
 
+        if user.authority != authclient.authority:
+            raise OAuthTokenError('authenticated client and JWT subject authorities do not match',
+                                  'invalid_grant')
+
         return (user, authclient)
 
     def create_token(self, user, authclient):


### PR DESCRIPTION
The authenticated authclient's authority has to match with the users
authority for the JWT grant token exchange to work.

This was a bug @seanh found when reviewing #3983.

Fixes #3999.