### PR TITLE
Remove non-Activity Pages version of logged out accounts forms

### DIFF
--- a/h/templates/accounts/forgot_password.html.jinja2
+++ b/h/templates/accounts/forgot_password.html.jinja2
@@ -1,41 +1,20 @@
 {% extends "h:templates/layouts/base.html.jinja2" %}
 
-{% if not feature('activity_pages') %}
-{% set style_bundle = 'legacy_site_css' %}
-{% endif %}
-
 {% block header %}
   {% include "h:templates/includes/logo-header.html.jinja2" %}
 {% endblock %}
 
 {% block page_title %}
-{% if feature('activity_pages') %}
 Reset your password
-{% else %}
-Password reset
-{% endif %}
 {% endblock %}
 
 {% block content %}
-{%if feature('activity_pages') %}
-  <div class="form-container content">
-    <h1 class="form-header">Reset your password</h1>
-    {{ form }}
-    <footer class="form-footer">
-      Already know your password?
-      <a class="link--footer" href="{{ request.route_path('login') }}">Log in</a>
-    </footer>
-  </div>
-{% else %}
-  <div class="content paper">
-    <div class="form-vertical">
-      <ul class="nav nav-tabs">
-        <li><a href="{{ request.route_path('login') }}">Log in</a></li>{#
-        #}<li><a href="{{ request.route_path('signup') }}">Create an account</a></li>{#
-        #}<li class="active"><a href="{{ request.route_path('forgot_password') }}">Password reset</a></li>
-      </ul>
-      {{ form }}
-    </div>
-  </div>
-{% endif %}
+<div class="form-container content">
+  <h1 class="form-header">Reset your password</h1>
+  {{ form }}
+  <footer class="form-footer">
+    Already know your password?
+    <a class="link--footer" href="{{ request.route_path('login') }}">Log in</a>
+  </footer>
+</div>
 {% endblock content %}

--- a/h/templates/accounts/login.html.jinja2
+++ b/h/templates/accounts/login.html.jinja2
@@ -1,9 +1,5 @@
 {% extends "h:templates/layouts/base.html.jinja2" %}
 
-{% if not feature('activity_pages') %}
-{% set style_bundle = 'legacy_site_css' %}
-{% endif %}
-
 {% block header %}
   {% include "h:templates/includes/logo-header.html.jinja2" %}
 {% endblock %}
@@ -11,24 +7,12 @@
 {% block page_title %}Log in{% endblock %}
 
 {% block content %}
-  {%if feature('activity_pages') %}
-    <div class="form-container content">
-      <h1 class="form-header">Log in</h1>
-      {{ form }}
-      <footer class="form-footer">
-        Don't have a Hypothesis account?
-        <a class="link--footer" href="{{ request.route_path('signup') }}">Sign up</a>
-      </footer>
-    </div>
-  {% else %}
-    <div class="content paper">
-      <div class="form-vertical">
-        <ul class="nav nav-tabs">
-          <li class="active"><a href="{{ request.route_path('login') }}">Log in</a></li>{#
-          #}<li><a href="{{ request.route_path('signup') }}">Create an account</a></li>
-        </ul>
-        {{ form }}
-      </div>
-    </div>
-  {% endif %}
+  <div class="form-container content">
+    <h1 class="form-header">Log in</h1>
+    {{ form }}
+    <footer class="form-footer">
+      Don't have a Hypothesis account?
+      <a class="link--footer" href="{{ request.route_path('signup') }}">Sign up</a>
+    </footer>
+  </div>
 {% endblock content %}

--- a/h/templates/accounts/reset.html.jinja2
+++ b/h/templates/accounts/reset.html.jinja2
@@ -1,58 +1,28 @@
 {% extends "h:templates/layouts/base.html.jinja2" %}
 
-{% if not feature('activity_pages') %}
-{% set style_bundle = 'legacy_site_css' %}
-{% endif %}
-
 {% block header %}
   {% include "h:templates/includes/logo-header.html.jinja2" %}
 {% endblock %}
 
 {% block page_title %}
-{% if feature('activity_pages') %}
 Reset your password
-{% else %}
-Password reset
-{% endif %}
 {% endblock %}
 
 {% block content %}
-  {% if feature('activity_pages') %}
-  <div class="form-container content">
-    <h1 class="form-header">New password</h1>
-    {% if not has_code %}
-    <div class="form-description">
-    {% trans %}
-    Please check your email. We've sent you a reset code that you must enter
-    below in order to set your new password.
-    {% endtrans %}
-    </div>
-    {% endif %}
-    {{ form }}
-    <footer class="form-footer">
-      Already know your password?
-      <a class="link--footer" href="{{ request.route_path('login') }}">Log in</a>
-    </footer>
-  </div>
-  {% else %}
-  <div class="content paper">
-    <div class="form-vertical">
-      <ul class="nav nav-tabs">
-        <li><a href="{{ request.route_path('login') }}">Log in</a></li>{#
-        #}<li><a href="{{ request.route_path('signup') }}">Create an account</a></li>{#
-        #}<li class="active"><a href="">New password</a></li>
-      </ul>
-      {% if not has_code %}
-      <legend>
-        {% trans %}
-        When you reset your password, we will send you an email containing a
-        code you can use to complete the process. Please check your email and
-        retrieve the code in order to set your new password.
-        {% endtrans %}
-      </legend>
-      {% endif %}
-      {{ form }}
-    </div>
+<div class="form-container content">
+  <h1 class="form-header">New password</h1>
+  {% if not has_code %}
+  <div class="form-description">
+  {% trans %}
+  Please check your email. We've sent you a reset code that you must enter
+  below in order to set your new password.
+  {% endtrans %}
   </div>
   {% endif %}
+  {{ form }}
+  <footer class="form-footer">
+    Already know your password?
+    <a class="link--footer" href="{{ request.route_path('login') }}">Log in</a>
+  </footer>
+</div>
 {% endblock content %}

--- a/h/templates/accounts/signup.html.jinja2
+++ b/h/templates/accounts/signup.html.jinja2
@@ -1,40 +1,20 @@
 {% extends "h:templates/layouts/base.html.jinja2" %}
 
-{% if not feature('activity_pages') %}
-{% set style_bundle = 'legacy_site_css' %}
-{% endif %}
-
 {% block header %}
   {% include "h:templates/includes/logo-header.html.jinja2" %}
 {% endblock %}
 
 {% block page_title %}
-{% if feature('activity_pages') %}
 Sign up for Hypothesis
-{% else %}
-Create account
-{% endif %}
 {% endblock %}
 
 {% block content %}
-  {%if feature('activity_pages') %}
-    <div class="form-container content">
-      <h1 class="form-header">Sign up for Hypothesis</h1>
-      {{ form }}
-      <footer class="form-footer">
-        Already have an account?
-        <a class="link--footer" href="{{ request.route_path('login') }}">Log in</a>
-      </footer>
-    </div>
-  {% else %}
-  <div class="content paper">
-    <div class="form-vertical">
-      <ul class="nav nav-tabs">
-        <li><a href="{{ request.route_path('login') }}">Log in</a></li>{#
-        #}<li class="active"><a href="{{ request.route_path('signup') }}">Create an account</a></li>
-      </ul>
-      {{ form }}
-    </div>
-  </div>
-  {% endif %}
+<div class="form-container content">
+  <h1 class="form-header">Sign up for Hypothesis</h1>
+  {{ form }}
+  <footer class="form-footer">
+    Already have an account?
+    <a class="link--footer" href="{{ request.route_path('login') }}">Log in</a>
+  </footer>
+</div>
 {% endblock content %}

--- a/h/templates/includes/logo-header.html.jinja2
+++ b/h/templates/includes/logo-header.html.jinja2
@@ -1,10 +1,4 @@
 <header class="masthead">
-  {% if feature('activity_pages') %}
   <a href="/" title="Hypothesis homepage"><!--
     !-->{{ svg_icon('logo', 'masthead-logo') }}</a>
-  {% else %}
-  <hgroup>
-	<a href="https://hypothes.is" class="masthead-heading">Hypothes<span class="red">.</span>is</a>
-  </hgroup>
-  {% endif %}
 </header>

--- a/h/templates/panels/navbar.html.jinja2
+++ b/h/templates/panels/navbar.html.jinja2
@@ -2,8 +2,6 @@
 
 {% block content %}
 
-{% if feature('activity_pages') %}
-
 {% macro lozenge(facetName, facetValue) %}
   <div class="lozenge">
     <div class="lozenge__content">
@@ -111,5 +109,4 @@
 <script type="application/json" class="js-group-suggestions">
   {{groups_suggestions | to_json}}
 </script>
-{% endif %}
 {% endblock %}

--- a/tests/functional/test_accounts.py
+++ b/tests/functional/test_accounts.py
@@ -18,7 +18,7 @@ class TestAccountSettings(object):
 
         res = email_form.submit().follow()
 
-        assert res.body.startswith('<!DOCTYPE html>')
+        assert res.text.startswith('<!DOCTYPE html>')
 
     def test_submit_email_form_with_xhr_returns_partial_html_snippet(self,
                                                                      app):
@@ -30,7 +30,7 @@ class TestAccountSettings(object):
 
         res = email_form.submit(xhr=True, status=200)
 
-        assert res.body.strip('\n').startswith('<form')
+        assert res.text.strip('\n').startswith('<form')
 
     def test_submit_email_form_with_xhr_returns_plain_text(self, app):
         res = app.get('/account/settings')
@@ -54,7 +54,7 @@ class TestAccountSettings(object):
 
         res = password_form.submit().follow()
 
-        assert res.body.startswith('<!DOCTYPE html>')
+        assert res.text.startswith('<!DOCTYPE html>')
 
     def test_submit_password_form_with_xhr_returns_partial_html_snippet(self,
                                                                         app):
@@ -67,7 +67,7 @@ class TestAccountSettings(object):
 
         res = password_form.submit(xhr=True)
 
-        assert res.body.strip('\n').startswith('<form')
+        assert res.text.strip('\n').startswith('<form')
 
     def test_submit_password_form_with_xhr_returns_plain_text(self, app):
         res = app.get('/account/settings')


### PR DESCRIPTION
Also remove uses of the `activity_pages` flag in the navbar and masthead, since all pages using them have now had their own use of the `activity_pages` flag removed.