### PR TITLE
Factor group join into separate view

### DIFF
--- a/h/views/__init__.py
+++ b/h/views/__init__.py
@@ -3,3 +3,4 @@
 
 def includeme(config):
     config.scan(__name__)
+    config.include('h.views.predicates')

--- a/h/views/predicates.py
+++ b/h/views/predicates.py
@@ -1,0 +1,21 @@
+"""Custom Pyramid view predicates."""
+
+
+class HasPermissionPredicate(object):
+    """True if the request has the given permission on the context object."""
+
+    def __init__(self, permission, config):
+        self.permission = permission
+
+    def text(self):
+        return 'has_permission = {permission}'.format(
+            permission=self.permission)
+
+    phash = text
+
+    def __call__(self, context, request):
+        return request.has_permission(self.permission)
+
+
+def includeme(config):
+    config.add_view_predicate('has_permission', HasPermissionPredicate)

--- a/tests/h/views/groups_test.py
+++ b/tests/h/views/groups_test.py
@@ -194,18 +194,6 @@ class TestGroupRead(object):
         assert result['group'] == group
         assert result['document_links'] == ['link1', 'link2']
 
-    def test_renders_join_template_if_not_member(self,
-                                                 pyramid_config,
-                                                 pyramid_request):
-        group = FakeGroup('abc123', 'some-slug')
-        pyramid_config.testing_securitypolicy('bohus', permissive=False)
-        pyramid_request.matchdict['slug'] = 'some-slug'
-
-        result = views.read(group, pyramid_request)
-
-        assert 'join.html' in pyramid_request.override_renderer
-        assert result == {'group': group}
-
 
 @pytest.mark.usefixtures('routes')
 class TestGroupReadUnauthenticated(object):
@@ -238,28 +226,6 @@ def test_read_noslug_redirects(pyramid_request):
 
 
 @pytest.mark.usefixtures('groups_service', 'routes')
-class TestGroupJoin(object):
-    def test_joins_group(self,
-                         groups_service,
-                         pyramid_config,
-                         pyramid_request):
-        group = FakeGroup('abc123', 'some-slug')
-        pyramid_config.testing_securitypolicy('gentiana')
-
-        views.join(group, pyramid_request)
-
-        assert (group, 'gentiana') in groups_service.joined
-
-    def test_redirects_to_group_page(self, pyramid_request):
-        group = FakeGroup('abc123', 'some-slug')
-
-        result = views.join(group, pyramid_request)
-
-        assert isinstance(result, HTTPSeeOther)
-        assert result.location == '/g/abc123/some-slug'
-
-
-@pytest.mark.usefixtures('groups_service', 'routes')
 class TestGroupLeave(object):
     def test_leaves_group(self,
                           groups_service,
@@ -278,6 +244,49 @@ class TestGroupLeave(object):
         result = views.leave(group, pyramid_request)
 
         assert isinstance(result, HTTPNoContent)
+
+
+@pytest.mark.usefixtures('groups_service', 'routes')
+class TestGroupJoinController(object):
+
+    def test_get_returns_the_group_to_the_template(self, controller, group):
+        assert controller.get()['group'] == group
+
+    def test_post_joins_the_group(self,
+                                  controller,
+                                  group,
+                                  groups_service,
+                                  pyramid_config):
+        pyramid_config.testing_securitypolicy('gentiana')
+
+        controller.post()
+
+        assert (group, 'gentiana') in groups_service.joined
+
+    def test_post_redirects_to_group_page(self,
+                                          controller,
+                                          group):
+        result = controller.post()
+
+        assert isinstance(result, HTTPSeeOther)
+        assert result.location == '/g/{pubid}/{slug}'.format(
+            pubid=group.pubid, slug=group.slug)
+
+    @pytest.fixture
+    def controller(self, group, pyramid_request):
+        return views.GroupJoinController(group, pyramid_request)
+
+    @pytest.fixture
+    def group(self, factories):
+        return factories.Group()
+
+    @pytest.fixture
+    def pyramid_request(self, group, pyramid_request):
+        # The matchdict needs to contain the correct pubid and slug,
+        # otherwise initializing the controller will redirect.
+        pyramid_request.matchdict['pubid'] = group.pubid
+        pyramid_request.matchdict['slug'] = group.slug
+        return pyramid_request
 
 
 class FakeGroup(object):

--- a/tests/h/views/predicates_test.py
+++ b/tests/h/views/predicates_test.py
@@ -1,0 +1,28 @@
+import mock
+
+from h.views import predicates
+
+
+class TestHasPermissionPredicate(object):
+
+    def test_text(self):
+        predicate = predicates.HasPermissionPredicate('foo',
+                                                      mock.sentinel.config)
+
+        assert predicate.text() == 'has_permission = foo'
+
+    def test_phash(self):
+        predicate = predicates.HasPermissionPredicate('foo',
+                                                      mock.sentinel.config)
+
+        assert predicate.phash() == 'has_permission = foo'
+
+    def test__call__(self):
+        request = mock.Mock(spec_set=['has_permission'])
+        predicate = predicates.HasPermissionPredicate('bar',
+                                                      mock.sentinel.config)
+
+        result = predicate(mock.sentinel.context, request)
+
+        request.has_permission.assert_called_once_with('bar')
+        assert result == request.has_permission.return_value


### PR DESCRIPTION
Factor the group join page (the view for the 'group_read' route when the
user is logged-in but isn't a member of the group) into a separate view
callable.

Previously h.views.groups.read() was called for the 'group_read' route
when the user was logged-in, whether they're a member of the group or
not.

In the future the classic group page that this read() view provides is
going to be used only when the 'search_page' feature flag is off, and a
completely separate view (h.views.activity.GroupSearchController) is
going to be used when the flag is on. We'll add a view config predicate
to read() so that it's not called if the flag is on.

But we still want the join group page to be called even if the feature
flag is on, so we can't have this read() function (which is not going to
be called when the flag is on anymore) also being responsible for the
join page.

Additionally there was a separate view function, join(), which was
called when the user is logged-in but isn't a member of the group and
POSTs to the group_read route. It's a little odd that GET requests in
the "join group" scenario (group_read route, logged-in, not a member)
are handled by read() (which also handles the read group scenario)
whereas POST requests in the join group scenario are handled by a
separate join() function.

So refactor things so that:

* read() is only for the group read page that you see when you're a
  member of the group

* The new JoinController is for the join page that you see when you
  aren't a member, and has separate methods for GET and POST to this page

Note that there's still one more separate view function for this route as
well, which this commit doesn't touch: read_unauthenticated() (for when you're
not logged in).