### PR TITLE
First pass schema-based comment import validator

### DIFF
--- a/h/cli/__init__.py
+++ b/h/cli/__init__.py
@@ -18,6 +18,7 @@ SUBCOMMANDS = (
     'h.cli.commands.celery.celery',
     'h.cli.commands.devserver.devserver',
     'h.cli.commands.groups.groups',
+    'h.cli.commands.import.import_annotations',
     'h.cli.commands.init.init',
     'h.cli.commands.initdb.initdb',
     'h.cli.commands.migrate.migrate',

--- a/h/cli/commands/import.py
+++ b/h/cli/commands/import.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+
+import click
+import json
+
+from h.schemas.annotation_import import AnnotationImportSchema
+
+# from h import models
+
+
+@click.command('import')
+@click.pass_context
+@click.argument('annotation_file', type=click.File('rb'))
+def import_annotations(ctx, annotation_file):
+
+    with annotation_file:
+        raw_annotations = json.load(annotation_file)
+
+    click.echo('{} annotations to import'.format(len(raw_annotations)))
+
+    schema = AnnotationImportSchema()
+
+    [schema.validate(ann) for ann in raw_annotations]

--- a/h/cli/commands/import.py
+++ b/h/cli/commands/import.py
@@ -2,22 +2,55 @@
 
 import click
 import json
+from datetime import datetime
+import strict_rfc3339
 
 from h.schemas.annotation_import import AnnotationImportSchema
-
-# from h import models
+from h.models import Annotation
 
 
 @click.command('import')
 @click.pass_context
 @click.argument('annotation_file', type=click.File('rb'))
 def import_annotations(ctx, annotation_file):
+    """Import annotations manually from a file."""
+    schema = AnnotationImportSchema()
 
     with annotation_file:
         raw_annotations = json.load(annotation_file)
 
     click.echo('{} annotations to import'.format(len(raw_annotations)))
 
-    schema = AnnotationImportSchema()
+    validated_annotations = [schema.validate(ann) for ann in raw_annotations]
 
-    [schema.validate(ann) for ann in raw_annotations]
+    top_level = [a for a in validated_annotations if a['motivation'] == 'commenting']
+    replies = [a for a in validated_annotations if a['motivation'] == 'replying']
+    click.echo('{} top-level annotations'.format(len(top_level)))
+    click.echo('{} replies'.format(len(replies)))
+
+    def annotation_model(annotation_dict):
+        annotation = Annotation()
+        annotation.created = datetime.utcfromtimestamp(
+                strict_rfc3339.rfc3339_to_timestamp(
+                    annotation_dict['created']
+                )
+            )
+        annotation.updated = datetime.utcfromtimestamp(
+                strict_rfc3339.rfc3339_to_timestamp(
+                    annotation_dict['modified']
+                )
+            )
+
+        # TODO: validate that this account exists
+        annotation.userid = annotation_dict['creator']
+
+        # We've already validated that there's only a single body
+        annotation.text = annotation_dict['body'][0]['value']
+
+        annotation.target
+
+        return annotation
+
+    click.echo(annotation_model(top_level[0]))
+
+    # [annotation_model(d) for d in validated_annotations]

--- a/h/schemas/annotation_import.py
+++ b/h/schemas/annotation_import.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+"""Classes for validating manually-imported annotations."""
+
+from h.schemas.base import JSONSchema
+
+
+class AnnotationImportSchema(JSONSchema):
+
+    """Validate an annotation for import.
+
+    This schema is based on the W3C Web Annotation model, but only implements
+    the subset of the specification we need for importing purposes.
+    """
+
+    schema = {
+        '$schema': 'http://json-schema.org/draft-04/schema#',
+        'type': 'object',
+        'properties': {
+            '@context': {
+                'enum': ['http://www.w3.org/ns/anno.jsonld'],
+            },
+            'id': {
+                'type': 'string',
+                'format': 'uri',
+            },
+            'type': {
+                'enum': ['Annotation'],
+            },
+            'created': {
+                'type': 'string',
+                'format': 'date-time',
+            },
+            'modified': {
+                'type': 'string',
+                'format': 'date-time',
+            },
+            'creator': {
+                'type': 'string',
+                'format': 'uri',
+                'pattern': '^acct:.+$',
+            },
+            'motivation': {
+                'enum': ['commenting', 'replying']
+            },
+            'body': {
+                'type': 'array',
+                'minItems': 1,
+                'maxItems': 1,
+                'items': {
+                    'type': 'object',
+                    'properties': {
+                        'type': {
+                            'type': 'string',
+                            'enum': ['TextualBody'],
+                        },
+                        'value': {
+                            'type': 'string',
+                        },
+                        'format': {
+                            'type': 'string',
+                            'enum': ['text/markdown'],
+                        },
+                    },
+                    'required': [
+                        'format',
+                        'type',
+                        'value',
+                    ],
+                    'additionalProperties': False,
+                },
+            },
+            'target': {
+                'type': 'string',
+                'format': 'uri',
+            }
+        },
+        'required': [
+            '@context',
+            'id',
+            'type',
+            'created',
+            'modified',
+            'creator',
+            'body',
+            'motivation',
+            'target',
+        ],
+        'additionalProperties': False,
+    }

--- a/requirements.in
+++ b/requirements.in
@@ -37,7 +37,9 @@ python-dateutil
 python-slugify < 1.2.0
 raven
 requests-aws4auth >= 0.9
+rfc3987
 statsd
+strict-rfc3339
 transaction
 venusian
 wsaccel

--- a/requirements.txt
+++ b/requirements.txt
@@ -67,9 +67,11 @@ repoze.lru==0.6           # via pyramid
 repoze.sendmail==4.3      # via pyramid-mailer
 requests-aws4auth==0.9
 requests==2.13.0          # via requests-aws4auth
+rfc3987==1.3.7
 six==1.10.0               # via bcrypt, bleach, cryptography, html5lib, packaging, python-dateutil
 sqlalchemy==1.1.4
 statsd==3.2.1
+strict-rfc3339==0.7
 transaction==2.1.2
 translationstring==1.3    # via colander, deform, pyramid
 unidecode==0.4.19         # via python-slugify

--- a/tests/h/schemas/annotation_import_test.py
+++ b/tests/h/schemas/annotation_import_test.py
@@ -1,0 +1,144 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from contextlib import contextmanager
+import pytest
+
+from h.schemas import ValidationError
+from h.schemas.annotation_import import AnnotationImportSchema
+
+
+class TestAnnotationImportSchema(object):
+
+    def test_empty_dictionary(self, schema):
+        with pytest.raises(ValidationError):
+            schema.validate({})
+
+    def test_comment_annotation(self, schema, comment):
+        assert schema.validate(comment) == comment
+
+    def test_reply_annotation(self, schema, reply):
+        assert schema.validate(reply) == reply
+
+    @pytest.mark.parametrize('key', ('@context', 'id', 'type', 'created',
+                                     'modified', 'creator', 'body',
+                                     'motivation', 'target'))
+    def test_missing_key(self, schema, comment, key):
+        del comment[key]
+        with pytest.raises(ValidationError):
+            schema.validate(comment)
+
+    def test_wrong_context(self, schema, comment):
+        bad_context = 'http://json-ld.org/contexts/person.jsonld'
+        comment['@context'] = bad_context
+        with raises_error_starting('@context: '):
+            schema.validate(comment)
+
+    def test_wrong_type(self, schema, comment):
+        comment['type'] = 'Badger'
+        with raises_error_starting('type: '):
+            schema.validate(comment)
+
+    def test_invalid_motivation(self, schema, comment):
+        comment['motivation'] = 'indeterminate'
+        with raises_error_starting('motivation: '):
+            schema.validate(comment)
+
+    @pytest.mark.parametrize('created', ('2017', 'yesterday', '2017-02-12'))
+    def test_invalid_created(self, schema, comment, created):
+        comment['created'] = created
+        with raises_error_starting('created: '):
+            schema.validate(comment)
+
+    @pytest.mark.parametrize('modified', ('2017', 'yesterday', '2017-02-12'))
+    def test_invalid_modified(self, schema, comment, modified):
+        comment['modified'] = modified
+        with raises_error_starting('modified: '):
+            schema.validate(comment)
+
+    @pytest.mark.parametrize('creator', ('', 'bob', 'bob@example.com', 6,
+                                         'http://example.com'))
+    def test_invalid_creator(self, schema, comment, creator):
+        comment['creator'] = creator
+        with raises_error_starting('creator: '):
+            schema.validate(comment)
+
+    def test_no_body(self, schema, comment):
+        comment['body'] = []
+        with raises_error_starting('body: '):
+            schema.validate(comment)
+
+    def test_multiple_bodies(self, schema, comment):
+        comment['body'] = [comment['body'][0], comment['body'][0]]
+        with raises_error_starting('body: '):
+            schema.validate(comment)
+
+    @pytest.mark.parametrize('body_key', ('format', 'type', 'value'))
+    def test_no_body_type(self, schema, comment, body_key):
+        del comment['body'][0][body_key]
+        with raises_error_starting('body.0: '):
+            schema.validate(comment)
+
+    @pytest.mark.parametrize('target', ('', 'bob', 'bob@example.com'))
+    def test_invalid_target(self, schema, comment, target):
+        comment['target'] = target
+        with raises_error_starting('target: '):
+            schema.validate(comment)
+
+    def test_unknown_property(self, schema, comment):
+        comment['synergy'] = 'enterprise'
+        with pytest.raises(ValidationError):
+            schema.validate(comment)
+
+    @pytest.fixture
+    def schema(self):
+        return AnnotationImportSchema()
+
+    @pytest.fixture
+    def comment(self):
+        return {
+            "@context": "http://www.w3.org/ns/anno.jsonld",
+            "id": "import:123456789",
+            "type": "Annotation",
+            "created": "2017-01-25T23:00:00Z",
+            "modified": "2017-01-25T23:30:00Z",
+            "creator": "acct:commenter@example.com",
+            "body": [
+                {
+                    "type": "TextualBody",
+                    "value": "Hi",
+                    "format": "text/markdown"
+                }
+            ],
+            "motivation": "commenting",
+            "target": "https://example.com/foo"
+        }
+
+    @pytest.fixture
+    def reply(self):
+        return {
+            "@context": "http://www.w3.org/ns/anno.jsonld",
+            "id": "import:987654321",
+            "type": "Annotation",
+            "created": "2017-01-25T23:00:00Z",
+            "modified": "2017-01-25T23:30:00Z",
+            "creator": "acct:commenter@example.com",
+            "body": [
+                {
+                    "type": "TextualBody",
+                    "value": "Hi yourself",
+                    "format": "text/markdown"
+                }
+            ],
+            "motivation": "commenting",
+            "target": "import:123456789"
+        }
+
+
+@contextmanager
+def raises_error_starting(prefix):
+    """Test whether a code block raises a particular ValidationError."""
+    with pytest.raises(ValidationError) as error:
+        yield
+
+    assert error.value.message.startswith(prefix)


### PR DESCRIPTION
This is a part of https://github.com/hypothesis/product-backlog/issues/349.

This is a work in progress, hence not being wired into the rest of the app anywhere. I’d appreciate any early-stage feedback.

A few disorganised thoughts:

* I've tried to be pretty strict with what this validator will accept, purely from the point of view that we are only going to extend this as we want to accept more use cases and features in the future.
* I haven't put tagging into this yet, although that was in the original proposal. I haven't seen this in any of the data we want to accept so far, so we may be able to avoid doing this for now.
* I've added a context manager that wraps around `pytest.raises`; this also checks what the validation error message looks like. The reason I introduced this was that I named a key incorrectly in one of the tests and it still passed (because it failed as an unrecognised key). This seems a reasonable thing to add, but I'm aware that in a test suite it might make more sense to duplicate some code rather than introduce any new complexity.
* The new dependencies are libraries required by `jsonschema` to validate particular formats. `rfc3987` validates URIs and `strict-rfc3339` validates timestamps. There's an argument that this
  stricter validation isn't worth the cost of the additional dependencies, and that we might be ok with simpler regex-based validation.