### PR TITLE
Match dot- and case-variants when looking up by username

### DIFF
--- a/tests/h/models/user_test.py
+++ b/tests/h/models/user_test.py
@@ -67,6 +67,30 @@ def test_cannot_create_case_variant_of_user(db_session):
         db_session.flush()
 
 
+def test_filtering_by_username_matches_dot_variant_of_user(db_session):
+    fred = models.User(authority='example.com',
+                       username='fredbloggs',
+                       email='fred@example.com')
+    db_session.add(fred)
+    db_session.flush()
+
+    result = db_session.query(models.User).filter_by(username='fred.bloggs').one()
+
+    assert result == fred
+
+
+def test_filtering_by_username_matches_case_variant_of_user(db_session):
+    fred = models.User(authority='example.com',
+                       username='fredbloggs',
+                       email='fred@example.com')
+    db_session.add(fred)
+    db_session.flush()
+
+    result = db_session.query(models.User).filter_by(username='FredBloggs').one()
+
+    assert result == fred
+
+
 def test_userid_derived_from_username_and_authority():
     fred = models.User(authority='example.net',
                        username='fredbloggs',


### PR DESCRIPTION
We've had a number of support tickets from users who have created their accounts with usernames such as "JoeBloggs", and are later confused because they can't log in as "joebloggs".

This gets particularly confusing when, having had the login form tell them "User does not exist," they go and try and sign up again, at which point the signup form tells them that the username is taken.

This commit addresses this at the ORM level, by ensuring that all lookups against the "username" field are actually performed against the normalised "uid" field. That is, a query such as

```python
request.db.query(models.User).filter_by(username='Joe.Bloggs')
```

which would previously have resulted in a WHERE clause of

```sql
WHERE username = 'Joe.Bloggs'
```

will now result in a WHERE clause more like

```sql
WHERE uid = 'joebloggs'
```

where the term on the RHS has been run through the same `_username_to_uid` function that is used to generate the "uid" field in the first place.

Making this change in the User model rather than higher in the code could be argued to be a bit surprising if a developer isn't already familiar with this behaviour. On balance I think it's safer to put it here, as I can't think of any valid reason for wanting to look up a user by a literal username match rather than using this more liberal behaviour.