### PR TITLE
Cleanup and de-duplicate CORS policy

### DIFF
--- a/h/util/view.py
+++ b/h/util/view.py
@@ -10,8 +10,9 @@ cors_policy = cors.policy(
     allow_headers=(
         'Authorization',
         'Content-Type',
+        'X-Client-Id',
     ),
-    allow_methods=('HEAD', 'GET', 'POST', 'PUT', 'DELETE'),
+    allow_methods=('HEAD', 'GET', 'PATCH', 'POST', 'PUT', 'DELETE'),
     allow_preflight=True)
 
 

--- a/h/views/api.py
+++ b/h/views/api.py
@@ -29,20 +29,9 @@ from h.presenters import AnnotationJSONPresenter, AnnotationJSONLDPresenter
 from h.resources import AnnotationResource
 from h.schemas.annotation import CreateAnnotationSchema, UpdateAnnotationSchema
 from h.util import cors
+from h.util.view import cors_policy
 
 _ = i18n.TranslationStringFactory(__package__)
-
-# FIXME: unify (or at least deduplicate) CORS policy between this file and
-#        `h.util.view`
-cors_policy = cors.policy(
-    allow_headers=(
-        'Authorization',
-        'Content-Type',
-        'X-Annotator-Auth-Token',
-        'X-Client-Id',
-    ),
-    allow_methods=('HEAD', 'GET', 'PATCH', 'POST', 'PUT', 'DELETE'),
-    allow_preflight=True)
 
 
 def add_api_view(config, view, link_name=None, description=None, **settings):


### PR DESCRIPTION
We had two different sets of CORS policies in the codebase, one used for the API views and one used for the OAuth token views.

There was a FIXME to deduplicate them and I couldn't see any reason to keep them separate. A consequence of de-duplicating them is that the `X-Client-Id` header, which is sent by the client on every request to identify the client session, is now allowed for the OAuth token views.

Together with https://github.com/hypothesis/h/pull/4626, this makes it possible to run a custom build of the Hypothesis client served from a non-hypothes.is domain, which is a good test case for a third-party OAuth client, against the production service.

 - Remove duplicated CORS definitions
 - Allow 'X-Client-Id' header for all CORS views. The client
   sets this per-session ID for all HTTP requests it makes.
 - Remove unused 'X-Annotator-Auth-Token' header