### PR TITLE
Show flag summary information to group moderators

### DIFF
--- a/h/formatters/__init__.py
+++ b/h/formatters/__init__.py
@@ -4,8 +4,10 @@ from __future__ import unicode_literals
 
 from h.formatters.annotation_flag import AnnotationFlagFormatter
 from h.formatters.annotation_hidden import AnnotationHiddenFormatter
+from h.formatters.annotation_moderation import AnnotationModerationFormatter
 
 __all__ = (
     'AnnotationFlagFormatter',
     'AnnotationHiddenFormatter',
+    'AnnotationModerationFormatter',
 )

--- a/h/formatters/annotation_moderation.py
+++ b/h/formatters/annotation_moderation.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import sqlalchemy as sa
+from zope.interface import implementer
+
+from h import models
+from h.formatters.interfaces import IAnnotationFormatter
+
+
+@implementer(IAnnotationFormatter)
+class AnnotationModerationFormatter(object):
+    """
+    Formatter for exposing an annotation's moderation information.
+
+    If the passed-in user has permission to hide the annotation (if they are a
+    moderator of the annotation's group, for instance), this formatter will
+    add a `moderation` key to the payload, with a count of how many users have
+    flagged the annotation.
+    """
+
+    def __init__(self, session, user, has_permission):
+        self._session = session
+        self._user = user
+        self._has_permission = has_permission
+
+        # Local cache of flag counts. We don't need to care about detached
+        # instances because we only store the annotation id and a count.
+        self._cache = {}
+
+    def preload(self, ids):
+        if self._user is None:
+            return
+
+        if not ids:
+            return
+
+        query = self._session.query(sa.func.count(models.Flag.id).label('flag_count'),
+                                    models.Flag.annotation_id) \
+                             .filter(models.Flag.annotation_id.in_(ids)) \
+                             .group_by(models.Flag.annotation_id)
+
+        flag_counts = {f.annotation_id: f.flag_count for f in query}
+        missing_ids = set(ids) - set(flag_counts.keys())
+        flag_counts.update({id_: 0 for id_ in missing_ids})
+
+        self._cache.update(flag_counts)
+
+        return flag_counts
+
+    def format(self, annotation_resource):
+        if not self._has_permission('admin', annotation_resource.group):
+            return {}
+
+        flag_count = self._load(annotation_resource.annotation.id)
+        return {'moderation': {'flagCount': flag_count}}
+
+    def _load(self, id_):
+        if id_ in self._cache:
+            return self._cache[id_]
+
+        flag_count = self._session.query(sa.func.count(models.Flag.id)) \
+                                  .filter_by(annotation_id=id_) \
+                                  .scalar()
+        self._cache[id_] = flag_count
+        return flag_count

--- a/h/services/annotation_json_presentation.py
+++ b/h/services/annotation_json_presentation.py
@@ -13,14 +13,15 @@ from h.interfaces import IGroupService
 
 
 class AnnotationJSONPresentationService(object):
-    def __init__(self, session, user, group_svc, links_svc, flag_svc, moderation_svc):
+    def __init__(self, session, user, group_svc, links_svc, flag_svc, moderation_svc, has_permission):
         self.session = session
         self.group_svc = group_svc
         self.links_svc = links_svc
 
         self.formatters = [
             formatters.AnnotationFlagFormatter(flag_svc, user),
-            formatters.AnnotationHiddenFormatter(moderation_svc, user)
+            formatters.AnnotationHiddenFormatter(moderation_svc, user),
+            formatters.AnnotationModerationFormatter(self.session, user, has_permission)
         ]
 
     def present(self, annotation_resource):
@@ -62,4 +63,5 @@ def annotation_json_presentation_service_factory(context, request):
                                              group_svc=group_svc,
                                              links_svc=links_svc,
                                              flag_svc=flag_svc,
-                                             moderation_svc=moderation_svc)
+                                             moderation_svc=moderation_svc,
+                                             has_permission=request.has_permission)

