### PR TITLE
Use the version of MutableList shipped with SQLAlchemy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ CLASSIFIERS = [
     'Programming Language :: Python :: 2.7',
 ]
 INSTALL_REQUIRES = [
-    'SQLAlchemy>=1.0.13',
+    'SQLAlchemy>=1.1.0',
     'bleach>=1.4.3,<1.5',
     'certifi',
     'elasticsearch>=1.1.0,<2.0.0',

--- a/src/memex/db/types.py
+++ b/src/memex/db/types.py
@@ -9,7 +9,6 @@ import uuid
 from sqlalchemy import types
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.exc import DontWrapMixin
-from sqlalchemy.ext.mutable import Mutable
 
 
 # A magic byte (expressed as two hexadecimal nibbles) which we use to expand a
@@ -64,81 +63,6 @@ class URLSafeUUID(types.TypeDecorator):
             return None
         hexstring = uuid.UUID(value).hex
         return _get_urlsafe_from_hex(hexstring)
-
-
-# This class can be deleted when we upgrade to SQLAlchemy 1.1 which adds
-# sqlalchemy.ext.mutable.MutableList.
-class MutableList(Mutable, list):
-
-    """
-    A list subclass that persists in-place changes.
-
-    If you use a normal list as an attribute of an ORM class then in-place
-    changes to the list won't be persisted to the session, so use this class
-    instead.
-
-    To use this class wrap another list-like type in this class's as_mutable()
-    class method when declaring a column:
-
-        my_array_column = sa.Column(
-            MutableList.as_mutable(pg.Array(sa.UnicodeText)))
-
-    See: http://docs.sqlalchemy.org/en/rel_1_0/orm/extensions/mutable.html
-    """
-
-    @classmethod
-    def coerce(cls, key, value):
-        if not isinstance(value, MutableList):
-            if isinstance(value, list):
-                return MutableList(value)
-            return Mutable.coerce(key, value)
-        else:
-            return value
-
-    def __setitem__(self, idx, value):
-        list.__setitem__(self, idx, value)
-        self.changed()
-
-    def __setslice__(self, start, stop, values):
-        list.__setslice__(self, start, stop, values)
-        self.changed()
-
-    def __delitem__(self, idx):
-        list.__delitem__(self, idx)
-        self.changed()
-
-    def __delslice__(self, start, stop):
-        list.__delslice__(self, start, stop)
-        self.changed()
-
-    def append(self, value):
-        list.append(self, value)
-        self.changed()
-
-    def insert(self, idx, value):
-        list.insert(self, idx, value)
-        self.changed()
-
-    def extend(self, values):
-        list.extend(self, values)
-        self.changed()
-
-    def pop(self, *args, **kw):
-        value = list.pop(self, *args, **kw)
-        self.changed()
-        return value
-
-    def remove(self, value):
-        list.remove(self, value)
-        self.changed()
-
-    def sort(self, *args, **kwargs):
-        list.sort(self, *args, **kwargs)
-        self.changed()
-
-    def reverse(self):
-        list.reverse(self)
-        self.changed()
 
 
 class AnnotationSelectorJSONB(types.TypeDecorator):

--- a/src/memex/models/annotation.py
+++ b/src/memex/models/annotation.py
@@ -7,7 +7,7 @@ import datetime
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql as pg
 from sqlalchemy.ext.hybrid import hybrid_property
-from sqlalchemy.ext.mutable import MutableDict
+from sqlalchemy.ext.mutable import MutableDict, MutableList
 
 from memex import markdown
 from memex import uri
@@ -67,10 +67,10 @@ class Annotation(Base):
     _text = sa.Column('text', sa.UnicodeText)
     #: The Markdown-rendered and HTML-sanitized textual body of the annotation.
     _text_rendered = sa.Column('text_rendered', sa.UnicodeText)
+
     #: The tags associated with the annotation.
-    tags = sa.Column(
-        types.MutableList.as_mutable(
-            pg.ARRAY(sa.UnicodeText, zero_indexes=True)))
+    tags = sa.Column(MutableList.as_mutable(pg.ARRAY(sa.UnicodeText,
+                                                     zero_indexes=True)))
 
     #: A boolean indicating whether this annotation is shared with members of
     #: the group it is published in. "Private"/"Only me" annotations have

--- a/tests/memex/db/types_test.py
+++ b/tests/memex/db/types_test.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-import mock
 import pytest
 
 from sqlalchemy.dialects.postgresql import dialect
@@ -110,51 +109,3 @@ def test_annotation_selector_deserialize_missing_text_quote_selector():
         'endoffset': 1
     }]
     assert t.process_result_value(selectors, dialect) == selectors
-
-
-class TestMutableList(object):
-
-    @mock.patch.object(types.Mutable, 'changed')
-    @pytest.mark.parametrize('operation', [
-        lambda l: l.__setitem__(0, 'value'),
-        lambda l: l.__setslice__(1, 3, ['a', 'b']),
-        lambda l: l.__delitem__(0),
-        lambda l: l.__delslice__(1, 3),
-        lambda l: l.append('value'),
-        lambda l: l.insert(0, 'value'),
-        lambda l: l.extend(['value']),
-        lambda l: l.pop(),
-        lambda l: l.remove(1),
-        lambda l: l.sort(),
-        lambda l: l.reverse(),
-    ])
-    def test_it_calls_changed(self, changed, operation):
-        list_ = types.MutableList([1, 2, 3])
-        assert not changed.called
-
-        operation(list_)
-
-        changed.assert_called_once_with()
-
-    @pytest.mark.parametrize('operation,expected_result', [
-        (lambda l: l.__setitem__(0, 'value'), ['value', 3, 2]),
-        (lambda l: l.__setslice__(1, 3, ['a', 'b']), [1, 'a', 'b']),
-        (lambda l: l.__delitem__(0), [3, 2]),
-        (lambda l: l.__delslice__(1, 3), [1]),
-        (lambda l: l.append('value'), [1, 3, 2, 'value']),
-        (lambda l: l.insert(0, 'value'), ['value', 1, 3, 2]),
-        (lambda l: l.extend(['value']), [1, 3, 2, 'value']),
-        (lambda l: l.pop(), [1, 3]),
-        (lambda l: l.remove(1), [3, 2]),
-        (lambda l: l.sort(), [1, 2, 3]),
-        (lambda l: l.reverse(), [2, 3, 1]),
-    ])
-    def test_it_mutates_the_list(self, operation, expected_result):
-        list_ = types.MutableList([1, 3, 2])
-
-        operation(list_)
-
-        assert list_ == expected_result
-
-    def test_pop_returns_the_popped_value(self):
-        assert types.MutableList(['value']).pop() == 'value'


### PR DESCRIPTION
When we first added support for in-place mutation of the Annotation tags field, SQLAlchemy 1.1 hadn't yet been released, so we needed to copy their implementation of MutableList into our code.

SQLAlchemy 1.1 has since been released, and we're already using it in production.

This commit removes our "vendored" copy of MutableList in favour of using the one in sqlalchemy.ext.mutable.

This ensures that in-place changes to the tags list will be detected by the session:

     $ hypothesis --dev shell

     ...

     In [1]: ann = session.query(m.Annotation).first()

     In [2]: ann
     Out[2]: <Annotation 3WOBzPqXRH2n4wvubCPh7g>

     In [3]: ann.tags
     Out[3]: [u'3860']

     In [4]: session.dirty
     Out[4]: IdentitySet([])

     In [5]: ann.tags.append('helo')

     In [6]: session.dirty
     Out[6]: IdentitySet([<Annotation 3WOBzPqXRH2n4wvubCPh7g>])