### PR TITLE
Sort feature flags by name in admin UI

### DIFF
--- a/h/views/admin_features.py
+++ b/h/views/admin_features.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 from pyramid import httpexceptions
-from pyramid import session
 from pyramid.view import view_config
 
 from h import models
@@ -14,8 +13,11 @@ from h.i18n import TranslationString as _
              renderer='h:templates/admin/features.html.jinja2',
              permission='admin_features')
 def features_index(request):
+
+    features = sorted(models.Feature.all(request.db), key=lambda f: f.name)
+
     return {
-        "features": models.Feature.all(request.db),
+        "features": features,
         "cohorts": request.db.query(models.FeatureCohort).all(),
     }
 

--- a/tests/h/views/admin_features_test.py
+++ b/tests/h/views/admin_features_test.py
@@ -10,6 +10,7 @@ from h.views.admin_features import (
     cohorts_edit_add,
     cohorts_edit_remove,
     cohorts_index,
+    features_index,
     features_save,
 )
 
@@ -23,6 +24,17 @@ class DummyFeature(object):
 
 
 features_save_fixtures = pytest.mark.usefixtures('Feature')
+
+
+def test_features_index_sorts_features(Feature, pyramid_request):
+    alpha = DummyFeature(name='alpha')
+    beta = DummyFeature(name='beta')
+    delta = DummyFeature(name='delta')
+    Feature.all.return_value = [beta, delta, alpha]
+
+    ctx = features_index(pyramid_request)
+
+    assert ctx['features'] == [alpha, beta, delta]
 
 
 @features_save_fixtures


### PR DESCRIPTION
Sort feature flag list at /admin/features by name. This makes it a bit
easier to skim the list if there are several active flags.