### PR TITLE
Remove unnecessary `patch` in session tests

### DIFF
--- a/tests/h/session_test.py
+++ b/tests/h/session_test.py
@@ -11,8 +11,7 @@ class FakeGroup(object):
         self.slug = pubid
 
 
-@mock.patch('h.models.User', autospec=True)
-def test_model_sorts_groups(User):
+def test_model_sorts_groups():
     fake_user = mock.Mock()
     fake_user.groups = [
         FakeGroup('c', 'Group A'),


### PR DESCRIPTION
This patch dates from when we used `User.get_by_userid` to retrieve the currently logged-in user, and so needed to stub out user lookup. Now that this user is accessed through the  `authenticated_user` property on the request, this patch is no longer necessary.