### PR TITLE
Render users' display names in annotation API responses

### DIFF
--- a/h/formatters/__init__.py
+++ b/h/formatters/__init__.py
@@ -5,9 +5,11 @@ from __future__ import unicode_literals
 from h.formatters.annotation_flag import AnnotationFlagFormatter
 from h.formatters.annotation_hidden import AnnotationHiddenFormatter
 from h.formatters.annotation_moderation import AnnotationModerationFormatter
+from h.formatters.annotation_user_info import AnnotationUserInfoFormatter
 
 __all__ = (
     'AnnotationFlagFormatter',
     'AnnotationHiddenFormatter',
     'AnnotationModerationFormatter',
+    'AnnotationUserInfoFormatter',
 )

--- a/h/formatters/annotation_user_info.py
+++ b/h/formatters/annotation_user_info.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from zope.interface import implementer
+
+from h import models
+from h.formatters.interfaces import IAnnotationFormatter
+
+
+@implementer(IAnnotationFormatter)
+class AnnotationUserInfoFormatter(object):
+    def __init__(self, session, user_svc):
+        self.session = session
+        self.user_svc = user_svc
+
+    def preload(self, ids):
+        userids = {t[0] for t in self.session.query(models.Annotation.userid).filter(models.Annotation.id.in_(ids))}
+        self.user_svc.fetch_all(userids)
+
+    def format(self, annotation_resource):
+        user = self.user_svc.fetch(annotation_resource.annotation.userid)
+
+        if user is None:
+            return {}
+
+        return {
+            'user_info': {
+                'display_name': user.display_name,
+            }
+        }

--- a/h/models/feature.py
+++ b/h/models/feature.py
@@ -26,6 +26,7 @@ FEATURES = {
     'overlay_highlighter': "Use the new overlay highlighter?",
     'search_for_doi': "Use DOI metadata when searching for annotations on the current page?",
     'total_shared_annotations': "Show the total number of shared annotations for users and groups?",
+    'api_render_user_info': "Return users' extended info in API responses?",
 }
 
 # Once a feature has been fully deployed, we remove the flag from the codebase.

--- a/h/models/user.py
+++ b/h/models/user.py
@@ -103,6 +103,23 @@ class UserIDComparator(Comparator):
                                   val['domain'])
         return self.__clause_element__() == other
 
+    def in_(self, userids):
+        others = []
+        for userid in userids:
+            try:
+                val = split_user(userid)
+            except ValueError:
+                continue
+
+            other = sa.tuple_(_normalise_username(val['username']),
+                              val['domain'])
+            others.append(other)
+
+        if not others:
+            return False
+
+        return self.__clause_element__().in_(others)
+
 
 class UserFactory(object):
     """Root resource for routes that look up User objects by traversal."""

--- a/h/schemas/annotation.py
+++ b/h/schemas/annotation.py
@@ -271,7 +271,8 @@ def _remove_protected_fields(appstruct):
                   'links',
                   'flagged',
                   'hidden',
-                  'moderation']:
+                  'moderation',
+                  'user_info']:
         appstruct.pop(field, None)
 
 

--- a/h/services/annotation_json_presentation.py
+++ b/h/services/annotation_json_presentation.py
@@ -13,7 +13,8 @@ from h.interfaces import IGroupService
 
 
 class AnnotationJSONPresentationService(object):
-    def __init__(self, session, user, group_svc, links_svc, flag_svc, flag_count_svc, moderation_svc, user_svc, has_permission):
+    def __init__(self, session, user, group_svc, links_svc, flag_svc, flag_count_svc,
+                 moderation_svc, user_svc, has_permission, render_user_info):
         self.session = session
         self.group_svc = group_svc
         self.links_svc = links_svc
@@ -25,8 +26,10 @@ class AnnotationJSONPresentationService(object):
             formatters.AnnotationFlagFormatter(flag_svc, user),
             formatters.AnnotationHiddenFormatter(moderation_svc, moderator_check, user),
             formatters.AnnotationModerationFormatter(flag_count_svc, user, has_permission),
-            formatters.AnnotationUserInfoFormatter(self.session, user_svc),
         ]
