### PR TITLE
Fix double-reporting of DB session warning to Sentry

### DIFF
--- a/h/db/__init__.py
+++ b/h/db/__init__.py
@@ -108,11 +108,11 @@ def _session(request):
     def close_the_sqlalchemy_session(request):
         changes = tracker.uncommitted_changes() if tracker else []
         if changes:
-            msg = 'closing a session with uncommitted changes'
-            request.sentry.captureMessage(msg, stack=True, extra={
+            msg = 'closing a session with uncommitted changes %s'
+            log.warn(msg, changes, extra={
+                'stack': True,
                 'changes': changes,
             })
-            log.warn('{} {}'.format(msg, changes))
         session.close()
 
     return session


### PR DESCRIPTION
We use Sentry's integration with the "logging" package to log all
messages >= WARNING to Sentry. Therefore by using `log.warn` and also
explicitly calling `request.sentry.captureMessage` we were capturing two
reports for the same event.

Since the change list was included in the format argument to `log.warn`
rather than being passed as a separate argument, Sentry was unable to
correctly group the reports.

Fix this by removing the `captureMessage` call and passing the changes
list as a separate argument to `log.warn` so that it appears in the log
output without affecting Sentry's ability to group reports.