### PR TITLE
Don't delete annotations synchronously

### DIFF
--- a/h/celery.py
+++ b/h/celery.py
@@ -34,12 +34,12 @@ celery.conf.update(
     BROKER_URL=os.environ.get('CELERY_BROKER_URL',
         os.environ.get('BROKER_URL', 'amqp://guest:guest@localhost:5672//')),
     CELERYBEAT_SCHEDULE={
-        'delete-expired-authtickets': {
-            'task': 'h.tasks.auth.delete_expired_auth_tickets',
+        'purge-expired-authtickets': {
+            'task': 'h.tasks.cleanup.purge_expired_auth_tickets',
             'schedule': timedelta(hours=1)
         },
-        'delete-expired-tokens': {
-            'task': 'h.tasks.auth.delete_expired_tokens',
+        'purge-expired-tokens': {
+            'task': 'h.tasks.cleanup.purge_expired_tokens',
             'schedule': timedelta(hours=1)
         },
     },
@@ -52,7 +52,7 @@ celery.conf.update(
     CELERY_IGNORE_RESULT=True,
     CELERY_IMPORTS=(
         'h.tasks.admin',
-        'h.tasks.auth',
+        'h.tasks.cleanup',
         'h.tasks.indexer',
         'h.tasks.mailer',
         'h.tasks.nipsa',

--- a/h/celery.py
+++ b/h/celery.py
@@ -34,6 +34,10 @@ celery.conf.update(
     BROKER_URL=os.environ.get('CELERY_BROKER_URL',
         os.environ.get('BROKER_URL', 'amqp://guest:guest@localhost:5672//')),
     CELERYBEAT_SCHEDULE={
+        'purge-deleted-annotations': {
+            'task': 'h.tasks.cleanup.purge_deleted_annotations',
+            'schedule': timedelta(hours=1)
+        },
         'purge-expired-authtickets': {
             'task': 'h.tasks.cleanup.purge_expired_auth_tickets',
             'schedule': timedelta(hours=1)

--- a/h/migrations/versions/9cbc5c5ad23d_fill_in_missing_annotation_deleted.py
+++ b/h/migrations/versions/9cbc5c5ad23d_fill_in_missing_annotation_deleted.py
@@ -1,0 +1,28 @@
+"""
+Fill in missing Annotation.deleted
+
+Revision ID: 9cbc5c5ad23d
+Revises: 5bfdfde681ea
+Create Date: 2016-12-19 12:41:25.269188
+"""
+
+from __future__ import unicode_literals
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = '9cbc5c5ad23d'
+down_revision = '5bfdfde681ea'
+
+annotation = sa.table('annotation', sa.column('deleted', sa.Boolean))
+
+
+def upgrade():
+    op.execute(annotation
+               .update()
+               .where(annotation.c.deleted == None)
+               .values(deleted=False))
+
+
+def downgrade():
+    pass

--- a/h/migrations/versions/f0f42ffaa27d_add_annotation_deleted_constraints.py
+++ b/h/migrations/versions/f0f42ffaa27d_add_annotation_deleted_constraints.py
@@ -1,0 +1,30 @@
+"""
+Add constraints and defaults to annotation deleted column
+
+Revision ID: f0f42ffaa27d
+Revises: 9cbc5c5ad23d
+Create Date: 2016-12-19 14:06:37.956780
+"""
+
+from __future__ import unicode_literals
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = 'f0f42ffaa27d'
+down_revision = '9cbc5c5ad23d'
+
+
+def upgrade():
+    op.alter_column('annotation',
+                    'deleted',
+                    nullable=False,
+                    server_default=sa.sql.expression.false())
+
+
+def downgrade():
+    op.alter_column('annotation',
+                    'deleted',
+                    nullable=True,
+                    server_default=None)

--- a/h/tasks/cleanup.py
+++ b/h/tasks/cleanup.py
@@ -2,7 +2,7 @@
 
 from __future__ import unicode_literals
 
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from h import models
 from h.celery import celery
@@ -10,6 +10,23 @@ from h.celery import get_task_logger
 
 
 log = get_task_logger(__name__)
+
+
+@celery.task
+def purge_deleted_annotations():
+    """
+    Remove annotations marked as deleted from the database.
+
+    Deletes all annotations flagged as deleted more than 10 minutes ago. This
+    buffer period should ensure that this task doesn't delete annotations
+    deleted just before the task runs, which haven't yet been processed by the
+    streamer.
+    """
+    cutoff = datetime.utcnow() - timedelta(minutes=10)
+    celery.request.db.query(models.Annotation) \
+        .filter_by(deleted=True) \
+        .filter(models.Annotation.updated < cutoff) \
+        .delete()
 
 
 @celery.task

--- a/h/tasks/cleanup.py
+++ b/h/tasks/cleanup.py
@@ -13,14 +13,14 @@ log = get_task_logger(__name__)
 
 
 @celery.task
-def delete_expired_auth_tickets():
+def purge_expired_auth_tickets():
     celery.request.db.query(models.AuthTicket) \
         .filter(models.AuthTicket.expires < datetime.utcnow()) \
         .delete()
 
 
 @celery.task
-def delete_expired_tokens():
+def purge_expired_tokens():
     celery.request.db.query(models.Token) \
         .filter(models.Token.expires < datetime.utcnow()) \
         .delete()

--- a/src/memex/models/annotation.py
+++ b/src/memex/models/annotation.py
@@ -100,6 +100,12 @@ class Annotation(Base):
                       server_default=sa.func.jsonb('{}'),
                       nullable=False)
 
+    #: Has the annotation been deleted?
+    deleted = sa.Column(sa.Boolean,
+                        nullable=False,
+                        default=False,
+                        server_default=sa.sql.expression.false())
+
     document_id = sa.Column(sa.Integer,
                             sa.ForeignKey('document.id'),
                             nullable=False)

--- a/src/memex/resources.py
+++ b/src/memex/resources.py
@@ -30,6 +30,11 @@ class AnnotationResource(object):
 
     def __acl__(self):
         """Return a Pyramid ACL for this annotation."""
+        # If the annotation has been deleted, nobody has any privileges on it
+        # any more.
+        if self.annotation.deleted:
+            return [security.DENY_ALL]
+
         acl = []
         if self.annotation.shared:
             for principal in _group_principals(self.group):

--- a/src/memex/storage.py
+++ b/src/memex/storage.py
@@ -195,7 +195,9 @@ def delete_annotation(session, id_):
     :param id_: the annotation ID
     :type id_: str
     """
-    session.query(models.Annotation).filter_by(id=id_).delete()
+    annotation = session.query(models.Annotation).get(id_)
+    annotation.updated = datetime.utcnow()
+    annotation.deleted = True
 
 
 def expand_uri(session, uri):

--- a/tests/memex/resources_test.py
+++ b/tests/memex/resources_test.py
@@ -71,6 +71,19 @@ class TestAnnotationResource(object):
             assert policy.permits(res, ['saoirse'], perm)
             assert not policy.permits(res, ['someoneelse'], perm)
 
+    def test_acl_deleted(self, factories, pyramid_request):
+        """
+        Nobody -- not even the owner -- should have any permissions on a
+        deleted annotation.
+        """
+        policy = ACLAuthorizationPolicy()
+
+        ann = factories.Annotation(userid='saoirse', deleted=True)
+        res = AnnotationResource(pyramid_request, ann)
+
+        for perm in ['read', 'admin', 'update', 'delete']:
+            assert not policy.permits(res, ['saiorse'], perm)
+
     @pytest.mark.parametrize('groupid,userid,permitted', [
         ('freeforall', 'jim', True),
         ('freeforall', 'saoirse', True),

--- a/tests/memex/storage_test.py
+++ b/tests/memex/storage_test.py
@@ -458,14 +458,19 @@ class TestUpdateAnnotation(object):
 
 class TestDeleteAnnotation(object):
 
-    def test_it_deletes_the_annotation(self, db_session, factories):
-        ann_1, ann_2 = (factories.Annotation(), factories.Annotation())
+    def test_it_marks_the_annotation_as_deleted(self, db_session, factories):
+        ann = factories.Annotation()
 
-        storage.delete_annotation(db_session, ann_1.id)
-        db_session.commit()
+        storage.delete_annotation(db_session, ann.id)
 
-        assert db_session.query(Annotation).get(ann_1.id) is None
-        assert db_session.query(Annotation).get(ann_2.id) == ann_2
+        assert ann.deleted
+
+    def test_it_touches_the_updated_field(self, db_session, factories, datetime):
+        ann = factories.Annotation()
+
+        storage.delete_annotation(db_session, ann.id)
+
+        assert ann.updated == datetime.utcnow()
 
 
 @pytest.fixture


### PR DESCRIPTION
Removing the annotation from the database synchronously (i.e. in the DELETE request) is problematic, as it complicates the process of streaming that delete to WebSocket users.

This commit adds a "deleted" property to the Annotation model (added to the table in 11f8aba) and updates the AnnotationResource ACL so that nobody has any permissions on a deleted annotation.

This ensures that the annotation cannot be returned in any direct-access request. The preexisting search index code will ensure that the annotation is not returned in search results.

This PR also adds a celerybeat task to clean up these deleted annotations on an hourly basis.