### PR TITLE
Make dropdown menus in navbar accessible

### DIFF
--- a/h/static/scripts/controllers/dropdown-menu-controller.js
+++ b/h/static/scripts/controllers/dropdown-menu-controller.js
@@ -41,6 +41,7 @@ class DropdownMenuController extends Controller {
 
   update(state) {
     setElementState(this.refs.dropdownMenuContent, {open: state.open});
+    this.refs.dropdownMenuToggle.setAttribute('aria-expanded', state.open.toString());
   }
 }
 

--- a/h/static/scripts/tests/controllers/dropdown-menu-controller-test.js
+++ b/h/static/scripts/tests/controllers/dropdown-menu-controller-test.js
@@ -5,7 +5,7 @@ const util = require('./util');
 
 const TEMPLATE = [
   '<div class="js-dropdown-menu">',
-  '<span data-ref="dropdownMenuToggle">Toggle</span>',
+  '<a href="#" data-ref="dropdownMenuToggle">Toggle</a>',
   '<span data-ref="dropdownMenuContent">Menu</span>',
   '</div>',
 ].join('\n');
@@ -34,6 +34,13 @@ describe('DropdownMenuController', () => {
     assert.isTrue(isOpen());
     toggleEl.dispatchEvent(new Event('click'));
     assert.isFalse(isOpen());
+  });
+
+  it('should toggle expanded state on click', () => {
+    toggleEl.dispatchEvent(new Event('click'));
+    assert.equal(toggleEl.getAttribute('aria-expanded'), 'true');
+    toggleEl.dispatchEvent(new Event('click'));
+    assert.equal(toggleEl.getAttribute('aria-expanded'), 'false');
   });
 
   it('should close menu on click outside', () => {

--- a/h/static/scripts/tests/controllers/dropdown-menu-controller-test.js
+++ b/h/static/scripts/tests/controllers/dropdown-menu-controller-test.js
@@ -29,28 +29,32 @@ describe('DropdownMenuController', () => {
     return menuEl.classList.contains('is-open');
   }
 
+  function clickMenuLink() {
+    toggleEl.dispatchEvent(new Event('click', { cancelable: true }));
+  }
+
   it('should toggle menu on click', () => {
-    toggleEl.dispatchEvent(new Event('click'));
+    clickMenuLink();
     assert.isTrue(isOpen());
-    toggleEl.dispatchEvent(new Event('click'));
+    clickMenuLink();
     assert.isFalse(isOpen());
   });
 
   it('should toggle expanded state on click', () => {
-    toggleEl.dispatchEvent(new Event('click'));
+    clickMenuLink();
     assert.equal(toggleEl.getAttribute('aria-expanded'), 'true');
-    toggleEl.dispatchEvent(new Event('click'));
+    clickMenuLink();
     assert.equal(toggleEl.getAttribute('aria-expanded'), 'false');
   });
 
   it('should close menu on click outside', () => {
-    toggleEl.dispatchEvent(new Event('click'));
+    clickMenuLink();
     document.body.dispatchEvent(new Event('click'));
     assert.isFalse(isOpen());
   });
 
   it('should not close menu on click inside', () => {
-    toggleEl.dispatchEvent(new Event('click'));
+    clickMenuLink();
     menuEl.dispatchEvent(new Event('click'));
     assert.isTrue(isOpen());
   });

--- a/h/templates/includes/dropdown_menu.html.jinja2
+++ b/h/templates/includes/dropdown_menu.html.jinja2
@@ -5,29 +5,37 @@
 
   Usage:
     {% call dropdown_menu(items, title='Menu') %}
-      <a href="/link-used-if-JS-is-inactive">Menu</a>
+      Menu
     {% endcall %}
 
   :param items: List of items to include in the menu
+  :param fallback_link: Fallback URL for menu link if JS fails to load
+  :param link_class: CSS class for menu link
   :param title: Title to display at the top of the menu
   :param footer_item: Optional item to display at the bottom of the menu,
                       visually separated from the rest of the menu items
 #}
-{% macro dropdown_menu(items, title='', footer_item=None) -%}
+{% macro dropdown_menu(items, fallback_link = '#', link_class = '', title='', footer_item=None) -%}
 <div class="dropdown-menu js-dropdown-menu">
-  <span data-ref="dropdownMenuToggle">
+  <a aria-expanded="false"
+     aria-haspopup="true"
+     aria-label="{{ title }}"
+     class="{{ link_class }}"
+     data-ref="dropdownMenuToggle"
+     href="{{ fallback_link }}"
+     title="{{ title }}">
     {{ caller() }}
-  </span>
+  </a>
   <div class="dropdown-menu__menu" data-ref="dropdownMenuContent">
     <h2 class="dropdown-menu__title">{{ title }}</h2>
-    <ul>
+    <ul role="menu">
       {% for item in items %}
-      <li>
+      <li role="menuitem">
         <a class="dropdown-menu__item" href="{{ item.link }}">{{ item.title }}</a>
       </li>
       {% endfor %}
       {% if footer_item %}
-      <li>
+      <li role="menuitem">
         <a class="dropdown-menu__item dropdown-menu__item--footer"
            href="{{ footer_item.link }}">{{ footer_item.title }}</a>
       </li>

--- a/h/templates/panels/navbar.html.jinja2
+++ b/h/templates/panels/navbar.html.jinja2
@@ -65,7 +65,7 @@
 
     <div class="u-stretch"></div>
 
-    <div class="nav-bar-links">
+    <nav class="nav-bar-links">
       {% if username %}
       <span class="nav-bar-links__item">
         <a class="nav-bar-links__link"
@@ -97,7 +97,7 @@
       <a class="nav-bar-links__item nav-bar-links__link"
          href="{{ request.route_url('signup') }}">Sign up</a>
       {% endif %}
-    </div>
+    </nav>
   </div>
 </header>
 

--- a/h/templates/panels/navbar.html.jinja2
+++ b/h/templates/panels/navbar.html.jinja2
@@ -74,20 +74,21 @@
         </a>
       </span>
       <span class="nav-bar-links__item">
-      {% call dropdown_menu(groups_menu_items, title='Groups', footer_item=create_group_item) %}
-        <a class="nav-bar-links__link" href="">Groups
-          <span class="nav-bar-links__dropdown-arrow">▾</span>
-        </a>
+      {% call dropdown_menu(groups_menu_items,
+                            link_class='nav-bar-links__link',
+                            title='Groups',
+                            footer_item=create_group_item) %}
+        Groups <span class="nav-bar-links__dropdown-arrow">▾</span>
       {% endcall %}
       </span>
       <span class="nav-bar-links__item">
-      {% call dropdown_menu(settings_menu_items, title='Settings', footer_item=signout_item) %}
-        <a class="nav-bar-links__link"
-           href="{{ request.route_url("account") }}"
-           title="Settings">
+      {% call dropdown_menu(settings_menu_items,
+                            link_class='nav-bar-links__link',
+                            fallback_link='{{ request.route_url("account") }}',
+                            title='Settings',
+                            footer_item=signout_item) %}
           {{ svg_icon('settings') }}
           <span class="nav-bar-links__dropdown-arrow" href="">▾</span>
-        </a>
       {% endcall %}
       </span>
       {% else %}


### PR DESCRIPTION
This PR is a collection of accessibility fixes for the navigation menu in the top-right corner of the navbar:

- Use a `<nav>` element for the navigation links container so that they are grouped together and marked as a landmark when assistive technologies (eg. screen readers) traverse the page.
- Use `role` attributes to indicate the menu-ness of the dropdown menus and the current state of the menu (expanded/collapsed) to A.T.s
- Provide an accessible name for the "Settings" menu. I had assumed that the screen reader would read the title for the link but it didn't, instead VoiceOver at least read out the unicode dropdown arrow symbol as "dropdown arrow".

Fixes #4555

----

**Testing**:

1. Familiarise yourself with VoiceOver / Orca / Other Screen Reader enough to do basic navigation of web pages. VoiceOver has a built-in tutorial.
2. Try to navigate to the navbar links (username / Groups menu / Settings menu) using the screen reader, open and close the menus and select menu items. Compare output with master branch.