### PR TITLE
Send authenticated user ID in error reports from client

### DIFF
--- a/h/static/scripts/base/raven.js
+++ b/h/static/scripts/base/raven.js
@@ -16,15 +16,12 @@ function init(config) {
   Raven.config(config.dsn, {
     release: config.release,
   }).install();
-  installUnhandledPromiseErrorHandler();
-}
 
-function setUserInfo(info) {
-  if (info) {
-    Raven.setUserContext(info);
-  } else {
-    Raven.setUserContext();
+  if (config.userid) {
+    Raven.setUserContext({id: config.userid});
   }
+
+  installUnhandledPromiseErrorHandler();
 }
 
 /**
@@ -79,6 +76,5 @@ function installUnhandledPromiseErrorHandler() {
 
 module.exports = {
   init: init,
-  setUserInfo: setUserInfo,
   report: report,
 };

--- a/h/static/scripts/site.js
+++ b/h/static/scripts/site.js
@@ -5,7 +5,6 @@ const settings = require('./base/settings')(document);
 if (settings.raven) {
   const raven = require('./base/raven');
   raven.init(settings.raven);
-  raven.setUserInfo({userid: settings.raven.userid});
 }
 
 require('./polyfills');

--- a/h/static/scripts/site.js
+++ b/h/static/scripts/site.js
@@ -3,7 +3,9 @@
 // Configure error reporting
 const settings = require('./base/settings')(document);
 if (settings.raven) {
-  require('./base/raven').init(settings.raven);
+  const raven = require('./base/raven');
+  raven.init(settings.raven);
+  raven.setUserInfo({userid: settings.raven.userid});
 }
 
 require('./polyfills');

--- a/h/static/scripts/tests/base/raven-test.js
+++ b/h/static/scripts/tests/base/raven-test.js
@@ -14,6 +14,7 @@ describe('raven', () => {
       }),
 
       captureException: sinon.stub(),
+      setUserContext: sinon.stub(),
     };
 
     raven = proxyquire('../../base/raven', noCallThru({
@@ -21,7 +22,38 @@ describe('raven', () => {
     }));
   });
 
-  describe('.install()', () => {
+  describe('.init()', () => {
+    it('configures the Sentry client', () => {
+      raven.init({
+        dsn: 'dsn',
+        release: 'release',
+        userid: 'acct:foobar@hypothes.is',
+      });
+      assert.calledWith(fakeRavenJS.config, 'dsn', sinon.match({
+        release: 'release',
+      }));
+    });
+
+    it('sets the user context when a userid is specified', () => {
+      raven.init({
+        dsn: 'dsn',
+        release: 'release',
+        userid: 'acct:foobar@hypothes.is',
+      });
+      assert.calledWith(fakeRavenJS.setUserContext, sinon.match({
+        id: 'acct:foobar@hypothes.is',
+      }));
+    });
+
+    it('does not set the user context when a userid is not specified', () => {
+      raven.init({
+        dsn: 'dsn',
+        release: 'release',
+        userid: null,
+      });
+      assert.notCalled(fakeRavenJS.setUserContext);
+    });
+
     it('installs a handler for uncaught promises', () => {
       raven.init({
         dsn: 'dsn',

--- a/h/templates/layouts/base.html.jinja2
+++ b/h/templates/layouts/base.html.jinja2
@@ -66,7 +66,8 @@
         {
           "raven": {
             "dsn": "{{ request.sentry.get_public_dsn('https') }}",
-            "release": "{{ h_version }}"
+            "release": "{{ h_version }}",
+            "userid": {{ request.authenticated_userid | to_json }}
           }
         }
       </script>


### PR DESCRIPTION
Provide the authenticated user ID in reports to Sentry from client code.

This allows us to associate JavaScript errors with the user who experienced them. In Sentry reports, this will show up like this:

![sentry-logged-in-user](https://cloud.githubusercontent.com/assets/2458/20978606/5ffa82c8-bca1-11e6-9171-2df25599b1c1.png)

For logged-out users, the value appears as "None".
