### PR TITLE
Fix annotation stats missing grouping keys

### DIFF
--- a/h/services/annotation_stats.py
+++ b/h/services/annotation_stats.py
@@ -21,9 +21,12 @@ class AnnotationStatsService(object):
         ], else_='group')
 
         result = dict(self.session.query(grouping, sa.func.count(annotations.c.id)).group_by(grouping).all())
-        result['total'] = result.get('public', 0) + \
-            result.get('group', 0) + \
-            result.get('private', 0)
+        for key in ['public', 'group', 'private']:
+            result.setdefault(key, 0)
+
+        result['total'] = result['public'] + \
+            result['group'] + \
+            result['private']
 
         return result
 

--- a/h/services/annotation_stats.py
+++ b/h/services/annotation_stats.py
@@ -14,7 +14,9 @@ class AnnotationStatsService(object):
     def user_annotation_counts(self, userid):
         """Return the count of annotations for this user."""
 
-        annotations = self.session.query(Annotation).filter_by(userid=userid).options(sa.orm.load_only('groupid', 'shared')).subquery()
+        annotations = self.session.query(Annotation). \
+            filter_by(userid=userid, deleted=False). \
+            options(sa.orm.load_only('groupid', 'shared')).subquery()
         grouping = sa.case([
             (sa.not_(annotations.c.shared), 'private'),
             (annotations.c.groupid == '__world__', 'public'),
@@ -37,7 +39,7 @@ class AnnotationStatsService(object):
 
         return (
             self.session.query(Annotation)
-            .filter_by(groupid=pubid, shared=True)
+            .filter_by(groupid=pubid, shared=True, deleted=False)
             .count())
 
 

--- a/h/services/annotation_stats.py
+++ b/h/services/annotation_stats.py
@@ -19,7 +19,13 @@ class AnnotationStatsService(object):
             (sa.not_(annotations.c.shared), 'private'),
             (annotations.c.groupid == '__world__', 'public'),
         ], else_='group')
-        return dict(self.session.query(grouping, sa.func.count(annotations.c.id)).group_by(grouping).all())
+
+        result = dict(self.session.query(grouping, sa.func.count(annotations.c.id)).group_by(grouping).all())
+        result['total'] = result.get('public', 0) + \
+            result.get('group', 0) + \
+            result.get('private', 0)
+
+        return result
 
     def group_annotation_count(self, pubid):
         """

--- a/h/views/activity.py
+++ b/h/views/activity.py
@@ -260,7 +260,7 @@ class UserSearchController(SearchController):
             user_annotation_counts = self.request.find_service(name='annotation_stats').user_annotation_counts(self.user.userid)
             annotation_count = user_annotation_counts['public']
             if self.request.authenticated_userid == self.user.userid:
-                annotation_count = annotation_count + user_annotation_counts['private'] + user_annotation_counts['group']
+                annotation_count = user_annotation_counts['total']
 
         result['stats'] = {
             'annotation_count': annotation_count,

--- a/tests/h/services/annotation_stats_test.py
+++ b/tests/h/services/annotation_stats_test.py
@@ -45,6 +45,14 @@ class TestAnnotationStatsService(object):
 
         assert results['total'] == expected_total
 
+    def test_user_annotation_counts_returns_default_values(self, svc, factories):
+        results = svc.user_annotation_counts('123')
+
+        assert results['public'] == 0
+        assert results['private'] == 0
+        assert results['group'] == 0
+        assert results['total'] == 0
+
     def test_annotation_count_returns_count_of_shared_annotations_for_group(self, svc, factories):
         pubid = 'abc123'
         for i in range(3):

--- a/tests/h/services/annotation_stats_test.py
+++ b/tests/h/services/annotation_stats_test.py
@@ -25,6 +25,26 @@ class TestAnnotationStatsService(object):
         assert results['private'] == 2
         assert results['group'] == 4
 
+    @pytest.mark.parametrize('public,group,private,expected_total', [
+        (3, 2, 4, 9),
+        (3, 2, 0, 5),
+        (3, 0, 4, 7),
+        (0, 2, 4, 6),
+     ])
+    def test_user_annotation_counts_includes_total_count_of_annotations_for_user(
+            self, svc, factories, public, group, private, expected_total):
+        userid = '123'
+        for i in range(public):
+            factories.Annotation(userid=userid, shared=True)
+        for i in range(private):
+            factories.Annotation(userid=userid, shared=False)
+        for i in range(group):
+            factories.Annotation(userid=userid, groupid='abc', shared=True)
+
+        results = svc.user_annotation_counts(userid)
+
+        assert results['total'] == expected_total
+
     def test_annotation_count_returns_count_of_shared_annotations_for_group(self, svc, factories):
         pubid = 'abc123'
         for i in range(3):

--- a/tests/h/services/annotation_stats_test.py
+++ b/tests/h/services/annotation_stats_test.py
@@ -53,6 +53,22 @@ class TestAnnotationStatsService(object):
         assert results['group'] == 0
         assert results['total'] == 0
 
+    def test_user_annotation_counts_ignores_deleted_annotations(self, svc, factories):
+        userid = '123'
+        for i in range(3):
+            factories.Annotation(userid=userid, deleted=True, shared=True)
+        for i in range(2):
+            factories.Annotation(userid=userid, deleted=True, shared=False)
+        for i in range(4):
+            factories.Annotation(userid=userid, deleted=True, groupid='abc', shared=True)
+
+        results = svc.user_annotation_counts(userid)
+
+        assert results['public'] == 0
+        assert results['private'] == 0
+        assert results['group'] == 0
+        assert results['total'] == 0
+
     def test_annotation_count_returns_count_of_shared_annotations_for_group(self, svc, factories):
         pubid = 'abc123'
         for i in range(3):
@@ -61,6 +77,13 @@ class TestAnnotationStatsService(object):
             factories.Annotation(groupid=pubid, shared=False)
 
         assert svc.group_annotation_count(pubid) == 3
+
+    def test_group_annotation_count_excludes_deleted_annotations(self, svc, factories):
+        pubid = 'abc123'
+        for i in range(3):
+            factories.Annotation(groupid=pubid, shared=True, deleted=True)
+
+        assert svc.group_annotation_count(pubid) == 0
 
 
 class TestAnnotationStatsFactory(object):

--- a/tests/h/views/activity_test.py
+++ b/tests/h/views/activity_test.py
@@ -879,7 +879,7 @@ class TestGroupAndUserSearchController(object):
 
 class FakeAnnotationStatsService(object):
     def user_annotation_counts(self, userid):
-        return {'public': 1, 'private': 3, 'group': 2}
+        return {'public': 1, 'private': 3, 'group': 2, 'total': 6}
 
     def group_annotation_count(self, pubid):
         return 5


### PR DESCRIPTION
This fixes an issue where we get a bunch of `KeyError` exceptions when
one of the three named groups doesn't exist in the result set (e.g. a
user has not made a group annotation yet).