### PR TITLE
Dynamically resolve upstream hostnames in nginx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN apk-install \
     ca-certificates \
     collectd \
     collectd-nginx \
+    gettext \
     libffi \
     libpq \
     nginx \

--- a/bin/start-nginx
+++ b/bin/start-nginx
@@ -7,11 +7,33 @@ set -eu
 CONF_TEMPLATE=/etc/nginx/nginx.conf.tpl
 CONF_DEST=/etc/nginx/nginx.conf
 
+# By default, the "fallback" URLs will return a placeholder message. If an
+# explicit upstream is given, we reverse proxy to it.
+FALLBACK_DIRECTIVES=$({
+    echo 'add_header Content-Type "text/plain; charset=UTF-8";'
+    echo 'return 200 "This URL path would fall through to WordPress in production.";'
+})
 if [ -n "$FALLBACK_UPSTREAM" ]; then
-    FALLBACK_TEXT="proxy_set_header Host \$host; proxy_pass $FALLBACK_UPSTREAM;"
-    sed -e '/# FALLBACK-START/,/# FALLBACK-END/c\'"$FALLBACK_TEXT" "$CONF_TEMPLATE"
-else
-    cat "$CONF_TEMPLATE"
-fi >"$CONF_DEST"
+    # We store the upstream endpoint in a variable to trigger dynamic resolution
+    # of the upstream hostname.
+    FALLBACK_DIRECTIVES=$({
+        echo 'proxy_set_header Host $host;'
+        echo 'set $fallback_upstream "'"${FALLBACK_UPSTREAM}"'";'
+        echo 'proxy_pass $fallback_upstream;'
+    })
+fi
+
+# Add "resolver" directives to the nginx config so that dynamic resolution can
+# occur.
+RESOLVER_DIRECTIVES=$({
+    printf "resolver "
+    printf "$(awk '$1=="nameserver" {print $2}' /etc/resolv.conf | xargs)"
+    printf ";\n"
+})
+
+# Write out nginx configuration file
+export FALLBACK_DIRECTIVES
+export RESOLVER_DIRECTIVES
+envsubst '$FALLBACK_DIRECTIVES $RESOLVER_DIRECTIVES' <"$CONF_TEMPLATE" >"$CONF_DEST"
 
 exec nginx

--- a/conf/nginx.conf.tpl
+++ b/conf/nginx.conf.tpl
@@ -17,6 +17,9 @@ http {
 
   access_log off;
 
+  # Dynamic DNS resolution of upstream hostnames requires a resolver to be set.
+  ${RESOLVER_DIRECTIVES}
+
   # We set fail_timeout=0 so that the upstream isn't marked as down if a single
   # request fails (e.g. if gunicorn kills a worker for taking too long to handle
   # a single request).
@@ -78,10 +81,7 @@ http {
     }
 
     location / {
-      # FALLBACK-START
-      add_header Content-Type "text/plain; charset=UTF-8";
-      return 200 "This URL path would fall through to WordPress in production.";
-      # FALLBACK-END
+      ${FALLBACK_DIRECTIVES}
     }
   }
 


### PR DESCRIPTION
Unfortunately, nginx does not respect DNS TTLs for the hostnames of upstream servers by default. This means that if the DNS record for FALLBACK_UPSTREAM is updated, the nginx instance will continue to send requests to old hosts. This is a very real possibility if FALLBACK_UPSTREAM points to an Elastic Load Balancer, where hosts may be dynamically swapped out to ensure continued availability of the load balancer.

This can be fixed by moving the upstream hostname into a variable, per the documentation for proxy_pass[1]:

>   A server name, its port and the passed URI can also be specified using variables:
>
>       proxy_pass http://$host$uri;
>
>   or even like this:
>
>       proxy_pass $request;
>
>   In this case, the server name is searched among the described server
>   groups, and, if not found, is determined using a resolver.

This also means that we have to specify a valid "resolver" directive in the nginx configuration. This is done by parsing /etc/resolv.conf within the container and injecting the appropriate directive.

In order to make it easier to understand what's going on when templating the nginx configuration, this commit also switches to using the envsubst program[2] from gettext rather than arcane sed invocations.

[1]: https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_pass
[2]: https://www.gnu.org/software/gettext/manual/html_node/envsubst-Invocation.html