### PR TITLE
Update the style of the account claim page

### DIFF
--- a/h/templates/accounts/claim_account_legacy.html.jinja2
+++ b/h/templates/accounts/claim_account_legacy.html.jinja2
@@ -1,12 +1,11 @@
 {% extends "h:templates/layouts/base.html.jinja2" %}
 
-{% set style_bundle = 'legacy_site_css' %}
-
 {% block page_title %}Claim account{% endblock page_title %}
 
 {% block content %}
-  <div id="claim" class="content paper">
-    {% include "h:templates/includes/logo-header.html.jinja2" %}
+  {% include "h:templates/includes/logo-header.html.jinja2" %}
+  <div class="form-container">
+    <h1 class="form-header">Claim account</h1>
     <p>
       Sorry, your claim link has expired. If you still wish to claim a username
       you reserved, please contact us at


### PR DESCRIPTION
Update the style to match the look of the new website and remove use of
the legacy style bundle.

There is a note in the code that the account claim page should be removed after October 2016, so perhaps we can just remove this page instead?

----

![updated-claim-account](https://cloud.githubusercontent.com/assets/2458/21453151/4c55b656-c904-11e6-9489-c58bb5957abb.png)
