### PR TITLE
Annotation formatters and exposing flag state

### DIFF
--- a/h/formatters/__init__.py
+++ b/h/formatters/__init__.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from h.formatters.annotation_flag import AnnotationFlagFormatter
+
+__all__ = (
+    'AnnotationFlagFormatter',
+)

--- a/h/formatters/annotation_flag.py
+++ b/h/formatters/annotation_flag.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from zope.interface import implementer
+
+from h import models
+from h.formatters.interfaces import IAnnotationFormatter
+
+
+@implementer(IAnnotationFormatter)
+class AnnotationFlagFormatter(object):
+    """
+    Formatter for exposing a user's annotation flags.
+
+    If the passed-in user has flagged an annotation, this formatter will
+    add: `"flagged": true` to the payload, otherwise `"flagged": false`.
+    """
+
+    def __init__(self, session, authenticated_user=None):
+        self.session = session
+        self.authenticated_user = authenticated_user
+
+        # Local cache of flags. We don't need to care about detached
+        # instances because we only store the annotation id and a boolean flag.
+        self._cache = {}
+
+    def preload(self, ids):
+        if self.authenticated_user is None:
+            return
+
+        query = self.session.query(models.Flag) \
+                            .filter(models.Flag.annotation_id.in_(ids),
+                                    models.Flag.user == self.authenticated_user)
+
+        flags = {f.annotation_id: True for f in query}
+
+        # Set flags which have not been found explicitly to False to indicate
+        # that we already tried to load them.
+        missing_ids = set(ids) - set(flags.keys())
+        missing = {id_: False for id_ in missing_ids}
+        flags.update(missing)
+
+        self._cache.update(flags)
+        return flags
+
+    def format(self, annotation):
+        flagged = self._load(annotation.id)
+        return {'flagged': flagged}
+
+    def _load(self, id_):
+        if self.authenticated_user is None:
+            return False
+
+        if id_ in self._cache:
+            return self._cache[id_]
+
+        flag = self.session.query(models.Flag) \
+                           .filter_by(annotation_id=id_,
+                                      user=self.authenticated_user) \
+                           .one_or_none()
+
+        self._cache[id_] = (flag is not None)
+        return self._cache[id_]

--- a/h/formatters/interfaces.py
+++ b/h/formatters/interfaces.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from zope.interface import Interface
+
+
+class IAnnotationFormatter(Interface):
+    """
+    Interface for annotation formatters.
+
+    Annotation formatters are ways to add data to the annotation JSON payload
+    without putting everything in the annotation presenter, thus allowing better
+    decoupling of code.
+
+    The main method is ``format(annotation)`` which is expected to return a
+    dictionary representation based on the passed-in annotation. If the
+    formatter depends on other data it should be able to load it on-demand
+    for the given annotation.
+
+    Since we are rendering lists of potentially hundreds of annotations in one
+    request formatters need to be able to optimize the fetching of additional
+    data (e.g. from the database). Which is why this interface defines the
+    ``preload(ids)`` method.
+    Each formatter implementation is expected to handle a cache internally which
+    is being preloaded with said method.
+    """
+
+    def preload(ids):  # noqa: N805
+        """
+        Batch load data based on annotation ids.
+
+        :param ids: List of annotation ids based on which data should be preloaded.
+        :type ids: list of unicode
+        """
+
+    def format(annotation):  # noqa: N805
+        """
+        Presents additional annotation data that will be served to API clients.
+
+        :param annotation: The annotation object that needs presenting.
+        :type annotation: memex.models.Annotation
+
+        :returns: A formatted dictionary.
+        :rtype: dict
+        """

--- a/h/services/__init__.py
+++ b/h/services/__init__.py
@@ -6,6 +6,8 @@ from __future__ import unicode_literals
 
 
 def includeme(config):
+    config.register_service_factory('.annotation_json_presentation.annotation_json_presentation_service_factory',
+                                    name='annotation_json_presentation')
     config.register_service_factory('.annotation_stats.annotation_stats_factory', name='annotation_stats')
     config.register_service_factory('.auth_ticket.auth_ticket_service_factory',
                                     iface='pyramid_authsanity.interfaces.IAuthService')

