### PR TITLE
Update designs of OAuth login and authorization screens

### DIFF
--- a/h/static/scripts/controllers/form-cancel-controller.js
+++ b/h/static/scripts/controllers/form-cancel-controller.js
@@ -17,12 +17,7 @@ class FormCancelController extends Controller {
 
     element.addEventListener('click', (event) => {
       event.preventDefault();
-
-      if (window_.history.length > 1) {
-        window_.history.back();
-      } else {
-        window_.close();
-      }
+      window_.close();
     });
   }
 }

--- a/h/static/scripts/controllers/form-cancel-controller.js
+++ b/h/static/scripts/controllers/form-cancel-controller.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const Controller = require('../base/controller');
+
+/**
+ * Button for canceling a form in a single-form page.
+ *
+ * This is used only when the form is *not* using inline editing.
+ * Forms which use inline editing have a cancel button that is shown below the
+ * active field. That is managed by `FormController`.
+ */
+class FormCancelController extends Controller {
+  constructor(element, options) {
+    super(element, options);
+
+    const window_ = options.window || window;
+
+    element.addEventListener('click', (event) => {
+      event.preventDefault();
+
+      if (window_.history.length > 1) {
+        window_.history.back();
+      } else {
+        window_.close();
+      }
+    });
+  }
+}
+
+module.exports = FormCancelController;

--- a/h/static/scripts/site.js
+++ b/h/static/scripts/site.js
@@ -16,6 +16,7 @@ const ConfirmSubmitController = require('./controllers/confirm-submit-controller
 const CreateGroupFormController = require('./controllers/create-group-form-controller');
 const DropdownMenuController = require('./controllers/dropdown-menu-controller');
 const FormController = require('./controllers/form-controller');
+const FormCancelController = require('./controllers/form-cancel-controller');
 const FormSelectOnFocusController = require('./controllers/form-select-onfocus-controller');
 const InputAutofocusController = require('./controllers/input-autofocus-controller');
 const SearchBarController = require('./controllers/search-bar-controller');
@@ -33,6 +34,7 @@ const controllers = {
   '.js-create-group-form': CreateGroupFormController,
   '.js-dropdown-menu': DropdownMenuController,
   '.js-form': FormController,
+  '.js-form-cancel': FormCancelController,
   '.js-input-autofocus': InputAutofocusController,
   '.js-select-onfocus': FormSelectOnFocusController,
   '.js-search-bar': SearchBarController,

--- a/h/static/scripts/tests/controllers/form-cancel-controller-test.js
+++ b/h/static/scripts/tests/controllers/form-cancel-controller-test.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const FormCancelController = require('../../controllers/form-cancel-controller');
+
+describe('FormCancelController', () => {
+  it('should close the window when clicked', () => {
+    const fakeWindow = { close: sinon.stub() };
+    const btn = document.createElement('button');
+    new FormCancelController(btn, { window: fakeWindow });
+
+    btn.click();
+
+    assert.called(fakeWindow.close);
+  });
+});

--- a/h/static/styles/partials-v2/_btn.scss
+++ b/h/static/styles/partials-v2/_btn.scss
@@ -14,6 +14,10 @@
   padding-left: 15px;
   padding-right: 15px;
   white-space: nowrap;
+
+  &:hover {
+    background-color: $brand;
+  }
 }
 
 .btn.is-hidden {
@@ -21,14 +25,15 @@
 }
 
 .btn--cancel {
-  background-color: $grey-4;
+  color: $grey-6;
+  background-color: white;
+
+  &:hover {
+    background-color: $grey-2;
+  }
 }
 
 .btn--danger {
-  background-color: $brand;
-}
-
-.btn:hover {
   background-color: $brand;
 }
 

--- a/h/static/styles/partials-v2/_btn.scss
+++ b/h/static/styles/partials-v2/_btn.scss
@@ -29,7 +29,8 @@
   background-color: white;
 
   &:hover {
-    background-color: $grey-2;
+    background-color: white;
+    color: $brand;
   }
 }
 

--- a/h/static/styles/partials-v2/_form-actions.scss
+++ b/h/static/styles/partials-v2/_form-actions.scss
@@ -22,10 +22,3 @@
 .form-actions.is-saving {
   opacity: .5;
 }
-
-.form-actions__message {
-  @include font-small;
-
-  color: $grey-4;
-  padding-left: 15px;
-}

--- a/h/static/styles/partials-v2/_form-actions.scss
+++ b/h/static/styles/partials-v2/_form-actions.scss
@@ -9,7 +9,7 @@
   margin-bottom: 30px;
 
   display: flex;
-  flex-direction: row-reverse;
+  flex-direction: row;
   align-items: center;
   position: relative;
   z-index: $zindex-modal-content;

--- a/h/static/styles/partials-v2/_form-container.scss
+++ b/h/static/styles/partials-v2/_form-container.scss
@@ -2,16 +2,23 @@
 // Used for pages whose primary purpose is to display a form.
 // ---------------------------------------------------------
 
