### PR TITLE
Show private and group annotation count if user is looking at their o…

### DIFF
--- a/h/services/__init__.py
+++ b/h/services/__init__.py
@@ -6,6 +6,7 @@ from __future__ import unicode_literals
 
 
 def includeme(config):
+    config.register_service_factory('.annotation_stats.annotation_stats_factory', name='annotation_stats')
     config.register_service_factory('.auth_ticket.auth_ticket_service_factory',
                                     iface='pyramid_authsanity.interfaces.IAuthService')
     config.register_service_factory('.group.groups_factory', name='group')

--- a/h/services/annotation_stats.py
+++ b/h/services/annotation_stats.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+
+import sqlalchemy as sa
+
+from h.models import Annotation
+
+
+class AnnotationStatsService(object):
+    """A service for retrieving annotation stats for users and groups."""
+
+    def __init__(self, session):
+        self.session = session
+
+    def user_annotation_counts(self, userid):
+        """Return the count of annotations for this user."""
+
+        annotations = self.session.query(Annotation).filter_by(userid=userid).options(sa.orm.load_only('groupid', 'shared')).subquery()
+        grouping = sa.case([
+            (sa.not_(annotations.c.shared), 'private'),
+            (annotations.c.groupid == '__world__', 'public'),
+        ], else_='group')
+        return dict(self.session.query(grouping, sa.func.count(annotations.c.id)).group_by(grouping).all())
+
+    def group_annotation_count(self, pubid):
+        """
+        Return the count of shared annotations for this group.
+        """
+
+        return (
+            self.session.query(Annotation)
+            .filter_by(groupid=pubid, shared=True)
+            .count())
+
+
+def annotation_stats_factory(context, request):
+    """Return an AnnotationStatsService instance for the passed context and request."""
+    return AnnotationStatsService(session=request.db)

--- a/h/services/group.py
+++ b/h/services/group.py
@@ -94,16 +94,6 @@ class GroupService(object):
         if self.publish:
             self.publish('group-leave', group.pubid, userid)
 
