### PR TITLE
Extend `/api/profile` to logged-in third-party users

### DIFF
--- a/h/groups/util.py
+++ b/h/groups/util.py
@@ -7,7 +7,7 @@ from pyramid import security
 
 class WorldGroup(object):
     """
-    A Group object for the __world__ group, it only implements __acl__.
+    A Group object for the __world__ group.
 
     This is so we don't have to store a __world__ group in the database.
     """
@@ -21,3 +21,15 @@ class WorldGroup(object):
             (security.Allow, 'authority:{}'.format(self.auth_domain), 'write'),
             security.DENY_ALL,
         ]
+
+    @property
+    def name(self):
+        return 'Public'
+
+    @property
+    def pubid(self):
+        return '__world__'
+
+    @property
+    def is_public(self):
+        return True

--- a/h/models/group.py
+++ b/h/models/group.py
@@ -104,6 +104,10 @@ class Group(Base, mixins.Timestamps):
         """A version of this group's name suitable for use in a URL."""
         return slugify.slugify(self.name)
 
+    @property
+    def is_public(self):
+        return self.readable_by == ReadableBy.world
+
     def documents(self, limit=25):
         """
         Return this group's most recently annotated documents.

--- a/h/services/__init__.py
+++ b/h/services/__init__.py
@@ -11,6 +11,7 @@ def includeme(config):
                                     iface='pyramid_authsanity.interfaces.IAuthService')
     config.register_service_factory('.auth_token.auth_token_service_factory', name='auth_token')
     config.register_service_factory('.group.groups_factory', name='group')
+    config.register_service_factory('.authority_group.authority_group_factory', name='authority_group')
     config.register_service_factory('.nipsa.nipsa_factory', name='nipsa')
     config.register_service_factory('.oauth.oauth_service_factory', name='oauth')
     config.register_service_factory('.rename_user.rename_user_factory', name='rename_user')

--- a/h/services/authority_group.py
+++ b/h/services/authority_group.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+
+from h import models
+from h.groups import util
+from h.models import group
+
+
+class AuthorityGroupService(object):
+
+    """A service for listing groups under a particular authority."""
+
+    def __init__(self, session, auth_domain):
+        """
+        Create a new authority group service.
+
+        :param session: the current database session
+        :param auth_domain: the authority domain for the current site
+
+        """
+        self._session = session
+        self._auth_domain = auth_domain
+
+    def public_groups(self, authority):
+        if authority == self._auth_domain:
+            return [util.WorldGroup(self._auth_domain)]
+        else:
+            return (self._session.query(models.Group)
+                    .filter_by(authority=authority,
+                               readable_by=group.ReadableBy.world)
+                    .all())
+
+
+def authority_group_factory(context, request):
+    """Return a AuthorityGroupService for the passed context and request."""
+    return AuthorityGroupService(session=request.db,
+                                 auth_domain=request.auth_domain)

--- a/h/session.py
+++ b/h/session.py
@@ -2,7 +2,6 @@
 
 from pyramid.session import SignedCookieSessionFactory
 
-from h.groups import util
 from h.security import derive_key
 
 
@@ -51,19 +50,12 @@ def _current_groups(request):
 
     user = request.authenticated_user
     authority = user.authority if user else request.auth_domain
+    authority_groups = (request.find_service(name='authority_group')
+                        .public_groups(authority=authority))
 
-    groups = (_authority_groups(request.auth_domain, authority) +
-              _user_groups(user))
+    groups = authority_groups + _user_groups(user)
 
     return [_group_model(request.route_url, group) for group in groups]
-
-
-def _authority_groups(auth_domain, authority):
-    """Return the default groups associated with an authority."""
-    if authority == auth_domain:
-        return [util.WorldGroup(auth_domain)]
-    else:
-        return []
 
 
 def _user_groups(user):

--- a/h/session.py
+++ b/h/session.py
@@ -47,10 +47,12 @@ def _current_groups(request):
     This list is meant to be returned to the client in the "session" model.
 
     """
-    groups = [
-        {'name': 'Public', 'id': '__world__', 'public': True},
-    ]
+
     user = request.authenticated_user
+    authority = user.authority if user else request.auth_domain
+
+    groups = _authority_groups(request.auth_domain, authority)
+
     if user is None:
         return groups
     for group in sorted(user.groups, key=_group_sort_key):
@@ -62,6 +64,14 @@ def _current_groups(request):
                                      slug=group.slug),
         })
     return groups
+
+
+def _authority_groups(auth_domain, authority):
+    """Return the default groups associated with an authority."""
+    if authority == auth_domain:
+        return [{'name': 'Public', 'id': '__world__', 'public': True}]
+    else:
+        return []
 
 
 def _user_preferences(user):

