### PR TITLE
Remove unused `models` import

### DIFF
--- a/h/groups/util.py
+++ b/h/groups/util.py
@@ -4,8 +4,6 @@ from __future__ import unicode_literals
 
 from pyramid import security
 
-from h import models
-
 
 class WorldGroup(object):
     """


### PR DESCRIPTION
It looks like this became redundant in commit 0d6510b52a6b.