### PR TITLE
Fix "hypothesis init" command

### DIFF
--- a/h/cli/commands/init.py
+++ b/h/cli/commands/init.py
@@ -6,6 +6,7 @@ import click
 import sqlalchemy
 
 from h import db
+from h import models  # noqa: import to ensure memex model base class is set
 from memex import search
 
 log = logging.getLogger(__name__)


### PR DESCRIPTION
This wasn't creating the tables managed by `memex`, because by importing `memex.search` before running the application bootstrap, we were accidentally importing the memex models before the code in `h.db` (which overrides the model base class) could run.