### PR TITLE
Add a caching helper for services to use

### DIFF
--- a/h/services/groupfinder.py
+++ b/h/services/groupfinder.py
@@ -7,7 +7,7 @@ from zope.interface import implementer
 from memex.interfaces import IGroupService
 
 from h import models
-from h import util
+from h.util.db import lru_cache_in_transaction
 from h.groups.util import WorldGroup
 
 
@@ -19,24 +19,18 @@ class GroupfinderService(object):
         self.session = session
         self.auth_domain = auth_domain
 
-        # Local cache of fetched groups.
-        self._cache = {}
-
-        # But don't allow the cache to persist after the session is closed.
-        @util.db.on_transaction_end(session)
-        def flush_cache():
-            self._cache = {}
+        self._cached_find = lru_cache_in_transaction(self.session)(self._find)
 
     def find(self, id_):
+        return self._cached_find(id_)
+
+    def _find(self, id_):
         if id_ == '__world__':
             return WorldGroup(self.auth_domain)
 
-        if id_ not in self._cache:
-            self._cache[id_] = (self.session.query(models.Group)
-                                .filter_by(pubid=id_)
-                                .one_or_none())
-
-        return self._cache[id_]
+        return (self.session.query(models.Group)
+                    .filter_by(pubid=id_)
+                    .one_or_none())
 
 
 def groupfinder_service_factory(context, request):

--- a/h/util/db.py
+++ b/h/util/db.py
@@ -2,7 +2,51 @@
 
 from __future__ import unicode_literals
 
+try:
+    from functools import lru_cache
+except ImportError:
+    from backports.functools_lru_cache import lru_cache
+
 import sqlalchemy
+
+
+class lru_cache_in_transaction(object):
+    """
+    Decorator to wrap a function with a memoizing callable that saves up to
+    the `maxsize` most recent calls. The underlying cache is automatically
+    cleared at the end of the database transaction.
+
+    Since a dictionary is used to cache results, the positional and keyword
+    arguments to the function must be hashable.
+
+    For documentation of the `maxsize` and `typed` arguments, see the
+    documentation of :py:func:`functools.lru_cache`.
+
+    Example::
+
+        @lru_cache_in_transaction(session)
+        def fetch_user(userid):
+            return session.query(models.User).filter_by(userid=userid).one_or_none()
+
+        fetch_user('acct:foo@example.com')  # => executes a query
+        fetch_user('acct:foo@example.com')  # => returns cached value
+        fetch_user('acct:bar@example.com')  # => executes a query
+
+        session.commit()
+
+        fetch_user('acct:foo@example.com')  # => executes a query
+    """
+
+    def __init__(self, session, maxsize=128, typed=False):
+        self._session = session
+        self._maxsize = maxsize
+        self._typed = typed
+
+    def __call__(self, func):
+        decorator = lru_cache(maxsize=self._maxsize, typed=self._typed)
+        wrapped = decorator(func)
+        on_transaction_end(self._session)(wrapped.cache_clear)
+        return wrapped
 
 
 def on_transaction_end(session):

--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,7 @@
 PyJWT
 SQLAlchemy >= 1.1.4
 alembic
+backports.functools_lru_cache
 bcrypt
 celery == 3.1.25  # Pin to latest 3.1.x to ensure forwards-compat with 4.x
 certifi

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@
 alembic==0.8.7
 amqp==1.4.9               # via kombu
 anyjson==0.3.3            # via kombu
+backports.functools-lru-cache==1.2.1
 bcrypt==3.1.0
 billiard==3.3.0.23        # via celery
 bleach==1.4.3

--- a/tests/h/services/groupfinder_test.py
+++ b/tests/h/services/groupfinder_test.py
@@ -30,49 +30,6 @@ class TestGroupfinderService(object):
 
         assert svc.find('bogus') is None
 
-    def test_caches_groups(self, svc, factories, db_session):
-        group = factories.Group()
-        pubid = group.pubid
-
-        svc.find(group.pubid)
-        db_session.delete(group)
-        db_session.flush()
-        group = svc.find(pubid)
-
-        assert group is not None
-        assert group.pubid == pubid
-
-    def test_sets_up_cache_clearing_on_transaction_end(self, patch, db_session):
-        decorator = patch('h.services.groupfinder.util.db.on_transaction_end')
-
-        GroupfinderService(db_session, 'example.com')
-
-        decorator.assert_called_once_with(db_session)
-
-    def test_clears_cache_on_transaction_end(self, patch, db_session, factories):
-        funcs = {}
-
-        # We need to capture the inline `clear_cache` function so we can
-        # call it manually later
-        def on_transaction_end_decorator(session):
-            def on_transaction_end(func):
-                funcs['clear_cache'] = func
-            return on_transaction_end
-
-        decorator = patch('h.services.user.util.db.on_transaction_end')
-        decorator.side_effect = on_transaction_end_decorator
-
-        group = factories.Group()
-        pubid = group.pubid
-        svc = GroupfinderService(db_session, 'example.com')
-        svc.find(pubid)
-        db_session.delete(group)
-
-        funcs['clear_cache']()
-
-        group = svc.find(pubid)
-        assert group is None
-
     @pytest.fixture
     def svc(self, db_session):
         return GroupfinderService(db_session, 'example.com')


### PR DESCRIPTION
While doing some refactoring unrelated to the content of this commit (converting the feature flag client into a service) I found myself implementing caching functionality and tests for it in Yet Another Service.

Rather than have each service that needs to cache stuff for the duration of the database transaction implement and test its own caching behaviour, it makes sense to introduce a general purpose tool to achieve the same ends.

This commit introduces a decorator, `lru_cache_in_transaction`, which is a thin wrapper around the `lru_cache` decorator from Python >= 3.3, with the added bonus that it clears its internal cache when the database transaction
ends. It converts both the GroupfinderService and the UserService to use this new helper.

Given the way that the caching helper works, I think it will be sufficiently hard to use incorrectly without breaking the core functionality of the service in question that I have removed the tests that check caching for each individual service.