### PR TITLE
Simplify embed.js view

### DIFF
--- a/h/client.py
+++ b/h/client.py
@@ -11,6 +11,7 @@ from h import __version__
 
 jinja_env = Environment(loader=PackageLoader(__package__, 'templates'))
 
+
 def url_with_path(url):
     if urlparse.urlparse(url).path == '':
         return '{}/'.format(url)
@@ -19,7 +20,7 @@ def url_with_path(url):
 
 
 def _app_html_context(assets_env, api_url, service_url, sentry_public_dsn,
-                      websocket_url, ga_client_tracking_id):
+                      websocket_url, ga_client_tracking_id, client_boot_url):
     """
     Returns a dict of asset URLs and contents used by the sidebar app
     HTML tempate.
@@ -52,10 +53,17 @@ def _app_html_context(assets_env, api_url, service_url, sentry_public_dsn,
             'googleAnalytics': ga_client_tracking_id
         })
 
+    if client_boot_url:
+        app_css_urls = []
+        app_js_urls = [client_boot_url]
+    else:
+        app_css_urls = assets_env.urls('app_css')
+        app_js_urls = assets_env.urls('app_js')
+
     return {
         'app_config': json.dumps(app_config),
-        'app_css_urls': assets_env.urls('app_css'),
-        'app_js_urls': assets_env.urls('app_js'),
+        'app_css_urls': app_css_urls,
+        'app_js_urls': app_js_urls,
     }
 
 
@@ -65,7 +73,8 @@ def render_app_html(assets_env,
                     sentry_public_dsn,
                     websocket_url=None,
                     ga_client_tracking_id=None,
-                    extra=None):
+                    extra=None,
+                    client_boot_url=None):
     """
     Return the HTML for the Hypothesis app page,
     used by the sidebar, stream and single-annotation page.
