### PR TITLE
Make memex.search._get_client public

### DIFF
--- a/src/memex/search/__init__.py
+++ b/src/memex/search/__init__.py
@@ -6,10 +6,14 @@ from memex.search.core import Search
 from memex.search.core import FILTERS_KEY
 from memex.search.core import MATCHERS_KEY
 
-__all__ = ('Search',)
+__all__ = (
+    'Search',
+    'get_client',
+    'init',
+)
 
 
-def _get_client(settings):
+def get_client(settings):
     """Return a client for the Elasticsearch index."""
     host = settings['es.host']
     index = settings['es.index']
@@ -45,7 +49,7 @@ def includeme(config):
     # Add a property to all requests for easy access to the elasticsearch
     # client. This can be used for direct or bulk access without having to
     # reread the settings.
-    config.registry['es.client'] = client = _get_client(settings)
+    config.registry['es.client'] = client = get_client(settings)
     config.add_request_method(
         lambda r: r.registry['es.client'],
         name='es',

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -62,8 +62,8 @@ def init_db(db_engine):
 
 @pytest.fixture(scope='session', autouse=True)
 def init_elasticsearch():
-    from memex.search import init, _get_client
-    client = _get_client(TEST_SETTINGS)
+    from memex.search import init, get_client
+    client = get_client(TEST_SETTINGS)
     _drop_indices(TEST_SETTINGS)
     init(client)
 


### PR DESCRIPTION
This is used by tests and will shortly be used by a CLI tool, so it probably shouldn't remain a module private function.