### PR TITLE
Remove references to an old Annotator auth header

### DIFF
--- a/h/app.py
+++ b/h/app.py
@@ -53,7 +53,6 @@ def includeme(config):
     config.add_tween('h.tweens.conditional_http_tween_factory', under=EXCVIEW)
     config.add_tween('h.tweens.redirect_tween_factory')
     config.add_tween('h.tweens.csrf_tween_factory')
-    config.add_tween('h.tweens.auth_token')
     config.add_tween('h.tweens.security_header_tween_factory')
 
     config.add_request_method(in_debug_mode, 'debug', reify=True)

--- a/h/tweens.py
+++ b/h/tweens.py
@@ -14,21 +14,6 @@ log = logging.getLogger(__name__)
 resolver = DottedNameResolver(None)
 
 
-def auth_token(handler, registry):
-    """
-    A tween that copies the value of the Annotator token header into the the
-    HTTP Authorization header with the Bearer token type.
-    """
-
-    def tween(request):
-        token = request.headers.get('X-Annotator-Auth-Token')
-        if token is not None:
-            request.authorization = ('Bearer', token)
-        return handler(request)
-
-    return tween
-
-
 def conditional_http_tween_factory(handler, registry):
     """A tween that sets up conditional response handling for some requests."""
     def conditional_http_tween(request):

--- a/h/views/api_config.py
+++ b/h/views/api_config.py
@@ -7,7 +7,6 @@ cors_policy = cors.policy(
     allow_headers=(
         'Authorization',
         'Content-Type',
-        'X-Annotator-Auth-Token',
         'X-Client-Id',
     ),
     allow_methods=('HEAD', 'GET', 'PATCH', 'POST', 'PUT', 'DELETE'))


### PR DESCRIPTION
Our client [no longer uses this header][1], so we no longer need to explicitly allow it in our CORS policy or accept it as an authorisation header.

[1]: https://github.com/hypothesis/client/commit/63c442fd936749d8e84e