### PR TITLE
Remove the build manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,0 @@
-include AUTHORS CHANGES CODE_OF_CONDUCT LICENSE NOTICE
-include *.rst
-graft src
-global-exclude __pycache__
-global-exclude *.py[co]


### PR DESCRIPTION
Since we removed the remnants of `memex` (329273762ae5d58f), I don't believe this file is necessary any more. It certainly doesn't look like it would do anyone much good, as it tries to `graft` in files from the non-existent `src` directory.