### PR TITLE
Properly handle other OAuth errors in authorize view

### DIFF
--- a/tests/h/views/api_auth_test.py
+++ b/tests/h/views/api_auth_test.py
@@ -103,7 +103,7 @@ class TestOAuthAuthorizeController(object):
 
     @pytest.fixture
     def controller(self, pyramid_request):
-        return views.OAuthAuthorizeController(pyramid_request)
+        return views.OAuthAuthorizeController(None, pyramid_request)
 
     @pytest.fixture
     def oauth_provider(self, pyramid_config, auth_client):


### PR DESCRIPTION
Some errors that might happen are not `InvalidRequestError` or
`InvalidRequestFatalError`, for example `UnsupportedResponseTypeError`
or `InvalidScopeError`.

The error view now also has to move into the authorize controller to
ensure that we don't render an HTML page on another error that should
render for example JSON.

Related Sentry issue: https://sentry.io/hypothesis/h/issues/317677678/activity/