### PR TITLE
Rename request.authenticated_user to request.user

### DIFF
--- a/h/accounts/__init__.py
+++ b/h/accounts/__init__.py
@@ -23,8 +23,8 @@ class JSONError(Error):
     pass
 
 
-def authenticated_user(request):
-    """Return the authenticated user or None.
+def get_user(request):
+    """Return the user for the request or None.
 
     :rtype: h.models.User or None
 
@@ -41,7 +41,7 @@ def authenticated_user(request):
 def includeme(config):
     """A local identity provider."""
 
-    # Add a `request.authenticated_user` property.
+    # Add a `request.user` property.
     #
     # N.B. we use `property=True` and not `reify=True` here because it is
     # important that responsibility for caching user lookups is left to the
@@ -50,7 +50,7 @@ def includeme(config):
     # This prevents retried requests (those that raise
     # `transaction.interfaces.TransientError`) gaining access to a stale
     # `User` instance.
-    config.add_request_method(authenticated_user, property=True)
+    config.add_request_method(get_user, name='user', property=True)
 
     config.include('.schemas')
     config.include('.subscribers')

--- a/h/accounts/schemas.py
+++ b/h/accounts/schemas.py
@@ -277,7 +277,7 @@ class EmailChangeSchema(CSRFSchema):
         super(EmailChangeSchema, self).validator(node, value)
         exc = colander.Invalid(node)
         request = node.bindings['request']
-        user = request.authenticated_user
+        user = request.user
 
         if not user.check_password(value.get('password')):
             exc['password'] = _('Wrong password.')
@@ -303,7 +303,7 @@ class PasswordChangeSchema(CSRFSchema):
         super(PasswordChangeSchema, self).validator(node, value)
         exc = colander.Invalid(node)
         request = node.bindings['request']
-        user = request.authenticated_user
+        user = request.user
 
         if value.get('new_password') != value.get('new_password_confirm'):
             exc['new_password_confirm'] = _('The passwords must match')

--- a/h/formatters/annotation_flag.py
+++ b/h/formatters/annotation_flag.py
@@ -17,21 +17,21 @@ class AnnotationFlagFormatter(object):
     add: `"flagged": true` to the payload, otherwise `"flagged": false`.
     """
 
-    def __init__(self, session, authenticated_user=None):
+    def __init__(self, session, user=None):
         self.session = session
-        self.authenticated_user = authenticated_user
+        self.user = user
 
         # Local cache of flags. We don't need to care about detached
         # instances because we only store the annotation id and a boolean flag.
         self._cache = {}
 
     def preload(self, ids):
-        if self.authenticated_user is None:
+        if self.user is None:
             return
 
         query = self.session.query(models.Flag) \
                             .filter(models.Flag.annotation_id.in_(ids),
-                                    models.Flag.user == self.authenticated_user)
+                                    models.Flag.user == self.user)
 
         flags = {f.annotation_id: True for f in query}
 
@@ -49,7 +49,7 @@ class AnnotationFlagFormatter(object):
         return {'flagged': flagged}
 
     def _load(self, id_):
-        if self.authenticated_user is None:
+        if self.user is None:
             return False
 
         if id_ in self._cache:
@@ -57,7 +57,7 @@ class AnnotationFlagFormatter(object):
 
         flag = self.session.query(models.Flag) \
                            .filter_by(annotation_id=id_,
-                                      user=self.authenticated_user) \
+                                      user=self.user) \
                            .one_or_none()
 
         self._cache[id_] = (flag is not None)

--- a/h/groups/search.py
+++ b/h/groups/search.py
@@ -9,10 +9,10 @@ class GroupAuthFilter(object):
     """
 
     def __init__(self, request):
-        self.authenticated_user = request.authenticated_user
+        self.user = request.user
         self.session = request.db
         self.group_service = request.find_service(name='group')
 
     def __call__(self, _):
-        groups = self.group_service.groupids_readable_by(self.authenticated_user)
+        groups = self.group_service.groupids_readable_by(self.user)
         return {'terms': {'group': groups}}

