### PR TITLE
Remove formatting from ListGroupsService and make api_groups view use JSON presenter

### DIFF
--- a/h/presenters/__init__.py
+++ b/h/presenters/__init__.py
@@ -15,6 +15,7 @@ from h.presenters.document_html import DocumentHTMLPresenter
 from h.presenters.document_json import DocumentJSONPresenter
 from h.presenters.document_searchindex import DocumentSearchIndexPresenter
 from h.presenters.group_json import GroupJSONPresenter
+from h.presenters.group_json import GroupsJSONPresenter
 from h.presenters.user_json import UserJSONPresenter
 
 __all__ = (
@@ -26,5 +27,6 @@ __all__ = (
     'DocumentJSONPresenter',
     'DocumentSearchIndexPresenter',
     'GroupJSONPresenter',
+    'GroupsJSONPresenter',
     'UserJSONPresenter',
 )

--- a/h/presenters/group_json.py
+++ b/h/presenters/group_json.py
@@ -36,7 +36,7 @@ class GroupJSONPresenter(object):
         return model
 
 
-class GroupsJSONPresenter(GroupJSONPresenter):
+class GroupsJSONPresenter(object):
     """Present a list of groups as JSON"""
 
     def __init__(self, groups, route_url=None):
@@ -44,4 +44,4 @@ class GroupsJSONPresenter(GroupJSONPresenter):
         self._route_url = route_url
 
     def asdicts(self):
-        return [self._model(group) for group in self.groups]
+        return [GroupJSONPresenter(group, self._route_url).asdict() for group in self.groups]

--- a/h/views/api_groups.py
+++ b/h/views/api_groups.py
@@ -19,7 +19,7 @@ def groups(request):
     all_groups = svc.all_groups(user=request.user,
                                 authority=authority,
                                 document_uri=document_uri)
-    all_groups = GroupsJSONPresenter(groups, request.route_url).asdicts()
+    all_groups = GroupsJSONPresenter(all_groups, request.route_url).asdicts()
     return all_groups
 
 

--- a/h/views/api_groups.py
+++ b/h/views/api_groups.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 
 from pyramid import security
 from pyramid.httpexceptions import HTTPNoContent, HTTPBadRequest
-
+from h.presenters import GroupJSONPresenter
 from h.views.api import api_config
 
 
@@ -16,9 +16,11 @@ def groups(request):
     authority = request.params.get('authority')
     document_uri = request.params.get('document_uri')
     svc = request.find_service(name='list_groups')
-    return svc.all_groups(user=request.user,
-                          authority=authority,
-                          document_uri=document_uri)
+    all_groups = svc.all_groups(user=request.user,
+                                authority=authority,
+                                document_uri=document_uri)
+    all_groups = [GroupJSONPresenter(group, request.route_url).asdict() for group in all_groups]
+    return all_groups
 
 
 @api_config(route_name='api.group_member',

--- a/h/views/api_groups.py
+++ b/h/views/api_groups.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 
 from pyramid import security
 from pyramid.httpexceptions import HTTPNoContent, HTTPBadRequest
-from h.presenters import GroupJSONPresenter
+from h.presenters import GroupsJSONPresenter
 from h.views.api import api_config
 
 
@@ -19,7 +19,7 @@ def groups(request):
     all_groups = svc.all_groups(user=request.user,
                                 authority=authority,
                                 document_uri=document_uri)
-    all_groups = [GroupJSONPresenter(group, request.route_url).asdict() for group in all_groups]
+    all_groups = GroupsJSONPresenter(groups, request.route_url).asdicts()
     return all_groups
 
 

--- a/tests/h/presenters/group_json_test.py
+++ b/tests/h/presenters/group_json_test.py
@@ -2,6 +2,7 @@
 
 from __future__ import unicode_literals
 
+import pytest
 import mock
 
 from h.presenters.group_json import GroupJSONPresenter, GroupsJSONPresenter
@@ -63,6 +64,23 @@ class TestGroupJSONPresenter(object):
 
 class TestGroupsJSONPresenter(object):
 
+    def test_asdicts_creates_GroupJSONPresenter_objects(self, factories, group_json_presenter):  # noqa: N802
+        groups = [factories.Group(), factories.OpenGroup()]
+        presenter = GroupsJSONPresenter(groups)
+
+        presenter.asdicts()
+
+        assert group_json_presenter.call_count == 2
+
+    def test_asdicts_passes_route_url(self, factories, group_json_presenter):
+        groups = [factories.Group()]
+        route_url = mock.Mock()
+        presenter = GroupsJSONPresenter(groups, route_url=route_url)
+
+        presenter.asdicts()
+
+        group_json_presenter.assert_called_with(groups[0], route_url=route_url)
+
     def test_asdicts_returns_list_of_dicts(self, factories):
         groups = [factories.Group(name=u'filbert'), factories.OpenGroup(name=u'delbert')]
         presenter = GroupsJSONPresenter(groups)
@@ -81,3 +99,13 @@ class TestGroupsJSONPresenter(object):
         for group in result:
             assert group['url']
             assert group['urls']['group']
+
+
+@pytest.fixture
+def group_json_presenter(patch):
+    return patch('h.presenters.group_json.GroupJSONPresenter')
+
+
+@pytest.fixture
+def group_json_presenter_asdict(patch):
+    return patch('h.presenters.group_json.GroupJSONPresenter.asdict')

--- a/tests/h/presenters/group_json_test.py
+++ b/tests/h/presenters/group_json_test.py
@@ -104,8 +104,3 @@ class TestGroupsJSONPresenter(object):
 @pytest.fixture
 def group_json_presenter(patch):
     return patch('h.presenters.group_json.GroupJSONPresenter')
-
-
-@pytest.fixture
-def group_json_presenter_asdict(patch):
-    return patch('h.presenters.group_json.GroupJSONPresenter.asdict')

--- a/tests/h/presenters/group_json_test.py
+++ b/tests/h/presenters/group_json_test.py
@@ -64,22 +64,15 @@ class TestGroupJSONPresenter(object):
 
 class TestGroupsJSONPresenter(object):
 
-    def test_asdicts_creates_GroupJSONPresenter_objects(self, factories, group_json_presenter):  # noqa: N802
+    def test_proxies_to_GroupJSONPresenter(self, factories, group_json_presenter):  # noqa: N802
         groups = [factories.Group(), factories.OpenGroup()]
-        presenter = GroupsJSONPresenter(groups)
-
-        presenter.asdicts()
-
-        assert group_json_presenter.call_count == 2
-
-    def test_asdicts_passes_route_url(self, factories, group_json_presenter):
-        groups = [factories.Group()]
         route_url = mock.Mock()
         presenter = GroupsJSONPresenter(groups, route_url=route_url)
+        expected_call_args = [mock.call(group, route_url) for group in groups]
 
         presenter.asdicts()
 
-        group_json_presenter.assert_called_with(groups[0], route_url=route_url)
+        assert group_json_presenter.call_args_list == expected_call_args
 
     def test_asdicts_returns_list_of_dicts(self, factories):
         groups = [factories.Group(name=u'filbert'), factories.OpenGroup(name=u'delbert')]

--- a/tests/h/presenters/group_json_test.py
+++ b/tests/h/presenters/group_json_test.py
@@ -64,7 +64,7 @@ class TestGroupJSONPresenter(object):
 
 class TestGroupsJSONPresenter(object):
 
-    def test_proxies_to_GroupJSONPresenter(self, factories, group_json_presenter):  # noqa: N802
+    def test_proxies_to_GroupJSONPresenter(self, factories, GroupJSONPresenter_):  # noqa: [N802, N803]
         groups = [factories.Group(), factories.OpenGroup()]
         route_url = mock.Mock()
         presenter = GroupsJSONPresenter(groups, route_url=route_url)
@@ -72,7 +72,7 @@ class TestGroupsJSONPresenter(object):
 
         presenter.asdicts()
 
-        assert group_json_presenter.call_args_list == expected_call_args
+        assert GroupJSONPresenter_.call_args_list == expected_call_args
 
     def test_asdicts_returns_list_of_dicts(self, factories):
         groups = [factories.Group(name=u'filbert'), factories.OpenGroup(name=u'delbert')]
@@ -95,5 +95,5 @@ class TestGroupsJSONPresenter(object):
 
 
 @pytest.fixture
-def group_json_presenter(patch):
+def GroupJSONPresenter_(patch):  # noqa: N802
     return patch('h.presenters.group_json.GroupJSONPresenter')

--- a/tests/h/services/list_groups_test.py
+++ b/tests/h/services/list_groups_test.py
@@ -2,7 +2,6 @@
 
 from __future__ import unicode_literals
 
-import mock
 import pytest
 
 from h.services.list_groups import ListGroupsService
@@ -12,35 +11,35 @@ from h.services.list_groups import list_groups_factory
 class TestListGroupsAllGroups(object):
 
     def test_returns_open_groups_when_no_user(self, list_groups_service, open_groups):
-        open_group_ids = {group.pubid for group in open_groups}
-        open_group_ids.add('__world__')
+        open_group_pubids = {group.pubid for group in open_groups}
+        open_group_pubids.add('__world__')
 
         groups = list_groups_service.all_groups()
 
-        assert {group['id'] for group in groups} == open_group_ids
+        assert {group.pubid for group in groups} == open_group_pubids
         for group in groups:
-            assert group['type'] == 'open'
+            assert group.is_public
 
     def test_returns_all_group_types_when_user(self, list_groups_service, factories):
         user = factories.User()
         user.groups = [factories.Group(), factories.Group()]
-        expected_ids = [group.pubid for group in user.groups]
-        expected_ids.append('__world__')
+        expected_pubids = [group.pubid for group in user.groups]
+        expected_pubids.append('__world__')
 
         groups = list_groups_service.all_groups(user=user)
 
-        group_ids = [group['id'] for group in groups]
-        for expected_id in expected_ids:
-            assert expected_id in group_ids
+        group_pubids = [group.pubid for group in groups]
+        for expected_id in expected_pubids:
+            assert expected_id in group_pubids
 
     def test_ignores_authority_when_user_present(self, list_groups_service, factories, authority_open_groups):
         user = factories.User(authority='foo.com')
         another_authority_open_group = factories.OpenGroup(authority='somewhere-else.com')
-        auth_group_ids = {group.pubid for group in authority_open_groups}
+        auth_group_ids = {group.id for group in authority_open_groups}
 
         groups = list_groups_service.all_groups(user=user, authority='somewhere-else.com')
 
-        group_ids = {group['id'] for group in groups}
+        group_ids = {group.id for group in groups}
         assert group_ids == auth_group_ids
         assert another_authority_open_group.pubid not in group_ids
 
@@ -55,7 +54,7 @@ class TestListGroupsAllGroups(object):
         groups = list_groups_service.all_groups(user=user)
 
         # open groups first
-        assert [group['id'] for group in groups] == ['azaz', 'zaza', 'zoinks', 'aaaa', 'zzzz']
+        assert [group.pubid for group in groups] == ['azaz', 'zaza', 'zoinks', 'aaaa', 'zzzz']
 
     def test_groups_are_sorted_alphabetically(self, list_groups_service, factories):
         user = factories.User(authority='z.com')
@@ -64,7 +63,7 @@ class TestListGroupsAllGroups(object):
 
         groups = list_groups_service.all_groups(user=user)
 
-        assert [group['name'] for group in groups] == ['foobar', 'Lilac']
+        assert [group.name for group in groups] == ['foobar', 'Lilac']
 
     def test_user_groups_not_mutated(self, list_groups_service, factories):
         user = factories.User(authority='z.com')
@@ -83,21 +82,6 @@ class TestListGroupsAllGroups(object):
 
 class TestListGroupsPrivateGroups(object):
 
-    @pytest.mark.parametrize('attribute', [
-        ('id'),
-        ('name'),
-        ('public'),
-        ('scoped'),
-        ('type')
-    ])
-    def test_returns_formatted_groups(self, list_groups_service, factories, attribute):
-        user = factories.User()
-        user.groups = [factories.Group()]
-
-        groups = list_groups_service.private_groups(user)
-
-        assert attribute in groups[0]
-
     def test_returns_private_groups_only(self, list_groups_service, factories):
         user = factories.User()
         user.groups = [factories.Group(), factories.Group(), factories.Group()]
@@ -106,7 +90,7 @@ class TestListGroupsPrivateGroups(object):
 
         assert len(groups) == 3
         for group in groups:
-            assert group['type'] == 'private'
+            assert not group.is_public
 
     def test_returns_empty_when_user_no_private_groups(self, list_groups_service, factories):
         user = factories.User()
@@ -129,7 +113,7 @@ class TestListGroupsPrivateGroups(object):
 
         groups = list_groups_service.private_groups(user=user)
 
-        assert [group['id'] for group in groups] == ['zoinks', 'aaaa', 'zzzz']
+        assert [group.pubid for group in groups] == ['zoinks', 'aaaa', 'zzzz']
 
 
 class TestListGroupsOpenGroups(object):
@@ -139,7 +123,7 @@ class TestListGroupsOpenGroups(object):
 
         groups = list_groups_service.open_groups(authority='foo.com')
 
-        assert {group['name'] for group in groups} == o_group_names
+        assert {group.name for group in groups} == o_group_names
 
     def test_no_groups_from_mismatched_authority(self, list_groups_service, authority_open_groups):
 
@@ -150,7 +134,7 @@ class TestListGroupsOpenGroups(object):
     def test_returns_groups_from_default_authority(self, list_groups_service):
         groups = list_groups_service.open_groups()
 
-        assert groups[0]['id'] == '__world__'
+        assert groups[0].pubid == '__world__'
 
     def test_returns_groups_for_user_authority(self, list_groups_service, authority_open_groups, factories):
         user = factories.User(authority='foo.com')
@@ -158,7 +142,7 @@ class TestListGroupsOpenGroups(object):
 
         o_groups = list_groups_service.open_groups(user=user)
 
-        assert {group['name'] for group in o_groups} == o_group_names
+        assert {group.name for group in o_groups} == o_group_names
 
     def test_ignores_authority_if_user(self, list_groups_service, authority_open_groups, factories):
         user = factories.User(authority='somethingelse.com')
@@ -174,7 +158,7 @@ class TestListGroupsOpenGroups(object):
 
         groups = list_groups_service.open_groups(authority='z.com')
 
-        assert [group['id'] for group in groups] == ['zoinks', 'aaaa', 'zzzz']
+        assert [group.pubid for group in groups] == ['zoinks', 'aaaa', 'zzzz']
 
 
 class TestListGroupsFactory(object):
@@ -200,7 +184,6 @@ def authority_open_groups(factories):
 
 @pytest.fixture
 def pyramid_request(pyramid_request):
-    pyramid_request.route_url = mock.Mock(return_value='/group/a')
     return pyramid_request
 
 
@@ -208,6 +191,5 @@ def pyramid_request(pyramid_request):
 def list_groups_service(pyramid_request, db_session):
     return ListGroupsService(
         session=db_session,
-        request_authority=pyramid_request.authority,
-        route_url=pyramid_request.route_url
+        request_authority=pyramid_request.authority
     )

--- a/tests/h/views/api_groups_test.py
+++ b/tests/h/views/api_groups_test.py
@@ -12,6 +12,7 @@ from h.services.list_groups import ListGroupsService
 from h.services.group import GroupService
 
 
+@pytest.mark.usefixtures('GroupJSONPresenter')
 class TestGroups(object):
 
     def test_all_groups_proxies_to_service(self, anonymous_request, list_groups_service):
@@ -43,20 +44,20 @@ class TestGroups(object):
             document_uri='http://example.com/thisthing.html'
         )
 
-    def test_uses_presenter_for_formatting(self, anonymous_request, open_groups, list_groups_service, presenter):
+    def test_uses_presenter_for_formatting(self, anonymous_request, open_groups, list_groups_service, GroupJSONPresenter):  # noqa: N803
         list_groups_service.all_groups.return_value = open_groups
 
         views.groups(anonymous_request)
 
-        assert presenter.call_count == 2
+        assert GroupJSONPresenter.call_count == 2
 
-    def test_returns_formatted_groups(self, anonymous_request, open_groups, list_groups_service, presenter):
+    def test_returns_formatted_groups(self, anonymous_request, open_groups, list_groups_service, GroupJSONPresenter):  # noqa: N803
         list_groups_service.all_groups.return_value = open_groups
-        presenter.asdict.return_value = {'foo': 'bar'}
+        GroupJSONPresenter.asdict.return_value = {'foo': 'bar'}
 
         result = views.groups(anonymous_request)
 
-        assert result == [presenter(group, None).asdict() for group in open_groups]
+        assert result == [GroupJSONPresenter(group, None).asdict() for group in open_groups]
 
     @pytest.fixture
     def pyramid_request(self, pyramid_request):
@@ -83,10 +84,6 @@ class TestGroups(object):
         user = factories.User()
         user.groups = [factories.Group(), factories.Group()]
         return user
-
-    @pytest.fixture
-    def presenter(self, patch):
-        return patch('h.views.api_groups.GroupJSONPresenter')
 
 
 @pytest.mark.usefixtures('authenticated_userid', 'group_service')
@@ -133,3 +130,13 @@ class TestRemoveMember(object):
         userid = 'acct:bob@example.org'
         pyramid_config.testing_securitypolicy(userid)
         return userid
+
+
+@pytest.fixture
+def GroupJSONPresenter(patch):  # noqa: N802
+    return patch('h.views.api_groups.GroupJSONPresenter')
+
+
+@pytest.fixture
+def GroupsJSONPresenter(patch):  # noqa: N802
+    return patch('h.views.api_groups.GroupsJSONPresenter')

--- a/tests/h/views/api_groups_test.py
+++ b/tests/h/views/api_groups_test.py
@@ -11,8 +11,9 @@ from h.views import api_groups as views
 from h.services.list_groups import ListGroupsService
 from h.services.group import GroupService
 
+pytestmark = pytest.mark.usefixtures('GroupsJSONPresenter')
 
-@pytest.mark.usefixtures('GroupsJSONPresenter')
+
 class TestGroups(object):
 
     def test_all_groups_proxies_to_service(self, anonymous_request, list_groups_service):
@@ -49,7 +50,14 @@ class TestGroups(object):
 
         views.groups(anonymous_request)
 
-        assert GroupsJSONPresenter.call_count == 1
+        GroupsJSONPresenter.assert_called_once_with(open_groups, anonymous_request.route_url)
+
+    def test_returns_dicts_from_presenter(self, anonymous_request, open_groups, list_groups_service, GroupsJSONPresenter):  # noqa: N803
+        list_groups_service.all_groups.return_value = open_groups
+
+        result = views.groups(anonymous_request)
+
+        assert result == GroupsJSONPresenter(open_groups, anonymous_request).asdicts.return_value
 
     @pytest.fixture
     def pyramid_request(self, pyramid_request):

--- a/tests/h/views/api_groups_test.py
+++ b/tests/h/views/api_groups_test.py
@@ -71,12 +71,6 @@ class TestGroups(object):
         pyramid_request.user = None
         return pyramid_request
 
-    @pytest.fixture
-    def user_with_private_groups(self, factories):
-        user = factories.User()
-        user.groups = [factories.Group(), factories.Group()]
-        return user
-
 
 @pytest.mark.usefixtures('authenticated_userid', 'group_service')
 class TestRemoveMember(object):

--- a/tests/h/views/api_groups_test.py
+++ b/tests/h/views/api_groups_test.py
@@ -60,11 +60,6 @@ class TestGroups(object):
         assert result == GroupsJSONPresenter(open_groups, anonymous_request).asdicts.return_value
 
     @pytest.fixture
-    def pyramid_request(self, pyramid_request):
-        pyramid_request.route_url = mock.Mock(return_value='/groups/foo')
-        return pyramid_request
-
-    @pytest.fixture
     def open_groups(self, factories):
         return [factories.OpenGroup(), factories.OpenGroup()]
 

--- a/tests/h/views/api_groups_test.py
+++ b/tests/h/views/api_groups_test.py
@@ -12,7 +12,7 @@ from h.services.list_groups import ListGroupsService
 from h.services.group import GroupService
 
 
-@pytest.mark.usefixtures('GroupJSONPresenter')
+@pytest.mark.usefixtures('GroupsJSONPresenter')
 class TestGroups(object):
 
     def test_all_groups_proxies_to_service(self, anonymous_request, list_groups_service):
@@ -44,20 +44,12 @@ class TestGroups(object):
             document_uri='http://example.com/thisthing.html'
         )
 
