### PR TITLE
Add strict-origin-when-cross-origin for browsers that support it

### DIFF
--- a/h/tweens.py
+++ b/h/tweens.py
@@ -108,9 +108,11 @@ def security_header_tween_factory(handler, registry):
         resp = handler(request)
         # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy
         #
-        # We'd like to use strict-origin-when-cross-origin here, but this
-        # doesn't yet have wide browser support.
-        resp.headers['Referrer-Policy'] = 'origin-when-cross-origin'
+        # Browsers should respect the last value they recognise from this
+        # list, thus browsers that don't support
+        # strict-origin-when-cross-origin will fall back to
+        # origin-when-cross-origin.
+        resp.headers['Referrer-Policy'] = 'origin-when-cross-origin, strict-origin-when-cross-origin'
         # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection
         resp.headers['X-XSS-Protection'] = '1; mode=block'
         return resp

--- a/tests/h/tweens_test.py
+++ b/tests/h/tweens_test.py
@@ -56,5 +56,5 @@ def test_tween_security_header_adds_headers(pyramid_request):
 
     response = tween(pyramid_request)
 
-    assert response.headers['Referrer-Policy'] == 'origin-when-cross-origin'
+    assert response.headers['Referrer-Policy'] == 'origin-when-cross-origin, strict-origin-when-cross-origin'
     assert response.headers['X-XSS-Protection'] == '1; mode=block'


### PR DESCRIPTION
[Apparently][1] Referrer-Policy allows multiple comma-separated values in order to allow the rollout of newer policy types while providing a fallback for older browsers.

As a result, we can add the "strict-origin-when-cross-origin" policy (which will never send any referrer information to insecure origins) to take advantage of it as support is rolled out.

[1]: https://www.w3.org/TR/referrer-policy/#unknown-policy-values