### PR TITLE
Add responsive layout to the group search page sidebar

### DIFF
--- a/h/static/styles/partials-v2/_pager.scss
+++ b/h/static/styles/partials-v2/_pager.scss
@@ -1,7 +1,10 @@
 .pager {
   display: flex;
   flex-direction: row;
-  margin: 40px auto;
+  margin-top: 0;
+  margin-bottom: 40px;
+  margin-left: auto;
+  margin-right: auto;
   font-weight: bold;
   justify-content: center;
 }

--- a/h/static/styles/partials-v2/_search-result-sidebar.scss
+++ b/h/static/styles/partials-v2/_search-result-sidebar.scss
@@ -71,3 +71,13 @@
   margin-right: 3px;
   margin-bottom: 7px;
 }
+
+@media screen and (max-width: $tablet-width) {
+  // On tablet-sized screens and below the "sidebar" is displayed in the center
+  // of the screen instead of on the side (this is achieved by media queries
+  // on the sidebar's parent element), so make it full the whole width of the
+  // screen.
+  .search-result-sidebar {
+    width: 100%;
+  }
+}

--- a/h/static/styles/partials-v2/_search-result-sidebar.scss
+++ b/h/static/styles/partials-v2/_search-result-sidebar.scss
@@ -1,5 +1,7 @@
 .search-result-sidebar {
-  width: 300px;
+  width: 200px;
+  flex-shrink: 0;
+  margin-bottom: 40px;
 }
 
 .search-result-sidebar__title {
@@ -14,6 +16,10 @@
 
 .search-result-sidebar__section {
   margin-bottom: 26px;
+}
+
+.search-result-sidebar__section:last-child {
+  margin-bottom: 0;
 }
 
 .search-result-sidebar__section p:first-of-type {

--- a/h/static/styles/partials-v2/_search.scss
+++ b/h/static/styles/partials-v2/_search.scss
@@ -7,9 +7,7 @@
   display: none;
   align-items: center;
   justify-content: space-between;
-
   margin-bottom: 40px;
-  margin-right: 10px;
 }
 
 .search-result-nav__title {
@@ -242,5 +240,16 @@
   .search-bucket-stats {
     margin-left: 5px;
     margin-top: 10px;
+  }
+
+  .search-result-container {
+    // Align the left edge of the search result list with the left edge of the
+    // navbar content.
+    margin-left: 10px;
+    margin-right: 10px;
+  }
+
+  .search-result-list {
+    margin-right: 0;
   }
 }

--- a/h/static/styles/partials-v2/_search.scss
+++ b/h/static/styles/partials-v2/_search.scss
@@ -8,6 +8,10 @@
   font-size: $normal-font-size;
   margin-top: 50px;
   color: $grey-6;
+
+  // Align the left edge of the search result list with the left edge of the
+  // navbar content.
+  margin-left: 30px;
 }
 
 .search-result-list {
@@ -19,10 +23,8 @@
   padding-left: 0;
   padding-right: 0;
 
-  // These margins are set so that the left edge of the search result list
-  // aligns with the left edge of the navbar content
-  margin-left: 30px;
   margin-right: 30px;
+  margin-bottom: 40px;
 }
 
 .search-result__timeframe {
@@ -174,9 +176,17 @@
     }
 }
 
+// As the screen size gets smaller, just before it would have introduced a
+// horizontal scrollbar move the sidebar below the search results.
+@media screen and (max-width: $tablet-width + 225px) {
+  .search-result-container {
+    flex-direction: column;
+  }
+}
+
 // On large tablets and below left-align annotation cards in order to make more
 // space for the stats to the right of the annotation card.
