### PR TITLE
Add documentation for the "real time" API

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,5 +16,6 @@ Contents
    community
    publishers/index
    The Hypothesis API <http://h.readthedocs.io/en/latest/api/>
+   realtime
    developing/index
    CHANGES

--- a/docs/realtime.rst
+++ b/docs/realtime.rst
@@ -1,0 +1,117 @@
+The Hypothesis Real Time API
+============================
+
+.. warning::
+
+   This document describes an API that is in the early stages of being
+   documented and refined for public use. Details may change, and your systems
+   may break in the future.
+
+In addition to the `HTTP API <http://h.readthedocs.io/en/latest/api/>`_
+Hypothesis has a WebSocket-based API that allows developers to receive near
+real-time notifications of annotation events.
+
+Overview
+--------
+
+.. note::
+
+   At the moment, use of the Real Time API is limited to server-side clients.
+   JavaScript applications running in the browser **will not be able to use this
+   API** due to security restrictions. We hope to lift this restriction in the
+   future.
+
+To use the Real Time API, you should open a WebSocket connection to the
+following endpoint::
+
+    wss://hypothes.is/ws
+
+Communication with this endpoint consists of JSON-encoded messages sent from
+client to server and vice versa.
+
+Server messages
+---------------
+
+Each messages from the server will be either an :term:`event` or a
+:term:`reply`:
+
+.. glossary::
+
+   event
+      An event is sent to clients as a result of an action taken elsewhere in
+      the system. For example: if an annotation is made which matches one of the
+      client's subscriptions, the client will receive an event message. All
+      event messages have a ``type`` field.
+
+   reply
+      A reply is sent in response to a message sent by the client. All replies
+      have an ``ok`` field which indicates whether the server successfully
+      processed the client's message, and a ``reply_to`` field which indicates
+      which client message the server is responding to.
+
+Clients should ignore events with types that they do not recognise, as this will
+allow us to add new events in future without breaking your client.
+
+.. note::
+
+   We will add documentation for specific event types as we upgrade the
+   protocol.
+
+Sending messages
+----------------
+
+All messages sent to the server must have a numeric ID which is unique for the
+connection. The ID should be sent with the message in the ``id`` field. In
+addition, every message sent to the server must have a valid ``type`` field. See
+below for the different types of message you can send.
+
+.. contents:: Message types
+   :local:
+   :depth: 1
+
+``ping``
+~~~~~~~~
+
+To verify that the connection is still open, clients can (and are encouraged to)
+send a "ping" message:
+
+.. code-block:: json
+
+   {
+      "id": 123,
+      "type": "ping"
+   }
+
+The server replies with a ``pong`` message:
+
+.. code-block:: json
+
+   {
+      "ok": true,
+      "reply_to": 123,
+      "type": "pong"
+   }
+
+``whoami``
+~~~~~~~~~~
+
+Primarily for debugging purposes, you can send the server a "who am I?" message
+to check whether you have authenticated correctly to the WebSocket.
+
+.. code-block:: json
+
+   {
+      "id": 123,
+      "type": "whoami"
+   }
+
+The server will respond with a ``whoyouare`` message:
+
+.. code-block:: json
+
+   {
+      "ok": true,
+      "reply_to": 123,
+      "type": "whoyouare",
+      "userid": "acct:joe.bloggs@hypothes.is"
+   }

--- a/h/streamer/websocket.py
+++ b/h/streamer/websocket.py
@@ -160,6 +160,12 @@ def handle_filter_message(message, session=None):
 MESSAGE_HANDLERS['filter'] = handle_filter_message
 
 
+def handle_ping_message(message, session=None):
+    """A client requesting a pong."""
+    message.reply({'type': 'pong'})
+MESSAGE_HANDLERS['ping'] = handle_ping_message
+
+
 def handle_unknown_message(message, session=None):
     """Message type missing or not recognised."""
     type_ = json.dumps(message.payload.get('type'))

--- a/h/streamer/websocket.py
+++ b/h/streamer/websocket.py
@@ -166,6 +166,13 @@ def handle_ping_message(message, session=None):
 MESSAGE_HANDLERS['ping'] = handle_ping_message
 
 
+def handle_whoami_message(message, session=None):
+    """A client requesting information on its auth state."""
+    message.reply({'type': 'whoyouare',
+                   'userid': message.socket.authenticated_userid})
+MESSAGE_HANDLERS['whoami'] = handle_whoami_message
+
+
 def handle_unknown_message(message, session=None):
     """Message type missing or not recognised."""
     type_ = json.dumps(message.payload.get('type'))

--- a/tests/h/streamer/websocket_test.py
+++ b/tests/h/streamer/websocket_test.py
@@ -370,6 +370,18 @@ class TestHandleFilterMessage(object):
         return socket
 
 
+class TestHandlePingMessage(object):
+    def test_pong(self):
+        message = websocket.Message(socket=mock.sentinel.socket, payload={
+            'type': 'ping',
+        })
+
+        with mock.patch.object(websocket.Message, 'reply') as mock_reply:
+            websocket.handle_ping_message(message)
+
+        mock_reply.assert_called_once_with({'type': 'pong'})
+
+
 class TestUnknownMessage(object):
     def test_error(self, matchers):
         message = websocket.Message(socket=mock.sentinel.socket, payload={

--- a/tests/h/streamer/websocket_test.py
+++ b/tests/h/streamer/websocket_test.py
@@ -382,6 +382,31 @@ class TestHandlePingMessage(object):
         mock_reply.assert_called_once_with({'type': 'pong'})
 
 
+class TestHandleWhoamiMessage(object):
+    @pytest.mark.parametrize('userid', [
+        None,
+        'acct:foo@example.com',
+    ])
+    def test_replies_with_whoyouare_message(self, socket, userid):
+        """Send back a `whoyouare` message with a userid (which may be null)."""
+        socket.authenticated_userid = userid
+        message = websocket.Message(socket=socket, payload={
+            'type': 'whoami',
+        })
+
+        with mock.patch.object(websocket.Message, 'reply') as mock_reply:
+            websocket.handle_whoami_message(message)
+
+        mock_reply.assert_called_once_with({'type': 'whoyouare',
+                                            'userid': userid})
+
+    @pytest.fixture
+    def socket(self):
+        socket = mock.Mock()
+        socket.authenticated_userid = None
+        return socket
+
+
 class TestUnknownMessage(object):
     def test_error(self, matchers):
         message = websocket.Message(socket=mock.sentinel.socket, payload={


### PR DESCRIPTION
This PR adds a couple of message types to the websocket protocol (a PING/PONG and a simple mechanism of interrogating auth status) and adds some initial documentation for the protocol.

I have deliberately not documented any of the actually useful message types at the moment because I think we need to audit them and decide whether they're going to be part of the public API or whether they need reimplementing.