### PR TITLE
Center search page content

### DIFF
--- a/h/static/styles/partials-v2/_base.scss
+++ b/h/static/styles/partials-v2/_base.scss
@@ -54,10 +54,10 @@ $touch-target-size: 44px;
 
 // Misc
 // ----
-$content-margin-left: 30px;
-$content-margin-right: 60px;
-$content-margin-left-on-small-screens: 10px;
-$content-margin-right-on-small-screens: 10px;
+$content-padding-left: 30px;
+$content-padding-right: 60px;
+$content-padding-left-on-small-screens: 10px;
+$content-padding-right-on-small-screens: 10px;
 
 // Include all mixins, making them available to the stylesheet. N.B. Mixins
 // should *never* output CSS, so this is safe.

--- a/h/static/styles/partials-v2/_base.scss
+++ b/h/static/styles/partials-v2/_base.scss
@@ -54,6 +54,12 @@ $touch-target-size: 44px;
 
 // Misc
 // ----
+$search-results-max-width: 950px;
+$search-results-margin-right: 30px;
+$search-result-sidebar-width: 285px;
+
+$content-max-width: $search-results-max-width + $search-results-margin-right + $search-result-sidebar-width;
+
 $content-padding-left: 30px;
 $content-padding-right: 60px;
 $content-padding-left-on-small-screens: 10px;

--- a/h/static/styles/partials-v2/_group-invite.scss
+++ b/h/static/styles/partials-v2/_group-invite.scss
@@ -5,7 +5,7 @@
 
 .group-invite__container {
   position: relative;
-  max-width: 285px;
+  max-width: $search-result-sidebar-width;
 }
 
 .group-invite__input {

--- a/h/static/styles/partials-v2/_nav-bar.scss
+++ b/h/static/styles/partials-v2/_nav-bar.scss
@@ -15,8 +15,13 @@
 .nav-bar__content {
   display: flex;
   flex-direction: row;
-  margin-left: $content-margin-left;
-  margin-right: $content-margin-right;
+
+  padding-left: $content-padding-left;
+  padding-right: $content-padding-right;
+
+  max-width: 1265px;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .nav-bar__logo-container {
@@ -93,8 +98,8 @@
   // Reduce horizontal margins on smaller screens to provide more space for
   // search bar
   .nav-bar__content {
-    margin-left: $content-margin-left-on-small-screens;
-    margin-right: $content-margin-right-on-small-screens;
+    padding-left: $content-padding-left-on-small-screens;
+    padding-right: $content-padding-right-on-small-screens;
   }
 }
 

--- a/h/static/styles/partials-v2/_nav-bar.scss
+++ b/h/static/styles/partials-v2/_nav-bar.scss
@@ -19,7 +19,7 @@
   padding-left: $content-padding-left;
   padding-right: $content-padding-right;
 
-  max-width: 1265px;
+  max-width: $content-max-width;
   margin-left: auto;
   margin-right: auto;
 }

--- a/h/static/styles/partials-v2/_search-result-sidebar.scss
+++ b/h/static/styles/partials-v2/_search-result-sidebar.scss
@@ -1,5 +1,5 @@
 .search-result-sidebar {
-  width: 285px;
+  width: $search-result-sidebar-width;
   flex-shrink: 0;
   margin-bottom: 40px;
 }

--- a/h/static/styles/partials-v2/_search.scss
+++ b/h/static/styles/partials-v2/_search.scss
@@ -38,8 +38,12 @@
 
   // Align the left and right edges of the search result list with the left and
   // right edges of the navbar content.
-  margin-left: $content-margin-left;
-  margin-right: $content-margin-right;
+  padding-left: $content-padding-left;
+  padding-right: $content-padding-right;
+
+  max-width: 1265px;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .search-result-container--empty {
@@ -391,7 +395,7 @@ $stats-icon-column-width: 20px;
   // Align the left and right edges of the search result list with the left and
   // right edges of the navbar content.
   .search-result-container {
-    margin-left: $content-margin-left-on-small-screens;
-    margin-right: $content-margin-right-on-small-screens;
+    padding-left: $content-padding-left-on-small-screens;
+    padding-right: $content-padding-right-on-small-screens;
   }
 }

--- a/h/static/styles/partials-v2/_search.scss
+++ b/h/static/styles/partials-v2/_search.scss
@@ -41,7 +41,7 @@
   padding-left: $content-padding-left;
   padding-right: $content-padding-right;
 
-  max-width: 1265px;
+  max-width: $content-max-width;
   margin-left: auto;
   margin-right: auto;
 }
@@ -60,9 +60,9 @@
 // They control the inner layouts for those columns
 .search-results,
 .search-result-zero {
-  flex-basis: 950px;
-  max-width: 950px;
-  margin-right: 30px;
+  flex-basis: $search-results-max-width;
+  max-width: $search-results-max-width;
+  margin-right: $search-results-margin-right;
 }
 
 .search-results__total {


### PR DESCRIPTION
<del>Depends on https://github.com/hypothesis/h/pull/4175</del>

Fixes https://github.com/hypothesis/h/issues/4018

When the window is wider than about 1355px then most of the page contents get pushed all the way along to the left side of the window but the account and groups menus etc get pushed all the way along to the right.

Instead, centre the contents of both the nav bar and the main page, as in the designs.

Before:

![screenshot from 2016-12-07 14-22-27](https://cloud.githubusercontent.com/assets/22498/20971309/e1964560-bc88-11e6-8bb7-c8594c9f430d.png)

After:

![screenshot from 2016-12-07 14-22-48](https://cloud.githubusercontent.com/assets/22498/20971324/ef1a7cd8-bc88-11e6-8ffe-bb428ec6c68e.png)

