### PR TITLE
Check for and cleanup dirty zope.sqlalchemy state at end of request

### DIFF
--- a/h/db/__init__.py
+++ b/h/db/__init__.py
@@ -115,6 +115,22 @@ def _session(request):
             })
         session.close()
 
+        # zope.sqlalchemy maintains an internal `id(session) => state` map with
+        # an entry for each active DB session which is registered with it.
+        #
+        # Entries are normally cleared at the end of a request when the
+        # transaction manager (`request.tm`) commits. DB writes after this can
+        # leave stale entries in the map which can cause problems in future
+        # requests if another session gets the same ID as the current one.
+        dm = zope.sqlalchemy.datamanager
+        if len(dm._SESSION_STATE) > 0:
+            log.warn('request ended with non-empty zope.sqlalchemy state', extra={
+                'data': {
+                    'zope.sqlalchemy.datamanager._SESSION_STATE': dm._SESSION_STATE,
+                },
+            })
+            dm._SESSION_STATE = {}
+
     return session
 
 


### PR DESCRIPTION
`zope.sqlalchemy.register` (called in `h.db.__init__._session`) adds a set of event listeners to a session which trigger population of an internal `id(session) => state` map
whenever a session becomes dirty. This map is usually cleared when the
DB transaction is committed as a result of the transaction manager being
committed or aborted at the end of a web request by pyramid_tm.

If however `request.session` is accessed outside of pyramid_tm's tween
and DB changes are made, the event listeners will fire and references to
the session's ID will be left in the internal _SESSION_STATE map when
the request ends.

This commit adds a check for a non-empty map at the end of a request and
logs a warning, to help track down causes of DB writes that are causing
the issue, it then cleans up the dirty state.

Unfortunately there are no public APIs for deregistering a session [1], so
we clear zope.sqlalchemy's private internal map directly.

This is not intended to be the final fix, but it should help us confirm the problem and figure out how to fix it more cleanly.

[1] https://github.com/zopefoundation/zope.sqlalchemy/issues/9
  