### PR TITLE
Make all search page requests use get

### DIFF
--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -10,7 +10,6 @@
   <nav class="search-result-nav">
     {%- if more_info %}
       <button form="search-bar"
-              formaction="{{ request.path_url }}"
               name="back"
               class="search-result-nav__button">
         {% trans %}Back{% endtrans %}
@@ -18,7 +17,6 @@
     {% else %}
       <h1 class="search-result-nav__title">{{ name }}</h1>
       <button form="search-bar"
-              formaction="{{ request.path_url }}"
               name="more_info"
               class="search-result-nav__button">
         {% trans %}More info{% endtrans %}
@@ -141,7 +139,6 @@
     {% for tag in aggregations.tags %}
       <button type="submit"
               form="search-bar"
-              formaction="{{ request.path_url }}"
               name="toggle_tag_facet"
               value="{{ tag.tag }}"
               class="search-result-sidebar__tag">
@@ -210,7 +207,6 @@
                   type="submit"
                   form="search-bar"
                   formmethod="POST"
-                  formaction="{{ request.path_url }}"
                   name="group_leave"
                   value="{{ group.pubid }}"
                   data-confirm-message="Are you sure you want to leave the group &quot;{{ group.name }}&quot;?">
@@ -234,7 +230,6 @@
           <li>
             <button type="submit"
                     form="search-bar"
-                    formaction="{{ request.path_url }}"
                     name="toggle_user_facet"
                     value="{{ user.userid }}"
                     {% if user.faceted_by %}

--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -5,12 +5,11 @@
 {% macro search_result_nav(name) %}
 {# This <form> is needed for IE because it doesn't support the `form`
    attribute. See commit message. #}
-<form method="POST" action="{{ request.path_url }}">
+<form method="GET" action="{{ request.path_url }}">
   <input type="hidden" name="q" value="{{ q }}">
   <nav class="search-result-nav">
     {%- if more_info %}
       <button form="search-bar"
-              formmethod="POST"
               formaction="{{ request.path_url }}"
               name="back"
               class="search-result-nav__button">
@@ -19,7 +18,6 @@
     {% else %}
       <h1 class="search-result-nav__title">{{ name }}</h1>
       <button form="search-bar"
-              formmethod="POST"
               formaction="{{ request.path_url }}"
               name="more_info"
               class="search-result-nav__button">
@@ -143,7 +141,6 @@
     {% for tag in aggregations.tags %}
       <button type="submit"
               form="search-bar"
-              formmethod="POST"
               formaction="{{ request.path_url }}"
               name="toggle_tag_facet"
               value="{{ tag.tag }}"
@@ -163,7 +160,7 @@
 
   {#- This form element is needed for Internet Explorer because it
       doesn't support the `form` attribute. See commit message. #}
-  <form method="POST" action="{{ request.path_url }}">
+  <form method="GET" action="{{ request.path_url }}">
     <input type="hidden" name="q" value="{{ q }}">
 
     <h1 class="search-result-sidebar__title">{{ title }}</h1>
@@ -237,7 +234,6 @@
           <li>
             <button type="submit"
                     form="search-bar"
-                    formmethod="POST"
                     formaction="{{ request.path_url }}"
                     name="toggle_user_facet"
                     value="{{ user.userid }}"

--- a/h/views/activity.py
+++ b/h/views/activity.py
@@ -94,7 +94,8 @@ class SearchController(object):
                renderer='h:templates/activity/search.html.jinja2',
                effective_principals=security.Authenticated,
                has_feature_flag='search_page',
-               has_permission='read')
+               has_permission='read',
+               request_method='GET')
 class GroupSearchController(SearchController):
     """View callables unique to the "group_read" route."""
 
@@ -175,8 +176,7 @@ class GroupSearchController(SearchController):
 
         return httpexceptions.HTTPSeeOther(location=location)
 
-    @view_config(request_method='POST',
-                 request_param='toggle_user_facet')
+    @view_config(request_param='toggle_user_facet')
     def toggle_user_facet(self):
         """
         Toggle the given user from the search facets.
@@ -190,10 +190,10 @@ class GroupSearchController(SearchController):
         search query.
 
         """
