### PR TITLE
Move business logic around Tokens into services

### DIFF
--- a/h/services/__init__.py
+++ b/h/services/__init__.py
@@ -14,6 +14,7 @@ def includeme(config):
                                     iface='pyramid_authsanity.interfaces.IAuthService')
     config.register_service_factory('.auth_token.auth_token_service_factory', name='auth_token')
     config.register_service_factory('.authority_group.authority_group_factory', name='authority_group')
+    config.register_service_factory('.developer_token.developer_token_service_factory', name='developer_token')
     config.register_service_factory('.feature.feature_service_factory', name='feature')
     config.register_service_factory('.flag.flag_service_factory', name='flag')
     config.register_service_factory('.flag_count.flag_count_service_factory', name='flag_count')

--- a/h/services/developer_token.py
+++ b/h/services/developer_token.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from h import models
+from h import security
+from h.util.db import lru_cache_in_transaction
+
+PREFIX = '6879-'
+
+
+class DeveloperTokenService(object):
+    """A service for retrieving and performing common operations on developer tokens."""
+
+    def __init__(self, session):
+        """
+        Create a new developer token service.
+
+        :param session: the SQLAlchemy session object
+        """
+        self.session = session
+
+        self._cached_fetch = lru_cache_in_transaction(self.session)(self._fetch)
+
+    def fetch(self, userid):
+        """
+        Fetch a developer token by its userid.
+
+        :param userid: The userid, typically of the currently authenticated user.
+        :type userid: unicode
+
+        :returns: a token instance, if found
+        :rtype: h.models.Token or None
+        """
+        return self._cached_fetch(userid)
+
+    def create(self, userid):
+        """
+        Creates a developer token for the given userid.
+
+        :param userid: The userid for which the developer token gets created.
+        :type userid: unicode
+
+        :returns: a token instance
+        :rtype: h.models.Token
+        """
+        token = models.Token(userid=userid,
+                             value=self._generate_token())
+        self.session.add(token)
+        return token
+
+    def regenerate(self, token):
+        """
+        Regenerates a developer token.
+
+        The implementation changes the token value in-place, however when calling
+        this method you should not rely on this implementation detail. You should
+        use the return value of this method as the new token object.
+
+        :param token: The token instance which needs to be regenerated.
+        :type token: h.models.Token
+
+        :returns: a regenerated token instance
+        :rtype: h.models.Token
+        """
+        token.value = self._generate_token()
+        return token
+
+    def _fetch(self, userid):
+        if userid is None:
+            return None
+
+        return (self.session.query(models.Token)
+                .filter_by(userid=userid, authclient=None)
+                .order_by(models.Token.created.desc())
+                .one_or_none())
+
+    def _generate_token(self):
+        return PREFIX + security.token_urlsafe()
+
+
+def developer_token_service_factory(context, request):
+    return DeveloperTokenService(request.db)

--- a/h/services/oauth.py
+++ b/h/services/oauth.py
@@ -8,11 +8,15 @@ import jwt
 import sqlalchemy as sa
 
 from h import models
+from h import security
 from h.exceptions import OAuthTokenError
 from h._compat import text_type
 
 # TTL of an OAuth token
 TOKEN_TTL = datetime.timedelta(hours=1)
+
+ACCESS_TOKEN_PREFIX = '5768-'
+REFRESH_TOKEN_PREFIX = '4657-'
 
 
 class OAuthService(object):
