### PR TITLE
Make the User factory into a ModelFactory

### DIFF
--- a/tests/common/factories.py
+++ b/tests/common/factories.py
@@ -70,14 +70,9 @@ class AuthClient(ModelFactory):
     secret = factory.LazyAttribute(lambda _: unicode(FAKER.sha256()))
 
 
-class User(factory.Factory):
+class User(ModelFactory):
 
-    """A factory class that generates h.models.User objects.
-
-    Note that this class doesn't add the User to the database session for you,
-    if tests want the user added to a session they should do that themselves.
-
-    """
+    """A factory class that generates h.models.User objects."""
 
     class Meta(object):
         model = models.User

--- a/tests/functional/test_accounts.py
+++ b/tests/functional/test_accounts.py
@@ -94,7 +94,6 @@ class TestAccountSettings(object):
     @pytest.fixture
     def user(self, db_session, factories):
         user = factories.User(authority='localhost', password='pass')
-        db_session.add(user)
         db_session.commit()
         return user
 

--- a/tests/functional/test_api.py
+++ b/tests/functional/test_api.py
@@ -74,7 +74,6 @@ def annotation(db_session, factories):
 @pytest.fixture
 def user(db_session, factories):
     user = factories.User()
-    db_session.add(user)
     db_session.commit()
     return user
 

--- a/tests/functional/test_groups.py
+++ b/tests/functional/test_groups.py
@@ -65,7 +65,6 @@ def test_submit_create_group_form_with_xhr_returns_plain_text(app):
 @pytest.fixture
 def user(db_session, factories):
     user = factories.User(authority='localhost', password='pass')
-    db_session.add(user)
     db_session.commit()
     return user
 

--- a/tests/h/accounts/__init___test.py
+++ b/tests/h/accounts/__init___test.py
@@ -13,7 +13,7 @@ class TestAuthenticatedUser(object):
                                         pyramid_request,
                                         user_service):
         pyramid_config.testing_securitypolicy('userid')
-        user_service.fetch.return_value = factories.User()
+        user_service.fetch.return_value = factories.User.build()
 
         accounts.authenticated_user(pyramid_request)
 
@@ -42,7 +42,7 @@ class TestAuthenticatedUser(object):
                           pyramid_request,
                           user_service):
         pyramid_config.testing_securitypolicy('userid')
-        user = user_service.fetch.return_value = factories.User()
+        user = user_service.fetch.return_value = factories.User.build()
 
         result = accounts.authenticated_user(pyramid_request)
 

--- a/tests/h/accounts/schemas_test.py
+++ b/tests/h/accounts/schemas_test.py
@@ -132,7 +132,7 @@ class TestLoginSchema(object):
                                                           factories,
                                                           pyramid_csrf_request,
                                                           user_service):
-        user = factories.User(username='jeannie')
+        user = factories.User.build(username='jeannie')
         user_service.login.return_value = user
         schema = schemas.LoginSchema().bind(request=pyramid_csrf_request)
 
@@ -148,7 +148,7 @@ class TestLoginSchema(object):
                                         factories,
                                         pyramid_csrf_request,
                                         user_service):
-        user = factories.User(username='jeannie')
+        user = factories.User.build(username='jeannie')
         user_service.login.return_value = user
         schema = schemas.LoginSchema().bind(request=pyramid_csrf_request)
 
@@ -463,7 +463,7 @@ class TestEmailChangeSchema(object):
 
     @pytest.fixture
     def user(self, factories):
-        return factories.User(password=self.PASSWORD)
+        return factories.User.build(password=self.PASSWORD)
 
     @pytest.fixture
     def models(self, patch):

--- a/tests/h/activity/query_test.py
+++ b/tests/h/activity/query_test.py
@@ -182,7 +182,7 @@ class TestCheckURL(object):
     @pytest.fixture
     def user_service(self, factories, pyramid_config):
         user_service = mock.Mock(spec_set=['fetch'])
-        user_service.fetch.return_value = factories.User()
+        user_service.fetch.return_value = factories.User.build()
         pyramid_config.register_service(user_service, name='user')
         return user_service
 

--- a/tests/h/admin/views/admins_test.py
+++ b/tests/h/admin/views/admins_test.py
@@ -148,7 +148,6 @@ def users(db_session, factories):
         'flora': factories.User(username='flora', authority='foo.org', admin=False),
     }
 
-    db_session.add_all(users.values())
     db_session.flush()
 
     return users

--- a/tests/h/admin/views/features_test.py
+++ b/tests/h/admin/views/features_test.py
@@ -100,7 +100,6 @@ def test_cohorts_edit_add_user(factories, pyramid_request):
     user = factories.User(username='benoit')
     cohort = models.FeatureCohort(name='FractalCohort')
 
-    pyramid_request.db.add(user)
     pyramid_request.db.add(cohort)
     pyramid_request.db.flush()
 
