### PR TITLE
Enable zero-based indexing on `references`

### DIFF
--- a/h/models/annotation.py
+++ b/h/models/annotation.py
@@ -28,6 +28,10 @@ class Annotation(Base):
         #
         sa.Index('ix__annotation_tags', 'tags', postgresql_using='gin'),
         sa.Index('ix__annotation_updated', 'updated'),
+
+        # This is a functional index on the *first* of the annotation's
+        # references, pointing to the top-level annotation it refers to. We're
+        # using 1 here because Postgres uses 1-based array indexing.
         sa.Index('ix__annotation_thread_root', sa.text('("references"[1])')),
     )
 
@@ -89,7 +93,7 @@ class Annotation(Base):
                                  server_default=sa.func.jsonb('[]'))
 
     #: An array of annotation IDs which are ancestors of this annotation.
-    references = sa.Column(pg.ARRAY(types.URLSafeUUID),
+    references = sa.Column(pg.ARRAY(types.URLSafeUUID, zero_indexes=True),
                            default=list,
                            server_default=sa.text('ARRAY[]::uuid[]'))
 


### PR DESCRIPTION
With this option set on the field, SQLAlchemy will automatically convert between Python's 0-based array indexing and Postgres' 1-based array indexing, so we can use these indexes consistently.

There's only one place remaining where we use the 1-based array indexing in our model code, and that's the index declaration -- because that's using `sa.text` to declare the index, that doesn't get mapped through SQLAlchemy's index correction logic.