### PR TITLE
use tooltip to announce actions available behind timestamp link

### DIFF
--- a/h/templates/includes/annotation_card.html.jinja2
+++ b/h/templates/includes/annotation_card.html.jinja2
@@ -20,7 +20,7 @@
         class="annotation-card__username">
         {{ presented_annotation.annotation.username }}
       </a>
-      <a title="date" href="{{ request.route_url('annotation', id=presented_annotation.annotation.id) }}"
+      <a title="reply, edit, delete, flag" href="{{ request.route_url('annotation', id=presented_annotation.annotation.id) }}"
         class="annotation-card__timestamp">
         {{ presented_annotation.annotation.updated.strftime('%d %b %Y') }}
       </a>


### PR DESCRIPTION
Until we can more fully integrate the functions of the standalone /a/ID card, which is linked from the timestamp, whose tooltip currently just says `date`, this PR adjusts the tooltip to indicate that the timestamp's link is the gateway to functions (reply, edit, delete, flag) available there.

Background: A user accidentally annotated a Gmail page, found the annotation using /search, but was unable to find it in the sidebar. I don't know exactly why not. Group confusion? Orphan confusion? In any case, the direct path to the standalone annotation card is non-obvious and a more informative tooltip can make it slightly less so. Again, as an interim solution until the /search card can include those functions.