### PR TITLE
Add the 'flagged' field to the set of protected fields

### DIFF
--- a/src/memex/schemas.py
+++ b/src/memex/schemas.py
@@ -293,7 +293,7 @@ def _format_jsonschema_error(error):
 
 def _remove_protected_fields(appstruct):
     # Some fields are not to be set by the user, ignore them.
-    for field in ['created', 'updated', 'user', 'id', 'links']:
+    for field in ['created', 'updated', 'user', 'id', 'links', 'flagged']:
         appstruct.pop(field, None)
 
 

--- a/tests/memex/schemas_test.py
+++ b/tests/memex/schemas_test.py
@@ -216,6 +216,7 @@ class TestCreateUpdateAnnotationSchema(object):
         'user',
         'id',
         'links',
+        'flagged',
     ])
     def test_it_removes_protected_fields(self, pyramid_request, validate, field):
         data = {}
@@ -380,6 +381,7 @@ class TestCreateUpdateAnnotationSchema(object):
             'target': [],
             'group': '__world__',
             'references': ['parent'],
+            'flagged': True,
 
             # These should end up in extra.
             'foo': 1,


### PR DESCRIPTION
Since ca82568, "flagged" is included in the JSON rendering of annotation objects. This field is set by the separate` /api/annotations/<id>/flag` endpoint, and should be ignored by the annotation update endpoint.

We may also need a separate migration to clean up any "flagged" values that got into annotation "extras" fields.