### PR TITLE
Match dot- and case-variants when looking up by username

### DIFF
--- a/h/templates/admin/users.html.jinja2
+++ b/h/templates/admin/users.html.jinja2
@@ -26,7 +26,6 @@
         <tbody>
           <tr><th>Username</th><td>{{ user.username }}</td></tr>
           <tr><th>Authority</th><td>{{ user.authority }}</td></tr>
-          <tr><th>UID</th><td>{{ user.uid }}</td></tr>
           <tr><th>Email</th><td>{{ user.email }}</td></tr>
           <tr><th>Registered</th><td>{{ user.registered_date }}</td></tr>
           <tr><th>Last login</th><td>{{ user.last_login_date }}</td></tr>

--- a/tests/common/factories.py
+++ b/tests/common/factories.py
@@ -87,10 +87,6 @@ class User(ModelFactory):
     email = factory.Faker('email')
     registered_date = factory.Faker('date_time_this_decade')
 
-    @factory.lazy_attribute
-    def uid(self):
-        return self.username.replace('.', '').lower()
-
 
 class Group(ModelFactory):
 

--- a/tests/h/models/user_test.py
+++ b/tests/h/models/user_test.py
@@ -67,6 +67,30 @@ def test_cannot_create_case_variant_of_user(db_session):
         db_session.flush()
 
 
+def test_filtering_by_username_matches_dot_variant_of_user(db_session):
+    fred = models.User(authority='example.com',
+                       username='fredbloggs',
+                       email='fred@example.com')
+    db_session.add(fred)
+    db_session.flush()
+
+    result = db_session.query(models.User).filter_by(username='fred.bloggs').one()
+
+    assert result == fred
+
+
+def test_filtering_by_username_matches_case_variant_of_user(db_session):
+    fred = models.User(authority='example.com',
+                       username='fredbloggs',
+                       email='fred@example.com')
+    db_session.add(fred)
+    db_session.flush()
+
+    result = db_session.query(models.User).filter_by(username='FredBloggs').one()
+
+    assert result == fred
+
+
 def test_userid_derived_from_username_and_authority():
     fred = models.User(authority='example.net',
                        username='fredbloggs',

--- a/tests/h/services/rename_user_test.py
+++ b/tests/h/services/rename_user_test.py
@@ -32,9 +32,9 @@ class TestRenameUserService(object):
 
         It's possible to have two different usernames, for example "bob.smith"
         and "Bob.Smith", that are "equivalent" in that they both reduce to the
-        same uid "bobsmith". While we can't allow two different users to have
-        the usernames "bob.smith" and "Bob.Smith", we _should_ allow renaming
-        a single "bob.smith" user to "Bob.Smith".
+        same normalised username "bobsmith". While we can't allow two
+        different users to have the usernames "bob.smith" and "Bob.Smith", we
+        _should_ allow renaming a single "bob.smith" user to "Bob.Smith".
 
         get_by_username() returns a User whose username is the same as or
         equivalent to the given username. If the returned User is the same user


### PR DESCRIPTION
We've had a number of support tickets from users who have created their accounts with usernames such as "JoeBloggs", and are later confused because they can't log in as "joebloggs".

This gets particularly confusing when, having had the login form tell them "User does not exist," they go and try and sign up again, at which point the signup form tells them that the username is taken.

This commit addresses this at the database and ORM level, by ensuring that all for comparisons against the username column, both sides of the comparison are normalised first. For example

```python
request.db.query(models.User).filter_by(username='Joe.Bloggs')
```

which would previously have resulted in a WHERE clause of

```sql
WHERE username = 'Joe.Bloggs'
```

will now result in a WHERE clause more like

```sql
WHERE lower(replace(username,     '.', '')) =
      lower(replace('Joe.Bloggs', '.', ''))
```

In order to make this feasible, I've made some changes to the user model. The separate `uid` column is gone, replaced by a unique functional index on the tuple:

    lower(replace(username, '.', '')), authority

This simultaneously achieves three ends:

1. It makes lookups by normalised username fast.
2. It ensures uniqueness of (normalised username, authority)
3. It (together with some changes to the UserIDComparator) makes lookups by userid fast.

With this in place, we're also able to remove the index on `authority` alone.

_**N.B.** This depends on #4396 being deployed and migrations run before merging._