### PR TITLE
Fix height of activity pages with few results

### DIFF
--- a/h/static/styles/partials-v2/_search.scss
+++ b/h/static/styles/partials-v2/_search.scss
@@ -346,6 +346,7 @@ $stats-icon-column-width: 20px;
   .search-results,
   .search-result-zero {
     margin-right: 0;
+    flex-basis: auto;
   }
 
   .search-result-zero {


### PR DESCRIPTION
The search box on activity search pages has a CSS `flex-basis` of `950px`
to ensure that it's always wide enough.

When the window is smaller, the flex container that the search box is in
changes from a horizontal to a vertical layout (its `flex-direction`
changes to `column`) and the search box's `flex-basis`, which made sense
in the horizontal flex container, no longer makes sense in the vertical
one.

In fact the `flex-basis` now enforces a minimum height of `950px`. When
there are few search results on the page and the content is less than
`950px` tall, this has the effect of pushing the page footer down off
the bottom of the window leaving lots of whitespace and a vertical
scrollbar before getting to the footer.

Fix this by setting the search box's `flex-basis` to `auto` when the
vertical layout kicks in.

Fixes https://github.com/hypothesis/product-backlog/issues/107