### PR TITLE
Rename publisher groups to open groups

### DIFF
--- a/h/cli/commands/groups.py
+++ b/h/cli/commands/groups.py
@@ -8,17 +8,17 @@ def groups():
     """Manage groups."""
 
 
-@groups.command('add-publisher-group')
+@groups.command('add-open-group')
 @click.option('--name', prompt=True, help="The name of the group")
 @click.option('--authority', prompt=True, help="The authority which the group is associated with")
 @click.option('--creator', prompt=True, help="The username of the group's creator")
 @click.pass_context
-def add_publisher_group(ctx, name, authority, creator):
+def add_open_group(ctx, name, authority, creator):
     """
-    Create a new "publisher" group.
+    Create a new open group.
 
-    Create a new group which everyone can read but which only users belonging
-    to a given authority can write to.
+    Create a new group that everyone can read and any logged-in user belonging
+    to the same authority as the group and write to.
     """
     request = ctx.obj['bootstrap']()
 
@@ -26,6 +26,6 @@ def add_publisher_group(ctx, name, authority, creator):
                                                            authority=authority)
     group_svc = request.find_service(name='group')
     group_svc.create(name=name, authority=authority, userid=creator_userid,
-                     type_='publisher')
+                     type_='open')
 
     request.tm.commit()

--- a/h/services/group.py
+++ b/h/services/group.py
@@ -14,7 +14,7 @@ GROUP_ACCESS_FLAGS = {
         'readable_by': ReadableBy.members,
         'writeable_by': WriteableBy.members,
      },
