### PR TITLE
Query parameter token auth for WebSocket clients

### DIFF
--- a/conf/development-websocket.ini
+++ b/conf/development-websocket.ini
@@ -8,6 +8,7 @@ origins:
 # Use gevent-compatible transport for the Sentry client
 raven.transport: gevent
 
+h.client_secret: nosuchsecret
 secret_key: notverysecretafterall
 
 # SQLAlchemy configuration -- See SQLAlchemy documentation

--- a/h/auth/policy.py
+++ b/h/auth/policy.py
@@ -78,7 +78,12 @@ class TokenAuthenticationPolicy(CallbackAuthenticationPolicy):
         :returns: the userid authenticated for the passed request or None
         :rtype: unicode or None
         """
-        token_str = getattr(request, 'auth_token', None)
+        token_str = None
+        if _is_ws_request(request):
+            token_str = request.GET.get('access_token', None)
+        if token_str is None:
+            token_str = getattr(request, 'auth_token', None)
+
         if token_str is None:
             return None
 
@@ -93,3 +98,7 @@ class TokenAuthenticationPolicy(CallbackAuthenticationPolicy):
 def _is_api_request(request):
     return (request.path.startswith('/api') and
             request.path not in ['/api/token', '/api/badge'])
+
+
+def _is_ws_request(request):
+    return request.path == '/ws'

--- a/h/auth/policy.py
+++ b/h/auth/policy.py
@@ -78,8 +78,13 @@ class TokenAuthenticationPolicy(CallbackAuthenticationPolicy):
         :returns: the userid authenticated for the passed request or None
         :rtype: unicode or None
         """
-        token = getattr(request, 'auth_token', None)
-        if token is None or not token.is_valid():
+        token_str = getattr(request, 'auth_token', None)
+        if token_str is None:
+            return None
+
+        svc = request.find_service(name='auth_token')
+        token = svc.validate(token_str)
+        if token is None:
             return None
 
         return token.userid

--- a/h/auth/tokens.py
+++ b/h/auth/tokens.py
@@ -6,7 +6,6 @@ import jwt
 from zope.interface import implementer
 
 from h._compat import text_type
-from h import models
 from h.auth.interfaces import IAuthenticationToken
 
 
@@ -122,20 +121,4 @@ def auth_token(request):
     if not token:
         return None
 
-    token_model = (request.db.query(models.Token)
-                   .filter_by(value=token)
-                   .one_or_none())
-    if token_model is not None:
-        return Token(token_model)
-
-    # If we've got this far it's possible the token is a legacy client JWT.
-    return _maybe_jwt(token, request)
-
-
-def _maybe_jwt(token, request):
-    try:
-        return LegacyClientJWT(token,
-                               key=request.registry.settings['h.client_secret'],
-                               audience=request.host_url)
-    except jwt.InvalidTokenError:
-        return None
+    return token

