### PR TITLE
First version of group search page sidebar

### DIFF
--- a/h/static/scripts/controllers/confirm-submit-controller.js
+++ b/h/static/scripts/controllers/confirm-submit-controller.js
@@ -1,0 +1,28 @@
+'use strict';
+
+var Controller = require('../base/controller');
+
+/* Turn a normal submit element into one that shows a confirm dialog.
+ *
+ * The element's form will only be submitted if the user answers the
+ * confirmation dialog positively.
+ *
+ */
+class ConfirmSubmitController extends Controller {
+  constructor(element, options) {
+    super(element);
+
+    var window_ = options.window || window;
+
+    element.addEventListener('click', (event) => {
+      if (!window_.confirm(element.dataset.confirmMessage)) {
+        event.preventDefault();
+        event.stopPropagation();
+        event.stopImmediatePropagation();
+        return;
+      }
+    }, /*capture*/ true);
+  }
+}
+
+module.exports = ConfirmSubmitController;

--- a/h/static/scripts/site.js
+++ b/h/static/scripts/site.js
@@ -10,6 +10,7 @@ require('./polyfills');
 
 var CharacterLimitController = require('./controllers/character-limit-controller');
 var CopyButtonController = require('./controllers/copy-button-controller');
+var ConfirmSubmitController = require('./controllers/confirm-submit-controller');
 var CreateGroupFormController = require('./controllers/create-group-form-controller');
 var DropdownMenuController = require('./controllers/dropdown-menu-controller');
 var FormController = require('./controllers/form-controller');
@@ -23,6 +24,7 @@ var upgradeElements = require('./base/upgrade-elements');
 var controllers = {
   '.js-character-limit': CharacterLimitController,
   '.js-copy-button': CopyButtonController,
+  '.js-confirm-submit': ConfirmSubmitController,
   '.js-create-group-form': CreateGroupFormController,
   '.js-dropdown-menu': DropdownMenuController,
   '.js-form': FormController,

--- a/h/static/scripts/tests/controllers/confirm-submit-controller-test.js
+++ b/h/static/scripts/tests/controllers/confirm-submit-controller-test.js
@@ -1,0 +1,83 @@
+'use strict';
+
+var ConfirmSubmitController = require('../../controllers/confirm-submit-controller');
+var util = require('./util');
+
+describe('ConfirmSubmitController', function () {
+
+  var ctrl;
+
+  afterEach(function () {
+    if (ctrl) {
+      ctrl.element.remove();
+      ctrl = null;
+    }
+  });
+
+  /**
+   * Make a <button type="submit"> with the confirm submit controller
+   * enhancement applied and return the various parts of the component.
+   *
+   */
+  function component(windowConfirmReturnValue) {
+    var confirmMessage = "Are you sure you want to leave the group 'Test Group'?";
+    var template = `<button type="submit"
+      class="js-confirm-submit"
+      data-confirm-message="${confirmMessage}">
+    `;
+
+    var fakeWindow = {
+      confirm: sinon.stub().returns(windowConfirmReturnValue),
+    };
+
+    ctrl = util.setupComponent(document,
+                               template,
+                               ConfirmSubmitController,
+                               {window: fakeWindow});
+
+    return {
+      ctrl: ctrl,
+      fakeWindow: fakeWindow,
+      confirmMessage: confirmMessage,
+    };
+  }
+
+  function fakeEvent() {
+    var event = new Event('click');
+    event.preventDefault = sinon.stub();
+    event.stopPropagation = sinon.stub();
+    event.stopImmediatePropagation = sinon.stub();
+    return event;
+  }
+
+  it('shows a confirm dialog using the text from the data-confirm-message attribute', function () {
+    var {ctrl, fakeWindow, confirmMessage} = component(true);
+
+    ctrl.element.dispatchEvent(new Event('click'));
+
+    assert.calledOnce(fakeWindow.confirm);
+    assert.calledWithExactly(fakeWindow.confirm, confirmMessage);
+  });
+
+  it('prevents form submission if the user refuses the confirm dialog', function () {
+    var ctrl = component(false).ctrl;
+    var event = fakeEvent();
+
+    ctrl.element.dispatchEvent(event);
+
+    assert.called(event.preventDefault);
+    assert.called(event.stopPropagation);
+    assert.called(event.stopImmediatePropagation);
+  });
+
+  it('allows form submission if the user confirms the confirm dialog', function () {
+    var ctrl = component(true).ctrl;
+    var event = fakeEvent();
+
+    ctrl.element.dispatchEvent(event);
+
+    assert.isFalse(event.preventDefault.called);
+    assert.isFalse(event.stopPropagation.called);
+    assert.isFalse(event.stopImmediatePropagation.called);
+  });
+});

--- a/h/static/styles/partials-v2/_search-result-sidebar.scss
+++ b/h/static/styles/partials-v2/_search-result-sidebar.scss
@@ -52,6 +52,11 @@
   text-decoration: underline;
 }
 
