### PR TITLE
Pass the PYTEST_ADDOPTS env var to pytest

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,7 @@ deps =
     h: -rrequirements.txt
 passenv =
     TEST_DATABASE_URL
+    PYTEST_ADDOPTS
 commands =
     h: coverage run --parallel --source h,tests/h -m pytest {posargs:tests/h/}
     memex: coverage run --parallel --source memex,tests/memex -m pytest {posargs:tests/memex/}
@@ -36,6 +37,7 @@ passenv =
     BROKER_URL
     ELASTICSEARCH_HOST
     TEST_DATABASE_URL
+    PYTEST_ADDOPTS
 commands = py.test {posargs:tests/functional/}
 
 [testenv:clean]


### PR DESCRIPTION
Configure tox to pass the PYTEST_ADDOPTS environment variable through to
pytest. This enables developers to set their own PYTEST_ADDOPTS
environment variable containing their default options that they always
want to be passed to pytest, for example:

    export PYTEST_ADDOPTS="--verbose --exitfirst --failed-first --showlocals"