### PR TITLE
Remove an unused parameter from a test helper

### DIFF
--- a/tests/h/services/oauth_test.py
+++ b/tests/h/services/oauth_test.py
@@ -259,9 +259,8 @@ class TestOAuthServiceVerifyJWTBearerRequest(object):
     def jwt_token(self, claims, secret, algorithm='HS256'):
         return text_type(jwt.encode(claims, secret, algorithm=algorithm))
 
-    def epoch(self, timestamp=None, delta=None):
-        if timestamp is None:
-            timestamp = datetime.utcnow()
+    def epoch(self, delta=None):
+        timestamp = datetime.utcnow()
 
         if delta is not None:
             timestamp = timestamp + delta


### PR DESCRIPTION
This helper gives the option of specifying a custom base timestamp as well as a `timedelta` offset, but none of the tests currently use it.