### PR TITLE
Allow to configure gunicorn workers for app and websockets

### DIFF
--- a/conf/supervisord.conf
+++ b/conf/supervisord.conf
@@ -12,14 +12,14 @@ stdout_events_enabled=true
 stderr_events_enabled=true
 
 [program:web]
-command=newrelic-admin run-program gunicorn --paste conf/app.ini -b unix:/tmp/gunicorn-web.sock
+command=newrelic-admin run-program gunicorn --name web --paste conf/app.ini -b unix:/tmp/gunicorn-web.sock
 stdout_logfile=NONE
 stderr_logfile=NONE
 stdout_events_enabled=true
 stderr_events_enabled=true
 
 [program:websocket]
-command=gunicorn --paste conf/websocket.ini --worker-connections 4096 -b unix:/tmp/gunicorn-websocket.sock
+command=gunicorn --paste conf/websocket.ini --name websocket --worker-connections 4096 -b unix:/tmp/gunicorn-websocket.sock
 environment=GUNICORN_STATS_DISABLE="1"
 stdout_logfile=NONE
 stderr_logfile=NONE

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -43,7 +43,7 @@ def post_fork(server, worker):
 
 def when_ready(server):
     name = server.proc_name
-    if name.endswith('app.ini') and 'H_WEB_CONCURRENCY' in os.environ:
+    if name == 'web' and 'H_WEB_CONCURRENCY' in os.environ:
         server.num_workers = int(os.environ['H_WEB_CONCURRENCY'])
-    elif name.endswith('websocket.ini') and 'H_WEBSOCKET_CONCURRENCY' in os.environ:
+    elif name == 'websocket' and 'H_WEBSOCKET_CONCURRENCY' in os.environ:
         server.num_workers = int(os.environ['H_WEBSOCKET_CONCURRENCY'])

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -43,7 +43,7 @@ def post_fork(server, worker):
 
 def when_ready(server):
     name = server.proc_name
-    if name == 'web' and 'H_WEB_CONCURRENCY' in os.environ:
-        server.num_workers = int(os.environ['H_WEB_CONCURRENCY'])
-    elif name == 'websocket' and 'H_WEBSOCKET_CONCURRENCY' in os.environ:
-        server.num_workers = int(os.environ['H_WEBSOCKET_CONCURRENCY'])
+    if name == 'web' and 'WEB_NUM_WORKERS' in os.environ:
+        server.num_workers = int(os.environ['WEB_NUM_WORKERS'])
+    elif name == 'websocket' and 'WEBSOCKET_NUM_WORKERS' in os.environ:
+        server.num_workers = int(os.environ['WEBSOCKET_NUM_WORKERS'])

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -39,3 +39,11 @@ def post_fork(server, worker):
         import psycogreen.gevent
         psycogreen.gevent.patch_psycopg()
         worker.log.info("Made psycopg green")
+
+
+def when_ready(server):
+    name = server.proc_name
+    if name.endswith('app.ini') and 'H_WEB_CONCURRENCY' in os.environ:
+        server.num_workers = int(os.environ['H_WEB_CONCURRENCY'])
+    elif name.endswith('websocket.ini') and 'H_WEBSOCKET_CONCURRENCY' in os.environ:
+        server.num_workers = int(os.environ['H_WEBSOCKET_CONCURRENCY'])

--- a/h/cli/commands/devserver.py
+++ b/h/cli/commands/devserver.py
@@ -76,10 +76,10 @@ def devserver(https, web, ws, worker, assets, beat):
 
     m = Manager()
     if web:
-        m.add_process('web', 'gunicorn --reload --paste conf/development-app.ini %s' % gunicorn_args)
+        m.add_process('web', 'gunicorn --name web --reload --paste conf/development-app.ini %s' % gunicorn_args)
 
     if ws:
-        m.add_process('ws', 'gunicorn --reload --paste conf/development-websocket.ini %s' % gunicorn_args)
+        m.add_process('ws', 'gunicorn --name websocket --reload --paste conf/development-websocket.ini %s' % gunicorn_args)
 
     if worker:
         m.add_process('worker', 'hypothesis --dev celery worker --autoreload')


### PR DESCRIPTION
Now that we're running both the web and the websocket gunicorn processes
in the same container, we can't easily use the `WEB_CONCURRENCY`
environment variable anymore to define how many gunicorn workers we want
to run. Unless we want both the web and websocket gunicorn processes to
run with the same amount of workers, which is unlikely.

The easiest way to allow to separately configure the amount of workers
for the web and websocket gunicorn instances is to have two separate
environment variables (`H_WEB_CONCURRENCY` and
`H_WEBSOCKET_CONCURRENCY`), and then check if we're starting the app or
the websocket process, and set the number of workers to the number in
defined in the respective environment variable.

This change is implemented in the `when_ready` [1] hook which is run
after the master process has been started but none of the workers has
been forked-off yet.
In this hook we're checking the `proc_name` configuration, which in our
configuration includes the path to the paster config file. This seems to
be the easiest way to do it at the moment, it might be a bit more safe
if we would pass `-n web` or `-n websocket` to the gunicorn process (in
the supervisor configuration) and then check for that. But I think this
will do for now.

After talking to Nick we figured it would be better to pass the name explicitly because we're looking at phasing out support for the paster ini config files, so we shouldn't add another dependency on it.

[1]: http://docs.gunicorn.org/en/stable/settings.html#when-ready