### PR TITLE
enabling activity pages for open groups

### DIFF
--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -143,7 +143,7 @@
 {% macro tags_section() %}
 <section class="search-result-sidebar__section">
   <h3 class="search-result-sidebar__subtitle">
-    {% trans %}Tags{% endtrans %}
+    {% trans %}Top tags{% endtrans %}
     <span class="search-result-sidebar__subtitle-count">
       {{ search_results.aggregations['tags'] | length }}
     </span>

--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -143,7 +143,7 @@
 {% macro tags_section() %}
 <section class="search-result-sidebar__section">
   <h3 class="search-result-sidebar__subtitle">
-    {% trans %}Top tags{% endtrans %}
+    {% trans %}Tags{% endtrans %}
     <span class="search-result-sidebar__subtitle-count">
       {{ search_results.aggregations['tags'] | length }}
     </span>
@@ -170,6 +170,44 @@
       </button>
     {% endfor %}
   </div>
+</section>
+{% endmacro %}
+
+{% macro group_users(title, users, creator) %}
+<section class="search-result-sidebar__section">
+  <h3 class="search-result-sidebar__subtitle">
+    {% trans %} {{title}} {% endtrans %}
+    <span class="search-result-sidebar-title__annotations-count">
+      {{ users|length }}
+    <span>
+  </h3>
+  <ul>
+    {% for user in users %}
+      <li>
+        <button type="submit"
+                form="search-bar"
+                name="toggle_user_facet"
+                value="{{ user.userid }}"
+                {% if user.faceted_by %}
+                  title="{% trans username=user.username %}Remove {{ username }} from the search query{% endtrans %}"
+                {% else %}
+                  title="{% trans username=user.username %}Limit the search to annotations by {{ username }}{% endtrans %}"
+                {% endif %}
+                class="search-result-sidebar__username">
+          {{ user.username }}
+          <span class="search-result-sidebar__annotations-count">
+            {{ user.count }}
+          </span>
+          {% if user.userid == creator %}
+            <span class="search-result-sidebar__annotations-count">
+              creator
+            </span>
+          {% endif %}
+        </button>
+      </li>
+      {% endfor %}
+    </ul>
+  </form>
 </section>
 {% endmacro %}
 
@@ -200,12 +238,10 @@
   {% call sidebar(group.name, group.description) %}
     <section class="search-result-sidebar__section">
       <dl>
-        {% if stats.annotation_count  %}
-          <dt class="search-result-sidebar__dt">
-            {% trans %}Shared annotations:{% endtrans %}
-          </dt>
-          <dd class="search-result-sidebar__dd">{{ stats.annotation_count }}</dd>
-        {% endif %}
+        <dt class="search-result-sidebar__dt">
+          {% trans %}Annotations:{% endtrans %}
+        </dt>
+        <dd class="search-result-sidebar__dd">{{ stats.annotation_count }}</dd>
         <dt class="search-result-sidebar__dt">
           {% trans %}Created:{% endtrans %}
         </dt>
@@ -223,59 +259,39 @@
             </a>
           </li>
         {% endif %}
