### PR TITLE
Format annotation count on activity pages w/ ','

### DIFF
--- a/h/jinja_extensions.py
+++ b/h/jinja_extensions.py
@@ -26,6 +26,7 @@ class Filters(Extension):
 
         environment.filters['to_json'] = to_json
         environment.filters['human_timestamp'] = human_timestamp
+        environment.filters['format_number'] = format_number
 
 
 def human_timestamp(timestamp, now=datetime.datetime.utcnow):
@@ -34,6 +35,10 @@ def human_timestamp(timestamp, now=datetime.datetime.utcnow):
     if timestamp.year < now().year:
         fmt = '%d %B %Y at %H:%M'
     return timestamp.strftime(fmt)
+
+
+def format_number(num):
+    return "{:,}".format(num)
 
 
 def to_json(value):

--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -164,7 +164,7 @@
         <span class="search-result-sidebar__tag-container">
           {{ tag.tag }}
           <span class="search-result-sidebar__tag-count">
-            {{ tag.count }}
+            {{ tag.count | format_number}}
           </span>
         </span>
       </button>
@@ -196,7 +196,7 @@
                 class="search-result-sidebar__username">
           {{ user.username }}
           <span class="search-result-sidebar__annotations-count">
-            {{ user.count }}
+            {{ user.count | format_number}}
           </span>
           {% if user.userid == creator %}
             <span class="search-result-sidebar__creator">
@@ -240,7 +240,7 @@
       <div class="search-result-sidebar__subsection">
         <p class="search-result-sidebar__subsection-p">
           <span class="search-result-sidebar__subsection-key">{% trans %}Annotations:{% endtrans %}</span>
-          <span class="search-result-sidebar__subsection-val">{{ stats.annotation_count }}</span>
+          <span class="search-result-sidebar__subsection-val">{{ stats.annotation_count | format_number}}</span>
         </p>
         <p class="search-result-sidebar__subsection-p">
           <span class="search-result-sidebar__subsection-key">{% trans %}Created:{% endtrans %}</span>
@@ -321,7 +321,7 @@
       {% if stats.annotation_count %}
         <p class="search-result-sidebar__subsection-p">
           <span class="search-result-sidebar__subsection-key">{% trans %}Annotations:{% endtrans %}</span>
-          <span class="search-result-sidebar__subsection-val">{{ stats.annotation_count }}</span>
+          <span class="search-result-sidebar__subsection-val">{{ stats.annotation_count | format_number}}</span>
         </p>
       {% endif %}
         <p class="search-result-sidebar__subsection-p">
@@ -389,7 +389,7 @@
       <div class="search-results {%- if more_info %} search-result-hide-on-small-screens{% endif %}">
 
         {% if q or user or group %}
-        <div class="search-results__total"> {{search_results.total}} <b>{% trans %}Matching Annotations{% endtrans %}</b></div>
+        <div class="search-results__total"> {{search_results.total | format_number}} <b>{% trans %}Matching Annotations{% endtrans %}</b></div>
         {% endif %}
 
         <ol class="search-results__list"

--- a/tests/h/jinja_extension_test.py
+++ b/tests/h/jinja_extension_test.py
@@ -39,6 +39,12 @@ def test_human_timestamp(timestamp_in, string_out):
     assert result == string_out
 
 
+def test_format_number():
+    num = 134908
+    result = ext.format_number(num)
+    assert result == '134,908'
+
+
 def test_svg_icon_loads_icon():
     def read_icon(name):
         return '<svg id="{}"></svg>'.format(name)


### PR DESCRIPTION
Add , as thousands delimiter in annotation count on activity
pages. The annotation count blends together when it's really
large and it makes it hard to read. This formatting was added
as a jinja extension and a corresponding test was also added.
This formats the search result Matching # annotations as well
as the group and user side bar total annotations to be ,
delimited.