### PR TITLE
Remove client cookie auth support

### DIFF
--- a/conf/app.ini
+++ b/conf/app.ini
@@ -14,12 +14,6 @@ use: call:h.app:create_app
 #es.host: http://localhost:9200
 #es.index: hypothesis
 
-# OAuth settings
-# These client credentials are used by the built-in Web client.
-# If not provided, both default to a random URL-safe base64-encoded string.
-#h.client_id:
-#h.client_secret:
-
 # SQLAlchemy configuration -- See SQLAlchemy documentation
 sqlalchemy.url: postgresql://postgres@localhost/postgres
 

--- a/conf/development-app.ini
+++ b/conf/development-app.ini
@@ -11,11 +11,6 @@ pyramid.reload_templates: True
 
 h.authority: localhost
 
-# Set a default persistent secret for development. DO NOT copy this into a
-# production settings file.
-h.client_id: nosuchid
-h.client_secret: nosuchsecret
-
 h.debug: True
 h.reload_assets: True
 

--- a/conf/development-websocket.ini
+++ b/conf/development-websocket.ini
@@ -4,7 +4,6 @@ use: call:h.websocket:create_app
 # Use gevent-compatible transport for the Sentry client
 raven.transport: gevent
 
-h.client_secret: nosuchsecret
 secret_key: notverysecretafterall
 
 # SQLAlchemy configuration -- See SQLAlchemy documentation

--- a/h/auth/tokens.py
+++ b/h/auth/tokens.py
@@ -2,7 +2,6 @@
 
 import datetime
 
-import jwt
 from zope.interface import implementer
 
 from h._compat import text_type
@@ -33,32 +32,6 @@ class Token(object):
             return True
         now = datetime.datetime.utcnow()
         return now < self.expires
-
-
-@implementer(IAuthenticationToken)
-class LegacyClientJWT(object):
-
-    """
-    A wrapper around JWT issued to the Hypothesis client.
-
-    Exposes the standard "auth token" interface on top of legacy tokens.
-    """
-
-    def __init__(self, body, key, leeway=240):
-        self.payload = jwt.decode(body,
-                                  key=key,
-                                  leeway=leeway,
-                                  algorithms=['HS256'])
-
-    def is_valid(self):
-        """Check if the token is valid. Always true for JWTs."""
-        # JWT validity checks happen at construction time. If an instance is
-        # successfully constructed, it is by definition valid.
-        return True
-
-    @property
-    def userid(self):
-        return self.payload.get('sub')
 
 
 def auth_token(request):

--- a/h/auth/tokens.py
+++ b/h/auth/tokens.py
@@ -61,40 +61,6 @@ class LegacyClientJWT(object):
         return self.payload.get('sub')
 
 
