### PR TITLE
Add migration for `group.authority` column

### DIFF
--- a/h/migrations/versions/3acf258322d5_add_authority_column_to_group.py
+++ b/h/migrations/versions/3acf258322d5_add_authority_column_to_group.py
@@ -1,0 +1,24 @@
+"""
+Add authority column to group
+
+Revision ID: 3acf258322d5
+Revises: c36369fe730f
+Create Date: 2016-11-24 16:33:40.238726
+"""
+
+from __future__ import unicode_literals
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '3acf258322d5'
+down_revision = 'c36369fe730f'
+
+
+def upgrade():
+    op.add_column('group', sa.Column('authority', sa.UnicodeText(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('group', 'authority')


### PR DESCRIPTION
This is just adding a new database column. This has to be deployed and run on production before the next pull request is merged.

Being able to choose an authority for a group is the first step in making publisher groups possible. The second step will be a bunch of flags (`readable_by`, `writeable_by`, `joinable_by`, each with a set of possible values: `None`, `"authority"`, `"members"`, `"world"`), with which we can have a group that is scoped by the publishers authority and will automatically allow users with the same authority to write to it.