### PR TITLE
Improve a test

### DIFF
--- a/tests/h/auth/util_test.py
+++ b/tests/h/auth/util_test.py
@@ -158,7 +158,11 @@ def test_translate_annotation_principals(p_in, p_out):
 
 
 class TestAuthDomain(object):
-    def test_it_returns_the_request_domain(self, pyramid_request):
+    def test_it_returns_the_request_domain_if_authority_isnt_set(
+            self, pyramid_request):
+        # Make sure h.authority isn't set.
+        pyramid_request.registry.settings.pop('h.authority', None)
+
         assert util.authority(pyramid_request) == pyramid_request.domain
 
     def test_it_allows_overriding_request_domain(self, pyramid_request):


### PR DESCRIPTION
I did this as part of another PR but ended up not needing it for that PR:

Clarify in the test name that this tests that `authority()` returns the request's domain _if_ the `h.authority` setting isn't set.

Also ensure, in the test, that `h.authority` isn't set rather than implicitly relying on the `pyramid_settings` fixture not containing an `h.authority` setting.

In fact the `pyramid_settings` fixture _doesn't_ containing an `h.authority` setting so this test was passing just fine. But for another test that I was writing (and didn't end up using in the end) I had to add `h.authority` to the `pyramid_settings` fixture and doing so would have broken this test.