### PR TITLE
Look up annotations in DB when deleting user

### DIFF
--- a/tests/h/cli/commands/user_test.py
+++ b/tests/h/cli/commands/user_test.py
@@ -186,7 +186,7 @@ class TestPasswordCommand(object):
 
 
 class TestDeleteUserCommand(object):
-    def test_it_deletes_user(self, cli, cliconfig, user, db_session, annotations):
+    def test_it_deletes_user(self, cli, cliconfig, user, db_session):
         result = cli.invoke(user_cli.delete,
                             [user.username],
                             obj=cliconfig)
@@ -194,7 +194,7 @@ class TestDeleteUserCommand(object):
         assert result.exit_code == 0
         user = db_session.query(models.User).filter_by(id=user.id).count() == 0
 
-    def test_it_deletes_user_with_specific_authority(self, cli, cliconfig, user, db_session, annotations):
+    def test_it_deletes_user_with_specific_authority(self, cli, cliconfig, user, db_session):
         user.authority = u'partner.org'
         db_session.flush()
 
@@ -228,13 +228,6 @@ class TestDeleteUserCommand(object):
         user = factories.User()
         db_session.flush()
         return user
-
-    @pytest.fixture
-    def annotations(self, pyramid_request, patch):
-        pyramid_request.es = mock.Mock()
-        es_helpers = patch('h.views.admin_users.es_helpers')
-        es_helpers.scan = mock.Mock(return_value=[])
-        return es_helpers.scan
 
 
 @pytest.fixture


### PR DESCRIPTION
This fixes a secondary issue uncovered after I discovered https://github.com/hypothesis/h/issues/4652

Given that finding annotations created by a particular user only
requires a query on the indexed `annotation.userid` column, we can do
the lookup directly in the source of truth (the DB) rather than ES.

This avoids a hazard where the ES helper query could fail to load an
annotation if for any reason ES is not fully in sync with the state of
the DB. In the case of #4652, the index was not in sync because the annotation
doesn't get deleted from ES. Even when that is resolved, there will be a delay between
the annotation being deleted from the DB and it being deleted from ES.