### PR TITLE
Rename Sphinx project to "Hypothesis Web Service"

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=invalid-name
 #
-# The Hypothesis Annotation Framework documentation build configuration file, created by
+# The h documentation build configuration file, created by
 # sphinx-quickstart on Fri Oct 12 19:21:42 2012.
 #
 # This file is execfile()d with the current directory set to its containing dir.
@@ -54,7 +54,7 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'The Hypothesis Annotation Framework'
+project = u'h'
 copyright = u'2012-{}, Hypothes.is Project and contributors'.format(CURRENT_YEAR)
 
 # The version info for the project you're documenting, acts as replacement for
@@ -189,7 +189,7 @@ html_extra_path = ['_extra']
 #html_file_suffix = None
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'TheHypothesisAnnotationFrameworkdoc'
+htmlhelp_basename = 'h'
 
 
 # -- Options for LaTeX output --------------------------------------------------
@@ -208,7 +208,7 @@ latex_elements = {
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-  ('index', 'TheHypothesisAnnotationFramework.tex', u'The Hypothesis Annotation Framework Documentation',
+  ('index', 'h.tex', u'The h Documentation',
    u'Hypothes.is Project and contributors', 'manual'),
 ]
 
@@ -238,7 +238,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('index', 'thehypothesisannotationframework', u'The Hypothesis Annotation Framework Documentation',
+    ('index', 'h', u'The h Documentation',
      [u'Hypothes.is Project and contributors'], 1)
 ]
 
@@ -252,8 +252,8 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  ('index', 'TheHypothesisAnnotationFramework', u'The Hypothesis Annotation Framework Documentation',
-   u'Hypothes.is Project and contributors', 'TheHypothesisAnnotationFramework', 'One line description of project.',
+  ('index', 'h', u'The h Documentation',
+   u'Hypothes.is Project and contributors', 'h', 'One line description of project.',
    'Miscellaneous'),
 ]
 


### PR DESCRIPTION
In the top left of the h docs (top of the sidebar) it says "The Hypothesis Annotation Framework" (also in other places, like the title of the PDF docs).

Rename the Sphinx project from "The Hypothesis Annotation Framework
Documentation" to "The Hypothesis Web Service Documentation". This is
the documentation for the web service only, the client (and browser
extensions etc) have their own separate documentations. And I'm not sure
there was ever really an annotation framework.