### PR TITLE
Adding max bounds to lozenge growth and proper wrapping of lozenges

### DIFF
--- a/h/static/scripts/controllers/lozenge-controller.js
+++ b/h/static/scripts/controllers/lozenge-controller.js
@@ -20,8 +20,10 @@ const searchTextParser = require('../util/search-text-parser');
 class LozengeController extends Controller {
   constructor(containerEl, options) {
     super(containerEl, options);
-    const lozengeEl = document.createElement('div');
+    const lozTempContainer = document.createElement('div');
+    let lozengeEl = document.createElement('div');
     let lozengeMarkup = escapeHtml(options.content);
+    const currentLozenges = containerEl.querySelectorAll('.lozenge');
 
     if (searchTextParser.hasKnownNamedQueryTerm(options.content)) {
       const queryTerm = searchTextParser.getLozengeFacetNameAndValue(options.content);
@@ -42,7 +44,22 @@ class LozengeController extends Controller {
       '</div>';
     lozengeEl.classList.add('lozenge');
     lozengeEl.classList.add('js-lozenge');
-    containerEl.appendChild(lozengeEl);
+
+    lozTempContainer.appendChild(lozengeEl);
+
+    // append the lozenge after the last lozenge child
+    // or as the very first element in the container.
+    // We are doing this over appendChild because we don't want to limit
+    // the ability for the container to also hold other elements like an
+    // input field - allowing them to flow together in the same box model
+    if (currentLozenges && currentLozenges.length > 0) {
+      currentLozenges[currentLozenges.length - 1].insertAdjacentHTML('afterend', lozTempContainer.innerHTML);
+    } else {
+      containerEl.insertAdjacentHTML('afterbegin', lozTempContainer.innerHTML);
+    }
+
+    // update reference to point to the actual dom element
+    lozengeEl = containerEl.querySelectorAll('.lozenge')[currentLozenges ? currentLozenges.length : 0];
 
     lozengeEl.querySelector('.js-lozenge__close').addEventListener('mousedown', () => {
       lozengeEl.remove();

--- a/h/static/scripts/tests/controllers/search-bar-controller-test.js
+++ b/h/static/scripts/tests/controllers/search-bar-controller-test.js
@@ -578,6 +578,82 @@ describe('SearchBarController', () => {
         assert.equal(hiddenInput.value, 'group:pid124');
       });
 
+
+      it('places lozenges as first elements in container', (done) => {
+        const template = `
+            <div>
+              <form data-ref="searchBarForm">
+                <div class="search-bar__lozenges" data-ref="searchBarLozenges">
+                    <input data-ref="searchBarInput" class="search-bar__input" name="q" value="">
+                </div>
+              </form>
+            </div>
+          `.trim();
+
+        const ctrl = util.setupComponent(document, template, SearchBarController);
+
+        // Stub the submit method so it doesn't actually do a full page reload.
+        ctrl.refs.searchBarForm.submit = sinon.stub();
+
+        const container = ctrl.element.querySelector('.search-bar__lozenges');
+        const input = ctrl.refs.searchBarInput;
+
+        let currentChildrenCount = container.children.length;
+
+        syn
+          .click(input)
+          .type('foo[space]', () => {
+
+            currentChildrenCount += 1;
+
+            assert.lengthOf(container.children, currentChildrenCount, 'lozenge add should be added as a child');
+
+            assert.ok(container.children[0].classList.contains('lozenge'), 'should be set as first child');
+
+            done();
+          });
+      });
+
+      it('places lozenges after any initial lozenges', (done) => {
+        const template = `
+            <div>
+              <form data-ref="searchBarForm">
+                <div class="search-bar__lozenges" data-ref="searchBarLozenges">
+                    <div class="lozenge js-lozenge"><div class="js-lozenge__content lozenge__content">seeded</div></div>
+                    <input data-ref="searchBarInput" class="search-bar__input" name="q" value="">
+                </div>
+              </form>
+            </div>
+          `.trim();
+
+        const ctrl = util.setupComponent(document, template, SearchBarController);
+
+        // Stub the submit method so it doesn't actually do a full page reload.
+        ctrl.refs.searchBarForm.submit = sinon.stub();
+
+        const container = ctrl.element.querySelector('.search-bar__lozenges');
+        const input = ctrl.refs.searchBarInput;
+
+        let currentChildrenCount = container.children.length;
+
+        syn
+          .click(input)
+          .type('foo[space]', () => {
+
+            currentChildrenCount += 1;
+
+            assert.lengthOf(container.children, currentChildrenCount);
+
+            assert.ok(container.children[0].classList.contains('lozenge'));
+            assert.ok(container.children[1].classList.contains('lozenge'));
+
+            assert.equal(container.children[0].textContent, 'seeded');
+            assert.equal(container.children[1].textContent, 'foo', 'new lozenge should be added after the initial lozenge - but before anything else');
+
+            done();
+          });
+      });
+
     });
   });
 });

