### PR TITLE
Use flag service for annotation flag formatter

### DIFF
--- a/h/services/annotation_json_presentation.py
+++ b/h/services/annotation_json_presentation.py
@@ -14,13 +14,13 @@ from h.interfaces import IGroupService
 
 
 class AnnotationJSONPresentationService(object):
-    def __init__(self, session, user, group_svc, links_svc):
+    def __init__(self, session, user, group_svc, links_svc, flag_svc):
         self.session = session
         self.group_svc = group_svc
         self.links_svc = links_svc
 
         self.formatters = [
-            formatters.AnnotationFlagFormatter(self.session, user)
+            formatters.AnnotationFlagFormatter(flag_svc, user)
         ]
 
     def present(self, annotation_resource):
@@ -55,7 +55,9 @@ class AnnotationJSONPresentationService(object):
 def annotation_json_presentation_service_factory(context, request):
     group_svc = request.find_service(IGroupService)
     links_svc = request.find_service(name='links')
+    flag_svc = request.find_service(name='flag')
     return AnnotationJSONPresentationService(session=request.db,
                                              user=request.user,
                                              group_svc=group_svc,
-                                             links_svc=links_svc)
+                                             links_svc=links_svc,
+                                             flag_svc=flag_svc)

--- a/h/services/flag.py
+++ b/h/services/flag.py
@@ -28,6 +28,25 @@ class FlagService(object):
         query = self.session.query(models.Flag).filter_by(user=user, annotation=annotation)
         return query.count() > 0
 
+    def all_flagged(self, user, annotation_ids):
+        """
+        Check which of the given annotation IDs the given user has flagged.
+
+        :param user: The user to check for a flag.
+        :type user: h.models.User
+
+        :param annotation_ids: The IDs of the annotations to check.
+        :type annotation_ids: sequence of unicode
+
+        :returns The subset of the IDs that the given user has flagged.
+        :rtype set of unicode
+        """
+        query = self.session.query(models.Flag.annotation_id) \
+                            .filter(models.Flag.annotation_id.in_(annotation_ids),
+                                    models.Flag.user == user)
+
+        return set([f.annotation_id for f in query])
+
     def create(self, user, annotation):
         """
         Create a flag for the given user and annotation.

--- a/h/services/flag.py
+++ b/h/services/flag.py
@@ -41,6 +41,11 @@ class FlagService(object):
         :returns The subset of the IDs that the given user has flagged.
         :rtype set of unicode
         """
+        # SQLAlchemy doesn't behave in the way we might expect when handed an
+        # `in_` condition with an empty sequence
+        if not annotation_ids:
+            return set()
+
         query = self.session.query(models.Flag.annotation_id) \
                             .filter(models.Flag.annotation_id.in_(annotation_ids),
                                     models.Flag.user == user)

--- a/tests/h/formatters/annotation_flag_test.py
+++ b/tests/h/formatters/annotation_flag_test.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 import pytest
 
 from h.formatters.annotation_flag import AnnotationFlagFormatter
+from h.services.flag import FlagService
 
 
 class TestAnnotationFlagFormatter(object):
@@ -45,8 +46,12 @@ class TestAnnotationFlagFormatter(object):
         return factories.User()
 
     @pytest.fixture
-    def formatter(self, db_session, current_user):
-        return AnnotationFlagFormatter(db_session, current_user)
+    def formatter(self, flag_service, current_user):
+        return AnnotationFlagFormatter(flag_service, current_user)
+
+    @pytest.fixture
+    def flag_service(self, db_session):
+        return FlagService(db_session)
 
     @pytest.fixture
     def flags(self, factories, current_user, other_user):

--- a/tests/h/services/annotation_json_presentation_test.py
+++ b/tests/h/services/annotation_json_presentation_test.py
@@ -16,16 +16,18 @@ class TestAnnotationJSONPresentationService(object):
         AnnotationJSONPresentationService(session=mock.sentinel.session,
                                           user=mock.sentinel.user,
                                           group_svc=mock.sentinel.group_svc,
-                                          links_svc=mock.sentinel.links_svc)
+                                          links_svc=mock.sentinel.links_svc,
+                                          flag_svc=mock.sentinel.flag_svc)
 
