### PR TITLE
Remove the ability to autoconfigure from Docker links

### DIFF
--- a/h/config.py
+++ b/h/config.py
@@ -12,7 +12,6 @@ from pyramid.settings import asbool
 
 from h.settings import (
     DeprecatedSetting,
-    DockerSetting,
     EnvSetting,
     SettingError,
     database_url,
@@ -32,18 +31,7 @@ DEFAULT_SALT = (b"\xbc\x9ck!k\x81(\xb6I\xaa\x90\x0f'}\x07\xa1P\xd9\xb7\xcb"
 
 # The list of all settings read from the system environment. These are in
 # reverse-priority order, meaning that later settings trump earlier settings.
-# In general, automatic setup (such as Docker links) is overridden by explicit
-# settings.
 SETTINGS = [
-    # Automatic configuration of remote services via Docker links
-    DockerSetting('es.host', 'elasticsearch',
-                  pattern='http://{port_9200_tcp_addr}:{port_9200_tcp_port}'),
-    DockerSetting('mail.host', 'mail',
-                  pattern='{port_25_tcp_addr}'),
-    DockerSetting('mail.port', 'mail', pattern='{port_25_tcp_port}'),
-    DockerSetting('statsd.host', 'statsd', pattern='{port_8125_udp_addr}'),
-    DockerSetting('statsd.port', 'statsd', pattern='{port_8125_udp_port}'),
-
     # Mailer configuration for Mandrill
     mandrill_settings,
 

--- a/h/settings.py
+++ b/h/settings.py
@@ -5,7 +5,6 @@
 from __future__ import unicode_literals
 
 import logging
-import string
 
 log = logging.getLogger(__name__)
 
@@ -62,31 +61,6 @@ class EnvSetting(object):
 
     def __str__(self):
         return 'environment variable {name}'.format(name=self.varname)
-
-
-class DockerSetting(object):
-
-    """A setting read from Docker link environment variables."""
-
-    def __init__(self, setting, link, pattern):
-        self.setting = setting
-        self.link = link.upper()
-        self.pattern = pattern
-
-        # Determine the settings that need to be present
-        formatter = string.Formatter()
-        self.placeholders = [field
-                             for _, field, _, _ in formatter.parse(pattern)
-                             if field is not None]
-
-    def __call__(self, environ):
-        try:
-            values = {x: environ['{}_{}'.format(self.link, x.upper())]
-                      for x in self.placeholders}
-        except KeyError:
-            pass
-        else:
-            return {self.setting: self.pattern.format(**values)}
 
 
 def database_url(url):

--- a/tests/h/settings_test.py
+++ b/tests/h/settings_test.py
@@ -69,28 +69,6 @@ def test_env_setting_returns_nicer_error_for_type_failure():
         func({'PORT': 'notanint'})
 
 
-@pytest.mark.parametrize('setting,link,pattern,environ,expected', (
-    # Should return None if any of the required vars aren't set
-    ('database_url', 'db', 'db://{addr}', {}, None),
-    ('database_url', 'db', 'db://{addr}', {'DB_HOST': 'foo'}, None),
-    ('database_url', 'db', 'db://{host}:{port}', {'DB_ADDR': 'foo'}, None),
-
-    # Should return the settings object if all of the parts are available
-    ('database_url', 'db', 'db://{addr}',
-     {'DB_ADDR': 'foo'},
-     {'database_url': 'db://foo'}),
-    ('database_url', 'db', 'db://{host}:{port}',
-     {'DB_HOST': 'foo', 'DB_PORT': '123'},
-     {'database_url': 'db://foo:123'}),
-))
-def test_docker_setting(setting, link, pattern, environ, expected):
-    func = settings.DockerSetting(setting, link, pattern)
-
-    result = func(environ)
-
-    assert result == expected
-
-
 def test_database_url():
     url = 'postgres://postgres:1234/database'
     expected = 'postgresql+psycopg2://postgres:1234/database'


### PR DESCRIPTION
As far as I know nobody uses the Docker link automagical configuration support, so this commit removes it. Even if people do currently use this setup mechanism, they probably shouldn't: Docker links are deprecated[1].

[1]: https://docs.docker.com/engine/userguide/networking/default_network/dockerlinks/