### PR TITLE
Refactor session and WorldGroup tests

### DIFF
--- a/tests/h/groups/util_test.py
+++ b/tests/h/groups/util_test.py
@@ -2,34 +2,30 @@
 
 from __future__ import unicode_literals
 
+import pytest
+
 from pyramid import security
 
 from h.groups import util
 
 
-def test_world_group_acl():
-    group = util.WorldGroup('example.com')
+class TestWorldGroup(object):
+    def test_acl(self, group):
+        assert group.__acl__() == [
+            (security.Allow, security.Everyone, 'read'),
+            (security.Allow, 'authority:example.com', 'write'),
+            security.DENY_ALL,
+        ]
 
-    assert group.__acl__() == [
-        (security.Allow, security.Everyone, 'read'),
-        (security.Allow, 'authority:example.com', 'write'),
-        security.DENY_ALL,
-    ]
+    def test_name(self, group):
+        assert group.name == 'Public'
 
+    def test_pubid(self, group):
+        assert group.pubid == '__world__'
 
-def test_world_group_name():
-    group = util.WorldGroup('example.com')
+    def test_is_public(self, group):
+        assert group.is_public
 
-    assert group.name == 'Public'
-
-
-def test_world_group_pubid():
-    group = util.WorldGroup('example.com')
-
-    assert group.pubid == '__world__'
-
-
-def test_world_group_is_public():
-    group = util.WorldGroup('example.com')
-
-    assert group.is_public
+    @pytest.fixture
+    def group(self):
+        return util.WorldGroup('example.com')


### PR DESCRIPTION
This just refactors the tests in `tests/h/groups/util_test.py` and `tests/h/session_test.py` to use test classes.

The next pull request will add some more tests to both of these classes, so using test classes will make them a bit more readable. The tests themselves haven't actually changed, I just moved them around, sometimes changed the test name, and obviously added the `self` parameter to all of them.