### PR TITLE
Remove form schemas used by non-AP email change form

### DIFF
--- a/h/accounts/schemas.py
+++ b/h/accounts/schemas.py
@@ -267,32 +267,6 @@ class ResetPasswordSchema(CSRFSchema):
         widget=deform.widget.PasswordWidget(disable_autocomplete=True))
 
 
-class LegacyEmailChangeSchema(CSRFSchema):
-    email = email_node(title=_('New email address'))
-    # No validators: all validation is done on the email field and we merely
-    # assert that the confirmation field is the same.
-    email_confirm = colander.SchemaNode(
-        colander.String(),
-        title=_('Confirm new email address'),
-        widget=deform.widget.TextInputWidget(template='emailinput'))
-    password = new_password_node(title=_('Current password'))
-
-    def validator(self, node, value):
-        super(LegacyEmailChangeSchema, self).validator(node, value)
-        exc = colander.Invalid(node)
-        request = node.bindings['request']
-        user = request.authenticated_user
-
-        if value.get('email') != value.get('email_confirm'):
-            exc['email_confirm'] = _('The emails must match')
-
-        if not user.check_password(value.get('password')):
-            exc['password'] = _('Wrong password.')
-
-        if exc.children:
-            raise exc
-
-
 class EmailChangeSchema(CSRFSchema):
     email = email_node(title=_('Email address'))
     # No validators: all validation is done on the email field

--- a/h/views/accounts.py
+++ b/h/views/accounts.py
@@ -488,9 +488,6 @@ class AccountController(object):
         self.request = request
 
         email_schema = schemas.EmailChangeSchema().bind(request=request)
-        save_email_label = _('Save')
-        save_password_label = _('Save')
-
         password_schema = schemas.PasswordChangeSchema().bind(request=request)
 
         # Ensure deform generates unique field IDs for each field in this
@@ -499,12 +496,12 @@ class AccountController(object):
 
         self.forms = {
             'email': request.create_form(email_schema,
-                                         buttons=(save_email_label,),
+                                         buttons=(_('Save'),),
                                          formid='email',
                                          counter=counter,
                                          use_inline_editing=True),
             'password': request.create_form(password_schema,
-                                            buttons=(save_password_label,),
+                                            buttons=(_('Save'),),
                                             formid='password',
                                             counter=counter,
                                             use_inline_editing=True),

--- a/h/views/accounts.py
+++ b/h/views/accounts.py
@@ -487,15 +487,9 @@ class AccountController(object):
     def __init__(self, request):
         self.request = request
 
-        save_email_label = _('Change email address')
-        save_password_label = _('Change password')
-
-        if request.feature('activity_pages'):
-            email_schema = schemas.EmailChangeSchema().bind(request=request)
-            save_email_label = _('Save')
-            save_password_label = _('Save')
-        else:
-            email_schema = schemas.LegacyEmailChangeSchema().bind(request=request)
+        email_schema = schemas.EmailChangeSchema().bind(request=request)
+        save_email_label = _('Save')
+        save_password_label = _('Save')
 
         password_schema = schemas.PasswordChangeSchema().bind(request=request)
 
@@ -551,11 +545,7 @@ class AccountController(object):
         """Return the data needed to render accounts.html.jinja2."""
         email = self.request.authenticated_user.email
         password_form = self.forms['password'].render()
-
-        if self.request.feature('activity_pages'):
-            email_form = self.forms['email'].render({'email': email})
-        else:
-            email_form = self.forms['email'].render()
+        email_form = self.forms['email'].render({'email': email})
 
         return {'email': email,
                 'email_form': email_form,

--- a/tests/functional/test_accounts.py
+++ b/tests/functional/test_accounts.py
@@ -14,7 +14,6 @@ class TestAccountSettings(object):
 
         email_form = res.forms['email']
         email_form['email'] = 'new_email@example.com'
-        email_form['email_confirm'] = 'new_email@example.com'
         email_form['password'] = 'pass'
 
         res = email_form.submit().follow()
@@ -27,7 +26,6 @@ class TestAccountSettings(object):
 
         email_form = res.forms['email']
         email_form['email'] = 'new_email@example.com'
-        email_form['email_confirm'] = 'new_email@example.com'
         email_form['password'] = 'pass'
 
         res = email_form.submit(xhr=True, status=200)
@@ -39,22 +37,11 @@ class TestAccountSettings(object):
 
         email_form = res.forms['email']
         email_form['email'] = 'new_email@example.com'
-        email_form['email_confirm'] = 'new_email@example.com'
         email_form['password'] = 'pass'
 
         res = email_form.submit(xhr=True)
 
         assert res.content_type == 'text/plain'
-
-    def test_submit_invalid_email_form_with_xhr_returns_400(self, app):
-        res = app.get('/account/settings')
-
-        email_form = res.forms['email']
-        email_form['email'] = 'new_email@example.com'
-        email_form['email_confirm'] = 'WRONG'
-        email_form['password'] = 'pass'
-
-        email_form.submit(xhr=True, status=400)
 
     def test_submit_password_form_without_xhr_returns_full_html_page(self,
                                                                      app):

--- a/tests/h/accounts/schemas_test.py
+++ b/tests/h/accounts/schemas_test.py
@@ -341,47 +341,6 @@ class TestResetPasswordSchema(object):
             raise BadData("Invalid token")
 
 
-@pytest.mark.usefixtures('user_model')
-class TestLegacyEmailChangeSchema(object):
-
-    def test_it_is_invalid_if_emails_dont_match(self,
-                                                pyramid_csrf_request,
-                                                user_model):
-        user = Mock()
-        pyramid_csrf_request.authenticated_user = user
-        schema = schemas.LegacyEmailChangeSchema().bind(
-            request=pyramid_csrf_request)
-        # The email isn't taken
-        user_model.get_by_email.return_value = None
-
-        with pytest.raises(colander.Invalid) as exc:
-            schema.deserialize({'email': 'foo@bar.com',
-                                'email_confirm': 'foo@baz.com',
-                                'password': 'flibble'})
-
-        assert 'email_confirm' in exc.value.asdict()
-
-    def test_it_is_invalid_if_password_wrong(self,
-                                             pyramid_csrf_request,
-                                             user_model):
-        user = Mock()
-        pyramid_csrf_request.authenticated_user = user
-        schema = schemas.LegacyEmailChangeSchema().bind(
-            request=pyramid_csrf_request)
-        # The email isn't taken
-        user_model.get_by_email.return_value = None
-        # The password does not check out
-        user.check_password.return_value = False
-
-        with pytest.raises(colander.Invalid) as exc:
-            schema.deserialize({'email': 'foo@bar.com',
-                                'email_confirm': 'foo@bar.com',
-                                'password': 'flibble'})
-
-        user.check_password.assert_called_once_with('flibble')
-        assert 'password' in exc.value.asdict()
-
-
 @pytest.mark.usefixtures('models')
 class TestEmailChangeSchema(object):
 


### PR DESCRIPTION
**Follow up to https://github.com/hypothesis/h/pull/4254**

Remove the schema for the legacy email change form that was used by the
pre-Activity Pages version of the site.
