### PR TITLE
Remove unused indices and columns from user table

### DIFF
--- a/h/migrations/versions/18dfed902c9e_remove_unused_user_indices.py
+++ b/h/migrations/versions/18dfed902c9e_remove_unused_user_indices.py
@@ -1,0 +1,42 @@
+"""
+Remove unused user indices
+
+Revision ID: 18dfed902c9e
+Revises: 7e2443f8d7d6
+Create Date: 2017-03-03 12:13:16.122752
+"""
+
+from __future__ import unicode_literals
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '18dfed902c9e'
+down_revision = '7e2443f8d7d6'
+
+
+def upgrade():
+    op.drop_constraint('uq__user__uid', 'user')
+    op.drop_constraint('uq__user__username', 'user')
+    op.drop_index(op.f('ix__user__authority'), 'user')
+
+
+def downgrade():
+    op.execute('COMMIT')
+
+    op.create_index(op.f('ix__user__authority'), 'user', ['authority'],
+                    postgresql_concurrently=True)
+
+    # We add the index back first, and then create a constraint from the
+    # index, to avoid holding the table locked for the entire time the index
+    # is building.
+    op.create_index(op.f('uq__user__uid'), 'user', ['uid', 'authority'],
+                    unique=True,
+                    postgresql_concurrently=True)
+    op.execute(sa.text('ALTER TABLE "user" ADD CONSTRAINT uq__user__uid UNIQUE USING INDEX uq__user__uid'))
+
+    op.create_index(op.f('uq__user__username'), 'user', ['username', 'authority'],
+                    unique=True,
+                    postgresql_concurrently=True)
+    op.execute(sa.text('ALTER TABLE "user" ADD CONSTRAINT uq__user__username UNIQUE USING INDEX uq__user__username'))

--- a/h/migrations/versions/c322c57b49db_remove_user_uid_column.py
+++ b/h/migrations/versions/c322c57b49db_remove_user_uid_column.py
@@ -1,0 +1,24 @@
+"""
+Remove user uid column
+
+Revision ID: c322c57b49db
+Revises: 18dfed902c9e
+Create Date: 2017-03-03 12:24:19.739583
+"""
+
+from __future__ import unicode_literals
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = 'c322c57b49db'
+down_revision = '18dfed902c9e'
+
+
+def upgrade():
+    op.drop_column('user', 'uid')
+
+
+def downgrade():
+    op.add_column('user', sa.Column('uid', sa.UnicodeText(), nullable=True))


### PR DESCRIPTION
As of c9a5aeb several indices (or constraints) on the "user" table are
redundant or unnecessary. Namely:

1. uq__user__uid, which guarantees the uniqueness of the (uid, authority) tuple, is more-or-less directly replaced by ix__user__userid.

2. uq__user__username, which guarantees the uniqueness of the (username, authority) tuple, is no longer needed as it if two usernames satisfy ix__user__userid's uniqueness requirement they are clearly unique. We also do not do lookups against the raw "username" so this isn't needed for performance reasons.

3. ix__user__authority, which indexed the authority column. Any queries which need to query against authority can now use the compound index provided by ix__user__userid, e.g.

       postgres=# explain select count(*) from "user" where authority = 'test.foobar.org';
                                               QUERY PLAN
       ---------------------------------------------------------------------------------------------
       Aggregate  (cost=2249.51..2249.52 rows=1 width=8)
         ->  Index Only Scan using ix__user__userid on "user" (cost=0.42..2249.51 rows=1 width=0)
               Index Cond: (authority = 'test.foobar.org'::text)
       (3 rows)

Also removes the `uid` column.