### PR TITLE
Mark annotations as deleted in search index

### DIFF
--- a/src/memex/search/core.py
+++ b/src/memex/search/core.py
@@ -147,6 +147,7 @@ class Search(object):
 
 def default_querybuilder(request):
     builder = query.Builder()
+    builder.append_filter(query.DeletedFilter())
     builder.append_filter(query.AuthFilter(request))
     builder.append_filter(query.UriFilter(request))
     builder.append_filter(query.GroupFilter())

--- a/src/memex/search/index.py
+++ b/src/memex/search/index.py
@@ -59,10 +59,10 @@ def index(es, annotation, request):
 
 def delete(es, annotation_id):
     """
-    Delete an annotation from the search index.
+    Mark an annotation as deleted in the search index.
 
-    If no annotation with the given annotation's ID exists in the search index,
-    just log the resulting elasticsearch exception (don't crash).
+    This will write a new body that only contains the ``deleted`` boolean field
+    with the value ``true``.
 
     :param es: the Elasticsearch client object to use
     :type es: memex.search.Client
@@ -72,15 +72,11 @@ def delete(es, annotation_id):
     :type annotation_id: str
 
     """
-    try:
-        es.conn.delete(
-            index=es.index,
-            doc_type=es.t.annotation,
-            id=annotation_id,
-        )
-    except elasticsearch.NotFoundError:
-        log.exception('Tried to delete a nonexistent annotation from the '
-                      'search index, annotation id: %s', annotation_id)
+    es.conn.index(
+        index=es.index,
+        doc_type=es.t.annotation,
+        body={'deleted': True},
+        id=annotation_id)
 
 
 def reindex(session, es, request):

--- a/src/memex/search/query.py
+++ b/src/memex/search/query.py
@@ -200,6 +200,19 @@ class UserFilter(object):
         return {'terms': {'user': users}}
 
 
+class DeletedFilter(object):
+
+    """
+    A filter that only returns non-deleted documents.
+
+    Documents are not getting deleted from the index, they only get marked as
+    deleted.
+    """
+
+    def __call__(self, _):
+        return {"bool": {"must_not": {"exists": {"field": "deleted"}}}}
+
+
 class AnyMatcher(object):
 
     """

--- a/tests/memex/search/core_test.py
+++ b/tests/memex/search/core_test.py
@@ -259,6 +259,7 @@ class TestSearch(object):
 
 
 @pytest.mark.parametrize('filter_type', [
+    'DeletedFilter',
     'AuthFilter',
     'UriFilter',
     'UserFilter',

--- a/tests/memex/search/index_test.py
+++ b/tests/memex/search/index_test.py
@@ -68,29 +68,17 @@ class TestIndexAnnotation:
         return presenters
 
 
-@pytest.mark.usefixtures('log')
 class TestDeleteAnnotation:
 
-    def test_it_deletes_the_annotation(self, es):
+    def test_it_marks_annotation_as_deleted(self, es):
         index.delete(es, 'test_annotation_id')
 
-        es.conn.delete.assert_called_once_with(
+        es.conn.index.assert_called_once_with(
             index='hypothesis',
             doc_type='annotation',
-            id='test_annotation_id',
+            body={'deleted': True},
+            id='test_annotation_id'
         )
-
-    def test_it_logs_NotFoundErrors(self, es, log):
-        """NotFoundErrors from elasticsearch should be caught and logged."""
-        es.conn.delete.side_effect = elasticsearch.NotFoundError()
-
-        index.delete(es, mock.Mock())
-
-        assert log.exception.called
-
-    @pytest.fixture
-    def log(self, patch):
-        return patch('memex.search.index.log')
 
 
 @pytest.mark.usefixtures('BatchIndexer',

--- a/tests/memex/search/query_test.py
+++ b/tests/memex/search/query_test.py
@@ -423,6 +423,15 @@ class TestUserFilter(object):
         assert userfilter({}) is None
 
 
+class TestDeletedFilter(object):
+    def test_filter(self):
+        deletedfilter = query.DeletedFilter()
+
+        assert deletedfilter({}) == {
+            "bool": {"must_not": {"exists": {"field": "deleted"}}}
+        }
+
+
 class TestAnyMatcher():
     def test_any_query(self):
         anymatcher = query.AnyMatcher()


### PR DESCRIPTION
Part of hypothesis/product-backlog#106.

This makes sure that we don't delete annotations from the search index, but rather mark them as deleted. These annotations then need to be filtered out when we query the index.