### PR TITLE
Use the UserPasswordService when checking passwords

### DIFF
--- a/tests/h/services/user_test.py
+++ b/tests/h/services/user_test.py
@@ -4,13 +4,8 @@ from __future__ import unicode_literals
 
 import pytest
 
-from h.services.user import (
-    UserNotActivated,
-    UserNotKnown,
-    UserService,
-    user_service_factory,
-)
 from h.models import User
+from h.services.user import UserNotActivated, UserService, user_service_factory
 
 
 @pytest.mark.usefixtures('users')
@@ -25,33 +20,27 @@ class TestUserService(object):
 
         assert isinstance(result, User)
 
-    def test_login_by_username(self, svc, users):
+    def test_fetch_for_login_by_username(self, svc, users):
         _, steve, _ = users
-        assert svc.login('steve', 'stevespassword') is steve
+        assert svc.fetch_for_login('steve') is steve
 
-    def test_login_by_email(self, svc, users):
+    def test_fetch_for_login_by_email(self, svc, users):
         _, steve, _ = users
-        assert svc.login('steve@steveo.com', 'stevespassword') is steve
+        assert svc.fetch_for_login('steve@steveo.com') is steve
 
-    def test_login_bad_password(self, svc):
-        assert svc.login('steve', 'incorrect') is None
-        assert svc.login('steve@steveo.com', 'incorrect') is None
+    def test_fetch_for_login_by_username_wrong_authority(self, svc):
+        assert svc.fetch_for_login('jacqui') is None
 
-    def test_login_by_username_wrong_authority(self, svc):
-        with pytest.raises(UserNotKnown):
-            svc.login('jacqui', 'jacquispassword')
+    def test_fetch_for_login_by_email_wrong_authority(self, svc):
+        assert svc.fetch_for_login('jacqui@jj.com') is None
 
-    def test_login_by_email_wrong_authority(self, svc):
-        with pytest.raises(UserNotKnown):
-            svc.login('jacqui@jj.com', 'jacquispassword')
-
-    def test_login_by_username_not_activated(self, svc):
+    def test_fetch_for_login_by_username_not_activated(self, svc):
         with pytest.raises(UserNotActivated):
-            svc.login('mirthe', 'mirthespassword')
+            svc.fetch_for_login('mirthe')
 
-    def test_login_by_email_not_activated(self, svc, users):
+    def test_fetch_for_login_by_email_not_activated(self, svc, users):
         with pytest.raises(UserNotActivated):
-            svc.login('mirthe@deboer.com', 'mirthespassword')
+            svc.fetch_for_login('mirthe@deboer.com')
 
     def test_update_preferences_tutorial_enable(self, svc, factories):
         user = factories.User.build(sidebar_tutorial_dismissed=True)
@@ -83,16 +72,13 @@ class TestUserService(object):
     def users(self, db_session, factories):
         users = [factories.User(username='jacqui',
                                 email='jacqui@jj.com',
-                                authority='foo.com',
-                                password='jacquispassword'),
+                                authority='foo.com'),
                  factories.User(username='steve',
                                 email='steve@steveo.com',
-                                authority='example.com',
-                                password='stevespassword'),
+                                authority='example.com'),
                  factories.User(username='mirthe',
                                 email='mirthe@deboer.com',
                                 authority='example.com',
-                                password='mirthespassword',
                                 inactive=True)]
         db_session.flush()
         return users

--- a/tests/h/views/admin_users_test.py
+++ b/tests/h/views/admin_users_test.py
@@ -338,7 +338,6 @@ def models(patch):
 def user_service(pyramid_config, db_session):
     service = Mock(spec_set=UserService(default_authority='example.com',
                                         session=db_session))
-    service.login.return_value = None
     pyramid_config.register_service(service, name='user')
     return service
 


### PR DESCRIPTION
This commit makes all parts of the code that *check* user passwords do so using the UserPasswordService. Note that it does not change the parts of the code that *update* user passwords, and so we are relying on the fact that passwords set by the code in the User model will be correctly checked by the code in the new service.

Previously, some parts of the code checked user passwords directly using `User.check_password`, while at login, passwords were checked by the UserService's `login` method.

This commit renames the UserService's `login` method to `fetch_for_login` and removes the part of that method that checks user passwords.

Then, we:

- update all parts of the code which called `User.check_password` directly to use the user password service instead

- update all parts of the code which called the UserService's `login` method to use `fetch_for_login` and separately check the password with the user password service.

N.B. There remain a couple of calls to `User.check_password` in the tests, but these are used to check that *setting* passwords is happening correctly, and will be addressed in a later commit.

_**N.B.** This depends on #4468 and will need to be rebased after that has merged._