### PR TITLE
Extract the flag-counting logic into a service

### DIFF
--- a/h/services/__init__.py
+++ b/h/services/__init__.py
@@ -16,6 +16,7 @@ def includeme(config):
     config.register_service_factory('.authority_group.authority_group_factory', name='authority_group')
     config.register_service_factory('.feature.feature_service_factory', name='feature')
     config.register_service_factory('.flag.flag_service_factory', name='flag')
+    config.register_service_factory('.flag_count.flag_count_service_factory', name='flag_count')
     config.register_service_factory('.group.groups_factory', name='group')
     config.register_service_factory('.groupfinder.groupfinder_service_factory', iface='h.interfaces.IGroupService')
     config.register_service_factory('.links.links_factory', name='links')

--- a/h/services/annotation_json_presentation.py
+++ b/h/services/annotation_json_presentation.py
@@ -13,7 +13,7 @@ from h.interfaces import IGroupService
 
 
 class AnnotationJSONPresentationService(object):
-    def __init__(self, session, user, group_svc, links_svc, flag_svc, moderation_svc, has_permission):
+    def __init__(self, session, user, group_svc, links_svc, flag_svc, flag_count_svc, moderation_svc, has_permission):
         self.session = session
         self.group_svc = group_svc
         self.links_svc = links_svc
@@ -21,7 +21,7 @@ class AnnotationJSONPresentationService(object):
         self.formatters = [
             formatters.AnnotationFlagFormatter(flag_svc, user),
             formatters.AnnotationHiddenFormatter(moderation_svc, user),
-            formatters.AnnotationModerationFormatter(self.session, user, has_permission)
+            formatters.AnnotationModerationFormatter(flag_count_svc, user, has_permission)
         ]
 
     def present(self, annotation_resource):
@@ -57,11 +57,13 @@ def annotation_json_presentation_service_factory(context, request):
     group_svc = request.find_service(IGroupService)
     links_svc = request.find_service(name='links')
     flag_svc = request.find_service(name='flag')
+    flag_count_svc = request.find_service(name='flag_count')
     moderation_svc = request.find_service(name='annotation_moderation')
     return AnnotationJSONPresentationService(session=request.db,
                                              user=request.user,
                                              group_svc=group_svc,
                                              links_svc=links_svc,
                                              flag_svc=flag_svc,
+                                             flag_count_svc=flag_count_svc,
                                              moderation_svc=moderation_svc,
                                              has_permission=request.has_permission)

--- a/h/services/flag_count.py
+++ b/h/services/flag_count.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import sqlalchemy as sa
+
+from h.models import Flag
+
+
+class FlagCountService(object):
+    def __init__(self, session):
+        self._session = session
+
+    def flag_count(self, annotation):
+        """
+        Return the number of times a given annotation has been flagged.
+
+        :param annotation: The annotation to check for flags.
+        :type annotation: h.models.Annotation
+
+        :returns: The number of times the annotation has been flagged.
+        :rtype int
+        """
+        return self._session.query(sa.func.count(Flag.id)) \
+                            .filter_by(annotation_id=annotation.id) \
+                            .scalar()
+
+    def flag_counts(self, annotation_ids):
+        """
+        Return flag counts for a batch of annotations.
+
+        :param annotation_ids: The IDs of the annotations to check.
+        :type annotation_ids: sequence of unicode
+
+        :returns: A map of annotation IDs to flag counts.
+        :rtype dict[unicode, int]
+        """
+        if not annotation_ids:
+            return {}
+
+        query = self._session.query(sa.func.count(Flag.id).label('flag_count'),
+                                    Flag.annotation_id) \
+                             .filter(Flag.annotation_id.in_(annotation_ids)) \
+                             .group_by(Flag.annotation_id)
+
+        flag_counts = {f.annotation_id: f.flag_count for f in query}
+        missing_ids = set(annotation_ids) - set(flag_counts.keys())
+        flag_counts.update({id_: 0 for id_ in missing_ids})
+        return flag_counts
+
+
+def flag_count_service_factory(context, request):
+    return FlagCountService(request.db)

