### PR TITLE
Fix statsd prefix ec2 instance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,4 +64,4 @@ ENV PYTHONPATH /var/lib/hypothesis:$PYTHONPATH
 
 # Start the web server by default
 USER hypothesis
-CMD ["supervisord", "-c" , "conf/supervisord.conf"]
+CMD ["init-env", "supervisord", "-c" , "conf/supervisord.conf"]

--- a/bin/init-env
+++ b/bin/init-env
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+: ${STATSD_PREFIX:=}
+
+set -eu
+
+extend_statsd_prefix () {
+  local statsd_prefix=${1}
+  local instance_id=${2}
+
+  local hostname
+  if [ -z "${instance_id}" ]; then
+    hostname=$(hostname)
+  else
+    hostname=${instance_id}
+  fi
+
+  if [ -n "${statsd_prefix}" ]; then
+    statsd_prefix="${statsd_prefix}."
+  fi
+  echo "${statsd_prefix}${hostname}"
+}
+
+export INSTANCE_ID=$(wget -O - -T 1 http://169.254.169.254/1.0/meta-data/instance-id 2>/dev/null || echo '')
+export STATSD_PREFIX=$(extend_statsd_prefix "$STATSD_PREFIX" "$INSTANCE_ID")
+
+exec "$@"

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -23,8 +23,7 @@ if not os.environ.get('GUNICORN_STATS_DISABLE', None):
         statsd_host = '{}:{}'.format(_host, _port)
 
     if 'STATSD_PREFIX' in os.environ:
-        _hostname = socket.gethostname()
-        statsd_prefix = '.'.join([os.environ['STATSD_PREFIX'], _hostname])
+        statsd_prefix = os.environ['STATSD_PREFIX']
 
 
 def post_fork(server, worker):

--- a/h/config.py
+++ b/h/config.py
@@ -112,8 +112,4 @@ def configure(environ=None, settings=None):
             level = logging.DEBUG
         logging.getLogger('sqlalchemy.engine').setLevel(level)
 
-    if 'STATSD_PREFIX' in os.environ:
-        hostname = socket.gethostname()
-        settings['statsd.prefix'] = '.'.join([os.environ['STATSD_PREFIX'], hostname])
-
     return Configurator(settings=settings)


### PR DESCRIPTION
This removes the rather crude handling of the `STATSD_PREFIX` where we add the hostname of the instance at the end of the configured (or empty) prefix (done [here](https://github.com/hypothesis/h/blob/0c716a0ffdf58ff74a98cc4bdcf82b2975b92eab/gunicorn.conf.py#L26-L27) and [here](https://github.com/hypothesis/h/blob/0c716a0ffdf58ff74a98cc4bdcf82b2975b92eab/h/config.py#L115-L117)).

To achieve this we add a new shell script `init-env` which wraps supervisor. It first tries to get the instance id from the EC2 metadata API and sets the `INSTANCE_ID` environment variable to this value (or empty when we're not running in a non-EC2 environment). Then it appends either the instance id, or `hostname` to at the end of the already configured (or empty) `STATSD_PREFIX` environment variable.

This way we can get rid of any special `STATSD_PREFIX` handling from the Python code and only deal with it in the helper scripts.