### PR TITLE
Add PATCH support for annotation update API endpoint

### DIFF
--- a/docs/_extra/api/hypothesis.yaml
+++ b/docs/_extra/api/hypothesis.yaml
@@ -131,8 +131,18 @@ paths:
           description: Annotation not found or no permission to view
           schema:
             $ref: '#/definitions/Error'
-    put:
+    patch:
       summary: Update an annotation
+      description: |
+        This endpoint is available under both the `PATCH` and `PUT`
+        request methods. Both endpoints have PATCH-characteristics
+        as defined in [RFC5789](https://tools.ietf.org/html/rfc5789#section-1),
+        meaning the request body does not have to include the whole annotation
+        object.
+
+        New implementations should use the `PATCH` request method, and existing
+        implementations continue to work under `PUT` but should switch to `PATCH`.
+
       operationId: updateAnnotation
       parameters:
         - name: id

--- a/src/memex/views.py
+++ b/src/memex/views.py
@@ -254,6 +254,9 @@ def read_jsonld(context, request):
             description='Update an annotation')
 def update(context, request):
     """Update the specified annotation with data from the PATCH payload."""
+    if request.method == 'PUT' and hasattr(request, 'stats'):
+        request.stats.incr('memex.api.deprecated.put_update_annotation')
+
     schema = schemas.UpdateAnnotationSchema(request,
                                             context.annotation.target_uri,
                                             context.annotation.groupid)

--- a/src/memex/views.py
+++ b/src/memex/views.py
@@ -248,12 +248,12 @@ def read_jsonld(context, request):
 
 
 @api_config(route_name='api.annotation',
-            request_method='PUT',
+            request_method=('PATCH', 'PUT'),
             permission='update',
             link_name='annotation.update',
             description='Update an annotation')
 def update(context, request):
-    """Update the specified annotation with data from the PUT payload."""
+    """Update the specified annotation with data from the PATCH payload."""
     schema = schemas.UpdateAnnotationSchema(request,
                                             context.annotation.target_uri,
                                             context.annotation.groupid)

--- a/src/memex/views.py
+++ b/src/memex/views.py
@@ -42,7 +42,7 @@ cors_policy = cors.policy(
         'X-Annotator-Auth-Token',
         'X-Client-Id',
     ),
-    allow_methods=('HEAD', 'GET', 'POST', 'PUT', 'DELETE'),
+    allow_methods=('HEAD', 'GET', 'PATCH', 'POST', 'PUT', 'DELETE'),
     allow_preflight=True)
 
 
@@ -99,7 +99,7 @@ def add_api_view(config, view, link_name=None, description=None, **settings):
     if not isinstance(request_method, tuple):
         request_method = (request_method,)
     if len(request_method) == 0:
-        request_method = ('DELETE', 'GET', 'HEAD', 'POST', 'PUT',)
+        request_method = ('DELETE', 'GET', 'HEAD', 'PATCH', 'POST', 'PUT',)
     settings['request_method'] = request_method + ('OPTIONS',)
 
     if link_name:

--- a/tests/memex/views_test.py
+++ b/tests/memex/views_test.py
@@ -142,7 +142,7 @@ class TestIndex(object):
         assert links['annotation']['read']['method'] == 'GET'
         assert links['annotation']['read']['url'] == (
             host + '/dummy/annotations/:id')
-        assert links['annotation']['update']['method'] == 'PUT'
+        assert links['annotation']['update']['method'] == 'PATCH'
         assert links['annotation']['update']['url'] == (
             host + '/dummy/annotations/:id')
         assert links['search']['method'] == 'GET'

--- a/tests/memex/views_test.py
+++ b/tests/memex/views_test.py
@@ -78,7 +78,7 @@ class TestAddApiView(object):
         views.add_api_view(pyramid_config, view)
         (_, kwargs) = pyramid_config.add_view.call_args
         assert kwargs['request_method'] == (
-            'DELETE', 'GET', 'HEAD', 'POST', 'PUT', 'OPTIONS')
+            'DELETE', 'GET', 'HEAD', 'PATCH', 'POST', 'PUT', 'OPTIONS')
 
     @pytest.mark.parametrize('link_name,description,request_method,expected_method', [
         ('thing.read', 'Fetch a thing', None, 'GET'),

--- a/tests/memex/views_test.py
+++ b/tests/memex/views_test.py
@@ -501,6 +501,14 @@ class TestUpdate(object):
         assert returned == (
             AnnotationJSONPresenter.return_value.asdict.return_value)
 
+    def test_it_tracks_deprecated_put_requests(self, pyramid_request):
+        pyramid_request.method = 'PUT'
+        pyramid_request.stats = mock.Mock(spec_set=['incr'])
+
+        views.update(mock.Mock(), pyramid_request)
+
+        pyramid_request.stats.incr.assert_called_once_with('memex.api.deprecated.put_update_annotation')
+
     @pytest.fixture
     def pyramid_request(self, pyramid_request):
         pyramid_request.json_body = {}


### PR DESCRIPTION
The current update annotations endpoint mixes the `PUT` request method with `PATCH` characteristics. This PR changes this, but we can't just remove the `PUT` request method as there might still be API clients out there that are using `PUT`, so we support both for now.

This also adds a statsd counter that gets incremented every time we get a request with the `PUT` request method, this will allow us to determine when we can remove `PUT` support.

Backlog ticket: hypothesis/product-backlog#147