### PR TITLE
Add groupscope model and service for creating open groups

### DIFF
--- a/h/models/__init__.py
+++ b/h/models/__init__.py
@@ -30,6 +30,7 @@ from h.models.feature import Feature
 from h.models.feature_cohort import FeatureCohort
 from h.models.flag import Flag
 from h.models.group import Group
+from h.models.group_scope import GroupScope
 from h.models.setting import Setting
 from h.models.subscriptions import Subscriptions
 from h.models.token import Token
@@ -50,6 +51,7 @@ __all__ = (
     'FeatureCohort',
     'Flag',
     'Group',
+    'GroupScope',
     'Setting',
     'Subscriptions',
     'Token',

--- a/h/models/group_scope.py
+++ b/h/models/group_scope.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import sqlalchemy as sa
+
+from h._compat import urlparse
+from h.db import Base, mixins
+
+
+class GroupScope(Base):
+    __tablename__ = 'groupscope'
+    id = sa.Column(sa.Integer, autoincrement=True, primary_key=True)
+
+    #: A fully qualified domain name, e.g. example.com, www.nytimes.com or
+    #: web.hypothes.is.
+    hostname = sa.Column('hostname', sa.UnicodeText)
+
+    groups = sa.orm.relationship(
+        'Group',
+        secondary='groupscope_group',
+        backref=sa.orm.backref('scopes', order_by='Group.name'),
+    )
+
+    def __repr__(self):
+        return '<GroupScope %s>' % self.id
+
+
+GROUP_GROUPSCOPE_TABLE = sa.Table('groupscope_group', Base.metadata,
+    sa.Column('id', sa.Integer, autoincrement=True, primary_key=True),
+    sa.Column('group_id', sa.Integer, sa.ForeignKey('group.id')),
+    sa.Column('groupscope_id', sa.Integer, sa.ForeignKey('groupscope.id')),
+    sa.UniqueConstraint('group_id', 'groupscope_id'),
+)


### PR DESCRIPTION
Preview of some progress on the groups model. This is the direction I'm heading in.

Usage at the model level:

```python
$ ./bin/hypothesis --dev shell
Python 2.7.14 (default, Sep 23 2017, 22:06:14) 
Type "copyright", "credits" or "license" for more information.

IPython 5.5.0 -- An enhanced Interactive Python.
?         -> Introduction and overview of IPython's features.
%quickref -> Quick reference.
help      -> Python's own help system.
object?   -> Details about 'object', use 'object??' for extra details.

Environment:
  m, models    The `h.models` module.
  registry     Active Pyramid registry.
  request      Active request object.
  session      Active database session.

In [1]: s1 = models.GroupScope(hostname=u'www.nytimes.com')

In [2]: s2 = models.GroupScope(hostname=u'example.com')

In [3]: request.db.add_all([s1, s2])

In [4]: request.db.flush()

In [5]: g = models.Group(pubid=u'abc123', authority=u'localhost', name=u'Foobar', scopes=[s1, s2])

In [6]: g.scopes
Out[6]: [<GroupScope 10>, <GroupScope 11>]

In [7]: s1.groups
Out[7]: [<Group: foobar>]
```

Usage at the service level:

```python
In [1]: svc = request.find_service(name='group')

In [2]: svc.create_open_group(u'Foobar', u'localhost', u'acct:seanh@localhost', [u'www.nytimes.com', u'www.seanh.cc'])
Out[2]: <Group: foobar>
```