### PR TITLE
Enable collectd nginx plugin and nginx's status page

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ MAINTAINER Hypothes.is Project and contributors
 RUN apk-install \
     ca-certificates \
     collectd \
+    collectd-nginx \
     libffi \
     libpq \
     nginx \

--- a/conf/collectd.conf
+++ b/conf/collectd.conf
@@ -42,6 +42,7 @@ LoadPlugin interface
 LoadPlugin irq
 LoadPlugin load
 LoadPlugin memory
+LoadPlugin nginx
 LoadPlugin processes
 LoadPlugin swap
 LoadPlugin users
@@ -82,6 +83,10 @@ LoadPlugin users
 <Plugin interface>
 	Interface "eth0"
 	IgnoreSelected false
+</Plugin>
+
+<Plugin "nginx">
+	URL "http://127.0.0.234:5000/status"
 </Plugin>
 
 <Include "/etc/collectd/collectd.conf.d">

--- a/conf/nginx.conf.tpl
+++ b/conf/nginx.conf.tpl
@@ -84,4 +84,16 @@ http {
       # FALLBACK-END
     }
   }
+
+  server {
+    listen 127.0.0.234:5000;
+    server_name _;
+
+    location /status {
+      stub_status on;
+      access_log off;
+      allow 127.0.0.0/24;
+      deny all;
+    }
+  }
 }


### PR DESCRIPTION
The nginx status page is only going to be accessible locally inside the
docker container, collectd is then sending the data off with the other
metrics to graphite.