### PR TITLE
Fix docker-compose logs cmd

### DIFF
--- a/docs/developing/install.rst
+++ b/docs/developing/install.rst
@@ -163,7 +163,7 @@ can be installed on:
 
    .. code-block:: bash
 
-      docker-compose logs rabbitmq
+      docker-compose logs rabbit
 
    For more on how to use Docker and Docker Compose see the `Docker website`_.
 


### PR DESCRIPTION
Service is named `rabbit` in the `docker-compose.yml` not `rabbitmq`