### PR TITLE
Add a feature flag to enable first-party users to flag annotations

### DIFF
--- a/h/models/feature.py
+++ b/h/models/feature.py
@@ -15,6 +15,8 @@ FEATURES = {
                                " updates to annotations in the client?"),
     'filter_highlights': ("Filter highlights in document based on visible"
                           " annotations in sidebar?"),
+    'flag_action': ("Enable user to flag inappropriate annotations in the "
+                    "client?"),
     'orphans_tab': "Show the orphans tab to separate anchored and unanchored annotations?",
     'total_shared_annotations': "Show the total number of shared annotations for users and groups?",
 }


### PR DESCRIPTION
Add a feature flag which will cause the client to show the 'Flag' button on an annotation card.

Note that the client will _always_ show the 'Flag' action for third-party users.

The counterpart client PR to make use of this feature flag is https://github.com/hypothesis/client/pull/343

Together these two PRs will enable us to start testing out moderation in private groups.