### PR TITLE
Fix error when validating response type for client without one

### DIFF
--- a/h/services/oauth_validator.py
+++ b/h/services/oauth_validator.py
@@ -233,7 +233,8 @@ class OAuthValidatorService(RequestValidator):
 
         client = self.find_client(client_id)
         if client is not None:
-            return (client.response_type.value == response_type)
+            return (client.response_type is not None and
+                    client.response_type.value == response_type)
         return False
 
     def validate_scopes(self, client_id, scopes, request, *args, **kwargs):

--- a/tests/h/services/oauth_validator_test.py
+++ b/tests/h/services/oauth_validator_test.py
@@ -440,6 +440,12 @@ class TestValidateResponseType(object):
         id_ = text_type(uuid.uuid1())
         assert svc.validate_response_type(id_, 'code', None) is False
 
+    def test_returns_false_for_missing_client_response_type(self, svc, client):
+        client.response_type = None
+
+        actual = svc.validate_response_type(client.id, 'code', None)
+        assert actual is False
+
     @pytest.fixture
     def client(self, factories):
         return factories.AuthClient(response_type=AuthClientResponseType.code)


### PR DESCRIPTION
We blindly try to call `authclient.response_type.value`, even though
clients don't need to have a `response_type` (it isn't needed for some
grant types, like the JWT bearer one).

This currently still renders a 500 error because it throws an exception that isn't handled but will be once #4612 is merged.