### PR TITLE
Simplify CSP view deriver code

### DIFF
--- a/h/app.py
+++ b/h/app.py
@@ -39,6 +39,8 @@ def create_app(global_config, **settings):
 
 
 def includeme(config):
+    settings = config.registry.settings
+
     # We need to include `h.models` before pretty much everything else to
     # avoid the possibility that one of the imports below directly or
     # indirectly imports `memex.models`. See the comment at the top of
@@ -94,20 +96,16 @@ def includeme(config):
     })
     config.include('pyramid_tm')
 
-    # Enable a Content Security Policy
-    # This is initially copied from:
-    # https://github.com/pypa/warehouse/blob/e1cf03faf9bbaa15d67d0de2c70f9a9f732596aa/warehouse/config.py#L327
-    client_url = config.registry.settings.get('h.client_url', DEFAULT_CLIENT_URL)
+    # Define the global default Content Security Policy
+    client_url = settings.get('h.client_url', DEFAULT_CLIENT_URL)
     client_host = urlparse.urlparse(client_url).netloc
-
-    config.add_settings({
-        "csp": {
-            "font-src": ["'self'", "fonts.gstatic.com", client_host],
-            "report-uri": [config.registry.settings.get("csp.report_uri")],
-            "script-src": ["'self'", client_host, "www.google-analytics.com"],
-            "style-src": ["'self'", "fonts.googleapis.com", client_host],
-        },
-    })
+    settings['csp'] = {
+        "font-src": ["'self'", "fonts.gstatic.com", client_host],
+        "script-src": ["'self'", client_host, "www.google-analytics.com"],
+        "style-src": ["'self'", "fonts.googleapis.com", client_host],
+    }
+    if 'csp.report_uri' in settings:
+        settings['csp']['report-uri'] = [settings['csp.report_uri']]
 
     # API module
     #

--- a/h/viewderivers.py
+++ b/h/viewderivers.py
@@ -21,11 +21,9 @@ def csp_protected_view(view, info):
         return view
 
     policy = info.registry.settings.get('csp', {})
-    policy = "; ".join([
-        " ".join([k] + [v2 for v2 in v if v2 is not None])
-        for k, v in sorted(policy.items())
-        if [v2 for v2 in v if v2 is not None]
-    ])
+    clauses = [" ".join([directive] + values)
+               for directive, values in sorted(policy.items())]
+    header_value = "; ".join(clauses)
 
     if info.registry.settings.get('csp.report_only', False):
         header_name = 'Content-Security-Policy-Report-Only'
@@ -34,7 +32,7 @@ def csp_protected_view(view, info):
 
     def wrapper_view(context, request):
         resp = view(context, request)
-        resp.headers[header_name] = policy.format(request=request)
+        resp.headers[header_name] = header_value
         return resp
     return wrapper_view
 


### PR DESCRIPTION
The code responsible for constructing the CSP header value was somewhat inscrutable, apparently to account for the possibility that null values would be provided in the settings.

Cleaning up the default CSP policy settings allows us to remove this complexity and make it a bit more obvious how the header value is constructed.

~~_**N.B** This depends on #4416 and will need a rebase once that merges._~~