### PR TITLE
Fix Python 3 compat issues with annotation ID conversion helpers

### DIFF
--- a/h/db/types.py
+++ b/h/db/types.py
@@ -140,9 +140,6 @@ def _get_urlsafe_from_hex(value):
     :rtype: unicode
     """
 
-    if not isinstance(value, string_types):
-        raise ValueError('`value` is {}, expected one of {}'.format(type(value), string_types))
-
     # Validate and normalise hex string
     hexstring = uuid.UUID(hex=value).hex
 

--- a/tests/py3-expected-failures.txt
+++ b/tests/py3-expected-failures.txt
@@ -1,11 +1,6 @@
-/h/h/db/types.py:88:
 /h/h/models/document.py:482:
 /h/h/search/config.py:190:
 /h/tests/h/auth/util_test.py:69:
-/h/tests/h/cli/commands/annotation_id_test.py:11:
-/h/tests/h/db/types_test.py:57:
-/h/tests/h/feeds/rss_test.py:93:
-/h/tests/h/feeds/util_test.py:17:
 /h/tests/h/jinja_extension_test.py:48:
 /h/tests/h/jinja_extension_test.py:55:
 /h/tests/h/jinja_extension_test.py:63:


### PR DESCRIPTION
Annotation IDs are stored as UUIDs in Postgres ("7b6d8026-51d8-40d0-86ef-46d72fb82bd7") but represented in the API in a "URL-safe base 64 encoded" form ("e22AJlHYQNCG70bXL7gr1w"). This PR fixes some Py 3 compatibility issues with the conversion functions:

 - `_get_urlsafe_from_hex` and `_get_hex_from_urlsafe` were returning
   `bytes` in Py 3 instead of Unicode strings as other code expected.

 - Generate a more helpful exception message if these functions are given
   the wrong type of input in Python 3.

 - Support the `binascii.Error` exception raised in Py 3 when input is
   not valid base 64.