### PR TITLE
Clarify that userid of the creator is published

### DIFF
--- a/h/services/group.py
+++ b/h/services/group.py
@@ -68,7 +68,7 @@ class GroupService(object):
         self.session.add(group)
         self.session.flush()
 
-        self.publish('group-join', group.pubid, userid)
+        self.publish('group-join', group.pubid, group.creator.userid)
 
         return group
 

--- a/tests/h/services/group_test.py
+++ b/tests/h/services/group_test.py
@@ -86,7 +86,7 @@ class TestGroupService(object):
     def test_create_publishes_join_event(self, service, publish):
         group = service.create('Dishwasher disassemblers', 'foobar.com', 'theresa')
 
-        publish.assert_called_once_with('group-join', group.pubid, 'theresa')
+        publish.assert_called_once_with('group-join', group.pubid, 'acct:theresa@example.com')
 
     def test_member_join_adds_user_to_group(self, service, group, users):
         service.member_join(group, 'theresa')


### PR DESCRIPTION
Clarify that it's the userid of the group's creator that's published
when the 'group-join' event is published when creating a group, by
publishing group.creator.userid instead of the local variable userid.

This will also make later refactoring easier as the publish line needs
only group and not the local userid variable.

Also fix a test: this group service test was expecting 'theresa' (the
username) to be published but in all cases what the real code actually
publishes is 'acct:theresa@example.com' (the userid) (see h/views/groups.py
and also h/cli/commands/groups.py, and note that the local variable was
called userid not username). Fix the test to expect the userid not the
username.