-        <li>
-          <button class="link--btn js-confirm-submit"
-                  type="submit"
-                  form="search-bar"
-                  formmethod="POST"
-                  name="group_leave"
-                  value="{{ group.pubid }}"
-                  data-confirm-message="Are you sure you want to leave the group &quot;{{ group.name }}&quot;?">
-              {% trans %}Leave this group{% endtrans %}
-          </button>
-        </li>
+        {# only show ability to leave group if group has concept of members #}
+        {% if group.members %}
+          <li>
+            <button class="link--btn js-confirm-submit"
+                    type="submit"
+                    form="search-bar"
+                    formmethod="POST"
+                    name="group_leave"
+                    value="{{ group.pubid }}"
+                    data-confirm-message="Are you sure you want to leave the group &quot;{{ group.name }}&quot;?">
+                {% trans %}Leave this group{% endtrans %}
+            </button>
+          </li>
+        {% endif %}
       </ul>
     </section>
 
     {{ tags_section() }}
-
-    <section class="search-result-sidebar__section">
-      <h3 class="search-result-sidebar__subtitle">
-        {% trans %}Members{% endtrans %}
-        <span class="search-result-sidebar-title__annotations-count">
-          {{ group.members|length }}
-        <span>
+    {# if the group has a concept of members display members and join text #}
+    {% if group.members %} 
+      {{ group_users("Members", group.members, group.creator) }}
+      <h3 class="group-invite__title">
+        {% trans %}Invite new members{% endtrans %}
       </h3>
-      <ul>
-        {% for user in group.members %}
-          <li>
-            <button type="submit"
-                    form="search-bar"
-                    name="toggle_user_facet"
-                    value="{{ user.userid }}"
-                    {% if user.faceted_by %}
-                      title="{% trans username=user.username %}Remove {{ username }} from the search query{% endtrans %}"
-                    {% else %}
-                      title="{% trans username=user.username %}Limit the search to annotations by {{ username }}{% endtrans %}"
-                    {% endif %}
-                    class="search-result-sidebar__username">
-              {{ user.username }}
-              {% if user.count > 0 %}
-              <span class="search-result-sidebar__annotations-count">
-                {{ user.count }}
-              </span>
-              {% endif %}
-            </button>
-          </li>
-          {% endfor %}
-        </ul>
-      </form>
-    </section>
-
-    <h3 class="group-invite__title">
-      {% trans %}Invite new members{% endtrans %}
-    </h3>
-    Sharing the link below lets people join this group:
+      Sharing the link lets people join this group:
+    {# if the group has no concept of members display moderators and share text #}
+    {% else %}
+      {{ group_users("Moderators", group.moderators, group.creator) }}
+      <h3 class="group-invite__title">
+        {% trans %}Share group{% endtrans %}
+      </h3>
+      Sharing the link lets people view this group:
+    {% endif %}
     <div class="group-invite__container js-copy-button">
       <input class="group-invite__input js-select-onfocus"
              data-ref="input"

--- a/h/views/activity.py
+++ b/h/views/activity.py
@@ -110,6 +110,7 @@ class GroupSearchController(SearchController):
         # and the user is not in the list of members
         if self.group.joinable_by and (self.request.user not in self.group.members):
             return result
+
         def user_annotation_count(aggregation, userid):
             for user in aggregation:
                 if user['user'] == userid:

--- a/h/views/activity.py
+++ b/h/views/activity.py
@@ -106,9 +106,10 @@ class GroupSearchController(SearchController):
 
         result['opts'] = {'search_groupname': self.group.name}
 
-        if self.request.user not in self.group.members:
+        # if the group has a concept of members (aka joinable_by is not None)
+        # and the user is not in the list of members
+        if self.group.joinable_by and (self.request.user not in self.group.members):
             return result
-
         def user_annotation_count(aggregation, userid):
             for user in aggregation:
                 if user['user'] == userid:
@@ -116,23 +117,39 @@ class GroupSearchController(SearchController):
             return 0
 
         q = query.extract(self.request)
+        members = None
+        moderators = None
         users_aggregation = result['search_results'].aggregations.get('users', [])
-        members = [{'username': u.username,
-                    'userid': u.userid,
-                    'count': user_annotation_count(users_aggregation,
-                                                   u.userid),
-                    'faceted_by': _faceted_by_user(self.request,
-                                                   u.username,
-                                                   q)}
-                   for u in self.group.members]
-        members = sorted(members, key=lambda k: k['username'].lower())
+        # if the group has a concept of members provide list of member info
+        # else provide list of moderators instead
+        if self.group.joinable_by:
+            members = [{'username': u.username,
+                        'userid': u.userid,
+                        'count': user_annotation_count(users_aggregation,
+                                                       u.userid),
+                        'faceted_by': _faceted_by_user(self.request,
+                                                       u.username,
+                                                       q)}
+                       for u in self.group.members]
+            members = sorted(members, key=lambda k: k['username'].lower())
+        else:
+            # anticipating that [self.group.creator] will change
+            # to an actual list of moderators at some point
+            moderators = [{'username': u.username,
+                           'userid': u.userid,
+                           'count': user_annotation_count(users_aggregation,
+                                                          u.userid),
+                           'faceted_by': _faceted_by_user(self.request,
+                                                          u.username,
+                                                          q)}
+                          for u in [self.group.creator]]
+            moderators = sorted(moderators, key=lambda k: k['username'].lower())
 
         group_annotation_count = self.request.find_service(name='annotation_stats').group_annotation_count(self.group.pubid)
 
         result['stats'] = {
             'annotation_count': group_annotation_count,
         }
-
         result['group'] = {
             'created': self.group.created.strftime('%B, %Y'),
             'description': self.group.description,
@@ -142,8 +159,9 @@ class GroupSearchController(SearchController):
                                           pubid=self.group.pubid,
                                           slug=self.group.slug),
             'members': members,
+            'moderators': moderators,
+            'creator': self.group.creator.userid,
         }
-
         if self.request.has_permission('admin', self.group):
             result['group_edit_url'] = self.request.route_url(
                 'group_edit', pubid=self.group.pubid)

--- a/tests/common/factories/group.py
+++ b/tests/common/factories/group.py
@@ -34,6 +34,7 @@ class OpenGroup(Group):
     joinable_by = None
     readable_by = ReadableBy.world
     writeable_by = WriteableBy.authority
+    members = []
 
     @factory.post_generation
     def scopes(self, create, scopes=0, **kwargs):

--- a/tests/h/views/activity_test.py
+++ b/tests/h/views/activity_test.py
@@ -1106,11 +1106,6 @@ def group(factories):
 
 @pytest.fixture
 def no_creator_group(factories):
-    # Create some other groups as well, just to make sure it gets the right
-    # one from the db.
-    factories.Group()
-    factories.OpenGroup()
-
     group = factories.Group()
     group.creator = None
     group.members.extend([factories.User(), factories.User()])
@@ -1130,11 +1125,6 @@ def open_group(factories):
 
 @pytest.fixture
 def no_creator_open_group(factories):
-    # Create some other groups as well, just to make sure it gets the right
-    # one from the db.
-    factories.Group()
-    factories.OpenGroup()
-
     open_group = factories.OpenGroup()
     open_group.creator = None
     return open_group

--- a/tests/h/views/activity_test.py
+++ b/tests/h/views/activity_test.py
@@ -11,6 +11,9 @@ from h.activity.query import ActivityResults
 from h.views import activity
 
 
+GROUP_TYPE_OPTIONS = ('group', 'open_group')
+
+
 @pytest.mark.usefixtures('annotation_stats_service', 'paginate', 'query', 'routes')
 class TestSearchController(object):
 
@@ -109,459 +112,12 @@ class TestSearchController(object):
 
 
 @pytest.mark.usefixtures('annotation_stats_service', 'group_service', 'routes', 'search')
-class TestOpenGroupSearchController(object):
-
-    """Tests unique to GroupSearchController."""
-
-    def test_renders_join_template_when_no_read_permission(self, controller, pyramid_request, open_group):
-        """When the request has no read permission but join, it should render the join template."""
-
-        def fake_has_permission(permission, context=None):
-            if permission == 'read':
-                return False
-            if permission == 'join':
-                return True
-        pyramid_request.has_permission = mock.Mock(side_effect=fake_has_permission)
-        pyramid_request.override_renderer = mock.PropertyMock()
-
-        result = controller.search()
-
-        assert 'join.html' in pyramid_request.override_renderer
-        assert result == {'group': open_group}
-
-    def test_renders_join_template_when_not_logged_in(self, controller, factories, pyramid_request, open_group):
-        """
-        If user is logged out and has no read permission, prompt to login and join.
-        """
-        def fake_has_permission(permission, context=None):
-            if permission in ('read', 'join'):
-                return False
-        pyramid_request.user = None
-        pyramid_request.has_permission = mock.Mock(side_effect=fake_has_permission)
-
-        result = controller.search()
-
-        assert 'join.html' in pyramid_request.override_renderer
-        assert result == {'group': open_group}
-
-    def test_raises_not_found_when_no_read_or_join_permissions(self, controller, factories, pyramid_request):
-        def fake_has_permission(permission, context=None):
-            if permission in ('read', 'join'):
-                return False
-        pyramid_request.user = factories.User()  # User logged in
-        pyramid_request.has_permission = mock.Mock(side_effect=fake_has_permission)
-
-        with pytest.raises(httpexceptions.HTTPNotFound):
-            controller.search()
-
-    def test_search_redirects_if_slug_wrong(self,
-                                            controller,
-                                            open_group,
-                                            pyramid_request):
-        """
-        If the slug in the URL is wrong it should redirect to the right one.
-
-        For example /groups/<pubid>/foobar redirects to /groups/<pubid>/<slug>.
-
-        The other 'group_read' views on h.views.groups do this, this tests that
-        the ones in h.views.activity do as well.
-
-        """
-        pyramid_request.matchdict['slug'] = 'wrong'
-
-        with pytest.raises(httpexceptions.HTTPMovedPermanently) as exc:
-            controller.search()
-
-        assert exc.value.location == '/groups/{pubid}/{slug}'.format(
-            pubid=open_group.pubid, slug=open_group.slug)
-
-    def test_search_calls_search_with_the_request(self,
-                                                  controller,
-                                                  factories,
-                                                  open_group,
-                                                  pyramid_request,
-                                                  search):
-        for user in (None, open_group.creator, factories.User()):
-            pyramid_request.user = user
-
-            controller.search()
-
-            search.assert_called_once_with(controller)
-
-            search.reset_mock()
-
-    def test_search_just_returns_search_result_if_group_does_not_exist(
-            self, controller, factories, open_group, pyramid_request, search):
-        for user in (None, open_group.creator, factories.User()):
-            pyramid_request.user = user
-            pyramid_request.matchdict['pubid'] = 'does_not_exist'
-
-            assert controller.search() == search.return_value
-
-    def test_search_just_returns_search_result_if_user_not_logged_in(
-            self, controller, pyramid_request, search):
-        pyramid_request.user = None
-
-        assert controller.search() == search.return_value
-
-    def test_search_just_returns_search_result_if_user_not_a_member_of_group(
-            self, controller, factories, pyramid_request, search):
-        pyramid_request.user = factories.User()
-
-        assert controller.search() == search.return_value
-
-    def test_search_returns_group_info_if_user_a_member_of_group(self,
-                                                                 controller,
-                                                                 factories,
-                                                                 open_group,
-                                                                 pyramid_request):
-        pyramid_request.user = factories.User()
-
-        group_info = controller.search()['group']
-
-        assert group_info['created'] == open_group.created.strftime('%B, %Y')
-        assert group_info['description'] == open_group.description
-        assert group_info['name'] == open_group.name
-        assert group_info['pubid'] == open_group.pubid
-
-    def test_search_does_not_show_the_edit_link_to_group_members(self,
-                                                                 controller,
-                                                                 factories,
-                                                                 open_group,
-                                                                 pyramid_request):
-        def fake_has_permission(permission, context=None):
-            return permission != 'admin'
-        pyramid_request.has_permission = mock.Mock(side_effect=fake_has_permission)
-        pyramid_request.user = factories.User()
-
-        result = controller.search()
-
-        assert 'group_edit_url' not in result
-
-    def test_search_does_show_the_group_edit_link_to_group_creators(self,
-                                                                    controller,
-                                                                    open_group,
-                                                                    pyramid_request):
-        pyramid_request.has_permission = mock.Mock(return_value=True)
-        pyramid_request.user = open_group.creator
-
-        result = controller.search()
-
-        assert 'group_edit_url' in result
-
-    def test_search_shows_the_more_info_version_of_the_page_if_more_info_is_in_the_request_params(
-            self,
-            controller,
-            factories,
-            open_group,
-            pyramid_request):
-        pyramid_request.user = factories.User()
-        pyramid_request.params['more_info'] = ''
-
-        assert controller.search()['more_info'] is True
-
-    def test_search_shows_the_normal_version_of_the_page_if_more_info_is_not_in_the_request_params(
-            self,
-            controller,
-            factories,
-            open_group,
-            pyramid_request):
-        pyramid_request.user = factories.User()
-
-        assert controller.search()['more_info'] is False
-
-    def test_search_returns_name_in_opts(self,
-                                         controller,
-                                         open_group,
-                                         pyramid_request):
-        result = controller.search()
-
-        assert result['opts']['search_groupname'] == open_group.name
-
-    def test_search_returns_group_moderators_usernames(self,
-                                                 controller,
-                                                 factories,
-                                                 pyramid_request,
-                                                 open_group):
-        pyramid_request.user = factories.User()
-
-        result = controller.search()
-
-        actual = set([m['username'] for m in result['group']['moderators']])
-        expected = set([open_group.creator.username])
-        assert actual == expected
-
-    def test_search_returns_group_moderators_userid(self,
-                                                 controller,
-                                                 factories,
-                                                 pyramid_request,
-                                                 open_group):
-        pyramid_request.user = factories.User()
-
-        result = controller.search()
-
-        actual = set([m['userid'] for m in result['group']['moderators']])
-        expected = set([open_group.creator.userid])
-        assert actual == expected
-
-    def test_search_returns_group_moderators(self,
-                                                     controller,
-                                                     factories,
-                                                     pyramid_request,
-                                                     open_group):
-        pyramid_request.user = factories.User()
-
-        pyramid_request.params = {'q': 'user:%s' % "does_not_matter"}
-
-        result = controller.search()
-        assert result['group']['members'] is None, "Open group search should return members=None."
-        for moderator in result['group']['moderators']:
-            assert not moderator['faceted_by']
-
-    def test_search_returns_annotation_count_for_group_members(self,
-                                                               controller,
-                                                               pyramid_request,
-                                                               open_group,
-                                                               search,
-                                                               factories):
-        user_1 = open_group.creator
-        user_2 = factories.User()
-
-        pyramid_request.user = factories.User()
-
-        counts = {user_1.userid: 24, user_2.userid: 6}
-        users_aggregation = [
-            {'user': user_1.userid, 'count': counts[user_1.userid]},
-            {'user': user_2.userid, 'count': counts[user_2.userid]},
-        ]
-        search.return_value = {
-            'search_results': ActivityResults(total=200,
-                                              aggregations={'users': users_aggregation},
-                                              timeframes=[]),
-        }
-
-        result = controller.search()
-        for moderator in result['group']['moderators']:
-            assert moderator['count'] == counts[moderator['userid']]
-
-    def test_search_returns_the_default_zero_message_to_the_template(
-            self, controller, factories, open_group, pyramid_request, search):
-        """If there's a non-empty query it uses the default zero message."""
-        pyramid_request.user = factories.User()
-        search.return_value['q'] = 'foo'
-
-        result = controller.search()
-
-        assert result['zero_message'] == 'No annotations matched your search.'
-
-    def test_search_returns_the_group_zero_message_to_the_template(
-            self, controller, factories, open_group, pyramid_request, search):
-        """If the query is empty it overrides the default zero message."""
-        pyramid_request.user = factories.User()
-        search.return_value['q'] = ''
-
-        result = controller.search()
-
-        assert result['zero_message'] == (
-            "The group “{name}” has not made any annotations yet.".format(
-                name=open_group.name))
-
-    def test_leave_redirects_to_the_search_page(self,
-                                                controller,
-                                                open_group,
-                                                group_leave_request):
-        # This should be in the redirect URL.
-        group_leave_request.POST['q'] = 'foo bar gar'
-        # This should *not* be in the redirect URL.
-        group_leave_request.POST['group_leave'] = open_group.pubid
-
-        result = controller.leave()
-
-        assert isinstance(result, httpexceptions.HTTPSeeOther)
-        assert result.location == 'http://example.com/search?q=foo+bar+gar'
-
-    def test_join_raises_not_found_when_not_joinable(self, controller, pyramid_request):
-        pyramid_request.has_permission = mock.Mock(return_value=False)
-
-        with pytest.raises(httpexceptions.HTTPNotFound):
-            controller.join()
-
-    def test_join_adds_group_member(self, controller, open_group, pyramid_request, pyramid_config, group_service):
-        pyramid_config.testing_securitypolicy('acct:doe@example.org')
-
-        controller.join()
-
-        group_service.member_join.assert_called_once_with(open_group, 'acct:doe@example.org')
-
-    def test_join_redirects_to_search_page(self, controller, open_group, pyramid_request):
-        result = controller.join()
-
-        assert isinstance(result, httpexceptions.HTTPSeeOther)
-        expected = pyramid_request.route_url('group_read', pubid=open_group.pubid, slug=open_group.slug)
-        assert result.location == expected
-
-    def test_search_passes_the_group_annotation_count_to_the_template(self,
-                                                                      controller,
-                                                                      factories,
-                                                                      open_group,
-                                                                      pyramid_request):
-        pyramid_request.user = factories.User()
-        result = controller.search()['stats']
-
-        assert result['annotation_count'] == 5
-
-    @pytest.mark.parametrize('q', ['', '   '])
-    def test_leave_removes_empty_query_from_url(self,
-                                                controller,
-                                                open_group,
-                                                group_leave_request,
-                                                q):
-        """
-        It should remove an empty q from the URL it redirects to.
-
-        We don't want to redirect to a URL with a pointless trailing empty ?q=.
-
-        """
-        group_leave_request.POST['q'] = q
-        group_leave_request.POST['group_leave'] = open_group.pubid
-
-        result = controller.leave()
-
-        assert isinstance(result, httpexceptions.HTTPSeeOther)
-        assert result.location == 'http://example.com/search'
-
-    def test_back_redirects_to_group_search(self,
-                                            controller,
-                                            open_group,
-                                            pyramid_request):
-        """It should redirect and preserve the search query param."""
-        pyramid_request.matched_route = mock.Mock()
-        pyramid_request.matched_route.name = 'group_read'
-        pyramid_request.params = {'q': 'foo bar', 'back': ''}
-
-        result = controller.back()
-
-        assert isinstance(result, httpexceptions.HTTPSeeOther)
-        assert result.location == (
-            'http://example.com/groups/{pubid}/{slug}?q=foo+bar'.format(
-                pubid=open_group.pubid, slug=open_group.slug))
-
-    @pytest.mark.usefixtures('toggle_user_facet_request')
-    def test_toggle_user_facet_returns_a_redirect(self, controller):
-        result = controller.toggle_user_facet()
-
-        assert isinstance(result, httpexceptions.HTTPSeeOther)
-
-    @pytest.mark.usefixtures('toggle_user_facet_request')
-    def test_toggle_user_facet_adds_the_user_facet_into_the_url(self,
-                                                                controller,
-                                                                open_group):
-        result = controller.toggle_user_facet()
-
-        assert result.location == (
-            'http://example.com/groups/{pubid}/{slug}'
-            '?q=user%3Afred'.format(pubid=open_group.pubid, slug=open_group.slug))
-
-    def test_toggle_user_facet_removes_the_user_facet_from_the_url(self,
-                                                                   controller,
-                                                                   open_group,
-                                                                   toggle_user_facet_request):
-        toggle_user_facet_request.params['q'] = 'user:"fred"'
-
-        result = controller.toggle_user_facet()
-
-        assert result.location == (
-            'http://example.com/groups/{pubid}/{slug}'.format(
-                pubid=open_group.pubid, slug=open_group.slug))
-
-    def test_toggle_user_facet_preserves_query_when_adding_user_facet(self,
-                                                                      controller,
-                                                                      open_group,
-                                                                      toggle_user_facet_request):
-        toggle_user_facet_request.params['q'] = 'foo bar'
-
-        result = controller.toggle_user_facet()
-
-        assert result.location == (
-            'http://example.com/groups/{pubid}/{slug}'
-            '?q=foo+bar+user%3Afred'.format(pubid=open_group.pubid, slug=open_group.slug))
-
-    def test_toggle_user_facet_preserves_query_when_removing_user_facet(self,
-                                                                        controller,
-                                                                        open_group,
-                                                                        toggle_user_facet_request):
-        toggle_user_facet_request.params['q'] = 'user:"fred" foo bar'
-
-        result = controller.toggle_user_facet()
-
-        assert result.location == (
-            'http://example.com/groups/{pubid}/{slug}'
-            '?q=foo+bar'.format(pubid=open_group.pubid, slug=open_group.slug))
-
-    def test_toggle_user_facet_preserves_query_when_removing_one_of_multiple_username_facets(
-            self, controller, open_group, toggle_user_facet_request):
-        toggle_user_facet_request.params['q'] = 'user:"foo" user:"fred" user:"bar"'
-
-        result = controller.toggle_user_facet()
-
-        assert result.location == (
-            'http://example.com/groups/{pubid}/{slug}'
-            '?q=user%3Afoo+user%3Abar'.format(pubid=open_group.pubid, slug=open_group.slug))
-
-    @pytest.mark.parametrize('q', ['user:fred', '  user:fred   '])
-    def test_toggle_user_facet_removes_empty_query(self,
-                                                   controller,
-                                                   open_group,
-                                                   toggle_user_facet_request,
-                                                   q):
-        """
-        It should remove an empty query from the URL.
-
-        We don't want to redirect to a URL with a pointless trailing empty ?q=.
-
-        """
-        toggle_user_facet_request.params['q'] = q
-
-        result = controller.toggle_user_facet()
-
-        assert result.location == (
-            'http://example.com/groups/{pubid}/{slug}'.format(
-                pubid=open_group.pubid, slug=open_group.slug))
-
-    @pytest.fixture
-    def controller(self, open_group, pyramid_request):
-        return activity.GroupSearchController(open_group, pyramid_request)
-
-    @pytest.fixture
-    def group_leave_request(self, open_group, pyramid_request):
-        pyramid_request.POST = {'group_leave': open_group.pubid}
-        return pyramid_request
-
-    @pytest.fixture
-    def group_service(self, patch, pyramid_config):
-        group_service = patch('h.services.group.GroupService')
-        pyramid_config.register_service(group_service, name='group')
-        return group_service
-
-    @pytest.fixture
-    def pyramid_request(self, open_group, pyramid_request):
-        pyramid_request.matchdict['pubid'] = open_group.pubid
-        pyramid_request.matchdict['slug'] = open_group.slug
-        pyramid_request.user = None
-        return pyramid_request
-
-    @pytest.fixture
-    def toggle_user_facet_request(self, open_group, pyramid_request):
-        pyramid_request.params['toggle_user_facet'] = 'acct:fred@hypothes.is'
-        return pyramid_request
-
-
-@pytest.mark.usefixtures('annotation_stats_service', 'group_service', 'routes', 'search')
 class TestGroupSearchController(object):
 
     """Tests unique to GroupSearchController."""
 
-    def test_renders_join_template_when_no_read_permission(self, controller, pyramid_request, group):
+    @pytest.mark.parametrize('test_group', GROUP_TYPE_OPTIONS, indirect=['test_group'])
+    def test_renders_join_template_when_no_read_permission(self, controller, pyramid_request, test_group):
         """When the request has no read permission but join, it should render the join template."""
 
         def fake_has_permission(permission, context=None):
@@ -575,36 +131,37 @@ class TestGroupSearchController(object):
         result = controller.search()
 
         assert 'join.html' in pyramid_request.override_renderer
-        assert result == {'group': group}
+        assert result == {'group': test_group}
 
-    def test_renders_join_template_when_not_logged_in(self, controller, factories, pyramid_request, group):
+    @pytest.mark.parametrize('test_group', GROUP_TYPE_OPTIONS, indirect=['test_group'])
+    def test_renders_join_template_when_not_logged_in(self, controller, factories, pyramid_request, test_group):
         """
         If user is logged out and has no read permission, prompt to login and join.
         """
         def fake_has_permission(permission, context=None):
             if permission in ('read', 'join'):
                 return False
-        pyramid_request.user = None
         pyramid_request.has_permission = mock.Mock(side_effect=fake_has_permission)
 
         result = controller.search()
 
         assert 'join.html' in pyramid_request.override_renderer
-        assert result == {'group': group}
+        assert result == {'group': test_group}
 
-    def test_raises_not_found_when_no_read_or_join_permissions(self, controller, factories, pyramid_request):
+    @pytest.mark.parametrize('test_group,test_user', [('group', 'member')], indirect=['test_group', 'test_user'])
+    def test_raises_not_found_when_no_read_or_join_permissions(self, controller, factories, pyramid_request, test_group, test_user):
         def fake_has_permission(permission, context=None):
             if permission in ('read', 'join'):
                 return False
-        pyramid_request.user = factories.User()  # User logged in
         pyramid_request.has_permission = mock.Mock(side_effect=fake_has_permission)
 
         with pytest.raises(httpexceptions.HTTPNotFound):
             controller.search()
 
+    @pytest.mark.parametrize('test_group', GROUP_TYPE_OPTIONS, indirect=['test_group'])
     def test_search_redirects_if_slug_wrong(self,
                                             controller,
-                                            group,
+                                            test_group,
                                             pyramid_request):
         """
         If the slug in the URL is wrong it should redirect to the right one.
@@ -621,155 +178,204 @@ class TestGroupSearchController(object):
             controller.search()
 
         assert exc.value.location == '/groups/{pubid}/{slug}'.format(
-            pubid=group.pubid, slug=group.slug)
+            pubid=test_group.pubid, slug=test_group.slug)
 
+    @pytest.mark.parametrize('test_group,test_user',
+                             [('group', None), ('open_group', 'creator'), ('group', 'user')],
+                             indirect=['test_group', 'test_user'])
     def test_search_calls_search_with_the_request(self,
                                                   controller,
-                                                  group,
+                                                  factories,
+                                                  test_group,
+                                                  test_user,
                                                   pyramid_request,
                                                   search):
-        for user in (None, group.creator, group.members[-1]):
-            pyramid_request.user = user
+        controller.search()
 
-            controller.search()
+        search.assert_called_once_with(controller)
 
-            search.assert_called_once_with(controller)
+        search.reset_mock()
 
-            search.reset_mock()
-
+    @pytest.mark.parametrize('test_group,test_user',
+                             [('group', None), ('open_group', 'creator'), ('group', 'user')],
+                             indirect=['test_group', 'test_user'])
     def test_search_just_returns_search_result_if_group_does_not_exist(
-            self, controller, group, pyramid_request, search):
-        for user in (None, group.creator, group.members[-1]):
-            pyramid_request.user = user
-            pyramid_request.matchdict['pubid'] = 'does_not_exist'
+            self, controller, factories, test_group, test_user, pyramid_request, search):
+        pyramid_request.matchdict['pubid'] = 'does_not_exist'
 
-            assert controller.search() == search.return_value
+        assert controller.search() == search.return_value
 
+    @pytest.mark.parametrize('test_group', GROUP_TYPE_OPTIONS, indirect=['test_group'])
     def test_search_just_returns_search_result_if_user_not_logged_in(
-            self, controller, pyramid_request, search):
-        pyramid_request.user = None
-
+            self, controller, test_group, pyramid_request, search):
         assert controller.search() == search.return_value
 
+    @pytest.mark.parametrize('test_group,test_user', [('group', 'user')], indirect=['test_group', 'test_user'])
     def test_search_just_returns_search_result_if_user_not_a_member_of_group(
-            self, controller, factories, pyramid_request, search):
-        pyramid_request.user = factories.User()
+            self, controller, test_group, test_user, factories, pyramid_request, search):
 
         assert controller.search() == search.return_value
 
-    def test_search_returns_group_info_if_user_a_member_of_group(self,
+    @pytest.mark.parametrize('test_group,test_user',
+                             [('no_creator_group', 'member'), ('no_creator_open_group', 'user')],
+                             indirect=['test_group', 'test_user'])
+    def test_search_returns_group_info_if_group_creator_is_empty(self,
                                                                  controller,
-                                                                 group,
+                                                                 factories,
+                                                                 test_group,
+                                                                 test_user,
                                                                  pyramid_request):
-        pyramid_request.user = group.members[-1]
-
         group_info = controller.search()['group']
 
-        assert group_info['created'] == group.created.strftime('%B, %Y')
-        assert group_info['description'] == group.description
-        assert group_info['name'] == group.name
-        assert group_info['pubid'] == group.pubid
+        assert group_info['creator'] is None
 
-    def test_search_does_not_show_the_edit_link_to_group_members(self,
+    @pytest.mark.parametrize('test_group,test_user',
+                             [('no_creator_group', 'member'), ('no_creator_open_group', 'user')],
+                             indirect=['test_group', 'test_user'])
+    def test_search_returns_group_info_if_user_is_member_of_group(self,
                                                                  controller,
-                                                                 group,
+                                                                 factories,
+                                                                 test_group,
+                                                                 test_user,
                                                                  pyramid_request):
+        # Technically open groups don't have members but this should work for them with any user.
+        group_info = controller.search()['group']
+
+        assert group_info['created'] == test_group.created.strftime('%B, %Y')
+        assert group_info['description'] == test_group.description
+        assert group_info['name'] == test_group.name
+        assert group_info['pubid'] == test_group.pubid
+
+    @pytest.mark.parametrize('test_group,test_user',
+                             [('no_creator_group', 'member'), ('no_creator_open_group', 'user')],
+                             indirect=['test_group', 'test_user'])
+    def test_search_does_not_show_the_edit_link_to_non_admin_users(self,
+                                                                   controller,
+                                                                   factories,
+                                                                   test_group,
+                                                                   test_user,
+                                                                   pyramid_request):
         def fake_has_permission(permission, context=None):
             return permission != 'admin'
         pyramid_request.has_permission = mock.Mock(side_effect=fake_has_permission)
-        pyramid_request.user = group.members[-1]
 
         result = controller.search()
 
         assert 'group_edit_url' not in result
 
+    @pytest.mark.parametrize('test_group,test_user',
+                             [('open_group', 'creator'), ('group', 'creator')],
+                             indirect=['test_group', 'test_user'])
     def test_search_does_show_the_group_edit_link_to_group_creators(self,
                                                                     controller,
-                                                                    group,
+                                                                    test_group,
+                                                                    test_user,
                                                                     pyramid_request):
         pyramid_request.has_permission = mock.Mock(return_value=True)
-        pyramid_request.user = group.creator
 
         result = controller.search()
 
         assert 'group_edit_url' in result
 
+    @pytest.mark.parametrize('test_group,test_user',
+                             [('group', 'member')],
+                             indirect=['test_group', 'test_user'])
     def test_search_shows_the_more_info_version_of_the_page_if_more_info_is_in_the_request_params(
             self,
             controller,
-            group,
+            factories,
+            test_group,
+            test_user,
             pyramid_request):
-        pyramid_request.user = group.members[-1]
         pyramid_request.params['more_info'] = ''
 
         assert controller.search()['more_info'] is True
 
+    @pytest.mark.parametrize('test_group,test_user',
+                             [('group', 'member')],
+                             indirect=['test_group', 'test_user'])
     def test_search_shows_the_normal_version_of_the_page_if_more_info_is_not_in_the_request_params(
             self,
             controller,
-            group,
+            factories,
+            test_group,
+            test_user,
             pyramid_request):
-        pyramid_request.user = group.members[-1]
 
         assert controller.search()['more_info'] is False
 
+    @pytest.mark.parametrize('test_group', GROUP_TYPE_OPTIONS, indirect=['test_group'])
     def test_search_returns_name_in_opts(self,
                                          controller,
-                                         group,
+                                         test_group,
                                          pyramid_request):
         result = controller.search()
 
-        assert result['opts']['search_groupname'] == group.name
+        assert result['opts']['search_groupname'] == test_group.name
 
+    @pytest.mark.parametrize('test_group,test_user',
+                             [('group', 'member'), ('open_group', 'user')],
+                             indirect=['test_group', 'test_user'])
+    def test_search_returns_group_creator(self,
+                                          controller,
+                                          factories,
+                                          pyramid_request,
+                                          test_user,
+                                          test_group):
+        result = controller.search()
+
+        assert result['group']['creator'] == test_group.creator.userid
+
+    @pytest.mark.parametrize('test_group,test_user', [('group', 'member')], indirect=['test_group', 'test_user'])
     def test_search_returns_group_members_usernames(self,
                                                     controller,
                                                     pyramid_request,
-                                                    group):
-        pyramid_request.user = group.members[-1]
-
+                                                    test_user,
+                                                    test_group):
         result = controller.search()
 
         actual = set([m['username'] for m in result['group']['members']])
-        expected = set([m.username for m in group.members])
+        expected = set([m.username for m in test_group.members])
         assert actual == expected
 
+    @pytest.mark.parametrize('test_group,test_user', [('group', 'member')], indirect=['test_group', 'test_user'])
     def test_search_returns_group_members_userid(self,
                                                  controller,
                                                  pyramid_request,
-                                                 group):
-        pyramid_request.user = group.members[-1]
-
+                                                 test_user,
+                                                 test_group):
         result = controller.search()
 
         actual = set([m['userid'] for m in result['group']['members']])
-        expected = set([m.userid for m in group.members])
+        expected = set([m.userid for m in test_group.members])
         assert actual == expected
 
+    @pytest.mark.parametrize('test_group,test_user', [('group', 'member')], indirect=['test_group', 'test_user'])
     def test_search_returns_group_members_faceted_by(self,
                                                      controller,
                                                      pyramid_request,
-                                                     group):
-        pyramid_request.user = group.members[-1]
-
-        faceted_user = group.members[0]
-        pyramid_request.params = {'q': 'user:%s' % group.members[0].username}
+                                                     test_user,
+                                                     test_group):
+        faceted_user = test_group.members[0]
+        pyramid_request.params = {'q': 'user:%s' % test_group.members[0].username}
 
         result = controller.search()
 
         for member in result['group']['members']:
             assert member['faceted_by'] is (member['userid'] == faceted_user.userid)
 
+    @pytest.mark.parametrize('test_group', ['group'], indirect=['test_group'])
     def test_search_returns_annotation_count_for_group_members(self,
                                                                controller,
                                                                pyramid_request,
-                                                               group,
+                                                               test_group,
                                                                search,
                                                                factories):
         user_1 = factories.User()
         user_2 = factories.User()
-        group.members = [user_1, user_2]
+        test_group.members = [user_1, user_2]
 
-        pyramid_request.user = group.members[-1]
+        pyramid_request.user = test_group.members[-1]
 
         counts = {user_1.userid: 24, user_2.userid: 6}
         users_aggregation = [
@@ -787,88 +393,178 @@ class TestGroupSearchController(object):
         for member in result['group']['members']:
             assert member['count'] == counts[member['userid']]
 
+    @pytest.mark.parametrize('test_group,test_user',
+                             [('open_group', 'user')],
+                             indirect=['test_group', 'test_user'])
+    def test_search_returns_group_moderators_usernames(self,
+                                                       controller,
+                                                       factories,
+                                                       pyramid_request,
+                                                       test_user,
+                                                       test_group):
+        result = controller.search()
+
+        actual = set([m['username'] for m in result['group']['moderators']])
+        expected = set([test_group.creator.username])
+        assert actual == expected
+
+    @pytest.mark.parametrize('test_group,test_user',
+                             [('open_group', 'user')],
+                             indirect=['test_group', 'test_user'])
+    def test_search_returns_group_moderators_userid(self,
+                                                    controller,
+                                                    factories,
+                                                    pyramid_request,
+                                                    test_user,
+                                                    test_group):
+        result = controller.search()
+
+        actual = set([m['userid'] for m in result['group']['moderators']])
+        expected = set([test_group.creator.userid])
+        assert actual == expected
+
+    @pytest.mark.parametrize('test_group,test_user',
+                             [('open_group', 'user')],
+                             indirect=['test_group', 'test_user'])
+    def test_search_returns_group_moderators_faceted_by(self,
+                                                        controller,
+                                                        factories,
+                                                        pyramid_request,
+                                                        test_user,
+                                                        test_group):
+        pyramid_request.params = {'q': 'user:%s' % "does_not_matter"}
+
+        result = controller.search()
+        assert result['group']['members'] is None, "Open group search should return members=None."
+        for moderator in result['group']['moderators']:
+            assert not moderator['faceted_by']
+
+    @pytest.mark.parametrize('test_group,test_user',
+                             [('open_group', 'user')],
+                             indirect=['test_group', 'test_user'])
+    def test_search_returns_annotation_count_for_group_moderators(self,
+                                                                  controller,
+                                                                  pyramid_request,
+                                                                  test_group,
+                                                                  test_user,
+                                                                  search,
+                                                                  factories):
+        user_1 = test_group.creator
+        user_2 = factories.User()
+
+        counts = {user_1.userid: 24, user_2.userid: 6}
+        users_aggregation = [
+            {'user': user_1.userid, 'count': counts[user_1.userid]},
+            {'user': user_2.userid, 'count': counts[user_2.userid]},
+        ]
+        search.return_value = {
+            'search_results': ActivityResults(total=200,
+                                              aggregations={'users': users_aggregation},
+                                              timeframes=[]),
+        }
+
+        result = controller.search()
+        for moderator in result['group']['moderators']:
+            assert moderator['count'] == counts[moderator['userid']]
+
+    @pytest.mark.parametrize('test_group,test_user',
+                             [('open_group', 'user'), ('group', 'user')],
+                             indirect=['test_group', 'test_user'])
     def test_search_returns_the_default_zero_message_to_the_template(
-            self, controller, group, pyramid_request, search):
+            self, controller, factories, test_group, test_user, pyramid_request, search):
         """If there's a non-empty query it uses the default zero message."""
-        pyramid_request.user = group.members[-1]
         search.return_value['q'] = 'foo'
 
         result = controller.search()
 
         assert result['zero_message'] == 'No annotations matched your search.'
 
+    @pytest.mark.parametrize('test_group,test_user',
+                             [('open_group', 'user'), ('group', 'member')],
+                             indirect=['test_group', 'test_user'])
     def test_search_returns_the_group_zero_message_to_the_template(
-            self, controller, group, pyramid_request, search):
+            self, controller, factories, test_group, test_user, pyramid_request, search):
         """If the query is empty it overrides the default zero message."""
-        pyramid_request.user = group.members[-1]
         search.return_value['q'] = ''
 
         result = controller.search()
 
         assert result['zero_message'] == (
             "The group “{name}” has not made any annotations yet.".format(
-                name=group.name))
+                name=test_group.name))
 
