### PR TITLE
Remove `total_shared_annotations` flag checks

### DIFF
--- a/h/models/feature.py
+++ b/h/models/feature.py
@@ -24,7 +24,6 @@ FEATURES = {
     'orphans_tab': "Show the orphans tab to separate anchored and unanchored annotations?",
     'overlay_highlighter': "Use the new overlay highlighter?",
     'search_for_doi': "Use DOI metadata when searching for annotations on the current page?",
-    'total_shared_annotations': "Show the total number of shared annotations for users and groups?",
     'api_render_user_info': "Return users' extended info in API responses?",
     'client_display_names': "Render display names instead of user names in the client",
 }
@@ -51,6 +50,7 @@ FEATURES_PENDING_REMOVAL = {
     'activity_pages': "Show the new activity pages?",
     'homepage_redirects': "Enable homepage redirects (for WordPress migration)?",
     'search_page': "Show the activity pages search skeleton page?",
+    'total_shared_annotations': "Show the total number of shared annotations for users and groups?",
     'use_client_boot_script': "Use the client's boot script?",
 }
 

--- a/h/views/activity.py
+++ b/h/views/activity.py
@@ -129,9 +129,7 @@ class GroupSearchController(SearchController):
                    for u in self.group.members]
         members = sorted(members, key=lambda k: k['username'].lower())
 
-        group_annotation_count = None
-        if self.request.feature('total_shared_annotations'):
-            group_annotation_count = self.request.find_service(name='annotation_stats').group_annotation_count(self.group.pubid)
+        group_annotation_count = self.request.find_service(name='annotation_stats').group_annotation_count(self.group.pubid)
 
         result['stats'] = {
             'annotation_count': group_annotation_count,
@@ -286,12 +284,10 @@ class UserSearchController(SearchController):
                 return None
             return urlparse.urlparse(user.uri).netloc
 
-        annotation_count = None
-        if self.request.feature('total_shared_annotations'):
-            user_annotation_counts = self.request.find_service(name='annotation_stats').user_annotation_counts(self.user.userid)
-            annotation_count = user_annotation_counts['public']
-            if self.request.authenticated_userid == self.user.userid:
-                annotation_count = user_annotation_counts['total']
+        user_annotation_counts = self.request.find_service(name='annotation_stats').user_annotation_counts(self.user.userid)
+        annotation_count = user_annotation_counts['public']
+        if self.request.authenticated_userid == self.user.userid:
+            annotation_count = user_annotation_counts['total']
 
         result['stats'] = {
             'annotation_count': annotation_count,

--- a/tests/h/views/activity_test.py
+++ b/tests/h/views/activity_test.py
@@ -401,18 +401,6 @@ class TestGroupSearchController(object):
 
         assert result['annotation_count'] == 5
 
-    def test_search_does_not_pass_annotation_count_to_the_template(self,
-                                                                   controller,
-                                                                   group,
-                                                                   pyramid_request):
-        """ It should not pass the annotation count to the view when the feature flag is turned off."""
-
-        pyramid_request.user = group.members[-1]
-        pyramid_request.feature.flags['total_shared_annotations'] = False
-        result = controller.search()['stats']
-
-        assert result['annotation_count'] is None
-
     @pytest.mark.parametrize('q', ['', '   '])
     def test_leave_removes_empty_query_from_url(self,
                                                 controller,
@@ -613,16 +601,6 @@ class TestUserSearchController(object):
 
         assert stats['annotation_count'] == 6
 
-    def test_search_does_not_pass_the_user_annotation_counts_to_the_template(self,
-                                                                             controller,
-                                                                             pyramid_request):
-        """ It should not pass the annotation counts to the view when the feature flag is turned off."""
-
-        pyramid_request.feature.flags['total_shared_annotations'] = False
-        result = controller.search()['stats']
-
-        assert result['annotation_count'] is None
-
     def test_search_passes_public_annotation_counts_to_the_template(self,
                                                                     controller,
                                                                     factories,
@@ -633,7 +611,6 @@ class TestUserSearchController(object):
         if the user whose page we are on is different from the authenticated user.
 
         """
-        pyramid_request.feature.flags['total_shared_annotations'] = True
         pyramid_config.testing_securitypolicy(factories.User().userid)
 
         stats = controller.search()['stats']


### PR DESCRIPTION
This feature has been enabled for everyone in production for 11+ months.