### PR TITLE
Upgrade to cryptography 1.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@
 alembic==0.8.7
 amqp==1.4.9               # via kombu
 anyjson==0.3.3            # via kombu
+asn1crypto==0.22.0        # via cryptography
 backports.functools-lru-cache==1.2.1
 bcrypt==3.1.3
 billiard==3.3.0.23        # via celery
@@ -20,7 +21,7 @@ chameleon==2.24           # via deform
 click==6.6
 colander==1.3.1           # via deform
 contextlib2==0.5.4        # via raven
-cryptography==1.4
+cryptography==1.8.1
 deform-jinja2==0.5
 deform==0.9.9
 elasticsearch==1.9.0
@@ -30,8 +31,8 @@ gevent==1.1.2
 greenlet==0.4.10          # via gevent
 gunicorn==19.6.0
 html5lib==0.9999999       # via bleach
-idna==2.1                 # via cryptography
-ipaddress==1.0.16         # via cryptography
+idna==2.5                 # via cryptography
+ipaddress==1.0.18         # via cryptography
 iso8601==0.1.11           # via colander
 itsdangerous==0.24
 jinja2==2.8               # via deform-jinja2, pyramid-jinja2
@@ -42,16 +43,16 @@ mako==1.0.4               # via alembic
 markupsafe==0.23          # via jinja2, mako, pyramid-jinja2
 mistune==0.7.3
 newrelic==2.68.0.50
+packaging==16.8           # via cryptography
 passlib==1.7.1
 pastedeploy==1.5.2        # via pyramid
 peppercorn==0.5           # via deform
 psycogreen==1.0
 psycopg2==2.6.2
-pyasn1==0.1.9             # via cryptography
 pycparser==2.14           # via cffi
 pyjwt==1.4.1
-pyparsing==2.1.5
 git+https://github.com/usingnamespace/pyramid_authsanity.git@7d0b70582cd693052a62b4683e521c1f4e2b4aa8#egg=pyramid_authsanity
+pyparsing==2.1.10         # via packaging
 pyramid-jinja2==2.6.2
 pyramid-layout==1.0
 pyramid-mailer==0.15.1
@@ -67,7 +68,7 @@ repoze.lru==0.6           # via pyramid
 repoze.sendmail==4.3      # via pyramid-mailer
 requests-aws4auth==0.9
 requests==2.13.0          # via requests-aws4auth
-six==1.10.0               # via bcrypt, bleach, cryptography, html5lib, python-dateutil
+six==1.10.0               # via bcrypt, bleach, cryptography, html5lib, packaging, python-dateutil
 sqlalchemy==1.1.4
 statsd==3.2.1
 transaction==2.1.2        # via pyramid-mailer, pyramid-tm, repoze.sendmail, zope.sqlalchemy


### PR DESCRIPTION
Upgrade to the latest cryptography, mainly to ensure that we're staying current with security-critical libraries.

In particular, we appear to have entirely missed that cryptography 1.5.3 contained a security fix for an issue with HKDF, which we use for key derivation (CVE-2016-9243).