### PR TITLE
Add our own OAuth provider class

### DIFF
--- a/h/oauth/__init__.py
+++ b/h/oauth/__init__.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 
 from h.oauth.errors import (
     InvalidJWTGrantTokenClaimError,
+    InvalidRefreshTokenError,
     MissingJWTGrantTokenClaimError,
 )
 from h.oauth.jwt_grant import JWTAuthorizationGrant
@@ -13,5 +14,6 @@ __all__ = (
     'JWTAuthorizationGrant',
     'JWTGrantToken',
     'InvalidJWTGrantTokenClaimError',
+    'InvalidRefreshTokenError',
     'MissingJWTGrantTokenClaimError',
 )

--- a/h/oauth/errors.py
+++ b/h/oauth/errors.py
@@ -2,7 +2,7 @@
 
 from __future__ import unicode_literals
 
-from oauthlib.oauth2 import InvalidGrantError
+from oauthlib.oauth2 import InvalidGrantError, InvalidRequestFatalError
 
 
 class MissingJWTGrantTokenClaimError(InvalidGrantError):
@@ -19,3 +19,7 @@ class InvalidJWTGrantTokenClaimError(InvalidGrantError):
             self.description = "Invalid claim '{}' ({}) in grant token.".format(claim, claim_description)
         else:
             self.description = "Invalid claim '{}' in grant token.".format(claim)
+
+
+class InvalidRefreshTokenError(InvalidRequestFatalError):
+    description = 'Invalid refresh_token.'

--- a/h/services/__init__.py
+++ b/h/services/__init__.py
@@ -23,6 +23,7 @@ def includeme(config):
     config.register_service_factory('.links.links_factory', name='links')
     config.register_service_factory('.nipsa.nipsa_factory', name='nipsa')
     config.register_service_factory('.oauth.oauth_service_factory', name='oauth')
+    config.register_service_factory('.oauth_provider.oauth_provider_service_factory', name='oauth_provider')
     config.register_service_factory('.oauth_validator.oauth_validator_service_factory', name='oauth_validator')
     config.register_service_factory('.rename_user.rename_user_factory', name='rename_user')
     config.register_service_factory('.settings.settings_factory', name='settings')

--- a/h/services/oauth_provider.py
+++ b/h/services/oauth_provider.py
@@ -1,0 +1,94 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import datetime
+
+from oauthlib.oauth2 import (
+    AuthorizationCodeGrant,
+    AuthorizationEndpoint,
+    BearerToken,
+    RefreshTokenGrant,
+    TokenEndpoint,
+)
+
+from h.oauth import InvalidRefreshTokenError, JWTAuthorizationGrant
+from h.security import token_urlsafe
+
+TOKEN_TTL = datetime.timedelta(hours=1).total_seconds()
+
+
+class OAuthProviderService(AuthorizationEndpoint, TokenEndpoint):
+    """
+    The OAuth 2 provider service.
+
+    This service subclasses both the oauthlib `authorization endpoint`_
+    and the `token endpoint`_. Its goal is to provide a complete
+    configuration on how to provide the necessary functionality of
+    an OAuth authorization server.
+
+    .. _`authorization endpoint`: https://oauthlib.readthedocs.io/en/latest/oauth2/endpoints/authorization.html
+    .. _`token endpoint`: https://oauthlib.readthedocs.io/en/latest/oauth2/endpoints/token.html
+    """
+    def __init__(self, oauth_validator, user_svc, domain):
+        self.oauth_validator = oauth_validator
+
+        auth_code_grant = AuthorizationCodeGrant(oauth_validator)
+        jwt_auth_grant = JWTAuthorizationGrant(oauth_validator, user_svc, domain)
+        refresh_grant = RefreshTokenGrant(oauth_validator)
+
+        refresh_grant.custom_validators.pre_token.append(self.load_client_id_from_refresh_token)
+
+        bearer = BearerToken(oauth_validator,
+                             token_generator=self.generate_access_token,
+                             expires_in=TOKEN_TTL,
+                             refresh_token_generator=self.generate_refresh_token)
+
+        AuthorizationEndpoint.__init__(self,
+                                       default_response_type='code',
+                                       response_types={'code': auth_code_grant},
+                                       default_token_type=bearer)
+        TokenEndpoint.__init__(self, default_grant_type='authorization_code',
+                               grant_types={
+                                   'authorization_code': auth_code_grant,
+                                   'refresh_token': refresh_grant,
+                                   'urn:ietf:params:oauth:grant-type:jwt-bearer': jwt_auth_grant,
+                               },
+                               default_token_type=bearer)
+
+    def load_client_id_from_refresh_token(self, request):
+        """
+        Custom validator which sets the client_id from a given refresh token
+
+        For the refresh token flow, RFC 6749 states that public clients only need
+        to be verified when the `client_id` is provided. oauthlib seems to be
+        ignoring this and always expects the `client_id` parameter.
+        We need to work around this problem since this is an issue with our
+        third-party accounts integration, where the piece of code that is
+        refreshing a token is not the same as the piece of code that is initially
+        generating a JWT bearer token.
+
+        This custom validator tries to load the token from the database, based on
+        the given refresh token string and sets the `client_id` from the model.
+        Thus allowing oauthlib to continue verifying that the client still exists.
+        """
+        if not request.refresh_token:
+            return
+
+        token = self.oauth_validator.find_refresh_token(request.refresh_token)
+        if token:
+            request.client_id = token.authclient.id
+        else:
+            raise InvalidRefreshTokenError()
+
+    def generate_access_token(self, oauth_request):
+        return '5768-{}'.format(token_urlsafe())
+
+    def generate_refresh_token(self, oauth_request):
+        return '4657-{}'.format(token_urlsafe())
+
+
+def oauth_provider_service_factory(context, request):
+    validator_svc = request.find_service(name='oauth_validator')
+    user_svc = request.find_service(name='user')
+    return OAuthProviderService(validator_svc, user_svc, request.domain)

