### PR TITLE
Publish 'delete' event for annotations deleted when deleting a user

### DIFF
--- a/h/views/admin_users.py
+++ b/h/views/admin_users.py
@@ -9,6 +9,7 @@ from pyramid.view import view_config
 from h import models
 from h import storage
 from h.accounts.events import ActivationEvent
+from h.events import AnnotationEvent
 from h.services.rename_user import UserRenameError
 from h.tasks.admin import rename_user
 from h.i18n import TranslationString as _  # noqa
@@ -148,6 +149,8 @@ def delete_user(request, user):
                             .filter_by(userid=user.userid)
     for annotation in annotations:
         storage.delete_annotation(request.db, annotation.id)
+        event = AnnotationEvent(request, annotation.id, 'delete')
+        request.notify_after_commit(event)
 
     request.db.delete(user)
 

--- a/tests/common/matchers.py
+++ b/tests/common/matchers.py
@@ -93,7 +93,7 @@ class mapping_containing(Matcher):  # noqa: N801
         return '<mapping containing {!r}>'.format(self.key)
 
 
-class redirect_302_to(Matcher):
+class redirect_302_to(Matcher):  # noqa: N801
     """Matches any HTTPFound redirect to the given URL."""
 
     def __init__(self, location):
@@ -105,7 +105,7 @@ class redirect_302_to(Matcher):
         return other.location == self.location
 
 
-class redirect_303_to(Matcher):
+class redirect_303_to(Matcher):  # noqa: N801
     """Matches any HTTPSeeOther redirect to the given URL."""
 
     def __init__(self, location):
@@ -117,7 +117,7 @@ class redirect_303_to(Matcher):
         return other.location == self.location
 
 
-class regex(Matcher):
+class regex(Matcher):  # noqa: N801
     """Matches any string matching the passed regex."""
 
     def __init__(self, patt):
@@ -130,7 +130,7 @@ class regex(Matcher):
         return '<string matching re {!r}>'.format(self.patt.pattern)
 
 
-class unordered_list(Matcher):
+class unordered_list(Matcher):  # noqa: N801
     """
     Matches a list with the same items in any order.
 


### PR DESCRIPTION
_This is a replacement for https://github.com/hypothesis/h/pull/4654_

This ensures that clients of the Real Time API and ElasticSearch indexes
are updated correctly after deleting a user.

Fixes #4652