### PR TITLE
Pull preloading logic out of formatters

### DIFF
--- a/h/formatters/annotation_flag.py
+++ b/h/formatters/annotation_flag.py
@@ -21,34 +21,9 @@ class AnnotationFlagFormatter(object):
         self.flag_service = flag_service
         self.user = user
 
-        # Local cache of flags. We don't need to care about detached
-        # instances because we only store the annotation id and a boolean flag.
-        self._cache = {}
-
-    def preload(self, ids):
-        if self.user is None:
-            return
-
-        flagged_ids = self.flag_service.all_flagged(user=self.user,
-                                                    annotation_ids=ids)
-
-        flags = {id_: (id_ in flagged_ids) for id_ in ids}
-        self._cache.update(flags)
-        return flags
-
     def format(self, annotation_resource):
         flagged = self._load(annotation_resource.annotation)
         return {'flagged': flagged}
 
     def _load(self, annotation):
-        if self.user is None:
-            return False
-
-        id_ = annotation.id
-
-        if id_ in self._cache:
-            return self._cache[id_]
-
-        flagged = self.flag_service.flagged(user=self.user, annotation=annotation)
-        self._cache[id_] = flagged
-        return self._cache[id_]
+        return self.flag_service.flagged(user=self.user, annotation=annotation)

--- a/h/formatters/annotation_hidden.py
+++ b/h/formatters/annotation_hidden.py
@@ -29,17 +29,6 @@ class AnnotationHiddenFormatter(object):
         self._moderator_check = moderator_check
         self._user = user
 
-        # Local cache of hidden flags. We don't need to care about detached
-        # instances because we only store the annotation id and a boolean flag.
-        self._cache = {}
-
-    def preload(self, ids):
-        hidden_ids = self._moderation_svc.all_hidden(ids)
-
-        hidden = {id_: (id_ in hidden_ids) for id_ in ids}
-        self._cache.update(hidden)
-        return hidden
-
     def format(self, annotation_resource):
         annotation = annotation_resource.annotation
         group = annotation_resource.group
@@ -62,11 +51,4 @@ class AnnotationHiddenFormatter(object):
         return self._user and self._user.userid == annotation.userid
 
     def _is_hidden(self, annotation):
-        id_ = annotation.id
-
-        if id_ in self._cache:
-            return self._cache[id_]
-
-        hidden = self._moderation_svc.hidden(annotation)
-        self._cache[id_] = hidden
-        return self._cache[id_]
+        return self._moderation_svc.hidden(annotation)

--- a/h/formatters/annotation_moderation.py
+++ b/h/formatters/annotation_moderation.py
@@ -23,21 +23,6 @@ class AnnotationModerationFormatter(object):
         self._user = user
         self._has_permission = has_permission
 
-        # Local cache of flag counts. We don't need to care about detached
-        # instances because we only store the annotation id and a count.
-        self._cache = {}
-
-    def preload(self, ids):
-        if self._user is None:
-            return
-
-        if not ids:
-            return
-
-        flag_counts = self._flag_count_svc.flag_counts(ids)
-        self._cache.update(flag_counts)
-        return flag_counts
-
     def format(self, annotation_resource):
         if not self._has_permission('admin', annotation_resource.group):
             return {}
@@ -46,11 +31,4 @@ class AnnotationModerationFormatter(object):
         return {'moderation': {'flagCount': flag_count}}
 
     def _load(self, annotation):
-        id_ = annotation.id
-
-        if id_ in self._cache:
-            return self._cache[id_]
-
-        flag_count = self._flag_count_svc.flag_count(annotation)
-        self._cache[id_] = flag_count
-        return flag_count
+        return self._flag_count_svc.flag_count(annotation)

--- a/h/formatters/interfaces.py
+++ b/h/formatters/interfaces.py
@@ -17,22 +17,7 @@ class IAnnotationFormatter(Interface):
     return a dictionary representation based on the passed-in annotation. If
     the formatter depends on other data it should be able to load it on-demand
     for the given annotation.
