### PR TITLE
Add "Create Group" Panel, Basic Parts of Form

### DIFF
--- a/h/routes.py
+++ b/h/routes.py
@@ -39,6 +39,7 @@ def includeme(config):
     config.add_route('admin_cohorts', '/admin/features/cohorts')
     config.add_route('admin_cohorts_edit', '/admin/features/cohorts/{id}')
     config.add_route('admin_groups', '/admin/groups')
+    config.add_route('admin_groups_create', '/admin/groups/new')
     config.add_route('admin_mailer', '/admin/mailer')
     config.add_route('admin_mailer_test', '/admin/mailer/test')
     config.add_route('admin_nipsa', '/admin/nipsa')

--- a/h/schemas/admin_group.py
+++ b/h/schemas/admin_group.py
@@ -32,7 +32,7 @@ class CreateAdminGroupSchema(CSRFSchema):
 
     name = colander.SchemaNode(
         colander.String(),
-        title=_('Name'),
+        title=_('Group Name'),
         validator=validators.Length(min=GROUP_NAME_MIN_LENGTH,
                                     max=GROUP_NAME_MAX_LENGTH),
     )
@@ -40,8 +40,17 @@ class CreateAdminGroupSchema(CSRFSchema):
     authority = colander.SchemaNode(
         colander.String(),
         title=_('Authority'),
+        description=_("The group's authority"),
         hint=_('The authority within which this group should be created.'
                ' Note that only users within the designated authority'
                ' will be able to be associated with this group (as'
                ' creator or member).')
+    )
+
+    creator = colander.SchemaNode(
+        colander.String(),
+        title=_('Creator'),
+        description=_("Username for this group's creator"),
+        hint=_('This user will be set as the "creator" of the group. Note that'
+               ' the user must be on the same authority as the group authority'),
     )

--- a/h/schemas/admin_group.py
+++ b/h/schemas/admin_group.py
@@ -17,9 +17,9 @@ from h.schemas.base import CSRFSchema
 _ = i18n.TranslationString
 
 VALID_GROUP_TYPES = (
-    (u'private', _('Private')),
-    (u'restricted', _('Restricted')),
-    (u'open', _('Open')),
+    ('private', _('Private')),
+    ('restricted', _('Restricted')),
+    ('open', _('Open')),
 )
 
 
