### PR TITLE
Fix removing current tag facet from tag sidebar

### DIFF
--- a/h/views/activity.py
+++ b/h/views/activity.py
@@ -318,10 +318,9 @@ def toggle_tag_facet(request):
         # so remove that tag facet.
         tag_facets = _tag_facets(request, parsed_query)
         tag_facets.remove(tag)
-        if tag_facets:
-            parsed_query['tag'] = tag_facets
-        else:
-            del parsed_query['tag']
+        del parsed_query['tag']
+        for tag_facet in tag_facets:
+            parsed_query.add('tag', tag_facet)
     else:
         # The search query is not yet faceted by the given tag, so add a facet
         # for the tag.

--- a/tests/h/views/activity_test.py
+++ b/tests/h/views/activity_test.py
@@ -684,6 +684,16 @@ class TestToggleTagFacet(object):
             'http://example.com/users/foo/search'
             '?q=foo+bar')
 
+    def test_it_preserves_query_when_removing_one_of_multiple_tag_facets(self,
+                                                                         pyramid_request):
+        pyramid_request.POST['q'] = 'tag:"foo" tag:"gar" tag:"bar"'
+
+        result = activity.toggle_tag_facet(pyramid_request)
+
+        assert result.location == (
+            'http://example.com/users/foo/search'
+            '?q=tag%3Afoo+tag%3Abar')
+
     @pytest.fixture
     def pyramid_request(self, pyramid_request):
         pyramid_request.matched_route = mock.Mock()


### PR DESCRIPTION
When the current search query includes "tag:foo tag:bar" and the user is
clicking on the tag "foo" in the sidebar (which toggles the tag), we end
up with a search query that looks like: "tag:[u'bar']".

This is because we're building up a list of tag facets, removing the one
the user wants to remove, and then set the list of remaining tags on the
parameters (which is a MultiDict). What we need to do is loop through
the list of remaining tags and add them one by one to the MultiDict
parameters.

Fixes #4076.