### PR TITLE
update CLA redirects

### DIFF
--- a/h/redirects
+++ b/h/redirects
@@ -76,10 +76,10 @@
 /contact/                                              exact https://web.hypothes.is/contact/
 /contribute                                            exact https://web.hypothes.is/developers/
 /contribute/                                           exact https://web.hypothes.is/developers/
-/contribute/entity-cla                                 exact https://web.hypothes.is/developers/
-/contribute/entity-cla/                                exact https://web.hypothes.is/developers/
-/contribute/individual-cla                             exact https://web.hypothes.is/developers/
-/contribute/individual-cla/                            exact https://web.hypothes.is/developers/
+/contribute/entity-cla                                 exact https://web.hypothes.is/developers/entity-cla/
+/contribute/entity-cla/                                exact https://web.hypothes.is/developers/entity-cla/
+/contribute/individual-cla                             exact https://web.hypothes.is/developers/individual-cla/
+/contribute/individual-cla/                            exact https://web.hypothes.is/developers/individual-cla/
 /creating-groups                                       exact https://web.hypothes.is/creating-groups/
 /creating-groups/                                      exact https://web.hypothes.is/creating-groups/
 /curate-a-novel-chapter                                exact https://web.hypothes.is/curate-a-novel-chapter/


### PR DESCRIPTION
@segdeha noted that links to the HTML versions of our Contributor License Agreements from [our documentation](http://h.readthedocs.io/en/latest/developing/cla/) were not working. Part of the issue was the redirects at this level.