### PR TITLE
Allow logged-out users to view group pages for world-readable groups

### DIFF
--- a/h/views/activity.py
+++ b/h/views/activity.py
@@ -8,7 +8,6 @@ import urlparse
 
 from jinja2 import Markup
 from pyramid import httpexceptions
-from pyramid import security
 from pyramid.view import view_config
 from pyramid.view import view_defaults
 
@@ -87,7 +86,6 @@ class SearchController(object):
 
 @view_defaults(route_name='group_read',
                renderer='h:templates/activity/search.html.jinja2',
-               effective_principals=security.Authenticated,
                request_method='GET')
 class GroupSearchController(SearchController):
     """View callables unique to the "group_read" route."""
@@ -257,9 +255,15 @@ class GroupSearchController(SearchController):
 
     def _check_access_permissions(self):
         if not self.request.has_permission('read', self.group):
-            if self.request.has_permission('join', self.group):
+            show_join_page = self.request.has_permission('join', self.group)
+            if not self.request.user:
+                # Show a page which will prompt the user to login to join.
+                show_join_page = True
+
+            if show_join_page:
                 self.request.override_renderer = 'h:templates/groups/join.html.jinja2'
                 return {'group': self.group}
+
             raise httpexceptions.HTTPNotFound()
 
 

--- a/h/views/groups.py
+++ b/h/views/groups.py
@@ -3,7 +3,6 @@
 import deform
 from pyramid import httpexceptions
 from pyramid import security
-from pyramid.config import not_
 from pyramid.view import view_config, view_defaults
 
 from h import form
@@ -103,20 +102,6 @@ class GroupEditController(object):
     def _update_group(self, appstruct):
         self.group.name = appstruct['name']
         self.group.description = appstruct['description']
-
-
-@view_config(route_name='group_read',
-             request_method='GET',
-             renderer='h:templates/groups/join.html.jinja2',
-             effective_principals=not_(security.Authenticated))
-def read_unauthenticated(group, request):
-    """Group view for logged-out users, allowing them to join the group."""
-    check_slug(group, request)
-
-    if group.joinable_by is None:
-        raise httpexceptions.HTTPNotFound()
-
-    return {'group': group}
 
 
 @view_config(route_name='group_read_noslug', request_method='GET')

--- a/tests/h/views/groups_test.py
+++ b/tests/h/views/groups_test.py
@@ -146,33 +146,6 @@ class TestGroupEditController(object):
 
 
 @pytest.mark.usefixtures('routes')
-class TestGroupReadUnauthenticated(object):
-    def test_redirects_if_slug_incorrect(self, pyramid_request):
-        group = FakeGroup('abc123', 'some-slug')
-        pyramid_request.matchdict['slug'] = 'another-slug'
-
-        with pytest.raises(HTTPMovedPermanently) as exc:
-            views.read_unauthenticated(group, pyramid_request)
-
-        assert exc.value.location == '/g/abc123/some-slug'
-
-    def test_returns_template_context(self, pyramid_request):
-        group = FakeGroup('abc123', 'some-slug')
-        pyramid_request.matchdict['slug'] = 'some-slug'
-
-        result = views.read_unauthenticated(group, pyramid_request)
-
-        assert result == {'group': group}
-
-    def test_raises_not_found_when_not_joinable(self, pyramid_request):
-        group = FakeGroup('abc123', 'some-slug', joinable_by=None)
-        pyramid_request.matchdict['slug'] = 'some-slug'
-
-        with pytest.raises(HTTPNotFound):
-            views.read_unauthenticated(group, pyramid_request)
-
-
-@pytest.mark.usefixtures('routes')
 def test_read_noslug_redirects(pyramid_request):
     group = FakeGroup('abc123', 'some-slug')
 


### PR DESCRIPTION
sConsolidate the logic for handling group read pages for logged-in and
logged-out users in `h.views.activity.GroupSearchController`, and let
logged-out users view world-readable groups.

With this change, it is now possible for a logged-out user to see the
activity page for a world-readable group such as "Public" or in future
open or restricted groups, eg. at https://hypothes.is/groups/__world__

This should also fix an issue @seanh spotted where an existing link to `/groups/__world__` is broken for anonymous users:

1. Go to the `/search` page when logged out
2. Find an annotation from the _Public_ group and click on the link to the _Public_ group in the top left of the annotation card
3. Link takes you to https://hypothes.is/groups/__world__/public which 404s