### PR TITLE
Render display names rather than usernames in reply email notifications

### DIFF
--- a/h/emails/reply_notification.py
+++ b/h/emails/reply_notification.py
@@ -20,34 +20,38 @@ def generate(request, notification):
     if not document_title:
         document_title = notification.parent.target_uri
 
+    parent_user = notification.parent_user
     parent_user_url = request.route_url('stream.user_query',
-                                        user=notification.parent_user.username)
+                                        user=parent_user.username)
+    parent_user_display_name = parent_user.display_name or parent_user.username
 
     reply_url = links.incontext_link(request, notification.reply)
     if not reply_url:
         reply_url = request.route_url('annotation', id=notification.reply.id)
 
+    reply_user = notification.reply_user
     reply_user_url = request.route_url('stream.user_query',
-                                       user=notification.reply_user.username)
+                                       user=reply_user.username)
+    reply_user_display_name = reply_user.display_name or reply_user.username
 
-    unsubscribe_token = _unsubscribe_token(request, notification.parent_user)
+    unsubscribe_token = _unsubscribe_token(request, parent_user)
     unsubscribe_url = request.route_url('unsubscribe', token=unsubscribe_token)
 
     context = {
         'document_title': document_title,
         'document_url': notification.parent.target_uri,
         'parent': notification.parent,
-        'parent_user': notification.parent_user,
+        'parent_user_display_name': parent_user_display_name,
         'parent_user_url': parent_user_url,
         'reply': notification.reply,
         'reply_url': reply_url,
-        'reply_user': notification.reply_user,
+        'reply_user_display_name': reply_user_display_name,
         'reply_user_url': reply_user_url,
         'unsubscribe_url': unsubscribe_url,
     }
 
     subject = '{user} has replied to your annotation'.format(
-        user=notification.reply_user.username)
+        user=reply_user_display_name)
     text = render('h:templates/emails/reply_notification.txt.jinja2',
                   context,
                   request=request)

--- a/h/templates/emails/reply_notification.html.jinja2
+++ b/h/templates/emails/reply_notification.html.jinja2
@@ -1,5 +1,5 @@
 <p>
-  <a href="{{ reply_user_url }}">{{ reply_user.username }}</a>
+  <a href="{{ reply_user_url }}">{{ reply_user_display_name }}</a>
   has
   <a href="{{ reply_url }}">replied to your annotation</a>
   on
@@ -9,7 +9,7 @@
 <p>
   On
   {{ parent.created | human_timestamp }}
-  <a href="{{ parent_user_url }}">{{ parent_user.username }}</a>
+  <a href="{{ parent_user_url }}">{{ parent_user_display_name }}</a>
   commented:
 </p>
 
@@ -18,7 +18,7 @@
 <p>
   On
   {{ reply.created | human_timestamp }}
-  <a href="{{ reply_user_url }}">{{ reply_user.username }}</a>
+  <a href="{{ reply_user_url }}">{{ reply_user_display_name }}</a>
   replied:
 </p>
 

--- a/h/templates/emails/reply_notification.txt.jinja2
+++ b/h/templates/emails/reply_notification.txt.jinja2
@@ -1,10 +1,10 @@
-{{ reply_user.username }} has replied to your annotation on "{{ document_title }}":
+{{ reply_user_display_name }} has replied to your annotation on "{{ document_title }}":
 
-On {{ parent.created | human_timestamp }} {{ parent_user.username }} commented:
+On {{ parent.created | human_timestamp }} {{ parent_user_display_name }} commented:
 
 > {{ parent.text or "" }}
 
-On {{ reply.created | human_timestamp }} {{ reply_user.username }} replied:
+On {{ reply.created | human_timestamp }} {{ reply_user_display_name }} replied:
 
 > {{ reply.text or "" }}
 

--- a/tests/h/emails/reply_notification_test.py
+++ b/tests/h/emails/reply_notification_test.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
+
 import datetime
 
 import mock
@@ -37,11 +39,11 @@ class TestGenerate(object):
             'document_title': 'My fascinating page',
             'document_url': 'http://example.org/',
             'parent': notification.parent,
-            'parent_user': parent_user,
+            'parent_user_display_name': parent_user.display_name,
             'parent_user_url': 'http://example.com/stream/user/patricia',
             'reply': notification.reply,
             'reply_url': links.incontext_link.return_value,
-            'reply_user': reply_user,
+            'reply_user_display_name': reply_user.display_name,
             'reply_user_url': 'http://example.com/stream/user/ron',
             'unsubscribe_url': 'http://example.com/unsub/FAKETOKEN',
         }
@@ -85,14 +87,31 @@ class TestGenerate(object):
             'document_title': 'My fascinating page',
             'document_url': 'http://example.org/',
             'parent': notification.parent,
-            'parent_user': parent_user,
+            'parent_user_display_name': parent_user.display_name,
             'parent_user_url': 'http://example.com/stream/user/patricia',
             'reply': notification.reply,
             'reply_url': 'http://example.com/ann/bar456',
-            'reply_user': reply_user,
+            'reply_user_display_name': reply_user.display_name,
             'reply_user_url': 'http://example.com/stream/user/ron',
             'unsubscribe_url': 'http://example.com/unsub/FAKETOKEN',
         }
+        html_renderer.assert_(**expected_context)
+        text_renderer.assert_(**expected_context)
+
+    def test_returns_usernames_if_no_display_names(self,
+                                                   notification,
+                                                   pyramid_request,
+                                                   html_renderer,
+                                                   text_renderer,
+                                                   parent_user,
+                                                   reply_user):
+        parent_user.display_name = None
+        reply_user.display_name = None
+
+        generate(pyramid_request, notification)
+
+        expected_context = {'parent_user_display_name': parent_user.username,
+                            'reply_user_display_name': reply_user.username}
         html_renderer.assert_(**expected_context)
         text_renderer.assert_(**expected_context)
 
@@ -109,7 +128,13 @@ class TestGenerate(object):
         assert html == 'HTML output'
         assert text == 'Text output'
 
-    def test_returns_subject_with_reply_username(self, notification, pyramid_request):
+    def test_returns_subject_with_reply_display_name(self, notification, pyramid_request, reply_user):
+        _, subject, _, _ = generate(pyramid_request, notification)
+
+        assert subject == 'Ron Burgundy has replied to your annotation'
+
+    def test_returns_subject_with_reply_username(self, notification, pyramid_request, reply_user):
+        reply_user.display_name = None
         _, subject, _, _ = generate(pyramid_request, notification)
 
         assert subject == 'ron has replied to your annotation'
@@ -175,7 +200,8 @@ class TestGenerate(object):
 
     @pytest.fixture
     def parent_user(self, factories):
-        return factories.User(username=u'patricia', email=u'pat@ric.ia')
+        return factories.User(username=u'patricia', email=u'pat@ric.ia',
+                              display_name='Patricia Demylus')
 
     @pytest.fixture
     def reply(self):
@@ -189,7 +215,8 @@ class TestGenerate(object):
 
     @pytest.fixture
     def reply_user(self, factories):
-        return factories.User(username=u'ron', email=u'ron@thesmiths.com')
+        return factories.User(username=u'ron', email=u'ron@thesmiths.com',
+                              display_name='Ron Burgundy')
 
     @pytest.fixture
     def routes(self, pyramid_config):


### PR DESCRIPTION
Render display names rather than usernames in reply email notifications if the user has set one. This is important particularly for third party accounts which have generated usernames not designed to be
human-friendly.

Slack discussion: https://hypothes-is.slack.com/archives/C2N6HPG2G/p1512663476000485