### PR TITLE
Make JSON data payloads embedded in search results page HTML-safe

### DIFF
--- a/h/jinja_extensions.py
+++ b/h/jinja_extensions.py
@@ -38,8 +38,25 @@ def human_timestamp(timestamp, now=datetime.datetime.utcnow):
 
 
 def to_json(value):
-    """Convert a dict into a JSON string"""
-    return Markup(json.dumps(value))
+    """
+    Serialize a value as an HTML-safe JSON string.
+
+    The resulting value can be safely used inside a <script> tag in an HTML
+    document.
+
+    See http://benalpert.com/2012/08/03/preventing-xss-json.html for an
+    explanation of why JSON needs to be escaped when embedding it in an HTML
+    context.
+    """
+
+    # Adapted from Flask's htmlsafe_dumps() function / tojson filter.
+    result = json.dumps(value) \
+                 .replace(u'<', u'\\u003c') \
+                 .replace(u'>', u'\\u003e') \
+                 .replace(u'&', u'\\u0026') \
+                 .replace(u"'", u'\\u0027')
+
+    return Markup(result)
 
 
 class SvgIcon(Extension):

--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -323,11 +323,11 @@
 
   {{ panel('navbar', opts or {}) }}
 
-  <script class="js-tag-suggestions">
+  <script type="application/json" class="js-tag-suggestions">
     {{aggregations['tags'] | to_json}}
   </script>
 
-  <script class="js-group-suggestions">
+  <script type="application/json" class="js-group-suggestions">
     {{groups_suggestions | to_json}}
   </script>
 

--- a/tests/h/jinja_extension_test.py
+++ b/tests/h/jinja_extension_test.py
@@ -8,7 +8,14 @@ import pytest
 from h import jinja_extensions as ext
 
 @pytest.mark.parametrize("value_in,json_out", [
-    ({"foo": 42}, "{\"foo\": 42}")
+    ({"foo": 42}, "{\"foo\": 42}"),
+
+    # to_json should escape HTML tags so that the result can be safely included
+    # in HTML, eg. for encoding data payloads that are used by JavaScript code
+    # on the page.
+    ('<html-tag>&\'', '"\\u003chtml-tag\\u003e\\u0026\\u0027"'),
+    ('</script><script>alert("foo")</script>',
+     '"\\u003c/script\\u003e\\u003cscript\\u003ealert(\\"foo\\")\\u003c/script\\u003e"'),
 ])
 def test_to_json(value_in, json_out):
     result = str(ext.to_json(value_in))


### PR DESCRIPTION
Escape '<', '>' and '&' when serializing values to JSON that is embedded in HTML.

Fixes hypothesis/product-backlog#82
