### PR TITLE
Remove a reference to Annotator Store

### DIFF
--- a/h/views/api.py
+++ b/h/views/api.py
@@ -58,7 +58,6 @@ def index(context, request):
         _set_at_path(links, link['name'].split('.'), method_info)
 
     return {
-        'message': "Annotator Store API",
         'links': links,
     }
 


### PR DESCRIPTION
Remove a very old reference to the annotator-store project [1] which showed
up in the `/api/` response. I'm guessing this originates from https://github.com/openannotation/annotator-store/blob/90aaad3168d2741d236815d4dbcbce1144928142/annotator/store.py#L77

I think it very unlikely that any API clients depend on this field.

_[1] For context, early versions of Hypothesis were derived from [Annotator](http://annotatorjs.org) and [related projects](https://github.com/openannotation). Over the course of the last few years, almost all the pieces have been replaced._