### PR TITLE
Pull formatters into the presenter constructor

### DIFF
--- a/h/presenters/annotation_json.py
+++ b/h/presenters/annotation_json.py
@@ -17,18 +17,22 @@ class AnnotationJSONPresenter(AnnotationBasePresenter):
 
     """Present an annotation in the JSON format returned by API requests."""
 
-    def __init__(self, annotation_resource):
+    def __init__(self, annotation_resource, formatters=None):
         super(AnnotationJSONPresenter, self).__init__(annotation_resource)
 
-        self.formatters = []
+        self._formatters = []
 
-    def add_formatter(self, formatter):
+        if formatters is not None:
+            for formatter in formatters:
+                self._add_formatter(formatter)
+
+    def _add_formatter(self, formatter):
         try:
             verifyObject(IAnnotationFormatter, formatter)
         except DoesNotImplement:
             raise ValueError('formatter is not implementing IAnnotationFormatter interface')
 
-        self.formatters.append(formatter)
+        self._formatters.append(formatter)
 
     def asdict(self):
         docpresenter = DocumentJSONPresenter(self.annotation.document)
@@ -54,7 +58,7 @@ class AnnotationJSONPresenter(AnnotationBasePresenter):
         annotation = copy.copy(self.annotation.extra) or {}
         annotation.update(base)
 
-        for formatter in self.formatters:
+        for formatter in self._formatters:
             annotation.update(formatter.format(self.annotation_resource))
 
         return annotation

--- a/h/services/annotation_json_presentation.py
+++ b/h/services/annotation_json_presentation.py
@@ -45,12 +45,8 @@ class AnnotationJSONPresentationService(object):
                 for ann in annotations]
 
     def _get_presenter(self, annotation_resource):
-        presenter = presenters.AnnotationJSONPresenter(annotation_resource)
-
-        for formatter in self.formatters:
-            presenter.add_formatter(formatter)
-
-        return presenter
+        return presenters.AnnotationJSONPresenter(annotation_resource,
+                                                  self.formatters)
 
 
 def annotation_json_presentation_service_factory(context, request):

--- a/tests/h/services/annotation_json_presentation_test.py
+++ b/tests/h/services/annotation_json_presentation_test.py
@@ -43,16 +43,15 @@ class TestAnnotationJSONPresentationService(object):
     def test_present_inits_presenter(self, svc, presenters, annotation_resource):
         svc.present(annotation_resource)
 
-        presenters.AnnotationJSONPresenter.assert_called_once_with(annotation_resource)
+        presenters.AnnotationJSONPresenter.assert_called_once_with(annotation_resource, mock.ANY)
 
     def test_present_adds_formatters(self, svc, annotation_resource, presenters):
         formatters = [mock.Mock(), mock.Mock()]
         svc.formatters = formatters
-        presenter = presenters.AnnotationJSONPresenter.return_value
 
         svc.present(annotation_resource)
 
-        assert presenter.add_formatter.mock_calls == [mock.call(f) for f in formatters]
+        presenters.AnnotationJSONPresenter.assert_called_once_with(mock.ANY, formatters)
 
     def test_present_returns_presenter_dict(self, svc, presenters):
         presenter = presenters.AnnotationJSONPresenter.return_value


### PR DESCRIPTION
By pulling this into a constructor argument and adding the mystic underscore to take the `formatters` attribute out of the public interface, I'm hoping to achieve two things:

- Make it easier to pull formatters into a more general-purpose capability for all presenters.
- Stop us having to worry about extra formatters being added to a presenter after it's been constructed. We weren't doing this anywhere anyway, so making it so we don't even have to think about it seems helpful.

I've committed the cardinal Python sin here of putting a mutable default value into a constructor (the empty list of presenters). This saves having to assign it a default value within the method, and since we iterate over the argument and then discard it I don't think it's a risk, but we can change this if people have strong feelings.