### PR TITLE
Make h flake8 clean and lint during Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,16 @@ matrix:
     - env: ACTION=frontend-lint
       language: node_js
       node_js: '6.7'
-      script: gulp lint
+      script:
+        gulp lint
+
+    # Lint backend code
+    - env: ACTION=backend-lint
+      language: python
+      python: '2.7'
+      script:
+        make lint
+
 
 cache:
   directories:

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,10 @@ test: node_modules/.uptodate
 	tox
 	$(GULP) test
 
+.PHONY: lint
+lint: .pydeps
+	flake8 h
+
 ################################################################################
 
 # Fake targets to aid with deps installation

--- a/h/_version.py
+++ b/h/_version.py
@@ -20,6 +20,7 @@ VERSION_GIT_DATE = '$Format:%ct$'
 # Fallback version in case we cannot derive the version.
 VERSION_UNKNOWN = '0+unknown'
 
+
 def fetch_git_ref():
     return subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD'],
                                    stderr=DEVNULL).strip()

--- a/h/accounts/util.py
+++ b/h/accounts/util.py
@@ -6,6 +6,7 @@ import re
 
 from h._compat import urlparse
 
+
 def validate_url(url):
     """
     Validate an HTTP(S) URL as a link for a user's profile.

--- a/h/accounts/util.py
+++ b/h/accounts/util.py
@@ -44,9 +44,9 @@ def validate_orcid(orcid):
     Returns the normalized ORCID if successfully parsed or raises a ValueError
     otherwise.
     """
-    ORCID_REGEX = '\A[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{3}[0-9X]\Z'
+    orcid_regex = '\A[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{3}[0-9X]\Z'
 
-    if not re.match(ORCID_REGEX, orcid):
+    if not re.match(orcid_regex, orcid):
         raise ValueError('The format of this ORCID is incorrect'.format(orcid))
 
     if _orcid_checksum_digit(orcid[:-1]) != orcid[-1:]:

--- a/h/activity/query.py
+++ b/h/activity/query.py
@@ -12,7 +12,7 @@ from h import links
 from h import presenters
 from h import storage
 from h.activity import bucketing
