### PR TITLE
Fix spurious unicode warnings

### DIFF
--- a/h/cli/commands/init.py
+++ b/h/cli/commands/init.py
@@ -7,6 +7,7 @@ import sqlalchemy
 
 from h import db
 from h import search
+from h._compat import text_type
 
 log = logging.getLogger(__name__)
 
@@ -29,7 +30,7 @@ def _init_db(settings):
         engine.execute('select 1 from alembic_version')
     except sqlalchemy.exc.ProgrammingError:
         log.info("initializing database")
-        db.init(engine, should_create=True, authority=settings['h.authority'])
+        db.init(engine, should_create=True, authority=text_type(settings['h.authority']))
     else:
         log.info("detected alembic_version table, skipping db initialization")
 

--- a/h/db/__init__.py
+++ b/h/db/__init__.py
@@ -111,7 +111,7 @@ def _maybe_create_world_group(engine, authority):
     session = Session(bind=engine)
     world_group = session.query(models.Group).filter_by(pubid='__world__').one_or_none()
     if world_group is None:
-        world_group = models.Group(name='Public',
+        world_group = models.Group(name=u'Public',
                                    authority=authority,
                                    joinable_by=None,
                                    readable_by=ReadableBy.world,


### PR DESCRIPTION
SQLAlchemy expects unicode objects for `name` and `authority` on groups. This commit ensures that we don't emit potentially confusing warnings on database initialisation.