### PR TITLE
Add group JSON presentation service

### DIFF
--- a/h/presenters/group_json.py
+++ b/h/presenters/group_json.py
@@ -6,9 +6,9 @@ from __future__ import unicode_literals
 class GroupJSONPresenter(object):
     """Present a group in the JSON format returned by API requests."""
 
-    def __init__(self, group, route_url=None):
+    def __init__(self, group, link_svc=None):
         self.group = group
-        self._route_url = route_url
+        self._link_svc = link_svc
 
     def asdict(self):
         return self._model(self.group)
@@ -22,26 +22,27 @@ class GroupJSONPresenter(object):
           'type': 'open' if group.is_public else 'private'  # TODO
         }
         model = self._inject_urls(group, model)
+
+        if 'group' in model['urls']:
+            model['url'] = model['urls']['group']
+
         return model
 
     def _inject_urls(self, group, model):
-        model['urls'] = {}
-        if not self._route_url:
+        if not self._link_svc:
+            model['urls'] = {}
             return model
-
-        model['url'] = self._route_url('group_read',
-                                       pubid=group.pubid,
-                                       slug=group.slug)
-        model['urls']['group'] = model['url']
+        links = self._link_svc(group)
+        model['urls'] = links or {}
         return model
 
 
 class GroupsJSONPresenter(object):
     """Present a list of groups as JSON"""
 
-    def __init__(self, groups, route_url=None):
+    def __init__(self, groups, link_svc=None):
         self.groups = groups
-        self._route_url = route_url
+        self._link_svc = link_svc
 
     def asdicts(self):
-        return [GroupJSONPresenter(group, self._route_url).asdict() for group in self.groups]
+        return [GroupJSONPresenter(group, self._link_svc).asdict() for group in self.groups]

--- a/h/services/__init__.py
+++ b/h/services/__init__.py
@@ -20,6 +20,7 @@ def includeme(config):
     config.register_service_factory('.flag_count.flag_count_service_factory', name='flag_count')
     config.register_service_factory('.group.groups_factory', name='group')
     config.register_service_factory('.groupfinder.groupfinder_service_factory', iface='h.interfaces.IGroupService')
+    config.register_service_factory('.group_json_presentation.group_json_presentation_service_factory', name='group_json_presentation')
     config.register_service_factory('.links.links_factory', name='links')
     config.register_service_factory('.list_groups.list_groups_factory', name='list_groups')
     config.register_service_factory('.nipsa.nipsa_factory', name='nipsa')

--- a/h/services/group_json_presentation.py
+++ b/h/services/group_json_presentation.py
@@ -21,9 +21,10 @@ class GroupJSONPresentationService(object):
 
     def get_links(self, group):
         links = {}
-        links['group'] = self._route_url('group_read',
-                                         pubid=group.pubid,
-                                         slug=group.slug)
+        if group.authority == self._request_authority:
+            links['group'] = self._route_url('group_read',
+                                             pubid=group.pubid,
+                                             slug=group.slug)
         return links
 
 

--- a/h/services/group_json_presentation.py
+++ b/h/services/group_json_presentation.py
@@ -12,12 +12,19 @@ class GroupJSONPresentationService(object):
         self._route_url = route_url
 
     def present(self, group):
-        presenter = GroupJSONPresenter(group, self._route_url)
+        presenter = GroupJSONPresenter(group, self.get_links)
         return presenter.asdict()
 
     def present_all(self, groups):
-        presenter = GroupsJSONPresenter(groups, self._route_url)
+        presenter = GroupsJSONPresenter(groups, self.get_links)
         return presenter.asdicts()
+
+    def get_links(self, group):
+        links = {}
+        links['group'] = self._route_url('group_read',
+                                         pubid=group.pubid,
+                                         slug=group.slug)
+        return links
 
 
 def group_json_presentation_service_factory(context, request):

--- a/h/services/group_json_presentation.py
+++ b/h/services/group_json_presentation.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from h.presenters.group_json import GroupJSONPresenter, GroupsJSONPresenter
+
+
+class GroupJSONPresentationService(object):
+    def __init__(self, session, request_authority, route_url):
+        self._session = session
+        self._request_authority = request_authority
+        self._route_url = route_url
+
+    def present(self, group):
+        presenter = GroupJSONPresenter(group, self._route_url)
+        return presenter.asdict()
+
+    def present_all(self, groups):
+        presenter = GroupsJSONPresenter(groups, self._route_url)
+        return presenter.asdicts()
+
+
+def group_json_presentation_service_factory(context, request):
+    return GroupJSONPresentationService(session=request.db,
+                                        request_authority=request.authority,
+                                        route_url=request.route_url)

