### PR TITLE
Inline logo svg file

### DIFF
--- a/h/static/styles/partials-v2/_masthead.scss
+++ b/h/static/styles/partials-v2/_masthead.scss
@@ -7,3 +7,7 @@
   padding-right: 15px;
   padding-top: 15px;
 }
+
+.masthead-logo {
+  color: $grey-6;
+}

--- a/h/templates/includes/logo-header.html.jinja2
+++ b/h/templates/includes/logo-header.html.jinja2
@@ -1,7 +1,7 @@
 <header class="masthead">
   {% if feature('activity_pages') %}
   <a href="/" title="Hypothesis homepage"><!--
-    !--><img alt="Hypothesis logo" class="masthead-logo" src="{{ asset_url('images/icons/logo.svg') }}"></a>
+    !-->{{ svg_icon('logo', 'masthead-logo', translate_z=True) }}</a>
   {% else %}
   <hgroup>
 	<a href="https://hypothes.is" class="masthead-heading">Hypothes<span class="red">.</span>is</a>


### PR DESCRIPTION
For consistency's sake, always use an inline svg when using the logo.svg file. I don't think there's any actual reason to do this here, other than consistency.