### PR TITLE
Make usernames in search sidebar clickable

### DIFF
--- a/h/static/styles/mixins/_reset.scss
+++ b/h/static/styles/mixins/_reset.scss
@@ -10,3 +10,15 @@
   border: 0;
 }
 
+/** Remove default border, background and padding from <button> elements. */
+@mixin reset-button {
+  background: none;
+  border: none;
+  padding: 0;
+
+  // See http://stackoverflow.com/questions/5517744
+  &::-moz-focus-inner {
+    padding: 0;
+    border-width: 0;
+  }
+}

--- a/h/static/styles/partials-v2/_search-result-sidebar.scss
+++ b/h/static/styles/partials-v2/_search-result-sidebar.scss
@@ -46,15 +46,8 @@
 }
 
 .search-result-sidebar__leave-button {
-  background: none;
-  border: none;
-  padding: 0;
+  @include reset-button;
   text-decoration: underline;
-}
-
-.search-result-sidebar__leave-button::-moz-focus-inner {
-  padding: 0;
-  border-width: 0;
 }
 
 .search-result-sidebar-title__annotations-count {
@@ -67,6 +60,8 @@
 }
 
 .search-result-sidebar__username {
+  @include reset-button;
   font-weight: bold;
   margin-right: 3px;
+  margin-bottom: 7px;
 }

--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -169,12 +169,22 @@
         <ul>
           {% for user in aggregations.users %}
             <li>
-              <a class="search-result-sidebar__username">
+              <button type="submit"
+                      form="search-bar"
+                      formmethod="POST"
+                      name="toggle_user_facet"
+                      value="{{ user.userid }}"
+                      {% if user.faceted_by %}
+                        title="{% trans username=user.username %}Remove {{ username }} from the search query{% endtrans %}"
+                      {% else %}
+                        title="{% trans username=user.username %}Limit the search to annotations by {{ username }}{% endtrans %}"
+                      {% endif %}
+                      class="search-result-sidebar__username">
                 {{ user.username }}
-              </a>
-              <span class="search-result-sidebar__annotations-count">
-                {{ user.count }}
-              </span>
+                <span class="search-result-sidebar__annotations-count">
+                  {{ user.count }}
+                </span>
+              </button>
             </li>
           {% endfor %}
         </ul>

--- a/h/views/activity.py
+++ b/h/views/activity.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 
-"""
-Activity pages views.
-"""
+"""Activity pages views."""
 
 from __future__ import unicode_literals
 

--- a/h/views/activity.py
+++ b/h/views/activity.py
@@ -9,6 +9,7 @@ from __future__ import unicode_literals
 from pyramid import httpexceptions
 from pyramid.view import view_config
 from sqlalchemy.orm import exc
+from memex.search import parser
 
 from h import models
 from h.activity import query
@@ -44,6 +45,8 @@ def search(request):
 
     for user in result.aggregations.get('users', []):
         user['username'] = util.user.split_user(user['user'])['username']
