### PR TITLE
Use ActivityResults container object in templates

### DIFF
--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -132,11 +132,11 @@
   <h3 class="search-result-sidebar__subtitle">
     {% trans %}Top tags{% endtrans %}
     <span class="search-result-sidebar__subtitle-count">
-      {{ aggregations['tags'] | length }}
+      {{ search_results.aggregations['tags'] | length }}
     </span>
   </h3>
   <div class="search-result-sidebar-tags">
-    {% for tag in aggregations.tags %}
+    {% for tag in search_results.aggregations.tags %}
       <button type="submit"
               form="search-bar"
               name="toggle_tag_facet"
@@ -324,30 +324,30 @@
   {{ panel('navbar', opts or {}) }}
 
   <script type="application/json" class="js-tag-suggestions">
-    {{aggregations['tags'] | to_json}}
+    {{search_results.aggregations['tags'] | to_json}}
   </script>
 
   <script type="application/json" class="js-group-suggestions">
     {{groups_suggestions | to_json}}
   </script>
 
-  <div class="search-result-container {%- if not timeframes %} search-result-container--empty{% endif %}">
+  <div class="search-result-container {%- if not search_results.timeframes %} search-result-container--empty{% endif %}">
     {% if group %}
       {{ search_result_nav(group.name) }}
     {% elif user %}
       {{ search_result_nav(user.name) }}
     {% endif %}
 
-    {% if timeframes %}
+    {% if search_results.timeframes %}
 
       <div class="search-results {%- if more_info %} search-result-hide-on-small-screens{% endif %}">
 
         {% if q or user or group %}
-        <div class="search-results__total"><b>{% trans %}Annotations{% endtrans %}</b> {{total}}</div>
+        <div class="search-results__total"><b>{% trans %}Annotations{% endtrans %}</b> {{search_results.total}}</div>
         {% endif %}
 
         <ol class="search-results__list">
-          {% for timeframe in timeframes %}
+          {% for timeframe in search_results.timeframes %}
           <li class="search-result__timeframe">
             {{ timeframe.label }}
           </li>
@@ -409,7 +409,7 @@
     {% endif %}
 
     {% if group %}
-      {{ group_sidebar(group, group_edit_url, total) }}
+      {{ group_sidebar(group, group_edit_url, search_results.total) }}
     {% elif user %}
       {{ user_sidebar(user) }}
     {% endif %}

--- a/h/views/activity.py
+++ b/h/views/activity.py
@@ -50,7 +50,7 @@ class SearchController(object):
             page_size = PAGE_SIZE
 
         # Fetch results.
-        result = query.execute(self.request, q, page_size=page_size)
+        results = query.execute(self.request, q, page_size=page_size)
 
         groups_suggestions = []
 
@@ -75,14 +75,12 @@ class SearchController(object):
                                           username=username)
 
         return {
-            'aggregations': result.aggregations,
+            'search_results': results,
             'groups_suggestions': groups_suggestions,
-            'page': paginate(self.request, result.total, page_size=page_size),
+            'page': paginate(self.request, results.total, page_size=page_size),
             'pretty_link': pretty_link,
             'q': self.request.params.get('q', ''),
             'tag_link': tag_link,
-            'timeframes': result.timeframes,
-            'total': result.total,
             'user_link': user_link,
             'username_from_id': username_from_id,
             # The message that is shown (only) if there's no search results.
@@ -121,7 +119,7 @@ class GroupSearchController(SearchController):
             return 0
 
         q = query.extract(self.request)
-        users_aggregation = result.get('aggregations', {}).get('users', [])
+        users_aggregation = result['search_results'].aggregations.get('users', [])
         members = [{'username': u.username,
                     'userid': u.userid,
                     'count': user_annotation_count(users_aggregation,
@@ -255,7 +253,7 @@ class UserSearchController(SearchController):
 
         result['user'] = {
             'name': self.user.display_name or self.user.username,
-            'num_annotations': result['total'],
+            'num_annotations': result['search_results'].total,
             'description': self.user.description,
             'registered_date': self.user.registered_date.strftime('%B, %Y'),
             'location': self.user.location,


### PR DESCRIPTION
This is a small refactoring which changes how the search results are passed into templates. This will make it easier to extract the rendering of the search results into independent partial templates or panels.