### PR TITLE
Fix static asset version mismatch

### DIFF
--- a/h/assets.py
+++ b/h/assets.py
@@ -160,13 +160,15 @@ def _load_bundles(fp):
     return {k: aslist(v) for k, v in parser.items('bundles')}
 
 
+ABOUT_TEN_YEARS = 60 * 60 * 24 * 365 * 10
+
 def includeme(config):
     # Site assets
     assets_env = Environment('/assets',
                              'h/assets.ini',
                              'build/manifest.json')
     assets_view = static_view('h:../build',
-                              cache_max_age=None,
+                              cache_max_age=ABOUT_TEN_YEARS,
                               use_subpath=True)
     assets_view = _check_version(assets_env, assets_view)
     assets_view = _add_cors_header(assets_view)
@@ -176,7 +178,7 @@ def includeme(config):
                                     'h/assets_client.ini',
                                     'node_modules/hypothesis/build/manifest.json')
     assets_client_view = static_view('h:../node_modules/hypothesis/build',
-                                     cache_max_age=None,
+                                     cache_max_age=ABOUT_TEN_YEARS,
                                      use_subpath=True)
     assets_client_view = _check_version(assets_client_env, assets_client_view)
     assets_client_view = _add_cors_header(assets_client_view)

--- a/h/assets.py
+++ b/h/assets.py
@@ -162,30 +162,39 @@ def _load_bundles(fp):
 
 ABOUT_TEN_YEARS = 60 * 60 * 24 * 365 * 10
 
+
+def create_assets_view(assets_env, file_path):
+    """
+    Create an `Environment` and view callable for serving static assets.
+
+    :param env: The `Environment`
+    :param file_path: Package or file path of directory containing assets
+    :rtype: (Environment, callable)
+    """
+    assets_view = static_view(file_path,
+                              cache_max_age=ABOUT_TEN_YEARS,
+                              use_subpath=True)
+    assets_view = _check_version(assets_env, assets_view)
+    assets_view = _add_cors_header(assets_view)
+    return assets_view
+
+
 def includeme(config):
     # Site assets
     assets_env = Environment('/assets',
                              'h/assets.ini',
                              'build/manifest.json')
-    assets_view = static_view('h:../build',
-                              cache_max_age=ABOUT_TEN_YEARS,
-                              use_subpath=True)
-    assets_view = _check_version(assets_env, assets_view)
-    assets_view = _add_cors_header(assets_view)
+    assets_view = create_assets_view(assets_env, 'h:../build')
 
     # Client assets
     assets_client_env = Environment('/assets/client',
                                     'h/assets_client.ini',
                                     'node_modules/hypothesis/build/manifest.json')
-    assets_client_view = static_view('h:../node_modules/hypothesis/build',
-                                     cache_max_age=ABOUT_TEN_YEARS,
-                                     use_subpath=True)
-    assets_client_view = _check_version(assets_client_env, assets_client_view)
-    assets_client_view = _add_cors_header(assets_client_view)
+    assets_client_view = create_assets_view(assets_client_env,
+                                            'h:../node_modules/hypothesis/build')
 
     config.add_view(route_name='assets', view=assets_view)
     config.add_view(route_name='assets_client', view=assets_client_view)
-
 
     # We store the environment objects on the registry so that the Jinja2
     # integration can be configured in app.py

--- a/tests/h/assets_test.py
+++ b/tests/h/assets_test.py
@@ -3,9 +3,12 @@
 from sys import version_info
 from StringIO import StringIO
 
-from mock import patch
+from mock import Mock, patch
+from pyramid import httpexceptions
+from pyramid.response import Response
+import pytest
 
-from h.assets import Environment
+from h.assets import Environment, create_assets_view
 
 if version_info.major == 2:
     open_target = '__builtin__.open'
@@ -34,6 +37,12 @@ def _fake_open(path):
         return StringIO(BUNDLE_INI)
     elif path == 'manifest.json':
         return StringIO(MANIFEST_JSON)
+
+
+def _fake_static_view(file_path, cache_max_age, use_subpath):
+    def fake_view(context, request):
+        return Response('Content of ' + request.path)
+    return fake_view
 
 
 @patch(open_target, _fake_open)
