### PR TITLE
Wrap page contents in <main> element

### DIFF
--- a/h/templates/accounts/forgot_password.html.jinja2
+++ b/h/templates/accounts/forgot_password.html.jinja2
@@ -4,6 +4,10 @@
 {% set style_bundle = 'legacy_site_css' %}
 {% endif %}
 
+{% block header %}
+  {% include "h:templates/includes/logo-header.html.jinja2" %}
+{% endblock %}
+
 {% block page_title %}
 {% if feature('activity_pages') %}
 Reset your password
@@ -14,7 +18,6 @@ Password reset
 
 {% block content %}
 {%if feature('activity_pages') %}
-  {% include "h:templates/includes/logo-header.html.jinja2" %}
   <div class="form-container content">
     <h1 class="form-header">Reset your password</h1>
     {{ form }}
@@ -25,7 +28,6 @@ Password reset
   </div>
 {% else %}
   <div class="content paper">
-    {% include "h:templates/includes/logo-header.html.jinja2" %}
     <div class="form-vertical">
       <ul class="nav nav-tabs">
         <li><a href="{{ request.route_path('login') }}">Log in</a></li>{#

--- a/h/templates/accounts/login.html.jinja2
+++ b/h/templates/accounts/login.html.jinja2
@@ -4,11 +4,14 @@
 {% set style_bundle = 'legacy_site_css' %}
 {% endif %}
 
+{% block header %}
+  {% include "h:templates/includes/logo-header.html.jinja2" %}
+{% endblock %}
+
 {% block page_title %}Log in{% endblock %}
 
 {% block content %}
   {%if feature('activity_pages') %}
-    {% include "h:templates/includes/logo-header.html.jinja2" %}
     <div class="form-container content">
       <h1 class="form-header">Log in</h1>
       {{ form }}
@@ -19,7 +22,6 @@
     </div>
   {% else %}
     <div class="content paper">
-      {% include "h:templates/includes/logo-header.html.jinja2" %}
       <div class="form-vertical">
         <ul class="nav nav-tabs">
           <li class="active"><a href="{{ request.route_path('login') }}">Log in</a></li>{#

--- a/h/templates/accounts/reset.html.jinja2
+++ b/h/templates/accounts/reset.html.jinja2
@@ -4,6 +4,10 @@
 {% set style_bundle = 'legacy_site_css' %}
 {% endif %}
 
+{% block header %}
+  {% include "h:templates/includes/logo-header.html.jinja2" %}
+{% endblock %}
+
 {% block page_title %}
 {% if feature('activity_pages') %}
 Reset your password
@@ -14,7 +18,6 @@ Password reset
 
 {% block content %}
   {% if feature('activity_pages') %}
-  {% include "h:templates/includes/logo-header.html.jinja2" %}
   <div class="form-container content">
     <h1 class="form-header">New password</h1>
     {% if not has_code %}
@@ -33,7 +36,6 @@ Password reset
   </div>
   {% else %}
   <div class="content paper">
-    {% include "h:templates/includes/logo-header.html.jinja2" %}
     <div class="form-vertical">
       <ul class="nav nav-tabs">
         <li><a href="{{ request.route_path('login') }}">Log in</a></li>{#

--- a/h/templates/accounts/signup.html.jinja2
+++ b/h/templates/accounts/signup.html.jinja2
@@ -4,6 +4,10 @@
 {% set style_bundle = 'legacy_site_css' %}
 {% endif %}
 
+{% block header %}
+  {% include "h:templates/includes/logo-header.html.jinja2" %}
+{% endblock %}
+
 {% block page_title %}
 {% if feature('activity_pages') %}
 Sign up for Hypothesis
@@ -14,7 +18,6 @@ Create account
 
 {% block content %}
   {%if feature('activity_pages') %}
-    {% include "h:templates/includes/logo-header.html.jinja2" %}
     <div class="form-container content">
       <h1 class="form-header">Sign up for Hypothesis</h1>
       {{ form }}
@@ -25,7 +28,6 @@ Create account
     </div>
   {% else %}
   <div class="content paper">
-    {% include "h:templates/includes/logo-header.html.jinja2" %}
     <div class="form-vertical">
       <ul class="nav nav-tabs">
         <li><a href="{{ request.route_path('login') }}">Log in</a></li>{#

--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -333,10 +333,11 @@
   {% endcall %}
 {% endmacro %}
 
-{% block content %}
-
+{% block header %}
   {{ panel('navbar', search_results, opts) }}
+{% endblock %}
 
+{% block content %}
   <div class="search-result-container {%- if not search_results.timeframes %} search-result-container--empty{% endif %}">
     {% if group %}
       {{ search_result_nav(group.name) }}

--- a/h/templates/home.html.jinja2
+++ b/h/templates/home.html.jinja2
@@ -17,8 +17,8 @@
   <meta property="og:image" content="{{ base_url }}assets/images/logo_new.png" />
 {% endblock %}
 
-{% block content %}
 
+{% block header %}
   <header class="banner hiring">
     <div class="container">
       <span>
@@ -88,7 +88,9 @@
       {% include "h:templates/includes/flashbar.html.jinja2" %}
     </div>
   </header>
+{% endblock %}
 
+{% block content %}
   <div class="wrap container" role="document">
     <div class="content row">
       <main class="main">

--- a/h/templates/layouts/account.html.jinja2
+++ b/h/templates/layouts/account.html.jinja2
@@ -21,10 +21,13 @@
 
 {% block page_title %}{{ page_title }}{% endblock %}
 
-{% block content %}
+{% block header %}
   {% if feature('activity_pages') %}
-  {{ panel('navbar') }}
+    {{ panel('navbar') }}
   {% endif %}
+{% endblock %}
+
+{% block content %}
   <div class="content paper">
     {% if feature('activity_pages') %}
       <div class="form-container">

--- a/h/templates/layouts/base.html.jinja2
+++ b/h/templates/layouts/base.html.jinja2
@@ -78,7 +78,12 @@
     {% endfor %}
   </head>
   <body class="body">
-    {% block content %}{% endblock %}
+    {% block header %}{% endblock %}
+
+    <main>
+      {% block content %}{% endblock %}
+    </main>
+
     {% block scripts %}
     {% for url in asset_urls("site_js") %}
     <script src="{{ url }}"></script>

--- a/h/templates/layouts/group.html.jinja2
+++ b/h/templates/layouts/group.html.jinja2
@@ -6,11 +6,13 @@
 
 {% block page_title %}{{ page_title }}{% endblock %}
 
-{% block content %}
+{% block header %}
   {% if feature('activity_pages') %}
     {% include "h:templates/includes/logo-header.html.jinja2" %}
   {%- endif %}
+{% endblock %}
 
+{% block content %}
   <div class="content paper">
     <div class="form-container">
       {% if request.session.peek_flash('success') -%}


### PR DESCRIPTION
Wrap the main contents of every page that uses the base.html.jinja2 layout in a
`<main>` element.

This is going to enable us to use `display: flex`
(with `flex-direction: column`) on the `<body>` element. We need `<body>` to
be a flex container so that we can add a sticky, variable-height footer to some
pages, using this technique: https://philipwalton.github.io/solved-by-flexbox/

Normally making `<body>` a flex container would mess up the widths of the
content elements of some pages, because a flex container treats widths
differently to a non-flex container. (In particular, it doesn't seem to treat
`max-width` in the same way.) By wrapping the contents of every page in a
`<main>` we ensure that this `<main>`, and not the contents of the page, will
be subject to the `<body>`'s new flex layout, and avoid any unwanted changes to
the widths of page contents.

Using `<main>` also adds some semantic information.