+        user['userid'] = user['user']
+        user['faceted_by'] = _faceted_by_user(request, user['username'], q)
         del user['user']
 
     return {
@@ -115,3 +118,86 @@ def group_leave(request):
     location = request.route_url('activity.search', _query=new_params)
 
     return httpexceptions.HTTPSeeOther(location=location)
+
+
+@view_config(route_name='activity.group_search',
+             request_method='POST',
+             renderer='h:templates/activity/search.html.jinja2',
+             request_param='toggle_user_facet')
+def toggle_user_facet(request):
+    """
+    Toggle the given user from the search facets.
+
+    If the search is not already faceted by the userid given in the
+    "toggle_user_facet" request param then redirect the browser to the same
+    page but with the a facet for this user added to the search query.
+
+    If the search is already faceted by the userid then redirect the browser
+    to the same page but with this user facet removed from the search query.
+
+    """
+    if not request.feature('search_page'):
+        raise httpexceptions.HTTPNotFound()
+
+    userid = request.params['toggle_user_facet']
+    username = util.user.split_user(userid)['username']
+
+    new_params = request.params.copy()
+
+    del new_params['toggle_user_facet']
+
+    parsed_query = _parsed_query(request)
+    if _faceted_by_user(request, username, parsed_query):
+        # The search query is already faceted by the given user,
+        # so remove that user facet.
+        username_facets = _username_facets(request, parsed_query)
+        username_facets.remove(username)
+        if username_facets:
+            parsed_query['user'] = username_facets
+        else:
+            del parsed_query['user']
+    else:
+        # The search query is not yet faceted by the given user, so add a facet
+        # for the user.
+        parsed_query.add('user', username)
+
+    new_params['q'] = parser.unparse(parsed_query)
+
+    location = request.route_url('activity.group_search',
+                                 pubid=request.matchdict['pubid'],
+                                 _query=new_params)
+
+    return httpexceptions.HTTPSeeOther(location=location)
+
+
+def _parsed_query(request):
+    """
+    Return the parsed (MultiDict) query from the given request.
+
+    Return a copy of the given search page request's search query, parsed from
+    a string into a MultiDict.
+
+    """
+    return parser.parse(request.params.get('q', ''))
+
+
+def _username_facets(request, parsed_query=None):
+    """
+    Return a list of the usernames that the search is faceted by.
+
+    Returns a (possibly empty) list of all the usernames that the given
+    search page request's search query is already faceted by.
+
+    """
+    return (parsed_query or _parsed_query(request)).getall('user')
+
+
+def _faceted_by_user(request, username, parsed_query=None):
+    """
+    Return True if the given request is already faceted by the given username.
+
+    Return True if the given search page request's search query already
+    contains a user facet for the given username, False otherwise.
+
+    """
+    return username in _username_facets(request, parsed_query)


### PR DESCRIPTION
Make clicking on one of the usernames in the sidebar on the `/groups/<pubid>/search` page add a facet for that user into the current search query. Clicking on a username adds a user facet to the query, without losing any existing parts of the query (even unsubmitted query words), and reloads the page to update the search results. Once the search is faceted by a user, clicking on the username in the sidebar again _removes_ the facet (same as clicking on the facet's x in the search bar):

![peek 2016-11-09 19-05](https://cloud.githubusercontent.com/assets/22498/20151326/a5fa2cd4-a6b1-11e6-9b5b-75f9c1a55f56.gif)

* * *

There are a number of problems with this list of usernames and annotation counts in the sidebar (and tags, when added, will have the same issues). The problems emerge from the statistics that the server-side code already makes available to the page and that are supposed to be used to render the sidebar. The problems _aren't_ introduced by the code in this PR, this PR just brings them to light. I will describe the problems below, and I think we probably want to make some changes to address these, but I would beg that this current pull request (which does not address any of these problems) be merged first so that we can deploy it behind the feature flag and then demonstrate it to and discuss it with the right people and decide what to do.

The problems that I see are:

My understanding of the requirements for the group search sidebar (and also the user search sidebar still to come) has been that the various stats displayed were to come from the stats that the server-side code already makes available to the page. The `search()` and `group_search()` views make available:

* The total number of annotations that matched the search
* A list of all the users that have created annotations that matched the search (also the number of users that have annotations that matched the search is the length of this list)
* For each user, the number of their annotations that matched the search
* Also the group name, description, date that the group was created on

![screenshot from 2016-11-09 19-25-53](https://cloud.githubusercontent.com/assets/22498/20151538/5ca6780c-a6b2-11e6-9729-ec69b2bc3000.png)

All of these stats are based on _the set of annotations that matched the search_ though, which means the stats are probably not what users will assume they are. For example:

* Users that are members of the group but that haven't created any shared annotations in the group will _not_ be listed
* Users that have created shared annotations in the group but who are no longer members of the group _will_ be listed

It gets worse when you start searching for annotations within the group. For example if I go to `/groups/<pubid>/search` and then type "metrics" into the search box and hit Enter I will end up on `/groups/<pubid>/search?q=metrics` and:

* The total number of annotations shown in the sidebar counts only annotations that belong to the group _and that match the search "metrics"_
* The list of all the users contains only those users that have created an annotation in the group _that matches the search "metrics"
* The number of annotations next to each username will count only those annotations created by that user in the group _and that match the search metrics_

Another example: go to `/groups/<pubid>/search` and click on the username **seanh** in the sidebar. It adds a user:seanh facet into the search query, so you end up at `groups/<pubid>/search?q=user%3A%22seanh%22`. _Now only a single user, seanh, is listed in the list of the group's members in the sidebar_. Because seanh is, obviously, the only user who has created an annotation that was created by seanh.

This raises the question of what should happen if I click on "seanh" in the sidebar when the search is already faceted by seanh, since the sidebar button is supposed to add a search facet into the query, but the query already contains one. For now I've made it _toggle_ the facet into/out of the query, so it'll remove it.