@@ -28,7 +28,7 @@ class CreateAdminGroupSchema(CSRFSchema):
     group_type = colander.SchemaNode(
         colander.String(),
         title=_('Group Type'),
-        widget=SelectWidget(values=((u'', _('Select')),) + VALID_GROUP_TYPES)
+        widget=SelectWidget(values=(('', _('Select')),) + VALID_GROUP_TYPES)
     )
 
     name = colander.SchemaNode(

--- a/h/schemas/admin_group.py
+++ b/h/schemas/admin_group.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import colander
+
+from h import i18n
+from h import validators
+from h.models.group import (
+    GROUP_NAME_MIN_LENGTH,
+    GROUP_NAME_MAX_LENGTH,
+)
+from h.schemas.base import CSRFSchema
+
+_ = i18n.TranslationString
+
+
+class CreateAdminGroupSchema(CSRFSchema):
+    name = colander.SchemaNode(
+        colander.String(),
+        title=_('Name'),
+        validator=validators.Length(min=GROUP_NAME_MIN_LENGTH,
+                                    max=GROUP_NAME_MAX_LENGTH),
+    )
+
+    authority = colander.SchemaNode(
+        colander.String(),
+        title=_('Authority'),
+        hint=_('The authority within which this group should be created.'
+               ' Note that only users within the designated authority'
+               ' will be able to be associated with this group (as'
+               ' creator or member).')
+    )

--- a/h/schemas/admin_group.py
+++ b/h/schemas/admin_group.py
@@ -3,6 +3,7 @@
 from __future__ import unicode_literals
 
 import colander
+from deform.widget import SelectWidget
 
 from h import i18n
 from h import validators
@@ -14,8 +15,21 @@ from h.schemas.base import CSRFSchema
 
 _ = i18n.TranslationString
 
+VALID_GROUP_TYPES = (
+    (u'private', _('Private')),
+    (u'restricted', _('Restricted')),
+    (u'open', _('Open')),
+)
+
 
 class CreateAdminGroupSchema(CSRFSchema):
+
+    group_type = colander.SchemaNode(
+        colander.String(),
+        title=_('Group Type'),
+        widget=SelectWidget(values=((u'', _('Select')),) + VALID_GROUP_TYPES)
+    )
+
     name = colander.SchemaNode(
         colander.String(),
         title=_('Name'),

--- a/h/schemas/admin_group.py
+++ b/h/schemas/admin_group.py
@@ -3,13 +3,14 @@
 from __future__ import unicode_literals
 
 import colander
-from deform.widget import SelectWidget
+from deform.widget import SelectWidget, TextAreaWidget
 
 from h import i18n
 from h import validators
 from h.models.group import (
     GROUP_NAME_MIN_LENGTH,
     GROUP_NAME_MAX_LENGTH,
+    GROUP_DESCRIPTION_MAX_LENGTH
 )
 from h.schemas.base import CSRFSchema
 
@@ -53,4 +54,13 @@ class CreateAdminGroupSchema(CSRFSchema):
         description=_("Username for this group's creator"),
         hint=_('This user will be set as the "creator" of the group. Note that'
                ' the user must be on the same authority as the group authority'),
+    )
+
+    description = colander.SchemaNode(
+        colander.String(),
+        title=_('Description'),
+        description=_('Optional group description'),
+        validator=colander.Length(max=GROUP_DESCRIPTION_MAX_LENGTH),
+        widget=TextAreaWidget(rows=3),
+        missing=None
     )

--- a/h/schemas/admin_group.py
+++ b/h/schemas/admin_group.py
@@ -3,7 +3,7 @@
 from __future__ import unicode_literals
 
 import colander
-from deform.widget import SelectWidget, TextAreaWidget
+from deform.widget import SelectWidget, TextInputWidget
 
 from h import i18n
 from h import validators
@@ -61,6 +61,6 @@ class CreateAdminGroupSchema(CSRFSchema):
         title=_('Description'),
         description=_('Optional group description'),
         validator=colander.Length(max=GROUP_DESCRIPTION_MAX_LENGTH),
-        widget=TextAreaWidget(rows=3),
+        widget=TextInputWidget(rows=3),
         missing=None
     )

--- a/h/static/styles/admin.scss
+++ b/h/static/styles/admin.scss
@@ -31,3 +31,7 @@ body {
 .pager .pager__item--more {
   border: none;
 }
+
+.form-input__error-list {
+  list-style-type: none;
+}

--- a/h/static/styles/partials/_form-input.scss
+++ b/h/static/styles/partials/_form-input.scss
@@ -149,6 +149,11 @@
     border-radius: 3px;
   }
 
