### PR TITLE
Add additional validation of target selectors

### DIFF
--- a/docs/_extra/api/schemas/annotation-schema.json
+++ b/docs/_extra/api/schemas/annotation-schema.json
@@ -36,15 +36,21 @@
     },
     "target": {
       "type": "array",
-      "items": [
-        {
-          "type": "object",
-          "properties": {
-            "selector": {
+      "items": {
+        "type": "object",
+        "properties": {
+          "selector": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "type": {"type": "string"}
+              },
+              "required": ["type"]
             }
           }
         }
-      ]
+      }
     },
     "text": {
       "type": "string"

--- a/src/memex/schemas.py
+++ b/src/memex/schemas.py
@@ -136,15 +136,21 @@ class AnnotationSchema(JSONSchema):
             },
             'target': {
                 'type': 'array',
-                'items': [
-                    {
-                        'type': 'object',
-                        'properties': {
-                            'selector': {
-                            },
+                'items': {
+                    'type': 'object',
+                    'properties': {
+                        'selector': {
+                            'type': 'array',
+                            'items': {
+                                'type': 'object',
+                                'properties': {
+                                    'type': {'type': 'string'}
+                                },
+                                'required': ['type']
+                            }
                         },
                     },
-                ],
+                },
             },
             'text': {
                 'type': 'string',


### PR DESCRIPTION
Ensure that incoming target selector properties are:

- an array
- of objects
- each of which has a type property
- which is a string

This should prevent a repeat of https://sentry.io/hypothesis/h/issues/239837148/.