### PR TITLE
Remove cookie-based authentication for WebSocket

### DIFF
--- a/conf/development-websocket.ini
+++ b/conf/development-websocket.ini
@@ -1,10 +1,6 @@
 [app:main]
 use: call:h.websocket:create_app
 
-# Allowed websocket origins
-origins:
-    http://localhost:5000
-
 # Use gevent-compatible transport for the Sentry client
 raven.transport: gevent
 

--- a/docs/realtime.rst
+++ b/docs/realtime.rst
@@ -14,13 +14,6 @@ real-time notifications of annotation events.
 Overview
 --------
 
-.. note::
-
-   At the moment, use of the Real Time API is limited to server-side clients.
-   JavaScript applications running in the browser **will not be able to use this
-   API** due to security restrictions. We hope to lift this restriction in the
-   future.
-
 To use the Real Time API, you should open a WebSocket connection to the
 following endpoint::
 
@@ -28,6 +21,25 @@ following endpoint::
 
 Communication with this endpoint consists of JSON-encoded messages sent from
 client to server and vice versa.
+
+Authorization
+-------------
+
+Clients that are only interested in receiving notifications about public
+annotations on a page do not need to authenticate. Clients that want to receive
+notifications about all updates relevant to a particular user must
+authenticate.
+
+Server-side clients can authenticate to the Real Time API by providing an access
+token in an Authorization header::
+
+    Authorization: Bearer <token>
+
+Browser-based clients are not able to set this header due to limitations of the
+the browser's ``WebSocket`` API. Instead they can authenticate by setting an
+``access_token`` query parameter in the URL when connecting::
+
+    var socket = new WebSocket(`wss://hypothes.is/ws?access_token=${token}`)
 
 Server messages
 ---------------

--- a/h/auth/__init__.py
+++ b/h/auth/__init__.py
@@ -6,7 +6,6 @@ import logging
 
 from pyramid.authentication import RemoteUserAuthenticationPolicy
 import pyramid_authsanity
-from pyramid_multiauth import MultiAuthenticationPolicy
 
 from h.auth.policy import AuthenticationPolicy, TokenAuthenticationPolicy
 from h.auth.util import auth_domain, groupfinder
@@ -26,7 +25,7 @@ TOKEN_POLICY = TokenAuthenticationPolicy(callback=groupfinder)
 
 DEFAULT_POLICY = AuthenticationPolicy(api_policy=TOKEN_POLICY,
                                       fallback_policy=TICKET_POLICY)
-WEBSOCKET_POLICY = MultiAuthenticationPolicy([TOKEN_POLICY, TICKET_POLICY])
+WEBSOCKET_POLICY = TOKEN_POLICY
 
 
 def includeme(config):
@@ -51,8 +50,7 @@ def includeme(config):
 
         DEFAULT_POLICY = AuthenticationPolicy(api_policy=TOKEN_POLICY,
                                               fallback_policy=PROXY_POLICY)
-        WEBSOCKET_POLICY = MultiAuthenticationPolicy([TOKEN_POLICY,
-                                                      PROXY_POLICY])
+        WEBSOCKET_POLICY = TOKEN_POLICY
 
     # Set the default authentication policy. This can be overridden by modules
     # that include this one.

--- a/h/cli/commands/devserver.py
+++ b/h/cli/commands/devserver.py
@@ -67,8 +67,6 @@ def devserver(https, web, ws, worker, assets, beat):
         gunicorn_args = '--certfile=.tlscert.pem --keyfile=.tlskey.pem'
         os.environ['APP_URL'] = 'https://localhost:5000'
         os.environ['WEBSOCKET_URL'] = 'wss://localhost:5001/ws'
-        os.environ['ALLOWED_ORIGINS'] = ' '.join(
-            ['https://localhost:5000', os.environ.get('ALLOWED_ORIGINS', '')])
     else:
         gunicorn_args = ''
         os.environ['APP_URL'] = 'http://localhost:5000'

