### PR TITLE
Set ES clustername to build version on Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,7 +30,7 @@ node {
     postgres = docker.image('postgres:9.4').run('-P -e POSTGRES_DB=htest')
     databaseUrl = "postgresql://postgres@${hostIp}:${containerPort(postgres, 5432)}/htest"
 
-    elasticsearch = docker.image('nickstenning/elasticsearch-icu').run('-P')
+    elasticsearch = docker.image('nickstenning/elasticsearch-icu').run('-P', "-Des.cluster.name=${buildVersion}")
     elasticsearchHost = "http://${hostIp}:${containerPort(elasticsearch, 9200)}"
 
     rabbit = docker.image('rabbitmq').run('-P')


### PR DESCRIPTION
We are having an issue that sometimes when two builds are running at the same time we get errors from the integration tests saying that the index already exists when it tries to create the index. This is due to the fact that two elasticsearch docker containers will discover each other and join the same cluster. The easiest way to avoid this is to set the cluster name to something unique, like the build version.