### PR TITLE
Reindex write to both indices

### DIFF
--- a/h/indexer/__init__.py
+++ b/h/indexer/__init__.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+
+from h.indexer.reindexer import reindex
+
+__all__ = (
+    'reindex',
+)
+
+
+def includeme(config):
+    config.add_subscriber('h.indexer.subscribers.subscribe_annotation_event',
+                          'memex.events.AnnotationEvent')

--- a/h/indexer/reindexer.py
+++ b/h/indexer/reindexer.py
@@ -2,8 +2,6 @@
 
 import logging
 
-from h.tasks.indexer import add_annotation, delete_annotation
-
 from memex.search.config import (
     configure_index,
     get_aliased_index,
@@ -47,15 +45,3 @@ def reindex(session, es, request):
     finally:
         settings.delete(SETTING_NEW_INDEX)
         request.tm.commit()
-
-
-def subscribe_annotation_event(event):
-    if event.action in ['create', 'update']:
-        add_annotation.delay(event.annotation_id)
-    elif event.action == 'delete':
-        delete_annotation.delay(event.annotation_id)
-
-
-def includeme(config):
-    config.add_subscriber('h.indexer.subscribe_annotation_event',
-                          'memex.events.AnnotationEvent')

--- a/h/indexer/subscribers.py
+++ b/h/indexer/subscribers.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+
+from h.tasks.indexer import add_annotation, delete_annotation
+
+
+def subscribe_annotation_event(event):
+    if event.action in ['create', 'update']:
+        add_annotation.delay(event.annotation_id)
+    elif event.action == 'delete':
+        delete_annotation.delay(event.annotation_id)

--- a/h/tasks/indexer.py
+++ b/h/tasks/indexer.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from h.celery import celery
+from h.indexer.reindexer import SETTING_NEW_INDEX
 
 from memex import storage
 from memex.search.index import index
@@ -13,7 +14,27 @@ def add_annotation(id_):
     if annotation:
         index(celery.request.es, annotation, celery.request)
 
+        # If a reindex is running at the moment, add annotation to the new index
+        # as well.
+        future_index = _current_reindex_new_name(celery.request)
+        if future_index is not None:
+            index(celery.request.es, annotation, celery.request,
+                  target_index=future_index)
+
 
 @celery.task
 def delete_annotation(id_):
     delete(celery.request.es, id_)
+
+    # If a reindex is running at the moment, delete annotation from the
+    # new index as well.
+    future_index = _current_reindex_new_name(celery.request)
+    if future_index is not None:
+        delete(celery.request.es, id_, target_index=future_index)
+
+
+def _current_reindex_new_name(request):
+    settings = celery.request.find_service(name='settings')
+    new_index = settings.get(SETTING_NEW_INDEX)
+
+    return new_index

--- a/src/memex/search/index.py
+++ b/src/memex/search/index.py
@@ -57,7 +57,7 @@ def index(es, annotation, request, target_index=None):
     )
 
 
-def delete(es, annotation_id):
+def delete(es, annotation_id, target_index=None):
     """
     Mark an annotation as deleted in the search index.
 
@@ -72,9 +72,15 @@ def delete(es, annotation_id):
         delete from the search index
     :type annotation_id: str
 
+    :param target_index: the index name, uses default index if not given
+    :type target_index: unicode
     """
+
+    if target_index is None:
+        target_index = es.index
+
     es.conn.index(
-        index=es.index,
+        index=target_index,
         doc_type=es.t.annotation,
         body={'deleted': True},
         id=annotation_id)

--- a/src/memex/search/index.py
+++ b/src/memex/search/index.py
@@ -23,7 +23,7 @@ class Window(namedtuple('Window', ['start', 'end'])):
     pass
 
 
-def index(es, annotation, request):
+def index(es, annotation, request, target_index=None):
     """
     Index an annotation into the search index.
 
@@ -37,6 +37,8 @@ def index(es, annotation, request):
     :param annotation: the annotation to index
     :type annotation: memex.models.Annotation
 
+    :param target_index: the index name, uses default index if not given
+    :type target_index: unicode
     """
     presenter = presenters.AnnotationSearchIndexPresenter(annotation)
     annotation_dict = presenter.asdict()
@@ -44,8 +46,11 @@ def index(es, annotation, request):
     event = AnnotationTransformEvent(request, annotation_dict)
     request.registry.notify(event)
 
