### PR TITLE
Public/Open Groups

### DIFF
--- a/h/cli/commands/groups.py
+++ b/h/cli/commands/groups.py
@@ -42,6 +42,22 @@ def add_public_group(ctx, name, authority, creator):
     _create_group('public', ctx, name, authority, creator)
 
 
+@groups.command('add-open-group')
+@click.option('--name', prompt=True, help="The name of the group")
+@click.option('--authority', prompt=True,
+              help="The authority which the group is associated with")
+@click.option('--creator', prompt=True,
+              help="The username of the group's creator")
+@click.pass_context
+def add_open_group(ctx, name, authority, creator):
+    """
+    Create a new "open" group.
+
+    Create a new group which everyone can read and any logged-in user can write to
+    """
+    _create_group('open', ctx, name, authority, creator)
+
+
 def _create_group(type, ctx, name, authority, creator):
     """
     Create a group using group service

--- a/h/cli/commands/groups.py
+++ b/h/cli/commands/groups.py
@@ -23,7 +23,7 @@ def add_publisher_group(ctx, name, authority, creator):
     Create a new group which everyone can read but which only users belonging
     to a given authority can write to.
     """
-    _create_group('publisher', ctx, name, authority, creator)
+    _create_group('open', ctx, name, authority, creator)
 
 
 @groups.command('add-public-group')

--- a/h/cli/commands/groups.py
+++ b/h/cli/commands/groups.py
@@ -86,9 +86,11 @@ def join(ctx, user, authority, group):
     group_id = group
     request = ctx.obj['bootstrap']()
 
-    user = User.get_by_username(request.db, user, authority)
+    username = user
+    user = User.get_by_username(request.db, username, authority)
     if not user:
-        raise ValueError('Could not find user {0}@{1}'.format(user, authority))
+        raise ValueError(
+            'Could not find user {0}@{1}'.format(username, authority))
 
     group = request.db.query(Group).filter_by(pubid=group_id).one_or_none()
     if not group:

--- a/h/form.py
+++ b/h/form.py
@@ -95,7 +95,7 @@ def configure_environment(config):  # pragma: no cover
     config.registry[ENVIRONMENT_KEY] = create_environment(base)
 
 
-def handle_form_submission(request, form, on_success, on_failure):
+def handle_form_submission(request, form, on_success, on_failure, flash=True):
     """
     Handle the submission of the given form in a standard way.
 
@@ -125,8 +125,8 @@ def handle_form_submission(request, form, on_success, on_failure):
     """
     try:
         appstruct = form.validate(request.POST.items())
-    except deform.ValidationFailure:
-        result = on_failure()
+    except deform.ValidationFailure, e:
+        result = on_failure(exception=e)
         request.response.status_int = 400
     else:
         result = on_success(appstruct)
@@ -134,7 +134,7 @@ def handle_form_submission(request, form, on_success, on_failure):
         if result is None:
             result = httpexceptions.HTTPFound(location=request.url)
 
-        if not request.is_xhr:
+        if flash and not request.is_xhr:
             request.session.flash(_("Success. We've saved your changes."),
                                   'success')
 

--- a/h/form.py
+++ b/h/form.py
@@ -125,7 +125,7 @@ def handle_form_submission(request, form, on_success, on_failure, flash=True):
     """
     try:
         appstruct = form.validate(request.POST.items())
-    except deform.ValidationFailure, e:
+    except deform.ValidationFailure as e:
         result = on_failure(exception=e)
         request.response.status_int = 400
     else:

--- a/h/groups/schemas.py
+++ b/h/groups/schemas.py
@@ -8,7 +8,6 @@ import slugify
 from h import i18n
 from h import validators
 from h.accounts.schemas import CSRFSchema
-from h.services.group import GROUP_TYPES
 from h.models.group import (
     GROUP_DESCRIPTION_MAX_LENGTH,
     GROUP_NAME_MIN_LENGTH,
@@ -63,24 +62,4 @@ def group_schema(autofocus_name=False):
     schema.add(name)
     schema.add(description)
 
-    return schema
-
-
-def admin_group_create_schema(group_types=GROUP_TYPES):
-    schema = group_schema()
-    group_type = colander.SchemaNode(
-        colander.String(),
-        name='group_type',
-        title=_("Group Type"),
-        validator=colander.OneOf(group_types.keys()),
-        widget=deform.widget.SelectWidget(
-            values=[
-                [group_type, '{title} - {description}'.format(
-                    title=group_type.capitalize(), description=group_type_info['description'])]
-                for [group_type, group_type_info]
-                in group_types.items()
-            ]
-        )
-    )
-    schema.add(group_type)
     return schema

--- a/h/groups/schemas.py
+++ b/h/groups/schemas.py
@@ -8,6 +8,7 @@ import slugify
 from h import i18n
 from h import validators
 from h.accounts.schemas import CSRFSchema
+from h.services.group import GROUP_TYPES
 from h.models.group import (
     GROUP_DESCRIPTION_MAX_LENGTH,
     GROUP_NAME_MIN_LENGTH,
@@ -65,16 +66,19 @@ def group_schema(autofocus_name=False):
     return schema
 
 
-def admin_group_create_schema():
+def admin_group_create_schema(group_types=GROUP_TYPES):
     schema = group_schema()
     group_type = colander.SchemaNode(
         colander.String(),
         name='group_type',
         title=_("Group Type"),
-        validator=colander.OneOf(['public', 'open']),
+        validator=colander.OneOf(group_types.keys()),
         widget=deform.widget.SelectWidget(
             values=[
-                ['public', 'Public'], ['open', 'Open']
+                [group_type, '{title} - {description}'.format(
+                    title=group_type.capitalize(), description=group_type_info['description'])]
+                for [group_type, group_type_info]
+                in group_types.items()
             ]
         )
     )

--- a/h/groups/schemas.py
+++ b/h/groups/schemas.py
@@ -28,7 +28,6 @@ def unblacklisted_group_name_slug(node, value, blacklist=GROUPSLUG_BLACKLIST):
 
 
 def group_schema(autofocus_name=False):
-
     """Return a schema for the form for creating or editing a group."""
 
     schema = CSRFSchema()
@@ -37,7 +36,8 @@ def group_schema(autofocus_name=False):
         name='name',
         title=_("Name"),
         validator=colander.All(
-            validators.Length(min=GROUP_NAME_MIN_LENGTH, max=GROUP_NAME_MAX_LENGTH),
+            validators.Length(min=GROUP_NAME_MIN_LENGTH,
+                              max=GROUP_NAME_MAX_LENGTH),
             unblacklisted_group_name_slug),
         widget=deform.widget.TextInputWidget(
             autofocus=autofocus_name,
@@ -62,4 +62,21 @@ def group_schema(autofocus_name=False):
     schema.add(name)
     schema.add(description)
 
+    return schema
+
+
+def admin_group_create_schema():
+    schema = group_schema()
+    group_type = colander.SchemaNode(
+        colander.String(),
+        name='group_type',
+        title=_("Group Type"),
+        validator=colander.OneOf(['public', 'open']),
+        widget=deform.widget.SelectWidget(
+            values=[
+                ['public', 'Public'], ['open', 'Open']
+            ]
+        )
+    )
+    schema.add(group_type)
     return schema

--- a/h/models/group.py
+++ b/h/models/group.py
@@ -23,7 +23,7 @@ class GroupFactory(object):
 
     def __getitem__(self, pubid):
         try:
-            group_service = request.find_service(name='group')
+            group_service = self.request.find_service(name='group')
             return group_service.get_by_pubid(pubid=pubid)
         except exc.NoResultFound:
             raise KeyError()

--- a/h/models/group.py
+++ b/h/models/group.py
@@ -23,7 +23,8 @@ class GroupFactory(object):
 
     def __getitem__(self, pubid):
         try:
-            return self.request.db.query(Group).filter_by(pubid=pubid).one()
+            group_service = request.find_service(name='group')
+            return group_service.get_by_pubid(pubid=pubid)
         except exc.NoResultFound:
             raise KeyError()
 

--- a/h/models/group.py
+++ b/h/models/group.py
@@ -121,7 +121,6 @@ class Group(Base, mixins.Timestamps):
 
         if self.creator:
             terms.append((security.Allow, self.creator.userid, 'admin'))
-        terms.append(security.DENY_ALL)
 
         return terms
 

--- a/h/resources.py
+++ b/h/resources.py
@@ -10,7 +10,7 @@ from pyramid.security import (
 )
 
 from h import storage
-from h.models import AuthClient
+from h.models import AuthClient, Group
 from h.auth import role
 from h.interfaces import IGroupService
 
@@ -103,6 +103,27 @@ class AuthClientFactory(object):
             return client
         except:
             # No such client found or not a valid UUID.
+            raise KeyError()
+
+
+class GroupFactory(object):
+
+    def __init__(self, request):
+        self.request = request
+
+    def __getitem__(self, pubid):
+        try:
+            group = self.request.db.query(Group) \
+                .filter_by(pubid=pubid).one()
+
+            # Inherit global ACL.
+            # See `pyramid.authorization.ACLAuthorizationPolicy` docs.
+            # @TODO (bengo): Can I just put this in the model definition or even h.db:Base?
+            group.__parent__ = Root(self.request)
+
+            return group
+        except:
+            # No such group found or not a valid UUID.
             raise KeyError()
 
 

--- a/h/resources.py
+++ b/h/resources.py
@@ -107,11 +107,21 @@ class AuthClientFactory(object):
 
 
 class GroupFactory(object):
+    """
+    dict-like for looking up Group models by pubid.
+    Values will have .__parent__ set to request's root resource (and thus overlay the root ACL)
+    """
 
     def __init__(self, request):
+        """
+        :param Request request: http request of end-user who's looking up the group
+        """
         self.request = request
 
     def __getitem__(self, pubid):
+        """
+        :param str pubid: pubid of Group to lookup
+        """
         try:
             group = self.request.db.query(Group) \
                 .filter_by(pubid=pubid).one()
@@ -123,7 +133,7 @@ class GroupFactory(object):
 
             return group
         except:
-            # No such group found or not a valid UUID.
+            # No such group found
             raise KeyError()
 
 

--- a/h/resources.py
+++ b/h/resources.py
@@ -16,6 +16,7 @@ from h.interfaces import IGroupService
 
 
 class Root(object):
+    __parent__ = None
     __acl__ = [
         (Allow, role.Staff, 'admin_index'),
         (Allow, role.Staff, 'admin_groups'),

--- a/h/routes.py
+++ b/h/routes.py
@@ -19,10 +19,12 @@ def includeme(config):
     config.add_route('account_reset_with_code', '/account/reset/{code}')
     config.add_route('account', '/account/settings')
     config.add_route('account_profile', '/account/profile')
-    config.add_route('account_notifications', '/account/settings/notifications')
+    config.add_route('account_notifications',
+                     '/account/settings/notifications')
     config.add_route('account_developer', '/account/developer')
     config.add_route('claim_account_legacy', '/claim_account/{token}')
-    config.add_route('dismiss_sidebar_tutorial', '/app/dismiss_sidebar_tutorial')
+    config.add_route('dismiss_sidebar_tutorial',
+                     '/app/dismiss_sidebar_tutorial')
 
     # Activity
     config.add_route('activity.search', '/search')
@@ -39,6 +41,7 @@ def includeme(config):
     config.add_route('admin_cohorts', '/admin/features/cohorts')
     config.add_route('admin_cohorts_edit', '/admin/features/cohorts/{id}')
     config.add_route('admin_groups', '/admin/groups')
+    config.add_route('admin_groups_create', '/admin/groups/create')
     config.add_route('admin_mailer', '/admin/mailer')
     config.add_route('admin_mailer_test', '/admin/mailer/test')
     config.add_route('admin_nipsa', '/admin/nipsa')

--- a/h/routes.py
+++ b/h/routes.py
@@ -43,8 +43,8 @@ def includeme(config):
     config.add_route('admin_groups', '/admin/groups')
     config.add_route('admin_groups_create', '/admin/groups/create')
     # Match "/<pubid>/": we redirect to the version with the slug.
-    config.add_route('admin_group_members',
-                     '/admin/groups/{pubid}/{slug:[^/]*}/members/',
+    config.add_route('admin_group_read',
+                     '/admin/groups/{pubid}/{slug:[^/]*}/',
                      factory='h.resources.GroupFactory',
                      traverse='/{pubid}')
     config.add_route('admin_mailer', '/admin/mailer')

--- a/h/routes.py
+++ b/h/routes.py
@@ -42,6 +42,11 @@ def includeme(config):
     config.add_route('admin_cohorts_edit', '/admin/features/cohorts/{id}')
     config.add_route('admin_groups', '/admin/groups')
     config.add_route('admin_groups_create', '/admin/groups/create')
+    # Match "/<pubid>/": we redirect to the version with the slug.
+    config.add_route('admin_group_members',
+                     '/admin/groups/{pubid}/{slug:[^/]*}/members/',
+                     factory='h.resources.GroupFactory',
+                     traverse='/{pubid}')
     config.add_route('admin_mailer', '/admin/mailer')
     config.add_route('admin_mailer_test', '/admin/mailer/test')
     config.add_route('admin_nipsa', '/admin/nipsa')

--- a/h/routes.py
+++ b/h/routes.py
@@ -104,6 +104,14 @@ def includeme(config):
                      traverse='/{id}')
     config.add_route('api.profile', '/api/profile')
     config.add_route('api.debug_token', '/api/debug-token')
+    config.add_route('api.group_read',
+                     '/api/groups/{pubid}/{slug:[^/]*}',
+                     factory='h.models.group:GroupFactory',
+                     traverse='/{pubid}')
+    config.add_route('api.group_read_noslug',
+                     '/api/groups/{pubid}',
+                     factory='h.models.group:GroupFactory',
+                     traverse='/{pubid}')
     config.add_route('api.group_member',
                      '/api/groups/{pubid}/members/{user}',
                      factory='h.models.group:GroupFactory',

--- a/h/services/authority_group.py
+++ b/h/services/authority_group.py
@@ -23,7 +23,7 @@ class AuthorityGroupService(object):
         return (self._session.query(models.Group)
                     .filter_by(authority=authority,
                                readable_by=group.ReadableBy.world,
-                               writeable_by=group.WriteableBy.members)
+                               writeable_by=group.WriteableBy.authority)
                     .all())
 
 

--- a/h/services/authority_group.py
+++ b/h/services/authority_group.py
@@ -22,7 +22,8 @@ class AuthorityGroupService(object):
     def public_groups(self, authority):
         return (self._session.query(models.Group)
                     .filter_by(authority=authority,
-                               readable_by=group.ReadableBy.world)
+                               readable_by=group.ReadableBy.world,
+                               writeable_by=group.WriteableBy.members)
                     .all())
 
 

--- a/h/services/group.py
+++ b/h/services/group.py
@@ -56,10 +56,12 @@ GROUP_ACCESS_FLAGS = {
 def get_group_type(group, request=None):
     """given a Group, try to figure out what 'type' it is"""
     for group_type_name, access_flags in GROUP_ACCESS_FLAGS.items():
-        for field, value in access_flags.items():
-            if getattr(group, field) != value:
-                # continue to next group_type
-                break
+        has_correct_access_flags = all((getattr(group, field) == value) for (
+            field, value) in access_flags.items())
+        if not has_correct_access_flags:
+            continue
+        # has correct access flags for this group_type_name
+        # some group types (open/publisher) can only be discriminated based on an incomig web request
         matches_request = GROUP_TYPES.get(
             group_type_name, {}).get('matches_request')
         if request and callable(matches_request):

--- a/h/services/group.py
+++ b/h/services/group.py
@@ -54,6 +54,7 @@ GROUP_ACCESS_FLAGS = {
 
 
 def get_group_type(group, request=None):
+    """given a Group, try to figure out what 'type' it is"""
     for group_type_name, access_flags in GROUP_ACCESS_FLAGS.items():
         for field, value in access_flags.items():
             if getattr(group, field) != value:

--- a/h/services/group.py
+++ b/h/services/group.py
@@ -72,6 +72,11 @@ class GroupService(object):
         self.user_fetcher = user_fetcher
         self.publish = publish
 
+    def get_by_pubid(self, pubid):
+        """get a single group by providing its pubid"""
+        group = self.session.query(Group).filter_by(pubid=pubid).one()
+        return group
+
     def create(self, name, authority, userid, description=None, type_='private'):
         """
         Create a new group.

