### PR TITLE
Add supporting code for using JWT bearer token exchange with oauthlib

### DIFF
--- a/h/oauth/__init__.py
+++ b/h/oauth/__init__.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from h.oauth.errors import (
+    InvalidJWTGrantTokenClaimError,
+    MissingJWTGrantTokenClaimError,
+)
+from h.oauth.jwt_grant import JWTAuthorizationGrant
+from h.oauth.jwt_grant_token import JWTGrantToken
+
+__all__ = (
+    'JWTAuthorizationGrant',
+    'JWTGrantToken',
+    'InvalidJWTGrantTokenClaimError',
+    'MissingJWTGrantTokenClaimError',
+)

--- a/h/oauth/errors.py
+++ b/h/oauth/errors.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from oauthlib.oauth2 import InvalidGrantError
+
+
+class MissingJWTGrantTokenClaimError(InvalidGrantError):
+    def __init__(self, claim, claim_description=None):
+        if claim_description:
+            self.description = "Missing claim '{}' ({}) from grant token.".format(claim, claim_description)
+        else:
+            self.description = "Missing claim '{}' from grant token.".format(claim)
+
+
+class InvalidJWTGrantTokenClaimError(InvalidGrantError):
+    def __init__(self, claim, claim_description=None):
+        if claim_description:
+            self.description = "Invalid claim '{}' ({}) in grant token.".format(claim, claim_description)
+        else:
+            self.description = "Invalid claim '{}' in grant token.".format(claim)

--- a/h/oauth/jwt_grant.py
+++ b/h/oauth/jwt_grant.py
@@ -1,0 +1,126 @@
+# -*- coding: utf-8 -*-
+
+"""
+Provides an oauthlib compatible JWT Authorization grant type.
+
+This module provides a grant type implementation that can be used
+for the oauthlib token endpoint. It needs to provide a
+`create_token_response` method.
+
+The implementation is based on `RFC 7523`_.
+
+Example of how to register the ``JWTAuthorizationGrant`` with oauthlib alongside
+the authorization code grant, and the refresh token grant:
+
+::
+
+    class OAuthProvider(AuthorizationEndpoint, TokenEndpoint):
+
+        def __init__(self, oauth_validator, user_svc, domain):
+
+            ...
+            jwt_auth_grant = JWTAuthorizationGrant(oauth_validator, user_svc, domain)
+
+            TokenEndpoint.__init__(self, default_grant_type='authorization_code',
+                                   grant_types={'authorization_code': ...,
+                                                'refresh_token': ...,
+                                                'urn:ietf:params:oauth:grant-type:jwt-bearer': jwt_auth_grant},
+                                   default_token_type=...)
+            ...
+
+
+For more information, see the `oauthlib documentation`_ on grant types.
+
+.. _`RFC 7523`: https://tools.ietf.org/html/rfc7523
+.. _`oauthlib documentation`: http://oauthlib.readthedocs.io/en/latest/oauth2/grants/grants.html
+"""
+
+from __future__ import unicode_literals
+
+import json
+
+from oauthlib.oauth2.rfc6749 import errors
+from oauthlib.oauth2.rfc6749.grant_types.base import GrantTypeBase
+
+from h.oauth.jwt_grant_token import JWTGrantToken
+
+
+class JWTAuthorizationGrant(GrantTypeBase):
+    def __init__(self, request_validator, user_svc, domain):
+        self.request_validator = request_validator
+        self.user_svc = user_svc
+        self.domain = domain
+
+    def create_token_response(self, request, token_handler):
+        """
+        Create a new token from a JWT authorization grant.
+
+        If valid and authorized, this creates a new access token and returns
+        the token. Otherwise it returns an error response.
+
+        :param request: the oauthlib request
+        :type request: oauthlib.common.Request
+
+        :param token_handler: Token generator responding to `create_token`.
+        :type token_handler: oauthlib.oauth2.rfc6749.tokens.TokenBase
+
+        :returns: HTTP response tuple: headers, body, status
+        :rtype: headers (dict), body (unicode), status (int)
+        """
+
+        headers = {
+            'Content-Type': 'application/json',
+            'Cache-Control': 'no-store',
+            'Pragma': 'no-cache',
+        }
+
+        try:
+            self.validate_token_request(request)
+        except errors.OAuth2Error as e:
+            return headers, e.json, e.status_code
+
+        token = token_handler.create_token(request, refresh_token=True, save_token=False)
+        self.request_validator.save_token(token, request)
+        return headers, json.dumps(token), 200
+
+    def validate_token_request(self, request):
+        """
+        Validates a token request.
+
+        Sets the ``client_id`` property on the passed-in request to the JWT
+        issuer, and finds the user based on the JWT subject and sets it as
+        the ``user`` property.
+
+        Raises subclasses of ``oauthlib.oauth2.rfc6749.OAuth2Error`` when
+        validation fails.
+
+        :param request: the oauthlib request
+        :type request: oauthlib.common.Request
+        """
+
+        try:
+            assertion = request.assertion
+        except AttributeError:
+            raise errors.InvalidRequestFatalError('Missing assertion.')
+
+        token = JWTGrantToken(assertion)
+
+        # Update client_id in oauthlib request
+        request.client_id = token.issuer
+
+        if not self.request_validator.authenticate_client_id(request.client_id, request):
+            raise errors.InvalidClientError(request=request)
+
+        # Ensure client is authorized use of this grant type
+        self.validate_grant_type(request)
+
+        verified_token = token.verified(key=request.client.secret, audience=self.domain)
+
+        user = self.user_svc.fetch(verified_token.subject)
+        if user is None:
+            raise errors.InvalidGrantError('Grant token subject (sub) could not be found.')
+
+        if user.authority != request.client.authority:
+            raise errors.InvalidGrantError('Grant token subject (sub) does not match issuer (iss).')
+
+        request.user = user

