### PR TITLE
List Groups Service

### DIFF
--- a/h/services/list_groups.py
+++ b/h/services/list_groups.py
@@ -1,0 +1,118 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from h import models
+from h.models import group
+
+
+class ListGroupsService(object):
+
+    """
+    A service for providing filtered lists of groups.
+
+    This service filters groups by user session, scope, etc.
+
+    ALl public methods return a list of relevant groups,
+    as dicts (see _group_model) for consumption by e.g. API services.
+    """
+
+    def __init__(self, session, request_authority, route_url):
+        """
+        Create a new list_groups service.
+
+        :param _session: the SQLAlchemy session object
+        :param _request_authority: the authority to use as a default
+        :param _route_url: a callable for generating URLs for app routes
+        """
+        self._session = session
+        self._route_url = route_url
+        self.request_authority = request_authority
+
+    def _authority(self, user=None, authority=None):
+        """Determine which authority to use.
+
+           Determine the appropriate authority to use for querying groups.
+           User's authority will always supersede if present; otherwise provide
+           default value—request.authority—if no authority specified.
+        """
+
+        if user is not None:
+            return user.authority
+        return authority or self.request_authority
+
+    def all_groups(self, user=None, authority=None, document_uri=None):
+        """
+        Return a list of groups relevant to this session/profile (i.e. user).
+
+        Return a list of groups filtered on user, authority, document_uri.
+        Include all types of relevant groups (open and private).
+        """
+        open_groups = self.open_groups(user, authority, document_uri)
+        private_groups = self.private_groups(user)
+
+        return open_groups + private_groups
+
+    def open_groups(self, user=None, authority=None, document_uri=None):
+        """
+        Return all matching open groups for the authority and target URI.
+
+        Return matching open groups for the authority (or request_authority
+        default), filtered by scope as per ``document_uri``.
+        """
+
+        authority = self._authority(user, authority)
+        # TODO This is going to change once scopes and model updates in place
+        groups = (self._session.query(models.Group)
+                      .filter_by(authority=authority,
+                                 readable_by=group.ReadableBy.world)
+                      .all())
+        return self._format(groups)
+
+    def private_groups(self, user=None):
+        """Return this user's private groups per user.groups."""
+
+        if user is None:
+            return []
+        return self._format(user.groups)
+
+    def _group_model(self, group):
+        """
+        Return dict representing group for API use.
+
+        Take a Group and return a formatted dict for API consumption.
+
+        :param group: Group model for formatting
+        """
+
+        model = {
+          'name': group.name,
+          'id': group.pubid,
+          'public': group.is_public,
+          'scoped': False,  # TODO
+          'type': 'open' if group.is_public else 'private',  # TODO
+          'urls': {}
+        }
+        if not group.is_public:
+            # `url` legacy property support
+            model['url'] = self._route_url('group_read',
+                                           pubid=group.pubid,
+                                           slug=group.slug)
+            # `urls` are the future
+            model['urls']['group'] = model['url']
+        return model
+
+    def _format(self, groups):
+        """Sort and format groups into ordered lists of dicts"""
+        return [self._group_model(group) for group in self._sort(groups)]
+
+    def _sort(self, groups):
+        """ sort a list of groups of a single type """
+        return sorted(groups, key=lambda group: (group.name.lower(), group.pubid))
+
+
+def list_groups_factory(context, request):
+    """Return a ListGroupsService instance for the passed context and request."""
+    return ListGroupsService(session=request.db,
+                             request_authority=request.authority,
+                             route_url=request.route_url)

