### PR TITLE
API-based annotation importer

### DIFF
--- a/h/cli/__init__.py
+++ b/h/cli/__init__.py
@@ -18,6 +18,7 @@ SUBCOMMANDS = (
     'h.cli.commands.celery.celery',
     'h.cli.commands.devserver.devserver',
     'h.cli.commands.groups.groups',
+    'h.cli.commands.import.import_annotations',
     'h.cli.commands.init.init',
     'h.cli.commands.initdb.initdb',
     'h.cli.commands.migrate.migrate',

--- a/h/cli/commands/import.py
+++ b/h/cli/commands/import.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+
+import click
+import json
+
+from h.schemas.annotation_import import AnnotationImportSchema
+
+# from h import models
+
+
+@click.command('import')
+@click.pass_context
+@click.argument('annotation_file', type=click.File('rb'))
+def import_annotations(ctx, annotation_file):
+
+    with annotation_file:
+        raw_annotations = json.load(annotation_file)
+
+    click.echo('{} annotations to import'.format(len(raw_annotations)))
+
+    schema = AnnotationImportSchema()
+
+    [schema.validate(ann) for ann in raw_annotations]

--- a/h/cli/commands/import.py
+++ b/h/cli/commands/import.py
@@ -7,6 +7,10 @@ import click
 from h.schemas.annotation_import import AnnotationImportSchema
 
 
+def err_echo(message):
+    click.echo(message, err=True)
+
+
 @click.command('import')
 @click.argument('annotation_file', type=click.File('rb'))
 def import_annotations(annotation_file):
@@ -14,17 +18,16 @@ def import_annotations(annotation_file):
     with annotation_file:
         raw_annotations = json.load(annotation_file)
 
-    click.echo('{} annotations to import'.format(len(raw_annotations)))
+    err_echo('{} annotations to import'.format(len(raw_annotations)))
 
     schema = AnnotationImportSchema()
     validated_annotations = [schema.validate(ann) for ann in raw_annotations]
 
     top_level = [a for a in validated_annotations if a['motivation'] == 'commenting']
     replies = [a for a in validated_annotations if a['motivation'] == 'replying']
-    click.echo('{} top-level annotations'.format(len(top_level)))
-    click.echo('{} replies'.format(len(replies)))
-
     group_id = 'foobangwibble'
+    err_echo('{} top-level annotations'.format(len(top_level)))
+    err_echo('{} replies'.format(len(replies)))
 
     shared_permissions = {
             'read': ['group:{}'.format(group_id)],
@@ -42,4 +45,4 @@ def import_annotations(annotation_file):
         }
 
     for annotation in top_level:
-        click.echo(json.dumps(top_level_payload(annotation), indent=2))
+        err_echo(json.dumps(top_level_payload(annotation), indent=2))

--- a/h/cli/commands/import.py
+++ b/h/cli/commands/import.py
@@ -28,6 +28,8 @@ def import_annotations(annotation_file):
     api_root = required_envvar('H_API_ROOT')
     group_id = required_envvar('H_GROUP')
 
+    debug = bool(getenv('H_DEBUG'))
+
     auth_headers = {'Authorization': 'Bearer {}'.format(token)}
 
     api_index = requests.get(api_root).json()
@@ -70,7 +72,8 @@ def import_annotations(annotation_file):
         }
 
     for annotation in top_level:
-        err_echo(json.dumps(top_level_payload(annotation), indent=2))
+        if debug:
+            err_echo(json.dumps(top_level_payload(annotation), indent=2))
         create_response = requests.post(create_annotation_url,
                                         json=top_level_payload(annotation),
                                         headers=auth_headers)
@@ -78,3 +81,5 @@ def import_annotations(annotation_file):
             err_reason = create_response.json().get('reason')
             err_echo('Could not create {}. Error: {}'.format(annotation['id'], err_reason))
             raise click.Abort()
+        if debug:
+            err_echo(json.dumps(create_response.json(), indent=2))

--- a/h/cli/commands/import.py
+++ b/h/cli/commands/import.py
@@ -37,6 +37,9 @@ def import_annotations(annotation_file):
     profile = requests.get(profile_url, headers=auth_headers).json()
 
     err_echo('Importing as {}'.format(profile['userid']))
+
+    create_annotation_url = api_index['links']['annotation']['create']['url']
+
     with annotation_file:
         raw_annotations = json.load(annotation_file)
 
@@ -67,3 +70,10 @@ def import_annotations(annotation_file):
 
     for annotation in top_level:
         err_echo(json.dumps(top_level_payload(annotation), indent=2))
