### PR TITLE
Fix search results right margin

### DIFF
--- a/h/static/styles/partials-v2/_base.scss
+++ b/h/static/styles/partials-v2/_base.scss
@@ -56,6 +56,8 @@ $touch-target-size: 44px;
 // ----
 $search-result-container-margin-left: 30px;
 $search-result-container-margin-right: 60px;
+$search-result-container-margin-left-on-small-screens: 10px;
+$search-result-container-margin-right-on-small-screens: 10px;
 
 // Include all mixins, making them available to the stylesheet. N.B. Mixins
 // should *never* output CSS, so this is safe.

--- a/h/static/styles/partials-v2/_base.scss
+++ b/h/static/styles/partials-v2/_base.scss
@@ -54,10 +54,10 @@ $touch-target-size: 44px;
 
 // Misc
 // ----
-$search-result-container-margin-left: 30px;
-$search-result-container-margin-right: 60px;
-$search-result-container-margin-left-on-small-screens: 10px;
-$search-result-container-margin-right-on-small-screens: 10px;
+$content-margin-left: 30px;
+$content-margin-right: 60px;
+$content-margin-left-on-small-screens: 10px;
+$content-margin-right-on-small-screens: 10px;
 
 // Include all mixins, making them available to the stylesheet. N.B. Mixins
 // should *never* output CSS, so this is safe.

--- a/h/static/styles/partials-v2/_base.scss
+++ b/h/static/styles/partials-v2/_base.scss
@@ -52,6 +52,11 @@ $max-phone-width: 500px;
 $tablet-width: 768px;
 $touch-target-size: 44px;
 
+// Misc
+// ----
+$search-result-container-margin-left: 30px;
+$search-result-container-margin-right: 60px;
+
 // Include all mixins, making them available to the stylesheet. N.B. Mixins
 // should *never* output CSS, so this is safe.
 @import 'mixins/all';

--- a/h/static/styles/partials-v2/_nav-bar.scss
+++ b/h/static/styles/partials-v2/_nav-bar.scss
@@ -15,8 +15,8 @@
 .nav-bar__content {
   display: flex;
   flex-direction: row;
-  margin-left: $search-result-container-margin-left;
-  margin-right: $search-result-container-margin-right;
+  margin-left: $content-margin-left;
+  margin-right: $content-margin-right;
 }
 
 .nav-bar__logo-container {
@@ -93,8 +93,8 @@
   // Reduce horizontal margins on smaller screens to provide more space for
   // search bar
   .nav-bar__content {
-    margin-left: $search-result-container-margin-left-on-small-screens;
-    margin-right: $search-result-container-margin-right-on-small-screens;
+    margin-left: $content-margin-left-on-small-screens;
+    margin-right: $content-margin-right-on-small-screens;
   }
 }
 

