### PR TITLE
Add an admin page which can send test mails

### DIFF
--- a/h/admin/views/__init__.py
+++ b/h/admin/views/__init__.py
@@ -7,6 +7,7 @@ def includeme(config):
     config.include('.badge')
     config.include('.features')
     config.include('.groups')
+    config.include('.mailer')
     config.include('.nipsa')
     config.include('.staff')
     config.include('.users')

--- a/h/admin/views/mailer.py
+++ b/h/admin/views/mailer.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from pyramid.httpexceptions import HTTPSeeOther
+from pyramid.view import view_config
+
+from h.emails import test
+from h.tasks import mailer
+
+
+@view_config(route_name='admin_mailer',
+             request_method='GET',
+             renderer='h:templates/admin/mailer.html.jinja2',
+             permission='admin_mailer')
+def mailer_index(request):
+    """Show the mailer test tools."""
+    return {
+        'taskid': request.params.get('taskid')
+    }
+
+
+@view_config(route_name='admin_mailer_test',
+             request_method='POST',
+             permission='admin_mailer')
+def mailer_test(request):
+    """Send a test email."""
+    if 'recipient' not in request.params:
+        index = request.route_path('admin_mailer')
+        return HTTPSeeOther(location=index)
+
+    mail = test.generate(request, request.params['recipient'])
+    result = mailer.send.delay(*mail)
+    index = request.route_path('admin_mailer',
+                               _query={'taskid': result.task_id})
+    return HTTPSeeOther(location=index)
+
+
+def includeme(config):
+    config.scan(__name__)

--- a/h/emails/test.py
+++ b/h/emails/test.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import datetime
+import platform
+
+from pyramid.renderers import render
+
+from h import __version__
+
+
+def generate(request, recipient):
+    """
+    Generate a test email.
+
+    :param request: the current request
+    :type request: pyramid.request.Request
+    :param recipient: the recipient of the test email
+    :type recipient: str
+
+    :returns: a 4-element tuple containing: recipients, subject, text, html
+    """
+
+    context = {
+        'time': datetime.datetime.utcnow().isoformat(),
+        'hostname': platform.node(),
+        'python_version': platform.python_version(),
+        'version': __version__,
+    }
+
+    text = render('h:templates/emails/test.txt.jinja2', context, request=request)
+    html = render('h:templates/emails/test.html.jinja2', context, request=request)
+
+    return [recipient], 'Test mail', text, html

--- a/h/resources.py
+++ b/h/resources.py
@@ -11,6 +11,7 @@ class Root(object):
     __acl__ = [
         (Allow, role.Staff, 'admin_index'),
         (Allow, role.Staff, 'admin_groups'),
+        (Allow, role.Staff, 'admin_mailer'),
         (Allow, role.Staff, 'admin_users'),
         (Allow, role.Admin, ALL_PERMISSIONS),
         DENY_ALL

--- a/h/routes.py
+++ b/h/routes.py
@@ -40,6 +40,8 @@ def includeme(config):
     config.add_route('admin_cohorts_edit', '/admin/features/cohorts/{id}')
     config.add_route('admin_groups', '/admin/groups')
     config.add_route('admin_groups_csv', '/admin/groups.csv')
+    config.add_route('admin_mailer', '/admin/mailer')
+    config.add_route('admin_mailer_test', '/admin/mailer/test')
     config.add_route('admin_nipsa', '/admin/nipsa')
     config.add_route('admin_staff', '/admin/staff')
     config.add_route('admin_users', '/admin/users')

--- a/h/templates/admin/mailer.html.jinja2
+++ b/h/templates/admin/mailer.html.jinja2
@@ -1,0 +1,30 @@
+{% extends "h:templates/layouts/admin.html.jinja2" %}
+
+{% set page_id = 'mailer' %}
+{% set page_title = 'Mailer' %}
+
+{% block content %}
+
+{% if taskid %}
+  <div class="alert alert-info alert-dismissable" role="alert">
+    <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+    <p>Task submitted with ID: <code>{{ taskid }}</code></p>
+  </div>
+{% endif %}
+
+  <div class="panel panel-default">
+    <div class="panel-heading">
+      <h3 class="panel-title">Send a test email</h3>
+    </div>
+    <div class="panel-body">
+      <form method="POST" action="{{ request.route_path('admin_mailer_test') }}" class="form-inline">
+        <div class="form-group">
+          <label for="recipient">Recipient</label>
+          <input type="text" class="form-control" name="recipient">
+          <input type="submit" class="btn btn-default" value="Send">
+        </div>
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/h/templates/emails/test.html.jinja2
+++ b/h/templates/emails/test.html.jinja2
@@ -1,0 +1,10 @@
+<p>This is a Hypothesis test email. Is this thing on...?</p>
+
+<pre><code>
+    time:            {{ time }}
+    hostname:        {{ hostname }}
+    python_version:  {{ python_version }}
+    version:         {{ version }}
+</code></pre>
+
+<p>Regards,<br> The Mail Robot</p>

--- a/h/templates/emails/test.txt.jinja2
+++ b/h/templates/emails/test.txt.jinja2
@@ -1,0 +1,9 @@
+This is a Hypothesis test email. Is this thing on...?
+
+    time:            {{ time }}
+    hostname:        {{ hostname }}
+    python_version:  {{ python_version }}
+    version:         {{ version }}
+
+Regards,
+The Mail Robot

--- a/h/templates/layouts/admin.html.jinja2
+++ b/h/templates/layouts/admin.html.jinja2
@@ -4,6 +4,7 @@
       ('features', 'admin_features', 'Manage feature flags'),
       ('cohorts', 'admin_cohorts', 'Manage feature cohorts'),
     ]),
