### PR TITLE
Enforce group scope on `PATCH /api/annotations`

### DIFF
--- a/h/storage.py
+++ b/h/storage.py
@@ -160,7 +160,7 @@ def create_annotation(request, data, group_service):
     return annotation
 
 
-def update_annotation(session, id_, data):
+def update_annotation(session, id_, data, group_service):
     """
     Update an existing annotation and its associated document metadata.
 

--- a/h/storage.py
+++ b/h/storage.py
@@ -160,15 +160,14 @@ def create_annotation(request, data, group_service):
     return annotation
 
 
-def update_annotation(session, id_, data, group_service):
+def update_annotation(request, id_, data, group_service):
     """
     Update an existing annotation and its associated document metadata.
 
     Update the annotation identified by id_ with the given
     data. Create, delete and update document metadata as appropriate.
 
-    :param session: the database session
-    :type session: sqlalchemy.orm.session.Session
+    :param request: the request object
 
     :param id_: the ID of the annotation to be updated, this is assumed to be a
         validated ID of an annotation that does already exist in the database
@@ -176,6 +175,10 @@ def update_annotation(session, id_, data, group_service):
 
     :param data: the validated data with which to update the annotation
     :type data: dict
+
+    :param group_service: a service object that implements
+        :py:class:`h.interfaces.IGroupService`
+    :type group_service: :py:class:`h.interfaces.IGroupService`
 
     :returns: the updated annotation
     :rtype: h.models.Annotation
@@ -187,7 +190,7 @@ def update_annotation(session, id_, data, group_service):
     # annotation object.
     document = data.pop('document', None)
 
-    annotation = session.query(models.Annotation).get(id_)
+    annotation = request.db.query(models.Annotation).get(id_)
     annotation.updated = updated
 
     annotation.extra.update(data.pop('extra', {}))
@@ -198,7 +201,7 @@ def update_annotation(session, id_, data, group_service):
     if document:
         document_uri_dicts = document['document_uri_dicts']
         document_meta_dicts = document['document_meta_dicts']
-        document = update_document_metadata(session,
+        document = update_document_metadata(request.db,
                                             annotation.target_uri,
                                             document_meta_dicts,
                                             document_uri_dicts,

--- a/h/views/api.py
+++ b/h/views/api.py
@@ -172,7 +172,7 @@ def update(context, request):
     appstruct = schema.validate(_json_payload(request))
     group_service = request.find_service(IGroupService)
 
-    annotation = storage.update_annotation(request.db,
+    annotation = storage.update_annotation(request,
                                            context.annotation.id,
                                            appstruct,
                                            group_service)

--- a/h/views/api.py
+++ b/h/views/api.py
@@ -170,10 +170,12 @@ def update(context, request):
                                     context.annotation.target_uri,
                                     context.annotation.groupid)
     appstruct = schema.validate(_json_payload(request))
+    group_service = request.find_service(IGroupService)
 
     annotation = storage.update_annotation(request.db,
                                            context.annotation.id,
-                                           appstruct)
+                                           appstruct,
+                                           group_service)
 
     _publish_annotation_event(request, annotation, 'update')
 

--- a/tests/h/storage_test.py
+++ b/tests/h/storage_test.py
@@ -478,6 +478,15 @@ class TestUpdateAnnotation(object):
 
         assert str(exc.value).startswith('group scope: ')
 
+    def test_it_allows_group_scope_when_no_target_uri(self, annotation_data, pyramid_request, group_service, scoped_open_group):
+        annotation_data.pop('target_uri')
+        group_service.find.return_value = scoped_open_group
+
+        # this should not raise
+        annotation = storage.update_annotation(pyramid_request, 'test_annotation_id', annotation_data, group_service)
+
+        assert annotation == pyramid_request.db.query.return_value.get.return_value
+
     @pytest.mark.usefixtures('scope_feature_off')
     def test_it_allows_scope_mismatch_when_feature_off(self, annotation_data, pyramid_request, group_service, scoped_open_group):
         annotation_data['target_uri'] = u'http://www.bar.com/baz/ding.html'

--- a/tests/h/views/api_test.py
+++ b/tests/h/views/api_test.py
@@ -346,7 +346,8 @@ class TestUpdate(object):
     def test_it_updates_the_annotation_in_storage(self,
                                                   pyramid_request,
                                                   storage,
-                                                  update_schema):
+                                                  update_schema,
+                                                  group_service):
         context = mock.Mock()
         schema = update_schema.return_value
         schema.validate.return_value = mock.sentinel.validated_data
@@ -356,7 +357,8 @@ class TestUpdate(object):
         storage.update_annotation.assert_called_once_with(
             pyramid_request.db,
             context.annotation.id,
-            mock.sentinel.validated_data
+            mock.sentinel.validated_data,
+            group_service
         )
 
     def test_it_raises_if_storage_raises(self, pyramid_request, storage):

--- a/tests/h/views/api_test.py
+++ b/tests/h/views/api_test.py
@@ -355,7 +355,7 @@ class TestUpdate(object):
         views.update(context, pyramid_request)
 
         storage.update_annotation.assert_called_once_with(
-            pyramid_request.db,
+            pyramid_request,
             context.annotation.id,
             mock.sentinel.validated_data,
             group_service


### PR DESCRIPTION
This PR addresses the remainder of https://github.com/hypothesis/product-backlog/issues/483 by enforcing URI-level group scope on `PATCH` requests to `/api/annotations` (`h.storage.update_annotation`).

It required a bit of refactoring of the `update_annotation` method to get at a few more pieces of `request` that were needed, as well as the `group_service` for group lookup.

The service will raise (i.e. return a 400) if all of the following:

1. A request is made to `PATCH /api/annotations` containing a `target_uri` value (not all patches contain all fields)
2. The `filter_groups_by_scope` feature flag is ON
3. The annotation's group has 1 or more `scopes`
4. The new `target_uri` does not match any of the group's scopes