### PR TITLE
Remove redundant check on `authenticated_userid`

### DIFF
--- a/h/session.py
+++ b/h/session.py
@@ -50,9 +50,6 @@ def _current_groups(request):
     groups = [
         {'name': 'Public', 'id': '__world__', 'public': True},
     ]
-    userid = request.authenticated_userid
-    if userid is None:
-        return groups
     user = request.authenticated_user
     if user is None:
         return groups


### PR DESCRIPTION
Since the changes to incorporate `authenticated_user` into the request object instead of invoking `User.get_by_userid` (see 92b85804b431), whenever `authenticated_userid` is `None`, `authenticated_user` will also be `None`, so we can remove this extra check.