### PR TITLE
Fix renaming user to equivalent username

### DIFF
--- a/h/admin/views/users.py
+++ b/h/admin/views/users.py
@@ -86,7 +86,7 @@ def users_rename(request):
 
     try:
         svc = request.find_service(name='rename_user')
-        svc.check(new_username, request.auth_domain)
+        svc.check(user, new_username, request.auth_domain)
 
         rename_user.delay(user.id, new_username)
 

--- a/h/admin/views/users.py
+++ b/h/admin/views/users.py
@@ -86,7 +86,7 @@ def users_rename(request):
 
     try:
         svc = request.find_service(name='rename_user')
-        svc.check(user, new_username, request.auth_domain)
+        svc.check(user, new_username)
 
         rename_user.delay(user.id, new_username)
 

--- a/h/services/rename_user.py
+++ b/h/services/rename_user.py
@@ -31,15 +31,15 @@ class RenameUserService(object):
         self.session = session
         self.reindex = reindex
 
-    def check(self, user, new_username, authority):
-        existing_user = models.User.get_by_username(self.session, new_username, authority)
+    def check(self, user, new_username):
+        existing_user = models.User.get_by_username(self.session, new_username, user.authority)
         if existing_user and existing_user != user:
             raise UserRenameError('Another user already has the username "%s"' % new_username)
 
         return True
 
     def rename(self, user, new_username):
-        self.check(user, new_username, user.authority)
+        self.check(user, new_username)
 
         old_userid = user.userid
 

--- a/h/services/rename_user.py
+++ b/h/services/rename_user.py
@@ -31,15 +31,15 @@ class RenameUserService(object):
         self.session = session
         self.reindex = reindex
 
-    def check(self, new_username, authority):
+    def check(self, user, new_username, authority):
         existing_user = models.User.get_by_username(self.session, new_username, authority)
-        if existing_user:
+        if existing_user and existing_user != user:
             raise UserRenameError('Another user already has the username "%s"' % new_username)
 
         return True
 
     def rename(self, user, new_username):
-        self.check(new_username, user.authority)
+        self.check(user, new_username, user.authority)
 
         old_userid = user.userid
 

--- a/tests/h/services/rename_user_test.py
+++ b/tests/h/services/rename_user_test.py
@@ -15,7 +15,7 @@ from h.services.rename_user import (
 
 class TestRenameUserService(object):
     def test_check_returns_true_when_new_username_does_not_exist(self, service, user):
-        assert service.check(user, 'panda', 'foobar.org') is True
+        assert service.check(user, 'panda') is True
 
     def test_check_raises_when_new_userid_is_already_taken(self, service, user, db_session, factories):
         user_taken = factories.User(username='panda')
@@ -23,7 +23,7 @@ class TestRenameUserService(object):
         db_session.flush()
 
         with pytest.raises(UserRenameError) as err:
-            service.check(user, 'panda', user_taken.authority)
+            service.check(user, 'panda')
         assert err.value.message == 'Another user already has the username "panda"'
 
     @mock.patch('h.models.user.User.get_by_username')
@@ -45,12 +45,12 @@ class TestRenameUserService(object):
         """
         get_by_username.return_value = user
 
-        assert service.check(user, 'panda', user.authority) is True
+        assert service.check(user, 'panda') is True
 
     def test_rename_checks_first(self, service, check, user):
         service.rename(user, 'panda')
 
-        check.assert_called_once_with(service, user, 'panda', user.authority)
+        check.assert_called_once_with(service, user, 'panda')
 
     def test_rename_changes_the_username(self, service, user, db_session):
         service.rename(user, 'panda')


### PR DESCRIPTION
It was not possible to rename a user, e.g. "bob.smith", to a new
username that reduces to the same uid, e.g. "Bob.Smith", because the
rename user service would think that the username "Bob.Smith" already
exists.

Fix it to allow renaming "bob.smith" to "Bob.Smith" but *don't* allow
renaming a different user, e.g. "fred", to a username such as
"Bob.Smith" that's equivalent to the other "bob.smith" user's username.