### PR TITLE
Revert "Remove unused group leave view"

### DIFF
--- a/h/views/groups.py
+++ b/h/views/groups.py
@@ -124,10 +124,13 @@ def read_noslug(group, request):
     check_slug(group, request)
 
 
+# FIXME: This view is only used by the client, it needs to be refactored
+#        into a proper API endpoint under the /api namespace.
 @view_config(route_name='group_leave',
              request_method='POST',
              effective_principals=security.Authenticated)
 def leave(group, request):
+    """Route for leaving a group. Used by the Hypothesis client."""
     groups_service = request.find_service(name='group')
     groups_service.member_leave(group, request.authenticated_userid)
 

--- a/h/views/groups.py
+++ b/h/views/groups.py
@@ -124,6 +124,16 @@ def read_noslug(group, request):
     check_slug(group, request)
 
 
+@view_config(route_name='group_leave',
+             request_method='POST',
+             effective_principals=security.Authenticated)
+def leave(group, request):
+    groups_service = request.find_service(name='group')
+    groups_service.member_leave(group, request.authenticated_userid)
+
+    return httpexceptions.HTTPNoContent()
+
+
 def check_slug(group, request):
     """Redirect if the request slug does not match that of the group."""
     slug = request.matchdict.get('slug')


### PR DESCRIPTION
This reverts commit eb0baaa39721e9aef7c88ce6225284486fb3633b.

This view is still used by the client.

Fixes hypothesis/client#203

----

To avoid this confusion in future, I suggest we should provide a proper API-based method for leaving a group. I'm restoring this route for the moment since existing clients in the wild depend on it.