### PR TITLE
Use case-insensitive check for email when logging in

### DIFF
--- a/tests/h/services/user_test.py
+++ b/tests/h/services/user_test.py
@@ -27,6 +27,7 @@ class TestUserService(object):
     def test_fetch_for_login_by_email(self, svc, users):
         _, steve, _ = users
         assert svc.fetch_for_login('steve@steveo.com') is steve
+        assert svc.fetch_for_login('StEvE@steveo.COM') is steve
 
     def test_fetch_for_login_by_username_wrong_authority(self, svc):
         assert svc.fetch_for_login('jacqui') is None


### PR DESCRIPTION
Thought I'd give a stab at this - following on from https://github.com/hypothesis/h/issues/4443#issuecomment-288034702, the login flow will no longer reject emails based on case sensitivity. At least, I think that's what was the proposed outcome of that ticket :sweat_smile: 