### PR TITLE
Prepare list groups for filtering

### DIFF
--- a/h/services/list_groups.py
+++ b/h/services/list_groups.py
@@ -97,6 +97,23 @@ class ListGroupsService(object):
         """ sort a list of groups of a single type """
         return sorted(groups, key=lambda group: (group.name.lower(), group.pubid))
 
+    def _world_group(self, authority):
+        """
+        Return the world group for the given authority, if any.
+
+        Return the so-called 'world-readable Public group' (or channel) for
+        the indicated authority.
+
+        The Public group is special: at present its metadata makes it look
+        identical to any non-scoped open group. Its only distinguishing
+        characteristic is its unique and predictable ``pubid``
+        """
+        return (self._session.query(models.Group)
+                    .filter_by(authority=authority,
+                               readable_by=group.ReadableBy.world,
+                               pubid=u'__world__')
+                    .one_or_none())
+
 
 def list_groups_factory(context, request):
     """Return a ListGroupsService instance for the passed context and request."""

--- a/h/services/list_groups.py
+++ b/h/services/list_groups.py
@@ -47,12 +47,12 @@ class ListGroupsService(object):
         Return a list of groups filtered on user, authority, document_uri.
         Include all types of relevant groups (open and private).
         """
-        open_groups = self.open_groups(user, authority, document_uri)
-        private_groups = self.private_groups(user)
+        open_groups = self._open_groups(user, authority, document_uri)
+        private_groups = self._private_groups(user)
 
         return open_groups + private_groups
 
-    def open_groups(self, user=None, authority=None, document_uri=None):
+    def _open_groups(self, user=None, authority=None, document_uri=None):
         """
         Return all matching open groups for the authority and target URI.
 
@@ -68,7 +68,7 @@ class ListGroupsService(object):
                       .all())
         return self._sort(groups)
 
-    def private_groups(self, user=None):
+    def _private_groups(self, user=None):
         """Return this user's private groups per user.groups."""
 
         if user is None:

--- a/h/services/list_groups.py
+++ b/h/services/list_groups.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 
 from h import models
 from h.models import group
+from h._compat import urlparse
 
 
 class ListGroupsService(object):
@@ -73,6 +74,24 @@ class ListGroupsService(object):
         if user is None:
             return []
         return self._sort(user.groups)
+
+    def _parse_origin(self, uri):
+        """
+        Return the origin of a URI or None if empty or invalid.
+
+        Per https://tools.ietf.org/html/rfc6454#section-7 :
+        Return ``<scheme> + '://' + <host> + <port>``
+        for a URI.
+
+        :param uri: URI string
+        """
+
+        if uri is None:
+            return None
+        parsed = urlparse.urlsplit(uri)
+        # netloc contains both host and port
+        origin = urlparse.SplitResult(parsed.scheme, parsed.netloc, '', '', '')
+        return origin.geturl() or None
 
     def _sort(self, groups):
         """ sort a list of groups of a single type """

--- a/tests/h/services/list_groups_test.py
+++ b/tests/h/services/list_groups_test.py
@@ -163,7 +163,7 @@ class TestListGroupsOpenGroups(object):
 
 class TestListGroupsParseOrigin(object):
 
