### PR TITLE
Remove more instances of "web service" from docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
-Hypothesis Web Service
-======================
+h
+=
 
 .. image:: https://travis-ci.org/hypothesis/h.svg?branch=master
    :target: https://travis-ci.org/hypothesis/h
@@ -16,11 +16,10 @@ Hypothesis Web Service
 .. image:: https://img.shields.io/badge/python-2.7-blue.svg
    :alt: Python version badge
 
-The Hypothesis web service is the web app that serves most of the
-https://hypothes.is/ website, including the web annotations API at
-https://hypothes.is/api/.
+h is the web app that serves most of the https://hypothes.is/ website,
+including the web annotations API at https://hypothes.is/api/.
 The `Hypothesis client <https://github.com/hypothesis/client>`_
-is a browser-based annotator that is a client for the web service's API.
+is a browser-based annotator that is a client for h's API.
 
 
 Development

--- a/docs/developing/install.rst
+++ b/docs/developing/install.rst
@@ -7,8 +7,8 @@ environment the first thing you need to do is install h's system dependencies.
 
 .. seealso::
 
-   This page documents how to setup a development install of the Hypothesis
-   web service. For installing the Hypothesis client for development see
+   This page documents how to setup a development install of h.
+   For installing the Hypothesis client for development see
    https://github.com/hypothesis/client/, and for the browser extension
    see https://github.com/hypothesis/browser-extension.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,14 +5,14 @@ Welcome to the h Documentation!
 https://hypothes.is/ website, including the web annotations API at
 https://hypothes.is/api/.
 The `Hypothesis client <https://github.com/hypothesis/client>`_
-is a browser-based annotator that is a client for the web service's API, see
+is a browser-based annotator that is a client for h's API, see
 `the client's own documentation site <https://h.readthedocs.io/projects/client/>`_
 for docs about the client.
 
 This documentation is for:
 
-* Developers working with data stored in the Hypothesis service.
-* Contributors to the Hypothesis service and client.
+* Developers working with data stored in h
+* Contributors to h
 
 Contents
 --------


### PR DESCRIPTION
We're just calling it "h" not "the Hypothesis web service".