### PR TITLE
Change text for annotation count in user sidebar from shared annotati…

### DIFF
--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -276,7 +276,7 @@
       <dl>
         {% if user.annotation_count %}
           <dt class="search-result-sidebar__dt">
-            {% trans %}Shared annotations:{% endtrans %}
+            {% trans %}Public annotations:{% endtrans %}
           </dt>
           <dd class="search-result-sidebar__dd">{{ user.annotation_count }}</dd>
         {% endif %}


### PR DESCRIPTION
…ons ro public annotations.

Change the text that appears next to the annotation count in the user side bar to "Public annotations" instead of "shared annotations" because shared could imply non-public but annotations shared within groups. Public annotations refer to annotations created in the public channel, which is what the count represents.