### PR TITLE
Upgrade SQLAlchemy to 1.1

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 PyJWT
-SQLAlchemy
+SQLAlchemy >= 1.1.4
 alembic
 bcrypt
 celery == 3.1.25  # Pin to latest 3.1.x to ensure forwards-compat with 4.x

--- a/requirements.in
+++ b/requirements.in
@@ -15,7 +15,7 @@ gunicorn
 itsdangerous
 jsonpointer == 1.0
 jsonschema
-kombu
+kombu <3.1 # Pinned because of celery pin
 newrelic
 passlib
 psycogreen

--- a/requirements.txt
+++ b/requirements.txt
@@ -66,7 +66,7 @@ raven==5.24.3
 repoze.lru==0.6           # via pyramid
 repoze.sendmail==4.1
 six==1.10.0               # via bcrypt, bleach, cryptography, html5lib, python-dateutil
-SQLAlchemy==1.0.14        # via alembic, zope.sqlalchemy
+SQLAlchemy==1.1.4         # via alembic, zope.sqlalchemy
 statsd==3.2.1
 transaction==2.0.3        # via pyramid-tm, repoze.sendmail, zope.sqlalchemy
 translationstring==1.3    # via colander, deform, pyramid


### PR DESCRIPTION
Version 1.1 provides better handling of the enum datatype which is needed for the next chunk of work for publisher groups.