### PR TITLE
pytest 3.0.3 has been released -- remove pin

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,9 +15,7 @@ skip_install =
 deps =
     coverage
     mock
-    # Pin pytest until https://github.com/pytest-dev/pytest/issues/1905 is
-    # resolved
-    pytest==3.0.1
+    pytest
     hypothesis
     factory-boy
     h: -rrequirements.txt
@@ -30,9 +28,7 @@ commands =
 [testenv:functional]
 skip_install = true
 deps =
-    # Pin pytest until https://github.com/pytest-dev/pytest/issues/1905 is
-    # resolved
-    pytest==3.0.1
+    pytest
     webtest
     factory-boy
     -rrequirements.txt


### PR DESCRIPTION
This pin was to work around a bug which has now been fixed in Pytest
3.0.3.