### PR TITLE
Extract user deletion logic into a service

### DIFF
--- a/h/cli/commands/user.py
+++ b/h/cli/commands/user.py
@@ -4,7 +4,6 @@ import click
 import sqlalchemy
 
 from h import models
-from h.views.admin_users import delete_user
 
 
 @click.group()
@@ -127,7 +126,8 @@ def delete(ctx, username, authority):
         msg = 'no user with username "{}" and authority "{}"'.format(username, authority)
         raise click.ClickException(msg)
 
-    delete_user(request, user)
+    svc = request.find_service(name='delete_user')
+    svc.delete(user)
     request.tm.commit()
 
     click.echo("User {} deleted.".format(username), err=True)

--- a/h/services/__init__.py
+++ b/h/services/__init__.py
@@ -14,6 +14,7 @@ def includeme(config):
                                     iface='pyramid_authsanity.interfaces.IAuthService')
     config.register_service_factory('.auth_token.auth_token_service_factory', name='auth_token')
     config.register_service_factory('.authority_group.authority_group_factory', name='authority_group')
+    config.register_service_factory('.delete_user.delete_user_service_factory', name='delete_user')
     config.register_service_factory('.developer_token.developer_token_service_factory', name='developer_token')
     config.register_service_factory('.feature.feature_service_factory', name='feature')
     config.register_service_factory('.flag.flag_service_factory', name='flag')

--- a/h/services/delete_user.py
+++ b/h/services/delete_user.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from h.events import AnnotationEvent
+from h.models import Annotation, Group
+from h import storage
+
+
+class UserDeleteError(Exception):
+    pass
+
+
+class DeleteUserService(object):
+    def __init__(self, request):
+        self.request = request
+
+    def delete(self, user):
+        """
+        Deletes a user with all their group memberships and annotations.
+
+        Raises UserDeleteError when deletion fails with the appropriate error
+        message.
+        """
+
+        if Group.created_by(self.request.db, user).count() > 0:
+            raise UserDeleteError('Cannot delete user who is a group creator.')
+
+        user.groups = []
+        annotations = self.request.db.query(Annotation) \
+                                     .filter_by(userid=user.userid)
+        for annotation in annotations:
+            storage.delete_annotation(self.request.db, annotation.id)
+            event = AnnotationEvent(self.request, annotation.id, 'delete')
+            self.request.notify_after_commit(event)
+
+        self.request.db.delete(user)
+
+
+def delete_user_service_factory(context, request):
+    return DeleteUserService(request=request)

--- a/tests/h/cli/commands/user_test.py
+++ b/tests/h/cli/commands/user_test.py
@@ -6,6 +6,7 @@ from passlib.context import CryptContext
 
 from h import models
 from h.cli.commands import user as user_cli
+from h.services.delete_user import DeleteUserService
 from h.services.user_password import UserPasswordService
 
 
@@ -254,9 +255,16 @@ def password_service(hasher):
 
 
 @pytest.fixture
-def pyramid_config(pyramid_config, signup_service, password_service):
+def delete_user_service(pyramid_request):
+    return DeleteUserService(request=pyramid_request)
+
+
+@pytest.fixture
+def pyramid_config(pyramid_config, signup_service, password_service,
+                   delete_user_service):
     pyramid_config.register_service(signup_service, name='user_signup')
     pyramid_config.register_service(password_service, name='user_password')
+    pyramid_config.register_service(delete_user_service, name='delete_user')
     return pyramid_config
 
 

