### PR TITLE
Enable deletion of group creators from the admin panel

### DIFF
--- a/h/services/delete_user.py
+++ b/h/services/delete_user.py
@@ -3,7 +3,7 @@
 from __future__ import unicode_literals
 
 from h.events import AnnotationEvent
-from h.models import Annotation, Group
+from h.models import Annotation
 from h import storage
 
 
@@ -23,10 +23,22 @@ class DeleteUserService(object):
         message.
         """
 
-        if Group.created_by(self.request.db, user).count() > 0:
-            raise UserDeleteError('Cannot delete user who is a group creator.')
+        # Check whether this user has created any groups that others have
+        # annotated in.
+        #
+        # We check for non-empty `group_ids` before querying the DB to avoid an
+        # expensive SQL query if `in_` is given an empty list (see
+        # https://stackoverflow.com/questions/23523147/)
+        group_ids = [g.pubid for g in user.groups]
+        if len(group_ids) > 0:
+            other_user_group_anns = self.request.db.query(Annotation) \
+                                                   .filter(Annotation.groupid.in_(group_ids),
+                                                           Annotation.userid != user.userid) \
+                                                   .count()
+            if other_user_group_anns > 0:
+                raise UserDeleteError('Other users have annotated in groups created by this user')
 
-        user.groups = []
+        # Delete the user's annotations
         annotations = self.request.db.query(Annotation) \
                                      .filter_by(userid=user.userid)
         for annotation in annotations:
@@ -34,6 +46,11 @@ class DeleteUserService(object):
             event = AnnotationEvent(self.request, annotation.id, 'delete')
             self.request.notify_after_commit(event)
 
+        # Delete groups created by this user.
+        for group in user.groups:
+            self.request.db.delete(group)
+
+        # Finally, delete the user.
         self.request.db.delete(user)
 
 

--- a/h/services/delete_user.py
+++ b/h/services/delete_user.py
@@ -33,11 +33,11 @@ class DeleteUserService(object):
                                         .filter(Group.creator == user)
         group_ids = [g.pubid for g in created_groups]
         if len(group_ids) > 0:
-            other_user_group_anns = self.request.db.query(Annotation) \
-                                                   .filter(Annotation.groupid.in_(group_ids),
-                                                           Annotation.userid != user.userid) \
-                                                   .count()
-            if other_user_group_anns > 0:
+            other_user_ann_count = self.request.db.query(Annotation) \
+                                                  .filter(Annotation.groupid.in_(group_ids),
+                                                          Annotation.userid != user.userid) \
+                                                  .count()
+            if other_user_ann_count > 0:
                 raise UserDeleteError('Other users have annotated in groups created by this user')
 
         # Delete the user's annotations

--- a/tests/h/services/delete_user_test.py
+++ b/tests/h/services/delete_user_test.py
@@ -6,25 +6,14 @@ import pytest
 from mock import Mock, call
 
 from h.events import AnnotationEvent
+from h.models import Annotation, Document, Group
 from h.services.delete_user import (
     UserDeleteError,
     delete_user_service_factory,
 )
 
-delete_user_fixtures = pytest.mark.usefixtures('api_storage',
-                                               'user_created_no_groups')
 
-
-@delete_user_fixtures
 class TestDeleteUserService(object):
-
-    def test_delete_raises_when_group_creator(self, Group, svc): # noqa N803
-        user = Mock()
-
-        Group.created_by.return_value.count.return_value = 10
-
-        with pytest.raises(UserDeleteError):
-            svc.delete(user)
 
     def test_delete_disassociate_group_memberships(self, factories, svc):
         user = factories.User()
@@ -64,16 +53,26 @@ class TestDeleteUserService(object):
 
         assert user in db_session.deleted
 
+    def test_delete_user_removes_groups_if_no_collaborators(self, db_session, group_with_two_users, pyramid_request, svc):
+        pyramid_request.db = db_session
+        (group, user, other_user, user_ann, other_user_ann) = group_with_two_users
+        db_session.delete(other_user_ann)
+
+        svc.delete(user)
+
+        assert group in db_session.deleted
+
+    def test_delete_user_fails_if_groups_have_collaborators(self, db_session, group_with_two_users, pyramid_request, svc):
+        pyramid_request.db = db_session
+        (group, user, other_user, user_ann, other_user_ann) = group_with_two_users
+
+        with pytest.raises(UserDeleteError):
+            svc.delete(user)
+
     @pytest.fixture
     def svc(self, db_session, pyramid_request):
         pyramid_request.db = db_session
         return delete_user_service_factory({}, pyramid_request)
-
-
-@pytest.fixture
-def user_created_no_groups(Group): # noqa N803
-    # By default, pretend that all users are the creators of 0 groups.
-    Group.created_by.return_value.count.return_value = 0
 
 
 @pytest.fixture
@@ -88,5 +87,23 @@ def api_storage(patch):
 
 
 @pytest.fixture
-def Group(patch): # noqa N802
-    return patch('h.services.delete_user.Group')
+def group_with_two_users(db_session, factories):
+    """
+    Create a group with two members and an annotation created by each.
+    """
+    user = factories.User()
+    other_user = factories.User()
+
+    group = Group(authority=user.authority, creator=user, members=[user, other_user],
+                  name='test', pubid='group_with_two_users')
+    db_session.add(group)
+
+    doc = Document(web_uri='https://example.org')
+    user_ann = Annotation(userid=user.userid, groupid=group.pubid, document=doc)
+    other_user_ann = Annotation(userid=other_user.userid, groupid=group.pubid,
+                                document=doc)
+    db_session.add(user_ann)
+    db_session.add(other_user_ann)
+    db_session.flush()
+
+    return (group, user, other_user, user_ann, other_user_ann)

--- a/tests/h/services/delete_user_test.py
+++ b/tests/h/services/delete_user_test.py
@@ -69,6 +69,15 @@ class TestDeleteUserService(object):
         with pytest.raises(UserDeleteError):
             svc.delete(user)
 
+    def test_delete_user_removes_only_groups_created_by_user(self, db_session, group_with_two_users, pyramid_request, svc):
+        pyramid_request.db = db_session
+        (group, user, other_user, user_ann, other_user_ann) = group_with_two_users
+
+        # Delete the user who is a member of the group, but did not create it.
+        svc.delete(other_user)
+
+        assert group not in db_session.deleted
+
     @pytest.fixture
     def svc(self, db_session, pyramid_request):
         pyramid_request.db = db_session


### PR DESCRIPTION
**~~Depends on https://github.com/hypothesis/h/pull/4724~~**

The admin control panel currently does not support deleting users who have created groups, even if those groups are just empty "test" groups. This requires manual futzing around with the database to fix,

This PR enables such users to be deleted from the admin control panel, _provided that no other users have created annotations in groups they created (Edited)_.