### PR TITLE
Notifications Toggle Error

### DIFF
--- a/h/static/scripts/controllers/form-controller.js
+++ b/h/static/scripts/controllers/form-controller.js
@@ -243,7 +243,7 @@ class FormController extends Controller {
         // If there was an error processing the request or the server could
         // not be reached, display a helpful error
         this.setState({
-          submitError: err.reason,
+          submitError: err.reason || 'There was a problem saving changes.',
           saving: false,
         });
       }

--- a/h/static/scripts/tests/controllers/form-controller-test.js
+++ b/h/static/scripts/tests/controllers/form-controller-test.js
@@ -229,9 +229,16 @@ describe('FormController', () => {
   });
 
   it('displays an error if form submission fails without returning a new form', () => {
-    fakeSubmitForm.returns(Promise.reject({status: 500, reason: 'Internal Server Error'}));
+    fakeSubmitForm.returns(Promise.reject({status: 501, reason: 'Internal Server Error'}));
     return submitForm().then(() => {
       assert.equal(submitError(), 'Internal Server Error');
+    });
+  });
+
+  it('Displays a generic error message when an internal error occurs inside of submit form', () => {
+    fakeSubmitForm.returns(Promise.reject(new Error('An internal issue')));
+    return submitForm().then(() => {
+      assert.equal(submitError(), 'There was a problem saving changes.');
     });
   });
 

--- a/h/static/scripts/tests/util/submit-form-test.js
+++ b/h/static/scripts/tests/util/submit-form-test.js
@@ -8,6 +8,10 @@ const { unroll } = require('../util');
 describe('submitForm', () => {
   const FORM_URL = 'http://example.org/things';
 
+  afterEach(() => {
+    fetchMock.restore();
+  });
+
   function mockResponse(response, url = FORM_URL) {
     fetchMock.post(url, response);
   }
@@ -81,4 +85,5 @@ describe('submitForm', () => {
       assert.match(err, sinon.match({status: 500, reason: 'Internal Server Error'}));
     });
   });
+
 });


### PR DESCRIPTION
Fixes: #4179

While incorrectly going down the path of testing what happens on the submit-form utility when we throw an error, I came across the fact that we were not cleaning up our global fetch usage. 

Regarding the actual error. I don't think it's at all helpful to present an actual error to the user in the form but we need to have something to make it obvious that something went wrong. So I added a generic error there so we/they have something to tell us if it needs support.