+        create_response = requests.post(create_annotation_url,
+                                        json=top_level_payload(annotation),
+                                        headers=auth_headers)
+        if not create_response.ok:
+            err_reason = create_response.json().get('reason')
+            err_echo('Could not create {}. Error: {}'.format(annotation['id'], err_reason))
+            raise click.Abort()

--- a/h/cli/commands/import.py
+++ b/h/cli/commands/import.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from os import getenv
 import json
 
 import click
@@ -11,10 +12,18 @@ def err_echo(message):
     click.echo(message, err=True)
 
 
+def required_envvar(envvar):
+    result = getenv(envvar)
+    if not result:
+        raise click.ClickException('The {} environment variable is required'.format(envvar))
+    return result
+
+
 @click.command('import')
 @click.argument('annotation_file', type=click.File('rb'))
 def import_annotations(annotation_file):
 
+    group_id = required_envvar('H_GROUP')
     with annotation_file:
         raw_annotations = json.load(annotation_file)
 
@@ -25,7 +34,6 @@ def import_annotations(annotation_file):
 
     top_level = [a for a in validated_annotations if a['motivation'] == 'commenting']
     replies = [a for a in validated_annotations if a['motivation'] == 'replying']
-    group_id = 'foobangwibble'
     err_echo('{} top-level annotations'.format(len(top_level)))
     err_echo('{} replies'.format(len(replies)))
 

--- a/h/cli/commands/import.py
+++ b/h/cli/commands/import.py
@@ -4,6 +4,7 @@ from os import getenv
 import json
 
 import click
+import requests
 
 from h.schemas.annotation_import import AnnotationImportSchema
 
@@ -23,7 +24,19 @@ def required_envvar(envvar):
 @click.argument('annotation_file', type=click.File('rb'))
 def import_annotations(annotation_file):
 
+    token = required_envvar('H_API_TOKEN')
+    api_root = required_envvar('H_API_ROOT')
     group_id = required_envvar('H_GROUP')
+
+    auth_headers = {'Authorization': 'Bearer {}'.format(token)}
+
+    api_index = requests.get(api_root).json()
+
+    profile_url = api_index['links']['profile']['read']['url']
+
+    profile = requests.get(profile_url, headers=auth_headers).json()
+
+    err_echo('Importing as {}'.format(profile['userid']))
     with annotation_file:
         raw_annotations = json.load(annotation_file)
 

--- a/h/cli/commands/import.py
+++ b/h/cli/commands/import.py
@@ -5,8 +5,6 @@ import json
 
 from h.schemas.annotation_import import AnnotationImportSchema
 
-# from h import models
-
 
 @click.command('import')
 @click.pass_context

--- a/h/cli/commands/import.py
+++ b/h/cli/commands/import.py
@@ -83,3 +83,5 @@ def import_annotations(annotation_file):
             raise click.Abort()
         if debug:
             err_echo(json.dumps(create_response.json(), indent=2))
+
+        click.echo('{} {}'.format(annotation['id'], create_response.json()['id']))

--- a/h/cli/commands/import.py
+++ b/h/cli/commands/import.py
@@ -16,5 +16,29 @@ def import_annotations(annotation_file):
     click.echo('{} annotations to import'.format(len(raw_annotations)))
 
     schema = AnnotationImportSchema()
+    validated_annotations = [schema.validate(ann) for ann in raw_annotations]
 
-    [schema.validate(ann) for ann in raw_annotations]
+    top_level = [a for a in validated_annotations if a['motivation'] == 'commenting']
+    replies = [a for a in validated_annotations if a['motivation'] == 'replying']
+    click.echo('{} top-level annotations'.format(len(top_level)))
+    click.echo('{} replies'.format(len(replies)))
+
+    group_id = 'foobangwibble'
+
+    shared_permissions = {
+            'read': ['group:{}'.format(group_id)],
+    }
+
+    def top_level_payload(annotation):
+        return {
+                'group': group_id,
+                'permissions': shared_permissions,
+                'references': [],
+                'tags': [],
+                'target': [],
+                'text': annotation['body'][0]['value'],
+                'uri': annotation['target'],
+        }
+
+    for annotation in top_level:
+        click.echo(json.dumps(top_level_payload(annotation), indent=2))

--- a/h/cli/commands/import.py
+++ b/h/cli/commands/import.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 
-import click
 import json
+
+import click
 
 from h.schemas.annotation_import import AnnotationImportSchema
 

--- a/h/cli/commands/import.py
+++ b/h/cli/commands/import.py
@@ -7,9 +7,8 @@ from h.schemas.annotation_import import AnnotationImportSchema
 
 
 @click.command('import')
-@click.pass_context
 @click.argument('annotation_file', type=click.File('rb'))
