### PR TITLE
Instrument elasticsearch queries to statsd

### DIFF
--- a/h/activity/query.py
+++ b/h/activity/query.py
@@ -157,7 +157,7 @@ def fetch_annotations(session, ids, reply_ids):
 
 @newrelic.agent.function_trace()
 def _execute_search(request, query, page_size):
-    search = Search(request, separate_replies=True)
+    search = Search(request, separate_replies=True, stats=request.stats)
     for agg in aggregations_for(query):
         search.append_aggregation(agg)
 

--- a/h/views/badge.py
+++ b/h/views/badge.py
@@ -29,6 +29,6 @@ def badge(request):
         return {'total': 0}
 
     query = {'uri': uri, 'limit': 0}
-    result = search.Search(request).run(query)
+    result = search.Search(request, stats=request.stats).run(query)
 
     return {'total': result.total}

--- a/h/views/feeds.py
+++ b/h/views/feeds.py
@@ -15,7 +15,7 @@ _ = i18n.TranslationStringFactory(__package__)
 
 def _annotations(request):
     """Return the annotations from the search API."""
-    result = search.Search(request).run(request.params)
+    result = search.Search(request, stats=request.stats).run(request.params)
     return fetch_ordered_annotations(request.db, result.annotation_ids)
 
 

--- a/src/memex/views.py
+++ b/src/memex/views.py
@@ -145,8 +145,10 @@ def search(request):
     params = request.params.copy()
 
     separate_replies = params.pop('_separate_replies', False)
-    result = search_lib.Search(request, separate_replies=separate_replies) \
-        .run(params)
+    stats = getattr(request, 'stats', None)
+    result = search_lib.Search(request,
+                               separate_replies=separate_replies,
+                               stats=stats).run(params)
 
     out = {
         'total': result.total,

--- a/tests/h/activity/query_test.py
+++ b/tests/h/activity/query_test.py
@@ -165,9 +165,12 @@ class TestExecute(object):
     PAGE_SIZE = 23
 
     def test_it_creates_a_search_query(self, pyramid_request, Search):
+        pyramid_request.stats = mock.Mock()
         execute(pyramid_request, MultiDict(), self.PAGE_SIZE)
 
-        Search.assert_called_once_with(pyramid_request, separate_replies=True)
+        Search.assert_called_once_with(pyramid_request,
+                                       separate_replies=True,
+                                       stats=pyramid_request.stats)
 
     def test_it_adds_a_tags_aggregation_to_the_search_query(self,
                                                             pyramid_request,
@@ -494,6 +497,11 @@ class TestExecute(object):
     @pytest.fixture
     def UsersAggregation(self, patch):
         return patch('h.activity.query.UsersAggregation')
+
+    @pytest.fixture
+    def pyramid_request(self, pyramid_request):
+        pyramid_request.stats = None
+        return pyramid_request
 
 
 class TestFetchAnnotations(object):

--- a/tests/h/views/feeds_test.py
+++ b/tests/h/views/feeds_test.py
@@ -60,6 +60,12 @@ def fetch_ordered_annotations(patch):
 
 
 @pytest.fixture
+def pyramid_request(pyramid_request):
+    pyramid_request.stats = None
+    return pyramid_request
+
+
+@pytest.fixture
 def pyramid_settings(pyramid_settings):
     settings = {}
     settings.update(pyramid_settings)

--- a/tests/memex/views_test.py
+++ b/tests/memex/views_test.py
@@ -111,10 +111,14 @@ class TestIndex(object):
 class TestSearch(object):
 
     def test_it_searches(self, pyramid_request, search_lib):
+        pyramid_request.stats = mock.Mock()
+
         views.search(pyramid_request)
 
         search = search_lib.Search.return_value
-        search_lib.Search.assert_called_with(pyramid_request, separate_replies=False)
+        search_lib.Search.assert_called_with(pyramid_request,
+                                             separate_replies=False,
+                                             stats=pyramid_request.stats)
         search.run.assert_called_once_with(pyramid_request.params)
 
     def test_it_loads_annotations_from_database(self, pyramid_request, search_run, storage):


### PR DESCRIPTION
We have two functions that send a request to ElasticSearch, this commit
adds an optional instrumentation code path to these two functions. When
the Search client gets initialized with a stats client, then we'll time
how long it takes the request to finish, and also add counters for
successful, timed-out, and errored search queries.

These new metrics are:

* `memex.search.query` (in graphite as `stats.$host.timers.memex.search.query`)
* `memex.search.query.success` (in graphite as `stats.$host.counters.memex.search.query.success`)
* `memex.search.query.timeout` (in graphite as `stats.$host.counters.memex.search.query.timeout`)
* `memex.search.query.error` (in graphite as `stats.$host.counters.memex.search.query.error`)