### PR TITLE
Add scoped-group-filtering feature

### DIFF
--- a/h/models/feature.py
+++ b/h/models/feature.py
@@ -15,6 +15,8 @@ FEATURES = {
                           "using a cached version?"),
     'filter_highlights': ("Filter highlights in document based on visible"
                           " annotations in sidebar?"),
+    'filter_groups_by_scope': ("Only show open groups that match current authority and"
+                               " 'document_uri'? Non-scoped groups won't be returned"),
     'overlay_highlighter': "Use the new overlay highlighter?",
     'api_render_user_info': "Return users' extended info in API responses?",
     'client_display_names': "Render display names instead of user names in the client",

--- a/tests/h/services/list_groups_test.py
+++ b/tests/h/services/list_groups_test.py
@@ -10,381 +10,153 @@ from h.services.list_groups import list_groups_factory
 
 class TestListGroupsAllGroups(object):
 
-    def test_returns_open_groups_when_no_user(self, list_groups_service, open_groups):
-        open_group_pubids = {group.pubid for group in open_groups}
-        open_group_pubids.add('__world__')
+    def test_returns_world_group_if_no_user(self, svc):
+        results = svc.all_groups()
 
-        groups = list_groups_service.all_groups()
+        assert u'__world__' in [group.pubid for group in results]
 
-        assert {group.pubid for group in groups} == open_group_pubids
-        for group in groups:
-            assert group.is_public
-
-    def test_returns_scoped_open_groups_when_no_user(self, list_groups_service, scoped_group_builder):
-        scoped_group = scoped_group_builder('http://foo.com', authority='zow.com')
-
-        groups = list_groups_service.all_groups(authority='zow.com')
-
-        assert scoped_group in groups
-
-    def test_returns_all_group_types_when_user(self, list_groups_service, factories):
-        user = factories.User()
-        user.groups = [factories.Group(), factories.Group()]
-        expected_pubids = [group.pubid for group in user.groups]
-        expected_pubids.append('__world__')
-
-        groups = list_groups_service.all_groups(user=user)
-
-        group_pubids = [group.pubid for group in groups]
-        for expected_id in expected_pubids:
-            assert expected_id in group_pubids
-
-    def test_returns_scoped_open_groups_when_user(self, list_groups_service, factories, scoped_group_builder):
-        user = factories.User(authority='zow.com')
-        scoped_group = scoped_group_builder('http://foo.com', authority='zow.com')
-
-        # scoped groups returned even when no URI/origin match
-        groups = list_groups_service.all_groups(user=user)
-
-        assert scoped_group in groups
-
-    def test_ignores_authority_when_user_present(self, list_groups_service, factories, authority_open_groups):
-        user = factories.User(authority='foo.com')
-        another_authority_open_group = factories.OpenGroup(authority='somewhere-else.com')
-        auth_group_ids = {group.id for group in authority_open_groups}
-
-        groups = list_groups_service.all_groups(user=user, authority='somewhere-else.com')
-
-        group_ids = {group.id for group in groups}
-        assert group_ids == auth_group_ids
-        assert another_authority_open_group.pubid not in group_ids
-
-    def test_groups_are_sorted(self, list_groups_service, factories):
-        user = factories.User(authority='z.com')
-        user.groups = [factories.Group(name='alpha', pubid='zzzz', authority='z.com'),
-                       factories.Group(name='alpha', pubid='aaaa', authority='z.com'),
-                       factories.Group(name='aardvark', pubid='zoinks', authority='z.com')]
-        factories.OpenGroup(name='alpha', pubid='zaza', authority='z.com')
-        factories.OpenGroup(name='alpha', pubid='azaz', authority='z.com')
-
-        groups = list_groups_service.all_groups(user=user)
-
-        # open groups first
-        assert [group.pubid for group in groups] == ['azaz', 'zaza', 'zoinks', 'aaaa', 'zzzz']
-
-    def test_groups_are_sorted_alphabetically(self, list_groups_service, factories):
-        user = factories.User(authority='z.com')
-        user.groups = [factories.Group(name='Lilac', authority='z.com'),
-                       factories.Group(name='foobar', authority='z.com')]
-
-        groups = list_groups_service.all_groups(user=user)
-
-        assert [group.name for group in groups] == ['foobar', 'Lilac']
-
-    def test_user_groups_not_mutated(self, list_groups_service, factories):
-        user = factories.User(authority='z.com')
-        user.groups = [factories.Group(name='Lilac', authority='z.com'),
-                       factories.Group(name='Alpha', authority='z.com'),
-                       factories.Group(name='foobar', authority='z.com')]
-
-        list_groups_service.all_groups(user=user)
-
-        assert [group.name for group in user.groups] == ['Lilac', 'Alpha', 'foobar']
-
-    @pytest.fixture
-    def open_groups(self, factories):
-        return [factories.OpenGroup(), factories.OpenGroup()]
-
-
-class TestListGroupsRequestGroups(object):
-
-    def test_returns_scoped_open_groups_no_user(self, authority, document_uri, scoped_open_groups, list_groups_service):
-        results = list_groups_service.request_groups(authority=authority,
-                                                     document_uri=document_uri)
-        assert results == scoped_open_groups
-
-    def test_returns_no_unscoped_groups_no_user(self, authority, document_uri, scoped_open_groups, unscoped_open_groups, list_groups_service):
-        results = list_groups_service.request_groups(authority=authority,
-                                                     document_uri=document_uri)
+    def test_returns_scoped_open_groups_if_no_user(self, svc, authority, scoped_open_groups):
+        results = svc.all_groups(authority=authority)
 
         assert results == scoped_open_groups
