### PR TITLE
Flag endpoint

### DIFF
--- a/h/routes.py
+++ b/h/routes.py
@@ -65,6 +65,9 @@ def includeme(config):
     config.add_route('badge', '/api/badge')
     config.add_route('api.profile', '/api/profile')
     config.add_route('api.debug_token', '/api/debug-token')
+    config.add_route('api.flags',
+                     '/api/flags',
+                     factory='memex.resources:AnnotationResourceFactory')
     config.add_route('token', '/api/token')
     config.add_route('api.users', '/api/users')
 

--- a/h/services/__init__.py
+++ b/h/services/__init__.py
@@ -10,6 +10,7 @@ def includeme(config):
     config.register_service_factory('.auth_ticket.auth_ticket_service_factory',
                                     iface='pyramid_authsanity.interfaces.IAuthService')
     config.register_service_factory('.auth_token.auth_token_service_factory', name='auth_token')
+    config.register_service_factory('.flag.flag_service_factory', name='flag')
     config.register_service_factory('.group.groups_factory', name='group')
     config.register_service_factory('.authority_group.authority_group_factory', name='authority_group')
     config.register_service_factory('.nipsa.nipsa_factory', name='nipsa')

--- a/h/services/flag.py
+++ b/h/services/flag.py
@@ -25,6 +25,31 @@ class FlagService(object):
         query = self.session.query(models.Flag).filter_by(user=user, annotation=annotation)
         return query.count() > 0
 
+    def create(self, user, annotation):
+        """
+        Create a flag for the given user and annotation.
+
+        We enforce the uniqueness of a flag, meaning one user can only
+        flag one annotation once. This method first checks if the annotation
+        is already flagged by the user, if that is the case, then this
+        is a no-op.
+
+        :param user: The user flagging the annotation.
+        :type user: h.models.User
+
+        :param annotation: The annotation to be flagged.
+        :type annotation: h.models.Annotation
+
+        :returns: None
+        :rtype: NoneType
+        """
+        if self.flagged(user, annotation):
+            return
+
+        flag = models.Flag(user=user,
+                           annotation=annotation)
+        self.session.add(flag)
+
 
 def flag_service_factory(context, request):
     return FlagService(request.db)

--- a/h/services/flag.py
+++ b/h/services/flag.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from h import models
+
+
+class FlagService(object):
+    def __init__(self, session):
+        self.session = session
+
+    def flagged(self, user, annotation):
+        """
+        Check if a given user has flagged a given annotation.
+
+        :param user: The user to check for a flag.
+        :type user: h.models.User
+
+        :param annotation: The annotation to check for a flag.
+        :type annotation: h.models.Annotation
+
+        :returns: True/False depending on the existence of a flag.
+        :rtype: bool
+        """
+        query = self.session.query(models.Flag).filter_by(user=user, annotation=annotation)
+        return query.count() > 0
+
+
+def flag_service_factory(context, request):
+    return FlagService(request.db)

--- a/h/views/api_exceptions.py
+++ b/h/views/api_exceptions.py
@@ -14,6 +14,7 @@ from pyramid.view import notfound_view_config
 
 from h.i18n import TranslationString as _
 from h.exceptions import APIError
+from h.schemas import ValidationError
 from h.util.view import handle_exception, json_view
 
 
@@ -32,6 +33,12 @@ def api_notfound(request):
 def api_error(context, request):
     """Handle an expected/deliberately thrown API exception."""
     request.response.status_code = context.status_code
+    return {'status': 'failure', 'reason': context.message}
+
+
+@json_view(context=ValidationError, path_info='/api/')
+def api_validation_error(context, request):
+    request.response.status_code = 400
     return {'status': 'failure', 'reason': context.message}
 
 

