### PR TITLE
Fix warnings in test output

### DIFF
--- a/tests/common/factories/activation.py
+++ b/tests/common/factories/activation.py
@@ -9,4 +9,4 @@ class Activation(ModelFactory):
 
     class Meta:
         model = models.Activation
-        force_flush = True
+        sqlalchemy_session_persistence = 'flush'

--- a/tests/common/factories/annotation.py
+++ b/tests/common/factories/annotation.py
@@ -18,7 +18,7 @@ class Annotation(ModelFactory):
 
     class Meta:
         model = models.Annotation
-        force_flush = True  # Always flush the db to generate annotation.id.
+        sqlalchemy_session_persistence = 'flush'  # Always flush the db to generate annotation.id.
 
     tags = factory.LazyFunction(lambda: FAKER.words(nb=random.randint(0, 5)))
     target_uri = factory.Faker('uri')

--- a/tests/common/factories/annotation_moderation.py
+++ b/tests/common/factories/annotation_moderation.py
@@ -12,6 +12,6 @@ class AnnotationModeration(ModelFactory):
 
     class Meta:
         model = models.AnnotationModeration
-        force_flush = True
+        sqlalchemy_session_persistence = 'flush'
 
     annotation = factory.SubFactory(Annotation)

--- a/tests/common/factories/auth_client.py
+++ b/tests/common/factories/auth_client.py
@@ -14,7 +14,7 @@ class AuthClient(ModelFactory):
 
     class Meta:
         model = models.AuthClient
-        force_flush = True
+        sqlalchemy_session_persistence = 'flush'
 
     authority = 'example.com'
     secret = factory.LazyAttribute(lambda _: text_type(FAKER.sha256()))

--- a/tests/common/factories/base.py
+++ b/tests/common/factories/base.py
@@ -29,6 +29,6 @@ class ModelFactory(factory.alchemy.SQLAlchemyModelFactory):
             raise RuntimeError('no session: did you use the factories fixture?')
         obj = model_class(*args, **kwargs)
         SESSION.add(obj)
-        if cls._meta.force_flush:
+        if cls._meta.sqlalchemy_session_persistence == 'flush':
             SESSION.flush()
         return obj

--- a/tests/common/factories/flag.py
+++ b/tests/common/factories/flag.py
@@ -15,7 +15,7 @@ class Flag(ModelFactory):
 
     class Meta:
         model = models.Flag
-        force_flush = True
+        sqlalchemy_session_persistence = 'flush'
 
     user = factory.SubFactory(User)
     annotation = factory.SubFactory(Annotation)

--- a/tests/common/factories/group.py
+++ b/tests/common/factories/group.py
@@ -15,7 +15,7 @@ class Group(ModelFactory):
 
     class Meta:
         model = models.Group
-        force_flush = True
+        sqlalchemy_session_persistence = 'flush'
 
     name = factory.Sequence(lambda n: 'Test Group {n}'.format(n=str(n)))
     authority = 'example.com'

--- a/tests/common/factories/setting.py
+++ b/tests/common/factories/setting.py
@@ -13,7 +13,7 @@ class Setting(ModelFactory):
 
     class Meta:
         model = models.Setting
-        force_flush = True
+        sqlalchemy_session_persistence = 'flush'
 
     key = factory.LazyAttribute(lambda _: FAKER.domain_word())
     value = factory.LazyAttribute(lambda _: FAKER.catch_phrase())

--- a/tests/common/factories/token.py
+++ b/tests/common/factories/token.py
@@ -13,6 +13,6 @@ class Token(ModelFactory):
 
     class Meta:
         model = models.Token
-        force_flush = True
+        sqlalchemy_session_persistence = 'flush'
 
     userid = factory.LazyAttribute(lambda _: ('acct:' + FAKER.user_name() + '@example.com'))

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -7,6 +7,8 @@ import os
 import pytest
 from webtest import TestApp
 
+from h._compat import text_type
+
 
 TEST_SETTINGS = {
     'es.host': os.environ.get('ELASTICSEARCH_HOST', 'http://localhost:9200'),
@@ -26,7 +28,7 @@ def app(pyramid_app, db_engine):
 
     _clean_database(db_engine)
     _clean_elasticsearch(TEST_SETTINGS)
-    db.init(db_engine, authority=TEST_SETTINGS['h.authority'])
+    db.init(db_engine, authority=text_type(TEST_SETTINGS['h.authority']))
 
     return TestApp(pyramid_app)
 
@@ -59,7 +61,7 @@ def factories(db_session):
 @pytest.fixture(scope='session', autouse=True)
 def init_db(db_engine):
     from h import db
-    authority = TEST_SETTINGS['h.authority']
+    authority = text_type(TEST_SETTINGS['h.authority'])
     db.init(db_engine, should_drop=True, should_create=True, authority=authority)
 
 

--- a/tests/h/cli/commands/authclient_test.py
+++ b/tests/h/cli/commands/authclient_test.py
@@ -29,7 +29,7 @@ class TestAddCommand(object):
         assert result.exit_code == 0
 
         authclient = db_session.query(models.AuthClient).filter(
-                   models.AuthClient.authority == 'publisher.org').first()
+                   models.AuthClient.authority == u'publisher.org').first()
         return (authclient, result.output)
 
 

