### PR TITLE
Don't send incontext links for third-party annotations

### DIFF
--- a/h/links.py
+++ b/h/links.py
@@ -26,8 +26,7 @@ def pretty_link(url):
 
 def html_link(request, annotation):
     """Return a link to an HTML representation of the given annotation, or None."""
-    is_third_party_annotation = annotation.authority != request.authority
-    if is_third_party_annotation:
+    if _is_third_party_annotation(request, annotation):
         # We don't currently support HTML representations of third party
         # annotations.
         return None
@@ -36,6 +35,10 @@ def html_link(request, annotation):
 
 def incontext_link(request, annotation):
     """Generate a link to an annotation on the page where it was made."""
+    if _is_third_party_annotation(request, annotation):
+        # We don't currently support incontext links to third party annotations
+        return None
+
     bouncer_url = request.registry.settings.get('h.bouncer_url')
     if not bouncer_url:
         return None
@@ -62,6 +65,10 @@ def json_link(request, annotation):
 
 def jsonld_id_link(request, annotation):
     return request.route_url('annotation', id=annotation.id)
+
+
+def _is_third_party_annotation(request, annotation):
+    return annotation.authority != request.authority
 
 
 def includeme(config):

--- a/tests/h/links_test.py
+++ b/tests/h/links_test.py
@@ -13,6 +13,7 @@ class FakeAnnotation(object):
         self.references = None
         self.target_uri = 'http://example.com/foo/bar'
         self.document = None
+        self.authority = 'example.com'
 
 
 class FakeDocumentURI(object):
@@ -64,6 +65,13 @@ def test_incontext_link(pyramid_request):
     link = links.incontext_link(pyramid_request, annotation)
 
     assert link == 'https://hyp.is/123/example.com/foo/bar'
+
+
+def test_incontext_link_returns_None_for_third_party_annotations(pyramid_request):
+    annotation = FakeAnnotation()
+    annotation.authority = 'elifesciences.org'
+
+    assert links.incontext_link(pyramid_request, annotation) is None
 
 
 @pytest.mark.parametrize('target_uri,expected', [


### PR DESCRIPTION
Don't send incontext links in the API responses for third-party annotations. Incontext links don't work for third-party annotations yet.

This is one half of the fix for <https://github.com/hypothesis/client/issues/613>, the other half is <https://github.com/hypothesis/client/pull/618>.