### PR TITLE
Add group_links Service

### DIFF
--- a/h/presenters/group_json.py
+++ b/h/presenters/group_json.py
@@ -6,9 +6,9 @@ from __future__ import unicode_literals
 class GroupJSONPresenter(object):
     """Present a group in the JSON format returned by API requests."""
 
-    def __init__(self, group, route_url=None):
+    def __init__(self, group, links_svc=None):
         self.group = group
-        self._route_url = route_url
+        self._links_svc = links_svc
 
     def asdict(self):
         return self._model(self.group)
@@ -26,22 +26,21 @@ class GroupJSONPresenter(object):
 
     def _inject_urls(self, group, model):
         model['urls'] = {}
-        if not self._route_url:
+        if not self._links_svc:
             return model
 
-        model['url'] = self._route_url('group_read',
-                                       pubid=group.pubid,
-                                       slug=group.slug)
-        model['urls']['group'] = model['url']
+        model['urls'] = self._links_svc.get_all(group)
+        if 'group' in model['urls']:
+            model['url'] = model['urls']['group']
         return model
 
 
 class GroupsJSONPresenter(object):
     """Present a list of groups as JSON"""
 
-    def __init__(self, groups, route_url=None):
+    def __init__(self, groups, links_svc=None):
         self.groups = groups
-        self._route_url = route_url
+        self._links_svc = links_svc
 
     def asdicts(self):
-        return [GroupJSONPresenter(group, self._route_url).asdict() for group in self.groups]
+        return [GroupJSONPresenter(group, self._links_svc).asdict() for group in self.groups]

--- a/h/services/__init__.py
+++ b/h/services/__init__.py
@@ -19,6 +19,7 @@ def includeme(config):
     config.register_service_factory('.flag.flag_service_factory', name='flag')
     config.register_service_factory('.flag_count.flag_count_service_factory', name='flag_count')
     config.register_service_factory('.group.groups_factory', name='group')
+    config.register_service_factory('.group_links.group_links_factory', name='group_links')
     config.register_service_factory('.groupfinder.groupfinder_service_factory', iface='h.interfaces.IGroupService')
     config.register_service_factory('.links.links_factory', name='links')
     config.register_service_factory('.list_groups.list_groups_factory', name='list_groups')

--- a/h/services/group_links.py
+++ b/h/services/group_links.py
@@ -6,7 +6,7 @@ from __future__ import unicode_literals
 class GroupLinksService(object):
 
     """
-    A service for providing appropriate links for a given group object
+    A service for providing appropriate links (URLs) for a given group object
     """
 
     def __init__(self, request_authority, route_url):
@@ -14,12 +14,13 @@ class GroupLinksService(object):
         Create a group_links service.
 
         :param request_authority: The request's "default" authority
+        :param route_url: The request's route_url method for building URLs
         """
         self._authority = request_authority
         self._route_url = route_url
 
     def get_all(self, group):
-        """Return all links"""
+        """Return a dict of all applicable links for this group"""
         links = {}
         if group.authority == self._authority:
             # Only groups for the default authority should have an activity page

--- a/h/services/group_links.py
+++ b/h/services/group_links.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+
+class GroupLinksService(object):
+
+    """
+    A service for providing appropriate links for a given group object
+    """
+
+    def __init__(self, request_authority, route_url):
+        """
+        Create a group_links service.
+
+        :param request_authority: The request's "default" authority
+        """
+        self._authority = request_authority
+        self._route_url = route_url
+
+    def get_all(self, group):
+        """Return all links"""
+        links = {}
+        if group.authority == self._authority:
+            # Only groups for the default authority should have an activity page
+            # link. Note that the default authority may differ from the
+            # user's authority.
+            links['group'] = self._route_url('group_read',
+                                             pubid=group.pubid,
+                                             slug=group.slug)
+        return links
+
+
+def group_links_factory(context, request):
+    """Return a GroupLinksService instance for the passed context and request."""
+    return GroupLinksService(request_authority=request.authority,
+                             route_url=request.route_url)

--- a/h/services/group_links.py
+++ b/h/services/group_links.py
@@ -9,20 +9,20 @@ class GroupLinksService(object):
     A service for providing appropriate links (URLs) for a given group object
     """
 
-    def __init__(self, request_authority, route_url):
+    def __init__(self, default_authority, route_url):
         """
         Create a group_links service.
 
-        :param request_authority: The request's "default" authority
+        :param default_authority: h's "default" authority
         :param route_url: The request's route_url method for building URLs
         """