--- a/tests/functional/test_moderation.py
+++ b/tests/functional/test_moderation.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import pytest
+
+
+@pytest.mark.functional
+class TestModeration(object):
+
+    def test_moderator_flag_listing(self, app, group, flagged_annotation, moderator_with_token):
+        moderator, token = moderator_with_token
+
+        headers = {'Authorization': str('Bearer {}'.format(token.value))}
+        annotation_url = '/api/annotations/{}'.format(flagged_annotation.id)
+        res = app.get(annotation_url, headers=headers)
+
+        assert 'moderation' in res.json
+        assert res.json['moderation']['flagCount'] > 0
+
+
+@pytest.fixture
+def group(db_session, factories, moderator):
+    group = factories.Group(creator=moderator)
+    db_session.commit()
+    return group
+
+
+@pytest.fixture
+def flagged_annotation(group, db_session, factories):
+    ann = factories.Annotation(groupid=group.pubid, shared=True)
+    factories.Flag(annotation=ann)
+    db_session.commit()
+    return ann
+
+
+@pytest.fixture
+def moderator(db_session, factories):
+    user = factories.User()
+    db_session.commit()
+    return user
+
+
+@pytest.fixture
+def moderator_with_token(moderator, db_session, factories):
+    token = factories.Token(userid=moderator.userid)
+    db_session.commit()
+    return (moderator, token)

--- a/tests/h/formatters/annotation_moderation_test.py
+++ b/tests/h/formatters/annotation_moderation_test.py
@@ -1,0 +1,113 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from collections import namedtuple
+
+import pytest
+
+from h.formatters.annotation_moderation import AnnotationModerationFormatter
+
+FakeAnnotationResource = namedtuple('FakeAnnotationResource',
+                                    ['annotation', 'group'])
+
+
+class FakePermissionCheck(object):
+
+    def __init__(self):
+        self._permissions = {}
+
+    def add_permission(self, permission, context, granted):
+        self._permissions[(permission, context)] = granted
+
+    def __call__(self, permission, context):
+        return self._permissions[(permission, context)]
+
+
+class TestAnnotationModerationFormatter(object):
+    def test_preload_sets_flag_counts(self, db_session, flagged, unflagged, user):
+        formatter = AnnotationModerationFormatter(db_session,
+                                                  user,
+                                                  has_permission=None)
+
+        preload = formatter.preload([flagged.id, unflagged.id])
+
+        assert preload == {flagged.id: 2, unflagged.id: 0}
+
+    def test_preload_skipped_without_user(self, db_session):
+        formatter = AnnotationModerationFormatter(db_session,
+                                                  user=None,
+                                                  has_permission=None)
+        assert formatter.preload(['annotation-id']) is None
+
+    def test_preload_skipped_without_ids(self, db_session, user):
+        formatter = AnnotationModerationFormatter(db_session,
+                                                  user,
+                                                  has_permission=None)
+        assert formatter.preload([]) is None
+
+    def test_format_returns_empty_for_non_moderator(self, db_session, user, group, flagged, permission_denied):
+        formatter = AnnotationModerationFormatter(db_session,
+                                                  user,
+                                                  permission_denied)
+        annotation_resource = FakeAnnotationResource(flagged, group)
+
+        assert formatter.format(annotation_resource) == {}
+
+    def test_format_returns_flag_count_for_moderator(self, db_session, user, group, flagged, permission_granted):
+        formatter = AnnotationModerationFormatter(db_session,
+                                                  user,
+                                                  permission_granted)
+        annotation_resource = FakeAnnotationResource(flagged, group)
+
+        output = formatter.format(annotation_resource)
+        assert output == {'moderation': {'flagCount': 2}}
+
+    def test_format_returns_zero_flag_count(self, db_session, user, group, unflagged, permission_granted):
+        formatter = AnnotationModerationFormatter(db_session,
+                                                  user,
+                                                  permission_granted)
+        annotation_resource = FakeAnnotationResource(unflagged, group)
+
+        output = formatter.format(annotation_resource)
+        assert output == {'moderation': {'flagCount': 0}}
+
+    def test_format_for_preloaded_annotation(self, db_session, user, group, flagged, permission_granted):
+        formatter = AnnotationModerationFormatter(db_session,
+                                                  user,
+                                                  permission_granted)
+        annotation_resource = FakeAnnotationResource(flagged, group)
+
+        formatter.preload([flagged.id])
+        output = formatter.format(annotation_resource)
+        assert output == {'moderation': {'flagCount': 2}}
+
+    @pytest.fixture
+    def user(self, factories):
+        return factories.User()
+
+    @pytest.fixture
+    def group(self, factories):
+        return factories.Group()
+
+    @pytest.fixture
+    def permission_granted(self, group):
+        has_permission = FakePermissionCheck()
+        has_permission.add_permission('admin', group, True)
+        return has_permission
+
+    @pytest.fixture
+    def permission_denied(self, group):
+        has_permission = FakePermissionCheck()
+        has_permission.add_permission('admin', group, False)
+        return has_permission
+
+    @pytest.fixture
+    def flagged(self, factories):
+        annotation = factories.Annotation()
+        factories.Flag.create_batch(2, annotation=annotation)
+        return annotation
+
+    @pytest.fixture
+    def unflagged(self, factories):
+        return factories.Annotation()

