### PR TITLE
Separate refresh token expiration

### DIFF
--- a/h/models/token.py
+++ b/h/models/token.py
@@ -65,9 +65,17 @@ class Token(Base, mixins.Timestamps):
 
     @property
     def expired(self):
-        """True if this token has expired, False otherwise."""
+        """True if this access token has expired, False otherwise."""
         if self.expires:
             return datetime.datetime.utcnow() > self.expires
+
+        return False
+
+    @property
+    def refresh_token_expired(self):
+        """True if this refresh token has expired, False otherwise."""
+        if self.refresh_token_expires:
+            return datetime.datetime.utcnow() > self.refresh_token_expires
 
         return False
 

--- a/h/models/token.py
+++ b/h/models/token.py
@@ -49,6 +49,11 @@ class Token(Base, mixins.Timestamps):
                                       unique=True,
                                       nullable=True)
 
+    #: A timestamp after which this token's refresh token will no longer be
+    #: considered valid. A NULL value in this column indicates a refresh token
+    #: that does not expire.
+    refresh_token_expires = sqlalchemy.Column(sqlalchemy.DateTime, nullable=True)
+
     _authclient_id = sqlalchemy.Column('authclient_id',
                                        postgresql.UUID(),
                                        sqlalchemy.ForeignKey('authclient.id', ondelete='cascade'),

--- a/h/oauth/__init__.py
+++ b/h/oauth/__init__.py
@@ -9,8 +9,10 @@ from h.oauth.errors import (
 )
 from h.oauth.jwt_grant import JWTAuthorizationGrant
 from h.oauth.jwt_grant_token import JWTGrantToken
+from h.oauth.tokens import BearerToken
 
 __all__ = (
+    'BearerToken',
     'JWTAuthorizationGrant',
     'JWTGrantToken',
     'InvalidJWTGrantTokenClaimError',

--- a/h/oauth/tokens.py
+++ b/h/oauth/tokens.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from oauthlib.oauth2 import BearerToken as OAuthlibBearerToken
+
+
+class BearerToken(OAuthlibBearerToken):
+    def __init__(self, request_validator=None, token_generator=None,
+                 expires_in=None, refresh_token_generator=None,
+                 refresh_token_expires_in=None):
+        super(BearerToken, self).__init__(request_validator=request_validator,
+                                          token_generator=token_generator,
+                                          expires_in=expires_in,
+                                          refresh_token_generator=refresh_token_generator)
+
+        self.refresh_token_expires_in = refresh_token_expires_in
+
+    def create_token(self, request, refresh_token=False, save_token=True):
+        if request.extra_credentials is None:
+            request.extra_credentials = {}
+        request.extra_credentials['refresh_token_expires_in'] = self.refresh_token_expires_in
+
+        return super(BearerToken, self).create_token(request,
+                                                     refresh_token=refresh_token,
+                                                     save_token=save_token)

--- a/h/services/oauth_provider.py
+++ b/h/services/oauth_provider.py
@@ -7,18 +7,22 @@ import datetime
 from oauthlib.oauth2 import (
     AuthorizationCodeGrant,
     AuthorizationEndpoint,
-    BearerToken,
     RefreshTokenGrant,
     RevocationEndpoint,
     TokenEndpoint,
 )
 
-from h.oauth import InvalidRefreshTokenError, JWTAuthorizationGrant
+from h.oauth import (
+    BearerToken,
+    InvalidRefreshTokenError,
+    JWTAuthorizationGrant,
+)
 from h.security import token_urlsafe
 
-TOKEN_TTL = datetime.timedelta(hours=1).total_seconds()
 ACCESS_TOKEN_PREFIX = '5768-'
+ACCESS_TOKEN_TTL = datetime.timedelta(hours=1).total_seconds()
 REFRESH_TOKEN_PREFIX = '4657-'
+REFRESH_TOKEN_TTL = datetime.timedelta(days=7).total_seconds()
 
 
 class OAuthProviderService(AuthorizationEndpoint, RevocationEndpoint, TokenEndpoint):
@@ -44,8 +48,9 @@ class OAuthProviderService(AuthorizationEndpoint, RevocationEndpoint, TokenEndpo
 
         bearer = BearerToken(oauth_validator,
                              token_generator=self.generate_access_token,
-                             expires_in=TOKEN_TTL,
-                             refresh_token_generator=self.generate_refresh_token)
+                             expires_in=ACCESS_TOKEN_TTL,
+                             refresh_token_generator=self.generate_refresh_token,
+                             refresh_token_expires_in=REFRESH_TOKEN_TTL)
 
         AuthorizationEndpoint.__init__(self,
                                        default_response_type='code',

--- a/h/services/oauth_validator.py
+++ b/h/services/oauth_validator.py
@@ -172,10 +172,16 @@ class OAuthValidatorService(RequestValidator):
 
     def save_bearer_token(self, token, request, *args, **kwargs):
         """Saves a generated bearer token for the authenticated user to the database."""
+        expires = utcnow() + datetime.timedelta(seconds=token['expires_in'])
+
+        refresh_token_expires = utcnow() + datetime.timedelta(seconds=token['refresh_token_expires_in'])
+        del token['refresh_token_expires_in']  # We don't want to render this in the response.
+
         oauth_token = models.Token(userid=request.user.userid,
                                    value=token['access_token'],
                                    refresh_token=token['refresh_token'],
-                                   expires=(utcnow() + datetime.timedelta(seconds=token['expires_in'])),
+                                   expires=expires,
+                                   refresh_token_expires=refresh_token_expires,
                                    authclient=request.client.authclient)
         self.session.add(oauth_token)
         return oauth_token

--- a/h/services/oauth_validator.py
+++ b/h/services/oauth_validator.py
@@ -253,7 +253,7 @@ class OAuthValidatorService(RequestValidator):
         """
         token = self.find_refresh_token(refresh_token)
 
-        if not token or token.expired or token.authclient.id != client.client_id:
+        if not token or token.refresh_token_expired or token.authclient.id != client.client_id:
             return False
 
         request.user = self.user_svc.fetch(token.userid)

--- a/h/tasks/cleanup.py
+++ b/h/tasks/cleanup.py
@@ -45,8 +45,10 @@ def purge_expired_authz_codes():
 
 @celery.task
 def purge_expired_tokens():
+    now = datetime.utcnow()
     celery.request.db.query(models.Token) \
-        .filter(models.Token.expires < datetime.utcnow()) \
+        .filter(models.Token.expires < now,
+                models.Token.refresh_token_expires < now) \
         .delete()
 
 

--- a/tests/common/factories/token.py
+++ b/tests/common/factories/token.py
@@ -34,4 +34,5 @@ class OAuth2Token(ModelFactory):
     value = factory.LazyAttribute(lambda _: (ACCESS_TOKEN_PREFIX + security.token_urlsafe()))
     refresh_token = factory.LazyAttribute(lambda _: (REFRESH_TOKEN_PREFIX + security.token_urlsafe()))
     expires = factory.LazyAttribute(lambda _: (datetime.utcnow() + timedelta(hours=1)))
+    refresh_token_expires = factory.LazyAttribute(lambda _: (datetime.utcnow() + timedelta(days=7)))
     authclient = factory.SubFactory(AuthClient)

--- a/tests/h/models/token_test.py
+++ b/tests/h/models/token_test.py
@@ -37,6 +37,23 @@ class TestToken(object):
 
         assert token.expired is True
 
+    def test_refresh_token_expired_is_false_if_in_future(self):
+        refresh_token_expires = datetime.datetime.utcnow() + datetime.timedelta(hours=1)
+        token = Token(refresh_token_expires=refresh_token_expires)
+
+        assert token.refresh_token_expired is False
+
+    def test_refresh_token_expired_is_false_if_none(self):
+        token = Token(refresh_token_expires=None)
+
+        assert token.refresh_token_expired is False
+
+    def test_refresh_token_expired_is_true_if_in_past(self):
+        refresh_token_expires = datetime.datetime.utcnow() - datetime.timedelta(hours=1)
+        token = Token(refresh_token_expires=refresh_token_expires)
+
+        assert token.refresh_token_expired is True
+
     @pytest.fixture
     def security(self, patch):
         security = patch('h.models.token.security')

--- a/tests/h/oauth/tokens_test.py
+++ b/tests/h/oauth/tokens_test.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import pytest
+import mock
+
+from oauthlib.common import Request as OAuthRequest
+
+from h.oauth.tokens import BearerToken
+
+
+class TestBearerToken(object):
+    @pytest.mark.parametrize('attr', [
+        'request_validator',
+        'token_generator',
+        'expires_in',
+        'refresh_token_generator',
+        'refresh_token_expires_in'
+    ])
+    def test_init_sets_instance_vars(self, attr):
+        value = mock.Mock()
+        token = BearerToken(**{attr: value})
+        assert getattr(token, attr) == value
+
+    def test_create_token_sets_refresh_token_expires_in(self, oauth_request):
+        value = mock.Mock()
+        token = BearerToken(request_validator=mock.Mock(), refresh_token_expires_in=value)
+
+        assert oauth_request.extra_credentials is None
+        token.create_token(oauth_request)
+        assert oauth_request.extra_credentials.get('refresh_token_expires_in') == value
+
+    def test_create_token_does_not_override_extras(self, oauth_request):
+        value = mock.Mock()
+        token = BearerToken(request_validator=mock.Mock(), refresh_token_expires_in=value)
+
+        oauth_request.extra_credentials = {'foo': 'bar'}
+        token.create_token(oauth_request)
+        assert oauth_request.extra_credentials.get('refresh_token_expires_in') == value
+        assert oauth_request.extra_credentials.get('foo') == 'bar'
+
+    @pytest.fixture
+    def oauth_request(self):
+        return OAuthRequest('/')

--- a/tests/h/services/oauth_validator_test.py
+++ b/tests/h/services/oauth_validator_test.py
@@ -439,8 +439,8 @@ class TestValidateRefreshToken(object):
         result = svc.validate_refresh_token('missing', client, oauth_request)
         assert result is False
 
-    def test_returns_false_when_token_expired(self, svc, client, oauth_request, token):
-        token.expires = datetime.datetime.utcnow() - datetime.timedelta(minutes=2)
+    def test_returns_false_when_refresh_token_expired(self, svc, client, oauth_request, token):
+        token.refresh_token_expires = datetime.datetime.utcnow() - datetime.timedelta(minutes=2)
         result = svc.validate_refresh_token(token.refresh_token, client, oauth_request)
         assert result is False
 
@@ -450,6 +450,11 @@ class TestValidateRefreshToken(object):
         assert result is False
 
     def test_returns_true_when_token_valid(self, svc, client, oauth_request, token):
+        result = svc.validate_refresh_token(token.refresh_token, client, oauth_request)
+        assert result is True
+
+    def test_returns_true_when_access_token_expired(self, svc, client, oauth_request, token):
+        token.expires = datetime.datetime.utcnow() - datetime.timedelta(minutes=2)
         result = svc.validate_refresh_token(token.refresh_token, client, oauth_request)
         assert result is True
 

--- a/tests/h/services/oauth_validator_test.py
+++ b/tests/h/services/oauth_validator_test.py
@@ -304,9 +304,20 @@ class TestSaveBearerToken(object):
         token = svc.save_bearer_token(token_payload, oauth_request)
         assert token.expires == datetime.datetime(2017, 7, 13, 19, 29, 28)
 
+    def test_it_sets_refresh_token_expires(self, svc, token_payload, oauth_request, utcnow):
+        utcnow.return_value = datetime.datetime(2017, 7, 13, 18, 29, 28)
+
+        token = svc.save_bearer_token(token_payload, oauth_request)
+        assert token.refresh_token_expires == datetime.datetime(2017, 7, 13, 20, 29, 28)
+
     def test_it_sets_authclient(self, svc, token_payload, oauth_request):
         token = svc.save_bearer_token(token_payload, oauth_request)
         assert token.refresh_token == 'test-refresh-token'
+
+    def test_it_removes_refresh_token_expires_in_from_payload(self, svc, token_payload, oauth_request):
+        assert 'refresh_token_expires_in' in token_payload
+        svc.save_bearer_token(token_payload, oauth_request)
+        assert 'refresh_token_expires_in' not in token_payload
 
     @pytest.fixture
     def oauth_request(self, factories):
@@ -319,6 +330,7 @@ class TestSaveBearerToken(object):
             'access_token': 'test-access-token',
             'refresh_token': 'test-refresh-token',
             'expires_in': 3600,
+            'refresh_token_expires_in': 7200,
         }
 
 


### PR DESCRIPTION
The rest of hypothesis/product-backlog#329.

This will separate the expiration times of tokens, allowing the refresh token to be valid for much longer than the access token. For more detailed descriptions please refer to the individual commit messages.
