### PR TITLE
Fix form buttons on "more info" page

### DIFF
--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -5,12 +5,13 @@
 {% macro search_result_nav(name) %}
 {# This <form> is needed for IE because it doesn't support the `form`
    attribute. See commit message. #}
-<form method="POST">
+<form method="POST" action="{{ request.path_url }}">
   <input type="hidden" name="q" value="{{ q }}">
   <nav class="search-result-nav">
     {%- if more_info %}
       <button form="search-bar"
               formmethod="POST"
+              formaction="{{ request.path_url }}"
               name="back"
               class="search-result-nav__button">
         {% trans %}Back{% endtrans %}
@@ -19,6 +20,7 @@
       <h1 class="search-result-nav__title">{{ name }}</h1>
       <button form="search-bar"
               formmethod="POST"
+              formaction="{{ request.path_url }}"
               name="more_info"
               class="search-result-nav__button">
         {% trans %}More info{% endtrans %}
@@ -117,6 +119,7 @@
       <button type="submit"
               form="search-bar"
               formmethod="POST"
+              formaction="{{ request.path_url }}"
               name="toggle_tag_facet"
               value="{{ tag.tag }}"
               class="search-result-sidebar__tag">
@@ -135,7 +138,7 @@
 
   {#- This form element is needed for Internet Explorer because it
       doesn't support the `form` attribute. See commit message. #}
-  <form method="POST">
+  <form method="POST" action="{{ request.path_url }}">
     <input type="hidden" name="q" value="{{ q }}">
 
     <h1 class="search-result-sidebar__title">{{ title }}</h1>
@@ -185,6 +188,7 @@
                   type="submit"
                   form="search-bar"
                   formmethod="POST"
+                  formaction="{{ request.path_url }}"
                   name="group_leave"
                   value="{{ group.pubid }}"
                   data-confirm-message="Are you sure you want to leave the group &quot;{{ group.name }}&quot;?">
@@ -209,6 +213,7 @@
             <button type="submit"
                     form="search-bar"
                     formmethod="POST"
+                    formaction="{{ request.path_url }}"
                     name="toggle_user_facet"
                     value="{{ user.userid }}"
                     {% if user.faceted_by %}


### PR DESCRIPTION
When on the "More info" page (so &more_info is in the URL) various
buttons (usernames for adding a user facet to the search query, tag
names for adding tags into the search query, the leave group button...)
were not working.

The problem is to do with query parameters in the URL and post
parameters in the body of a POST request. When you click on a tag for
example, this does a POST request form submission with `q` (the search
query entered so far) and `toggle_tag_facet` in the post body. BUT
&more_info is in the URL of the current page, so that is also submitted
to the server as a URL query parameter.

Server-side we use Pyramid's request_param view config predicate to
decide which view function to call, and because &more_info is present in
the URL it calls the search_more_info() function instead of
toggle_tag_facet(). Pyramid view config does not distinguish between URL
query params and post body params - there us a single request_param view
predicate and it looks for the named param in either the URL query
string or the post body.

The fix is to remove the URL query string from all of the form submission POSTs
that happen when you click on these buttons. Since we're never
(intentionally) using the URL query, but always want to use the post
body, having the URL query be present is just a hazard.

The query string can be removed by having the server set the `action`
attribute of the forms (or `formaction` in the case of buttons that are
outside of their form).

Fixes #4054.