### PR TITLE
Fix unicode encoding error when sending reply notification emails

### DIFF
--- a/h/emails/reply_notification.py
+++ b/h/emails/reply_notification.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
+
 from h import links
 
 from pyramid.renderers import render

--- a/tests/h/emails/reply_notification_test.py
+++ b/tests/h/emails/reply_notification_test.py
@@ -98,6 +98,20 @@ class TestGenerate(object):
         html_renderer.assert_(**expected_context)
         text_renderer.assert_(**expected_context)
 
+    def test_supports_non_ascii_display_names(self,
+                                              notification,
+                                              pyramid_request,
+                                              html_renderer,
+                                              text_renderer,
+                                              parent_user,
+                                              reply_user):
+        parent_user.display_name = 'Parent 👩'
+        reply_user.display_name = 'Child 👧'
+
+        (_, subject, _, _) = generate(pyramid_request, notification)
+
+        assert subject == 'Child 👧 has replied to your annotation'
+
     def test_returns_usernames_if_no_display_names(self,
                                                    notification,
                                                    pyramid_request,


### PR DESCRIPTION
Generating the subject line of reply notification emails failed if the
replying user's display name contained non-ASCII chars due to the format
string being a non-Unicode literal.

Fixes #4733

Also fixes one of the causes of #4741 (_Edit: Verified that indeed, it does_)