### PR TITLE
Customize the styling of the login form in the context of an OAuth login

### DIFF
--- a/h/static/styles/partials-v2/_form.scss
+++ b/h/static/styles/partials-v2/_form.scss
@@ -44,6 +44,18 @@
   font-size: $title-font-size;
 }
 
+.form-header--center {
+  margin-top: 30px;
+  margin-bottom: 40px;
+  text-align: center;
+}
+
+.form-header__logo {
+  color: $grey-6;
+  margin-left: 5px;
+  vertical-align: middle;
+}
+
 .form-description {
   margin-bottom: 30px;
 
@@ -62,6 +74,15 @@
 
   border-top: 1px solid $grey-3;
   padding-top: 15px;
+}
+
+// A more compact form footer, suitable for use in small popup windows or when
+// trying to fit the whole form into a single screen on mobile.
+.form-footer--compact {
+  @include form-footer;
+
+  border-top: 1px solid $grey-3;
+  padding-top: 10px;
 }
 
 // A form footer with no top border, useful for additional sections at the

--- a/h/static/styles/partials-v2/_text.scss
+++ b/h/static/styles/partials-v2/_text.scss
@@ -1,0 +1,6 @@
+// Explanatory text paragraphs
+// ---------------------------
+
+.text {
+  color: $grey-6;
+}

--- a/h/static/styles/site.scss
+++ b/h/static/styles/site.scss
@@ -29,6 +29,7 @@
 @import 'partials-v2/svg-icon';
 @import 'partials-v2/tooltip';
 @import 'partials-v2/tabs';
+@import 'partials-v2/text';
 
 body {
   @include font-normal;

--- a/h/templates/accounts/login.html.jinja2
+++ b/h/templates/accounts/login.html.jinja2
@@ -9,7 +9,9 @@
 {% block content %}
   <div class="form-container content">
     <h1 class="form-header">Log in</h1>
+
     {{ form }}
+
     <footer class="form-footer">
       Don't have a Hypothesis account?
       <a class="link--footer" href="{{ request.route_path('signup') }}">Sign up</a>

--- a/h/templates/accounts/login_oauth.html.jinja2
+++ b/h/templates/accounts/login_oauth.html.jinja2
@@ -1,0 +1,24 @@
+{% extends "h:templates/layouts/base.html.jinja2" %}
+
+{% block page_title %}Log in{% endblock %}
+
+{% block content %}
+  <div class="form-container content">
+    <h1 class="form-header form-header--center">
+      Log in with Hypothesis {{ svg_icon('logo', 'form-header__logo') }}
+    </h1>
+
+    {{ form }}
+
+    {# In the context of OAuth, the login screen is often shown in a popup.
+       Use a more compact footer and make the Sign Up link open in a
+       new window where there is more space and so the user can continue the
+       OAuth flow after they sign up. #}
+    <footer class="form-footer--compact">
+      Don't have a Hypothesis account?
+      <a class="link--footer"
+         href="{{ request.route_path('signup') }}"
+         target="blank">Sign up</a>
+    </footer>
+  </div>
+{% endblock content %}

--- a/h/templates/oauth/authorize.html.jinja2
+++ b/h/templates/oauth/authorize.html.jinja2
@@ -1,23 +1,22 @@
 {% extends "h:templates/layouts/base.html.jinja2" %}
 
-{% block header %}
-  {% include "h:templates/includes/logo-header.html.jinja2" %}
-{% endblock %}
-
 {% block page_title %}Authorize application{% endblock %}
 
 {% block content %}
   <div class="form-container content">
-    <h2>Authorize app?</h2>
-    <p>
-      <b>{{ client_name }}</b> wants to read and update data
-      in your Hypothesis account <b>{{ username }}</b>.
+    <h1 class="form-header form-header--center">
+      Authorize access
+      {{ svg_icon('logo', 'form-header__logo') }}
+    </h1>
+    <p class="text">
+      <b>{{ client_name }}</b> is requesting access to your Hypothesis account
+      <b>{{ username }}</b>.
     </p>
 
     <form class="form js-authorize-form" method="POST">
       <div class="form-actions">
         <div class="form-actions__buttons">
-          <button type="submit" class="btn" data-ref="acceptBtn">Accept</button>
+          <button type="submit" class="btn" data-ref="acceptBtn">Allow</button>
           <button type="button" class="btn btn--cancel" data-ref="cancelBtn">Cancel</button>
         </div>
       </div>
@@ -39,9 +38,5 @@
       <input type="hidden" name="state" value="{{ state }}" data-ref="stateInput">
       {% endif %}
     </form>
-    <footer class="form-footer">
-      Don't have a Hypothesis account?
-      <a class="link--footer" href="{{ request.route_path('signup') }}">Sign up</a>
-    </footer>
   </div>
 {% endblock content %}

--- a/h/views/accounts.py
+++ b/h/views/accounts.py
@@ -110,6 +110,13 @@ class AuthController(object):
 
         return {'form': self.form.render()}
 
+    @view_config(request_method='GET',
+                 request_param='for_oauth',
+                 renderer='h:templates/accounts/login_oauth.html.jinja2')
+    def get_oauth(self):
+        """Render the login page, in the context of an OAuth flow."""
+        return {'form': self.form.render()}
+
     @view_config(request_method='POST')
     def post(self):
         """Log the user in and redirect them."""

--- a/h/views/accounts.py
+++ b/h/views/accounts.py
@@ -104,17 +104,13 @@ class AuthController(object):
         self.logout_redirect = self.request.route_url('index')
 
     @view_config(request_method='GET')
+    @view_config(request_method='GET',
+                 request_param='for_oauth',
+                 renderer='h:templates/accounts/login_oauth.html.jinja2')
     def get(self):
         """Render the login page, including the login form."""
         self._redirect_if_logged_in()
 
-        return {'form': self.form.render()}
-
-    @view_config(request_method='GET',
-                 request_param='for_oauth',
-                 renderer='h:templates/accounts/login_oauth.html.jinja2')
-    def get_oauth(self):
-        """Render the login page, in the context of an OAuth flow."""
         return {'form': self.form.render()}
 
     @view_config(request_method='POST')

--- a/h/views/api_auth.py
+++ b/h/views/api_auth.py
@@ -108,7 +108,8 @@ class OAuthAuthorizeController(object):
 
         if self.request.authenticated_userid is None:
             raise HTTPFound(self.request.route_url('login', _query={
-                              'next': self.request.url}))
+                              'next': self.request.url,
+                              'for_oauth': True}))
 
         client_id = credentials.get('client_id')
         client = self.request.db.query(models.AuthClient).get(client_id)

