### PR TITLE
Fix some flakey tests

### DIFF
--- a/tests/common/factories/annotation.py
+++ b/tests/common/factories/annotation.py
@@ -77,15 +77,22 @@ class Annotation(ModelFactory):
         document_uri_dicts = [document_uri_dict()
                               for _ in range(random.randint(1, 3))]
 
-        def document_meta_dict(**kwargs):
+        def document_meta_dict(type_=None):
             """
             Return a randomly generated DocumentMeta dict for this annotation.
 
             This doesn't add anything to the database session yet.
             """
-            kwargs.setdefault('document', None)
-            kwargs.setdefault('claimant', self.target_uri)
+            kwargs = {
+                'document': None,
+                'claimant': self.target_uri,
+            }
+
+            if type_ is not None:
+                kwargs['type'] = type_
+
             document_meta = DocumentMeta.build(**kwargs)
+
             return dict(
                 claimant=document_meta.claimant,
                 type=document_meta.type,
@@ -98,7 +105,7 @@ class Annotation(ModelFactory):
         # Make sure that there's always at least one DocumentMeta with
         # type='title', so that we never get annotation.document.title is None:
         if 'title' not in [m['type'] for m in document_meta_dicts]:
-            document_meta_dicts.append(document_meta_dict(type='title'))
+            document_meta_dicts.append(document_meta_dict(type_='title'))
 
         self.document = update_document_metadata(
             orm.object_session(self),

--- a/tests/common/factories/annotation.py
+++ b/tests/common/factories/annotation.py
@@ -83,7 +83,7 @@ class Annotation(ModelFactory):
 
             This doesn't add anything to the database session yet.
             """
-            kwargs.setdefault('document', self.document)
+            kwargs.setdefault('document', None)
             kwargs.setdefault('claimant', self.target_uri)
             document_meta = DocumentMeta.build(**kwargs)
             return dict(


### PR DESCRIPTION
This fixes an `IntegrityError` that could be caused by the `Annotation` test factory that could cause many different tests to intermittently fail. It's a bit of a tricky one - see the individual commit messages. We should probably simplify a bunch of our test factories, not to mention our whole document equivalence system, to avoid this sort of thing. But for now this should fix some flakey tests.

Example of a flakey test fail caused by this: https://travis-ci.org/hypothesis/h/jobs/342170595

You can verify that `factories.Annotation` alone is responsible for crashes in a dev shell. This will crash:

```python
$ ./bin/hypothesis --dev shell
Python 2.7.14 (default, Sep 23 2017, 22:06:14)
Type "copyright", "credits" or "license" for more information.

IPython 5.5.0 -- An enhanced Interactive Python.
?         -> Introduction and overview of IPython's features.
%quickref -> Quick reference.
help      -> Python's own help system.
object?   -> Details about 'object', use 'object??' for extra details.

Environment:
  m, models    The `h.models` module.
  registry     Active Pyramid registry.
  request      Active request object.
  session      Active database session.

In [1]: from tests.common import factories

In [2]: factories.set_session(request.db)

In [3]: for _ in range(999999):
   ...:     factories.Annotation()
   ...:
```

Note there are multiple bugs with the annotation factory and this pr only fixes one of them. The above will still crash on this branch. More prs to follow.