### PR TITLE
Refresh token request

### DIFF
--- a/h/migrations/versions/02db2fa6ea98_add_unique_constraint_to_refresh_token_column.py
+++ b/h/migrations/versions/02db2fa6ea98_add_unique_constraint_to_refresh_token_column.py
@@ -1,0 +1,30 @@
+"""
+Add a unique constraint to the token.refresh_token column.
+
+Revision ID: 02db2fa6ea98
+Revises: c739ee2ae59c
+Create Date: 2017-01-31 17:24:03.855420
+"""
+
+from __future__ import unicode_literals
+
+from alembic import op
+import sqlalchemy
+
+
+revision = '02db2fa6ea98'
+down_revision = 'c739ee2ae59c'
+
+
+def upgrade():
+    op.execute('COMMIT')
+    try:
+        op.create_unique_constraint('uq__token__refresh_token', 'token',
+                                    ['refresh_token'])
+    except sqlalchemy.exc.ProgrammingError as exc:
+        if 'relation "uq__token__refresh_token" already exists' not in exc.message:
+            raise
+
+
+def downgrade():
+    op.drop_constraint('uq__token__refresh_token', 'token')

--- a/h/views/api_auth.py
+++ b/h/views/api_auth.py
@@ -11,9 +11,7 @@ from h.util.view import cors_json_view
 def access_token(request):
     svc = request.find_service(name='oauth')
 
