### PR TITLE
Don't return expires_in if token doesn't expire

### DIFF
--- a/h/views/api_auth.py
+++ b/h/views/api_auth.py
@@ -19,8 +19,10 @@ def access_token(request):
     response = {
         'access_token': token.value,
         'token_type': 'bearer',
-        'expires_in': TOKEN_TTL.total_seconds(),
     }
+
+    if token.expires:
+        response['expires_in'] = TOKEN_TTL.total_seconds()
 
     if token.refresh_token:
         response['refresh_token'] = token.refresh_token


### PR DESCRIPTION
This doesn't change how expires_in is calculated but just omits it for tokens that don't expire.