### PR TITLE
Upgrade pyramid_authsanity to 1.0.0

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -26,9 +26,7 @@ psycogreen
 psycopg2
 pyparsing >= 2.1.5
 pyramid
-# Pin pyramid_authsanity to latest master until our bugfix
-# (https://github.com/usingnamespace/pyramid_authsanity/pull/7) is released.
-git+https://github.com/usingnamespace/pyramid_authsanity.git@7d0b70582cd693052a62b4683e521c1f4e2b4aa8#egg=pyramid_authsanity
+pyramid_authsanity >= 1.0.0  # 1.0.0 fixes an IE bug: https://git.io/vH3mi
 pyramid_layout
 pyramid-jinja2
 pyramid-services

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@
 #
 #    pip-compile --output-file requirements.txt requirements.in
 #
-
 alembic==0.8.7
 amqp==1.4.9               # via kombu
 anyjson==0.3.3            # via kombu
@@ -50,8 +49,8 @@ psycogreen==1.0
 psycopg2==2.6.2
 pycparser==2.14           # via cffi
 pyjwt==1.4.1
-git+https://github.com/usingnamespace/pyramid_authsanity.git@7d0b70582cd693052a62b4683e521c1f4e2b4aa8#egg=pyramid_authsanity
-pyparsing==2.1.10         # via packaging
+pyparsing==2.1.10
+pyramid-authsanity==1.0.0
 pyramid-jinja2==2.6.2
 pyramid-layout==1.0
 pyramid-mailer==0.15.1
@@ -70,14 +69,15 @@ requests==2.13.0          # via requests-aws4auth
 six==1.10.0               # via bcrypt, bleach, cryptography, html5lib, packaging, python-dateutil
 sqlalchemy==1.1.4
 statsd==3.2.1
-transaction==2.1.2        # via pyramid-mailer, pyramid-tm, repoze.sendmail, zope.sqlalchemy
+transaction==2.1.2
 translationstring==1.3    # via colander, deform, pyramid
 unidecode==0.4.19         # via python-slugify
 urllib3==1.16             # via elasticsearch
-venusian==1.0             # via pyramid
+venusian==1.0
+webencodings==0.5.1       # via html5lib
 webob==1.6.1              # via pyramid
 ws4py==0.4.2
 wsaccel==0.6.2
 zope.deprecation==4.1.2   # via deform, pyramid, pyramid-jinja2
-zope.interface==4.3.2     # via pyramid, pyramid-authsanity, pyramid-services, repoze.sendmail, transaction, zope.sqlalchemy
+zope.interface==4.3.2
 zope.sqlalchemy==0.7.7


### PR DESCRIPTION
[Our fix](https://github.com/usingnamespace/pyramid_authsanity/pull/7) for an esoteric IE bug (where we'd set a correctly signed cookie instead of removing a cookie) is in the latest release of this package.

There are a couple of small changes to the generated requirements.txt that aren't directly related to this upgrade, but they all look harmless to me and are mostly the result of us acquiring direct dependencies on packages that were previously transitive dependencies (such as transaction, venusian and zope.interface).