### PR TITLE
Fix an exception in the stream_user_redirect view

### DIFF
--- a/h/views/main.py
+++ b/h/views/main.py
@@ -98,7 +98,12 @@ def stream_user_redirect(request):
 
     # The client generates /u/ links which include the full account ID
     if user.startswith('acct:'):
-        user = split_user(user)['username']
+        try:
+            user = split_user(user)['username']
+        except ValueError:
+            # If it's not a valid userid, catch the exception and just treat
+            # the parameter as a literal username.
+            pass
 
     location = request.route_url('activity.user_search', username=user)
 

--- a/tests/h/views/main_test.py
+++ b/tests/h/views/main_test.py
@@ -110,6 +110,14 @@ class TestStreamUserRedirect(object):
 
         assert exc.value.location == 'http://example.com/user/bob'
 
+    def test_doesnt_choke_on_invalid_userids(self, pyramid_request):
+        pyramid_request.matchdict['user'] = 'acct:bob'
+
+        with pytest.raises(httpexceptions.HTTPFound) as exc:
+            main.stream_user_redirect(pyramid_request)
+
+        assert exc.value.location == 'http://example.com/user/acct%3Abob'
+
     @pytest.fixture
     def routes(self, pyramid_config):
         pyramid_config.add_route('activity.search', '/search')


### PR DESCRIPTION
Handle the case when the stream_user_redirect view (/u/acct:foo@example.com) receives an invalid userid (e.g. "/u/acct:wibble").

Previously this threw an application error, as reported [in Sentry](https://sentry.io/hypothesis/h/issues/227318570/).