### PR TITLE
Add fake request class to remove test duplication

### DIFF
--- a/tests/h/session_test.py
+++ b/tests/h/session_test.py
@@ -11,62 +11,45 @@ class FakeGroup(object):
         self.slug = pubid
 
 
-def test_model_sorts_groups():
-    fake_user = mock.Mock()
-    fake_user.groups = [
+def test_model_sorts_groups(authenticated_request):
+    authenticated_request.set_groups([
         FakeGroup('c', 'Group A'),
         FakeGroup('b', 'Group B'),
         FakeGroup('a', 'Group B'),
-    ]
-    request = mock.Mock(authenticated_user=fake_user)
-    session_model = session.model(request)
+    ])
+    session_model = session.model(authenticated_request)
 
     ids = [group['id'] for group in session_model['groups']]
 
     assert ids == ['__world__', 'c', 'a', 'b']
 
 
-def test_model_includes_features(fake_user):
+def test_model_includes_features(authenticated_request):
     feature_dict = {
         'feature_one': True,
         'feature_two': False,
     }
-    request = mock.Mock(authenticated_user=fake_user)
-    request.feature.all.return_value = feature_dict
+    authenticated_request.set_features(feature_dict)
 
-    assert session.model(request)['features'] == feature_dict
+    assert session.model(authenticated_request)['features'] == feature_dict
 
 
-@pytest.mark.parametrize(
-    "user_authenticated,tutorial_dismissed,show_tutorial",
-    [(False, False, False),
-     (True,  False, True),
-     (True,  True,  False)])
-def test_model_show_sidebar_tutorial(
-        fake_user, user_authenticated, tutorial_dismissed, show_tutorial):
-    """It should return or not return "show_sidebar_tutorial" correctly.
+def test_anonymous_model_hides_sidebar_tutorial(unauthenticated_request):
+    preferences = session.model(unauthenticated_request)['preferences']
 
-    It should return "show_sidebar_tutorial": True only if a user
-    is authorized _and_ that user has not dismissed
-    the tutorial. Otherwise, preferences should contain no
-    "show_sidebar_tutorial" value at all.
+    assert 'show_sidebar_tutorial' not in preferences
 
-    """
-    fake_user.sidebar_tutorial_dismissed = tutorial_dismissed
-    if user_authenticated:
-        authenticated_user = fake_user
-    else:
-        authenticated_user = None
-    request = mock.Mock(
-        authenticated_user=authenticated_user,
-        )
 
-    preferences = session.model(request)['preferences']
+@pytest.mark.parametrize('dismissed', [True, False])
+def test_authenticated_model_sidebar_tutorial(authenticated_request, dismissed):
+    authenticated_request.set_sidebar_tutorial_dismissed(dismissed)
 
-    if show_tutorial:
-        assert preferences['show_sidebar_tutorial'] is True
-    else:
+    preferences = session.model(authenticated_request)['preferences']
+
+    if dismissed:
         assert 'show_sidebar_tutorial' not in preferences
+    else:
+        assert preferences['show_sidebar_tutorial'] is True
 
 
 def test_profile_userid_unauthenticated(unauthenticated_request):
@@ -78,77 +61,84 @@ def test_profile_userid_authenticated(authenticated_request):
     assert profile['userid'] == u'acct:user@example.com'
 
 
-def test_profile_sorts_groups():
-    fake_user = mock.Mock()
-    fake_user.groups = [
+def test_profile_sorts_groups(authenticated_request):
+    authenticated_request.set_groups([
         FakeGroup('c', 'Group A'),
         FakeGroup('b', 'Group B'),
         FakeGroup('a', 'Group B'),
-    ]
-    request = mock.Mock(authenticated_user=fake_user)
-    profile = session.profile(request)
+    ])
+    profile = session.profile(authenticated_request)
 
     ids = [group['id'] for group in profile['groups']]
 
     assert ids == ['__world__', 'c', 'a', 'b']
 
 
-def test_profile_includes_features(fake_user):
+def test_profile_includes_features(authenticated_request):
     feature_dict = {
         'feature_one': True,
         'feature_two': False,
     }
-    request = mock.Mock(authenticated_user=fake_user)
-    request.feature.all.return_value = feature_dict
+    authenticated_request.set_features(feature_dict)
 