--- a/h/services/group.py
+++ b/h/services/group.py
@@ -10,16 +10,20 @@ from h.models.group import JoinableBy, ReadableBy, WriteableBy
 
 GROUP_TYPES = {
     'private': {
-        'description': 'Anyone can join. Members can read/write.'
+        'description': 'Anyone can join. Members can read/write.',
+        'creator_is_immediate_member': True
     },
     'publisher': {
-        'description': 'Anyone can read. Anyone in authority can write. Intended for 3rd-party namespaces.'
+        'description': 'Anyone can read. Anyone in authority can write. Intended for 3rd-party namespaces.',
+        'creator_is_immediate_member': False
     },
     'public': {
-        'description': 'Anyone can read. Members can write. Group creator can invite members.'
+        'description': 'Anyone can read. Members can write. Group creator can invite members.',
+        'creator_is_immediate_member': True
     },
     'open': {
-        'description': 'Anyone can read. Anyone in authority can write. Intended for h namespace.'
+        'description': 'Anyone can read. Anyone in authority can write. Intended for h namespace.',
+        'creator_is_immediate_member': True
     }
 }
 
@@ -88,7 +92,7 @@ class GroupService(object):
         for attr, value in access_flags.iteritems():
             setattr(group, attr, value)
 
-        if group.joinable_by is not None:
+        if GROUP_TYPES[type_].get('creator_is_immediate_member'):
             group.members.append(creator)
 
         self.session.add(group)

--- a/h/services/group.py
+++ b/h/services/group.py
@@ -96,7 +96,7 @@ class GroupService(object):
         for attr, value in access_flags.iteritems():
             setattr(group, attr, value)
 
-        if GROUP_TYPES[type_].get('creator_is_immediate_member'):
+        if GROUP_TYPES[type_]['creator_is_immediate_member']:
             group.members.append(creator)
 
         self.session.add(group)

--- a/h/services/group.py
+++ b/h/services/group.py
@@ -52,12 +52,6 @@ def get_group_type(group, request=None):
         if not has_correct_access_flags:
             continue
         # has correct access flags for this group_type_name
-        # some group types (open/publisher) can only be discriminated based on an incomig web request
-        matches_request = GROUP_TYPES.get(
-            group_type_name, {}).get('matches_request')
-        if request and callable(matches_request):
-            if not matches_request(group, request):
-                continue
         return group_type_name
     return None
 

--- a/h/services/group.py
+++ b/h/services/group.py
@@ -13,7 +13,7 @@ GROUP_ACCESS_FLAGS = {
         'joinable_by': JoinableBy.authority,
         'readable_by': ReadableBy.members,
         'writeable_by': WriteableBy.members,
-     },
+    },
     'publisher': {
         'joinable_by': None,
         'readable_by': ReadableBy.world,
@@ -24,6 +24,11 @@ GROUP_ACCESS_FLAGS = {
         'joinable_by': None,
         'readable_by': ReadableBy.world,
         'writeable_by': WriteableBy.members,
+    },
+    'open': {
+        'joinable_by': None,
+        'readable_by': ReadableBy.world,
+        'writeable_by': WriteableBy.authority,
     }
 }
 
@@ -113,7 +118,8 @@ class GroupService(object):
         readable = (Group.readable_by == ReadableBy.world)
 
         if user is not None:
-            readable_member = sa.and_(Group.readable_by == ReadableBy.members, Group.members.any(User.id == user.id))
+            readable_member = sa.and_(
+                Group.readable_by == ReadableBy.members, Group.members.any(User.id == user.id))
             readable = sa.or_(readable, readable_member)
 
         return [record.pubid for record in self.session.query(Group.pubid).filter(readable)]

--- a/h/services/group.py
+++ b/h/services/group.py
@@ -19,19 +19,13 @@ GROUP_TYPES = {
         'description': 'Anyone can join. Members can read/write.',
         'creator_is_immediate_member': True
     },
-    'publisher': {
-        'description': 'Anyone can read. Anyone in authority can write. Intended for 3rd-party namespaces.',
-        'creator_is_immediate_member': False,
-        'matches_request': lambda group, request: not authority_is_primary_for_request(request, group.authority),
-    },
     'public': {
         'description': 'Anyone can read. Members can write. Group creator can invite members.',
         'creator_is_immediate_member': True
     },
     'open': {
-        'description': 'Anyone can read. Anyone in authority can write. Intended for h namespace.',
-        'creator_is_immediate_member': True,
-        'matches_request': lambda group, request: authority_is_primary_for_request(request, group.authority),
+        'description': 'Anyone can read. Anyone in authority can write.',
+        'creator_is_immediate_member': True
     }
 }
 
