### PR TITLE
Add user sidebar to user search page

### DIFF
--- a/h/static/styles/partials-v2/_search-result-sidebar.scss
+++ b/h/static/styles/partials-v2/_search-result-sidebar.scss
@@ -55,6 +55,11 @@
   text-decoration: underline;
 }
 
+.search-result-sidebar__user-link,
+.search-result-sidebar__orcid-link {
+  color: inherit;
+}
+
 .search-result-sidebar__leave-button {
   @include reset-button;
   text-decoration: underline;

--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -105,6 +105,29 @@
 </div>
 {% endmacro %}
 
+{% macro tags_section() %}
+<section class="search-result-sidebar__section">
+  <h3 class="search-result-sidebar__subtitle">
+    {% trans %}Tags{% endtrans %}
+    <span class="search-result-sidebar__subtitle-count">
+      {{ aggregations['tags'] | length }}
+    </span>
+  </h3>
+  <div class="search-result-tags">
+    {% for tag in aggregations.tags %}
+      <div class="search-result-tag js-tag">
+        <div class="search-result-tag__name">
+          {{ tag.tag }}
+        </div>
+        <div class="search-result-tag__count">
+          {{ tag.count }}
+        </div>
+      </div>
+    {% endfor %}
+  </div>
+</section>
+{% endmacro %}
+
 {% macro sidebar(title, description) %}
 <aside class="search-result-sidebar {%- if not more_info %} search-result-hide-on-small-screens{% endif %}">
   <h1 class="search-result-sidebar__title">{{ title }}</h1>
@@ -166,26 +189,7 @@
       </ul>
     </section>
 
-    <section class="search-result-sidebar__section">
-      <h3 class="search-result-sidebar__subtitle">
-        {% trans %}Tags{% endtrans %}
-        <span class="search-result-sidebar__subtitle-count">
-          {{ aggregations['tags'] | length }}
-        </span>
-      </h3>
-      <div class="search-result-tags">
-        {% for tag in aggregations.tags %}
-          <div class="search-result-tag js-tag">
-            <div class="search-result-tag__name">
-              {{ tag.tag }}
-            </div>
-            <div class="search-result-tag__count">
-              {{ tag.count }}
-            </div>
-          </div>
-        {% endfor %}
-      </div>
-    </section>
+    {{ tags_section() }}
 
     <section class="search-result-sidebar__section">
       <h3 class="search-result-sidebar__subtitle">
@@ -281,6 +285,8 @@
         {% endif %}
       </ul>
     </section>
+
+    {{ tags_section() }}
   {% endcall %}
 {% endmacro %}
 

--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -2,7 +2,7 @@
 
 {% from '../includes/annotation_card.html.jinja2' import annotation_card %}
 
-{% macro search_result_nav(group_name) %}
+{% macro search_result_nav(name) %}
 <nav class="search-result-nav">
   {%- if more_info %}
     <form method="POST"> {# This <form> is needed for IE because it doesn't
@@ -15,7 +15,7 @@
       </button>
     </form>
   {% else %}
-    <h1 class="search-result-nav__title">{{ group_name }}</h1>
+    <h1 class="search-result-nav__title">{{ name }}</h1>
     <form method="POST"> {# This <form> is needed for IE because it doesn't
                             support the `form` attribute. #}
       <button form="search-bar"
@@ -105,17 +105,21 @@
 </div>
 {% endmacro %}
 
+{% macro search_result_sidebar_description(description) %}
+{% if description %}
+<section class="search-result-sidebar__section">
+  {% for paragraph in description.split('\n') %}
+    <p>{{ paragraph }}</p>
+  {% endfor %}
+</section>
+{% endif %}
+{% endmacro %}
+
 {% macro group_sidebar(group, group_edit_url, total) %}
 <aside class="search-result-sidebar {%- if not more_info %} search-result-hide-on-small-screens{% endif %}">
   <h1 class="search-result-sidebar__title">{{ group.name }}</h1>
 
-  {% if group.description %}
-  <section class="search-result-sidebar__section">
-    {% for paragraph in group.description.split('\n') %}
-      <p>{{ paragraph }}</p>
-    {% endfor %}
-  </section>
-  {% endif %}
+  {{ search_result_sidebar_description(group.description) }}
 
   <section class="search-result-sidebar__section">
     <dl>
@@ -216,6 +220,72 @@
 </aside>
 {% endmacro %}
 
+{% macro user_sidebar(user) %}
+<aside class="search-result-sidebar {%- if not more_info %} search-result-hide-on-small-screens{% endif %}">
+  <h1 class="search-result-sidebar__title">{{ user.name }}</h1>
+
+  {{ search_result_sidebar_description(user.description) }}
+
+  <section class="search-result-sidebar__section">
+    <dl>
+      <dt class="search-result-sidebar__dt">
+        {% trans %}Annotations:{% endtrans %}
+      </dt>
+      <dd class="search-result-sidebar__dd">{{ user.num_annotations }}</dd>
+
+      <dt class="search-result-sidebar__dt">
+        {% trans %}Joined:{% endtrans %}
+      </dt>
+      <dd class="search-result-sidebar__dd">{{ user.registered_date }}</dd>
+
+      {%- if user.location %}
+        <dt class="search-result-sidebar__dt">
+          {% trans %}Location:{% endtrans %}
+        </dt>
+        <dd class="search-result-sidebar__dd">{{ user.location }}</dd>
+      {% endif -%}
+
+      {%- if user.uri %}
+        <dt class="search-result-sidebar__dt">
+          {% trans %}Link:{% endtrans %}
+        </dt>
+        <dd class="search-result-sidebar__dd">
+          <a href="{{ user.uri }}" class="search-result-sidebar__user-link">
+            {{ user.domain }}
+          </a>
+        </dd>
+      {% endif -%}
+
+      {%- if user.orcid %}
+        <dt class="search-result-sidebar__dt">
+          {% trans %}ORCID:{% endtrans %}
+        </dt>
+        <dd class="search-result-sidebar__dd">
+          <a href="https://orcid.org/{{ user.orcid }}"
+             class="search-result-sidebar__orcid-link">
+            {{ user.orcid }}
+          </a>
+        </dd>
+      {% endif -%}
+    </dl>
+    <div style="clear: both;"></div>
+  </section>
+
+  <section class="search-result-sidebar__section">
+    <ul>
+      {% if user.edit_url %}
+        <li>
+          <a class="search-result-sidebar__link"
+             href="{{ user.edit_url }}">
+            {% trans %}Edit profile{% endtrans %}
+          </a>
+        </li>
+      {% endif %}
+    </ul>
+  </section>
+</aside>
+{% endmacro %}
+
 {% block content %}
 
   {{ panel('navbar', opts or {}) }}
@@ -231,6 +301,8 @@
   <div class="search-result-container">
     {% if group %}
       {{ search_result_nav(group.name) }}
+    {% elif user %}
+      {{ search_result_nav(user.name) }}
     {% endif %}
 
     <ol class="search-result-list {%- if more_info %} search-result-hide-on-small-screens{% endif %}">
@@ -248,6 +320,8 @@
 
     {% if group %}
       {{ group_sidebar(group, group_edit_url, total) }}
+    {% elif user %}
+      {{ user_sidebar(user) }}
     {% endif %}
   </div>
 

--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -105,6 +105,117 @@
 </div>
 {% endmacro %}
 
+{% macro group_sidebar(group, group_edit_url, total) %}
+<aside class="search-result-sidebar {%- if not more_info %} search-result-hide-on-small-screens{% endif %}">
+  <h1 class="search-result-sidebar__title">{{ group.name }}</h1>
+
+  {% if group.description %}
+  <section class="search-result-sidebar__section">
+    {% for paragraph in group.description.split('\n') %}
+      <p>{{ paragraph }}</p>
+    {% endfor %}
+  </section>
+  {% endif %}
+
+  <section class="search-result-sidebar__section">
+    <dl>
+      <dt class="search-result-sidebar__dt">
+        {% trans %}Annotations:{% endtrans %}
+      </dt>
+      <dd class="search-result-sidebar__dd">{{ total }}</dd>
+
+      <dt class="search-result-sidebar__dt">
+        {% trans %}Created:{% endtrans %}
+      </dt>
+      <dd class="search-result-sidebar__dd">{{ group.created }}</dd>
+    </dl>
+    <div style="clear: both;"></div>
+  </section>
+
+  <section class="search-result-sidebar__section">
+    <ul>
+      {% if group_edit_url %}
+        <li>
+          <a class="search-result-sidebar__link"
+             href="{{ group_edit_url }}">
+            {% trans %}Edit group{% endtrans %}
+          </a>
+        </li>
+      {% endif %}
+        <li>
+        {#- This form element is needed for Internet Explorer because it
+            doesn't support the `form` attribute. See commit message. #}
+        <form method="POST">
+          <button class="search-result-sidebar__leave-button js-confirm-submit"
+                  form="search-bar"
+                  formmethod="POST"
+                  type="submit"
+                  name="group_leave"
+                  value="{{ group.pubid }}"
+                  data-confirm-message="Are you sure you want to leave the group &quot;{{ group.name }}&quot;?">
+              {% trans %}Leave this group{% endtrans %}
+          </button>
+        </form>
+      </li>
+    </ul>
+  </section>
+
+  <section class="search-result-sidebar__section">
+    <h3 class="search-result-sidebar__subtitle">
+      {% trans %}Tags{% endtrans %}
+      <span class="search-result-sidebar__subtitle-count">
+        {{ aggregations['tags'] | length }}
+      </span>
+    </h3>
+    <div class="search-result-tags">
+      {% for tag in aggregations.tags %}
+        <div class="search-result-tag js-tag">
+          <div class="search-result-tag__name">
+            {{ tag.tag }}
+          </div>
+          <div class="search-result-tag__count">
+            {{ tag.count }}
+          </div>
+        </div>
+      {% endfor %}
+    </div>
+  </section>
+
+  <section class="search-result-sidebar__section">
+    <h3 class="search-result-sidebar__subtitle">
+      {% trans %}Members{% endtrans %}
+      <span class="search-result-sidebar-title__annotations-count">
+        {{ aggregations.users|length }}
+      <span>
+    </h3>
+    <ul>
+      {% for user in aggregations.users %}
+        <li>
+          <button type="submit"
+                  form="search-bar"
+                  formmethod="POST"
+                  name="toggle_user_facet"
+                  value="{{ user.userid }}"
+                  {% if user.faceted_by %}
+                    title="{% trans username=user.username %}Remove {{ username }} from the search query{% endtrans %}"
+                  {% else %}
+                    title="{% trans username=user.username %}Limit the search to annotations by {{ username }}{% endtrans %}"
+                  {% endif %}
+                  class="search-result-sidebar__username">
+            {{ user.username }}
+            <span class="search-result-sidebar__annotations-count">
+              {{ user.count }}
+            </span>
+          </button>
+        </li>
+      {% endfor %}
+    </ul>
+  </section>
+
+  {{ panel('group_invite', group.url) }}
+</aside>
+{% endmacro %}
+
 {% block content %}
 
   {{ panel('navbar', opts or {}) }}
@@ -136,114 +247,7 @@
     </ol>
 
     {% if group %}
-    <aside class="search-result-sidebar {%- if not more_info %} search-result-hide-on-small-screens{% endif %}">
-      <h1 class="search-result-sidebar__title">{{ group.name }}</h1>
-
-      {% if group.description %}
-      <section class="search-result-sidebar__section">
-        {% for paragraph in group.description.split('\n') %}
-          <p>{{ paragraph }}</p>
-        {% endfor %}
-      </section>
-      {% endif %}
-
-      <section class="search-result-sidebar__section">
-        <dl>
-          <dt class="search-result-sidebar__dt">
-            {% trans %}Annotations:{% endtrans %}
-          </dt>
-          <dd class="search-result-sidebar__dd">{{ total }}</dd>
-
-          <dt class="search-result-sidebar__dt">
-            {% trans %}Created:{% endtrans %}
-          </dt>
-          <dd class="search-result-sidebar__dd">{{ group.created }}</dd>
-        </dl>
-        <div style="clear: both;"></div>
-      </section>
-
-      <section class="search-result-sidebar__section">
-        <ul>
-          {% if group_edit_url %}
-            <li>
-              <a class="search-result-sidebar__link"
-                 href="{{ group_edit_url }}">
-                {% trans %}Edit group{% endtrans %}
-              </a>
-            </li>
-          {% endif %}
-            <li>
-            {#- This form element is needed for Internet Explorer because it
-                doesn't support the `form` attribute. See commit message. #}
-            <form method="POST">
-              <button class="search-result-sidebar__leave-button js-confirm-submit"
-                      form="search-bar"
-                      formmethod="POST"
-                      type="submit"
-                      name="group_leave"
-                      value="{{ group.pubid }}"
-                      data-confirm-message="Are you sure you want to leave the group &quot;{{ group.name }}&quot;?">
-                  {% trans %}Leave this group{% endtrans %}
-              </button>
-            </form>
-          </li>
-        </ul>
-      </section>
-
-      <section class="search-result-sidebar__section">
-        <h3 class="search-result-sidebar__subtitle">
-          {% trans %}Members{% endtrans %}
-          <span class="search-result-sidebar-title__annotations-count">
-            {{ aggregations.users|length }}
-          <span>
-        </h3>
-        <ul>
-          {% for user in aggregations.users %}
-            <li>
-              <button type="submit"
-                      form="search-bar"
-                      formmethod="POST"
-                      name="toggle_user_facet"
-                      value="{{ user.userid }}"
-                      {% if user.faceted_by %}
-                        title="{% trans username=user.username %}Remove {{ username }} from the search query{% endtrans %}"
-                      {% else %}
-                        title="{% trans username=user.username %}Limit the search to annotations by {{ username }}{% endtrans %}"
-                      {% endif %}
-                      class="search-result-sidebar__username">
-                {{ user.username }}
-                <span class="search-result-sidebar__annotations-count">
-                  {{ user.count }}
-                </span>
-              </button>
-            </li>
-          {% endfor %}
-        </ul>
-      </section>
-
-      <section class="search-result-sidebar__section">
-        <h3 class="search-result-sidebar__subtitle">
-          {% trans %}Tags{% endtrans %}
-          <span class="search-result-sidebar__subtitle-count">
-            {{ aggregations['tags'] | length }}
-          </span>
-        </h3>
-        <div class="search-result-tags">
-          {% for tag in aggregations.tags %}
-            <div class="search-result-tag js-tag">
-              <div class="search-result-tag__name">
-                {{ tag.tag }}
-              </div>
-              <div class="search-result-tag__count">
-                {{ tag.count }}
-              </div>
-            </div>
-          {% endfor %}
-        </div>
-      </section>
-
-      {{ panel('group_invite', group.url) }}
-    </aside>
+      {{ group_sidebar(group, group_edit_url, total) }}
     {% endif %}
   </div>
 

--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -105,185 +105,183 @@
 </div>
 {% endmacro %}
 
-{% macro search_result_sidebar_description(description) %}
-{% if description %}
-<section class="search-result-sidebar__section">
-  {% for paragraph in description.split('\n') %}
-    <p>{{ paragraph }}</p>
-  {% endfor %}
-</section>
-{% endif %}
+{% macro sidebar(title, description) %}
+<aside class="search-result-sidebar {%- if not more_info %} search-result-hide-on-small-screens{% endif %}">
+  <h1 class="search-result-sidebar__title">{{ title }}</h1>
+
+  {% if description %}
+  <section class="search-result-sidebar__section">
+    {% for paragraph in description.split('\n') %}
+      <p>{{ paragraph }}</p>
+    {% endfor %}
+  </section>
+  {% endif %}
+
+  {{ caller() }}
+</aside>
 {% endmacro %}
 
 {% macro group_sidebar(group, group_edit_url, total) %}
-<aside class="search-result-sidebar {%- if not more_info %} search-result-hide-on-small-screens{% endif %}">
-  <h1 class="search-result-sidebar__title">{{ group.name }}</h1>
+  {% call sidebar(group.name, group.description) %}
+    <section class="search-result-sidebar__section">
+      <dl>
+        <dt class="search-result-sidebar__dt">
+          {% trans %}Annotations:{% endtrans %}
+        </dt>
+        <dd class="search-result-sidebar__dd">{{ total }}</dd>
 
-  {{ search_result_sidebar_description(group.description) }}
+        <dt class="search-result-sidebar__dt">
+          {% trans %}Created:{% endtrans %}
+        </dt>
+        <dd class="search-result-sidebar__dd">{{ group.created }}</dd>
+      </dl>
+      <div style="clear: both;"></div>
+    </section>
 
-  <section class="search-result-sidebar__section">
-    <dl>
-      <dt class="search-result-sidebar__dt">
-        {% trans %}Annotations:{% endtrans %}
-      </dt>
-      <dd class="search-result-sidebar__dd">{{ total }}</dd>
-
-      <dt class="search-result-sidebar__dt">
-        {% trans %}Created:{% endtrans %}
-      </dt>
-      <dd class="search-result-sidebar__dd">{{ group.created }}</dd>
-    </dl>
-    <div style="clear: both;"></div>
-  </section>
-
-  <section class="search-result-sidebar__section">
-    <ul>
-      {% if group_edit_url %}
-        <li>
-          <a class="search-result-sidebar__link"
-             href="{{ group_edit_url }}">
-            {% trans %}Edit group{% endtrans %}
-          </a>
+    <section class="search-result-sidebar__section">
+      <ul>
+        {% if group_edit_url %}
+          <li>
+            <a class="search-result-sidebar__link"
+               href="{{ group_edit_url }}">
+              {% trans %}Edit group{% endtrans %}
+            </a>
+          </li>
+        {% endif %}
+          <li>
+          {#- This form element is needed for Internet Explorer because it
+              doesn't support the `form` attribute. See commit message. #}
+          <form method="POST">
+            <button class="search-result-sidebar__leave-button js-confirm-submit"
+                    form="search-bar"
+                    formmethod="POST"
+                    type="submit"
+                    name="group_leave"
+                    value="{{ group.pubid }}"
+                    data-confirm-message="Are you sure you want to leave the group &quot;{{ group.name }}&quot;?">
+                {% trans %}Leave this group{% endtrans %}
+            </button>
+          </form>
         </li>
-      {% endif %}
-        <li>
-        {#- This form element is needed for Internet Explorer because it
-            doesn't support the `form` attribute. See commit message. #}
-        <form method="POST">
-          <button class="search-result-sidebar__leave-button js-confirm-submit"
-                  form="search-bar"
-                  formmethod="POST"
-                  type="submit"
-                  name="group_leave"
-                  value="{{ group.pubid }}"
-                  data-confirm-message="Are you sure you want to leave the group &quot;{{ group.name }}&quot;?">
-              {% trans %}Leave this group{% endtrans %}
-          </button>
-        </form>
-      </li>
-    </ul>
-  </section>
+      </ul>
+    </section>
 
-  <section class="search-result-sidebar__section">
-    <h3 class="search-result-sidebar__subtitle">
-      {% trans %}Tags{% endtrans %}
-      <span class="search-result-sidebar__subtitle-count">
-        {{ aggregations['tags'] | length }}
-      </span>
-    </h3>
-    <div class="search-result-tags">
-      {% for tag in aggregations.tags %}
-        <div class="search-result-tag js-tag">
-          <div class="search-result-tag__name">
-            {{ tag.tag }}
+    <section class="search-result-sidebar__section">
+      <h3 class="search-result-sidebar__subtitle">
+        {% trans %}Tags{% endtrans %}
+        <span class="search-result-sidebar__subtitle-count">
+          {{ aggregations['tags'] | length }}
+        </span>
+      </h3>
+      <div class="search-result-tags">
+        {% for tag in aggregations.tags %}
+          <div class="search-result-tag js-tag">
+            <div class="search-result-tag__name">
+              {{ tag.tag }}
+            </div>
+            <div class="search-result-tag__count">
+              {{ tag.count }}
+            </div>
           </div>
-          <div class="search-result-tag__count">
-            {{ tag.count }}
-          </div>
-        </div>
-      {% endfor %}
-    </div>
-  </section>
+        {% endfor %}
+      </div>
+    </section>
 
-  <section class="search-result-sidebar__section">
-    <h3 class="search-result-sidebar__subtitle">
-      {% trans %}Members{% endtrans %}
-      <span class="search-result-sidebar-title__annotations-count">
-        {{ aggregations.users|length }}
-      <span>
-    </h3>
-    <ul>
-      {% for user in aggregations.users %}
-        <li>
-          <button type="submit"
-                  form="search-bar"
-                  formmethod="POST"
-                  name="toggle_user_facet"
-                  value="{{ user.userid }}"
-                  {% if user.faceted_by %}
-                    title="{% trans username=user.username %}Remove {{ username }} from the search query{% endtrans %}"
-                  {% else %}
-                    title="{% trans username=user.username %}Limit the search to annotations by {{ username }}{% endtrans %}"
-                  {% endif %}
-                  class="search-result-sidebar__username">
-            {{ user.username }}
-            <span class="search-result-sidebar__annotations-count">
-              {{ user.count }}
-            </span>
-          </button>
-        </li>
-      {% endfor %}
-    </ul>
-  </section>
+    <section class="search-result-sidebar__section">
+      <h3 class="search-result-sidebar__subtitle">
+        {% trans %}Members{% endtrans %}
+        <span class="search-result-sidebar-title__annotations-count">
+          {{ aggregations.users|length }}
+        <span>
+      </h3>
+      <ul>
+        {% for user in aggregations.users %}
+          <li>
+            <button type="submit"
+                    form="search-bar"
+                    formmethod="POST"
+                    name="toggle_user_facet"
+                    value="{{ user.userid }}"
+                    {% if user.faceted_by %}
+                      title="{% trans username=user.username %}Remove {{ username }} from the search query{% endtrans %}"
+                    {% else %}
+                      title="{% trans username=user.username %}Limit the search to annotations by {{ username }}{% endtrans %}"
+                    {% endif %}
+                    class="search-result-sidebar__username">
+              {{ user.username }}
+              <span class="search-result-sidebar__annotations-count">
+                {{ user.count }}
+              </span>
+            </button>
+          </li>
+        {% endfor %}
+      </ul>
+    </section>
 
-  {{ panel('group_invite', group.url) }}
-</aside>
+    {{ panel('group_invite', group.url) }}
+  {% endcall %}
 {% endmacro %}
 
 {% macro user_sidebar(user) %}
-<aside class="search-result-sidebar {%- if not more_info %} search-result-hide-on-small-screens{% endif %}">
-  <h1 class="search-result-sidebar__title">{{ user.name }}</h1>
-
-  {{ search_result_sidebar_description(user.description) }}
-
-  <section class="search-result-sidebar__section">
-    <dl>
-      <dt class="search-result-sidebar__dt">
-        {% trans %}Annotations:{% endtrans %}
-      </dt>
-      <dd class="search-result-sidebar__dd">{{ user.num_annotations }}</dd>
-
-      <dt class="search-result-sidebar__dt">
-        {% trans %}Joined:{% endtrans %}
-      </dt>
-      <dd class="search-result-sidebar__dd">{{ user.registered_date }}</dd>
-
-      {%- if user.location %}
+  {% call sidebar(user.name, user.description) %}
+    <section class="search-result-sidebar__section">
+      <dl>
         <dt class="search-result-sidebar__dt">
-          {% trans %}Location:{% endtrans %}
+          {% trans %}Annotations:{% endtrans %}
         </dt>
-        <dd class="search-result-sidebar__dd">{{ user.location }}</dd>
-      {% endif -%}
+        <dd class="search-result-sidebar__dd">{{ user.num_annotations }}</dd>
 
-      {%- if user.uri %}
         <dt class="search-result-sidebar__dt">
-          {% trans %}Link:{% endtrans %}
+          {% trans %}Joined:{% endtrans %}
         </dt>
-        <dd class="search-result-sidebar__dd">
-          <a href="{{ user.uri }}" class="search-result-sidebar__user-link">
-            {{ user.domain }}
-          </a>
-        </dd>
-      {% endif -%}
+        <dd class="search-result-sidebar__dd">{{ user.registered_date }}</dd>
 
-      {%- if user.orcid %}
-        <dt class="search-result-sidebar__dt">
-          {% trans %}ORCID:{% endtrans %}
-        </dt>
-        <dd class="search-result-sidebar__dd">
-          <a href="https://orcid.org/{{ user.orcid }}"
-             class="search-result-sidebar__orcid-link">
-            {{ user.orcid }}
-          </a>
-        </dd>
-      {% endif -%}
-    </dl>
-    <div style="clear: both;"></div>
-  </section>
+        {%- if user.location %}
+          <dt class="search-result-sidebar__dt">
+            {% trans %}Location:{% endtrans %}
+          </dt>
+          <dd class="search-result-sidebar__dd">{{ user.location }}</dd>
+        {% endif -%}
 
-  <section class="search-result-sidebar__section">
-    <ul>
-      {% if user.edit_url %}
-        <li>
-          <a class="search-result-sidebar__link"
-             href="{{ user.edit_url }}">
-            {% trans %}Edit profile{% endtrans %}
-          </a>
-        </li>
-      {% endif %}
-    </ul>
-  </section>
-</aside>
+        {%- if user.uri %}
+          <dt class="search-result-sidebar__dt">
+            {% trans %}Link:{% endtrans %}
+          </dt>
+          <dd class="search-result-sidebar__dd">
+            <a href="{{ user.uri }}" class="search-result-sidebar__user-link">
+              {{ user.domain }}
+            </a>
+          </dd>
+        {% endif -%}
+
+        {%- if user.orcid %}
+          <dt class="search-result-sidebar__dt">
+            {% trans %}ORCID:{% endtrans %}
+          </dt>
+          <dd class="search-result-sidebar__dd">
+            <a href="https://orcid.org/{{ user.orcid }}"
+               class="search-result-sidebar__orcid-link">
+              {{ user.orcid }}
+            </a>
+          </dd>
+        {% endif -%}
+      </dl>
+      <div style="clear: both;"></div>
+    </section>
+
+    <section class="search-result-sidebar__section">
+      <ul>
+        {% if user.edit_url %}
+          <li>
+            <a class="search-result-sidebar__link"
+               href="{{ user.edit_url }}">
+              {% trans %}Edit profile{% endtrans %}
+            </a>
+          </li>
+        {% endif %}
+      </ul>
+    </section>
+  {% endcall %}
 {% endmacro %}
 
 {% block content %}

--- a/h/views/activity.py
+++ b/h/views/activity.py
@@ -110,9 +110,8 @@ def user_search(request):
     result['opts'] = {'search_username': username}
     result['more_info'] = 'more_info' in request.params
 
-    user = request.find_service(name='user').fetch(
-        'acct:{username}@{authority}'.format(username=username,
-                                             authority=request.auth_domain))
+    user = request.find_service(name='user').fetch(username,
+                                                   request.auth_domain)
 
     if not user:
         return result

--- a/h/views/activity.py
+++ b/h/views/activity.py
@@ -4,6 +4,8 @@
 
 from __future__ import unicode_literals
 
+import urlparse
+
 from pyramid import httpexceptions
 from pyramid.view import view_config
 from sqlalchemy.orm import exc
@@ -51,6 +53,7 @@ def search(request):
         'page': paginate(request, result.total, page_size=page_size),
     }
 
+
 @view_config(route_name='activity.group_search',
              request_method='GET',
              renderer='h:templates/activity/search.html.jinja2')
@@ -92,31 +95,76 @@ def group_search(request):
 
     return result
 
+
+@view_config(route_name='activity.user_search',
+             request_method='GET',
+             renderer='h:templates/activity/search.html.jinja2')
+def user_search(request):
+    if not request.feature('search_page'):
+        raise httpexceptions.HTTPNotFound()
+
+    username = request.matchdict['username']
+
+    result = search(request)
+
+    result['opts'] = {'search_username': username}
+    result['more_info'] = 'more_info' in request.params
+
+    user = request.find_service(name='user').fetch(
+        'acct:{username}@{authority}'.format(username=username,
+                                             authority=request.auth_domain))
+
+    if not user:
+        return result
+
+    def domain(user):
+        if not user.uri:
+            return None
+        return urlparse.urlparse(user.uri).netloc
+
+    result['user'] = {
+        'name': user.display_name or user.username,
+        'num_annotations': result['total'],
+        'description': user.description,
+        'registered_date': user.registered_date.strftime('%B, %Y'),
+        'location': user.location,
+        'uri': user.uri,
+        'domain': domain(user),
+        'orcid': user.orcid,
+    }
+
+    if request.authenticated_user == user:
+        result['user']['edit_url'] = request.route_url('account_profile')
+
+    return result
+
+
 @view_config(route_name='activity.group_search',
              request_method='POST',
              renderer='h:templates/activity/search.html.jinja2',
              request_param='more_info')
-def group_search_more_info(request):
+@view_config(route_name='activity.user_search',
+             request_method='POST',
+             renderer='h:templates/activity/search.html.jinja2',
+             request_param='more_info')
+def search_more_info(request):
     """Respond to a click on the ``more_info`` button."""
-    new_params = request.POST.copy()
-    location = request.route_url('activity.group_search',
-                                 pubid=request.matchdict['pubid'],
-                                 _query=new_params)
-    return httpexceptions.HTTPSeeOther(location=location)
+    return _redirect_to_user_or_group_search(request, request.POST)
 
 
 @view_config(route_name='activity.group_search',
              request_method='POST',
              renderer='h:templates/activity/search.html.jinja2',
              request_param='back')
-def group_search_back(request):
+@view_config(route_name='activity.user_search',
+             request_method='POST',
+             renderer='h:templates/activity/search.html.jinja2',
+             request_param='back')
+def search_back(request):
     """Respond to a click on the ``back`` button."""
     new_params = request.POST.copy()
     del new_params['back']
-    location = request.route_url('activity.group_search',
-                                 pubid=request.matchdict['pubid'],
-                                 _query=new_params)
-    return httpexceptions.HTTPSeeOther(location=location)
+    return _redirect_to_user_or_group_search(request, new_params)
 
 
 @view_config(route_name='activity.group_search',
@@ -148,6 +196,7 @@ def group_leave(request):
     location = request.route_url('activity.search', _query=new_params)
 
     return httpexceptions.HTTPSeeOther(location=location)
+
 
 @view_config(route_name='activity.group_search',
              request_method='POST',
@@ -231,18 +280,14 @@ def _faceted_by_user(request, username, parsed_query=None):
     """
     return username in _username_facets(request, parsed_query)
 
-@view_config(route_name='activity.user_search',
-             request_method='GET',
-             renderer='h:templates/activity/search.html.jinja2')
-def user_search(request):
-    if not request.feature('search_page'):
-        raise httpexceptions.HTTPNotFound()
 
-    opts = {}
-    result = search(request)
-    username = request.matchdict['username']
-
-    opts['search_username'] = username
-    result['opts'] = opts
-
-    return result
+def _redirect_to_user_or_group_search(request, params):
+    if request.matched_route.name == 'activity.group_search':
+        location = request.route_url('activity.group_search',
+                                     pubid=request.matchdict['pubid'],
+                                     _query=params)
+    elif request.matched_route.name == 'activity.user_search':
+        location = request.route_url('activity.user_search',
+                                     username=request.matchdict['username'],
+                                     _query=params)
+    return httpexceptions.HTTPSeeOther(location=location)

--- a/tests/common/factories.py
+++ b/tests/common/factories.py
@@ -89,6 +89,7 @@ class User(factory.Factory):
     authority = 'example.com'
     username = factory.Faker('user_name')
     email = factory.Faker('email')
+    registered_date = factory.Faker('date_time_this_decade')
 
     @factory.lazy_attribute
     def uid(self):

--- a/tests/h/accounts/services_test.py
+++ b/tests/h/accounts/services_test.py
@@ -24,6 +24,11 @@ class TestUserService(object):
 
         assert isinstance(result, User)
 
+    def test_fetch_retrieves_user_by_username_and_authority(self, svc):
+        result = svc.fetch('jacqui', 'foo.com')
+
+        assert isinstance(result, User)
+
     def test_fetch_caches_fetched_users(self, db_session, svc, users):
         jacqui, _, _ = users
 

--- a/tests/h/views/activity_test.py
+++ b/tests/h/views/activity_test.py
@@ -421,7 +421,8 @@ class TestUserSearch(object):
     def test_it_fetches_the_user(self, pyramid_request, user, user_service):
         activity.user_search(pyramid_request)
 
-        user_service.fetch.assert_called_once_with(user.userid)
+        user_service.fetch.assert_called_once_with(user.username,
+                                                   'example.com')
 
     def test_it_does_not_pass_user_to_template_if_user_does_not_exist(
             self, pyramid_request, user_service):

--- a/tests/h/views/activity_test.py
+++ b/tests/h/views/activity_test.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 
-import pytest
+import datetime
 
+import pytest
 import mock
 from pyramid import httpexceptions
 from webob.multidict import NestedMultiDict
@@ -247,14 +248,16 @@ class TestGroupSearch(object):
         pyramid_config.add_route('group_edit', '/groups/{pubid}/edit')
 
 @pytest.mark.usefixtures('routes')
-class TestGroupSearchMoreInfo(object):
+class TestSearchMoreInfo(object):
 
     def test_it_redirects_to_group_search(self, pyramid_request):
         """It should redirect and preserve the search query param."""
         pyramid_request.matchdict['pubid'] = 'test_pubid'
+        pyramid_request.matched_route = mock.Mock()
+        pyramid_request.matched_route.name='activity.group_search'
         pyramid_request.POST = {'q': 'foo bar', 'more_info': ''}
 
-        result = activity.group_search_more_info(pyramid_request)
+        result = activity.search_more_info(pyramid_request)
 
         assert isinstance(result, httpexceptions.HTTPSeeOther)
         assert result.location.startswith(
@@ -264,30 +267,66 @@ class TestGroupSearchMoreInfo(object):
         assert 'more_info=' in result.location
         assert 'q=foo+bar' in result.location
 
+    def test_it_redirects_to_user_search(self, pyramid_request):
+        """It should redirect and preserve the search query param."""
+        pyramid_request.matchdict['username'] = 'test_username'
+        pyramid_request.matched_route = mock.Mock()
+        pyramid_request.matched_route.name='activity.user_search'
+        pyramid_request.POST = {'q': 'foo bar', 'more_info': ''}
+
+        result = activity.search_more_info(pyramid_request)
+
+        assert isinstance(result, httpexceptions.HTTPSeeOther)
+        assert result.location.startswith(
+            'http://example.com/users/test_username/search?')
+        # The order of the params vary (because they're in an unordered dict)
+        # but they should both be there.
+        assert 'more_info=' in result.location
+        assert 'q=foo+bar' in result.location
+
     @pytest.fixture
     def routes(self, pyramid_config):
         pyramid_config.add_route('activity.group_search',
                                  '/groups/{pubid}/search')
+        pyramid_config.add_route('activity.user_search',
+                                 '/users/{username}/search')
 
 
 @pytest.mark.usefixtures('routes')
-class TestGroupSearchBack(object):
+class TestSearchBack(object):
 
     def test_it_redirects_to_group_search(self, pyramid_request):
         """It should redirect and preserve the search query param."""
         pyramid_request.matchdict['pubid'] = 'test_pubid'
+        pyramid_request.matched_route = mock.Mock()
+        pyramid_request.matched_route.name='activity.group_search'
         pyramid_request.POST = {'q': 'foo bar', 'back': ''}
 
-        result = activity.group_search_back(pyramid_request)
+        result = activity.search_back(pyramid_request)
 
         assert isinstance(result, httpexceptions.HTTPSeeOther)
         assert result.location == (
             'http://example.com/groups/test_pubid/search?q=foo+bar')
 
+    def test_it_redirects_to_user_search(self, pyramid_request):
+        """It should redirect and preserve the search query param."""
+        pyramid_request.matchdict['username'] = 'test_username'
+        pyramid_request.matched_route = mock.Mock()
+        pyramid_request.matched_route.name='activity.user_search'
+        pyramid_request.POST = {'q': 'foo bar', 'back': ''}
+
+        result = activity.search_back(pyramid_request)
+
+        assert isinstance(result, httpexceptions.HTTPSeeOther)
+        assert result.location == (
+            'http://example.com/users/test_username/search?q=foo+bar')
+
     @pytest.fixture
     def routes(self, pyramid_config):
         pyramid_config.add_route('activity.group_search',
                                  '/groups/{pubid}/search')
+        pyramid_config.add_route('activity.user_search',
+                                 '/users/{username}/search')
 
 @pytest.mark.usefixtures('groups_service', 'routes')
 class TestGroupLeave(object):
@@ -347,6 +386,7 @@ class TestGroupLeave(object):
     def routes(self, pyramid_config):
         pyramid_config.add_route('activity.search', '/search')
 
+@pytest.mark.usefixtures('routes', 'search', 'user_service')
 class TestUserSearch(object):
     def test_it_returns_404_when_feature_turned_off(self,
                                                     pyramid_request):
@@ -355,26 +395,128 @@ class TestUserSearch(object):
         with pytest.raises(httpexceptions.HTTPNotFound):
             activity.user_search(pyramid_request)
 
-    @pytest.mark.usefixtures('search')
     def test_it_calls_search_with_request(self, pyramid_request, search):
         activity.user_search(pyramid_request)
         search.assert_called_once_with(pyramid_request)
 
-    @pytest.mark.usefixtures('search')
-    def test_it_returns_user_search_results(self, pyramid_request, search):
+    def test_it_returns_user_search_results(self,
+                                            pyramid_request,
+                                            search,
+                                            user):
       results = activity.user_search(pyramid_request)
-      assert results['opts']['search_username'] == 'foo'
+      assert results['opts']['search_username'] == user.username
+
+    def test_it_shows_the_more_info_version_of_the_page_if_more_info_is_in_the_request_params(
+            self,
+            pyramid_request):
+        pyramid_request.params['more_info'] = ''
+
+        assert activity.user_search(pyramid_request)['more_info'] is True
+
+    def test_it_shows_the_normal_version_of_the_page_if_more_info_is_not_in_the_request_params(
+            self,
+            pyramid_request):
+        assert activity.user_search(pyramid_request)['more_info'] is False
+
+    def test_it_fetches_the_user(self, pyramid_request, user, user_service):
+        activity.user_search(pyramid_request)
+
+        user_service.fetch.assert_called_once_with(user.userid)
+
+    def test_it_does_not_pass_user_to_template_if_user_does_not_exist(
+            self, pyramid_request, user_service):
+        user_service.fetch.return_value = None
+
+        assert 'user' not in activity.user_search(pyramid_request)
+
+    def test_it_passes_the_username_to_the_template_if_the_user_has_no_display_name(
+            self, pyramid_request, user):
+        user.display_name = None
+
+        username = activity.user_search(pyramid_request)['user']['name']
+
+        assert username == user.username
+
+    def test_it_passes_the_display_name_to_the_template_if_the_user_has_one(
+            self, pyramid_request, user):
+        user.display_name = "Display Name"
+
+        username = activity.user_search(pyramid_request)['user']['name']
+
+        assert username == user.display_name
+
+    def test_it_passes_the_num_annotations_to_the_template(self,
+                                                           pyramid_request,
+                                                           search):
+        user_details = activity.user_search(pyramid_request)['user']
+
+        assert user_details['num_annotations'] == search.return_value['total']
+
+    def test_it_passes_the_other_user_details_to_the_template(self,
+                                                              factories,
+                                                              pyramid_request,
+                                                              user_service):
+        user = factories.User(
+            registered_date=datetime.datetime(year=2016, month=8, day=1),
+            uri='http://www.example.com/me',
+            orcid='0000-0000-0000-0000',
+        )
+        user_service.fetch.return_value = user
+
+        user_details = activity.user_search(pyramid_request)['user']
+
+        assert user_details['description'] == user.description
+        assert user_details['registered_date'] == 'August, 2016'
+        assert user_details['location'] == user.location
+        assert user_details['uri'] == user.uri
+        assert user_details['domain'] == 'www.example.com'
+        assert user_details['orcid'] == user.orcid
+
+    def test_it_passes_the_edit_url_to_the_template(self,
+                                                    pyramid_request,
+                                                    user,
+                                                    user_service):
+        # The user whose page we're on is the same user as the authenticated
+        # user.
+        pyramid_request.authenticated_user = user
+        user_service.fetch.return_value = user
+
+        user_details = activity.user_search(pyramid_request)['user']
+
+        assert user_details['edit_url'] == 'http://example.com/account/profile'
+
+    def test_it_does_not_pass_the_edit_url_to_the_template(self,
+                                                           factories,
+                                                           pyramid_request,
+                                                           user_service):
+        # The user whose page we're on is *not* the same user as the
+        # authenticated user.
+        pyramid_request.authenticated_user = factories.User()
+        user_service.fetch.return_value = factories.User()
+
+        assert 'edit_url' not in activity.user_search(pyramid_request)['user']
 
     @pytest.fixture
-    def pyramid_request(self, pyramid_request):
-        pyramid_request.matchdict['username'] = 'foo'
+    def pyramid_request(self, pyramid_request, user):
+        pyramid_request.matchdict['username'] = user.username
+        pyramid_request.authenticated_user = user
         return pyramid_request
 
-@pytest.fixture
-def search(patch):
-    search = patch('h.views.activity.search')
-    search.return_value = {}
-    return search
+    @pytest.fixture
+    def routes(self, pyramid_config):
+        pyramid_config.add_route('account_profile', '/account/profile')
+
+    @pytest.fixture
+    def user(self, factories):
+        return factories.User()
+
+    @pytest.fixture
+    def user_service(self, pyramid_config, user):
+        user_service = mock.Mock(spec_set=['fetch'])
+        user_service.fetch.return_value = user
+        pyramid_config.register_service(user_service, name='user')
+        return user_service
+
 
 @pytest.mark.usefixtures('routes', 'search')
 class TestToggleUserFacet(object):
@@ -468,5 +610,7 @@ def pyramid_request(pyramid_request):
 @pytest.fixture
 def search(patch):
     search = patch('h.views.activity.search')
-    search.return_value = {}
+    search.return_value = {
+        'total': 200,
+    }
     return search


### PR DESCRIPTION
* Sidebar appears on `/users/<username>/search` page only
* Display name is used, falls back on username if no display name
* Num. annotations and date joined are shown
* Description is shown, only if user has one
* Location is shown, if user has one
* Link is shown (domain name part only) and hyperlinked, if user has one
* ORCID is shown and linked to ORCID site if user has one
* Edit profile link is shown if you're logged-in and on your own user search page
* If you go to a `/users/<username>/search` for a `<username>` that doesn't exist you just get no sidebar, same as group sidebar
* The mobile layout with more info / back buttons works the same way as the group sidebar
* As with the groups sidebar there's no tags component yet