--- a/h/oauth/jwt_grant_token.py
+++ b/h/oauth/jwt_grant_token.py
@@ -1,0 +1,115 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import datetime
+
+import jwt
+from oauthlib.oauth2 import (
+    InvalidClientError,
+    InvalidGrantError,
+    InvalidRequestFatalError,
+)
+
+from h.oauth import errors
+
+
+class JWTGrantToken(object):
+    """
+    Represents a JWT bearer grant token.
+
+    This class is responsible for a couple of things: firstly, verifying that
+    the token is a correctly-formatted JSON Web Token, and that it contains all
+    the required claims in the right formats. Some of this processing is
+    deferred to the `jwt` module, but that doesn't handle all the fields we
+    want to validate.
+
+    """
+
+    def __init__(self, token):
+        self._token = token
+
+        try:
+            self._claims = jwt.decode(token, verify=False)
+        except jwt.DecodeError:
+            raise InvalidRequestFatalError('Invalid JWT grant token format.')
+
+    @property
+    def issuer(self):
+        iss = self._claims.get('iss', None)
+        if not iss:
+            raise errors.MissingJWTGrantTokenClaimError('iss', 'issuer')
+        return iss
+
+    def verified(self, key, audience):
+        return VerifiedJWTGrantToken(self._token, key, audience)
+
+
+class VerifiedJWTGrantToken(JWTGrantToken):
+    """
+    Represents a JWT bearer grant token verified with a secret key.
+
+    This exposes more claims than the `GrantToken` superclass, so that it's not
+    possible to access the subject ID without first verifying the token.
+
+    """
+
+    MAX_LIFETIME = datetime.timedelta(minutes=10)
+    LEEWAY = datetime.timedelta(seconds=10)
+
+    def __init__(self, token, key, audience):
+        super(VerifiedJWTGrantToken, self).__init__(token)
+        self._verify(key, audience)
+
+    def _verify(self, key, audience):
+        if self.expiry - self.not_before > self.MAX_LIFETIME:
+            raise InvalidGrantError('Grant token lifetime is too long.')
+        try:
+            jwt.decode(self._token,
+                       algorithms=['HS256'],
+                       audience=audience,
+                       key=key,
+                       leeway=self.LEEWAY)
+        except TypeError:
+            raise InvalidClientError('Client is invalid.')
+        except jwt.DecodeError:
+            raise InvalidGrantError('Invalid grant token signature.')
+        except jwt.exceptions.InvalidAlgorithmError:
+            raise InvalidGrantError('Invalid grant token signature algorithm.')
+        except jwt.MissingRequiredClaimError as exc:
+            if exc.claim == 'aud':
+                raise errors.MissingJWTGrantTokenClaimError('aud', 'audience')
+            else:
+                raise errors.MissingJWTGrantTokenClaimError(exc.claim)
+        except jwt.InvalidAudienceError:
+            raise errors.InvalidJWTGrantTokenClaimError('aud', 'audience')
+        except jwt.ImmatureSignatureError:
+            raise InvalidGrantError('Grant token is not yet valid.')
+        except jwt.ExpiredSignatureError:
+            raise InvalidGrantError('Grant token is expired.')
+        except jwt.InvalidIssuedAtError:
+            raise InvalidGrantError('Grant token issue time (iat) is in the future.')
+
+    @property
+    def expiry(self):
+        return self._timestamp_claim('exp', 'expiry')
+
+    @property
+    def not_before(self):
+        return self._timestamp_claim('nbf', 'start time')
+
+    def _timestamp_claim(self, key, description):
+        claim = self._claims.get(key, None)
+        if claim is None:
+            raise errors.MissingJWTGrantTokenClaimError(key, description)
+        try:
+            return datetime.datetime.utcfromtimestamp(claim)
+        except (TypeError, ValueError):
+            raise errors.InvalidJWTGrantTokenClaimError(key, description)
+
+    @property
+    def subject(self):
+        sub = self._claims.get('sub', None)
+        if not sub:
+            raise errors.MissingJWTGrantTokenClaimError('sub', 'subject')
+        return sub

