### PR TITLE
Expose moderated annotations with `hidden` key in payload.

### DIFF
--- a/h/formatters/__init__.py
+++ b/h/formatters/__init__.py
@@ -3,7 +3,9 @@
 from __future__ import unicode_literals
 
 from h.formatters.annotation_flag import AnnotationFlagFormatter
+from h.formatters.annotation_hidden import AnnotationHiddenFormatter
 
 __all__ = (
     'AnnotationFlagFormatter',
+    'AnnotationHiddenFormatter',
 )

--- a/h/formatters/annotation_hidden.py
+++ b/h/formatters/annotation_hidden.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from zope.interface import implementer
+
+from h.formatters.interfaces import IAnnotationFormatter
+
+
+@implementer(IAnnotationFormatter)
+class AnnotationHiddenFormatter(object):
+    """
+    Formatter for exposing whether an annotation is hidden or not.
+
+    If the annotation is hidden, this formatter will add: `"hidden": true`
+    to the payload, otherwise `"hidden": false`.
+    When the currently authenticated user is the annotation author, then this
+    formatter will always add `"hidden": false`, to not signal that the
+    annotation is hidden.
+    """
+
+    def __init__(self, moderation_svc, user=None):
+        self.moderation_svc = moderation_svc
+        self.user = user
+
+        # Local cache of hidden flags. We don't need to care about detached
+        # instances because we only store the annotation id and a boolean flag.
+        self._cache = {}
+
+    def preload(self, ids):
+        hidden_ids = self.moderation_svc.all_hidden(ids)
+
+        hidden = {id_: (id_ in hidden_ids) for id_ in ids}
+        self._cache.update(hidden)
+        return hidden
+
+    def format(self, annotation_resource):
+        annotation = annotation_resource.annotation
+
+        if self.user and self.user.userid == annotation.userid:
+            hidden = False
+        else:
+            hidden = self._load(annotation)
+        return {'hidden': hidden}
+
+    def _load(self, annotation):
+        id_ = annotation.id
+
+        if id_ in self._cache:
+            return self._cache[id_]
+
+        hidden = self.moderation_svc.hidden(annotation.id)
+        self._cache[id_] = hidden
+        return self._cache[id_]

--- a/h/services/annotation_json_presentation.py
+++ b/h/services/annotation_json_presentation.py
@@ -13,13 +13,14 @@ from h.interfaces import IGroupService
 
 
 class AnnotationJSONPresentationService(object):
-    def __init__(self, session, user, group_svc, links_svc, flag_svc):
+    def __init__(self, session, user, group_svc, links_svc, flag_svc, moderation_svc):
         self.session = session
         self.group_svc = group_svc
         self.links_svc = links_svc
 
         self.formatters = [
-            formatters.AnnotationFlagFormatter(flag_svc, user)
+            formatters.AnnotationFlagFormatter(flag_svc, user),
+            formatters.AnnotationHiddenFormatter(moderation_svc, user)
         ]
 
     def present(self, annotation_resource):
@@ -55,8 +56,10 @@ def annotation_json_presentation_service_factory(context, request):
     group_svc = request.find_service(IGroupService)
     links_svc = request.find_service(name='links')
     flag_svc = request.find_service(name='flag')
+    moderation_svc = request.find_service(name='annotation_moderation')
     return AnnotationJSONPresentationService(session=request.db,
                                              user=request.user,
                                              group_svc=group_svc,
                                              links_svc=links_svc,
-                                             flag_svc=flag_svc)
+                                             flag_svc=flag_svc,
+                                             moderation_svc=moderation_svc)

--- a/h/services/annotation_moderation.py
+++ b/h/services/annotation_moderation.py
@@ -23,6 +23,24 @@ class AnnotationModerationService(object):
                         .filter_by(annotation_id=annotation_id)
         return self.session.query(q.exists()).scalar()
 