+    @pytest.mark.parametrize('test_group,test_user', [('group', 'member')], indirect=['test_group', 'test_user'])
     def test_leave_leaves_the_group(self,
                                     controller,
-                                    group,
+                                    test_group,
+                                    test_user,
                                     group_leave_request,
                                     group_service,
+                                    pyramid_request,
                                     pyramid_config):
-        pyramid_config.testing_securitypolicy(group.members[-1].userid)
+        pyramid_config.testing_securitypolicy(test_user.userid)
 
         controller.leave()
 
         group_service.member_leave.assert_called_once_with(
-            group, group.members[-1].userid)
+            test_group, test_user.userid)
 
+    @pytest.mark.parametrize('test_group', ['group'], indirect=['test_group'])
     def test_leave_redirects_to_the_search_page(self,
                                                 controller,
-                                                group,
+                                                test_group,
                                                 group_leave_request):
         # This should be in the redirect URL.
         group_leave_request.POST['q'] = 'foo bar gar'
         # This should *not* be in the redirect URL.
-        group_leave_request.POST['group_leave'] = group.pubid
+        group_leave_request.POST['group_leave'] = test_group.pubid
 
         result = controller.leave()
 
         assert isinstance(result, httpexceptions.HTTPSeeOther)
         assert result.location == 'http://example.com/search?q=foo+bar+gar'
 
