### PR TITLE
Explicitly allow logging from the memex package

### DIFF
--- a/conf/app.ini
+++ b/conf/app.ini
@@ -35,7 +35,7 @@ host: 0.0.0.0
 port: 5000
 
 [loggers]
-keys = root, alembic, gunicorn.error, h, sentry
+keys = root, alembic, gunicorn.error, h, memex, sentry
 
 [handlers]
 keys = console, sentry
@@ -61,6 +61,11 @@ qualname = gunicorn.error
 level = INFO
 handlers =
 qualname = h
+
+[logger_memex]
+level = INFO
+handlers =
+qualname = memex
 
 [logger_sentry]
 level = WARNING

--- a/conf/development-app.ini
+++ b/conf/development-app.ini
@@ -35,7 +35,7 @@ errorlog: -
 reload: True
 
 [loggers]
-keys = root, gunicorn.error, h, raven
+keys = root, gunicorn.error, h, memex, raven
 
 [handlers]
 keys = console
@@ -56,6 +56,11 @@ qualname = gunicorn.error
 level = INFO
 handlers =
 qualname = h
+
+[logger_memex]
+level = INFO
+handlers =
+qualname = memex
 
 [logger_raven]
 level = WARNING


### PR DESCRIPTION
By default, logging.fileConfig (which we call through paster.setup_logging) disables existing loggers, which includes those reified by `log = logging.getLogger(__name__)` lines.

Adding memex stanzas to the config files ensures that we always get log output from the memex package.