### PR TITLE
Token auth for WebSocket API

### DIFF
--- a/conf/development-websocket.ini
+++ b/conf/development-websocket.ini
@@ -8,6 +8,10 @@ origins:
 # Use gevent-compatible transport for the Sentry client
 raven.transport: gevent
 
+# Set a default persistent secret for development. DO NOT copy this into a
+# production settings file.
+h.client_secret: nosuchsecret
+
 secret_key: notverysecretafterall
 
 # SQLAlchemy configuration -- See SQLAlchemy documentation

--- a/h/auth/__init__.py
+++ b/h/auth/__init__.py
@@ -62,4 +62,4 @@ def includeme(config):
     config.add_request_method(auth_domain, name='auth_domain', reify=True)
 
     # Allow retrieval of the auth token (if present) from the request object.
-    config.add_request_method('.tokens.auth_token', reify=True)
+    config.add_request_method('.tokens.AuthTokenFetcher', name='auth_token', reify=True)

--- a/h/auth/__init__.py
+++ b/h/auth/__init__.py
@@ -8,7 +8,7 @@ from pyramid.authentication import RemoteUserAuthenticationPolicy
 import pyramid_authsanity
 from pyramid_multiauth import MultiAuthenticationPolicy
 
-from h.auth.policy import AuthenticationPolicy, TokenAuthenticationPolicy
+from h.auth.policy import AuthenticationPolicy, TokenAuthenticationPolicy, TokenParameterAuthenticationPolicy
 from h.auth.util import auth_domain, groupfinder
 from h.security import derive_key
 
@@ -23,10 +23,11 @@ PROXY_POLICY = RemoteUserAuthenticationPolicy(environ_key='HTTP_X_FORWARDED_USER
                                               callback=groupfinder)
 TICKET_POLICY = pyramid_authsanity.AuthServicePolicy()
 TOKEN_POLICY = TokenAuthenticationPolicy(callback=groupfinder)
+TOKEN_PARAM_POLICY = TokenParameterAuthenticationPolicy(callback=groupfinder, debug=True)
 
 DEFAULT_POLICY = AuthenticationPolicy(api_policy=TOKEN_POLICY,
                                       fallback_policy=TICKET_POLICY)
-WEBSOCKET_POLICY = MultiAuthenticationPolicy([TOKEN_POLICY, TICKET_POLICY])
+WEBSOCKET_POLICY = MultiAuthenticationPolicy([TOKEN_PARAM_POLICY, TOKEN_POLICY, TICKET_POLICY])
 
 
 def includeme(config):
@@ -51,7 +52,8 @@ def includeme(config):
 
         DEFAULT_POLICY = AuthenticationPolicy(api_policy=TOKEN_POLICY,
                                               fallback_policy=PROXY_POLICY)
