### PR TITLE
Use `===` consistently for top level headings in docs

### DIFF
--- a/docs/community.rst
+++ b/docs/community.rst
@@ -1,5 +1,5 @@
 The Hypothesis community
-########################
+========================
 
 Please be courteous and respectful in your communication on Slack_, IRC
 (`#hypothes.is`_ on `freenode.net`_), the mailing list (`subscribe`_,

--- a/docs/developing/cla.rst
+++ b/docs/developing/cla.rst
@@ -1,5 +1,5 @@
 Contributor License Agreement
-#############################
+=============================
 
 Before submitting significant contributions, we ask that you sign one of
 our Contributor License Agreements. This practice ensures that the

--- a/docs/developing/code-style.rst
+++ b/docs/developing/code-style.rst
@@ -1,5 +1,5 @@
 Code style
-##########
+==========
 
 This section contains some code style guidelines for the different programming
 languages used in the project.

--- a/docs/developing/documentation.rst
+++ b/docs/developing/documentation.rst
@@ -1,5 +1,5 @@
 Writing documentation
-#####################
+=====================
 
 To build the documentation issue the ``make dirhtml`` command from the ``docs``
 directory:

--- a/docs/developing/index.rst
+++ b/docs/developing/index.rst
@@ -1,5 +1,5 @@
 Developing Hypothesis
-#####################
+=====================
 
 The following sections document how to setup a development environment for h
 and how to contribute code or documentation to the project.

--- a/docs/developing/submitting-a-pr.rst
+++ b/docs/developing/submitting-a-pr.rst
@@ -1,5 +1,5 @@
 Submitting a Pull Request
-#########################
+=========================
 
 To submit code or documentation to h you should submit a pull request.
 

--- a/docs/developing/testing.rst
+++ b/docs/developing/testing.rst
@@ -1,5 +1,5 @@
 Testing
-#######
+=======
 
 This section covers writing tests for the ``h`` codebase.
 

--- a/docs/publishers/authorization-grant-tokens.rst
+++ b/docs/publishers/authorization-grant-tokens.rst
@@ -1,7 +1,7 @@
 .. _Generating authorization grant tokens:
 
 Generating authorization grant tokens
-#####################################
+=====================================
 
 .. warning::
 

--- a/docs/publishers/index.rst
+++ b/docs/publishers/index.rst
@@ -1,5 +1,5 @@
 Advice for publishers
-#####################
+=====================
 
 If you publish content on the web and want to allow people to annotate your
 content, the following documents will help you get started.


### PR DESCRIPTION
Top-level headings in reST files were split between `===` and `###`.

Use `===` consistently everywhere. This convention matches
readthedocs.org's own reST docs. See 479827ee9a9

The one exception is _CHANGES.rst_ because that imports _CHANGES_ which uses `===` for sub-headings. The changes file is now effectively obsolete because we stopped updating it after moving to continuous deployments well over a year ago, so we should probably just remove that.