--- a/h/views/api_flags.py
+++ b/h/views/api_flags.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from pyramid import security
+from pyramid.httpexceptions import HTTPNoContent, HTTPNotFound
+
+from memex.views import api_config
+
+from h.schemas import ValidationError
+
+
+@api_config(route_name='api.flags',
+            request_method='POST',
+            link_name='flag.create',
+            description='Flag an annotation for review.',
+            effective_principals=security.Authenticated)
+def create(context, request):
+    annotation = _fetch_annotation(context, request)
+    svc = request.find_service(name='flag')
+    svc.create(request.authenticated_user, annotation)
+    return HTTPNoContent()
+
+
+def _fetch_annotation(context, request):
+    try:
+        annotation_id = request.json_body.get('annotation')
+
+        if not annotation_id:
+            raise ValueError()
+    except ValueError:
+        raise ValidationError('annotation id is required')
+
+    not_found_msg = 'cannot find annotation with id %s' % annotation_id
+
+    try:
+        resource = context[annotation_id]
+        if not request.has_permission('read', resource):
+            raise HTTPNotFound(not_found_msg)
+
+        return resource.annotation
+    except KeyError:
+        raise HTTPNotFound(not_found_msg)

--- a/tests/common/factories.py
+++ b/tests/common/factories.py
@@ -143,3 +143,13 @@ class Setting(ModelFactory):
 
     key = factory.LazyAttribute(lambda _: FAKER.domain_word())
     value = factory.LazyAttribute(lambda _: FAKER.catch_phrase())
+
+
+class Flag(ModelFactory):
+
+    class Meta:  # pylint: disable=no-init, old-style-class
+        model = models.Flag
+        force_flush = True
+
+    user = factory.SubFactory(User)
+    annotation = factory.SubFactory(Annotation)

--- a/tests/h/routes_test.py
+++ b/tests/h/routes_test.py
@@ -59,6 +59,7 @@ def test_includeme():
         call('badge', '/api/badge'),
         call('api.profile', '/api/profile'),
         call('api.debug_token', '/api/debug-token'),
+        call('api.flags', '/api/flags', factory='memex.resources:AnnotationResourceFactory'),
         call('token', '/api/token'),
         call('api.users', '/api/users'),
         call('session', '/app'),

--- a/tests/h/services/flag_test.py
+++ b/tests/h/services/flag_test.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import pytest
+
+from h.services import flag
+from h._compat import xrange
+
+
+@pytest.mark.usefixtures('flags')
+class TestFlagServiceFlagged(object):
+    def test_it_returns_true_when_flag_exists(self, svc, flags):
+        user = flags[-1].user
+        annotation = flags[-1].annotation
+
+        assert svc.flagged(user, annotation) is True
+
+    def test_it_returns_false_when_flag_does_not_exist(self, svc, factories):
+        user = factories.User()
+        annotation = factories.Annotation(userid=user.userid)
+
+        assert svc.flagged(user, annotation) is False
+
+    @pytest.fixture
+    def flags(self, factories):
+        return [factories.Flag() for _ in xrange(3)]
+
+    @pytest.fixture
+    def svc(self, db_session):
+        return flag.FlagService(db_session)
+
+
+class TestFlagServiceFactory(object):
+    def test_it_returns_flag_service(self, pyramid_request):
+        svc = flag.flag_service_factory(None, pyramid_request)
+        assert isinstance(svc, flag.FlagService)
+
+    def test_it_provides_request_db_as_session(self, pyramid_request):
+        svc = flag.flag_service_factory(None, pyramid_request)
+        assert svc.session == pyramid_request.db

--- a/tests/h/views/api_exceptions_test.py
+++ b/tests/h/views/api_exceptions_test.py
@@ -3,11 +3,12 @@
 from __future__ import unicode_literals
 
 from h.exceptions import APIError
-from h.views.api_exceptions import api_notfound, api_error, json_error
+from h.schemas import ValidationError
+from h.views import api_exceptions as views
 
 
 def test_api_notfound_view(pyramid_request):
-    result = api_notfound(pyramid_request)
+    result = views.api_notfound(pyramid_request)
 
     assert pyramid_request.response.status_int == 404
     assert result['status'] == 'failure'
@@ -17,17 +18,27 @@ def test_api_notfound_view(pyramid_request):
 def test_api_error_view(pyramid_request):
     context = APIError(message='asplosions!', status_code=418)
 
-    result = api_error(context, pyramid_request)
+    result = views.api_error(context, pyramid_request)
 
     assert pyramid_request.response.status_code == 418
     assert result['status'] == 'failure'
     assert result['reason'] == 'asplosions!'
 
 
+def test_api_validation_error(pyramid_request):
+    context = ValidationError('missing required userid')
+
+    result = views.api_validation_error(context, pyramid_request)
+
+    assert pyramid_request.response.status_code == 400
+    assert result['status'] == 'failure'
+    assert result['reason'] == 'missing required userid'
+
+
 def test_json_error_view(patch, pyramid_request):
     handle_exception = patch('h.views.api_exceptions.handle_exception')
 
