### PR TITLE
Raise Elasticsearch timeout for reindex CLI command

### DIFF
--- a/h/cli/commands/search.py
+++ b/h/cli/commands/search.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+import os
+
 import click
 
 from memex.search import config
@@ -21,6 +23,8 @@ def reindex(ctx):
     updates the index alias. This requires that the index is aliased already,
     and will raise an error if it is not.
     """
+
+    os.environ['ELASTICSEARCH_CLIENT_TIMEOUT'] = '30'
 
     request = ctx.obj['bootstrap']()
 

--- a/tests/h/cli/commands/search_test.py
+++ b/tests/h/cli/commands/search_test.py
@@ -1,12 +1,18 @@
 # -*- coding: utf-8 -*-
 
 import mock
+import os
 import pytest
 
 from h.cli.commands import search
 
 
 class TestReindexCommand(object):
+    @pytest.mark.usefixtures('reindex')
+    def test_it_raises_timeout(self, cli, cliconfig):
+        cli.invoke(search.reindex, [], obj=cliconfig)
+        assert os.getenv('ELASTICSEARCH_CLIENT_TIMEOUT') == '30'
+
     def test_calls_reindex(self, cli, cliconfig, pyramid_request, reindex):
         result = cli.invoke(search.reindex, [], obj=cliconfig)
 


### PR DESCRIPTION
Since I'm always the one that forgets to set this env variable, now it
is automatically doing it for me.