### PR TITLE
Add a 'Back' link to the footer of the accounts forms

### DIFF
--- a/h/static/styles/partials-v2/_form.scss
+++ b/h/static/styles/partials-v2/_form.scss
@@ -50,14 +50,26 @@
   color: $grey-5;
 }
 
-.form-footer {
+@mixin form-footer {
   @include font-normal;
+  color: $grey-5;
+}
+
+.form-footer {
+  @include form-footer;
 
   margin-top: 80px;
 
   border-top: 1px solid $grey-3;
-  color: $grey-5;
   padding-top: 15px;
+}
+
+// A form footer with no top border, useful for additional sections at the
+// bottom of a footer.
+.form-footer--no-border {
+  @include form-footer;
+
+  margin-top: 15px;
 }
 
 .form-help-text {

--- a/h/static/styles/partials-v2/_link.scss
+++ b/h/static/styles/partials-v2/_link.scss
@@ -12,3 +12,8 @@
 .link:hover {
   color: $brand;
 }
+
+// A light link which appears at the footer of the page.
+.link--footer {
+  color: $grey-5;
+}

--- a/h/templates/groups/edit.html.jinja2
+++ b/h/templates/groups/edit.html.jinja2
@@ -7,6 +7,6 @@
   {{ form }}
 
   <footer class="form-footer">
-    <a class="link" href="{{ group_path }}">&#8592; Back to the groups page</a>
+    {{ panel('back_link') }}
   </footer>
 {% endblock page_content %}

--- a/h/templates/layouts/account.html.jinja2
+++ b/h/templates/layouts/account.html.jinja2
@@ -48,6 +48,10 @@
           </div>
         {%- endif %}
         {{ self.page_content() }}
+
+        <footer class="form-footer--no-border">
+          {{ panel('back_link') }}
+        </footer>
       </div>
     {% else %}
       {% include "h:templates/includes/logo-header.html.jinja2" %}

--- a/h/templates/panels/back_link.html.jinja2
+++ b/h/templates/panels/back_link.html.jinja2
@@ -1,0 +1,4 @@
+{% if back_location and back_label %}
+<a class="link link--footer"
+   href="{{ back_location }}">← {{ back_label }}</a>
+{% endif %}

--- a/h/views/activity.py
+++ b/h/views/activity.py
@@ -144,7 +144,8 @@ class GroupSearchController(SearchController):
 
         if self.request.has_permission('admin', group):
             result['group_edit_url'] = self.request.route_url('group_edit',
-                                                              pubid=pubid)
+                pubid=pubid,
+                _query={'back_label': _('Back to group overview page')})
 
         result['more_info'] = 'more_info' in self.request.params
 
@@ -267,7 +268,8 @@ class UserSearchController(SearchController):
 
         if self.request.authenticated_user == user:
             result['user']['edit_url'] = self.request.route_url(
-                'account_profile')
+                'account_profile',
+                _query={'back_label': _('Back to your profile')})
 
         if not result.get('q'):
             if self.request.authenticated_user == user:

--- a/h/views/activity.py
+++ b/h/views/activity.py
@@ -144,8 +144,7 @@ class GroupSearchController(SearchController):
 
         if self.request.has_permission('admin', group):
             result['group_edit_url'] = self.request.route_url('group_edit',
-                pubid=pubid,
-                _query={'back_label': _('Back to group overview page')})
+                                                              pubid=pubid)
 
         result['more_info'] = 'more_info' in self.request.params
 
@@ -268,8 +267,7 @@ class UserSearchController(SearchController):
 
         if self.request.authenticated_user == user:
             result['user']['edit_url'] = self.request.route_url(
-                'account_profile',
-                _query={'back_label': _('Back to your profile')})
+                'account_profile')
 
         if not result.get('q'):
             if self.request.authenticated_user == user:

--- a/h/views/panels.py
+++ b/h/views/panels.py
@@ -17,6 +17,21 @@ def group_invite(context, request, group_url):
     return {'group_url': group_url}
 
 
