### PR TITLE
Upgrade pyramid_mailer and repoze.sendmail

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -40,8 +40,4 @@ wsaccel
 ws4py
 zope.sqlalchemy
 
-# Version pin for known bug
-# https://github.com/repoze/repoze.sendmail/issues/31
-repoze.sendmail < 4.2
-
 -e .  # memex

--- a/requirements.txt
+++ b/requirements.txt
@@ -54,7 +54,7 @@ pyparsing==2.1.5
 git+https://github.com/usingnamespace/pyramid_authsanity.git@7d0b70582cd693052a62b4683e521c1f4e2b4aa8#egg=pyramid_authsanity
 pyramid-jinja2==2.6.2
 pyramid-layout==1.0
-pyramid-mailer==0.14.1
+pyramid-mailer==0.15.1
 pyramid-services==0.4
 pyramid-tm==1.1.1
 pyramid==1.7.3
@@ -64,13 +64,13 @@ python-slugify==1.1.4
 pytz==2016.6.1            # via celery
 raven==6.0.0
 repoze.lru==0.6           # via pyramid
-repoze.sendmail==4.1
+repoze.sendmail==4.3      # via pyramid-mailer
 requests-aws4auth==0.9
 requests==2.13.0          # via requests-aws4auth
 six==1.10.0               # via bcrypt, bleach, cryptography, html5lib, python-dateutil
 sqlalchemy==1.1.4
 statsd==3.2.1
-transaction==2.0.3        # via pyramid-tm, repoze.sendmail, zope.sqlalchemy
+transaction==2.1.2        # via pyramid-mailer, pyramid-tm, repoze.sendmail, zope.sqlalchemy
 translationstring==1.3    # via colander, deform, pyramid
 unicodecsv==0.14.1
 unidecode==0.4.19         # via python-slugify


### PR DESCRIPTION
A long-standing bug in repoze.sendmail has now been fixed (https://github.com/repoze/repoze.sendmail/pull/38), which means we can finally remove our version pin for this package.