### PR TITLE
Expose moderation role in `/api/profile`

### DIFF
--- a/h/groups/util.py
+++ b/h/groups/util.py
@@ -33,3 +33,7 @@ class WorldGroup(object):
     @property
     def is_public(self):
         return True
+
+    @property
+    def creator_id(self):
+        return None

--- a/h/session.py
+++ b/h/session.py
@@ -68,7 +68,7 @@ def _current_groups(request, authority):
 
     groups = authority_groups + _user_groups(user)
 
-    return [_group_model(request.route_url, group) for group in groups]
+    return [_group_model(request.route_url, group, user) for group in groups]
 
 
 def _user_groups(user):
@@ -78,8 +78,12 @@ def _user_groups(user):
         return sorted(user.groups, key=_group_sort_key)
 
 
-def _group_model(route_url, group):
-    model = {'name': group.name, 'id': group.pubid, 'public': group.is_public}
+def _group_model(route_url, group, user):
+    is_moderator = user is not None and user.id == group.creator_id
+    model = {'name': group.name,
+             'id': group.pubid,
+             'public': group.is_public,
+             'is_moderator': is_moderator}
 
     # We currently want to show URLs for secret groups, but not for publisher
     # groups, and not for the `__world__` group (where it doesn't make sense).
@@ -89,6 +93,7 @@ def _group_model(route_url, group):
         model['url'] = route_url('group_read',
                                  pubid=group.pubid,
                                  slug=group.slug)
+
     return model
 
 

--- a/tests/h/groups/util_test.py
+++ b/tests/h/groups/util_test.py
@@ -26,6 +26,9 @@ class TestWorldGroup(object):
     def test_is_public(self, group):
         assert group.is_public
 
+    def test_creator_id(self, group):
+        assert group.creator_id is None
+
     @pytest.fixture
     def group(self):
         return util.WorldGroup('example.com')


### PR DESCRIPTION
We decided that we will have two separate endpoints for getting the flags status for a given URL and group, one for normal group users, and one for moderators. Because of this, the client will need to know if the authenticated user has moderation abilities for a given group, we can return this flag in the response of `/api/profile`.

It will look similar to this:
```json
{
  "preferences": {},
  "userid": "acct:chdorner@localhost",
  "groups": [
    {
      "public": true,
      "name": "Public",
      "id": "__world__"
    },
    {
      "url": "https://localhost:5000/groups/redacted/chdorner-testing",
      "public": false,
      "is_moderator": true,
      "name": "chdorner-testing",
      "id": "redacted"
    },
    {
      "url": "https://localhost:5000/groups/redacted/hypothesis-reading",
      "public": false,
      "name": "Hypothesis Reading",
      "id": "redacted"
    }
  ],
  "authority": "localhost",
  "features": {
    "total_shared_annotations": true,
    "defer_realtime_updates": true,
    "orphans_tab": true,
    "filter_highlights": false
  }
}
```

Note that the `is_moderator` key only exists when the user is a moderator, otherwise it will be missing.