### PR TITLE
Update the style of the 403/404 page

### DIFF
--- a/h/panels/navbar.py
+++ b/h/panels/navbar.py
@@ -37,7 +37,9 @@ def navbar(context, request, search=None, opts=None):
                                               username=request.authenticated_user.username)
         username = request.authenticated_user.username
 
-    if request.matched_route.name in ['group_read', 'activity.user_search']:
+    route = request.matched_route
+
+    if route and route.name in ['group_read', 'activity.user_search']:
         search_url = request.current_route_url()
     else:
         search_url = request.route_url('activity.search')

--- a/h/templates/notfound.html.jinja2
+++ b/h/templates/notfound.html.jinja2
@@ -1,23 +1,15 @@
 {% extends "layouts/base.html.jinja2" %}
 
-{% set style_bundle = 'legacy_site_css' %}
-
 {% block title %}Page Not Found{% endblock %}
 
 {% block content %}
-  <main class="content paper styled-text page">
-    <h1>There&rsquo;s nothing here!</h1>
-    <p>Either this page doesn&rsquo;t exist, or you don&rsquo;t have the permissions required for viewing it.</p>
-    <form class="form" action="/stream" method="get">
-      <div class="form-field">
-        <label class="form-label" for="search">Search annotations:</label>
-        <input class="form-input" name="q" type="text" />
-        <div class="form-actions">
-          <div class="form-actions-buttons">
-            <button class="btn btn-primary" type="submit">Search</button>
-          </div>
-        </div>
-      </div>
-    </form>
-  </main>
+  {{ panel('navbar') }}
+  <div class="form-container">
+    <h1 class="form-header">Page not found</h1>
+    <p>Either this page does not exist, or you do not have the permissions required for viewing it.</p>
+  </div>
+{% endblock %}
+
+{% block footer %}
+  {% include "h:templates/includes/footer.html.jinja2" %}
 {% endblock %}

--- a/tests/h/panels/navbar_test.py
+++ b/tests/h/panels/navbar_test.py
@@ -66,6 +66,11 @@ class TestNavbar(object):
         result = navbar({}, req)
         assert result['search_url'] == 'http://example.com/search'
 
+    def test_it_includes_default_search_url_if_no_matched_route(self, req):
+        req.matched_route = None
+        result = navbar({}, req)
+        assert result['search_url'] == 'http://example.com/search'
+
     @pytest.fixture
     def routes(self, pyramid_config):
         pyramid_config.add_route('account', '/account')


### PR DESCRIPTION
Update the 403/404 page to:

 - Look like the rest of the new site
 - Include useful navigation links to pages on the site that do exist,
   by including the navbar and footer.
 - Link to the /search page instead of the stream (via the navbar)

----

![updated-404-page](https://cloud.githubusercontent.com/assets/2458/21453085/bf4dce92-c903-11e6-9da1-15dc5842e2b5.png)