-        formatters.AnnotationFlagFormatter.assert_called_once_with(mock.sentinel.session,
+        formatters.AnnotationFlagFormatter.assert_called_once_with(mock.sentinel.flag_svc,
                                                                    mock.sentinel.user)
 
     def test_it_configures_flag_formatter(self, formatters):
         svc = AnnotationJSONPresentationService(session=mock.sentinel.session,
                                                 user=mock.sentinel.user,
                                                 group_svc=mock.sentinel.group_svc,
-                                                links_svc=mock.sentinel.links_svc)
+                                                links_svc=mock.sentinel.links_svc,
+                                                flag_svc=mock.sentinel.flag_svc)
 
         assert formatters.AnnotationFlagFormatter.return_value in svc.formatters
 
@@ -89,10 +91,12 @@ class TestAnnotationJSONPresentationService(object):
     def svc(self, db_session):
         group_svc = mock.Mock()
         links_svc = mock.Mock()
+        flag_svc = mock.Mock()
         return AnnotationJSONPresentationService(session=db_session,
                                                  user=None,
                                                  group_svc=group_svc,
-                                                 links_svc=links_svc)
+                                                 links_svc=links_svc,
+                                                 flag_svc=flag_svc)
 
     @pytest.fixture
     def annotation_resource(self):
@@ -119,7 +123,7 @@ class TestAnnotationJSONPresentationService(object):
         return patch('h.services.annotation_json_presentation.formatters')
 
 
-@pytest.mark.usefixtures('group_svc', 'links_svc')
+@pytest.mark.usefixtures('group_svc', 'links_svc', 'flag_svc')
 class TestAnnotationJSONPresentationServiceFactory(object):
     def test_returns_service(self, pyramid_request):
         svc = annotation_json_presentation_service_factory(None, pyramid_request)
@@ -150,6 +154,12 @@ class TestAnnotationJSONPresentationServiceFactory(object):
         _, kwargs = service_class.call_args
         assert kwargs['links_svc'] == links_svc
 
+    def test_provides_flag_service(self, pyramid_request, service_class, flag_svc):
+        annotation_json_presentation_service_factory(None, pyramid_request)
+
+        _, kwargs = service_class.call_args
+        assert kwargs['flag_svc'] == flag_svc
+
     @pytest.fixture
     def service_class(self, patch):
         return patch('h.services.annotation_json_presentation.AnnotationJSONPresentationService')
@@ -164,6 +174,12 @@ class TestAnnotationJSONPresentationServiceFactory(object):
     def links_svc(self, pyramid_config):
         svc = mock.Mock()
         pyramid_config.register_service(svc, name='links')
+        return svc
+
+    @pytest.fixture
+    def flag_svc(self, pyramid_config):
+        svc = mock.Mock()
+        pyramid_config.register_service(svc, name='flag')
         return svc
 
     @pytest.fixture

--- a/tests/h/services/flag_test.py
+++ b/tests/h/services/flag_test.py
@@ -23,6 +23,23 @@ class TestFlagServiceFlagged(object):
 
         assert svc.flagged(user, annotation) is False
 
+    def test_it_lists_flagged_ids(self, svc, flags):
+        user = flags[-1].user
+
+        all_flagged = svc.all_flagged(user, [f.annotation_id for f in flags])
+
+        assert all_flagged == set([flags[-1].annotation_id])
+
+    @pytest.mark.usefixtures('flags')
+    def test_it_handles_all_flagged_with_no_ids(self, svc, factories):
+        user = factories.User()
+        assert svc.all_flagged(user, []) == set()
+
+    def test_it_handles_all_flagged_with_no_user(self, svc, flags):
+        annotation_ids = [f.annotation_id for f in flags]
+
+        assert svc.all_flagged(None, annotation_ids) == set()
+
     @pytest.fixture
     def flags(self, factories):
         return [factories.Flag() for _ in xrange(3)]


### PR DESCRIPTION
Now that we have a service to query for flag state, we can add a method to it to list subsets of flagged annotations and simplify the `AnnotationFlagFormatter`, removing its knowledge of the session and the model logic.

To make it clear that the behaviour of the formatter hasn't changed, I've left the tests as they are, and introduced a test dependency on the `FlagService`. This might be something to simplify in a later commit, faking out the `FlagService`, or it may be worth leaving in place to function as an integration test.