@@ -40,11 +34,6 @@ GROUP_ACCESS_FLAGS = {
         'joinable_by': JoinableBy.authority,
         'readable_by': ReadableBy.members,
         'writeable_by': WriteableBy.members,
-    },
-    'publisher': {
-        'joinable_by': None,
-        'readable_by': ReadableBy.world,
-        'writeable_by': WriteableBy.authority,
     },
     # https://docs.google.com/document/d/1tsyUGDfLLaQsa4Pmc-loHRcYCIe4Q56meery6Be6CoA/edit#heading=h.ge43xo9poyis
     'public': {

--- a/h/services/group.py
+++ b/h/services/group.py
@@ -9,11 +9,6 @@ from h.models import Annotation, Group, User
 from h.models.group import JoinableBy, ReadableBy, WriteableBy
 
 
-def authority_is_primary_for_request(request, authority):
-    """is the provided authority the one we'd consider the "hypothes.is" authority in production?"""
-    return request.domain == authority
-
-
 GROUP_TYPES = {
     'private': {
         'description': 'Anyone can join. Members can read/write.',

--- a/h/services/group.py
+++ b/h/services/group.py
@@ -52,6 +52,20 @@ GROUP_ACCESS_FLAGS = {
 }
 
 
+def get_group_type(group):
+    for group_type_name, access_flags in GROUP_ACCESS_FLAGS.items():
+        if group_type_name == 'publisher':
+            # don't label things publisher for now as it will also match on 'open'
+            # Gienin the future this function might need to look at settings and group.authority to distinguish between publisher/open
+            continue
+        for field, value in access_flags.items():
+            if getattr(group, field) != value:
+                # continue to next group_type
+                break
+            return group_type_name
+    return None
+
+
 class GroupService(object):
 
     """A service for manipulating groups and group membership."""

--- a/h/services/group.py
+++ b/h/services/group.py
@@ -8,6 +8,12 @@ from h import session
 from h.models import Annotation, Group, User
 from h.models.group import JoinableBy, ReadableBy, WriteableBy
 
+
+def authority_is_primary_for_request(request, authority):
+    """is the provided authority the one we'd consider the "hypothes.is" authority in production?"""
+    return request.domain == authority
+
+
 GROUP_TYPES = {
     'private': {
         'description': 'Anyone can join. Members can read/write.',
@@ -16,7 +22,7 @@ GROUP_TYPES = {
     'publisher': {
         'description': 'Anyone can read. Anyone in authority can write. Intended for 3rd-party namespaces.',
         'creator_is_immediate_member': False,
-        'matches_request': lambda group, request: request.domain != group.authority
+        'matches_request': lambda group, request: not authority_is_primary_for_request(request, group.authority),
     },
     'public': {
         'description': 'Anyone can read. Members can write. Group creator can invite members.',
@@ -24,7 +30,8 @@ GROUP_TYPES = {
     },
     'open': {
         'description': 'Anyone can read. Anyone in authority can write. Intended for h namespace.',
-        'creator_is_immediate_member': True
+        'creator_is_immediate_member': True,
+        'matches_request': lambda group, request: authority_is_primary_for_request(request, group.authority),
     }
 }
 

--- a/h/services/group.py
+++ b/h/services/group.py
@@ -8,6 +8,21 @@ from h import session
 from h.models import Annotation, Group, User
 from h.models.group import JoinableBy, ReadableBy, WriteableBy
 
+GROUP_TYPES = {
+    'private': {
+        'description': 'Anyone can join. Members can read/write.'
+    },
+    'publisher': {
+        'description': 'Anyone can read. Anyone in authority can write. Intended for 3rd-party namespaces.'
+    },
+    'public': {
+        'description': 'Anyone can read. Members can write. Group creator can invite members.'
+    },
+    'open': {
+        'description': 'Anyone can read. Anyone in authority can write. Intended for h namespace.'
+    }
+}
+
 GROUP_ACCESS_FLAGS = {
     'private': {
         'joinable_by': JoinableBy.authority,

--- a/h/services/group.py
+++ b/h/services/group.py
@@ -24,7 +24,7 @@ GROUP_TYPES = {
         'creator_is_immediate_member': True
     },
     'open': {
-        'description': 'Anyone can read. Anyone in authority can write.',
+        'description': 'Anyone can read. Anyone in namespace can write.',
         'creator_is_immediate_member': True
     }
 }

--- a/h/session.py
+++ b/h/session.py
@@ -87,13 +87,13 @@ def _current_groups(request, authority):
     authority_groups = (request.find_service(name='authority_group')
                         .public_groups(authority=authority))
 
-    groups = _deduplicate(
+    groups = deduplicate(
         authority_groups + _user_groups(user), lambda g: g.pubid)
 
     return [_group_model(request.route_url, group) for group in groups]
 
 
-def _deduplicate(items, get_key=lambda x: x):
+def deduplicate(items, get_key=lambda x: x):
     """
     Given a list of items, return another list that has duplicates removed.
     Where 'duplicate' means the same return value of get_key(item).

--- a/h/session.py
+++ b/h/session.py
@@ -88,7 +88,7 @@ def _current_groups(request, authority):
                         .public_groups(authority=authority))
 
     groups = _deduplicate(
-        authority_groups + _user_groups(user), lambda g: g.id)
+        authority_groups + _user_groups(user), lambda g: g.pubid)
 
     return [_group_model(request.route_url, group) for group in groups]
 

--- a/h/session.py
+++ b/h/session.py
@@ -87,9 +87,26 @@ def _current_groups(request, authority):
     authority_groups = (request.find_service(name='authority_group')
                         .public_groups(authority=authority))
 
-    groups = authority_groups + _user_groups(user)
+    groups = _deduplicate(
+        authority_groups + _user_groups(user), lambda g: g.id)
 
     return [_group_model(request.route_url, group) for group in groups]
+
+
+def _deduplicate(items, get_key=lambda x: x):
+    """
+    Given a list of items, return another list that has duplicates removed.
+    Where 'duplicate' means the same return value of get_key(item).
+    """
+    seen_keys = []
+    unique = []
+    for item in items:
+        key = get_key(item)
+        if key in seen_keys:
+            continue
+        unique.append(item)
+        seen_keys.append(key)
+    return unique
 
 
 def _user_groups(user):

--- a/h/static/styles/admin.scss
+++ b/h/static/styles/admin.scss
@@ -37,3 +37,9 @@ body {
     list-style-type: none;
   }
 }
+
+.admin-group-remove-member-form__form {
+  & .form-actions {
+    margin: 0;
+  }
+}

--- a/h/static/styles/admin.scss
+++ b/h/static/styles/admin.scss
@@ -31,3 +31,9 @@ body {
 .pager .pager__item--more {
   border: none;
 }
+
+.admin-form__form {
+  & .form-input__error-list {
+    list-style-type: none;
+  }
+}

--- a/h/static/styles/admin.scss
+++ b/h/static/styles/admin.scss
@@ -41,5 +41,9 @@ body {
 .admin-group-remove-member-form__form {
   & .form-actions {
     margin: 0;
+
+    & .u-stretch {
+      flex-grow: unset;
+    }
   }
 }

--- a/h/static/styles/partials/_form-input.scss
+++ b/h/static/styles/partials/_form-input.scss
@@ -149,6 +149,10 @@
     border-radius: 3px;
   }
 
+  select.form-input__input {
+    margin-top: $top-padding;
+  }
+
   .form-input__input.has-hint {
     .env-js-capable & {
       padding-top: $top-padding;

--- a/h/static/styles/partials/_form.scss
+++ b/h/static/styles/partials/_form.scss
@@ -31,6 +31,10 @@
   }
 }
 
+.form__errors {
+  color: $brand;
+}
+
 .form.is-editing > .form__backdrop {
   display: block;
 }

--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -272,20 +272,22 @@
       </form>
     </section>
 
-    <h3 class="group-invite__title">
-      {% trans %}Invite new members{% endtrans %}
-    </h3>
-    Sharing the link below lets people join this group:
-    <div class="group-invite__container js-copy-button">
-      <input class="group-invite__input js-select-onfocus"
-             data-ref="input"
-             value="{{ group.url }}">
-      <button class="group-invite__clipboard-button"
-              data-ref="button"
-              title="Copy to clipboard">
-        {{ svg_icon('copy_to_clipboard', 'group-invite__clipboard-image') }}
-      </button>
-    </div>
+    {% if show_invite_new_user %}
+      <h3 class="group-invite__title">
+        {% trans %}Invite new members{% endtrans %}
+      </h3>
+      Sharing the link below lets people join this group:
+      <div class="group-invite__container js-copy-button">
+        <input class="group-invite__input js-select-onfocus"
+               data-ref="input"
+               value="{{ group.url }}">
+        <button class="group-invite__clipboard-button"
+                data-ref="button"
+                title="Copy to clipboard">
+          {{ svg_icon('copy_to_clipboard', 'group-invite__clipboard-image') }}
+        </button>
+      </div>
+    {% endif %}
   {% endcall %}
 {% endmacro %}
 

--- a/h/templates/admin/group_read.html.jinja2
+++ b/h/templates/admin/group_read.html.jinja2
@@ -10,7 +10,8 @@
     <dt>authority</dt>
       <dd>{{ group.authority }}</dd>
     <dt>type</dt>
-      <dd>{{ get_group_type(group) }} - {{ get_group_type_description(get_group_type(group)) }}</dd>
+      {% set group_type = get_group_type(group) %}
+      <dd>{{ group_type }} - {{ get_group_type_description(group_type) }}</dd>
     <dt>URL</dt>
       <dd><a href="{{ group_url }}">{{ group_url }}</a></dd>
     <dt>pubid</dt>

--- a/h/templates/admin/group_read.html.jinja2
+++ b/h/templates/admin/group_read.html.jinja2
@@ -7,7 +7,7 @@
   <h2>Details</h2>
   {% set group_url = request.route_url('group_read_noslug', pubid=group.pubid) %}
   <dl>
-    <dt>authority</dt>
+    <dt>namespace/authority</dt>
       <dd>{{ group.authority }}</dd>
     <dt>type</dt>
       {% set group_type = get_group_type(group) %}

--- a/h/templates/admin/group_read.html.jinja2
+++ b/h/templates/admin/group_read.html.jinja2
@@ -1,6 +1,6 @@
 {% extends "h:templates/layouts/admin.html.jinja2" %}
 
-{% set page_id = 'group_members' %}
+{% set page_id = 'admin_group_read' %}
 {% set page_title = '{group}'.format(group=group.name) %}
 
 {% block content %}
@@ -22,6 +22,7 @@
       <dd><a href="{{ group_creator_url }}">{{ group.creator.userid }}</a></dd>
   </dl>
 
+  <a name="members"></a>
   <h2>Add Member</h2>
   {{ add_member_form }}
 
@@ -48,7 +49,7 @@
             <td>{{ user.username }}</td>
             <td><a href="mailto:{{ user.email }}">{{ user.email }}</a></td>
             <td>
-              <span class="test-TestAdminGroupMembers__remove-member">
+              <span class="test-TestAdminGroupRead__remove-member">
                 {{ remove_member_form(group, user.userid).render() }}
               </span>
             </td>

--- a/h/templates/admin/group_read.html.jinja2
+++ b/h/templates/admin/group_read.html.jinja2
@@ -24,7 +24,7 @@
 
   <a name="members"></a>
   <h2>Add Member</h2>
-  {{ add_member_form }}
+  {{ add_member_form.render() }}
 
   <h2>All Members</h2>
   <div class="table-responsive">

--- a/h/templates/admin/groups.html.jinja2
+++ b/h/templates/admin/groups.html.jinja2
@@ -5,7 +5,7 @@
 
 {% block content %}
   <p>
-    On this page you can see a list of all the groups and their details.
+    On this page you can see a list of all the groups and their details. Or <a href="{{ request.route_url('admin_groups_create') }}">click here to create a group</a>.
   </p>
 
   <div class="table-responsive">

--- a/h/templates/admin/groups.html.jinja2
+++ b/h/templates/admin/groups.html.jinja2
@@ -20,8 +20,9 @@
       </thead>
       <tbody>
         {% for group in results %}
+          {% set group_admin_url = request.route_url('admin_group_read', pubid=group.pubid, slug=group.slug) %}
           <tr>
-            <td>{{ group.name }}</td>
+            <td><a href="{{ group_admin_url }}">{{ group.name }}</a></td>
             <td>
               {% set group_url = request.route_url('group_read', pubid=group.pubid, slug=group.slug) %}
               <a href="{{ group_url }}">
@@ -36,7 +37,7 @@
               {% endif %}
             </td>
             <td>
-              <a href="{{ request.route_url('admin_group_members', pubid=group.pubid, slug=group.slug) }}">
+              <a href="{{ group_admin_url }}#members">
                 {{ group.members|length }}
               </a>
             </td>

--- a/h/templates/admin/groups.html.jinja2
+++ b/h/templates/admin/groups.html.jinja2
@@ -13,6 +13,7 @@
       <thead>
         <tr>
           <th>Name</th>
+          <th>Authority</th>
           <th>Type</th>
           <th>URL</th>
           <th>Created by</th>
@@ -24,6 +25,7 @@
           {% set group_admin_url = request.route_url('admin_group_read', pubid=group.pubid, slug=group.slug) %}
           <tr>
             <td><a href="{{ group_admin_url }}">{{ group.name }}</a></td>
+            <td>{{ group.authority }}</td>
             <td>
               <span title="{{ get_group_type_description(get_group_type(group)) }}">{{ get_group_type(group) }}</span>
             </td>

--- a/h/templates/admin/groups.html.jinja2
+++ b/h/templates/admin/groups.html.jinja2
@@ -35,7 +35,11 @@
                 </a>
               {% endif %}
             </td>
-            <td>{{ group.members|length }}</td>
+            <td>
+              <a href="{{ request.route_url('admin_group_members', pubid=group.pubid, slug=group.slug) }}">
+                {{ group.members|length }}
+              </a>
+            </td>
           </tr>
         {% endfor %}
       </tbody>

--- a/h/templates/admin/groups.html.jinja2
+++ b/h/templates/admin/groups.html.jinja2
@@ -27,7 +27,8 @@
             <td><a href="{{ group_admin_url }}">{{ group.name }}</a></td>
             <td>{{ group.authority }}</td>
             <td>
-              <span title="{{ get_group_type_description(get_group_type(group)) }}">{{ get_group_type(group) }}</span>
+              {% set group_type = get_group_type(group, request) %}
+              <span title="{{ get_group_type_description(group_type) }}">{{ group_type }}</span>
             </td>
             <td>
               {% set group_url = request.route_url('group_read', pubid=group.pubid, slug=group.slug) %}

--- a/h/templates/admin/groups.html.jinja2
+++ b/h/templates/admin/groups.html.jinja2
@@ -13,7 +13,7 @@
       <thead>
         <tr>
           <th>Name</th>
-          <th>Authority</th>
+          <th>Namespace</th>
           <th>Type</th>
           <th>URL</th>
           <th>Created by</th>

--- a/h/templates/admin/groups.html.jinja2
+++ b/h/templates/admin/groups.html.jinja2
@@ -13,6 +13,7 @@
       <thead>
         <tr>
           <th>Name</th>
+          <th>Type</th>
           <th>URL</th>
           <th>Created by</th>
           <th>Members</th>
@@ -23,6 +24,9 @@
           {% set group_admin_url = request.route_url('admin_group_read', pubid=group.pubid, slug=group.slug) %}
           <tr>
             <td><a href="{{ group_admin_url }}">{{ group.name }}</a></td>
+            <td>
+              <span title="{{ get_group_type_description(get_group_type(group)) }}">{{ get_group_type(group) }}</span>
+            </td>
             <td>
               {% set group_url = request.route_url('group_read', pubid=group.pubid, slug=group.slug) %}
               <a href="{{ group_url }}">

--- a/h/templates/admin/groups_create.html.jinja2
+++ b/h/templates/admin/groups_create.html.jinja2
@@ -1,6 +1,6 @@
 {% extends "h:templates/layouts/admin.html.jinja2" %}
 
-{% set page_id = 'groups' %}
+{% set page_id = 'groups_create' %}
 {% set page_title = 'Create a new group' %}
 
 {% block content %}
@@ -8,7 +8,6 @@
     On this page you can create a new group
   </p>
 
-  <h1 class="form-header">Create a new group</h1>
   {{ form }}
 
   <footer class="form-footer">

--- a/h/templates/admin/groups_create.html.jinja2
+++ b/h/templates/admin/groups_create.html.jinja2
@@ -1,0 +1,25 @@
+{% extends "h:templates/layouts/admin.html.jinja2" %}
+
+{% set page_id = 'groups' %}
+{% set page_title = 'Create a new group' %}
+
+{% block content %}
+  <p>
+    On this page you can create a new group
+  </p>
+
+  <h1 class="form-header">Create a new group</h1>
+  {{ form }}
+
+  <footer class="form-footer">
+    {# This form has at least one required field. If that changes we should update this footer. #}
+    <span class="form-footer__required">
+      <span class="form-footer__symbol">
+      *
+      </span>
+      <span class="form-footer__text">
+        Required
+      </span>
+    </span>
+  </footer>
+{% endblock %}

--- a/h/templates/admin/groups_members.html.jinja2
+++ b/h/templates/admin/groups_members.html.jinja2
@@ -1,0 +1,43 @@
+{% extends "h:templates/layouts/admin.html.jinja2" %}
+
+{% set page_id = 'group_members' %}
+{% set page_title = 'Group Members' %}
+
+{% block content %}
+  <h2>Add Member</h2>
+  {{ add_member_form }}
+
+  <h2>All Members</h2>
+  <div class="table-responsive">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>userid</th>
+          <th>user</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for user in results %}
+          <tr>
+            <td>{{ user.userid }}</td>
+            {% set user_url = request.route_url('activity.user_search', username=user.username) %}
+            <td><a href="{{ user_url }}">{{ user_url }}</a></td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+
+  {% include "h:templates/includes/paginator.html.jinja2" %}
+  <footer class="form-footer">
+    {# This form has at least one required field. If that changes we should update this footer. #}
+    <span class="form-footer__required">
+      <span class="form-footer__symbol">
+      *
+      </span>
+      <span class="form-footer__text">
+        Required
+      </span>
+    </span>
+  </footer>
+{% endblock %}

--- a/h/templates/admin/groups_members.html.jinja2
+++ b/h/templates/admin/groups_members.html.jinja2
@@ -18,8 +18,8 @@
       </thead>
       <tbody>
         {% for user in results %}
-          <tr>
-            <td>{{ user.userid }}</td>
+          <tr typeof="User">
+            <td property="userid">{{ user.userid }}</td>
             {% set user_url = request.route_url('activity.user_search', username=user.username) %}
             <td><a href="{{ user_url }}">{{ user_url }}</a></td>
           </tr>

--- a/h/templates/admin/groups_members.html.jinja2
+++ b/h/templates/admin/groups_members.html.jinja2
@@ -1,9 +1,27 @@
 {% extends "h:templates/layouts/admin.html.jinja2" %}
 
 {% set page_id = 'group_members' %}
-{% set page_title = 'Group Members' %}
+{% set page_title = '{group}'.format(group=group.name) %}
 
 {% block content %}
+  <h2>Details</h2>
+  {% set group_url = request.route_url('group_read_noslug', pubid=group.pubid) %}
+  <dl>
+    <dt>authority</dt>
+      <dd>{{ group.authority }}</dd>
+    <dt>type</dt>
+      <dd>{{ get_group_type(group) }} - {{ get_group_type_description(get_group_type(group)) }}</dd>
+    <dt>URL</dt>
+      <dd><a href="{{ group_url }}">{{ group_url }}</a></dd>
+    <dt>pubid</dt>
+      <dd>{{ group.pubid }}</dd>
+    <dt>id</dt>
+      <dd>{{ group.id }}</dd>
+    <dt>creator</dt>
+      {% set group_creator_url = request.route_url('activity.user_search', username=group.creator.username) %}
+      <dd><a href="{{ group_creator_url }}">{{ group.creator.userid }}</a></dd>
+  </dl>
+
   <h2>Add Member</h2>
   {{ add_member_form }}
 
@@ -13,15 +31,27 @@
       <thead>
         <tr>
           <th>userid</th>
-          <th>user</th>
+          <th>username</th>
+          <th>email</th>
+          <th>Actions</th>
         </tr>
       </thead>
       <tbody>
         {% for user in results %}
           <tr typeof="User">
-            <td property="userid">{{ user.userid }}</td>
             {% set user_url = request.route_url('activity.user_search', username=user.username) %}
-            <td><a href="{{ user_url }}">{{ user_url }}</a></td>
+            <td property="userid">
+              <a href="{{ user_url }}">
+                {{ user.userid }}
+              </a>
+            </td>
+            <td>{{ user.username }}</td>
+            <td><a href="mailto:{{ user.email }}">{{ user.email }}</a></td>
+            <td>
+              <span class="test-TestAdminGroupMembers__remove-member">
+                {{ remove_member_form(group, user.userid).render() }}
+              </span>
+            </td>
           </tr>
         {% endfor %}
       </tbody>

--- a/h/templates/deform/form.jinja2
+++ b/h/templates/deform/form.jinja2
@@ -9,6 +9,14 @@
              {%- if field.use_inline_editing %} js-form {% endif %}">
   <input type="hidden" name="__formid__" value="{{ field.formid }}" />
 
+  {% if field.error %}
+    <div class="form__errors">
+      {% for error in field.error.messages() %}
+        <p>{{ field.error.msg }}</p>
+      {% endfor %}
+    </div>
+  {% endif %}
+
   <div class="form__backdrop" data-ref="formBackdrop"></div>
 
   {%- for f in field.children -%}

--- a/h/templates/deform/select.jinja2
+++ b/h/templates/deform/select.jinja2
@@ -1,0 +1,14 @@
+<select
+{% include "includes/common_attrs.jinja2" %}
+>
+{% for value, description in field.widget.values %}
+ <option
+        {% if value == cstruct %}
+        selected="selected"
+        {% endif %}
+        {% if field.widget.css_class %}
+        class="{{ field.widget.css_class }}"
+        {% endif %}
+        value="{{ value }}">{{ description }}</option>
+{% endfor %}
+</select>

--- a/h/templates/help.html.jinja2
+++ b/h/templates/help.html.jinja2
@@ -8,7 +8,8 @@
   <script type="application/json" class="js-hypothesis-config">
     {
       "openSidebar": true,
-      "openLoginForm": true
+      "openLoginForm": true,
+      "pageGroups": ["http://h.hypothesis:5000/groups/MGkYz9j2/http-test-localhost"]
     }
   </script>
   {% if not is_onboarding %}

--- a/h/templates/help.html.jinja2
+++ b/h/templates/help.html.jinja2
@@ -8,8 +8,7 @@
   <script type="application/json" class="js-hypothesis-config">
     {
       "openSidebar": true,
-      "openLoginForm": true,
-      "pageGroups": ["http://h.hypothesis:5000/groups/MGkYz9j2/http-test-localhost"]
+      "openLoginForm": true
     }
   </script>
   {% if not is_onboarding %}

--- a/h/templates/layouts/admin.html.jinja2
+++ b/h/templates/layouts/admin.html.jinja2
@@ -7,7 +7,10 @@
       ('features', 'admin_features', 'Manage feature flags'),
       ('cohorts', 'admin_cohorts', 'Manage feature cohorts'),
     ]),
-    ('groups', 'admin_groups', 'Groups', []),
+    ('groups', 'admin_groups', 'Groups', [
+      ('groups', 'admin_groups', 'List Groups',),
+      ('groups_create', 'admin_groups_create', 'Create Group',),
+    ]),
     ('mailer', 'admin_mailer', 'Mailer', []),
     ('nipsa', 'admin_nipsa', 'NIPSA', []),
     ('oauth', 'admin_oauthclients', 'OAuth clients', []),

--- a/h/views/accounts.py
+++ b/h/views/accounts.py
@@ -494,7 +494,7 @@ class AccountController(object):
         svc = self.request.find_service(name='user_password')
         svc.update_password(self.request.user, appstruct['new_password'])
 
-    def _template_data(self):
+    def _template_data(self, **kwargs):
         """Return the data needed to render accounts.html.jinja2."""
         email = self.request.user.email
         password_form = self.forms['password'].render()
@@ -538,7 +538,7 @@ class EditProfileController(object):
             on_success=self._update_user,
             on_failure=self._template_data)
 
-    def _template_data(self):
+    def _template_data(self, **kwargs):
         return {'form': self.form.render()}
 
     def _update_user(self, appstruct):
@@ -585,7 +585,7 @@ class NotificationsController(object):
         for n in self._user_notifications():
             n.active = n.type in appstruct['notifications']
 
-    def _template_data(self):
+    def _template_data(self, **kwargs):
         return {'form': self.form.render()}
 
     def _user_notifications(self):

--- a/h/views/activity.py
+++ b/h/views/activity.py
@@ -106,6 +106,7 @@ class GroupSearchController(SearchController):
 
         result = super(GroupSearchController, self).search()
 
+        result['show_invite_new_user'] = bool(self.group.joinable_by)
         result['opts'] = {'search_groupname': self.group.name}
 
         if self.request.user not in self.group.members:
@@ -118,7 +119,8 @@ class GroupSearchController(SearchController):
             return 0
 
         q = query.extract(self.request)
-        users_aggregation = result['search_results'].aggregations.get('users', [])
+        users_aggregation = result['search_results'].aggregations.get(
+            'users', [])
         members = [{'username': u.username,
                     'userid': u.userid,
                     'count': user_annotation_count(users_aggregation,

--- a/h/views/admin_groups.py
+++ b/h/views/admin_groups.py
@@ -5,7 +5,6 @@ import re
 
 from pyramid import httpexceptions
 from pyramid import security
-from pyramid.config import not_
 from pyramid.view import view_config, view_defaults
 from sqlalchemy import or_
 
@@ -146,6 +145,7 @@ class CSVScalarWidget(deform.widget.TextAreaCSVWidget):
     This is a little different in that its for a sequence of scalars (like
     strings), and you can put multiple items in the sequence on the same line.
     """
+
     def _split(self, values_string):
         """Split the textarea input into a list of scalar values"""
         return re.split('[,\n ]', values_string)
@@ -348,8 +348,13 @@ class AdminGroupReadController(object):
                     groups_service.member_join(group, user.userid)
                     return user
                 added_users = map(add_user, users)
-                self.request.session.flash('Added {user} to group'.format(user=added_users[0].username if len(added_users) == 1 else '{num} users'.format(num=len(added_users))),
-                                           queue='success')
+                self.request.session.flash(
+                    'Added {user} to group'.format(
+                        user=added_users[0].username
+                        if len(added_users) == 1
+                        else '{num} users'.format(um=len(added_users))),
+                    queue='success'
+                )
                 return httpexceptions.HTTPSeeOther(self.request.url)
             elif isinstance(form_for_formid.schema, RemoveMemberSchema):
                 # remove user from group

--- a/h/views/admin_groups.py
+++ b/h/views/admin_groups.py
@@ -25,13 +25,20 @@ _ = i18n.TranslationString
 admin_form_class = 'admin-form__form'
 
 
+def _get_group_type_description(
+    group_type): return GROUP_TYPES[group_type]['description']
+
+
 @view_config(route_name='admin_groups',
              request_method='GET',
              renderer='h:templates/admin/groups.html.jinja2',
              permission='admin_groups')
-@paginator.paginate_query
 def groups_index(context, request):
-    return request.db.query(models.Group).order_by(models.Group.created.desc())
+    context = dict(get_group_type=get_group_type,
+                   get_group_type_description=_get_group_type_description,)
+    context.update(**paginator.paginate_query(lambda group, request: request.db.query(
+        models.Group).order_by(models.Group.created.desc()))(context, request))
+    return context
 
 
 @view_defaults(route_name='admin_groups_create',
@@ -167,8 +174,7 @@ class AdminGroupReadController(object):
         context = get_paging_context(self.request.context, self.request)
         context.update(dict(group=self.request.context,
                             get_group_type=get_group_type,
-                            get_group_type_description=lambda group_type: GROUP_TYPES[
-                                group_type]['description'],
+                            get_group_type_description=_get_group_type_description,
                             add_member_form=add_member_form or self._create_add_member_form(),
                             remove_member_form=self._create_remove_member_form,))
         return context

--- a/h/views/admin_groups.py
+++ b/h/views/admin_groups.py
@@ -53,7 +53,7 @@ def admin_group_create_schema():
     schema = schemas.group_schema()
     schema.add(colander.SchemaNode(colander.String(),
                                    name='authority',
-                                   title=_("Authority"),
+                                   title=_("Namespace"),
                                    ))
     schema.add(colander.SchemaNode(colander.String(),
                                    name='group_type',

--- a/h/views/admin_groups.py
+++ b/h/views/admin_groups.py
@@ -20,6 +20,8 @@ from jinja2 import Markup
 
 _ = i18n.TranslationString
 
+admin_form_class = 'admin-form__form'
+
 
 @view_config(route_name='admin_groups',
              request_method='GET',
@@ -51,7 +53,8 @@ class AdminGroupCreateController(object):
                                          'js-create-group-create-btn')
         self.form = request.create_form(self.schema,
                                         formid='admin-group-create-form',
-                                        css_class='admin-group-create-form__form',
+                                        css_class=' '.join(
+                                            [admin_form_class, 'admin-group-create-form__form']),
                                         buttons=(submit,))
 
     @view_config(request_method='GET')
@@ -108,7 +111,8 @@ class AdminGroupMembersController(object):
                                         appstruct=dict(
                                             pubid=self.request.context.pubid),
                                         formid='admin-group-add-member-form',
-                                        css_class='admin-group-add-member-form__form',
+                                        css_class=' '.join(
+                                            [admin_form_class, 'admin-group-add-member-form__form']),
                                         buttons=(deform.Button(
                                             title=_(
                                                 'Add Member to Group'),

--- a/h/views/admin_groups.py
+++ b/h/views/admin_groups.py
@@ -352,7 +352,7 @@ class AdminGroupReadController(object):
                     'Added {user} to group'.format(
                         user=added_users[0].username
                         if len(added_users) == 1
-                        else '{num} users'.format(um=len(added_users))),
+                        else '{num} users'.format(num=len(added_users))),
                     queue='success'
                 )
                 return httpexceptions.HTTPSeeOther(self.request.url)

--- a/h/views/admin_groups.py
+++ b/h/views/admin_groups.py
@@ -97,8 +97,8 @@ class AdminGroupCreateController(object):
         return {'form': self.form.render()}
 
 
-@view_defaults(route_name='admin_group_members',
-               renderer='h:templates/admin/groups_members.html.jinja2',
+@view_defaults(route_name='admin_group_read',
+               renderer='h:templates/admin/group_read.html.jinja2',
                permission='admin_groups',
                effective_principals=security.Authenticated)
 class AdminGroupMembersController(object):
@@ -174,7 +174,7 @@ class AdminGroupMembersController(object):
         group_filters = dict([field, form_values[field]] for field in (
             'username', 'email') if form_values.get(field))
         user = self.request.db.query(User).filter(or_(
-            *[getattr(User, field) == form_values for [field, form_values] in group_filters.items()])).one()
+            *[getattr(User, field) == form_values for [field, form_values] in group_filters.items()])).first()
         return user
 
     def _remove_member_formid(self):

--- a/h/views/admin_groups.py
+++ b/h/views/admin_groups.py
@@ -1,9 +1,18 @@
 # -*- coding: utf-8 -*-
+import deform
 
-from pyramid.view import view_config
+from pyramid import httpexceptions
+from pyramid import security
+from pyramid.config import not_
+from pyramid.view import view_config, view_defaults
 
+from h import form
+from h import i18n
 from h import models
 from h import paginator
+from h.groups import schemas
+
+_ = i18n.TranslationString
 
 
 @view_config(route_name='admin_groups',
@@ -13,3 +22,59 @@ from h import paginator
 @paginator.paginate_query
 def groups_index(context, request):
     return request.db.query(models.Group).order_by(models.Group.created.desc())
+
+
+@view_defaults(route_name='admin_groups_create',
+               renderer='h:templates/admin/groups_create.html.jinja2',
+               permission='admin_groups',
+               effective_principals=security.Authenticated)
+class AdminGroupCreateController(object):
+    """
+    Controller for feature that lets user create a new group
+    """
+
+    def __init__(self, request):
+        self.request = request
+
+        self.schema = schemas.admin_group_create_schema().bind(
+            request=self.request)
+
+        submit = deform.Button(title=_('Create a new group'),
+                               css_class='primary-action-btn '
+                                         'admin-group-create-form__submit-btn '
+                                         'js-create-group-create-btn')
+        self.form = request.create_form(self.schema,
+                                        formid='admin-group-create-form',
+                                        css_class='admin-group-create-form__form',
+                                        buttons=(submit,))
+
+    @view_config(request_method='GET')
+    def get(self):
+        """Render the form for creating a new group."""
+        return self._template_data()
+
+    @view_config(request_method='POST')
+    def post(self):
+        """Respond to a submission of the create group form."""
+        def on_success(appstruct):
+            groups_service = self.request.find_service(name='group')
+            group = groups_service.create(
+                name=appstruct['name'],
+                authority=self.request.authority,
+                description=appstruct.get('description'),
+                userid=self.request.authenticated_userid)
+
+            url = self.request.route_path('group_read',
+                                          pubid=group.pubid,
+                                          slug=group.slug)
+            return httpexceptions.HTTPSeeOther(url)
+
+        return form.handle_form_submission(
+            self.request,
+            self.form,
+            on_success=on_success,
+            on_failure=self._template_data)
+
+    def _template_data(self):
+        """Return the data needed to render this controller's page."""
+        return {'form': self.form.render()}

--- a/h/views/admin_groups.py
+++ b/h/views/admin_groups.py
@@ -109,7 +109,7 @@ class AdminGroupCreateController(object):
             groups_service = self.request.find_service(name='group')
             group = groups_service.create(
                 name=form_data['name'],
-                authority=self.request.authority,
+                authority=form_data['authority'],
                 description=form_data.get('description'),
                 userid=self.request.authenticated_userid,
                 type_=form_data['group_type'])

--- a/h/views/admin_groups.py
+++ b/h/views/admin_groups.py
@@ -12,6 +12,8 @@ from h import models
 from h import paginator
 from h.groups import schemas
 
+from jinja2 import Markup
+
 _ = i18n.TranslationString
 
 
@@ -62,18 +64,25 @@ class AdminGroupCreateController(object):
                 name=appstruct['name'],
                 authority=self.request.authority,
                 description=appstruct.get('description'),
-                userid=self.request.authenticated_userid)
+                userid=self.request.authenticated_userid,
+                type_=appstruct['group_type'])
+            group_url = self.request.route_path('group_read',
+                                                pubid=group.pubid,
+                                                slug=group.slug)
+            self.request.session.flash(Markup(
+                'Group Created <a href="{url}">{url}</a>'.format(url=group_url)), queue='success')
+            return httpexceptions.HTTPSeeOther(self.request.url)
 
-            url = self.request.route_path('group_read',
-                                          pubid=group.pubid,
-                                          slug=group.slug)
-            return httpexceptions.HTTPSeeOther(url)
+        def on_failure(exception):
+            print "on_failure", exception
+            return self._template_data()
 
         return form.handle_form_submission(
             self.request,
             self.form,
             on_success=on_success,
-            on_failure=self._template_data)
+            on_failure=on_failure,
+            flash=False)
 
     def _template_data(self):
         """Return the data needed to render this controller's page."""

--- a/h/views/api.py
+++ b/h/views/api.py
@@ -46,7 +46,7 @@ def index(context, request):
     # parameter names are added, we'll need to add them here, or this view will
     # break (and get caught by the `test_api_index` functional test).
     templater = AngularRouteTemplater(request.route_url,
-                                      params=['id', 'pubid', 'user'])
+                                      params=['id', 'pubid', 'user', 'slug'])
 
     links = {}
     for link in api_links:

--- a/h/views/api_groups.py
+++ b/h/views/api_groups.py
@@ -34,8 +34,7 @@ def remove_member(group, request):
             description='Read a Group',
             renderer='json')
 def get_group(group, request):
-    return dict((f, getattr(group, f, None)) for f in ('pubid', 'description', 'name'))
-
+    return dict([(f, getattr(group, f, None)) for f in ('description', 'name')], id=group.pubid)
 
 @api_config(route_name='api.group_read_noslug',
             link_name='group.read',

--- a/h/views/api_groups.py
+++ b/h/views/api_groups.py
@@ -36,6 +36,7 @@ def remove_member(group, request):
 def get_group(group, request):
     return dict([(f, getattr(group, f, None)) for f in ('description', 'name')], id=group.pubid)
 
+
 @api_config(route_name='api.group_read_noslug',
             link_name='group.read',
             request_method='GET',

--- a/h/views/api_groups.py
+++ b/h/views/api_groups.py
@@ -3,7 +3,7 @@
 from __future__ import unicode_literals
 
 from pyramid import security
-from pyramid.httpexceptions import HTTPNoContent, HTTPBadRequest
+from pyramid.httpexceptions import HTTPNoContent, HTTPBadRequest, HTTPMovedPermanently
 
 from h.views.api import api_config
 from h.views.api_config import cors_policy
@@ -50,4 +50,4 @@ def redirect_to_with_slug(group, request):
     if slug is None or slug != group.slug:
         path = request.route_path(
             'api.group_read', pubid=group.pubid, slug=group.slug)
-        raise httpexceptions.HTTPMovedPermanently(path)
+        raise HTTPMovedPermanently(path)

--- a/h/views/groups.py
+++ b/h/views/groups.py
@@ -127,9 +127,8 @@ def read_unauthenticated(group, request):
              request_method='GET',
              accept='application/json',
              renderer='json',
-             effective_principals=not_(security.Authenticated),
              decorator=cors_policy)
-def read_unauthenticated_json(group, request):
+def read_group_json(group, request):
     """If the end-user wants json, redirect to the API"""
     if not group:
         raise HTTPNotFound()

--- a/h/views/groups.py
+++ b/h/views/groups.py
@@ -40,7 +40,6 @@ class GroupCreateController(object):
     def post(self):
         """Respond to a submission of the create group form."""
         def on_success(appstruct):
-            print 'form post appstruct', appstruct
             groups_service = self.request.find_service(name='group')
             group = groups_service.create(
                 name=appstruct['name'],

--- a/h/views/groups.py
+++ b/h/views/groups.py
@@ -28,7 +28,7 @@ class GroupCreateController(object):
                                          'group-form__submit-btn '
                                          'js-create-group-create-btn')
         self.form = request.create_form(self.schema,
-                                        css_class='group-form__form',
+                                        css_class='admin-create-group-form__form',
                                         buttons=(submit,))
 
     @view_config(request_method='GET')
@@ -40,6 +40,7 @@ class GroupCreateController(object):
     def post(self):
         """Respond to a submission of the create group form."""
         def on_success(appstruct):
+            print 'form post appstruct', appstruct
             groups_service = self.request.find_service(name='group')
             group = groups_service.create(
                 name=appstruct['name'],
@@ -87,10 +88,10 @@ class GroupEditController(object):
     @view_config(request_method='POST')
     def post(self):
         return form.handle_form_submission(
-                self.request,
-                self.form,
-                on_success=self._update_group,
-                on_failure=self._template_data)
+            self.request,
+            self.form,
+            on_success=self._update_group,
+            on_failure=self._template_data)
 
     def _template_data(self):
         return {
@@ -128,5 +129,6 @@ def check_slug(group, request):
     """Redirect if the request slug does not match that of the group."""
     slug = request.matchdict.get('slug')
     if slug is None or slug != group.slug:
-        path = request.route_path('group_read', pubid=group.pubid, slug=group.slug)
+        path = request.route_path(
+            'group_read', pubid=group.pubid, slug=group.slug)
         raise httpexceptions.HTTPMovedPermanently(path)

--- a/h/views/groups.py
+++ b/h/views/groups.py
@@ -4,6 +4,7 @@ import deform
 from pyramid import httpexceptions
 from pyramid import security
 from pyramid.config import not_
+from pyramid.exceptions import HTTPNotFound
 from pyramid.view import view_config, view_defaults
 
 from h import form
@@ -130,6 +131,8 @@ def read_unauthenticated(group, request):
              decorator=cors_policy)
 def read_unauthenticated_json(group, request):
     """If the end-user wants json, redirect to the API"""
+    if not group:
+        raise HTTPNotFound()
     url = request.route_path('api.group_read',
                              pubid=group.pubid,
                              slug=group.slug)
@@ -155,4 +158,4 @@ def check_slug(group, request):
     if slug is None or slug != group.slug:
         path = request.route_path(
             'group_read', pubid=group.pubid, slug=group.slug)
-        return httpexceptions.HTTPMovedPermanently(path)
+        raise httpexceptions.HTTPMovedPermanently(path)

--- a/tests/functional/test_admin_groups.py
+++ b/tests/functional/test_admin_groups.py
@@ -68,6 +68,18 @@ class TestAdminGroupMembers(object):
         add_member_form['email'] = user_to_add.email
         form_submit_res = add_member_form.submit().follow()
 
+    def test_cant_add_by_both_username_and_email(self, app, admin_user_and_password, group, user_to_add):
+        admin_user, admin_user_password = admin_user_and_password
+        app = _login(app, admin_user.username, admin_user_password)
+        admin_group_members_url = '/admin/groups/{pubid}/{slug}/members/'.format(
+            pubid=group.pubid, slug=group.slug)
+        res = app.get(admin_group_members_url)
+        add_member_form = res.forms['admin-group-add-member-form']
+        add_member_form['email'] = user_to_add.email
+        add_member_form['username'] = user_to_add.username
+        form_submit_res = add_member_form.submit(expect_errors=True)
+        assert form_submit_res.status_code == 400
+
     @pytest.fixture
     def group(self, db_session, factories):
         group = factories.Group(

--- a/tests/functional/test_admin_groups.py
+++ b/tests/functional/test_admin_groups.py
@@ -44,6 +44,13 @@ def admin_user_and_password(db_session, factories):
     return (user, password)
 
 
+def _members_res_has_user(res, user):
+    all_member_els = res.html.select('[typeof=User]')
+    member_el = filter(lambda e: e.select_one(
+        '[property=userid]').text == user.userid, all_member_els)
+    return member_el
+
+
 @pytest.mark.functional
 class TestAdminGroupMembers(object):
     """Tests for the /admin/groups/{pubid}/{slug}/members page."""
@@ -51,34 +58,36 @@ class TestAdminGroupMembers(object):
     def test_can_add_member_by_username(self, app, admin_user_and_password, group, user_to_add):
         admin_user, admin_user_password = admin_user_and_password
         app = _login(app, admin_user.username, admin_user_password)
-        admin_group_members_url = '/admin/groups/{pubid}/{slug}/members/'.format(
-            pubid=group.pubid, slug=group.slug)
-        res = app.get(admin_group_members_url)
-        add_member_form = res.forms['admin-group-add-member-form']
-        add_member_form['username'] = user_to_add.username
-        form_submit_res = add_member_form.submit().follow()
+        form_submit_res = _add_member(
+            app, user_to_add, group, auth_with_fields=('username',))
+        members_res = form_submit_res.follow()
+        assert _members_res_has_user(members_res, user_to_add)
 
     def test_can_add_member_by_email(self, app, admin_user_and_password, group, user_to_add):
         admin_user, admin_user_password = admin_user_and_password
         app = _login(app, admin_user.username, admin_user_password)
-        admin_group_members_url = '/admin/groups/{pubid}/{slug}/members/'.format(
-            pubid=group.pubid, slug=group.slug)
-        res = app.get(admin_group_members_url)
-        add_member_form = res.forms['admin-group-add-member-form']
-        add_member_form['email'] = user_to_add.email
-        form_submit_res = add_member_form.submit().follow()
+        form_submit_res = _add_member(
+            app, user_to_add, group, auth_with_fields=('email',))
+        members_res = form_submit_res.follow()
+        assert _members_res_has_user(members_res, user_to_add)
 
     def test_cant_add_by_both_username_and_email(self, app, admin_user_and_password, group, user_to_add):
         admin_user, admin_user_password = admin_user_and_password
         app = _login(app, admin_user.username, admin_user_password)
-        admin_group_members_url = '/admin/groups/{pubid}/{slug}/members/'.format(
-            pubid=group.pubid, slug=group.slug)
-        res = app.get(admin_group_members_url)
-        add_member_form = res.forms['admin-group-add-member-form']
-        add_member_form['email'] = user_to_add.email
-        add_member_form['username'] = user_to_add.username
-        form_submit_res = add_member_form.submit(expect_errors=True)
+        form_submit_res = _add_member(app, user_to_add, group, auth_with_fields=(
+            'email', 'username'), expect_errors=True)
         assert form_submit_res.status_code == 400
+        assert not _members_res_has_user(form_submit_res, user_to_add)
+
+    def test_can_remove_member(self, app, admin_user_and_password, group, member):
+        admin_user, admin_user_password = admin_user_and_password
+        app = _login(app, admin_user.username, admin_user_password)
+        res = app.get(
+            '/admin/groups/{pubid}/{slug}/members/'.format(pubid=group.pubid, slug=group.slug))
+        all_member_els = res.html.select('[typeof=User]')
+        member_el = filter(lambda e: e.select_one(
+            '[property=userid]').text == member.userid, all_member_els)
+        assert member_el
 
     @pytest.fixture
     def group(self, db_session, factories):
@@ -93,3 +102,27 @@ class TestAdminGroupMembers(object):
             username='member', authority=authority, email='member@email.com')
         db_session.commit()
         return user
+
+    @pytest.fixture
+    def member(self, app, admin_user_and_password, group, user_to_add):
+        admin_user, admin_user_password = admin_user_and_password
+        app = _login(app, admin_user.username, admin_user_password)
+        _add_member(app, user_to_add, group)
+        member = user_to_add
+        _logout(app)
+        return member
+
+
+def _logout(app):
+    app.get('/logout')
+
+
+def _add_member(app, user_to_add, group, auth_with_fields=('email',), expect_errors=False):
+    admin_group_members_url = '/admin/groups/{pubid}/{slug}/members/'.format(
+        pubid=group.pubid, slug=group.slug)
+    res = app.get(admin_group_members_url)
+    add_member_form = res.forms['admin-group-add-member-form']
+    for field in auth_with_fields:
+        add_member_form[field] = getattr(user_to_add, field)
+    form_submit_res = add_member_form.submit(expect_errors=expect_errors)
+    return form_submit_res

--- a/tests/functional/test_admin_groups.py
+++ b/tests/functional/test_admin_groups.py
@@ -60,7 +60,9 @@ def _group_read_res_has_user(res, user):
 
 @pytest.mark.functional
 class TestAdminGroupRead(object):
-    """Tests for the /admin/groups/{pubid}/{slug}/members page."""
+    """
+    Tests for the /admin/groups/{pubid}/{slug}/members page.
+    """
 
     def test_cant_add_no_one(self, app, admin_user_and_password, group):
         admin_user, admin_user_password = admin_user_and_password
@@ -138,6 +140,14 @@ class TestAdminGroupRead(object):
         remove_member_res = remove_member_form.submit()
         group_read_res = remove_member_res.follow()
         assert not _group_read_res_has_user(group_read_res, member)
+
+    def test_cant_add_user_from_other_authority(self, app, admin_user_and_password, group, create_user):
+        admin_user, admin_user_password = admin_user_and_password
+        app = _login(app, admin_user.username, admin_user_password)
+        authority_b_user = create_user(authority='bengo.is')
+        form_submit_res = _add_members(
+            app, authority_b_user.email, group, expect_errors=True)
+        assert form_submit_res.status_code == 400
 
     @pytest.fixture
     def group(self, db_session, factories):

--- a/tests/functional/test_admin_groups.py
+++ b/tests/functional/test_admin_groups.py
@@ -7,18 +7,18 @@ import pytest
 
 @pytest.mark.functional
 class TestAdminGroupCreate(object):
-    """Tests for the /account/settings page."""
+    """Tests for the /admin/groups/create page."""
 
     def test_can_create_group(self, app, admin_user_and_password):
         admin_user, admin_user_password = admin_user_and_password
         app = self._login(app, admin_user.username, admin_user_password)
         res = app.get('/admin/groups/create')
         create_group_form = res.forms['admin-group-create-form']
-        create_group_form['name'] = 'Public Group From TestAdminGroupCreate'
+        create_group_form['name'] = 'Public Group for Test'
         create_group_form['description'] = 'description of awesome group'
         create_group_form['group_type'].select('public')
         form_submit_res = create_group_form.submit().follow()
-        # assert res.text.startswith('<!DOCTYPE html>')
+        assert form_submit_res.text.startswith('<!DOCTYPE html>')
 
     def _login(self, app, username, password):
         res = app.get('/login')

--- a/tests/functional/test_admin_groups.py
+++ b/tests/functional/test_admin_groups.py
@@ -48,7 +48,7 @@ def admin_user_and_password(db_session, factories):
 class TestAdminGroupMembers(object):
     """Tests for the /admin/groups/{pubid}/{slug}/members page."""
 
-    def test_can_add_member(self, app, admin_user_and_password, group, user_to_add):
+    def test_can_add_member_by_username(self, app, admin_user_and_password, group, user_to_add):
         admin_user, admin_user_password = admin_user_and_password
         app = _login(app, admin_user.username, admin_user_password)
         admin_group_members_url = '/admin/groups/{pubid}/{slug}/members/'.format(
@@ -56,11 +56,17 @@ class TestAdminGroupMembers(object):
         res = app.get(admin_group_members_url)
         add_member_form = res.forms['admin-group-add-member-form']
         add_member_form['username'] = user_to_add.username
-        # add_member_form['name'] = 'Public Group for Test'
-        # add_member_form['description'] = 'description of awesome group'
-        # add_member_form['group_type'].select(group_type)
         form_submit_res = add_member_form.submit().follow()
-        # assert form_submit_res.text.startswith('<!DOCTYPE html>')
+
+    def test_can_add_member_by_email(self, app, admin_user_and_password, group, user_to_add):
+        admin_user, admin_user_password = admin_user_and_password
+        app = _login(app, admin_user.username, admin_user_password)
+        admin_group_members_url = '/admin/groups/{pubid}/{slug}/members/'.format(
+            pubid=group.pubid, slug=group.slug)
+        res = app.get(admin_group_members_url)
+        add_member_form = res.forms['admin-group-add-member-form']
+        add_member_form['email'] = user_to_add.email
+        form_submit_res = add_member_form.submit().follow()
 
     @pytest.fixture
     def group(self, db_session, factories):
@@ -71,6 +77,7 @@ class TestAdminGroupMembers(object):
 
     @pytest.fixture
     def user_to_add(self, db_session, factories):
-        user = factories.User(username='member', authority=authority)
+        user = factories.User(
+            username='member', authority=authority, email='member@email.com')
         db_session.commit()
         return user

--- a/tests/functional/test_admin_groups.py
+++ b/tests/functional/test_admin_groups.py
@@ -4,19 +4,22 @@ from __future__ import unicode_literals
 
 import pytest
 
+from h.services.group import GROUP_TYPES
+
 
 @pytest.mark.functional
 class TestAdminGroupCreate(object):
     """Tests for the /admin/groups/create page."""
 
-    def test_can_create_group(self, app, admin_user_and_password):
+    @pytest.mark.parametrize('group_type', GROUP_TYPES.keys())
+    def test_can_create_group(self, app, admin_user_and_password, group_type):
         admin_user, admin_user_password = admin_user_and_password
         app = self._login(app, admin_user.username, admin_user_password)
         res = app.get('/admin/groups/create')
         create_group_form = res.forms['admin-group-create-form']
         create_group_form['name'] = 'Public Group for Test'
         create_group_form['description'] = 'description of awesome group'
-        create_group_form['group_type'].select('public')
+        create_group_form['group_type'].select(group_type)
         form_submit_res = create_group_form.submit().follow()
         assert form_submit_res.text.startswith('<!DOCTYPE html>')
 

--- a/tests/functional/test_admin_groups.py
+++ b/tests/functional/test_admin_groups.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import pytest
+
+
+@pytest.mark.functional
+class TestAdminGroupCreate(object):
+    """Tests for the /account/settings page."""
+
+    def test_can_create_group(self, app, admin_user_and_password):
+        admin_user, admin_user_password = admin_user_and_password
+        app = self._login(app, admin_user.username, admin_user_password)
+        res = app.get('/admin/groups/create')
+        create_group_form = res.forms['admin-group-create-form']
+        create_group_form['name'] = 'Public Group From TestAdminGroupCreate'
+        create_group_form['description'] = 'description of awesome group'
+        create_group_form['group_type'].select('public')
+        form_submit_res = create_group_form.submit().follow()
+        # assert res.text.startswith('<!DOCTYPE html>')
+
+    def _login(self, app, username, password):
+        res = app.get('/login')
+        res.form['username'] = username
+        res.form['password'] = password
+        res.form.submit()
+        return app
+
+    @pytest.fixture
+    def admin_user_and_password(self, db_session, factories):
+        # Password is 'pass'
+        password = 'pass'
+        user = factories.User(admin=True, username='admin',
+                              password='$2b$12$21I1LjTlGJmLXzTDrQA8gusckjHEMepTmLY5WN3Kx8hSaqEEKj9V6')
+        db_session.commit()
+        return (user, password)

--- a/tests/functional/test_admin_groups.py
+++ b/tests/functional/test_admin_groups.py
@@ -13,7 +13,7 @@ DEFAULT_AUTHORITY = 'example.com'
 
 
 def randomstr(n): return ''.join(
-    [random.choice(string.lowercase) for i in xrange(n)])
+    [random.choice(string.lowercase) for i in range(n)])
 
 
 @pytest.mark.functional
@@ -124,7 +124,7 @@ class TestAdminGroupRead(object):
     def test_can_remove_member(self, app, admin_user_and_password, group, user_to_add):
         admin_user, admin_user_password = admin_user_and_password
         app = _login(app, admin_user.username, admin_user_password)
-        add_member_res = _add_members(app, user_to_add.username, group)
+        _add_members(app, user_to_add.username, group)
         member = user_to_add
         res = app.get(
             '/admin/groups/{pubid}/{slug}/'.format(pubid=group.pubid, slug=group.slug))
@@ -136,7 +136,7 @@ class TestAdminGroupRead(object):
             '.test-TestAdminGroupRead__remove-member')
         assert remove_member_el
         remove_member_form_el = remove_member_el.select_one('form')
-        remove_member_form = Form(res, unicode(remove_member_form_el))
+        remove_member_form = Form(res, str(remove_member_form_el))
         remove_member_res = remove_member_form.submit()
         group_read_res = remove_member_res.follow()
         assert not _group_read_res_has_user(group_read_res, member)
@@ -165,8 +165,8 @@ class TestAdminGroupRead(object):
         def create_user(*args, **kwargs):
             kwargs = kwargs.copy()
             username = kwargs.setdefault('username', randomstr(16))
-            authority = kwargs.setdefault('authority', DEFAULT_AUTHORITY)
-            email = kwargs.setdefault(
+            kwargs.setdefault('authority', DEFAULT_AUTHORITY)
+            kwargs.setdefault(
                 'email', '{username}@email.com'.format(username=username))
             user = factories.User(**kwargs)
             db_session.commit()

--- a/tests/functional/test_group_api.py
+++ b/tests/functional/test_group_api.py
@@ -8,6 +8,12 @@ import pytest
 @pytest.mark.functional
 class TestGroupAPI(object):
 
+    def test_get_group(self, app, group):
+        headers = dict()
+        response = app.get('/api/groups/{}'.format(group.pubid),
+                           headers=headers).maybe_follow()
+        assert response.json.get('id')
+
     def test_leave_group(self, app, group, group_member_with_token):
         """Test a request to leave a group through the API."""
 

--- a/tests/functional/test_group_api.py
+++ b/tests/functional/test_group_api.py
@@ -10,9 +10,16 @@ class TestGroupAPI(object):
 
     def test_get_group(self, app, group):
         headers = dict()
+        response = app.get('/api/groups/{}/{}'.format(group.pubid, group.slug),
+                           headers=headers).maybe_follow()
+        assert response.json.get('id')
+
+    def test_read_noslug(self, app, group):
+        headers = dict()
         response = app.get('/api/groups/{}'.format(group.pubid),
                            headers=headers).maybe_follow()
         assert response.json.get('id')
+
 
     def test_leave_group(self, app, group, group_member_with_token):
         """Test a request to leave a group through the API."""
@@ -31,7 +38,7 @@ class TestGroupAPI(object):
 
 @pytest.fixture
 def group(db_session, factories):
-    group = factories.Group()
+    group = factories.Group(name='group-fixture', description='group-fixture description')
     db_session.commit()
     return group
 

--- a/tests/h/cli/commands/groups_test.py
+++ b/tests/h/cli/commands/groups_test.py
@@ -84,9 +84,9 @@ class TestJoinCommand(object):
         db_session.commit()
 
         result = cli.invoke(groups_cli.join,
-                            [u'--user', username_of_user_to_add,
+                            [u'--user', user_to_add.username,
                              u'--authority', authority,
-                             u'--group', pubid],
+                             u'--group', group.pubid],
                             obj=cliconfig)
 
         assert result.exit_code == 0

--- a/tests/h/cli/commands/groups_test.py
+++ b/tests/h/cli/commands/groups_test.py
@@ -35,8 +35,27 @@ class TestAddCommand(object):
 
         group_service.create.assert_called_with(authority=authority,
                                                 name=name,
-                                                userid='acct:{0}@{1}'.format(creator, authority),
+                                                userid='acct:{0}@{1}'.format(
+                                                    creator, authority),
                                                 type_='public')
+
+    def test_it_creates_a_open_group(self, cli, cliconfig, group_service):
+        name = 'Open Group Name'
+        creator = 'admin'
+        authority = 'publisher.org'
+        result = cli.invoke(groups_cli.add_open_group,
+                            [u'--name', name,
+                             u'--authority', authority,
+                             u'--creator', creator],
+                            obj=cliconfig)
+
+        assert result.exit_code == 0
+
+        group_service.create.assert_called_with(authority=authority,
+                                                name=name,
+                                                userid='acct:{0}@{1}'.format(
+                                                    creator, authority),
+                                                type_='open')
 
 
 @pytest.fixture

--- a/tests/h/cli/commands/groups_test.py
+++ b/tests/h/cli/commands/groups_test.py
@@ -8,6 +8,25 @@ from h.cli.commands import groups as groups_cli
 
 class TestAddCommand(object):
 
+    def test_it_creates_a_publisher_group(self, cli, cliconfig, group_service):
+        """this is deprecated and now called 'open', but keeping this to not break scripts"""
+        name = 'Publisher Group Name'
+        creator = 'admin'
+        authority = 'publisher.org'
+        result = cli.invoke(groups_cli.add_publisher_group,
+                            [u'--name', name,
+                             u'--authority', authority,
+                             u'--creator', creator],
+                            obj=cliconfig)
+
+        assert result.exit_code == 0
+
+        group_service.create.assert_called_with(authority=authority,
+                                                name=name,
+                                                userid='acct:{0}@{1}'.format(
+                                                    creator, authority),
+                                                type_='open')
+
     def test_it_creates_a_public_group(self, cli, cliconfig, group_service):
         name = 'Public Group Name'
         creator = 'admin'

--- a/tests/h/cli/commands/groups_test.py
+++ b/tests/h/cli/commands/groups_test.py
@@ -8,19 +8,6 @@ from h.cli.commands import groups as groups_cli
 
 class TestAddCommand(object):
 
-    def test_it_creates_a_publisher_group(self, cli, cliconfig, group_service):
-        result = cli.invoke(groups_cli.add_publisher_group,
-                            [u'--name', 'Publisher', u'--authority', 'publisher.org',
-                             u'--creator', 'admin'],
-                            obj=cliconfig)
-
-        assert result.exit_code == 0
-
-        group_service.create.assert_called_with(name=u'Publisher',
-                                                authority=u'publisher.org',
-                                                userid='acct:admin@publisher.org',
-                                                type_='publisher')
-
     def test_it_creates_a_public_group(self, cli, cliconfig, group_service):
         name = 'Public Group Name'
         creator = 'admin'

--- a/tests/h/form_test.py
+++ b/tests/h/form_test.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import deform
 import mock
 import pytest
 
@@ -176,15 +177,15 @@ class TestHandleFormSubmission(object):
 
     def test_if_validation_fails_it_calls_on_failure(self,
                                                      pyramid_request,
-                                                     invalid_form):
+                                                     invalid_form,
+                                                     matchers):
         on_failure = mock_callable()
 
         form.handle_form_submission(pyramid_request,
                                     invalid_form(),
                                     mock.sentinel.on_success,
                                     on_failure)
-
-        on_failure.assert_called_once_with()
+        on_failure.assert_called_once_with(exception=matchers.instance_of(deform.ValidationFailure))
 
     def test_if_validation_fails_it_calls_to_xhr_response(self,
                                                           invalid_form,

--- a/tests/h/resources_test.py
+++ b/tests/h/resources_test.py
@@ -228,7 +228,7 @@ class FakeGroup(object):
 
 class TestGroupResourceFactory(object):
     def test_get_item_returns_an_group(self, pyramid_request):
-        group = Group(name='test', authority='example.com')
+        group = Group(name='test', authority=u'example.com')
         pyramid_request.db.add(group)
         pyramid_request.db.flush()
 

--- a/tests/h/routes_test.py
+++ b/tests/h/routes_test.py
@@ -42,6 +42,8 @@ def test_includeme():
         call('admin_cohorts', '/admin/features/cohorts'),
         call('admin_cohorts_edit', '/admin/features/cohorts/{id}'),
         call('admin_groups', '/admin/groups'),
+        call('admin_groups_create', '/admin/groups/create'),
+        call('admin_group_read', '/admin/groups/{pubid}/{slug:[^/]*}/', factory='h.resources.GroupFactory', traverse='/{pubid}'),
         call('admin_mailer', '/admin/mailer'),
         call('admin_mailer_test', '/admin/mailer/test'),
         call('admin_nipsa', '/admin/nipsa'),

--- a/tests/h/routes_test.py
+++ b/tests/h/routes_test.py
@@ -81,6 +81,8 @@ def test_includeme():
              traverse='/{id}'),
         call('api.profile', '/api/profile'),
         call('api.debug_token', '/api/debug-token'),
+        call('api.group_read', '/api/groups/{pubid}/{slug:[^/]*}', factory='h.models.group:GroupFactory', traverse='/{pubid}'),
+        call('api.group_read_noslug', '/api/groups/{pubid}', factory='h.models.group:GroupFactory', traverse='/{pubid}'),
         call('api.group_member', '/api/groups/{pubid}/members/{user}', factory='h.models.group:GroupFactory', traverse='/{pubid}'),
         call('api.search', '/api/search'),
         call('api.users', '/api/users'),

--- a/tests/h/services/group_test.py
+++ b/tests/h/services/group_test.py
@@ -109,7 +109,10 @@ class TestGroupService(object):
         (None, True),
     ])
     def test_get_group_type(self, pyramid_request, db_session, users, group_type, use_h_authority):
-        h_authority = unicode(pyramid_request.domain)
+        def ensure_unicode(maybe_bytes):
+            return maybe_bytes.decode() if isinstance(maybe_bytes, bytes) else maybe_bytes
+        # python2 will have request.domain as a bytes. case to unicode str to prevent downstream type warnings
+        h_authority = ensure_unicode(pyramid_request.domain)
         publisher_authority = 'publisher.test_groupids_created_by_excludes_other_groups'
         svc = GroupService(db_session, users.get)
         group = svc.create('Group of type {}'.format(group_type),

--- a/tests/h/services/group_test.py
+++ b/tests/h/services/group_test.py
@@ -59,7 +59,6 @@ class TestGroupService(object):
     @pytest.mark.parametrize(('group_type', 'creator_should_be_member'), [
         (None, True),
         ('private', True),
-        ('publisher', False),
         ('open', True),
         ('public', True),
     ])
@@ -78,9 +77,6 @@ class TestGroupService(object):
         ('private', 'joinable_by', JoinableBy.authority),
         ('private', 'readable_by', ReadableBy.members),
         ('private', 'writeable_by', WriteableBy.members),
-        ('publisher', 'joinable_by', None),
-        ('publisher', 'readable_by', ReadableBy.world),
-        ('publisher', 'writeable_by', WriteableBy.authority),
         ('public', 'joinable_by', None),
         ('public', 'readable_by', ReadableBy.world),
         ('public', 'writeable_by', WriteableBy.members),
@@ -105,7 +101,6 @@ class TestGroupService(object):
         ('private', True),
         ('public', True),
         ('open', True),
-        ('publisher', False),
         (None, True),
     ])
     def test_get_group_type(self, pyramid_request, db_session, users, group_type, use_h_authority):

--- a/tests/h/services/group_test.py
+++ b/tests/h/services/group_test.py
@@ -105,15 +105,20 @@ class TestGroupService(object):
         ('private', True),
         ('public', True),
         ('open', True),
-        ('publisher', False), ])
+        ('publisher', False),
+        (None, True),
+    ])
     def test_get_group_type(self, pyramid_request, db_session, users, group_type, use_h_authority):