-    @pytest.mark.parametrize('document_uri', [
+    @pytest.mark.parametrize('document_uri,expected_origin', [
         (u'http://www.foo.bar:80/ding', u'http://www.foo.bar:80'),
         (u'http://www.foo.bar:80/', u'http://www.foo.bar:80'),
         (u'http://www.foo.bar:80/flop.html', u'http://www.foo.bar:80'),
@@ -172,19 +172,19 @@ class TestListGroupsParseOrigin(object):
         (u'https://userfoo:hitherepassword@foo.bar/zowie/bang.pdf', u'https://userfoo:hitherepassword@foo.bar'),
         (u'//zounds.com', u'//zounds.com')
     ])
-    def test_it_returns_origin_from_uri_string(self, list_groups_service, document_uri):
-        result = list_groups_service._parse_origin(document_uri[0])
+    def test_it_returns_origin_from_uri_string(self, list_groups_service, document_uri, expected_origin):
+        result = list_groups_service._parse_origin(document_uri)
 
-        assert result == document_uri[1]
+        assert result == expected_origin
 
-    @pytest.mark.parametrize('document_uri', [
+    @pytest.mark.parametrize('document_uri,expected_origin', [
         (None, None),
         ('foobar', None)
     ])
-    def test_it_returns_none_for_none_or_invalid(self, list_groups_service, document_uri):
-        result = list_groups_service._parse_origin(document_uri[0])
+    def test_it_returns_none_for_none_or_invalid(self, list_groups_service, document_uri, expected_origin):
+        result = list_groups_service._parse_origin(document_uri)
 
-        assert result == document_uri[1]
+        assert result == expected_origin
 
 
 class TestListGroupsWorldGroup(object):

--- a/tests/h/services/list_groups_test.py
+++ b/tests/h/services/list_groups_test.py
@@ -86,7 +86,7 @@ class TestListGroupsPrivateGroups(object):
         user = factories.User()
         user.groups = [factories.Group(), factories.Group(), factories.Group()]
 
-        groups = list_groups_service.private_groups(user)
+        groups = list_groups_service._private_groups(user)
 
         assert len(groups) == 3
         for group in groups:
@@ -95,13 +95,13 @@ class TestListGroupsPrivateGroups(object):
     def test_returns_empty_when_user_no_private_groups(self, list_groups_service, factories):
         user = factories.User()
 
-        groups = list_groups_service.private_groups(user)
+        groups = list_groups_service._private_groups(user)
 
         assert groups == []
 
     def test_returns_no_groups_for_no_user(self, list_groups_service):
 
-        groups = list_groups_service.private_groups(user=None)
+        groups = list_groups_service._private_groups(user=None)
 
         assert groups == []
 
@@ -111,7 +111,7 @@ class TestListGroupsPrivateGroups(object):
                        factories.Group(name='alpha', pubid='aaaa', authority='z.com'),
                        factories.Group(name='aardvark', pubid='zoinks', authority='z.com')]
 
-        groups = list_groups_service.private_groups(user=user)
+        groups = list_groups_service._private_groups(user=user)
 
         assert [group.pubid for group in groups] == ['zoinks', 'aaaa', 'zzzz']
 
@@ -121,18 +121,18 @@ class TestListGroupsOpenGroups(object):
     def test_returns_authority_open_groups(self, list_groups_service, authority_open_groups):
         o_group_names = {o_group.name for o_group in authority_open_groups}
 
-        groups = list_groups_service.open_groups(authority='foo.com')
+        groups = list_groups_service._open_groups(authority='foo.com')
 
         assert {group.name for group in groups} == o_group_names
 
     def test_no_groups_from_mismatched_authority(self, list_groups_service, authority_open_groups):
 
-        groups = list_groups_service.open_groups(authority='bar.com')
+        groups = list_groups_service._open_groups(authority='bar.com')
 
         assert groups == []
 
     def test_returns_groups_from_default_authority(self, list_groups_service):
-        groups = list_groups_service.open_groups()
+        groups = list_groups_service._open_groups()
 
         assert groups[0].pubid == '__world__'
 
@@ -140,14 +140,14 @@ class TestListGroupsOpenGroups(object):
         user = factories.User(authority='foo.com')
         o_group_names = {o_group.name for o_group in authority_open_groups}
 
-        o_groups = list_groups_service.open_groups(user=user)
+        o_groups = list_groups_service._open_groups(user=user)
 
         assert {group.name for group in o_groups} == o_group_names
 
     def test_ignores_authority_if_user(self, list_groups_service, authority_open_groups, factories):
         user = factories.User(authority='somethingelse.com')
 
-        o_groups = list_groups_service.open_groups(user=user, authority='foo.com')
+        o_groups = list_groups_service._open_groups(user=user, authority='foo.com')
 
         assert o_groups == []
 
@@ -156,7 +156,7 @@ class TestListGroupsOpenGroups(object):
         factories.OpenGroup(name='alpha', pubid='aaaa', authority='z.com')
         factories.OpenGroup(name='aardvark', pubid='zoinks', authority='z.com')
 
-        groups = list_groups_service.open_groups(authority='z.com')
+        groups = list_groups_service._open_groups(authority='z.com')
 
         assert [group.pubid for group in groups] == ['zoinks', 'aaaa', 'zzzz']
 

--- a/tests/h/services/list_groups_test.py
+++ b/tests/h/services/list_groups_test.py
@@ -187,6 +187,19 @@ class TestListGroupsParseOrigin(object):
         assert result == document_uri[1]
 
 
+class TestListGroupsWorldGroup(object):
+
+    def test_it_returns_world_group_for_authority(self, list_groups_service, pyramid_request):
+        result = list_groups_service._world_group(pyramid_request.authority)
+
+        assert result.pubid == u'__world__'
+
+    def test_it_returns_world_group_for_authority_only(self, list_groups_service):
+        result = list_groups_service._world_group('dingdong')
+
+        assert result is None
+
+
 class TestListGroupsFactory(object):
 
     def test_list_groups_factory(self, pyramid_request):

--- a/tests/h/services/list_groups_test.py
+++ b/tests/h/services/list_groups_test.py
@@ -161,6 +161,32 @@ class TestListGroupsOpenGroups(object):
         assert [group.pubid for group in groups] == ['zoinks', 'aaaa', 'zzzz']
 
 
+class TestListGroupsParseOrigin(object):
+
+    @pytest.mark.parametrize('document_uri', [
+        (u'http://www.foo.bar:80/ding', u'http://www.foo.bar:80'),
+        (u'http://www.foo.bar:80/', u'http://www.foo.bar:80'),
+        (u'http://www.foo.bar:80/flop.html', u'http://www.foo.bar:80'),
+        (u'http://www.foo.bar:80/flop.html#fragment', u'http://www.foo.bar:80'),
+        (u'https://foo.bar/', u'https://foo.bar'),
+        (u'https://userfoo:hitherepassword@foo.bar/zowie/bang.pdf', u'https://userfoo:hitherepassword@foo.bar'),
+        (u'//zounds.com', u'//zounds.com')
+    ])
+    def test_it_returns_origin_from_uri_string(self, list_groups_service, document_uri):
+        result = list_groups_service._parse_origin(document_uri[0])
+
+        assert result == document_uri[1]
+
+    @pytest.mark.parametrize('document_uri', [
+        (None, None),
+        ('foobar', None)
+    ])
+    def test_it_returns_none_for_none_or_invalid(self, list_groups_service, document_uri):
+        result = list_groups_service._parse_origin(document_uri[0])
+
+        assert result == document_uri[1]
+
+
 class TestListGroupsFactory(object):
 
     def test_list_groups_factory(self, pyramid_request):


### PR DESCRIPTION
This PR puts a few supporting things in place in the `ListGroupsService` module to prepare for filtering groups by scope. It:

* adds an internal method for parsing origins from URI strings
* adds an internal method to retrieve the rarified world-Public group
* renames a couple of methods to mark them as internal-only to keep the notion of "type" from spreading out too far