### PR TITLE
Clear nipsa service cache before running celery tasks

### DIFF
--- a/h/celery.py
+++ b/h/celery.py
@@ -99,6 +99,13 @@ def reset_feature_flags(sender, **kwargs):
     sender.app.request.feature.clear()
 
 
+@signals.task_prerun.connect
+def reset_nipsa_cache(sender, **kwargs):
+    """Reset nipsa service cache before running each task."""
+    svc = sender.app.request.find_service(name='nipsa')
+    svc.clear()
+
+
 @signals.task_success.connect
 def transaction_commit(sender, **kwargs):
     """Commit the request transaction after each successful task execution."""

--- a/h/services/nipsa.py
+++ b/h/services/nipsa.py
@@ -53,6 +53,9 @@ class NipsaService(object):
         user.nipsa = False
         remove_nipsa.delay(user.userid)
 
+    def clear(self):
+        self._flagged_userids = None
+
 
 def nipsa_factory(context, request):
     """Return a NipsaService instance for the passed context and request."""

--- a/tests/h/celery_test.py
+++ b/tests/h/celery_test.py
@@ -53,6 +53,15 @@ class TestCelery(object):
 
         sender.app.request.feature.clear.assert_called_once_with()
 
+    def test_nipsa_cache(self, pyramid_config, pyramid_request):
+        sender = mock.Mock(app=mock.Mock(request=pyramid_request))
+        nipsa_svc = mock.Mock()
+        pyramid_config.register_service(nipsa_svc, name='nipsa')
+
+        celery.reset_nipsa_cache(sender)
+
+        nipsa_svc.clear.assert_called_once_with()
+
     def test_transaction_commit_commits_request_transaction(self):
         sender = mock.Mock(spec=['app'])
 

--- a/tests/h/services/nipsa_test.py
+++ b/tests/h/services/nipsa_test.py
@@ -56,6 +56,19 @@ class TestNipsaService(object):
 
         remove_nipsa.delay.assert_called_once_with('acct:renata@example.com')
 
+    def test_clear_resets_cache(self, db_session, users):
+        svc = NipsaService(db_session)
+
+        assert svc.flagged_userids == set(['acct:renata@example.com',
+                                           'acct:cecilia@example.com'])
+
+        users['dominic'].nipsa = True
+        svc.clear()
+
+        assert svc.flagged_userids == set(['acct:renata@example.com',
+                                           'acct:cecilia@example.com',
+                                           'acct:dominic@example.com'])
+
 
 def test_nipsa_factory(pyramid_request):
     svc = nipsa_factory(None, pyramid_request)


### PR DESCRIPTION
This fixes a bug where new annotations by a recently (since last restart
of the celery workers) nipsa'd user are still being indexed into the
search index without the proper `"nipsa": true` property.

I played around with giving each worker task a new request, but that will need additional testing and the way we configure Sentry for failed tasks would probably leak database sessions. This might be something we want to look into later down the road, for now we just do the same as we do for feature flags.

Fixes #4278.