### PR TITLE
Allow to set statsd prefix

### DIFF
--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -22,11 +22,9 @@ if not os.environ.get('GUNICORN_STATS_DISABLE', None):
         _port = os.environ.get('STATSD_PORT', '8125')
         statsd_host = '{}:{}'.format(_host, _port)
 
-    _hostname = socket.gethostname()
     if 'STATSD_PREFIX' in os.environ:
+        _hostname = socket.gethostname()
         statsd_prefix = '.'.join([os.environ['STATSD_PREFIX'], _hostname])
-    else:
-        statsd_prefix = _hostname
 
 
 def post_fork(server, worker):

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import os
+import socket
 
 if 'GUNICORN_TIMEOUT' in os.environ:
     timeout = int(os.environ['GUNICORN_TIMEOUT'])
@@ -20,6 +21,12 @@ if not os.environ.get('GUNICORN_STATS_DISABLE', None):
         _host = os.environ['STATSD_HOST']
         _port = os.environ.get('STATSD_PORT', '8125')
         statsd_host = '{}:{}'.format(_host, _port)
+
+    _hostname = socket.gethostname()
+    if 'STATSD_PREFIX' in os.environ:
+        statsd_prefix = '.'.join([os.environ['STATSD_PREFIX'], _hostname])
+    else:
+        statsd_prefix = _hostname
 
 
 def post_fork(server, worker):

--- a/h/config.py
+++ b/h/config.py
@@ -6,6 +6,7 @@ from __future__ import unicode_literals
 
 import logging
 import os
+import socket
 
 from pyramid.config import Configurator
 from pyramid.settings import asbool
@@ -57,6 +58,7 @@ SETTINGS = [
     EnvSetting('sqlalchemy.url', 'DATABASE_URL', type=database_url),
     EnvSetting('statsd.host', 'STATSD_HOST'),
     EnvSetting('statsd.port', 'STATSD_PORT', type=int),
+    EnvSetting('statsd.prefix', 'STATSD_PREFIX'),
 
     # Configuration for Pyramid
     EnvSetting('secret_key', 'SECRET_KEY', type=bytes),
@@ -110,5 +112,11 @@ def configure(environ=None, settings=None):
         if settings['debug_query'] == 'trace':
             level = logging.DEBUG
         logging.getLogger('sqlalchemy.engine').setLevel(level)
+
+    hostname = socket.gethostname()
+    if 'STATSD_PREFIX' in os.environ:
+        settings['statsd.prefix'] = '.'.join([os.environ['STATSD_PREFIX'], hostname])
+    else:
+        settings['statsd.prefix'] = hostname
 
     return Configurator(settings=settings)

--- a/h/config.py
+++ b/h/config.py
@@ -113,10 +113,8 @@ def configure(environ=None, settings=None):
             level = logging.DEBUG
         logging.getLogger('sqlalchemy.engine').setLevel(level)
 
-    hostname = socket.gethostname()
     if 'STATSD_PREFIX' in os.environ:
+        hostname = socket.gethostname()
         settings['statsd.prefix'] = '.'.join([os.environ['STATSD_PREFIX'], hostname])
-    else:
-        settings['statsd.prefix'] = hostname
 
     return Configurator(settings=settings)

--- a/h/stats.py
+++ b/h/stats.py
@@ -6,7 +6,8 @@ __all__ = ('get_client',)
 
 def get_client(settings):
     return statsd.StatsClient(host=settings.get('statsd.host', 'localhost'),
-                              port=settings.get('statsd.port', 8125))
+                              port=settings.get('statsd.port', 8125),
+                              prefix=settings.get('statsd.prefix', ''))
 
 
 def includeme(config):


### PR DESCRIPTION
This should be the last piece before we can thoroughly test `h` on skyliner.

The biggest downside here is that starting supervisor will fail if the `ENV`, `APP`, or `HOSTNAME` environment variables are not set. This is not an issue for us, because all of them are set by Skyliner by default, but it makes it harder for other people to run the docker container with its default settings.

I've tried multiple ways to achieve this with Skyliner environment variables and the docker env file, but couldn't get the hostname into the string. Similarly, I've been trying to check if I can get supervisor to not fail when one of the env variables is not set, but this doesn't seem to be an option as they basically just use the Python string interpolation (`"%(ENV_APP)s" % {"ENV_APP": "foobar"}`) and there is no support for a default value without having access to the dictionary.