### PR TITLE
Fix minimum annotation card width

### DIFF
--- a/h/static/styles/partials-v2/_search.scss
+++ b/h/static/styles/partials-v2/_search.scss
@@ -201,11 +201,14 @@
   padding-bottom: 5px;
 }
 
+// The container for the contents of a search result bucket.
 .search-result-bucket__content {
   padding-left: 10px;
   padding-right: 10px;
 }
 
+// The contents of a search result bucket which is shown when the bucket is
+// expanded.
 .search-result-bucket__annotation-cards-container {
   padding-left: 130px;
 
@@ -321,7 +324,7 @@ $stats-icon-column-width: 20px;
 }
 
 // As the screen size gets smaller, just before it would have introduced a
-// horizontal scrollbar move the sidebar below the search results.
+// horizontal scrollbar move the user/group sidebar below the search results.
 @media screen and (max-width: $tablet-width + 250px) {
   .search-result-container {
     flex-direction: column;

--- a/h/static/styles/partials-v2/_search.scss
+++ b/h/static/styles/partials-v2/_search.scss
@@ -218,10 +218,15 @@
   }
 }
 
+// Preferred width of annotation cards on large screens.
+$annotation-card-width: 500px;
+
+// The list of annotation cards in a bucket.
 .search-result-bucket__annotation-cards {
+  flex-basis: $annotation-card-width;
   flex-grow: 1;
-  max-width: 500px;
   flex-shrink: 0;
+  max-width: $annotation-card-width;
   padding-left: 0;
   padding-right: 0;
 }
@@ -367,6 +372,10 @@ $stats-icon-column-width: 20px;
 
   .search-result-bucket__annotation-cards {
     width: 100%;
+
+    // Set the preferred height of the annotation card list based on its
+    // contents.
+    flex-basis: auto;
   }
 
   .search-bucket-stats {


### PR DESCRIPTION
**Before:**

![ann-card-short](https://cloud.githubusercontent.com/assets/2458/20935340/37d6554a-bbd6-11e6-9e02-bd72e6f0d933.png)

**After:**

![ann-with-flex-basis](https://cloud.githubusercontent.com/assets/2458/20935348/3fe37ede-bbd6-11e6-858b-2c303022792a.png)

The fix is to use `flex-basis` to set the initial ("preferred") width of an annotation card to 500px on desktop rather than using the size of the card's contents.
