### PR TITLE
Make document links in URL buckets clickable

### DIFF
--- a/h/activity/bucketing.py
+++ b/h/activity/bucketing.py
@@ -10,6 +10,7 @@ import newrelic.agent
 from pyramid import i18n
 
 from h._compat import urlparse
+from h import links
 from h import presenters
 
 
@@ -40,6 +41,19 @@ class DocumentBucket(object):
     @property
     def annotations_count(self):
         return len(self.annotations)
+
+    def incontext_link(self, request):
+        """
+        Return a link to view this bucket's annotations in context.
+
+        The bouncer service and Hypothesis client do not currently provide
+        direct links to view a document's annotations without specifying a
+        specific annotation, so here we just link to the first annotation in the
+        document.
+        """
+        if len(self.annotations) == 0:
+            return None
+        return links.incontext_link(request, self.annotations[0])
 
     def append(self, annotation):
         self.annotations.append(annotation)

--- a/h/activity/query.py
+++ b/h/activity/query.py
@@ -123,11 +123,12 @@ def execute(request, query, page_size):
     # Add group information to buckets and present annotations
     for timeframe in result.timeframes:
         for bucket in timeframe.document_buckets.values():
-            for index, annotation in enumerate(bucket.annotations):
-                bucket.annotations[index] = {
+            bucket.presented_annotations = []
+            for annotation in bucket.annotations:
+                bucket.presented_annotations.append({
                     'annotation': presenters.AnnotationHTMLPresenter(annotation),
                     'group': groups.get(annotation.groupid)
-                }
+                })
 
     return result
 

