### PR TITLE
Remove "client_oauth" feature flag

### DIFF
--- a/h/models/feature.py
+++ b/h/models/feature.py
@@ -11,8 +11,6 @@ from h.db import Base
 log = logging.getLogger(__name__)
 
 FEATURES = {
-    'client_oauth': ("Use OAuth for first party accounts in client? "
-                     "(Only takes effect if enabled for everyone)"),
     'embed_cachebuster': ("Cache-bust client entry point URL to prevent browser/CDN from "
                           "using a cached version?"),
     'filter_highlights': ("Filter highlights in document based on visible"
@@ -45,6 +43,8 @@ FEATURES = {
 #
 FEATURES_PENDING_REMOVAL = {
     'activity_pages': "Show the new activity pages?",
+    'client_oauth': ("Use OAuth for first party accounts in client? "
+                     "(Only takes effect if enabled for everyone)"),
     'defer_realtime_updates': ("Require a user action before applying real-time"
                                " updates to annotations in the client?"),
     'homepage_redirects': "Enable homepage redirects (for WordPress migration)?",

--- a/h/templates/help.html.jinja2
+++ b/h/templates/help.html.jinja2
@@ -19,17 +19,6 @@
     </script>
     <script async defer src="{{ embed_js_url }}"></script>
   {% endif %}
-  {#
-    Make the help page usable for testing OAuth login to the client
-    by visiting `/docs/help?__feature__[client_oauth]`.
-  #}
-  {% if request.feature('client_oauth') %}
-    <script type="application/json" class="js-hypothesis-config">
-    {
-      "oauthEnabled": true
-    }
-    </script>
-  {% endif %}
 {% endblock %}
 
 {% block content %}

--- a/h/views/client.py
+++ b/h/views/client.py
@@ -51,19 +51,7 @@ def sidebar_app(request, extra=None):
     app_config = {
         'apiUrl': request.route_url('api.index'),
         'authDomain': request.authority,
-
-        # OAuth config.
         'oauthClientId': settings.get('h.client_oauth_id'),
-
-        # The OAuth feature flag is included as part of the `app.html` config
-        # rather than being delivered via the "features" key in /api/profile so
-        # that it is available as soon as the client starts before
-        # API tokens are fetched.
-        #
-        # TODO - This should be removed once OAuth for first-party accounts is
-        #        shipped.
-        'oauthEnabled': request.feature('client_oauth'),
-
         'release': __version__,
         'serviceUrl': request.route_url('index'),
 

--- a/tests/h/views/client_test.py
+++ b/tests/h/views/client_test.py
@@ -28,7 +28,6 @@ class TestSidebarApp(object):
                 'authDomain': 'example.com',
                 'googleAnalytics': 'UA-4567',
                 'oauthClientId': 'test-client-id',
-                'oauthEnabled': True,
                 'rpcAllowedOrigins': 'https://lti.hypothes.is',
                 }
 
@@ -40,14 +39,6 @@ class TestSidebarApp(object):
         ctx = client.sidebar_app(pyramid_request)
 
         assert ctx['embed_url'] == '/embed.js'
-
-    def test_it_disables_oauth(self, pyramid_request):
-        pyramid_request.feature.flags['client_oauth'] = False
-
-        ctx = client.sidebar_app(pyramid_request)
-        cfg = json.loads(ctx['app_config'])
-
-        assert cfg['oauthEnabled'] is False
 
 
 @pytest.mark.usefixtures('routes', 'pyramid_settings')


### PR DESCRIPTION
This flag caused the `oauthEnabled` config setting to be set in the client sidebar app configuration. This setting is no longer used since client v1.49 [1]
    
[1] https://github.com/hypothesis/client/commit/68e6524bacb94e41fae8ac04824193c4258b8475