### PR TITLE
Mark external links on search pages as rel="nofollow"

### DIFF
--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -35,7 +35,7 @@
       {{ svg_icon('up-right-arrow', css_class='search-bucket-stats__icon') }}
       <a class="search-bucket-stats__incontext-link"
          href="{{ bucket.incontext_link(request) }}"
-         rel="nofollow"
+         rel="nofollow noopener"
          target="_blank">
          {% trans %}Visit annotations in context{% endtrans %}
        </a>
@@ -73,7 +73,7 @@
     </div>
     <div class="search-bucket-stats__val search-bucket-stats__url">
         <a class="link--plain"
-           rel="nofollow"
+           rel="nofollow noopener"
            href="{{ bucket.uri }}"
            target="_blank">{{ pretty_link(bucket.uri) }}</a>
     </div>
@@ -102,7 +102,7 @@
       <span class="search-result-bucket__domain-text">{{ bucket.domain }}</span>
       <a class="link--plain search-result-bucket__domain-link"
          href="{{ bucket.incontext_link(request) }}"
-         rel="nofollow"
+         rel="nofollow noopener"
          title="Visit annotations in context"
          target="_blank"
          data-ref="domainLink">
@@ -309,7 +309,7 @@
             {% trans %}Link:{% endtrans %}
           </dt>
           <dd class="search-result-sidebar__dd">
-            <a href="{{ user.uri }}" rel="nofollow" class="link--plain">
+            <a href="{{ user.uri }}" rel="nofollow noopener" class="link--plain">
               {{ pretty_link(user.uri) }}
             </a>
           </dd>

--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -35,6 +35,7 @@
       {{ svg_icon('up-right-arrow', css_class='search-bucket-stats__icon') }}
       <a class="search-bucket-stats__incontext-link"
          href="{{ bucket.incontext_link(request) }}"
+         rel="nofollow"
          target="_blank">
          {% trans %}Visit annotations in context{% endtrans %}
        </a>
@@ -72,6 +73,7 @@
     </div>
     <div class="search-bucket-stats__val search-bucket-stats__url">
         <a class="link--plain"
+           rel="nofollow"
            href="{{ bucket.uri }}"
            target="_blank">{{ pretty_link(bucket.uri) }}</a>
     </div>
@@ -100,6 +102,7 @@
       <span class="search-result-bucket__domain-text">{{ bucket.domain }}</span>
       <a class="link--plain search-result-bucket__domain-link"
          href="{{ bucket.incontext_link(request) }}"
+         rel="nofollow"
          title="Visit annotations in context"
          target="_blank"
          data-ref="domainLink">
@@ -306,7 +309,7 @@
             {% trans %}Link:{% endtrans %}
           </dt>
           <dd class="search-result-sidebar__dd">
-            <a href="{{ user.uri }}" class="link--plain">
+            <a href="{{ user.uri }}" rel="nofollow" class="link--plain">
               {{ pretty_link(user.uri) }}
             </a>
           </dd>

--- a/h/templates/includes/annotation_card.html.jinja2
+++ b/h/templates/includes/annotation_card.html.jinja2
@@ -62,7 +62,9 @@
   </section>
   <footer class="annotation-card__footer">
     {% if presented_annotation.incontext_link %}
-      <a href="{{ presented_annotation.incontext_link }}" target="_blank" title="{% trans %}Visit annotation in context{% endtrans %}">
+      <a href="{{ presented_annotation.incontext_link }}"
+         rel="nofollow"
+         target="_blank" title="{% trans %}Visit annotation in context{% endtrans %}">
         {{ svg_icon('up-right-arrow', 'annotation-card__footer-link annotation-card__incontext-link') }}
       </a>
       <a href="#"

--- a/h/templates/includes/annotation_card.html.jinja2
+++ b/h/templates/includes/annotation_card.html.jinja2
@@ -63,7 +63,7 @@
   <footer class="annotation-card__footer">
     {% if presented_annotation.incontext_link %}
       <a href="{{ presented_annotation.incontext_link }}"
-         rel="nofollow"
+         rel="nofollow noopener"
          target="_blank" title="{% trans %}Visit annotation in context{% endtrans %}">
         {{ svg_icon('up-right-arrow', 'annotation-card__footer-link annotation-card__incontext-link') }}
       </a>


### PR DESCRIPTION
Add `rel="nofollow"` to user-controlled external links to signify that Hypothesis does not endorse external pages linked to from search results. This _may_ decrease the attractiveness of Hypothesis to spammers a little.

This includes:

 - Links to the document on which an annotation has been made (3 per
   bucket plus one on each annotation card).

 - The user-provided link in their profile on /users/{username} pages

Fixes #4279