### PR TITLE
Set X-Forwarded-Proto header for WordPress proxying in nginx config

### DIFF
--- a/bin/start-nginx
+++ b/bin/start-nginx
@@ -8,7 +8,7 @@ CONF_TEMPLATE=/etc/nginx/nginx.conf.tpl
 CONF_DEST=/etc/nginx/nginx.conf
 
 if [ -n "$FALLBACK_UPSTREAM" ]; then
-    FALLBACK_TEXT="proxy_set_header Host \$host; proxy_pass $FALLBACK_UPSTREAM;"
+    FALLBACK_TEXT="proxy_set_header Host \$host; proxy_set_header X-Forwarded-Proto \$scheme; proxy_pass $FALLBACK_UPSTREAM;"
     sed -e '/# FALLBACK-START/,/# FALLBACK-END/c\'"$FALLBACK_TEXT" "$CONF_TEMPLATE"
 else
     cat "$CONF_TEMPLATE"


### PR DESCRIPTION
Making the WordPress-generated URLs use the correct protocol on Skyliner we need to forward the correct protocol of the initial request here to the WordPress Skyliner application. I will probably have to do something similar with the [nginx](https://github.com/hypothesis/wordpress/blob/master/nginx.conf) configuration in our WordPress docker image.