--- a/h/panels/back_link.py
+++ b/h/panels/back_link.py
@@ -18,7 +18,7 @@ def back_link(context, request):
     """
 
     referrer_path = urlparse.urlparse(request.referrer or '').path
-    current_username = request.authenticated_user.username
+    current_username = request.user.username
 
     if referrer_path == request.route_path('activity.user_search',
                                            username=current_username):

--- a/h/panels/navbar.py
+++ b/h/panels/navbar.py
@@ -23,8 +23,8 @@ def navbar(context, request, search=None, opts=None):
     user_activity_url = None
     username = None
 
-    if request.authenticated_user:
-        for group in request.authenticated_user.groups:
+    if request.user:
+        for group in request.user.groups:
             groups_menu_items.append({
                 'title': group.name,
                 'link': request.route_url('group_read', pubid=group.pubid, slug=group.slug)
@@ -34,8 +34,8 @@ def navbar(context, request, search=None, opts=None):
                 'pubid': group.pubid
             })
         user_activity_url = request.route_url('activity.user_search',
-                                              username=request.authenticated_user.username)
-        username = request.authenticated_user.username
+                                              username=request.user.username)
+        username = request.user.username
 
     route = request.matched_route
 

--- a/h/services/annotation_json_presentation.py
+++ b/h/services/annotation_json_presentation.py
@@ -14,13 +14,13 @@ from h import storage
 
 
 class AnnotationJSONPresentationService(object):
-    def __init__(self, session, authenticated_user, group_svc, links_svc):
+    def __init__(self, session, user, group_svc, links_svc):
         self.session = session
         self.group_svc = group_svc
         self.links_svc = links_svc
 
         self.formatters = [
-            formatters.AnnotationFlagFormatter(self.session, authenticated_user)
+            formatters.AnnotationFlagFormatter(self.session, user)
         ]
 
     def present(self, annotation_resource):
@@ -56,6 +56,6 @@ def annotation_json_presentation_service_factory(context, request):
     group_svc = request.find_service(IGroupService)
     links_svc = request.find_service(name='links')
     return AnnotationJSONPresentationService(session=request.db,
-                                             authenticated_user=request.authenticated_user,
+                                             user=request.user,
                                              group_svc=group_svc,
                                              links_svc=links_svc)

--- a/h/services/feature.py
+++ b/h/services/feature.py
@@ -28,11 +28,11 @@ class FeatureRequestProperty(object):
 
     def __call__(self, name):
         """Get the status of feature flag `name` for the current user."""
-        return self.svc.enabled(name, user=self.request.authenticated_user)
+        return self.svc.enabled(name, user=self.request.user)
 
     def all(self):
         """Get the status of all feature flags for the current user."""
-        return self.svc.all(user=self.request.authenticated_user)
+        return self.svc.all(user=self.request.user)
 
 
 class FeatureService(object):

--- a/h/session.py
+++ b/h/session.py
@@ -11,7 +11,7 @@ def model(request):
     session['userid'] = request.authenticated_userid
     session['groups'] = _current_groups(request, request.auth_domain)
     session['features'] = request.feature.all()
-    session['preferences'] = _user_preferences(request.authenticated_user)
+    session['preferences'] = _user_preferences(request.user)
     return session
 
 
@@ -25,7 +25,7 @@ def profile(request, authority=None):
     request). This parameter is ignored for authenticated requests.
 
     """
-    user = request.authenticated_user
+    user = request.user
 
     if user is not None:
         authority = user.authority