-.form-container {
-  margin-left: auto;
-  margin-right: auto;
+@at-root {
+  $h-padding: 15px;
+  .form-container {
+    margin-left: auto;
+    margin-right: auto;
 
-  // Max width of form fields should be 500px. It is set to 530px here to
-  // account for the padding
-  max-width: 530px;
+    // Max width of form fields should be 500px. It is set to 530px here to
+    // account for the padding
+    max-width: 530px;
 
-  // Account form padding is set to align left edge of form with left edge of
-  // masthead
-  padding-left: 15px;
-  padding-right: 15px;
+    // Account form padding is set to align left edge of form with left edge of
+    // masthead
+    padding-left: $h-padding;
+    padding-right: $h-padding;
+  }
+
+  .form-container--popup {
+    max-width: #{340px + ($h-padding * 2)};
+  }
 }

--- a/h/static/styles/partials-v2/_form.scss
+++ b/h/static/styles/partials-v2/_form.scss
@@ -62,6 +62,22 @@
   color: $grey-5;
 }
 
+/**
+ * A footer which appears between form fields and the form's action buttons.
+ *
+ * Unlike "form-footer" which appears below the form, use this for things you
+ * want the user to read before they submit the form.
+ */
+.form-presubmit-footer {
+  @include font-small;
+
+  display: flex;
+  justify-content: flex-end;
+  padding-bottom: 10px;
+
+  color: $grey-4;
+}
+
 @mixin form-footer {
   @include font-normal;
   color: $grey-5;
@@ -76,13 +92,26 @@
   padding-top: 15px;
 }
 