+    if target_index is None:
+        target_index = es.index
+
     es.conn.index(
-        index=es.index,
+        index=target_index,
         doc_type=es.t.annotation,
         body=annotation_dict,
         id=annotation_dict["id"],

--- a/tests/h/indexer/subscribers_test.py
+++ b/tests/h/indexer/subscribers_test.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+
+from memex import events
+
+from h.indexer import subscribers
+
+
+@pytest.mark.usefixtures('add_annotation', 'delete_annotation')
+class TestSubscribeAnnotationEvent(object):
+
+    @pytest.mark.parametrize('action', ['create', 'update'])
+    def test_it_enqueues_add_annotation_celery_task(self,
+                                                    action,
+                                                    add_annotation,
+                                                    delete_annotation,
+                                                    pyramid_request):
+        event = events.AnnotationEvent(pyramid_request,
+                                       {'id': 'test_annotation_id'},
+                                       action)
+
+        subscribers.subscribe_annotation_event(event)
+
+        add_annotation.delay.assert_called_once_with(event.annotation_id)
+        assert not delete_annotation.delay.called
+
+    def test_it_enqueues_delete_annotation_celery_task_for_delete(self,
+                                                                  add_annotation,
+                                                                  delete_annotation,
+                                                                  pyramid_request):
+        event = events.AnnotationEvent(pyramid_request,
+                                       {'id': 'test_annotation_id'},
+                                       'delete')
+
+        subscribers.subscribe_annotation_event(event)
+
+        delete_annotation.delay.assert_called_once_with(event.annotation_id)
+        assert not add_annotation.delay.called
+
+    @pytest.fixture
+    def add_annotation(self, patch):
+        return patch('h.indexer.subscribers.add_annotation')
+
+    @pytest.fixture
+    def delete_annotation(self, patch):
+        return patch('h.indexer.subscribers.delete_annotation')

--- a/tests/h/tasks/indexer_test.py
+++ b/tests/h/tasks/indexer_test.py
@@ -3,10 +3,22 @@
 import mock
 import pytest
 
+from h.indexer.reindexer import SETTING_NEW_INDEX
 from h.tasks import indexer
 
 
-@pytest.mark.usefixtures('celery', 'index')
+class FakeSettingsService(object):
+    def __init__(self):
+        self._data = {}
+
+    def get(self, key):
+        return self._data.get(key)
+
+    def put(self, key, value):
+        self._data[key] = value
+
+
+@pytest.mark.usefixtures('celery', 'index', 'settings_service')
 class TestAddAnnotation(object):
 
     def test_it_fetches_the_annotation(self, fetch_annotation, celery):
@@ -32,6 +44,27 @@ class TestAddAnnotation(object):
 
         assert index.called is False
 
+    def test_during_reindex_adds_to_current_index(self, fetch_annotation, index, celery, settings_service):
+        settings_service.put(SETTING_NEW_INDEX, 'hypothesis-abcdef123')
+        fetch_annotation.return_value = mock.sentinel.annotation
+
+        indexer.add_annotation('test-annotation-id')
+
+        index.assert_any_call(celery.request.es,
+                              mock.sentinel.annotation,
+                              celery.request)
+
+    def test_during_reindex_adds_to_new_index(self, fetch_annotation, index, celery, settings_service):
+        settings_service.put(SETTING_NEW_INDEX, 'hypothesis-abcdef123')
+        fetch_annotation.return_value = mock.sentinel.annotation
+
+        indexer.add_annotation('test-annotation-id')
+
+        index.assert_any_call(celery.request.es,
+                              mock.sentinel.annotation,
+                              celery.request,
+                              target_index='hypothesis-abcdef123')
+
     @pytest.fixture
     def index(self, patch):
         return patch('h.tasks.indexer.index')
@@ -41,7 +74,7 @@ class TestAddAnnotation(object):
         return patch('h.tasks.indexer.storage.fetch_annotation')
 
 
-@pytest.mark.usefixtures('celery', 'delete')
+@pytest.mark.usefixtures('celery', 'delete', 'settings_service')
 class TestDeleteAnnotation(object):
 
     def test_it_deletes_from_index(self, delete, celery):
@@ -49,6 +82,23 @@ class TestDeleteAnnotation(object):
         indexer.delete_annotation(id_)
 
         delete.assert_called_once_with(celery.request.es, id_)
+
+    def test_during_reindex_deletes_from_current_index(self, delete, celery, settings_service):
+        settings_service.put(SETTING_NEW_INDEX, 'hypothesis-abcdef123')
+
+        indexer.delete_annotation('test-annotation-id')
+
+        delete.assert_any_call(celery.request.es,
+                               'test-annotation-id')
+
+    def test_during_reindex_deletes_from_new_index(self, delete, celery, settings_service):
+        settings_service.put(SETTING_NEW_INDEX, 'hypothesis-abcdef123')
+
+        indexer.delete_annotation('test-annotation-id')
+
+        delete.assert_any_call(celery.request.es,
+                               'test-annotation-id',
+                               target_index='hypothesis-abcdef123')
 
     @pytest.fixture
     def delete(self, patch):
@@ -66,3 +116,10 @@ def celery(patch, pyramid_request):
 def pyramid_request(pyramid_request):
     pyramid_request.es = mock.Mock()
     return pyramid_request
+
+
+@pytest.fixture
+def settings_service(pyramid_config):
+    service = FakeSettingsService()
+    pyramid_config.register_service(service, name='settings')
+    return service

--- a/tests/memex/search/index_test.py
+++ b/tests/memex/search/index_test.py
@@ -53,6 +53,12 @@ class TestIndexAnnotation:
             id='test_annotation_id',
         )
 
