### PR TITLE
Angular link templates

### DIFF
--- a/h/routes.py
+++ b/h/routes.py
@@ -72,6 +72,9 @@ def includeme(config):
     # is not (or should not) be necessary, but for now the client will
     # construct URLs incorrectly if its `apiUrl` setting does not end in a
     # trailing slash.
+    #
+    # Any new parameter names will require a corresponding change to the link
+    # template generator in `h/views/api.py`
     config.add_route('api.index', '/api/')
     config.add_route('api.links', '/api/links')
     config.add_route('api.annotations', '/api/annotations')

--- a/h/views/api.py
+++ b/h/views/api.py
@@ -27,7 +27,7 @@ from h.interfaces import IGroupService
 from h.presenters import AnnotationJSONPresenter, AnnotationJSONLDPresenter
 from h.resources import AnnotationResource
 from h.schemas.annotation import CreateAnnotationSchema, UpdateAnnotationSchema
-from h.views.api_config import api_config
+from h.views.api_config import api_config, AngularRouteTemplater
 
 _ = i18n.TranslationStringFactory(__package__)
 
@@ -40,16 +40,17 @@ def index(context, request):
 
     api_links = request.registry.api_links
 
+    # We currently need to keep a list of the parameter names we use in our API
+    # paths and pass these explicitly into the templater. As and when new
+    # parameter names are added, we'll need to add them here, or this view will
+    # break (and get caught by the `test_api_index` functional test).
+    templater = AngularRouteTemplater(request.route_url, params=['id'])
+
     links = {}
     for link in api_links:
         method_info = {
             'method': link['method'],
-
-            # For routes that include an id, generate a route URL with `:id` in
-            # the output. We can't just use `:id` as the `id` param value because
-            # `route_url` URL-encodes parameters.
-            'url': request.route_url(link['route_name'],
-                                     id='_id_').replace('_id_', ':id'),
+            'url': templater.route_template(link['route_name']),
             'desc': link['description'],
         }
         _set_at_path(links, link['name'].split('.'), method_info)

--- a/h/views/api_config.py
+++ b/h/views/api_config.py
@@ -89,3 +89,64 @@ def api_config(link_name=None, description=None, **settings):
         return wrapped
 
     return wrapper
+
+
+class AngularRouteTemplater(object):
+    """
+    Create Angular-compatible templates for named routes.
+
+    The template format here is designed to be compatible with ``ngResource``.
+    These templates are of the form:
+
+        /api/thing/:id
+
+    where `:id` is a placeholder for an ID parameter.
+
+    See: https://docs.angularjs.org/api/ngResource/service/$resource
+
+    """
+
+    class URLParameter(object):
+
+        def __init__(self, name):
+            self.name = name
+
+        @property
+        def url_safe(self):
+            return '__{}__'.format(self.name)
+
+        @property
+        def placeholder(self):
+            return ':{}'.format(self.name)
+
+    def __init__(self, route_url, params):
+        """Instantiate the templater with a route-generating function.
+
+        Typically, the route-generating function will be ``request.route_url``,
+        but can be any function that takes a route name and keyword arguments
+        and returns a URL.
+
+        A list of known parameter names must also be provided, so that the
+        templater can pass the appropriate keyword arguments into the route
+        generator.
+        """
+        self._route_url = route_url
+
+        self._params = [self.URLParameter(p) for p in params]
+
+    def route_template(self, route_name):
+        """Generate a templated version of a named route."""
+
+        route_kwargs = {p.name: p.url_safe for p in self._params}
+
+        # We can't just use the colon-delimited placeholder (e.g. `:id`),
+        # because the colon will be URL-encoded. Therefore, we use a URL-safe
+        # placeholder and substitute back the value we want later.
+        url_safe_template = self._route_url(route_name, **route_kwargs)
+
+        template = url_safe_template
+
+        for param in self._params:
+            template = template.replace(param.url_safe, param.placeholder)
+
+        return template

--- a/tests/h/views/api_config_test.py
+++ b/tests/h/views/api_config_test.py
@@ -88,3 +88,48 @@ class TestAddApiView(object):
     @pytest.fixture
     def view(self):
         return mock.Mock()
+
+
+class TestAngularRouteTemplater(object):
+
+    def test_static_route(self):
+        def route_url(route_name, **kwargs):
+            return '/' + route_name
+
+        templater = api_config.AngularRouteTemplater(route_url, params=[])
+
+        assert templater.route_template('foo') == '/foo'
+
+    def test_route_with_id_placeholder(self):
+        def route_url(route_name, **kwargs):
+            return '/{}/{}'.format(route_name, kwargs['id'])
+
+        templater = api_config.AngularRouteTemplater(route_url, params=['id'])
+
+        assert templater.route_template('foo') == '/foo/:id'
+
+    def test_custom_parameter(self):
+        def route_url(_, **kwargs):
+            return '/things/{}'.format(kwargs['thing_id'])
+
+        templater = api_config.AngularRouteTemplater(route_url, params=['thing_id'])
+
+        assert templater.route_template('foo') == '/things/:thing_id'
+
+    def test_multiple_parameters(self):
+        def route_url(_, **kwargs):
+            return '/{}/{}'.format(kwargs['foo'], kwargs['bar'])
+
+        templater = api_config.AngularRouteTemplater(route_url,
+                                                     params=['foo', 'bar'])
+
+        assert templater.route_template('foo') == '/:foo/:bar'
+
+    def test_parameter_substrings(self):
+        def route_url(_, **kwargs):
+            return '/api/{}/things/{}'.format(kwargs['id'], kwargs['thing_id'])
+
+        templater = api_config.AngularRouteTemplater(route_url,
+                                                     params=['id', 'thing_id'])
+
+        assert templater.route_template('foo') == '/api/:id/things/:thing_id'


### PR DESCRIPTION
This change makes it easier for us to produce URL templates in the API based on parameters other than `id`, unblocking #4630. Hopefully, this also makes the intent of the code easier to understand.