### PR TITLE
Retain original query term while redirecting search url to group_search or user_search.…

### DIFF
--- a/h/activity/query.py
+++ b/h/activity/query.py
@@ -84,7 +84,7 @@ def check_url(request, query, unparse=parser.unparse):
                                       pubid=pubid,
                                       _query={'q': unparse(query)})
 
-    if _single_entry(query, 'user'):
+    elif _single_entry(query, 'user'):
         username = query.pop('user')
         redirect = request.route_path('activity.user_search',
                                       username=username,

--- a/tests/h/activity/query_test.py
+++ b/tests/h/activity/query_test.py
@@ -101,7 +101,15 @@ class TestCheckURL(object):
 
         unparse.assert_called_once_with({'tag': 'foo'})
 
-    def test_redirects_to_user_search_page_if_one_group_in_query(self, pyramid_request, unparse):
+    def test_preserves_user_query_terms_for_group_search(self, pyramid_request, unparse):
+        query = MultiDict({'group': 'bar', 'user': 'foo'})
+
+        with pytest.raises(HTTPFound):
+            check_url(pyramid_request, query, unparse=unparse)
+
+        unparse.assert_called_once_with({'user': 'foo'})
+
+    def test_redirects_to_user_search_page_if_one_user_in_query(self, pyramid_request, unparse):
         query = MultiDict({'user': 'jose'})
 
         with pytest.raises(HTTPFound) as e:


### PR DESCRIPTION
When the query terms contain both `group` and `user` terms, the `group` query term
gets popped during the redirect and eventually gets lost.
This change fixes that problem.

https://github.com/hypothesis/product-backlog/issues/36