### PR TITLE
Add flag index endpoint

### DIFF
--- a/h/migrations/versions/e554d862135f_add_index_to_flag_user_id.py
+++ b/h/migrations/versions/e554d862135f_add_index_to_flag_user_id.py
@@ -1,0 +1,25 @@
+"""
+Add index to flag.user_id
+
+Revision ID: e554d862135f
+Revises: 5655d56d7c29
+Create Date: 2017-03-16 12:35:45.791202
+"""
+
+from __future__ import unicode_literals
+
+from alembic import op
+
+
+revision = 'e554d862135f'
+down_revision = '5655d56d7c29'
+
+
+def upgrade():
+    op.execute('COMMIT')
+    op.create_index(op.f('ix__flag__user_id'), 'flag', ['user_id'],
+                    unique=False, postgresql_concurrently=True)
+
+
+def downgrade():
+    op.drop_index(op.f('ix__flag__user_id'), 'flag')

--- a/h/models/flag.py
+++ b/h/models/flag.py
@@ -32,7 +32,7 @@ class Flag(Base, Timestamps):
 
     user_id = sa.Column(sa.Integer,
                         sa.ForeignKey('user.id', ondelete='cascade'),
-                        nullable=False)
+                        nullable=False, index=True)
 
     #: The user who created the flag.
     user = sa.orm.relationship('User')

--- a/h/services/flag.py
+++ b/h/services/flag.py
@@ -50,6 +50,19 @@ class FlagService(object):
                            annotation=annotation)
         self.session.add(flag)
 
+    def list(self, user):
+        """
+        Return a list of flags made by the given user.
+
+        :param user: The user to filter flags on.
+        :type user: h.models.User
+
+        :returns: list of flags (``h.models.Flag``)
+        :rtype: list
+        """
+
+        return self.session.query(models.Flag).filter_by(user=user)
+
 
 def flag_service_factory(context, request):
     return FlagService(request.db)

--- a/h/services/flag.py
+++ b/h/services/flag.py
@@ -2,7 +2,10 @@
 
 from __future__ import unicode_literals
 
+from memex import uri
+
 from h import models
+from h import storage
 
 
 class FlagService(object):
@@ -50,7 +53,7 @@ class FlagService(object):
                            annotation=annotation)
         self.session.add(flag)
 
-    def list(self, user, group=None):
+    def list(self, user, group=None, uris=None):
         """
         Return a list of flags made by the given user.
 
@@ -60,15 +63,32 @@ class FlagService(object):
         :param group: The annotation group pubid for filtering flags.
         :type group: unicode
 
+        :param uris: A list of annotation uris for filtering flags.
+        :type uris: list of unicode
+
         :returns: list of flags (``h.models.Flag``)
         :rtype: list
         """
 
         query = self.session.query(models.Flag).filter_by(user=user)
 
+        joined_annotation = False
+
         if group is not None:
+            joined_annotation = True
             query = query.join(models.Annotation) \
                          .filter(models.Annotation.groupid == group)
+
+        if uris:
+            query_uris = set()
+            for u in uris:
+                expanded = storage.expand_uri(self.session, u)
+                query_uris.update([uri.normalize(e) for e in expanded])
+
+            if not joined_annotation:
+                joined_annotation = True
+                query = query.join(models.Annotation)
+            query = query.filter(models.Annotation.target_uri_normalized.in_(query_uris))
 
         return query
 

--- a/h/services/flag.py
+++ b/h/services/flag.py
@@ -50,18 +50,27 @@ class FlagService(object):
                            annotation=annotation)
         self.session.add(flag)
 
-    def list(self, user):
+    def list(self, user, group=None):
         """
         Return a list of flags made by the given user.
 
         :param user: The user to filter flags on.
         :type user: h.models.User
 
+        :param group: The annotation group pubid for filtering flags.
+        :type group: unicode
+
         :returns: list of flags (``h.models.Flag``)
         :rtype: list
         """
 
-        return self.session.query(models.Flag).filter_by(user=user)
+        query = self.session.query(models.Flag).filter_by(user=user)
+
+        if group is not None:
+            query = query.join(models.Annotation) \
+                         .filter(models.Annotation.groupid == group)
+
+        return query
 
 
 def flag_service_factory(context, request):

