### PR TITLE
Initial implementation of an OAuth authorization endpoint

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -101,6 +101,10 @@ var bundles = [{
   // Header script inserted inline at the top of the page
   name: 'header',
   entry: './h/static/scripts/header',
+},{
+  // Helper script for the OAuth post-authorization page.
+  name: 'post-auth',
+  entry: './h/static/scripts/post-auth',
 }];
 
 var bundleConfigs = bundles.map(function (config) {

--- a/h/assets.ini
+++ b/h/assets.ini
@@ -23,6 +23,9 @@ site_js =
 header_js =
   scripts/header.bundle.js
 
+post_auth_js =
+  scripts/post-auth.bundle.js
+
 site_css =
   styles/site.css
 

--- a/h/routes.py
+++ b/h/routes.py
@@ -91,6 +91,7 @@ def includeme(config):
     config.add_route('api.users', '/api/users')
     config.add_route('badge', '/api/badge')
     config.add_route('token', '/api/token')
+    config.add_route('oauth_authorize', '/oauth/authorize')
 
     # Client
     config.add_route('session', '/app')

--- a/h/services/oauth.py
+++ b/h/services/oauth.py
@@ -149,6 +149,25 @@ class OAuthService(object):
 
         return token
 
+    def create_grant_token(self, user, authclient):
+        """
+        Generate a JWT bearer grant token for a user.
+
+        :param user: The user to generate the token for.
+        :type user: h.models.User
+        :param authclient: The OAuth client that is going to use the token.
+        :type authclient: h.models.AuthClient
+        """
+        now = datetime.datetime.utcnow()
+        claims = {
+            'aud': self.domain,
+            'iss': authclient.id,
+            'sub': 'acct:{}@{}'.format(user.username, user.authority),
+            'nbf': now,
+            'exp': now + datetime.timedelta(minutes=5),
+        }
+        return jwt.encode(claims, authclient.secret, algorithm='HS256')
+
 
 class GrantToken(object):
     """

--- a/h/services/oauth.py
+++ b/h/services/oauth.py
@@ -75,7 +75,7 @@ class OAuthService(object):
 
         token = GrantToken(body['assertion'])
 
-        authclient = self._get_authclient_by_id(token.issuer)
+        authclient = self.get_authclient_by_id(token.issuer)
         if not authclient:
             raise OAuthTokenError('grant token issuer (iss) is invalid', 'invalid_grant')
 
@@ -93,7 +93,12 @@ class OAuthService(object):
 
         return (user, authclient)
 
-    def _get_authclient_by_id(self, client_id):
+    def get_authclient_by_id(self, client_id):
+        """
+        Return the AuthClient with the given ID.
+
+        Returns `False` if no such client exists.
+        """
         try:
             return self.session.query(models.AuthClient).get(client_id)
         except sa.exc.StatementError as exc:

--- a/h/services/oauth.py
+++ b/h/services/oauth.py
@@ -162,7 +162,7 @@ class OAuthService(object):
         claims = {
             'aud': self.domain,
             'iss': authclient.id,
-            'sub': 'acct:{}@{}'.format(user.username, user.authority),
+            'sub': user.userid,
             'nbf': now,
             'exp': now + datetime.timedelta(minutes=5),
         }

--- a/h/services/oauth.py
+++ b/h/services/oauth.py
@@ -97,7 +97,7 @@ class OAuthService(object):
         """
         Return the AuthClient with the given ID.
 
-        Returns `False` if no such client exists.
+        Returns `None` if no such client exists.
         """
         try:
             return self.session.query(models.AuthClient).get(client_id)

--- a/h/static/scripts/controllers/authorize-form-controller.js
+++ b/h/static/scripts/controllers/authorize-form-controller.js
@@ -1,0 +1,60 @@
+'use strict';
+
+const Controller = require('../base/controller');
+
+/**
+ * Controller for the OAuth authorization popup.
+ */
+class AuthorizeFormController extends Controller {
+  constructor(element) {
+    super(element);
+
+    this.on('submit', () => {
+      // Prevent multiple submission or clicking the "Cancel" button after
+      // clicking "Accept".
+      this.setState({ submitting: true });
+    });
+
+    this.refs.cancelBtn.addEventListener('click', () => {
+      window.close();
+    });
+
+    window.addEventListener('beforeunload', () => {
+      this._sendAuthCanceledMessage();
+    });
+  }
+
+  /**
+   * Notify the parent window that auth was canceled.
+   *
+   * This is necessary since there isn't a DOM event that a cross-origin opener
+   * window can listen for to know when a popup window is closed.
+   */
+  _sendAuthCanceledMessage() {
+    if (this.state.submitting) {
+      // User already pressed "Accept" button.
+      return;
+    }
+
+    if (window.opener) {
+      let state;
+      if (this.refs.stateInput) {
+        state = this.refs.stateInput.value;
+      }
+
+      // Since this message contains no private data, just set the origin to
+      // '*' (any).
+      window.opener.postMessage({
+        type: 'authorization_canceled',
+        state,
+      }, '*');
+    }
+  }
+
+  update() {
+    this.refs.cancelBtn.disabled = !this.state.submitting;
+    this.refs.acceptBtn.disabled = !this.state.submitting;
+  }
+}
+
+module.exports = AuthorizeFormController;

--- a/h/static/scripts/post-auth.js
+++ b/h/static/scripts/post-auth.js
@@ -1,0 +1,24 @@
+'use strict';
+
+/**
+ * Script which runs in the small HTML page served by the OAuth Authorization
+ * endpoint after successful authorization.
+ *
+ * It communicates the auth code back to the web app which initiated
+ * authorization.
+ */
+
+const settings = require('./base/settings')(document);
+
+if (window.opener) {
+  const msg = {
+    type: 'authorization_response',
+    code: settings.code,
+    state: settings.state,
+  };
+  window.opener.postMessage(msg, settings.origin);
+  window.close();
+} else {
+  console.error('The opening window has closed');
+}
+

--- a/h/static/scripts/site.js
+++ b/h/static/scripts/site.js
@@ -9,6 +9,7 @@ if (settings.raven) {
 
 require('./polyfills');
 
+const AuthorizeFormController = require('./controllers/authorize-form-controller');
 const CharacterLimitController = require('./controllers/character-limit-controller');
 const CopyButtonController = require('./controllers/copy-button-controller');
 const ConfirmSubmitController = require('./controllers/confirm-submit-controller');
@@ -25,6 +26,7 @@ const TooltipController = require('./controllers/tooltip-controller');
 const upgradeElements = require('./base/upgrade-elements');
 
 const controllers = {
+  '.js-authorize-form': AuthorizeFormController,
   '.js-character-limit': CharacterLimitController,
   '.js-copy-button': CopyButtonController,
   '.js-confirm-submit': ConfirmSubmitController,

--- a/h/templates/oauth/authorize.html.jinja2
+++ b/h/templates/oauth/authorize.html.jinja2
@@ -1,0 +1,47 @@
+{% extends "h:templates/layouts/base.html.jinja2" %}
+
+{% block header %}
+  {% include "h:templates/includes/logo-header.html.jinja2" %}
+{% endblock %}
+
+{% block page_title %}Authorize application{% endblock %}
+
+{% block content %}
+  <div class="form-container content">
+    <h2>Authorize app?</h2>
+    <p>
+      <b>{{ client_name }}</b> wants to read and update data
+      in your Hypothesis account <b>{{ username }}</b>.
+    </p>
+
+    <form class="form js-authorize-form" method="POST">
+      <div class="form-actions">
+        <div class="form-actions__buttons">
+          <button type="submit" class="btn" data-ref="acceptBtn">Accept</button>
+          <button type="button" class="btn btn--cancel" data-ref="cancelBtn">Cancel</button>
+        </div>
+      </div>
+
+      {# Parameters from the initial request #}
+      <input type="hidden" name="response_mode" value="{{ response_mode }}">
+      <input type="hidden" name="response_type" value="{{ response_type }}">
+      <input type="hidden" name="client_id" value="{{ client_id }}">
+
+      {% if origin %}
+      <input type="hidden" name="origin" value="{{ origin }}">
+      {% endif %}
+
+      {% if redirect_uri %}
+      <input type="hidden" name="redirect_uri" value="{{ redirect_uri }}">
+      {% endif %}
+
+      {% if state %}
+      <input type="hidden" name="state" value="{{ state }}" data-ref="stateInput">
+      {% endif %}
+    </form>
+    <footer class="form-footer">
+      Don't have a Hypothesis account?
+      <a class="link--footer" href="{{ request.route_path('signup') }}">Sign up</a>
+    </footer>
+  </div>
+{% endblock content %}

--- a/h/templates/oauth/post_authorize.html.jinja2
+++ b/h/templates/oauth/post_authorize.html.jinja2
@@ -1,0 +1,16 @@
+<html>
+<head>
+<title>Authorization completed</title>
+<script type="application/json" class="js-hypothesis-settings">
+{
+  "code": {{ code | to_json }},
+  "origin": {{ origin | to_json }},
+  "state": {{ state | to_json }}
+}
+</script>
+{% for url in asset_urls('post_auth_js') %}
+<script src="{{ url }}"></script>
+{% endfor %}
+</script>
+</head>
+</html>

--- a/h/views/api_auth.py
+++ b/h/views/api_auth.py
@@ -84,6 +84,10 @@ class OAuthAuthorizeController(object):
         if not authclient:
             raise HTTPBadRequest('Unknown client ID "{}"'.format(client_id))
 
+        if authclient.authority != self.request.authority:
+            raise HTTPBadRequest('Client "{}" not allowed to authorize "{}" users'.format(
+                                 client_id, self.request.authority))
+
         response_type = params.get('response_type')
         if response_type != 'code':
             raise HTTPBadRequest('Unsupported response type "{}"'

--- a/h/views/api_auth.py
+++ b/h/views/api_auth.py
@@ -2,9 +2,98 @@
 
 from __future__ import unicode_literals
 
+from pyramid.httpexceptions import HTTPBadRequest, HTTPFound
+from pyramid.view import view_config, view_defaults
+from pyramid import security
+
 from h.exceptions import OAuthTokenError
 from h.util.view import cors_json_view
 from h.util.datetime import utc_iso8601
+
+
+@view_defaults(route_name='oauth_authorize')
+class OAuthAuthorizeController(object):
+
+    def __init__(self, request):
+        self.request = request
+        self.oauth_svc = self.request.find_service(name='oauth')
+        self.user_svc = self.request.find_service(name='user')
+
+    @view_config(request_method='GET',
+                 renderer='h:templates/oauth/authorize.html.jinja2')
+    def get(self):
+        """
+        Check the user's authentication status and present the authorization
+        page.
+        """
+        self._check_params()
+
+        if self.request.authenticated_userid is None:
+            raise HTTPFound(self.request.route_url('login', _query={
+                              'next': self.request.url}))
+
+        params = self.request.params
+        user = self.user_svc.fetch(self.request.authenticated_userid)
+
+        return {'username': user.username,
+                'client_name': 'Hypothesis',
+                'client_id': params['client_id'],
+                'response_type': params['response_type'],
+                'response_mode': params['response_mode'],
+                'state': params.get('state')}
+
+    @view_config(request_method='POST',
+                 renderer='h:templates/oauth/post_authorize.html.jinja2',
+                 effective_principals=security.Authenticated)
+    def post(self):
+        """
+        Process an authentication request and return an auth code to the client.
+
+        Depending on the "response_mode" parameter the auth code will be
+        delivered either via a redirect or via a `postMessage` call to the
+        opening window.
+        """
+        authclient = self._check_params()
+
+        user = self.user_svc.fetch(self.request.authenticated_userid)
+
+        # Create an "authorization code" for the response.
+        # This is in fact just a JWT grant token since auth codes have not yet
+        # been implemented.
+        auth_code = self.oauth_svc.create_grant_token(user, authclient)
+
+        params = self.request.params
+
+        return {'code': auth_code,
+                # Once authclients have an Origin property, that should be used
+                # instead here.
+                'origin': self.request.host_url,
+                'state': params.get('state')}
+
+    def _check_params(self):
+        """
+        Check parameters for the authorization request.
+
+        If the parameters are valid, returns an authclient.
+        Otherwise, raises an exception.
+        """
+        params = self.request.params
+
+        client_id = params.get('client_id', '')
+        authclient = self.oauth_svc._get_authclient_by_id(client_id)
+        if not authclient:
+            raise HTTPBadRequest('Unknown client ID "{}"'.format(client_id))
+
+        response_type = params.get('response_type')
+        if response_type != 'code':
+            raise HTTPBadRequest('Unsupported response type "{}"'
+                                 .format(response_type))
+
+        response_mode = params.get('response_mode', 'query')
+        if response_mode != 'web_message':
+            raise HTTPBadRequest('Unsupported response mode "{}"'.format(response_mode))
+
+        return authclient
 
 
 @cors_json_view(route_name='token', request_method='POST')

--- a/h/views/api_auth.py
+++ b/h/views/api_auth.py
@@ -80,7 +80,7 @@ class OAuthAuthorizeController(object):
         params = self.request.params
 
         client_id = params.get('client_id', '')
-        authclient = self.oauth_svc._get_authclient_by_id(client_id)
+        authclient = self.oauth_svc.get_authclient_by_id(client_id)
         if not authclient:
             raise HTTPBadRequest('Unknown client ID "{}"'.format(client_id))
 

--- a/h/views/client.py
+++ b/h/views/client.py
@@ -54,6 +54,9 @@ def sidebar_app(request, extra=None):
     app_config = {
         'apiUrl': request.route_url('api.index'),
         'authDomain': request.authority,
+
+        # OAuth config.
+        'oauthAuthorizeUrl': request.route_url('oauth_authorize'),
         'oauthClientId': settings.get('h.client_oauth_id'),
 
         # The OAuth feature flag is included as part of the `app.html` config

--- a/tests/h/routes_test.py
+++ b/tests/h/routes_test.py
@@ -80,6 +80,7 @@ def test_includeme():
         call('api.users', '/api/users'),
         call('badge', '/api/badge'),
         call('token', '/api/token'),
+        call('oauth_authorize', '/oauth/authorize'),
         call('session', '/app'),
         call('sidebar_app', '/app.html'),
         call('embed', '/embed.js'),

--- a/tests/h/views/api_auth_test.py
+++ b/tests/h/views/api_auth_test.py
@@ -22,7 +22,7 @@ class TestOAuthAuthorizeController(object):
     def test_get_verifies_client_id(self, auth_ctrl, pyramid_request,
                                     oauth_service):
 
-        oauth_service._get_authclient_by_id.return_value = None
+        oauth_service.get_authclient_by_id.return_value = None
 
         with pytest.raises(httpexceptions.HTTPBadRequest) as exc:
             auth_ctrl.get()

--- a/tests/h/views/api_auth_test.py
+++ b/tests/h/views/api_auth_test.py
@@ -79,7 +79,10 @@ class TestOAuthAuthorizeController(object):
         assert ctx['state'] == 'a_random_string'
 
     @pytest.fixture
-    def auth_ctrl(self, factories, pyramid_config, pyramid_request):
+    def auth_ctrl(self, pyramid_config, pyramid_request):
+        """
+        Configure a valid request for `OAuthAuthorizeController.get`.
+        """
         pyramid_config.testing_securitypolicy('acct:fred@example.org')
 
         pyramid_request.GET['client_id'] = 'valid_id'
@@ -90,7 +93,10 @@ class TestOAuthAuthorizeController(object):
         return views.OAuthAuthorizeController(pyramid_request)
 
     @pytest.fixture
-    def post_auth_ctrl(self, factories, pyramid_config, pyramid_request):
+    def post_auth_ctrl(self, pyramid_config, pyramid_request):
+        """
+        Configure a valid request for `OAuthAuthorizeController.post`.
+        """
         pyramid_config.testing_securitypolicy('acct:fred@example.org')
 
         pyramid_request.POST['client_id'] = 'valid_id'

--- a/tests/h/views/api_auth_test.py
+++ b/tests/h/views/api_auth_test.py
@@ -2,10 +2,12 @@
 
 from __future__ import unicode_literals
 
+from h._compat import url_quote
 import datetime
 
 import mock
 import pytest
+from pyramid import httpexceptions
 
 from h.services.auth_token import auth_token_service_factory
 from h.services.oauth import oauth_service_factory
@@ -13,6 +15,106 @@ from h.services.user import user_service_factory
 from h.exceptions import OAuthTokenError
 from h.util.datetime import utc_iso8601
 from h.views import api_auth as views
+
+
+@pytest.mark.usefixtures('routes', 'user_service', 'oauth_service')
+class TestOAuthAuthorizeController(object):
+    def test_get_verifies_client_id(self, auth_ctrl, pyramid_request,
+                                    oauth_service):
+
+        oauth_service._get_authclient_by_id.return_value = None
+
+        with pytest.raises(httpexceptions.HTTPBadRequest) as exc:
+            auth_ctrl.get()
+
+        assert 'Unknown client ID' in exc.value.message
+
+    def test_get_verifies_response_mode(self, auth_ctrl, pyramid_request):
+        pyramid_request.GET['response_mode'] = 'invalid_mode'
+
+        with pytest.raises(httpexceptions.HTTPBadRequest) as exc:
+            auth_ctrl.get()
+
+        assert 'Unsupported response mode' in exc.value.message
+
+    def test_get_verifies_response_type(self, auth_ctrl, pyramid_request):
+        pyramid_request.GET['response_type'] = 'invalid_type'
+
+        with pytest.raises(httpexceptions.HTTPBadRequest) as exc:
+            auth_ctrl.get()
+
+        assert 'Unsupported response type' in exc.value.message
+
+    def test_get_redirects_if_user_not_logged_in(self, auth_ctrl,
+                                                 pyramid_config, pyramid_request):
+        pyramid_config.testing_securitypolicy(None)
+        pyramid_request.url = 'http://example.com/auth?client_id=bar'
+
+        with pytest.raises(httpexceptions.HTTPFound) as exc:
+            auth_ctrl.get()
+
+        assert exc.value.location == 'http://example.com/login?next={}'.format(
+                                       url_quote(pyramid_request.url, safe=''))
+
+    def test_get_returns_expected_context(self, auth_ctrl, user_service):
+        ctx = auth_ctrl.get()
+
+        assert ctx == {'username': user_service.fetch.return_value.username,
+                       'client_name': 'Hypothesis',
+                       'client_id': 'valid_id',
+                       'response_type': 'code',
+                       'response_mode': 'web_message',
+                       'state': 'a_random_string'}
+
+    def test_post_returns_auth_code(self, post_auth_ctrl, oauth_service):
+        ctx = post_auth_ctrl.post()
+        assert ctx['code'] == oauth_service.create_grant_token.return_value
+
+    def test_post_sets_origin(self, post_auth_ctrl):
+        ctx = post_auth_ctrl.post()
+        assert ctx['origin'] == 'http://example.com'
+
+    def test_post_returns_state(self, post_auth_ctrl, pyramid_request):
+        ctx = post_auth_ctrl.post()
+        assert ctx['state'] == 'a_random_string'
+
+    @pytest.fixture
+    def auth_ctrl(self, factories, pyramid_config, pyramid_request):
+        pyramid_config.testing_securitypolicy('acct:fred@example.org')
+
+        pyramid_request.GET['client_id'] = 'valid_id'
+        pyramid_request.GET['response_mode'] = 'web_message'
+        pyramid_request.GET['response_type'] = 'code'
+        pyramid_request.GET['state'] = 'a_random_string'
+
+        return views.OAuthAuthorizeController(pyramid_request)
+
+    @pytest.fixture
+    def post_auth_ctrl(self, factories, pyramid_config, pyramid_request):
+        pyramid_config.testing_securitypolicy('acct:fred@example.org')
+
+        pyramid_request.POST['client_id'] = 'valid_id'
+        pyramid_request.POST['response_mode'] = 'web_message'
+        pyramid_request.POST['response_type'] = 'code'
+        pyramid_request.POST['state'] = 'a_random_string'
+
+        return views.OAuthAuthorizeController(pyramid_request)
+
+    @pytest.fixture
+    def oauth_service(self, pyramid_config, pyramid_request):
+        svc = mock.Mock(spec_set=oauth_service_factory(None, pyramid_request))
+        pyramid_config.register_service(svc, name='oauth')
+        return svc
+
+    @pytest.fixture
+    def user_service(self, pyramid_config, pyramid_request):
+        svc = mock.Mock(spec_set=user_service_factory(None, pyramid_request))
+        pyramid_config.register_service(svc, name='user')
+        return svc
+
+    @pytest.fixture
+    def routes(self, pyramid_config):
+        pyramid_config.add_route('login', '/login')
 
 
 @pytest.mark.usefixtures('user_service', 'oauth_service')

--- a/tests/h/views/client_test.py
+++ b/tests/h/views/client_test.py
@@ -39,6 +39,7 @@ class TestSidebarApp(object):
                 },
                 'authDomain': 'example.com',
                 'googleAnalytics': 'UA-4567',
+                'oauthAuthorizeUrl': 'http://example.com/oauth/authorize',
                 'oauthClientId': 'test-client-id',
                 'oauthEnabled': True,
                 }
@@ -100,6 +101,7 @@ def routes(pyramid_config):
     pyramid_config.add_route('embed', '/embed.js')
     pyramid_config.add_route('index', '/')
     pyramid_config.add_route('sidebar_app', '/app.html')
+    pyramid_config.add_route('oauth_authorize', '/oauth/authorize')
 
 
 @pytest.fixture


### PR DESCRIPTION
Issue: https://github.com/hypothesis/product-backlog/issues/310
Corresponding client PR: https://github.com/hypothesis/client/pull/476

Add an `/oauth/authorize` page which allows a user to authorize an
OAuth client, such as the Hypothesis client, to access their data on the
service. When the client is authorized, the endpoint returns an auth
code to the client via `window.postMessage`.

This is an initial minimal implementation with several limitations:

 * The only supported response mode is "web_message", which is designed
   to be convenient for web app clients to use. In particular, the
   standard redirect response mode is not supported.

 * It only allows one client, the sidebar application served from the
   `/app.html` route, to use this endpoint. Once the OAuth client model
   has been extended to include an "origin" property, any registered
   client can be used providing that the request comes from the correct
   origin.

 * The "auth code" is in fact, just a JWT grant token of the same type
   that publishers can generate when they embed Hypothesis on their
   pages and have registered with us to use third party accounts.