-@media screen and (max-width: $tablet-width + 150px) {
+@media screen and (max-width: 1127px) {
   .search-result-bucket__annotation-cards-container {
     padding-left: 0;
   }

--- a/h/static/styles/partials-v2/_search.scss
+++ b/h/static/styles/partials-v2/_search.scss
@@ -230,13 +230,6 @@
 // On normal tablets and below, display annotation stats below annotation list
 @media screen and (max-width: $tablet-width) {
 
-  // Reduce margins on tablet and below to match navbar left/right margins
-  // on these screen sizes
-  .search-result-list {
-    margin-left: 10px;
-    margin-right: 10px;
-  }
-
   .search-result-bucket__annotation-cards-container {
     flex-direction: column;
   }

--- a/h/static/styles/partials-v2/_search.scss
+++ b/h/static/styles/partials-v2/_search.scss
@@ -3,6 +3,32 @@
 // Styles for the search page which displays the results
 // of activity queries.
 
+.search-result-nav {
+  display: none;
+  align-items: center;
+  justify-content: space-between;
+
+  margin-bottom: 40px;
+  margin-right: 10px;
+}
+
+.search-result-nav__title {
+  color: $brand;
+  margin: 0;
+}
+
+.search-result-nav__button {
+  background-color: $grey-2;
+  border: none;
+  color: inherit;
+  font-weight: bold;
+  padding-top: 10px;
+  padding-bottom: 10px;
+  padding-left: 15px;
+  padding-right: 15px;
+  text-decoration: none;
+}
+
 .search-result-container {
   display: flex;
   font-size: $normal-font-size;
@@ -181,6 +207,15 @@
 @media screen and (max-width: $tablet-width + 225px) {
   .search-result-container {
     flex-direction: column;
+    margin-top: 25px;
+  }
+
+  .search-result-nav {
+    display: flex;
+  }
+
+  .search-result-hide-on-small-screens {
+    display: none;
   }
 }
 

--- a/h/static/styles/partials-v2/_search.scss
+++ b/h/static/styles/partials-v2/_search.scss
@@ -15,6 +15,7 @@
 .search-result-nav__title {
   color: $brand;
   margin: 0;
+  line-height: 22px;
 }
 
 .search-result-nav__button {

--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -2,6 +2,33 @@
 
 {% from '../includes/annotation_card.html.jinja2' import annotation_card %}
 
+{% macro search_result_nav(group_name) %}
+<nav class="search-result-nav">
+  {%- if more_info %}
+    <form method="POST"> {# This <form> is needed for IE because it doesn't
+                            support the `form` attribute. #}
+      <button form="search-bar"
+              formmethod="POST"
+              name="back"
+              class="search-result-nav__button">
+        {% trans %}Back{% endtrans %}
+      </button>
+    </form>
+  {% else %}
+    <h1 class="search-result-nav__title">{{ group_name }}</h1>
+    <form method="POST"> {# This <form> is needed for IE because it doesn't
+                            support the `form` attribute. #}
+      <button form="search-bar"
+              formmethod="POST"
+              name="more_info"
+              class="search-result-nav__button">
+        {% trans %}More info{% endtrans %}
+      </button>
+    </form>
+  {% endif -%}
+</nav>
+{% endmacro %}
+
 {# Card displaying statistics about a bucket of annotations. #}
 {% macro search_bucket_stats(bucket) %}
 <div class="search-bucket-stats">
@@ -92,30 +119,7 @@
 
   <div class="search-result-container">
     {% if group %}
-    <nav class="search-result-nav">
-      {%- if more_info %}
-        <form method="POST"> {# This <form> is needed for IE because it doesn't
-                                support the `form` attribute. #}
-          <button form="search-bar"
-                  formmethod="POST"
-                  name="back"
-                  class="search-result-nav__button">
-            {% trans %}Back{% endtrans %}
-          </button>
-        </form>
-      {% else %}
-        <h1 class="search-result-nav__title">{{ group.name }}</h1>
-        <form method="POST"> {# This <form> is needed for IE because it doesn't
-                                support the `form` attribute. #}
-          <button form="search-bar"
-                  formmethod="POST"
-                  name="more_info"
-                  class="search-result-nav__button">
-            {% trans %}More info{% endtrans %}
-          </button>
-        </form>
-      {% endif -%}
-    </nav>
+      {{ search_result_nav(group.name) }}
     {% endif %}
 
     <ol class="search-result-list {%- if more_info %} search-result-hide-on-small-screens{% endif %}">

--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -94,20 +94,26 @@
     {% if group %}
     <nav class="search-result-nav">
       {%- if more_info %}
-        <button form="search-bar"
-                formmethod="POST"
-                name="back"
-                class="search-result-nav__button">
-          {% trans %}Back{% endtrans %}
-        </button>
+        <form method="POST"> {# This <form> is needed for IE because it doesn't
+                                support the `form` attribute. #}
+          <button form="search-bar"
+                  formmethod="POST"
+                  name="back"
+                  class="search-result-nav__button">
+            {% trans %}Back{% endtrans %}
+          </button>
+        </form>
       {% else %}
         <h1 class="search-result-nav__title">{{ group.name }}</h1>
-        <button form="search-bar"
-                formmethod="POST"
-                name="more_info"
-                class="search-result-nav__button">
-          {% trans %}More info{% endtrans %}
-        </button>
+        <form method="POST"> {# This <form> is needed for IE because it doesn't
+                                support the `form` attribute. #}
+          <button form="search-bar"
+                  formmethod="POST"
+                  name="more_info"
+                  class="search-result-nav__button">
+            {% trans %}More info{% endtrans %}
+          </button>
+        </form>
       {% endif -%}
     </nav>
     {% endif %}

--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -91,7 +91,28 @@
   </script>
 
   <div class="search-result-container">
-    <ol class="search-result-list">
+    {% if group %}
+    <nav class="search-result-nav">
+      {%- if more_info %}
+        <button form="search-bar"
+                formmethod="POST"
+                name="back"
+                class="search-result-nav__button">
+          {% trans %}Back{% endtrans %}
+        </button>
+      {% else %}
+        <h1 class="search-result-nav__title">{{ group.name }}</h1>
+        <button form="search-bar"
+                formmethod="POST"
+                name="more_info"
+                class="search-result-nav__button">
+          {% trans %}More info{% endtrans %}
+        </button>
+      {% endif -%}
+    </nav>
+    {% endif %}
+
+    <ol class="search-result-list {%- if more_info %} search-result-hide-on-small-screens{% endif %}">
       {% for timeframe in timeframes %}
         <li class="search-result__timeframe">
           {{ timeframe.label }}
@@ -105,7 +126,7 @@
     </ol>
 
     {% if group %}
-    <aside class="search-result-sidebar">
+    <aside class="search-result-sidebar {%- if not more_info %} search-result-hide-on-small-screens{% endif %}">
       <h1 class="search-result-sidebar__title">{{ group.name }}</h1>
 
       {% if group.description %}
@@ -193,7 +214,7 @@
     {% endif %}
   </div>
 
-  {% if page and page.max > 1 %}
+  {% if not more_info and page and page.max > 1 %}
     {% include "h:templates/includes/paginator.html.jinja2" %}
   {% endif %}
 {% endblock %}

--- a/h/views/activity.py
+++ b/h/views/activity.py
@@ -84,7 +84,36 @@ def group_search(request):
     if request.has_permission('admin', group):
         result['group_edit_url'] = request.route_url('group_edit', pubid=pubid)
 
+    result['more_info'] = 'more_info' in request.params
+
     return result
+
+
+@view_config(route_name='activity.group_search',
+             request_method='POST',
+             renderer='h:templates/activity/search.html.jinja2',
+             request_param='more_info')
+def group_search_more_info(request):
+    """Respond to a click on the ``more_info`` button."""
+    new_params = request.POST.copy()
+    location = request.route_url('activity.group_search',
+                                 pubid=request.matchdict['pubid'],
+                                 _query=new_params)
+    return httpexceptions.HTTPSeeOther(location=location)
+
+
+@view_config(route_name='activity.group_search',
+             request_method='POST',
+             renderer='h:templates/activity/search.html.jinja2',
+             request_param='back')
+def group_search_back(request):
+    """Respond to a click on the ``back`` button."""
+    new_params = request.POST.copy()
+    del new_params['back']
+    location = request.route_url('activity.group_search',
+                                 pubid=request.matchdict['pubid'],
+                                 _query=new_params)
+    return httpexceptions.HTTPSeeOther(location=location)
 
 
 @view_config(route_name='activity.group_search',

--- a/tests/h/views/activity_test.py
+++ b/tests/h/views/activity_test.py
@@ -255,9 +255,12 @@ class TestGroupSearchMoreInfo(object):
         result = activity.group_search_more_info(pyramid_request)
 
         assert isinstance(result, httpexceptions.HTTPSeeOther)
-        assert result.location == (
-            'http://example.com/groups/test_pubid/search'
-            '?more_info=&q=foo+bar')
+        assert result.location.startswith(
+            'http://example.com/groups/test_pubid/search?')
+        # The order of the params vary (because they're in an unordered dict)
+        # but they should both be there.
+        assert 'more_info=' in result.location
+        assert 'q=foo+bar' in result.location
 
     @pytest.fixture
     def routes(self, pyramid_config):


### PR DESCRIPTION
<del>This is marked as WIP because it requires https://github.com/hypothesis/h/pull/4021 to be merged first and then will need a rebase.</del> (Done)

This adds responsive layout to the sidebar on the group search page. This is an MVP of this responsive layout, when you click on the "More info" button to open the sidebar it does a full page load and it does not show any animated "slide in" of the sidebar. It can be enhanced with JavaScript later (and this no-js behaviour kept for when js is not available), but I propose that this no-js version gets us 99% and is probably fine to ship with activity pages v1.

The way it works is:

* A CSS media query means that when the screen is too small to show both the search results and the sidebar together then only the search results are shown and the sidebar is `display: none;`

* Another media query means that on such small screens an additional `<nav>` containing the group name and a "More info" button is shown above the search results, instead of the sidebar

* Clicking on the "More info" button does a full page reload and adds an `&more_info` param to the URL. This param causes the server to render a version of the page that, if the screen is too small to show both the search results and the sidebar together, shows only the sidebar rather than only the search results (this is just a case of toggling a CSS class on/off using a Jinja2 `{% if %}`). It also replaces the "More info" button with a "Back" button.

* The "Back" button also does a full page reload and just removes the `&more_info` param so you get the first version of the page again.

### Mockup

Note that this mockup also contains a bunch of other new components that are not part of this PR:

![30c697e2-9d3b-11e6-9193-c8995babfebf](https://cloud.githubusercontent.com/assets/22498/20016112/17e8d2c8-a2b6-11e6-968f-52401e89e99a.png)

### Screenshots

#### Phone

![screenshot from 2016-11-04 17-45-31](https://cloud.githubusercontent.com/assets/22498/20016319/db7e76a2-a2b6-11e6-8c83-4608f8d984a6.png)

![screenshot from 2016-11-04 17-46-00](https://cloud.githubusercontent.com/assets/22498/20016326/e1a6e60e-a2b6-11e6-93c0-ebbbccca37f5.png)

#### Tablet

![screenshot from 2016-11-04 17-46-33](https://cloud.githubusercontent.com/assets/22498/20016347/f3a1a0b0-a2b6-11e6-8202-31e0fec67e4b.png)

![screenshot from 2016-11-04 17-46-49](https://cloud.githubusercontent.com/assets/22498/20016351/f8c18d4e-a2b6-11e6-8aec-cb6ec7985fab.png)

#### Desktop

When the screen is large enough the sidebar appears on the side as normal:

![screenshot from 2016-11-04 17-47-27](https://cloud.githubusercontent.com/assets/22498/20016361/0ffd4322-a2b7-11e6-87b7-65a0e3705e94.png)

### Transition

GIF of the transition to and from the "More info" page on my dev machine (we'll see how fast this is on production):

![peek 2016-11-04 15-44](https://cloud.githubusercontent.com/assets/22498/20016382/29143b4a-a2b7-11e6-8857-3c93366b0686.gif)

### Resizing the window

Whether you're on the search results or the sidebar version of the page, if you make the window bigger you will get the search results and the sidebar. This is relevant not only to people who resize windows (or maximize or fullscreen) but to bookmarking and then opening a bookmark, opening from browser history, sharing a link with someone else, using various OS and browser features to share tabs between phone and desktop, etc. There are many ways in which the `&more_info` version of the URL may get opened on a larger screen.

![peek 2016-11-04 17-38](https://cloud.githubusercontent.com/assets/22498/20016463/769f8e3c-a2b7-11e6-90b0-64b3339853f7.gif)

### Known issues

* In Internet Explorer, any search query is lost when you click on the "More info" or "Back" button. This does not happen in other browsers. I don't think it can be fixed in IE except by using JavaScript.