### PR TITLE
Add ... to indicate join link overflow in sidebar

### DIFF
--- a/h/static/styles/partials/_group-invite.scss
+++ b/h/static/styles/partials/_group-invite.scss
@@ -19,6 +19,7 @@
   border-radius: 2px;
   width: 100%;
   height: 31px;
+  text-overflow: ellipsis;
 }
 
 .group-invite__clipboard-button {


### PR DESCRIPTION
Currently when the join link is too large to fit inside the input
box it cuts off the remaining text. Sometimes this happens in the
middle of a letter and is visually displeasing. Instead of cutting
off the join link url, now we add a ... on the end using elipsis
to indicate the url is too large to fit in the box. If the user
clicks on the box the whole link will be visible as normal.