### PR TITLE
Remove warning when request ends with non-empty zope.sqlalchemy state

### DIFF
--- a/h/db/__init__.py
+++ b/h/db/__init__.py
@@ -141,11 +141,6 @@ def _session(request):
         #
         dm = zope.sqlalchemy.datamanager
         if len(dm._SESSION_STATE) > 0:
-            log.warn('request ended with non-empty zope.sqlalchemy state', extra={
-                'data': {
-                    'zope.sqlalchemy.datamanager._SESSION_STATE': dm._SESSION_STATE,
-                },
-            })
             dm._SESSION_STATE = {}
 
     return session


### PR DESCRIPTION
This currently happens very frequently due to DB accesses happening
after the pyramid_tm tween does its post-view processing, in particular:

 - Use of `request.feature` in `add_renderer_globals` (this is a read-only usage)

 - Use of `request.authenticated_userid` outside of the main request
   handler, eg. in `request.sentry` calls (this reads and possibly extends the lifetime of auth tickets)

Since we have a mitigation in place for this, remove the warning to
avoid spamming Sentry unnecessarily.