### PR TITLE
UI tweaks for group sidebar and "Matching annotations" header

### DIFF
--- a/h/static/styles/partials/_group-invite.scss
+++ b/h/static/styles/partials/_group-invite.scss
@@ -8,7 +8,7 @@
   padding-left: 5px;
   padding-right: 22px;  /* Make space for the clipboard icon. */
   padding-top: 0;
-  margin-top: 12px;
+  margin-top: 5px;
   margin-bottom: 8px;
   border: 1px solid $grey-3;
   border-radius: 2px;
@@ -24,7 +24,7 @@
   border: none;
   position: absolute;
   right: 0;
-  top: 12px;
+  top: 5px;
 
   display: none;
   .env-js-capable & {

--- a/h/static/styles/partials/_search-result-sidebar.scss
+++ b/h/static/styles/partials/_search-result-sidebar.scss
@@ -19,6 +19,7 @@
 }
 
 .search-result-sidebar__subtitle-count {
+  font-size: $normal-font-size;
   font-weight: normal;
 }
 
@@ -74,7 +75,7 @@
   background-color: $grey-2;
   border-radius: 2px;
   margin-bottom: 5px;
-  margin-right: 5px;
+  margin-right: 7px;
   padding-bottom: 1px;
   padding-top: 1px;
   padding-left: 3px;

--- a/h/static/styles/partials/_search.scss
+++ b/h/static/styles/partials/_search.scss
@@ -57,6 +57,7 @@
 }
 
 .search-results__total {
+  font-size: 1.1em;
   color: $brand;
   margin-bottom: 25px;
 }


### PR DESCRIPTION
Some subtle changes requested by @dawariley  to what's currently in QA:
- increase font size of # Matching Annotations
- make font size match between Top Tags and Members/Moderators counts
- move share/join group input closer to description/instructional text.

Before:
![image](https://user-images.githubusercontent.com/30059933/36818959-3201460c-1c9c-11e8-9691-74bd179e0035.png)


After:
![image](https://user-images.githubusercontent.com/30059933/36818837-c8ef97a4-1c9b-11e8-86c1-1cee5e05b902.png)
