### PR TITLE
Collapse document expansion from base of expanded form.

### DIFF
--- a/h/static/images/icons/collapse-view.svg
+++ b/h/static/images/icons/collapse-view.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="11px" height="13px" viewBox="0 0 11 13" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 41 (35326) - http://www.bohemiancoding.com/sketch -->
+    <title>Collapse Icon</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Symbols" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Collapse-Icon" transform="translate(-1.000000, 0.000000)">
+            <g id="Group-Copy-2" transform="translate(6.500000, 6.500000) rotate(-45.000000) translate(-6.500000, -6.500000) translate(2.000000, 2.000000)">
+                <rect id="Rectangle-5" fill="#3F3F3F" x="2" y="0" width="7" height="2"></rect>
+                <rect id="Rectangle-5-Copy" fill="#3F3F3F" x="7" y="0" width="2" height="7"></rect>
+                <path d="M8,1 L0,9" id="Path-2" stroke="#3F3F3F" stroke-width="2"></path>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/h/static/scripts/controllers/search-bucket-controller.js
+++ b/h/static/scripts/controllers/search-bucket-controller.js
@@ -33,6 +33,10 @@ class SearchBucketController extends Controller {
       this.setState({expanded: !this.state.expanded});
     });
 
+    this.refs.collapseView.addEventListener('click', () => {
+      this.setState({expanded: !this.state.expanded});
+    });
+
     const envFlags = this.options.envFlags || window.envFlags;
 
     this.setState({

--- a/h/static/scripts/tests/controllers/search-bucket-controller-test.js
+++ b/h/static/scripts/tests/controllers/search-bucket-controller-test.js
@@ -8,6 +8,7 @@ const TEMPLATE = `<div class="js-search-bucket">
     <a data-ref="domainLink">foo.com</a>
   </div>
   <div data-ref="content"></div>
+  <button data-ref="collapseView"></button>
 </div>
 `;
 
@@ -51,6 +52,12 @@ describe('SearchBucketController', () => {
   it('removes the is-expanded CSS class when clicked again', () => {
     ctrl.refs.header.dispatchEvent(new Event('click'));
     ctrl.refs.header.dispatchEvent(new Event('click'));
+    assert.isFalse(ctrl.refs.content.classList.contains('is-expanded'));
+  });
+
+  it('removes the is-expanded CSS class when collapse view is clicked', () => {
+    ctrl.refs.header.dispatchEvent(new Event('click'));
+    ctrl.refs.collapseView.dispatchEvent(new Event('click'));
     assert.isFalse(ctrl.refs.content.classList.contains('is-expanded'));
   });
 

--- a/h/static/styles/partials-v2/_search.scss
+++ b/h/static/styles/partials-v2/_search.scss
@@ -230,6 +230,8 @@ $annotation-card-width: 500px;
 // Card displaying stats about a group of annotations in search results
 .search-bucket-stats {
   @include font-normal;
+  display: flex;
+  flex-direction: column;
   margin-left: 30px;
   word-wrap: break-word;
   min-width: 0;  // Without this min-width stats containing really
@@ -277,6 +279,22 @@ $stats-icon-column-width: 20px;
   top: 1px;
   height: 9px;
   width: 9px;
+}
+
+.search-bucket-stats__collapse-view {
+  @include reset-button;
+  color: $grey-6;
+  margin-bottom: 15px;
+  text-align: left;
+}
+
+.search-bucket-stats__collapse-view-icon {
+  margin-right: 4px;
+  width: 12px;
+}
+
+.search-bucket-stats__collapse-view:focus {
+  outline:0;
 }
 
 // On large tablets and below, display bucket titles beneath rather than

--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -76,6 +76,14 @@
            target="_blank">{{ pretty_link(bucket.uri) }}</a>
     </div>
   {% endif %}
+  <div class="u-stretch">
+  </div>
+  <button class="search-bucket-stats__collapse-view"
+          data-ref="collapseView"
+          title="Collapse view">
+    {{ svg_icon('collapse-view', 'search-bucket-stats__collapse-view-icon') }}
+    Collapse view
+  </button>
 </div>
 {% endmacro %}
 


### PR DESCRIPTION
Collapsing a document which has several annotations means having to
scroll back up the header and then clicking it. This commit gives the user
the ability to collapse an open document with annotations, from the
bottom also.

Fixes https://github.com/hypothesis/product-backlog/issues/79