-        h_authority = pyramid_request.domain
+        h_authority = unicode(pyramid_request.domain)
         publisher_authority = 'publisher.test_groupids_created_by_excludes_other_groups'
         svc = GroupService(db_session, users.get)
         group = svc.create('Group of type {}'.format(group_type),
                            h_authority if use_h_authority else publisher_authority,
                            'cazimir',
-                           type_=group_type)
+                           type_=group_type or u'public')
+        if not group_type:
+            # modify group so it doesnt correspond to any group_type
+            group.joinable_by = 'fake'
         assert get_group_type(group, pyramid_request) == group_type
 
     def test_create_raises_for_invalid_group_type(self, db_session, users):

--- a/tests/h/services/group_test.py
+++ b/tests/h/services/group_test.py
@@ -43,7 +43,8 @@ class TestGroupService(object):
     def test_create_sets_description_when_present(self, db_session, users):
         svc = GroupService(db_session, users.get)
 
-        group = svc.create('Anteater fans', 'foobar.com', 'cazimir', 'all about ant eaters')
+        group = svc.create('Anteater fans', 'foobar.com',
+                           'cazimir', 'all about ant eaters')
 
         assert group.description == 'all about ant eaters'
 
@@ -64,7 +65,8 @@ class TestGroupService(object):
     def test_create_doesnt_add_group_creator_to_members_for_publisher_groups(self, db_session, users):
         svc = GroupService(db_session, users.get)
 
