### PR TITLE
API Change: Enforce Scope Restrictions on `POST /api/annotations`

### DIFF
--- a/h/interfaces.py
+++ b/h/interfaces.py
@@ -13,5 +13,7 @@ class IGroupService(Interface):
         :param id_: The group id.
         :type id_: unicode
 
-        :returns A group object with an ``__acl__()`` method.
+        :returns A group object with:
+          * an ``__acl__()`` method
+          * a ``scopes`` property (``list``)
         """


### PR DESCRIPTION
This PR introduces restriction to scope on incoming annotations to the API. If the scoped-group feature flag is on _and_ the annotation's designated group has 1 or more _scopes_ _and_ the annotation's `target_uri` does not match one of those scopes, the API will return a `400` with a relevant scope-violation message.

I have of course written tests, and I've thrown some requests at my local API to see how it behaves, but I'd love extra eyes on this particular PR because it touches one of the most highly-used pieces of the application. I don't want to break the ability to add annotations for our users, of course.

----

Both of the following examples assume the scoped-groups feature flag is on and that the annotation in question is being posted to a group that has a scope to the local client (`http://localhost:3000`).

If a request is sent to the API (here my local `5000`) with a `target_uri` that matches scope, things go fine—you'll get a 200 response and a representation of the new resource in response:

![image](https://user-images.githubusercontent.com/439947/36612918-ee2d1054-18a5-11e8-8315-c4db0171cab0.png)

But if you send a request with a mismatched scope—here I've changed the port number so that the origins no longer match—you'll get a 400 and and error message:

![image](https://user-images.githubusercontent.com/439947/36613050-43c476d8-18a6-11e8-8b0b-90a1195a91aa.png)

After a conversation with @robertknight I elected to "update" the `IGroupInterface` to denote that returned objects should have a `list` of `scopes`.

Fixes https://github.com/hypothesis/product-backlog/issues/483