### PR TITLE
Add `user_info` object to `GET /api/profile` response

### DIFF
--- a/h/formatters/annotation_user_info.py
+++ b/h/formatters/annotation_user_info.py
@@ -6,6 +6,7 @@ from zope.interface import implementer
 
 from h import models
 from h.formatters.interfaces import IAnnotationFormatter
+from h.session import user_info
 
 
 @implementer(IAnnotationFormatter)
@@ -23,12 +24,4 @@ class AnnotationUserInfoFormatter(object):
 
     def format(self, annotation_resource):
         user = self.user_svc.fetch(annotation_resource.annotation.userid)
-
-        if user is None:
-            return {}
-
-        return {
-            'user_info': {
-                'display_name': user.display_name,
-            }
-        }
+        return user_info(user)

--- a/h/session.py
+++ b/h/session.py
@@ -38,6 +38,8 @@ def profile(request, authority=None):
     profile['groups'] = _current_groups(request, authority)
     profile['features'] = request.feature.all()
     profile['preferences'] = _user_preferences(user)
+    profile.update(user_info(user))
+
     return profile
 
 

--- a/h/session.py
+++ b/h/session.py
@@ -41,6 +41,23 @@ def profile(request, authority=None):
     return profile
 
 
+def user_info(user):
+    """
+    Returns the `user_info` JSON object.
+
+    This is being used in the JSON representation of an annotation,
+    and for the user profile.
+    """
+    if user is None:
+        return {}
+
+    return {
+        'user_info': {
+            'display_name': user.display_name,
+        }
+    }
+
+
 def pop_flash(request):
     return {k: request.session.pop_flash(k)
             for k in ['error', 'info', 'warning', 'success']}

--- a/tests/h/formatters/annotation_user_info_test.py
+++ b/tests/h/formatters/annotation_user_info_test.py
@@ -34,29 +34,26 @@ class TestAnnotationUserInfoFormatter(object):
 
         user_svc.fetch.assert_called_once_with(annotation.userid)
 
-    def test_format_returns_user_info_object(self, formatter, user_svc):
-        user_svc.fetch.return_value = mock.Mock(display_name='Jane Doe')
-        resource = FakeAnnotationResource(mock.Mock())
+    def test_format_uses_user_info(self, formatter, user_svc, user_info):
+        user = mock.Mock(display_name='Jane Doe')
+        user_svc.fetch.return_value = user
 
-        result = formatter.format(resource)
-        assert result == {'user_info': {'display_name': 'Jane Doe'}}
+        formatter.format(FakeAnnotationResource(mock.Mock()))
 
-    def test_format_allows_null_display_name(self, formatter, user_svc):
-        user_svc.fetch.return_value = mock.Mock(display_name=None)
-        resource = FakeAnnotationResource(mock.Mock())
+        user_info.assert_called_once_with(user)
 
-        result = formatter.format(resource)
-        assert result == {'user_info': {'display_name': None}}
+    def test_format_returns_formatted_user_info(self, formatter, user_info):
+        result = formatter.format(FakeAnnotationResource(mock.Mock()))
 
-    def test_format_returns_empty_dict_when_user_missing(self, formatter, user_svc):
-        user_svc.fetch.return_value = None
-        resource = FakeAnnotationResource(mock.Mock())
-
-        assert formatter.format(resource) == {}
+        assert result == user_info.return_value
 
     @pytest.fixture
     def formatter(self, db_session, user_svc):
         return AnnotationUserInfoFormatter(db_session, user_svc)
+
+    @pytest.fixture
+    def user_info(self, patch):
+        return patch('h.formatters.annotation_user_info.user_info')
 
     @pytest.fixture
     def user_svc(self):

--- a/tests/h/session_test.py
+++ b/tests/h/session_test.py
@@ -205,6 +205,15 @@ class TestProfile(object):
 
         assert profile['authority'] == third_party_domain
 
+    def test_user_info_authenticated(self, authenticated_request, patch):
+        profile = session.profile(authenticated_request)
+        user_info = profile['user_info']
+        assert user_info['display_name'] == authenticated_request.user.display_name
+
+    def test_user_info_unauthenticated(self, unauthenticated_request):
+        profile = session.profile(unauthenticated_request)
+        assert 'user_info' not in profile
+
     @pytest.fixture
     def third_party_domain(self):
         return u'thirdparty.example.org'

--- a/tests/h/session_test.py
+++ b/tests/h/session_test.py
@@ -221,6 +221,23 @@ class TestProfile(object):
         return FakeGroup('abcdef', 'Publisher group', is_public=True)
 
 
+class TestUserInfo(object):
+    def test_returns_user_info_object(self, factories):
+        user = factories.User.build(display_name='Jane Doe')
+
+        result = session.user_info(user)
+        assert result == {'user_info': {'display_name': 'Jane Doe'}}
+
+    def test_allows_null_display_name(self, factories):
+        user = factories.User.build(display_name=None)
+
+        result = session.user_info(user)
+        assert result == {'user_info': {'display_name': None}}
+
+    def test_format_returns_empty_dict_when_user_missing(self):
+        assert session.user_info(None) == {}
+
+
 class FakeAuthorityGroupService(object):
 
     def __init__(self, public_groups):


### PR DESCRIPTION
This is in addition to #4645, so that the client can render the display name for new annotation cards that haven't been synced to the backend yet.