@@ -62,7 +62,7 @@ def _current_groups(request, authority):
 
     """
 
-    user = request.authenticated_user
+    user = request.user
     authority_groups = (request.find_service(name='authority_group')
                         .public_groups(authority=authority))
 

--- a/h/views/accounts.py
+++ b/h/views/accounts.py
@@ -40,7 +40,7 @@ def ajax_payload(request, data):
 
 def _login_redirect_url(request):
     return request.route_url('activity.user_search',
-                             username=request.authenticated_user.username)
+                             username=request.user.username)
 
 
 @view_config(context=BadCSRFToken,
@@ -449,7 +449,7 @@ class ActivateController(object):
         except ValueError:
             raise httpexceptions.HTTPNotFound()
 
-        if id_ == self.request.authenticated_user.id:
+        if id_ == self.request.user.id:
             # The user is already logged in to the account (so the account
             # must already be activated).
             self.request.session.flash(jinja2.Markup(_(
@@ -521,14 +521,14 @@ class AccountController(object):
             on_failure=self._template_data)
 
     def update_email_address(self, appstruct):
-        self.request.authenticated_user.email = appstruct['email']
+        self.request.user.email = appstruct['email']
 
     def update_password(self, appstruct):
-        self.request.authenticated_user.password = appstruct['new_password']
+        self.request.user.password = appstruct['new_password']
 
     def _template_data(self):
         """Return the data needed to render accounts.html.jinja2."""
-        email = self.request.authenticated_user.email
+        email = self.request.user.email
         password_form = self.forms['password'].render()
         email_form = self.forms['email'].render({'email': email})
 
@@ -552,7 +552,7 @@ class EditProfileController(object):
     @view_config(request_method='GET')
     def get(self):
         """Render the 'Edit Profile' form"""
-        user = self.request.authenticated_user
+        user = self.request.user
         self.form.set_appstruct({
             'display_name': user.display_name or '',
             'description': user.description or '',
@@ -574,7 +574,7 @@ class EditProfileController(object):
         return {'form': self.form.render()}
 
     def _update_user(self, appstruct):
-        user = self.request.authenticated_user
+        user = self.request.user
         user.display_name = appstruct['display_name']
         user.description = appstruct['description']
         user.location = appstruct['location']
@@ -685,5 +685,5 @@ def dismiss_sidebar_tutorial(request):
     if request.authenticated_userid is None:
         raise accounts.JSONError()
     else:
-        request.authenticated_user.sidebar_tutorial_dismissed = True
+        request.user.sidebar_tutorial_dismissed = True
         return ajax_payload(request, {'status': 'okay'})

--- a/h/views/activity.py
+++ b/h/views/activity.py
@@ -51,8 +51,8 @@ class SearchController(object):
 
         groups_suggestions = []
 
-        if self.request.authenticated_user:
-            for group in self.request.authenticated_user.groups:
+        if self.request.user:
+            for group in self.request.user.groups:
                 groups_suggestions.append({
                     'name': group.name,
                     'pubid': group.pubid
@@ -108,7 +108,7 @@ class GroupSearchController(SearchController):
 
         result['opts'] = {'search_groupname': self.group.name}
 
-        if self.request.authenticated_user not in self.group.members:
+        if self.request.user not in self.group.members:
             return result
 
         def user_annotation_count(aggregation, userid):
@@ -307,12 +307,12 @@ class UserSearchController(SearchController):
             'orcid': self.user.orcid,
         }
 
-        if self.request.authenticated_user == self.user:
+        if self.request.user == self.user:
             result['user']['edit_url'] = self.request.route_url(
                 'account_profile')
 
         if not result.get('q'):
-            if self.request.authenticated_user == self.user:
+            if self.request.user == self.user:
                 # Tell the template that it should show "How to get started".
                 result['zero_message'] = '__SHOW_GETTING_STARTED__'
             else:

--- a/h/views/api_flags.py
+++ b/h/views/api_flags.py
@@ -16,5 +16,5 @@ from h.views.api import api_config
             permission='read')
 def create(context, request):
     svc = request.find_service(name='flag')
-    svc.create(request.authenticated_user, context.annotation)
+    svc.create(request.user, context.annotation)
     return HTTPNoContent()

--- a/h/views/api_profile.py
+++ b/h/views/api_profile.py
@@ -28,7 +28,7 @@ def update_preferences(request):
 
     svc = request.find_service(name='user')
     try:
-        svc.update_preferences(request.authenticated_user, **preferences)
+        svc.update_preferences(request.user, **preferences)
     except TypeError as e:
         raise APIError(e.message, status_code=400)
 

--- a/h/views/home.py
+++ b/h/views/home.py
@@ -25,8 +25,8 @@ def via_redirect(context, request):
 def index(context, request):
     context = {}
 
-    if request.authenticated_user:
-        username = request.authenticated_user.username
+    if request.user:
+        username = request.user.username
         context['username'] = username
         context['user_account_link'] = (
             request.route_url('stream.user_query', user=username)

--- a/tests/h/accounts/__init___test.py
+++ b/tests/h/accounts/__init___test.py
@@ -6,7 +6,7 @@ from h import accounts
 
 
 @pytest.mark.usefixtures('user_service')
-class TestAuthenticatedUser(object):
+class TestGetUser(object):
     def test_fetches_user_using_service(self,
                                         factories,
                                         pyramid_config,
@@ -15,7 +15,7 @@ class TestAuthenticatedUser(object):
         pyramid_config.testing_securitypolicy('userid')
         user_service.fetch.return_value = factories.User.build()
 
-        accounts.authenticated_user(pyramid_request)
+        accounts.get_user(pyramid_request)
 
         user_service.fetch.assert_called_once_with('userid')
 
@@ -32,7 +32,7 @@ class TestAuthenticatedUser(object):
         """
         pyramid_request.session.invalidate = mock.Mock()
 