-        group = svc.create('Anteater fans', 'foobar.com', 'cazimir', type_='publisher')
+        group = svc.create('Anteater fans', 'foobar.com',
+                           'cazimir', type_='publisher')
 
         assert users['cazimir'] not in group.members
 
@@ -78,7 +80,10 @@ class TestGroupService(object):
         ('public', 'joinable_by', None),
         ('public', 'readable_by', ReadableBy.world),
         ('public', 'writeable_by', WriteableBy.members),
-        ])
+        ('open', 'joinable_by', None),
+        ('open', 'readable_by', ReadableBy.world),
+        ('open', 'writeable_by', WriteableBy.authority),
+    ])
     def test_create_sets_access_flags_for_group_types(self,
                                                       db_session,
                                                       users,
@@ -87,7 +92,8 @@ class TestGroupService(object):
                                                       expected_value):
         svc = GroupService(db_session, users.get)
 
-        group = svc.create('Anteater fans', 'foobar.com', 'cazimir', type_=group_type)
+        group = svc.create('Anteater fans', 'foobar.com',
+                           'cazimir', type_=group_type)
 
         assert getattr(group, flag) == expected_value
 

--- a/tests/h/services/group_test.py
+++ b/tests/h/services/group_test.py
@@ -112,11 +112,12 @@ class TestGroupService(object):
         def ensure_unicode(maybe_bytes):
             return maybe_bytes.decode() if isinstance(maybe_bytes, bytes) else maybe_bytes
         # python2 will have request.domain as a bytes. case to unicode str to prevent downstream type warnings
