### PR TITLE
Refactor annotation presenters to get links from resource

### DIFF
--- a/h/streamer/messages.py
+++ b/h/streamer/messages.py
@@ -147,8 +147,8 @@ def _generate_annotation_event(message, socket, annotation, user_nipsad, group_s
     base_url = socket.registry.settings.get('h.app_url',
                                             'http://localhost:5000')
     links_service = LinksService(base_url, socket.registry)
-    resource = AnnotationResource(annotation, group_service)
-    serialized = presenters.AnnotationJSONPresenter(resource, links_service).asdict()
+    resource = AnnotationResource(annotation, group_service, links_service)
+    serialized = presenters.AnnotationJSONPresenter(resource).asdict()
 
     permissions = serialized.get('permissions')
     if not _authorized_to_read(socket.effective_principals, permissions):

--- a/src/memex/presenters.py
+++ b/src/memex/presenters.py
@@ -10,11 +10,9 @@ from pyramid import security
 
 
 class AnnotationBasePresenter(object):
-    def __init__(self, annotation_resource, links_service):
+    def __init__(self, annotation_resource):
         self.annotation_resource = annotation_resource
         self.annotation = annotation_resource.annotation
-
-        self._links_service = links_service
 
     @property
     def created(self):
@@ -29,7 +27,7 @@ class AnnotationBasePresenter(object):
     @property
     def links(self):
         """A dictionary of named hypermedia links for this annotation."""
-        return self._links_service.get_all(self.annotation)
+        return self.annotation_resource.links
 
     @property
     def text(self):
@@ -172,7 +170,7 @@ class AnnotationJSONLDPresenter(AnnotationBasePresenter):
 
     @property
     def id(self):
-        return self._links_service.get(self.annotation, 'jsonld_id')
+        return self.annotation_resource.link('jsonld_id')
 
     @property
     def bodies(self):

--- a/src/memex/resources.py
+++ b/src/memex/resources.py
@@ -18,17 +18,26 @@ class AnnotationResourceFactory(object):
             raise KeyError()
 
         group_service = self.request.find_service(IGroupService)
-        return AnnotationResource(annotation, group_service)
+        links_service = self.request.find_service(name='links')
+        return AnnotationResource(annotation, group_service, links_service)
 
 
 class AnnotationResource(object):
-    def __init__(self, annotation, group_service):
+    def __init__(self, annotation, group_service, links_service):
         self.group_service = group_service
+        self.links_service = links_service
         self.annotation = annotation
 
     @property
     def group(self):
         return self.group_service.find(self.annotation.groupid)
+
+    @property
+    def links(self):
+        return self.links_service.get_all(self.annotation)
+
+    def link(self, name):
+        return self.links_service.get(self.annotation, name)
 
     def __acl__(self):
         """Return a Pyramid ACL for this annotation."""

--- a/src/memex/views.py
+++ b/src/memex/views.py
@@ -177,8 +177,8 @@ def create(request):
 
     links_service = request.find_service(name='links')
     group_service = request.find_service(IGroupService)
-    resource = AnnotationResource(annotation, group_service)
-    presenter = AnnotationJSONPresenter(resource, links_service)
+    resource = AnnotationResource(annotation, group_service, links_service)
+    presenter = AnnotationJSONPresenter(resource)
     return presenter.asdict()
 
 
@@ -187,8 +187,7 @@ def create(request):
             permission='read')
 def read(context, request):
     """Return the annotation (simply how it was stored in the database)."""
-    links_service = request.find_service(name='links')
-    presenter = AnnotationJSONPresenter(context, links_service)
+    presenter = AnnotationJSONPresenter(context)
     return presenter.asdict()
 
 
@@ -199,8 +198,7 @@ def read_jsonld(context, request):
     request.response.content_type = 'application/ld+json'
     request.response.content_type_params = {
         'profile': AnnotationJSONLDPresenter.CONTEXT_URL}
