### PR TITLE
Annotation 'read' permissions delegate to their group

### DIFF
--- a/tests/memex/resources_test.py
+++ b/tests/memex/resources_test.py
@@ -1,9 +1,12 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
+
 from mock import Mock
 import pytest
 
 from pyramid import security
+from pyramid.authorization import ACLAuthorizationPolicy
 
 from memex.resources import AnnotationResourceFactory, AnnotationResource
 
@@ -41,6 +44,7 @@ class TestAnnotationResourceFactory(object):
         return patch('memex.resources.storage')
 
 
+@pytest.mark.usefixtures('groupfinder')
 class TestAnnotationResource(object):
     def test_acl_private(self, factories, pyramid_request):
         ann = factories.Annotation(shared=False, userid='saoirse')
@@ -53,24 +57,78 @@ class TestAnnotationResource(object):
                   security.DENY_ALL]
         assert actual == expect
 
-    def test_acl_world_shared(self, factories, pyramid_request):
-        ann = factories.Annotation(shared=True, userid='saoirse', groupid='__world__')
-        res = AnnotationResource(pyramid_request, ann)
-        actual = res.__acl__()
-        expect = [(security.Allow, security.Everyone, 'read'),
-                  (security.Allow, 'saoirse', 'admin'),
-                  (security.Allow, 'saoirse', 'update'),
-                  (security.Allow, 'saoirse', 'delete'),
-                  security.DENY_ALL]
-        assert actual == expect
+    def test_acl_shared_admin_perms(self, factories, pyramid_request):
+        """
+        Shared annotation resources should still only give admin/update/delete
+        permissions to the owner.
+        """
+        policy = ACLAuthorizationPolicy()
 
-    def test_acl_group_shared(self, factories, pyramid_request):
-        ann = factories.Annotation(shared=True, userid='saoirse', groupid='lulapalooza')
+        ann = factories.Annotation(shared=False, userid='saoirse')
         res = AnnotationResource(pyramid_request, ann)
-        actual = res.__acl__()
-        expect = [(security.Allow, 'group:lulapalooza', 'read'),
-                  (security.Allow, 'saoirse', 'admin'),
-                  (security.Allow, 'saoirse', 'update'),
-                  (security.Allow, 'saoirse', 'delete'),
-                  security.DENY_ALL]
-        assert actual == expect
+
+        for perm in ['admin', 'update', 'delete']:
+            assert policy.permits(res, ['saoirse'], perm)
+            assert not policy.permits(res, ['someoneelse'], perm)
+
+    @pytest.mark.parametrize('groupid,userid,permitted', [
+        ('freeforall', 'jim', True),
+        ('freeforall', 'saoirse', True),
+        ('freeforall', None, True),
+        ('only-saoirse', 'jim', False),
+        ('only-saoirse', 'saoirse', True),
+        ('only-saoirse', None, False),
+        ('pals', 'jim', True),
+        ('pals', 'saoirse', True),
+        ('pals', 'francis', False),
+        ('pals', None, False),
+        ('unknown-group', 'jim', False),
+        ('unknown-group', 'saoirse', False),
+        ('unknown-group', 'francis', False),
+        ('unknown-group', None, False),
+    ])
+    def test_acl_shared(self,
+                        factories,
+                        pyramid_config,
+                        pyramid_request,
+                        groupid,
+                        userid,
+                        permitted):
+        """
+        Shared annotation resources should delegate their 'read' permission to
+        their containing group.
+        """
+        # Set up the test with a dummy authn policy and a real ACL authz
+        # policy:
+        policy = ACLAuthorizationPolicy()
+        pyramid_config.testing_securitypolicy(userid)
+        pyramid_config.set_authorization_policy(policy)
+
+        ann = factories.Annotation(shared=True,
+                                   userid='mioara',
+                                   groupid=groupid)
+        res = AnnotationResource(pyramid_request, ann)
+
+        if permitted:
+            assert pyramid_request.has_permission('read', res)
+        else:
+            assert not pyramid_request.has_permission('read', res)
+
+    @pytest.fixture
+    def groups(self):
+        return {
+            'freeforall': FakeGroup([security.Everyone]),
+            'only-saoirse': FakeGroup(['saoirse']),
+            'pals': FakeGroup(['saoirse', 'jim']),
+        }
+
+    @pytest.fixture
+    def groupfinder(self, groups, patch):
+        groupfinder = patch('memex.resources.groups.find')
+        groupfinder.side_effect = lambda r, groupid: groups.get(groupid)
+        return groupfinder
+
+
+class FakeGroup(object):
+    def __init__(self, principals):
+        self.__acl__ = [(security.Allow, p, 'read') for p in principals]


### PR DESCRIPTION
Instead of hard-coding the principals allowed the annotation 'read' permission based on our existing types of group, delegate the permissions through to the underlying group resource returned by memex.groups.find.

With only two kinds of group, namely,

1. Public (everyone can read)
2. Private (members can read)

computing the annotation ACL was straightforward.

But now we are looking to introduce new kinds of groups where every user with a given authority can read the annotations in a group, or everyone can read annotations in a group despite it not being the "__world__" group.

Now we have to actually fetch the group in question and delegate the 'read' permission on the annotation to those principals permitted the 'read' permission on the containing group.