### PR TITLE
Simplify database and search index initialization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ clean:
 ## Run the development H server locally
 .PHONY: dev
 dev: build/manifest.json .pydeps
+	@bin/hypothesis --dev init
 	@bin/hypothesis devserver
 
 ## Build hypothesis/hypothesis docker image

--- a/h/app.py
+++ b/h/app.py
@@ -112,11 +112,6 @@ def includeme(config):
     # - we can override behaviour from `memex` if necessary.
     config.include('memex', route_prefix='/api')
 
-    # If search autoconfig is false, then override memex.search.init with a
-    # no-op.
-    if not asbool(config.registry.settings.get('h.search.autoconfig')):
-        config.action('memex.search.init', lambda: None)
-
     # Override memex group service
     config.register_service_factory('h.services.groupfinder.groupfinder_service_factory',
                                     iface='memex.interfaces.IGroupService')

--- a/h/cli/__init__.py
+++ b/h/cli/__init__.py
@@ -17,6 +17,7 @@ log = logging.getLogger('h')
 SUBCOMMANDS = (
     'h.cli.commands.celery.celery',
     'h.cli.commands.devserver.devserver',
+    'h.cli.commands.init.init',
     'h.cli.commands.initdb.initdb',
     'h.cli.commands.migrate.migrate',
     'h.cli.commands.move_uri.move_uri',

--- a/h/cli/commands/devserver.py
+++ b/h/cli/commands/devserver.py
@@ -76,10 +76,7 @@ def devserver(https, web, ws, worker, assets, beat):
 
     m = Manager()
     if web:
-        m.add_process('web',
-                      'MODEL_CREATE_ALL=true '
-                      'SEARCH_AUTOCONFIG=true '
-                      'gunicorn --reload --paste conf/development-app.ini %s' % gunicorn_args)
+        m.add_process('web', 'gunicorn --reload --paste conf/development-app.ini %s' % gunicorn_args)
 
     if ws:
         m.add_process('ws', 'gunicorn --reload --paste conf/development-websocket.ini %s' % gunicorn_args)

--- a/h/cli/commands/init.py
+++ b/h/cli/commands/init.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+
+import logging
+
+import click
+import sqlalchemy
+
+from h import db
+from memex import search
+
+log = logging.getLogger(__name__)
+
+
+@click.command()
+@click.pass_context
+def init(ctx):
+    request = ctx.obj['bootstrap']()
+
+    _init_db(request.registry.settings)
+    _init_search(request.registry.settings)
+
+
+def _init_db(settings):
+    engine = db.make_engine(settings)
+
+    # If the alembic_version table is present, then the database is managed by
+    # alembic, and we shouldn't call `db.init`.
+    try:
+        engine.execute('select 1 from alembic_version')
+    except sqlalchemy.exc.ProgrammingError:
+        log.info("initializing database")
+        db.init(engine, should_create=True)
+    else:
+        log.info("detected alembic_version table, skipping db initialization")
+
+
+def _init_search(settings):
+    client = search.get_client(settings)
+
+    log.info("initializing search index")
+    search.init(client)

--- a/h/cli/commands/initdb.py
+++ b/h/cli/commands/initdb.py
@@ -1,18 +1,8 @@
 # -*- coding: utf-8 -*-
 
-import os
-
 import click
 
 
 @click.command()
-@click.pass_context
-def initdb(ctx):
-    """Create database tables and elasticsearch indices."""
-    # Settings to autocreate database tables and indices
-    os.environ['MODEL_CREATE_ALL'] = 'true'
-    os.environ['SEARCH_AUTOCONFIG'] = 'true'
-
-    # Start the application
-    bootstrap = ctx.obj['bootstrap']
-    bootstrap()
+def initdb():
+    raise click.ClickException('use the init command instead')

--- a/h/config.py
+++ b/h/config.py
@@ -69,10 +69,7 @@ SETTINGS = [
     EnvSetting('h.bouncer_url', 'BOUNCER_URL'),
     EnvSetting('h.client_id', 'CLIENT_ID'),
     EnvSetting('h.client_secret', 'CLIENT_SECRET'),
-    EnvSetting('h.db.should_create_all', 'MODEL_CREATE_ALL', type=asbool),
-    EnvSetting('h.db.should_drop_all', 'MODEL_DROP_ALL', type=asbool),
     EnvSetting('h.proxy_auth', 'PROXY_AUTH', type=asbool),
-    EnvSetting('h.search.autoconfig', 'SEARCH_AUTOCONFIG', type=asbool),
     EnvSetting('h.websocket_url', 'WEBSOCKET_URL'),
     # The client Sentry DSN should be of the public kind, lacking the password
     # component in the DSN URI.

--- a/src/memex/search/__init__.py
+++ b/src/memex/search/__init__.py
@@ -49,10 +49,8 @@ def includeme(config):
     # Add a property to all requests for easy access to the elasticsearch
     # client. This can be used for direct or bulk access without having to
     # reread the settings.
-    config.registry['es.client'] = client = get_client(settings)
+    config.registry['es.client'] = get_client(settings)
     config.add_request_method(
         lambda r: r.registry['es.client'],
         name='es',
         reify=True)
-
-    config.action('memex.search.init', init, args=(client,), order=10)

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -12,9 +12,6 @@ TEST_SETTINGS = {
     'es.host': os.environ.get('ELASTICSEARCH_HOST', 'http://localhost:9200'),
     'es.index': 'hypothesis-test',
     'h.app_url': 'http://localhost',
-    'h.db.should_create_all': False,
-    'h.db.should_drop_all': False,
-    'h.search.autoconfig': False,
     'pyramid.debug_all': True,
     'sqlalchemy.url': os.environ.get('TEST_DATABASE_URL',
                                      'postgresql://postgres@localhost/htest')

--- a/tests/h/cli/commands/init_test.py
+++ b/tests/h/cli/commands/init_test.py
@@ -1,0 +1,70 @@
+
+# -*- coding: utf-8 -*-
+
+import mock
+import pytest
+
+from h.cli.commands import init as init_cli
+
+
+@pytest.mark.usefixtures('db', 'search')
+class TestInitCommand(object):
+    def test_initialises_database(self,
+                                  cli,
+                                  cliconfig,
+                                  db,
+                                  db_engine,
+                                  pyramid_settings):
+        db.make_engine.return_value = db_engine
+
+        result = cli.invoke(init_cli.init, obj=cliconfig)
+
+        db.make_engine.assert_called_once_with(pyramid_settings)
+        db.init.assert_called_once_with(db_engine, should_create=True)
+        assert result.exit_code == 0
+
+    def test_skips_database_init_if_alembic_managed(self,
+                                                    request,
+                                                    cli,
+                                                    cliconfig,
+                                                    db,
+                                                    db_engine):
+        db.make_engine.return_value = db_engine
+        db_engine.execute('CREATE TABLE alembic_version (version_num VARCHAR(32));')
+
+        @request.addfinalizer
+        def _cleanup():
+            db_engine.execute('DROP TABLE alembic_version;')
+
+        result = cli.invoke(init_cli.init, obj=cliconfig)
+
+        assert not db.init.called
+        assert result.exit_code == 0
+
+    def test_initialises_search(self,
+                                cli,
+                                cliconfig,
+                                search,
+                                pyramid_settings):
+        client = search.get_client.return_value
+
+        result = cli.invoke(init_cli.init, obj=cliconfig)
+
+        search.get_client.assert_called_once_with(pyramid_settings)
+        search.init.assert_called_once_with(client)
+        assert result.exit_code == 0
+
+
+@pytest.fixture
+def cliconfig(pyramid_request):
+    return {'bootstrap': mock.Mock(return_value=pyramid_request)}
+
+
+@pytest.fixture
+def db(patch):
+    return patch('h.cli.commands.init.db')
+
+
+@pytest.fixture
+def search(patch):
+    return patch('h.cli.commands.init.search')


### PR DESCRIPTION
This commit removes the automatic (and hence racy) initialisation of database tables and search index, in favour of a `hypothesis init` command which must be called explicitly.

This simplifies the integration of memex into h (no more overriding of memex's automatic search index initialization), and various other parts of the application boot code, at the cost of requiring an explicit initialisation of the database before first use.

In addition, this commit adds support for detecting if a database is managed by Alembic, and skips automatic database initialisation in that case. This should prevent a number of confusing behaviours which crop up for developers when new tables are added to the database.

For development environments, this should remain largely transparent to the user, thanks to an additional call made by the Makefile's `dev` target.

The following settings are removed with this commit:

- MODEL_CREATE_ALL (h.db.should_create_all)
- MODEL_DROP_ALL (h.db.should_drop_all)
- SEARCH_AUTOCONFIG (h.search.autoconfig)

Fixes #4290.

~~_**N.B.** This depends on #4311, and will need to be rebased after that has merged._~~