### PR TITLE
Move transaction handling from memex.eventqueue to h

### DIFF
--- a/h/subscribers.py
+++ b/h/subscribers.py
@@ -44,19 +44,8 @@ def send_reply_notifications(event,
     with request.tm:
         annotation = storage.fetch_annotation(event.request.db,
                                               event.annotation_id)
-        action = event.action
-        try:
-            notification = get_notification(request, annotation, action)
-            if notification is None:
-                return
-            send_params = generate_mail(request, notification)
-            send(*send_params)
-        # We don't want any exceptions thrown by this code to cause the
-        # annotation CRUD action to fail, but we do want to collect the error
-        # in Sentry, so we explicitly wrap this here.
-        #
-        # FIXME: Fix the underlying bugs and remove this try/except.
-        except Exception:
-            event.request.sentry.captureException()
-            if event.request.debug:
-                raise
+        notification = get_notification(request, annotation, event.action)
+        if notification is None:
+            return
+        send_params = generate_mail(request, notification)
+        send(*send_params)

--- a/h/subscribers.py
+++ b/h/subscribers.py
@@ -41,20 +41,22 @@ def send_reply_notifications(event,
                              send=mailer.send.delay):
     """Queue any reply notification emails triggered by an annotation event."""
     request = event.request
-    annotation = storage.fetch_annotation(event.request.db, event.annotation_id)
-    action = event.action
-    try:
-        notification = get_notification(request, annotation, action)
-        if notification is None:
-            return
-        send_params = generate_mail(request, notification)
-        send(*send_params)
-    # We don't want any exceptions thrown by this code to cause the annotation
-    # CRUD action to fail, but we do want to collect the error in Sentry, so we
-    # explicitly wrap this here.
-    #
-    # FIXME: Fix the underlying bugs and remove this try/except.
-    except Exception:
-        event.request.sentry.captureException()
-        if event.request.debug:
-            raise
+    with request.tm:
+        annotation = storage.fetch_annotation(event.request.db,
+                                              event.annotation_id)
+        action = event.action
+        try:
+            notification = get_notification(request, annotation, action)
+            if notification is None:
+                return
+            send_params = generate_mail(request, notification)
+            send(*send_params)
+        # We don't want any exceptions thrown by this code to cause the
+        # annotation CRUD action to fail, but we do want to collect the error
+        # in Sentry, so we explicitly wrap this here.
+        #
+        # FIXME: Fix the underlying bugs and remove this try/except.
+        except Exception:
+            event.request.sentry.captureException()
+            if event.request.debug:
+                raise

--- a/src/memex/eventqueue.py
+++ b/src/memex/eventqueue.py
@@ -40,8 +40,7 @@ class EventQueue(object):
         if request.exception is not None:
             return
 
-        with request.tm:
-            self.publish_all()
+        self.publish_all()
 
 
 def includeme(config):

--- a/tests/h/subscribers_test.py
+++ b/tests/h/subscribers_test.py
@@ -108,3 +108,8 @@ class TestSendReplyNotifications(object):
     @pytest.fixture
     def fetch_annotation(self, patch):
         return patch('h.subscribers.storage.fetch_annotation')
+
+    @pytest.fixture
+    def pyramid_request(self, pyramid_request):
+        pyramid_request.tm = mock.MagicMock()
+        return pyramid_request

--- a/tests/h/subscribers_test.py
+++ b/tests/h/subscribers_test.py
@@ -76,35 +76,6 @@ class TestSendReplyNotifications(object):
                                               mock.sentinel.notification)
         assert send.lastcall == (['foo@example.com'], 'Your email', 'Text body', 'HTML body')
 
