### PR TITLE
Use Node 6.7 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,14 +21,14 @@ matrix:
       # We currently build production against Alpine v3.4:
       #
       #   https://pkgs.alpinelinux.org/packages?name=nodejs&branch=v3.4
-      node_js: '6.2'
+      node_js: '6.7'
       before_install: npm install gulp-cli
       script: gulp test
 
     # Lint frontend code
     - env: ACTION=frontend-lint
       language: node_js
-      node_js: '6.2'
+      node_js: '6.7'
       script: gulp lint
 
 cache:


### PR DESCRIPTION
We are building our production docker images with Node 6.7, so we should also use this version on Travis.