-        for unscoped_group in unscoped_open_groups:
-            assert unscoped_group not in results
 
-    def test_returns_world_group_no_user_no_uri(self, default_authority, list_groups_service):
-        results = list_groups_service.request_groups(authority=default_authority)
+    def test_returns_unscoped_open_groups_if_no_user(self, svc, authority, unscoped_open_groups):
+        results = svc.all_groups(authority=authority)
 
-        assert results[0].pubid == '__world__'
+        assert results == unscoped_open_groups
 
-    def test_returns_no_private_groups_no_user(self, default_authority, document_uri,  scoped_open_groups, unscoped_open_groups, list_groups_service):
-        results = list_groups_service.request_groups(authority=default_authority, document_uri=document_uri)
+    def test_returns_all_open_groups_if_no_user(self, svc, authority, scoped_open_groups, unscoped_open_groups):
+        results = svc.all_groups(authority=authority)
+
+        for s_group in scoped_open_groups:
+            assert s_group in results
+        for u_group in unscoped_open_groups:
+            assert u_group in results
+
+    def test_returns_only_open_groups_if_no_user(self, svc, authority, scoped_open_groups, unscoped_open_groups):
+        results = svc.all_groups(authority=authority)
 
         for group in results:
             assert group.type == 'open'
 
-    def test_returns_groups_sorted_no_user(self, default_authority, document_uri, origin, scoped_group_builder, list_groups_service):
-        scoped_group = scoped_group_builder(origin=origin, authority=default_authority)
+    def test_returns_world_group_if_user(self, svc, default_user):
+        results = svc.all_groups(user=default_user)
 
-        results = list_groups_service.request_groups(authority=default_authority, document_uri=document_uri)
+        assert u'__world__' in [group.pubid for group in results]
 
-        assert results[0] == scoped_group
-        assert results[1].pubid == '__world__'
-
-    def test_returns_scoped_open_groups_with_user(self, document_uri, user, scoped_open_groups, list_groups_service):
-        results = list_groups_service.request_groups(user=user, authority=user.authority, document_uri=document_uri)
+    def test_returns_scoped_open_groups_if_user(self, svc, user, scoped_open_groups):
+        results = svc.all_groups(user=user)
 
         assert results == scoped_open_groups
 
-    def test_returns_no_unscoped_groups_with_user(self, document_uri, user, scoped_open_groups, unscoped_open_groups, list_groups_service):
-        results = list_groups_service.request_groups(user=user, authority=user.authority, document_uri=document_uri)
+    def test_returns_unscoped_open_groups_if_user(self, svc, user, unscoped_open_groups):
+        results = svc.all_groups(user=user)
 
