### PR TITLE
Check annotation write permission from group's access flags

### DIFF
--- a/h/groups/__init__.py
+++ b/h/groups/__init__.py
@@ -1,5 +1,9 @@
 # -*- coding: utf-8 -*-
 
+from h.groups.auth import annotation_group_write_permitted
+
 
 def includeme(config):
+    config.set_memex_group_write_permitted(annotation_group_write_permitted)
+
     config.register_service_factory('.services.groups_factory', name='groups')

--- a/h/groups/auth.py
+++ b/h/groups/auth.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from h.models import Group
+from h.models.group import WriteableBy
+
+
+def annotation_group_write_permitted(request, groupid):
+    if groupid == '__world__':
+        principal = 'authority:%s' % request.auth_domain
+        return (principal in request.effective_principals)
+
+    group = _fetch_group(request.db, groupid)
+
+    if group is None or group.writeable_by is None:
+        return False
+
+    if group.writeable_by == WriteableBy.authority:
+        principal = 'authority:%s' % group.authority
+        return (principal in request.effective_principals)
+
+    if group.writeable_by == WriteableBy.members:
+        principal = 'group:%s' % groupid
+        return (principal in request.effective_principals)
+
+    return False
+
+
+def _fetch_group(session, groupid):
+    # Ideally this will be moved into the GroupService with a caching layer,
+    # similar to the UserService.fetch
+    return session.query(Group).filter_by(pubid=groupid).one_or_none()

--- a/h/models/group.py
+++ b/h/models/group.py
@@ -85,11 +85,15 @@ class Group(Base, mixins.Timestamps):
         'User', secondary='user_group', backref=sa.orm.backref(
             'groups', order_by='Group.name'))
 
-    def __init__(self, name, authority, creator, description=None):
+    def __init__(self, name, authority, creator, description=None,
+                 joinable_by=None, readable_by=None, writeable_by=None):
         self.name = name
         self.authority = authority
         self.description = description
         self.creator = creator
+        self.joinable_by = joinable_by
+        self.readable_by = readable_by
+        self.writeable_by = writeable_by
         self.members.append(creator)
 
     @sa.orm.validates('name')

--- a/src/memex/__init__.py
+++ b/src/memex/__init__.py
@@ -5,6 +5,7 @@ __version__ = '0.39.0+dev'
 
 
 def includeme(config):
+    config.include('memex.auth')
     config.include('memex.eventqueue')
     config.include('memex.links')
     config.include('memex.presenters')

--- a/src/memex/auth.py
+++ b/src/memex/auth.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+"""
+Annotation authorization.
+
+This module provides default-permissive group authorization methods that can
+be overriden by the application.
+"""
+
+GROUP_WRITE_PERMITTED_KEY = 'memex.auth.group_write_permitted'
+
+
+def group_write_permitted(request, groupid):
+    """
+    Returns if the current request is allowed to write to the specified group.
+
+    :param request: the request
+    :type request: pyramid.request.Request
+
+    :param groupid: the groupid
+    :type groupid: unicode
+
+    :returns: a boolean for allowing or disallowing the write
+    :rtype: bool
+    """
+    return True
+
+
+def includeme(config):
+    def set_write_permitted(config, func):
+        config.registry[GROUP_WRITE_PERMITTED_KEY] = func
+    config.add_directive('set_memex_group_write_permitted', set_write_permitted)

--- a/tests/common/factories.py
+++ b/tests/common/factories.py
@@ -12,6 +12,7 @@ import factory
 import faker
 
 from h import models
+from h.models.group import JoinableBy, ReadableBy, WriteableBy
 
 from ..memex import factories as memex_factories
 
@@ -105,6 +106,9 @@ class Group(ModelFactory):
     name = factory.Sequence(lambda n:'Test Group {n}'.format(n=str(n)))
     authority = 'example.com'
     creator = factory.SubFactory(User)
+    joinable_by = JoinableBy.authority
+    readable_by = ReadableBy.members
+    writeable_by = WriteableBy.members
 
 
 class AuthTicket(ModelFactory):

