### PR TITLE
Rename some metrics with memex in their name

### DIFF
--- a/h/search/core.py
+++ b/h/search/core.py
@@ -130,15 +130,15 @@ class Search(object):
             return
 
         s = self.stats.pipeline()
-        timer = s.timer('memex.search.query').start()
+        timer = s.timer('search.query').start()
         try:
             yield
-            s.incr('memex.search.query.success')
+            s.incr('search.query.success')
         except ConnectionTimeout:
-            s.incr('memex.search.query.timeout')
+            s.incr('search.query.timeout')
             raise
         except:
-            s.incr('memex.search.query.error')
+            s.incr('search.query.error')
             raise
         finally:
             timer.stop()

--- a/h/views/api.py
+++ b/h/views/api.py
@@ -250,7 +250,7 @@ def read_jsonld(context, request):
 def update(context, request):
     """Update the specified annotation with data from the PATCH payload."""
     if request.method == 'PUT' and hasattr(request, 'stats'):
-        request.stats.incr('memex.api.deprecated.put_update_annotation')
+        request.stats.incr('api.deprecated.put_update_annotation')
 
     schema = UpdateAnnotationSchema(request,
                                     context.annotation.target_uri,

--- a/tests/h/views/api_test.py
+++ b/tests/h/views/api_test.py
@@ -488,7 +488,7 @@ class TestUpdate(object):
 
         views.update(mock.Mock(), pyramid_request)
 
-        pyramid_request.stats.incr.assert_called_once_with('memex.api.deprecated.put_update_annotation')
+        pyramid_request.stats.incr.assert_called_once_with('api.deprecated.put_update_annotation')
 
     @pytest.fixture
     def pyramid_request(self, pyramid_request):


### PR DESCRIPTION
Rename some statsd metric names to reflect the fact that `memex` is no longer a thing.