### PR TITLE
Add a way to leave groups through the API

### DIFF
--- a/h/routes.py
+++ b/h/routes.py
@@ -97,7 +97,7 @@ def includeme(config):
     config.add_route('api.profile', '/api/profile')
     config.add_route('api.debug_token', '/api/debug-token')
     config.add_route('api.group_member',
-                     '/api/groups/{pubid}/members/me',
+                     '/api/groups/{pubid}/members/{user}',
                      factory='h.models.group:GroupFactory',
                      traverse='/{pubid}')
     config.add_route('api.search', '/api/search')

--- a/h/routes.py
+++ b/h/routes.py
@@ -96,6 +96,10 @@ def includeme(config):
                      traverse='/{id}')
     config.add_route('api.profile', '/api/profile')
     config.add_route('api.debug_token', '/api/debug-token')
+    config.add_route('api.group_member',
+                     '/api/groups/{pubid}/members/me',
+                     factory='h.models.group:GroupFactory',
+                     traverse='/{pubid}')
     config.add_route('api.search', '/api/search')
     config.add_route('api.users', '/api/users')
     config.add_route('badge', '/api/badge')

--- a/h/views/api.py
+++ b/h/views/api.py
@@ -44,7 +44,8 @@ def index(context, request):
     # paths and pass these explicitly into the templater. As and when new
     # parameter names are added, we'll need to add them here, or this view will
     # break (and get caught by the `test_api_index` functional test).
-    templater = AngularRouteTemplater(request.route_url, params=['id'])
+    templater = AngularRouteTemplater(request.route_url,
+                                      params=['id', 'pubid'])
 
     links = {}
     for link in api_links:

--- a/h/views/api.py
+++ b/h/views/api.py
@@ -45,7 +45,7 @@ def index(context, request):
     # parameter names are added, we'll need to add them here, or this view will
     # break (and get caught by the `test_api_index` functional test).
     templater = AngularRouteTemplater(request.route_url,
-                                      params=['id', 'pubid'])
+                                      params=['id', 'pubid', 'user'])
 
     links = {}
     for link in api_links:

--- a/h/views/api_groups.py
+++ b/h/views/api_groups.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from pyramid import security
+from pyramid.httpexceptions import HTTPNoContent
+
+from h.views.api import api_config
+
+
+@api_config(route_name='api.group_member',
+            request_method='DELETE',
+            link_name='group.member.delete',
+            description='Remove the current user from a group.',
+            effective_principals=security.Authenticated)
+def remove_member(group, request):
+    """Remove a member from the given group."""
+
+    # Currently, we only support removing the requesting user
+    userid = request.authenticated_userid
+
+    group_service = request.find_service(name='group')
+    group_service.member_leave(group, userid)
+
+    return HTTPNoContent()

--- a/h/views/api_groups.py
+++ b/h/views/api_groups.py
@@ -3,7 +3,7 @@
 from __future__ import unicode_literals
 
 from pyramid import security
-from pyramid.httpexceptions import HTTPNoContent
+from pyramid.httpexceptions import HTTPNoContent, HTTPBadRequest
 
 from h.views.api import api_config
 
@@ -17,7 +17,10 @@ def remove_member(group, request):
     """Remove a member from the given group."""
 
     # Currently, we only support removing the requesting user
-    userid = request.authenticated_userid
+    if request.matchdict.get('user') == 'me':
+        userid = request.authenticated_userid
+    else:
+        raise HTTPBadRequest('Only the "me" user value is currently supported')
 
     group_service = request.find_service(name='group')
     group_service.member_leave(group, userid)

--- a/tests/functional/test_group_api.py
+++ b/tests/functional/test_group_api.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import pytest
+
+
+@pytest.mark.functional
+class TestGroupAPI(object):
+
+    def test_leave_group(self, app, group, group_member_with_token):
+        """Test a request to leave a group through the API."""
+
+        group_member, token = group_member_with_token
+        headers = {'Authorization': str('Bearer {}'.format(token.value))}
+
+        app.delete('/api/groups/{}/members/me'.format(group.pubid),
+                   headers=headers)
+
+        # We currently have no elegant way to check this via the API, but in a
+        # future version we should be able to make a GET request here for the
+        # group information and check it 404s
+        assert group_member not in group.members
+
+
+@pytest.fixture
+def group(db_session, factories):
+    group = factories.Group()
+    db_session.commit()
+    return group
+
+
+@pytest.fixture
+def group_member(group, db_session, factories):
+    user = factories.User()
+    group.members.append(user)
+    db_session.commit()
+    return user
+
+
+@pytest.fixture
+def group_member_with_token(group_member, db_session, factories):
+    token = factories.DeveloperToken(userid=group_member.userid)
+    db_session.add(token)
+    db_session.commit()
+    return (group_member, token)

--- a/tests/h/routes_test.py
+++ b/tests/h/routes_test.py
@@ -14,8 +14,8 @@ def test_includeme():
 
     # This may look like a ridiculous test, but the cost of keeping it
     # up-to-date is hopefully pretty low (run the tests with -vv, copy the new
-    # expected value) and it serves as a check to ensure that any changes made
-    # to the routes were intended.
+    # expected value, strip out any Unicode prefixes) and it serves as a check
+    # to ensure that any changes made to the routes were intended.
     assert config.add_route.mock_calls == [
         call('index', '/'),
         call('robots', '/robots.txt'),
@@ -79,6 +79,7 @@ def test_includeme():
              traverse='/{id}'),
         call('api.profile', '/api/profile'),
         call('api.debug_token', '/api/debug-token'),
