### PR TITLE
Add the new `/api/links` endpoint

### DIFF
--- a/h/routes.py
+++ b/h/routes.py
@@ -68,6 +68,7 @@ def includeme(config):
     # construct URLs incorrectly if its `apiUrl` setting does not end in a
     # trailing slash.
     config.add_route('api.index', '/api/')
+    config.add_route('api.links', '/api/links')
     config.add_route('api.annotations', '/api/annotations')
     config.add_route('api.annotation',
                      '/api/annotations/{id:[A-Za-z0-9_-]{20,22}}',

--- a/h/views/api.py
+++ b/h/views/api.py
@@ -179,6 +179,32 @@ def index(context, request):
     }
 
 
+@api_config(route_name='api.links',
+            link_name='links',
+            description='URL templates for generating URLs for HTML pages')
+def links(context, request):
+    group_leave_url = request.route_url('group_leave', pubid='_id_')
+    group_leave_url = group_leave_url.replace('_id_', ':id')
+
+    tag_search_url = request.route_url('activity.search',
+                                       _query={'q': '_query_'})
+    tag_search_url = tag_search_url.replace('_query_', 'tag:":tag"')
+
+    user_url = request.route_url('stream.user_query', user='_user_')
+    user_url = user_url.replace('_user_', ':user')
+
+    return {
+        'account.settings': request.route_url('account'),
+        'forgot-password': request.route_url('forgot_password'),
+        'groups.leave': group_leave_url,
+        'groups.new': request.route_url('group_create'),
+        'help': request.route_url('help'),
+        'search.tag': tag_search_url,
+        'signup': request.route_url('signup'),
+        'user': user_url,
+    }
+
+
 @api_config(route_name='api.search',
             link_name='search',
             description='Search for annotations')

--- a/tests/h/routes_test.py
+++ b/tests/h/routes_test.py
@@ -57,6 +57,7 @@ def test_includeme():
         call('stream.tag_query', '/t/{tag}'),
         call('assets', '/assets/*subpath'),
         call('api.index', '/api/'),
+        call('api.links', '/api/links'),
         call('api.annotations', '/api/annotations'),
         call('api.annotation',
              '/api/annotations/{id:[A-Za-z0-9_-]{20,22}}',

--- a/tests/h/views/api_test.py
+++ b/tests/h/views/api_test.py
@@ -126,6 +126,7 @@ class TestIndex(object):
         pyramid_config.add_route('api.search', '/dummy/search')
         pyramid_config.add_route('api.annotations', '/dummy/annotations')
         pyramid_config.add_route('api.annotation', '/dummy/annotations/:id')
+        pyramid_config.add_route('api.links', '/dummy/links')
 
         result = views.index(testing.DummyResource(), pyramid_request)
 
@@ -146,6 +147,32 @@ class TestIndex(object):
         assert links['search']['method'] == 'GET'
         assert links['search']['url'] == host + '/dummy/search'
 
+
+class TestLinks(object):
+
+    def test_it_returns_the_right_links(self, pyramid_config, pyramid_request):
+        pyramid_config.add_route('account', '/account/settings')
+        pyramid_config.add_route('forgot_password', '/forgot-password')
+        pyramid_config.add_route('group_leave', '/groups/{pubid}/leave')
+        pyramid_config.add_route('group_create', '/groups/new')
+        pyramid_config.add_route('help', '/docs/help')
+        pyramid_config.add_route('activity.search', '/search')
+        pyramid_config.add_route('signup', '/signup')
+        pyramid_config.add_route('stream.user_query', '/u/{user}')
+
+        links = views.links(testing.DummyResource(), pyramid_request)
+
+        host = 'http://example.com'  # Pyramid's default host URL.
+        assert links == {
+            'account.settings': host + '/account/settings',
+            'forgot-password': host + '/forgot-password',
+            'groups.leave': host + '/groups/:id/leave',
+            'groups.new': host + '/groups/new',
+            'help': host + '/docs/help',
+            'search.tag': host + '/search?q=tag:":tag"',
+            'signup': host + '/signup',
+            'user': host + '/u/:user',
+        }
 
 @pytest.mark.usefixtures('presentation_service', 'search_lib')
 class TestSearch(object):


### PR DESCRIPTION
Add the new `/api/links` endpoint and add a link to this endpoint to the existing `/api` endpoint. This new endpoint will be used by the client to get the URL templates for generating URLs to HTML pages of the web service. This is part of https://github.com/hypothesis/product-backlog/issues/215