--- a/h/services/oauth_validator.py
+++ b/h/services/oauth_validator.py
@@ -26,6 +26,12 @@ class OAuthValidatorService(RequestValidator):
 
         self._cached_find_client = lru_cache_in_transaction(self.session)(self._find_client)
 
+    def authenticate_client_id(self, client_id, request, *args, **kwargs):
+        """Authenticates a client_id, returns True if the client_id exists."""
+        client = self.find_client(client_id)
+        request.client = client
+        return (client is not None)
+
     def find_client(self, id_):
         return self._cached_find_client(id_)
 
@@ -54,11 +60,28 @@ class OAuthValidatorService(RequestValidator):
         self.session.add(authzcode)
         return authzcode
 
+    def save_bearer_token(self, token, request, *args, **kwargs):
+        """Saves a generated bearer token for the authenticated user to the database."""
+        oauth_token = models.Token(userid=request.user.userid,
+                                   value=token['access_token'],
+                                   refresh_token=token['refresh_token'],
+                                   expires=(utcnow() + datetime.timedelta(seconds=token['expires_in'])),
+                                   authclient=request.client)
+        self.session.add(oauth_token)
+        return oauth_token
+
     def validate_client_id(self, client_id, request, *args, **kwargs):
         """Checks if the provided client_id belongs to a valid AuthClient."""
 
         client = self.find_client(client_id)
         return (client is not None)
+
+    def validate_grant_type(self, client_id, grant_type, client, request, *args, **kwargs):
+        """Validates that the given client is allowed to use the give grant type."""
+        if client.grant_type is None:
+            return False
+
+        return (grant_type == client.grant_type.value)
 
     def validate_redirect_uri(self, client_id, redirect_uri, request, *args, **kwargs):
         """Validate that the provided ``redirect_uri`` matches the one stored on the client."""
@@ -84,6 +107,9 @@ class OAuthValidatorService(RequestValidator):
         return (scopes == default_scopes)
 
     def _find_client(self, id_):
+        if id_ is None:
+            return None
+
         try:
             return self.session.query(models.AuthClient).get(id_)
         except StatementError:

--- a/tests/h/oauth/errors_test.py
+++ b/tests/h/oauth/errors_test.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from h.oauth.errors import (
+    InvalidJWTGrantTokenClaimError,
+    MissingJWTGrantTokenClaimError,
+)
+
+
+class TestMissingJWTGrantTokenClaimError(object):
+    def test_sets_correct_description_with_claim_description(self):
+        exc = MissingJWTGrantTokenClaimError('iss', 'issuer')
+        assert exc.description == "Missing claim 'iss' (issuer) from grant token."
+
+    def test_sets_correct_description_without_claim_description(self):
+        exc = MissingJWTGrantTokenClaimError('iss')
+        assert exc.description == "Missing claim 'iss' from grant token."
+
+
+class TestInvalidJWTGrantTokenClaimError(object):
+    def test_sets_correct_description_with_claim_description(self):
+        exc = InvalidJWTGrantTokenClaimError('iss', 'issuer')
+        assert exc.description == "Invalid claim 'iss' (issuer) in grant token."
+
+    def test_sets_correct_description_without_claim_description(self):
+        exc = InvalidJWTGrantTokenClaimError('iss')
+        assert exc.description == "Invalid claim 'iss' in grant token."

