### PR TITLE
Use the best DocumentURI for Document.web_uri

### DIFF
--- a/src/memex/models/document.py
+++ b/src/memex/models/document.py
@@ -58,9 +58,6 @@ class Document(Base, mixins.Timestamps):
         Set self.web_uri to None if there's no http(s) DocumentURIs.
 
         """
-        if self.web_uri is not None:
-            return
-
         def first_http_url(type_=None):
             """
             Return this document's first http(s) URL of the given type.

--- a/src/memex/models/document.py
+++ b/src/memex/models/document.py
@@ -32,7 +32,7 @@ class Document(Base, mixins.Timestamps):
     #: The denormalized value of the first DocumentMeta record with type title.
     title = sa.Column('title', sa.UnicodeText())
 
-    #: The denormalized value of the first http(s) DocumentURI
+    #: The denormalized value of the "best" http(s) DocumentURI for this Document.
     web_uri = sa.Column('web_uri', sa.UnicodeText())
 
     # FIXME: This relationship should be named `uris` again after the
@@ -48,6 +48,41 @@ class Document(Base, mixins.Timestamps):
 
     def __repr__(self):
         return '<Document %s>' % self.id
+
+    def update_web_uri(self):
+        """
+        Update the value of the self.web_uri field.
+
+        Set self.web_uri to the "best" http(s) URL from self.document_uris.
+
+        Set self.web_uri to None if there's no http(s) DocumentURIs.
+
+        """
+        if self.web_uri is not None:
+            return
+
+        def first_http_url(type_=None):
+            """
+            Return this document's first http(s) URL of the given type.
+
+            Return None if this document doesn't have any http(s) URLs of the
+            given type.
+
+            If no type is given just return this document's first http(s)
+            URL, or None.
+
+            """
+            for document_uri in self.document_uris:
+                uri = document_uri.uri
+                if type_ is not None and document_uri.type != type_:
+                    continue
+                if urlparse.urlparse(uri).scheme not in ['http', 'https']:
+                    continue
+                return document_uri.uri
+
+        self.web_uri = (first_http_url(type_='self-claim') or
+                        first_http_url(type_='rel-canonical') or
+                        first_http_url())
 
     @classmethod
     def find_by_uris(cls, session, uris):
@@ -281,11 +316,6 @@ def create_or_update_document_uri(session,
 
     docuri.updated = updated
 
-    if not document.web_uri:
-        parsed = urlparse.urlparse(uri)
-        if parsed.scheme in ['http', 'https']:
-            document.web_uri = uri
-
     try:
         session.flush()
     except sa.exc.IntegrityError:
@@ -470,6 +500,8 @@ def update_document_metadata(session,
             created=created,
             updated=updated,
             **document_uri_dict)
+
+    document.update_web_uri()
 
     for document_meta_dict in document_meta_dicts:
         create_or_update_document_meta(


### PR DESCRIPTION
Denormalize the "best" DocumentURI.uri that we have into the
Document.web_uri field, instead of just taking the first one.

This fixes an issue that, depending on what order the DocumentURIs are
processed in, a rel-shortlink URI (for example) might be used instead of
a self-claim or canonical URI. We want to display the best available URI
for a document, a self-claim or canonical one if possible, to users.

The first time a given document is annotated consider all of the
DocumentURIs that we've generated from the document metadata sent by the
client and:

- Use a self-claim URI if there is one
- Use a rel-canonical URI if there's no self-claim
- Use any other http(s) URI if there's no self-claim or canonical
- Set web_uri to None if there are not http(s) URIs for the document

I'll need to send a follow-up PR to update the existing web_uris in the production db.