### PR TITLE
API profile endpoint (for authenticated H users)

### DIFF
--- a/h/routes.py
+++ b/h/routes.py
@@ -62,6 +62,7 @@ def includeme(config):
 
     # API (other than those provided by memex)
     config.add_route('badge', '/api/badge')
+    config.add_route('api.profile', '/api/profile')
     config.add_route('token', '/api/token')
     config.add_route('api.users', '/api/users')
 

--- a/h/session.py
+++ b/h/session.py
@@ -11,11 +11,20 @@ def model(request):
     session['userid'] = request.authenticated_userid
     session['groups'] = _current_groups(request)
     session['features'] = request.feature.all()
-    session['preferences'] = {}
-    user = request.authenticated_user
-    if user and not user.sidebar_tutorial_dismissed:
-        session['preferences']['show_sidebar_tutorial'] = True
+    session['preferences'] = _user_preferences(request.authenticated_user)
     return session
+
+
+def profile(request):
+    """
+    Return a representation of the current user's information and settings.
+    """
+    profile = {}
+    profile['userid'] = request.authenticated_userid
+    profile['groups'] = _current_groups(request)
+    profile['features'] = request.feature.all()
+    profile['preferences'] = _user_preferences(request.authenticated_user)
+    return profile
 
 
 def pop_flash(request):
@@ -56,6 +65,13 @@ def _current_groups(request):
                                      slug=group.slug),
         })
     return groups
+
+
+def _user_preferences(user):
+    preferences = {}
+    if user and not user.sidebar_tutorial_dismissed:
+        preferences['show_sidebar_tutorial'] = True
+    return preferences
 
 
 def includeme(config):

--- a/h/views/api_profile.py
+++ b/h/views/api_profile.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from pyramid import security
+
+from h import session as h_session
+from h.util.view import json_view
+
+
+@json_view(route_name='api.profile',
+           request_method='GET',
+           effective_principals=security.Authenticated)
+def profile(request):
+    return h_session.model(request)

--- a/h/views/api_profile.py
+++ b/h/views/api_profile.py
@@ -12,4 +12,4 @@ from h.util.view import json_view
            request_method='GET',
            effective_principals=security.Authenticated)
 def profile(request):
-    return h_session.model(request)
+    return h_session.profile(request)

--- a/tests/functional/test_api.py
+++ b/tests/functional/test_api.py
@@ -49,6 +49,18 @@ class TestAPI(object):
         assert res.status_code == 400
         assert res.json['reason'].startswith('group:')
 
+    def test_profile_api(self, app, user_with_token):
+        """Fetch a profile through the API for an authenticated user."""
+
+        user, token = user_with_token
+
+        headers = {'Authorization': str('Bearer {}'.format(token.value))}
+
+        res = app.get('/api/profile', headers=headers)
+
+        assert res.json['userid'] == user.userid
+        assert [group['id'] for group in res.json['groups']] == ['__world__']
+
 
 @pytest.fixture
 def annotation(db_session, factories):

--- a/tests/h/routes_test.py
+++ b/tests/h/routes_test.py
@@ -56,6 +56,7 @@ def test_includeme():
         call('assets_client', '/assets/client/*subpath'),
         call('assets', '/assets/*subpath'),
         call('badge', '/api/badge'),
+        call('api.profile', '/api/profile'),
         call('token', '/api/token'),
         call('api.users', '/api/users'),
         call('session', '/app'),

--- a/tests/h/session_test.py
+++ b/tests/h/session_test.py
@@ -78,6 +78,64 @@ def test_profile_userid_authenticated(authenticated_request):
     assert profile['userid'] == u'acct:user@example.com'
 
 