-    def test_join_raises_not_found_when_not_joinable(self, controller, pyramid_request):
+    @pytest.mark.parametrize('test_group', ['group'], indirect=['test_group'])
+    def test_join_raises_not_found_when_not_joinable(self, controller, pyramid_request, test_group):
         pyramid_request.has_permission = mock.Mock(return_value=False)
 
         with pytest.raises(httpexceptions.HTTPNotFound):
             controller.join()
 
-    def test_join_adds_group_member(self, controller, group, pyramid_request, pyramid_config, group_service):
+    @pytest.mark.parametrize('test_group', ['group'], indirect=['test_group'])
+    def test_join_adds_group_member(self, controller, test_group, pyramid_request, pyramid_config, group_service):
         pyramid_config.testing_securitypolicy('acct:doe@example.org')
 
         controller.join()
 
-        group_service.member_join.assert_called_once_with(group, 'acct:doe@example.org')
+        group_service.member_join.assert_called_once_with(test_group, 'acct:doe@example.org')
 
-    def test_join_redirects_to_search_page(self, controller, group, pyramid_request):
+    @pytest.mark.parametrize('test_group', GROUP_TYPE_OPTIONS, indirect=['test_group'])
+    def test_join_redirects_to_search_page(self, controller, test_group, pyramid_request):
+        # Although open groups aren't joinable they still have a share link that looks the same.
         result = controller.join()
 
         assert isinstance(result, httpexceptions.HTTPSeeOther)
