### PR TITLE
Schema migrations in preparation for user model changes

### DIFF
--- a/h/migrations/versions/1a40e75a524d_add_normalised_username_index.py
+++ b/h/migrations/versions/1a40e75a524d_add_normalised_username_index.py
@@ -1,0 +1,29 @@
+"""
+Add normalised username index
+
+Revision ID: 1a40e75a524d
+Revises: 02db2fa6ea98
+Create Date: 2017-03-02 13:55:24.290975
+"""
+
+from __future__ import unicode_literals
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '1a40e75a524d'
+down_revision = '02db2fa6ea98'
+
+
+def upgrade():
+    # Creating an index concurrently does not work inside a transaction
+    op.execute('COMMIT')
+    op.create_index(op.f('ix__user__userid'),
+                    'user',
+                    [sa.text("lower(replace(username, '.', ''))"), 'authority'],
+                    postgresql_concurrently=True)
+
+
+def downgrade():
+    op.drop_index(op.f('ix__user__userid'), 'user')

--- a/h/migrations/versions/faefe3b614db_make_user_uid_nullable.py
+++ b/h/migrations/versions/faefe3b614db_make_user_uid_nullable.py
@@ -1,0 +1,32 @@
+"""
+Make user uid nullable
+
+Revision ID: faefe3b614db
+Revises: 1a40e75a524d
+Create Date: 2017-03-02 14:17:41.708781
+"""
+
+from __future__ import unicode_literals
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = 'faefe3b614db'
+down_revision = '1a40e75a524d'
+
+user = sa.table('user',
+                sa.column('username', sa.UnicodeText()),
+                sa.column('uid', sa.UnicodeText()))
+
+def upgrade():
+    op.alter_column('user', 'uid', nullable=True)
+
+
+def downgrade():
+    # Backfill the uid column for any users that were created before this was
+    # rolled back.
+    op.execute(user.update()
+              .where(user.c.uid==None)
+              .values(uid=sa.func.lower(sa.func.replace(user.c.username, '.', ''))))
+    op.alter_column('user', 'uid', nullable=False)


### PR DESCRIPTION
We've had a number of support tickets from users who have created their accounts with usernames such as "JoeBloggs", and are later confused because they can't log in as "joebloggs".

This gets particularly confusing when, having had the login form tell them "User does not exist," they go and try and sign up again, at which point the signup form tells them that the username is taken.

This PR contains a couple of schema migrations which prepare for changes to model code (which will come in a following PR), which must be deployed and run first.