### PR TITLE
Adding support for client_ga_tracking_id for client property analytics

### DIFF
--- a/h/config.py
+++ b/h/config.py
@@ -63,6 +63,7 @@ SETTINGS = [
     EnvSetting('csp.report_uri', 'CSP_REPORT_URI'),
     EnvSetting('csp.report_only', 'CSP_REPORT_ONLY'),
     EnvSetting('ga_tracking_id', 'GOOGLE_ANALYTICS_TRACKING_ID'),
+    EnvSetting('ga_client_tracking_id', 'GOOGLE_ANALYTICS_CLIENT_TRACKING_ID'),
     EnvSetting('h.app_url', 'APP_URL'),
     EnvSetting('h.auth_domain', 'AUTH_DOMAIN'),
     EnvSetting('h.bouncer_url', 'BOUNCER_URL'),

--- a/h/templates/app.html.jinja2
+++ b/h/templates/app.html.jinja2
@@ -34,20 +34,6 @@
     {% for url in app_js_urls %}
     <script src="{{ url }}"></script>
     {% endfor %}
-
-    <!-- Analytics !-->
-    {% if ga_tracking_id %}
-      <!-- Google Analytics -->
-      <script async src='//www.google-analytics.com/analytics.js'></script>
-      <script>
-       window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-       ga('create', 'UA-{{ga_tracking_id}}', '{{ga_cookie_domain}}');
-
-       {# No pageview event is sent here because that is handled by the
-          Angular GA integration in the client app after it boots.
-        #}
-      </script>
-      <!-- End Google Analytics -->
-    {% endif %}
+    
   </body>
 </html>

--- a/h/views/client.py
+++ b/h/views/client.py
@@ -29,9 +29,9 @@ def render_app(request, extra=None):
         # URLs.
         api_url=request.route_url('api.index'),
         service_url=request.route_url('index'),
-        ga_tracking_id=request.registry.settings.get('ga_tracking_id'),
         sentry_public_dsn=client_sentry_dsn,
         websocket_url=request.registry.settings.get('h.websocket_url'),
+        ga_client_tracking_id=request.registry.settings.get('ga_client_tracking_id'),
         extra=extra)
     request.response.text = html
     return request.response

--- a/tests/h/client_test.py
+++ b/tests/h/client_test.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+
+import json
+import mock
+import pytest
+
+from h.client import render_app_html
+from h import __version__
+
+
+class TestAppHtml(object):
+
+    def test_it_includes_client_config(self, jinja_env):
+        assets_env = mock.Mock(spec_set=['urls'])
+        template = mock.Mock(spec_set=['render'])
+        jinja_env.get_template.return_value = template
+
+        render_app_html(assets_env=assets_env,
+                        service_url='https://hypothes.is/',
+                        api_url='https://hypothes.is/api',
+                        sentry_public_dsn='test-sentry-dsn',
+                        ga_client_tracking_id='UA-4567',
+                        websocket_url='wss://hypothes.is/')
+
+        expected_config = {
+                'apiUrl': 'https://hypothes.is/api',
+                'websocketUrl': 'wss://hypothes.is/',
+                'serviceUrl': 'https://hypothes.is/',
+                'release': __version__,
+                'raven': {
+                    'dsn': 'test-sentry-dsn',
+                    'release': __version__
+                },
+                'googleAnalytics': 'UA-4567'
+                }
+        ((context,), kwargs) = template.render.call_args
+        actual_config = json.loads(context['app_config'])
+        assert actual_config == expected_config
+
+    @pytest.fixture
+    def jinja_env(self, patch):
+        jinja_env = patch('h.client.jinja_env')
+        return jinja_env


### PR DESCRIPTION
Part of the work for: https://github.com/hypothesis/product-backlog/issues/117

Adds support for telling the client about client_ga_tracking_id as the "googleAnalytics" field in the hypothesis settings.

This PR's job is just to pipe the property down to the client
