### PR TITLE
Add support for "trusted" OAuth clients

### DIFF
--- a/h/views/api_auth.py
+++ b/h/views/api_auth.py
@@ -24,12 +24,14 @@ log = logging.getLogger(__name__)
 
 @view_defaults(route_name='oauth_authorize')
 class OAuthAuthorizeController(object):
-    def __init__(self, request):
+    def __init__(self, request, oauth_server=None):
         self.request = request
+        oauth_server = oauth_server or WebApplicationServer  # Test seam
+
         self.user_svc = self.request.find_service(name='user')
 
         validator = self.request.find_service(name='oauth_validator')
-        self.oauth = WebApplicationServer(validator)
+        self.oauth = oauth_server(validator)
 
     @view_config(request_method='GET',
                  renderer='h:templates/oauth/authorize.html.jinja2')

--- a/h/views/api_auth.py
+++ b/h/views/api_auth.py
@@ -43,10 +43,17 @@ class OAuthAuthorizeController(object):
                               'next': self.request.url}))
 
         client_id = credentials.get('client_id')
-        state = credentials.get('state')
-
-        user = self.user_svc.fetch(self.request.authenticated_userid)
         client = self.request.db.query(models.AuthClient).get(client_id)
+
+        # If the client is "trusted" -- which means its code is
+        # owned/controlled by us -- then we don't ask the user to explicitly
+        # authorize it. It is assumed to be authorized to act on behalf of the
+        # logged-in user.
+        if client.trusted:
+            return self._authorized_response()
+
+        state = credentials.get('state')
+        user = self.user_svc.fetch(self.request.authenticated_userid)
 
         return {'username': user.username,
                 'client_name': client.name,
@@ -57,6 +64,9 @@ class OAuthAuthorizeController(object):
     @view_config(request_method='POST',
                  effective_principals=security.Authenticated)
     def post(self):
+        return self._authorized_response()
+
+    def _authorized_response(self):
         # We don't support scopes at the moment, but oauthlib does need a scope,
         # so we're explicitly overwriting whatever the client provides.
         scopes = DEFAULT_SCOPES

--- a/tests/h/views/api_auth_test.py
+++ b/tests/h/views/api_auth_test.py
@@ -62,6 +62,24 @@ class TestOAuthAuthorizeController(object):
             'username': authenticated_user.username,
         }
 
+    def test_get_creates_authorization_response_for_trusted_clients(self, controller, auth_client, authenticated_user, pyramid_request):
+        auth_client.trusted = True
+
+        controller.get()
+
+        controller.oauth.create_authorization_response.assert_called_once_with(
+            pyramid_request.url,
+            credentials={'user': authenticated_user},
+            scopes=DEFAULT_SCOPES)
+
+    def test_returns_redirect_immediately_for_trusted_clients(self, controller, auth_client, authenticated_user, pyramid_request):
+        auth_client.trusted = True
+
+        response = controller.get()
+        expected = '{}?code=abcdef123456'.format(auth_client.redirect_uri)
+
+        assert response.location == expected
+
     def test_post_creates_authorization_response(self, controller, pyramid_request, authenticated_user):
         pyramid_request.url = 'http://example.com/auth?client_id=the-client-id' + \
                                                      '&response_type=code' + \


### PR DESCRIPTION
Certain clients are trusted, by which we mean that we know that they can be trusted with an access token for a user. That means that we don't ask the user to explicitly authorize trusted clients, and instead skip straight to an authorized response (i.e. a redirect with an authz code or in future a postMessage with same).