### PR TITLE
More permissive ignore for Celery's schedule file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,5 @@ node_modules/
 *.log
 
 celerybeat-schedule
+celerybeat-schedule.*
 celerybeat.pid


### PR DESCRIPTION
Because the scheduler's persistence uses [`shelve`][0], which uses [`anydbm`][1], which picks one of a number of underlying libraries to manage the file on disk, the file might be created with the bare filename of `celerybeat-schedule`, or it might add an extension onto the end, depending on the library. The extension this used on my machine was `.db`, but there appear to be [a number of possible suffixes][2], depending on the individual machine's configuration.

[0]: https://docs.python.org/2/library/shelve.html
[1]: https://docs.python.org/2/library/anydbm.html
[2]: https://github.com/celery/celery/blob/df73e0a7/celery/beat.py#L352