-        for group in unscoped_open_groups:
-            assert group not in results
+        assert results == unscoped_open_groups
 
-    def test_returns_world_group_with_user(self, factories, list_groups_service):
-        user = factories.User()
-        results = list_groups_service.request_groups(user=user, authority=user.authority)
+    def test_returns_all_open_groups_if_user(self, svc, user, scoped_open_groups, unscoped_open_groups):
+        expected_ids = {group.id for group in (scoped_open_groups + unscoped_open_groups)}
 
-        assert results[0].pubid == '__world__'
+        results = svc.all_groups(user=user)
+        actual_ids = {group.id for group in results}
 
-    def test_returns_private_groups_with_user(self, factories, scoped_open_groups, unscoped_open_groups, list_groups_service):
-        user = factories.User()
-        user.groups = [factories.Group(), factories.Group()]
+        assert actual_ids == expected_ids
 
-        results = list_groups_service.request_groups(user=user, authority=user.authority)
+    def test_returns_private_groups_if_user(self, svc, user, private_groups):
+        user.groups = private_groups
 
-        for group in user.groups:
-            assert group in results
+        results = svc.all_groups(user=user)
 
-    def test_returns_groups_sorted_with_user(self, document_uri, factories, origin, scoped_group_builder, list_groups_service):
-        user = factories.User()
-        user.groups = [factories.Group()]
-        scoped_open_group = scoped_group_builder(origin, authority=user.authority)
-        unscoped_open_group = factories.OpenGroup(authority=user.authority)
+        assert results == private_groups
 
-        results = list_groups_service.request_groups(user=user, authority=user.authority, document_uri=document_uri)
+    def test_returns_open_and_private_groups_if_user(self, svc, user, scoped_open_groups, unscoped_open_groups, private_groups):
+        user.groups = private_groups
+        expected_ids = {group.id for group in (scoped_open_groups + unscoped_open_groups + private_groups)}
 
-        assert results[0] == scoped_open_group
-        assert unscoped_open_group not in results
-        assert results[1].pubid == '__world__'
-        assert results[2] == user.groups[0]
+        results = svc.all_groups(user=user)
+        actual_ids = {group.id for group in results}
 
-    @pytest.fixture
-    def origin(self):
-        return 'http://www.zow.com'
+        assert actual_ids == expected_ids
 
-    @pytest.fixture
-    def authority(self):
-        return 'zow.com'
+    def test_returns_groups_matching_authority_if_no_user(self, svc, alternate_authority, alternate_unscoped_open_groups, unscoped_open_groups):
+        results = svc.all_groups(authority=alternate_authority)
 
-    @pytest.fixture
-    def scoped_open_groups(self, scoped_group_builder, origin, authority):
-        return [
-            scoped_group_builder(origin, authority=authority),
-            scoped_group_builder(origin, authority=authority)
-        ]
+        assert results == alternate_unscoped_open_groups
 
-    @pytest.fixture
-    def unscoped_open_groups(self, factories, authority):
-        return [
-            factories.OpenGroup(authority=authority),
-            factories.OpenGroup(authority=authority)
-        ]
+    def test_returns_groups_for_user_authority(self, svc, user, unscoped_open_groups):
+        expected_ids = {group.id for group in unscoped_open_groups}
 
-    @pytest.fixture
-    def default_authority(self, pyramid_request):
-        # __world__ group exists on the default authority
-        return pyramid_request.authority
+        results = svc.all_groups(user=user)
 
-    @pytest.fixture
-    def user(self, factories, authority):
-        return factories.User(authority=authority)
+        actual_ids = {group.id for group in results}
+        assert actual_ids == expected_ids
 
-    @pytest.fixture
-    def document_uri(self):
-        return 'http://www.zow.com/foo/bar/baz.html'
+    def test_overrides_authority_param_if_user(self, svc, user, alternate_authority, alternate_unscoped_open_groups, unscoped_open_groups):
+        # User has a different authority than authority param
+        expected_ids = {group.id for group in unscoped_open_groups}
 