-        expected = pyramid_request.route_url('group_read', pubid=group.pubid, slug=group.slug)
+        expected = pyramid_request.route_url('group_read', pubid=test_group.pubid, slug=test_group.slug)
         assert result.location == expected
 
+    @pytest.mark.parametrize('test_group,test_user',
+                             [('group', 'member'), ('open_group', 'user')],
+                             indirect=['test_group', 'test_user'])
     def test_search_passes_the_group_annotation_count_to_the_template(self,
                                                                       controller,
-                                                                      group,
+                                                                      factories,
+                                                                      test_group,
+                                                                      test_user,
                                                                       pyramid_request):
-        pyramid_request.user = group.members[-1]
         result = controller.search()['stats']
-
         assert result['annotation_count'] == 5
 
-    @pytest.mark.parametrize('q', ['', '   '])
+    @pytest.mark.parametrize('q,test_group', [('', 'open_group'), ('   ', 'group')], indirect=['test_group'])
     def test_leave_removes_empty_query_from_url(self,
                                                 controller,
-                                                group,
+                                                test_group,
+                                                pyramid_request,
                                                 group_leave_request,
                                                 q):
         """
@@ -878,16 +574,17 @@ class TestGroupSearchController(object):
 
         """
         group_leave_request.POST['q'] = q
