### PR TITLE
Fix search bar in Internet Explorer and Edge

### DIFF
--- a/h/static/scripts/polyfills.js
+++ b/h/static/scripts/polyfills.js
@@ -16,6 +16,15 @@ require('unorm');
 // Element.prototype.dataset, required by IE 10
 require('element-dataset')();
 
+// Element.prototype.remove. Required by IE 10/11
+if (!Element.prototype.remove) {
+  Element.prototype.remove = function () {
+    if (this.parentNode) {
+      this.parentNode.removeChild(this);
+    }
+  };
+}
+
 // URL constructor, required by IE 10/11,
 // early versions of Microsoft Edge.
 try {

--- a/h/static/scripts/tests/util/dom-test.js
+++ b/h/static/scripts/tests/util/dom-test.js
@@ -57,8 +57,18 @@ describe('util/dom', () => {
   });
 
   describe('cloneTemplate', () => {
-    it('returns a clone of the first child Element of the template', () => {
-      const template = createDOM('<template id="test-template"><div id="child"></div></template>');
+    it('clones the first child of the template when <template> is supported', () => {
+      const frag = document.createDocumentFragment();
+      frag.appendChild(createDOM('<div id="child"></div>'));
+      frag.appendChild(createDOM('<div id="child-b"></div>'));
+      const template = document.createElement('template');
+      template.content = frag;
+      const clone = domUtil.cloneTemplate(template);
+      assert.deepEqual(clone.outerHTML, '<div id="child"></div>');
+    });
+
+    it('clones the first child of the template when <template> is not supported', () => {
+      const template = createDOM('<fake-template><div id="child"></div></fake-template>');
       const clone = domUtil.cloneTemplate(template);
       assert.deepEqual(clone.outerHTML, '<div id="child"></div>');
     });

--- a/h/static/scripts/util/dom.js
+++ b/h/static/scripts/util/dom.js
@@ -52,6 +52,23 @@ function findRefs(el) {
 }
 
 /**
+ * Return the first child of `node` which is an `Element`.
+ *
+ * Work around certain browsers (IE, Edge) not supporting firstElementChild on
+ * Document, DocumentFragment.
+ *
+ * @param {Node} node
+ */
+function firstElementChild(node) {
+  for (let i=0; i < node.childNodes.length; i++) {
+    if (node.childNodes[i].nodeType === Node.ELEMENT_NODE) {
+      return node.childNodes[i];
+    }
+  }
+  return null;
+}
+
+/**
  * Clone the content of a <template> element and return the first child Element.
  *
  * @param {HTMLTemplateElement} templateEl
@@ -60,7 +77,7 @@ function cloneTemplate(templateEl) {
   if (templateEl.content) {
     // <template> supported natively.
     const content = templateEl.content.cloneNode(true);
-    return content.firstElementChild;
+    return firstElementChild(content);
   } else {
     // <template> not supported. Browser just treats it as an unknown Element.
     return templateEl.firstElementChild.cloneNode(true);


### PR DESCRIPTION
This fixes input in the search bar in Internet Explorer and Edge.

1. Internet Explorer needed a polyfill for `Element.prototype.remove` - triggered when you click on the delete button on a lozenge.

2. Microsoft Edge supports `<template>` elements (used to render a template for the lozenge on the server) but only supports `firstElementChild` on `Element` objects, not `DocumentFragment` objects as returned by `template.content`.

Fixes https://github.com/hypothesis/product-backlog/issues/75