### PR TITLE
Add rudimentary profile/groups API endpoint and service

### DIFF
--- a/docs/_extra/api-reference/hypothesis.yaml
+++ b/docs/_extra/api-reference/hypothesis.yaml
@@ -168,9 +168,9 @@ paths:
           description: Profile information
           schema:
             $ref: '#/definitions/Profile'
-  /profile/groups:
+  /groups:
     get:
-      summary: Get list of groups for profile
+      summary: Get list of groups
       description: >
         Retrieve a list of accessible, applicable groups.
 

--- a/docs/_extra/api-reference/hypothesis.yaml
+++ b/docs/_extra/api-reference/hypothesis.yaml
@@ -168,6 +168,34 @@ paths:
           description: Profile information
           schema:
             $ref: '#/definitions/Profile'
+  /profile/groups:
+    get:
+      summary: Get list of groups for profile
+      description: >
+        Retrieve a list of accessible, applicable groups.
+
+      parameters:
+        - name: authority
+          in: query
+          description: >
+            Used to identify available public groups.
+            Applies only to non-authorized requests.
+          required: false
+          type: string
+          default: "hypothes.is"
+        - name: document_url
+          in: query
+          description: >
+            The URI for the current annotation target document.
+            All scoped public groups that apply to this URI will be included.
+          required: false
+          type: string
+          format: uri
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/GroupResults'
   /search:
     get:
       summary: Search for annotations
@@ -354,6 +382,12 @@ definitions:
       total:
         description: Total number of results matching query.
         type: integer
+  GroupResults:
+    type: array
+    items:
+      $ref: '#/definitions/Group'
+  Group:
+    $ref: './schemas/group-schema.json'
   NewUser:
     $ref: './schemas/new-user-schema.json'
   UpdateUser:

--- a/docs/_extra/api-reference/hypothesis.yaml
+++ b/docs/_extra/api-reference/hypothesis.yaml
@@ -174,6 +174,9 @@ paths:
       description: >
         Retrieve a list of accessible, applicable groups.
 
+        Note: This API service is pre-release and currently under development.
+        Be aware that parameters and response body will be changing.
+
       parameters:
         - name: authority
           in: query
@@ -183,19 +186,11 @@ paths:
           required: false
           type: string
           default: "hypothes.is"
-        - name: document_url
-          in: query
-          description: >
-            The URI for the current annotation target document.
-            All scoped public groups that apply to this URI will be included.
-          required: false
-          type: string
-          format: uri
       responses:
         '200':
           description: Success
           schema:
-            $ref: '#/definitions/GroupResults'
+            $ref: '#/definitions/ProfileGroupResults'
   /search:
     get:
       summary: Search for annotations
@@ -382,12 +377,12 @@ definitions:
       total:
         description: Total number of results matching query.
         type: integer
-  GroupResults:
+  ProfileGroupResults:
     type: array
     items:
-      $ref: '#/definitions/Group'
-  Group:
-    $ref: './schemas/group-schema.json'
+      $ref: '#/definitions/ProfileGroup'
+  ProfileGroup:
+    $ref: './schemas/profile-group-schema.json'
   NewUser:
     $ref: './schemas/new-user-schema.json'
   UpdateUser:

--- a/docs/_extra/api-reference/schemas/group-schema.json
+++ b/docs/_extra/api-reference/schemas/group-schema.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "required": [
+    "id",
+    "access",
+    "links",
+    "name",
+    "public",
+    "scoped",
+    "type"
+  ],
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "access": {
+      "type": "object",
+      "required": [
+        "write",
+        "leave"
+      ],
+      "properties": {
+        "write": {
+          "type": "boolean",
+          "description": "true if this user may post annotations to this group"
+        },
+        "leave": {
+          "type": "boolean",
+          "description": "true if this user is a member of this group"
+        }
+      }
+    },
+    "icon": {
+      "description": "present if this group has a custom icon",
+      "type": "string",
+      "format": "uri"
+    },
+    "urls": {
+      "type": "object",
+      "properties": {
+        "group": {
+          "description": "URL to the group's main page",
+          "type": "string",
+          "format": "uri"
+        },
+        "leave": {
+          "description": "URL for leaving (ending membership for) this group. Present on groups the user is a member of",
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "name": {
+      "type": "string"
+    },
+    "scoped": {
+      "type": "boolean",
+      "description": "Whether or not this group has URL restrictions for documents that may be annotated within it. Non-scoped (scope: false) groups allow annotation to documents at any URL."
+    },
+    "type": {
+      "type": "string",
+      "enum": ["private", "open"],
+      "description": "Derived group 'type' based on group access and scope settings"
+    },
+    "public": {
+      "type": "boolean",
+      "description": "indicates whether a group's annotations are world-readable"
+    },
+    "url": {
+      "type": "string",
+      "format": "uri",
+      "description": "URL to group page (only applies to some group types)"
+    }
+  }
+}

--- a/docs/_extra/api-reference/schemas/profile-group-schema.json
+++ b/docs/_extra/api-reference/schemas/profile-group-schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "required": [
+    "id",
+    "name",
+    "public"
+  ],
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "name": {
+      "type": "string"
+    },
+    "public": {
+      "type": "boolean",
+      "description": "indicates whether a group's annotations are world-readable"
+    }
+  }
+}