-
-    Since we are rendering lists of potentially hundreds of annotations in one
-    request, formatters need to be able to optimize the fetching of additional
-    data (e.g. from the database). Which is why this interface defines the
-    ``preload(ids)`` method.
-    Each formatter implementation is expected to handle a cache internally which
-    is being preloaded with said method.
     """
-
-    def preload(ids):  # noqa: N805
-        """
-        Batch load data based on annotation ids.
-
-        :param ids: List of annotation ids based on which data should be preloaded.
-        :type ids: list of unicode
-        """
 
     def format(annotation_resource):  # noqa: N805
         """

--- a/h/services/annotation_json_presentation.py
+++ b/h/services/annotation_json_presentation.py
@@ -11,6 +11,7 @@ from h import resources
 from h import storage
 from h.interfaces import IGroupService
 from h.services.flag_count import PreloadedFlagCountService
+from h.services.flag import PreloadedFlagService
 
 
 class AnnotationJSONPresentationService(object):
@@ -43,8 +44,9 @@ class AnnotationJSONPresentationService(object):
     def _preloaded_formatters(self, annotation_ids):
         flag_count_svc = PreloadedFlagCountService(self.flag_count_svc,
                                                    annotation_ids)
+        flag_svc = PreloadedFlagService(self.flag_svc, self.user, annotation_ids)
         return [
-            formatters.AnnotationFlagFormatter(self.flag_svc, self.user),
+            formatters.AnnotationFlagFormatter(flag_svc, self.user),
             formatters.AnnotationHiddenFormatter(self.moderation_svc,
                                                  self._moderator_check,
                                                  self.user),

--- a/h/services/annotation_json_presentation.py
+++ b/h/services/annotation_json_presentation.py
@@ -45,9 +45,12 @@ class AnnotationJSONPresentationService(object):
         flag_count_svc = PreloadedFlagCountService(self.flag_count_svc,
                                                    annotation_ids)
         flag_svc = PreloadedFlagService(self.flag_svc, self.user, annotation_ids)
+        moderation_svc = PreloadedAnnotationModerationService(self.moderation_svc,
+                                                              annotation_ids)
+
         return [
             formatters.AnnotationFlagFormatter(flag_svc, self.user),
-            formatters.AnnotationHiddenFormatter(self.moderation_svc,
+            formatters.AnnotationHiddenFormatter(moderation_svc,
                                                  self._moderator_check,
                                                  self.user),
             formatters.AnnotationModerationFormatter(flag_count_svc,

--- a/h/services/annotation_moderation.py
+++ b/h/services/annotation_moderation.py
@@ -71,5 +71,24 @@ class AnnotationModerationService(object):
         annotation.moderation = None
 
 
+class PreloadedAnnotationModerationService(object):
+
+    def __init__(self, service, annotation_ids):
+        self._annotation_ids = annotation_ids
+        self._hidden_ids = service.all_hidden(annotation_ids)
+
+    def hidden(self, annotation):
+        if annotation.id not in self._annotation_ids:
+            raise NotPreloadedError(annotation.id)
+
+        return annotation.id in self._hidden_ids
+
+
+class NotPreloadedError(Exception):
+    def __init__(self, annotation_id):
+        message = 'ID {} not in preloaded IDs'.format(annotation_id)
+        super(NotPreloadedError, self).__init__(message)
+
+
 def annotation_moderation_service_factory(context, request):
     return AnnotationModerationService(request.db)

--- a/h/services/annotation_moderation.py
+++ b/h/services/annotation_moderation.py
@@ -3,6 +3,7 @@
 from __future__ import unicode_literals
 
 from h import models
+from .exceptions import NotPreloadedError
 
 
 class AnnotationModerationService(object):
@@ -82,12 +83,6 @@ class PreloadedAnnotationModerationService(object):
             raise NotPreloadedError(annotation.id)
 
         return annotation.id in self._hidden_ids
-
-
-class NotPreloadedError(Exception):
-    def __init__(self, annotation_id):
-        message = 'ID {} not in preloaded IDs'.format(annotation_id)
-        super(NotPreloadedError, self).__init__(message)
 
 
 def annotation_moderation_service_factory(context, request):

--- a/h/services/exceptions.py
+++ b/h/services/exceptions.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+
+class NotPreloadedError(Exception):
+    def __init__(self, annotation_id):
+        message = 'ID {} not in preloaded IDs'.format(annotation_id)
+        super(NotPreloadedError, self).__init__(message)

--- a/h/services/flag.py
+++ b/h/services/flag.py
@@ -3,6 +3,7 @@
 from __future__ import unicode_literals
 
 from h import models
+from .exceptions import NotPreloadedError
 
 
 class FlagService(object):
@@ -89,12 +90,6 @@ class PreloadedFlagService(object):
             raise NotPreloadedError(annotation.id)
 
         return annotation.id in self._flagged_ids
-
-
-class NotPreloadedError(Exception):
-    def __init__(self, annotation_id):
-        message = 'ID {} not in preloaded IDs'.format(annotation_id)
-        super(NotPreloadedError, self).__init__(message)
 
 
 def flag_service_factory(context, request):

--- a/h/services/flag.py
+++ b/h/services/flag.py
@@ -75,5 +75,27 @@ class FlagService(object):
         self.session.add(flag)
 
 
+class PreloadedFlagService(object):
+
+    def __init__(self, service, user, annotation_ids):
+        self._annotation_ids = set(annotation_ids)
+        if user:
+            self._flagged_ids = service.all_flagged(user, annotation_ids)
+        else:
+            self._flagged_ids = set()
+
+    def flagged(self, annotation):
+        if annotation.id not in self._annotation_ids:
+            raise NotPreloadedError(annotation.id)
+
+        return annotation.id in self._flagged_ids
+
+
+class NotPreloadedError(Exception):
+    def __init__(self, annotation_id):
+        message = 'ID {} not in preloaded IDs'.format(annotation_id)
+        super(NotPreloadedError, self).__init__(message)
+
+
 def flag_service_factory(context, request):
     return FlagService(request.db)

--- a/h/services/flag_count.py
+++ b/h/services/flag_count.py
@@ -49,5 +49,23 @@ class FlagCountService(object):
         return flag_counts
 
 
+class PreloadedFlagCountService(object):
+
+    def __init__(self, service, annotation_ids):
+        self._flag_counts = service.flag_counts(annotation_ids)
+
+    def flag_count(self, annotation):
+        if annotation.id not in self._flag_counts:
+            raise NotPreloadedError(annotation.id)
+
+        return self._flag_counts[annotation.id]
+
+
+class NotPreloadedError(Exception):
+    def __init__(self, annotation_id):
+        message = 'ID {} not in preloaded IDs'.format(annotation_id)
+        super(NotPreloadedError, self).__init__(message)
+
+
 def flag_count_service_factory(context, request):
     return FlagCountService(request.db)

--- a/h/services/flag_count.py
+++ b/h/services/flag_count.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 import sqlalchemy as sa
 
 from h.models import Flag
+from .exceptions import NotPreloadedError
 
 
 class FlagCountService(object):
@@ -59,12 +60,6 @@ class PreloadedFlagCountService(object):
             raise NotPreloadedError(annotation.id)
 
         return self._flag_counts[annotation.id]
-
-
-class NotPreloadedError(Exception):
-    def __init__(self, annotation_id):
-        message = 'ID {} not in preloaded IDs'.format(annotation_id)
-        super(NotPreloadedError, self).__init__(message)
 
 
 def flag_count_service_factory(context, request):

--- a/tests/h/formatters/annotation_flag_test.py
+++ b/tests/h/formatters/annotation_flag_test.py
@@ -13,17 +13,6 @@ FakeAnnotationResource = namedtuple('FakeAnnotationResource', ['annotation'])
 
 
 class TestAnnotationFlagFormatter(object):
-    def test_preload_sets_found_flags_to_true(self, flags, formatter, current_user):
-        annotation_ids = [f.annotation_id for f in flags[current_user]]
-
-        expected = {id_: True for id_ in annotation_ids}
-        assert formatter.preload(annotation_ids) == expected
-
-    def test_preload_sets_missing_flags_to_false(self, flags, formatter, other_user):
-        annotation_ids = [f.annotation_id for f in flags[other_user]]
-
-        expected = {id_: False for id_ in annotation_ids}
-        assert formatter.preload(annotation_ids) == expected
 
     def test_format_for_existing_flag(self, formatter, factories, current_user):
         flag = factories.Flag(user=current_user)

--- a/tests/h/formatters/annotation_hidden_test.py
+++ b/tests/h/formatters/annotation_hidden_test.py
@@ -12,26 +12,6 @@ from h.services.annotation_moderation import AnnotationModerationService
 FakeAnnotationResource = namedtuple('FakeAnnotationResource', ['annotation', 'group'])
 
 
-class TestAnnotationHiddenFormatter(object):
-    def test_preload_sets_founds_hidden_annotations_to_true(self, annotations, formatter):
-        annotation_ids = [a.id for a in annotations['hidden']]
-
-        expected = {id_: True for id_ in annotation_ids}
-        assert formatter.preload(annotation_ids) == expected
-
-    def test_preload_sets_missing_flags_to_false(self, annotations, formatter):
-        annotation_ids = [a.id for a in annotations['public']]
-
-        expected = {id_: False for id_ in annotation_ids}
-        assert formatter.preload(annotation_ids) == expected
-
-    @pytest.fixture
-    def annotations(self, factories):
-        hidden = [mod.annotation for mod in factories.AnnotationModeration.create_batch(3)]
-        public = factories.Annotation.create_batch(2)
-        return {'hidden': hidden, 'public': public}
-
-
 class TestAnonymousUserHiding(object):
     """An anonymous user will see redacted annotations when they're hidden."""
 

--- a/tests/h/formatters/annotation_moderation_test.py
+++ b/tests/h/formatters/annotation_moderation_test.py
@@ -26,19 +26,6 @@ class FakePermissionCheck(object):
 
 
 class TestAnnotationModerationFormatter(object):
-    def test_preload_sets_flag_counts(self, formatter, flagged, unflagged):
-        preload = formatter.preload([flagged.id, unflagged.id])
-
-        assert preload == {flagged.id: 2, unflagged.id: 0}
-
-    def test_preload_skipped_without_user(self, flag_count_svc):
-        formatter = AnnotationModerationFormatter(flag_count_svc,
-                                                  user=None,
-                                                  has_permission=None)
-        assert formatter.preload(['annotation-id']) is None
-
-    def test_preload_skipped_without_ids(self, formatter):
-        assert formatter.preload([]) is None
 
     def test_format_returns_empty_for_non_moderator(self, flag_count_svc, user, group, flagged, permission_denied):
         formatter = AnnotationModerationFormatter(flag_count_svc,
@@ -59,13 +46,6 @@ class TestAnnotationModerationFormatter(object):
 
         output = formatter.format(annotation_resource)
         assert output == {'moderation': {'flagCount': 0}}
-
-    def test_format_for_preloaded_annotation(self, formatter, group, flagged):
-        annotation_resource = FakeAnnotationResource(flagged, group)
-
-        formatter.preload([flagged.id])
-        output = formatter.format(annotation_resource)
-        assert output == {'moderation': {'flagCount': 2}}
 
     @pytest.fixture
     def user(self, factories):

--- a/tests/h/services/annotation_moderation_test.py
+++ b/tests/h/services/annotation_moderation_test.py
@@ -7,10 +7,10 @@ import pytest
 from h import models
 from h.services.annotation_moderation import (
     AnnotationModerationService,
-    NotPreloadedError,
     PreloadedAnnotationModerationService,
     annotation_moderation_service_factory,
 )
+from h.services.exceptions import NotPreloadedError
 
 
 class TestAnnotationModerationServiceHidden(object):

--- a/tests/h/services/annotation_moderation_test.py
+++ b/tests/h/services/annotation_moderation_test.py
@@ -5,8 +5,12 @@ from __future__ import unicode_literals
 import pytest
 
 from h import models
-from h.services.annotation_moderation import AnnotationModerationService
-from h.services.annotation_moderation import annotation_moderation_service_factory
+from h.services.annotation_moderation import (
+    AnnotationModerationService,
+    NotPreloadedError,
+    PreloadedAnnotationModerationService,
+    annotation_moderation_service_factory,
+)
 
 
 class TestAnnotationModerationServiceHidden(object):
@@ -85,6 +89,29 @@ class TestAnnotationModerationServiceUnhide(object):
         svc.unhide(annotation)
 
         assert svc.hidden(annotation) is False
+
+
+class TestPreloadedAnnotationModerationService(object):
+
+    def test_hidden_annotation(self, svc, factories):
+        moderation = factories.AnnotationModeration()
+        annotation_ids = [moderation.annotation.id]
+        psvc = PreloadedAnnotationModerationService(svc, annotation_ids)
+
+        assert psvc.hidden(moderation.annotation) is True
+
+    def test_visible_annotation(self, svc, factories):
+        annotation = factories.Annotation()
+        psvc = PreloadedAnnotationModerationService(svc, [annotation.id])
+
+        assert psvc.hidden(annotation) is False
+
+    def test_unloaded_id(self, svc, factories):
+        annotation = factories.Annotation()
+        psvc = PreloadedAnnotationModerationService(svc, [])
+
+        with pytest.raises(NotPreloadedError):
+            psvc.hidden(annotation)
 
 
 class TestAnnotationNipsaServiceFactory(object):

--- a/tests/h/services/flag_test.py
+++ b/tests/h/services/flag_test.py
@@ -4,8 +4,13 @@ from __future__ import unicode_literals
 
 import pytest
 
-from h.services import flag
 from h import models
+from h.services.flag import (
+    FlagService,
+    NotPreloadedError,
+    PreloadedFlagService,
+    flag_service_factory,
+)
 
 
 @pytest.mark.usefixtures('flags')
@@ -69,16 +74,50 @@ class TestFlagServiceCreate(object):
                          .count() == 1
 
 
+class TestPreloadedFlagService(object):
+
+    def test_flagged_annotation(self, svc, flags):
+        flag = flags[-1]
+        psvc = PreloadedFlagService(svc, flag.user, [flag.annotation.id])
+
+        assert psvc.flagged(flag.annotation) is True
+
+    def test_unflagged_annotation(self, svc, factories):
+        user = factories.User()
+        annotation = factories.Annotation()
+        psvc = PreloadedFlagService(svc, user, [annotation.id])
+
+        assert psvc.flagged(annotation) is False
+
+    def test_no_user(self, svc, flags):
+        annotation = flags[-1].annotation
+        psvc = PreloadedFlagService(svc, None, [annotation.id])
+
+        assert psvc.flagged(annotation) is False
+
+    def test_unloaded_id(self, svc, factories):
+        annotation = factories.Annotation()
+        user = factories.User()
+        psvc = PreloadedFlagService(svc, user, [])
+
+        with pytest.raises(NotPreloadedError):
+            psvc.flagged(annotation)
+
+    @pytest.fixture
+    def flags(self, factories):
+        return factories.Flag.create_batch(3)
+
+
 class TestFlagServiceFactory(object):
     def test_it_returns_flag_service(self, pyramid_request):
-        svc = flag.flag_service_factory(None, pyramid_request)
-        assert isinstance(svc, flag.FlagService)
+        svc = flag_service_factory(None, pyramid_request)
+        assert isinstance(svc, FlagService)
 
     def test_it_provides_request_db_as_session(self, pyramid_request):
-        svc = flag.flag_service_factory(None, pyramid_request)
+        svc = flag_service_factory(None, pyramid_request)
         assert svc.session == pyramid_request.db
 
 
 @pytest.fixture
 def svc(db_session):
-    return flag.FlagService(db_session)
+    return FlagService(db_session)

--- a/tests/h/services/flag_test.py
+++ b/tests/h/services/flag_test.py
@@ -7,10 +7,10 @@ import pytest
 from h import models
 from h.services.flag import (
     FlagService,
-    NotPreloadedError,
     PreloadedFlagService,
     flag_service_factory,
 )
+from h.services.exceptions import NotPreloadedError
 
 
 @pytest.mark.usefixtures('flags')


### PR DESCRIPTION
This is still very much work in progress, and I’m unlikely to find time this week to finish up the last bits on the `AnnotationJSONPresentationService` and its tests, but feedback on the general approach is very welcome.