### PR TITLE
Ignore pidfiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,8 +24,8 @@ node_modules/
 *.pyc
 *.pyo
 
+*.pid
 *.log
 
 celerybeat-schedule
 celerybeat-schedule.*
-celerybeat.pid


### PR DESCRIPTION
Instances in production are reporting their version numbers as ".dirty" because of nginx and supervisor pidfiles which are placed in the root of the repository.

Ignore "*.pid" so that pidfiles don't contribute to the version dirty state.