### PR TITLE
Autofocus search input when user types a letter, number or backspace

### DIFF
--- a/h/static/scripts/controllers/input-autofocus-controller.js
+++ b/h/static/scripts/controllers/input-autofocus-controller.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const Controller = require('../base/controller');
+
+function isWordChar(event) {
+  return event.key.match(/^\w$/) && !event.ctrlKey && !event.altKey;
+}
+
+/**
+ * Automatically focuses an input field when the user presses a letter, number
+ * or backspace if no other element on the page has keyboard focus. The field's
+ * focus can also be blurred by pressing Escape.
+ *
+ * This provides behavior similar to Google.com where the user can "type" in the
+ * search box even if it is not focused.
+ */
+class InputAutofocusController extends Controller {
+  constructor(element) {
+    super(element);
+
+    this._onKeyDown = (event) => {
+      if (document.activeElement === document.body) {
+        if (isWordChar(event) || event.key === 'Backspace') {
+          element.focus();
+        }
+      } else if (document.activeElement === element && event.key === 'Escape') {
+        element.blur();
+      }
+    };
+
+    document.addEventListener('keydown', this._onKeyDown);
+  }
+
+  beforeRemove() {
+    document.removeEventListener('keydown', this._onKeyDown);
+  }
+}
+
+module.exports = InputAutofocusController;

--- a/h/static/scripts/polyfills.js
+++ b/h/static/scripts/polyfills.js
@@ -24,6 +24,10 @@ try {
   require('js-polyfills/url');
 }
 
+// KeyboardEvent.prototype.key
+// (Native in Chrome >= 51, Firefox >= 23, IE >= 9)
+require('keyboardevent-key-polyfill');
+
 // Fetch API
 // https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API
 require('whatwg-fetch');

--- a/h/static/scripts/site.js
+++ b/h/static/scripts/site.js
@@ -15,6 +15,7 @@ const CreateGroupFormController = require('./controllers/create-group-form-contr
 const DropdownMenuController = require('./controllers/dropdown-menu-controller');
 const FormController = require('./controllers/form-controller');
 const FormSelectOnFocusController = require('./controllers/form-select-onfocus-controller');
+const InputAutofocusController = require('./controllers/input-autofocus-controller');
 const SearchBarController = require('./controllers/search-bar-controller');
 const SearchBucketController = require('./controllers/search-bucket-controller');
 const SignupFormController = require('./controllers/signup-form-controller');
@@ -28,6 +29,7 @@ const controllers = {
   '.js-create-group-form': CreateGroupFormController,
   '.js-dropdown-menu': DropdownMenuController,
   '.js-form': FormController,
+  '.js-input-autofocus': InputAutofocusController,
   '.js-select-onfocus': FormSelectOnFocusController,
   '.js-search-bar': SearchBarController,
   '.js-search-bucket': SearchBucketController,

--- a/h/static/scripts/tests/controllers/input-autofocus-controller-test.js
+++ b/h/static/scripts/tests/controllers/input-autofocus-controller-test.js
@@ -1,0 +1,93 @@
+'use strict';
+
+const InputAutofocusController = require('../../controllers/input-autofocus-controller');
+const { setupComponent } = require('./util');
+
+/**
+ * Send a 'keydown' event to the active element.
+ *
+ * @param {string} key - The key name value for the KeyboardEvent#key property.
+ * @param {object} opts - Options for the keyboard event
+ */
+function sendKey(key, opts = {}) {
+  // Note: PhantomJS 2.x does not support the KeyboardEvent constructor
+  const event = new Event('keydown', {bubbles: true});
+  event.key = key;
+  Object.assign(event, opts);
+  document.activeElement.dispatchEvent(event);
+}
+
+describe('InputAutofocusController', () => {
+  let ctrl;
+  let otherInput;
+
+  before(() => {
+    otherInput = document.createElement('input');
+    document.body.appendChild(otherInput);
+  });
+
+  after(() => {
+    otherInput.remove();
+  });
+
+  beforeEach(() => {
+    const template = '<input>';
+    ctrl = setupComponent(document, template, InputAutofocusController);
+  });
+
+  afterEach(() => {
+    ctrl.beforeRemove();
+  });
+
+  context('when no other element has focus', () => {
+    beforeEach(() => {
+      if (document.activeElement !== document.body) {
+        document.activeElement.blur();
+        assert.equal(document.activeElement, document.body);
+      }
+    });
+
+    it('should focus the input if a letter key is pressed', () => {
+      sendKey('a');
+      assert.equal(document.activeElement, ctrl.element);
+    });
+
+    it('should focus the input if Backspace is pressed', () => {
+      sendKey('Backspace');
+      assert.equal(document.activeElement, ctrl.element);
+    });
+
+    it('should not focus the input if a non-letter key is pressed', () => {
+      sendKey('Enter');
+      assert.notEqual(document.activeElement, ctrl.element);
+    });
+
+    it('should not focus the input if a letter key is pressed with a modifier', () => {
+      sendKey('a', {ctrlKey: true});
+      sendKey('b', {altKey: true});
+      assert.notEqual(document.activeElement, ctrl.element);
+    });
+  });
+
+  context('when another element has focus', () => {
+    beforeEach(() => {
+      otherInput.focus();
+    });
+
+    it('should not focus the input if a letter key is pressed', () => {
+      sendKey('a');
+      assert.notEqual(document.activeElement, ctrl.element);
+    });
+  });
+
+  context('when the input has focus', () => {
+    beforeEach(() => {
+      ctrl.element.focus();
+    });
+
+    it('should blur the input if the Escape key is pressed', () => {
+      sendKey('Escape');
+      assert.notEqual(document.activeElement, ctrl.element);
+    });
+  });
+});

--- a/h/templates/panels/navbar.html.jinja2
+++ b/h/templates/panels/navbar.html.jinja2
@@ -50,7 +50,7 @@
             {{ lozenge('group', opts['search_groupname']) }}
           {% endif %}
         </div>
-        <input class="search-bar__input"
+        <input class="search-bar__input js-input-autofocus"
                autocapitalize="off"
                autocomplete="off"
                data-ref="searchBarInput"

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "is-equal-shallow": "^0.1.3",
     "jquery": "1.11.1",
     "js-polyfills": "^0.1.16",
+    "keyboardevent-key-polyfill": "^1.0.2",
     "mkdirp": "^0.5.1",
     "node-sass": "^3.8.0",
     "postcss": "^5.0.6",


### PR DESCRIPTION
Copy the behavior seen on Google.com where the search field is
autofocused when the user types an alphanumeric character or presses
Backspace, if no other input on the page has focus.

This allows the user to start typing a search query as soon as the page loads
without having to focus the input field first.

The reason for doing this over just automatically focusing the search input on page load is to avoid obscuring the top results on the page with the autosuggest box which is shown when the search input gains focus.