### PR TITLE
Remove most references to the memex name

### DIFF
--- a/h/groups/__init__.py
+++ b/h/groups/__init__.py
@@ -2,4 +2,4 @@
 
 
 def includeme(config):
-    config.memex_add_search_filter('h.groups.search.GroupAuthFilter')
+    config.add_search_filter('h.groups.search.GroupAuthFilter')

--- a/h/nipsa/__init__.py
+++ b/h/nipsa/__init__.py
@@ -8,4 +8,4 @@ def includeme(config):
                           'h.events.AnnotationTransformEvent')
 
     # Register an additional filter with the API search module
-    config.memex_add_search_filter('h.nipsa.search.Filter')
+    config.add_search_filter('h.nipsa.search.Filter')

--- a/h/search/__init__.py
+++ b/h/search/__init__.py
@@ -22,13 +22,13 @@ def includeme(config):
     # search matcher factories.
     config.registry[FILTERS_KEY] = []
     config.registry[MATCHERS_KEY] = []
-    config.add_directive('memex_add_search_filter',
+    config.add_directive('add_search_filter',
                          lambda c, f: c.registry[FILTERS_KEY].append(config.maybe_dotted(f)))
-    config.add_directive('memex_get_search_filters',
+    config.add_directive('get_search_filters',
                          lambda c: c.registry[FILTERS_KEY])
-    config.add_directive('memex_add_search_matcher',
+    config.add_directive('add_search_matcher',
                          lambda c, m: c.registry[MATCHERS_KEY].append(config.maybe_dotted(m)))
-    config.add_directive('memex_get_search_matchers',
+    config.add_directive('get_search_matchers',
                          lambda c: c.registry[MATCHERS_KEY])
 
     # Add a property to all requests for easy access to the elasticsearch

--- a/h/search/core.py
+++ b/h/search/core.py
@@ -7,8 +7,8 @@ from elasticsearch.exceptions import ConnectionTimeout
 
 from h.search import query
 
-FILTERS_KEY = 'memex.search.filters'
-MATCHERS_KEY = 'memex.search.matchers'
+FILTERS_KEY = 'h.search.filters'
+MATCHERS_KEY = 'h.search.matchers'
 
 log = logging.getLogger(__name__)
 

--- a/h/services/groupfinder.py
+++ b/h/services/groupfinder.py
@@ -10,7 +10,8 @@ from h.util.db import lru_cache_in_transaction
 from h.groups.util import WorldGroup
 
 
-# Ideally this would be called the GroupService to match nomenclature in memex.
+# Ideally this would be called the GroupService to match the nomenclature of
+# the interface.
 # FIXME: rename / split existing GroupService and rename this.
 @implementer(IGroupService)
 class GroupfinderService(object):

--- a/tests/functional/test_api.py
+++ b/tests/functional/test_api.py
@@ -26,7 +26,7 @@ class TestAPI(object):
         Write an annotation to a group that doesn't allow writes.
 
         This is a basic test to check that h is correctly configuring the
-        memex groupfinder. Because memex is permissive by default.
+        groupfinder.
         """
 
         user, token = user_with_token

--- a/tests/h/groups/__init___test.py
+++ b/tests/h/groups/__init___test.py
@@ -8,16 +8,16 @@ from h.groups.search import GroupAuthFilter
 
 def test_includeme_registers_search_filter(pyramid_config):
     includeme(pyramid_config)
-    assert GroupAuthFilter in pyramid_config.memex_get_search_filters()
+    assert GroupAuthFilter in pyramid_config.get_search_filters()
 
 
 @pytest.fixture
 def pyramid_config(pyramid_config):
-    pyramid_config.add_directive('memex_set_groupfinder', lambda c, f: None)
+    pyramid_config.add_directive('set_groupfinder', lambda c, f: None)
 
     filters = []
-    pyramid_config.add_directive('memex_add_search_filter',
+    pyramid_config.add_directive('add_search_filter',
                                  lambda c, f: filters.append(pyramid_config.maybe_dotted(f)))
-    pyramid_config.add_directive('memex_get_search_filters',
+    pyramid_config.add_directive('get_search_filters',
                                  lambda c: filters)
     return pyramid_config


### PR DESCRIPTION
This commit:

- renames some configuration directives that come from memex
- renames a couple of internal registry keys
- updates some code comments

to remove most of the remaining references to the "memex" name from the code.

The main remaining items are:

- clean up a duplication of APIError exception classes between h and (ex-)memex code
- rename some metrics