--- a/h/services/annotation_json_presentation.py
+++ b/h/services/annotation_json_presentation.py
@@ -2,14 +2,42 @@
 
 from __future__ import unicode_literals
 
+from sqlalchemy.orm import subqueryload
+
+from memex import resources
+from memex.interfaces import IGroupService
+
+from h import models
 from h import presenters
+from h import storage
 
 
 class AnnotationJSONPresentationService(object):
+    def __init__(self, session, group_svc, links_svc):
+        self.session = session
+        self.group_svc = group_svc
+        self.links_svc = links_svc
+
     def present(self, annotation_resource):
         presenter = presenters.AnnotationJSONPresenter(annotation_resource)
         return presenter.asdict()
 
+    def present_all(self, annotation_ids):
+        def eager_load_documents(query):
+            return query.options(
+                subqueryload(models.Annotation.document))
+
+        annotations = storage.fetch_ordered_annotations(
+            self.session, annotation_ids, query_processor=eager_load_documents)
+
+        return [self.present(
+                    resources.AnnotationResource(ann, self.group_svc, self.links_svc))
+                for ann in annotations]
+
 
 def annotation_json_presentation_service_factory(context, request):
-    return AnnotationJSONPresentationService()
+    group_svc = request.find_service(IGroupService)
+    links_svc = request.find_service(name='links')
+    return AnnotationJSONPresentationService(request.db,
+                                             group_svc,
+                                             links_svc)

--- a/h/services/annotation_json_presentation.py
+++ b/h/services/annotation_json_presentation.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from h import presenters
+
+
+class AnnotationJSONPresentationService(object):
+    def present(self, annotation_resource):
+        presenter = presenters.AnnotationJSONPresenter(annotation_resource)
+        return presenter.asdict()
+
+
+def annotation_json_presentation_service_factory(context, request):
+    return AnnotationJSONPresentationService()

--- a/h/services/annotation_json_presentation.py
+++ b/h/services/annotation_json_presentation.py
@@ -24,7 +24,7 @@ class AnnotationJSONPresentationService(object):
         ]
 
     def present(self, annotation_resource):
-        presenter = self.get_presenter(annotation_resource)
+        presenter = self._get_presenter(annotation_resource)
         return presenter.asdict()
 
     def present_all(self, annotation_ids):
@@ -43,7 +43,7 @@ class AnnotationJSONPresentationService(object):
                     resources.AnnotationResource(ann, self.group_svc, self.links_svc))
                 for ann in annotations]
 
-    def get_presenter(self, annotation_resource):
+    def _get_presenter(self, annotation_resource):
         presenter = presenters.AnnotationJSONPresenter(annotation_resource)
 
         for formatter in self.formatters:

--- a/h/services/annotation_json_presentation.py
+++ b/h/services/annotation_json_presentation.py
@@ -7,18 +7,21 @@ from sqlalchemy.orm import subqueryload
 from memex import resources
 from memex.interfaces import IGroupService
 
+from h import formatters
 from h import models
 from h import presenters
 from h import storage
 
 
 class AnnotationJSONPresentationService(object):
-    def __init__(self, session, group_svc, links_svc):
+    def __init__(self, session, authenticated_user, group_svc, links_svc):
         self.session = session
         self.group_svc = group_svc
         self.links_svc = links_svc
 
-        self.formatters = []
+        self.formatters = [
+            formatters.AnnotationFlagFormatter(self.session, authenticated_user)
+        ]
 
     def present(self, annotation_resource):
         presenter = self.get_presenter(annotation_resource)
@@ -52,6 +55,7 @@ class AnnotationJSONPresentationService(object):
 def annotation_json_presentation_service_factory(context, request):
     group_svc = request.find_service(IGroupService)
     links_svc = request.find_service(name='links')
