### PR TITLE
Refactor `session` to use `ListGroupsService`

### DIFF
--- a/h/session.py
+++ b/h/session.py
@@ -75,20 +75,10 @@ def _current_groups(request, authority):
     """
 
     user = request.user
-    authority_groups = (request.find_service(name='authority_group')
-                        .public_groups(authority=authority))
-
-    groups = authority_groups + _user_groups(user, request)
+    svc = request.find_service(name='list_groups')
+    groups = svc.all_groups(user=user, authority=authority)
 
     return [_group_model(request.route_url, group) for group in groups]
-
-
-def _user_groups(user, request):
-    if user is None:
-        return []
-    else:
-        profile_groups_svc = request.find_service(name='profile_group')
-        return profile_groups_svc.sort(user.groups)
 
 
 def _group_model(route_url, group):

--- a/tests/h/session_test.py
+++ b/tests/h/session_test.py
@@ -5,14 +5,6 @@ from h import session
 from h.services.list_groups import ListGroupsService
 
 
-class FakeGroup(object):
-    def __init__(self, pubid, name, is_public=False):
-        self.pubid = pubid
-        self.name = name
-        self.slug = pubid
-        self.is_public = is_public
-
-
 class TestModel(object):
     def test_proxies_group_lookup_to_service(self, authenticated_request):
         svc = authenticated_request.find_service(name='list_groups')
@@ -238,15 +230,6 @@ class TestUserInfo(object):
 
     def test_format_returns_empty_dict_when_user_missing(self):
         assert session.user_info(None) == {}
-
-
-class FakeListGroupsService(object):
-
-    def __init__(self, open_groups):
-        self._open_groups = open_groups
-
-    def open_groups(self, authority):
-        return self._open_groups[authority]
 
 
 class FakeRequest(object):


### PR DESCRIPTION
`session` is the last module making use of the `ProfileGroupService` (and, by extension, the `AuthorityGroupService`). This PR refactors `session`'s group-finding code to use the `ListGroupsService` (thus DRYing it out). `session` maintains its own formatting of its `group` objects, using its own `_group_model` method — we could change that in the future if we wanted session's groups to be at parity with other consumers of the `ListGroupsService`.