-    assert session.profile(request)['features'] == feature_dict
+    assert session.profile(authenticated_request)['features'] == feature_dict
 
 
-@pytest.mark.parametrize(
-    "user_authenticated,tutorial_dismissed,show_tutorial",
-    [(False, False, False),
-     (True,  False, True),
-     (True,  True,  False)])
-def test_profile_show_sidebar_tutorial(
-        fake_user, user_authenticated, tutorial_dismissed, show_tutorial):
-    """It should return or not return "show_sidebar_tutorial" correctly.
+def test_anonymous_profile_hides_sidebar_tutorial(unauthenticated_request):
+    preferences = session.profile(unauthenticated_request)['preferences']
 
-    It should return "show_sidebar_tutorial": True only if a user
-    is authorized _and_ that user has not dismissed
-    the tutorial. Otherwise, preferences should contain no
-    "show_sidebar_tutorial" value at all.
+    assert 'show_sidebar_tutorial' not in preferences
 
-    """
-    fake_user.sidebar_tutorial_dismissed = tutorial_dismissed
-    if user_authenticated:
-        authenticated_user = fake_user
-    else:
-        authenticated_user = None
-    request = mock.Mock(
-        authenticated_user=authenticated_user,
-        )
 
-    preferences = session.profile(request)['preferences']
+@pytest.mark.parametrize('dismissed', [True, False])
+def test_authenticated_profile_sidebar_tutorial(authenticated_request, dismissed):
+    authenticated_request.set_sidebar_tutorial_dismissed(dismissed)
 
-    if show_tutorial:
-        assert preferences['show_sidebar_tutorial'] is True
-    else:
+    preferences = session.profile(authenticated_request)['preferences']
+
+    if dismissed:
         assert 'show_sidebar_tutorial' not in preferences
+    else:
+        assert preferences['show_sidebar_tutorial'] is True
+
+
+class FakeRequest(object):
+
+    def __init__(self, auth_domain, userid, user_authority):
+        self.auth_domain = auth_domain
+        self.authenticated_userid = userid
+
+        if userid is None:
+            self.authenticated_user = None
+        else:
+            self.authenticated_user = mock.Mock(groups=[], authority=user_authority)
+
+        self.feature = mock.Mock(spec_set=['all'])
+        self.route_url = mock.Mock(return_value='/group/a')
+        self.session = mock.Mock(get_csrf_token=lambda: '__CSRF__')
+
+    def set_groups(self, groups):
+        self.authenticated_user.groups = groups
+
+    def set_features(self, feature_dict):
+        self.feature.all.return_value = feature_dict
+
+    def set_sidebar_tutorial_dismissed(self, dismissed):
+        self.authenticated_user.sidebar_tutorial_dismissed = dismissed
 
 
 @pytest.fixture
-def fake_user():
-    fake_user = mock.Mock()
-    fake_user.groups = []
-    return fake_user
+def auth_domain():
+    return u'example.com'
 
 
 @pytest.fixture
-def unauthenticated_request():
-    return mock.Mock(authenticated_userid=None, authenticated_user=None)
+def unauthenticated_request(auth_domain):
+    return FakeRequest(auth_domain, None, None)
 
 
 @pytest.fixture
-def authenticated_request(fake_user):
-    return mock.Mock(authenticated_userid=u'acct:user@example.com',
-                     authenticated_user=fake_user)
+def authenticated_request(auth_domain):
+    return FakeRequest(auth_domain,
+                       u'acct:user@{}'.format(auth_domain),
+                       auth_domain)


### PR DESCRIPTION
A lot of these tests were building up the same set of nested mock objects as one another, with different sets of groups and features.  For the sake of simplicity (and at @nickstenning's suggestion), this sets up a `FakeRequest` class that sets up the request methods that the `model` and `profile` functions expect, and that knows how to customise its own internals in a few set ways. This means the user fixtures are no longer referenced and can be removed.

I found that this approach didn't work very nicely with the heavily-parametrized tests around user preferences, so I split these into separate tests for authenticated and unauthenticated requests, which removed a good chunk of the complexity.

(Further context: I pulled this change out of #4333 as a discrete reviewable chunk.)