### PR TITLE
Add unhide annotation endpoint

### DIFF
--- a/h/services/annotation_moderation.py
+++ b/h/services/annotation_moderation.py
@@ -43,6 +43,20 @@ class AnnotationModerationService(object):
         mod = models.AnnotationModeration(annotation=annotation)
         self.session.add(mod)
 
+    def unhide(self, annotation):
+        """
+        Show a hidden annotation again to other users.
+
+        In case the given annotation is not moderated, this method is a no-op.
+
+        :param annotation: The annotation to unhide.
+        :type annotation: h.models.Annotation
+        """
+
+        self.session.query(models.AnnotationModeration) \
+                    .filter_by(annotation=annotation) \
+                    .delete()
+
 
 def annotation_moderation_service_factory(context, request):
     return AnnotationModerationService(request.db)

--- a/h/views/api_moderation.py
+++ b/h/views/api_moderation.py
@@ -25,3 +25,21 @@ def create(context, request):
     request.notify_after_commit(event)
 
     return HTTPNoContent()
+
+
+@api_config(route_name='api.annotation_hide',
+            request_method='DELETE',
+            link_name='annotation.unhide',
+            description='Unhide an annotation as a group moderator.',
+            effective_principals=security.Authenticated)
+def delete(context, request):
+    if not request.has_permission('admin', context.group):
+        raise HTTPNotFound()
+
+    svc = request.find_service(name='annotation_moderation')
+    svc.unhide(context.annotation)
+
+    event = events.AnnotationEvent(request, context.annotation.id, 'update')
+    request.notify_after_commit(event)
+
+    return HTTPNoContent()

--- a/tests/h/services/annotation_moderation_test.py
+++ b/tests/h/services/annotation_moderation_test.py
@@ -44,6 +44,30 @@ class TestAnnotationModerationServiceHide(object):
         assert count == 1
 
 
+class TestAnnotationModerationServiceUnhide(object):
+    def test_it_unhides_given_annotation(self, svc, factories, db_session):
+        mod = factories.AnnotationModeration()
+        annotation = mod.annotation
+
+        svc.unhide(annotation)
+
+        assert svc.hidden(annotation.id) is False
+
+    def test_it_leaves_othes_annotations_hidden(self, svc, factories, db_session):
+        mod1, mod2 = factories.AnnotationModeration(), factories.AnnotationModeration()
+
+        svc.unhide(mod1.annotation)
+
+        assert svc.hidden(mod2.annotation.id) is True
+
+    def test_it_skips_hiding_annotation_when_not_hidden(self, svc, factories, db_session):
+        annotation = factories.Annotation()
+
+        svc.unhide(annotation)
+
+        assert svc.hidden(annotation.id) is False
+
+
 class TestAnnotationNipsaServiceFactory(object):
     def test_it_returns_service(self, pyramid_request):
         svc = annotation_moderation_service_factory(None, pyramid_request)

--- a/tests/h/views/api_moderation_test.py
+++ b/tests/h/views/api_moderation_test.py
@@ -39,27 +39,62 @@ class TestCreate(object):
         with pytest.raises(HTTPNotFound):
             views.create(resource, pyramid_request)
 
-    @pytest.fixture
-    def resource(self):
-        return mock.Mock(spec_set=['annotation', 'group'])
 
-    @pytest.fixture
-    def moderation_service(self, pyramid_config):
-        svc = mock.Mock(spec_set=['hide'])
-        pyramid_config.register_service(svc, name='annotation_moderation')
-        return svc
+@pytest.mark.usefixtures('moderation_service', 'has_permission')
+class TestDelete(object):
+    def test_it_unhides_the_annotation(self, pyramid_request, resource, moderation_service):
+        views.delete(resource, pyramid_request)
 
-    @pytest.fixture
-    def has_permission(self, pyramid_request):
-        func = mock.Mock(return_value=True)
-        pyramid_request.has_permission = func
-        return func
+        moderation_service.unhide.assert_called_once_with(resource.annotation)
 
-    @pytest.fixture
-    def events(self, patch):
-        return patch('h.views.api_moderation.events')
+    def test_it_publishes_update_event(self, pyramid_request, resource, events):
+        views.delete(resource, pyramid_request)
 
-    @pytest.fixture
-    def pyramid_request(self, pyramid_request):
-        pyramid_request.notify_after_commit = mock.Mock()
-        return pyramid_request
+        events.AnnotationEvent.assert_called_once_with(
+            pyramid_request, resource.annotation.id, 'update')
+
+        pyramid_request.notify_after_commit.assert_called_once_with(
+            events.AnnotationEvent.return_value)
+
+    def test_it_renders_no_content(self, pyramid_request, resource):
+        response = views.delete(resource, pyramid_request)
+        assert isinstance(response, HTTPNoContent)
+
+    def test_it_checks_for_group_admin_permission(self, pyramid_request, resource):
+        views.delete(resource, pyramid_request)
+        pyramid_request.has_permission.assert_called_once_with('admin', resource.group)
+
+    def test_it_responds_with_not_found_when_no_admin_access_in_group(self, pyramid_request, resource):
+        pyramid_request.has_permission.return_value = False
+        with pytest.raises(HTTPNotFound):
+            views.delete(resource, pyramid_request)
+
+
+@pytest.fixture
+def resource():
+    return mock.Mock(spec_set=['annotation', 'group'])
+
+
+@pytest.fixture
+def moderation_service(pyramid_config):
+    svc = mock.Mock(spec_set=['hide', 'unhide'])
+    pyramid_config.register_service(svc, name='annotation_moderation')
+    return svc
+
+
+@pytest.fixture
+def has_permission(pyramid_request):
+    func = mock.Mock(return_value=True)
+    pyramid_request.has_permission = func
+    return func
+
+
+@pytest.fixture
+def events(patch):
+    return patch('h.views.api_moderation.events')
+
+
+@pytest.fixture
+def pyramid_request(pyramid_request):
+    pyramid_request.notify_after_commit = mock.Mock()
+    return pyramid_request


### PR DESCRIPTION
~This is based on #4473 and needs a rebase once that one is merged.~

This adds the `DELETE /api/annotations/<annid>/hide` endpoint, which
removes the moderation of the given annotation, effectively showing the
annotation to all group readers again.

See hypothesis/product-backlog#240 for the sprint card.