### PR TITLE
Use 'example.com' as authority in functional tests

### DIFF
--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -11,7 +11,8 @@ from webtest import TestApp
 TEST_SETTINGS = {
     'es.host': os.environ.get('ELASTICSEARCH_HOST', 'http://localhost:9200'),
     'es.index': 'hypothesis-test',
-    'h.app_url': 'http://localhost',
+    'h.app_url': 'http://example.com',
+    'h.auth_domain': 'example.com',
     'pyramid.debug_all': True,
     'sqlalchemy.url': os.environ.get('TEST_DATABASE_URL',
                                      'postgresql://postgres@localhost/htest')

--- a/tests/functional/test_accounts.py
+++ b/tests/functional/test_accounts.py
@@ -93,7 +93,7 @@ class TestAccountSettings(object):
 
     @pytest.fixture
     def user(self, db_session, factories):
-        user = factories.User(authority='localhost', password='pass')
+        user = factories.User(password='pass')
         db_session.commit()
         return user
 

--- a/tests/functional/test_api.py
+++ b/tests/functional/test_api.py
@@ -19,7 +19,7 @@ class TestAPI(object):
         res = app.get('/api/annotations/' + annotation.id + '.jsonld')
         data = res.json
         assert data['@context'] == 'http://www.w3.org/ns/anno.jsonld'
-        assert data['id'] == 'http://localhost/a/' + annotation.id
+        assert data['id'] == 'http://example.com/a/' + annotation.id
 
     def test_annotation_write_unauthorized_group(self, app, user_with_token, non_writeable_group):
         """
@@ -64,7 +64,7 @@ class TestAPI(object):
 
 @pytest.fixture
 def annotation(db_session, factories):
-    ann =  factories.Annotation(userid='acct:testuser@localhost',
+    ann =  factories.Annotation(userid='acct:testuser@example.com',
                                 groupid='__world__',
                                 shared=True)
     db_session.commit()

--- a/tests/functional/test_groups.py
+++ b/tests/functional/test_groups.py
@@ -64,7 +64,7 @@ def test_submit_create_group_form_with_xhr_returns_plain_text(app):
 
 @pytest.fixture
 def user(db_session, factories):
-    user = factories.User(authority='localhost', password='pass')
+    user = factories.User(password='pass')
     db_session.commit()
     return user
 


### PR DESCRIPTION
The functional tests default to an authority of `localhost`, whereas users, groups and auth clients are created using `example.com`. This causes some problems in the profile endpoint, where some of the logic involves checking the user's authority against the `auth_domain` of the request.

For the sake of consistency, going with `example.com` everywhere seems reasonable.