### PR TITLE
Add initial documentation on writing tests

### DIFF
--- a/docs/developing/index.rst
+++ b/docs/developing/index.rst
@@ -13,6 +13,7 @@ and how to contribute code or documentation to the project.
    introduction
    submitting-a-pr
    code-style
+   testing
    documentation
    ssl
    making-changes-to-model-code

--- a/docs/developing/testing.rst
+++ b/docs/developing/testing.rst
@@ -11,3 +11,23 @@ our tests, which covers some of the tools we use (``tox`` and ``pytest``) and
 some of the testing techniques they provide (factories and parametrization).
 
 .. _guide to getting started: https://www.seanh.cc/posts/running-the-h-tests
+
+Using mock objects
+------------------
+
+The ``mock`` library lets us construct fake versions of our objects to help with
+testing. While this can make it easier to write fast, isolated tests, it also
+makes it easier to write tests that don't reflect reality.
+
+Where practical, we prefer to write tests using (in order of preference):
+
+1. Real objects
+2. Fake objects
+3. Mock objects constructed with ``spec_set`` or ``autospec`` – these objects
+   will only respond to the same methods as the real objects they replace,
+   which reduces the risk of mocks that do not behave like their real
+   counterparts
+4. Generic mock objects
+
+This is a deliberate decision that, when we have to choose between test
+isolation and test fidelity, we usually want to choose test fidelity.

--- a/docs/developing/testing.rst
+++ b/docs/developing/testing.rst
@@ -27,15 +27,23 @@ The ``mock`` library lets us construct fake versions of our objects to help with
 testing. While this can make it easier to write fast, isolated tests, it also
 makes it easier to write tests that don't reflect reality.
 
-Where practical, we prefer to write tests using (in order of preference):
+In an ideal world, we would always be able to use real objects instead of stubs
+or mocks, but sometimes this can result in:
 
-1. Real objects
-2. Fake objects
-3. Mock objects constructed with ``spec_set`` or ``autospec`` – these objects
-   will only respond to the same methods as the real objects they replace,
-   which reduces the risk of mocks that do not behave like their real
-   counterparts
-4. Generic mock objects
+- complicated test setup code
+- slow tests
+- coupling of test assertions to non-interface implementation details
 
-This is a deliberate decision that, when we have to choose between test
-isolation and test fidelity, we usually want to choose test fidelity.
+For new code, it's usually a good idea to design the code so that it's easy to
+test with "real" objects, rather than stubs or mocks. It can help to make
+extensive use of `value objects`_ in tested interfaces (using
+``collections.namedtuple`` from the standard library, for example) and apply
+the `functional core, imperative shell`_ pattern.
+
+For older code which doesn't make testing so easy, or for code that is part of
+the "imperative shell" (see link in previous paragraph) it can sometimes be
+hard to test what you need without resorting to stubs or mock objects, and
+that's fine.
+
+.. _value objects: https://martinfowler.com/bliki/ValueObject.html
+.. _functional core, imperative shell: https://www.destroyallsoftware.com/talks/boundaries

--- a/docs/developing/testing.rst
+++ b/docs/developing/testing.rst
@@ -1,0 +1,13 @@
+Testing
+#######
+
+This section covers writing tests for the ``h`` codebase.
+
+Getting started
+---------------
+
+Sean Hammond has written up a `guide to getting started`_ running and writing
+our tests, which covers some of the tools we use (``tox`` and ``pytest``) and
+some of the testing techniques they provide (factories and parametrization).
+
+.. _guide to getting started: https://www.seanh.cc/posts/running-the-h-tests

--- a/docs/developing/testing.rst
+++ b/docs/developing/testing.rst
@@ -12,6 +12,14 @@ some of the testing techniques they provide (factories and parametrization).
 
 .. _guide to getting started: https://www.seanh.cc/posts/running-the-h-tests
 
+Unit and functional tests
+-------------------------
+
+We keep our functional tests separate from our unit tests, in the
+``tests/functional`` directory. Because these are slow to run, we will usually
+write one or two functional tests to check a new feature works in the common
+case, and unit tests for all the other cases.
+
 Using mock objects
 ------------------
 


### PR DESCRIPTION
This initially sprang out of some confusion on my part, where I assumed – based on the [tests for the session module](https://github.com/hypothesis/h/blob/4db28c5da0ca91b765c11d2d6bbc6c7a4231b52f/tests/h/session_test.py) that we wanted to use mocks heavily in our codebase.

This is by no means complete, and may well not be an accurate representation of how we collectively want to work. Comments, musings and enthusiastic agreement or dissent are all welcome.