@@ -147,8 +151,13 @@ class OAuthService(object):
 
         :rtype: h.models.Token
         """
+        value = ACCESS_TOKEN_PREFIX + security.token_urlsafe()
+        refresh_token = REFRESH_TOKEN_PREFIX + security.token_urlsafe()
+
         token = models.Token(userid=user.userid,
+                             value=value,
                              expires=(utcnow() + TOKEN_TTL),
+                             refresh_token=refresh_token,
                              authclient=authclient)
         self.session.add(token)
 

--- a/tests/common/factories/__init__.py
+++ b/tests/common/factories/__init__.py
@@ -16,7 +16,7 @@ from .feature_cohort import FeatureCohort
 from .flag import Flag
 from .group import Group, PublisherGroup
 from .setting import Setting
-from .token import Token
+from .token import DeveloperToken
 from .user import User
 
 __all__ = (
@@ -27,6 +27,7 @@ __all__ = (
     'AuthTicket',
     'AuthzCode',
     'ConfidentialAuthClient',
+    'DeveloperToken',
     'Document',
     'DocumentMeta',
     'DocumentURI',
@@ -36,7 +37,6 @@ __all__ = (
     'Group',
     'PublisherGroup',
     'Setting',
-    'Token',
     'User',
     'set_session',
 )

--- a/tests/common/factories/token.py
+++ b/tests/common/factories/token.py
@@ -5,14 +5,17 @@ from __future__ import unicode_literals
 import factory
 
 from h import models
+from h import security
+from h.services.developer_token import PREFIX
 
 from .base import FAKER, ModelFactory
 
 
-class Token(ModelFactory):
+class DeveloperToken(ModelFactory):
 
     class Meta:
         model = models.Token
         sqlalchemy_session_persistence = 'flush'
 
     userid = factory.LazyAttribute(lambda _: ('acct:' + FAKER.user_name() + '@example.com'))
+    value = factory.LazyAttribute(lambda _: (PREFIX + security.token_urlsafe()))

--- a/tests/functional/test_api.py
+++ b/tests/functional/test_api.py
@@ -108,7 +108,7 @@ def user(db_session, factories):
 
 @pytest.fixture
 def user_with_token(user, db_session, factories):
-    token = factories.Token(userid=user.userid)
+    token = factories.DeveloperToken(userid=user.userid)
     db_session.add(token)
     db_session.commit()
     return (user, token)
@@ -137,7 +137,7 @@ def publisher_group(auth_client, db_session, factories):
 
 @pytest.fixture
 def third_party_user_with_token(third_party_user, db_session, factories):
-    token = factories.Token(userid=third_party_user.userid)
+    token = factories.DeveloperToken(userid=third_party_user.userid)
     db_session.commit()
     return (third_party_user, token)
 

--- a/tests/functional/test_moderation.py
+++ b/tests/functional/test_moderation.py
@@ -43,6 +43,6 @@ def moderator(db_session, factories):
 
 @pytest.fixture
 def moderator_with_token(moderator, db_session, factories):
-    token = factories.Token(userid=moderator.userid)
+    token = factories.DeveloperToken(userid=moderator.userid)
     db_session.commit()
     return (moderator, token)

--- a/tests/functional/test_oauth.py
+++ b/tests/functional/test_oauth.py
@@ -35,7 +35,7 @@ class TestOAuth(object):
     def test_request_fails_if_access_token_expired(self, app, authclient,
                                                    db_session, factories,
                                                    userid):
-        token = factories.Token(
+        token = factories.DeveloperToken(
             expires=datetime.datetime.utcnow() - datetime.timedelta(hours=1))
         token = token.value
         db_session.commit()
@@ -96,7 +96,7 @@ class TestOAuth(object):
                                                           db_session,
                                                           factories,
                                                           userid):
-        token = factories.Token(
+        token = factories.DeveloperToken(
             expires=datetime.datetime.utcnow() - datetime.timedelta(hours=1))
         refresh_token = token.refresh_token
         db_session.commit()

--- a/tests/h/models/token_test.py
+++ b/tests/h/models/token_test.py
@@ -11,34 +11,6 @@ from h.models import Token
 
 @pytest.mark.usefixtures('security')
 class TestToken(object):
-    def test_init_dev_token(self, security):
-        userid = 'acct:test@hypothes.is'
-
-        dev_token = Token(userid=userid)
-
-        assert dev_token.userid == userid
-        assert dev_token.value.startswith(Token.prefix)
-        assert dev_token.value[len(Token.prefix):] in security.token_urlsafe.side_effect.generated_tokens
-        assert not dev_token.expires
-        assert not dev_token.authclient
-        assert not dev_token.refresh_token
-
-    def test_init_access_token(self, security):
-        userid = 'acct:test@hypothes.is'
-        expires = one_hour_from_now()
-        authclient = 'example.com'
-
-        access_token = Token(userid=userid,
-                             expires=expires,
-                             authclient=authclient)
-
-        assert access_token.userid == userid
-        assert access_token.value.startswith(Token.prefix)
-        assert access_token.value[len(Token.prefix):] in security.token_urlsafe.side_effect.generated_tokens
-        assert access_token.expires == expires
-        assert access_token.authclient == authclient
-        assert access_token.refresh_token in security.token_urlsafe.side_effect.generated_tokens
-
     def test_ttl_is_none_if_token_has_no_expires(self):
         assert Token().ttl is None
 
@@ -64,23 +36,6 @@ class TestToken(object):
         token = Token(expires=expires)
 
         assert token.expired is True
-
-    def test_get_dev_token_by_userid_filters_by_userid(self, db_session, factories):
-        token_1 = factories.Token(userid='acct:vanessa@example.org', authclient=None)
-        token_2 = factories.Token(userid='acct:david@example.org', authclient=None)
-
-        assert Token.get_dev_token_by_userid(db_session, token_2.userid) == token_2
-
-    def test_get_dev_token_by_userid_only_returns_the_latest_token(self, db_session, factories):
-        token_1 = factories.Token(authclient=None)
-        token_2 = factories.Token(userid=token_1.userid, authclient=None)
-
-        assert Token.get_dev_token_by_userid(db_session, token_1.userid) == token_2
-
-    def test_get_dev_token_by_userid_filters_out_non_dev_tokens(self, db_session, factories):
-        token = factories.Token(authclient=factories.AuthClient())
-
-        assert Token.get_dev_token_by_userid(db_session, token.userid) is None
 
     @pytest.fixture
     def security(self, patch):

--- a/tests/h/services/auth_token_test.py
+++ b/tests/h/services/auth_token_test.py
@@ -16,7 +16,7 @@ from h._compat import text_type
 
 class TestAuthTokenService(object):
     def test_validate_returns_database_token(self, svc, factories):
-        token_model = factories.Token(expires=self.time(1))
+        token_model = factories.DeveloperToken(expires=self.time(1))
 
         result = svc.validate(token_model.value)
 
@@ -24,7 +24,7 @@ class TestAuthTokenService(object):
         assert result.userid == token_model.userid
 
     def test_validate_caches_database_token(self, svc, factories, db_session):
-        token_model = factories.Token(expires=self.time(1))
+        token_model = factories.DeveloperToken(expires=self.time(1))
 
         svc.validate(token_model.value)
         db_session.delete(token_model)
@@ -33,7 +33,7 @@ class TestAuthTokenService(object):
         assert result is not None
 
     def test_validate_returns_none_for_cached_invalid_token(self, svc, factories, db_session):
-        token_model = factories.Token(expires=self.time(-1))
+        token_model = factories.DeveloperToken(expires=self.time(-1))
 
         svc.validate(token_model.value)
         db_session.delete(token_model)
@@ -42,7 +42,7 @@ class TestAuthTokenService(object):
         assert result is None
 
     def test_validate_returns_none_for_invalid_database_token(self, svc, factories):
-        token_model = factories.Token(expires=self.time(-1))
+        token_model = factories.DeveloperToken(expires=self.time(-1))
 
         result = svc.validate(token_model.value)
 
@@ -80,7 +80,7 @@ class TestAuthTokenService(object):
 
     @pytest.fixture
     def token(self, factories):
-        return factories.Token()
+        return factories.DeveloperToken()
 
     def time(self, days_delta=0):
         return datetime.datetime.utcnow() + datetime.timedelta(days=days_delta)

--- a/tests/h/services/developer_token_test.py
+++ b/tests/h/services/developer_token_test.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import pytest
+
+from h import models
+from h.services.developer_token import (
+    DeveloperTokenService,
+    developer_token_service_factory,
+)
+
+
+class TestDeveloperTokenService(object):
+    def test_fetch_returns_developer_token_for_userid(self, svc, developer_token, userid):
+        assert svc.fetch(userid) == developer_token
+
+    def test_fetch_returns_none_for_missing_developer_token(self, svc, userid):
+        assert svc.fetch(userid) is None
+
+    def test_create_creates_new_developer_token_for_userid(self, svc, db_session, userid):
+        assert db_session.query(models.Token).count() == 0
+        svc.create(userid)
+        assert db_session.query(models.Token).count() == 1
+
+    def test_create_returns_new_developer_token_for_userid(self, svc, userid, patch):
+        token_urlsafe = patch('h.services.developer_token.security.token_urlsafe')
+        token_urlsafe.return_value = 'secure-token'
+
+        token = svc.create(userid)
+
+        assert token.userid == userid
+        assert token.value == '6879-secure-token'
+        assert token.expires is None
+        assert token.authclient is None
+        assert token.refresh_token is None
+
+    def test_regenerate_sets_a_new_token_value(self, svc, developer_token):
+        old_userid = developer_token.userid
+        old_value = developer_token.value
+
+        svc.regenerate(developer_token)
+
+        assert old_userid == developer_token.userid
+        assert old_value != developer_token.value
+
+    @pytest.fixture
+    def svc(self, pyramid_request):
+        return developer_token_service_factory(None, pyramid_request)
+
+    @pytest.fixture
+    def developer_token(self, factories, userid):
+        return factories.DeveloperToken(userid=userid)
+
+    @pytest.fixture
+    def userid(self, factories):
+        return 'acct:john@doe.org'
+
+
+class TestDeveloperTokenServiceFactory(object):
+    def test_it_returns_developer_token_service(self, pyramid_request):
+        svc = developer_token_service_factory(None, pyramid_request)
+        assert isinstance(svc, DeveloperTokenService)
+
+    def test_it_provides_request_db_as_session(self, pyramid_request):
+        svc = developer_token_service_factory(None, pyramid_request)
+        assert svc.session == pyramid_request.db

--- a/tests/h/services/oauth_test.py
+++ b/tests/h/services/oauth_test.py
@@ -434,7 +434,7 @@ class TestOAuthServiceVerifyRefreshTokenRequest(object):
         fixture.
 
         """
