### PR TITLE
Fix crashing login page

### DIFF
--- a/h/templates/includes/logo-header.html.jinja2
+++ b/h/templates/includes/logo-header.html.jinja2
@@ -1,7 +1,7 @@
 <header class="masthead">
   {% if feature('activity_pages') %}
   <a href="/" title="Hypothesis homepage"><!--
-    !--><img alt="Hypothesis logo" class="masthead-logo" src="{{ asset_url('images/logo.svg') }}"></a>
+    !--><img alt="Hypothesis logo" class="masthead-logo" src="{{ asset_url('images/icons/logo.svg') }}"></a>
   {% else %}
   <hgroup>
 	<a href="https://hypothes.is" class="masthead-heading">Hypothes<span class="red">.</span>is</a>


### PR DESCRIPTION
With the activity_pages feature flag on, when logged out, the /login
page is crashing because it's trying to access an SVG file that has been
moved. Update it to use the file's new path.