### PR TITLE
Fix Python 3-incompatible dict usage

### DIFF
--- a/h/search/config.py
+++ b/h/search/config.py
@@ -214,7 +214,7 @@ def get_aliased_index(client):
     if len(result) > 1:
         raise RuntimeError("We don't support managing aliases that "
                            "point to multiple indices at the moment!")
-    return result.keys()[0]
+    return list(result.keys())[0]
 
 
 def update_aliased_index(client, new_target):

--- a/h/search/core.py
+++ b/h/search/core.py
@@ -113,7 +113,7 @@ class Search(object):
             return {}
 
         results = {}
-        for key, result in aggregations.iteritems():
+        for key, result in aggregations.items():
             for agg in self.builder.aggregations:
                 if key != agg.key:
                     continue

--- a/h/search/parser.py
+++ b/h/search/parser.py
@@ -86,7 +86,7 @@ def unparse(q):
     """
     terms = []
 
-    for key, val in q.iteritems():
+    for key, val in q.items():
         if key == 'any':
             terms.append(_escape_term(val))
         else:

--- a/h/services/user.py
+++ b/h/services/user.py
@@ -105,7 +105,7 @@ class UserService(object):
 
         userid_tuples = set(cache_keys.keys())
         missing_tuples = userid_tuples - set(self._cache.keys())
-        missing_ids = [v for k, v in cache_keys.iteritems() if k in missing_tuples]
+        missing_ids = [v for k, v in cache_keys.items() if k in missing_tuples]
 
         if missing_ids:
             users = self.session.query(User).filter(User.userid.in_(missing_ids))
@@ -113,7 +113,7 @@ class UserService(object):
                 cache_key = (user.username, user.authority)
                 self._cache[cache_key] = user
 
-        return [v for k, v in self._cache.iteritems() if k in cache_keys.keys()]
+        return [v for k, v in self._cache.items() if k in cache_keys.keys()]
 
     def fetch_for_login(self, username_or_email):
         """

--- a/h/util/document_claims.py
+++ b/h/util/document_claims.py
@@ -112,7 +112,7 @@ def document_metas_from_data(document_data, claimant):
         if path_prefix is None:
             path_prefix = []
 
-        for key, value in items.iteritems():
+        for key, value in items.items():
             keypath = path_prefix[:]
             keypath.append(key)
 
@@ -140,7 +140,7 @@ def document_metas_from_data(document_data, claimant):
                     'claimant': claimant,
                 })
 
-    items = {k: v for k, v in document_data.iteritems() if k != 'link'}
+    items = {k: v for k, v in document_data.items() if k != 'link'}
     document_meta_dicts = []
     transform_meta_(document_meta_dicts, items)
     return document_meta_dicts
@@ -158,18 +158,22 @@ def document_uris_from_links(link_dicts, claimant):
     document_uris = []
     for link in link_dicts:
 
+        # In Py 3, `dict.keys()` does not return a list and cannot be compared
+        # with a list, so explicitly convert the result.
+        link_keys = list(link.keys())
+
         # Disregard self-claim URLs as they're added separately later.
-        if link.keys() == ['href'] and link['href'] == claimant:
+        if link_keys == ['href'] and link['href'] == claimant:
             continue
 
         # Disregard doi links as these are being added separately from the
         # highwire and dc metadata later on.
-        if link.keys() == ['href'] and link['href'].startswith('doi:'):
+        if link_keys == ['href'] and link['href'].startswith('doi:'):
             continue
 
         # Disregard Highwire PDF links as these are being added separately from
         # the highwire metadata later on.
-        if set(link.keys()) == set(['href', 'type']):
+        if set(link_keys) == set(['href', 'type']):
             if link['type'] == 'application/pdf':
                 continue
 

--- a/h/util/session_tracker.py
+++ b/h/util/session_tracker.py
@@ -38,7 +38,7 @@ class Tracker(object):
         changed = copy(self._flushed_changes)
         changed.update(self._unflushed_changes())
 
-        return list(changed.iteritems())
+        return list(changed.items())
 
     def _unflushed_changes(self):
         """

--- a/tests/h/search/query_test.py
+++ b/tests/h/search/query_test.py
@@ -89,7 +89,7 @@ class TestBuilder(object):
 
         sort = q["sort"]
         assert len(sort) == 1
-        assert sort[0].keys() == ["updated"]
+        assert list(sort[0].keys()) == ["updated"]
 
     def test_sort_includes_ignore_unmapped(self):
         """'ignore_unmapped': True is used in the sort clause."""

--- a/tests/h/tasks/indexer_test.py
+++ b/tests/h/tasks/indexer_test.py
@@ -131,7 +131,7 @@ class TestDeleteAnnotation(object):
 @pytest.mark.usefixtures('celery')
 class TestReindexUserAnnotations(object):
     def test_it_reindexes_users_annotations(self, batch_indexer, annotation_ids):
-        userid = annotation_ids.keys()[0]
+        userid = list(annotation_ids.keys())[0]
 
         indexer.reindex_user_annotations(userid)
 

--- a/tests/py3-expected-failures.txt
+++ b/tests/py3-expected-failures.txt
@@ -2,13 +2,8 @@
 /h/h/db/types.py:88:
 /h/h/models/document.py:482:
 /h/h/search/config.py:190:
-/h/h/search/config.py:217:
-/h/h/search/core.py:116:
-/h/h/search/parser.py:89:
-/h/h/services/user.py:108:
 /h/h/settings.py:53:
 /h/h/streamer/websocket.py:68:
-/h/h/util/document_claims.py:143:
 /h/h/util/uri.py:140:
 /h/h/views/api_auth.py:226:
 /h/h/views/api_exceptions.py:36:
@@ -38,7 +33,6 @@
 /h/tests/h/schemas/base_test.py:79:
 /h/tests/h/search/config_test.py:58:
 /h/tests/h/search/config_test.py:93:
-/h/tests/h/search/query_test.py:92:
 /h/tests/h/security_test.py:34:
 /h/tests/h/security_test.py:50:
 /h/tests/h/security_test.py:65:
@@ -50,8 +44,6 @@
 /h/tests/h/tasks/admin_test.py:14:
 /h/tests/h/util/cors_test.py:139:
 /h/tests/h/util/cors_test.py:180:
-/h/tests/h/util/document_claims_test.py:34:
-/h/tests/h/util/document_claims_test.py:57:
 /h/tests/h/util/redirects_test.py:145:
 /h/tests/h/util/redirects_test.py:150:
 /h/tests/h/views/api_auth_test.py:255:


### PR DESCRIPTION
**Depends on https://github.com/hypothesis/h/pull/4786**

- `iteritems` does not exist in Python 3
- `dict.keys()` does not return a `list` in Python 3 but a `dict_keys` object. This object cannot be indexed and cannot be compared with lists for value equality.