### PR TITLE
Add scopes support to OpenGroup factory

### DIFF
--- a/tests/common/factories/group.py
+++ b/tests/common/factories/group.py
@@ -8,6 +8,7 @@ from h import models
 from h.models.group import JoinableBy, ReadableBy, WriteableBy
 
 from .base import ModelFactory
+from .group_scope import GroupScope
 from .user import User
 
 
@@ -33,3 +34,10 @@ class OpenGroup(Group):
     joinable_by = None
     readable_by = ReadableBy.world
     writeable_by = WriteableBy.authority
+
+    @factory.post_generation
+    def scopes(self, create, scopes=0, **kwargs):
+        if isinstance(scopes, int):
+            scopes = [GroupScope(group=self) for _ in range(0, scopes)]
+
+        self.scopes = scopes or []

--- a/tests/common/factories/group_scope.py
+++ b/tests/common/factories/group_scope.py
@@ -7,7 +7,6 @@ import factory
 from h import models
 
 from .base import ModelFactory
-from .group import OpenGroup
 
 
 class GroupScope(ModelFactory):
@@ -15,4 +14,4 @@ class GroupScope(ModelFactory):
         model = models.GroupScope
 
     origin = factory.Faker('url')
-    group = factory.SubFactory(OpenGroup)
+    group = factory.SubFactory('tests.common.factories.OpenGroup')

--- a/tests/h/models/group_scope_test.py
+++ b/tests/h/models/group_scope_test.py
@@ -104,9 +104,12 @@ class TestGroupScope(object):
         group_1 = factories.OpenGroup()
         group_2 = factories.OpenGroup()
         group_3 = factories.OpenGroup()
-        factories.GroupScope(origin=origin, group=group_1)
-        factories.GroupScope(origin=origin, group=group_2)
-        factories.GroupScope(origin=origin, group=group_3)
+        db_session.add_all((
+            factories.GroupScope(origin=origin, group=group_1),
+            factories.GroupScope(origin=origin, group=group_2),
+            factories.GroupScope(origin=origin, group=group_3),
+        ))
+        db_session.flush()
 
         db_session.delete(group_1.scopes[0])
         db_session.flush()


### PR DESCRIPTION
Usage:

By default `factories.OpenGroup()` will return a group with a random
number of randomly generated scopes:

    >>> group = factories.OpenGroup()
    >>> group.scopes
    [<GroupScope http://martinez-shepherd.com/>,
     <GroupScope https://prince-ochoa.com/>]

You can specify how many randomly generated scopes you want a group to
have:

    >>> group = factories.OpenGroup(scopes=5)
    >>> len(group.scopes)
    5

You can create an open group with no scopes:

    >>> group = factories.OpenGroup(scopes=0)
    >>> group.scopes
    []

(passing `scopes=[]` will also work).

If you have some `GroupScope` objects you can create an open group with
a particular list of scopes or a list of one scope:

    group = factories.OpenGroup(scopes=[my_scope])

Private groups created with `factories.Group()` will have no scopes.

Incidentally this change also means that when you create a scope using
`factories.GroupScope()` and an open group is randomly generated for
that scope to belong to, a random number of _other scopes_ will also be
generated and added to the group's scopes:

    >>> scope = factories.GroupScope()
    <GroupScope https://www.jacobs-frazier.com/>

    >>> scope.group.scopes
    [<GroupScope https://www.payne-owens.info/>,
     <GroupScope https://www.jacobs-frazier.com/>]