### PR TITLE
Add scopes support to GroupService and CLI

### DIFF
--- a/h/cli/commands/groups.py
+++ b/h/cli/commands/groups.py
@@ -12,8 +12,9 @@ def groups():
 @click.option('--name', prompt=True, help="The name of the group")
 @click.option('--authority', prompt=True, help="The authority which the group is associated with")
 @click.option('--creator', prompt=True, help="The username of the group's creator")
+@click.option('--origin', prompt=True, multiple=True, help='The origin(s) that the group should be scoped to, .e.g. "https://example.com"')
 @click.pass_context
-def add_open_group(ctx, name, authority, creator):
+def add_open_group(ctx, name, authority, creator, origin):
     """
     Create a new open group.
 
@@ -25,6 +26,7 @@ def add_open_group(ctx, name, authority, creator):
     creator_userid = u'acct:{username}@{authority}'.format(username=creator,
                                                            authority=authority)
     group_svc = request.find_service(name='group')
-    group_svc.create_open_group(name=name, userid=creator_userid)
+    group_svc.create_open_group(
+        name=name, userid=creator_userid, origins=origin)
 
     request.tm.commit()

--- a/h/services/group.py
+++ b/h/services/group.py
@@ -5,7 +5,7 @@ from functools import partial
 import sqlalchemy as sa
 
 from h import session
-from h.models import Group, User
+from h.models import Group, GroupScope, User
 from h.models.group import JoinableBy, ReadableBy, WriteableBy
 
 
@@ -52,7 +52,7 @@ class GroupService(object):
         self.publish('group-join', group.pubid, group.creator.userid)
         return group
 
-    def create_open_group(self, name, userid, description=None):
+    def create_open_group(self, name, userid, origins, description=None):
         """
         Create a new open group.
 
@@ -70,6 +70,7 @@ class GroupService(object):
                             joinable_by=None,
                             readable_by=ReadableBy.world,
                             writeable_by=WriteableBy.authority,
+                            scopes=[GroupScope(origin=o) for o in origins],
                             )
 
     def member_join(self, group, userid):
@@ -120,7 +121,7 @@ class GroupService(object):
 
         return [g.pubid for g in self.session.query(Group.pubid).filter_by(creator=user)]
 
-    def _create(self, name, userid, description, joinable_by, readable_by, writeable_by):
+    def _create(self, name, userid, description, joinable_by, readable_by, writeable_by, scopes=[]):
         """Create a group and save it to the DB."""
         creator = self.user_fetcher(userid)
         group = Group(name=name,
@@ -130,6 +131,7 @@ class GroupService(object):
                       joinable_by=joinable_by,
                       readable_by=readable_by,
                       writeable_by=writeable_by,
+                      scopes=scopes,
                       )
         self.session.add(group)
         return group

--- a/tests/h/cli/commands/groups_test.py
+++ b/tests/h/cli/commands/groups_test.py
@@ -12,13 +12,36 @@ class TestAddCommand(object):
     def test_it_creates_a_third_party_open_group(self, cli, cliconfig, group_service):
         result = cli.invoke(groups_cli.add_open_group,
                             [u'--name', 'Publisher', u'--authority', 'publisher.org',
-                             u'--creator', 'admin'],
+                             u'--creator', 'admin', u'--origin', 'http://publisher.org'],
                             obj=cliconfig)
 
         assert result.exit_code == 0
 
         group_service.create_open_group.assert_called_once_with(
-            name=u'Publisher', userid='acct:admin@publisher.org')
+            name=u'Publisher',
+            userid='acct:admin@publisher.org',
+            origins=('http://publisher.org',),
+        )
+
+    def test_it_accepts_multiple_origin_options_on_the_command_line(self,
+                                                                      cli,
+                                                                      cliconfig,
+                                                                      group_service):
+        cli_options = [
+            u'--name', 'Publisher',
+            u'--authority', 'publisher.org',
+            u'--creator', 'admin',
+            u'--origin', 'https://hostname1.org',
+            u'--origin', 'https://hostname2.org',
+            u'--origin', 'https://hostname3.org:8080',
+        ]
+
+        result = cli.invoke(groups_cli.add_open_group, cli_options, obj=cliconfig)
+
+        assert result.exit_code == 0
+        assert group_service.create_open_group.call_args[1]['origins'] == (
+            'https://hostname1.org', 'https://hostname2.org', 'https://hostname3.org:8080',
+        )
 
 
 @pytest.fixture


### PR DESCRIPTION
Add scopes (origins) support to GroupService.create_open_group() and add a --origin argument to the add-open-group CLI.

Now that `Group.scopes` has been added to the model we can add a required `origins` argument to `GroupService.create_open_groups()` - all open groups created with this method will now be scoped to one or more origins. (You can pass `origins=[]` though, there's no validation against that at the service level, maybe there should be.)

This breaks the `add-open-group` CLI which calls `create_open_groups()` without an `origins` arg, so add a mandatory `--origin` option to the CLI.