### PR TITLE
Change NipsaService#flagged_users to #flagged_userids

### DIFF
--- a/h/admin/views/nipsa.py
+++ b/h/admin/views/nipsa.py
@@ -18,7 +18,7 @@ class UserNotFoundError(Exception):
 def nipsa_index(request):
     nipsa_service = request.find_service(name='nipsa')
     return {
-        "userids": [u.userid for u in nipsa_service.flagged_users],
+        "userids": sorted(nipsa_service.flagged_userids),
         "default_authority": request.auth_domain,
     }
 

--- a/h/nipsa/services.py
+++ b/h/nipsa/services.py
@@ -13,21 +13,23 @@ class NipsaService(object):
 
     def __init__(self, session):
         self.session = session
+        self._flagged_userids = None
 
     @property
-    def flagged_users(self):
+    def flagged_userids(self):
         """
-        A list of all the NIPSA'd users.
+        A list of all the NIPSA'd userids.
 
-        :rtype: list of unicode strings
+        :rtype: set of unicode strings
         """
-        return self.session.query(User).filter_by(nipsa=True)
+        if self._flagged_userids is None:
+            query = self.session.query(User).filter_by(nipsa=True)
+            self._flagged_userids = set([u.userid for u in query])
+        return self._flagged_userids
 
     def is_flagged(self, userid):
         """Return whether the given userid is flagged as "NIPSA"."""
-        cnt = self.session.query(User).filter_by(userid=userid,
-                                                 nipsa=True).count()
-        return cnt != 0
+        return userid in self.flagged_userids
 
     def flag(self, user):
         """

--- a/tests/h/admin/views/nipsa_test.py
+++ b/tests/h/admin/views/nipsa_test.py
@@ -86,8 +86,8 @@ class FakeNipsaService(object):
         self.flagged = set([u for u in users if u.nipsa])
 
     @property
-    def flagged_users(self):
-        return list(self.flagged)
+    def flagged_userids(self):
+        return set([u.userid for u in self.flagged])
 
     def flag(self, user):
         self.flagged.add(user)

--- a/tests/h/nipsa/services_test.py
+++ b/tests/h/nipsa/services_test.py
@@ -10,11 +10,11 @@ from h.nipsa.services import nipsa_factory
 
 @pytest.mark.usefixtures('users', 'add_nipsa', 'remove_nipsa')
 class TestNipsaService(object):
-    def test_flagged_user_returns_list_of_users(self, db_session, users):
+    def test_flagged_userids_returns_set_of_userids(self, db_session):
         svc = NipsaService(db_session)
 
-        assert set(svc.flagged_users) == set([users['renata'],
-                                              users['cecilia']])
+        assert svc.flagged_userids == set(['acct:renata@example.com',
+                                           'acct:cecilia@example.com'])
 
     def test_is_flagged_returns_true_for_flagged_users(self, db_session, users):
         svc = NipsaService(db_session)


### PR DESCRIPTION
This commit updates the NipsaService, replacing the "flagged_users" method (which returned a list of users) with "flagged_userids" which returns a *memoized* list of userids.

This will allow us to use the NipsaService to provide significantly faster reindexing.