### PR TITLE
Remove non-Activity Pages version of logged-in accounts forms

### DIFF
--- a/h/templates/accounts/account.html.jinja2
+++ b/h/templates/accounts/account.html.jinja2
@@ -5,30 +5,9 @@
 
 {% block page_content %}
   <div class="form-vertical">
-    {% if not feature('activity_pages') -%}
-    <h2 class="form-heading">
-      <span>{% trans %}Change your email address{% endtrans %}</span>
-    </h2>
-    <legend>
-      {% trans %}Your current email address is:{% endtrans %}
-      <strong>{{ email }}</strong>.
-    </legend>
-    {%- endif %}
     {{ email_form }}
-
-    <h2 class="form-heading">
-    {% if not feature('activity_pages') -%}
-      <span>{% trans %}Change your password{% endtrans %}</span>
-    {%- endif %}
-    </h2>
     {{ password_form }}
 
-    {% if not feature('activity_pages') -%}
-    <h2 class="form-heading">
-      <span>{% trans %}Delete account{% endtrans %}</span>
-    </h2>
-    {%- endif %}
-    {% if feature('activity_pages') -%}
     <footer class="form-footer">
       {% trans %}
         If you would like to delete your account, please email us at
@@ -36,14 +15,5 @@
         registered email address, and we'll take it from there.
       {% endtrans %}
     </footer>
-    {% else %}
-    <legend>
-      {% trans %}
-        If you would like to delete your account, please email us at
-        <a href="mailto:support@hypothes.is">support@hypothes.is</a> from your
-        registered email address, and we'll take it from there.
-      {% endtrans %}
-    </legend>
-    {%- endif %}
   </div>
 {% endblock page_content %}

--- a/h/templates/accounts/developer.html.jinja2
+++ b/h/templates/accounts/developer.html.jinja2
@@ -5,85 +5,35 @@
 
 {% block page_content %}
   <div class="form-vertical">
-    {% if not feature('activity_pages') -%}
-    <h2 class="form-heading">
-      <span>{% trans %}Generate your API token{% endtrans %}</span>
-    </h2>
-    {% endif %}
-
     {% if token %}
-      {% if feature('activity_pages') %}
-        <p class="form-help-text">
-        <label for="token">{% trans %}Your API token is:{% endtrans %}</label>
-        </p>
-        <input id="token"
-               type="text"
-               value="{{ token }}"
-               readonly="readonly"
-               class="api-token">
-        <p class="form-help-text">
-          Please keep your API token safe as it can be used to access your account.
-        </p>
-      {% else %}
+      <p class="form-help-text">
       <label for="token">{% trans %}Your API token is:{% endtrans %}</label>
-      <input id="token" type="text" value="{{ token }}" readonly="readonly"
-             class="api-token-input">
-      <span class="help-block">
-        Please keep your API token safe as it can be used to access your
-        account.
-      </span>
-      {% endif %}
-    {% else %}
-      {% if not feature('activity_pages') -%}
-      <legend>
-        {% trans %}You haven't generated an API token yet.{% endtrans %}
-      </legend>
-      {%- endif %}
+      </p>
+      <input id="token"
+             type="text"
+             value="{{ token }}"
+             readonly="readonly"
+             class="api-token">
+      <p class="form-help-text">
+        Please keep your API token safe as it can be used to access your account.
+      </p>
     {% endif %}
 
       <form method="POST">
-        {% if feature('activity_pages') %}
-          {% if token %}
-            <button type="submit" class="btn"
-                    title="{% trans %}Delete your API token and generate a new one{% endtrans%}">
-              Regenerate your API token
-            </button>
-          {% else %}
-            <button type="submit" class="btn btn-primary">
-              {% trans %}Generate your API token{% endtrans %}
-            </button>
-          {% endif %}
+        {% if token %}
+          <button type="submit" class="btn"
+                  title="{% trans %}Delete your API token and generate a new one{% endtrans%}">
+            Regenerate your API token
+          </button>
         {% else %}
-        <div class="form-actions">
-          <div class="form-actions-buttons">
-
-    {% if token %}
-            <button type="submit" class="btn btn-danger"
-                    title="{% trans %}Delete your API token and generate a new one{% endtrans%}">
-              Regenerate your API token
-            </button>
-    {% else %}
-            <button type="submit" class="btn btn-primary">
-              {% trans %}Generate your API token{% endtrans %}
-            </button>
-    {% endif %}
-          </div>
-        </div>
+          <button type="submit" class="btn btn-primary">
+            {% trans %}Generate your API token{% endtrans %}
+          </button>
         {% endif %}
       </form>
-      {% if feature('activity_pages') -%}
       <footer class="form-footer">
         You can learn more about the Hypothesis API at
         <a class="link--footer" href="https://h.readthedocs.io/en/latest/api.html">h.readthedocs.io/en/latest/api.html</a>
       </footer>
