### PR TITLE
Support CORS requests for POST /api/token endpoint

### DIFF
--- a/h/util/view.py
+++ b/h/util/view.py
@@ -11,7 +11,8 @@ cors_policy = cors.policy(
         'Authorization',
         'Content-Type',
     ),
-    allow_methods=('HEAD', 'GET', 'POST', 'PUT', 'DELETE'))
+    allow_methods=('HEAD', 'GET', 'POST', 'PUT', 'DELETE'),
+    allow_preflight=True)
 
 
 def handle_exception(request):
@@ -38,4 +39,12 @@ def cors_json_view(**settings):
     CORS with Authorization and Content-Type headers.
     """
     settings.setdefault('decorator', cors_policy)
+
+    request_method = settings.get('request_method', ())
+    if not isinstance(request_method, tuple):
+        request_method = (request_method,)
+    if len(request_method) == 0:
+        request_method = ('DELETE', 'GET', 'HEAD', 'POST', 'PUT',)
+    settings['request_method'] = request_method + ('OPTIONS',)
+
     return json_view(**settings)

--- a/h/util/view.py
+++ b/h/util/view.py
@@ -4,6 +4,15 @@ from __future__ import unicode_literals
 
 from pyramid.view import view_config
 
+from memex import cors
+
+cors_policy = cors.policy(
+    allow_headers=(
+        'Authorization',
+        'Content-Type',
+    ),
+    allow_methods=('HEAD', 'GET', 'POST', 'PUT', 'DELETE'))
+
 
 def handle_exception(request):
     """Handle an uncaught exception for the passed request."""
@@ -20,3 +29,13 @@ def json_view(**settings):
     settings.setdefault('accept', 'application/json')
     settings.setdefault('renderer', 'json')
     return view_config(**settings)
+
+
+def cors_json_view(**settings):
+    """
+    A view configuration decorator with JSON defaults and CORS.
+
+    CORS with Authorization and Content-Type headers.
+    """
+    settings.setdefault('decorator', cors_policy)
+    return json_view(**settings)

--- a/h/views/api_auth.py
+++ b/h/views/api_auth.py
@@ -4,10 +4,10 @@ from __future__ import unicode_literals
 
 from h.auth.services import TOKEN_TTL
 from h.exceptions import OAuthTokenError
-from h.util.view import json_view
+from h.util.view import cors_json_view
 
 
-@json_view(route_name='token', request_method='POST')
+@cors_json_view(route_name='token', request_method='POST')
 def access_token(request):
     svc = request.find_service(name='oauth')
 
@@ -23,7 +23,7 @@ def access_token(request):
     }
 
 
-@json_view(context=OAuthTokenError)
+@cors_json_view(context=OAuthTokenError)
 def api_token_error(context, request):
     """Handle an expected/deliberately thrown API exception."""
     request.response.status_code = context.status_code

--- a/src/memex/cors.py
+++ b/src/memex/cors.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
 from pyramid.httpexceptions import HTTPBadRequest
+from pyramid.response import Response
 
 
 def policy(allow_credentials=False,
            allow_headers=None,
            allow_methods=None,
+           allow_preflight=False,
            expose_headers=None,
            max_age=86400):
     """
@@ -17,7 +19,10 @@ def policy(allow_credentials=False,
 
     def cors_decorator(wrapped):
         def wrapper(context, request):
-            response = wrapped(context, request)
+            if allow_preflight and request.method == 'OPTIONS':
+                response = Response()
+            else:
+                response = wrapped(context, request)
             return set_cors_headers(request, response,
                                     allow_credentials=allow_credentials,
                                     allow_headers=allow_headers,

--- a/src/memex/views.py
+++ b/src/memex/views.py
@@ -39,7 +39,8 @@ cors_policy = cors.policy(
         'X-Annotator-Auth-Token',
         'X-Client-Id',
     ),
-    allow_methods=('HEAD', 'GET', 'POST', 'PUT', 'DELETE'))
+    allow_methods=('HEAD', 'GET', 'POST', 'PUT', 'DELETE'),
+    allow_preflight=True)
 
 
 class APIError(Exception):
@@ -71,6 +72,14 @@ def api_config(**settings):
     settings.setdefault('accept', 'application/json')
     settings.setdefault('renderer', 'json')
     settings.setdefault('decorator', cors_policy)
+
+    request_method = settings.get('request_method', ())
+    if not isinstance(request_method, tuple):
+        request_method = (request_method,)
+    if len(request_method) == 0:
+        request_method = ('DELETE', 'GET', 'HEAD', 'POST', 'PUT',)
+    settings['request_method'] = request_method + ('OPTIONS',)
+
     return view_config(**settings)
 
 

