### PR TITLE
Allow auth clients without a secret - DB Migration

### DIFF
--- a/h/migrations/versions/a2295c2bbe29_make_client_secret_nullable.py
+++ b/h/migrations/versions/a2295c2bbe29_make_client_secret_nullable.py
@@ -1,0 +1,23 @@
+"""
+Make Client.secret nullable
+
+Revision ID: a2295c2bbe29
+Revises: 05bd63575f19
+Create Date: 2017-07-18 11:15:39.885020
+"""
+
+from __future__ import unicode_literals
+
+from alembic import op
+
+
+revision = 'a2295c2bbe29'
+down_revision = '05bd63575f19'
+
+
+def upgrade():
+    op.alter_column('authclient', 'secret', nullable=True)
+
+
+def downgrade():
+    op.alter_column('authclient', 'secret', nullable=False)


### PR DESCRIPTION
We will have support for both public and confidential OAuth clients (definition is [here](https://tools.ietf.org/html/rfc6749#section-2.1)). The best and easiest way to distinguish between these types is the presence of a client secret because a public OAuth client will never need a secret. 

This is the migration which removes the `NOT NULL` constraint from the database column.