--- a/tests/h/conftest.py
+++ b/tests/h/conftest.py
@@ -24,7 +24,7 @@ from h import form
 from h.settings import database_url
 from h._compat import text_type
 
-TEST_AUTHORITY = 'example.com'
+TEST_AUTHORITY = u'example.com'
 TEST_DATABASE_URL = database_url(os.environ.get('TEST_DATABASE_URL',
                                                 'postgresql://postgres@localhost/htest'))
 

--- a/tests/h/emails/reply_notification_test.py
+++ b/tests/h/emails/reply_notification_test.py
@@ -142,7 +142,7 @@ class TestGenerate(object):
 
     @pytest.fixture
     def document(self, db_session):
-        doc = Document(title='My fascinating page')
+        doc = Document(title=u'My fascinating page')
         db_session.add(doc)
         db_session.flush()
         return doc
@@ -175,7 +175,7 @@ class TestGenerate(object):
 
     @pytest.fixture
     def parent_user(self, factories):
-        return factories.User(username='patricia', email='pat@ric.ia')
+        return factories.User(username=u'patricia', email=u'pat@ric.ia')
 
     @pytest.fixture
     def reply(self):
@@ -189,7 +189,7 @@ class TestGenerate(object):
 
     @pytest.fixture
     def reply_user(self, factories):
-        return factories.User(username='ron', email='ron@thesmiths.com')
+        return factories.User(username=u'ron', email=u'ron@thesmiths.com')
 
     @pytest.fixture
     def routes(self, pyramid_config):

--- a/tests/h/feeds/atom_test.py
+++ b/tests/h/feeds/atom_test.py
@@ -99,7 +99,7 @@ def test_entry_id(util, factories):
 
 def test_entry_author(factories):
     """The authors of entries should come from the annotation usernames."""
-    annotation = factories.Annotation(userid='acct:nobu@hypothes.is')
+    annotation = factories.Annotation(userid=u'acct:nobu@hypothes.is')
 
     feed = atom.feed_from_annotations(
         [annotation], "atom_url", lambda annotation: "annotation url")

--- a/tests/h/feeds/rss_test.py
+++ b/tests/h/feeds/rss_test.py
@@ -61,7 +61,7 @@ def test_feed_from_annotations_html_links(factories):
 
 def test_feed_from_annotations_item_titles(factories):
     """Feed items should include the annotation's document's title."""
-    document = factories.Document(title='Hello, World')
+    document = factories.Document(title=u'Hello, World')
     annotation = factories.Annotation(document=document)
 
     feed = rss.feed_from_annotations(

--- a/tests/h/models/groups_test.py
+++ b/tests/h/models/groups_test.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
 import pytest
 
 from pyramid import security

--- a/tests/h/tasks/indexer_test.py
+++ b/tests/h/tasks/indexer_test.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
+
 import mock
 import pytest
 

--- a/tests/h/util/query_test.py
+++ b/tests/h/util/query_test.py
@@ -8,6 +8,7 @@ import pytest
 
 import sqlalchemy as sa
 
+from h._compat import text_type
 from h.util.query import column_windows
 
 
@@ -35,7 +36,7 @@ class TestColumnWindows(object):
     ])
     def test_basic_windowing(self, db_session, windowsize, expected):
         """Check that windowing returns the correct batches of rows."""
-        testdata = [{'name': l, 'enabled': True}
+        testdata = [{'name': text_type(l), 'enabled': True}
                     for l in string.lowercase]
         db_session.execute(test_cw.insert().values(testdata))
 
@@ -57,8 +58,8 @@ class TestColumnWindows(object):
         testdata = []
         enabled = string.lowercase[:13]
         disabled = string.lowercase[13:]
-        testdata.extend([{'name': l, 'enabled': True} for l in enabled])
-        testdata.extend([{'name': l, 'enabled': False} for l in disabled])
+        testdata.extend([{'name': text_type(l), 'enabled': True} for l in enabled])
+        testdata.extend([{'name': text_type(l), 'enabled': False} for l in disabled])
         db_session.execute(test_cw.insert().values(testdata))
 
         filter_ = test_cw.c.enabled

--- a/tests/h/views/admin_badge_test.py
+++ b/tests/h/views/admin_badge_test.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
+
 import mock
 import pytest
 from pyramid import httpexceptions

--- a/tests/h/views/admin_features_test.py
+++ b/tests/h/views/admin_features_test.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
+
 import mock
 import pytest
 

--- a/tests/h/views/notification_test.py
+++ b/tests/h/views/notification_test.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
+
 import mock
 import pytest
 


### PR DESCRIPTION
Due to a recent dependency upgrade (probably pytest itself), pytest lists all SQLAlchemy warnings at the end of each test run. This means that the test output is a bit hard to read, see an example [here](https://travis-ci.org/hypothesis/h/jobs/254849959#L449-L537).

This fixes a bunch of these warnings, plus a few more that I found when running pytest with `-Wall`, I didn't fix all of the normally invisible ones though.