### PR TITLE
Turn get_aliased_index/update_aliased_index into helpers

### DIFF
--- a/src/memex/search/index.py
+++ b/src/memex/search/index.py
@@ -17,7 +17,11 @@ from memex import models
 from memex import presenters
 from memex._compat import xrange
 from memex.events import AnnotationTransformEvent
-from memex.search.config import configure_index
+from memex.search.config import (
+    configure_index,
+    get_aliased_index,
+    update_aliased_index,
+)
 
 log = logging.getLogger(__name__)
 
@@ -84,7 +88,7 @@ def delete(es, annotation_id):
 def reindex(session, es, request):
     """Reindex all annotations into a new index, and update the alias."""
 
-    aliased = es.get_aliased_index() is not None
+    aliased = get_aliased_index(es) is not None
 
     # If the index we're using is an alias, then we index into a brand new
     # index and update the alias at the end.
@@ -106,7 +110,7 @@ def reindex(session, es, request):
                 errored))
 
     if aliased:
-        es.update_aliased_index(new_index)
+        update_aliased_index(es, new_index)
     else:
         deleter = BatchDeleter(session, es)
         deleter.delete_all()

--- a/tests/memex/search/client_test.py
+++ b/tests/memex/search/client_test.py
@@ -5,66 +5,8 @@ from __future__ import unicode_literals
 import mock
 import pytest
 
-from elasticsearch.exceptions import NotFoundError
-
 from memex.search.client import Client
 
 
 class TestClient(object):
-    def test_get_aliased_index(self, conn):
-        """If ``index`` is an alias, return the name of the concrete index."""
-        conn.indices.get_alias.return_value = {
-            'target-index': {'aliases': {'foo': {}}},
-        }
-        client = Client('localhost', 'foo')
-
-        assert client.get_aliased_index() == 'target-index'
-
-    def test_get_aliased_index_no_alias(self, conn):
-        """If ``index`` is a concrete index, return None."""
-        conn.indices.get_alias.side_effect = NotFoundError('test', 'test desc')
-        client = Client('localhost', 'foo')
-
-        assert client.get_aliased_index() is None
-
-    def test_get_aliased_index_multiple_indices(self, conn):
-        """Raise if ``index`` is an alias pointing to multiple indices."""
-        conn.indices.get_alias.return_value = {
-            'index-one': {'aliases': {'foo': {}}},
-            'index-two': {'aliases': {'foo': {}}},
-        }
-        client = Client('localhost', 'foo')
-
-        with pytest.raises(RuntimeError):
-            client.get_aliased_index()
-
-    def test_update_aliased_index(self, conn):
-        """Update the alias atomically."""
-        conn.indices.get_alias.return_value = {
-            'old-target': {'aliases': {'foo': {}}},
-        }
-        client = Client('localhost', 'foo')
-
-        client.update_aliased_index('new-target')
-
-        conn.indices.update_aliases.assert_called_once_with(body={
-            'actions': [
-                {'add': {'index': 'new-target', 'alias': 'foo'}},
-                {'remove': {'index': 'old-target', 'alias': 'foo'}},
-            ],
-        })
-
-    def test_update_aliased_index_with_concrete_index(self, conn):
-        """Raise if called for a concrete index."""
-        conn.indices.get_alias.side_effect = NotFoundError('test', 'test desc')
-        client = Client('localhost', 'foo')
-
-        with pytest.raises(RuntimeError):
-            client.update_aliased_index('new-target')
-
-    @pytest.fixture
-    def conn(self, patch):
-        es = patch('memex.search.client.Elasticsearch')
-        conn = es.return_value
-        conn.indices = mock.Mock()
-        return conn
+    pass

--- a/tests/memex/search/index_test.py
+++ b/tests/memex/search/index_test.py
@@ -457,7 +457,6 @@ def es():
     mock_es = mock.Mock(spec=client.Client('localhost', 'hypothesis'))
     mock_es.index = 'hypothesis'
     mock_es.t.annotation = 'annotation'
-    mock_es.get_aliased_index.return_value = None
     return mock_es
 
 


### PR DESCRIPTION
This is a refactoring, moving get_aliased_index and update_aliased_index off the client instance and into helper functions that receive a client instance. Implementing these as methods on `memex.search.client.Client` probably isn't wise when the `Client` instance lives for the life of the application -- every method on that class is an opportunity to leak state between requests.