### PR TITLE
Make SVG icons sharper in Firefox

### DIFF
--- a/h/jinja_extensions.py
+++ b/h/jinja_extensions.py
@@ -74,7 +74,7 @@ class SvgIcon(Extension):
         environment.globals['svg_icon'] = partial(svg_icon, read_icon)
 
 
-def svg_icon(loader, name, css_class='', translate_z=False):
+def svg_icon(loader, name, css_class=''):
     """
     Return inline SVG markup for an icon.
 
@@ -90,10 +90,9 @@ def svg_icon(loader, name, css_class='', translate_z=False):
     :param loader: Callable accepting an icon name and returning XML markup for
                    the SVG.
     :param name: The name of the SVG file to render
-    :param css_class: CSS class attribute for the returned `<svg>` element
-    :param translate_z: Whether or not to apply a hack that fixes blurry SVG
-                        rendering in Firefox
-
+    :param css_class: CSS class attribute for the returned `<svg>` element. The
+                      'svg-icon' class will be added in addition to any classes
+                      specified here.
     """
 
     # Register SVG as the default namespace. This avoids a problem where
@@ -104,14 +103,10 @@ def svg_icon(loader, name, css_class='', translate_z=False):
     root = ElementTree.fromstring(loader(name))
 
     if css_class:
-        root.set('class', css_class)
-
-    if translate_z:
-        # Trigger snapping of the <svg>'s left and top edges to pixel
-        # boundaries in Firefox.
-        # See also https://bugzilla.mozilla.org/show_bug.cgi?id=608812 and
-        # https://github.com/hypothesis/h/pull/4215#issuecomment-267012849
-        root.set('style', 'transform: translateZ(0px)')
+        css_class = 'svg-icon ' + css_class
+    else:
+        css_class = 'svg-icon'
+    root.set('class', css_class)
 
     # If the SVG has its own title, ignore it in favor of the title attribute
     # of the <svg> or its containing element, which is usually a link.

--- a/h/static/styles/partials-v2/_svg-icon.scss
+++ b/h/static/styles/partials-v2/_svg-icon.scss
@@ -1,0 +1,9 @@
+.svg-icon {
+  // This apparently no-op transform triggers snapping of the <svg> element to
+  // the nearest pixel, resulting in sharper rendering of icons, assuming that
+  // the icon itself has been pixel-fitted.
+  //
+  // See also https://bugzilla.mozilla.org/show_bug.cgi?id=608812 and
+  // https://github.com/hypothesis/h/pull/4215#issuecomment-267012849
+  transform: translateX(0);
+}

--- a/h/static/styles/site-v2.scss
+++ b/h/static/styles/site-v2.scss
@@ -26,6 +26,7 @@
 @import 'partials-v2/search-bar';
 @import 'partials-v2/search-result-sidebar';
 @import 'partials-v2/share-widget';
+@import 'partials-v2/svg-icon';
 @import 'partials-v2/tooltip';
 @import 'partials-v2/tabs';
 

--- a/h/templates/includes/logo-header.html.jinja2
+++ b/h/templates/includes/logo-header.html.jinja2
@@ -1,7 +1,7 @@
 <header class="masthead">
   {% if feature('activity_pages') %}
   <a href="/" title="Hypothesis homepage"><!--
-    !-->{{ svg_icon('logo', 'masthead-logo', translate_z=True) }}</a>
+    !-->{{ svg_icon('logo', 'masthead-logo') }}</a>
   {% else %}
   <hgroup>
 	<a href="https://hypothes.is" class="masthead-heading">Hypothes<span class="red">.</span>is</a>

--- a/h/templates/panels/navbar.html.jinja2
+++ b/h/templates/panels/navbar.html.jinja2
@@ -30,7 +30,7 @@
   </template>
   <div class="nav-bar__content">
     <a href="/" title="Hypothesis homepage" class="nav-bar__logo-container"><!--