@@ -82,6 +91,7 @@ def render_app_html(assets_env,
     :param extra: A dict of optional properties specifying link tags and
                   meta attributes to be included on the page, passed through to
                   app.html.jinja2
+    :param client_boot_url: The absolute URL of the client's main entry point
     """
     template = jinja_env.get_template('app.html.jinja2')
     context = _app_html_context(api_url=api_url,
@@ -89,13 +99,15 @@ def render_app_html(assets_env,
                                 sentry_public_dsn=sentry_public_dsn,
                                 assets_env=assets_env,
                                 websocket_url=websocket_url,
-                                ga_client_tracking_id=ga_client_tracking_id).copy()
+                                ga_client_tracking_id=ga_client_tracking_id,
+                                client_boot_url=client_boot_url).copy()
     if extra is not None:
         context.update(extra)
     return template.render(context)
 
 
-def render_embed_js(assets_env, app_html_url, base_url=None):
+def render_embed_js(assets_env, app_html_url, base_url=None,
+                    client_asset_root=None, client_boot_url=None):
     """
     Return the code for the script which is injected into a page in order
     to load the Hypothesis annotation client into it.
@@ -103,6 +115,8 @@ def render_embed_js(assets_env, app_html_url, base_url=None):
     :param assets_env: The assets environment
     :param app_html_url: The URL of the app.html page for the sidebar
     :param base_url: The absolute base URL of the web service
+    :param client_asset_root: The absolute URL where client assets are hosted
+    :param client_boot_url: The URL of the client's boot script
     """
 
     def absolute_asset_urls(bundle_name):
@@ -112,7 +126,9 @@ def render_embed_js(assets_env, app_html_url, base_url=None):
     template = jinja_env.get_template('embed.js.jinja2')
     template_args = {
         'app_html_url': app_html_url,
-        'inject_resource_urls': absolute_asset_urls('inject_js') +
-                                absolute_asset_urls('inject_css')
+        'client_asset_root': client_asset_root,
+        'client_boot_url': client_boot_url,
+        'inject_resource_urls': (absolute_asset_urls('inject_js') +
+                                 absolute_asset_urls('inject_css'))
     }
     return template.render(template_args)

--- a/h/client.py
+++ b/h/client.py
@@ -106,11 +106,10 @@ def render_app_html(assets_env,
     return template.render(context)
 
 
-def render_embed_js(assets_env, app_html_url, base_url=None,
-                    client_asset_root=None, client_boot_url=None):
+def embed_context(assets_env, app_html_url, base_url=None,
+                  client_asset_root=None, client_boot_url=None):
     """
-    Return the code for the script which is injected into a page in order
-    to load the Hypothesis annotation client into it.
+    Return the context for the `embed.js` template.
 
     :param assets_env: The assets environment
     :param app_html_url: The URL of the app.html page for the sidebar
@@ -123,12 +122,10 @@ def render_embed_js(assets_env, app_html_url, base_url=None,
         return [urlparse.urljoin(base_url, url)
                 for url in assets_env.urls(bundle_name)]
 
-    template = jinja_env.get_template('embed.js.jinja2')
-    template_args = {
+    return {
         'app_html_url': app_html_url,
         'client_asset_root': client_asset_root,
         'client_boot_url': client_boot_url,
         'inject_resource_urls': (absolute_asset_urls('inject_js') +
                                  absolute_asset_urls('inject_css'))
     }
-    return template.render(template_args)

--- a/h/client.py
+++ b/h/client.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """
-Provides functions for building the assets for the Hypothesis client
-application.
+Provides functions for rendering the `app.html` entry point for the Hypothesis
+client's sidebar application.
 """
 import json
 from h._compat import urlparse
@@ -104,28 +104,3 @@ def render_app_html(assets_env,
     if extra is not None:
         context.update(extra)
     return template.render(context)
-
-
-def embed_context(assets_env, app_html_url, base_url=None,
-                  client_asset_root=None, client_boot_url=None):
-    """
-    Return the context for the `embed.js` template.
-
-    :param assets_env: The assets environment
-    :param app_html_url: The URL of the app.html page for the sidebar
-    :param base_url: The absolute base URL of the web service
-    :param client_asset_root: The absolute URL where client assets are hosted
-    :param client_boot_url: The URL of the client's boot script
-    """
-
-    def absolute_asset_urls(bundle_name):
-        return [urlparse.urljoin(base_url, url)
-                for url in assets_env.urls(bundle_name)]
-
-    return {
-        'app_html_url': app_html_url,
-        'client_asset_root': client_asset_root,
-        'client_boot_url': client_boot_url,
-        'inject_resource_urls': (absolute_asset_urls('inject_js') +
-                                 absolute_asset_urls('inject_css'))
-    }

--- a/h/models/feature.py
+++ b/h/models/feature.py
@@ -15,6 +15,7 @@ FEATURES = {
                                " updates to annotations in the client?"),
     'orphans_tab': "Show the orphans tab to separate anchored and unanchored annotations?",
     'total_shared_annotations': "Show the total number of shared annotations for users and groups?",
+    'use_client_boot_script': "Use the client's boot script?",
 }
 
 # Once a feature has been fully deployed, we remove the flag from the codebase.

--- a/h/templates/app.html.jinja2
+++ b/h/templates/app.html.jinja2
@@ -9,7 +9,7 @@
      only ever displays a single route.
      #}
     <base target="_top" href="/" />
-  {% for url in app_css_urls %}
+    {% for url in app_css_urls %}
     <link rel="stylesheet" href="{{ url }}">
     {% endfor %}
     {% for attrs in meta_attrs -%}
@@ -34,6 +34,6 @@
     {% for url in app_js_urls %}
     <script src="{{ url }}"></script>
     {% endfor %}
-    
+
   </body>
 </html>

--- a/h/templates/embed.js.jinja2
+++ b/h/templates/embed.js.jinja2
@@ -1,3 +1,13 @@
+{% if client_boot_url %}
+(function () {
+  window.__HYP_APP_HTML_URL__ = '{{ app_html_url }}';
+  window.__HYP_CLIENT_ASSET_ROOT__ = '{{ client_asset_root }}';
+
+  var bootScriptEl = document.createElement('script');
+  bootScriptEl.src = '{{ client_boot_url }}';
+  document.head.appendChild(bootScriptEl);
+})();
+{% else %}
 (function () {
 // Detect presence of Hypothesis in the page
 var appLinkEl = document.querySelector('link[type="application/annotator+html"]');
@@ -57,3 +67,4 @@ install();
 
 return {installedURL: baseUrl.href};
 })();
+{% endif %}

--- a/h/views/client.py
+++ b/h/views/client.py
@@ -30,9 +30,6 @@ def render_app(request, extra=None):
     client_sentry_dsn = request.registry.settings.get('h.client.sentry_dsn')
     html = client.render_app_html(
         assets_env=request.registry['assets_client_env'],
-        # FIXME: The '' here is to ensure this has a trailing slash. This seems
-        # rather messy, and is inconsistent with the rest of the application's
-        # URLs.
         api_url=request.route_url('api.index'),
         service_url=request.route_url('index'),
         sentry_public_dsn=client_sentry_dsn,

--- a/h/views/client.py
+++ b/h/views/client.py
@@ -18,6 +18,11 @@ from h.util.view import json_view
 
 def render_app(request, extra=None):
     """Render a page that serves a preconfigured annotation client."""
+
+    client_boot_url = None
+    if request.feature('use_client_boot_script'):
+        client_boot_url = request.route_url('assets_client', subpath='boot.js')
+
     client_sentry_dsn = request.registry.settings.get('h.client.sentry_dsn')
     html = client.render_app_html(
         assets_env=request.registry['assets_client_env'],
@@ -29,7 +34,8 @@ def render_app(request, extra=None):
         sentry_public_dsn=client_sentry_dsn,
         websocket_url=request.registry.settings.get('h.websocket_url'),
         ga_client_tracking_id=request.registry.settings.get('ga_client_tracking_id'),
-        extra=extra)
+        extra=extra,
+        client_boot_url=client_boot_url)
     request.response.text = html
     return request.response
 
@@ -52,11 +58,17 @@ def annotator_token(request):
 
 @view_config(route_name='embed')
 def embed(context, request):
+    client_boot_url = None
+    if request.feature('use_client_boot_script'):
+        client_boot_url = request.route_url('assets_client', subpath='boot.js')
+
     request.response.content_type = b'text/javascript'
     request.response.text = client.render_embed_js(
         assets_env=request.registry['assets_client_env'],
         app_html_url=request.route_url('widget'),
-        base_url=request.route_url('index'))
+        base_url=request.route_url('index'),
+        client_asset_root=request.route_url('assets_client', subpath=''),
+        client_boot_url=client_boot_url)
     return request.response
 
 

--- a/tests/h/views/client_test.py
+++ b/tests/h/views/client_test.py
@@ -2,6 +2,7 @@
 
 from __future__ import unicode_literals
 
+from mock import Mock
 import pytest
 
 from h.views import client
@@ -17,6 +18,52 @@ def test_annotator_token_returns_token(generate_jwt, pyramid_request):
     result = client.annotator_token(pyramid_request)
 
     assert result == generate_jwt.return_value
+
+
+@pytest.mark.usefixtures('routes')
+class TestRenderApp(object):
+    def test_uses_client_boot_script(self, pyramid_request_):
+        pyramid_request_.feature.flags['use_client_boot_script'] = True
+        rsp = client.render_app(pyramid_request_)
+        assert '<script src="http://example.com/assets/client/boot.js"></script>' in rsp.text
+
+    def test_does_not_use_client_boot_script_when_disabled(self, pyramid_request_):
+        pyramid_request_.feature.flags['use_client_boot_script'] = False
+        rsp = client.render_app(pyramid_request_)
+        assert '<script src="http://example.com/assets/client/boot.js"></script>' not in rsp.text
+
+
+@pytest.mark.usefixtures('routes')
+class TestEmbed(object):
+    def test_uses_client_boot_script(self, pyramid_request_):
+        pyramid_request_.feature.flags['use_client_boot_script'] = True
+        ctx = client.embed(pyramid_request_)
+        assert ctx['client_boot_url'] == 'http://example.com/assets/client/boot.js'
+
+    def test_does_not_use_client_boot_script_when_disabled(self, pyramid_request_):
+        pyramid_request_.feature.flags['use_client_boot_script'] = False
+        ctx = client.embed(pyramid_request_)
+        assert ctx['client_boot_url'] is None
+
+    def test_sets_content_type(self, pyramid_request_):
+        client.embed(pyramid_request_)
+        assert pyramid_request_.response.content_type == 'text/javascript'
+
+
+@pytest.fixture
+def pyramid_request_(pyramid_request):
+    assets_client_env = Mock(spec_set=['urls'])
+    assets_client_env.urls.return_value = []
+    pyramid_request.registry['assets_client_env'] = assets_client_env
+    return pyramid_request
+
+
+@pytest.fixture
+def routes(pyramid_config):
+    pyramid_config.add_route('api.index', '/api')
+    pyramid_config.add_route('assets_client', '/assets/client/{subpath}')
+    pyramid_config.add_route('index', '/')
+    pyramid_config.add_route('widget', '/app.html')
 
 
 @pytest.fixture

--- a/tests/h/views/main_test.py
+++ b/tests/h/views/main_test.py
@@ -143,6 +143,7 @@ def pyramid_config(pyramid_config):
 def routes(pyramid_config):
     pyramid_config.add_route('api.annotation', '/api/ann/{id}')
     pyramid_config.add_route('api.index', '/api/index')
+    pyramid_config.add_route('assets_client', '/assets/client')
     pyramid_config.add_route('index', '/index')
 
 


### PR DESCRIPTION
This is a follow-up to https://github.com/hypothesis/h/pull/4355 which removes an unnecessary separation between `h.client.embed_context` and `h.views.client.embed`. The separation dated back to when `h.client` was used to build the browser extension.