### PR TITLE
Add new GroupScope model class

### DIFF
--- a/h/models/__init__.py
+++ b/h/models/__init__.py
@@ -30,6 +30,7 @@ from h.models.feature import Feature
 from h.models.feature_cohort import FeatureCohort
 from h.models.flag import Flag
 from h.models.group import Group
+from h.models.group_scope import GroupScope
 from h.models.setting import Setting
 from h.models.subscriptions import Subscriptions
 from h.models.token import Token
@@ -50,6 +51,7 @@ __all__ = (
     'FeatureCohort',
     'Flag',
     'Group',
+    'GroupScope',
     'Setting',
     'Subscriptions',
     'Token',

--- a/h/models/group_scope.py
+++ b/h/models/group_scope.py
@@ -13,7 +13,8 @@ class GroupScope(Base):
 
     #: A fully qualified domain name, e.g. example.com, www.nytimes.com or
     #: web.hypothes.is.
-    hostname = sa.Column('hostname', sa.UnicodeText, nullable=False, unique=True)
+    hostname = sa.Column(
+        'hostname', sa.UnicodeText, nullable=False, unique=True)
 
     groups = sa.orm.relationship(
         'Group',
@@ -26,8 +27,14 @@ class GroupScope(Base):
 
 
 GROUP_GROUPSCOPE_TABLE = sa.Table(
-    'group_groupscope', Base.metadata,
-    sa.Column('group_id', sa.Integer, sa.ForeignKey('group.id'), nullable=False),
-    sa.Column('groupscope_id', sa.Integer, sa.ForeignKey('groupscope.id'), nullable=False),
+    'group_groupscope',
+    Base.metadata,
+    sa.Column(
+        'group_id', sa.Integer, sa.ForeignKey('group.id'), nullable=False),
+    sa.Column(
+        'groupscope_id',
+        sa.Integer,
+        sa.ForeignKey('groupscope.id'),
+        nullable=False),
     sa.PrimaryKeyConstraint('group_id', 'groupscope_id'),
 )

--- a/h/models/group_scope.py
+++ b/h/models/group_scope.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import sqlalchemy as sa
+
+from h.db import Base
+
+
+class GroupScope(Base):
+    __tablename__ = 'groupscope'
+    id = sa.Column(sa.Integer, autoincrement=True, primary_key=True)
+
+    #: A fully qualified domain name, e.g. example.com, www.nytimes.com or
+    #: web.hypothes.is.
+    hostname = sa.Column('hostname', sa.UnicodeText, nullable=False, unique=True)
+
+    groups = sa.orm.relationship(
+        'Group',
+        secondary='group_groupscope',
+        backref=sa.orm.backref('scopes'),
+    )
+
+    def __repr__(self):
+        return '<GroupScope %s>' % self.hostname
+
+
+GROUP_GROUPSCOPE_TABLE = sa.Table(
+    'group_groupscope', Base.metadata,
+    sa.Column('id', sa.Integer, autoincrement=True, primary_key=True),
+    sa.Column('group_id', sa.Integer, sa.ForeignKey('group.id')),
+    sa.Column('groupscope_id', sa.Integer, sa.ForeignKey('groupscope.id')),
+    sa.UniqueConstraint('group_id', 'groupscope_id'),
+)

--- a/h/models/group_scope.py
+++ b/h/models/group_scope.py
@@ -27,8 +27,7 @@ class GroupScope(Base):
 
 GROUP_GROUPSCOPE_TABLE = sa.Table(
     'group_groupscope', Base.metadata,
-    sa.Column('id', sa.Integer, autoincrement=True, primary_key=True),
-    sa.Column('group_id', sa.Integer, sa.ForeignKey('group.id')),
-    sa.Column('groupscope_id', sa.Integer, sa.ForeignKey('groupscope.id')),
-    sa.UniqueConstraint('group_id', 'groupscope_id'),
+    sa.Column('group_id', sa.Integer, sa.ForeignKey('group.id'), nullable=False),
+    sa.Column('groupscope_id', sa.Integer, sa.ForeignKey('groupscope.id'), nullable=False),
+    sa.PrimaryKeyConstraint('group_id', 'groupscope_id'),
 )

--- a/tests/common/factories/__init__.py
+++ b/tests/common/factories/__init__.py
@@ -15,6 +15,7 @@ from .feature import Feature
 from .feature_cohort import FeatureCohort
 from .flag import Flag
 from .group import Group, OpenGroup
+from .group_scope import GroupScope
 from .setting import Setting
 from .token import DeveloperToken, OAuth2Token
 from .user import User
@@ -35,6 +36,7 @@ __all__ = (
     'FeatureCohort',
     'Flag',
     'Group',
+    'GroupScope',
     'OAuth2Token',
     'OpenGroup',
     'Setting',

--- a/tests/common/factories/group_scope.py
+++ b/tests/common/factories/group_scope.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import random
+
+import factory
+
+from h import models
+
+from .base import ModelFactory
+from .group import Group
+
+
+class GroupScope(ModelFactory):
+    class Meta:
+        model = models.GroupScope
+
+    hostname = factory.Faker('domain_name')
+
+    @factory.post_generation
+    def groups(self, create, groups, **kwargs):
+        if groups is None:
+            groups = random.randint(1, 3)
+
+        if isinstance(groups, int):
+            groups = [Group() for _ in range(0, groups)]
+
+        self.groups = groups or []

--- a/tests/h/models/group_scope_test.py
+++ b/tests/h/models/group_scope_test.py
@@ -9,7 +9,6 @@ from h.models import GroupScope
 
 
 class TestGroupScope(object):
-
     def test_save_and_retrieve_hostname(self, db_session, factories):
         hostname = 'test_hostname'
         factories.GroupScope(hostname=hostname)
@@ -23,12 +22,14 @@ class TestGroupScope(object):
 
     def test_hostname_must_be_unique(self, db_session):
         hostname = 'test_hostname'
-        db_session.add_all((GroupScope(hostname=hostname), GroupScope(hostname=hostname)))
+        db_session.add_all((GroupScope(hostname=hostname),
+                            GroupScope(hostname=hostname)))
 
         with pytest.raises(IntegrityError):
             db_session.flush()
 
-    def test_a_single_group_can_have_many_scopes(self, db_session, factories, matchers):
+    def test_a_single_group_can_have_many_scopes(self, db_session, factories,
+                                                 matchers):
         group = factories.Group()
         group_scopes = [
             factories.GroupScope(groups=[group]),
@@ -40,7 +41,8 @@ class TestGroupScope(object):
 
         assert group.scopes == matchers.unordered_list(group_scopes)
 
-    def test_a_single_scope_can_have_many_groups(self, db_session, factories, matchers):
+    def test_a_single_scope_can_have_many_groups(self, db_session, factories,
+                                                 matchers):
         groups = [factories.Group(), factories.Group(), factories.Group()]
         group_scope = factories.GroupScope(groups=groups)
         db_session.add(group_scope)

--- a/tests/h/models/group_scope_test.py
+++ b/tests/h/models/group_scope_test.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from h.models import GroupScope
+
+
+class TestGroupScope(object):
+
+    def test_save_and_retrieve_hostname(self, db_session, factories):
+        hostname = 'test_hostname'
+        factories.GroupScope(hostname=hostname)
+        group_scope = db_session.query(GroupScope).one()
+
+        assert group_scope.hostname == 'test_hostname'
+
+    def test_hostname_is_required(self, db_session, factories):
+        with pytest.raises(IntegrityError):
+            db_session.add(factories.GroupScope(hostname=None))
+
+    def test_hostname_must_be_unique(self, db_session):
+        hostname = 'test_hostname'
+        db_session.add_all((GroupScope(hostname=hostname), GroupScope(hostname=hostname)))
+
+        with pytest.raises(IntegrityError):
+            db_session.flush()
+
+    def test_a_single_group_can_have_many_scopes(self, db_session, factories, matchers):
+        group = factories.Group()
+        group_scopes = [
+            factories.GroupScope(groups=[group]),
+            factories.GroupScope(groups=[group]),
+            factories.GroupScope(groups=[group]),
+        ]
+        db_session.add_all(group_scopes)
+        db_session.flush()
+
+        assert group.scopes == matchers.unordered_list(group_scopes)
+
+    def test_a_single_scope_can_have_many_groups(self, db_session, factories, matchers):
+        groups = [factories.Group(), factories.Group(), factories.Group()]
+        group_scope = factories.GroupScope(groups=groups)
+        db_session.add(group_scope)
+        db_session.flush()
+
+        assert group_scope.groups == matchers.unordered_list(groups)


### PR DESCRIPTION
**Don't merge this yet** - <https://github.com/hypothesis/h/pull/4780> needs to be merged and run before this pr can be merged.

Add a new GroupScope model class and tests. No code uses this class yet,
though. (A Group can optionally be related to one or more GroupScopes
but no production code relates any Groups to any GroupScopes yet.)

The "scope" of a group is, currently, the list of one or more hostnames
that the group can be used on (when the client is launched on a URL
matching one of those hostnames).

The generic term "scope" is used because we might want to extend a
group's scope beyond just hostnames in the future. E.g. allow scopes to
be other kinds of URIs, or allow a scope to contain both a hostname and
a path.

For now only hostnames are supported, so the `groupscope` table has just
a single `hostname` column.

These "hostnames" are actually just strings - there's no validation yet.

There's a many-many relationship between groups and scopes:

    # All the groups related to a given scope.
    my_scope.groups

    # All of a given group's scopes.
    my_group.scopes

It's not mandatory for a group to have any scopes (`my_group.scopes` can
be `[]`), the intention is that in the future open groups will always
have one or more scopes (enforced at the service level) but private
groups will never have any scopes.

Usage of the new `GroupScope` class:

    my_group = models.Group(...)
    my_scope = models.GroupScope(hostname=u'biopub.org')
    my_scope.groups.append(my_group)
    my_scope.groups  # [<Group: foobar>]
    my_group.scopes  # [<GroupScope biopub.org>]

You can also set a group's scopes directly when you create the group:

    models.Group(..., scopes=[my_scope, my_other_scope])

This pull request also contains a [factory_boy](https://factoryboy.readthedocs.io/en/latest/)
factory for conveniently creating GroupScopes in tests.
`factories.GroupScope()` will return a new GroupScope with a randomly
generated hostname and a randomly chosen number of randomly generated
groups:

    s = factories.GroupScope()  # <GroupScope pacheco.net>
    s.hostname                  # u'pacheco.net'
    s.groups                    # [<Group: test-group-0>, <Group: test-group-1>]

(So this means that creating a GroupScope with factories.GroupScope() also
creates some Groups and adds them to the DB session as well.)

You can pass in your own hostname:

    factories.GroupScope(hostname=u'biopub.org')  # <GroupScope biopub.org>

You can control the number of groups by passing in an int as the `groups`
argument. For example to create a GroupScope with no groups:

    s = factories.GroupScope(groups=0)
    s.groups  # []

You can create a GroupScope for some preexisting groups by passing in a
list of `models.Group` objects as the `groups` argument:

    factories.GroupScope(groups=[my_group, another_group])