--- a/h/routes.py
+++ b/h/routes.py
@@ -95,6 +95,7 @@ def includeme(config):
                      factory='h.resources:AnnotationResourceFactory',
                      traverse='/{id}')
     config.add_route('api.profile', '/api/profile')
+    config.add_route('api.profile_groups', '/api/profile/groups')
     config.add_route('api.debug_token', '/api/debug-token')
     config.add_route('api.group_member',
                      '/api/groups/{pubid}/members/{user}',

--- a/h/routes.py
+++ b/h/routes.py
@@ -95,7 +95,7 @@ def includeme(config):
                      factory='h.resources:AnnotationResourceFactory',
                      traverse='/{id}')
     config.add_route('api.profile', '/api/profile')
-    config.add_route('api.profile_groups', '/api/profile/groups')
+    config.add_route('api.profile_groups', '/api/groups')
     config.add_route('api.debug_token', '/api/debug-token')
     config.add_route('api.group_member',
                      '/api/groups/{pubid}/members/{user}',

--- a/h/services/__init__.py
+++ b/h/services/__init__.py
@@ -25,6 +25,7 @@ def includeme(config):
     config.register_service_factory('.nipsa.nipsa_factory', name='nipsa')
     config.register_service_factory('.oauth_provider.oauth_provider_service_factory', name='oauth_provider')
     config.register_service_factory('.oauth_validator.oauth_validator_service_factory', name='oauth_validator')
+    config.register_service_factory('.profile_group.profile_groups_factory', name='profile_group')
     config.register_service_factory('.rename_user.rename_user_factory', name='rename_user')
     config.register_service_factory('.settings.settings_factory', name='settings')
     config.register_service_factory('.user.user_service_factory', name='user')

--- a/h/services/profile_group.py
+++ b/h/services/profile_group.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 
 class ProfileGroupService(object):
 

--- a/h/services/profile_group.py
+++ b/h/services/profile_group.py
@@ -1,8 +1,5 @@
 # -*- coding: utf-8 -*-
 
-import sqlalchemy as sa
-
-from h import session as h_session
 
 class ProfileGroupService(object):
 
@@ -33,6 +30,7 @@ class ProfileGroupService(object):
     def _group_model(self, group):
         model = {'name': group.name, 'id': group.pubid, 'public': group.is_public}
         return model
+
 
 def profile_groups_factory(context, request):
     """Return a ProfileGroupService instance for the passed context and request."""

--- a/h/services/profile_group.py
+++ b/h/services/profile_group.py
@@ -2,6 +2,7 @@
 
 from __future__ import unicode_literals
 
+
 class ProfileGroupService(object):
 
     """A service for retrieving groups associated with users."""

--- a/h/services/profile_group.py
+++ b/h/services/profile_group.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+
+import sqlalchemy as sa
+
+from h import session as h_session
+
+class ProfileGroupService(object):
+
+    """A service for retrieving groups associated with users."""
+
+    def __init__(self, session, open_group_finder):
+        """
+        Create a new profile_groups service.
+
+        :param session: the SQLAlchemy session object
+        :param open_group_finder: a callable for finding open groups
+        """
+        self.session = session
+        self.open_group_finder = open_group_finder
+
+    def all(self, user=None, authority=None):
+        """ return a list of all user groups"""
+
+        open_groups = self.open_group_finder(authority) or []
+        private_groups = []
+        if user is not None:
+            private_groups = user.groups
+
+        groups = open_groups + private_groups
+
+        return [self._group_model(group) for group in groups]
+
+    def _group_model(self, group):
+        model = {'name': group.name, 'id': group.pubid, 'public': group.is_public}
+        return model
+
+def profile_groups_factory(context, request):
+    """Return a ProfileGroupService instance for the passed context and request."""
+    auth_group_svc = request.find_service(name='authority_group')
+    return ProfileGroupService(session=request.db,
+                               open_group_finder=auth_group_svc.public_groups)

--- a/h/views/api_profile.py
+++ b/h/views/api_profile.py
@@ -34,6 +34,7 @@ def update_preferences(request):
 
     return h_session.profile(request)
 
+
 @api_config(route_name='api.profile_groups',
             request_method='GET',
             link_name='profile_groups.read',

--- a/h/views/api_profile.py
+++ b/h/views/api_profile.py
@@ -33,3 +33,11 @@ def update_preferences(request):
         raise APIError(e.message, status_code=400)
 
     return h_session.profile(request)
+
+@api_config(route_name='api.profile_groups',
+            request_method='GET',
+            link_name='profile_groups.read',
+            description="Fetch the user's groups")
+def profile(request):
+    authority = request.params.get('authority')
+    return h_session.profile(request, authority)

--- a/h/views/api_profile.py
+++ b/h/views/api_profile.py
@@ -38,6 +38,7 @@ def update_preferences(request):
             request_method='GET',
             link_name='profile_groups.read',
             description="Fetch the user's groups")
-def profile(request):
+def profile_groups(request):
     authority = request.params.get('authority')
-    return h_session.profile(request, authority)
+    svc = request.find_service(name='profile_group')
+    return svc.all(request.user, authority)

--- a/tests/h/routes_test.py
+++ b/tests/h/routes_test.py
@@ -78,6 +78,7 @@ def test_includeme():
              factory='h.resources:AnnotationResourceFactory',
              traverse='/{id}'),
         call('api.profile', '/api/profile'),
