### PR TITLE
Update user API endpoint

### DIFF
--- a/docs/_extra/api/hypothesis.yaml
+++ b/docs/_extra/api/hypothesis.yaml
@@ -318,6 +318,31 @@ paths:
             $ref: '#/definitions/Error'
       security:
         - authClientCredentials: []
+  /users/{username}:
+    patch:
+      summary: Update an existing user
+      description: |
+        Only for specific auth clients, this API call allows clients with a
+        designated authority to update users within their authority.
+      operationId: updateUser
+      parameters:
+        - name: user
+          in: body
+          description: User to be created
+          required: true
+          schema:
+            $ref: '#/definitions/UpdateUser'
+      responses:
+        '200':
+          description: User successfully updated
+          schema:
+            $ref: '#/definitions/User'
+        '400':
+          description: Could not update user from your request
+          schema:
+            $ref: '#/definitions/Error'
+      security:
+        - authClientCredentials: []
   /groups/{id}/members/{user}:
     delete:
       summary: Remove a member from a group
@@ -381,6 +406,8 @@ definitions:
         type: integer
   NewUser:
     $ref: './schemas/new-user-schema.json'
+  UpdateUser:
+    $ref: './schemas/update-user-schema.json'
   User:
     $ref: './schemas/user-schema.json'
   Profile:

--- a/docs/_extra/api/schemas/update-user-schema.json
+++ b/docs/_extra/api/schemas/update-user-schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "email": {
+      "type": "string",
+      "format": "email"
+    },
+    "display_name": {
+      "type": "string",
+      "maxLength": 30
+    }
+  }
+}

--- a/h/accounts/schemas.py
+++ b/h/accounts/schemas.py
@@ -392,5 +392,24 @@ class CreateUserAPISchema(JSONSchema):
     }
 
 
+class UpdateUserAPISchema(JSONSchema):
+    """Validate a user JSON object."""
+
+    schema = {
+        'type': 'object',
+        'properties': {
+            'email': {
+                'type': 'string',
+                'format': 'email',
+                'maxLength': EMAIL_MAX_LENGTH,
+            },
+            'display_name': {
+                'type': 'string',
+                'maxLength': DISPLAY_NAME_MAX_LENGTH,
+            },
+        },
+    }
+
+
 def includeme(config):
     pass

--- a/h/presenters/__init__.py
+++ b/h/presenters/__init__.py
@@ -14,6 +14,7 @@ from h.presenters.annotation_searchindex import AnnotationSearchIndexPresenter
 from h.presenters.document_html import DocumentHTMLPresenter
 from h.presenters.document_json import DocumentJSONPresenter
 from h.presenters.document_searchindex import DocumentSearchIndexPresenter
+from h.presenters.user_json import UserJSONPresenter
 
 __all__ = (
     'AnnotationHTMLPresenter',
@@ -23,4 +24,5 @@ __all__ = (
     'DocumentHTMLPresenter',
     'DocumentJSONPresenter',
     'DocumentSearchIndexPresenter',
+    'UserJSONPresenter',
 )

--- a/h/presenters/user_json.py
+++ b/h/presenters/user_json.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+
+class UserJSONPresenter(object):
+    """
+    Present a user in the JSON format returned by API requests.
+
+    Note that this presenter as of now returns some information
+    that should not be publicly available, like the users email
+    address. This is fine for now because it is only used in
+    places where the caller has access to this. We would need
+    to refactor this as soon as we use this presenter for a
+    public API.
+    """
+
+    def __init__(self, user):
+        self.user = user
+
+    def asdict(self):
+        return {
+            'authority': self.user.authority,
+            'email': self.user.email,
+            'userid': self.user.userid,
+            'username': self.user.username,
+            'display_name': self.user.display_name,
+        }

--- a/h/routes.py
+++ b/h/routes.py
@@ -102,6 +102,7 @@ def includeme(config):
                      traverse='/{pubid}')
     config.add_route('api.search', '/api/search')
     config.add_route('api.users', '/api/users')
+    config.add_route('api.user', '/api/users/{username}')
     config.add_route('badge', '/api/badge')
     config.add_route('token', '/api/token')
     config.add_route('oauth_authorize', '/oauth/authorize')

