### PR TITLE
Slim down the healthcheck endpoint

### DIFF
--- a/h/views/status.py
+++ b/h/views/status.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 
 import logging
 
-from h.celery import celery
 from h.exceptions import APIError
 from h.util.view import json_view
 
@@ -14,45 +13,9 @@ log = logging.getLogger(__name__)
 
 @json_view(route_name='status')
 def status(request):
-    _check_database(request)
-    _check_search(request)
-    _check_celery()
-    return {'status': 'okay'}
-
-
-def _check_database(request):
     try:
         request.db.execute('SELECT 1')
     except Exception as exc:
         log.exception(exc)
         raise APIError('Database connection failed')
-
-
-def _check_search(request):
-    try:
-        info = request.es.conn.cluster.health()
-        if info['status'] not in ('green', 'yellow'):
-            raise APIError('Search cluster state is %s' % info['status'])
-    except Exception as exc:
-        log.exception(exc)
-        raise APIError('Search connection failed')
-
-
-def _check_celery():
-    try:
-        result = celery.control.ping(timeout=0.25)
-        if not result:
-            raise APIError('Celery ping failed')
-
-        for item in result:
-            if len(item) != 1:
-                continue
-
-            reply = item.values()[0]
-            if reply.get('ok') == 'pong':
-                return
-
-        raise APIError('Celery: no worker returned pong')
-    except IOError as exc:
-        log.exception(exc)
-        raise APIError('Celery connection failed')
+    return {'status': 'okay'}

--- a/tests/h/views/status_test.py
+++ b/tests/h/views/status_test.py
@@ -9,13 +9,13 @@ from h.exceptions import APIError
 from h.views.status import status
 
 
-@pytest.mark.usefixtures('celery', 'db', 'es')
+@pytest.mark.usefixtures('db')
 class TestStatus(object):
     def test_it_returns_okay_on_success(self, pyramid_request):
         result = status(pyramid_request)
         assert result
 
-    def test_it_fails_when_databse_unreachable(self, pyramid_request, db):
+    def test_it_fails_when_database_unreachable(self, pyramid_request, db):
         db.execute.side_effect = Exception('explode!')
 
         with pytest.raises(APIError) as exc:
@@ -23,75 +23,8 @@ class TestStatus(object):
 
         assert 'Database connection failed' in exc.value.message
 
-    def test_it_fails_when_search_unreachable(self, pyramid_request, es):
-        es.conn.cluster.health.side_effect = Exception('explode!')
-
-        with pytest.raises(APIError) as exc:
-            status(pyramid_request)
-
-        assert 'Search connection failed' in exc.value.message
-
-    def test_it_fails_when_search_cluster_status_red(self, pyramid_request, es):
-        es.conn.cluster.health.return_value = {'status': 'red'}
-
-        with pytest.raises(APIError) as exc:
-            status(pyramid_request)
-
-        assert 'Search connection failed' in exc.value.message
-
-    def test_it_fails_when_celery_connection_unreachable(self, pyramid_request, celery):
-        celery.control.ping.side_effect = IOError('explode!')
-
-        with pytest.raises(APIError) as exc:
-            status(pyramid_request)
-
-        assert 'Celery connection failed' in exc.value.message
-
-    def test_it_fails_when_celery_workers_dont_respond(self, pyramid_request, celery):
-        celery.control.ping.return_value = []
-
-        with pytest.raises(APIError) as exc:
-            status(pyramid_request)
-
-        assert 'Celery ping failed' in exc.value.message
-
-    def test_it_succeeds_when_one_celery_workers_succeeds(self, pyramid_request, celery):
-        celery.control.ping.return_value = [
-            {'celery@test-worker-1': {'fail': 'some error'}},
-            {'celery@test-worker-2': {'ok': 'pong'}},
-        ]
-
-        result = status(pyramid_request)
-        assert result
-
-    def test_it_fails_when_all_celery_workers_fail(self, pyramid_request, celery):
-        celery.control.ping.return_value = [
-            {'celery@test-worker-1': {'fail': 'some error'}},
-            {'celery@test-worker-2': {'foo': 'bar'}},
-        ]
-
-        with pytest.raises(APIError) as exc:
-            status(pyramid_request)
-
-        assert 'no worker returned pong' in exc.value.message
-
     @pytest.fixture
     def db(self, pyramid_request):
         db = mock.Mock()
         pyramid_request.db = db
         return db
-
-    @pytest.fixture
-    def es(self, pyramid_request):
-        es = mock.Mock()
-        es.conn.cluster.health.return_value = {'status': 'green'}
-        pyramid_request.es = es
-        return es
-
-    @pytest.fixture
-    def celery(self, patch):
-        celery = patch('h.views.status.celery')
-
-        celery.control.ping.return_value = [{'celery@test-worker': {'ok': 'pong'}}]
-
-        return celery


### PR DESCRIPTION
Having the healthcheck/status endpoint talk to all the backing services is not the greatest idea in the world, on reflection.

The problem (apart from the fact that it's quite slow) is that it tightly couples the health of the service to the health of the backing services. If ElasticSearch is temporarily unavailable, a failing healthcheck will take the entire site offline as all instances are removed from the load balancer. By contrast, a healthcheck that returns only the health of the web application will allow those parts of the site that don't depend on ElasticSearch to keep working.

The counter-argument is that if a single instance is having networking issues, it is useful to have it removed from the load balancer so it doesn't keep serving requests.

This commit slims down the healthcheck endpoint to only check Postgres. Very little of the site currently works without a database so this seems like a reasonable compromise for now.