### PR TITLE
Use op_type "create" when reindexing

### DIFF
--- a/src/memex/search/index.py
+++ b/src/memex/search/index.py
@@ -108,10 +108,11 @@ class BatchIndexer(object):
     the search index.
     """
 
-    def __init__(self, session, es_client, request, target_index=None):
+    def __init__(self, session, es_client, request, target_index=None, op_type='index'):
         self.session = session
         self.es_client = es_client
         self.request = request
+        self.op_type = op_type
 
         # By default, index into the open index
         if target_index is None:
@@ -141,13 +142,13 @@ class BatchIndexer(object):
         errored = set()
         for ok, item in indexing:
             if not ok:
-                errored.add(item['index']['_id'])
+                errored.add(item[self.op_type]['_id'])
         return errored
 
     def _prepare(self, annotation):
-        action = {'index': {'_index': self._target_index,
-                            '_type': self.es_client.t.annotation,
-                            '_id': annotation.id}}
+        action = {self.op_type: {'_index': self._target_index,
+                                 '_type': self.es_client.t.annotation,
+                                 '_id': annotation.id}}
         data = presenters.AnnotationSearchIndexPresenter(annotation).asdict()
 
         event = AnnotationTransformEvent(self.request, data)

--- a/src/memex/search/index.py
+++ b/src/memex/search/index.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 
 import itertools
 import logging
+import re
 from collections import namedtuple
 
 import elasticsearch
@@ -142,7 +143,10 @@ class BatchIndexer(object):
         errored = set()
         for ok, item in indexing:
             if not ok:
-                errored.add(item[self.op_type]['_id'])
+                status = item[self.op_type]
+                if self.op_type != 'create' and \
+                        not re.match('^.*document already exists', status['error']):
+                    errored.add(status['_id'])
         return errored
 
     def _prepare(self, annotation):


### PR DESCRIPTION
This is part of hypothesis/product-backlog#106.

The indexer workers will soon write to both the current and the new index during a re-index operation. To ensure that the re-indexer doesn't override any annotations already in the index with potentially old data we will set the Elasticsearch `op_type` to `"create"`. This means that indexing a document that already exists in the index will fail with an error. Since these errors are expected we will not return them to the caller.