--- a/h/views/api_users.py
+++ b/h/views/api_users.py
@@ -39,13 +39,8 @@ def create(request):
 
     user_signup_service = request.find_service(name='user_signup')
     user = user_signup_service.signup(require_activation=False, **appstruct)
-    return {
-        'authority': user.authority,
-        'email': user.email,
-        'userid': user.userid,
-        'username': user.username,
-        'display_name': user.display_name,
-    }
+    presenter = UserJSONPresenter(user)
+    return presenter.asdict()
 
 
 @json_view(route_name='api.user', request_method='PATCH')

--- a/h/views/api_users.py
+++ b/h/views/api_users.py
@@ -5,12 +5,14 @@ from __future__ import unicode_literals
 import hmac
 
 import sqlalchemy as sa
+from pyramid.exceptions import HTTPNotFound
 
 from h import models
 from h.accounts import schemas
 from h.auth.util import basic_auth_creds
 from h.exceptions import ClientUnauthorized, PayloadError
 from h.models.auth_client import GrantType
+from h.presenters import UserJSONPresenter
 from h.schemas import ValidationError
 from h.util.view import json_view
 
@@ -44,6 +46,31 @@ def create(request):
         'username': user.username,
         'display_name': user.display_name,
     }
+
+
+@json_view(route_name='api.user', request_method='PATCH')
+def update(request):
+    """
+    Update a user.
+
+    This API endpoint allows authorised clients (those able to provide a valid
+    Client ID and Client Secret) to update users in their authority.
+    """
+    client = _request_client(request)
+
+    user_svc = request.find_service(name='user')
+    user = user_svc.fetch(request.matchdict['username'],
+                          client.authority)
+    if user is None:
+        raise HTTPNotFound()
+
+    schema = schemas.UpdateUserAPISchema()
+    appstruct = schema.validate(_json_payload(request))
+
+    _update_user(user, appstruct)
+
+    presenter = UserJSONPresenter(user)
+    return presenter.asdict()
 
 
 def _check_authority(client, data):
@@ -98,6 +125,13 @@ def _request_client(request):
         raise ClientUnauthorized()
 
     return client
+
+
+def _update_user(user, appstruct):
+    if 'email' in appstruct:
+        user.email = appstruct['email']
+    if 'display_name' in appstruct:
+        user.display_name = appstruct['display_name']
 
 
 def _json_payload(request):

--- a/tests/h/accounts/schemas_test.py
+++ b/tests/h/accounts/schemas_test.py
@@ -665,6 +665,59 @@ class TestCreateUserAPISchema(object):
         return schemas.CreateUserAPISchema()
 
 
+class TestUpdateUserAPISchema(object):
+    def test_it_raises_when_email_empty(self, schema, payload):
+        payload['email'] = ''
+
+        with pytest.raises(ValidationError):
+            schema.validate(payload)
+
+    def test_it_raises_when_email_not_a_string(self, schema, payload):
+        payload['email'] = {'foo': 'bar'}
+
+        with pytest.raises(ValidationError):
+            schema.validate(payload)
+
+    def test_it_raises_when_email_format_invalid(self, schema, payload):
+        payload['email'] = 'not-an-email'
+
+        with pytest.raises(ValidationError):
+            schema.validate(payload)
+
+    def test_it_raises_when_email_too_long(self, schema, payload):
+        payload['email'] = ('dagrun.bibianne.selen.asya.'
+                            'dagrun.bibianne.selen.asya.'
+                            'dagrun.bibianne.selen.asya.'
+                            'dagrun.bibianne.selen.asya'
+                            '@foobar.com')
+
+        with pytest.raises(ValidationError):
+            schema.validate(payload)
+
+    def test_it_raises_when_display_name_not_a_string(self, schema, payload):
+        payload['display_name'] = 42
+
+        with pytest.raises(ValidationError):
+            schema.validate(payload)
+
+    def test_it_raises_when_display_name_too_long(self, schema, payload):
+        payload['display_name'] = 'Dagrun Bibianne Selen Asya Foobar'
+
+        with pytest.raises(ValidationError):
+            schema.validate(payload)
+
+    @pytest.fixture
+    def payload(self):
+        return {
+            'email': 'dagrun@foobar.org',
+            'display_name': 'Dagrun Foobar',
+        }
+
+    @pytest.fixture
+    def schema(self):
+        return schemas.UpdateUserAPISchema()
+
+
 @pytest.fixture
 def validate_url(patch):
     return patch('h.accounts.schemas.util.validate_url')

