### PR TITLE
Fix input autofocus in Safari / Mac

### DIFF
--- a/h/static/scripts/controllers/input-autofocus-controller.js
+++ b/h/static/scripts/controllers/input-autofocus-controller.js
@@ -3,7 +3,8 @@
 const Controller = require('../base/controller');
 
 function isWordChar(event) {
-  return event.key.match(/^\w$/) && !event.ctrlKey && !event.altKey;
+  return event.key.match(/^\w$/) && !event.ctrlKey && !event.altKey &&
+                                    !event.metaKey;
 }
 
 /**

--- a/h/static/scripts/polyfills.js
+++ b/h/static/scripts/polyfills.js
@@ -26,7 +26,7 @@ try {
 
 // KeyboardEvent.prototype.key
 // (Native in Chrome >= 51, Firefox >= 23, IE >= 9)
-require('keyboardevent-key-polyfill');
+require('keyboardevent-key-polyfill').polyfill();
 
 // Fetch API
 // https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API

--- a/h/static/scripts/tests/controllers/input-autofocus-controller-test.js
+++ b/h/static/scripts/tests/controllers/input-autofocus-controller-test.js
@@ -65,6 +65,7 @@ describe('InputAutofocusController', () => {
     it('should not focus the input if a letter key is pressed with a modifier', () => {
       sendKey('a', {ctrlKey: true});
       sendKey('b', {altKey: true});
+      sendKey('c', {metaKey: true});
       assert.notEqual(document.activeElement, ctrl.element);
     });
   });


### PR DESCRIPTION
* Fix https://github.com/hypothesis/h/issues/4187 by installing the `KeyboardEvent.key` polyfill correctly.
* Fix https://github.com/hypothesis/h/issues/4181 by ignoring keypresses with the Command modifier key held (`KeyboardEvent.metaKey` on Mac) when deciding whether to autofocus the search input. The ctrl and alt modifier keys are already ignored.


