### PR TITLE
Attempt to improve a flakey test failure message

### DIFF
--- a/tests/h/search/index_test.py
+++ b/tests/h/search/index_test.py
@@ -98,9 +98,18 @@ class TestBatchIndexer(object):
 
         indexer.index()
 
-        streaming_bulk.assert_called_once_with(
-            indexer.es_client.conn, matchers.iterable_with([ann_1, ann_2]),
-            chunk_size=mock.ANY, raise_on_error=False, expand_action_callback=mock.ANY)
+        assert streaming_bulk.call_count == 1
+
+        args = streaming_bulk.call_args[0]
+        kwargs = streaming_bulk.call_args[1]
+
+        assert len(args) == 2
+        assert args[0] == indexer.es_client.conn
+        assert list(args[1]) == [ann_1, ann_2]
+
+        assert kwargs.keys() == matchers.unordered_list((
+            'chunk_size', 'raise_on_error', 'expand_action_callback'))
+        assert kwargs['raise_on_error'] is False
 
     def test_index_skips_deleted_annotations_when_indexing_all(self, db_session, indexer, matchers, streaming_bulk, factories):
         ann_1, ann_2 = factories.Annotation(), factories.Annotation()


### PR DESCRIPTION
Edit this test so that it should be testing the same things as before
but is should give us a better clue as to why exactly the test failed
when it fails.

tests/h/search/index_test.py::TestBatchIndexer::test_index_indexes_all_annotations_to_es
is occassionally failing with this assertion error:

    E AssertionError:
    Expected call: streaming_bulk(
        <Mock name='mock.conn' id='140410258777232'>,
        <iterable with [<Annotation 3l0CPAzaEei6VmNdOzSvCg>, <Annotation 3mUY-gzaEei6Vl97TJaBfg>]>,
        chunk_size=<ANY>,
        expand_action_callback=<ANY>,
        raise_on_error=False)
    Actual call: streaming_bulk(
        <Mock name='mock.conn' id='140410258777232'>,
        <generator object _log_status at 0x7fb3cf345be0>,
        chunk_size=100,
        expand_action_callback=<bound method BatchIndexer._prepare of <h.search.index.BatchIndexer object at 0x7fb3cf284a10>>,
        raise_on_error=False)

The expected call looks the same as the actual call, assuming that
`<iterable with [<Annotation 3l0CPAzaEei6VmNdOzSvCg>, <Annotation 3mUY-gzaEei6Vl97TJaBfg>]>`
matches `<generator object _log_status at 0x7fb3cf345be0>`, which is
usually does (the test usually passes).

My hunch is that the iterable sometimes fails to match the generator
because the order in which the generator returns the two annotations is
sometimes different.