### PR TITLE
Fix remaining unit tests under Python 3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,18 +43,7 @@ test: node_modules/.uptodate
 
 .PHONY: test-py3
 test-py3: node_modules/.uptodate
-	@pip install -q tox
-	@mkdir -p .tox
-	@ # Ensure stdout is blocking. Travis appears to turn on O_NONBLOCK on stdout by default which
-	@ # can cause `tee` to fail if it receives `EAGAIN`. Requires Python >= 3.5.
-	@ # See https://github.com/travis-ci/travis-ci/issues/4704
-	@ python3 -c 'import os, sys; os.set_blocking(sys.stdout.fileno(), True);'
-	# 1. Run tox, configured to print just one line per error in the form `{path}:{line no}:{line}`.
-	# 2. Extract unique error locations and write to file.
-	tox -e py36 -- --tb=line --no-print-logs tests/h/ | tee .tox/py36-log
-	cat .tox/py36-log | egrep -o '/h/[^:]+:[0-9]+:' | sort | uniq > tests/py3-actual-failures.txt
-	# 3. Compare actual and expected failures, this command will fail if they differ.
-	diff -u tests/py3-expected-failures.txt tests/py3-actual-failures.txt
+	tox -e py36 -- tests/h/
 
 .PHONY: lint
 lint: .pydeps

--- a/tests/h/form_test.py
+++ b/tests/h/form_test.py
@@ -164,7 +164,7 @@ class TestToXHRResponse(object):
 @pytest.mark.usefixtures('to_xhr_response')
 class TestHandleFormSubmission(object):
 
-    def test_it_calls_validate(self, pyramid_request):
+    def test_it_calls_validate(self, pyramid_request, matchers):
         form_ = mock.Mock(spec_set=['validate'])
 
         form.handle_form_submission(pyramid_request,
@@ -172,7 +172,8 @@ class TestHandleFormSubmission(object):
                                     mock_callable(),
                                     mock.sentinel.on_failure)
 
-        form_.validate.assert_called_once_with(pyramid_request.POST.items())
+        post_items = matchers.iterable_with(list(pyramid_request.POST.items()))
+        form_.validate.assert_called_once_with(post_items)
 
     def test_if_validation_fails_it_calls_on_failure(self,
                                                      pyramid_request,

--- a/tests/py3-expected-failures.txt
+++ b/tests/py3-expected-failures.txt
@@ -1,1 +1,0 @@
-/h/tests/h/schemas/annotation_test.py:197:


### PR DESCRIPTION
This PR contains the two remaining fixes required for all unit tests to pass under Python 3. See commit messages for details.

Additionally it simplifies the `test-py3` make target to remove the diff-ing of actual and expected failures since there are none any longer.

The next step after this will be to resolve issues with functional tests and get them running under Python 3 on Jenkins.