### PR TITLE
Fix 'Copy to clipboard' link on iOS 10 and improve mobile UX of 'Copy to clipboard' field

### DIFF
--- a/h/static/scripts/controllers/copy-button-controller.js
+++ b/h/static/scripts/controllers/copy-button-controller.js
@@ -7,7 +7,12 @@ class CopyButtonController extends Controller {
     super(element);
 
     this.refs.button.onclick = () => {
-      this.refs.input.select(); // We need to select the text before we copy.
+
+      // Method for selecting <input> text taken from 'select' package.
+      // See https://github.com/zenorocha/select/issues/1 and
+      // http://stackoverflow.com/questions/3272089
+      this.refs.input.focus();
+      this.refs.input.setSelectionRange(0, this.refs.input.value.length);
 
       const notificationText = document.execCommand('copy') ?
         'Link copied to clipboard!' :

--- a/h/static/scripts/controllers/copy-button-controller.js
+++ b/h/static/scripts/controllers/copy-button-controller.js
@@ -2,9 +2,22 @@
 
 const Controller = require('../base/controller');
 
+function isProbablyMobileSafari(userAgent) {
+  return /\bMobile\b/.test(userAgent) && /\bSafari\b/.test(userAgent);
+}
+
 class CopyButtonController extends Controller {
-  constructor(element) {
-    super(element);
+  constructor(element, options = {}) {
+    super(element, options);
+
+    const userAgent = options.userAgent || navigator.userAgent;
+
+    // Make the input field read-only to avoid the user accidentally modifying
+    // the link before copying it.
+    //
+    // An exception is made for Mobile Safari because selecting the contents of
+    // a read-only input field is hard in that browser.
+    this.refs.input.readOnly = !isProbablyMobileSafari(userAgent);
 
     this.refs.button.onclick = () => {
 

--- a/h/static/scripts/tests/controllers/copy-button-controller-test.js
+++ b/h/static/scripts/tests/controllers/copy-button-controller-test.js
@@ -1,0 +1,51 @@
+'use strict';
+
+const CopyButtonController = require('../../controllers/copy-button-controller');
+const { setupComponent } = require('./util');
+
+describe('CopyButtonController', () => {
+  const template = `<div>
+    <input data-ref="input">
+    <button data-ref="button"></button>
+  </div>`;
+
+  let copiedText;
+  let copySuccess;
+  let ctrl;
+
+  beforeEach(() => {
+    copySuccess = false;
+    copiedText = '';
+    sinon.stub(document, 'execCommand', (command) => {
+      if (command === 'copy') {
+        copiedText = document.getSelection().toString();
+        return copySuccess;
+      }
+      return false;
+    });
+    ctrl = setupComponent(document, template, CopyButtonController);
+    ctrl.refs.input.value = 'Text to copy';
+  });
+
+  afterEach(() => {
+    document.execCommand.restore();
+  });
+
+  it('copies text when button is clicked', () => {
+    copySuccess = true;
+    ctrl.refs.button.click();
+    assert.equal(copiedText, 'Text to copy');
+  });
+
+  it('displays success message if text was copied', () => {
+    copySuccess = true;
+    ctrl.refs.button.click();
+    assert.include(ctrl.refs.input.value, 'Link copied');
+  });
+
+  it('displays alternative message if text was not copied', () => {
+    copySuccess = false;
+    ctrl.refs.button.click();
+    assert.include(ctrl.refs.input.value, 'Copying link failed');
+  });
+});

--- a/h/static/scripts/tests/controllers/copy-button-controller-test.js
+++ b/h/static/scripts/tests/controllers/copy-button-controller-test.js
@@ -48,4 +48,16 @@ describe('CopyButtonController', () => {
     ctrl.refs.button.click();
     assert.include(ctrl.refs.input.value, 'Copying link failed');
   });
+
+  it('makes the input field read-only', () => {
+    assert.isTrue(ctrl.refs.input.readOnly);
+  });
+
+  it('leaves the input field read-write on Mobile Safari', () => {
+    const mobileSafariUserAgent = 'Mozilla/5.0 (iPhone; CPU iPhone OS 10_0 like Mac OS X) AppleWebKit/602.1.38 (KHTML, like Gecko) Version/10.0 Mobile/14A5297c Safari/602.1';
+    ctrl = setupComponent(document, template, CopyButtonController, {
+      userAgent: mobileSafariUserAgent,
+    });
+    assert.isFalse(ctrl.refs.input.readOnly);
+  });
 });

--- a/h/static/styles/partials-v2/_group-invite.scss
+++ b/h/static/styles/partials-v2/_group-invite.scss
@@ -9,22 +9,16 @@
 }
 
 .group-invite__input {
-  padding: 5px;
-  padding-top: 0;
   padding-bottom: 0;
+  padding-left: 5px;
+  padding-right: 22px;  /* Make space for the clipboard icon. */
+  padding-top: 0;
   margin-top: 12px;
   margin-bottom: 8px;
   border: 1px solid $grey-3;
   border-radius: 2px;
   width: 100%;
   height: 31px;
-
-  .env-js-capable & {
-    padding-right: 22px;  /* Make space for the clipboard icon. */
-  }
-  .env-js-timeout & {
-    padding-right: 3px;
-  }
 }
 
 .group-invite__clipboard-button {
@@ -62,4 +56,20 @@
 
 .group-invite__clipboard-button:hover > .group-invite__clipboard-image {
   fill: $grey-7;
+}
+
+// On mobile, increase the size of the 'Copy to clipboard' button to make it
+// easier to tap.
+@include touch-input {
+  .group-invite__input {
+    font-size: $touch-input-font-size;
+  }
+
+  .group-invite__input {
+    padding-right: $touch-target-size;
+  }
+
+  .group-invite__clipboard-button {
+    width: $touch-target-size;
+  }
 }

--- a/h/templates/panels/group_invite.html.jinja2
+++ b/h/templates/panels/group_invite.html.jinja2
@@ -5,8 +5,7 @@ Sharing the link below lets people join this group:
 <div class="group-invite__container js-copy-button">
   <input class="group-invite__input js-select-onfocus"
          data-ref="input"
-         value="{{ group_url }}"
-         readonly>
+         value="{{ group_url }}">
   <button class="group-invite__clipboard-button"
           data-ref="button"
           title="Copy to clipboard">


### PR DESCRIPTION
This fixes several usability issues with the group link on iOS:

1. The "Copy" button did not work because `HTMLInputElement.prototype.select()` does not work properly on iOS (See first commit)
2. The field had several mobile UX issues - the copy button was too small and the font size of the input was also too small (See second commit)
3. Copying text from a read-only input field, in the event that the "Copy" button fails to work (iOS < 10), is hard in Mobile Safari. Therefore I made the field read-write in Mobile Safari.

Fixes #4049 