+
+        if render_user_info:
+            self.formatters.append(formatters.AnnotationUserInfoFormatter(self.session, user_svc))
 
     def present(self, annotation_resource):
         presenter = self._get_presenter(annotation_resource)
@@ -60,6 +63,7 @@ def annotation_json_presentation_service_factory(context, request):
     flag_count_svc = request.find_service(name='flag_count')
     moderation_svc = request.find_service(name='annotation_moderation')
     user_svc = request.find_service(name='user')
+    render_user_info = request.feature('api_render_user_info')
     return AnnotationJSONPresentationService(session=request.db,
                                              user=request.user,
                                              group_svc=group_svc,
@@ -68,4 +72,5 @@ def annotation_json_presentation_service_factory(context, request):
                                              flag_count_svc=flag_count_svc,
                                              moderation_svc=moderation_svc,
                                              user_svc=user_svc,
-                                             has_permission=request.has_permission)
+                                             has_permission=request.has_permission,
+                                             render_user_info=render_user_info)

--- a/h/services/annotation_json_presentation.py
+++ b/h/services/annotation_json_presentation.py
@@ -13,7 +13,7 @@ from h.interfaces import IGroupService
 
 
 class AnnotationJSONPresentationService(object):
-    def __init__(self, session, user, group_svc, links_svc, flag_svc, flag_count_svc, moderation_svc, has_permission):
+    def __init__(self, session, user, group_svc, links_svc, flag_svc, flag_count_svc, moderation_svc, user_svc, has_permission):
         self.session = session
         self.group_svc = group_svc
         self.links_svc = links_svc
@@ -24,7 +24,8 @@ class AnnotationJSONPresentationService(object):
         self.formatters = [
             formatters.AnnotationFlagFormatter(flag_svc, user),
             formatters.AnnotationHiddenFormatter(moderation_svc, moderator_check, user),
-            formatters.AnnotationModerationFormatter(flag_count_svc, user, has_permission)
+            formatters.AnnotationModerationFormatter(flag_count_svc, user, has_permission),
+            formatters.AnnotationUserInfoFormatter(self.session, user_svc),
         ]
 
     def present(self, annotation_resource):
@@ -58,6 +59,7 @@ def annotation_json_presentation_service_factory(context, request):
     flag_svc = request.find_service(name='flag')
     flag_count_svc = request.find_service(name='flag_count')
     moderation_svc = request.find_service(name='annotation_moderation')
+    user_svc = request.find_service(name='user')
     return AnnotationJSONPresentationService(session=request.db,
                                              user=request.user,
                                              group_svc=group_svc,
@@ -65,4 +67,5 @@ def annotation_json_presentation_service_factory(context, request):
                                              flag_svc=flag_svc,
                                              flag_count_svc=flag_count_svc,
                                              moderation_svc=moderation_svc,
+                                             user_svc=user_svc,
                                              has_permission=request.has_permission)

--- a/tests/common/factories/annotation.py
+++ b/tests/common/factories/annotation.py
@@ -23,7 +23,8 @@ class Annotation(ModelFactory):
     tags = factory.LazyFunction(lambda: FAKER.words(nb=random.randint(0, 5)))
     target_uri = factory.Faker('uri')
     text = factory.Faker('paragraph')
-    userid = factory.Faker('user_name')
+    userid = factory.LazyFunction(lambda: "acct:{username}@{authority}".format(
+        username=FAKER.user_name(), authority=FAKER.domain_name(levels=1)))
     document = factory.SubFactory(Document)
 
     @factory.lazy_attribute