+        results = svc.all_groups(user=user, authority=alternate_authority)
 
-class TestListGroupsPrivateGroups(object):
+        actual_ids = {group.id for group in results}
+        assert actual_ids == expected_ids
 
-    def test_returns_private_groups_only(self, list_groups_service, factories):
-        user = factories.User()
-        user.groups = [factories.Group(), factories.Group(), factories.Group()]
+    def test_sorts_groups_by_type(self, svc, user, mixed_groups):
+        expected_sorted_types = ['open', 'open', 'open', 'open', 'private', 'private']
+        results = svc.all_groups(user=user)
 
-        groups = list_groups_service._private_groups(user)
+        assert [group.type for group in results] == expected_sorted_types
 
-        assert len(groups) == 3
-        for group in groups:
-            assert not group.is_public
+    def test_sorts_groups_alphabetically(self, svc, user, mixed_groups):
+        expected_sorted_pubids = ['wadsworth', 'xander', 'yaks', 'zebra', 'spectacle', 'yams']
+        results = svc.all_groups(user=user)
 
-    def test_returns_empty_when_user_no_private_groups(self, list_groups_service, factories):
-        user = factories.User()
+        assert [group.pubid for group in results] == expected_sorted_pubids
 
-        groups = list_groups_service._private_groups(user)
 
-        assert groups == []
+class TestListGroupsRequestGroups(object):
 
-    def test_returns_no_groups_for_no_user(self, list_groups_service):
+    def test_it_returns_world_group(self, svc, default_authority):
+        results = svc.request_groups(authority=default_authority)
 
-        groups = list_groups_service._private_groups(user=None)
+        assert results[0].pubid == u'__world__'
 
-        assert groups == []
+    def test_it_returns_matching_scoped_open_groups(self, svc, authority, document_uri, scoped_open_groups):
+        results = svc.request_groups(authority=authority, document_uri=document_uri)
 
-    def test_groups_are_sorted(self, list_groups_service, factories):
-        user = factories.User(authority='z.com')
-        user.groups = [factories.Group(name='alpha', pubid='zzzz', authority='z.com'),
-                       factories.Group(name='alpha', pubid='aaaa', authority='z.com'),
-                       factories.Group(name='aardvark', pubid='zoinks', authority='z.com')]
+        assert results == scoped_open_groups
 
