### PR TITLE
Run gunicorn with --workers 7 in dev

### DIFF
--- a/h/cli/commands/devserver.py
+++ b/h/cli/commands/devserver.py
@@ -79,7 +79,7 @@ def devserver(https, web, ws, worker, assets, beat):
         m.add_process('web',
                       'MODEL_CREATE_ALL=true '
                       'SEARCH_AUTOCONFIG=true '
-                      'gunicorn --reload --paste conf/development-app.ini %s' % gunicorn_args)
+                      'gunicorn --reload --paste conf/development-app.ini --workers 7 %s' % gunicorn_args)
 
     if ws:
         m.add_process('ws', 'gunicorn --reload --paste conf/development-websocket.ini %s' % gunicorn_args)


### PR DESCRIPTION
Run gunicorn with the --workers=7 argument for the web process in
`make dev` and `hypothesis devserver`.

This fixes a problem that page loads would frequently take 20 seconds or
longer in development environments.

The hypothesis behind this is that browsers will (at least sometimes)
open up to 6 TCP connections to one domain at once even if they aren't
going to use all 6 right away, and sometimes this can block all of
gunicorn's workers. Giving gunicorn 7 workers seems to keep it out of
trouble. See Slack discussion starting here:

https://hypothes-is.slack.com/archives/backend/p1484241382001768