### PR TITLE
Fix character limit counter in IE

### DIFF
--- a/h/static/styles/partials-v2/_form-input.scss
+++ b/h/static/styles/partials-v2/_form-input.scss
@@ -72,7 +72,7 @@
 
     // Show fallback "counter" if loading js times out.
     .env-js-timeout & {
-      display: initial;
+      display: block;
     }
 
     // Immediately hide counter if js capable - prevents momentary flash of
@@ -84,7 +84,7 @@
     // The js controller adds this class when it's ready - show the now
     // enhanced counter.
     &.is-ready {
-      display: initial;
+      display: block;
     }
 
     &.is-too-long {


### PR DESCRIPTION
The character limit counter wasn't appearing in IE because IE doesn't
support display: initial. Instead hardcode the value (display: block)
that display: initial actually results in for this element in other
browsers.

Fixes https://github.com/hypothesis/h/issues/3808