-        groups = list_groups_service._private_groups(user=user)
-
-        assert [group.pubid for group in groups] == ['zoinks', 'aaaa', 'zzzz']
-
-
-class TestListGroupsOpenGroups(object):
-
-    def test_returns_authority_open_groups(self, list_groups_service, authority_open_groups):
-        o_group_names = {o_group.name for o_group in authority_open_groups}
-
-        groups = list_groups_service._open_groups(authority='foo.com')
-
-        assert {group.name for group in groups} == o_group_names
-
-    def test_no_groups_from_mismatched_authority(self, list_groups_service, authority_open_groups):
-
-        groups = list_groups_service._open_groups(authority='bar.com')
-
-        assert groups == []
-
-    def test_returns_groups_with_scope(self, list_groups_service, factories):
-        # Temporary: test that service returns scoped open groups even with no
-        # document_uri
-        group_scope = factories.GroupScope.build(group=None, origin='www.foo.bar')
-        group = factories.OpenGroup(scopes=[group_scope], authority='ding.com')
-
-        groups = list_groups_service._open_groups(authority='ding.com')
-
-        assert group in groups
-
-    def test_returns_groups_from_default_authority(self, list_groups_service):
-        groups = list_groups_service._open_groups()
-
-        assert groups[0].pubid == '__world__'
-
-    def test_returns_groups_for_user_authority(self, list_groups_service, authority_open_groups, factories):
-        user = factories.User(authority='foo.com')
-        o_group_names = {o_group.name for o_group in authority_open_groups}
-
-        o_groups = list_groups_service._open_groups(user=user)
-
-        assert {group.name for group in o_groups} == o_group_names
-
-    def test_ignores_authority_if_user(self, list_groups_service, authority_open_groups, factories):
-        user = factories.User(authority='somethingelse.com')
-
-        o_groups = list_groups_service._open_groups(user=user, authority='foo.com')
-
-        assert o_groups == []
-
-    def test_groups_are_sorted(self, list_groups_service, factories):
-        factories.OpenGroup(name='alpha', pubid='zzzz', authority='z.com')
-        factories.OpenGroup(name='alpha', pubid='aaaa', authority='z.com')
-        factories.OpenGroup(name='aardvark', pubid='zoinks', authority='z.com')
-
-        groups = list_groups_service._open_groups(authority='z.com')
-
-        assert [group.pubid for group in groups] == ['zoinks', 'aaaa', 'zzzz']
-
-
-class TestListGroupsScopedOpenGroups(object):
-
-    def test_it_returns_scoped_groups_for_authority(self, list_groups_service, scoped_group_builder, factories):
-        scoped_group = scoped_group_builder('http://www.zow.com', authority='zow.com')
-        unscoped_group = factories.OpenGroup(authority='zow.com')
-
-        results = list_groups_service._scoped_open_groups('zow.com', 'http://www.zow.com')
-
-        assert scoped_group in results
-        assert unscoped_group not in results
-
-    def test_it_sorts_scoped_groups(self, list_groups_service, scoped_group_builder):
-        scoped_group_builder('http://www.zow.com', name='aaaa', pubid='zzzz', authority='zow.com')
-        scoped_group_builder('http://www.zow.com', name='AAAA', pubid='bbbb', authority='zow.com')
-        scoped_group_builder('http://www.zow.com', name='aaaa', pubid='aaaa', authority='zow.com')
-
-        results = list_groups_service._scoped_open_groups('zow.com', 'http://www.zow.com')
-
-        pubids = [group.pubid for group in results]
-        assert pubids == ['aaaa', 'bbbb', 'zzzz']
-
-    def test_it_returns_only_groups_matching_authority(self, list_groups_service, scoped_group_builder):
-        auth_scoped_group = scoped_group_builder('http://www.zow.com', name='Authority', authority='zow.com')
-        other_scoped_group = scoped_group_builder('http://www.zow.com', name='Not Authority', authority='yow.com')
-
-        results = list_groups_service._scoped_open_groups('zow.com', 'http://www.zow.com')
-
-        assert auth_scoped_group in results
-        assert other_scoped_group not in results
-
-    def test_it_returns_scoped_groups_for_uri(self, list_groups_service, scoped_group_builder):
-        scoped_group = scoped_group_builder('http://www.zow.com', authority='zow.com')
-
-        results = list_groups_service._scoped_open_groups('zow.com', 'http://www.zow.com/foo/bar/baz.html')
-
-        assert scoped_group in results
-
-    def test_group_scope_must_match_origin(self, list_groups_service, scoped_group_builder):
-        scoped_group = scoped_group_builder('http://www.zow.com', authority='zow.com')
-
-        results = list_groups_service._scoped_open_groups('zow.com', 'http://zow.com/')
-
-        assert scoped_group not in results
-
-    def test_it_returns_empty_on_bad_uri(self, list_groups_service, factories):
-        factories.OpenGroup(authority='zow.com')
-
-        results = list_groups_service._scoped_open_groups('zow.com', 'bogus_uri')
+    def test_it_returns_no_scoped_groups_if_uri_missing(self, svc, authority, scoped_open_groups):
+        results = svc.request_groups(authority=authority)
 
         assert results == []
 
+    def test_it_returns_no_unscoped_open_groups(self, svc, authority, scoped_open_groups, unscoped_open_groups):
+        results = svc.request_groups(authority=authority)
 
-class TestListGroupsParseOrigin(object):
+        assert results == []
 