--- a/h/session.py
+++ b/h/session.py
@@ -2,6 +2,7 @@
 
 from pyramid.session import SignedCookieSessionFactory
 
+from h.groups import util
 from h.security import derive_key
 
 
@@ -51,17 +52,16 @@ def _current_groups(request):
     user = request.authenticated_user
     authority = user.authority if user else request.auth_domain
 
-    groups = _authority_groups(request.auth_domain, authority)
+    groups = (_authority_groups(request.auth_domain, authority) +
+              _user_groups(user))
 
-    groups.extend(_group_model(request.route_url, group)
-                  for group in _user_groups(user))
-    return groups
+    return [_group_model(request.route_url, group) for group in groups]
 
 
 def _authority_groups(auth_domain, authority):
     """Return the default groups associated with an authority."""
     if authority == auth_domain:
-        return [{'name': 'Public', 'id': '__world__', 'public': True}]
+        return [util.WorldGroup(auth_domain)]
     else:
         return []
 

--- a/h/session.py
+++ b/h/session.py
@@ -60,7 +60,7 @@ def _current_groups(request):
             'url': request.route_url('group_read',
                                      pubid=group.pubid,
                                      slug=group.slug),
-            'public': False,
+            'public': group.is_public,
         })
     return groups
 

--- a/h/session.py
+++ b/h/session.py
@@ -60,6 +60,7 @@ def _current_groups(request):
             'url': request.route_url('group_read',
                                      pubid=group.pubid,
                                      slug=group.slug),
+            'public': False,
         })
     return groups
 

--- a/h/session.py
+++ b/h/session.py
@@ -53,9 +53,7 @@ def _current_groups(request):
 
     groups = _authority_groups(request.auth_domain, authority)
 
