### PR TITLE
Fix setElementState() in Internet Explorer

### DIFF
--- a/h/static/scripts/util/dom.js
+++ b/h/static/scripts/util/dom.js
@@ -19,7 +19,11 @@ const hyphenate = stringUtil.hyphenate;
 function setElementState(el, state) {
   Object.keys(state).forEach((key) => {
     const stateClass = 'is-' + hyphenate(key);
-    el.classList.toggle(stateClass, !!state[key]);
+    if (state[key]) {
+      el.classList.add(stateClass);
+    } else {
+      el.classList.remove(stateClass);
+    }
   });
 }
 


### PR DESCRIPTION
IE lacks support for the second argument to
`DOMTokenList.prototype.toggle`.

Since this is the only place we use this function, just use {add,
remove} rather than trying to polyfill this API.

See #3953