### PR TITLE
Upgrade bleach and html5lib

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ asn1crypto==0.22.0        # via cryptography
 backports.functools-lru-cache==1.2.1
 bcrypt==3.1.3
 billiard==3.3.0.23        # via celery
-bleach==1.4.3
+bleach==2.0.0
 celery==3.1.25
 certifi==2016.2.28
 cffi==1.7.0
@@ -30,7 +30,7 @@ functools32==3.2.3.post2  # via jsonschema
 gevent==1.2.1
 greenlet==0.4.10          # via gevent
 gunicorn==19.6.0
-html5lib==0.9999999       # via bleach
+html5lib==0.999999999     # via bleach
 idna==2.5                 # via cryptography
 ipaddress==1.0.18         # via cryptography
 iso8601==0.1.11           # via colander

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ CLASSIFIERS = [
 INSTALL_REQUIRES = [
     'Jinja2>=2.8',
     'SQLAlchemy>=1.1.0',
-    'bleach>=1.4.3,<1.5',
+    'bleach>=2.0,<2.1',
     'certifi',
     'elasticsearch>=1.1.0,<2.0.0',
     'jsonschema>=2.5.1,<2.6',

--- a/tests/memex/markdown_test.py
+++ b/tests/memex/markdown_test.py
@@ -36,6 +36,8 @@ class TestRender(object):
 class TestSanitize(object):
     @pytest.mark.parametrize("text,expected", [
         ('<a href="https://example.org">example</a>', '<a href="https://example.org" rel="nofollow noopener" target="_blank">example</a>'),
+        # Don't add rel and target attrs to mailto: links
+        ('<a href="mailto:foo@example.net">example</a>', None),
         ('<a title="foobar">example</a>', None),
         ('<a href="https://example.org" rel="nofollow noopener" target="_blank" title="foobar">example</a>', None),
         ('<blockquote>Foobar</blockquote>', None),


### PR DESCRIPTION
html5lib before 0.99999999 (eight nines) has a couple of XSS vulnerabilities (CVE-2016-9909 and CVE-2016-9910).

Upgrading to the latest html5lib (0.999999999, nine nines) requires that we upgrade bleach to 2.0.0, which in turn requires a few small changes in our code that integrates with bleach. These include:

- attribute filter callables now always take the tag name as the first parameter
- linkify callbacks now expose attributes as a dictionary of _namespaced_ attributes, so we have to use tuples as keys into the dictionary rather than simple strings

At the same time, it made sense to use the Cleaner and LinkifyFilter classes, new in 2.0, which make it possible to configure sanitisation and linkification once and reuse the configuration for each string to be sanitised.