-    links_service = request.find_service(name='links')
-    presenter = AnnotationJSONLDPresenter(context, links_service)
+    presenter = AnnotationJSONLDPresenter(context)
     return presenter.asdict()
 
 
@@ -222,8 +220,8 @@ def update(context, request):
 
     links_service = request.find_service(name='links')
     group_service = request.find_service(IGroupService)
-    resource = AnnotationResource(annotation, group_service)
-    presenter = AnnotationJSONPresenter(resource, links_service)
+    resource = AnnotationResource(annotation, group_service, links_service)
+    presenter = AnnotationJSONPresenter(resource)
     return presenter.asdict()
 
 
@@ -269,8 +267,8 @@ def _present_annotations(request, ids):
                                                     query_processor=eager_load_documents)
     group_service = request.find_service(IGroupService)
     links_service = request.find_service(name='links')
-    return [AnnotationJSONPresenter(AnnotationResource(ann, group_service),
-                                    links_service).asdict()
+    return [AnnotationJSONPresenter(
+                AnnotationResource(ann, group_service, links_service)).asdict()
             for ann in annotations]
 
 

--- a/tests/h/streamer/messages_test.py
+++ b/tests/h/streamer/messages_test.py
@@ -207,11 +207,11 @@ class TestHandleAnnotationEvent(object):
 
         annotation_resource.assert_called_once_with(
             fetch_annotation.return_value,
-            groupfinder_service.return_value)
+            groupfinder_service.return_value,
+            links_service.return_value)
 
         presenters.AnnotationJSONPresenter.assert_called_once_with(
-            annotation_resource.return_value,
-            links_service.return_value)
+            annotation_resource.return_value)
         assert presenters.AnnotationJSONPresenter.return_value.asdict.called
 
     def test_notification_format(self, presenter_asdict):

--- a/tests/h/views/main_test.py
+++ b/tests/h/views/main_test.py
@@ -14,9 +14,9 @@ from h.views import main
 
 @mock.patch('h.client.render_app_html')
 @pytest.mark.usefixtures('routes')
-def test_og_document(render_app_html, annotation_document, document_title, pyramid_request, group_service):
+def test_og_document(render_app_html, annotation_document, document_title, pyramid_request, group_service, links_service):
     annotation = Annotation(id='123', userid='foo', target_uri='http://example.com')
-    context = AnnotationResource(annotation, group_service)
+    context = AnnotationResource(annotation, group_service, links_service)
     document = Document()
     annotation_document.return_value = document
     document_title.return_value = 'WikiHow — How to Make a ☆Starmap☆'
