### PR TITLE
Fix form field error messages in IE

### DIFF
--- a/h/static/styles/partials-v2/_form-input.scss
+++ b/h/static/styles/partials-v2/_form-input.scss
@@ -47,7 +47,7 @@
     }
 
     & > .form-input__error-list {
-      display: initial;
+      display: list-item;
     }
   }
 


### PR DESCRIPTION
Form field error messages where not being shown in IE because it doesn't
support display: initial. In other browsers display: initial actually
results in display: list-item for these error messages, so hardcode
display: list-item instead so that it works in IE.

Fixes https://github.com/hypothesis/h/issues/4206