### PR TITLE
Remove an unused shortcut to an unused fixture

### DIFF
--- a/tests/h/models/annotation_test.py
+++ b/tests/h/models/annotation_test.py
@@ -8,9 +8,6 @@ import pytest
 from h.models.annotation import Annotation
 
 
-annotation_fixture = pytest.mark.usefixtures('annotation')
-
-
 def test_parent_id_of_direct_reply():
     ann = Annotation(references=['parent_id'])
 


### PR DESCRIPTION
The fixture this refers to was just removed in commit 19df9f002; since this shortcut is no longer used either (since commit 2e85fd3bf), none of the tests picked up on it.