### PR TITLE
Use a distinct DSN for frontend Sentry reports

### DIFF
--- a/h/config.py
+++ b/h/config.py
@@ -86,10 +86,10 @@ SETTINGS = [
     # label only.
     EnvSetting('h.env', 'ENV'),
     EnvSetting('h.proxy_auth', 'PROXY_AUTH', type=asbool),
+    # Sentry DSNs for frontend code should be of the public kind, lacking the
+    # password component in the DSN URI.
+    EnvSetting('h.sentry_dsn_client', 'SENTRY_DSN_CLIENT'),
     EnvSetting('h.websocket_url', 'WEBSOCKET_URL'),
-    # The client Sentry DSN should be of the public kind, lacking the password
-    # component in the DSN URI.
-    EnvSetting('h.client.sentry_dsn', 'SENTRY_DSN_CLIENT'),
 
     # Debug/development settings
     EnvSetting('debug_query', 'DEBUG_QUERY'),

--- a/h/config.py
+++ b/h/config.py
@@ -89,6 +89,7 @@ SETTINGS = [
     # Sentry DSNs for frontend code should be of the public kind, lacking the
     # password component in the DSN URI.
     EnvSetting('h.sentry_dsn_client', 'SENTRY_DSN_CLIENT'),
+    EnvSetting('h.sentry_dsn_frontend', 'SENTRY_DSN_FRONTEND'),
     EnvSetting('h.websocket_url', 'WEBSOCKET_URL'),
 
     # Debug/development settings

--- a/h/subscribers.py
+++ b/h/subscribers.py
@@ -11,12 +11,22 @@ from h.tasks import mailer
 def add_renderer_globals(event):
     request = event['request']
 
-    event['h_version'] = __version__
     event['base_url'] = request.route_url('index')
     event['feature'] = request.feature
 
     # Add Google Analytics
     event['ga_tracking_id'] = request.registry.settings.get('ga_tracking_id')
+
+    # Add a frontend settings object which will be rendered as JSON into the
+    # page.
+    event['frontend_settings'] = {}
+
+    if 'h.sentry_dsn_frontend' in request.registry.settings:
+        event['frontend_settings']['raven'] = {
+            'dsn': request.registry.settings['h.sentry_dsn_frontend'],
+            'release': __version__,
+            'userid': request.authenticated_userid,
+        }
 
 
 def publish_annotation_event(event):

--- a/h/templates/includes/settings.html.jinja2
+++ b/h/templates/includes/settings.html.jinja2
@@ -1,0 +1,5 @@
+{% if frontend_settings %}
+<script class="js-hypothesis-settings" type="application/json">
+{{ frontend_settings | to_json }}
+</script>
+{% endif %}

--- a/h/templates/layouts/admin.html.jinja2
+++ b/h/templates/layouts/admin.html.jinja2
@@ -31,16 +31,7 @@
 <link rel="stylesheet" href="{{ url }}">
 {% endfor %}
 
-    {% if request.sentry.get_public_dsn() %}
-      <script class="js-hypothesis-settings" type="application/json">
-        {
-          "raven": {
-            "dsn": "{{ request.sentry.get_public_dsn('https') }}",
-            "release": "{{ h_version }}"
-          }
-        }
-      </script>
-    {% endif %}
+    {% include 'h:templates/includes/settings.html.jinja2' %}
   </head>
   <body>
     <nav class="navbar navbar-inverse navbar-fixed-top">

--- a/h/templates/layouts/base.html.jinja2
+++ b/h/templates/layouts/base.html.jinja2
@@ -55,17 +55,7 @@
             in the DOM before header.js is included. #}
     {% endif %}
 
-    {% if request.sentry.get_public_dsn() %}
-      <script class="js-hypothesis-settings" type="application/json">
-        {
-          "raven": {
-            "dsn": "{{ request.sentry.get_public_dsn('https') }}",
-            "release": "{{ h_version }}",
-            "userid": {{ request.authenticated_userid | to_json }}
-          }
-        }
-      </script>
-    {% endif %}
+    {% include 'h:templates/includes/settings.html.jinja2' %}
 
     {% for url in asset_urls("header_js") %}
     <script src="{{ url }}"></script>

--- a/h/views/client.py
+++ b/h/views/client.py
@@ -43,7 +43,7 @@ def sidebar_app(request, extra=None):
 
     settings = request.registry.settings
     ga_client_tracking_id = settings.get('ga_client_tracking_id')
-    sentry_public_dsn = settings.get('h.client.sentry_dsn')
+    sentry_public_dsn = settings.get('h.sentry_dsn_client')
     websocket_url = settings.get('h.websocket_url')
 
     app_config = {

--- a/tests/h/views/client_test.py
+++ b/tests/h/views/client_test.py
@@ -65,7 +65,7 @@ def pyramid_settings(pyramid_settings):
 
     pyramid_settings.update({
         'ga_client_tracking_id': 'UA-4567',
-        'h.client.sentry_dsn': 'test-sentry-dsn',
+        'h.sentry_dsn_client': 'test-sentry-dsn',
         'h.websocket_url': 'wss://example.com/ws',
         'auth_domain': 'example.com'
         })


### PR DESCRIPTION
Despite our best efforts, there is still a lot of unavoidable noise generated by Sentry reports from JavaScript, due to adware, browser extensions, and so on.

This commit adds the SENTRY_DSN_FRONTEND environment setting, which allows operators to specify a distinct DSN for the frontend.