### PR TITLE
Remove unused imports from flag service test

### DIFF
--- a/tests/h/services/flag_test.py
+++ b/tests/h/services/flag_test.py
@@ -6,7 +6,6 @@ import pytest
 
 from h.services import flag
 from h import models
-from h._compat import text_type, xrange
 
 
 @pytest.mark.usefixtures('flags')


### PR DESCRIPTION
The code that used the `xrange` import disappeared in commit 22cb7a1, and the code that used the `text_type` import disappeared in commit a83b508.