### PR TITLE
Fix CORS preflight requests for authenticated API views

### DIFF
--- a/h/util/cors.py
+++ b/h/util/cors.py
@@ -6,7 +6,6 @@ from pyramid.response import Response
 def policy(allow_credentials=False,
            allow_headers=None,
            allow_methods=None,
-           allow_preflight=False,
            expose_headers=None,
            max_age=86400):
     """
@@ -28,10 +27,7 @@ def policy(allow_credentials=False,
 
     def cors_decorator(wrapped):
         def wrapper(context, request):
-            if allow_preflight and request.method == 'OPTIONS':
-                response = Response()
-            else:
-                response = wrapped(context, request)
+            response = wrapped(context, request)
             return set_cors_headers(request, response,
                                     allow_credentials=allow_credentials,
                                     allow_headers=allow_headers,

--- a/h/util/cors.py
+++ b/h/util/cors.py
@@ -106,10 +106,10 @@ def add_preflight_view(config, route_name, cors_policy):
     # For a given route there may be multiple views with different predicates
     # (eg. to handle authenticated vs unauthenticated users). However we only
     # want one preflight view.
-    if not hasattr(config.registry, 'preflighted_views'):
-        config.registry.preflighted_views = set()
+    if not hasattr(config.registry, 'cors_preflighted_views'):
+        config.registry.cors_preflighted_views = set()
 
-    if route_name in config.registry.preflighted_views:
+    if route_name in config.registry.cors_preflighted_views:
         return
 
     def preflight_view(context, request):
@@ -117,4 +117,4 @@ def add_preflight_view(config, route_name, cors_policy):
 
     config.add_view(preflight_view, decorator=cors_policy,
                     route_name=route_name, request_method='OPTIONS')
-    config.registry.preflighted_views.add(route_name)
+    config.registry.cors_preflighted_views.add(route_name)

--- a/h/util/cors.py
+++ b/h/util/cors.py
@@ -10,11 +10,20 @@ def policy(allow_credentials=False,
            expose_headers=None,
            max_age=86400):
     """
-    View decorator that provides CORS support.
+    View decorator factory that provides CORS support.
 
     CORS stands for "Cross-Origin Resource Sharing," and is a protocol
     implemented in browsers to allow safe dispatch of XMLHttpRequests across
     origins.
+
+    To CORS-enable a view:
+
+     1. Create a decorator using this function and set it as the view's
+        decorator when calling `add_view`.
+     2. To support requests that do not qualify as "simple requests" [1], add a
+        preflight view using `add_preflight_view`.
+
+    [1] https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS#Simple_requests
     """
 
     def cors_decorator(wrapped):
@@ -87,3 +96,29 @@ def set_cors_headers(request, response,
         headers['Access-Control-Expose-Headers'] = ', '.join(expose_headers)
 
     return response
+
+
+def add_preflight_view(config, route_name, cors_policy):
+    """
+    Add a view to handle CORS preflight requests for a given route.
+
+    :param route_name: The route
+    :param cors_policy: CORS policy created via a call to `policy`.
+    """
+    # Keep track of which routes already have preflight views registered.
+    #
+    # For a given route there may be multiple views with different predicates
+    # (eg. to handle authenticated vs unauthenticated users). However we only
+    # want one preflight view.
+    if not hasattr(config.registry, 'preflighted_views'):
+        config.registry.preflighted_views = set()
+
+    if route_name in config.registry.preflighted_views:
+        return
+
+    def preflight_view(context, request):
+        return Response()
+
+    config.add_view(preflight_view, decorator=cors_policy,
+                    route_name=route_name, request_method='OPTIONS')
+    config.registry.preflighted_views.add(route_name)

--- a/h/util/view.py
+++ b/h/util/view.py
@@ -11,8 +11,7 @@ cors_policy = cors.policy(
         'Authorization',
         'Content-Type',
     ),
-    allow_methods=('HEAD', 'GET', 'POST', 'PUT', 'DELETE'),
-    allow_preflight=True)
+    allow_methods=('HEAD', 'GET', 'POST', 'PUT', 'DELETE'))
 
 
 def handle_exception(request):

--- a/h/util/view.py
+++ b/h/util/view.py
@@ -4,15 +4,6 @@ from __future__ import unicode_literals
 
 from pyramid.view import view_config
 
-from h.util import cors
-
-cors_policy = cors.policy(
-    allow_headers=(
-        'Authorization',
-        'Content-Type',
-    ),
-    allow_methods=('HEAD', 'GET', 'POST', 'PUT', 'DELETE'))
-
 
 def handle_exception(request):
     """Handle an uncaught exception for the passed request."""
@@ -29,21 +20,3 @@ def json_view(**settings):
     settings.setdefault('accept', 'application/json')
     settings.setdefault('renderer', 'json')
     return view_config(**settings)
-
-
-def cors_json_view(**settings):
-    """
-    A view configuration decorator with JSON defaults and CORS.
-
-    CORS with Authorization and Content-Type headers.
-    """
-    settings.setdefault('decorator', cors_policy)
-
-    request_method = settings.get('request_method', ())
-    if not isinstance(request_method, tuple):
-        request_method = (request_method,)
-    if len(request_method) == 0:
-        request_method = ('DELETE', 'GET', 'HEAD', 'POST', 'PUT',)
-    settings['request_method'] = request_method + ('OPTIONS',)
-
-    return json_view(**settings)

--- a/h/views/api.py
+++ b/h/views/api.py
@@ -32,8 +32,6 @@ from h.util import cors
 
 _ = i18n.TranslationStringFactory(__package__)
 
-# FIXME: unify (or at least deduplicate) CORS policy between this file and
-#        `h.util.view`
 cors_policy = cors.policy(
     allow_headers=(
         'Authorization',
@@ -44,7 +42,8 @@ cors_policy = cors.policy(
     allow_methods=('HEAD', 'GET', 'PATCH', 'POST', 'PUT', 'DELETE'))
 
 
-def add_api_view(config, view, link_name=None, description=None, **settings):
+def add_api_view(config, view, link_name=None, description=None,
+                 enable_preflight=True, **settings):
 
     """
     Add a view configuration for an API view.
