### PR TITLE
Return refresh tokens along with access tokens

### DIFF
--- a/h/views/api_auth.py
+++ b/h/views/api_auth.py
@@ -16,11 +16,16 @@ def access_token(request):
         grant_type=request.POST.get('grant_type'))
     token = svc.create_token(user, authclient)
 
-    return {
+    response = {
         'access_token': token.value,
         'token_type': 'bearer',
         'expires_in': TOKEN_TTL.total_seconds(),
     }
+
+    if token.refresh_token:
+        response['refresh_token'] = token.refresh_token
+
+    return response
 
 
 @cors_json_view(context=OAuthTokenError)

--- a/tests/h/views/api_auth_test.py
+++ b/tests/h/views/api_auth_test.py
@@ -28,35 +28,32 @@ class TestAccessToken(object):
         oauth_service.create_token.assert_called_once_with(
             mock.sentinel.user, mock.sentinel.authclient)
 
-    def test_it_returns_an_oauth_compliant_response(self, factories, pyramid_request, oauth_service):
-        token = factories.Token()
-        oauth_service.create_token.return_value = token
-
+    def test_it_returns_an_oauth_compliant_response(self, pyramid_request, token):
         response = views.access_token(pyramid_request)
 
         assert response['access_token'] == token.value
         assert response['token_type'] == 'bearer'
         assert response['expires_in'] == TOKEN_TTL.total_seconds()
 
-    def test_it_returns_the_refresh_token_if_the_token_has_one(self, factories, pyramid_request, oauth_service):
-        token = factories.Token()
-        refresh_token = token.refresh_token = 'test_refresh_token'
-        oauth_service.create_token.return_value = token
+    def test_it_returns_the_refresh_token_if_the_token_has_one(self, pyramid_request, token):
+        token.refresh_token = 'test_refresh_token'
 
-        assert views.access_token(pyramid_request)['refresh_token'] == refresh_token
+        assert views.access_token(pyramid_request)['refresh_token'] == token.refresh_token
 
-    def test_it_does_not_returns_the_refresh_token_if_the_token_does_not_have_one(self, factories, pyramid_request, oauth_service):
-        token = factories.Token()
-        oauth_service.create_token.return_value = token
-
+    def test_it_does_not_returns_the_refresh_token_if_the_token_does_not_have_one(self, pyramid_request):
         assert 'refresh_token' not in views.access_token(pyramid_request)
 
     @pytest.fixture
-    def oauth_service(self, pyramid_config, pyramid_request):
+    def oauth_service(self, pyramid_config, pyramid_request, token):
         svc = mock.Mock(spec_set=oauth_service_factory(None, pyramid_request))
         svc.verify_jwt_bearer.return_value = (mock.sentinel.user, mock.sentinel.authclient)
+        svc.create_token.return_value = token
         pyramid_config.register_service(svc, name='oauth')
         return svc
+
+    @pytest.fixture
+    def token(self, factories):
+        return factories.Token()
 
     @pytest.fixture
     def user_service(self, pyramid_config, pyramid_request):

--- a/tests/h/views/api_auth_test.py
+++ b/tests/h/views/api_auth_test.py
@@ -33,11 +33,11 @@ class TestAccessToken(object):
         token = models.Token()
         oauth_service.create_token.return_value = token
 
-        assert views.access_token(pyramid_request) == {
-            'access_token': token.value,
-            'token_type': 'bearer',
-            'expires_in': TOKEN_TTL.total_seconds(),
-        }
+        response = views.access_token(pyramid_request)
+
+        assert response['access_token'] == token.value
+        assert response['token_type'] == 'bearer'
+        assert response['expires_in'] == TOKEN_TTL.total_seconds()
 
     def test_it_returns_the_refresh_token_if_the_token_has_one(self, pyramid_request, oauth_service):
         token = models.Token()

--- a/tests/h/views/api_auth_test.py
+++ b/tests/h/views/api_auth_test.py
@@ -39,6 +39,19 @@ class TestAccessToken(object):
             'expires_in': TOKEN_TTL.total_seconds(),
         }
 
+    def test_it_returns_the_refresh_token_if_the_token_has_one(self, pyramid_request, oauth_service):
+        token = models.Token()
+        refresh_token = token.refresh_token = 'test_refresh_token'
+        oauth_service.create_token.return_value = token
+
+        assert views.access_token(pyramid_request)['refresh_token'] == refresh_token
+
+    def test_it_does_not_returns_the_refresh_token_if_the_token_does_not_have_one(self, pyramid_request, oauth_service):
+        token = models.Token()
+        oauth_service.create_token.return_value = token
+
+        assert 'refresh_token' not in views.access_token(pyramid_request)
+
     @pytest.fixture
     def oauth_service(self, pyramid_config, pyramid_request):
         svc = mock.Mock(spec_set=oauth_service_factory(None, pyramid_request))

--- a/tests/h/views/api_auth_test.py
+++ b/tests/h/views/api_auth_test.py
@@ -5,7 +5,6 @@ from __future__ import unicode_literals
 import mock
 import pytest
 
-from h import models
 from h.services.oauth import oauth_service_factory, TOKEN_TTL
 from h.services.user import user_service_factory
 from h.exceptions import OAuthTokenError
@@ -29,8 +28,8 @@ class TestAccessToken(object):
         oauth_service.create_token.assert_called_once_with(
             mock.sentinel.user, mock.sentinel.authclient)
 
-    def test_it_returns_an_oauth_compliant_response(self, pyramid_request, oauth_service):
-        token = models.Token()
+    def test_it_returns_an_oauth_compliant_response(self, factories, pyramid_request, oauth_service):
+        token = factories.Token()
         oauth_service.create_token.return_value = token
 
         response = views.access_token(pyramid_request)
@@ -39,15 +38,15 @@ class TestAccessToken(object):
         assert response['token_type'] == 'bearer'
         assert response['expires_in'] == TOKEN_TTL.total_seconds()
 
-    def test_it_returns_the_refresh_token_if_the_token_has_one(self, pyramid_request, oauth_service):
-        token = models.Token()
+    def test_it_returns_the_refresh_token_if_the_token_has_one(self, factories, pyramid_request, oauth_service):
+        token = factories.Token()
         refresh_token = token.refresh_token = 'test_refresh_token'
         oauth_service.create_token.return_value = token
 
         assert views.access_token(pyramid_request)['refresh_token'] == refresh_token
 
-    def test_it_does_not_returns_the_refresh_token_if_the_token_does_not_have_one(self, pyramid_request, oauth_service):
-        token = models.Token()
+    def test_it_does_not_returns_the_refresh_token_if_the_token_does_not_have_one(self, factories, pyramid_request, oauth_service):
+        token = factories.Token()
         oauth_service.create_token.return_value = token
 
         assert 'refresh_token' not in views.access_token(pyramid_request)


### PR DESCRIPTION
When a client asks for a short-lived API access token, also return the
access token's refresh token along with the access token itself in the
response.

This is compatible with the OAuth 2.0 access token response in RFC 6749.