--- a/tests/h/oauth/jwt_grant_test.py
+++ b/tests/h/oauth/jwt_grant_test.py
@@ -1,0 +1,180 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import json
+from calendar import timegm
+from datetime import datetime, timedelta
+
+import mock
+import pytest
+
+import jwt
+from oauthlib.common import Request as OAuthRequest
+from oauthlib.oauth2.rfc6749 import errors
+
+from h.oauth.jwt_grant import JWTAuthorizationGrant
+from h.services.user import user_service_factory
+
+
+class TestJWTAuthorizationGrantCreateTokenResponse(object):
+    def test_returns_error_when_validation_fails(self, grant, oauth_request, token_handler, authclient):
+        authclient.secret = None
+        headers, body, status = grant.create_token_response(oauth_request, token_handler)
+        assert headers == {'Content-Type': 'application/json',
+                           'Cache-Control': 'no-store',
+                           'Pragma': 'no-cache'}
+        assert body == json.dumps({'error': 'invalid_client',
+                                   'error_description': 'Client is invalid.'})
+        assert status == 401
+
+    def test_creates_token(self, grant, oauth_request, token_handler):
+        grant.create_token_response(oauth_request, token_handler)
+
+        token_handler.create_token.assert_called_once_with(oauth_request,
+                                                           refresh_token=True,
+                                                           save_token=False)
+
+    def test_saves_token(self, grant, oauth_request, token_handler, db_session, request_validator):
+        token = token_handler.create_token.return_value
+
+        grant.create_token_response(oauth_request, token_handler)
+
+        request_validator.save_token.assert_called_once_with(token, oauth_request)
+
+    def test_returns_correct_headers(self, grant, oauth_request, token_handler):
+        headers, _, _ = grant.create_token_response(oauth_request, token_handler)
+        assert headers == {'Content-Type': 'application/json',
+                           'Cache-Control': 'no-store',
+                           'Pragma': 'no-cache'}
+
+    def test_returns_correct_body(self, grant, oauth_request, token_handler):
+        _, body, _ = grant.create_token_response(oauth_request, token_handler)
+        assert body == json.dumps({'access_token': 'test-access-token',
+                                   'expires_in': 3600,
+                                   'token_type': 'Bearer'})
+
+    def test_returns_correct_status(self, grant, oauth_request, token_handler):
+        _, _, status = grant.create_token_response(oauth_request, token_handler)
+
+        assert status == 200
+
+    @pytest.fixture
+    def token_handler(self):
+        handler = mock.Mock(spec_set=['create_token'])
+        handler.create_token.return_value = {
+            'access_token': 'test-access-token',
+            'expires_in': 3600,
+            'token_type': 'Bearer',
+        }
+        return handler
+
+
+class TestJWTAuthorizationGrantValidateTokenRequest(object):
+    def test_does_not_raise_for_valid_input(self, grant, oauth_request):
+        grant.validate_token_request(oauth_request)
+
+    def test_sets_client_id_from_token_on_request(self, grant, oauth_request, authclient):
+        assert oauth_request.client_id is None
+
+        grant.validate_token_request(oauth_request)
+
+        assert oauth_request.client_id == authclient.id
+
+    def test_raises_for_missing_assertion(self, grant, oauth_request):
+        del oauth_request._params['assertion']
+
+        with pytest.raises(errors.InvalidRequestFatalError) as exc:
+            grant.validate_token_request(oauth_request)
+
+        assert exc.value.description == 'Missing assertion.'
+
+    def test_raises_when_client_id_authentication_fails(self, grant, oauth_request, request_validator, authclient):
+        def fake_authenticate_client_id(client_id, request):
+            # Only return fail authentication when parameters match
+            if client_id == authclient.id and request == oauth_request:
+                return False
+            return True
+        request_validator.authenticate_client_id.side_effect = fake_authenticate_client_id
+
+        with pytest.raises(errors.InvalidClientError):
+            grant.validate_token_request(oauth_request)
+
+    def test_validates_grant_type(self, grant, oauth_request, request_validator):
+        request_validator.validate_grant_type.return_value = False
+
+        with pytest.raises(errors.UnauthorizedClientError):
+            grant.validate_token_request(oauth_request)
+
+    def test_verifies_grant_token(self, grant, oauth_request):
+        oauth_request.client.secret = 'bogus'
+
+        with pytest.raises(errors.InvalidGrantError) as exc:
+            grant.validate_token_request(oauth_request)
+
+        assert exc.value.description == 'Invalid grant token signature.'
+
+    def test_sets_user_on_request(self, grant, oauth_request, user):
+        assert oauth_request.user is None
+
+        grant.validate_token_request(oauth_request)
+
+        assert oauth_request.user == user
+
+    def test_raises_when_user_cannot_be_found(self, grant, oauth_request, user, db_session):
+        db_session.delete(user)
+
+        with pytest.raises(errors.InvalidGrantError) as exc:
+            grant.validate_token_request(oauth_request)
+
+        assert exc.value.description == 'Grant token subject (sub) could not be found.'
+
+    def test_raises_when_user_authority_does_not_match_client_authority(self, grant, authclient, user):
+        user.authority = 'bogus.org'
+        request = oauth_request(authclient, user)
+
+        with pytest.raises(errors.InvalidGrantError) as exc:
+            grant.validate_token_request(request)
+
+        assert exc.value.description == 'Grant token subject (sub) does not match issuer (iss).'
+
+
+@pytest.fixture
+def grant(pyramid_request, request_validator):
+    user_svc = user_service_factory(None, pyramid_request)
+
+    return JWTAuthorizationGrant(request_validator, user_svc, 'domain.test')
+
+
+@pytest.fixture
+def oauth_request(authclient, user):
+    exp = datetime.utcnow() + timedelta(minutes=5)
+    nbf = datetime.utcnow() - timedelta(seconds=2)
+    claims = {
+        'aud': 'domain.test',
+        'exp': timegm(exp.utctimetuple()),
+        'iss': authclient.id,
+        'nbf': timegm(nbf.utctimetuple()),
+        'sub': user.userid,
+    }
+    jwttok = jwt.encode(claims, authclient.secret, algorithm='HS256')
+
+    return OAuthRequest('/', body={'assertion': jwttok,
+                                   'client': authclient})
+
+
+@pytest.fixture
+def authclient(factories):
+    return factories.ConfidentialAuthClient()
+
+
+@pytest.fixture
+def user(factories, db_session):
+    user = factories.User()
+    db_session.flush()
+    return user
+
+
+@pytest.fixture
+def request_validator():
+    return mock.Mock()

