### PR TITLE
Show hidden annotations with replies

### DIFF
--- a/h/formatters/annotation_hidden.py
+++ b/h/formatters/annotation_hidden.py
@@ -10,25 +10,31 @@ from h.formatters.interfaces import IAnnotationFormatter
 @implementer(IAnnotationFormatter)
 class AnnotationHiddenFormatter(object):
     """
-    Formatter for exposing whether an annotation is hidden or not.
+    Formatter for dealing with annotations that a moderator has hidden.
 
-    If the annotation is hidden, this formatter will add: `"hidden": true`
-    to the payload, otherwise `"hidden": false`.
-    When the currently authenticated user is the annotation author, then this
-    formatter will always add `"hidden": false`, to not signal that the
-    annotation is hidden.
+    Any user who has permission to moderate a group will always be able to see
+    whether annotations in a group have been hidden, and will be able to see
+    the content of those annotations. In the unlikely event that these
+    annotations are their own, they'll still be able to see them.
+
+    Moderators aside, users are never shown that their own annotations have
+    been hidden. They are always given a `False` value for the `hidden` flag.
+
+    For any other users, if an annotation has been hidden it is presented with
+    the `hidden` flag set to `True`, and the annotation's content is redacted.
     """
 
-    def __init__(self, moderation_svc, user=None):
-        self.moderation_svc = moderation_svc
-        self.user = user
+    def __init__(self, moderation_svc, moderator_check, user):
+        self._moderation_svc = moderation_svc
+        self._moderator_check = moderator_check
+        self._user = user
 
         # Local cache of hidden flags. We don't need to care about detached
         # instances because we only store the annotation id and a boolean flag.
         self._cache = {}
 
     def preload(self, ids):
-        hidden_ids = self.moderation_svc.all_hidden(ids)
+        hidden_ids = self._moderation_svc.all_hidden(ids)
 
         hidden = {id_: (id_ in hidden_ids) for id_ in ids}
         self._cache.update(hidden)
@@ -36,19 +42,31 @@ class AnnotationHiddenFormatter(object):
 
     def format(self, annotation_resource):
         annotation = annotation_resource.annotation
+        group = annotation_resource.group
 
-        if self.user and self.user.userid == annotation.userid:
-            hidden = False
+        if self._current_user_is_moderator(group):
+            return {'hidden': self._is_hidden(annotation)}
+
+        if self._current_user_is_author(annotation):
+            return {'hidden': False}
+
+        if self._is_hidden(annotation):
+            return {'hidden': True, 'text': '', 'tags': []}
         else:
-            hidden = self._load(annotation)
-        return {'hidden': hidden}
+            return {'hidden': False}
 
-    def _load(self, annotation):
+    def _current_user_is_moderator(self, group):
+        return self._moderator_check(group)
+
+    def _current_user_is_author(self, annotation):
+        return self._user and self._user.userid == annotation.userid
+
+    def _is_hidden(self, annotation):
         id_ = annotation.id
 
         if id_ in self._cache:
             return self._cache[id_]
 
-        hidden = self.moderation_svc.hidden(annotation)
+        hidden = self._moderation_svc.hidden(annotation)
         self._cache[id_] = hidden
         return self._cache[id_]