--- a/tests/h/services/oauth_provider_test.py
+++ b/tests/h/services/oauth_provider_test.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import mock
+import pytest
+
+from oauthlib.common import Request as OAuthRequest
+
+from h.oauth.errors import InvalidRefreshTokenError
+from h.services.oauth_provider import (
+    OAuthProviderService,
+    oauth_provider_service_factory,
+)
+
+
+@pytest.mark.usefixtures('validator_service', 'user_service')
+class TestOAuthProviderService(object):
+    def test_load_client_id_sets_client_id_from_refresh_token(self, svc, oauth_request, factories, validator_service):
+        token_1, token_2 = factories.OAuth2Token(), factories.OAuth2Token()
+        oauth_request.refresh_token = token_2.refresh_token
+
+        def fake_find_refresh_token(refresh_token):
+            if refresh_token == token_1.refresh_token:
+                return token_1
+            elif refresh_token == token_2.refresh_token:
+                return token_2
+        validator_service.find_refresh_token.side_effect = fake_find_refresh_token
+
+        assert oauth_request.client_id is None
+        svc.load_client_id_from_refresh_token(oauth_request)
+        assert oauth_request.client_id == token_2.authclient.id
+
+    def test_load_client_id_skips_setting_client_id_when_not_refresh_token(self, svc, oauth_request, factories, validator_service):
+        token = factories.OAuth2Token()
+
+        def fake_find_refresh_token(refresh_token):
+            if refresh_token == token.refresh_token:
+                return token
+        validator_service.find_refresh_token.side_effect = fake_find_refresh_token
+
+        svc.load_client_id_from_refresh_token(oauth_request)
+        assert oauth_request.client_id is None
+
+    def test_load_client_id_raises_for_missing_refresh_token(self, svc, oauth_request, validator_service):
+        validator_service.find_refresh_token.return_value = None
+        oauth_request.refresh_token = 'missing'
+
+        with pytest.raises(InvalidRefreshTokenError):
+            svc.load_client_id_from_refresh_token(oauth_request)
+
+    def test_generate_access_token(self, svc, token_urlsafe):
+        token_urlsafe.return_value = 'very-secret'
+        assert svc.generate_access_token(None) == '5768-very-secret'
+
+    def test_generate_refresh_token(self, svc, token_urlsafe):
+        token_urlsafe.return_value = 'top-secret'
+        assert svc.generate_refresh_token(None) == '4657-top-secret'
+
+    @pytest.fixture
+    def svc(self, pyramid_request):
+        return oauth_provider_service_factory(None, pyramid_request)
+
+    @pytest.fixture
+    def token_urlsafe(self, patch):
+        return patch('h.services.oauth_provider.token_urlsafe')
+
+    @pytest.fixture
+    def oauth_request(self):
+        return OAuthRequest('/')
+
+
+@pytest.mark.usefixtures('validator_service', 'user_service')
+class TestOAuthProviderServiceFactory(object):
+    def test_it_returns_oauth_provider_service(self, pyramid_request):
+        svc = oauth_provider_service_factory(None, pyramid_request)
+        assert isinstance(svc, OAuthProviderService)
+
+
+@pytest.fixture
+def validator_service(pyramid_config):
+    svc = mock.Mock()
+    pyramid_config.register_service(svc, name='oauth_validator')
+    return svc
+
+
+@pytest.fixture
+def user_service(pyramid_config):
+    svc = mock.Mock()
+    pyramid_config.register_service(svc, name='user')
+    return svc


### PR DESCRIPTION
This change is part of removing our custom OAuth implementation with one that is based on oauthlib. It will still only work for the JWT bearer token exchange and refresh token exchange.

This is replacing the class that tied everything together (`oauthlib.oauth2.WebApplicationServer`) with our own implementation (`h.services.oauth_provider`) that configures oauthlib the way we use OAuth in `h` (sets token generators, configures the jwt-bearer with the oauthlib `TokenEndpoint` endpoint).

_This is split out from #4602. It also depends on #4604 and needs to be rebased when that one is merged._