### PR TITLE
Upgrade Celery to 3.1.25

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -2,7 +2,7 @@ PyJWT
 SQLAlchemy
 alembic
 bcrypt
-celery
+celery == 3.1.25  # Pin to latest 3.1.x to ensure forwards-compat with 4.x
 certifi
 cffi
 click

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ anyjson==0.3.3            # via kombu
 bcrypt==3.1.0
 billiard==3.3.0.23        # via celery
 bleach==1.4.3
-celery==3.1.23
+celery==3.1.25
 certifi==2016.2.28
 cffi==1.7.0
 Chameleon==2.24           # via deform
@@ -36,7 +36,7 @@ itsdangerous==0.24
 Jinja2==2.8               # via deform-jinja2, pyramid-jinja2
 jsonpointer==1.0
 jsonschema==2.5.1
-kombu==3.0.35
+kombu==3.0.37
 Mako==1.0.4               # via alembic
 MarkupSafe==0.23          # via jinja2, mako, pyramid-jinja2
 mistune==0.7.3


### PR DESCRIPTION
Celery 4.x has just been released. It's mostly backwards-compatible with 3.x but a few things need to be resolved before we can upgrade. 3.1.25 is a forwards-compatibility release of Celery, and is the first step to upgrading.