### PR TITLE
Add CLIENT_RPC_ALLOWED_ORIGINS setting

### DIFF
--- a/docs/developing/envvars.rst
+++ b/docs/developing/envvars.rst
@@ -13,3 +13,9 @@ This section documents the environment variables supported by h.
 
    The OAuth client ID for the Hypothesis client on pages that embed it using
    the service's /embed.js script.
+
+.. envvar:: CLIENT_RPC_ALLOWED_ORIGINS
+
+   The list of origins that the client will respond to cross-origin RPC
+   requests from. A space-separated list of origins. For example:
+   ``https://lti.hypothes.is https://example.com http://localhost.com:8001``.

--- a/h/config.py
+++ b/h/config.py
@@ -8,7 +8,7 @@ import logging
 import os
 
 from pyramid.config import Configurator
-from pyramid.settings import asbool
+from pyramid.settings import asbool, aslist
 
 from h.settings import (
     DeprecatedSetting,
@@ -82,6 +82,11 @@ SETTINGS = [
     # making requests to OAuth endpoints. As a public client, it does not have a
     # secret.
     EnvSetting('h.client_oauth_id', 'CLIENT_OAUTH_ID'),
+
+    # The list of origins that the client will respond to cross-origin RPC
+    # requests from.
+    EnvSetting('h.client_rpc_allowed_origins',
+               'CLIENT_RPC_ALLOWED_ORIGINS', type=aslist),
 
     # Environment name, provided by the deployment environment. Please do
     # *not* toggle functionality based on this value. It is intended as a

--- a/h/views/client.py
+++ b/h/views/client.py
@@ -69,6 +69,10 @@ def sidebar_app(request, extra=None):
 
         'release': __version__,
         'serviceUrl': request.route_url('index'),
+
+        # The list of origins that the client will respond to cross-origin RPC
+        # requests from.
+        'rpcAllowedOrigins': settings.get('h.client_rpc_allowed_origins'),
     }
 
     if websocket_url:

--- a/tests/h/views/client_test.py
+++ b/tests/h/views/client_test.py
@@ -41,6 +41,7 @@ class TestSidebarApp(object):
                 'googleAnalytics': 'UA-4567',
                 'oauthClientId': 'test-client-id',
                 'oauthEnabled': True,
+                'rpcAllowedOrigins': 'https://lti.hypothes.is',
                 }
 
         actual_config = json.loads(ctx['app_config'])
@@ -88,6 +89,7 @@ def pyramid_settings(pyramid_settings):
         'h.client_oauth_id': 'test-client-id',
         'h.sentry_dsn_client': 'test-sentry-dsn',
         'h.websocket_url': 'wss://example.com/ws',
+        'h.client_rpc_allowed_origins': 'https://lti.hypothes.is',
         'authority': 'example.com'
         })
 


### PR DESCRIPTION
Add a new environment variable CLIENT_RPC_ALLOWED_ORIGINS. All h does is
read in this environment variable and pass it to the client as the
rpcAllowedOrigins client config setting.

This is for a new client feature that the client (sidebar app) responds
to JSON-RPC requests over postMessage from frames on other origins. The
origins whitelisted in the CLIENT_RPC_ALLOWED_ORIGINS setting are the
origins that the client will respond to such requests from.

See also:

* [Client pull request that adds the cross-origin RPC feature](https://github.com/hypothesis/client/pull/550)
* [LTI app PR that makes it use the feature](https://github.com/hypothesis/lti/pull/112)