### PR TITLE
Reduce word spacing and date color in search

### DIFF
--- a/h/static/styles/partials/_search.scss
+++ b/h/static/styles/partials/_search.scss
@@ -59,7 +59,6 @@
 .search-results__total {
   color: $brand;
   margin-bottom: 25px;
-  word-spacing: 4px;
 }
 
 .search-results__list {
@@ -95,6 +94,7 @@
 }
 
 .search-result__timeframe {
+  color: $grey-4;
   font-weight: bold;
   padding-bottom: 10px;
   border-bottom: 1px solid $grey-2;


### PR DESCRIPTION
Got rid of extra spacing between words in "# Matching Annotations"
search results because it looks funny. ALso change color of date
to be lighter grey so that user focus is on the annotation and
not the date.

Before:
![image](https://user-images.githubusercontent.com/30059933/36776533-016747b6-1c1b-11e8-9d63-edd7a4074656.png)

After:
![image](https://user-images.githubusercontent.com/30059933/36776086-754e7368-1c19-11e8-8c94-e20e6c684d04.png)

