### PR TITLE
Run nginx and all (most) processes in container

### DIFF
--- a/bin/logger
+++ b/bin/logger
@@ -1,0 +1,109 @@
+#!/usr/bin/env python
+
+"""
+logger is a supervisord event listener program.
+
+It aggregates the output of multiple programs running in supervisor and
+reprints their output with the addition of a honcho-like prefix. This prefix
+helps to distinguish the output of different programs.
+
+Here's an example supervisor configuration file that uses logger:
+
+    [supervisord]
+    nodaemon=true
+    environment=PYTHONUNBUFFERED="1"
+    logfile=/dev/null
+    logfile_maxbytes=0
+
+    [program:web]
+    command=gunicorn myproject:app
+    stdout_logfile=NONE
+    stderr_logfile=NONE
+    stdout_events_enabled=true
+    stderr_events_enabled=true
+
+    [program:worker]
+    command=celery -A myproject worker -l info
+    stdout_logfile=NONE
+    stderr_logfile=NONE
+    stdout_events_enabled=true
+    stderr_events_enabled=true
+
+    [eventlistener:logger]
+    command=logger
+    buffer_size=100
+    events=PROCESS_LOG
+    stderr_logfile=/dev/fd/1
+    stderr_logfile_maxbytes=0
+
+And here's an example of the output you might see from supervisord:
+
+    2017-01-24 17:25:02,903 INFO supervisord started with pid 15433
+    2017-01-24 17:25:03,907 INFO spawned: 'logger' with pid 15439
+    2017-01-24 17:25:03,910 INFO spawned: 'web' with pid 15440
+    2017-01-24 17:25:03,913 INFO spawned: 'worker' with pid 15441
+    2017-01-24 17:25:05,216 INFO success: logger entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
+    2017-01-24 17:25:05,217 INFO success: web entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
+    2017-01-24 17:25:05,217 INFO success: worker entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
+    web (stderr)         | 2017-01-24 17:25:04,203 [15440] [gunicorn.error:INFO] Starting gunicorn 19.6.0
+    web (stderr)         | 2017-01-24 17:25:04,205 [15440] [gunicorn.error:INFO] Listening at: http://127.0.0.1:5000 (15440)
+    web (stderr)         | 2017-01-24 17:25:04,206 [15440] [gunicorn.error:INFO] Using worker: sync
+    web (stderr)         | 2017-01-24 17:25:04,211 [15449] [gunicorn.error:INFO] Booting worker with pid: 15449
+    worker               |
+    worker               |  -------------- celery@mahler.local v3.1.25 (Cipater)
+    worker               | ---- **** -----
+    worker               | --- * ***  * -- Darwin-16.3.0-x86_64-i386-64bit
+    ...
+
+Note that in the configuration above we disable the logfiles for the
+individual programs and for the supervisor daemon itself. This isn't required
+but may be useful in containerised environments.
+
+By setting "stderr_logfile=/dev/fd/1" in the [eventlistener:logger] section,
+we redirect the aggregated output back to STDOUT (FD 1). You can also log the
+aggregated output to a single file.
+"""
+
+import sys
+
+WIDTH = 20
+
+
+def main():
+    while True:
+        _write('READY\n')
+        header = _parse_header(sys.stdin.readline())
+        payload = sys.stdin.read(int(header['len']))
+
+        # Only handle PROCESS_LOG_* events and just ACK anything else.
+        if header['eventname'] == 'PROCESS_LOG_STDOUT':
+            _log_payload(payload)
+        elif header['eventname'] == 'PROCESS_LOG_STDERR':
+            _log_payload(payload, err=True)
+
+        _write('RESULT 2\nOK')
+
+
+def _write(s):
+    sys.stdout.write(s)
+    sys.stdout.flush()
+
+
+def _parse_header(data):
+    return dict([x.split(':') for x in data.split()])
+
+
+def _log_payload(payload, err=False):
+    headerdata, data = payload.split('\n', 1)
+    header = _parse_header(headerdata)
+    name = header['processname']
+    if err:
+        name += ' (stderr)'
+    prefix = '{name:{width}} | '.format(name=name, width=WIDTH)
+    for line in data.splitlines():
+        sys.stderr.write(prefix + line + '\n')
+    sys.stderr.flush()
+
+
+if __name__ == '__main__':
+    main()

--- a/bin/start-nginx
+++ b/bin/start-nginx
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+: ${FALLBACK_UPSTREAM:=}
+
+set -eu
+
+CONF_TEMPLATE=/etc/nginx/nginx.conf.tpl
+CONF_DEST=/etc/nginx/nginx.conf
+
+if [ -n "$FALLBACK_UPSTREAM" ]; then
+    FALLBACK_TEXT="proxy_set_header Host \$host; proxy_pass $FALLBACK_UPSTREAM;"
+    sed -e '/# FALLBACK-START/,/# FALLBACK-END/c\'"$FALLBACK_TEXT" "$CONF_TEMPLATE"
+else
+    cat "$CONF_TEMPLATE"
+fi >"$CONF_DEST"
+
+exec nginx

