### PR TITLE
Remove unwanted search bar margins on mobile

### DIFF
--- a/h/static/styles/partials-v2/_nav-bar.scss
+++ b/h/static/styles/partials-v2/_nav-bar.scss
@@ -116,7 +116,8 @@
   .nav-bar__search {
     order: 3; // swaping into links original position
     width:100%;
-    margin: 10px;
+    margin-top: 10px;
+    margin-bottom: 10px;
   }
 
   .nav-bar-links {


### PR DESCRIPTION
On mobile devices the search bar has 10px left and right margins which
means that it has 10px more whitespace to the left and right of it than
any of the other elements on the screen, creating a ragged look.

Remove these margins so that the search bar's left and right borders are
left and right aligned with the rest of the elements on the screen.

Before:

![before](https://cloud.githubusercontent.com/assets/22498/21050617/98b4cc5e-be13-11e6-833b-8718bae51be2.png)

After:

![after](https://cloud.githubusercontent.com/assets/22498/21050620/9de9a4a6-be13-11e6-88c1-2c5238f703ef.png)
