### PR TITLE
Fix vertical stretch of logo SVG in IE

### DIFF
--- a/h/static/styles/partials-v2/_nav-bar.scss
+++ b/h/static/styles/partials-v2/_nav-bar.scss
@@ -26,6 +26,7 @@
 
 .nav-bar__logo-container {
   display: flex;
+  align-items: center;
   justify-content: center;
 }
 


### PR DESCRIPTION
In IE the SVG image of the h logo was being vertically stretched to be
as tall as its containing element. Add an align-items CSS rule to
explicitly tell it not to do this.

Fixes https://github.com/hypothesis/h/issues/4074