### PR TITLE
Index the first of an annotation's references

### DIFF
--- a/h/migrations/versions/9389d52b037d_add_index_to_annotation_thread_root.py
+++ b/h/migrations/versions/9389d52b037d_add_index_to_annotation_thread_root.py
@@ -1,0 +1,27 @@
+"""
+Add index to annotation thread root
+
+Revision ID: 9389d52b037d
+Revises: b102c50b1133
+Create Date: 2017-04-18 12:36:53.842280
+"""
+
+from __future__ import unicode_literals
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = '9389d52b037d'
+down_revision = 'b102c50b1133'
+
+
+def upgrade():
+    op.execute('COMMIT')
+    op.create_index(op.f('ix__annotation_thread_root'),
+                    'annotation',
+                    [sa.text('("references"[1])')],
+                    postgresql_concurrently=True)
+
+
+def downgrade():
+    op.drop_index(op.f('ix__annotation_thread_root'), 'annotation')

--- a/h/models/annotation.py
+++ b/h/models/annotation.py
@@ -28,6 +28,7 @@ class Annotation(Base):
         #
         sa.Index('ix__annotation_tags', 'tags', postgresql_using='gin'),
         sa.Index('ix__annotation_updated', 'updated'),
+        sa.Index('ix__annotation_thread_root', sa.text('("references"[1])')),
     )
 
     #: Annotation ID: these are stored as UUIDs in the database, and mapped


### PR DESCRIPTION
This is the first step toward indexing a top-level annotation's thread IDs (all annotations which cite the annotation as their top-level reference, so the entire tree of replies) into Elasticsearch, so that we don't end up hiding an entire thread when its root annotation gets hidden by a moderator.

A few notes on the expression for this index:

    [sa.text('("references"[1])')]

This is fairly heavily strewn with punctuation, and I feel I should explain what I understand of why. The double quotes around `references` are reasonably understandable: `references`, as well as being the name of the column, is a SQL keyword used when defining foreign keys, so it needs quoting as a column name. The extra parentheses I understand a little less well, but without them the migration fails with a syntax error:

    sqlalchemy.exc.ProgrammingError: (psycopg2.ProgrammingError) syntax error at or near ")"
    LINE 1: ...Y ix__annotation_thread_root ON annotation ("references"[1])
                                                                          ^
     [SQL: 'CREATE INDEX CONCURRENTLY ix__annotation_thread_root ON annotation ("references"[1])']

As for the "1" in the middle: Postgres uses 1-based indexing for its arrays, rather than 0-based indexing like most languages. Usually, SQLAlchemy's ORM hides this difference away from us, but we're not in the ORM world here.