### PR TITLE
Skip rendering annotation text when None

### DIFF
--- a/h/templates/includes/annotation_card.html.jinja2
+++ b/h/templates/includes/annotation_card.html.jinja2
@@ -50,7 +50,9 @@
     </section>
   {% endif %}
   <section class="annotation-card__text">
-    {{ presented_annotation.annotation.text_rendered|safe }}
+    {% if presented_annotation.annotation.text_rendered %}
+      {{ presented_annotation.annotation.text_rendered|safe }}
+    {% endif %}
   </section>
   <section class="annotation-card__tags">
     {% for tag in presented_annotation.annotation.tags%}


### PR DESCRIPTION
Jinja seems to be rendering the string "None" instead of rendering
nothing.

Fixes #4183.