-def import_annotations(ctx, annotation_file):
+def import_annotations(annotation_file):
 
     with annotation_file:
         raw_annotations = json.load(annotation_file)

--- a/h/cli/commands/import.py
+++ b/h/cli/commands/import.py
@@ -59,6 +59,7 @@ def import_annotations(annotation_file):
 
     def top_level_payload(annotation):
         return {
+                'imported_id': annotation['id'],
                 'group': group_id,
                 'permissions': shared_permissions,
                 'references': [],

--- a/h/schemas/annotation_import.py
+++ b/h/schemas/annotation_import.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+"""Classes for validating manually-imported annotations."""
+
+from h.schemas.base import JSONSchema
+
+
+class AnnotationImportSchema(JSONSchema):
+
+    """Validate an annotation for import.
+
+    This schema is based on the W3C Web Annotation model, but only implements
+    the subset of the specification we need for importing purposes.
+    """
+
+    schema = {
+        '$schema': 'http://json-schema.org/draft-04/schema#',
+        'type': 'object',
+        'properties': {
+            '@context': {
+                'enum': ['http://www.w3.org/ns/anno.jsonld'],
+            },
+            'id': {
+                'type': 'string',
+                'format': 'uri',
+            },
+            'type': {
+                'enum': ['Annotation'],
+            },
+            'created': {
+                'type': 'string',
+                'format': 'date-time',
+            },
+            'modified': {
+                'type': 'string',
+                'format': 'date-time',
+            },
+            'creator': {
+                'type': 'string',
+                'format': 'uri',
+                'pattern': '^acct:.+$',
+            },
+            'motivation': {
+                'enum': ['commenting', 'replying']
+            },
+            'body': {
+                'type': 'array',
+                'minItems': 1,
+                'maxItems': 1,
+                'items': {
+                    'type': 'object',
+                    'properties': {
+                        'type': {
+                            'type': 'string',
+                            'enum': ['TextualBody'],
+                        },
+                        'value': {
+                            'type': 'string',
+                        },
+                        'format': {
+                            'type': 'string',
+                            'enum': ['text/markdown'],
+                        },
+                    },
+                    'required': [
+                        'format',
+                        'type',
+                        'value',
+                    ],
+                    'additionalProperties': False,
+                },
+            },
+            'target': {
+                'type': 'string',
+                'format': 'uri',
+            }
+        },
+        'required': [
+            '@context',
+            'id',
+            'type',
+            'created',
+            'modified',
+            'creator',
+            'body',
+            'motivation',
+            'target',
+        ],
+        'additionalProperties': False,
+    }

--- a/requirements.in
+++ b/requirements.in
@@ -37,7 +37,9 @@ python-dateutil
 python-slugify < 1.2.0
 raven
 requests-aws4auth >= 0.9
+rfc3987
 statsd
+strict-rfc3339
 transaction
 venusian
 wsaccel

--- a/requirements.txt
+++ b/requirements.txt
@@ -67,9 +67,11 @@ repoze.lru==0.6           # via pyramid
 repoze.sendmail==4.3      # via pyramid-mailer
 requests-aws4auth==0.9
 requests==2.13.0          # via requests-aws4auth
+rfc3987==1.3.7
 six==1.10.0               # via bcrypt, bleach, cryptography, html5lib, packaging, python-dateutil
 sqlalchemy==1.1.4
 statsd==3.2.1
+strict-rfc3339==0.7
 transaction==2.1.2
 translationstring==1.3    # via colander, deform, pyramid
 unidecode==0.4.19         # via python-slugify

--- a/tests/h/schemas/annotation_import_test.py
+++ b/tests/h/schemas/annotation_import_test.py
@@ -1,0 +1,144 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from contextlib import contextmanager
+import pytest
+
+from h.schemas import ValidationError
+from h.schemas.annotation_import import AnnotationImportSchema
+
+
+class TestAnnotationImportSchema(object):
+
+    def test_empty_dictionary(self, schema):
+        with pytest.raises(ValidationError):
+            schema.validate({})
+
+    def test_comment_annotation(self, schema, comment):
+        assert schema.validate(comment) == comment
+
+    def test_reply_annotation(self, schema, reply):
+        assert schema.validate(reply) == reply
+
+    @pytest.mark.parametrize('key', ('@context', 'id', 'type', 'created',
+                                     'modified', 'creator', 'body',
+                                     'motivation', 'target'))
+    def test_missing_key(self, schema, comment, key):
+        del comment[key]
+        with pytest.raises(ValidationError):
+            schema.validate(comment)
+
+    def test_wrong_context(self, schema, comment):
+        bad_context = 'http://json-ld.org/contexts/person.jsonld'
+        comment['@context'] = bad_context
+        with raises_error_starting('@context: '):
+            schema.validate(comment)
+
+    def test_wrong_type(self, schema, comment):
+        comment['type'] = 'Badger'
+        with raises_error_starting('type: '):
+            schema.validate(comment)
+
+    def test_invalid_motivation(self, schema, comment):
+        comment['motivation'] = 'indeterminate'
+        with raises_error_starting('motivation: '):
+            schema.validate(comment)
+
+    @pytest.mark.parametrize('created', ('2017', 'yesterday', '2017-02-12'))
+    def test_invalid_created(self, schema, comment, created):
+        comment['created'] = created
+        with raises_error_starting('created: '):
+            schema.validate(comment)
+
+    @pytest.mark.parametrize('modified', ('2017', 'yesterday', '2017-02-12'))
+    def test_invalid_modified(self, schema, comment, modified):
+        comment['modified'] = modified
+        with raises_error_starting('modified: '):
+            schema.validate(comment)
+
+    @pytest.mark.parametrize('creator', ('', 'bob', 'bob@example.com', 6,
+                                         'http://example.com'))
+    def test_invalid_creator(self, schema, comment, creator):
+        comment['creator'] = creator
+        with raises_error_starting('creator: '):
+            schema.validate(comment)
+
+    def test_no_body(self, schema, comment):
+        comment['body'] = []
+        with raises_error_starting('body: '):
+            schema.validate(comment)
+
+    def test_multiple_bodies(self, schema, comment):
+        comment['body'] = [comment['body'][0], comment['body'][0]]
+        with raises_error_starting('body: '):
+            schema.validate(comment)
+
+    @pytest.mark.parametrize('body_key', ('format', 'type', 'value'))
+    def test_no_body_type(self, schema, comment, body_key):
+        del comment['body'][0][body_key]
+        with raises_error_starting('body.0: '):
+            schema.validate(comment)
+
+    @pytest.mark.parametrize('target', ('', 'bob', 'bob@example.com'))
+    def test_invalid_target(self, schema, comment, target):
+        comment['target'] = target
+        with raises_error_starting('target: '):
+            schema.validate(comment)
+
+    def test_unknown_property(self, schema, comment):
+        comment['synergy'] = 'enterprise'
+        with pytest.raises(ValidationError):
+            schema.validate(comment)
+
+    @pytest.fixture
+    def schema(self):
+        return AnnotationImportSchema()
+
+    @pytest.fixture
+    def comment(self):
+        return {
+            "@context": "http://www.w3.org/ns/anno.jsonld",
+            "id": "import:123456789",
+            "type": "Annotation",
+            "created": "2017-01-25T23:00:00Z",
+            "modified": "2017-01-25T23:30:00Z",
+            "creator": "acct:commenter@example.com",
+            "body": [
+                {
+                    "type": "TextualBody",
+                    "value": "Hi",
+                    "format": "text/markdown"
+                }
+            ],
+            "motivation": "commenting",
+            "target": "https://example.com/foo"
+        }
+
+    @pytest.fixture
+    def reply(self):
+        return {
+            "@context": "http://www.w3.org/ns/anno.jsonld",
+            "id": "import:987654321",
+            "type": "Annotation",
+            "created": "2017-01-25T23:00:00Z",
+            "modified": "2017-01-25T23:30:00Z",
+            "creator": "acct:commenter@example.com",
+            "body": [
+                {
+                    "type": "TextualBody",
+                    "value": "Hi yourself",
+                    "format": "text/markdown"
+                }
+            ],
+            "motivation": "commenting",
+            "target": "import:123456789"
+        }
+
+
+@contextmanager
+def raises_error_starting(prefix):
+    """Test whether a code block raises a particular ValidationError."""
+    with pytest.raises(ValidationError) as error:
+        yield
+
+    assert error.value.message.startswith(prefix)


### PR DESCRIPTION
This was originally planned as the solution to https://github.com/hypothesis/product-backlog/issues/349, by importing annotations from a file through our public API. As it’s turned out, we don’t need this for the import we thought we would, but it could still prove a useful reference implementation for later.

This PR isn’t intended to be merged – in fact, I’m planning to close it immediately. This is more of a side-effect of the way GitHub works, in that pull requests are a little more searchable and a lot harder to delete than branches.

If we wanted to get a version of this merged into `master` at a later date, we’d probably need some slightly better factoring of the code, and a whole pile more tests. We might also want to integrate it more tightly into the rest of our codebase; keeping it at arm’s length was a deliberate design decision in this case, so that it would be usable by people outside Hypothesis with as little tweaking as possible.