-        accounts.authenticated_user(pyramid_request)
+        accounts.get_user(pyramid_request)
 
         assert not pyramid_request.session.invalidate.called
 
@@ -44,7 +44,7 @@ class TestAuthenticatedUser(object):
         pyramid_config.testing_securitypolicy('userid')
         user = user_service.fetch.return_value = factories.User.build()
 
-        result = accounts.authenticated_user(pyramid_request)
+        result = accounts.get_user(pyramid_request)
 
         assert result == user
 

--- a/tests/h/accounts/schemas_test.py
+++ b/tests/h/accounts/schemas_test.py
@@ -454,7 +454,7 @@ class TestEmailChangeSchema(object):
 
     @pytest.fixture
     def pyramid_request(self, pyramid_csrf_request, user):
-        pyramid_csrf_request.authenticated_user = user
+        pyramid_csrf_request.user = user
         return pyramid_csrf_request
 
     @pytest.fixture
@@ -480,7 +480,7 @@ class TestPasswordChangeSchema(object):
 
     def test_it_is_invalid_if_passwords_dont_match(self, pyramid_csrf_request):
         user = Mock()
-        pyramid_csrf_request.authenticated_user = user
+        pyramid_csrf_request.user = user
         schema = schemas.PasswordChangeSchema().bind(
             request=pyramid_csrf_request)
 
@@ -494,7 +494,7 @@ class TestPasswordChangeSchema(object):
     def test_it_is_invalid_if_current_password_is_wrong(self,
                                                         pyramid_csrf_request):
         user = Mock()
-        pyramid_csrf_request.authenticated_user = user
+        pyramid_csrf_request.user = user
         schema = schemas.PasswordChangeSchema().bind(
             request=pyramid_csrf_request)
         # The password does not check out

--- a/tests/h/formatters/annotation_flag_test.py
+++ b/tests/h/formatters/annotation_flag_test.py
@@ -32,7 +32,7 @@ class TestAnnotationFlagFormatter(object):
     def test_format_for_unauthenticated_user(self, db_session, factories):
         annotation = factories.Annotation()
         formatter = AnnotationFlagFormatter(db_session,
-                                            authenticated_user=None)
+                                            user=None)
 
         assert formatter.format(annotation) == {'flagged': False}
 

--- a/tests/h/groups/search_test.py
+++ b/tests/h/groups/search_test.py
@@ -11,7 +11,7 @@ from h.groups import search
 @pytest.mark.usefixtures('group_service')
 class TestGroupAuthFilter(object):
     def test_fetches_readable_groups(self, pyramid_request, group_service):
-        pyramid_request.authenticated_user = mock.sentinel.user
+        pyramid_request.user = mock.sentinel.user
 
         filter_ = search.GroupAuthFilter(pyramid_request)
         filter_({})
@@ -34,5 +34,5 @@ class TestGroupAuthFilter(object):
 
     @pytest.fixture
     def pyramid_request(self, pyramid_request):
-        pyramid_request.authenticated_user = None
+        pyramid_request.user = None
         return pyramid_request

--- a/tests/h/panels/back_link_test.py
+++ b/tests/h/panels/back_link_test.py
@@ -35,7 +35,7 @@ class TestBackLink(object):
 
     @pytest.fixture
     def pyramid_request(self, pyramid_request):
