### PR TITLE
Sort test imports in their own group

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,6 +5,8 @@ max-line-length = 160
 [isort]
 include_trailing_comma = True
 multi_line_output = 3
+known_test = hypothesis,mock,pytest,webtest
+sections = FUTURE,STDLIB,TEST,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
 
 [yapf]
 based_on_style = pep8


### PR DESCRIPTION
This commit adds isort configuration to setup.cfg which makes it easier to enforce a convention we're already (loosely) applying, namely to sort test imports into their own group between system imports and the remaining 3rd-party imports.

That is, with this change, isort will now automatically turn something like

```python
from __future__ import unicode_literals
import os
from collections import defaultdict
from pyramid.exceptions import BadCSRFToken
from h.schemas import ValidationError
import pytest
from h.schemas.base import CSRFSchema, JSONSchema
from mock import Mock, MagicMock
import mock
```

into something like

```python
from __future__ import unicode_literals

import os
from collections import defaultdict

import mock
import pytest
from mock import MagicMock, Mock

from pyramid.exceptions import BadCSRFToken

from h.schemas import ValidationError
from h.schemas.base import CSRFSchema, JSONSchema
```

(Preceding messiness exaggerated for effect.)