### PR TITLE
Add scoped-groups-filtering to `session`

### DIFF
--- a/h/session.py
+++ b/h/session.py
@@ -76,7 +76,10 @@ def _current_groups(request, authority):
 
     user = request.user
     svc = request.find_service(name='list_groups')
-    groups = svc.all_groups(user=user, authority=authority)
+    if request.feature('filter_groups_by_scope'):
+        groups = svc.request_groups(user=user, authority=authority)
+    else:
+        groups = svc.all_groups(user=user, authority=authority)
 
     return [_group_model(request.route_url, group) for group in groups]
 


### PR DESCRIPTION
This also, by extension, updates the groups
returned by `GET /api/profile`, which will now
exclude any open groups except for the Public group.

Fixes https://github.com/hypothesis/product-backlog/issues/482