@@ -117,7 +116,6 @@ def test_cohorts_edit_add_user_strips_spaces(factories, pyramid_request):
     user = factories.User(username='benoit', authority='foo.org')
     cohort = models.FeatureCohort(name='FractalCohort')
 
-    pyramid_request.db.add(user)
     pyramid_request.db.add(cohort)
     pyramid_request.db.flush()
 
@@ -135,7 +133,6 @@ def test_cohorts_edit_remove_user(factories, pyramid_request):
     cohort = models.FeatureCohort(name='FractalCohort')
     cohort.members.append(user)
 
-    pyramid_request.db.add(user)
     pyramid_request.db.add(cohort)
     pyramid_request.db.flush()
 
@@ -167,8 +164,6 @@ def test_cohorts_edit_with_users(factories, pyramid_request):
     cohort.members.append(user1)
     cohort.members.append(user2)
 
-    pyramid_request.db.add(user1)
-    pyramid_request.db.add(user2)
     pyramid_request.db.add(cohort)
     pyramid_request.db.flush()
 

--- a/tests/h/admin/views/nipsa_test.py
+++ b/tests/h/admin/views/nipsa_test.py
@@ -116,6 +116,5 @@ def users(db_session, factories):
         'ursula': factories.User(username='ursula', authority='foo.org', nipsa=True),
         'osono': factories.User(username='osono', authority='example.com', nipsa=True),
     }
-    db_session.add_all([u for u in users.values()])
     db_session.flush()
     return users

--- a/tests/h/admin/views/staff_test.py
+++ b/tests/h/admin/views/staff_test.py
@@ -139,7 +139,6 @@ def users(db_session, factories):
         'eva': factories.User(username='eva', authority='foo.org', staff=False),
         'flora': factories.User(username='flora', authority='foo.org', staff=False),
     }
-    db_session.add_all(users.values())
     db_session.flush()
 
     return users

--- a/tests/h/admin/views/users_test.py
+++ b/tests/h/admin/views/users_test.py
@@ -66,7 +66,7 @@ def test_users_index_strips_spaces(models, pyramid_request):
 
 @users_index_fixtures
 def test_users_index_queries_annotation_count_by_userid(models, factories, pyramid_request, annotation_stats_service):
-    user = factories.User(username='bob')
+    user = factories.User.build(username='bob')
     models.User.get_by_username.return_value = user
     annotation_stats_service.user_annotation_counts.return_value = {'total': 8}
 
@@ -95,8 +95,8 @@ def test_users_index_no_user_found(models, pyramid_request):
 @users_index_fixtures
 def test_users_index_user_found(models, pyramid_request, db_session, factories):
     pyramid_request.params = {"username": "bob", "authority": "foo.org"}
-    user = models.User.get_by_username.return_value = factories.User(username='bob',
-                                                                     authority='foo.org')
+    user = factories.User.build(username='bob', authority='foo.org')
+    models.User.get_by_username.return_value = user
 
     result = views.users_index(pyramid_request)
 

--- a/tests/h/cli/commands/user_test.py
+++ b/tests/h/cli/commands/user_test.py
@@ -122,7 +122,6 @@ class TestAdminCommand(object):
 
     def _user(self, db_session, factories, admin):
         user = factories.User(admin=admin)
-        db_session.add(user)
         db_session.flush()
         return user
 

--- a/tests/h/models/user_test.py
+++ b/tests/h/models/user_test.py
@@ -23,7 +23,7 @@ class TestUserFactory(object):
             user_factory["does_not_exist"]
 
     def test_it_returns_users(self, factories, user_factory, user_service):
-        user_service.fetch.return_value = user = factories.User()
+        user_service.fetch.return_value = user = factories.User.build()
 
         assert user_factory[user.username] == user
 
@@ -264,7 +264,6 @@ class TestUserGetByEmail(object):
             'norma': factories.User(username='norma', email='norma@foo.org', authority='foo.org'),
             'meredith': factories.User(username='meredith', email='meredith@gmail.com', authority='example.com'),
         }
-        db_session.add_all(users.values())
         db_session.flush()
         return users
 
@@ -296,6 +295,5 @@ class TestUserGetByUsername(object):
             'norma': factories.User(username='norma', authority='foo.org'),
             'meredith': factories.User(username='meredith', authority='example.com'),
         }
-        db_session.add_all(users.values())
         db_session.flush()
         return users

--- a/tests/h/services/auth_ticket_test.py
+++ b/tests/h/services/auth_ticket_test.py
@@ -187,7 +187,6 @@ class TestAuthTicketService(object):
     @pytest.fixture
     def user(self, factories, db_session):
         user = factories.User()
-        db_session.add(user)
         db_session.flush()
         return user
 

