### PR TITLE
Make group facet return user associated groups

### DIFF
--- a/h/panels/navbar.py
+++ b/h/panels/navbar.py
@@ -29,13 +29,13 @@ def navbar(context, request, search=None, opts=None):
                 'title': group.name,
                 'link': request.route_url('group_read', pubid=group.pubid, slug=group.slug)
             })
-            groups_suggestions.append({
-                'name': group.name,
-                'pubid': group.pubid
-            })
         user_activity_url = request.route_url('activity.user_search',
                                               username=request.user.username)
         username = request.user.username
+    # Make all groups associated with the user visible in the search auto complete.
+    list_group_service = request.find_service(name='list_groups')
+    groups = list_group_service.associated_groups(request.user)
+    groups_suggestions = [{'name': group.name, 'pubid': group.pubid} for group in groups]
 
     route = request.matched_route
 

--- a/tests/h/panels/navbar_test.py
+++ b/tests/h/panels/navbar_test.py
@@ -2,13 +2,15 @@
 
 from __future__ import unicode_literals
 
+import mock
 from mock import PropertyMock
 import pytest
 
 from h.panels.navbar import navbar
+from h.services.list_groups import ListGroupsService
 
 
-@pytest.mark.usefixtures('routes')
+@pytest.mark.usefixtures('routes', 'list_groups_svc')
 class TestNavbar(object):
     def test_it_sets_null_username_when_logged_out(self, req):
         result = navbar({}, req)
@@ -29,10 +31,9 @@ class TestNavbar(object):
             for g in user.groups
         ]
 
-    def test_includes_groups_suggestions_when_logged_in(self, req, user):
+    def test_includes_groups_suggestions_when_logged_in(self, req, user, open_group):
         req.user = user
         result = navbar({}, req)
-
         assert result['groups_suggestions'] == [{'name': g.name, 'pubid': g.pubid}
                                                 for g in user.groups]
 
@@ -84,6 +85,10 @@ class TestNavbar(object):
         pyramid_config.add_route('logout', '/logout')
 
     @pytest.fixture
+    def open_group(self, factories):
+        return factories.OpenGroup()
+
+    @pytest.fixture
     def user(self, factories):
         user = factories.User(username='vannevar')
         user.groups = [factories.Group(), factories.Group()]
@@ -93,3 +98,10 @@ class TestNavbar(object):
     def req(self, pyramid_request):
         pyramid_request.user = None
         return pyramid_request
+
+    @pytest.fixture
+    def list_groups_svc(self, pyramid_config, user):
+        svc = mock.create_autospec(ListGroupsService, spec_set=True, instance=True)
+        svc.associated_groups.return_value = user.groups
+        pyramid_config.register_service(svc, name='list_groups')
+        return svc


### PR DESCRIPTION
On the activity page, when searching for a group, any group the user is associated with should show up in the search autocomplete drop down. Associated with meaning the user is a creator or member of the group. This is a fix for https://github.com/hypothesis/product-backlog/issues/510.
![image](https://user-images.githubusercontent.com/30059933/37441384-665b51d6-27be-11e8-81ed-b9fce09d7c00.png)
