### PR TITLE
Py 3 compat - Fix text handling issues in JSON schema tests

### DIFF
--- a/tests/h/schemas/base_test.py
+++ b/tests/h/schemas/base_test.py
@@ -2,6 +2,7 @@
 
 from __future__ import unicode_literals
 
+from h._compat import PY2
 import enum
 from mock import Mock
 import pytest
@@ -18,14 +19,18 @@ class ExampleCSRFSchema(CSRFSchema):
 
 
 class ExampleJSONSchema(JSONSchema):
+    # Use `bytes` for property names in Py 2 so that exception messages about
+    # missing properties have the same content in Py 2 + Py 3.
+    prop_name_type = bytes if PY2 else str
+
     schema = {
-        b'$schema': b'http://json-schema.org/draft-04/schema#',
-        b'type': b'object',
-        b'properties': {
-            b'foo': {b'type': b'string'},
-            b'bar': {b'type': b'integer'},
+        '$schema': 'http://json-schema.org/draft-04/schema#',
+        'type': 'object',
+        'properties': {
+            prop_name_type('foo'): {'type': 'string'},
+            prop_name_type('bar'): {'type': 'integer'},
         },
-        b'required': [b'foo', b'bar'],
+        'required': [prop_name_type('foo'), prop_name_type('bar')],
     }
 
 

--- a/tests/py3-expected-failures.txt
+++ b/tests/py3-expected-failures.txt
@@ -1,6 +1,3 @@
 /h/h/models/document.py:482:
 /h/tests/h/auth/util_test.py:69:
 /h/tests/h/schemas/annotation_test.py:197:
-/h/tests/h/schemas/base_test.py:64:
-/h/tests/h/schemas/base_test.py:70:
-/h/tests/h/schemas/base_test.py:79:


### PR DESCRIPTION
Using bytes keys in the test schema and string fields in the test case
JSON input caused validation to fail in Python 3.

For Python 3, use unicode keys in the test schema and JSON input to
resolve the issue. Using Unicode literals for property names in Python 2
results in different exception messages (`u'foo'` vs `'foo'`). Work
around this by using `bytes` as the type for property names in Py 2.