+        call('api.profile_groups', '/api/profile/groups'),
         call('api.debug_token', '/api/debug-token'),
         call('api.group_member', '/api/groups/{pubid}/members/{user}', factory='h.models.group:GroupFactory', traverse='/{pubid}'),
         call('api.search', '/api/search'),

--- a/tests/h/routes_test.py
+++ b/tests/h/routes_test.py
@@ -78,7 +78,7 @@ def test_includeme():
              factory='h.resources:AnnotationResourceFactory',
              traverse='/{id}'),
         call('api.profile', '/api/profile'),
-        call('api.profile_groups', '/api/profile/groups'),
+        call('api.profile_groups', '/api/groups'),
         call('api.debug_token', '/api/debug-token'),
         call('api.group_member', '/api/groups/{pubid}/members/{user}', factory='h.models.group:GroupFactory', traverse='/{pubid}'),
         call('api.search', '/api/search'),

--- a/tests/h/services/profile_group_test.py
+++ b/tests/h/services/profile_group_test.py
@@ -1,0 +1,116 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import mock
+import pytest
+
+from h.models.group import JoinableBy, ReadableBy, WriteableBy
+from h.services.profile_group import ProfileGroupService
+from h.services.profile_group import profile_groups_factory
+
+class TestProfileGroupService(object):
+    def test_all_returns_private_groups_for_user(self, db_session, user):
+        auth_group_svc = FakeAuthorityGroupService([])
+        svc = ProfileGroupService(db_session, open_group_finder=auth_group_svc.public_groups)
+
+        groups = svc.all(user)
+
+        assert [group['id'] for group in groups] == [group.pubid for group in user.groups]
+
+    def test_all_returns_no_private_groups_for_no_user(self, db_session):
+        auth_group_svc = FakeAuthorityGroupService([])
+        svc = ProfileGroupService(db_session, open_group_finder=auth_group_svc.public_groups)
+        groups = svc.all(user=None)
+
+        assert groups == []
+
+    def test_all_returns_world_group_for_no_user(self, db_session, world_group):
+        auth_group_svc = FakeAuthorityGroupService([world_group])
+        svc = ProfileGroupService(db_session,
+                                  open_group_finder=auth_group_svc.public_groups)
+
+        groups = svc.all(user=None)
+
+        assert groups[0]['id'] == world_group.pubid
+
+    def test_all_returns_open_groups_for_no_user(self, db_session, open_groups):
+        auth_group_svc = FakeAuthorityGroupService(open_groups)
+        svc = ProfileGroupService(db_session,
+                                  open_group_finder=auth_group_svc.public_groups)
+
+        groups = svc.all(user=None)
+
+        assert [group['id'] for group in groups] == [group.pubid for group in open_groups]
+
+    def test_all_proxies_authority_parameter_to_svc(self, db_session):
+        auth_group_svc = mock.Mock(spec_set=['public_groups'])
+        auth_group_svc.public_groups.return_value = []
+        svc = ProfileGroupService(db_session,
+                                  open_group_finder=auth_group_svc.public_groups)
+
+        groups = svc.all(user=None, authority="foo")
+
+        auth_group_svc.public_groups.assert_called_once_with("foo")
+
+    def test_all_includes_group_attributes(self, db_session, open_groups, user):
+        auth_group_svc = FakeAuthorityGroupService(open_groups)
+        svc = ProfileGroupService(db_session, open_group_finder=auth_group_svc.public_groups)
+
+        groups = svc.all(user)
+
+        assert 'id' in groups[0]
+        assert 'name' in groups[0]
+        assert 'public' in groups[0]
+
+@pytest.mark.usefixtures('authority_group_service')
+class TestProfileGroupsFactory(object):
+    def test_returns_profile_group_service(self, pyramid_request):
+        svc = profile_groups_factory(None, pyramid_request)
+
+        assert isinstance(svc, ProfileGroupService)
+
+    def test_provides_request_db_as_session(self, pyramid_request):
+        svc = profile_groups_factory(None, pyramid_request)
+
+        assert svc.session == pyramid_request.db
+
+    def test_wraps_auth_group_service_as_finder(self, pyramid_request, authority_group_service):
+        svc = profile_groups_factory(None, pyramid_request)
+
+        svc.all(authority='foo')
+
+        authority_group_service.public_groups.assert_called_once_with('foo')
+
+class FakeAuthorityGroupService(object):
+
+    def __init__(self, public_groups):
+        self._public_groups = public_groups
+
+    def public_groups(self, authority):
+        #return self._public_groups[authority]
+        return self._public_groups
+
+@pytest.fixture
+def user(factories):
+    user = factories.User(username='freya')
+    user.groups = [factories.Group(), factories.Group()]
+    return user
+
+@pytest.fixture
+def world_group(factories):
+    return factories.Group(name=u'Public',
+                    joinable_by=None,
+                    readable_by=ReadableBy.world,
+                    writeable_by=WriteableBy.authority)
+
+@pytest.fixture
+def open_groups(factories):
+    return [factories.OpenGroup(), factories.OpenGroup()]
+
+@pytest.fixture
+def authority_group_service(pyramid_config):
+    service = mock.Mock(spec_set=['public_groups'])
+    service.public_groups.return_value = None
+    pyramid_config.register_service(service, name='authority_group')
+    return service

