### PR TITLE
Only display back links in specific cases

### DIFF
--- a/h/views/panels.py
+++ b/h/views/panels.py
@@ -45,8 +45,6 @@ def back_link(context, request):
         back_label = _('Back to your profile page')
     elif _matches_route(referrer_path, request, 'activity.group_search'):
         back_label = _('Back to group overview page')
-    elif referrer_path:
-        back_label = _('Back')
     else:
         back_label = None
 

--- a/tests/h/views/panels_test.py
+++ b/tests/h/views/panels_test.py
@@ -103,9 +103,9 @@ class TestBackLink(object):
     @pytest.mark.parametrize('referrer,label', [
         ('https://example.com/users/currentuser', 'Back to your profile page'),
         ('https://example.com/users/currentuser?q=tag:foo', 'Back to your profile page'),
-        ('https://example.com/users/otheruser', 'Back'),
+        ('https://example.com/users/otheruser', None),
         ('https://example.com/groups/abc', 'Back to group overview page'),
-        ('https://example.com/search', 'Back'),
+        ('https://example.com/search', None),
         (None, None),
     ])
     def test_it_sets_back_label(self, pyramid_request, referrer, label):


### PR DESCRIPTION
Previously, this code would display a generic "Back" link if any HTTP "Referer" was set, resulting in a back link being displayed when clicking around between different panes of the account area.

This commit restricts the display of the "back" link to only the two cases identified in the original card[1].

[1]: https://github.com/hypothesis/product-backlog/issues/42