### PR TITLE
Optimise annotation moderation reindex

### DIFF
--- a/h/events.py
+++ b/h/events.py
@@ -20,6 +20,7 @@ class AnnotationTransformEvent(object):
     annotation just before it is indexed or in other use-cases.
     """
 
-    def __init__(self, request, annotation_dict):
+    def __init__(self, request, annotation, annotation_dict):
         self.request = request
+        self.annotation = annotation
         self.annotation_dict = annotation_dict

--- a/h/formatters/annotation_hidden.py
+++ b/h/formatters/annotation_hidden.py
@@ -49,6 +49,6 @@ class AnnotationHiddenFormatter(object):
         if id_ in self._cache:
             return self._cache[id_]
 
-        hidden = self.moderation_svc.hidden(annotation.id)
+        hidden = self.moderation_svc.hidden(annotation)
         self._cache[id_] = hidden
         return self._cache[id_]

--- a/h/models/annotation_moderation.py
+++ b/h/models/annotation_moderation.py
@@ -26,7 +26,10 @@ class AnnotationModeration(Base, Timestamps):
 
     #: The annotation which has been flagged.
     annotation = sa.orm.relationship('Annotation',
-                                     backref=sa.orm.backref('moderation', uselist=False))
+                                     backref=sa.orm.backref('moderation',
+                                                            uselist=False,
+                                                            cascade='all, delete-orphan',
+                                                            passive_deletes=True))
 
     def __repr__(self):
         return '<AnnotationModeration annotation_id=%s>' % self.annotation_id

--- a/h/models/annotation_moderation.py
+++ b/h/models/annotation_moderation.py
@@ -25,7 +25,8 @@ class AnnotationModeration(Base, Timestamps):
                               nullable=False)
 
     #: The annotation which has been flagged.
-    annotation = sa.orm.relationship('Annotation')
+    annotation = sa.orm.relationship('Annotation',
+                                     backref=sa.orm.backref('moderation', uselist=False))
 
     def __repr__(self):
         return '<AnnotationModeration annotation_id=%s>' % self.annotation_id

--- a/h/nipsa/subscribers.py
+++ b/h/nipsa/subscribers.py
@@ -22,4 +22,4 @@ def _user_nipsa(request, payload):
 
 def _annotation_moderated(request, annotation):
     svc = request.find_service(name='annotation_moderation')
-    return svc.hidden(annotation.id)
+    return svc.hidden(annotation)

--- a/h/nipsa/subscribers.py
+++ b/h/nipsa/subscribers.py
@@ -5,10 +5,11 @@ from __future__ import unicode_literals
 
 def transform_annotation(event):
     """Add a {"nipsa": True} field on moderated annotations or those whose users are flagged."""
+    annotation = event.annotation
     payload = event.annotation_dict
 
     nipsa = _user_nipsa(event.request, payload)
-    nipsa = nipsa or _annotation_moderated(event.request, payload)
+    nipsa = nipsa or _annotation_moderated(event.request, annotation)
 
     if nipsa:
         payload['nipsa'] = True
@@ -19,6 +20,6 @@ def _user_nipsa(request, payload):
     return 'user' in payload and nipsa_service.is_flagged(payload['user'])
 
 
-def _annotation_moderated(request, payload):
+def _annotation_moderated(request, annotation):
     svc = request.find_service(name='annotation_moderation')
-    return svc.hidden(payload['id'])
+    return svc.hidden(annotation.id)

--- a/h/search/index.py
+++ b/h/search/index.py
@@ -189,7 +189,8 @@ def _annotation_filter():
 def _eager_loaded_annotations(session):
     return session.query(models.Annotation).options(
         subqueryload(models.Annotation.document).subqueryload(models.Document.document_uris),
-        subqueryload(models.Annotation.document).subqueryload(models.Document.meta)
+        subqueryload(models.Annotation.document).subqueryload(models.Document.meta),
+        subqueryload(models.Annotation.moderation),
     )
 
 

--- a/h/search/index.py
+++ b/h/search/index.py
@@ -46,7 +46,7 @@ def index(es, annotation, request, target_index=None):
     presenter = presenters.AnnotationSearchIndexPresenter(annotation)
     annotation_dict = presenter.asdict()
 
-    event = AnnotationTransformEvent(request, annotation_dict)
+    event = AnnotationTransformEvent(request, annotation, annotation_dict)
     request.registry.notify(event)
 
     if target_index is None:
@@ -149,7 +149,7 @@ class BatchIndexer(object):
                                  '_id': annotation.id}}
         data = presenters.AnnotationSearchIndexPresenter(annotation).asdict()
 
-        event = AnnotationTransformEvent(self.request, data)
+        event = AnnotationTransformEvent(self.request, annotation, data)
         self.request.registry.notify(event)
 
         return (action, data)

--- a/h/services/annotation_moderation.py
+++ b/h/services/annotation_moderation.py
@@ -19,10 +19,7 @@ class AnnotationModerationService(object):
         :returns: true/false boolean
         :rtype: bool
         """
-        # We need to also check if the moderation model is in the
-        # session, in case it has just been deleted.
-        return (annotation.moderation is not None and
-                annotation.moderation in self.session)
+        return annotation.moderation is not None
 
     def all_hidden(self, annotation_ids):
         """
@@ -59,8 +56,7 @@ class AnnotationModerationService(object):
         if self.hidden(annotation):
             return
 
-        mod = models.AnnotationModeration(annotation=annotation)
-        self.session.add(mod)
+        annotation.moderation = models.AnnotationModeration()
 
     def unhide(self, annotation):
         """