-    'publisher': {
+    'open': {
         'joinable_by': None,
         'readable_by': ReadableBy.world,
         'writeable_by': WriteableBy.authority,
@@ -45,7 +45,7 @@ class GroupService(object):
         :param name: the human-readable name of the group
         :param userid: the userid of the group creator
         :param description: the description of the group
-        :param type_: the type of group (private or publisher) which sets the
+        :param type_: the type of group (private or open) which sets the
                       appropriate access flags
 
         :returns: the created group

--- a/h/session.py
+++ b/h/session.py
@@ -102,7 +102,7 @@ def _user_groups(user):
 def _group_model(route_url, group):
     model = {'name': group.name, 'id': group.pubid, 'public': group.is_public}
 
-    # We currently want to show URLs for secret groups, but not for publisher
+    # We currently want to show URLs for secret groups, but not for open
     # groups, and not for the `__world__` group (where it doesn't make sense).
     # This is currently all non-public groups, which saves us needing to do a
     # check in here on the group's authority.

--- a/tests/common/factories/__init__.py
+++ b/tests/common/factories/__init__.py
@@ -14,7 +14,7 @@ from .document import Document, DocumentMeta, DocumentURI
 from .feature import Feature
 from .feature_cohort import FeatureCohort
 from .flag import Flag
-from .group import Group, PublisherGroup
+from .group import Group, OpenGroup
 from .setting import Setting
 from .token import DeveloperToken, OAuth2Token
 from .user import User
@@ -36,7 +36,7 @@ __all__ = (
     'Flag',
     'Group',
     'OAuth2Token',
-    'PublisherGroup',
+    'OpenGroup',
     'Setting',
     'User',
     'set_session',

--- a/tests/common/factories/group.py
+++ b/tests/common/factories/group.py
@@ -26,9 +26,9 @@ class Group(ModelFactory):
     members = factory.LazyAttribute(lambda obj: [obj.creator])
 
 
-class PublisherGroup(Group):
+class OpenGroup(Group):
 
-    name = factory.Sequence(lambda n: 'Test Publisher Group {n}'.format(n=str(n)))
+    name = factory.Sequence(lambda n: 'Test Open Group {n}'.format(n=str(n)))
 
     joinable_by = None
     readable_by = ReadableBy.world

--- a/tests/functional/test_api.py
+++ b/tests/functional/test_api.py
@@ -85,7 +85,7 @@ class TestAPI(object):
         assert res.json['userid'] == user.userid
         assert [group['id'] for group in res.json['groups']] == ['__world__']
 
-    def test_third_party_profile_api(self, app, publisher_group, third_party_user_with_token):
+    def test_third_party_profile_api(self, app, open_group, third_party_user_with_token):
         """Fetch a profile for a third-party account."""
 
         user, token = third_party_user_with_token
@@ -97,7 +97,7 @@ class TestAPI(object):
         assert res.json['userid'] == user.userid
 
         group_ids = [group['id'] for group in res.json['groups']]
-        assert group_ids == [publisher_group.pubid]
+        assert group_ids == [open_group.pubid]
 
     def test_cors_preflight(self, app):
         # Simulate a CORS preflight request made by the browser from a client
@@ -157,8 +157,8 @@ def third_party_user(auth_client, db_session, factories):
 
 
 @pytest.fixture
-def publisher_group(auth_client, db_session, factories):
-    group = factories.PublisherGroup(authority=auth_client.authority)
+def open_group(auth_client, db_session, factories):
+    group = factories.OpenGroup(authority=auth_client.authority)
     db_session.commit()
     return group
 

--- a/tests/functional/test_moderation.py
+++ b/tests/functional/test_moderation.py
@@ -21,7 +21,7 @@ class TestModeration(object):
 
 @pytest.fixture
 def group(db_session, factories, moderator):
-    group = factories.PublisherGroup(creator=moderator)
+    group = factories.OpenGroup(creator=moderator)
     db_session.commit()
     return group
 

--- a/tests/h/cli/commands/groups_test.py
+++ b/tests/h/cli/commands/groups_test.py
@@ -8,8 +8,8 @@ from h.cli.commands import groups as groups_cli
 
 class TestAddCommand(object):
 
-    def test_it_creates_a_publisher_group(self, cli, cliconfig, group_service):
-        result = cli.invoke(groups_cli.add_publisher_group,
+    def test_it_creates_a_third_party_open_group(self, cli, cliconfig, group_service):
+        result = cli.invoke(groups_cli.add_open_group,
                             [u'--name', 'Publisher', u'--authority', 'publisher.org',
                              u'--creator', 'admin'],
                             obj=cliconfig)
@@ -19,7 +19,7 @@ class TestAddCommand(object):
         group_service.create.assert_called_with(name=u'Publisher',
                                                 authority=u'publisher.org',
                                                 userid='acct:admin@publisher.org',
-                                                type_='publisher')
+                                                type_='open')
 
 
 @pytest.fixture

--- a/tests/h/presenters/annotation_json_test.py
+++ b/tests/h/presenters/annotation_json_test.py
@@ -154,7 +154,7 @@ class TestAnnotationJSONPresenter(object):
         (mock.Mock(userid='acct:luke', groupid='abcde', shared=False), 'members', 'read', ['acct:luke']),
         (mock.Mock(groupid='__world__', shared=True), 'world', 'read', ['group:__world__']),
         (mock.Mock(groupid='lulapalooza', shared=True), 'members', 'read', ['group:lulapalooza']),
-        (mock.Mock(groupid='publisher', shared=True), 'world', 'read', ['group:__world__']),
+        (mock.Mock(groupid='open', shared=True), 'world', 'read', ['group:__world__']),
         (mock.Mock(userid='acct:luke'), None, 'admin', ['acct:luke']),
         (mock.Mock(userid='acct:luke'), None, 'update', ['acct:luke']),
         (mock.Mock(userid='acct:luke'), None, 'delete', ['acct:luke']),

--- a/tests/h/services/authority_group_test.py
+++ b/tests/h/services/authority_group_test.py
@@ -19,8 +19,8 @@ def test_excludes_world_group_for_non_matching_domain(svc):
     assert '__world__' not in [group.pubid for group in public_groups]
 
 
-def test_returns_public_groups_for_non_matching_domain(svc, publisher_group):
-    assert publisher_group in svc.public_groups('partner.org')
+def test_returns_public_groups_for_non_matching_domain(svc, open_group):
+    assert open_group in svc.public_groups('partner.org')
 
 
 def test_excludes_third_party_private_groups(svc, third_party_private_group):
@@ -42,8 +42,8 @@ def private_group(factories):
 
 
 @pytest.fixture
-def publisher_group(factories):
-    return factories.PublisherGroup(authority='partner.org')
+def open_group(factories):
+    return factories.OpenGroup(authority='partner.org')
 
 
 @pytest.fixture

--- a/tests/h/services/group_test.py
+++ b/tests/h/services/group_test.py
@@ -61,10 +61,10 @@ class TestGroupService(object):
 
         assert users['cazimir'] in group.members
 
-    def test_create_doesnt_add_group_creator_to_members_for_publisher_groups(self, db_session, users):
+    def test_create_doesnt_add_group_creator_to_members_for_open_groups(self, db_session, users):
         svc = GroupService(db_session, users.get)
 
-        group = svc.create('Anteater fans', 'foobar.com', 'cazimir', type_='publisher')
+        group = svc.create('Anteater fans', 'foobar.com', 'cazimir', type_='open')
 
         assert users['cazimir'] not in group.members
 
@@ -72,9 +72,9 @@ class TestGroupService(object):
         ('private', 'joinable_by', JoinableBy.authority),
         ('private', 'readable_by', ReadableBy.members),
         ('private', 'writeable_by', WriteableBy.members),
-        ('publisher', 'joinable_by', None),
-        ('publisher', 'readable_by', ReadableBy.world),
-        ('publisher', 'writeable_by', WriteableBy.authority)])
+        ('open', 'joinable_by', None),
+        ('open', 'readable_by', ReadableBy.world),
+        ('open', 'writeable_by', WriteableBy.authority)])
     def test_create_sets_access_flags_for_group_types(self,
                                                       db_session,
                                                       users,

--- a/tests/h/session_test.py
+++ b/tests/h/session_test.py
@@ -128,9 +128,9 @@ class TestProfile(object):
 
         assert private_group['public'] is False
 
-    def test_publisher_group_is_public(self, third_party_request, publisher_group):
+    def test_open_group_is_public(self, third_party_request, open_group):
         profile = session.profile(third_party_request)
-        group = [g for g in profile['groups'] if g['id'] == publisher_group.pubid][0]
+        group = [g for g in profile['groups'] if g['id'] == open_group.pubid][0]
 
         assert group['public'] is True
 
@@ -148,9 +148,9 @@ class TestProfile(object):
 
         assert private_group['url']
 
-    def test_publisher_group_has_no_url(self, third_party_request, publisher_group):
+    def test_open_group_has_no_url(self, third_party_request, open_group):
         profile = session.profile(third_party_request)
-        group = [g for g in profile['groups'] if g['id'] == publisher_group.pubid][0]
+        group = [g for g in profile['groups'] if g['id'] == open_group.pubid][0]
 
         assert 'url' not in group
 
@@ -224,16 +224,16 @@ class TestProfile(object):
         return u'thirdparty.example.org'
 
     @pytest.fixture
-    def third_party_request(self, authority, third_party_domain, publisher_group, fake_feature):
+    def third_party_request(self, authority, third_party_domain, open_group, fake_feature):
         return FakeRequest(authority,
                            u'acct:user@{}'.format(third_party_domain),
                            third_party_domain,
-                           {third_party_domain: [publisher_group]},
+                           {third_party_domain: [open_group]},
                            fake_feature)
 
     @pytest.fixture
-    def publisher_group(self):
-        return FakeGroup('abcdef', 'Publisher group', is_public=True)
+    def open_group(self):
+        return FakeGroup('abcdef', 'Open group', is_public=True)
 
 
 class TestUserInfo(object):


### PR DESCRIPTION
This is just a few commits renaming "publisher group" to "open group" throughout h. No behaviour changes here, just renaming.

It turns out that we we originally called "publisher groups" when we developed them for the eLife project (groups that are readable by anyone, writeable by anyone in the same authority, and can't be joined) are the same kind of groups as what we now want for the new "open groups" feature, so we're renaming the existing "publisher groups" to "open groups" throughout.

The only difference is that groups like eLife's belong to a third-party authority (they're "third-party open groups") whereas the new open groups we're working on are going to be first-party.

The new open groups also need to be scoped to a domain or domains, but that should and will also be true of eLife's group (which is currently not scoped but should be).

P.S. Even without any behaviour changes **it is already possible to create a first- or third-party open group in the DB**:

```
./bin/hypothesis --dev groups add-open-group --name Foobar --authority hypothes.is --creator seanh
```

It's not scoped, and it doesn't appear to work (doesn't appear in groups dropdown on activity pages or in client), but that will create a first-party open group in the DB. (Haven't tested what happens if you try to use this group via the API, or visit its activity page directly.)

P.S. I'll also look in to a client commit to rename publisher to open.