### PR TITLE
Use unicode literals in annotation stats service

### DIFF
--- a/h/services/annotation_stats.py
+++ b/h/services/annotation_stats.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
+
 import sqlalchemy as sa
 
 from h.models import Annotation


### PR DESCRIPTION
Fixes this warning when loading the user profile:
`SAWarning: Unicode type received non-unicode bind param value '__world__'. (this warning may be suppressed after 10 occurrences) (util.ellipses_string(value),))`