### PR TITLE
Don't test that JWT's issued in future are invalid

### DIFF
--- a/tests/h/auth/tokens_test.py
+++ b/tests/h/auth/tokens_test.py
@@ -48,11 +48,6 @@ INVALID_TOKEN_EXAMPLES = [
     lambda k: jwt.encode({'exp': _seconds_from_now(-3600)},
                          key=k),
 
-    # Issued in the future
-    lambda k: jwt.encode({'exp': _seconds_from_now(3600),
-                          'iat': _seconds_from_now(1800)},
-                         key=k),
-
     # Incorrect encoding key
     lambda k: jwt.encode({'exp': _seconds_from_now(3600)},
                          key='somethingelse'),

--- a/tests/h/oauth/jwt_grant_token_test.py
+++ b/tests/h/oauth/jwt_grant_token_test.py
@@ -173,15 +173,6 @@ class TestVerifiedJWTGrantToken(object):
 
         assert exc.value.description == 'Grant token is not yet valid.'
 
-    def test_init_raises_for_iat_claim_in_future(self, claims):
-        claims['iat'] = epoch(delta=timedelta(minutes=13))
-        jwttok = jwt_token(claims)
-
-        with pytest.raises(InvalidGrantError) as exc:
-            VerifiedJWTGrantToken(jwttok, 'top-secret', 'test-audience')
-
-        assert exc.value.description == 'Grant token issue time (iat) is in the future.'
-
     def test_expiry_returns_exp_claim(self, claims):
         now = datetime.utcnow().replace(microsecond=0)
         delta = timedelta(minutes=2)


### PR DESCRIPTION
Remove two tests that JWT's whose `iat` value claims that they were
issued in the future fail validation.

These two tests fail on newer versions of PyJWT:

https://github.com/hypothesis/h/pull/4672

This is because PyJWT no longer raises an exception for future `iat`
times:

https://github.com/jpadilla/pyjwt/issues/190

PyJWT removed this validation because:

- Clock skew can cause one party to generate `iat` times a few seconds
or minutes ahead of another's current time

- The JWT spec (RFC 7519) doesn't say that a JWT with a future `iat`
should be considered invalid, these JWTs are valid

- Other JWT libraries don't do this check