-    return AnnotationJSONPresentationService(request.db,
-                                             group_svc,
-                                             links_svc)
+    return AnnotationJSONPresentationService(session=request.db,
+                                             authenticated_user=request.authenticated_user,
+                                             group_svc=group_svc,
+                                             links_svc=links_svc)

--- a/h/views/api.py
+++ b/h/views/api.py
@@ -233,8 +233,8 @@ def create(request):
             description='Fetch an annotation')
 def read(context, request):
     """Return the annotation (simply how it was stored in the database)."""
-    presenter = AnnotationJSONPresenter(context)
-    return presenter.asdict()
+    svc = request.find_service(name='annotation_json_presentation')
+    return svc.present(context)
 
 
 @api_config(route_name='api.annotation.jsonld',

--- a/tests/h/formatters/annotation_flag_test.py
+++ b/tests/h/formatters/annotation_flag_test.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import pytest
+
+from h.formatters.annotation_flag import AnnotationFlagFormatter
+
+
+class TestAnnotationFlagFormatter(object):
+    def test_preload_sets_found_flags_to_true(self, flags, formatter, current_user):
+        annotation_ids = [f.annotation_id for f in flags[current_user]]
+
+        expected = {id_: True for id_ in annotation_ids}
+        assert formatter.preload(annotation_ids) == expected
+
+    def test_preload_sets_missing_flags_to_false(self, flags, formatter, other_user):
+        annotation_ids = [f.annotation_id for f in flags[other_user]]
+
+        expected = {id_: False for id_ in annotation_ids}
+        assert formatter.preload(annotation_ids) == expected
+
+    def test_format_for_existing_flag(self, formatter, factories, current_user):
+        flag = factories.Flag(user=current_user)
+        assert formatter.format(flag.annotation) == {'flagged': True}
+
+    def test_format_for_missing_flag(self, formatter, factories):
+        annotation = factories.Annotation()
+
+        assert formatter.format(annotation) == {'flagged': False}
+
+    def test_format_for_unauthenticated_user(self, db_session, factories):
+        annotation = factories.Annotation()
+        formatter = AnnotationFlagFormatter(db_session,
+                                            authenticated_user=None)
+
+        assert formatter.format(annotation) == {'flagged': False}
+
+    @pytest.fixture
+    def current_user(self, factories):
+        return factories.User()
+
+    @pytest.fixture
+    def other_user(self, factories):
+        return factories.User()
+
+    @pytest.fixture
+    def formatter(self, db_session, current_user):
+        return AnnotationFlagFormatter(db_session, current_user)
+
+    @pytest.fixture
+    def flags(self, factories, current_user, other_user):
+        return {
+            current_user: [factories.Flag(user=current_user) for _ in range(3)],
+            other_user: [factories.Flag(user=other_user) for _ in range(2)],
+        }

--- a/tests/h/presenters/annotation_json_test.py
+++ b/tests/h/presenters/annotation_json_test.py
@@ -9,9 +9,23 @@ import pytest
 
 from pyramid import security
 from pyramid.authorization import ACLAuthorizationPolicy
+from zope.interface import implementer
 
+from h.formatters.interfaces import IAnnotationFormatter
 from h.presenters.annotation_json import AnnotationJSONPresenter
 from memex.resources import AnnotationResource
+
+
+@implementer(IAnnotationFormatter)
+class FakeFormatter(object):
+    def __init__(self, data=None):
+        self.data = data or {}
+
+    def preload(self, ids):
+        pass
+
+    def format(self, annotation):
+        return self.data
 
 
 class TestAnnotationJSONPresenter(object):
@@ -76,6 +90,18 @@ class TestAnnotationJSONPresenter(object):
         # Presenting the annotation shouldn't change the "extra" dict.
         assert extra == {'foo': 'bar'}
 
+    def test_asdict_merges_formatters(self, group_service, fake_links_service):
+        ann = mock.Mock(id='the-real-id', extra={})
+        resource = AnnotationResource(ann, group_service, fake_links_service)
+
+        presenter = AnnotationJSONPresenter(resource)
+        presenter.add_formatter(FakeFormatter({'flagged': 'nope'}))
+        presenter.add_formatter(FakeFormatter({'nipsa': 'maybe'}))
+        presented = presenter.asdict()
+
+        assert presented['flagged'] == 'nope'
+        assert presented['nipsa'] == 'maybe'
+
     @pytest.mark.usefixtures('policy')
     @pytest.mark.parametrize('annotation,group_readable,action,expected', [
         (mock.Mock(userid='acct:luke', shared=False), 'world', 'read', ['acct:luke']),
@@ -102,6 +128,24 @@ class TestAnnotationJSONPresenter(object):
         resource = AnnotationResource(annotation, group_service, fake_links_service)
         presenter = AnnotationJSONPresenter(resource)
         assert expected == presenter.permissions[action]
+
+    def test_add_formatter(self):
+        presenter = AnnotationJSONPresenter(mock.Mock())
+
+        formatter = FakeFormatter()
+
+        presenter.add_formatter(formatter)
+        assert formatter in presenter.formatters
+
+    def test_add_formatter_raises_for_wrong_formatter_type(self):
+        presenter = AnnotationJSONPresenter(mock.Mock())
+
+        formatter = mock.Mock()
+
+        with pytest.raises(ValueError) as exc:
+            presenter.add_formatter(formatter)
+
+        assert 'not implementing IAnnotationFormatter interface' in exc.value.message
 
     @pytest.fixture
     def document_asdict(self, patch):

--- a/tests/h/services/annotation_json_presentation_test.py
+++ b/tests/h/services/annotation_json_presentation_test.py
@@ -5,10 +5,13 @@ from __future__ import unicode_literals
 import mock
 import pytest
 
+from memex.interfaces import IGroupService
+
 from h.services.annotation_json_presentation import AnnotationJSONPresentationService
 from h.services.annotation_json_presentation import annotation_json_presentation_service_factory
 
 
+@pytest.mark.usefixtures('presenters')
 class TestAnnotationJSONPresentationService(object):
     def test_present_inits_presenter(self, svc, presenters):
         resource = mock.Mock()
@@ -24,17 +27,86 @@ class TestAnnotationJSONPresentationService(object):
 
         assert result == presenter.asdict.return_value
 
+    def test_present_all_loads_annotations_from_db(self, svc, storage):
+        svc.present_all(['id-1', 'id-2'])
+
+        storage.fetch_ordered_annotations.assert_called_once_with(
+            svc.session, ['id-1', 'id-2'], query_processor=mock.ANY)
+
+    def test_present_all_initialises_annotation_resources(self, svc, storage, resources):
+        ann = mock.Mock()
+        storage.fetch_ordered_annotations.return_value = [ann]
+
+        svc.present_all(['ann-1'])
+
+        resources.AnnotationResource.assert_called_once_with(ann, svc.group_svc, svc.links_svc)
+
+    def test_present_all_presents_annotation_resources(self, svc, storage, resources, present):
+        storage.fetch_ordered_annotations.return_value = [mock.Mock()]
+        resource = resources.AnnotationResource.return_value
+
+        svc.present_all(['ann-1'])
+        present.assert_called_once_with(svc, resource)
+
+    def test_returns_presented_annotations(self, svc, storage, present):
+        storage.fetch_ordered_annotations.return_value = [mock.Mock()]
+
+        result = svc.present_all(['ann-1'])
+        assert result == [present.return_value]
+
     @pytest.fixture
-    def svc(self):
-        return AnnotationJSONPresentationService()
+    def svc(self, db_session):
+        group_svc = mock.Mock()
+        links_svc = mock.Mock()
+        return AnnotationJSONPresentationService(db_session, group_svc, links_svc)
 
     @pytest.fixture
     def presenters(self, patch):
         return patch('h.services.annotation_json_presentation.presenters')
 
+    @pytest.fixture
+    def storage(self, patch):
+        return patch('h.services.annotation_json_presentation.storage')
 
+    @pytest.fixture
+    def resources(self, patch):
+        return patch('h.services.annotation_json_presentation.resources')
+
+    @pytest.fixture
+    def present(self, patch):
+        return patch('h.services.annotation_json_presentation.AnnotationJSONPresentationService.present')
+
+
+@pytest.mark.usefixtures('group_svc', 'links_svc')
 class TestAnnotationJSONPresentationServiceFactory(object):
     def test_returns_service(self, pyramid_request):
         svc = annotation_json_presentation_service_factory(None, pyramid_request)
 
         assert isinstance(svc, AnnotationJSONPresentationService)
+
+    def test_provides_session(self, pyramid_request):
+        svc = annotation_json_presentation_service_factory(None, pyramid_request)
+
+        assert svc.session == pyramid_request.db
+
+    def test_provides_group_service(self, pyramid_request, group_svc):
+        svc = annotation_json_presentation_service_factory(None, pyramid_request)
+
+        assert svc.group_svc == group_svc
+
+    def test_passes_links_service(self, pyramid_request, links_svc):
+        svc = annotation_json_presentation_service_factory(None, pyramid_request)
+
+        assert svc.links_svc == links_svc
+
+    @pytest.fixture
+    def group_svc(self, pyramid_config):
+        svc = mock.Mock()
+        pyramid_config.register_service(svc, iface=IGroupService)
+        return svc
+
+    @pytest.fixture
+    def links_svc(self, pyramid_config):
+        svc = mock.Mock()
+        pyramid_config.register_service(svc, name='links')
+        return svc

--- a/tests/h/services/annotation_json_presentation_test.py
+++ b/tests/h/services/annotation_json_presentation_test.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import mock
+import pytest
+
+from h.services.annotation_json_presentation import AnnotationJSONPresentationService
+from h.services.annotation_json_presentation import annotation_json_presentation_service_factory
+
+
+class TestAnnotationJSONPresentationService(object):
+    def test_present_inits_presenter(self, svc, presenters):
+        resource = mock.Mock()
+
+        svc.present(resource)
+
+        presenters.AnnotationJSONPresenter.assert_called_once_with(resource)
+
+    def test_present_returns_presenter_dict(self, svc, presenters):
+        presenter = presenters.AnnotationJSONPresenter.return_value
+
+        result = svc.present(mock.Mock())
+
+        assert result == presenter.asdict.return_value
+
+    @pytest.fixture
+    def svc(self):
+        return AnnotationJSONPresentationService()
+
+    @pytest.fixture
+    def presenters(self, patch):
+        return patch('h.services.annotation_json_presentation.presenters')
+
+
+class TestAnnotationJSONPresentationServiceFactory(object):
+    def test_returns_service(self, pyramid_request):
+        svc = annotation_json_presentation_service_factory(None, pyramid_request)
+
+        assert isinstance(svc, AnnotationJSONPresentationService)

--- a/tests/h/services/annotation_json_presentation_test.py
+++ b/tests/h/services/annotation_json_presentation_test.py
@@ -9,16 +9,17 @@ from memex.interfaces import IGroupService
 
 from h.services.annotation_json_presentation import AnnotationJSONPresentationService
 from h.services.annotation_json_presentation import annotation_json_presentation_service_factory
+from h.presenters import AnnotationJSONPresenter
 
 
 @pytest.mark.usefixtures('presenters')
 class TestAnnotationJSONPresentationService(object):
-    def test_present_inits_presenter(self, svc, presenters):
-        resource = mock.Mock()
+    def test_present_gets_presenter(self, svc, patch, annotation_resource):
+        get_presenter = patch('h.services.annotation_json_presentation.AnnotationJSONPresentationService.get_presenter')
 
-        svc.present(resource)
+        svc.present(annotation_resource)
 
-        presenters.AnnotationJSONPresenter.assert_called_once_with(resource)
+        get_presenter.assert_called_once_with(svc, annotation_resource)
 
     def test_present_returns_presenter_dict(self, svc, presenters):
         presenter = presenters.AnnotationJSONPresenter.return_value
@@ -48,17 +49,49 @@ class TestAnnotationJSONPresentationService(object):
         svc.present_all(['ann-1'])
         present.assert_called_once_with(svc, resource)
 
+    def test_present_all_preloads_formatters(self, svc, storage):
+        formatter = mock.Mock(spec_set=['preload'])
+        svc.formatters = [formatter]
+
+        svc.present_all(['ann-1', 'ann-2'])
+
+        formatter.preload.assert_called_once_with(['ann-1', 'ann-2'])
+
     def test_returns_presented_annotations(self, svc, storage, present):
         storage.fetch_ordered_annotations.return_value = [mock.Mock()]
 
         result = svc.present_all(['ann-1'])
         assert result == [present.return_value]
 
+    def test_get_presenter_inits_presenter(self, svc, presenters, annotation_resource):
+        svc.get_presenter(annotation_resource)
+
+        presenters.AnnotationJSONPresenter.assert_called_once_with(annotation_resource)
+
+    def test_get_presenter_returns_presenter(self, svc):
+        resource = mock.Mock()
+
+        result = svc.get_presenter(resource)
+        assert isinstance(result, AnnotationJSONPresenter)
+
+    def test_get_presenter_adds_formatters(self, svc, annotation_resource, presenters):
+        formatters = [mock.Mock(), mock.Mock()]
+        svc.formatters = formatters
+        presenter = presenters.AnnotationJSONPresenter.return_value
+
+        svc.get_presenter(annotation_resource)
+
+        assert presenter.add_formatter.mock_calls == [mock.call(f) for f in formatters]
+
     @pytest.fixture
     def svc(self, db_session):
         group_svc = mock.Mock()
         links_svc = mock.Mock()
         return AnnotationJSONPresentationService(db_session, group_svc, links_svc)
+
+    @pytest.fixture
+    def annotation_resource(self):
+        return mock.Mock(spec_set=['annotation'], annotation=mock.Mock())
 
     @pytest.fixture
     def presenters(self, patch):

--- a/tests/h/views/api_test.py
+++ b/tests/h/views/api_test.py
@@ -150,7 +150,7 @@ class TestIndex(object):
         assert links['search']['url'] == host + '/dummy/search'
 
 
-@pytest.mark.usefixtures('group_service', 'links_service', 'search_lib')
+@pytest.mark.usefixtures('presentation_service', 'search_lib')
 class TestSearch(object):
 
     def test_it_searches(self, pyramid_request, search_lib):
@@ -164,57 +164,39 @@ class TestSearch(object):
                                              stats=pyramid_request.stats)
         search.run.assert_called_once_with(pyramid_request.params)
 
-    def test_it_loads_annotations_from_database(self, pyramid_request, search_run, storage):
+    def test_it_presents_search_results(self, pyramid_request, search_run, presentation_service):
         search_run.return_value = SearchResult(2, ['row-1', 'row-2'], [], {})
 
         views.search(pyramid_request)
 
-        storage.fetch_ordered_annotations.assert_called_once_with(
-            pyramid_request.db, ['row-1', 'row-2'], query_processor=mock.ANY)
+        presentation_service.present_all.assert_called_once_with(['row-1', 'row-2'])
 
-    def test_it_renders_search_results(self, links_service, pyramid_request, search_run, factories, group_service):
-        ann1 = AnnotationResource(factories.Annotation(userid='luke'), group_service, links_service)
-        ann2 = AnnotationResource(factories.Annotation(userid='sarah'), group_service, links_service)
-
-        search_run.return_value = SearchResult(2, [ann1.annotation.id, ann2.annotation.id], [], {})
+    def test_it_returns_search_results(self, pyramid_request, search_run, presentation_service):
+        search_run.return_value = SearchResult(2, ['row-1', 'row-2'], [], {})
 
         expected = {
             'total': 2,
-            'rows': [
-                presenters.AnnotationJSONPresenter(ann1).asdict(),
-                presenters.AnnotationJSONPresenter(ann2).asdict(),
-            ]
+            'rows': presentation_service.present_all.return_value
         }
 
         assert views.search(pyramid_request) == expected
 
-    def test_it_loads_replies_from_database(self, pyramid_request, search_run, storage):
+    def test_it_presents_replies(self, pyramid_request, search_run, presentation_service):
         pyramid_request.params = {'_separate_replies': '1'}
         search_run.return_value = SearchResult(1, ['row-1'], ['reply-1', 'reply-2'], {})
 
         views.search(pyramid_request)
 
-        assert mock.call(pyramid_request.db, ['reply-1', 'reply-2'],
-                         query_processor=mock.ANY) in storage.fetch_ordered_annotations.call_args_list
+        presentation_service.present_all.assert_called_with(['reply-1', 'reply-2'])
 
-    def test_it_renders_replies(self, links_service, pyramid_request, search_run, factories, group_service):
-        ann = AnnotationResource(factories.Annotation(userid='luke'), group_service, links_service)
-        reply1 = AnnotationResource(factories.Annotation(userid='sarah', references=[ann.annotation.id]), group_service, links_service)
-        reply2 = AnnotationResource(factories.Annotation(userid='sarah', references=[ann.annotation.id]), group_service, links_service)
-
-        search_run.return_value = SearchResult(1,
-                                               [ann.annotation.id],
-                                               [reply1.annotation.id, reply2.annotation.id], {})
-
+    def test_it_returns_replies(self, pyramid_request, search_run, presentation_service):
         pyramid_request.params = {'_separate_replies': '1'}
+        search_run.return_value = SearchResult(1, ['row-1'], ['reply-1', 'reply-2'], {})
 
         expected = {
             'total': 1,
-            'rows': [presenters.AnnotationJSONPresenter(ann).asdict()],
-            'replies': [
-                presenters.AnnotationJSONPresenter(reply1).asdict(),
-                presenters.AnnotationJSONPresenter(reply2).asdict(),
-            ]
+            'rows': presentation_service.present_all(['row-1']),
+            'replies': presentation_service.present_all(['reply-1', 'reply-2'])
         }
 
         assert views.search(pyramid_request) == expected
@@ -575,7 +557,7 @@ def links_service(pyramid_config):
 
 @pytest.fixture
 def presentation_service(pyramid_config):
-    svc = mock.Mock(spec_set=['present'])
+    svc = mock.Mock(spec_set=['present', 'present_all'])
     pyramid_config.register_service(svc, name='annotation_json_presentation')
     return svc
 

--- a/tests/h/views/api_test.py
+++ b/tests/h/views/api_test.py
@@ -339,21 +339,19 @@ class TestCreate(object):
         return pyramid_request
 
 
-@pytest.mark.usefixtures('AnnotationJSONPresenter', 'links_service')
+@pytest.mark.usefixtures('presentation_service')
 class TestRead(object):
 
     def test_it_returns_presented_annotation(self,
-                                             AnnotationJSONPresenter,
+                                             presentation_service,
                                              pyramid_request):
         context = mock.Mock()
-        presenter = mock.Mock()
-        AnnotationJSONPresenter.return_value = presenter
 
         result = views.read(context, pyramid_request)
 
-        AnnotationJSONPresenter.assert_called_once_with(context)
+        presentation_service.present.assert_called_once_with(context)
 
-        assert result == presenter.asdict()
+        assert result == presentation_service.present.return_value
 
 
 @pytest.mark.usefixtures('AnnotationJSONLDPresenter', 'links_service')
@@ -573,6 +571,13 @@ def links_service(pyramid_config):
     service = mock.Mock(spec_set=['get', 'get_all'])
     pyramid_config.register_service(service, name='links')
     return service
+
+
+@pytest.fixture
+def presentation_service(pyramid_config):
+    svc = mock.Mock(spec_set=['present'])
+    pyramid_config.register_service(svc, name='annotation_json_presentation')
+    return svc
 
 
 @pytest.fixture


### PR DESCRIPTION
This introduces a new layer that is annotation formatters. They can be hooked into the rendering pipeline to allow a bit more code separation. For example, it doesn't make much sense to make the annotation rendering code know about all the details of flagging and nipsa.