### PR TITLE
Upgrade jQuery per Vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "gulp-svgmin": "^1.2.2",
     "gulp-util": "^3.0.7",
     "is-equal-shallow": "^0.1.3",
-    "jquery": "1.11.1",
+    "jquery": "^3.3.1",
     "js-polyfills": "^0.1.16",
     "keyboardevent-key-polyfill": "^1.0.2",
     "mkdirp": "^0.5.1",


### PR DESCRIPTION
The upgrading of jQuery (used on `h` admin pages) was trivial.

I spent some time trying to get `bootstrap` up to date, but there were multiple complexities. I'll open a separate issue to track it for another time.