-        userid = self.request.POST['toggle_user_facet']
+        userid = self.request.params['toggle_user_facet']
         username = util.user.split_user(userid)['username']
 
-        new_params = self.request.POST.copy()
+        new_params = self.request.params.copy()
 
         del new_params['toggle_user_facet']
 
@@ -219,11 +219,7 @@ class GroupSearchController(SearchController):
 
         return httpexceptions.HTTPSeeOther(location=location)
 
-    @view_config(request_method='POST', request_param='more_info')
-    def more_info(self):
-        return _more_info(self.request)
-
-    @view_config(request_method='POST', request_param='back')
+    @view_config(request_param='back')
     def back(self):
         return _back(self.request)
 
@@ -231,7 +227,7 @@ class GroupSearchController(SearchController):
     def delete_lozenge(self):
         return _delete_lozenge(self.request)
 
-    @view_config(request_method='POST', request_param='toggle_tag_facet')
+    @view_config(request_param='toggle_tag_facet')
     def toggle_tag_facet(self):
         return _toggle_tag_facet(self.request)
 
@@ -283,11 +279,7 @@ class UserSearchController(SearchController):
 
         return result
 
-    @view_config(request_method='POST', request_param='more_info')
-    def more_info(self):
-        return _more_info(self.request)
-
-    @view_config(request_method='POST', request_param='back')
+    @view_config(request_param='back')
     def back(self):
         return _back(self.request)
 
@@ -295,20 +287,20 @@ class UserSearchController(SearchController):
     def delete_lozenge(self):
         return _delete_lozenge(self.request)
 
-    @view_config(request_method='POST', request_param='toggle_tag_facet')
+    @view_config(request_param='toggle_tag_facet')
     def toggle_tag_facet(self):
         return _toggle_tag_facet(self.request)
 
 
 def _parsed_query(request):
     """
-    Return the parsed (MultiDict) query from the given POST request.
+    Return the parsed (MultiDict) query from the given request.
 
     Return a copy of the given search page request's search query, parsed from
     a string into a MultiDict.
 
     """
-    return parser.parse(request.POST.get('q', ''))
+    return parser.parse(request.params.get('q', ''))
 
 
 def _username_facets(request, parsed_query=None):
@@ -368,14 +360,9 @@ def _redirect_to_user_or_group_search(request, params):
     return httpexceptions.HTTPSeeOther(location=location)
 
 
-def _more_info(request):
-    """Respond to a click on the ``more_info`` button."""
-    return _redirect_to_user_or_group_search(request, request.POST)
-
-
 def _back(request):
     """Respond to a click on the ``back`` button."""
-    new_params = request.POST.copy()
+    new_params = request.params.copy()
     del new_params['back']
     return _redirect_to_user_or_group_search(request, new_params)
 
