### PR TITLE
Generalise redirect tween

### DIFF
--- a/h/redirects
+++ b/h/redirects
@@ -1,0 +1,12 @@
+# Redirects to be checked before passing a request on to the application.
+#
+# Note that if this file is removed or incorrectly formatted, the application
+# will fail to boot. For details of the format, see h/util/redirects.py.
+
+# Legacy application URLs
+/profile/notifications internal-prefix account_notifications
+/profile/developer     internal-prefix account_developer
+/profile               internal-prefix account
+/register              internal-prefix signup
+/forgot_password       internal-prefix forgot_password
+/reset_password        internal-prefix account_reset

--- a/h/util/redirects.py
+++ b/h/util/redirects.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+
+"""
+Utilities for processing a set of redirect specifications from a text file.
+
+Redirects can be specified in a simple text-based format, in which each line
+consists of three whitespace-delimited fields:
+
+    <source path> <redirect type> <destination>
+
+The redirect type can be one of the following:
+
+    exact           - requests with paths that exactly match the specified
+                      source path will be redirected to the destination URL.
+    prefix          - requests with paths that start with the specified source
+                      path will be redirected to URLs relative to the
+                      destination URL.
+    internal-exact  - same as `exact`, but the destination will be treated as
+                      a route name rather than a URL.
+    internal-prefix - same as `prefix`, but the destination will be treated as
+                      a route name rather than a URL.
+
+Lines that contain only whitespace, or which start with a '#' character, will
+be ignored.
+"""
+
+from collections import namedtuple
+
+
+class Redirect(namedtuple('Redirect', [
+    'src',       # matching prefix (if prefix redirect) or path (if exact)
+    'dst',       # route name (if internal redirect) or URL (if external)
+    'prefix',    # prefix redirect if true, exact otherwise
+    'internal',  # internal redirect if true, external otherwise
+])):
+    pass
+
+
+class ParseError(Exception):
+    pass
+
+
+def lookup(redirects, request):
+    """
+    Check if a request matches any of a list of redirects.
+
+    Returns None if the request does not match, and the URL to redirect to
+    otherwise.
+    """
+    for r in redirects:
+        if r.prefix and request.path.startswith(r.src):
+            suffix = request.path.replace(r.src, '', 1)
+            return _dst_root(request, r) + suffix
+        elif not r.prefix and request.path == r.src:
+            return _dst_root(request, r)
+    return None
+
+
+def parse(specs):
+    """Parse a list of redirects from a sequence of redirect specifiers."""
+    result = []
+    for line in specs:
+        # Ignore comments and blank lines
+        if line.startswith('#') or not line.strip():
+            continue
+
+        try:
+            src, typ, dst = line.split(None, 3)
+        except ValueError:
+            raise ParseError('invalid redirect specification: {!r}'.format(line))
+        if typ == 'internal-exact':
+            r = Redirect(prefix=False, internal=True, src=src, dst=dst)
+        elif typ == 'internal-prefix':
+            r = Redirect(prefix=True, internal=True, src=src, dst=dst)
+        elif typ == 'exact':
+            r = Redirect(prefix=False, internal=False, src=src, dst=dst)
+        elif typ == 'prefix':
+            r = Redirect(prefix=True, internal=False, src=src, dst=dst)
+        else:
+            raise ParseError('unknown redirect type: {!r}'.format(typ))
+        result.append(r)
+    return result
+
+
+def _dst_root(request, redirect):
+    if redirect.internal:
+        return request.route_url(redirect.dst)
+    else:
+        return redirect.dst