--- a/tests/h/services/annotation_json_presentation_test.py
+++ b/tests/h/services/annotation_json_presentation_test.py
@@ -30,6 +30,16 @@ class TestAnnotationJSONPresentationService(object):
         svc = self.svc(services)
         assert formatters.AnnotationHiddenFormatter.return_value in svc.formatters
 
+    def test_initializes_moderation_formatter(self, services, formatters):
+        self.svc(services)
+        formatters.AnnotationModerationFormatter.assert_called_once_with(mock.sentinel.db_session,
+                                                                         mock.sentinel.user,
+                                                                         mock.sentinel.has_permission)
+
+    def test_it_configures_moderation_formatter(self, services, formatters):
+        svc = self.svc(services)
+        assert formatters.AnnotationModerationFormatter.return_value in svc.formatters
+
     def test_present_inits_presenter(self, svc, presenters, annotation_resource):
         svc.present(annotation_resource)
 
@@ -93,7 +103,8 @@ class TestAnnotationJSONPresentationService(object):
                                                  group_svc=services['group'],
                                                  links_svc=services['links'],
                                                  flag_svc=services['flag'],
-                                                 moderation_svc=services['annotation_moderation'])
+                                                 moderation_svc=services['annotation_moderation'],
+                                                 has_permission=mock.sentinel.has_permission)
 
     @pytest.fixture
     def annotation_resource(self):
@@ -162,6 +173,12 @@ class TestAnnotationJSONPresentationServiceFactory(object):
 
         _, kwargs = service_class.call_args
         assert kwargs['moderation_svc'] == services['annotation_moderation']
+
+    def test_provides_has_permission(self, pyramid_request, service_class):
+        annotation_json_presentation_service_factory(None, pyramid_request)
+
+        _, kwargs = service_class.call_args
+        assert kwargs['has_permission'] == pyramid_request.has_permission
 
     @pytest.fixture
     def service_class(self, patch):


### PR DESCRIPTION
When presenting annotations for someone who is a moderator in their group, this will now include a `moderation` key in the annotation JSON. Currently it just shows the number of times each annotation has been flagged for the moderator’s attention.

My current plan:

- [x] Pull out the model logic into a service, akin to #4475 – this could go in a subsequent PR
- [x] Give the commits some hefty rejigging
- [x] Consider changing the name of the formatter class, since it could now be confused with the `AnnotationModeration` model
- [x] Decide whether to keep the functional test, remove it, or add to it

This work is for hypothesis/product-backlog#208.