--- a/tests/h/presenters/user_json_test.py
+++ b/tests/h/presenters/user_json_test.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from h.presenters.user_json import UserJSONPresenter
+
+
+class TestUserJSONPresenter(object):
+    def test_asdict(self, factories):
+        user = factories.User(authority='example.org',
+                              email='jack@doe.com',
+                              username='jack',
+                              display_name='Jack Doe')
+        presenter = UserJSONPresenter(user)
+
+        assert presenter.asdict() == {
+            'authority': 'example.org',
+            'email': 'jack@doe.com',
+            'userid': 'acct:jack@example.org',
+            'username': 'jack',
+            'display_name': 'Jack Doe',
+        }

--- a/tests/h/routes_test.py
+++ b/tests/h/routes_test.py
@@ -82,6 +82,7 @@ def test_includeme():
         call('api.group_member', '/api/groups/{pubid}/members/{user}', factory='h.models.group:GroupFactory', traverse='/{pubid}'),
         call('api.search', '/api/search'),
         call('api.users', '/api/users'),
+        call('api.user', '/api/users/{username}'),
         call('badge', '/api/badge'),
         call('token', '/api/token'),
         call('oauth_authorize', '/oauth/authorize'),

--- a/tests/h/views/api_users_test.py
+++ b/tests/h/views/api_users_test.py
@@ -5,11 +5,98 @@ from __future__ import unicode_literals
 import pytest
 from mock import Mock, PropertyMock
 
+from pyramid.exceptions import HTTPNotFound
+
 from h.exceptions import ClientUnauthorized, PayloadError
 from h.models.auth_client import GrantType
 from h.schemas import ValidationError
 from h.services.user_signup import UserSignupService
-from h.views.api_users import create
+from h.views.api_users import create, update
+
+
+@pytest.mark.parametrize('type_,view', [
+    ('create', create),
+    ('update', update),
+])
+@pytest.mark.usefixtures('basic_auth_creds')
+class TestCreateAndUpdateAuth(object):
+    def test_raises_when_no_creds(self, pyramid_request, type_, view):
+        pyramid_request.json_body = self.valid_payload(type_)
+
+        with pytest.raises(ClientUnauthorized):
+            view(pyramid_request)
+
+    def test_raises_when_malformed_client_id(self,
+                                             basic_auth_creds,
+                                             pyramid_request,
+                                             type_,
+                                             view):
+        basic_auth_creds.return_value = ('foobar', 'somerandomsecret')
+        pyramid_request.json_body = self.valid_payload(type_)
+
+        with pytest.raises(ClientUnauthorized):
+            view(pyramid_request)
+
+    def test_raises_when_no_client(self,
+                                   basic_auth_creds,
+                                   pyramid_request,
+                                   type_,
+                                   view):
+        basic_auth_creds.return_value = ('C69BA868-5089-4EE4-ABB6-63A1C38C395B',
+                                         'somerandomsecret')
+        pyramid_request.json_body = self.valid_payload(type_)
+
+        with pytest.raises(ClientUnauthorized):
+            view(pyramid_request)
+
+    def test_raises_when_client_secret_invalid(self,
+                                               auth_client,
+                                               basic_auth_creds,
+                                               pyramid_request,
+                                               type_,
+                                               view):
+        basic_auth_creds.return_value = (auth_client.id, 'incorrectsecret')
+        pyramid_request.json_body = self.valid_payload(type_)
+
+        with pytest.raises(ClientUnauthorized):
+            view(pyramid_request)
+
+    def test_raises_for_public_client(self,
+                                      factories,
+                                      basic_auth_creds,
+                                      pyramid_request,
+                                      type_,
+                                      view):
+        auth_client = factories.AuthClient(authority='weylandindustries.com')
+        basic_auth_creds.return_value = (auth_client.id, '')
+        pyramid_request.json_body = self.valid_payload(type_)
+
+        with pytest.raises(ClientUnauthorized):
+            view(pyramid_request)
+
+    def test_raises_for_invalid_client_grant_type(self,
+                                                  factories,
+                                                  basic_auth_creds,
+                                                  pyramid_request,
+                                                  type_,
+                                                  view):
+        auth_client = factories.ConfidentialAuthClient(authority='weylandindustries.com',
+                                                       grant_type=GrantType.authorization_code)
+        basic_auth_creds.return_value = (auth_client.id, auth_client.secret)
+        pyramid_request.json_body = self.valid_payload(type_)
+
+        with pytest.raises(ClientUnauthorized):
+            view(pyramid_request)
+
+    def valid_payload(self, type_):
+        payload = {'email': 'jeremy@weylandtech.com',
+                   'display_name': 'Jeremy Weyland'}
+
+        if type_ == 'create':
+            payload.update({'authority': 'weylandindustries',
+                            'username': 'jeremy'})
+
+        return payload
 
 
 @pytest.mark.usefixtures('auth_client',
@@ -53,61 +140,6 @@ class TestCreate(object):
             username='jeremy',
             email='jeremy@weylandtech.com',
             display_name='Jeremy Weyland')
