### PR TITLE
Index authority of annotation creator as a separate field in ES

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,13 @@ matrix:
       python: '2.7'
       addons:
         postgresql: "9.4"
+      before_install:
+        # Install Elasticsearch v1.6.2 and the ICU plugin to match the
+        # production environment.
+        - curl -O https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-1.6.2.deb && sudo dpkg -i elasticsearch-1.6.2.deb && true
+        - 'echo ''index.number_of_shards: 1'' | sudo tee --append /etc/elasticsearch/elasticsearch.yml'
+        - sudo /usr/share/elasticsearch/bin/plugin install elasticsearch/elasticsearch-analysis-icu/2.6.0
+        - sudo service elasticsearch start
       install: pip install tox
       before_script: createdb htest
       script: tox

--- a/h/presenters/annotation_searchindex.py
+++ b/h/presenters/annotation_searchindex.py
@@ -16,6 +16,7 @@ class AnnotationSearchIndexPresenter(AnnotationBasePresenter):
         docpresenter = DocumentSearchIndexPresenter(self.annotation.document)
 
         result = {
+            'authority': self.annotation.userid,
             'id': self.annotation.id,
             'created': self.created,
             'updated': self.updated,

--- a/h/search/config.py
+++ b/h/search/config.py
@@ -24,6 +24,7 @@ ANNOTATION_MAPPING = {
     'analyzer': 'keyword',
     'properties': {
         'annotator_schema_version': {'type': 'string'},
+        'authority': {'type': 'string', 'index': 'analyzed', 'analyzer': 'authority'},
         'created': {'type': 'date'},
         'updated': {'type': 'date'},
         'quote': {'type': 'string', 'analyzer': 'uni_normalizer'},
@@ -123,6 +124,11 @@ ANALYSIS_SETTINGS = {
         },
     },
     'filter': {
+        'authority': {
+            'type': 'pattern_capture',
+            'preserve_original': 'false',
+            'patterns': ['^acct:.*@(.+)$']
+        },
         'path_url': {
             'type': 'pattern_capture',
             'preserve_original': 'false',
@@ -148,6 +154,10 @@ ANALYSIS_SETTINGS = {
         }
     },
     'analyzer': {
+        'authority': {
+            'tokenizer': 'keyword',
+            'filter': ['authority'],
+        },
         'uri': {
             'tokenizer': 'keyword',
             'char_filter': ['strip_scheme'],

--- a/h/search/index.py
+++ b/h/search/index.py
@@ -26,13 +26,17 @@ class Window(namedtuple('Window', ['start', 'end'])):
     pass
 
 
-def index(es, annotation, request, target_index=None):
+def index(es, annotation, request, target_index=None, refresh=False):
     """
     Index an annotation into the search index.
 
     A new annotation document will be created in the search index or,
     if the index already contains an annotation document with the same ID as
     the given annotation then it will be updated.
+
+    If the `refresh` option is `True` the change will be immediately visible in
+    searches, otherwise there may be a short delay (eg. of a second or two)
+    before it becomes visible.
 
     :param es: the Elasticsearch client object to use
     :type es: h.search.Client
@@ -42,6 +46,9 @@ def index(es, annotation, request, target_index=None):
 
     :param target_index: the index name, uses default index if not given
     :type target_index: unicode
+
+    :param refresh: Whether to make this change immediately visible to searches
+    :type refresh: bool
     """
     presenter = presenters.AnnotationSearchIndexPresenter(annotation)
     annotation_dict = presenter.asdict()
@@ -57,6 +64,7 @@ def index(es, annotation, request, target_index=None):
         doc_type=es.t.annotation,
         body=annotation_dict,
         id=annotation_dict["id"],
+        refresh=refresh,
     )
 
 

--- a/tests/h/conftest.py
+++ b/tests/h/conftest.py
@@ -21,12 +21,16 @@ from webob.multidict import MultiDict
 
 from h import db
 from h import form
+from h import search
 from h.settings import database_url
 from h._compat import text_type
 
 TEST_AUTHORITY = u'example.com'
 TEST_DATABASE_URL = database_url(os.environ.get('TEST_DATABASE_URL',
                                                 'postgresql://postgres@localhost/htest'))
+TEST_ELASTICSEARCH_HOST = os.environ.get('ELASTICSEARCH_HOST',
+                                         'http://localhost:9200')
+TEST_ELASTICSEARCH_INDEX = 'hypothesis-test'
 
 Session = sessionmaker()
 
@@ -252,3 +256,22 @@ def pyramid_settings():
     return {
         'sqlalchemy.url': TEST_DATABASE_URL
     }
+
+
+@pytest.fixture(scope='session')
+def search_client():
+    """
+    Prepare an empty ElasticSearch index and return a client for it.
+
+    :rtype h.search.client.Client:
+    """
+    index_name = TEST_ELASTICSEARCH_INDEX
+    settings = {'es.host': TEST_ELASTICSEARCH_HOST,
+                'es.index': index_name}
+
+    client = search.get_client(settings)
+    if client.conn.indices.exists(index=index_name):
+        client.conn.indices.delete(index=index_name)
+    search.init(client)
+
+    return client

--- a/tests/h/presenters/annotation_searchindex_test.py
+++ b/tests/h/presenters/annotation_searchindex_test.py
@@ -34,6 +34,7 @@ class TestAnnotationSearchIndexPresenter(object):
         annotation_dict = AnnotationSearchIndexPresenter(annotation).asdict()
 
         assert annotation_dict == {
+            'authority': 'acct:luke@hypothes.is',
             'id': 'xyz123',
             'created': '2016-02-24T18:03:25.000768+00:00',
             'updated': '2016-02-29T10:24:05.000564+00:00',

--- a/tests/h/search/config_test.py
+++ b/tests/h/search/config_test.py
@@ -18,6 +18,13 @@ from h.search.config import (
 )
 
 
+def test_authority_filter():
+    patterns = ANALYSIS_SETTINGS['filter']['authority']['patterns']
+    assert(captures(patterns, 'acct:mark@partner.org') == [
+        'partner.org'
+    ])
+
+
 def test_strip_scheme_char_filter():
     f = ANALYSIS_SETTINGS['char_filter']['strip_scheme']
     p = f['pattern']

--- a/tests/h/search/index_test.py
+++ b/tests/h/search/index_test.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+from datetime import datetime
+
 import mock
 import pytest
-
-import elasticsearch
 
 from h import presenters
 from h.search import client
@@ -13,6 +13,9 @@ from h.search import index
 
 @pytest.mark.usefixtures('presenters')
 class TestIndexAnnotation:
+    """
+    Annotation indexing tests that use a mock ElasticSearch connection.
+    """
 
     def test_it_presents_the_annotation(self, es, presenters, pyramid_request):
         annotation = mock.Mock()
@@ -52,6 +55,7 @@ class TestIndexAnnotation:
             doc_type='annotation',
             body=presenters.AnnotationSearchIndexPresenter.return_value.asdict.return_value,
             id='test_annotation_id',
+            refresh=False,
         )
 
     def test_it_allows_to_override_target_index(self, es, presenters, pyramid_request):
@@ -75,6 +79,40 @@ class TestIndexAnnotation:
         return presenters
 
 
+class TestIndexAnnotationWithES:
+    """
+    Annotation indexing tests that use a real ElasticSearch connection.
+    """
+
+    def test_indexes_authority(self, ann, pyramid_request, search_client):
+        index.index(search_client, ann, pyramid_request, refresh=True)
+        query = {'term': {'authority': 'partner.org'}}
+        assert count_hits(search_client, query) == 1
+
+    @pytest.fixture
+    def ann(self):
+        ann = mock.Mock(
+            created=datetime(2017, 1, 1),
+            document=mock.Mock(
+                title='Example website',
+                web_uri='https://example.org',
+                ),
+            groupid='abcd',
+            id='1234',
+            references=[],
+            shared=True,
+            target_selectors=[],
+            target_uri='https://example.org',
+            target_uri_normalized='https://example.org',
+            text='annotation content',
+            thread_ids=[],
+            updated=datetime(2017, 1, 1),
+            userid='acct:jim@partner.org',
+            tags=[],
+            )
+        return ann
+
+
 class TestDeleteAnnotation:
 
     def test_it_marks_annotation_as_deleted(self, es):
@@ -84,7 +122,7 @@ class TestDeleteAnnotation:
             index='hypothesis',
             doc_type='annotation',
             body={'deleted': True},
-            id='test_annotation_id'
+            id='test_annotation_id',
         )
 
     def test_it_allows_to_override_target_index(self, es):
@@ -301,6 +339,12 @@ class TestBatchIndexer(object):
     @pytest.fixture
     def streaming_bulk(self, patch):
         return patch('h.search.index.es_helpers.streaming_bulk')
+
+
+def count_hits(search_client, query):
+    result = search_client.conn.count(body={'query': query},
+                                      index=search_client.index)
+    return result['count']
 
 
 @pytest.fixture

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,7 @@ deps =
     factory-boy
     -rrequirements.txt
 passenv =
+    ELASTICSEARCH_HOST
     TEST_DATABASE_URL
     PYTEST_ADDOPTS
 commands =


### PR DESCRIPTION
Index the authority part of the `userid` field in an Annotation (which has the form `acct:user@authority`) as a separate field in ES so that the search API and activity pages can efficiently query for annotations associated with a specific authority.

In order to build an actually useful test for this, I introduced a unit test which actually uses ES rather than mocking it.

The next step after this will be to filter out annotations from authorities other than the default one on activity pages.

~~**WIP while I get the new `h.search.index` tests working in Jenkins**~~ _Fixed: Tox needed to be configured to pass the ELASTICSEARCH_HOST env var through to the tests_.