### PR TITLE
Document CLIENT_URL

### DIFF
--- a/docs/developing/envvars.rst
+++ b/docs/developing/envvars.rst
@@ -1,0 +1,10 @@
+Environment Variables
+=====================
+
+This section documents the environment variables supported by h.
+
+.. envvar:: CLIENT_URL
+
+   The URL at which the Hypothesis client code is hosted.
+   This is the URL to the client entrypoint script, by default
+   https://cdn.hypothes.is/hypothesis.

--- a/docs/developing/index.rst
+++ b/docs/developing/index.rst
@@ -17,3 +17,4 @@ and how to contribute code or documentation to the project.
    documentation
    ssl
    making-changes-to-model-code
+   envvars


### PR DESCRIPTION
And start a page at which more environment variables can also be
documented.

This allows any page of the docs to link to an env var like this:

```
See the :envvar:`CLIENT_URL` env var.
```

This will:

1. Render the envvar mention as a `<code class="std-envvar">`
   (among other CSS classes), this is then styled specially by the
   Sphinx theme

2. Automatically hyperlink it to the env var's definition on the
   env vars page

3. Generate a warning if an envvar with that name isn't defined
   (if the -n arg to sphinx-build is used)

I think this will also allow docs in the client repo to link to env vars
defined in the h repo docs in this way too, because we have intersphinx
set up (there's already a couple of CLIENT_URL references in the client
docs).

In the future we might be able to use Sphinx's autodoc extension to
generate this envvars page from docstrings in the code.