### PR TITLE
Use autospec in groups cli test

### DIFF
--- a/tests/h/cli/commands/groups_test.py
+++ b/tests/h/cli/commands/groups_test.py
@@ -24,7 +24,7 @@ class TestAddCommand(object):
 
 
 @pytest.fixture
-def group_service(pyramid_config):
+def group_service():
     return mock.create_autospec(GroupService, spec_set=True, instance=True)
 
 

--- a/tests/h/cli/commands/groups_test.py
+++ b/tests/h/cli/commands/groups_test.py
@@ -4,6 +4,7 @@ import mock
 import pytest
 
 from h.cli.commands import groups as groups_cli
+from h.services.group import GroupService
 
 
 class TestAddCommand(object):
@@ -24,8 +25,7 @@ class TestAddCommand(object):
 
 @pytest.fixture
 def group_service(pyramid_config):
-    group_service = mock.Mock(spec_set=['create'])
-    return group_service
+    return mock.create_autospec(GroupService, spec_set=True, instance=True)
 
 
 @pytest.fixture


### PR DESCRIPTION
This mock groups service uses `spec_set` to hardcode that the mock object has only a `create()` method. When I add a `create_open_group()` method to `GroupService` and update the CLI code to call it then the tests will fail because the mock only has a `create()` method. Rather than adding `create_open_group()` to the mock's `spec_set`, create the mock using `create_autospec()` instead so that the mock always has the same methods as the real `GroupService`.

This also means that the mock's methods are constrained to the _arguments_ that the real object's have.