### PR TITLE
When indexing a reply, index its top-level parent

### DIFF
--- a/h/models/annotation.py
+++ b/h/models/annotation.py
@@ -157,6 +157,10 @@ class Annotation(Base):
         return [thread_annotation.id for thread_annotation in self.thread]
 
     @property
+    def is_reply(self):
+        return bool(self.references)
+
+    @property
     def parent_id(self):
         """
         Return the ID of the annotation that this annotation is a reply to.

--- a/h/tasks/indexer.py
+++ b/h/tasks/indexer.py
@@ -21,6 +21,8 @@ def add_annotation(id_):
             index(celery.request.es, annotation, celery.request,
                   target_index=future_index)
 
+        if annotation.is_reply:
+            add_annotation.delay(annotation.thread_root_id)
 
 @celery.task
 def delete_annotation(id_):

--- a/tests/h/models/annotation_test.py
+++ b/tests/h/models/annotation_test.py
@@ -20,6 +20,18 @@ def test_parent_id_of_reply_to_reply():
     assert ann.parent_id == 'parent_id'
 
 
+def test_reply_is_reply():
+    ann = Annotation(references=['parent_id'])
+
+    assert ann.is_reply is True
+
+
+def test_non_reply_is_not_reply():
+    ann = Annotation()
+
+    assert ann.is_reply is False
+
+
 def test_parent_id_of_annotation():
     ann = Annotation()
 


### PR DESCRIPTION
Now that we're indexing all of the annotation IDs in a thread using the `thread_ids` field (#4540), we want to update this when a new reply gets created, especially as we're hoping in future to use this field to avoid a second Elasticsearch query to find reply IDs.

This feels like it might be giving the `add_annotation` task quite a few distinct responsibilities (it needs to be aware of the multiple indices used during reindexing, and also requires some knowledge of the annotation model. As the code currently stands, though, it was a choice between putting this code directly into the API layer or putting it into this task – all the code in-between only has access to the annotation's ID – and this is much more a search engine concern than an API concern.