+.search-result-sidebar__leave-button::-moz-focus-inner {
+  padding: 0;
+  border-width: 0;
+}
+
 .search-result-sidebar-title__annotations-count {
   font-size: $normal-font-size;
   font-weight: normal;

--- a/h/static/styles/partials-v2/_search-result-sidebar.scss
+++ b/h/static/styles/partials-v2/_search-result-sidebar.scss
@@ -1,0 +1,60 @@
+.search-result-sidebar {
+  width: 300px;
+}
+
+.search-result-sidebar__title {
+  margin-top: 0;
+  margin-bottom: 26px;
+}
+
+.search-result-sidebar__title,
+.search-result-sidebar__subtitle {
+  color: $brand;
+}
+
+.search-result-sidebar__section {
+  margin-bottom: 26px;
+}
+
+.search-result-sidebar__section p:first-of-type {
+  margin-top: 0; 
+}
+
+.search-result-sidebar__section p:last-of-type {
+  margin-bottom: 0;
+}
+
+.search-result-sidebar__dt {
+  font-weight: bold;
+  float: left;
+  clear: left;
+  margin-right: 3px;
+}
+
+.search-result-sidebar__dd {
+  float: left;
+  margin-left: 0;
+}
+
+.search-result-sidebar__link {
+  color: inherit;
+  text-decoration: underline;
+}
+
+.search-result-sidebar__link:hover {
+  text-decoration: underline;
+}
+
+.search-result-sidebar-title__annotations-count {
+  font-size: $normal-font-size;
+  font-weight: normal;
+}
+
+.search-result-sidebar__annotations-count {
+  color: $grey-5;
+}
+
+.search-result-sidebar__username {
+  font-weight: bold;
+  margin-right: 3px;
+}

--- a/h/static/styles/partials-v2/_search-result-sidebar.scss
+++ b/h/static/styles/partials-v2/_search-result-sidebar.scss
@@ -45,6 +45,13 @@
   text-decoration: underline;
 }
 
+.search-result-sidebar__leave-button {
+  background: none;
+  border: none;
+  padding: 0;
+  text-decoration: underline;
+}
+
 .search-result-sidebar-title__annotations-count {
   font-size: $normal-font-size;
   font-weight: normal;

--- a/h/static/styles/partials-v2/_search.scss
+++ b/h/static/styles/partials-v2/_search.scss
@@ -4,8 +4,9 @@
 // of activity queries.
 
 .search-result-container {
+  display: flex;
   font-size: $normal-font-size;
-  margin-top: 20px;
+  margin-top: 50px;
   color: $grey-6;
 }
 
@@ -28,6 +29,10 @@
   padding-bottom: 10px;
   border-bottom: 1px solid $grey-2;
   margin-top: 30px;
+}
+
+.search-result__timeframe:first-child {
+  margin-top: 0;
 }
 
 // A group of search results

