### PR TITLE
Add refresh tokens to api tokens

### DIFF
--- a/h/models/token.py
+++ b/h/models/token.py
@@ -9,6 +9,7 @@ import os
 import sqlalchemy
 from sqlalchemy.dialects import postgresql
 
+from h import security
 from h.auth.interfaces import IAuthenticationToken
 from h.db import Base
 from h.db import mixins
@@ -60,7 +61,7 @@ class Token(Base, mixins.Timestamps):
         self.regenerate()
 
         if expires:
-            self.refresh_token = _token()
+            self.refresh_token = security.token_urlsafe()
 
     @classmethod
     def get_dev_token_by_userid(cls, session, userid):

--- a/h/models/token.py
+++ b/h/models/token.py
@@ -24,9 +24,6 @@ class Token(Base, mixins.Timestamps):
     #: to, for example, one of the short-lived JWTs that the client uses).
     prefix = u'6879-'
 
-    #: A prefix that identifies a token as a refresh token.
-    refresh_token_prefix = u'7980-'
-
     id = sqlalchemy.Column(sqlalchemy.Integer,
                            autoincrement=True,
                            primary_key=True)
@@ -63,7 +60,7 @@ class Token(Base, mixins.Timestamps):
         self.regenerate()
 
         if expires:
-            self.refresh_token = self.refresh_token_prefix + _token()
+            self.refresh_token = _token()
 
     @classmethod
     def get_dev_token_by_userid(cls, session, userid):

--- a/h/models/token.py
+++ b/h/models/token.py
@@ -56,11 +56,11 @@ class Token(Base, mixins.Timestamps):
     #: A NULL value means it is a developer token.
     authclient = sqlalchemy.orm.relationship('AuthClient')
 
-    def __init__(self, expires=None, **kwargs):
-        super(Token, self).__init__(expires=expires, **kwargs)
+    def __init__(self, **kwargs):
+        super(Token, self).__init__(**kwargs)
         self.regenerate()
 
-        if expires:
+        if self.expires:
             self.refresh_token = security.token_urlsafe()
 
     @classmethod

--- a/h/models/token.py
+++ b/h/models/token.py
@@ -24,6 +24,9 @@ class Token(Base, mixins.Timestamps):
     #: to, for example, one of the short-lived JWTs that the client uses).
     prefix = u'6879-'
 
+    #: A prefix that identifies a token as a refresh token.
+    refresh_token_prefix = u'7980-'
+
     id = sqlalchemy.Column(sqlalchemy.Integer,
                            autoincrement=True,
                            primary_key=True)
@@ -39,6 +42,13 @@ class Token(Base, mixins.Timestamps):
     #: A NULL value in this column indicates a token that does not expire.
     expires = sqlalchemy.Column(sqlalchemy.DateTime, nullable=True)
 
+    #: A refresh token that can be exchanged for a new token (with a new value
+    #: and expiry time). A NULL value in this column indicates a token that
+    #: cannot be refreshed.
+    refresh_token = sqlalchemy.Column(sqlalchemy.UnicodeText(),
+                                      unique=True,
+                                      nullable=True)
+
     _authclient_id = sqlalchemy.Column('authclient_id',
                                        postgresql.UUID(),
                                        sqlalchemy.ForeignKey('authclient.id', ondelete='cascade'),
@@ -48,9 +58,12 @@ class Token(Base, mixins.Timestamps):
     #: A NULL value means it is a developer token.
     authclient = sqlalchemy.orm.relationship('AuthClient')
 
-    def __init__(self, **kwargs):
-        super(Token, self).__init__(**kwargs)
+    def __init__(self, expires=None, **kwargs):
+        super(Token, self).__init__(expires=expires, **kwargs)
         self.regenerate()
+
+        if expires:
+            self.refresh_token = self.refresh_token_prefix + _token()
 
     @classmethod
     def get_dev_token_by_userid(cls, session, userid):

--- a/tests/h/models/token_test.py
+++ b/tests/h/models/token_test.py
@@ -35,7 +35,6 @@ class TestToken(object):
         assert access_token.expires == expires
         assert access_token.authclient == authclient
         assert access_token.refresh_token
-        assert access_token.refresh_token.startswith("7980-")
 
     def test_get_dev_token_by_userid_filters_by_userid(self, db_session, factories):
         token_1 = factories.Token(userid='acct:vanessa@example.org', authclient=None)

--- a/tests/h/models/token_test.py
+++ b/tests/h/models/token_test.py
@@ -18,6 +18,7 @@ class TestToken(object):
         assert dev_token.value.startswith("6879-")
         assert not dev_token.expires
         assert not dev_token.authclient
+        assert not dev_token.refresh_token
 
     def test_init_access_token(self):
         userid = 'acct:test@hypothes.is'
@@ -33,6 +34,8 @@ class TestToken(object):
         assert access_token.value.startswith("6879-")
         assert access_token.expires == expires
         assert access_token.authclient == authclient
+        assert access_token.refresh_token
+        assert access_token.refresh_token.startswith("7980-")
 
     def test_get_dev_token_by_userid_filters_by_userid(self, db_session, factories):
         token_1 = factories.Token(userid='acct:vanessa@example.org', authclient=None)

--- a/tests/h/models/token_test.py
+++ b/tests/h/models/token_test.py
@@ -2,12 +2,37 @@
 
 from __future__ import unicode_literals
 
+import datetime
+
 from h.models import Token
 
 
 class TestToken(object):
-    def test_init_generates_value(self):
-        assert Token().value
+    def test_init_dev_token(self):
+        userid = 'acct:test@hypothes.is'
+
+        dev_token = Token(userid=userid)
+
+        assert dev_token.userid == userid
+        assert dev_token.value
+        assert dev_token.value.startswith("6879-")
+        assert not dev_token.expires
+        assert not dev_token.authclient
+
+    def test_init_access_token(self):
+        userid = 'acct:test@hypothes.is'
+        expires = one_hour_from_now()
+        authclient = 'example.com'
+
+        access_token = Token(userid=userid,
+                             expires=expires,
+                             authclient=authclient)
+
+        assert access_token.userid == userid
+        assert access_token.value
+        assert access_token.value.startswith("6879-")
+        assert access_token.expires == expires
+        assert access_token.authclient == authclient
 
     def test_get_dev_token_by_userid_filters_by_userid(self, db_session, factories):
         token_1 = factories.Token(userid='acct:vanessa@example.org', authclient=None)
@@ -25,3 +50,7 @@ class TestToken(object):
         token = factories.Token(authclient=factories.AuthClient())
 
         assert Token.get_dev_token_by_userid(db_session, token.userid) is None
+
+
+def one_hour_from_now():
+    return datetime.datetime.now() + datetime.timedelta(hours=1)


### PR DESCRIPTION
Adds `refresh_token` to the `Token` model and ensures that *if* an `expires` time is given when creating a token then a `refresh_token` is also generated for it.

This is marked WIP because I need to write a db migration pr that will need to be merged before this one.