--- a/h/views/api_flags.py
+++ b/h/views/api_flags.py
@@ -21,6 +21,17 @@ def create(context, request):
     return HTTPNoContent()
 
 
+@api_config(route_name='api.flags',
+            request_method='GET',
+            link_name='flag.index',
+            description='List a users flagged annotations for review.',
+            effective_principals=security.Authenticated)
+def index(request):
+    svc = request.find_service(name='flag')
+    flags = svc.list(request.authenticated_user)
+    return [{'annotation': flag.annotation_id} for flag in flags]
+
+
 def _fetch_annotation(context, request):
     try:
         annotation_id = request.json_body.get('annotation')

--- a/h/views/api_flags.py
+++ b/h/views/api_flags.py
@@ -27,8 +27,12 @@ def create(context, request):
             description='List a users flagged annotations for review.',
             effective_principals=security.Authenticated)
 def index(request):
+    group = request.GET.get('group')
+    if not group:
+        group = None
+
     svc = request.find_service(name='flag')
-    flags = svc.list(request.authenticated_user)
+    flags = svc.list(request.authenticated_user, group=group)
     return [{'annotation': flag.annotation_id} for flag in flags]
 
 

--- a/h/views/api_flags.py
+++ b/h/views/api_flags.py
@@ -31,8 +31,10 @@ def index(request):
     if not group:
         group = None
 
+    uris = request.GET.getall('uri')
+
     svc = request.find_service(name='flag')
-    flags = svc.list(request.authenticated_user, group=group)
+    flags = svc.list(request.authenticated_user, group=group, uris=uris)
     return [{'annotation': flag.annotation_id} for flag in flags]
 
 

--- a/tests/h/conftest.py
+++ b/tests/h/conftest.py
@@ -17,6 +17,7 @@ import sqlalchemy
 from pyramid import testing
 from pyramid.request import apply_request_extensions
 from sqlalchemy.orm import sessionmaker
+from webob.multidict import MultiDict
 
 from h import db
 from h import models  # noqa: ensure base class set for memex
@@ -229,6 +230,9 @@ def pyramid_request(db_session, fake_feature, pyramid_settings):
     request.matched_route = mock.Mock()
     request.registry.settings = pyramid_settings
     request.is_xhr = False
+    request.params = MultiDict()
+    request.GET = request.params
+    request.POST = request.params
     return request
 
 

--- a/tests/h/services/flag_test.py
+++ b/tests/h/services/flag_test.py
@@ -53,6 +53,28 @@ class TestFlagServiceCreate(object):
                          .count() == 1
 
 
+@pytest.mark.usefixtures('flags')
+class TestFlagServiceList(object):
+    def test_it_filters_by_user(self, svc, users, flags):
+        expected = {f for f in flags if f.user == users['alice']}
+        assert set(svc.list(users['alice'])) == expected
+
+    @pytest.fixture
+    def users(self, factories):
+        return {'alice': factories.User(username='alice'),
+                'bob': factories.User(username='bob')}
+
+    @pytest.fixture
+    def flags(self, factories, users):
+        return [
+            factories.Flag(user=users['alice']),
+            factories.Flag(user=users['alice']),
+            factories.Flag(user=users['bob']),
+            factories.Flag(user=users['bob']),
+            factories.Flag(user=users['alice']),
+        ]
+
+
 class TestFlagServiceFactory(object):
     def test_it_returns_flag_service(self, pyramid_request):
         svc = flag.flag_service_factory(None, pyramid_request)

--- a/tests/h/views/api_flags_test.py
+++ b/tests/h/views/api_flags_test.py
@@ -108,7 +108,8 @@ class TestIndex(object):
     def test_it_passes_user_filter(self, pyramid_request, flag_service):
         views.index(pyramid_request)
         flag_service.list.assert_called_once_with(pyramid_request.authenticated_user,
-                                                  group=None)
+                                                  group=None,
+                                                  uris=[])
 
     def test_it_passes_group_filter(self, pyramid_request, flag_service):
         pyramid_request.GET['group'] = 'test-pubid'
