### PR TITLE
Fix Docker builds reporting as ".dirty" when they're not

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,9 @@ RUN mkdir /etc/collectd/collectd.conf.d \
 # Copy the rest of the application files.
 COPY . .
 
+# If we're building from a git clone, ensure that .git is writeable
+RUN [ -d .git ] && chown -R hypothesis:hypothesis .git || :
+
 # Build frontend assets
 RUN npm install --production \
   && NODE_ENV=production node_modules/.bin/gulp build \

--- a/h/_version.py
+++ b/h/_version.py
@@ -31,6 +31,9 @@ def fetch_git_date(ref):
 
 
 def fetch_git_dirty():
+    # Ensure git index is up-to-date first. This usually isn't necessary, but
+    # can be needed inside a docker container where the index is out of date.
+    subprocess.call(['git', 'update-index', '-q', '--refresh'])
     dirty_tree = subprocess.call(['git', 'diff-files', '--quiet']) != 0
     dirty_index = subprocess.call(['git', 'diff-index', '--quiet',
                                    '--cached', 'HEAD']) != 0


### PR DESCRIPTION
The builds that we push to Docker Hub are built from a `git archive` tarball, and are thus guaranteed to be built from a clean committed tree. In Skyliner, however, the whole repository is added to the Docker image, including the `.git` directory.

At the moment, all Skyliner builds are reporting themselves as having dirty trees, because some aspect of the filesystem inside the container leads git to believe that every single file has been modified. This seems to be because the git index (`.git/index`) has stale data in its stat cache, and updating this explicitly with `git update-index --refresh` or by running `git status` fixes the issue.

In order to be able to do this the `.git` directory needs to be writeable by the user that runs the application, so this commit:

- ensures that `.git`, if present, is writeable by the `hypothesis` user

- explicitly runs `git update-index -q --refresh` before checking the dirty state of the working tree