-        group_leave_request.POST['group_leave'] = group.pubid
+        group_leave_request.POST['group_leave'] = test_group.pubid
 
         result = controller.leave()
 
         assert isinstance(result, httpexceptions.HTTPSeeOther)
         assert result.location == 'http://example.com/search'
 
+    @pytest.mark.parametrize('test_group', GROUP_TYPE_OPTIONS, indirect=['test_group'])
     def test_back_redirects_to_group_search(self,
                                             controller,
-                                            group,
+                                            test_group,
                                             pyramid_request):
         """It should redirect and preserve the search query param."""
         pyramid_request.matched_route = mock.Mock()
@@ -899,27 +596,32 @@ class TestGroupSearchController(object):
         assert isinstance(result, httpexceptions.HTTPSeeOther)
         assert result.location == (
             'http://example.com/groups/{pubid}/{slug}?q=foo+bar'.format(
-                pubid=group.pubid, slug=group.slug))
+                pubid=test_group.pubid, slug=test_group.slug))
 
+    @pytest.mark.parametrize('test_group', GROUP_TYPE_OPTIONS, indirect=['test_group'])
     @pytest.mark.usefixtures('toggle_user_facet_request')
-    def test_toggle_user_facet_returns_a_redirect(self, controller):
+    def test_toggle_user_facet_returns_a_redirect(self, controller, test_group):
         result = controller.toggle_user_facet()
 
         assert isinstance(result, httpexceptions.HTTPSeeOther)
 
