### PR TITLE
Use traversal for /users/{username} pages

### DIFF
--- a/h/activity/query.py
+++ b/h/activity/query.py
@@ -86,9 +86,12 @@ def check_url(request, query, unparse=parser.unparse):
 
     elif _single_entry(query, 'user'):
         username = query.pop('user')
-        redirect = request.route_path('activity.user_search',
-                                      username=username,
-                                      _query={'q': unparse(query)})
+        user = request.find_service(name='user').fetch(username,
+                                                       request.auth_domain)
+        if user:
+            redirect = request.route_path('activity.user_search',
+                                          username=username,
+                                          _query={'q': unparse(query)})
 
     if redirect is not None:
         raise HTTPFound(location=redirect)

--- a/h/models/user.py
+++ b/h/models/user.py
@@ -41,6 +41,22 @@ class UserIDComparator(Comparator):
                        val['domain'] == self.authority)
 
 
+class UserFactory(object):
+    """Root resource for routes that look up User objects by traversal."""
+
+    def __init__(self, request):
+        self.request = request
+
+    def __getitem__(self, username):
+        user = self.request.find_service(name='user').fetch(
+            username, self.request.auth_domain)
+
+        if not user:
+            raise KeyError()
+
+        return user
+
+
 class User(Base):
     __tablename__ = 'user'
     __table_args__ = (

--- a/h/routes.py
+++ b/h/routes.py
@@ -27,7 +27,10 @@ def includeme(config):
     # Activity
     config.add_route('activity.search', '/search')
     config.add_route('activity.group_search', '/groups/{pubid}/search')
-    config.add_route('activity.user_search', '/users/{username}')
+    config.add_route('activity.user_search',
+                     '/users/{username}',
+                     factory='h.models.user:UserFactory',
+                     traverse='/{username}')
 
     # Admin
     config.add_route('admin_index', '/admin/')

--- a/tests/h/routes_test.py
+++ b/tests/h/routes_test.py
@@ -35,7 +35,7 @@ def test_includeme():
         call('dismiss_sidebar_tutorial', '/app/dismiss_sidebar_tutorial'),
         call('activity.search', '/search'),
         call('activity.group_search', '/groups/{pubid}/search'),
-        call('activity.user_search', '/users/{username}'),
+        call('activity.user_search', '/users/{username}', factory=u'h.models.user:UserFactory', traverse=u'/{username}'),
         call('admin_index', '/admin/'),
         call('admin_admins', '/admin/admins'),
         call('admin_badge', '/admin/badge'),


### PR DESCRIPTION
This is a precursor to a [following pull request](https://github.com/hypothesis/h/pull/4139) that will change `/groups/{pubid}/search` to `/groups/{pubid}/{slug}`. That pull request is going to change the previously `/groups/{pubid}/search` views to use Pyramid's traversal to match the views already at `/groups/{pubid}/{slug}`. _This_ pull request changes the `/users/{username}` views to also use traversal like the rest will be doing. In the interests of sending smaller pull requests I've broken this out into its own PR:

Use Pyramid's traversal mechanism to find the user model object for the `/users/{username}` route, as we do for the `/groups/{pubid}/{slug}` route.

This commit introduces a couple of behavioral changes:

1. Searching for `user:does_not_exist` on the `/search page` will stay on the `/search` page (the URL will become `/search?q=user:does_not_exist`). The server no longer redirects the browser to `/users/does_not_exist`.

2. `/users/does_not_exist` now 404s for users that don't exist in the db

3. Searching for `user:username_that_does_exist` on the `/search` page still redirects you to `/users/username_that_does_exist` as before. The view function for this page (`UserSearchController.search()`) no longer needs to look up the User model object in the database itself, because Pyramid passes this object to the view as the context object. The view also no longer needs to handle the case where the user doesn't exist, because Pyramid's view lookup will now 404 the page and not call the view at all in this case.

`UserFactory` is added in `h.models.user` for Pyramid traversal to use. This is the same as `GroupFactory` in `h.models.group` (I'm not sure that a traversal resource belongs in a models file but I'm putting it in the same place as `GroupFactory`).

The `add_route()` for the `'activity.user_search'` route is changed to use the `factory` and `traverse` arguments, the same as the `group_read` route.