### PR TITLE
Move memex.links to h.services.links

### DIFF
--- a/h/services/__init__.py
+++ b/h/services/__init__.py
@@ -28,7 +28,7 @@ def includeme(config):
     config.register_service_factory('.user_signup.user_signup_service_factory', name='user_signup')
 
     config.add_directive('add_annotation_link_generator',
-                         '.links._add_annotation_link_generator')
+                         '.links.add_annotation_link_generator')
     config.add_request_method('.feature.FeatureRequestProperty',
                               name='feature',
                               reify=True)

--- a/h/services/__init__.py
+++ b/h/services/__init__.py
@@ -13,11 +13,12 @@ def includeme(config):
     config.register_service_factory('.auth_ticket.auth_ticket_service_factory',
                                     iface='pyramid_authsanity.interfaces.IAuthService')
     config.register_service_factory('.auth_token.auth_token_service_factory', name='auth_token')
+    config.register_service_factory('.authority_group.authority_group_factory', name='authority_group')
     config.register_service_factory('.feature.feature_service_factory', name='feature')
     config.register_service_factory('.flag.flag_service_factory', name='flag')
     config.register_service_factory('.group.groups_factory', name='group')
     config.register_service_factory('.groupfinder.groupfinder_service_factory', iface='h.interfaces.IGroupService')
-    config.register_service_factory('.authority_group.authority_group_factory', name='authority_group')
+    config.register_service_factory('.links.links_factory', name='links')
     config.register_service_factory('.nipsa.nipsa_factory', name='nipsa')
     config.register_service_factory('.oauth.oauth_service_factory', name='oauth')
     config.register_service_factory('.rename_user.rename_user_factory', name='rename_user')
@@ -26,6 +27,8 @@ def includeme(config):
     config.register_service_factory('.user_password.user_password_service_factory', name='user_password')
     config.register_service_factory('.user_signup.user_signup_service_factory', name='user_signup')
 
+    config.add_directive('add_annotation_link_generator',
+                         '.links._add_annotation_link_generator')
     config.add_request_method('.feature.FeatureRequestProperty',
                               name='feature',
                               reify=True)

--- a/h/services/links.py
+++ b/h/services/links.py
@@ -71,7 +71,7 @@ def links_factory(context, request):
                         registry=request.registry)
 
 
-def add_annotation_link_generator(registry, name, generator, hidden=False):
+def add_annotation_link_generator(config, name, generator, hidden=False):
     """
     Registers a function which generates a named link for an annotation.
 
@@ -84,13 +84,7 @@ def add_annotation_link_generator(registry, name, generator, hidden=False):
     If `hidden` is True, then the link generator will not be included in the
     default links output when rendering annotations.
     """
+    registry = config.registry
     if LINK_GENERATORS_KEY not in registry:
         registry[LINK_GENERATORS_KEY] = {}
     registry[LINK_GENERATORS_KEY][name] = (generator, hidden)
-
-
-def _add_annotation_link_generator(config, name, generator, hidden=False):
-    add_annotation_link_generator(config.registry,
-                                  name,
-                                  generator,
-                                  hidden=hidden)

--- a/h/services/links.py
+++ b/h/services/links.py
@@ -1,13 +1,12 @@
 # -*- coding: utf-8 -*-
-"""
-Tools for generating links to domain objects.
-"""
+
+"""Tools for generating links to domain objects. """
 
 from __future__ import unicode_literals
 
 from pyramid.request import Request
 
-LINK_GENERATORS_KEY = 'memex.links.link_generators'
+LINK_GENERATORS_KEY = 'h.links.link_generators'
 
 
 class LinksService(object):
@@ -95,10 +94,3 @@ def _add_annotation_link_generator(config, name, generator, hidden=False):
                                   name,
                                   generator,
                                   hidden=hidden)
-
-
-def includeme(config):  # pragma: no cover
-    config.register_service_factory(links_factory, name='links')
-
-    config.add_directive('add_annotation_link_generator',
-                         _add_annotation_link_generator)

