### PR TITLE
Use traversal for group search page

### DIFF
--- a/h/activity/query.py
+++ b/h/activity/query.py
@@ -80,9 +80,11 @@ def check_url(request, query, unparse=parser.unparse):
 
     if _single_entry(query, 'group'):
         pubid = query.pop('group')
-        redirect = request.route_path('activity.group_search',
-                                      pubid=pubid,
-                                      _query={'q': unparse(query)})
+        group = request.db.query(Group).filter_by(pubid=pubid).one_or_none()
+        if group:
+            redirect = request.route_path('activity.group_search',
+                                          pubid=group.pubid,
+                                          _query={'q': unparse(query)})
 
     elif _single_entry(query, 'user'):
         username = query.pop('user')

--- a/h/routes.py
+++ b/h/routes.py
@@ -26,7 +26,10 @@ def includeme(config):
 
     # Activity
     config.add_route('activity.search', '/search')
-    config.add_route('activity.group_search', '/groups/{pubid}/search')
+    config.add_route('activity.group_search',
+                     '/groups/{pubid}/search',
+                     factory='h.models.group:GroupFactory',
+                     traverse='/{pubid}')
     config.add_route('activity.user_search',
                      '/users/{username}',
                      factory='h.models.user:UserFactory',

--- a/tests/h/routes_test.py
+++ b/tests/h/routes_test.py
@@ -34,7 +34,7 @@ def test_includeme():
         call('claim_account_legacy', '/claim_account/{token}'),
         call('dismiss_sidebar_tutorial', '/app/dismiss_sidebar_tutorial'),
         call('activity.search', '/search'),
-        call('activity.group_search', '/groups/{pubid}/search'),
+        call(u'activity.group_search', u'/groups/{pubid}/search', factory=u'h.models.group:GroupFactory', traverse=u'/{pubid}'),
         call('activity.user_search', '/users/{username}', factory=u'h.models.user:UserFactory', traverse=u'/{username}'),
         call('admin_index', '/admin/'),
         call('admin_admins', '/admin/admins'),

--- a/tests/h/views/activity_test.py
+++ b/tests/h/views/activity_test.py
@@ -137,11 +137,13 @@ class TestSearchController(object):
 @pytest.mark.usefixtures('groups_service', 'routes', 'search')
 class TestGroupSearchController(object):
 
-    def test_init_returns_404_when_feature_turned_off(self, pyramid_request):
+    def test_init_returns_404_when_feature_turned_off(self,
+                                                      group,
+                                                      pyramid_request):
         pyramid_request.feature.flags['search_page'] = False
 
         with pytest.raises(httpexceptions.HTTPNotFound):
-            activity.GroupSearchController(pyramid_request)
+            activity.GroupSearchController(group, pyramid_request)
 
     def test_search_calls_search_with_the_request(self,
                                                   controller,
@@ -247,16 +249,6 @@ class TestGroupSearchController(object):
 
         assert result['opts']['search_groupname'] == group.name
 
-    def test_search_returns_pubid_in_opts_if_group_does_not_exist(self,
-                                                                  controller,
-                                                                  group,
-                                                                  pyramid_request):
-        pyramid_request.matchdict['pubid'] = 'does_not_exist'
-
-        result = controller.search()
-
-        assert result['opts']['search_groupname'] == 'does_not_exist'
-
     def test_search_returns_group_members_usernames(self,
                                                     controller,
                                                     pyramid_request,
@@ -345,15 +337,6 @@ class TestGroupSearchController(object):
         assert result['zero_message'] == (
             "The group “{name}” has not made any annotations yet.".format(
                 name=group.name))
-
-    def test_leave_returns_404_when_the_group_does_not_exist(self,
-                                                             controller,
-                                                             group_leave_request):
-        group_leave_request.POST = NestedMultiDict({
-            'group_leave': 'does_not_exist'})
-
-        with pytest.raises(httpexceptions.HTTPNotFound):
-            controller.leave()
 
     def test_leave_leaves_the_group(self,
                                     controller,
@@ -445,8 +428,8 @@ class TestGroupSearchController(object):
             '?q=user%3Afoo+user%3Abar'.format(pubid=group.pubid))
 
     @pytest.fixture
-    def controller(self, pyramid_request):
-        return activity.GroupSearchController(pyramid_request)
+    def controller(self, group, pyramid_request):
+        return activity.GroupSearchController(group, pyramid_request)
 
     @pytest.fixture
     def group_leave_request(self, group, pyramid_request):


### PR DESCRIPTION
Second in a sequence of PRs to refactor the groups and activity views so that we can easily change the `/groups/<pubid>/search` URL to share `/groups/<pubid>/<slug>` with the other group pages.

This means that:

* `/groups/<pubid_that_does_not_exist>/search` is now a 404, same as `/users/<username_that_does_not_exist>`, instead of an empty search page

* Searching for `group:pubid_that_does_not_exist` will no longer redirect you to `/groups/<pubid_that_does_not_exist>/search`. Again, same as for users