### PR TITLE
Remove special-case handling of deletes in streamer

### DIFF
--- a/h/subscribers.py
+++ b/h/subscribers.py
@@ -32,9 +32,6 @@ def publish_annotation_event(event):
         'annotation_id': event.annotation_id,
         'src_client_id': event.request.headers.get('X-Client-Id'),
     }
-    if event.annotation_dict:
-        data['annotation_dict'] = event.annotation_dict
-
     event.request.realtime.publish_annotation(data)
 
 

--- a/src/memex/events.py
+++ b/src/memex/events.py
@@ -4,11 +4,10 @@
 class AnnotationEvent(object):
     """An event representing an action on an annotation."""
 
-    def __init__(self, request, annotation_id, action, annotation_dict=None):
+    def __init__(self, request, annotation_id, action):
         self.request = request
         self.annotation_id = annotation_id
         self.action = action
-        self.annotation_dict = annotation_dict
 
 
 class AnnotationTransformEvent(object):

--- a/src/memex/views.py
+++ b/src/memex/views.py
@@ -269,13 +269,7 @@ def _publish_annotation_event(request,
                               annotation,
                               action):
     """Publish an event to the annotations queue for this annotation action."""
-    links_service = request.find_service(name='links')
-    annotation_dict = None
-    if action == 'delete':
-        presenter = AnnotationJSONPresenter(annotation, links_service)
-        annotation_dict = presenter.asdict()
-
-    event = AnnotationEvent(request, annotation.id, action, annotation_dict)
+    event = AnnotationEvent(request, annotation.id, action)
     request.notify_after_commit(event)
 
 

--- a/tests/h/streamer/messages_test.py
+++ b/tests/h/streamer/messages_test.py
@@ -271,56 +271,15 @@ class TestHandleAnnotationEvent(object):
 
         assert socket.send_json_payloads == []
 
-    def test_no_send_if_annotation_delete_nipsad(self, fetch_annotation, nipsa_service):
-        """
-        Should return None if the annotation is a deletion from a NIPSA'd
-        user.
-        """
-        message = {
-            'action': 'delete',
-            'src_client_id': '_',
-            'annotation_id': '_',
-            'annotation_dict': self.serialized_annotation({'user': 'geraldine'}),
-        }
-        fetch_annotation.return_value = None
-        socket = FakeSocket('giraffe')
-        session = mock.sentinel.db_session
-        def is_flagged(userid):
-            return userid == 'geraldine'
-        nipsa_service.return_value.is_flagged.side_effect = is_flagged
-
-        messages.handle_annotation_event(message, [socket], session)
-
-        assert socket.send_json_payloads == []
-
-    def test_sends_nipsad_annotations_to_owners(self, nipsa_service, presenter_asdict):
+    def test_sends_nipsad_annotations_to_owners(self, fetch_annotation, nipsa_service, presenter_asdict):
         """NIPSA'd users should see their own annotations."""
         message = {'action': '_', 'src_client_id': '_', 'annotation_id': '_'}
+        fetch_annotation.return_value.userid = 'fred'
         socket = FakeSocket('giraffe')
         socket.authenticated_userid = 'fred'
         session = mock.sentinel.db_session
         presenter_asdict.return_value = self.serialized_annotation()
         nipsa_service.return_value.is_flagged.return_value = True
-
-        messages.handle_annotation_event(message, [socket], session)
-
-        assert len(socket.send_json_payloads) == 1
-
-    def test_sends_nipsad_deletes_to_owners(self, fetch_annotation, nipsa_service):
-        """NIPSA'd users should see their own deletions."""
-        message = {
-            'action': 'delete',
-            'src_client_id': '_',
-            'annotation_id': '_',
-            'annotation_dict': self.serialized_annotation({'user': 'geraldine'}),
-        }
-        fetch_annotation.return_value = None
-        socket = FakeSocket('giraffe')
-        socket.authenticated_userid = 'geraldine'
-        session = mock.sentinel.db_session
-        def is_flagged(userid):
-            return userid == 'geraldine'
-        nipsa_service.return_value.is_flagged.side_effect = is_flagged
 
         messages.handle_annotation_event(message, [socket], session)
 
@@ -377,7 +336,6 @@ class TestHandleAnnotationEvent(object):
             data = {}
 
         serialized = {
-            'user': 'fred',
             'permissions': {'read': ['group:__world__']}
         }
         serialized.update(data)
@@ -385,8 +343,10 @@ class TestHandleAnnotationEvent(object):
         return serialized
 
     @pytest.fixture
-    def fetch_annotation(self, patch):
-        return patch('h.streamer.messages.storage.fetch_annotation')
+    def fetch_annotation(self, factories, patch):
+        fetch = patch('h.streamer.messages.storage.fetch_annotation')
+        fetch.return_value = factories.Annotation()
+        return fetch
 
     @pytest.fixture
     def presenters(self, patch):

--- a/tests/h/streamer/messages_test.py
+++ b/tests/h/streamer/messages_test.py
@@ -213,6 +213,26 @@ class TestHandleAnnotationEvent(object):
             'options': {'action': 'update'},
         }
 