-        return factories.Token(refresh_token=refresh_token)
+        return factories.DeveloperToken(refresh_token=refresh_token)
 
     @pytest.fixture
     def user(self, token):
@@ -472,6 +472,20 @@ class TestOAuthServiceCreateToken(object):
     def test_it_sets_the_passed_in_authclient(self, svc, user, authclient):
         token = svc.create_token(user, authclient)
         assert token.authclient == authclient
+
+    def test_it_generates_token_value(self, svc, user, authclient, patch):
+        token_urlsafe = patch('h.services.oauth.security.token_urlsafe')
+        token_urlsafe.return_value = 'very-secret-token'
+
+        token = svc.create_token(user, authclient)
+        assert token.value == '5768-very-secret-token'
+
+    def test_it_generates_refresh_token(self, svc, user, authclient, patch):
+        token_urlsafe = patch('h.services.oauth.security.token_urlsafe')
+        token_urlsafe.return_value = 'top-secret-token'
+
+        token = svc.create_token(user, authclient)
+        assert token.refresh_token == '4657-top-secret-token'
 
     @pytest.fixture
     def svc(self, pyramid_request, db_session, user_service):

--- a/tests/h/tasks/cleanup_test.py
+++ b/tests/h/tasks/cleanup_test.py
@@ -101,24 +101,24 @@ class TestPurgeExpiredAuthzCodes(object):
 @pytest.mark.usefixtures('celery')
 class TestPurgeExpiredTokens(object):
     def test_it_removes_expired_tokens(self, db_session, factories):