-        self._authority = request_authority
+        self._default_authority = default_authority
         self._route_url = route_url
 
     def get_all(self, group):
         """Return a dict of all applicable links for this group"""
         links = {}
-        if group.authority == self._authority:
+        if group.authority == self._default_authority:
             # Only groups for the default authority should have an activity page
             # link. Note that the default authority may differ from the
             # user's authority.
@@ -34,5 +34,5 @@ class GroupLinksService(object):
 
 def group_links_factory(context, request):
     """Return a GroupLinksService instance for the passed context and request."""
-    return GroupLinksService(request_authority=request.authority,
+    return GroupLinksService(default_authority=request.authority,
                              route_url=request.route_url)

--- a/h/views/api_groups.py
+++ b/h/views/api_groups.py
@@ -15,7 +15,8 @@ from h.views.api import api_config
 def groups(request):
     authority = request.params.get('authority')
     document_uri = request.params.get('document_uri')
-    svc = request.find_service(name='list_groups')
+    list_svc = request.find_service(name='list_groups')
+    links_svc = request.find_service(name='group_links')
 
     if request.feature('filter_groups_by_scope'):
         # Filter open groups by scope against the ``document_uri`` param.
@@ -26,14 +27,14 @@ def groups(request):
             authority = request.user.authority
         else:
             authority = authority or request.authority
-        all_groups = svc.request_groups(user=request.user,
-                                        authority=authority,
-                                        document_uri=document_uri)
+        all_groups = list_svc.request_groups(user=request.user,
+                                             authority=authority,
+                                             document_uri=document_uri)
     else:
-        all_groups = svc.all_groups(user=request.user,
-                                    authority=authority,
-                                    document_uri=document_uri)
-    all_groups = GroupsJSONPresenter(all_groups, request.route_url).asdicts()
+        all_groups = list_svc.all_groups(user=request.user,
+                                         authority=authority,
+                                         document_uri=document_uri)
+    all_groups = GroupsJSONPresenter(all_groups, links_svc).asdicts()
     return all_groups
 
 

--- a/tests/h/services/group_links_test.py
+++ b/tests/h/services/group_links_test.py
@@ -36,7 +36,7 @@ class TestGroupLinksFactory(object):
 
         svc = group_links_factory(None, pyramid_request)
 
-        assert svc._authority == 'bar.com'
+        assert svc._default_authority == 'bar.com'
 
 
 @pytest.fixture
@@ -47,6 +47,6 @@ def routes(pyramid_config):
 @pytest.fixture
 def svc(pyramid_request, db_session):
     return GroupLinksService(
-        request_authority=pyramid_request.authority,
+        default_authority=pyramid_request.authority,
         route_url=pyramid_request.route_url
     )

--- a/tests/h/services/group_links_test.py
+++ b/tests/h/services/group_links_test.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import pytest
+
+from h.services.group_links import GroupLinksService
+from h.services.group_links import group_links_factory
+
+
+@pytest.mark.usefixtures('routes')
+class TestGroupLinks(object):
+
+    def test_it_returns_activity_link_for_default_authority_group(self, pyramid_request, factories, svc):
+        group = factories.OpenGroup(authority=pyramid_request.authority)
+        links = svc.get_all(group)
+
+        assert 'group' in links
+
+    def test_it_returns_no_activity_link_for_non_default_authority_group(self, pyramid_request, factories, svc):
+        group = factories.OpenGroup(authority='foo.com')
+        links = svc.get_all(group)
+
+        assert 'group' not in links
+
+
+class TestGroupLinksFactory(object):
+
+    def test_list_groups_factory(self, pyramid_request):
+        svc = group_links_factory(None, pyramid_request)
+
+        assert isinstance(svc, GroupLinksService)
+
+    def test_uses_request_authority(self, pyramid_request):
+        pyramid_request.authority = 'bar.com'
+
+        svc = group_links_factory(None, pyramid_request)
+
+        assert svc._authority == 'bar.com'
+
+
+@pytest.fixture
+def routes(pyramid_config):
+    pyramid_config.add_route('group_read', '/groups/{pubid}')
+
+
+@pytest.fixture
+def svc(pyramid_request, db_session):
+    return GroupLinksService(
+        request_authority=pyramid_request.authority,
+        route_url=pyramid_request.route_url
+    )


### PR DESCRIPTION
This is part of https://github.com/hypothesis/product-backlog/issues/487

Add an interstitial service so that we can remove URL/routing logic from `GroupJSONPresenter`. This will make things more manageable as our API response logic gets more complex.

The new service's `get_all` method is _loosely_ based on pre-existing `Links` service but is far less complex. It returns a dict of applicable URLs/links for a group.