### PR TITLE
Expose OAuth feature flag & client ID to client

### DIFF
--- a/docs/developing/envvars.rst
+++ b/docs/developing/envvars.rst
@@ -8,3 +8,8 @@ This section documents the environment variables supported by h.
    The URL at which the Hypothesis client code is hosted.
    This is the URL to the client entrypoint script, by default
    https://cdn.hypothes.is/hypothesis.
+
+.. envvar:: CLIENT_OAUTH_ID
+
+   The OAuth client ID for the Hypothesis client on pages that embed it using
+   the service's /embed.js script.

--- a/h/config.py
+++ b/h/config.py
@@ -70,9 +70,19 @@ SETTINGS = [
                       message='use the AUTHORITY environment variable instead'),
     EnvSetting('h.authority', 'AUTHORITY'),
     EnvSetting('h.bouncer_url', 'BOUNCER_URL'),
+
+    # ID and secret used for the issuer when signing JWT tokens for legacy API
+    # auth.
     EnvSetting('h.client_id', 'CLIENT_ID'),
     EnvSetting('h.client_secret', 'CLIENT_SECRET'),
+
     EnvSetting('h.client_url', 'CLIENT_URL'),
+
+    # ID for the OAuth authclient that the embedded client should use when
+    # making requests to OAuth endpoints. As a public client, it does not have a
+    # secret.
+    EnvSetting('h.client_oauth_id', 'CLIENT_OAUTH_ID'),
+
     # Environment name, provided by the deployment environment. Please do
     # *not* toggle functionality based on this value. It is intended as a
     # label only.

--- a/h/models/feature.py
+++ b/h/models/feature.py
@@ -11,6 +11,8 @@ from h.db import Base
 log = logging.getLogger(__name__)
 
 FEATURES = {
+    'client_oauth': ("Use OAuth for first party accounts in client? "
+                     "(Only takes effect if enabled for everyone)"),
     'defer_realtime_updates': ("Require a user action before applying real-time"
                                " updates to annotations in the client?"),
     'filter_highlights': ("Filter highlights in document based on visible"

--- a/h/models/feature.py
+++ b/h/models/feature.py
@@ -19,11 +19,10 @@ FEATURES = {
                     "client?"),
     'homepage_redirects': "Enable homepage redirects (for WordPress migration)?",
     'orphans_tab': "Show the orphans tab to separate anchored and unanchored annotations?",
+    'overlay_highlighter': "Use the new overlay highlighter?",
     'search_for_doi': "Use DOI metadata when searching for annotations on the current page?",
     'total_shared_annotations': "Show the total number of shared annotations for users and groups?",
-    'overlay_highlighter': "Use the new overlay highlighter?",
     'view-switcher': 'Use the new-style [Annotations|Page Notes|Orphans] view switcher control at the top of the sidebar',
-
 }
 
 # Once a feature has been fully deployed, we remove the flag from the codebase.

--- a/h/templates/help.html.jinja2
+++ b/h/templates/help.html.jinja2
@@ -19,6 +19,17 @@
     </script>
     <script async defer src="{{ embed_js_url }}"></script>
   {% endif %}
+  {#
+    Make the help page usable for testing OAuth login to the client
+    by visiting `/docs/help?__feature__[client_oauth]`.
+  #}
+  {% if request.feature('client_oauth') %}
+    <script type="application/json" class="js-hypothesis-config">
+    {
+      "oauthEnabled": true
+    }
+    </script>
+  {% endif %}
 {% endblock %}
 
 {% block content %}

--- a/h/views/client.py
+++ b/h/views/client.py
@@ -56,7 +56,8 @@ def sidebar_app(request, extra=None):
         # that it is available as soon as the client starts before
         # API tokens are fetched.
         #
-        # This should be removed once OAuth for first-party accounts is shipped.
+        # TODO - This should be removed once OAuth for first-party accounts is
+        #        shipped.
         'oauthEnabled': request.feature('client_oauth'),
 
         'release': __version__,

--- a/h/views/client.py
+++ b/h/views/client.py
@@ -49,6 +49,16 @@ def sidebar_app(request, extra=None):
     app_config = {
         'apiUrl': request.route_url('api.index'),
         'authDomain': request.authority,
+        'oauthClientId': settings.get('h.client_oauth_id'),
+
+        # The OAuth feature flag is included as part of the `app.html` config
+        # rather than being delivered via the "features" key in /api/profile so
+        # that it is available as soon as the client starts before
+        # API tokens are fetched.
+        #
+        # This should be removed once OAuth for first-party accounts is shipped.
+        'oauthEnabled': request.feature('client_oauth'),
+
         'release': __version__,
         'serviceUrl': request.route_url('index'),
     }

--- a/tests/h/views/client_test.py
+++ b/tests/h/views/client_test.py
@@ -38,7 +38,9 @@ class TestSidebarApp(object):
                     'release': __version__
                 },
                 'authDomain': 'example.com',
-                'googleAnalytics': 'UA-4567'
+                'googleAnalytics': 'UA-4567',
+                'oauthClientId': 'test-client-id',
+                'oauthEnabled': True,
                 }
 
         actual_config = json.loads(ctx['app_config'])
@@ -49,6 +51,14 @@ class TestSidebarApp(object):
         ctx = client.sidebar_app(pyramid_request)
 
         assert ctx['embed_url'] == '/embed.js'
+
+    def test_it_disables_oauth(self, pyramid_request):
+        pyramid_request.feature.flags['client_oauth'] = False
+
+        ctx = client.sidebar_app(pyramid_request)
+        cfg = json.loads(ctx['app_config'])
+
+        assert cfg['oauthEnabled'] is False
 
 
 @pytest.mark.usefixtures('routes', 'pyramid_settings')
@@ -65,6 +75,7 @@ def pyramid_settings(pyramid_settings):
 
     pyramid_settings.update({
         'ga_client_tracking_id': 'UA-4567',
+        'h.client_oauth_id': 'test-client-id',
         'h.sentry_dsn_client': 'test-sentry-dsn',
         'h.websocket_url': 'wss://example.com/ws',
         'authority': 'example.com'


### PR DESCRIPTION
This adds a facility to expose an OAuth client ID to the client in the configuration for app.html and a feature flag indicating whether to use it or not. The feature flag is separate so we can turn it on/off, including allowing the client to override it, without needing to change the service environment.

Enabling it to be overridden it for testing purposes in client configuration will require a small client change (https://github.com/hypothesis/client/pull/470).

For convenient testing in development and production, the last commit in this PR configures the client to use OAuth when visiting `/docs/help` with the "client_oauth" flag enabled, which can be done using the existing `__feature__[<name>]` query param support. In other words, given a client with the change in https://github.com/hypothesis/client/pull/470, visiting `/docs/help?__feature__[client_oauth]` will load an embedded client configured to use OAuth.