-      !-->{{ svg_icon('logo', 'nav-bar__logo', translate_z=True) }}</a>
+      !-->{{ svg_icon('logo', 'nav-bar__logo') }}</a>
 
     <div class="nav-bar__search js-search-bar" data-ref="searchBar">
       <form class="search-bar"

--- a/tests/h/jinja_extension_test.py
+++ b/tests/h/jinja_extension_test.py
@@ -7,6 +7,7 @@ import pytest
 
 from h import jinja_extensions as ext
 
+
 @pytest.mark.parametrize("value_in,json_out", [
     ({"foo": 42}, "{\"foo\": 42}"),
 
@@ -44,7 +45,7 @@ def test_svg_icon_loads_icon():
 
     result = ext.svg_icon(read_icon, 'settings')
 
-    assert result == Markup('<svg id="settings" />')
+    assert result == Markup('<svg class="svg-icon" id="settings" />')
 
 
 def test_svg_icon_removes_title():
@@ -52,7 +53,7 @@ def test_svg_icon_removes_title():
         return '<svg xmlns="http://www.w3.org/2000/svg"><title>foo</title></svg>'
 
     assert (ext.svg_icon(read_icon, 'icon') ==
-        Markup('<svg xmlns="http://www.w3.org/2000/svg" />'))
+            Markup('<svg xmlns="http://www.w3.org/2000/svg" class="svg-icon" />'))
 
 
 def test_svg_icon_strips_default_xml_namespace():
@@ -60,7 +61,7 @@ def test_svg_icon_strips_default_xml_namespace():
         return '<svg xmlns="http://www.w3.org/2000/svg"></svg>'
 
     assert (ext.svg_icon(read_icon, 'icon') ==
-        Markup('<svg xmlns="http://www.w3.org/2000/svg" />'))
+            Markup('<svg xmlns="http://www.w3.org/2000/svg" class="svg-icon" />'))
 
 
 def test_svg_icon_sets_css_class():
@@ -69,22 +70,4 @@ def test_svg_icon_sets_css_class():
 
     result = ext.svg_icon(read_icon, 'icon', css_class='fancy-icon')
 
-    assert result == Markup('<svg class="fancy-icon" />')
-
-
-def test_svg_icon_does_not_set_transform_by_default():
-    def read_icon(name):
-        return '<svg></svg>'
-
-    result = ext.svg_icon(read_icon, 'icon')
-
-    assert result == Markup('<svg />')
-
-
-def test_svg_icon_sets_transform_when_asked_to():
-    def read_icon(name):
-        return '<svg></svg>'
-
-    result = ext.svg_icon(read_icon, 'icon', translate_z=True)
-
-    assert result == Markup('<svg style="transform: translateZ(0px)" />')
+    assert result == Markup('<svg class="svg-icon fancy-icon" />')


### PR DESCRIPTION
Apply a null transform to all SVG icons to force the <svg> element to be
snapped to the nearest pixel when rendered, matching Chrome's behavior,
and thus appear sharper.

Previously the transform hack was applied only to specific icons in
order to avoid creating large numbers of new layers [1].

However, it turns out that pixel snapping is triggered by an element
having an active transform, rather than by elements having their own
layer, so we can use `transformX` (which does not trigger layer creation) instead of `transformZ`.

[1] https://aerotwist.com/blog/on-translate3d-and-layer-creation-hacks/

**Before**

![firefox-no-snapping](https://cloud.githubusercontent.com/assets/2458/21311092/5503b066-c5dd-11e6-9937-ae7074a74d0a.png)

**After**

![firefox-with-snapping](https://cloud.githubusercontent.com/assets/2458/21311093/58a85596-c5dd-11e6-80b4-3a30cb6f6567.png)

To see the effect more visibly, toggle all the rules for the "svg-icon" class off/on and look at the logo in the navbar.

----

Testing Notes: To see what layers are actually created in the browser, enable the "Layer borders" rendering option in Chrome (see https://developer.chrome.com/devtools/docs/rendering-settings) or the "layers.draw-borders" debug flag in Firefox (under about:config).

You can see that before this PR, a border is drawn around the logo in the navbar in Chrome, but not afterwards.
