### PR TITLE
Remove authority param from GroupService.create()

### DIFF
--- a/h/cli/commands/groups.py
+++ b/h/cli/commands/groups.py
@@ -25,7 +25,6 @@ def add_open_group(ctx, name, authority, creator):
     creator_userid = u'acct:{username}@{authority}'.format(username=creator,
                                                            authority=authority)
     group_svc = request.find_service(name='group')
-    group_svc.create(name=name, authority=authority, userid=creator_userid,
-                     type_='open')
+    group_svc.create(name=name, userid=creator_userid, type_='open')
 
     request.tm.commit()

--- a/h/services/group.py
+++ b/h/services/group.py
@@ -38,7 +38,7 @@ class GroupService(object):
         self.user_fetcher = user_fetcher
         self.publish = publish
 
-    def create(self, name, authority, userid, description=None, type_='private'):
+    def create(self, name, userid, description=None, type_='private'):
         """
         Create a new group.
 
@@ -52,7 +52,7 @@ class GroupService(object):
         """
         creator = self.user_fetcher(userid)
         group = Group(name=name,
-                      authority=authority,
+                      authority=creator.authority,
                       creator=creator,
                       description=description)
 

--- a/h/views/groups.py
+++ b/h/views/groups.py
@@ -42,7 +42,6 @@ class GroupCreateController(object):
             groups_service = self.request.find_service(name='group')
             group = groups_service.create(
                 name=appstruct['name'],
-                authority=self.request.authority,
                 description=appstruct.get('description'),
                 userid=self.request.authenticated_userid)
 

--- a/tests/h/cli/commands/groups_test.py
+++ b/tests/h/cli/commands/groups_test.py
@@ -18,7 +18,6 @@ class TestAddCommand(object):
         assert result.exit_code == 0
 
         group_service.create.assert_called_with(name=u'Publisher',
-                                                authority=u'publisher.org',
                                                 userid='acct:admin@publisher.org',
                                                 type_='open')
 

--- a/tests/h/services/group_test.py
+++ b/tests/h/services/group_test.py
@@ -13,42 +13,42 @@ from h.services.group import groups_factory
 
 class TestGroupService(object):
     def test_create_returns_group(self, service):
-        group = service.create('Anteater fans', 'foobar.com', 'cazimir')
+        group = service.create('Anteater fans', 'cazimir')
 
         assert isinstance(group, Group)
 
     def test_create_sets_group_name(self, service):
-        group = service.create('Anteater fans', 'foobar.com', 'cazimir')
+        group = service.create('Anteater fans', 'cazimir')
 
         assert group.name == 'Anteater fans'
 
     def test_create_sets_group_authority(self, service):
-        group = service.create('Anteater fans', 'foobar.com', 'cazimir')
+        group = service.create('Anteater fans', 'cazimir')
 
-        assert group.authority == 'foobar.com'
+        assert group.authority == 'example.com'
 
     def test_create_sets_group_creator(self, service, users):
-        group = service.create('Anteater fans', 'foobar.com', 'cazimir')
+        group = service.create('Anteater fans', 'cazimir')
 
         assert group.creator == users['cazimir']
 
     def test_create_sets_description_when_present(self, service):
-        group = service.create('Anteater fans', 'foobar.com', 'cazimir', 'all about ant eaters')
+        group = service.create('Anteater fans', 'cazimir', 'all about ant eaters')
 
         assert group.description == 'all about ant eaters'
 
     def test_create_skips_setting_description_when_missing(self, service):
-        group = service.create('Anteater fans', 'foobar.com', 'cazimir')
+        group = service.create('Anteater fans', 'cazimir')
 
         assert group.description is None
 
     def test_create_adds_group_creator_to_members(self, service, users):
-        group = service.create('Anteater fans', 'foobar.com', 'cazimir')
+        group = service.create('Anteater fans', 'cazimir')
 
         assert users['cazimir'] in group.members
 
     def test_create_doesnt_add_group_creator_to_members_for_open_groups(self, service, users):
-        group = service.create('Anteater fans', 'foobar.com', 'cazimir', type_='open')
+        group = service.create('Anteater fans', 'cazimir', type_='open')
 
         assert users['cazimir'] not in group.members
 
@@ -64,27 +64,27 @@ class TestGroupService(object):
                                                       group_type,
                                                       flag,
                                                       expected_value):
-        group = service.create('Anteater fans', 'foobar.com', 'cazimir', type_=group_type)
+        group = service.create('Anteater fans', 'cazimir', type_=group_type)
 
         assert getattr(group, flag) == expected_value
 
     def test_create_raises_for_invalid_group_type(self, service):
         with pytest.raises(ValueError):
-            service.create('Anteater fans', 'foobar.com', 'cazimir', type_='foo')
+            service.create('Anteater fans', 'cazimir', type_='foo')
 
     def test_create_adds_group_to_session(self, db_session, service):
-        group = service.create('Anteater fans', 'foobar.com', 'cazimir')
+        group = service.create('Anteater fans', 'cazimir')
 
         assert group in db_session
 
     def test_create_sets_group_ids(self, service):
-        group = service.create('Anteater fans', 'foobar.com', 'cazimir')
+        group = service.create('Anteater fans', 'cazimir')
 
         assert group.id
         assert group.pubid
 
     def test_create_publishes_join_event(self, service, publish):
-        group = service.create('Dishwasher disassemblers', 'foobar.com', 'theresa')
+        group = service.create('Dishwasher disassemblers', 'theresa')
 
         publish.assert_called_once_with('group-join', group.pubid, 'acct:theresa@example.com')
 

--- a/tests/h/views/groups_test.py
+++ b/tests/h/views/groups_test.py
@@ -56,7 +56,7 @@ class TestGroupCreateController(object):
         controller.post()
 
         assert group_service.create.call_args_list == [
-            mock.call(name='my_new_group', authority='example.com', userid='ariadna', description='foobar'),
+            mock.call(name='my_new_group', userid='ariadna', description='foobar'),
         ]
 
     def test_post_redirects_if_form_valid(self,


### PR DESCRIPTION
This parameter isn't needed because the authority can be retrieved from
the user who is creating the group. Also, it's not actually valid /
doesn't make any sense for the group's authority to be different from
that of the group's creator, but having authority as a separate param
allows this to happen.

Note that one of the tests was actually expecting a group to be created
with an authority different from that of the creator - I had to fix the test.

Also note that you can still create an open group in any authority using
the --authority argument to the add-open-group CLI. The CLI code uses
this authority argument to form the userid of the group's creator, not to
pass it in to group_svc.create().