### PR TITLE
Don't lose unsubmitted search query terms

### DIFF
--- a/h/views/activity.py
+++ b/h/views/activity.py
@@ -190,7 +190,7 @@ def group_leave(request):
     if not request.feature('search_page'):
         raise httpexceptions.HTTPNotFound()
 
-    pubid = request.params['group_leave']
+    pubid = request.POST['group_leave']
 
     try:
         group = request.db.query(models.Group).filter_by(pubid=pubid).one()
@@ -201,6 +201,7 @@ def group_leave(request):
     groups_service.member_leave(group, request.authenticated_userid)
 
     new_params = request.POST.copy()
+    del new_params['group_leave']
     location = request.route_url('activity.search', _query=new_params)
 
     return httpexceptions.HTTPSeeOther(location=location)
@@ -250,10 +251,10 @@ def toggle_user_facet(request):
     if not request.feature('search_page'):
         raise httpexceptions.HTTPNotFound()
 
-    userid = request.params['toggle_user_facet']
+    userid = request.POST['toggle_user_facet']
     username = util.user.split_user(userid)['username']
 
-    new_params = request.params.copy()
+    new_params = request.POST.copy()
 
     del new_params['toggle_user_facet']
 
@@ -304,9 +305,9 @@ def toggle_tag_facet(request):
     if not request.feature('search_page'):
         raise httpexceptions.HTTPNotFound()
 
-    tag = request.params['toggle_tag_facet']
+    tag = request.POST['toggle_tag_facet']
 
-    new_params = request.params.copy()
+    new_params = request.POST.copy()
 
     del new_params['toggle_tag_facet']
 
@@ -331,13 +332,13 @@ def toggle_tag_facet(request):
 
 def _parsed_query(request):
     """
-    Return the parsed (MultiDict) query from the given request.
+    Return the parsed (MultiDict) query from the given POST request.
 
     Return a copy of the given search page request's search query, parsed from
     a string into a MultiDict.
 
     """
-    return parser.parse(request.params.get('q', ''))
+    return parser.parse(request.POST.get('q', ''))
 
 
 def _username_facets(request, parsed_query=None):


### PR DESCRIPTION
In some cases unsubmitted search query terms were being lost on page
load. For example, go to the /groups/<pubid>/search page, type "foo"
into the search box but don't submit it yet (so "foo" is in the search
form, but is not yet in the URL), then click on a tag in the sidebar to
add a facet for that tag into the search query.

The page reloads and the tag facet has been added into the query, but
"foo" (and any unsubmitted query terms, whether they had been
"lozengified" by JavaScript or not) has been lost from the query.

The problem is that code is accessing the search query parameter `q`
from request.params, which is the params in the URL. It should be
accessing it from request.POST, which is the params from the HTML form.

In the tests, by default DummyRequest.params and DummyRequest.POST are
**the same object**. So if a test does, for example,
DummyRequest.POST['q'] = 'foo' this will set both DummyRequest.POST['q']
and DummyRequest.params['q'], if it then tests that "foo" is preserved
in the URL that a view function redirects to, this will test will pass
even though the code is incorrectly accessing DummyRequest.params
instead of DummyRequest.POST.

The fix is to set DummyRequest.POST and DummyRequest.params to two
different objects in the tests, so that they can catch this bug.