### PR TITLE
Update Alpine Linux base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN addgroup -S hypothesis && adduser -S -G hypothesis -h /var/lib/hypothesis hy
 WORKDIR /var/lib/hypothesis
 
 # Ensure nginx state and log directories writeable by unprivileged user.
-RUN chown -R hypothesis:hypothesis /var/log/nginx /var/lib/nginx
+RUN chown -R hypothesis:hypothesis /var/log/nginx /var/lib/nginx /var/tmp/nginx
 
 # Copy minimal data to allow installation of dependencies.
 COPY requirements.txt ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,16 @@
-FROM gliderlabs/alpine:3.4
+FROM alpine:3.7
 MAINTAINER Hypothes.is Project and contributors
 
 # Install system build and runtime dependencies.
-RUN apk-install \
+RUN apk add --no-cache \
     ca-certificates \
     collectd \
     collectd-nginx \
     libffi \
     libpq \
     nginx \
-    python \
-    py-pip \
+    python2 \
+    py2-pip \
     nodejs \
     git
 
@@ -25,7 +25,7 @@ RUN chown -R hypothesis:hypothesis /var/log/nginx /var/lib/nginx
 COPY requirements.txt ./
 
 # Install build deps, build, and then clean up.
-RUN apk-install --virtual build-deps \
+RUN apk add --no-cache --virtual build-deps \
     build-base \
     libffi-dev \
     postgresql-dev \
@@ -50,8 +50,7 @@ RUN [ -d .git ] && chown -R hypothesis:hypothesis .git || :
 
 # Build frontend assets
 RUN npm install --production \
-  && NODE_ENV=production node_modules/.bin/gulp build \
-  && npm cache clean
+  && NODE_ENV=production node_modules/.bin/gulp build
 
 # Expose the default port.
 EXPOSE 5000

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,7 @@ node {
                                          "-e ELASTICSEARCH_HOST=${elasticsearchHost} " +
                                          "-e TEST_DATABASE_URL=${databaseUrl}") {
                 // Test dependencies
-                sh 'apk-install build-base libffi-dev postgresql-dev python-dev'
+                sh 'apk add --no-cache build-base libffi-dev postgresql-dev python-dev'
                 sh 'pip install -q tox'
 
                 // Unit tests

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,23 @@ dev: build/manifest.json .pydeps
 docker:
 	git archive HEAD | docker build -t hypothesis/hypothesis:$(DOCKER_TAG) -
 
+# Run docker image built with `docker` task
+.PHONY: run-docker
+run-docker:
+	$(eval RABBITMQ_CONTAINER ?= rabbitmq)
+	$(eval PG_CONTAINER ?= postgres)
+	$(eval ES_CONTAINER ?= elasticsearch)
+	docker run \
+		--link $(RABBITMQ_CONTAINER) \
+		--link $(PG_CONTAINER) \
+		--link $(ES_CONTAINER) \
+		-e "APP_URL=http://localhost:5000" \
+		-e "BROKER_URL=amqp://guest:guest@$(RABBITMQ_CONTAINER):5672//" \
+		-e "DATABASE_URL=postgresql://postgres@$(PG_CONTAINER)/postgres" \
+		-e "ELASTICSEARCH_HOST=http://$(ES_CONTAINER):9200" \
+		-p 5000:5000 \
+		hypothesis/hypothesis:$(DOCKER_TAG)
+
 ## Run test suite
 .PHONY: test
 test: node_modules/.uptodate


### PR DESCRIPTION
Update the Alpine Linux base used by the Docker image from 3.4 to 3.7. Alpine is now an [official image](https://github.com/docker-library/official-images/pull/3762) rather than one from the gliderlabs org.

This brings along Python 3.6 but also security updates etc. in other packages. ~~Depends on https://github.com/hypothesis/h/pull/4843 for a build fix.~~

Changes required in the Dockerfile:

- Replaced removed `apk-install` with `apk add --no-cache`
- Fixed an issue on nginx startup by making a tmp dir it uses writable by the "hypothesis" user which runs nginx
- Removed use of `npm cache clean` which is no longer supported by the newer version of npm

I also added a script to document how to run an h Docker image built locally using `make docker`. Assuming you have a standard local dev setup using the suggested container names, `./scripts/run-h-dev-in-docker` will run the local Docker image configured to talk to the local Postgres, Elasticsearch and RabbitMQ containers.

