### PR TITLE
Replace inline script for homepage Via form

### DIFF
--- a/h/static/scripts/legacy-site.js
+++ b/h/static/scripts/legacy-site.js
@@ -30,3 +30,14 @@ if (chromeextInstaller) {
     event.preventDefault();
   });
 }
+
+const viaForm = document.querySelector('.js-via-form');
+if (viaForm) {
+  viaForm.addEventListener('submit', (event) => {
+    const url = event.target.elements.url.value;
+    if (url !== '') {
+      window.location.href = 'https://via.hypothes.is/' + url;
+    }
+    event.preventDefault();
+  });
+}

--- a/h/templates/home.html.jinja2
+++ b/h/templates/home.html.jinja2
@@ -133,12 +133,14 @@
                 </span>
 
                 <em class="or hidden-xs">Or...</em>
-                <form class="via" onsubmit="url = document.getElementById('search').value; if (url != '') { window.location.href = 'https://via.hypothes.is/h/' + url; } return false;">
+                <form class="via js-via-form">
                   <span class="input-group"
                         title="Insert a URL to annotate that page.">
-                    <input id="search" class="form-control" type="text"
-                            name="search" placeholder="Paste a link...">
-                    <span class="input-group-btn" data-via-button="">
+                    <input class="form-control"
+                           type="text"
+                           name="url"
+                           placeholder="Paste a link...">
+                    <span class="input-group-btn">
                       <button class="btn btn-primary" type="submit">
                         Annotate!
                       </button>


### PR DESCRIPTION
The form on the homepage which sends people to Via used an inline event handler which violates our Content Security Policy.

Replace the onsubmit handler with code provided in legacy-site.js.

This commit also:

- removes an apparently unused data- attribute in the HTML
- renames the input from "search" to "url"
- finds the input through the form rather than by document ID
- sends users to the correct Via URL, saving them a redirect

Fixes #4438.