+  select.form-input__input {
+    margin-top: $top-padding;
+    height: $hint-height;
+  }
+
   .form-input__input.has-hint {
     .env-js-capable & {
       padding-top: $top-padding;

--- a/h/static/styles/partials/_form-input.scss
+++ b/h/static/styles/partials/_form-input.scss
@@ -151,7 +151,6 @@
 
   select.form-input__input {
     margin-top: $top-padding;
-    height: $hint-height;
   }
 
   .form-input__input.has-hint {

--- a/h/templates/admin/groups_create.html.jinja2
+++ b/h/templates/admin/groups_create.html.jinja2
@@ -1,0 +1,10 @@
+{% extends "h:templates/layouts/admin.html.jinja2" %}
+
+{% set page_id = 'groups_create' %}
+{% set page_title = 'Create Group' %}
+
+{% block content %}
+  <p>
+    On this page you will ultimately be able to create a new group.
+  </p>
+{% endblock %}

--- a/h/templates/admin/groups_create.html.jinja2
+++ b/h/templates/admin/groups_create.html.jinja2
@@ -6,5 +6,6 @@
 {% block content %}
   <p>
     On this page you will ultimately be able to create a new group.
+    {{ foo }}
   </p>
 {% endblock %}

--- a/h/templates/admin/groups_create.html.jinja2
+++ b/h/templates/admin/groups_create.html.jinja2
@@ -6,6 +6,7 @@
 {% block content %}
   <p>
     On this page you will ultimately be able to create a new group.
-    {{ foo }}
   </p>
+
+  {{ form }}
 {% endblock %}

--- a/h/templates/deform/select.jinja2
+++ b/h/templates/deform/select.jinja2
@@ -1,0 +1,14 @@
+<select
+{% include "includes/common_attrs.jinja2" %}
+>
+{% for value, description in field.widget.values %}
+ <option
+        {% if value == cstruct %}
+        selected="selected"
+        {% endif %}
+        {% if field.widget.css_class %}
+        class="{{ field.widget.css_class }}"
+        {% endif %}
+        value="{{ value }}">{{ description }}</option>
+{% endfor %}
+</select>

--- a/h/templates/layouts/admin.html.jinja2
+++ b/h/templates/layouts/admin.html.jinja2
@@ -7,7 +7,10 @@
       ('features', 'admin_features', 'Manage feature flags'),
       ('cohorts', 'admin_cohorts', 'Manage feature cohorts'),
     ]),
-    ('groups', 'admin_groups', 'Groups', []),
+    ('groups', 'admin_groups', 'Groups', [
+      ('groups', 'admin_groups', 'List Groups'),
+      ('groups_create', 'admin_groups_create', 'Create a Group'),
+    ]),
     ('mailer', 'admin_mailer', 'Mailer', []),
     ('nipsa', 'admin_nipsa', 'NIPSA', []),
     ('oauth', 'admin_oauthclients', 'OAuth clients', []),

--- a/h/views/admin_groups.py
+++ b/h/views/admin_groups.py
@@ -36,6 +36,7 @@ class GroupCreateController(object):
     def get(self):
         self.form.set_appstruct({
             'authority': self.request.authority,
+            'creator': self.request.user.username,
         })
         return self._template_context()
 
@@ -43,7 +44,15 @@ class GroupCreateController(object):
     def post(self):
         def on_success(appstruct):
             read_url = self.request.route_url('admin_groups')
-            return HTTPFound(location=read_url)
+            self.request.session.flash('TODO: I will add a {gtype} group called "{name}"'
+                                       ' for authority {authority}, created by {creator}'.format(
+                                            gtype=appstruct['group_type'],
+                                            name=appstruct['name'],
+                                            authority=appstruct['authority'],
+                                            creator=appstruct['creator']
+                                       ), queue='success')
+            response = HTTPFound(location=read_url)
+            return response
 
         return form.handle_form_submission(self.request, self.form,
                                            on_success=on_success,

--- a/h/views/admin_groups.py
+++ b/h/views/admin_groups.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from pyramid.view import view_config, view_defaults
+from pyramid.httpexceptions import HTTPFound
 
 from h import form  # noqa F401
 from h import i18n
@@ -37,6 +38,16 @@ class GroupCreateController(object):
             'authority': self.request.authority,
         })
         return self._template_context()
+
+    @view_config(request_method='POST')
+    def post(self):
+        def on_success(appstruct):
+            read_url = self.request.route_url('admin_groups')
+            return HTTPFound(location=read_url)
+
+        return form.handle_form_submission(self.request, self.form,
+                                           on_success=on_success,
+                                           on_failure=self._template_context)
 
     def _template_context(self):
         return {'form': self.form.render()}

--- a/h/views/admin_groups.py
+++ b/h/views/admin_groups.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from pyramid.view import view_config
+from pyramid.view import view_config, view_defaults
 
 from h import models
 from h import paginator
@@ -15,9 +15,23 @@ def groups_index(context, request):
     return request.db.query(models.Group).order_by(models.Group.created.desc())
 
 
-@view_config(route_name='admin_groups_create',
-             request_method='GET',
-             renderer='h:templates/admin/groups_create.html.jinja2',
-             permission='admin_groups')
-def groups_create(context, request):
-    return []
+@view_defaults(route_name='admin_groups_create',
+               renderer='h:templates/admin/groups_create.html.jinja2',
+               permission='admin_groups')
+class GroupCreateController(object):
+
+    def __init__(self, request):
+        self.request = request
+
+    @view_config(request_method='GET')
+    def get(self):
+        # self.form.set_appstruct({
+        #     'authority': self.request.authority,
+        #     'grant_type': GrantType.authorization_code,
+        #     'response_type': ResponseType.code,
+        #     'trusted': False,
+        # })
+        return self._template_context()
+
+    def _template_context(self):
+        return {'foo': 'bar'}

