### PR TITLE
Add feature flag to append cachebuster to client URL

### DIFF
--- a/h/models/feature.py
+++ b/h/models/feature.py
@@ -13,6 +13,8 @@ log = logging.getLogger(__name__)
 FEATURES = {
     'defer_realtime_updates': ("Require a user action before applying real-time"
                                " updates to annotations in the client?"),
+    'embed_cachebuster': ("Cache-bust client entry point URL to prevent browser/CDN from "
+                          "using a cached version?"),
     'filter_highlights': ("Filter highlights in document based on visible"
                           " annotations in sidebar?"),
     'flag_action': ("Enable user to flag inappropriate annotations in the "

--- a/h/views/client.py
+++ b/h/views/client.py
@@ -9,6 +9,7 @@ Views which exist either to serve or support the Hypothesis client.
 from __future__ import unicode_literals
 
 import json
+import time
 
 from pyramid.httpexceptions import HTTPFound
 from pyramid.view import view_config
@@ -27,7 +28,11 @@ def _client_url(request):
     """
     Return the configured URL for the client.
     """
-    return request.registry.settings.get('h.client_url', DEFAULT_CLIENT_URL)
+    url = request.registry.settings.get('h.client_url', DEFAULT_CLIENT_URL)
+
+    if request.feature('embed_cachebuster'):
+        url += '?cachebuster=' + str(int(time.time()))
+    return url
 
 
 @view_config(route_name='sidebar_app',

--- a/tests/h/views/client_test.py
+++ b/tests/h/views/client_test.py
@@ -54,10 +54,20 @@ class TestSidebarApp(object):
 @pytest.mark.usefixtures('routes', 'pyramid_settings')
 class TestEmbedRedirect(object):
     def test_redirects_to_client_boot_script(self, pyramid_request):
+        pyramid_request.feature.flags['embed_cachebuster'] = False
+
         rsp = client.embed_redirect(pyramid_request)
 
         assert isinstance(rsp, HTTPFound)
         assert rsp.location == 'https://cdn.hypothes.is/hypothesis'
+
+    def test_adds_cachebuster(self, pyramid_request):
+        pyramid_request.feature.flags['embed_cachebuster'] = True
+
+        rsp = client.embed_redirect(pyramid_request)
+
+        assert isinstance(rsp, HTTPFound)
+        assert '?cachebuster=' in rsp.location
 
 
 @pytest.fixture


### PR DESCRIPTION
Add a feature flag which causes a cachebuster to be appended to the
URL of the client's boot script when serving the embed. When enabled for a request, the client URL is returned as "https://cdn.hypothes.is/hypothesis?cachebuster=$TIMESTAMP".

This provides a way to bypass the CDN cache on a per-cohort basis (eg.
temporarily enable for a dev after a client release for testing), or on
a per-request basis (eg. create a bookmarklet which serves
`.../embed.js?__feature__[embed_cachebuster]` and sets the sidebar app
URL to `.../app.html?__feature__[embed_cachebuster]`).

There are other ways we could potentially do this, see [this issue](https://github.com/hypothesis/product-backlog/issues/331) for some ideas. I'm open to alternative suggestions.