### PR TITLE
Add token revocation endpoint

### DIFF
--- a/h/routes.py
+++ b/h/routes.py
@@ -92,6 +92,7 @@ def includeme(config):
     config.add_route('badge', '/api/badge')
     config.add_route('token', '/api/token')
     config.add_route('oauth_authorize', '/oauth/authorize')
+    config.add_route('oauth_revoke', '/oauth/revoke')
 
     # Client
     config.add_route('session', '/app')

--- a/h/services/oauth_provider.py
+++ b/h/services/oauth_provider.py
@@ -9,6 +9,7 @@ from oauthlib.oauth2 import (
     AuthorizationEndpoint,
     BearerToken,
     RefreshTokenGrant,
+    RevocationEndpoint,
     TokenEndpoint,
 )
 
@@ -20,7 +21,7 @@ ACCESS_TOKEN_PREFIX = '5768-'
 REFRESH_TOKEN_PREFIX = '4657-'
 
 
-class OAuthProviderService(AuthorizationEndpoint, TokenEndpoint):
+class OAuthProviderService(AuthorizationEndpoint, RevocationEndpoint, TokenEndpoint):
     """
     The OAuth 2 provider service.
 
@@ -57,6 +58,7 @@ class OAuthProviderService(AuthorizationEndpoint, TokenEndpoint):
                                    'urn:ietf:params:oauth:grant-type:jwt-bearer': jwt_auth_grant,
                                },
                                default_token_type=bearer)
+        RevocationEndpoint.__init__(self, oauth_validator)
 
     def load_client_id_from_refresh_token(self, request):
         """

--- a/h/views/api_auth.py
+++ b/h/views/api_auth.py
@@ -180,6 +180,23 @@ class OAuthAccessTokenController(object):
             raise exception_response(status, body=body)
 
 
+@view_defaults(route_name='oauth_revoke')
+class OAuthRevocationController(object):
+    def __init__(self, request):
+        self.request = request
+
+        self.oauth = self.request.find_service(name='oauth_provider')
+
+    @cors_json_view(request_method='POST')
+    def post(self):
+        headers, body, status = self.oauth.create_revocation_response(
+            self.request.url, self.request.method, self.request.POST, self.request.headers)
+        if status == 200:
+            return {}
+        else:
+            raise exception_response(status, body=body)
+
+
 @cors_json_view(route_name='api.debug_token', request_method='GET')
 def debug_token(request):
     if not request.auth_token:

--- a/h/views/client.py
+++ b/h/views/client.py
@@ -58,6 +58,7 @@ def sidebar_app(request, extra=None):
         # OAuth config.
         'oauthAuthorizeUrl': request.route_url('oauth_authorize'),
         'oauthClientId': settings.get('h.client_oauth_id'),
+        'oauthRevokeUrl': request.route_url('oauth_revoke'),
 
         # The OAuth feature flag is included as part of the `app.html` config
         # rather than being delivered via the "features" key in /api/profile so

--- a/tests/h/routes_test.py
+++ b/tests/h/routes_test.py
@@ -81,6 +81,7 @@ def test_includeme():
         call('badge', '/api/badge'),
         call('token', '/api/token'),
         call('oauth_authorize', '/oauth/authorize'),
+        call('oauth_revoke', '/oauth/revoke'),
         call('session', '/app'),
         call('sidebar_app', '/app.html'),
         call('embed', '/embed.js'),

--- a/tests/h/views/client_test.py
+++ b/tests/h/views/client_test.py
@@ -40,6 +40,7 @@ class TestSidebarApp(object):
                 'authDomain': 'example.com',
                 'googleAnalytics': 'UA-4567',
                 'oauthAuthorizeUrl': 'http://example.com/oauth/authorize',
+                'oauthRevokeUrl': 'http://example.com/oauth/revoke',
                 'oauthClientId': 'test-client-id',
                 'oauthEnabled': True,
                 }
@@ -102,6 +103,7 @@ def routes(pyramid_config):
     pyramid_config.add_route('index', '/')
     pyramid_config.add_route('sidebar_app', '/app.html')
     pyramid_config.add_route('oauth_authorize', '/oauth/authorize')
+    pyramid_config.add_route('oauth_revoke', '/oauth/revoke')
 
 
 @pytest.fixture


### PR DESCRIPTION
This adds a new `POST /oauth/revoke` endpoint which allows revoking tokens either by access token or by refresh token. It works according to [RFC 7009][RFC 7009].

[RFC 7009]: https://tools.ietf.org/html/rfc7009