### PR TITLE
Remove the `thread` field from the search index

### DIFF
--- a/h/search/config.py
+++ b/h/search/config.py
@@ -105,10 +105,6 @@ ANNOTATION_MAPPING = {
         'document': {
             'enabled': False,  # not indexed
         },
-        'thread': {
-            'type': 'string',
-            'analyzer': 'thread'
-        },
         'group': {
             'type': 'string',
         }
@@ -149,9 +145,6 @@ ANALYSIS_SETTINGS = {
         }
     },
     'analyzer': {
-        'thread': {
-            'tokenizer': 'path_hierarchy'
-        },
         'uri': {
             'tokenizer': 'keyword',
             'char_filter': ['strip_scheme'],


### PR DESCRIPTION
This field, and its associated analyzer, are declared in the search config but never used.

As far as I can tell, this is a remnant of a previous way of representing threaded conversation in the search index. It's quite difficult to track down the history, though, given it dates back to 2014 (commit c12dc5bda593) and has endured multiple renames and refactorings since then. Still, it looks like it's now unused, so we can remove it to avoid confusion with the upcoming field to index the IDs of all replies and subreplies in an annotation's thread.