+    ('mailer', 'admin_mailer', 'Mailer', []),
     ('nipsa', 'admin_nipsa', 'NIPSA', []),
     ('admins', 'admin_admins', 'Administrators', []),
     ('staff', 'admin_staff', 'Staff', []),

--- a/tests/h/admin/views/mailer_test.py
+++ b/tests/h/admin/views/mailer_test.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import pytest
+
+from pyramid.httpexceptions import HTTPSeeOther
+
+from h.admin.views import mailer as views
+
+
+class TestMailerIndex(object):
+
+    def test_when_no_taskid(self, pyramid_request):
+        result = views.mailer_index(pyramid_request)
+
+        assert result == {'taskid': None}
+
+    def test_with_taskid(self, pyramid_request):
+        pyramid_request.params['taskid'] = 'abcd1234'
+
+        result = views.mailer_index(pyramid_request)
+
+        assert result == {'taskid': 'abcd1234'}
+
+
+@pytest.mark.usefixtures('mailer', 'testmail', 'routes')
+class TestMailerTest(object):
+
+    def test_doesnt_mail_when_no_recipient(self, mailer, pyramid_request):
+        views.mailer_test(pyramid_request)
+
+        assert not mailer.send.delay.called
+
+    def test_redirects_when_no_recipient(self, pyramid_request):
+        result = views.mailer_test(pyramid_request)
+
+        assert isinstance(result, HTTPSeeOther)
+        assert result.location == '/adm/mailer'
+
+    def test_sends_mail(self, mailer, pyramid_request, testmail):
+        pyramid_request.params['recipient'] = 'meerkat@example.com'
+
+        views.mailer_test(pyramid_request)
+
+        mailer.send.delay.assert_called_once_with(['meerkat@example.com'], 'TEST', 'text', 'html')
+
+    def test_redirects(self, mailer, pyramid_request, testmail):
+        pyramid_request.params['recipient'] = 'meerkat@example.com'
+
+        result = views.mailer_test(pyramid_request)
+
+        assert isinstance(result, HTTPSeeOther)
+        assert result.location == '/adm/mailer?taskid=a1b2c3'
+
+
+class FakeResult(object):
+    def __init__(self):
+        self.task_id = 'a1b2c3'
+
+
+@pytest.fixture
+def mailer(patch):
+    mailer = patch('h.admin.views.mailer.mailer')
+    mailer.send.delay.return_value = FakeResult()
+    return mailer
+
+
+@pytest.fixture
+def testmail(patch):
+    test = patch('h.admin.views.mailer.test')
+    test.generate.side_effect = lambda _, r: ([r], 'TEST', 'text', 'html')
+    return test
+
+
+@pytest.fixture
+def routes(pyramid_config):
+    pyramid_config.add_route('admin_mailer', '/adm/mailer')

--- a/tests/h/emails/test_test.py
+++ b/tests/h/emails/test_test.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import pytest
+
+from h._compat import string_types
+from h.emails.test import generate
+
+from h import __version__
+
+
+class TestGenerate(object):
+
+    def test_calls_renderers_with_appropriate_context(self,
+                                                      pyramid_request,
+                                                      html_renderer,
+                                                      text_renderer,
+                                                      matchers):
+        generate(pyramid_request, 'meerkat@example.com')
+
+        expected_context = {
+            'time': matchers.instance_of(string_types),
+            'hostname': matchers.instance_of(string_types),
+            'python_version': matchers.instance_of(string_types),
+            'version': __version__,
+        }
+        html_renderer.assert_(**expected_context)
+        text_renderer.assert_(**expected_context)
+
+    def test_appropriate_return_values(self,
+                                       pyramid_request,
+                                       html_renderer,
+                                       text_renderer):
+
+        html_renderer.string_response = 'HTML output'
+        text_renderer.string_response = 'Text output'
+
+        recipients, subject, text, html = generate(pyramid_request, 'meerkat@example.com')
+
+        assert recipients == ['meerkat@example.com']
+        assert subject == 'Test mail'
+        assert html == 'HTML output'
+        assert text == 'Text output'
+
+    def test_jinja_templates_render(self,
+                                    pyramid_config,
+                                    pyramid_request):
+        """Ensure that the jinja templates don't contain syntax errors"""
+        pyramid_config.include('pyramid_jinja2')
+
+        generate(pyramid_request, 'meerkat@example.com')
+
+    @pytest.fixture
+    def html_renderer(self, pyramid_config):
+        return pyramid_config.testing_add_renderer('h:templates/emails/test.html.jinja2')
+
+    @pytest.fixture
+    def text_renderer(self, pyramid_config):
+        return pyramid_config.testing_add_renderer('h:templates/emails/test.txt.jinja2')

--- a/tests/h/routes_test.py
+++ b/tests/h/routes_test.py
@@ -43,6 +43,8 @@ def test_includeme():
         call('admin_cohorts_edit', '/admin/features/cohorts/{id}'),
         call('admin_groups', '/admin/groups'),
         call('admin_groups_csv', '/admin/groups.csv'),
+        call('admin_mailer', '/admin/mailer'),
+        call('admin_mailer_test', '/admin/mailer/test'),
         call('admin_nipsa', '/admin/nipsa'),
         call('admin_staff', '/admin/staff'),
         call('admin_users', '/admin/users'),


### PR DESCRIPTION
Adds a section to the admin panel which can be used to test email sending. Any staff user can send test emails quickly and easily without having to sign up test accounts or awkwardly log into two accounts and send replies.

This is prompted by a mail outage yesterday, and part of a broader wish to add better tools to h for [testing in production](https://www.theguardian.com/info/developer-blog/2016/dec/20/testing-in-production-rethinking-the-conventional-deployment-pipeline).