### PR TITLE
Do not render `user_info` in /api/profile response if flag off

### DIFF
--- a/h/session.py
+++ b/h/session.py
@@ -38,7 +38,9 @@ def profile(request, authority=None):
     profile['groups'] = _current_groups(request, authority)
     profile['features'] = request.feature.all()
     profile['preferences'] = _user_preferences(user)
-    profile.update(user_info(user))
+
+    if request.feature('api_render_user_info'):
+        profile.update(user_info(user))
 
     return profile
 

--- a/tests/h/conftest.py
+++ b/tests/h/conftest.py
@@ -48,6 +48,9 @@ class DummyFeature(object):
     def __call__(self, name, *args, **kwargs):
         return self.flags.get(name, True)
 
+    def all(self):
+        return self.flags
+
     def load(self):
         self.loaded = True
 

--- a/tests/h/session_test.py
+++ b/tests/h/session_test.py
@@ -210,6 +210,11 @@ class TestProfile(object):
         user_info = profile['user_info']
         assert user_info['display_name'] == authenticated_request.user.display_name
 
+    def test_user_info_authenticated_when_flag_off(self, authenticated_request):
+        authenticated_request.feature.flags['api_render_user_info'] = False
+        profile = session.profile(authenticated_request)
+        assert 'user_info' not in profile
+
     def test_user_info_unauthenticated(self, unauthenticated_request):
         profile = session.profile(unauthenticated_request)
         assert 'user_info' not in profile
@@ -219,11 +224,12 @@ class TestProfile(object):
         return u'thirdparty.example.org'
 
     @pytest.fixture
-    def third_party_request(self, authority, third_party_domain, publisher_group):
+    def third_party_request(self, authority, third_party_domain, publisher_group, fake_feature):
         return FakeRequest(authority,
                            u'acct:user@{}'.format(third_party_domain),
                            third_party_domain,
-                           {third_party_domain: [publisher_group]})
+                           {third_party_domain: [publisher_group]},
+                           fake_feature)
 
     @pytest.fixture
     def publisher_group(self):
@@ -258,7 +264,8 @@ class FakeAuthorityGroupService(object):
 
 class FakeRequest(object):
 
-    def __init__(self, authority, userid, user_authority, public_groups):
+    def __init__(self, authority, userid, user_authority, public_groups,
+                 fake_feature):
         self.authority = authority
         self.authenticated_userid = userid
 
@@ -267,7 +274,7 @@ class FakeRequest(object):
         else:
             self.user = mock.Mock(groups=[], authority=user_authority)
 
-        self.feature = mock.Mock(spec_set=['all'])
+        self.feature = fake_feature
         self.route_url = mock.Mock(return_value='/group/a')
         self.session = mock.Mock(get_csrf_token=lambda: '__CSRF__')
 
@@ -277,7 +284,7 @@ class FakeRequest(object):
         self.user.groups = groups
 
     def set_features(self, feature_dict):
-        self.feature.all.return_value = feature_dict
+        self.feature.flags = feature_dict
 
     def set_sidebar_tutorial_dismissed(self, dismissed):
         self.user.sidebar_tutorial_dismissed = dismissed
@@ -304,13 +311,15 @@ def world_group():
 
 
 @pytest.fixture
-def unauthenticated_request(authority, world_group):
-    return FakeRequest(authority, None, None, {authority: [world_group]})
+def unauthenticated_request(authority, world_group, fake_feature):
+    return FakeRequest(authority, None, None, {authority: [world_group]},
+                       fake_feature)
 
 
 @pytest.fixture
-def authenticated_request(authority, world_group):
+def authenticated_request(authority, world_group, fake_feature):
     return FakeRequest(authority,
                        u'acct:user@{}'.format(authority),
                        authority,
-                       {authority: [world_group]})
+                       {authority: [world_group]},
+                       fake_feature)


### PR DESCRIPTION
Resolve an issue where the client would incorrectly use the display name
of the logged-in user for every annotation if the `api_render_user_info`
flag was off for that user [1].

This is a quick fix to address the issue this evening until I've had a
chance to discuss a better solution tomorrow.

[1] https://hypothes-is.slack.com/archives/C4K6M7P5E/p1506364131000304