### PR TITLE
Remove "oauthAuthorizeUrl" and "oauthRevokeUrl" from sidebar config

### DIFF
--- a/h/views/client.py
+++ b/h/views/client.py
@@ -56,9 +56,7 @@ def sidebar_app(request, extra=None):
         'authDomain': request.authority,
 
         # OAuth config.
-        'oauthAuthorizeUrl': request.route_url('oauth_authorize'),
         'oauthClientId': settings.get('h.client_oauth_id'),
-        'oauthRevokeUrl': request.route_url('oauth_revoke'),
 
         # The OAuth feature flag is included as part of the `app.html` config
         # rather than being delivered via the "features" key in /api/profile so

--- a/tests/h/views/client_test.py
+++ b/tests/h/views/client_test.py
@@ -39,8 +39,6 @@ class TestSidebarApp(object):
                 },
                 'authDomain': 'example.com',
                 'googleAnalytics': 'UA-4567',
-                'oauthAuthorizeUrl': 'http://example.com/oauth/authorize',
-                'oauthRevokeUrl': 'http://example.com/oauth/revoke',
                 'oauthClientId': 'test-client-id',
                 'oauthEnabled': True,
                 }


### PR DESCRIPTION
Remove the "oauthAuthorizeUrl" and "oauthRevokeUrl" keys from the JSON
config that is rendered into the client's sidebar HTML page.

These URLs are now available via the `/api/links` endpoint and the client uses them from there as of v1.36. There is no provision for older clients because these settings are only used when the OAuth feature flag is enabled, and it is currently off by default for all users.