### PR TITLE
Don't collect disk usage metrics for weird mountpoints

### DIFF
--- a/conf/collectd.conf
+++ b/conf/collectd.conf
@@ -55,11 +55,14 @@ LoadPlugin users
 ##############################################################################
 
 <Plugin df>
-	# ignore rootfs; else, the root file-system would appear twice, causing
+	# Ignore (rather than include) the specific filesystems listed below.
+	IgnoreSelected true
+
+	# Ignore rootfs; else, the root file-system would appear twice, causing
 	# one of the updates to fail and spam the log
 	FSType rootfs
 
-	# ignore the usual virtual / temporary file-systems
+	# Ignore the usual virtual / temporary file-systems
 	FSType sysfs
 	FSType proc
 	FSType devtmpfs
@@ -67,7 +70,11 @@ LoadPlugin users
 	FSType tmpfs
 	FSType fusectl
 	FSType cgroup
-	IgnoreSelected true
+
+	# Ignore pointless docker bind-mounts
+	MountPoint "/etc/hostname"
+	MountPoint "/etc/hosts"
+	MountPoint "/etc/resolv.conf"
 
 	ReportInodes true
 


### PR DESCRIPTION
These single-file mountpoints are an artifact of the Docker engine, and so aren't worth reporting to graphite.