### PR TITLE
Database migrations for supporting OAuth 2 authorization code grant flow

### DIFF
--- a/h/migrations/versions/0d1b3fd8807c_create_authzcode_table.py
+++ b/h/migrations/versions/0d1b3fd8807c_create_authzcode_table.py
@@ -1,0 +1,36 @@
+"""
+Create authzcode table
+
+Revision ID: 0d1b3fd8807c
+Revises: b980b1a8f6af
+Create Date: 2017-07-10 12:04:28.328864
+"""
+
+from __future__ import unicode_literals
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = '0d1b3fd8807c'
+down_revision = 'b980b1a8f6af'
+
+
+def upgrade():
+    op.create_table('authzcode',
+        sa.Column('id', sa.Integer(), autoincrement=True, primary_key=True, nullable=False),
+        sa.Column('created', sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.Column('updated', sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.Column('expires', sa.DateTime(), nullable=False),
+        sa.Column('code', sa.UnicodeText, nullable=False),
+        sa.Column('authclient_id', postgresql.UUID(), nullable=False),
+        sa.Column('user_id', sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(['user_id'], ['user.id']),
+        sa.ForeignKeyConstraint(['authclient_id'], ['authclient.id']),
+    )
+    op.create_index(op.f('uq__authzcode__code'), 'authzcode', ['code'], unique=True)
+
+
+def downgrade():
+    op.drop_index(op.f('uq__authzcode__code'), table_name='authzcode')
+    op.drop_table('authzcode')

--- a/h/migrations/versions/dba81a22ea75_add_redirect_uri_column_to_authclient.py
+++ b/h/migrations/versions/dba81a22ea75_add_redirect_uri_column_to_authclient.py
@@ -1,0 +1,24 @@
+"""
+Add redirect_uri column to authclient
+
+Revision ID: dba81a22ea75
+Revises: 0d1b3fd8807c
+Create Date: 2017-07-12 15:17:05.036842
+"""
+
+from __future__ import unicode_literals
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = 'dba81a22ea75'
+down_revision = '0d1b3fd8807c'
+
+
+def upgrade():
+    op.add_column('authclient', sa.Column('redirect_uri', sa.UnicodeText(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('authclient', 'redirect_uri')


### PR DESCRIPTION
This adds:

* New `authzcode` table which represents an OAuth 2 authorization code
* Adds a `redirect_uri` column to the `authclient` table, which is needed for the authorization code flow