### PR TITLE
Use presentation service when creating and updating annotation

### DIFF
--- a/h/views/api.py
+++ b/h/views/api.py
@@ -24,7 +24,7 @@ from h import storage
 from h.exceptions import PayloadError
 from h.events import AnnotationEvent
 from h.interfaces import IGroupService
-from h.presenters import AnnotationJSONPresenter, AnnotationJSONLDPresenter
+from h.presenters import AnnotationJSONLDPresenter
 from h.resources import AnnotationResource
 from h.schemas.annotation import CreateAnnotationSchema, UpdateAnnotationSchema
 from h.views.api_config import api_config, AngularRouteTemplater
@@ -130,11 +130,9 @@ def create(request):
 
     _publish_annotation_event(request, annotation, 'create')
 
-    links_service = request.find_service(name='links')
-    group_service = request.find_service(IGroupService)
-    resource = AnnotationResource(annotation, group_service, links_service)
-    presenter = AnnotationJSONPresenter(resource)
-    return presenter.asdict()
+    svc = request.find_service(name='annotation_json_presentation')
+    annotation_resource = _annotation_resource(request, annotation)
+    return svc.present(annotation_resource)
 
 
 @api_config(route_name='api.annotation',
@@ -180,11 +178,9 @@ def update(context, request):
 
     _publish_annotation_event(request, annotation, 'update')
 
-    links_service = request.find_service(name='links')
-    group_service = request.find_service(IGroupService)
-    resource = AnnotationResource(annotation, group_service, links_service)
-    presenter = AnnotationJSONPresenter(resource)
-    return presenter.asdict()
+    svc = request.find_service(name='annotation_json_presentation')
+    annotation_resource = _annotation_resource(request, annotation)
+    return svc.present(annotation_resource)
 
 
 @api_config(route_name='api.annotation',
@@ -245,3 +241,9 @@ def _set_at_path(dict_, path, value):
         dict_[key] = value
     else:
         _set_at_path(dict_[key], path[1:], value)
+
+
+def _annotation_resource(request, annotation):
+    group_service = request.find_service(IGroupService)
+    links_service = request.find_service(name='links')
+    return AnnotationResource(annotation, group_service, links_service)

--- a/tests/h/views/api_test.py
+++ b/tests/h/views/api_test.py
@@ -140,10 +140,10 @@ class TestSearch(object):
 
 
 @pytest.mark.usefixtures('AnnotationEvent',
-                         'AnnotationJSONPresenter',
                          'create_schema',
                          'links_service',
                          'group_service',
+                         'presentation_service',
                          'storage')
 class TestCreate(object):
 
@@ -199,20 +199,6 @@ class TestCreate(object):
 
         assert exc.value.message == 'asplode'
 
-    def test_it_inits_AnnotationJSONPresenter(self,
-                                              AnnotationJSONPresenter,
-                                              annotation_resource,
-                                              links_service,
-                                              group_service,
-                                              pyramid_request,
-                                              storage):
-        views.create(pyramid_request)
-
-        annotation_resource.assert_called_once_with(
-                storage.create_annotation.return_value, group_service, links_service)
-
-        AnnotationJSONPresenter.assert_called_once_with(annotation_resource.return_value)
-
     def test_it_publishes_annotation_event(self,
                                            AnnotationEvent,
                                            pyramid_request,
@@ -228,14 +214,33 @@ class TestCreate(object):
         pyramid_request.notify_after_commit.assert_called_once_with(
             AnnotationEvent.return_value)
 
-    def test_it_returns_presented_annotation(self,
-                                             AnnotationJSONPresenter,
-                                             pyramid_request):
+    def test_it_initialises_annotation_resource(self,
+                                                storage,
+                                                annotation_resource,
+                                                pyramid_request,
+                                                group_service,
+                                                links_service):
+
+        annotation = storage.create_annotation.return_value
+
+        views.create(pyramid_request)
+
+        annotation_resource.assert_called_once_with(
+                annotation, group_service, links_service)
+
+    def test_it_presents_annotation(self,
+                                    annotation_resource,
+                                    presentation_service,
+                                    pyramid_request):
+        views.create(pyramid_request)
+
+        presentation_service.present.assert_called_once_with(
+                annotation_resource.return_value)
+
+    def test_it_returns_presented_annotation(self, presentation_service, pyramid_request):
         result = views.create(pyramid_request)
 
-        AnnotationJSONPresenter.return_value.asdict.assert_called_once_with()
-        assert result == (
-            AnnotationJSONPresenter.return_value.asdict.return_value)
+        assert result == presentation_service.present.return_value
 
     @pytest.fixture
     def pyramid_request(self, pyramid_request):
@@ -297,9 +302,9 @@ class TestReadJSONLD(object):
 
 
 @pytest.mark.usefixtures('AnnotationEvent',
-                         'AnnotationJSONPresenter',
                          'links_service',
                          'group_service',
+                         'presentation_service',
                          'update_schema',
                          'storage')
 class TestUpdate(object):
@@ -378,34 +383,35 @@ class TestUpdate(object):
         pyramid_request.notify_after_commit.assert_called_once_with(
             AnnotationEvent.return_value)
 
-    def test_it_inits_a_presenter(self,
-                                  AnnotationJSONPresenter,
-                                  annotation_resource,
-                                  group_service,
-                                  links_service,
-                                  pyramid_request,
-                                  storage):
+    def test_it_initialises_annotation_resource(self,
+                                                storage,
+                                                annotation_resource,
+                                                pyramid_request,
+                                                group_service,
+                                                links_service):
+
+        annotation = storage.update_annotation.return_value
+
         views.update(mock.Mock(), pyramid_request)
 
         annotation_resource.assert_called_once_with(
-                storage.update_annotation.return_value, group_service, links_service)
+                annotation, group_service, links_service)
 
-        AnnotationJSONPresenter.assert_any_call(annotation_resource.return_value)
-
-    def test_it_dictizes_the_presenter(self,
-                                       AnnotationJSONPresenter,
-                                       pyramid_request):
+    def test_it_presents_annotation(self,
+                                    annotation_resource,
+                                    presentation_service,
+                                    pyramid_request):
         views.update(mock.Mock(), pyramid_request)
 
-        AnnotationJSONPresenter.return_value.asdict.assert_called_with()
+        presentation_service.present.assert_called_once_with(
+                annotation_resource.return_value)
 
     def test_it_returns_a_presented_dict(self,
-                                         AnnotationJSONPresenter,
+                                         presentation_service,
                                          pyramid_request):
         returned = views.update(mock.Mock(), pyramid_request)
 
-        assert returned == (
-            AnnotationJSONPresenter.return_value.asdict.return_value)
+        assert returned == presentation_service.present.return_value
 
     def test_it_tracks_deprecated_put_requests(self, pyramid_request):
         pyramid_request.method = 'PUT'
@@ -427,7 +433,6 @@ class TestUpdate(object):
 
 
 @pytest.mark.usefixtures('AnnotationEvent',
-                         'AnnotationJSONPresenter',
                          'links_service',
                          'storage')
 class TestDelete(object):
@@ -442,7 +447,6 @@ class TestDelete(object):
 
     def test_it_inits_and_fires_an_AnnotationEvent(self,
                                                    AnnotationEvent,
-                                                   AnnotationJSONPresenter,
                                                    pyramid_request):
         context = mock.Mock()
         event = AnnotationEvent.return_value
@@ -465,11 +469,6 @@ class TestDelete(object):
 @pytest.fixture
 def AnnotationEvent(patch):
     return patch('h.views.api.AnnotationEvent')
-
-
-@pytest.fixture
-def AnnotationJSONPresenter(patch):
-    return patch('h.views.api.AnnotationJSONPresenter')
 
 
 @pytest.fixture


### PR DESCRIPTION
We currently only initialise a new presenter when generating the response for `POST /api/annotations` and `PATCH /api/annotations/{id}`. This means that we don't actually render any information that is currently implemented as formatters.

This changes the view code to go through the `AnnotationJSONPresentation` service. This means that all three API endpoints that currently render a JSON annotation are running through the same code path.