### PR TITLE
Work around limitations of `window.postMessage` in IE 11

### DIFF
--- a/h/static/scripts/post-auth.js
+++ b/h/static/scripts/post-auth.js
@@ -10,15 +10,50 @@
 
 const settings = require('./base/settings')(document);
 
-if (window.opener) {
+function sendAuthResponse() {
+  if (!window.opener) {
+    console.error('The client window was closed');
+    return;
+  }
+
   const msg = {
     type: 'authorization_response',
     code: settings.code,
     state: settings.state,
   };
+
+  // `document.documentMode` is a non-standard IE-only property.
+  const isIE = 'documentMode' in document;
+  if (isIE) {
+    try {
+      // IE 11 does not support `window.postMessage` between top-level windows
+      // [1]. For the specific use case of the Hypothesis client, the sidebar
+      // HTML page is on the same domain as the h service, so we can dispatch
+      // the "message" event manually. Third-party clients will need to use
+      // redirects to receive the auth code if they want to support IE 11.
+      //
+      // [1] https://blogs.msdn.microsoft.com/thebeebs/2011/12/21/postmessage-popups-and-ie/
+
+      // Create an event in the target window.
+      const clientWindow = window.opener;
+      const event = clientWindow.document.createEvent('HTMLEvents');
+      event.initEvent('message', true, true);
+
+      // Clone the `msg` object into an object belonging to the target window.
+      event.data = clientWindow.JSON.parse(JSON.stringify(msg));
+
+      // Trigger "message" event listener in the target window.
+      clientWindow.dispatchEvent(event);
+      window.close();
+    } catch (err) {
+      console.error('The "web_message" response mode is not supported in IE', err);
+    }
+    return;
+  }
+
   window.opener.postMessage(msg, settings.origin);
   window.close();
-} else {
-  console.error('The opening window has closed');
 }
+
+sendAuthResponse();
 


### PR DESCRIPTION
In IE 11, postMessage support is limited to frames embedded within a
page and doesn't work between a popup window and its opener. This means
that OAuth clients wanting to support this browser will need to use a
redirect rather than the "web_message" response mode.

For the specific use case of the Hypothesis client, we can work around
the problem by manually dispatching the "message" event, in the target
window, that a `postMessage` call usually results in. This only works
because the sidebar's "app.html" and the auth popup are served from the
same domain.

IE 11 usage is currently around ~1% of client views, so it seems likely
that we might just be able to drop support a few months from now.

----

Testing this without IE can be done by changing the `const isIE` initialization to `const isIE = true`. If actually testing in IE, you'll need to open the dev tools at the "Network" tab and check the "Always refresh from the server" toolbar icon to work around some caching issues that currently affect XHR responses, at least in development.