### PR TITLE
Limit OAuth grant token lifetime (take 2)

### DIFF
--- a/tests/h/services/oauth_test.py
+++ b/tests/h/services/oauth_test.py
@@ -210,6 +210,65 @@ class TestOAuthServiceVerifyJWTBearerRequest(object):
         assert exc.value.type == 'invalid_grant'
         assert 'authenticated client and JWT subject authorities do not match' in exc.value
 
+    def test_missing_expiry(self, svc, claims, authclient, jwt_bearer_body):
+        del claims['exp']
+        jwt_bearer_body['assertion'] = self.jwt_token(claims, authclient.secret)
+
+        with pytest.raises(OAuthTokenError) as exc:
+            svc.verify_token_request(jwt_bearer_body)
+
+        assert exc.value.type == 'invalid_grant'
+        assert 'JWT is missing claim exp' in exc.value
+
+    def test_missing_nbf(self, svc, claims, authclient, jwt_bearer_body):
+        del claims['nbf']
+        jwt_bearer_body['assertion'] = self.jwt_token(claims, authclient.secret)
+
+        with pytest.raises(OAuthTokenError) as exc:
+            svc.verify_token_request(jwt_bearer_body)
+
+        assert exc.value.type == 'invalid_grant'
+        assert 'JWT is missing claim nbf' in exc.value
+
+    @pytest.mark.parametrize('claim_name', ['nbf', 'exp'])
+    def test_null_timestamp(self, svc, claims, authclient, jwt_bearer_body, claim_name):
+        claims[claim_name] = None
+        jwt_bearer_body['assertion'] = self.jwt_token(claims, authclient.secret)
+
+        with pytest.raises(OAuthTokenError) as exc:
+            svc.verify_token_request(jwt_bearer_body)
+
+        assert exc.value.type == 'invalid_grant'
+        assert 'JWT is missing claim {}'.format(claim_name) in exc.value
+
+    @pytest.mark.parametrize('claim_name,delta',
+                             [['nbf', timedelta(minutes=-5)],
+                              ['exp', timedelta(minutes=5)]])
+    def test_string_timestamp(self, svc, claims, authclient, jwt_bearer_body, claim_name, delta):
+        claims[claim_name] = text_type(self.epoch(delta=delta))
+        jwt_bearer_body['assertion'] = self.jwt_token(claims, authclient.secret)
+
+        with pytest.raises(OAuthTokenError) as exc:
+            svc.verify_token_request(jwt_bearer_body)
+
+        assert exc.value.type == 'invalid_grant'
+        assert 'invalid claim {}'.format(claim_name) in exc.value
+
+    @pytest.mark.parametrize('grant_start,grant_expiry',
+                             [[None, timedelta(minutes=15)],
+                              [timedelta(minutes=-15), None],
+                              [timedelta(minutes=-9), timedelta(minutes=9)]])
+    def test_overlong_expiry(self, svc, claims, authclient, jwt_bearer_body, grant_start, grant_expiry):
+        claims['nbf'] = self.epoch(delta=grant_start)
+        claims['exp'] = self.epoch(delta=grant_expiry)
+        jwt_bearer_body['assertion'] = self.jwt_token(claims, authclient.secret)
+
+        with pytest.raises(OAuthTokenError) as exc:
+            svc.verify_token_request(jwt_bearer_body)
+
+        assert exc.value.type == 'invalid_grant'
+        assert 'grant token lifetime is too long' in exc.value
+
     @pytest.fixture
     def svc(self, pyramid_request, db_session, user_service):
         return oauth.OAuthService(db_session, user_service, pyramid_request.domain)


### PR DESCRIPTION
This is another implementation of #4369, using the new grant token classes. It’s part of hypothesis/product-backlog#138.

To mitigate the security risks if a grant token is compromised, we're now making sure that these tokens will only be honoured if they are short-lived – namely, that they have a start time (`nbf`) and an expiry time (`exp`) and that the difference between them is no more than 10 minutes.

As part of this, the format validation on these timestamps is now more restrictive. The `pyjwt` library is pretty permissive, allowing `None` values and timestamp values as strings (e.g. `"1487339382"`).  Given that RFC 7519 [insists that these values MUST be numbers][1], we can reasonably reject values that are not number types.

[1]: https://tools.ietf.org/html/rfc7519#section-4.1.4