### PR TITLE
Fix removing current user facet from group members sidebar

### DIFF
--- a/h/views/activity.py
+++ b/h/views/activity.py
@@ -294,10 +294,9 @@ def toggle_user_facet(request):
         # so remove that user facet.
         username_facets = _username_facets(request, parsed_query)
         username_facets.remove(username)
-        if username_facets:
-            parsed_query['user'] = username_facets
-        else:
-            del parsed_query['user']
+        del parsed_query['user']
+        for username_facet in username_facets:
+            parsed_query.add('user', username_facet)
     else:
         # The search query is not yet faceted by the given user, so add a facet
         # for the user.

--- a/tests/h/views/activity_test.py
+++ b/tests/h/views/activity_test.py
@@ -627,6 +627,16 @@ class TestToggleUserFacet(object):
             'http://example.com/groups/{pubid}/search'
             '?q=foo+bar'.format(pubid=group.pubid))
 
+    def test_it_preserves_query_when_removing_one_of_multiple_username_facets(
+            self, group, pyramid_request):
+        pyramid_request.POST['q'] = 'user:"foo" user:"fred" user:"bar"'
+
+        result = activity.toggle_user_facet(pyramid_request)
+
+        assert result.location == (
+            'http://example.com/groups/{pubid}/search'
+            '?q=user%3Afoo+user%3Abar'.format(pubid=group.pubid))
+
     @pytest.fixture
     def pyramid_request(self, group, pyramid_request):
         pyramid_request.feature.flags['search_page'] = True


### PR DESCRIPTION
When the current search query includes "user:fred user:mary" and the user is
clicking on the username "fred" in the sidebar (which toggles the user facet),
we end up with a search query that looks like: "user:[u'mary']".

This is because we're building up a list of user facets, removing the one
the user wants to remove, and then set the list of remaining user facets on the
parameters (which is a MultiDict). What we need to do is loop through
the list of remaining user facets and add them one by one to the MultiDict
parameters.

Fixes #4101.

(This is the same bug and fix as with the tag facet, see #4095)