-def generate_jwt(request, expires_in):
-    """Return a signed JSON Web Token for the given request.
-
-    The token can be used in the Authorization header in subsequent requests to
-    the API to authenticate the user identified by the
-    request.authenticated_userid of the _current_ request.
-
-    :param request: the HTTP request to return a token for, the token will
-        authenticate the userid given by this request's authenticated_userid
-        property
-    :type request: pyramid.request.Request
-
-    :param expires_in: when the returned token should expire, in seconds from
-        the current time
-    :type expires_in: int
-
-    :returns: a signed JSON Web Token
-    :rtype: string
-
-    """
-    now = datetime.datetime.utcnow().replace(microsecond=0)
-
-    claims = {
-        'iss': request.registry.settings['h.client_id'],
-        'sub': request.authenticated_userid,
-        'exp': now + datetime.timedelta(seconds=expires_in),
-        'iat': now,
-    }
-
-    return jwt.encode(claims,
-                      request.registry.settings['h.client_secret'],
-                      algorithm='HS256')
-
-
 def auth_token(request):
     """
     Fetch the token (if any) associated with a request.

--- a/h/config.py
+++ b/h/config.py
@@ -71,11 +71,6 @@ SETTINGS = [
     EnvSetting('h.authority', 'AUTHORITY'),
     EnvSetting('h.bouncer_url', 'BOUNCER_URL'),
 
-    # ID and secret used for the issuer when signing JWT tokens for legacy API
-    # auth.
-    EnvSetting('h.client_id', 'CLIENT_ID'),
-    EnvSetting('h.client_secret', 'CLIENT_SECRET'),
-
     EnvSetting('h.client_url', 'CLIENT_URL'),
 
     # ID for the OAuth authclient that the embedded client should use when

--- a/h/routes.py
+++ b/h/routes.py
@@ -109,7 +109,6 @@ def includeme(config):
     config.add_route('oauth_revoke', '/oauth/revoke')
 
     # Client
-    config.add_route('session', '/app')
     config.add_route('sidebar_app', '/app.html')
     config.add_route('embed', '/embed.js')
 

--- a/h/services/auth_token.py
+++ b/h/services/auth_token.py
@@ -17,7 +17,7 @@ class AuthTokenService(object):
 
         This will return a token object implementing
         ``h.auth.interfaces.IAuthenticationToken``, or ``None`` when the token
-        cannot be found, is not a legacy JWT token, or is not valid.
+        cannot be found, or is not valid.
 
         :param token_str: the token string
         :type token_str: unicode

--- a/h/services/auth_token.py
+++ b/h/services/auth_token.py
@@ -2,17 +2,13 @@
 
 from __future__ import unicode_literals
 
-import jwt
-
 from h import models
-from h.auth.tokens import LegacyClientJWT, Token
+from h.auth.tokens import Token
 
 
 class AuthTokenService(object):
-    def __init__(self, session, client_secret):
+    def __init__(self, session):
         self._session = session
-        self._client_secret = client_secret
-
         self._validate_cache = {}
 
     def validate(self, token_str):
@@ -64,17 +60,8 @@ class AuthTokenService(object):
             token = Token(token_model)
             return token
 
-        # If we've got this far it's possible the token is a legacy client JWT.
-        return _maybe_jwt(token_str, self._client_secret)
+        return None
 
 
 def auth_token_service_factory(context, request):
-    client_secret = request.registry.settings['h.client_secret']
-    return AuthTokenService(request.db, client_secret)
-
-
-def _maybe_jwt(token, client_secret):
-    try:
-        return LegacyClientJWT(token, key=client_secret)
-    except jwt.InvalidTokenError:
-        return None
+    return AuthTokenService(request.db)

--- a/h/views/accounts.py
+++ b/h/views/accounts.py
@@ -164,49 +164,6 @@ class AuthController(object):
         return headers
 
 
-@view_defaults(route_name='session',
-               accept='application/json',
-               renderer='json')
-class AjaxAuthController(AuthController):
-
-    def __init__(self, request):
-        self.request = request
-        self.schema = schemas.LoginSchema().bind(request=self.request)
-        self.form = request.create_form(self.schema)
-
-    @view_config(request_param='__formid__=login')
-    def login(self):
-        try:
-            json_body = self.request.json_body
-        except ValueError as exc:
-            raise accounts.JSONError(
-                _('Could not parse request body as JSON: {message}'.format(
-                    message=exc.message)))
-
-        if not isinstance(json_body, dict):
-            raise accounts.JSONError(
-                _('Request JSON body must have a top-level object'))
-
-        # Transform non-string usernames and password into strings.
-        # Deform crashes otherwise.
-        json_body['username'] = unicode(json_body.get('username') or '')
-        json_body['password'] = unicode(json_body.get('password') or '')
-
-        appstruct = self.form.validate(json_body.items())
-
-        user = appstruct['user']
-        headers = self._login(user)
-        self.request.response.headers.extend(headers)
-
-        return ajax_payload(self.request, {'status': 'okay'})
-
-    @view_config(request_param='__formid__=logout')
-    def logout(self):
-        headers = self._logout()
-        self.request.response.headers.extend(headers)
-        return ajax_payload(self.request, {'status': 'okay'})
-
-
 @view_defaults(route_name='forgot_password',
                renderer='h:templates/accounts/forgot_password.html.jinja2')
 class ForgotPasswordController(object):

--- a/h/views/client.py
+++ b/h/views/client.py
@@ -14,7 +14,6 @@ import time
 from pyramid.httpexceptions import HTTPFound
 from pyramid.view import view_config
 
-from h.auth.tokens import generate_jwt
 from h import __version__
 
 # Default URL for the client, which points to the latest version of the client
@@ -100,22 +99,6 @@ def sidebar_app(request, extra=None):
         ctx.update(extra)
 
     return ctx
-
-
-# This view requires credentials (a cookie) so is not currently accessible
-# off-origin, unlike the rest of the API. Given that this method of
-# authenticating to the API is not intended to remain, this seems like a
-# limitation we do not need to lift any time soon.
-@view_config(route_name='token', renderer='string', request_method='GET')
-def annotator_token(request):
-    """
-    Return a JWT access token for the given request.
-
-    The token can be used in the Authorization header in subsequent requests to
-    the API to authenticate the user identified by the
-    request.authenticated_userid of the _current_ request, which may be None.
-    """
-    return generate_jwt(request, 3600)
 
 
 @view_config(route_name='embed',

--- a/h/views/client.py
+++ b/h/views/client.py
@@ -14,9 +14,7 @@ import time
 from pyramid.httpexceptions import HTTPFound
 from pyramid.view import view_config
 
-from h import session as h_session
 from h.auth.tokens import generate_jwt
-from h.util.view import json_view
 from h import __version__
 
 # Default URL for the client, which points to the latest version of the client
@@ -130,10 +128,3 @@ def embed_redirect(request):
     client, typically hosted on a CDN.
     """
     return HTTPFound(_client_url(request))
