### PR TITLE
Remove old features in a Celery task (not at boot)

### DIFF
--- a/h/celery.py
+++ b/h/celery.py
@@ -46,6 +46,10 @@ celery.conf.update(
             'task': 'h.tasks.cleanup.purge_expired_tokens',
             'schedule': timedelta(hours=1)
         },
+        'purge-removed-features': {
+            'task': 'h.tasks.cleanup.purge_removed_features',
+            'schedule': timedelta(hours=6)
+        },
     },
     CELERY_ACCEPT_CONTENT=['json'],
     # Enable at-least-once delivery mode. This probably isn't actually what we

--- a/h/cli/__init__.py
+++ b/h/cli/__init__.py
@@ -33,13 +33,6 @@ def bootstrap(app_url, dev=False):
 
     Returns a bootstrapped request object.
     """
-    # Set a flag in the environment that other code can use to detect if it's
-    # running in a script rather than a full web application.
-    #
-    # FIXME: This is a nasty hack and should go when we no longer need to spin
-    # up an entire application to build the extensions.
-    os.environ['H_SCRIPT'] = 'true'
-
     # In development, we will happily provide a default APP_URL, but it must be
     # set in production mode.
     if not app_url:

--- a/h/features/__init__.py
+++ b/h/features/__init__.py
@@ -10,7 +10,5 @@ __all__ = ('Client',)
 def includeme(config):
     config.add_request_method(Client, name='feature', reify=True)
 
-    config.add_subscriber('h.features.subscribers.remove_old_flags',
-                          'pyramid.events.ApplicationCreated')
     config.add_subscriber('h.features.subscribers.preload_flags',
                           'pyramid.events.NewRequest')

--- a/h/features/subscribers.py
+++ b/h/features/subscribers.py
@@ -2,26 +2,6 @@
 
 from __future__ import unicode_literals
 
-import os
-
-from h import db
-from h.models import Feature
-
-
-def remove_old_flags(event):
-    """Remove old feature flags from the database."""
-    # Skip this if we're in a script, not actual app startup. See the comment
-    # in h.cli:main for an explanation.
-    if 'H_SCRIPT' in os.environ:
-        return
-
-    engine = db.make_engine(event.app.registry.settings)
-    session = db.Session(bind=engine)
-    Feature.remove_old_flags(session)
-    session.commit()
-    session.close()
-    engine.dispose()
-
 
 def preload_flags(event):
     """Load all feature flags from the database for this request."""

--- a/h/tasks/cleanup.py
+++ b/h/tasks/cleanup.py
@@ -41,3 +41,9 @@ def purge_expired_tokens():
     celery.request.db.query(models.Token) \
         .filter(models.Token.expires < datetime.utcnow()) \
         .delete()
+
+
+@celery.task
+def purge_removed_features():
+    """Remove old feature flags from the database."""
+    models.Feature.remove_old_flags(celery.request.db)

--- a/tests/h/features/subscribers_test.py
+++ b/tests/h/features/subscribers_test.py
@@ -3,12 +3,10 @@
 from __future__ import unicode_literals
 
 import pytest
-from mock import patch
 
-from pyramid.registry import Registry
-from pyramid.events import ApplicationCreated, NewRequest
+from pyramid.events import NewRequest
 
-from h.features.subscribers import preload_flags, remove_old_flags
+from h.features.subscribers import preload_flags
 
 
 class TestPreloadFlags(object):
@@ -30,40 +28,3 @@ class TestPreloadFlags(object):
         preload_flags(event)
 
         assert not event.request.feature.loaded
-
-
-class TestRemoveOldFlags(object):
-    def test_removes_flags(self, patch):
-        db = patch('h.features.subscribers.db')
-        Feature = patch('h.features.subscribers.Feature')
-        event = ApplicationCreated(DummyApp())
-
-        remove_old_flags(event)
-
-        Feature.remove_old_flags.assert_called_once_with(db.Session.return_value)
-
-    def test_cleans_up_database_session_and_connection(self, patch):
-        db = patch('h.features.subscribers.db')
-        patch('h.features.subscribers.Feature')
-        event = ApplicationCreated(DummyApp())
-
-        remove_old_flags(event)
-
-        db.Session.return_value.close.assert_called_once_with()
-        db.make_engine.return_value.dispose.assert_called_once_with()
-
-    @patch.dict('os.environ', {'H_SCRIPT': '1'})
-    def test_does_nothing_when_in_script(self, patch):
-        patch('h.features.subscribers.db')
-        Feature = patch('h.features.subscribers.Feature')
-        event = ApplicationCreated(DummyApp())
-
-        remove_old_flags(event)
-
-        assert not Feature.remove_old_flags.called
-
-
-class DummyApp(object):
-    def __init__(self):
-        self.registry = Registry('testing')
-        self.registry.settings = {'sqlalchemy.url': 'sqlite:///:memory:'}

--- a/tests/h/tasks/cleanup_test.py
+++ b/tests/h/tasks/cleanup_test.py
@@ -11,6 +11,7 @@ from h.tasks.cleanup import (
     purge_deleted_annotations,
     purge_expired_auth_tickets,
     purge_expired_tokens,
+    purge_removed_features,
 )
 
 
@@ -96,6 +97,16 @@ class TestPurgeExpiredTokens(object):
         assert db_session.query(Token).count() == 2
         purge_expired_tokens()
         assert db_session.query(Token).count() == 2
+
+
+@pytest.mark.usefixtures('celery')
+class TestPurgeRemovedFeatures(object):
+    def test_calls_remove_old_flags(self, db_session, patch):
+        Feature = patch('h.tasks.cleanup.models.Feature')
+
+        purge_removed_features()
+
+        Feature.remove_old_flags.assert_called_once_with(db_session)
 
 
 @pytest.fixture


### PR DESCRIPTION
We remove old feature flags from the database so that if we later accidentally reuse a feature name it doesn't unexpectedly come up switched on.

At the moment this is handled at application boot time, which means that the application fails to boot if the database isn't available. Instead, this commit adds a celery task to perform the removal, and an entry in the Celery Beat schedule to run it every six hours.

(This is one step towards allowing the application to boot without a database available.)