### PR TITLE
Update class name for config script tag in sidebar app

### DIFF
--- a/h/templates/app.html.jinja2
+++ b/h/templates/app.html.jinja2
@@ -25,8 +25,11 @@
   <body>
     <hypothesis-app></hypothesis-app>
 
+    {# The `js-hypothesis-settings` class should be removed once
+       https://github.com/hypothesis/client/pull/243 is released.
+     #}
     <!-- App Configuration !-->
-    <script class="js-hypothesis-settings" type="application/json">
+    <script class="js-hypothesis-config js-hypothesis-settings" type="application/json">
       {{ app_config | safe }}
     </script>
 


### PR DESCRIPTION
**This needs to be merged before https://github.com/hypothesis/client/pull/243 is deployed to the service**

https://github.com/hypothesis/client/pull/243 changes the client to use
the same class name, `js-hypothesis-config`, for config script tags in
both the sidebar app and host page.

This updates the service code to use the expected name.