--- a/h/static/styles/partials-v2/_search.scss
+++ b/h/static/styles/partials-v2/_search.scss
@@ -11,6 +11,7 @@
 }
 
 .search-result-list {
+  flex-basis: 950px;
   max-width: 950px;
 
   // Remove default padding from <ol>

--- a/h/static/styles/partials-v2/_util.scss
+++ b/h/static/styles/partials-v2/_util.scss
@@ -1,5 +1,9 @@
 // Utility classes
 
+.u-hidden {
+  display: none;
+}
+
 // Stretch an element to fill available space in its container.
 // Also useful for creating spacers
 .u-stretch {

--- a/h/static/styles/site-v2.scss
+++ b/h/static/styles/site-v2.scss
@@ -21,6 +21,7 @@
 @import 'partials-v2/pager';
 @import 'partials-v2/search';
 @import 'partials-v2/search-bar';
+@import 'partials-v2/search-result-sidebar';
 @import 'partials-v2/tooltip';
 @import 'partials-v2/tabs';
 

--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -135,14 +135,18 @@
           {% endif %}
           {% if show_group_leave_button %}
             <li>
-              <button class="search-result-sidebar__leave-button"
-                      form="search-bar"
-                      formmethod="POST"
-                      type="submit"
-                      name="group_leave"
-                      value="{{ group.pubid }}">
-                  {% trans %}Leave this group{% endtrans %}
-              </button>
+              {#- This form element is needed for Internet Explorer because it
+                  doesn't support the `form` attribute. See commit message. #}
+              <form method="POST">
+                <button class="search-result-sidebar__leave-button"
+                        form="search-bar"
+                        formmethod="POST"
+                        type="submit"
+                        name="group_leave"
+                        value="{{ group.pubid }}">
+                    {% trans %}Leave this group{% endtrans %}
+                </button>
+              </form>
             </li>
           {% endif %}
         </ul>

--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -138,12 +138,13 @@
               {#- This form element is needed for Internet Explorer because it
                   doesn't support the `form` attribute. See commit message. #}
               <form method="POST">
-                <button class="search-result-sidebar__leave-button"
+                <button class="search-result-sidebar__leave-button js-confirm-submit"
                         form="search-bar"
                         formmethod="POST"
                         type="submit"
                         name="group_leave"
-                        value="{{ group.pubid }}">
+                        value="{{ group.pubid }}"
+                        data-confirm-message="Are you sure you want to leave the group &quot;{{ group.name }}&quot;?">
                     {% trans %}Leave this group{% endtrans %}
                 </button>
               </form>

--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -95,6 +95,69 @@
         </li>
       {% endfor %}
     </ol>
+
+    {% if group %}
+    <aside class="search-result-sidebar">
+      <h1 class="search-result-sidebar__title">{{ group.name }}</h1>
+
+      {% if group.description %}
+      <section class="search-result-sidebar__section">
+        {% for paragraph in group.description.split('\n') %}
+          <p>{{ paragraph }}</p>
+        {% endfor %}
+      </section>
+      {% endif %}
+
+      <section class="search-result-sidebar__section">
+        <dl>
+          <dt class="search-result-sidebar__dt">
+            {% trans %}Annotations:{% endtrans %}
+          </dt>
+          <dd class="search-result-sidebar__dd">{{ total }}</dd>
+
+          <dt class="search-result-sidebar__dt">
+            {% trans %}Created:{% endtrans %}
+          </dt>
+          <dd class="search-result-sidebar__dd">{{ group.created }}</dd>
+        </dl>
+        <div style="clear: both;"></div>
+      </section>
+
+      <section class="search-result-sidebar__section">
+        <ul>
+          {% if group_edit_url %}
+            <li>
+              <a class="search-result-sidebar__link"
+                 href="{{ group_edit_url }}">
+                {% trans %}Edit group{% endtrans %}
+              </a>
+            </li>
+          {% endif %}
+        </ul>
+      </section>
+
+      <section class="search-result-sidebar__section">
+        <h3 class="search-result-sidebar__subtitle">
+          {% trans %}Members{% endtrans %}
+          <span class="search-result-sidebar-title__annotations-count">
+            {{ aggregations.users|length }}
+          <span>
+        </h3>
+        <ul>
+          {% for user in aggregations.users %}
+            <li>
+              <a class="search-result-sidebar__username">
+                {{ user.username }}
+              </a>
+              <span class="search-result-sidebar__annotations-count">
+                {{ user.count }}
+              </span>
+            </li>
+          {% endfor %}
+        </ul>
+      </section>
+    </aside>
+    {% endif %}
   </div>
 
   {% if page and page.max > 1 %}

--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -133,6 +133,18 @@
               </a>
             </li>
           {% endif %}
+          {% if show_group_leave_button %}
+            <li>
+              <button class="search-result-sidebar__leave-button"
+                      form="search-bar"
+                      formmethod="POST"
+                      type="submit"
+                      name="group_leave"
+                      value="{{ group.pubid }}">
+                  {% trans %}Leave this group{% endtrans %}
+              </button>
+            </li>
+          {% endif %}
         </ul>
       </section>
 

--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -133,23 +133,21 @@
               </a>
             </li>
           {% endif %}
-          {% if show_group_leave_button %}
             <li>
-              {#- This form element is needed for Internet Explorer because it
-                  doesn't support the `form` attribute. See commit message. #}
-              <form method="POST">
-                <button class="search-result-sidebar__leave-button js-confirm-submit"
-                        form="search-bar"
-                        formmethod="POST"
-                        type="submit"
-                        name="group_leave"
-                        value="{{ group.pubid }}"
-                        data-confirm-message="Are you sure you want to leave the group &quot;{{ group.name }}&quot;?">
-                    {% trans %}Leave this group{% endtrans %}
-                </button>
-              </form>
-            </li>
-          {% endif %}
+            {#- This form element is needed for Internet Explorer because it
+                doesn't support the `form` attribute. See commit message. #}
+            <form method="POST">
+              <button class="search-result-sidebar__leave-button js-confirm-submit"
+                      form="search-bar"
+                      formmethod="POST"
+                      type="submit"
+                      name="group_leave"
+                      value="{{ group.pubid }}"
+                      data-confirm-message="Are you sure you want to leave the group &quot;{{ group.name }}&quot;?">
+                  {% trans %}Leave this group{% endtrans %}
+              </button>
+            </form>
+          </li>
         </ul>
       </section>
 

--- a/h/templates/panels/navbar.html.jinja2
+++ b/h/templates/panels/navbar.html.jinja2
@@ -15,6 +15,13 @@
         {{ svg_icon('search', 'search-bar__icon') }}
         <div class="search-bar__lozenges" data-ref="searchBarLozenges"></div>
         <input class="search-bar__input" data-ref="searchBarInput" name="q" value="{{ q }}" placeholder="Search…" autocomplete="off">
+
+        {#- This seemingly pointless <input> is actually needed to make the
+            form work correctly. If you remove this input then when the user
+            presses Enter in the search bar input, the browser will act as if
+            the user had clicked one of the form's other submit elements
+            (e.g. the leave group button). #}
+        <input type="submit" style="display: none;">
       </form>
     </div>
 

--- a/h/templates/panels/navbar.html.jinja2
+++ b/h/templates/panels/navbar.html.jinja2
@@ -21,7 +21,7 @@
             presses Enter in the search bar input, the browser will act as if
             the user had clicked one of the form's other submit elements
             (e.g. the leave group button). #}
-        <input type="submit" style="display: none;">
+        <input type="submit" class="u-hidden">
       </form>
     </div>
 

--- a/h/views/activity.py
+++ b/h/views/activity.py
@@ -80,9 +80,6 @@ def group_search(request):
         'pubid': group.pubid,
     }
 
-    result['show_group_leave_button'] = (
-        group.creator != request.authenticated_user)
-
     if request.has_permission('admin', group):
         result['group_edit_url'] = request.route_url('group_edit', pubid=pubid)
 

--- a/h/views/activity.py
+++ b/h/views/activity.py
@@ -8,17 +8,17 @@ from __future__ import unicode_literals
 
 from pyramid import httpexceptions
 from pyramid.view import view_config
+from sqlalchemy.orm import exc
 
+from h import models
 from h.activity import query
 from h.paginator import paginate
+from h import util
 
 PAGE_SIZE = 200
 
 
 @view_config(route_name='activity.search',
-             request_method='GET',
-             renderer='h:templates/activity/search.html.jinja2')
-@view_config(route_name='activity.group_search',
              request_method='GET',
              renderer='h:templates/activity/search.html.jinja2')
 @view_config(route_name='activity.user_search',
@@ -42,9 +42,44 @@ def search(request):
     # Fetch results
     result = query.execute(request, q, page_size=page_size)
 
+    for user in result.aggregations.get('users', []):
+        user['username'] = util.user.split_user(user['user'])['username']
+        del user['user']
+
     return {
         'total': result.total,
         'aggregations': result.aggregations,
         'timeframes': result.timeframes,
         'page': paginate(request, result.total, page_size=page_size),
     }
+
+
+@view_config(route_name='activity.group_search',
+             request_method='GET',
+             renderer='h:templates/activity/search.html.jinja2')
+def group_search(request):
+    if not request.feature('search_page'):
+        raise httpexceptions.HTTPNotFound()
+
+    result = search(request)
+
+    pubid = request.matchdict['pubid']
+
+    try:
+        group = request.db.query(models.Group).filter_by(pubid=pubid).one()
+    except exc.NoResultFound:
+        return result
+
+    if request.authenticated_user not in group.members:
+        return result
+
+    result['group'] = {
+        'created': group.created.strftime('%B, %Y'),
+        'description': group.description,
+        'name': group.name,
+    }
+
+    if request.has_permission('admin', group):
+        result['group_edit_url'] = request.route_url('group_edit', pubid=pubid)
+
+    return result

--- a/tests/h/views/activity_test.py
+++ b/tests/h/views/activity_test.py
@@ -162,23 +162,6 @@ class TestGroupSearch(object):
         assert group_info['name'] == group.name
         assert group_info['pubid'] == group.pubid
 
-    def test_it_shows_the_leave_button_to_group_members(self,
-                                                        group,
-                                                        pyramid_request):
-        pyramid_request.authenticated_user = group.members[-1]
-
-        result = activity.group_search(pyramid_request)
-
-        assert result['show_group_leave_button'] is True
-
-    def test_it_does_not_show_the_leave_button_to_group_creators(
-            self, group, pyramid_request):
-        pyramid_request.authenticated_user = group.creator
-
-        result = activity.group_search(pyramid_request)
-
-        assert result['show_group_leave_button'] is False
-
     def test_it_checks_whether_the_user_has_admin_permission_on_the_group(
             self, group, pyramid_request):
         pyramid_request.authenticated_user = group.members[-1]

--- a/tests/h/views/activity_test.py
+++ b/tests/h/views/activity_test.py
@@ -9,6 +9,7 @@ from h.views.activity import PAGE_SIZE
 from h.views.activity import search
 
 
+@pytest.mark.usefixtures('paginate', 'query')
 class TestSearch(object):
     def test_it_returns_404_when_feature_turned_off(self, pyramid_request):
         pyramid_request.feature.flags['search_page'] = False
@@ -53,7 +54,6 @@ class TestSearch(object):
                                               query.extract.return_value,
                                               page_size=PAGE_SIZE)
 
-    @pytest.mark.usefixtures('query')
     def test_is_uses_passed_in_page_size_for_pagination(self, pyramid_request, paginate):
         pyramid_request.feature.flags['search_page'] = True
 

--- a/tests/h/views/activity_test.py
+++ b/tests/h/views/activity_test.py
@@ -9,9 +9,6 @@ from h.views.activity import PAGE_SIZE
 from h.views.activity import search
 
 
-# The search view is just a skeleton at the moment, the only part we should
-# test at the moment is that it returns a 404 response when the feature flag
-# is turned off.
 class TestSearch(object):
     def test_it_returns_404_when_feature_turned_off(self, pyramid_request):
         pyramid_request.feature.flags['search_page'] = False

--- a/tests/h/views/activity_test.py
+++ b/tests/h/views/activity_test.py
@@ -18,16 +18,12 @@ class TestSearch(object):
             search(pyramid_request)
 
     def test_it_checks_for_redirects(self, pyramid_request, query):
-        pyramid_request.feature.flags['search_page'] = True
-
         search(pyramid_request)
 
         query.check_url.assert_called_once_with(pyramid_request,
                                                 query.extract.return_value)
 
     def test_it_executes_a_search_query(self, pyramid_request, query):
-        pyramid_request.feature.flags['search_page'] = True
-
         search(pyramid_request)
 
         query.execute.assert_called_once_with(pyramid_request,
@@ -35,8 +31,6 @@ class TestSearch(object):
                                               page_size=PAGE_SIZE)
 
     def test_it_allows_to_specify_the_page_size(self, pyramid_request, query):
-        pyramid_request.feature.flags['search_page'] = True
-
         pyramid_request.params['page_size'] = 100
         search(pyramid_request)
 
@@ -45,8 +39,6 @@ class TestSearch(object):
                                               page_size=100)
 
     def test_it_uses_default_page_size_when_value_is_a_string(self, pyramid_request, query):
-        pyramid_request.feature.flags['search_page'] = True
-
         pyramid_request.params['page_size'] = 'foobar'
         search(pyramid_request)
 
@@ -55,8 +47,6 @@ class TestSearch(object):
                                               page_size=PAGE_SIZE)
 
     def test_it_uses_passed_in_page_size_for_pagination(self, pyramid_request, paginate):
-        pyramid_request.feature.flags['search_page'] = True
-
         pyramid_request.params['page_size'] = 100
         search(pyramid_request)
 
@@ -71,3 +61,8 @@ class TestSearch(object):
     @pytest.fixture
     def paginate(self, patch):
         return patch('h.views.activity.paginate')
+
+    @pytest.fixture
+    def pyramid_request(self, pyramid_request):
+        pyramid_request.feature.flags['search_page'] = True
+        return pyramid_request

--- a/tests/h/views/activity_test.py
+++ b/tests/h/views/activity_test.py
@@ -54,7 +54,7 @@ class TestSearch(object):
                                               query.extract.return_value,
                                               page_size=PAGE_SIZE)
 
-    def test_is_uses_passed_in_page_size_for_pagination(self, pyramid_request, paginate):
+    def test_it_uses_passed_in_page_size_for_pagination(self, pyramid_request, paginate):
         pyramid_request.feature.flags['search_page'] = True
 
         pyramid_request.params['page_size'] = 100

--- a/tests/h/views/activity_test.py
+++ b/tests/h/views/activity_test.py
@@ -5,8 +5,7 @@ import pytest
 import mock
 from pyramid import httpexceptions
 
-from h.views.activity import PAGE_SIZE
-from h.views.activity import search
+from h.views import activity
 
 
 @pytest.mark.usefixtures('paginate', 'query')
@@ -15,24 +14,24 @@ class TestSearch(object):
         pyramid_request.feature.flags['search_page'] = False
 
         with pytest.raises(httpexceptions.HTTPNotFound):
-            search(pyramid_request)
+            activity.search(pyramid_request)
 
     def test_it_checks_for_redirects(self, pyramid_request, query):
-        search(pyramid_request)
+        activity.search(pyramid_request)
 
         query.check_url.assert_called_once_with(pyramid_request,
                                                 query.extract.return_value)
 
     def test_it_executes_a_search_query(self, pyramid_request, query):
-        search(pyramid_request)
+        activity.search(pyramid_request)
 
         query.execute.assert_called_once_with(pyramid_request,
                                               query.extract.return_value,
-                                              page_size=PAGE_SIZE)
+                                              page_size=activity.PAGE_SIZE)
 
     def test_it_allows_to_specify_the_page_size(self, pyramid_request, query):
         pyramid_request.params['page_size'] = 100
-        search(pyramid_request)
+        activity.search(pyramid_request)
 
         query.execute.assert_called_once_with(pyramid_request,
                                               query.extract.return_value,
@@ -40,15 +39,15 @@ class TestSearch(object):
 
     def test_it_uses_default_page_size_when_value_is_a_string(self, pyramid_request, query):
         pyramid_request.params['page_size'] = 'foobar'
-        search(pyramid_request)
+        activity.search(pyramid_request)
 
         query.execute.assert_called_once_with(pyramid_request,
                                               query.extract.return_value,
-                                              page_size=PAGE_SIZE)
+                                              page_size=activity.PAGE_SIZE)
 
     def test_it_uses_passed_in_page_size_for_pagination(self, pyramid_request, paginate):
         pyramid_request.params['page_size'] = 100
-        search(pyramid_request)
+        activity.search(pyramid_request)
 
         paginate.assert_called_once_with(pyramid_request,
                                          mock.ANY,


### PR DESCRIPTION
This adds a first version of the group sidebar on the `/groups/<pubid>/search` page. See <https://github.com/hypothesis/product-backlog/issues/12> for requirements.

What this includes:

- [x] Sidebar shows only on the `/groups/<pubid>/search` page
- [x] Sidebar does not show if no group with the given pubid exists
- [x] Sidebar does not show if the user isn't logged in or isn't a member of the group
- [x] Sidebar contains group name, description, num. annotations, created date, num. members, list of members sorted by num. annotations and num. annotations for each member
- [x] Multi-paragraph group descriptions are handled
- [x] Group name and description are escaped
- [x] Edit group link if you are the group's creator
- [x] Leave group button if you are _not_ the group's creator
- [x] Confirm dialog before leaving group (js only), the text that this dialog uses is the same as when leaving a group in the client sidebar

What this does not include:

* No tags in the sidebar, that's a [separate card](https://github.com/hypothesis/product-backlog/issues/10)
* No group invite link in the sidebar, that's to be done in a [follow-up PR](https://github.com/hypothesis/h/pull/4037)
* The members are not clickable, that's to be done in a follow-up PR
* No responsive design, full-sized desktop layout only, responsive is to be done in a [follow-up PR](https://github.com/hypothesis/h/pull/4025)

Known issues:

* The "<- Back to the groups page" link on the edit group page takes you back to the old group page, not to the page that you came from.

* <del>When you click on the _Leave group_ button any search times that you've typed that have 1. Been turned into lozenges by the JavaScript and 2. Not been submitted to the server yet (so they aren't in the URL yet) will be lost when the page reloads. I think this needs to be solved but propose to do it in a later PR.</del> (This is fixed now that <https://github.com/hypothesis/h/pull/4026> is merged.)

*  Hard line breaks in group descriptions:
   
   ```
   This is the first line
   This is the second line, of the first paragraph
   ```
   
   Will produce two separate paragraphs (two `<p>` elements), just as it would if there was an empty line between the two lines:
   
   ```
   This is the first paragraph
   
   This is the second paragraph
   ```