### PR TITLE
Add a "trusted" boolean to authclient table

### DIFF
--- a/h/migrations/versions/05bd63575f19_add_trusted_column_to_authclient_table.py
+++ b/h/migrations/versions/05bd63575f19_add_trusted_column_to_authclient_table.py
@@ -1,0 +1,23 @@
+"""
+Add trusted column to authclient table
+
+Revision ID: 05bd63575f19
+Revises: dfb8b45674db
+Create Date: 2017-07-18 13:45:12.301240
+"""
+
+from __future__ import unicode_literals
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = '05bd63575f19'
+down_revision = 'dfb8b45674db'
+
+
+def upgrade():
+    op.add_column('authclient', sa.Column('trusted', sa.Boolean(), server_default=sa.sql.expression.false(), nullable=False))
+
+
+def downgrade():
+    op.drop_column('authclient', 'trusted')


### PR DESCRIPTION
This will be used to indicate whether the client is a trusted client or not, and can thus skip the explicit authorization step when logging users in.