-        pyramid_request.authenticated_user = Mock(username='currentuser')
+        pyramid_request.user = Mock(username='currentuser')
         return pyramid_request
 
     @pytest.fixture

--- a/tests/h/panels/navbar_test.py
+++ b/tests/h/panels/navbar_test.py
@@ -14,30 +14,30 @@ class TestNavbar(object):
         result = navbar({}, req)
         assert result['username'] is None
 
-    def test_it_sets_username_when_logged_in(self, req, authenticated_user):
-        req.authenticated_user = authenticated_user
+    def test_it_sets_username_when_logged_in(self, req, user):
+        req.user = user
         result = navbar({}, req)
 
         assert result['username'] == 'vannevar'
 
-    def test_it_lists_groups_when_logged_in(self, req, authenticated_user):
-        req.authenticated_user = authenticated_user
+    def test_it_lists_groups_when_logged_in(self, req, user):
+        req.user = user
         result = navbar({}, req)
 
         assert result['groups_menu_items'] == [
             {'title': g.name, 'link': 'http://example.com/groups/' + g.pubid + '/' + g.slug}
-            for g in authenticated_user.groups
+            for g in user.groups
         ]
 
-    def test_includes_groups_suggestions_when_logged_in(self, req, authenticated_user):
-        req.authenticated_user = authenticated_user
+    def test_includes_groups_suggestions_when_logged_in(self, req, user):
+        req.user = user
         result = navbar({}, req)
 
         assert result['groups_suggestions'] == [{'name': g.name, 'pubid': g.pubid}
-                                                for g in authenticated_user.groups]
+                                                for g in user.groups]
 
-    def test_username_url_when_logged_in(self, req, authenticated_user):
-        req.authenticated_user = authenticated_user
+    def test_username_url_when_logged_in(self, req, user):
+        req.user = user
         result = navbar({}, req)
 
         assert result['username_url'] == 'http://example.com/users/vannevar'
@@ -84,12 +84,12 @@ class TestNavbar(object):
         pyramid_config.add_route('logout', '/logout')
 
     @pytest.fixture
-    def authenticated_user(self, factories):
-        authenticated_user = factories.User(username='vannevar')
-        authenticated_user.groups = [factories.Group(), factories.Group()]
-        return authenticated_user
+    def user(self, factories):
+        user = factories.User(username='vannevar')
+        user.groups = [factories.Group(), factories.Group()]
+        return user
 
     @pytest.fixture
     def req(self, pyramid_request):
-        pyramid_request.authenticated_user = None
+        pyramid_request.user = None
         return pyramid_request

--- a/tests/h/services/annotation_json_presentation_test.py
+++ b/tests/h/services/annotation_json_presentation_test.py
@@ -15,16 +15,16 @@ from h.services.annotation_json_presentation import annotation_json_presentation
 class TestAnnotationJSONPresentationService(object):
     def test_initializes_flag_formatter(self, formatters):
         AnnotationJSONPresentationService(session=mock.sentinel.session,
-                                          authenticated_user=mock.sentinel.authenticated_user,
+                                          user=mock.sentinel.user,
                                           group_svc=mock.sentinel.group_svc,
                                           links_svc=mock.sentinel.links_svc)
 
         formatters.AnnotationFlagFormatter.assert_called_once_with(mock.sentinel.session,
-                                                                   mock.sentinel.authenticated_user)
+                                                                   mock.sentinel.user)
 
     def test_it_configures_flag_formatter(self, formatters):
         svc = AnnotationJSONPresentationService(session=mock.sentinel.session,
-                                                authenticated_user=mock.sentinel.authenticated_user,
+                                                user=mock.sentinel.user,
                                                 group_svc=mock.sentinel.group_svc,
                                                 links_svc=mock.sentinel.links_svc)
 
@@ -91,7 +91,7 @@ class TestAnnotationJSONPresentationService(object):
         group_svc = mock.Mock()
         links_svc = mock.Mock()
         return AnnotationJSONPresentationService(session=db_session,
-                                                 authenticated_user=None,
+                                                 user=None,
                                                  group_svc=group_svc,
                                                  links_svc=links_svc)
 
