### PR TITLE
Make tests flake8 "clean"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ test: node_modules/.uptodate
 .PHONY: lint
 lint: .pydeps
 	flake8 h
+	flake8 tests
 
 ################################################################################
 

--- a/tests/functional/test_api.py
+++ b/tests/functional/test_api.py
@@ -120,9 +120,9 @@ class TestAPI(object):
 
 @pytest.fixture
 def annotation(db_session, factories):
-    ann =  factories.Annotation(userid='acct:testuser@example.com',
-                                groupid='__world__',
-                                shared=True)
+    ann = factories.Annotation(userid='acct:testuser@example.com',
+                               groupid='__world__',
+                               shared=True)
     db_session.commit()
     return ann
 

--- a/tests/h/accounts/schemas_test.py
+++ b/tests/h/accounts/schemas_test.py
@@ -533,7 +533,7 @@ class TestPasswordChangeSchema(object):
 class TestEditProfileSchema(object):
     def test_accepts_valid_input(self, pyramid_csrf_request):
         schema = schemas.EditProfileSchema().bind(request=pyramid_csrf_request)
-        appstruct = schema.deserialize({
+        schema.deserialize({
             'display_name': 'Michael Granitzer',
             'description': 'Professor at University of Passau',
             'link': 'http://mgrani.github.io/',

--- a/tests/h/accounts/util_test.py
+++ b/tests/h/accounts/util_test.py
@@ -2,6 +2,7 @@ import pytest
 
 from h.accounts.util import validate_orcid, validate_url
 
+
 def test_validate_url_rejects_urls_without_domains():
     with pytest.raises(ValueError):
         validate_url('http:///path')

--- a/tests/h/activity/bucketing_test.py
+++ b/tests/h/activity/bucketing_test.py
@@ -194,7 +194,7 @@ class TestDocumentBucket(object):
         bucket = bucketing.DocumentBucket(document)
         request = Mock()
 
-        assert bucket.incontext_link(request) == None
+        assert bucket.incontext_link(request) is None
 
     @pytest.fixture
     def document(self, db_session):

--- a/tests/h/activity/bucketing_test.py
+++ b/tests/h/activity/bucketing_test.py
@@ -190,7 +190,7 @@ class TestDocumentBucket(object):
         assert bucket.incontext_link(request) == incontext_link.return_value
 
     def test_incontext_link_returns_none_if_bucket_empty(self, document, patch):
-        incontext_link = patch('h.links.incontext_link')
+        patch('h.links.incontext_link')
         bucket = bucketing.DocumentBucket(document)
         request = Mock()
 

--- a/tests/h/activity/query_test.py
+++ b/tests/h/activity/query_test.py
@@ -143,7 +143,6 @@ class TestCheckURL(object):
 
         assert check_url(pyramid_request, query) is None
 
-
     def test_removes_user_term_from_query(self, pyramid_request, unparse):
         query = MultiDict({'user': 'jose'})
 

--- a/tests/h/auth/util_test.py
+++ b/tests/h/auth/util_test.py
@@ -29,7 +29,7 @@ FakeGroup = namedtuple('FakeGroup', ['pubid'])
 #
 #     CTL            =  %x00-1F / %x7F
 #
-CONTROL_CHARS = set(chr(n) for n in range(0x00, 0x1F+1)) | set('\x7f')
+CONTROL_CHARS = set(chr(n) for n in range(0x00, 0x1F + 1)) | set('\x7f')
 
 # Furthermore, from RFC 7617:
 #

--- a/tests/h/auth/util_test.py
+++ b/tests/h/auth/util_test.py
@@ -181,6 +181,7 @@ def user_service(pyramid_config):
     pyramid_config.register_service(service, name='user')
     return service
 
+
 @pytest.fixture
 def principals_for_user(patch):
     return patch('h.auth.util.principals_for_user')

--- a/tests/h/cli/commands/normalize_uris_test.py
+++ b/tests/h/cli/commands/normalize_uris_test.py
@@ -162,8 +162,7 @@ def test_it_reindexes_changed_annotations(req, index, factories, db_session):
 
 
 def test_it_skips_reindexing_unaltered_annotations(req, index, factories, db_session):
-    annotation_1 = factories.Annotation(userid='luke',
-                                        target_uri='http://example.org/')
+    factories.Annotation(userid='luke', target_uri='http://example.org/')
     annotation_2 = factories.Annotation(userid='luke',
                                         target_uri='http://example.net/')
     annotation_2._target_uri_normalized = 'http://example.net'

--- a/tests/h/cli/commands/normalize_uris_test.py
+++ b/tests/h/cli/commands/normalize_uris_test.py
@@ -150,7 +150,7 @@ def test_it_reindexes_changed_annotations(req, index, factories, db_session):
     annotation_1._target_uri_normalized = 'http://example.org'
     annotation_2 = factories.Annotation(userid='luke',
                                         target_uri='http://example.net/')
-    annotation_2._target_uri_normalized='http://example.net'
+    annotation_2._target_uri_normalized = 'http://example.net'
     db_session.flush()
 
     indexer = index.BatchIndexer.return_value

--- a/tests/h/conftest.py
+++ b/tests/h/conftest.py
@@ -20,7 +20,6 @@ from sqlalchemy.orm import sessionmaker
 from webob.multidict import MultiDict
 
 from h import db
-from h import form
 from h.settings import database_url
 from h._compat import text_type
 

--- a/tests/h/conftest.py
+++ b/tests/h/conftest.py
@@ -56,6 +56,7 @@ class DummyFeature(object):
     def clear(self):
         self.flags = {}
 
+
 class DummySession(object):
 
     """

--- a/tests/h/emails/reply_notification_test.py
+++ b/tests/h/emails/reply_notification_test.py
@@ -210,7 +210,6 @@ class TestGenerate(object):
         html_renderer.assert_(**expected_context)
         text_renderer.assert_(**expected_context)
 
-
     @pytest.fixture
     def document(self, db_session):
         doc = Document(title=u'My fascinating page')

--- a/tests/h/feeds/atom_test.py
+++ b/tests/h/feeds/atom_test.py
@@ -88,13 +88,14 @@ def test_html_url_link():
 def test_entry_id(util, factories):
     """The ids of feed entries should come from tag_uri_for_annotation()."""
     annotation = factories.Annotation()
-    annotations_url_function = lambda annotation: "annotation url"
 
-    feed = atom.feed_from_annotations(
-        [annotation], "atom_url", annotations_url_function)
+    def annotation_url(ann):
+        return 'annotation url'
+
+    feed = atom.feed_from_annotations([annotation], "atom_url", annotation_url)
 
     util.tag_uri_for_annotation.assert_called_once_with(
-        annotation, annotations_url_function)
+        annotation, annotation_url)
     assert feed['entries'][0]['id'] == util.tag_uri_for_annotation.return_value
 
 

--- a/tests/h/feeds/atom_test.py
+++ b/tests/h/feeds/atom_test.py
@@ -52,6 +52,7 @@ def test_feed_contains_entries(_feed_entry_from_annotation, factories):
         "feed entry for annotation 2",
         "feed entry for annotation 3"
     ]
+
     def pop(*args, **kwargs):
         return entries.pop(0)
     _feed_entry_from_annotation.side_effect = pop

--- a/tests/h/links_test.py
+++ b/tests/h/links_test.py
@@ -136,7 +136,7 @@ def test_jsonld_id_link(factories, pyramid_config, pyramid_request):
     ('http://www.google.com', 'google.com'),
     ('http://site.com/with-a-path', 'site.com/with-a-path'),
     ('https://site.com/with-a-path?q=and-a-query-string', 'site.com/with-a-path'),
-    ('http://site.com/path%20with%20spaces','site.com/path with spaces'),
+    ('http://site.com/path%20with%20spaces', 'site.com/path with spaces'),
     ('', ''),
     ('site.com/no-scheme', 'site.com/no-scheme'),
     ('does not look like a URL', 'does not look like a URL'),

--- a/tests/h/models/annotation_test.py
+++ b/tests/h/models/annotation_test.py
@@ -2,7 +2,6 @@
 
 from __future__ import unicode_literals
 
-from pyramid import security
 import pytest
 
 from h.models.annotation import Annotation

--- a/tests/h/models/document_test.py
+++ b/tests/h/models/document_test.py
@@ -985,8 +985,10 @@ def mock_db_session():
     class DB(object):
         def add(self, obj):
             pass
+
         def query(self, cls):
             pass
+
         def flush(self):
             pass
     return mock.Mock(spec=DB())

--- a/tests/h/models/token_test.py
+++ b/tests/h/models/token_test.py
@@ -4,8 +4,6 @@ from __future__ import unicode_literals
 
 import datetime
 
-import pytest
-
 from h.models import Token
 
 

--- a/tests/h/models/user_test.py
+++ b/tests/h/models/user_test.py
@@ -191,7 +191,7 @@ def test_cannot_create_user_with_invalid_chars():
 
 def test_cannot_create_user_with_too_long_email():
     with pytest.raises(ValueError):
-        models.User(email='bob@b' + 'o'*100 +'b.com')
+        models.User(email='bob@b' + 'o' * 100 + 'b.com')
 
 
 def test_User_activate_activates_user(db_session):

--- a/tests/h/paginator_test.py
+++ b/tests/h/paginator_test.py
@@ -26,7 +26,7 @@ class TestPaginate(object):
       ('60',  [1, '...', 57, 58, 59, 60]),
 
       # If the current page is in the middle.
-      ('30',  [1, '...',27, 28, 29, 30, 31, 32, 33, '...', 60]),
+      ('30',  [1, '...', 27, 28, 29, 30, 31, 32, 33, '...', 60]),
 
       # If the current page is near the first page.
       ('2',  [1, 2, 3, 4, 5, '...', 60]),

--- a/tests/h/presenters/annotation_jsonld_test.py
+++ b/tests/h/presenters/annotation_jsonld_test.py
@@ -58,7 +58,7 @@ class TestAnnotationJSONLDPresenter(object):
         resource = AnnotationResource(annotation, group_service, fake_links_service)
 
         presenter = AnnotationJSONLDPresenter(resource)
-        _ = presenter.id
+        presenter.id
 
         assert fake_links_service.last_annotation == annotation
 

--- a/tests/h/schemas/annotation_test.py
+++ b/tests/h/schemas/annotation_test.py
@@ -513,7 +513,6 @@ class TestUpdateAnnotationSchema(object):
             'group': 'new-group'
         })
 
-
         assert 'groupid' not in appstruct
         assert 'groupid' not in appstruct.get('extra', {})
         assert 'group' not in appstruct

--- a/tests/h/search/index_test.py
+++ b/tests/h/search/index_test.py
@@ -115,7 +115,7 @@ class TestBatchIndexer(object):
             chunk_size=mock.ANY, raise_on_error=False, expand_action_callback=mock.ANY)
 
     def test_index_indexes_filtered_annotations_to_es(self, db_session, indexer, matchers, streaming_bulk, factories):
-        ann_1, ann_2 = factories.Annotation(), factories.Annotation()
+        _, ann_2 = factories.Annotation(), factories.Annotation()  # noqa: F841
 
         indexer.index([ann_2.id])
 

--- a/tests/h/search/index_test.py
+++ b/tests/h/search/index_test.py
@@ -4,8 +4,6 @@ from __future__ import unicode_literals
 import mock
 import pytest
 
-import elasticsearch
-
 from h import presenters
 from h.search import client
 from h.search import index

--- a/tests/h/search/query_test.py
+++ b/tests/h/search/query_test.py
@@ -97,7 +97,7 @@ class TestBuilder(object):
 
         q = builder.build({})
 
-        assert q["sort"][0]["updated"]["ignore_unmapped"] == True
+        assert q["sort"][0]["updated"]["ignore_unmapped"] is True
 
     def test_with_custom_sort(self):
         """Custom sorts are returned in the query dict."""

--- a/tests/h/services/rename_user_test.py
+++ b/tests/h/services/rename_user_test.py
@@ -18,7 +18,7 @@ class TestRenameUserService(object):
         assert service.check(user, 'panda') is True
 
     def test_check_raises_when_new_userid_is_already_taken(self, service, user, db_session, factories):
-        user_taken = factories.User(username='panda')
+        factories.User(username='panda')
         db_session.flush()
 
         with pytest.raises(UserRenameError) as err:

--- a/tests/h/views/admin_features_test.py
+++ b/tests/h/views/admin_features_test.py
@@ -50,7 +50,7 @@ def test_features_save_sets_attributes_when_checkboxes_on(Feature, pyramid_reque
 
     features_save(pyramid_request)
 
-    assert foo.everyone == foo.staff == bar.admins == True
+    assert foo.everyone is foo.staff is bar.admins is True
 
 
 @features_save_fixtures
@@ -63,7 +63,7 @@ def test_features_save_sets_attributes_when_checkboxes_off(Feature, pyramid_requ
 
     features_save(pyramid_request)
 
-    assert foo.everyone == foo.staff == False
+    assert foo.everyone is foo.staff is False
 
 
 @features_save_fixtures
@@ -75,7 +75,7 @@ def test_features_save_ignores_unknown_fields(Feature, pyramid_request):
 
     features_save(pyramid_request)
 
-    assert foo.admins == False
+    assert foo.admins is False
 
 
 def test_cohorts_index_without_cohorts(pyramid_request):

--- a/tests/h/views/groups_test.py
+++ b/tests/h/views/groups_test.py
@@ -3,8 +3,7 @@
 import deform
 import mock
 import pytest
-from pyramid.httpexceptions import (HTTPMovedPermanently, HTTPNoContent,
-                                    HTTPNotFound)
+from pyramid.httpexceptions import HTTPMovedPermanently
 
 from h.views import groups as views
 from h.models import (Group, User)

--- a/tests/h/views/help_test.py
+++ b/tests/h/views/help_test.py
@@ -3,7 +3,6 @@
 from __future__ import unicode_literals
 
 import pytest
-import mock
 from pyramid import httpexceptions
 
 from h.views import help

--- a/tests/setup.cfg
+++ b/tests/setup.cfg
@@ -1,0 +1,23 @@
+[flake8]
+
+max-line-length = 160
+
+ignore = \
+    # Lint warnings that are specifically disabled for tests:
+    #   E241 - multiple spaces after ','
+    #   E722 - do not use bare except
+    #
+    #   N802 - function name should be lowercase
+    #   N803 - argument name should be lowercase
+    #   N806 - variable name should be lowercase
+    E241, E722, N802, N803, N806 \
+
+    # Lint warnings ignored to ease the process of making tests lint-clean:
+    #   E121 - continuation line under-indented for hanging indent
+    #   E122 - continuation line missing indentation or outdented
+    #   E123 - closing bracket does not match indentation of opening bracket's line
+    #   E126 - continuation line over-indented
+    #   E127 - continuation line over-indented for visual indent
+    #   E128 - continuation line under-intended for visual indent
+    E121, E122, E123, E126, E127, E128,
+


### PR DESCRIPTION
Following on from https://github.com/hypothesis/h/pull/4766, this PR:

- Adds a custom flake8 config for the tests that ignores lint warnings that are, IMO, fine to ignore in tests (see comments in `tests/setup.cfg`).
- Includes a set of commits to fix the remaining flake8 violations
- Causes the lint Travis task to run flake8 over the tests

In the interests of keeping the PR small I opted to ignore all indentation-related errors in tests for this initial change.

One issue I'm note sure about, but is whether the setup.cfg file will end up entirely replacing the top-level setup.cfg file for non-flake8 tools or whether the configuration is combined.