--- a/tests/h/util/redirects_test.py
+++ b/tests/h/util/redirects_test.py
@@ -1,0 +1,150 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+from hypothesis import strategies as st
+from hypothesis import given
+
+from h.util.redirects import ParseError, Redirect, lookup, parse
+
+WHITESPACE = ' \t'
+
+
+@pytest.mark.usefixtures('routes')
+class TestLookup(object):
+
+    def test_none_when_empty(self, pyramid_request):
+        result = lookup([], pyramid_request)
+
+        assert result is None
+
+    def test_none_when_no_match(self, pyramid_request):
+        pyramid_request.path = '/bar'
+        redirects = [
+            Redirect(src='/foo', dst='http://giraffe.com/bar', internal=False, prefix=False),
+        ]
+
+        result = lookup(redirects, pyramid_request)
+
+        assert result is None
+
+    def test_exact(self, pyramid_request):
+        pyramid_request.path = '/foo'
+        redirects = [
+            Redirect(src='/foo', dst='http://giraffe.com/bar', internal=False, prefix=False),
+        ]
+
+        result = lookup(redirects, pyramid_request)
+
+        assert result == 'http://giraffe.com/bar'
+
+    def test_prefix(self, pyramid_request):
+        pyramid_request.path = '/foo/bar'
+        redirects = [
+            Redirect(src='/foo', dst='http://giraffe.com', internal=False, prefix=True),
+        ]
+
+        result = lookup(redirects, pyramid_request)
+
+        assert result == 'http://giraffe.com/bar'
+
+    def test_internal_exact(self, pyramid_request):
+        pyramid_request.path = '/foo'
+        redirects = [
+            Redirect(src='/foo', dst='donkey', internal=True, prefix=False),
+        ]
+
+        result = lookup(redirects, pyramid_request)
+
+        assert result == 'http://example.com/donkey'
+
+    def test_internal_prefix(self, pyramid_request):
+        pyramid_request.path = '/foo/bar'
+        redirects = [
+            Redirect(src='/foo', dst='donkey', internal=True, prefix=True),
+        ]
+
+        result = lookup(redirects, pyramid_request)
+
+        assert result == 'http://example.com/donkey/bar'
+
+    def test_ordering_indicates_priority(self, pyramid_request):
+        """
+        Earlier matching redirect specifications should be chosen over later
+        ones.
+        """
+        pyramid_request.path = '/foo/bar'
+        redirects = [
+            Redirect(src='/foo', dst='http://giraffe.com', internal=False, prefix=True),
+            Redirect(src='/foo/bar', dst='http://elephant.com', internal=False, prefix=False),
+        ]
+
+        result = lookup(redirects, pyramid_request)
+
+        assert result == 'http://giraffe.com/bar'
+
+    @pytest.fixture
+    def routes(self, pyramid_config):
+        pyramid_config.add_route('donkey', '/donkey')
+
+
+class TestParse(object):
+
+    def test_basic(self):
+        result = parse(['/foo exact http://giraffe.com/bar'])
+
+        assert result == [
+            Redirect(src='/foo', dst='http://giraffe.com/bar', internal=False, prefix=False),
+        ]
+
+    def test_multiline(self):
+        result = parse(['/foo exact http://giraffe.com/bar',
+                        '/bar prefix http://elephant.org/',
+                        '/baz/bat internal-exact tapir',
+                        '/qux internal-prefix donkey'])
+
+        assert result == [
+            Redirect(src='/foo', dst='http://giraffe.com/bar', internal=False, prefix=False),
+            Redirect(src='/bar', dst='http://elephant.org/', internal=False, prefix=True),
+            Redirect(src='/baz/bat', dst='tapir', internal=True, prefix=False),
+            Redirect(src='/qux', dst='donkey', internal=True, prefix=True),
+        ]
+
+    @given(st.data())
+    def test_ignores_whitespace(self, data):
+        line = [
+            data.draw(st.text(alphabet=WHITESPACE)),
+            '/foo',
+            data.draw(st.text(alphabet=WHITESPACE, min_size=1)),
+            'exact',
+            data.draw(st.text(alphabet=WHITESPACE, min_size=1)),
+            'http://giraffe.com/bar',
+            data.draw(st.text(alphabet=WHITESPACE)),
+        ]
+
+        result = parse([''.join(line)])
+
+        assert result == [
+            Redirect(src='/foo', dst='http://giraffe.com/bar', internal=False, prefix=False),
+        ]
+
+    @given(lines=st.lists(st.text(alphabet=WHITESPACE)))
+    def test_ignores_whitespace_only_lines(self, lines):
+        result = parse(lines)
+
+        assert result == []
+
+    @given(lines=st.lists(st.text()))
+    def test_ignores_comment_lines(self, lines):
+        result = parse(['#' + l for l in lines])
+
+        assert result == []
+
+    def test_misformatted_line_raises(self):
+        with pytest.raises(ParseError) as e:
+            parse(['/foo exact somethingelse http://giraffe.com/bar'])
+        assert 'invalid' in e.value.message
+
+    def test_unknown_type_raises(self):
+        with pytest.raises(ParseError) as e:
+            parse(['/foo magic http://giraffe.com/bar'])
+        assert 'type' in e.value.message


### PR DESCRIPTION
We are shortly going to need to add a large number of redirects to the application. In preparation for this, this commit:

- moves the definition of redirects into a text file with a relatively simple format
- moves the parsing of this file and the looking up of redirects into functions provided by a `h.util.redirects` module
- adds support for various types of redirect not currently supported by the redirect tween