-        factories.Token(expires=datetime(2014, 5, 6, 7, 8, 9))
-        factories.Token(expires=(datetime.utcnow() - timedelta(seconds=1)))
+        factories.DeveloperToken(expires=datetime(2014, 5, 6, 7, 8, 9))
+        factories.DeveloperToken(expires=(datetime.utcnow() - timedelta(seconds=1)))
 
         assert db_session.query(Token).count() == 2
         purge_expired_tokens()
         assert db_session.query(Token).count() == 0
 
     def test_it_leaves_valid_tickets(self, db_session, factories):
-        factories.Token(expires=datetime(2014, 5, 6, 7, 8, 9))
-        factories.Token(expires=(datetime.utcnow() + timedelta(hours=1)))
+        factories.DeveloperToken(expires=datetime(2014, 5, 6, 7, 8, 9))
+        factories.DeveloperToken(expires=(datetime.utcnow() + timedelta(hours=1)))
 
         assert db_session.query(Token).count() == 2
         purge_expired_tokens()
         assert db_session.query(Token).count() == 1
 
     def test_it_leaves_tickets_without_an_expiration_date(self, db_session, factories):
-        factories.Token(expires=None)
-        factories.Token(expires=None)
+        factories.DeveloperToken(expires=None)
+        factories.DeveloperToken(expires=None)
 
         assert db_session.query(Token).count() == 2
         purge_expired_tokens()