-
-
-@json_view(route_name='session', http_cache=0)
-def session_view(request):
-    flash = h_session.pop_flash(request)
-    model = h_session.model(request)
-    return dict(status='okay', flash=flash, model=model)

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -15,7 +15,6 @@ TEST_SETTINGS = {
     'es.index': 'hypothesis-test',
     'h.app_url': 'http://example.com',
     'h.authority': 'example.com',
-    'h.client_secret': 'notsosecret',
     'pyramid.debug_all': True,
     'sqlalchemy.url': os.environ.get('TEST_DATABASE_URL',
                                      'postgresql://postgres@localhost/htest')

--- a/tests/h/auth/tokens_test.py
+++ b/tests/h/auth/tokens_test.py
@@ -107,35 +107,6 @@ class TestLegacyClientJWT(object):
         assert result.userid is None
 
 
-def test_generate_jwt_calls_encode(jwt_, pyramid_config, pyramid_request):
-    """It should pass the right arguments to encode()."""
-    pyramid_config.testing_securitypolicy('acct:testuser@hypothes.is')
-    before = datetime.datetime.utcnow()
-
-    tokens.generate_jwt(pyramid_request, 3600)
-
-    assert jwt_.encode.call_args[0][0]['sub'] == 'acct:testuser@hypothes.is', (
-        "It should encode the userid as 'sub'")
-    after = datetime.datetime.utcnow() + datetime.timedelta(seconds=3600)
-    assert before < jwt_.encode.call_args[0][0]['exp'] < after, (
-        "It should encode the expiration time as 'exp'")
-    assert jwt_.encode.call_args[1]['algorithm'] == 'HS256', (
-        "It should pass the right algorithm to encode()")
-
-
-def test_generate_jwt_when_authenticated_userid_is_None(jwt_, pyramid_request):
-    """It should work when request.authenticated_userid is None."""
-    tokens.generate_jwt(pyramid_request, 3600)
-
-    assert jwt_.encode.call_args[0][0]['sub'] is None
-
-
-def test_generate_jwt_returns_token(jwt_, pyramid_request):
-    result = tokens.generate_jwt(pyramid_request, 3600)
-
-    assert result == jwt_.encode.return_value
-
-
 class TestAuthToken(object):
     def test_retrieves_token_for_request(self, pyramid_request):
         pyramid_request.headers['Authorization'] = 'Bearer abcdef123'
@@ -183,11 +154,6 @@ def pyramid_settings(pyramid_settings):
         'h.client_secret': 'secret',
     })
     return pyramid_settings
