### PR TITLE
Use consistent markup for client and server rendered lozenges

### DIFF
--- a/h/static/scripts/controllers/lozenge-controller.js
+++ b/h/static/scripts/controllers/lozenge-controller.js
@@ -21,6 +21,13 @@ class LozengeController extends Controller {
   constructor(element, options) {
     super(element, options);
 
+    // Work-around for HTMLFormElement#submit() failing in Firefox if a submit
+    // button removes itself during click event handler.
+    //
+    // See https://bugzilla.mozilla.org/show_bug.cgi?id=494755#c4 and
+    // https://bugzilla.mozilla.org/show_bug.cgi?id=586329
+    this.refs.deleteButton.type = 'button';
+
     let facetName = '';
     let facetValue = options.content;
 

--- a/h/static/scripts/controllers/lozenge-controller.js
+++ b/h/static/scripts/controllers/lozenge-controller.js
@@ -1,70 +1,65 @@
 'use strict';
 
-const escapeHtml = require('escape-html');
-
 const Controller = require('../base/controller');
 const searchTextParser = require('../util/search-text-parser');
+const { setElementState } = require('../util/dom');
 
 /**
- * Create a lozenge with options.content as its content and append it to containerEl.
+ * A lozenge representing a single search term.
  *
- * A lozenge is made of two parts - the lozenge content and
- * the 'x' button which when clicked removes the lozenge
- * from the container and executes the delete callback provided.
+ * A lozenge consists of two parts - the lozenge content and the 'x' button
+ * which when clicked calls the `deleteCallback` handler passed in the
+ * controller's options.
  *
- * var lozenge = new Lozenge(containerEl, {
- *   content: content,
- *   deleteCallback: deleteCallback,
+ * const lozenge = new Lozenge(element, {
+ *   content,
+ *   deleteCallback,
  * });
  */
 class LozengeController extends Controller {
-  constructor(containerEl, options) {
-    super(containerEl, options);
-    const lozTempContainer = document.createElement('div');
-    let lozengeEl = document.createElement('div');
-    let lozengeMarkup = escapeHtml(options.content);
-    const currentLozenges = containerEl.querySelectorAll('.lozenge');
+
+  constructor(element, options) {
+    super(element, options);
+
+    let facetName = '';
+    let facetValue = options.content;
 
     if (searchTextParser.hasKnownNamedQueryTerm(options.content)) {
       const queryTerm = searchTextParser.getLozengeFacetNameAndValue(options.content);
-      lozengeMarkup = '<span class="lozenge__facet-name">' +
-        escapeHtml(queryTerm.facetName) +
-        '</span>' +
-        ':' +
-        '<span class="lozenge__facet-value">' +
-        escapeHtml(queryTerm.facetValue) +
-        '</span>';
-    }
-    lozengeEl.innerHTML =
-      '<div class="js-lozenge__content lozenge__content">'+
-      lozengeMarkup +
-      '</div>' +
-      '<div class="js-lozenge__close lozenge__close">' +
-      '<img alt="Delete lozenge" src="/assets/images/icons/lozenge-close.svg">' +
-      '</div>';
-    lozengeEl.classList.add('lozenge');
-    lozengeEl.classList.add('js-lozenge');
-
-    lozTempContainer.appendChild(lozengeEl);
-
-    // append the lozenge after the last lozenge child
-    // or as the very first element in the container.
-    // We are doing this over appendChild because we don't want to limit
-    // the ability for the container to also hold other elements like an
-    // input field - allowing them to flow together in the same box model
-    if (currentLozenges && currentLozenges.length > 0) {
-      currentLozenges[currentLozenges.length - 1].insertAdjacentHTML('afterend', lozTempContainer.innerHTML);
-    } else {
-      containerEl.insertAdjacentHTML('afterbegin', lozTempContainer.innerHTML);
+      facetName = queryTerm.facetName;
+      facetValue = queryTerm.facetValue;
     }
 
-    // update reference to point to the actual dom element
-    lozengeEl = containerEl.querySelectorAll('.lozenge')[currentLozenges ? currentLozenges.length : 0];
+    element.classList.add('js-lozenge');
 
-    lozengeEl.querySelector('.js-lozenge__close').addEventListener('mousedown', () => {
-      lozengeEl.remove();
+    this.refs.deleteButton.addEventListener('click', (event) => {
+      event.preventDefault();
       options.deleteCallback();
     });
+
+    this.setState({
+      facetName,
+      facetValue,
+      disabled: false,
+    });
+  }
+
+  update(state) {
+    setElementState(this.element, {disabled: state.disabled});
+    let facetName = state.facetName;
+    if (facetName) {
+      facetName += ':';
+    }
+    this.refs.facetName.textContent = facetName;
+    this.refs.facetValue.textContent = state.facetValue;
+  }
+
+  inputValue() {
+    if (this.state.facetName) {
+      return this.state.facetName + ':' + this.state.facetValue;
+    } else {
+      return this.state.facetValue;
+    }
   }
 }
 

--- a/h/static/scripts/tests/controllers/lozenge-controller-test.js
+++ b/h/static/scripts/tests/controllers/lozenge-controller-test.js
@@ -1,65 +1,32 @@
 'use strict';
 
 const LozengeController = require('../../controllers/lozenge-controller');
+const lozengeTemplate = require('./lozenge-template');
+const { setupComponent } = require('./util');
 
 describe('LozengeController', () => {
-  let el;
-  let opts;
-  let lozengeEl;
-  let lozengeContentEl;
-  let lozengeDeleteEl;
-
-  beforeEach(() => {
-    el = document.createElement('div');
-    opts = {
-      content: 'foo',
+  function createLozenge(content) {
+    return setupComponent(document, lozengeTemplate, LozengeController, {
+      content,
       deleteCallback: sinon.spy(),
-    };
+    });
+  }
 
-    new LozengeController(el, opts);
-    lozengeEl = el.querySelector('.js-lozenge');
-    lozengeContentEl = lozengeEl.querySelector('.js-lozenge__content');
-    lozengeDeleteEl = lozengeEl.querySelector('.js-lozenge__close');
-  });
-
-  it('creates a new lozenge inside the container provided', () => {
-    assert.equal(lozengeContentEl.textContent, opts.content);
-  });
-
-  it('creates a new lozenge for a known named query term inside the container provided', () => {
-    el = document.createElement('div');
-    opts = {
-      content: 'user:foo',
-    };
-
-    new LozengeController(el, opts);
-    lozengeEl = el.querySelector('.js-lozenge');
-    lozengeContentEl = lozengeEl.querySelector('.js-lozenge__content');
-    const facetNameEl = lozengeContentEl.querySelector('.lozenge__facet-name');
-    const facetValueEl = lozengeContentEl.querySelector('.lozenge__facet-value');
-
-    assert.equal(facetNameEl.textContent, 'user');
-    assert.equal(facetValueEl.textContent, 'foo');
+  it('displays the facet name and value for recognized facets', () => {
+    const ctrl = createLozenge('user:foo');
+    assert.equal(ctrl.refs.facetName.textContent, 'user:');
+    assert.equal(ctrl.refs.facetValue.textContent, 'foo');
   });
 
   it('does not create a new lozenge for named query term which is not known', () => {
-    el = document.createElement('div');
-    opts = {
-      content: 'foo:bar',
-    };
-
-    new LozengeController(el, opts);
-    lozengeEl = el.querySelector('.js-lozenge');
-    lozengeContentEl = lozengeEl.querySelector('.js-lozenge__content');
-
-    assert.isNull(lozengeContentEl.querySelector('.lozenge__facet-name'));
-    assert.isNull(lozengeContentEl.querySelector('.lozenge__facet-value'));
-    assert.equal(lozengeContentEl.textContent, opts.content);
+    const ctrl = createLozenge('foo:bar');
+    assert.equal(ctrl.refs.facetName.textContent, '');
+    assert.equal(ctrl.refs.facetValue.textContent, 'foo:bar');
   });
 
   it('removes the lozenge and executes the delete callback provided', () => {
-    lozengeDeleteEl.dispatchEvent(new Event('mousedown'));
-    assert(opts.deleteCallback.calledOnce);
-    assert.isNull(el.querySelector('.js-lozenge'));
+    const ctrl = createLozenge('deleteme');
+    ctrl.refs.deleteButton.dispatchEvent(new Event('click'));
+    assert.calledOnce(ctrl.options.deleteCallback);
   });
 });

--- a/h/static/scripts/tests/controllers/lozenge-template.js
+++ b/h/static/scripts/tests/controllers/lozenge-template.js
@@ -1,0 +1,19 @@
+'use strict';
+
+// Template copied from navbar.html.jinja2
+module.exports = `<div class="lozenge">
+  <div class="lozenge__content">
+    <span class="lozenge__facet-name" data-ref="facetName">
+      {{ facetName }}:
+    </span><!--
+    !--><span class="lozenge__facet-value" data-ref="facetValue">
+      {{ facetValue }}
+    </span>
+  </div>
+  <button data-ref="deleteButton"
+          class="lozenge__close"
+          type="submit"
+          name="delete_lozenge">
+    <!-- Delete icon here !-->
+  </button>
+</div>`;

--- a/h/static/scripts/tests/util/dom-test.js
+++ b/h/static/scripts/tests/util/dom-test.js
@@ -55,4 +55,12 @@ describe('util/dom', () => {
       assert.deepEqual(Array.from(btn.classList), []);
     });
   });
+
+  describe('cloneTemplate', () => {
+    it('returns a clone of the first child Element of the template', () => {
+      const template = createDOM('<template id="test-template"><div id="child"></div></template>');
+      const clone = domUtil.cloneTemplate(template);
+      assert.deepEqual(clone.outerHTML, '<div id="child"></div>');
+    });
+  });
 });

--- a/h/static/scripts/util/dom.js
+++ b/h/static/scripts/util/dom.js
@@ -51,7 +51,24 @@ function findRefs(el) {
   return map;
 }
 
+/**
+ * Clone the content of a <template> element and return the first child Element.
+ *
+ * @param {HTMLTemplateElement} templateEl
+ */
+function cloneTemplate(templateEl) {
+  if (templateEl.content) {
+    // <template> supported natively.
+    const content = templateEl.content.cloneNode(true);
+    return content.firstElementChild;
+  } else {
+    // <template> not supported. Browser just treats it as an unknown Element.
+    return templateEl.firstElementChild.cloneNode(true);
+  }
+}
+
 module.exports = {
-  findRefs: findRefs,
-  setElementState: setElementState,
+  cloneTemplate,
+  findRefs,
+  setElementState,
 };

--- a/h/static/styles/partials-v2/_elements.scss
+++ b/h/static/styles/partials-v2/_elements.scss
@@ -23,3 +23,9 @@ input[type=text],
 textarea {
   appearance: none;
 }
+
+// Hide contents of <template> elements in browsers that do not support
+// this element natively (eg. IE).
+template {
+  display: none;
+}

--- a/h/templates/panels/navbar.html.jinja2
+++ b/h/templates/panels/navbar.html.jinja2
@@ -7,14 +7,15 @@
 {% macro lozenge(facetName, facetValue) %}
   <div class="lozenge">
     <div class="lozenge__content">
-      <span class="lozenge__facet-name">
+      <span class="lozenge__facet-name" data-ref="facetName">
         {{ facetName }}:
       </span>
-      <span class="lozenge__facet-value">
+      <span class="lozenge__facet-value" data-ref="facetValue">
         {{ facetValue }}
       </span>
     </div>
-    <button class="lozenge__close"
+    <button data-ref="deleteButton"
+            class="lozenge__close"
             type="submit"
             name="delete_lozenge">
       <img alt="{% trans %}Delete lozenge{% endtrans %}"
@@ -24,6 +25,9 @@
 {% endmacro %}
 
 <header class="nav-bar">
+  <template id="lozenge-template">
+    {{ lozenge('','') }}
+  </template>
   <div class="nav-bar__content">
     <a href="/" title="Hypothesis homepage" class="nav-bar__logo-container"><!--
       !--><img alt="Hypothesis logo" class="nav-bar__logo" src="/assets/images/logo.svg"></a>


### PR DESCRIPTION
_This is ready for review but marked as WIP because of an issue seen in Firefox (but not Chrome) where removing a client-rendered lozenge does not result in the search bar form being submitted_

The client-side implementation of lozenges used a different DOM-structure than
server-rendered lozenges. This caused several problems:

 - The client JS code for lozenges could not be used with server-rendered
   lozenges.

 - The client DOM structure failed at accessibility by using a `<div>` rather
   than a `<button>` for the close button - hence it did not support keyboard
   focus, identify as a button for screen readers etc.

 - LozengeController did not follow the patterns and conventions of other
   controllers, which all work by taking an existing server-rendered element as
   input and enhancing it with behavior.

Fix this by rendering a `<template>` [1] for client-generated lozenges in the markup
from the server and cloning that as the basis for new lozenges in client code.

Sharing the structure will also make a few other things easier in future:
* We can fix the current flash of "Delete lozenge" text as the delete icon loads by replacing it with an inline SVG
* We can eliminate the FOUC in the navbar on page load by server-rendering the lozenges that correspond to the initial search query

[1] https://developer.mozilla.org/en/docs/Web/HTML/Element/template