### PR TITLE
Use token_urlsafe() to generate API tokens

### DIFF
--- a/h/models/token.py
+++ b/h/models/token.py
@@ -71,9 +71,4 @@ class Token(Base, mixins.Timestamps):
                 .first())
 
     def regenerate(self):
-        self.value = self.prefix + _token()
-
-
-def _token():
-    """Return a random string suitable for use in an API token."""
-    return binascii.hexlify(os.urandom(16))
+        self.value = self.prefix + security.token_urlsafe()

--- a/tests/h/models/token_test.py
+++ b/tests/h/models/token_test.py
@@ -4,23 +4,26 @@ from __future__ import unicode_literals
 
 import datetime
 
+import pytest
+
 from h.models import Token
 
 
+@pytest.mark.usefixtures('security')
 class TestToken(object):
-    def test_init_dev_token(self):
+    def test_init_dev_token(self, security):
         userid = 'acct:test@hypothes.is'
 
         dev_token = Token(userid=userid)
 
         assert dev_token.userid == userid
-        assert dev_token.value
-        assert dev_token.value.startswith("6879-")
+        assert dev_token.value.startswith(Token.prefix)
+        assert dev_token.value[len(Token.prefix):] in security.token_urlsafe.side_effect.generated_tokens
         assert not dev_token.expires
         assert not dev_token.authclient
         assert not dev_token.refresh_token
 
-    def test_init_access_token(self):
+    def test_init_access_token(self, security):
         userid = 'acct:test@hypothes.is'
         expires = one_hour_from_now()
         authclient = 'example.com'
@@ -30,11 +33,11 @@ class TestToken(object):
                              authclient=authclient)
 
         assert access_token.userid == userid
-        assert access_token.value
-        assert access_token.value.startswith("6879-")
+        assert access_token.value.startswith(Token.prefix)
+        assert access_token.value[len(Token.prefix):] in security.token_urlsafe.side_effect.generated_tokens
         assert access_token.expires == expires
         assert access_token.authclient == authclient
-        assert access_token.refresh_token
+        assert access_token.refresh_token in security.token_urlsafe.side_effect.generated_tokens
 
     def test_get_dev_token_by_userid_filters_by_userid(self, db_session, factories):
         token_1 = factories.Token(userid='acct:vanessa@example.org', authclient=None)
@@ -52,6 +55,25 @@ class TestToken(object):
         token = factories.Token(authclient=factories.AuthClient())
 
         assert Token.get_dev_token_by_userid(db_session, token.userid) is None
+
+    @pytest.fixture
+    def security(self, patch):
+        security = patch('h.models.token.security')
+
+        class TestTokenGenerator(object):
+            """Return "TOKEN_1", then "TOKEN_2" and so on."""
+
+            def __init__(self):
+                self.i = 1
+                self.generated_tokens = []
+
+            def __call__(self):
+                self.generated_tokens.append("TOKEN_" + str(self.i))
+                self.i += 1
+                return self.generated_tokens[-1]
+
+        security.token_urlsafe.side_effect = TestTokenGenerator()
+        return security
 
 
 def one_hour_from_now():


### PR DESCRIPTION
Use h.security.token_urlsafe() to generate access and dev API tokens, as
we already do for refresh tokens.