--- a/h/links.py
+++ b/h/links.py
@@ -5,7 +5,23 @@ Provides links to different representations of annotations.
 """
 
 
-from h._compat import urlparse
+from h._compat import urlparse, url_unquote
+
+
+def pretty_link(url):
+    """
+    Return a nicely formatted version of a URL.
+
+    This strips off 'visual noise' from the URL including common schemes
+    (HTTP, HTTPS), domain prefixes ('www.') and query strings.
+    """
+    parsed = urlparse.urlparse(url)
+    if parsed.scheme not in ['http', 'https']:
+        return url
+    netloc = parsed.netloc
+    if netloc.startswith('www.'):
+        netloc = netloc[4:]
+    return url_unquote(netloc + parsed.path)
 
 
 def html_link(request, annotation):

--- a/h/presenters.py
+++ b/h/presenters.py
@@ -7,6 +7,7 @@ from dateutil import parser
 import jinja2
 
 from h._compat import text_type
+from h.links import incontext_link
 
 
 def _format_document_link(href, title, link_text, host_or_filename):
@@ -131,6 +132,10 @@ class AnnotationHTMLPresenter(object):
             return self.document.link
         else:
             return ''
+
+    def incontext_link(self, request):
+        """Return a link to view this annotation in context."""
+        return incontext_link(request, self.annotation)
 
     @property
     def filename(self):

--- a/h/presenters.py
+++ b/h/presenters.py
@@ -7,7 +7,6 @@ from dateutil import parser
 import jinja2
 
 from h._compat import text_type
-from h.links import incontext_link
 
 
 def _format_document_link(href, title, link_text, host_or_filename):
@@ -132,10 +131,6 @@ class AnnotationHTMLPresenter(object):
             return self.document.link
         else:
             return ''
-
-    def incontext_link(self, request):
-        """Return a link to view this annotation in context."""
-        return incontext_link(request, self.annotation)
 
     @property
     def filename(self):

--- a/h/static/images/icons/up-right-arrow.svg
+++ b/h/static/images/icons/up-right-arrow.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="11px" height="11px" viewBox="0 0 11 11" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 41 (35326) - http://www.bohemiancoding.com/sketch -->
+    <title>Artboard</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Artboard" fill="currentColor">
+            <path d="M7.58578644,2 L4,2 L4,0 L9.99707067,0 C10.2745102,0 10.5256382,0.111357782 10.707208,0.292404446 C10.8876843,0.46880727 11,0.719917532 11,1.00292933 L11,7 L9,7 L9,3.41421356 L1.70710678,10.7071068 L0.292893219,9.29289322 L7.58578644,2 L7.58578644,2 Z" id="Combined-Shape"></path>
+        </g>
+    </g>
+</svg>

--- a/h/static/scripts/controllers/search-bucket-controller.js
+++ b/h/static/scripts/controllers/search-bucket-controller.js
@@ -26,7 +26,10 @@ class SearchBucketController extends Controller {
 
     this.scrollTo = this.options.scrollTo || scrollIntoView;
 
-    this.refs.header.addEventListener('click', () => {
+    this.refs.header.addEventListener('click', (event) => {
+      if (this.refs.domainLink.contains(event.target)) {
+        return;
+      }
       this.setState({expanded: !this.state.expanded});
     });
 

--- a/h/static/scripts/tests/controllers/search-bucket-controller-test.js
+++ b/h/static/scripts/tests/controllers/search-bucket-controller-test.js
@@ -3,12 +3,13 @@
 const SearchBucketController = require('../../controllers/search-bucket-controller');
 const util = require('./util');
 
-const TEMPLATE = [
-  '<div class="js-search-bucket">',
-  '<div data-ref="header"></div>',
-  '<div data-ref="content"></div>',
-  '</div>',
-].join('\n');
+const TEMPLATE = `<div class="js-search-bucket">
+  <div data-ref="header">
+    <a data-ref="domainLink">foo.com</a>
+  </div>
+  <div data-ref="content"></div>
+</div>
+`;
 
 class FakeEnvFlags {
   constructor (flags = []) {
@@ -40,6 +41,11 @@ describe('SearchBucketController', () => {
   it('adds the is-expanded CSS class when clicked', () => {
     ctrl.refs.header.dispatchEvent(new Event('click'));
     assert.isTrue(ctrl.refs.content.classList.contains('is-expanded'));
+  });
+
+  it('does not expand when domain link is clicked', () => {
+    ctrl.refs.domainLink.dispatchEvent(new Event('click', {bubbles: true}));
+    assert.isFalse(ctrl.refs.content.classList.contains('is-expanded'));
   });
 
   it('removes the is-expanded CSS class when clicked again', () => {

--- a/h/static/styles/partials-v2/_search.scss
+++ b/h/static/styles/partials-v2/_search.scss
@@ -84,6 +84,11 @@
 
   cursor: pointer;
   user-select: none;
+
+  // The in-context arrow icon is hidden until the bucket header is hovered
+  &:hover .search-result-bucket__incontext-icon {
+    visibility: visible;
+  }
 }
 
 .search-result-bucket__domain {
@@ -93,6 +98,21 @@
   color: $grey-4;
   margin-right: 10px;
   word-wrap: break-word;
+}
+
+.search-result-bucket__domain-link {
+  color: inherit;
+  &:visited {
+    color: inherit;
+  }
+}
+
+.search-result-bucket__incontext-icon {
+  // The in-context arrow icon is hidden until the bucket header is hovered
+  visibility: hidden;
+  width: 9px;
+  height: 9px;
+  color: $grey-4;
 }
 
 .search-result-bucket__title-and-annotations-count {

--- a/h/static/styles/partials-v2/_search.scss
+++ b/h/static/styles/partials-v2/_search.scss
@@ -169,7 +169,9 @@
 }
 
 .search-bucket-stats__key {
-  color: $grey-4;
+  margin-bottom: 2px;
+  color: $grey-6;
+  font-weight: bold;
 }
 
 .search-bucket-stats__val {
@@ -177,9 +179,21 @@
   margin-bottom: 20px;
 }
 
-.search-bucket-stats__address,
+.search-bucket-stats__url,
 .search-bucket-stats__username {
   word-break: break-all;
+}
+
+.search-bucket-stats__link {
+  color: $grey-6;
+  &:visited {
+    color: $grey-6;
+  }
+}
+
+.search-bucket-stats__alt-link {
+  color: $grey-5;
+  font-style: italic;
 }
 
 // On large tablets and below, display bucket titles beneath rather than

--- a/h/static/styles/partials-v2/_search.scss
+++ b/h/static/styles/partials-v2/_search.scss
@@ -100,6 +100,13 @@
   word-wrap: break-word;
 }
 
+// The domain name in the bucket header is a clickable link on the left-hand
+// side in desktop layouts. On smaller screens it spans the full width of the
+// header and becomes plain text to avoid accidental clicks.
+.search-result-bucket__domain-text {
+  display: none;
+}
+
 .search-result-bucket__domain-link {
   color: inherit;
   &:visited {
@@ -239,6 +246,16 @@
 
     .search-result-bucket__domain {
       width: 100%;
+    }
+
+    // Make domain plain text rather than a link to avoid the user accidentally
+    // clicking it
+    .search-result-bucket__domain-text {
+      display: inline;
+    }
+
+    .search-result-bucket__domain-link {
+      display: none;
     }
 
     .search-result-bucket__content {

--- a/h/static/styles/partials-v2/_search.scss
+++ b/h/static/styles/partials-v2/_search.scss
@@ -191,9 +191,19 @@
   }
 }
 
-.search-bucket-stats__alt-link {
-  color: $grey-5;
-  font-style: italic;
+.search-bucket-stats__incontext-link {
+  display: block;
+  margin-top: 5px;
+
+  color: $grey-6;
+  font-weight: bold;
+}
+
+.search-bucket-stats__incontext-icon {
+  position: relative;
+  top: 1px;
+  height: 9px;
+  width: 9px;
 }
 
 // On large tablets and below, display bucket titles beneath rather than

--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -43,8 +43,11 @@
                 href="{{ bucket.uri }}">{{ pretty_link(bucket.uri) }}</a></div>
         {% if bucket_incontext_link %}
         <div>
-          <a class="search-bucket-stats__alt-link"
-             href="{{ bucket_incontext_link }}">Visit annotations in context</a>
+          <a class="search-bucket-stats__incontext-link"
+             href="{{ bucket_incontext_link }}"
+             target="_blank">
+             Visit annotations in context {{ svg_icon('up-right-arrow', css_class='search-bucket-stats__incontext-icon') }}
+           </a>
         </div>
         {% endif %}
     </div>

--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -88,7 +88,8 @@
       <a class="search-result-bucket__domain-link"
          href="{{ bucket.incontext_link(request) }}"
          title="Visit annotations in context"
-         target="_blank">
+         target="_blank"
+         data-ref="domainLink">
          {{ bucket.domain }}
          {{ svg_icon('up-right-arrow', css_class='search-result-bucket__incontext-icon') }}</a>
     </div>

--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -84,6 +84,7 @@
      clicked #}
   <div class="search-result-bucket__header" data-ref="header">
     <div class="search-result-bucket__domain">
+      <span class="search-result-bucket__domain-text">{{ bucket.domain }}</span>
       <a class="search-result-bucket__domain-link"
          href="{{ bucket.incontext_link(request) }}"
          title="Visit annotations in context"

--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -84,7 +84,12 @@
      clicked #}
   <div class="search-result-bucket__header" data-ref="header">
     <div class="search-result-bucket__domain">
-      {{ bucket.domain }}
+      <a class="search-result-bucket__domain-link"
+         href="{{ bucket.incontext_link(request) }}"
+         title="Visit annotations in context"
+         target="_blank">
+         {{ bucket.domain }}
+         {{ svg_icon('up-right-arrow', css_class='search-result-bucket__incontext-icon') }}</a>
     </div>
     <div class="search-result-bucket__title-and-annotations-count">
         <div class="search-result-bucket__title">

--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -40,7 +40,7 @@
     </div>
     <div class="search-bucket-stats__val search-bucket-stats__url">
         <div><a class="search-bucket-stats__link"
-                href="{{ bucket.uri }}">{{ bucket.uri }}</a></div>
+                href="{{ bucket.uri }}">{{ pretty_link(bucket.uri) }}</a></div>
         {% if bucket_incontext_link %}
         <div>
           <a class="search-bucket-stats__alt-link"
@@ -272,7 +272,7 @@
           </dt>
           <dd class="search-result-sidebar__dd">
             <a href="{{ user.uri }}" class="search-result-sidebar__user-link">
-              {{ user.domain }}
+              {{ pretty_link(user.uri) }}
             </a>
           </dd>
         {% endif -%}

--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -32,7 +32,6 @@
 
 {# Card displaying statistics about a bucket of annotations. #}
 {% macro search_bucket_stats(bucket) %}
-{% set bucket_incontext_link = bucket.annotations[0].annotation.incontext_link(request) %}
 <div class="search-bucket-stats">
   {% if bucket.uri %}
     <div class="search-bucket-stats__key">
@@ -41,10 +40,10 @@
     <div class="search-bucket-stats__val search-bucket-stats__url">
         <div><a class="search-bucket-stats__link"
                 href="{{ bucket.uri }}">{{ pretty_link(bucket.uri) }}</a></div>
-        {% if bucket_incontext_link %}
+        {% if bucket.incontext_link(request) %}
         <div>
           <a class="search-bucket-stats__incontext-link"
-             href="{{ bucket_incontext_link }}"
+             href="{{ bucket.incontext_link(request) }}"
              target="_blank">
              Visit annotations in context {{ svg_icon('up-right-arrow', css_class='search-bucket-stats__incontext-icon') }}
            </a>
@@ -107,7 +106,7 @@
   <div class="search-result-bucket__content">
     <div class="search-result-bucket__annotation-cards-container" data-ref="content">
       <ol class="search-result-bucket__annotation-cards">
-        {% for result in bucket.annotations %}
+        {% for result in bucket.presented_annotations %}
           {{ annotation_card(result.annotation, request, result.group) }}
         {% endfor %}
       </ol>

--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -32,13 +32,21 @@
 
 {# Card displaying statistics about a bucket of annotations. #}
 {% macro search_bucket_stats(bucket) %}
+{% set bucket_incontext_link = bucket.annotations[0].annotation.incontext_link(request) %}
 <div class="search-bucket-stats">
   {% if bucket.uri %}
     <div class="search-bucket-stats__key">
-        Address
+        URL
     </div>
-    <div class="search-bucket-stats__val search-bucket-stats__address">
-        {{ bucket.uri }}
+    <div class="search-bucket-stats__val search-bucket-stats__url">
+        <div><a class="search-bucket-stats__link"
+                href="{{ bucket.uri }}">{{ bucket.uri }}</a></div>
+        {% if bucket_incontext_link %}
+        <div>
+          <a class="search-bucket-stats__alt-link"
+             href="{{ bucket_incontext_link }}">Visit annotations in context</a>
+        </div>
+        {% endif %}
     </div>
   {% endif %}
   {% if bucket.tags %}

--- a/h/views/activity.py
+++ b/h/views/activity.py
@@ -13,6 +13,7 @@ from memex.search import parser
 
 from h import models
 from h.activity import query
+from h.links import pretty_link
 from h.paginator import paginate
 from h import util
 
@@ -54,12 +55,14 @@ def search(request):
                 'name': group.name,
                 'pubid': group.pubid
                 })
+
     return {
         'total': result.total,
         'aggregations': result.aggregations,
         'groups_suggestions': groups_suggestions,
         'timeframes': result.timeframes,
         'page': paginate(request, result.total, page_size=page_size),
+        'pretty_link': pretty_link,
         'q': request.params.get('q', ''),
     }
 

--- a/tests/h/activity/bucketing_test.py
+++ b/tests/h/activity/bucketing_test.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 
 import datetime
 import pytest
+from mock import Mock
 
 from h.activity import bucketing
 from tests.common import factories
@@ -178,6 +179,22 @@ class TestDocumentBucket(object):
         bucket_2.title = 'Second Title'
 
         assert not bucket_1 == bucket_2
+
+    def test_incontext_link_returns_link_to_first_annotation(self, document, patch):
+        incontext_link = patch('h.links.incontext_link')
+        bucket = bucketing.DocumentBucket(document)
+        ann = factories.Annotation()
+        bucket.append(ann)
+        request = Mock()
+
+        assert bucket.incontext_link(request) == incontext_link.return_value
+
+    def test_incontext_link_returns_none_if_bucket_empty(self, document, patch):
+        incontext_link = patch('h.links.incontext_link')
+        bucket = bucketing.DocumentBucket(document)
+        request = Mock()
+
+        assert bucket.incontext_link(request) == None
 
     @pytest.fixture
     def document(self, db_session):

--- a/tests/h/activity/query_test.py
+++ b/tests/h/activity/query_test.py
@@ -335,7 +335,7 @@ class TestExecute(object):
         presented_annotations = []
         for timeframe in result.timeframes:
             for bucket in timeframe.document_buckets.values():
-                presented_annotations.extend(bucket.annotations)
+                presented_annotations.extend(bucket.presented_annotations)
 
         for annotation in annotations:
             for presented_annotation in presented_annotations:
@@ -354,7 +354,7 @@ class TestExecute(object):
         presented_annotations = []
         for timeframe in result.timeframes:
             for bucket in timeframe.document_buckets.values():
-                presented_annotations.extend(bucket.annotations)
+                presented_annotations.extend(bucket.presented_annotations)
 
         for group in _fetch_groups.return_value:
             for presented_annotation in presented_annotations:
@@ -442,7 +442,8 @@ class TestExecute(object):
         """
         def document_bucket(annotations):
             """Return a mock document bucket like the ones bucket() returns."""