--- a/h/nipsa/search.py
+++ b/h/nipsa/search.py
@@ -32,7 +32,10 @@ def nipsa_filter(group_service, user=None):
     """
     # If any one of these "should" clauses is true then the annotation will
     # get through the filter.
-    should_clauses = [{"not": {"term": {"nipsa": True}}}]
+    should_clauses = [
+        {"not": {"term": {"nipsa": True}}},
+        {"exists": {"field": "thread_ids"}},
+    ]
 
     if user is not None:
         # Always show the logged-in user's annotations even if they have nipsa.

--- a/h/services/annotation_json_presentation.py
+++ b/h/services/annotation_json_presentation.py
@@ -18,9 +18,12 @@ class AnnotationJSONPresentationService(object):
         self.group_svc = group_svc
         self.links_svc = links_svc
 
+        def moderator_check(group):
+            return has_permission('admin', group)
+
         self.formatters = [
             formatters.AnnotationFlagFormatter(flag_svc, user),
-            formatters.AnnotationHiddenFormatter(moderation_svc, user),
+            formatters.AnnotationHiddenFormatter(moderation_svc, moderator_check, user),
             formatters.AnnotationModerationFormatter(flag_count_svc, user, has_permission)
         ]
 

--- a/tests/h/formatters/annotation_hidden_test.py
+++ b/tests/h/formatters/annotation_hidden_test.py
@@ -9,7 +9,7 @@ import pytest
 from h.formatters.annotation_hidden import AnnotationHiddenFormatter
 from h.services.annotation_moderation import AnnotationModerationService
 
-FakeAnnotationResource = namedtuple('FakeAnnotationResource', ['annotation'])
+FakeAnnotationResource = namedtuple('FakeAnnotationResource', ['annotation', 'group'])
 
 
 class TestAnnotationHiddenFormatter(object):
@@ -25,44 +25,113 @@ class TestAnnotationHiddenFormatter(object):
         expected = {id_: False for id_ in annotation_ids}
         assert formatter.preload(annotation_ids) == expected
 
-    def test_format_for_hidden_annotation(self, formatter, factories):
-        mod = factories.AnnotationModeration()
-        resource = FakeAnnotationResource(mod.annotation)
-        assert formatter.format(resource) == {'hidden': True}
-
-    def test_format_for_public_annotation(self, formatter, factories):
-        annotation = factories.Annotation()
-        resource = FakeAnnotationResource(annotation)
-
-        assert formatter.format(resource) == {'hidden': False}
-
-    def test_format_for_hidden_annotation_as_annotation_author(self, formatter, factories, current_user):
-        annotation = factories.Annotation(userid=current_user.userid)
-        resource = FakeAnnotationResource(annotation)
-        factories.AnnotationModeration(annotation=annotation)
-
-        assert formatter.format(resource) == {'hidden': False}
-
-    def test_format_works_for_missing_user(self, moderation_svc, factories):
-        formatter = AnnotationHiddenFormatter(moderation_svc)
-        mod = factories.AnnotationModeration()
-        resource = FakeAnnotationResource(mod.annotation)
-        assert formatter.format(resource) == {'hidden': True}
-
-    @pytest.fixture
-    def current_user(self, factories):
-        return factories.User()
-
-    @pytest.fixture
-    def formatter(self, moderation_svc, current_user):
-        return AnnotationHiddenFormatter(moderation_svc, current_user)
-
-    @pytest.fixture
-    def moderation_svc(self, db_session):
-        return AnnotationModerationService(db_session)
-
     @pytest.fixture
     def annotations(self, factories):
         hidden = [mod.annotation for mod in factories.AnnotationModeration.create_batch(3)]
         public = factories.Annotation.create_batch(2)
         return {'hidden': hidden, 'public': public}
+
+
+class TestAnonymousUserHiding(object):
+    """An anonymous user will see redacted annotations when they're hidden."""
+
+    def test_format_for_unhidden_annotation(self, formatter, annotation, group):
+        resource = FakeAnnotationResource(annotation, group)
+        assert formatter.format(resource) == {'hidden': False}
+
+    def test_format_for_hidden_annotation(self, formatter, hidden_annotation, group):
+        resource = FakeAnnotationResource(hidden_annotation, group)
+
+        censored = {'hidden': True, 'text': '', 'tags': []}
+        assert formatter.format(resource) == censored
+
+    @pytest.fixture
+    def current_user(self):
+        return None
+
+
+class TestNonAuthorHiding(object):
+    """Regular users see redacted annotations, unless they are a moderator."""
+
+    def test_format_for_unhidden_annotation(self, formatter, annotation, group):
+        resource = FakeAnnotationResource(annotation, group)
+        assert formatter.format(resource) == {'hidden': False}
+
+    def test_format_for_non_moderator(self, formatter, hidden_annotation, group):
+        resource = FakeAnnotationResource(hidden_annotation, group)
+
+        censored = {'hidden': True, 'text': '', 'tags': []}
+        assert formatter.format(resource) == censored
+
+    def test_format_for_moderator(self, formatter, hidden_annotation, moderated_group):
+        resource = FakeAnnotationResource(hidden_annotation, moderated_group)
+        assert formatter.format(resource) == {'hidden': True}
+
+
+class TestAuthorHiding(object):
+    """The author usually does not see their annotations have been hidden.
+
+    The one exception is when they are also a moderator for the group.
+    """
+
+    def test_format_for_public_annotation(self, formatter, annotation, group):
+        resource = FakeAnnotationResource(annotation, group)
+        assert formatter.format(resource) == {'hidden': False}
+
+    def test_format_for_non_moderator(self, formatter, hidden_annotation, group):
+        resource = FakeAnnotationResource(hidden_annotation, group)
+        assert formatter.format(resource) == {'hidden': False}
+
+    def test_format_for_moderator(self, formatter, hidden_annotation, moderated_group):
+        resource = FakeAnnotationResource(hidden_annotation, moderated_group)
+        assert formatter.format(resource) == {'hidden': True}
+
+    @pytest.fixture
+    def annotation(self, factories, current_user):
+        return factories.Annotation(userid=current_user.userid)
+
+    @pytest.fixture
+    def hidden_annotation(self, factories, annotation):
+        factories.AnnotationModeration(annotation=annotation)
+        return annotation
+
+
+@pytest.fixture
+def current_user(factories):
+    return factories.User()
+
+
+@pytest.fixture
+def formatter(moderation_svc, moderator_check, current_user):
+    return AnnotationHiddenFormatter(moderation_svc, moderator_check, current_user)
+
+
+@pytest.fixture
+def moderation_svc(db_session):
+    return AnnotationModerationService(db_session)
+
+
+@pytest.fixture
+def moderator_check(moderated_group):
+    return lambda group: (group == moderated_group)
+
+
+@pytest.fixture
+def moderated_group(factories):
+    return factories.Group()
+
+
+@pytest.fixture
+def group(factories):
+    return factories.Group()
+
+
+@pytest.fixture
+def annotation(factories):
+    return factories.Annotation()
+
+
+@pytest.fixture
+def hidden_annotation(factories):
+    mod = factories.AnnotationModeration()
+    return mod.annotation

