### PR TITLE
Add migration for group access flag columns

### DIFF
--- a/h/migrations/versions/af88524994ce_add_group_access_flags.py
+++ b/h/migrations/versions/af88524994ce_add_group_access_flags.py
@@ -1,0 +1,55 @@
+"""
+Add group access flags
+
+Revision ID: af88524994ce
+Revises: 8990247b876c
+Create Date: 2016-11-25 15:58:59.517470
+"""
+
+from __future__ import unicode_literals
+
+import enum
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = 'af88524994ce'
+down_revision = '8990247b876c'
+
+class JoinableBy(enum.Enum):
+    authority = 'authority'
+joinable_type = sa.Enum(JoinableBy, name='group_joinable_by')
+
+class ReadableBy(enum.Enum):
+    authority = 'authority'
+    members = 'members'
+    world = 'world'
+readable_type = sa.Enum(ReadableBy, name='group_readable_by')
+
+class WriteableBy(enum.Enum):
+    authority = 'authority'
+    members = 'members'
+writeable_type = sa.Enum(WriteableBy, name='group_writeable_by')
+
+
+
+def upgrade():
+    joinable_type.create(op.get_bind())
+    op.add_column('group', sa.Column('joinable_by', joinable_type, nullable=True))
+
+    readable_type.create(op.get_bind())
+    op.add_column('group', sa.Column('readable_by', readable_type, nullable=True))
+
+    writeable_type.create(op.get_bind())
+    op.add_column('group', sa.Column('writeable_by', writeable_type, nullable=True))
+
+
+def downgrade():
+    op.drop_column('group', 'joinable_by')
+    joinable_type.drop(op.get_bind())
+
+    op.drop_column('group', 'readable_by')
+    readable_type.drop(op.get_bind())
+
+    op.drop_column('group', 'writeable_by')
+    writeable_type.drop(op.get_bind())

--- a/requirements.in
+++ b/requirements.in
@@ -10,6 +10,7 @@ cryptography
 deform < 1.0
 deform-jinja2
 elasticsearch < 2.0.0
+enum34
 gevent
 gunicorn
 itsdangerous

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ cryptography==1.4
 deform-jinja2==0.5
 deform==0.9.9
 elasticsearch==1.9.0
-enum34==1.1.6             # via cryptography
+enum34==1.1.6
 functools32==3.2.3.post2  # via jsonschema
 gevent==1.1.2
 greenlet==0.4.10          # via gevent


### PR DESCRIPTION
These are a bunch of columns for the groups table so we can represent the different types of groups that we have and are about to build. This is based on the findings on the [spike card](https://github.com/hypothesis/product-backlog/issues/39#issuecomment-262810123).

* `joinable_by` represents which type of user is allowed to join the group.
  * value `None` (`NULL`) means that no user is allowed to join this group
  * value `authority` means that users with the same authority as the group's authority are allowed to join the group
* `readable_by` represents which type of user is allowed to read the groups information and its annotations
  *  value `None` (`NULL`) means that no user is allowed to read the annotations
  * value `members` means that users who joined (an entry in the `user_group` table must exist) are allowed the annotations
  * value `authority` means that users with the same authority as the group's authority are allowed to read the annotations (note: this means that no entry in the `user_group` table is necessary)
  * value `world` means that everybody is allowed to read the annotations (note: this means that no entry in `user_group` table is necessary). This also means that logged-out users are allowed to read the annotations.
* `writeable_by` represents which type of user is allowed to write annotations to the group
  * value `None` (`NULL`) means that no user is allowed to write annotations to the group
  * value `members` means that users who joined (an entry in the `user_group` table must exist) are allowed to write annotations to the group.
  * value `authority` means that users with the same authority as the group's authority are allowed to write annotations to the group (note: this means that no entry in the `user_group` table is necessary).

We know that we want to keep the current (private) groups, and that we want to implement publisher groups. These can be represented with the flags above:

**Private (current) groups:**
* `joinable_by: authority`
* `readable_by: members`
* `writeable_by: members`

**Publisher groups:**
* `joinable_by: None`
* `readable_by: world`
* `writeable_by: authority`

While we  don't want to predict the future but rather keep our data model flexible and changing, it's sometimes useful to test a decision for future ideas that are only slightly defined. We know we would like to do something like public groups, where everybody can read but only selected users can write, this is mostly possible with the above flags and values (`readable_by: world` and `writeable_by: members`, the joining will have to be implemented in a way that only selected people can be invited).