### PR TITLE
Refactor memex groupfinder

### DIFF
--- a/h/app.py
+++ b/h/app.py
@@ -117,6 +117,10 @@ def includeme(config):
     if not asbool(config.registry.settings.get('h.search.autoconfig')):
         config.action('memex.search.init', lambda: None)
 
+    # Override memex group service
+    config.register_service_factory('h.services.groupfinder.groupfinder_service_factory',
+                                    iface='memex.interfaces.IGroupService')
+
     # Core site modules
     config.include('h.assets')
     config.include('h.auth')

--- a/h/groups/__init__.py
+++ b/h/groups/__init__.py
@@ -2,5 +2,4 @@
 
 
 def includeme(config):
-    config.memex_set_groupfinder('h.groups.util.fetch_group')
     config.memex_add_search_filter('h.groups.search.GroupAuthFilter')

--- a/h/groups/util.py
+++ b/h/groups/util.py
@@ -23,11 +23,3 @@ class WorldGroup(object):
             (security.Allow, 'authority:{}'.format(self.auth_domain), 'write'),
             security.DENY_ALL,
         ]
-
-
-def fetch_group(request, id_):
-    if id_ == '__world__':
-        return WorldGroup(request.auth_domain)
-
-    # This should probably use the GroupService with a built-in caching layer.
-    return request.db.query(models.Group).filter_by(pubid=id_).one_or_none()

--- a/h/services/groupfinder.py
+++ b/h/services/groupfinder.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from zope.interface import implementer
+
+from memex.interfaces import IGroupService
+
+from h import models
+from h.groups.util import WorldGroup
+
+
+@implementer(IGroupService)
+class GroupfinderService(object):
+    def __init__(self, session, auth_domain):
+        self.session = session
+        self.auth_domain = auth_domain
+
+    def find(self, id_):
+        if id_ == '__world__':
+            return WorldGroup(self.auth_domain)
+
+        # TODO: caching
+        return self.session.query(models.Group).filter_by(pubid=id_).one_or_none()
+
+
+def groupfinder_service_factory(context, request):
+    return GroupfinderService(request.db, request.auth_domain)

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ INSTALL_REQUIRES = [
     'pyramid>=1.7,<1.8',
     'python-dateutil>=2.1',
     'transaction',
+    'zope.interface',
 ]
 EXTRAS_REQUIRE = {}
 ENTRY_POINTS = {}

--- a/src/memex/__init__.py
+++ b/src/memex/__init__.py
@@ -12,7 +12,6 @@ def includeme(config):
     config.include('memex.models')
 
     config.include('memex.eventqueue')
-    config.include('memex.groups')
     config.include('memex.links')
     config.include('memex.presenters')
     config.include('memex.search')

--- a/src/memex/__init__.py
+++ b/src/memex/__init__.py
@@ -29,3 +29,6 @@ def includeme(config):
                      factory='memex.resources:AnnotationResourceFactory',
                      traverse='/{id}')
     config.add_route('api.search', '/search')
+
+    config.register_service_factory('memex.groups.default_group_service_factory',
+                                    iface='memex.interfaces.IGroupService')

--- a/src/memex/groups.py
+++ b/src/memex/groups.py
@@ -3,6 +3,9 @@
 from __future__ import unicode_literals
 
 from pyramid import security
+from zope.interface import implementer
+
+from memex.interfaces import IGroupService
 
 GROUPFINDER_KEY = 'memex.groupfinder'
 
@@ -17,6 +20,16 @@ class DefaultGroupContext(object):
                     (security.Allow, security.Everyone, 'read'),
                     security.DENY_ALL]
         return [security.DENY_ALL]
+
+
+@implementer(IGroupService)
+class DefaultGroupService(object):
+    def find(self, id_):
+        return DefaultGroupContext(id_)
+
+
+def default_group_service_factory(context, request):
+    return DefaultGroupService()
 
 
 def find(request, id_):

--- a/src/memex/groups.py
+++ b/src/memex/groups.py
@@ -7,8 +7,6 @@ from zope.interface import implementer
 
 from memex.interfaces import IGroupService
 
-GROUPFINDER_KEY = 'memex.groupfinder'
-
 
 class DefaultGroupContext(object):
     def __init__(self, id_):
@@ -30,21 +28,3 @@ class DefaultGroupService(object):
 
 def default_group_service_factory(context, request):
     return DefaultGroupService()
