### PR TITLE
Redirect group overview page to group search page

### DIFF
--- a/h/views/groups.py
+++ b/h/views/groups.py
@@ -122,6 +122,11 @@ def read(group, request):
         request.override_renderer = 'h:templates/groups/join.html.jinja2'
         return {'group': group}
 
+    # Redirect to new group overview page if search page is enabled
+    if request.feature('search_page'):
+        url = request.route_path('activity.group_search', pubid=group.pubid)
+        return HTTPSeeOther(url)
+
     return {'group': group,
             'document_links': [presenters.DocumentHTMLPresenter(d).link
                                for d in group.documents()],

--- a/tests/h/views/groups_test.py
+++ b/tests/h/views/groups_test.py
@@ -170,6 +170,14 @@ class TestGroupRead(object):
 
         assert exc.value.location == '/g/abc123/some-slug'
 
+    def test_redirects_if_search_page_enabled(self, matchers, pyramid_request):
+        group = FakeGroup('abc123', 'some-slug')
+        pyramid_request.matchdict['slug'] = 'some-slug'
+        pyramid_request.feature.flags['search_page'] = True
+
+        assert views.read(group, pyramid_request) == matchers.redirect_303_to(
+            '/g/abc123/search')
+
     def test_returns_template_context(self, patch, pyramid_request):
         group = FakeGroup('abc123', 'some-slug')
         group.documents = lambda: ['d1', 'd2']
@@ -325,3 +333,10 @@ def groups_service(pyramid_config):
 @pytest.fixture
 def routes(pyramid_config):
     pyramid_config.add_route('group_read', '/g/{pubid}/{slug}')
+    pyramid_config.add_route('activity.group_search', '/g/{pubid}/search')
+
+
+@pytest.fixture
+def pyramid_request(pyramid_request):
+    pyramid_request.feature.flags['search_page'] = False
+    return pyramid_request


### PR DESCRIPTION
For users with the search_page feature enabled, redirect requests for
the legacy group overview page to the new group profile page which is a
variant of the search page.

This results in the navbar's dropdown group links and links to the
group's page from the client land on the new group profile page.