### PR TITLE
Allow groups without a creator

### DIFF
--- a/h/migrations/versions/21b1ce37e327_allow_null_group_creator.py
+++ b/h/migrations/versions/21b1ce37e327_allow_null_group_creator.py
@@ -1,0 +1,23 @@
+"""
+Allow null group.creator
+
+Revision ID: 21b1ce37e327
+Revises: 9389d52b037d
+Create Date: 2017-04-13 16:49:16.218511
+"""
+
+from __future__ import unicode_literals
+
+from alembic import op
+
+
+revision = '21b1ce37e327'
+down_revision = '9389d52b037d'
+
+
+def upgrade():
+    op.alter_column('group', 'creator_id', nullable=True)
+
+
+def downgrade():
+    op.alter_column('group', 'creator_id', nullable=False)

--- a/h/models/group.py
+++ b/h/models/group.py
@@ -59,7 +59,7 @@ class Group(Base, mixins.Timestamps):
     # currently, but it seems careless to lose this information when in the
     # future these people may be the first admins of their groups.
     creator_id = sa.Column(
-        sa.Integer, sa.ForeignKey('user.id'), nullable=False)
+        sa.Integer, sa.ForeignKey('user.id'))
     creator = sa.orm.relationship('User')
 
     description = sa.Column(sa.UnicodeText())
@@ -147,7 +147,8 @@ class Group(Base, mixins.Timestamps):
         if write_principal is not None:
             terms.append((security.Allow, write_principal, 'write'))
 
-        terms.append((security.Allow, self.creator.userid, 'admin'))
+        if self.creator:
+            terms.append((security.Allow, self.creator.userid, 'admin'))
         terms.append(security.DENY_ALL)
 
         return terms

--- a/h/templates/admin/groups.html.jinja2
+++ b/h/templates/admin/groups.html.jinja2
@@ -35,9 +35,11 @@
               </a>
             </td>
             <td>
-              <a href="{{ request.route_url('admin_users', _query={'username': group.creator.username, 'authority': group.creator.authority}) }}">
-                {{ group.creator.username }}
-              </a>
+              {% if group.creator %}
+                <a href="{{ request.route_url('admin_users', _query={'username': group.creator.username, 'authority': group.creator.authority}) }}">
+                  {{ group.creator.username }}
+                </a>
+              {% endif %}
             </td>
             <td>{{ group.members|length }}</td>
           </tr>

--- a/h/views/admin_groups.py
+++ b/h/views/admin_groups.py
@@ -24,13 +24,21 @@ def groups_index_csv(request):
 
     header = ['Group name', 'Group URL', 'Creator username',
               'Creator email', 'Number of members']
-    rows = [[group.name,
+    rows = []
+    for group in groups:
+        creator_name = None
+        creator_email = None
+        if group.creator:
+            creator_name = group.creator.username
+            creator_email = group.creator.email
+
+        rows.append([
              request.route_url('group_read',
                                pubid=group.pubid,
                                slug=group.slug),
-             group.creator.username,
-             group.creator.email,
-             len(group.members)] for group in groups]
+             creator_name,
+             creator_email,
+             len(group.members)])
 
     filename = 'groups.csv'
     request.response.content_disposition = 'attachment;filename=' + filename

--- a/tests/h/models/groups_test.py
+++ b/tests/h/models/groups_test.py
@@ -196,6 +196,12 @@ class TestGroupACL(object):
     def test_creator_has_admin_permissions(self, group, authz_policy):
         assert authz_policy.permits(group, 'acct:luke@example.com', 'admin')
 
+    def test_no_admin_permission_when_no_creator(self, group, authz_policy):
+        group.creator = None
+
+        principals = authz_policy.principals_allowed_by_permission(group, 'admin')
+        assert len(principals) == 0
+
     def test_fallback_is_deny_all(self, group, authz_policy):
         assert not authz_policy.permits(group, [security.Everyone], 'foobar')
 


### PR DESCRIPTION
As a preparation for moving the `__world__` group into the database,
which gets created automatically. While most instances of h should
have set a creator for this group, we don't want to make the
decision of who the creator will be.