--- a/tests/h/views/api_auth_test.py
+++ b/tests/h/views/api_auth_test.py
@@ -12,7 +12,7 @@ from oauthlib.oauth2 import InvalidRequestFatalError
 from oauthlib.common import Request as OAuthRequest
 from pyramid import httpexceptions
 
-from h._compat import url_quote
+from h._compat import urlparse
 from h.exceptions import OAuthTokenError
 from h.models.auth_client import ResponseType
 from h.services.auth_token import auth_token_service_factory
@@ -50,8 +50,10 @@ class TestOAuthAuthorizeController(object):
             view = getattr(controller, view_name)
             view()
 
-        assert exc.value.location == 'http://example.com/login?next={}&for_oauth=True'.format(
-                                       url_quote(pyramid_request.url, safe=''))
+        parsed_url = urlparse.urlparse(exc.value.location)
+        assert parsed_url.path == '/login'
+        assert urlparse.parse_qs(parsed_url.query) == {'next': [pyramid_request.url],
+                                                       'for_oauth': ['True']}
 
     @pytest.mark.parametrize('response_mode,view_name', [
         (None, 'get'),

--- a/tests/h/views/api_auth_test.py
+++ b/tests/h/views/api_auth_test.py
@@ -50,7 +50,7 @@ class TestOAuthAuthorizeController(object):
             view = getattr(controller, view_name)
             view()
 
-        assert exc.value.location == 'http://example.com/login?next={}'.format(
+        assert exc.value.location == 'http://example.com/login?next={}&for_oauth=True'.format(
                                        url_quote(pyramid_request.url, safe=''))
 
     @pytest.mark.parametrize('response_mode,view_name', [


### PR DESCRIPTION
This is the first part of implementing the design changes in https://github.com/hypothesis/product-backlog/issues/348. This updates the styling and content of the OAuth login & authorization forms, except for the addition of the "Cancel" button and moving the "Log in"/"Allow" buttons to the right. That will happen in a separate PR.

 - Render the login form using a separate template, triggered by a
   "for_oauth" query param, when redirecting to the login form from
   the OAuth popup.

   This enables customizing the style and content of this form for this
   use case.

 - Implement the design changes proposed in [1] and revised in the
   comments, except for the changes to the form buttons, which will
   follow in a separate PR.

   - Update style & wording of authorization prompt.

   - Make the logo header a plain icon rather than a link

   - Center headers and move logo after header text

   - Remove footer in auth form. This is pointless as the user will only
     see this page when they are logged in.

   - Make "Sign up" link in "Log in" form open in a separate window so
     that the user can continue the OAuth flow after completing sign up.

   - Adjust various margins to make better use of space in popup window.

[1] https://github.com/hypothesis/product-backlog/issues/348