-
-    def test_raises_when_no_creds(self, pyramid_request, valid_payload):
-        pyramid_request.json_body = valid_payload
-
-        with pytest.raises(ClientUnauthorized):
-            create(pyramid_request)
-
-    def test_raises_when_malformed_client_id(self,
-                                             basic_auth_creds,
-                                             pyramid_request,
-                                             valid_payload):
-        basic_auth_creds.return_value = ('foobar', 'somerandomsecret')
-        pyramid_request.json_body = valid_payload
-
-        with pytest.raises(ClientUnauthorized):
-            create(pyramid_request)
-
-    def test_raises_when_no_client(self,
-                                   basic_auth_creds,
-                                   pyramid_request,
-                                   valid_payload):
-        basic_auth_creds.return_value = ('C69BA868-5089-4EE4-ABB6-63A1C38C395B',
-                                         'somerandomsecret')
-        pyramid_request.json_body = valid_payload
-
-        with pytest.raises(ClientUnauthorized):
-            create(pyramid_request)
-
-    def test_raises_when_client_secret_invalid(self,
-                                               auth_client,
-                                               basic_auth_creds,
-                                               pyramid_request,
-                                               valid_payload):
-        basic_auth_creds.return_value = (auth_client.id, 'incorrectsecret')
-        pyramid_request.json_body = valid_payload
-
-        with pytest.raises(ClientUnauthorized):
-            create(pyramid_request)
-
-    def test_raises_for_public_client(self, factories, basic_auth_creds, pyramid_request, valid_payload):
-        auth_client = factories.AuthClient(authority='weylandindustries.com')
-        basic_auth_creds.return_value = (auth_client.id, '')
-        pyramid_request.json_body = valid_payload
-
-        with pytest.raises(ClientUnauthorized):
-            create(pyramid_request)
-
-    def test_raises_for_invalid_client_grant_type(self, factories, basic_auth_creds, pyramid_request, valid_payload):
-        auth_client = factories.ConfidentialAuthClient(authority='weylandindustries.com',
-                                                       grant_type=GrantType.authorization_code)
-        basic_auth_creds.return_value = (auth_client.id, auth_client.secret)
-        pyramid_request.json_body = valid_payload
-
-        with pytest.raises(ClientUnauthorized):
-            create(pyramid_request)
 
     @pytest.mark.usefixtures('valid_auth')
     def test_it_validates_the_input(self, pyramid_request, valid_payload, schemas):
@@ -207,8 +239,114 @@ class TestCreate(object):
             create(pyramid_request)
 
     @pytest.fixture
