### PR TITLE
Split GroupService.create() into two separate methods

### DIFF
--- a/h/cli/commands/groups.py
+++ b/h/cli/commands/groups.py
@@ -25,6 +25,6 @@ def add_open_group(ctx, name, authority, creator):
     creator_userid = u'acct:{username}@{authority}'.format(username=creator,
                                                            authority=authority)
     group_svc = request.find_service(name='group')
-    group_svc.create(name=name, userid=creator_userid, type_='open')
+    group_svc.create_open_group(name=name, userid=creator_userid)
 
     request.tm.commit()

--- a/h/services/group.py
+++ b/h/services/group.py
@@ -13,11 +13,6 @@ GROUP_ACCESS_FLAGS = {
         'joinable_by': JoinableBy.authority,
         'readable_by': ReadableBy.members,
         'writeable_by': WriteableBy.members,
-     },
-    'open': {
-        'joinable_by': None,
-        'readable_by': ReadableBy.world,
-        'writeable_by': WriteableBy.authority,
     }
 }
 

--- a/h/services/group.py
+++ b/h/services/group.py
@@ -8,14 +8,6 @@ from h import session
 from h.models import Group, User
 from h.models.group import JoinableBy, ReadableBy, WriteableBy
 
-GROUP_ACCESS_FLAGS = {
-    'private': {
-        'joinable_by': JoinableBy.authority,
-        'readable_by': ReadableBy.members,
-        'writeable_by': WriteableBy.members,
-    }
-}
-
 
 class GroupService(object):
 
@@ -49,11 +41,11 @@ class GroupService(object):
         group = Group(name=name,
                       authority=creator.authority,
                       creator=creator,
-                      description=description)
-
-        access_flags = GROUP_ACCESS_FLAGS.get('private')
-        for attr, value in access_flags.iteritems():
-            setattr(group, attr, value)
+                      description=description,
+                      joinable_by=JoinableBy.authority,
+                      readable_by=ReadableBy.members,
+                      writeable_by=WriteableBy.members,
+                      )
 
         if group.joinable_by is not None:
             group.members.append(creator)

--- a/h/services/group.py
+++ b/h/services/group.py
@@ -25,7 +25,7 @@ class GroupService(object):
         self.user_fetcher = user_fetcher
         self.publish = publish
 
-    def create(self, name, userid, description=None):
+    def create_private_group(self, name, userid, description=None):
         """
         Create a new private group.
 

--- a/h/services/group.py
+++ b/h/services/group.py
@@ -72,6 +72,30 @@ class GroupService(object):
 
         return group
 
+    def create_open_group(self, name, userid, description=None):
+        """
+        Create a new open group.
+
+        An open group is one that anyone can read or write.
+
+        :param name: the human-readable name of the group
+        :param userid: the userid of the group creator
+        :param description: the description of the group
+
+        :returns: the created group
+        """
+        creator = self.user_fetcher(userid)
+        group = Group(name=name,
+                      authority=creator.authority,
+                      creator=creator,
+                      description=description,
+                      joinable_by=None,
+                      readable_by=ReadableBy.world,
+                      writeable_by=WriteableBy.authority,
+                      )
+        self.session.add(group)
+        return group
+
     def member_join(self, group, userid):
         """Add `userid` to the member list of `group`."""
         user = self.user_fetcher(userid)

--- a/h/services/group.py
+++ b/h/services/group.py
@@ -56,7 +56,7 @@ class GroupService(object):
         """
         Create a new open group.
 
-        An open group is one that anyone can read or write.
+        An open group is one that anyone in the same authority can read or write.
 
         :param name: the human-readable name of the group
         :param userid: the userid of the group creator

--- a/h/services/group.py
+++ b/h/services/group.py
@@ -47,8 +47,7 @@ class GroupService(object):
                       writeable_by=WriteableBy.members,
                       )
 
-        if group.joinable_by is not None:
-            group.members.append(creator)
+        group.members.append(creator)
 
         self.session.add(group)
         self.session.flush()