-        h_authority = ensure_unicode(pyramid_request.domain)
-        publisher_authority = 'publisher.test_groupids_created_by_excludes_other_groups'
+        h_authority = pyramid_request.domain
+        publisher_authority = 'publisher.org'
         svc = GroupService(db_session, users.get)
         group = svc.create('Group of type {}'.format(group_type),
-                           h_authority if use_h_authority else publisher_authority,
+                           ensure_unicode(
+                               h_authority if use_h_authority else publisher_authority),
                            'cazimir',
                            type_=group_type or u'public')
         if not group_type:

--- a/tests/h/session_test.py
+++ b/tests/h/session_test.py
@@ -128,9 +128,9 @@ class TestProfile(object):
 
         assert private_group['public'] is False
 
-    def test_publisher_group_is_public(self, third_party_request, publisher_group):
+    def test_open_group_is_public(self, third_party_request, open_group):
         profile = session.profile(third_party_request)
-        group = [g for g in profile['groups'] if g['id'] == publisher_group.pubid][0]
+        group = [g for g in profile['groups'] if g['id'] == open_group.pubid][0]
 
         assert group['public'] is True
 
@@ -148,9 +148,9 @@ class TestProfile(object):
 
         assert private_group['url']
 
-    def test_publisher_group_has_no_url(self, third_party_request, publisher_group):
+    def test_open_group_has_no_url(self, third_party_request, open_group):
         profile = session.profile(third_party_request)
