### PR TITLE
Remove activity pages feature flags from FEATURES_PENDING_REMOVAL

### DIFF
--- a/h/models/feature.py
+++ b/h/models/feature.py
@@ -35,10 +35,7 @@ FEATURES = {
 #
 # 4. Finally, remove the feature from FEATURES_PENDING_REMOVAL.
 #
-FEATURES_PENDING_REMOVAL = {
-    'activity_pages': "Show the new activity pages?",
-    'search_page': "Show the activity pages search skeleton page?",
-}
+FEATURES_PENDING_REMOVAL = {}
 
 
 class Feature(Base):


### PR DESCRIPTION
The removal of the feature flags has now been deployed all the way out to production as per the comments above the `FEATURES_PENDING_REMOVAL` variable.