### PR TITLE
Add `postgresql` to homebrew requirements

### DIFF
--- a/docs/developing/install/website.rst
+++ b/docs/developing/install/website.rst
@@ -64,6 +64,7 @@ Install the following packages:
         libevent \
         libffi \
         node \
+        postgresql \
         python
 
 


### PR DESCRIPTION
I've just set up the dev environment on my MacBook and ran into this issue when installing the python dependencies. Even though the install docs use PostgreSQL in a Docker container, we still need to install the homebrew package to be able to install the psycopg2 python package.