### PR TITLE
Make `h.util.uri.normalize` work with Python 3

### DIFF
--- a/h/util/uri.py
+++ b/h/util/uri.py
@@ -66,7 +66,7 @@ elsewhere in the Hypothesis application. URI expansion is handled by
 import re
 
 from h._compat import (
-    text_type,
+    PY2,
     url_quote,
     url_quote_plus,
     url_unquote,
@@ -132,8 +132,27 @@ VIA_PREFIX = "https://via.hypothes.is/"
 
 
 def normalize(uristr):
-    """Translate the given URI into a normalized form."""
-    uristr = uristr.encode('utf-8')
+    """
+    Translate the given URI into a normalized form.
+
+    :type uristr: unicode
+    :rtype: unicode
+    """
+
+    # In Python 2 functions in urllib expect a byte string whereas in Python 3
+    # some functions in urllib work with a byte string or unicode but
+    # others (eg. `unquote`) require unicode.
+    #
+    # Hence we work with byte strings internally in Py 2 and unicode internally
+    # in Python 3. In both we always return unicode.
+    if PY2:
+        uristr = uristr.encode('utf-8')
+
+    def decode_result(result):
+        if PY2:
+            return result.decode('utf-8')
+        else:
+            return result
 
     # Strip proxy prefix for proxied URLs
     for scheme in URL_SCHEMES:
@@ -146,11 +165,11 @@ def normalize(uristr):
 
     # If this isn't a URL, we don't perform any normalization
     if uri.scheme.lower() not in URL_SCHEMES:
-        return text_type(uristr, 'utf-8')
+        return decode_result(uristr)
 
     # Don't perform normalization on URLs with no hostname.
     if uri.hostname is None:
-        return text_type(uristr, 'utf-8')
+        return decode_result(uristr)
 
     scheme = _normalize_scheme(uri)
     netloc = _normalize_netloc(uri)
@@ -160,7 +179,7 @@ def normalize(uristr):
 
     uri = urlparse.SplitResult(scheme, netloc, path, query, fragment)
 
-    return text_type(uri.geturl(), 'utf-8')
+    return decode_result(uri.geturl())
 
 
 def _normalize_scheme(uri):

--- a/tests/py3-expected-failures.txt
+++ b/tests/py3-expected-failures.txt
@@ -1,10 +1,11 @@
 /h/h/db/types.py:88:
 /h/h/models/document.py:482:
 /h/h/search/config.py:190:
-/h/h/util/uri.py:140:
 /h/tests/h/auth/util_test.py:69:
 /h/tests/h/cli/commands/annotation_id_test.py:11:
 /h/tests/h/db/types_test.py:57:
+/h/tests/h/feeds/rss_test.py:93:
+/h/tests/h/feeds/util_test.py:17:
 /h/tests/h/jinja_extension_test.py:48:
 /h/tests/h/jinja_extension_test.py:55:
 /h/tests/h/jinja_extension_test.py:63:


### PR DESCRIPTION
urllib in Python 2 and 3 have differences in whether they expect byte
strings vs unicode. After some trial and error, the easiest path appears
to be to use byte strings internally in Python 2 and unicode strings
internally in Python 3. I am relying on the existing tests to verify
consistency across both.

Fixing this issue "uncovers" some other Py 3 failures in existing tests.