+    @pytest.mark.parametrize('test_group', GROUP_TYPE_OPTIONS, indirect=['test_group'])
     @pytest.mark.usefixtures('toggle_user_facet_request')
     def test_toggle_user_facet_adds_the_user_facet_into_the_url(self,
                                                                 controller,
-                                                                group):
+                                                                pyramid_request,
+                                                                test_group):
         result = controller.toggle_user_facet()
 
         assert result.location == (
             'http://example.com/groups/{pubid}/{slug}'
-            '?q=user%3Afred'.format(pubid=group.pubid, slug=group.slug))
+            '?q=user%3Afred'.format(pubid=test_group.pubid, slug=test_group.slug))
 
+    @pytest.mark.parametrize('test_group', GROUP_TYPE_OPTIONS, indirect=['test_group'])
     def test_toggle_user_facet_removes_the_user_facet_from_the_url(self,
                                                                    controller,
-                                                                   group,
+                                                                   test_group,
+                                                                   pyramid_request,
                                                                    toggle_user_facet_request):
         toggle_user_facet_request.params['q'] = 'user:"fred"'
 
@@ -927,11 +629,13 @@ class TestGroupSearchController(object):
 
         assert result.location == (
             'http://example.com/groups/{pubid}/{slug}'.format(
-                pubid=group.pubid, slug=group.slug))
+                pubid=test_group.pubid, slug=test_group.slug))
 