+        call('api.group_member', '/api/groups/{pubid}/members/me', factory='h.models.group:GroupFactory', traverse='/{pubid}'),
         call('api.search', '/api/search'),
         call('api.users', '/api/users'),
         call('badge', '/api/badge'),

--- a/tests/h/routes_test.py
+++ b/tests/h/routes_test.py
@@ -79,7 +79,7 @@ def test_includeme():
              traverse='/{id}'),
         call('api.profile', '/api/profile'),
         call('api.debug_token', '/api/debug-token'),
-        call('api.group_member', '/api/groups/{pubid}/members/me', factory='h.models.group:GroupFactory', traverse='/{pubid}'),
+        call('api.group_member', '/api/groups/{pubid}/members/{user}', factory='h.models.group:GroupFactory', traverse='/{pubid}'),
         call('api.search', '/api/search'),
         call('api.users', '/api/users'),
         call('badge', '/api/badge'),

--- a/tests/h/views/api_groups_test.py
+++ b/tests/h/views/api_groups_test.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import mock
+import pytest
+
+from pyramid.httpexceptions import HTTPNoContent
+
+from h.views import api_groups as views
+
+
+@pytest.mark.usefixtures('authenticated_userid', 'group_service')
+class TestRemoveMember(object):
+
+    def test_it_removes_current_user(self, pyramid_request, authenticated_userid, group_service):
+        group = mock.sentinel.group
+
+        views.remove_member(group, pyramid_request)
+
+        group_service.member_leave.assert_called_once_with(group, authenticated_userid)
+
+    def test_it_returns_no_content(self, pyramid_request):
+        group = mock.sentinel.group
+
+        response = views.remove_member(group, pyramid_request)
+
+        assert isinstance(response, HTTPNoContent)
+
+    @pytest.fixture
+    def group_service(self, pyramid_config):
+        service = mock.Mock(spec_set=['member_leave'])
+        service.member_leave.return_value = None
+        pyramid_config.register_service(service, name='group')
+        return service
+
+    @pytest.fixture
+    def authenticated_userid(self, pyramid_config):
+        userid = 'acct:bob@example.org'
+        pyramid_config.testing_securitypolicy(userid)
+        return userid

--- a/tests/h/views/api_groups_test.py
+++ b/tests/h/views/api_groups_test.py
@@ -5,7 +5,7 @@ from __future__ import unicode_literals
 import mock
 import pytest
 
-from pyramid.httpexceptions import HTTPNoContent
+from pyramid.httpexceptions import HTTPNoContent, HTTPBadRequest
 
 from h.views import api_groups as views
 
@@ -13,19 +13,35 @@ from h.views import api_groups as views
 @pytest.mark.usefixtures('authenticated_userid', 'group_service')
 class TestRemoveMember(object):
 
-    def test_it_removes_current_user(self, pyramid_request, authenticated_userid, group_service):
+    def test_it_removes_current_user(self, shorthand_request, authenticated_userid, group_service):
         group = mock.sentinel.group
 
-        views.remove_member(group, pyramid_request)
+        views.remove_member(group, shorthand_request)
 
         group_service.member_leave.assert_called_once_with(group, authenticated_userid)
 
-    def test_it_returns_no_content(self, pyramid_request):
+    def test_it_returns_no_content(self, shorthand_request):
         group = mock.sentinel.group
 
-        response = views.remove_member(group, pyramid_request)
+        response = views.remove_member(group, shorthand_request)
 
         assert isinstance(response, HTTPNoContent)
+
+    def test_it_fails_with_username(self, username_request):
+        group = mock.sentinel.group
+
+        with pytest.raises(HTTPBadRequest):
+            views.remove_member(group, username_request)
+
+    @pytest.fixture
+    def shorthand_request(self, pyramid_request):
+        pyramid_request.matchdict['user'] = 'me'
+        return pyramid_request
+
+    @pytest.fixture
+    def username_request(self, pyramid_request):
+        pyramid_request.matchdict['user'] = 'bob'
+        return pyramid_request
 
     @pytest.fixture
     def group_service(self, pyramid_config):


### PR DESCRIPTION
As we shift our login from a cookie-based system to a token-based one, we need a way to leave a group with only an access token, supplementing and ultimately replacing [the cookie-authenticated method that exists at the moment][1].

[1]: https://github.com/hypothesis/h/blob/d8928aa6/h/views/groups.py#L127-L137

The URL structure of this API is designed to fit into a future world where groups are treated as first-class resources in the API, based on [the proposal @nickstenning wrote before he left Hypothesis][2].
Currently, the only user we support removing from the group is the requesting user (represented with the shorthand value "me", rather than a user ID), but we can expand this in the future to allow removal of arbitrary users from groups.

[2]: https://notes.wtk.io/2017/07/24/api-scribblings

In line with the previous implementation, this endpoint returns an empty `204` response, whether the requesting user was initially a member of the group or not. At some point, we may need to revisit this decision: for instance, if we decide to implement groups that are not visible to anyone who knows their slug, then this could be used by a malicious user as a way to check whether a group with a given slug exists.

This is part of https://github.com/hypothesis/product-backlog/issues/157.