--- a/h/streamer/messages.py
+++ b/h/streamer/messages.py
@@ -10,8 +10,8 @@ from h import realtime
 from h import storage
 from h.realtime import Consumer
 from h.resources import AnnotationResource
-from memex.links import LinksService
 from h.auth.util import translate_annotation_principals
+from h.services.links import LinksService
 from h.services.nipsa import NipsaService
 from h.services.groupfinder import GroupfinderService
 from h.streamer import websocket

--- a/h/websocket.py
+++ b/h/websocket.py
@@ -168,18 +168,12 @@ def create_app(global_config, **settings):
     config.include('h.session')
     config.include('h.search')
     config.include('h.sentry')
+    config.include('h.services')
     config.include('h.stats')
-
-    # We have to include parts of the `memex` package in order to provide
-    # the links service.
-    config.include('memex.links')
 
     # We include links in order to set up the alternative link registrations
     # for annotations.
     config.include('h.links')
-
-    # Access to services
-    config.include('h.services')
 
     # And finally we add routes. Static routes are not resolvable by HTTP
     # clients, but can be used for URL generation within the websocket server.

--- a/src/memex/__init__.py
+++ b/src/memex/__init__.py
@@ -10,5 +10,3 @@ def includeme(config):
     # This must be included first so it can set up the model base class if
     # need be.
     config.include('memex.models')
-
-    config.include('memex.links')

--- a/tests/h/services/links_test.py
+++ b/tests/h/services/links_test.py
@@ -5,9 +5,11 @@ from __future__ import unicode_literals
 import mock
 import pytest
 
-from memex.links import LinksService
-from memex.links import add_annotation_link_generator
-from memex.links import links_factory
+from h.services.links import (
+    LinksService,
+    add_annotation_link_generator,
+    links_factory,
+)
 
 
 class TestLinksService(object):

--- a/tests/h/services/links_test.py
+++ b/tests/h/services/links_test.py
@@ -94,27 +94,25 @@ def registry(pyramid_config):
     pyramid_config.add_route('some.named.route', '/some/path')
     pyramid_config.add_route('param.route', '/annotations/{id}')
 
-    registry = pyramid_config.registry
-
-    add_annotation_link_generator(registry,
+    add_annotation_link_generator(pyramid_config,
                                   'giraffe',
                                   lambda r, a: 'http://giraffes.com')
-    add_annotation_link_generator(registry,
+    add_annotation_link_generator(pyramid_config,
                                   'elephant',
                                   lambda r, a: 'https://elephant.org')
-    add_annotation_link_generator(registry,
+    add_annotation_link_generator(pyramid_config,
                                   'kiwi',
                                   lambda r, a: 'http://kiwi.net',
                                   hidden=True)
-    add_annotation_link_generator(registry,
+    add_annotation_link_generator(pyramid_config,
                                   'returnsnone',
                                   lambda r, a: None)
-    add_annotation_link_generator(registry,
+    add_annotation_link_generator(pyramid_config,
                                   'namedroute',
                                   lambda r, a: r.route_url('some.named.route'))
-    add_annotation_link_generator(registry,
+    add_annotation_link_generator(pyramid_config,
                                   'paramroute',
                                   lambda r, a: r.route_url('param.route', id=a.id),
                                   hidden=True)
 
-    return registry
+    return pyramid_config.registry


### PR DESCRIPTION
Moves the links service into the h package alongside other services. Happily, this services is relatively self-contained, and so this is a straight move from one place to another.

The only slight "gotcha" is that `h.services` must now be included before `h.links`, otherwise the `add_annotation_link_generator` configuration directive won't be defined.

This is part of a project to reintegrate the `memex` package into the main `h` package: https://notes.wtk.io/2017/03/08/reintegrating-memex.

_This and #4495 can be merged in either order, although there will likely be a small conflict in the `h.streamer.messages` imports which will need resolving regardless._