### PR TITLE
Fix display of tag buttons in Firefox

### DIFF
--- a/h/static/styles/partials-v2/_search-result-sidebar.scss
+++ b/h/static/styles/partials-v2/_search-result-sidebar.scss
@@ -66,11 +66,14 @@
   @include reset-button;
   background-color: $grey-2;
   border-radius: 2px;
-  display: flex;
   margin-bottom: 5px;
   margin-right: 5px;
   padding: 5px;
   font-weight: bold;
+}
+
+.search-result-sidebar__tag-container {
+  display: flex;
 }
 
 .search-result-sidebar__tag-count {

--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -154,9 +154,17 @@
               name="toggle_tag_facet"
               value="{{ tag.tag }}"
               class="search-result-sidebar__tag">
-        {{ tag.tag }}
-        <span class="search-result-sidebar__tag-count">
-          {{ tag.count }}
+        {#
+          Add an extra container element to work around the fact that <button>s
+          can't be flex containers in FF51 and earlier:
+
+            https://bugzilla.mozilla.org/show_bug.cgi?id=984869
+        #}
+        <span class="search-result-sidebar__tag-container">
+          {{ tag.tag }}
+          <span class="search-result-sidebar__tag-count">
+            {{ tag.count }}
+          </span>
         </span>
       </button>
     {% endfor %}


### PR DESCRIPTION
As reported in #4296, Firefox (< 52) doesn't display the little tag buttons in search results correctly, due to a problem with declaring a <button> as a flex container:

  https://bugzilla.mozilla.org/show_bug.cgi?id=984869

Add a wrapper <span> within the button to serve as the flex container.

Fixes #4296.