### PR TITLE
Py 3 compat - Fix MagicMock <=> int comparison error

### DIFF
--- a/tests/h/models/document_test.py
+++ b/tests/h/models/document_test.py
@@ -961,7 +961,9 @@ class TestUpdateDocumentMetadata(object):
 
     @pytest.fixture
     def Document(self, patch):
-        return patch('h.models.document.Document')
+        Document = patch('h.models.document.Document')
+        Document.find_or_create_by_uris.return_value.count.return_value = 1
+        return Document
 
     @pytest.fixture
     def merge_documents(self, patch):

--- a/tests/py3-expected-failures.txt
+++ b/tests/py3-expected-failures.txt
@@ -1,4 +1,3 @@
-/h/h/models/document.py:482:
 /h/tests/h/auth/util_test.py:69:
 /h/tests/h/schemas/annotation_test.py:197:
 /h/tests/h/schemas/base_test.py:64:


### PR DESCRIPTION
Fix an error when code tried to compare the result of
`Document.find_or_create_by_uris(...).count()` to an int literal.

Previously `count()` returned a MagicMock, now it returns a hardcoded
int, which is Good Enough™ for the current tests.