-// A more compact form footer, suitable for use in small popup windows or when
-// trying to fit the whole form into a single screen on mobile.
-.form-footer--compact {
+// The "popup" variation of the form footer is designed to be used outside of a
+// "form-container" and appear at the bottom of a popup window, spanning its
+// full width.
+.form-footer--popup {
   @include form-footer;
 
+  position: fixed;
+  bottom: 25px;
+  left: 0;
+  right: 0;
+  height: 25px;
+
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+
   border-top: 1px solid $grey-3;
-  padding-top: 10px;
+  padding-top: 20px;
+  padding-left: 15px;
+  padding-right: 15px;
 }
 
 // A form footer with no top border, useful for additional sections at the

--- a/h/static/styles/partials-v2/_text.scss
+++ b/h/static/styles/partials-v2/_text.scss
@@ -4,3 +4,9 @@
 .text {
   color: $grey-6;
 }
+
+// Prompt used in the OAuth "Authorize access?" screen.
+.text--auth-prompt {
+  color: $grey-5;
+  margin-bottom: 50px;
+}

--- a/h/templates/accounts/login_oauth.html.jinja2
+++ b/h/templates/accounts/login_oauth.html.jinja2
@@ -3,22 +3,23 @@
 {% block page_title %}Log in{% endblock %}
 
 {% block content %}
-  <div class="form-container content">
+  <div class="form-container form-container--popup content">
     <h1 class="form-header form-header--center">
       Log in with Hypothesis {{ svg_icon('logo', 'form-header__logo') }}
     </h1>
 
     {{ form }}
-
-    {# In the context of OAuth, the login screen is often shown in a popup.
+  </div>
+  {# In the context of OAuth, the login screen is often shown in a popup.
        Use a more compact footer and make the Sign Up link open in a
        new window where there is more space and so the user can continue the
        OAuth flow after they sign up. #}
-    <footer class="form-footer--compact">
+  <footer class="form-footer--popup">
+    <span>
       Don't have a Hypothesis account?
       <a class="link--footer"
          href="{{ request.route_path('signup') }}"
          target="blank">Sign up</a>
-    </footer>
-  </div>
+    </span>
+  </footer>
 {% endblock content %}

--- a/h/templates/deform/form.jinja2
+++ b/h/templates/deform/form.jinja2
@@ -31,6 +31,10 @@
     <button type="button"
             class="btn btn--cancel is-hidden" data-ref="cancelBtn">Cancel</button>
     {% endif %}
+    {% if field.show_cancel_button %}
+    <button type="button"
+            class="btn btn--cancel js-form-cancel">Cancel</button>
+    {% endif %}
     <div class="u-stretch"></div>
     <div class="form-actions__buttons">
       {%- for button in field.buttons -%}

--- a/h/templates/deform/form.jinja2
+++ b/h/templates/deform/form.jinja2
@@ -27,6 +27,10 @@
       <span>{% trans %}Unable to save changes: {% endtrans %}</span>
       <span data-ref="formSubmitErrorMessage"></span>
     </div>
+    {% if field.use_inline_editing %}
+    <button type="button"
+            class="btn btn--cancel is-hidden" data-ref="cancelBtn">Cancel</button>
+    {% endif %}
     <div class="u-stretch"></div>
     <div class="form-actions__buttons">
       {%- for button in field.buttons -%}
@@ -41,7 +45,6 @@
                 >
         {{ _(button.title) }}
         </button>
-        <button class="btn btn--cancel is-hidden" data-ref="cancelBtn">Cancel</button>
       {% endfor -%}
     </div>
   </div>

--- a/h/templates/deform/form.jinja2
+++ b/h/templates/deform/form.jinja2
@@ -15,14 +15,17 @@
     {{ field.renderer(field.widget.item_template, field=f, cstruct=cstruct.get(f.name, null)) }}
   {% endfor -%}
 
+  {% if field.footer %}
+  <div class="form-presubmit-footer">
+    <span>{{ field.footer | safe }}</span>
+  </div>
+  {% endif %}
+
   <div class="form-actions {% if field.use_inline_editing %} is-hidden-when-loading {% endif %}"
        data-ref="formActions">
     <div class="form__submit-error" data-ref="formSubmitError">
       <span>{% trans %}Unable to save changes: {% endtrans %}</span>
       <span data-ref="formSubmitErrorMessage"></span>
-    </div>
-    <div class="form-actions__message">
-      {%- if field.footer %}{{ field.footer | safe }}{% endif -%}
     </div>
     <div class="u-stretch"></div>
     <div class="form-actions__buttons">

--- a/h/templates/oauth/authorize.html.jinja2
+++ b/h/templates/oauth/authorize.html.jinja2
@@ -8,7 +8,7 @@
       Authorize access
       {{ svg_icon('logo', 'form-header__logo') }}
     </h1>
-    <p class="text">
+    <p class="text text--auth-prompt">
       <b>{{ client_name }}</b> is requesting access to your Hypothesis account
       <b>{{ username }}</b>.
     </p>

--- a/h/templates/oauth/authorize.html.jinja2
+++ b/h/templates/oauth/authorize.html.jinja2
@@ -15,9 +15,10 @@
 
     <form class="form js-authorize-form" method="POST">
       <div class="form-actions">
+        <button type="button" class="btn btn--cancel" data-ref="cancelBtn">Cancel</button>
+        <div class="u-stretch"></div>
         <div class="form-actions__buttons">
           <button type="submit" class="btn" data-ref="acceptBtn">Allow</button>
-          <button type="button" class="btn btn--cancel" data-ref="cancelBtn">Cancel</button>
         </div>
       </div>
 

--- a/h/templates/oauth/authorize.html.jinja2
+++ b/h/templates/oauth/authorize.html.jinja2
@@ -3,7 +3,7 @@
 {% block page_title %}Authorize application{% endblock %}
 
 {% block content %}
-  <div class="form-container content">
+  <div class="form-container form-container--popup content">
     <h1 class="form-header form-header--center">
       Authorize access
       {{ svg_icon('logo', 'form-header__logo') }}

--- a/h/views/accounts.py
+++ b/h/views/accounts.py
@@ -97,9 +97,12 @@ class AuthController(object):
 
         self.request = request
         self.schema = schemas.LoginSchema().bind(request=self.request)
+
+        show_cancel_button = bool(request.params.get('for_oauth', False))
         self.form = request.create_form(self.schema,
                                         buttons=(_('Log in'),),
-                                        footer=form_footer)
+                                        footer=form_footer,
+                                        show_cancel_button=show_cancel_button)
 
         self.logout_redirect = self.request.route_url('index')
 


### PR DESCRIPTION
This is the result of polishing the design of the OAuth login and authorization screens in concern with @dawariley. This includes a change to the way "OK" and "Cancel" buttons are displayed across forms on the website. The "OK" button is now right-aligned (as on eg. GitHub). The "Cancel" button is now left-aligned and more visually subtle.

Testing should be done against the latest master of the client repo which adjusts the default size of the popup window. The forms are still responsive for user agents that don't respect this size, but the default size gives the "preferred" layout.

The changes are:
- Update the design of "OK" and "Cancel" buttons across all forms
- Make the footer of the login form span the full width of the login popup
- Adjust the padding around the login and authorization forms
- Add a "Cancel" button to the login form. Note that this currently behaves slightly differently when clicked in the client (No notification shown) vs. the authorization screen's cancel button (shows an "Authorization window closed" message in the client). This is an issue I will address separately in the client itself.

<img width="539" alt="screenshot 2017-09-20 13 11 00" src="https://user-images.githubusercontent.com/2458/30643237-05101412-9e06-11e7-9006-f1ec6e670f27.png">

![screenshot 2017-09-20 13 07 17](https://user-images.githubusercontent.com/2458/30643262-13a0029e-9e06-11e7-80c8-c819490b133f.png)

![screenshot 2017-09-20 13 07 25](https://user-images.githubusercontent.com/2458/30643270-1a4edebc-9e06-11e7-8cd4-e10d303a1392.png)


