### PR TITLE
Don't use an inline script to configure Google Analytics

### DIFF
--- a/h/static/scripts/header.js
+++ b/h/static/scripts/header.js
@@ -9,3 +9,13 @@ const EnvironmentFlags = require('./base/environment-flags');
 
 window.envFlags = new EnvironmentFlags(document.documentElement);
 window.envFlags.init();
+
+// Set up the Google Analytics command queue if we have a tracking ID.
+const gaTrackingId = document.querySelector('meta[name="google-analytics-tracking-id"]');
+if (gaTrackingId) {
+  /* eslint-disable */
+  window.ga = window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+  ga('create', gaTrackingId.content, 'auto');
+  ga('send', 'pageview');
+  /* eslint-enable */
+}

--- a/h/subscribers.py
+++ b/h/subscribers.py
@@ -16,13 +16,7 @@ def add_renderer_globals(event):
     event['feature'] = request.feature
 
     # Add Google Analytics
-    ga_tracking_id = request.registry.settings.get('ga_tracking_id')
-    if ga_tracking_id is not None:
-        event['ga_tracking_id'] = ga_tracking_id
-        if 'localhost' in request.host:
-            event['ga_cookie_domain'] = "none"
-        else:
-            event['ga_cookie_domain'] = "auto"
+    event['ga_tracking_id'] = request.registry.settings.get('ga_tracking_id')
 
 
 def publish_annotation_event(event):

--- a/h/templates/layouts/base.html.jinja2
+++ b/h/templates/layouts/base.html.jinja2
@@ -49,16 +49,10 @@
           href="{{ asset_url('images/favicons/favicon.ico') }}">
 
     {% if ga_tracking_id %}
-      <!-- Google Analytics -->
-      <script async src='//www.google-analytics.com/analytics.js'></script>
-      <script>
-       window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-       ga('create', '{{ga_tracking_id}}', 'auto');
-       {% block ga_pageview %}
-       ga('send', 'pageview');
-       {% endblock %}
-      </script>
-      <!-- End Google Analytics -->
+    <meta name="google-analytics-tracking-id" content="{{ ga_tracking_id }}">
+    <script async src="https://www.google-analytics.com/analytics.js"></script>
+    {# N.B. The "ga" command queue is set up by header.js. The meta tag must be
+            in the DOM before header.js is included. #}
     {% endif %}
 
     {% if request.sentry.get_public_dsn() %}

--- a/h/templates/layouts/base.html.jinja2
+++ b/h/templates/layouts/base.html.jinja2
@@ -53,7 +53,7 @@
       <script async src='//www.google-analytics.com/analytics.js'></script>
       <script>
        window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-       ga('create', '{{ga_tracking_id}}', '{{ga_cookie_domain}}');
+       ga('create', '{{ga_tracking_id}}', 'auto');
        {% block ga_pageview %}
        ga('send', 'pageview');
        {% endblock %}


### PR DESCRIPTION
Using an inline script to set up Google Analytics prevents us from turning on a restrictive Content-Security-Policy.

Instead, dump the tracking ID into a meta tag if it's available, and retrieve it and set up the "ga" command queue in header.js.

An earlier commit removes some unnecessary configurability from our GA usage.