-            return mock.Mock(spec_set=['annotations'], annotations=annotations)
+            return mock.Mock(spec_set=['annotations', 'presented_annotations'],
+                annotations=annotations)
 
         return [
             document_bucket(annotations[:3]),

--- a/tests/h/links_test.py
+++ b/tests/h/links_test.py
@@ -76,6 +76,22 @@ def test_incontext_link_skips_uri_for_pdfs_with_no_document(pyramid_request):
     assert link == 'https://hyp.is/123'
 
 
+@pytest.mark.parametrize('uri,formatted', [
+    ('http://notsecure.com', 'notsecure.com'),
+    ('https://secure.com', 'secure.com'),
+    ('ftp://not_http', 'ftp://not_http'),
+    ('http://www.google.com', 'google.com'),
+    ('http://site.com/with-a-path', 'site.com/with-a-path'),
+    ('https://site.com/with-a-path?q=and-a-query-string', 'site.com/with-a-path'),
+    ('http://site.com/path%20with%20spaces','site.com/path with spaces'),
+    ('', ''),
+    ('site.com/no-scheme', 'site.com/no-scheme'),
+    ('does not look like a URL', 'does not look like a URL'),
+])
+def test_pretty_link(uri, formatted):
+    assert links.pretty_link(uri) == formatted
+
+
 @pytest.fixture
 def pyramid_settings(pyramid_settings):
     pyramid_settings.update({


### PR DESCRIPTION
This implements the document links as shown in the "URLs" section of the bucket in the mocks at https://projects.invisionapp.com/share/B88RCLRFN#/screens

For each bucket, there are two links at the top:
- A prettified version of the URL which goes to the URL without the Hypothesis overlay activated
- A "Visit annotations in context" link which is a direct link to the first annotation in the bucket. When the user lands on that URL, they can click "Show all annotations" to see the rest of the annotations from that bucket

If the user happens to be looking at a specific group, then this will result in the overlay automatically switching to the appropriate group.

The implementation here changes the label from "Address" to "URLs" as in the mock and tweaks the presentation of the section labels in the bucket sidebar, but does not currently include the icons.

Fixes #4058 

![bucket-url-links](https://cloud.githubusercontent.com/assets/2458/20396327/ba07819a-acdd-11e6-987b-34fb1c648ded.png)
