### PR TITLE
Fix the test for whether an annotation is private

### DIFF
--- a/h/templates/includes/annotation_card.html.jinja2
+++ b/h/templates/includes/annotation_card.html.jinja2
@@ -21,7 +21,7 @@
             {{ group.name }}
         </a>
       {% endif %}
-      {% if annotation.shared %}
+      {% if not annotation.shared %}
         <span class="annotation-card__is-private">
           {{ svg_icon('lock', 'annotation-card__is-private-icon') }}
           {% if not group %}


### PR DESCRIPTION
Only show the lock icon when an annotation is private rather than
shared.