### PR TITLE
Add endpoint for debugging OAuth tokens

### DIFF
--- a/h/models/token.py
+++ b/h/models/token.py
@@ -66,7 +66,10 @@ class Token(Base, mixins.Timestamps):
     @property
     def expired(self):
         """True if this token has expired, False otherwise."""
-        return self.expires and datetime.datetime.utcnow() > self.expires
+        if self.expires:
+            return datetime.datetime.utcnow() > self.expires
+
+        return False
 
     @property
     def ttl(self):

--- a/h/routes.py
+++ b/h/routes.py
@@ -63,6 +63,7 @@ def includeme(config):
     # API (other than those provided by memex)
     config.add_route('badge', '/api/badge')
     config.add_route('api.profile', '/api/profile')
+    config.add_route('api.debug_token', '/api/debug-token')
     config.add_route('token', '/api/token')
     config.add_route('api.users', '/api/users')
 

--- a/h/services/auth_token.py
+++ b/h/services/auth_token.py
@@ -30,7 +30,10 @@ class AuthTokenService(object):
         """
 
         if token_str in self._validate_cache:
-            return self._validate_cache[token_str]
+            token = self._validate_cache[token_str]
+            if token is not None and token.is_valid():
+                return token
+            return None
 
         token = self._fetch_auth_token(token_str)
         self._validate_cache[token_str] = token

--- a/h/services/auth_token.py
+++ b/h/services/auth_token.py
@@ -32,16 +32,31 @@ class AuthTokenService(object):
         if token_str in self._validate_cache:
             return self._validate_cache[token_str]
 
-        token = self._fetch_token(token_str)
+        token = self._fetch_auth_token(token_str)
         self._validate_cache[token_str] = token
         if token is not None and token.is_valid():
             return token
         return None
 
-    def _fetch_token(self, token_str):
-        token_model = (self._session.query(models.Token)
-                       .filter_by(value=token_str)
-                       .one_or_none())
+    def fetch(self, token_str):
+        """
+        Fetch and return a token.
+
+        This returns a ``h.models.Token`` in comparison to what ``validate``
+        returns. Note that this method does not cache the loaded tokens, thus
+        it will potentially run the same database query multiple times.
+
+        :param token_str: the token string
+        :type token_str: unicode
+
+        :returns: the token object or ``None``
+        """
+        return (self._session.query(models.Token)
+                    .filter_by(value=token_str)
+                    .one_or_none())
+
+    def _fetch_auth_token(self, token_str):
+        token_model = self.fetch(token_str)
         if token_model is not None:
             token = Token(token_model)
             return token

--- a/tests/functional/test_oauth.py
+++ b/tests/functional/test_oauth.py
@@ -18,19 +18,18 @@ class TestOAuth(object):
         access_token = response['access_token']
 
         # Test that you can use the access token to authorize with the API.
-        profile = app.get(
-            '/api/profile',
+        app.get(
+            '/api/debug-token',
             headers={'Authorization': str('Bearer {}'.format(access_token))},
         )
-        assert profile.json_body['userid']
 
     def test_request_fails_if_access_token_wrong(self, app, authclient,
                                                  userid):
-        profile = app.get(
-            '/api/profile',
+        app.get(
+            '/api/debug-token',
             headers={'Authorization': str('Bearer wrong')},
+            status=401,
         )
-        assert profile.json_body['userid'] is None
 
     def test_request_fails_if_access_token_expired(self, app, authclient,
                                                    db_session, factories,
@@ -40,11 +39,11 @@ class TestOAuth(object):
         token = token.value
         db_session.commit()
 
-        profile = app.get(
-            '/api/profile',
+        app.get(
+            '/api/debug-token',
             headers={'Authorization': str('Bearer {}'.format(token))},
+            status=401,
         )
-        assert profile.json_body['userid'] is None
 
     def test_using_a_refresh_token(self, app, authclient, userid):
         """Get a new access token by POSTing a refresh token to /api/token."""
@@ -64,22 +63,20 @@ class TestOAuth(object):
         new_access_token = response.json_body['access_token']
 
         # Test that the new access token works.
-        new_token_profile = app.get(
-            '/api/profile',
+        app.get(
+            '/api/debug-token',
             headers={
                 'Authorization': str('Bearer {}'.format(new_access_token)),
             },
         )
-        assert new_token_profile.json_body['userid']
 
         # Test that the old access token still works, too.
-        old_token_profile = app.get(
-            '/api/profile',
+        app.get(
+            '/api/debug-token',
             headers={
                 'Authorization': str('Bearer {}'.format(old_access_token)),
             },
         )
-        assert old_token_profile.json_body['userid']
 
     def test_refresh_token_request_fails_if_refresh_token_wrong(self, app,
                                                                 authclient,
@@ -117,11 +114,11 @@ class TestOAuth(object):
         response = self.get_access_token(app, authclient, userid)
         refresh_token = response['refresh_token']
 
-        profile = app.get(
-            '/api/profile',
+        app.get(
+            '/api/debug-token',
             headers={'Authorization': str('Bearer {}'.format(refresh_token))},
+            status=401,
         )
-        assert profile.json_body['userid'] is None
 
     def get_access_token(self, app, authclient, userid):
         """Get an access token by POSTing a grant token to /api/token."""

--- a/tests/h/models/token_test.py
+++ b/tests/h/models/token_test.py
@@ -52,18 +52,18 @@ class TestToken(object):
         expires = datetime.datetime.utcnow() + datetime.timedelta(hours=1)
         token = Token(expires=expires)
 
-        assert not token.expired
+        assert token.expired is False
 
     def test_expired_is_false_if_expires_is_none(self):
         token = Token(expires=None)
 
-        assert not token.expired
+        assert token.expired is False
 
     def test_expired_is_true_if_expires_is_in_the_past(self):
         expires = datetime.datetime.utcnow() - datetime.timedelta(hours=1)
         token = Token(expires=expires)
 
-        assert token.expired
+        assert token.expired is True
 
     def test_get_dev_token_by_userid_filters_by_userid(self, db_session, factories):
         token_1 = factories.Token(userid='acct:vanessa@example.org', authclient=None)

--- a/tests/h/routes_test.py
+++ b/tests/h/routes_test.py
@@ -57,6 +57,7 @@ def test_includeme():
         call('assets', '/assets/*subpath'),
         call('badge', '/api/badge'),
         call('api.profile', '/api/profile'),
+        call('api.debug_token', '/api/debug-token'),
         call('token', '/api/token'),
         call('api.users', '/api/users'),
         call('session', '/app'),

--- a/tests/h/services/auth_token_test.py
+++ b/tests/h/services/auth_token_test.py
@@ -58,9 +58,20 @@ class TestAuthTokenService(object):
 
         assert result is None
 
+    def test_fetch_returns_database_model(self, svc, token):
+        assert svc.fetch(token.value) == token
+
+    @pytest.mark.usefixtures('token')
+    def test_fetch_returns_none_when_not_found(self, svc):
+        assert svc.fetch('bogus') is None
+
     @pytest.fixture
     def svc(self, db_session):
         return AuthTokenService(db_session, 'secret')
+
+    @pytest.fixture
+    def token(self, factories):
+        return factories.Token()
 
     def time(self, days_delta=0):
         return datetime.datetime.utcnow() + datetime.timedelta(days=days_delta)

--- a/tests/h/services/auth_token_test.py
+++ b/tests/h/services/auth_token_test.py
@@ -32,6 +32,15 @@ class TestAuthTokenService(object):
 
         assert result is not None
 
+    def test_validate_returns_none_for_cached_invalid_token(self, svc, factories, db_session):
+        token_model = factories.Token(expires=self.time(-1))
+
+        svc.validate(token_model.value)
+        db_session.delete(token_model)
+        result = svc.validate(token_model.value)
+
+        assert result is None
+
     def test_validate_returns_none_for_invalid_database_token(self, svc, factories):
         token_model = factories.Token(expires=self.time(-1))
 


### PR DESCRIPTION
This endpoint will return some information about the token at hand. This
only works with OAuth 2 and developer tokens, not with our legacy client
JWT tokens. Since this will mostly be used by other developers, I don't
think we need to add support for our legacy client tokens to this
endpoint.

Example request with successful response for developer token:

```
GET /api/debug-token
Authorization: Bearer {developer token}

HTTP/1.1 200 OK
{
  "userid": "acct:chdorner@localhost",
  "issued_at": "2016-12-21T18:13:24.970395+00:00",
  "expired": false,
  "expires_at": null
}
```

Example request with successful response for OAuth 2 token:

```
GET /api/debug-token
Authorization: Bearer {developer token}

HTTP/1.1 200 OK
{
  "userid": "acct:fred@partner-1.org",
  "client": {
    "id": "5a2a8d1a-9074-11e6-b888-d705d9289341",
    "name": "Partner 1"
  },
  "issued_at": "2017-02-08T14:18:56.041786+00:00",
  "expires_at": "2017-02-08T15:18:49.868218+00:00"
  "expired": false,
}
```

There are two error cases.

1. The token is missing in the Authentication HTTP header:

```
GET /api/debug-token

HTTP/1.1 401 Unauthorized
{
  "error_description": "Bearer token is missing in Authorization HTTP header",
  "error": "missing_token"
}
```

2. The token either does not exist, or is expired:

```
GET /api/debug-token
Authorization: Bearer {expired token}

HTTP/1.1 401 Unauthorized
{
  "error_description": "Bearer token does not exist or is expired",
  "error": "missing_token"
}
```