### PR TITLE
Change default client URL to cdn.hypothes.is

### DIFF
--- a/h/views/client.py
+++ b/h/views/client.py
@@ -13,7 +13,6 @@ import json
 from pyramid.config import not_
 from pyramid.httpexceptions import HTTPFound
 from pyramid.view import view_config
-import requests
 
 from h._compat import urlparse
 from h import session as h_session
@@ -23,7 +22,7 @@ from h import __version__
 
 # Default URL for the client, which points to the latest version of the client
 # that was published to npm.
-DEFAULT_CLIENT_URL = 'https://unpkg.com/hypothesis'
+DEFAULT_CLIENT_URL = 'https://cdn.hypothes.is/hypothesis'
 
 
 def url_with_path(url):
@@ -38,20 +37,6 @@ def _client_url(request):
     Return the configured URL for the client.
     """
     return request.registry.settings.get('h.client_url', DEFAULT_CLIENT_URL)
-
-
-def _resolve_client_url(request):
-    """
-    Return the URL for the client after following any redirects.
-    """
-    client_url = _client_url(request)
-
-    # `requests.get` fetches the URL and follows any redirects along the way.
-    # The response URL will be the final URL that returned the content of the
-    # boot script.
-    client_script_rsp = requests.get(client_url)
-    client_script_rsp.raise_for_status()
-    return client_script_rsp.url
 
 
 def _app_html_context(assets_env, api_url, service_url, sentry_public_dsn,
@@ -187,8 +172,7 @@ def embed_redirect(request):
     This view provides a fixed URL which redirects to the latest version of the
     client, typically hosted on a CDN.
     """
-    client_url = _resolve_client_url(request)
-    return HTTPFound(location=client_url)
+    return HTTPFound(_client_url(request))
 
 
 @json_view(route_name='session', http_cache=0)

--- a/tests/h/views/client_test.py
+++ b/tests/h/views/client_test.py
@@ -2,13 +2,11 @@
 
 from __future__ import unicode_literals
 
-from h._compat import StringIO
 import json
 
-from mock import Mock, patch
+from mock import Mock
 from pyramid.httpexceptions import HTTPFound
 import pytest
-import requests
 
 from h.views import client
 from h import __version__
@@ -80,38 +78,13 @@ class TestEmbed(object):
         assert pyramid_request.response.content_type == 'text/javascript'
 
 
-@pytest.mark.usefixtures('requests_get', 'routes', 'pyramid_settings')
+@pytest.mark.usefixtures('routes', 'pyramid_settings')
 class TestEmbedRedirect(object):
-    def test_fetches_client_boot_script(self, pyramid_request, requests_get):
-        client.embed_redirect(pyramid_request)
-        requests_get.assert_called_with('https://unpkg.com/hypothesis')
-
-    def test_fetches_custom_client_boot_script(self, pyramid_request, requests_get):
-        pyramid_request.registry.settings['h.client_url'] = 'https://client.hypothes.is'
-        client.embed_redirect(pyramid_request)
-        requests_get.assert_called_with('https://client.hypothes.is')
-
     def test_redirects_to_client_boot_script(self, pyramid_request):
         rsp = client.embed_redirect(pyramid_request)
 
         assert isinstance(rsp, HTTPFound)
-        assert rsp.location == 'https://unpkg.com/hypothesis@0.100'
-
-
-@pytest.yield_fixture
-def requests_get(fake_client_boot_response):
-    with patch('h.views.client.requests.get') as requests_get:
-        requests_get.return_value = fake_client_boot_response
-        yield requests_get
-
-
-@pytest.fixture
-def fake_client_boot_response():
-    rsp = requests.models.Response()
-    rsp.url = 'https://unpkg.com/hypothesis@0.100'
-    rsp.raw = StringIO(b'/* client boot script */')
-    rsp.status_code = 200
-    return rsp
+        assert rsp.location == 'https://cdn.hypothes.is/hypothesis'
 
 
 @pytest.fixture


### PR DESCRIPTION
Change the default client URL to https://cdn.hypothes.is/hypothesis and remove
the logic for resolving the redirect which is not required since
`https://cdn.hypothes.is/hypothesis` returns the latest version of the
boot script rather than a redirect.