-    def annotation_count(self, pubid):
-        """
-        Return the count of shared annotations for this group.
-        """
-
-        return (
-            self.session.query(Annotation)
-            .filter_by(groupid=pubid, shared=True)
-            .count())
-
     def groupids_readable_by(self, user):
         """
         Return a list of pubids for which the user has read access.

--- a/h/services/user.py
+++ b/h/services/user.py
@@ -110,16 +110,6 @@ class UserService(object):
 
         return None
 
-    def annotation_count(self, userid):
-        """
-        Return the count of shared annotations for this user.
-        """
-
-        return (
-            self.session.query(Annotation)
-            .filter_by(userid=userid, groupid='__world__',  shared=True)
-            .count())
-
 
 def user_service_factory(context, request):
     """Return a UserService instance for the passed context and request."""

--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -176,15 +176,15 @@
 </aside>
 {% endmacro %}
 
-{% macro group_sidebar(group, group_edit_url, total) %}
+{% macro group_sidebar(group, group_edit_url, total, stats) %}
   {% call sidebar(group.name, group.description) %}
     <section class="search-result-sidebar__section">
       <dl>
-        {% if group.annotation_count  %}
+        {% if stats.annotation_count  %}
           <dt class="search-result-sidebar__dt">
             {% trans %}Shared annotations:{% endtrans %}
           </dt>
-          <dd class="search-result-sidebar__dd">{{ group.annotation_count }}</dd>
+          <dd class="search-result-sidebar__dd">{{ stats.annotation_count }}</dd>
         {% endif %}
         <dt class="search-result-sidebar__dt">
           {% trans %}Created:{% endtrans %}
@@ -270,15 +270,15 @@
   {% endcall %}
 {% endmacro %}
 
-{% macro user_sidebar(user) %}
+{% macro user_sidebar(user, stats) %}
   {% call sidebar(user.name, user.description) %}
     <section class="search-result-sidebar__section">
       <dl>
-        {% if user.annotation_count %}
+        {% if stats.annotation_count %}
           <dt class="search-result-sidebar__dt">
-            {% trans %}Public annotations:{% endtrans %}
+            {% trans %}Annotations:{% endtrans %}
           </dt>
-          <dd class="search-result-sidebar__dd">{{ user.annotation_count }}</dd>
+          <dd class="search-result-sidebar__dd">{{ stats.annotation_count }}</dd>
         {% endif %}
 
         <dt class="search-result-sidebar__dt">
@@ -420,9 +420,9 @@
     {% endif %}
 
     {% if group %}
-      {{ group_sidebar(group, group_edit_url, search_results.total) }}
+      {{ group_sidebar(group, group_edit_url, search_results.total, stats) }}
     {% elif user %}
-      {{ user_sidebar(user) }}
+      {{ user_sidebar(user, stats) }}
     {% endif %}
 
     <div class="js-share-widget is-hidden-when-loading">

--- a/tests/h/services/annotation_stats_test.py
+++ b/tests/h/services/annotation_stats_test.py
@@ -10,7 +10,7 @@ from h.services.annotation_stats import annotation_stats_factory
 
 
 class TestAnnotationStatsService(object):
-    def test_user_annotation_counts_returns_count_of_annotations_for_user(self, svc, factories, db_session):
+    def test_user_annotation_counts_returns_count_of_annotations_for_user(self, svc, factories):
         userid = '123'
         for i in range(3):
             factories.Annotation(userid=userid, shared=True)
@@ -25,7 +25,7 @@ class TestAnnotationStatsService(object):
         assert results['private'] == 2
         assert results['group'] == 4
 
-    def test_annotation_count_returns_count_of_shared_annotations_for_group(self, svc, db_session, factories):
+    def test_annotation_count_returns_count_of_shared_annotations_for_group(self, svc, factories):
         pubid = 'abc123'
         for i in range(3):
             factories.Annotation(groupid=pubid, shared=True)

--- a/tests/h/services/annotation_stats_test.py
+++ b/tests/h/services/annotation_stats_test.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import mock
+import pytest
+
+from h.services.annotation_stats import AnnotationStatsService
+from h.services.annotation_stats import annotation_stats_factory
+
+
+class TestAnnotationStatsService(object):
+    def test_user_annotation_counts_returns_count_of_annotations_for_user(self, svc, factories, db_session):
+        userid = '123'
+        for i in range(3):
+            factories.Annotation(userid=userid, shared=True)
+        for i in range(2):
+            factories.Annotation(userid=userid, shared=False)
+        for i in range(4):
+            factories.Annotation(userid=userid, groupid='abc', shared=True)
+
+        results = svc.user_annotation_counts(userid)
+
+        assert results['public'] == 3
+        assert results['private'] == 2
+        assert results['group'] == 4
+
+    def test_annotation_count_returns_count_of_shared_annotations_for_group(self, svc, db_session, factories):
+        pubid = 'abc123'
+        for i in range(3):
+            factories.Annotation(groupid=pubid, shared=True)
+        for i in range(2):
+            factories.Annotation(groupid=pubid, shared=False)
+
+        assert svc.group_annotation_count(pubid) == 3
+
+
+class TestAnnotationStatsFactory(object):
+    def test_returns_service(self):
+        svc = annotation_stats_factory(mock.Mock(), mock.Mock())
+
+        assert isinstance(svc, AnnotationStatsService)
+
+    def test_sets_session(self):
+        request = mock.Mock()
+        svc = annotation_stats_factory(mock.Mock(), request)
+
+        assert svc.session == request.db
+
+
+@pytest.fixture
+def svc(db_session):
+    return AnnotationStatsService(session=db_session)

--- a/tests/h/services/group_test.py
+++ b/tests/h/services/group_test.py
@@ -162,18 +162,6 @@ class TestGroupService(object):
 
         publish.assert_called_once_with('group-leave', 'abc123', 'cazimir')
 
-    def test_annotation_count_returns_count_of_shared_annotations_for_group(self, db_session, users, factories):
-        svc = GroupService(db_session, users.get)
-        group = Group(name='Donkey Trust',
-                      authority='foobari.com',
-                      creator=users['theresa'])
-        group.pubid = 'abc123'
-        for i in range(3):
-            factories.Annotation(groupid=group.pubid, shared=True)
-        for i in range(2):
-            factories.Annotation(groupid=group.pubid, shared=False)
-
-        assert svc.annotation_count(group.pubid) == 3
 
     @pytest.mark.parametrize('with_user', [True, False])
     def test_groupids_readable_by_includes_world(self, with_user, service, db_session, factories):

--- a/tests/h/services/user_test.py
+++ b/tests/h/services/user_test.py
@@ -47,17 +47,6 @@ class TestUserService(object):
 
         assert user is None
 
-    def test_annotation_count_returns_count_of_shared_annotations_for_user(self, svc, users, factories, db_session):
-        _, steve, _ = users
-        for i in range(3):
-            factories.Annotation(userid=steve.userid, shared=True)
-        for i in range(2):
-            factories.Annotation(userid=steve.userid, shared=False)
-        for i in range(4):
-            factories.Annotation(userid=steve.userid, groupid='abc', shared=True)
-
-        assert svc.annotation_count(steve.userid) == 3
-
     def test_login_by_username(self, svc, users):
         _, steve, _ = users
         assert svc.login('steve', 'stevespassword') is steve

--- a/tests/h/views/activity_test.py
+++ b/tests/h/views/activity_test.py
@@ -12,7 +12,7 @@ from h.activity.query import ActivityResults
 from h.views import activity
 
 
-@pytest.mark.usefixtures('paginate', 'query', 'routes')
+@pytest.mark.usefixtures('annotation_stats_service', 'paginate', 'query', 'routes')
 class TestSearchController(object):
 
     def test_init_returns_404_when_feature_turned_off(self, pyramid_request):
@@ -115,7 +115,7 @@ class TestSearchController(object):
         return pyramid_request
 
 
-@pytest.mark.usefixtures('group_service', 'routes', 'search')
+@pytest.mark.usefixtures('annotation_stats_service', 'group_service', 'routes', 'search')
 class TestGroupSearchController(object):
 
     """Tests unique to GroupSearchController."""
@@ -372,28 +372,26 @@ class TestGroupSearchController(object):
         assert isinstance(result, httpexceptions.HTTPSeeOther)
         assert result.location == 'http://example.com/search?q=foo+bar+gar'
 
-    def test_search_passes_the_annotation_count_to_the_template(self,
-                                                                controller,
-                                                                search,
-                                                                group,
-                                                                group_service,
-                                                                pyramid_request):
+    def test_search_passes_the_group_annotation_count_to_the_template(self,
+                                                                      controller,
+                                                                      group,
+                                                                      pyramid_request):
         pyramid_request.authenticated_user = group.members[-1]
-        controller.search()
+        result = controller.search()['stats']
 
-        group_service.annotation_count.assert_called_once_with(group.pubid)
+        assert result['annotation_count'] == 5
 
-    def test_search_does_not_pass_annotation_count_to_the_template_when_flag_is_disabled(self,
-                                                                                         controller,
-                                                                                         search,
-                                                                                         group,
-                                                                                         group_service,
-                                                                                         pyramid_request):
+    def test_search_does_not_pass_annotation_count_to_the_template(self,
+                                                                   controller,
+                                                                   group,
+                                                                   pyramid_request):
+        """ It should not pass the annotation count to the view when the feature flag is turned off."""
+
         pyramid_request.authenticated_user = group.members[-1]
         pyramid_request.feature.flags['total_shared_annotations'] = False
-        controller.search()
+        result = controller.search()['stats']
 
-        assert group_service.annotation_count.called is False
+        assert result['annotation_count'] is None
 
     @pytest.mark.parametrize('q', ['', '   '])
     def test_leave_removes_empty_query_from_url(self,
@@ -542,7 +540,7 @@ class TestGroupSearchController(object):
         return pyramid_request
 
 
-@pytest.mark.usefixtures('user_service', 'routes', 'search')
+@pytest.mark.usefixtures('annotation_stats_service', 'user_service', 'routes', 'search')
 class TestUserSearchController(object):
 
     """Tests unique to UserSearchController."""
@@ -594,25 +592,42 @@ class TestUserSearchController(object):
 
         assert username == user.display_name
 
-    def test_search_passes_the_annotation_count_to_the_template(self,
-                                                                controller,
-                                                                search,
-                                                                user,
-                                                                user_service):
-        controller.search()
+    def test_search_passes_the_user_annotation_counts_to_the_template(self,
+                                                                      controller,
+                                                                      pyramid_config,
+                                                                      user):
+        pyramid_config.testing_securitypolicy(user.userid)
 
-        user_service.annotation_count.assert_called_once_with(user.userid)
+        stats = controller.search()['stats']
 
-    def test_search_does_not_pass_the_annotation_count_to_the_template_when_flag_is_disabled(self,
-                                                                                             controller,
-                                                                                             search,
-                                                                                             user,
-                                                                                             user_service,
-                                                                                             pyramid_request):
+        assert stats['annotation_count'] == 6
+
+    def test_search_does_not_pass_the_user_annotation_counts_to_the_template(self,
+                                                                             controller,
+                                                                             pyramid_request):
+        """ It should not pass the annotation counts to the view when the feature flag is turned off."""
+
         pyramid_request.feature.flags['total_shared_annotations'] = False
-        controller.search()
+        result = controller.search()['stats']
 
-        assert user_service.annotation_count.called == False
+        assert result['annotation_count'] is None
+
+    def test_search_passes_public_annotation_counts_to_the_template(self,
+                                                                    controller,
+                                                                    factories,
+                                                                    pyramid_config,
+                                                                    pyramid_request):
+        """
+        The annotation count passed to the view should not include private and group annotation counts
+        if the user whose page we are on is different from the authenticated user.
+
+        """
+        pyramid_request.feature.flags['total_shared_annotations'] = True
+        pyramid_config.testing_securitypolicy(factories.User().userid)
+
+        stats = controller.search()['stats']
+
+        assert stats['annotation_count'] == 1
 
     def test_search_passes_the_other_user_details_to_the_template(self,
                                                                   controller,
@@ -886,6 +901,14 @@ class TestGroupAndUserSearchController(object):
         return activity.UserSearchController(user, pyramid_request)
 
 
+class FakeAnnotationStatsService(object):
+    def user_annotation_counts(self, userid):
+        return {'public': 1, 'private': 3, 'group': 2}
+
+    def group_annotation_count(self, pubid):
+        return 5
+
+
 @pytest.fixture
 def group(factories):
     # Create some other groups as well, just to make sure it gets the right
@@ -918,6 +941,11 @@ def routes(pyramid_config):
     pyramid_config.add_route('group_read', '/groups/{pubid}/{slug}')
     pyramid_config.add_route('group_edit', '/groups/{pubid}/edit')
     pyramid_config.add_route('account_profile', '/account/profile')
+
+
+@pytest.fixture
+def annotation_stats_service(pyramid_config):
+    pyramid_config.register_service(FakeAnnotationStatsService(), name='annotation_stats')
 
 
 @pytest.fixture


### PR DESCRIPTION
…wn profile.

We want the user to see their total number of private annotations as well as the number of shared annotations they have made in groups while viewing their own profile.

I have the following questions:
1. Does the query to retrieve annotations also include notes?
2. Is there a better way to retrieve the total number of shared annotations across groups for a user?
3. Should we use the same feature flag 'total_shared_annotations' be used for private and group annotations as well?

https://github.com/hypothesis/h/issues/4168