### PR TITLE
Add GroupJSONPresenter

### DIFF
--- a/h/presenters/__init__.py
+++ b/h/presenters/__init__.py
@@ -14,6 +14,7 @@ from h.presenters.annotation_searchindex import AnnotationSearchIndexPresenter
 from h.presenters.document_html import DocumentHTMLPresenter
 from h.presenters.document_json import DocumentJSONPresenter
 from h.presenters.document_searchindex import DocumentSearchIndexPresenter
+from h.presenters.group_json import GroupJSONPresenter
 from h.presenters.user_json import UserJSONPresenter
 
 __all__ = (
@@ -24,5 +25,6 @@ __all__ = (
     'DocumentHTMLPresenter',
     'DocumentJSONPresenter',
     'DocumentSearchIndexPresenter',
+    'GroupJSONPresenter',
     'UserJSONPresenter',
 )

--- a/h/presenters/group_json.py
+++ b/h/presenters/group_json.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+
+class GroupJSONPresenter(object):
+    """Present a group in the JSON format returned by API requests."""
+
+    def __init__(self, group, route_url=None):
+        self.group = group
+        self._route_url = route_url
+
+    def asdict(self):
+        return self._model(self.group)
+
+    def _model(self, group):
+        model = {
+          'name': group.name,
+          'id': group.pubid,
+          'public': group.is_public,
+          'scoped': False,  # TODO
+          'type': 'open' if group.is_public else 'private'  # TODO
+        }
+        model = self._inject_urls(group, model)
+        return model
+
+    def _inject_urls(self, group, model):
+        model['urls'] = {}
+        if not self._route_url:
+            return model
+
+        model['url'] = self._route_url('group_read',
+                                       pubid=group.pubid,
+                                       slug=group.slug)
+        model['urls']['group'] = model['url']
+        return model
+
+
+class GroupsJSONPresenter(GroupJSONPresenter):
+    """Present a list of groups as JSON"""
+
+    def __init__(self, groups, route_url=None):
+        self.groups = groups
+        self._route_url = route_url
+
+    def asdicts(self):
+        return [self._model(group) for group in self.groups]

--- a/tests/h/presenters/group_json_test.py
+++ b/tests/h/presenters/group_json_test.py
@@ -56,7 +56,6 @@ class TestGroupJSONPresenter(object):
         presenter = GroupJSONPresenter(group, route_url=route_url)
 
         model = presenter.asdict()
-        print model
 
         assert model['urls']['group'] == '/group/a'
         assert model['url'] == '/group/a'

--- a/tests/h/presenters/group_json_test.py
+++ b/tests/h/presenters/group_json_test.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import mock
+
+from h.presenters.group_json import GroupJSONPresenter, GroupsJSONPresenter
+
+
+class TestGroupJSONPresenter(object):
+    def test_private_group_asdict_no_urls(self, factories):
+        group = factories.Group(name='My Group',
+                                pubid='mygroup')
+
+        presenter = GroupJSONPresenter(group)
+
+        assert presenter.asdict() == {
+            'name': 'My Group',
+            'id': 'mygroup',
+            'type': 'private',
+            'public': False,
+            'scoped': False,
+            'urls': {}
+        }
+
+    def test_open_group_asdict_no_urls(self, factories):
+        group = factories.OpenGroup(name='My Group',
+                                    pubid='mygroup')
+
+        presenter = GroupJSONPresenter(group)
+
+        assert presenter.asdict() == {
+            'name': 'My Group',
+            'id': 'mygroup',
+            'type': 'open',
+            'public': True,
+            'scoped': False,
+            'urls': {}
+        }
+
+    def test_private_group_asdict_with_urls(self, factories):
+        group = factories.Group(name='My Group',
+                                pubid='mygroup')
+        route_url = mock.Mock(return_value='/group/a')
+        presenter = GroupJSONPresenter(group, route_url=route_url)
+
+        model = presenter.asdict()
+
+        assert model['urls']['group'] == '/group/a'
+        assert model['url'] == '/group/a'
+
+    def test_open_group_asdict_with_urls(self, factories):
+        group = factories.OpenGroup(name='My Group',
+                                    pubid='mygroup')
+        route_url = mock.Mock(return_value='/group/a')
+        presenter = GroupJSONPresenter(group, route_url=route_url)
+
+        model = presenter.asdict()
+        print model
+
+        assert model['urls']['group'] == '/group/a'
+        assert model['url'] == '/group/a'
+
+
+class TestGroupsJSONPresenter(object):
+
+    def test_asdicts_returns_list_of_dicts(self, factories):
+        groups = [factories.Group(name=u'filbert'), factories.OpenGroup(name=u'delbert')]
+        presenter = GroupsJSONPresenter(groups)
+
+        result = presenter.asdicts()
+
+        assert [group['name'] for group in result] == [u'filbert', u'delbert']
+
+    def test_asdicts_injects_urls(self, factories):
+        route_url = mock.Mock(return_value='/group/a')
+        groups = [factories.Group(), factories.OpenGroup()]
+        presenter = GroupsJSONPresenter(groups, route_url)
+
+        result = presenter.asdicts()
+
+        for group in result:
+            assert group['url']
+            assert group['urls']['group']


### PR DESCRIPTION
This is part 2 of breaking down big PR #4785 

This PR adds a new presenter for formatting `Group` objects as dicts for consumption by the API. Refactored from original to provide `GroupsJSONPresenter` subclass for collections of groups.