### PR TITLE
Add Annotation.shared field to the search index

### DIFF
--- a/src/memex/presenters.py
+++ b/src/memex/presenters.py
@@ -107,6 +107,7 @@ class AnnotationSearchIndexPresenter(AnnotationBasePresenter):
             'tags_raw': self.tags,
             'group': self.annotation.groupid,
             'permissions': self.permissions,
+            'shared': self.annotation.shared,
             'target': self.target,
             'document': docpresenter.asdict(),
         }

--- a/src/memex/search/config.py
+++ b/src/memex/search/config.py
@@ -99,6 +99,7 @@ ANNOTATION_MAPPING = {
                 'admin': {'type': 'string'}
             }
         },
+        'shared': {'type': 'boolean'},
         'references': {'type': 'string'},
         'document': {
             'enabled': False,  # not indexed

--- a/tests/memex/presenters_test.py
+++ b/tests/memex/presenters_test.py
@@ -223,6 +223,7 @@ class TestAnnotationSearchIndexPresenter(object):
                             'admin': ['acct:luke@hypothes.is'],
                             'update': ['acct:luke@hypothes.is'],
                             'delete': ['acct:luke@hypothes.is']},
+            'shared': True,
             'target': [{'scope': ['http://example.com/normalized'],
                         'source': 'http://example.com',
                         'selector': [{'TestSelector': 'foobar'}]}],


### PR DESCRIPTION
This will allow us to update the `AuthFilter` to only filter out
private annotations of other users. In addition to that we will add a
new filter that checks for the correct group permissions.

This is step one from hypothesis/product-backlog#95.