-
-
-def find(request, id_):
-    groupfinder = request.registry.get(GROUPFINDER_KEY)
-    return groupfinder(request, id_)
-
-
-def default_groupfinder(request, id_):
-    return DefaultGroupContext(id_)
-
-
-def set_groupfinder(config, func):
-    config.registry[GROUPFINDER_KEY] = config.maybe_dotted(func)
-
-
-def includeme(config):
-    config.add_directive('memex_set_groupfinder', set_groupfinder)
-    config.memex_set_groupfinder(default_groupfinder)

--- a/src/memex/interfaces.py
+++ b/src/memex/interfaces.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from zope.interface import Interface
+
+
+class IGroupService(Interface):
+    def find(self, id_):
+        """
+        Finds and returns a group based on the given id.
+
+        :param id_: The group id.
+        :type id_: unicode
+
+        :returns A group object with an ``__acl__()`` method.
+        """

--- a/src/memex/resources.py
+++ b/src/memex/resources.py
@@ -4,8 +4,8 @@ from __future__ import unicode_literals
 
 from pyramid import security
 
-from memex import groups
 from memex import storage
+from memex.interfaces import IGroupService
 
 
 class AnnotationResourceFactory(object):
@@ -16,17 +16,19 @@ class AnnotationResourceFactory(object):
         annotation = storage.fetch_annotation(self.request.db, id)
         if annotation is None:
             raise KeyError()
-        return AnnotationResource(self.request, annotation)
+
+        group_service = self.request.find_service(IGroupService)
+        return AnnotationResource(annotation, group_service)
 
 
 class AnnotationResource(object):
-    def __init__(self, request, annotation):
-        self.request = request
+    def __init__(self, annotation, group_service):
+        self.group_service = group_service
         self.annotation = annotation
 
     @property
     def group(self):
-        return groups.find(self.request, self.annotation.groupid)
+        return self.group_service.find(self.annotation.groupid)
 
     def __acl__(self):
         """Return a Pyramid ACL for this annotation."""

--- a/src/memex/storage.py
+++ b/src/memex/storage.py
@@ -12,7 +12,6 @@ from datetime import datetime
 from pyramid import i18n
 
 from memex import schemas
-from memex import groups
 from memex import models
 from memex.db import types
 
@@ -75,7 +74,7 @@ def fetch_ordered_annotations(session, ids, query_processor=None):
     return anns
 
 
