### PR TITLE
Fix a wrong test parameter in the flag formatter

### DIFF
--- a/tests/h/formatters/annotation_flag_test.py
+++ b/tests/h/formatters/annotation_flag_test.py
@@ -36,10 +36,10 @@ class TestAnnotationFlagFormatter(object):
 
         assert formatter.format(annotation_resource) == {'flagged': False}
 
-    def test_format_for_unauthenticated_user(self, db_session, factories):
+    def test_format_for_unauthenticated_user(self, flag_service, factories):
         annotation = factories.Annotation()
         annotation_resource = FakeAnnotationResource(annotation)
-        formatter = AnnotationFlagFormatter(db_session,
+        formatter = AnnotationFlagFormatter(flag_service,
                                             user=None)
 
         assert formatter.format(annotation_resource) == {'flagged': False}


### PR DESCRIPTION
We started using a service to determine whether an annotation had been flagged, but this test wasn't updated and was still passing in the database session. The test still worked, because we don't bother asking the service anything when there is no user.