--- a/h/static/styles/partials-v2/_nav-bar.scss
+++ b/h/static/styles/partials-v2/_nav-bar.scss
@@ -92,12 +92,9 @@
 @media screen and (max-width: $tablet-width) {
   // Reduce horizontal margins on smaller screens to provide more space for
   // search bar
-  .nav-bar__logo {
-    margin-left: 10px;
-  }
-
-  .nav-bar-links {
-    margin-right: 10px;
+  .nav-bar__content {
+    margin-left: $search-result-container-margin-left-on-small-screens;
+    margin-right: $search-result-container-margin-right-on-small-screens;
   }
 }
 

--- a/h/static/styles/partials-v2/_nav-bar.scss
+++ b/h/static/styles/partials-v2/_nav-bar.scss
@@ -15,6 +15,8 @@
 .nav-bar__content {
   display: flex;
   flex-direction: row;
+  margin-left: 30px;
+  margin-right: 60px;
 }
 
 .nav-bar__logo-container {
@@ -23,7 +25,6 @@
 }
 
 .nav-bar__logo {
-  margin-left: 30px;
   margin-right: 30px;
 }
 
@@ -46,7 +47,6 @@
 
 .nav-bar-links {
   margin-left: 10px;
-  margin-right: 60px;
 
   display: flex;
   flex-direction: row;

--- a/h/static/styles/partials-v2/_nav-bar.scss
+++ b/h/static/styles/partials-v2/_nav-bar.scss
@@ -15,8 +15,8 @@
 .nav-bar__content {
   display: flex;
   flex-direction: row;
-  margin-left: 30px;
-  margin-right: 60px;
+  margin-left: $search-result-container-margin-left;
+  margin-right: $search-result-container-margin-right;
 }
 
 .nav-bar__logo-container {

--- a/h/static/styles/partials-v2/_search.scss
+++ b/h/static/styles/partials-v2/_search.scss
@@ -38,8 +38,8 @@
 
   // Align the left edge of the search result list with the left edge of the
   // navbar content.
-  margin-left: 30px;
-  margin-right: 60px;
+  margin-left: $search-result-container-margin-left;
+  margin-right: $search-result-container-margin-right;
 }
 
 .search-result-container--empty {

--- a/h/static/styles/partials-v2/_search.scss
+++ b/h/static/styles/partials-v2/_search.scss
@@ -39,7 +39,7 @@
   // Align the left edge of the search result list with the left edge of the
   // navbar content.
   margin-left: 30px;
-  margin-right: 30px;
+  margin-right: 60px;
 }
 
 .search-result-container--empty {

--- a/h/static/styles/partials-v2/_search.scss
+++ b/h/static/styles/partials-v2/_search.scss
@@ -373,11 +373,13 @@ $stats-icon-column-width: 20px;
     margin-left: 5px;
     margin-top: 10px;
   }
+}
 
+@media screen and (max-width: $tablet-width) {
+  // Align the left and right edges of the search result list with the left and
+  // right edges of the navbar content.
   .search-result-container {
-    // Align the left edge of the search result list with the left edge of the
-    // navbar content.
-    margin-left: 10px;
-    margin-right: 10px;
+    margin-left: $search-result-container-margin-left-on-small-screens;
+    margin-right: $search-result-container-margin-right-on-small-screens;
   }
 }

--- a/h/static/styles/partials-v2/_search.scss
+++ b/h/static/styles/partials-v2/_search.scss
@@ -36,8 +36,8 @@
   margin-top: 40px;
   color: $grey-6;
 
-  // Align the left edge of the search result list with the left edge of the
-  // navbar content.
+  // Align the left and right edges of the search result list with the left and
+  // right edges of the navbar content.
   margin-left: $search-result-container-margin-left;
   margin-right: $search-result-container-margin-right;
 }

--- a/h/static/styles/partials-v2/_search.scss
+++ b/h/static/styles/partials-v2/_search.scss
@@ -38,8 +38,8 @@
 
   // Align the left and right edges of the search result list with the left and
   // right edges of the navbar content.
-  margin-left: $search-result-container-margin-left;
-  margin-right: $search-result-container-margin-right;
+  margin-left: $content-margin-left;
+  margin-right: $content-margin-right;
 }
 
 .search-result-container--empty {
@@ -379,7 +379,7 @@ $stats-icon-column-width: 20px;
   // Align the left and right edges of the search result list with the left and
   // right edges of the navbar content.
   .search-result-container {
-    margin-left: $search-result-container-margin-left-on-small-screens;
-    margin-right: $search-result-container-margin-right-on-small-screens;
+    margin-left: $content-margin-left-on-small-screens;
+    margin-right: $content-margin-right-on-small-screens;
   }
 }


### PR DESCRIPTION
The contents of the nav bar header and of the search results container (which contains the search results and the sidebar) are supposed to be left- and right-aligned with each other but the right margins are actually different, the  nav bar contents are more indented:

![screenshot from 2016-12-07 11-26-30](https://cloud.githubusercontent.com/assets/22498/20966925/9a87a056-bc74-11e6-8e40-bc7e84739aab.png)

This PR aligns those two right margins correctly:

![screenshot from 2016-12-07 12-03-46](https://cloud.githubusercontent.com/assets/22498/20967042/3f0e3e46-bc75-11e6-8e04-85e8f03ccfff.png)
