### PR TITLE
Fix extra space at end of search queries

### DIFF
--- a/h/static/scripts/controllers/search-bar-controller.js
+++ b/h/static/scripts/controllers/search-bar-controller.js
@@ -132,10 +132,10 @@ class SearchBarController extends Controller {
       var hiddenInput = document.createElement('input');
       hiddenInput.type = 'hidden';
 
-      Array.from(this._lozengeContainer.querySelectorAll('.js-lozenge__content')).forEach((loz) => {
-        hiddenInput.value = hiddenInput.value + loz.textContent + ' ';
-      });
-      hiddenInput.value = hiddenInput.value + getTrimmedInputValue();
+      var lozenges = this._lozengeContainer.querySelectorAll('.js-lozenge__content');
+      hiddenInput.value = Array.from(lozenges).map((loz) => {
+        return loz.textContent;
+      }).join(' ') + getTrimmedInputValue();
 
       // When JavaScript isn't enabled this._input is submitted to the server
       // as the q param. With JavaScript we submit hiddenInput instead.

--- a/h/static/scripts/tests/controllers/search-bar-controller-test.js
+++ b/h/static/scripts/tests/controllers/search-bar-controller-test.js
@@ -68,14 +68,14 @@ describe('SearchBarController', function () {
     it('allows submitting the form dropdown is open but has no selected value', function (done) {
       let form = testEl.querySelector('form');
       let submit = sinon.stub(form, 'submit');
-      
+
       syn
         .click(input)
         .type('test[space]', () => {
           assert.isTrue(dropdown.classList.contains('is-open'));
         })
         .type('[enter]', () => {
-          assert.equal(testEl.querySelector('input[type=hidden]').value, 'test ');
+          assert.equal(testEl.querySelector('input[type=hidden]').value, 'test');
           assert.isTrue(submit.calledOnce);
           done();
         });


### PR DESCRIPTION
Instead of looping through the lozenges and appending the content and a
trailing space, we just get an array of the lozenge contents and join
it. This way we avoid the extra space at the end.

Fixes #3985.