### PR TITLE
Add API endpoint for updating user preferences

### DIFF
--- a/h/services/user.py
+++ b/h/services/user.py
@@ -7,6 +7,8 @@ import sqlalchemy
 from h.models import Annotation, User
 from h import util
 
+UPDATE_PREFS_ALLOWED_KEYS = set(['show_sidebar_tutorial'])
+
 
 class LoginError(Exception):
     pass
@@ -109,6 +111,15 @@ class UserService(object):
             return user
 
         return None
+
+    def update_preferences(self, user, **kwargs):
+        invalid_keys = set(kwargs.keys()) - UPDATE_PREFS_ALLOWED_KEYS
+        if invalid_keys:
+            keys = ', '.join(sorted(invalid_keys))
+            raise TypeError("settings with keys %s are not allowed" % keys)
+
+        if 'show_sidebar_tutorial' in kwargs:
+            user.sidebar_tutorial_dismissed = not kwargs['show_sidebar_tutorial']
 
 
 def user_service_factory(context, request):

--- a/h/views/api_profile.py
+++ b/h/views/api_profile.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 from pyramid import security
 
 from h import session as h_session
+from h.exceptions import APIError
 from memex.views import api_config
 
 
@@ -14,4 +15,21 @@ from memex.views import api_config
             link_name='profile.read',
             description="Fetch the user's profile")
 def profile(request):
+    return h_session.profile(request)
+
+
+@api_config(route_name='api.profile',
+            request_method='PATCH',
+            effective_principals=security.Authenticated,
+            link_name='profile.update',
+            description="Update a user's preferences")
+def update_preferences(request):
+    preferences = request.json_body.get('preferences', {})
+
+    svc = request.find_service(name='user')
+    try:
+        svc.update_preferences(request.authenticated_user, **preferences)
+    except TypeError as e:
+        raise APIError(e.message, status_code=400)
+
     return h_session.profile(request)

--- a/tests/h/services/user_test.py
+++ b/tests/h/services/user_test.py
@@ -75,6 +75,28 @@ class TestUserService(object):
         with pytest.raises(UserNotActivated):
             svc.login('mirthe@deboer.com', 'mirthespassword')
 
+    def test_update_preferences_tutorial_enable(self, svc, factories):
+        user = factories.User.build(sidebar_tutorial_dismissed=True)
+
+        svc.update_preferences(user, show_sidebar_tutorial=True)
+
+        assert user.sidebar_tutorial_dismissed is False
+
+    def test_update_preferences_tutorial_disable(self, svc, factories):
+        user = factories.User.build(sidebar_tutorial_dismissed=False)
+
+        svc.update_preferences(user, show_sidebar_tutorial=False)
+
+        assert user.sidebar_tutorial_dismissed is True
+
+    def test_update_preferences_raises_for_unsupported_keys(self, svc, factories):
+        user = factories.User.build()
+
+        with pytest.raises(TypeError) as exc:
+            svc.update_preferences(user, foo='bar', baz='qux')
+
+        assert 'keys baz, foo are not allowed' in exc.value.message
+
     @pytest.fixture
     def svc(self, db_session):
         return UserService(default_authority='example.com', session=db_session)

--- a/tests/h/views/api_profile_test.py
+++ b/tests/h/views/api_profile_test.py
@@ -2,8 +2,10 @@
 
 from __future__ import unicode_literals
 
+import mock
 import pytest
 
+from h.exceptions import APIError
 from h.views import api_profile
 
 
@@ -13,6 +15,53 @@ class TestProfile(object):
         result = api_profile.profile(pyramid_request)
         assert result == {'foo': 'bar'}
 
+
+@pytest.mark.usefixtures('user_service', 'session_profile')
+class TestUpdatePreferences(object):
+    def test_updates_preferences(self, pyramid_request, user, user_service):
+        pyramid_request.json_body = {'preferences': {'show_sidebar_tutorial': True}}
+
+        api_profile.update_preferences(pyramid_request)
+
+        user_service.update_preferences.assert_called_once_with(
+                user, show_sidebar_tutorial=True)
+
+    def test_handles_invalid_preferences_error(self, pyramid_request, user_service):
+        user_service.update_preferences.side_effect = TypeError('uh oh, wrong prefs')
+
+        with pytest.raises(APIError) as exc:
+            api_profile.update_preferences(pyramid_request)
+
+        assert exc.value.message == 'uh oh, wrong prefs'
+
+    def test_handles_missing_preferences_payload(self, pyramid_request):
+        pyramid_request.json_body = {'foo': 'bar'}
+
+        # should not raise
+        api_profile.update_preferences(pyramid_request)
+
+    def test_returns_session_profile(self, pyramid_request, session_profile):
+        result = api_profile.update_preferences(pyramid_request)
+
+        assert result == session_profile.return_value
+
     @pytest.fixture
-    def session_profile(self, patch):
-        return patch('h.session.profile')
+    def pyramid_request(self, pyramid_request, user):
+        pyramid_request.authenticated_user = user
+        pyramid_request.json_body = {}
+        return pyramid_request
+
+    @pytest.fixture
+    def user(self, factories):
+        return factories.User.build()
+
+    @pytest.fixture
+    def user_service(self, pyramid_config):
+        svc = mock.Mock()
+        pyramid_config.register_service(svc, name='user')
+        return svc
+
+
+@pytest.fixture
+def session_profile(patch):
+    return patch('h.session.profile')

--- a/tests/h/views/api_profile_test.py
+++ b/tests/h/views/api_profile_test.py
@@ -7,12 +7,12 @@ import pytest
 from h.views import api_profile
 
 
-def test_profile_view_proxies_to_session(session_profile, pyramid_request):
-    session_profile.return_value = {'foo': 'bar'}
-    result = api_profile.profile(pyramid_request)
-    assert result == {'foo': 'bar'}
+class TestProfile(object):
+    def test_profile_view_proxies_to_session(self, session_profile, pyramid_request):
+        session_profile.return_value = {'foo': 'bar'}
+        result = api_profile.profile(pyramid_request)
+        assert result == {'foo': 'bar'}
 
-
-@pytest.fixture
-def session_profile(patch):
-    return patch('h.session.profile')
+    @pytest.fixture
+    def session_profile(self, patch):
+        return patch('h.session.profile')


### PR DESCRIPTION
This is the backend work for hypothesis/product-backlog#133.

This adds a new API endpoint for updating user preferences, we currently only have `show_sidebar_tutorial`, so it will work with a request like:

```
PATCH /api/profile
{
  "preferences": {
    "show_sidebar_tutorial": false
  }
}
```