### PR TITLE
Check for uncommitted DB changes when requests finish

### DIFF
--- a/h/config.py
+++ b/h/config.py
@@ -83,6 +83,8 @@ SETTINGS = [
     EnvSetting('h.client_rpc_allowed_origins',
                'CLIENT_RPC_ALLOWED_ORIGINS', type=aslist),
 
+    EnvSetting('h.db_session_checks', 'DB_SESSION_CHECKS', type=asbool),
+
     # Environment name, provided by the deployment environment. Please do
     # *not* toggle functionality based on this value. It is intended as a
     # label only.

--- a/h/db/__init__.py
+++ b/h/db/__init__.py
@@ -21,6 +21,8 @@ import zope.sqlalchemy.datamanager
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 
+from h.util.session_tracker import Tracker
+
 __all__ = (
     'Base',
     'Session',
@@ -82,6 +84,10 @@ def _session(request):
     else:
         zope.sqlalchemy.register(session, transaction_manager=tm)
 
+    # Track uncommitted changes so we can verify that everything was either
+    # committed or rolled back when the request finishes.
+    tracker = Tracker(session)
+
     # pyramid_tm doesn't always close the database session for us.
     #
     # For example if an exception view accesses the session and causes a new
@@ -96,10 +102,13 @@ def _session(request):
     # See: https://github.com/Pylons/pyramid_tm/issues/40
     @request.add_finished_callback
     def close_the_sqlalchemy_session(request):
-        if session.dirty:
-            request.sentry.captureMessage('closing a dirty session', stack=True, extra={
-                'dirty': session.dirty,
+        changes = tracker.uncommitted_changes()
+        if changes:
+            msg = 'closing a session with uncommitted changes'
+            request.sentry.captureMessage(msg, stack=True, extra={
+                'changes': changes,
             })
+            log.warn('{} {}'.format(msg, changes))
         session.close()
 
     return session

--- a/h/util/session_tracker.py
+++ b/h/util/session_tracker.py
@@ -1,0 +1,74 @@
+from copy import copy
+from enum import Enum
+
+from sqlalchemy.event import listen
+from sqlalchemy.orm.util import identity_key
+
+
+class ObjectState(Enum):
+    ADDED = 'added'
+    DELETED = 'deleted'
+    CHANGED = 'changed'
+
+
+class Tracker(object):
+    """
+    Observer which tracks whether a SQLAlchemy `Session` has uncommitted changes.
+    """
+
+    def __init__(self, session):
+        self.session = session
+
+        # Changes which have been flushed to the database (and thus not present
+        # in `session.new`, `session.dirty` or `session.deleted) but have not
+        # yet been _committed_.
+        self._flushed_changes = {}
+
+        listen(session, 'after_flush', self._after_flush)
+        listen(session, 'after_commit', self._after_commit)
+        listen(session, 'after_rollback', self._after_rollback)
+
+    def uncommitted_changes(self):
+        """
+        Return a list of changes to the `Session` which have not yet been
+        _committed_ to the DB.
+
+        The result is a list of (identity key, ObjectState) tuples.
+        """
+        changed = copy(self._flushed_changes)
+        changed.update(self._unflushed_changes())
+
+        return list(changed.iteritems())
+
+    def _unflushed_changes(self):
+        """
+        Return a map of changes which have not yet been flushed to the DB.
+
+        In the context of the "after_flush" event handler, this returns changes
+        which have just been flushed.
+
+        If an object goes through multiple states in the same session (eg.
+        added, then flushed, then changed) then only the last state for a given
+        object is recorded.
+        """
+        changes = {}
+
+        for obj in self.session.new:
+            changes[identity_key(instance=obj)] = ObjectState.ADDED
+
+        for obj in self.session.dirty:
+            changes[identity_key(instance=obj)] = ObjectState.CHANGED
+
+        for obj in self.session.deleted:
+            changes[identity_key(instance=obj)] = ObjectState.DELETED
+
+        return changes
+
+    def _after_rollback(self, *args):
+        self._flushed_changes = {}
+
+    def _after_commit(self, *args):
+        self._flushed_changes = {}
+
+    def _after_flush(self, *args):
+        self._flushed_changes.update(self._unflushed_changes())

--- a/tests/h/config_test.py
+++ b/tests/h/config_test.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+import pytest
+
 from h.config import configure
 
 
@@ -13,3 +15,19 @@ def test_configure_doesnt_override_secret_key():
     config = configure(environ={}, settings={'secret_key': 'foobar'})
 
     assert config.registry.settings['secret_key'] == 'foobar'
+
+
+@pytest.mark.parametrize('env_var,env_val,setting_name,setting_val', [
+    (None, None, 'h.db_session_checks', True),
+    ('DB_SESSION_CHECKS', "False", 'h.db_session_checks', False),
+
+    # There are many other settings that can be updated from env vars.
+    # These are not currently tested.
+])
+def test_configure_updates_settings_from_env_vars(env_var, env_val, setting_name, setting_val):
+    environ = {env_var: env_val} if env_var else {}
+    settings_from_conf = {'h.db_session_checks': True}
+
+    config = configure(environ=environ, settings=settings_from_conf)
+
+    assert config.registry.settings[setting_name] == setting_val

--- a/tests/h/util/session_tracker_test.py
+++ b/tests/h/util/session_tracker_test.py
@@ -1,0 +1,91 @@
+from __future__ import unicode_literals
+
+from uuid import uuid4
+import pytest
+from sqlalchemy.orm.util import identity_key
+
+from h.db.types import _get_urlsafe_from_hex
+from h.models import Annotation, Document
+from h.util.session_tracker import Tracker, ObjectState
+
+
+def generate_ann_id():
+    """
+    Generate a random annotation identifier in the encoded form used by the API.
+    """
+    return _get_urlsafe_from_hex(str(uuid4()))
+
+
+class TestTracker(object):
+
+    def test_uncommitted_changes_returns_unflushed_changes(self, tracker, session, expected_changes):
+        added_entry, changed_entry, deleted_entry = expected_changes
+
+        changes = tracker.uncommitted_changes()
+
+        assert added_entry in changes
+        assert changed_entry in changes
+        assert deleted_entry in changes
+
+    def test_uncommitted_changes_returns_flushed_changes(self, tracker, session, expected_changes):
+        added_entry, changed_entry, deleted_entry = expected_changes
+
+        session.flush()
+        changes = tracker.uncommitted_changes()
+
+        assert added_entry in changes
+        assert changed_entry in changes
+        assert deleted_entry in changes
+
+    def test_uncommitted_changes_does_not_return_committed_changes(self, tracker, session):
+        session.commit()
+        assert tracker.uncommitted_changes() == []
+
+    def test_uncommitted_changes_does_not_return_rolled_back_changes(self, tracker, session):
+        session.rollback()
+        assert tracker.uncommitted_changes() == []
+
+    @pytest.fixture
+    def expected_changes(self, added_ann_id, changed_ann_id, deleted_ann_id):
+        added_entry = (identity_key(Annotation, (added_ann_id,)), ObjectState.ADDED)
+        changed_entry = (identity_key(Annotation, (changed_ann_id,)), ObjectState.CHANGED)
+        deleted_entry = (identity_key(Annotation, (deleted_ann_id,)), ObjectState.DELETED)
+
+        return (added_entry, changed_entry, deleted_entry)
+
+    @pytest.fixture
+    def added_ann_id(self):
+        return generate_ann_id()
+
+    @pytest.fixture
+    def changed_ann_id(self):
+        return generate_ann_id()
+
+    @pytest.fixture
+    def deleted_ann_id(self):
+        return generate_ann_id()
+
+    @pytest.fixture
+    def session(self, db_session, added_ann_id, changed_ann_id, deleted_ann_id):
+        # Populate the DB session with different types of change relative to the
+        # last-committed state. We could use any model object for this purpose
+        # but annotations are the primary object in the system.
+
+        doc = Document(web_uri='https://example.org')
+        changed = Annotation(id=changed_ann_id, userid='foo', groupid='wibble', document=doc)
+        deleted = Annotation(id=deleted_ann_id, userid='foo', groupid='wibble', document=doc)
+        db_session.add(changed)
+        db_session.add(deleted)
+        db_session.commit()
+
+        changed.text = 'changed text'
+        db_session.delete(deleted)
+
+        added = Annotation(id=added_ann_id, userid='foo', groupid='wibble', document=doc)
+        db_session.add(added)
+
+        return db_session
+
+    @pytest.fixture
+    def tracker(self, db_session):
+        return Tracker(db_session)


### PR DESCRIPTION
Extend the logging added in 844a60dd0e6cd177935aea6ed96298199492badc to check whether a request ends with uncommitted DB changes to also check for:

- Additions and removals of objects (present in `session.new` and `session.deleted` but not `session.dirty`) which have not been flushed or committed.
- Changes which have been _flushed_ to the DB but not yet _committed_

The purpose of this is to check whether the missing DB annotations reported in https://github.com/hypothesis/h/issues/4704 are missing because the DB session was not committed or missing because the DB session was rolled back. I strongly suspect the former, but want to rule out the latter.

In addition to logging via Sentry, the issue is logged via our normal logging so that we can see details of events which have been filtered out via Sentry's rate limiting.

----

**Testing**

The easiest way to test this is to comment out [the pyramid_tm include](https://github.com/hypothesis/h/blob/b6530c431c3730dc8e91effec834106d85ff85ce/h/app.py#L90) in app.py which will have the effect of preventing sessions from being committed at the end of a request or rolled back on error. If you then create annotations or other entities you'll see log entries output at the end of the request with details of the uncommitted changes. If you re-enabled that line, the log messages should stop appearing.
  