### PR TITLE
Remove a couple of unneeded uses of the Jinja2 "safe" filter

### DIFF
--- a/h/presenters.py
+++ b/h/presenters.py
@@ -75,9 +75,16 @@ class AnnotationHTMLPresenter(object):
 
     @property
     def text_rendered(self):
-        """The body text of this annotation."""
+        """
+        The body text of this annotation.
 
-        return self.annotation.text_rendered
+        This return value of this field is marked safe because it is rendered
+        to HTML on write by :py:func:`memex.markdown.render`, which must take
+        care of all necessary escaping.
+        """
+        if self.annotation.text_rendered:
+            return jinja2.Markup(self.annotation.text_rendered)
+        return jinja2.Markup('')
 
     @property
     def quote(self):

--- a/h/templates/includes/annotation_card.html.jinja2
+++ b/h/templates/includes/annotation_card.html.jinja2
@@ -46,13 +46,11 @@
   </header>
   {% if presented_annotation.annotation.quote %}
     <section class="annotation-card__quote">
-      {{ presented_annotation.annotation.quote|safe }}
+      {{ presented_annotation.annotation.quote }}
     </section>
   {% endif %}
   <section class="annotation-card__text">
-    {% if presented_annotation.annotation.text_rendered %}
-      {{ presented_annotation.annotation.text_rendered|safe }}
-    {% endif %}
+    {{ presented_annotation.annotation.text_rendered }}
   </section>
   <section class="annotation-card__tags">
     {% for tag in presented_annotation.annotation.tags%}

--- a/src/memex/models/annotation.py
+++ b/src/memex/models/annotation.py
@@ -127,6 +127,11 @@ class Annotation(Base):
     @text.setter
     def text(self, value):
         self._text = value
+        # N.B. We MUST take care here of appropriately escaping the user
+        # input. Code elsewhere will assume that the content of the
+        # `text_rendered` field is safe for printing without further escaping.
+        #
+        # `markdown.render` does the hard work for now.
         self._text_rendered = markdown.render(value)
 
     @hybrid_property

--- a/tests/h/presenters_test.py
+++ b/tests/h/presenters_test.py
@@ -65,12 +65,17 @@ class TestAnnotationHTMLPresenter(object):
 
         assert annotation.tags == annotation.annotation.tags
 
-    def test_text_rendered(self):
+    @pytest.mark.parametrize('value,expected', [
+        (None, jinja2.Markup('')),
+        ('', jinja2.Markup('')),
+        ('donkeys with umbrellas', jinja2.Markup('donkeys with umbrellas')),
+    ])
+    def test_text_rendered(self, value, expected):
         annotation = self._annotation(
-            annotation=mock.Mock()
+            annotation=mock.Mock(text_rendered=value)
         )
 
-        assert annotation.text_rendered == annotation.annotation.text_rendered
+        assert annotation.text_rendered == expected
 
     def test_description(self):
         annotation = self._annotation(


### PR DESCRIPTION
This is a scary filter to see in a template. In general, values should be clearly marked as safe by the code that handles them *before* they get to the templates.

This commit removes the use of the "safe" Jinja2 filter from a couple of places, and adds some comments explaining when and where user input gets escaped.