-    @pytest.mark.parametrize('document_uri,expected_origin', [
-        (u'http://www.foo.bar:80/ding', u'http://www.foo.bar:80'),
-        (u'http://www.foo.bar:80/', u'http://www.foo.bar:80'),
-        (u'http://www.foo.bar:80/flop.html', u'http://www.foo.bar:80'),
-        (u'http://www.foo.bar:80/flop.html#fragment', u'http://www.foo.bar:80'),
-        (u'https://foo.bar/', u'https://foo.bar'),
-        (u'https://userfoo:hitherepassword@foo.bar/zowie/bang.pdf', u'https://userfoo:hitherepassword@foo.bar'),
-        (u'//zounds.com', u'//zounds.com')
-    ])
-    def test_it_returns_origin_from_uri_string(self, list_groups_service, document_uri, expected_origin):
-        result = list_groups_service._parse_origin(document_uri)
+    def test_it_returns_private_groups_if_user(self, svc, user, authority, private_groups):
+        user.groups = private_groups
+        results = svc.request_groups(user=user, authority=authority)
 
-        assert result == expected_origin
+        assert results == private_groups
 
-    @pytest.mark.parametrize('document_uri,expected_origin', [
-        (None, None),
-        ('foobar', None)
-    ])
-    def test_it_returns_none_for_none_or_invalid(self, list_groups_service, document_uri, expected_origin):
-        result = list_groups_service._parse_origin(document_uri)
+    def test_returned_open_groups_must_match_authority(self, svc, alternate_authority, unscoped_open_groups, scoped_open_groups):
+        results = svc.request_groups(authority=alternate_authority)
 
-        assert result == expected_origin
+        assert results == []
 
+    def test_groups_are_sorted_by_type(self, svc, user, mixed_groups, authority, document_uri):
+        expected_sorted_types = ['open', 'open', 'private', 'private']
+        results = svc.request_groups(user=user, authority=authority, document_uri=document_uri)
 
-class TestListGroupsWorldGroup(object):
+        assert [group.type for group in results] == expected_sorted_types
 
-    def test_it_returns_world_group_for_authority(self, list_groups_service, pyramid_request):
-        result = list_groups_service._world_group(pyramid_request.authority)
+    def test_groups_are_sorted_alphabetically(self, svc, user, mixed_groups, authority, document_uri):
+        expected_sorted_pubids = ['wadsworth', 'yaks', 'spectacle', 'yams']
+        results = svc.request_groups(user=user, authority=authority, document_uri=document_uri)
 
-        assert result.pubid == u'__world__'
-
-    def test_it_returns_world_group_for_authority_only(self, list_groups_service):
-        result = list_groups_service._world_group('dingdong')
-
-        assert result is None
+        assert [group.pubid for group in results] == expected_sorted_pubids
 
 
 class TestListGroupsFactory(object):
@@ -403,35 +175,113 @@ class TestListGroupsFactory(object):
 
 
 @pytest.fixture
-def authority_open_groups(factories):
-    return [factories.OpenGroup(authority='foo.com'),
-            factories.OpenGroup(authority='foo.com')]
+def authority():
+    """Return a consistent, different authority for groups in these tests"""
+    return 'surreptitious.com'
 
 
 @pytest.fixture
-def pyramid_request(pyramid_request):
-    return pyramid_request
+def default_authority(pyramid_request):
+    """
+    Return the test env request's default authority, i.e. 'example.com'
+
+    Return the default authority—this automatically has a `__world__` group
+    """
+    return pyramid_request.authority
 
 
 @pytest.fixture
