### PR TITLE
Remove duplication of exception classes

### DIFF
--- a/h/exceptions.py
+++ b/h/exceptions.py
@@ -7,8 +7,6 @@ from __future__ import unicode_literals
 from h.i18n import TranslationString as _
 
 
-# N.B. This class **only** covers exceptions thrown by API code provided by
-# the h package. memex code has its own base APIError class.
 class APIError(Exception):
 
     """Base exception for problems handling API requests."""
@@ -42,3 +40,15 @@ class OAuthTokenError(APIError):
     def __init__(self, message, type_, status_code=400):
         self.type = type_
         super(OAuthTokenError, self).__init__(message, status_code=status_code)
+
+
+class PayloadError(APIError):
+
+    """
+    Exception raised for API requests made with missing/invalid
+    payloads.
+    """
+
+    def __init__(self):
+        message = _('Expected a valid JSON payload, but none was found!')
+        super(PayloadError, self).__init__(message, status_code=400)

--- a/h/views/api.py
+++ b/h/views/api.py
@@ -22,11 +22,11 @@ import venusian
 
 from h import search as search_lib
 from h import storage
+from h.exceptions import PayloadError
 from h.events import AnnotationEvent
 from h.interfaces import IGroupService
 from h.presenters import AnnotationJSONPresenter, AnnotationJSONLDPresenter
 from h.resources import AnnotationResource
-from h.schemas import ValidationError
 from h.schemas.annotation import CreateAnnotationSchema, UpdateAnnotationSchema
 from h.util import cors
 
@@ -43,26 +43,6 @@ cors_policy = cors.policy(
     ),
     allow_methods=('HEAD', 'GET', 'PATCH', 'POST', 'PUT', 'DELETE'),
     allow_preflight=True)
-
-
-class APIError(Exception):
-
-    """Base exception for problems handling API requests."""
-
-    def __init__(self, message, status_code=500):
-        self.status_code = status_code
-        super(APIError, self).__init__(message)
-
-
-class PayloadError(APIError):
-
-    """Exception raised for API requests made with missing/invalid payloads."""
-
-    def __init__(self):
-        super(PayloadError, self).__init__(
-            _('Expected a valid JSON payload, but none was found!'),
-            status_code=400
-        )
 
 
 def add_api_view(config, view, link_name=None, description=None, **settings):
@@ -136,18 +116,6 @@ def api_config(link_name=None, description=None, **settings):
         return wrapped
 
     return wrapper
-
-
-@api_config(context=APIError)
-def error_api(context, request):
-    request.response.status_code = context.status_code
-    return {'status': 'failure', 'reason': context.message}
-
-
-@api_config(context=ValidationError)
-def error_validation(context, request):
-    request.response.status_code = 400
-    return {'status': 'failure', 'reason': context.message}
 
 
 @api_config(route_name='api.index')

--- a/tests/h/views/api_test.py
+++ b/tests/h/views/api_test.py
@@ -11,30 +11,6 @@ from h.search.core import SearchResult
 from h.views import api as views
 
 
-class TestError(object):
-
-    def test_it_sets_status_code_from_error(self, pyramid_request):
-        exc = views.APIError("it exploded", status_code=429)
-
-        views.error_api(exc, pyramid_request)
-
-        assert pyramid_request.response.status_code == 429
-
-    def test_it_returns_status_object(self, pyramid_request):
-        exc = views.APIError("it exploded", status_code=429)
-
-        result = views.error_api(exc, pyramid_request)
-
-        assert result == {'status': 'failure', 'reason': 'it exploded'}
-
-    def test_it_sets_bad_request_status_code(self, pyramid_request):
-        exc = mock.Mock(message="it exploded")
-
-        views.error_validation(exc, pyramid_request)
-
-        assert pyramid_request.response.status_code == 400
-
-
 class TestAddApiView(object):
     def test_it_sets_accept_setting(self, pyramid_config, view):
         views.add_api_view(pyramid_config, view)


### PR DESCRIPTION
Removes some duplication of exception classes and exception views introduced by the reintegration of the memex package. APIError is now defined in one place and the views in `h/views/api_exceptions.py` are the only exception views for the API.