### PR TITLE
Cleanup few oauthlib related ends

### DIFF
--- a/h/oauth/jwt_grant.py
+++ b/h/oauth/jwt_grant.py
@@ -114,13 +114,15 @@ class JWTAuthorizationGrant(GrantTypeBase):
         # Ensure client is authorized use of this grant type
         self.validate_grant_type(request)
 
-        verified_token = token.verified(key=request.client.secret, audience=self.domain)
+        authclient = request.client.authclient
+
+        verified_token = token.verified(key=authclient.secret, audience=self.domain)
 
         user = self.user_svc.fetch(verified_token.subject)
         if user is None:
             raise errors.InvalidGrantError('Grant token subject (sub) could not be found.')
 
-        if user.authority != request.client.authority:
+        if user.authority != authclient.authority:
             raise errors.InvalidGrantError('Grant token subject (sub) does not match issuer (iss).')
 
         request.user = user

--- a/tests/h/oauth/jwt_grant_test.py
+++ b/tests/h/oauth/jwt_grant_test.py
@@ -15,6 +15,7 @@ from oauthlib.oauth2.rfc6749 import errors
 
 from h.oauth.jwt_grant import JWTAuthorizationGrant
 from h.services.user import user_service_factory
+from h.services.oauth_validator import Client
 
 
 class TestJWTAuthorizationGrantCreateTokenResponse(object):
@@ -107,7 +108,7 @@ class TestJWTAuthorizationGrantValidateTokenRequest(object):
             grant.validate_token_request(oauth_request)
 
     def test_verifies_grant_token(self, grant, oauth_request):
-        oauth_request.client.secret = 'bogus'
+        oauth_request.client.authclient.secret = 'bogus'
 
         with pytest.raises(errors.InvalidGrantError) as exc:
             grant.validate_token_request(oauth_request)
@@ -160,7 +161,7 @@ def oauth_request(authclient, user):
     jwttok = jwt.encode(claims, authclient.secret, algorithm='HS256')
 
     return OAuthRequest('/', body={'assertion': jwttok,
-                                   'client': authclient})
+                                   'client': Client(authclient)})
 
 
 @pytest.fixture

--- a/tests/h/services/oauth_validator_test.py
+++ b/tests/h/services/oauth_validator_test.py
@@ -21,6 +21,44 @@ from h.services.oauth_validator import (
 )
 
 
+class TestAuthenticateClient(object):
+    def test_returns_true_when_client_secret_matches_request(self, svc, client, oauth_request):
+        oauth_request.client_id = client.id
+        oauth_request.client_secret = client.secret
+
+        assert svc.authenticate_client(oauth_request) is True
+
+    def test_sets_client_on_request_when_authentication_succeded(self, svc, client, oauth_request):
+        oauth_request.client_id = client.id
+        oauth_request.client_secret = client.secret
+
+        svc.authenticate_client(oauth_request)
+        assert oauth_request.client == client
+
+    def test_returns_false_for_missing_request_parameters(self, svc, oauth_request):
+        assert svc.authenticate_client(oauth_request) is False
+
+    def test_returns_false_for_missing_client(self, svc, client, oauth_request):
+        oauth_request.client_id = uuid.uuid1()
+        oauth_request.client_secret = client.secret
+
+        assert svc.authenticate_client(oauth_request) is False
+
+    def test_returns_false_when_secrets_do_not_match(self, svc, client, oauth_request):
+        oauth_request.client_id = client.id
+        oauth_request.client_secret = 'this-is-invalid'
+
+        assert svc.authenticate_client(oauth_request) is False
+
+    @pytest.fixture
+    def oauth_request(self):
+        return OAuthRequest('/')
+
+    @pytest.fixture
+    def client(self, factories):
+        return factories.ConfidentialAuthClient()
+
+
 class TestAuthenticateClientId(object):
     def test_returns_true_when_client_found(self, svc, client, oauth_request):
         assert svc.authenticate_client_id(client.id, oauth_request) is True


### PR DESCRIPTION
~_This is based on #4606 and will need to be rebased._~

I've missed and "mis-implemented" a few things along the way with our oauthlib integration. This fixes these.

First up is that I've never implemented the `authenticate_client` method in the OAuth validator. This method is getting called when our provider determines that client authentication is necessary.

Next is that the oauthlib documentation states that the client property on the request that the validator needs to set, is expected to have a `client_id` property. Since our `AuthClient` does not have a `client_id` property I've decided to use a wrapper class that both gives access to the `client_id`, but also to the model itself.