--- a/tests/h/services/profile_group_test.py
+++ b/tests/h/services/profile_group_test.py
@@ -13,8 +13,7 @@ from h.services.profile_group import profile_groups_factory
 class TestProfileGroupService(object):
     def test_all_returns_private_groups_for_user(self, db_session, user):
         open_grp_svc = FakeAuthorityGroupService([])
-        svc = ProfileGroupService(db_session,
-                                  open_group_finder=open_grp_svc.public_groups)
+        svc = ProfileGroupService(db_session, open_group_finder=open_grp_svc.public_groups)
 
         groups = svc.all(user)
 
@@ -23,17 +22,13 @@ class TestProfileGroupService(object):
 
     def test_all_returns_no_private_groups_for_no_user(self, db_session):
         open_group_svc = FakeAuthorityGroupService([])
-        svc = ProfileGroupService(
-          db_session,
-          open_group_finder=open_group_svc.public_groups
-        )
+        svc = ProfileGroupService(db_session, open_group_finder=open_group_svc.public_groups)
 
         groups = svc.all(user=None)
 
         assert groups == []
 
-    def test_all_returns_world_group_for_no_user(self,
-                                                 db_session, world_group):
+    def test_all_returns_world_group_for_no_user(self, db_session, world_group):
         auth_group_svc = FakeAuthorityGroupService([world_group])
         svc = ProfileGroupService(db_session, open_group_finder=auth_group_svc.public_groups)
 
