### PR TITLE
Update psycopg2 for compatibility with Postgres 10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,6 @@ greenlet==0.4.10          # via gevent
 gunicorn==19.6.0
 html5lib==0.999999999     # via bleach
 idna==2.5                 # via cryptography
-ipaddress==1.0.18         # via cryptography
 iso8601==0.1.11           # via colander
 itsdangerous==0.24
 jinja2==2.8               # via deform-jinja2, pyramid-jinja2
@@ -47,7 +46,7 @@ passlib==1.7.1
 pastedeploy==1.5.2        # via pyramid
 peppercorn==0.5           # via deform
 psycogreen==1.0
-psycopg2==2.6.2
+psycopg2==2.7.3.2
 pycparser==2.14           # via cffi
 pyjwt==1.5.3
 pyparsing==2.1.10

--- a/tests/h/views/admin_nipsa_test.py
+++ b/tests/h/views/admin_nipsa_test.py
@@ -41,7 +41,7 @@ class TestNipsaAddRemove(object):
 
         assert users['carl'] in nipsa_service.flagged
 
-    @pytest.mark.parametrize('user', ['', 'donkeys', '\x00'])
+    @pytest.mark.parametrize('user', ['', 'donkeys'])
     def test_add_raises_when_user_not_found(self, user, nipsa_service, pyramid_request):
         pyramid_request.params = {"add": user, "authority": "example.com"}
 


### PR DESCRIPTION
Update psycopg2 using `pip-compile --upgrade-package psycopg2`.

I removed a test case that fails with this update. It was added without
clear explanation in c7d3380e4a431b0ee8438a74259007ed1a7cf4ef and it
isn't obvious to me why it would be needed _in this context_.

_Update: We discovered that some time ago there were issues related to do with NUL bytes in JSON strings being received from the client, where the null bytes had apparently been extracted from PDF metadata. However that isn't relevant to where this code is used AFAICS_

Fixes #4674