+def test_profile_sorts_groups():
+    fake_user = mock.Mock()
+    fake_user.groups = [
+        FakeGroup('c', 'Group A'),
+        FakeGroup('b', 'Group B'),
+        FakeGroup('a', 'Group B'),
+    ]
+    request = mock.Mock(authenticated_user=fake_user)
+    profile = session.profile(request)
+
+    ids = [group['id'] for group in profile['groups']]
+
+    assert ids == ['__world__', 'c', 'a', 'b']
+
+
+def test_profile_includes_features(fake_user):
+    feature_dict = {
+        'feature_one': True,
+        'feature_two': False,
+    }
+    request = mock.Mock(authenticated_user=fake_user)
+    request.feature.all.return_value = feature_dict
+
+    assert session.profile(request)['features'] == feature_dict
+
+
+@pytest.mark.parametrize(
+    "user_authenticated,tutorial_dismissed,show_tutorial",
+    [(False, False, False),
+     (True,  False, True),
+     (True,  True,  False)])
+def test_profile_show_sidebar_tutorial(
+        fake_user, user_authenticated, tutorial_dismissed, show_tutorial):
+    """It should return or not return "show_sidebar_tutorial" correctly.
+
+    It should return "show_sidebar_tutorial": True only if a user
+    is authorized _and_ that user has not dismissed
+    the tutorial. Otherwise, preferences should contain no
+    "show_sidebar_tutorial" value at all.
+
+    """
+    fake_user.sidebar_tutorial_dismissed = tutorial_dismissed
+    if user_authenticated:
+        authenticated_user = fake_user
+    else:
+        authenticated_user = None
+    request = mock.Mock(
+        authenticated_user=authenticated_user,
+        )
+
+    preferences = session.profile(request)['preferences']
+
+    if show_tutorial:
+        assert preferences['show_sidebar_tutorial'] is True
+    else:
+        assert 'show_sidebar_tutorial' not in preferences
+
+
 @pytest.fixture
 def fake_user():
     fake_user = mock.Mock()

--- a/tests/h/session_test.py
+++ b/tests/h/session_test.py
@@ -69,8 +69,28 @@ def test_model_show_sidebar_tutorial(
         assert 'show_sidebar_tutorial' not in preferences
 
 
+def test_profile_userid_unauthenticated(unauthenticated_request):
+    assert session.profile(unauthenticated_request)['userid'] is None
+
+
+def test_profile_userid_authenticated(authenticated_request):
+    profile = session.profile(authenticated_request)
+    assert profile['userid'] == u'acct:user@example.com'
+
+
 @pytest.fixture
 def fake_user():
     fake_user = mock.Mock()
     fake_user.groups = []
     return fake_user
+
+
+@pytest.fixture
+def unauthenticated_request():
+    return mock.Mock(authenticated_userid=None, authenticated_user=None)
+
+
+@pytest.fixture
+def authenticated_request(fake_user):
+    return mock.Mock(authenticated_userid=u'acct:user@example.com',
+                     authenticated_user=fake_user)

--- a/tests/h/views/api_profile_test.py
+++ b/tests/h/views/api_profile_test.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import pytest
+
+from h.views import api_profile
+
+
+def test_profile_view_proxies_to_session(session_profile, pyramid_request):
+    session_profile.return_value = {'foo': 'bar'}
+    result = api_profile.profile(pyramid_request)
+    assert result == {'foo': 'bar'}
+
+
+@pytest.fixture
+def session_profile(patch):
+    return patch('h.session.profile')


### PR DESCRIPTION
This is a first step towards hypothesis/product-backlog#119 – so far it only replicates the existing behaviour of the `/app` endpoint for logged-in users (minus the CSRF token), but the next steps are to:

* Get this working for third-party users, once I’ve got a better understanding of how third-party groups work (including whether there’s an equivalent to the `__world__` group).
* Add an `authority` parameter so we can show first– and third-party groups
* Get it working for anonymous users and remove the auth requirement from the view decorator

At this stage, I’m mostly looking for guidance on whether I’m following our team conventions, whether I seem to be heading in a sensible direction, whether I’m likely to head down any nasty rabbit holes, or whether there are any handy tricks I seem to have missed. I’m intending to smush a load of the commits around before merging, to get rid of some of my stream-of-consciousness commit messages while leaving enough context for future developers (who may or may not be me).