### PR TITLE
Remove the navbar from the 404 page

### DIFF
--- a/h/templates/notfound.html.jinja2
+++ b/h/templates/notfound.html.jinja2
@@ -3,7 +3,7 @@
 {% block title %}Page Not Found{% endblock %}
 
 {% block content %}
-  {{ panel('navbar') }}
+  {% include 'h:templates/includes/logo-header.html.jinja2' %}
   <div class="form-container">
     <h1 class="form-header">Page not found</h1>
     <p>Either this page does not exist, or you do not have the permissions required for viewing it.</p>


### PR DESCRIPTION
On staging attempting to render the navbar from the 404 page triggered
a SQLAlchemy exception. See https://sentry.io/hypothesis/stage/issues/196768845/

Until a fix for that is available, just remove the navbar from the 404
page for the moment.