### PR TITLE
Backfill group access flags and set them on new groups

### DIFF
--- a/h/groups/services.py
+++ b/h/groups/services.py
@@ -4,6 +4,20 @@ from functools import partial
 
 from h import session
 from h.models import Group
+from h.models.group import JoinableBy, ReadableBy, WriteableBy
+
+GROUP_ACCESS_FLAGS = {
+    'private': {
+        'joinable_by': JoinableBy.authority,
+        'readable_by': ReadableBy.members,
+        'writeable_by': WriteableBy.members,
+     },
+    'publisher': {
+        'joinable_by': None,
+        'readable_by': ReadableBy.world,
+        'writeable_by': WriteableBy.authority,
+    }
+}
 
 
 class GroupsService(object):
@@ -22,13 +36,15 @@ class GroupsService(object):
         self.user_fetcher = user_fetcher
         self.publish = publish
 
-    def create(self, name, authority, userid, description=None):
+    def create(self, name, authority, userid, description=None, type_='private'):
         """
         Create a new group.
 
         :param name: the human-readable name of the group
         :param userid: the userid of the group creator
         :param description: the description of the group
+        :param type_: the type of group (private or publisher) which sets the
+                      appropriate access flags
 
         :returns: the created group
         """
@@ -37,6 +53,13 @@ class GroupsService(object):
                       authority=authority,
                       creator=creator,
                       description=description)
+
+        access_flags = GROUP_ACCESS_FLAGS.get(type_)
+        if access_flags is None:
+            raise ValueError('Invalid group type %s' % type_)
+        for attr, value in access_flags.iteritems():
+            setattr(group, attr, value)
+
         self.session.add(group)
         self.session.flush()
 

--- a/h/migrations/versions/8ae9d103551f_backfill_group_access_flags.py
+++ b/h/migrations/versions/8ae9d103551f_backfill_group_access_flags.py
@@ -1,0 +1,48 @@
+"""
+Backfill group access flags
+
+Revision ID: 8ae9d103551f
+Revises: af88524994ce
+Create Date: 2016-11-29 12:51:31.247598
+"""
+
+from __future__ import unicode_literals
+
+import enum
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '8ae9d103551f'
+down_revision = 'af88524994ce'
+
+
+class JoinableBy(enum.Enum):
+    authority = 'authority'
+joinable_type = sa.Enum(JoinableBy, name='group_joinable_by')
+
+
+class ReadableBy(enum.Enum):
+    members = 'members'
+readable_type = sa.Enum(ReadableBy, name='group_readable_by')
+
+
+class WriteableBy(enum.Enum):
+    members = 'members'
+writeable_type = sa.Enum(WriteableBy, name='group_writeable_by')
+
+group_table = sa.table('group',
+                       sa.Column('joinable_by', joinable_type, nullable=True),
+                       sa.Column('readable_by', readable_type, nullable=True),
+                       sa.Column('writeable_by', writeable_type, nullable=True))
+
+
+def upgrade():
+    op.execute(group_table.update().values(joinable_by=JoinableBy.authority,
+                                           readable_by=ReadableBy.members,
+                                           writeable_by=WriteableBy.members))
+
+
+def downgrade():
+    pass

--- a/h/migrations/versions/af88524994ce_add_group_access_flags.py
+++ b/h/migrations/versions/af88524994ce_add_group_access_flags.py
@@ -1,0 +1,55 @@
+"""
+Add group access flags
+
+Revision ID: af88524994ce
+Revises: 8990247b876c
+Create Date: 2016-11-25 15:58:59.517470
+"""
+
+from __future__ import unicode_literals
+
+import enum
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = 'af88524994ce'
+down_revision = '8990247b876c'
+
+class JoinableBy(enum.Enum):
+    authority = 'authority'
+joinable_type = sa.Enum(JoinableBy, name='group_joinable_by')
+
+class ReadableBy(enum.Enum):
+    authority = 'authority'
+    members = 'members'
+    world = 'world'
+readable_type = sa.Enum(ReadableBy, name='group_readable_by')
+
+class WriteableBy(enum.Enum):
+    authority = 'authority'
+    members = 'members'
+writeable_type = sa.Enum(WriteableBy, name='group_writeable_by')
+
+
+
+def upgrade():
+    joinable_type.create(op.get_bind())
+    op.add_column('group', sa.Column('joinable_by', joinable_type, nullable=True))
+
+    readable_type.create(op.get_bind())
+    op.add_column('group', sa.Column('readable_by', readable_type, nullable=True))
+
+    writeable_type.create(op.get_bind())
+    op.add_column('group', sa.Column('writeable_by', writeable_type, nullable=True))
+
+
+def downgrade():
+    op.drop_column('group', 'joinable_by')
+    joinable_type.drop(op.get_bind())
+
+    op.drop_column('group', 'readable_by')
+    readable_type.drop(op.get_bind())
+
+    op.drop_column('group', 'writeable_by')
+    writeable_type.drop(op.get_bind())

--- a/h/models/group.py
+++ b/h/models/group.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import enum
 import sqlalchemy as sa
 from pyramid import security
 from sqlalchemy.orm import exc
@@ -27,6 +28,21 @@ class GroupFactory(object):
             raise KeyError()
 
 
+class JoinableBy(enum.Enum):
+    authority = 'authority'
+
+
+class ReadableBy(enum.Enum):
+    authority = 'authority'
+    members = 'members'
+    world = 'world'
+
+
+class WriteableBy(enum.Enum):
+    authority = 'authority'
+    members = 'members'
+
+
 class Group(Base, mixins.Timestamps):
     __tablename__ = 'group'
 
@@ -48,6 +64,21 @@ class Group(Base, mixins.Timestamps):
     creator = sa.orm.relationship('User')
 
     description = sa.Column(sa.UnicodeText())
+
+    #: Which type of user is allowed to join this group, possible values are:
+    #: authority, None
+    joinable_by = sa.Column(sa.Enum(JoinableBy, name='group_joinable_by'),
+                            nullable=True)
+
+    #: Which type of user is allowed to read annotations in this group,
+    #: possible values are: authority, members, world
+    readable_by = sa.Column(sa.Enum(ReadableBy, name='group_readable_by'),
+                            nullable=True)
+
+    #: Which type of user is allowed to write to this group, possible values
+    #: are: authority, members
+    writeable_by = sa.Column(sa.Enum(WriteableBy, name='group_writeable_by'),
+                             nullable=True)
 
     # Group membership
     members = sa.orm.relationship(

--- a/requirements.in
+++ b/requirements.in
@@ -10,6 +10,7 @@ cryptography
 deform < 1.0
 deform-jinja2
 elasticsearch < 2.0.0
+enum34
 gevent
 gunicorn
 itsdangerous

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ cryptography==1.4
 deform-jinja2==0.5
 deform==0.9.9
 elasticsearch==1.9.0
-enum34==1.1.6             # via cryptography
+enum34==1.1.6
 functools32==3.2.3.post2  # via jsonschema
 gevent==1.1.2
 greenlet==0.4.10          # via gevent


### PR DESCRIPTION
This PR adds a migration to set the group access flags for all the private groups that are already in the database. It also introduces a new `type_` parameter to the `GroupsService.create` method. Currently we have two group types: `private` and `publisher`. Based on the value of that parameter we set the access flags of the new group.

For more information about the access flags and the different types of groups, see #4133.