### PR TITLE
Fix userid index in database

### DIFF
--- a/h/migrations/versions/7e2443f8d7d6_make_userid_index_unique.py
+++ b/h/migrations/versions/7e2443f8d7d6_make_userid_index_unique.py
@@ -1,0 +1,42 @@
+"""
+Make userid index unique
+
+Revision ID: 7e2443f8d7d6
+Revises: faefe3b614db
+Create Date: 2017-03-07 10:25:23.165687
+"""
+
+from __future__ import unicode_literals
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '7e2443f8d7d6'
+down_revision = 'faefe3b614db'
+
+
+def upgrade():
+    op.execute(sa.text('ALTER INDEX ix__user__userid RENAME TO ix__user__userid_old'))
+
+    op.execute('COMMIT')
+    op.create_index(op.f('ix__user__userid'),
+                'user',
+                [sa.text("lower(replace(username, '.', ''))"), 'authority'],
+                postgresql_concurrently=True,
+                unique=True)
+
+    op.drop_index(op.f('ix__user__userid_old'))
+
+
+def downgrade():
+    op.execute(sa.text('ALTER INDEX ix__user__userid RENAME TO ix__user__userid_old'))
+
+    op.execute('COMMIT')
+    op.create_index(op.f('ix__user__userid'),
+                'user',
+                [sa.text("lower(replace(username, '.', ''))"), 'authority'],
+                postgresql_concurrently=True)
+
+    op.drop_index(op.f('ix__user__userid_old'))
+


### PR DESCRIPTION
Unfortunately, the migration in c9a5aeb12 was incorrect, as it failed to specify that the index to be added was unique.

This migration fixes the problem by moving the old index out of the way, recreating it as unique, and then dropping the old index.

Note that the index is still referred to using a normal index prefix ("ix__") rather than a unique constraint prefix ("uq__") because unique constraints cannot be created using functional indices.