-
-
-@pytest.fixture
-def jwt_(patch):
-    return patch('h.auth.tokens.jwt')
 
 
 def _seconds_from_now(seconds):

--- a/tests/h/auth/tokens_test.py
+++ b/tests/h/auth/tokens_test.py
@@ -147,14 +147,5 @@ class TestAuthToken(object):
         assert result is None
 
 
-@pytest.fixture
-def pyramid_settings(pyramid_settings):
-    pyramid_settings.update({
-        'h.client_id': 'id',
-        'h.client_secret': 'secret',
-    })
-    return pyramid_settings
-
-
 def _seconds_from_now(seconds):
     return datetime.datetime.utcnow() + datetime.timedelta(seconds=seconds)

--- a/tests/h/auth/tokens_test.py
+++ b/tests/h/auth/tokens_test.py
@@ -54,59 +54,6 @@ INVALID_TOKEN_EXAMPLES = [
 ]
 
 
-class TestLegacyClientJWT(object):
-    @pytest.mark.parametrize('get_token', VALID_TOKEN_EXAMPLES)
-    def test_ok_for_valid_jwt(self, get_token):
-        token = get_token('secrets!')
-
-        result = tokens.LegacyClientJWT(token, key='secrets!')
-
-        assert isinstance(result, tokens.LegacyClientJWT)
-
-    @pytest.mark.parametrize('get_token', INVALID_TOKEN_EXAMPLES)
-    def test_raises_for_invalid_jwt(self, get_token):
-        token = get_token('secrets!')
-
-        with pytest.raises(jwt.InvalidTokenError):
-            tokens.LegacyClientJWT(token,
-                                   key='secrets!')
-
-    def test_payload(self):
-        payload = {'exp': _seconds_from_now(3600),
-                   'sub': 'foobar'}
-        token = jwt.encode(payload, key='s3cr37')
-
-        result = tokens.LegacyClientJWT(token, key='s3cr37')
-
-        assert result.payload == payload
-
-    def test_always_valid(self):
-        payload = {'exp': _seconds_from_now(3600),
-                   'sub': 'foobar'}
-        token = jwt.encode(payload, key='s3cr37')
-
-        result = tokens.LegacyClientJWT(token, key='s3cr37')
-
-        assert result.is_valid()
-
-    def test_userid_gets_payload_sub(self):
-        payload = {'exp': _seconds_from_now(3600),
-                   'sub': 'foobar'}
-        token = jwt.encode(payload, key='s3cr37')
-
-        result = tokens.LegacyClientJWT(token, key='s3cr37')
-
-        assert result.userid == 'foobar'
-
-    def test_userid_none_if_sub_missing(self):
-        payload = {'exp': _seconds_from_now(3600)}
-        token = jwt.encode(payload, key='s3cr37')
-
-        result = tokens.LegacyClientJWT(token, key='s3cr37')
-
-        assert result.userid is None
-
-
 class TestAuthToken(object):
     def test_retrieves_token_for_request(self, pyramid_request):
         pyramid_request.headers['Authorization'] = 'Bearer abcdef123'

--- a/tests/h/routes_test.py
+++ b/tests/h/routes_test.py
@@ -87,7 +87,6 @@ def test_includeme():
         call('token', '/api/token'),
         call('oauth_authorize', '/oauth/authorize'),
         call('oauth_revoke', '/oauth/revoke'),
-        call('session', '/app'),
         call('sidebar_app', '/app.html'),
         call('embed', '/embed.js'),
         call('stream_atom', '/stream.atom'),

--- a/tests/h/views/accounts_test.py
+++ b/tests/h/views/accounts_test.py
@@ -561,7 +561,7 @@ class TestActivateController(object):
         assert success_flash
         assert success_flash[0].startswith("Your account has been activated")
 