+    @pytest.mark.parametrize('test_group', GROUP_TYPE_OPTIONS, indirect=['test_group'])
     def test_toggle_user_facet_preserves_query_when_adding_user_facet(self,
                                                                       controller,
-                                                                      group,
+                                                                      test_group,
+                                                                      pyramid_request,
                                                                       toggle_user_facet_request):
         toggle_user_facet_request.params['q'] = 'foo bar'
 
@@ -939,11 +643,13 @@ class TestGroupSearchController(object):
 
         assert result.location == (
             'http://example.com/groups/{pubid}/{slug}'
-            '?q=foo+bar+user%3Afred'.format(pubid=group.pubid, slug=group.slug))
+            '?q=foo+bar+user%3Afred'.format(pubid=test_group.pubid, slug=test_group.slug))
 
+    @pytest.mark.parametrize('test_group', GROUP_TYPE_OPTIONS, indirect=['test_group'])
     def test_toggle_user_facet_preserves_query_when_removing_user_facet(self,
                                                                         controller,
-                                                                        group,
+                                                                        test_group,
+                                                                        pyramid_request,
                                                                         toggle_user_facet_request):
         toggle_user_facet_request.params['q'] = 'user:"fred" foo bar'
 
@@ -951,22 +657,24 @@ class TestGroupSearchController(object):
 
         assert result.location == (
             'http://example.com/groups/{pubid}/{slug}'
-            '?q=foo+bar'.format(pubid=group.pubid, slug=group.slug))
+            '?q=foo+bar'.format(pubid=test_group.pubid, slug=test_group.slug))
 
+    @pytest.mark.parametrize('test_group', GROUP_TYPE_OPTIONS, indirect=['test_group'])
     def test_toggle_user_facet_preserves_query_when_removing_one_of_multiple_username_facets(
-            self, controller, group, toggle_user_facet_request):
+            self, controller, test_group, pyramid_request, toggle_user_facet_request):
         toggle_user_facet_request.params['q'] = 'user:"foo" user:"fred" user:"bar"'
 
         result = controller.toggle_user_facet()
 
         assert result.location == (
             'http://example.com/groups/{pubid}/{slug}'
-            '?q=user%3Afoo+user%3Abar'.format(pubid=group.pubid, slug=group.slug))
+            '?q=user%3Afoo+user%3Abar'.format(pubid=test_group.pubid, slug=test_group.slug))
 
-    @pytest.mark.parametrize('q', ['user:fred', '  user:fred   '])
+    @pytest.mark.parametrize('q,test_group', [('user:fred', 'open_group'), ('  user:fred   ', 'group')], indirect=['test_group'])
     def test_toggle_user_facet_removes_empty_query(self,
                                                    controller,
-                                                   group,
+                                                   test_group,
+                                                   pyramid_request,
                                                    toggle_user_facet_request,
                                                    q):
         """
@@ -981,14 +689,35 @@ class TestGroupSearchController(object):
 
         assert result.location == (
             'http://example.com/groups/{pubid}/{slug}'.format(
-                pubid=group.pubid, slug=group.slug))
+                pubid=test_group.pubid, slug=test_group.slug))
+
+    @pytest.fixture(scope='function')
+    def test_group(self, request, groups):
+        return groups[request.param]
+
+    @pytest.fixture(scope='function')
+    def test_user(self, request, users):
+        # Since open groups don't have members we only eval this
+        # if member was specifically requested.
+        if request.param == "member":
+            return request.getfixturevalue('test_group').members[-1]
+        return users[request.param]
 
     @pytest.fixture
-    def controller(self, group, pyramid_request):
+    def users(self, request, user, factories):
+        group = request.getfixturevalue('test_group')
+        return {None: None,
+                "creator": group.creator,
+                "user": factories.User()}
+
+    @pytest.fixture
+    def controller(self, request, pyramid_request):
+        group = request.getfixturevalue('test_group')
         return activity.GroupSearchController(group, pyramid_request)
 
     @pytest.fixture
-    def group_leave_request(self, group, pyramid_request):
+    def group_leave_request(self, request, pyramid_request):
+        group = request.getfixturevalue('test_group')
         pyramid_request.POST = {'group_leave': group.pubid}
         return pyramid_request
 
@@ -999,14 +728,17 @@ class TestGroupSearchController(object):
         return group_service
 
     @pytest.fixture
-    def pyramid_request(self, group, pyramid_request):
+    def pyramid_request(self, request, pyramid_request):
+        group = request.getfixturevalue('test_group')
         pyramid_request.matchdict['pubid'] = group.pubid
         pyramid_request.matchdict['slug'] = group.slug
         pyramid_request.user = None
+        if 'test_user' in request.fixturenames:
+            pyramid_request.user = request.getfixturevalue('test_user')
         return pyramid_request
 
     @pytest.fixture
-    def toggle_user_facet_request(self, group, pyramid_request):
+    def toggle_user_facet_request(self, pyramid_request):
         pyramid_request.params['toggle_user_facet'] = 'acct:fred@hypothes.is'
         return pyramid_request
 
@@ -1374,6 +1106,19 @@ def group(factories):
 
 
 @pytest.fixture
+def no_creator_group(factories):
+    # Create some other groups as well, just to make sure it gets the right
+    # one from the db.
+    factories.Group()
+    factories.OpenGroup()
+
+    group = factories.Group()
+    group.creator = None
+    group.members.extend([factories.User(), factories.User()])
+    return group
+
+
+@pytest.fixture
 def open_group(factories):
     # Create some other groups as well, just to make sure it gets the right
     # one from the db.
@@ -1382,6 +1127,26 @@ def open_group(factories):
 
     open_group = factories.OpenGroup()
     return open_group
+
+
+@pytest.fixture
+def no_creator_open_group(factories):
+    # Create some other groups as well, just to make sure it gets the right
+    # one from the db.
+    factories.Group()
+    factories.OpenGroup()
+
+    open_group = factories.OpenGroup()
+    open_group.creator = None
+    return open_group
+
+
+@pytest.fixture
+def groups(group, open_group, no_creator_group, no_creator_open_group):
+    return {"open_group": open_group,
+            "group": group,
+            "no_creator_open_group": no_creator_open_group,
+            "no_creator_group": no_creator_group}
 
 
 @pytest.fixture


### PR DESCRIPTION
Enabled members to be a None type and added 'moderators' and 'creator'. If members
is None it indicates that the group has no concept of members and
is an "open" group. Moderators looks just like members but is simply
a list of the creator-this will probably be expanded at some point
to be an actual list of moderators but until then it's a list of one. Creator 
is used to identify the user who created the group via a 'creator' label on the front end.
Suggested groups which is used to auto-complete the search now contains
suggestions for open groups.
This adds features required for https://github.com/hypothesis/product-backlog/issues/422.