### PR TITLE
Fix user and group search pages on iOS Safari

### DIFF
--- a/h/static/styles/partials-v2/_nav-bar.scss
+++ b/h/static/styles/partials-v2/_nav-bar.scss
@@ -32,6 +32,17 @@
   max-width: 650px;
 }
 
+.nav-bar__search-hidden-input {
+  /* Don't display this input to the user.
+     We use visibility: hidden; instead of display: none; because
+     display: none; causes iOS Safari to ignore the <input> and not use it for
+     form submission. */
+  visibility: hidden;
+
+  /* Prevent the hidden input from affecting the layout of the visible parts. */
+  position: absolute;
+}
+
 .nav-bar-links {
   margin-left: 10px;
   margin-right: 60px;

--- a/h/templates/panels/navbar.html.jinja2
+++ b/h/templates/panels/navbar.html.jinja2
@@ -44,7 +44,7 @@
             presses Enter in the search bar input, the browser will act as if
             the user had clicked one of the form's other submit elements
             (e.g. the leave group button). #}
-        <input type="submit" class="u-hidden">
+        <input type="submit" class="nav-bar__search-hidden-input">
 
         {{ svg_icon('search', 'search-bar__icon') }}
         <div class="search-bar__lozenges" data-ref="searchBarLozenges">


### PR DESCRIPTION
Fix https://github.com/hypothesis/h/issues/4116

When submitting the search form using the keyboard on the
/groups/{pubid}/{slug} page or the /users/{username} page on mobile
Safari, the group or user lozenge was being incorrectly deleted and the
browser incorrectly redirected to the /search page. On other browsers
this was not happening.

There is an `<input type="submit">` that's hidden with CSS that is the
submit button that's submitted when you hit Enter in the search form.
The problem is that mobile Safari was not finding this submit button,
skipping over it and instead finding the delete button on the user or
group lozenge and submitting that instead.

The reason turns out to be that display: none; was used in CSS to hide
the hidden input, and that causes Safari to ignore it for form
submission purposes. (This seems like a bug in mobile Safari - CSS
probably shouldn't affect form behavior.)

The fix is to use visibility: hidden; instead. That then breaks the
search box layout, so add position: absolute; to fix it again.