### PR TITLE
Add group authority field and use it

### DIFF
--- a/h/groups/services.py
+++ b/h/groups/services.py
@@ -22,7 +22,7 @@ class GroupsService(object):
         self.user_fetcher = user_fetcher
         self.publish = publish
 
-    def create(self, name, userid, description=None):
+    def create(self, name, authority, userid, description=None):
         """
         Create a new group.
 
@@ -33,7 +33,10 @@ class GroupsService(object):
         :returns: the created group
         """
         creator = self.user_fetcher(userid)
-        group = Group(name=name, creator=creator, description=description)
+        group = Group(name=name,
+                      authority=authority,
+                      creator=creator,
+                      description=description)
         self.session.add(group)
         self.session.flush()
 

--- a/h/migrations/versions/140b450225cd_backfill_group_authority.py
+++ b/h/migrations/versions/140b450225cd_backfill_group_authority.py
@@ -1,0 +1,25 @@
+"""
+Backfill group.authority
+
+Revision ID: 140b450225cd
+Revises: 3acf258322d5
+Create Date: 2016-11-25 15:17:22.792448
+"""
+
+from __future__ import unicode_literals
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = '140b450225cd'
+down_revision = '3acf258322d5'
+
+group_table = sa.table('group', sa.Column('authority', sa.UnicodeText()))
+
+
+def upgrade():
+    op.execute(group_table.update().values(authority='hypothes.is'))
+
+
+def downgrade():
+    pass

--- a/h/migrations/versions/8990247b876c_disallow_group_authority_null.py
+++ b/h/migrations/versions/8990247b876c_disallow_group_authority_null.py
@@ -1,0 +1,22 @@
+"""
+Disallow group.authority null
+
+Revision ID: 8990247b876c
+Revises: 140b450225cd
+Create Date: 2016-11-25 15:33:53.417103
+"""
+
+from __future__ import unicode_literals
+
+from alembic import op
+
+revision = '8990247b876c'
+down_revision = '140b450225cd'
+
+
+def upgrade():
+    op.alter_column('group', 'authority', nullable=False)
+
+
+def downgrade():
+    op.alter_column('group', 'authority', nullable=True)

--- a/h/models/group.py
+++ b/h/models/group.py
@@ -37,6 +37,7 @@ class Group(Base, mixins.Timestamps):
                       default=pubid.generate,
                       unique=True,
                       nullable=False)
+    authority = sa.Column(sa.UnicodeText(), nullable=False)
     name = sa.Column(sa.UnicodeText(), nullable=False, index=True)
 
     # We store information about who created the group -- we don't use this

--- a/h/models/group.py
+++ b/h/models/group.py
@@ -54,8 +54,9 @@ class Group(Base, mixins.Timestamps):
         'User', secondary='user_group', backref=sa.orm.backref(
             'groups', order_by='Group.name'))
 
-    def __init__(self, name, creator, description=None):
+    def __init__(self, name, authority, creator, description=None):
         self.name = name
+        self.authority = authority
         self.description = description
         self.creator = creator
         self.members.append(creator)

--- a/h/views/groups.py
+++ b/h/views/groups.py
@@ -47,6 +47,7 @@ class GroupCreateController(object):
             groups_service = self.request.find_service(name='groups')
             group = groups_service.create(
                 name=appstruct['name'],
+                authority=self.request.auth_domain,
                 description=appstruct.get('description'),
                 userid=self.request.authenticated_userid)
 

--- a/tests/common/factories.py
+++ b/tests/common/factories.py
@@ -103,6 +103,7 @@ class Group(ModelFactory):
         force_flush = True
 
     name = factory.Sequence(lambda n:'Test Group {n}'.format(n=str(n)))
+    authority = 'example.com'
     creator = factory.SubFactory(User)
 
 

--- a/tests/h/models/groups_test.py
+++ b/tests/h/models/groups_test.py
@@ -9,15 +9,17 @@ from h import models
 
 def test_init(db_session, factories):
     name = "My Hypothesis Group"
+    authority = "foobar.com"
     description = "This group is awesome"
     user = factories.User()
 
-    group = models.Group(name=name, creator=user, description=description)
+    group = models.Group(name=name, authority=authority, creator=user, description=description)
     db_session.add(group)
     db_session.flush()
 
     assert group.id
     assert group.name == name
+    assert group.authority == authority
     assert group.description == description
     assert group.created
     assert group.updated