@@ -43,8 +38,7 @@ class TestProfileGroupService(object):
 
     def test_all_returns_open_groups_for_no_user(self, db_session, open_groups):
         auth_group_svc = FakeAuthorityGroupService(open_groups)
-        svc = ProfileGroupService(db_session,
-                                  open_group_finder=auth_group_svc.public_groups)
+        svc = ProfileGroupService(db_session, open_group_finder=auth_group_svc.public_groups)
 
         groups = svc.all(user=None)
 
@@ -53,22 +47,24 @@ class TestProfileGroupService(object):
     def test_all_proxies_authority_parameter_to_svc(self, db_session):
         auth_group_svc = mock.Mock(spec_set=['public_groups'])
         auth_group_svc.public_groups.return_value = []
-        svc = ProfileGroupService(db_session,
-                                  open_group_finder=auth_group_svc.public_groups)
+        svc = ProfileGroupService(db_session, open_group_finder=auth_group_svc.public_groups)
 
         svc.all(user=None, authority="foo")
 
         auth_group_svc.public_groups.assert_called_once_with("foo")
 
-    def test_all_includes_group_attributes(self, db_session, open_groups, user):
+    @pytest.mark.parametrize('attribute', [
+        ('id'),
+        ('name'),
+        ('public')
+    ])
+    def test_all_includes_group_attributes(self, db_session, open_groups, user, attribute):
         auth_group_svc = FakeAuthorityGroupService(open_groups)
         svc = ProfileGroupService(db_session, open_group_finder=auth_group_svc.public_groups)
 
         groups = svc.all(user)
 
-        assert 'id' in groups[0]
-        assert 'name' in groups[0]
-        assert 'public' in groups[0]
+        assert attribute in groups[0]
 
 
 @pytest.mark.usefixtures('authority_group_service')

--- a/tests/h/services/profile_group_test.py
+++ b/tests/h/services/profile_group_test.py
@@ -5,30 +5,37 @@ from __future__ import unicode_literals
 import mock
 import pytest
 
-from h.models.group import JoinableBy, ReadableBy, WriteableBy
+from h.models.group import ReadableBy, WriteableBy
 from h.services.profile_group import ProfileGroupService
 from h.services.profile_group import profile_groups_factory
 
+
 class TestProfileGroupService(object):
     def test_all_returns_private_groups_for_user(self, db_session, user):
-        auth_group_svc = FakeAuthorityGroupService([])
-        svc = ProfileGroupService(db_session, open_group_finder=auth_group_svc.public_groups)
+        open_grp_svc = FakeAuthorityGroupService([])
+        svc = ProfileGroupService(db_session,
+                                  open_group_finder=open_grp_svc.public_groups)
 
         groups = svc.all(user)
 
-        assert [group['id'] for group in groups] == [group.pubid for group in user.groups]
+        assert ([group['id'] for group in groups] ==
+                [group.pubid for group in user.groups])
 
     def test_all_returns_no_private_groups_for_no_user(self, db_session):
-        auth_group_svc = FakeAuthorityGroupService([])
-        svc = ProfileGroupService(db_session, open_group_finder=auth_group_svc.public_groups)
+        open_group_svc = FakeAuthorityGroupService([])
+        svc = ProfileGroupService(
+          db_session,
+          open_group_finder=open_group_svc.public_groups
+        )
+
         groups = svc.all(user=None)
 
         assert groups == []
 
-    def test_all_returns_world_group_for_no_user(self, db_session, world_group):
+    def test_all_returns_world_group_for_no_user(self,
+                                                 db_session, world_group):
         auth_group_svc = FakeAuthorityGroupService([world_group])
-        svc = ProfileGroupService(db_session,
-                                  open_group_finder=auth_group_svc.public_groups)
+        svc = ProfileGroupService(db_session, open_group_finder=auth_group_svc.public_groups)
 
         groups = svc.all(user=None)
 
@@ -49,7 +56,7 @@ class TestProfileGroupService(object):
         svc = ProfileGroupService(db_session,
                                   open_group_finder=auth_group_svc.public_groups)
 
-        groups = svc.all(user=None, authority="foo")
+        svc.all(user=None, authority="foo")
 
         auth_group_svc.public_groups.assert_called_once_with("foo")
 
