### PR TITLE
Py 3 compat - Do not pass extra args to `object.__new__`

### DIFF
--- a/h/streamer/websocket.py
+++ b/h/streamer/websocket.py
@@ -65,7 +65,7 @@ class WebSocket(_WebSocket):
         self._work_queue = environ['h.ws.streamer_work_queue']
 
     def __new__(cls, *args, **kwargs):
-        instance = super(WebSocket, cls).__new__(cls, *args, **kwargs)
+        instance = super(WebSocket, cls).__new__(cls)
         cls.instances.add(instance)
         return instance
 

--- a/tests/py3-expected-failures.txt
+++ b/tests/py3-expected-failures.txt
@@ -1,7 +1,6 @@
 /h/h/db/types.py:88:
 /h/h/models/document.py:482:
 /h/h/search/config.py:190:
-/h/h/streamer/websocket.py:68:
 /h/h/util/uri.py:140:
 /h/tests/h/auth/util_test.py:69:
 /h/tests/h/cli/commands/annotation_id_test.py:11:


### PR DESCRIPTION
`WebSocket.__new__` receives all the arguments passed to the `WebSocket(...)` call to create the object, but `super(WebSocket, cls).__new__` calls `object.__new__` which only takes a single `cls` argument. In Python 3 passing extra args raises an exception.

See https://mail.python.org/pipermail/python-list/2016-March/704026.html