--- a/h/auth/tokens.py
+++ b/h/auth/tokens.py
@@ -44,10 +44,9 @@ class LegacyClientJWT(object):
     Exposes the standard "auth token" interface on top of legacy tokens.
     """
 
-    def __init__(self, body, key, audience=None, leeway=240):
+    def __init__(self, body, key, leeway=240):
         self.payload = jwt.decode(body,
                                   key=key,
-                                  audience=audience,
                                   leeway=leeway,
                                   algorithms=['HS256'])
 
@@ -86,7 +85,6 @@ def generate_jwt(request, expires_in):
 
     claims = {
         'iss': request.registry.settings['h.client_id'],
-        'aud': request.host_url,
         'sub': request.authenticated_userid,
         'exp': now + datetime.timedelta(seconds=expires_in),
         'iat': now,

--- a/h/services/__init__.py
+++ b/h/services/__init__.py
@@ -9,6 +9,7 @@ def includeme(config):
     config.register_service_factory('.annotation_stats.annotation_stats_factory', name='annotation_stats')
     config.register_service_factory('.auth_ticket.auth_ticket_service_factory',
                                     iface='pyramid_authsanity.interfaces.IAuthService')
+    config.register_service_factory('.auth_token.auth_token_service_factory', name='auth_token')
     config.register_service_factory('.group.groups_factory', name='group')
     config.register_service_factory('.nipsa.nipsa_factory', name='nipsa')
     config.register_service_factory('.oauth.oauth_service_factory', name='oauth')

--- a/h/services/auth_token.py
+++ b/h/services/auth_token.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import jwt
+
+from h import models
+from h.auth.tokens import LegacyClientJWT, Token
+
+
+class AuthTokenService(object):
+    def __init__(self, session, client_secret, host_url):
+        self._session = session
+        self._client_secret = client_secret
+        self._host_url = host_url
+
+        self._validate_cache = {}
+
+    def validate(self, token_str):
+        """
+        Load and validate a token.
+
+        This will return a token object implementing
+        ``h.auth.interfaces.IAuthenticationToken``, or ``None`` when the token
+        cannot be found, is not a legacy JWT token, or is not valid.
+
+        :param token_str: the token string
+        :type token_str: unicode
+
+        :returns: the token object, if found and valid, or ``None``.
+        """
+
+        if token_str in self._validate_cache:
+            return self._validate_cache[token_str]
+
+        token = self._fetch_token(token_str)
+        self._validate_cache[token_str] = token
+        if token is not None and token.is_valid():
+            return token
+        return None
+
+    def _fetch_token(self, token_str):
+        token_model = (self._session.query(models.Token)
+                       .filter_by(value=token_str)
+                       .one_or_none())
+        if token_model is not None:
+            token = Token(token_model)
+            return token
+
+        # If we've got this far it's possible the token is a legacy client JWT.
+        return _maybe_jwt(token_str, self._client_secret, self._host_url)
+
+
+def auth_token_service_factory(context, request):
+    client_secret = request.registry.settings['h.client_secret']
+    return AuthTokenService(request.db, client_secret, request.host_url)
+
+
+def _maybe_jwt(token, client_secret, audience):
+    try:
+        return LegacyClientJWT(token, key=client_secret, audience=audience)
+    except jwt.InvalidTokenError:
+        return None

--- a/h/services/auth_token.py
+++ b/h/services/auth_token.py
@@ -9,10 +9,9 @@ from h.auth.tokens import LegacyClientJWT, Token
 
 
 class AuthTokenService(object):
-    def __init__(self, session, client_secret, host_url):
+    def __init__(self, session, client_secret):
         self._session = session
         self._client_secret = client_secret
-        self._host_url = host_url
 
         self._validate_cache = {}
 
@@ -48,16 +47,16 @@ class AuthTokenService(object):
             return token
 
         # If we've got this far it's possible the token is a legacy client JWT.
-        return _maybe_jwt(token_str, self._client_secret, self._host_url)
+        return _maybe_jwt(token_str, self._client_secret)
 
 
 def auth_token_service_factory(context, request):
     client_secret = request.registry.settings['h.client_secret']
-    return AuthTokenService(request.db, client_secret, request.host_url)
+    return AuthTokenService(request.db, client_secret)
 
 
-def _maybe_jwt(token, client_secret, audience):
+def _maybe_jwt(token, client_secret):
     try:
-        return LegacyClientJWT(token, key=client_secret, audience=audience)
+        return LegacyClientJWT(token, key=client_secret)
     except jwt.InvalidTokenError:
         return None

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -13,6 +13,7 @@ TEST_SETTINGS = {
     'es.index': 'hypothesis-test',
     'h.app_url': 'http://example.com',
     'h.auth_domain': 'example.com',
+    'h.client_secret': 'notsosecret',
     'pyramid.debug_all': True,
     'sqlalchemy.url': os.environ.get('TEST_DATABASE_URL',
                                      'postgresql://postgres@localhost/htest')

--- a/tests/h/auth/policy_test.py
+++ b/tests/h/auth/policy_test.py
@@ -108,6 +108,7 @@ class TestAuthenticationPolicy(object):
         assert result == self.api_policy.forget.return_value
 
 
+@pytest.mark.usefixtures('token_service')
 class TestTokenAuthenticationPolicy(object):
     def test_remember_does_nothing(self, pyramid_request):
         policy = TokenAuthenticationPolicy()
@@ -124,38 +125,38 @@ class TestTokenAuthenticationPolicy(object):
 
         assert policy.unauthenticated_userid(pyramid_request) is None
 
-    def test_unauthenticated_userid_returns_userid_from_token(self, fake_token, pyramid_request):
+    def test_unauthenticated_userid_returns_userid_from_token(self, pyramid_request):
         policy = TokenAuthenticationPolicy()
-        pyramid_request.auth_token = fake_token
+        pyramid_request.auth_token = 'valid123'
 
         result = policy.unauthenticated_userid(pyramid_request)
 
         assert result == 'acct:foo@example.com'
 
-    def test_unauthenticated_userid_returns_none_if_token_invalid(self, pyramid_request):
+    def test_unauthenticated_userid_returns_none_if_token_invalid(self, pyramid_request, token_service):
         policy = TokenAuthenticationPolicy()
-        token = DummyToken(valid=False)
-        pyramid_request.auth_token = token
+        token_service.validate.return_value = None
+        pyramid_request.auth_token = 'abcd123'
 
         result = policy.unauthenticated_userid(pyramid_request)
 
         assert result is None
 
-    def test_authenticated_userid_uses_callback(self, fake_token, pyramid_request):
+    def test_authenticated_userid_uses_callback(self, pyramid_request):
         def callback(userid, request):
             return None
         policy = TokenAuthenticationPolicy(callback=callback)
-        pyramid_request.auth_token = fake_token
+        pyramid_request.auth_token = 'valid123'
 
         result = policy.authenticated_userid(pyramid_request)
 
         assert result is None
 
-    def test_effective_principals_uses_callback(self, fake_token, pyramid_request):
+    def test_effective_principals_uses_callback(self, pyramid_request):
         def callback(userid, request):
             return [userid + '.foo', 'group:donkeys']
         policy = TokenAuthenticationPolicy(callback=callback)
-        pyramid_request.auth_token = fake_token
+        pyramid_request.auth_token = 'valid123'
 
         result = policy.effective_principals(pyramid_request)
 
@@ -166,6 +167,16 @@ class TestTokenAuthenticationPolicy(object):
     @pytest.fixture
     def fake_token(self):
         return DummyToken()
+
+    @pytest.fixture
+    def token_service(self, pyramid_config, fake_token):
+        def validate(token_str):
+            if token_str == 'valid123':
+                return fake_token
+            return None
+        svc = mock.Mock(validate=mock.Mock(side_effect=validate))
+        pyramid_config.register_service(svc, name='auth_token')
+        return svc
 
 
 class DummyToken(object):

--- a/tests/h/auth/policy_test.py
+++ b/tests/h/auth/policy_test.py
@@ -142,6 +142,42 @@ class TestTokenAuthenticationPolicy(object):
 
         assert result is None
 
+    def test_unauthenticated_userid_returns_userid_from_query_params_token(self, pyramid_request):
+        """When the path is `/ws` then we look into the query string parameters as well."""
+
+        policy = TokenAuthenticationPolicy()
+        pyramid_request.GET['access_token'] = 'valid123'
+        pyramid_request.path = '/ws'
+
+        result = policy.unauthenticated_userid(pyramid_request)
+
+        assert result == 'acct:foo@example.com'
+
+    def test_unauthenticated_userid_returns_none_for_invalid_query_param_token(self, pyramid_request):
+        """When the path is `/ws` but the token is invalid, it should still return None."""
+
+        policy = TokenAuthenticationPolicy()
+        pyramid_request.GET['access_token'] = 'expired'
+        pyramid_request.path = '/ws'
+
+        result = policy.unauthenticated_userid(pyramid_request)
+
+        assert result is None
+
+    def test_unauthenticated_userid_skips_query_param_for_non_ws_requests(self, pyramid_request):
+        """
+        When we have a valid token in the `access_token` query param, but it's
+        not a request to /ws, then we should ignore this access token.
+        """
+
+        policy = TokenAuthenticationPolicy()
+        pyramid_request.GET['access_token'] = 'valid123'
+        pyramid_request.path = '/api'
+
+        result = policy.unauthenticated_userid(pyramid_request)
+
+        assert result is None
+
     def test_authenticated_userid_uses_callback(self, pyramid_request):
         def callback(userid, request):
             return None

--- a/tests/h/auth/tokens_test.py
+++ b/tests/h/auth/tokens_test.py
@@ -35,100 +35,79 @@ class TestToken(object):
 
 VALID_TOKEN_EXAMPLES = [
     # Valid
-    lambda a, k: jwt.encode({'aud': a, 'exp': _seconds_from_now(3600)},
-                            key=k),
+    lambda k: jwt.encode({'exp': _seconds_from_now(3600)},
+                         key=k),
 
     # Expired, but within leeway
-    lambda a, k: jwt.encode({'aud': a, 'exp': _seconds_from_now(-120)},
-                            key=k),
+    lambda k: jwt.encode({'exp': _seconds_from_now(-120)},
+                         key=k),
 ]
 
 INVALID_TOKEN_EXAMPLES = [
     # Expired 1 hour ago
-    lambda a, k: jwt.encode({'aud': a, 'exp': _seconds_from_now(-3600)},
-                            key=k),
+    lambda k: jwt.encode({'exp': _seconds_from_now(-3600)},
+                         key=k),
 
     # Issued in the future
-    lambda a, k: jwt.encode({'aud': a,
-                             'exp': _seconds_from_now(3600),
-                             'iat': _seconds_from_now(1800)},
-                            key=k),
-
-    # Incorrect audience
-    lambda a, k: jwt.encode({'aud': 'https://bar.com',
-                             'exp': _seconds_from_now(3600)},
-                            key=k),
+    lambda k: jwt.encode({'exp': _seconds_from_now(3600),
+                          'iat': _seconds_from_now(1800)},
+                         key=k),
 
     # Incorrect encoding key
-    lambda a, k: jwt.encode({'aud': a, 'exp': _seconds_from_now(3600)},
-                            key='somethingelse'),
+    lambda k: jwt.encode({'exp': _seconds_from_now(3600)},
+                         key='somethingelse'),
 ]
 
 
 class TestLegacyClientJWT(object):
     @pytest.mark.parametrize('get_token', VALID_TOKEN_EXAMPLES)
     def test_ok_for_valid_jwt(self, get_token):
-        token = get_token('http://example.com', 'secrets!')
+        token = get_token('secrets!')
 
-        result = tokens.LegacyClientJWT(token,
-                                        audience='http://example.com',
-                                        key='secrets!')
+        result = tokens.LegacyClientJWT(token, key='secrets!')
 
         assert isinstance(result, tokens.LegacyClientJWT)
 
     @pytest.mark.parametrize('get_token', INVALID_TOKEN_EXAMPLES)
     def test_raises_for_invalid_jwt(self, get_token):
-        token = get_token('http://example.com', 'secrets!')
+        token = get_token('secrets!')
 
         with pytest.raises(jwt.InvalidTokenError):
             tokens.LegacyClientJWT(token,
-                                   audience='http://example.com',
                                    key='secrets!')
 
     def test_payload(self):
-        payload = {'aud': 'http://foo.com',
-                   'exp': _seconds_from_now(3600),
+        payload = {'exp': _seconds_from_now(3600),
                    'sub': 'foobar'}
         token = jwt.encode(payload, key='s3cr37')
 
-        result = tokens.LegacyClientJWT(token,
-                                        audience='http://foo.com',
-                                        key='s3cr37')
+        result = tokens.LegacyClientJWT(token, key='s3cr37')
 
         assert result.payload == payload
 
     def test_always_valid(self):
-        payload = {'aud': 'http://foo.com',
-                   'exp': _seconds_from_now(3600),
+        payload = {'exp': _seconds_from_now(3600),
                    'sub': 'foobar'}
         token = jwt.encode(payload, key='s3cr37')
 
-        result = tokens.LegacyClientJWT(token,
-                                        audience='http://foo.com',
-                                        key='s3cr37')
+        result = tokens.LegacyClientJWT(token, key='s3cr37')
 
         assert result.is_valid()
 
     def test_userid_gets_payload_sub(self):
-        payload = {'aud': 'http://foo.com',
-                   'exp': _seconds_from_now(3600),
+        payload = {'exp': _seconds_from_now(3600),
                    'sub': 'foobar'}
         token = jwt.encode(payload, key='s3cr37')
 
-        result = tokens.LegacyClientJWT(token,
-                                        audience='http://foo.com',
-                                        key='s3cr37')
+        result = tokens.LegacyClientJWT(token, key='s3cr37')
 
         assert result.userid == 'foobar'
 
     def test_userid_none_if_sub_missing(self):
-        payload = {'aud': 'http://foo.com',
-                   'exp': _seconds_from_now(3600)}
+        payload = {'exp': _seconds_from_now(3600)}
         token = jwt.encode(payload, key='s3cr37')
 
-        result = tokens.LegacyClientJWT(token,
-                                        audience='http://foo.com',
-                                        key='s3cr37')
+        result = tokens.LegacyClientJWT(token, key='s3cr37')
 
         assert result.userid is None
 
@@ -145,8 +124,6 @@ def test_generate_jwt_calls_encode(jwt_, pyramid_config, pyramid_request):
     after = datetime.datetime.utcnow() + datetime.timedelta(seconds=3600)
     assert before < jwt_.encode.call_args[0][0]['exp'] < after, (
         "It should encode the expiration time as 'exp'")
-    assert jwt_.encode.call_args[0][0]['aud'] == pyramid_request.host_url, (
-        "It should encode request.host_url as 'aud'")
     assert jwt_.encode.call_args[1]['algorithm'] == 'HS256', (
         "It should pass the right algorithm to encode()")
 

--- a/tests/h/services/auth_token_test.py
+++ b/tests/h/services/auth_token_test.py
@@ -1,0 +1,108 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import datetime
+
+import jwt
+import mock
+import pytest
+
+from h.auth.tokens import LegacyClientJWT
+from h.services.auth_token import AuthTokenService
+from h.services.auth_token import auth_token_service_factory
+from h._compat import text_type
+
+
+class TestAuthTokenService(object):
+    def test_validate_returns_database_token(self, svc, factories):
+        token_model = factories.Token(expires=self.time(1))
+
+        result = svc.validate(token_model.value)
+
+        assert result.expires == token_model.expires
+        assert result.userid == token_model.userid
+
+    def test_validate_caches_database_token(self, svc, factories, db_session):
+        token_model = factories.Token(expires=self.time(1))
+
+        svc.validate(token_model.value)
+        db_session.delete(token_model)
+        result = svc.validate(token_model.value)
+
+        assert result is not None
+
+    def test_validate_returns_none_for_invalid_database_token(self, svc, factories):
+        token_model = factories.Token(expires=self.time(-1))
+
+        result = svc.validate(token_model.value)
+
+        assert result is None
+
+    def test_validate_returns_legacy_client_token(self, svc):
+        token = text_type(jwt.encode({'aud': 'http://example.com',
+                                      'exp': self.time(1)},
+                                     key='secret'))
+
+        result = svc.validate(token)
+
+        assert isinstance(result, LegacyClientJWT)
+
+    def test_validate_returns_none_for_invalid_legacy_client_token(self, svc):
+        token = text_type(jwt.encode({'aud': 'http://example.com',
+                                      'exp': self.time(-1)},
+                                     key='secret'))
+
+        result = svc.validate(token)
+
+        assert result is None
+
+    def test_validate_returns_none_for_non_existing_token(self, svc):
+        result = svc.validate('abcde123')
+
+        assert result is None
+
+    @pytest.fixture
+    def svc(self, db_session):
+        return AuthTokenService(db_session, 'secret', 'http://example.com')
+
+    def time(self, days_delta=0):
+        return datetime.datetime.utcnow() + datetime.timedelta(days=days_delta)
+
+
+@pytest.mark.usefixtures('pyramid_settings')
+class TestAuthTokenServiceFactory(object):
+    def test_it_returns_service(self, pyramid_request):
+        result = auth_token_service_factory(None, pyramid_request)
+
+        assert isinstance(result, AuthTokenService)
+
+    def test_it_passes_session(self, pyramid_request, mocked_service):
+        auth_token_service_factory(None, pyramid_request)
+
+        mocked_service.assert_called_once_with(pyramid_request.db,
+                                               mock.ANY,
+                                               mock.ANY)
+
+    def test_it_passes_client_secret(self, pyramid_request, mocked_service):
+        auth_token_service_factory(None, pyramid_request)
+
+        mocked_service.assert_called_once_with(mock.ANY,
+                                               'the-secret',
+                                               mock.ANY)
+
+    def test_it_passes_host_url(self, pyramid_request, mocked_service):
+        auth_token_service_factory(None, pyramid_request)
+
+        mocked_service.assert_called_once_with(mock.ANY,
+                                               mock.ANY,
+                                               pyramid_request.host_url)
+
+    @pytest.fixture
+    def pyramid_settings(self, pyramid_settings):
+        pyramid_settings['h.client_secret'] = 'the-secret'
+        return pyramid_settings
+
+    @pytest.fixture
+    def mocked_service(self, patch):
+        return patch('h.services.auth_token.AuthTokenService')

--- a/tests/h/services/auth_token_test.py
+++ b/tests/h/services/auth_token_test.py
@@ -40,18 +40,14 @@ class TestAuthTokenService(object):
         assert result is None
 
     def test_validate_returns_legacy_client_token(self, svc):
-        token = text_type(jwt.encode({'aud': 'http://example.com',
-                                      'exp': self.time(1)},
-                                     key='secret'))
+        token = text_type(jwt.encode({'exp': self.time(1)}, key='secret'))
 
         result = svc.validate(token)
 
         assert isinstance(result, LegacyClientJWT)
 
     def test_validate_returns_none_for_invalid_legacy_client_token(self, svc):
-        token = text_type(jwt.encode({'aud': 'http://example.com',
-                                      'exp': self.time(-1)},
-                                     key='secret'))
+        token = text_type(jwt.encode({'exp': self.time(-1)}, key='secret'))
 
         result = svc.validate(token)
 
@@ -64,7 +60,7 @@ class TestAuthTokenService(object):
 
     @pytest.fixture
     def svc(self, db_session):
-        return AuthTokenService(db_session, 'secret', 'http://example.com')
+        return AuthTokenService(db_session, 'secret')
 
     def time(self, days_delta=0):
         return datetime.datetime.utcnow() + datetime.timedelta(days=days_delta)
@@ -80,23 +76,12 @@ class TestAuthTokenServiceFactory(object):
     def test_it_passes_session(self, pyramid_request, mocked_service):
         auth_token_service_factory(None, pyramid_request)
 
-        mocked_service.assert_called_once_with(pyramid_request.db,
-                                               mock.ANY,
-                                               mock.ANY)
+        mocked_service.assert_called_once_with(pyramid_request.db, mock.ANY)
 
     def test_it_passes_client_secret(self, pyramid_request, mocked_service):
         auth_token_service_factory(None, pyramid_request)
 
-        mocked_service.assert_called_once_with(mock.ANY,
-                                               'the-secret',
-                                               mock.ANY)
-
-    def test_it_passes_host_url(self, pyramid_request, mocked_service):
-        auth_token_service_factory(None, pyramid_request)
-
-        mocked_service.assert_called_once_with(mock.ANY,
-                                               mock.ANY,
-                                               pyramid_request.host_url)
+        mocked_service.assert_called_once_with(mock.ANY, 'the-secret')
 
     @pytest.fixture
     def pyramid_settings(self, pyramid_settings):


### PR DESCRIPTION
This will add support for authenticating websocket connections with a query string parameter, e.g. wss://hypothes.is/ws?access_token={token}. This token can be a new OAuth 2 token, a developer token, or a legacy client JWT token.

After some more research, @robertknight found out that HTTP basic auth support for WebSockets is not fully supported by all browsers, so this supersedes #4330.

I had to move quite a bit of things around for a nice implementation of this, as we can't import any models in the Python files that contain the authentication policies.