--- a/tests/h/oauth/jwt_grant_token_test.py
+++ b/tests/h/oauth/jwt_grant_token_test.py
@@ -1,0 +1,258 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from calendar import timegm
+from datetime import datetime, timedelta
+
+import pytest
+
+import jwt
+from oauthlib.oauth2 import (
+    InvalidClientError,
+    InvalidGrantError,
+    InvalidRequestFatalError,
+)
+
+from h.oauth import (
+    InvalidJWTGrantTokenClaimError,
+    MissingJWTGrantTokenClaimError,
+)
+from h.oauth.jwt_grant_token import JWTGrantToken, VerifiedJWTGrantToken
+
+
+class TestJWTGrantToken(object):
+    def test_init_decodes_token_without_verifying(self, patch):
+        jwt_decode = patch('h.oauth.jwt_grant_token.jwt.decode')
+
+        JWTGrantToken('abcdef123456')
+
+        jwt_decode.assert_called_once_with('abcdef123456', verify=False)
+
+    def test_init_raises_for_invalid_token(self):
+        with pytest.raises(InvalidRequestFatalError) as exc:
+            JWTGrantToken('abcdef123456')
+
+        assert exc.value.description == 'Invalid JWT grant token format.'
+
+    def test_issuer_returns_iss_claim(self):
+        jwttok = jwt_token({'iss': 'test-issuer', 'foo': 'bar'})
+        grant_token = JWTGrantToken(jwttok)
+
+        assert grant_token.issuer == 'test-issuer'
+
+    def test_issuer_raises_for_missing_iss_claim(self):
+        jwttok = jwt_token({'foo': 'bar'})
+        grant_token = JWTGrantToken(jwttok)
+
+        with pytest.raises(MissingJWTGrantTokenClaimError) as exc:
+            grant_token.issuer
+
+        assert exc.value.description == "Missing claim 'iss' (issuer) from grant token."
+
+    def test_verified_initializes_verified_token(self, patch):
+        verified_token = patch('h.oauth.jwt_grant_token.VerifiedJWTGrantToken')
+
+        jwttok = jwt_token({'iss': 'test-issuer'})
+        grant_token = JWTGrantToken(jwttok)
+
+        grant_token.verified('top-secret', 'test-audience')
+
+        verified_token.assert_called_once_with(jwttok, 'top-secret', 'test-audience')
+
+    def test_verified_returns_verified_token(self, patch):
+        verified_token = patch('h.oauth.jwt_grant_token.VerifiedJWTGrantToken')
+
+        jwttok = jwt_token({'iss': 'test-issuer'})
+        grant_token = JWTGrantToken(jwttok)
+
+        actual = grant_token.verified('top-secret', 'test-audience')
+        assert actual == verified_token.return_value
+
+
+class TestVerifiedJWTGrantToken(object):
+    def test_init_returns_token_when_valid(self, claims):
+        jwttok = jwt_token(claims)
+
+        actual = VerifiedJWTGrantToken(jwttok, 'top-secret', 'test-audience')
+        assert isinstance(actual, VerifiedJWTGrantToken)
+
+    def test_init_raises_for_none_key(self, claims):
+        jwttok = jwt_token(claims)
+
+        with pytest.raises(InvalidClientError) as exc:
+            VerifiedJWTGrantToken(jwttok, None, 'test-audience')
+
+        assert exc.value.description == 'Client is invalid.'
+
+    def test_init_raises_for_empty_key(self, claims):
+        pass
+
+    def test_init_raises_for_too_long_token_lifetime(self, claims):
+        claims['exp'] = epoch(delta=timedelta(minutes=15))
+        jwttok = jwt_token(claims)
+
+        with pytest.raises(InvalidGrantError) as exc:
+            VerifiedJWTGrantToken(jwttok, 'top-secret', 'test-audience')
+
+        assert exc.value.description == 'Grant token lifetime is too long.'
+
+    def test_init_raises_for_invalid_signature(self, claims):
+        jwttok = jwt_token(claims)
+
+        with pytest.raises(InvalidGrantError) as exc:
+            VerifiedJWTGrantToken(jwttok, 'wrong-secret', 'test-audience')
+
+        assert exc.value.description == 'Invalid grant token signature.'
+
+    def test_init_raises_for_invalid_signature_algorithm(self, claims):
+        jwttok = jwt_token(claims, alg='HS512')
+
+        with pytest.raises(InvalidGrantError) as exc:
+            VerifiedJWTGrantToken(jwttok, 'top-secret', 'test-audience')
+
+        assert exc.value.description == 'Invalid grant token signature algorithm.'
+
+    @pytest.mark.parametrize('claim,description', [
+        ['aud', 'audience'],
+        ['exp', 'expiry'],
+        ['nbf', 'start time'],
+    ])
+    def test_init_raises_for_missing_claims(self, claims, claim, description):
+        del claims[claim]
+        jwttok = jwt_token(claims)
+
+        with pytest.raises(InvalidGrantError) as exc:
+            VerifiedJWTGrantToken(jwttok, 'top-secret', 'test-audience')
+
+        assert exc.value.description == "Missing claim '{}' ({}) from grant token.".format(claim, description)
+
+    def test_init_raises_for_invalid_aud(self, claims):
+        claims['aud'] = 'different-audience'
+        jwttok = jwt_token(claims)
+
+        with pytest.raises(InvalidJWTGrantTokenClaimError) as exc:
+            VerifiedJWTGrantToken(jwttok, 'top-secret', 'test-audience')
+
+        assert exc.value.description == "Invalid claim 'aud' (audience) in grant token."
+
+    @pytest.mark.parametrize('claim,description', [
+        ['exp', 'expiry'],
+        ['nbf', 'start time'],
+    ])
+    def test_init_raises_for_invalid_timestamp_types(self, claims, claim, description):
+        claims[claim] = 'wut'
+        jwttok = jwt_token(claims)
+
+        with pytest.raises(InvalidJWTGrantTokenClaimError) as exc:
+            VerifiedJWTGrantToken(jwttok, 'top-secret', 'test-audience')
+
+        assert exc.value.description == "Invalid claim '{}' ({}) in grant token.".format(claim, description)
+
+    def test_init_returns_token_when_expired_but_in_leeway(self, claims):
+        claims['exp'] = epoch(delta=timedelta(seconds=-8))
+        jwttok = jwt_token(claims)
+
+        VerifiedJWTGrantToken(jwttok, 'top-secret', 'test-audience')
+
+    def test_init_raises_when_expired_with_leeway(self, claims):
+        claims['exp'] = epoch(delta=timedelta(minutes=-2))
+        jwttok = jwt_token(claims)
+
+        with pytest.raises(InvalidGrantError) as exc:
+            VerifiedJWTGrantToken(jwttok, 'top-secret', 'test-audience')
+
+        assert exc.value.description == 'Grant token is expired.'
+
+    def test_init_raises_for_nbf_claim_in_future(self, claims):
+        claims['nbf'] = epoch(delta=timedelta(minutes=2))
+        jwttok = jwt_token(claims)
+
+        with pytest.raises(InvalidGrantError) as exc:
+            VerifiedJWTGrantToken(jwttok, 'top-secret', 'test-audience')
+
+        assert exc.value.description == 'Grant token is not yet valid.'
+
+    def test_init_raises_for_iat_claim_in_future(self, claims):
+        claims['iat'] = epoch(delta=timedelta(minutes=13))
+        jwttok = jwt_token(claims)
+
+        with pytest.raises(InvalidGrantError) as exc:
+            VerifiedJWTGrantToken(jwttok, 'top-secret', 'test-audience')
+
+        assert exc.value.description == 'Grant token issue time (iat) is in the future.'
+
+    def test_expiry_returns_exp_claim(self, claims):
+        now = datetime.utcnow().replace(microsecond=0)
+        delta = timedelta(minutes=2)
+
+        claims['exp'] = epoch(timestamp=now, delta=delta)
+        jwttok = jwt_token(claims)
+
+        grant_token = VerifiedJWTGrantToken(jwttok, 'top-secret', 'test-audience')
+
+        assert grant_token.expiry == (now + delta)
+
+    def test_not_before_returns_nbf_claim(self, claims):
+        now = datetime.utcnow().replace(microsecond=0)
+        delta = timedelta(minutes=-2)
+
+        claims['nbf'] = epoch(timestamp=now, delta=delta)
+        jwttok = jwt_token(claims)
+
+        grant_token = VerifiedJWTGrantToken(jwttok, 'top-secret', 'test-audience')
+
+        assert grant_token.not_before == (now + delta)
+
+    def test_subject_returns_sub_claim(self, claims):
+        jwttok = jwt_token(claims)
+
+        grant_token = VerifiedJWTGrantToken(jwttok, 'top-secret', 'test-audience')
+
+        assert grant_token.subject == 'test-subject'
+
+    def test_subject_raises_for_missing_sub_claim(self, claims):
+        del claims['sub']
+        jwttok = jwt_token(claims)
+
+        grant_token = VerifiedJWTGrantToken(jwttok, 'top-secret', 'test-audience')
+        with pytest.raises(InvalidGrantError) as exc:
+            grant_token.subject
+
+        assert exc.value.description == "Missing claim 'sub' (subject) from grant token."
+
+    def test_subject_raises_for_empty_sub_claim(self, claims):
+        claims['sub'] = ''
+        jwttok = jwt_token(claims)
+
+        grant_token = VerifiedJWTGrantToken(jwttok, 'top-secret', 'test-audience')
+        with pytest.raises(InvalidGrantError) as exc:
+            grant_token.subject
+
+        assert exc.value.description == "Missing claim 'sub' (subject) from grant token."
+
+    @pytest.fixture
+    def claims(self):
+        """Returns claims for a valid JWT token."""
+
+        return {
+            'aud': 'test-audience',
+            'exp': epoch(delta=timedelta(minutes=5)),
+            'iss': 'test-issuer',
+            'nbf': epoch(),
+            'sub': 'test-subject',
+        }
+
+
+def epoch(timestamp=None, delta=None):
+    if timestamp is None:
+        timestamp = datetime.utcnow()
+
+    if delta is not None:
+        timestamp = timestamp + delta
+
+    return timegm(timestamp.utctimetuple())
+
+
+def jwt_token(claims, alg='HS256'):
+    return jwt.encode(claims, 'top-secret', algorithm=alg)