--- a/h/services/group.py
+++ b/h/services/group.py
@@ -37,23 +37,19 @@ class GroupService(object):
 
         :returns: the created group
         """
-        creator = self.user_fetcher(userid)
-        group = Group(name=name,
-                      authority=creator.authority,
-                      creator=creator,
-                      description=description,
-                      joinable_by=JoinableBy.authority,
-                      readable_by=ReadableBy.members,
-                      writeable_by=WriteableBy.members,
-                      )
+        group = self._create(name=name,
+                             userid=userid,
+                             description=description,
+                             joinable_by=JoinableBy.authority,
+                             readable_by=ReadableBy.members,
+                             writeable_by=WriteableBy.members,
+                             )
+        group.members.append(group.creator)
 
-        group.members.append(creator)
-
-        self.session.add(group)
+        # Flush the DB to generate group.pubid before publish()ing it.
         self.session.flush()
 
         self.publish('group-join', group.pubid, group.creator.userid)
-
         return group
 
     def create_open_group(self, name, userid, description=None):
@@ -68,17 +64,13 @@ class GroupService(object):
 
         :returns: the created group
         """
-        creator = self.user_fetcher(userid)
-        group = Group(name=name,
-                      authority=creator.authority,
-                      creator=creator,
-                      description=description,
-                      joinable_by=None,
-                      readable_by=ReadableBy.world,
-                      writeable_by=WriteableBy.authority,
-                      )
-        self.session.add(group)
-        return group
+        return self._create(name=name,
+                            userid=userid,
+                            description=description,
+                            joinable_by=None,
+                            readable_by=ReadableBy.world,
+                            writeable_by=WriteableBy.authority,
+                            )
 
     def member_join(self, group, userid):
         """Add `userid` to the member list of `group`."""
@@ -127,6 +119,20 @@ class GroupService(object):
             return []
 
         return [g.pubid for g in self.session.query(Group.pubid).filter_by(creator=user)]
+
+    def _create(self, name, userid, description, joinable_by, readable_by, writeable_by):
+        """Create a group and save it to the DB."""
+        creator = self.user_fetcher(userid)
+        group = Group(name=name,
+                      authority=creator.authority,
+                      creator=creator,
+                      description=description,
+                      joinable_by=joinable_by,
+                      readable_by=readable_by,
+                      writeable_by=writeable_by,
+                      )
+        self.session.add(group)
+        return group
 
 
 def groups_factory(context, request):

--- a/h/services/group.py
+++ b/h/services/group.py
@@ -33,15 +33,15 @@ class GroupService(object):
         self.user_fetcher = user_fetcher
         self.publish = publish
 
-    def create(self, name, userid, description=None, type_='private'):
+    def create(self, name, userid, description=None):
         """
-        Create a new group.
+        Create a new private group.
+
+        A private group is one that only members can read or write.
 
         :param name: the human-readable name of the group
         :param userid: the userid of the group creator
         :param description: the description of the group
-        :param type_: the type of group (private or open) which sets the
-                      appropriate access flags
 
         :returns: the created group
         """
@@ -51,9 +51,7 @@ class GroupService(object):
                       creator=creator,
                       description=description)
 
-        access_flags = GROUP_ACCESS_FLAGS.get(type_)
-        if access_flags is None:
-            raise ValueError('Invalid group type %s' % type_)
+        access_flags = GROUP_ACCESS_FLAGS.get('private')
         for attr, value in access_flags.iteritems():
             setattr(group, attr, value)
 

--- a/h/views/groups.py
+++ b/h/views/groups.py
@@ -40,7 +40,7 @@ class GroupCreateController(object):
         """Respond to a submission of the create group form."""
         def on_success(appstruct):
             groups_service = self.request.find_service(name='group')
