### PR TITLE
Increase limit of tags in the groups activity pages from 10 to 50.

### DIFF
--- a/h/activity/query.py
+++ b/h/activity/query.py
@@ -142,11 +142,11 @@ def execute(request, query, page_size):
 
 
 def aggregations_for(query):
-    aggregations = [TagsAggregation(limit=10)]
+    aggregations = [TagsAggregation(limit=50)]
 
     # Should we aggregate by user?
     if _single_entry(query, 'group'):
-        aggregations.append(UsersAggregation(limit=10))
+        aggregations.append(UsersAggregation(limit=50))
 
     return aggregations
 

--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -130,7 +130,7 @@
 {% macro tags_section() %}
 <section class="search-result-sidebar__section">
   <h3 class="search-result-sidebar__subtitle">
-    {% trans %}Tags{% endtrans %}
+    {% trans %}Top tags{% endtrans %}
     <span class="search-result-sidebar__subtitle-count">
       {{ aggregations['tags'] | length }}
     </span>

--- a/tests/h/activity/query_test.py
+++ b/tests/h/activity/query_test.py
@@ -216,7 +216,7 @@ class TestExecute(object):
                                                             TagsAggregation):
         execute(pyramid_request, MultiDict(), self.PAGE_SIZE)
 
-        TagsAggregation.assert_called_once_with(limit=10)
+        TagsAggregation.assert_called_once_with(limit=50)
         search.append_aggregation.assert_called_with(
             TagsAggregation.return_value)
 
@@ -236,7 +236,7 @@ class TestExecute(object):
 
         execute(pyramid_request, query, self.PAGE_SIZE)
 
-        UsersAggregation.assert_called_once_with(limit=10)
+        UsersAggregation.assert_called_once_with(limit=50)
         search.append_aggregation.assert_called_with(
             UsersAggregation.return_value)
 


### PR DESCRIPTION
Fixes https://github.com/hypothesis/product-backlog/issues/46