### PR TITLE
Move logic to publish annotation events into `h.storage`

### DIFF
--- a/h/views/admin_users.py
+++ b/h/views/admin_users.py
@@ -12,7 +12,7 @@ from h import storage
 from h.accounts.events import ActivationEvent
 from h.services.rename_user import UserRenameError
 from h.tasks.admin import rename_user
-from h.i18n import TranslationString as _
+from h.i18n import TranslationString as _  # noqa: N813
 
 
 class UserDeletionError(Exception):
@@ -149,7 +149,7 @@ def delete_user(request, user):
     query = _all_user_annotations_query(request, user)
     annotations = es_helpers.scan(client=request.es.conn, query={'query': query})
     for annotation in annotations:
-        storage.delete_annotation(request.db, annotation['_id'])
+        storage.delete_annotation(request, annotation['_id'])
 
     request.db.delete(user)
 

--- a/tests/common/matchers.py
+++ b/tests/common/matchers.py
@@ -93,7 +93,24 @@ class mapping_containing(Matcher):  # noqa: N801
         return '<mapping containing {!r}>'.format(self.key)
 
 
-class redirect_302_to(Matcher):
+class same_dicts(Matcher):  # noqa: N801
+    """
+    An object __eq__ any other object with the same __dict__.
+
+    This is useful when comparing objects that are essentially simple records.
+    """
+
+    def __init__(self, value):
+        self.value = value
+
+    def __eq__(self, other):
+        return self.value.__dict__ == other.__dict__
+
+    def __repr__(self):
+        return '<object matching {}>'.format(repr(self.value.__dict__))
+
+
+class redirect_302_to(Matcher):  # noqa: N801
     """Matches any HTTPFound redirect to the given URL."""
 
     def __init__(self, location):
@@ -105,7 +122,7 @@ class redirect_302_to(Matcher):
         return other.location == self.location
 
 
-class redirect_303_to(Matcher):
+class redirect_303_to(Matcher):  # noqa: N801
     """Matches any HTTPSeeOther redirect to the given URL."""
 
     def __init__(self, location):
@@ -117,7 +134,7 @@ class redirect_303_to(Matcher):
         return other.location == self.location
 
 
-class regex(Matcher):
+class regex(Matcher):  # noqa: N801
     """Matches any string matching the passed regex."""
 
     def __init__(self, patt):
@@ -130,7 +147,7 @@ class regex(Matcher):
         return '<string matching re {!r}>'.format(self.patt.pattern)
 
 
-class unordered_list(Matcher):
+class unordered_list(Matcher):  # noqa: N801
     """
     Matches a list with the same items in any order.
 

--- a/tests/h/views/admin_users_test.py
+++ b/tests/h/views/admin_users_test.py
@@ -281,8 +281,8 @@ def test_delete_user_deletes_annotations(api_storage, elasticsearch_helpers, fak
     delete_user(pyramid_request, user)
 
     assert api_storage.delete_annotation.mock_calls == [
-        call(pyramid_request.db, 'annotation-1'),
-        call(pyramid_request.db, 'annotation-2')
+        call(pyramid_request, 'annotation-1'),
+        call(pyramid_request, 'annotation-2')
     ]
 
 


### PR DESCRIPTION
Ensure that when `h.storage.{create, update, delete}_annotation` methods
are used outside of `h.views.api`, the correct annotation events are
published so that the streamer and ElasticSearch indexes are updated
correctly.

This fixes an issue where deleting users did not remove their annotations from ElasticSearch, though it should have done.

This bug probably means that we have a whole bunch of annotations in the prod ES
instance that are associated with user accounts that no longer exist. I'm not sure that reindexing will fix that because it doesn't remove invalid entries from ES AFAIK.

Fixes #4652