-def list_groups_service(pyramid_request, db_session):
+def alternate_authority():
+    return 'bar.com'
+
+
+@pytest.fixture
+def default_user(factories, default_authority):
+    return factories.User(authority=default_authority)
+
+
+@pytest.fixture
+def user(factories, authority):
+    return factories.User(authority=authority)
+
+
+@pytest.fixture
+def alternate_user(factories, alternate_authority):
+    return factories.User(authority=alternate_authority)
+
+
+@pytest.fixture
+def origin():
+    return 'http://foo.com'
+
+
+@pytest.fixture
+def document_uri():
+    return 'http://foo.com/bar/fun.html'
+
+
+@pytest.fixture
+def scoped_open_groups(factories, authority, origin):
+    return [
+        factories.OpenGroup(authority=authority,
+                            scopes=[factories.GroupScope(origin=origin)]),
+        factories.OpenGroup(authority=authority,
+                            scopes=[factories.GroupScope(origin=origin)])
+    ]
+
+
+@pytest.fixture
+def unscoped_open_groups(factories, authority):
+    return [
+        factories.OpenGroup(authority=authority),
+        factories.OpenGroup(authority=authority)
+    ]
+
+
+@pytest.fixture
+def alternate_unscoped_open_groups(factories, alternate_authority):
+    return [
+        factories.OpenGroup(authority=alternate_authority),
+        factories.OpenGroup(authority=alternate_authority)
+    ]
+
+
+@pytest.fixture
+def private_groups(factories, authority):
+    return [
+        factories.Group(authority=authority),
+        factories.Group(authority=authority)
+    ]
+
+
+@pytest.fixture
+def mixed_groups(factories, user, authority, origin):
+    """Return a list of open groups with different names and scope/not scoped"""
+    user.groups = [
+        factories.Group(name='Yams', pubid='yams', authority=authority),
+        factories.Group(name='Spectacle', pubid='spectacle', authority=authority)
+    ]
+    return [
+        factories.OpenGroup(name='Zebra',
+                            pubid='zebra',
+                            authority=authority),
+        factories.OpenGroup(name='Yaks',
+                            pubid='yaks',
+                            authority=authority,
+                            scopes=[factories.GroupScope(origin=origin)]),
+        factories.OpenGroup(name='Xander',
+                            pubid='xander',
+                            authority=authority),
+        factories.OpenGroup(name='wadsworth',
+                            pubid='wadsworth',
+                            authority=authority,
+                            scopes=[factories.GroupScope(origin=origin)])
+    ]
+
+
+@pytest.fixture
+def svc(pyramid_request, db_session):
     return ListGroupsService(
         session=db_session,
         request_authority=pyramid_request.authority
     )
-
-
-@pytest.fixture
-def scope_factory(factories):
-    def scope_builder(origin, group=None):
-        return factories.GroupScope.build(origin=origin, group=group)
-    return scope_builder
-
-
-@pytest.fixture
-def scoped_group_builder(factories, scope_factory):
-    def group_builder(origin, **kwargs):
-        scope = scope_factory(origin, group=None)
-        group = factories.OpenGroup(scopes=[scope], **kwargs)
-        return group
-    return group_builder

--- a/tests/h/views/api_groups_test.py
+++ b/tests/h/views/api_groups_test.py
@@ -25,23 +25,14 @@ class TestGroupsWithScope(object):
             document_uri=None
         )
 
-    def test_proxies_authority_param(self, anonymous_request, list_groups_service):
+    def test_proxies_request_params(self, anonymous_request, list_groups_service):
+        anonymous_request.params['document_uri'] = 'http://example.com/thisthing.html'
         anonymous_request.params['authority'] = 'foo.com'
         views.groups(anonymous_request)
 
         list_groups_service.request_groups.assert_called_once_with(
             user=None,
             authority='foo.com',
-            document_uri=None
-        )
-
-    def test_proxies_document_uri_param(self, anonymous_request, list_groups_service):
-        anonymous_request.params['document_uri'] = 'http://example.com/thisthing.html'
-        views.groups(anonymous_request)
-
-        list_groups_service.request_groups.assert_called_once_with(
-            user=None,
-            authority=anonymous_request.authority,
             document_uri='http://example.com/thisthing.html'
         )
 

--- a/tests/h/views/api_groups_test.py
+++ b/tests/h/views/api_groups_test.py
@@ -14,9 +14,69 @@ from h.services.group import GroupService
 pytestmark = pytest.mark.usefixtures('GroupsJSONPresenter')
 
 
