### PR TITLE
Add a command-line tool to convert annotation IDs

### DIFF
--- a/h/cli/__init__.py
+++ b/h/cli/__init__.py
@@ -14,6 +14,7 @@ from h import __version__
 log = logging.getLogger('h')
 
 SUBCOMMANDS = (
+    'h.cli.commands.annotation_id.annotation_id',
     'h.cli.commands.authclient.authclient',
     'h.cli.commands.celery.celery',
     'h.cli.commands.devserver.devserver',

--- a/h/cli/commands/annotation_id.py
+++ b/h/cli/commands/annotation_id.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+
+import click
+
+from uuid import UUID
+
+from h.db.types import _get_hex_from_urlsafe, _get_urlsafe_from_hex
+
+
+@click.group('annotation-id')
+def annotation_id():
+    """Utility commands to convert annotation IDS."""
+
+
+@annotation_id.command('from-urlsafe')
+@click.argument('urlsafe_id')
+def from_urlsafe(urlsafe_id):
+    """Convert an annotation ID from its URL-safe representation."""
+    click.echo(str(UUID(_get_hex_from_urlsafe(urlsafe_id))))
+
+
+@annotation_id.command('to-urlsafe')
+@click.argument('annotation_id')
+def to_urlsafe(annotation_id):
+    """Convert an annotation ID into its URL-safe representation."""
+    click.echo(_get_urlsafe_from_hex(UUID(annotation_id).hex))

--- a/tests/h/cli/commands/annotation_id_test.py
+++ b/tests/h/cli/commands/annotation_id_test.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+
+from h.cli.commands import annotation_id
+
+
+class TestConvertFromURLSafe(object):
+
+    def test_converts_from_url_safe_id(self, cli):
+        result = cli.invoke(annotation_id.from_urlsafe,
+                            ['3jgSANNlEeebpLMf36MACw'])
+        assert result.exit_code == 0
+        assert result.output == 'de381200-d365-11e7-9ba4-b31fdfa3000b\n'
+
+    def test_fails_on_malformed_id(self, cli):
+        result = cli.invoke(annotation_id.from_urlsafe,
+                            ['horse?'])
+        assert result.exit_code != 0
+        assert not result.output
+
+
+class TestConvertToURLSafe(object):
+
+    def test_converts_to_url_safe_id(self, cli):
+        result = cli.invoke(annotation_id.to_urlsafe,
+                            ['de381200-d365-11e7-9ba4-b31fdfa3000b'])
+        assert result.exit_code == 0
+        assert result.output == '3jgSANNlEeebpLMf36MACw\n'
+
+    def test_fails_on_malformed_id(self, cli):
+        result = cli.invoke(annotation_id.to_urlsafe,
+                            ['horse?'])
+        assert result.exit_code != 0
+        assert not result.output


### PR DESCRIPTION
There are a few occasions where we need to convert between the encoded URL-safe versions of our annotation IDs (e.g. '3jgSANNlEeebpLMf36MACw') and their UUID versions (e.g. 'de381200-d365-11e7-9ba4-b31fdfa3000b'). This tool lets us do that without having to mess around importing bits of Python.

This tool currently relies on private functionality within the `h.db.types` module. While this isn't great, it seems better to have it this way and keep the functions private to discourage their use
elsewhere, than to remove the underscores and risk having them used more widely across the codebase. To mitigate against the risk that someone will change these functions (fairly assuming that they're not used outside the module) and break this functionality, I've used the real implementations of `_get_urlsafe_from_hex` and `_get_hex_from_urlsafe` in the tests, rather than mocking them out.