### PR TITLE
Fix RSS and Atom validator errors

### DIFF
--- a/h/feeds/render.py
+++ b/h/feeds/render.py
@@ -65,8 +65,6 @@ def render_rss(request, annotations, rss_url, html_url, title, description):
     :rtype: pyramid.response.Response
 
     """
-    request.response.content_type = "application/rss+xml"
-
     def annotation_url(annotation):
         """Return the HTML permalink URL for the given annotation."""
         return request.route_url('annotation', id=annotation.id)
@@ -76,5 +74,7 @@ def render_rss(request, annotations, rss_url, html_url, title, description):
         rss_url=rss_url, html_url=html_url, title=title,
         description=description)
 
-    return renderers.render_to_response(
+    response = renderers.render_to_response(
         'h:templates/rss.xml.jinja2', {"feed": feed}, request=request)
+    response.content_type = 'application/rss+xml'
+    return response

--- a/h/feeds/render.py
+++ b/h/feeds/render.py
@@ -25,8 +25,6 @@ def render_atom(request, annotations, atom_url, html_url, title, subtitle):
     :rtype: pyramid.response.Response
 
     """
-    request.response.content_type = "application/atom+xml"
-
     def annotation_url(annotation):
         """Return the HTML permalink URL for the given annotation."""
         return request.route_url('annotation', id=annotation.id)
@@ -40,8 +38,10 @@ def render_atom(request, annotations, atom_url, html_url, title, subtitle):
         annotation_url=annotation_url, annotation_api_url=annotation_api_url,
         html_url=html_url, title=title, subtitle=subtitle)
 
