### PR TITLE
Add basic "zero state" when no search results

### DIFF
--- a/h/static/styles/partials-v2/_search.scss
+++ b/h/static/styles/partials-v2/_search.scss
@@ -40,17 +40,36 @@
   margin-right: 30px;
 }
 
-.search-result-list {
+.search-result-container--empty {
+  /* The default height of the search container is calculated to so that it
+     stretches to the bottom of the viewport and no further.
+     The px value here is the height of the stuff above the
+     search-result-container. */
+  height: calc(100vh - 134px);
+  margin-bottom: 0;
+}
+
+.search-result-list,
+.search-result-zero {
   flex-basis: 950px;
   max-width: 950px;
+  margin-right: 30px;
+}
 
+.search-result-list {
   // Remove default padding from <ol>
   list-style: none;
   padding-left: 0;
   padding-right: 0;
-
-  margin-right: 30px;
   margin-bottom: 40px;
+}
+
+.search-result-zero {
+  background: $grey-2;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 10px;
 }
 
 .search-result__timeframe {
@@ -271,6 +290,14 @@
     margin-top: 25px;
   }
 
+  .search-result-container--empty {
+    /* The default height of the search container is calculated to so that it
+       stretches to the bottom of the viewport and no further.
+       The px value here is the height of the stuff above the
+       search-result-container. */
+    height: calc(100vh - 155px);
+  }
+
   .search-result-nav {
     display: flex;
   }
@@ -279,7 +306,8 @@
     display: none;
   }
 
-  .search-result-list {
+  .search-result-list,
+  .search-result-zero {
     margin-right: 0;
   }
 }

--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -334,25 +334,31 @@
     {{groups_suggestions | to_json}}
   </script>
 
-  <div class="search-result-container">
+  <div class="search-result-container {%- if not timeframes %} search-result-container--empty{% endif %}">
     {% if group %}
       {{ search_result_nav(group.name) }}
     {% elif user %}
       {{ search_result_nav(user.name) }}
     {% endif %}
 
-    <ol class="search-result-list {%- if more_info %} search-result-hide-on-small-screens{% endif %}">
-      {% for timeframe in timeframes %}
-        <li class="search-result__timeframe">
-          {{ timeframe.label }}
-        </li>
-        <li>
-          {% for bucket in timeframe.document_buckets.values() %}
-            {{ search_result_bucket(bucket) }}
-          {% endfor %}
-        </li>
-      {% endfor %}
-    </ol>
+    {% if timeframes %}
+      <ol class="search-result-list {%- if more_info %} search-result-hide-on-small-screens{% endif %}">
+        {% for timeframe in timeframes %}
+          <li class="search-result__timeframe">
+            {{ timeframe.label }}
+          </li>
+          <li>
+            {% for bucket in timeframe.document_buckets.values() %}
+              {{ search_result_bucket(bucket) }}
+            {% endfor %}
+          </li>
+        {% endfor %}
+      </ol>
+    {% else %}
+      <div class="search-result-zero {%- if more_info %} search-result-hide-on-small-screens{% endif %}">
+        {{ zero_message }}
+      </div>
+    {% endif %}
 
     {% if group %}
       {{ group_sidebar(group, group_edit_url, total) }}


### PR DESCRIPTION
On the /search page, if there are no search results, show a grey box
that says "No annotations matched your search."

If on the `/groups/<pubid>/search` page and there is no search query
(other than the group) then the message changes to 'The group "{name}
have not made any annotations yet." When there is a search query other
than just the group the original  "No annotations matched your search"
message is still used.

If on the `/users/<username>/search` page and there is no search query
(other than the user) then the message changes to "{name} hasn't made
any annotations yet". If this is the search page of the authorized user
then "You haven't made any annotations yet" is used. When there is a search
query other than just the user the original  "No annotations matched your
search" message is still used.

The message that's used when you're on your own user page and have no annotations is going to be changed to this one https://cloud.githubusercontent.com/assets/8598901/20438202/f9daacc8-adb6-11e6-815c-3a563000f7fd.png in a following PR.

This also incidentally fixes https://github.com/hypothesis/h/issues/4102