### PR TITLE
Filter on readable groups based on request

### DIFF
--- a/h/groups/__init__.py
+++ b/h/groups/__init__.py
@@ -1,4 +1,8 @@
 # -*- coding: utf-8 -*-
 
+from h.groups import search
+
+
 def includeme(config):
     config.memex_set_groupfinder('h.groups.util.fetch_group')
+    config.memex_add_search_filter(search.GroupAuthFilter)

--- a/h/groups/__init__.py
+++ b/h/groups/__init__.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from h.groups import search
-
 
 def includeme(config):
     config.memex_set_groupfinder('h.groups.util.fetch_group')
-    config.memex_add_search_filter(search.GroupAuthFilter)
+    config.memex_add_search_filter('h.groups.search.GroupAuthFilter')

--- a/h/groups/search.py
+++ b/h/groups/search.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from h.models import Group
+from h.models.group import ReadableBy
+
+
+class GroupAuthFilter(object):
+    """
+    A memex search filter that filters out groups the request isn't authorized to read.
+    """
+
+    def __init__(self, request):
+        self.authenticated_user = request.authenticated_user
+        self.session = request.db
+
+    def __call__(self, _):
+        groups = set(['__world__'])
+
+        if self.authenticated_user:
+            for group in self.authenticated_user.groups:
+                groups.add(group.pubid)
+
+        world_readable_groups = self.session.query(Group.pubid).filter_by(readable_by=ReadableBy.world)
+        for group in world_readable_groups:
+            groups.add(group[0])
+
+        return {'terms': {'group': list(groups)}}

--- a/h/groups/search.py
+++ b/h/groups/search.py
@@ -2,9 +2,6 @@
 
 from __future__ import unicode_literals
 