--- a/tests/h/views/accounts_test.py
+++ b/tests/h/views/accounts_test.py
@@ -8,6 +8,7 @@ import deform
 from pyramid import httpexceptions
 
 from h import accounts
+from h.services.developer_token import developer_token_service_factory
 from h.services.user_password import UserPasswordService
 from h.views import accounts as views
 
@@ -925,81 +926,65 @@ class TestEditProfileController(object):
         assert user.location == 'Paris'
 
 
-@pytest.mark.usefixtures('models')
+@pytest.mark.usefixtures('authenticated_userid', 'token_service')
 class TestDeveloperController(object):
+    def test_get_fetches_token(self, controller, token_service, authenticated_userid):
+        controller.get()
 
-    def test_get_gets_token_for_authenticated_userid(self, models, pyramid_request):
-        views.DeveloperController(pyramid_request).get()
+        token_service.fetch.assert_called_once_with(authenticated_userid)
 
-        models.Token.get_dev_token_by_userid.assert_called_once_with(
-            pyramid_request.db,
-            pyramid_request.authenticated_userid)
+    def test_get_returns_token_for_authenticated_user(self, controller, token_service):
+        assert controller.get() == {'token': token_service.fetch.return_value.value}
 
-    def test_get_returns_token(self, models, pyramid_request):
-        models.Token.get_dev_token_by_userid.return_value.value = u'abc123'
+    def test_get_returns_empty_context_for_missing_token(self, controller, token_service):
+        token_service.fetch.return_value = None
 
-        data = views.DeveloperController(pyramid_request).get()
+        assert controller.get() == {}
 
-        assert data.get('token') == u'abc123'
+    def test_post_fetches_token(self, controller, token_service, authenticated_userid):
+        controller.post()
 
-    def test_get_with_no_token(self, models, pyramid_request):
-        models.Token.get_dev_token_by_userid.return_value = None
+        token_service.fetch.assert_called_once_with(authenticated_userid)
 
-        result = views.DeveloperController(pyramid_request).get()
+    def test_post_regenerates_token_when_found(self, controller, token_service):
+        controller.post()
 
-        assert result == {}
+        token_service.regenerate.assert_called_once_with(token_service.fetch.return_value)
 
-    def test_post_gets_token_for_authenticated_userid(self, models, pyramid_request):
-        views.DeveloperController(pyramid_request).post()
+    def test_post_returns_regenerated_token_when_found(self, controller, token_service):
+        result = controller.post()
 
-        models.Token.get_dev_token_by_userid.assert_called_once_with(
-            pyramid_request.db,
-            pyramid_request.authenticated_userid)
+        assert result == {'token': token_service.regenerate.return_value.value}
 
-    def test_post_calls_regenerate(self, models, pyramid_request):
-        """If the user already has a token it should regenerate it."""
-        views.DeveloperController(pyramid_request).post()
+    def test_post_creates_new_token_when_not_found(self, controller, token_service, authenticated_userid):
+        token_service.fetch.return_value = None
 
-        models.Token.get_dev_token_by_userid.return_value.regenerate.assert_called_with()
+        controller.post()
 
