### PR TITLE
Remove password hashing functionality from the User model

### DIFF
--- a/h/accounts/schemas.py
+++ b/h/accounts/schemas.py
@@ -12,7 +12,6 @@ from h.accounts import util
 from h.services.user import UserNotActivated
 from h.models.user import (
     EMAIL_MAX_LENGTH,
-    PASSWORD_MIN_LENGTH,
     USERNAME_MAX_LENGTH,
     USERNAME_MIN_LENGTH,
     USERNAME_PATTERN,
@@ -22,6 +21,7 @@ from h.schemas import JSONSchema
 _ = i18n.TranslationString
 log = logging.getLogger(__name__)
 
+PASSWORD_MIN_LENGTH = 2  # FIXME: this is ridiculous
 USERNAME_BLACKLIST = None
 
 

--- a/tests/functional/test_accounts.py
+++ b/tests/functional/test_accounts.py
@@ -93,7 +93,8 @@ class TestAccountSettings(object):
 
     @pytest.fixture
     def user(self, db_session, factories):
-        user = factories.User(password='pass')
+        # Password is 'pass'
+        user = factories.User(password='$2b$12$21I1LjTlGJmLXzTDrQA8gusckjHEMepTmLY5WN3Kx8hSaqEEKj9V6')
         db_session.commit()
         return user
 

--- a/tests/functional/test_groups.py
+++ b/tests/functional/test_groups.py
@@ -64,7 +64,8 @@ def test_submit_create_group_form_with_xhr_returns_plain_text(app):
 
 @pytest.fixture
 def user(db_session, factories):
-    user = factories.User(password='pass')
+    # Password is 'pass'
+    user = factories.User(password='$2b$12$21I1LjTlGJmLXzTDrQA8gusckjHEMepTmLY5WN3Kx8hSaqEEKj9V6')
     db_session.commit()
     return user
 

--- a/tests/h/models/user_test.py
+++ b/tests/h/models/user_test.py
@@ -8,7 +8,6 @@ from sqlalchemy import exc
 from h import models
 from h.services.user import user_service_factory
 from h.models.user import UserFactory
-from h.security import password_context
 
 
 @pytest.mark.usefixtures('user_service')
@@ -142,102 +141,6 @@ def test_cannot_create_user_with_invalid_chars():
 def test_cannot_create_user_with_too_long_email():
     with pytest.raises(ValueError):
         models.User(email='bob@b' + 'o'*100 +'b.com')
-
-
-def test_cannot_create_user_with_too_short_password():
-    with pytest.raises(ValueError):
-        models.User(password='a')
-
-
-def test_check_password_false_with_null_password():
-    user = models.User(username='barnet')
-
-    assert not user.check_password('anything')
-
-
-def test_check_password_false_with_empty_password():
-    user = models.User(username='barnet')
-    user._password = ''
-
-    assert not user.check_password('')
-
-
-def test_check_password_true_with_matching_password():
-    user = models.User(username='barnet', password='s3cr37')
-
-    assert user.check_password('s3cr37')
-
-
-def test_check_password_false_with_incorrect_password():
-    user = models.User(username='barnet', password='s3cr37')
-
-    assert not user.check_password('somethingelse')
-
-
-def test_check_password_validates_old_style_passwords():
-    user = models.User(username='barnet')
-    user.salt = 'somesalt'
-    # Generated with passlib.hash.bcrypt.encrypt('foobar' + 'somesalt', rounds=10)
-    user._password = '$2a$10$il7Mi/T5WtvbqP5m3dbjeeohDf5XeDx35N5tdwyJ8uRB35NnIlozy'
-
-    assert user.check_password('foobar')
-    assert not user.check_password('somethingelse')
-
-
-def test_check_password_upgrades_old_style_passwords():
-    user = models.User(username='barnet')
-    user.salt = 'somesalt'
-    # Generated with passlib.hash.bcrypt.encrypt('foobar' + 'somesalt', rounds=10)
-    user._password = '$2a$10$il7Mi/T5WtvbqP5m3dbjeeohDf5XeDx35N5tdwyJ8uRB35NnIlozy'
-
-    user.check_password('foobar')
-
-    assert user.salt is None
-    assert not password_context.needs_update(user._password)
-
-
-def test_check_password_only_upgrades_when_password_is_correct():
-    user = models.User(username='barnet')
-    user.salt = 'somesalt'
-    # Generated with passlib.hash.bcrypt.encrypt('foobar' + 'somesalt', rounds=10)
-    user._password = '$2a$10$il7Mi/T5WtvbqP5m3dbjeeohDf5XeDx35N5tdwyJ8uRB35NnIlozy'
-
-    user.check_password('donkeys')
-
-    assert user.salt is not None
-    assert password_context.needs_update(user._password)
-
-
-def test_check_password_works_after_upgrade():
-    user = models.User(username='barnet')
-    user.salt = 'somesalt'
-    # Generated with passlib.hash.bcrypt.encrypt('foobar' + 'somesalt', rounds=10)
-    user._password = '$2a$10$il7Mi/T5WtvbqP5m3dbjeeohDf5XeDx35N5tdwyJ8uRB35NnIlozy'
-
-    user.check_password('foobar')
-
-    assert user.check_password('foobar')
-
-
-def test_check_password_upgrades_new_style_passwords():
-    user = models.User(username='barnet')
-    # Generated with passlib.hash.bcrypt.encrypt('foobar', rounds=4, ident='2b')
-    user._password = '$2b$04$L2j.vXxlLt9JJNHHsy0EguslcaphW7vssSpHbhqCmf9ECsMiuTd1y'
-
-    user.check_password('foobar')
-
-    assert not password_context.needs_update(user._password)
-
-
-def test_setting_password_unsets_salt():
-    user = models.User(username='barnet')
-    user.salt = 'somesalt'
-    user._password = 'whatever'
-
-    user.password = 'flibble'
-
-    assert user.salt is None
-    assert user.check_password('flibble')
 
 
 def test_User_activate_activates_user(db_session):

--- a/tests/h/services/user_password_test.py
+++ b/tests/h/services/user_password_test.py
@@ -14,7 +14,7 @@ class TestUserPasswordService(object):
         assert not svc.check_password(user, 'anything')
 
     def test_check_password_false_with_empty_password(self, svc, user):
-        user._password = ''
+        user.password = ''
 
         assert not svc.check_password(user, '')
 
@@ -31,7 +31,7 @@ class TestUserPasswordService(object):
     def test_check_password_validates_old_style_passwords(self, svc, user):
         user.salt = 'somesalt'
         # Generated with passlib.hash.bcrypt.encrypt('foobar' + 'somesalt', rounds=4)
-        user._password = '$2a$04$zDQnlV/YBG.ju2i14V15p.5nWYL52ZBqjGsBWgLAisGkEJw812BHy'
+        user.password = '$2a$04$zDQnlV/YBG.ju2i14V15p.5nWYL52ZBqjGsBWgLAisGkEJw812BHy'
 
         assert not svc.check_password(user, 'somethingelse')
         assert svc.check_password(user, 'foobar')
@@ -39,27 +39,27 @@ class TestUserPasswordService(object):
     def test_check_password_upgrades_old_style_passwords(self, hasher, svc, user):
         user.salt = 'somesalt'
         # Generated with passlib.hash.bcrypt.encrypt('foobar' + 'somesalt', rounds=4)
-        user._password = '$2a$04$zDQnlV/YBG.ju2i14V15p.5nWYL52ZBqjGsBWgLAisGkEJw812BHy'
+        user.password = '$2a$04$zDQnlV/YBG.ju2i14V15p.5nWYL52ZBqjGsBWgLAisGkEJw812BHy'
 
         svc.check_password(user, 'foobar')
 
         assert user.salt is None
-        assert not hasher.needs_update(user._password)
+        assert not hasher.needs_update(user.password)
 
     def test_check_password_only_upgrades_when_password_is_correct(self, hasher, svc, user):
         user.salt = 'somesalt'
         # Generated with passlib.hash.bcrypt.encrypt('foobar' + 'somesalt', rounds=4)
-        user._password = '$2a$04$zDQnlV/YBG.ju2i14V15p.5nWYL52ZBqjGsBWgLAisGkEJw812BHy'
+        user.password = '$2a$04$zDQnlV/YBG.ju2i14V15p.5nWYL52ZBqjGsBWgLAisGkEJw812BHy'
 
         svc.check_password(user, 'donkeys')
 
         assert user.salt is not None
-        assert hasher.needs_update(user._password)
+        assert hasher.needs_update(user.password)
 
     def test_check_password_works_after_upgrade(self, svc, user):
         user.salt = 'somesalt'
         # Generated with passlib.hash.bcrypt.encrypt('foobar' + 'somesalt', rounds=4)
-        user._password = '$2a$04$zDQnlV/YBG.ju2i14V15p.5nWYL52ZBqjGsBWgLAisGkEJw812BHy'
+        user.password = '$2a$04$zDQnlV/YBG.ju2i14V15p.5nWYL52ZBqjGsBWgLAisGkEJw812BHy'
 
         svc.check_password(user, 'foobar')
 
@@ -67,15 +67,15 @@ class TestUserPasswordService(object):
 
     def test_check_password_upgrades_new_style_passwords(self, hasher, svc, user):
         # Generated with passlib.hash.bcrypt.encrypt('foobar', rounds=4, ident='2b')
-        user._password = '$2b$04$L2j.vXxlLt9JJNHHsy0EguslcaphW7vssSpHbhqCmf9ECsMiuTd1y'
+        user.password = '$2b$04$L2j.vXxlLt9JJNHHsy0EguslcaphW7vssSpHbhqCmf9ECsMiuTd1y'
 
         svc.check_password(user, 'foobar')
 
-        assert not hasher.needs_update(user._password)
+        assert not hasher.needs_update(user.password)
 
     def test_updating_password_unsets_salt(self, svc, user):
         user.salt = 'somesalt'
-        user._password = 'whatever'
+        user.password = 'whatever'
 
         svc.update_password(user, 'flibble')
 

--- a/tests/h/services/user_signup_test.py
+++ b/tests/h/services/user_signup_test.py
@@ -59,7 +59,7 @@ class TestUserSignupService(object):
                           password='wibble')
 
         user_password_service.update_password.assert_called_once_with(user, 'wibble')
-        assert user._password == 'fakehash'
+        assert user.password == 'fakehash'
 
     def test_passes_user_info_to_signup_email(self, svc, signup_email):
         user = svc.signup(username='foo', email='foo@bar.com')
@@ -173,7 +173,7 @@ def user_password_service(pyramid_config):
     service = mock.Mock(spec_set=UserPasswordService())
 
     def password_setter(user, password):
-        user._password = 'fakehash'
+        user.password = 'fakehash'
     service.update_password.side_effect = password_setter
 
     pyramid_config.register_service(service, name='user_password')


### PR DESCRIPTION
This completes the work to move all password checking and updating
responsibilities to the UserPasswordService by:

- removing the custom setter for the `password` property on the User model
- updating the name of the underlying column property from `_password` to `password` and changing the UserPasswordService so that it uses the new name
- updating a couple of places in the functional tests that assumed they could set plaintext passwords using the User constructor

_**N.B.** This PR depends on #4468, #4469, and #4470, and will need rebasing after those have merged._