### PR TITLE
Conditionally redirect users from homepage

### DIFF
--- a/h/config.py
+++ b/h/config.py
@@ -89,6 +89,8 @@ SETTINGS = [
     # *not* toggle functionality based on this value. It is intended as a
     # label only.
     EnvSetting('h.env', 'ENV'),
+    # Where should logged-out users visiting the homepage be redirected?
+    EnvSetting('h.homepage_redirect_url', 'HOMEPAGE_REDIRECT_URL'),
     EnvSetting('h.proxy_auth', 'PROXY_AUTH', type=asbool),
     # Sentry DSNs for frontend code should be of the public kind, lacking the
     # password component in the DSN URI.

--- a/h/models/feature.py
+++ b/h/models/feature.py
@@ -17,6 +17,7 @@ FEATURES = {
                           " annotations in sidebar?"),
     'flag_action': ("Enable user to flag inappropriate annotations in the "
                     "client?"),
+    'homepage_redirects': "Enable homepage redirects (for WordPress migration)?",
     'orphans_tab': "Show the orphans tab to separate anchored and unanchored annotations?",
     'total_shared_annotations': "Show the total number of shared annotations for users and groups?",
 }

--- a/h/views/home.py
+++ b/h/views/home.py
@@ -33,3 +33,21 @@ def index(context, request):
         )
 
     return context
+
+
+@view_config(route_name='index',
+             request_method='GET',
+             feature='homepage_redirects')
+def index_redirect(context, request):
+    try:
+        redirect = request.registry.settings['h.homepage_redirect_url']
+    except KeyError:
+        # When the redirect URL isn't explicitly configured, we send people to
+        # the main activity stream.
+        redirect = request.route_url('activity.search')
+
+    if request.user is not None:
+        redirect = request.route_url('activity.user_search',
+                                     username=request.user.username)
+
+    raise httpexceptions.HTTPFound(redirect)

--- a/tests/h/views/home_test.py
+++ b/tests/h/views/home_test.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import pytest
+
+from pyramid.httpexceptions import HTTPFound
+
+from h.views.home import index_redirect
+
+
+@pytest.mark.usefixtures('routes')
+class TestIndexRedirect(object):
+    def test_redirects_to_user_search_page_for_user(self,
+                                                    factories,
+                                                    pyramid_request):
+        pyramid_request.user = factories.User(username='petronela')
+
+        with pytest.raises(HTTPFound) as exc:
+            index_redirect(None, pyramid_request)
+
+        assert exc.value.location == 'http://example.com/u/s/petronela'
+
+    def test_redirects_to_search_if_no_user(self, pyramid_request):
+        pyramid_request.user = None
+
+        with pytest.raises(HTTPFound) as exc:
+            index_redirect(None, pyramid_request)
+
+        assert exc.value.location == 'http://example.com/s'
+
+    def test_respects_setting(self, pyramid_request):
+        pyramid_request.registry.settings['h.homepage_redirect_url'] = 'https://web.hypothes.is'
+        pyramid_request.user = None
+
+        with pytest.raises(HTTPFound) as exc:
+            index_redirect(None, pyramid_request)
+
+        assert exc.value.location == 'https://web.hypothes.is'
+
+
+@pytest.fixture
+def routes(pyramid_config):
+    pyramid_config.add_route('activity.search', '/s')
+    pyramid_config.add_route('activity.user_search', '/u/s/{username}')


### PR DESCRIPTION
Once our marketing website has moved fully off the main application domain, we'll serve redirects from the root URL that depend on the user's logged-in status.

If a user is logged in, they are redirected to their own profile page. If they're not, they are redirected to the marketing website.

The URL to which logged-out users are redirected is configured using the `HOMEPAGE_REDIRECT_URL` environment variable.

This change is feature-flagged (`homepage_redirects`).

~~_**N.B.** This PR is based on #4518 and will probably be easier to review once that's merged and this is rebased._~~