--- a/tests/h/services/oauth_validator_test.py
+++ b/tests/h/services/oauth_validator_test.py
@@ -8,15 +8,34 @@ import uuid
 import mock
 import pytest
 
+from oauthlib.common import Request as OAuthRequest
 from oauthlib.oauth2 import InvalidClientIdError
 
-from h._compat import text_type
 from h import models
-from h.models.auth_client import ResponseType
+from h._compat import text_type
+from h.models.auth_client import GrantType as AuthClientGrantType
+from h.models.auth_client import ResponseType as AuthClientResponseType
 from h.services.oauth_validator import (
     OAuthValidatorService,
     oauth_validator_service_factory,
 )
+
+
+class TestAuthenticateClientId(object):
+    def test_returns_true_when_client_found(self, svc, client, oauth_request):
+        assert svc.authenticate_client_id(client.id, oauth_request) is True
+
+    def test_sets_client_on_request_when_found(self, svc, client, oauth_request):
+        assert oauth_request.client is None
+        svc.authenticate_client_id(client.id, oauth_request)
+        assert oauth_request.client == client
+
+    def test_returns_false_when_client_missing(self, svc, oauth_request):
+        assert svc.authenticate_client_id(text_type(uuid.uuid1()), oauth_request) is False
+
+    @pytest.fixture
+    def oauth_request(self):
+        return OAuthRequest('/')
 
 
 class TestFindClient(object):
