### PR TITLE
Fix pagination control alignment

### DIFF
--- a/h/static/styles/partials-v2/_pager.scss
+++ b/h/static/styles/partials-v2/_pager.scss
@@ -2,7 +2,12 @@
   display: flex;
   flex-direction: row;
   margin-top: 0;
-  margin-bottom: 40px;
+
+  /* margin-bottom here doesn't seem to work on some mobile devices
+     (e.g. mobile Safari on an iPhone 5S) so use padding-bottom instead. */
+  margin-bottom: 0;
+  padding-bottom: 40px;
+
   margin-left: auto;
   margin-right: auto;
   font-weight: bold;

--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -358,6 +358,10 @@
           </li>
           {% endfor %}
         </ol>
+
+        {% if page.max > 1 %}
+          {% include "h:templates/includes/paginator.html.jinja2" %}
+        {% endif %}
       </div>
     {% else %}
       <div class="search-result-zero {%- if more_info %} search-result-hide-on-small-screens{% endif %}">
@@ -410,8 +414,4 @@
       {{ user_sidebar(user) }}
     {% endif %}
   </div>
-
-  {% if not more_info and page and page.max > 1 %}
-    {% include "h:templates/includes/paginator.html.jinja2" %}
-  {% endif %}
 {% endblock %}


### PR DESCRIPTION
Horizontally align the pagination control with the center of the search
results, rather than with the center of the page contents (which makes
it off-center relative to the search results).

Before:

![screenshot from 2016-12-07 14-17-48](https://cloud.githubusercontent.com/assets/22498/20971059/0213949c-bc88-11e6-98a8-feb06772909f.png)

After:

![screenshot from 2016-12-07 14-18-07](https://cloud.githubusercontent.com/assets/22498/20971065/072dbab6-bc88-11e6-8633-dd8b094ebee0.png)

