### PR TITLE
Report celery task failure to the log in dev

### DIFF
--- a/h/celery.py
+++ b/h/celery.py
@@ -122,6 +122,19 @@ def transaction_abort(sender, **kwargs):
     sender.app.request.tm.abort()
 
 
+@signals.task_failure.connect
+def report_failure(sender, task_id, args, kwargs, einfo, **kw):
+    """Report a task failure to the console in development."""
+    if not sender.app.request.debug:
+        return
+    log.error('task failure: %s (%s) called with args=%s, kwargs=%s',
+              sender.name,
+              task_id,
+              args,
+              kwargs,
+              exc_info=einfo.exc_info)
+
+
 def start(argv, bootstrap):
     """Run the Celery CLI."""
     # We attach the bootstrap function directly to the Celery application


### PR DESCRIPTION
As reported in #4291, celery task failure isn't reported in development. Add a `task_failure` signal handler which logs exceptions thrown in tasks.

Fixes #4291.