### PR TITLE
Add a UserPasswordService for managing user passwords

### DIFF
--- a/h/services/__init__.py
+++ b/h/services/__init__.py
@@ -23,6 +23,7 @@ def includeme(config):
     config.register_service_factory('.rename_user.rename_user_factory', name='rename_user')
     config.register_service_factory('.settings.settings_factory', name='settings')
     config.register_service_factory('.user.user_service_factory', name='user')
+    config.register_service_factory('.user_password.user_password_service_factory', name='user_password')
     config.register_service_factory('.user_signup.user_signup_service_factory', name='user_signup')
 
     config.add_request_method('.feature.FeatureRequestProperty',

--- a/h/services/user_password.py
+++ b/h/services/user_password.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import datetime
+
+from h._compat import text_type
+from h.security import password_context
+
+# FIXME: This service currently interacts with the underscored "_password"
+# property of the user model. This is to make it possible to roll this change
+# out incrementally. When all password checking functionality has been removed
+# from the user model, we should rename the password hash property to plain
+# "password" (no underscore) and use that in this service.
+
+
+class UserPasswordService(object):
+
+    """
+    A service for checking and updating user passwords.
+
+    This service is responsible for verifying and updating user passwords, and
+    specifically for ensuring that we automatically upgrade user password
+    hashes to the latest secure hash when verifying, if appropriate.
+    """
+
+    def __init__(self):
+        # Test seam
+        self.hasher = password_context
+
+    def check_password(self, user, password):
+        """Check the password for this user, and upgrade it if necessary."""
+        if not user._password:
+            return False
+
+        # Old-style separate salt.
+        #
+        # TODO: remove this deprecated code path when a suitable proportion of
+        # users have updated their password by logging-in. (Check how many
+        # users still have a non-null salt in the database.)
+        if user.salt is not None:
+            verified = self.hasher.verify(password + user.salt, user._password)
+
+            # If the password is correct, take this opportunity to upgrade the
+            # password and remove the salt.
+            if verified:
+                self.update_password(user, password)
+
+            return verified
+
+        verified, new_hash = self.hasher.verify_and_update(password,
+                                                           user._password)
+        if not verified:
+            return False
+
+        if new_hash is not None:
+            user._password = text_type(new_hash)
+
+        return verified
+
+    def update_password(self, user, new_password):
+        """Update the user's password."""
+        # Remove any existing explicit salt (the password context salts the
+        # password automatically).
+        user.salt = None
+        user._password = text_type(self.hasher.encrypt(new_password))
+        user.password_updated = datetime.datetime.utcnow()
+
+
+def user_password_service_factory(context, request):
+    """Return a UserPasswordService instance for the passed context and request."""
+    return UserPasswordService()

--- a/tests/h/services/user_password_test.py
+++ b/tests/h/services/user_password_test.py
@@ -1,0 +1,106 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import pytest
+from passlib.context import CryptContext
+
+from h.security import password_context
+from h.services.user_password import UserPasswordService
+
+
+class TestUserPasswordService(object):
+    def test_check_password_false_with_null_password(self, svc, user):
+        assert not svc.check_password(user, 'anything')
+
+    def test_check_password_false_with_empty_password(self, svc, user):
+        user._password = ''
+
+        assert not svc.check_password(user, '')
+
+    def test_check_password_true_with_matching_password(self, svc, user):
+        svc.update_password(user, 's3cr37')
+
+        assert svc.check_password(user, 's3cr37')
+
+    def test_check_password_false_with_incorrect_password(self, svc, user):
+        svc.update_password(user, 's3cr37')
+
+        assert not svc.check_password(user, 'somethingelse')
+
+    def test_check_password_validates_old_style_passwords(self, svc, user):
+        user.salt = 'somesalt'
+        # Generated with passlib.hash.bcrypt.encrypt('foobar' + 'somesalt', rounds=4)
+        user._password = '$2a$04$zDQnlV/YBG.ju2i14V15p.5nWYL52ZBqjGsBWgLAisGkEJw812BHy'
+
+        assert not svc.check_password(user, 'somethingelse')
+        assert svc.check_password(user, 'foobar')
+
+    def test_check_password_upgrades_old_style_passwords(self, hasher, svc, user):
+        user.salt = 'somesalt'
+        # Generated with passlib.hash.bcrypt.encrypt('foobar' + 'somesalt', rounds=4)
+        user._password = '$2a$04$zDQnlV/YBG.ju2i14V15p.5nWYL52ZBqjGsBWgLAisGkEJw812BHy'
+
+        svc.check_password(user, 'foobar')
+
+        assert user.salt is None
+        assert not hasher.needs_update(user._password)
+
+    def test_check_password_only_upgrades_when_password_is_correct(self, hasher, svc, user):
+        user.salt = 'somesalt'
+        # Generated with passlib.hash.bcrypt.encrypt('foobar' + 'somesalt', rounds=4)
+        user._password = '$2a$04$zDQnlV/YBG.ju2i14V15p.5nWYL52ZBqjGsBWgLAisGkEJw812BHy'
+
+        svc.check_password(user, 'donkeys')
+
+        assert user.salt is not None
+        assert hasher.needs_update(user._password)
+
+    def test_check_password_works_after_upgrade(self, svc, user):
+        user.salt = 'somesalt'
+        # Generated with passlib.hash.bcrypt.encrypt('foobar' + 'somesalt', rounds=4)
+        user._password = '$2a$04$zDQnlV/YBG.ju2i14V15p.5nWYL52ZBqjGsBWgLAisGkEJw812BHy'
+
+        svc.check_password(user, 'foobar')
+
+        assert svc.check_password(user, 'foobar')
+
+    def test_check_password_upgrades_new_style_passwords(self, hasher, svc, user):
+        # Generated with passlib.hash.bcrypt.encrypt('foobar', rounds=4, ident='2b')
+        user._password = '$2b$04$L2j.vXxlLt9JJNHHsy0EguslcaphW7vssSpHbhqCmf9ECsMiuTd1y'
+
+        svc.check_password(user, 'foobar')
+
+        assert not hasher.needs_update(user._password)
+
+    def test_updating_password_unsets_salt(self, svc, user):
+        user.salt = 'somesalt'
+        user._password = 'whatever'
+
+        svc.update_password(user, 'flibble')
+
+        assert user.salt is None
+        assert svc.check_password(user, 'flibble')
+
+    def test_uses_global_password_context_by_default(self):
+        svc = UserPasswordService()
+        assert svc.hasher == password_context
+
+    @pytest.fixture
+    def hasher(self):
+        # Use a much faster hasher for testing purposes. DO NOT use as few as
+        # 5 rounds of bcrypt in production code under ANY CIRCUMSTANCES.
+        return CryptContext(schemes=['bcrypt'],
+                            bcrypt__ident='2b',
+                            bcrypt__min_rounds=5,
+                            bcrypt__max_rounds=5)
+
+    @pytest.fixture
+    def svc(self, hasher):
+        svc = UserPasswordService()
+        svc.hasher = hasher
+        return svc
+
+    @pytest.fixture
+    def user(self, factories):
+        return factories.User.build()


### PR DESCRIPTION
This PR adds a (currently unused) service which has responsibility for checking (and updating) user passwords. This is in preparation for removing that functionality from the user model.

This is desirable primarily because it makes it much easier to make our tests fast. At the moment, many tests which interact with User model instances end up computing the 12-round bcrypt hash of passwords, which is *very* slow.

By encapsulating the password checking functionality in a service of its own we can limit the performance impact of password checking in tests to just this service. In addition, it is made much easier to add an appropriate test seam which allows swapping out the password `CryptContext` for a faster one when testing.

For the sake of concreteness, I see something like a 30% speedup when running the `tests/h` suite on my local branch which uses this service everywhere appropriate: suite runtimes of ~100s drop to times of ~75s.