### PR TITLE
Check authclient grant type in user creation API

### DIFF
--- a/h/schemas/auth_client.py
+++ b/h/schemas/auth_client.py
@@ -29,7 +29,8 @@ class CreateAuthClientSchema(CSRFSchema):
                                      missing=None,
                                      title=_('Grant type'),
                                      hint=_('"authorization_code" for most applications, '
-                                            '"jwt_bearer" for keys for JWT grants used by publishers'))
+                                            '"jwt_bearer" for keys for JWT grants used by publishers, '
+                                            '"client_credentials" for allowing access to the user creation API'))
 
     trusted = colander.SchemaNode(
                 colander.Boolean(),

--- a/h/views/admin_oauthclients.py
+++ b/h/views/admin_oauthclients.py
@@ -59,7 +59,7 @@ class AuthClientCreateController(object):
         def on_success(appstruct):
             grant_type = appstruct['grant_type']
 
-            if grant_type == GrantType.jwt_bearer:
+            if grant_type in [GrantType.jwt_bearer, GrantType.client_credentials]:
                 secret = self.secret_gen()
             else:
                 secret = None

--- a/h/views/api_users.py
+++ b/h/views/api_users.py
@@ -10,6 +10,7 @@ from h import models
 from h.accounts import schemas
 from h.auth.util import basic_auth_creds
 from h.exceptions import ClientUnauthorized
+from h.models.auth_client import GrantType
 from h.schemas import ValidationError
 from h.util.view import json_view
 
@@ -88,6 +89,8 @@ def _request_client(request):
     if client is None:
         raise ClientUnauthorized()
     if client.secret is None:  # client is not confidential
+        raise ClientUnauthorized()
+    if client.grant_type != GrantType.client_credentials:  # client not allowed to create users
         raise ClientUnauthorized()
 
     if not hmac.compare_digest(client.secret, client_secret):

--- a/tests/h/views/admin_oauthclients_test.py
+++ b/tests/h/views/admin_oauthclients_test.py
@@ -94,6 +94,17 @@ class TestAuthClientCreateController(object):
         client = pyramid_request.db.query(AuthClient).one()
         assert client.secret == 'keep-me-secret'
 
+    def test_post_generates_secret_for_client_credentials_clients(self, form_post, pyramid_request):
+        pyramid_request.POST = form_post
+        pyramid_request.POST['grant_type'] = 'client_credentials'
+        secret_gen = Mock(return_value='keep-me-secret')
+        ctrl = AuthClientCreateController(pyramid_request, secret_gen=secret_gen)
+
+        ctrl.post()
+
+        client = pyramid_request.db.query(AuthClient).one()
+        assert client.secret == 'keep-me-secret'
+
     def test_post_does_not_generate_secret_for_authcode_clients(self, form_post, pyramid_request):
         pyramid_request.POST = form_post
         pyramid_request.POST['grant_type'] = 'authorization_code'


### PR DESCRIPTION
We currently allow any confidential auth client to create users in their
authority. This is a bad idea.

I've opted for checking that the configured grant type is
`client_credentials` and only then allowing these auth clients to create
users.
This works for now as we don't use the `client_credentials` grant type,
but once we do support it the way it is meant to be used by the spec, we
should rethink this and maybe add a boolean field for this.