### PR TITLE
Describe OAuth in authorization docs

### DIFF
--- a/docs/_extra/api-reference/hypothesis.yaml
+++ b/docs/_extra/api-reference/hypothesis.yaml
@@ -1,63 +1,13 @@
 swagger: "2.0"
 info:
   version: 1.0.0
-  title: Hypothesis
+  title: Hypothesis API Reference
   description: |
-    # Hypothesis API documentation
+    # Hypothesis API Reference
 
-    This document details the Hypothesis public HTTP API. It is targeted at
-    developers interested in integrating functionality from Hypothesis into
-    their own applications.
-
-    ## Authorization
-
-    ### API tokens
-    Some of the API URLs documented below require a valid API token.
-    To use these API URLs you should:
-
-    1. Generate yourself an API token on your [Hypothesis developer
-       page](https://hypothes.is/account/developer) (you must be logged in to
-       Hypothesis to get to this page).
-    2. Put the API token in the `Authorization` header in your request.
-
-    *Example request:*
-
-        GET /api
-        Host: hypothes.is
-        Accept: application/json
-        Authorization: Bearer 6879-nUYZBzc15MsjDDicz-0xEaKBrVGGruwCHW9-p8BMqq4
-
-    (Replace `6879-nUYZBzc15MsjDDicz-0xEaKBrVGGruwCHW9-p8BMqq4` with your own API token.)
-
-    ### Client credentials direct authorization
-    The user creation API is intended for use by "third-party accounts" clients.
-    These endpoints are authenticated by HTTP Basic Auth using your client ID as
-    the username and your client secret as the password.
-
-    For example, with client details as follows
-
-        Client ID: 96653f8e-80be-11e6-b32b-c7bcde86613a
-        Client Secret: E-hReVMuRyZbyr1GikieEw4JslaM6sDpb18_9V59PFw
-
-    you can compute the Authorization header [as described in
-    RFC7617](https://tools.ietf.org/html/rfc7617):
-
-        $ echo -n '96653f8e-80be-11e6-b32b-c7bcde86613a:E-hReVMuRyZbyr1GikieEw4JslaM6sDpb18_9V59PFw' | base64
-        OTY2NTNmOGUtODBiZS0xMWU2LWIzMmItYzdiY2RlODY2MTNhOkUtaFJlVk11UnlaYnlyMUdpa2llRXc0SnNsYU02c0RwYjE4XzlWNTlQRnc=
-
-    *Example request:*
-
-        POST /users
-        Host: hypothes.is
-        Accept: application/json
-        Content-Type: application/json
-        Authorization: Basic OTY2NTNmOGUtODBiZS0xMWU2LWIzMmItYzdiY2RlODY2MTNhOkUtaFJlVk11UnlaYnlyMUdpa2llRXc0SnNsYU02c0RwYjE4XzlWNTlQRnc=
-
-        {
-          "authority": "example.com",
-          "username": "jbloggs1",
-          "email": "jbloggs1@example.com"
-        }
+    This is a reference for the Hypothesis HTTP API.
+    See [the API overview](../api/) for an introduction to the API and information
+    on how authorization works.
 
   termsOfService: https://hypothes.is/terms-of-service
   license:

--- a/docs/api/authorization.rst
+++ b/docs/api/authorization.rst
@@ -1,0 +1,90 @@
+Authorization
+#############
+
+API requests which only read public data do not require authorization.
+
+API requests made as a particular user or which manage user accounts or groups
+require authorization.
+
+.. toctree::
+   :maxdepth: 1
+
+   using-oauth
+
+Access tokens
+-------------
+
+API requests which read or write data as a specific user need to be authorized
+with an access token. Access tokens can be obtained in two ways:
+
+1. By generating a personal API token on the `Hypothesis developer
+   page <https://hypothes.is/account/developer>`_ (you must be logged in to
+   Hypothesis to get to this page). This is the simplest method, however
+   these tokens are only suitable for enabling your application to make
+   requests as a single specific user.
+
+2. By :ref:`registering <registering-an-oauth-client>` an "OAuth client" and
+   :ref:`implementing <implementing-oauth-flow>` the OAuth authentication flow
+   in your application. This method allows any user to authorize your
+   application to read and write data via the API as that user.  The Hypothesis
+   client is an example of an application that uses OAuth.
+
+   See :doc:`using-oauth` for details of how to implement this method.
+
+Once an access token has been obtained, requests can be authorized by putting
+the token in the ``Authorization`` header.
+
+*Example request:*
+
+..  code-block:: http
+
+    GET /api HTTP/1.1
+    Host: hypothes.is
+    Accept: application/json
+    Authorization: Bearer $TOKEN
+
+(Replace ``$TOKEN`` with your own API token or OAuth access token.)
+
+Client credentials
+------------------
+
+Endpoints for managing user accounts are authorized using a client ID and secret
+("client credentials"). These can be obtained by :ref:`registering an OAuth
+client <registering-an-oauth-client>` with the grant type set to
+``client_credentials``.
+
+Once a client ID and secret have been obtained, requests are authorized using
+HTTP Basic Auth, where the client ID is the username and the client secret is
+the password.
+
+For example, with client details as follows
+
+..  code-block:: bash
+
+    Client ID: 96653f8e-80be-11e6-b32b-c7bcde86613a
+    Client Secret: E-hReVMuRyZbyr1GikieEw4JslaM6sDpb18_9V59PFw
+
+you can compute the Authorization header [as described in
+RFC7617](https://tools.ietf.org/html/rfc7617):
+
+..  code-block:: bash
+
+    $ echo -n '96653f8e-80be-11e6-b32b-c7bcde86613a:E-hReVMuRyZbyr1GikieEw4JslaM6sDpb18_9V59PFw' | base64
+    OTY2NTNmOGUtODBiZS0xMWU2LWIzMmItYzdiY2RlODY2MTNhOkUtaFJlVk11UnlaYnlyMUdpa2llRXc0SnNsYU02c0RwYjE4XzlWNTlQRnc=
+
+*Example request:*
+
+..  code-block:: http
+
+    POST /users HTTP/1.1
+    Host: hypothes.is
+    Accept: application/json
+    Content-Type: application/json
+    Authorization: Basic OTY2NTNmOGUtODBiZS0xMWU2LWIzMmItYzdiY2RlODY2MTNhOkUtaFJlVk11UnlaYnlyMUdpa2llRXc0SnNsYU02c0RwYjE4XzlWNTlQRnc=
+
+    {
+      "authority": "example.com",
+      "username": "jbloggs1",
+      "email": "jbloggs1@example.com"
+    }
+

--- a/docs/api/authorization.rst
+++ b/docs/api/authorization.rst
@@ -1,5 +1,5 @@
 Authorization
-#############
+=============
 
 API requests which only read public data do not require authorization.
 

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -7,5 +7,6 @@ write data from the Hypothesis service.
 .. toctree::
    :maxdepth: 1
 
+   authorization
    API Reference <../api-reference/index>
    realtime

--- a/docs/api/using-oauth.rst
+++ b/docs/api/using-oauth.rst
@@ -24,7 +24,7 @@ works as follows:
    authorize API requests, and a long-lived refresh token.
 
 5. When the access token expires, the application obtains a new access token
-   using the ``POST /api/token`` endpoint.
+   by submitting the refresh token to the ``POST /api/token`` endpoint.
 
 To build an application for Hypothesis that uses OAuth, there are two steps:
 
@@ -39,9 +39,9 @@ To build an application for Hypothesis that uses OAuth, there are two steps:
 Registering an OAuth client
 ---------------------------
 
-To register an OAuth client, go to the `/admin/oauthclients` page on the h
-service. To register an OAuth client on the public h service at
-https://hypothes.is, please contact us.
+To register an OAuth client on an instance of the h service for which you have
+admin access, go to the `/admin/oauthclients` page. To register an OAuth client
+on the public h service at https://hypothes.is, please contact us.
 
 To register a new client as an admin of the "h" service:
 

--- a/docs/api/using-oauth.rst
+++ b/docs/api/using-oauth.rst
@@ -17,7 +17,7 @@ works as follows:
    asked to approve access.
 
 3. If they approve, the authorization endpoint will send an authorization code
-   back to the application (via a redirect or ``window.postMessage`` call).
+   back to the application (via a redirect).
 
 4. The application exchanges the authorization code for a pair of tokens using
    the h service's ``POST /api/token`` endpoint: A short-lived access token to
@@ -31,8 +31,8 @@ To build an application for Hypothesis that uses OAuth, there are two steps:
 1. Register an OAuth client for your application in the h service.
 
 2. Implement the client-side part of the OAuth flow above in your application.
-   Since OAuth is a widely implemented standard, there are many existing
-   libraries for various languages which you can use.
+   You may be able to use an existing OAuth 2 client library for your language
+   and platform.
 
 .. _registering-an-oauth-client:
 
@@ -43,8 +43,7 @@ To register an OAuth client, go to the `/admin/oauthclients` page on the h
 service. To register an OAuth client on the public h service at
 https://hypothes.is, please contact us.
 
-As an admin of the "h" service you can register a client for a browser-based
-client:
+To register a new client as an admin of the "h" service:
 
 1. Go to `/admin/oauthclients` and click "Register a new OAuth client".
 

--- a/docs/api/using-oauth.rst
+++ b/docs/api/using-oauth.rst
@@ -1,0 +1,80 @@
+Using OAuth
+###########
+
+`OAuth <https://en.wikipedia.org/wiki/OAuth>`_ is an open standard that enables
+users to grant an application (an "OAuth client") the ability to interact with a
+service as that user, but without providing their authentication credentials
+(eg. username and password) directly to that application.
+
+OAuth clients follow an authorization process, at the end of which they get an
+access token which is included in API requests to the service. This process
+works as follows:
+
+1. The user clicks a login button or link in the application.
+
+2. The application sends them to an authorization page from the h service
+   (``/oauth/authorize``) via a redirect or popup, where the user will be
+   asked to approve access.
+
+3. If they approve, the authorization endpoint will send an authorization code
+   back to the application (via a redirect or ``window.postMessage`` call).
+
+4. The application exchanges the authorization code for a pair of tokens using
+   the h service's ``POST /oauth/token`` endpoint: A short-lived access token to
+   authorize API requests, and a long-lived refresh token.
+
+5. When the access token expires, the application obtains a new access token
+   using the ``POST /oauth/token`` endpoint.
+
+To build an application for Hypothesis that uses OAuth, there are two steps:
+
+1. Register an OAuth client for your application in the h service.
+
+2. Implement the client-side part of the OAuth flow above in your application.
+   Since OAuth is a widely implemented standard, there are many existing
+   libraries for various languages which you can use.
+
+.. _registering-an-oauth-client:
+
+Registering an OAuth client
+---------------------------
+
+To register an OAuth client, go to the `/admin/oauthclients` page on the h
+service. To register an OAuth client on the public h service at
+https://hypothes.is, please contact us.
+
+As an admin of the "h" service you can register a client for a browser-based
+client:
+
+1. Go to `/admin/oauthclients` and click "Register a new OAuth client".
+
+2. Enter a name for a client, select "authorization_code" as the grant type and
+   enter the URL where your client will listen for the authorization code as the
+   "redirect URL".
+
+3. Click "Register client" to create the client. Make a note of the randomly
+   generated client ID.
+
+.. _implementing-oauth-flow:
+
+Implementing the OAuth flow
+---------------------------
+
+The h service implements the standard OAuth flow, with the following endpoints:
+
+- Authorization page: ``GET /oauth/authorize``
+- Token exchange: ``POST /oauth/token``
+- Token refresh: ``POST /oauth/token``
+
+See the `Authorization section
+<https://aaronparecki.com/oauth-2-simplified/#authorization>`_ of "OAuth 2
+simplified" for a description of how to implement the authorization flow for
+different types of client.
+
+Further reading
+---------------
+
+- `"OAuth 2 simplified" <https://aaronparecki.com/oauth-2-simplified/>`_ is a
+  good introduction for developers.
+- The `OAuth specification <https://tools.ietf.org/html/rfc6749>`_ describes the
+  standard in detail.

--- a/docs/api/using-oauth.rst
+++ b/docs/api/using-oauth.rst
@@ -1,5 +1,5 @@
 Using OAuth
-###########
+===========
 
 `OAuth <https://en.wikipedia.org/wiki/OAuth>`_ is an open standard that enables
 users to grant an application (an "OAuth client") the ability to interact with a

--- a/docs/api/using-oauth.rst
+++ b/docs/api/using-oauth.rst
@@ -60,7 +60,9 @@ client:
 Implementing the OAuth flow
 ---------------------------
 
-The h service implements the standard OAuth flow, with the following endpoints:
+The h service implements the `"Authorization code grant"
+<https://tools.ietf.org/html/rfc6749#section-4.1>`_ OAuth flow, with the
+following endpoints:
 
 - Authorization endpoint: ``/oauth/authorize``
 - Token endpoint: ``/api/token``

--- a/docs/api/using-oauth.rst
+++ b/docs/api/using-oauth.rst
@@ -66,10 +66,52 @@ The h service implements the standard OAuth flow, with the following endpoints:
 - Token exchange: ``POST /oauth/token``
 - Token refresh: ``POST /oauth/token``
 
-See the `Authorization section
-<https://aaronparecki.com/oauth-2-simplified/#authorization>`_ of "OAuth 2
-simplified" for a description of how to implement the authorization flow for
-different types of client.
+In order to implement the flow, your application must do the following:
+
+1. When a user clicks the "Login" link, the application should open the h
+   service's authorization page at ``/oauth/authorize`` using the query
+   parameters described in `4.1.1 Authorization Request
+   <https://tools.ietf.org/html/rfc6749#section-4.1.1>`_.
+
+   *Example request:*
+
+   .. code-block:: http
+
+      GET /oauth/authorize?client_id=510cd02e-767b-11e7-b34b-ebcff2e51409&redirect_uri=https%3A%2F%2Fmyapp.com%2Fauthorize&response_type=code&state=aa3d3062b4dbe0a1 HTTP/1.1
+
+2. After the user authorizes the application, it will receive an authorization
+   code via a call to the redirect URI. The application must exchange this code
+   for an access token by making a request to the ``POST /oauth/token`` endpoint
+   as described in `4.1.3 Access Token Request
+   <https://tools.ietf.org/html/rfc6749#section-4.1.3>`_.
+
+   *Example request:*
+
+   .. code-block:: http
+
+      POST /oauth/token HTTP/1.1
+      Content-Type: application/x-www-form-urlencoded
+
+      client_id=631206c8-7792-11e7-90b3-872e79925778&code=V1bjcvKDivRUc6Sg1jhEc8ckDwyLNG&grant_type=authorization_code
+
+   *Example response:*
+
+   .. code-block:: json
+
+      {
+        "token_type": "Bearer",
+        "access_token": "5768-mfoPT52ogx0Si7NkU8QFicj183Wz1O4OQmbNIvBhjTQ",
+        "expires_in": 3600,
+        "refresh_token": "4657-dkJGNdVn8dmhDvgCHVPmIJ2Zi0cYQgDNb7RWXkpGIZs",
+        "scope": "annotation:read annotation:write"
+      }
+
+3. Once the application has an access token, it can make API requests and
+   connect to the real time API. See :doc:`authorization` for details of how
+   to include this token in requests.
+4. The access token expires after a while, and must be refreshed by making a
+   request to the ``POST /oauth/token`` endpoint as described in `6. Refreshing
+   an access token <https://tools.ietf.org/html/rfc6749#section-6>`_.
 
 Further reading
 ---------------

--- a/docs/api/using-oauth.rst
+++ b/docs/api/using-oauth.rst
@@ -20,11 +20,11 @@ works as follows:
    back to the application (via a redirect or ``window.postMessage`` call).
 
 4. The application exchanges the authorization code for a pair of tokens using
-   the h service's ``POST /oauth/token`` endpoint: A short-lived access token to
+   the h service's ``POST /api/token`` endpoint: A short-lived access token to
    authorize API requests, and a long-lived refresh token.
 
 5. When the access token expires, the application obtains a new access token
-   using the ``POST /oauth/token`` endpoint.
+   using the ``POST /api/token`` endpoint.
 
 To build an application for Hypothesis that uses OAuth, there are two steps:
 
@@ -62,9 +62,8 @@ Implementing the OAuth flow
 
 The h service implements the standard OAuth flow, with the following endpoints:
 
-- Authorization page: ``GET /oauth/authorize``
-- Token exchange: ``POST /oauth/token``
-- Token refresh: ``POST /oauth/token``
+- Authorization endpoint: ``/oauth/authorize``
+- Token endpoint: ``/api/token``
 
 In order to implement the flow, your application must do the following:
 
@@ -81,7 +80,7 @@ In order to implement the flow, your application must do the following:
 
 2. After the user authorizes the application, it will receive an authorization
    code via a call to the redirect URI. The application must exchange this code
-   for an access token by making a request to the ``POST /oauth/token`` endpoint
+   for an access token by making a request to the ``POST /api/token`` endpoint
    as described in `4.1.3 Access Token Request
    <https://tools.ietf.org/html/rfc6749#section-4.1.3>`_.
 
@@ -89,7 +88,7 @@ In order to implement the flow, your application must do the following:
 
    .. code-block:: http
 
-      POST /oauth/token HTTP/1.1
+      POST /api/token HTTP/1.1
       Content-Type: application/x-www-form-urlencoded
 
       client_id=631206c8-7792-11e7-90b3-872e79925778&code=V1bjcvKDivRUc6Sg1jhEc8ckDwyLNG&grant_type=authorization_code
@@ -110,7 +109,7 @@ In order to implement the flow, your application must do the following:
    connect to the real time API. See :doc:`authorization` for details of how
    to include this token in requests.
 4. The access token expires after a while, and must be refreshed by making a
-   request to the ``POST /oauth/token`` endpoint as described in `6. Refreshing
+   request to the ``POST /api/token`` endpoint as described in `6. Refreshing
    an access token <https://tools.ietf.org/html/rfc6749#section-6>`_.
 
 Further reading

--- a/docs/api/using-oauth.rst
+++ b/docs/api/using-oauth.rst
@@ -114,6 +114,27 @@ In order to implement the flow, your application must do the following:
    request to the ``POST /api/token`` endpoint as described in `6. Refreshing
    an access token <https://tools.ietf.org/html/rfc6749#section-6>`_.
 
+   *Example request:*
+
+   .. code-block:: http
+
+      POST /api/token HTTP/1.1
+      Content-Type: application/x-www-form-urlencoded
+
+      grant_type=refresh_token&refresh_token=4657-diyCpZ9oPRBaBkaW6ZrKgI0yagvZ9yBgLmxJ9k4HfeM
+
+   *Example response:*
+
+   .. code-block:: json
+
+      {
+        "token_type": "Bearer",
+        "access_token": "5768-8CHodeMUAPCLmuBooabXolnpHReBUI5cC3txCXk7sQA",
+        "expires_in": 3600,
+        "refresh_token": "4657-11f1CUrhZs29QvXpywDpsXFwlfl_wPEIY5N8whwUrRw",
+        "scope": "annotation:read annotation:write"
+      }
+
 Further reading
 ---------------
 

--- a/docs/api/using-oauth.rst
+++ b/docs/api/using-oauth.rst
@@ -134,6 +134,25 @@ In order to implement the flow, your application must do the following:
         "scope": "annotation:read annotation:write"
       }
 
+Revoking tokens
+---------------
+
+If your application no longer needs an OAuth token, for example because a user
+has logged out of your application which uses Hypothesis accounts, it is good
+practice to revoke the access and refresh tokens.
+
+Hypothesis implements the `OAuth 2 Token Revocation endpoint
+<https://tools.ietf.org/html/rfc7009>`_ at ``/oauth/revoke``.
+
+*Example request:*
+
+.. code-block:: http
+
+   POST /oauth/revoke HTTP/1.1
+   Content-Type: application/x-www-form-urlencoded
+
+   token=5768-yXoTA2R94b5fB0dTBbXHSvc_IX4I1Gc_bGQ4KyjM5dY
+
 Further reading
 ---------------
 
@@ -141,3 +160,5 @@ Further reading
   good introduction for developers.
 - The `OAuth specification <https://tools.ietf.org/html/rfc6749>`_ describes the
   standard in detail.
+- The `OAuth Token Revocation specification <https://tools.ietf.org/html/rfc7009>`_
+  describes an extension to support revoking tokens.


### PR DESCRIPTION
Update authorization docs to describe how to create OAuth clients for the h service and implement the OAuth authorization flow.

Explaining all the possibilities of OAuth in detail is IMO beyond the scope of the documentation here, as is a lengthy explanation of the problem that OAuth solves. I've focused on providing enough information to implement a browser or web-service based client for the APIs plus links to relevant parts of the specs.

In this PR I'm only describing the flow we implement that is part of the main OAuth 2 standard (using a redirect rather than a `window.postMessage` response) to keep the size of this change down.