### PR TITLE
Ignore the debug mailer directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ dist/
 docs/_build/
 node_modules/
 
+# Pyramid debug mailer
+mail/
+
 # py.test state cache
 .cache/
 .coverage


### PR DESCRIPTION
Pyramid's debug mailer (which we stared using in 110d39f2dbac53d7) saves test emails to the `mail/` directory. For the sake of avoiding accidental commits and annoying status messages, we should ignore this directory.