### PR TITLE
Remove the `defer_realtime_updates` flag

### DIFF
--- a/h/models/feature.py
+++ b/h/models/feature.py
@@ -13,8 +13,6 @@ log = logging.getLogger(__name__)
 FEATURES = {
     'client_oauth': ("Use OAuth for first party accounts in client? "
                      "(Only takes effect if enabled for everyone)"),
-    'defer_realtime_updates': ("Require a user action before applying real-time"
-                               " updates to annotations in the client?"),
     'embed_cachebuster': ("Cache-bust client entry point URL to prevent browser/CDN from "
                           "using a cached version?"),
     'filter_highlights': ("Filter highlights in document based on visible"
@@ -49,6 +47,8 @@ FEATURES = {
 #
 FEATURES_PENDING_REMOVAL = {
     'activity_pages': "Show the new activity pages?",
+    'defer_realtime_updates': ("Require a user action before applying real-time"
+                               " updates to annotations in the client?"),
     'homepage_redirects': "Enable homepage redirects (for WordPress migration)?",
     'search_page': "Show the activity pages search skeleton page?",
     'use_client_boot_script': "Use the client's boot script?",


### PR DESCRIPTION
The client-side checks for this flag were removed in v0.49 on
2016-11-30.