### PR TITLE
Accessible activity cards

### DIFF
--- a/h/static/scripts/controllers/search-bucket-controller.js
+++ b/h/static/scripts/controllers/search-bucket-controller.js
@@ -53,6 +53,8 @@ class SearchBucketController extends Controller {
     setElementState(this.refs.content, {expanded: state.expanded});
     setElementState(this.element, {expanded: state.expanded});
 
+    this.refs.title.setAttribute('aria-expanded', state.expanded.toString());
+
     // Scroll to element when expanded, except on initial load
     if (typeof prevState.expanded !== 'undefined' && state.expanded) {
       this.scrollTo(this.element);

--- a/h/static/scripts/controllers/search-bucket-controller.js
+++ b/h/static/scripts/controllers/search-bucket-controller.js
@@ -33,6 +33,11 @@ class SearchBucketController extends Controller {
       this.setState({expanded: !this.state.expanded});
     });
 
+    this.refs.title.addEventListener('click', (event) => {
+      this.setState({expanded: !this.state.expanded});
+      event.stopPropagation();
+    });
+
     this.refs.collapseView.addEventListener('click', () => {
       this.setState({expanded: !this.state.expanded});
     });

--- a/h/static/scripts/tests/controllers/search-bucket-controller-test.js
+++ b/h/static/scripts/tests/controllers/search-bucket-controller-test.js
@@ -8,6 +8,7 @@ const TEMPLATE = `<div class="js-search-bucket">
     <a data-ref="domainLink">foo.com</a>
   </div>
   <div data-ref="content"></div>
+  <a data-ref="title"></a>
   <button data-ref="collapseView"></button>
 </div>
 `;

--- a/h/static/scripts/tests/controllers/search-bucket-controller-test.js
+++ b/h/static/scripts/tests/controllers/search-bucket-controller-test.js
@@ -68,6 +68,14 @@ describe('SearchBucketController', () => {
     assert.calledWith(ctrl.scrollTo, ctrl.element);
   });
 
+  it('sets ARIA expanded state when expanded or collapsed', () => {
+    ctrl.refs.title.dispatchEvent(new Event('click'));
+    assert.equal(ctrl.refs.title.getAttribute('aria-expanded'), 'true');
+
+    ctrl.refs.title.dispatchEvent(new Event('click'));
+    assert.equal(ctrl.refs.title.getAttribute('aria-expanded'), 'false');
+  });
+
   it('collapses search results on initial load', () => {
     assert.isFalse(ctrl.state.expanded);
   });

--- a/h/static/styles/partials-v2/_search.scss
+++ b/h/static/styles/partials-v2/_search.scss
@@ -165,6 +165,8 @@
 }
 
 .search-result-bucket__title {
+  color: black;
+  text-decoration: none;
   font-weight: bold;
   flex-grow: 1;
   margin-right: 5px;

--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -110,13 +110,13 @@
          {{ svg_icon('up-right-arrow', css_class='search-result-bucket__incontext-icon') }}</a>
     </div>
     <div class="search-result-bucket__title-and-annotations-count">
-        <div class="search-result-bucket__title">
+        <a href="#" class="search-result-bucket__title">
         {% if bucket.title %}
             {{ bucket.title }}
         {% else %}
             {% trans %}Untitled document{% endtrans %}
         {% endif %}
-        </div>
+        </a>
         <div class="search-result-bucket__annotations-count">
         <div class="search-result-bucket__annotations-count-container">
             {{ bucket.annotations_count }}

--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -43,10 +43,10 @@
     <div class="search-bucket-stats__val"></div>
   {% endif %}
   {% if bucket.tags %}
-    <div class="search-bucket-stats__key">
+    <header role="banner" title="tags" class="search-bucket-stats__key">
       {{ svg_icon('tag', css_class='search-bucket-stats__icon') }}
       {% trans %}Tags{% endtrans %}
-    </div>
+    </header>
     <ul class="search-bucket-stats__val">
       {% for tag in bucket.tags %}
         <li><a class="link--plain"
@@ -54,10 +54,10 @@
       {% endfor %}
     </ul>
   {% endif %}
-  <div class="search-bucket-stats__key">
+  <header role="banner" title="annotators" class="search-bucket-stats__key">
     {{ svg_icon('account', css_class='search-bucket-stats__icon') }}
     {% trans %}Annotators{% endtrans %}
-  </div>
+  </header>
   <ul class="search-bucket-stats__val">
     {% for user in bucket.users %}
       <li class="search-bucket-stats__username">
@@ -67,10 +67,10 @@
     {% endfor %}
   </ul>
   {% if bucket.uri %}
-    <div class="search-bucket-stats__key">
+    <header role="banner" title="url" div class="search-bucket-stats__key">
       {{ svg_icon('link', css_class='search-bucket-stats__icon') }}
       {% trans %}URL{% endtrans %}
-    </div>
+    </header>
     <div class="search-bucket-stats__val search-bucket-stats__url">
         <a class="link--plain"
            rel="nofollow noopener"
@@ -117,11 +117,11 @@
             {% trans %}Untitled document{% endtrans %}
         {% endif %}
         </a>
-        <div class="search-result-bucket__annotations-count">
+        <header role="banner" title="annotation count" class="search-result-bucket__annotations-count">
         <div class="search-result-bucket__annotations-count-container">
             {{ bucket.annotations_count }}
         </div>
-    </div>
+        </header>
     </div>
   </div>
 

--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -374,16 +374,18 @@
         <div class="search-results__total"> {{search_results.total}} <b>{% trans %}Matching Annotations{% endtrans %}</b></div>
         {% endif %}
 
-        <ol class="search-results__list">
+        <ol class="search-results__list"
+            role="list"
+            aria-label="Search results grouped by date">
           {% for timeframe in search_results.timeframes %}
           <li class="search-result__timeframe">
             {{ timeframe.label }}
           </li>
-          <li>
-            {% for bucket in timeframe.document_buckets.values() %}
+          {% for bucket in timeframe.document_buckets.values() %}
+          <li role="listitem">
             {{ search_result_bucket(bucket) }}
-            {% endfor %}
           </li>
+          {% endfor %}
           {% endfor %}
         </ol>
 

--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -117,11 +117,12 @@
             {% trans %}Untitled document{% endtrans %}
         {% endif %}
         </a>
-        <header role="banner" title="annotation count" class="search-result-bucket__annotations-count">
-        <div class="search-result-bucket__annotations-count-container">
-            {{ bucket.annotations_count }}
+        <div title="{{ bucket.annotations_count }} annotations added"
+             class="search-result-bucket__annotations-count">
+          <div class="search-result-bucket__annotations-count-container">
+              {{ bucket.annotations_count }}
+          </div>
         </div>
-        </header>
     </div>
   </div>
 

--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -43,7 +43,7 @@
     <div class="search-bucket-stats__val"></div>
   {% endif %}
   {% if bucket.tags %}
-    <div role="navigation" title="tags" class="search-bucket-stats__key">
+    <div class="search-bucket-stats__key">
       {{ svg_icon('tag', css_class='search-bucket-stats__icon') }}
       {% trans %}Tags{% endtrans %}
     </div>
@@ -54,7 +54,7 @@
       {% endfor %}
     </ul>
   {% endif %}
-  <div role="navigation" title="annotators" class="search-bucket-stats__key">
+  <div class="search-bucket-stats__key">
     {{ svg_icon('account', css_class='search-bucket-stats__icon') }}
     {% trans %}Annotators{% endtrans %}
   </div>
@@ -67,7 +67,7 @@
     {% endfor %}
   </ul>
   {% if bucket.uri %}
-    <div role="navigation" title="URL" class="search-bucket-stats__key">
+    <div class="search-bucket-stats__key">
       {{ svg_icon('link', css_class='search-bucket-stats__icon') }}
       {% trans %}URL{% endtrans %}
     </div>
@@ -117,7 +117,7 @@
             {% trans %}Untitled document{% endtrans %}
         {% endif %}
         </a>
-        <div role="navigation" title="annotation count" class="search-result-bucket__annotations-count">
+        <div class="search-result-bucket__annotations-count">
         <div class="search-result-bucket__annotations-count-container">
             {{ bucket.annotations_count }}
         </div>

--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -43,10 +43,10 @@
     <div class="search-bucket-stats__val"></div>
   {% endif %}
   {% if bucket.tags %}
-    <header role="banner" title="tags" class="search-bucket-stats__key">
+    <h4 title="tags" class="search-bucket-stats__key">
       {{ svg_icon('tag', css_class='search-bucket-stats__icon') }}
       {% trans %}Tags{% endtrans %}
-    </header>
+    </h4>
     <ul class="search-bucket-stats__val">
       {% for tag in bucket.tags %}
         <li><a class="link--plain"
@@ -54,10 +54,10 @@
       {% endfor %}
     </ul>
   {% endif %}
-  <header role="banner" title="annotators" class="search-bucket-stats__key">
+  <h4 title="annotators" class="search-bucket-stats__key">
     {{ svg_icon('account', css_class='search-bucket-stats__icon') }}
     {% trans %}Annotators{% endtrans %}
-  </header>
+  </h4>
   <ul class="search-bucket-stats__val">
     {% for user in bucket.users %}
       <li class="search-bucket-stats__username">
@@ -67,10 +67,10 @@
     {% endfor %}
   </ul>
   {% if bucket.uri %}
-    <header role="banner" title="url" div class="search-bucket-stats__key">
+    <h4 title="url" div class="search-bucket-stats__key">
       {{ svg_icon('link', css_class='search-bucket-stats__icon') }}
       {% trans %}URL{% endtrans %}
-    </header>
+    </h4>
     <div class="search-bucket-stats__val search-bucket-stats__url">
         <a class="link--plain"
            rel="nofollow noopener"

--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -43,7 +43,7 @@
     <div class="search-bucket-stats__val"></div>
   {% endif %}
   {% if bucket.tags %}
-    <div class="search-bucket-stats__key">
+    <div role="navigation" title="tags" class="search-bucket-stats__key">
       {{ svg_icon('tag', css_class='search-bucket-stats__icon') }}
       {% trans %}Tags{% endtrans %}
     </div>
@@ -54,7 +54,7 @@
       {% endfor %}
     </ul>
   {% endif %}
-  <div class="search-bucket-stats__key">
+  <div role="navigation" title="annotators" class="search-bucket-stats__key">
     {{ svg_icon('account', css_class='search-bucket-stats__icon') }}
     {% trans %}Annotators{% endtrans %}
   </div>
@@ -67,7 +67,7 @@
     {% endfor %}
   </ul>
   {% if bucket.uri %}
-    <div class="search-bucket-stats__key">
+    <div role="navigation" title="URL" class="search-bucket-stats__key">
       {{ svg_icon('link', css_class='search-bucket-stats__icon') }}
       {% trans %}URL{% endtrans %}
     </div>
@@ -110,14 +110,14 @@
          {{ svg_icon('up-right-arrow', css_class='search-result-bucket__incontext-icon') }}</a>
     </div>
     <div class="search-result-bucket__title-and-annotations-count">
-        <a href="#" class="search-result-bucket__title">
+        <a title="expand annotations for this url" data-ref="title" href="#" class="search-result-bucket__title">
         {% if bucket.title %}
             {{ bucket.title }}
         {% else %}
             {% trans %}Untitled document{% endtrans %}
         {% endif %}
         </a>
-        <div class="search-result-bucket__annotations-count">
+        <div role="navigation" title="annotation count" class="search-result-bucket__annotations-count">
         <div class="search-result-bucket__annotations-count-container">
             {{ bucket.annotations_count }}
         </div>

--- a/h/templates/includes/annotation_card.html.jinja2
+++ b/h/templates/includes/annotation_card.html.jinja2
@@ -16,18 +16,18 @@
 <li class="annotation-card">
   <header class="annotation-card__header">
     <div class="annotation-card__username-timestamp">
-      <a href="{{ request.route_url('activity.user_search', username=presented_annotation.annotation.username) }}"
+      <a title="username" href="{{ request.route_url('activity.user_search', username=presented_annotation.annotation.username) }}"
         class="annotation-card__username">
         {{ presented_annotation.annotation.username }}
       </a>
-      <a href="{{ request.route_url('annotation', id=presented_annotation.annotation.id) }}"
+      <a title="date" href="{{ request.route_url('annotation', id=presented_annotation.annotation.id) }}"
         class="annotation-card__timestamp">
         {{ presented_annotation.annotation.updated.strftime('%d %b %Y') }}
       </a>
     </div>
     <div class="annotation-card__share-info">
       {% if presented_annotation.group %}
-        <a href="{{ request.route_url('group_read', pubid=presented_annotation.group.pubid, slug=presented_annotation.group.slug) }}"
+        <a title="group" href="{{ request.route_url('group_read', pubid=presented_annotation.group.pubid, slug=presented_annotation.group.slug) }}"
           class="annotation-card__groupname">
             in
             {{ svg_icon('groups', 'annotation-card__groups-icon') }}
@@ -46,14 +46,14 @@
     </div>
   </header>
   {% if presented_annotation.annotation.quote %}
-    <section role="navigation" class="annotation-card__quote">
+    <section title="annotation quote" role="navigation" class="annotation-card__quote">
       {{ presented_annotation.annotation.quote }}
     </section>
   {% endif %}
-  <section role="navigation" class="annotation-card__text">
+  <section title="annotation body" role="navigation" class="annotation-card__text">
     {{ presented_annotation.annotation.text_rendered }}
   </section>
-  <section class="annotation-card__tags">
+  <section title="tags" role="navigation" class="annotation-card__tags">
     {% for tag in presented_annotation.annotation.tags%}
       <a class="annotation-card__tag" href="{{ tag_link(tag) }}">
         {{ tag }}

--- a/h/templates/includes/annotation_card.html.jinja2
+++ b/h/templates/includes/annotation_card.html.jinja2
@@ -14,7 +14,7 @@
 
 {% macro annotation_card(presented_annotation, request, tag_link) -%}
 <li class="annotation-card">
-  <header class="annotation-card__header">
+  <div class="annotation-card__header">
     <div class="annotation-card__username-timestamp">
       <a title="username" href="{{ request.route_url('activity.user_search', username=presented_annotation.annotation.username) }}"
         class="annotation-card__username">
@@ -44,22 +44,22 @@
         </span>
       {% endif %}
     </div>
-  </header>
+  </div>
   {% if presented_annotation.annotation.quote %}
-    <section title="annotation quote" role="navigation" class="annotation-card__quote">
+    <blockquote title="Annotation quote" class="annotation-card__quote">
       {{ presented_annotation.annotation.quote }}
-    </section>
+    </blockquote>
   {% endif %}
-  <section title="annotation body" role="navigation" class="annotation-card__text">
+  <p class="annotation-card__text">
     {{ presented_annotation.annotation.text_rendered }}
-  </section>
-  <section title="tags" role="navigation" class="annotation-card__tags">
+  </p>
+  <div title="Tags" class="annotation-card__tags">
     {% for tag in presented_annotation.annotation.tags%}
       <a class="annotation-card__tag" href="{{ tag_link(tag) }}">
         {{ tag }}
       </a>
     {% endfor %}
-  </section>
+  </div>
   <footer class="annotation-card__footer">
     {% if presented_annotation.incontext_link %}
       <a href="{{ presented_annotation.incontext_link }}"

--- a/h/templates/includes/annotation_card.html.jinja2
+++ b/h/templates/includes/annotation_card.html.jinja2
@@ -46,11 +46,11 @@
     </div>
   </header>
   {% if presented_annotation.annotation.quote %}
-    <section class="annotation-card__quote">
+    <section role="navigation" class="annotation-card__quote">
       {{ presented_annotation.annotation.quote }}
     </section>
   {% endif %}
-  <section class="annotation-card__text">
+  <section role="navigation" class="annotation-card__text">
     {{ presented_annotation.annotation.text_rendered }}
   </section>
   <section class="annotation-card__tags">


### PR DESCRIPTION
This PR is intended to be a first step on a long road toward a more accessible product. It adds navigation roles and titles to key elements: the annotation quote and body, the count, the sidebar containers.

Screencast: http://jonudell.net/h/accessibility_06.mp4

Background: [H Accessibility](https://docs.google.com/document/d/1-XyRheGNgufrRVCv7AdshoGgfxsGI0hluAo2JuAkNeM/edit?usp=sharing)

That document also proposes tweaks to the injector (so highlights in the main doc are navigable/audible) and to the client (so cards in the sidebar are accessible in ways analogous to the behavior proposed here for activity pages).  But perhaps we should work through these first, then address the other cases where annotations are not consumable in a screenreader, and then think about how to tackle enabling screenreader-assisted creation of annotations.


