### PR TITLE
Fix inconsistencies in front-end code style

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,7 @@
 {
   "extends": "hypothesis",
   "rules": {
+    "arrow-parens": ["error", "as-needed", { "requireForBlockBody": true }],
     "arrow-spacing": "error",
     "keyword-spacing": "error",
     "space-before-blocks": "error"

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,7 @@
 {
   "extends": "hypothesis",
   "rules": {
+    "arrow-spacing": "error",
     "keyword-spacing": "error",
     "space-before-blocks": "error"
   }

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,7 @@
 {
   "extends": "hypothesis",
   "rules": {
+    "keyword-spacing": "error",
     "space-before-blocks": "error"
   }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -3,8 +3,10 @@
   "rules": {
     "arrow-parens": ["error", "as-needed", { "requireForBlockBody": true }],
     "arrow-spacing": "error",
+    "no-var": "error",
     "keyword-spacing": "error",
     "prefer-arrow-callback": "error",
+    "prefer-const": ["error", { "destructuring": "all" }],
     "space-before-blocks": "error"
   }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -4,6 +4,7 @@
     "arrow-parens": ["error", "as-needed", { "requireForBlockBody": true }],
     "arrow-spacing": "error",
     "keyword-spacing": "error",
+    "prefer-arrow-callback": "error",
     "space-before-blocks": "error"
   }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,6 @@
 {
-  "extends": "hypothesis"
+  "extends": "hypothesis",
+  "rules": {
+    "space-before-blocks": "error"
+  }
 }

--- a/h/static/scripts/admin-site.js
+++ b/h/static/scripts/admin-site.js
@@ -1,7 +1,7 @@
 'use strict';
 
 // configure error reporting
-var settings = require('./base/settings')(document);
+const settings = require('./base/settings')(document);
 if (settings.raven) {
   require('./base/raven').init(settings.raven);
 }
@@ -9,10 +9,10 @@ if (settings.raven) {
 window.$ = window.jQuery = require('jquery');
 require('bootstrap');
 
-var AdminUsersController = require('./controllers/admin-users-controller');
-var upgradeElements = require('./base/upgrade-elements');
+const AdminUsersController = require('./controllers/admin-users-controller');
+const upgradeElements = require('./base/upgrade-elements');
 
-var controllers = {
+const controllers = {
   '.js-users-delete-form': AdminUsersController,
 };
 

--- a/h/static/scripts/base/controller.js
+++ b/h/static/scripts/base/controller.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var { findRefs } = require('../util/dom');
+const { findRefs } = require('../util/dom');
 
 /*
  * @typedef {Object} ControllerOptions
@@ -56,7 +56,7 @@ class Controller {
    * method provided by the subclass to update the DOM to match the current state.
    */
   setState(changes) {
-    var prevState = this.state;
+    const prevState = this.state;
     this.state = Object.freeze(Object.assign({}, this.state, changes));
     this.update(this.state, prevState);
   }

--- a/h/static/scripts/base/controller.js
+++ b/h/static/scripts/base/controller.js
@@ -35,7 +35,7 @@ class Controller {
    */
   constructor(element, options = {}) {
 
-    if (!element){
+    if (!element) {
       throw new Error('Controllers require an element passed to the constructor');
     } else if (!element.controllers) {
       element.controllers = [this];

--- a/h/static/scripts/base/environment-flags.js
+++ b/h/static/scripts/base/environment-flags.js
@@ -30,7 +30,7 @@ class EnvironmentFlags {
    * @param {string} flag
    */
   get(flag) {
-    var flagClass = 'env-' + flag;
+    const flagClass = 'env-' + flag;
     return this._element.classList.contains(flagClass);
   }
 
@@ -44,7 +44,7 @@ class EnvironmentFlags {
    * @param {boolean} on
    */
   set(flag, on) {
-    var flagClass = 'env-' + flag;
+    const flagClass = 'env-' + flag;
     if (on) {
       this._element.classList.add(flagClass);
     } else {
@@ -62,7 +62,7 @@ class EnvironmentFlags {
    * @param {string} [url] - Optional value to use as the URL for flag overrides
    */
   init(url) {
-    var JS_LOAD_TIMEOUT = 5000;
+    const JS_LOAD_TIMEOUT = 5000;
 
     // Mark browser as JS capable
     this.set('js-capable', true);
@@ -79,7 +79,7 @@ class EnvironmentFlags {
     }, JS_LOAD_TIMEOUT);
 
     // Process flag overrides specified in URL
-    var flags = envFlagsFromUrl(url || this._element.ownerDocument.location.href);
+    const flags = envFlagsFromUrl(url || this._element.ownerDocument.location.href);
     flags.forEach((flag) => {
       if (flag.indexOf('no-') === 0) {
         this.set(flag.slice(3), false);
@@ -106,8 +106,8 @@ class EnvironmentFlags {
  * @return {Array<string>} flags
  */
 function envFlagsFromUrl(url) {
-  var match = /\b__env__=([^&]+)/.exec(url);
-  var flags = [];
+  const match = /\b__env__=([^&]+)/.exec(url);
+  let flags = [];
   if (match) {
     flags = match[1].split(';');
   }

--- a/h/static/scripts/base/environment-flags.js
+++ b/h/static/scripts/base/environment-flags.js
@@ -80,7 +80,7 @@ class EnvironmentFlags {
 
     // Process flag overrides specified in URL
     var flags = envFlagsFromUrl(url || this._element.ownerDocument.location.href);
-    flags.forEach(flag => {
+    flags.forEach((flag) => {
       if (flag.indexOf('no-') === 0) {
         this.set(flag.slice(3), false);
       } else {

--- a/h/static/scripts/base/raven.js
+++ b/h/static/scripts/base/raven.js
@@ -10,7 +10,7 @@
 
 require('core-js/fn/object/assign');
 
-var Raven = require('raven-js');
+const Raven = require('raven-js');
 
 function init(config) {
   Raven.config(config.dsn, {
@@ -51,7 +51,7 @@ function report(error, when, context) {
     }
   }
 
-  var extra = Object.assign({ when: when }, context);
+  const extra = Object.assign({ when: when }, context);
   Raven.captureException(error, { extra: extra });
 }
 

--- a/h/static/scripts/base/raven.js
+++ b/h/static/scripts/base/raven.js
@@ -70,7 +70,7 @@ function report(error, when, context) {
  * automatically, in which case this code can simply be removed.
  */
 function installUnhandledPromiseErrorHandler() {
-  window.addEventListener('unhandledrejection', function (event) {
+  window.addEventListener('unhandledrejection', (event) => {
     if (event.reason) {
       report(event.reason, 'Unhandled Promise rejection');
     }

--- a/h/static/scripts/base/settings.js
+++ b/h/static/scripts/base/settings.js
@@ -18,11 +18,11 @@ function settings(document, settingsClass) {
   if (!settingsClass) {
     settingsClass = 'js-hypothesis-settings';
   }
-  var settingsElements =
+  const settingsElements =
     document.querySelectorAll('script.' + settingsClass);
 
-  var config = {};
-  for (var i=0; i < settingsElements.length; i++) {
+  const config = {};
+  for (let i=0; i < settingsElements.length; i++) {
     Object.assign(config, JSON.parse(settingsElements[i].textContent));
   }
   return config;

--- a/h/static/scripts/base/upgrade-elements.js
+++ b/h/static/scripts/base/upgrade-elements.js
@@ -6,7 +6,7 @@
 function markReady(element) {
   var HIDE_CLASS = 'is-hidden-when-loading';
   var hideOnLoad = Array.from(element.querySelectorAll('.' + HIDE_CLASS));
-  hideOnLoad.forEach(function (el) {
+  hideOnLoad.forEach((el) => {
     el.classList.remove(HIDE_CLASS);
   });
   element.classList.remove(HIDE_CLASS);
@@ -65,9 +65,9 @@ function upgradeElements(root, controllers) {
     return newElement;
   }
 
-  Object.keys(controllers).forEach(function (selector) {
+  Object.keys(controllers).forEach((selector) => {
     var elements = Array.from(root.querySelectorAll(selector));
-    elements.forEach(function (el) {
+    elements.forEach((el) => {
       var ControllerClass = controllers[selector];
       try {
         new ControllerClass(el, {

--- a/h/static/scripts/base/upgrade-elements.js
+++ b/h/static/scripts/base/upgrade-elements.js
@@ -4,8 +4,8 @@
  * Mark an element as having been upgraded.
  */
 function markReady(element) {
-  var HIDE_CLASS = 'is-hidden-when-loading';
-  var hideOnLoad = Array.from(element.querySelectorAll('.' + HIDE_CLASS));
+  const HIDE_CLASS = 'is-hidden-when-loading';
+  const hideOnLoad = Array.from(element.querySelectorAll('.' + HIDE_CLASS));
   hideOnLoad.forEach((el) => {
     el.classList.remove(HIDE_CLASS);
   });
@@ -13,7 +13,7 @@ function markReady(element) {
 }
 
 // List of all elements which have had upgrades applied
-var upgradedElements = [];
+let upgradedElements = [];
 
 /**
  * Remove all of the controllers for elements under `root`.
@@ -56,19 +56,19 @@ function upgradeElements(root, controllers) {
     if (typeof html !== 'string') {
       throw new Error('Replacement markup must be a string');
     }
-    var container = document.createElement('div');
+    const container = document.createElement('div');
     container.innerHTML = html;
     upgradeElements(container, controllers);
 
-    var newElement = container.children[0];
+    const newElement = container.children[0];
     element.parentElement.replaceChild(newElement, element);
     return newElement;
   }
 
   Object.keys(controllers).forEach((selector) => {
-    var elements = Array.from(root.querySelectorAll(selector));
+    const elements = Array.from(root.querySelectorAll(selector));
     elements.forEach((el) => {
-      var ControllerClass = controllers[selector];
+      const ControllerClass = controllers[selector];
       try {
         new ControllerClass(el, {
           reload: reload.bind(null, el),

--- a/h/static/scripts/base/upgrade-elements.js
+++ b/h/static/scripts/base/upgrade-elements.js
@@ -23,7 +23,7 @@ var upgradedElements = [];
  * document.
  */
 function removeControllers(root) {
-  upgradedElements = upgradedElements.filter(el => {
+  upgradedElements = upgradedElements.filter((el) => {
     if (root.contains(el)) {
       el.controllers.forEach(ctrl => ctrl.beforeRemove());
       el.controllers = [];

--- a/h/static/scripts/controllers/admin-users-controller.js
+++ b/h/static/scripts/controllers/admin-users-controller.js
@@ -1,12 +1,12 @@
 'use strict';
 
-var Controller = require('../base/controller');
+const Controller = require('../base/controller');
 
 class AdminUsersController extends Controller {
   constructor(element, options) {
     super(element, options);
 
-    var window_ = options.window || window;
+    const window_ = options.window || window;
     function confirmFormSubmit() {
       return window_.confirm('This will permanently delete all the user\'s data. Are you sure?');
     }

--- a/h/static/scripts/controllers/admin-users-controller.js
+++ b/h/static/scripts/controllers/admin-users-controller.js
@@ -11,7 +11,7 @@ class AdminUsersController extends Controller {
       return window_.confirm('This will permanently delete all the user\'s data. Are you sure?');
     }
 
-    this.on('submit', event => {
+    this.on('submit', (event) => {
       if (!confirmFormSubmit()) {
         event.preventDefault();
       }

--- a/h/static/scripts/controllers/autosuggest-dropdown-controller.js
+++ b/h/static/scripts/controllers/autosuggest-dropdown-controller.js
@@ -126,7 +126,7 @@ class AutosuggestDropdownController extends Controller {
         currentActive.classList.remove(this.options.classNames.activeItem);
       }
 
-      if (newState.activeId && newState.list.find((item) => item.__suggestionId === newState.activeId)) {
+      if (newState.activeId && newState.list.find(item => item.__suggestionId === newState.activeId)) {
         this._listContainer
           .querySelector(`[data-suggestion-id="${newState.activeId}"]`)
           .classList.add(this.options.classNames.activeItem);

--- a/h/static/scripts/controllers/autosuggest-dropdown-controller.js
+++ b/h/static/scripts/controllers/autosuggest-dropdown-controller.js
@@ -42,15 +42,15 @@ class AutosuggestDropdownController extends Controller {
 
     super(inputElement, configOptions);
 
-    if (!configOptions.renderListItem){
+    if (!configOptions.renderListItem) {
       throw new Error('Missing renderListItem callback in AutosuggestDropdownController constructor');
     }
 
-    if (!configOptions.listFilter){
+    if (!configOptions.listFilter) {
       throw new Error('Missing listFilter function in AutosuggestDropdownController constructor');
     }
 
-    if (!configOptions.onSelect){
+    if (!configOptions.onSelect) {
       throw new Error('Missing onSelect callback in AutosuggestDropdownController constructor');
     }
 
@@ -58,7 +58,7 @@ class AutosuggestDropdownController extends Controller {
     // Note, we currently are not doing anything with the default
     // classes, but we have them if we wanted to give something for a default
     // styling.
-    if (configOptions.classNames){
+    if (configOptions.classNames) {
       this.options.classNames.container = configOptions.classNames.container || 'autosuggest__container';
       this.options.classNames.list = configOptions.classNames.list || 'autosuggest__list';
       this.options.classNames.item = configOptions.classNames.item || 'autosuggest__list-item';
@@ -90,43 +90,43 @@ class AutosuggestDropdownController extends Controller {
     this.setHeader = this._setHeader;
   }
 
-  update(newState, prevState){
+  update(newState, prevState) {
 
     // if our prev state is empty then
     // we assume that this is the first update/render call
-    if (!('visible' in prevState)){
+    if (!('visible' in prevState)) {
 
       // create the elements that make up the component
       this._renderContentContainers();
       this._addTopLevelEventListeners();
     }
 
-    if (newState.visible !== prevState.visible){
+    if (newState.visible !== prevState.visible) {
       // updates the dom to change the class which actually updates visibilty
       setElementState(this._suggestionContainer, { open: newState.visible});
     }
 
-    if (newState.header !== prevState.header){
+    if (newState.header !== prevState.header) {
       this._header.innerHTML = newState.header;
     }
 
     let listChanged = updateHelper.listIsDifferent(newState.list, prevState.list);
 
-    if (listChanged){
+    if (listChanged) {
       this._renderListItems();
     }
 
     // list change detection is needed to persist the
     // currently active elements over to the new list
-    if (newState.activeId !== prevState.activeId || listChanged){
+    if (newState.activeId !== prevState.activeId || listChanged) {
 
       let currentActive = this._getActiveListItemElement();
 
-      if (prevState.activeId && currentActive){
+      if (prevState.activeId && currentActive) {
         currentActive.classList.remove(this.options.classNames.activeItem);
       }
 
-      if (newState.activeId && newState.list.find((item)=>item.__suggestionId === newState.activeId)){
+      if (newState.activeId && newState.list.find((item)=>item.__suggestionId === newState.activeId)) {
         this._listContainer
           .querySelector(`[data-suggestion-id="${newState.activeId}"]`)
           .classList.add(this.options.classNames.activeItem);
@@ -141,7 +141,7 @@ class AutosuggestDropdownController extends Controller {
    * @param  {string} header Html to place in header. You can pass plain text
    *  as well.
    */
-  _setHeader(header){
+  _setHeader(header) {
     this.setState({
       header,
     });
@@ -152,9 +152,9 @@ class AutosuggestDropdownController extends Controller {
    *
    * @param  {Array} list The new list.
    */
-  _setList(list){
+  _setList(list) {
 
-    if (!Array.isArray(list)){
+    if (!Array.isArray(list)) {
       throw new TypeError('setList requires an array first argument');
     }
 
@@ -181,7 +181,7 @@ class AutosuggestDropdownController extends Controller {
    *  filtered and sorted, that will be set the new working list state and
    *  be rerendered.
    */
-  _filterListFromInput(){
+  _filterListFromInput() {
     this.setState({
       list: this.options.listFilter(this.state.rootList, this._input.value) || [],
     });
@@ -191,7 +191,7 @@ class AutosuggestDropdownController extends Controller {
    * hit the consumers filter function to determine
    *   if we still have list items that need to be shown to the user.
    */
-  _filterAndToggleVisibility(){
+  _filterAndToggleVisibility() {
     this._filterListFromInput();
 
     this._toggleSuggestionsVisibility(/*show*/ this.state.list.length > 0);
@@ -202,13 +202,13 @@ class AutosuggestDropdownController extends Controller {
    *  object from list that was passed in, and invoke the onSelect callback.
    *  This is process to actually make a selection
    */
-  _selectCurrentActiveItem(){
+  _selectCurrentActiveItem() {
 
     const currentActive = this._getActiveListItemElement();
     const suggestionId = currentActive && currentActive.getAttribute('data-suggestion-id');
     const selection = this.state.list.filter((item)=>{ return item.__suggestionId === suggestionId;})[0];
 
-    if (selection){
+    if (selection) {
       this.options.onSelect(selection);
       this._filterAndToggleVisibility();
       this.setState({
@@ -224,12 +224,12 @@ class AutosuggestDropdownController extends Controller {
    * @param  {bool} hovering are we hovering on the current element
    * @param  {Event} event    event used to pull the list item being targeted
    */
-  _toggleItemHoverState(hovering, event){
+  _toggleItemHoverState(hovering, event) {
 
     let currentActive = this._getActiveListItemElement();
     let target = event.currentTarget;
 
-    if ( hovering && currentActive && currentActive.contains(target)){
+    if ( hovering && currentActive && currentActive.contains(target)) {
       return;
     }
 
@@ -257,7 +257,7 @@ class AutosuggestDropdownController extends Controller {
   /**
    * @returns {HTMLElement}  the active list item element
    */
-  _getActiveListItemElement(){
+  _getActiveListItemElement() {
     return this._listContainer.querySelector('.' + this.options.classNames.activeItem);
   }
 
@@ -267,15 +267,15 @@ class AutosuggestDropdownController extends Controller {
    *
    * @param  {bool} down is the user navigating down the list?
    */
-  _keyboardSelectionChange(down){
+  _keyboardSelectionChange(down) {
 
     const currentActive = this._getActiveListItemElement();
     let nextActive;
 
     // we have a starting point, navigate on siblings of current
-    if (currentActive){
+    if (currentActive) {
 
-      if (down){
+      if (down) {
         nextActive = currentActive.nextSibling;
       } else {
         nextActive = currentActive.previousSibling;
@@ -283,7 +283,7 @@ class AutosuggestDropdownController extends Controller {
 
     // we have no starting point, let's navigate based on
     // the directional expectation of what the first item would be
-    } else if (down){
+    } else if (down) {
       nextActive = this._listContainer.firstChild;
     } else {
       nextActive = this._listContainer.lastChild;
@@ -298,7 +298,7 @@ class AutosuggestDropdownController extends Controller {
    * build the DOM structure that makes up
    *  the suggestion box and content containers.
    */
-  _renderContentContainers(){
+  _renderContentContainers() {
 
     // container of all suggestion elements
     this._suggestionContainer = document.createElement('div');
@@ -317,7 +317,7 @@ class AutosuggestDropdownController extends Controller {
 
     // put the suggestions adjacent to the input element
     // firefox does not support insertAdjacentElement
-    if (HTMLElement.prototype.insertAdjacentElement){
+    if (HTMLElement.prototype.insertAdjacentElement) {
       this._input.insertAdjacentElement('afterend', this._suggestionContainer);
     } else {
       this._input.parentNode.insertBefore(this._suggestionContainer, this._input.nextSibling);
@@ -328,7 +328,7 @@ class AutosuggestDropdownController extends Controller {
    * updates the content of the list container and builds
    *  the new set of list items.
    */
-  _renderListItems(){
+  _renderListItems() {
     // Create the new list items, render their contents
     // and update the dom with the new elements.
 
@@ -363,7 +363,7 @@ class AutosuggestDropdownController extends Controller {
    * The events that can be set on a "global" or top
    *  level scope, we are going to set them here.
    */
-  _addTopLevelEventListeners(){
+  _addTopLevelEventListeners() {
 
     // we need to use mousedown instead of click
     // so we can beat the blur event which can
@@ -375,12 +375,12 @@ class AutosuggestDropdownController extends Controller {
       // when clicking the input itself or if we are
       // or a global click was made while we were not visible
       // do nothing
-      if (!this.state.visible || target === this._input){
+      if (!this.state.visible || target === this._input) {
         return;
       }
 
       // see if inside interaction areas
-      if (this._suggestionContainer.contains(target)){
+      if (this._suggestionContainer.contains(target)) {
 
         event.preventDefault();
         event.stopPropagation();
@@ -400,14 +400,14 @@ class AutosuggestDropdownController extends Controller {
 
       // only consume the ENTER event if
       // we have an active item
-      if (key === ENTER && !this._getActiveListItemElement()){
+      if (key === ENTER && !this._getActiveListItemElement()) {
         return;
       }
 
       // these keys are going to be consumed and not propagated
-      if ([ENTER, UP, DOWN].indexOf(key) > -1){
+      if ([ENTER, UP, DOWN].indexOf(key) > -1) {
 
-        if (key === ENTER){
+        if (key === ENTER) {
           this._selectCurrentActiveItem();
         } else {
           this._keyboardSelectionChange(/*down*/key === DOWN);
@@ -424,7 +424,7 @@ class AutosuggestDropdownController extends Controller {
 
     this._input.addEventListener('keyup', (event)=>{
 
-      if ([ENTER, UP, DOWN].indexOf(event.keyCode) === -1){
+      if ([ENTER, UP, DOWN].indexOf(event.keyCode) === -1) {
         this._filterAndToggleVisibility();
       }
 

--- a/h/static/scripts/controllers/autosuggest-dropdown-controller.js
+++ b/h/static/scripts/controllers/autosuggest-dropdown-controller.js
@@ -110,7 +110,7 @@ class AutosuggestDropdownController extends Controller {
       this._header.innerHTML = newState.header;
     }
 
-    let listChanged = updateHelper.listIsDifferent(newState.list, prevState.list);
+    const listChanged = updateHelper.listIsDifferent(newState.list, prevState.list);
 
     if (listChanged) {
       this._renderListItems();
@@ -120,7 +120,7 @@ class AutosuggestDropdownController extends Controller {
     // currently active elements over to the new list
     if (newState.activeId !== prevState.activeId || listChanged) {
 
-      let currentActive = this._getActiveListItemElement();
+      const currentActive = this._getActiveListItemElement();
 
       if (prevState.activeId && currentActive) {
         currentActive.classList.remove(this.options.classNames.activeItem);
@@ -226,8 +226,8 @@ class AutosuggestDropdownController extends Controller {
    */
   _toggleItemHoverState(hovering, event) {
 
-    let currentActive = this._getActiveListItemElement();
-    let target = event.currentTarget;
+    const currentActive = this._getActiveListItemElement();
+    const target = event.currentTarget;
 
     if ( hovering && currentActive && currentActive.contains(target)) {
       return;
@@ -335,7 +335,7 @@ class AutosuggestDropdownController extends Controller {
     this._listContainer.innerHTML = '';
 
     this.state.list.forEach((listItem) => {
-      let li = document.createElement('li');
+      const li = document.createElement('li');
       li.classList.add(this.options.classNames.item);
       li.setAttribute('data-suggestion-id', listItem.__suggestionId);
 

--- a/h/static/scripts/controllers/autosuggest-dropdown-controller.js
+++ b/h/static/scripts/controllers/autosuggest-dropdown-controller.js
@@ -126,7 +126,7 @@ class AutosuggestDropdownController extends Controller {
         currentActive.classList.remove(this.options.classNames.activeItem);
       }
 
-      if (newState.activeId && newState.list.find((item)=>item.__suggestionId === newState.activeId)) {
+      if (newState.activeId && newState.list.find((item) => item.__suggestionId === newState.activeId)) {
         this._listContainer
           .querySelector(`[data-suggestion-id="${newState.activeId}"]`)
           .classList.add(this.options.classNames.activeItem);
@@ -159,7 +159,7 @@ class AutosuggestDropdownController extends Controller {
     }
 
     this.setState({
-      rootList: list.map((item)=>{
+      rootList: list.map((item) => {
         return Object.assign({}, item, {
           // create an id that lets us direction map
           // selection to arbitrary item in list.
@@ -206,7 +206,7 @@ class AutosuggestDropdownController extends Controller {
 
     const currentActive = this._getActiveListItemElement();
     const suggestionId = currentActive && currentActive.getAttribute('data-suggestion-id');
-    const selection = this.state.list.filter((item)=>{ return item.__suggestionId === suggestionId;})[0];
+    const selection = this.state.list.filter((item) => { return item.__suggestionId === suggestionId;})[0];
 
     if (selection) {
       this.options.onSelect(selection);
@@ -334,7 +334,7 @@ class AutosuggestDropdownController extends Controller {
 
     this._listContainer.innerHTML = '';
 
-    this.state.list.forEach((listItem)=>{
+    this.state.list.forEach((listItem) => {
       let li = document.createElement('li');
       li.classList.add(this.options.classNames.item);
       li.setAttribute('data-suggestion-id', listItem.__suggestionId);
@@ -344,7 +344,7 @@ class AutosuggestDropdownController extends Controller {
       // But for now this binding has no real affect on small list perf
       li.addEventListener('mouseenter', this._toggleItemHoverState.bind(this, /*hovering*/true));
       li.addEventListener('mouseleave', this._toggleItemHoverState.bind(this, /*hovering*/false));
-      li.addEventListener('mousedown', (event)=>{
+      li.addEventListener('mousedown', (event) => {
         // for situations like mobile, hovering might not be
         // the first event to set the active state for an element
         // so we will mimic that on mouse down and let selection happen
@@ -368,7 +368,7 @@ class AutosuggestDropdownController extends Controller {
     // we need to use mousedown instead of click
     // so we can beat the blur event which can
     // change visibility/target of the active event
-    document.addEventListener('mousedown', (event)=>{
+    document.addEventListener('mousedown', (event) => {
 
       const target = event.target;
 
@@ -394,7 +394,7 @@ class AutosuggestDropdownController extends Controller {
     // Note, keydown needed here to properly prevent the default
     // nature of navigating keystrokes - like DOWN ARROW at the end of an
     // input takes the cursor to the beginning of the input value.
-    this._input.addEventListener('keydown', (event)=>{
+    this._input.addEventListener('keydown', (event) => {
 
       const key = event.keyCode;
 
@@ -422,7 +422,7 @@ class AutosuggestDropdownController extends Controller {
       // stop propagation after inspecting input value
     }, /*useCapturePhase*/ true);
 
-    this._input.addEventListener('keyup', (event)=>{
+    this._input.addEventListener('keyup', (event) => {
 
       if ([ENTER, UP, DOWN].indexOf(event.keyCode) === -1) {
         this._filterAndToggleVisibility();
@@ -432,11 +432,11 @@ class AutosuggestDropdownController extends Controller {
       // stop propagation after inspecting input value
     }, /*useCapturePhase*/ true);
 
-    this._input.addEventListener('focus', ()=>{
+    this._input.addEventListener('focus', () => {
       this._filterAndToggleVisibility();
     });
 
-    this._input.addEventListener('blur', ()=>{
+    this._input.addEventListener('blur', () => {
       this._toggleSuggestionsVisibility(/*show*/false);
     });
 

--- a/h/static/scripts/controllers/character-limit-controller.js
+++ b/h/static/scripts/controllers/character-limit-controller.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var Controller = require('../base/controller');
-var { setElementState } = require('../util/dom');
+const Controller = require('../base/controller');
+const { setElementState } = require('../util/dom');
 
 class CharacterLimitController extends Controller {
   constructor(element) {
@@ -14,9 +14,9 @@ class CharacterLimitController extends Controller {
   }
 
   update() {
-    var input = this.refs.characterLimitInput;
-    var maxlength = parseInt(input.dataset.maxlength);
-    var counter = this.refs.characterLimitCounter;
+    const input = this.refs.characterLimitInput;
+    const maxlength = parseInt(input.dataset.maxlength);
+    const counter = this.refs.characterLimitCounter;
     counter.textContent = input.value.length + '/' + maxlength;
     setElementState(counter, {tooLong: input.value.length > maxlength});
     setElementState(this.refs.characterLimitCounter, {ready: true});

--- a/h/static/scripts/controllers/confirm-submit-controller.js
+++ b/h/static/scripts/controllers/confirm-submit-controller.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Controller = require('../base/controller');
+const Controller = require('../base/controller');
 
 /* Turn a normal submit element into one that shows a confirm dialog.
  *
@@ -12,7 +12,7 @@ class ConfirmSubmitController extends Controller {
   constructor(element, options) {
     super(element);
 
-    var window_ = options.window || window;
+    const window_ = options.window || window;
 
     element.addEventListener('click', (event) => {
       if (!window_.confirm(element.dataset.confirmMessage)) {

--- a/h/static/scripts/controllers/copy-button-controller.js
+++ b/h/static/scripts/controllers/copy-button-controller.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Controller = require('../base/controller');
+const Controller = require('../base/controller');
 
 class CopyButtonController extends Controller {
   constructor(element) {
@@ -9,7 +9,7 @@ class CopyButtonController extends Controller {
     this.refs.button.onclick = () => {
       this.refs.input.select(); // We need to select the text before we copy.
 
-      let notificationText = document.execCommand('copy') ?
+      const notificationText = document.execCommand('copy') ?
         'Link copied to clipboard!' :
         'Copying link failed';
 

--- a/h/static/scripts/controllers/create-group-form-controller.js
+++ b/h/static/scripts/controllers/create-group-form-controller.js
@@ -15,7 +15,7 @@ function CreateGroupFormController(element) {
   self._groupNameInput.addEventListener('input', groupNameChanged);
   groupNameChanged();
 
-  this._infoLink.addEventListener('click', function (event) {
+  this._infoLink.addEventListener('click', (event) => {
     event.preventDefault();
     self._infoLink.classList.add('is-hidden');
     self._infoText.classList.remove('is-hidden');

--- a/h/static/scripts/controllers/create-group-form-controller.js
+++ b/h/static/scripts/controllers/create-group-form-controller.js
@@ -2,7 +2,7 @@
 
 function CreateGroupFormController(element) {
   // Create Group form handling
-  var self = this;
+  const self = this;
   this._submitBtn = element.querySelector('.js-create-group-create-btn');
   this._groupNameInput = element.querySelector('.js-group-name-input');
   this._infoLink = element.querySelector('.js-group-info-link');

--- a/h/static/scripts/controllers/dropdown-menu-controller.js
+++ b/h/static/scripts/controllers/dropdown-menu-controller.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var Controller = require('../base/controller');
-var setElementState = require('../util/dom').setElementState;
+const Controller = require('../base/controller');
+const setElementState = require('../util/dom').setElementState;
 
 /**
  * Controller for dropdown menus.
@@ -10,9 +10,9 @@ class DropdownMenuController extends Controller {
   constructor(element) {
     super(element);
 
-    var toggleEl = this.refs.dropdownMenuToggle;
+    const toggleEl = this.refs.dropdownMenuToggle;
 
-    var handleClickOutside = (event) => {
+    const handleClickOutside = (event) => {
       if (!this.refs.dropdownMenuContent.contains(event.target)) {
         // When clicking outside the menu on the toggle element, stop the event
         // so that it does not re-trigger the menu

--- a/h/static/scripts/controllers/dropdown-menu-controller.js
+++ b/h/static/scripts/controllers/dropdown-menu-controller.js
@@ -12,7 +12,7 @@ class DropdownMenuController extends Controller {
 
     var toggleEl = this.refs.dropdownMenuToggle;
 
-    var handleClickOutside = event => {
+    var handleClickOutside = (event) => {
       if (!this.refs.dropdownMenuContent.contains(event.target)) {
         // When clicking outside the menu on the toggle element, stop the event
         // so that it does not re-trigger the menu
@@ -28,7 +28,7 @@ class DropdownMenuController extends Controller {
       }
     };
 
-    toggleEl.addEventListener('click', event => {
+    toggleEl.addEventListener('click', (event) => {
       event.preventDefault();
       event.stopPropagation();
 

--- a/h/static/scripts/controllers/form-controller.js
+++ b/h/static/scripts/controllers/form-controller.js
@@ -45,14 +45,14 @@ class FormController extends Controller {
     super(element, options);
 
     setElementState(this.refs.cancelBtn, {hidden: false});
-    this.refs.cancelBtn.addEventListener('click', event => {
+    this.refs.cancelBtn.addEventListener('click', (event) => {
       event.preventDefault();
       this.cancel();
     });
 
     // List of groups of controls that constitute each form field
     this._fields = Array.from(element.querySelectorAll('.js-form-input'))
-      .map(el => {
+      .map((el) => {
         var parts = findRefs(el);
         return {
           container: el,
@@ -61,7 +61,7 @@ class FormController extends Controller {
         };
       });
 
-    this.on('focus', event => {
+    this.on('focus', (event) => {
       var field = this._fields.find(field => field.input === event.target);
       if (!field) {
         return;
@@ -73,13 +73,13 @@ class FormController extends Controller {
       });
     }, true /* capture - focus does not bubble */);
 
-    this.on('change', event => {
+    this.on('change', (event) => {
       if (shouldAutosubmit(event.target.type)) {
         this.submit();
       }
     });
 
-    this.on('input', event => {
+    this.on('input', (event) => {
       // Some but not all browsers deliver an `input` event for radio/checkbox
       // inputs. Since we auto-submit when such inputs change, don't mark the
       // field as dirty.
@@ -89,7 +89,7 @@ class FormController extends Controller {
       this.setState({dirty: true});
     });
 
-    this.on('keydown', event => {
+    this.on('keydown', (event) => {
       event.stopPropagation();
       if (event.key === 'Escape') {
         this.cancel();
@@ -97,13 +97,13 @@ class FormController extends Controller {
     });
 
     // Ignore clicks outside of the active field when editing
-    this.refs.formBackdrop.addEventListener('mousedown', event => {
+    this.refs.formBackdrop.addEventListener('mousedown', (event) => {
       event.preventDefault();
       event.stopPropagation();
     });
 
     // Setup AJAX handling for forms
-    this.on('submit', event => {
+    this.on('submit', (event) => {
       event.preventDefault();
       this.submit();
     });
@@ -166,7 +166,7 @@ class FormController extends Controller {
    * @param {Object} state - The internal state of the form
    */
   _updateFields(state) {
-    this._fields.forEach(field => {
+    this._fields.forEach((field) => {
       setElementState(field.container, {
         editing: state.editingFields.includes(field),
         focused: field === state.focusedField,
@@ -214,9 +214,9 @@ class FormController extends Controller {
 
     this.setState({saving: true});
 
-    return submitForm(this.element).then(response => {
+    return submitForm(this.element).then((response) => {
       this.options.reload(response.form);
-    }).catch(err => {
+    }).catch((err) => {
       if (err.form) {
         // The server processed the request but rejected the submission.
         // Display the returned form which will contain any validation error
@@ -267,7 +267,7 @@ class FormController extends Controller {
    * Trap focus within the set of form fields currently being edited.
    */
   _trapFocus() {
-    this._releaseFocus = modalFocus.trap(this._focusGroup(), newFocusedElement => {
+    this._releaseFocus = modalFocus.trap(this._focusGroup(), (newFocusedElement) => {
       // Keep focus in the current field when it has unsaved changes,
       // otherwise let the user focus another field in the form or move focus
       // outside the form entirely.

--- a/h/static/scripts/controllers/form-controller.js
+++ b/h/static/scripts/controllers/form-controller.js
@@ -1,12 +1,12 @@
 'use strict';
 
-var Controller = require('../base/controller');
-var { findRefs, setElementState } = require('../util/dom');
-var modalFocus = require('../util/modal-focus');
-var submitForm = require('../util/submit-form');
+const Controller = require('../base/controller');
+const { findRefs, setElementState } = require('../util/dom');
+const modalFocus = require('../util/modal-focus');
+const submitForm = require('../util/submit-form');
 
 function shouldAutosubmit(type) {
-  var autosubmitTypes = ['checkbox', 'radio'];
+  const autosubmitTypes = ['checkbox', 'radio'];
   return autosubmitTypes.indexOf(type) !== -1;
 }
 
@@ -53,7 +53,7 @@ class FormController extends Controller {
     // List of groups of controls that constitute each form field
     this._fields = Array.from(element.querySelectorAll('.js-form-input'))
       .map((el) => {
-        var parts = findRefs(el);
+        const parts = findRefs(el);
         return {
           container: el,
           input: parts.formInput,
@@ -62,7 +62,7 @@ class FormController extends Controller {
       });
 
     this.on('focus', (event) => {
-      var field = this._fields.find(field => field.input === event.target);
+      const field = this._fields.find(field => field.input === event.target);
       if (!field) {
         return;
       }
@@ -144,7 +144,7 @@ class FormController extends Controller {
       this._trapFocus();
     }
 
-    var isEditing = state.editingFields.length > 0;
+    const isEditing = state.editingFields.length > 0;
     setElementState(this.element, {editing: isEditing});
     setElementState(this.refs.formActions, {
       hidden: !isEditing || shouldAutosubmit(state.editingFields[0].input.type),
@@ -175,9 +175,9 @@ class FormController extends Controller {
       });
 
       // Update labels
-      var activeLabel = field.container.dataset.activeLabel;
-      var inactiveLabel = field.container.dataset.inactiveLabel;
-      var isEditing = state.editingFields.includes(field);
+      const activeLabel = field.container.dataset.activeLabel;
+      const inactiveLabel = field.container.dataset.inactiveLabel;
+      const isEditing = state.editingFields.includes(field);
 
       if (activeLabel && inactiveLabel) {
         field.label.textContent = isEditing ? activeLabel : inactiveLabel;
@@ -205,9 +205,9 @@ class FormController extends Controller {
    * result.
    */
   submit() {
-    var originalForm = this.state.originalForm;
+    const originalForm = this.state.originalForm;
 
-    var activeInputId;
+    let activeInputId;
     if (this.state.editingFields.length > 0) {
       activeInputId = this.state.editingFields[0].input.id;
     }
@@ -221,12 +221,12 @@ class FormController extends Controller {
         // The server processed the request but rejected the submission.
         // Display the returned form which will contain any validation error
         // messages.
-        var newFormEl = this.options.reload(err.form);
-        var newFormCtrl = newFormEl.controllers.find(ctrl =>
+        const newFormEl = this.options.reload(err.form);
+        const newFormCtrl = newFormEl.controllers.find(ctrl =>
           ctrl instanceof FormController);
 
         // Resume editing the field where validation failed
-        var newInput = document.getElementById(activeInputId);
+        const newInput = document.getElementById(activeInputId);
         if (newInput) {
           newInput.focus();
         }
@@ -255,7 +255,7 @@ class FormController extends Controller {
    * depending upon the field which is currently focused.
    */
   _focusGroup() {
-    var fieldContainers = this.state.editingFields.map(field => field.container);
+    const fieldContainers = this.state.editingFields.map(field => field.container);
     if (fieldContainers.length === 0) {
       return null;
     }

--- a/h/static/scripts/controllers/form-select-onfocus-controller.js
+++ b/h/static/scripts/controllers/form-select-onfocus-controller.js
@@ -11,7 +11,7 @@ class FormSelectOnFocusController extends Controller {
       element.select();
     }
 
-    element.addEventListener('focus', event => {
+    element.addEventListener('focus', (event) => {
       event.target.select();
     });
   }

--- a/h/static/scripts/controllers/form-select-onfocus-controller.js
+++ b/h/static/scripts/controllers/form-select-onfocus-controller.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Controller = require('../base/controller');
+const Controller = require('../base/controller');
 
 class FormSelectOnFocusController extends Controller {
   constructor(element) {

--- a/h/static/scripts/controllers/lozenge-controller.js
+++ b/h/static/scripts/controllers/lozenge-controller.js
@@ -1,9 +1,9 @@
 'use strict';
 
-var escapeHtml = require('escape-html');
+const escapeHtml = require('escape-html');
 
-var Controller = require('../base/controller');
-var searchTextParser = require('../util/search-text-parser');
+const Controller = require('../base/controller');
+const searchTextParser = require('../util/search-text-parser');
 
 /**
  * Create a lozenge with options.content as its content and append it to containerEl.
@@ -20,11 +20,11 @@ var searchTextParser = require('../util/search-text-parser');
 class LozengeController extends Controller {
   constructor(containerEl, options) {
     super(containerEl, options);
-    var lozengeEl = document.createElement('div');
-    var lozengeMarkup = escapeHtml(options.content);
+    const lozengeEl = document.createElement('div');
+    let lozengeMarkup = escapeHtml(options.content);
 
     if (searchTextParser.hasKnownNamedQueryTerm(options.content)) {
-      var queryTerm = searchTextParser.getLozengeFacetNameAndValue(options.content);
+      const queryTerm = searchTextParser.getLozengeFacetNameAndValue(options.content);
       lozengeMarkup = '<span class="lozenge__facet-name">' +
         escapeHtml(queryTerm.facetName) +
         '</span>' +

--- a/h/static/scripts/controllers/search-bar-controller.js
+++ b/h/static/scripts/controllers/search-bar-controller.js
@@ -19,7 +19,7 @@ const MAX_SUGGESTIONS = 5;
  * Normalize a string for use in comparisons of user input with a suggestion.
  * This causes differences in unicode composition and combining characters/accents to be ignored.
  */
-var normalizeStr = function(str){
+var normalizeStr = function(str) {
   return stringUtil.fold(stringUtil.normalize(str));
 };
 
@@ -69,10 +69,10 @@ class SearchBarController extends Controller {
       const tagSuggestionJSON = document.querySelector('.js-tag-suggestions');
       let tagSuggestions = [];
 
-      if(tagSuggestionJSON){
+      if(tagSuggestionJSON) {
         try{
           tagSuggestions = JSON.parse(tagSuggestionJSON.innerHTML.trim());
-        }catch(e){
+        }catch(e) {
           console.error('Could not parse .js-tag-suggestions JSON content', e);
         }
       }
@@ -91,10 +91,10 @@ class SearchBarController extends Controller {
       const groupSuggestionJSON = document.querySelector('.js-group-suggestions');
       let groupSuggestions = [];
 
-      if(groupSuggestionJSON){
+      if(groupSuggestionJSON) {
         try{
           groupSuggestions = JSON.parse(groupSuggestionJSON.innerHTML.trim());
-        }catch(e){
+        }catch(e) {
           console.error('Could not parse .js-group-suggestions JSON content', e);
         }
       }
@@ -136,16 +136,16 @@ class SearchBarController extends Controller {
       let groupVal = groupLoz.substr(groupLoz.indexOf(':') + 1).trim();
       let inputVal = groupVal.trim();
       let displayVal = groupVal;
-      let wrapQuotesIfNeeded = function(str){
+      let wrapQuotesIfNeeded = function(str) {
         return str.indexOf(' ') > -1 ? `"${str}"` : str;
       };
 
 
       // remove quotes from value
-      if(groupVal[0] === '"' || groupVal[0] === '\''){
+      if(groupVal[0] === '"' || groupVal[0] === '\'') {
         groupVal = groupVal.substr(1);
       }
-      if(groupVal[groupVal.length - 1] === '"' || groupVal[groupVal.length - 1] === '\''){
+      if(groupVal[groupVal.length - 1] === '"' || groupVal[groupVal.length - 1] === '\'') {
         groupVal = groupVal.slice(0, -1);
       }
 
@@ -161,14 +161,14 @@ class SearchBarController extends Controller {
         return item.type === GROUP_TYPE && item.pubid.toLowerCase() === matchVal;
       });
 
-      if(matchByPubid){
+      if(matchByPubid) {
         inputVal = matchByPubid.pubid;
         displayVal = wrapQuotesIfNeeded(matchByPubid.name);
       }else {
         const matchByName = this._suggestionsMap.find((item)=>{
           return item.type === GROUP_TYPE && item.matchOn.toLowerCase() === matchVal;
         });
-        if(matchByName){
+        if(matchByName) {
           inputVal = matchByName.pubid;
           displayVal = wrapQuotesIfNeeded(matchByName.name);
         }
@@ -218,7 +218,7 @@ class SearchBarController extends Controller {
 
         let inputValue = loz.querySelector('.js-lozenge__content').textContent;
 
-        if(inputValue.indexOf('group:') === 0){
+        if(inputValue.indexOf('group:') === 0) {
           inputValue = getInputAndDisplayValsForGroup(inputValue).input;
         }
         newValue = newValue + inputValue + ' ';
@@ -247,7 +247,7 @@ class SearchBarController extends Controller {
       // groups have extra logic to show one value
       // but have their input/search value be different
       // make sure we grab the right value to display
-      if(content.indexOf('group:') === 0){
+      if(content.indexOf('group:') === 0) {
         content = getInputAndDisplayValsForGroup(content).display;
       }
 
@@ -312,7 +312,7 @@ class SearchBarController extends Controller {
 
         let itemContents = `<span class="search-bar__dropdown-menu-title"> ${escapeHtml(listItem.title)} </span>`;
 
-        if (listItem.explanation){
+        if (listItem.explanation) {
           itemContents += `<span class="search-bar__dropdown-menu-explanation"> ${listItem.explanation} </span>`;
         }
 
@@ -324,24 +324,24 @@ class SearchBarController extends Controller {
         currentInput = (currentInput || '').trim();
 
         let typeFilter = FACET_TYPE;
-        if(currentInput.indexOf('tag:') === 0){
+        if(currentInput.indexOf('tag:') === 0) {
           typeFilter = TAG_TYPE;
-        }else if(currentInput.indexOf('group:') === 0){
+        }else if(currentInput.indexOf('group:') === 0) {
           typeFilter = GROUP_TYPE;
         }
 
         let inputFilter = normalizeStr(currentInput);
 
-        if(typeFilter === TAG_TYPE || typeFilter === GROUP_TYPE){
+        if(typeFilter === TAG_TYPE || typeFilter === GROUP_TYPE) {
           inputFilter = inputFilter.substr(inputFilter.indexOf(':') + 1);
 
           // remove the initial quote for comparisons if it exists
-          if(inputFilter[0] === '\'' || inputFilter[0] === '"'){
+          if(inputFilter[0] === '\'' || inputFilter[0] === '"') {
             inputFilter = inputFilter.substr(1);
           }
         }
 
-        if(this.state.suggestionsType !== typeFilter){
+        if(this.state.suggestionsType !== typeFilter) {
           this.setState({
             suggestionsType: typeFilter,
           });
@@ -357,14 +357,14 @@ class SearchBarController extends Controller {
           // original list take effect if they have equal
           // index values or there is no current input value
 
-          if (inputFilter){
+          if (inputFilter) {
             let aIndex = a.matchOn.indexOf(inputFilter);
             let bIndex = b.matchOn.indexOf(inputFilter);
 
             // match score
-            if (aIndex > bIndex){
+            if (aIndex > bIndex) {
               return 1;
-            } else if (aIndex < bIndex){
+            } else if (aIndex < bIndex) {
               return -1;
             }
           }
@@ -372,8 +372,8 @@ class SearchBarController extends Controller {
 
           // If we are filtering on tags, we need to arrange
           // by popularity
-          if(typeFilter === TAG_TYPE){
-            if(a.usageCount > b.usageCount){
+          if(typeFilter === TAG_TYPE) {
+            if(a.usageCount > b.usageCount) {
               return -1;
             }else if(a.usageCount < b.usageCount) {
               return 1;
@@ -387,14 +387,14 @@ class SearchBarController extends Controller {
 
       onSelect: (itemSelected)=>{
 
-        if (itemSelected.type === TAG_TYPE || itemSelected.type === GROUP_TYPE){
+        if (itemSelected.type === TAG_TYPE || itemSelected.type === GROUP_TYPE) {
           const prefix = itemSelected.type === TAG_TYPE ? 'tag:' : 'group:';
 
           let valSelection = itemSelected.title;
 
           // wrap multi word phrases with quotes to keep
           // autosuggestions consistent with what user needs to do
-          if(valSelection.indexOf(' ') > -1){
+          if(valSelection.indexOf(' ') > -1) {
             valSelection = `"${valSelection}"`;
           }
 
@@ -417,16 +417,16 @@ class SearchBarController extends Controller {
     lozengifyInput();
   }
 
-  update(newState, prevState){
+  update(newState, prevState) {
 
-    if(!this._suggestionsHandler){
+    if(!this._suggestionsHandler) {
       return;
     }
 
-    if(newState.suggestionsType !== prevState.suggestionsType){
-      if(newState.suggestionsType === TAG_TYPE){
+    if(newState.suggestionsType !== prevState.suggestionsType) {
+      if(newState.suggestionsType === TAG_TYPE) {
         this._suggestionsHandler.setHeader('Popular tags:');
-      }else if(newState.suggestionsType === GROUP_TYPE){
+      }else if(newState.suggestionsType === GROUP_TYPE) {
         this._suggestionsHandler.setHeader('Your groups:');
       }else {
         this._suggestionsHandler.setHeader('Narrow your search:');

--- a/h/static/scripts/controllers/search-bar-controller.js
+++ b/h/static/scripts/controllers/search-bar-controller.js
@@ -69,10 +69,10 @@ class SearchBarController extends Controller {
       const tagSuggestionJSON = document.querySelector('.js-tag-suggestions');
       let tagSuggestions = [];
 
-      if(tagSuggestionJSON) {
-        try{
+      if (tagSuggestionJSON) {
+        try {
           tagSuggestions = JSON.parse(tagSuggestionJSON.innerHTML.trim());
-        }catch(e) {
+        } catch (e) {
           console.error('Could not parse .js-tag-suggestions JSON content', e);
         }
       }
@@ -91,10 +91,10 @@ class SearchBarController extends Controller {
       const groupSuggestionJSON = document.querySelector('.js-group-suggestions');
       let groupSuggestions = [];
 
-      if(groupSuggestionJSON) {
-        try{
+      if (groupSuggestionJSON) {
+        try {
           groupSuggestions = JSON.parse(groupSuggestionJSON.innerHTML.trim());
-        }catch(e) {
+        } catch (e) {
           console.error('Could not parse .js-group-suggestions JSON content', e);
         }
       }
@@ -142,10 +142,10 @@ class SearchBarController extends Controller {
 
 
       // remove quotes from value
-      if(groupVal[0] === '"' || groupVal[0] === '\'') {
+      if (groupVal[0] === '"' || groupVal[0] === '\'') {
         groupVal = groupVal.substr(1);
       }
-      if(groupVal[groupVal.length - 1] === '"' || groupVal[groupVal.length - 1] === '\'') {
+      if (groupVal[groupVal.length - 1] === '"' || groupVal[groupVal.length - 1] === '\'') {
         groupVal = groupVal.slice(0, -1);
       }
 
@@ -161,14 +161,14 @@ class SearchBarController extends Controller {
         return item.type === GROUP_TYPE && item.pubid.toLowerCase() === matchVal;
       });
 
-      if(matchByPubid) {
+      if (matchByPubid) {
         inputVal = matchByPubid.pubid;
         displayVal = wrapQuotesIfNeeded(matchByPubid.name);
-      }else {
+      } else {
         const matchByName = this._suggestionsMap.find((item)=>{
           return item.type === GROUP_TYPE && item.matchOn.toLowerCase() === matchVal;
         });
-        if(matchByName) {
+        if (matchByName) {
           inputVal = matchByName.pubid;
           displayVal = wrapQuotesIfNeeded(matchByName.name);
         }
@@ -218,7 +218,7 @@ class SearchBarController extends Controller {
 
         let inputValue = loz.querySelector('.js-lozenge__content').textContent;
 
-        if(inputValue.indexOf('group:') === 0) {
+        if (inputValue.indexOf('group:') === 0) {
           inputValue = getInputAndDisplayValsForGroup(inputValue).input;
         }
         newValue = newValue + inputValue + ' ';
@@ -247,7 +247,7 @@ class SearchBarController extends Controller {
       // groups have extra logic to show one value
       // but have their input/search value be different
       // make sure we grab the right value to display
-      if(content.indexOf('group:') === 0) {
+      if (content.indexOf('group:') === 0) {
         content = getInputAndDisplayValsForGroup(content).display;
       }
 
@@ -324,24 +324,24 @@ class SearchBarController extends Controller {
         currentInput = (currentInput || '').trim();
 
         let typeFilter = FACET_TYPE;
-        if(currentInput.indexOf('tag:') === 0) {
+        if (currentInput.indexOf('tag:') === 0) {
           typeFilter = TAG_TYPE;
-        }else if(currentInput.indexOf('group:') === 0) {
+        } else if (currentInput.indexOf('group:') === 0) {
           typeFilter = GROUP_TYPE;
         }
 
         let inputFilter = normalizeStr(currentInput);
 
-        if(typeFilter === TAG_TYPE || typeFilter === GROUP_TYPE) {
+        if (typeFilter === TAG_TYPE || typeFilter === GROUP_TYPE) {
           inputFilter = inputFilter.substr(inputFilter.indexOf(':') + 1);
 
           // remove the initial quote for comparisons if it exists
-          if(inputFilter[0] === '\'' || inputFilter[0] === '"') {
+          if (inputFilter[0] === '\'' || inputFilter[0] === '"') {
             inputFilter = inputFilter.substr(1);
           }
         }
 
-        if(this.state.suggestionsType !== typeFilter) {
+        if (this.state.suggestionsType !== typeFilter) {
           this.setState({
             suggestionsType: typeFilter,
           });
@@ -372,10 +372,10 @@ class SearchBarController extends Controller {
 
           // If we are filtering on tags, we need to arrange
           // by popularity
-          if(typeFilter === TAG_TYPE) {
-            if(a.usageCount > b.usageCount) {
+          if (typeFilter === TAG_TYPE) {
+            if (a.usageCount > b.usageCount) {
               return -1;
-            }else if(a.usageCount < b.usageCount) {
+            } else if (a.usageCount < b.usageCount) {
               return 1;
             }
           }
@@ -394,7 +394,7 @@ class SearchBarController extends Controller {
 
           // wrap multi word phrases with quotes to keep
           // autosuggestions consistent with what user needs to do
-          if(valSelection.indexOf(' ') > -1) {
+          if (valSelection.indexOf(' ') > -1) {
             valSelection = `"${valSelection}"`;
           }
 
@@ -419,16 +419,16 @@ class SearchBarController extends Controller {
 
   update(newState, prevState) {
 
-    if(!this._suggestionsHandler) {
+    if (!this._suggestionsHandler) {
       return;
     }
 
-    if(newState.suggestionsType !== prevState.suggestionsType) {
-      if(newState.suggestionsType === TAG_TYPE) {
+    if (newState.suggestionsType !== prevState.suggestionsType) {
+      if (newState.suggestionsType === TAG_TYPE) {
         this._suggestionsHandler.setHeader('Popular tags:');
-      }else if(newState.suggestionsType === GROUP_TYPE) {
+      } else if (newState.suggestionsType === GROUP_TYPE) {
         this._suggestionsHandler.setHeader('Your groups:');
-      }else {
+      } else {
         this._suggestionsHandler.setHeader('Narrow your search:');
       }
     }

--- a/h/static/scripts/controllers/search-bar-controller.js
+++ b/h/static/scripts/controllers/search-bar-controller.js
@@ -1,12 +1,12 @@
 'use strict';
 
-var escapeHtml = require('escape-html');
+const escapeHtml = require('escape-html');
 
-var Controller = require('../base/controller');
-var LozengeController = require('./lozenge-controller');
-var AutosuggestDropdownController = require('./autosuggest-dropdown-controller');
-var SearchTextParser = require('../util/search-text-parser');
-var stringUtil = require('../util/string');
+const Controller = require('../base/controller');
+const LozengeController = require('./lozenge-controller');
+const AutosuggestDropdownController = require('./autosuggest-dropdown-controller');
+const SearchTextParser = require('../util/search-text-parser');
+const stringUtil = require('../util/string');
 
 
 const FACET_TYPE = 'FACET';
@@ -19,7 +19,7 @@ const MAX_SUGGESTIONS = 5;
  * Normalize a string for use in comparisons of user input with a suggestion.
  * This causes differences in unicode composition and combining characters/accents to be ignored.
  */
-var normalizeStr = function(str) {
+const normalizeStr = function(str) {
   return stringUtil.fold(stringUtil.normalize(str));
 };
 
@@ -41,7 +41,7 @@ class SearchBarController extends Controller {
      */
     this._suggestionsMap = (() => {
 
-      let explanationList = [
+      const explanationList = [
         {
           matchOn: 'user',
           title: 'user:',
@@ -77,7 +77,7 @@ class SearchBarController extends Controller {
         }
       }
 
-      let tagsList = ((tagSuggestions) || []).map((item) => {
+      const tagsList = ((tagSuggestions) || []).map((item) => {
         return Object.assign(item, {
           type: TAG_TYPE,
           title: item.tag, // make safe
@@ -99,7 +99,7 @@ class SearchBarController extends Controller {
         }
       }
 
-      let groupsList = ((groupSuggestions) || []).map((item) => {
+      const groupsList = ((groupSuggestions) || []).map((item) => {
         return Object.assign(item, {
           type: GROUP_TYPE,
           title: item.name, // make safe
@@ -112,7 +112,7 @@ class SearchBarController extends Controller {
       return explanationList.concat(tagsList, groupsList);
     })();
 
-    var getTrimmedInputValue = () => {
+    const getTrimmedInputValue = () => {
       return this._input.value.trim();
     };
 
@@ -132,11 +132,11 @@ class SearchBarController extends Controller {
      *      input: {String}    // like group:pid1234
      *    }
      */
-    var getInputAndDisplayValsForGroup = (groupLoz) => {
+    const getInputAndDisplayValsForGroup = (groupLoz) => {
       let groupVal = groupLoz.substr(groupLoz.indexOf(':') + 1).trim();
       let inputVal = groupVal.trim();
       let displayVal = groupVal;
-      let wrapQuotesIfNeeded = function(str) {
+      const wrapQuotesIfNeeded = function(str) {
         return str.indexOf(' ') > -1 ? `"${str}"` : str;
       };
 
@@ -189,8 +189,8 @@ class SearchBarController extends Controller {
      * q parameter.
      *
      */
-    var insertHiddenInput = () => {
-      var hiddenInput = document.createElement('input');
+    const insertHiddenInput = () => {
+      const hiddenInput = document.createElement('input');
       hiddenInput.type = 'hidden';
 
       // When JavaScript isn't enabled this._input is submitted to the server
@@ -212,7 +212,7 @@ class SearchBarController extends Controller {
      * the DOM, and whenever the text in the visible input changes.
      *
      */
-    var updateHiddenInput = () => {
+    const updateHiddenInput = () => {
       let newValue = '';
       Array.from(this._lozengeContainer.querySelectorAll('.js-lozenge')).forEach((loz) => {
 
@@ -234,9 +234,9 @@ class SearchBarController extends Controller {
      *
      * @param {string} content The search term
      */
-    var addLozenge = (content) => {
+    const addLozenge = (content) => {
 
-      var deleteCallback = () => {
+      const deleteCallback = () => {
         Array.from(this._lozengeContainer.querySelectorAll('.js-lozenge')).forEach((loz) => {
           loz.classList.add('is-disabled');
         });
@@ -265,7 +265,7 @@ class SearchBarController extends Controller {
      * page load and update lozenges that are already in the lozenges container
      * so they are hooked up with the proper event handling
      */
-    var lozengifyInput = () => {
+    const lozengifyInput = () => {
 
       const {lozengeValues, incompleteInputValue} = SearchTextParser.getLozengeValues(this._input.value);
 
@@ -276,7 +276,7 @@ class SearchBarController extends Controller {
     };
 
 
-    var onInputKeyDown = (event) => {
+    const onInputKeyDown = (event) => {
       const SPACE_KEY_CODE = 32;
 
       if (event.keyCode === SPACE_KEY_CODE) {
@@ -358,8 +358,8 @@ class SearchBarController extends Controller {
           // index values or there is no current input value
 
           if (inputFilter) {
-            let aIndex = a.matchOn.indexOf(inputFilter);
-            let bIndex = b.matchOn.indexOf(inputFilter);
+            const aIndex = a.matchOn.indexOf(inputFilter);
+            const bIndex = b.matchOn.indexOf(inputFilter);
 
             // match score
             if (aIndex > bIndex) {

--- a/h/static/scripts/controllers/search-bar-controller.js
+++ b/h/static/scripts/controllers/search-bar-controller.js
@@ -276,7 +276,7 @@ class SearchBarController extends Controller {
     };
 
 
-    var onInputKeyDown = event => {
+    var onInputKeyDown = (event) => {
       const SPACE_KEY_CODE = 32;
 
       if (event.keyCode === SPACE_KEY_CODE) {

--- a/h/static/scripts/controllers/search-bar-controller.js
+++ b/h/static/scripts/controllers/search-bar-controller.js
@@ -39,7 +39,7 @@ class SearchBarController extends Controller {
      *  static or dynamic living in the dom - into one mapping
      *  lists of all suggestion values.
      */
-    this._suggestionsMap = (()=>{
+    this._suggestionsMap = (() => {
 
       let explanationList = [
         {
@@ -62,7 +62,7 @@ class SearchBarController extends Controller {
           title: 'group:',
           explanation: 'show annotations created in a group you are a member of',
         },
-      ].map((item)=>{ return Object.assign(item, { type: FACET_TYPE}); });
+      ].map((item) => { return Object.assign(item, { type: FACET_TYPE}); });
 
       // tagSuggestions are made available by the scoped template data.
       // see search.html.jinja2 for definition
@@ -77,7 +77,7 @@ class SearchBarController extends Controller {
         }
       }
 
-      let tagsList = ((tagSuggestions) || []).map((item)=>{
+      let tagsList = ((tagSuggestions) || []).map((item) => {
         return Object.assign(item, {
           type: TAG_TYPE,
           title: item.tag, // make safe
@@ -99,7 +99,7 @@ class SearchBarController extends Controller {
         }
       }
 
-      let groupsList = ((groupSuggestions) || []).map((item)=>{
+      let groupsList = ((groupSuggestions) || []).map((item) => {
         return Object.assign(item, {
           type: GROUP_TYPE,
           title: item.name, // make safe
@@ -157,7 +157,7 @@ class SearchBarController extends Controller {
       // them equal to us. Since that is very unlikely to occur for one user's group
       // set, the convenience of being defensive about bad input/urls is more valuable
       // than the risk of overlap.
-      const matchByPubid = this._suggestionsMap.find((item)=>{
+      const matchByPubid = this._suggestionsMap.find((item) => {
         return item.type === GROUP_TYPE && item.pubid.toLowerCase() === matchVal;
       });
 
@@ -165,7 +165,7 @@ class SearchBarController extends Controller {
         inputVal = matchByPubid.pubid;
         displayVal = wrapQuotesIfNeeded(matchByPubid.name);
       } else {
-        const matchByName = this._suggestionsMap.find((item)=>{
+        const matchByName = this._suggestionsMap.find((item) => {
           return item.type === GROUP_TYPE && item.matchOn.toLowerCase() === matchVal;
         });
         if (matchByName) {
@@ -234,7 +234,7 @@ class SearchBarController extends Controller {
      *
      * @param {string} content The search term
      */
-    var addLozenge = (content)=> {
+    var addLozenge = (content) => {
 
       var deleteCallback = () => {
         Array.from(this._lozengeContainer.querySelectorAll('.js-lozenge')).forEach(function(loz) {
@@ -308,7 +308,7 @@ class SearchBarController extends Controller {
         activeItem: 'js-search-bar-dropdown-menu-item--active',
       },
 
-      renderListItem: (listItem)=>{
+      renderListItem: (listItem) => {
 
         let itemContents = `<span class="search-bar__dropdown-menu-title"> ${escapeHtml(listItem.title)} </span>`;
 
@@ -319,7 +319,7 @@ class SearchBarController extends Controller {
         return itemContents;
       },
 
-      listFilter: (list, currentInput)=>{
+      listFilter: (list, currentInput) => {
 
         currentInput = (currentInput || '').trim();
 
@@ -347,9 +347,9 @@ class SearchBarController extends Controller {
           });
         }
 
-        return list.filter((item)=>{
+        return list.filter((item) => {
           return item.type === typeFilter && item.matchOn.toLowerCase().indexOf(inputFilter.toLowerCase()) >= 0;
-        }).sort((a,b)=>{
+        }).sort((a,b) => {
 
           // this sort functions intention is to
           // sort partial matches as lower index match
@@ -385,7 +385,7 @@ class SearchBarController extends Controller {
         }).slice(0, MAX_SUGGESTIONS);
       },
 
-      onSelect: (itemSelected)=>{
+      onSelect: (itemSelected) => {
 
         if (itemSelected.type === TAG_TYPE || itemSelected.type === GROUP_TYPE) {
           const prefix = itemSelected.type === TAG_TYPE ? 'tag:' : 'group:';
@@ -403,7 +403,7 @@ class SearchBarController extends Controller {
           this._input.value = '';
         } else {
           this._input.value = itemSelected.title;
-          setTimeout(()=>{
+          setTimeout(() => {
             this._input.focus();
           }, 0);
         }

--- a/h/static/scripts/controllers/search-bar-controller.js
+++ b/h/static/scripts/controllers/search-bar-controller.js
@@ -237,7 +237,7 @@ class SearchBarController extends Controller {
     var addLozenge = (content) => {
 
       var deleteCallback = () => {
-        Array.from(this._lozengeContainer.querySelectorAll('.js-lozenge')).forEach(function(loz) {
+        Array.from(this._lozengeContainer.querySelectorAll('.js-lozenge')).forEach((loz) => {
           loz.classList.add('is-disabled');
         });
         updateHiddenInput();

--- a/h/static/scripts/controllers/search-bucket-controller.js
+++ b/h/static/scripts/controllers/search-bucket-controller.js
@@ -1,9 +1,9 @@
 'use strict';
 
-var scrollIntoView = require('scroll-into-view');
+const scrollIntoView = require('scroll-into-view');
 
-var Controller = require('../base/controller');
-var setElementState = require('../util/dom').setElementState;
+const Controller = require('../base/controller');
+const setElementState = require('../util/dom').setElementState;
 
 /**
  * @typedef Options
@@ -30,7 +30,7 @@ class SearchBucketController extends Controller {
       this.setState({expanded: !this.state.expanded});
     });
 
-    var envFlags = this.options.envFlags || window.envFlags;
+    const envFlags = this.options.envFlags || window.envFlags;
 
     this.setState({
       expanded: !!envFlags.get('js-timeout'),

--- a/h/static/scripts/controllers/signup-form-controller.js
+++ b/h/static/scripts/controllers/signup-form-controller.js
@@ -1,12 +1,12 @@
 'use strict';
 
-var Controller = require('../base/controller');
+const Controller = require('../base/controller');
 
 class SignupFormController extends Controller {
   constructor(element) {
     super(element);
 
-    var submitBtn = element.querySelector('.js-signup-btn');
+    const submitBtn = element.querySelector('.js-signup-btn');
 
     element.addEventListener('submit', () => {
       submitBtn.disabled = true;

--- a/h/static/scripts/controllers/tooltip-controller.js
+++ b/h/static/scripts/controllers/tooltip-controller.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Controller = require('../base/controller');
+const Controller = require('../base/controller');
 
 /**
  * A custom tooltip similar to the one used in Google Docs which appears
@@ -47,8 +47,8 @@ class TooltipController extends Controller {
       return;
     }
 
-    var target = state.target;
-    var label = target.getAttribute('aria-label');
+    const target = state.target;
+    const label = target.getAttribute('aria-label');
     this._labelEl.textContent = label;
 
     Object.assign(this._tooltipEl.style, {

--- a/h/static/scripts/header.js
+++ b/h/static/scripts/header.js
@@ -5,7 +5,7 @@
 // This should be a small script which does things like setting up flags to
 // indicate that scripting is active, send analytics events etc.
 
-var EnvironmentFlags = require('./base/environment-flags');
+const EnvironmentFlags = require('./base/environment-flags');
 
 window.envFlags = new EnvironmentFlags(document.documentElement);
 window.envFlags.init();

--- a/h/static/scripts/legacy-site.js
+++ b/h/static/scripts/legacy-site.js
@@ -4,8 +4,8 @@ window.$ = window.jQuery = require('jquery');
 require('bootstrap');
 
 if (window.chrome !== undefined) {
-  var elements = document.getElementsByClassName('unhide-in-chrome');
-  var i;
+  let elements = document.getElementsByClassName('unhide-in-chrome');
+  let i;
   for (i = 0; i < elements.length; i++) {
     elements[i].classList.remove('hidden');
   }
@@ -15,7 +15,7 @@ if (window.chrome !== undefined) {
   }
 }
 
-var bookmarkletInstaller = document.getElementById('js-bookmarklet-install');
+const bookmarkletInstaller = document.getElementById('js-bookmarklet-install');
 if (bookmarkletInstaller) {
   bookmarkletInstaller.addEventListener('click', (event) => {
     window.alert('Drag me to the bookmarks bar');
@@ -23,7 +23,7 @@ if (bookmarkletInstaller) {
   });
 }
 
-var chromeextInstaller = document.getElementById('js-chrome-extension-install');
+const chromeextInstaller = document.getElementById('js-chrome-extension-install');
 if (chromeextInstaller) {
   chromeextInstaller.addEventListener('click', (event) => {
     window.chrome.webstore.install();

--- a/h/static/scripts/legacy-site.js
+++ b/h/static/scripts/legacy-site.js
@@ -17,7 +17,7 @@ if (window.chrome !== undefined) {
 
 var bookmarkletInstaller = document.getElementById('js-bookmarklet-install');
 if (bookmarkletInstaller) {
-  bookmarkletInstaller.addEventListener('click', function (event) {
+  bookmarkletInstaller.addEventListener('click', (event) => {
     window.alert('Drag me to the bookmarks bar');
     event.preventDefault();
   });
@@ -25,7 +25,7 @@ if (bookmarkletInstaller) {
 
 var chromeextInstaller = document.getElementById('js-chrome-extension-install');
 if (chromeextInstaller) {
-  chromeextInstaller.addEventListener('click', function (event) {
+  chromeextInstaller.addEventListener('click', (event) => {
     window.chrome.webstore.install();
     event.preventDefault();
   });

--- a/h/static/scripts/site.js
+++ b/h/static/scripts/site.js
@@ -1,27 +1,27 @@
 'use strict';
 
 // Configure error reporting
-var settings = require('./base/settings')(document);
+const settings = require('./base/settings')(document);
 if (settings.raven) {
   require('./base/raven').init(settings.raven);
 }
 
 require('./polyfills');
 
-var CharacterLimitController = require('./controllers/character-limit-controller');
-var CopyButtonController = require('./controllers/copy-button-controller');
-var ConfirmSubmitController = require('./controllers/confirm-submit-controller');
-var CreateGroupFormController = require('./controllers/create-group-form-controller');
-var DropdownMenuController = require('./controllers/dropdown-menu-controller');
-var FormController = require('./controllers/form-controller');
-var FormSelectOnFocusController = require('./controllers/form-select-onfocus-controller');
-var SearchBarController = require('./controllers/search-bar-controller');
-var SearchBucketController = require('./controllers/search-bucket-controller');
-var SignupFormController = require('./controllers/signup-form-controller');
-var TooltipController = require('./controllers/tooltip-controller');
-var upgradeElements = require('./base/upgrade-elements');
+const CharacterLimitController = require('./controllers/character-limit-controller');
+const CopyButtonController = require('./controllers/copy-button-controller');
+const ConfirmSubmitController = require('./controllers/confirm-submit-controller');
+const CreateGroupFormController = require('./controllers/create-group-form-controller');
+const DropdownMenuController = require('./controllers/dropdown-menu-controller');
+const FormController = require('./controllers/form-controller');
+const FormSelectOnFocusController = require('./controllers/form-select-onfocus-controller');
+const SearchBarController = require('./controllers/search-bar-controller');
+const SearchBucketController = require('./controllers/search-bucket-controller');
+const SignupFormController = require('./controllers/signup-form-controller');
+const TooltipController = require('./controllers/tooltip-controller');
+const upgradeElements = require('./base/upgrade-elements');
 
-var controllers = {
+const controllers = {
   '.js-character-limit': CharacterLimitController,
   '.js-copy-button': CopyButtonController,
   '.js-confirm-submit': ConfirmSubmitController,

--- a/h/static/scripts/tests/base/controller-test.js
+++ b/h/static/scripts/tests/base/controller-test.js
@@ -9,31 +9,31 @@ class TestController extends Controller {
   }
 }
 
-describe('Controller', function () {
+describe('Controller', () => {
   var ctrl;
 
-  beforeEach(function () {
+  beforeEach(() => {
     var root = document.createElement('div');
     root.innerHTML = '<div data-ref="test"></div>';
     document.body.appendChild(root);
     ctrl = new TestController(root);
   });
 
-  afterEach(function () {
+  afterEach(() => {
     ctrl.element.remove();
   });
 
-  it('exposes controllers via the `.controllers` element property', function () {
+  it('exposes controllers via the `.controllers` element property', () => {
     assert.equal(ctrl.element.controllers.length, 1);
     assert.instanceOf(ctrl.element.controllers[0], TestController);
   });
 
-  it('exposes elements with "data-ref" attributes on the `refs` property', function () {
+  it('exposes elements with "data-ref" attributes on the `refs` property', () => {
     assert.deepEqual(ctrl.refs, {test: ctrl.element.children[0]});
   });
 
-  describe('#setState', function () {
-    it('calls update() with new and previous state', function () {
+  describe('#setState', () => {
+    it('calls update() with new and previous state', () => {
       ctrl.setState({open: true});
       ctrl.update = sinon.stub();
       ctrl.setState({open: true, saving: true});

--- a/h/static/scripts/tests/base/controller-test.js
+++ b/h/static/scripts/tests/base/controller-test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Controller = require('../../base/controller');
+const Controller = require('../../base/controller');
 
 class TestController extends Controller {
   constructor(element, options) {
@@ -10,10 +10,10 @@ class TestController extends Controller {
 }
 
 describe('Controller', () => {
-  var ctrl;
+  let ctrl;
 
   beforeEach(() => {
-    var root = document.createElement('div');
+    const root = document.createElement('div');
     root.innerHTML = '<div data-ref="test"></div>';
     document.body.appendChild(root);
     ctrl = new TestController(root);

--- a/h/static/scripts/tests/base/environment-flags-test.js
+++ b/h/static/scripts/tests/base/environment-flags-test.js
@@ -4,70 +4,70 @@ var EnvironmentFlags = require('../../base/environment-flags');
 
 var TIMEOUT_DELAY = 10000;
 
-describe('EnvironmentFlags', function () {
+describe('EnvironmentFlags', () => {
   var clock;
   var el;
   var flags;
 
-  beforeEach(function () {
+  beforeEach(() => {
     el = document.createElement('div');
     flags = new EnvironmentFlags(el);
     clock = sinon.useFakeTimers();
   });
 
-  afterEach(function () {
+  afterEach(() => {
     clock.restore();
   });
 
-  describe('#init', function () {
-    it('should mark document as JS capable on load', function () {
+  describe('#init', () => {
+    it('should mark document as JS capable on load', () => {
       flags.init();
       assert.isTrue(el.classList.contains('env-js-capable'));
     });
 
-    it('should mark JS load as failed after a timeout', function () {
+    it('should mark JS load as failed after a timeout', () => {
       flags.init();
       clock.tick(TIMEOUT_DELAY);
       assert.isTrue(el.classList.contains('env-js-timeout'));
     });
 
-    it('should not add "env-touch" flag if touch events are not supported', function () {
+    it('should not add "env-touch" flag if touch events are not supported', () => {
       flags.init();
       assert.isFalse(el.classList.contains('env-touch'));
     });
 
-    it('should add "env-touch" flag if touch events are available', function () {
+    it('should add "env-touch" flag if touch events are available', () => {
       el.ontouchstart = function () {};
       flags.init();
       assert.isTrue(el.classList.contains('env-touch'));
     });
 
-    it('should add flags specified in the document URL', function () {
+    it('should add flags specified in the document URL', () => {
       flags.init('http://example.org/?__env__=touch;js-timeout');
       assert.isTrue(el.classList.contains('env-touch'));
       assert.isTrue(el.classList.contains('env-js-timeout'));
     });
 
-    it('should remove flags with a "no-" prefix specified in the document URL', function () {
+    it('should remove flags with a "no-" prefix specified in the document URL', () => {
       flags.init('http://example.org/?__env__=no-js-capable');
       assert.isFalse(el.classList.contains('env-js-capable'));
     });
 
-    it('should remove "js-capable" flag if "nojs=1" is present in URL', function () {
+    it('should remove "js-capable" flag if "nojs=1" is present in URL', () => {
       flags.init('http://example.org/?nojs=1');
       assert.isFalse(el.classList.contains('env-js-capable'));
     });
   });
 
-  describe('#ready', function () {
-    it('should prevent JS load timeout flag from being set', function () {
+  describe('#ready', () => {
+    it('should prevent JS load timeout flag from being set', () => {
       flags.init();
       flags.ready();
       clock.tick(TIMEOUT_DELAY);
       assert.isFalse(el.classList.contains('env-js-timeout'));
     });
 
-    it('should not clear timeout flag if already set', function () {
+    it('should not clear timeout flag if already set', () => {
       flags.init();
       clock.tick(TIMEOUT_DELAY);
       flags.ready();
@@ -75,25 +75,25 @@ describe('EnvironmentFlags', function () {
     });
   });
 
-  describe('#set', function () {
-    it('should add a flag if `on` is true', function () {
+  describe('#set', () => {
+    it('should add a flag if `on` is true', () => {
       flags.set('shiny-feature', true);
       assert.isTrue(el.classList.contains('env-shiny-feature'));
     });
 
-    it('should remove a flag if `on` is false', function () {
+    it('should remove a flag if `on` is false', () => {
       flags.set('shiny-feature', false);
       assert.isFalse(el.classList.contains('env-shiny-feature'));
     });
   });
 
-  describe('#get', function () {
-    it('should return true if the flag is set', function () {
+  describe('#get', () => {
+    it('should return true if the flag is set', () => {
       flags.set('shiny-feature', true);
       assert.isTrue(flags.get('shiny-feature'));
     });
 
-    it('should return false if the flag is set', function () {
+    it('should return false if the flag is set', () => {
       assert.isFalse(flags.get('shiny-feature'));
     });
   });

--- a/h/static/scripts/tests/base/environment-flags-test.js
+++ b/h/static/scripts/tests/base/environment-flags-test.js
@@ -1,13 +1,13 @@
 'use strict';
 
-var EnvironmentFlags = require('../../base/environment-flags');
+const EnvironmentFlags = require('../../base/environment-flags');
 
-var TIMEOUT_DELAY = 10000;
+const TIMEOUT_DELAY = 10000;
 
 describe('EnvironmentFlags', () => {
-  var clock;
-  var el;
-  var flags;
+  let clock;
+  let el;
+  let flags;
 
   beforeEach(() => {
     el = document.createElement('div');

--- a/h/static/scripts/tests/base/raven-test.js
+++ b/h/static/scripts/tests/base/raven-test.js
@@ -3,11 +3,11 @@
 var proxyquire = require('proxyquire');
 var noCallThru = require('../util').noCallThru;
 
-describe('raven', function () {
+describe('raven', () => {
   var fakeRavenJS;
   var raven;
 
-  beforeEach(function () {
+  beforeEach(() => {
     fakeRavenJS = {
       config: sinon.stub().returns({
         install: sinon.stub(),
@@ -21,8 +21,8 @@ describe('raven', function () {
     }));
   });
 
-  describe('.install()', function () {
-    it('installs a handler for uncaught promises', function () {
+  describe('.install()', () => {
+    it('installs a handler for uncaught promises', () => {
       raven.init({
         dsn: 'dsn',
         release: 'release',
@@ -37,8 +37,8 @@ describe('raven', function () {
     });
   });
 
-  describe('.report()', function () {
-    it('extracts the message property from Error-like objects', function () {
+  describe('.report()', () => {
+    it('extracts the message property from Error-like objects', () => {
       raven.report({message: 'An error'}, 'context');
       assert.calledWith(fakeRavenJS.captureException, 'An error', {
         extra: {
@@ -47,7 +47,7 @@ describe('raven', function () {
       });
     });
 
-    it('passes extra details through', function () {
+    it('passes extra details through', () => {
       var error = new Error('an error');
       raven.report(error, 'some operation', { url: 'foobar.com' });
       assert.calledWith(fakeRavenJS.captureException, error, {

--- a/h/static/scripts/tests/base/raven-test.js
+++ b/h/static/scripts/tests/base/raven-test.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var proxyquire = require('proxyquire');
-var noCallThru = require('../util').noCallThru;
+const proxyquire = require('proxyquire');
+const noCallThru = require('../util').noCallThru;
 
 describe('raven', () => {
-  var fakeRavenJS;
-  var raven;
+  let fakeRavenJS;
+  let raven;
 
   beforeEach(() => {
     fakeRavenJS = {
@@ -27,7 +27,7 @@ describe('raven', () => {
         dsn: 'dsn',
         release: 'release',
       });
-      var event = document.createEvent('Event');
+      const event = document.createEvent('Event');
       event.initEvent('unhandledrejection', true /* bubbles */, true /* cancelable */);
       event.reason = new Error('Some error');
       window.dispatchEvent(event);
@@ -48,7 +48,7 @@ describe('raven', () => {
     });
 
     it('passes extra details through', () => {
-      var error = new Error('an error');
+      const error = new Error('an error');
       raven.report(error, 'some operation', { url: 'foobar.com' });
       assert.calledWith(fakeRavenJS.captureException, error, {
         extra: {

--- a/h/static/scripts/tests/base/settings-test.js
+++ b/h/static/scripts/tests/base/settings-test.js
@@ -1,9 +1,9 @@
 'use strict';
 
-var settings = require('../../base/settings');
+const settings = require('../../base/settings');
 
 function createJSONScriptTag(obj, className) {
-  var el = document.createElement('script');
+  const el = document.createElement('script');
   el.type = 'application/json';
   el.textContent = JSON.stringify(obj);
   el.classList.add(className);
@@ -12,8 +12,8 @@ function createJSONScriptTag(obj, className) {
 }
 
 function removeJSONScriptTags() {
-  var elements = document.querySelectorAll('.js-settings-test');
-  for (var i=0; i < elements.length; i++) {
+  const elements = document.querySelectorAll('.js-settings-test');
+  for (let i=0; i < elements.length; i++) {
     elements[i].parentNode.removeChild(elements[i]);
   }
 }

--- a/h/static/scripts/tests/base/settings-test.js
+++ b/h/static/scripts/tests/base/settings-test.js
@@ -18,23 +18,23 @@ function removeJSONScriptTags() {
   }
 }
 
-describe('settings', function () {
+describe('settings', () => {
   afterEach(removeJSONScriptTags);
 
-  it('reads config from .js-hypothesis-settings <script> tags', function () {
+  it('reads config from .js-hypothesis-settings <script> tags', () => {
     document.body.appendChild(createJSONScriptTag({key:'value'},
       'js-hypothesis-settings'));
     assert.deepEqual(settings(document), {key:'value'});
   });
 
-  it('reads config from <script> tags with the specified class name', function () {
+  it('reads config from <script> tags with the specified class name', () => {
     document.body.appendChild(createJSONScriptTag({foo:'bar'},
       'js-custom-settings'));
     assert.deepEqual(settings(document), {});
     assert.deepEqual(settings(document, 'js-custom-settings'), {foo:'bar'});
   });
 
-  it('merges settings from all config <script> tags', function () {
+  it('merges settings from all config <script> tags', () => {
     document.body.appendChild(createJSONScriptTag({a: 1}, 'settings'));
     document.body.appendChild(createJSONScriptTag({b: 2}, 'settings'));
     assert.deepEqual(settings(document, 'settings'), {a: 1, b: 2});

--- a/h/static/scripts/tests/base/upgrade-elements-test.js
+++ b/h/static/scripts/tests/base/upgrade-elements-test.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var Controller = require('../../base/controller');
-var upgradeElements = require('../../base/upgrade-elements');
+const Controller = require('../../base/controller');
+const upgradeElements = require('../../base/upgrade-elements');
 
 class TestController extends Controller {
   constructor(element, options) {
@@ -11,7 +11,7 @@ class TestController extends Controller {
 
 describe('upgradeElements', () => {
   it('should upgrade elements matching selectors', () => {
-    var root = document.createElement('div');
+    const root = document.createElement('div');
     root.innerHTML = '<div class="js-test"></div>';
 
     upgradeElements(root, {'.js-test': TestController});
@@ -20,7 +20,7 @@ describe('upgradeElements', () => {
   });
 
   it('should unhide elements hidden until upgrade', () => {
-    var root = document.createElement('div');
+    const root = document.createElement('div');
     root.innerHTML = '<div class="js-test is-hidden-when-loading"></div>';
 
     upgradeElements(root, {'.js-test': TestController});
@@ -29,7 +29,7 @@ describe('upgradeElements', () => {
   });
 
   it('should unhide child elements hidden until upgrade', () => {
-    var root = document.createElement('div');
+    const root = document.createElement('div');
     root.innerHTML = '<div class="js-test">' +
                      '<span class="is-hidden-when-loading"></span>' +
                      '</div>';
@@ -40,42 +40,42 @@ describe('upgradeElements', () => {
   });
 
   describe('reload function', () => {
-    var newContent = '<div class="js-test">Reloaded element</div>';
+    const newContent = '<div class="js-test">Reloaded element</div>';
 
     function setupAndReload() {
-      var root = document.createElement('div');
+      const root = document.createElement('div');
       root.innerHTML = '<div class="js-test">Original content</div>';
       upgradeElements(root, {'.js-test': TestController});
 
-      var reloadFn = root.children[0].controllers[0].options.reload;
-      var reloadResult = reloadFn(newContent);
+      const reloadFn = root.children[0].controllers[0].options.reload;
+      const reloadResult = reloadFn(newContent);
       return {root: root, reloadResult: reloadResult};
     }
 
     it('replaces element markup', () => {
-      var root = setupAndReload().root;
+      const root = setupAndReload().root;
       assert.equal(root.innerHTML, newContent);
     });
 
     it('returns the replaced element', () => {
-      var result = setupAndReload();
+      const result = setupAndReload();
       assert.equal(result.root.children[0], result.reloadResult);
     });
 
     it('re-applies element upgrades', () => {
-      var root = setupAndReload().root;
-      var replacedElement = root.children[0];
-      var ctrl = replacedElement.controllers[0];
+      const root = setupAndReload().root;
+      const replacedElement = root.children[0];
+      const ctrl = replacedElement.controllers[0];
       assert.instanceOf(ctrl, TestController);
     });
 
     it('calls #beforeRemove on the original controllers', () => {
-      var root = document.createElement('div');
+      const root = document.createElement('div');
       root.innerHTML = '<div class="js-test">Original content</div>';
       upgradeElements(root, {'.js-test': TestController});
-      var ctrl = root.children[0].controllers[0];
+      const ctrl = root.children[0].controllers[0];
       ctrl.beforeRemove = sinon.stub();
-      var reloadFn = ctrl.options.reload;
+      const reloadFn = ctrl.options.reload;
 
       reloadFn(newContent);
 

--- a/h/static/scripts/tests/base/upgrade-elements-test.js
+++ b/h/static/scripts/tests/base/upgrade-elements-test.js
@@ -9,8 +9,8 @@ class TestController extends Controller {
   }
 }
 
-describe('upgradeElements', function () {
-  it('should upgrade elements matching selectors', function () {
+describe('upgradeElements', () => {
+  it('should upgrade elements matching selectors', () => {
     var root = document.createElement('div');
     root.innerHTML = '<div class="js-test"></div>';
 
@@ -19,7 +19,7 @@ describe('upgradeElements', function () {
     assert.instanceOf(root.children[0].controllers[0], TestController);
   });
 
-  it('should unhide elements hidden until upgrade', function () {
+  it('should unhide elements hidden until upgrade', () => {
     var root = document.createElement('div');
     root.innerHTML = '<div class="js-test is-hidden-when-loading"></div>';
 
@@ -28,7 +28,7 @@ describe('upgradeElements', function () {
     assert.equal(root.querySelectorAll('.is-hidden-when-loading').length, 0);
   });
 
-  it('should unhide child elements hidden until upgrade', function () {
+  it('should unhide child elements hidden until upgrade', () => {
     var root = document.createElement('div');
     root.innerHTML = '<div class="js-test">' +
                      '<span class="is-hidden-when-loading"></span>' +
@@ -39,7 +39,7 @@ describe('upgradeElements', function () {
     assert.equal(root.querySelectorAll('.is-hidden-when-loading').length, 0);
   });
 
-  describe('reload function', function () {
+  describe('reload function', () => {
     var newContent = '<div class="js-test">Reloaded element</div>';
 
     function setupAndReload() {
@@ -52,24 +52,24 @@ describe('upgradeElements', function () {
       return {root: root, reloadResult: reloadResult};
     }
 
-    it('replaces element markup', function () {
+    it('replaces element markup', () => {
       var root = setupAndReload().root;
       assert.equal(root.innerHTML, newContent);
     });
 
-    it('returns the replaced element', function () {
+    it('returns the replaced element', () => {
       var result = setupAndReload();
       assert.equal(result.root.children[0], result.reloadResult);
     });
 
-    it('re-applies element upgrades', function () {
+    it('re-applies element upgrades', () => {
       var root = setupAndReload().root;
       var replacedElement = root.children[0];
       var ctrl = replacedElement.controllers[0];
       assert.instanceOf(ctrl, TestController);
     });
 
-    it('calls #beforeRemove on the original controllers', function () {
+    it('calls #beforeRemove on the original controllers', () => {
       var root = document.createElement('div');
       root.innerHTML = '<div class="js-test">Original content</div>';
       upgradeElements(root, {'.js-test': TestController});

--- a/h/static/scripts/tests/controllers/admin-users-controller-test.js
+++ b/h/static/scripts/tests/controllers/admin-users-controller-test.js
@@ -1,14 +1,14 @@
 'use strict';
 
-var AdminUsersController = require('../../controllers/admin-users-controller');
+const AdminUsersController = require('../../controllers/admin-users-controller');
 
 function submitEvent() {
   return new Event('submit', {bubbles: true, cancelable: true});
 }
 
 describe('AdminUsersController', () => {
-  var root;
-  var form;
+  let root;
+  let form;
 
   beforeEach(() => {
     root = document.createElement('div');
@@ -22,8 +22,8 @@ describe('AdminUsersController', () => {
   });
 
   it('it submits the form when confirm returns true', () => {
-    var event = submitEvent();
-    var fakeWindow = {confirm: sinon.stub().returns(true)};
+    const event = submitEvent();
+    const fakeWindow = {confirm: sinon.stub().returns(true)};
     new AdminUsersController(root, {window: fakeWindow});
 
     form.dispatchEvent(event);
@@ -32,8 +32,8 @@ describe('AdminUsersController', () => {
   });
 
   it('it cancels the form submission when confirm returns false', () => {
-    var event = submitEvent();
-    var fakeWindow = {confirm: sinon.stub().returns(false)};
+    const event = submitEvent();
+    const fakeWindow = {confirm: sinon.stub().returns(false)};
     new AdminUsersController(root, {window: fakeWindow});
 
     form.dispatchEvent(event);

--- a/h/static/scripts/tests/controllers/admin-users-controller-test.js
+++ b/h/static/scripts/tests/controllers/admin-users-controller-test.js
@@ -6,22 +6,22 @@ function submitEvent() {
   return new Event('submit', {bubbles: true, cancelable: true});
 }
 
-describe('AdminUsersController', function () {
+describe('AdminUsersController', () => {
   var root;
   var form;
 
-  beforeEach(function () {
+  beforeEach(() => {
     root = document.createElement('div');
     root.innerHTML = '<form><input type="submit"></form>';
     form = root.querySelector('form');
     document.body.appendChild(root);
   });
 
-  afterEach(function () {
+  afterEach(() => {
     root.remove();
   });
 
-  it('it submits the form when confirm returns true', function () {
+  it('it submits the form when confirm returns true', () => {
     var event = submitEvent();
     var fakeWindow = {confirm: sinon.stub().returns(true)};
     new AdminUsersController(root, {window: fakeWindow});
@@ -31,7 +31,7 @@ describe('AdminUsersController', function () {
     assert.isFalse(event.defaultPrevented);
   });
 
-  it('it cancels the form submission when confirm returns false', function () {
+  it('it cancels the form submission when confirm returns false', () => {
     var event = submitEvent();
     var fakeWindow = {confirm: sinon.stub().returns(false)};
     new AdminUsersController(root, {window: fakeWindow});

--- a/h/static/scripts/tests/controllers/autosuggest-dropdown-controller-test.js
+++ b/h/static/scripts/tests/controllers/autosuggest-dropdown-controller-test.js
@@ -48,7 +48,7 @@ describe('AutosuggestDropdownController', () => {
     let input;
     let form;
 
-    let defaultConfig = {
+    const defaultConfig = {
       list: [
         {
           title: 'user:',
@@ -270,7 +270,7 @@ describe('AutosuggestDropdownController', () => {
         });
     });
 
-    var navigationExpectations = [
+    const navigationExpectations = [
       { travel: '[down]', selectedIndex: 0 },
       { travel: '[up]', selectedIndex: 3 },
       { travel: '[down][up]', selectedIndex: -1 },
@@ -291,7 +291,7 @@ describe('AutosuggestDropdownController', () => {
       syn
         .click(input)
         .type(fixture.travel, () => {
-          var active = getCurrentActiveElements();
+          const active = getCurrentActiveElements();
           if (fixture.selectedIndex === -1) {
             assert.lengthOf(active, 0);
           } else {

--- a/h/static/scripts/tests/controllers/autosuggest-dropdown-controller-test.js
+++ b/h/static/scripts/tests/controllers/autosuggest-dropdown-controller-test.js
@@ -41,9 +41,9 @@ function center(element) {
 }
 
 
-describe('AutosuggestDropdownController', function () {
+describe('AutosuggestDropdownController', () => {
 
-  describe('provides suggestions', function() {
+  describe('provides suggestions', () => {
     let container;
     let input;
     let form;
@@ -121,7 +121,7 @@ describe('AutosuggestDropdownController', function () {
       return list.querySelectorAll('.' + defaultConfig.classNames.activeItem);
     };
 
-    beforeEach(function () {
+    beforeEach(() => {
       container = document.createElement('div');
       container.innerHTML = '<form><input id="input-el"/></form>';
       document.body.appendChild(container);
@@ -130,7 +130,7 @@ describe('AutosuggestDropdownController', function () {
       form.onsubmit = sinon.spy();
     });
 
-    afterEach(function () {
+    afterEach(() => {
       document.body.removeChild(container);
 
       // clear up spies
@@ -144,7 +144,7 @@ describe('AutosuggestDropdownController', function () {
     });
 
 
-    it('should initialize the controller with correct dom', function() {
+    it('should initialize the controller with correct dom', () => {
 
       assert.isTrue(form.childNodes.length === 1, 'baseline');
 
@@ -165,7 +165,7 @@ describe('AutosuggestDropdownController', function () {
     });
 
 
-    it('opens and closes based on focus status', function (done) {
+    it('opens and closes based on focus status', (done) => {
 
       new AutosuggestDropdownController(input, defaultConfig);
 
@@ -185,7 +185,7 @@ describe('AutosuggestDropdownController', function () {
     });
 
 
-    it('changes suggestion container and item visibility on matching input', function(done) {
+    it('changes suggestion container and item visibility on matching input', (done) => {
 
       const reduceSpy = sinon.spy(defaultConfig, 'listFilter');
 
@@ -236,7 +236,7 @@ describe('AutosuggestDropdownController', function () {
 
     });
 
-    it('allows click selection', function(done) {
+    it('allows click selection', (done) => {
       const onSelectSpy = sinon.spy(defaultConfig, 'onSelect');
 
       assert.equal(onSelectSpy.callCount, 0);
@@ -282,7 +282,7 @@ describe('AutosuggestDropdownController', function () {
       { travel: '[up][down][up][down][down][down][down][up]', selectedIndex: 1 },
     ];
 
-    unroll('allows keyboard navigation', function(done, fixture) {
+    unroll('allows keyboard navigation', (done, fixture) => {
 
       new AutosuggestDropdownController(input, defaultConfig);
 
@@ -303,7 +303,7 @@ describe('AutosuggestDropdownController', function () {
     }, navigationExpectations);
 
 
-    it('persists active navigation through list filter', function(done) {
+    it('persists active navigation through list filter', (done) => {
       new AutosuggestDropdownController(input, defaultConfig);
 
       const list = container.querySelector('.' + defaultConfig.classNames.list);
@@ -323,7 +323,7 @@ describe('AutosuggestDropdownController', function () {
         });
     });
 
-    it('allows keyboard selection', function(done) {
+    it('allows keyboard selection', (done) => {
       const onSelectSpy = sinon.spy(defaultConfig, 'onSelect');
 
       assert.equal(onSelectSpy.callCount, 0);
@@ -347,7 +347,7 @@ describe('AutosuggestDropdownController', function () {
         });
     });
 
-    it('can hover items', function(done) {
+    it('can hover items', (done) => {
 
       new AutosuggestDropdownController(input, defaultConfig);
 
@@ -376,7 +376,7 @@ describe('AutosuggestDropdownController', function () {
 
     });
 
-    it('correctly sets active elements when swapping between keyboard and mouse setting', function(done) {
+    it('correctly sets active elements when swapping between keyboard and mouse setting', (done) => {
 
       new AutosuggestDropdownController(input, defaultConfig);
 

--- a/h/static/scripts/tests/controllers/autosuggest-dropdown-controller-test.js
+++ b/h/static/scripts/tests/controllers/autosuggest-dropdown-controller-test.js
@@ -9,7 +9,7 @@ const AutosuggestDropdownController = require('../../controllers/autosuggest-dro
 
 // syn's move functionality does not fire
 // mouseenter and mouseleave events.
-const mouseMove = (()=>{
+const mouseMove = (() => {
 
   let _lastMovePos;
 
@@ -78,7 +78,7 @@ describe('AutosuggestDropdownController', function () {
         activeItem: 'an-active-item',
       },
 
-      renderListItem: (listItem)=>{
+      renderListItem: (listItem) => {
 
         let itemContents = `<span class="a-title"> ${listItem.title} </span>`;
 
@@ -94,7 +94,7 @@ describe('AutosuggestDropdownController', function () {
 
         currentInput = (currentInput || '').trim();
 
-        return list.filter((item)=>{
+        return list.filter((item) => {
 
           if (!currentInput) {
             return item;
@@ -106,17 +106,17 @@ describe('AutosuggestDropdownController', function () {
       onSelect: function() {},
     };
 
-    const isSuggestionContainerVisible = ()=>{
+    const isSuggestionContainerVisible = () => {
       const suggestionContainer = container.querySelector('.' + defaultConfig.classNames.container);
       return suggestionContainer.classList.contains('is-open');
     };
 
-    const getListItems = ()=>{
+    const getListItems = () => {
       const suggestionContainer = container.querySelector('.' + defaultConfig.classNames.container);
       return suggestionContainer.querySelectorAll('.' + defaultConfig.classNames.item);
     };
 
-    const getCurrentActiveElements = ()=>{
+    const getCurrentActiveElements = () => {
       const list = container.querySelector('.' + defaultConfig.classNames.list);
       return list.querySelectorAll('.' + defaultConfig.classNames.activeItem);
     };
@@ -254,7 +254,7 @@ describe('AutosuggestDropdownController', function () {
           assert.isTrue(isSuggestionContainerVisible(), 'pre select show');
 
           syn
-            .click(items[0], ()=>{
+            .click(items[0], () => {
 
               assert.equal(onSelectSpy.callCount, 1);
 
@@ -354,7 +354,7 @@ describe('AutosuggestDropdownController', function () {
       const list = container.querySelector('.' + defaultConfig.classNames.list);
 
       syn
-        .click(input, ()=>{
+        .click(input, () => {
 
           mouseMove(center(list.childNodes[1]));
 
@@ -383,7 +383,7 @@ describe('AutosuggestDropdownController', function () {
       const list = container.querySelector('.' + defaultConfig.classNames.list);
 
       syn
-        .click(input, ()=>{
+        .click(input, () => {
 
           mouseMove(center(list.childNodes[2]));
 
@@ -391,11 +391,11 @@ describe('AutosuggestDropdownController', function () {
           assert.isTrue(list.childNodes[2].classList.contains(defaultConfig.classNames.activeItem));
 
         })
-        .type('[down]', ()=>{
+        .type('[down]', () => {
           assert.lengthOf(getCurrentActiveElements(), 1);
           assert.isTrue(list.childNodes[3].classList.contains(defaultConfig.classNames.activeItem));
         })
-        .type('[up][up][up]', ()=>{
+        .type('[up][up][up]', () => {
           assert.lengthOf(getCurrentActiveElements(), 1);
           assert.isTrue(list.childNodes[0].classList.contains(defaultConfig.classNames.activeItem));
 

--- a/h/static/scripts/tests/controllers/autosuggest-dropdown-controller-test.js
+++ b/h/static/scripts/tests/controllers/autosuggest-dropdown-controller-test.js
@@ -15,7 +15,7 @@ const mouseMove = (()=>{
 
   return (posObj) => {
 
-    if (_lastMovePos){
+    if (_lastMovePos) {
       const prevEl = document.elementFromPoint(_lastMovePos.pageX, _lastMovePos.pageY);
       const leaveEvent = document.createEvent( 'Events' );
       leaveEvent.initEvent( 'mouseleave', true, false );
@@ -43,7 +43,7 @@ function center(element) {
 
 describe('AutosuggestDropdownController', function () {
 
-  describe('provides suggestions', function(){
+  describe('provides suggestions', function() {
     let container;
     let input;
     let form;
@@ -82,28 +82,28 @@ describe('AutosuggestDropdownController', function () {
 
         let itemContents = `<span class="a-title"> ${listItem.title} </span>`;
 
-        if (listItem.explanation){
+        if (listItem.explanation) {
           itemContents += `<span class="an-explanation"> ${listItem.explanation} </span>`;
         }
 
         return itemContents;
       },
 
-      listFilter: function(list, currentInput){
+      listFilter: function(list, currentInput) {
 
 
         currentInput = (currentInput || '').trim();
 
         return list.filter((item)=>{
 
-          if (!currentInput){
+          if (!currentInput) {
             return item;
           }
           return item.title.toLowerCase().indexOf(currentInput) >= 0;
         });
       },
 
-      onSelect: function(){},
+      onSelect: function() {},
     };
 
     const isSuggestionContainerVisible = ()=>{
@@ -134,17 +134,17 @@ describe('AutosuggestDropdownController', function () {
       document.body.removeChild(container);
 
       // clear up spies
-      if ('restore' in defaultConfig.listFilter){
+      if ('restore' in defaultConfig.listFilter) {
         defaultConfig.listFilter.restore();
       }
 
-      if ('restore' in defaultConfig.onSelect){
+      if ('restore' in defaultConfig.onSelect) {
         defaultConfig.onSelect.restore();
       }
     });
 
 
-    it('should initialize the controller with correct dom', function(){
+    it('should initialize the controller with correct dom', function() {
 
       assert.isTrue(form.childNodes.length === 1, 'baseline');
 
@@ -185,7 +185,7 @@ describe('AutosuggestDropdownController', function () {
     });
 
 
-    it('changes suggestion container and item visibility on matching input', function(done){
+    it('changes suggestion container and item visibility on matching input', function(done) {
 
       const reduceSpy = sinon.spy(defaultConfig, 'listFilter');
 
@@ -236,7 +236,7 @@ describe('AutosuggestDropdownController', function () {
 
     });
 
-    it('allows click selection', function(done){
+    it('allows click selection', function(done) {
       const onSelectSpy = sinon.spy(defaultConfig, 'onSelect');
 
       assert.equal(onSelectSpy.callCount, 0);
@@ -282,7 +282,7 @@ describe('AutosuggestDropdownController', function () {
       { travel: '[up][down][up][down][down][down][down][up]', selectedIndex: 1 },
     ];
 
-    unroll('allows keyboard navigation', function(done, fixture){
+    unroll('allows keyboard navigation', function(done, fixture) {
 
       new AutosuggestDropdownController(input, defaultConfig);
 
@@ -292,7 +292,7 @@ describe('AutosuggestDropdownController', function () {
         .click(input)
         .type(fixture.travel, () => {
           var active = getCurrentActiveElements();
-          if (fixture.selectedIndex === -1){
+          if (fixture.selectedIndex === -1) {
             assert.lengthOf(active, 0);
           } else {
             assert.isTrue(list.childNodes[fixture.selectedIndex].classList.contains(defaultConfig.classNames.activeItem));
@@ -303,7 +303,7 @@ describe('AutosuggestDropdownController', function () {
     }, navigationExpectations);
 
 
-    it('persists active navigation through list filter', function(done){
+    it('persists active navigation through list filter', function(done) {
       new AutosuggestDropdownController(input, defaultConfig);
 
       const list = container.querySelector('.' + defaultConfig.classNames.list);
@@ -323,7 +323,7 @@ describe('AutosuggestDropdownController', function () {
         });
     });
 
-    it('allows keyboard selection', function(done){
+    it('allows keyboard selection', function(done) {
       const onSelectSpy = sinon.spy(defaultConfig, 'onSelect');
 
       assert.equal(onSelectSpy.callCount, 0);
@@ -347,7 +347,7 @@ describe('AutosuggestDropdownController', function () {
         });
     });
 
-    it('can hover items', function(done){
+    it('can hover items', function(done) {
 
       new AutosuggestDropdownController(input, defaultConfig);
 
@@ -376,7 +376,7 @@ describe('AutosuggestDropdownController', function () {
 
     });
 
-    it('correctly sets active elements when swapping between keyboard and mouse setting', function(done){
+    it('correctly sets active elements when swapping between keyboard and mouse setting', function(done) {
 
       new AutosuggestDropdownController(input, defaultConfig);
 

--- a/h/static/scripts/tests/controllers/character-limit-controller-test.js
+++ b/h/static/scripts/tests/controllers/character-limit-controller-test.js
@@ -3,11 +3,11 @@
 var CharacterLimitController = require('../../controllers/character-limit-controller');
 var util = require('./util');
 
-describe('CharacterLimitController', function () {
+describe('CharacterLimitController', () => {
 
   var ctrl;
 
-  afterEach(function () {
+  afterEach(() => {
     if (ctrl) {
       ctrl.element.remove();
       ctrl = null;
@@ -38,25 +38,25 @@ describe('CharacterLimitController', function () {
     };
   }
 
-  it('adds the ready class', function () {
+  it('adds the ready class', () => {
     var counterEl = component().counterEl;
 
     assert.equal(counterEl.classList.contains('is-ready'), true);
   });
 
-  it('shows the counter initially even if textarea empty', function () {
+  it('shows the counter initially even if textarea empty', () => {
     var counterEl = component().counterEl;
 
     assert.equal(counterEl.innerHTML, '0/250');
   });
 
-  it('shows the counter if the element has pre-rendered text', function () {
+  it('shows the counter if the element has pre-rendered text', () => {
     var counterEl = component('pre-rendered').counterEl;
 
     assert.equal(counterEl.innerHTML, '12/250');
   });
 
-  it('continues to show the container after text deleted', function() {
+  it('continues to show the container after text deleted', () => {
     var parts = component();
     var counterEl = parts.counterEl;
     var textarea = parts.textarea;
@@ -72,13 +72,13 @@ describe('CharacterLimitController', function () {
     assert.equal(counterEl.innerHTML, '0/250');
   });
 
-  it('reads the max length from the data-maxlength attribute', function () {
+  it('reads the max length from the data-maxlength attribute', () => {
     var counterEl = component('foo', 500).counterEl;
 
     assert.equal(counterEl.innerHTML, '3/500');
   });
 
-  it('updates the counter when text is added on "input" events', function () {
+  it('updates the counter when text is added on "input" events', () => {
     var parts = component();
     var textarea = parts.textarea;
     var counterEl = parts.counterEl;
@@ -89,7 +89,7 @@ describe('CharacterLimitController', function () {
     assert.equal(counterEl.innerHTML, '7/250');
   });
 
-  it('updates the counter when text is removed on "input" events', function () {
+  it('updates the counter when text is removed on "input" events', () => {
     var parts = component('Testing testing');
     var textarea = parts.textarea;
     var counterEl = parts.counterEl;
@@ -101,28 +101,28 @@ describe('CharacterLimitController', function () {
     assert.equal(counterEl.innerHTML, '7/250');
   });
 
-  it('does not add error class when no pre-rendered text', function() {
+  it('does not add error class when no pre-rendered text', () => {
     var counterEl = component(null, 5).counterEl;
 
     assert.equal(counterEl.classList.contains('is-too-long'),
                  false);
   });
 
-  it('does not add error class when pre-rendered text short enough', function() {
+  it('does not add error class when pre-rendered text short enough', () => {
     var counterEl = component('foo', 5).counterEl;
 
     assert.equal(counterEl.classList.contains('is-too-long'),
                  false);
   });
 
-  it('adds an error class to the counter when pre-rendered value too long', function() {
+  it('adds an error class to the counter when pre-rendered value too long', () => {
     var counterEl = component('Too long', 5).counterEl;
 
     assert.equal(counterEl.classList.contains('is-too-long'),
                  true);
   });
 
-  it('adds an error class to the counter when too much text entered', function() {
+  it('adds an error class to the counter when too much text entered', () => {
     var parts = component(null, 5);
     var counterEl = parts.counterEl;
     var textarea = parts.textarea;
@@ -134,7 +134,7 @@ describe('CharacterLimitController', function () {
                  true);
   });
 
-  it('removes error class from counter when text reduced', function() {
+  it('removes error class from counter when text reduced', () => {
     var parts = component('too long', 6);
     var counterEl = parts.counterEl;
     var textarea = parts.textarea;

--- a/h/static/scripts/tests/controllers/character-limit-controller-test.js
+++ b/h/static/scripts/tests/controllers/character-limit-controller-test.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var CharacterLimitController = require('../../controllers/character-limit-controller');
-var util = require('./util');
+const CharacterLimitController = require('../../controllers/character-limit-controller');
+const util = require('./util');
 
 describe('CharacterLimitController', () => {
 
-  var ctrl;
+  let ctrl;
 
   afterEach(() => {
     if (ctrl) {
@@ -21,7 +21,7 @@ describe('CharacterLimitController', () => {
   function component(value, maxlength) {
     maxlength = maxlength || 250;
 
-    var template = '<div class="js-character-limit">';
+    let template = '<div class="js-character-limit">';
     template += '<textarea data-ref="characterLimitInput" data-maxlength="' + maxlength + '">';
     if (value) {
       template += value;
@@ -39,27 +39,27 @@ describe('CharacterLimitController', () => {
   }
 
   it('adds the ready class', () => {
-    var counterEl = component().counterEl;
+    const counterEl = component().counterEl;
 
     assert.equal(counterEl.classList.contains('is-ready'), true);
   });
 
   it('shows the counter initially even if textarea empty', () => {
-    var counterEl = component().counterEl;
+    const counterEl = component().counterEl;
 
     assert.equal(counterEl.innerHTML, '0/250');
   });
 
   it('shows the counter if the element has pre-rendered text', () => {
-    var counterEl = component('pre-rendered').counterEl;
+    const counterEl = component('pre-rendered').counterEl;
 
     assert.equal(counterEl.innerHTML, '12/250');
   });
 
   it('continues to show the container after text deleted', () => {
-    var parts = component();
-    var counterEl = parts.counterEl;
-    var textarea = parts.textarea;
+    const parts = component();
+    const counterEl = parts.counterEl;
+    const textarea = parts.textarea;
 
     // Trigger the counter to be shown.
     textarea.value = 'Some text';
@@ -73,15 +73,15 @@ describe('CharacterLimitController', () => {
   });
 
   it('reads the max length from the data-maxlength attribute', () => {
-    var counterEl = component('foo', 500).counterEl;
+    const counterEl = component('foo', 500).counterEl;
 
     assert.equal(counterEl.innerHTML, '3/500');
   });
 
   it('updates the counter when text is added on "input" events', () => {
-    var parts = component();
-    var textarea = parts.textarea;
-    var counterEl = parts.counterEl;
+    const parts = component();
+    const textarea = parts.textarea;
+    const counterEl = parts.counterEl;
 
     textarea.value = 'testing';
     textarea.dispatchEvent(new Event('input'));
@@ -90,9 +90,9 @@ describe('CharacterLimitController', () => {
   });
 
   it('updates the counter when text is removed on "input" events', () => {
-    var parts = component('Testing testing');
-    var textarea = parts.textarea;
-    var counterEl = parts.counterEl;
+    const parts = component('Testing testing');
+    const textarea = parts.textarea;
+    const counterEl = parts.counterEl;
 
     // Make the text shorter.
     textarea.value = 'Testing';
@@ -102,30 +102,30 @@ describe('CharacterLimitController', () => {
   });
 
   it('does not add error class when no pre-rendered text', () => {
-    var counterEl = component(null, 5).counterEl;
+    const counterEl = component(null, 5).counterEl;
 
     assert.equal(counterEl.classList.contains('is-too-long'),
                  false);
   });
 
   it('does not add error class when pre-rendered text short enough', () => {
-    var counterEl = component('foo', 5).counterEl;
+    const counterEl = component('foo', 5).counterEl;
 
     assert.equal(counterEl.classList.contains('is-too-long'),
                  false);
   });
 
   it('adds an error class to the counter when pre-rendered value too long', () => {
-    var counterEl = component('Too long', 5).counterEl;
+    const counterEl = component('Too long', 5).counterEl;
 
     assert.equal(counterEl.classList.contains('is-too-long'),
                  true);
   });
 
   it('adds an error class to the counter when too much text entered', () => {
-    var parts = component(null, 5);
-    var counterEl = parts.counterEl;
-    var textarea = parts.textarea;
+    const parts = component(null, 5);
+    const counterEl = parts.counterEl;
+    const textarea = parts.textarea;
 
     textarea.value = 'too long';
     textarea.dispatchEvent(new Event('input'));
@@ -135,9 +135,9 @@ describe('CharacterLimitController', () => {
   });
 
   it('removes error class from counter when text reduced', () => {
-    var parts = component('too long', 6);
-    var counterEl = parts.counterEl;
-    var textarea = parts.textarea;
+    const parts = component('too long', 6);
+    const counterEl = parts.counterEl;
+    const textarea = parts.textarea;
 
     textarea.value = 'short';
     textarea.dispatchEvent(new Event('input'));

--- a/h/static/scripts/tests/controllers/confirm-submit-controller-test.js
+++ b/h/static/scripts/tests/controllers/confirm-submit-controller-test.js
@@ -3,11 +3,11 @@
 var ConfirmSubmitController = require('../../controllers/confirm-submit-controller');
 var util = require('./util');
 
-describe('ConfirmSubmitController', function () {
+describe('ConfirmSubmitController', () => {
 
   var ctrl;
 
-  afterEach(function () {
+  afterEach(() => {
     if (ctrl) {
       ctrl.element.remove();
       ctrl = null;
@@ -50,7 +50,7 @@ describe('ConfirmSubmitController', function () {
     return event;
   }
 
-  it('shows a confirm dialog using the text from the data-confirm-message attribute', function () {
+  it('shows a confirm dialog using the text from the data-confirm-message attribute', () => {
     var {ctrl, fakeWindow, confirmMessage} = component(true);
 
     ctrl.element.dispatchEvent(new Event('click'));
@@ -59,7 +59,7 @@ describe('ConfirmSubmitController', function () {
     assert.calledWithExactly(fakeWindow.confirm, confirmMessage);
   });
 
-  it('prevents form submission if the user refuses the confirm dialog', function () {
+  it('prevents form submission if the user refuses the confirm dialog', () => {
     var ctrl = component(false).ctrl;
     var event = fakeEvent();
 
@@ -70,7 +70,7 @@ describe('ConfirmSubmitController', function () {
     assert.called(event.stopImmediatePropagation);
   });
 
-  it('allows form submission if the user confirms the confirm dialog', function () {
+  it('allows form submission if the user confirms the confirm dialog', () => {
     var ctrl = component(true).ctrl;
     var event = fakeEvent();
 

--- a/h/static/scripts/tests/controllers/confirm-submit-controller-test.js
+++ b/h/static/scripts/tests/controllers/confirm-submit-controller-test.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var ConfirmSubmitController = require('../../controllers/confirm-submit-controller');
-var util = require('./util');
+const ConfirmSubmitController = require('../../controllers/confirm-submit-controller');
+const util = require('./util');
 
 describe('ConfirmSubmitController', () => {
 
-  var ctrl;
+  let ctrl;
 
   afterEach(() => {
     if (ctrl) {
@@ -20,13 +20,13 @@ describe('ConfirmSubmitController', () => {
    *
    */
   function component(windowConfirmReturnValue) {
-    var confirmMessage = "Are you sure you want to leave the group 'Test Group'?";
-    var template = `<button type="submit"
+    const confirmMessage = "Are you sure you want to leave the group 'Test Group'?";
+    const template = `<button type="submit"
       class="js-confirm-submit"
       data-confirm-message="${confirmMessage}">
     `;
 
-    var fakeWindow = {
+    const fakeWindow = {
       confirm: sinon.stub().returns(windowConfirmReturnValue),
     };
 
@@ -43,7 +43,7 @@ describe('ConfirmSubmitController', () => {
   }
 
   function fakeEvent() {
-    var event = new Event('click');
+    const event = new Event('click');
     event.preventDefault = sinon.stub();
     event.stopPropagation = sinon.stub();
     event.stopImmediatePropagation = sinon.stub();
@@ -51,7 +51,7 @@ describe('ConfirmSubmitController', () => {
   }
 
   it('shows a confirm dialog using the text from the data-confirm-message attribute', () => {
-    var {ctrl, fakeWindow, confirmMessage} = component(true);
+    const {ctrl, fakeWindow, confirmMessage} = component(true);
 
     ctrl.element.dispatchEvent(new Event('click'));
 
@@ -60,8 +60,8 @@ describe('ConfirmSubmitController', () => {
   });
 
   it('prevents form submission if the user refuses the confirm dialog', () => {
-    var ctrl = component(false).ctrl;
-    var event = fakeEvent();
+    const ctrl = component(false).ctrl;
+    const event = fakeEvent();
 
     ctrl.element.dispatchEvent(event);
 
@@ -71,8 +71,8 @@ describe('ConfirmSubmitController', () => {
   });
 
   it('allows form submission if the user confirms the confirm dialog', () => {
-    var ctrl = component(true).ctrl;
-    var event = fakeEvent();
+    const ctrl = component(true).ctrl;
+    const event = fakeEvent();
 
     ctrl.element.dispatchEvent(event);
 

--- a/h/static/scripts/tests/controllers/create-group-form-controller-test.js
+++ b/h/static/scripts/tests/controllers/create-group-form-controller-test.js
@@ -15,23 +15,23 @@ function sendEvent(element, eventType) {
   element.dispatchEvent(event);
 }
 
-describe('CreateGroupFormController', function () {
+describe('CreateGroupFormController', () => {
   var element;
   var template;
 
-  before(function () {
+  before(() => {
     template = '<input type="text" class="js-group-name-input">' +
                '<input type="submit" class="js-create-group-create-btn">' +
                '<a href="" class="js-group-info-link">Tell me more!</a>' +
                '<div class="js-group-info-text is-hidden">More!</div>';
   });
 
-  beforeEach(function () {
+  beforeEach(() => {
     element = document.createElement('div');
     element.innerHTML = template;
   });
 
-  it('should enable submission if form is valid', function () {
+  it('should enable submission if form is valid', () => {
     var controller = new CreateGroupFormController(element);
     controller._groupNameInput.value = '';
     sendEvent(controller._groupNameInput, 'input');
@@ -41,7 +41,7 @@ describe('CreateGroupFormController', function () {
     assert.equal(controller._submitBtn.disabled, false);
   });
 
-  it('should toggle info text when explain link is clicked', function () {
+  it('should toggle info text when explain link is clicked', () => {
     var controller = new CreateGroupFormController(element);
     assert.equal(isHidden(controller._infoText), true);
     sendEvent(controller._infoLink, 'click');

--- a/h/static/scripts/tests/controllers/create-group-form-controller-test.js
+++ b/h/static/scripts/tests/controllers/create-group-form-controller-test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var CreateGroupFormController = require('../../controllers/create-group-form-controller');
+const CreateGroupFormController = require('../../controllers/create-group-form-controller');
 
 function isHidden(elt) {
   return elt.classList.contains('is-hidden');
@@ -10,14 +10,14 @@ function isHidden(elt) {
 function sendEvent(element, eventType) {
   // createEvent() used instead of Event constructor
   // for PhantomJS compatibility
-  var event = document.createEvent('Event');
+  const event = document.createEvent('Event');
   event.initEvent(eventType, true /* bubbles */, true /* cancelable */);
   element.dispatchEvent(event);
 }
 
 describe('CreateGroupFormController', () => {
-  var element;
-  var template;
+  let element;
+  let template;
 
   before(() => {
     template = '<input type="text" class="js-group-name-input">' +
@@ -32,7 +32,7 @@ describe('CreateGroupFormController', () => {
   });
 
   it('should enable submission if form is valid', () => {
-    var controller = new CreateGroupFormController(element);
+    const controller = new CreateGroupFormController(element);
     controller._groupNameInput.value = '';
     sendEvent(controller._groupNameInput, 'input');
     assert.equal(controller._submitBtn.disabled, true);
@@ -42,7 +42,7 @@ describe('CreateGroupFormController', () => {
   });
 
   it('should toggle info text when explain link is clicked', () => {
-    var controller = new CreateGroupFormController(element);
+    const controller = new CreateGroupFormController(element);
     assert.equal(isHidden(controller._infoText), true);
     sendEvent(controller._infoLink, 'click');
     assert.equal(isHidden(controller._infoText), false);

--- a/h/static/scripts/tests/controllers/dropdown-menu-controller-test.js
+++ b/h/static/scripts/tests/controllers/dropdown-menu-controller-test.js
@@ -10,18 +10,18 @@ var TEMPLATE = [
   '</div>',
 ].join('\n');
 
-describe('DropdownMenuController', function () {
+describe('DropdownMenuController', () => {
   var ctrl;
   var toggleEl;
   var menuEl;
 
-  beforeEach(function () {
+  beforeEach(() => {
     ctrl = util.setupComponent(document, TEMPLATE, DropdownMenuController);
     toggleEl = ctrl.refs.dropdownMenuToggle;
     menuEl = ctrl.refs.dropdownMenuContent;
   });
 
-  afterEach(function () {
+  afterEach(() => {
     ctrl.element.remove();
   });
 
@@ -29,20 +29,20 @@ describe('DropdownMenuController', function () {
     return menuEl.classList.contains('is-open');
   }
 
-  it('should toggle menu on click', function () {
+  it('should toggle menu on click', () => {
     toggleEl.dispatchEvent(new Event('click'));
     assert.isTrue(isOpen());
     toggleEl.dispatchEvent(new Event('click'));
     assert.isFalse(isOpen());
   });
 
-  it('should close menu on click outside', function () {
+  it('should close menu on click outside', () => {
     toggleEl.dispatchEvent(new Event('click'));
     document.body.dispatchEvent(new Event('click'));
     assert.isFalse(isOpen());
   });
 
-  it('should not close menu on click inside', function () {
+  it('should not close menu on click inside', () => {
     toggleEl.dispatchEvent(new Event('click'));
     menuEl.dispatchEvent(new Event('click'));
     assert.isTrue(isOpen());

--- a/h/static/scripts/tests/controllers/dropdown-menu-controller-test.js
+++ b/h/static/scripts/tests/controllers/dropdown-menu-controller-test.js
@@ -1,9 +1,9 @@
 'use strict';
 
-var DropdownMenuController = require('../../controllers/dropdown-menu-controller');
-var util = require('./util');
+const DropdownMenuController = require('../../controllers/dropdown-menu-controller');
+const util = require('./util');
 
-var TEMPLATE = [
+const TEMPLATE = [
   '<div class="js-dropdown-menu">',
   '<span data-ref="dropdownMenuToggle">Toggle</span>',
   '<span data-ref="dropdownMenuContent">Menu</span>',
@@ -11,9 +11,9 @@ var TEMPLATE = [
 ].join('\n');
 
 describe('DropdownMenuController', () => {
-  var ctrl;
-  var toggleEl;
-  var menuEl;
+  let ctrl;
+  let toggleEl;
+  let menuEl;
 
   beforeEach(() => {
     ctrl = util.setupComponent(document, TEMPLATE, DropdownMenuController);

--- a/h/static/scripts/tests/controllers/form-controller-test.js
+++ b/h/static/scripts/tests/controllers/form-controller-test.js
@@ -17,7 +17,7 @@ var upgradeElements = require('../../base/upgrade-elements');
  */
 function dataAttrs(data) {
   var dataAttrs = [];
-  Object.keys(data || {}).forEach(key => {
+  Object.keys(data || {}).forEach((key) => {
     dataAttrs.push(`data-${hyphenate(key)}="${data[key]}"`);
   });
   return dataAttrs.join(' ');
@@ -88,7 +88,7 @@ describe('FormController', function () {
     // spy on calls to it and update `ctrl` to the new controller instance
     // when the form is reloaded
     var reloadFn = ctrl.options.reload;
-    reloadSpy = sinon.spy(html => {
+    reloadSpy = sinon.spy((html) => {
       var newElement = reloadFn(html);
       ctrl = newElement.controllers[0];
       return newElement;
@@ -377,7 +377,7 @@ describe('FormController', function () {
       var containers = [ctrl.refs.emailContainer, ctrl.refs.passwordContainer];
       var inputs = [ctrl.refs.emailInput, ctrl.refs.passwordInput];
 
-      inputs.forEach(input => {
+      inputs.forEach((input) => {
         input.focus();
 
         var editing = containers.filter(el => el.classList.contains('is-editing'));

--- a/h/static/scripts/tests/controllers/form-controller-test.js
+++ b/h/static/scripts/tests/controllers/form-controller-test.js
@@ -1,10 +1,10 @@
 'use strict';
 
-var proxyquire = require('proxyquire');
+const proxyquire = require('proxyquire');
 
-var { hyphenate } = require('../../util/string');
-var { noCallThru } = require('../util');
-var upgradeElements = require('../../base/upgrade-elements');
+const { hyphenate } = require('../../util/string');
+const { noCallThru } = require('../util');
+const upgradeElements = require('../../base/upgrade-elements');
 
 /**
  * Converts a map of data attribute names to string values into a string
@@ -16,7 +16,7 @@ var upgradeElements = require('../../base/upgrade-elements');
  * eg. dataAttrs({activeLabel: 'label'}) => 'data-active-label="label"'
  */
 function dataAttrs(data) {
-  var dataAttrs = [];
+  const dataAttrs = [];
   Object.keys(data || {}).forEach((key) => {
     dataAttrs.push(`data-${hyphenate(key)}="${data[key]}"`);
   });
@@ -26,8 +26,8 @@ function dataAttrs(data) {
 // Simplified version of form fields rendered by deform on the server in
 // mapping_item.jinja2
 function fieldTemplate(field) {
-  var dataAttr = dataAttrs(field.data);
-  var typeAttr = field.type ? `type="${field.type}"` : '';
+  const dataAttr = dataAttrs(field.data);
+  const typeAttr = field.type ? `type="${field.type}"` : '';
 
   return `<div class="js-form-input" data-ref="${field.fieldRef}" ${dataAttr}>
     <label data-ref="label ${field.labelRef}">Label</label>
@@ -52,7 +52,7 @@ function formTemplate(fields) {
 `;
 }
 
-var FORM_TEMPLATE = formTemplate([{
+const FORM_TEMPLATE = formTemplate([{
   ref: 'firstInput',
   value: 'original value',
 },{
@@ -63,20 +63,20 @@ var FORM_TEMPLATE = formTemplate([{
   type: 'checkbox',
 }]);
 
-var UPDATED_FORM = FORM_TEMPLATE.replace('js-form', 'js-form is-updated');
+const UPDATED_FORM = FORM_TEMPLATE.replace('js-form', 'js-form is-updated');
 
 describe('FormController', () => {
-  var ctrl;
-  var fakeSubmitForm;
-  var reloadSpy;
+  let ctrl;
+  let fakeSubmitForm;
+  let reloadSpy;
 
   function initForm(template) {
     fakeSubmitForm = sinon.stub();
-    var FormController = proxyquire('../../controllers/form-controller', {
+    const FormController = proxyquire('../../controllers/form-controller', {
       '../util/submit-form': noCallThru(fakeSubmitForm),
     });
 
-    var container = document.createElement('div');
+    const container = document.createElement('div');
     container.innerHTML = template;
     upgradeElements(container, {
       '.js-form': FormController,
@@ -87,9 +87,9 @@ describe('FormController', () => {
     // Wrap the original `reload` function passed to the controller so we can
     // spy on calls to it and update `ctrl` to the new controller instance
     // when the form is reloaded
-    var reloadFn = ctrl.options.reload;
+    const reloadFn = ctrl.options.reload;
     reloadSpy = sinon.spy((html) => {
-      var newElement = reloadFn(html);
+      const newElement = reloadFn(html);
       ctrl = newElement.controllers[0];
       return newElement;
     });
@@ -147,7 +147,7 @@ describe('FormController', () => {
 
   it('reverts the form when "Escape" key is pressed', () => {
     startEditing();
-    var event = new Event('keydown', {bubbles: true});
+    const event = new Event('keydown', {bubbles: true});
     event.key = 'Escape';
     ctrl.refs.firstInput.dispatchEvent(event);
     assert.equal(ctrl.refs.firstInput.value, 'original value');
@@ -221,7 +221,7 @@ describe('FormController', () => {
 
   it('enters the "saving" state while the form is being submitted', () => {
     fakeSubmitForm.returns(Promise.resolve({status: 200, form: UPDATED_FORM}));
-    var saved = submitForm();
+    const saved = submitForm();
     assert.isTrue(isSaving());
     return saved.then(() => {
       assert.isFalse(isSaving());
@@ -237,7 +237,7 @@ describe('FormController', () => {
 
   it('ignores clicks outside the field being edited', () => {
     startEditing();
-    var event = new Event('mousedown', {cancelable: true});
+    const event = new Event('mousedown', {cancelable: true});
     ctrl.refs.formBackdrop.dispatchEvent(event);
     assert.isTrue(event.defaultPrevented);
   });
@@ -253,7 +253,7 @@ describe('FormController', () => {
   context('when focus moves to another input while editing', () => {
     it('clears editing state of first input', () => {
       startEditing();
-      var inputs = ctrl.element.querySelectorAll('.js-form-input');
+      const inputs = ctrl.element.querySelectorAll('.js-form-input');
 
       // Focus second input. Although the user cannot focus the second input with
       // the mouse while the first is focused, they can navigate to it with the
@@ -276,7 +276,7 @@ describe('FormController', () => {
   });
 
   context('when focus moves outside of form', () => {
-    var outsideEl;
+    let outsideEl;
 
     beforeEach(() => {
       outsideEl = document.createElement('input');
@@ -363,7 +363,7 @@ describe('FormController', () => {
     });
 
     it('hides initially-hidden fields when no input is focused', () => {
-      var externalControl = document.createElement('input');
+      const externalControl = document.createElement('input');
       document.body.appendChild(externalControl);
 
       ctrl.refs.emailInput.focus();
@@ -374,13 +374,13 @@ describe('FormController', () => {
     });
 
     it('shows all fields in an editing state when any is focused', () => {
-      var containers = [ctrl.refs.emailContainer, ctrl.refs.passwordContainer];
-      var inputs = [ctrl.refs.emailInput, ctrl.refs.passwordInput];
+      const containers = [ctrl.refs.emailContainer, ctrl.refs.passwordContainer];
+      const inputs = [ctrl.refs.emailInput, ctrl.refs.passwordInput];
 
       inputs.forEach((input) => {
         input.focus();
 
-        var editing = containers.filter(el => el.classList.contains('is-editing'));
+        const editing = containers.filter(el => el.classList.contains('is-editing'));
         assert.equal(editing.length, 2);
       });
     });

--- a/h/static/scripts/tests/controllers/form-controller-test.js
+++ b/h/static/scripts/tests/controllers/form-controller-test.js
@@ -65,7 +65,7 @@ var FORM_TEMPLATE = formTemplate([{
 
 var UPDATED_FORM = FORM_TEMPLATE.replace('js-form', 'js-form is-updated');
 
-describe('FormController', function () {
+describe('FormController', () => {
   var ctrl;
   var fakeSubmitForm;
   var reloadSpy;
@@ -99,12 +99,12 @@ describe('FormController', function () {
     document.body.appendChild(ctrl.element);
   }
 
-  beforeEach(function () {
+  beforeEach(() => {
     // Setup a form with the default template
     initForm(FORM_TEMPLATE);
   });
 
-  afterEach(function () {
+  afterEach(() => {
     ctrl.beforeRemove();
     ctrl.element.remove();
   });
@@ -132,20 +132,20 @@ describe('FormController', function () {
     return ctrl.refs.formSubmitErrorMessage.textContent;
   }
 
-  it('begins editing when a field is focused', function () {
+  it('begins editing when a field is focused', () => {
     ctrl.refs.firstInput.focus();
     ctrl.refs.firstInput.dispatchEvent(new Event('focus'));
     assert.isTrue(isEditing());
   });
 
-  it('reverts the form when "Cancel" is clicked', function () {
+  it('reverts the form when "Cancel" is clicked', () => {
     startEditing();
     ctrl.refs.firstInput.value = 'new value';
     ctrl.refs.cancelBtn.click();
     assert.equal(ctrl.refs.firstInput.value, 'original value');
   });
 
-  it('reverts the form when "Escape" key is pressed', function () {
+  it('reverts the form when "Escape" key is pressed', () => {
     startEditing();
     var event = new Event('keydown', {bubbles: true});
     event.key = 'Escape';
@@ -153,7 +153,7 @@ describe('FormController', function () {
     assert.equal(ctrl.refs.firstInput.value, 'original value');
   });
 
-  it('submits the form when "Save" is clicked', function () {
+  it('submits the form when "Save" is clicked', () => {
     fakeSubmitForm.returns(Promise.resolve({status: 200, form: UPDATED_FORM}));
     ctrl.refs.testSaveBtn.click();
     assert.calledWith(fakeSubmitForm, ctrl.element);
@@ -163,48 +163,48 @@ describe('FormController', function () {
     return Promise.resolve();
   });
 
-  context('when form is successfully submitted', function () {
-    it('updates form with new rendered version from server', function () {
+  context('when form is successfully submitted', () => {
+    it('updates form with new rendered version from server', () => {
       fakeSubmitForm.returns(Promise.resolve({status: 200, form: UPDATED_FORM}));
-      return submitForm().then(function () {
+      return submitForm().then(() => {
         assert.isTrue(ctrl.element.classList.contains('is-updated'));
       });
     });
 
-    it('stops editing the form', function () {
+    it('stops editing the form', () => {
       fakeSubmitForm.returns(Promise.resolve({status: 200, form: UPDATED_FORM}));
-      return submitForm().then(function () {
+      return submitForm().then(() => {
         assert.isFalse(isEditing());
       });
     });
   });
 
-  context('when validation fails', function () {
-    it('updates form with rendered version from server', function () {
+  context('when validation fails', () => {
+    it('updates form with rendered version from server', () => {
       startEditing();
       fakeSubmitForm.returns(Promise.reject({status: 400, form: UPDATED_FORM}));
-      return submitForm().then(function () {
+      return submitForm().then(() => {
         assert.isTrue(ctrl.element.classList.contains('is-updated'));
       });
     });
 
-    it('marks updated form as dirty', function () {
+    it('marks updated form as dirty', () => {
       startEditing();
       fakeSubmitForm.returns(Promise.reject({status: 400, form: UPDATED_FORM}));
-      return submitForm().then(function () {
+      return submitForm().then(() => {
         assert.isTrue(ctrl.state.dirty);
       });
     });
 
-    it('continues editing current field', function () {
+    it('continues editing current field', () => {
       startEditing();
       fakeSubmitForm.returns(Promise.reject({status: 400, form: UPDATED_FORM}));
-      return submitForm().then(function () {
+      return submitForm().then(() => {
         assert.isTrue(isEditing());
       });
     });
 
-    it('focuses the matching input field in the re-rendered form', function () {
+    it('focuses the matching input field in the re-rendered form', () => {
       startEditing();
       fakeSubmitForm.returns(Promise.reject({status: 400, form: UPDATED_FORM}));
 
@@ -212,37 +212,37 @@ describe('FormController', function () {
       // changes the focus from the input field to the button
       ctrl.refs.testSaveBtn.focus();
 
-      return submitForm().then(function () {
+      return submitForm().then(() => {
         // In the re-rendered form, the input field should be focused
         assert.equal(document.activeElement.id, 'deformField');
       });
     });
   });
 
-  it('enters the "saving" state while the form is being submitted', function () {
+  it('enters the "saving" state while the form is being submitted', () => {
     fakeSubmitForm.returns(Promise.resolve({status: 200, form: UPDATED_FORM}));
     var saved = submitForm();
     assert.isTrue(isSaving());
-    return saved.then(function () {
+    return saved.then(() => {
       assert.isFalse(isSaving());
     });
   });
 
-  it('displays an error if form submission fails without returning a new form', function () {
+  it('displays an error if form submission fails without returning a new form', () => {
     fakeSubmitForm.returns(Promise.reject({status: 500, reason: 'Internal Server Error'}));
-    return submitForm().then(function () {
+    return submitForm().then(() => {
       assert.equal(submitError(), 'Internal Server Error');
     });
   });
 
-  it('ignores clicks outside the field being edited', function () {
+  it('ignores clicks outside the field being edited', () => {
     startEditing();
     var event = new Event('mousedown', {cancelable: true});
     ctrl.refs.formBackdrop.dispatchEvent(event);
     assert.isTrue(event.defaultPrevented);
   });
 
-  it('sets form state to dirty if user modifies active field', function () {
+  it('sets form state to dirty if user modifies active field', () => {
     startEditing();
 
     ctrl.refs.firstInput.dispatchEvent(new Event('input', {bubbles: true}));
@@ -250,8 +250,8 @@ describe('FormController', function () {
     assert.isTrue(ctrl.state.dirty);
   });
 
-  context('when focus moves to another input while editing', function () {
-    it('clears editing state of first input', function () {
+  context('when focus moves to another input while editing', () => {
+    it('clears editing state of first input', () => {
       startEditing();
       var inputs = ctrl.element.querySelectorAll('.js-form-input');
 
@@ -264,7 +264,7 @@ describe('FormController', function () {
       assert.isTrue(inputs[1].classList.contains('is-editing'));
     });
 
-    it('keeps focus in previous input if it has unsaved changes', function () {
+    it('keeps focus in previous input if it has unsaved changes', () => {
       startEditing();
       ctrl.setState({dirty: true});
 
@@ -275,19 +275,19 @@ describe('FormController', function () {
     });
   });
 
-  context('when focus moves outside of form', function () {
+  context('when focus moves outside of form', () => {
     var outsideEl;
 
-    beforeEach(function () {
+    beforeEach(() => {
       outsideEl = document.createElement('input');
       document.body.appendChild(outsideEl);
     });
 
-    afterEach(function () {
+    afterEach(() => {
       outsideEl.remove();
     });
 
-    it('clears editing state if field does not have unsaved changes', function () {
+    it('clears editing state if field does not have unsaved changes', () => {
       startEditing();
 
       // Simulate user moving focus outside of form (eg. via tab key).
@@ -296,7 +296,7 @@ describe('FormController', function () {
       assert.isFalse(isEditing());
     });
 
-    it('keeps current field focused if it has unsaved changes', function () {
+    it('keeps current field focused if it has unsaved changes', () => {
       startEditing();
       ctrl.setState({dirty: true});
 
@@ -308,29 +308,29 @@ describe('FormController', function () {
     });
   });
 
-  context('when a checkbox is toggled', function () {
-    beforeEach(function () {
+  context('when a checkbox is toggled', () => {
+    beforeEach(() => {
       fakeSubmitForm.returns(Promise.resolve({status: 200, form: UPDATED_FORM}));
       ctrl.refs.checkboxInput.focus();
       ctrl.refs.checkboxInput.dispatchEvent(new Event('change', {bubbles: true}));
     });
 
-    afterEach(function () {
+    afterEach(() => {
       // Wait for form submission to complete
       return Promise.resolve();
     });
 
-    it('does not show form save buttons', function () {
+    it('does not show form save buttons', () => {
       assert.isTrue(ctrl.refs.formActions.classList.contains('is-hidden'));
     });
 
-    it('automatically submits the form', function () {
+    it('automatically submits the form', () => {
       assert.calledWith(fakeSubmitForm, ctrl.element);
     });
   });
 
-  describe('forms with hidden fields', function () {
-    beforeEach(function () {
+  describe('forms with hidden fields', () => {
+    beforeEach(() => {
       // Setup a form like the 'Change Email' which has a field that is initially
       // visible plus additional fields that are shown once the form is being
       // edited
@@ -353,16 +353,16 @@ describe('FormController', function () {
       return ctrl.refs.passwordContainer.classList.contains('is-hidden');
     }
 
-    it('hides initially-hidden fields', function () {
+    it('hides initially-hidden fields', () => {
       assert.isTrue(isConfirmFieldHidden());
     });
 
-    it('shows initially-hidden fields when the email input is focused', function () {
+    it('shows initially-hidden fields when the email input is focused', () => {
       ctrl.refs.emailInput.focus();
       assert.isFalse(isConfirmFieldHidden());
     });
 
-    it('hides initially-hidden fields when no input is focused', function () {
+    it('hides initially-hidden fields when no input is focused', () => {
       var externalControl = document.createElement('input');
       document.body.appendChild(externalControl);
 
@@ -373,7 +373,7 @@ describe('FormController', function () {
       externalControl.remove();
     });
 
-    it('shows all fields in an editing state when any is focused', function () {
+    it('shows all fields in an editing state when any is focused', () => {
       var containers = [ctrl.refs.emailContainer, ctrl.refs.passwordContainer];
       var inputs = [ctrl.refs.emailInput, ctrl.refs.passwordInput];
 
@@ -386,8 +386,8 @@ describe('FormController', function () {
     });
   });
 
-  describe('fields with inactive and active labels', function () {
-    beforeEach(function () {
+  describe('fields with inactive and active labels', () => {
+    beforeEach(() => {
       initForm(formTemplate([{
         labelRef: 'passwordLabel',
         ref: 'passwordInput',
@@ -399,30 +399,30 @@ describe('FormController', function () {
       }]));
     });
 
-    it('uses the inactive label for fields when the form is inactive', function () {
+    it('uses the inactive label for fields when the form is inactive', () => {
       assert.equal(ctrl.refs.passwordLabel.textContent, 'Password');
     });
 
-    it('uses the active label for fields when the form is active', function () {
+    it('uses the active label for fields when the form is active', () => {
       ctrl.refs.passwordInput.focus();
       assert.equal(ctrl.refs.passwordLabel.textContent, 'Current password');
     });
   });
 
-  describe('password fields', function () {
-    beforeEach(function () {
+  describe('password fields', () => {
+    beforeEach(() => {
       initForm(formTemplate([{
         ref: 'password',
         type: 'password',
       }]));
     });
 
-    it('adds a placeholder to inactive password fields', function () {
+    it('adds a placeholder to inactive password fields', () => {
       assert.equal(ctrl.refs.password.getAttribute('placeholder'),
         '••••••••');
     });
 
-    it('clears the placeholder when the password field is focused', function () {
+    it('clears the placeholder when the password field is focused', () => {
       ctrl.refs.password.focus();
       assert.equal(ctrl.refs.password.getAttribute('placeholder'), '');
     });

--- a/h/static/scripts/tests/controllers/form-select-onfocus-controller-test.js
+++ b/h/static/scripts/tests/controllers/form-select-onfocus-controller-test.js
@@ -11,21 +11,21 @@ function sendEvent(element, eventType) {
   element.dispatchEvent(event);
 }
 
-describe('FormSelectOnFocusController', function() {
+describe('FormSelectOnFocusController', () => {
   var root;
 
-  beforeEach(function() {
+  beforeEach(() => {
     root = document.createElement('div');
     root.innerHTML = '<form id="js-users-delete-form">' +
                      '<input type="text" class="js-select-onfocus" value="some-test-value">';
     document.body.appendChild(root);
   });
 
-  afterEach(function() {
+  afterEach(() => {
     root.parentNode.removeChild(root);
   });
 
-  it('it selects the element on focus event', function() {
+  it('it selects the element on focus event', () => {
     new FormSelectOnFocusController(root);
     var input = root.querySelector('input');
     sendEvent(input, 'focus');
@@ -33,7 +33,7 @@ describe('FormSelectOnFocusController', function() {
     assert.strictEqual(input.selectionEnd, input.value.length);
   });
 
-  it('it selects the element without focus event when it is the active element', function() {
+  it('it selects the element without focus event when it is the active element', () => {
     // Focus element before instantiating the controller
     var input = root.querySelector('input');
     input.focus();

--- a/h/static/scripts/tests/controllers/form-select-onfocus-controller-test.js
+++ b/h/static/scripts/tests/controllers/form-select-onfocus-controller-test.js
@@ -1,18 +1,18 @@
 'use strict';
 
-var FormSelectOnFocusController = require('../../controllers/form-select-onfocus-controller');
+const FormSelectOnFocusController = require('../../controllers/form-select-onfocus-controller');
 
 // helper to dispatch a native event to an element
 function sendEvent(element, eventType) {
   // createEvent() used instead of Event constructor
   // for PhantomJS compatibility
-  var event = document.createEvent('Event');
+  const event = document.createEvent('Event');
   event.initEvent(eventType, true /* bubbles */, true /* cancelable */);
   element.dispatchEvent(event);
 }
 
 describe('FormSelectOnFocusController', () => {
-  var root;
+  let root;
 
   beforeEach(() => {
     root = document.createElement('div');
@@ -27,7 +27,7 @@ describe('FormSelectOnFocusController', () => {
 
   it('it selects the element on focus event', () => {
     new FormSelectOnFocusController(root);
-    var input = root.querySelector('input');
+    const input = root.querySelector('input');
     sendEvent(input, 'focus');
     assert.strictEqual(input.selectionStart, 0);
     assert.strictEqual(input.selectionEnd, input.value.length);
@@ -35,7 +35,7 @@ describe('FormSelectOnFocusController', () => {
 
   it('it selects the element without focus event when it is the active element', () => {
     // Focus element before instantiating the controller
-    var input = root.querySelector('input');
+    const input = root.querySelector('input');
     input.focus();
 
     new FormSelectOnFocusController(document.body);

--- a/h/static/scripts/tests/controllers/lozenge-controller-test.js
+++ b/h/static/scripts/tests/controllers/lozenge-controller-test.js
@@ -1,13 +1,13 @@
 'use strict';
 
-var LozengeController = require('../../controllers/lozenge-controller');
+const LozengeController = require('../../controllers/lozenge-controller');
 
 describe('LozengeController', () => {
-  var el;
-  var opts;
-  var lozengeEl;
-  var lozengeContentEl;
-  var lozengeDeleteEl;
+  let el;
+  let opts;
+  let lozengeEl;
+  let lozengeContentEl;
+  let lozengeDeleteEl;
 
   beforeEach(() => {
     el = document.createElement('div');
@@ -27,9 +27,6 @@ describe('LozengeController', () => {
   });
 
   it('creates a new lozenge for a known named query term inside the container provided', () => {
-    var facetNameEl;
-    var facetValueEl;
-
     el = document.createElement('div');
     opts = {
       content: 'user:foo',
@@ -38,8 +35,8 @@ describe('LozengeController', () => {
     new LozengeController(el, opts);
     lozengeEl = el.querySelector('.js-lozenge');
     lozengeContentEl = lozengeEl.querySelector('.js-lozenge__content');
-    facetNameEl = lozengeContentEl.querySelector('.lozenge__facet-name');
-    facetValueEl = lozengeContentEl.querySelector('.lozenge__facet-value');
+    const facetNameEl = lozengeContentEl.querySelector('.lozenge__facet-name');
+    const facetValueEl = lozengeContentEl.querySelector('.lozenge__facet-value');
 
     assert.equal(facetNameEl.textContent, 'user');
     assert.equal(facetValueEl.textContent, 'foo');

--- a/h/static/scripts/tests/controllers/lozenge-controller-test.js
+++ b/h/static/scripts/tests/controllers/lozenge-controller-test.js
@@ -2,14 +2,14 @@
 
 var LozengeController = require('../../controllers/lozenge-controller');
 
-describe('LozengeController', function () {
+describe('LozengeController', () => {
   var el;
   var opts;
   var lozengeEl;
   var lozengeContentEl;
   var lozengeDeleteEl;
 
-  beforeEach(function () {
+  beforeEach(() => {
     el = document.createElement('div');
     opts = {
       content: 'foo',
@@ -22,11 +22,11 @@ describe('LozengeController', function () {
     lozengeDeleteEl = lozengeEl.querySelector('.js-lozenge__close');
   });
 
-  it('creates a new lozenge inside the container provided', function () {
+  it('creates a new lozenge inside the container provided', () => {
     assert.equal(lozengeContentEl.textContent, opts.content);
   });
 
-  it('creates a new lozenge for a known named query term inside the container provided', function () {
+  it('creates a new lozenge for a known named query term inside the container provided', () => {
     var facetNameEl;
     var facetValueEl;
 
@@ -45,7 +45,7 @@ describe('LozengeController', function () {
     assert.equal(facetValueEl.textContent, 'foo');
   });
 
-  it('does not create a new lozenge for named query term which is not known', function () {
+  it('does not create a new lozenge for named query term which is not known', () => {
     el = document.createElement('div');
     opts = {
       content: 'foo:bar',
@@ -60,7 +60,7 @@ describe('LozengeController', function () {
     assert.equal(lozengeContentEl.textContent, opts.content);
   });
 
-  it('removes the lozenge and executes the delete callback provided', function () {
+  it('removes the lozenge and executes the delete callback provided', () => {
     lozengeDeleteEl.dispatchEvent(new Event('mousedown'));
     assert(opts.deleteCallback.calledOnce);
     assert.isNull(el.querySelector('.js-lozenge'));

--- a/h/static/scripts/tests/controllers/search-bar-controller-test.js
+++ b/h/static/scripts/tests/controllers/search-bar-controller-test.js
@@ -23,7 +23,7 @@ describe('SearchBarController', function () {
     `;
 
     var getItemTitles = function() {
-      return Array.from(dropdown.querySelectorAll('.search-bar__dropdown-menu-title')).map((node)=>{
+      return Array.from(dropdown.querySelectorAll('.search-bar__dropdown-menu-title')).map((node) => {
         return node.textContent.trim();
       });
     };
@@ -167,10 +167,10 @@ describe('SearchBarController', function () {
 
     it('it filters and updates input with autosuggested facet selection', function (done) {
       syn
-        .click(input, ()=>{
+        .click(input, () => {
           assert.notOk(input.value, 'baseline no value in input');
         })
-        .type('r[down][enter]', ()=>{
+        .type('r[down][enter]', () => {
           assert.equal(input.value, 'url:');
           done();
         });
@@ -196,7 +196,7 @@ describe('SearchBarController', function () {
     describe('it allows group value suggestions', function () {
 
       const getLozengeValues = function () {
-        return Array.from(testEl.querySelectorAll('.lozenge')).map((el)=>{
+        return Array.from(testEl.querySelectorAll('.lozenge')).map((el) => {
           return el.querySelector('.lozenge__content').textContent;
         });
       };
@@ -332,7 +332,7 @@ describe('SearchBarController', function () {
           .type('[backspace][backspace][backspace][backspace]\'mul', () => {
             assert.deepEqual(getItemTitles(), [ 'multi word' ], 'supports matching on a single quote initial input');
           })
-          .type('[down][enter][enter]', ()=>{
+          .type('[down][enter][enter]', () => {
             assert.equal(testEl.querySelector('input[type=hidden]').value.trim(), 'tag:"multi word"', 'selecting a multi word tag should wrap with quotes');
             done();
           });
@@ -401,7 +401,7 @@ describe('SearchBarController', function () {
      * return the array of all of lozenges values
      */
     const getLozengeValues = function () {
-      return Array.from(ctrl.refs.searchBarLozenges.querySelectorAll('.lozenge')).map((el)=>{
+      return Array.from(ctrl.refs.searchBarLozenges.querySelectorAll('.lozenge')).map((el) => {
         return el.querySelector('.lozenge__content').innerText;
       });
     };
@@ -535,7 +535,7 @@ describe('SearchBarController', function () {
 
       let groupsScript;
 
-      beforeEach(()=>{
+      beforeEach(() => {
         let suggestions = [{
           name: 'abc 123',
           pubid: 'pid124',
@@ -547,7 +547,7 @@ describe('SearchBarController', function () {
         document.body.appendChild(groupsScript);
       });
 
-      afterEach(()=>{
+      afterEach(() => {
         groupsScript.remove();
       });
 

--- a/h/static/scripts/tests/controllers/search-bar-controller-test.js
+++ b/h/static/scripts/tests/controllers/search-bar-controller-test.js
@@ -22,13 +22,13 @@ describe('SearchBarController', function () {
       </div>
     `;
 
-    var getItemTitles = function(){
+    var getItemTitles = function() {
       return Array.from(dropdown.querySelectorAll('.search-bar__dropdown-menu-title')).map((node)=>{
         return node.textContent.trim();
       });
     };
 
-    var setup = function(){
+    var setup = function() {
       testEl = document.createElement('div');
       testEl.innerHTML = TEMPLATE;
       document.body.appendChild(testEl);
@@ -39,20 +39,20 @@ describe('SearchBarController', function () {
       dropdown = input.nextSibling;
     };
 
-    var teardown = function(){
+    var teardown = function() {
       document.body.removeChild(testEl);
       let tagsJSON = document.querySelector('.js-tag-suggestions');
-      if(tagsJSON){
+      if(tagsJSON) {
         tagsJSON.remove();
       }
 
       let groupsJSON = document.querySelector('.js-group-suggestions');
-      if(groupsJSON){
+      if(groupsJSON) {
         groupsJSON.remove();
       }
     };
 
-    var addTagSuggestions = function(){
+    var addTagSuggestions = function() {
       let suggestions = [
         {
           tag: 'aaaa',
@@ -98,7 +98,7 @@ describe('SearchBarController', function () {
       document.body.appendChild(tagsScript);
     };
 
-    var addGroupSuggestions = function(){
+    var addGroupSuggestions = function() {
       let suggestions = [
         {
           name: 'aaac',
@@ -195,13 +195,13 @@ describe('SearchBarController', function () {
 
     describe('it allows group value suggestions', function () {
 
-      const getLozengeValues = function (){
+      const getLozengeValues = function () {
         return Array.from(testEl.querySelectorAll('.lozenge')).map((el)=>{
           return el.querySelector('.lozenge__content').textContent;
         });
       };
 
-      beforeEach(function(){
+      beforeEach(function() {
         // we need to setup the env vars before invoking controller
         teardown();
         addGroupSuggestions();
@@ -210,7 +210,7 @@ describe('SearchBarController', function () {
         sinon.stub(testEl.querySelector('form'), 'submit');
       });
 
-      it('shows group suggestions', function(done){
+      it('shows group suggestions', function(done) {
         syn
           .click(input)
           .type('group:', () => {
@@ -226,7 +226,7 @@ describe('SearchBarController', function () {
           });
       });
 
-      it('orders groups by earliest value match first', function(done){
+      it('orders groups by earliest value match first', function(done) {
         syn
           .click(input)
           .type('group:', () => {
@@ -238,7 +238,7 @@ describe('SearchBarController', function () {
           });
       });
 
-      it('supports multi word matching', function(done){
+      it('supports multi word matching', function(done) {
         syn
           .click(input)
           .type('group:"mul', () => {
@@ -250,7 +250,7 @@ describe('SearchBarController', function () {
           });
       });
 
-      it('handles filtering matches with unicode', function(done){
+      it('handles filtering matches with unicode', function(done) {
         syn
           .click(input)
           .type('group:éf', () => {
@@ -259,7 +259,7 @@ describe('SearchBarController', function () {
           });
       });
 
-      it('sets input and display friendly name value', function(done){
+      it('sets input and display friendly name value', function(done) {
         syn
           .click(input)
           .type('group:"mul[down][enter]', () => {
@@ -273,7 +273,7 @@ describe('SearchBarController', function () {
           });
       });
 
-      it('matches escaped values', function(done){
+      it('matches escaped values', function(done) {
         syn
           .click(input)
           .type('group:<[down][enter]', () => {
@@ -286,7 +286,7 @@ describe('SearchBarController', function () {
 
     describe('it allows tag value suggestions', function () {
 
-      beforeEach(function(){
+      beforeEach(function() {
         // we need to setup the env vars before invoking controller
         teardown();
         addTagSuggestions();
@@ -295,7 +295,7 @@ describe('SearchBarController', function () {
         sinon.stub(testEl.querySelector('form'), 'submit');
       });
 
-      it('shows tag suggestions', function(done){
+      it('shows tag suggestions', function(done) {
         syn
           .click(input)
           .type('tag:', () => {
@@ -311,7 +311,7 @@ describe('SearchBarController', function () {
           });
       });
 
-      it('orders tags by priority and indexOf score', function(done){
+      it('orders tags by priority and indexOf score', function(done) {
         syn
           .click(input)
           .type('tag:', () => {
@@ -323,7 +323,7 @@ describe('SearchBarController', function () {
           });
       });
 
-      it('matches on multi word searches', function(done){
+      it('matches on multi word searches', function(done) {
         syn
           .click(input)
           .type('tag:"mul', () => {
@@ -338,7 +338,7 @@ describe('SearchBarController', function () {
           });
       });
 
-      it('handles filtering matches with unicode', function(done){
+      it('handles filtering matches with unicode', function(done) {
         syn
           .click(input)
           .type('tag:éf', () => {
@@ -400,7 +400,7 @@ describe('SearchBarController', function () {
     /**
      * return the array of all of lozenges values
      */
-    const getLozengeValues = function (){
+    const getLozengeValues = function () {
       return Array.from(ctrl.refs.searchBarLozenges.querySelectorAll('.lozenge')).map((el)=>{
         return el.querySelector('.lozenge__content').innerText;
       });
@@ -531,7 +531,7 @@ describe('SearchBarController', function () {
         });
     });
 
-    describe('mapping initial input value to proper group lozenge and input values', function(){
+    describe('mapping initial input value to proper group lozenge and input values', function() {
 
       let groupsScript;
 
@@ -551,7 +551,7 @@ describe('SearchBarController', function () {
         groupsScript.remove();
       });
 
-      it('should map an initial group name to proper group pubid input value', function(){
+      it('should map an initial group name to proper group pubid input value', function() {
 
         const {input, hiddenInput} = component("group:'abc 123'");
 
@@ -560,7 +560,7 @@ describe('SearchBarController', function () {
         assert.equal(hiddenInput.value, 'group:pid124');
       });
 
-      it('should map an initial group pubid to proper group name lozenge value', function(){
+      it('should map an initial group pubid to proper group name lozenge value', function() {
 
         const {input, hiddenInput} = component('group:pid124');
 

--- a/h/static/scripts/tests/controllers/search-bar-controller-test.js
+++ b/h/static/scripts/tests/controllers/search-bar-controller-test.js
@@ -1,18 +1,18 @@
 'use strict';
 
-var syn = require('syn');
-var util = require('./util');
+const syn = require('syn');
+const util = require('./util');
 
-var SearchBarController = require('../../controllers/search-bar-controller');
+const SearchBarController = require('../../controllers/search-bar-controller');
 
 
 describe('SearchBarController', () => {
   describe('Autosuggest', () => {
-    var testEl;
-    var input;
-    var dropdown;
-    var ctrl;
-    var TEMPLATE = `
+    let testEl;
+    let input;
+    let dropdown;
+    let ctrl;
+    const TEMPLATE = `
       <div>
         <form data-ref="searchBarForm">
           <div class="search-bar__lozenges" data-ref="searchBarLozenges">
@@ -22,13 +22,13 @@ describe('SearchBarController', () => {
       </div>
     `;
 
-    var getItemTitles = function() {
+    const getItemTitles = function() {
       return Array.from(dropdown.querySelectorAll('.search-bar__dropdown-menu-title')).map((node) => {
         return node.textContent.trim();
       });
     };
 
-    var setup = function() {
+    const setup = function() {
       testEl = document.createElement('div');
       testEl.innerHTML = TEMPLATE;
       document.body.appendChild(testEl);
@@ -39,21 +39,21 @@ describe('SearchBarController', () => {
       dropdown = input.nextSibling;
     };
 
-    var teardown = function() {
+    const teardown = function() {
       document.body.removeChild(testEl);
-      let tagsJSON = document.querySelector('.js-tag-suggestions');
+      const tagsJSON = document.querySelector('.js-tag-suggestions');
       if (tagsJSON) {
         tagsJSON.remove();
       }
 
-      let groupsJSON = document.querySelector('.js-group-suggestions');
+      const groupsJSON = document.querySelector('.js-group-suggestions');
       if (groupsJSON) {
         groupsJSON.remove();
       }
     };
 
-    var addTagSuggestions = function() {
-      let suggestions = [
+    const addTagSuggestions = function() {
+      const suggestions = [
         {
           tag: 'aaaa',
           count: 1,
@@ -92,14 +92,14 @@ describe('SearchBarController', () => {
         },
       ];
 
-      let tagsScript = document.createElement('script');
+      const tagsScript = document.createElement('script');
       tagsScript.innerHTML = JSON.stringify(suggestions);
       tagsScript.className = 'js-tag-suggestions';
       document.body.appendChild(tagsScript);
     };
 
-    var addGroupSuggestions = function() {
-      let suggestions = [
+    const addGroupSuggestions = function() {
+      const suggestions = [
         {
           name: 'aaac',
           pubid: 'pid1',
@@ -142,7 +142,7 @@ describe('SearchBarController', () => {
         },
       ];
 
-      let groupsScript = document.createElement('script');
+      const groupsScript = document.createElement('script');
       groupsScript.innerHTML = JSON.stringify(suggestions);
       groupsScript.className = 'js-group-suggestions';
       document.body.appendChild(groupsScript);
@@ -178,8 +178,8 @@ describe('SearchBarController', () => {
 
 
     it('allows submitting the form dropdown is open but has no selected value', (done) => {
-      let form = testEl.querySelector('form');
-      let submit = sinon.stub(form, 'submit');
+      const form = testEl.querySelector('form');
+      const submit = sinon.stub(form, 'submit');
 
       syn
         .click(input)
@@ -216,7 +216,7 @@ describe('SearchBarController', () => {
           .type('group:', () => {
             assert.isTrue(dropdown.classList.contains('is-open'));
 
-            let titles = getItemTitles();
+            const titles = getItemTitles();
 
             assert.lengthOf(titles, 5, 'we should be enforcing the 5 item max');
           })
@@ -301,7 +301,7 @@ describe('SearchBarController', () => {
           .type('tag:', () => {
             assert.isTrue(dropdown.classList.contains('is-open'));
 
-            let titles = getItemTitles();
+            const titles = getItemTitles();
 
             assert.lengthOf(titles, 5, 'we should be enforcing the 5 item max');
           })
@@ -351,7 +351,7 @@ describe('SearchBarController', () => {
   });
 
   describe('Lozenges', () => {
-    var ctrl;
+    let ctrl;
 
     afterEach(() => {
       if (ctrl) {
@@ -368,7 +368,7 @@ describe('SearchBarController', () => {
     function component(value, lozengeContent) {
       value = value || '';
       lozengeContent = lozengeContent || '';
-      var template = `
+      const template = `
         <div>
           <form data-ref="searchBarForm">
             <div class="search-bar__lozenges" data-ref="searchBarLozenges">${lozengeContent}</div>
@@ -407,7 +407,7 @@ describe('SearchBarController', () => {
     };
 
     it('should create lozenges for existing query terms in the input on page load', () => {
-      var {ctrl} = component('foo');
+      const {ctrl} = component('foo');
 
       assert.equal(getLozenges(ctrl)[0].textContent, 'foo');
     });
@@ -486,14 +486,14 @@ describe('SearchBarController', () => {
     });
 
     it('should not create a lozenge for incomplete query strings in the input on page load', () => {
-      var {ctrl, input} = component("'bar");
+      const {ctrl, input} = component("'bar");
 
       assert.equal(getLozenges(ctrl).length, 0);
       assert.equal(input.value, "'bar");
     });
 
     it('should create a lozenge when the user presses space and there are no incomplete query strings in the input', (done) => {
-      var {ctrl, input} = component('foo');
+      const {ctrl, input} = component('foo');
 
       syn
         .click(input)
@@ -505,7 +505,7 @@ describe('SearchBarController', () => {
     });
 
     it('should create a lozenge when the user completes a previously incomplete query string and then presses the space key', (done) => {
-      var {ctrl, input} = component("'bar gar'");
+      const {ctrl, input} = component("'bar gar'");
 
       syn
         .click(input)
@@ -517,14 +517,14 @@ describe('SearchBarController', () => {
     });
 
     it('should not create a lozenge when the user does not completes a previously incomplete query string and presses the space key', (done) => {
-      var {ctrl, input} = component("'bar");
+      const {ctrl, input} = component("'bar");
 
       syn
         .click(input)
         .type('[space]')
         .type('gar')
         .type('[space]', () => {
-          var lozenges = getLozenges(ctrl);
+          const lozenges = getLozenges(ctrl);
           assert.equal(lozenges.length, 0);
           assert.equal(input.value, "'bar gar ");
           done();
@@ -536,7 +536,7 @@ describe('SearchBarController', () => {
       let groupsScript;
 
       beforeEach(() => {
-        let suggestions = [{
+        const suggestions = [{
           name: 'abc 123',
           pubid: 'pid124',
         }];

--- a/h/static/scripts/tests/controllers/search-bar-controller-test.js
+++ b/h/static/scripts/tests/controllers/search-bar-controller-test.js
@@ -42,12 +42,12 @@ describe('SearchBarController', function () {
     var teardown = function() {
       document.body.removeChild(testEl);
       let tagsJSON = document.querySelector('.js-tag-suggestions');
-      if(tagsJSON) {
+      if (tagsJSON) {
         tagsJSON.remove();
       }
 
       let groupsJSON = document.querySelector('.js-group-suggestions');
-      if(groupsJSON) {
+      if (groupsJSON) {
         groupsJSON.remove();
       }
     };

--- a/h/static/scripts/tests/controllers/search-bar-controller-test.js
+++ b/h/static/scripts/tests/controllers/search-bar-controller-test.js
@@ -6,8 +6,8 @@ var util = require('./util');
 var SearchBarController = require('../../controllers/search-bar-controller');
 
 
-describe('SearchBarController', function () {
-  describe('Autosuggest', function () {
+describe('SearchBarController', () => {
+  describe('Autosuggest', () => {
     var testEl;
     var input;
     var dropdown;
@@ -151,7 +151,7 @@ describe('SearchBarController', function () {
     beforeEach(setup);
     afterEach(teardown);
 
-    it('uses autosuggestion for initial facets', function (done) {
+    it('uses autosuggestion for initial facets', (done) => {
 
       assert.isFalse(dropdown.classList.contains('is-open'));
 
@@ -165,7 +165,7 @@ describe('SearchBarController', function () {
         });
     });
 
-    it('it filters and updates input with autosuggested facet selection', function (done) {
+    it('it filters and updates input with autosuggested facet selection', (done) => {
       syn
         .click(input, () => {
           assert.notOk(input.value, 'baseline no value in input');
@@ -177,7 +177,7 @@ describe('SearchBarController', function () {
     });
 
 
-    it('allows submitting the form dropdown is open but has no selected value', function (done) {
+    it('allows submitting the form dropdown is open but has no selected value', (done) => {
       let form = testEl.querySelector('form');
       let submit = sinon.stub(form, 'submit');
 
@@ -193,7 +193,7 @@ describe('SearchBarController', function () {
         });
     });
 
-    describe('it allows group value suggestions', function () {
+    describe('it allows group value suggestions', () => {
 
       const getLozengeValues = function () {
         return Array.from(testEl.querySelectorAll('.lozenge')).map((el) => {
@@ -201,7 +201,7 @@ describe('SearchBarController', function () {
         });
       };
 
-      beforeEach(function() {
+      beforeEach(() => {
         // we need to setup the env vars before invoking controller
         teardown();
         addGroupSuggestions();
@@ -210,7 +210,7 @@ describe('SearchBarController', function () {
         sinon.stub(testEl.querySelector('form'), 'submit');
       });
 
-      it('shows group suggestions', function(done) {
+      it('shows group suggestions', (done) => {
         syn
           .click(input)
           .type('group:', () => {
@@ -226,7 +226,7 @@ describe('SearchBarController', function () {
           });
       });
 
-      it('orders groups by earliest value match first', function(done) {
+      it('orders groups by earliest value match first', (done) => {
         syn
           .click(input)
           .type('group:', () => {
@@ -238,7 +238,7 @@ describe('SearchBarController', function () {
           });
       });
 
-      it('supports multi word matching', function(done) {
+      it('supports multi word matching', (done) => {
         syn
           .click(input)
           .type('group:"mul', () => {
@@ -250,7 +250,7 @@ describe('SearchBarController', function () {
           });
       });
 
-      it('handles filtering matches with unicode', function(done) {
+      it('handles filtering matches with unicode', (done) => {
         syn
           .click(input)
           .type('group:éf', () => {
@@ -259,7 +259,7 @@ describe('SearchBarController', function () {
           });
       });
 
-      it('sets input and display friendly name value', function(done) {
+      it('sets input and display friendly name value', (done) => {
         syn
           .click(input)
           .type('group:"mul[down][enter]', () => {
@@ -273,7 +273,7 @@ describe('SearchBarController', function () {
           });
       });
 
-      it('matches escaped values', function(done) {
+      it('matches escaped values', (done) => {
         syn
           .click(input)
           .type('group:<[down][enter]', () => {
@@ -284,9 +284,9 @@ describe('SearchBarController', function () {
       });
     });
 
-    describe('it allows tag value suggestions', function () {
+    describe('it allows tag value suggestions', () => {
 
-      beforeEach(function() {
+      beforeEach(() => {
         // we need to setup the env vars before invoking controller
         teardown();
         addTagSuggestions();
@@ -295,7 +295,7 @@ describe('SearchBarController', function () {
         sinon.stub(testEl.querySelector('form'), 'submit');
       });
 
-      it('shows tag suggestions', function(done) {
+      it('shows tag suggestions', (done) => {
         syn
           .click(input)
           .type('tag:', () => {
@@ -311,7 +311,7 @@ describe('SearchBarController', function () {
           });
       });
 
-      it('orders tags by priority and indexOf score', function(done) {
+      it('orders tags by priority and indexOf score', (done) => {
         syn
           .click(input)
           .type('tag:', () => {
@@ -323,7 +323,7 @@ describe('SearchBarController', function () {
           });
       });
 
-      it('matches on multi word searches', function(done) {
+      it('matches on multi word searches', (done) => {
         syn
           .click(input)
           .type('tag:"mul', () => {
@@ -338,7 +338,7 @@ describe('SearchBarController', function () {
           });
       });
 
-      it('handles filtering matches with unicode', function(done) {
+      it('handles filtering matches with unicode', (done) => {
         syn
           .click(input)
           .type('tag:éf', () => {
@@ -350,10 +350,10 @@ describe('SearchBarController', function () {
     });
   });
 
-  describe('Lozenges', function () {
+  describe('Lozenges', () => {
     var ctrl;
 
-    afterEach(function () {
+    afterEach(() => {
       if (ctrl) {
         ctrl.element.remove();
         ctrl = null;
@@ -406,55 +406,55 @@ describe('SearchBarController', function () {
       });
     };
 
-    it('should create lozenges for existing query terms in the input on page load', function () {
+    it('should create lozenges for existing query terms in the input on page load', () => {
       var {ctrl} = component('foo');
 
       assert.equal(getLozenges(ctrl)[0].textContent, 'foo');
     });
 
-    it('inserts a hidden input on init', function () {
+    it('inserts a hidden input on init', () => {
       const {hiddenInput} = component();
 
       assert.notEqual(hiddenInput, null);
     });
 
-    it('removes the name="q" attribute from the input on init', function () {
+    it('removes the name="q" attribute from the input on init', () => {
       const {input} = component();
 
       assert.isFalse(input.hasAttribute('name'));
     });
 
-    it('adds the name="q" attribute to the hidden input on init', function () {
+    it('adds the name="q" attribute to the hidden input on init', () => {
       const {hiddenInput} = component();
 
       assert.equal(hiddenInput.getAttribute('name'), 'q');
     });
 
-    it('leaves the hidden input empty on init if the visible input is empty', function () {
+    it('leaves the hidden input empty on init if the visible input is empty', () => {
       const {hiddenInput} = component();
 
       assert.equal(hiddenInput.value, '');
     });
 
-    it('copies lozengifiable text from the input into the hidden input on init', function () {
+    it('copies lozengifiable text from the input into the hidden input on init', () => {
       const {hiddenInput} = component('these are my tag:lozenges');
 
       assert.equal(hiddenInput.value, 'these are my tag:lozenges');
     });
 
-    it('copies unlozengifiable text from the input into the hidden input on init', function () {
+    it('copies unlozengifiable text from the input into the hidden input on init', () => {
       const {hiddenInput} = component("group:'unclosed quotes");
 
       assert.equal(hiddenInput.value, "group:'unclosed quotes");
     });
 
-    it('copies lozengifiable and unlozengifiable text from the input into the hidden input on init', function () {
+    it('copies lozengifiable and unlozengifiable text from the input into the hidden input on init', () => {
       const {hiddenInput} = component("these are my tag:lozenges group:'unclosed quotes");
 
       assert.equal(hiddenInput.value, "these are my tag:lozenges group:'unclosed quotes");
     });
 
-    it('updates the value of the hidden input as text is typed into the visible input', function () {
+    it('updates the value of the hidden input as text is typed into the visible input', () => {
       const {input, hiddenInput} = component('initial text');
 
       input.value = 'new text';  // This is just "new text" and not
@@ -466,7 +466,7 @@ describe('SearchBarController', function () {
       assert.equal(hiddenInput.value, 'initial text new text');
     });
 
-    it('updates the value of the hidden input as unlozengifiable text is typed into the visible input', function () {
+    it('updates the value of the hidden input as unlozengifiable text is typed into the visible input', () => {
       const {input, hiddenInput} = component("group:'unclosed quotes");
 
       input.value = "group:'unclosed quotes still unclosed";
@@ -475,7 +475,7 @@ describe('SearchBarController', function () {
       assert.equal(hiddenInput.value, "group:'unclosed quotes still unclosed");
     });
 
-    it('updates the value of the hidden input when a lozenge is deleted', function () {
+    it('updates the value of the hidden input when a lozenge is deleted', () => {
       const {ctrl, hiddenInput} = component('foo bar');
 
       const lozenge = getLozenges(ctrl)[0];
@@ -485,14 +485,14 @@ describe('SearchBarController', function () {
       assert.equal(hiddenInput.value, 'bar');
     });
 
-    it('should not create a lozenge for incomplete query strings in the input on page load', function () {
+    it('should not create a lozenge for incomplete query strings in the input on page load', () => {
       var {ctrl, input} = component("'bar");
 
       assert.equal(getLozenges(ctrl).length, 0);
       assert.equal(input.value, "'bar");
     });
 
-    it('should create a lozenge when the user presses space and there are no incomplete query strings in the input', function (done) {
+    it('should create a lozenge when the user presses space and there are no incomplete query strings in the input', (done) => {
       var {ctrl, input} = component('foo');
 
       syn
@@ -504,7 +504,7 @@ describe('SearchBarController', function () {
         });
     });
 
-    it('should create a lozenge when the user completes a previously incomplete query string and then presses the space key', function (done) {
+    it('should create a lozenge when the user completes a previously incomplete query string and then presses the space key', (done) => {
       var {ctrl, input} = component("'bar gar'");
 
       syn
@@ -516,7 +516,7 @@ describe('SearchBarController', function () {
         });
     });
 
-    it('should not create a lozenge when the user does not completes a previously incomplete query string and presses the space key', function (done) {
+    it('should not create a lozenge when the user does not completes a previously incomplete query string and presses the space key', (done) => {
       var {ctrl, input} = component("'bar");
 
       syn
@@ -531,7 +531,7 @@ describe('SearchBarController', function () {
         });
     });
 
-    describe('mapping initial input value to proper group lozenge and input values', function() {
+    describe('mapping initial input value to proper group lozenge and input values', () => {
 
       let groupsScript;
 
@@ -551,7 +551,7 @@ describe('SearchBarController', function () {
         groupsScript.remove();
       });
 
-      it('should map an initial group name to proper group pubid input value', function() {
+      it('should map an initial group name to proper group pubid input value', () => {
 
         const {input, hiddenInput} = component("group:'abc 123'");
 
@@ -560,7 +560,7 @@ describe('SearchBarController', function () {
         assert.equal(hiddenInput.value, 'group:pid124');
       });
 
-      it('should map an initial group pubid to proper group name lozenge value', function() {
+      it('should map an initial group pubid to proper group name lozenge value', () => {
 
         const {input, hiddenInput} = component('group:pid124');
 

--- a/h/static/scripts/tests/controllers/search-bucket-controller-test.js
+++ b/h/static/scripts/tests/controllers/search-bucket-controller-test.js
@@ -20,48 +20,48 @@ class FakeEnvFlags {
   }
 }
 
-describe('SearchBucketController', function () {
+describe('SearchBucketController', () => {
   var ctrl;
 
-  beforeEach(function () {
+  beforeEach(() => {
     ctrl = util.setupComponent(document, TEMPLATE, SearchBucketController, {
       envFlags: new FakeEnvFlags(),
     });
   });
 
-  afterEach(function () {
+  afterEach(() => {
     ctrl.element.remove();
   });
 
-  it('does not have the is-expanded CSS class initially', function () {
+  it('does not have the is-expanded CSS class initially', () => {
     assert.isFalse(ctrl.refs.content.classList.contains('is-expanded'));
   });
 
-  it('adds the is-expanded CSS class when clicked', function () {
+  it('adds the is-expanded CSS class when clicked', () => {
     ctrl.refs.header.dispatchEvent(new Event('click'));
     assert.isTrue(ctrl.refs.content.classList.contains('is-expanded'));
   });
 
-  it('removes the is-expanded CSS class when clicked again', function () {
+  it('removes the is-expanded CSS class when clicked again', () => {
     ctrl.refs.header.dispatchEvent(new Event('click'));
     ctrl.refs.header.dispatchEvent(new Event('click'));
     assert.isFalse(ctrl.refs.content.classList.contains('is-expanded'));
   });
 
-  it('scrolls element into view when expanded', function () {
+  it('scrolls element into view when expanded', () => {
     ctrl.scrollTo = sinon.stub();
     ctrl.refs.header.dispatchEvent(new Event('click'));
     assert.calledWith(ctrl.scrollTo, ctrl.element);
   });
 
-  it('collapses search results on initial load', function () {
+  it('collapses search results on initial load', () => {
     assert.isFalse(ctrl.state.expanded);
   });
 
-  context('when initial load times out', function () {
+  context('when initial load times out', () => {
     var scrollTo;
 
-    beforeEach(function () {
+    beforeEach(() => {
       scrollTo = sinon.stub();
       ctrl = util.setupComponent(document, TEMPLATE, SearchBucketController, {
         scrollTo: scrollTo,
@@ -69,11 +69,11 @@ describe('SearchBucketController', function () {
       });
     });
 
-    it('does not scroll page on initial load', function () {
+    it('does not scroll page on initial load', () => {
       assert.notCalled(scrollTo);
     });
 
-    it('expands bucket on initial load', function () {
+    it('expands bucket on initial load', () => {
       assert.isTrue(ctrl.state.expanded);
     });
   });

--- a/h/static/scripts/tests/controllers/search-bucket-controller-test.js
+++ b/h/static/scripts/tests/controllers/search-bucket-controller-test.js
@@ -1,9 +1,9 @@
 'use strict';
 
-var SearchBucketController = require('../../controllers/search-bucket-controller');
-var util = require('./util');
+const SearchBucketController = require('../../controllers/search-bucket-controller');
+const util = require('./util');
 
-var TEMPLATE = [
+const TEMPLATE = [
   '<div class="js-search-bucket">',
   '<div data-ref="header"></div>',
   '<div data-ref="content"></div>',
@@ -21,7 +21,7 @@ class FakeEnvFlags {
 }
 
 describe('SearchBucketController', () => {
-  var ctrl;
+  let ctrl;
 
   beforeEach(() => {
     ctrl = util.setupComponent(document, TEMPLATE, SearchBucketController, {
@@ -59,7 +59,7 @@ describe('SearchBucketController', () => {
   });
 
   context('when initial load times out', () => {
-    var scrollTo;
+    let scrollTo;
 
     beforeEach(() => {
       scrollTo = sinon.stub();

--- a/h/static/scripts/tests/controllers/signup-form-controller-test.js
+++ b/h/static/scripts/tests/controllers/signup-form-controller-test.js
@@ -8,19 +8,19 @@ var TEMPLATE = `
   </form>
   `;
 
-describe('SignupFormController', function () {
+describe('SignupFormController', () => {
   var element;
   var form;
   var submitBtn;
 
-  beforeEach(function () {
+  beforeEach(() => {
     element = document.createElement('div');
     element.innerHTML = TEMPLATE;
     form = element.querySelector('.js-signup-form');
     submitBtn = element.querySelector('.js-signup-btn');
   });
 
-  it('disables the submit button on form submit', function () {
+  it('disables the submit button on form submit', () => {
     new SignupFormController(form);
     assert.isFalse(submitBtn.disabled);
     form.dispatchEvent(new Event('submit'));

--- a/h/static/scripts/tests/controllers/signup-form-controller-test.js
+++ b/h/static/scripts/tests/controllers/signup-form-controller-test.js
@@ -1,17 +1,17 @@
 'use strict';
 
-var SignupFormController = require('../../controllers/signup-form-controller');
+const SignupFormController = require('../../controllers/signup-form-controller');
 
-var TEMPLATE = `
+const TEMPLATE = `
   <form class="js-signup-form">
     <input type="submit" class="js-signup-btn">
   </form>
   `;
 
 describe('SignupFormController', () => {
-  var element;
-  var form;
-  var submitBtn;
+  let element;
+  let form;
+  let submitBtn;
 
   beforeEach(() => {
     element = document.createElement('div');

--- a/h/static/scripts/tests/controllers/tooltip-controller-test.js
+++ b/h/static/scripts/tests/controllers/tooltip-controller-test.js
@@ -2,18 +2,18 @@
 
 var TooltipController = require('../../controllers/tooltip-controller');
 
-describe('TooltipController', function () {
+describe('TooltipController', () => {
   var targetEl;
   var template;
   var testEl;
   var tooltipEl;
 
-  before(function () {
+  before(() => {
     template = '<div class="form-input__hint-icon js-tooltip"' +
      'aria-label="Test"></div>';
   });
 
-  beforeEach(function () {
+  beforeEach(() => {
     testEl = document.createElement('div');
     testEl.innerHTML = template;
 
@@ -24,17 +24,17 @@ describe('TooltipController', function () {
   });
 
 
-  it('appears when the target is hovered', function () {
+  it('appears when the target is hovered', () => {
     targetEl.dispatchEvent(new Event('mouseover'));
     assert.equal(tooltipEl.style.visibility, '');
   });
 
-  it('sets the label from the target\'s "aria-label" attribute', function () {
+  it('sets the label from the target\'s "aria-label" attribute', () => {
     targetEl.dispatchEvent(new Event('mouseover'));
     assert.equal(tooltipEl.textContent, 'Test');
   });
 
-  it('disappears when the target is unhovered', function () {
+  it('disappears when the target is unhovered', () => {
     targetEl.dispatchEvent(new Event('mouseout'));
     assert.equal(tooltipEl.style.visibility, 'hidden');
   });

--- a/h/static/scripts/tests/controllers/tooltip-controller-test.js
+++ b/h/static/scripts/tests/controllers/tooltip-controller-test.js
@@ -1,12 +1,12 @@
 'use strict';
 
-var TooltipController = require('../../controllers/tooltip-controller');
+const TooltipController = require('../../controllers/tooltip-controller');
 
 describe('TooltipController', () => {
-  var targetEl;
-  var template;
-  var testEl;
-  var tooltipEl;
+  let targetEl;
+  let template;
+  let testEl;
+  let tooltipEl;
 
   before(() => {
     template = '<div class="form-input__hint-icon js-tooltip"' +

--- a/h/static/scripts/tests/controllers/util.js
+++ b/h/static/scripts/tests/controllers/util.js
@@ -10,9 +10,9 @@
  * @return {Controller} - The controller instance
  */
 function setupComponent(document, template, ControllerClass, options) {
-  var container = document.createElement('div');
+  const container = document.createElement('div');
   container.innerHTML = template;
-  var root = container.firstChild;
+  const root = container.firstChild;
   document.body.appendChild(root);
   container.remove();
   return new ControllerClass(root, options);

--- a/h/static/scripts/tests/promise-util.js
+++ b/h/static/scripts/tests/promise-util.js
@@ -8,9 +8,9 @@
  * as expected in tests.
  */
 function toResult(promise) {
-  return promise.then(function (result) {
+  return promise.then((result) => {
     return { result: result };
-  }).catch(function (err) {
+  }).catch((err) => {
     return { error: err };
   });
 }

--- a/h/static/scripts/tests/util.js
+++ b/h/static/scripts/tests/util.js
@@ -52,18 +52,18 @@ function noCallThru(stubs) {
  * @param {Array<T>} fixtures - Array of fixture objects.
  */
 function unroll(description, testFn, fixtures) {
-  fixtures.forEach(function (fixture) {
-    var caseDescription = Object.keys(fixture).reduce(function (desc, key) {
+  fixtures.forEach((fixture) => {
+    var caseDescription = Object.keys(fixture).reduce((desc, key) => {
       return desc.replace('#' + key, String(fixture[key]));
     }, description);
-    it(caseDescription, function (done) {
+    it(caseDescription, (done) => {
       if (testFn.length === 1) {
         // Test case does not accept a 'done' callback argument, so we either
         // call done() immediately if it returns a non-Promiselike object
         // or when the Promise resolves otherwise
         var result = testFn(fixture);
         if (typeof result === 'object' && result.then) {
-          result.then(function () { done(); }, done);
+          result.then(() => { done(); }, done);
         } else {
           done();
         }

--- a/h/static/scripts/tests/util.js
+++ b/h/static/scripts/tests/util.js
@@ -53,7 +53,7 @@ function noCallThru(stubs) {
  */
 function unroll(description, testFn, fixtures) {
   fixtures.forEach((fixture) => {
-    var caseDescription = Object.keys(fixture).reduce((desc, key) => {
+    const caseDescription = Object.keys(fixture).reduce((desc, key) => {
       return desc.replace('#' + key, String(fixture[key]));
     }, description);
     it(caseDescription, (done) => {
@@ -61,7 +61,7 @@ function unroll(description, testFn, fixtures) {
         // Test case does not accept a 'done' callback argument, so we either
         // call done() immediately if it returns a non-Promiselike object
         // or when the Promise resolves otherwise
-        var result = testFn(fixture);
+        const result = testFn(fixture);
         if (typeof result === 'object' && result.then) {
           result.then(() => { done(); }, done);
         } else {

--- a/h/static/scripts/tests/util/dom-test.js
+++ b/h/static/scripts/tests/util/dom-test.js
@@ -2,7 +2,7 @@
 
 var domUtil = require('../../util/dom');
 
-describe('util/dom', function () {
+describe('util/dom', () => {
   function createDOM(html) {
     var el = document.createElement('div');
     el.innerHTML = html;
@@ -12,8 +12,8 @@ describe('util/dom', function () {
     return child;
   }
 
-  describe('findRefs', function () {
-    it('returns a map of name to DOM element', function () {
+  describe('findRefs', () => {
+    it('returns a map of name to DOM element', () => {
       var root = createDOM(`
         <div>
           <label data-ref="label">Input label</label>
@@ -29,7 +29,7 @@ describe('util/dom', function () {
       });
     });
 
-    it('allows elements to have more than one name', function () {
+    it('allows elements to have more than one name', () => {
       var root = createDOM('<div><div data-ref="one two"></div></div>');
       assert.deepEqual(domUtil.findRefs(root), {
         one: root.firstChild,
@@ -38,8 +38,8 @@ describe('util/dom', function () {
     });
   });
 
-  describe('setElementState', function () {
-    it('adds "is-$state" classes for keys with truthy values', function () {
+  describe('setElementState', () => {
+    it('adds "is-$state" classes for keys with truthy values', () => {
       var btn = createDOM('<button></button>');
       domUtil.setElementState(btn, {
         visible: true,
@@ -47,7 +47,7 @@ describe('util/dom', function () {
       assert.deepEqual(Array.from(btn.classList), ['is-visible']);
     });
 
-    it('removes "is-$state" classes for keys with falsey values', function () {
+    it('removes "is-$state" classes for keys with falsey values', () => {
       var btn = createDOM('<button class="is-hidden"></button>');
       domUtil.setElementState(btn, {
         hidden: false,

--- a/h/static/scripts/tests/util/dom-test.js
+++ b/h/static/scripts/tests/util/dom-test.js
@@ -1,12 +1,12 @@
 'use strict';
 
-var domUtil = require('../../util/dom');
+const domUtil = require('../../util/dom');
 
 describe('util/dom', () => {
   function createDOM(html) {
-    var el = document.createElement('div');
+    const el = document.createElement('div');
     el.innerHTML = html;
-    var child = el.children[0];
+    const child = el.children[0];
     document.body.appendChild(child);
     el.remove();
     return child;
@@ -14,14 +14,14 @@ describe('util/dom', () => {
 
   describe('findRefs', () => {
     it('returns a map of name to DOM element', () => {
-      var root = createDOM(`
+      const root = createDOM(`
         <div>
           <label data-ref="label">Input label</label>
           <input data-ref="input">
         </div>
       `);
-      var labelEl = root.querySelector('label');
-      var inputEl = root.querySelector('input');
+      const labelEl = root.querySelector('label');
+      const inputEl = root.querySelector('input');
 
       assert.deepEqual(domUtil.findRefs(root), {
         label: labelEl,
@@ -30,7 +30,7 @@ describe('util/dom', () => {
     });
 
     it('allows elements to have more than one name', () => {
-      var root = createDOM('<div><div data-ref="one two"></div></div>');
+      const root = createDOM('<div><div data-ref="one two"></div></div>');
       assert.deepEqual(domUtil.findRefs(root), {
         one: root.firstChild,
         two: root.firstChild,
@@ -40,7 +40,7 @@ describe('util/dom', () => {
 
   describe('setElementState', () => {
     it('adds "is-$state" classes for keys with truthy values', () => {
-      var btn = createDOM('<button></button>');
+      const btn = createDOM('<button></button>');
       domUtil.setElementState(btn, {
         visible: true,
       });
@@ -48,7 +48,7 @@ describe('util/dom', () => {
     });
 
     it('removes "is-$state" classes for keys with falsey values', () => {
-      var btn = createDOM('<button class="is-hidden"></button>');
+      const btn = createDOM('<button class="is-hidden"></button>');
       domUtil.setElementState(btn, {
         hidden: false,
       });

--- a/h/static/scripts/tests/util/modal-focus-test.js
+++ b/h/static/scripts/tests/util/modal-focus-test.js
@@ -1,14 +1,14 @@
 'use strict';
 
-var modalFocus = require('../../util/modal-focus');
+const modalFocus = require('../../util/modal-focus');
 
 describe('util/modal-focus', () => {
   // Elements inside the focus group
-  var insideEls;
+  let insideEls;
   // Element outside the focus group
-  var outsideEl;
-  var onFocusOut;
-  var releaseFocus;
+  let outsideEl;
+  let onFocusOut;
+  let releaseFocus;
 
   beforeEach(() => {
     insideEls = [1,2,3].map(() => document.createElement('input'));

--- a/h/static/scripts/tests/util/modal-focus-test.js
+++ b/h/static/scripts/tests/util/modal-focus-test.js
@@ -2,7 +2,7 @@
 
 var modalFocus = require('../../util/modal-focus');
 
-describe('util/modal-focus', function () {
+describe('util/modal-focus', () => {
   // Elements inside the focus group
   var insideEls;
   // Element outside the focus group
@@ -10,7 +10,7 @@ describe('util/modal-focus', function () {
   var onFocusOut;
   var releaseFocus;
 
-  beforeEach(function () {
+  beforeEach(() => {
     insideEls = [1,2,3].map(() => document.createElement('input'));
     insideEls.forEach(el => document.body.appendChild(el));
 
@@ -21,36 +21,36 @@ describe('util/modal-focus', function () {
     releaseFocus = modalFocus.trap(insideEls, onFocusOut);
   });
 
-  afterEach(function () {
+  afterEach(() => {
     insideEls.forEach(el => el.remove());
     releaseFocus();
   });
 
-  describe('#trap', function () {
-    it('does not invoke the callback when an element in the group is focused', function () {
+  describe('#trap', () => {
+    it('does not invoke the callback when an element in the group is focused', () => {
       insideEls[0].focus();
       insideEls[1].focus();
       assert.notCalled(onFocusOut);
     });
 
-    it('invokes the callback when an element outside the group is focused', function () {
+    it('invokes the callback when an element outside the group is focused', () => {
       outsideEl.focus();
       assert.calledWith(onFocusOut, outsideEl);
     });
 
-    it('does not prevent the focus change if the callback returns null', function () {
+    it('does not prevent the focus change if the callback returns null', () => {
       onFocusOut.returns(null);
       outsideEl.focus();
       assert.equal(document.activeElement, outsideEl);
     });
 
-    it('prevents a focus change if the callback returns an element', function () {
+    it('prevents a focus change if the callback returns an element', () => {
       onFocusOut.returns(insideEls[0]);
       outsideEl.focus();
       assert.equal(document.activeElement, insideEls[0]);
     });
 
-    it('releases focus when returned function is called', function () {
+    it('releases focus when returned function is called', () => {
       onFocusOut.returns(insideEls[0]);
 
       releaseFocus();

--- a/h/static/scripts/tests/util/search-text-parser-test.js
+++ b/h/static/scripts/tests/util/search-text-parser-test.js
@@ -3,8 +3,8 @@
 var searchTextParser = require('../../util/search-text-parser');
 var unroll = require('../util').unroll;
 
-describe('SearchTextParser', function () {
-  unroll('should create a lozenge #input', function (fixture) {
+describe('SearchTextParser', () => {
+  unroll('should create a lozenge #input', (fixture) => {
     assert.isTrue(searchTextParser.shouldLozengify(fixture.input));
   },[
     {input: 'foo'},
@@ -22,7 +22,7 @@ describe('SearchTextParser', function () {
     {input: 'foo\'bar:'},
   ]);
 
-  unroll('should not create a lozenge for', function (fixture) {
+  unroll('should not create a lozenge for', (fixture) => {
     assert.isFalse(searchTextParser.shouldLozengify(fixture.input));
   },[
     {input: 'foo\''},

--- a/h/static/scripts/tests/util/search-text-parser-test.js
+++ b/h/static/scripts/tests/util/search-text-parser-test.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var searchTextParser = require('../../util/search-text-parser');
-var unroll = require('../util').unroll;
+const searchTextParser = require('../../util/search-text-parser');
+const unroll = require('../util').unroll;
 
 describe('SearchTextParser', () => {
   unroll('should create a lozenge #input', (fixture) => {

--- a/h/static/scripts/tests/util/string-test.js
+++ b/h/static/scripts/tests/util/string-test.js
@@ -2,16 +2,16 @@
 
 var stringUtil = require('../../util/string');
 
-describe('util/string', function () {
-  describe('hyphenate', function () {
-    it('converts input to kebab-case', function () {
+describe('util/string', () => {
+  describe('hyphenate', () => {
+    it('converts input to kebab-case', () => {
       assert.equal(stringUtil.hyphenate('fooBar'), 'foo-bar');
       assert.equal(stringUtil.hyphenate('FooBar'), '-foo-bar');
     });
   });
 
-  describe('unhyphenate', function () {
-    it('converts input to camelCase', function () {
+  describe('unhyphenate', () => {
+    it('converts input to camelCase', () => {
       assert.equal(stringUtil.unhyphenate('foo-bar'), 'fooBar');
       assert.equal(stringUtil.unhyphenate('foo-bar-'), 'fooBar');
       assert.equal(stringUtil.unhyphenate('foo-bar-baz'), 'fooBarBaz');
@@ -19,9 +19,9 @@ describe('util/string', function () {
     });
   });
 
-  describe('stringUtil helpers', function() {
+  describe('stringUtil helpers', () => {
 
-    it('removes hungarian marks', function() {
+    it('removes hungarian marks', () => {
       let text = 'Fürge rőt róka túlszökik zsíros étkű kutyán';
       let decoded = stringUtil.fold(stringUtil.normalize(text));
       let expected = 'Furge rot roka tulszokik zsiros etku kutyan';
@@ -29,7 +29,7 @@ describe('util/string', function () {
       assert.equal(decoded, expected);
     });
 
-    it('removes greek marks', function() {
+    it('removes greek marks', () => {
       let text = 'Καλημέρα κόσμε';
       let decoded = stringUtil.fold(stringUtil.normalize(text));
       let expected = 'Καλημερα κοσμε';
@@ -37,7 +37,7 @@ describe('util/string', function () {
       assert.equal(decoded, expected);
     });
 
-    it('removes japanese marks', function() {
+    it('removes japanese marks', () => {
       let text = 'カタカナコンバータ';
       let decoded = stringUtil.fold(stringUtil.normalize(text));
       let expected = 'カタカナコンハータ';
@@ -45,7 +45,7 @@ describe('util/string', function () {
       assert.equal(decoded, expected);
     });
 
-    it('removes marathi marks', function() {
+    it('removes marathi marks', () => {
       let text = 'काचं शक्नोम्यत्तुम';
       let decoded = stringUtil.fold(stringUtil.normalize(text));
       let expected = 'कच शकनमयततम';
@@ -53,7 +53,7 @@ describe('util/string', function () {
       assert.equal(decoded, expected);
     });
 
-    it('removes thai marks', function() {
+    it('removes thai marks', () => {
       let text = 'ฉันกินกระจกได้ แต่มันไม่ทำให้ฉันเจ็บ';
       let decoded = stringUtil.fold(stringUtil.normalize(text));
       let expected = 'ฉนกนกระจกได แตมนไมทาใหฉนเจบ';
@@ -61,7 +61,7 @@ describe('util/string', function () {
       assert.equal(decoded, expected);
     });
 
-    it('removes all marks', function() {
+    it('removes all marks', () => {
       let text = '̀ ́ ̂ ̃ ̄ ̅ ̆ ̇ ̈ ̉ ̊ ̋ ̌ ̍ ̎ ̏ ̐ ̑ ̒ ̓ ̔ ̕ ̖ ̗ ̘ ̙ ̚ ̛ ̜ ̝ ̞ ̟ ̠ ̡ ̢ ̣ ̤ ̥ ̦ ̧ ̨ ̩ ̪ ̫ ̬ ̭ ̮ ̯ ̰ ̱ ̲ ̳ ̴ ̵ ̶ ̷ ̸ ̹ ̺ ̻ ̼ ̽ ̾ ̿ ̀ ́ ͂ ̓ ̈́ ͅ ͠ ͡"';
       let decoded = stringUtil.fold(stringUtil.normalize(text));
       let expected = '                                                                       "';

--- a/h/static/scripts/tests/util/string-test.js
+++ b/h/static/scripts/tests/util/string-test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var stringUtil = require('../../util/string');
+const stringUtil = require('../../util/string');
 
 describe('util/string', () => {
   describe('hyphenate', () => {
@@ -22,49 +22,49 @@ describe('util/string', () => {
   describe('stringUtil helpers', () => {
 
     it('removes hungarian marks', () => {
-      let text = 'Fürge rőt róka túlszökik zsíros étkű kutyán';
-      let decoded = stringUtil.fold(stringUtil.normalize(text));
-      let expected = 'Furge rot roka tulszokik zsiros etku kutyan';
+      const text = 'Fürge rőt róka túlszökik zsíros étkű kutyán';
+      const decoded = stringUtil.fold(stringUtil.normalize(text));
+      const expected = 'Furge rot roka tulszokik zsiros etku kutyan';
 
       assert.equal(decoded, expected);
     });
 
     it('removes greek marks', () => {
-      let text = 'Καλημέρα κόσμε';
-      let decoded = stringUtil.fold(stringUtil.normalize(text));
-      let expected = 'Καλημερα κοσμε';
+      const text = 'Καλημέρα κόσμε';
+      const decoded = stringUtil.fold(stringUtil.normalize(text));
+      const expected = 'Καλημερα κοσμε';
 
       assert.equal(decoded, expected);
     });
 
     it('removes japanese marks', () => {
-      let text = 'カタカナコンバータ';
-      let decoded = stringUtil.fold(stringUtil.normalize(text));
-      let expected = 'カタカナコンハータ';
+      const text = 'カタカナコンバータ';
+      const decoded = stringUtil.fold(stringUtil.normalize(text));
+      const expected = 'カタカナコンハータ';
 
       assert.equal(decoded, expected);
     });
 
     it('removes marathi marks', () => {
-      let text = 'काचं शक्नोम्यत्तुम';
-      let decoded = stringUtil.fold(stringUtil.normalize(text));
-      let expected = 'कच शकनमयततम';
+      const text = 'काचं शक्नोम्यत्तुम';
+      const decoded = stringUtil.fold(stringUtil.normalize(text));
+      const expected = 'कच शकनमयततम';
 
       assert.equal(decoded, expected);
     });
 
     it('removes thai marks', () => {
-      let text = 'ฉันกินกระจกได้ แต่มันไม่ทำให้ฉันเจ็บ';
-      let decoded = stringUtil.fold(stringUtil.normalize(text));
-      let expected = 'ฉนกนกระจกได แตมนไมทาใหฉนเจบ';
+      const text = 'ฉันกินกระจกได้ แต่มันไม่ทำให้ฉันเจ็บ';
+      const decoded = stringUtil.fold(stringUtil.normalize(text));
+      const expected = 'ฉนกนกระจกได แตมนไมทาใหฉนเจบ';
 
       assert.equal(decoded, expected);
     });
 
     it('removes all marks', () => {
-      let text = '̀ ́ ̂ ̃ ̄ ̅ ̆ ̇ ̈ ̉ ̊ ̋ ̌ ̍ ̎ ̏ ̐ ̑ ̒ ̓ ̔ ̕ ̖ ̗ ̘ ̙ ̚ ̛ ̜ ̝ ̞ ̟ ̠ ̡ ̢ ̣ ̤ ̥ ̦ ̧ ̨ ̩ ̪ ̫ ̬ ̭ ̮ ̯ ̰ ̱ ̲ ̳ ̴ ̵ ̶ ̷ ̸ ̹ ̺ ̻ ̼ ̽ ̾ ̿ ̀ ́ ͂ ̓ ̈́ ͅ ͠ ͡"';
-      let decoded = stringUtil.fold(stringUtil.normalize(text));
-      let expected = '                                                                       "';
+      const text = '̀ ́ ̂ ̃ ̄ ̅ ̆ ̇ ̈ ̉ ̊ ̋ ̌ ̍ ̎ ̏ ̐ ̑ ̒ ̓ ̔ ̕ ̖ ̗ ̘ ̙ ̚ ̛ ̜ ̝ ̞ ̟ ̠ ̡ ̢ ̣ ̤ ̥ ̦ ̧ ̨ ̩ ̪ ̫ ̬ ̭ ̮ ̯ ̰ ̱ ̲ ̳ ̴ ̵ ̶ ̷ ̸ ̹ ̺ ̻ ̼ ̽ ̾ ̿ ̀ ́ ͂ ̓ ̈́ ͅ ͠ ͡"';
+      const decoded = stringUtil.fold(stringUtil.normalize(text));
+      const expected = '                                                                       "';
 
       assert.equal(decoded, expected);
     });

--- a/h/static/scripts/tests/util/string-test.js
+++ b/h/static/scripts/tests/util/string-test.js
@@ -19,9 +19,9 @@ describe('util/string', function () {
     });
   });
 
-  describe('stringUtil helpers', function(){
+  describe('stringUtil helpers', function() {
 
-    it('removes hungarian marks', function(){
+    it('removes hungarian marks', function() {
       let text = 'Fürge rőt róka túlszökik zsíros étkű kutyán';
       let decoded = stringUtil.fold(stringUtil.normalize(text));
       let expected = 'Furge rot roka tulszokik zsiros etku kutyan';
@@ -29,7 +29,7 @@ describe('util/string', function () {
       assert.equal(decoded, expected);
     });
 
-    it('removes greek marks', function(){
+    it('removes greek marks', function() {
       let text = 'Καλημέρα κόσμε';
       let decoded = stringUtil.fold(stringUtil.normalize(text));
       let expected = 'Καλημερα κοσμε';
@@ -37,7 +37,7 @@ describe('util/string', function () {
       assert.equal(decoded, expected);
     });
 
-    it('removes japanese marks', function(){
+    it('removes japanese marks', function() {
       let text = 'カタカナコンバータ';
       let decoded = stringUtil.fold(stringUtil.normalize(text));
       let expected = 'カタカナコンハータ';
@@ -45,7 +45,7 @@ describe('util/string', function () {
       assert.equal(decoded, expected);
     });
 
-    it('removes marathi marks', function(){
+    it('removes marathi marks', function() {
       let text = 'काचं शक्नोम्यत्तुम';
       let decoded = stringUtil.fold(stringUtil.normalize(text));
       let expected = 'कच शकनमयततम';
@@ -53,7 +53,7 @@ describe('util/string', function () {
       assert.equal(decoded, expected);
     });
 
-    it('removes thai marks', function(){
+    it('removes thai marks', function() {
       let text = 'ฉันกินกระจกได้ แต่มันไม่ทำให้ฉันเจ็บ';
       let decoded = stringUtil.fold(stringUtil.normalize(text));
       let expected = 'ฉนกนกระจกได แตมนไมทาใหฉนเจบ';
@@ -61,7 +61,7 @@ describe('util/string', function () {
       assert.equal(decoded, expected);
     });
 
-    it('removes all marks', function(){
+    it('removes all marks', function() {
       let text = '̀ ́ ̂ ̃ ̄ ̅ ̆ ̇ ̈ ̉ ̊ ̋ ̌ ̍ ̎ ̏ ̐ ̑ ̒ ̓ ̔ ̕ ̖ ̗ ̘ ̙ ̚ ̛ ̜ ̝ ̞ ̟ ̠ ̡ ̢ ̣ ̤ ̥ ̦ ̧ ̨ ̩ ̪ ̫ ̬ ̭ ̮ ̯ ̰ ̱ ̲ ̳ ̴ ̵ ̶ ̷ ̸ ̹ ̺ ̻ ̼ ̽ ̾ ̿ ̀ ́ ͂ ̓ ̈́ ͅ ͠ ͡"';
       let decoded = stringUtil.fold(stringUtil.normalize(text));
       let expected = '                                                                       "';

--- a/h/static/scripts/tests/util/submit-form-test.js
+++ b/h/static/scripts/tests/util/submit-form-test.js
@@ -4,7 +4,7 @@ var fetchMock = require('fetch-mock');
 
 var submitForm = require('../../util/submit-form');
 
-describe('submitForm', function () {
+describe('submitForm', () => {
   var FORM_URL = 'http://example.org/things';
 
   function mockResponse(response) {
@@ -19,27 +19,27 @@ describe('submitForm', function () {
     return form;
   }
 
-  it('submits the form data', function () {
+  it('submits the form data', () => {
     var form = createForm();
     mockResponse('<form><!-- updated form !--></form>');
 
-    return submitForm(form, fetchMock.fetchMock).then(function () {
+    return submitForm(form, fetchMock.fetchMock).then(() => {
       var [,requestInit] = fetchMock.lastCall(FORM_URL);
       assert.instanceOf(requestInit.body, FormData);
     });
   });
 
-  it('returns the markup for the updated form if validation succeeds', function () {
+  it('returns the markup for the updated form if validation succeeds', () => {
     var form = createForm();
     var responseBody = '<form><!-- updated form !--></form>';
     mockResponse(responseBody);
 
-    return submitForm(form, fetchMock.fetchMock).then(function (response) {
+    return submitForm(form, fetchMock.fetchMock).then((response) => {
       assert.equal(response.form, responseBody);
     });
   });
 
-  it('rejects with the updated form markup if validation fails', function () {
+  it('rejects with the updated form markup if validation fails', () => {
     var form = createForm();
     mockResponse({status: 400, body: 'response'});
 
@@ -50,7 +50,7 @@ describe('submitForm', function () {
     });
   });
 
-  it('rejects with an error message if submission fails', function () {
+  it('rejects with an error message if submission fails', () => {
     var form = createForm();
     mockResponse({status: 500, statusText: 'Internal Server Error'});
 

--- a/h/static/scripts/tests/util/submit-form-test.js
+++ b/h/static/scripts/tests/util/submit-form-test.js
@@ -45,7 +45,7 @@ describe('submitForm', function () {
 
     var done = submitForm(form, fetchMock.fetchMock);
 
-    return done.catch(err => {
+    return done.catch((err) => {
       assert.match(err, sinon.match({status: 400, form: 'response'}));
     });
   });
@@ -56,7 +56,7 @@ describe('submitForm', function () {
 
     var done = submitForm(form, fetchMock.fetchMock);
 
-    return done.catch(err => {
+    return done.catch((err) => {
       assert.match(err, sinon.match({status: 500, reason: 'Internal Server Error'}));
     });
   });

--- a/h/static/scripts/tests/util/submit-form-test.js
+++ b/h/static/scripts/tests/util/submit-form-test.js
@@ -1,18 +1,18 @@
 'use strict';
 
-var fetchMock = require('fetch-mock');
+const fetchMock = require('fetch-mock');
 
-var submitForm = require('../../util/submit-form');
+const submitForm = require('../../util/submit-form');
 
 describe('submitForm', () => {
-  var FORM_URL = 'http://example.org/things';
+  const FORM_URL = 'http://example.org/things';
 
   function mockResponse(response) {
     fetchMock.post(FORM_URL, response);
   }
 
   function createForm() {
-    var form = document.createElement('form');
+    const form = document.createElement('form');
     form.action = FORM_URL;
     form.method = 'POST';
     form.innerHTML = '<input name="field" value="value">';
@@ -20,18 +20,18 @@ describe('submitForm', () => {
   }
 
   it('submits the form data', () => {
-    var form = createForm();
+    const form = createForm();
     mockResponse('<form><!-- updated form !--></form>');
 
     return submitForm(form, fetchMock.fetchMock).then(() => {
-      var [,requestInit] = fetchMock.lastCall(FORM_URL);
+      const [,requestInit] = fetchMock.lastCall(FORM_URL);
       assert.instanceOf(requestInit.body, FormData);
     });
   });
 
   it('returns the markup for the updated form if validation succeeds', () => {
-    var form = createForm();
-    var responseBody = '<form><!-- updated form !--></form>';
+    const form = createForm();
+    const responseBody = '<form><!-- updated form !--></form>';
     mockResponse(responseBody);
 
     return submitForm(form, fetchMock.fetchMock).then((response) => {
@@ -40,10 +40,10 @@ describe('submitForm', () => {
   });
 
   it('rejects with the updated form markup if validation fails', () => {
-    var form = createForm();
+    const form = createForm();
     mockResponse({status: 400, body: 'response'});
 
-    var done = submitForm(form, fetchMock.fetchMock);
+    const done = submitForm(form, fetchMock.fetchMock);
 
     return done.catch((err) => {
       assert.match(err, sinon.match({status: 400, form: 'response'}));
@@ -51,10 +51,10 @@ describe('submitForm', () => {
   });
 
   it('rejects with an error message if submission fails', () => {
-    var form = createForm();
+    const form = createForm();
     mockResponse({status: 500, statusText: 'Internal Server Error'});
 
-    var done = submitForm(form, fetchMock.fetchMock);
+    const done = submitForm(form, fetchMock.fetchMock);
 
     return done.catch((err) => {
       assert.match(err, sinon.match({status: 500, reason: 'Internal Server Error'}));

--- a/h/static/scripts/util/annotation-ids.js
+++ b/h/static/scripts/util/annotation-ids.js
@@ -11,7 +11,7 @@ function extractIDFromURL(url) {
   try {
     // Annotation IDs are url-safe-base64 identifiers
     // See https://tools.ietf.org/html/rfc4648#page-7
-    var annotFragmentMatch = url.match(/#annotations:([A-Za-z0-9_-]+)$/);
+    const annotFragmentMatch = url.match(/#annotations:([A-Za-z0-9_-]+)$/);
     if (annotFragmentMatch) {
       return annotFragmentMatch[1];
     } else {

--- a/h/static/scripts/util/dom.js
+++ b/h/static/scripts/util/dom.js
@@ -1,8 +1,8 @@
 'use strict';
 
-var stringUtil = require('./string');
+const stringUtil = require('./string');
 
-var hyphenate = stringUtil.hyphenate;
+const hyphenate = stringUtil.hyphenate;
 
 /**
  * Utility functions for DOM manipulation.
@@ -18,7 +18,7 @@ var hyphenate = stringUtil.hyphenate;
  */
 function setElementState(el, state) {
   Object.keys(state).forEach((key) => {
-    var stateClass = 'is-' + hyphenate(key);
+    const stateClass = 'is-' + hyphenate(key);
     el.classList.toggle(stateClass, !!state[key]);
   });
 }
@@ -31,14 +31,14 @@ function setElementState(el, state) {
  * reference to them subsequently in code.
  */
 function findRefs(el) {
-  var map = {};
+  const map = {};
 
-  var descendantsWithRef = el.querySelectorAll('[data-ref]');
-  for (var i=0; i < descendantsWithRef.length; i++) {
+  const descendantsWithRef = el.querySelectorAll('[data-ref]');
+  for (let i=0; i < descendantsWithRef.length; i++) {
     // Use `Element#getAttribute` rather than `Element#dataset` to support IE 10
     // and avoid https://bugs.webkit.org/show_bug.cgi?id=161454
-    var refEl = descendantsWithRef[i];
-    var refs = (refEl.getAttribute('data-ref') || '').split(' ');
+    const refEl = descendantsWithRef[i];
+    const refs = (refEl.getAttribute('data-ref') || '').split(' ');
     refs.forEach((ref) => {
       map[ref] = refEl;
     });

--- a/h/static/scripts/util/dom.js
+++ b/h/static/scripts/util/dom.js
@@ -17,7 +17,7 @@ var hyphenate = stringUtil.hyphenate;
  *                 is true or removed otherwise.
  */
 function setElementState(el, state) {
-  Object.keys(state).forEach(function (key) {
+  Object.keys(state).forEach((key) => {
     var stateClass = 'is-' + hyphenate(key);
     el.classList.toggle(stateClass, !!state[key]);
   });
@@ -39,7 +39,7 @@ function findRefs(el) {
     // and avoid https://bugs.webkit.org/show_bug.cgi?id=161454
     var refEl = descendantsWithRef[i];
     var refs = (refEl.getAttribute('data-ref') || '').split(' ');
-    refs.forEach(function (ref) {
+    refs.forEach((ref) => {
       map[ref] = refEl;
     });
   }

--- a/h/static/scripts/util/modal-focus.js
+++ b/h/static/scripts/util/modal-focus.js
@@ -1,7 +1,7 @@
 'use strict';
 
 // Focus release function returned by most recent call to trap()
-var currentReleaseFn;
+let currentReleaseFn;
 
 /**
  * Trap focus within a group of elements.
@@ -33,7 +33,7 @@ function trap(elements, callback) {
   //
   // Instead we watch the 'focus' event on the document itself.
 
-  var onFocusChange = (event) => {
+  const onFocusChange = (event) => {
     if (elements.some(el => el.contains(event.target))) {
       // Focus remains within modal group
       return;
@@ -41,7 +41,7 @@ function trap(elements, callback) {
 
     // Focus is trying to move outside of the modal group, test whether to
     // allow this
-    var newTarget = callback(event.target);
+    const newTarget = callback(event.target);
     if (newTarget) {
       event.preventDefault();
       event.stopPropagation();
@@ -52,7 +52,7 @@ function trap(elements, callback) {
   };
   document.addEventListener('focus', onFocusChange, true /* useCapture */);
 
-  var releaseFn = () => {
+  const releaseFn = () => {
     if (currentReleaseFn === releaseFn) {
       currentReleaseFn = null;
       document.removeEventListener('focus', onFocusChange, true /* useCapture */);

--- a/h/static/scripts/util/modal-focus.js
+++ b/h/static/scripts/util/modal-focus.js
@@ -33,7 +33,7 @@ function trap(elements, callback) {
   //
   // Instead we watch the 'focus' event on the document itself.
 
-  var onFocusChange = event => {
+  var onFocusChange = (event) => {
     if (elements.some(el => el.contains(event.target))) {
       // Focus remains within modal group
       return;

--- a/h/static/scripts/util/search-text-parser.js
+++ b/h/static/scripts/util/search-text-parser.js
@@ -93,7 +93,7 @@ function getLozengeValues(queryString) {
   var inputTerms = '';
   var quoted;
   var queryTerms = [];
-  queryString.split(' ').forEach(function(term) {
+  queryString.split(' ').forEach((term) => {
     if (quoted) {
       inputTerms = inputTerms + ' ' + term;
       if (shouldLozengify(inputTerms)) {

--- a/h/static/scripts/util/search-text-parser.js
+++ b/h/static/scripts/util/search-text-parser.js
@@ -58,7 +58,7 @@ function canLozengify(phrase) {
 function shouldLozengify(phrase) {
   // if the phrase has a facet and value
   if (phrase.indexOf(':') >= 0) {
-    var queryTerm = getLozengeFacetNameAndValue(phrase);
+    const queryTerm = getLozengeFacetNameAndValue(phrase);
 
     if (!canLozengify(queryTerm.facetName)) {
       return false;
@@ -90,9 +90,9 @@ function shouldLozengify(phrase) {
  * getLozengeValues('foo key:"foo bar" gar "unclosed')
  */
 function getLozengeValues(queryString) {
-  var inputTerms = '';
-  var quoted;
-  var queryTerms = [];
+  let inputTerms = '';
+  let quoted;
+  const queryTerms = [];
   queryString.split(' ').forEach((term) => {
     if (quoted) {
       inputTerms = inputTerms + ' ' + term;
@@ -137,9 +137,7 @@ function hasKnownNamedQueryTerm(queryTerm) {
     'group',
     'tag'];
 
-  var facetName;
-
-  facetName = getLozengeFacetNameAndValue(queryTerm).facetName;
+  const facetName = getLozengeFacetNameAndValue(queryTerm).facetName;
 
   return knownNamedQueryTerms.indexOf(facetName) >= 0;
 }
@@ -166,8 +164,8 @@ function hasKnownNamedQueryTerm(queryTerm) {
  * getLozengeFacetNameAndValue('gar')
  */
 function getLozengeFacetNameAndValue(queryTerm) {
-  var i;
-  var lozengeFacetNameAndValue = {
+  let i;
+  const lozengeFacetNameAndValue = {
     facetName: '',
     facetValue: '',
   };

--- a/h/static/scripts/util/string.js
+++ b/h/static/scripts/util/string.js
@@ -36,14 +36,14 @@ function normalize(str) {
   // This require is coming from a vendor bundle
   // that is loaded globally on the running webpage
   // not a require in the node context
-  try{
+  try {
     // polyfill String.prototype.normalize
     require('unorm');
-  }catch(e) {
+  } catch (e) {
     console.error('unorm not available');
   }
 
-  if(!String.prototype.normalize) {
+  if (!String.prototype.normalize) {
     return str;
   }
 

--- a/h/static/scripts/util/string.js
+++ b/h/static/scripts/util/string.js
@@ -31,7 +31,7 @@ function unhyphenate(name) {
  * @param  {String}
  * @returns {String}
  */
-function normalize(str){
+function normalize(str) {
 
   // This require is coming from a vendor bundle
   // that is loaded globally on the running webpage
@@ -39,11 +39,11 @@ function normalize(str){
   try{
     // polyfill String.prototype.normalize
     require('unorm');
-  }catch(e){
+  }catch(e) {
     console.error('unorm not available');
   }
 
-  if(!String.prototype.normalize){
+  if(!String.prototype.normalize) {
     return str;
   }
 
@@ -57,7 +57,7 @@ function normalize(str){
  * @param  {String}
  * @returns {String}
  */
-function fold(str){
+function fold(str) {
   return str.replace(COMBINING_MARKS, '');
 }
 

--- a/h/static/scripts/util/string.js
+++ b/h/static/scripts/util/string.js
@@ -9,17 +9,17 @@ const COMBINING_MARKS = /[\u0300-\u036F\u0483-\u0489\u0591-\u05BD\u05BF\u05C1\u0
  * Convert a `camelCase` or `CapitalCase` string to `kebab-case`
  */
 function hyphenate(name) {
-  var uppercasePattern = /([A-Z])/g;
+  const uppercasePattern = /([A-Z])/g;
   return name.replace(uppercasePattern, '-$1').toLowerCase();
 }
 
 /** Convert a `kebab-case` string to `camelCase` */
 function unhyphenate(name) {
-  var idx = name.indexOf('-');
+  const idx = name.indexOf('-');
   if (idx === -1) {
     return name;
   } else {
-    var ch = (name[idx+1] || '').toUpperCase();
+    const ch = (name[idx+1] || '').toUpperCase();
     return unhyphenate(name.slice(0,idx) + ch + name.slice(idx+2));
   }
 }

--- a/h/static/scripts/util/submit-form.js
+++ b/h/static/scripts/util/submit-form.js
@@ -41,7 +41,7 @@ class FormSubmitError extends Error {
  *         request fails.
  */
 function submitForm(formEl, fetch = window.fetch) {
-  var response;
+  let response;
   return fetch(formEl.action, {
     body: new FormData(formEl),
     credentials: 'same-origin',
@@ -53,7 +53,7 @@ function submitForm(formEl, fetch = window.fetch) {
     response = response_;
     return response.text();
   }).then((body) => {
-    var { status } = response;
+    const { status } = response;
     switch (status) {
     case 200:
       return {status, form: body};

--- a/h/static/scripts/util/submit-form.js
+++ b/h/static/scripts/util/submit-form.js
@@ -49,10 +49,10 @@ function submitForm(formEl, fetch = window.fetch) {
     headers: {
       'X-Requested-With': 'XMLHttpRequest',
     },
-  }).then(response_ => {
+  }).then((response_) => {
     response = response_;
     return response.text();
-  }).then(body => {
+  }).then((body) => {
     var { status } = response;
     switch (status) {
     case 200:

--- a/h/static/scripts/util/update-helpers.js
+++ b/h/static/scripts/util/update-helpers.js
@@ -20,7 +20,7 @@ module.exports = {
       return true;
     }
 
-    return !listA.every((item, index)=>{
+    return !listA.every((item, index) => {
       return item === listB[index];
     });
   },

--- a/h/static/scripts/util/update-helpers.js
+++ b/h/static/scripts/util/update-helpers.js
@@ -10,13 +10,13 @@ module.exports = {
    * @returns {bool}       the result of comparing if the two
    *   arrays seem like they have changed. True if they have changed
    */
-  listIsDifferent: function(listA, listB){
+  listIsDifferent: function(listA, listB) {
 
-    if (!(Array.isArray(listA) && Array.isArray(listB))){
+    if (!(Array.isArray(listA) && Array.isArray(listB))) {
       return true;
     }
 
-    if (listA.length !== listB.length){
+    if (listA.length !== listB.length) {
       return true;
     }
 

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "chai": "^3.5.0",
     "check-dependencies": "^0.12.0",
     "diff": "^2.2.2",
-    "eslint": "^3.1.1",
+    "eslint": "^3.9.1",
     "eslint-config-hypothesis": "^1.0.0",
     "fetch-mock": "^5.1.5",
     "gulp-eslint": "^3.0.1",


### PR DESCRIPTION
When the use of ES2015+ was initially enabled in the JS codebase, it was done so without a clear plan for how we would ensure consistent code style. Consequently, we're now mixing arrow and regular functions, let/var/const etc. Additionally, not all of our spacing rules were codified in the lint config.

Since then, I proposed and we've agreed to broadly use the [Airbnb style](https://github.com/airbnb/javascript) as a basis, since it was consistent with our existing style and is very widely used. This PR is a series of commits which fixes these inconsistencies using the same approach that was used for the client repo. The resulting code is much closer to the Airbnb style.

Each commit:

1. Enables an ESLint rule following the appropriate section of the Airbnb guide
2. Uses `eslint --fix h/static/scripts` to fix all violations in the existing codebase

The changes included here are:

1. Consistent spacing around keywords (if/else/function etc.)
2. Consistent spacing before blocks
3. Consistent use of const/let/var (use const everywhere possible, let otherwise)
4. Consistent use of arrow functions (always use them for anonymous functions, parens around the arguments if there is a block, no parens otherwise if the function has just one argument)

In future we'll fold at least the ES5-compatible config changes into the [shared config](https://github.com/hypothesis/frontend-toolkit/tree/master/packages/eslint-config-hypothesis).

When reviewing this, the easiest way is just to go through each commit and look at the commit message plus the first few lines of each diff.