### PR TITLE
Fix exception when authenticating client without secret parameter

### DIFF
--- a/h/services/oauth_validator.py
+++ b/h/services/oauth_validator.py
@@ -45,7 +45,12 @@ class OAuthValidatorService(RequestValidator):
         if client is None:
             return False
 
-        if not hmac.compare_digest(client.secret, request.client_secret):
+        provided_secret = request.client_secret
+        if request.client_secret is None:
+            # hmac.compare_digest raises when one value is `None`
+            provided_secret = ''
+
+        if not hmac.compare_digest(client.secret, provided_secret):
             return False
 
         request.client = Client(client)

--- a/tests/h/services/oauth_validator_test.py
+++ b/tests/h/services/oauth_validator_test.py
@@ -37,7 +37,11 @@ class TestAuthenticateClient(object):
         assert oauth_request.client.client_id == client.id
         assert oauth_request.client.authclient == client
 
-    def test_returns_false_for_missing_request_parameters(self, svc, oauth_request):
+    def test_returns_false_for_missing_client_id_request_param(self, svc, client, oauth_request):
+        assert svc.authenticate_client(oauth_request) is False
+
+    def test_returns_false_for_missing_client_secret_request_param(self, svc, client, oauth_request):
+        oauth_request.client_id = client.id
         assert svc.authenticate_client(oauth_request) is False
 
     def test_returns_false_for_missing_client(self, svc, client, oauth_request):


### PR DESCRIPTION
`hmac.compare_digest` raises when one of the two value is `None`. This
can only happen when the request specifies the `client_id` of a client
that has a secret, but there is no `client_secret` parameter.