### PR TITLE
Remove CSP-violating inline styles from search page

### DIFF
--- a/h/static/styles/partials-v2/_search-result-sidebar.scss
+++ b/h/static/styles/partials-v2/_search-result-sidebar.scss
@@ -20,6 +20,7 @@
 
 .search-result-sidebar__section {
   margin-bottom: 26px;
+  @include pie-clearfix;
 }
 
 .search-result-sidebar__section:last-child {

--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -210,7 +210,6 @@
         </dt>
         <dd class="search-result-sidebar__dd">{{ group.created }}</dd>
       </dl>
-      <div style="clear: both;"></div>
     </section>
 
     <section class="search-result-sidebar__section">
@@ -335,7 +334,6 @@
           </dd>
         {% endif -%}
       </dl>
-      <div style="clear: both;"></div>
     </section>
 
     <section class="search-result-sidebar__section">


### PR DESCRIPTION
These inline styles violate our tentative Content-Security-Policy, and are apparently easily removed.