@@ -133,11 +133,11 @@ class TestAnnotationJSONPresentationServiceFactory(object):
         _, kwargs = service_class.call_args
         assert kwargs['session'] == pyramid_request.db
 
-    def test_provides_authenticated_user(self, pyramid_request, service_class):
+    def test_provides_user(self, pyramid_request, service_class):
         annotation_json_presentation_service_factory(None, pyramid_request)
 
         _, kwargs = service_class.call_args
-        assert kwargs['authenticated_user'] == pyramid_request.authenticated_user
+        assert kwargs['user'] == pyramid_request.user
 
     def test_provides_group_service(self, pyramid_request, service_class, group_svc):
         annotation_json_presentation_service_factory(None, pyramid_request)
@@ -169,5 +169,5 @@ class TestAnnotationJSONPresentationServiceFactory(object):
 
     @pytest.fixture
     def pyramid_request(self, pyramid_request):
-        pyramid_request.authenticated_user = mock.Mock()
+        pyramid_request.user = mock.Mock()
         return pyramid_request

--- a/tests/h/services/feature_test.py
+++ b/tests/h/services/feature_test.py
@@ -46,7 +46,7 @@ class TestFeatureRequestProperty(object):
     def pyramid_request(self, pyramid_request):
         # Remove the preexisting dummy feature client
         delattr(pyramid_request, 'feature')
-        pyramid_request.authenticated_user = mock.sentinel.user
+        pyramid_request.user = mock.sentinel.user
         return pyramid_request
 
 
@@ -188,5 +188,5 @@ class TestFeatureServiceFactory(object):
 
     @pytest.fixture
     def pyramid_request(self, pyramid_request):
-        pyramid_request.authenticated_user = mock.sentinel.user
+        pyramid_request.user = mock.sentinel.user
         return pyramid_request

--- a/tests/h/session_test.py
+++ b/tests/h/session_test.py
@@ -237,9 +237,9 @@ class FakeRequest(object):
         self.authenticated_userid = userid
 
         if userid is None:
-            self.authenticated_user = None
+            self.user = None
         else:
-            self.authenticated_user = mock.Mock(groups=[], authority=user_authority)
+            self.user = mock.Mock(groups=[], authority=user_authority)
 
         self.feature = mock.Mock(spec_set=['all'])
         self.route_url = mock.Mock(return_value='/group/a')
@@ -248,13 +248,13 @@ class FakeRequest(object):
         self._authority_group_service = FakeAuthorityGroupService(public_groups)
 
     def set_groups(self, groups):
-        self.authenticated_user.groups = groups
+        self.user.groups = groups
 
     def set_features(self, feature_dict):
         self.feature.all.return_value = feature_dict
 
     def set_sidebar_tutorial_dismissed(self, dismissed):
-        self.authenticated_user.sidebar_tutorial_dismissed = dismissed
+        self.user.sidebar_tutorial_dismissed = dismissed
 
     def set_public_groups(self, public_groups):
         self._authority_group_service = FakeAuthorityGroupService(public_groups)

--- a/tests/h/views/activity_test.py
+++ b/tests/h/views/activity_test.py
@@ -104,7 +104,7 @@ class TestSearchController(object):
 
     @pytest.fixture
     def pyramid_request(self, factories, pyramid_request):
-        pyramid_request.authenticated_user = factories.User()
+        pyramid_request.user = factories.User()
         return pyramid_request
 
 
@@ -165,7 +165,7 @@ class TestGroupSearchController(object):
                                                   pyramid_request,
                                                   search):
         for user in (None, group.creator, group.members[-1]):
-            pyramid_request.authenticated_user = user
+            pyramid_request.user = user
 
             controller.search()
 
@@ -176,20 +176,20 @@ class TestGroupSearchController(object):
     def test_search_just_returns_search_result_if_group_does_not_exist(
             self, controller, group, pyramid_request, search):
         for user in (None, group.creator, group.members[-1]):
-            pyramid_request.authenticated_user = user
+            pyramid_request.user = user
             pyramid_request.matchdict['pubid'] = 'does_not_exist'
 
             assert controller.search() == search.return_value
 
     def test_search_just_returns_search_result_if_user_not_logged_in(
             self, controller, pyramid_request, search):