--- a/tests/h/services/annotation_json_presentation_test.py
+++ b/tests/h/services/annotation_json_presentation_test.py
@@ -32,7 +32,7 @@ class TestAnnotationJSONPresentationService(object):
 
     def test_initializes_moderation_formatter(self, services, formatters):
         self.svc(services)
-        formatters.AnnotationModerationFormatter.assert_called_once_with(mock.sentinel.db_session,
+        formatters.AnnotationModerationFormatter.assert_called_once_with(services['flag_count'],
                                                                          mock.sentinel.user,
                                                                          mock.sentinel.has_permission)
 
@@ -103,6 +103,7 @@ class TestAnnotationJSONPresentationService(object):
                                                  group_svc=services['group'],
                                                  links_svc=services['links'],
                                                  flag_svc=services['flag'],
+                                                 flag_count_svc=services['flag_count'],
                                                  moderation_svc=services['annotation_moderation'],
                                                  has_permission=mock.sentinel.has_permission)
 
@@ -174,6 +175,12 @@ class TestAnnotationJSONPresentationServiceFactory(object):
         _, kwargs = service_class.call_args
         assert kwargs['moderation_svc'] == services['annotation_moderation']
 
+    def test_provides_flag_count_service(self, pyramid_request, service_class, services):
+        annotation_json_presentation_service_factory(None, pyramid_request)
+
+        _, kwargs = service_class.call_args
+        assert kwargs['flag_count_svc'] == services['flag_count']
+
     def test_provides_has_permission(self, pyramid_request, service_class):
         annotation_json_presentation_service_factory(None, pyramid_request)
 
@@ -194,7 +201,7 @@ class TestAnnotationJSONPresentationServiceFactory(object):
 def services(pyramid_config):
     service_mocks = {}
 
-    for name in ['links', 'flag', 'annotation_moderation']:
+    for name in ['links', 'flag', 'flag_count', 'annotation_moderation']:
         svc = mock.Mock()
         service_mocks[name] = svc
         pyramid_config.register_service(svc, name=name)

--- a/tests/h/services/flag_count_test.py
+++ b/tests/h/services/flag_count_test.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import pytest
+
+from h.services import flag_count
+
+
+class TestFlagCountService(object):
+    def test_flag_count_returns_zero_for_unflagged_annotation(self, svc, unflagged):
+        assert svc.flag_count(unflagged) == 0
+
+    def test_flag_count_returns_flag_count_for_flagged_annotation(self, svc, flagged):
+        assert svc.flag_count(flagged) == 2
+
+    def test_flag_counts_returns_empty_dict_for_no_ids(self, svc):
+        assert svc.flag_counts([]) == {}
+
+    def test_flag_counts_returns_all_ids_in_result(self, svc, flagged, unflagged):
+        ann_ids = [flagged.id, unflagged.id]
+
+        flag_counts = svc.flag_counts(ann_ids)
+
+        assert set(flag_counts.keys()) == set(ann_ids)
+
+    def test_flag_counts_returns_zero_for_unflagged_annotation(self, svc, unflagged):
+        flag_counts = svc.flag_counts([unflagged.id])
+
+        assert flag_counts[unflagged.id] == 0
+
+    def test_flag_counts_returns_flag_count_for_flagged_annotation(self, svc, flagged):
+        flag_counts = svc.flag_counts([flagged.id])
+
+        assert flag_counts[flagged.id] == 2
+
+    @pytest.fixture
+    def unflagged(self, factories):
+        return factories.Annotation()
+
+    @pytest.fixture
+    def flagged(self, factories):
+        annotation = factories.Annotation()
+        factories.Flag.create_batch(2, annotation=annotation)
+        return annotation
+
+    @pytest.fixture
+    def svc(self, db_session):
+        return flag_count.FlagCountService(db_session)


### PR DESCRIPTION
Extracting flag-counting logic into a service means the `AnnotationModerationFormatter` doesn't need to know anything about how the flag models are laid out, and so doesn't need direct access to the database session.