### PR TITLE
Add profile groups properties

### DIFF
--- a/docs/_extra/api-reference/schemas/profile-group-schema.json
+++ b/docs/_extra/api-reference/schemas/profile-group-schema.json
@@ -4,7 +4,10 @@
   "required": [
     "id",
     "name",
-    "public"
+    "public",
+    "scoped",
+    "type",
+    "urls"
   ],
   "properties": {
     "id": {
@@ -16,6 +19,35 @@
     "public": {
       "type": "boolean",
       "description": "indicates whether a group's annotations are world-readable"
+    },
+    "scoped": {
+      "type": "boolean",
+      "description": "Whether or not this group has URL restrictions for documents that may be annotated within it. Non-scoped (scope: false) groups allow annotation to documents at any URL."
+    },
+    "type": {
+      "type": "string",
+      "enum": ["private", "open"],
+      "description": "Derived group 'type' based on group access and scope settings"
+    },
+    "url": {
+      "type": "string",
+      "format": "uri",
+      "description": "URL to group page (only applies to some group types)"
+    },
+    "urls": {
+      "type": "object",
+      "properties": {
+        "group": {
+          "description": "URL to the group's main page",
+          "type": "string",
+          "format": "uri"
+        },
+        "leave": {
+          "description": "URL for leaving (ending membership for) this group. Present on groups the user is a member of",
+          "type": "string",
+          "format": "uri"
+        }
+      }
     }
   }
 }

--- a/h/services/profile_group.py
+++ b/h/services/profile_group.py
@@ -7,7 +7,7 @@ class ProfileGroupService(object):
 
     """A service for retrieving groups associated with users."""
 
-    def __init__(self, session, open_group_finder):
+    def __init__(self, session, route_url, open_group_finder):
         """
         Create a new profile_groups service.
 
@@ -15,6 +15,7 @@ class ProfileGroupService(object):
         :param open_group_finder: a callable for finding open groups
         """
         self.session = session
+        self.route_url = route_url
         self.open_group_finder = open_group_finder
 
     def all(self, user=None, authority=None):
@@ -30,7 +31,21 @@ class ProfileGroupService(object):
         return [self._group_model(group) for group in groups]
 
     def _group_model(self, group):
-        model = {'name': group.name, 'id': group.pubid, 'public': group.is_public}
+        model = {
+          'name': group.name,
+          'id': group.pubid,
+          'public': group.is_public,
+          'scoped': False,  # TODO
+          'type': 'open' if group.is_public else 'private',  # TODO
+          'urls': {}
+        }
+        if not group.is_public:
+            # `url` legacy property support
+            model['url'] = self.route_url('group_read',
+                                          pubid=group.pubid,
+                                          slug=group.slug)
+            # `urls` are the future
+            model['urls']['group'] = model['url']
         return model
 
 
@@ -38,4 +53,5 @@ def profile_groups_factory(context, request):
     """Return a ProfileGroupService instance for the passed context and request."""
     auth_group_svc = request.find_service(name='authority_group')
     return ProfileGroupService(session=request.db,
+                               route_url=request.route_url,
                                open_group_finder=auth_group_svc.public_groups)

--- a/h/services/profile_group.py
+++ b/h/services/profile_group.py
@@ -18,6 +18,10 @@ class ProfileGroupService(object):
         self.route_url = route_url
         self.open_group_finder = open_group_finder
 
+    def sort(self, groups):
+        """ sort a list of groups of a single type """
+        return sorted(groups, key=lambda group: (group.name.lower(), group.pubid))
+
     def all(self, user=None, authority=None):
         """ return a list of all user groups"""
 
@@ -26,7 +30,7 @@ class ProfileGroupService(object):
         if user is not None:
             private_groups = user.groups
 
-        groups = open_groups + private_groups
+        groups = self.sort(open_groups) + self.sort(private_groups)
 
         return [self._group_model(group) for group in groups]
 

--- a/h/session.py
+++ b/h/session.py
@@ -67,15 +67,6 @@ def pop_flash(request):
             for k in ['error', 'info', 'warning', 'success']}
 
 