+    def all_hidden(self, annotation_ids):
+        """
+        Check which of the given annotation ids is hidden.
+
+        :param annotation_ids: The ids of the annotations to check.
+        :type annotation: list of unicode
+
+        :returns: The subset of the annotation ids that are hidden.
+        :rtype: set of unicode
+        """
+        if not annotation_ids:
+            return set()
+
+        query = self.session.query(models.AnnotationModeration.annotation_id) \
+                            .filter(models.AnnotationModeration.annotation_id.in_(annotation_ids))
+
+        return set([m.annotation_id for m in query])
+
     def hide(self, annotation):
         """
         Hide an annotation from other users.

--- a/tests/h/formatters/annotation_hidden_test.py
+++ b/tests/h/formatters/annotation_hidden_test.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from collections import namedtuple
+
+import pytest
+
+from h.formatters.annotation_hidden import AnnotationHiddenFormatter
+from h.services.annotation_moderation import AnnotationModerationService
+
+FakeAnnotationResource = namedtuple('FakeAnnotationResource', ['annotation'])
+
+
+class TestAnnotationHiddenFormatter(object):
+    def test_preload_sets_founds_hidden_annotations_to_true(self, annotations, formatter):
+        annotation_ids = [a.id for a in annotations['hidden']]
+
+        expected = {id_: True for id_ in annotation_ids}
+        assert formatter.preload(annotation_ids) == expected
+
+    def test_preload_sets_missing_flags_to_false(self, annotations, formatter):
+        annotation_ids = [a.id for a in annotations['public']]
+
+        expected = {id_: False for id_ in annotation_ids}
+        assert formatter.preload(annotation_ids) == expected
+
+    def test_format_for_hidden_annotation(self, formatter, factories):
+        mod = factories.AnnotationModeration()
+        resource = FakeAnnotationResource(mod.annotation)
+        assert formatter.format(resource) == {'hidden': True}
+
+    def test_format_for_public_annotation(self, formatter, factories):
+        annotation = factories.Annotation()
+        resource = FakeAnnotationResource(annotation)
+
+        assert formatter.format(resource) == {'hidden': False}
+
+    def test_format_for_hidden_annotation_as_annotation_author(self, formatter, factories, current_user):
+        annotation = factories.Annotation(userid=current_user.userid)
+        resource = FakeAnnotationResource(annotation)
+        factories.AnnotationModeration(annotation=annotation)
+
+        assert formatter.format(resource) == {'hidden': False}
+
+    def test_format_works_for_missing_user(self, moderation_svc, factories):
+        formatter = AnnotationHiddenFormatter(moderation_svc)
+        mod = factories.AnnotationModeration()
+        resource = FakeAnnotationResource(mod.annotation)
+        assert formatter.format(resource) == {'hidden': True}
+
+    @pytest.fixture
+    def current_user(self, factories):
+        return factories.User()
+
+    @pytest.fixture
+    def formatter(self, moderation_svc, current_user):
+        return AnnotationHiddenFormatter(moderation_svc, current_user)
+
+    @pytest.fixture
+    def moderation_svc(self, db_session):
+        return AnnotationModerationService(db_session)
+
+    @pytest.fixture
+    def annotations(self, factories):
+        hidden = [mod.annotation for mod in factories.AnnotationModeration.create_batch(3)]
+        public = factories.Annotation.create_batch(2)
+        return {'hidden': hidden, 'public': public}

--- a/tests/h/services/annotation_moderation_test.py
+++ b/tests/h/services/annotation_moderation_test.py
@@ -21,6 +21,25 @@ class TestAnnotationModerationServiceHidden(object):
         assert svc.hidden(annotation.id) is False
 
 
+@pytest.mark.usefixtures('mods')
+class TestAnnotationModerationServiceAllHidden(object):
+    def test_it_lists_moderated_annotation_ids(self, svc, mods):
+        ids = [m.annotation.id for m in mods[0:-1]]
+        assert svc.all_hidden(ids) == set(ids)
+
+    def test_it_skips_non_moderated_annotations(self, svc, factories):
+        annotation = factories.Annotation()
+
+        assert svc.all_hidden([annotation.id]) == set()
+
+    def test_it_handles_with_no_ids(self, svc):
+        assert svc.all_hidden([]) == set()
+
+    @pytest.fixture
+    def mods(self, factories):
+        return factories.AnnotationModeration.create_batch(3)
+
+
 class TestAnnotationModerationServiceHide(object):
     def test_it_creates_annotation_moderation(self, svc, factories, db_session):
         annotation = factories.Annotation()


### PR DESCRIPTION
This is part of hypothesis/product-backlog#239

This will make sure the client can either show a special banner for
group moderators to unhide the annotation, or if a moderated annotation
has replies we want to show blacked-out text, so this will signal that
to the client as well.