### PR TITLE
Allow auth clients without a secret

### DIFF
--- a/h/cli/commands/authclient.py
+++ b/h/cli/commands/authclient.py
@@ -3,6 +3,7 @@
 import click
 
 from h import models
+from h.security import token_urlsafe
 
 
 @click.group()
@@ -13,14 +14,17 @@ def authclient():
 @authclient.command()
 @click.option('--name', prompt=True, help="The name of the client")
 @click.option('--authority', prompt=True, help="The authority (domain name) of the resources managed by the client")
+@click.option('--type', 'type_', type=click.Choice(['public', 'confidential']), prompt=True, help="The OAuth client type (public, or confidential)")
 @click.pass_context
-def add(ctx, name, authority):
+def add(ctx, name, authority, type_):
     """
     Create a new OAuth client.
     """
     request = ctx.obj['bootstrap']()
 
     authclient = models.AuthClient(name=name, authority=authority)
+    if type_ == 'confidential':
+        authclient.secret = token_urlsafe()
     request.db.add(authclient)
     request.db.flush()
 
@@ -29,7 +33,9 @@ def add(ctx, name, authority):
 
     request.tm.commit()
 
-    click.echo('OAuth client for {authority} created\n'
-               'Client ID: {id}\n'
-               'Client Secret: {secret}'.format(authority=authority, id=id_,
-                                                secret=secret))
+    message = ('OAuth client for {authority} created\n'
+               'Client ID: {id}')
+    if type_ == 'confidential':
+        message += '\nClient Secret: {secret}'
+
+    click.echo(message.format(authority=authority, id=id_, secret=secret))

--- a/h/models/auth_client.py
+++ b/h/models/auth_client.py
@@ -8,7 +8,6 @@ from sqlalchemy.dialects import postgresql
 
 from h.db import Base
 from h.db.mixins import Timestamps
-from h.security import token_urlsafe
 
 
 class GrantType(enum.Enum):
@@ -86,7 +85,7 @@ class AuthClient(Base, Timestamps):
     name = sa.Column(sa.UnicodeText, nullable=True)
 
     #: Client secret
-    secret = sa.Column(sa.UnicodeText, default=token_urlsafe, nullable=False)
+    secret = sa.Column(sa.UnicodeText, nullable=True)
 
     #: Authority for which this client is allowed to authorize users.
     authority = sa.Column(sa.UnicodeText, nullable=False)

--- a/h/views/api_users.py
+++ b/h/views/api_users.py
@@ -87,6 +87,8 @@ def _request_client(request):
         raise ClientUnauthorized()
     if client is None:
         raise ClientUnauthorized()
+    if client.secret is None:  # client is not confidential
+        raise ClientUnauthorized()
 
     if not hmac.compare_digest(client.secret, client_secret):
         raise ClientUnauthorized()

--- a/tests/common/factories/__init__.py
+++ b/tests/common/factories/__init__.py
@@ -7,7 +7,7 @@ from .base import set_session
 from .activation import Activation
 from .annotation import Annotation
 from .annotation_moderation import AnnotationModeration
-from .auth_client import AuthClient
+from .auth_client import AuthClient, ConfidentialAuthClient
 from .auth_ticket import AuthTicket
 from .authz_code import AuthzCode
 from .document import Document, DocumentMeta, DocumentURI
