### PR TITLE
Make usernames link to new user activity page

### DIFF
--- a/h/templates/includes/annotation_card.html.jinja2
+++ b/h/templates/includes/annotation_card.html.jinja2
@@ -2,7 +2,7 @@
 
 <li class="annotation-card">
   <header class="annotation-card__header">
-    <a href="{{ request.route_url('stream') }}?q=user:{{ annotation.username }}"
+    <a href="{{ request.route_url('activity.user_search', username=annotation.username) }}"
       class="annotation-card__username">
       {{ annotation.username }}
     </a>

--- a/h/views/home.py
+++ b/h/views/home.py
@@ -32,8 +32,7 @@ def index(context, request):
         username = request.authenticated_user.username
         context['username'] = username
         context['user_account_link'] = (
-            request.route_url("stream") +
-            "?q=user:{username}".format(username=username)
+            request.route_url('stream.user_query', user=username)
         )
 
     return context

--- a/h/views/main.py
+++ b/h/views/main.py
@@ -15,6 +15,7 @@ from pyramid import response
 from pyramid.view import view_config
 
 from h.views.client import render_app
+from h.util.user import split_user
 
 log = logging.getLogger(__name__)
 
@@ -75,6 +76,20 @@ def stream_tag_redirect(request):
 
 @view_config(route_name='stream.user_query')
 def stream_user_redirect(request):
-    query = {'q': 'user:{}'.format(request.matchdict['user'])}
-    location = request.route_url('stream', _query=query)
+    """
+    Redirect to a user's activity page.
+    """
+
+    user = request.matchdict['user']
+
+    # The client generates /u/ links which include the full account ID
+    if user.startswith('acct:'):
+        user = split_user(user)['username']
+
+    if request.feature('search_page'):
+        location = request.route_url('activity.user_search', username=user)
+    else:
+        query = {'q': 'user:{}'.format(user)}
+        location = request.route_url('stream', _query=query)
+
     raise httpexceptions.HTTPFound(location=location)

--- a/h/views/panels.py
+++ b/h/views/panels.py
@@ -18,7 +18,7 @@ def navbar(context, request):
     """
 
     groups_menu_items = []
-    stream_url = None
+    user_activity_url = None
     username = None
 
     if request.authenticated_user:
@@ -27,8 +27,8 @@ def navbar(context, request):
                 'title': group.name,
                 'link': request.route_url('group_read', pubid=group.pubid, slug=group.slug)
                 })
-        stream_url = (request.route_url('activity.search') +
-            "?q=user:{}".format(request.authenticated_user.username))
+        user_activity_url = request.route_url('activity.user_search',
+            username=request.authenticated_user.username)
         username = request.authenticated_user.username
 
     if request.matched_route.name in ['activity.group_search', 'activity.user_search']:
@@ -48,7 +48,7 @@ def navbar(context, request):
         'create_group_item':
             {'title': _('Create new group'), 'link': request.route_url('group_create')},
         'username': username,
-        'username_url': stream_url,
+        'username_url': user_activity_url,
         'search_url': search_url,
         'q': request.params.get('q', ''),
     }

--- a/tests/h/views/main_test.py
+++ b/tests/h/views/main_test.py
@@ -3,6 +3,7 @@
 from __future__ import unicode_literals
 
 import mock
+from pyramid import httpexceptions
 import pytest
 
 from memex.models.annotation import Annotation
@@ -38,6 +39,40 @@ def test_og_no_document(render_app_html, pyramid_request):
     assert any(test(d) for d in kwargs['extra']['meta_attrs'])
 
 
+@pytest.mark.usefixtures('routes')
+class TestStreamUserRedirect(object):
+
+    def test_it_redirects_to_stream(self, pyramid_request):
+        pyramid_request.matchdict['user'] = 'bob'
+        with pytest.raises(httpexceptions.HTTPFound) as exc:
+            main.stream_user_redirect(pyramid_request)
+
+        assert exc.value.location == 'http://example.com/stream?q=user%3Abob'
+
+    def test_it_redirects_to_user_activity_page(self, pyramid_request):
+        pyramid_request.feature.flags['search_page'] = True
+        pyramid_request.matchdict['user'] = 'bob'
+
+        with pytest.raises(httpexceptions.HTTPFound) as exc:
+            main.stream_user_redirect(pyramid_request)
+
+        assert exc.value.location == 'http://example.com/user/bob/search'
+
+    def test_it_extracts_username_from_account_id(self, pyramid_request):
+        pyramid_request.feature.flags['search_page'] = True
+        pyramid_request.matchdict['user'] = 'acct:bob@hypothes.is'
+
+        with pytest.raises(httpexceptions.HTTPFound) as exc:
+            main.stream_user_redirect(pyramid_request)
+
+        assert exc.value.location == 'http://example.com/user/bob/search'
+
+    @pytest.fixture
+    def routes(self, pyramid_config):
+        pyramid_config.add_route('activity.user_search', '/user/{username}/search')
+        pyramid_config.add_route('stream', '/stream')
+
+
 @pytest.fixture
 def annotation_document(patch):
     return patch('memex.models.annotation.Annotation.document',
@@ -57,6 +92,12 @@ def pyramid_config(pyramid_config):
     # Pretend the client assets environment has been configured
     pyramid_config.registry['assets_client_env'] = mock.Mock()
     return pyramid_config
+
+
+@pytest.fixture
+def pyramid_request(pyramid_request):
+    pyramid_request.feature.flags['search_page'] = False
+    return pyramid_request
 
 
 @pytest.fixture

--- a/tests/h/views/panels_test.py
+++ b/tests/h/views/panels_test.py
@@ -36,7 +36,7 @@ class TestNavbar(object):
         req.authenticated_user = authenticated_user
         result = panels.navbar({}, req)
 
-        assert result['username_url'] == 'http://example.com/search?q=user:vannevar'
+        assert result['username_url'] == 'http://example.com/users/vannevar/search'
 
     def test_it_includes_search_query(self, req):
         req.params['q'] = 'tag:question'


### PR DESCRIPTION
This makes usernames in several places link to the new user activity page instead of the stream, when the search_page feature flag is enabled:

 * The username in the navbar on the home page
 * Usernames in annotation cards in search results
 * Usernames linked in annotation cards from the client

In order to achieve this:
 * The existing `/u/{username|account}` URL now redirects to `/users/{username}/search` if the search_page flag is enabled
 * The homepage now uses the `/u/{username}` route instead of generating the stream URL manually
 * The navbar and search result pages now use the `activity.user_search` route instead of generating URLs manually