### PR TITLE
Py 3 compat - Fix UTF-8 encoding issue in basic auth tests

### DIFF
--- a/h/_compat.py
+++ b/h/_compat.py
@@ -26,10 +26,12 @@ if not PY2:
     text_type = str
     string_types = (str,)
     xrange = range
+    unichr = chr
 else:
     text_type = unicode  # noqa
     string_types = (str, unicode)  # noqa
     xrange = xrange
+    unichr = unichr
 
 try:
     import ConfigParser as configparser

--- a/tests/h/auth/util_test.py
+++ b/tests/h/auth/util_test.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
+
 import base64
 from collections import namedtuple
+from h._compat import unichr
 
 import pytest
 import mock
@@ -29,13 +32,19 @@ FakeGroup = namedtuple('FakeGroup', ['pubid'])
 #
 #     CTL            =  %x00-1F / %x7F
 #
-CONTROL_CHARS = set(chr(n) for n in range(0x00, 0x1F + 1)) | set('\x7f')
+CONTROL_CHARS = set(unichr(n) for n in range(0x00, 0x1F + 1)) | set('\x7f')
+
+# We assume user ID and password strings are UTF-8 and surrogates are not
+# allowed in UTF-8.
+SURROGATE_CHARS = set(unichr(n) for n in range(0xD800, 0xDBFF + 1)) | \
+                  set(unichr(n) for n in range(0xDC00, 0xDFFF + 1))
+INVALID_USER_PASS_CHARS = CONTROL_CHARS | SURROGATE_CHARS
 
 # Furthermore, from RFC 7617:
 #
 #     a user-id containing a colon character is invalid
 #
-INVALID_USERNAME_CHARS = CONTROL_CHARS | set(':')
+INVALID_USERNAME_CHARS = INVALID_USER_PASS_CHARS | set(':')
 
 # The character encoding of the user-id and password is *undefined* by
 # specification for historical reasons:
@@ -57,7 +66,7 @@ INVALID_USERNAME_CHARS = CONTROL_CHARS | set(':')
 # successfully decode valid Unicode user-pass strings.
 #
 VALID_USERNAME_CHARS = st.characters(blacklist_characters=INVALID_USERNAME_CHARS)
-VALID_PASSWORD_CHARS = st.characters(blacklist_characters=CONTROL_CHARS)
+VALID_PASSWORD_CHARS = st.characters(blacklist_characters=INVALID_USER_PASS_CHARS)
 
 
 class TestBasicAuthCreds(object):

--- a/tests/py3-expected-failures.txt
+++ b/tests/py3-expected-failures.txt
@@ -1,4 +1,3 @@
-/h/tests/h/auth/util_test.py:69:
 /h/tests/h/schemas/annotation_test.py:197:
 /h/tests/h/schemas/base_test.py:64:
 /h/tests/h/schemas/base_test.py:70:


### PR DESCRIPTION
The hypothesis property tests for basic auth would generate Unicode
strings containing surrogate chars (0xD800-0xDBFF, 0xDC00-0xDFFF).
Python 3 throws an exception when trying to encode these chars into a
UTF-8 byte string, whereas Python 2 does not.

Resolve the issue by blacklisting these chars from generated char
sequences.

Also use `unicode_literals` and `unichr` to make the types used in the
test consistent between Py 2 and Py 3.