### PR TITLE
Fix Py 3 compat issues in h.search.config

### DIFF
--- a/h/search/config.py
+++ b/h/search/config.py
@@ -298,4 +298,4 @@ def _update_index_mappings(conn, name, mappings):
 
 def _random_id():
     """Generate a short random hex string."""
-    return binascii.hexlify(os.urandom(4))
+    return binascii.hexlify(os.urandom(4)).decode()

--- a/tests/h/search/config_test.py
+++ b/tests/h/search/config_test.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 
+from h._compat import url_quote_plus
+
 import itertools
 import re
-import urllib
 
 import mock
 import pytest
@@ -55,7 +56,7 @@ def test_uri_part_tokenizer():
         'http', '', '', 'a', 'b', 'foo', 'bar', 'c', 'd', 'stuff'
     ])
 
-    text = urllib.quote_plus(text)
+    text = url_quote_plus(text)
     assert(re.split(pattern, 'http://jump.to/?u=' + text) == [
         'http', '', '', 'jump', 'to', '', 'u',
         'http', '', '', 'a', 'b', 'foo', 'bar', 'c', 'd', 'stuff'

--- a/tests/py3-expected-failures.txt
+++ b/tests/py3-expected-failures.txt
@@ -1,5 +1,4 @@
 /h/h/models/document.py:482:
-/h/h/search/config.py:190:
 /h/tests/h/auth/util_test.py:69:
 /h/tests/h/jinja_extension_test.py:48:
 /h/tests/h/jinja_extension_test.py:55:
@@ -9,4 +8,3 @@
 /h/tests/h/schemas/base_test.py:64:
 /h/tests/h/schemas/base_test.py:70:
 /h/tests/h/schemas/base_test.py:79:
-/h/tests/h/search/config_test.py:58:


### PR DESCRIPTION
 - Make `_random_id` always return a `str` rather than `bytes` in Python 3.

 - Use compat import for `quote_plus`