### PR TITLE
Fix search page scrolling to top after collapsing bucket

### DIFF
--- a/h/static/scripts/controllers/search-bucket-controller.js
+++ b/h/static/scripts/controllers/search-bucket-controller.js
@@ -30,12 +30,18 @@ class SearchBucketController extends Controller {
       if (this.refs.domainLink.contains(event.target)) {
         return;
       }
+
+      event.stopPropagation();
+      event.preventDefault();
+
       this.setState({expanded: !this.state.expanded});
     });
 
     this.refs.title.addEventListener('click', (event) => {
-      this.setState({expanded: !this.state.expanded});
       event.stopPropagation();
+      event.preventDefault();
+
+      this.setState({expanded: !this.state.expanded});
     });
 
     this.refs.collapseView.addEventListener('click', () => {


### PR DESCRIPTION
Prevent default response when clicking on the document title link at the
top of a bucket, which caused the page to scroll up when collapsing a
bucket.

Fixes #4577