### PR TITLE
Hide third party annotations from activity pages

### DIFF
--- a/h/activity/query.py
+++ b/h/activity/query.py
@@ -16,6 +16,7 @@ from h.models import Annotation, Document, Group
 from h.search import Search
 from h.search import parser
 from h.search.query import (
+    AuthorityFilter,
     TagsAggregation,
     TopLevelAnnotationsFilter,
     UsersAggregation,
@@ -163,6 +164,7 @@ def fetch_annotations(session, ids):
 @newrelic.agent.function_trace()
 def _execute_search(request, query, page_size):
     search = Search(request, stats=request.stats)
+    search.append_filter(AuthorityFilter(authority=request.authority))
     search.append_filter(TopLevelAnnotationsFilter())
     for agg in aggregations_for(query):
         search.append_aggregation(agg)

--- a/h/search/query.py
+++ b/h/search/query.py
@@ -107,6 +107,19 @@ class TopLevelAnnotationsFilter(object):
         return {'missing': {'field': 'references'}}
 
 
+class AuthorityFilter(object):
+
+    """
+    Match only annotations created by users belonging to a specific authority.
+    """
+
+    def __init__(self, authority):
+        self.authority = authority
+
+    def __call__(self, params):
+        return {'term': {'authority': self.authority}}
+
+
 class AuthFilter(object):
 
     """

--- a/tests/h/activity/query_test.py
+++ b/tests/h/activity/query_test.py
@@ -195,6 +195,7 @@ class TestCheckURL(object):
                          '_fetch_groups',
                          'bucketing',
                          'presenters',
+                         'AuthorityFilter',
                          'Search',
                          'TagsAggregation',
                          'TopLevelAnnotationsFilter',
@@ -217,8 +218,16 @@ class TestExecute(object):
         execute(pyramid_request, MultiDict(), self.PAGE_SIZE)
 
         TopLevelAnnotationsFilter.assert_called_once_with()
-        search.append_filter.assert_called_once_with(
-            TopLevelAnnotationsFilter.return_value)
+        search.append_filter.assert_any_call(TopLevelAnnotationsFilter.return_value)
+
+    def test_it_only_shows_annotations_from_current_authority(self,
+                                                              pyramid_request,
+                                                              search,
+                                                              AuthorityFilter):
+        execute(pyramid_request, MultiDict(), self.PAGE_SIZE)
+
+        AuthorityFilter.assert_called_once_with(pyramid_request.authority)
+        search.append_filter.assert_any_call(AuthorityFilter.return_value)
 
     def test_it_adds_a_tags_aggregation_to_the_search_query(self,
                                                             pyramid_request,
@@ -566,6 +575,10 @@ class TestExecute(object):
     @pytest.fixture
     def TagsAggregation(self, patch):
         return patch('h.activity.query.TagsAggregation')
+
+    @pytest.fixture
+    def AuthorityFilter(self, patch):
+        return patch('h.activity.query.AuthorityFilter')
 
     @pytest.fixture
     def TopLevelAnnotationsFilter(self, patch):

--- a/tests/h/search/query_test.py
+++ b/tests/h/search/query_test.py
@@ -250,6 +250,11 @@ class TestBuilder(object):
         }
 
 
+def test_authority_filter_adds_authority_term():
+    filter_ = query.AuthorityFilter(authority='partner.org')
+    assert filter_({}) == {'term': {'authority': 'partner.org'}}
+
+
 class TestAuthFilter(object):
     def test_unauthenticated(self):
         request = mock.Mock(authenticated_userid=None)


### PR DESCRIPTION
~~**Depends on a search reindex being run in production after #4708 is deployed.**~~ _Search reindex has been run in production_.

We may support some form of activity pages for third party users in future, but for the time being restrict them to showing annotations from first-party accounts.
    
Fixes #4697