+    def test_it_allows_to_override_target_index(self, es, presenters, pyramid_request):
+        index.index(es, mock.Mock(), pyramid_request, target_index='custom-index')
+
+        _, kwargs = es.conn.index.call_args
+        assert kwargs['index'] == 'custom-index'
+
     @pytest.fixture
     def presenters(self, patch):
         presenters = patch('memex.search.index.presenters')

--- a/tests/memex/search/index_test.py
+++ b/tests/memex/search/index_test.py
@@ -86,6 +86,12 @@ class TestDeleteAnnotation:
             id='test_annotation_id'
         )
 
+    def test_it_allows_to_override_target_index(self, es):
+        index.delete(es, 'test_annotation_id', target_index='custom-index')
+
+        _, kwargs = es.conn.index.call_args
+        assert kwargs['index'] == 'custom-index'
+
 
 class TestBatchIndexer(object):
     def test_index_indexes_all_annotations_to_es(self, db_session, indexer, matchers, streaming_bulk, factories):


### PR DESCRIPTION
~~**Depends on #4249 to be merged and then this needs a rebase.**~~

This is the last piece of the puzzle that is zero-downtime re-indexing (hypothesis/product-backlog#106).

This PR:
* Allows to specify an index name for `memex.search.index.index` and `memex.search.index.delete`, it defaults to `request.es.index`
* Makes sure that the indexer workers for adding and deleting annotations are calling doing their operation twice, once with the default index, and once with the new index name that is stored in the `setting` table

---

This is making sure that certain race-conditions don't break the new index during a re-index. So testing this manually is a bit cumbersome. I've made sure that I have two annotations in my database (and index), one for updating its text, and one for deleting, both during the re-index at specific points. You will have to make a note of the ids of these two annotations (in the examples below I'm using `annotation-id-update`, and `annotation-id-delete`).

Apply this diff to `src/memex/search/index.py` (and replace the annotation ids):
```diff
diff --git a/src/memex/search/index.py b/src/memex/search/index.py
index 15b013d..f6b67fc 100644
--- a/src/memex/search/index.py
+++ b/src/memex/search/index.py
@@ -144,6 +144,16 @@ class BatchIndexer(object):
         event = AnnotationTransformEvent(self.request, data)
         self.request.registry.notify(event)
 
+        if annotation.id == 'annotation-id-update':
+            import time
+            print('now update annotation-id-update - sleeping...')
+            time.sleep(30)
+
+        if annotation.id == 'annotation-id-delete':
+            import time
+            print('now delete annotation-id-delete - sleeping...')
+            time.sleep(30)
+
         return (action, data)
 
     def _stream_all_annotations(self, chunksize=2000):
```
This will make sure that right after it renders each of the two test annotations (but before sending it to Elasticsearch),  the re-index process will pause for 30 seconds allowing you to either edit the annotation's text or to delete it.

Open these tabs (make sure to replace the annotation ids):

* https://localhost:5000/a/annotation-id-update
* https://localhost:5000/a/annotation-id-delete
* http://localhost:9200/hypothesis/annotation/annotation-id-update
* http://localhost:9200/hypothesis/annotation/annotation-id-delete

Then follow these steps:

Experience the bug:

1. Check out the `master` branch
2. Run a re-index without making any changes, to make sure you start with a correct index
3. Run `bin/hypothesis --dev search reindex`
4. Wait for console print "now update annotation annotation-id-update - sleeping..."
5. Edit the text of `annotation-id-update` in the first browser tab
6. Reload the third browser tab to see that the text change has made it into the current index
7. Wait for console print "now delete annotation annotation-id-delete - sleeping..."
8. Delete annotation `annotation-id-delete` in the second browser tab
9. Reload the fourth browser tab to see that the annotation is marked as deleted in the current index
10. Wait for the re-index to finish (the `hypothesis` alias has been swapped to the new index)
11. Reload the third browser tab: notice that the text changed to its initial state 💣 💥 
12. Reload the fourth browser tab: notice that the deleted annotation is back again 💣 💥 

Experience the fix:

1. Check out this branch (`reindex-write-to-both-indices`)
2. Re-create the test annotation that will be deleted (as it is now gone from the database)
3. Replace all occurrences of the old "to-delete-annotation-id" to the new id
4. Run a re-index without making any changes, to make sure you start with a correct index
5. Run `bin/hypothesis --dev search reindex`
6. Wait for console print "now update annotation annotation-id-update - sleeping..."
7. Edit the text of `annotation-id-update` in the first browser tab
8. Reload the third browser tab to see that the text change has made it into the current index
9. Wait for console print "now delete annotation annotation-id-delete - sleeping..."
10. Delete annotation `annotation-id-delete` in the second browser tab
11. Reload the fourth browser tab to see that the annotation is marked as deleted in the current index
12. Wait for the re-index to finish (the `hypothesis` alias has been swapped to the new index)
13. Reload the third browser tab: notice that the text is still correct ✔️ 🎉 
14. Reload the fourth browser tab: notice that the deleted annotation is missing from the index ✔️ 🎉 