-from h.models import Group
-from h.models.group import ReadableBy
-
 
 class GroupAuthFilter(object):
     """
@@ -14,16 +11,8 @@ class GroupAuthFilter(object):
     def __init__(self, request):
         self.authenticated_user = request.authenticated_user
         self.session = request.db
+        self.group_service = request.find_service(name='group')
 
     def __call__(self, _):
-        groups = set(['__world__'])
-
-        if self.authenticated_user:
-            for group in self.authenticated_user.groups:
-                groups.add(group.pubid)
-
-        world_readable_groups = self.session.query(Group.pubid).filter_by(readable_by=ReadableBy.world)
-        for group in world_readable_groups:
-            groups.add(group[0])
-
-        return {'terms': {'group': list(groups)}}
+        groups = self.group_service.groupids_readable_by(self.authenticated_user)
+        return {'terms': {'group': groups}}

--- a/h/nipsa/__init__.py
+++ b/h/nipsa/__init__.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from h.nipsa import search
-
 
 def includeme(config):
     # Register the transform_annotation subscriber so that nipsa fields are
@@ -10,4 +8,4 @@ def includeme(config):
                           'memex.events.AnnotationTransformEvent')
 
     # Register an additional filter with the API search module
-    config.memex_add_search_filter(search.Filter)
+    config.memex_add_search_filter('h.nipsa.search.Filter')

--- a/h/nipsa/__init__.py
+++ b/h/nipsa/__init__.py
@@ -10,4 +10,4 @@ def includeme(config):
                           'memex.events.AnnotationTransformEvent')
 
     # Register an additional filter with the API search module
-    config.add_search_filter(search.Filter)
+    config.memex_add_search_filter(search.Filter)

--- a/src/memex/search/__init__.py
+++ b/src/memex/search/__init__.py
@@ -35,9 +35,9 @@ def includeme(config):
     # search matcher factories.
     config.registry[FILTERS_KEY] = []
     config.registry[MATCHERS_KEY] = []
-    config.add_directive('add_search_filter',
+    config.add_directive('memex_add_search_filter',
                          lambda c, f: c.registry[FILTERS_KEY].append(f))
-    config.add_directive('add_search_matcher',
+    config.add_directive('memex_add_search_matcher',
                          lambda c, m: c.registry[MATCHERS_KEY].append(m))
 
     # Add a property to all requests for easy access to the elasticsearch

--- a/src/memex/search/__init__.py
+++ b/src/memex/search/__init__.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from pyramid.settings import asbool
-
 from memex.search.client import Client
 from memex.search.config import init
 from memex.search.core import Search
@@ -36,11 +34,11 @@ def includeme(config):
     config.registry[FILTERS_KEY] = []
     config.registry[MATCHERS_KEY] = []
     config.add_directive('memex_add_search_filter',
-                         lambda c, f: c.registry[FILTERS_KEY].append(f))
+                         lambda c, f: c.registry[FILTERS_KEY].append(config.maybe_dotted(f)))
     config.add_directive('memex_get_search_filters',
                          lambda c: c.registry[FILTERS_KEY])
     config.add_directive('memex_add_search_matcher',
-                         lambda c, m: c.registry[MATCHERS_KEY].append(m))
+                         lambda c, m: c.registry[MATCHERS_KEY].append(config.maybe_dotted(m)))
     config.add_directive('memex_get_search_matchers',
                          lambda c: c.registry[MATCHERS_KEY])
 

--- a/src/memex/search/__init__.py
+++ b/src/memex/search/__init__.py
@@ -37,8 +37,12 @@ def includeme(config):
     config.registry[MATCHERS_KEY] = []
     config.add_directive('memex_add_search_filter',
                          lambda c, f: c.registry[FILTERS_KEY].append(f))
+    config.add_directive('memex_get_search_filters',
+                         lambda c: c.registry[FILTERS_KEY])
     config.add_directive('memex_add_search_matcher',
                          lambda c, m: c.registry[MATCHERS_KEY].append(m))
+    config.add_directive('memex_get_search_matchers',
+                         lambda c: c.registry[MATCHERS_KEY])
 
     # Add a property to all requests for easy access to the elasticsearch
     # client. This can be used for direct or bulk access without having to

--- a/tests/h/groups/__init___test.py
+++ b/tests/h/groups/__init___test.py
@@ -17,7 +17,7 @@ def pyramid_config(pyramid_config):
 
     filters = []
     pyramid_config.add_directive('memex_add_search_filter',
-                                 lambda c, f: filters.append(f))
+                                 lambda c, f: filters.append(pyramid_config.maybe_dotted(f)))
     pyramid_config.add_directive('memex_get_search_filters',
                                  lambda c: filters)
     return pyramid_config

--- a/tests/h/groups/__init___test.py
+++ b/tests/h/groups/__init___test.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+
+from h.groups import includeme
+from h.groups.search import GroupAuthFilter
+
+
+def test_includeme_registers_search_filter(pyramid_config):
+    includeme(pyramid_config)
+    assert GroupAuthFilter in pyramid_config.memex_get_search_filters()
+
+
+@pytest.fixture
+def pyramid_config(pyramid_config):
+    pyramid_config.add_directive('memex_set_groupfinder', lambda c, f: None)
+
+    filters = []
+    pyramid_config.add_directive('memex_add_search_filter',
+                                 lambda c, f: filters.append(f))
+    pyramid_config.add_directive('memex_get_search_filters',
+                                 lambda c: filters)
+    return pyramid_config

--- a/tests/h/groups/search_test.py
+++ b/tests/h/groups/search_test.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import pytest
+
+from h.groups import search
+from h.models.group import ReadableBy
+
+
+class TestGroupAuthFilter(object):
+    @pytest.mark.parametrize('is_authenticated', [True, False])
+    def test_filter_includes_world_group(self, pyramid_request, factories, is_authenticated):
+        if is_authenticated:
+            pyramid_request.authenticated_user = factories.User()
+
+        filter_ = search.GroupAuthFilter(pyramid_request)
+
+        filtered_groups = filter_(None)['terms']['group']
+        assert '__world__' in filtered_groups
+
+    @pytest.mark.parametrize('is_authenticated', [True, False])
+    def test_filter_includes_world_readable_groups(
+            self, pyramid_request, db_session, factories, is_authenticated):
+        group_1 = factories.Group(readable_by=ReadableBy.members)
+        group_2 = factories.Group(readable_by=ReadableBy.world)
+        group_3 = factories.Group(readable_by=ReadableBy.members)
+        group_4 = factories.Group(readable_by=ReadableBy.world)
+        db_session.add_all([group_1, group_2])
+
+        if is_authenticated:
+            user = factories.User()
+            db_session.add(user)
+            pyramid_request.authenticated_user = user
+
+        filter_ = search.GroupAuthFilter(pyramid_request)
+
+        filtered_groups = filter_(None)['terms']['group']
+        assert group_1.pubid not in filtered_groups
+        assert group_3.pubid not in filtered_groups
+        assert group_2.pubid in filtered_groups
+        assert group_4.pubid in filtered_groups
+
+    def test_filter_includes_group_memberships(self, pyramid_request, db_session, factories):
+        user = factories.User()
+        group_1 = factories.Group(creator=user)
+        group_2 = factories.Group()
+        group_3 = factories.Group()
+        group_3.members.append(user)
+        db_session.add_all([user, group_1, group_2, group_3])
+        db_session.flush()
+
+        pyramid_request.authenticated_user = user
+        filter_ = search.GroupAuthFilter(pyramid_request)
+
+        filtered_groups = filter_(None)['terms']['group']
+        assert group_1.pubid in filtered_groups
+        assert group_3.pubid in filtered_groups
+        assert group_2.pubid not in filtered_groups
+
+    @pytest.fixture
+    def pyramid_request(self, pyramid_request):
+        pyramid_request.authenticated_user = None
+        return pyramid_request
+
+    @pytest.fixture
+    def user(self, db_session, factories):
+        user = factories.User()
+        db_session.add(user)
+        db_session.flush()
+        return user

--- a/tests/h/groups/search_test.py
+++ b/tests/h/groups/search_test.py
@@ -2,70 +2,37 @@
 
 from __future__ import unicode_literals
 
+import mock
 import pytest
 
 from h.groups import search
-from h.models.group import ReadableBy
 
 
+@pytest.mark.usefixtures('group_service')
 class TestGroupAuthFilter(object):
-    @pytest.mark.parametrize('is_authenticated', [True, False])
-    def test_filter_includes_world_group(self, pyramid_request, factories, is_authenticated):
-        if is_authenticated:
-            pyramid_request.authenticated_user = factories.User()
+    def test_fetches_readable_groups(self, pyramid_request, group_service):
+        pyramid_request.authenticated_user = mock.sentinel.user
 
         filter_ = search.GroupAuthFilter(pyramid_request)
+        filter_({})
 
-        filtered_groups = filter_(None)['terms']['group']
-        assert '__world__' in filtered_groups
+        group_service.groupids_readable_by.assert_called_once_with(mock.sentinel.user)
 
-    @pytest.mark.parametrize('is_authenticated', [True, False])
-    def test_filter_includes_world_readable_groups(
-            self, pyramid_request, db_session, factories, is_authenticated):
-        group_1 = factories.Group(readable_by=ReadableBy.members)
-        group_2 = factories.Group(readable_by=ReadableBy.world)
-        group_3 = factories.Group(readable_by=ReadableBy.members)
-        group_4 = factories.Group(readable_by=ReadableBy.world)
-        db_session.add_all([group_1, group_2])
-
-        if is_authenticated:
-            user = factories.User()
-            db_session.add(user)
-            pyramid_request.authenticated_user = user
+    def test_returns_terms_filter(self, pyramid_request, group_service):
+        group_service.groupids_readable_by.return_value = ['group-a', 'group-b']
 
         filter_ = search.GroupAuthFilter(pyramid_request)
+        result = filter_({})
 
-        filtered_groups = filter_(None)['terms']['group']
-        assert group_1.pubid not in filtered_groups
-        assert group_3.pubid not in filtered_groups
-        assert group_2.pubid in filtered_groups
-        assert group_4.pubid in filtered_groups
+        assert result == {'terms': {'group': ['group-a', 'group-b']}}
 
-    def test_filter_includes_group_memberships(self, pyramid_request, db_session, factories):
-        user = factories.User()
-        group_1 = factories.Group(creator=user)
-        group_2 = factories.Group()
-        group_3 = factories.Group()
-        group_3.members.append(user)
-        db_session.add_all([user, group_1, group_2, group_3])
-        db_session.flush()
-
-        pyramid_request.authenticated_user = user
-        filter_ = search.GroupAuthFilter(pyramid_request)
-
-        filtered_groups = filter_(None)['terms']['group']
-        assert group_1.pubid in filtered_groups
-        assert group_3.pubid in filtered_groups
-        assert group_2.pubid not in filtered_groups
+    @pytest.fixture
+    def group_service(self, patch, pyramid_config):
+        svc = patch('h.services.group.GroupService')
+        pyramid_config.register_service(svc, name='group')
+        return svc
 
     @pytest.fixture
     def pyramid_request(self, pyramid_request):
         pyramid_request.authenticated_user = None
         return pyramid_request
-
-    @pytest.fixture
-    def user(self, db_session, factories):
-        user = factories.User()
-        db_session.add(user)
-        db_session.flush()
-        return user


### PR DESCRIPTION
This adds a new filter to all memex search queries which makes sure that we do a terms filter on the group field with all the groups that the user has access to, which are:

* `__world__`
* All groups the user is a member of
* All groups with `readable_by=ReadableBy.world`

This is part of hypothesis/product-backlog#95.