@@ -29,13 +31,14 @@ def test_init(db_session, factories):
 def test_with_short_name(factories):
     """Should raise ValueError if name shorter than 4 characters."""
     with pytest.raises(ValueError):
-        models.Group(name="abc", creator=factories.User())
+        models.Group(name="abc", authority="foobar.com", creator=factories.User())
 
 
 def test_with_long_name(factories):
     """Should raise ValueError if name longer than 25 characters."""
     with pytest.raises(ValueError):
         models.Group(name="abcdefghijklmnopqrstuvwxyz",
+                     authority="foobar.com",
                      creator=factories.User())
 
 
@@ -43,7 +46,7 @@ def test_slug(db_session, factories):
     name = "My Hypothesis Group"
     user = factories.User()
 
-    group = models.Group(name=name, creator=user)
+    group = models.Group(name=name, authority="foobar.com", creator=user)
     db_session.add(group)
     db_session.flush()
 
@@ -54,7 +57,7 @@ def test_repr(db_session, factories):
     name = "My Hypothesis Group"
     user = factories.User()
 
-    group = models.Group(name=name, creator=user)
+    group = models.Group(name=name, authority='foobar.com', creator=user)
     db_session.add(group)
     db_session.flush()
 
@@ -66,8 +69,8 @@ def test_created_by(db_session, factories):
     name_2 = "My second group"
     user = factories.User()
 
-    group_1 = models.Group(name=name_1, creator=user)
-    group_2 = models.Group(name=name_2, creator=user)
+    group_1 = models.Group(name=name_1, authority='foobar.com', creator=user)
+    group_2 = models.Group(name=name_2, authority='foobar.com', creator=user)
 
     db_session.add(group_1, group_2)
     db_session.flush()
@@ -254,7 +257,9 @@ def documents(db_session):
 @pytest.fixture
 def group(db_session, factories):
     """Add a new group to the db and return it."""
-    group_ = models.Group(name='test-group', creator=factories.User())
+    group_ = models.Group(name='test-group',
+                          authority='foobar.com',
+                          creator=factories.User())
     db_session.add(group_)
     group_.pubid = 'test-group'
     return group_

--- a/tests/h/views/groups_test.py
+++ b/tests/h/views/groups_test.py
@@ -53,7 +53,7 @@ class TestGroupCreateController(object):
 
         controller.post()
 
-        assert groups_service.created == [('my_new_group', 'ariadna', 'foobar')]
+        assert groups_service.created == [('my_new_group', 'example.com', 'ariadna', 'foobar')]
 
     def test_post_creates_new_group_if_legacy_form_valid(self,
                                                          controller,
@@ -70,7 +70,7 @@ class TestGroupCreateController(object):
 
         controller.post()
 
-        assert groups_service.created == [('my_new_group', 'ariadna', None)]
+        assert groups_service.created == [('my_new_group', 'example.com', 'ariadna', None)]
 
     def test_post_redirects_if_form_valid(self,
                                           controller,
@@ -127,6 +127,7 @@ class TestGroupEditController(object):
 
         creator = User(username='luke', authority='example.org')
         group = Group(name='Birdwatcher Community',
+                      authority='foobar.com',
                       description='We watch birds all day long',
                       creator=creator)
         group.pubid = 'the-test-pubid'
@@ -144,6 +145,7 @@ class TestGroupEditController(object):
     def test_post_sets_group_properties(self, form_validating_to, pyramid_request):
         creator = User(username='luke', authority='example.org')
         group = Group(name='Birdwatcher Community',
+                      authority='foobar.com',
                       description='We watch birds all day long',
                       creator=creator)
         group.pubid = 'the-test-pubid'
@@ -290,8 +292,8 @@ class FakeGroupsService(object):
         self.joined = []
         self.left = []
 
-    def create(self, name, userid, description):
-        self.created.append((name, userid, description))
+    def create(self, name, authority, userid, description):
+        self.created.append((name, authority, userid, description))
         return FakeGroup('abc123', 'fake-group')
 
     def member_join(self, group, userid):


### PR DESCRIPTION
~**This is based on #4125 and needs rebasing once that one is merged. The migration in #4125 also needs to run in production first.**~

This pull request uses the Group authority field in the code base by writing the value of `request.auth_domain` when a new group gets created. This also includes a migration that sets all current groups authority field to "hypothes.is" and then disallows `NULL` values.