### PR TITLE
Convert API groups view to use new ListGroupsService

### DIFF
--- a/h/services/__init__.py
+++ b/h/services/__init__.py
@@ -22,6 +22,7 @@ def includeme(config):
     config.register_service_factory('.group.groups_factory', name='group')
     config.register_service_factory('.groupfinder.groupfinder_service_factory', iface='h.interfaces.IGroupService')
     config.register_service_factory('.links.links_factory', name='links')
+    config.register_service_factory('.list_groups.list_groups_factory', name='list_groups')
     config.register_service_factory('.nipsa.nipsa_factory', name='nipsa')
     config.register_service_factory('.oauth_provider.oauth_provider_service_factory', name='oauth_provider')
     config.register_service_factory('.oauth_validator.oauth_validator_service_factory', name='oauth_validator')

--- a/h/views/api_groups.py
+++ b/h/views/api_groups.py
@@ -15,10 +15,10 @@ from h.views.api import api_config
 def groups(request):
     authority = request.params.get('authority')
     document_uri = request.params.get('document_uri')
-    svc = request.find_service(name='profile_group')
-    return svc.all(user=request.user,
-                   authority=authority,
-                   document_uri=document_uri)
+    svc = request.find_service(name='list_groups')
+    return svc.all_groups(user=request.user,
+                          authority=authority,
+                          document_uri=document_uri)
 
 
 @api_config(route_name='api.group_member',

--- a/tests/h/views/api_groups_test.py
+++ b/tests/h/views/api_groups_test.py
@@ -8,31 +8,30 @@ import pytest
 from pyramid.httpexceptions import HTTPNoContent, HTTPBadRequest
 
 from h.views import api_groups as views
-from h.services.profile_group import ProfileGroupService
+from h.services.list_groups import ListGroupsService
 from h.services.group import GroupService
 
 
-@pytest.mark.usefixtures('profile_group_service')
 class TestGroups(object):
-    def test_groups_proxies_to_service(self, pyramid_request, profile_group_service):
+    def test_groups_proxies_to_service(self, pyramid_request, list_groups_service):
         views.groups(pyramid_request)
 
-        profile_group_service.all.assert_called_once()
+        list_groups_service.all_groups.assert_called_once()
 
-    def test_groups_passes_authority_parameter(self, pyramid_request, profile_group_service):
+    def test_groups_passes_authority_parameter(self, pyramid_request, list_groups_service):
         pyramid_request.params = {'authority': 'foo.com'}
 
         views.groups(pyramid_request)
 
-        c_args, c_kwargs = profile_group_service.all.call_args
+        c_args, c_kwargs = list_groups_service.all_groups.call_args
         assert c_kwargs['authority'] == 'foo.com'
 
-    def test_groups_passes_document_uri_parameter(self, pyramid_request, profile_group_service):
+    def test_groups_passes_document_uri_parameter(self, pyramid_request, list_groups_service):
         pyramid_request.params = {'document_uri': 'foo.example.com'}
 
         views.groups(pyramid_request)
 
-        c_args, c_kwargs = profile_group_service.all.call_args
+        c_args, c_kwargs = list_groups_service.all_groups.call_args
         assert c_kwargs['document_uri'] == 'foo.example.com'
 
     @pytest.fixture
@@ -46,9 +45,9 @@ class TestGroups(object):
         return factories.User.build()
 
     @pytest.fixture
-    def profile_group_service(self, pyramid_config):
-        svc = mock.create_autospec(ProfileGroupService, spec_set=True, instance=True)
-        pyramid_config.register_service(svc, name='profile_group')
+    def list_groups_service(self, pyramid_config):
+        svc = mock.create_autospec(ListGroupsService, spec_set=True, instance=True)
+        pyramid_config.register_service(svc, name='list_groups')
         return svc
 
 


### PR DESCRIPTION
Part 3 of breaking down PR #4785 

This PR converts the `api_groups` view to use the new `ListGroupsService`.

Note that it does not make use of the new `GroupJSONPresenter`; that'll come after #4798 is merged.

Note also that view tests will need refactor as per comments in #4785 but that will happen in the PR that converts it to use the presenter.