### PR TITLE
Move memex.uri to h.util package

### DIFF
--- a/h/cli/commands/move_uri.py
+++ b/h/cli/commands/move_uri.py
@@ -5,7 +5,7 @@ import click
 from h import models
 from h.models.document import merge_documents
 from h.search.index import BatchIndexer
-from memex import uri
+from h.util import uri
 
 
 @click.command('move-uri')

--- a/h/cli/commands/normalize_uris.py
+++ b/h/cli/commands/normalize_uris.py
@@ -6,7 +6,7 @@ import click
 from h import models
 from h.models.document import merge_documents
 from h.search import index
-from memex import uri
+from h.util import uri
 
 
 class Window(namedtuple('Window', ['start', 'end'])):

--- a/h/migrations/versions/bcdd81e23920_fill_in_missing_annotation_document_id.py
+++ b/h/migrations/versions/bcdd81e23920_fill_in_missing_annotation_document_id.py
@@ -18,7 +18,7 @@ from sqlalchemy.orm import sessionmaker
 from sqlalchemy.orm import subqueryload
 
 from h.db import types
-from memex.uri import normalize as uri_normalize
+from h.util.uri import normalize as uri_normalize
 
 
 revision = 'bcdd81e23920'

--- a/h/models/annotation.py
+++ b/h/models/annotation.py
@@ -10,8 +10,8 @@ from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.ext.mutable import MutableDict, MutableList
 
 from h.db import Base, types
+from h.util import uri
 from memex import markdown
-from memex import uri
 
 
 class Annotation(Base):

--- a/h/models/document.py
+++ b/h/models/document.py
@@ -13,7 +13,7 @@ from sqlalchemy.ext.hybrid import hybrid_property
 from h._compat import urlparse
 from h.db import Base, mixins
 from h.models.annotation import Annotation
-from memex.uri import normalize as uri_normalize
+from h.util.uri import normalize as uri_normalize
 
 log = logging.getLogger(__name__)
 

--- a/h/search/query.py
+++ b/h/search/query.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from h import storage
-from memex import uri
+from h.util import uri
 
 LIMIT_DEFAULT = 20
 LIMIT_MAX = 200

--- a/h/services/flag.py
+++ b/h/services/flag.py
@@ -2,10 +2,7 @@
 
 from __future__ import unicode_literals
 
-from memex import uri
-
 from h import models
-from h import storage
 
 
 class FlagService(object):

--- a/h/util/uri.py
+++ b/h/util/uri.py
@@ -62,13 +62,17 @@ This package is responsible for defining URI normalization routines for use
 elsewhere in the Hypothesis application. URI expansion is handled by
 :py:function:`h.storage.expand_uri`.
 """
+
 import re
 
-from memex._compat import text_type
-from memex._compat import urlparse
-from memex._compat import url_quote, url_quote_plus
-from memex._compat import url_unquote, url_unquote_plus
-
+from h._compat import (
+    text_type,
+    url_quote,
+    url_quote_plus,
+    url_unquote,
+    url_unquote_plus,
+    urlparse,
+)
 
 URL_SCHEMES = set(['http', 'https'])
 

--- a/tests/h/util/uri_test.py
+++ b/tests/h/util/uri_test.py
@@ -4,8 +4,8 @@ from __future__ import unicode_literals
 
 import pytest
 
-from memex import uri
-from memex._compat import text_type
+from h._compat import text_type
+from h.util import uri
 
 TEST_URLS = [
     # Should replace http and https protocol with httpx


### PR DESCRIPTION
This moves the URI normalisation utilities to the `h.util.uri` module.

This is part of a project to reintegrate the `memex` package into the main `h` package: https://notes.wtk.io/2017/03/08/reintegrating-memex.