### PR TITLE
Don't return same publisher group twice

### DIFF
--- a/h/session.py
+++ b/h/session.py
@@ -66,7 +66,7 @@ def _current_groups(request, authority):
     authority_groups = (request.find_service(name='authority_group')
                         .public_groups(authority=authority))
 
-    groups = authority_groups + _user_groups(user)
+    groups = set(authority_groups + _user_groups(user))
 
     return [_group_model(request.route_url, group) for group in groups]
 


### PR DESCRIPTION
Don't return the same publisher group twice in the `/api/profile` response.

Steps to reproduce:

1. Follow the instructions at https://github.com/hypothesis/publisher-account-test-site
   to get the publisher account site setup
2. Login to the publisher test site as "admin" (the publisher group
   creator)

Result: You'll see the same Partner.org publisher group listed twice in
the groups dropdown menu in the client:

![screenshot from 2017-05-06 22-56-31](https://cloud.githubusercontent.com/assets/22498/25776179/85c736a2-32af-11e7-88c8-aedcc119bb3a.png)




Expected: You should only see the group once.

The problem appears to be that in the `_current_groups()` function the
publisher group appears in both the `authority_groups` and the
`_user_groups()`. The admin user, who is the creator of the publisher
group, is also a member of the group.