### PR TITLE
Make tags and annotator names in the bucket sidebar links

### DIFF
--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -57,7 +57,8 @@
     </div>
     <ul class="search-bucket-stats__val">
       {% for tag in bucket.tags %}
-        <li>{{ tag }}</li>
+        <li><a class="search-bucket-stats__link"
+               href="{{ tag_link(tag) }}">{{ tag }}</a></li>
       {% endfor %}
     </ul>
   {% endif %}
@@ -67,7 +68,8 @@
   <ul class="search-bucket-stats__val">
     {% for user in bucket.users %}
       <li class="search-bucket-stats__username">
-        {{ user.split(':')[1].split('@')[0] }}
+        <a class="search-bucket-stats__link"
+           href="{{ user_link(user) }}">{{ username_from_id(user) }}</a>
       </li>
     {% endfor %}
   </ul>

--- a/h/views/activity.py
+++ b/h/views/activity.py
@@ -16,6 +16,7 @@ from h.activity import query
 from h.links import pretty_link
 from h.paginator import paginate
 from h import util
+from h.util.user import split_user
 
 PAGE_SIZE = 200
 
@@ -56,14 +57,29 @@ def search(request):
                 'pubid': group.pubid
                 })
 
+    def tag_link(tag):
+        q = parser.unparse({'tag': tag})
+        return request.route_url('activity.search', _query=[('q', q)])
+
+    def username_from_id(userid):
+        parts = split_user(userid)
+        return parts['username']
+
+    def user_link(userid):
+        username=username_from_id(userid)
+        return request.route_url('activity.user_search', username=username)
+
     return {
-        'total': result.total,
         'aggregations': result.aggregations,
         'groups_suggestions': groups_suggestions,
-        'timeframes': result.timeframes,
         'page': paginate(request, result.total, page_size=page_size),
         'pretty_link': pretty_link,
         'q': request.params.get('q', ''),
+        'tag_link': tag_link,
+        'timeframes': result.timeframes,
+        'total': result.total,
+        'user_link': user_link,
+        'username_from_id': username_from_id,
     }
 
 

--- a/tests/h/views/activity_test.py
+++ b/tests/h/views/activity_test.py
@@ -10,7 +10,7 @@ from webob.multidict import NestedMultiDict
 from h.views import activity
 
 
-@pytest.mark.usefixtures('paginate', 'query')
+@pytest.mark.usefixtures('paginate', 'query', 'routes')
 class TestSearch(object):
     def test_it_returns_404_when_feature_turned_off(self, pyramid_request):
         pyramid_request.feature.flags['search_page'] = False
@@ -139,6 +139,21 @@ class TestSearch(object):
             {'name': fake_group_2.name, 'pubid': fake_group_2.pubid},
             {'name': fake_group_3.name, 'pubid': fake_group_3.pubid},
         ]
+
+    def test_it_generates_tag_links(self, pyramid_request):
+        result = activity.search(pyramid_request)
+        tag_link = result['tag_link']('foo')
+        assert tag_link == 'http://example.com/search?q=tag%3Afoo'
+
+    def test_it_generates_usernames(self, pyramid_request):
+        result = activity.search(pyramid_request)
+        username = result['username_from_id']('acct:jim.smith@hypothes.is')
+        assert username == 'jim.smith'
+
+    def test_it_generates_username_links(self, pyramid_request):
+        result = activity.search(pyramid_request)
+        user_link = result['user_link']('acct:jim.smith@hypothes.is')
+        assert user_link == 'http://example.com/users/jim.smith/search'
 
     @pytest.fixture
     def query(self, patch):


### PR DESCRIPTION
Make tags and annotator names in the bucket sidebar links to activity
page searches for the corresponding tags and usernames.

Note that the `search-bucket-stats__link` CSS class is defined in #4090 

Fixes #4060
Fixes #4059