@@ -30,9 +30,9 @@ def test_og_document(render_app_html, annotation_document, document_title, pyram
 
 @mock.patch('h.client.render_app_html')
 @pytest.mark.usefixtures('routes')
-def test_og_no_document(render_app_html, pyramid_request, group_service):
+def test_og_no_document(render_app_html, pyramid_request, group_service, links_service):
     annotation = Annotation(id='123', userid='foo', target_uri='http://example.com')
-    context = AnnotationResource(annotation, group_service)
+    context = AnnotationResource(annotation, group_service, links_service)
 
     render_app_html.return_value = '<html></html>'
     main.annotation_page(context, pyramid_request)
@@ -151,3 +151,10 @@ def group_service(pyramid_config):
     group_service = mock.Mock(spec_set=['find'])
     pyramid_config.register_service(group_service, iface='memex.interfaces.IGroupService')
     return group_service
+
+
+@pytest.fixture
+def links_service(pyramid_config):
+    service = mock.Mock(spec_set=['get', 'get_all'])
+    pyramid_config.register_service(service, name='links')
+    return service

--- a/tests/memex/presenters_test.py
+++ b/tests/memex/presenters_test.py
@@ -21,110 +21,100 @@ from memex.resources import AnnotationResource
 
 class TestAnnotationBasePresenter(object):
 
-    def test_constructor_args(self, fake_links_service):
+    def test_constructor_args(self):
         annotation = mock.Mock()
         resource = mock.Mock(annotation=annotation)
 
-        presenter = AnnotationBasePresenter(resource, fake_links_service)
+        presenter = AnnotationBasePresenter(resource)
 
         assert presenter.annotation_resource == resource
         assert presenter.annotation == annotation
 
-    def test_created_returns_none_if_missing(self, fake_links_service):
+    def test_created_returns_none_if_missing(self):
         annotation = mock.Mock(created=None)
         resource = mock.Mock(annotation=annotation)
 
-        created = AnnotationBasePresenter(resource, fake_links_service).created
+        created = AnnotationBasePresenter(resource).created
 
         assert created is None
 
-    def test_created_uses_iso_format(self, fake_links_service):
+    def test_created_uses_iso_format(self):
         when = datetime.datetime(2012, 3, 14, 23, 34, 47, 12)
         annotation = mock.Mock(created=when)
         resource = mock.Mock(annotation=annotation)
 
-        created = AnnotationBasePresenter(resource, fake_links_service).created
+        created = AnnotationBasePresenter(resource).created
 
         assert created == '2012-03-14T23:34:47.000012+00:00'
 
-    def test_updated_returns_none_if_missing(self, fake_links_service):
+    def test_updated_returns_none_if_missing(self):
         annotation = mock.Mock(updated=None)
         resource = mock.Mock(annotation=annotation)
 
-        updated = AnnotationBasePresenter(resource, fake_links_service).updated
+        updated = AnnotationBasePresenter(resource).updated
 
         assert updated is None
 
-    def test_updated_uses_iso_format(self, fake_links_service):
+    def test_updated_uses_iso_format(self):
         when = datetime.datetime(1983, 8, 31, 7, 18, 20, 98763)
         annotation = mock.Mock(updated=when)
         resource = mock.Mock(annotation=annotation)
 
-        updated = AnnotationBasePresenter(resource, fake_links_service).updated
+        updated = AnnotationBasePresenter(resource).updated
 
         assert updated == '1983-08-31T07:18:20.098763+00:00'
 
-    def test_links(self, fake_links_service):
+    def test_links(self):
         annotation = mock.Mock()
         resource = mock.Mock(annotation=annotation)
 
-        links = AnnotationBasePresenter(resource, fake_links_service).links
+        links = AnnotationBasePresenter(resource).links
+        assert links == resource.links
 
-        assert links == {'giraffe': 'http://giraffe.com',
-                         'toad': 'http://toad.net'}
-
-    def test_links_passes_annotation(self, fake_links_service):
-        annotation = mock.Mock()
-        resource = mock.Mock(annotation=annotation)
-
-        AnnotationBasePresenter(resource, fake_links_service).links
-
-        assert fake_links_service.last_annotation == annotation
-
-    def test_text(self, fake_links_service):
+    def test_text(self):
         annotation = mock.Mock(text='It is magical!')
         resource = mock.Mock(annotation=annotation)
-        presenter = AnnotationBasePresenter(resource, fake_links_service)
+        presenter = AnnotationBasePresenter(resource)
 
         assert 'It is magical!' == presenter.text
 
-    def test_text_missing(self, fake_links_service):
+    def test_text_missing(self):
         annotation = mock.Mock(text=None)
         resource = mock.Mock(annotation=annotation)
-        presenter = AnnotationBasePresenter(resource, fake_links_service)
+        presenter = AnnotationBasePresenter(resource)
 
         assert '' == presenter.text
 
-    def test_tags(self, fake_links_service):
+    def test_tags(self):
         annotation = mock.Mock(tags=['interesting', 'magic'])
         resource = mock.Mock(annotation=annotation)
-        presenter = AnnotationBasePresenter(resource, fake_links_service)
+        presenter = AnnotationBasePresenter(resource)
 
         assert ['interesting', 'magic'] == presenter.tags
 
-    def test_tags_missing(self, fake_links_service):
+    def test_tags_missing(self):
         annotation = mock.Mock(tags=None)
         resource = mock.Mock(annotation=annotation)
-        presenter = AnnotationBasePresenter(resource, fake_links_service)
+        presenter = AnnotationBasePresenter(resource)
 
         assert [] == presenter.tags
 
-    def test_target(self, fake_links_service):
+    def test_target(self):
         annotation = mock.Mock(target_uri='http://example.com',
                                target_selectors={'PositionSelector': {'start': 0, 'end': 12}})
         resource = mock.Mock(annotation=annotation)
 
         expected = [{'source': 'http://example.com', 'selector': {'PositionSelector': {'start': 0, 'end': 12}}}]
-        actual = AnnotationBasePresenter(resource, fake_links_service).target
+        actual = AnnotationBasePresenter(resource).target
         assert expected == actual
 
-    def test_target_missing_selectors(self, fake_links_service):
+    def test_target_missing_selectors(self):
         annotation = mock.Mock(target_uri='http://example.com',
                                target_selectors=None)
         resource = mock.Mock(annotation=annotation)
 
         expected = [{'source': 'http://example.com'}]
-        actual = AnnotationBasePresenter(resource, fake_links_service).target
+        actual = AnnotationBasePresenter(resource).target
         assert expected == actual
 
 
@@ -142,7 +132,7 @@ class TestAnnotationJSONPresenter(object):
                         target_selectors=[{'TestSelector': 'foobar'}],
                         references=['referenced-id-1', 'referenced-id-2'],
                         extra={'extra-1': 'foo', 'extra-2': 'bar'})
