### PR TITLE
Add documentation for the `/api/profile` endpoint

### DIFF
--- a/docs/_extra/api/hypothesis.yaml
+++ b/docs/_extra/api/hypothesis.yaml
@@ -197,6 +197,27 @@ paths:
           description: Annotation not found or no permission to delete
           schema:
             $ref: '#/definitions/Error'
+  /profile:
+    get:
+      summary: Get the user's profile
+      description: >
+        This can either be accessed with an API key, in which case it will show
+        the authenticated user's profile, or without, in which case it will show
+        information for a logged-out profile, including only public groups for
+        the current authority.
+      parameters:
+        - name: authority
+          in: query
+          description: >
+            The current authority if the user is not logged in.
+          required: false
+          type: string
+          default: "hypothes.is"
+      responses:
+        '200':
+          description: Profile information
+          schema:
+            $ref: '#/definitions/Profile'
   /search:
     get:
       summary: Search for annotations
@@ -337,3 +358,5 @@ definitions:
     $ref: './schemas/new-user-schema.json'
   User:
     $ref: './schemas/user-schema.json'
+  Profile:
+    $ref: './schemas/profile-schema.json'

--- a/docs/_extra/api/schemas/profile-schema.json
+++ b/docs/_extra/api/schemas/profile-schema.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "required": [
+    "authority",
+    "features",
+    "groups",
+    "preferences",
+    "userid"
+  ],
+  "properties": {
+    "authority": {
+      "type": "string"
+    },
+    "features": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "boolean"
+      }
+    },
+    "groups": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "public": {
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "preferences": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "boolean"
+      }
+    },
+    "userid": {
+      "type": ["null", "string"]
+    }
+  }
+}


### PR DESCRIPTION
While this endpoint probably still counts as slightly experimental, I think it's probably better documented than not.

This is some follow-up work for hypothesis/product-backlog#119.