### PR TITLE
Make userid mandatory

### DIFF
--- a/h/models/token.py
+++ b/h/models/token.py
@@ -24,6 +24,9 @@ class Token(Base, mixins.Timestamps):
     #: to, for example, one of the short-lived JWTs that the client uses).
     prefix = u'6879-'
 
+    #: A prefix that identifies a token as a refresh token.
+    refresh_token_prefix = u'7980-'
+
     id = sqlalchemy.Column(sqlalchemy.Integer,
                            autoincrement=True,
                            primary_key=True)
@@ -39,6 +42,13 @@ class Token(Base, mixins.Timestamps):
     #: A NULL value in this column indicates a token that does not expire.
     expires = sqlalchemy.Column(sqlalchemy.DateTime, nullable=True)
 
+    #: A refresh token that can be exchanged for a new token (with a new value
+    #: and expiry time). A NULL value in this column indicates a token that
+    #: cannot be refreshed.
+    refresh_token = sqlalchemy.Column(sqlalchemy.UnicodeText(),
+                                      unique=True,
+                                      nullable=True)
+
     _authclient_id = sqlalchemy.Column('authclient_id',
                                        postgresql.UUID(),
                                        sqlalchemy.ForeignKey('authclient.id', ondelete='cascade'),
@@ -48,9 +58,12 @@ class Token(Base, mixins.Timestamps):
     #: A NULL value means it is a developer token.
     authclient = sqlalchemy.orm.relationship('AuthClient')
 
-    def __init__(self, **kwargs):
-        super(Token, self).__init__(**kwargs)
+    def __init__(self, expires=None, **kwargs):
+        super(Token, self).__init__(expires=expires, **kwargs)
         self.regenerate()
+
+        if expires:
+            self.refresh_token = self.refresh_token_prefix + _token()
 
     @classmethod
     def get_dev_token_by_userid(cls, session, userid):

--- a/h/models/token.py
+++ b/h/models/token.py
@@ -58,8 +58,8 @@ class Token(Base, mixins.Timestamps):
     #: A NULL value means it is a developer token.
     authclient = sqlalchemy.orm.relationship('AuthClient')
 
-    def __init__(self, expires=None, **kwargs):
-        super(Token, self).__init__(expires=expires, **kwargs)
+    def __init__(self, userid, expires=None, **kwargs):
+        super(Token, self).__init__(userid=userid, expires=expires, **kwargs)
         self.regenerate()
 
         if expires:

--- a/h/services/oauth.py
+++ b/h/services/oauth.py
@@ -101,7 +101,7 @@ class OAuthService(object):
 
         :rtype: h.models.Token
         """
-        token = models.Token(userid=user.userid,
+        token = models.Token(user.userid,
                              expires=(utcnow() + TOKEN_TTL),
                              authclient=authclient)
         self.session.add(token)

--- a/h/views/accounts.py
+++ b/h/views/accounts.py
@@ -666,7 +666,7 @@ class DeveloperController(object):
             token.regenerate()
         else:
             # The user doesn't have an API token yet, generate one for them.
-            token = models.Token(userid=self.request.authenticated_userid)
+            token = models.Token(self.request.authenticated_userid)
             self.request.db.add(token)
 
         return {'token': token.value}

--- a/tests/h/models/token_test.py
+++ b/tests/h/models/token_test.py
@@ -11,7 +11,7 @@ class TestToken(object):
     def test_init_dev_token(self):
         userid = 'acct:test@hypothes.is'
 
-        dev_token = Token(userid=userid)
+        dev_token = Token(userid)
 
         assert dev_token.userid == userid
         assert dev_token.value
@@ -25,7 +25,7 @@ class TestToken(object):
         expires = one_hour_from_now()
         authclient = 'example.com'
 
-        access_token = Token(userid=userid,
+        access_token = Token(userid,
                              expires=expires,
                              authclient=authclient)
 

--- a/tests/h/models/token_test.py
+++ b/tests/h/models/token_test.py
@@ -18,6 +18,7 @@ class TestToken(object):
         assert dev_token.value.startswith("6879-")
         assert not dev_token.expires
         assert not dev_token.authclient
+        assert not dev_token.refresh_token
 
     def test_init_access_token(self):
         userid = 'acct:test@hypothes.is'
@@ -33,6 +34,8 @@ class TestToken(object):
         assert access_token.value.startswith("6879-")
         assert access_token.expires == expires
         assert access_token.authclient == authclient
+        assert access_token.refresh_token
+        assert access_token.refresh_token.startswith("7980-")
 
     def test_get_dev_token_by_userid_filters_by_userid(self, db_session, factories):
         token_1 = factories.Token(userid='acct:vanessa@example.org', authclient=None)

--- a/tests/h/models/token_test.py
+++ b/tests/h/models/token_test.py
@@ -2,12 +2,37 @@
 
 from __future__ import unicode_literals
 
+import datetime
+
 from h.models import Token
 
 
 class TestToken(object):
-    def test_init_generates_value(self):
-        assert Token().value
+    def test_init_dev_token(self):
+        userid = 'acct:test@hypothes.is'
+
+        dev_token = Token(userid=userid)
+
+        assert dev_token.userid == userid
+        assert dev_token.value
+        assert dev_token.value.startswith("6879-")
+        assert not dev_token.expires
+        assert not dev_token.authclient
+
+    def test_init_access_token(self):
+        userid = 'acct:test@hypothes.is'
+        expires = one_hour_from_now()
+        authclient = 'example.com'
+
+        access_token = Token(userid=userid,
+                             expires=expires,
+                             authclient=authclient)
+
+        assert access_token.userid == userid
+        assert access_token.value
+        assert access_token.value.startswith("6879-")
+        assert access_token.expires == expires
+        assert access_token.authclient == authclient
 
     def test_get_dev_token_by_userid_filters_by_userid(self, db_session, factories):
         token_1 = factories.Token(userid='acct:vanessa@example.org', authclient=None)
@@ -25,3 +50,7 @@ class TestToken(object):
         token = factories.Token(authclient=factories.AuthClient())
 
         assert Token.get_dev_token_by_userid(db_session, token.userid) is None
+
+
+def one_hour_from_now():
+    return datetime.datetime.now() + datetime.timedelta(hours=1)

--- a/tests/h/views/api_auth_test.py
+++ b/tests/h/views/api_auth_test.py
@@ -30,7 +30,7 @@ class TestAccessToken(object):
             mock.sentinel.user, mock.sentinel.authclient)
 
     def test_it_returns_an_oauth_compliant_response(self, pyramid_request, oauth_service):
-        token = models.Token()
+        token = models.Token('acct:test@hypothes.is')
         oauth_service.create_token.return_value = token
 
         assert views.access_token(pyramid_request) == {


### PR DESCRIPTION
Depends on https://github.com/hypothesis/h/pull/4321

You can't create a Token without a userid (you can create the Python
object fine, but if you add it to a db session and then try to flush or
commit that session you will get an IntegrityError - userid is not
nullable in the database).

Make the userid arg a positional arg on the Token class so that its
mandatoriness is explicit and so that you can't create an invalid ORM
object.