@@ -29,6 +48,9 @@ class TestFindClient(object):
     def test_returns_none_when_not_found(self, svc, client):
         id_ = text_type(uuid.uuid1())
         assert svc.find_client(id_) is None
+
+    def test_returns_none_when_id_none(self, svc):
+        assert svc.find_client(None) is None
 
 
 class TestGetDefaultRedirectUri(object):
@@ -89,9 +111,42 @@ class TestSaveAuthorizationCode(object):
     def oauth_request(self, factories):
         return mock.Mock(user=factories.User(), spec_set=['user'])
 
+
+class TestSaveBearerToken(object):
+    def test_it_saves_token(self, svc, db_session, token_payload, oauth_request):
+        assert db_session.query(models.Token).count() == 0
+        svc.save_bearer_token(token_payload, oauth_request)
+        assert db_session.query(models.Token).count() == 1
+
+    def test_it_sets_userid(self, svc, token_payload, oauth_request):
+        token = svc.save_bearer_token(token_payload, oauth_request)
+        assert token.userid == oauth_request.user.userid
+
+    def test_it_sets_value(self, svc, token_payload, oauth_request):
+        token = svc.save_bearer_token(token_payload, oauth_request)
+        assert token.value == 'test-access-token'
+
+    def test_it_sets_expires(self, svc, token_payload, oauth_request, utcnow):
+        utcnow.return_value = datetime.datetime(2017, 7, 13, 18, 29, 28)
+
+        token = svc.save_bearer_token(token_payload, oauth_request)
+        assert token.expires == datetime.datetime(2017, 7, 13, 19, 29, 28)
+
+    def test_it_sets_authclient(self, svc, token_payload, oauth_request):
+        token = svc.save_bearer_token(token_payload, oauth_request)
+        assert token.refresh_token == 'test-refresh-token'
+
     @pytest.fixture
