### PR TITLE
Support refreshing tokens in oauthlib integration

### DIFF
--- a/h/services/oauth_validator.py
+++ b/h/services/oauth_validator.py
@@ -8,6 +8,7 @@ from oauthlib.oauth2 import InvalidClientIdError, RequestValidator
 from sqlalchemy.exc import StatementError
 
 from h import models
+from h.models.auth_client import GrantType as AuthClientGrantType
 from h.util.db import lru_cache_in_transaction
 
 AUTHZ_CODE_TTL = datetime.timedelta(minutes=10)
@@ -21,10 +22,12 @@ class OAuthValidatorService(RequestValidator):
     This implements the ``oauthlib.oauth2.RequestValidator`` interface.
     """
 
-    def __init__(self, session):
+    def __init__(self, session, user_svc):
         self.session = session
+        self.user_svc = user_svc
 
         self._cached_find_client = lru_cache_in_transaction(self.session)(self._find_client)
+        self._cached_find_refresh_token = lru_cache_in_transaction(self.session)(self._find_refresh_token)
 
     def authenticate_client_id(self, client_id, request, *args, **kwargs):
         """Authenticates a client_id, returns True if the client_id exists."""
@@ -32,8 +35,32 @@ class OAuthValidatorService(RequestValidator):
         request.client = client
         return (client is not None)
 
+    def client_authentication_required(self, request, *args, **kwargs):
+        """
+        Determine if client authentication is required for an access token request.
+
+        Confidential clients usually require client authentication.
+        Except there is a special case where a token which initially used the JWT bearer
+        grant type, which only works with confidential clients, can be refreshed
+        without requiring client authentication.
+        """
+
+        client = self.find_client(request.client_id)
+        if client is None:
+            # `authenticate_client_id` will not authenticate a missing client.
+            return False
+
+        if (request.grant_type == 'refresh_token' and
+                client.grant_type == AuthClientGrantType.jwt_bearer):
+            return False
+
+        return (client.secret is not None)
+
     def find_client(self, id_):
         return self._cached_find_client(id_)
+
+    def find_refresh_token(self, value):
+        return self._cached_find_refresh_token(value)
 
     def get_default_redirect_uri(self, client_id, request, *args, **kwargs):
         """Returns the ``redirect_uri`` stored on the client with the given id."""
@@ -45,6 +72,10 @@ class OAuthValidatorService(RequestValidator):
     def get_default_scopes(self, client_id, request, *args, **kwargs):
         """Return the default scopes for the provided client."""
         return DEFAULT_SCOPES
+
+    def get_original_scopes(self, refresh_token, request, *args, **kwargs):
+        """As we don't supports scopes, this returns the default scopes."""
+        return self.get_default_scopes(self, request.client_id, request)
 
     def save_authorization_code(self, client_id, code, request, *args, **kwargs):
         client = self.find_client(client_id)
@@ -81,6 +112,9 @@ class OAuthValidatorService(RequestValidator):
         if client.grant_type is None:
             return False
 
+        if grant_type == 'refresh_token':
+            return True
+
         return (grant_type == client.grant_type.value)
 
     def validate_redirect_uri(self, client_id, redirect_uri, request, *args, **kwargs):
@@ -90,6 +124,26 @@ class OAuthValidatorService(RequestValidator):
         if client is not None:
             return (client.redirect_uri == redirect_uri)
         return False
+
+    def validate_refresh_token(self, refresh_token, client, request, *args, **kwargs):
+        """
+        Validate a supplied refresh token.
+
+        Check that the refresh token supplied with an access token request a) exists,
+        b) has not expired, and c) is associated with the client identified in the request.
+        If we return True from this function, we can assume that it is safe to issue a
+        new access token to the requesting client.
+
+        This function also finds the user associated with the given refresh token, and sets
+        it on the given oauth request object as the ``user`` property.
+        """
+        token = self.find_refresh_token(refresh_token)
+
+        if not token or token.expired or token.authclient != client:
+            return False
+
+        request.user = self.user_svc.fetch(token.userid)
+        return True
 
     def validate_response_type(self, client_id, response_type, request, *args, **kwargs):
         """Validate that the provided ``response_type`` matches the one stored on the client."""
