### PR TITLE
Add a feature flag for filtering highlights based on visible annotations in sidebar

### DIFF
--- a/h/models/feature.py
+++ b/h/models/feature.py
@@ -13,6 +13,8 @@ log = logging.getLogger(__name__)
 FEATURES = {
     'defer_realtime_updates': ("Require a user action before applying real-time"
                                " updates to annotations in the client?"),
+    'filter_highlights': ("Filter highlights in document based on visible"
+                          " annotations in sidebar?"),
     'orphans_tab': "Show the orphans tab to separate anchored and unanchored annotations?",
     'total_shared_annotations': "Show the total number of shared annotations for users and groups?",
 }


### PR DESCRIPTION
We are investigating changing the visible highlights in an annotated document based on the current filter settings in the sidebar. Add a feature flag so we can test out behavior and performance impact with a select group of users.

See https://github.com/hypothesis/client/issues/217 for more context.

CC @greebie