### PR TITLE
Choose login redirect URL based on feature flags for logged-in user

### DIFF
--- a/h/views/accounts.py
+++ b/h/views/accounts.py
@@ -39,7 +39,8 @@ def ajax_payload(request, data):
 
 def _login_redirect_url(request):
     if request.feature('search_page'):
-        return request.route_url('activity.search')
+        return request.route_url('activity.user_search',
+            username=request.authenticated_user.username)
     else:
         return request.route_url('stream')
 

--- a/tests/h/conftest.py
+++ b/tests/h/conftest.py
@@ -49,6 +49,8 @@ class DummyFeature(object):
     def load(self):
         self.loaded = True
 
+    def clear(self):
+        self.flags = {}
 
 class DummySession(object):
 


### PR DESCRIPTION
Previously the URL to redirect to after login was determined at the
start of request processing before authentication completed and
consequently it used the feature flags for _logged out_ users.

This makes the request redirect based on the flags for the logged in
user by deferring retrieval of the login URL until after login and
clearing the feature flag cache just before the login is processed.

No new unit tests added here because the original bug depends on the
interactions of several services and behavior of the feature flag client, so it would
need an integration test.

Fixes #4070