-        group = [g for g in profile['groups'] if g['id'] == publisher_group.pubid][0]
+        group = [g for g in profile['groups'] if g['id'] == open_group.pubid][0]
 
         assert 'url' not in group
 
@@ -224,16 +224,16 @@ class TestProfile(object):
         return u'thirdparty.example.org'
 
     @pytest.fixture
-    def third_party_request(self, authority, third_party_domain, publisher_group, fake_feature):
+    def third_party_request(self, authority, third_party_domain, open_group, fake_feature):
         return FakeRequest(authority,
                            u'acct:user@{}'.format(third_party_domain),
                            third_party_domain,
-                           {third_party_domain: [publisher_group]},
+                           {third_party_domain: [open_group]},
                            fake_feature)
 
     @pytest.fixture
-    def publisher_group(self):
-        return FakeGroup('abcdef', 'Publisher group', is_public=True)
+    def open_group(self):
+        return FakeGroup('abcdef', 'Open group', is_public=True)
 
 
 class TestUserInfo(object):

--- a/tests/h/session_test.py
+++ b/tests/h/session_test.py
@@ -4,6 +4,14 @@ import mock
 from h import session
 
 
+class TestDeduplicate(object):
+    def test_deduplicates(self):
+        group = dict(pubid='fake')
+        items = [group] * 2
+        deduplicated = session.deduplicate(items, lambda g: g.get('pubid'))
+        assert len(deduplicated) == 1
+
+
 class FakeGroup(object):
     def __init__(self, pubid, name, is_public=False):
         self.pubid = pubid

