### PR TITLE
Change group route

### DIFF
--- a/h/routes.py
+++ b/h/routes.py
@@ -26,7 +26,6 @@ def includeme(config):
 
     # Activity
     config.add_route('activity.search', '/search')
-    config.add_route('activity.group_search', '/groups/{pubid}/search')
     config.add_route('activity.user_search',
                      '/users/{username}',
                      factory='h.models.user:UserFactory',

--- a/h/templates/includes/annotation_card.html.jinja2
+++ b/h/templates/includes/annotation_card.html.jinja2
@@ -8,7 +8,7 @@
         {{ annotation.username }}
       </a>
       {% if group %}
-        <a href="{{ request.route_url('activity.group_search', pubid=group.pubid) }}"
+        <a href="{{ request.route_url('group_read', pubid=group.pubid, slug=group.slug) }}"
           class="annotation-card__groupname">
             in
             {{ svg_icon('groups', 'annotation-card__groups-icon') }}

--- a/h/views/activity.py
+++ b/h/views/activity.py
@@ -21,6 +21,7 @@ from h.paginator import paginate
 from h import util
 from h.util.user import split_user
 from h.views import custom_predicates
+from h.views.groups import check_slug
 
 
 PAGE_SIZE = 200
@@ -100,6 +101,7 @@ class GroupSearchController(SearchController):
     def __init__(self, group, request):
         super(GroupSearchController, self).__init__(request)
         self.group = group
+        check_slug(self.group, self.request)
 
     @view_config(request_method='GET')
     def search(self):

--- a/h/views/activity.py
+++ b/h/views/activity.py
@@ -94,7 +94,8 @@ class SearchController(object):
 
 @view_defaults(route_name='group_read',
                renderer='h:templates/activity/search.html.jinja2',
-               custom_predicates=[custom_predicates.has_read_permission])
+               custom_predicates=[custom_predicates.has_read_permission,
+                                  custom_predicates.feature('search_page')])
 class GroupSearchController(SearchController):
     """View callables unique to the "group_read" route."""
 

--- a/h/views/custom_predicates.py
+++ b/h/views/custom_predicates.py
@@ -1,0 +1,11 @@
+"""
+Custom Pyramid view predicates.
+
+Functions suitable for being passed to Pyramid view config's custom_predicates
+argument.
+
+"""
+
+
+def has_read_permission(info, request):
+    return request.has_permission('read')

--- a/h/views/custom_predicates.py
+++ b/h/views/custom_predicates.py
@@ -9,3 +9,8 @@ argument.
 
 def has_read_permission(info, request):
     return request.has_permission('read')
+
+
+def feature(flag):
+    """Return a custom predicate for the named feature flag."""
+    return lambda info, request: request.feature(flag)

--- a/h/views/groups.py
+++ b/h/views/groups.py
@@ -118,7 +118,7 @@ class GroupEditController(object):
              custom_predicates=[not_(custom_predicates.has_read_permission)])
 def read(group, request):
     """Group view for logged-in users."""
-    _check_slug(group, request)
+    check_slug(group, request)
 
     # If the current user is not a member of the group, they will not have the
     # 'read' permission on the group. In this case, we show them the join
@@ -144,13 +144,13 @@ def read(group, request):
              effective_principals=not_(security.Authenticated))
 def read_unauthenticated(group, request):
     """Group view for logged-out users, allowing them to join the group."""
-    _check_slug(group, request)
+    check_slug(group, request)
     return {'group': group}
 
 
 @view_config(route_name='group_read_noslug', request_method='GET')
 def read_noslug(group, request):
-    _check_slug(group, request)
+    check_slug(group, request)
 
 
 @view_config(route_name='group_read',
@@ -174,7 +174,7 @@ def leave(group, request):
     return HTTPNoContent()
 
 
-def _check_slug(group, request):
+def check_slug(group, request):
     """Redirect if the request slug does not match that of the group."""
     slug = request.matchdict.get('slug')
     if slug is None or slug != group.slug:

--- a/h/views/groups.py
+++ b/h/views/groups.py
@@ -115,18 +115,11 @@ class GroupEditController(object):
              request_method='GET',
              renderer='h:templates/groups/share.html.jinja2',
              effective_principals=security.Authenticated,
-             custom_predicates=[not_(custom_predicates.has_read_permission)])
+             custom_predicates=[custom_predicates.has_read_permission,
+                                not_(custom_predicates.feature('search_page'))])
 def read(group, request):
