### PR TITLE
Move annotation ACL to memex.resources.AnnotationResource

### DIFF
--- a/h/routes.py
+++ b/h/routes.py
@@ -50,7 +50,7 @@ def includeme(config):
     # Annotations & stream
     config.add_route('annotation',
                      '/a/{id}',
-                     factory='memex.resources:AnnotationFactory',
+                     factory='memex.resources:AnnotationResourceFactory',
                      traverse='/{id}')
     config.add_route('stream', '/stream')
     config.add_route('stream.user_query', '/u/{user}')

--- a/h/views/main.py
+++ b/h/views/main.py
@@ -21,7 +21,8 @@ log = logging.getLogger(__name__)
 
 
 @view_config(route_name='annotation', permission='read')
-def annotation_page(annotation, request):
+def annotation_page(context, request):
+    annotation = context.annotation
     document = annotation.document
     if document and document.title:
         title = 'Annotation by {user} on {title}'.format(

--- a/src/memex/__init__.py
+++ b/src/memex/__init__.py
@@ -16,10 +16,10 @@ def includeme(config):
     config.add_route('api.annotations', '/annotations')
     config.add_route('api.annotation',
                      '/annotations/{id:[A-Za-z0-9_-]{20,22}}',
-                     factory='memex.resources:AnnotationFactory',
+                     factory='memex.resources:AnnotationResourceFactory',
                      traverse='/{id}')
     config.add_route('api.annotation.jsonld',
                      '/annotations/{id:[A-Za-z0-9_-]{20,22}}.jsonld',
-                     factory='memex.resources:AnnotationFactory',
+                     factory='memex.resources:AnnotationResourceFactory',
                      traverse='/{id}')
     config.add_route('api.search', '/search')

--- a/src/memex/models/annotation.py
+++ b/src/memex/models/annotation.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 
 import datetime
 
-from pyramid import security
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql as pg
 from sqlalchemy.ext.hybrid import hybrid_property
@@ -164,25 +163,6 @@ class Annotation(Base):
         else:
             return self.id
 
-    def __acl__(self):
-        """Return a Pyramid ACL for this annotation."""
-        acl = []
-        if self.shared:
-            group = 'group:{}'.format(self.groupid)
-            if self.groupid == '__world__':
-                group = security.Everyone
-
-            acl.append((security.Allow, group, 'read'))
-        else:
-            acl.append((security.Allow, self.userid, 'read'))
-
-        for action in ['admin', 'update', 'delete']:
-            acl.append((security.Allow, self.userid, action))
-
-        # If we haven't explicitly authorized it, it's not allowed.
-        acl.append(security.DENY_ALL)
-
-        return acl
 
     def __repr__(self):
         return '<Annotation %s>' % self.id

--- a/src/memex/resources.py
+++ b/src/memex/resources.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
 
+from pyramid import security
+
 from memex import storage
 
 
-class AnnotationFactory(object):
+class AnnotationResourceFactory(object):
     def __init__(self, request):
         self.request = request
 
@@ -11,4 +13,30 @@ class AnnotationFactory(object):
         annotation = storage.fetch_annotation(self.request.db, id)
         if annotation is None:
             raise KeyError()
-        return annotation
+        return AnnotationResource(self.request, annotation)
+
+
+class AnnotationResource(object):
+    def __init__(self, request, annotation):
+        self.request = request
+        self.annotation = annotation
+
+    def __acl__(self):
+        """Return a Pyramid ACL for this annotation."""
+        acl = []
+        if self.annotation.shared:
+            group = 'group:{}'.format(self.annotation.groupid)
+            if self.annotation.groupid == '__world__':
+                group = security.Everyone
+
+            acl.append((security.Allow, group, 'read'))
+        else:
+            acl.append((security.Allow, self.annotation.userid, 'read'))
+
+        for action in ['admin', 'update', 'delete']:
+            acl.append((security.Allow, self.annotation.userid, action))
+
+        # If we haven't explicitly authorized it, it's not allowed.
+        acl.append(security.DENY_ALL)
+
+        return acl

--- a/tests/h/routes_test.py
+++ b/tests/h/routes_test.py
@@ -49,7 +49,7 @@ def test_includeme():
         call('admin_users_activate', '/admin/users/activate'),
         call('admin_users_delete', '/admin/users/delete'),
         call('admin_users_rename', '/admin/users/rename'),
-        call('annotation', '/a/{id}', factory='memex.resources:AnnotationFactory', traverse='/{id}'),
+        call('annotation', '/a/{id}', factory='memex.resources:AnnotationResourceFactory', traverse='/{id}'),
         call('stream', '/stream'),
         call('stream.user_query', '/u/{user}'),
         call('stream.tag_query', '/t/{tag}'),

--- a/tests/h/views/main_test.py
+++ b/tests/h/views/main_test.py
@@ -8,6 +8,7 @@ import pytest
 
 from memex.models.annotation import Annotation
 from memex.models.document import Document
+from memex.resources import AnnotationResource
 from h.views import main
 
 
@@ -16,12 +17,13 @@ from h.views import main
 @pytest.mark.usefixtures('routes')
 def test_og_document(render_app_html, annotation_document, document_title, pyramid_request):
     annotation = Annotation(id='123', userid='foo', target_uri='http://example.com')
+    context = AnnotationResource(pyramid_request, annotation)
     document = Document()
     annotation_document.return_value = document
     document_title.return_value = 'WikiHow — How to Make a ☆Starmap☆'
 
     render_app_html.return_value = '<html></html>'
-    main.annotation_page(annotation, pyramid_request)
+    main.annotation_page(context, pyramid_request)
     args, kwargs = render_app_html.call_args
     test = lambda d: 'foo' in d['content'] and 'Starmap' in d['content']
     assert any(test(d) for d in kwargs['extra']['meta_attrs'])
@@ -31,9 +33,10 @@ def test_og_document(render_app_html, annotation_document, document_title, pyram
 @pytest.mark.usefixtures('routes')
 def test_og_no_document(render_app_html, pyramid_request):
     annotation = Annotation(id='123', userid='foo', target_uri='http://example.com')
+    context = AnnotationResource(pyramid_request, annotation)
 
     render_app_html.return_value = '<html></html>'
-    main.annotation_page(annotation, pyramid_request)
+    main.annotation_page(context, pyramid_request)
     args, kwargs = render_app_html.call_args
     test = lambda d: 'foo' in d['content']
     assert any(test(d) for d in kwargs['extra']['meta_attrs'])

--- a/tests/memex/models/annotation_test.py
+++ b/tests/memex/models/annotation_test.py
@@ -69,39 +69,6 @@ def test_text_setter_renders_markdown(markdown):
     annotation.text_rendered == markdown.render.return_value
 
 
-def test_acl_private():
-    ann = Annotation(shared=False, userid='saoirse')
-    actual = ann.__acl__()
-    expect = [(security.Allow, 'saoirse', 'read'),
-              (security.Allow, 'saoirse', 'admin'),
-              (security.Allow, 'saoirse', 'update'),
-              (security.Allow, 'saoirse', 'delete'),
-              security.DENY_ALL]
-    assert actual == expect
-
-
-def test_acl_world_shared():
-    ann = Annotation(shared=True, userid='saoirse', groupid='__world__')
-    actual = ann.__acl__()
-    expect = [(security.Allow, security.Everyone, 'read'),
-              (security.Allow, 'saoirse', 'admin'),
-              (security.Allow, 'saoirse', 'update'),
-              (security.Allow, 'saoirse', 'delete'),
-              security.DENY_ALL]
-    assert actual == expect
-
-
-def test_acl_group_shared():
-    ann = Annotation(shared=True, userid='saoirse', groupid='lulapalooza')
-    actual = ann.__acl__()
-    expect = [(security.Allow, 'group:lulapalooza', 'read'),
-              (security.Allow, 'saoirse', 'admin'),
-              (security.Allow, 'saoirse', 'update'),
-              (security.Allow, 'saoirse', 'delete'),
-              security.DENY_ALL]
-    assert actual == expect
-
-
 def test_setting_extras_inline_is_persisted(db_session, factories):
     """
     In-place changes to Annotation.extra should be persisted.

--- a/tests/memex/resources_test.py
+++ b/tests/memex/resources_test.py
@@ -3,25 +3,34 @@
 from mock import Mock
 import pytest
 
-from memex.resources import AnnotationFactory
+from pyramid import security
+
+from memex.resources import AnnotationResourceFactory, AnnotationResource
 
 
-class TestAnnotationFactory(object):
+class TestAnnotationResourceFactory(object):
     def test_get_item_fetches_annotation(self, pyramid_request, storage):
-        factory = AnnotationFactory(pyramid_request)
+        factory = AnnotationResourceFactory(pyramid_request)
 
         factory['123']
         storage.fetch_annotation.assert_called_once_with(pyramid_request.db, '123')
 
-    def test_get_item_returns_annotation(self, pyramid_request, storage):
-        factory = AnnotationFactory(pyramid_request)
+    def test_get_item_returns_annotation_resource(self, pyramid_request, storage):
+        factory = AnnotationResourceFactory(pyramid_request)
         storage.fetch_annotation.return_value = Mock()
 
-        annotation = factory['123']
-        assert annotation == storage.fetch_annotation.return_value
+        resource = factory['123']
+        assert isinstance(resource, AnnotationResource)
+
+    def test_get_item_resource_has_right_annotation(self, pyramid_request, storage):
+        factory = AnnotationResourceFactory(pyramid_request)
+        storage.fetch_annotation.return_value = Mock()
+
+        resource = factory['123']
+        assert resource.annotation == storage.fetch_annotation.return_value
 
     def test_get_item_raises_when_annotation_is_not_found(self, storage, pyramid_request):
-        factory = AnnotationFactory(pyramid_request)
+        factory = AnnotationResourceFactory(pyramid_request)
         storage.fetch_annotation.return_value = None
 
         with pytest.raises(KeyError):
@@ -30,3 +39,38 @@ class TestAnnotationFactory(object):
     @pytest.fixture
     def storage(self, patch):
         return patch('memex.resources.storage')
+
+
+class TestAnnotationResource(object):
+    def test_acl_private(self, factories, pyramid_request):
+        ann = factories.Annotation(shared=False, userid='saoirse')
+        res = AnnotationResource(pyramid_request, ann)
+        actual = res.__acl__()
+        expect = [(security.Allow, 'saoirse', 'read'),
+                  (security.Allow, 'saoirse', 'admin'),
+                  (security.Allow, 'saoirse', 'update'),
+                  (security.Allow, 'saoirse', 'delete'),
+                  security.DENY_ALL]
+        assert actual == expect
+
+    def test_acl_world_shared(self, factories, pyramid_request):
+        ann = factories.Annotation(shared=True, userid='saoirse', groupid='__world__')
+        res = AnnotationResource(pyramid_request, ann)
+        actual = res.__acl__()
+        expect = [(security.Allow, security.Everyone, 'read'),
+                  (security.Allow, 'saoirse', 'admin'),
+                  (security.Allow, 'saoirse', 'update'),
+                  (security.Allow, 'saoirse', 'delete'),
+                  security.DENY_ALL]
+        assert actual == expect
+
+    def test_acl_group_shared(self, factories, pyramid_request):
+        ann = factories.Annotation(shared=True, userid='saoirse', groupid='lulapalooza')
+        res = AnnotationResource(pyramid_request, ann)
+        actual = res.__acl__()
+        expect = [(security.Allow, 'group:lulapalooza', 'read'),
+                  (security.Allow, 'saoirse', 'admin'),
+                  (security.Allow, 'saoirse', 'update'),
+                  (security.Allow, 'saoirse', 'delete'),
+                  security.DENY_ALL]
+        assert actual == expect


### PR DESCRIPTION
As part of introducing new kinds of group, we need to be able to have an annotation's ACL depend on the ACL of the group it is in. This is problematic if the ACL lives on the Annotation model because:

1. In order to retrieve the group we need to use memex.groups.find, which takes the request as its first argument.
2. The __acl__ method does not have access to the request.
3. There's no easy way to pass the request to the constructor of a SQLAlchemy mapped class.

The most straightforward way to solve this problem seems to be to introduce a wrapper class, AnnotationResource, which acts as the request context for views operating on annotations, and thus which holds the ACL for the annotation.

This PR does not change any of the access control rules for annotations, it merely introduces the AnnotationResource wrapper class and updates the various views that previously received Annotation objects as context to receive AnnotationResource objects instead.