### PR TITLE
Update Token code and tests to use UTC timestamps

### DIFF
--- a/h/models/token.py
+++ b/h/models/token.py
@@ -66,7 +66,7 @@ class Token(Base, mixins.Timestamps):
     @property
     def expired(self):
         """True if this token has expired, False otherwise."""
-        return self.expires and datetime.datetime.now() > self.expires
+        return self.expires and datetime.datetime.utcnow() > self.expires
 
     @classmethod
     def get_dev_token_by_userid(cls, session, userid):

--- a/tests/h/models/token_test.py
+++ b/tests/h/models/token_test.py
@@ -40,7 +40,7 @@ class TestToken(object):
         assert access_token.refresh_token in security.token_urlsafe.side_effect.generated_tokens
 
     def test_expired_is_false_if_expires_is_in_the_future(self):
-        expires = datetime.datetime.now() + datetime.timedelta(hours=1)
+        expires = datetime.datetime.utcnow() + datetime.timedelta(hours=1)
         token = Token(expires=expires)
 
         assert not token.expired
@@ -51,7 +51,7 @@ class TestToken(object):
         assert not token.expired
 
     def test_expired_is_true_if_expires_is_in_the_past(self):
-        expires = datetime.datetime.now() - datetime.timedelta(hours=1)
+        expires = datetime.datetime.utcnow() - datetime.timedelta(hours=1)
         token = Token(expires=expires)
 
         assert token.expired


### PR DESCRIPTION
As the timestamp is stored in UTC in the database, and `datetime.now` returns an object that doesn't understand timezones, this may cause time offset bugs, depending on the server's configuration.

This is a fix to #4337, as pointed out by @nickstenning.