### PR TITLE
Use unanalyzed `user_raw` field for AuthFilter

### DIFF
--- a/src/memex/search/query.py
+++ b/src/memex/search/query.py
@@ -132,7 +132,7 @@ class AuthFilter(object):
 
         return {'or': [
             public_filter,
-            {'term': {'user': userid}},
+            {'term': {'user_raw': userid}},
         ]}
 
 

--- a/tests/memex/search/query_test.py
+++ b/tests/memex/search/query_test.py
@@ -264,7 +264,7 @@ class TestAuthFilter(object):
         assert authfilter({}) == {
             'or': [
                 {'term': {'shared': True}},
-                {'term': {'user': 'acct:doe@example.org'}},
+                {'term': {'user_raw': 'acct:doe@example.org'}},
             ]
         }
 


### PR DESCRIPTION
The `user` field in the search index is lowercased, while the AuthFilter
does not lower-case the user's id when it passes it in. This is
preventing users from seeing their own private annotations.

The fix is to use the unanalyzed `user_raw` field which closes ways of
exploiting this behaviour by manging to create users with the same
username as another, but different upper- and lowercase letters and thus
managing to see another users' private annotations.