--- a/tests/h/services/list_groups_test.py
+++ b/tests/h/services/list_groups_test.py
@@ -1,0 +1,213 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import mock
+import pytest
+
+from h.services.list_groups import ListGroupsService
+from h.services.list_groups import list_groups_factory
+
+
+class TestListGroupsAllGroups(object):
+
+    def test_returns_open_groups_when_no_user(self, list_groups_service, open_groups):
+        open_group_ids = {group.pubid for group in open_groups}
+        open_group_ids.add('__world__')
+
+        groups = list_groups_service.all_groups()
+
+        assert {group['id'] for group in groups} == open_group_ids
+        for group in groups:
+            assert group['type'] == 'open'
+
+    def test_returns_all_group_types_when_user(self, list_groups_service, factories):
+        user = factories.User()
+        user.groups = [factories.Group(), factories.Group()]
+        expected_ids = [group.pubid for group in user.groups]
+        expected_ids.append('__world__')
+
+        groups = list_groups_service.all_groups(user=user)
+
+        group_ids = [group['id'] for group in groups]
+        for expected_id in expected_ids:
+            assert expected_id in group_ids
+
+    def test_ignores_authority_when_user_present(self, list_groups_service, factories, authority_open_groups):
+        user = factories.User(authority='foo.com')
+        another_authority_open_group = factories.OpenGroup(authority='somewhere-else.com')
+        auth_group_ids = {group.pubid for group in authority_open_groups}
+
+        groups = list_groups_service.all_groups(user=user, authority='somewhere-else.com')
+
+        group_ids = {group['id'] for group in groups}
+        assert group_ids == auth_group_ids
+        assert another_authority_open_group.pubid not in group_ids
+
+    def test_groups_are_sorted(self, list_groups_service, factories):
+        user = factories.User(authority='z.com')
+        user.groups = [factories.Group(name='alpha', pubid='zzzz', authority='z.com'),
+                       factories.Group(name='alpha', pubid='aaaa', authority='z.com'),
+                       factories.Group(name='aardvark', pubid='zoinks', authority='z.com')]
+        factories.OpenGroup(name='alpha', pubid='zaza', authority='z.com')
+        factories.OpenGroup(name='alpha', pubid='azaz', authority='z.com')
+
+        groups = list_groups_service.all_groups(user=user)
+
+        # open groups first
+        assert [group['id'] for group in groups] == ['azaz', 'zaza', 'zoinks', 'aaaa', 'zzzz']
+
+    def test_groups_are_sorted_alphabetically(self, list_groups_service, factories):
+        user = factories.User(authority='z.com')
+        user.groups = [factories.Group(name='Lilac', authority='z.com'),
+                       factories.Group(name='foobar', authority='z.com')]
+
+        groups = list_groups_service.all_groups(user=user)
+
+        assert [group.name for group in groups] == ['foobar', 'Lilac']
+
+    def test_user_groups_not_mutated(self, list_groups_service, factories):
+        user = factories.User(authority='z.com')
+        user.groups = [factories.Group(name='Lilac', authority='z.com'),
+                       factories.Group(name='Alpha', authority='z.com'),
+                       factories.Group(name='foobar', authority='z.com')]
+
+        list_groups_service.all_groups(user=user)
+
+        assert [group.name for group in user.groups] == ['Lilac', 'Alpha', 'foobar']
+
+    @pytest.fixture
+    def open_groups(self, factories):
+        return [factories.OpenGroup(), factories.OpenGroup()]
+
+
+class TestListGroupsPrivateGroups(object):
+
+    @pytest.mark.parametrize('attribute', [
+        ('id'),
+        ('name'),
+        ('public'),
+        ('scoped'),
+        ('type')
+    ])
+    def test_returns_formatted_groups(self, list_groups_service, factories, attribute):
+        user = factories.User()
+        user.groups = [factories.Group()]
+
+        groups = list_groups_service.private_groups(user)
+
+        assert attribute in groups[0]
+
+    def test_returns_private_groups_only(self, list_groups_service, factories):
+        user = factories.User()
+        user.groups = [factories.Group(), factories.Group(), factories.Group()]
+
+        groups = list_groups_service.private_groups(user)
+
+        assert len(groups) == 3
+        for group in groups:
+            assert group['type'] == 'private'
+
+    def test_returns_empty_when_user_no_private_groups(self, list_groups_service, factories):
+        user = factories.User()
+
+        groups = list_groups_service.private_groups(user)
+
+        assert groups == []
+
+    def test_returns_no_groups_for_no_user(self, list_groups_service):
+
+        groups = list_groups_service.private_groups(user=None)
+
+        assert groups == []
+
+    def test_groups_are_sorted(self, list_groups_service, factories):
+        user = factories.User(authority='z.com')
+        user.groups = [factories.Group(name='alpha', pubid='zzzz', authority='z.com'),
+                       factories.Group(name='alpha', pubid='aaaa', authority='z.com'),
+                       factories.Group(name='aardvark', pubid='zoinks', authority='z.com')]
+
+        groups = list_groups_service.private_groups(user=user)
+
+        assert [group['id'] for group in groups] == ['zoinks', 'aaaa', 'zzzz']
+
+
+class TestListGroupsOpenGroups(object):
+
+    def test_returns_authority_open_groups(self, list_groups_service, authority_open_groups):
+        o_group_names = {o_group.name for o_group in authority_open_groups}
+
+        groups = list_groups_service.open_groups(authority='foo.com')
+
+        assert {group['name'] for group in groups} == o_group_names
+
+    def test_no_groups_from_mismatched_authority(self, list_groups_service, authority_open_groups):
+
+        groups = list_groups_service.open_groups(authority='bar.com')
+
+        assert groups == []
+
+    def test_returns_groups_from_default_authority(self, list_groups_service):
+        groups = list_groups_service.open_groups()
+
+        assert groups[0]['id'] == '__world__'
+
+    def test_returns_groups_for_user_authority(self, list_groups_service, authority_open_groups, factories):
+        user = factories.User(authority='foo.com')
+        o_group_names = {o_group.name for o_group in authority_open_groups}
+
+        o_groups = list_groups_service.open_groups(user=user)
+
+        assert {group['name'] for group in o_groups} == o_group_names
+
+    def test_ignores_authority_if_user(self, list_groups_service, authority_open_groups, factories):
+        user = factories.User(authority='somethingelse.com')
+
+        o_groups = list_groups_service.open_groups(user=user, authority='foo.com')
+
+        assert o_groups == []
+
+    def test_groups_are_sorted(self, list_groups_service, factories):
+        factories.OpenGroup(name='alpha', pubid='zzzz', authority='z.com')
+        factories.OpenGroup(name='alpha', pubid='aaaa', authority='z.com')
+        factories.OpenGroup(name='aardvark', pubid='zoinks', authority='z.com')
+
+        groups = list_groups_service.open_groups(authority='z.com')
+
+        assert [group['id'] for group in groups] == ['zoinks', 'aaaa', 'zzzz']
+
+
+class TestListGroupsFactory(object):
+
+    def test_list_groups_factory(self, pyramid_request):
+        svc = list_groups_factory(None, pyramid_request)
+
+        assert isinstance(svc, ListGroupsService)
+
+    def test_uses_request_authority(self, pyramid_request):
+        pyramid_request.authority = 'bar.com'
+
+        svc = list_groups_factory(None, pyramid_request)
+
+        assert svc.request_authority == 'bar.com'
+
+
+@pytest.fixture
+def authority_open_groups(factories):
+    return [factories.OpenGroup(authority='foo.com'),
+            factories.OpenGroup(authority='foo.com')]
+
+
+@pytest.fixture
+def pyramid_request(pyramid_request):
+    pyramid_request.route_url = mock.Mock(return_value='/group/a')
+    return pyramid_request
+
+
+@pytest.fixture
+def list_groups_service(pyramid_request, db_session):
+    return ListGroupsService(
+        session=db_session,
+        request_authority=pyramid_request.authority,
+        route_url=pyramid_request.route_url
+    )

--- a/tests/h/services/list_groups_test.py
+++ b/tests/h/services/list_groups_test.py
@@ -64,7 +64,7 @@ class TestListGroupsAllGroups(object):
 
         groups = list_groups_service.all_groups(user=user)
 
-        assert [group.name for group in groups] == ['foobar', 'Lilac']
+        assert [group['name'] for group in groups] == ['foobar', 'Lilac']
 
     def test_user_groups_not_mutated(self, list_groups_service, factories):
         user = factories.User(authority='z.com')


### PR DESCRIPTION
This is part one of breaking down #4785 

This PR adds a first draft of `ListGroupsService`, which will ultimately replace `AuthorityGroupService` and `ProfileGroupService`. Note that in this variant, dict formatting is still happening within the service; it will move into a presenter in a subsequent PR.