### PR TITLE
Add Token.get_by_refresh_token() classmethod

### DIFF
--- a/h/models/token.py
+++ b/h/models/token.py
@@ -64,6 +64,19 @@ class Token(Base, mixins.Timestamps):
             self.refresh_token = security.token_urlsafe()
 
     @classmethod
+    def get_by_refresh_token(cls, session, refresh_token):
+        """
+        Return the token with the given refresh token (there can be only one).
+
+        Return None if there's no token with the given refresh_token.
+
+        """
+        return (session.query(cls)
+                .filter_by(refresh_token=refresh_token)
+                .order_by(cls.created.desc())
+                .first())
+
+    @classmethod
     def get_dev_token_by_userid(cls, session, userid):
         return (session.query(cls)
                 .filter_by(userid=userid, authclient=None)

--- a/tests/h/models/token_test.py
+++ b/tests/h/models/token_test.py
@@ -39,6 +39,28 @@ class TestToken(object):
         assert access_token.authclient == authclient
         assert access_token.refresh_token in security.token_urlsafe.side_effect.generated_tokens
 
+    def test_get_by_refresh_token_returns_the_token(self, db_session, factories):
+        refresh_token = 'xyz123'
+        # A token that should *not* be returned.
+        factories.Token(refresh_token='something_else')
+        # The token that should be returned.
+        expected_token = factories.Token(refresh_token=refresh_token)
+        # Another token that should not be returned.
+        factories.Token()
+
+        returned_token = Token.get_by_refresh_token(db_session, refresh_token)
+
+        assert returned_token == expected_token
+
+    def test_get_by_refresh_token_returns_None_if_theres_no_token(self, db_session, factories):
+        refresh_token = 'xyz123'
+        # A token that should *not* be returned.
+        factories.Token(refresh_token='something_else')
+        # Another token that should not be returned.
+        factories.Token()
+
+        assert Token.get_by_refresh_token(db_session, refresh_token) is None
+
     def test_get_dev_token_by_userid_filters_by_userid(self, db_session, factories):
         token_1 = factories.Token(userid='acct:vanessa@example.org', authclient=None)
         token_2 = factories.Token(userid='acct:david@example.org', authclient=None)


### PR DESCRIPTION
This is needed to implement the OAuth 2 refresh token request in which
the client submits a refresh token (only) and we need to find the
corresponding API token in order to make and return a new token for the
same user and authclient.