-    return renderers.render_to_response(
+    response = renderers.render_to_response(
         'h:templates/atom.xml.jinja2', {"feed": feed}, request=request)
+    response.content_type = "application/atom+xml"
+    return response
 
 
 def render_rss(request, annotations, rss_url, html_url, title, description):

--- a/h/feeds/rss.py
+++ b/h/feeds/rss.py
@@ -1,4 +1,8 @@
 """Functions for generating RSS feeds."""
+
+from calendar import timegm
+from email.utils import formatdate
+
 from pyramid import i18n
 
 from h import presenters
@@ -9,18 +13,16 @@ import h.feeds.util
 _ = i18n.TranslationStringFactory(__package__)
 
 
-def _pubDate_string_from_annotation(annotation):
-    """Return a correctly-formatted pubDate string for the given annotation.
+def _pubDate_string(timestamp):
+    """Return a RFC2822-formatted pubDate string for the given timestamp.
 
-    Return a pubDate string like 'Tue, 03 Jun 2003 09:39:21 GMT' from a
-    Hypothesis API 'created' datetime string like
-    '2015-03-11T10:43:54.537626+00:00'.
+    Return a pubDate string like 'Tue, 03 Jun 2003 09:39:21 -0000'.
 
     Suitable for use as the contents of a <pubDate> element in an <item>
     element of an RSS feed.
 
     """
-    return annotation.created.strftime('%a, %d %b %Y %H:%M:%S +0000')
+    return formatdate(timegm(timestamp.utctimetuple()))
 
 
 def _feed_item_from_annotation(annotation, annotation_url):
@@ -40,7 +42,7 @@ def _feed_item_from_annotation(annotation, annotation_url):
         "author": {"name": name},
         "title": annotation.title,
         "description": annotation.description,
-        "pubDate": _pubDate_string_from_annotation(annotation),
+        "pubDate": _pubDate_string(annotation.created),
         "guid": h.feeds.util.tag_uri_for_annotation(annotation, annotation_url),
         "link": annotation_url(annotation)
     }

--- a/h/feeds/rss.py
+++ b/h/feeds/rss.py
@@ -73,6 +73,6 @@ def feed_from_annotations(annotations, annotation_url, rss_url, html_url,
     }
 
     if annotations:
-        feed['pubDate'] = annotations[0].updated.strftime('%a, %d %b %Y %H:%M:%S UTC')
+        feed['pubDate'] = _pubDate_string(annotations[0].updated)
 
     return feed

--- a/h/templates/rss.xml.jinja2
+++ b/h/templates/rss.xml.jinja2
@@ -22,7 +22,7 @@ render the feed to RSS XML.
        <title>{{ item.title }}</title>
        <description>{{ item.description|safe }}</description>
        <pubDate>{{ item.pubDate }}</pubDate>
-       <guid isPermaLink="true">{{ item.guid }}</guid>
+       <guid isPermaLink="false">{{ item.guid }}</guid>
        <link>{{ item.link }}</link>
        <dc:creator><![CDATA[{{ item.author.name }}]]></dc:creator>
     </item>

--- a/tests/h/feeds/render_test.py
+++ b/tests/h/feeds/render_test.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import mock
+import pytest
+
+from pyramid.response import Response
+
+from h.feeds import render
+
+
+@pytest.mark.usefixtures('render_to_response')
+class TestRenderRSS(object):
+    def test_it_sets_response_content_type(self, pyramid_request):
+        response = render.render_rss(
+                request=pyramid_request,
+                annotations=[],
+                rss_url='',
+                html_url='',
+                title='',
+                description='')
+        assert response.content_type == 'application/rss+xml'
+
+    @pytest.fixture
+    def render_to_response(self, patch):
+        response = mock.Mock(spec_set=Response)
+        func = patch('h.feeds.render.renderers.render_to_response')
+        func.return_value = response
+        return func

--- a/tests/h/feeds/render_test.py
+++ b/tests/h/feeds/render_test.py
@@ -11,6 +11,18 @@ from h.feeds import render
 
 
 @pytest.mark.usefixtures('render_to_response')
+class TestRenderAtom(object):
+    def test_it_sets_response_content_type(self, pyramid_request):
+        response = render.render_atom(request=pyramid_request,
+                                      annotations=[],
+                                      atom_url='',
+                                      html_url='',
+                                      title='',
+                                      subtitle='')
+        assert response.content_type == 'application/atom+xml'
+
+
+@pytest.mark.usefixtures('render_to_response')
 class TestRenderRSS(object):
     def test_it_sets_response_content_type(self, pyramid_request):
         response = render.render_rss(
@@ -22,9 +34,10 @@ class TestRenderRSS(object):
                 description='')
         assert response.content_type == 'application/rss+xml'
 
-    @pytest.fixture
-    def render_to_response(self, patch):
-        response = mock.Mock(spec_set=Response)
-        func = patch('h.feeds.render.renderers.render_to_response')
-        func.return_value = response
-        return func
+
+@pytest.fixture
+def render_to_response(patch):
+    response = mock.Mock(spec_set=Response)
+    func = patch('h.feeds.render.renderers.render_to_response')
+    func.return_value = response
+    return func

--- a/tests/h/feeds/rss_test.py
+++ b/tests/h/feeds/rss_test.py
@@ -45,7 +45,7 @@ def test_feed_annotations_pubDate():
     feed = rss.feed_from_annotations(
         [ann], _annotation_url(), mock.Mock(), '', '', '')
 
-    assert feed['entries'][0]['pubDate'] == 'Wed, 11 Mar 2015 10:43:54 +0000'
+    assert feed['entries'][0]['pubDate'] == 'Wed, 11 Mar 2015 10:43:54 -0000'
 
 
 def test_feed_from_annotations_html_links(factories):

--- a/tests/h/feeds/rss_test.py
+++ b/tests/h/feeds/rss_test.py
@@ -157,4 +157,4 @@ def test_feed_from_annotations_pubDate():
     feed = rss.feed_from_annotations(
         annotations, _annotation_url(), mock.Mock(), '', '', '')
 
-    assert feed['pubDate'] == 'Wed, 11 Mar 2015 10:45:54 UTC'
+    assert feed['pubDate'] == 'Wed, 11 Mar 2015 10:45:54 -0000'


### PR DESCRIPTION
Check the individual commit messages for more information. This makes sure to pass the [w3 feed validator](http://validator.w3.org/feed/check.cgi) for both our RSS and Atom feeds.

Fixes #3976.