### PR TITLE
Open group activity pages style

### DIFF
--- a/h/static/styles/partials/_group-invite.scss
+++ b/h/static/styles/partials/_group-invite.scss
@@ -1,8 +1,3 @@
-.group-invite__title {
-  color: $brand;
-  margin-bottom: 0;
-}
-
 .group-invite__container {
   position: relative;
   max-width: $search-result-sidebar-width;

--- a/h/static/styles/partials/_search-result-sidebar.scss
+++ b/h/static/styles/partials/_search-result-sidebar.scss
@@ -86,6 +86,7 @@
 .search-result-sidebar__tag-container {
   display: flex;
   color: $grey-6;
+  align-items: center;
 }
 
 .search-result-sidebar__tag-count {

--- a/h/static/styles/partials/_search-result-sidebar.scss
+++ b/h/static/styles/partials/_search-result-sidebar.scss
@@ -28,7 +28,9 @@
 }
 
 .search-result-sidebar__share-link {
+  margin-top: auto;
   margin-bottom: 0;
+  padding-top: 2px;
 }
 
 .search-result-sidebar__subsection {

--- a/h/static/styles/partials/_search-result-sidebar.scss
+++ b/h/static/styles/partials/_search-result-sidebar.scss
@@ -31,20 +31,21 @@
   margin-bottom: 0;
 }
 
-.search-result-sidebar__section p:last-of-type {
-  margin-bottom: 0;
+.search-result-sidebar__subsection {
+  margin-top: 17px;
 }
 
-.search-result-sidebar__dt {
+.search-result-sidebar__subsection-p {
+  margin-top: 2px;
+  margin-bottom: 2px;
+}
+
+.search-result-sidebar__subsection-key {
   font-weight: bold;
-  float: left;
-  clear: left;
-  margin-right: 3px;
 }
 
-.search-result-sidebar__dd {
-  float: left;
-  margin-left: 0;
+.search-result-sidebar__subsection-val {
+  color: $grey-6;
 }
 
 .search-result-sidebar-title__annotations-count {

--- a/h/static/styles/partials/_search-result-sidebar.scss
+++ b/h/static/styles/partials/_search-result-sidebar.scss
@@ -64,7 +64,6 @@
   display: flex;
   flex-wrap: wrap;
   max-width: 350px;
-  margin-top: 30px;
 }
 
 .search-result-sidebar__tag {
@@ -73,7 +72,11 @@
   border-radius: 2px;
   margin-bottom: 5px;
   margin-right: 5px;
-  padding: 5px;
+  padding-bottom: 1px;
+  padding-top: 1px;
+  padding-left: 3px;
+  padding-right: 3px;
+  border-radius: 3px 3px;
   font-weight: bold;
 }
 
@@ -84,7 +87,7 @@
 
 .search-result-sidebar__tag-count {
   color: $grey-4;
-  margin-left: 10px;
+  margin-left: 5px;
   font-weight: normal;
 }
 

--- a/h/static/styles/partials/_search-result-sidebar.scss
+++ b/h/static/styles/partials/_search-result-sidebar.scss
@@ -6,7 +6,11 @@
 
 .search-result-sidebar__title {
   margin-top: 0;
-  margin-bottom: 26px;
+  margin-bottom: 20px;
+}
+
+.search-result-sidebar__subtitle {
+  margin-bottom: 9px;
 }
 
 .search-result-sidebar__title,
@@ -23,12 +27,8 @@
   @include pie-clearfix;
 }
 
-.search-result-sidebar__section:last-child {
+.search-result-sidebar__share-link {
   margin-bottom: 0;
-}
-
-.search-result-sidebar__section p:first-of-type {
-  margin-top: 0;
 }
 
 .search-result-sidebar__section p:last-of-type {

--- a/h/static/styles/partials/_search-result-sidebar.scss
+++ b/h/static/styles/partials/_search-result-sidebar.scss
@@ -53,6 +53,10 @@
 }
 
 .search-result-sidebar__annotations-count {
+  color: $grey-4;
+}
+
+.search-result-sidebar__creator {
   color: $grey-5;
 }
 
@@ -75,6 +79,7 @@
 
 .search-result-sidebar__tag-container {
   display: flex;
+  color: $grey-6;
 }
 
 .search-result-sidebar__tag-count {

--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -211,7 +211,7 @@
 </section>
 {% endmacro %}
 
-{% macro sidebar(title, description) %}
+{% macro sidebar(title) %}
 <aside class="search-result-sidebar {%- if not more_info %} search-result-hide-on-small-screens{% endif %}">
 
   {#- This form element is needed for Internet Explorer because it
@@ -221,21 +221,22 @@
 
     <h1 class="search-result-sidebar__title">{{ title }}</h1>
 
-    {% if description %}
-    <section class="search-result-sidebar__section">
-      {% for paragraph in description.split('\n') %}
-        <p>{{ paragraph }}</p>
-      {% endfor %}
-    </section>
-    {% endif %}
-
     {{ caller() }}
   </form>
 </aside>
 {% endmacro %}
 
 {% macro group_sidebar(group, group_edit_url, total, stats) %}
-  {% call sidebar(group.name, group.description) %}
+  {% call sidebar(group.name) %}
+
+    {% if group.description %}
+    <section class="search-result-sidebar__section">
+      {% for paragraph in group.description.split('\n') %}
+        <p>{{ paragraph }}</p>
+      {% endfor %}
+    </section>
+    {% endif %}
+
     <section class="search-result-sidebar__section">
       <dl>
         <dt class="search-result-sidebar__dt">
@@ -310,7 +311,16 @@
 {% endmacro %}
 
 {% macro user_sidebar(user, stats) %}
-  {% call sidebar(user.name, user.description) %}
+  {% call sidebar(user.name) %}
+
+    {% if user.description %}
+    <section class="search-result-sidebar__section">
+      {% for paragraph in user.description.split('\n') %}
+        <p>{{ paragraph }}</p>
+      {% endfor %}
+    </section>
+    {% endif %}
+
     <section class="search-result-sidebar__section">
       <dl>
         {% if stats.annotation_count %}

--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -199,7 +199,7 @@
             {{ user.count }}
           </span>
           {% if user.userid == creator %}
-            <span class="search-result-sidebar__annotations-count">
+            <span class="search-result-sidebar__creator">
               creator
             </span>
           {% endif %}

--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -229,55 +229,50 @@
 {% macro group_sidebar(group, group_edit_url, total, stats) %}
   {% call sidebar(group.name) %}
 
-    {% if group.description %}
     <section class="search-result-sidebar__section">
-      {% for paragraph in group.description.split('\n') %}
-        <p>{{ paragraph }}</p>
-      {% endfor %}
-    </section>
-    {% endif %}
-
-    <section class="search-result-sidebar__section">
-      <dl>
-        <dt class="search-result-sidebar__dt">
-          {% trans %}Annotations:{% endtrans %}
-        </dt>
-        <dd class="search-result-sidebar__dd">{{ stats.annotation_count }}</dd>
-        <dt class="search-result-sidebar__dt">
-          {% trans %}Created:{% endtrans %}
-        </dt>
-        <dd class="search-result-sidebar__dd">{{ group.created }}</dd>
-      </dl>
-    </section>
-
-    <section class="search-result-sidebar__section">
-      <ul>
-        {% if group_edit_url %}
-          <li>
-            <a class="link"
-               href="{{ group_edit_url }}">
-              {% trans %}Edit group{% endtrans %}
-            </a>
-          </li>
-        {% endif %}
-        {# only show ability to leave group if group has concept of members #}
-        {% if group.members %}
-          <li>
-            <button class="link--btn js-confirm-submit"
-                    type="submit"
-                    form="search-bar"
-                    formmethod="POST"
-                    name="group_leave"
-                    value="{{ group.pubid }}"
-                    data-confirm-message="Are you sure you want to leave the group &quot;{{ group.name }}&quot;?">
-                {% trans %}Leave this group{% endtrans %}
-            </button>
-          </li>
-        {% endif %}
-      </ul>
+      {% if group.description %}
+        <div class="search-result-sidebar__subsection">
+        {% for paragraph in group.description.split('\n') %}
+          <p>{{ paragraph }}</p>
+        {% endfor %}
+        </div>
+      {% endif %}
+      <div class="search-result-sidebar__subsection">
+        <p class="search-result-sidebar__subsection-p">
+          <span class="search-result-sidebar__subsection-key">{% trans %}Annotations:{% endtrans %}</span>
+          <span class="search-result-sidebar__subsection-val">{{ stats.annotation_count }}</span>
+        </p>
+        <p class="search-result-sidebar__subsection-p">
+          <span class="search-result-sidebar__subsection-key">{% trans %}Created:{% endtrans %}</span>
+          <span class="search-result-sidebar__subsection-val">{{ group.created }}</span>
+        </p>
+      </div>
+      <div class="search-result-sidebar__subsection">
+      {% if group_edit_url %}
+        <p class="search-result-sidebar__subsection-p">
+          <a class="link"
+              href="{{ group_edit_url }}">
+             {% trans %}Edit group{% endtrans %}
+          </a>
+        </p>
+      {% endif %}
+      {# only show ability to leave group if group has concept of members #}
+      {% if group.members %}
+        <button class="link--btn js-confirm-submit"
+                type="submit"
+                form="search-bar"
+                formmethod="POST"
+                name="group_leave"
+                value="{{ group.pubid }}"
+                data-confirm-message="Are you sure you want to leave the group &quot;{{ group.name }}&quot;?">
+          {% trans %}Leave this group{% endtrans %}
+        </button>
+      {% endif %}
+      </div>
     </section>
 
     {{ tags_section() }}
+
     {# if the group has a concept of members display members and join text #}
     {% if group.members %} 
       {{ group_users("Members", group.members, group.creator) }}
@@ -312,72 +307,62 @@
 
 {% macro user_sidebar(user, stats) %}
   {% call sidebar(user.name) %}
-
-    {% if user.description %}
     <section class="search-result-sidebar__section">
-      {% for paragraph in user.description.split('\n') %}
-        <p>{{ paragraph }}</p>
-      {% endfor %}
-    </section>
-    {% endif %}
-
-    <section class="search-result-sidebar__section">
-      <dl>
-        {% if stats.annotation_count %}
-          <dt class="search-result-sidebar__dt">
-            {% trans %}Annotations:{% endtrans %}
-          </dt>
-          <dd class="search-result-sidebar__dd">{{ stats.annotation_count }}</dd>
-        {% endif %}
-
-        <dt class="search-result-sidebar__dt">
-          {% trans %}Joined:{% endtrans %}
-        </dt>
-        <dd class="search-result-sidebar__dd">{{ user.registered_date }}</dd>
-
-        {%- if user.location %}
-          <dt class="search-result-sidebar__dt">
-            {% trans %}Location:{% endtrans %}
-          </dt>
-          <dd class="search-result-sidebar__dd">{{ user.location }}</dd>
-        {% endif -%}
-
-        {%- if user.uri %}
-          <dt class="search-result-sidebar__dt">
-            {% trans %}Link:{% endtrans %}
-          </dt>
-          <dd class="search-result-sidebar__dd">
+      {% if user.description %}
+        {% for paragraph in user.description.split('\n') %}
+          <p>{{ paragraph }}</p>
+        {% endfor %}
+      {% endif %}
+    
+      <div class="search-result-sidebar__subsection">
+      {% if stats.annotation_count %}
+        <p class="search-result-sidebar__subsection-p">
+          <span class="search-result-sidebar__subsection-key">{% trans %}Annotations:{% endtrans %}</span>
+          <span class="search-result-sidebar__subsection-val">{{ stats.annotation_count }}</span>
+        </p>
+      {% endif %}
+        <p class="search-result-sidebar__subsection-p">
+          <span class="search-result-sidebar__subsection-key">{% trans %}Joined:{% endtrans %}</span>
+          <span class="search-result-sidebar__subsection-val">{{ user.registered_date }}</span>
+        </p>
+      {%- if user.location %}
+        <p class="search-result-sidebar__subsection-p">
+          <span class="search-result-sidebar__subsection-key">{% trans %}Location:{% endtrans %}</span>
+          <span class="search-result-sidebar__subsection-val">{{ user.location }}</span>
+        </p>
+      {% endif %}
+      {%- if user.uri %}
+        <p class="search-result-sidebar__subsection-p">
+          <span class="search-result-sidebar__subsection-key">{% trans %}Link:{% endtrans %}</span>
+          <span class="search-result-sidebar__subsection-val">
             <a href="{{ user.uri }}" rel="nofollow noopener" class="link--plain">
               {{ pretty_link(user.uri) }}
             </a>
-          </dd>
-        {% endif -%}
-
-        {%- if user.orcid %}
-          <dt class="search-result-sidebar__dt">
-            {% trans %}ORCID:{% endtrans %}
-          </dt>
-          <dd class="search-result-sidebar__dd">
+          </span>
+        </p>
+      {% endif %}
+      {%- if user.orcid %}
+        <p class="search-result-sidebar__subsection-p">
+          <span class="search-result-sidebar__subsection-key">{% trans %}ORCID:{% endtrans %}</span>
+          <span class="search-result-sidebar__subsection-val">
             <a href="https://orcid.org/{{ user.orcid }}"
                class="link--plain">
               {{ user.orcid }}
             </a>
-          </dd>
-        {% endif -%}
-      </dl>
-    </section>
-
-    <section class="search-result-sidebar__section">
-      <ul>
-        {% if user.edit_url %}
-          <li>
-            <a class="link"
-               href="{{ user.edit_url }}">
-              {% trans %}Edit profile{% endtrans %}
-            </a>
-          </li>
-        {% endif %}
-      </ul>
+          </span>
+        </p>
+      {% endif %}
+      </div>
+      <div class="search-result-sidebar__subsection">
+      {% if user.edit_url %}
+        <p class="search-result-sidebar__subsection-p">
+          <a class="link"
+             href="{{ user.edit_url }}">
+            {% trans %}Edit profile{% endtrans %}
+          </a>
+        </p>
+      {% endif %}
+      </div>
     </section>
 
     {{ tags_section() }}

--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -276,21 +276,23 @@
     {# if the group has a concept of members display members and join text #}
     {% if group.members %} 
       {{ group_users("Members", group.members, group.creator) }}
-      <h3 class="group-invite__title">
-        {% trans %}Invite new members{% endtrans %}
-      </h3>
-      <p class="search-result-sidebar__share-link">
-        {% trans %}Sharing the link lets people join this group:{% endtrans %}
-      </p>
+      <section class="search-result-sidebar__section">
+        <h3 class="search-result-sidebar__subtitle">
+          {% trans %}Invite new members{% endtrans %}
+        </h3>
+        <p class="search-result-sidebar__share-link">
+          {% trans %}Sharing the link lets people join this group:{% endtrans %}
+        </p>
     {# if the group has no concept of members display moderators and share text #}
     {% else %}
       {{ group_users("Moderators", group.moderators, group.creator) }}
-      <h3 class="group-invite__title">
-        {% trans %}Share group{% endtrans %}
-      </h3>
-      <p class="search-result-sidebar__share-link">
-        {% trans %}Sharing the link lets people view this group:{% endtrans %}
-      </p>
+      <section class="search-result-sidebar__section">
+        <h3 class="search-result-sidebar__subtitle">
+          {% trans %}Share group{% endtrans %}
+        </h3>
+        <p class="search-result-sidebar__share-link">
+          {% trans %}Sharing the link lets people view this group:{% endtrans %}
+        </p>
     {% endif %}
     <div class="group-invite__container js-copy-button">
       <input class="group-invite__input js-select-onfocus"
@@ -302,6 +304,7 @@
         {{ svg_icon('copy_to_clipboard', 'group-invite__clipboard-image') }}
       </button>
     </div>
+  </section>
   {% endcall %}
 {% endmacro %}
 

--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -283,14 +283,18 @@
       <h3 class="group-invite__title">
         {% trans %}Invite new members{% endtrans %}
       </h3>
-      Sharing the link lets people join this group:
+      <p class="search-result-sidebar__share-link">
+        {% trans %}Sharing the link lets people join this group:{% endtrans %}
+      </p>
     {# if the group has no concept of members display moderators and share text #}
     {% else %}
       {{ group_users("Moderators", group.moderators, group.creator) }}
       <h3 class="group-invite__title">
         {% trans %}Share group{% endtrans %}
       </h3>
-      Sharing the link lets people view this group:
+      <p class="search-result-sidebar__share-link">
+        {% trans %}Sharing the link lets people view this group:{% endtrans %}
+      </p>
     {% endif %}
     <div class="group-invite__container js-copy-button">
       <input class="group-invite__input js-select-onfocus"


### PR DESCRIPTION
Reformat the side bar on group/user activity pages


Contains minor tweaks to colors, spacing, and adds some additional info (like the day to the date, a Moderators section for open groups, and a creator label next to the user who created the group). This is a fix for https://github.com/hypothesis/product-backlog/issues/490.

![image 1](https://user-images.githubusercontent.com/30059933/36774537-606be062-1c13-11e8-88e1-eb2fc98fbf9e.png)
![image](https://user-images.githubusercontent.com/30059933/36774541-62b0511e-1c13-11e8-9ac4-7112ce9645c2.png)

List of changes:
- Increase spacing between sections on the sidebar.
- Standardize spacing between section titles and their content as well as between sections.
- Tighten up the grey box around the tag to be closer to the text in order to not create an optical illusion of the spacing between the title of the section and the tag varying from other sections.
- Update grey colors on the users/tag names to be 
         name #.....................to be..............dark-grey lightest-grey
         name # creator.........to be..............dark-grey lightest-grey light-grey
- Level the text in tags and users to be at the same level as the #s (previously the numbers were slightly higher)
- Move group description, dl's, and edit/join links into their own section (this also includes a change from using dl to using p and span elements).
- Move the share/invite info into it's own section also - this just makes it easier to keep everything consistent and in one place.