### PR TITLE
Disable automatic reloading of assets in production

### DIFF
--- a/conf/development-app.ini
+++ b/conf/development-app.ini
@@ -17,6 +17,7 @@ h.client_id: nosuchid
 h.client_secret: nosuchsecret
 
 h.debug: True
+h.reload_assets: True
 
 secret_key: notverysecretafterall
 

--- a/h/assets.py
+++ b/h/assets.py
@@ -2,7 +2,7 @@
 import os
 
 import json
-from pyramid.settings import aslist
+from pyramid.settings import asbool, aslist
 from pyramid.static import static_view
 
 from h._compat import configparser
@@ -11,31 +11,37 @@ from h._compat import configparser
 class _CachedFile(object):
 
     """
-    Parses content from a file and caches the result until the file changes.
+    Parses content from a file and caches the result.
 
     _CachedFile reads a file at a given path and parses the content using a
-    provided loader. The result is cached until the mtime of the file changes.
+    provided loader.
     """
 
-    def __init__(self, path, loader):
+    def __init__(self, path, loader, auto_reload=False):
         """
         :param path: The path to the file to load.
         :param loader: A callable that will be passed the file object and
                        should return the parsed content.
+        :param auto_reload: If True, the parsed content is discarded if the
+                            mtime of the file changes.
         """
         self.path = path
         self.loader = loader
         self._mtime = None
         self._cached = None
+        self._auto_reload = auto_reload
 
     def load(self):
         """
         Return the current content of the file parsed with the loader.
 
-        If the file has not been loaded or has changed since the last call
-        to load(), it will be reloaded, otherwise the cached content will
-        be returned.
+        The file is loaded using the provided loader when this is called the
+        first time or if auto-reload is enabled and the file changed since the
+        last call to ``load()``.
         """
+        if self._mtime and not self._auto_reload:
+            return self._cached
+
         current_mtime = os.path.getmtime(self.path)
         if not self._mtime or self._mtime < current_mtime:
             self._cached = self.loader(open(self.path))
@@ -59,7 +65,8 @@ class Environment(object):
     URLs for a bundle via the urls() method.
     """
 
-    def __init__(self, assets_base_url, bundle_config_path, manifest_path):
+    def __init__(self, assets_base_url, bundle_config_path, manifest_path,
+                 auto_reload=False):
         """
         Construct an Environment from the given configuration files.
 
@@ -68,10 +75,14 @@ class Environment(object):
         :param bundle_config_path: Asset bundles config file.
         :param manifest_path: JSON file mapping file paths in the bundle config
                               file to cache-busted URLs.
+        :param auto_reload: If True the config and manifest files are
+                            automatically reloaded if they change.
         """
         self.assets_base_url = assets_base_url
-        self.manifest = _CachedFile(manifest_path, json.load)
-        self.bundles = _CachedFile(bundle_config_path, _load_bundles)
+        self.manifest = _CachedFile(manifest_path, json.load,
+                                    auto_reload=auto_reload)
+        self.bundles = _CachedFile(bundle_config_path, _load_bundles,
+                                   auto_reload=auto_reload)
 
     def files(self, bundle):
         """Return the file paths for all files in a bundle."""
@@ -137,15 +148,19 @@ assets_client_view = _add_cors_header(assets_client_view)
 
 
 def includeme(config):
+    auto_reload = asbool(config.registry.settings.get('h.reload_assets', False))
+
     config.add_view(route_name='assets', view=assets_view)
     config.add_view(route_name='assets_client', view=assets_client_view)
 
     assets_env = Environment('/assets',
                              'h/assets.ini',
-                             'build/manifest.json')
+                             'build/manifest.json',
+                             auto_reload=auto_reload)
     assets_client_env = Environment('/assets/client',
                                     'h/assets_client.ini',
-                                    'node_modules/hypothesis/build/manifest.json')
+                                    'node_modules/hypothesis/build/manifest.json',
+                                    auto_reload=auto_reload)
 
     # We store the environment objects on the registry so that the Jinja2
     # integration can be configured in app.py

--- a/tests/h/assets_test.py
+++ b/tests/h/assets_test.py
@@ -4,6 +4,7 @@ from sys import version_info
 from StringIO import StringIO
 
 from mock import patch
+import pytest
 
 from h.assets import Environment
 
@@ -66,9 +67,10 @@ def test_environment_url_returns_cache_busted_url(mtime):
     assert env.url('app.bundle.js') == '/assets/app.bundle.js?abcdef'
 
 
+@pytest.mark.parametrize('auto_reload', [True, False])
 @patch(open_target)
 @patch('os.path.getmtime')
-def test_environment_reloads_manifest_on_change(mtime, open):
+def test_environment_reloads_manifest_on_change(mtime, open, auto_reload):
     manifest_content = '{"app.bundle.js":"app.bundle.js?oldhash"}'
     bundle_content = '[bundles]\napp_js = \n  app.bundle.js'
 
@@ -80,7 +82,8 @@ def test_environment_reloads_manifest_on_change(mtime, open):
 
     open.side_effect = _fake_open
     mtime.return_value = 100
-    env = Environment('/assets', 'bundles.ini', 'manifest.json')
+    env = Environment('/assets', 'bundles.ini', 'manifest.json',
+                      auto_reload=auto_reload)
 
     # An initial call to urls() should read and cache the manifest
     env.urls('app_js')
@@ -91,4 +94,8 @@ def test_environment_reloads_manifest_on_change(mtime, open):
     # Once the manifest's mtime changes, the Environment should re-read
     # the manifest
     mtime.return_value = 101
-    assert env.urls('app_js') == ['/assets/app.bundle.js?newhash']
+
+    if auto_reload:
+        assert env.urls('app_js') == ['/assets/app.bundle.js?newhash']
+    else:
+        assert env.urls('app_js') == ['/assets/app.bundle.js?oldhash']


### PR DESCRIPTION
In production builds, avoid stat-ing the manifest and bundle files on
each call to Environment.url since the assets never change until the
service is re-deployed.

See https://github.com/hypothesis/h/pull/4128#issuecomment-263509992

FWIW I did some basic benchmarking of `os.path.getmtime()` locally. When all of the calls hit the stat cache, my system can manage ~1M calls/sec (native) or ~300K calls/sec (Docker container). On that basis I think it is quite unlikely that this would ever end up being a bottleneck, but adding a flag doesn't add much complexity either.