-    if user is None:
-        return groups
-    for group in sorted(user.groups, key=_group_sort_key):
+    for group in _user_groups(user):
         groups.append({
             'name': group.name,
             'id': group.pubid,
@@ -72,6 +70,13 @@ def _authority_groups(auth_domain, authority):
         return [{'name': 'Public', 'id': '__world__', 'public': True}]
     else:
         return []
+
+
+def _user_groups(user):
+    if user is None:
+        return []
+    else:
+        return sorted(user.groups, key=_group_sort_key)
 
 
 def _user_preferences(user):

--- a/tests/common/factories.py
+++ b/tests/common/factories.py
@@ -106,6 +106,15 @@ class Group(ModelFactory):
     writeable_by = WriteableBy.members
 
 
+class PublisherGroup(Group):
+
+    name = factory.Sequence(lambda n: 'Test Publisher Group {n}'.format(n=str(n)))
+
+    joinable_by = None
+    readable_by = ReadableBy.world
+    writeable_by = WriteableBy.authority
+
+
 class AuthTicket(ModelFactory):
 
     class Meta:  # pylint: disable=no-init, old-style-class

--- a/tests/functional/test_api.py
+++ b/tests/functional/test_api.py
@@ -61,7 +61,7 @@ class TestAPI(object):
         assert res.json['userid'] == user.userid
         assert [group['id'] for group in res.json['groups']] == ['__world__']
 
-    def test_third_party_profile_api(self, app, third_party_user_with_token):
+    def test_third_party_profile_api(self, app, publisher_group, third_party_user_with_token):
         """Fetch a profile for a third-party account."""
 
         user, token = third_party_user_with_token
@@ -71,7 +71,9 @@ class TestAPI(object):
         res = app.get('/api/profile', headers=headers)
 
         assert res.json['userid'] == user.userid
-        assert [group['id'] for group in res.json['groups']] == []
+
+        group_ids = [group['id'] for group in res.json['groups']]
+        assert group_ids == [publisher_group.pubid]
 
 
 @pytest.fixture
@@ -110,6 +112,13 @@ def third_party_user(auth_client, db_session, factories):
     user = factories.User(authority=auth_client.authority)
     db_session.commit()
     return user
+
+
+@pytest.fixture
+def publisher_group(auth_client, db_session, factories):
+    group = factories.PublisherGroup(authority=auth_client.authority)
+    db_session.commit()
+    return group
 
 
 @pytest.fixture

--- a/tests/h/groups/util_test.py
+++ b/tests/h/groups/util_test.py
@@ -15,3 +15,21 @@ def test_world_group_acl():
         (security.Allow, 'authority:example.com', 'write'),
         security.DENY_ALL,
     ]
+
+
+def test_world_group_name():
+    group = util.WorldGroup('example.com')
+
+    assert group.name == 'Public'
+
+
+def test_world_group_pubid():
+    group = util.WorldGroup('example.com')
+
+    assert group.pubid == '__world__'
+
+
+def test_world_group_is_public():
+    group = util.WorldGroup('example.com')
+
+    assert group.is_public

--- a/tests/h/models/groups_test.py
+++ b/tests/h/models/groups_test.py
@@ -71,6 +71,18 @@ def test_created_by(db_session, factories):
     assert models.Group.created_by(db_session, user).all() == [group_1, group_2]
 
 
+def test_public_group():
+    group = models.Group(readable_by=ReadableBy.world)
+
+    assert group.is_public
+
+
+def test_non_public_group():
+    group = models.Group(readable_by=ReadableBy.members)
+
+    assert not group.is_public
+
+
 @pytest.mark.usefixtures('documents')
 def test_documents_returns_groups_annotated_documents(db_session, group):
     # Three different documents each with a shared annotation in the group.

--- a/tests/h/services/authority_group_test.py
+++ b/tests/h/services/authority_group_test.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import pytest
+
+from h.services import authority_group
+
+
+def test_returns_world_group_for_matching_domain(svc):
+    public_groups = svc.public_groups('example.com')
+
+    assert [group.pubid for group in public_groups] == ['__world__']
+
+
+def test_excludes_world_group_for_non_matching_domain(svc):
+    public_groups = svc.public_groups('partner.org')
+
+    assert '__world__' not in [group.pubid for group in public_groups]
+
+
+def test_returns_public_groups_for_non_matching_domain(svc, publisher_group):
+    assert publisher_group in svc.public_groups('partner.org')
+
+
+def test_excludes_third_party_private_groups(svc, third_party_private_group):
+    assert third_party_private_group not in svc.public_groups('partner.org')
+
+
+def test_excludes_private_groups(svc, private_group):
+    assert private_group not in svc.public_groups('partner.org')
+
+
+@pytest.fixture
+def svc(db_session):
+    return authority_group.AuthorityGroupService(db_session, 'example.com')
+
+
+@pytest.fixture
+def private_group(factories):
+    return factories.Group(authority='example.com')
+
+
+@pytest.fixture
+def publisher_group(factories):
+    return factories.PublisherGroup(authority='partner.org')
+
+
+@pytest.fixture
+def third_party_private_group(factories):
+    return factories.Group(authority='partner.org')

--- a/tests/h/session_test.py
+++ b/tests/h/session_test.py
@@ -74,6 +74,24 @@ def test_profile_sorts_groups(authenticated_request):
     assert ids == ['__world__', 'c', 'a', 'b']
 
 
+def test_world_group_in_authenticated_profile(authenticated_request):
+    result = session.profile(authenticated_request)
+
+    assert '__world__' in [g['id'] for g in result['groups']]
+
+
+def test_world_group_in_anonymous_profile(unauthenticated_request):
+    result = session.profile(unauthenticated_request)
+
+    assert '__world__' in [g['id'] for g in result['groups']]
+
+
+def test_world_group_not_in_third_party_profile(third_party_request):
+    result = session.profile(third_party_request)
+
+    assert '__world__' not in [g['id'] for g in result['groups']]
+
+
 def test_profile_includes_features(authenticated_request):
     feature_dict = {
         'feature_one': True,
@@ -133,6 +151,11 @@ def auth_domain():
 
 
 @pytest.fixture
+def third_party_domain():
+    return u'thirdparty.example.org'
+
+
+@pytest.fixture
 def unauthenticated_request(auth_domain):
     return FakeRequest(auth_domain, None, None)
 
@@ -142,3 +165,10 @@ def authenticated_request(auth_domain):
     return FakeRequest(auth_domain,
                        u'acct:user@{}'.format(auth_domain),
                        auth_domain)
+
+
+@pytest.fixture
+def third_party_request(auth_domain, third_party_domain):
+    return FakeRequest(auth_domain,
+                       u'acct:user@{}'.format(third_party_domain),
+                       third_party_domain)

--- a/tests/h/session_test.py
+++ b/tests/h/session_test.py
@@ -24,6 +24,22 @@ def test_model_sorts_groups(authenticated_request):
     assert ids == ['__world__', 'c', 'a', 'b']
 
 
+def test_world_group_is_public_in_model(authenticated_request):
+    model = session.model(authenticated_request)
+    world_group = [g for g in model['groups'] if g['id'] == '__world__'][0]
+
+    assert world_group['public'] is True
+
+
+def test_private_group_is_not_public_in_model(authenticated_request):
+    authenticated_request.set_groups([FakeGroup('a', 'Group A')])
+
+    model = session.model(authenticated_request)
+    private_group = [g for g in model['groups'] if g['id'] == 'a'][0]
+
+    assert private_group['public'] is False
+
+
 def test_model_includes_features(authenticated_request):
     feature_dict = {
         'feature_one': True,
@@ -90,6 +106,22 @@ def test_world_group_not_in_third_party_profile(third_party_request):
     result = session.profile(third_party_request)
 
     assert '__world__' not in [g['id'] for g in result['groups']]
+
+
+def test_world_group_is_public_in_profile(authenticated_request):
+    profile = session.profile(authenticated_request)
+    world_group = [g for g in profile['groups'] if g['id'] == '__world__'][0]
+
+    assert world_group['public'] is True
+
+
+def test_private_group_is_not_public_in_profile(authenticated_request):
+    authenticated_request.set_groups([FakeGroup('a', 'Group A')])
+
+    profile = session.profile(authenticated_request)
+    private_group = [g for g in profile['groups'] if g['id'] == 'a'][0]
+
+    assert private_group['public'] is False
 
 
 def test_profile_includes_features(authenticated_request):

--- a/tests/h/session_test.py
+++ b/tests/h/session_test.py
@@ -5,10 +5,11 @@ from h import session
 
 
 class FakeGroup(object):
-    def __init__(self, pubid, name):
+    def __init__(self, pubid, name, is_public=False):
         self.pubid = pubid
         self.name = name
         self.slug = pubid
+        self.is_public = is_public
 
 
 def test_model_sorts_groups(authenticated_request):
@@ -122,6 +123,15 @@ def test_private_group_is_not_public_in_profile(authenticated_request):
     private_group = [g for g in profile['groups'] if g['id'] == 'a'][0]
 
     assert private_group['public'] is False
+
+
+def test_publisher_group_is_public_in_profile(third_party_request):
+    third_party_request.set_groups([FakeGroup('a', 'Group A', is_public=True)])
+
+    profile = session.profile(third_party_request)
+    publisher_group = [g for g in profile['groups'] if g['id'] == 'a'][0]
+
+    assert publisher_group['public'] is True
 
 
 def test_profile_includes_features(authenticated_request):

--- a/tests/h/session_test.py
+++ b/tests/h/session_test.py
@@ -41,6 +41,31 @@ def test_private_group_is_not_public_in_model(authenticated_request):
     assert private_group['public'] is False
 
 
+def test_world_group_has_no_url_in_model(authenticated_request):
+    model = session.model(authenticated_request)
+    world_group = [g for g in model['groups'] if g['id'] == '__world__'][0]
+
+    assert 'url' not in world_group
+
+
+def test_private_group_has_url_in_model(authenticated_request):
+    authenticated_request.set_groups([FakeGroup('a', 'Group A')])
+
+    model = session.model(authenticated_request)
+    private_group = [g for g in model['groups'] if g['id'] == 'a'][0]
+
+    assert private_group['url']
+
+
+def test_publisher_group_has_no_url_in_model(third_party_request):
+    third_party_request.set_groups([FakeGroup('a', 'Group A', is_public=True)])
+
+    model = session.model(third_party_request)
+    publisher_group = [g for g in model['groups'] if g['id'] == 'a'][0]
+
+    assert 'url' not in publisher_group
+
+
 def test_model_includes_features(authenticated_request):
     feature_dict = {
         'feature_one': True,
@@ -132,6 +157,31 @@ def test_publisher_group_is_public_in_profile(third_party_request):
     publisher_group = [g for g in profile['groups'] if g['id'] == 'a'][0]
 
     assert publisher_group['public'] is True
+
+
+def test_world_group_has_no_url_in_profile(authenticated_request):
+    profile = session.profile(authenticated_request)
+    world_group = [g for g in profile['groups'] if g['id'] == '__world__'][0]
+
+    assert 'url' not in world_group
+
+
+def test_private_group_has_url_in_profile(authenticated_request):
+    authenticated_request.set_groups([FakeGroup('a', 'Group A')])
+
+    profile = session.profile(authenticated_request)
+    private_group = [g for g in profile['groups'] if g['id'] == 'a'][0]
+
+    assert private_group['url']
+
+
+def test_publisher_group_has_no_url_in_profile(third_party_request):
+    third_party_request.set_groups([FakeGroup('a', 'Group A', is_public=True)])
+
+    profile = session.profile(third_party_request)
+    publisher_group = [g for g in profile['groups'] if g['id'] == 'a'][0]
+
+    assert 'url' not in publisher_group
 
 
 def test_profile_includes_features(authenticated_request):


### PR DESCRIPTION
As the next stage of hypothesis/product-backlog#119, this extends the `/api/profile` endpoint to work for authenticated users belonging to a third party. Part of this involves extracting an `AuthorityGroupService` to list the public groups under an authority, so that the `session` module no longer needs hard-coded knowledge about the `__world__` pseudo-group.