### PR TITLE
Support email addresses with international domain names

### DIFF
--- a/h/validators.py
+++ b/h/validators.py
@@ -6,11 +6,27 @@ from __future__ import unicode_literals
 import colander
 
 
-class Email(colander.Email):
-    def __init__(self, *args, **kwargs):
-        if 'msg' not in kwargs:
-            kwargs['msg'] = "Invalid email address."
-        super(Email, self).__init__(*args, **kwargs)
+# Regex for email addresses.
+#
+# Taken from Chromium and derived from the WhatWG HTML spec
+# (4.10.7.1.5 E-Mail state).
+#
+# This was chosen because it is a widely used and relatively simple pattern.
+# Unlike `colander.Email` it supports International Domain Names (IDNs) in
+# Punycode form.
+HTML5_EMAIL_REGEX = ("^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@"
+                     "[a-zA-Z0-9-]+(?:\\.[a-zA-Z0-9-]+)*$")
+
+
+class Email(colander.Regex):
+    """
+    Validator for email addresses.
+
+    This is a replacement for `colander.Email` which rejects certain valid email
+    addresses (see https://github.com/hypothesis/h/issues/4662).
+    """
+    def __init__(self, msg='Invalid email address.'):
+        super(Email, self).__init__(HTML5_EMAIL_REGEX, msg=msg)
 
 
 class Length(colander.Length):

--- a/tests/h/validators_test.py
+++ b/tests/h/validators_test.py
@@ -1,0 +1,35 @@
+import pytest
+
+from mock import Mock
+
+import colander
+
+from h.validators import Email
+
+
+class TestEmail(object):
+    @pytest.mark.parametrize('email', [
+        'jimsmith@foobar.com',
+        'international@xn--domain.com',
+        'jim.smith@gmail.com',
+        'jim.smith@foo.bar.com',
+    ])
+    def test_accepts_valid_addresses(self, schema_node, email):
+        validator = Email()
+        validator(schema_node, email)
+
+    @pytest.mark.parametrize('email', [
+        ' spaces @ spaces.com',
+    ])
+    def test_rejects_invalid_addresses(self, schema_node, email):
+        validator = Email()
+
+        with pytest.raises(colander.Invalid):
+            validator(schema_node, email)
+
+    @pytest.fixture
+    def schema_node(self):
+        """
+        Mock for `colander.SchemaNode` arg that validator callables require.
+        """
+        return Mock(spec_set=[])

--- a/tests/h/validators_test.py
+++ b/tests/h/validators_test.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import pytest
+from mock import Mock
 
 import colander
-from mock import Mock
-import pytest
 
 from h.validators import Email
 

--- a/tests/h/validators_test.py
+++ b/tests/h/validators_test.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import pytest
 
 from mock import Mock
@@ -13,6 +15,7 @@ class TestEmail(object):
         'international@xn--domain.com',
         'jim.smith@gmail.com',
         'jim.smith@foo.bar.com',
+        'a.range!of#punctuation-chars$are+accepted@gmail.com',
     ])
     def test_accepts_valid_addresses(self, schema_node, email):
         validator = Email()
@@ -20,6 +23,13 @@ class TestEmail(object):
 
     @pytest.mark.parametrize('email', [
         ' spaces @ spaces.com',
+        'sorry-ascii-only-🤠@gmail.com',
+        'no-domain-part@',
+        '@no-local-part.com',
+        'no-at-separator',
+
+        # A non-TLD part is required, but the TLD itself is optional.
+        'local@.only-a-tld',
     ])
     def test_rejects_invalid_addresses(self, schema_node, email):
         validator = Email()

--- a/tests/h/validators_test.py
+++ b/tests/h/validators_test.py
@@ -1,10 +1,8 @@
 # -*- coding: utf-8 -*-
 
-import pytest
-
-from mock import Mock
-
 import colander
+from mock import Mock
+import pytest
 
 from h.validators import Email
 


### PR DESCRIPTION
`colander.Email` uses a regex which does not allow domain names
beginning with `xn--` or Unicode characters. Either of these limitations
prevents users from registering with email addresses that use
international domain names.

This commit replaces the validator with an alternate pattern taken from
the HTML spec which is used by Chrome and which at least allows the
Punycode version of an internationalized email address to be used.

I opted not to just allow unicode chars because we first have to make
sure that the rest of our stack supports it. Alternatively we could
convert to Punycode automatically when deserializing the user's input.

Fixes #4662