--- a/tests/h/views/api_groups_test.py
+++ b/tests/h/views/api_groups_test.py
@@ -10,7 +10,7 @@ from pyramid.httpexceptions import HTTPNoContent, HTTPBadRequest, HTTPMovedPerma
 from .groups_test import FakeGroupService
 
 from h.views import api_groups as views
-from h.models import (Group, User)
+
 
 @pytest.mark.usefixtures('group_service')
 class TestRead(object):
@@ -18,12 +18,15 @@ class TestRead(object):
     def test_read_noslug(self, pyramid_request, group_service):
         group = group_service.create(u'test_read_noslug', 'localhost', 0)
         pyramid_request.matchdict[u'pubid'] = group.pubid
+
         # request.route_path is not defined on DummyRequest
         def _route_path(route_name, pubid, slug):
             return '/api/groups/{pubid}/{slug}'.format(pubid=pubid, slug=slug)
+
         pyramid_request.route_path = _route_path
         with pytest.raises(HTTPMovedPermanently) as redirect_exc:
             views.read_noslug(group, pyramid_request)
+        assert redirect_exc.value.headers.get('Location')
 
     def test_get_group(self, pyramid_request, group_service):
         group = group_service.create(u'test_read_noslug', 'localhost', 0)

--- a/tests/h/views/api_groups_test.py
+++ b/tests/h/views/api_groups_test.py
@@ -5,9 +5,40 @@ from __future__ import unicode_literals
 import mock
 import pytest
 
-from pyramid.httpexceptions import HTTPNoContent, HTTPBadRequest
+from pyramid.httpexceptions import HTTPNoContent, HTTPBadRequest, HTTPMovedPermanently
+
+from .groups_test import FakeGroupService
 
 from h.views import api_groups as views
+from h.models import (Group, User)
+
+@pytest.mark.usefixtures('group_service')
+class TestRead(object):
+
+    def test_read_noslug(self, pyramid_request, group_service):
+        group = group_service.create(u'test_read_noslug', 'localhost', 0)
+        pyramid_request.matchdict[u'pubid'] = group.pubid
+        # request.route_path is not defined on DummyRequest
+        def _route_path(route_name, pubid, slug):
+            return '/api/groups/{pubid}/{slug}'.format(pubid=pubid, slug=slug)
+        pyramid_request.route_path = _route_path
+        with pytest.raises(HTTPMovedPermanently) as redirect_exc:
+            views.read_noslug(group, pyramid_request)
+
+    def test_get_group(self, pyramid_request, group_service):
+        group = group_service.create(u'test_read_noslug', 'localhost', 0)
+        pyramid_request.matchdict[u'slug'] = group.slug
+        pyramid_request.matchdict[u'pubid'] = group.pubid
+        response = views.get_group(group, pyramid_request)
+        assert response
+        for k in ('id', 'name', 'description'):
+            assert k in response
+
+    @pytest.fixture
+    def group_service(self, pyramid_config):
+        service = FakeGroupService()
+        pyramid_config.register_service(service, name='group')
+        return service
 
 
 @pytest.mark.usefixtures('authenticated_userid', 'group_service')

--- a/tests/h/views/groups_test.py
+++ b/tests/h/views/groups_test.py
@@ -182,7 +182,7 @@ class TestGroupReadUnauthenticated(object):
         pyramid_request.matchdict['slug'] = 'some-slug'
         pyramid_request.headers['accept'] = 'application/json'
 
-        result = views.read_unauthenticated_json(group, pyramid_request)
+        result = views.read_group_json(group, pyramid_request)
         assert result.status_code == 303
         assert result.location == '/api/groups/{}/{}'.format(
             group.pubid, group.slug)

--- a/tests/h/views/groups_test.py
+++ b/tests/h/views/groups_test.py
@@ -187,6 +187,24 @@ class TestGroupReadUnauthenticated(object):
         assert result.location == '/api/groups/{}/{}'.format(
             group.pubid, group.slug)
 
+    def test_json_request_bad_group_404s(self, pyramid_request):
+        pyramid_request.matchdict['slug'] = 'some-slug'
+        pyramid_request.headers['accept'] = 'application/json'
+        group = None
+        with pytest.raises(HTTPNotFound) as exc:
+            result = views.read_group_json(group, pyramid_request)
+
+    def test_options_request(self, pyramid_request):
+        """
+        Requesting JSON from a Group URL will redirect to the API to return documented JSON format.
+        The client will request this when fetching page-configured groups (which are configured by URL)
+        """
+        group = FakeGroup('abc123', 'some-slug')
+        pyramid_request.matchdict['slug'] = 'some-slug'
+        pyramid_request.headers['accept'] = 'application/json'
+        result = views.options_group_read(group, pyramid_request)
+        assert result == {}
+
 
 @pytest.mark.usefixtures('routes')
 def test_read_noslug_redirects(pyramid_request):

--- a/tests/h/views/groups_test.py
+++ b/tests/h/views/groups_test.py
@@ -229,7 +229,7 @@ class FakeGroupService(object):
         self.joined = []
         self.left = []
 
-    def create(self, name, authority, userid, description):
+    def create(self, name, authority, userid, description=None):
         self.created.append((name, authority, userid, description))
         return FakeGroup('abc123', 'fake-group')
 

--- a/tests/h/views/groups_test.py
+++ b/tests/h/views/groups_test.py
@@ -191,8 +191,8 @@ class TestGroupReadUnauthenticated(object):
         pyramid_request.matchdict['slug'] = 'some-slug'
         pyramid_request.headers['accept'] = 'application/json'
         group = None
-        with pytest.raises(HTTPNotFound) as exc:
-            result = views.read_group_json(group, pyramid_request)
+        with pytest.raises(HTTPNotFound):
+            views.read_group_json(group, pyramid_request)
 
     def test_options_request(self, pyramid_request):
         """


### PR DESCRIPTION
Implements
* https://github.com/hypothesis/product-backlog/issues/369
* https://github.com/hypothesis/product-backlog/issues/370

We're adding the ability for publishers to configure hypothesis/clients to feature one or more groups. So the client will show groups you're a member of, but now also groups the publisher want to promote.

Publishers can configure one or more `pageGroups` (happy to change that to whatever) like:
```
window.hypothesisConfig = function () {
    return {
        pageGroups: [
            "http://h.hypothesis:5000/groups/2JKqAjYE/scipub-com-open-group",
            "http://h.hypothesis:5000/groups/wg54vyqQ/h-hypothesis-open",
        ]
    };
};
```

Changes

* h.cli.commands.groups
  * New commands for add-public-group, add-open-group, join (to add a user to a group)
* h.form
  * `handle_form_submission`
    * on_failure callback can look at the error that occurred to determine what to do
    * can disable the previous flash, e.g. if the caller wants to show a more customized one
* h.models.group
  * __acl__ * remove final `terms.append(security.DENY_ALL)`. This way this model can be attached to the large authz graph, and acl lookups will go up to the parent, instead of always being denied here. Helped get authz working right for me in the admin.
* h.resources
  * GroupFactory - get a group model, but with `__parent__` the main authz Root
* h.routes
  * admin_group_create - show a form to create a new group
  * admin_group_read - get details about a group and manage members
* h.services.group
  * define `GROUP_TYPES` to reflect the business' domain model for what they want. This powers things like the group creation form's 'type' input
* h.session - `_current_groups` now deduplicates results to fix bug where API would return same group multiple times
* h/static/styles/admin.scss - The default form css is not very flexible. Had to make some tweaks.
* h/templates/activity/search.html.jinja2 - Don't always show component "Invite new members"
* h/templates/deform/form.jinja2 - Show form-level validation errors
* h/views/admin_groups.py
  * AdminGroupCreateController - for form to create new groups
  * CSVScalarWidget - deform widget for the multi-entry field when adding group members by username, email, delimited by any combination of spaces, newlines
  * AdminGroupReadController - for page of group details and member management form
* tests.functional.test_admin_groups - lots of functional tests of the admin groups forms
* tests.h.cli.commands.groups_test - tests for new group cli commands
* more tests...
* h.views.api_groups
  * Add get_group handler for API to get the id, description, name of a group
* h.views.groups
  * read_unauthenticated_json new func that responds to JSON requests to route_name='group_read'. It redirects to the api.group_read route.
    * This way the urls that users enter, which resolve to HTML in a web browser, can point over to the API and say 'look over there for the group'. I assumed it might be preferred to centralized JSON-responses in the API, but we could also have h.views.groups respond with JSON here directly.
  * route group_read now respond to OPTIONS requests for CORS supprot
* tests.h.views.groups_test - tests that these group URLs eventually redirect to a JSON object #