### PR TITLE
Use factory_boy's `create_batch` method

### DIFF
--- a/tests/h/activity/query_test.py
+++ b/tests/h/activity/query_test.py
@@ -583,7 +583,7 @@ class TestExecute(object):
 
 class TestFetchAnnotations(object):
     def test_it_returns_annotations_by_ids(self, db_session, factories):
-        annotations = [factories.Annotation() for _ in xrange(3)]
+        annotations = factories.Annotation.create_batch(3)
         ids = [a.id for a in annotations]
 
         result = fetch_annotations(db_session, ids)

--- a/tests/h/formatters/annotation_flag_test.py
+++ b/tests/h/formatters/annotation_flag_test.py
@@ -51,6 +51,6 @@ class TestAnnotationFlagFormatter(object):
     @pytest.fixture
     def flags(self, factories, current_user, other_user):
         return {
-            current_user: [factories.Flag(user=current_user) for _ in range(3)],
-            other_user: [factories.Flag(user=other_user) for _ in range(2)],
+            current_user: factories.Flag.create_batch(3, user=current_user),
+            other_user: factories.Flag.create_batch(2, user=other_user),
         }

--- a/tests/h/services/flag_test.py
+++ b/tests/h/services/flag_test.py
@@ -25,7 +25,7 @@ class TestFlagServiceFlagged(object):
 
     @pytest.fixture
     def flags(self, factories):
-        return [factories.Flag() for _ in xrange(3)]
+        return factories.Flag.create_batch(3)
 
 
 class TestFlagServiceCreate(object):


### PR DESCRIPTION
This seems to show the intent more clearly than list comprehensions, and also means we don't need to think about `range` versus `xrange`.

I left one instance in place in `tests/h/services/rename_user_test.py`, because that was also extracting the ids from the objects it created, so we were going to need a list comprehension anyway.