### PR TITLE
Add label to grant tokens section

### DIFF
--- a/docs/publishers/authorization-grant-tokens.rst
+++ b/docs/publishers/authorization-grant-tokens.rst
@@ -1,3 +1,5 @@
+.. _Generating authorization grant tokens:
+
 Generating authorization grant tokens
 #####################################
 


### PR DESCRIPTION
This is needed so that the client docs can cross-ref to this page using
intersphinx.