### PR TITLE
Add the search results total annotation count

### DIFF
--- a/h/static/styles/partials-v2/_search.scss
+++ b/h/static/styles/partials-v2/_search.scss
@@ -28,10 +28,12 @@
   text-decoration: none;
 }
 
+// The result container holds all of the main content
+// for the page and is in charge of layout
 .search-result-container {
   display: flex;
   font-size: $normal-font-size;
-  margin-top: 50px;
+  margin-top: 40px;
   color: $grey-6;
 
   // Align the left edge of the search result list with the left edge of the
@@ -49,14 +51,23 @@
   margin-bottom: 0;
 }
 
-.search-result-list,
+// search-results and search-zero map to the internal states of the page
+// when there are actual results to be displayed or when there are none.
+// They control the inner layouts for those columns
+.search-results,
 .search-result-zero {
   flex-basis: 950px;
   max-width: 950px;
   margin-right: 30px;
 }
 
-.search-result-list {
+.search-results__total {
+  color: $brand;
+  margin-bottom: 25px;
+  word-spacing: 4px;
+}
+
+.search-results__list {
   // Remove default padding from <ol>
   list-style: none;
   padding-left: 0;
@@ -328,7 +339,7 @@ $stats-icon-column-width: 20px;
     display: none;
   }
 
-  .search-result-list,
+  .search-results,
   .search-result-zero {
     margin-right: 0;
   }

--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -348,18 +348,26 @@
     {% endif %}
 
     {% if timeframes %}
-      <ol class="search-result-list {%- if more_info %} search-result-hide-on-small-screens{% endif %}">
-        {% for timeframe in timeframes %}
+
+      <div class="search-results">
+
+        {% if q or user or group %}
+        <div class="search-results__total"><b>{% trans %}Annotations{% endtrans %}</b> {{total}}</div>
+        {% endif %}
+
+        <ol class="search-results__list {%- if more_info %} search-result-hide-on-small-screens{% endif %}">
+          {% for timeframe in timeframes %}
           <li class="search-result__timeframe">
             {{ timeframe.label }}
           </li>
           <li>
             {% for bucket in timeframe.document_buckets.values() %}
-              {{ search_result_bucket(bucket) }}
+            {{ search_result_bucket(bucket) }}
             {% endfor %}
           </li>
-        {% endfor %}
-      </ol>
+          {% endfor %}
+        </ol>
+      </div>
     {% else %}
       <div class="search-result-zero {%- if more_info %} search-result-hide-on-small-screens{% endif %}">
         {% if zero_message == '__SHOW_GETTING_STARTED__' %}


### PR DESCRIPTION
fixes [#55](https://github.com/hypothesis/product-backlog/issues/55)

Adds the annotation count to the top left of the search results page if there is some sort of search criteria (at least one lozenge). 

Note, on mobile there is room to rework our use of vertical whitespace on the user profile page. Because we put the user name in bold and the big button for more info.. _then_ we add this annotations bit. It is fine for now, though.

The renaming was needed to keep some logical grouping with the many container level elements in the UI.