### PR TITLE
Remove extra group creation in fixtures

### DIFF
--- a/tests/h/views/activity_test.py
+++ b/tests/h/views/activity_test.py
@@ -1093,13 +1093,7 @@ class FakeAnnotationStatsService(object):
 
 @pytest.fixture
 def group(factories):
-    # Create some other groups as well, just to make sure it gets the right
-    # one from the db.
-    factories.Group()
-    factories.OpenGroup()
-
     group = factories.Group()
-
     group.members.extend([factories.User(), factories.User()])
     return group
 
@@ -1114,11 +1108,6 @@ def no_creator_group(factories):
 
 @pytest.fixture
 def open_group(factories):
-    # Create some other groups as well, just to make sure it gets the right
-    # one from the db.
-    factories.Group()
-    factories.OpenGroup()
-
     open_group = factories.OpenGroup()
     return open_group
 


### PR DESCRIPTION
Creating extra groups is pretty unnecessary as both the group
search controller class and the base class do not have any
group selection logic for the query so it would be fairly
unlikely to introduce a bug there. If this is something to
be tested it should/could be tested at a lower level. Creating
extra groups in the fixtures each time, creates a performance
hit.