### PR TITLE
Add feature flag for fetching annotations based on DOI metadata

### DIFF
--- a/h/models/feature.py
+++ b/h/models/feature.py
@@ -19,6 +19,7 @@ FEATURES = {
                     "client?"),
     'homepage_redirects': "Enable homepage redirects (for WordPress migration)?",
     'orphans_tab': "Show the orphans tab to separate anchored and unanchored annotations?",
+    'search_for_doi': "Use DOI metadata when searching for annotations on the current page?",
     'total_shared_annotations': "Show the total number of shared annotations for users and groups?",
 }
 


### PR DESCRIPTION
Add a client feature flag for searching for annotations associated with
DOIs matching the DOI metadata of the current page.

See https://github.com/hypothesis/client/pull/402