--- a/conf/nginx.conf.tpl
+++ b/conf/nginx.conf.tpl
@@ -1,0 +1,87 @@
+daemon off;
+worker_processes auto;
+pid /var/lib/hypothesis/nginx.pid;
+error_log /dev/stderr;
+
+events {
+  worker_connections 4096;
+}
+
+http {
+  client_max_body_size 20m;
+  sendfile on;
+  server_tokens off;
+
+  include mime.types;
+  default_type application/octet-stream;
+
+  access_log off;
+
+  # We set fail_timeout=0 so that the upstream isn't marked as down if a single
+  # request fails (e.g. if gunicorn kills a worker for taking too long to handle
+  # a single request).
+  upstream web { server unix:/tmp/gunicorn-web.sock fail_timeout=0; }
+  upstream websocket { server unix:/tmp/gunicorn-websocket.sock fail_timeout=0; }
+
+  server {
+    listen 5000;
+
+    server_name _;
+    server_tokens off;
+
+    root /var/www;
+
+    rewrite ^/index\.html$ / permanent;
+    rewrite ^/app/embed.js /embed.js;
+    rewrite ^/minutes/(\d+)/(.*) https://hypothesis-meeting-logs.s3.amazonaws.com/$1/$2 redirect;
+    rewrite ^/minutes/(.*) https://shrub.appspot.com/hypothesis-meeting-logs/$1 redirect;
+
+    location = /xmlrpc.php {
+      return 499;
+    }
+
+    location ~ ^/(|a|u|t|account|admin|api|app|app.html|assets|docs/help|embed\.js.*|forgot-password|login|logout|activate|groups|notification|robots\.txt|search|signup|stream|stream\.atom|stream\.rss|users|viewer|welcome)(/|$) {
+      proxy_pass http://web;
+      proxy_http_version 1.1;
+      proxy_connect_timeout 10s;
+      proxy_send_timeout 10s;
+      proxy_read_timeout 10s;
+      proxy_redirect off;
+      proxy_set_header Host $host;
+      proxy_set_header X-Forwarded-Server $http_host;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Request-Start "t=${msec}";
+    }
+
+    location /ws {
+      proxy_pass http://websocket;
+      proxy_http_version 1.1;
+      proxy_redirect off;
+      proxy_buffering off;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection upgrade;
+      proxy_set_header Host $host;
+      proxy_set_header X-Forwarded-Server $http_host;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
+    location /annotating-all-knowledge/ {
+      proxy_pass https://hypothesis.github.io;
+      proxy_http_version 1.1;
+      proxy_set_header Host $proxy_host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
+    location /roadmap {
+      return 302 "https://trello.com/b/2ajZ2dWe/public-roadmap";
+    }
+
+    location / {
+      # FALLBACK-START
+      add_header Content-Type "text/plain; charset=UTF-8";
+      return 200 "This URL path would fall through to WordPress in production.";
+      # FALLBACK-END
+    }
+  }
+}

--- a/conf/supervisord.conf
+++ b/conf/supervisord.conf
@@ -1,0 +1,41 @@
+[supervisord]
+nodaemon=true
+environment=PYTHONUNBUFFERED="1"
+logfile=/dev/null
+logfile_maxbytes=0
+
+[program:nginx]
+command=start-nginx
+stdout_logfile=NONE
+stderr_logfile=NONE
+stdout_events_enabled=true
+stderr_events_enabled=true
+
+[program:web]
+command=newrelic-admin run-program gunicorn --paste conf/app.ini -b unix:/tmp/gunicorn-web.sock
+stdout_logfile=NONE
+stderr_logfile=NONE
+stdout_events_enabled=true
+stderr_events_enabled=true
+
+[program:websocket]
+command=gunicorn --paste conf/websocket.ini --worker-connections 4096 -b unix:/tmp/gunicorn-websocket.sock
+environment=GUNICORN_STATS_DISABLE="1"
+stdout_logfile=NONE
+stderr_logfile=NONE
+stdout_events_enabled=true
+stderr_events_enabled=true
+
+[program:worker]
+command=newrelic-admin run-program hypothesis celery worker
+stdout_logfile=NONE
+stderr_logfile=NONE
+stdout_events_enabled=true
+stderr_events_enabled=true
+
+[eventlistener:logger]
+command=logger
+buffer_size=100
+events=PROCESS_LOG
+stderr_logfile=/dev/fd/1
+stderr_logfile_maxbytes=0


### PR DESCRIPTION
The easiest way for us to migrate to Skyliner involves us having a single deployable artifact built from this repository which spins up everything we need to run the application.

This commit does two important things:

1. Adds nginx (and an nginx configuration) to the Docker image, allowing us to run both web server and websocket server on a single port.

2. Installs [supervisord][1] to manage the various processes which must run concurrently and sets up supervisor to be the default command for the image.

There are a couple of additional conveniences added, namely:

- A helper script called `logprefix` which emulates the line-prefixing behaviour of honcho so that it's easy to tell which log line comes from which subprocess.

- A helper script called `start-nginx` which is responsible for replacing the fallback upstream if the `FALLBACK_UPSTREAM` environment variable is set. This will be used to forward appropriate requests to WordPress for the time being, and we hope will be removable in due course.

Observations and caveats:

- This commit shouldn't prevent us from continuing to deploy as we currently do, with the one caveat that we'll need to explicitly set the command for the `web` container.

- Setting the WEB_CONCURRENCY environment variable for the container will currently adjust the number of workers started for *both* the web application and the websocket server. This may result in unintended behaviour.

- We don't currently run a Celery beat process in the container. This will need to be managed separately for the time being.

- These changes add only about ~5MB to the image size.

[1]: http://supervisord.org/