### PR TITLE
Rework AuthFilter

### DIFF
--- a/tests/memex/search/query_test.py
+++ b/tests/memex/search/query_test.py
@@ -251,20 +251,21 @@ class TestBuilder(object):
 
 
 class TestAuthFilter(object):
-    def test_world_not_in_principals(self):
-        request = mock.Mock(effective_principals=['foo'])
+    def test_unauthenticated(self):
+        request = mock.Mock(authenticated_userid=None)
+        authfilter = query.AuthFilter(request)
+
+        assert authfilter({}) == {'term': {'shared': True}}
+
+    def test_authenticated(self):
+        request = mock.Mock(authenticated_userid='acct:doe@example.org')
         authfilter = query.AuthFilter(request)
 
         assert authfilter({}) == {
-            'terms': {'permissions.read': ['group:__world__', 'foo']}
-        }
-
-    def test_world_in_principals(self):
-        request = mock.Mock(effective_principals=['group:__world__', 'foo'])
-        authfilter = query.AuthFilter(request)
-
-        assert authfilter({}) == {
-            'terms': {'permissions.read': ['group:__world__', 'foo']}
+            'or': [
+                {'term': {'shared': True}},
+                {'term': {'user': 'acct:doe@example.org'}},
+            ]
         }
 
 


### PR DESCRIPTION
We have moved the filtering on the groups into the new groups filter
that lives in `h` (#4263). The memex auth filter will now only check for the
`shared` field. It filters out private annotations of other users, if
the request is done on behalf of a logged-in user. Otherwise it filters
out all private annotations.

This is part of hypothesis/product-backlog#95.