### PR TITLE
Run collectd inside docker container for system metrics

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ MAINTAINER Hypothes.is Project and contributors
 # Install system build and runtime dependencies.
 RUN apk-install \
     ca-certificates \
+    collectd \
     libffi \
     libpq \
     nginx \
@@ -37,6 +38,11 @@ RUN apk-install --virtual build-deps \
 COPY conf/nginx.conf.tpl /etc/nginx/nginx.conf.tpl
 COPY conf/nginx.conf.tpl /etc/nginx/nginx.conf
 RUN chown hypothesis:hypothesis /etc/nginx/nginx.conf
+
+# Copy collectd config
+COPY conf/collectd.conf /etc/collectd/collectd.conf
+RUN mkdir /etc/collectd/collectd.conf.d \
+ && chown hypothesis:hypothesis /etc/collectd/collectd.conf.d
 
 # Copy the rest of the application files.
 COPY . .

--- a/bin/start-collectd
+++ b/bin/start-collectd
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+: ${GRAPHITE_HOST:=}
+: ${GRAPHITE_PORT:="2003"}
+
+set -eu
+
+CONF_TEMPLATE=/etc/collectd/collectd.conf.tpl
+CONF_DEST=/etc/collectd/collectd.conf
+EXTRA_CONF_DIR=/etc/collectd/collectd.conf.d
+
+if [ -n "$GRAPHITE_HOST" ]; then
+    HOSTNAME=$(wget -O - -T 1 http://169.254.169.254/1.0/meta-data/instance-id 2>/dev/null || hostname)
+    echo "Hostname \"${HOSTNAME}\"" > "$EXTRA_CONF_DIR/hostname.conf"
+
+    cat >"$EXTRA_CONF_DIR/graphite.conf" <<EOM
+LoadPlugin write_graphite
+<Plugin write_graphite>
+  <Node "default">
+    Host "${GRAPHITE_HOST}"
+    Port "${GRAPHITE_PORT}"
+    Protocol "tcp"
+    LogSendErrors true
+    Prefix "collectd."
+    StoreRates true
+    AlwaysAppendDS false
+    EscapeCharacter "_"
+  </Node>
+</Plugin>
+EOM
+
+    exec collectd -f -C $CONF_DEST
+else
+  echo "INFO: GRAPHITE_HOST not provided so collectd will not be started"
+  exit 0
+fi

--- a/conf/collectd.conf
+++ b/conf/collectd.conf
@@ -1,0 +1,91 @@
+Interval 10
+
+Timeout 2
+ReadThreads 5
+WriteThreads 5
+
+# Limit the size of the write queue. Default is no limit. Setting up a limit
+# is recommended for servers handling a high volume of traffic.
+WriteQueueLimitHigh 1000000
+WriteQueueLimitLow   800000
+
+##############################################################################
+# Logging                                                                    #
+#----------------------------------------------------------------------------#
+# Plugins which provide logging functions should be loaded first, so log     #
+# messages generated when loading or configuring other plugins can be        #
+# accessed.                                                                  #
+##############################################################################
+
+
+LoadPlugin logfile
+
+<Plugin "logfile">
+  LogLevel info
+  File stdout
+  Timestamp true
+</Plugin>
+
+##############################################################################
+# LoadPlugin section                                                         #
+#----------------------------------------------------------------------------#
+# Specify what features to activate.                                         #
+##############################################################################
+
+LoadPlugin conntrack
+LoadPlugin contextswitch
+LoadPlugin cpu
+LoadPlugin df
+LoadPlugin disk
+LoadPlugin entropy
+LoadPlugin interface
+LoadPlugin irq
+LoadPlugin load
+LoadPlugin memory
+LoadPlugin processes
+LoadPlugin swap
+LoadPlugin users
+
+##############################################################################
+# Plugin configuration                                                       #
+#----------------------------------------------------------------------------#
+# In this section configuration stubs for each plugin are provided. A desc-  #
+# ription of those options is available in the collectd.conf(5) manual page. #
+##############################################################################
+
+<Plugin df>
+	# ignore rootfs; else, the root file-system would appear twice, causing
+	# one of the updates to fail and spam the log
+	FSType rootfs
+
+	# ignore the usual virtual / temporary file-systems
+	FSType sysfs
+	FSType proc
+	FSType devtmpfs
+	FSType devpts
+	FSType tmpfs
+	FSType fusectl
+	FSType cgroup
+	IgnoreSelected true
+
+	ReportInodes true
+
+	ValuesAbsolute true
+	ValuesPercentage true
+</Plugin>
+
+<Plugin disk>
+	# Disk "/xvd/"
+	IgnoreSelected false
+</Plugin>
+
+<Plugin interface>
+	Interface "eth0"
+	IgnoreSelected false
+</Plugin>
+
+<Include "/etc/collectd/collectd.conf.d">
+	Filter "*.conf"
+</Include>
+
+TypesDB "/usr/share/collectd/types.db"

--- a/conf/supervisord.conf
+++ b/conf/supervisord.conf
@@ -33,6 +33,14 @@ stderr_logfile=NONE
 stdout_events_enabled=true
 stderr_events_enabled=true
 
+[program:collectd]
+command=start-collectd
+startsecs=0
+stdout_logfile=NONE
+stderr_logfile=NONE
+stdout_events_enabled=true
+stderr_events_enabled=true
+
 [eventlistener:logger]
 command=logger
 buffer_size=100


### PR DESCRIPTION
In order to get system metrics from h running on Skyliner, we need to
run collectd inside the container.

This adds the exact same collectd configuration as we currently use on
the old infrastructure instances, except for the removal of the nptd
plugin which doesn't work due to [a
bug](https://github.com/collectd/collectd/issues/932).

The `start-collectd` script will configure collectd to send the metrics
to graphite if the `GRAPHITE_HOST` environment variable is set,
otherwise it will configure the basic `write_log` plugin.
Similar to that it tries to get the EC2 instance id through the metadata
API, if it isn't available it will fallback to the local hostname
(calling `hostname`).