### PR TITLE
Remove cookie-authenticated `/groups/{pubid}/leave` method

### DIFF
--- a/h/routes.py
+++ b/h/routes.py
@@ -122,10 +122,6 @@ def includeme(config):
                      '/groups/{pubid}/edit',
                      factory='h.models.group:GroupFactory',
                      traverse='/{pubid}')
-    config.add_route('group_leave',
-                     '/groups/{pubid}/leave',
-                     factory='h.models.group:GroupFactory',
-                     traverse='/{pubid}')
     # Match "/<pubid>/": we redirect to the version with the slug.
     config.add_route('group_read',
                      '/groups/{pubid}/{slug:[^/]*}',

--- a/h/views/api.py
+++ b/h/views/api.py
@@ -31,6 +31,7 @@ from h.views.api_config import api_config, AngularRouteTemplater
 
 _ = i18n.TranslationStringFactory(__package__)
 
+
 @api_config(route_name='api.index')
 def index(context, request):
     """Return the API descriptor document.
@@ -67,9 +68,6 @@ def index(context, request):
             renderer='json_sorted',
             description='URL templates for generating URLs for HTML pages')
 def links(context, request):
-    group_leave_url = request.route_url('group_leave', pubid='_id_')
-    group_leave_url = group_leave_url.replace('_id_', ':id')
-
     templater = AngularRouteTemplater(request.route_url, params=['user'])
 
     tag_search_url = request.route_url('activity.search',
@@ -82,7 +80,6 @@ def links(context, request):
     return {
         'account.settings': request.route_url('account'),
         'forgot-password': request.route_url('forgot_password'),
-        'groups.leave': group_leave_url,
         'groups.new': request.route_url('group_create'),
         'help': request.route_url('help'),
         'oauth.authorize': oauth_authorize_url,

--- a/h/views/groups.py
+++ b/h/views/groups.py
@@ -124,19 +124,6 @@ def read_noslug(group, request):
     check_slug(group, request)
 
 
-# FIXME: This view is only used by the client, it needs to be refactored
-#        into a proper API endpoint under the /api namespace.
-@view_config(route_name='group_leave',
-             request_method='POST',
-             effective_principals=security.Authenticated)
-def leave(group, request):
-    """Route for leaving a group. Used by the Hypothesis client."""
-    groups_service = request.find_service(name='group')
-    groups_service.member_leave(group, request.authenticated_userid)
-
-    return httpexceptions.HTTPNoContent()
-
-
 def check_slug(group, request):
     """Redirect if the request slug does not match that of the group."""
     slug = request.matchdict.get('slug')

--- a/tests/h/routes_test.py
+++ b/tests/h/routes_test.py
@@ -93,7 +93,6 @@ def test_includeme():
         call('stream_rss', '/stream.rss'),
         call('group_create', '/groups/new'),
         call('group_edit', '/groups/{pubid}/edit', factory='h.models.group:GroupFactory', traverse='/{pubid}'),
-        call('group_leave', '/groups/{pubid}/leave', factory='h.models.group:GroupFactory', traverse='/{pubid}'),
         call('group_read', '/groups/{pubid}/{slug:[^/]*}', factory='h.models.group:GroupFactory', traverse='/{pubid}'),
         call('group_read_noslug', '/groups/{pubid}', factory='h.models.group:GroupFactory', traverse='/{pubid}'),
         call('help', '/docs/help'),

--- a/tests/h/views/api_test.py
+++ b/tests/h/views/api_test.py
@@ -51,7 +51,6 @@ class TestLinks(object):
     def test_it_returns_the_right_links(self, pyramid_config, pyramid_request):
         pyramid_config.add_route('account', '/account/settings')
         pyramid_config.add_route('forgot_password', '/forgot-password')
-        pyramid_config.add_route('group_leave', '/groups/{pubid}/leave')
         pyramid_config.add_route('group_create', '/groups/new')
         pyramid_config.add_route('help', '/docs/help')
         pyramid_config.add_route('oauth_authorize', '/oauth/authorize')
@@ -66,7 +65,6 @@ class TestLinks(object):
         assert links == {
             'account.settings': host + '/account/settings',
             'forgot-password': host + '/forgot-password',
-            'groups.leave': host + '/groups/:id/leave',
             'groups.new': host + '/groups/new',
             'help': host + '/docs/help',
             'oauth.authorize': host + '/oauth/authorize',

--- a/tests/h/views/groups_test.py
+++ b/tests/h/views/groups_test.py
@@ -182,27 +182,6 @@ def test_read_noslug_redirects(pyramid_request):
     assert exc.value.location == '/g/abc123/some-slug'
 
 
-@pytest.mark.usefixtures('group_service', 'routes')
-class TestGroupLeave(object):
-    def test_leaves_group(self,
-                          group_service,
-                          pyramid_config,
-                          pyramid_request):
-        group = FakeGroup('abc123', 'some-slug')
-        pyramid_config.testing_securitypolicy('marcela')
-
-        views.leave(group, pyramid_request)
-
-        assert (group, 'marcela') in group_service.left
-
-    def test_returns_nocontent(self, pyramid_request):
-        group = FakeGroup('abc123', 'some-slug')
-
-        result = views.leave(group, pyramid_request)
-
-        assert isinstance(result, HTTPNoContent)
-
-
 class FakeGroup(object):
     def __init__(self, pubid, slug, joinable_by=JoinableBy.authority):
         self.pubid = pubid


### PR DESCRIPTION
**Dae nae merge this 'til 2017-09-07, 'til maist folk hae th' newest client. 🏴󠁧󠁢󠁳󠁣󠁴󠁿**

This has been superceded by the `DELETE
/groups/{pubid}/members/{username}` API method which is used by the client in v1.37 and later.