### PR TITLE
return /api/search results as jsonld

### DIFF
--- a/h/services/annotation_json_presentation.py
+++ b/h/services/annotation_json_presentation.py
@@ -57,7 +57,7 @@ class AnnotationJSONPresentationService(object):
 
 
 def annotation_json_presentation_service_factory(context, request):
-    jsonld = context.request.GET.pop('jsonld', False) is not False
+    jsonld = context is not None and context.request.GET.pop('jsonld', False) is not False
     group_svc = request.find_service(IGroupService)
     links_svc = request.find_service(name='links')
     flag_svc = request.find_service(name='flag')

--- a/h/services/annotation_json_presentation.py
+++ b/h/services/annotation_json_presentation.py
@@ -13,10 +13,11 @@ from h.interfaces import IGroupService
 
 
 class AnnotationJSONPresentationService(object):
-    def __init__(self, session, user, group_svc, links_svc, flag_svc, flag_count_svc, moderation_svc, has_permission):
+    def __init__(self, session, user, group_svc, links_svc, flag_svc, flag_count_svc, moderation_svc, has_permission, jsonld):
         self.session = session
         self.group_svc = group_svc
         self.links_svc = links_svc
+        self.jsonld = jsonld
 
         def moderator_check(group):
             return has_permission('admin', group)
@@ -48,11 +49,15 @@ class AnnotationJSONPresentationService(object):
                 for ann in annotations]
 
     def _get_presenter(self, annotation_resource):
-        return presenters.AnnotationJSONPresenter(annotation_resource,
-                                                  self.formatters)
+        if self.jsonld:
+            return presenters.AnnotationJSONLDPresenter(annotation_resource)
+        else:
+            return presenters.AnnotationJSONPresenter(annotation_resource,
+                                                      self.formatters)
 
 
 def annotation_json_presentation_service_factory(context, request):
+    jsonld = context.request.GET.pop('jsonld', False) is not False
     group_svc = request.find_service(IGroupService)
     links_svc = request.find_service(name='links')
     flag_svc = request.find_service(name='flag')
@@ -65,4 +70,5 @@ def annotation_json_presentation_service_factory(context, request):
                                              flag_svc=flag_svc,
                                              flag_count_svc=flag_count_svc,
                                              moderation_svc=moderation_svc,
-                                             has_permission=request.has_permission)
+                                             has_permission=request.has_permission,
+                                             jsonld=jsonld)

--- a/h/views/api.py
+++ b/h/views/api.py
@@ -181,6 +181,8 @@ def search(request):
     params = request.params.copy()
 
     separate_replies = params.pop('_separate_replies', False)
+    if 'jsonld' in params:
+        params.pop('jsonld') # not a query param
     stats = getattr(request, 'stats', None)
     result = search_lib.Search(request,
                                separate_replies=separate_replies,

--- a/tests/h/services/annotation_json_presentation_test.py
+++ b/tests/h/services/annotation_json_presentation_test.py
@@ -105,7 +105,8 @@ class TestAnnotationJSONPresentationService(object):
                                                  flag_svc=services['flag'],
                                                  flag_count_svc=services['flag_count'],
                                                  moderation_svc=services['annotation_moderation'],
-                                                 has_permission=mock.sentinel.has_permission)
+                                                 has_permission=mock.sentinel.has_permission,
+                                                 jsonld=False)
 
     @pytest.fixture
     def annotation_resource(self):


### PR DESCRIPTION
# overview

A step in the direction of a more complete implementation of W3C-standard output.

Currently we support, e.g, https://hypothes.is/api/annotations/Dms34EbzEeebxbfPD5_8Rw.jsonld as the standard alternative to https://hypothes.is/api/annotations/Dms34EbzEeebxbfPD5_8Rw.

This change invokes the jsonld presenter for search results when an API query includes `&jsonld=true`

# sample output

```
{
	"rows": [{
		"body": [{
			"type": "TextualBody",
			"value": "",
			"format": "text/markdown"
		}, {
			"type": "TextualBody",
			"purpose": "tagging",
			"value": "FrontGroup"
		}, {
			"type": "TextualBody",
			"purpose": "tagging",
			"value": "SourceWatch"
		}, {
			"type": "TextualBody",
			"purpose": "tagging",
			"value": "Capital Research Center"
		}],
		"target": [{
			"source": "https://www.indianagazette.com/news/opinions/commentary-inside-the-liberal-dystopia,26312437/"
		}],
		"created": "2017-05-30T20:13:24.861874+00:00",
		"@context": "http://www.w3.org/ns/anno.jsonld",
		"creator": "acct:jon@localhost",
		"type": "Annotation",
		"id": "http://localhost:5000/a/b53cFEV0Eeev9cP7e7gJAw",
		"modified": "2017-05-30T20:13:24.861874+00:00"
	}, {
		"body": [{
			"type": "TextualBody",
			"value": "This may be a front group. [Investigate](http://www.sourcewatch.org/index.php/Capital_Research_Center), find additional sources, and leave research notes in the comments.",
			"format": "text/markdown"
		}, {
			"type": "TextualBody",
			"purpose": "tagging",
			"value": "FrontGroup"
		}, {
			"type": "TextualBody",
			"purpose": "tagging",
			"value": "SourceWatch"
		}, {
			"type": "TextualBody",
			"purpose": "tagging",
			"value": "Capital Research Center"
		}],
		"target": [{
			"source": "https://www.indianagazette.com/news/opinions/commentary-inside-the-liberal-dystopia,26312437/"
		}],
		"created": "2017-05-30T20:11:07.459662+00:00",
		"@context": "http://www.w3.org/ns/anno.jsonld",
		"creator": "acct:jon@localhost",
		"type": "Annotation",
		"id": "http://localhost:5000/a/HbPi4EV0Eeev9RdU_F__SQ",
		"modified": "2017-05-30T20:11:07.459662+00:00"
	}],
	"total": 2128
}
```

# notes

I noticed while doing this that our JSONLDPresenter doesn't do anything with the `references` field so there's no distinction between annotations and replies.