### PR TITLE
Add "How to get started" box to user search page

### DIFF
--- a/h/static/styles/partials-v2/_search.scss
+++ b/h/static/styles/partials-v2/_search.scss
@@ -66,10 +66,21 @@
 
 .search-result-zero {
   background: $grey-2;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  padding: 10px;
+  padding: 30px;
+}
+
+.search-result-zero__title {
+  margin-top: 0;
+}
+
+.search-result-zero__list {
+  list-style-position: inside;
+  padding-left: 0;
+}
+
+.search-result-zero a {
+  color: inherit;
+  text-decoration: underline;
 }
 
 .search-result__timeframe {
@@ -309,6 +320,11 @@
   .search-result-list,
   .search-result-zero {
     margin-right: 0;
+  }
+
+  .search-result-zero {
+    padding-left: 10px;
+    padding-top: 20px;
   }
 }
 

--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -356,7 +356,46 @@
       </ol>
     {% else %}
       <div class="search-result-zero {%- if more_info %} search-result-hide-on-small-screens{% endif %}">
-        {{ zero_message }}
+        {% if zero_message == '__SHOW_GETTING_STARTED__' %}
+          <div>
+            <h2 class="search-result-zero__title">
+              {% trans %}How to get started{% endtrans %}
+            </h2>
+            <ol class="search-result-zero__list">
+              <li><p>
+                <a href="https://chrome.google.com/webstore/detail/hypothesis-web-pdf-annota/bjfhmglciegochdpefhhlphglcehbmek">
+                  {% trans %}Install our Chrome extension{% endtrans %}
+                </a>
+              </p></li>
+              <li><p>
+                {% trans url=request.route_url('activity.search') %}
+                  Check out some of the
+                  <a href="{{ url }}">
+                    recently annotated documents
+                  </a>
+                {% endtrans %}
+              </p></li>
+              <li><p>
+                {% trans url=user.edit_url %}
+                  Let other users know more about you by
+                  <a href="{{ url }}">
+                    adding more information to your profile
+                  </a>
+                {% endtrans %}
+              </p></li>
+              <li><p>
+                {% trans %}
+                  Read more about
+                  <a href="https://hypothes.is/annotating-with-groups/">
+                    how to annotate with groups
+                  </a>
+                {% endtrans %}
+              </p></li>
+            </ol>
+          </div>
+        {% else %}
+          <strong>{{ zero_message }}</strong>
+        {% endif %}
       </div>
     {% endif %}
 

--- a/h/views/activity.py
+++ b/h/views/activity.py
@@ -185,9 +185,8 @@ def user_search(request):
 
     if not result.get('q'):
         if request.authenticated_user == user:
-            result['zero_message'] = _(
-                "You have not made any annotations yet.")
-
+            # Tell the template that it should show the "How to get started".
+            result['zero_message'] = '__SHOW_GETTING_STARTED__'
         else:
             result['zero_message'] = _(
                 "{name} has not made any annotations yet.".format(

--- a/tests/h/views/activity_test.py
+++ b/tests/h/views/activity_test.py
@@ -573,14 +573,13 @@ class TestUserSearch(object):
             '{name} has not made any annotations yet.'.format(
                 name=user.username))
 
-    def test_it_returns_a_different_zero_message_when_on_your_own_page(
+    def test_it_shows_the_getting_started_box_when_on_your_own_page(
             self, pyramid_request, search, user):
         search.return_value['q'] = ''
 
         result = activity.user_search(pyramid_request)
 
-        assert result['zero_message'] == (
-            'You have not made any annotations yet.')
+        assert result['zero_message'] == '__SHOW_GETTING_STARTED__'
 
     @pytest.fixture
     def pyramid_request(self, pyramid_request, user):


### PR DESCRIPTION
On the `/users/<username>/search` page, if this is your own user page
and you haven't made any annotations yet, show a "How to get started"
box with some links.

Fixes https://github.com/hypothesis/h/issues/4022

This is what users will see after they login for the first time (and every time they login until they create some annotations) after registering a new account.

Issue:

https://github.com/hypothesis/h/issues/4022#issuecomment-261580094

Design mockup:

![f9daacc8-adb6-11e6-815c-3a563000f7fd](https://cloud.githubusercontent.com/assets/22498/20572409/3f1e6a50-b1a3-11e6-867d-fbda27ff4838.png)

Screenshot on desktop:

![screenshot from 2016-11-23 17-36-16](https://cloud.githubusercontent.com/assets/22498/20572442/6027a6e4-b1a3-11e6-85b1-a3c02b7089ac.png)

Screenshot on mobile:

![screenshot from 2016-11-23 17-36-56](https://cloud.githubusercontent.com/assets/22498/20572467/78afef3c-b1a3-11e6-8d8e-f41b1df07d51.png)

For what the links should link to see [this comment](https://github.com/hypothesis/h/issues/4022#issuecomment-262237198) and [this comment](https://github.com/hypothesis/h/issues/4022#issuecomment-262321707).

As [suggested by Dan](https://github.com/hypothesis/h/issues/4022#issuecomment-262322468) (also see [discussion in Slack](https://hypothes-is.slack.com/archives/design/p1479919630001008) the design of the other zero messages has also been tweaked:

![screenshot from 2016-11-23 16-56-41](https://cloud.githubusercontent.com/assets/22498/20572496/99bc25ec-b1a3-11e6-967e-09f85414486b.png)