--- a/tests/h/formatters/annotation_user_info_test.py
+++ b/tests/h/formatters/annotation_user_info_test.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from collections import namedtuple
+
+import mock
+import pytest
+
+from h.formatters.annotation_user_info import AnnotationUserInfoFormatter
+
+FakeAnnotationResource = namedtuple('FakeAnnotationResource', ['annotation'])
+
+
+class TestAnnotationUserInfoFormatter(object):
+    def test_preload_fetches_users_by_id(self, formatter, factories, user_svc):
+        annotation_1 = factories.Annotation()
+        annotation_2 = factories.Annotation()
+
+        formatter.preload([annotation_1.id, annotation_2.id])
+
+        user_svc.fetch_all.assert_called_once_with(
+                set([annotation_1.userid, annotation_2.userid]))
+
+    def test_format_fetches_user_by_id(self, formatter, factories, user_svc):
+        annotation = factories.Annotation.build()
+        resource = FakeAnnotationResource(annotation)
+
+        formatter.format(resource)
+
+        user_svc.fetch.assert_called_once_with(annotation.userid)
+
+    def test_format_returns_user_info_object(self, formatter, user_svc):
+        user_svc.fetch.return_value = mock.Mock(display_name='Jane Doe')
+        resource = FakeAnnotationResource(mock.Mock())
+
+        result = formatter.format(resource)
+        assert result == {'user_info': {'display_name': 'Jane Doe'}}
+
+    def test_format_allows_null_display_name(self, formatter, user_svc):
+        user_svc.fetch.return_value = mock.Mock(display_name=None)
+        resource = FakeAnnotationResource(mock.Mock())
+
+        result = formatter.format(resource)
+        assert result == {'user_info': {'display_name': None}}
+
+    def test_format_returns_empty_dict_when_user_missing(self, formatter, user_svc):
+        user_svc.fetch.return_value = None
+        resource = FakeAnnotationResource(mock.Mock())
+
+        assert formatter.format(resource) == {}
+
+    @pytest.fixture
+    def formatter(self, db_session, user_svc):
+        return AnnotationUserInfoFormatter(db_session, user_svc)
+
+    @pytest.fixture
+    def user_svc(self):
+        return mock.Mock(spec_set=['fetch_all', 'fetch'])

--- a/tests/h/schemas/annotation_test.py
+++ b/tests/h/schemas/annotation_test.py
@@ -205,6 +205,7 @@ class TestCreateUpdateAnnotationSchema(object):
         'flagged',
         'hidden',
         'moderation',
+        'user_info',
     ])
     def test_it_removes_protected_fields(self, pyramid_request, validate, field):
         data = {}

--- a/tests/h/services/annotation_json_presentation_test.py
+++ b/tests/h/services/annotation_json_presentation_test.py
@@ -50,6 +50,10 @@ class TestAnnotationJSONPresentationService(object):
         svc = self.svc(services)
         assert formatters.AnnotationUserInfoFormatter.return_value in svc.formatters
 
+    def test_it_skips_configuring_user_info_formatter_when_told_to(self, services, formatters):
+        svc = self.svc(services, render_user_info=False)
+        assert formatters.AnnotationUserInfoFormatter.return_value not in svc.formatters
+
     def test_present_inits_presenter(self, svc, presenters, annotation_resource):
         svc.present(annotation_resource)
 
@@ -106,7 +110,7 @@ class TestAnnotationJSONPresentationService(object):
         assert result == [present.return_value]
 
     @pytest.fixture
-    def svc(self, services):
+    def svc(self, services, render_user_info=True):
         return AnnotationJSONPresentationService(session=mock.sentinel.db_session,
                                                  user=mock.sentinel.user,
                                                  group_svc=services['group'],
@@ -115,7 +119,8 @@ class TestAnnotationJSONPresentationService(object):
                                                  flag_count_svc=services['flag_count'],
                                                  moderation_svc=services['annotation_moderation'],
                                                  user_svc=services['user'],
-                                                 has_permission=mock.sentinel.has_permission)
+                                                 has_permission=mock.sentinel.has_permission,
+                                                 render_user_info=render_user_info)
 
     @pytest.fixture
     def annotation_resource(self):

--- a/tests/h/services/annotation_json_presentation_test.py
+++ b/tests/h/services/annotation_json_presentation_test.py
@@ -41,6 +41,15 @@ class TestAnnotationJSONPresentationService(object):
         svc = self.svc(services)
         assert formatters.AnnotationModerationFormatter.return_value in svc.formatters
 
+    def test_initializes_user_info_formatter(self, services, formatters):
+        self.svc(services)
+        formatters.AnnotationUserInfoFormatter.assert_called_once_with(mock.sentinel.db_session,
+                                                                       services['user'])
+
+    def test_it_configures_user_info_formatter(self, services, formatters):
+        svc = self.svc(services)
+        assert formatters.AnnotationUserInfoFormatter.return_value in svc.formatters
+
     def test_present_inits_presenter(self, svc, presenters, annotation_resource):
         svc.present(annotation_resource)
 