--- a/tests/h/services/group_test.py
+++ b/tests/h/services/group_test.py
@@ -168,7 +168,6 @@ class TestGroupService(object):
         user = None
         if with_user:
             user = factories.User()
-            db_session.add(user)
             db_session.flush()
 
         assert '__world__' in service.groupids_readable_by(user)
@@ -183,14 +182,12 @@ class TestGroupService(object):
         user = None
         if with_user:
             user = factories.User()
-            db_session.add(user)
             db_session.flush()
 
         assert group.pubid in service.groupids_readable_by(user)
 
     def test_groupids_readable_by_includes_memberships(self, service, db_session, factories):
         user = factories.User()
-        db_session.add(user)
 
         group = factories.Group(readable_by=ReadableBy.members)
         group.members.append(user)

--- a/tests/h/services/nipsa_test.py
+++ b/tests/h/services/nipsa_test.py
@@ -94,6 +94,5 @@ def users(db_session, factories):
         'cecilia': factories.User(username='cecilia', nipsa=True),
         'dominic': factories.User(username='dominic', nipsa=False),
     }
-    db_session.add_all([u for u in users.values()])
     db_session.flush()
     return users

--- a/tests/h/services/oauth_test.py
+++ b/tests/h/services/oauth_test.py
@@ -253,7 +253,7 @@ class TestOAuthServiceVerifyJWTBearer(object):
 
     @pytest.fixture
     def user(self, factories, authclient, user_service):
-        user = factories.User(authority=authclient.authority)
+        user = factories.User.build(authority=authclient.authority)
         user_service.fetch.return_value = user
         return user
 

--- a/tests/h/services/rename_user_test.py
+++ b/tests/h/services/rename_user_test.py
@@ -19,7 +19,6 @@ class TestRenameUserService(object):
 
     def test_check_raises_when_new_userid_is_already_taken(self, service, user, db_session, factories):
         user_taken = factories.User(username='panda')
-        db_session.add(user_taken)
         db_session.flush()
 
         with pytest.raises(UserRenameError) as err:
@@ -91,7 +90,6 @@ class TestRenameUserService(object):
     @pytest.fixture
     def user(self, factories, db_session):
         user = factories.User(username='giraffe')
-        db_session.add(user)
         db_session.flush()
         return user
 

--- a/tests/h/services/user_test.py
+++ b/tests/h/services/user_test.py
@@ -94,7 +94,6 @@ class TestUserService(object):
                                 authority='example.com',
                                 password='mirthespassword',
                                 inactive=True)]
-        db_session.add_all(users)
         db_session.flush()
         return users
 

--- a/tests/h/tasks/admin_test.py
+++ b/tests/h/tasks/admin_test.py
@@ -28,7 +28,6 @@ class TestRenameUser(object):
     @pytest.fixture
     def user(self, factories, db_session):
         user = factories.User(username='giraffe')
-        db_session.add(user)
         db_session.flush()
         return user
 

--- a/tests/h/views/api_users_test.py
+++ b/tests/h/views/api_users_test.py
@@ -23,7 +23,7 @@ class TestCreate(object):
                                  user_signup_service,
                                  valid_payload):
         pyramid_request.json_body = valid_payload
-        user_signup_service.signup.return_value = factories.User(**valid_payload)
+        user_signup_service.signup.return_value = factories.User.build(**valid_payload)
 
         result = create(pyramid_request)
 
@@ -41,7 +41,7 @@ class TestCreate(object):
                            user_signup_service,
                            valid_payload):
         pyramid_request.json_body = valid_payload
-        user_signup_service.signup.return_value = factories.User(**valid_payload)
+        user_signup_service.signup.return_value = factories.User.build(**valid_payload)
 
         create(pyramid_request)
 
@@ -128,7 +128,6 @@ class TestCreate(object):
                                         factories,
                                         auth_client):
         existing_user = factories.User(authority=auth_client.authority)
-        db_session.add(existing_user)
         db_session.flush()
 
         payload = valid_payload
@@ -148,7 +147,6 @@ class TestCreate(object):
                                      factories,
                                      auth_client):
         existing_user = factories.User(authority=auth_client.authority)
-        db_session.add(existing_user)
         db_session.flush()
 
         payload = valid_payload


### PR DESCRIPTION
This factory was originally created as a subclass of the base `Factory` (see commit a928eb5e) rather than our custom `ModelFactory`, which meant it would not add the objects it generated to the current session. This is different behaviour to the other factories, which can be a little confusing. We also have the `build` method, which achieves the same outcome.

I've gone through the tests that invoke this factory, and I think I've got them all working as intended. Where the tests rely on patching out method calls, I've assumed that this means the behaviour of not adding the new objects to the session is intended, and changed the call to a `build` call. Where the factory is immediately followed by `session.add` calls, I've removed them as they now happen automatically. In other cases, I've mostly assumed that adding the new object to the session or not has no effect on the test, and have left the method as it stands.