### PR TITLE
Allow to set display name when signing users up through API

### DIFF
--- a/docs/_extra/api/schemas/new-user-schema.json
+++ b/docs/_extra/api/schemas/new-user-schema.json
@@ -15,6 +15,10 @@
     "email": {
       "type": "string",
       "format": "email"
+    },
+    "display_name": {
+      "type": "string",
+      "maxLength": 30
     }
   },
   "required": [

--- a/h/accounts/schemas.py
+++ b/h/accounts/schemas.py
@@ -10,6 +10,7 @@ from h import i18n, models, validators
 from h.accounts import util
 from h.services.user import UserNotActivated
 from h.models.user import (
+    DISPLAY_NAME_MAX_LENGTH,
     EMAIL_MAX_LENGTH,
     USERNAME_MAX_LENGTH,
     USERNAME_MIN_LENGTH,
@@ -376,6 +377,10 @@ class CreateUserAPISchema(JSONSchema):
             'email': {
                 'type': 'string',
                 'format': 'email',
+            },
+            'display_name': {
+                'type': 'string',
+                'maxLength': DISPLAY_NAME_MAX_LENGTH,
             },
         },
         'required': [

--- a/h/accounts/schemas.py
+++ b/h/accounts/schemas.py
@@ -312,7 +312,7 @@ class EditProfileSchema(CSRFSchema):
     display_name = colander.SchemaNode(
         colander.String(),
         missing=None,
-        validator=validators.Length(max=30),
+        validator=validators.Length(max=DISPLAY_NAME_MAX_LENGTH),
         title=_('Display name'))
 
     description = colander.SchemaNode(
@@ -370,8 +370,8 @@ class CreateUserAPISchema(JSONSchema):
             },
             'username': {
                 'type': 'string',
-                'minLength': 3,
-                'maxLength': 30,
+                'minLength': USERNAME_MIN_LENGTH,
+                'maxLength': USERNAME_MAX_LENGTH,
                 'pattern': '^[A-Za-z0-9._]+$',
             },
             'email': {

--- a/h/accounts/schemas.py
+++ b/h/accounts/schemas.py
@@ -377,6 +377,7 @@ class CreateUserAPISchema(JSONSchema):
             'email': {
                 'type': 'string',
                 'format': 'email',
+                'maxLength': EMAIL_MAX_LENGTH,
             },
             'display_name': {
                 'type': 'string',

--- a/h/models/user.py
+++ b/h/models/user.py
@@ -15,6 +15,7 @@ USERNAME_MIN_LENGTH = 3
 USERNAME_MAX_LENGTH = 30
 USERNAME_PATTERN = '(?i)^[A-Z0-9._]+$'
 EMAIL_MAX_LENGTH = 100
+DISPLAY_NAME_MAX_LENGTH = 30
 
 
 def _normalise_username(username):

--- a/h/views/api_users.py
+++ b/h/views/api_users.py
@@ -9,7 +9,7 @@ import sqlalchemy as sa
 from h import models
 from h.accounts import schemas
 from h.auth.util import basic_auth_creds
-from h.exceptions import ClientUnauthorized
+from h.exceptions import ClientUnauthorized, PayloadError
 from h.models.auth_client import GrantType
 from h.schemas import ValidationError
 from h.util.view import json_view
@@ -28,7 +28,7 @@ def create(request):
     client = _request_client(request)
 
     schema = schemas.CreateUserAPISchema()
-    appstruct = schema.validate(request.json_body)
+    appstruct = schema.validate(_json_payload(request))
 
     _check_authority(client, appstruct)
     appstruct['authority'] = client.authority
@@ -98,3 +98,10 @@ def _request_client(request):
         raise ClientUnauthorized()
 
     return client
+
+
+def _json_payload(request):
+    try:
+        return request.json_body
+    except ValueError:
+        raise PayloadError()

--- a/h/views/api_users.py
+++ b/h/views/api_users.py
@@ -42,6 +42,7 @@ def create(request):
         'email': user.email,
         'userid': user.userid,
         'username': user.username,
+        'display_name': user.display_name,
     }
 
 

--- a/tests/h/accounts/schemas_test.py
+++ b/tests/h/accounts/schemas_test.py
@@ -629,12 +629,25 @@ class TestCreateUserAPISchema(object):
         with pytest.raises(ValidationError):
             schema.validate(payload)
 
+    def test_it_raises_when_display_name_not_a_string(self, schema, payload):
+        payload['display_name'] = 42
+
+        with pytest.raises(ValidationError):
+            schema.validate(payload)
+
+    def test_it_raises_when_display_name_too_long(self, schema, payload):
+        payload['display_name'] = 'Dagrun Bibianne Selen Asya Foobar'
+
+        with pytest.raises(ValidationError):
+            schema.validate(payload)
+
     @pytest.fixture
     def payload(self):
         return {
             'authority': 'foobar.org',
             'username': 'dagrun',
             'email': 'dagrun@foobar.org',
+            'display_name': 'Dagrun Foobar',
         }
 
     @pytest.fixture

--- a/tests/h/accounts/schemas_test.py
+++ b/tests/h/accounts/schemas_test.py
@@ -629,6 +629,16 @@ class TestCreateUserAPISchema(object):
         with pytest.raises(ValidationError):
             schema.validate(payload)
 
+    def test_it_raises_when_email_too_long(self, schema, payload):
+        payload['email'] = ('dagrun.bibianne.selen.asya.'
+                            'dagrun.bibianne.selen.asya.'
+                            'dagrun.bibianne.selen.asya.'
+                            'dagrun.bibianne.selen.asya'
+                            '@foobar.com')
+
+        with pytest.raises(ValidationError):
+            schema.validate(payload)
+
     def test_it_raises_when_display_name_not_a_string(self, schema, payload):
         payload['display_name'] = 42
 

--- a/tests/h/views/api_users_test.py
+++ b/tests/h/views/api_users_test.py
@@ -31,6 +31,7 @@ class TestCreate(object):
         assert result == {
             'userid': 'acct:jeremy@weylandindustries.com',
             'username': 'jeremy',
+            'display_name': 'Jeremy Weyland',
             'email': 'jeremy@weylandtech.com',
             'authority': 'weylandindustries.com',
         }
@@ -50,7 +51,8 @@ class TestCreate(object):
             require_activation=False,
             authority='weylandindustries.com',
             username='jeremy',
-            email='jeremy@weylandtech.com')
+            email='jeremy@weylandtech.com',
+            display_name='Jeremy Weyland')
 
     def test_raises_when_no_creds(self, pyramid_request, valid_payload):
         pyramid_request.json_body = valid_payload
@@ -238,4 +240,5 @@ def valid_payload():
         'authority': 'weylandindustries.com',
         'email': 'jeremy@weylandtech.com',
         'username': 'jeremy',
+        'display_name': 'Jeremy Weyland',
     }

--- a/tests/h/views/api_users_test.py
+++ b/tests/h/views/api_users_test.py
@@ -3,9 +3,9 @@
 from __future__ import unicode_literals
 
 import pytest
-from mock import Mock
+from mock import Mock, PropertyMock
 
-from h.exceptions import ClientUnauthorized
+from h.exceptions import ClientUnauthorized, PayloadError
 from h.models.auth_client import GrantType
 from h.schemas import ValidationError
 from h.services.user_signup import UserSignupService
@@ -198,6 +198,13 @@ class TestCreate(object):
 
         assert ('email address %s already exists' % existing_user.email) in str(exc.value)
         assert ('username %s already exists' % existing_user.username) in str(exc.value)
+
+    @pytest.mark.usefixtures('valid_auth')
+    def test_raises_for_invalid_json_body(self, pyramid_request, patch):
+        type(pyramid_request).json_body = PropertyMock(side_effect=ValueError())
+
+        with pytest.raises(PayloadError):
+            create(pyramid_request)
 
     @pytest.fixture
     def schemas(self, patch):


### PR DESCRIPTION
This is part of hypothesis/product-backlog#323.

It allows API clients who use the `POST /api/users` endpoint to set the display name of a user at the time the user is getting signed up.