@@ -410,9 +397,9 @@ def _toggle_tag_facet(request):
     to the same page but with this facet removed from the search query.
 
     """
-    tag = request.POST['toggle_tag_facet']
+    tag = request.params['toggle_tag_facet']
 
-    new_params = request.POST.copy()
+    new_params = request.params.copy()
 
     del new_params['toggle_tag_facet']
 

--- a/tests/h/views/activity_test.py
+++ b/tests/h/views/activity_test.py
@@ -306,7 +306,7 @@ class TestGroupSearchController(object):
         pyramid_request.authenticated_user = group.members[-1]
 
         faceted_user = group.members[0]
-        pyramid_request.POST = {'q': 'user:%s' % group.members[0].username}
+        pyramid_request.params = {'q': 'user:%s' % group.members[0].username}
 
         result = controller.search()
 
@@ -388,26 +388,6 @@ class TestGroupSearchController(object):
         assert isinstance(result, httpexceptions.HTTPSeeOther)
         assert result.location == 'http://example.com/search?q=foo+bar+gar'
 
-    def test_more_info_redirects_to_group_search(self,
-                                                 controller,
-                                                 group,
-                                                 pyramid_request):
-        """It should redirect and preserve the search query param."""
-        pyramid_request.matched_route = mock.Mock()
-        pyramid_request.matched_route.name = 'group_read'
-        pyramid_request.POST = {'q': 'foo bar', 'more_info': ''}
-
-        result = controller.more_info()
-
-        assert isinstance(result, httpexceptions.HTTPSeeOther)
-        assert result.location.startswith(
-            'http://example.com/groups/{pubid}/{slug}?'.format(
-                pubid=group.pubid, slug=group.slug))
-        # The order of the params vary (because they're in an unordered dict)
-        # but they should both be there.
-        assert 'more_info=' in result.location
-        assert 'q=foo+bar' in result.location
-
     def test_back_redirects_to_group_search(self,
                                             controller,
                                             group,
@@ -415,7 +395,7 @@ class TestGroupSearchController(object):
         """It should redirect and preserve the search query param."""
         pyramid_request.matched_route = mock.Mock()
         pyramid_request.matched_route.name = 'group_read'
-        pyramid_request.POST = {'q': 'foo bar', 'back': ''}
+        pyramid_request.params = {'q': 'foo bar', 'back': ''}
 
         result = controller.back()
 
@@ -444,7 +424,7 @@ class TestGroupSearchController(object):
                                                                    controller,
                                                                    group,
                                                                    toggle_user_facet_request):
-        toggle_user_facet_request.POST['q'] = 'user:"fred"'
+        toggle_user_facet_request.params['q'] = 'user:"fred"'
 
         result = controller.toggle_user_facet()
 
@@ -456,7 +436,7 @@ class TestGroupSearchController(object):
                                                                       controller,
                                                                       group,
                                                                       toggle_user_facet_request):
-        toggle_user_facet_request.POST['q'] = 'foo bar'
+        toggle_user_facet_request.params['q'] = 'foo bar'
 
         result = controller.toggle_user_facet()
 
@@ -468,7 +448,7 @@ class TestGroupSearchController(object):
                                                                         controller,
                                                                         group,
                                                                         toggle_user_facet_request):
-        toggle_user_facet_request.POST['q'] = 'user:"fred" foo bar'
+        toggle_user_facet_request.params['q'] = 'user:"fred" foo bar'
 
         result = controller.toggle_user_facet()
 
@@ -478,7 +458,7 @@ class TestGroupSearchController(object):
 
     def test_toggle_user_facet_preserves_query_when_removing_one_of_multiple_username_facets(
             self, controller, group, toggle_user_facet_request):
-        toggle_user_facet_request.POST['q'] = 'user:"foo" user:"fred" user:"bar"'
+        toggle_user_facet_request.params['q'] = 'user:"foo" user:"fred" user:"bar"'
 
         result = controller.toggle_user_facet()
 
@@ -511,7 +491,7 @@ class TestGroupSearchController(object):
 
     @pytest.fixture
     def toggle_user_facet_request(self, group, pyramid_request):
-        pyramid_request.POST['toggle_user_facet'] = 'acct:fred@hypothes.is'
+        pyramid_request.params['toggle_user_facet'] = 'acct:fred@hypothes.is'
         return pyramid_request
 
 
@@ -637,26 +617,6 @@ class TestUserSearchController(object):
 
         assert result['zero_message'] == '__SHOW_GETTING_STARTED__'
 
-    def test_more_info_redirects_to_user_search(self,
-                                                controller,
-                                                user,
-                                                pyramid_request):
-        """It should redirect and preserve the search query param."""
-        pyramid_request.matched_route = mock.Mock()
-        pyramid_request.matched_route.name = 'activity.user_search'
-        pyramid_request.POST = {'q': 'foo bar', 'more_info': ''}
-
-        result = controller.more_info()
-
-        assert isinstance(result, httpexceptions.HTTPSeeOther)
-        assert result.location.startswith(
-            'http://example.com/users/{username}'.format(
-                username=user.username))
-        # The order of the params vary (because they're in an unordered dict)
-        # but they should both be there.
-        assert 'more_info=' in result.location
-        assert 'q=foo+bar' in result.location
-
     def test_back_redirects_to_user_search(self,
                                            controller,
                                            user,
@@ -664,7 +624,7 @@ class TestUserSearchController(object):
         """It should redirect and preserve the search query param."""
         pyramid_request.matched_route = mock.Mock()
         pyramid_request.matched_route.name = 'activity.user_search'
-        pyramid_request.POST = {'q': 'foo bar', 'back': ''}
+        pyramid_request.params = {'q': 'foo bar', 'back': ''}
 
         result = controller.back()
 
@@ -711,7 +671,7 @@ class TestGroupAndUserSearchController(object):
     def test_delete_lozenge_preserves_the_query_param(self,
                                                       controller,
                                                       delete_lozenge_request):
-        delete_lozenge_request.POST['q'] = 'foo bar'
+        delete_lozenge_request.params['q'] = 'foo bar'
 
         location = controller.delete_lozenge().location
 
@@ -732,7 +692,7 @@ class TestGroupAndUserSearchController(object):
 
     def test_toggle_tag_facet_removes_the_tag_facet_from_the_url(
             self, controller, toggle_tag_facet_request):
-        toggle_tag_facet_request.POST['q'] = 'tag:"gar"'
+        toggle_tag_facet_request.params['q'] = 'tag:"gar"'
 
         result = controller.toggle_tag_facet()
 
@@ -740,7 +700,7 @@ class TestGroupAndUserSearchController(object):
 
     def test_toggle_tag_facet_preserves_query_when_adding_tag_facet(
             self, controller, toggle_tag_facet_request):
-        toggle_tag_facet_request.POST['q'] = 'foo bar'
+        toggle_tag_facet_request.params['q'] = 'foo bar'
 
         result = controller.toggle_tag_facet()
 
@@ -749,7 +709,7 @@ class TestGroupAndUserSearchController(object):
 
     def test_toggle_tag_facet_preserves_query_when_removing_tag_facet(
             self, controller, toggle_tag_facet_request):
-        toggle_tag_facet_request.POST['q'] = 'tag:"gar" foo bar'
+        toggle_tag_facet_request.params['q'] = 'tag:"gar" foo bar'
 
         result = controller.toggle_tag_facet()
 
@@ -757,7 +717,7 @@ class TestGroupAndUserSearchController(object):
 
     def test_toggle_tag_facet_preserves_query_when_removing_one_of_multiple_tag_facets(
             self, controller, toggle_tag_facet_request):
-        toggle_tag_facet_request.POST['q'] = 'tag:"foo" tag:"gar" tag:"bar"'
+        toggle_tag_facet_request.params['q'] = 'tag:"foo" tag:"gar" tag:"bar"'
 
         result = controller.toggle_tag_facet()
 
@@ -793,7 +753,7 @@ class TestGroupAndUserSearchController(object):
         pyramid_request.matched_route = mock.Mock()
         pyramid_request.matched_route.name = 'activity.user_search'
         pyramid_request.feature.flags['search_page'] = True
-        pyramid_request.POST['toggle_tag_facet'] = 'gar'
+        pyramid_request.params['toggle_tag_facet'] = 'gar'
         pyramid_request.matchdict['username'] = 'foo'
         return pyramid_request
 


### PR DESCRIPTION
This will unblock https://github.com/hypothesis/h/pull/4164

Make all the forms and buttons on the search (and group and user search)
pages use GET rather than POST requests.

GET is more semantically correct for submitting a search form (because
the requests are idempotent / they don't change anything on the server). This
is also more consistent as some of the search form fields and buttons
were using GET and some POST - now they're all GET.

The one button on the search page that remains a POST request is the
"Leave group" button on the group search page - this is semantically
correct as a POST.

For most buttons this is simply a change from "GET" to "POST" and the
Python code now needs to look at request.params instead of request.POST.

The one exception is the "More info" button - this button no longer
requires a server-side redirect that it had, so that Python code is
removed.

This does result in one behavior change - when on the more info page, if
you submit the search form (by hitting enter in the search box or by
clicking on a tag or username) when the page reloads you will be back on
the search results page looking at the updated results. This is arguably
an improvement.