@@ -105,6 +114,7 @@ class TestAnnotationJSONPresentationService(object):
                                                  flag_svc=services['flag'],
                                                  flag_count_svc=services['flag_count'],
                                                  moderation_svc=services['annotation_moderation'],
+                                                 user_svc=services['user'],
                                                  has_permission=mock.sentinel.has_permission)
 
     @pytest.fixture
@@ -201,7 +211,7 @@ class TestAnnotationJSONPresentationServiceFactory(object):
 def services(pyramid_config):
     service_mocks = {}
 
-    for name in ['links', 'flag', 'flag_count', 'annotation_moderation']:
+    for name in ['links', 'flag', 'flag_count', 'annotation_moderation', 'user']:
         svc = mock.Mock()
         service_mocks[name] = svc
         pyramid_config.register_service(svc, name=name)

--- a/tests/h/services/user_test.py
+++ b/tests/h/services/user_test.py
@@ -31,6 +31,24 @@ class TestUserService(object):
         assert user is not None
         assert user.username == 'jacqui'
 
+    def test_fetch_all_retrieves_users_by_userid(self, svc):
+        result = svc.fetch_all(['acct:jacqui@foo.com', 'acct:steve@example.com'])
+
+        assert len(result) == 2
+        assert isinstance(result[0], User)
+        assert isinstance(result[1], User)
+
+    def test_fetch_all_caches_fetched_users(self, db_session, svc, users):
+        jacqui, _, _ = users
+
+        svc.fetch_all(['acct:jacqui@foo.com'])
+        db_session.delete(jacqui)
+        db_session.flush()
+
+        result = svc.fetch_all(['acct:jacqui@foo.com'])
+        assert len(result) == 1
+        assert result[0].username == 'jacqui'
+
     def test_fetch_for_login_by_username(self, svc, users):
         _, steve, _ = users
         assert svc.fetch_for_login('steve') is steve

--- a/tests/h/services/user_test.py
+++ b/tests/h/services/user_test.py
@@ -20,6 +20,17 @@ class TestUserService(object):
 
         assert isinstance(result, User)
 
+    def test_fetch_caches_fetched_users(self, db_session, svc, users):
+        jacqui, _, _ = users
+
+        svc.fetch('acct:jacqui@foo.com')
+        db_session.delete(jacqui)
+        db_session.flush()
+        user = svc.fetch('acct:jacqui@foo.com')
+
+        assert user is not None
+        assert user.username == 'jacqui'
+
     def test_fetch_for_login_by_username(self, svc, users):
         _, steve, _ = users
         assert svc.fetch_for_login('steve') is steve
@@ -64,6 +75,36 @@ class TestUserService(object):
             svc.update_preferences(user, foo='bar', baz='qux')
 
         assert 'keys baz, foo are not allowed' in exc.value.message
+
+    def test_sets_up_cache_clearing_on_transaction_end(self, patch, db_session):
+        decorator = patch('h.services.user.on_transaction_end')
+
+        UserService(default_authority='example.com', session=db_session)
+
+        decorator.assert_called_once_with(db_session)
+
+    def test_clears_cache_on_transaction_end(self, patch, db_session, users):
+        funcs = {}
+
+        # We need to capture the inline `clear_cache` function so we can
+        # call it manually later
+        def on_transaction_end_decorator(session):
+            def on_transaction_end(func):
+                funcs['clear_cache'] = func
+            return on_transaction_end
+
+        decorator = patch('h.services.user.on_transaction_end')
+        decorator.side_effect = on_transaction_end_decorator
+
+        jacqui, _, _ = users
+        svc = UserService(default_authority='example.com', session=db_session)
+        svc.fetch('acct:jacqui@foo.com')
+        db_session.delete(jacqui)
+
+        funcs['clear_cache']()
+
+        user = svc.fetch('acct:jacqui@foo.com')
+        assert user is None
 
     @pytest.fixture
     def svc(self, db_session):


### PR DESCRIPTION
It will be much easier to review commit-by-commit as I had to shuffle quite a bit of code around.

This is adding a new `"user_info": {"display_name": "John Doe"}` object to the annotation JSON response. It is also behind a feature flag, mostly to test out and have a quick way out in case it puts too much pressure on the database.