-      {% else %}
-      <h2 class="form-heading">
-        <span>{% trans %}API documentation{% endtrans %}</span>
-      </h2>
-      <legend>
-        You can learn more about the Hypothesis API at
-        <a href="https://h.readthedocs.io/en/latest/api.html">h.readthedocs.io/en/latest/api.html</a>.
-      </legend>
-      {%- endif %}
   </div>
 {% endblock page_content %}

--- a/h/templates/accounts/notifications.html.jinja2
+++ b/h/templates/accounts/notifications.html.jinja2
@@ -1,21 +1,8 @@
 {% extends "h:templates/layouts/account.html.jinja2" %}
 
-{% if not feature('activity_pages') %}
-{% set style_bundle = 'legacy_site_css' %}
-{% endif %}
-
 {% set page_route = 'account_notifications' %}
 {% set page_title = 'Notifications' %}
 
 {% block page_content %}
-  {% if feature('activity_pages') %}
-    {{ form }}
-  {% else %}
-    <div class="form-vertical">
-      <h2 class="form-heading">
-        <span>{% trans %}Update your notification settings{% endtrans %}</span>
-      </h2>
-      {{ form }}
-    </div>
-  {% endif %}
+  {{ form }}
 {% endblock page_content %}

--- a/h/templates/layouts/account.html.jinja2
+++ b/h/templates/layouts/account.html.jinja2
@@ -1,84 +1,49 @@
 {% extends "h:templates/layouts/base.html.jinja2" %}
 
-{% if not feature('activity_pages') %}
-{% set style_bundle = 'legacy_site_css' %}
-{% endif %}
-
-{% if feature('activity_pages') %}
 {%- set nav_pages = [
     ('account', 'Account'),
     ('account_profile', 'Edit profile'),
     ('account_notifications', 'Notifications'),
     ('account_developer', 'Developer'),
 ] -%}
-{% else %}
-{%- set nav_pages = [
-    ('account', 'Account'),
-    ('account_notifications', 'Notifications'),
-    ('account_developer', 'Developer'),
-] -%}
-{% endif %}
 
 {% block page_title %}{{ page_title }}{% endblock %}
 
 {% block header %}
-  {% if feature('activity_pages') %}
-    {{ panel('navbar') }}
-  {% endif %}
+  {{ panel('navbar') }}
 {% endblock %}
 
 {% block content %}
   <div class="content paper">
-    {% if feature('activity_pages') %}
-      <div class="form-container">
-        <nav class="tabs">
-          <ul>
-            {% for route, title in nav_pages %}
-              <li class="tabs__item">
-                  <a href="{{ request.route_url(route) }}"
-                     class="tabs__link{% if route == page_route %} is-active{% endif %}">
-                    {{ title }}
-                  </a>
-              </li>
-            {% endfor %}
-          </ul>
-        </nav>
-        {% if request.session.peek_flash('success') -%}
-          <div class="form-flash">
-            {% for message in request.session.pop_flash('success') %}
-              <p>{{ message }}</p>
-            {%- endfor %}
-          </div>
-        {%- endif %}
-        {{ self.page_content() }}
-
-        <footer class="form-footer--no-border">
-          {{ panel('back_link') }}
-        </footer>
-      </div>
-    {% else %}
-      {% include "h:templates/includes/logo-header.html.jinja2" %}
-      <ul class="nav nav-tabs">
-        {% for route, title in nav_pages %}
-          <li{% if route == page_route %} class="active"{% endif %}>
-              <a href="{{ request.route_url(route) }}">{{ title }}</a>
-          </li>
-        {% endfor %}
-      </ul>
+    <div class="form-container">
+      <nav class="tabs">
+        <ul>
+          {% for route, title in nav_pages %}
+            <li class="tabs__item">
+                <a href="{{ request.route_url(route) }}"
+                   class="tabs__link{% if route == page_route %} is-active{% endif %}">
+                  {{ title }}
+                </a>
+            </li>
+          {% endfor %}
+        </ul>
+      </nav>
       {% if request.session.peek_flash('success') -%}
-      <div class="form-flash">
-        {% for message in request.session.pop_flash('success') %}
-          <p>{{ message }}</p>
-        {%- endfor %}
-      </div>
+        <div class="form-flash">
+          {% for message in request.session.pop_flash('success') %}
+            <p>{{ message }}</p>
+          {%- endfor %}
+        </div>
       {%- endif %}
       {{ self.page_content() }}
-    {% endif %}
+
+      <footer class="form-footer--no-border">
+        {{ panel('back_link') }}
+      </footer>
+    </div>
   </div>
 {% endblock content %}
 
 {% block footer %}
-  {% if feature('activity_pages') %}
-    {% include "h:templates/includes/footer.html.jinja2" %}
-  {% endif %}
+  {% include "h:templates/includes/footer.html.jinja2" %}
 {% endblock %}


### PR DESCRIPTION
_This is the first of a set of PRs to start removing the non-Activity Pages version of the site, starting with the logged-in accounts forms._

This removes the non-Activity Pages sections of the templates for the logged-in accounts forms.

Once this lands, we'll no longer be able to turn off the Activity Pages feature flag.