@@ -116,7 +117,8 @@ class TestIndex(object):
         views.index(pyramid_request)
 
         flag_service.list.assert_called_once_with(mock.ANY,
-                                                  group='test-pubid')
+                                                  group='test-pubid',
+                                                  uris=[])
 
     def test_it_skips_empty_group_filter(self, pyramid_request, flag_service):
         pyramid_request.GET['group'] = ''
@@ -124,7 +126,18 @@ class TestIndex(object):
         views.index(pyramid_request)
 
         flag_service.list.assert_called_once_with(mock.ANY,
-                                                  group=None)
+                                                  group=None,
+                                                  uris=[])
+
+    def test_it_passes_uris_filter(self, pyramid_request, flag_service):
+        pyramid_request.GET.add('uri', 'https://example.com/document')
+        pyramid_request.GET.add('uri', 'https://example.org/document')
+
+        views.index(pyramid_request)
+
+        flag_service.list.assert_called_once_with(mock.ANY,
+                                                  group=mock.ANY,
+                                                  uris=['https://example.com/document', 'https://example.org/document'])
 
     def test_it_renders_flags(self, pyramid_request, flags):
         expected = [{'annotation': f.annotation_id} for f in flags]

--- a/tests/h/views/api_flags_test.py
+++ b/tests/h/views/api_flags_test.py
@@ -107,7 +107,24 @@ class TestCreate(object):
 class TestIndex(object):
     def test_it_passes_user_filter(self, pyramid_request, flag_service):
         views.index(pyramid_request)
-        flag_service.list.assert_called_once_with(pyramid_request.authenticated_user)
+        flag_service.list.assert_called_once_with(pyramid_request.authenticated_user,
+                                                  group=None)
+
+    def test_it_passes_group_filter(self, pyramid_request, flag_service):
+        pyramid_request.GET['group'] = 'test-pubid'
+
+        views.index(pyramid_request)
+
+        flag_service.list.assert_called_once_with(mock.ANY,
+                                                  group='test-pubid')
+
+    def test_it_skips_empty_group_filter(self, pyramid_request, flag_service):
+        pyramid_request.GET['group'] = ''
+
+        views.index(pyramid_request)
+
+        flag_service.list.assert_called_once_with(mock.ANY,
+                                                  group=None)
 
     def test_it_renders_flags(self, pyramid_request, flags):
         expected = [{'annotation': f.annotation_id} for f in flags]

--- a/tests/h/views/api_flags_test.py
+++ b/tests/h/views/api_flags_test.py
@@ -101,3 +101,34 @@ class TestCreate(object):
         flag_service = mock.Mock(spec_set=['create'])
         pyramid_config.register_service(flag_service, name='flag')
         return flag_service
+
+
+@pytest.mark.usefixtures('flag_service')
+class TestIndex(object):
+    def test_it_passes_user_filter(self, pyramid_request, flag_service):
+        views.index(pyramid_request)
+        flag_service.list.assert_called_once_with(pyramid_request.authenticated_user)
+
+    def test_it_renders_flags(self, pyramid_request, flags):
+        expected = [{'annotation': f.annotation_id} for f in flags]
+
+        response = views.index(pyramid_request)
+        assert response == expected
+
+    @pytest.fixture
+    def flags(self, factories):
+        return [factories.Flag.build(annotation_id='test-annotation-1'),
+                factories.Flag.build(annotation_id='test-annotation-2'),
+                factories.Flag.build(annotation_id='test-annotation-3')]
+
+    @pytest.fixture
+    def flag_service(self, pyramid_config, flags):
+        flag_service = mock.Mock(spec_set=['list'])
+        flag_service.list.return_value = flags
+        pyramid_config.register_service(flag_service, name='flag')
+        return flag_service
+
+    @pytest.fixture
+    def pyramid_request(self, pyramid_request):
+        pyramid_request.authenticated_user = mock.Mock()
+        return pyramid_request


### PR DESCRIPTION
Implements hypothesis/product-backlog#207.

This adds the `GET /api/flags` endpoint which can optionally be filtered with one or more `uri` parameters, or with the `group` filter.
The `uri` parameter will take the document equivalence into account.