### PR TITLE
Make search autocomplete accessible

### DIFF
--- a/h/static/scripts/controllers/autosuggest-dropdown-controller.js
+++ b/h/static/scripts/controllers/autosuggest-dropdown-controller.js
@@ -22,7 +22,7 @@ class AutosuggestDropdownController extends Controller {
    *   and input changes made by user. The function will receieve the full list
    *   and the current value of the input. This is meant to be an pure function
    *   that will return a filtered list based on the consumer's domain needs.
-   * @properly {Function} onSelect - called once the user has made a selection of an
+   * @property {Function} onSelect - called once the user has made a selection of an
    *   item in the autosuggest. It will receive the item selected as the only argument.
    * @property {Object} [classNames] - this is the enumerated list of class name
    *   overrides for consumers to customize the UI.
@@ -312,6 +312,7 @@ class AutosuggestDropdownController extends Controller {
     this._suggestionContainer.appendChild(this._header);
 
     this._listContainer = document.createElement('ul');
+    this._listContainer.setAttribute('role', 'listbox');
     this._listContainer.classList.add(this.options.classNames.list);
     this._suggestionContainer.appendChild(this._listContainer);
 
@@ -336,6 +337,7 @@ class AutosuggestDropdownController extends Controller {
 
     this.state.list.forEach((listItem) => {
       const li = document.createElement('li');
+      li.setAttribute('role', 'option');
       li.classList.add(this.options.classNames.item);
       li.setAttribute('data-suggestion-id', listItem.__suggestionId);
 

--- a/h/templates/panels/navbar.html.jinja2
+++ b/h/templates/panels/navbar.html.jinja2
@@ -34,7 +34,8 @@
       <form class="search-bar"
             data-ref="searchBarForm"
             id="search-bar"
-            action="{{ search_url }}">
+            action="{{ search_url }}"
+            role="search">
 
         {#- This seemingly pointless <input> is actually needed to make the
             form work correctly. If you remove this input then when the user
@@ -53,11 +54,15 @@
           {% endif %}
 
           <input class="search-bar__input js-input-autofocus"
+                 aria-autocomplete="list"
+                 aria-label="Search annotations"
+                 aria-haspopup="true"
                  autocapitalize="off"
                  autocomplete="off"
                  data-ref="searchBarInput"
                  name="q"
                  placeholder="Search…"
+                 role="combobox"
                  value="{{ q }}">
         </div>
       </form>

--- a/h/templates/panels/navbar.html.jinja2
+++ b/h/templates/panels/navbar.html.jinja2
@@ -55,7 +55,7 @@
 
           <input class="search-bar__input js-input-autofocus"
                  aria-autocomplete="list"
-                 aria-label="Search annotations"
+                 aria-label="{{ _('Search annotations') }}"
                  aria-haspopup="true"
                  autocapitalize="off"
                  autocomplete="off"


### PR DESCRIPTION
This adds some basic ARIA markup to make the navbar search autocomplete popup accessible. This doesn't cover all the accessibility information that might be useful, but it at least makes the search box more "visible" when using the screen reader in a way that is similar to how the autocomplete list "appears" on eg. Google.

 * Mark the search input as a combobox with a popup. This is similar to
   how the search field is marked up on eg. Google.

 * Use the `listbox` and `option` roles for the listbox and menu items
   respectively

Fixes #4556 

----

Testing:

- When the search box is focused, the screen reader should announce it as a combobox and indicate that it has menu options associated with it. On Mac you'll be told to press VO+Space to show items, but this does nothing. That is expected and matches the behaviour on eg. Google and Facebook.
-  The suggestions in the dropdown menu should be grouped as together as a "list box" which you can navigate into or out of using the screen reader.