--- a/h/static/styles/partials-v2/_lozenge.scss
+++ b/h/static/styles/partials-v2/_lozenge.scss
@@ -5,12 +5,18 @@
   border-radius: 2px;
   margin-left: 10px;
   margin-top: 15px;
-  margin-bottom: 15px;
+  height: 22px;
+  max-width: 55%;
 }
 
 .lozenge__content {
+  // offset is for the close button
+  max-width: calc(100% - 20px);
+
   padding: 3px 5px 3px 5px;
   white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .lozenge__facet-value {

--- a/h/static/styles/partials-v2/_nav-bar.scss
+++ b/h/static/styles/partials-v2/_nav-bar.scss
@@ -90,15 +90,22 @@
 }
 
 @media screen and (max-width: $max-phone-width) {
-  // Display search bar full-width underneath nav links on phone-sized screens
-  .nav-bar {
-    height: 120px;
+
+  // In order to make the search bar flow below the other
+  // two sections of the nav, we need to change the flow order
+  // and utilize the flex-wrap to allow the search to push
+  // into the next row
+  .nav-bar__content {
+    flex-wrap: wrap;
+  }
+  
+  .nav-bar__search {
+    order: 3; // swaping into links original position
+    width:100%;
+    margin: 10px;
   }
 
-  .nav-bar__search {
-    position: absolute;
-    top: 50px;
-    left: 10px;
-    right: 10px;
+  .nav-bar-links {
+    order: 2; // swaping into search's original position
   }
 }

--- a/h/static/styles/partials-v2/_search-bar.scss
+++ b/h/static/styles/partials-v2/_search-bar.scss
@@ -6,13 +6,14 @@
   border: 1px solid $grey-3;
   border-radius: 2px;
   display: flex;
+  flex-wrap: wrap;
 
   // scope absolute positioned elements
   position: relative;
 }
 
 .search-bar__input {
-  width: 100%;
+  flex: 1;
 
   border: none;
 
@@ -21,6 +22,9 @@
   padding-top: 18px;
   padding-bottom: 18px;
   padding-right: 3px;
+
+  // prevent the search input from being squashed
+  min-width:30%;
 
   .env-js-capable & {
     visibility: hidden;
@@ -38,7 +42,10 @@
 }
 
 .search-bar__lozenges {
+  // offset is the width of the magnifying glass icon left of input
+  width: calc(100% - 24px);
   display: flex;
+  flex-wrap: wrap;
 }
 
 .search-bar__icon {
@@ -63,8 +70,9 @@
   display: none;
   padding: 20px 0 0 0;
   position: absolute;
-  top: 52px;
+  top: 100%;
   left: 0;
+  margin-top: 1px;
   width: 100%;
   z-index: $zindex-dropdown-menu;
   max-width: 650px;

--- a/h/templates/panels/navbar.html.jinja2
+++ b/h/templates/panels/navbar.html.jinja2
@@ -49,14 +49,15 @@
           {% if opts['search_groupname'] %}
             {{ lozenge('group', opts['search_groupname']) }}
           {% endif %}
+
+          <input class="search-bar__input js-input-autofocus"
+                 autocapitalize="off"
+                 autocomplete="off"
+                 data-ref="searchBarInput"
+                 name="q"
+                 placeholder="Search…"
+                 value="{{ q }}">
         </div>
-        <input class="search-bar__input js-input-autofocus"
-               autocapitalize="off"
-               autocomplete="off"
-               data-ref="searchBarInput"
-               name="q"
-               placeholder="Search…"
-               value="{{ q }}">
       </form>
     </div>
 


### PR DESCRIPTION
Fixes #3988 

PR adds the maximum width to lozenges that is responsive to the width of the container form. 

We talked about wanting to have the search box remain inline with lozenges if the start wrapping. This means we need to put them inside of the same flex parent which is the lozenge container. There were changes needed to make sure we keep the elements in the right order - that's where properly injecting elements changes come from.