### PR TITLE
Index annotations’ thread IDs

### DIFF
--- a/h/models/annotation.py
+++ b/h/models/annotation.py
@@ -115,6 +115,12 @@ class Annotation(Base):
 
     document = sa.orm.relationship('Document', backref='annotations')
 
+    thread = sa.orm.relationship('Annotation',
+                                 primaryjoin=(sa.orm.foreign(id) ==
+                                              sa.orm.remote(references[0])),
+                                 viewonly=True,
+                                 uselist=True)
+
     @hybrid_property
     def target_uri(self):
         return self._target_uri

--- a/h/models/annotation.py
+++ b/h/models/annotation.py
@@ -153,6 +153,10 @@ class Annotation(Base):
         return self._text_rendered
 
     @property
+    def thread_ids(self):
+        return [thread_annotation.id for thread_annotation in self.thread]
+
+    @property
     def parent_id(self):
         """
         Return the ID of the annotation that this annotation is a reply to.

--- a/h/presenters/annotation_searchindex.py
+++ b/h/presenters/annotation_searchindex.py
@@ -29,6 +29,7 @@ class AnnotationSearchIndexPresenter(AnnotationBasePresenter):
             'shared': self.annotation.shared,
             'target': self.target,
             'document': docpresenter.asdict(),
+            'thread_ids': self.annotation.thread_ids
         }
 
         result['target'][0]['scope'] = [self.annotation.target_uri_normalized]

--- a/h/search/config.py
+++ b/h/search/config.py
@@ -111,6 +111,9 @@ ANNOTATION_MAPPING = {
         },
         'group': {
             'type': 'string',
+        },
+        'thread_ids': {
+            'type': 'string', 'index': 'not_analyzed'
         }
     }
 }

--- a/h/search/index.py
+++ b/h/search/index.py
@@ -191,6 +191,7 @@ def _eager_loaded_annotations(session):
         subqueryload(models.Annotation.document).subqueryload(models.Document.document_uris),
         subqueryload(models.Annotation.document).subqueryload(models.Document.meta),
         subqueryload(models.Annotation.moderation),
+        subqueryload(models.Annotation.thread).load_only("id"),
     )
 
 

--- a/tests/h/models/annotation_test.py
+++ b/tests/h/models/annotation_test.py
@@ -136,6 +136,31 @@ def test_deleting_tags_inline_is_persisted(db_session, factories):
     assert 'foo' not in annotation.tags
 
 
+class TestThread(object):
+
+    def test_empty_thread(self, root):
+        assert root.thread == []
+
+    def test_thread_with_replies(self, root, reply, subreply):
+        assert set(root.thread) == set([reply, subreply])
+
+    @pytest.mark.usefixtures('subreply')
+    def test_reply_has_no_thread(self, reply):
+        assert reply.thread == []
+
+    @pytest.fixture
+    def root(self, factories):
+        return factories.Annotation()
+
+    @pytest.fixture
+    def reply(self, factories, root):
+        return factories.Annotation(references=[root.id])
+
+    @pytest.fixture
+    def subreply(self, factories, root, reply):
+        return factories.Annotation(references=[root.id, reply.id])
+
+
 @pytest.fixture
 def markdown(patch):
     return patch('h.models.annotation.markdown')

--- a/tests/h/models/annotation_test.py
+++ b/tests/h/models/annotation_test.py
@@ -141,12 +141,22 @@ class TestThread(object):
     def test_empty_thread(self, root):
         assert root.thread == []
 
+    def test_empty_thread_ids(self, root):
+        assert root.thread_ids == []
+
     def test_thread_with_replies(self, root, reply, subreply):
         assert set(root.thread) == set([reply, subreply])
+
+    def test_thread_ids_with_replies(self, root, reply, subreply):
+        assert set(root.thread_ids) == set([reply.id, subreply.id])
 
     @pytest.mark.usefixtures('subreply')
     def test_reply_has_no_thread(self, reply):
         assert reply.thread == []
+
+    @pytest.mark.usefixtures('subreply')
+    def test_reply_has_no_thread_ids(self, reply):
+        assert reply.thread_ids == []
 
     @pytest.fixture
     def root(self, factories):

--- a/tests/h/presenters/annotation_searchindex_test.py
+++ b/tests/h/presenters/annotation_searchindex_test.py
@@ -27,6 +27,7 @@ class TestAnnotationSearchIndexPresenter(object):
             shared=True,
             target_selectors=[{'TestSelector': 'foobar'}],
             references=['referenced-id-1', 'referenced-id-2'],
+            thread_ids=['thread-id-1', 'thread-id-2'],
             extra={'extra-1': 'foo', 'extra-2': 'bar'})
         DocumentSearchIndexPresenter.return_value.asdict.return_value = {'foo': 'bar'}
 
@@ -49,6 +50,7 @@ class TestAnnotationSearchIndexPresenter(object):
                         'selector': [{'TestSelector': 'foobar'}]}],
             'document': {'foo': 'bar'},
             'references': ['referenced-id-1', 'referenced-id-2'],
+            'thread_ids': ['thread-id-1', 'thread-id-2'],
         }
 
     def test_it_copies_target_uri_normalized_to_target_scope(self):


### PR DESCRIPTION
This is the indexing side of hypothesis/product-backlog#231. For some previous context that means this isn’t horrendously slow, see #4532.

To be able to decide whether to return moderator-hidden annotations in search results when someone has replied to them, we need our search index to be aware of whether a top-level annotation has any replies. By putting these into a `thread_ids` field, in the future we should also be able to eliminate the second search query we make to get any replies to the top-level annotations we’ve returned.