-        pyramid_request.authenticated_user = None
+        pyramid_request.user = None
 
         assert controller.search() == search.return_value
 
     def test_search_just_returns_search_result_if_user_not_a_member_of_group(
             self, controller, factories, pyramid_request, search):
-        pyramid_request.authenticated_user = factories.User()
+        pyramid_request.user = factories.User()
 
         assert controller.search() == search.return_value
 
@@ -197,7 +197,7 @@ class TestGroupSearchController(object):
                                                                  controller,
                                                                  group,
                                                                  pyramid_request):
-        pyramid_request.authenticated_user = group.members[-1]
+        pyramid_request.user = group.members[-1]
 
         group_info = controller.search()['group']
 
@@ -213,7 +213,7 @@ class TestGroupSearchController(object):
         def fake_has_permission(permission, context=None):
             return permission != 'admin'
         pyramid_request.has_permission = mock.Mock(side_effect=fake_has_permission)
-        pyramid_request.authenticated_user = group.members[-1]
+        pyramid_request.user = group.members[-1]
 
         result = controller.search()
 
@@ -224,7 +224,7 @@ class TestGroupSearchController(object):
                                                                     group,
                                                                     pyramid_request):
         pyramid_request.has_permission = mock.Mock(return_value=True)
-        pyramid_request.authenticated_user = group.creator
+        pyramid_request.user = group.creator
 
         result = controller.search()
 
@@ -235,7 +235,7 @@ class TestGroupSearchController(object):
             controller,
             group,
             pyramid_request):
-        pyramid_request.authenticated_user = group.members[-1]
+        pyramid_request.user = group.members[-1]
         pyramid_request.params['more_info'] = ''
 
         assert controller.search()['more_info'] is True
@@ -245,7 +245,7 @@ class TestGroupSearchController(object):
             controller,
             group,
             pyramid_request):
-        pyramid_request.authenticated_user = group.members[-1]
+        pyramid_request.user = group.members[-1]
 
         assert controller.search()['more_info'] is False
 
@@ -261,7 +261,7 @@ class TestGroupSearchController(object):
                                                     controller,
                                                     pyramid_request,
                                                     group):
-        pyramid_request.authenticated_user = group.members[-1]
+        pyramid_request.user = group.members[-1]
 
         result = controller.search()
 
@@ -273,7 +273,7 @@ class TestGroupSearchController(object):
                                                  controller,
                                                  pyramid_request,
                                                  group):
-        pyramid_request.authenticated_user = group.members[-1]
+        pyramid_request.user = group.members[-1]
 
         result = controller.search()
 
@@ -285,7 +285,7 @@ class TestGroupSearchController(object):
                                                      controller,
                                                      pyramid_request,
                                                      group):
-        pyramid_request.authenticated_user = group.members[-1]
+        pyramid_request.user = group.members[-1]
 
         faceted_user = group.members[0]
         pyramid_request.params = {'q': 'user:%s' % group.members[0].username}
@@ -305,7 +305,7 @@ class TestGroupSearchController(object):
         user_2 = factories.User()
         group.members = [user_1, user_2]
 
-        pyramid_request.authenticated_user = group.members[-1]
+        pyramid_request.user = group.members[-1]
 
         counts = {user_1.userid: 24, user_2.userid: 6}
         users_aggregation = [
@@ -326,7 +326,7 @@ class TestGroupSearchController(object):
     def test_search_returns_the_default_zero_message_to_the_template(
             self, controller, group, pyramid_request, search):
         """If there's a non-empty query it uses the default zero message."""
-        pyramid_request.authenticated_user = group.members[-1]
+        pyramid_request.user = group.members[-1]
         search.return_value['q'] = 'foo'
 
         result = controller.search()
@@ -336,7 +336,7 @@ class TestGroupSearchController(object):
     def test_search_returns_the_group_zero_message_to_the_template(
             self, controller, group, pyramid_request, search):
         """If the query is empty it overrides the default zero message."""
-        pyramid_request.authenticated_user = group.members[-1]
+        pyramid_request.user = group.members[-1]
         search.return_value['q'] = ''
 
         result = controller.search()
@@ -396,7 +396,7 @@ class TestGroupSearchController(object):
                                                                       controller,
                                                                       group,
                                                                       pyramid_request):
