### PR TITLE
Update presenter to use group attributes for new props

### DIFF
--- a/h/presenters/group_json.py
+++ b/h/presenters/group_json.py
@@ -18,8 +18,8 @@ class GroupJSONPresenter(object):
           'name': group.name,
           'id': group.pubid,
           'public': group.is_public,
-          'scoped': False,  # TODO
-          'type': 'open' if group.is_public else 'private'  # TODO
+          'scoped': True if group.scopes else False,
+          'type': group.type
         }
         model = self._inject_urls(group, model)
         return model

--- a/tests/h/presenters/group_json_test.py
+++ b/tests/h/presenters/group_json_test.py
@@ -39,6 +39,22 @@ class TestGroupJSONPresenter(object):
             'urls': {}
         }
 
+    def test_open_scoped_group_asdict(self, factories):
+        group = factories.OpenGroup(name='My Group',
+                                    pubid='groupy',
+                                    scopes=[factories.GroupScope(origin='http://foo.com')])
+
+        presenter = GroupJSONPresenter(group)
+
+        assert presenter.asdict() == {
+            'name': 'My Group',
+            'id': 'groupy',
+            'type': 'open',
+            'public': True,
+            'scoped': True,
+            'urls': {}
+        }
+
     def test_private_group_asdict_with_urls(self, factories):
         group = factories.Group(name='My Group',
                                 pubid='mygroup')


### PR DESCRIPTION
This small PR updates the `GroupJSONPresenter` to use group model attributes to populate properties for the API response. The `scoped` property is now "real" (though jury is still out as to whether this is a useful property) and `type` uses `group.type`.