### PR TITLE
Mark orphans_tab flag as pending removal.

### DIFF
--- a/h/models/feature.py
+++ b/h/models/feature.py
@@ -21,7 +21,6 @@ FEATURES = {
                           " annotations in sidebar?"),
     'flag_action': ("Enable user to flag inappropriate annotations in the "
                     "client?"),
-    'orphans_tab': "Show the orphans tab to separate anchored and unanchored annotations?",
     'overlay_highlighter': "Use the new overlay highlighter?",
     'search_for_doi': "Use DOI metadata when searching for annotations on the current page?",
     'total_shared_annotations': "Show the total number of shared annotations for users and groups?",
@@ -50,6 +49,7 @@ FEATURES = {
 FEATURES_PENDING_REMOVAL = {
     'activity_pages': "Show the new activity pages?",
     'homepage_redirects': "Enable homepage redirects (for WordPress migration)?",
+    'orphans_tab': "Show the orphans tab to separate anchored and unanchored annotations?",
     'search_page': "Show the activity pages search skeleton page?",
     'use_client_boot_script': "Use the client's boot script?",
 }


### PR DESCRIPTION
Checks for this flag were removed in the v1.52 Hypothesis client
release.