-        resource = AnnotationResource(ann, group_service)
+        resource = AnnotationResource(ann, group_service, fake_links_service)
 
         document_asdict.return_value = {'foo': 'bar'}
 
@@ -167,25 +157,25 @@ class TestAnnotationJSONPresenter(object):
                     'extra-1': 'foo',
                     'extra-2': 'bar'}
 
-        result = AnnotationJSONPresenter(resource, fake_links_service).asdict()
+        result = AnnotationJSONPresenter(resource).asdict()
 
         assert result == expected
 
     def test_asdict_extra_cannot_override_other_data(self, document_asdict, group_service, fake_links_service):
         ann = mock.Mock(id='the-real-id', extra={'id': 'the-extra-id'})
-        resource = AnnotationResource(ann, group_service)
+        resource = AnnotationResource(ann, group_service, fake_links_service)
         document_asdict.return_value = {}
 
-        presented = AnnotationJSONPresenter(resource, fake_links_service).asdict()
+        presented = AnnotationJSONPresenter(resource).asdict()
         assert presented['id'] == 'the-real-id'
 
     def test_asdict_extra_uses_copy_of_extra(self, document_asdict, group_service, fake_links_service):
         extra = {'foo': 'bar'}
         ann = mock.Mock(id='my-id', extra=extra)
-        resource = AnnotationResource(ann, group_service)
+        resource = AnnotationResource(ann, group_service, fake_links_service)
         document_asdict.return_value = {}
 
-        AnnotationJSONPresenter(resource, fake_links_service).asdict()
+        AnnotationJSONPresenter(resource).asdict()
 
         # Presenting the annotation shouldn't change the "extra" dict.
         assert extra == {'foo': 'bar'}
@@ -213,8 +203,8 @@ class TestAnnotationJSONPresenter(object):
         group.__acl__.return_value = [group_principals[group_readable]]
         group_service.find.return_value = group
 
-        resource = AnnotationResource(annotation, group_service)
-        presenter = AnnotationJSONPresenter(resource, fake_links_service)
+        resource = AnnotationResource(annotation, group_service, fake_links_service)
+        presenter = AnnotationJSONPresenter(resource)
         assert expected == presenter.permissions[action]
 
     @pytest.fixture
@@ -316,33 +306,33 @@ class TestAnnotationJSONLDPresenter(object):
                         'selector': [{'TestSelector': 'foobar'}]}]
         }
 
