### PR TITLE
Add username from url as a lozenge to the nav bar.

### DIFF
--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -107,7 +107,7 @@
 
 {% block content %}
 
-  {{ panel('navbar') }}
+  {{ panel('navbar', opts or {}) }}
 
   {% for url in asset_urls("search_js") %}
     <script src="{{ url }}"></script>

--- a/h/templates/panels/navbar.html.jinja2
+++ b/h/templates/panels/navbar.html.jinja2
@@ -4,6 +4,19 @@
 
 {% if feature('activity_pages') %}
 
+{% macro lozenge(facetName, facetValue) %}
+  <div class="lozenge">
+    <div class="lozenge__content">
+      <span class="lozenge__facet-name">
+        {{ facetName }}:
+      </span>
+      <span class="lozenge__facet-value">
+        {{ facetValue }}
+      </span>
+    </div>
+  </div>
+{% endmacro %}
+
 <header class="nav-bar">
   <div class="nav-bar__content">
     <a href="/" title="Hypothesis homepage" class="nav-bar__logo-container"><!--
@@ -15,6 +28,14 @@
             id="search-bar"
             action="{{ search_url }}">
         {{ svg_icon('search', 'search-bar__icon') }}
+        <div class="search-bar__lozenges">
+          {% if opts['search_username'] %}
+            {{ lozenge('user', opts['search_username']) }}
+          {% endif %}
+          {% if opts['search_groupname'] %}
+            {{ lozenge('group', opts['search_groupname']) }}
+          {% endif %}
+        </div>
         <div class="search-bar__lozenges" data-ref="searchBarLozenges"></div>
         <input class="search-bar__input" data-ref="searchBarInput" name="q" value="{{ q }}" placeholder="Search…" autocomplete="off">
 

--- a/h/views/activity.py
+++ b/h/views/activity.py
@@ -20,9 +20,6 @@ PAGE_SIZE = 200
 @view_config(route_name='activity.search',
              request_method='GET',
              renderer='h:templates/activity/search.html.jinja2')
-@view_config(route_name='activity.user_search',
-             request_method='GET',
-             renderer='h:templates/activity/search.html.jinja2')
 def search(request):
     if not request.feature('search_page'):
         raise httpexceptions.HTTPNotFound()
@@ -54,7 +51,6 @@ def search(request):
         'page': paginate(request, result.total, page_size=page_size),
     }
 
-
 @view_config(route_name='activity.group_search',
              request_method='GET',
              renderer='h:templates/activity/search.html.jinja2')
@@ -62,9 +58,14 @@ def group_search(request):
     if not request.feature('search_page'):
         raise httpexceptions.HTTPNotFound()
 
+    opts = {}
+
     result = search(request)
 
     pubid = request.matchdict['pubid']
+
+    opts['search_groupname'] = request.matchdict['pubid']
+    result['opts'] = opts
 
     try:
         group = request.db.query(models.Group).filter_by(pubid=pubid).one()
@@ -90,7 +91,6 @@ def group_search(request):
     result['more_info'] = 'more_info' in request.params
 
     return result
-
 
 @view_config(route_name='activity.group_search',
              request_method='POST',
@@ -148,7 +148,6 @@ def group_leave(request):
     location = request.route_url('activity.search', _query=new_params)
 
     return httpexceptions.HTTPSeeOther(location=location)
-
 
 @view_config(route_name='activity.group_search',
              request_method='POST',
@@ -231,3 +230,19 @@ def _faceted_by_user(request, username, parsed_query=None):
 
     """
     return username in _username_facets(request, parsed_query)
+
+@view_config(route_name='activity.user_search',
+             request_method='GET',
+             renderer='h:templates/activity/search.html.jinja2')
+def user_search(request):
+    if not request.feature('search_page'):
+        raise httpexceptions.HTTPNotFound()
+
+    opts = {}
+    result = search(request)
+    username = request.matchdict['username']
+
+    opts['search_username'] = username
+    result['opts'] = opts
+
+    return result

--- a/h/views/panels.py
+++ b/h/views/panels.py
@@ -18,7 +18,7 @@ def group_invite(context, request, group_url):
 
 
 @panel_config(name='navbar', renderer='h:templates/panels/navbar.html.jinja2')
-def navbar(context, request):
+def navbar(context, request, opts={}):
     """
     The navigation bar displayed at the top of the page.
     """
@@ -57,4 +57,5 @@ def navbar(context, request):
         'username_url': stream_url,
         'search_url': search_url,
         'q': request.params.get('q', ''),
+        'opts': opts,
     }


### PR DESCRIPTION
User and Group profile pages are not adding the facet to the search box on load.
This is because a query 'q' from which lozenges are created and which contains a
single group or user term is redirected to the specific group or user search page
with that term removed.

https://github.com/hypothesis/product-backlog/issues/16