### PR TITLE
Consider group join permission when rendering group views

### DIFF
--- a/h/templates/groups/join.html.jinja2
+++ b/h/templates/groups/join.html.jinja2
@@ -19,7 +19,7 @@
       </div>
       {% if request.authenticated_userid %}
         <form method="POST">
-          <button class="btn primary-action-btn group-form__submit-btn" type="submit">
+          <button class="btn primary-action-btn group-form__submit-btn" name="group_join" type="submit">
             Join {{ group.name }}
           </button>
         </form>

--- a/h/views/activity.py
+++ b/h/views/activity.py
@@ -162,6 +162,27 @@ class GroupSearchController(SearchController):
         return result
 
     @view_config(request_method='POST',
+                 request_param='group_join')
+    def join(self):
+        """
+        Join the given group.
+
+        This adds the authenticated user to the given group and redirect the
+        browser to the search page.
+        """
+        if not self.request.has_permission('join', self.group):
+            raise httpexceptions.HTTPNotFound()
+
+        groups_service = self.request.find_service(name='group')
+        groups_service.member_join(self.group,
+                                   self.request.authenticated_userid)
+
+        url = self.request.route_url('group_read',
+                                     pubid=self.group.pubid,
+                                     slug=self.group.slug)
+        return httpexceptions.HTTPSeeOther(location=url)
+
+    @view_config(request_method='POST',
                  request_param='group_leave')
     def leave(self):
         """

--- a/h/views/groups.py
+++ b/h/views/groups.py
@@ -116,34 +116,6 @@ def read_unauthenticated(group, request):
     return {'group': group}
 
 
-@view_defaults(route_name='group_read',
-               renderer='h:templates/groups/join.html.jinja2',
-               effective_principals=security.Authenticated,
-               has_permission=not_('read'))
-class GroupJoinController(object):
-    """Views for "group_read" when logged in but not a member of the group."""
-
-    def __init__(self, group, request):
-        self.group = group
-        self.request = request
-
-    @view_config(request_method='GET')
-    def get(self):
-        check_slug(self.group, self.request)
-        return {'group': self.group}
-
-    @view_config(request_method='POST')
-    def post(self):
-        groups_service = self.request.find_service(name='group')
-        groups_service.member_join(self.group,
-                                   self.request.authenticated_userid)
-
-        url = self.request.route_path('group_read',
-                                      pubid=self.group.pubid,
-                                      slug=self.group.slug)
-        return HTTPSeeOther(url)
-
-
 @view_config(route_name='group_read_noslug', request_method='GET')
 def read_noslug(group, request):
     check_slug(group, request)

--- a/h/views/groups.py
+++ b/h/views/groups.py
@@ -3,8 +3,7 @@
 import deform
 from pyramid import security
 from pyramid.config import not_
-from pyramid.httpexceptions import (HTTPMovedPermanently, HTTPNoContent,
-                                    HTTPSeeOther)
+from pyramid.httpexceptions import (HTTPMovedPermanently, HTTPSeeOther)
 from pyramid.view import view_config, view_defaults
 
 from h import form
@@ -119,17 +118,6 @@ def read_unauthenticated(group, request):
 @view_config(route_name='group_read_noslug', request_method='GET')
 def read_noslug(group, request):
     check_slug(group, request)
-
-
-@view_config(route_name='group_leave',
-             request_method='POST',
-             effective_principals=security.Authenticated,
-             has_permission='read')
-def leave(group, request):
-    groups_service = request.find_service(name='group')
-    groups_service.member_leave(group, request.authenticated_userid)
-
-    return HTTPNoContent()
 
 
 def check_slug(group, request):

--- a/h/views/groups.py
+++ b/h/views/groups.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 
 import deform
+from pyramid import httpexceptions
 from pyramid import security
 from pyramid.config import not_
-from pyramid.httpexceptions import (HTTPMovedPermanently, HTTPSeeOther)
 from pyramid.view import view_config, view_defaults
 
 from h import form
@@ -50,7 +50,7 @@ class GroupCreateController(object):
             url = self.request.route_path('group_read',
                                           pubid=group.pubid,
                                           slug=group.slug)
-            return HTTPSeeOther(url)
+            return httpexceptions.HTTPSeeOther(url)
 
         return form.handle_form_submission(
             self.request,
@@ -112,6 +112,10 @@ class GroupEditController(object):
 def read_unauthenticated(group, request):
     """Group view for logged-out users, allowing them to join the group."""
     check_slug(group, request)
+
+    if group.joinable_by is None:
+        raise httpexceptions.HTTPNotFound()
+
     return {'group': group}
 
 
@@ -124,6 +128,5 @@ def check_slug(group, request):
     """Redirect if the request slug does not match that of the group."""
     slug = request.matchdict.get('slug')
     if slug is None or slug != group.slug:
-        raise HTTPMovedPermanently(request.route_path('group_read',
-                                                      pubid=group.pubid,
-                                                      slug=group.slug))
+        path = request.route_path('group_read', pubid=group.pubid, slug=group.slug)
+        raise httpexceptions.HTTPMovedPermanently(path)

--- a/h/views/predicates.py
+++ b/h/views/predicates.py
@@ -17,22 +17,5 @@ class HasFeatureFlagPredicate(object):
         return request.feature(self.feature_flag)
 
 
-class HasPermissionPredicate(object):
-    """True if the request has the given permission on the context object."""
-
-    def __init__(self, permission, config):
-        self.permission = permission
-
-    def text(self):
-        return 'has_permission = {permission}'.format(
-            permission=self.permission)
-
-    phash = text
-
-    def __call__(self, context, request):
-        return request.has_permission(self.permission)
-
-
 def includeme(config):
     config.add_view_predicate('has_feature_flag', HasFeatureFlagPredicate)
-    config.add_view_predicate('has_permission', HasPermissionPredicate)

--- a/tests/h/views/activity_test.py
+++ b/tests/h/views/activity_test.py
@@ -113,6 +113,31 @@ class TestGroupSearchController(object):
 
     """Tests unique to GroupSearchController."""
 
+    def test_search_renders_join_template(self, controller, pyramid_request, group):
+        """When the request has no read permission but join, it should render the join template."""
+
+        def fake_has_permission(permission, context=None):
+            if permission == 'read':
+                return False
+            if permission == 'join':
+                return True
+        pyramid_request.has_permission = mock.Mock(side_effect=fake_has_permission)
+        pyramid_request.override_renderer = mock.PropertyMock()
+
+        result = controller.search()
+
+        assert 'join.html' in pyramid_request.override_renderer
+        assert result == {'group': group}
+
+    def test_raises_not_found_when_no_read_or_join_permissions(self, controller, pyramid_request):
+        def fake_has_permission(permission, context=None):
+            if permission in ('read', 'join'):
+                return False
+        pyramid_request.has_permission = mock.Mock(side_effect=fake_has_permission)
+
+        with pytest.raises(httpexceptions.HTTPNotFound):
+            controller.search()
+
     def test_search_redirects_if_slug_wrong(self,
                                             controller,
                                             group,
@@ -181,19 +206,13 @@ class TestGroupSearchController(object):
         assert group_info['name'] == group.name
         assert group_info['pubid'] == group.pubid
 
-    def test_search_checks_whether_the_user_has_admin_permission_on_the_group(
-            self, controller, group, pyramid_request):
-        pyramid_request.authenticated_user = group.members[-1]
-
-        controller.search()
-
-        pyramid_request.has_permission.assert_called_once_with('admin', group)
-
     def test_search_does_not_show_the_edit_link_to_group_members(self,
                                                                  controller,
                                                                  group,
                                                                  pyramid_request):
-        pyramid_request.has_permission = mock.Mock(return_value=False)
+        def fake_has_permission(permission, context=None):
+            return permission != 'admin'
+        pyramid_request.has_permission = mock.Mock(side_effect=fake_has_permission)
         pyramid_request.authenticated_user = group.members[-1]
 
         result = controller.search()
@@ -242,7 +261,6 @@ class TestGroupSearchController(object):
                                                     controller,
                                                     pyramid_request,
                                                     group):
-        pyramid_request.has_permission = mock.Mock(return_value=False)
         pyramid_request.authenticated_user = group.members[-1]
 
         result = controller.search()
@@ -255,7 +273,6 @@ class TestGroupSearchController(object):
                                                  controller,
                                                  pyramid_request,
                                                  group):
-        pyramid_request.has_permission = mock.Mock(return_value=False)
         pyramid_request.authenticated_user = group.members[-1]
 
         result = controller.search()
@@ -268,7 +285,6 @@ class TestGroupSearchController(object):
                                                      controller,
                                                      pyramid_request,
                                                      group):
-        pyramid_request.has_permission = mock.Mock(return_value=False)
         pyramid_request.authenticated_user = group.members[-1]
 
         faceted_user = group.members[0]
@@ -289,7 +305,6 @@ class TestGroupSearchController(object):
         user_2 = factories.User()
         group.members = [user_1, user_2]
 
-        pyramid_request.has_permission = mock.Mock(return_value=False)
         pyramid_request.authenticated_user = group.members[-1]
 
         counts = {user_1.userid: 24, user_2.userid: 6}
@@ -516,7 +531,6 @@ class TestGroupSearchController(object):
         pyramid_request.matchdict['pubid'] = group.pubid
         pyramid_request.matchdict['slug'] = group.slug
         pyramid_request.authenticated_user = None
-        pyramid_request.has_permission = mock.Mock(return_value=False)
         return pyramid_request
 
     @pytest.fixture

--- a/tests/h/views/groups_test.py
+++ b/tests/h/views/groups_test.py
@@ -3,8 +3,7 @@
 import deform
 import mock
 import pytest
-from pyramid.httpexceptions import (HTTPMovedPermanently, HTTPNoContent,
-                                    HTTPSeeOther)
+from pyramid.httpexceptions import (HTTPMovedPermanently, HTTPNoContent)
 
 from h.views import groups as views
 from h.models import (Group, User)
@@ -193,49 +192,6 @@ class TestGroupLeave(object):
         result = views.leave(group, pyramid_request)
 
         assert isinstance(result, HTTPNoContent)
-
-
-@pytest.mark.usefixtures('group_service', 'routes')
-class TestGroupJoinController(object):
-
-    def test_get_returns_the_group_to_the_template(self, controller, group):
-        assert controller.get()['group'] == group
-
-    def test_post_joins_the_group(self,
-                                  controller,
-                                  group,
-                                  group_service,
-                                  pyramid_config):
-        pyramid_config.testing_securitypolicy('gentiana')
-
-        controller.post()
-
-        assert (group, 'gentiana') in group_service.joined
-
-    def test_post_redirects_to_group_page(self,
-                                          controller,
-                                          group):
-        result = controller.post()
-
-        assert isinstance(result, HTTPSeeOther)
-        assert result.location == '/g/{pubid}/{slug}'.format(
-            pubid=group.pubid, slug=group.slug)
-
-    @pytest.fixture
-    def controller(self, group, pyramid_request):
-        return views.GroupJoinController(group, pyramid_request)
-
-    @pytest.fixture
-    def group(self, factories):
-        return factories.Group()
-
-    @pytest.fixture
-    def pyramid_request(self, group, pyramid_request):
-        # The matchdict needs to contain the correct pubid and slug,
-        # otherwise initializing the controller will redirect.
-        pyramid_request.matchdict['pubid'] = group.pubid
-        pyramid_request.matchdict['slug'] = group.slug
-        return pyramid_request
 
 
 class FakeGroup(object):

--- a/tests/h/views/groups_test.py
+++ b/tests/h/views/groups_test.py
@@ -3,7 +3,7 @@
 import deform
 import mock
 import pytest
-from pyramid.httpexceptions import (HTTPMovedPermanently, HTTPNoContent)
+from pyramid import httpexceptions
 
 from h.views import groups as views
 from h.models import (Group, User)
@@ -149,7 +149,7 @@ class TestGroupReadUnauthenticated(object):
         group = FakeGroup('abc123', 'some-slug')
         pyramid_request.matchdict['slug'] = 'another-slug'
 
-        with pytest.raises(HTTPMovedPermanently) as exc:
+        with pytest.raises(httpexceptions.HTTPMovedPermanently) as exc:
             views.read_unauthenticated(group, pyramid_request)
 
         assert exc.value.location == '/g/abc123/some-slug'
@@ -167,31 +167,10 @@ class TestGroupReadUnauthenticated(object):
 def test_read_noslug_redirects(pyramid_request):
     group = FakeGroup('abc123', 'some-slug')
 
-    with pytest.raises(HTTPMovedPermanently) as exc:
+    with pytest.raises(httpexceptions.HTTPMovedPermanently) as exc:
         views.read_noslug(group, pyramid_request)
 
     assert exc.value.location == '/g/abc123/some-slug'
-
-
-@pytest.mark.usefixtures('group_service', 'routes')
-class TestGroupLeave(object):
-    def test_leaves_group(self,
-                          group_service,
-                          pyramid_config,
-                          pyramid_request):
-        group = FakeGroup('abc123', 'some-slug')
-        pyramid_config.testing_securitypolicy('marcela')
-
-        views.leave(group, pyramid_request)
-
-        assert (group, 'marcela') in group_service.left
-
-    def test_returns_nocontent(self, pyramid_request):
-        group = FakeGroup('abc123', 'some-slug')
-
-        result = views.leave(group, pyramid_request)
-
-        assert isinstance(result, HTTPNoContent)
 
 
 class FakeGroup(object):

--- a/tests/h/views/groups_test.py
+++ b/tests/h/views/groups_test.py
@@ -7,6 +7,7 @@ from pyramid import httpexceptions
 
 from h.views import groups as views
 from h.models import (Group, User)
+from h.models.group import JoinableBy
 
 
 @pytest.mark.usefixtures('group_service', 'handle_form_submission', 'routes')
@@ -162,6 +163,13 @@ class TestGroupReadUnauthenticated(object):
 
         assert result == {'group': group}
 
+    def test_raises_not_found_when_not_joinable(self, pyramid_request):
+        group = FakeGroup('abc123', 'some-slug', joinable_by=None)
+        pyramid_request.matchdict['slug'] = 'some-slug'
+
+        with pytest.raises(httpexceptions.HTTPNotFound):
+            views.read_unauthenticated(group, pyramid_request)
+
 
 @pytest.mark.usefixtures('routes')
 def test_read_noslug_redirects(pyramid_request):
@@ -174,9 +182,10 @@ def test_read_noslug_redirects(pyramid_request):
 
 
 class FakeGroup(object):
-    def __init__(self, pubid, slug):
+    def __init__(self, pubid, slug, joinable_by=JoinableBy.authority):
         self.pubid = pubid
         self.slug = slug
+        self.joinable_by = joinable_by
 
 
 class FakeGroupService(object):

--- a/tests/h/views/predicates_test.py
+++ b/tests/h/views/predicates_test.py
@@ -26,28 +26,3 @@ class TestHasFeatureFlagPredicate(object):
 
         request.feature.assert_called_once_with('bar')
         assert result == request.feature.return_value
-
-
-class TestHasPermissionPredicate(object):
-
-    def test_text(self):
-        predicate = predicates.HasPermissionPredicate('foo',
-                                                      mock.sentinel.config)
-
-        assert predicate.text() == 'has_permission = foo'
-
-    def test_phash(self):
-        predicate = predicates.HasPermissionPredicate('foo',
-                                                      mock.sentinel.config)
-
-        assert predicate.phash() == 'has_permission = foo'
-
-    def test__call__(self):
-        request = mock.Mock(spec_set=['has_permission'])
-        predicate = predicates.HasPermissionPredicate('bar',
-                                                      mock.sentinel.config)
-
-        result = predicate(mock.sentinel.context, request)
-
-        request.has_permission.assert_called_once_with('bar')
-        assert result == request.has_permission.return_value


### PR DESCRIPTION
These changes will make sure that we always show the correct search/join/404 page depending on the logged-in user (or not) and the group's `joinable_by` value.

It wasn't possible to do this change and still have the group search (activity) page and join controller separated as we had before, because we would have to check for `not read permission and join permission`, which doesn't work with our `has_permission` predicate, or any other method, except for creating a new custom view predicate just for this use case which doesn't sound like a good solution to me.

This also means that the group joining and leaving is now in the same place.