### PR TITLE
Fix tags aggregation

### DIFF
--- a/src/memex/presenters.py
+++ b/src/memex/presenters.py
@@ -104,6 +104,7 @@ class AnnotationSearchIndexPresenter(AnnotationBasePresenter):
             'uri': self.annotation.target_uri,
             'text': self.text,
             'tags': self.tags,
+            'tags_raw': self.tags,
             'group': self.annotation.groupid,
             'permissions': self.permissions,
             'target': self.target,

--- a/src/memex/search/config.py
+++ b/src/memex/search/config.py
@@ -28,6 +28,7 @@ ANNOTATION_MAPPING = {
         'updated': {'type': 'date'},
         'quote': {'type': 'string', 'analyzer': 'uni_normalizer'},
         'tags': {'type': 'string', 'analyzer': 'uni_normalizer'},
+        'tags_raw': {'type': 'string', 'index': 'not_analyzed'},
         'text': {'type': 'string', 'analyzer': 'uni_normalizer'},
         'deleted': {'type': 'boolean'},
         'uri': {

--- a/src/memex/search/query.py
+++ b/src/memex/search/query.py
@@ -257,7 +257,7 @@ class TagsAggregation(object):
     def __call__(self, _):
         return {
             "terms": {
-                "field": "tags",
+                "field": "tags_raw",
                 "size": self.limit
             }
         }

--- a/tests/memex/presenters_test.py
+++ b/tests/memex/presenters_test.py
@@ -217,6 +217,7 @@ class TestAnnotationSearchIndexPresenter(object):
             'uri': 'http://example.com',
             'text': 'It is magical!',
             'tags': ['magic'],
+            'tags_raw': ['magic'],
             'group': '__world__',
             'permissions': {'read': ['group:__world__'],
                             'admin': ['acct:luke@hypothes.is'],

--- a/tests/memex/search/query_test.py
+++ b/tests/memex/search/query_test.py
@@ -490,13 +490,13 @@ class TestTagsAggregations(object):
     def test_elasticsearch_aggregation(self):
         agg = query.TagsAggregation()
         assert agg({}) == {
-            'terms': {'field': 'tags', 'size': 0}
+            'terms': {'field': 'tags_raw', 'size': 0}
         }
 
     def test_it_allows_to_set_a_limit(self):
         agg = query.TagsAggregation(limit=14)
         assert agg({}) == {
-            'terms': {'field': 'tags', 'size': 14}
+            'terms': {'field': 'tags_raw', 'size': 14}
         }
 
     def parse_result(self):


### PR DESCRIPTION
Analyzed fields do affect aggregations as they return buckets of the
tokenized field values, not the raw string ([see here]). Thus we are adding a new
field to the search index that contains the non-analyzed list of tag
strings.

Similar to the `user_raw` field that was introduced in 3514315.

[see here]: https://www.elastic.co/guide/en/elasticsearch/guide/1.x/aggregations-and-analysis.html#aggregations-and-analysis