### PR TITLE
Add a note about what happens if a subscriber throws an exception

### DIFF
--- a/h/eventqueue.py
+++ b/h/eventqueue.py
@@ -25,6 +25,12 @@ class EventQueue(object):
                 break
 
             try:
+                # Notify all subscribers to this particular event. Note that the
+                # order in which subcribers run is not guaranteed [1] and if one
+                # fails, remaining subscribers to the same event which have not
+                # yet run will be skipped.
+                #
+                # [1] See https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/events.html
                 self.request.registry.notify(event)
             except Exception:
                 sentry = getattr(event.request, 'sentry', None)


### PR DESCRIPTION
It isn't clearly specified in the Pyramid documentation, but the
behavior is that if one event subscriber throws an exception, this can
prevent other subscribers to the same event from running.

This doesn't look to be easy to change, so at least flag it up as a
hazard for others to be aware of. For example, this caused an issue with
sending reply notifications (#4733) to interfere with indexing of affected
annotations (#4741).