-        pyramid_request.authenticated_user = group.members[-1]
+        pyramid_request.user = group.members[-1]
         result = controller.search()['stats']
 
         assert result['annotation_count'] == 5
@@ -407,7 +407,7 @@ class TestGroupSearchController(object):
                                                                    pyramid_request):
         """ It should not pass the annotation count to the view when the feature flag is turned off."""
 
-        pyramid_request.authenticated_user = group.members[-1]
+        pyramid_request.user = group.members[-1]
         pyramid_request.feature.flags['total_shared_annotations'] = False
         result = controller.search()['stats']
 
@@ -550,7 +550,7 @@ class TestGroupSearchController(object):
     def pyramid_request(self, group, pyramid_request):
         pyramid_request.matchdict['pubid'] = group.pubid
         pyramid_request.matchdict['slug'] = group.slug
-        pyramid_request.authenticated_user = None
+        pyramid_request.user = None
         return pyramid_request
 
     @pytest.fixture
@@ -658,7 +658,7 @@ class TestUserSearchController(object):
                                                         user):
         # The user whose page we're on is the same user as the authenticated
         # user.
-        pyramid_request.authenticated_user = user
+        pyramid_request.user = user
 
         user_details = controller.search()['user']
 
@@ -670,7 +670,7 @@ class TestUserSearchController(object):
                                                                pyramid_request):
         # The user whose page we're on is *not* the same user as the
         # authenticated user.
-        pyramid_request.authenticated_user = factories.User()
+        pyramid_request.user = factories.User()
 
         assert 'edit_url' not in controller.search()['user']
 
@@ -686,7 +686,7 @@ class TestUserSearchController(object):
     def test_search_returns_the_user_zero_message_to_the_template(
             self, controller, factories, pyramid_request, search, user):
         """If the query is empty it overrides the default zero message."""
-        pyramid_request.authenticated_user = factories.User()
+        pyramid_request.user = factories.User()
         search.return_value['q'] = ''
 
         result = controller.search()
@@ -749,7 +749,7 @@ class TestUserSearchController(object):
     @pytest.fixture
     def pyramid_request(self, pyramid_request, user):
         pyramid_request.matchdict['username'] = user.username
-        pyramid_request.authenticated_user = user
+        pyramid_request.user = user
         return pyramid_request
 
     @pytest.fixture

--- a/tests/h/views/api_flags_test.py
+++ b/tests/h/views/api_flags_test.py
@@ -17,7 +17,7 @@ class TestCreate(object):
 
         views.create(context, pyramid_request)
 
-        flag_service.create.assert_called_once_with(pyramid_request.authenticated_user,
+        flag_service.create.assert_called_once_with(pyramid_request.user,
                                                     context.annotation)
 
     def test_it_returns_no_content(self, pyramid_request):
@@ -28,7 +28,7 @@ class TestCreate(object):
 
     @pytest.fixture
     def pyramid_request(self, pyramid_request):
-        pyramid_request.authenticated_user = mock.Mock()
+        pyramid_request.user = mock.Mock()
         pyramid_request.json_body = {}
         return pyramid_request
 

--- a/tests/h/views/api_profile_test.py
+++ b/tests/h/views/api_profile_test.py
@@ -56,7 +56,7 @@ class TestUpdatePreferences(object):
 
     @pytest.fixture
     def pyramid_request(self, pyramid_request, user):
-        pyramid_request.authenticated_user = user
+        pyramid_request.user = user
         pyramid_request.json_body = {}
         return pyramid_request
 


### PR DESCRIPTION
The additional verbosity is cumbersome and not particularly enlightening. We originally had to use `authenticated_user` rather than `user` because the latter was already used by code that has since been removed.

The `authenticated_` prefix mirrors the Pyramid-provided `request.authenticated_userid`, but that property is so named to distinguish it from `request.unauthenticated_userid`, whereas there is no such corresponding property for us to distinguish ourselves from with this one.