### PR TITLE
Lint frontend code via a Travis job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,13 @@ matrix:
       node_js: '6.2'
       before_install: npm install gulp-cli
       script: gulp test
+
+    # Lint frontend code
+    - env: ACTION=frontend-lint
+      language: node_js
+      node_js: '6.2'
+      script: gulp lint
+
 cache:
   directories:
     - node_modules

--- a/h/static/scripts/tests/controllers/dropdown-menu-controller-test.js
+++ b/h/static/scripts/tests/controllers/dropdown-menu-controller-test.js
@@ -3,10 +3,12 @@
 var DropdownMenuController = require('../../controllers/dropdown-menu-controller');
 var util = require('./util');
 
-var TEMPLATE = ['<div class="js-dropdown-menu">',
+var TEMPLATE = [
+  '<div class="js-dropdown-menu">',
   '<span data-ref="dropdownMenuToggle">Toggle</span>',
   '<span data-ref="dropdownMenuContent">Menu</span>',
-  '</div>'].join('\n');
+  '</div>',
+].join('\n');
 
 describe('DropdownMenuController', function () {
   var ctrl;

--- a/h/static/scripts/util/search-text-parser.js
+++ b/h/static/scripts/util/search-text-parser.js
@@ -101,13 +101,11 @@ function getLozengeValues(queryString) {
         inputTerms = '';
         quoted = false;
       }
+    } else if (shouldLozengify(term)) {
+      queryTerms.push(term);
     } else {
-      if (shouldLozengify(term)) {
-        queryTerms.push(term);
-      } else {
-        inputTerms = term;
-        quoted = true;
-      }
+      inputTerms = term;
+      quoted = true;
     }
   });
   return {


### PR DESCRIPTION
This adds a separate job to the Travis build matrix which lints the frontend code, following the same approach that we use for the client repository.

Why Travis instead of Hound etc? It allows us to run arbitrary tasks/configs during the lint, it has proven reliable in the client repo and it doesn't add additional infrastructure to worry about. Furthermore it is more obvious what versions of tools are being used and how developers can run the same lint tasks locally.

Since our codebase is lint clean (after a couple of fixes in the second commit in this PR), the task runs on all frontend code. If we add new lint rules in future, we can configure the task to only run on code that changed in the branch, or we can enable new lint rules on a per directory basis, or we can do what we did in the client repo and fix all existing instances of an issue when a new rule is added.