-    def utcnow(self, patch):
-        return patch('h.services.oauth_validator.utcnow')
+    def oauth_request(self, factories):
+        return OAuthRequest('/', body={'user': factories.User()})
+
+    @pytest.fixture
+    def token_payload(self):
+        return {
+            'access_token': 'test-access-token',
+            'refresh_token': 'test-refresh-token',
+            'expires_in': 3600,
+        }
 
 
 class TestValidateClientId(object):
@@ -101,6 +156,30 @@ class TestValidateClientId(object):
     def test_returns_false_for_missing_client(self, svc):
         id_ = text_type(uuid.uuid1())
         assert svc.validate_client_id(id_, None) is False
+
+
+class TestValidateGrantType(object):
+    def test_returns_false_when_client_does_not_have_grant_types(self, svc, client, oauth_request):
+        client.grant_type = None
+
+        result = svc.validate_grant_type(client.id, 'authorization_code', client, oauth_request)
+        assert result is False
+
+    def test_returns_true_when_grant_type_matches_client(self, svc, client, oauth_request):
+        client.grant_type = AuthClientGrantType.authorization_code
+
+        result = svc.validate_grant_type(client.id, 'authorization_code', client, oauth_request)
+        assert result is True
+
+    def test_returns_false_when_grant_type_does_not_match_client(self, svc, client, oauth_request):
+        client.grant_type = AuthClientGrantType.client_credentials
+
+        result = svc.validate_grant_type(client.id, 'authorization_code', client, oauth_request)
+        assert result is False
+
+    @pytest.fixture
+    def oauth_request(self):
+        return OAuthRequest('/')
 
 
 class TestValidateRedirectUri(object):
@@ -140,7 +219,7 @@ class TestValidateResponseType(object):
 
     @pytest.fixture
     def client(self, factories):
-        return factories.AuthClient(response_type=ResponseType.code)
+        return factories.AuthClient(response_type=AuthClientResponseType.code)
 
 
 class TestValidateScopes(object):
@@ -175,3 +254,8 @@ def svc(db_session):
 @pytest.fixture
 def client(factories):
     return factories.AuthClient()
+
+
+@pytest.fixture
+def utcnow(patch):
+    return patch('h.services.oauth_validator.utcnow')


### PR DESCRIPTION
This change is part of removing our custom OAuth implementation with one that is based on oauthlib. It will still only work for the JWT bearer token exchange and refresh token exchange.

This is adding a new grant type (`h.oauth.jwt_grant`) in the form oauthlib understands (responding to `create_token_response` and `validate_token_request`).

_This is split out from #4602._