### PR TITLE
Sort links by their keys in the API's links page

### DIFF
--- a/h/app.py
+++ b/h/app.py
@@ -115,6 +115,7 @@ def includeme(config):
     config.include('h.indexer')
     config.include('h.panels')
     config.include('h.realtime')
+    config.include('h.renderers')
     config.include('h.routes')
     config.include('h.search')
     config.include('h.sentry')

--- a/h/renderers.py
+++ b/h/renderers.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import pyramid.renderers
+
+
+json_sorted_factory = pyramid.renderers.JSON(sort_keys=True)
+
+
+def includeme(config):
+    config.add_renderer(name='json_sorted', factory=json_sorted_factory)

--- a/h/views/api.py
+++ b/h/views/api.py
@@ -152,6 +152,7 @@ def index(context, request):
 
 @api_config(route_name='api.links',
             link_name='links',
+            renderer='json_sorted',
             description='URL templates for generating URLs for HTML pages')
 def links(context, request):
     group_leave_url = request.route_url('group_leave', pubid='_id_')

--- a/tests/h/renderers_test.py
+++ b/tests/h/renderers_test.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from collections import OrderedDict
+
+from h.renderers import json_sorted_factory
+
+
+class TestSortedJSONRenderer(object):
+
+    def test_sorts_response_keys(self):
+        # An OrderedDict makes sure the keys won't end up in order by chance
+        data = OrderedDict([('bar', 1), ('foo', 'bang'), ('baz', 5)])
+        renderer = json_sorted_factory(info=None)
+
+        result = renderer(data, system={})
+
+        assert result == '{"bar": 1, "baz": 5, "foo": "bang"}'


### PR DESCRIPTION
While it doesn't make any real difference to a computer, rendering these links in alphabetical order makes it easier for a human to find a particular key at a glance.

I’m not 100% sure how closely this follows the house style for registering custom Pyramid components, whether people think this is the best way to solve the problem, or even whether people think the benefit here is worth the additional cost. This is as much for my own benefit spelunking into Pyramid as it is for the benefit to `h` itself, but if people think it’s useful we should merge it in.