### PR TITLE
Add methods for managing aliased indices to Client

### DIFF
--- a/src/memex/search/client.py
+++ b/src/memex/search/client.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 
-import elasticsearch
+from elasticsearch import Elasticsearch
+from elasticsearch.exceptions import NotFoundError
+
+__all__ = ('Client',)
 
 
 class Client(object):
@@ -15,13 +18,45 @@ class Client(object):
     :param index: index name
     """
 
-    class t(object):
+    class t(object):  # noqa
         """Document types"""
         annotation = 'annotation'
         document = 'document'
 
     def __init__(self, host, index, **kwargs):
         self.index = index
-        self.conn = elasticsearch.Elasticsearch([host],
-                                                verify_certs=True,
-                                                **kwargs)
+        self.conn = Elasticsearch([host], verify_certs=True, **kwargs)
+
+    def get_aliased_index(self):
+        """
+        Fetch the name of the underlying index.
+
+        Returns ``None`` if the index is not aliased or does not exist.
+        """
+        try:
+            result = self.conn.indices.get_alias(name=self.index)
+        except NotFoundError:  # no alias with that name
+            return None
+        if len(result) > 1:
+            raise RuntimeError("We don't support managing aliases that "
+                               "point to multiple indices at the moment!")
+        return result.keys()[0]
+
+    def update_aliased_index(self, new_target):
+        """
+        Update the alias to point to a new target index.
+
+        Will raise `RuntimeError` if the index is not aliased or does not
+        exist.
+        """
+        old_target = self.get_aliased_index()
+        if old_target is None:
+            raise RuntimeError("Cannot update aliased index for index that "
+                               "is not already aliased.")
+
+        self.conn.indices.update_aliases(body={
+            'actions': [
+                {'add': {'index': new_target, 'alias': self.index}},
+                {'remove': {'index': old_target, 'alias': self.index}},
+            ],
+        })

--- a/tests/memex/search/client_test.py
+++ b/tests/memex/search/client_test.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import mock
+import pytest
+
+from elasticsearch.exceptions import NotFoundError
+
+from memex.search.client import Client
+
+
+class TestClient(object):
+    def test_get_aliased_index(self, conn):
+        """If ``index`` is an alias, return the name of the concrete index."""
+        conn.indices.get_alias.return_value = {
+            'target-index': {'aliases': {'foo': {}}},
+        }
+        client = Client('localhost', 'foo')
+
+        assert client.get_aliased_index() == 'target-index'
+
+    def test_get_aliased_index_no_alias(self, conn):
+        """If ``index`` is a concrete index, return None."""
+        conn.indices.get_alias.side_effect = NotFoundError('test', 'test desc')
+        client = Client('localhost', 'foo')
+
+        assert client.get_aliased_index() is None
+
+    def test_get_aliased_index_multiple_indices(self, conn):
+        """Raise if ``index`` is an alias pointing to multiple indices."""
+        conn.indices.get_alias.return_value = {
+            'index-one': {'aliases': {'foo': {}}},
+            'index-two': {'aliases': {'foo': {}}},
+        }
+        client = Client('localhost', 'foo')
+
+        with pytest.raises(RuntimeError):
+            client.get_aliased_index()
+
+    def test_update_aliased_index(self, conn):
+        """Update the alias atomically."""
+        conn.indices.get_alias.return_value = {
+            'old-target': {'aliases': {'foo': {}}},
+        }
+        client = Client('localhost', 'foo')
+
+        client.update_aliased_index('new-target')
+
+        conn.indices.update_aliases.assert_called_once_with(body={
+            'actions': [
+                {'add': {'index': 'new-target', 'alias': 'foo'}},
+                {'remove': {'index': 'old-target', 'alias': 'foo'}},
+            ],
+        })
+
+    def test_update_aliased_index_with_concrete_index(self, conn):
+        """Raise if called for a concrete index."""
+        conn.indices.get_alias.side_effect = NotFoundError('test', 'test desc')
+        client = Client('localhost', 'foo')
+
+        with pytest.raises(RuntimeError):
+            client.update_aliased_index('new-target')
+
+    @pytest.fixture
+    def conn(self, patch):
+        es = patch('memex.search.client.Elasticsearch')
+        conn = es.return_value
+        conn.indices = mock.Mock()
+        return conn


### PR DESCRIPTION
Adds get_aliased_index and update_aliased_index methods to the Elasticsearch client which can be used to interrogate and update index aliases for the open search index.