### PR TITLE
Remove the 'UA-' prefix from the Google Analytics tracking ID

### DIFF
--- a/h/templates/layouts/base.html.jinja2
+++ b/h/templates/layouts/base.html.jinja2
@@ -53,7 +53,7 @@
       <script async src='//www.google-analytics.com/analytics.js'></script>
       <script>
        window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-       ga('create', 'UA-{{ga_tracking_id}}', '{{ga_cookie_domain}}');
+       ga('create', '{{ga_tracking_id}}', '{{ga_cookie_domain}}');
        {% block ga_pageview %}
        ga('send', 'pageview');
        {% endblock %}


### PR DESCRIPTION
The prefix is part of the ID, so it has been moved to the configuration
for the service in the playbook.

See https://github.com/hypothesis/playbook/pull/88#issuecomment-274102054

This needs to be deployed together with https://github.com/hypothesis/playbook/pull/89