### PR TITLE
Protect more fields

### DIFF
--- a/h/migrations/versions/b102c50b1133_clean_up_moderation_extra_key.py
+++ b/h/migrations/versions/b102c50b1133_clean_up_moderation_extra_key.py
@@ -1,0 +1,54 @@
+"""
+Clean up moderation extra key
+
+Revision ID: b102c50b1133
+Revises: 50df3e6782aa
+Create Date: 2017-04-10 14:58:14.472500
+"""
+
+from __future__ import unicode_literals
+
+import logging
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql as pg
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.ext.mutable import MutableDict, MutableList
+from sqlalchemy.orm import sessionmaker
+
+from h.db import types
+
+revision = 'b102c50b1133'
+down_revision = '50df3e6782aa'
+
+Base = declarative_base()
+Session = sessionmaker()
+
+log = logging.getLogger(__name__)
+
+
+class Annotation(Base):
+    __tablename__ = 'annotation'
+    id = sa.Column(types.URLSafeUUID, primary_key=True)
+    extra = sa.Column(MutableDict.as_mutable(pg.JSONB),
+                      default=dict,
+                      server_default=sa.func.jsonb('{}'),
+                      nullable=False)
+
+
+def upgrade():
+    session = Session(bind=op.get_bind())
+
+    anns = session.query(Annotation).filter(Annotation.extra.has_key('moderation'))
+    found = 0
+    for ann in anns:
+        del ann.extra['moderation']
+        found += 1
+
+    log.info('Found and cleaned up %d annotations with a moderation key in the extras field', found)
+    session.commit()
+
+
+def downgrade():
+    pass

--- a/h/schemas/annotation.py
+++ b/h/schemas/annotation.py
@@ -264,7 +264,14 @@ def _format_jsonschema_error(error):
 
 def _remove_protected_fields(appstruct):
     # Some fields are not to be set by the user, ignore them.
-    for field in ['created', 'updated', 'user', 'id', 'links', 'flagged', 'hidden']:
+    for field in ['created',
+                  'updated',
+                  'user',
+                  'id',
+                  'links',
+                  'flagged',
+                  'hidden',
+                  'moderation']:
         appstruct.pop(field, None)
 
 

--- a/h/schemas/annotation.py
+++ b/h/schemas/annotation.py
@@ -264,7 +264,7 @@ def _format_jsonschema_error(error):
 
 def _remove_protected_fields(appstruct):
     # Some fields are not to be set by the user, ignore them.
-    for field in ['created', 'updated', 'user', 'id', 'links', 'flagged']:
+    for field in ['created', 'updated', 'user', 'id', 'links', 'flagged', 'hidden']:
         appstruct.pop(field, None)
 
 

--- a/tests/h/schemas/annotation_test.py
+++ b/tests/h/schemas/annotation_test.py
@@ -204,6 +204,7 @@ class TestCreateUpdateAnnotationSchema(object):
         'links',
         'flagged',
         'hidden',
+        'moderation',
     ])
     def test_it_removes_protected_fields(self, pyramid_request, validate, field):
         data = {}

--- a/tests/h/schemas/annotation_test.py
+++ b/tests/h/schemas/annotation_test.py
@@ -203,6 +203,7 @@ class TestCreateUpdateAnnotationSchema(object):
         'id',
         'links',
         'flagged',
+        'hidden',
     ])
     def test_it_removes_protected_fields(self, pyramid_request, validate, field):
         data = {}


### PR DESCRIPTION
Similar to #4462, this will add two new fields to the protected list. Since there is a subtle bug with having the `moderation` key in the extras field, I have also added a migration to clean that key up.

There are ideas floating around that we probably should and can maybe get rid of the `extra` field, so I haven't added a migration for cleaning up the `flagged` and `hidden` fields in that field.