### PR TITLE
Update cryptography dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ chameleon==2.24           # via deform
 click==6.6
 colander==1.3.1           # via deform
 contextlib2==0.5.4        # via raven
-cryptography==1.8.1
+cryptography==2.1.4
 deform-jinja2==0.5
 deform==0.9.9
 elasticsearch==1.9.0
@@ -42,7 +42,6 @@ markupsafe==0.23          # via jinja2, mako, pyramid-jinja2
 mistune==0.7.3
 newrelic==2.68.0.50
 oauthlib==2.0.2
-packaging==16.8           # via cryptography
 passlib==1.7.1
 pastedeploy==1.5.2        # via pyramid
 peppercorn==0.5           # via deform
@@ -67,7 +66,7 @@ repoze.lru==0.6           # via pyramid
 repoze.sendmail==4.3      # via pyramid-mailer
 requests-aws4auth==0.9
 requests==2.13.0          # via requests-aws4auth
-six==1.10.0               # via bcrypt, bleach, cryptography, html5lib, packaging, python-dateutil
+six==1.10.0               # via bcrypt, bleach, cryptography, html5lib, python-dateutil
 sqlalchemy==1.1.4
 statsd==3.2.1
 transaction==2.1.2


### PR DESCRIPTION
This is in preparation for updating the Alpine Linux base used by the Docker image from 3.4 => 3.7 and resolving a build issue I ran into along the way related to LibreSSL.

Upstream changelog: https://cryptography.io/en/latest/changelog/ . I cannot see any breaking changes that would affect us.