### PR TITLE
Fix incorrect key in test expectation

### DIFF
--- a/tests/h/emails/reply_notification_test.py
+++ b/tests/h/emails/reply_notification_test.py
@@ -7,7 +7,7 @@ import pytest
 
 from h.emails.reply_notification import generate
 from h.models import Annotation
-from h.models import Document, DocumentMeta
+from h.models import Document
 from h.notification.reply import Notification
 
 
@@ -86,7 +86,7 @@ class TestGenerate(object):
             'document_url': 'http://example.org/',
             'parent': notification.parent,
             'parent_user': parent_user,
-            'reply_user_url': 'http://example.com/stream/user/patricia',
+            'parent_user_url': 'http://example.com/stream/user/patricia',
             'reply': notification.reply,
             'reply_url': 'http://example.com/ann/bar456',
             'reply_user': reply_user,


### PR DESCRIPTION
 - The `reply_user_url` key was repeated twice with different values in one test.
 - Also fix a lint warning by removing an unused import.