### PR TITLE
Import h.models while initialising database

### DIFF
--- a/h/cli/commands/init.py
+++ b/h/cli/commands/init.py
@@ -6,7 +6,6 @@ import click
 import sqlalchemy
 
 from h import db
-from h import models  # noqa: import to ensure memex model base class is set
 from h import search
 
 log = logging.getLogger(__name__)

--- a/h/db/__init__.py
+++ b/h/db/__init__.py
@@ -51,6 +51,8 @@ Session = sessionmaker()
 
 def init(engine, base=Base, should_create=False, should_drop=False):
     """Initialise the database tables managed by `h.db`."""
+    # Import models package to populate the metadata
+    import h.models  # noqa
     if should_drop:
         base.metadata.reflect(engine)
         base.metadata.drop_all(engine)

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -55,7 +55,6 @@ def factories(db_session):
 @pytest.fixture(scope='session', autouse=True)
 def init_db(db_engine):
     from h import db
-    from h import models  # noqa
     db.init(db_engine, should_drop=True, should_create=True)
 
 


### PR DESCRIPTION
Rather than having each place that calls `h.db.init` have to ensure that the model metadata is correctly populated, it makes sense to move this responsibility into the `init` function itself.