### PR TITLE
Add day to date on activity page sidebar

### DIFF
--- a/h/util/datetime.py
+++ b/h/util/datetime.py
@@ -6,3 +6,8 @@
 def utc_iso8601(datetime):
     """Convert a UTC datetime into an ISO8601 timestamp string."""
     return datetime.strftime('%Y-%m-%dT%H:%M:%S.%f+00:00')
+
+
+def utc_us_style_date(datetime):
+    """Convert a UTC datetime into a Month day, year (August 1, 1990)"""
+    return "{d:%B} {d.day}, {d:%Y}".format(d=datetime)

--- a/h/views/activity.py
+++ b/h/views/activity.py
@@ -19,6 +19,7 @@ from h.paginator import paginate
 from h.search import parser
 from h.util.user import split_user
 from h.views.groups import check_slug
+from h.util.datetime import utc_us_style_date
 
 
 PAGE_SIZE = 200
@@ -154,7 +155,7 @@ class GroupSearchController(SearchController):
             'annotation_count': group_annotation_count,
         }
         result['group'] = {
-            'created': self.group.created.strftime('%B, %Y'),
+            'created': utc_us_style_date(self.group.created),
             'description': self.group.description,
             'name': self.group.name,
             'pubid': self.group.pubid,
@@ -321,7 +322,7 @@ class UserSearchController(SearchController):
         result['user'] = {
             'name': self.user.display_name or self.user.username,
             'description': self.user.description,
-            'registered_date': self.user.registered_date.strftime('%B, %Y'),
+            'registered_date': utc_us_style_date(self.user.registered_date),
             'location': self.user.location,
             'uri': self.user.uri,
             'domain': domain(self.user),

--- a/tests/h/util/datetime_test.py
+++ b/tests/h/util/datetime_test.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 
 import datetime
 
-from h.util.datetime import utc_iso8601
+from h.util.datetime import utc_iso8601, utc_us_style_date
 
 
 class Berlin(datetime.tzinfo):
@@ -28,3 +28,8 @@ def test_utc_iso8601():
 def test_utc_iso8601_ignores_timezone():
     t = datetime.datetime(2016, 2, 24, 18, 3, 25, 7685, Berlin())
     assert utc_iso8601(t) == '2016-02-24T18:03:25.007685+00:00'
+
+
+def test_utc_us_style_date():
+    t = datetime.datetime(2016, 2, 4)
+    assert utc_us_style_date(t) == "February 4, 2016"

--- a/tests/h/views/activity_test.py
+++ b/tests/h/views/activity_test.py
@@ -238,7 +238,7 @@ class TestGroupSearchController(object):
                                                                  pyramid_request):
         group_info = controller.search()['group']
 
-        assert group_info['created'] == test_group.created.strftime('%B, %Y')
+        assert group_info['created'] == "{d:%B} {d.day}, {d:%Y}".format(d=test_group.created)
         assert group_info['description'] == test_group.description
         assert group_info['name'] == test_group.name
         assert group_info['pubid'] == test_group.pubid
@@ -819,7 +819,7 @@ class TestUserSearchController(object):
         user_details = controller.search()['user']
 
         assert user_details['description'] == user.description
-        assert user_details['registered_date'] == 'August, 2016'
+        assert user_details['registered_date'] == 'August 1, 2016'
         assert user_details['location'] == user.location
         assert user_details['uri'] == user.uri
         assert user_details['domain'] == 'www.example.com'


### PR DESCRIPTION
Add day to group created date on sidebar so date format is now:
Month day, year aka: August 1, 2018. Some tests were updated to
expect this new date format. Note the date format was changed from
using the c library strftime to using the python format method as
the c library does not support %-d on all systems (a way of removing
the default zero padding of the day). This is a fix for 
https://github.com/hypothesis/client/issues/644.