--- a/tests/h/services/delete_user_test.py
+++ b/tests/h/services/delete_user_test.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import pytest
+from mock import Mock, call
+
+from h.events import AnnotationEvent
+from h.services.delete_user import (
+    UserDeleteError,
+    delete_user_service_factory,
+)
+
+delete_user_fixtures = pytest.mark.usefixtures('api_storage',
+                                               'user_created_no_groups')
+
+
+@delete_user_fixtures
+class TestDeleteUserService(object):
+
+    def test_delete_raises_when_group_creator(self, Group, svc): # noqa N803
+        user = Mock()
+
+        Group.created_by.return_value.count.return_value = 10
+
+        with pytest.raises(UserDeleteError):
+            svc.delete(user)
+
+    def test_delete_disassociate_group_memberships(self, factories, svc):
+        user = factories.User()
+
+        svc.delete(user)
+
+        assert user.groups == []
+
+    def test_delete_deletes_annotations(self, api_storage, factories, pyramid_request, svc):
+        user = factories.User(username='bob')
+        anns = [factories.Annotation(userid=user.userid),
+                factories.Annotation(userid=user.userid)]
+
+        svc.delete(user)
+
+        api_storage.delete_annotation.assert_has_calls([
+            call(pyramid_request.db, anns[0].id),
+            call(pyramid_request.db, anns[1].id),
+        ], any_order=True)
+
+    def test_delete_publishes_event(self, api_storage, db_session, factories,
+                                    matchers, pyramid_request, svc):
+        user = factories.User()
+        ann = factories.Annotation(userid=user.userid)
+
+        svc.delete(user)
+
+        expected_event = AnnotationEvent(pyramid_request, ann.id, 'delete')
+        actual_event = pyramid_request.notify_after_commit.call_args[0][0]
+        assert (expected_event.request, expected_event.annotation_id, expected_event.action) == \
+               (actual_event.request, actual_event.annotation_id, actual_event.action)
+
+    def test_delete_deletes_user(self, db_session, factories, pyramid_request, svc):
+        user = factories.User()
+
+        svc.delete(user)
+
+        assert user in db_session.deleted
+
+    @pytest.fixture
+    def svc(self, db_session, pyramid_request):
+        pyramid_request.db = db_session
+        return delete_user_service_factory({}, pyramid_request)
+
+
+@pytest.fixture
+def user_created_no_groups(Group): # noqa N803
+    # By default, pretend that all users are the creators of 0 groups.
+    Group.created_by.return_value.count.return_value = 0
+
+
+@pytest.fixture
+def pyramid_request(pyramid_request):
+    pyramid_request.notify_after_commit = Mock()
+    return pyramid_request
+
+
+@pytest.fixture
+def api_storage(patch):
+    return patch('h.services.delete_user.storage')
+
+
+@pytest.fixture
+def Group(patch): # noqa N802
+    return patch('h.services.delete_user.Group')

--- a/tests/h/views/admin_users_test.py
+++ b/tests/h/views/admin_users_test.py
@@ -2,21 +2,17 @@
 
 from __future__ import unicode_literals
 
-import mock
 from mock import Mock
 from mock import MagicMock
-from mock import call
 from pyramid import httpexceptions
 import pytest
 
-from h.events import AnnotationEvent
 from h.services.annotation_stats import AnnotationStatsService