-    def test_get_when_not_logged_in_successful_creates_ActivationEvent(  # noqa
+    def test_get_when_not_logged_in_successful_creates_ActivationEvent(  # noqa: N802, N803
             self,
             pyramid_request,
             user_model,

--- a/tests/h/views/accounts_test.py
+++ b/tests/h/views/accounts_test.py
@@ -561,7 +561,7 @@ class TestActivateController(object):
         assert success_flash
         assert success_flash[0].startswith("Your account has been activated")
 
-    def test_get_when_not_logged_in_successful_creates_ActivationEvent(
+    def test_get_when_not_logged_in_successful_creates_ActivationEvent(  # noqa
             self,
             pyramid_request,
             user_model,
@@ -574,7 +574,7 @@ class TestActivateController(object):
         ActivationEvent.assert_called_once_with(
             pyramid_request, user_model.get_by_activation.return_value)
 
-    def test_get_when_not_logged_in_successful_notifies(self,
+    def test_get_when_not_logged_in_successful_notifies(self,  # noqa: N803
                                                         notify,
                                                         pyramid_request,
                                                         user_model,
@@ -677,7 +677,6 @@ class TestAccountController(object):
 
     def test_post_password_form_with_invalid_data_does_not_change_password(
             self, invalid_form, pyramid_request, user_password_service):
-        user = pyramid_request.user
         controller = views.AccountController(pyramid_request)
         controller.forms['password'] = invalid_form()
 
@@ -913,7 +912,7 @@ def activation_model(patch):
 
 
 @pytest.fixture
-def ActivationEvent(patch):
+def ActivationEvent(patch):  # noqa: N802
     return patch('h.views.accounts.ActivationEvent')
 
 

--- a/tests/h/views/accounts_test.py
+++ b/tests/h/views/accounts_test.py
@@ -4,10 +4,8 @@
 import mock
 import pytest
 
-import deform
 from pyramid import httpexceptions
 
-from h import accounts
 from h.services.developer_token import developer_token_service_factory
 from h.services.user_password import UserPasswordService
 from h.views import accounts as views
@@ -211,99 +209,6 @@ class TestAuthController(object):
         pyramid_config.add_route('forgot_password', '/forgot')
         pyramid_config.add_route('index', '/index')
         pyramid_config.add_route('stream', '/stream')
-
-
-@pytest.mark.usefixtures('session')
-class TestAjaxAuthController(object):
-
-    def test_login_returns_status_okay_when_validation_succeeds(self,
-                                                                factories,
-                                                                form_validating_to,
-                                                                pyramid_request):
-        pyramid_request.json_body = {}
-        controller = views.AjaxAuthController(pyramid_request)
-        controller.form = form_validating_to({'user': factories.User(username='bob')})
-
-        result = controller.login()
-
-        assert result['status'] == 'okay'
-
-    def test_login_raises_JSONError_on_non_json_body(self, pyramid_request):
-        type(pyramid_request).json_body = {}
-        with mock.patch.object(type(pyramid_request),
-                               'json_body',
-                               new_callable=mock.PropertyMock) as json_body:
-            json_body.side_effect = ValueError()
-
-            controller = views.AjaxAuthController(pyramid_request)
-
-            with pytest.raises(accounts.JSONError) as exc_info:
-                controller.login()
-                assert exc_info.value.message.startswith(
-                    'Could not parse request body as JSON: ')
-
-    def test_login_raises_JSONError_on_non_object_json(self, pyramid_request):
-        pyramid_request.user = mock.Mock(groups=[])
-        pyramid_request.json_body = 'foo'
-
-        controller = views.AjaxAuthController(pyramid_request)
-        expected_message = 'Request JSON body must have a top-level object'
-
-        with pytest.raises(accounts.JSONError) as exc_info:
-            controller.login()
-
-        assert exc_info.value.message == expected_message
-
-    def test_login_converts_non_string_usernames_to_strings(self, pyramid_csrf_request):
-        for input_, expected_output in ((None, ''),
-                                        (23, '23'),
-                                        (True, 'True')):
-            pyramid_csrf_request.json_body = {'username': input_,
-                                              'password': 'pass'}
-            controller = views.AjaxAuthController(pyramid_csrf_request)
-            controller.form.validate = mock.Mock(
-                return_value={'user': mock.Mock()})
-
-            controller.login()
-
-            assert controller.form.validate.called
-            pstruct = controller.form.validate.call_args[0][0]
-            assert sorted(pstruct) == sorted([('username', expected_output),
-                                              ('password', 'pass')])
-
-    def test_login_converts_non_string_passwords_to_strings(self, pyramid_csrf_request):
-        for input_, expected_output in ((None, ''),
-                                        (23, '23'),
-                                        (True, 'True')):
-            pyramid_csrf_request.json_body = {'username': 'user',
-                                              'password': input_}
-            controller = views.AjaxAuthController(pyramid_csrf_request)
-            controller.form.validate = mock.Mock(
-                return_value={'user': mock.Mock()})
-
-            controller.login()
-
-            assert controller.form.validate.called
-            pstruct = controller.form.validate.call_args[0][0]
-            assert sorted(pstruct) == sorted([('username', 'user'),
-                                              ('password', expected_output)])
-
-    def test_login_raises_ValidationFailure_on_ValidationFailure(self,
-                                                                 invalid_form,
-                                                                 pyramid_request):
-        pyramid_request.json_body = {}
-        controller = views.AjaxAuthController(pyramid_request)
-        controller.form = invalid_form({'password': 'too short'})
-
-        with pytest.raises(deform.ValidationFailure) as exc_info:
-            controller.login()
-
-        assert exc_info.value.error.asdict() == {'password': 'too short'}
-
-    def test_logout_returns_status_okay(self, pyramid_request):
-        result = views.AjaxAuthController(pyramid_request).logout()
-
-        assert result['status'] == 'okay'
 
 
 @pytest.mark.usefixtures('activation_model',

--- a/tests/h/views/api_auth_test.py
+++ b/tests/h/views/api_auth_test.py
@@ -367,7 +367,6 @@ class TestDebugToken(object):
 
     @pytest.fixture
     def token_service(self, pyramid_config, pyramid_request):
-        pyramid_config.registry.settings['h.client_secret'] = 'notsosecretafterall'
         svc = mock.Mock(spec_set=auth_token_service_factory(None, pyramid_request))
         pyramid_config.register_service(svc, name='auth_token')
         return svc

--- a/tests/h/views/client_test.py
+++ b/tests/h/views/client_test.py
@@ -11,18 +11,6 @@ from h.views import client
 from h import __version__
 
 
-def test_annotator_token_calls_generate_jwt(generate_jwt, pyramid_request):
-    client.annotator_token(pyramid_request)
-
-    generate_jwt.assert_called_once_with(pyramid_request, 3600)
-
-
-def test_annotator_token_returns_token(generate_jwt, pyramid_request):
-    result = client.annotator_token(pyramid_request)
-
-    assert result == generate_jwt.return_value
-
-
 @pytest.mark.usefixtures('routes', 'pyramid_settings')
 class TestSidebarApp(object):
 
@@ -104,10 +92,3 @@ def routes(pyramid_config):
     pyramid_config.add_route('sidebar_app', '/app.html')
     pyramid_config.add_route('oauth_authorize', '/oauth/authorize')
     pyramid_config.add_route('oauth_revoke', '/oauth/revoke')
-
-
-@pytest.fixture
-def generate_jwt(patch):
-    func = patch('h.views.client.generate_jwt')
-    func.return_value = 'abc123'
-    return func


### PR DESCRIPTION
**Depends on https://github.com/hypothesis/client/pull/542 being merged & shipped**

This PR removes support for cookie-based authentication for the client in the web service. This includes:

- The `GET /app` route which was a predecessor of the `/api/profile` route
- The `GET /api/token` route which was used by the client to obtain a JWT "access token"
- Support for JWT "access tokens" generated by the `GET /api/token` route
- AJAX views for handling login & logout requests from the client.
- The "client_id" and "client_secret" env vars which were used to sign JWTs returned by the `GET /api/token` route

I included all the changes in this PR (one per commit) so they can all be tested together more easily. I'm happy to split some of the pieces out if people would prefer.

There has been some chatter in #design about whether login synchronisation between the embed and the website is something we might want to reintroduce in future. If we do then I imagine we'll revisit in a way that fits in better with the OAuth-based auth system rather than being an entirely separate thing.