### PR TITLE
Make the test for flag URL filters ignore order

### DIFF
--- a/tests/h/services/flag_test.py
+++ b/tests/h/services/flag_test.py
@@ -70,9 +70,9 @@ class TestFlagServiceList(object):
         assert result == expected
 
     def test_it_supports_multiple_uri_filters(self, svc, users, flags):
-        expected = [flags['alice-climate'], flags['alice-politics']]
+        expected = set([flags['alice-climate'], flags['alice-politics']])
         result = svc.list(users['alice'], uris=['https://science.org', 'https://news.com']).all()
-        assert result == expected
+        assert set(result) == expected
 
     @pytest.fixture
     def users(self, factories):


### PR DESCRIPTION
Because the service does not guarantee to return the flags in any specific order, this seems to cause occasional test failures when Postgres returns the flags in the "reverse" order.

There is a custom `unordered_list` matcher defined, which I believe would work equally well, but in this case I converted the lists to `set`s, for consistency with another test in the same class.