### PR TITLE
Disabled pep257:D212 rule in prospector.

### DIFF
--- a/.prospector.yaml
+++ b/.prospector.yaml
@@ -15,6 +15,9 @@ pep257:
     - D203 # "1 blank line required before class docstring" conflicts with
            # another pep257 rule D211 "No blank lines allowed before class
            # docstring"!
+    - D212 # "Multi-line docstring summary should start at the first line"
+           # conflicts with another pep257 rule D213 "Multi-line docstring 
+           # summary should start at the second line"
 pyflakes:
   run: false
 


### PR DESCRIPTION
Pep257:D212 conflicts with pep257:D213 which leads
to prospector lynt runs always being in violation
of one of these rules. This changes the .yaml of
prospector to use pep257:D213 as the rule (multi-
line docstrings should start at the second line).