-    result = json_error(pyramid_request)
+    result = views.json_error(pyramid_request)
 
     handle_exception.assert_called_once_with(pyramid_request)
     assert result['status'] == 'failure'

--- a/tests/h/views/api_flags_test.py
+++ b/tests/h/views/api_flags_test.py
@@ -1,0 +1,103 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import mock
+import pytest
+
+from pyramid.httpexceptions import HTTPNoContent, HTTPNotFound
+
+from h.schemas import ValidationError
+from h.views import api_flags as views
+
+
+class FakeAnnotationResourceFactory(object):
+    def __init__(self, expected_annotation):
+        self.expected_annotation = expected_annotation
+
+    def __getitem__(self, id_):
+        """Return the expected annotation when the id matches, otherwise raise."""
+
+        if id_ == self.expected_annotation.id:
+            return mock.Mock(annotation=self.expected_annotation)
+
+        raise KeyError()
+
+
+@pytest.mark.usefixtures('flag_service')
+class TestCreate(object):
+    def test_it_flags_annotation(self,
+                                 pyramid_request,
+                                 annotation,
+                                 flag_service):
+        pyramid_request.json_body = {'annotation': annotation.id}
+        context = FakeAnnotationResourceFactory(annotation)
+
+        views.create(context, pyramid_request)
+
+        flag_service.create.assert_called_once_with(pyramid_request.authenticated_user,
+                                                    annotation)
+
+    def test_it_returns_no_content(self, pyramid_request, annotation):
+        pyramid_request.json_body = {'annotation': annotation.id}
+        context = FakeAnnotationResourceFactory(annotation)
+
+        response = views.create(context, pyramid_request)
+        assert isinstance(response, HTTPNoContent)
+
+    def test_it_raises_for_malformed_request_body(self, pyramid_request, annotation):
+        type(pyramid_request).json_body = mock.PropertyMock(side_effect=ValueError('not json!'))
+        context = FakeAnnotationResourceFactory(annotation)
+
+        with pytest.raises(ValidationError):
+            views.create(context, pyramid_request)
+
+    def test_it_raises_for_missing_annotation_id(self, pyramid_request, annotation):
+        pyramid_request.json_body = {}
+        context = FakeAnnotationResourceFactory(annotation)
+
+        with pytest.raises(ValidationError):
+            views.create(context, pyramid_request)
+
+    def test_it_renders_error_when_annotation_does_not_exist(self, pyramid_request, annotation):
+        pyramid_request.json_body = {'annotation': 'bogus'}
+        context = FakeAnnotationResourceFactory(annotation)
+
+        with pytest.raises(HTTPNotFound) as exc:
+            views.create(context, pyramid_request)
+
+        assert 'cannot find annotation' in exc.value.message
+
+    def test_it_renders_error_when_user_does_not_have_read_permission(self,
+                                                                      pyramid_request,
+                                                                      annotation):
+
+        def fake_has_permission(action, _):
+            if action == 'read':
+                return False
+            return True
+
+        pyramid_request.has_permission = mock.Mock(side_effect=fake_has_permission)
+        pyramid_request.json_body = {'annotation': annotation.id}
+        context = FakeAnnotationResourceFactory(annotation)
+
+        with pytest.raises(HTTPNotFound) as exc:
+            views.create(context, pyramid_request)
+
+        assert 'cannot find annotation' in exc.value.message
+
+    @pytest.fixture
+    def pyramid_request(self, pyramid_request, annotation):
+        pyramid_request.authenticated_user = mock.Mock()
+        pyramid_request.json_body = {}
+        return pyramid_request
+
+    @pytest.fixture
+    def annotation(self, factories):
+        return factories.Annotation()
+
+    @pytest.fixture
+    def flag_service(self, pyramid_config):
+        flag_service = mock.Mock(spec_set=['create'])
+        pyramid_config.register_service(flag_service, name='flag')
+        return flag_service


### PR DESCRIPTION
This is the implementation of hypothesis/product-backlog#206.

This adds a new endpoint at `POST /api/flags/annotations/{id}` which will create a flag for the authenticated user and the given annotation id.