--- a/h/config.py
+++ b/h/config.py
@@ -54,7 +54,6 @@ SETTINGS = [
     EnvSetting('mail.default_sender', 'MAIL_DEFAULT_SENDER'),
     EnvSetting('mail.host', 'MAIL_HOST'),
     EnvSetting('mail.port', 'MAIL_PORT', type=int),
-    EnvSetting('origins', 'ALLOWED_ORIGINS'),
     EnvSetting('sqlalchemy.url', 'DATABASE_URL', type=database_url),
     EnvSetting('statsd.host', 'STATSD_HOST'),
     EnvSetting('statsd.port', 'STATSD_PORT', type=int),

--- a/h/streamer/views.py
+++ b/h/streamer/views.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from pyramid import httpexceptions
-from pyramid.config import aslist
 from pyramid.view import forbidden_view_config
 from pyramid.view import notfound_view_config
 from pyramid.view import view_config
@@ -13,15 +11,6 @@ from h.streamer import streamer, websocket
 
 @view_config(route_name='ws')
 def websocket_view(request):
-    # WebSockets can be opened across origins and send cookies. To prevent
-    # scripts on other sites from using this socket, ensure that the Origin
-    # header (if present) matches the request host URL or is whitelisted.
-    origin = request.headers.get('Origin')
-    allowed = request.registry.settings['origins']
-    if origin is not None:
-        if origin != request.host_url and origin not in allowed:
-            return httpexceptions.HTTPForbidden()
-
     # Provide environment which the WebSocket handler can use...
     request.environ.update({
         'h.ws.authenticated_userid': request.authenticated_userid,
@@ -87,7 +76,4 @@ def error(context, request):
 
 
 def includeme(config):
-    settings = config.registry.settings
-    settings['origins'] = aslist(settings.get('origins', ''))
-
     config.scan(__name__)

--- a/h/streamer/websocket.py
+++ b/h/streamer/websocket.py
@@ -45,7 +45,6 @@ class Message(namedtuple('Message', [
 class WebSocket(_WebSocket):
     # All instances of WebSocket, allowing us to iterate over open websockets
     instances = weakref.WeakSet()
-    origins = []
 
     # Instance attributes
     client_id = None

--- a/requirements.in
+++ b/requirements.in
@@ -25,7 +25,6 @@ pyramid
 pyramid_authsanity
 pyramid_layout
 pyramid-jinja2
-pyramid-multiauth
 pyramid-services
 pyramid_mailer
 pyramid_tm

--- a/requirements.txt
+++ b/requirements.txt
@@ -54,7 +54,6 @@ pyramid-authsanity==0.1.0a4
 pyramid-jinja2==2.6.2
 pyramid-layout==1.0
 pyramid-mailer==0.14.1
-pyramid-multiauth==0.8.0
 pyramid-services==0.4
 pyramid-tm==1.1.1
 pyramid==1.7.3

--- a/tests/h/streamer/views_test.py
+++ b/tests/h/streamer/views_test.py
@@ -1,31 +1,9 @@
 # -*- coding: utf-8 -*-
 
-import mock
 import pytest
 
 from h.streamer import views
 from h.streamer import streamer
-
-
-def test_websocket_view_bad_origin(pyramid_request):
-    pyramid_request.registry.settings.update({'origins': ['http://good']})
-    pyramid_request.headers = {'Origin': 'http://bad'}
-    res = views.websocket_view(pyramid_request)
-    assert res.code == 403
-
-
-def test_websocket_view_good_origin(pyramid_request):
-    pyramid_request.registry.settings.update({'origins': ['http://good']})
-    pyramid_request.headers = {'Origin': 'http://good'}
-    pyramid_request.get_response = lambda _: mock.sentinel.good_response
-    res = views.websocket_view(pyramid_request)
-    assert res == mock.sentinel.good_response
-
-
-def test_websocket_view_same_origin(pyramid_request):
-    pyramid_request.get_response = lambda _: mock.sentinel.good_response
-    res = views.websocket_view(pyramid_request)
-    assert res == mock.sentinel.good_response
 
 
 def test_websocket_view_adds_auth_state_to_environ(pyramid_config, pyramid_request):
@@ -59,7 +37,4 @@ def test_websocket_view_adds_work_queue_to_environ(pyramid_request):
 
 @pytest.fixture
 def pyramid_request(pyramid_request):
-    pyramid_request.registry.settings.update({'origins': []})
-    # example.com is the dummy request default host URL
-    pyramid_request.headers = {'Origin': 'http://example.com'}
     return pyramid_request


### PR DESCRIPTION
This PR removes cookies as an authentication method for the WebSocket, restricting authentication to access tokens passed in the header or via a query string parameter. As a result, it is possible to remove the origin restrictions.

* The first commit changes the auth policy for the WebSocket to token-only
* The second commit removes the origin checks for the WS and associated tests
* The third commit updates the documentation for the Real Time API

The latest Hypothesis client (v0.53, released on 02/02/17) always uses tokens for authentication. Earlier clients only used cookies. If earlier clients try to connect after this change is deployed, they will simply be connected to the WS as unauthenticated clients and will consequently not alert the user to non-public updates or update the groups list in real time.
