### PR TITLE
Fix FOUC in lozenges on page load

### DIFF
--- a/h/static/styles/partials-v2/_lozenge.scss
+++ b/h/static/styles/partials-v2/_lozenge.scss
@@ -27,7 +27,7 @@
   @include reset-button;
 
   font-weight: bold;
-  padding: 3px 5px 3px 5px;
+  padding: 0px 5px 0px 5px;
   cursor: default;
   border-radius: 0 2px 2px 0;
 

--- a/h/templates/panels/navbar.html.jinja2
+++ b/h/templates/panels/navbar.html.jinja2
@@ -17,9 +17,9 @@
     <button data-ref="deleteButton"
             class="lozenge__close"
             type="submit"
-            name="delete_lozenge">
-      <img alt="{% trans %}Delete lozenge{% endtrans %}"
-           src="/assets/images/icons/lozenge-close.svg">
+            name="delete_lozenge"
+            title="{% trans %}Remove search term{% endtrans %}">
+      {{ svg_icon('lozenge-close') }}
     </button>
   </div>
 {% endmacro %}


### PR DESCRIPTION
Use an inline SVG rather than an async-loaded image for the lozenge
delete icon to avoid a layout flicker and flash of `<img>` alt text on
page load.

The padding tweak is needed to ensure correct vertical centering of the
icon - tested in Firefox and Chrome.