### PR TITLE
Remove unnecessary _app_html_context function

### DIFF
--- a/h/templates/app.html.jinja2
+++ b/h/templates/app.html.jinja2
@@ -31,7 +31,7 @@
     </script>
 
     <!-- Client boot script !-->
-    <script src="{{ client_url }}"></script>
+    <script src="{{ embed_url }}"></script>
 
   </body>
 </html>

--- a/h/views/client.py
+++ b/h/views/client.py
@@ -41,7 +41,6 @@ def sidebar_app(request, extra=None):
     """
 
     settings = request.registry.settings
-    client_url = request.route_path('embed')
     ga_client_tracking_id = settings.get('ga_client_tracking_id')
     sentry_public_dsn = settings.get('h.client.sentry_dsn')
     websocket_url = settings.get('h.websocket_url')
@@ -73,7 +72,7 @@ def sidebar_app(request, extra=None):
 
     ctx = {
         'app_config': json.dumps(app_config),
-        'client_url': client_url,
+        'embed_url': request.route_path('embed'),
     }
 
     if extra is not None:

--- a/tests/h/views/client_test.py
+++ b/tests/h/views/client_test.py
@@ -45,10 +45,10 @@ class TestSidebarApp(object):
 
         assert actual_config == expected_config
 
-    def test_it_sets_client_url(self, pyramid_request):
+    def test_it_sets_embed_url(self, pyramid_request):
         ctx = client.sidebar_app(pyramid_request)
 
-        assert ctx['client_url'] == '/embed.js'
+        assert ctx['embed_url'] == '/embed.js'
 
 
 @pytest.mark.usefixtures('routes', 'pyramid_settings')


### PR DESCRIPTION
**Depends on https://github.com/hypothesis/h/pull/4399**

This removes an unnecessary `_app_html_context` helper function from the client views in favor of inlining its contents into the one place where it was used and a `url_with_path` helper this is also no longer required because the way we generate the service URL is now always guaranteed to include the path.