--- a/tests/h/groups/auth_test.py
+++ b/tests/h/groups/auth_test.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from h.groups.auth import annotation_group_write_permitted
+from h.models.group import WriteableBy
+
+
+class TestAnnotationGroupWritePermitted(object):
+    def test_allows_for_world_group_with_correct_authority(self, pyramid_config, pyramid_request):
+        pyramid_request.auth_domain = 'example.com'
+        pyramid_config.testing_securitypolicy('acct:testuser@example.com',
+                                              groupids=['authority:example.com'])
+
+        assert annotation_group_write_permitted(pyramid_request, '__world__') \
+            is True
+
+    def test_disallows_for_world_group_with_wrong_authority(self, pyramid_config, pyramid_request):
+        pyramid_request.auth_domain = 'foobar.com'
+        pyramid_config.testing_securitypolicy('acct:testuser@example.com',
+                                              groupids=['authority:example.com'])
+
+        assert annotation_group_write_permitted(pyramid_request, '__world__') \
+            is False
+
+    def test_disallows_when_group_missing(self, pyramid_request):
+        assert annotation_group_write_permitted(pyramid_request, 'bogus') \
+            is False
+
+    def test_disallows_when_group_non_writeable(self, pyramid_request, factories):
+        group = factories.Group(writeable_by=None)
+
+        assert annotation_group_write_permitted(pyramid_request, group.pubid) \
+            is False
+
+    def test_allows_for_authority_when_match(self, pyramid_config, pyramid_request, factories):
+        group = factories.Group(writeable_by=WriteableBy.authority)
+        pyramid_config.testing_securitypolicy('acct:testuser@example.com',
+                                              groupids=['authority:%s' % group.authority])
+
+        assert annotation_group_write_permitted(pyramid_request, group.pubid) \
+            is True
+
+    def test_disallows_for_authority_when_mismatch(self, pyramid_config, pyramid_request, factories):
+        group = factories.Group(writeable_by=WriteableBy.authority)
+        pyramid_config.testing_securitypolicy('acct:testuser@example.com',
+                                              groupids=['authority:foobar.net'])
+
+        assert annotation_group_write_permitted(pyramid_request, group.pubid) \
+            is False
+
+    def test_allows_for_group_member(self, pyramid_config, pyramid_request, factories):
+        group = factories.Group(writeable_by=WriteableBy.members)
+        pyramid_config.testing_securitypolicy('acct:testuser@example.com',
+                                              groupids=['group:%s' % group.pubid])
+
+        assert annotation_group_write_permitted(pyramid_request, group.pubid) \
+            is True
+
+    def test_disallows_for_non_group_members(self, pyramid_config, pyramid_request, factories):
+        group = factories.Group(writeable_by=WriteableBy.members)
+        pyramid_config.testing_securitypolicy('acct:testuser@example.com',
+                                              groupids=['group:foobar'])
+
+        assert annotation_group_write_permitted(pyramid_request, group.pubid) \
+            is False

--- a/tests/h/models/groups_test.py
+++ b/tests/h/models/groups_test.py
@@ -5,6 +5,7 @@ from pyramid import security
 
 import memex
 from h import models
+from h.models.group import JoinableBy, ReadableBy, WriteableBy
 
 
 def test_init(db_session, factories):
@@ -13,7 +14,13 @@ def test_init(db_session, factories):
     description = "This group is awesome"
     user = factories.User()
 
-    group = models.Group(name=name, authority=authority, creator=user, description=description)
+    group = models.Group(name=name,
+                         authority=authority,
+                         creator=user,
+                         description=description,
+                         joinable_by=JoinableBy.authority,
+                         readable_by=ReadableBy.members,
+                         writeable_by=WriteableBy.members)
     db_session.add(group)
     db_session.flush()
 
@@ -25,6 +32,9 @@ def test_init(db_session, factories):
     assert group.updated
     assert group.creator == user
     assert group.creator_id == user.id
+    assert group.joinable_by == JoinableBy.authority
+    assert group.readable_by == ReadableBy.members
+    assert group.writeable_by == WriteableBy.members
     assert group.members == [user]
 
 

--- a/tests/memex/auth_test.py
+++ b/tests/memex/auth_test.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import pytest
+
+from memex import auth
+
+
+@pytest.mark.parametrize('groupid', [
+    '__world__',
+    'foobar',
+    '',
+    None,
+])
+def test_group_write_permitted_returns_true(pyramid_request, groupid):
+    assert auth.group_write_permitted(pyramid_request, groupid) is True


### PR DESCRIPTION
This is changing the way we check if the current user is allowed to create an annotation in the given group. The old code just checked if the user is a member (if `group:{pubid}` is in `request.effective_principals`). Now that we have group access flags we need to change this behaviour. At the same time the separation between the knowledge of groups in h and memex was always a bit undefined. Memex at least knew about the `group` string and had some knowledge about authorization. This should now change as well by introducing a new configuration function that will get the current request and a groupid, and this function can be implemented by h and passed into memex. The default implementation of that function is permissive, that way we can easily allow applications to use memex without having to support the concept of groups.

See the individual commit messages for more information.