-            group = groups_service.create(
+            group = groups_service.create_private_group(
                 name=appstruct['name'],
                 description=appstruct.get('description'),
                 userid=self.request.authenticated_userid)

--- a/tests/h/cli/commands/groups_test.py
+++ b/tests/h/cli/commands/groups_test.py
@@ -17,9 +17,8 @@ class TestAddCommand(object):
 
         assert result.exit_code == 0
 
-        group_service.create.assert_called_with(name=u'Publisher',
-                                                userid='acct:admin@publisher.org',
-                                                type_='open')
+        group_service.create_open_group.assert_called_once_with(
+            name=u'Publisher', userid='acct:admin@publisher.org')
 
 
 @pytest.fixture

--- a/tests/h/services/group_test.py
+++ b/tests/h/services/group_test.py
@@ -47,11 +47,6 @@ class TestGroupService(object):
 
         assert users['cazimir'] in group.members
 
-    def test_create_private_group_doesnt_add_group_creator_to_members_for_open_groups(self, service, users):
-        group = service.create_open_group('Anteater fans', 'cazimir')
-
-        assert users['cazimir'] not in group.members
-
     @pytest.mark.parametrize('flag,expected_value', [
         ('joinable_by', JoinableBy.authority),
         ('readable_by', ReadableBy.members),

--- a/tests/h/services/group_test.py
+++ b/tests/h/services/group_test.py
@@ -12,42 +12,42 @@ from h.services.group import groups_factory
 
 
 class TestGroupService(object):
-    def test_create_returns_group(self, service):
-        group = service.create('Anteater fans', 'cazimir')
+    def test_create_private_group_returns_group(self, service):
+        group = service.create_private_group('Anteater fans', 'cazimir')
 
         assert isinstance(group, Group)
 
-    def test_create_sets_group_name(self, service):
-        group = service.create('Anteater fans', 'cazimir')
+    def test_create_private_group_sets_group_name(self, service):
+        group = service.create_private_group('Anteater fans', 'cazimir')
 
         assert group.name == 'Anteater fans'
 
-    def test_create_sets_group_authority(self, service):
-        group = service.create('Anteater fans', 'cazimir')
+    def test_create_private_group_sets_group_authority(self, service):
+        group = service.create_private_group('Anteater fans', 'cazimir')
 
         assert group.authority == 'example.com'
 
-    def test_create_sets_group_creator(self, service, users):
-        group = service.create('Anteater fans', 'cazimir')
+    def test_create_private_group_sets_group_creator(self, service, users):
+        group = service.create_private_group('Anteater fans', 'cazimir')
 
         assert group.creator == users['cazimir']
 
-    def test_create_sets_description_when_present(self, service):
-        group = service.create('Anteater fans', 'cazimir', 'all about ant eaters')
+    def test_create_private_group_sets_description_when_present(self, service):
+        group = service.create_private_group('Anteater fans', 'cazimir', 'all about ant eaters')
 
         assert group.description == 'all about ant eaters'
 
-    def test_create_skips_setting_description_when_missing(self, service):
-        group = service.create('Anteater fans', 'cazimir')
+    def test_create_private_group_skips_setting_description_when_missing(self, service):
+        group = service.create_private_group('Anteater fans', 'cazimir')
 
         assert group.description is None
 
-    def test_create_adds_group_creator_to_members(self, service, users):
-        group = service.create('Anteater fans', 'cazimir')
+    def test_create_private_group_adds_group_creator_to_members(self, service, users):
+        group = service.create_private_group('Anteater fans', 'cazimir')
 
         assert users['cazimir'] in group.members
 
-    def test_create_doesnt_add_group_creator_to_members_for_open_groups(self, service, users):
+    def test_create_private_group_doesnt_add_group_creator_to_members_for_open_groups(self, service, users):
         group = service.create_open_group('Anteater fans', 'cazimir')
 
         assert users['cazimir'] not in group.members
@@ -56,24 +56,24 @@ class TestGroupService(object):
         ('joinable_by', JoinableBy.authority),
         ('readable_by', ReadableBy.members),
         ('writeable_by', WriteableBy.members)])
-    def test_create_sets_access_flags(self, service, flag, expected_value):
-        group = service.create('Anteater fans', 'cazimir')
+    def test_create_private_group_sets_access_flags(self, service, flag, expected_value):
+        group = service.create_private_group('Anteater fans', 'cazimir')
 
         assert getattr(group, flag) == expected_value
 
-    def test_create_adds_group_to_session(self, db_session, service):
-        group = service.create('Anteater fans', 'cazimir')
+    def test_create_private_group_adds_group_to_session(self, db_session, service):
+        group = service.create_private_group('Anteater fans', 'cazimir')
 
         assert group in db_session
 
-    def test_create_sets_group_ids(self, service):
-        group = service.create('Anteater fans', 'cazimir')
+    def test_create_private_group_sets_group_ids(self, service):
+        group = service.create_private_group('Anteater fans', 'cazimir')
 
         assert group.id
         assert group.pubid
 
-    def test_create_publishes_join_event(self, service, publish):
-        group = service.create('Dishwasher disassemblers', 'theresa')
+    def test_create_private_group_publishes_join_event(self, service, publish):
+        group = service.create_private_group('Dishwasher disassemblers', 'theresa')
 
         publish.assert_called_once_with('group-join', group.pubid, 'acct:theresa@example.com')
 

--- a/tests/h/services/group_test.py
+++ b/tests/h/services/group_test.py
@@ -48,7 +48,7 @@ class TestGroupService(object):
         assert users['cazimir'] in group.members
 
     def test_create_doesnt_add_group_creator_to_members_for_open_groups(self, service, users):
-        group = service.create('Anteater fans', 'cazimir', type_='open')
+        group = service.create_open_group('Anteater fans', 'cazimir')
 
         assert users['cazimir'] not in group.members
 
@@ -60,10 +60,6 @@ class TestGroupService(object):
         group = service.create('Anteater fans', 'cazimir')
 
         assert getattr(group, flag) == expected_value
-
-    def test_create_raises_for_invalid_group_type(self, service):
-        with pytest.raises(ValueError):
-            service.create('Anteater fans', 'cazimir', type_='foo')
 
     def test_create_adds_group_to_session(self, db_session, service):
         group = service.create('Anteater fans', 'cazimir')

--- a/tests/h/views/groups_test.py
+++ b/tests/h/views/groups_test.py
@@ -55,7 +55,7 @@ class TestGroupCreateController(object):
 
         controller.post()
 
-        assert group_service.create.call_args_list == [
+        assert group_service.create_private_group.call_args_list == [
             mock.call(name='my_new_group', userid='ariadna', description='foobar'),
         ]
 
@@ -84,7 +84,7 @@ class TestGroupCreateController(object):
 
         controller.post()
 
-        assert not group_service.create.called
+        assert not group_service.create_private_group.called
 
     def test_post_returns_template_data_if_form_invalid(self,
                                                         controller,
@@ -190,7 +190,7 @@ def invalid_form():
 @pytest.fixture
 def group_service(pyramid_config):
     service = mock.create_autospec(GroupService, spec_set=True, instance=True)
-    service.create.return_value = FakeGroup('abc123', 'fake-group')
+    service.create_private_group.return_value = FakeGroup('abc123', 'fake-group')
     pyramid_config.register_service(service, name='group')
     return service
 


### PR DESCRIPTION
I recommend looking at the individual commits to get easier-to-read diffs.

This is hopefully the final `GroupService` refactoring that I need to do before I'm ready to introduce group model changes (adding scopes to the model) and change `GroupService` to work with the new model.

This pr splits `GroupService.create()`, which was a single method for creating either an open group or a private group (with a `type_="open"|"private"` argument) into two separate methods `create_private_group()` and `create_open_group()`. This simplifies things, avoiding a lot of branching logic based on `type_` in the `create()` method, and avoiding the single `create()` method getting too long, because what needs to happen for creating a private group differs from creating an open group:

* For private groups the creator is added to the group as a member, for open groups they aren't
* For private groups the DB needs to be flushed (to generate `group.pubid` right away), for open groups it doesn't
* For private groups a `'group-join'` event is published, but not for open groups

In a future pull request the two methods will diverge further:

* Private groups cannot have scopes (`create_private_group()` simply won't have any knowledge of scope
* Open groups _must_ be scoped (required `scopes` param will be added to `create_open_group()`)
* For open groups the scopes must be created if they don't already exist and must be added to the group

This refactoring also enables `type_` and `GROUP_ACCESS_FLAGS`, both of which are pretty awkward, to be removed.

