### PR TITLE
Upgrade to passlib 1.7

### DIFF
--- a/h/services/user_password.py
+++ b/h/services/user_password.py
@@ -57,7 +57,7 @@ class UserPasswordService(object):
         # Remove any existing explicit salt (the password context salts the
         # password automatically).
         user.salt = None
-        user.password = text_type(self.hasher.encrypt(new_password))
+        user.password = text_type(self.hasher.hash(new_password))
         user.password_updated = datetime.datetime.utcnow()
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ alembic==0.8.7
 amqp==1.4.9               # via kombu
 anyjson==0.3.3            # via kombu
 backports.functools-lru-cache==1.2.1
-bcrypt==3.1.0
+bcrypt==3.1.3
 billiard==3.3.0.23        # via celery
 bleach==1.4.3
 celery==3.1.25
@@ -42,7 +42,7 @@ mako==1.0.4               # via alembic
 markupsafe==0.23          # via jinja2, mako, pyramid-jinja2
 mistune==0.7.3
 newrelic==2.68.0.50
-passlib==1.6.5
+passlib==1.7.1
 pastedeploy==1.5.2        # via pyramid
 peppercorn==0.5           # via deform
 psycogreen==1.0

--- a/tests/h/services/user_password_test.py
+++ b/tests/h/services/user_password_test.py
@@ -30,7 +30,7 @@ class TestUserPasswordService(object):
 
     def test_check_password_validates_old_style_passwords(self, svc, user):
         user.salt = 'somesalt'
-        # Generated with passlib.hash.bcrypt.encrypt('foobar' + 'somesalt', rounds=4)
+        # Generated with passlib.hash.bcrypt.hash('foobar' + 'somesalt', rounds=4)
         user.password = '$2a$04$zDQnlV/YBG.ju2i14V15p.5nWYL52ZBqjGsBWgLAisGkEJw812BHy'
 
         assert not svc.check_password(user, 'somethingelse')
@@ -38,7 +38,7 @@ class TestUserPasswordService(object):
 
     def test_check_password_upgrades_old_style_passwords(self, hasher, svc, user):
         user.salt = 'somesalt'
-        # Generated with passlib.hash.bcrypt.encrypt('foobar' + 'somesalt', rounds=4)
+        # Generated with passlib.hash.bcrypt.hash('foobar' + 'somesalt', rounds=4)
         user.password = '$2a$04$zDQnlV/YBG.ju2i14V15p.5nWYL52ZBqjGsBWgLAisGkEJw812BHy'
 
         svc.check_password(user, 'foobar')
@@ -48,7 +48,7 @@ class TestUserPasswordService(object):
 
     def test_check_password_only_upgrades_when_password_is_correct(self, hasher, svc, user):
         user.salt = 'somesalt'
-        # Generated with passlib.hash.bcrypt.encrypt('foobar' + 'somesalt', rounds=4)
+        # Generated with passlib.hash.bcrypt.hash('foobar' + 'somesalt', rounds=4)
         user.password = '$2a$04$zDQnlV/YBG.ju2i14V15p.5nWYL52ZBqjGsBWgLAisGkEJw812BHy'
 
         svc.check_password(user, 'donkeys')
@@ -58,7 +58,7 @@ class TestUserPasswordService(object):
 
     def test_check_password_works_after_upgrade(self, svc, user):
         user.salt = 'somesalt'
-        # Generated with passlib.hash.bcrypt.encrypt('foobar' + 'somesalt', rounds=4)
+        # Generated with passlib.hash.bcrypt.hash('foobar' + 'somesalt', rounds=4)
         user.password = '$2a$04$zDQnlV/YBG.ju2i14V15p.5nWYL52ZBqjGsBWgLAisGkEJw812BHy'
 
         svc.check_password(user, 'foobar')
@@ -66,7 +66,7 @@ class TestUserPasswordService(object):
         assert svc.check_password(user, 'foobar')
 
     def test_check_password_upgrades_new_style_passwords(self, hasher, svc, user):
-        # Generated with passlib.hash.bcrypt.encrypt('foobar', rounds=4, ident='2b')
+        # Generated with passlib.hash.bcrypt.hash('foobar', rounds=4, ident='2b')
         user.password = '$2b$04$L2j.vXxlLt9JJNHHsy0EguslcaphW7vssSpHbhqCmf9ECsMiuTd1y'
 
         svc.check_password(user, 'foobar')


### PR DESCRIPTION
Upgrade to the latest passlib, mainly to ensure that we're staying current with security-critical libraries.

There are two changes that may affect us in 1.7:

- PasswordHash (and, by extension, CryptContext) objects deprecate the `encrypt()` method in favour of the identical but better-named `hash()` method. This change is applied to our code in this commit.
- Support for the Argon2 password hash, which is both memory- and CPU-hard. Our CryptContext hasn't changed here, but we are likely to add support for Argon2 hashing of passwords.