### PR TITLE
Filter out error logging from `ws4py`

### DIFF
--- a/conf/websocket.ini
+++ b/conf/websocket.ini
@@ -15,7 +15,7 @@ worker_class: h.websocket.Worker
 graceful_timeout: 0
 
 [loggers]
-keys = root, gunicorn.error, sentry
+keys = root, gunicorn.error, sentry, ws4py
 
 [handlers]
 keys = console, sentry
@@ -36,6 +36,13 @@ qualname = gunicorn.error
 level = WARNING
 handlers = console
 qualname = sentry.errors
+propagate = 0
+
+[logger_ws4py]
+level = WARNING
+qualname = ws4py
+handlers = console
+# Prevent these messages filtering through to Sentry
 propagate = 0
 
 [handler_console]


### PR DESCRIPTION
In theory, this is useful logging to have. In practice, this produces a large volume of errors of the form:

    Error when terminating the connection: [Errno 32] Broken pipe

Our best theory about these errors is that they come from over-enthusiastic AWS connection termination. Either way, it's not useful to us to have these messages, and even when we filter them out in Sentry, they still have a nasty habit of overflowing our usage quotas.

It's worth noting that this is a slightly blunt tool with which to deal with this problem, in that it will effectively silence all errors coming from the `ws4py` library. The other errors that have been known to occur in this library are:

    [Errno 9] File descriptor was closed in another greenlet
    [Errno 104] Connection reset by peer

I'm not sure either of these errors give us a whole lot of actionable information either, at least at the moment.

The `logging` library does provide us with some more fine-grained filters we could use, but that would require setting up the extra code structures to set these filters up on the logging objects. This would also come with the cost of having our logging filters set up in *two* places, rather than in a single configuration file.