@@ -59,6 +58,9 @@ def add_api_view(config, view, link_name=None, description=None, **settings):
     :param link_name: Dotted path of the metadata for this route in the output
                       of the `api.index` view
     :param description: Description of the view to use in the `api.index` view
+    :param enable_preflight: If `True` add support for CORS preflight requests
+                             for this view. If `True`, a `route_name` must be
+                             specified.
     :param settings: Arguments to pass on to `config.add_view`
     """
 
@@ -86,7 +88,8 @@ def add_api_view(config, view, link_name=None, description=None, **settings):
         registry.api_links.append(link)
 
     config.add_view(view=view, **settings)
-    cors.add_preflight_view(config, settings['route_name'], cors_policy)
+    if enable_preflight:
+        cors.add_preflight_view(config, settings['route_name'], cors_policy)
 
 
 def api_config(link_name=None, description=None, **settings):

--- a/h/views/api.py
+++ b/h/views/api.py
@@ -79,7 +79,7 @@ def add_api_view(config, view, link_name=None, description=None, **settings):
         request_method = (request_method,)
     if len(request_method) == 0:
         request_method = ('DELETE', 'GET', 'HEAD', 'PATCH', 'POST', 'PUT',)
-    settings['request_method'] = request_method + ('OPTIONS',)
+    settings['request_method'] = request_method
 
     if link_name:
         link = {'name': link_name,
@@ -94,6 +94,7 @@ def add_api_view(config, view, link_name=None, description=None, **settings):
         registry.api_links.append(link)
 
     config.add_view(view=view, **settings)
+    cors.add_preflight_view(config, settings['route_name'], cors_policy)
 
 
 def api_config(link_name=None, description=None, **settings):

--- a/h/views/api.py
+++ b/h/views/api.py
@@ -105,7 +105,14 @@ def api_config(link_name=None, description=None, **settings):
                      **settings)
 
     def wrapper(wrapped):
-        venusian.attach(wrapped, callback, category='pyramid')
+        info = venusian.attach(wrapped, callback, category='pyramid')
+
+        # Support use as a class method decorator.
+        # Taken from Pyramid's `view_config` decorator implementation.
+        if info.scope == 'class':
+            if settings.get('attr') is None:
+                settings['attr'] = wrapped.__name__
+
         return wrapped
 
     return wrapper

--- a/h/views/api.py
+++ b/h/views/api.py
@@ -73,13 +73,6 @@ def add_api_view(config, view, link_name=None, description=None, **settings):
     settings.setdefault('renderer', 'json')
     settings.setdefault('decorator', cors_policy)
 
-    request_method = settings.get('request_method', ())
-    if not isinstance(request_method, tuple):
-        request_method = (request_method,)
-    if len(request_method) == 0:
-        request_method = ('DELETE', 'GET', 'HEAD', 'PATCH', 'POST', 'PUT',)
-    settings['request_method'] = request_method
-
     if link_name:
         link = {'name': link_name,
                 'method': primary_method,

--- a/h/views/api.py
+++ b/h/views/api.py
@@ -41,8 +41,7 @@ cors_policy = cors.policy(
         'X-Annotator-Auth-Token',
         'X-Client-Id',
     ),
-    allow_methods=('HEAD', 'GET', 'PATCH', 'POST', 'PUT', 'DELETE'),
-    allow_preflight=True)
+    allow_methods=('HEAD', 'GET', 'PATCH', 'POST', 'PUT', 'DELETE'))
 
 
 def add_api_view(config, view, link_name=None, description=None, **settings):

--- a/h/views/api_auth.py
+++ b/h/views/api_auth.py
@@ -15,7 +15,7 @@ from h._compat import urlparse
 from h.exceptions import OAuthTokenError
 from h.services.oauth_validator import DEFAULT_SCOPES
 from h.util.datetime import utc_iso8601
-from h.util.view import cors_json_view
+from h.views.api import api_config
 
 log = logging.getLogger(__name__)
 
@@ -170,7 +170,7 @@ class OAuthAccessTokenController(object):
 
         self.oauth = self.request.find_service(name='oauth_provider')
 
-    @cors_json_view(route_name='token', request_method='POST')
+    @api_config(route_name='token', request_method='POST')
     def post(self):
         headers, body, status = self.oauth.create_token_response(
             self.request.url, self.request.method, self.request.POST, self.request.headers)
@@ -180,14 +180,13 @@ class OAuthAccessTokenController(object):
             raise exception_response(status, body=body)
 
 
-@view_defaults(route_name='oauth_revoke')
 class OAuthRevocationController(object):
     def __init__(self, request):
         self.request = request
 
         self.oauth = self.request.find_service(name='oauth_provider')
 
-    @cors_json_view(request_method='POST')
+    @api_config(route_name='oauth_revoke', request_method='POST')
     def post(self):
         headers, body, status = self.oauth.create_revocation_response(
             self.request.url, self.request.method, self.request.POST, self.request.headers)
@@ -197,7 +196,7 @@ class OAuthRevocationController(object):
             raise exception_response(status, body=body)
 
 
-@cors_json_view(route_name='api.debug_token', request_method='GET')
+@api_config(route_name='api.debug_token', request_method='GET')
 def debug_token(request):
     if not request.auth_token:
         raise OAuthTokenError('Bearer token is missing in Authorization HTTP header',
@@ -215,7 +214,10 @@ def debug_token(request):
     return _present_debug_token(token)
 
 
-@cors_json_view(context=OAuthTokenError)
+@api_config(context=OAuthTokenError,
+            # This is a handler called only if a request fails, so the CORS
+            # preflight request will have been handled by the original view.
+            enable_preflight=False)
 def api_token_error(context, request):
     """Handle an expected/deliberately thrown API exception."""
     request.response.status_code = context.status_code

--- a/tests/functional/test_oauth.py
+++ b/tests/functional/test_oauth.py
@@ -124,6 +124,30 @@ class TestOAuth(object):
             status=401,
         )
 
+    def test_revoke_token(self, app, authclient, userid):
+        response = self.get_access_token(app, authclient, userid)
+        refresh_token = response['refresh_token']
+
+        app.post(
+            '/oauth/revoke',
+            {
+                'token': refresh_token,
+            },
+            status=200,
+        )
+
+    @pytest.mark.parametrize('method, path', [
+        ('POST', '/api/token'),
+        ('POST', '/oauth/revoke'),
+    ])
+    def test_oauth_routes_support_cors_preflight(self, app, method, path):
+        app.options(
+            path,
+            headers={'Origin': str('https://third-party-client.herokuapp.com'),
+                     'Access-Control-Request-Method': str(method)},
+            status=200,
+        )
+
     def get_access_token(self, app, authclient, userid):
         """Get an access token by POSTing a grant token to /api/token."""
         claims = {

--- a/tests/h/util/view_test.py
+++ b/tests/h/util/view_test.py
@@ -5,7 +5,7 @@ from __future__ import unicode_literals
 import pytest
 from mock import Mock
 
-from h.util.view import handle_exception, json_view, cors_json_view
+from h.util.view import handle_exception, json_view
 
 
 class TestHandleException(object):
@@ -73,36 +73,3 @@ class TestJsonView(object):
         view_config = patch('h.util.view.view_config')
         view_config.side_effect = _return_kwargs
         return view_config
-
-
-@pytest.mark.usefixtures('json_view')
-class TestCorsJsonView(object):
-    def test_it_uses_json_view(self, json_view):
-        json_view.side_effect = None
-
-        settings = cors_json_view()
-        assert settings == json_view.return_value
-
-    def test_it_sets_cors_decorator(self, cors_policy):
-        settings = cors_json_view()
-        assert settings['decorator'] == cors_policy
-
-    def test_it_adds_OPTIONS_to_allowed_request_methods(self):
-        settings = cors_json_view(request_method='POST')
-        assert settings['request_method'] == ('POST', 'OPTIONS')
-
-    def test_it_adds_all_request_methods_when_not_defined(self):
-        settings = cors_json_view()
-        assert settings['request_method'] == ('DELETE', 'GET', 'HEAD', 'POST', 'PUT', 'OPTIONS')
-
-    @pytest.fixture
-    def json_view(self, patch):
-        def _return_kwargs(**kwargs):
-            return kwargs
-        json_view = patch('h.util.view.json_view')
-        json_view.side_effect = _return_kwargs
-        return json_view
-
-    @pytest.fixture
-    def cors_policy(self, patch):
-        return patch('h.util.view.cors_policy')

--- a/tests/h/views/api_test.py
+++ b/tests/h/views/api_test.py
@@ -51,12 +51,6 @@ class TestAddApiView(object):
         (_, kwargs) = pyramid_config.add_view.call_args
         assert kwargs['decorator'] == decorator
 
-    def test_it_adds_all_request_methods_when_not_defined(self, pyramid_config, view):
-        views.add_api_view(pyramid_config, view, route_name='thing.read')
-        (_, kwargs) = pyramid_config.add_view.call_args
-        assert kwargs['request_method'] == (
-            'DELETE', 'GET', 'HEAD', 'PATCH', 'POST', 'PUT')
-
     @pytest.mark.parametrize('link_name,description,request_method,expected_method', [
         ('thing.read', 'Fetch a thing', None, 'GET'),
         ('thing.update', 'Update a thing', ('PUT', 'PATCH'), 'PUT'),

--- a/tests/h/views/api_test.py
+++ b/tests/h/views/api_test.py
@@ -45,6 +45,11 @@ class TestAddApiView(object):
         assert route_name == 'thing.read'
         assert policy == views.cors_policy
 
+    def test_it_does_not_add_cors_preflight_view_if_disabled(self, pyramid_config, view, cors):
+        views.add_api_view(pyramid_config, view, route_name='thing.read',
+                           enable_preflight=False)
+        assert cors.add_preflight_view.call_count == 0
+
     def test_it_allows_decorator_override(self, pyramid_config, view):
         decorator = mock.Mock()
         views.add_api_view(pyramid_config, view, route_name='thing.read', decorator=decorator)


### PR DESCRIPTION
CORS preflight OPTIONS requests were failing for routes such as `POST
/api/annotations` because the `effective_principals=security.Authenticated` view
predicate was applied to both the POST request and the OPTIONS request. The
browser does not send the Authorization header with the OPTIONS request so the
route failed to match and the OPTIONS request 404-ed.

This prevents people from actually making use of the OAuth implementation to create browser-based clients for h which are hosted on domains other than https://hypothes.is, if those clients do more than just read data 😛

Fix the problem by registering a separate view to handle preflight requests,
which does not inherit any of the predicates applied to the actual view itself.

**Testing**

```
 curl -i -XOPTIONS 'http://localhost:5000/api/annotations' -H 'Origin:http://foo.com' -H'Access-Control-Request-Method: POST'
```

Before: Returns a 404 response
After: Returns a 200 response