### PR TITLE
Py 3 compat - Use compatibility import for xrange

### DIFF
--- a/h/cli/commands/normalize_uris.py
+++ b/h/cli/commands/normalize_uris.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 
+from h._compat import xrange
 from collections import namedtuple
+
 import click
 
 from h import models

--- a/tests/h/activity/bucketing_test.py
+++ b/tests/h/activity/bucketing_test.py
@@ -2,6 +2,8 @@
 
 from __future__ import unicode_literals
 
+from h._compat import xrange
+
 import datetime
 import pytest
 from mock import Mock

--- a/tests/h/services/rename_user_test.py
+++ b/tests/h/services/rename_user_test.py
@@ -2,6 +2,8 @@
 
 from __future__ import unicode_literals
 
+from h._compat import xrange
+
 import mock
 import pytest
 

--- a/tests/py3-expected-failures.txt
+++ b/tests/py3-expected-failures.txt
@@ -1,4 +1,3 @@
-/h/h/cli/commands/normalize_uris.py:142:
 /h/h/db/types.py:88:
 /h/h/models/document.py:482:
 /h/h/search/config.py:190:
@@ -14,9 +13,6 @@
 /h/h/views/api_exceptions.py:36:
 /h/h/views/api_exceptions.py:42:
 /h/h/views/api_profile.py:33:
-/h/tests/h/activity/bucketing_test.py:122:
-/h/tests/h/activity/bucketing_test.py:81:
-/h/tests/h/activity/bucketing_test.py:91:
 /h/tests/h/auth/util_test.py:69:
 /h/tests/h/cli/commands/annotation_id_test.py:11:
 /h/tests/h/cli/commands/search_test.py:42:
@@ -44,8 +40,7 @@
 /h/tests/h/security_test.py:65:
 /h/tests/h/security_test.py:77:
 /h/tests/h/security_test.py:88:
-/h/tests/h/services/rename_user_test.py:26:
-/h/tests/h/services/rename_user_test.py:60:
+/h/tests/h/services/rename_user_test.py:28:
 /h/tests/h/services/user_test.py:95:
 /h/tests/h/tasks/admin_test.py:14:
 /h/tests/h/util/cors_test.py:139:


### PR DESCRIPTION
`xrange` became `range` in Python 3. Use the `h._compat.xrange` alias to
handle this.