### PR TITLE
Index authority of annotation creator as a separate field

### DIFF
--- a/h/presenters/annotation_searchindex.py
+++ b/h/presenters/annotation_searchindex.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 
 from h.presenters.annotation_base import AnnotationBasePresenter
 from h.presenters.document_searchindex import DocumentSearchIndexPresenter
+from h.util.user import split_user
 
 
 class AnnotationSearchIndexPresenter(AnnotationBasePresenter):
@@ -14,8 +15,10 @@ class AnnotationSearchIndexPresenter(AnnotationBasePresenter):
 
     def asdict(self):
         docpresenter = DocumentSearchIndexPresenter(self.annotation.document)
+        userid_parts = split_user(self.annotation.userid)
 
         result = {
+            'authority': userid_parts['domain'],
             'id': self.annotation.id,
             'created': self.created,
             'updated': self.updated,

--- a/h/search/config.py
+++ b/h/search/config.py
@@ -24,6 +24,7 @@ ANNOTATION_MAPPING = {
     'analyzer': 'keyword',
     'properties': {
         'annotator_schema_version': {'type': 'string'},
+        'authority': {'type': 'string', 'index': 'not_analyzed'},
         'created': {'type': 'date'},
         'updated': {'type': 'date'},
         'quote': {'type': 'string', 'analyzer': 'uni_normalizer'},

--- a/tests/h/presenters/annotation_searchindex_test.py
+++ b/tests/h/presenters/annotation_searchindex_test.py
@@ -34,6 +34,7 @@ class TestAnnotationSearchIndexPresenter(object):
         annotation_dict = AnnotationSearchIndexPresenter(annotation).asdict()
 
         assert annotation_dict == {
+            'authority': 'hypothes.is',
             'id': 'xyz123',
             'created': '2016-02-24T18:03:25.000768+00:00',
             'updated': '2016-02-29T10:24:05.000564+00:00',
@@ -55,6 +56,7 @@ class TestAnnotationSearchIndexPresenter(object):
 
     def test_it_copies_target_uri_normalized_to_target_scope(self):
         annotation = mock.Mock(
+            userid='acct:luke@hypothes.is',
             target_uri_normalized='http://example.com/normalized',
             extra={})
 


### PR DESCRIPTION
This makes it possible to filter the annotations that a search returns
by authority. This can be used in order to eg. exclude annotations from
third party accounts from the public Hypothesis activity pages.

Unlike the current indexing for the "user" field, the preprocessing is
done in Python in order to be able to reuse the existing `split_user`
function.