### PR TITLE
Update a code comment

### DIFF
--- a/h/models/group.py
+++ b/h/models/group.py
@@ -55,9 +55,6 @@ class Group(Base, mixins.Timestamps):
     authority = sa.Column(sa.UnicodeText(), nullable=False)
     name = sa.Column(sa.UnicodeText(), nullable=False, index=True)
 
-    # We store information about who created the group -- we don't use this
-    # currently, but it seems careless to lose this information when in the
-    # future these people may be the first admins of their groups.
     creator_id = sa.Column(
         sa.Integer, sa.ForeignKey('user.id'))
     creator = sa.orm.relationship('User')


### PR DESCRIPTION
The group creator _is_ now used for some things. They're the one person
who can rename the group, for example. They're also the one and only
moderator of the group.

I didn't mention in the new code comment what the group creator is
currently used for as I think that comment would likely get out of date.