### PR TITLE
Add intersphinx mapping to client repo

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -266,6 +266,6 @@ texinfo_documents = [
 # How to display URL addresses: 'footnote', 'no', or 'inline'.
 #texinfo_show_urls = 'footnote'
 
-
-# Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'http://docs.python.org/': None}
+intersphinx_mapping = {
+    'client': ('https://h.readthedocs.io/projects/client/en/latest/', None),
+}


### PR DESCRIPTION
These means the :ref:`...` cross-references (and other kinds of
cross-references, like :js:func:, :option:, :envvar:, ...) can refer to
things defined in the client repo's docs, and Sphinx will generate URLs
to the client docs.

There aren't actually and refs in these docs that make use of this yet
but it's good to have it here.