-    def test_catches_exceptions_and_reports_to_sentry(self, pyramid_request):
-        send = FakeMailer()
-        get_notification = mock.Mock(spec_set=[], side_effect=RuntimeError('asplode!'))
-        generate_mail = mock.Mock(spec_set=[], return_value=[])
-        pyramid_request.debug = False
-        pyramid_request.sentry = mock.Mock()
-        event = AnnotationEvent(pyramid_request, None, None)
-
-        subscribers.send_reply_notifications(event,
-                                             get_notification=get_notification,
-                                             generate_mail=generate_mail,
-                                             send=send)
-
-        event.request.sentry.captureException.assert_called_once_with()
-
-    def test_reraises_exceptions_in_debug_mode(self, pyramid_request):
-        send = FakeMailer()
-        get_notification = mock.Mock(spec_set=[], side_effect=RuntimeError('asplode!'))
-        generate_mail = mock.Mock(spec_set=[], return_value=[])
-        pyramid_request.debug = True
-        pyramid_request.sentry = mock.Mock()
-        event = AnnotationEvent(pyramid_request, None, None)
-
-        with pytest.raises(RuntimeError):
-            subscribers.send_reply_notifications(event,
-                                                 get_notification=get_notification,
-                                                 generate_mail=generate_mail,
-                                                 send=send)
-
     @pytest.fixture
     def fetch_annotation(self, patch):
         return patch('h.subscribers.storage.fetch_annotation')

--- a/tests/h/subscribers_test.py
+++ b/tests/h/subscribers_test.py
@@ -40,42 +40,40 @@ class TestPublishAnnotationEvent:
 
 @pytest.mark.usefixtures('fetch_annotation')
 class TestSendReplyNotifications(object):
-    def test_calls_get_notification_with_request_annotation_and_action(self, fetch_annotation):
+    def test_calls_get_notification_with_request_annotation_and_action(self, fetch_annotation, pyramid_request):
         send = FakeMailer()
         get_notification = mock.Mock(spec_set=[], return_value=None)
         generate_mail = mock.Mock(spec_set=[], return_value=[])
-        event = AnnotationEvent(mock.sentinel.request,
+        event = AnnotationEvent(pyramid_request,
                                 mock.sentinel.annotation_id,
                                 mock.sentinel.action)
-        mock.sentinel.request.db = mock.Mock()
 
         subscribers.send_reply_notifications(event,
                                              get_notification=get_notification,
                                              generate_mail=generate_mail,
                                              send=send)
 
-        fetch_annotation.assert_called_once_with(mock.sentinel.request.db,
+        fetch_annotation.assert_called_once_with(pyramid_request.db,
                                                  mock.sentinel.annotation_id)
 
-        get_notification.assert_called_once_with(mock.sentinel.request,
+        get_notification.assert_called_once_with(pyramid_request,
                                                  fetch_annotation.return_value,
                                                  mock.sentinel.action)
 
-    def test_generates_and_sends_mail_for_any_notification(self):
-        s = mock.sentinel
+    def test_generates_and_sends_mail_for_any_notification(self, pyramid_request):
         send = FakeMailer()
-        get_notification = mock.Mock(spec_set=[], return_value=s.notification)
+        get_notification = mock.Mock(spec_set=[], return_value=mock.sentinel.notification)
         generate_mail = mock.Mock(spec_set=[])
         generate_mail.return_value = (['foo@example.com'], 'Your email', 'Text body', 'HTML body')
-        event = AnnotationEvent(s.request, None, None)
-        s.request.db = mock.Mock()
+        event = AnnotationEvent(pyramid_request, None, None)
 
         subscribers.send_reply_notifications(event,
                                              get_notification=get_notification,
                                              generate_mail=generate_mail,
                                              send=send)
 
-        generate_mail.assert_called_once_with(s.request, s.notification)
+        generate_mail.assert_called_once_with(pyramid_request,
+                                              mock.sentinel.notification)
         assert send.lastcall == (['foo@example.com'], 'Your email', 'Text body', 'HTML body')
 
     def test_catches_exceptions_and_reports_to_sentry(self, pyramid_request):

--- a/tests/memex/eventqueue_test.py
+++ b/tests/memex/eventqueue_test.py
@@ -76,7 +76,6 @@ class TestEventQueue(object):
         assert not publish_all.called
 
     def test_response_callback_publishes_events(self, publish_all, pyramid_request):
-        pyramid_request.tm = mock.MagicMock()
         queue = eventqueue.EventQueue(pyramid_request)
         queue(mock.Mock())
         queue.response_callback(pyramid_request, None)


### PR DESCRIPTION
This small piece of code in memex was the only part of memex that knew anything about the request transaction. Given that it is otherwise possible for memex to operate without knowledge of transaction handling, and that only one piece of code actually needs a valid database session in these after-request handlers, it seems sensible to just move the necessary context manager to where it's needed.