### PR TITLE
Fix link syntax in ADR 002

### DIFF
--- a/docs/arch/adr-002.rst
+++ b/docs/arch/adr-002.rst
@@ -38,11 +38,11 @@ One way to resolve this problem is to introduce a "services layer" between views
 and the rest of the application, which is intended to encapsulate the bulk of
 application business logic and hide persistence concerns from the views.
 
-[This blog post][1] by [Nando Farestan][2] may help provide additional
-background on the motivation for a "services layer."
+`This blog post`_ by `Nando Farestan`_ may help provide additional background
+on the motivation for a "services layer."
 
-[1]: http://nando.oui.com.br/2014/04/01/large_apps_with_sqlalchemy__architecture.html
-[2]: http://nando.oui.com.br/index.html
+.. _This blog post: http://nando.oui.com.br/2014/04/01/large_apps_with_sqlalchemy__architecture.html
+.. _Nando Farestan: http://nando.oui.com.br/index.html
 
 Decision
 --------


### PR DESCRIPTION
The links appear to be written using Markdown’s link syntax, which doesn't display as intended in `.rst` files.