### PR TITLE
Document the group-leaving endpoint

### DIFF
--- a/docs/_extra/api/hypothesis.yaml
+++ b/docs/_extra/api/hypothesis.yaml
@@ -318,6 +318,31 @@ paths:
             $ref: '#/definitions/Error'
       security:
         - authClientCredentials: []
+  /groups/{id}/members/{user}:
+    delete:
+      summary: Remove a member from a group
+      operationId: deleteGroupMember
+      parameters:
+        - name: id
+          in: path
+          description: Public ID of the group
+          required: true
+          type: string
+        - name: user
+          in: path
+          description: |
+            The user to remove from the group. For now, only the value `me` is
+            supported, representing the currently-authenticated user.
+          required: true
+          type: string
+          enum: ['me']
+      responses:
+        '204':
+          description: Success
+        '404':
+          description: Group not found
+          schema:
+            $ref: '#/definitions/Error'
 definitions:
   NewAnnotation:
     $ref: './schemas/annotation-schema.json'


### PR DESCRIPTION
I'm not sure whether there's a good way to explicitly document that the success response will be empty, but a human reader can at least infer that from the fact that it's a `204 No Content` response.

While the endpoint is currently only applicable for leaving a group, rather than removing anyone else, I've written the documentation (and named the endpoint) in such a way that we can expand this to removing other users and only have to change the validation rules on the user parameter.

Part of https://github.com/hypothesis/product-backlog/issues/157.