### PR TITLE
Require revalidation before using cached API responses

### DIFF
--- a/h/app.py
+++ b/h/app.py
@@ -54,6 +54,7 @@ def includeme(config):
     config.add_tween('h.tweens.redirect_tween_factory')
     config.add_tween('h.tweens.csrf_tween_factory')
     config.add_tween('h.tweens.security_header_tween_factory')
+    config.add_tween('h.tweens.cache_header_tween_factory')
 
     config.add_request_method(in_debug_mode, 'debug', reify=True)
 

--- a/h/tweens.py
+++ b/h/tweens.py
@@ -103,3 +103,19 @@ def security_header_tween_factory(handler, registry):
         return resp
 
     return security_header_tween
+
+
+def cache_header_tween_factory(handler, registry):
+    """
+    Sets default caching headers on responses depending on the content type.
+    """
+    def cache_header_tween(request):
+        resp = handler(request)
+
+        # Require revalidation before using any cached API responses.
+        if 'application/json' in resp.headers['Content-Type']:
+            resp.headers.setdefault('Cache-Control', 'no-cache')
+
+        return resp
+
+    return cache_header_tween

--- a/h/tweens.py
+++ b/h/tweens.py
@@ -113,7 +113,7 @@ def cache_header_tween_factory(handler, registry):
         resp = handler(request)
 
         # Require revalidation before using any cached API responses.
-        if 'application/json' in resp.headers['Content-Type']:
+        if 'application/json' in resp.headers.get('Content-Type', []):
             resp.headers.setdefault('Cache-Control', 'no-cache')
 
         return resp

--- a/tests/h/tweens_test.py
+++ b/tests/h/tweens_test.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+import pytest
+
 from h import tweens
 from h.util.redirects import Redirect
 
@@ -58,3 +60,17 @@ def test_tween_security_header_adds_headers(pyramid_request):
 
     assert response.headers['Referrer-Policy'] == 'origin-when-cross-origin, strict-origin-when-cross-origin'
     assert response.headers['X-XSS-Protection'] == '1; mode=block'
+
+
+@pytest.mark.parametrize('content_type, expected_cc_header', [
+    ('text/html', None),
+    ('application/json', 'no-cache'),
+])
+def test_tween_cache_header_adds_headers(pyramid_request, content_type, expected_cc_header):
+    tween = tweens.cache_header_tween_factory(lambda req: req.response,
+                                              pyramid_request.registry)
+    pyramid_request.response.headers['Content-Type'] = content_type
+
+    response = tween(pyramid_request)
+
+    assert response.headers.get('Cache-Control') == expected_cc_header

--- a/tests/h/tweens_test.py
+++ b/tests/h/tweens_test.py
@@ -63,13 +63,21 @@ def test_tween_security_header_adds_headers(pyramid_request):
 
 
 @pytest.mark.parametrize('content_type, expected_cc_header', [
+    # Web pages.
     ('text/html', None),
+
+    # An API or XHR response.
     ('application/json', 'no-cache'),
+
+    # A response with no content (eg. 204 response to a `DELETE` request).
+    (None, None),
 ])
 def test_tween_cache_header_adds_headers(pyramid_request, content_type, expected_cc_header):
     tween = tweens.cache_header_tween_factory(lambda req: req.response,
                                               pyramid_request.registry)
-    pyramid_request.response.headers['Content-Type'] = content_type
+
+    if content_type is not None:
+        pyramid_request.response.headers['Content-Type'] = content_type
 
     response = tween(pyramid_request)
 


### PR DESCRIPTION
Require the browser to revalidate any API responses using a request with
an `If-None-Match: <etag of last response>` header before using a
cached response.

This fixes an issue where IE 11 would cache responses to eg.
`/api/profile` requests and then re-use them even if the `Authorization`
header had changed. Other browsers have different heuristics and were
already revalidating the cached response in this case.

I'm currently doing additional testing with modern browsers to check whether adding this header has any unexpected effects on how they handle caching of API responses.