--- a/tests/h/nipsa/search_test.py
+++ b/tests/h/nipsa/search_test.py
@@ -48,7 +48,8 @@ def test_nipsa_filter_filters_out_nipsad_annotations(group_service):
     assert search.nipsa_filter(group_service) == {
         "bool": {
             "should": [
-                {'not': {'term': {'nipsa': True}}}
+                {'not': {'term': {'nipsa': True}}},
+                {'exists': {'field': 'thread_ids'}},
             ]
         }
     }

--- a/tests/h/services/annotation_json_presentation_test.py
+++ b/tests/h/services/annotation_json_presentation_test.py
@@ -21,9 +21,10 @@ class TestAnnotationJSONPresentationService(object):
         svc = self.svc(services)
         assert formatters.AnnotationFlagFormatter.return_value in svc.formatters
 
-    def test_initializes_hidden_formatter(self, services, formatters):
+    def test_initializes_hidden_formatter(self, matchers, services, formatters):
         self.svc(services)
         formatters.AnnotationHiddenFormatter.assert_called_once_with(services['annotation_moderation'],
+                                                                     matchers.any_callable(),
                                                                      mock.sentinel.user)
 
     def test_it_configures_hidden_formatter(self, services, formatters):


### PR DESCRIPTION
This is for hypothesis/product-backlog#231, and also deals with hypothesis/product-backlog#281 by always showing moderators the state of their own annotations.

For the indexing side that makes this possible, see #4540 and #4545.

Because we use top-level annotations to determine which replies to display, we need the search engine to return annotations that have replies, so hidden top-level annotations don't take the entire thread out with them. We then filter out the content itself in the presentation layer.