### PR TITLE
Implement updated design for search result bucket sidebar

### DIFF
--- a/h/static/images/icons/account.svg
+++ b/h/static/images/icons/account.svg
@@ -5,7 +5,7 @@
     <desc>Created with Sketch.</desc>
     <defs></defs>
     <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" sketch:type="MSPage">
-        <g id="Artboard-1-Copy" sketch:type="MSArtboardGroup" fill="#000000">
+        <g id="Artboard-1-Copy" sketch:type="MSArtboardGroup" fill="currentColor">
             <circle id="Oval-1" sketch:type="MSShapeGroup" cx="8" cy="4" r="3"></circle>
             <path d="M8,15 C11,15 14,14.4329966 14,12 C14,10.5670034 10,8 8,8 C6,8 2,10.5670034 2,12 C2,14.4329966 5,15 8,15 Z" id="Oval-1-Copy" sketch:type="MSShapeGroup"></path>
         </g>

--- a/h/static/styles/partials-v2/_search.scss
+++ b/h/static/styles/partials-v2/_search.scss
@@ -225,7 +225,18 @@
                  // work).
 }
 
+$stats-icon-column-width: 20px;
+
+.search-bucket-stats__icon {
+  width: 12px;
+  margin-right: $stats-icon-column-width - 12px;
+}
+
 .search-bucket-stats__key {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+
   margin-bottom: 2px;
   color: $grey-6;
   font-weight: bold;
@@ -233,7 +244,8 @@
 
 .search-bucket-stats__val {
   color: $grey-6;
-  margin-bottom: 20px;
+  margin-bottom: 15px;
+  margin-left: $stats-icon-column-width;
 }
 
 .search-bucket-stats__url,
@@ -249,11 +261,10 @@
 }
 
 .search-bucket-stats__incontext-link {
-  display: block;
-  margin-top: 5px;
-
   color: $grey-6;
-  font-weight: bold;
+  &:hover {
+    text-decoration: underline;
+  }
 }
 
 .search-bucket-stats__incontext-icon {

--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -39,7 +39,7 @@
       <a class="search-bucket-stats__incontext-link"
          href="{{ bucket.incontext_link(request) }}"
          target="_blank">
-         Visit annotations in context
+         {% trans %}Visit annotations in context{% endtrans %}
        </a>
     </div>
     <div class="search-bucket-stats__val"></div>
@@ -47,7 +47,7 @@
   {% if bucket.tags %}
     <div class="search-bucket-stats__key">
       {{ svg_icon('up-right-arrow', css_class='search-bucket-stats__icon') }}
-      Tags
+      {% trans %}Tags{% endtrans %}
     </div>
     <ul class="search-bucket-stats__val">
       {% for tag in bucket.tags %}
@@ -58,7 +58,7 @@
   {% endif %}
   <div class="search-bucket-stats__key">
     {{ svg_icon('account', css_class='search-bucket-stats__icon') }}
-    Annotators
+    {% trans %}Annotators{% endtrans %}
   </div>
   <ul class="search-bucket-stats__val">
     {% for user in bucket.users %}
@@ -71,7 +71,7 @@
   {% if bucket.uri %}
     <div class="search-bucket-stats__key">
       {{ svg_icon('up-right-arrow', css_class='search-bucket-stats__icon') }}
-      URL
+      {% trans %}URL{% endtrans %}
     </div>
     <div class="search-bucket-stats__val search-bucket-stats__url">
         <a class="search-bucket-stats__link"

--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -33,26 +33,20 @@
 {# Card displaying statistics about a bucket of annotations. #}
 {% macro search_bucket_stats(bucket) %}
 <div class="search-bucket-stats">
-  {% if bucket.uri %}
+  {% if bucket.uri and bucket.incontext_link(request) %}
     <div class="search-bucket-stats__key">
-        URL
+      {{ svg_icon('up-right-arrow', css_class='search-bucket-stats__icon') }}
+      <a class="search-bucket-stats__incontext-link"
+         href="{{ bucket.incontext_link(request) }}"
+         target="_blank">
+         Visit annotations in context
+       </a>
     </div>
-    <div class="search-bucket-stats__val search-bucket-stats__url">
-        <div><a class="search-bucket-stats__link"
-                href="{{ bucket.uri }}">{{ pretty_link(bucket.uri) }}</a></div>
-        {% if bucket.incontext_link(request) %}
-        <div>
-          <a class="search-bucket-stats__incontext-link"
-             href="{{ bucket.incontext_link(request) }}"
-             target="_blank">
-             Visit annotations in context {{ svg_icon('up-right-arrow', css_class='search-bucket-stats__incontext-icon') }}
-           </a>
-        </div>
-        {% endif %}
-    </div>
+    <div class="search-bucket-stats__val"></div>
   {% endif %}
   {% if bucket.tags %}
     <div class="search-bucket-stats__key">
+      {{ svg_icon('up-right-arrow', css_class='search-bucket-stats__icon') }}
       Tags
     </div>
     <ul class="search-bucket-stats__val">
@@ -63,6 +57,7 @@
     </ul>
   {% endif %}
   <div class="search-bucket-stats__key">
+    {{ svg_icon('account', css_class='search-bucket-stats__icon') }}
     Annotators
   </div>
   <ul class="search-bucket-stats__val">
@@ -73,6 +68,17 @@
       </li>
     {% endfor %}
   </ul>
+  {% if bucket.uri %}
+    <div class="search-bucket-stats__key">
+      {{ svg_icon('up-right-arrow', css_class='search-bucket-stats__icon') }}
+      URL
+    </div>
+    <div class="search-bucket-stats__val search-bucket-stats__url">
+        <a class="search-bucket-stats__link"
+           href="{{ bucket.uri }}"
+           target="_blank">{{ pretty_link(bucket.uri) }}</a>
+    </div>
+  {% endif %}
 </div>
 {% endmacro %}
 


### PR DESCRIPTION
Implement the design from https://github.com/hypothesis/h/issues/4058#issuecomment-261954000

 * Move in-context link to top of sidebar and URL section to bottom
 * Add icons to the left of the heading for each section

_**Note: This is not using the final icons for the Tags or URL sections, I will submit another PR to update the icons when I have them**_

**Spec:**

![](https://cloud.githubusercontent.com/assets/8598901/20486407/e705b336-afff-11e6-93a3-0985b23d02b8.png)

**Current screenshot (Ubuntu):**

![bucket-sidebar-v3](https://cloud.githubusercontent.com/assets/2458/20629681/b6e2fbfa-b324-11e6-86cd-1145c8336de3.png)
