### PR TITLE
Don't render bad html links on activity pages

### DIFF
--- a/h/activity/query.py
+++ b/h/activity/query.py
@@ -134,6 +134,7 @@ def execute(request, query, page_size):
                 bucket.presented_annotations.append({
                     'annotation': presenters.AnnotationHTMLPresenter(annotation),
                     'group': groups.get(annotation.groupid),
+                    'html_link': links.html_link(request, annotation),
                     'incontext_link': links.incontext_link(request, annotation)
                 })
 

--- a/h/templates/includes/annotation_card.html.jinja2
+++ b/h/templates/includes/annotation_card.html.jinja2
@@ -20,8 +20,9 @@
         class="annotation-card__username">
         {{ presented_annotation.annotation.username }}
       </a>
-      <a title="date" href="{{ request.route_url('annotation', id=presented_annotation.annotation.id) }}"
-        class="annotation-card__timestamp">
+      <a title="date"
+         {% if presented_annotation.html_link %}href="{{ presented_annotation.html_link }}"{% endif %}
+         class="annotation-card__timestamp">
         {{ presented_annotation.annotation.updated.strftime('%d %b %Y') }}
       </a>
     </div>

--- a/tests/h/activity/query_test.py
+++ b/tests/h/activity/query_test.py
@@ -441,6 +441,29 @@ class TestExecute(object):
             assert presented_annotation['incontext_link'] == (
                 'incontext_link_for_annotation_{id}'.format(id=presented_annotation['annotation'].annotation.id))
 
+    def test_it_returns_each_annotations_html_link(self,
+                                                   annotations,
+                                                   links,
+                                                   pyramid_request):
+        def html_link(request, annotation):
+            assert request == pyramid_request, (
+                "It should always pass the request to html_link")
+            # Return a predictable per-annotation value for the html link.
+            return 'html_link_for_annotation_{id}'.format(id=annotation.id)
+
+        links.html_link.side_effect = html_link
+
+        result = execute(pyramid_request, MultiDict(), self.PAGE_SIZE)
+
+        presented_annotations = []
+        for timeframe in result.timeframes:
+            for bucket in timeframe.document_buckets.values():
+                presented_annotations.extend(bucket.presented_annotations)
+
+        for presented_annotation in presented_annotations:
+            assert presented_annotation['html_link'] == (
+                'html_link_for_annotation_{id}'.format(id=presented_annotation['annotation'].annotation.id))
+
     def test_it_returns_the_total_number_of_matching_annotations(
             self, pyramid_request):
         assert execute(pyramid_request, MultiDict(), self.PAGE_SIZE).total == 20


### PR DESCRIPTION
Don't hyperlink the dates of annotations on activity pages to the
annotations' html pages if those annotations' don't have html pages.

Not all annotations have html links - for example the standalone
annotation pages aren't currently supported for third-party annotations,
see:

https://github.com/hypothesis/h/pull/4711

(particularly commit 73df3178e6da7a10cdd2a614adf557ea5f74fb3c).

Third-party annotations aren't currently rendered on activity pages, but
hopefully one day they will be, and not rendering html links for
annotations that don't have them is the correct behaviour for activity
pages anyway (and it removes some code duplication).

Activity pages are already smart enough to only render incontext links
for annotations that have them (and not, for example, for third-party
annotations):

https://github.com/hypothesis/h/blob/92886da2137992662b06d479f33166b9157d25fa/h/templates/includes/annotation_card.html.jinja2#L64-L80

This commit adds the same smarts to the activity pages templates for
html links.

This also removes some duplication: `annotation_card.html.jinja2` was
generating the html links itself, instead of using `h.links.html_link()`.

When an annotation doesn't have an html link, this commit renders the
annotation's timestamp as a "placeholder link", an `<a>` with no `href`
attribute. This is correct as of HTML5, see:

> If the a element has no href attribute, then the element represents a
> placeholder for where a link might otherwise have been placed, if it had
> been relevant, consisting of just the element's contents.
>
> https://html.spec.whatwg.org/#the-a-element

> A placeholder link resembles a traditional hyperlink, but does not lead
> anywhere.
> https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a

The behaviour of placeholder links in Chrome, Firefox, Edge and IE11 (I
tested) is that they look the same as normal links (unless specifically
styled differently) but are not clickable.

A common suggested use for placeholder links is for the current page in
a menu of navigation links:

* https://www.thoughtco.com/html5-placeholder-links-3468070
* https://www.enovate.co.uk/blog/2013/07/16/html5-placeholder-links
* https://coderwall.com/p/fs64gg/use-placeholder-links