-def _group_sort_key(group):
-    """Sort private groups for the session model list"""
-
-    # groups are sorted first by name but also by ID
-    # so that multiple groups with the same name are displayed
-    # in a consistent order in clients
-    return (group.name.lower(), group.pubid)
-
-
 def _current_groups(request, authority):
     """Return a list of the groups the current user is a member of.
 
@@ -87,16 +78,17 @@ def _current_groups(request, authority):
     authority_groups = (request.find_service(name='authority_group')
                         .public_groups(authority=authority))
 
-    groups = authority_groups + _user_groups(user)
+    groups = authority_groups + _user_groups(user, request)
 
     return [_group_model(request.route_url, group) for group in groups]
 
 
-def _user_groups(user):
+def _user_groups(user, request):
     if user is None:
         return []
     else:
-        return sorted(user.groups, key=_group_sort_key)
+        profile_groups_svc = request.find_service(name='profile_group')
+        return profile_groups_svc.sort(user.groups)
 
 
 def _group_model(route_url, group):

--- a/tests/h/services/profile_group_test.py
+++ b/tests/h/services/profile_group_test.py
@@ -40,6 +40,69 @@ class TestProfileGroupService(object):
 
         assert [group['id'] for group in groups] == [group.pubid for group in open_groups]
 
+    def test_sort_sorts_private_groups_by_name(self, profile_group_factory, factories):
+        user = factories.User()
+        user.groups = [factories.Group(name='zedd'),
+                       factories.Group(name='alpha')]
+        svc = profile_group_factory([])
+
+        groups = svc.all(user)
+
+        names = [group['name'] for group in groups]
+        assert names == ['alpha', 'zedd']
+
+    def test_sort_sorts_private_groups_by_pubid(self, profile_group_factory, factories):
+        user = factories.User()
+        user.groups = [factories.Group(name='zedd', pubid='yyyyy'),
+                       factories.Group(name='alpha', pubid='zzzzz'),
+                       factories.Group(name='zedd', pubid='aaaaa')]
+        svc = profile_group_factory([])
+
+        groups = svc.all(user)
+
+        sorted_groups = [(group['id'], group['name']) for group in groups]
+        assert sorted_groups == [('zzzzz', 'alpha'), ('aaaaa', 'zedd'), ('yyyyy', 'zedd')]
+
+    def test_sort_sorts_public_groups_by_name(self, profile_group_factory, factories):
+        svc = profile_group_factory([
+            factories.OpenGroup(name='zedd', pubid='aaaaa'),
+            factories.OpenGroup(name='alpha', pubid='zzzzz')
+        ])
+
+        groups = svc.all()
+
+        names = [group['name'] for group in groups]
+        assert names == ['alpha', 'zedd']
+
+    def test_sort_sorts_public_groups_by_pubid(self, profile_group_factory, factories):
+        svc = profile_group_factory([
+            factories.OpenGroup(name='zedd', pubid='yyyyy'),
+            factories.OpenGroup(name='zedd', pubid='aaaaa'),
+            factories.OpenGroup(name='alpha', pubid='zzzzz')
+        ])
+
+        groups = svc.all()
+
+        sorted_groups = [(group['id'], group['name']) for group in groups]
+        assert sorted_groups == [('zzzzz', 'alpha'), ('aaaaa', 'zedd'), ('yyyyy', 'zedd')]
+
+    def test_sort_sorts_groups_by_type(self, profile_group_factory, factories):
+        """ open groups should come first """
+        user = factories.User()
+        user.groups = [
+            factories.Group(name='zebra2', pubid='apple'),
+            factories.Group(name='zebra', pubid='zebra')
+        ]
+        svc = profile_group_factory([
+            factories.OpenGroup(name='zedd', pubid='yyyyy'),
+            factories.OpenGroup(name='alpha', pubid='zzzzz')
+        ])
+
+        groups = svc.all(user)
+
+        names = [group['name'] for group in groups]
+        assert names == ['alpha', 'zedd', 'zebra', 'zebra2']
+
     def test_all_proxies_authority_parameter_to_svc(self, db_session, pyramid_request):
         auth_group_svc = mock.Mock(spec_set=['public_groups'])
         auth_group_svc.public_groups.return_value = []

--- a/tests/h/services/profile_group_test.py
+++ b/tests/h/services/profile_group_test.py
@@ -11,43 +11,43 @@ from h.services.profile_group import profile_groups_factory
 
 
 class TestProfileGroupService(object):
-    def test_all_returns_private_groups_for_user(self, db_session, user):
-        open_grp_svc = FakeAuthorityGroupService([])
-        svc = ProfileGroupService(db_session, open_group_finder=open_grp_svc.public_groups)
+    def test_all_returns_private_groups_for_user(self, profile_group_factory, user):
+        svc = profile_group_factory([])
 
         groups = svc.all(user)
 
         assert ([group['id'] for group in groups] ==
                 [group.pubid for group in user.groups])
 
-    def test_all_returns_no_private_groups_for_no_user(self, db_session):
-        open_group_svc = FakeAuthorityGroupService([])
-        svc = ProfileGroupService(db_session, open_group_finder=open_group_svc.public_groups)
+    def test_all_returns_no_private_groups_for_no_user(self, profile_group_factory):
+        svc = profile_group_factory([])
 
         groups = svc.all(user=None)
 
         assert groups == []
 
-    def test_all_returns_world_group_for_no_user(self, db_session, world_group):
-        auth_group_svc = FakeAuthorityGroupService([world_group])
-        svc = ProfileGroupService(db_session, open_group_finder=auth_group_svc.public_groups)
+    def test_all_returns_world_group_for_no_user(self, profile_group_factory, world_group):
+        svc = profile_group_factory([world_group])
 
         groups = svc.all(user=None)
 
         assert groups[0]['id'] == world_group.pubid
 
-    def test_all_returns_open_groups_for_no_user(self, db_session, open_groups):
-        auth_group_svc = FakeAuthorityGroupService(open_groups)
-        svc = ProfileGroupService(db_session, open_group_finder=auth_group_svc.public_groups)
+    def test_all_returns_open_groups_for_no_user(self, profile_group_factory, open_groups):
+        svc = profile_group_factory(open_groups)
 
         groups = svc.all(user=None)
 
         assert [group['id'] for group in groups] == [group.pubid for group in open_groups]
 
-    def test_all_proxies_authority_parameter_to_svc(self, db_session):
+    def test_all_proxies_authority_parameter_to_svc(self, db_session, pyramid_request):
         auth_group_svc = mock.Mock(spec_set=['public_groups'])
         auth_group_svc.public_groups.return_value = []
-        svc = ProfileGroupService(db_session, open_group_finder=auth_group_svc.public_groups)
+        svc = ProfileGroupService(
+          db_session,
+          route_url=pyramid_request.route_url,
+          open_group_finder=auth_group_svc.public_groups
+        )
 
         svc.all(user=None, authority="foo")
 
@@ -56,15 +56,34 @@ class TestProfileGroupService(object):
     @pytest.mark.parametrize('attribute', [
         ('id'),
         ('name'),
-        ('public')
+        ('public'),
+        ('scoped'),
+        ('type')
     ])
-    def test_all_includes_group_attributes(self, db_session, open_groups, user, attribute):
-        auth_group_svc = FakeAuthorityGroupService(open_groups)
-        svc = ProfileGroupService(db_session, open_group_finder=auth_group_svc.public_groups)
+    def test_all_includes_group_attributes(self, profile_group_factory, open_groups, user, attribute):
+        svc = profile_group_factory(open_groups)
 
         groups = svc.all(user)
 
         assert attribute in groups[0]
+
+    def test_open_groups_do_not_have_group_url(self, profile_group_factory, open_groups):
+        svc = profile_group_factory(open_groups)
+
+        groups = svc.all()
+
+        for open_group in groups:
+            assert 'url' not in open_group
+            assert 'group' not in open_group['urls']
+
+    def test_private_groups_have_group_url(self, profile_group_factory, user):
+        svc = profile_group_factory([])
+
+        groups = svc.all(user)
+
+        for private_group in groups:
+            assert 'url' in private_group
+            assert 'group' in private_group['urls']
 
 
 @pytest.mark.usefixtures('authority_group_service')
@@ -122,3 +141,27 @@ def authority_group_service(pyramid_config):
     service.public_groups.return_value = None
     pyramid_config.register_service(service, name='authority_group')
     return service
+
+
+@pytest.fixture
+def pyramid_request(pyramid_request):
+    pyramid_request.route_url = mock.Mock(return_value='/group/a')
+    return pyramid_request
+
+
+@pytest.fixture
+def profile_group_factory(db_session, pyramid_request):
+    """
+    Return a callable that will create a ProfileGroupService.
+
+    Return a callable that will create a ProfileGroupService
+    with a fake AuthorityGroupService whose ``public_groups``
+    will return the passed ``open_groups``
+    """
+    def service_builder(open_groups):
+        return ProfileGroupService(
+          session=db_session,
+          route_url=pyramid_request.route_url,
+          open_group_finder=FakeAuthorityGroupService(open_groups).public_groups
+         )
+    return service_builder


### PR DESCRIPTION
This PR adds additional properties to groups objects returned by the new `GET /groups` service, including:

* `type`: either `private` or `open` and right now based on the value of the `is_public` attribute on group models (that will most likely change as we move forward)
* `scoped`: Boolean, currently hard-coded to `False` pending model changes
* `urls`: object containing 0-n URLs for the `group`
* `url`: support for the legacy `url` property (this may get dropped)

Groups are now nominally sorted, with open groups coming first.

Sorting has been moved out of `session` and into the `ProfileGroup` service.

Next step: make this service take a `document_uri` param.

related to https://github.com/hypothesis/product-backlog/issues/450