### PR TITLE
Reindex into new index when aliased

### DIFF
--- a/src/memex/search/index.py
+++ b/src/memex/search/index.py
@@ -97,6 +97,9 @@ class BatchIndexer(object):
         self.es_client = es_client
         self.request = request
 
+        # By default, index into the open index
+        self._target_index = self.es_client.index
+
     def index_all(self):
         """Reindex all annotations, and retry failed indexing operations once."""
 
@@ -135,7 +138,7 @@ class BatchIndexer(object):
         return errored
 
     def _prepare(self, annotation):
-        action = {'index': {'_index': self.es_client.index,
+        action = {'index': {'_index': self._target_index,
                             '_type': self.es_client.t.annotation,
                             '_id': annotation.id}}
         data = presenters.AnnotationSearchIndexPresenter(annotation).asdict()

--- a/tests/common/matchers.py
+++ b/tests/common/matchers.py
@@ -26,6 +26,9 @@ output if it fails, e.g.
     E       Actual call: set_value('a string')
 
 """
+
+import re
+
 from pyramid import httpexceptions
 
 
@@ -103,6 +106,19 @@ class redirect_303_to(object):
         if not isinstance(other, httpexceptions.HTTPSeeOther):
             return False
         return other.location == self.location
+
+
+class regex(object):
+    """Matches any string matching the passed regex."""
+
+    def __init__(self, patt):
+        self.patt = re.compile(patt)
+
+    def __eq__(self, other):
+        return bool(self.patt.match(other))
+
+    def __repr__(self):
+        return '<string matching re {!r}>'.format(self.patt.pattern)
 
 
 class unordered_list(object):

--- a/tests/memex/search/index_test.py
+++ b/tests/memex/search/index_test.py
@@ -173,7 +173,7 @@ class TestBatchIndexer(object):
         rendered['target'][0]['scope'] = [annotation.target_uri_normalized]
         assert results[0] == (
             {'index': {'_type': indexer.es_client.t.annotation,
-                       '_index': indexer.es_client.index,
+                       '_index': 'hypothesis',
                        '_id': annotation.id}},
             rendered
         )
@@ -211,7 +211,7 @@ class TestBatchIndexer(object):
 
         assert results[0] == (
             {'index': {'_type': indexer.es_client.t.annotation,
-                       '_index': indexer.es_client.index,
+                       '_index': 'hypothesis',
                        '_id': annotation.id}},
             rendered
         )
@@ -233,8 +233,8 @@ class TestBatchIndexer(object):
         assert result == set([ann_fail_1.id, ann_fail_2.id])
 
     @pytest.fixture
-    def indexer(self, db_session, pyramid_request):
-        return index.BatchIndexer(db_session, mock.MagicMock(), pyramid_request)
+    def indexer(self, db_session, es, pyramid_request):
+        return index.BatchIndexer(db_session, es, pyramid_request)
 
     @pytest.fixture
     def index(self, patch):


### PR DESCRIPTION
Adds support for reindexing into a brand-new index when the current index is aliased.

Dropping support for unaliased indices will come later.