-        resource = AnnotationResource(annotation, group_service)
-        result = AnnotationJSONLDPresenter(resource, fake_links_service).asdict()
+        resource = AnnotationResource(annotation, group_service, fake_links_service)
+        result = AnnotationJSONLDPresenter(resource).asdict()
 
         assert result == expected
 
     def test_id_returns_jsonld_id_link(self, group_service, fake_links_service):
         annotation = mock.Mock(id='foobar')
-        resource = AnnotationResource(annotation, group_service)
+        resource = AnnotationResource(annotation, group_service, fake_links_service)
 
-        presenter = AnnotationJSONLDPresenter(resource, fake_links_service)
+        presenter = AnnotationJSONLDPresenter(resource)
 
         assert presenter.id == 'http://fake-link/jsonld_id'
 
     def test_id_passes_annotation_to_link_service(self, group_service, fake_links_service):
         annotation = mock.Mock(id='foobar')
-        resource = AnnotationResource(annotation, group_service)
+        resource = AnnotationResource(annotation, group_service, fake_links_service)
 
-        presenter = AnnotationJSONLDPresenter(resource, fake_links_service)
+        presenter = AnnotationJSONLDPresenter(resource)
         _ = presenter.id
 
         assert fake_links_service.last_annotation == annotation
 
     def test_bodies_returns_textual_body(self, group_service, fake_links_service):
         annotation = mock.Mock(text='Flib flob flab', tags=None)
-        resource = AnnotationResource(annotation, group_service)
+        resource = AnnotationResource(annotation, group_service, fake_links_service)
 