--- a/h/views/api_groups.py
+++ b/h/views/api_groups.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 
 from pyramid import security
 from pyramid.httpexceptions import HTTPNoContent, HTTPBadRequest
-from h.presenters import GroupsJSONPresenter
 from h.views.api import api_config
 
 
@@ -15,7 +14,8 @@ from h.views.api import api_config
 def groups(request):
     authority = request.params.get('authority')
     document_uri = request.params.get('document_uri')
-    svc = request.find_service(name='list_groups')
+    list_svc = request.find_service(name='list_groups')
+    presentation_svc = request.find_service(name='group_json_presentation')
 
     if request.feature('filter_groups_by_scope'):
         # Filter open groups by scope against the ``document_uri`` param.
@@ -26,15 +26,14 @@ def groups(request):
             authority = request.user.authority
         else:
             authority = authority or request.authority
-        all_groups = svc.request_groups(user=request.user,
-                                        authority=authority,
-                                        document_uri=document_uri)
+        all_groups = list_svc.request_groups(user=request.user,
+                                             authority=authority,
+                                             document_uri=document_uri)
     else:
-        all_groups = svc.all_groups(user=request.user,
-                                    authority=authority,
-                                    document_uri=document_uri)
-    all_groups = GroupsJSONPresenter(all_groups, request.route_url).asdicts()
-    return all_groups
+        all_groups = list_svc.all_groups(user=request.user,
+                                         authority=authority,
+                                         document_uri=document_uri)
+    return presentation_svc.present_all(all_groups)
 
 
 @api_config(route_name='api.group_member',

--- a/tests/h/services/group_json_presentation_test.py
+++ b/tests/h/services/group_json_presentation_test.py
@@ -10,20 +10,20 @@ from h.services.group_json_presentation import group_json_presentation_service_f
 
 class TestGroupJSONPresentationService(object):
 
-    def test_present_proxies_to_presenter(self, svc, GroupJSONPresenter, pyramid_request, factories):  # noqa: N803
+    def test_present_proxies_to_presenter(self, svc, GroupJSONPresenter, factories):  # noqa: N803
         group = factories.Group()
 
         svc.present(group)
 
-        GroupJSONPresenter.assert_called_once_with(group, pyramid_request.route_url)
+        GroupJSONPresenter.assert_called_once_with(group, svc.get_links)
         GroupJSONPresenter(group).asdict.assert_called_once()
 
-    def test_present_all_proxies_to_presenter(self, svc, GroupsJSONPresenter, pyramid_request, factories):  # noqa: N803
+    def test_present_all_proxies_to_presenter(self, svc, GroupsJSONPresenter, factories):  # noqa: N803
         groups = [factories.Group(), factories.Group()]
 
         svc.present_all(groups)
 
-        GroupsJSONPresenter.assert_called_once_with(groups, pyramid_request.route_url)
+        GroupsJSONPresenter.assert_called_once_with(groups, svc.get_links)
         GroupsJSONPresenter(groups).asdicts.assert_called_once()
 
 

--- a/tests/h/services/group_json_presentation_test.py
+++ b/tests/h/services/group_json_presentation_test.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import pytest
+
+from h.services.group_json_presentation import GroupJSONPresentationService
+from h.services.group_json_presentation import group_json_presentation_service_factory
+
+
+class TestGroupJSONPresentationService(object):
+
+    def test_present_proxies_to_presenter(self, svc, GroupJSONPresenter, pyramid_request, factories):  # noqa: N803
+        group = factories.Group()
+
+        svc.present(group)
+
+        GroupJSONPresenter.assert_called_once_with(group, pyramid_request.route_url)
+        GroupJSONPresenter(group).asdict.assert_called_once()
+
+    def test_present_all_proxies_to_presenter(self, svc, GroupsJSONPresenter, pyramid_request, factories):  # noqa: N803
+        groups = [factories.Group(), factories.Group()]
+
+        svc.present_all(groups)
+
+        GroupsJSONPresenter.assert_called_once_with(groups, pyramid_request.route_url)
+        GroupsJSONPresenter(groups).asdicts.assert_called_once()
+
+
+class TestGroupJSONPresentationFactory(object):
+
+    def test_group_json_presentation_factory(self, pyramid_request):
+        svc = group_json_presentation_service_factory(None, pyramid_request)
+
+        assert isinstance(svc, GroupJSONPresentationService)
+
+
+@pytest.fixture
+def GroupJSONPresenter(patch):  # noqa: N802
+    return patch('h.services.group_json_presentation.GroupJSONPresenter')
+
+
+@pytest.fixture
+def GroupsJSONPresenter(patch):  # noqa: N802
+    return patch('h.services.group_json_presentation.GroupsJSONPresenter')
+
+
+@pytest.fixture
+def svc(pyramid_request, db_session):
+    return GroupJSONPresentationService(
+        session=db_session,
+        request_authority=pyramid_request.authority,
+        route_url=pyramid_request.route_url
+    )

--- a/tests/h/services/group_json_presentation_test.py
+++ b/tests/h/services/group_json_presentation_test.py
@@ -26,6 +26,20 @@ class TestGroupJSONPresentationService(object):
         GroupsJSONPresenter.assert_called_once_with(groups, svc.get_links)
         GroupsJSONPresenter(groups).asdicts.assert_called_once()
 
+    def test_get_links_returns_group_url_if_same_authority(self, svc, factories, routes):
+        group = factories.Group()
+
+        links = svc.get_links(group)
+
+        assert 'group' in links
+
+    def test_get_links_returns_no_group_url_if_mismatched_authority(self, svc, factories, routes):
+        group = factories.Group(authority='ding.com')
+
+        links = svc.get_links(group)
+
+        assert 'group' not in links
+
 
 class TestGroupJSONPresentationFactory(object):
 
@@ -43,6 +57,11 @@ def GroupJSONPresenter(patch):  # noqa: N802
 @pytest.fixture
 def GroupsJSONPresenter(patch):  # noqa: N802
     return patch('h.services.group_json_presentation.GroupsJSONPresenter')
+
+
+@pytest.fixture
+def routes(pyramid_config):
+    pyramid_config.add_route('group_read', '/g/{pubid}/{slug}')
 
 
 @pytest.fixture


### PR DESCRIPTION
The object of the game here is to not return group-activity URLs in the `GET /api/groups` response for groups whose authority doesn't match the `request.authority` (see also https://github.com/hypothesis/client/pull/675) . This seems like a simple question of:

```
if group.authority == self._request_authority:
```

which it _is_, but, alas, the technical debt I incurred by stuffing a tiny bit of logic into the `GroupJSONPresenter` caught up with me. To make this work sensibly, I needed to interject a service _between_ the API view and the Presenter, to perform the URL injection logic.

The truly _correct_ way to do all this would be to define a `group` resource similar to `annotation` way up in `h.resources` and then treat the various presenting and formatting tasks in similar (but hopefully simpler) ways than this is accomplished for `annotation`s. That is something we should discuss doing, but I digress.

In short, the check of whether there's an authority match really needs to happen in a service, not a presenter, so I whipped up the simplest service I could—`GroupJSONPresentationService`—to handle this need.

`GroupJSONPresenter` (and `GroupsJSONPresenter`) now optionally take a `link_svc` parameter in their constructors; this callable, when present, is invoked to build an appropriate dict of links for a group. It looks more complex than it is because of ongoing support for the legacy `url` API response property (side note: maybe we could get rid of that property in the future).

The `groups` API view here uses the presentation service instead of the presenter directly. 

I apologize for a larger-than-I'd-like-PR to solve such a small-sounding objective, but I hope that the approach here, with some further refinement as we go, will provide a more stable foundation, which, to summarize, is:

* The view uses the `ListGroup` service to get a list of groups (real `group` model objects) and hands these off to the `GroupJSONPresentation` service for formatting.
* The `GroupJSONPresentation` service handles any service-level munging of group metadata needed to get the correct object put together for the `Group[s]JSONPresenter`. The Presentation service follows a pattern established by a similar (but far more complex) annotation presentation service.

Finally, I'm sticking the WIP label on here for now because I want to take another glance in the morning with a fresher head.