### PR TITLE
Use the UserPasswordService when updating passwords

### DIFF
--- a/h/views/accounts.py
+++ b/h/views/accounts.py
@@ -314,7 +314,8 @@ class ResetController(object):
             raise httpexceptions.HTTPFound(self.request.route_path('index'))
 
     def _reset_password(self, user, password):
-        user.password = password
+        svc = self.request.find_service(name='user_password')
+        svc.update_password(user, password)
 
         self.request.session.flash(jinja2.Markup(_(
             'Your password has been reset. '
@@ -524,7 +525,8 @@ class AccountController(object):
         self.request.user.email = appstruct['email']
 
     def update_password(self, appstruct):
-        self.request.user.password = appstruct['new_password']
+        svc = self.request.find_service(name='user_password')
+        svc.update_password(self.request.user, appstruct['new_password'])
 
     def _template_data(self):
         """Return the data needed to render accounts.html.jinja2."""

--- a/tests/h/views/api_users_test.py
+++ b/tests/h/views/api_users_test.py
@@ -185,6 +185,7 @@ def user_signup_service(db_session, factories, pyramid_config):
     service = Mock(spec_set=UserSignupService(default_authority='example.com',
                                               mailer=None,
                                               session=None,
+                                              password_service=None,
                                               signup_email=None,
                                               stats=None))
     pyramid_config.register_service(service, name='user_signup')


### PR DESCRIPTION
There are only three places where we actually set user passwords:

1. at signup (or "simulated signup" via the API or CLI)
2. during a password reset
3. when the user explicitly updates their password using the accounts forms

This PR updates all three places to use the new UserSignupService to update the user's password.

_**N.B.** This depends on #4468 and #4469, and will need rebasing once those have merged._