### PR TITLE
Consolidate some ancient redirects

### DIFF
--- a/conf/nginx.conf.tpl
+++ b/conf/nginx.conf.tpl
@@ -39,12 +39,6 @@ http {
 
     root /var/www;
 
-    rewrite ^/index\.html$ / permanent;
-    rewrite ^/app/embed.js /embed.js;
-    rewrite ^/minutes/(\d+)/(.*) https://hypothesis-meeting-logs.s3.amazonaws.com/$1/$2 redirect;
-    rewrite ^/minutes/(.*) https://shrub.appspot.com/hypothesis-meeting-logs/$1 redirect;
-
-
     # Set the fallback upstream URL.
     # We store the upstream endpoint in a variable to trigger dynamic resolution
     # of the upstream hostname.

--- a/h/redirects
+++ b/h/redirects
@@ -3,6 +3,10 @@
 # Note that if this file is removed or incorrectly formatted, the application
 # will fail to boot. For details of the format, see h/util/redirects.py.
 
+# Ancient redirect
+/index.html            internal-exact index
+/app/embed.js          internal-exact embed
+
 # Legacy application URLs
 /profile/notifications internal-prefix account_notifications
 /profile/developer     internal-prefix account_developer


### PR DESCRIPTION
Remove a couple of ancient redirects to meeting logs from the pre-Slack era, and move a couple of ancient redirects into the application's redirects file.