### PR TITLE
Allow dockerised Elasticsearch to verify TLS certificates

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ CLASSIFIERS = [
 INSTALL_REQUIRES = [
     'SQLAlchemy>=1.0.13',
     'bleach>=1.4.3,<1.5',
+    'certifi',
     'elasticsearch>=1.1.0,<2.0.0',
     'jsonschema>=2.5.1,<2.6',
     'mistune>=0.7.3,<0.8',

--- a/src/memex/search/client.py
+++ b/src/memex/search/client.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import certifi
 from elasticsearch import Elasticsearch
 from elasticsearch.exceptions import NotFoundError
 
@@ -24,7 +25,12 @@ class Client(object):
 
     def __init__(self, host, index, **kwargs):
         self.index = index
-        self.conn = Elasticsearch([host], verify_certs=True, **kwargs)
+        self.conn = Elasticsearch([host],
+                                  verify_certs=True,
+                                  # N.B. this won't be necessary if we upgrade
+                                  # to elasticsearch>=5.0.0.
+                                  ca_certs=certifi.where(),
+                                  **kwargs)
 
     def get_aliased_index(self):
         """


### PR DESCRIPTION
Point the Elasticsearch client to the certifi CA bundle. This allows us
to connect to Elasticsearch over HTTPS within the container.