### PR TITLE
Combine errors in API responses

### DIFF
--- a/h/schemas/base.py
+++ b/h/schemas/base.py
@@ -9,7 +9,6 @@ import copy
 import colander
 import deform
 import jsonschema
-from jsonschema.exceptions import best_match
 from pyramid.session import check_csrf_token
 
 
@@ -66,9 +65,11 @@ class JSONSchema(object):
         """
         # Take a copy to ensure we don't modify what we were passed.
         appstruct = copy.deepcopy(data)
-        error = best_match(self.validator.iter_errors(appstruct))
-        if error is not None:
-            raise ValidationError(_format_jsonschema_error(error))
+
+        errors = list(self.validator.iter_errors(appstruct))
+        if errors:
+            msg = ', '.join([_format_jsonschema_error(e) for e in errors])
+            raise ValidationError(msg)
         return appstruct
 
 

--- a/h/views/api_users.py
+++ b/h/views/api_users.py
@@ -52,19 +52,22 @@ def _check_authority(client, data):
 
 
 def _check_existing_user(session, data):
+    errors = []
+
     existing_user = models.User.get_by_email(session,
                                              data['email'],
                                              data['authority'])
     if existing_user:
-        msg = "user with email address %s already exists" % data['email']
-        raise ValidationError(msg)
+        errors.append("user with email address %s already exists" % data['email'])
 
     existing_user = models.User.get_by_username(session,
                                                 data['username'],
                                                 data['authority'])
     if existing_user:
-        msg = "user with username %s already exists" % data['username']
-        raise ValidationError(msg)
+        errors.append("user with username %s already exists" % data['username'])
+
+    if errors:
+        raise ValidationError(', '.join(errors))
 
 
 def _request_client(request):

--- a/tests/h/views/api_users_test.py
+++ b/tests/h/views/api_users_test.py
@@ -158,6 +158,27 @@ class TestCreate(object):
 
         assert ('email address %s already exists' % existing_user.email) in str(exc.value)
 
+    @pytest.mark.usefixtures('valid_auth')
+    def test_combines_unique_username_email_errors(self,
+                                                   pyramid_request,
+                                                   valid_payload,
+                                                   db_session,
+                                                   factories,
+                                                   auth_client):
+        existing_user = factories.User(authority=auth_client.authority)
+        db_session.flush()
+
+        payload = valid_payload
+        payload['email'] = existing_user.email
+        payload['username'] = existing_user.username
+        pyramid_request.json_body = payload
+
+        with pytest.raises(ValidationError) as exc:
+            create(pyramid_request)
+
+        assert ('email address %s already exists' % existing_user.email) in str(exc.value)
+        assert ('username %s already exists' % existing_user.username) in str(exc.value)
+
     @pytest.fixture
     def schemas(self, patch):
         return patch('h.views.api_users.schemas')


### PR DESCRIPTION
**The solution has two parts:**

1.  Show all error messages for JSON validation errors

Previously we used the jsonschema's best_match[1] which tries to choose the most important error message and returns only that one in the error response. This results in a sub-optimal experience when trying to use the API, as sometimes a developer needs to call the API endpoint multiple times until the server accepts a valid request payload.

This commit changes this behaviour and returns all errors from an invalid payload as a comma-separated string.

2. Combine unique username and email errors

For a better user experience, we should return both errors in the same response if both the username and the email is not unique.
We don't add the mismatched authority error to this because we don't want to leak any information of existing users back to the client for a different authority than the one of the authenticated client.

**What this doesn't change:**
I've decided to not change the `POST /api/annotations` and `PUT /api/annotations` endpoints.

Looking at the code, there are multiple ways this can show errors in multiple steps, potentially degrading the experience of a developer working out the code to create annotations:

* schema validations are now combined, but any validation error that happens after the JSON payload is checked for correctness would not be returned at the same time
* if the annotation is a reply and the top-level annotation in the thread does not exist, we immediately return without checking for any other potential errors.
* if the annotation is being created in a group where the authenticated user does not have write access, we immediately return without checking for any other potential errors.

I've decided not to combine these errors in a single response because of the scope of the original issue. If don't think that combining these errors are that important, if people feel strongly about this, please shout and I will add a ticket to the engineering backlog so we can tackle this in a future sprint.

Fixes #4551.

[1]: https://python-jsonschema.readthedocs.io/en/latest/errors/#best-match-and-relevance