### PR TITLE
Add support for `web_message` in OAuth authorize endpoint

### DIFF
--- a/h/templates/oauth/authorize_web_message.html.jinja2
+++ b/h/templates/oauth/authorize_web_message.html.jinja2
@@ -1,0 +1,16 @@
+<html>
+<head>
+<title>Authorization completed</title>
+<script type="application/json" class="js-hypothesis-settings">
+{
+  "code": {{ code | to_json }},
+  "origin": {{ origin | to_json }},
+  "state": {{ state | to_json }}
+}
+</script>
+{% for url in asset_urls('post_auth_js') %}
+<script src="{{ url }}"></script>
+{% endfor %}
+</script>
+</head>
+</html>


### PR DESCRIPTION
This adds the ability to provide the created authorization code via the
`web_message` method as described in
[draft-sakimura-oauth-wmrm-00][draft-sakimura-oauth-wmrm-00].

[draft-sakimura-oauth-wmrm-00]: https://tools.ietf.org/html/draft-sakimura-oauth-wmrm-00