### PR TITLE
Fix encoding issue when handling secret key

### DIFF
--- a/h/security.py
+++ b/h/security.py
@@ -31,6 +31,15 @@ password_context = CryptContext(schemes=['bcrypt'],
 
 
 def derive_key(key_material, salt, info):
+    """
+    Derive a fixed-size (64-byte) key for use in cryptographic operations.
+
+    See https://cryptography.io/en/latest/hazmat/primitives/key-derivation-functions/
+
+    :type key_material: str or bytes
+    :type salt: bytes
+    :type info: bytes
+    """
     if not isinstance(key_material, bytes):
         key_material = key_material.encode()
     algorithm = hashes.SHA512()

--- a/h/security.py
+++ b/h/security.py
@@ -31,6 +31,8 @@ password_context = CryptContext(schemes=['bcrypt'],
 
 
 def derive_key(key_material, salt, info):
+    if not isinstance(key_material, bytes):
+        key_material = key_material.encode()
     algorithm = hashes.SHA512()
     length = algorithm.digest_size
     hkdf = HKDF(algorithm, length, salt, info, backend)

--- a/tests/h/security_test.py
+++ b/tests/h/security_test.py
@@ -91,6 +91,10 @@ class TestDeriveKey(object):
 
         assert len(derived) == 64
 
+    def test_it_encodes_str_key_material(self):
+        derived = derive_key('akey', b'somesalt', b'some-info')
+        assert len(derived) == 64
+
 
 def test_password_context():
     assert isinstance(password_context, CryptContext)


### PR DESCRIPTION
On startup the app reads a secret key from an environment variable (cunningly named `SECREY_KEY`) as a string and then passes it to a function (`h.security.derive_key`) which expects bytes as input. This happens to work in Python 2 where `str` is the same as `bytes`. Since the data is almost always a randomly generated ASCII password, the easiest change was just to allow this function to accept a string and encode it if necessary.

----

With this change, it is now possible to run h against Python 3 locally:

1. Delete your `celerybeat-schedule` file in the "h" repo, since the DB format is not Py 2/3 compatible
2. Create a new virtualenv using Python 3.6 (eg. `vf new -p /usr/local/bin/python3 h-py3` if you're using virtualfish)
3. Run h as you normally do

To switch back to Py 2.x, you'll need to delete `celerybeat-schedule` again, switch your virtualenv and restart h.

Basic functionality appears to be working - activity pages, using the client and performing CRUD operations on annotations. Celery tasks don't run. This is resolved in https://github.com/hypothesis/h/pull/4842.