### PR TITLE
Clear user service cache on transaction end

### DIFF
--- a/h/services/groupfinder.py
+++ b/h/services/groupfinder.py
@@ -3,11 +3,11 @@
 from __future__ import unicode_literals
 
 from zope.interface import implementer
-import sqlalchemy
 
 from memex.interfaces import IGroupService
 
 from h import models
+from h import util
 from h.groups.util import WorldGroup
 
 
@@ -23,9 +23,8 @@ class GroupfinderService(object):
         self._cache = {}
 
         # But don't allow the cache to persist after the session is closed.
-        @sqlalchemy.event.listens_for(session, 'after_commit')
-        @sqlalchemy.event.listens_for(session, 'after_rollback')
-        def flush_cache(session):
+        @util.db.on_transaction_end(session)
+        def flush_cache():
             self._cache = {}
 
     def find(self, id_):

--- a/h/services/user.py
+++ b/h/services/user.py
@@ -40,10 +40,17 @@ class UserService(object):
         self._cache = {}
 
         # But don't allow the cache to persist after the session is closed.
-        @sqlalchemy.event.listens_for(session, 'after_commit')
-        @sqlalchemy.event.listens_for(session, 'after_rollback')
-        def flush_cache(session):
-            self._cache = {}
+        #
+        # This makes sure that under all circumstances whenever the transaction
+        # ends the cache gets cleared. We used to only clear the cache on
+        # `after_commit` and `after_rollback`, but the latter only get called
+        # on explicit rollbacks, a rollback due to an exception does not fire
+        # off this event.
+        @sqlalchemy.event.listens_for(session, 'after_transaction_end')
+        def flush_cache(session, transaction):
+            # We only clear the cache when the top-level transaction finishes.
+            if transaction.parent is None:
+                self._cache = {}
 
     def fetch(self, userid_or_username, authority=None):
         """

--- a/h/util/__init__.py
+++ b/h/util/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
+from h.util import db
 from h.util import user
 from h.util import view
 
-__all__ = ('user', 'view')
+__all__ = ('db', 'user', 'view')

--- a/h/util/db.py
+++ b/h/util/db.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import sqlalchemy
+
+
+def on_transaction_end(session):
+    """
+    Decorator for a function which should run after a top-level transaction ended.
+
+    Transactions that are either implicitly or explicitly committed or rolled back will be
+    closed at the end of a Pyramid view. This is here for cleaning up caches so that
+    code after the view, exception views for example, will not be able to access
+    detached instances.
+
+    Example usage:
+
+    .. code-block:: python
+
+       @util.db.on_transaction_end(session)
+       def flush_cache():
+           self._cache = {}
+
+    """
+    def decorate(func):
+        def _handler(_, transaction):
+            # We only clear the cache when the top-level transaction finishes.
+            if transaction.parent is None:
+                func()
+
+        sqlalchemy.event.listen(session, 'after_transaction_end', _handler)
+        return func
+
+    return decorate

--- a/tests/h/services/user_test.py
+++ b/tests/h/services/user_test.py
@@ -3,6 +3,7 @@
 from __future__ import unicode_literals
 
 import pytest
+from sqlalchemy.orm import sessionmaker
 
 from h.services.user import (
     UserNotActivated,
@@ -25,27 +26,6 @@ class TestUserService(object):
         result = svc.fetch('jacqui', 'foo.com')
 
         assert isinstance(result, User)
-
-    def test_fetch_caches_fetched_users(self, db_session, svc, users):
-        jacqui, _, _ = users
-
-        svc.fetch('acct:jacqui@foo.com')
-        db_session.delete(jacqui)
-        db_session.flush()
-        user = svc.fetch('acct:jacqui@foo.com')
-
-        assert user is not None
-        assert user.username == 'jacqui'
-
-    def test_flushes_cache_on_session_commit(self, db_session, svc, users):
-        jacqui, _, _ = users
-
-        svc.fetch('acct:jacqui@foo.com')
-        db_session.delete(jacqui)
-        db_session.commit()
-        user = svc.fetch('acct:jacqui@foo.com')
-
-        assert user is None
 
     def test_login_by_username(self, svc, users):
         _, steve, _ = users
@@ -118,6 +98,65 @@ class TestUserService(object):
                                 inactive=True)]
         db_session.flush()
         return users
+
+
+class TestUserServiceCaching(object):
+    def test_fetch_caches_fetched_users(self, db_session, svc, users):
+        jacqui, _, _ = users
+
+        svc.fetch('acct:jacqui@foo.com')
+        db_session.delete(jacqui)
+        db_session.flush()
+        user = svc.fetch('acct:jacqui@foo.com')
+
+        assert user is not None
+        assert user.username == 'jacqui'
+
+    def test_flushes_cache_on_transaction_close(self, db_session, svc, users):
+        jacqui, _, _ = users
+        jacqui = users[0]
+
+        svc.fetch('acct:jacqui@foo.com')
+        db_session.delete(jacqui)
+        db_session.commit()
+        db_session.transaction.close()
+
+        user = svc.fetch('acct:jacqui@foo.com')
+        assert user is None
+
+    @pytest.yield_fixture
+    def users(self, db_session, factories):
+        users = [factories.User.build(username='jacqui',
+                                      authority='foo.com'),
+                 factories.User.build(),
+                 factories.User.build()]
+        db_session.add_all(users)
+        db_session.flush()
+
+        try:
+            yield users
+        finally:
+            # Since the `db_session` used here does not automatically
+            # clean up after itself, we have to remove the created objects
+            # again.
+            db_session.query(User).delete()
+
+    @pytest.fixture
+    def svc(self, db_session):
+        return UserService(default_authority='example.com', session=db_session)
+
+    @pytest.yield_fixture
+    def db_session(self, db_engine):
+        # The implementation relies on a top-level transaction being closed.
+        # The normal `db_session` is running all tests in a sub-transaction,
+        # for faster resetting of the database to a previous state.
+        # We need to circumvent this for these tests, which is why we use
+        # create a brand new database session here.
+        session = sessionmaker()(bind=db_engine)
+        try:
+            yield session
+        finally:
+            session.close()
 
 
 class TestUserServiceFactory(object):

--- a/tests/h/util/db_test.py
+++ b/tests/h/util/db_test.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import mock
+import pytest
+
+from h.util.db import on_transaction_end
+
+
+class TestOnTransactionEnd(object):
+    def test_calls_wrapped_function_when_parent_transaction(self, db_session, mock_transaction):
+        spy = mock.Mock()
+
+        @on_transaction_end(db_session)
+        def transaction_ended():
+            spy()
+
+        db_session.dispatch.after_transaction_end(db_session, mock_transaction)
+
+        spy.assert_called_once_with()
+
+    def test_skips_wrapped_function_when_nested_transaction(self, db_session, mock_transaction):
+        spy = mock.Mock()
+        type(mock_transaction).parent = mock.PropertyMock(
+                return_value=mock.Mock(spec=db_session.transaction))
+
+        @on_transaction_end(db_session)
+        def transaction_ended():
+            spy()
+
+        db_session.dispatch.after_transaction_end(db_session, mock_transaction)
+
+        assert not spy.called
+
+    @pytest.fixture
+    def mock_transaction(self, db_session):
+        transaction = mock.Mock(spec=db_session.transaction)
+        type(transaction).parent = mock.PropertyMock(return_value=None)
+        return transaction


### PR DESCRIPTION
We previously cleared the user service cache on `after_commit` and
`after_rollback` SQLAlchemy events. This caused issues where the view
was raising an exception, because SQLAlchemy only fires the
`after_rollback` event for an explicit rollback.

pyramid_tm and zope.sqlalchemy will close the database transaction when
the view raises an exception. A call to `SessionTransaction.close` does
implicitly send a `ROLLBACK` SQL query to the database, but it doesn't
emit the `after_rollback` event that we're relying on in order to clear
out the user service cache.
This results in a exception views potentially accessing detached
database objects which in turn throws another exception, which then
returns a generic 500 error back to the user.

For following all of this along at home:

1. pyramid_tm starts a transaction at the beginning of a request:
https://github.com/Pylons/pyramid_tm/blob/1.1.1/pyramid_tm/__init__.py#L86
2. pyramid_tm catches exceptions and if the error is not retryable,
aborts the transaction:
https://github.com/Pylons/pyramid_tm/blob/1.1.1/pyramid_tm/__init__.py#L116
3. The `abort` that pyramid_tm sends is finishing the transaction:
https://github.com/zopefoundation/zope.sqlalchemy/blob/0.7.7/src/zope/sqlalchemy/datamanager.py#L91
4. Finishing a transaction in turn will close it:
https://github.com/zopefoundation/zope.sqlalchemy/blob/0.7.7/src/zope/sqlalchemy/datamanager.py#L87

Whereas an explicit rollback works as we expected it to:
1. `sqlalchemy.orm.session.SessionTransaction.rollback` checks if it
needs to send a `ROLLBACK` SQL query to the database, and if it does...
(https://bitbucket.org/zzzeek/sqlalchemy/src/ce17fd4bf361e6cd08b6e698e49c118643abe724/lib/sqlalchemy/orm/session.py?at=rel_1_1_4&fileviewer=file-view-default#session.py-490)
2. calls `_rollback_impl` which emits the `after_rollback` event
(https://bitbucket.org/zzzeek/sqlalchemy/src/ce17fd4bf361e6cd08b6e698e49c118643abe724/lib/sqlalchemy/orm/session.py?at=rel_1_1_4&fileviewer=file-view-default#session.py-532).

Fixes #4398.