### PR TITLE
Fix error loading unorm

### DIFF
--- a/h/assets.ini
+++ b/h/assets.ini
@@ -17,13 +17,11 @@ admin_js =
 # The H website
 site_js =
   scripts/raven.bundle.js
+  scripts/unorm.bundle.js
   scripts/site.bundle.js
 
 header_js =
   scripts/header.bundle.js
-
-search_js =
-  scripts/unorm.bundle.js
 
 site_css =
   styles/site.css

--- a/h/static/scripts/polyfills.js
+++ b/h/static/scripts/polyfills.js
@@ -9,6 +9,10 @@ require('core-js/fn/array/includes');
 require('core-js/fn/object/assign');
 require('core-js/fn/string/starts-with');
 
+// String.prototype.normalize()
+// FIXME: This is a large polyfill which should be only loaded when necessary
+require('unorm');
+
 // Element.prototype.dataset, required by IE 10
 require('element-dataset')();
 

--- a/h/static/scripts/util/string.js
+++ b/h/static/scripts/util/string.js
@@ -32,17 +32,6 @@ function unhyphenate(name) {
  * @returns {String}
  */
 function normalize(str) {
-
-  // This require is coming from a vendor bundle
-  // that is loaded globally on the running webpage
-  // not a require in the node context
-  try {
-    // polyfill String.prototype.normalize
-    require('unorm');
-  } catch (e) {
-    console.error('unorm not available');
-  }
-
   if (!String.prototype.normalize) {
     return str;
   }

--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -297,14 +297,10 @@
 
   {{ panel('navbar', opts or {}) }}
 
-  {% for url in asset_urls("search_js") %}
-    <script src="{{ url }}"></script>
-  {% endfor %}
-
   <script class="js-tag-suggestions">
     {{aggregations['tags'] | to_json}}
   </script>
-  
+
   <script class="js-group-suggestions">
     {{groups_suggestions | to_json}}
   </script>


### PR DESCRIPTION
Fix an error when `normalize()` tries to require the 'unorm' bundle on
certain routes. This function is called on every page that displays the
navbar but the bundle was only included on /search routes.

This commit changes unorm to be loaded in the same way as other
polyfills and for the moment, included on every page.

In future we can be smarter and load the polyfill only in browsers that
actually need it, since the majority of our users have browsers which
support String.prototype.normalize() natively.