### PR TITLE
Add a "For Publishers" section to the docs

### DIFF
--- a/docs/embedding.rst
+++ b/docs/embedding.rst
@@ -1,28 +1,6 @@
-How to add Hypothesis to your website
-#####################################
+:orphan:
 
-.. If you update this page, please ensure you update the "For Publishers" page
-   on the Hypothesis website, or coordinate with someone who can
-   (https://hypothes.is/for-publishers/).
+This page has moved
+===================
 
-To add Hypothesis to your website, add the following line to the HTML source of
-your page:
-
-.. code-block:: html
-
-   <script src="https://hypothes.is/embed.js" async></script>
-
-You can configure Hypothesis by including a config tag above the the script tag.
-For example, the following arrangement will ensure that our yellow highlights
-are hidden by default:
-
-.. code-block:: html
-
-   <script type="application/json" class="js-hypothesis-config">
-   {"showHighlights": false}
-   </script>
-   <script src="https://hypothes.is/embed.js" async></script>
-
-You can find the `full list of configuration options
-<https://github.com/hypothesis/client/blob/master/docs/config.md>`_ in our
-client documentation.
+This page has moved to a new location: :doc:`publishers/embedding`.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,7 +14,7 @@ Contents
    :maxdepth: 1
 
    community
-   embedding
+   publishers/index
    The Hypothesis API <http://h.readthedocs.io/en/latest/api/>
    developing/index
    CHANGES

--- a/docs/publishers/embedding.rst
+++ b/docs/publishers/embedding.rst
@@ -1,0 +1,28 @@
+How to add Hypothesis to your website
+#####################################
+
+.. If you update this page, please ensure you update the "For Publishers" page
+   on the Hypothesis website, or coordinate with someone who can
+   (https://hypothes.is/for-publishers/).
+
+To add Hypothesis to your website, add the following line to the HTML source of
+your page:
+
+.. code-block:: html
+
+   <script src="https://hypothes.is/embed.js" async></script>
+
+You can configure Hypothesis by including a config tag above the the script tag.
+For example, the following arrangement will ensure that our yellow highlights
+are hidden by default:
+
+.. code-block:: html
+
+   <script type="application/json" class="js-hypothesis-config">
+   {"showHighlights": false}
+   </script>
+   <script src="https://hypothes.is/embed.js" async></script>
+
+You can find the `full list of configuration options
+<https://github.com/hypothesis/client/blob/master/docs/config.md>`_ in our
+client documentation.

--- a/docs/publishers/index.rst
+++ b/docs/publishers/index.rst
@@ -1,0 +1,10 @@
+Advice for publishers
+#####################
+
+If you publish content on the web and want to allow people to annotate your
+content, the following documents will help you get started.
+
+.. toctree::
+   :maxdepth: 1
+
+   embedding


### PR DESCRIPTION
This is primarily so I have somewhere sensible to put documentation of the JWT format used for third-party accounts.