### PR TITLE
Make cohort labels clickable in feature flag admin

### DIFF
--- a/h/templates/admin/features.html.jinja2
+++ b/h/templates/admin/features.html.jinja2
@@ -56,6 +56,7 @@
                 <fieldset>
                   <input
                     type="checkbox"
+                    id="{{ feat.name }}[cohorts][{{ c.name }}]"
                     name="{{ feat.name }}[cohorts][{{ c.name }}]"
                     {% if c in feat.cohorts %}checked{% endif %}>
                   <label for="{{ feat.name }}[cohorts][{{ c.name }}]">{{ c.name }}</label>


### PR DESCRIPTION
![clickable-cohorts](https://user-images.githubusercontent.com/32775/28881695-e1510170-77a0-11e7-9f67-59863e090fa1.png)


In the current feature flag admin, there are labelled checkboxes to enable individual features for each cohort of users we create. The labels have a `for` attribute, but as they refer to the `name`
attributes of their respective checkboxes, rather than their `id` attributes, clicking the cohort name doesn't toggle the checkbox (at least not according to the spec, or testing it in Safari, Firefox and
Chrome).

Adding an `id` attribute identical to the `name` attribute fixes this problem, giving our admins a slightly easier experience trying to click things.