### PR TITLE
Support unauthenticated `profile` requests

### DIFF
--- a/h/views/api_profile.py
+++ b/h/views/api_profile.py
@@ -11,11 +11,11 @@ from memex.views import api_config
 
 @api_config(route_name='api.profile',
             request_method='GET',
-            effective_principals=security.Authenticated,
             link_name='profile.read',
             description="Fetch the user's profile")
 def profile(request):
-    return h_session.profile(request)
+    authority = request.params.get('authority')
+    return h_session.profile(request, authority)
 
 
 @api_config(route_name='api.profile',

--- a/tests/functional/test_api.py
+++ b/tests/functional/test_api.py
@@ -49,6 +49,20 @@ class TestAPI(object):
         assert res.status_code == 400
         assert res.json['reason'].startswith('group:')
 
+    def test_anonymous_profile_api(self, app):
+        """
+        Fetch an anonymous "profile".
+
+        With no authentication and no authority parameter, this should default
+        to the site's `auth_domain` and show only the global group.
+        """
+
+        res = app.get('/api/profile')
+
+        assert res.json['userid'] is None
+        assert res.json['authority'] == 'example.com'
+        assert [group['id'] for group in res.json['groups']] == ['__world__']
+
     def test_profile_api(self, app, user_with_token):
         """Fetch a profile through the API for an authenticated user."""
 

--- a/tests/functional/test_oauth.py
+++ b/tests/functional/test_oauth.py
@@ -18,18 +18,19 @@ class TestOAuth(object):
         access_token = response['access_token']
 
         # Test that you can use the access token to authorize with the API.
-        app.get(
+        profile = app.get(
             '/api/profile',
             headers={'Authorization': str('Bearer {}'.format(access_token))},
         )
+        assert profile.json_body['userid']
 
     def test_request_fails_if_access_token_wrong(self, app, authclient,
                                                  userid):
-        app.get(
+        profile = app.get(
             '/api/profile',
             headers={'Authorization': str('Bearer wrong')},
-            status=404,
         )
+        assert profile.json_body['userid'] is None
 
     def test_request_fails_if_access_token_expired(self, app, authclient,
                                                    db_session, factories,
@@ -39,11 +40,11 @@ class TestOAuth(object):
         token = token.value
         db_session.commit()
 
-        app.get(
+        profile = app.get(
             '/api/profile',
             headers={'Authorization': str('Bearer {}'.format(token))},
-            status=404,
         )
+        assert profile.json_body['userid'] is None
 
     def test_using_a_refresh_token(self, app, authclient, userid):
         """Get a new access token by POSTing a refresh token to /api/token."""
@@ -63,20 +64,22 @@ class TestOAuth(object):
         new_access_token = response.json_body['access_token']
 
         # Test that the new access token works.
-        app.get(
+        new_token_profile = app.get(
             '/api/profile',
             headers={
                 'Authorization': str('Bearer {}'.format(new_access_token)),
             },
         )
+        assert new_token_profile.json_body['userid']
 
         # Test that the old access token still works, too.
-        app.get(
+        old_token_profile = app.get(
             '/api/profile',
             headers={
                 'Authorization': str('Bearer {}'.format(old_access_token)),
             },
         )
+        assert old_token_profile.json_body['userid']
 
     def test_refresh_token_request_fails_if_refresh_token_wrong(self, app,
                                                                 authclient,
@@ -114,11 +117,11 @@ class TestOAuth(object):
         response = self.get_access_token(app, authclient, userid)
         refresh_token = response['refresh_token']
 
-        app.get(
+        profile = app.get(
             '/api/profile',
             headers={'Authorization': str('Bearer {}'.format(refresh_token))},
-            status=404,
         )
+        assert profile.json_body['userid'] is None
 
     def get_access_token(self, app, authclient, userid):
         """Get an access token by POSTing a grant token to /api/token."""

--- a/tests/h/session_test.py
+++ b/tests/h/session_test.py
@@ -199,6 +199,38 @@ def test_authenticated_profile_sidebar_tutorial(authenticated_request, dismissed
         assert preferences['show_sidebar_tutorial'] is True
 
 
+def test_authority_in_anonymous_profile(unauthenticated_request, auth_domain):
+    assert session.profile(unauthenticated_request)['authority'] == auth_domain
+
+
+def test_authority_override(unauthenticated_request):
+    unauthenticated_request.set_public_groups({'foo.com': []})
+
+    profile = session.profile(unauthenticated_request, 'foo.com')
+
+    assert profile['authority'] == 'foo.com'
+
+
+def test_authority_in_authenticated_profile(authenticated_request, auth_domain):
+    assert session.profile(authenticated_request)['authority'] == auth_domain
+
+
+def test_authority_ignored_for_authenticated_profile(authenticated_request, auth_domain):
+    profile = session.profile(authenticated_request, 'foo.com')
+
+    assert profile['authority'] == auth_domain
+
+
+def test_authority_in_third_party_profile(third_party_request, third_party_domain):
+    assert session.profile(third_party_request)['authority'] == third_party_domain
+
+
+def test_authority_ignored_for_third_party_profile(third_party_request, third_party_domain):
+    profile = session.profile(third_party_request, 'foo.com')
+
+    assert profile['authority'] == third_party_domain
+
+
 class FakeAuthorityGroupService(object):
 
     def __init__(self, public_groups):
@@ -233,6 +265,9 @@ class FakeRequest(object):
 
     def set_sidebar_tutorial_dismissed(self, dismissed):
         self.authenticated_user.sidebar_tutorial_dismissed = dismissed
+
+    def set_public_groups(self, public_groups):
+        self._authority_group_service = FakeAuthorityGroupService(public_groups)
 
     def find_service(self, **kwargs):
         if kwargs == {'name': 'authority_group'}:

--- a/tests/h/views/api_profile_test.py
+++ b/tests/h/views/api_profile_test.py
@@ -11,9 +11,18 @@ from h.views import api_profile
 
 class TestProfile(object):
     def test_profile_view_proxies_to_session(self, session_profile, pyramid_request):
-        session_profile.return_value = {'foo': 'bar'}
         result = api_profile.profile(pyramid_request)
-        assert result == {'foo': 'bar'}
+
+        session_profile.assert_called_once_with(pyramid_request, None)
+        assert result == session_profile.return_value
+
+    def test_profile_passes_authority_parameter(self, session_profile, pyramid_request):
+        pyramid_request.params = {'authority': 'foo.com'}
+
+        result = api_profile.profile(pyramid_request)
+
+        session_profile.assert_called_once_with(pyramid_request, 'foo.com')
+        assert result == session_profile.return_value
 
 
 @pytest.mark.usefixtures('user_service', 'session_profile')


### PR DESCRIPTION
This functionality is necessary so that we can display a list of public groups and use a default set of feature flags before a user has logged in. This needs to work both for the default authority and for a third party.

There was some discussion around whether to expect the `authority` parameter, even for authenticated requests, and fail if the value did not match the user's authority. The main argument behind this was to provide separation between the different URLs used for profiles from different authorities. However, in the interests of unblocking the client component of this work, and given a piece of suggested upcoming investigation into providing entirely separate API namespaces for third parties, we've gone with the simplest option for the moment.

This is the final piece of hypothesis/product-backlog#119.

This depends on #4356, as the removed test breaks with this new functionality.