### PR TITLE
Return hidden annotation for group creators

### DIFF
--- a/h/services/group.py
+++ b/h/services/group.py
@@ -112,6 +112,17 @@ class GroupService(object):
 
         return ids
 
+    def groupids_created_by(self, user):
+        """
+        Return a list of pubids which the user created.
+
+        If the passed-in user is ``None``, this returns an empty list.
+        """
+        if user is None:
+            return []
+
+        return [g.pubid for g in self.session.query(Group.pubid).filter_by(creator=user)]
+
 
 def groups_factory(context, request):
     """Return a GroupService instance for the passed context and request."""

--- a/tests/h/nipsa/search_test.py
+++ b/tests/h/nipsa/search_test.py
@@ -1,11 +1,51 @@
 # -*- coding: utf-8 -*-
 
+import mock
+import pytest
+
 from h.nipsa import search
 
 
-def test_nipsa_filter_filters_out_nipsad_annotations():
+@pytest.mark.usefixtures('group_service')
+class TestFilter(object):
+    def test_call_returns_nipsa_filter(self, pyramid_request, nipsa_filter):
+        f = search.Filter(pyramid_request)
+
+        assert f({}) == nipsa_filter.return_value
+
+    def test_call_passes_group_service(self, pyramid_request, nipsa_filter, group_service):
+        f = search.Filter(pyramid_request)
+
+        f({})
+
+        nipsa_filter.assert_called_once_with(group_service, mock.ANY)
+
+    def test_call_passes_request_user(self, pyramid_request, nipsa_filter):
+        f = search.Filter(pyramid_request)
+
+        f({})
+
+        nipsa_filter.assert_called_once_with(mock.ANY, pyramid_request.user)
+
+    @pytest.fixture
+    def group_service(self, pyramid_config):
+        svc = mock.Mock()
+        pyramid_config.register_service(svc, name='group')
+        return svc
+
+    @pytest.fixture
+    def pyramid_request(self, pyramid_request):
+        pyramid_request.user = mock.Mock()
+        return pyramid_request
+
+    @pytest.fixture
+    def nipsa_filter(self, patch):
+        return patch('h.nipsa.search.nipsa_filter')
+
+
+def test_nipsa_filter_filters_out_nipsad_annotations(group_service):
     """nipsa_filter() filters out annotations with "nipsa": True."""
-    assert search.nipsa_filter() == {
+    assert search.nipsa_filter(group_service) == {
         "bool": {
             "should": [
                 {'not': {'term': {'nipsa': True}}}
@@ -14,18 +54,29 @@ def test_nipsa_filter_filters_out_nipsad_annotations():
     }
 
 
-def test_nipsa_filter_users_own_annotations_are_not_filtered():
-    filter_ = search.nipsa_filter(userid="fred")
+def test_nipsa_filter_users_own_annotations_are_not_filtered(group_service, user):
+    filter_ = search.nipsa_filter(group_service, user)
 
     assert {'term': {'user': 'fred'}} in (
         filter_["bool"]["should"])
 
 
-def test_nipsa_filter_coerces_userid_to_lowercase():
-    filter_ = search.nipsa_filter(userid="DonkeyNose")
+def test_nipsa_filter_coerces_userid_to_lowercase(group_service, user):
+    user.userid = 'DonkeyNose'
+
+    filter_ = search.nipsa_filter(group_service, user)
 
     assert {'term': {'user': 'donkeynose'}} in (
         filter_["bool"]["should"])
+
+
+def test_nipsa_filter_group_annotations_not_filtered_for_creator(group_service, user):
+    group_service.groupids_created_by.return_value = ['pubid-1', 'pubid-4', 'pubid-3']
+
+    filter_ = search.nipsa_filter(group_service, user)
+
+    assert {'terms': {'group': ['pubid-1', 'pubid-4', 'pubid-3']}} in (
+        filter_['bool']['should'])
 
 
 def test_nipsad_annotations_filters_by_userid():
@@ -62,3 +113,15 @@ def test_not_nipsad_annotations_filters_by_nipsa():
     must_clauses = query["query"]["filtered"]["filter"]["bool"]["must"]
     assert {"not": {"term": {"nipsa": True}}} in (
         must_clauses)
+
+
+@pytest.fixture
+def user():
+    return mock.Mock(userid='fred')
+
+
+@pytest.fixture
+def group_service():
+    svc = mock.Mock(spec_set=['groupids_created_by'])
+    svc.groupids_created_by.return_value = []
+    return svc

--- a/tests/h/services/group_test.py
+++ b/tests/h/services/group_test.py
@@ -196,6 +196,24 @@ class TestGroupService(object):
 
         assert group.pubid in service.groupids_readable_by(user)
 
+    def test_groupids_created_by_includes_created_groups(self, service, factories):
+        user = factories.User()
+        group = factories.Group(creator=user)
+
+        assert group.pubid in service.groupids_created_by(user)
+
+    def test_groupids_created_by_excludes_other_groups(self, service, db_session, factories):
+        user = factories.User()
+        private_group = factories.Group()
+        private_group.members.append(user)
+        factories.Group(readable_by=ReadableBy.world)
+        db_session.flush()
+
+        assert service.groupids_created_by(user) == []
+
+    def test_groupids_created_by_returns_empty_list_for_missing_user(self, service):
+        assert service.groupids_created_by(None) == []
+
     @pytest.fixture
     def group(self, users):
         return Group(name='Donkey Trust',


### PR DESCRIPTION
Group creators will see annotations that have been hidden in their
groups, we do this by adding another clause to the nipsa filter where we
check the group pubids that the current user created.