### PR TITLE
Disable click-tracking for accounts emails

### DIFF
--- a/h/emails/__init__.py
+++ b/h/emails/__init__.py
@@ -1,5 +1,9 @@
 # -*- coding: utf-8 -*-
 
-from h.emails import reply_notification, signup
+from h.emails import reply_notification, reset_password, signup
 
-__all__ = ('reply_notification', 'signup')
+__all__ = (
+    'reply_notification',
+    'reset_password',
+    'signup',
+)

--- a/h/emails/reset_password.py
+++ b/h/emails/reset_password.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from pyramid.renderers import render
+
+from h.i18n import TranslationString as _
+
+
+def generate(request, user):
+    """
+    Generate an email for a user password reset request.
+
+    :param request: the current request
+    :type request: pyramid.request.Request
+    :param user: the user to whom to send the reset code
+    :type user: h.models.User
+
+    :returns: a 4-element tuple containing: recipients, subject, text, html
+    """
+    serializer = request.registry.password_reset_serializer
+    code = serializer.dumps(user.username)
+    context = {
+        'username': user.username,
+        'reset_code': code,
+        'reset_link': request.route_url('account_reset_with_code', code=code)
+    }
+
+    subject = _('Reset your password')
+
+    text = render('h:templates/emails/reset_password.txt.jinja2',
+                  context,
+                  request=request)
+    html = render('h:templates/emails/reset_password.html.jinja2',
+                  context,
+                  request=request)
+
+    return [user.email], subject, text, html

--- a/h/templates/emails/reset_password.html.jinja2
+++ b/h/templates/emails/reset_password.html.jinja2
@@ -1,0 +1,17 @@
+<p>Hello {{ username }}!</p>
+
+<p>
+  Someone has requested to reset your password. If it was you, reset your
+  password by using this reset code:
+</p>
+
+<p>&nbsp;&nbsp;<code><pre>{{ reset_code }}</pre></code></p>
+
+<p>Alternatively, you can reset your password by clicking on this link:</p>
+
+<p>&nbsp;&nbsp;<a href="{{ reset_link }}">{{ reset_link }}</a></p>
+
+<p>
+  Regards,
+  The Hypothesis Team
+</p>

--- a/h/templates/emails/reset_password.html.jinja2
+++ b/h/templates/emails/reset_password.html.jinja2
@@ -9,7 +9,14 @@
 
 <p>Alternatively, you can reset your password by clicking on this link:</p>
 
-<p>&nbsp;&nbsp;<a href="{{ reset_link }}">{{ reset_link }}</a></p>
+{#
+  mc:disable-tracking disables click-tracking in MailChimp, and is necessary to
+  ensure that the reset link is not leaked (MailChimp click-tracking happens
+  over HTTP, not HTTPS):
+
+    https://mandrill.zendesk.com/hc/en-us/articles/205582927
+#}
+<p>&nbsp;&nbsp;<a href="{{ reset_link }}" mc:disable-tracking>{{ reset_link }}</a></p>
 
 <p>
   Regards,

--- a/h/templates/emails/reset_password.txt.jinja2
+++ b/h/templates/emails/reset_password.txt.jinja2
@@ -1,0 +1,13 @@
+Hello {{ username }}!
+
+Someone has requested to reset your password. If it was you, reset your password
+by using this reset code:
+
+{{ reset_code }}
+
+Alternatively, you can reset your password by clicking on this link:
+
+{{ reset_link }}
+
+Regards,
+The Hypothesis Team

--- a/h/templates/emails/signup.html.jinja2
+++ b/h/templates/emails/signup.html.jinja2
@@ -1,3 +1,10 @@
 <p>Please validate your email and activate your account by visiting:</p>
 
-<p>&nbsp;&nbsp;<a href="{{activate_link}}">{{activate_link}}</a></p>
+{#
+  mc:disable-tracking disables click-tracking in MailChimp, and is necessary to
+  ensure that the activate link is not leaked (MailChimp click-tracking happens
+  over HTTP, not HTTPS):
+
+    https://mandrill.zendesk.com/hc/en-us/articles/205582927
+#}
+<p>&nbsp;&nbsp;<a href="{{activate_link}}" mc:disable-tracking>{{activate_link}}</a></p>

--- a/tests/h/emails/reset_password_test.py
+++ b/tests/h/emails/reset_password_test.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import pytest
+import mock
+
+from h.emails.reset_password import generate
+
+
+@pytest.mark.usefixtures('routes')
+class TestGenerate(object):
+
+    def test_calls_renderers_with_appropriate_context(self,
+                                                      pyramid_request,
+                                                      html_renderer,
+                                                      text_renderer,
+                                                      serializer,
+                                                      user):
+        pyramid_request.registry.password_reset_serializer = serializer
+
+        generate(pyramid_request, user)
+
+        expected_context = {
+            'username': user.username,
+            'reset_code': 's3cr3t-r3s3t-c0d3',
+            'reset_link': 'http://example.com/reset/s3cr3t-r3s3t-c0d3',
+        }
+        html_renderer.assert_(**expected_context)
+        text_renderer.assert_(**expected_context)
+
+    @pytest.mark.usefixtures('html_renderer', 'text_renderer')
+    def test_generates_token_using_username(self,
+                                            pyramid_request,
+                                            serializer,
+                                            user):
+        pyramid_request.registry.password_reset_serializer = serializer
+
+        generate(pyramid_request, user)
+
+        serializer.dumps.assert_called_once_with(user.username)
+
+    def test_appropriate_return_values(self,
+                                       pyramid_request,
+                                       html_renderer,
+                                       text_renderer,
+                                       serializer,
+                                       user):
+        pyramid_request.registry.password_reset_serializer = serializer
+
+        html_renderer.string_response = 'HTML output'
+        text_renderer.string_response = 'Text output'
+
+        recipients, subject, text, html = generate(pyramid_request, user)
+
+        assert recipients == [user.email]
+        assert subject == 'Reset your password'
+        assert html == 'HTML output'
+        assert text == 'Text output'
+
+    def test_jinja_templates_render(self,
+                                    pyramid_config,
+                                    pyramid_request,
+                                    serializer,
+                                    user):
+        """Ensure that the jinja templates don't contain syntax errors"""
+        pyramid_config.include('pyramid_jinja2')
+        pyramid_request.registry.password_reset_serializer = serializer
+
+        generate(pyramid_request, user)
+
+    @pytest.fixture
+    def routes(self, pyramid_config):
+        pyramid_config.add_route('account_reset_with_code', '/reset/{code}')
+
+    @pytest.fixture
+    def serializer(self):
+        serializer = mock.Mock(spec_set=['dumps'])
+        serializer.dumps.return_value = 's3cr3t-r3s3t-c0d3'
+        return serializer
+
+    @pytest.fixture
+    def html_renderer(self, pyramid_config):
+        return pyramid_config.testing_add_renderer('h:templates/emails/reset_password.html.jinja2')
+
+    @pytest.fixture
+    def text_renderer(self, pyramid_config):
+        return pyramid_config.testing_add_renderer('h:templates/emails/reset_password.txt.jinja2')
+
+    @pytest.fixture
+    def user(self, factories):
+        return factories.User()


### PR DESCRIPTION
Mandrill's click-tracking system rewrites links in emails, and the resulting link is HTTP (not HTTPS), which means that a MitM attacker could easily sniff the link.

An attacker who can sniff the reset password link can take over the user's account, so it's important that we disable click-tracking for this link.

While activating the user's account is not a particular dangerous thing for an attacker to be able to do, we might in future choose to log the user in immediately after activation, so it seems appropriately cautious to disable click-tracking on this link, too.