-    def test_post_inits_new_token_for_authenticated_userid(self, models, pyramid_request):
-        """If the user doesn't have a token yet it should generate one."""
-        models.Token.get_dev_token_by_userid.return_value = None
+        token_service.create.assert_called_once_with(authenticated_userid)
 
-        views.DeveloperController(pyramid_request).post()
+    def test_post_returns_new_token_when_not_found(self, controller, token_service):
+        token_service.fetch.return_value = None
 
-        models.Token.assert_called_once_with(userid=pyramid_request.authenticated_userid)
+        result = controller.post()
 
-    def test_post_adds_new_token_to_db(self, models, pyramid_request):
-        """If the user doesn't have a token yet it should add one to the db."""
-        models.Token.get_dev_token_by_userid.return_value = None
-
-        views.DeveloperController(pyramid_request).post()
-
-        assert models.Token.return_value in pyramid_request.db.added
-
-        models.Token.assert_called_once_with(userid=pyramid_request.authenticated_userid)
-
-    def test_post_returns_token_after_regenerating(self, models, pyramid_request):
-        """After regenerating a token it should return its new value."""
-        data = views.DeveloperController(pyramid_request).post()
-
-        assert data['token'] == models.Token.get_dev_token_by_userid.return_value.value
-
-    def test_post_returns_token_after_generating(self, models, pyramid_request):
-        """After generating a new token it should return its value."""
-        models.Token.get_dev_token_by_userid.return_value = None
-
-        data = views.DeveloperController(pyramid_request).post()
-
-        assert data['token'] == models.Token.return_value.value
+        assert result == {'token': token_service.create.return_value.value}
 
     @pytest.fixture
-    def pyramid_request(self, pyramid_request, fake_db_session):
-        # Override the database session with a fake session implementation.
-        # FIXME: don't mock models...
-        pyramid_request.db = fake_db_session
-        return pyramid_request
+    def controller(self, pyramid_request):
+        return views.DeveloperController(pyramid_request)
+
+    @pytest.fixture
+    def token_service(self, pyramid_config, pyramid_request):
+        svc = mock.Mock(spec=developer_token_service_factory(None, pyramid_request))
+        pyramid_config.register_service(svc, name='developer_token')
+        return svc
+
+    @pytest.fixture
+    def authenticated_userid(self, pyramid_config):
+        userid = 'acct:jane@example.com'
+        pyramid_config.testing_securitypolicy(userid)
+        return userid
 
 
 @pytest.fixture

--- a/tests/h/views/api_auth_test.py
+++ b/tests/h/views/api_auth_test.py
@@ -192,7 +192,7 @@ class TestAccessToken(object):
         assert response['token_type'] == 'bearer'
 
     def test_it_returns_expires_in_if_the_token_expires(self, factories, pyramid_request, oauth_service):
-        token = factories.Token(
+        token = factories.DeveloperToken(
             expires=datetime.datetime.utcnow() + datetime.timedelta(hours=1))
         oauth_service.create_token.return_value = token
 
@@ -219,7 +219,7 @@ class TestAccessToken(object):
 
     @pytest.fixture
     def token(self, factories):
-        return factories.Token()
+        return factories.DeveloperToken()
 
     @pytest.fixture
     def user_service(self, pyramid_config, pyramid_request):
@@ -299,11 +299,11 @@ class TestDebugToken(object):
     def oauth_token(self, factories):
         authclient = factories.AuthClient(name='Example Client')
         expires = datetime.datetime.utcnow() + datetime.timedelta(minutes=10)
-        return factories.Token(authclient=authclient, expires=expires)
+        return factories.DeveloperToken(authclient=authclient, expires=expires)
 
     @pytest.fixture
     def developer_token(self, factories):
-        return factories.Token()
+        return factories.DeveloperToken()
 
 
 class TestAPITokenError(object):


### PR DESCRIPTION
This is in preparation for replacing our custom OAuth implementation with one that uses oauthlib.

This moves developer token business logic:
* from model into new developer token service
* from accounts view into the new developer token service

And OAuth token business logic:
* from model into the existing OAuth service