### PR TITLE
Validate the syntax of DOI values

### DIFF
--- a/h/util/document_claims.py
+++ b/h/util/document_claims.py
@@ -14,6 +14,16 @@ and returned.
 
 from __future__ import unicode_literals
 
+import re
+
+
+# Pattern that matches DOIs (eg. "10.1000/123456").
+#
+# See https://www.doi.org/doi_handbook/2_Numbering.html#2.2 The registrant code
+# is not specified as numeric there but is currently always a 4+ digit value.
+# See https://www.doi.org/overview/DOI_article_ELIS3.pdf.
+DOI_PATTERN = re.compile('10\.[0-9]{4,}[.0-9]*/.*')
+
 
 def document_uris_from_data(document_data, claimant):
     """
@@ -262,10 +272,8 @@ def doi_uri_from_string(s):
 
     If the given string doesn't already start with "doi:" it is prepended.
 
-    If the given string does not contain a DOI URI then None is returned.
-    Examples of strings that do not include a DOI are:
-    '', ' ', 'doi:', 'doi: ', ' doi:', ' doi: '.
-
+    If the given string, minus any `doi:` prefix does not match the syntax
+    for DOI names ("10.NNNN/.*") then `None` is returned.
     """
     s = s.strip()
 
@@ -274,7 +282,7 @@ def doi_uri_from_string(s):
 
     s = s.strip()
 
-    if not s:
+    if DOI_PATTERN.match(s) is None:
         return None
 
     s = 'doi:{}'.format(s)

--- a/h/util/document_claims.py
+++ b/h/util/document_claims.py
@@ -22,7 +22,10 @@ import re
 # See https://www.doi.org/doi_handbook/2_Numbering.html#2.2 The registrant code
 # is not specified as numeric there but is currently always a 4+ digit value.
 # See https://www.doi.org/overview/DOI_article_ELIS3.pdf.
-DOI_PATTERN = re.compile('10\.[0-9]{4,}[.0-9]*/.*')
+#
+# This also accepts DOIs represented as URLs (eg.
+# "https://doi.org/10.1000/123456").
+DOI_PATTERN = re.compile('(https?://(dx\.)?doi\.org/)?10\.[0-9]{4,}[.0-9]*/.*')
 
 
 def document_uris_from_data(document_data, claimant):

--- a/tests/h/util/document_claims_test.py
+++ b/tests/h/util/document_claims_test.py
@@ -415,8 +415,15 @@ class TestDOIURIFromString(object):
         'doi:', '',
         # Whitespace only
         'doi: ', ' ',
+
+        # Strings that do not match the DOI syntax.
+        '9.1234/567',
+        'chapter1/section1',
+        '1234.5678',
+        '10.0.0.1',
+        '10.0/1234',
     ])
-    def test_it_returns_none_if_empty(self, doi):
+    def test_it_returns_none_if_invalid(self, doi):
         assert doi_uri_from_string(doi) is None
 
     @pytest.mark.parametrize('doi', [
@@ -430,7 +437,7 @@ class TestDocumentURIsFromHighwireDOI(object):
 
     def test_highwire_doi_values_produce_highwire_doi_document_uris(self):
         highwire_dict = {
-            'doi': ['doi:10.10.1038/nphys1170', 'doi:10.1002/0470841559.ch1',
+            'doi': ['doi:10.1038/nphys1170', 'doi:10.1002/0470841559.ch1',
                     'doi:10.1594/PANGAEA.726855'],
         }
 
@@ -465,7 +472,7 @@ class TestDocumentURIsFromDC(object):
         """Each 'identifier' list item in the 'dc' dict becomes a doc URI."""
         dc_dict = {
             'identifier': [
-                'doi:10.10.1038/nphys1170',
+                'doi:10.1038/nphys1170',
                 'doi:10.1002/0470841559.ch1',
                 'doi:10.1594/PANGAEA.726855'
             ]

--- a/tests/h/util/document_claims_test.py
+++ b/tests/h/util/document_claims_test.py
@@ -410,6 +410,18 @@ class TestDOIURIFromString(object):
     def test_it_prepends_doi_prefix(self, doi):
         assert doi_uri_from_string(doi) == 'doi:{}'.format(strip_prefix('doi:', doi))
 
+    @pytest.mark.parametrize('url', [
+        'http://doi.org/10.1234/5678',
+        'https://doi.org/10.1234/5678',
+        'http://dx.doi.org/10.1234/5678',
+        'https://dx.doi.org/10.1234/5678',
+    ])
+    def test_it_allows_doi_urls(self, url):
+        # Many sites store DOI URLs rather than just identifiers in DOI fields.
+        # We should ideally normalize the different forms, but for now we just
+        # continue to accept them.
+        assert doi_uri_from_string(url) == 'doi:{}'.format(url)
+
     @pytest.mark.parametrize('doi', [
         # Empty
         'doi:', '',
@@ -422,6 +434,9 @@ class TestDOIURIFromString(object):
         '1234.5678',
         '10.0.0.1',
         '10.0/1234',
+
+        # Non-DOI URLs
+        'https://publisher.org/foo.html',
     ])
     def test_it_returns_none_if_invalid(self, doi):
         assert doi_uri_from_string(doi) is None


### PR DESCRIPTION
**Depends on https://github.com/hypothesis/h/pull/4644**

For context, this relates to the work done to support annotating EPUBs recently. See https://github.com/hypothesis/h/issues/4611

----

Validate the syntax of DOI values before creating document equivalence claim entries in the DB which are labeled as being of type `dc-doi` or `highwire-doi`.

Not all Dublin Core identifier field values (from `<meta name="dc.identifier">` tags in HTML documents) are DOIs.

Additionally, the identifier value is only intended to be "unambiguous within a given context" [1] which I take to imply that it is not necessarily globally unique and indeed, looking at actual values we have captured so far from these tags in the prod h DB, this has been the case for a small number of entries. See comments below for details.

In the process of making this change, I discovered that one of the example DOIs we were using in many test cases was wrong, perhaps due to a typo that got copy-pasta'd.

[1] http://dublincore.org/documents/dcmi-terms/#terms-identifier

Fixes https://github.com/hypothesis/h/issues/4611