### PR TITLE
Refactor Groups API Views Tests to use Autospec

### DIFF
--- a/h/views/api_groups.py
+++ b/h/views/api_groups.py
@@ -16,7 +16,9 @@ def groups(request):
     authority = request.params.get('authority')
     document_uri = request.params.get('document_uri')
     svc = request.find_service(name='profile_group')
-    return svc.all(request.user, authority, document_uri)
+    return svc.all(user=request.user,
+                   authority=authority,
+                   document_uri=document_uri)
 
 
 @api_config(route_name='api.group_member',

--- a/tests/h/views/api_groups_test.py
+++ b/tests/h/views/api_groups_test.py
@@ -9,6 +9,7 @@ from pyramid.httpexceptions import HTTPNoContent, HTTPBadRequest
 
 from h.views import api_groups as views
 from h.services.profile_group import ProfileGroupService
+from h.services.group import GroupService
 
 
 @pytest.mark.usefixtures('profile_group_service')
@@ -86,8 +87,7 @@ class TestRemoveMember(object):
 
     @pytest.fixture
     def group_service(self, pyramid_config):
-        service = mock.Mock(spec_set=['member_leave'])
-        service.member_leave.return_value = None
+        service = mock.create_autospec(GroupService, spec_set=True, instance=True)
         pyramid_config.register_service(service, name='group')
         return service
 

--- a/tests/h/views/api_groups_test.py
+++ b/tests/h/views/api_groups_test.py
@@ -8,6 +8,7 @@ import pytest
 from pyramid.httpexceptions import HTTPNoContent, HTTPBadRequest
 
 from h.views import api_groups as views
+from h.services.profile_group import ProfileGroupService
 
 
 @pytest.mark.usefixtures('profile_group_service')
@@ -15,21 +16,23 @@ class TestGroups(object):
     def test_groups_proxies_to_service(self, pyramid_request, profile_group_service):
         views.groups(pyramid_request)
 
-        assert profile_group_service.called_once()
+        profile_group_service.all.assert_called_once()
 
     def test_groups_passes_authority_parameter(self, pyramid_request, profile_group_service):
         pyramid_request.params = {'authority': 'foo.com'}
 
         views.groups(pyramid_request)
 
-        assert profile_group_service.called_once_with(pyramid_request, 'foo.com')
+        c_args, c_kwargs = profile_group_service.all.call_args
+        assert c_kwargs['authority'] == 'foo.com'
 
     def test_groups_passes_document_uri_parameter(self, pyramid_request, profile_group_service):
         pyramid_request.params = {'document_uri': 'foo.example.com'}
 
         views.groups(pyramid_request)
 
-        assert profile_group_service.called_once_with(pyramid_request, document_uri='foo.example.com')
+        c_args, c_kwargs = profile_group_service.all.call_args
+        assert c_kwargs['document_uri'] == 'foo.example.com'
 
     @pytest.fixture
     def pyramid_request(self, pyramid_request, user):
@@ -43,7 +46,7 @@ class TestGroups(object):
 
     @pytest.fixture
     def profile_group_service(self, pyramid_config):
-        svc = mock.Mock()
+        svc = mock.create_autospec(ProfileGroupService, spec_set=True, instance=True)
         pyramid_config.register_service(svc, name='profile_group')
         return svc
 


### PR DESCRIPTION
By using `autospec` these tests are now more sensible and have more meaningful (i.e. valid _at all_) results.

Small change to `api_groups` view to use named arguments when invoking `ProfileService.all`—this aids testing, but is also clearer code in general.