### PR TITLE
Measure coverage of test code as well

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -22,8 +22,8 @@ deps =
 passenv =
     TEST_DATABASE_URL
 commands =
-    h: coverage run --parallel --source h -m pytest {posargs:tests/h/}
-    memex: coverage run --parallel --source memex -m pytest {posargs:tests/memex/}
+    h: coverage run --parallel --source h,tests/h -m pytest {posargs:tests/h/}
+    memex: coverage run --parallel --source memex,tests/memex -m pytest {posargs:tests/memex/}
 
 [testenv:functional]
 skip_install = true


### PR DESCRIPTION
It can be very useful to see and check that the coverage of test code is as we expect. Without this feedback, it's easier for bugs like that fixed in https://github.com/hypothesis/h/pull/4258 to creep in.

While this does somewhat artificially inflate our coverage numbers, I think the value of the feedback is worthwhile.