### PR TITLE
Memex demo tweaks

### DIFF
--- a/h/app.py
+++ b/h/app.py
@@ -112,6 +112,11 @@ def includeme(config):
     # - we can override behaviour from `memex` if necessary.
     config.include('memex', route_prefix='/api')
 
+    # If search autoconfig is false, then override memex.search.init with a
+    # no-op.
+    if not asbool(config.registry.settings.get('h.search.autoconfig')):
+        config.action('memex.search.init', lambda: None)
+
     # Core site modules
     config.include('h.assets')
     config.include('h.auth')

--- a/src/memex/__init__.py
+++ b/src/memex/__init__.py
@@ -5,6 +5,8 @@ __version__ = '0.39.0+dev'
 
 
 def includeme(config):
+    config.include('pyramid_services')
+
     config.include('memex.eventqueue')
     config.include('memex.groups')
     config.include('memex.links')

--- a/src/memex/__init__.py
+++ b/src/memex/__init__.py
@@ -7,6 +7,10 @@ __version__ = '0.39.0+dev'
 def includeme(config):
     config.include('pyramid_services')
 
+    # This must be included first so it can set up the model base class if
+    # need be.
+    config.include('memex.models')
+
     config.include('memex.eventqueue')
     config.include('memex.groups')
     config.include('memex.links')

--- a/src/memex/db/__init__.py
+++ b/src/memex/db/__init__.py
@@ -1,5 +1,11 @@
 # -*- coding: utf-8 -*-
 
+import logging
+
+from sqlalchemy.ext.declarative import declarative_base
+
+log = logging.getLogger(__name__)
+
 #: The base class used by memex's models.
 #:
 #: This must be configured by the including application using
@@ -20,7 +26,14 @@ def init(engine, base=None, should_create=False, should_drop=False):
         base.metadata.create_all(engine)
 
 
-def set_base(basecls):
+def set_base(basecls=None):
     """Provide a base class for memex models."""
     global Base
+
+    if basecls is None:
+        if Base is None:
+            log.info('model base class not already set, using defaults')
+            Base = declarative_base()
+        return
+
     Base = basecls

--- a/src/memex/models/__init__.py
+++ b/src/memex/models/__init__.py
@@ -11,6 +11,10 @@ direct to the submodules of this package, but rather through the helper
 functions in `memex.storage`.
 """
 
+from memex.db import set_base
+
+set_base()  # noqa
+
 from memex.models.annotation import Annotation
 from memex.models.document import create_or_update_document_meta
 from memex.models.document import create_or_update_document_uri
@@ -30,3 +34,9 @@ __all__ = (
     'DocumentURI',
     'merge_documents',
 )
+
+
+def includeme(_):
+    # This module is included for side-effects only. SQLAlchemy models
+    # register with the global metadata object when imported.
+    pass

--- a/src/memex/search/__init__.py
+++ b/src/memex/search/__init__.py
@@ -43,12 +43,10 @@ def includeme(config):
     # Add a property to all requests for easy access to the elasticsearch
     # client. This can be used for direct or bulk access without having to
     # reread the settings.
-    config.registry['es.client'] = _get_client(settings)
+    config.registry['es.client'] = client = _get_client(settings)
     config.add_request_method(
         lambda r: r.registry['es.client'],
         name='es',
         reify=True)
 
-    # If requested, automatically configure the index
-    if asbool(settings.get('h.search.autoconfig', False)):
-        init(config.registry['es.client'])
+    config.action('memex.search.init', init, args=(client,), order=10)

--- a/tests/memex/conftest.py
+++ b/tests/memex/conftest.py
@@ -14,7 +14,6 @@ import pytest
 import sqlalchemy
 from pyramid import testing
 from pyramid.request import apply_request_extensions
-from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 
 from memex import db
@@ -22,8 +21,6 @@ from memex._compat import text_type
 
 TEST_DATABASE_URL = os.environ.get('TEST_DATABASE_URL',
                                    'postgresql://postgres@localhost/htest')
-
-db.set_base(declarative_base())
 
 Session = sessionmaker()
 


### PR DESCRIPTION
Minor tweaks to the memex package that are needed to be able to use it more easily independently from the rest of h:

- fix a missing include of `pyramid_services`
- allow automatic provision of a default model base class when needed
- move the handling of an `h.*` setting into h itself