### PR TITLE
Rename request.auth_domain to request.authority

### DIFF
--- a/conf/development-app.ini
+++ b/conf/development-app.ini
@@ -9,7 +9,7 @@ es.host: http://localhost:9200
 pyramid.debug_all: True
 pyramid.reload_templates: True
 
-h.auth_domain: localhost
+h.authority: localhost
 
 # Set a default persistent secret for development. DO NOT copy this into a
 # production settings file.

--- a/h/accounts/schemas.py
+++ b/h/accounts/schemas.py
@@ -50,7 +50,7 @@ def get_blacklist():
 def unique_email(node, value):
     '''Colander validator that ensures no user with this email exists.'''
     request = node.bindings['request']
-    user = models.User.get_by_email(request.db, value, request.auth_domain)
+    user = models.User.get_by_email(request.db, value, request.authority)
     if user and user.userid != request.authenticated_userid:
         msg = _("Sorry, an account with this email address already exists.")
         raise colander.Invalid(node, msg)
@@ -59,7 +59,7 @@ def unique_email(node, value):
 def unique_username(node, value):
     '''Colander validator that ensures the username does not exist.'''
     request = node.bindings['request']
-    user = models.User.get_by_username(request.db, value, request.auth_domain)
+    user = models.User.get_by_username(request.db, value, request.authority)
     if user:
         msg = _("This username is already taken.")
         raise colander.Invalid(node, msg)
@@ -181,7 +181,7 @@ class ForgotPasswordSchema(CSRFSchema):
 
         request = node.bindings['request']
         email = value.get('email')
-        user = models.User.get_by_email(request.db, email, request.auth_domain)
+        user = models.User.get_by_email(request.db, email, request.authority)
 
         if user is None:
             err = colander.Invalid(node)
@@ -245,7 +245,7 @@ class ResetCode(colander.SchemaType):
         except BadData:
             raise colander.Invalid(node, _('Wrong reset code.'))
 
-        user = models.User.get_by_username(request.db, username, request.auth_domain)
+        user = models.User.get_by_username(request.db, username, request.authority)
         if user is None:
             raise colander.Invalid(node, _('Your reset code is not valid'))
         if user.password_updated is not None and timestamp < user.password_updated:

