### PR TITLE
Configure oauth endpoints in `/api/links` response

### DIFF
--- a/h/views/api.py
+++ b/h/views/api.py
@@ -161,12 +161,17 @@ def links(context, request):
     user_url = request.route_url('stream.user_query', user='_user_')
     user_url = user_url.replace('_user_', ':user')
 
+    oauth_authorize_url = request.route_url('oauth_authorize')
+    oauth_revoke_url = request.route_url('oauth_revoke')
+
     return {
         'account.settings': request.route_url('account'),
         'forgot-password': request.route_url('forgot_password'),
         'groups.leave': group_leave_url,
         'groups.new': request.route_url('group_create'),
         'help': request.route_url('help'),
+        'oauth.authorize': oauth_authorize_url,
+        'oauth.revoke': oauth_revoke_url,
         'search.tag': tag_search_url,
         'signup': request.route_url('signup'),
         'user': user_url,

--- a/tests/h/views/api_test.py
+++ b/tests/h/views/api_test.py
@@ -132,6 +132,8 @@ class TestLinks(object):
         pyramid_config.add_route('group_leave', '/groups/{pubid}/leave')
         pyramid_config.add_route('group_create', '/groups/new')
         pyramid_config.add_route('help', '/docs/help')
+        pyramid_config.add_route('oauth_authorize', '/oauth/authorize')
+        pyramid_config.add_route('oauth_revoke', '/oauth/revoke')
         pyramid_config.add_route('activity.search', '/search')
         pyramid_config.add_route('signup', '/signup')
         pyramid_config.add_route('stream.user_query', '/u/{user}')
@@ -145,6 +147,8 @@ class TestLinks(object):
             'groups.leave': host + '/groups/:id/leave',
             'groups.new': host + '/groups/new',
             'help': host + '/docs/help',
+            'oauth.authorize': host + '/oauth/authorize',
+            'oauth.revoke': host + '/oauth/revoke',
             'search.tag': host + '/search?q=tag:":tag"',
             'signup': host + '/signup',
             'user': host + '/u/:user',


### PR DESCRIPTION
So they can be discovered by the client.