+class TestGroupsWithScope(object):
+
+    def test_proxies_to_service(self, anonymous_request, list_groups_service):
+        views.groups(anonymous_request)
+
+        list_groups_service.request_groups.assert_called_once_with(
+            user=None,
+            authority=anonymous_request.authority,
+            document_uri=None
+        )
+
+    def test_proxies_authority_param(self, anonymous_request, list_groups_service):
+        anonymous_request.params['authority'] = 'foo.com'
+        views.groups(anonymous_request)
+
+        list_groups_service.request_groups.assert_called_once_with(
+            user=None,
+            authority='foo.com',
+            document_uri=None
+        )
+
+    def test_proxies_document_uri_param(self, anonymous_request, list_groups_service):
+        anonymous_request.params['document_uri'] = 'http://example.com/thisthing.html'
+        views.groups(anonymous_request)
+
+        list_groups_service.request_groups.assert_called_once_with(
+            user=None,
+            authority=anonymous_request.authority,
+            document_uri='http://example.com/thisthing.html'
+        )
+
+    def test_overrides_authority_with_user_authority(self, authenticated_request, list_groups_service):
+        authenticated_request.params['authority'] = 'foo.com'
+
+        views.groups(authenticated_request)
+
+        list_groups_service.request_groups.assert_called_once_with(
+            user=authenticated_request.user,
+            authority=authenticated_request.user.authority,
+            document_uri=None
+        )
+
+    @pytest.fixture
+    def list_groups_service(self, pyramid_config):
+        svc = mock.create_autospec(ListGroupsService, spec_set=True, instance=True)
+        pyramid_config.register_service(svc, name='list_groups')
+        return svc
+
+    @pytest.fixture
+    def anonymous_request(self, pyramid_request):
+        pyramid_request.user = None
+        return pyramid_request
+
+    @pytest.fixture
+    def authenticated_request(self, pyramid_request, factories):
+        pyramid_request.user = factories.User()
+        return pyramid_request
+
+
+@pytest.mark.usefixtures('scope_feature_off')
 class TestGroups(object):
 
-    def test_all_groups_proxies_to_service(self, anonymous_request, list_groups_service):
+    def test_proxies_to_service(self, anonymous_request, list_groups_service):
         views.groups(anonymous_request)
 
         list_groups_service.all_groups.assert_called_once_with(
@@ -25,7 +85,7 @@ class TestGroups(object):
             document_uri=None
         )
 
-    def test_all_groups_proxies_authority_param(self, anonymous_request, list_groups_service):
+    def test_proxies_authority_param(self, anonymous_request, list_groups_service):
         anonymous_request.params['authority'] = 'foo.com'
         views.groups(anonymous_request)
 
@@ -35,7 +95,7 @@ class TestGroups(object):
             document_uri=None
         )
 
-    def test_all_groups_proxies_document_uri_param(self, anonymous_request, list_groups_service):
+    def test_proxies_document_uri_param(self, anonymous_request, list_groups_service):
         anonymous_request.params['document_uri'] = 'http://example.com/thisthing.html'
         views.groups(anonymous_request)
 
@@ -124,3 +184,8 @@ class TestRemoveMember(object):
 @pytest.fixture
 def GroupsJSONPresenter(patch):  # noqa: N802
     return patch('h.views.api_groups.GroupsJSONPresenter')
+
+
+@pytest.fixture
+def scope_feature_off(pyramid_request):
+    pyramid_request.feature.flags['filter_groups_by_scope'] = False


### PR DESCRIPTION
This PR introduces the ability to filter open groups by `origin` (a.k.a _scope_ or _domain_) via the `GET /api/groups` API endpoint. This feature is behind a feature flag. For now, `GET /api/profile` continues to return all open groups, unfiltered.

When the feature is enabled, `GET /groups` will only return open groups whose scope(s) match the origin of the `document_uri` parameter passed to the API service. More nuanced requirements are itemized here: https://github.com/hypothesis/product-backlog/issues/461

To support this:

* A feature flag is added
* A `_scoped_open_groups` method is added to the `ListGroupsService` to support this kind of filtering
* `ListGroupsService` now has two public methods: `all_groups` (open groups are not filtered) and `request_groups` (open groups are filtered)
* When feature flag enabled, the `api_groups` view will use `request_groups` instead of `all_groups`
* So very many tests
