### PR TITLE
Add environment name to Sentry client

### DIFF
--- a/h/config.py
+++ b/h/config.py
@@ -81,6 +81,10 @@ SETTINGS = [
     EnvSetting('h.client_id', 'CLIENT_ID'),
     EnvSetting('h.client_secret', 'CLIENT_SECRET'),
     EnvSetting('h.client_url', 'CLIENT_URL'),
+    # Environment name, provided by the deployment environment. Please do
+    # *not* toggle functionality based on this value. It is intended as a
+    # label only.
+    EnvSetting('h.env', 'ENV'),
     EnvSetting('h.proxy_auth', 'PROXY_AUTH', type=asbool),
     EnvSetting('h.websocket_url', 'WEBSOCKET_URL'),
     # The client Sentry DSN should be of the public kind, lacking the password

--- a/h/sentry.py
+++ b/h/sentry.py
@@ -48,7 +48,11 @@ def get_client(settings):
     transport_name = settings.get('raven.transport')
     transport = GeventedHTTPTransport if transport_name == 'gevent' else None
 
-    return raven.Client(release=__version__,
+    # Application environment name
+    environment = settings.get('h.env', 'dev')
+
+    return raven.Client(environment=environment,
+                        release=__version__,
                         transport=transport,
                         processors=PROCESSORS)
 

--- a/tests/h/sentry_test.py
+++ b/tests/h/sentry_test.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import pytest
+
+from h.sentry import get_client
+
+
+class TestGetClient(object):
+
+    @pytest.mark.parametrize('settings,env', [
+        ({}, 'dev'),
+        ({'h.env': 'qa'}, 'qa'),
+        ({'h.env': 'prod'}, 'prod'),
+    ])
+    def test_set_environment(self, settings, env):
+        client = get_client(settings)
+
+        assert client.environment == env


### PR DESCRIPTION
Skyliner provides the ENV environment variable for our application, which contains either "prod" or "qa" depending on the environment.

Sentry supports partitioning reports based on the environment within a single application. Adding this metadata to the `Client` allows us to migrate QA and Prod onto a single application in Sentry.