### PR TITLE
Add a group_scope utility

### DIFF
--- a/h/util/group_scope.py
+++ b/h/util/group_scope.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from h._compat import urlparse
+
+
+def match(uri, scopes):
+    """
+    Return boolean: Does the URI's scope match any of the scopes?
+
+    Return True if the scope of URI is present in the scopes list
+
+    :param uri: URI string in question
+    :param scopes: List of scope (URI origin) strings
+    """
+    scope = uri_scope(uri)
+    return scope in scopes
+
+
+def uri_scope(uri):
+    """
+    Return the scope for a given URI
+
+    Parse a scope from a URI string. Presently a scope is an origin, so this
+    proxies to _parse_origin.
+    """
+    return _parse_origin(uri)
+
+
+def _parse_origin(uri):
+    """
+    Return the origin of a URI or None if empty or invalid.
+
+    Per https://tools.ietf.org/html/rfc6454#section-7 :
+    Return ``<scheme> + '://' + <host> + <port>``
+    for a URI.
+
+    :param uri: URI string
+    """
+
+    if uri is None:
+        return None
+    parsed = urlparse.urlsplit(uri)
+    # netloc contains both host and port
+    origin = urlparse.SplitResult(parsed.scheme, parsed.netloc, '', '', '')
+    return origin.geturl() or None

--- a/tests/h/util/group_scope_test.py
+++ b/tests/h/util/group_scope_test.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import pytest
+
+from h.util import group_scope as scope_util
+
+
+@pytest.mark.parametrize('uri,expected_scope', [
+    ('https://www.foo.com', 'https://www.foo.com'),
+    ('http://foo.com', 'http://foo.com'),
+    ('https://foo.com/bar', 'https://foo.com'),
+    ('http://foo.com/', 'http://foo.com'),
+    ('http://www.foo.com/bar/baz.html', 'http://www.foo.com'),
+    ('randoscheme://foo.com', 'randoscheme://foo.com'),
+    ('foo', None),
+    ('foo.com', None),
+    ('http://www.foo.com/bar/baz.html?query=whatever', 'http://www.foo.com')
+])
+def test_it_parses_scope_from_uri(uri, expected_scope):
+    scope = scope_util.uri_scope(uri)
+
+    assert scope == expected_scope
+
+
+class TestScopeMatch(object):
+
+    @pytest.mark.parametrize('uri,expected', [
+        ('http://www.foo.com/bar/baz/ding.html', True),
+        ('https://www.foo.com/bar/baz/ding.html', False),
+        ('http://www.foo.com/', True),
+        ('http://foo.com/bar.html', False),
+        ('foo.com/bar.html', False)
+    ])
+    def test_it_matches_against_single_scope(self, uri, expected, single_scope):
+        result = scope_util.match(uri, single_scope)
+
+        assert result == expected
+
+    @pytest.mark.parametrize('uri,expected', [
+        ('http://www.foo.com/bar/baz/ding.html', True),
+        ('http://www.bar.com/bar/baz/ding.html', True),
+        ('http://www.foo.com/', True),
+        ('http://www.bar.com', True),
+        ('http://bar.com/bar.html', False),
+        ('bar.com/bar.html', False)
+    ])
+    def test_it_matches_against_multiple_scopes(self, uri, expected, multiple_scopes):
+        result = scope_util.match(uri, multiple_scopes)
+
+        assert result == expected
+
+    @pytest.fixture
+    def single_scope(self):
+        return ['http://www.foo.com']
+
+    @pytest.fixture
+    def multiple_scopes(self):
+        return ['http://www.foo.com', 'http://www.bar.com']


### PR DESCRIPTION
This is in pursuit of https://github.com/hypothesis/product-backlog/issues/483

This PR adds a `group_util` module for parsing scope out of URIs and determining whether a given URI  matches the scope of a list of scopes.

It will be used by the `storage` module for validating incoming annotations against group scope (subsequent PR #1). It will also be used by `ListGroupsService`, which presently has its own implementation of origin parsing (subsequent PR #2).

To keep the util module ignorant about models, it is expected that a caller would provide a list of origins (strings), not `GroupScope` models themselves.