### PR TITLE
Update Celery and Kombu dependencies

### DIFF
--- a/h/celery.py
+++ b/h/celery.py
@@ -31,9 +31,9 @@ celery = Celery('h')
 celery.conf.update(
     # Default to using database number 10 so we don't conflict with the session
     # store.
-    BROKER_URL=os.environ.get('CELERY_BROKER_URL',
+    broker_url=os.environ.get('CELERY_BROKER_URL',
                               os.environ.get('BROKER_URL', 'amqp://guest:guest@localhost:5672//')),
-    CELERYBEAT_SCHEDULE={
+    beat_schedule={
         'purge-deleted-annotations': {
             'task': 'h.tasks.cleanup.purge_deleted_annotations',
             'schedule': timedelta(hours=1)
@@ -55,26 +55,26 @@ celery.conf.update(
             'schedule': timedelta(hours=6)
         },
     },
-    CELERY_ACCEPT_CONTENT=['json'],
+    accept_content=['json'],
     # Enable at-least-once delivery mode. This probably isn't actually what we
     # want for all of our queues, but it makes the failure-mode behaviour of
     # Celery the same as our old NSQ worker:
-    CELERY_ACKS_LATE=True,
-    CELERY_DISABLE_RATE_LIMITS=True,
-    CELERY_IGNORE_RESULT=True,
-    CELERY_IMPORTS=(
+    task_acks_late=True,
+    worker_disable_rate_limits=True,
+    task_ignore_result=True,
+    imports=(
         'h.tasks.admin',
         'h.tasks.cleanup',
         'h.tasks.indexer',
         'h.tasks.mailer',
     ),
-    CELERY_ROUTES={
+    task_routes={
         'h.tasks.indexer.add_annotation': 'indexer',
         'h.tasks.indexer.delete_annotation': 'indexer',
         'h.tasks.indexer.reindex_user_annotations': 'indexer',
     },
-    CELERY_TASK_SERIALIZER='json',
-    CELERY_QUEUES=[
+    task_serializer='json',
+    task_queues=[
         Queue('celery',
               durable=True,
               routing_key='celery',
@@ -87,7 +87,7 @@ celery.conf.update(
     # Only accept one task at a time. This also probably isn't what we want
     # (especially not for, say, a search indexer task) but it makes the
     # behaviour consistent with the previous NSQ-based worker:
-    CELERYD_PREFETCH_MULTIPLIER=1,
+    worker_prefetch_multiplier=1,
 )
 
 

--- a/h/cli/commands/devserver.py
+++ b/h/cli/commands/devserver.py
@@ -80,7 +80,7 @@ def devserver(https, web, ws, worker, assets, beat):
         m.add_process('ws', 'gunicorn --name websocket --reload --paste conf/development-websocket.ini %s' % gunicorn_args)
 
     if worker:
-        m.add_process('worker', 'hypothesis --dev celery worker --autoreload -l INFO')
+        m.add_process('worker', 'hypothesis --dev celery worker -l INFO')
 
     if beat:
         m.add_process('beat', 'hypothesis --dev celery beat')

--- a/requirements.in
+++ b/requirements.in
@@ -4,7 +4,7 @@ alembic
 backports.functools_lru_cache
 bcrypt
 bleach >= 2.0
-celery == 3.1.25  # Pin to latest 3.1.x to ensure forwards-compat with 4.x
+celery >= 4.1
 certifi
 cffi
 click
@@ -19,7 +19,7 @@ gunicorn
 itsdangerous
 jsonpointer == 1.0
 jsonschema
-kombu <3.1 # Pinned because of celery pin
+kombu
 mistune
 newrelic
 oauthlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,14 +5,13 @@
 #    pip-compile --output-file requirements.txt requirements.in
 #
 alembic==0.9.7
-amqp==1.4.9               # via kombu
-anyjson==0.3.3            # via kombu
+amqp==2.2.2               # via kombu
 asn1crypto==0.22.0        # via cryptography
 backports.functools-lru-cache==1.2.1
 bcrypt==3.1.3
-billiard==3.3.0.23        # via celery
+billiard==3.5.0.3         # via celery
 bleach==2.1.3
-celery==3.1.25
+celery==4.1.0
 certifi==2016.2.28
 cffi==1.7.0
 chameleon==2.24           # via deform
@@ -36,7 +35,7 @@ itsdangerous==0.24
 jinja2==2.8               # via deform-jinja2, pyramid-jinja2
 jsonpointer==1.0
 jsonschema==2.5.1
-kombu==3.0.37
+kombu==4.1.0
 mako==1.0.4               # via alembic
 markupsafe==0.23          # via jinja2, mako, pyramid-jinja2
 mistune==0.7.3
@@ -74,6 +73,7 @@ translationstring==1.3    # via colander, deform, pyramid
 unidecode==0.4.19         # via python-slugify
 urllib3==1.16             # via elasticsearch
 venusian==1.0
+vine==1.1.4               # via amqp
 webencodings==0.5.1       # via html5lib
 webob==1.6.1              # via pyramid
 ws4py==0.4.2


### PR DESCRIPTION
Update Celery from 3.x to current 4.x release.

This is required to support the latest Python 3.x version. For changelog see http://celery.readthedocs.io/en/latest/whatsnew-4.0.html#upgrading-from-celery-3-1 . Note that we were already using 3.1.25 as highlighted in the migration notes.

The only breaking change I encountered was the removal of the `--autoreload` flag. I also applied an automated fix to `h/celery.py` to migrate setting names as documented in the changelog.

_Edit: Elsevier are also interested in this because I believe it should enable them to run h using Amazon SQS (which they already use) instead of setting up a separate RabbitMQ service._