### PR TITLE
Limit celery ping replies to one answer

### DIFF
--- a/h/views/status.py
+++ b/h/views/status.py
@@ -40,7 +40,7 @@ def _check_search(request):
 
 def _check_celery():
     try:
-        result = celery.control.ping(timeout=0.25)
+        result = celery.control.ping(timeout=0.25, limit=1)
         if not result:
             raise APIError('Celery ping failed')
 


### PR DESCRIPTION
Otherwise it tries to read messages until the given timeout is reached.
This should get our response times for the status endpoint down a bit.

This might return wrong data while we're running both the old infrastructure and Skyliner at the same time, but as soon as we turn off the old one this should always be correct.