+    def test_notification_format_delete(self, fetch_annotation, presenter_asdict):
+        """Check the format of the returned notification for deletes."""
+        message = {
+            'annotation_id': '_',
+            'action': 'delete',
+            'src_client_id': 'pigeon'
+        }
+        annotation = fetch_annotation.return_value
+        socket = FakeSocket('giraffe')
+        session = mock.sentinel.db_session
+        presenter_asdict.return_value = self.serialized_annotation()
+
+        messages.handle_annotation_event(message, [socket], session)
+
+        assert socket.send_json_payloads[0] == {
+            'payload': [{'id': annotation.id}],
+            'type': 'annotation-notification',
+            'options': {'action': 'delete'},
+        }
+
     def test_no_send_for_sender_socket(self, presenter_asdict):
         """Should return None if the socket's client_id matches the message's."""
         message = {'src_client_id': 'pigeon', 'annotation_id': '_', 'action': '_'}

--- a/tests/h/subscribers_test.py
+++ b/tests/h/subscribers_test.py
@@ -29,27 +29,12 @@ class TestPublishAnnotationEvent:
             'src_client_id': 'client_id'
         })
 
-    def test_it_adds_annotation_dict_to_realtime_event(self, event):
-        annotation_dict = mock.Mock()
-        type(event).annotation_dict = mock.PropertyMock(return_value=annotation_dict)
-        event.request.headers = {'X-Client-Id': 'client_id'}
-
-        subscribers.publish_annotation_event(event)
-
-        event.request.realtime.publish_annotation.assert_called_once_with({
-            'action': event.action,
-            'annotation_id': event.annotation_id,
-            'src_client_id': 'client_id',
-            'annotation_dict': annotation_dict
-        })
-
     @pytest.fixture
     def event(self, pyramid_request):
         pyramid_request.realtime = mock.Mock()
         event = AnnotationEvent(pyramid_request,
                                 'test_annotation_id',
                                 'create')
-        type(event).annotation_dict = mock.PropertyMock(return_value=None)
         return event
 
 

--- a/tests/memex/views_test.py
+++ b/tests/memex/views_test.py
@@ -267,8 +267,9 @@ class TestCreate(object):
 
         annotation = storage.create_annotation.return_value
 
-        AnnotationEvent.assert_called_once_with(
-            pyramid_request, annotation.id, 'create', annotation_dict=None)
+        AnnotationEvent.assert_called_once_with(pyramid_request,
+                                                annotation.id,
+                                                'create')
         pyramid_request.notify_after_commit.assert_called_once_with(
             AnnotationEvent.return_value)
 
@@ -414,9 +415,9 @@ class TestUpdate(object):
 
         views.update(context, pyramid_request)
 
-        AnnotationEvent.assert_called_once_with(
-            pyramid_request, storage.update_annotation.return_value.id, 'update',
-            annotation_dict=None)
+        AnnotationEvent.assert_called_once_with(pyramid_request,
+                                                storage.update_annotation.return_value.id,
+                                                'update')
 
     def test_it_fires_the_AnnotationEvent(self, AnnotationEvent, pyramid_request):
         views.update(mock.Mock(), pyramid_request)
@@ -471,31 +472,18 @@ class TestDelete(object):
         storage.delete_annotation.assert_called_once_with(pyramid_request.db,
                                                           context.annotation.id)
 
-    def test_it_serializes_the_annotation(self,
-                                          AnnotationJSONPresenter,
-                                          links_service,
-                                          pyramid_request):
-        context = mock.Mock()
-
-        views.delete(context, pyramid_request)
-
-        AnnotationJSONPresenter.assert_called_once_with(context.annotation,
-                                                        links_service)
-
     def test_it_inits_and_fires_an_AnnotationEvent(self,
                                                    AnnotationEvent,
                                                    AnnotationJSONPresenter,
                                                    pyramid_request):
         context = mock.Mock()
         event = AnnotationEvent.return_value
-        annotation_dict = AnnotationJSONPresenter.return_value.asdict.return_value
 
         views.delete(context, pyramid_request)
 
         AnnotationEvent.assert_called_once_with(pyramid_request,
                                                 context.annotation.id,
-                                                'delete',
-                                                annotation_dict=annotation_dict)
+                                                'delete')
         pyramid_request.notify_after_commit.assert_called_once_with(event)
 
     def test_it_returns_object(self, pyramid_request):


### PR DESCRIPTION
Until now it has been necessary to special-case the handling of "delete" activity when it flows through the streamer, because by the time the message gets to the streamer code, the annotation has been deleted.

As of e2e6dda this is no longer true: deleted annotations remain in the database for up to 70 minutes (a job runs every hour but has a 10-minute buffer, so an annotation deleted 9m59s before the job runs will have to wait until the following run), which should be plenty of time for the streamer to process the message.

This PR removes the special handling in `h.streamer.messages` and the support on the memex side in `memex.events.AnnotationEvent`.