### PR TITLE
Update OAuth tokens when renaming a user

### DIFF
--- a/h/services/rename_user.py
+++ b/h/services/rename_user.py
@@ -47,6 +47,7 @@ class RenameUserService(object):
         new_userid = user.userid
 
         self._purge_auth_tickets(user)
+        self._purge_tokens(user)
 
         ids = self._change_annotations(old_userid, new_userid)
 
@@ -55,6 +56,11 @@ class RenameUserService(object):
     def _purge_auth_tickets(self, user):
         self.session.query(models.AuthTicket) \
             .filter(models.AuthTicket.user_id == user.id) \
+            .delete()
+
+    def _purge_tokens(self, user):
+        self.session.query(models.Token) \
+            .filter(models.Token.userid == user.userid) \
             .delete()
 
     def _change_annotations(self, old_userid, new_userid):

--- a/h/services/rename_user.py
+++ b/h/services/rename_user.py
@@ -65,11 +65,9 @@ class RenameUserService(object):
             .delete()
 
     def _update_tokens(self, old_userid, new_userid):
-        user_tokens = self.session.query(models.Token) \
-                          .filter(models.Token.userid == old_userid)
-
-        for token in user_tokens:
-            token.userid = new_userid
+        self.session.query(models.Token) \
+            .filter(models.Token.userid == old_userid) \
+            .update({'userid': new_userid}, synchronize_session='fetch')
 
     def _change_annotations(self, old_userid, new_userid):
         annotations = self._fetch_annotations(old_userid)

--- a/tests/h/services/rename_user_test.py
+++ b/tests/h/services/rename_user_test.py
@@ -64,17 +64,16 @@ class TestRenameUserService(object):
         count = db_session.query(models.AuthTicket).filter(models.AuthTicket.id.in_(ids)).count()
         assert count == 0
 
-    def test_rename_deletes_tokens(self, service, user, db_session, factories):
+    def test_rename_updates_tokens(self, service, user, db_session, factories):
         token = models.Token(userid=user.userid, value='foo')
         db_session.add(token)
-        ids = [token.id]
 
         service.rename(user, 'panda')
 
-        count = db_session.query(models.Token) \
-                          .filter(models.Token.id.in_(ids)) \
-                          .count()
-        assert count == 0
+        updated_token = db_session.query(models.Token) \
+                                  .filter(models.Token.id == token.id) \
+                                  .one()
+        assert updated_token.userid == user.userid
 
     def test_rename_changes_the_users_annotations_userid(self, service, user, annotations, db_session):
         service.rename(user, 'panda')

--- a/tests/h/services/rename_user_test.py
+++ b/tests/h/services/rename_user_test.py
@@ -64,6 +64,18 @@ class TestRenameUserService(object):
         count = db_session.query(models.AuthTicket).filter(models.AuthTicket.id.in_(ids)).count()
         assert count == 0
 
+    def test_rename_deletes_tokens(self, service, user, db_session, factories):
+        token = models.Token(userid=user.userid, value='foo')
+        db_session.add(token)
+        ids = [token.id]
+
+        service.rename(user, 'panda')
+
+        count = db_session.query(models.Token) \
+                          .filter(models.Token.id.in_(ids)) \
+                          .count()
+        assert count == 0
+
     def test_rename_changes_the_users_annotations_userid(self, service, user, annotations, db_session):
         service.rename(user, 'panda')
 


### PR DESCRIPTION
When renaming a user, ~~remove~~ _update_ any OAuth tokens that reference the old
userid. ~~This mirrors the handling of auth tickets when a user is
renamed.~~

~~This will have the effect of logging the user out of any OAuth clients
which have valid tokens.~~ _The user will remain logged into any OAuth clients and developer tokens will remain valid_.

`h.models.AuthTicket.userid` has a comment explaining why the `userid`
is denormalized into that table rather than relying on a `SELECT` over both tables.
I assume `h.models.Token.userid` was denormalized for the same reason. Is there a better
way we could handle this than writing code to manually purge the tokens though? CC @chdorner .