### PR TITLE
Pin pyramid_authsanity to git master

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -23,7 +23,9 @@ passlib
 psycogreen
 psycopg2
 pyramid
-pyramid_authsanity
+# Pin pyramid_authsanity to latest master until our bugfix
+# (https://github.com/usingnamespace/pyramid_authsanity/pull/7) is released.
+git+https://github.com/usingnamespace/pyramid_authsanity.git@7d0b70582cd693052a62b4683e521c1f4e2b4aa8#egg=pyramid_authsanity
 pyramid_layout
 pyramid-jinja2
 pyramid-services

--- a/requirements.txt
+++ b/requirements.txt
@@ -51,7 +51,7 @@ pyasn1==0.1.9             # via cryptography
 pycparser==2.14           # via cffi
 PyJWT==1.4.1
 pyparsing==2.1.5
-pyramid-authsanity==0.1.0a4
+git+https://github.com/usingnamespace/pyramid_authsanity.git@7d0b70582cd693052a62b4683e521c1f4e2b4aa8#egg=pyramid_authsanity
 pyramid-jinja2==2.6.2
 pyramid-layout==1.0
 pyramid-mailer==0.14.1


### PR DESCRIPTION
Until upstream cuts a release of pyramid_authsanity which includes our fixes for an IE11 cookie removal bug.

This should fix https://sentry.io/hypothesis/h/issues/164510958/.