### PR TITLE
Make feature flag deletions cascade

### DIFF
--- a/h/migrations/versions/74bff6a7d9de_make_feature_flag_deletions_cascade.py
+++ b/h/migrations/versions/74bff6a7d9de_make_feature_flag_deletions_cascade.py
@@ -1,0 +1,26 @@
+"""
+Make feature flag deletions cascade
+
+Revision ID: 74bff6a7d9de
+Revises: 52a0b2e5a9c2
+Create Date: 2017-08-01 09:59:51.200253
+"""
+
+from __future__ import unicode_literals
+
+from alembic import op
+
+
+revision = '74bff6a7d9de'
+down_revision = '52a0b2e5a9c2'
+
+fk_name = 'fk__featurecohort_feature__feature_id__feature'
+
+def upgrade():
+    op.drop_constraint(fk_name, 'featurecohort_feature', type_='foreignkey')
+    op.create_foreign_key(op.f(fk_name), 'featurecohort_feature', 'feature', ['feature_id'], ['id'], ondelete='cascade')
+
+
+def downgrade():
+    op.drop_constraint(fk_name, 'featurecohort_feature', type_='foreignkey')
+    op.create_foreign_key(op.f(fk_name), 'featurecohort_feature', 'feature', ['feature_id'], ['id'])

--- a/h/models/feature_cohort.py
+++ b/h/models/feature_cohort.py
@@ -58,7 +58,7 @@ FEATURECOHORT_FEATURE_TABLE = sa.Table(
               nullable=False),
     sa.Column('feature_id',
               sa.Integer(),
-              sa.ForeignKey('feature.id'),
+              sa.ForeignKey('feature.id', ondelete='cascade'),
               nullable=False),
     sa.UniqueConstraint('cohort_id', 'feature_id'),
 )


### PR DESCRIPTION
Remove feature cohort <-> feature associations automatically when the
corresponding feature flag is removed.

This fixes a problem where the task to purge old feature flags could fail if the feature was still enabled for one or more cohorts.