### PR TITLE
Update the "engines" entry in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "websocket": "^1.0.22"
   },
   "engines": {
-    "node": "0.10.x"
+    "node": ">=6"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
We haven't supported Node v0.10 for a long time. The current requirement is Node v6+ (the current stable/LTS release).

_Edit: An earlier version of this PR removed the field entirely. At @fatbusinessman 's suggestion I've revised it to just update the field_.