--- a/h/views/admin_groups.py
+++ b/h/views/admin_groups.py
@@ -2,8 +2,13 @@
 
 from pyramid.view import view_config, view_defaults
 
+from h import form  # noqa F401
+from h import i18n
 from h import models
 from h import paginator
+from h.schemas.admin_group import CreateAdminGroupSchema
+
+_ = i18n.TranslationString
 
 
 @view_config(route_name='admin_groups',
@@ -22,16 +27,16 @@ class GroupCreateController(object):
 
     def __init__(self, request):
         self.request = request
+        self.schema = CreateAdminGroupSchema().bind(request=request)
+        self.form = request.create_form(self.schema,
+                                        buttons=(_('Create New Group'),))
 
     @view_config(request_method='GET')
     def get(self):
-        # self.form.set_appstruct({
-        #     'authority': self.request.authority,
-        #     'grant_type': GrantType.authorization_code,
-        #     'response_type': ResponseType.code,
-        #     'trusted': False,
-        # })
+        self.form.set_appstruct({
+            'authority': self.request.authority,
+        })
         return self._template_context()
 
     def _template_context(self):
-        return {'foo': 'bar'}
+        return {'form': self.form.render()}

--- a/h/views/admin_groups.py
+++ b/h/views/admin_groups.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals
 
 from pyramid.view import view_config, view_defaults
 from pyramid.httpexceptions import HTTPFound

--- a/h/views/admin_groups.py
+++ b/h/views/admin_groups.py
@@ -13,3 +13,11 @@ from h import paginator
 @paginator.paginate_query
 def groups_index(context, request):
     return request.db.query(models.Group).order_by(models.Group.created.desc())
+
+
+@view_config(route_name='admin_groups_create',
+             request_method='GET',
+             renderer='h:templates/admin/groups_create.html.jinja2',
+             permission='admin_groups')
+def groups_create(context, request):
+    return []

--- a/tests/h/routes_test.py
+++ b/tests/h/routes_test.py
@@ -42,6 +42,7 @@ def test_includeme():
         call('admin_cohorts', '/admin/features/cohorts'),
         call('admin_cohorts_edit', '/admin/features/cohorts/{id}'),
         call('admin_groups', '/admin/groups'),
+        call('admin_groups_create', '/admin/groups/new'),
         call('admin_mailer', '/admin/mailer'),
         call('admin_mailer_test', '/admin/mailer/test'),
         call('admin_nipsa', '/admin/nipsa'),

--- a/tests/h/schemas/admin_group_test.py
+++ b/tests/h/schemas/admin_group_test.py
@@ -18,7 +18,7 @@ class TestCreateGroupSchema(object):
         bound_schema.deserialize(group_data)
 
     def test_it_raises_if_name_too_short(self, group_data, bound_schema):
-        too_short_name = u'a' * (GROUP_NAME_MIN_LENGTH - 1)
+        too_short_name = 'a' * (GROUP_NAME_MIN_LENGTH - 1)
         group_data['name'] = too_short_name
         with pytest.raises(colander.Invalid) as exc:
             bound_schema.deserialize(group_data)
@@ -26,7 +26,7 @@ class TestCreateGroupSchema(object):
         assert str(exc.value).find('name') >= 0
 
     def test_it_raises_if_name_too_long(self, group_data, bound_schema):
-        too_long_name = u'a' * (GROUP_NAME_MAX_LENGTH + 1)
+        too_long_name = 'a' * (GROUP_NAME_MAX_LENGTH + 1)
         group_data['name'] = too_long_name
         with pytest.raises(colander.Invalid) as exc:
             bound_schema.deserialize(group_data)
@@ -34,7 +34,7 @@ class TestCreateGroupSchema(object):
         assert str(exc.value).find('name') >= 0
 
     def test_it_raises_if_description_too_long(self, group_data, bound_schema):
-        too_long_description = u'a' * (GROUP_DESCRIPTION_MAX_LENGTH + 1)
+        too_long_description = 'a' * (GROUP_DESCRIPTION_MAX_LENGTH + 1)
         group_data['description'] = too_long_description
 
         with pytest.raises(colander.Invalid) as exc:
@@ -64,11 +64,11 @@ class TestCreateGroupSchema(object):
 @pytest.fixture
 def group_data(factories):
     return {
-        'name': u'My Group',
-        'authority': u'example.com',
-        'group_type': u'open',
+        'name': 'My Group',
+        'authority': 'example.com',
+        'group_type': 'open',
         'creator': factories.User().username,
-        'description': u'Lorem ipsum dolor sit amet consectetuer',
+        'description': 'Lorem ipsum dolor sit amet consectetuer',
     }
 
 

--- a/tests/h/schemas/admin_group_test.py
+++ b/tests/h/schemas/admin_group_test.py
@@ -7,6 +7,7 @@ import pytest
 from h.models.group import (
     GROUP_NAME_MIN_LENGTH,
     GROUP_NAME_MAX_LENGTH,
+    GROUP_DESCRIPTION_MAX_LENGTH
 )
 from h.schemas.admin_group import CreateAdminGroupSchema
 
@@ -32,6 +33,15 @@ class TestCreateGroupSchema(object):
 
         assert str(exc.value).find('name') >= 0
 
+    def test_it_raises_if_description_too_long(self, group_data, bound_schema):
+        too_long_description = u'a' * (GROUP_DESCRIPTION_MAX_LENGTH + 1)
+        group_data['description'] = too_long_description
+
+        with pytest.raises(colander.Invalid) as exc:
+            bound_schema.deserialize(group_data)
+
+        assert str(exc.value).find('description') >= 0
+
     @pytest.mark.parametrize('required_field', (
         'name',
         'authority',
@@ -45,6 +55,11 @@ class TestCreateGroupSchema(object):
 
         assert str(exc.value).find(required_field) >= 0
 
+    def test_it_allows_when_optional_field_missing(self, group_data, bound_schema):
+        group_data.pop('description')
+
+        bound_schema.deserialize(group_data)
+
 
 @pytest.fixture
 def group_data(factories):
@@ -52,7 +67,8 @@ def group_data(factories):
         'name': u'My Group',
         'authority': u'example.com',
         'group_type': u'open',
-        'creator': factories.User().username
+        'creator': factories.User().username,
+        'description': u'Lorem ipsum dolor sit amet consectetuer',
     }
 
 

--- a/tests/h/schemas/admin_group_test.py
+++ b/tests/h/schemas/admin_group_test.py
@@ -13,6 +13,9 @@ from h.schemas.admin_group import CreateAdminGroupSchema
 
 class TestCreateGroupSchema(object):
 
+    def test_it_allows_with_valid_data(self, group_data, bound_schema):
+        bound_schema.deserialize(group_data)
+
     def test_it_raises_if_name_too_short(self, group_data, bound_schema):
         too_short_name = u'a' * (GROUP_NAME_MIN_LENGTH - 1)
         group_data['name'] = too_short_name
@@ -43,12 +46,21 @@ class TestCreateGroupSchema(object):
 
         assert str(exc.value).find('authority') >= 0
 
+    def test_it_raises_if_group_type_missing(self, group_data, bound_schema):
+        group_data.pop('group_type')
+
+        with pytest.raises(colander.Invalid) as exc:
+            bound_schema.deserialize(group_data)
+
+        assert str(exc.value).find('group_type') >= 0
+
 
 @pytest.fixture
 def group_data():
     return {
         'name': u'My Group',
-        'authority': u'example.com'
+        'authority': u'example.com',
+        'group_type': u'open'
     }
 
 

--- a/tests/h/schemas/admin_group_test.py
+++ b/tests/h/schemas/admin_group_test.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import colander
+import pytest
+
+from h.models.group import (
+    GROUP_NAME_MIN_LENGTH,
+    GROUP_NAME_MAX_LENGTH,
+)
+from h.schemas.admin_group import CreateAdminGroupSchema
+
+
+class TestCreateGroupSchema(object):
+
+    def test_it_raises_if_name_too_short(self, group_data, bound_schema):
+        too_short_name = u'a' * (GROUP_NAME_MIN_LENGTH - 1)
+        group_data['name'] = too_short_name
+        with pytest.raises(colander.Invalid) as exc:
+            bound_schema.deserialize(group_data)
+
+        assert str(exc.value).find('name') >= 0
+
+    def test_it_raises_if_name_too_long(self, group_data, bound_schema):
+        too_long_name = u'a' * (GROUP_NAME_MAX_LENGTH + 1)
+        group_data['name'] = too_long_name
+        with pytest.raises(colander.Invalid) as exc:
+            bound_schema.deserialize(group_data)
+
+        assert str(exc.value).find('name') >= 0
+
+    def test_it_raises_if_name_missing(self, group_data, bound_schema):
+        group_data.pop('name')
+        with pytest.raises(colander.Invalid) as exc:
+            bound_schema.deserialize(group_data)
+
+        assert str(exc.value).find('name') >= 0
+
+    def test_it_raises_if_authority_missing(self, group_data, bound_schema):
+        group_data.pop('authority')
+        with pytest.raises(colander.Invalid) as exc:
+            bound_schema.deserialize(group_data)
+
+        assert str(exc.value).find('authority') >= 0
+
+
+@pytest.fixture
+def group_data():
+    return {
+        'name': u'My Group',
+        'authority': u'example.com'
+    }
+
+
+@pytest.fixture
+def bound_schema(pyramid_csrf_request):
+    schema = CreateAdminGroupSchema().bind(request=pyramid_csrf_request)
+    return schema

--- a/tests/h/schemas/admin_group_test.py
+++ b/tests/h/schemas/admin_group_test.py
@@ -20,27 +20,23 @@ class TestCreateGroupSchema(object):
     def test_it_raises_if_name_too_short(self, group_data, bound_schema):
         too_short_name = 'a' * (GROUP_NAME_MIN_LENGTH - 1)
         group_data['name'] = too_short_name
-        with pytest.raises(colander.Invalid) as exc:
-            bound_schema.deserialize(group_data)
 
-        assert str(exc.value).find('name') >= 0
+        with pytest.raises(colander.Invalid, match='.*name.*'):
+            bound_schema.deserialize(group_data)
 
     def test_it_raises_if_name_too_long(self, group_data, bound_schema):
         too_long_name = 'a' * (GROUP_NAME_MAX_LENGTH + 1)
         group_data['name'] = too_long_name
-        with pytest.raises(colander.Invalid) as exc:
-            bound_schema.deserialize(group_data)
 
-        assert str(exc.value).find('name') >= 0
+        with pytest.raises(colander.Invalid, match='.*name.*'):
+            bound_schema.deserialize(group_data)
 
     def test_it_raises_if_description_too_long(self, group_data, bound_schema):
         too_long_description = 'a' * (GROUP_DESCRIPTION_MAX_LENGTH + 1)
         group_data['description'] = too_long_description
 
-        with pytest.raises(colander.Invalid) as exc:
+        with pytest.raises(colander.Invalid, match='.*description.*'):
             bound_schema.deserialize(group_data)
-
-        assert str(exc.value).find('description') >= 0
 
     @pytest.mark.parametrize('required_field', (
         'name',
@@ -50,10 +46,9 @@ class TestCreateGroupSchema(object):
     ))
     def test_it_raises_if_required_field_missing(self, group_data, bound_schema, required_field):
         group_data.pop(required_field)
-        with pytest.raises(colander.Invalid) as exc:
-            bound_schema.deserialize(group_data)
 
-        assert str(exc.value).find(required_field) >= 0
+        with pytest.raises(colander.Invalid, match='.*{field}.*'.format(field=required_field)):
+            bound_schema.deserialize(group_data)
 
     def test_it_allows_when_optional_field_missing(self, group_data, bound_schema):
         group_data.pop('description')

--- a/tests/h/schemas/admin_group_test.py
+++ b/tests/h/schemas/admin_group_test.py
@@ -32,35 +32,27 @@ class TestCreateGroupSchema(object):
 
         assert str(exc.value).find('name') >= 0
 
-    def test_it_raises_if_name_missing(self, group_data, bound_schema):
-        group_data.pop('name')
+    @pytest.mark.parametrize('required_field', (
+        'name',
+        'authority',
+        'group_type',
+        'creator'
+    ))
+    def test_it_raises_if_required_field_missing(self, group_data, bound_schema, required_field):
+        group_data.pop(required_field)
         with pytest.raises(colander.Invalid) as exc:
             bound_schema.deserialize(group_data)
 
-        assert str(exc.value).find('name') >= 0
-
-    def test_it_raises_if_authority_missing(self, group_data, bound_schema):
-        group_data.pop('authority')
-        with pytest.raises(colander.Invalid) as exc:
-            bound_schema.deserialize(group_data)
-
-        assert str(exc.value).find('authority') >= 0
-
-    def test_it_raises_if_group_type_missing(self, group_data, bound_schema):
-        group_data.pop('group_type')
-
-        with pytest.raises(colander.Invalid) as exc:
-            bound_schema.deserialize(group_data)
-
-        assert str(exc.value).find('group_type') >= 0
+        assert str(exc.value).find(required_field) >= 0
 
 
 @pytest.fixture
-def group_data():
+def group_data(factories):
     return {
         'name': u'My Group',
         'authority': u'example.com',
-        'group_type': u'open'
+        'group_type': u'open',
+        'creator': factories.User().username
     }
 
 

--- a/tests/h/views/admin_groups_test.py
+++ b/tests/h/views/admin_groups_test.py
@@ -45,6 +45,27 @@ class TestGroupCreateController(object):
 
         assert 'form' in ctx
 
+    def test_it_handles_form_submission(self, pyramid_request, handle_form_submission, matchers):
+        ctrl = GroupCreateController(pyramid_request)
+
+        ctrl.post()
+
+        handle_form_submission.assert_called_once_with(
+            ctrl.request,
+            ctrl.form,
+            matchers.any_callable(),
+            ctrl._template_context
+        )
+
+    def test_post_redirects_to_list_view_on_success(self, pyramid_request, matchers, routes):
+        pyramid_request.POST = {'name': 'foobar'}
+        ctrl = GroupCreateController(pyramid_request)
+
+        response = ctrl.post()
+
+        expected_location = pyramid_request.route_url('admin_groups')
+        assert response == matchers.redirect_302_to(expected_location)
+
 
 @pytest.fixture
 def pyramid_request(pyramid_request):
@@ -60,6 +81,11 @@ def authority():
 @pytest.fixture
 def paginate(patch):
     return patch('h.views.admin_groups.paginator.paginate')
+
+
+@pytest.fixture
+def handle_form_submission(patch):
+    return patch('h.views.admin_groups.form.handle_form_submission')
 
 
 @pytest.fixture

--- a/tests/h/views/admin_groups_test.py
+++ b/tests/h/views/admin_groups_test.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import datetime
+
+import pytest
+import mock
+
+# from h.models.auth_client import AuthClient, GrantType, ResponseType
+from h.views import admin_groups
+
+
+def test_index_lists_groups_sorted_by_created_desc(pyramid_request, routes, factories, authority):
+    groups = [factories.Group(created=datetime.datetime(2017, 8, 2)),
+              factories.Group(created=datetime.datetime(2015, 2, 1)),
+              factories.Group(),
+              factories.Group(created=datetime.datetime(2013, 2, 1))]
+
+    ctx = admin_groups.groups_index(None, pyramid_request)
+
+    # We can't avoid getting the Public group back, which is created outside of
+    # these tests' sphere of influence. Remove it as it is not feasible to
+    # assert where it will appear in creation order.
+    filtered_groups = list(filter(lambda group: group.pubid != u'__world__',
+                                  ctx['results']))
+
+    expected_groups = [groups[2], groups[0], groups[1], groups[3]]
+    assert filtered_groups == expected_groups
+
+
+def test_index_paginates_results(pyramid_request, routes, paginate):
+    admin_groups.groups_index(None, pyramid_request)
+
+    paginate.assert_called_once_with(pyramid_request, mock.ANY, mock.ANY)
+
+
+@pytest.fixture
+def pyramid_request(pyramid_request):
+    pyramid_request.session = mock.Mock(spec_set=['flash', 'get_csrf_token'])
+    return pyramid_request
+
+
+@pytest.fixture
+def authority():
+    return 'foo.com'
+
+
+@pytest.fixture
+def paginate(patch):
+    return patch('h.views.admin_groups.paginator.paginate')
+
+
+@pytest.fixture
+def routes(pyramid_config):
+    pyramid_config.add_route('admin_groups', '/admin/groups')
+    pyramid_config.add_route('admin_groups_create', '/admin/groups/new')

--- a/tests/h/views/admin_groups_test.py
+++ b/tests/h/views/admin_groups_test.py
@@ -23,7 +23,7 @@ def test_index_lists_groups_sorted_by_created_desc(pyramid_request, routes, fact
     # We can't avoid getting the Public group back, which is created outside of
     # these tests' sphere of influence. Remove it as it is not feasible to
     # assert where it will appear in creation order.
-    filtered_groups = list(filter(lambda group: group.pubid != u'__world__',
+    filtered_groups = list(filter(lambda group: group.pubid != '__world__',
                                   ctx['results']))
 
     expected_groups = [groups[2], groups[0], groups[1], groups[3]]

--- a/tests/h/views/admin_groups_test.py
+++ b/tests/h/views/admin_groups_test.py
@@ -9,6 +9,7 @@ import mock
 
 # from h.models.auth_client import AuthClient, GrantType, ResponseType
 from h.views import admin_groups
+from h.views.admin_groups import GroupCreateController
 
 
 def test_index_lists_groups_sorted_by_created_desc(pyramid_request, routes, factories, authority):
@@ -33,6 +34,16 @@ def test_index_paginates_results(pyramid_request, routes, paginate):
     admin_groups.groups_index(None, pyramid_request)
 
     paginate.assert_called_once_with(pyramid_request, mock.ANY, mock.ANY)
+
+
+class TestGroupCreateController(object):
+
+    def test_get_sets_foo(self, pyramid_request):
+        ctrl = GroupCreateController(pyramid_request)
+
+        ctx = ctrl.get()
+
+        assert 'foo' in ctx
 
 
 @pytest.fixture

--- a/tests/h/views/admin_groups_test.py
+++ b/tests/h/views/admin_groups_test.py
@@ -38,12 +38,12 @@ def test_index_paginates_results(pyramid_request, routes, paginate):
 
 class TestGroupCreateController(object):
 
-    def test_get_sets_foo(self, pyramid_request):
+    def test_get_sets_form(self, pyramid_request):
         ctrl = GroupCreateController(pyramid_request)
 
         ctx = ctrl.get()
 
-        assert 'foo' in ctx
+        assert 'form' in ctx
 
 
 @pytest.fixture


### PR DESCRIPTION
This PR represents work as part of https://github.com/hypothesis/product-backlog/issues/421

This PR:

* adds a new admin view ("panel") for creating a new group and its supporting elements
* adds a basic form with _some_ of the fields needed to create groups effectively and associated schema
* adds rudimentary form-submit handling with a redirect back to the list-groups page

I am submitting a PR at this point for a number of reasons. https://github.com/hypothesis/product-backlog/issues/421 has a lot of work in it. The diff here is already getting long. I'm butting up against a number of "should I really do it this way?" questions.

Please keep in mind that this work, _especially_ the fields and the form and whatnot, are very preliminary. Don't be alarmed by, e.g., the "type" field allowing you to create "private" groups in addition to open and restricted—we can hash that out later; or that there is no field for adding scopes—yet. The most important thing to note is that the submit-handling for this form _does not yet actually add any groups_. This is preliminary work to that.

----

Here are some screen shots for the curious.

Creating a new "group" of admin panels for groups:

![screen shot 2018-03-01 at 3 42 09 pm](https://user-images.githubusercontent.com/439947/36869167-d45d6436-1d68-11e8-84f1-e09ea31c230a.png)

The default layout and styling of the auto-generated form (via `deform`) had some significant defects, even by admin-use-only standards:

![image](https://user-images.githubusercontent.com/439947/36869315-5bb56a6e-1d69-11e8-946f-6e53436ecf6f.png)

1. The select-list label was sitting on top of the select element and the element itself is small and not like the other elements on the page
2. Crazy absolute alignment and dots
3. This little black list dot who even knows

So, I fixed those most egregious issues:

![image](https://user-images.githubusercontent.com/439947/36869381-9eddfa90-1d69-11e8-9cd2-d8276991d5a0.png)

1. Label alignment for select
2. Select spans width of parent, looks more like its peers, is also taller
3. No more odd alignment or list-element disc styling
4. bye bye random dot

At present, if you successfully submit a valid form, you'll get redirected back to the main groups panel, like so:

![screen shot 2018-03-01 at 3 47 14 pm](https://user-images.githubusercontent.com/439947/36869430-c9ab8012-1d69-11e8-95b0-3433b2f7c14b.png)

Ain't gonna lie—parts of this felt like pulling teeth, and I'm worried I may be headed down a few dead-end paths; part of why I'm PR-ing at this point. If this is way off-track, we can consider it a WIP PR.