### PR TITLE
Add libssl-dev dep to Ubuntu install docs

### DIFF
--- a/docs/developing/install.rst
+++ b/docs/developing/install.rst
@@ -37,6 +37,7 @@ Install the following packages:
         libffi-dev \
         libfontconfig \
         libpq-dev \
+        libssl-dev \
         python-dev \
         python-pip \
         python-virtualenv


### PR DESCRIPTION
When following the dev install instructions on a new laptop (Ubuntu
Gnome 17.10) I had to apt-get install this missing dependency.