-def create_annotation(request, data):
+def create_annotation(request, data, group_service):
     """
     Create an annotation from passed data.
 
@@ -112,7 +111,7 @@ def create_annotation(request, data):
     # they've asked to create one in. If the application didn't configure
     # a groupfinder we will allow writing this annotation without any
     # further checks.
-    group = groups.find(request, data['groupid'])
+    group = group_service.find(data['groupid'])
     if group is None or not request.has_permission('write', context=group):
         raise schemas.ValidationError('group: ' +
                                       _('You may not create annotations '

--- a/src/memex/views.py
+++ b/src/memex/views.py
@@ -24,6 +24,7 @@ from sqlalchemy.orm import subqueryload
 from memex import cors
 from memex import models
 from memex.events import AnnotationEvent
+from memex.interfaces import IGroupService
 from memex.presenters import AnnotationJSONPresenter
 from memex.presenters import AnnotationJSONLDPresenter
 from memex import search as search_lib
@@ -168,7 +169,8 @@ def create(request):
     """Create an annotation from the POST payload."""
     schema = schemas.CreateAnnotationSchema(request)
     appstruct = schema.validate(_json_payload(request))
-    annotation = storage.create_annotation(request, appstruct)
+    group_service = request.find_service(IGroupService)
+    annotation = storage.create_annotation(request, appstruct, group_service)
 
     _publish_annotation_event(request, annotation, 'create')
 

--- a/tests/h/groups/util_test.py
+++ b/tests/h/groups/util_test.py
@@ -15,26 +15,3 @@ def test_world_group_acl():
         (security.Allow, 'authority:example.com', 'write'),
         security.DENY_ALL,
     ]
-
-
-class TestFetchGroup(object):
-    def test_it_returns_the_correct_group(self, pyramid_request, factories):
-        groups = [factories.Group() for _ in xrange(3)]
-        assert util.fetch_group(pyramid_request, groups[1].pubid) == groups[1]
-
-    def test_it_returns_none_when_group_missing(self, pyramid_request, factories):
-        # create a group
-        factories.Group()
-
-        assert util.fetch_group(pyramid_request, 'bogus') is None
-
-    def test_it_returns_an_object_implementing_acl(self, pyramid_request, factories):
-        group = factories.Group()
-
-        result = util.fetch_group(pyramid_request, group.pubid)
-        # make sure this call doesn't raise
-        result.__acl__()
-
-    def test_it_returns_correct_group_for_world_group(self, pyramid_request):
-        group = util.fetch_group(pyramid_request, '__world__')
-        assert isinstance(group, util.WorldGroup)

--- a/tests/h/services/groupfinder_test.py
+++ b/tests/h/services/groupfinder_test.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import pytest
+
+from h.groups.util import WorldGroup
+from h.services.groupfinder import groupfinder_service_factory
+from h.services.groupfinder import GroupfinderService
+
+
+class TestGroupfinderService(object):
+    def test_returns_correct_group(self, svc, factories):
+        group = factories.Group()
+
+        assert svc.find(group.pubid) == group
+
+    def test_returns_correct_group_for_world(self, svc):
+        group = svc.find('__world__')
+
+        assert isinstance(group, WorldGroup)
+
+    def test_sets_auth_domain_on_world_group(self, svc):
+        group = svc.find('__world__')
+
+        assert group.auth_domain == 'example.com'
+
+    def test_returns_none_when_not_found(self, svc, factories):
+        factories.Group()
+
+        assert svc.find('bogus') is None
+
+    @pytest.fixture
+    def svc(self, db_session):
+        return GroupfinderService(db_session, 'example.com')
+
+
+class TestGroupfinderServiceFactory(object):
+    def test_returns_groupfinder_service(self, pyramid_request):
+        svc = groupfinder_service_factory(None, pyramid_request)
+
+        assert isinstance(svc, GroupfinderService)
+
+    def test_provides_database_session(self, pyramid_request):
+        svc = groupfinder_service_factory(None, pyramid_request)
+
+        assert svc.session == pyramid_request.db
+
+    def test_provides_auth_domain(self, pyramid_request):
+        svc = groupfinder_service_factory(None, pyramid_request)
+
+        assert svc.auth_domain == pyramid_request.auth_domain

--- a/tests/h/views/main_test.py
+++ b/tests/h/views/main_test.py
@@ -14,9 +14,9 @@ from h.views import main
 
 @mock.patch('h.client.render_app_html')
 @pytest.mark.usefixtures('routes')
-def test_og_document(render_app_html, annotation_document, document_title, pyramid_request):
+def test_og_document(render_app_html, annotation_document, document_title, pyramid_request, group_service):
     annotation = Annotation(id='123', userid='foo', target_uri='http://example.com')
-    context = AnnotationResource(pyramid_request, annotation)
+    context = AnnotationResource(annotation, group_service)
     document = Document()
     annotation_document.return_value = document
     document_title.return_value = 'WikiHow — How to Make a ☆Starmap☆'
@@ -30,9 +30,9 @@ def test_og_document(render_app_html, annotation_document, document_title, pyram
 
 @mock.patch('h.client.render_app_html')
 @pytest.mark.usefixtures('routes')
-def test_og_no_document(render_app_html, pyramid_request):
+def test_og_no_document(render_app_html, pyramid_request, group_service):
     annotation = Annotation(id='123', userid='foo', target_uri='http://example.com')
-    context = AnnotationResource(pyramid_request, annotation)
+    context = AnnotationResource(annotation, group_service)
 
     render_app_html.return_value = '<html></html>'
     main.annotation_page(context, pyramid_request)
@@ -144,3 +144,10 @@ def routes(pyramid_config):
     pyramid_config.add_route('api.annotation', '/api/ann/{id}')
     pyramid_config.add_route('api.index', '/api/index')
     pyramid_config.add_route('index', '/index')
+
+
+@pytest.fixture
+def group_service(pyramid_config):
+    group_service = mock.Mock(spec_set=['find'])
+    pyramid_config.register_service(group_service, iface='memex.interfaces.IGroupService')
+    return group_service

--- a/tests/memex/groups_test.py
+++ b/tests/memex/groups_test.py
@@ -2,9 +2,7 @@
 
 from __future__ import unicode_literals
 
-import mock
 from pyramid import security
-import pytest
 
 from memex import groups
 
@@ -21,65 +19,3 @@ class TestDefaultGroupContext(object):
     def test_acl_fallback(self):
         ctx = groups.DefaultGroupContext('foobar')
         assert ctx.__acl__() == [security.DENY_ALL]
-
-
-class TestFind(object):
-    def test_calls_groupfinder(self, pyramid_config, pyramid_request):
-        groupfinder = mock.Mock()
-        pyramid_config.registry[groups.GROUPFINDER_KEY] = groupfinder
-
-        groups.find(pyramid_request, mock.sentinel.groupid)
-
-        groupfinder.assert_called_once_with(pyramid_request, mock.sentinel.groupid)
-
-    def test_returns_groupfinder_result(self, pyramid_config, pyramid_request):
-        groupfinder = mock.Mock(return_value=mock.sentinel.groupcontext)
-        pyramid_config.registry[groups.GROUPFINDER_KEY] = groupfinder
-
-        result = groups.find(pyramid_request, mock.sentinel.groupid)
-
-        assert result == mock.sentinel.groupcontext
-
-
-class TestDefaultGroupfinder(object):
-    def test_returns_default_context(self):
-        result = groups.default_groupfinder(mock.sentinel.request, mock.sentinel.groupid)
-        assert isinstance(result, groups.DefaultGroupContext)
-
-    def test_sets_given_groupid(self):
-        result = groups.default_groupfinder(mock.sentinel.request, mock.sentinel.groupid)
-        assert result.id_ == mock.sentinel.groupid
-
-
-class TestSetGroupfinder(object):
-    def test_stores_given_groupfinder_in_registry(self, pyramid_config):
-        groups.set_groupfinder(pyramid_config, mock.sentinel.groupfinder)
-
-        assert pyramid_config.registry[groups.GROUPFINDER_KEY] == mock.sentinel.groupfinder
-
-    def test_resolves_dotted_path(self, pyramid_config):
-        pyramid_config.maybe_dotted = mock.Mock()
-
-        groups.set_groupfinder(pyramid_config, mock.sentinel.groupfinder)
-
-        pyramid_config.maybe_dotted.assert_called_once_with(mock.sentinel.groupfinder)
-
-    def test_sets_dotted_path_resolved_object(self, pyramid_config):
-        pyramid_config.maybe_dotted = mock.Mock()
-
-        groups.set_groupfinder(pyramid_config, mock.sentinel.groupfinder)
-
-        assert pyramid_config.registry[groups.GROUPFINDER_KEY] == pyramid_config.maybe_dotted.return_value
-
-
-class TestIncludeme(object):
-    def test_sets_default_groupfinder(self, testconfig):
-        groups.includeme(testconfig)
-        testconfig.memex_set_groupfinder.assert_called_once_with(groups.default_groupfinder)
-
-    @pytest.fixture
-    def testconfig(self):
-        return mock.Mock(spec_set=[
-            'add_directive',
-            'memex_set_groupfinder',
-        ])

--- a/tests/memex/views_test.py
+++ b/tests/memex/views_test.py
@@ -190,6 +190,7 @@ class TestSearch(object):
 @pytest.mark.usefixtures('AnnotationEvent',
                          'AnnotationJSONPresenter',
                          'links_service',
+                         'group_service',
                          'schemas',
                          'storage')
 class TestCreate(object):
@@ -229,13 +230,14 @@ class TestCreate(object):
     def test_it_creates_the_annotation_in_storage(self,
                                                   pyramid_request,
                                                   storage,
-                                                  schemas):
+                                                  schemas,
+                                                  group_service):
         schema = schemas.CreateAnnotationSchema.return_value
 
         views.create(pyramid_request)
 
         storage.create_annotation.assert_called_once_with(
-            pyramid_request, schema.validate.return_value)
+            pyramid_request, schema.validate.return_value, group_service)
 
     def test_it_raises_if_create_annotation_raises(self,
                                                    pyramid_request,
@@ -287,6 +289,12 @@ class TestCreate(object):
         pyramid_request.json_body = {}
         pyramid_request.notify_after_commit = mock.Mock()
         return pyramid_request
+
+    @pytest.fixture
+    def group_service(self, pyramid_config):
+        group_service = mock.Mock(spec_set=['find'])
+        pyramid_config.register_service(group_service, iface='memex.interfaces.IGroupService')
+        return group_service
 
 
 @pytest.mark.usefixtures('AnnotationJSONPresenter', 'links_service')


### PR DESCRIPTION
This changes the groupfinder from a configurable callable to a service which allows us greater flexibility how the finder is initialized and how it can access other data (`auth_domain` for example).