### PR TITLE
Add link to client's own docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,7 +6,7 @@ that serves most of the https://hypothes.is/ website, including the web
 annotations API at https://hypothes.is/api/.
 The `Hypothesis client <https://github.com/hypothesis/client>`_
 is a browser-based annotator that is a client for the web service's API, see
-`the client's own documentation site <http://h.readthedocs.io/projects/client/>`_
+`the client's own documentation site <https://h.readthedocs.io/projects/client/>`_
 for docs about the client.
 
 This documentation is for:
@@ -22,7 +22,7 @@ Contents
 
    community
    publishers/index
-   The Hypothesis API <http://h.readthedocs.io/en/latest/api/>
+   The Hypothesis API <https://h.readthedocs.io/en/latest/api/>
    realtime
    developing/index
    CHANGES

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,9 +1,16 @@
-Hypothesis
-==========
+Welcome to the Hypothesis Web Service’s Documentation!
+======================================================
 
-Hypothesis is a tool for annotating the web. This documentation is for:
+The `Hypothesis web service <https://github.com/hypothesis/h>` is the web app
+that serves most of the https://hypothes.is/ website, including the web
+annotations API at https://hypothes.is/api/.
+The `Hypothesis client <https://github.com/hypothesis/client>`_
+is a browser-based annotator that is a client for the web service's API, see
+`the client's own documentation site <http://h.readthedocs.io/projects/client/>`_
+for docs about the client.
 
-* Publishers embedding Hypothesis in their web pages.
+This documentation is for:
+
 * Developers working with data stored in the Hypothesis service.
 * Contributors to the Hypothesis service and client.
 


### PR DESCRIPTION
Clarify that h.readthedocs.io is the docs site for the web service only,
and provide a link to the client's own docs now that they're separate.