@@ -115,10 +169,20 @@ class OAuthValidatorService(RequestValidator):
         except StatementError:
             return None
 
+    def _find_refresh_token(self, value):
+        if value is None:
+            return None
+
+        return (self.session.query(models.Token)
+                    .filter_by(refresh_token=value)
+                    .order_by(models.Token.created.desc())
+                    .first())
+
 
 def oauth_validator_service_factory(context, request):
     """Return a OAuthValidator instance for the passed context and request."""
-    return OAuthValidatorService(request.db)
+    user_svc = request.find_service(name='user')
+    return OAuthValidatorService(request.db, user_svc)
 
 
 def utcnow():

--- a/tests/common/factories/__init__.py
+++ b/tests/common/factories/__init__.py
@@ -16,7 +16,7 @@ from .feature_cohort import FeatureCohort
 from .flag import Flag
 from .group import Group, PublisherGroup
 from .setting import Setting
-from .token import DeveloperToken
+from .token import DeveloperToken, OAuth2Token
 from .user import User
 
 __all__ = (
@@ -35,6 +35,7 @@ __all__ = (
     'FeatureCohort',
     'Flag',
     'Group',
+    'OAuth2Token',
     'PublisherGroup',
     'Setting',
     'User',

--- a/tests/common/factories/token.py
+++ b/tests/common/factories/token.py
@@ -2,12 +2,15 @@
 
 from __future__ import unicode_literals
 
+from datetime import datetime, timedelta
+
 import factory
 
-from h import models
-from h import security
-from h.services.developer_token import PREFIX
+from h import models, security
+from h.services.developer_token import PREFIX as DEVELOPER_TOKEN_PREFIX
+from h.services.oauth import ACCESS_TOKEN_PREFIX, REFRESH_TOKEN_PREFIX
 
+from .auth_client import AuthClient
 from .base import FAKER, ModelFactory
 
 
@@ -18,4 +21,17 @@ class DeveloperToken(ModelFactory):
         sqlalchemy_session_persistence = 'flush'
 
     userid = factory.LazyAttribute(lambda _: ('acct:' + FAKER.user_name() + '@example.com'))
-    value = factory.LazyAttribute(lambda _: (PREFIX + security.token_urlsafe()))
+    value = factory.LazyAttribute(lambda _: (DEVELOPER_TOKEN_PREFIX + security.token_urlsafe()))
+
+
+class OAuth2Token(ModelFactory):
+
+    class Meta:
+        model = models.Token
+        sqlalchemy_session_persistence = 'flush'
+
+    userid = factory.LazyAttribute(lambda _: ('acct:' + FAKER.user_name() + '@example.com'))
+    value = factory.LazyAttribute(lambda _: (ACCESS_TOKEN_PREFIX + security.token_urlsafe()))
+    refresh_token = factory.LazyAttribute(lambda _: (REFRESH_TOKEN_PREFIX + security.token_urlsafe()))
+    expires = factory.LazyAttribute(lambda _: (datetime.utcnow() + timedelta(hours=1)))
+    authclient = factory.SubFactory(AuthClient)

--- a/tests/h/views/api_auth_test.py
+++ b/tests/h/views/api_auth_test.py
@@ -129,7 +129,7 @@ class TestOAuthAuthorizeController(object):
         return oauth_server
 
     @pytest.fixture
-    def oauth_validator(self, pyramid_config, pyramid_request):
+    def oauth_validator(self, pyramid_config, pyramid_request, user_svc):
         svc = mock.Mock(spec=oauth_validator_service_factory(None, pyramid_request))
         pyramid_config.register_service(svc, name='oauth_validator')
         return svc


### PR DESCRIPTION
This change is part of removing our custom OAuth implementation with one that is based on oauthlib. It will still only work for the JWT bearer token exchange and refresh token exchange.

This implements the refresh token flow methods that oauthlib calls in the `h.services.oauth_validator` service.

_This is split out from #4602. It also depends on #4603 and needs to be rebased when that one is merged._