### PR TITLE
Fix 'How to get started' layout in Firefox

### DIFF
--- a/h/static/styles/partials-v2/_search.scss
+++ b/h/static/styles/partials-v2/_search.scss
@@ -93,6 +93,16 @@
   padding-left: 0;
 }
 
+.search-result-zero__list-item {
+  line-height: 35px;
+
+  // Add additional padding between marker and item content.
+  &:before {
+    content: "";
+    padding-left: 5px;
+  }
+}
+
 .search-result-zero a {
   color: inherit;
   text-decoration: underline;

--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -374,38 +374,38 @@
         {% if zero_message == '__SHOW_GETTING_STARTED__' %}
           <div>
             <h2 class="search-result-zero__title">
-              {% trans %}How to get started{% endtrans %}
+              {%- trans %}How to get started{% endtrans -%}
             </h2>
             <ol class="search-result-zero__list">
-              <li><p>
-                <a href="https://chrome.google.com/webstore/detail/hypothesis-web-pdf-annota/bjfhmglciegochdpefhhlphglcehbmek">
-                  {% trans %}Install our Chrome extension{% endtrans %}
+              <li class="search-result-zero__list-item"><!--
+                !--><a href="https://chrome.google.com/webstore/detail/hypothesis-web-pdf-annota/bjfhmglciegochdpefhhlphglcehbmek">
+                  {%- trans %}Install our Chrome extension{% endtrans -%}
                 </a>
-              </p></li>
-              <li><p>
-                {% trans url=request.route_url('activity.search') %}
+              </li>
+              <li class="search-result-zero__list-item">
+                {%- trans url=request.route_url('activity.search') -%}
                   Check out some of the
                   <a href="{{ url }}">
                     recently annotated documents
                   </a>
-                {% endtrans %}
-              </p></li>
-              <li><p>
-                {% trans url=user.edit_url %}
+                {%- endtrans -%}
+              </li>
+              <li class="search-result-zero__list-item">
+                {%- trans url=user.edit_url -%}
                   Let other users know more about you by
                   <a href="{{ url }}">
                     adding more information to your profile
                   </a>
-                {% endtrans %}
-              </p></li>
-              <li><p>
-                {% trans %}
+                {%- endtrans -%}
+              </li>
+              <li class="search-result-zero__list-item">
+                {%- trans -%}
                   Read more about
                   <a href="https://hypothes.is/annotating-with-groups/">
                     how to annotate with groups
                   </a>
-                {% endtrans %}
-              </p></li>
+                {%- endtrans -%}
+              </li>
             </ol>
           </div>
         {% else %}


### PR DESCRIPTION
This makes the layout of the "How to get started" view seen by new users after logging in for the first time closer to the mocks at https://cloud.githubusercontent.com/assets/22498/20572409/3f1e6a50-b1a3-11e6-867d-fbda27ff4838.png . Note that the link styling still does not match the mock (note the spacing at the bottom). I'll address that in a follow-up PR.

 * Fix list item contents appearing underneath item numberings by
   removing the paragraph tag used to create spacing between items and
   instead setting line-height on list items.

 * Fix difference in whitespace at the start of list items between
   Firefox and Chrome by removing whitespace around Jinja tags.

 * Adjust padding between list item marker and content.
   See http://stackoverflow.com/a/26336092/434243

----

**Before:**

![zero-state-firefox](https://cloud.githubusercontent.com/assets/2458/21101486/52fdff04-c071-11e6-8a1c-fcc73923a35b.png)

**After:**

![zero-state-firefox-after](https://cloud.githubusercontent.com/assets/2458/21101488/57b81aca-c071-11e6-8045-64fc425d28ba.png)