@@ -100,3 +109,35 @@ def test_environment_reloads_manifest_on_change(mtime, open):
     # the manifest
     mtime.return_value = 101
     assert env.urls('app_js') == ['/assets/app.bundle.js?newhash']
+
+
+@patch(open_target, _fake_open)
+@patch('os.path.getmtime', Mock())
+class TestAssetsView(object):
+    def test_returns_asset_when_version_is_correct(self, assets_view, pyramid_request):
+        pyramid_request.path = '/assets/app.bundle.js'
+        pyramid_request.query_string = 'abcdef'
+
+        result = assets_view(None, pyramid_request)
+
+        assert result.body == 'Content of /assets/app.bundle.js'
+
+    def test_returns_404_when_version_is_wrong(self, assets_view, pyramid_request):
+        pyramid_request.path = '/assets/app.bundle.js'
+        pyramid_request.query_string = 'wrong-version'
+
+        result = assets_view(None, pyramid_request)
+
+        assert isinstance(result, httpexceptions.HTTPNotFound)
+
+    def test_sets_cors_headers(self, assets_view, pyramid_request):
+        pyramid_request.path = '/assets/app.bundle.js'
+        result = assets_view(None, pyramid_request)
+
+        assert result.headers['Access-Control-Allow-Origin'] == '*'
+
+    @pytest.fixture
+    @patch('h.assets.static_view', _fake_static_view)
+    def assets_view(self):
+        env = Environment('/assets', 'bundles.ini', 'manifest.json')
+        return create_assets_view(env, file_path='')

--- a/tests/h/assets_test.py
+++ b/tests/h/assets_test.py
@@ -58,6 +58,22 @@ def test_environment_generates_bundle_urls(mtime):
     ]
 
 
+@patch(open_target, _fake_open)
+@patch('os.path.getmtime')
+def test_environment_version_returns_version_if_asset_exists(mtime):
+    env = Environment('/assets', 'bundles.ini', 'manifest.json')
+
+    assert env.version('app.bundle.js') == 'abcdef'
+
+
+@patch(open_target, _fake_open)
+@patch('os.path.getmtime')
+def test_environment_version_returns_none_if_asset_does_not_exist(mtime):
+    env = Environment('/assets', 'bundles.ini', 'manifest.json')
+
+    assert env.version('unknown.bundle.js') == None
+
+
 @patch(open_target)
 @patch('os.path.getmtime')
 def test_environment_reloads_manifest_on_change(mtime, open):

--- a/tests/h/assets_test.py
+++ b/tests/h/assets_test.py
@@ -130,6 +130,13 @@ class TestAssetsView(object):
 
         assert isinstance(result, httpexceptions.HTTPNotFound)
 
+    def test_returns_asset_when_version_is_unspecified(self, assets_view, pyramid_request):
+        pyramid_request.path = '/assets/app.bundle.js'
+
+        result = assets_view(None, pyramid_request)
+
+        assert result.body == 'Content of /assets/app.bundle.js'
+
     def test_sets_cors_headers(self, assets_view, pyramid_request):
         pyramid_request.path = '/assets/app.bundle.js'
         result = assets_view(None, pyramid_request)


### PR DESCRIPTION
I suspect that Sentry may sometimes be producing incorrect stacktraces when it processes reports because when it fetches the original JS and sourcemap for a URL it may request `/asset/scripts/foo.js?v1` as specified in the stacktrace but end up getting `/asset/scripts/foo.js?v2` which is the current version.

This PR fixes the general problem that a client can request a particular version of an asset but end up getting a different version by checking the version in the query string against the version in the manifest file. If they differ, the response is 404-ed. The benefit for this approach rather than baking the version into the file path is that it doesn't require any changes to the JS build for the client or server.

In order to keep old versions of assets around for the benefit of Sentry and other clients, we simply set a long max-age on requests so CDNs downstream will retain it in their caches for a long time.

A side benefit of this PR is that it enables browser caching of client and server assets during local development, making repeated loads of the client and server pages faster.