-    """Group view for logged-in users."""
+    """The legacy group page."""
     check_slug(group, request)
-
-    # If the current user is not a member of the group, they will not have the
-    # 'read' permission on the group. In this case, we show them the join
-    # page.
-    if not request.has_permission('read'):
-        request.override_renderer = 'h:templates/groups/join.html.jinja2'
-        return {'group': group}
-
     return {'group': group,
             'document_links': [presenters.DocumentHTMLPresenter(d).link
                                for d in group.documents()],
@@ -136,6 +129,33 @@ def read(group, request):
                 {'name': 'referrer', 'content': 'origin'},
                           ],
             }
+
+
+@view_defaults(route_name='group_read',
+               renderer='h:templates/groups/join.html.jinja2',
+               effective_principals=security.Authenticated,
+               custom_predicates=[not_(custom_predicates.has_read_permission)])
+class GroupJoinController(object):
+
+    def __init__(self, group, request):
+        check_slug(group, request)
+        self.group = group
+        self.request = request
+
+    @view_config(request_method='GET')
+    def get(self):
+        return {'group': self.group}
+
+    @view_config(request_method='POST')
+    def post(self):
+        groups_service = self.request.find_service(name='groups')
+        groups_service.member_join(self.group,
+                                   self.request.authenticated_userid)
+
+        url = self.request.route_path('group_read',
+                                      pubid=self.group.pubid,
+                                      slug=self.group.slug)
+        return HTTPSeeOther(url)
 
 
 @view_config(route_name='group_read',
@@ -151,17 +171,6 @@ def read_unauthenticated(group, request):
 @view_config(route_name='group_read_noslug', request_method='GET')
 def read_noslug(group, request):
     check_slug(group, request)
-
-
-@view_config(route_name='group_read',
-             request_method='POST',
-             effective_principals=security.Authenticated)
-def join(group, request):
-    groups_service = request.find_service(name='groups')
-    groups_service.member_join(group, request.authenticated_userid)
-
-    url = request.route_path('group_read', pubid=group.pubid, slug=group.slug)
-    return HTTPSeeOther(url)
 
 
 @view_config(route_name='group_leave',

--- a/h/views/panels.py
+++ b/h/views/panels.py
@@ -76,7 +76,7 @@ def navbar(context, request, opts={}):
             username=request.authenticated_user.username)
         username = request.authenticated_user.username
 
-    if request.matched_route.name in ['activity.group_search', 'activity.user_search']:
+    if request.matched_route.name in ['group_read', 'activity.user_search']:
         search_url = request.current_route_url()
     else:
         search_url = request.route_url('activity.search')

--- a/tests/h/activity/query_test.py
+++ b/tests/h/activity/query_test.py
@@ -44,7 +44,7 @@ class TestExtract(object):
         """
         parse.return_value = MultiDict({'foo': 'bar',
                                         'group': 'whattheusersent'})
-        pyramid_request.matched_route.name = 'activity.group_search'
+        pyramid_request.matched_route.name = 'group_read'
         pyramid_request.matchdict['pubid'] = 'abcd1234'
         pyramid_request.GET['q'] = 'giraffe'
 
@@ -77,32 +77,47 @@ class TestExtract(object):
 
 @pytest.mark.usefixtures('routes', 'user_service')
 class TestCheckURL(object):
-    def test_redirects_to_group_search_page_if_one_group_in_query(self, pyramid_request, unparse):
-        query = MultiDict({'group': 'abcd1234'})
+
+    def test_redirects_to_group_search_page_if_one_group_in_query(self,
+                                                                  group,
+                                                                  pyramid_request,
+                                                                  unparse):
+        query = MultiDict({'group': group.pubid})
 
         with pytest.raises(HTTPFound) as e:
             check_url(pyramid_request, query, unparse=unparse)
 
-        assert e.value.location == '/act/groups/abcd1234?q=UNPARSED_QUERY'
+        assert e.value.location == (
+            '/groups/{pubid}/{slug}?q=UNPARSED_QUERY'.format(pubid=group.pubid,
+                                                             slug=group.slug))
 
-    def test_removes_group_term_from_query(self, pyramid_request, unparse):
-        query = MultiDict({'group': 'abcd1234'})
+    def test_does_not_redirect_to_group_page_if_group_does_not_exist(
+            self, pyramid_request, unparse):
+        query = MultiDict({'group': 'does_not_exist'})
+
+        assert check_url(pyramid_request, query, unparse=unparse) is None
+
+    def test_removes_group_term_from_query(self, group, pyramid_request, unparse):
+        query = MultiDict({'group': group.pubid})
 
         with pytest.raises(HTTPFound):
             check_url(pyramid_request, query, unparse=unparse)
 
         unparse.assert_called_once_with({})
 
-    def test_preserves_other_query_terms_for_group_search(self, pyramid_request, unparse):
-        query = MultiDict({'group': 'abcd1234', 'tag': 'foo'})
+    def test_preserves_other_query_terms_for_group_search(self,
+                                                          group,
+                                                          pyramid_request,
+                                                          unparse):
+        query = MultiDict({'group': group.pubid, 'tag': 'foo'})
 
         with pytest.raises(HTTPFound):
             check_url(pyramid_request, query, unparse=unparse)
 
         unparse.assert_called_once_with({'tag': 'foo'})
 
-    def test_preserves_user_query_terms_for_group_search(self, pyramid_request, unparse):
-        query = MultiDict({'group': 'bar', 'user': 'foo'})
+    def test_preserves_user_query_terms_for_group_search(self, group, pyramid_request, unparse):
+        query = MultiDict({'group': group.pubid, 'user': 'foo'})
 
         with pytest.raises(HTTPFound):
             check_url(pyramid_request, query, unparse=unparse)
@@ -150,12 +165,16 @@ class TestCheckURL(object):
         assert result is None
 
     def test_does_nothing_if_not_on_search_page(self, pyramid_request, unparse):
-        pyramid_request.matched_route.name = 'activity.group_search'
+        pyramid_request.matched_route.name = 'group_read'
         query = MultiDict({'group': 'abcd1234'})
 
         result = check_url(pyramid_request, query, unparse=unparse)
 
         assert result is None
+
+    @pytest.fixture
+    def group(self, factories):
+        return factories.Group()
 
     @pytest.fixture
     def user_service(self, factories, pyramid_config):
@@ -557,5 +576,5 @@ def pyramid_request(pyramid_request):
 
 @pytest.fixture
 def routes(pyramid_config):
-    pyramid_config.add_route('activity.group_search', '/act/groups/{pubid}')
+    pyramid_config.add_route('group_read', '/groups/{pubid}/{slug}')
     pyramid_config.add_route('activity.user_search', '/act/users/{username}')

--- a/tests/h/routes_test.py
+++ b/tests/h/routes_test.py
@@ -34,7 +34,6 @@ def test_includeme():
         call('claim_account_legacy', '/claim_account/{token}'),
         call('dismiss_sidebar_tutorial', '/app/dismiss_sidebar_tutorial'),
         call('activity.search', '/search'),
-        call('activity.group_search', '/groups/{pubid}/search'),
         call('activity.user_search', '/users/{username}', factory=u'h.models.user:UserFactory', traverse=u'/{username}'),
         call('admin_index', '/admin/'),
         call('admin_admins', '/admin/admins'),

--- a/tests/h/views/activity_test.py
+++ b/tests/h/views/activity_test.py
@@ -145,6 +145,24 @@ class TestGroupSearchController(object):
         with pytest.raises(httpexceptions.HTTPNotFound):
             activity.GroupSearchController(group, pyramid_request)
 
+    def test_init_redirects_if_slug_wrong(self, group, pyramid_request):
+        """
+        If the slug in the URL is wrong it should redirect to the right one.
+
+        For example /groups/<pubid>/foobar redirects to /groups/<pubid>/<slug>.
+
+        The other 'group_read' views on h.views.groups do this, this tests that
+        the ones in h.views.activity do as well.
+
+        """
+        pyramid_request.matchdict['slug'] = 'wrong'
+
+        with pytest.raises(httpexceptions.HTTPMovedPermanently) as exc:
+            activity.GroupSearchController(group, pyramid_request)
+
+        assert exc.value.location == '/groups/{pubid}/{slug}'.format(
+            pubid=group.pubid, slug=group.slug)
+
     def test_search_calls_search_with_the_request(self,
                                                   controller,
                                                   group,
@@ -587,6 +605,11 @@ class TestGroupAndUserSearchController(object):
 
     @pytest.fixture
     def group_search_controller(self, group, pyramid_request):
+        # Set the slug in the URL to the slug of the group.
+        # Otherwise GroupSearchController will redirect the request to the
+        # correct URL.
+        pyramid_request.matchdict['slug'] = group.slug
+
         return activity.GroupSearchController(group, pyramid_request)
 
     @pytest.fixture

--- a/tests/h/views/groups_test.py
+++ b/tests/h/views/groups_test.py
@@ -83,7 +83,7 @@ class TestGroupCreateController(object):
         handle_form_submission.side_effect = return_on_success
 
         assert controller.post() == matchers.redirect_303_to(
-            '/g/abc123/fake-group')
+            '/groups/abc123/fake-group')
 
     def test_post_does_not_create_group_if_form_invalid(self,
                                                         controller,
@@ -139,7 +139,7 @@ class TestGroupEditController(object):
                 'name': 'Birdwatcher Community',
                 'description': 'We watch birds all day long',
             },
-            'group_path': '/g/the-test-pubid/birdwatcher-community'
+            'group_path': '/groups/the-test-pubid/birdwatcher-community'
         }
 
     def test_post_sets_group_properties(self, form_validating_to, pyramid_request):
@@ -170,15 +170,7 @@ class TestGroupRead(object):
         with pytest.raises(HTTPMovedPermanently) as exc:
             views.read(group, pyramid_request)
 
-        assert exc.value.location == '/g/abc123/some-slug'
-
-    def test_redirects_if_search_page_enabled(self, matchers, pyramid_request):
-        group = FakeGroup('abc123', 'some-slug')
-        pyramid_request.matchdict['slug'] = 'some-slug'
-        pyramid_request.feature.flags['search_page'] = True
-
-        assert views.read(group, pyramid_request) == matchers.redirect_303_to(
-            '/g/abc123/search')
+        assert exc.value.location == '/groups/abc123/some-slug'
 
     def test_returns_template_context(self, patch, pyramid_request):
         group = FakeGroup('abc123', 'some-slug')
@@ -216,7 +208,7 @@ class TestGroupReadUnauthenticated(object):
         with pytest.raises(HTTPMovedPermanently) as exc:
             views.read_unauthenticated(group, pyramid_request)
 
-        assert exc.value.location == '/g/abc123/some-slug'
+        assert exc.value.location == '/groups/abc123/some-slug'
 
     def test_returns_template_context(self, pyramid_request):
         group = FakeGroup('abc123', 'some-slug')
@@ -234,7 +226,7 @@ def test_read_noslug_redirects(pyramid_request):
     with pytest.raises(HTTPMovedPermanently) as exc:
         views.read_noslug(group, pyramid_request)
 
-    assert exc.value.location == '/g/abc123/some-slug'
+    assert exc.value.location == '/groups/abc123/some-slug'
 
 
 @pytest.mark.usefixtures('groups_service', 'routes')
@@ -256,7 +248,7 @@ class TestGroupJoin(object):
         result = views.join(group, pyramid_request)
 
         assert isinstance(result, HTTPSeeOther)
-        assert result.location == '/g/abc123/some-slug'
+        assert result.location == '/groups/abc123/some-slug'
 
 
 @pytest.mark.usefixtures('groups_service', 'routes')
@@ -334,8 +326,7 @@ def groups_service(pyramid_config):
 
 @pytest.fixture
 def routes(pyramid_config):
-    pyramid_config.add_route('group_read', '/g/{pubid}/{slug}')
-    pyramid_config.add_route('activity.group_search', '/g/{pubid}/search')
+    pyramid_config.add_route('group_read', '/groups/{pubid}/{slug}')
 
 
 @pytest.fixture

--- a/tests/h/views/panels_test.py
+++ b/tests/h/views/panels_test.py
@@ -52,11 +52,11 @@ class TestNavbar(object):
         assert result['search_url'] == 'http://example.com/users/luke'
 
     def test_it_includes_search_url_when_on_group_search(self, req):
-        type(req.matched_route).name = PropertyMock(return_value='activity.group_search')
-        req.matchdict = {'pubid': 'foobar'}
+        type(req.matched_route).name = PropertyMock(return_value='group_read')
+        req.matchdict = {'pubid': 'foobar', 'slug': 'slugbar'}
 
         result = panels.navbar({}, req)
-        assert result['search_url'] == 'http://example.com/groups/foobar/search'
+        assert result['search_url'] == 'http://example.com/groups/foobar/slugbar'
 
     def test_it_includes_default_search_url(self, req):
         result = panels.navbar({}, req)
@@ -70,7 +70,6 @@ class TestNavbar(object):
         pyramid_config.add_route('account_developer', '/account/developer')
         pyramid_config.add_route('activity.search', '/search')
         pyramid_config.add_route('activity.user_search', '/users/{username}')
-        pyramid_config.add_route('activity.group_search', '/groups/{pubid}/search')
         pyramid_config.add_route('group_create', '/groups/new')
         pyramid_config.add_route('group_read', '/groups/:pubid/:slug')
         pyramid_config.add_route('logout', '/logout')


### PR DESCRIPTION
Fixes https://github.com/hypothesis/h/issues/4004

<del>This is marked as WIP because it depends on <https://github.com/hypothesis/h/pull/4136>.</del>

This pull request changes the `/groups/{pubid}/search` URL to `/groups/{pubid}/{slug}`.

This is not nearly as simple as it may sound because `/groups/{pubid}/{slug}` is already a heavily overloaded URL (with different behaviours depending on whether you're logged in or not, a member of the group or not, whether the activity_pages or search_page feature flags are on or not, redirects when the slug is missing or incorrect...).  The `/groups/{pubid}/search` also has many different behaviours (for just getting the page and for submitting the search form and clicking various buttons in the sidebar) and these are now all piled onto the `/groups/{pubid}/{slug}` URL as well.  

In addition, the existing  `/groups/{pubid}/{slug}` views are in `h.views.groups` whereas the `/groups/{pubid}/search` are in `h.views.activity`, and the groups ones use traversal whereas the activity ones use URL dispatch.

Merging these two URLs into one has consequences for the structure and factoring of the codebase where the views for the two URLs (`h.views.groups` and `h.views.activity`) are concerned.

## Behaviour

The new behaviour that this pull request implements is:

* If you aren't logged in then `/groups/{pubid}/{slug}` shows the "Login to join group" page. Either the classic or the new version of this page, depending on the activity_pages feature flag.  

* If you are logged in, but aren't a member of the group, then `/groups/{pubid}/{slug}` shows the "Join group" page. Either the classic or the new version of this page, depending on the activity_pages feature flag.

* If you're already a member of the group then `/groups/{pubid}/{slug}` shows the group's activity search page if the search_page feature flag is on or the classic group page if it's not.

* `/groups/{pubid}`, `/groups/{pubid}/` and `/groups/{pubid}/{something_else}` all redirect to `/groups/{pubid}/{slug}` in all cases

* `/groups/{pubid}[/[{anything}]]` 404s if no group with the given pubid exists, in all cases (previously `/groups/{does_not_exist}/search` would show an empty search page, _not_ a 404, but `/groups/{does_not_exist}[/[{anything_else}]]` would 404)

* Each of these different "versions" of the page is implemented as a separate view function or method, and we use Pyramid routing to select the correct view depending on the situation. We don't have Python logic in the view functions saying "if the user is a member then X else Y" etc.

* The `/search` page no longer redirects to the group's page if you search for a group that doesn't exist. This is because we don't want to send users to a 404 page.

## Pyramid routing

The `/groups/{pubid}/search` page was implemented by the `"activity.group_search"` route and the views in `h.views.activity.GroupSearchController` and `h.views.activity.GroupUserSearchController` .

The `/groups/{pubid}/{slug}` page, which is already used on master for the "Login to join group", "Join group", and classic group home pages, was implemented by the `"group_read"` route and the views in `h.views.groups`.

It's not possible for both the `"activity.group_search"` and the `"group_read"` route to use the `/groups/{pubid}/{slug}` URL without overriding each other in unwanted ways. (Even if it is possible, this would be very brittle and not easily testable routing.)

In this pull request this has been reconciled by having the group activity search page views in `h.views.activity` share the `"group_read"` route with the other group views in `h.views.groups`.  The `"activity.group_search"` route is no longer used. The view configurations on the various views that use the `"group_read"` route have been tightened up to correctly and more explicitly declare which views should be called under which circumstances:

* `h.views.activity.GroupSearchController` (the new group activity search page) is only called when the user is a member of the group and the `'search_page'` feature is on.

  Once activity pages is released and the `'search_page'` feature flag is removed we can remove the `'search_page'` predicate from this.

* `h.views.groups.read()` (the classic group home page) is only called when the user is a member of the group and the `search_page` feature is _not_ on.

  Once activity pages is released and the `'search_page'` feature flag is removed we can delete this view function.

* `h.views.groups.GroupJoinController()` is only called when the user is logged in and is _not_ a member of the group

* `h.views.groups.read_unauthenticated()` is only called when the user is _not_ logged in.

## Traversal

The `"activity.group_search"` route (which has been deleted) used [Pyramid's URL dispatch mechanism](http://docs.pylonsproject.org/projects/pyramid//en/latest/narr/urldispatch.html) to look up and call the view for a request.

The `"group_read"` route, which is now shared by the previous `"group_read"` views and the views that used to use the `"activity.group_search"` route, uses [Pyramid's traversal mechanism](http://docs.pylonsproject.org/projects/pyramid//en/latest/narr/hellotraversal.html).

So the group activity search page views in `h.views.activity.GroupSearchController` now use traversal not URL dispatch, to match with the existing `"group_read"` views.

This means that the views no longer need to look up the group in the database, nor deal with the case when the group doesn't exist, because traversal handles this for them.

## Known issues

* The user activity page's route is called `"activity.user_search"` whereas the group activity page's route is `"group_read"`.

* The views for the `"group_read"` route are spread across two modules `h.views.activity` and `h.views.groups`.

  `h.views.activity.GroupSearchController` shares the `"group_read"` route with the other group views in `h.views.groups`. On the other hand, it shares much code with the other activity search views in `h.views.activity`.

In a follow-up pull request I think these issues could be resolved by:

* Moving all the group views from `h.views.groups` into `h.views.activity` and renaming the `"group_read"` route to `"activity.group_search"` to match with `"activity.user_search"`. Or

* Move `h.views.activity.GroupSearchController` into `h.views.groups` so that all of the group views are together in one place.  Also move `h.views.activity.UserSearchController` into a new `h.views.users` module to mirror this organisation.

  `GroupSearchController` and `UserSearchController` would both still inherit from `h.views.activity.SearchController`, which is implemented in a different module from either of the inheriting classes, but maybe that's okay.

  Several shared private helper functions in `h.views.activity` would also need to be made available to `GroupSearchController` and `UserSearchController` which are now in different files. Making these helper functions into methods of `SearchController` might work, or move them into a helpers module.