-        WEBSOCKET_POLICY = MultiAuthenticationPolicy([TOKEN_POLICY,
+        WEBSOCKET_POLICY = MultiAuthenticationPolicy([TOKEN_PARAM_POLICY,
+                                                      TOKEN_POLICY,
                                                       PROXY_POLICY])
 
     # Set the default authentication policy. This can be overridden by modules

--- a/h/auth/policy.py
+++ b/h/auth/policy.py
@@ -86,6 +86,26 @@ class TokenAuthenticationPolicy(CallbackAuthenticationPolicy):
         return token.userid
 
 
+@interface.implementer(interfaces.IAuthenticationPolicy)
+class TokenParameterAuthenticationPolicy(TokenAuthenticationPolicy):
+    def unauthenticated_userid(self, request):
+        """
+        Return the userid implied by the token in the passed request, if any.
+
+        :param request: a request object
+        :type request: pyramid.request.Request
+
+        :returns: the userid authenticated for the passed request or None
+        :rtype: unicode or None
+        """
+        auth_token = getattr(request, 'auth_token', lambda get_param: None)
+        token = auth_token(get_param='access_token')
+        if token is None or not token.is_valid():
+            return None
+
+        return token.userid
+
+
 def _is_api_request(request):
     return (request.path.startswith('/api') and
             request.path not in ['/api/token', '/api/badge'])

--- a/h/auth/policy.py
+++ b/h/auth/policy.py
@@ -47,7 +47,7 @@ class TokenAuthenticationPolicy(CallbackAuthenticationPolicy):
     This is a Pyramid authentication policy in which the user's identity is
     provided by and authenticated by the presence of a valid authentication
     token associated with the request. The token is retrieved from the
-    ``request.auth_token`` property, which is provided by the
+    ``request.auth_token`` method, which is provided by the
     :py:func:`h.auth.token.auth_token` function.
 
     It uses Pyramid's CallbackAuthenticationPolicy to divide responsibility
@@ -78,7 +78,8 @@ class TokenAuthenticationPolicy(CallbackAuthenticationPolicy):
         :returns: the userid authenticated for the passed request or None
         :rtype: unicode or None
         """
-        token = getattr(request, 'auth_token', None)
+        auth_token = getattr(request, 'auth_token', lambda: None)
+        token = auth_token()
         if token is None or not token.is_valid():
             return None
 

--- a/h/auth/tokens.py
+++ b/h/auth/tokens.py
@@ -45,10 +45,9 @@ class LegacyClientJWT(object):
     Exposes the standard "auth token" interface on top of legacy tokens.
     """
 
-    def __init__(self, body, key, audience=None, leeway=240):
+    def __init__(self, body, key, leeway=240):
         self.payload = jwt.decode(body,
                                   key=key,
-                                  audience=audience,
                                   leeway=leeway,
                                   algorithms=['HS256'])
 
@@ -87,7 +86,6 @@ def generate_jwt(request, expires_in):
 
     claims = {
         'iss': request.registry.settings['h.client_id'],
-        'aud': request.host_url,
         'sub': request.authenticated_userid,
         'exp': now + datetime.timedelta(seconds=expires_in),
         'iat': now,
@@ -156,8 +154,7 @@ class AuthTokenFetcher(object):
 def _maybe_jwt(token, request):
     try:
         return LegacyClientJWT(token,
-                               key=request.registry.settings['h.client_secret'],
-                               audience=request.host_url)
+                               key=request.registry.settings['h.client_secret'])
     except jwt.InvalidTokenError:
         return None
 

--- a/tests/h/auth/policy_test.py
+++ b/tests/h/auth/policy_test.py
@@ -7,6 +7,7 @@ from pyramid.interfaces import IAuthenticationPolicy
 
 from h.auth.policy import AuthenticationPolicy
 from h.auth.policy import TokenAuthenticationPolicy
+from h.auth.policy import TokenParameterAuthenticationPolicy
 
 API_PATHS = (
     '/api',
@@ -108,17 +109,43 @@ class TestAuthenticationPolicy(object):
         assert result == self.api_policy.forget.return_value
 
 
-class TestTokenAuthenticationPolicy(object):
-    def test_remember_does_nothing(self, pyramid_request):
-        policy = TokenAuthenticationPolicy()
+@pytest.mark.parametrize('policy_class', [TokenAuthenticationPolicy,
+                                          TokenParameterAuthenticationPolicy])
+class TestCommonTokenAuthenticationPolicy(object):
+    def test_remember_does_nothing(self, policy_class, pyramid_request):
+        policy = policy_class()
 
         assert policy.remember(pyramid_request, 'foo') == []
 
-    def test_forget_does_nothing(self, pyramid_request):
-        policy = TokenAuthenticationPolicy()
+    def test_forget_does_nothing(self, policy_class, pyramid_request):
+        policy = policy_class()
 
         assert policy.forget(pyramid_request) == []
 
+    def test_authenticated_userid_uses_callback(self, policy_class, fake_token, pyramid_request):
+        def callback(userid, request):
+            return None
+        policy = policy_class(callback=callback)
+        pyramid_request.auth_token = mock.Mock(return_value=fake_token)
+
+        result = policy.authenticated_userid(pyramid_request)
+
+        assert result is None
+
+    def test_effective_principals_uses_callback(self, policy_class, fake_token, pyramid_request):
+        def callback(userid, request):
+            return [userid + '.foo', 'group:donkeys']
+        policy = policy_class(callback=callback)
+        pyramid_request.auth_token = mock.Mock(return_value=fake_token)
+
+        result = policy.effective_principals(pyramid_request)
+
+        assert set(result) > set(['acct:foo@example.com',
+                                  'acct:foo@example.com.foo',
+                                  'group:donkeys'])
+
+
+class TestTokenAuthenticationPolicy(object):
     def test_unauthenticated_userid_is_none_if_no_token(self, pyramid_request):
         policy = TokenAuthenticationPolicy()
 
@@ -142,31 +169,37 @@ class TestTokenAuthenticationPolicy(object):
 
         assert result is None
 
-    def test_authenticated_userid_uses_callback(self, fake_token, pyramid_request):
-        def callback(userid, request):
-            return None
-        policy = TokenAuthenticationPolicy(callback=callback)
-        pyramid_request.auth_token = mock.Mock(return_value=fake_token)
 
-        result = policy.authenticated_userid(pyramid_request)
+class TestTokenParameterAuthenticationPolicy(object):
+    def test_unauthenticated_userid_is_none_if_no_token(self, pyramid_request):
+        policy = TokenParameterAuthenticationPolicy()
+
+        assert policy.unauthenticated_userid(pyramid_request) is None
+
+    def test_unauthenticated_userid_returns_userid_from_token(self, fake_token, pyramid_request):
+        policy = TokenParameterAuthenticationPolicy()
+
+        def fake_auth_token(get_param):
+            if get_param == 'access_token':
+                return fake_token
+        pyramid_request.auth_token = mock.Mock(side_effect=fake_auth_token)
+
+        result = policy.unauthenticated_userid(pyramid_request)
+
+        assert result == 'acct:foo@example.com'
+
+    def test_unauthenticated_userid_returns_none_if_token_invalid(self, pyramid_request):
+        policy = TokenParameterAuthenticationPolicy()
+        token = DummyToken(valid=False)
+
+        def fake_auth_token(get_param):
+            if get_param == 'access_token':
+                return token
+        pyramid_request.auth_token = mock.Mock(side_effect=fake_auth_token)
+
+        result = policy.unauthenticated_userid(pyramid_request)
 
         assert result is None
-
-    def test_effective_principals_uses_callback(self, fake_token, pyramid_request):
-        def callback(userid, request):
-            return [userid + '.foo', 'group:donkeys']
-        policy = TokenAuthenticationPolicy(callback=callback)
-        pyramid_request.auth_token = mock.Mock(return_value=fake_token)
-
-        result = policy.effective_principals(pyramid_request)
-
-        assert set(result) > set(['acct:foo@example.com',
-                                  'acct:foo@example.com.foo',
-                                  'group:donkeys'])
-
-    @pytest.fixture
-    def fake_token(self):
-        return DummyToken()
 
 
 class DummyToken(object):
@@ -176,3 +209,8 @@ class DummyToken(object):
 
     def is_valid(self):
         return self._valid
+
+
+@pytest.fixture
+def fake_token():
+    return DummyToken()

--- a/tests/h/auth/policy_test.py
+++ b/tests/h/auth/policy_test.py
@@ -126,7 +126,7 @@ class TestTokenAuthenticationPolicy(object):
 
     def test_unauthenticated_userid_returns_userid_from_token(self, fake_token, pyramid_request):
         policy = TokenAuthenticationPolicy()
-        pyramid_request.auth_token = fake_token
+        pyramid_request.auth_token = mock.Mock(return_value=fake_token)
 
         result = policy.unauthenticated_userid(pyramid_request)
 
@@ -136,6 +136,7 @@ class TestTokenAuthenticationPolicy(object):
         policy = TokenAuthenticationPolicy()
         token = DummyToken(valid=False)
         pyramid_request.auth_token = token
+        pyramid_request.auth_token = mock.Mock(return_value=token)
 
         result = policy.unauthenticated_userid(pyramid_request)
 
@@ -145,7 +146,7 @@ class TestTokenAuthenticationPolicy(object):
         def callback(userid, request):
             return None
         policy = TokenAuthenticationPolicy(callback=callback)
-        pyramid_request.auth_token = fake_token
+        pyramid_request.auth_token = mock.Mock(return_value=fake_token)
 
         result = policy.authenticated_userid(pyramid_request)
 
@@ -155,7 +156,7 @@ class TestTokenAuthenticationPolicy(object):
         def callback(userid, request):
             return [userid + '.foo', 'group:donkeys']
         policy = TokenAuthenticationPolicy(callback=callback)
-        pyramid_request.auth_token = fake_token
+        pyramid_request.auth_token = mock.Mock(return_value=fake_token)
 
         result = policy.effective_principals(pyramid_request)
 

--- a/tests/h/auth/tokens_test.py
+++ b/tests/h/auth/tokens_test.py
@@ -38,32 +38,24 @@ class TestToken(object):
 
 VALID_TOKEN_EXAMPLES = [
     # Valid
-    lambda a, k: jwt.encode({'aud': a, 'exp': _seconds_from_now(3600)},
-                            key=k),
+    lambda a, k: jwt.encode({'exp': _seconds_from_now(3600)}, key=k),
 
     # Expired, but within leeway
-    lambda a, k: jwt.encode({'aud': a, 'exp': _seconds_from_now(-120)},
-                            key=k),
+    lambda a, k: jwt.encode({'exp': _seconds_from_now(-120)}, key=k),
 ]
 
 INVALID_TOKEN_EXAMPLES = [
     # Expired 1 hour ago
-    lambda a, k: jwt.encode({'aud': a, 'exp': _seconds_from_now(-3600)},
+    lambda a, k: jwt.encode({'exp': _seconds_from_now(-3600)},
                             key=k),
 
     # Issued in the future
-    lambda a, k: jwt.encode({'aud': a,
-                             'exp': _seconds_from_now(3600),
+    lambda a, k: jwt.encode({'exp': _seconds_from_now(3600),
                              'iat': _seconds_from_now(1800)},
                             key=k),
 
-    # Incorrect audience
-    lambda a, k: jwt.encode({'aud': 'https://bar.com',
-                             'exp': _seconds_from_now(3600)},
-                            key=k),
-
     # Incorrect encoding key
-    lambda a, k: jwt.encode({'aud': a, 'exp': _seconds_from_now(3600)},
+    lambda a, k: jwt.encode({'exp': _seconds_from_now(3600)},
                             key='somethingelse'),
 ]
 
@@ -73,9 +65,7 @@ class TestLegacyClientJWT(object):
     def test_ok_for_valid_jwt(self, get_token):
         token = get_token('http://example.com', 'secrets!')
 
-        result = tokens.LegacyClientJWT(token,
-                                        audience='http://example.com',
-                                        key='secrets!')
+        result = tokens.LegacyClientJWT(token, key='secrets!')
 
         assert isinstance(result, tokens.LegacyClientJWT)
 
@@ -84,54 +74,40 @@ class TestLegacyClientJWT(object):
         token = get_token('http://example.com', 'secrets!')
 
         with pytest.raises(jwt.InvalidTokenError):
-            tokens.LegacyClientJWT(token,
-                                   audience='http://example.com',
-                                   key='secrets!')
+            tokens.LegacyClientJWT(token, key='secrets!')
 
     def test_payload(self):
-        payload = {'aud': 'http://foo.com',
-                   'exp': _seconds_from_now(3600),
+        payload = {'exp': _seconds_from_now(3600),
                    'sub': 'foobar'}
         token = jwt.encode(payload, key='s3cr37')
 
-        result = tokens.LegacyClientJWT(token,
-                                        audience='http://foo.com',
-                                        key='s3cr37')
+        result = tokens.LegacyClientJWT(token, key='s3cr37')
 
         assert result.payload == payload
 
     def test_always_valid(self):
-        payload = {'aud': 'http://foo.com',
-                   'exp': _seconds_from_now(3600),
+        payload = {'exp': _seconds_from_now(3600),
                    'sub': 'foobar'}
         token = jwt.encode(payload, key='s3cr37')
 
-        result = tokens.LegacyClientJWT(token,
-                                        audience='http://foo.com',
-                                        key='s3cr37')
+        result = tokens.LegacyClientJWT(token, key='s3cr37')
 
         assert result.is_valid()
 
     def test_userid_gets_payload_sub(self):
-        payload = {'aud': 'http://foo.com',
-                   'exp': _seconds_from_now(3600),
+        payload = {'exp': _seconds_from_now(3600),
                    'sub': 'foobar'}
         token = jwt.encode(payload, key='s3cr37')
 
-        result = tokens.LegacyClientJWT(token,
-                                        audience='http://foo.com',
-                                        key='s3cr37')
+        result = tokens.LegacyClientJWT(token, key='s3cr37')
 
         assert result.userid == 'foobar'
 
     def test_userid_none_if_sub_missing(self):
-        payload = {'aud': 'http://foo.com',
-                   'exp': _seconds_from_now(3600)}
+        payload = {'exp': _seconds_from_now(3600)}
         token = jwt.encode(payload, key='s3cr37')
 
-        result = tokens.LegacyClientJWT(token,
-                                        audience='http://foo.com',
-                                        key='s3cr37')
+        result = tokens.LegacyClientJWT(token, key='s3cr37')
 
         assert result.userid is None
 
@@ -148,8 +124,6 @@ def test_generate_jwt_calls_encode(jwt_, pyramid_config, pyramid_request):
     after = datetime.datetime.utcnow() + datetime.timedelta(seconds=3600)
     assert before < jwt_.encode.call_args[0][0]['exp'] < after, (
         "It should encode the expiration time as 'exp'")
-    assert jwt_.encode.call_args[0][0]['aud'] == pyramid_request.host_url, (
-        "It should encode request.host_url as 'aud'")
     assert jwt_.encode.call_args[1]['algorithm'] == 'HS256', (
         "It should pass the right algorithm to encode()")
 
@@ -223,8 +197,7 @@ class TestAuthTokenFetcher(object):
 
     @pytest.mark.usefixture('pyramid_settings')
     def test_returns_legacy_client_jwt_when_jwt(self, pyramid_request):
-        token = jwt.encode({'aud': pyramid_request.host_url,
-                            'exp': _seconds_from_now(3600)},
+        token = jwt.encode({'exp': _seconds_from_now(3600)},
                            key='secret')
         pyramid_request.headers['Authorization'] = 'Bearer ' + token
 


### PR DESCRIPTION
This will add support for authenticating websocket connections with a query string parameter, e.g. `wss://hypothes.is/ws?access_token={token}`. This token can be a new OAuth 2 token, a developer token, or a legacy client JWT token.

After some more research, @robertknight found out that HTTP basic auth support for WebSockets is not fully supported by all browsers, so this supersedes #4330.

I had to move quite a bit of things around for a nice implementation of this, as we can't import any models in the Python files that contain the authentication policies.

I suggest @robertknight should try out his client branch with this, and since there are quite a lot of authz related changes it would be great to get at least @nickstenning's eyes on this, others are welcome as well.