### PR TITLE
Support passing tokens with HTTP Basic Auth for API and WebSocket 

### DIFF
--- a/h/auth/tokens.py
+++ b/h/auth/tokens.py
@@ -46,10 +46,9 @@ class LegacyClientJWT(object):
     Exposes the standard "auth token" interface on top of legacy tokens.
     """
 
-    def __init__(self, body, key, audience=None, leeway=240):
+    def __init__(self, body, key, leeway=240):
         self.payload = jwt.decode(body,
                                   key=key,
-                                  audience=audience,
                                   leeway=leeway,
                                   algorithms=['HS256'])
 
@@ -88,7 +87,6 @@ def generate_jwt(request, expires_in):
 
     claims = {
         'iss': request.registry.settings['h.client_id'],
-        'aud': request.host_url,
         'sub': request.authenticated_userid,
         'exp': now + datetime.timedelta(seconds=expires_in),
         'iat': now,
@@ -136,8 +134,7 @@ def auth_token(request):
 def _maybe_jwt(token, request):
     try:
         return LegacyClientJWT(token,
-                               key=request.registry.settings['h.client_secret'],
-                               audience=request.host_url)
+                               key=request.registry.settings['h.client_secret'])
     except jwt.InvalidTokenError:
         return None
 


### PR DESCRIPTION
@robertknight mentioned that the [WebSocket JavaScript API](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket) does not support passing any custom headers to the request. The way we initially thought we would authenticate websocket connections is the same way as we do API requests, with a `Authorization: Bearer {token}` header.

What does work with the WebSocket JavaScript API is passing the HTTP basic auth username and password in the URL (`wss://username:password@hypothes.is/ws`), which lead us to implement another way of authenticating requests by passing the token as the HTTP basic auth password.
Note: Some implementations (Firefox, curl) do not support an empty username, in this case the client should just send a dummy string in the username (e.g. `wss://X:{token}@hypothes.is/ws`).