@@ -26,6 +26,7 @@ __all__ = (
     'AuthClient',
     'AuthTicket',
     'AuthzCode',
+    'ConfidentialAuthClient',
     'Document',
     'DocumentMeta',
     'DocumentURI',

--- a/tests/common/factories/auth_client.py
+++ b/tests/common/factories/auth_client.py
@@ -17,5 +17,15 @@ class AuthClient(ModelFactory):
         sqlalchemy_session_persistence = 'flush'
 
     authority = 'example.com'
+    redirect_uri = 'https://example.com/auth/callback'
+
+
+class ConfidentialAuthClient(ModelFactory):
+
+    class Meta:
+        model = models.AuthClient
+        sqlalchemy_session_persistence = 'flush'
+
+    authority = 'example.com'
     secret = factory.LazyAttribute(lambda _: text_type(FAKER.sha256()))
     redirect_uri = 'https://example.com/auth/callback'

--- a/tests/functional/test_oauth.py
+++ b/tests/functional/test_oauth.py
@@ -150,7 +150,7 @@ class TestOAuth(object):
 
     @pytest.fixture
     def authclient(self, db_session, factories):
-        authclient = factories.AuthClient()
+        authclient = factories.ConfidentialAuthClient()
         db_session.commit()
         return authclient
 

--- a/tests/h/cli/commands/authclient_test.py
+++ b/tests/h/cli/commands/authclient_test.py
@@ -9,21 +9,37 @@ from h.cli.commands import authclient as authclient_cli
 
 class TestAddCommand(object):
 
-    def test_it_creates_an_authclient(self, cli, cliconfig, db_session):
-        (authclient, _) = self._add_authclient(cli, cliconfig, db_session)
+    def test_it_creates_a_public_authclient(self, cli, cliconfig, db_session):
+        (authclient, _) = self._add_authclient(cli, cliconfig, db_session, type_=u'public')
 
         assert authclient.authority == 'publisher.org'
         assert authclient.name == 'Publisher'
+        assert authclient.secret is None
 
-    def test_it_prints_the_client_id_and_secret(self, cli, cliconfig, db_session):
-        (authclient, output) = self._add_authclient(cli, cliconfig, db_session)
+    def test_it_creates_a_confidential_authclient(self, cli, cliconfig, db_session, patch):
+        token_urlsafe = patch('h.cli.commands.authclient.token_urlsafe')
+        token_urlsafe.return_value = u'fixed-secret-token'
+
+        (authclient, _) = self._add_authclient(cli, cliconfig, db_session, type_=u'confidential')
+
+        assert authclient.authority == 'publisher.org'
+        assert authclient.name == 'Publisher'
+        assert authclient.secret == 'fixed-secret-token'
+
+    def test_it_prints_the_id_for_public_client(self, cli, cliconfig, db_session):
+        (authclient, output) = self._add_authclient(cli, cliconfig, db_session, type_=u'public')
+        expected_id_and_secret = 'Client ID: {}'.format(authclient.id)
+        assert expected_id_and_secret in output
+
+    def test_it_prints_the_id_and_secret_for_confidential_client(self, cli, cliconfig, db_session):
+        (authclient, output) = self._add_authclient(cli, cliconfig, db_session, type_=u'confidential')
         expected_id_and_secret = ('Client ID: {}\n'.format(authclient.id) +
                                   'Client Secret: {}'.format(authclient.secret))
         assert expected_id_and_secret in output
 
-    def _add_authclient(self, cli, cliconfig, db_session):
+    def _add_authclient(self, cli, cliconfig, db_session, type_):
         result = cli.invoke(authclient_cli.add,
-                            [u'--name', 'Publisher', u'--authority', 'publisher.org'],
+                            [u'--name', u'Publisher', u'--authority', u'publisher.org', u'--type', type_],
                             obj=cliconfig)
 
         assert result.exit_code == 0

--- a/tests/h/models/auth_client_test.py
+++ b/tests/h/models/auth_client_test.py
@@ -11,9 +11,6 @@ class TestAuthClient(object):
     def test_has_id(self, client):
         assert client.id
 
-    def test_has_secret(self, client):
-        assert client.secret
-
     @pytest.fixture
     def client(self, db_session):
         client = AuthClient(authority='example.com')

--- a/tests/h/views/api_users_test.py
+++ b/tests/h/views/api_users_test.py
@@ -89,6 +89,14 @@ class TestCreate(object):
         with pytest.raises(ClientUnauthorized):
             create(pyramid_request)
 
+    def test_raises_for_public_client(self, factories, basic_auth_creds, pyramid_request, valid_payload):
+        auth_client = factories.AuthClient(authority='weylandindustries.com')
+        basic_auth_creds.return_value = (auth_client.id, '')
+        pyramid_request.json_body = valid_payload
+
+        with pytest.raises(ClientUnauthorized):
+            create(pyramid_request)
+
     @pytest.mark.usefixtures('valid_auth')
     def test_it_validates_the_input(self, pyramid_request, valid_payload, schemas):
         create_schema = schemas.CreateUserAPISchema.return_value
@@ -186,7 +194,7 @@ class TestCreate(object):
 
 @pytest.fixture
 def auth_client(factories):
-    return factories.AuthClient(authority='weylandindustries.com')
+    return factories.ConfidentialAuthClient(authority='weylandindustries.com')
 
 
 @pytest.fixture


### PR DESCRIPTION
We will have support for both public and confidential OAuth clients (definition is [here](https://tools.ietf.org/html/rfc6749#section-2.1)). The best and easiest way to distinguish between these types is the presence of a client secret because a public OAuth client will never need a secret.

This should not be merged until #4598 is merged and the migration has been run on production.