### PR TITLE
Dont send HTML links for third party annotations

### DIFF
--- a/h/links.py
+++ b/h/links.py
@@ -25,7 +25,12 @@ def pretty_link(url):
 
 
 def html_link(request, annotation):
-    """Generate a link to an HTML representation of an annotation."""
+    """Return a link to an HTML representation of the given annotation, or None."""
+    is_third_party_annotation = annotation.authority != request.authority
+    if is_third_party_annotation:
+        # We don't currently support HTML representations of third party
+        # annotations.
+        return None
     return request.route_url('annotation', id=annotation.id)
 
 

--- a/h/models/annotation.py
+++ b/h/models/annotation.py
@@ -11,6 +11,7 @@ from sqlalchemy.ext.mutable import MutableDict, MutableList
 
 from h.db import Base, types
 from h.util import markdown, uri
+from h.util.user import split_user
 
 
 class Annotation(Base):
@@ -186,6 +187,23 @@ class Annotation(Base):
         else:
             return self.id
 
+    @property
+    def authority(self):
+        """
+        Return the authority of the user and group this annotation belongs to.
+
+        For example, returns "hypothes.is" for Hypothesis first-party
+        annotations, or "elifesciences.org" for eLife third-party annotations.
+
+        If this annotation doesn't have a userid (which is possible for
+        annotations that haven't been saved to the DB yet) then return None.
+
+        :raises ValueError: if the annotation's userid is invalid
+
+        """
+        if self.userid is None:
+            return None
+        return split_user(self.userid)['domain']
 
     def __repr__(self):
         return '<Annotation %s>' % self.id

--- a/h/services/links.py
+++ b/h/services/links.py
@@ -6,6 +6,8 @@ from __future__ import unicode_literals
 
 from pyramid.request import Request
 
+from h.auth import authority
+
 LINK_GENERATORS_KEY = 'h.links.link_generators'
 
 
@@ -45,6 +47,10 @@ class LinksService(object):
         # be used by link generators.
         self._request = Request.blank('/', base_url=base_url)
         self._request.registry = registry
+
+        # Allow retrieval of the authority from the fake request object, the
+        # same as we do for real requests.
+        self._request.set_property(authority, name='authority', reify=True)
 
     def get(self, annotation, name):
         """Get the link named `name` for the passed `annotation`."""

--- a/tests/h/models/annotation_test.py
+++ b/tests/h/models/annotation_test.py
@@ -78,6 +78,18 @@ def test_text_setter_renders_markdown(markdown):
     annotation.text_rendered == markdown.render.return_value
 
 
+@pytest.mark.parametrize('userid,authority', [
+    ('acct:bmason@hypothes.is', 'hypothes.is'),
+    ('acct:kaylawatson@elifesciences.org', 'elifesciences.org'),
+])
+def test_authority(factories, userid, authority):
+    assert factories.Annotation(userid=userid).authority == authority
+
+
+def test_authority_when_annotation_has_no_userid():
+    assert Annotation().authority is None
+
+
 def test_setting_extras_inline_is_persisted(db_session, factories):
     """
     In-place changes to Annotation.extra should be persisted.


### PR DESCRIPTION
This is part of the fix for <https://github.com/hypothesis/client/issues/612>. The other part is <https://github.com/hypothesis/client/pull/617>.