### PR TITLE
Fix inline form submission in IE

### DIFF
--- a/h/static/scripts/tests/util/submit-form-test.js
+++ b/h/static/scripts/tests/util/submit-form-test.js
@@ -7,8 +7,8 @@ const submitForm = require('../../util/submit-form');
 describe('submitForm', () => {
   const FORM_URL = 'http://example.org/things';
 
-  function mockResponse(response) {
-    fetchMock.post(FORM_URL, response);
+  function mockResponse(response, url = FORM_URL) {
+    fetchMock.post(url, response);
   }
 
   function createForm() {
@@ -25,6 +25,17 @@ describe('submitForm', () => {
 
     return submitForm(form, fetchMock.fetchMock).then(() => {
       const [,requestInit] = fetchMock.lastCall(FORM_URL);
+      assert.instanceOf(requestInit.body, FormData);
+    });
+  });
+
+  it('submits the form data to the current URL if the action attr is empty', () => {
+    const form = createForm();
+    form.setAttribute('action', '');
+    mockResponse('<form><!-- updated form !--></form>', document.location.href);
+
+    return submitForm(form, fetchMock.fetchMock).then(() => {
+      const [,requestInit] = fetchMock.lastCall(document.location.href);
       assert.instanceOf(requestInit.body, FormData);
     });
   });

--- a/h/static/scripts/tests/util/submit-form-test.js
+++ b/h/static/scripts/tests/util/submit-form-test.js
@@ -3,6 +3,7 @@
 const fetchMock = require('fetch-mock');
 
 const submitForm = require('../../util/submit-form');
+const { unroll } = require('../util');
 
 describe('submitForm', () => {
   const FORM_URL = 'http://example.org/things';
@@ -19,26 +20,35 @@ describe('submitForm', () => {
     return form;
   }
 
-  it('submits the form data', () => {
-    const form = createForm();
-    mockResponse('<form><!-- updated form !--></form>');
+  unroll('submits the form data', (testCase) => {
+    const form = document.createElement('form');
+    form.method = 'POST';
+    form.innerHTML = '<input name="field" value="value">';
+
+    if (typeof testCase.action === 'string') {
+      form.setAttribute('action', testCase.action);
+    }
+    mockResponse('<form><!-- updated form !--></form>', testCase.expectedSubmitUrl);
 
     return submitForm(form, fetchMock.fetchMock).then(() => {
-      const [,requestInit] = fetchMock.lastCall(FORM_URL);
+      const [,requestInit] = fetchMock.lastCall(testCase.expectedSubmitUrl);
       assert.instanceOf(requestInit.body, FormData);
     });
-  });
-
-  it('submits the form data to the current URL if the action attr is empty', () => {
-    const form = createForm();
-    form.setAttribute('action', '');
-    mockResponse('<form><!-- updated form !--></form>', document.location.href);
-
-    return submitForm(form, fetchMock.fetchMock).then(() => {
-      const [,requestInit] = fetchMock.lastCall(document.location.href);
-      assert.instanceOf(requestInit.body, FormData);
-    });
-  });
+  }, [{
+    action: FORM_URL,
+    expectedSubmitUrl: FORM_URL,
+  },{
+    // Setting "action" to an empty string is technically disallowed according
+    // to https://w3c.github.io/html/sec-forms.html#element-attrdef-form-action
+    // but in practice browsers treat it mostly the same way as a missing
+    // "action" attr.
+    action: '',
+    expectedSubmitUrl: document.location.href,
+  },{
+    // Omit "action" attr.
+    action: null,
+    expectedSubmitUrl: document.location.href,
+  }]);
 
   it('returns the markup for the updated form if validation succeeds', () => {
     const form = createForm();

--- a/h/static/scripts/util/submit-form.js
+++ b/h/static/scripts/util/submit-form.js
@@ -30,7 +30,7 @@ class FormSubmitError extends Error {
  * @param {HTMLFormElement} form
  */
 function formUrl(form) {
-  if (form.getAttribute('action').length > 0) {
+  if (form.getAttribute('action')) {
     return form.action;
   } else {
     // `form.action` returns an absolute URL created by resolving the URL

--- a/h/static/scripts/util/submit-form.js
+++ b/h/static/scripts/util/submit-form.js
@@ -25,6 +25,24 @@ class FormSubmitError extends Error {
 }
 
 /**
+ * Return the URL which a form should be submitted to.
+ *
+ * @param {HTMLFormElement} form
+ */
+function formUrl(form) {
+  if (form.getAttribute('action').length > 0) {
+    return form.action;
+  } else {
+    // `form.action` returns an absolute URL created by resolving the URL
+    // in the "action" attribute against the document's location.
+    //
+    // Browsers except IE implement a special case where the document's URL
+    // is returned if the "action" attribute is missing or an empty string.
+    return document.location.href;
+  }
+}
+
+/**
  * @typedef {Object} SubmitResult
  * @property {number} status - Always 200
  * @property {string} form - The HTML markup for the re-rendered form
@@ -42,7 +60,7 @@ class FormSubmitError extends Error {
  */
 function submitForm(formEl, fetch = window.fetch) {
   let response;
-  return fetch(formEl.action, {
+  return fetch(formUrl(formEl), {
     body: new FormData(formEl),
     credentials: 'same-origin',
     method: 'POST',

--- a/h/templates/deform/form.jinja2
+++ b/h/templates/deform/form.jinja2
@@ -6,7 +6,9 @@
 {% set form_message_class = 'form-actions-message' %}
 {% endif %}
 <form id="{{ field.formid }}"
+      {%- if field.action %}
       action="{{ field.action }}"
+      {%- endif %}
       method="{{ field.method }}"
       enctype="multipart/form-data"
       accept-charset="utf-8"


### PR DESCRIPTION
For `<form>` elements that have an empty "action" attribute, IE submits
the form to the correct location when using normal submission but
returns the wrong URL when reading the form's `action` property. This
URL was used when submitting the form via fetch().

One way to fix this would be to always specify an absolute URL for the
form in the deform template. I've opted to add a workaround in JS to
avoid the code breaking if it is ever used with forms not rendered by
deform.