-    def test_uses_presenter_for_formatting(self, anonymous_request, open_groups, list_groups_service, GroupJSONPresenter):  # noqa: N803
+    def test_uses_presenter_for_formatting(self, anonymous_request, open_groups, list_groups_service, GroupsJSONPresenter):  # noqa: N803
         list_groups_service.all_groups.return_value = open_groups
 
         views.groups(anonymous_request)
 
-        assert GroupJSONPresenter.call_count == 2
-
-    def test_returns_formatted_groups(self, anonymous_request, open_groups, list_groups_service, GroupJSONPresenter):  # noqa: N803
-        list_groups_service.all_groups.return_value = open_groups
-        GroupJSONPresenter.asdict.return_value = {'foo': 'bar'}
-
-        result = views.groups(anonymous_request)
-
-        assert result == [GroupJSONPresenter(group, None).asdict() for group in open_groups]
+        assert GroupsJSONPresenter.call_count == 1
 
     @pytest.fixture
     def pyramid_request(self, pyramid_request):
@@ -130,11 +122,6 @@ class TestRemoveMember(object):
         userid = 'acct:bob@example.org'
         pyramid_config.testing_securitypolicy(userid)
         return userid
-
-
-@pytest.fixture
-def GroupJSONPresenter(patch):  # noqa: N802
-    return patch('h.views.api_groups.GroupJSONPresenter')
 
 
 @pytest.fixture


### PR DESCRIPTION
This PR is a chunk of #4785 

This PR adapts `ListGroupsService` to remove legacy formatting of groups objects—`ListGroupsService` now deals exclusively in `Group` model objects. `api_groups` view now uses the `GroupsJSONPresenter` to format groups it gets from the `ListGroupsService.`

Also took the opportunity to refactor `GroupsJSONPresenter` not to inherit from `GroupJSONPresenter` but instead utilize `GroupJSONPresenter` instances in its `asdict` method.

Once _this_ PR is done and dusted, I can submit a PR to make `session` use all this new stuff and then finally we can kill `AuthorityGroupService` and `ProfileGroupService`