### PR TITLE
Add migration for new `token.refresh_token_expires` column

### DIFF
--- a/h/migrations/versions/9bcc39244e82_add_token_refresh_token_expires.py
+++ b/h/migrations/versions/9bcc39244e82_add_token_refresh_token_expires.py
@@ -1,0 +1,23 @@
+"""
+Add token refresh_token_expires
+
+Revision ID: 9bcc39244e82
+Revises: 74bff6a7d9de
+Create Date: 2017-08-02 15:19:39.710878
+"""
+
+from __future__ import unicode_literals
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = '9bcc39244e82'
+down_revision = '74bff6a7d9de'
+
+
+def upgrade():
+    op.add_column('token', sa.Column('refresh_token_expires', sa.DateTime, nullable=True))
+
+
+def downgrade():
+    op.drop_column('token', 'refresh_token_expires')


### PR DESCRIPTION
This is the database migration for hypothesis/product-backlog#329 and needs to be deployed and run in production first.

We will separate the expiration times of tokens, allowing the refresh token to be valid for much longer than the access token.