@@ -62,6 +69,7 @@ class TestProfileGroupService(object):
         assert 'id' in groups[0]
         assert 'name' in groups[0]
         assert 'public' in groups[0]
+
 
 @pytest.mark.usefixtures('authority_group_service')
 class TestProfileGroupsFactory(object):
@@ -82,14 +90,15 @@ class TestProfileGroupsFactory(object):
 
         authority_group_service.public_groups.assert_called_once_with('foo')
 
+
 class FakeAuthorityGroupService(object):
 
     def __init__(self, public_groups):
         self._public_groups = public_groups
 
     def public_groups(self, authority):
-        #return self._public_groups[authority]
         return self._public_groups
+
 
 @pytest.fixture
 def user(factories):
@@ -97,16 +106,19 @@ def user(factories):
     user.groups = [factories.Group(), factories.Group()]
     return user
 
+
 @pytest.fixture
 def world_group(factories):
     return factories.Group(name=u'Public',
-                    joinable_by=None,
-                    readable_by=ReadableBy.world,
-                    writeable_by=WriteableBy.authority)
+                           joinable_by=None,
+                           readable_by=ReadableBy.world,
+                           writeable_by=WriteableBy.authority)
+
 
 @pytest.fixture
 def open_groups(factories):
     return [factories.OpenGroup(), factories.OpenGroup()]
+
 
 @pytest.fixture
 def authority_group_service(pyramid_config):

--- a/tests/h/views/api_profile_test.py
+++ b/tests/h/views/api_profile_test.py
@@ -24,17 +24,18 @@ class TestProfile(object):
         session_profile.assert_called_once_with(pyramid_request, 'foo.com')
         assert result == session_profile.return_value
 
+
 @pytest.mark.usefixtures('profile_group_service')
 class TestProfileGroups(object):
     def test_profile_groups_proxies_to_service(self, pyramid_request, profile_group_service):
-        result = api_profile.profile_groups(pyramid_request)
+        api_profile.profile_groups(pyramid_request)
 
         assert profile_group_service.called_once()
 
     def test_profile_groups_passes_authority_parameter(self, pyramid_request, profile_group_service):
         pyramid_request.params = {'authority': 'foo.com'}
 
-        result = api_profile.profile_groups(pyramid_request)
+        api_profile.profile_groups(pyramid_request)
 
         assert profile_group_service.called_once_with(pyramid_request, 'foo.com')
 
@@ -53,6 +54,7 @@ class TestProfileGroups(object):
         svc = mock.Mock()
         pyramid_config.register_service(svc, name='profile_group')
         return svc
+
 
 @pytest.mark.usefixtures('user_service', 'session_profile')
 class TestUpdatePreferences(object):

--- a/tests/h/views/api_profile_test.py
+++ b/tests/h/views/api_profile_test.py
@@ -24,6 +24,20 @@ class TestProfile(object):
         session_profile.assert_called_once_with(pyramid_request, 'foo.com')
         assert result == session_profile.return_value
 
+class TestProfileGroups(object):
+    def test_profile_view_proxies_to_session(self, session_profile, pyramid_request):
+        result = api_profile.profile(pyramid_request)
+
+        session_profile.assert_called_once_with(pyramid_request, None)
+        assert result == session_profile.return_value
+
+    def test_profile_passes_authority_parameter(self, session_profile, pyramid_request):
+        pyramid_request.params = {'authority': 'foo.com'}
+
+        result = api_profile.profile(pyramid_request)
+
+        session_profile.assert_called_once_with(pyramid_request, 'foo.com')
+        assert result == session_profile.return_value
 
 @pytest.mark.usefixtures('user_service', 'session_profile')
 class TestUpdatePreferences(object):


### PR DESCRIPTION
What this does:

* Adds a new endpoint at `GET /profile/groups` with associated view and route
* Adds a new service `ProfileGroupService` which will be ultimately responsible for building a list of applicable groups for a given user based on a number of factors
* Satisfies the API signature and schema given in the exposed docs
* Provides properties of pre-existing `GET /profile` `groups`, excepting `url` for the moment

What this doesn't do but is on the immediate horizon:

* Sort groups
* Provide new attrs (`type`, e.g.)
* Provide URL(s) for groups 
* Accept `document_url` parameter

As it is additive and new, the addition of this service and endpoint shouldn't interact or affect any other services or endpoints in the backend application.

Related to https://github.com/hypothesis/product-backlog/issues/450