### PR TITLE
Move memex.schemas to h.schemas.annotation

### DIFF
--- a/h/schemas/annotation.py
+++ b/h/schemas/annotation.py
@@ -2,47 +2,12 @@
 """Classes for validating data passed to the annotations API."""
 
 import copy
-import jsonschema
-from jsonschema.exceptions import best_match
 from pyramid import i18n
 
+from h.schemas.base import JSONSchema, ValidationError
 from memex import parse_document_claims
 
 _ = i18n.TranslationStringFactory(__package__)
-
-
-class ValidationError(Exception):
-    pass
-
-
-class JSONSchema(object):
-
-    """
-    Validate data according to a Draft 4 JSON Schema.
-
-    Inherit from this class and override the `schema` class property with a
-    valid JSON schema.
-    """
-
-    schema = {}
-
-    def __init__(self):
-        self.validator = jsonschema.Draft4Validator(self.schema)
-
-    def validate(self, data):
-        """
-        Validate `data` according to the current schema.
-
-        :param data: The data to be validated
-        :return: valid data
-        :raises ValidationError: if the data is invalid
-        """
-        # Take a copy to ensure we don't modify what we were passed.
-        appstruct = copy.deepcopy(data)
-        error = best_match(self.validator.iter_errors(appstruct))
-        if error is not None:
-            raise ValidationError(_format_jsonschema_error(error))
-        return appstruct
 
 
 class AnnotationSchema(JSONSchema):

--- a/h/storage.py
+++ b/h/storage.py
@@ -21,7 +21,7 @@ from datetime import datetime
 
 from pyramid import i18n
 
-from memex import schemas
+from h import schemas
 from memex import models
 from memex.db import types
 

--- a/tests/h/storage_test.py
+++ b/tests/h/storage_test.py
@@ -7,11 +7,11 @@ import copy
 import pytest
 import mock
 
-from memex import schemas
 from memex.models.annotation import Annotation
 from memex.models.document import Document, DocumentURI
 
 from h import storage
+from h.schemas import ValidationError
 
 
 class FakeGroup(object):
@@ -147,7 +147,7 @@ class TestCreateAnnotation(object):
         # The annotation is a reply.
         data['references'] = ['parent_annotation_id']
 
-        with pytest.raises(schemas.ValidationError) as exc:
+        with pytest.raises(ValidationError) as exc:
             storage.create_annotation(pyramid_request, data, group_service)
 
         assert str(exc.value).startswith('references.0: ')
@@ -179,7 +179,7 @@ class TestCreateAnnotation(object):
         data = self.annotation_data()
         data['groupid'] = 'foo-group'
 
-        with pytest.raises(schemas.ValidationError) as exc:
+        with pytest.raises(ValidationError) as exc:
             storage.create_annotation(pyramid_request, data, group_service)
 
         assert str(exc.value).startswith('group: ')
@@ -191,7 +191,7 @@ class TestCreateAnnotation(object):
         data = self.annotation_data()
         data['groupid'] = 'missing-group'
 
-        with pytest.raises(schemas.ValidationError) as exc:
+        with pytest.raises(ValidationError) as exc:
             storage.create_annotation(pyramid_request, data, group_service)
 
         assert str(exc.value).startswith('group: ')

--- a/tox.ini
+++ b/tox.ini
@@ -12,12 +12,19 @@ skip_install =
     memex: false
 # N.B. "hypothesis" in the list below is the property-based testing library,
 #      not our own code.
+#
+# FIXME: "colander" and "deform" in the list below for memex is a temporary
+# measure while we move functionality back from memex into h. It allows memex
+# tests to run despite depending on modules in h, which in turn depend on
+# colander and deform.
 deps =
     coverage
     mock
     pytest
     hypothesis
     factory-boy
+    memex: colander
+    memex: deform
     h: -rrequirements.txt
 passenv =
     TEST_DATABASE_URL


### PR DESCRIPTION
This commit moves the `memex.schemas` module into the h package, removing a fair amount of duplication between h and memex packages.

In particular, there is now just one JSONSchema base class and one ValidationError exception class.

Unfortunately, this is made a little more complicated than would be ideal by cross-dependencies from other memex modules on the memex schemas. I've worked around this by adding temporary dependencies to be installed into the memex test environment to `tox.ini`. These will go in due course as the relevant modules move into h.

This is part of a project to reintegrate the `memex` package into the main `h` package: https://notes.wtk.io/2017/03/08/reintegrating-memex

_**N.B.** This depends on #4493 and will require a rebase after that merges._