### PR TITLE
Move responsibility for rendering suggestions data to navbar panel

### DIFF
--- a/h/panels/navbar.py
+++ b/h/panels/navbar.py
@@ -10,12 +10,16 @@ from h.i18n import TranslationString as _  # noqa
 
 
 @panel_config(name='navbar', renderer='h:templates/panels/navbar.html.jinja2')
-def navbar(context, request, opts={}):
+def navbar(context, request, search=None, opts=None):
     """
     The navigation bar displayed at the top of the page.
+
+    :param search: The current page's search state, if relevant.
+    :type search: h.activity.query.ActivityResults
     """
 
     groups_menu_items = []
+    groups_suggestions = []
     user_activity_url = None
     username = None
 
@@ -24,7 +28,11 @@ def navbar(context, request, opts={}):
             groups_menu_items.append({
                 'title': group.name,
                 'link': request.route_url('group_read', pubid=group.pubid, slug=group.slug)
-                })
+            })
+            groups_suggestions.append({
+                'name': group.name,
+                'pubid': group.pubid
+            })
         user_activity_url = request.route_url('activity.user_search',
                                               username=request.authenticated_user.username)
         username = request.authenticated_user.username
@@ -43,11 +51,13 @@ def navbar(context, request, opts={}):
         ],
         'signout_item': {'title': _('Sign out'), 'link': request.route_url('logout')},
         'groups_menu_items': groups_menu_items,
+        'groups_suggestions': groups_suggestions,
         'create_group_item':
             {'title': _('Create new group'), 'link': request.route_url('group_create')},
         'username': username,
         'username_url': user_activity_url,
+        'search': search,
         'search_url': search_url,
         'q': request.params.get('q', ''),
-        'opts': opts,
+        'opts': opts or {},
     }

--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -333,15 +333,7 @@
 
 {% block content %}
 
-  {{ panel('navbar', opts or {}) }}
-
-  <script type="application/json" class="js-tag-suggestions">
-    {{search_results.aggregations['tags'] | to_json}}
-  </script>
-
-  <script type="application/json" class="js-group-suggestions">
-    {{groups_suggestions | to_json}}
-  </script>
+  {{ panel('navbar', search_results, opts) }}
 
   <div class="search-result-container {%- if not search_results.timeframes %} search-result-container--empty{% endif %}">
     {% if group %}

--- a/h/templates/panels/navbar.html.jinja2
+++ b/h/templates/panels/navbar.html.jinja2
@@ -102,5 +102,15 @@
     </div>
   </div>
 </header>
+
+{% if search %}
+<script type="application/json" class="js-tag-suggestions">
+  {{search.aggregations['tags'] | to_json}}
+</script>
+{% endif %}
+
+<script type="application/json" class="js-group-suggestions">
+  {{groups_suggestions | to_json}}
+</script>
 {% endif %}
 {% endblock %}

--- a/tests/h/views/activity_test.py
+++ b/tests/h/views/activity_test.py
@@ -73,26 +73,6 @@ class TestSearchController(object):
                                          mock.ANY,
                                          page_size=100)
 
-    def test_search_returns_group_suggestions(self,
-                                              controller,
-                                              factories,
-                                              pyramid_request,
-                                              query):
-        """It should return a list of group_suggestions to the template."""
-        fake_group_1 = factories.Group()
-        fake_group_2 = factories.Group()
-        fake_group_3 = factories.Group()
-        pyramid_request.authenticated_user.groups = [
-            fake_group_1, fake_group_2, fake_group_3]
-
-        result = controller.search()
-
-        assert result['groups_suggestions'] == [
-            {'name': fake_group_1.name, 'pubid': fake_group_1.pubid},
-            {'name': fake_group_2.name, 'pubid': fake_group_2.pubid},
-            {'name': fake_group_3.name, 'pubid': fake_group_3.pubid},
-        ]
-
     def test_search_generates_tag_links(self, controller):
         result = controller.search()
 


### PR DESCRIPTION
This commit moves responsibility for rendering the JSON suggestions data from the activity pages views themselves to the "navbar" panel, which is the component that actually uses this data.

This fixes the issue of the groups suggestions not being available on pages which show the search box but do not have an active search (such as the account pages), but more generally it's a step towards including all "search state" context in a single "search" object which is passed to reusable panels such as this one.

~~~_**N.B.** This PR depends on #4209 and will need a rebase after that's merged._~~~