### PR TITLE
Deduplicate link styling

### DIFF
--- a/h/static/styles/partials-v2/_link.scss
+++ b/h/static/styles/partials-v2/_link.scss
@@ -1,19 +1,39 @@
 // Text links
 // ----------
-// Styling for text links. Note that these are not used for links to pages
-// for specific objects (eg. a document, a tag, a profile).
 
-.link {
+@mixin link {
   color: inherit;
-  padding-bottom: 2px;
-  border-bottom: 1px dotted;
+  &:visited {
+    color: inherit;
+  }
 }
 
-.link:hover {
-  color: $brand;
+@mixin link-underline($style) {
+  padding-bottom: 1px;
+  border-bottom: 1px #{$style};
 }
 
-// A light link which appears at the footer of the page.
+// A standard text link.
+.link {
+  @include link;
+  @include link-underline(solid);
+}
+
+// A text link that appears in the footer of a page.
 .link--footer {
-  color: $grey-5;
+  @include link;
+  @include link-underline(dotted);
+}
+
+// A link with no decoration.
+.link--plain {
+  @include link;
+}
+
+// A variant of `link` used when the style is applied to a button rather than
+// an anchor.
+.link--btn {
+  @include reset-button;
+  @include link;
+  @include link-underline(solid);
 }

--- a/h/static/styles/partials-v2/_search-result-sidebar.scss
+++ b/h/static/styles/partials-v2/_search-result-sidebar.scss
@@ -27,7 +27,7 @@
 }
 
 .search-result-sidebar__section p:first-of-type {
-  margin-top: 0; 
+  margin-top: 0;
 }
 
 .search-result-sidebar__section p:last-of-type {
@@ -44,25 +44,6 @@
 .search-result-sidebar__dd {
   float: left;
   margin-left: 0;
-}
-
-.search-result-sidebar__link {
-  color: inherit;
-  text-decoration: underline;
-}
-
-.search-result-sidebar__link:hover {
-  text-decoration: underline;
-}
-
-.search-result-sidebar__user-link,
-.search-result-sidebar__orcid-link {
-  color: inherit;
-}
-
-.search-result-sidebar__leave-button {
-  @include reset-button;
-  text-decoration: underline;
 }
 
 .search-result-sidebar-title__annotations-count {

--- a/h/static/styles/partials-v2/_search.scss
+++ b/h/static/styles/partials-v2/_search.scss
@@ -103,11 +103,6 @@
   }
 }
 
-.search-result-zero a {
-  color: inherit;
-  text-decoration: underline;
-}
-
 .search-result__timeframe {
   font-weight: bold;
   padding-bottom: 10px;
@@ -160,13 +155,6 @@
 // header and becomes plain text to avoid accidental clicks.
 .search-result-bucket__domain-text {
   display: none;
-}
-
-.search-result-bucket__domain-link {
-  color: inherit;
-  &:visited {
-    color: inherit;
-  }
 }
 
 .search-result-bucket__incontext-icon {
@@ -284,13 +272,6 @@ $stats-icon-column-width: 20px;
 .search-bucket-stats__url,
 .search-bucket-stats__username {
   word-break: break-all;
-}
-
-.search-bucket-stats__link {
-  color: $grey-6;
-  &:visited {
-    color: $grey-6;
-  }
 }
 
 .search-bucket-stats__incontext-link {

--- a/h/templates/accounts/account.html.jinja2
+++ b/h/templates/accounts/account.html.jinja2
@@ -32,7 +32,7 @@
     <footer class="form-footer">
       {% trans %}
         If you would like to delete your account, please email us at
-        <a class="link" href="mailto:support@hypothes.is">support@hypothes.is</a> from your
+        <a class="link--footer" href="mailto:support@hypothes.is">support@hypothes.is</a> from your
         registered email address, and we'll take it from there.
       {% endtrans %}
     </footer>

--- a/h/templates/accounts/developer.html.jinja2
+++ b/h/templates/accounts/developer.html.jinja2
@@ -74,7 +74,7 @@
       {% if feature('activity_pages') -%}
       <footer class="form-footer">
         You can learn more about the Hypothesis API at
-        <a class="link" href="https://h.readthedocs.io/en/latest/api.html">h.readthedocs.io/en/latest/api.html</a>
+        <a class="link--footer" href="https://h.readthedocs.io/en/latest/api.html">h.readthedocs.io/en/latest/api.html</a>
       </footer>
       {% else %}
       <h2 class="form-heading">

--- a/h/templates/accounts/forgot_password.html.jinja2
+++ b/h/templates/accounts/forgot_password.html.jinja2
@@ -20,7 +20,7 @@ Password reset
     {{ form }}
     <footer class="form-footer">
       Already know your password?
-      <a class="link" href="{{ request.route_path('login') }}">Log in</a>
+      <a class="link--footer" href="{{ request.route_path('login') }}">Log in</a>
     </footer>
   </div>
 {% else %}

--- a/h/templates/accounts/login.html.jinja2
+++ b/h/templates/accounts/login.html.jinja2
@@ -14,7 +14,7 @@
       {{ form }}
       <footer class="form-footer">
         Don't have a Hypothesis account?
-        <a class="link" href="{{ request.route_path('signup') }}">Sign up</a>
+        <a class="link--footer" href="{{ request.route_path('signup') }}">Sign up</a>
       </footer>
     </div>
   {% else %}

--- a/h/templates/accounts/reset.html.jinja2
+++ b/h/templates/accounts/reset.html.jinja2
@@ -28,7 +28,7 @@ Password reset
     {{ form }}
     <footer class="form-footer">
       Already know your password?
-      <a class="link" href="{{ request.route_path('login') }}">Log in</a>
+      <a class="link--footer" href="{{ request.route_path('login') }}">Log in</a>
     </footer>
   </div>
   {% else %}

--- a/h/templates/accounts/signup.html.jinja2
+++ b/h/templates/accounts/signup.html.jinja2
@@ -20,7 +20,7 @@ Create account
       {{ form }}
       <footer class="form-footer">
         Already have an account?
-        <a class="link" href="{{ request.route_path('login') }}">Log in</a>
+        <a class="link--footer" href="{{ request.route_path('login') }}">Log in</a>
       </footer>
     </div>
   {% else %}

--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -48,7 +48,7 @@
     </div>
     <ul class="search-bucket-stats__val">
       {% for tag in bucket.tags %}
-        <li><a class="search-bucket-stats__link"
+        <li><a class="link--plain"
                href="{{ tag_link(tag) }}">{{ tag }}</a></li>
       {% endfor %}
     </ul>
@@ -60,7 +60,7 @@
   <ul class="search-bucket-stats__val">
     {% for user in bucket.users %}
       <li class="search-bucket-stats__username">
-        <a class="search-bucket-stats__link"
+        <a class="link--plain"
            href="{{ user_link(user) }}">{{ username_from_id(user) }}</a>
       </li>
     {% endfor %}
@@ -71,7 +71,7 @@
       {% trans %}URL{% endtrans %}
     </div>
     <div class="search-bucket-stats__val search-bucket-stats__url">
-        <a class="search-bucket-stats__link"
+        <a class="link--plain"
            href="{{ bucket.uri }}"
            target="_blank">{{ pretty_link(bucket.uri) }}</a>
     </div>
@@ -90,7 +90,7 @@
   <div class="search-result-bucket__header" data-ref="header">
     <div class="search-result-bucket__domain">
       <span class="search-result-bucket__domain-text">{{ bucket.domain }}</span>
-      <a class="search-result-bucket__domain-link"
+      <a class="link--plain search-result-bucket__domain-link"
          href="{{ bucket.incontext_link(request) }}"
          title="Visit annotations in context"
          target="_blank"
@@ -197,14 +197,14 @@
       <ul>
         {% if group_edit_url %}
           <li>
-            <a class="search-result-sidebar__link"
+            <a class="link"
                href="{{ group_edit_url }}">
               {% trans %}Edit group{% endtrans %}
             </a>
           </li>
         {% endif %}
         <li>
-          <button class="search-result-sidebar__leave-button js-confirm-submit"
+          <button class="link--btn js-confirm-submit"
                   type="submit"
                   form="search-bar"
                   formmethod="POST"
@@ -295,7 +295,7 @@
             {% trans %}Link:{% endtrans %}
           </dt>
           <dd class="search-result-sidebar__dd">
-            <a href="{{ user.uri }}" class="search-result-sidebar__user-link">
+            <a href="{{ user.uri }}" class="link--plain">
               {{ pretty_link(user.uri) }}
             </a>
           </dd>
@@ -307,7 +307,7 @@
           </dt>
           <dd class="search-result-sidebar__dd">
             <a href="https://orcid.org/{{ user.orcid }}"
-               class="search-result-sidebar__orcid-link">
+               class="link--plain">
               {{ user.orcid }}
             </a>
           </dd>
@@ -320,7 +320,7 @@
       <ul>
         {% if user.edit_url %}
           <li>
-            <a class="search-result-sidebar__link"
+            <a class="link"
                href="{{ user.edit_url }}">
               {% trans %}Edit profile{% endtrans %}
             </a>
@@ -378,14 +378,15 @@
             </h2>
             <ol class="search-result-zero__list">
               <li class="search-result-zero__list-item"><!--
-                !--><a href="https://chrome.google.com/webstore/detail/hypothesis-web-pdf-annota/bjfhmglciegochdpefhhlphglcehbmek">
+                !--><a class="link"
+                       href="https://chrome.google.com/webstore/detail/hypothesis-web-pdf-annota/bjfhmglciegochdpefhhlphglcehbmek">
                   {%- trans %}Install our Chrome extension{% endtrans -%}
                 </a>
               </li>
               <li class="search-result-zero__list-item">
                 {%- trans url=request.route_url('activity.search') -%}
                   Check out some of the
-                  <a href="{{ url }}">
+                  <a class="link" href="{{ url }}">
                     recently annotated documents
                   </a>
                 {%- endtrans -%}
@@ -393,7 +394,7 @@
               <li class="search-result-zero__list-item">
                 {%- trans url=user.edit_url -%}
                   Let other users know more about you by
-                  <a href="{{ url }}">
+                  <a class="link" href="{{ url }}">
                     adding more information to your profile
                   </a>
                 {%- endtrans -%}
@@ -401,7 +402,7 @@
               <li class="search-result-zero__list-item">
                 {%- trans -%}
                   Read more about
-                  <a href="https://hypothes.is/annotating-with-groups/">
+                  <a class="link" href="https://hypothes.is/annotating-with-groups/">
                     how to annotate with groups
                   </a>
                 {%- endtrans -%}

--- a/h/templates/groups/join.html.jinja2
+++ b/h/templates/groups/join.html.jinja2
@@ -36,7 +36,7 @@
     </div>
 
     <footer class="form-footer">
-      What is Hypothesis? <a class="link" href="https://hypothes.is/about">Learn more</a>
+      What is Hypothesis? <a class="link--footer" href="https://hypothes.is/about">Learn more</a>
     </footer>
   {% else %}
     <div class="content content--narrow">

--- a/h/templates/panels/back_link.html.jinja2
+++ b/h/templates/panels/back_link.html.jinja2
@@ -1,4 +1,4 @@
 {% if back_location and back_label %}
-<a class="link link--footer"
+<a class="link--footer"
    href="{{ back_location }}">← {{ back_label }}</a>
 {% endif %}


### PR DESCRIPTION
Use variants of the `link` component style for all text links in search
result pages instead of defining a different class for each one.

The only visual change as a result of this commit is that links with
solid underlines now display the underline underneath the decenders, as
in this mock:
https://cloud.githubusercontent.com/assets/22498/20572409/3f1e6a50-b1a3-11e6-867d-fbda27ff4838.png #

**Before**

![zero-state-firefox-after](https://cloud.githubusercontent.com/assets/2458/21107389/6abd1388-c089-11e6-9cb9-7c3ec4c7b295.png)

**After**

![underline-below-descender](https://cloud.githubusercontent.com/assets/2458/21107378/6162bb44-c089-11e6-9057-3ff3e333acb3.png)
