### PR TITLE
Change annotation formatters to accept a resource

### DIFF
--- a/h/formatters/annotation_flag.py
+++ b/h/formatters/annotation_flag.py
@@ -36,8 +36,8 @@ class AnnotationFlagFormatter(object):
         self._cache.update(flags)
         return flags
 
-    def format(self, annotation):
-        flagged = self._load(annotation)
+    def format(self, annotation_resource):
+        flagged = self._load(annotation_resource.annotation)
         return {'flagged': flagged}
 
     def _load(self, annotation):

--- a/h/formatters/interfaces.py
+++ b/h/formatters/interfaces.py
@@ -13,13 +13,13 @@ class IAnnotationFormatter(Interface):
     without putting everything in the annotation presenter, thus allowing better
     decoupling of code.
 
-    The main method is ``format(annotation)`` which is expected to return a
-    dictionary representation based on the passed-in annotation. If the
-    formatter depends on other data it should be able to load it on-demand
+    The main method is ``format(annotation_resource)`` which is expected to
+    return a dictionary representation based on the passed-in annotation. If
+    the formatter depends on other data it should be able to load it on-demand
     for the given annotation.
 
     Since we are rendering lists of potentially hundreds of annotations in one
-    request formatters need to be able to optimize the fetching of additional
+    request, formatters need to be able to optimize the fetching of additional
     data (e.g. from the database). Which is why this interface defines the
     ``preload(ids)`` method.
     Each formatter implementation is expected to handle a cache internally which
@@ -34,12 +34,12 @@ class IAnnotationFormatter(Interface):
         :type ids: list of unicode
         """
 
-    def format(annotation):  # noqa: N805
+    def format(annotation_resource):  # noqa: N805
         """
         Presents additional annotation data that will be served to API clients.
 
-        :param annotation: The annotation object that needs presenting.
-        :type annotation: memex.models.Annotation
+        :param annotation_resource: The annotation that needs presenting.
+        :type annotation_resource: h.resources.AnnotationResource
 
         :returns: A formatted dictionary.
         :rtype: dict

--- a/h/presenters/annotation_json.py
+++ b/h/presenters/annotation_json.py
@@ -55,7 +55,7 @@ class AnnotationJSONPresenter(AnnotationBasePresenter):
         annotation.update(base)
 
         for formatter in self.formatters:
-            annotation.update(formatter.format(self.annotation))
+            annotation.update(formatter.format(self.annotation_resource))
 
         return annotation
 

--- a/tests/h/formatters/annotation_flag_test.py
+++ b/tests/h/formatters/annotation_flag_test.py
@@ -2,10 +2,14 @@
 
 from __future__ import unicode_literals
 
+from collections import namedtuple
+
 import pytest
 
 from h.formatters.annotation_flag import AnnotationFlagFormatter
 from h.services.flag import FlagService
+
+FakeAnnotationResource = namedtuple('FakeAnnotationResource', ['annotation'])
 
 
 class TestAnnotationFlagFormatter(object):
@@ -23,19 +27,22 @@ class TestAnnotationFlagFormatter(object):
 
     def test_format_for_existing_flag(self, formatter, factories, current_user):
         flag = factories.Flag(user=current_user)
-        assert formatter.format(flag.annotation) == {'flagged': True}
+        annotation_resource = FakeAnnotationResource(flag.annotation)
+        assert formatter.format(annotation_resource) == {'flagged': True}
 
     def test_format_for_missing_flag(self, formatter, factories):
         annotation = factories.Annotation()
+        annotation_resource = FakeAnnotationResource(annotation)
 
-        assert formatter.format(annotation) == {'flagged': False}
+        assert formatter.format(annotation_resource) == {'flagged': False}
 
     def test_format_for_unauthenticated_user(self, db_session, factories):
         annotation = factories.Annotation()
+        annotation_resource = FakeAnnotationResource(annotation)
         formatter = AnnotationFlagFormatter(db_session,
                                             user=None)
 
-        assert formatter.format(annotation) == {'flagged': False}
+        assert formatter.format(annotation_resource) == {'flagged': False}
 
     @pytest.fixture
     def current_user(self, factories):


### PR DESCRIPTION
Some formatters (including the forthcoming one to add flag counts for moderators) are going to need to make decisions based on the current user's permissions, so needs access to the resource object.

This makes some of the tests for the existing formatter slightly less neat, as they need to wrap the annotation up in something that quacks like a resource. I also needed to add a new test to the presenter, as changing the interface didn't end up breaking any of the existing tests.