### PR TITLE
Factor out GroupUserSearchController

### DIFF
--- a/h/views/activity.py
+++ b/h/views/activity.py
@@ -214,6 +214,22 @@ class GroupSearchController(SearchController):
 
         return httpexceptions.HTTPSeeOther(location=location)
 
+    @view_config(request_method='POST', request_param='more_info')
+    def more_info(self):
+        return _more_info(self.request)
+
+    @view_config(request_method='POST', request_param='back')
+    def back(self):
+        return _back(self.request)
+
+    @view_config(request_param='delete_lozenge')
+    def delete_lozenge(self):
+        return _delete_lozenge(self.request)
+
+    @view_config(request_method='POST', request_param='toggle_tag_facet')
+    def toggle_tag_facet(self):
+        return _toggle_tag_facet(self.request)
+
 
 @view_defaults(route_name='activity.user_search',
                renderer='h:templates/activity/search.html.jinja2')
@@ -262,96 +278,21 @@ class UserSearchController(SearchController):
 
         return result
 
-
-@view_defaults(request_method='GET',
-               renderer='h:templates/activity/search.html.jinja2')
-class GroupUserSearchController(SearchController):
-    """activity.group_search and activity.user_search shared views."""
-
-    @view_config(route_name='activity.group_search',
-                 request_method='POST',
-                 request_param='more_info')
-    @view_config(route_name='activity.user_search',
-                 request_method='POST',
-                 request_param='more_info')
+    @view_config(request_method='POST', request_param='more_info')
     def more_info(self):
-        """Respond to a click on the ``more_info`` button."""
-        return _redirect_to_user_or_group_search(self.request,
-                                                 self.request.POST)
+        return _more_info(self.request)
 
-    @view_config(route_name='activity.group_search',
-                 request_method='POST',
-                 request_param='back')
-    @view_config(route_name='activity.user_search',
-                 request_method='POST',
-                 request_param='back')
+    @view_config(request_method='POST', request_param='back')
     def back(self):
-        """Respond to a click on the ``back`` button."""
-        new_params = self.request.POST.copy()
-        del new_params['back']
-        return _redirect_to_user_or_group_search(self.request, new_params)
+        return _back(self.request)
 
-    @view_config(route_name='activity.group_search',
-                 request_param='delete_lozenge')
-    @view_config(route_name='activity.user_search',
-                 request_param='delete_lozenge')
+    @view_config(request_param='delete_lozenge')
     def delete_lozenge(self):
-        """
-        Redirect to the /search page, keeping the search query intact.
+        return _delete_lozenge(self.request)
 
-        When on the user or group search page a lozenge for the user or group
-        is rendered as the first lozenge in the search bar. The delete button
-        on that first lozenge calls this view. Redirect to the general /search
-        page, effectively deleting that first user or group lozenge, but
-        maintaining any other search terms that have been entered into the
-        search box.
-
-        """
-        new_params = self.request.params.copy()
-        del new_params['delete_lozenge']
-        location = self.request.route_url('activity.search', _query=new_params)
-        return httpexceptions.HTTPSeeOther(location=location)
-
-    @view_config(route_name='activity.group_search',
-                 request_method='POST',
-                 request_param='toggle_tag_facet')
-    @view_config(route_name='activity.user_search',
-                 request_method='POST',
-                 request_param='toggle_tag_facet')
+    @view_config(request_method='POST', request_param='toggle_tag_facet')
     def toggle_tag_facet(self):
-        """
-        Toggle the given tag from the search facets.
-
-        If the search is not already faceted by the tag given in the
-        "toggle_tag_facet" request param then redirect the browser to the same
-        page but with the a facet for this  added to the search query.
-
-        If the search is already faceted by the tag then redirect the browser
-        to the same page but with this facet removed from the search query.
-
-        """
-        tag = self.request.POST['toggle_tag_facet']
-
-        new_params = self.request.POST.copy()
-
-        del new_params['toggle_tag_facet']
-
-        parsed_query = _parsed_query(self.request)
-        if _faceted_by_tag(self.request, tag, parsed_query):
-            # The search query is already faceted by the given tag,
-            # so remove that tag facet.
-            tag_facets = _tag_facets(self.request, parsed_query)
-            tag_facets.remove(tag)
-            del parsed_query['tag']
-            for tag_facet in tag_facets:
-                parsed_query.add('tag', tag_facet)
-        else:
-            # The search query is not yet faceted by the given tag, so add a facet
-            # for the tag.
-            parsed_query.add('tag', tag)
-
-        new_params['q'] = parser.unparse(parsed_query)
-        return _redirect_to_user_or_group_search(self.request, new_params)
+        return _toggle_tag_facet(self.request)
 
 
 def _parsed_query(request):
