### PR TITLE
Create aliased Elasticsearch indexes by default

### DIFF
--- a/src/memex/search/__init__.py
+++ b/src/memex/search/__init__.py
@@ -3,7 +3,7 @@
 from pyramid.settings import asbool
 
 from memex.search.client import Client
-from memex.search.config import configure_index
+from memex.search.config import init
 from memex.search.core import Search
 from memex.search.core import FILTERS_KEY
 from memex.search.core import MATCHERS_KEY
@@ -51,4 +51,4 @@ def includeme(config):
 
     # If requested, automatically configure the index
     if asbool(settings.get('h.search.autoconfig', False)):
-        configure_index(_get_client(settings))
+        init(config.registry['es.client'])

--- a/src/memex/search/config.py
+++ b/src/memex/search/config.py
@@ -167,6 +167,11 @@ ANNOTATION_ANALYSIS = {
 }
 
 
+def init(client):
+    """Initialise Elasticsearch, creating necessary indices and aliases."""
+    configure_index(client)
+
+
 def configure_index(client, index=None):
     """Configure the elasticsearch index."""
 

--- a/src/memex/search/index.py
+++ b/src/memex/search/index.py
@@ -3,10 +3,8 @@
 
 from __future__ import unicode_literals
 
-import binascii
 import itertools
 import logging
-import os
 from collections import namedtuple
 
 import elasticsearch
@@ -93,8 +91,7 @@ def reindex(session, es, request):
     # If the index we're using is an alias, then we index into a brand new
     # index and update the alias at the end.
     if aliased:
-        new_index = es.index + '-' + _random_id()
-        configure_index(es, index=new_index)
+        new_index = configure_index(es)
         indexer = BatchIndexer(session, es, request, target_index=new_index)
     else:
         indexer = BatchIndexer(session, es, request)
@@ -290,8 +287,3 @@ class BatchDeleter(object):
             if not batch:
                 return
             yield batch
-
-
-def _random_id():
-    """Generate a short random hex string."""
-    return binascii.hexlify(os.urandom(4))

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -62,10 +62,10 @@ def init_db(db_engine):
 
 @pytest.fixture(scope='session', autouse=True)
 def init_elasticsearch():
-    from memex.search import configure_index, _get_client
+    from memex.search import init, _get_client
     client = _get_client(TEST_SETTINGS)
     _drop_indices(TEST_SETTINGS)
-    configure_index(client)
+    init(client)
 
 
 @pytest.fixture(scope='session')

--- a/tests/memex/search/config_test.py
+++ b/tests/memex/search/config_test.py
@@ -9,15 +9,17 @@ import pytest
 from elasticsearch.exceptions import NotFoundError
 
 from memex.search.config import (
-    ANNOTATION_ANALYSIS,
+    ANNOTATION_MAPPING,
+    ANALYSIS_SETTINGS,
     init,
+    configure_index,
     get_aliased_index,
     update_aliased_index,
 )
 
 
 def test_strip_scheme_char_filter():
-    f = ANNOTATION_ANALYSIS['char_filter']['strip_scheme']
+    f = ANALYSIS_SETTINGS['char_filter']['strip_scheme']
     p = f['pattern']
     r = f['replacement']
     assert(re.sub(p, r, 'http://ping/pong#hash') == 'ping/pong#hash')
@@ -30,7 +32,7 @@ def test_strip_scheme_char_filter():
 
 
 def test_path_url_filter():
-    patterns = ANNOTATION_ANALYSIS['filter']['path_url']['patterns']
+    patterns = ANALYSIS_SETTINGS['filter']['path_url']['patterns']
     assert(captures(patterns, 'example.com/foo/bar?query#hash') == [
         'example.com/foo/bar'
     ])
@@ -40,15 +42,15 @@ def test_path_url_filter():
 
 
 def test_rstrip_slash_filter():
-    p = ANNOTATION_ANALYSIS['filter']['rstrip_slash']['pattern']
-    r = ANNOTATION_ANALYSIS['filter']['rstrip_slash']['replacement']
+    p = ANALYSIS_SETTINGS['filter']['rstrip_slash']['pattern']
+    r = ANALYSIS_SETTINGS['filter']['rstrip_slash']['replacement']
     assert(re.sub(p, r, 'example.com/') == 'example.com')
     assert(re.sub(p, r, 'example.com/foo/bar/') == 'example.com/foo/bar')
 
 
 def test_uri_part_tokenizer():
     text = 'http://a.b/foo/bar?c=d#stuff'
-    pattern = ANNOTATION_ANALYSIS['tokenizer']['uri_part']['pattern']
+    pattern = ANALYSIS_SETTINGS['tokenizer']['uri_part']['pattern']
     assert(re.split(pattern, text) == [
         'http', '', '', 'a', 'b', 'foo', 'bar', 'c', 'd', 'stuff'
     ])
@@ -60,13 +62,73 @@ def test_uri_part_tokenizer():
     ])
 
 
+@pytest.mark.usefixtures('client', 'configure_index')
 class TestInit(object):
