### PR TITLE
Add focus state to lozenge removal button

### DIFF
--- a/h/static/images/icons/lozenge-close.svg
+++ b/h/static/images/icons/lozenge-close.svg
@@ -5,7 +5,7 @@
     <desc>Created with Sketch.</desc>
     <defs></defs>
     <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="Artboard" fill="#3F3F3F">
+        <g id="Artboard" fill="currentColor">
             <polygon id="Combined-Shape" points="3.58578644 5 1.29289322 7.29289322 0.585786438 8 2 9.41421356 2.70710678 8.70710678 5 6.41421356 7.29289322 8.70710678 8 9.41421356 9.41421356 8 8.70710678 7.29289322 6.41421356 5 8.70710678 2.70710678 9.41421356 2 8 0.585786438 7.29289322 1.29289322 5 3.58578644 2.70710678 1.29289322 2 0.585786438 0.585786438 2 1.29289322 2.70710678"></polygon>
         </g>
     </g>

--- a/h/static/styles/partials-v2/_lozenge.scss
+++ b/h/static/styles/partials-v2/_lozenge.scss
@@ -26,6 +26,7 @@
 .lozenge__close {
   @include reset-button;
 
+  color: $grey-6;
   font-weight: bold;
   padding: 0px 5px 0px 5px;
   cursor: default;
@@ -33,6 +34,11 @@
 
   &:hover {
     background-color: $grey-4;
+  }
+
+  &:focus {
+    background-color: $grey-6;
+    color: white;
   }
 }
 


### PR DESCRIPTION
Add focus state to lozenge removal button so that it is obvious when a
particular lozenge's remove button has keyboard focus (also applies when remove button is pressed).

Lozenge where close button has keyboard focus:

----

**Before:**

![lozenge-focus-before](https://cloud.githubusercontent.com/assets/2458/21311598/e2ef40dc-c5df-11e6-9735-a94193d7286a.png)

**After:**

![lozenge-focus-after](https://cloud.githubusercontent.com/assets/2458/21311604/ebfe7b02-c5df-11e6-821d-9fddee53da40.png)
