### PR TITLE
Remove check for CSRF token in `GET /api/token` endpoint

### DIFF
--- a/h/views/client.py
+++ b/h/views/client.py
@@ -48,15 +48,8 @@ def annotator_token(request):
 
     The token can be used in the Authorization header in subsequent requests to
     the API to authenticate the user identified by the
-    request.authenticated_userid of the _current_ request.
+    request.authenticated_userid of the _current_ request, which may be None.
     """
-    try:
-        # The client must supply the CSRF token in the X-CSRF-Token request
-        # header.
-        session.check_csrf_token(request)
-    except exceptions.BadCSRFToken:
-        raise httpexceptions.HTTPUnauthorized()
-
     return generate_jwt(request, 3600)
 
 

--- a/h/views/client.py
+++ b/h/views/client.py
@@ -8,9 +8,6 @@ Views which exist either to serve or support the JavaScript annotation client.
 
 from __future__ import unicode_literals
 
-from pyramid import exceptions
-from pyramid import httpexceptions
-from pyramid import session
 from pyramid.view import view_config
 
 from h import client

--- a/tests/h/views/client_test.py
+++ b/tests/h/views/client_test.py
@@ -3,22 +3,16 @@
 from __future__ import unicode_literals
 
 import pytest
-from pyramid import exceptions
-from pyramid import httpexceptions
 
 from h.views import client
 
-annotator_token_fixtures = pytest.mark.usefixtures('generate_jwt', 'session')
 
-
-@annotator_token_fixtures
 def test_annotator_token_calls_generate_jwt(generate_jwt, pyramid_request):
     client.annotator_token(pyramid_request)
 
     generate_jwt.assert_called_once_with(pyramid_request, 3600)
 
 
-@annotator_token_fixtures
 def test_annotator_token_returns_token(generate_jwt, pyramid_request):
     result = client.annotator_token(pyramid_request)
 
@@ -30,8 +24,3 @@ def generate_jwt(patch):
     func = patch('h.views.client.generate_jwt')
     func.return_value = 'abc123'
     return func
-
-
-@pytest.fixture
-def session(patch):
-    return patch('h.views.client.session')

--- a/tests/h/views/client_test.py
+++ b/tests/h/views/client_test.py
@@ -12,23 +12,6 @@ annotator_token_fixtures = pytest.mark.usefixtures('generate_jwt', 'session')
 
 
 @annotator_token_fixtures
-def test_annotator_token_calls_check_csrf_token(pyramid_request, session):
-    client.annotator_token(pyramid_request)
-
-    session.check_csrf_token.assert_called_once_with(pyramid_request)
-
-
-@annotator_token_fixtures
-def test_annotator_token_raises_Unauthorized_if_check_csrf_token_raises(
-        pyramid_request,
-        session):
-    session.check_csrf_token.side_effect = exceptions.BadCSRFToken
-
-    with pytest.raises(httpexceptions.HTTPUnauthorized):
-        client.annotator_token(pyramid_request)
-
-
-@annotator_token_fixtures
 def test_annotator_token_calls_generate_jwt(generate_jwt, pyramid_request):
     client.annotator_token(pyramid_request)
 


### PR DESCRIPTION
Since this endpoint does not modify any data and does not support CORS, there is no need to check the CSRF token that I can see.

Removing the CSRF check eliminates the need for the client to fetch the session state (in a separate API call) before it fetches an API token during the initial load. Removing this dependency will make implementing 3rd party authentication in the client simpler, until we can remove the legacy cookie-based auth.

I presume the CSRF check is there because historically (before 5b46ddc9000fcf4038ab27b4cde1dba22037dfe9) this endpoint used to support POST as well, so could have modified user data in theory.

I have tested this with a client (embed and Chrome extension) modified to stop sending the CSRF token.

Before I made this change, I hadn't realized that the `GET /api/token` endpoint returns a valid token even for unauthenticated users and the client relies on that behavior.