@@ -72,9 +68,7 @@ class AnnotationModerationService(object):
         :type annotation: h.models.Annotation
         """
 
-        self.session.query(models.AnnotationModeration) \
-                    .filter_by(annotation=annotation) \
-                    .delete()
+        annotation.moderation = None
 
 
 def annotation_moderation_service_factory(context, request):

--- a/h/services/annotation_moderation.py
+++ b/h/services/annotation_moderation.py
@@ -9,19 +9,20 @@ class AnnotationModerationService(object):
     def __init__(self, session):
         self.session = session
 
-    def hidden(self, annotation_id):
+    def hidden(self, annotation):
         """
         Check if an annotation id is hidden.
 
-        :param annotation_id: The id of the annotation to check.
-        :type annotation: unicode
+        :param annotation: The annotation to check.
+        :type annotation: h.models.Annotation
 
         :returns: true/false boolean
         :rtype: bool
         """
-        q = self.session.query(models.AnnotationModeration) \
-                        .filter_by(annotation_id=annotation_id)
-        return self.session.query(q.exists()).scalar()
+        # We need to also check if the moderation model is in the
+        # session, in case it has just been deleted.
+        return (annotation.moderation is not None and
+                annotation.moderation in self.session)
 
     def all_hidden(self, annotation_ids):
         """
@@ -55,7 +56,7 @@ class AnnotationModerationService(object):
         :type annotation: h.models.Annotation
         """
 
-        if self.hidden(annotation.id):
+        if self.hidden(annotation):
             return
 
         mod = models.AnnotationModeration(annotation=annotation)

--- a/tests/h/events_test.py
+++ b/tests/h/events_test.py
@@ -18,7 +18,8 @@ def test_annotation_event():
 
 
 def test_annotation_transform_event():
-    evt = AnnotationTransformEvent(s.request, s.annotation_dict)
+    evt = AnnotationTransformEvent(s.request, s.annotation, s.annotation_dict)
 
     assert evt.request == s.request
+    assert evt.annotation == s.annotation
     assert evt.annotation_dict == s.annotation_dict

--- a/tests/h/search/index_test.py
+++ b/tests/h/search/index_test.py
@@ -26,11 +26,12 @@ class TestIndexAnnotation:
                                                         es,
                                                         presenters,
                                                         pyramid_request):
+        annotation = mock.Mock()
         presented = presenters.AnnotationSearchIndexPresenter.return_value.asdict()
 
-        index.index(es, mock.Mock(), pyramid_request)
+        index.index(es, annotation, pyramid_request)
 
-        AnnotationTransformEvent.assert_called_once_with(pyramid_request, presented)
+        AnnotationTransformEvent.assert_called_once_with(pyramid_request, annotation, presented)
 
     def test_it_notifies_before_save_event(self,
                                            AnnotationTransformEvent,
@@ -193,6 +194,7 @@ class TestBatchIndexer(object):
                         '_id': annotation.id}},
             rendered
         )
+
     def test_index_emits_AnnotationTransformEvent_when_presenting_bulk_actions(self,
                                                                                db_session,
                                                                                indexer,
@@ -213,8 +215,9 @@ class TestBatchIndexer(object):
         streaming_bulk.side_effect = fake_streaming_bulk
 
         def transform(event):
-            data = event.annotation_dict
-            data['transformed'] = True
+            if event.annotation == annotation:
+                data = event.annotation_dict
+                data['transformed'] = True
 
         pyramid_config.add_subscriber(transform, 'h.events.AnnotationTransformEvent')
 

--- a/tests/h/services/annotation_moderation_test.py
+++ b/tests/h/services/annotation_moderation_test.py
@@ -13,12 +13,12 @@ class TestAnnotationModerationServiceHidden(object):
     def test_it_returns_true_for_moderated_annotation(self, svc, factories):
         mod = factories.AnnotationModeration()
 
-        assert svc.hidden(mod.annotation.id) is True
+        assert svc.hidden(mod.annotation) is True
 
     def test_it_returns_false_for_non_moderated_annotation(self, svc, factories):
         annotation = factories.Annotation()
 
-        assert svc.hidden(annotation.id) is False
+        assert svc.hidden(annotation) is False
 
 
 @pytest.mark.usefixtures('mods')
@@ -70,21 +70,21 @@ class TestAnnotationModerationServiceUnhide(object):
 
         svc.unhide(annotation)
 
-        assert svc.hidden(annotation.id) is False
+        assert svc.hidden(annotation) is False
 
     def test_it_leaves_othes_annotations_hidden(self, svc, factories, db_session):
         mod1, mod2 = factories.AnnotationModeration(), factories.AnnotationModeration()
 
         svc.unhide(mod1.annotation)
 
-        assert svc.hidden(mod2.annotation.id) is True
+        assert svc.hidden(mod2.annotation) is True
 
     def test_it_skips_hiding_annotation_when_not_hidden(self, svc, factories, db_session):
         annotation = factories.Annotation()
 
         svc.unhide(annotation)
 
-        assert svc.hidden(annotation.id) is False
+        assert svc.hidden(annotation) is False
 
 
 class TestAnnotationNipsaServiceFactory(object):


### PR DESCRIPTION
~**This is based on #4499 and needs a rebase once that one got merged.**~

The [recent changes to the nipsa subscriber](https://github.com/hypothesis/h/commit/c4b2bfcc22120dcff601a7ae27bd68bac9482095#diff-eb1d680a2a50ef1314ba44cd8edb1d12) meant that if we re-index batches of annotations (most notable when re-indexing from scratch) we did one query per annotation for checking the moderation state.

This PR adds a backref to the Annotation model (`Annotation.moderation`), and the `AnnotationModerationService.hidden` method changes the nipsa check to basically `(annotation.moderation is not None)`. This allows us to eager load this relationship and thus stop making a query per annotation.