--- a/tests/h/util/view_test.py
+++ b/tests/h/util/view_test.py
@@ -87,6 +87,14 @@ class TestCorsJsonView(object):
         settings = cors_json_view()
         assert settings['decorator'] == cors_policy
 
+    def test_it_adds_OPTIONS_to_allowed_request_methods(self):
+        settings = cors_json_view(request_method='POST')
+        assert settings['request_method'] == ('POST', 'OPTIONS')
+
+    def test_it_adds_all_request_methods_when_not_defined(self):
+        settings = cors_json_view()
+        assert settings['request_method'] == ('DELETE', 'GET', 'HEAD', 'POST', 'PUT', 'OPTIONS')
+
     @pytest.fixture
     def json_view(self, patch):
         def _return_kwargs(**kwargs):

--- a/tests/h/util/view_test.py
+++ b/tests/h/util/view_test.py
@@ -5,7 +5,7 @@ from __future__ import unicode_literals
 import pytest
 from mock import Mock
 
-from h.util.view import handle_exception, json_view
+from h.util.view import handle_exception, json_view, cors_json_view
 
 
 class TestHandleException(object):
@@ -73,3 +73,28 @@ class TestJsonView(object):
         view_config = patch('h.util.view.view_config')
         view_config.side_effect = _return_kwargs
         return view_config
+
+
+@pytest.mark.usefixtures('json_view')
+class TestCorsJsonView(object):
+    def test_it_uses_json_view(self, json_view):
+        json_view.side_effect = None
+
+        settings = cors_json_view()
+        assert settings == json_view.return_value
+
+    def test_it_sets_cors_decorator(self, cors_policy):
+        settings = cors_json_view()
+        assert settings['decorator'] == cors_policy
+
+    @pytest.fixture
+    def json_view(self, patch):
+        def _return_kwargs(**kwargs):
+            return kwargs
+        json_view = patch('h.util.view.json_view')
+        json_view.side_effect = _return_kwargs
+        return json_view
+
+    @pytest.fixture
+    def cors_policy(self, patch):
+        return patch('h.util.view.cors_policy')

--- a/tests/memex/views_test.py
+++ b/tests/memex/views_test.py
@@ -35,6 +35,42 @@ class TestError(object):
         assert pyramid_request.response.status_code == 400
 
 
+@pytest.mark.usefixtures('view_config')
+class TestApiConfigDecorator(object):
+    def test_it_sets_accept_setting(self):
+        settings = views.api_config()
+        assert settings['accept'] == 'application/json'
+
+    def test_it_allows_accept_setting_override(self):
+        settings = views.api_config(accept='application/xml')
+        assert settings['accept'] == 'application/xml'
+
+    def test_it_sets_renderer_setting(self):
+        settings = views.api_config()
+        assert settings['renderer'] == 'json'
+
+    def test_it_allows_renderer_setting_override(self):
+        settings = views.api_config(renderer='xml')
+        assert settings['renderer'] == 'xml'
+
+    def test_it_sets_cors_decorator(self):
+        settings = views.api_config()
+        assert settings['decorator'] == views.cors_policy
+
+    def test_it_allows_decorator_override(self):
+        decorator = mock.Mock()
+        settings = views.api_config(decorator=decorator)
+        assert settings['decorator'] == decorator
+
+    @pytest.fixture
+    def view_config(self, patch):
+        def _return_kwargs(**kwargs):
+            return kwargs
+        json_view = patch('memex.views.view_config')
+        json_view.side_effect = _return_kwargs
+        return json_view
+
+
 class TestIndex(object):
 
     def test_it_returns_the_right_links(self, pyramid_config, pyramid_request):

--- a/tests/memex/views_test.py
+++ b/tests/memex/views_test.py
@@ -62,6 +62,15 @@ class TestApiConfigDecorator(object):
         settings = views.api_config(decorator=decorator)
         assert settings['decorator'] == decorator
 
+    def test_it_adds_OPTIONS_to_allowed_request_methods(self):
+        settings = views.api_config(request_method='DELETE')
+        assert settings['request_method'] == ('DELETE', 'OPTIONS')
+
+    def test_it_adds_all_request_methods_when_not_defined(self):
+        settings = views.api_config()
+        assert settings['request_method'] == (
+            'DELETE', 'GET', 'HEAD', 'POST', 'PUT', 'OPTIONS')
+
     @pytest.fixture
     def view_config(self, patch):
         def _return_kwargs(**kwargs):


### PR DESCRIPTION
I'm using a similar CORS policy to the one we use for the memex endpoints, except that we (for now) only allow the `Authorization` and `Content-Type` headers which should be enough for the h side of the API.