+@panel_config(name='back_link',
+              renderer='h:templates/panels/back_link.html.jinja2')
+def back_link(context, request):
+    """
+    A link which takes the user back to the previous page on the site.
+
+    The link is only displayed if the referring page sets a label via the
+    "back_label" query param.
+    """
+    return {
+        'back_label': request.params.get('back_label'),
+        'back_location': request.referrer,
+    }
+
+
 @panel_config(name='navbar', renderer='h:templates/panels/navbar.html.jinja2')
 def navbar(context, request, opts={}):
     """

--- a/h/views/panels.py
+++ b/h/views/panels.py
@@ -7,8 +7,21 @@ from __future__ import unicode_literals
 from pyramid_layout.panel import panel_config
 
 from h import i18n
+from h._compat import urlparse
 
 _ = i18n.TranslationString
+
+
+def _matches_route(path, request, route_name):
+    """
+    Return ``True`` if ``path`` matches the URL pattern for a given route.
+    """
+
+    introspector = request.registry.introspector
+
+    # `route` is a pyramid.interfaces.IRoute
+    route = introspector.get('routes', route_name)['object']
+    return route.match(path) is not None
 
 
 @panel_config(name='group_invite',
@@ -22,12 +35,23 @@ def group_invite(context, request, group_url):
 def back_link(context, request):
     """
     A link which takes the user back to the previous page on the site.
-
-    The link is only displayed if the referring page sets a label via the
-    "back_label" query param.
     """
+
+    referrer_path = urlparse.urlparse(request.referrer or '').path
+    current_username = request.authenticated_user.username
+
+    if referrer_path == request.route_path('activity.user_search',
+                                           username=current_username):
+        back_label = _('Back to your profile page')
+    elif _matches_route(referrer_path, request, 'activity.group_search'):
+        back_label = _('Back to group overview page')
+    elif referrer_path:
+        back_label = _('Back')
+    else:
+        back_label = None
+
     return {
-        'back_label': request.params.get('back_label'),
+        'back_label': back_label,
         'back_location': request.referrer,
     }
 

--- a/tests/h/views/panels_test.py
+++ b/tests/h/views/panels_test.py
@@ -90,19 +90,39 @@ class TestNavbar(object):
         return pyramid_request
 
 
+@pytest.mark.usefixtures('routes')
 class TestBackLink(object):
 
-    def test_sets_back_location_from_referrer(self, pyramid_request):
+    def test_it_sets_back_location_from_referrer(self, pyramid_request):
         pyramid_request.referrer = 'https://example.com/prev-page'
 
         result = panels.back_link({}, pyramid_request)
 
         assert result['back_location'] == 'https://example.com/prev-page'
 
-    def test_it_sets_back_label(self, pyramid_request):
-        pyramid_request.params['back_label'] = 'Back to your profile'
-        pyramid_request.referrer = None
+    @pytest.mark.parametrize('referrer,label', [
+        ('https://example.com/users/currentuser', 'Back to your profile page'),
+        ('https://example.com/users/currentuser?q=tag:foo', 'Back to your profile page'),
+        ('https://example.com/users/otheruser', 'Back'),
+        ('https://example.com/groups/abc', 'Back to group overview page'),
+        ('https://example.com/search', 'Back'),
+        (None, None),
+    ])
+    def test_it_sets_back_label(self, pyramid_request, referrer, label):
+        pyramid_request.referrer = referrer
 
         result = panels.back_link({}, pyramid_request)
 
-        assert result['back_label'] == 'Back to your profile'
+        assert result['back_label'] == label
+
+    @pytest.fixture
+    def pyramid_request(self, pyramid_request):
+        pyramid_request.authenticated_user = Mock(username='currentuser')
+        return pyramid_request
+
+
+@pytest.fixture
+def routes(pyramid_config):
+    pyramid_config.add_route('activity.user_search', '/users/{username}')
+    pyramid_config.add_route('activity.group_search', '/groups/{pubid}')
+    return pyramid_config

--- a/tests/h/views/panels_test.py
+++ b/tests/h/views/panels_test.py
@@ -88,3 +88,21 @@ class TestNavbar(object):
     def req(self, pyramid_request):
         pyramid_request.authenticated_user = None
         return pyramid_request
+
+
+class TestBackLink(object):
+
+    def test_sets_back_location_from_referrer(self, pyramid_request):
+        pyramid_request.referrer = 'https://example.com/prev-page'
+
+        result = panels.back_link({}, pyramid_request)
+
+        assert result['back_location'] == 'https://example.com/prev-page'
+
+    def test_it_sets_back_label(self, pyramid_request):
+        pyramid_request.params['back_label'] = 'Back to your profile'
+        pyramid_request.referrer = None
+
+        result = panels.back_link({}, pyramid_request)
+
+        assert result['back_label'] == 'Back to your profile'


### PR DESCRIPTION
Add a 'Back' link to the footer of the accounts forms

Add a Back link at the bottom of the accounts forms that takes the user
back to the previous page, if they came from the 'Edit Profile' link in
the sidebar.

Fixes hypothesis/product-backlog#42