-    user, authclient = svc.verify_jwt_bearer(
-        assertion=request.POST.get('assertion'),
-        grant_type=request.POST.get('grant_type'))
+    user, authclient = svc.verify_token_request(request.POST)
     token = svc.create_token(user, authclient)
 
     response = {

--- a/tests/functional/test_oauth.py
+++ b/tests/functional/test_oauth.py
@@ -1,0 +1,146 @@
+# -*- coding: utf-8 -*-
+"""Functional tests for getting and using OAuth 2 access and refresh tokens."""
+
+from __future__ import unicode_literals
+
+import datetime
+
+import jwt
+import pytest
+
+
+@pytest.mark.functional
+class TestOAuth(object):
+    def test_getting_an_access_token(self, app, authclient, userid):
+        """Test using grant tokens and access tokens."""
+        # Test using a grant token to get an access token.
+        response = self.get_access_token(app, authclient, userid)
+        access_token = response['access_token']
+
+        # Test that you can use the access token to authorize with the API.
+        app.get(
+            '/api/profile',
+            headers={'Authorization': str('Bearer {}'.format(access_token))},
+        )
+
+    def test_request_fails_if_access_token_wrong(self, app, authclient,
+                                                 userid):
+        app.get(
+            '/api/profile',
+            headers={'Authorization': str('Bearer wrong')},
+            status=404,
+        )
+
+    def test_request_fails_if_access_token_expired(self, app, authclient,
+                                                   db_session, factories,
+                                                   userid):
+        token = factories.Token(
+            expires=datetime.datetime.utcnow() - datetime.timedelta(hours=1))
+        token = token.value
+        db_session.commit()
+
+        app.get(
+            '/api/profile',
+            headers={'Authorization': str('Bearer {}'.format(token))},
+            status=404,
+        )
+
+    def test_using_a_refresh_token(self, app, authclient, userid):
+        """Get a new access token by POSTing a refresh token to /api/token."""
+        # Start by getting an access token and refresh token.
+        response = self.get_access_token(app, authclient, userid)
+        old_access_token = response['access_token']
+        refresh_token = response['refresh_token']
+
+        # Use the refresh token to get a new access token.
+        response = app.post(
+            '/api/token',
+            {
+                'grant_type': 'refresh_token',
+                'refresh_token': refresh_token,
+            }
+        )
+        new_access_token = response.json_body['access_token']
+
+        # Test that the new access token works.
+        app.get(
+            '/api/profile',
+            headers={
+                'Authorization': str('Bearer {}'.format(new_access_token)),
+            },
+        )
+
+        # Test that the old access token still works, too.
+        app.get(
+            '/api/profile',
+            headers={
+                'Authorization': str('Bearer {}'.format(old_access_token)),
+            },
+        )
+
+    def test_refresh_token_request_fails_if_refresh_token_wrong(self, app,
+                                                                authclient,
+                                                                userid):
+        app.post(
+            '/api/token',
+            {
+                'grant_type': 'refresh_token',
+                'refresh_token': 'wrong',
+            },
+            status=400,
+        )
+
+    def test_refresh_token_request_fails_if_token_expired(self, app,
+                                                          authclient,
+                                                          db_session,
+                                                          factories,
+                                                          userid):
+        token = factories.Token(
+            expires=datetime.datetime.utcnow() - datetime.timedelta(hours=1))
+        refresh_token = token.refresh_token
+        db_session.commit()
+
+        app.post(
+            '/api/token',
+            {
+                'grant_type': 'refresh_token',
+                'refresh_token': refresh_token
+            },
+            status=400,
+        )
+
+    def test_you_cannot_use_a_refresh_token_to_authenticate_api_requests(
+            self, app, authclient, userid):
+        response = self.get_access_token(app, authclient, userid)
+        refresh_token = response['refresh_token']
+
+        app.get(
+            '/api/profile',
+            headers={'Authorization': str('Bearer {}'.format(refresh_token))},
+            status=404,
+        )
+
+    def get_access_token(self, app, authclient, userid):
+        """Get an access token by POSTing a grant token to /api/token."""
+        response = app.post(
+            '/api/token',
+            {
+                'grant_type': 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+                'assertion': jwt.encode({'iss': authclient.id,
+                                         'aud': 'localhost',
+                                         'sub': userid,
+                                         }, authclient.secret)},
+        )
+        return response.json_body
+
+    @pytest.fixture
+    def authclient(self, db_session, factories):
+        authclient = factories.AuthClient()
+        db_session.commit()
+        return authclient
+
+    @pytest.fixture
+    def userid(self, db_session, factories):
+        user = factories.User()
+        db_session.commit()
+        return user.userid

--- a/tests/h/services/oauth_test.py
+++ b/tests/h/services/oauth_test.py
@@ -16,46 +16,46 @@ from h.services.user import UserService
 from h._compat import text_type
 
 
-class TestOAuthServiceVerifyJWTBearer(object):
-    """ Tests for ``OAuthService.verify_jwt_bearer`` """
+class TestOAuthServiceVerifyJWTBearerRequest(object):
+    """Test for verifying jwt-bearer requests with OAuthService."""
 
     def test_it_returns_the_user_and_authclient_from_the_jwt_token(self, svc, claims, authclient, user):
         expected_user = user
         tok = self.jwt_token(claims, authclient.secret)
 
-        result = svc.verify_jwt_bearer(assertion=tok,
-                                       grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer')
+        result = svc.verify_token_request(dict(assertion=tok,
+                                               grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer'))
 
         assert (expected_user, authclient) == result
 
     def test_missing_grant_type(self, svc):
         with pytest.raises(OAuthTokenError) as exc:
-            svc.verify_jwt_bearer(assertion='jwt-token',
-                                  grant_type=None)
+            svc.verify_token_request(dict(assertion='jwt-token',
+                                          grant_type=None))
 
         assert exc.value.type == 'unsupported_grant_type'
         assert 'grant type is not supported' in exc.value.message
 
     def test_unsupported_grant_type(self, svc):
         with pytest.raises(OAuthTokenError) as exc:
-            svc.verify_jwt_bearer(assertion='jwt-token',
-                                  grant_type='authorization_code')
+            svc.verify_token_request(dict(assertion='jwt-token',
+                                          grant_type='authorization_code'))
 
         assert exc.value.type == 'unsupported_grant_type'
         assert 'grant type is not supported' in exc.value.message
 
     def test_missing_assertion(self, svc):
         with pytest.raises(OAuthTokenError) as exc:
-            svc.verify_jwt_bearer(assertion=None,
-                                  grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer')
+            svc.verify_token_request(dict(assertion=None,
+                                          grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer'))
 
         assert exc.value.type == 'invalid_request'
         assert 'assertion parameter is missing' in exc.value.message
 
     def test_non_jwt_assertion(self, svc):
         with pytest.raises(OAuthTokenError) as exc:
-            svc.verify_jwt_bearer(assertion='bogus',
-                                  grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer')
+            svc.verify_token_request(dict(assertion='bogus',
+                                          grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer'))
 
         assert exc.value.type == 'invalid_grant'
         assert 'invalid JWT signature' in exc.value.message
@@ -65,8 +65,8 @@ class TestOAuthServiceVerifyJWTBearer(object):
         tok = self.jwt_token(claims, authclient.secret)
 
         with pytest.raises(OAuthTokenError) as exc:
-            svc.verify_jwt_bearer(assertion=tok,
-                                  grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer')
+            svc.verify_token_request(dict(assertion=tok,
+                                          grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer'))
 
         assert exc.value.type == 'invalid_grant'
         assert 'issuer is missing' in exc.value.message
@@ -76,8 +76,8 @@ class TestOAuthServiceVerifyJWTBearer(object):
         tok = self.jwt_token(claims, authclient.secret)
 
         with pytest.raises(OAuthTokenError) as exc:
-            svc.verify_jwt_bearer(assertion=tok,
-                                  grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer')
+            svc.verify_token_request(dict(assertion=tok,
+                                          grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer'))
 
         assert exc.value.type == 'invalid_grant'
         assert 'issuer is missing' in exc.value.message
@@ -89,8 +89,8 @@ class TestOAuthServiceVerifyJWTBearer(object):
         tok = self.jwt_token(claims, authclient.secret)
 
         with pytest.raises(OAuthTokenError) as exc:
-            svc.verify_jwt_bearer(assertion=tok,
-                                  grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer')
+            svc.verify_token_request(dict(assertion=tok,
+                                          grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer'))
 
         assert exc.value.type == 'invalid_grant'
         assert 'issuer is invalid' in exc.value.message
@@ -100,8 +100,8 @@ class TestOAuthServiceVerifyJWTBearer(object):
         tok = self.jwt_token(claims, authclient.secret)
 
         with pytest.raises(OAuthTokenError) as exc:
-            svc.verify_jwt_bearer(assertion=tok,
-                                  grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer')
+            svc.verify_token_request(dict(assertion=tok,
+                                          grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer'))
 
         assert exc.value.type == 'invalid_grant'
         assert 'issuer is invalid' in exc.value.message
@@ -110,8 +110,8 @@ class TestOAuthServiceVerifyJWTBearer(object):
         tok = self.jwt_token(claims, 'different-secret')
 
         with pytest.raises(OAuthTokenError) as exc:
-            svc.verify_jwt_bearer(assertion=tok,
-                                  grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer')
+            svc.verify_token_request(dict(assertion=tok,
+                                          grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer'))
 
         assert exc.value.type == 'invalid_grant'
         assert 'invalid JWT signature' in exc.value.message
@@ -120,8 +120,8 @@ class TestOAuthServiceVerifyJWTBearer(object):
         tok = self.jwt_token(claims, authclient.secret, algorithm='HS512')
 
         with pytest.raises(OAuthTokenError) as exc:
-            svc.verify_jwt_bearer(assertion=tok,
-                                  grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer')
+            svc.verify_token_request(dict(assertion=tok,
+                                          grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer'))
 
         assert exc.value.type == 'invalid_grant'
         assert 'invalid JWT signature algorithm' in exc.value.message
@@ -131,8 +131,8 @@ class TestOAuthServiceVerifyJWTBearer(object):
         tok = self.jwt_token(claims, authclient.secret)
 
         with pytest.raises(OAuthTokenError) as exc:
-            svc.verify_jwt_bearer(assertion=tok,
-                                  grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer')
+            svc.verify_token_request(dict(assertion=tok,
+                                          grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer'))
 
         assert exc.value.type == 'invalid_grant'
         assert 'missing claim aud' in exc.value.message
@@ -142,8 +142,8 @@ class TestOAuthServiceVerifyJWTBearer(object):
         tok = self.jwt_token(claims, authclient.secret)
 
         with pytest.raises(OAuthTokenError) as exc:
-            svc.verify_jwt_bearer(assertion=tok,
-                                  grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer')
+            svc.verify_token_request(dict(assertion=tok,
+                                          grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer'))
 
         assert exc.value.type == 'invalid_grant'
         assert 'invalid JWT audience' in exc.value.message
@@ -153,8 +153,8 @@ class TestOAuthServiceVerifyJWTBearer(object):
         tok = self.jwt_token(claims, authclient.secret)
 
         with pytest.raises(OAuthTokenError) as exc:
-            svc.verify_jwt_bearer(assertion=tok,
-                                  grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer')
+            svc.verify_token_request(dict(assertion=tok,
+                                          grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer'))
 
         assert exc.value.type == 'invalid_grant'
         assert 'not before is in the future' in exc.value.message
@@ -164,8 +164,8 @@ class TestOAuthServiceVerifyJWTBearer(object):
         tok = self.jwt_token(claims, authclient.secret)
 
         with pytest.raises(OAuthTokenError) as exc:
-            svc.verify_jwt_bearer(assertion=tok,
-                                  grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer')
+            svc.verify_token_request(dict(assertion=tok,
+                                          grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer'))
 
         assert exc.value.type == 'invalid_grant'
         assert 'token is expired' in exc.value.message
@@ -175,8 +175,8 @@ class TestOAuthServiceVerifyJWTBearer(object):
         tok = self.jwt_token(claims, authclient.secret)
 
         with pytest.raises(OAuthTokenError) as exc:
-            svc.verify_jwt_bearer(assertion=tok,
-                                  grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer')
+            svc.verify_token_request(dict(assertion=tok,
+                                          grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer'))
 
         assert exc.value.type == 'invalid_grant'
         assert 'issued at is in the future' in exc.value.message
@@ -186,8 +186,8 @@ class TestOAuthServiceVerifyJWTBearer(object):
         tok = self.jwt_token(claims, authclient.secret)
 
         with pytest.raises(OAuthTokenError) as exc:
-            svc.verify_jwt_bearer(assertion=tok,
-                                  grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer')
+            svc.verify_token_request(dict(assertion=tok,
+                                          grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer'))
 
         assert exc.value.type == 'invalid_grant'
         assert 'subject is missing' in exc.value.message
@@ -197,8 +197,8 @@ class TestOAuthServiceVerifyJWTBearer(object):
         tok = self.jwt_token(claims, authclient.secret)
 
         with pytest.raises(OAuthTokenError) as exc:
-            svc.verify_jwt_bearer(assertion=tok,
-                                  grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer')
+            svc.verify_token_request(dict(assertion=tok,
+                                          grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer'))
 
         assert exc.value.type == 'invalid_grant'
         assert 'subject is missing' in exc.value.message
@@ -209,8 +209,8 @@ class TestOAuthServiceVerifyJWTBearer(object):
         tok = self.jwt_token(claims, authclient.secret)
 
         with pytest.raises(OAuthTokenError) as exc:
-            svc.verify_jwt_bearer(assertion=tok,
-                                  grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer')
+            svc.verify_token_request(dict(assertion=tok,
+                                          grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer'))
 
         assert exc.value.type == 'invalid_grant'
         assert 'user with userid described in subject could not be found' in exc.value.message
@@ -223,8 +223,8 @@ class TestOAuthServiceVerifyJWTBearer(object):
         tok = self.jwt_token(claims, authclient.secret)
 
         with pytest.raises(OAuthTokenError) as exc:
-            svc.verify_jwt_bearer(assertion=tok,
-                                  grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer')
+            svc.verify_token_request(dict(assertion=tok,
+                                          grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer'))
 
         assert exc.value.type == 'invalid_grant'
         assert 'authenticated client and JWT subject authorities do not match' in exc.value

--- a/tests/h/services/oauth_test.py
+++ b/tests/h/services/oauth_test.py
@@ -19,212 +19,192 @@ from h._compat import text_type
 class TestOAuthServiceVerifyJWTBearerRequest(object):
     """Test for verifying jwt-bearer requests with OAuthService."""
 
-    def test_it_returns_the_user_and_authclient_from_the_jwt_token(self, svc, claims, authclient, user):
+    def test_it_returns_the_user_and_authclient_from_the_jwt_token(self, svc, authclient, jwt_bearer_body, user):
         expected_user = user
-        tok = self.jwt_token(claims, authclient.secret)
 
-        result = svc.verify_token_request(dict(assertion=tok,
-                                               grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer'))
+        result = svc.verify_token_request(jwt_bearer_body)
 
         assert (expected_user, authclient) == result
 
-    def test_missing_grant_type(self, svc):
+    def test_missing_grant_type(self, svc, jwt_bearer_body):
+        del jwt_bearer_body['grant_type']
+
         with pytest.raises(OAuthTokenError) as exc:
-            svc.verify_token_request(dict(assertion='jwt-token',
-                                          grant_type=None))
+            svc.verify_token_request(jwt_bearer_body)
 
         assert exc.value.type == 'unsupported_grant_type'
         assert 'grant type is not supported' in exc.value.message
 
-    def test_unsupported_grant_type(self, svc):
+    def test_unsupported_grant_type(self, svc, jwt_bearer_body):
+        jwt_bearer_body['grant_type'] = 'authorization_code'
+
         with pytest.raises(OAuthTokenError) as exc:
-            svc.verify_token_request(dict(assertion='jwt-token',
-                                          grant_type='authorization_code'))
+            svc.verify_token_request(jwt_bearer_body)
 
         assert exc.value.type == 'unsupported_grant_type'
         assert 'grant type is not supported' in exc.value.message
 
-    def test_missing_assertion(self, svc):
+    def test_missing_assertion(self, svc, jwt_bearer_body):
+        del jwt_bearer_body['assertion']
+
         with pytest.raises(OAuthTokenError) as exc:
-            svc.verify_token_request(dict(assertion=None,
-                                          grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer'))
+            svc.verify_token_request(jwt_bearer_body)
 
         assert exc.value.type == 'invalid_request'
         assert 'assertion parameter is missing' in exc.value.message
 
-    def test_non_jwt_assertion(self, svc):
+    def test_non_jwt_assertion(self, svc, jwt_bearer_body):
+        jwt_bearer_body['assertion'] = 'bogus'
+
         with pytest.raises(OAuthTokenError) as exc:
-            svc.verify_token_request(dict(assertion='bogus',
-                                          grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer'))
+            svc.verify_token_request(jwt_bearer_body)
 
         assert exc.value.type == 'invalid_grant'
         assert 'invalid JWT signature' in exc.value.message
 
-    def test_missing_jwt_issuer(self, svc, claims, authclient):
+    def test_missing_jwt_issuer(self, svc, claims, authclient, jwt_bearer_body):
         del claims['iss']
-        tok = self.jwt_token(claims, authclient.secret)
+        jwt_bearer_body['assertion'] = self.jwt_token(claims, authclient.secret)
 
         with pytest.raises(OAuthTokenError) as exc:
-            svc.verify_token_request(dict(assertion=tok,
-                                          grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer'))
+            svc.verify_token_request(jwt_bearer_body)
 
         assert exc.value.type == 'invalid_grant'
         assert 'issuer is missing' in exc.value.message
 
-    def test_empty_jwt_issuer(self, svc, claims, authclient):
+    def test_empty_jwt_issuer(self, svc, claims, authclient, jwt_bearer_body):
         claims['iss'] = ''
-        tok = self.jwt_token(claims, authclient.secret)
+        jwt_bearer_body['assertion'] = self.jwt_token(claims, authclient.secret)
 
         with pytest.raises(OAuthTokenError) as exc:
-            svc.verify_token_request(dict(assertion=tok,
-                                          grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer'))
+            svc.verify_token_request(jwt_bearer_body)
 
         assert exc.value.type == 'invalid_grant'
         assert 'issuer is missing' in exc.value.message
 
-    def test_missing_authclient_with_given_jwt_issuer(self, svc, claims, authclient, db_session):
+    def test_missing_authclient_with_given_jwt_issuer(self, svc, authclient, db_session, jwt_bearer_body):
         db_session.delete(authclient)
         db_session.flush()
 
-        tok = self.jwt_token(claims, authclient.secret)
-
         with pytest.raises(OAuthTokenError) as exc:
-            svc.verify_token_request(dict(assertion=tok,
-                                          grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer'))
+            svc.verify_token_request(jwt_bearer_body)
 
         assert exc.value.type == 'invalid_grant'
         assert 'issuer is invalid' in exc.value.message
 
-    def test_non_uuid_jwt_issuer(self, svc, claims, authclient, db_session):
+    def test_non_uuid_jwt_issuer(self, svc, claims, authclient, jwt_bearer_body):
         claims['iss'] = 'bogus'
-        tok = self.jwt_token(claims, authclient.secret)
+        jwt_bearer_body['assertion'] = self.jwt_token(claims, authclient.secret)
 
         with pytest.raises(OAuthTokenError) as exc:
-            svc.verify_token_request(dict(assertion=tok,
-                                          grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer'))
+            svc.verify_token_request(jwt_bearer_body)
 
         assert exc.value.type == 'invalid_grant'
         assert 'issuer is invalid' in exc.value.message
 
-    def test_signed_with_different_secret(self, svc, claims):
-        tok = self.jwt_token(claims, 'different-secret')
+    def test_signed_with_different_secret(self, svc, claims, jwt_bearer_body):
+        jwt_bearer_body['assertion'] = self.jwt_token(claims, 'different-secret')
 
         with pytest.raises(OAuthTokenError) as exc:
-            svc.verify_token_request(dict(assertion=tok,
-                                          grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer'))
+            svc.verify_token_request(jwt_bearer_body)
 
         assert exc.value.type == 'invalid_grant'
         assert 'invalid JWT signature' in exc.value.message
 
-    def test_signed_with_unsupported_algorithm(self, svc, claims, authclient):
-        tok = self.jwt_token(claims, authclient.secret, algorithm='HS512')
+    def test_signed_with_unsupported_algorithm(self, svc, claims, authclient, jwt_bearer_body):
+        jwt_bearer_body['assertion'] = self.jwt_token(claims, authclient.secret, algorithm='HS512')
 
         with pytest.raises(OAuthTokenError) as exc:
-            svc.verify_token_request(dict(assertion=tok,
-                                          grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer'))
+            svc.verify_token_request(jwt_bearer_body)
 
         assert exc.value.type == 'invalid_grant'
         assert 'invalid JWT signature algorithm' in exc.value.message
 
-    def test_missing_jwt_audience(self, svc, claims, authclient):
+    def test_missing_jwt_audience(self, svc, claims, authclient, jwt_bearer_body):
         del claims['aud']
-        tok = self.jwt_token(claims, authclient.secret)
+        jwt_bearer_body['assertion'] = self.jwt_token(claims, authclient.secret)
 
         with pytest.raises(OAuthTokenError) as exc:
-            svc.verify_token_request(dict(assertion=tok,
-                                          grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer'))
+            svc.verify_token_request(jwt_bearer_body)
 
         assert exc.value.type == 'invalid_grant'
         assert 'missing claim aud' in exc.value.message
 
-    def test_invalid_jwt_audience(self, svc, claims, authclient):
+    def test_invalid_jwt_audience(self, svc, claims, authclient, jwt_bearer_body):
         claims['aud'] = 'foobar.org'
-        tok = self.jwt_token(claims, authclient.secret)
+        jwt_bearer_body['assertion'] = self.jwt_token(claims, authclient.secret)
 
         with pytest.raises(OAuthTokenError) as exc:
-            svc.verify_token_request(dict(assertion=tok,
-                                          grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer'))
+            svc.verify_token_request(jwt_bearer_body)
 
         assert exc.value.type == 'invalid_grant'
         assert 'invalid JWT audience' in exc.value.message
 
-    def test_jwt_not_before_in_future(self, svc, claims, authclient):
+    def test_jwt_not_before_in_future(self, svc, claims, authclient, jwt_bearer_body):
         claims['nbf'] = self.epoch(delta=timedelta(minutes=5))
-        tok = self.jwt_token(claims, authclient.secret)
+        jwt_bearer_body['assertion'] = self.jwt_token(claims, authclient.secret)
 
         with pytest.raises(OAuthTokenError) as exc:
-            svc.verify_token_request(dict(assertion=tok,
-                                          grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer'))
+            svc.verify_token_request(jwt_bearer_body)
 
         assert exc.value.type == 'invalid_grant'
         assert 'not before is in the future' in exc.value.message
 
-    def test_jwt_expires_with_leeway_in_the_past(self, svc, claims, authclient):
+    def test_jwt_expires_with_leeway_in_the_past(self, svc, claims, authclient, jwt_bearer_body):
         claims['exp'] = self.epoch(delta=timedelta(minutes=-2))
-        tok = self.jwt_token(claims, authclient.secret)
+        jwt_bearer_body['assertion'] = self.jwt_token(claims, authclient.secret)
 
         with pytest.raises(OAuthTokenError) as exc:
-            svc.verify_token_request(dict(assertion=tok,
-                                          grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer'))
+            svc.verify_token_request(jwt_bearer_body)
 
         assert exc.value.type == 'invalid_grant'
         assert 'token is expired' in exc.value.message
 
-    def test_jwt_issued_at_in_the_future(self, svc, claims, authclient):
+    def test_jwt_issued_at_in_the_future(self, svc, claims, authclient, jwt_bearer_body):
         claims['iat'] = self.epoch(delta=timedelta(minutes=2))
-        tok = self.jwt_token(claims, authclient.secret)
+        jwt_bearer_body['assertion'] = self.jwt_token(claims, authclient.secret)
 
         with pytest.raises(OAuthTokenError) as exc:
-            svc.verify_token_request(dict(assertion=tok,
-                                          grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer'))
+            svc.verify_token_request(jwt_bearer_body)
 
         assert exc.value.type == 'invalid_grant'
         assert 'issued at is in the future' in exc.value.message
 
-    def test_missing_jwt_subject(self, svc, claims, authclient):
+    def test_missing_jwt_subject(self, svc, claims, authclient, jwt_bearer_body):
         del claims['sub']
-        tok = self.jwt_token(claims, authclient.secret)
+        jwt_bearer_body['assertion'] = self.jwt_token(claims, authclient.secret)
 
         with pytest.raises(OAuthTokenError) as exc:
-            svc.verify_token_request(dict(assertion=tok,
-                                          grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer'))
+            svc.verify_token_request(jwt_bearer_body)
 
         assert exc.value.type == 'invalid_grant'
         assert 'subject is missing' in exc.value.message
 
-    def test_empty_jwt_subject(self, svc, claims, authclient):
+    def test_empty_jwt_subject(self, svc, claims, authclient, jwt_bearer_body):
         claims['sub'] = ''
-        tok = self.jwt_token(claims, authclient.secret)
+        jwt_bearer_body['assertion'] = self.jwt_token(claims, authclient.secret)
 
         with pytest.raises(OAuthTokenError) as exc:
-            svc.verify_token_request(dict(assertion=tok,
-                                          grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer'))
+            svc.verify_token_request(jwt_bearer_body)
 
         assert exc.value.type == 'invalid_grant'
         assert 'subject is missing' in exc.value.message
 
-    def test_user_not_found(self, svc, claims, authclient, user_service):
+    def test_user_not_found(self, svc, user_service, jwt_bearer_body):
         user_service.fetch.return_value = None
 
-        tok = self.jwt_token(claims, authclient.secret)
-
         with pytest.raises(OAuthTokenError) as exc:
-            svc.verify_token_request(dict(assertion=tok,
-                                          grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer'))
+            svc.verify_token_request(jwt_bearer_body)
 
         assert exc.value.type == 'invalid_grant'
         assert 'user with userid described in subject could not be found' in exc.value.message
 
-    def test_it_raises_when_client_authority_does_not_match_userid(self, svc, db_session, claims, authclient, user):
+    def test_it_raises_when_client_authority_does_not_match_userid(self, svc, db_session, user, jwt_bearer_body):
         user.authority = 'bogus-partner.org'
         db_session.flush()
 
-        claims['sub'] = user.userid
-        tok = self.jwt_token(claims, authclient.secret)
-
         with pytest.raises(OAuthTokenError) as exc:
-            svc.verify_token_request(dict(assertion=tok,
-                                          grant_type='urn:ietf:params:oauth:grant-type:jwt-bearer'))
+            svc.verify_token_request(jwt_bearer_body)
 
         assert exc.value.type == 'invalid_grant'
         assert 'authenticated client and JWT subject authorities do not match' in exc.value
@@ -256,6 +236,25 @@ class TestOAuthServiceVerifyJWTBearerRequest(object):
         user = factories.User.build(authority=authclient.authority)
         user_service.fetch.return_value = user
         return user
+
+    @pytest.fixture
+    def jwt_bearer_body(self, claims, authclient):
+        """
+        Return the body of an OAuth jwt-bearer request.
+
+        The JWT assertion in this request body contains the claims from
+        the claims fixture (including the userid from the user fixture
+        and the authclient from the authclient fixture) signed using the
+        authclient secret from the authclient fixture.
+
+        The request body also contains the correct grant_type for a
+        jwt-bearer request.
+
+        """
+        return {
+         'assertion': self.jwt_token(claims, authclient.secret),
+         'grant_type': 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+        }
 
     def jwt_token(self, claims, secret, algorithm='HS256'):
         return text_type(jwt.encode(claims, secret, algorithm=algorithm))

--- a/tests/h/views/api_auth_test.py
+++ b/tests/h/views/api_auth_test.py
@@ -15,13 +15,13 @@ from h.views import api_auth as views
 
 @pytest.mark.usefixtures('user_service', 'oauth_service')
 class TestAccessToken(object):
-    def test_it_verifies_the_jwt_bearer(self, pyramid_request, oauth_service):
+    def test_it_verifies_the_token(self, pyramid_request, oauth_service):
         pyramid_request.POST = {'assertion': 'the-assertion', 'grant_type': 'the-grant-type'}
 
         views.access_token(pyramid_request)
 
-        oauth_service.verify_jwt_bearer.assert_called_once_with(
-            assertion='the-assertion', grant_type='the-grant-type'
+        oauth_service.verify_token_request.assert_called_once_with(
+            pyramid_request.POST
         )
 
     def test_it_creates_a_token(self, pyramid_request, oauth_service):
@@ -57,7 +57,7 @@ class TestAccessToken(object):
     @pytest.fixture
     def oauth_service(self, pyramid_config, pyramid_request, token):
         svc = mock.Mock(spec_set=oauth_service_factory(None, pyramid_request))
-        svc.verify_jwt_bearer.return_value = (mock.sentinel.user, mock.sentinel.authclient)
+        svc.verify_token_request.return_value = (mock.sentinel.user, mock.sentinel.authclient)
         svc.create_token.return_value = token
         pyramid_config.register_service(svc, name='oauth')
         return svc


### PR DESCRIPTION
This pr adds support for getting a new access token by using the refresh_token that came with a not-yet-expired access token:

```
POST /api/token
grant_type=refresh_token&refresh_token=***
```

Using a refresh token does not expire or do anything else to the old access token, which will continue to work (until it expires). A follow-up PR could do something here.

* Small OAuthService refactor to make way for refresh tokens
* Add verifying refresh_token requests, as well as the existing jwt-bearer requests, to OAuthService. The /api/token view code doesn't need to change
* Some deduplication of test boilerplate
* Added functional tests, to prove to myself that getting and using access tokens and refresh tokens actually works. This is probably a good thing to have a few functional tests for.

Details in the commit messages.