### PR TITLE
Match reindex logging rate to Postgres window size

### DIFF
--- a/h/search/index.py
+++ b/h/search/index.py
@@ -125,7 +125,7 @@ class BatchIndexer(object):
                                                 ids=annotation_ids)
 
         # Report indexing status as we go
-        annotations = _log_status(annotations)
+        annotations = _log_status(annotations, log_every=PG_WINDOW_SIZE)
 
         indexing = es_helpers.streaming_bulk(self.es_client.conn, annotations,
                                              chunk_size=ES_CHUNK_SIZE,


### PR DESCRIPTION
Without explicitly specifying this rate, the logging will default to a log message every 1000 annotations, while the annotations are loaded from the database in batches of 2000. This means the rates the indexing task reports different alternating rates (~400 ann/s and ~2500 ann/s) depending on whether that particular 1000 annotations has already been fetched from the database.

By matching the log rate to the Postgres batch size, the log shows a more consistent rate, making it easier to guess how long the indexing task is likely to take, and making it easier to see how the rate actually varies across our dataset.