### PR TITLE
Add a reference to our branch naming convention

### DIFF
--- a/docs/developing/submitting-a-pr.rst
+++ b/docs/developing/submitting-a-pr.rst
@@ -30,6 +30,10 @@ Some things to remember when submitting or reviewing a pull request:
   Please minimize issue gardening by using the GitHub syntax for closing
   issues with commit messages.
 
+- We recommend giving your branch a relatively short, descriptive,
+  hyphen-delimited name. ``fix-editor-lists`` and ``tabbed-sidebar`` are good
+  examples of this convention.
+
 - Don't merge on feature branches. Feature branches should merge into upstream
   branches, but never contain merge commits in the other direction.
   Consider using ``--rebase`` when pulling if you must keep a long-running


### PR DESCRIPTION
I removed the previous guidance in #4306 because it was no longer being applied, and @robertknight pointed out that @nickstenning had [proposed this new convention][1] on an internal email list. Given we now appear to have adopted this convention, it makes sense to update the documentation for new starters.

I've reduced the strength of this to a recommendation, because I don't think it's reasonable to insist on a branch naming convention for external contributors; internally, of course, we can insist as hard as we like.


[1]: https://groups.google.com/a/list.hypothes.is/forum/#4D6A209F-6444-40EA-ACF4-753B07F7AB5D