### PR TITLE
Add GroupService.type() method

### DIFF
--- a/h/services/group.py
+++ b/h/services/group.py
@@ -72,6 +72,22 @@ class GroupService(object):
                             writeable_by=WriteableBy.authority,
                             )
 
+    def type(self, group):
+        """
+        Return the "type" of the given group, e.g. "open" or "private".
+
+        :rtype: string
+        :raises ValueError: if the type of the given group isn't recognized
+
+        """
+        for group_matcher in (_OpenGroupMatcher(), _PrivateGroupMatcher()):
+            if group_matcher == group:
+                return group_matcher.type_
+
+        raise ValueError(
+            "This group doesn't seem to match any known type of group. "
+            "This shouldn't be in the database!")
+
     def member_join(self, group, userid):
         """Add `userid` to the member list of `group`."""
         user = self.user_fetcher(userid)
@@ -150,3 +166,37 @@ def _publish(request, event_type, groupid, userid):
         'userid': userid,
         'group': groupid,
     })
+
+
+class _GroupMatcher(object):
+    """Abstract base class for group matcher classes."""
+
+    def __eq__(self, other):
+        """Return True if other has the same access flags as this matcher."""
+        attrs = ('joinable_by', 'readable_by', 'writeable_by')
+        for attr in attrs:
+            self_attr = getattr(self, attr)
+            other_attr = getattr(other, attr, None)
+            if self_attr != other_attr:
+                return False
+        return True
+
+    def __ne__(self, other):
+        """Return True if other has different access flags than this matcher."""
+        return not self.__eq__(other)
+
+
+class _OpenGroupMatcher(_GroupMatcher):
+    """An object that's equal to any open group."""
+    type_ = 'open'
+    joinable_by = None
+    readable_by = ReadableBy.world
+    writeable_by = WriteableBy.authority
+
+
+class _PrivateGroupMatcher(_GroupMatcher):
+    """An object that's equal to any private group."""
+    type_ = 'private'
+    joinable_by = JoinableBy.authority
+    readable_by = ReadableBy.members
+    writeable_by = WriteableBy.members

--- a/h/services/group.py
+++ b/h/services/group.py
@@ -40,9 +40,7 @@ class GroupService(object):
         group = self._create(name=name,
                              userid=userid,
                              description=description,
-                             joinable_by=JoinableBy.authority,
-                             readable_by=ReadableBy.members,
-                             writeable_by=WriteableBy.members,
+                             access_flags=_PrivateGroupMatcher,
                              )
         group.members.append(group.creator)
 
@@ -67,9 +65,7 @@ class GroupService(object):
         return self._create(name=name,
                             userid=userid,
                             description=description,
-                            joinable_by=None,
-                            readable_by=ReadableBy.world,
-                            writeable_by=WriteableBy.authority,
+                            access_flags=_OpenGroupMatcher,
                             )
 
     def type(self, group):
@@ -136,16 +132,16 @@ class GroupService(object):
 
         return [g.pubid for g in self.session.query(Group.pubid).filter_by(creator=user)]
 
-    def _create(self, name, userid, description, joinable_by, readable_by, writeable_by):
+    def _create(self, name, userid, description, access_flags):
         """Create a group and save it to the DB."""
         creator = self.user_fetcher(userid)
         group = Group(name=name,
                       authority=creator.authority,
                       creator=creator,
                       description=description,
-                      joinable_by=joinable_by,
-                      readable_by=readable_by,
-                      writeable_by=writeable_by,
+                      joinable_by=access_flags.joinable_by,
+                      readable_by=access_flags.readable_by,
+                      writeable_by=access_flags.writeable_by,
                       )
         self.session.add(group)
         return group

--- a/tests/h/services/group_test.py
+++ b/tests/h/services/group_test.py
@@ -93,6 +93,23 @@ class TestGroupService(object):
 
         assert group.description is None
 
+    def test_type_returns_open_for_open_groups(self, service, factories):
+        assert service.type(factories.OpenGroup()) == 'open'
+
+    def test_type_returns_private_for_private_groups(self, service, factories):
+        assert service.type(factories.Group()) == 'private'
+
+    def test_type_raises_for_unknown_type_of_group(self, service, factories):
+        group = factories.Group()
+        # Set the group's access flags to an invalid / unused combination.
+        group.joinable_by = None
+        group.readable_by = ReadableBy.members
+        group.writeable_by = WriteableBy.authority
+
+        expected_err = "^This group doesn't seem to match any known type"
+        with pytest.raises(ValueError, match=expected_err):
+            service.type(group)
+
     def test_member_join_adds_user_to_group(self, service, group, users):
         service.member_join(group, 'theresa')
 


### PR DESCRIPTION
This is sort of the return of the dreaded `GROUP_ACCESS_FLAGS` but instead of a dict-of-dicts I've done it using a couple of matcher classes, which I think is a lot more usable when you want to ask whether a given group is equal to a certain type of group. Also slightly more usable when you want to access the access flags for a type of group.