@@ -419,3 +360,69 @@ def _redirect_to_user_or_group_search(request, params):
                                      username=request.matchdict['username'],
                                      _query=params)
     return httpexceptions.HTTPSeeOther(location=location)
+
+
+def _more_info(request):
+    """Respond to a click on the ``more_info`` button."""
+    return _redirect_to_user_or_group_search(request, request.POST)
+
+
+def _back(request):
+    """Respond to a click on the ``back`` button."""
+    new_params = request.POST.copy()
+    del new_params['back']
+    return _redirect_to_user_or_group_search(request, new_params)
+
+
+def _delete_lozenge(request):
+    """
+    Redirect to the /search page, keeping the search query intact.
+
+    When on the user or group search page a lozenge for the user or group
+    is rendered as the first lozenge in the search bar. The delete button
+    on that first lozenge calls this view. Redirect to the general /search
+    page, effectively deleting that first user or group lozenge, but
+    maintaining any other search terms that have been entered into the
+    search box.
+
+    """
+    new_params = request.params.copy()
+    del new_params['delete_lozenge']
+    location = request.route_url('activity.search', _query=new_params)
+    return httpexceptions.HTTPSeeOther(location=location)
+
+
+def _toggle_tag_facet(request):
+    """
+    Toggle the given tag from the search facets.
+
+    If the search is not already faceted by the tag given in the
+    "toggle_tag_facet" request param then redirect the browser to the same
+    page but with the a facet for this  added to the search query.
+
+    If the search is already faceted by the tag then redirect the browser
+    to the same page but with this facet removed from the search query.
+
+    """
+    tag = request.POST['toggle_tag_facet']
+
+    new_params = request.POST.copy()
+
+    del new_params['toggle_tag_facet']
+
+    parsed_query = _parsed_query(request)
+    if _faceted_by_tag(request, tag, parsed_query):
+        # The search query is already faceted by the given tag,
+        # so remove that tag facet.
+        tag_facets = _tag_facets(request, parsed_query)
+        tag_facets.remove(tag)
+        del parsed_query['tag']
+        for tag_facet in tag_facets:
+            parsed_query.add('tag', tag_facet)
+    else:
+        # The search query is not yet faceted by the given tag, so add a facet
+        # for the tag.
+        parsed_query.add('tag', tag)
+
+    new_params['q'] = parser.unparse(parsed_query)
+    return _redirect_to_user_or_group_search(request, new_params)


### PR DESCRIPTION
Replace it with private helper methods instead. This is a refactoring
with no functional change. It should make it easier to make future
changes to these view classes by allowing view defaults to be specified
more easily.

`GroupUserSearchController` was a class containing view methods that each
had two `@view_config`s on: one for the `"activity.group_search"` route
and one for `"activity.user_search"`. This avoided duplicating the Python
code in the view methods, which is shared by the group and user search
routes.

The problem with this is that it ends up duplicating view config
declarations - `@view_defaults` can't be used effectively on
`GroupUserSearchController` because it can only contain defaults that
apply to both the group search and the user search routes for every view
method in the class. Additionally the view defaults needed for the group
search and user search routes are already on `@view_defaults`
declarations on `GroupSearchController` and `UserSearchController`
respectively.

Instead move all of `GroupUserSearchController`'s methods to private
helper functions: `_more_info(request)` etc. Then for each of the
private helper functions add a corresponding method to _both_
`GroupSearchController` _and_ `UserSearchController`:
`GroupSearchController.more_info(self)` etc. These duplicated methods
are just one-liners that call the helper methods (avoiding duplication
of Python code) and that have `@view_config`s on them. These
`@view_config`s can rely on the `@view_defaults` of
`GroupSearchController` and `UserSearchController`, avoiding duplication
of view config declarations.

We can now add more view defaults to `UserSearchController` or
`GroupSearchController` separately and have them apply to all the view
methods they contain.