--- a/h/activity/query.py
+++ b/h/activity/query.py
@@ -92,7 +92,7 @@ def check_url(request, query, unparse=parser.unparse):
     elif _single_entry(query, 'user'):
         username = query.pop('user')
         user = request.find_service(name='user').fetch(username,
-                                                       request.auth_domain)
+                                                       request.authority)
         if user:
             redirect = request.route_path('activity.user_search',
                                           username=username,

--- a/h/auth/__init__.py
+++ b/h/auth/__init__.py
@@ -8,7 +8,7 @@ from pyramid.authentication import RemoteUserAuthenticationPolicy
 import pyramid_authsanity
 
 from h.auth.policy import AuthenticationPolicy, TokenAuthenticationPolicy
-from h.auth.util import auth_domain, groupfinder
+from h.auth.util import authority, groupfinder
 from h.security import derive_key
 
 __all__ = (
@@ -57,8 +57,8 @@ def includeme(config):
     # that include this one.
     config.set_authentication_policy(DEFAULT_POLICY)
 
-    # Allow retrieval of the auth_domain from the request object.
-    config.add_request_method(auth_domain, name='auth_domain', reify=True)
+    # Allow retrieval of the authority from the request object.
+    config.add_request_method(authority, name='authority', reify=True)
 
     # Allow retrieval of the auth token (if present) from the request object.
     config.add_request_method('.tokens.auth_token', reify=True)

--- a/h/auth/util.py
+++ b/h/auth/util.py
@@ -101,10 +101,10 @@ def translate_annotation_principals(principals):
     return list(result)
 
 
-def auth_domain(request):
+def authority(request):
     """
-    Return the value of the h.auth_domain config settings.
+    Return the value of the h.authority config settings.
 
-    Falls back on returning request.domain if h.auth_domain isn't set.
+    Falls back on returning request.domain if h.authority isn't set.
     """
-    return text_type(request.registry.settings.get('h.auth_domain', request.domain))
+    return text_type(request.registry.settings.get('h.authority', request.domain))

--- a/h/cli/commands/user.py
+++ b/h/cli/commands/user.py
@@ -61,7 +61,7 @@ def admin(ctx, username, authority, on):
     request = ctx.obj['bootstrap']()
 
     if not authority:
-        authority = request.auth_domain
+        authority = request.authority
 
     user = models.User.get_by_username(request.db, username, authority)
     if user is None:

--- a/h/config.py
+++ b/h/config.py
@@ -10,11 +10,14 @@ import os
 from pyramid.config import Configurator
 from pyramid.settings import asbool
 
-from h.settings import DockerSetting
-from h.settings import EnvSetting
-from h.settings import SettingError
-from h.settings import database_url
-from h.settings import mandrill_settings
+from h.settings import (
+    DeprecatedSetting,
+    DockerSetting,
+    EnvSetting,
+    SettingError,
+    database_url,
+    mandrill_settings,
+)
 
 __all__ = ('configure',)
 
@@ -75,6 +78,8 @@ SETTINGS = [
     EnvSetting('ga_tracking_id', 'GOOGLE_ANALYTICS_TRACKING_ID'),
     EnvSetting('ga_client_tracking_id', 'GOOGLE_ANALYTICS_CLIENT_TRACKING_ID'),
     EnvSetting('h.app_url', 'APP_URL'),
+    DeprecatedSetting(EnvSetting('h.authority', 'AUTH_DOMAIN'),
+                      message='use the AUTHORITY environment variable instead'),
     EnvSetting('h.authority', 'AUTHORITY'),
     EnvSetting('h.bouncer_url', 'BOUNCER_URL'),
     EnvSetting('h.client_id', 'CLIENT_ID'),

--- a/h/config.py
+++ b/h/config.py
@@ -75,7 +75,7 @@ SETTINGS = [
     EnvSetting('ga_tracking_id', 'GOOGLE_ANALYTICS_TRACKING_ID'),
     EnvSetting('ga_client_tracking_id', 'GOOGLE_ANALYTICS_CLIENT_TRACKING_ID'),
     EnvSetting('h.app_url', 'APP_URL'),
-    EnvSetting('h.auth_domain', 'AUTH_DOMAIN'),
+    EnvSetting('h.authority', 'AUTHORITY'),
     EnvSetting('h.bouncer_url', 'BOUNCER_URL'),
     EnvSetting('h.client_id', 'CLIENT_ID'),
     EnvSetting('h.client_secret', 'CLIENT_SECRET'),

--- a/h/groups/util.py
+++ b/h/groups/util.py
@@ -12,13 +12,13 @@ class WorldGroup(object):
     This is so we don't have to store a __world__ group in the database.
     """
 
-    def __init__(self, auth_domain):
-        self.auth_domain = auth_domain
+    def __init__(self, authority):
+        self.authority = authority
 
     def __acl__(self):
         return [
             (security.Allow, security.Everyone, 'read'),
-            (security.Allow, 'authority:{}'.format(self.auth_domain), 'write'),
+            (security.Allow, 'authority:{}'.format(self.authority), 'write'),
             security.DENY_ALL,
         ]
 

--- a/h/models/user.py
+++ b/h/models/user.py
@@ -114,7 +114,7 @@ class UserFactory(object):
 
     def __getitem__(self, username):
         user = self.request.find_service(name='user').fetch(
-            username, self.request.auth_domain)
+            username, self.request.authority)
 
         if not user:
             raise KeyError()
@@ -146,7 +146,7 @@ class User(Base):
     #: The "authority" for this user. This represents the "namespace" in which
     #: this user lives. By default, all users are created in the namespace
     #: corresponding to `request.domain`, but this can be overridden with the
-    #: `AUTH_DOMAIN` environment variable.
+    #: `h.authority` setting.
     authority = sa.Column('authority', sa.UnicodeText(), nullable=False)
 
     #: The display name which will be used when rendering an annotation.

--- a/h/services/authority_group.py
+++ b/h/services/authority_group.py
@@ -9,20 +9,20 @@ class AuthorityGroupService(object):
 
     """A service for listing groups under a particular authority."""
 
-    def __init__(self, session, auth_domain):
+    def __init__(self, session, authority):
         """
         Create a new authority group service.
 
         :param session: the current database session
-        :param auth_domain: the authority domain for the current site
+        :param authority: the authority domain for the current site
 
         """
         self._session = session
-        self._auth_domain = auth_domain
+        self._authority = authority
 
     def public_groups(self, authority):
-        if authority == self._auth_domain:
-            return [util.WorldGroup(self._auth_domain)]
+        if authority == self._authority:
+            return [util.WorldGroup(self._authority)]
         else:
             return (self._session.query(models.Group)
                     .filter_by(authority=authority,
@@ -33,4 +33,4 @@ class AuthorityGroupService(object):
 def authority_group_factory(context, request):
     """Return a AuthorityGroupService for the passed context and request."""
     return AuthorityGroupService(session=request.db,
-                                 auth_domain=request.auth_domain)
+                                 authority=request.authority)

--- a/h/services/groupfinder.py
+++ b/h/services/groupfinder.py
@@ -15,9 +15,9 @@ from h.groups.util import WorldGroup
 # FIXME: rename / split existing GroupService and rename this.
 @implementer(IGroupService)
 class GroupfinderService(object):
-    def __init__(self, session, auth_domain):
+    def __init__(self, session, authority):
         self.session = session
-        self.auth_domain = auth_domain
+        self.authority = authority
 
         self._cached_find = lru_cache_in_transaction(self.session)(self._find)
 
@@ -26,7 +26,7 @@ class GroupfinderService(object):
 
     def _find(self, id_):
         if id_ == '__world__':
-            return WorldGroup(self.auth_domain)
+            return WorldGroup(self.authority)
 
         return (self.session.query(models.Group)
                     .filter_by(pubid=id_)
@@ -34,4 +34,4 @@ class GroupfinderService(object):
 
 
 def groupfinder_service_factory(context, request):
-    return GroupfinderService(request.db, request.auth_domain)
+    return GroupfinderService(request.db, request.authority)

--- a/h/services/user.py
+++ b/h/services/user.py
@@ -113,5 +113,5 @@ class UserService(object):
 
 def user_service_factory(context, request):
     """Return a UserService instance for the passed context and request."""
-    return UserService(default_authority=request.auth_domain,
+    return UserService(default_authority=request.authority,
                        session=request.db)

--- a/h/services/user_signup.py
+++ b/h/services/user_signup.py
@@ -88,7 +88,7 @@ class UserSignupService(object):
 
 def user_signup_service_factory(context, request):
     """Return a UserSignupService instance for the passed context and request."""
-    return UserSignupService(default_authority=request.auth_domain,
+    return UserSignupService(default_authority=request.authority,
                              mailer=mailer,
                              session=request.db,
                              signup_email=partial(signup.generate, request),

--- a/h/session.py
+++ b/h/session.py
@@ -9,7 +9,7 @@ def model(request):
     session = {}
     session['csrf'] = request.session.get_csrf_token()
     session['userid'] = request.authenticated_userid
-    session['groups'] = _current_groups(request, request.auth_domain)
+    session['groups'] = _current_groups(request, request.authority)
     session['features'] = request.feature.all()
     session['preferences'] = _user_preferences(request.authenticated_user)
     return session
@@ -21,7 +21,7 @@ def profile(request, authority=None):
 
     If the request is unauthenticated (and so not tied to a particular
     authority), the authority parameter can be used to override the authority
-    used to find public groups (by default, this is the `auth_domain` of the
+    used to find public groups (by default, this is the `authority` of the
     request). This parameter is ignored for authenticated requests.
 
     """
@@ -30,7 +30,7 @@ def profile(request, authority=None):
     if user is not None:
         authority = user.authority
     else:
-        authority = authority or request.auth_domain
+        authority = authority or request.authority
 
     profile = {}
     profile['userid'] = request.authenticated_userid

--- a/h/streamer/messages.py
+++ b/h/streamer/messages.py
@@ -94,8 +94,8 @@ def handle_annotation_event(message, sockets, settings, session):
     nipsa_service = NipsaService(session)
     user_nipsad = nipsa_service.is_flagged(annotation.userid)
 
-    auth_domain = text_type(settings.get('h.auth_domain', 'localhost'))
-    group_service = GroupfinderService(session, auth_domain)
+    authority = text_type(settings.get('h.authority', 'localhost'))
+    group_service = GroupfinderService(session, authority)
 
     for socket in sockets:
         reply = _generate_annotation_event(message, socket, annotation, user_nipsad, group_service)

--- a/h/views/admin_admins.py
+++ b/h/views/admin_admins.py
@@ -16,7 +16,7 @@ def admins_index(request):
     admins = request.db.query(models.User).filter(models.User.admin)
     return {
         "admin_users": [u.userid for u in admins],
-        "default_authority": request.auth_domain,
+        "default_authority": request.authority,
     }
 
 

--- a/h/views/admin_features.py
+++ b/h/views/admin_features.py
@@ -81,7 +81,7 @@ def cohorts_edit(context, request):
     return {
         'cohort': cohort,
         'members': cohort.members,
-        'default_authority': request.auth_domain
+        'default_authority': request.authority
     }
 
 

--- a/h/views/admin_nipsa.py
+++ b/h/views/admin_nipsa.py
@@ -19,7 +19,7 @@ def nipsa_index(request):
     nipsa_service = request.find_service(name='nipsa')
     return {
         "userids": sorted(nipsa_service.flagged_userids),
-        "default_authority": request.auth_domain,
+        "default_authority": request.authority,
     }
 
 

--- a/h/views/admin_staff.py
+++ b/h/views/admin_staff.py
@@ -16,7 +16,7 @@ def staff_index(request):
     staff = request.db.query(models.User).filter(models.User.staff)
     return {
         "staff": [u.userid for u in staff],
-        "default_authority": request.auth_domain,
+        "default_authority": request.authority,
     }
 
 

--- a/h/views/admin_users.py
+++ b/h/views/admin_users.py
@@ -46,7 +46,7 @@ def users_index(request):
         user_meta['annotations_count'] = counts['total']
 
     return {
-        'default_authority': request.auth_domain,
+        'default_authority': request.authority,
         'username': username,
         'authority': authority,
         'user': user,

--- a/h/views/client.py
+++ b/h/views/client.py
@@ -48,7 +48,7 @@ def sidebar_app(request, extra=None):
 
     app_config = {
         'apiUrl': request.route_url('api.index'),
-        'authDomain': request.auth_domain,
+        'authDomain': request.authority,
         'release': __version__,
         'serviceUrl': request.route_url('index'),
     }

--- a/h/views/groups.py
+++ b/h/views/groups.py
@@ -43,7 +43,7 @@ class GroupCreateController(object):
             groups_service = self.request.find_service(name='group')
             group = groups_service.create(
                 name=appstruct['name'],
-                authority=self.request.auth_domain,
+                authority=self.request.authority,
                 description=appstruct.get('description'),
                 userid=self.request.authenticated_userid)
 

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -12,7 +12,7 @@ TEST_SETTINGS = {
     'es.host': os.environ.get('ELASTICSEARCH_HOST', 'http://localhost:9200'),
     'es.index': 'hypothesis-test',
     'h.app_url': 'http://example.com',
-    'h.auth_domain': 'example.com',
+    'h.authority': 'example.com',
     'h.client_secret': 'notsosecret',
     'pyramid.debug_all': True,
     'sqlalchemy.url': os.environ.get('TEST_DATABASE_URL',

--- a/tests/functional/test_api.py
+++ b/tests/functional/test_api.py
@@ -54,7 +54,7 @@ class TestAPI(object):
         Fetch an anonymous "profile".
 
         With no authentication and no authority parameter, this should default
-        to the site's `auth_domain` and show only the global group.
+        to the site's `authority` and show only the global group.
         """
 
         res = app.get('/api/profile')

--- a/tests/h/accounts/schemas_test.py
+++ b/tests/h/accounts/schemas_test.py
@@ -44,7 +44,7 @@ class TestUniqueEmail(object):
 
         user_model.get_by_email.assert_called_with(pyramid_request.db,
                                                    "foo@bar.com",
-                                                   pyramid_request.auth_domain)
+                                                   pyramid_request.authority)
 
     def test_it_is_invalid_when_user_exists(self, dummy_node):
         pytest.raises(colander.Invalid,

--- a/tests/h/auth/util_test.py
+++ b/tests/h/auth/util_test.py
@@ -159,15 +159,15 @@ def test_translate_annotation_principals(p_in, p_out):
 
 class TestAuthDomain(object):
     def test_it_returns_the_request_domain(self, pyramid_request):
-        assert util.auth_domain(pyramid_request) == pyramid_request.domain
+        assert util.authority(pyramid_request) == pyramid_request.domain
 
     def test_it_allows_overriding_request_domain(self, pyramid_request):
-        pyramid_request.registry.settings['h.auth_domain'] = 'foo.org'
-        assert util.auth_domain(pyramid_request) == u'foo.org'
+        pyramid_request.registry.settings['h.authority'] = 'foo.org'
+        assert util.authority(pyramid_request) == u'foo.org'
 
     def test_it_returns_text_type(self, pyramid_request):
         pyramid_request.domain = str(pyramid_request.domain)
-        assert type(util.auth_domain(pyramid_request)) == text_type
+        assert type(util.authority(pyramid_request)) == text_type
 
 
 @pytest.fixture

--- a/tests/h/conftest.py
+++ b/tests/h/conftest.py
@@ -225,7 +225,7 @@ def pyramid_config(pyramid_settings, pyramid_request):
 def pyramid_request(db_session, fake_feature, pyramid_settings):
     """Dummy Pyramid request object."""
     request = testing.DummyRequest(db=db_session, feature=fake_feature)
-    request.auth_domain = text_type(request.domain)
+    request.authority = text_type(request.domain)
     request.create_form = mock.Mock()
     request.matched_route = mock.Mock()
     request.registry.settings = pyramid_settings

--- a/tests/h/services/groupfinder_test.py
+++ b/tests/h/services/groupfinder_test.py
@@ -20,10 +20,10 @@ class TestGroupfinderService(object):
 
         assert isinstance(group, WorldGroup)
 
-    def test_sets_auth_domain_on_world_group(self, svc):
+    def test_sets_authority_on_world_group(self, svc):
         group = svc.find('__world__')
 
-        assert group.auth_domain == 'example.com'
+        assert group.authority == 'example.com'
 
     def test_returns_none_when_not_found(self, svc, factories):
         factories.Group()
@@ -46,7 +46,7 @@ class TestGroupfinderServiceFactory(object):
 
         assert svc.session == pyramid_request.db
 
-    def test_provides_auth_domain(self, pyramid_request):
+    def test_provides_authority(self, pyramid_request):
         svc = groupfinder_service_factory(None, pyramid_request)
 
-        assert svc.auth_domain == pyramid_request.auth_domain
+        assert svc.authority == pyramid_request.authority

--- a/tests/h/services/user_signup_test.py
+++ b/tests/h/services/user_signup_test.py
@@ -118,10 +118,10 @@ class TestUserSignupServiceFactory(object):
 
         assert isinstance(svc, UserSignupService)
 
-    def test_provides_request_auth_domain_as_default_authority(self, pyramid_request):
+    def test_provides_request_authority_as_default_authority(self, pyramid_request):
         svc = user_signup_service_factory(None, pyramid_request)
 
-        assert svc.default_authority == pyramid_request.auth_domain
+        assert svc.default_authority == pyramid_request.authority
 
     def test_provides_request_db_as_session(self, pyramid_request):
         svc = user_signup_service_factory(None, pyramid_request)

--- a/tests/h/services/user_test.py
+++ b/tests/h/services/user_test.py
@@ -104,10 +104,10 @@ class TestUserServiceFactory(object):
 
         assert isinstance(svc, UserService)
 
-    def test_provides_request_auth_domain_as_default_authority(self, pyramid_request):
+    def test_provides_request_authority_as_default_authority(self, pyramid_request):
         svc = user_service_factory(None, pyramid_request)
 
-        assert svc.default_authority == pyramid_request.auth_domain
+        assert svc.default_authority == pyramid_request.authority
 
     def test_provides_request_db_as_session(self, pyramid_request):
         svc = user_service_factory(None, pyramid_request)

--- a/tests/h/session_test.py
+++ b/tests/h/session_test.py
@@ -179,8 +179,8 @@ class TestProfile(object):
         else:
             assert preferences['show_sidebar_tutorial'] is True
 
-    def test_anonymous_authority(self, unauthenticated_request, auth_domain):
-        assert session.profile(unauthenticated_request)['authority'] == auth_domain
+    def test_anonymous_authority(self, unauthenticated_request, authority):
+        assert session.profile(unauthenticated_request)['authority'] == authority
 
     def test_authority_override(self, unauthenticated_request):
         unauthenticated_request.set_public_groups({'foo.com': []})
@@ -189,13 +189,13 @@ class TestProfile(object):
 
         assert profile['authority'] == 'foo.com'
 
-    def test_authenticated_authority(self, authenticated_request, auth_domain):
-        assert session.profile(authenticated_request)['authority'] == auth_domain
+    def test_authenticated_authority(self, authenticated_request, authority):
+        assert session.profile(authenticated_request)['authority'] == authority
 
-    def test_authenticated_ignores_authority_override(self, authenticated_request, auth_domain):
+    def test_authenticated_ignores_authority_override(self, authenticated_request, authority):
         profile = session.profile(authenticated_request, 'foo.com')
 
-        assert profile['authority'] == auth_domain
+        assert profile['authority'] == authority
 
     def test_third_party_authority(self, third_party_request, third_party_domain):
         assert session.profile(third_party_request)['authority'] == third_party_domain
@@ -210,8 +210,8 @@ class TestProfile(object):
         return u'thirdparty.example.org'
 
     @pytest.fixture
-    def third_party_request(self, auth_domain, third_party_domain, publisher_group):
-        return FakeRequest(auth_domain,
+    def third_party_request(self, authority, third_party_domain, publisher_group):
+        return FakeRequest(authority,
                            u'acct:user@{}'.format(third_party_domain),
                            third_party_domain,
                            {third_party_domain: [publisher_group]})
@@ -232,8 +232,8 @@ class FakeAuthorityGroupService(object):
 
 class FakeRequest(object):
 
-    def __init__(self, auth_domain, userid, user_authority, public_groups):
-        self.auth_domain = auth_domain
+    def __init__(self, authority, userid, user_authority, public_groups):
+        self.authority = authority
         self.authenticated_userid = userid
 
         if userid is None:
@@ -268,7 +268,7 @@ class FakeRequest(object):
 
 
 @pytest.fixture
-def auth_domain():
+def authority():
     return u'example.com'
 
 
@@ -278,13 +278,13 @@ def world_group():
 
 
 @pytest.fixture
-def unauthenticated_request(auth_domain, world_group):
-    return FakeRequest(auth_domain, None, None, {auth_domain: [world_group]})
+def unauthenticated_request(authority, world_group):
+    return FakeRequest(authority, None, None, {authority: [world_group]})
 
 
 @pytest.fixture
-def authenticated_request(auth_domain, world_group):
-    return FakeRequest(auth_domain,
-                       u'acct:user@{}'.format(auth_domain),
-                       auth_domain,
-                       {auth_domain: [world_group]})
+def authenticated_request(authority, world_group):
+    return FakeRequest(authority,
+                       u'acct:user@{}'.format(authority),
+                       authority,
+                       {authority: [world_group]})

--- a/tests/h/streamer/messages_test.py
+++ b/tests/h/streamer/messages_test.py
@@ -184,7 +184,7 @@ class TestHandleAnnotationEvent(object):
         message = {'action': '_', 'annotation_id': '_', 'src_client_id': '_'}
         session = mock.sentinel.db_session
         socket = FakeSocket('giraffe')
-        settings = {'h.auth_domain': 'example.org'}
+        settings = {'h.authority': 'example.org'}
 
         messages.handle_annotation_event(message, [socket], settings, session)
 

--- a/tests/h/views/admin_admins_test.py
+++ b/tests/h/views/admin_admins_test.py
@@ -44,7 +44,7 @@ class TestAdminsAddRemove(object):
     def test_add_is_idempotent(self, pyramid_request, users):
         pyramid_request.params = {
             "add": "agnos",
-            "authority": pyramid_request.auth_domain,
+            "authority": pyramid_request.authority,
         }
 
         admins_add(pyramid_request)
@@ -61,7 +61,7 @@ class TestAdminsAddRemove(object):
     def test_add_redirects_to_index(self, pyramid_request):
         pyramid_request.params = {
             "add": "eva",
-            "authority": pyramid_request.auth_domain,
+            "authority": pyramid_request.authority,
         }
 
         result = admins_add(pyramid_request)
@@ -72,7 +72,7 @@ class TestAdminsAddRemove(object):
     def test_add_redirects_to_index_when_user_not_found(self, pyramid_request):
         pyramid_request.params = {
             "add": "florp",
-            "authority": pyramid_request.auth_domain,
+            "authority": pyramid_request.authority,
         }
 
         result = admins_add(pyramid_request)
@@ -83,7 +83,7 @@ class TestAdminsAddRemove(object):
     def test_add_flashes_when_user_not_found(self, pyramid_request):
         pyramid_request.params = {
             "add": "florp",
-            "authority": pyramid_request.auth_domain,
+            "authority": pyramid_request.authority,
         }
         pyramid_request.session.flash = mock.Mock()
 

--- a/tests/h/views/admin_staff_test.py
+++ b/tests/h/views/admin_staff_test.py
@@ -43,7 +43,7 @@ class TestStaffAddRemove(object):
     def test_add_is_idempotent(self, pyramid_request, users):
         pyramid_request.params = {
             "add": "agnos",
-            "authority": pyramid_request.auth_domain
+            "authority": pyramid_request.authority
         }
 
         staff_add(pyramid_request)
@@ -63,7 +63,7 @@ class TestStaffAddRemove(object):
     def test_add_redirects_to_index(self, pyramid_request):
         pyramid_request.params = {
             "add": "eva",
-            "authority": pyramid_request.auth_domain
+            "authority": pyramid_request.authority
         }
 
         result = staff_add(pyramid_request)
@@ -74,7 +74,7 @@ class TestStaffAddRemove(object):
     def test_add_redirects_to_index_when_user_not_found(self, pyramid_request):
         pyramid_request.params = {
             "add": "florp",
-            "authority": pyramid_request.auth_domain
+            "authority": pyramid_request.authority
         }
 
         result = staff_add(pyramid_request)
@@ -85,7 +85,7 @@ class TestStaffAddRemove(object):
     def test_add_flashes_when_user_not_found(self, pyramid_request):
         pyramid_request.params = {
             "add": "florp",
-            "authority": pyramid_request.auth_domain
+            "authority": pyramid_request.authority
         }
         pyramid_request.session.flash = mock.Mock()
 

--- a/tests/h/views/admin_users_test.py
+++ b/tests/h/views/admin_users_test.py
@@ -29,7 +29,7 @@ def test_users_index(pyramid_request):
     result = users_index(pyramid_request)
 
     assert result == {
-        'default_authority': pyramid_request.auth_domain,
+        'default_authority': pyramid_request.authority,
         'username': None,
         'authority': None,
         'user': None,

--- a/tests/h/views/client_test.py
+++ b/tests/h/views/client_test.py
@@ -67,7 +67,7 @@ def pyramid_settings(pyramid_settings):
         'ga_client_tracking_id': 'UA-4567',
         'h.sentry_dsn_client': 'test-sentry-dsn',
         'h.websocket_url': 'wss://example.com/ws',
-        'auth_domain': 'example.com'
+        'authority': 'example.com'
         })
 
     return pyramid_settings

--- a/tests/memex/conftest.py
+++ b/tests/memex/conftest.py
@@ -166,7 +166,7 @@ def pyramid_config(pyramid_settings, pyramid_request):
 def pyramid_request(db_session, fake_feature, pyramid_settings):
     """Dummy Pyramid request object."""
     request = testing.DummyRequest(db=db_session, feature=fake_feature)
-    request.auth_domain = text_type(request.domain)
+    request.authority = text_type(request.domain)
     request.create_form = mock.Mock()
     request.registry.settings = pyramid_settings
     return request


### PR DESCRIPTION
We are now consistently using the term "authority" to refer to the domain-like namespace that we use to partition users, groups, and annotations within our database.

`request.auth_domain` is a property which predates the use of the term "authority" within the codebase, but essentially represents the same concept, and so it makes sense to unify the language here.

This PR also includes a commit which ensures that any existing installations using the `AUTH_DOMAIN` environment variable will continue to work, but the application will emit a deprecation warning telling operators to move to the `AUTHORITY` var instead.