### PR TITLE
Use a single model metadata instance for h and memex

### DIFF
--- a/h/app.py
+++ b/h/app.py
@@ -37,6 +37,15 @@ def create_app(global_config, **settings):
 
 
 def includeme(config):
+    # We need to include `h.models` before pretty much everything else to
+    # avoid the possibility that one of the imports below directly or
+    # indirectly imports `memex.models`. See the comment at the top of
+    # `h.models` for details.
+    #
+    # FIXME: h modules should not access `memex.models`, even indirectly,
+    # except through `h.models`.
+    config.include('h.models')
+
     config.set_root_factory('h.resources:Root')
 
     config.add_subscriber('h.subscribers.add_renderer_globals',
@@ -111,7 +120,6 @@ def includeme(config):
     config.include('h.features')
     config.include('h.form')
     config.include('h.indexer')
-    config.include('h.models')
     config.include('h.panels')
     config.include('h.realtime')
     config.include('h.routes')

--- a/h/db/__init__.py
+++ b/h/db/__init__.py
@@ -20,11 +20,8 @@ import sqlalchemy
 import zope.sqlalchemy
 import zope.sqlalchemy.datamanager
 from pyramid.settings import asbool
-from sqlalchemy import event
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
-
-from memex import db as api_db
 
 __all__ = (
     'Base',
@@ -67,7 +64,6 @@ def init(engine, base=Base, should_create=False, should_drop=False):
         # extension.
         engine.execute('CREATE EXTENSION IF NOT EXISTS "uuid-ossp";')
         base.metadata.create_all(engine)
-    api_db.init(engine, should_create=should_create, should_drop=should_drop)
 
 
 def make_engine(settings):

--- a/h/migrations/env.py
+++ b/h/migrations/env.py
@@ -4,29 +4,17 @@ import logging
 import os
 
 from alembic import context
-from sqlalchemy import MetaData
 from sqlalchemy import engine_from_config, pool
 
+from h import db
 from h.settings import database_url
+
+# Import all model modules here in order to populate the metadata
+from h import models  # noqa
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
 config = context.config
-
-from h import db
-from memex import db as api_db
-
-# Import all model modules here in order to populate the metadata
-from h import models  # noqa
-from memex.models import annotation  # noqa
-
-# Since we have multiple MetaData objects (one from the app and one from the
-# API), we need to merge them all for alembic autogenerate to work correctly.
-target_metadata = MetaData(naming_convention=db.Base.metadata.naming_convention)
-
-for metadata in [db.Base.metadata, api_db.Base.metadata]:
-    for t in metadata.tables.values():
-        t.tometadata(target_metadata)
 
 
 def configure_logging():
@@ -85,7 +73,7 @@ def run_migrations_online():
     connection = engine.connect()
     context.configure(
         connection=connection,
-        target_metadata=target_metadata,
+        target_metadata=db.Base.metadata,
         transaction_per_migration=True,
     )
 

--- a/h/models/__init__.py
+++ b/h/models/__init__.py
@@ -18,6 +18,20 @@ key to. So for convenience the test module can instead just do
 
 """
 
+import h.db
+import memex.db
+
+# We want memex models and h models to share a base class (and hence a
+# metadata instance). This allows us to add relationships on
+# Annotation/Document from "outside" -- i.e. from the `h` package.
+#
+# Because metadata is filled at import time, we have to provide the Base class
+# for memex at import time too.
+#
+# Importing a memex model without having imported `h.models` will cause an
+# exception to be raised, and should be avoided.
+memex.db.set_base(h.db.Base)  # noqa
+
 from memex.models.annotation import Annotation
 from memex.models.document import Document, DocumentMeta, DocumentURI
 

--- a/src/memex/db/__init__.py
+++ b/src/memex/db/__init__.py
@@ -1,36 +1,16 @@
 # -*- coding: utf-8 -*-
 
-from sqlalchemy import MetaData
-from sqlalchemy.ext import declarative
+#: The base class used by memex's models.
+#:
+#: This must be configured by the including application using
+#: :py:func:`memex.db.set_base`.
+Base = None
 
 
-# Create a default metadata object with naming conventions for indexes and
-# constraints. This makes changing such constraints and indexes with alembic
-# after creation much easier. See:
-#
-#   http://docs.sqlalchemy.org/en/latest/core/constraints.html#configuring-constraint-naming-conventions
-#
-# The migrations we run with alembic use the naming convention from
-# :py:mod:`h.db`. In order that auto-created tables (i.e. those created by
-# `Base.metadata.create_all()`) are compatible with these naming conventions,
-# we need to specify them here, too, as `memex` has its own global metadata
-# object.
-#
-# N.B. This must be kept in sync with the naming conventions in :py:mod:`h.db`.
-#
-metadata = MetaData(naming_convention={
-    "ix": "ix__%(column_0_label)s",
-    "uq": "uq__%(table_name)s__%(column_0_name)s",
-    "ck": "ck__%(table_name)s__%(constraint_name)s",
-    "fk": "fk__%(table_name)s__%(column_0_name)s__%(referred_table_name)s",
-    "pk": "pk__%(table_name)s"
-})
-
-Base = declarative.declarative_base(metadata=metadata)  # pylint: disable=invalid-name
-
-
-def init(engine, base=Base, should_create=False, should_drop=False):
+def init(engine, base=None, should_create=False, should_drop=False):
     """Initialise the database tables managed by `memex.db`."""
+    if base is None:
+        base = Base
     if should_drop:
         base.metadata.drop_all(engine)
     if should_create:
@@ -38,3 +18,9 @@ def init(engine, base=Base, should_create=False, should_drop=False):
         # extension.
         engine.execute('CREATE EXTENSION IF NOT EXISTS "uuid-ossp";')
         base.metadata.create_all(engine)
+
+
+def set_base(basecls):
+    """Provide a base class for memex models."""
+    global Base
+    Base = basecls

--- a/tests/h/conftest.py
+++ b/tests/h/conftest.py
@@ -19,6 +19,7 @@ from pyramid.request import apply_request_extensions
 from sqlalchemy.orm import sessionmaker
 
 from h import db
+from h import models  # noqa: ensure base class set for memex
 from h import form
 from h.settings import database_url
 from h._compat import text_type

--- a/tests/memex/conftest.py
+++ b/tests/memex/conftest.py
@@ -14,6 +14,7 @@ import pytest
 import sqlalchemy
 from pyramid import testing
 from pyramid.request import apply_request_extensions
+from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 
 from memex import db
@@ -21,6 +22,8 @@ from memex._compat import text_type
 
 TEST_DATABASE_URL = os.environ.get('TEST_DATABASE_URL',
                                    'postgresql://postgres@localhost/htest')
+
+db.set_base(declarative_base())
 
 Session = sessionmaker()
 


### PR DESCRIPTION
Previously each of h and memex had its own independent model base class and associated `sqlalchemy.MetaData` instance. This is problematic if we want to add relationships between models defined in h and models defined in memex, because the SQLAlchemy mapper for h models doesn't know anything about memex models and vice versa.

This PR changes all that by ensuring that there is only one model base class, and it lives in h. We must manually set the base class for memex models before importing any memex model modules. This is handled by the `h.models` package.