### PR TITLE
Disable autocapitalization in the navbar search input

### DIFF
--- a/h/templates/panels/navbar.html.jinja2
+++ b/h/templates/panels/navbar.html.jinja2
@@ -50,7 +50,13 @@
             {{ lozenge('group', opts['search_groupname']) }}
           {% endif %}
         </div>
-        <input class="search-bar__input" data-ref="searchBarInput" name="q" value="{{ q }}" placeholder="Search…" autocomplete="off">
+        <input class="search-bar__input"
+               autocapitalize="off"
+               autocomplete="off"
+               data-ref="searchBarInput"
+               name="q"
+               placeholder="Search…"
+               value="{{ q }}">
       </form>
     </div>
 


### PR DESCRIPTION
Search is case insensitive, so autocapitalization is not useful.

See #4080