### PR TITLE
Mark moderated annotations as nipsa'd in search index

### DIFF
--- a/h/nipsa/subscribers.py
+++ b/h/nipsa/subscribers.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 
 
 def transform_annotation(event):
-    """Add a {"nipsa": True} field on moderated annotations or whose users are flagged."""
+    """Add a {"nipsa": True} field on moderated annotations or those whose users are flagged."""
     payload = event.annotation_dict
 
     nipsa = _user_nipsa(event.request, payload)

--- a/h/services/annotation_moderation.py
+++ b/h/services/annotation_moderation.py
@@ -9,6 +9,20 @@ class AnnotationModerationService(object):
     def __init__(self, session):
         self.session = session
 
+    def hidden(self, annotation_id):
+        """
+        Check if an annotation id is hidden.
+
+        :param annotation_id: The id of the annotation to check.
+        :type annotation: unicode
+
+        :returns: true/false boolean
+        :rtype: bool
+        """
+        q = self.session.query(models.AnnotationModeration) \
+                        .filter_by(annotation_id=annotation_id)
+        return self.session.query(q.exists()).scalar()
+
     def hide(self, annotation):
         """
         Hide an annotation from other users.
@@ -23,10 +37,7 @@ class AnnotationModerationService(object):
         :type annotation: h.models.Annotation
         """
 
-        query = self.session.query(models.AnnotationModeration) \
-                            .filter_by(annotation=annotation)
-
-        if query.count() > 0:
+        if self.hidden(annotation.id):
             return
 
         mod = models.AnnotationModeration(annotation=annotation)

--- a/h/views/api_moderation.py
+++ b/h/views/api_moderation.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 from pyramid import security
 from pyramid.httpexceptions import HTTPNoContent, HTTPNotFound
 
+from h import events
 from h.views.api import api_config
 
 
@@ -19,4 +20,8 @@ def create(context, request):
 
     svc = request.find_service(name='annotation_moderation')
     svc.hide(context.annotation)
+
+    event = events.AnnotationEvent(request, context.annotation.id, 'update')
+    request.notify_after_commit(event)
+
     return HTTPNoContent()

--- a/tests/h/nipsa/subscribers_test.py
+++ b/tests/h/nipsa/subscribers_test.py
@@ -10,28 +10,51 @@ from h.nipsa import subscribers
 FakeEvent = namedtuple('FakeEvent', ['request', 'annotation_dict'])
 
 
-@pytest.mark.usefixtures('nipsa_service')
-@pytest.mark.parametrize("ann,flagged", [
-    ({"user": "george"}, True),
-    ({"user": "georgia"}, False),
-    ({}, False),
-])
-def test_transform_annotation(ann, flagged, nipsa_service, pyramid_request):
-    nipsa_service.is_flagged.return_value = flagged
-    event = FakeEvent(request=pyramid_request,
-                      annotation_dict=ann)
+@pytest.mark.usefixtures('nipsa_service', 'moderation_service')
+class TestTransformAnnotation(object):
+    @pytest.mark.parametrize('ann,flagged', [
+        ({'id': 'ann-1', 'user': 'george'}, True),
+        ({'id': 'ann-2', 'user': 'georgia'}, False),
+        ({'id': 'ann-3'}, False),
+    ])
+    def test_with_user_nipsa(self, ann, flagged, nipsa_service, pyramid_request):
+        nipsa_service.is_flagged.return_value = flagged
+        event = FakeEvent(request=pyramid_request,
+                          annotation_dict=ann)
 
-    subscribers.transform_annotation(event)
+        subscribers.transform_annotation(event)
 
-    if flagged:
-        assert ann["nipsa"] is True
-    else:
-        assert "nipsa" not in ann
+        if flagged:
+            assert ann['nipsa'] is True
+        else:
+            assert 'nipsa' not in ann
 
+    @pytest.mark.parametrize('ann,moderated', [
+        ({'id': 'normal'}, False),
+        ({'id': 'moderated'}, True)
+    ])
+    def test_with_moderated_annotation(self, ann, moderated, moderation_service, pyramid_request):
+        moderation_service.hidden.return_value = moderated
+        event = FakeEvent(request=pyramid_request,
+                          annotation_dict=ann)
 
-@pytest.fixture
-def nipsa_service(pyramid_config):
-    service = mock.Mock(spec_set=['is_flagged'])
-    service.is_flagged.return_value = False
-    pyramid_config.register_service(service, name='nipsa')
-    return service
+        subscribers.transform_annotation(event)
+
+        if moderated:
+            assert ann['nipsa'] is True
+        else:
+            assert 'nipsa' not in ann
+
+    @pytest.fixture
+    def nipsa_service(self, pyramid_config):
+        service = mock.Mock(spec_set=['is_flagged'])
+        service.is_flagged.return_value = False
+        pyramid_config.register_service(service, name='nipsa')
+        return service
+
+    @pytest.fixture
+    def moderation_service(self, pyramid_config):
+        service = mock.Mock(spec_set=['hidden'])
+        service.hidden.return_value = False
+        pyramid_config.register_service(service, name='annotation_moderation')
+        return service

--- a/tests/h/services/annotation_moderation_test.py
+++ b/tests/h/services/annotation_moderation_test.py
@@ -9,6 +9,18 @@ from h.services.annotation_moderation import AnnotationModerationService
 from h.services.annotation_moderation import annotation_moderation_service_factory
 
 
+class TestAnnotationModerationServiceHidden(object):
+    def test_it_returns_true_for_moderated_annotation(self, svc, factories):
+        mod = factories.AnnotationModeration()
+
+        assert svc.hidden(mod.annotation.id) is True
+
+    def test_it_returns_false_for_non_moderated_annotation(self, svc, factories):
+        annotation = factories.Annotation()
+
+        assert svc.hidden(annotation.id) is False
+
+
 class TestAnnotationModerationServiceHide(object):
     def test_it_creates_annotation_moderation(self, svc, factories, db_session):
         annotation = factories.Annotation()
@@ -31,10 +43,6 @@ class TestAnnotationModerationServiceHide(object):
 
         assert count == 1
 
-    @pytest.fixture
-    def svc(self, db_session):
-        return AnnotationModerationService(db_session)
-
 
 class TestAnnotationNipsaServiceFactory(object):
     def test_it_returns_service(self, pyramid_request):
@@ -44,3 +52,8 @@ class TestAnnotationNipsaServiceFactory(object):
     def test_it_provides_request_db_as_session(self, pyramid_request):
         svc = annotation_moderation_service_factory(None, pyramid_request)
         assert svc.session == pyramid_request.db
+
+
+@pytest.fixture
+def svc(db_session):
+    return AnnotationModerationService(db_session)


### PR DESCRIPTION
This is part of hypothesis/product-backlog#239

For now, this is done the same way we already check if the user is
nipsa'd, and then add a `"nipsa": true` item to the search index
payload.

Ideally, we would also get rid of the `AnnotationTransformEvent` system
and build on top of the recently introduced formatters (or something
similar to that). But since the card for annotation moderation is
already quite big I've opted for extending the current system instead.