-        bodies = AnnotationJSONLDPresenter(resource, fake_links_service).bodies
+        bodies = AnnotationJSONLDPresenter(resource).bodies
 
         assert bodies == [{
             'type': 'TextualBody',
@@ -352,9 +342,9 @@ class TestAnnotationJSONLDPresenter(object):
 
     def test_bodies_appends_tag_bodies(self, group_service, fake_links_service):
         annotation = mock.Mock(text='Flib flob flab', tags=['giraffe', 'lion'])
-        resource = AnnotationResource(annotation, group_service)
+        resource = AnnotationResource(annotation, group_service, fake_links_service)
 
-        bodies = AnnotationJSONLDPresenter(resource, fake_links_service).bodies
+        bodies = AnnotationJSONLDPresenter(resource).bodies
 
         assert {
             'type': 'TextualBody',

--- a/tests/memex/resources_test.py
+++ b/tests/memex/resources_test.py
@@ -11,7 +11,7 @@ from pyramid.authorization import ACLAuthorizationPolicy
 from memex.resources import AnnotationResourceFactory, AnnotationResource
 
 
-@pytest.mark.usefixtures('group_service')
+@pytest.mark.usefixtures('group_service', 'links_service')
 class TestAnnotationResourceFactory(object):
     def test_get_item_fetches_annotation(self, pyramid_request, storage):
         factory = AnnotationResourceFactory(pyramid_request)
@@ -47,6 +47,13 @@ class TestAnnotationResourceFactory(object):
         resource = factory['123']
         assert resource.group_service == group_service
 
+    def test_get_item_has_right_links_service(self, pyramid_request, storage, links_service):
+        factory = AnnotationResourceFactory(pyramid_request)
+        storage.fetch_annotation.return_value = Mock()
+
+        resource = factory['123']
+        assert resource.links_service == links_service
+
     @pytest.fixture
     def storage(self, patch):
         return patch('memex.resources.storage')
@@ -57,12 +64,36 @@ class TestAnnotationResourceFactory(object):
         pyramid_config.register_service(group_service, iface='memex.interfaces.IGroupService')
         return group_service
 
+    @pytest.fixture
+    def links_service(self, pyramid_config):
+        service = Mock()
+        pyramid_config.register_service(service, name='links')
+        return service
 
-@pytest.mark.usefixtures('group_service')
+
+@pytest.mark.usefixtures('group_service', 'links_service')
 class TestAnnotationResource(object):
-    def test_acl_private(self, factories, group_service):
+    def test_links(self, group_service, links_service):
+        ann = Mock()
+        res = AnnotationResource(ann, group_service, links_service)
+
+        result = res.links
+
+        links_service.get_all.assert_called_once_with(ann)
+        assert result == links_service.get_all.return_value
+
+    def test_link(self, group_service, links_service):
+        ann = Mock()
+        res = AnnotationResource(ann, group_service, links_service)
+
+        result = res.link('json')
+
+        links_service.get.assert_called_once_with(ann, 'json')
+        assert result == links_service.get.return_value
+
+    def test_acl_private(self, factories, group_service, links_service):
         ann = factories.Annotation(shared=False, userid='saoirse')
-        res = AnnotationResource(ann, group_service)
+        res = AnnotationResource(ann, group_service, links_service)
         actual = res.__acl__()
         expect = [(security.Allow, 'saoirse', 'read'),
                   (security.Allow, 'saoirse', 'admin'),
@@ -71,7 +102,7 @@ class TestAnnotationResource(object):
                   security.DENY_ALL]
         assert actual == expect
 
-    def test_acl_shared_admin_perms(self, factories, group_service):
+    def test_acl_shared_admin_perms(self, factories, group_service, links_service):
         """
         Shared annotation resources should still only give admin/update/delete
         permissions to the owner.
@@ -79,13 +110,13 @@ class TestAnnotationResource(object):
         policy = ACLAuthorizationPolicy()
 
         ann = factories.Annotation(shared=False, userid='saoirse')
-        res = AnnotationResource(ann, group_service)
+        res = AnnotationResource(ann, group_service, links_service)
 
         for perm in ['admin', 'update', 'delete']:
             assert policy.permits(res, ['saoirse'], perm)
             assert not policy.permits(res, ['someoneelse'], perm)
 
-    def test_acl_deleted(self, factories, group_service):
+    def test_acl_deleted(self, factories, group_service, links_service):
         """
         Nobody -- not even the owner -- should have any permissions on a
         deleted annotation.
@@ -93,7 +124,7 @@ class TestAnnotationResource(object):
         policy = ACLAuthorizationPolicy()
 
         ann = factories.Annotation(userid='saoirse', deleted=True)
-        res = AnnotationResource(ann, group_service)
+        res = AnnotationResource(ann, group_service, links_service)
 
         for perm in ['read', 'admin', 'update', 'delete']:
             assert not policy.permits(res, ['saiorse'], perm)
@@ -121,7 +152,8 @@ class TestAnnotationResource(object):
                         groupid,
                         userid,
                         permitted,
-                        group_service):
+                        group_service,
+                        links_service):
         """
         Shared annotation resources should delegate their 'read' permission to
         their containing group.
@@ -135,7 +167,7 @@ class TestAnnotationResource(object):
         ann = factories.Annotation(shared=True,
                                    userid='mioara',
                                    groupid=groupid)
-        res = AnnotationResource(ann, group_service)
+        res = AnnotationResource(ann, group_service, links_service)
 
         if permitted:
             assert pyramid_request.has_permission('read', res)
@@ -156,6 +188,12 @@ class TestAnnotationResource(object):
         group_service.find.side_effect = lambda groupid: groups.get(groupid)
         pyramid_config.register_service(group_service, iface='memex.interfaces.IGroupService')
         return group_service
+
+    @pytest.fixture
+    def links_service(self, pyramid_config):
+        service = Mock(spec_set=['get', 'get_all'])
+        pyramid_config.register_service(service, name='links')
+        return service
 
 
 class FakeGroup(object):


### PR DESCRIPTION
This will allow for a better API when creating a presenter, as the
resource already has the group service, so it's better to also pass the
links service to the resource instead of directly to the presenter.

This way the presenter only needs to know about the resource and nothing
else.

This refactoring came out of discussions around #4299.