-from h.models import Annotation, Document, Group
+from h.models import Annotation, Group
 from h.search import Search
 from h.search import parser
 from h.search.query import (

--- a/h/celery.py
+++ b/h/celery.py
@@ -32,7 +32,7 @@ celery.conf.update(
     # Default to using database number 10 so we don't conflict with the session
     # store.
     BROKER_URL=os.environ.get('CELERY_BROKER_URL',
-        os.environ.get('BROKER_URL', 'amqp://guest:guest@localhost:5672//')),
+                              os.environ.get('BROKER_URL', 'amqp://guest:guest@localhost:5672//')),
     CELERYBEAT_SCHEDULE={
         'purge-deleted-annotations': {
             'task': 'h.tasks.cleanup.purge_deleted_annotations',

--- a/h/emails/flag_notification.py
+++ b/h/emails/flag_notification.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 
 from pyramid.renderers import render
 
-from h.i18n import TranslationString as _
+from h.i18n import TranslationString as _  # noqa: N813
 
 
 def generate(request, email, incontext_link):

--- a/h/emails/reset_password.py
+++ b/h/emails/reset_password.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 
 from pyramid.renderers import render
 
-from h.i18n import TranslationString as _
+from h.i18n import TranslationString as _  # noqa: N813
 
 
 def generate(request, user):

--- a/h/emails/signup.py
+++ b/h/emails/signup.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 
 from pyramid.renderers import render
 
-from h.i18n import TranslationString as _
+from h.i18n import TranslationString as _  # noqa: N813
 
 
 def generate(request, id, email, activation_code):

--- a/h/exceptions.py
+++ b/h/exceptions.py
@@ -4,7 +4,7 @@
 
 from __future__ import unicode_literals
 
-from h.i18n import TranslationString as _
+from h.i18n import TranslationString as _  # noqa: N813
 
 
 class APIError(Exception):

--- a/h/feeds/rss.py
+++ b/h/feeds/rss.py
@@ -13,7 +13,7 @@ import h.feeds.util
 _ = i18n.TranslationStringFactory(__package__)
 
 
-def _pubDate_string(timestamp):
+def _pubdate_string(timestamp):
     """Return a RFC2822-formatted pubDate string for the given timestamp.
 
     Return a pubDate string like 'Tue, 03 Jun 2003 09:39:21 -0000'.
@@ -42,7 +42,7 @@ def _feed_item_from_annotation(annotation, annotation_url):
         "author": {"name": name},
         "title": annotation.title,
         "description": annotation.description,
-        "pubDate": _pubDate_string(annotation.created),
+        "pubDate": _pubdate_string(annotation.created),
         "guid": h.feeds.util.tag_uri_for_annotation(annotation, annotation_url),
         "link": annotation_url(annotation)
     }
@@ -73,6 +73,6 @@ def feed_from_annotations(annotations, annotation_url, rss_url, html_url,
     }
 
     if annotations:
-        feed['pubDate'] = _pubDate_string(annotations[0].updated)
+        feed['pubDate'] = _pubdate_string(annotations[0].updated)
 
     return feed

--- a/h/feeds/util.py
+++ b/h/feeds/util.py
@@ -4,7 +4,7 @@ from h._compat import urlparse
 # See RFC4151 for details of the use and format of the tag date:
 #
 #   https://tools.ietf.org/html/rfc4151#section-2.1
-FEED_TAG_DATE='2015-09'
+FEED_TAG_DATE = '2015-09'
 
 
 def tag_uri_for_annotation(annotation, annotation_url):

--- a/h/formatters/annotation_flag.py
+++ b/h/formatters/annotation_flag.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 
 from zope.interface import implementer
 
-from h import models
 from h.formatters.interfaces import IAnnotationFormatter
 
 

--- a/h/jinja_extensions.py
+++ b/h/jinja_extensions.py
@@ -3,7 +3,6 @@
 import datetime
 from functools import partial
 import json
-import re
 
 try:
     from xml.etree import cElementTree as ElementTree

--- a/h/migrations/env.py
+++ b/h/migrations/env.py
@@ -82,6 +82,7 @@ def run_migrations_online():
     finally:
         connection.close()
 
+
 configure_logging()
 
 if context.is_offline_mode():

--- a/h/models/group.py
+++ b/h/models/group.py
@@ -6,7 +6,6 @@ from pyramid import security
 from sqlalchemy.orm import exc
 import slugify
 
-from h.models.annotation import Annotation
 from h.db import Base
 from h.db import mixins
 from h import pubid

--- a/h/models/token.py
+++ b/h/models/token.py
@@ -7,7 +7,6 @@ import datetime
 import sqlalchemy
 from sqlalchemy.dialects import postgresql
 
-from h import security
 from h.db import Base
 from h.db import mixins
 

--- a/h/models/user.py
+++ b/h/models/user.py
@@ -142,7 +142,7 @@ class User(Base):
     __tablename__ = 'user'
 
     @declared_attr
-    def __table_args__(cls):
+    def __table_args__(cls):  # noqa: N805
         return (
             # (email, authority) must be unique
             sa.UniqueConstraint('email', 'authority'),
@@ -214,7 +214,7 @@ class User(Base):
         self._username = value
 
     @username.comparator
-    def username(cls):
+    def username(cls):  # noqa: N805
         return UsernameComparator(cls._username)
 
     @hybrid_property
@@ -223,7 +223,7 @@ class User(Base):
                                                      authority=self.authority)
 
     @userid.comparator
-    def userid(cls):
+    def userid(cls):  # noqa: N805
         return UserIDComparator(cls.username, cls.authority)
 
     email = sa.Column(sa.UnicodeText(), nullable=False)

--- a/h/resources.py
+++ b/h/resources.py
@@ -101,7 +101,7 @@ class AuthClientFactory(object):
             client.__parent__ = Root(self.request)
 
             return client
-        except:
+        except:  # noqa: E722
             # No such client found or not a valid UUID.
             raise KeyError()
 

--- a/h/search/core.py
+++ b/h/search/core.py
@@ -137,7 +137,7 @@ class Search(object):
         except ConnectionTimeout:
             s.incr('search.query.timeout')
             raise
-        except:
+        except:  # noqa: E722
             s.incr('search.query.error')
             raise
         finally:

--- a/h/services/group.py
+++ b/h/services/group.py
@@ -5,7 +5,7 @@ from functools import partial
 import sqlalchemy as sa
 
 from h import session
-from h.models import Annotation, Group, User
+from h.models import Group, User
 from h.models.group import JoinableBy, ReadableBy, WriteableBy
 
 GROUP_ACCESS_FLAGS = {

--- a/h/services/links.py
+++ b/h/services/links.py
@@ -63,9 +63,9 @@ class LinksService(object):
         for name, (g, hidden) in self.registry[LINK_GENERATORS_KEY].items():
             if hidden:
                 continue
-            l = g(self._request, annotation)
-            if l is not None:
-                links[name] = l
+            link = g(self._request, annotation)
+            if link is not None:
+                links[name] = link
         return links
 
 

--- a/h/streamer/filter.py
+++ b/h/streamer/filter.py
@@ -161,7 +161,7 @@ class FilterHandler(object):
 
 def first_of(a, b):
     return a[0] == b
-setattr(operator, 'first_of', first_of)
+setattr(operator, 'first_of', first_of)  # noqa:E305
 
 
 def match_of(a, b):
@@ -169,32 +169,32 @@ def match_of(a, b):
         if subb in a:
             return True
     return False
-setattr(operator, 'match_of', match_of)
+setattr(operator, 'match_of', match_of)  # noqa:E305
 
 
 def lene(a, b):
     return len(a) == b
-setattr(operator, 'lene', lene)
+setattr(operator, 'lene', lene)  # noqa:E305
 
 
 def leng(a, b):
     return len(a) > b
-setattr(operator, 'leng', leng)
+setattr(operator, 'leng', leng)  # noqa:E305
 
 
 def lenge(a, b):
     return len(a) >= b
-setattr(operator, 'lenge', lenge)
+setattr(operator, 'lenge', lenge)  # noqa:E305
 
 
 def lenl(a, b):
     return len(a) < b
-setattr(operator, 'lenl', lenl)
+setattr(operator, 'lenl', lenl)  # noqa:E305
 
 
 def lenle(a, b):
     return len(a) <= b
-setattr(operator, 'lenle', lenle)
+setattr(operator, 'lenle', lenle)  # noqa:E305
 
 
 def uni_fold(text):

--- a/h/streamer/streamer.py
+++ b/h/streamer/streamer.py
@@ -100,7 +100,7 @@ def process_work_queue(settings, queue, session_factory=None):
         except (KeyboardInterrupt, SystemExit):
             session.rollback()
             raise
-        except:
+        except:  # noqa: E722
             log.exception('Caught exception handling streamer message:')
             session.rollback()
         else:
@@ -125,7 +125,7 @@ def supervise(greenlets):
         gevent.joinall(greenlets, raise_error=True)
     except (KeyboardInterrupt, SystemExit):
         raise
-    except:
+    except:  # noqa: E722
         log.critical('Unexpected exception in streamer greenlet:',
                      exc_info=True)
     else:

--- a/h/streamer/websocket.py
+++ b/h/streamer/websocket.py
@@ -132,7 +132,7 @@ def handle_client_id_message(message, session=None):
                       ok=False)
         return
     message.socket.client_id = message.payload['value']
-MESSAGE_HANDLERS['client_id'] = handle_client_id_message
+MESSAGE_HANDLERS['client_id'] = handle_client_id_message  # noqa: E305
 
 
 def handle_filter_message(message, session=None):
@@ -156,20 +156,20 @@ def handle_filter_message(message, session=None):
         # Add backend expands for clauses
         _expand_clauses(session, filter_)
     message.socket.filter = filter.FilterHandler(filter_)
-MESSAGE_HANDLERS['filter'] = handle_filter_message
+MESSAGE_HANDLERS['filter'] = handle_filter_message  # noqa: E305
 
 
 def handle_ping_message(message, session=None):
     """A client requesting a pong."""
     message.reply({'type': 'pong'})
-MESSAGE_HANDLERS['ping'] = handle_ping_message
+MESSAGE_HANDLERS['ping'] = handle_ping_message  # noqa: E305
 
 
 def handle_whoami_message(message, session=None):
     """A client requesting information on its auth state."""
     message.reply({'type': 'whoyouare',
                    'userid': message.socket.authenticated_userid})
-MESSAGE_HANDLERS['whoami'] = handle_whoami_message
+MESSAGE_HANDLERS['whoami'] = handle_whoami_message  # noqa: E305
 
 
 def handle_unknown_message(message, session=None):
@@ -180,7 +180,7 @@ def handle_unknown_message(message, session=None):
                              'description': 'invalid message type: '
                                             '{:s}'.format(type_)}},
                   ok=False)
-MESSAGE_HANDLERS[None] = handle_unknown_message
+MESSAGE_HANDLERS[None] = handle_unknown_message  # noqa: E305
 
 
 def _expand_clauses(session, filter_):

--- a/h/tasks/indexer.py
+++ b/h/tasks/indexer.py
@@ -24,6 +24,7 @@ def add_annotation(id_):
         if annotation.is_reply:
             add_annotation.delay(annotation.thread_root_id)
 
+
 @celery.task
 def delete_annotation(id_):
     delete(celery.request.es, id_)

--- a/h/util/db.py
+++ b/h/util/db.py
@@ -10,7 +10,7 @@ except ImportError:
 import sqlalchemy
 
 
-class lru_cache_in_transaction(object):
+class lru_cache_in_transaction(object):  # noqa: N801
     """
     Decorator to wrap a function with a memoizing callable that saves up to
     the `maxsize` most recent calls. The underlying cache is automatically

--- a/h/util/markdown.py
+++ b/h/util/markdown.py
@@ -30,6 +30,7 @@ def _filter_link_attributes(tag, name, value):
 
     return False
 
+
 MARKDOWN_ATTRIBUTES = {
     'a': _filter_link_attributes,
     'img': ['alt', 'src', 'title'],

--- a/h/views/activity.py
+++ b/h/views/activity.py
@@ -13,7 +13,7 @@ from pyramid.view import view_defaults
 
 from h import util
 from h.activity import query
-from h.i18n import TranslationString as _
+from h.i18n import TranslationString as _  # noqa: N813
 from h.links import pretty_link
 from h.paginator import paginate
 from h.search import parser

--- a/h/views/admin_admins.py
+++ b/h/views/admin_admins.py
@@ -4,7 +4,7 @@ from pyramid import httpexceptions
 from pyramid.view import view_config
 
 from h import models
-from h.i18n import TranslationString as _
+from h.i18n import TranslationString as _  # noqa: N813
 
 
 @view_config(route_name='admin_admins',

--- a/h/views/admin_badge.py
+++ b/h/views/admin_badge.py
@@ -5,7 +5,7 @@ from pyramid.view import view_config
 from sqlalchemy.exc import IntegrityError
 
 from h import models
-from h.i18n import TranslationString as _
+from h.i18n import TranslationString as _  # noqa: N813
 
 
 @view_config(route_name='admin_badge',

--- a/h/views/admin_features.py
+++ b/h/views/admin_features.py
@@ -5,7 +5,7 @@ from pyramid.view import view_config
 
 from h import models
 from h import paginator
-from h.i18n import TranslationString as _
+from h.i18n import TranslationString as _  # noqa: N813
 
 
 @view_config(route_name='admin_features',

--- a/h/views/admin_nipsa.py
+++ b/h/views/admin_nipsa.py
@@ -4,7 +4,7 @@ from pyramid import httpexceptions
 from pyramid.view import view_config
 
 from h import models
-from h.i18n import TranslationString as _
+from h.i18n import TranslationString as _  # noqa: N813
 
 
 class UserNotFoundError(Exception):

--- a/h/views/admin_staff.py
+++ b/h/views/admin_staff.py
@@ -4,7 +4,7 @@ from pyramid import httpexceptions
 from pyramid.view import view_config
 
 from h import models
-from h.i18n import TranslationString as _
+from h.i18n import TranslationString as _  # noqa: N813
 
 
 @view_config(route_name='admin_staff',

--- a/h/views/api_auth.py
+++ b/h/views/api_auth.py
@@ -151,7 +151,7 @@ class OAuthAuthorizeController(object):
     def _render_web_message_response(self, redirect_uri):
         location = urlparse.urlparse(redirect_uri)
         params = urlparse.parse_qs(location.query)
-        origin = '{l.scheme}://{l.netloc}'.format(l=location)
+        origin = '{url.scheme}://{url.netloc}'.format(url=location)
 
         state = None
         states = params.get('state', [])

--- a/h/views/api_exceptions.py
+++ b/h/views/api_exceptions.py
@@ -12,7 +12,7 @@ from __future__ import unicode_literals
 from pyramid.view import forbidden_view_config
 from pyramid.view import notfound_view_config
 
-from h.i18n import TranslationString as _
+from h.i18n import TranslationString as _  # noqa: N813
 from h.exceptions import APIError
 from h.schemas import ValidationError
 from h.util.view import handle_exception, json_view

--- a/h/websocket.py
+++ b/h/websocket.py
@@ -114,7 +114,7 @@ class GEventWebSocketPool(Pool):
                 websocket = greenlet._run.im_self
                 if websocket:
                     websocket.close(1001, 'Server is shutting down')
-            except:
+            except:  # noqa: E722
                 pass
             finally:
                 self.discard(greenlet)

--- a/tests/h/models/token_test.py
+++ b/tests/h/models/token_test.py
@@ -9,7 +9,6 @@ import pytest
 from h.models import Token
 
 
-@pytest.mark.usefixtures('security')
 class TestToken(object):
     def test_ttl_is_none_if_token_has_no_expires(self):
         assert Token().ttl is None
@@ -53,25 +52,6 @@ class TestToken(object):
         token = Token(refresh_token_expires=refresh_token_expires)
 
         assert token.refresh_token_expired is True
-
-    @pytest.fixture
-    def security(self, patch):
-        security = patch('h.models.token.security')
-
-        class TestTokenGenerator(object):
-            """Return "TOKEN_1", then "TOKEN_2" and so on."""
-
-            def __init__(self):
-                self.i = 1
-                self.generated_tokens = []
-
-            def __call__(self):
-                self.generated_tokens.append("TOKEN_" + str(self.i))
-                self.i += 1
-                return self.generated_tokens[-1]
-
-        security.token_urlsafe.side_effect = TestTokenGenerator()
-        return security
 
 
 def one_hour_from_now():


### PR DESCRIPTION
Following a [discussion on Slack](https://hypothes-is.slack.com/archives/C1MA4E9B9/p1517481793000097) I think we've reached consensus that current developers prefer the approach we use for linting frontend code versus backend code. Specifically:

 - The lint process is a standard tool which can be run the same way locally or as part of a CI build. In particular it is a tool which has good integration with IDEs (Vim, Atom, etc.)
 - Linting as part of the review process is done by a Travis task.
 - The codebase is lint-clean, or made clean on a per-directory basis. If we enable new checks, we just fix or suppress existing issues across the codebase at the time we enable the check.

This PR enables that workflow for the non-test code in "h" using flake8 as follows:

 - A series of commits fix or suppress all existing failures for our flake8 configuration
 - Add a `make lint` task which runs flake8 over lint-clean parts of the code
 - Run the `make lint` task as part of the Travis build.