### PR TITLE
Alias search query parameter `uri` with `url`

### DIFF
--- a/docs/_extra/api/hypothesis.yaml
+++ b/docs/_extra/api/hypothesis.yaml
@@ -230,6 +230,12 @@ paths:
             URI can be a URL (a web page address) or a URN representing another kind of resource such as DOI (Digital Object Identifier) or a PDF fingerprint.
           required: false
           type: string
+        - name: url
+          in: query
+          description: |
+            Alias of `uri`.
+          required: false
+          type: string
         - name: user
           in: query
           description: Limit the results to annotations made by the specified user.

--- a/h/static/scripts/util/search-text-parser.js
+++ b/h/static/scripts/util/search-text-parser.js
@@ -132,6 +132,7 @@ function getLozengeValues(queryString) {
  */
 function hasKnownNamedQueryTerm(queryTerm) {
   const knownNamedQueryTerms = ['user',
+    'uri',
     'url',
     'group',
     'tag'];

--- a/src/memex/search/parser.py
+++ b/src/memex/search/parser.py
@@ -16,7 +16,7 @@ from webob.multidict import MultiDict
 pp.ParserElement.enablePackrat()
 
 # Named fields we support when querying (e.g. `user:luke`)
-named_fields = ['user', 'tag', 'group', 'uri']
+named_fields = ['user', 'tag', 'group', 'uri', 'url']
 
 whitespace = set([
     "\u0009",  # character tabulation

--- a/src/memex/search/query.py
+++ b/src/memex/search/query.py
@@ -166,10 +166,13 @@ class UriFilter(object):
         self.request = request
 
     def __call__(self, params):
-        if 'uri' not in params:
+        if 'uri' not in params and 'url' not in params:
             return None
-        query_uris = [v for k, v in params.items() if k == 'uri']
-        del params['uri']
+        query_uris = [v for k, v in params.items() if k in ['uri', 'url']]
+        if 'uri' in params:
+            del params['uri']
+        if 'url' in params:
+            del params['url']
 
         uris = set()
         for query_uri in query_uris:

--- a/tests/memex/search/parser_test.py
+++ b/tests/memex/search/parser_test.py
@@ -41,6 +41,13 @@ from memex.search import parser
     ('uri:https://example.com?foo=bar&baz=qux#hello', MultiDict([('uri', 'https://example.com?foo=bar&baz=qux#hello')])),
     ('URI:https://example.com', MultiDict([('uri', 'https://example.com')])),
 
+    # url field
+    ('url:https://example.com', MultiDict([('url', 'https://example.com')])),
+    ('url:urn:x-pdf:hthe-fingerprint', MultiDict([('url', 'urn:x-pdf:hthe-fingerprint')])),
+    ('url:https://foo.com url:http://bar.com', MultiDict([('url', 'https://foo.com'), ('url', 'http://bar.com')])),
+    ('url:https://example.com?foo=bar&baz=qux#hello', MultiDict([('url', 'https://example.com?foo=bar&baz=qux#hello')])),
+    ('URL:https://example.com', MultiDict([('url', 'https://example.com')])),
+
     # any field
     ('foo', MultiDict([('any', 'foo')])),
     ('foo bar', MultiDict([('any', 'foo'), ('any', 'bar')])),

--- a/tests/memex/search/query_test.py
+++ b/tests/memex/search/query_test.py
@@ -351,6 +351,27 @@ class TestUriFilter(object):
                                              "httpx://elephants.com",
                                              "httpx://tigers.com"])
 
+    def test_accepts_url_aliases(self, storage):
+        request = mock.Mock()
+        params = multidict.MultiDict()
+        params.add("uri", "http://example.com")
+        params.add("url", "http://example.net")
+        storage.expand_uri.side_effect = [
+            ["http://giraffes.com/", "https://elephants.com/"],
+            ["http://tigers.com/", "https://elephants.com/"],
+        ]
+
+        urifilter = query.UriFilter(request)
+
+        result = urifilter(params)
+        query_uris = result["terms"]["target.scope"]
+
+        storage.expand_uri.assert_any_call(request.db, "http://example.com")
+        storage.expand_uri.assert_any_call(request.db, "http://example.net")
+        assert sorted(query_uris) == sorted(["httpx://giraffes.com",
+                                             "httpx://elephants.com",
+                                             "httpx://tigers.com"])
+
     @pytest.fixture
     def storage(self, patch):
         storage = patch('memex.search.query.storage')


### PR DESCRIPTION
Fixes #4035.

This will add an alias when turning search parameters into an ElasticSeach query for `url` and `uri` fields.
To ensure consistency between the free-form search query parsing and the parameters to `/api/search`, I've done this change all the way down the stack where we convert a dictionary of filters to an ElasticSearch query. I've also added the parameter to the API documentation, mentioning that the new `url` parameter is an alias of `uri`.