### PR TITLE
Don't index annotation "extra" field data

### DIFF
--- a/src/memex/presenters.py
+++ b/src/memex/presenters.py
@@ -95,7 +95,7 @@ class AnnotationSearchIndexPresenter(AnnotationBasePresenter):
     def asdict(self):
         docpresenter = DocumentSearchIndexPresenter(self.annotation.document)
 
-        base = {
+        result = {
             'id': self.annotation.id,
             'created': self.created,
             'updated': self.updated,
@@ -110,15 +110,12 @@ class AnnotationSearchIndexPresenter(AnnotationBasePresenter):
             'document': docpresenter.asdict(),
         }
 
-        base['target'][0]['scope'] = [self.annotation.target_uri_normalized]
+        result['target'][0]['scope'] = [self.annotation.target_uri_normalized]
 
         if self.annotation.references:
-            base['references'] = self.annotation.references
+            result['references'] = self.annotation.references
 
-        annotation = copy.copy(self.annotation.extra) or {}
-        annotation.update(base)
-
-        return annotation
+        return result
 
     @property
     def links(self):

--- a/tests/memex/presenters_test.py
+++ b/tests/memex/presenters_test.py
@@ -227,25 +227,7 @@ class TestAnnotationSearchIndexPresenter(object):
                         'selector': [{'TestSelector': 'foobar'}]}],
             'document': {'foo': 'bar'},
             'references': ['referenced-id-1', 'referenced-id-2'],
-            'extra-1': 'foo',
-            'extra-2': 'bar',
         }
-
-    def test_asdict_extra_cannot_override_other_data(self):
-        annotation = mock.Mock(id='the-real-id', extra={'id': 'the-extra-id'})
-
-        annotation_dict = AnnotationSearchIndexPresenter(annotation).asdict()
-
-        assert annotation_dict['id'] == 'the-real-id'
-
-    def test_asdict_does_not_modify_extra(self):
-        extra = {'foo': 'bar'}
-        annotation = mock.Mock(id='my-id', extra=extra)
-
-        AnnotationSearchIndexPresenter(annotation).asdict()
-
-        assert extra == {'foo': 'bar'}, (
-                "Presenting the annotation shouldn't change the 'extra' dict")
 
     @pytest.mark.parametrize('annotation,action,expected', [
         (mock.Mock(userid='acct:luke', shared=False), 'read', ['acct:luke']),


### PR DESCRIPTION
As convenient as it may be to allow people to attach arbitrary data to annotations and subsequently search by those fields, it's fundamentally problematic due to the nature of the inverted index that Elasticsearch builds for our documents.

Allowing end users to insert arbitrary keys into indexed documents means that they can quite straightforwardly perform a denial-of-service attack against Hypothesis by adding thousands of new keys to annotations.

In addition, the already-inflated size of our index mapping is one suspect in the mysterious slow query problems we've been having recently.