### PR TITLE
Make a single Elasticsearch client per application

### DIFF
--- a/src/memex/search/__init__.py
+++ b/src/memex/search/__init__.py
@@ -41,8 +41,9 @@ def includeme(config):
     # Add a property to all requests for easy access to the elasticsearch
     # client. This can be used for direct or bulk access without having to
     # reread the settings.
+    config.registry['es.client'] = _get_client(settings)
     config.add_request_method(
-        lambda r: _get_client(r.registry.settings),
+        lambda r: r.registry['es.client'],
         name='es',
         reify=True)
 


### PR DESCRIPTION
Previously, we made an Elasticsearch instance per-request, which is
appealing from an isolation point of view but unfortunate from a
resource usage and performance standpoint because the connection pool is
associated with the client instance.

(There is no distinction between an "engine" and a "session" as in
SQLAlchemy, which makes some sense because the client is in theory
stateless.)

This commit changes the code so that a single client is created on
startup, and reused in every request. This should make a noticeable
improvement on query latency, because we won't be creating and tearing
down the TCP connections and TLS sessions with Elasticsearch for every
single request.