### PR TITLE
Tighten read_unauthenticated() view config

### DIFF
--- a/h/views/groups.py
+++ b/h/views/groups.py
@@ -137,7 +137,8 @@ def read(group, request):
 
 @view_config(route_name='group_read',
              request_method='GET',
-             renderer='h:templates/groups/join.html.jinja2')
+             renderer='h:templates/groups/join.html.jinja2',
+             effective_principals=not_(security.Authenticated))
 def read_unauthenticated(group, request):
     """Group view for logged-out users, allowing them to join the group."""
     _check_slug(group, request)


### PR DESCRIPTION
Explicitly state that the read_unauthenticated() view should only be
called when the user is not logged in.

Previously this view could have been called when the user _was_ logged
in, and the only reason that it wasn't was that read(), which is more
specific, would be called instead.

If the read() view were deleted then read_unauthenticated() would be
called even for authenticated requests.

I think it's good to 1. Not have to read multiple @view_configs to
determine when one particular view will and will not be called, and
2. Be more explicit in @view_config and @view_defaults about when a view is and
is not intended to be called.