### PR TITLE
Add Referrer-Policy and X-XSS-Protection headers

### DIFF
--- a/h/app.py
+++ b/h/app.py
@@ -62,6 +62,7 @@ def includeme(config):
     config.add_tween('h.tweens.csrf_tween_factory')
     config.add_tween('h.tweens.auth_token')
     config.add_tween('h.tweens.content_security_policy_tween_factory')
+    config.add_tween('h.tweens.security_header_tween_factory')
 
     config.add_renderer('csv', 'h.renderers.CSV')
     config.add_request_method(in_debug_mode, 'debug', reify=True)

--- a/h/tweens.py
+++ b/h/tweens.py
@@ -125,3 +125,16 @@ def redirect_tween_factory(handler, registry, redirects=REDIRECTS):
         return handler(request)
 
     return redirect_tween
+
+
+def security_header_tween_factory(handler, registry):
+    """Add security-related headers to every response."""
+    def security_header_tween(request):
+        resp = handler(request)
+        # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy
+        resp.headers['Referrer-Policy'] = 'strict-origin-when-cross-origin'
+        # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection
+        resp.headers['X-XSS-Protection'] = '1; mode=block'
+        return resp
+
+    return security_header_tween

--- a/tests/h/tweens_test.py
+++ b/tests/h/tweens_test.py
@@ -150,3 +150,13 @@ def test_tween_redirect_matches_in_order(pyramid_request, pyramid_config):
 
     assert response.status_code == 301
     assert response.location == 'http://example.com/bar'
+
+
+def test_tween_security_header_adds_headers(pyramid_request):
+    tween = tweens.security_header_tween_factory(lambda req: req.response,
+                                                 pyramid_request.registry)
+
+    response = tween(pyramid_request)
+
+    assert response.headers['Referrer-Policy'] == 'strict-origin-when-cross-origin'
+    assert response.headers['X-XSS-Protection'] == '1; mode=block'


### PR DESCRIPTION
This commit adds a [Referrer-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy) and [X-XSS-Protection](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection) header to every response.

Referrer-Policy aims to address problems of URL leakage -- users visiting HTTPS web pages expect the URLs they visit to be protected, which they're not unless the Referer information is appropriately redacted. A value of "strict-origin-when-cross-origin" means that:

1. pages on the same origin will receive a full Referer header

2. pages on a different secure origin will receive an origin-only Referer header (i.e. the URL path is redacted)

3. pages on a different insecure origin will receive no Referer header.

This commit also adds a strict X-XSS-Protection header. This will be largely unnecessary when we deploy a strict CSP policy, but can nonetheless protect users from reflected XSS in older (pre-CSP) browsers.