### PR TITLE
Make the /docs/help page use the local Hypothesis service for annotation storage

### DIFF
--- a/h/templates/help.html.jinja2
+++ b/h/templates/help.html.jinja2
@@ -7,12 +7,16 @@
   {{ super() }}
   <script type="application/json" class="js-hypothesis-config">
     {
-      "firstRun": true, {# TODO: remove after 2016-09-01, by which time old clients will be gone. #}
       "openSidebar": true,
       "openLoginForm": true
     }
   </script>
   {% if not is_onboarding %}
+    <script type="application/json" class="js-hypothesis-config">
+    {
+      "sidebarAppUrl": "{{ request.route_url('sidebar_app') }}"
+    }
+    </script>
     <script async defer src="{{ embed_js_url }}"></script>
   {% endif %}
 {% endblock %}


### PR DESCRIPTION
By default the service uses the production client hosted at cdn.hypothes.is but
we still want pages hosted by the service to use the local service for annotation storage and the 'app.html' content.

Both of these things can be achieved by configuring the client on the `/docs/help` page to use the sidebar app HTML page served by the local service.

We might also want to do this for the bookmarklet but I'll make that a separate change.