### PR TITLE
Make token leeway into a `timedelta`

### DIFF
--- a/h/services/oauth.py
+++ b/h/services/oauth.py
@@ -192,6 +192,7 @@ class VerifiedGrantToken(GrantToken):
     """
 
     MAX_LIFETIME = datetime.timedelta(minutes=10)
+    LEEWAY = datetime.timedelta(seconds=10)
 
     def __init__(self, token, key, audience):
         super(VerifiedGrantToken, self).__init__(token)
@@ -206,7 +207,7 @@ class VerifiedGrantToken(GrantToken):
                        algorithms=['HS256'],
                        audience=audience,
                        key=key,
-                       leeway=10)
+                       leeway=self.LEEWAY)
         except jwt.DecodeError:
             raise OAuthTokenError('invalid JWT signature', 'invalid_grant')
         except jwt.exceptions.InvalidAlgorithmError:

--- a/tests/h/services/oauth_test.py
+++ b/tests/h/services/oauth_test.py
@@ -151,6 +151,12 @@ class TestOAuthServiceVerifyJWTBearerRequest(object):
         assert exc.value.type == 'invalid_grant'
         assert 'not before is in the future' in exc.value.message
 
+    def test_jwt_expires_within_leeway(self, svc, claims, authclient, jwt_bearer_body):
+        claims['exp'] = self.epoch(delta=timedelta(seconds=-8))
+        jwt_bearer_body['assertion'] = self.jwt_token(claims, authclient.secret)
+
+        svc.verify_token_request(jwt_bearer_body)
+
     def test_jwt_expires_with_leeway_in_the_past(self, svc, claims, authclient, jwt_bearer_body):
         claims['exp'] = self.epoch(delta=timedelta(minutes=-2))
         jwt_bearer_body['assertion'] = self.jwt_token(claims, authclient.secret)


### PR DESCRIPTION
The `pyjwt` library accepts either a number (of seconds) [or a `timedelta` instance][1]. For the sake of making it more apparent what the number represents, using a `timedelta` is clearer.

[1]: https://github.com/jpadilla/pyjwt/blob/1.4.1/jwt/api_jwt.py#L87-L88