### PR TITLE
Remove unhelpful words from our documentation

### DIFF
--- a/docs/developing/install.rst
+++ b/docs/developing/install.rst
@@ -135,7 +135,7 @@ can be installed on:
 
    .. note::
 
-      If at any point you want to shut the containers down, you can simply
+      If at any point you want to shut the containers down, you can
       interrupt the ``docker-compose`` command. If you want to run the
       containers in the background, you can run ``docker-compose up -d``.
 

--- a/docs/developing/making-changes-to-model-code.rst
+++ b/docs/developing/making-changes-to-model-code.rst
@@ -41,7 +41,7 @@ We use `Alembic <https://alembic.readthedocs.io/en/latest/>`_ to create and run
 migration scripts. See the Alembic docs (and look at existing scripts in
 `h/migrations/versions <https://github.com/hypothesis/h/tree/master/h/migrations/versions>`_)
 for details. The ``hypothesis migrate`` command is a wrapper around Alembic. The
-basic steps to create a new migration script for h are:
+steps to create a new migration script for h are:
 
 1. Create the revision script by running ``bin/hypothesis migrate revision``, for example:
 


### PR DESCRIPTION
There are some words ("just", "simply", "basic", "obvious") that are counter-productive in documentation. At best, they are unnecessary; at worst, they can make someone reading the documentation feel bad that something isn't as simple to them, or as obvious to them, as the documentation implies it should be.