### PR TITLE
Move memex.storage to h.storage

### DIFF
--- a/h/activity/query.py
+++ b/h/activity/query.py
@@ -17,9 +17,9 @@ from sqlalchemy.orm import subqueryload
 
 from h import links
 from h import presenters
+from h import storage
 from h.activity import bucketing
 from h.models import Annotation, Document, Group
-from memex import storage
 
 
 class ActivityResults(namedtuple('ActivityResults', [

--- a/h/admin/views/users.py
+++ b/h/admin/views/users.py
@@ -8,10 +8,10 @@ from pyramid import httpexceptions
 from pyramid.view import view_config
 
 from h import models
+from h import storage
 from h.accounts.events import ActivationEvent
 from h.services.rename_user import UserRenameError
 from h.tasks.admin import rename_user
-from memex import storage
 from h.i18n import TranslationString as _
 
 

--- a/h/notification/reply.py
+++ b/h/notification/reply.py
@@ -3,7 +3,7 @@
 from collections import namedtuple
 import logging
 
-from memex import storage
+from h import storage
 from h.models import Subscriptions
 
 log = logging.getLogger(__name__)

--- a/h/storage.py
+++ b/h/storage.py
@@ -7,6 +7,16 @@ for storing and retrieving annotations. Data passed to these functions is
 assumed to be validated.
 """
 
+# FIXME: This module was originally written to be a single point of
+#        indirection through which the storage backend could be swapped out on
+#        the fly. This helped us to migrate from Elasticsearch-based
+#        persistence to PostgreSQL persistence.
+#
+#        The purpose of this module is now primarily to serve as a place to
+#        wrap up the business logic of creating and retrieving annotations. As
+#        such, it probably makes more sense for this to be split up into a
+#        couple of different services at some point.
+
 from datetime import datetime
 
 from pyramid import i18n

--- a/h/streamer/messages.py
+++ b/h/streamer/messages.py
@@ -6,9 +6,9 @@ import logging
 from gevent.queue import Full
 
 from h import realtime
+from h import storage
 from h.realtime import Consumer
 from memex import presenters
-from memex import storage
 from memex.links import LinksService
 from memex.resources import AnnotationResource
 from h.auth.util import translate_annotation_principals

--- a/h/streamer/websocket.py
+++ b/h/streamer/websocket.py
@@ -10,7 +10,7 @@ from gevent.queue import Full
 import jsonschema
 from ws4py.websocket import WebSocket as _WebSocket
 
-from memex import storage
+from h import storage
 from h.streamer import filter
 
 log = logging.getLogger(__name__)

--- a/h/subscribers.py
+++ b/h/subscribers.py
@@ -3,7 +3,7 @@
 
 from h import __version__
 from h import emails
-from memex import storage
+from h import storage
 from h.notification import reply
 from h.tasks import mailer
 

--- a/h/tasks/indexer.py
+++ b/h/tasks/indexer.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 
+from h import storage
 from h.celery import celery
 from h.indexer.reindexer import SETTING_NEW_INDEX
 
-from memex import storage
 from memex.search.index import index
 from memex.search.index import delete
 

--- a/h/views/api.py
+++ b/h/views/api.py
@@ -29,8 +29,8 @@ from memex.presenters import AnnotationJSONLDPresenter
 from memex.resources import AnnotationResource
 from memex import search as search_lib
 from memex import schemas
-from memex import storage
 
+from h import storage
 from h.util import cors
 
 _ = i18n.TranslationStringFactory(__package__)

--- a/h/views/feeds.py
+++ b/h/views/feeds.py
@@ -6,8 +6,8 @@ from pyramid.view import view_config
 from pyramid import i18n
 
 from memex import search
-from memex.storage import fetch_ordered_annotations
 from h.feeds import render_atom, render_rss
+from h.storage import fetch_ordered_annotations
 
 
 _ = i18n.TranslationStringFactory(__package__)

--- a/src/memex/models/__init__.py
+++ b/src/memex/models/__init__.py
@@ -8,7 +8,7 @@ PostgreSQL database.
 
 Please note: access to these model objects should almost certainly not be
 direct to the submodules of this package, but rather through the helper
-functions in `memex.storage`.
+functions in `h.storage`.
 """
 
 from memex.db import set_base

--- a/src/memex/resources.py
+++ b/src/memex/resources.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 
 from pyramid import security
 
-from memex import storage
+from h import storage  # FIXME: this module needs to move to h
 from memex.interfaces import IGroupService
 
 

--- a/src/memex/search/query.py
+++ b/src/memex/search/query.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from memex import storage
+from h import storage  # FIXME: this module needs to move to h
 from memex import uri
 
 LIMIT_DEFAULT = 20

--- a/src/memex/uri.py
+++ b/src/memex/uri.py
@@ -60,7 +60,7 @@ possible if we can answer two questions:
 
 This package is responsible for defining URI normalization routines for use
 elsewhere in the Hypothesis application. URI expansion is handled by
-:py:function:`memex.storage.expand_uri`.
+:py:function:`h.storage.expand_uri`.
 """
 import re
 

--- a/tests/h/storage_test.py
+++ b/tests/h/storage_test.py
@@ -7,13 +7,11 @@ import copy
 import pytest
 import mock
 
-from pyramid import security
-
-from memex import groups
-from memex import storage
 from memex import schemas
 from memex.models.annotation import Annotation
-from memex.models.document import Document, DocumentURI, DocumentMeta
+from memex.models.document import Document, DocumentURI
+
+from h import storage
 
 
 class FakeGroup(object):
@@ -470,12 +468,12 @@ class TestDeleteAnnotation(object):
 
 @pytest.fixture
 def fetch_annotation(patch):
-    return patch('memex.storage.fetch_annotation')
+    return patch('h.storage.fetch_annotation')
 
 
 @pytest.fixture
 def models(patch):
-    models = patch('memex.storage.models', autospec=False)
+    models = patch('h.storage.models', autospec=False)
     models.Annotation.return_value.is_reply = False
     return models
 
@@ -495,4 +493,4 @@ def session(db_session):
 
 @pytest.fixture
 def datetime(patch):
-    return patch('memex.storage.datetime')
+    return patch('h.storage.datetime')

--- a/tests/h/streamer/websocket_test.py
+++ b/tests/h/streamer/websocket_test.py
@@ -291,7 +291,7 @@ class TestHandleFilterMessage(object):
 
         assert socket.filter is not None
 
-    @mock.patch('memex.storage.expand_uri')
+    @mock.patch('h.streamer.websocket.storage.expand_uri')
     def test_expands_uris_in_uri_filter_with_session(self, expand_uri, socket):
         expand_uri.return_value = ['http://example.com',
                                    'http://example.com/alter',
@@ -318,7 +318,7 @@ class TestHandleFilterMessage(object):
         assert 'http://example.com/alter' in uri_values
         assert 'http://example.com/print' in uri_values
 
-    @mock.patch('memex.storage.expand_uri')
+    @mock.patch('h.streamer.websocket.storage.expand_uri')
     def test_expands_uris_using_passed_session(self, expand_uri, socket):
         expand_uri.return_value = ['http://example.com', 'http://example.org/']
         session = mock.sentinel.db_session


### PR DESCRIPTION
This is part of a project to reintegrate the `memex` package into the main
`h` package: https://notes.wtk.io/2017/03/08/reintegrating-memex

Two things to note here:

1. This module predates the use of "services" to encapsulate business logic in our application. It would probably be better managed as a handful of services at this point, and I've added a note to that effect.

2. Moving this into `h` requires introducing some dependencies on `h` from `memex`. This isn't ideal, but if we're moving all of `memex` to `h` anyway it probably doesn't matter, and it's very likely better than having to move all connected parts of the dependency graph into `h` at once.

_*N.B.* This will need a rebase after #4432._