### PR TITLE
Add group type property

### DIFF
--- a/h/models/group.py
+++ b/h/models/group.py
@@ -114,7 +114,7 @@ class Group(Base, mixins.Timestamps):
             readable_by=self.readable_by,
             writeable_by=self.writeable_by)
 
-        for type_, type_flags in (('open', open_group_type_flags), ('private', private_group_type_flags)):
+        for type_, type_flags in (('open', OPEN_GROUP_TYPE_FLAGS), ('private', PRIVATE_GROUP_TYPE_FLAGS)):
             if self_type_flags == type_flags:
                 return type_
 
@@ -179,13 +179,13 @@ def _write_principal(group):
 TypeFlags = namedtuple('TypeFlags', 'joinable_by readable_by writeable_by')
 
 
-open_group_type_flags = TypeFlags(
+OPEN_GROUP_TYPE_FLAGS = TypeFlags(
     joinable_by=None,
     readable_by=ReadableBy.world,
     writeable_by=WriteableBy.authority)
 
 
-private_group_type_flags = TypeFlags(
+PRIVATE_GROUP_TYPE_FLAGS = TypeFlags(
     joinable_by=JoinableBy.authority,
     readable_by=ReadableBy.members,
     writeable_by=WriteableBy.members)

--- a/h/models/group.py
+++ b/h/models/group.py
@@ -107,9 +107,9 @@ class Group(Base, mixins.Timestamps):
         :raises ValueError: if the type of the group isn't recognized
 
         """
-        for group_matcher in (OpenGroupMatcher(), PrivateGroupMatcher()):
-            if self == group_matcher:
-                return group_matcher.type_
+        for type_flags in (OpenGroupTypeFlags(), PrivateGroupTypeFlags()):
+            if self == type_flags:
+                return type_flags.type_
 
         raise ValueError(
             "This group doesn't seem to match any known type of group. "
@@ -169,8 +169,8 @@ def _write_principal(group):
     }.get(group.writeable_by)
 
 
-class _GroupMatcher(object):
-    """Abstract base class for group matcher classes."""
+class _GroupTypeFlags(object):
+    """Abstract base class for group type flags classes."""
 
     def __eq__(self, other):
         """Return True if other has the same access flags as this matcher."""
@@ -187,16 +187,26 @@ class _GroupMatcher(object):
         return not self.__eq__(other)
 
 
-class OpenGroupMatcher(_GroupMatcher):
-    """An object that's equal to any open group."""
+class OpenGroupTypeFlags(_GroupTypeFlags):
+    """
+    A container for the property values that define an "open"-type group.
+
+    An instance of this class will also be == to any "open"-type group.
+
+    """
     type_ = 'open'
     joinable_by = None
     readable_by = ReadableBy.world
     writeable_by = WriteableBy.authority
 
 
-class PrivateGroupMatcher(_GroupMatcher):
-    """An object that's equal to any private group."""
+class PrivateGroupTypeFlags(_GroupTypeFlags):
+    """
+    A container for the property values that define a "private"-type group.
+
+    An instance of this class will also be == to any "private"-type group.
+
+    """
     type_ = 'private'
     joinable_by = JoinableBy.authority
     readable_by = ReadableBy.members

--- a/h/models/group.py
+++ b/h/models/group.py
@@ -107,7 +107,7 @@ class Group(Base, mixins.Timestamps):
         :raises ValueError: if the type of the group isn't recognized
 
         """
-        for group_matcher in (_OpenGroupMatcher(), _PrivateGroupMatcher()):
+        for group_matcher in (OpenGroupMatcher(), PrivateGroupMatcher()):
             if self == group_matcher:
                 return group_matcher.type_
 
@@ -187,7 +187,7 @@ class _GroupMatcher(object):
         return not self.__eq__(other)
 
 
-class _OpenGroupMatcher(_GroupMatcher):
+class OpenGroupMatcher(_GroupMatcher):
     """An object that's equal to any open group."""
     type_ = 'open'
     joinable_by = None
@@ -195,7 +195,7 @@ class _OpenGroupMatcher(_GroupMatcher):
     writeable_by = WriteableBy.authority
 
 
-class _PrivateGroupMatcher(_GroupMatcher):
+class PrivateGroupMatcher(_GroupMatcher):
     """An object that's equal to any private group."""
     type_ = 'private'
     joinable_by = JoinableBy.authority

--- a/h/services/group.py
+++ b/h/services/group.py
@@ -40,7 +40,7 @@ class GroupService(object):
         group = self._create(name=name,
                              userid=userid,
                              description=description,
-                             access_flags=PrivateGroupTypeFlags,
+                             type_flags=PrivateGroupTypeFlags,
                              )
         group.members.append(group.creator)
 
@@ -65,7 +65,7 @@ class GroupService(object):
         return self._create(name=name,
                             userid=userid,
                             description=description,
-                            access_flags=OpenGroupTypeFlags,
+                            type_flags=OpenGroupTypeFlags,
                             scopes=[GroupScope(origin=o) for o in origins],
                             )
 
@@ -117,16 +117,16 @@ class GroupService(object):
 
         return [g.pubid for g in self.session.query(Group.pubid).filter_by(creator=user)]
 
-    def _create(self, name, userid, description, access_flags, scopes=[]):
+    def _create(self, name, userid, description, type_flags, scopes=[]):
         """Create a group and save it to the DB."""
         creator = self.user_fetcher(userid)
         group = Group(name=name,
                       authority=creator.authority,
                       creator=creator,
                       description=description,
-                      joinable_by=access_flags.joinable_by,
-                      readable_by=access_flags.readable_by,
-                      writeable_by=access_flags.writeable_by,
+                      joinable_by=type_flags.joinable_by,
+                      readable_by=type_flags.readable_by,
+                      writeable_by=type_flags.writeable_by,
                       scopes=scopes,
                       )
         self.session.add(group)

--- a/h/services/group.py
+++ b/h/services/group.py
@@ -6,7 +6,7 @@ import sqlalchemy as sa
 
 from h import session
 from h.models import Group, GroupScope, User
-from h.models.group import ReadableBy, OpenGroupMatcher, PrivateGroupMatcher
+from h.models.group import ReadableBy, OpenGroupTypeFlags, PrivateGroupTypeFlags
 
 
 class GroupService(object):
@@ -40,7 +40,7 @@ class GroupService(object):
         group = self._create(name=name,
                              userid=userid,
                              description=description,
-                             access_flags=PrivateGroupMatcher,
+                             access_flags=PrivateGroupTypeFlags,
                              )
         group.members.append(group.creator)
 
@@ -65,7 +65,7 @@ class GroupService(object):
         return self._create(name=name,
                             userid=userid,
                             description=description,
-                            access_flags=OpenGroupMatcher,
+                            access_flags=OpenGroupTypeFlags,
                             scopes=[GroupScope(origin=o) for o in origins],
                             )
 

--- a/h/services/group.py
+++ b/h/services/group.py
@@ -6,7 +6,7 @@ import sqlalchemy as sa
 
 from h import session
 from h.models import Group, GroupScope, User
-from h.models.group import ReadableBy, open_group_type_flags, private_group_type_flags
+from h.models.group import ReadableBy, OPEN_GROUP_TYPE_FLAGS, PRIVATE_GROUP_TYPE_FLAGS
 
 
 class GroupService(object):
@@ -40,7 +40,7 @@ class GroupService(object):
         group = self._create(name=name,
                              userid=userid,
                              description=description,
-                             type_flags=private_group_type_flags,
+                             type_flags=PRIVATE_GROUP_TYPE_FLAGS,
                              )
         group.members.append(group.creator)
 
@@ -65,7 +65,7 @@ class GroupService(object):
         return self._create(name=name,
                             userid=userid,
                             description=description,
-                            type_flags=open_group_type_flags,
+                            type_flags=OPEN_GROUP_TYPE_FLAGS,
                             scopes=[GroupScope(origin=o) for o in origins],
                             )
 

--- a/h/services/group.py
+++ b/h/services/group.py
@@ -6,7 +6,7 @@ import sqlalchemy as sa
 
 from h import session
 from h.models import Group, GroupScope, User
-from h.models.group import ReadableBy, OpenGroupTypeFlags, PrivateGroupTypeFlags
+from h.models.group import ReadableBy, open_group_type_flags, private_group_type_flags
 
 
 class GroupService(object):
@@ -40,7 +40,7 @@ class GroupService(object):
         group = self._create(name=name,
                              userid=userid,
                              description=description,
-                             type_flags=PrivateGroupTypeFlags,
+                             type_flags=private_group_type_flags,
                              )
         group.members.append(group.creator)
 
@@ -65,7 +65,7 @@ class GroupService(object):
         return self._create(name=name,
                             userid=userid,
                             description=description,
-                            type_flags=OpenGroupTypeFlags,
+                            type_flags=open_group_type_flags,
                             scopes=[GroupScope(origin=o) for o in origins],
                             )
 

--- a/tests/h/models/groups_test.py
+++ b/tests/h/models/groups_test.py
@@ -41,6 +41,26 @@ def test_slug(db_session, factories):
     assert group.slug == "my-hypothesis-group"
 
 
+def test_type_returns_open_for_open_groups(factories):
+    assert factories.OpenGroup().type == 'open'
+
+
+def test_type_returns_private_for_private_groups(factories):
+    assert factories.Group().type == 'private'
+
+
+def test_type_raises_for_unknown_type_of_group(factories):
+    group = factories.Group()
+    # Set the group's access flags to an invalid / unused combination.
+    group.joinable_by = None
+    group.readable_by = ReadableBy.members
+    group.writeable_by = WriteableBy.authority
+
+    expected_err = "^This group doesn't seem to match any known type"
+    with pytest.raises(ValueError, match=expected_err):
+        group.type
+
+
 def test_repr(db_session, factories):
     name = "My Hypothesis Group"
     user = factories.User()

--- a/tests/h/models/groups_test.py
+++ b/tests/h/models/groups_test.py
@@ -61,6 +61,13 @@ def test_type_raises_for_unknown_type_of_group(factories):
         group.type
 
 
+def test_you_cannot_set_type(factories):
+    group = factories.Group()
+
+    with pytest.raises(AttributeError, match="can't set attribute"):
+        group.type = 'open'
+
+
 def test_repr(db_session, factories):
     name = "My Hypothesis Group"
     user = factories.User()


### PR DESCRIPTION
Add a `.type` property (`"private"` or `"open"`) to the `Group` model class.

Also refactor `GroupService.create_open_group()` and `create_private_group()` a little to make use of the definitions of the group types (joinable_by, readable_by, writeable_by) in the new `OpenGroupMatcher` and `PrivateGroupMatcher` classes in `h.models.group`. This is so that the values of the access flags aren't duplicated in two places.

`h.services.group` no longer needs access to `h.models.group.JoinableBy` or `WriteableBy` at all (it still uses `ReadableBy` for its `groupids_readable_by()` method).