-    def schemas(self, patch):
-        return patch('h.views.api_users.schemas')
+    def valid_payload(self):
+        return {
+            'authority': 'weylandindustries.com',
+            'email': 'jeremy@weylandtech.com',
+            'username': 'jeremy',
+            'display_name': 'Jeremy Weyland',
+        }
+
+
+@pytest.mark.usefixtures('auth_client',
+                         'basic_auth_creds',
+                         'user_svc',
+                         'user')
+class TestUpdate(object):
+    @pytest.mark.usefixtures('valid_auth')
+    def test_it_updates_display_name(self, pyramid_request, valid_payload, user):
+        pyramid_request.json_body = valid_payload
+        update(pyramid_request)
+
+        assert user.display_name == 'Jeremy Weyland'
+
+    @pytest.mark.usefixtures('valid_auth')
+    def test_it_updates_email(self, pyramid_request, valid_payload, user):
+        pyramid_request.json_body = valid_payload
+        update(pyramid_request)
+
+        assert user.email == 'jeremy@weylandtech.com'
+
+    @pytest.mark.usefixtures('valid_auth')
+    def test_it_presents_user(self, pyramid_request, valid_payload, user, presenter):
+        pyramid_request.json_body = valid_payload
+        update(pyramid_request)
+
+        presenter.assert_called_once_with(user)
+
+    @pytest.mark.usefixtures('valid_auth')
+    def test_it_returns_presented_user(self, pyramid_request, valid_payload, presenter):
+        pyramid_request.json_body = valid_payload
+        result = update(pyramid_request)
+
+        assert result == presenter.return_value.asdict()
+
+    @pytest.mark.usefixtures('valid_auth')
+    def test_raises_404_when_user_not_found(self, pyramid_request, valid_payload):
+        pyramid_request.matchdict['username'] = 'missing'
+
+        with pytest.raises(HTTPNotFound):
+            update(pyramid_request)
+
+    @pytest.mark.usefixtures('valid_auth')
+    def test_it_validates_the_input(self, pyramid_request, valid_payload, schemas):
+        update_schema = schemas.UpdateUserAPISchema.return_value
+        update_schema.validate.return_value = valid_payload
+        pyramid_request.json_body = valid_payload
+
+        update(pyramid_request)
+
+        update_schema.validate.assert_called_once_with(valid_payload)
+
+    @pytest.mark.usefixtures('valid_auth')
+    def test_raises_when_schema_validation_fails(self, pyramid_request, valid_payload, schemas):
+        update_schema = schemas.UpdateUserAPISchema.return_value
+        update_schema.validate.side_effect = ValidationError('validation failed')
+
+        pyramid_request.json_body = valid_payload
+
+        with pytest.raises(ValidationError):
+            update(pyramid_request)
+
+    @pytest.mark.usefixtures('valid_auth')
+    def test_raises_for_invalid_json_body(self, pyramid_request, patch):
+        type(pyramid_request).json_body = PropertyMock(side_effect=ValueError())
+
+        with pytest.raises(PayloadError):
+            update(pyramid_request)
+
+    @pytest.fixture
+    def pyramid_request(self, pyramid_request, user):
+        pyramid_request.matchdict['username'] = user.username
+        return pyramid_request
+
+    @pytest.fixture
+    def user(self, factories, auth_client):
+        return factories.User(authority=auth_client.authority)
+
+    @pytest.fixture
+    def valid_payload(self):
+        return {
+            'email': 'jeremy@weylandtech.com',
+            'display_name': 'Jeremy Weyland',
+        }
+
+    @pytest.fixture
+    def presenter(self, patch):
+        return patch('h.views.api_users.UserJSONPresenter')
+
+    @pytest.fixture
+    def user_svc(self, pyramid_config, user):
+        svc = Mock(spec_set=['fetch'])
+
+        def fake_fetch(username, authority):
+            if (username == user.username and
+                    authority == user.authority):
+                return user
+        svc.fetch.side_effect = fake_fetch
+
+        pyramid_config.register_service(svc, name='user')
+        return svc
 
 
 @pytest.fixture
@@ -242,10 +380,5 @@ def user_signup_service(db_session, factories, pyramid_config):
 
 
 @pytest.fixture
-def valid_payload():
-    return {
-        'authority': 'weylandindustries.com',
-        'email': 'jeremy@weylandtech.com',
-        'username': 'jeremy',
-        'display_name': 'Jeremy Weyland',
-    }
+def schemas(patch):
+    return patch('h.views.api_users.schemas')


### PR DESCRIPTION
This adds a `PATCH /api/users/{username}` endpoint. It finds the user based on the given username in the path and the authority of the client that is used to authenticate the request.

It is based on #4658 and will need rebasing once that one has been merged.