### PR TITLE
Containers integration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,9 @@ WORKDIR /var/lib/hypothesis
 
 # Ensure nginx state and log directories writeable by unprivileged user.
 RUN chown -R hypothesis:hypothesis /var/log/nginx /var/lib/nginx
+# /var/lib/nginx/tmp seems to be 700, so still not writable?
+# I thought nginx would run as the hypothesis user though
+# changing its permissions to 777 doesn't seem to have an effect
 
 # Copy minimal data to allow installation of dependencies.
 COPY requirements.txt ./

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -9,6 +9,11 @@ events {
 
 http {
   client_max_body_size 20m;
+  client_body_temp_path /tmp 1 2;
+  proxy_temp_path /tmp 1 2;
+  fastcgi_temp_path /tmp 1 2;
+  uwsgi_temp_path /tmp 1 2;
+  scgi_temp_path /tmp 1 2;
   sendfile on;
   server_tokens off;
 

--- a/conf/supervisord.conf
+++ b/conf/supervisord.conf
@@ -27,7 +27,7 @@ stdout_events_enabled=true
 stderr_events_enabled=true
 
 [program:worker]
-command=newrelic-admin run-program hypothesis celery worker
+command=newrelic-admin run-program hypothesis --app-url localhost:5000 celery worker
 stdout_logfile=NONE
 stderr_logfile=NONE
 stdout_events_enabled=true


### PR DESCRIPTION
`nginx` and `worker` were crashing and being continuously restarted.

Would have used `v0.38.0` rather than `master`, but it has no `docker-compose.yml` for the dependencies.

My goal is to have a container (plus its dependent containers) to run in testing environments, so that we can run automated end2end tests against a recent version of Hypothes.is and clean up its database nightly.