+from h.services.delete_user import DeleteUserService, UserDeleteError
 from h.services.user import UserService
 from h.models import Annotation
 from h.views.admin_users import (
-    UserDeletionError,
     UserNotFoundError,
-    delete_user,
     users_activate,
     users_delete,
     users_index,
@@ -185,7 +181,7 @@ def test_users_activate_redirects(pyramid_request):
     assert isinstance(result, httpexceptions.HTTPFound)
 
 
-users_delete_fixtures = pytest.mark.usefixtures('user_service', 'fake_delete_user')
+users_delete_fixtures = pytest.mark.usefixtures('user_service')
 
 
 @users_delete_fixtures
@@ -199,7 +195,7 @@ def test_users_delete_user_not_found_error(user_service, pyramid_request):
 
 
 @users_delete_fixtures
-def test_users_delete_deletes_user(user_service, fake_delete_user, pyramid_request):
+def test_users_delete_deletes_user(user_service, delete_user_service, pyramid_request):
     pyramid_request.params = {"userid": "acct:bob@example.com"}
     user = MagicMock()
 
@@ -207,92 +203,21 @@ def test_users_delete_deletes_user(user_service, fake_delete_user, pyramid_reque
 
     users_delete(pyramid_request)
 
-    fake_delete_user.assert_called_once_with(pyramid_request, user)
+    delete_user_service.delete.assert_called_once_with(user)
 
 
 @users_delete_fixtures
-def test_users_delete_group_creator_error(user_service, fake_delete_user, pyramid_request):
+def test_users_delete_reports_error(user_service, delete_user_service, pyramid_request):
     pyramid_request.params = {"userid": "acct:bob@example.com"}
     user = MagicMock()
-
     user_service.fetch.return_value = user
-    fake_delete_user.side_effect = UserDeletionError('group creator error')
+    delete_user_service.delete.side_effect = UserDeleteError('cannot delete user')
 
     users_delete(pyramid_request)
 
     assert pyramid_request.session.peek_flash('error') == [
-        'group creator error'
+        'cannot delete user'
     ]
-
-
-delete_user_fixtures = pytest.mark.usefixtures('api_storage',
-                                               'models',
-                                               'user_created_no_groups')
-
-
-@delete_user_fixtures
-def test_delete_user_raises_when_group_creator(models, pyramid_request):
-    user = Mock()
-
-    models.Group.created_by.return_value.count.return_value = 10
-
-    with pytest.raises(UserDeletionError):
-        delete_user(pyramid_request, user)
-
-
-@delete_user_fixtures
-def test_delete_user_disassociate_group_memberships(db_session, factories, pyramid_request):
-    pyramid_request.db = db_session
-    user = factories.User()
-
-    delete_user(pyramid_request, user)
-
-    assert user.groups == []
-
-
-@delete_user_fixtures
-def test_delete_user_deletes_annotations(api_storage, db_session, factories, pyramid_request):
-    pyramid_request.db = db_session
-    user = factories.User(username='bob')
-    anns = [factories.Annotation(userid=user.userid),
-            factories.Annotation(userid=user.userid)]
-
-    delete_user(pyramid_request, user)
-
-    api_storage.delete_annotation.assert_has_calls([
-        call(pyramid_request.db, anns[0].id),
-        call(pyramid_request.db, anns[1].id),
-    ], any_order=True)
-
-
-@delete_user_fixtures
-def test_delete_user_publishes_event(api_storage, db_session, factories, matchers, pyramid_request):
-    pyramid_request.db = db_session
-    user = factories.User()
-    ann = factories.Annotation(userid=user.userid)
-
-    delete_user(pyramid_request, user)
-
-    expected_event = AnnotationEvent(pyramid_request, ann.id, 'delete')
-    actual_event = pyramid_request.notify_after_commit.call_args[0][0]
-    assert (expected_event.request, expected_event.annotation_id, expected_event.action) == \
-           (actual_event.request, actual_event.annotation_id, actual_event.action)
-
-
-@delete_user_fixtures
-def test_delete_user_deletes_user(db_session, factories, pyramid_request):
-    pyramid_request.db = db_session
-    user = factories.User()
-
-    delete_user(pyramid_request, user)
-
-    assert user in db_session.deleted
-
-
-@pytest.fixture
-def pyramid_request(pyramid_request):
-    pyramid_request.notify_after_commit = mock.Mock()
-    return pyramid_request
 
 
 @pytest.fixture(autouse=True)
@@ -303,16 +228,6 @@ def routes(pyramid_config):
 @pytest.fixture
 def ActivationEvent(patch):  # noqa N802
     return patch('h.views.admin_users.ActivationEvent')
-
-
-@pytest.fixture
-def api_storage(patch):
-    return patch('h.views.admin_users.storage')
-
-
-@pytest.fixture
-def fake_delete_user(patch):
-    return patch('h.views.admin_users.delete_user')
 
 
 @pytest.fixture
@@ -339,6 +254,7 @@ def annotation_stats_service(pyramid_config, db_session):
 
 
 @pytest.fixture
-def user_created_no_groups(models):
-    # By default, pretend that all users are the creators of 0 groups.
-    models.Group.created_by.return_value.count.return_value = 0
+def delete_user_service(pyramid_config, pyramid_request):
+    service = Mock(spec_set=DeleteUserService(request=pyramid_request))
+    pyramid_config.register_service(service, name='delete_user')
+    return service

--- a/tests/h/views/admin_users_test.py
+++ b/tests/h/views/admin_users_test.py
@@ -181,10 +181,6 @@ def test_users_activate_redirects(pyramid_request):
     assert isinstance(result, httpexceptions.HTTPFound)
 
 
-users_delete_fixtures = pytest.mark.usefixtures('user_service')
-
-
-@users_delete_fixtures
 def test_users_delete_user_not_found_error(user_service, pyramid_request):
     pyramid_request.params = {"userid": "acct:bob@foo.org"}
 
@@ -194,7 +190,6 @@ def test_users_delete_user_not_found_error(user_service, pyramid_request):
         users_delete(pyramid_request)
 
 
-@users_delete_fixtures
 def test_users_delete_deletes_user(user_service, delete_user_service, pyramid_request):
     pyramid_request.params = {"userid": "acct:bob@example.com"}
     user = MagicMock()
@@ -206,7 +201,6 @@ def test_users_delete_deletes_user(user_service, delete_user_service, pyramid_re
     delete_user_service.delete.assert_called_once_with(user)
 
 
-@users_delete_fixtures
 def test_users_delete_reports_error(user_service, delete_user_service, pyramid_request):
     pyramid_request.params = {"userid": "acct:bob@example.com"}
     user = MagicMock()


### PR DESCRIPTION
Follow the pattern of keeping non-trivial logic involving models out of
views by extracting the logic for deleting a user (previously the `h.views.admin_users.delete_user` helper function) into a service.

This will also make it easier to reuse this functionality from other
views in future, such as an API for deleting users or a self-service
view for a user to delete their own account. The user deletion CLI
command was already inappropriately using the helper function from
`h.views.admin_users`.