### PR TITLE
Add /_status health check endpoint

### DIFF
--- a/conf/nginx.conf.tpl
+++ b/conf/nginx.conf.tpl
@@ -40,7 +40,7 @@ http {
       return 499;
     }
 
-    location ~ ^/(|a|u|t|account|admin|api|app|app.html|assets|docs/help|embed\.js.*|forgot-password|login|logout|activate|groups|notification|robots\.txt|search|signup|stream|stream\.atom|stream\.rss|users|viewer|welcome)(/|$) {
+    location ~ ^/(|_status|a|u|t|account|admin|api|app|app.html|assets|docs/help|embed\.js.*|forgot-password|login|logout|activate|groups|notification|robots\.txt|search|signup|stream|stream\.atom|stream\.rss|users|viewer|welcome)(/|$) {
       proxy_pass http://web;
       proxy_http_version 1.1;
       proxy_connect_timeout 10s;

--- a/h/routes.py
+++ b/h/routes.py
@@ -103,6 +103,9 @@ def includeme(config):
     # Notification
     config.add_route('unsubscribe', '/notification/unsubscribe/{token}')
 
+    # Health check
+    config.add_route('status', '/_status')
+
     # Static
     config.add_route('about', '/about/', static=True)
     config.add_route('bioscience', '/bioscience/', static=True)

--- a/h/views/status.py
+++ b/h/views/status.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import logging
+
+from h.celery import celery
+from h.exceptions import APIError
+from h.util.view import json_view
+
+
+log = logging.getLogger(__name__)
+
+
+@json_view(route_name='status')
+def status(request):
+    _check_database(request)
+    _check_search(request)
+    _check_celery()
+    return {'status': 'okay'}
+
+
+def _check_database(request):
+    try:
+        request.db.execute('SELECT 1')
+    except Exception as exc:
+        log.exception(exc)
+        raise APIError('Database connection failed')
+
+
+def _check_search(request):
+    try:
+        info = request.es.conn.cluster.health()
+        if info['status'] not in ('green', 'yellow'):
+            raise APIError('Search cluster state is %s' % info['status'])
+    except Exception as exc:
+        log.exception(exc)
+        raise APIError('Search connection failed')
+
+
+def _check_celery():
+    try:
+        result = celery.control.ping(timeout=0.25)
+        if not result:
+            raise APIError('Celery ping failed')
+
+        for item in result:
+            if len(item) != 1:
+                continue
+
+            reply = item.values()[0]
+            if reply.get('ok') == 'pong':
+                return
+
+        raise APIError('Celery: no worker returned pong')
+    except IOError as exc:
+        log.exception(exc)
+        raise APIError('Celery connection failed')

--- a/tests/h/routes_test.py
+++ b/tests/h/routes_test.py
@@ -73,6 +73,7 @@ def test_includeme():
         call('onboarding', '/welcome/'),
         call('custom_onboarding', '/welcome/{slug}'),
         call('unsubscribe', '/notification/unsubscribe/{token}'),
+        call('status', '/_status'),
         call('about', '/about/', static=True),
         call('bioscience', '/bioscience/', static=True),
         call('blog', '/blog/', static=True),

--- a/tests/h/views/status_test.py
+++ b/tests/h/views/status_test.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import mock
+import pytest
+
+from h.exceptions import APIError
+from h.views.status import status
+
+
+@pytest.mark.usefixtures('celery', 'db', 'es')
+class TestStatus(object):
+    def test_it_returns_okay_on_success(self, pyramid_request):
+        result = status(pyramid_request)
+        assert result
+
+    def test_it_fails_when_databse_unreachable(self, pyramid_request, db):
+        db.execute.side_effect = Exception('explode!')
+
+        with pytest.raises(APIError) as exc:
+            status(pyramid_request)
+
+        assert 'Database connection failed' in exc.value.message
+
+    def test_it_fails_when_search_unreachable(self, pyramid_request, es):
+        es.conn.cluster.health.side_effect = Exception('explode!')
+
+        with pytest.raises(APIError) as exc:
+            status(pyramid_request)
+
+        assert 'Search connection failed' in exc.value.message
+
+    def test_it_fails_when_search_cluster_status_red(self, pyramid_request, es):
+        es.conn.cluster.health.return_value = {'status': 'red'}
+
+        with pytest.raises(APIError) as exc:
+            status(pyramid_request)
+
+        assert 'Search connection failed' in exc.value.message
+
+    def test_it_fails_when_celery_connection_unreachable(self, pyramid_request, celery):
+        celery.control.ping.side_effect = IOError('explode!')
+
+        with pytest.raises(APIError) as exc:
+            status(pyramid_request)
+
+        assert 'Celery connection failed' in exc.value.message
+
+    def test_it_fails_when_celery_workers_dont_respond(self, pyramid_request, celery):
+        celery.control.ping.return_value = []
+
+        with pytest.raises(APIError) as exc:
+            status(pyramid_request)
+
+        assert 'Celery ping failed' in exc.value.message
+
+    def test_it_succeeds_when_one_celery_workers_succeeds(self, pyramid_request, celery):
+        celery.control.ping.return_value = [
+            {'celery@test-worker-1': {'fail': 'some error'}},
+            {'celery@test-worker-2': {'ok': 'pong'}},
+        ]
+
+        result = status(pyramid_request)
+        assert result
+
+    def test_it_fails_when_all_celery_workers_fail(self, pyramid_request, celery):
+        celery.control.ping.return_value = [
+            {'celery@test-worker-1': {'fail': 'some error'}},
+            {'celery@test-worker-2': {'foo': 'bar'}},
+        ]
+
+        with pytest.raises(APIError) as exc:
+            status(pyramid_request)
+
+        assert 'no worker returned pong' in exc.value.message
+
+    @pytest.fixture
+    def db(self, pyramid_request):
+        db = mock.Mock()
+        pyramid_request.db = db
+        return db
+
+    @pytest.fixture
+    def es(self, pyramid_request):
+        es = mock.Mock()
+        es.conn.cluster.health.return_value = {'status': 'green'}
+        pyramid_request.es = es
+        return es
+
+    @pytest.fixture
+    def celery(self, patch):
+        celery = patch('h.views.status.celery')
+
+        celery.control.ping.return_value = [{'celery@test-worker': {'ok': 'pong'}}]
+
+        return celery


### PR DESCRIPTION
This will be used by Skyliner to determine if a deploy was successful or not.

The endpoint itself is trying to contact Postgres, ElasticSearch, and RabbitMQ. With ElasticSearch it also checks that the cluster status is green.

Some questions:

* We should add tests, but short of mocking out the methods the view is calling, is there another, better way?
* I should probably check for the ElasticSearch cluster status to not be "red" instead of checking that it's "green" ("yellow" I think happens when it reshuffles shards, we don't want to be considered as down during this time). Correct?