### PR TITLE
Update zope.sqlalchemy and remove workaround

### DIFF
--- a/h/db/__init__.py
+++ b/h/db/__init__.py
@@ -115,34 +115,6 @@ def _session(request):
             })
         session.close()
 
-        # Remove stale sqlalchemy session IDs from zope.sqlalchemy's _SESSION_STATE.
-        #
-        # TODO: Once https://github.com/zopefoundation/zope.sqlalchemy/pull/23
-        # has been merged and we upgrade to a new version of zope.sqlalchemy
-        # that includes it, we can remove this workaround.
-        #
-        # _SESSION_STATE is a dict whose keys are the Python object IDs of
-        # sqlalchemy sessions. A session's ID is normally removed from
-        # _SESSION_STATE at the end of processing that session's request. But
-        # if something opens a new DB session by accessing the DB after the
-        # transaction manager has committed then that session's ID is **never**
-        # removed from _SESSION_STATE even after the session object has been
-        # garbage collected.
-        #
-        # If a future request's session then happens to get the same Python
-        # object ID as one of these "stale" IDs not removed from
-        # _SESSION_STATE, then zope.sqlalchemy does not join that sqlalchemy
-        # session to the transaction manager's transaction because it thinks it
-        # has already done so. As a result, that session is never committed
-        # (annotations are not saved, etc).
-        #
-        # To prevent that from happening we remove stale IDs from
-        # _SESSION_STATE here.
-        #
-        dm = zope.sqlalchemy.datamanager
-        if len(dm._SESSION_STATE) > 0:
-            dm._SESSION_STATE = {}
-
     return session
 
 

--- a/requirements.in
+++ b/requirements.in
@@ -43,5 +43,4 @@ venusian
 wsaccel
 ws4py >= 0.4.0
 zope.interface
-zope.sqlalchemy # When upgrading zope.sqlalchemy check if we can remove our
-                # _SESSION_STATE workaround yet. (See TODO in db/__init__.py)
+zope.sqlalchemy >= 1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -81,4 +81,4 @@ ws4py==0.4.2
 wsaccel==0.6.2
 zope.deprecation==4.1.2   # via deform, pyramid, pyramid-jinja2
 zope.interface==4.3.2
-zope.sqlalchemy==0.7.7
+zope.sqlalchemy==1.0


### PR DESCRIPTION
Update zope.sqlalchemy and remove workaround that cleared
its internal `_SESSION_STATE` dictionary at the end of each request.