-    def test_configures_index(self, patch):
+    def test_configures_index_when_index_missing(self, client, configure_index):
+        """Calls configure_index when one doesn't exist."""
+        init(client)
+
+        configure_index.assert_called_once_with(client)
+
+    def test_configures_alias(self, client):
+        """Adds an alias to the newly-created index."""
+        init(client)
+
+        client.conn.indices.put_alias.assert_called_once_with(index='foo-abcd1234', name='foo')
+
+    def test_does_not_recreate_extant_index(self, client, configure_index):
+        """Exits early if the index (or an alias) already exists."""
+        client.conn.indices.exists.return_value = True
+
+        init(client)
+
+        assert not configure_index.called
+
+    def test_raises_if_icu_analysis_plugin_unavailable(self, client):
+        client.conn.cat.plugins.return_value = ''
+
+        with pytest.raises(RuntimeError) as e:
+            init(client)
+
+        assert 'plugin is not installed' in e.value.message
+
+    @pytest.fixture
+    def client(self, client):
+        # By default, pretend that no index exists already...
+        client.conn.indices.exists.return_value = False
+        # Simulate the ICU Analysis plugin
+        client.conn.cat.plugins.return_value = '\n'.join(['foo', 'analysis-icu'])
+        return client
+
+    @pytest.fixture
+    def configure_index(self, patch):
         configure_index = patch('memex.search.config.configure_index')
+        configure_index.return_value = 'foo-abcd1234'
+        return configure_index
 
-        init(mock.sentinel.client)
 
-        configure_index.assert_called_once_with(mock.sentinel.client)
+class TestConfigureIndex(object):
+    def test_creates_randomly_named_index(self, client, matchers):
+        configure_index(client)
+
+        client.conn.indices.create.assert_called_once_with(
+            matchers.regex('foo-[0-9a-f]{8}'),
+            body=mock.ANY)
+
+    def test_returns_index_name(self, client, matchers):
+        name = configure_index(client)
+
+        assert name == matchers.regex('foo-[0-9a-f]{8}')
+
+    def test_sets_correct_mappings_and_settings(self, client):
+        configure_index(client)
+
+        client.conn.indices.create.assert_called_once_with(
+            mock.ANY,
+            body={
+                'mappings': {'annotation': ANNOTATION_MAPPING},
+                'settings': {'analysis': ANALYSIS_SETTINGS},
+            })
 
 
 class TestGetAliasedIndex(object):
@@ -129,6 +191,7 @@ def groups(pattern, text):
 
 @pytest.fixture
 def client():
-    client = mock.Mock(spec_set=['conn', 'index'])
+    client = mock.Mock(spec_set=['conn', 'index', 't'])
     client.index = 'foo'
+    client.t.annotation = 'annotation'
     return client

--- a/tests/memex/search/config_test.py
+++ b/tests/memex/search/config_test.py
@@ -10,6 +10,7 @@ from elasticsearch.exceptions import NotFoundError
 
 from memex.search.config import (
     ANNOTATION_ANALYSIS,
+    init,
     get_aliased_index,
     update_aliased_index,
 )
@@ -57,6 +58,15 @@ def test_uri_part_tokenizer():
         'http', '', '', 'jump', 'to', '', 'u',
         'http', '', '', 'a', 'b', 'foo', 'bar', 'c', 'd', 'stuff'
     ])
+
+
+class TestInit(object):
+    def test_configures_index(self, patch):
+        configure_index = patch('memex.search.config.configure_index')
+
+        init(mock.sentinel.client)
+
+        configure_index.assert_called_once_with(mock.sentinel.client)
 
 
 class TestGetAliasedIndex(object):

--- a/tests/memex/search/index_test.py
+++ b/tests/memex/search/index_test.py
@@ -120,20 +120,24 @@ class TestReindex(object):
         """If the current index isn't concrete, then create a new target index."""
         index.reindex(mock.sentinel.session, es, mock.sentinel.request)
 
-        configure_index.assert_called_once_with(es, matchers.regex('hypothesis-[0-9a-f]{8}'))
+        configure_index.assert_called_once_with(es)
 
-    def test_passes_new_index_to_indexer_if_aliased(self, es, matchers, BatchIndexer):
+    def test_passes_new_index_to_indexer_if_aliased(self, es, configure_index, BatchIndexer):
         """Pass the name of any new index as target_index to indexer."""
+        configure_index.return_value = 'hypothesis-abcd1234'
+
         index.reindex(mock.sentinel.session, es, mock.sentinel.request)
 
         _, kwargs = BatchIndexer.call_args
-        assert kwargs['target_index'] == matchers.regex('hypothesis-[0-9a-f]{8}')
+        assert kwargs['target_index'] == 'hypothesis-abcd1234'
 
-    def test_updates_alias_when_reindexed_if_aliased(self, es, matchers, update_aliased_index):
+    def test_updates_alias_when_reindexed_if_aliased(self, es, configure_index, update_aliased_index):
         """Call update_aliased_index on the client with the new index name."""
+        configure_index.return_value = 'hypothesis-abcd1234'
+
         index.reindex(mock.sentinel.session, es, mock.sentinel.request)
 
-        update_aliased_index.assert_called_once_with(es, matchers.regex('hypothesis-[0-9a-f]{8}'))
+        update_aliased_index.assert_called_once_with(es, 'hypothesis-abcd1234')
 
     def test_does_not_update_alias_if_indexing_fails(self, es, indexer, update_aliased_index):
         """Don't call update_aliased_index if index() fails..."""


### PR DESCRIPTION
In the development environment the application will automatically create a search index if it doesn't find one. In production the same behaviour can be triggered by a call to

    hypothesis initdb

This commit updates the code so that it creates a randomly named index (the name is based off the supplied index name) such as

    hypothesis-abcd1234

and creates an alias for the supplied index name pointing to the concrete index. This makes it much easier to reindex into a new index without having to redeploy or restart the application.

This commit also removes quite a bit of code that is no longer needed now that "documents" aren't stored in the search index, and adds tests for the config functionality.

_**N.B.** This branch is based on #4118 and will need rebasing once that's merged._