### PR TITLE
Converge on grey-6, font size & adjust icon margin in sidebar

### DIFF
--- a/h/static/styles/partials/_base.scss
+++ b/h/static/styles/partials/_base.scss
@@ -39,6 +39,9 @@ $title-font-size: 19px;
 // Font sizes for specific categories of control
 $input-font-size: 15px;
 
+// Font size for search results "# Matching Annotations" & sidebar subtitles
+$search-results-subtitle-font-size: 15px;
+
 // Minimum font size for <input> fields on iOS. If the font size is smaller than
 // this, iOS will zoom into the field when focused.
 $touch-input-font-size: 16px;

--- a/h/static/styles/partials/_group-invite.scss
+++ b/h/static/styles/partials/_group-invite.scss
@@ -26,6 +26,7 @@
   position: absolute;
   right: 0;
   top: 5px;
+  margin-right: 5px;
 
   display: none;
   .env-js-capable & {

--- a/h/static/styles/partials/_group-invite.scss
+++ b/h/static/styles/partials/_group-invite.scss
@@ -15,6 +15,7 @@
   width: 100%;
   height: 31px;
   text-overflow: ellipsis;
+  color: $grey-6;
 }
 
 .group-invite__clipboard-button {

--- a/h/static/styles/partials/_search-result-sidebar.scss
+++ b/h/static/styles/partials/_search-result-sidebar.scss
@@ -45,6 +45,7 @@
 }
 
 .search-result-sidebar__subsection-key {
+  color: $grey-6;
   font-weight: bold;
 }
 
@@ -97,6 +98,7 @@
   font-weight: bold;
   margin-right: 3px;
   margin-bottom: 7px;
+  color: $grey-6;
 }
 
 @media screen and (max-width: $tablet-width + 250px) {

--- a/h/static/styles/partials/_search-result-sidebar.scss
+++ b/h/static/styles/partials/_search-result-sidebar.scss
@@ -11,6 +11,7 @@
 
 .search-result-sidebar__subtitle {
   margin-bottom: 9px;
+  font-size: $search-results-subtitle-font-size;
 }
 
 .search-result-sidebar__title,
@@ -49,11 +50,6 @@
 
 .search-result-sidebar__subsection-val {
   color: $grey-6;
-}
-
-.search-result-sidebar-title__annotations-count {
-  font-size: $normal-font-size;
-  font-weight: normal;
 }
 
 .search-result-sidebar__annotations-count {

--- a/h/static/styles/partials/_search.scss
+++ b/h/static/styles/partials/_search.scss
@@ -166,7 +166,7 @@
 }
 
 .search-result-bucket__title {
-  color: black;
+  color: $grey-6;
   text-decoration: none;
   font-weight: bold;
   flex-grow: 1;
@@ -184,6 +184,7 @@
 
 .search-result-bucket__annotations-count-container {
   width: 30px;
+  color: $grey-6;
   background-color: $grey-2;
   text-align: center;
   border-radius: 2px;

--- a/h/static/styles/partials/_search.scss
+++ b/h/static/styles/partials/_search.scss
@@ -57,7 +57,7 @@
 }
 
 .search-results__total {
-  font-size: 1.1em;
+  font-size: $search-results-subtitle-font-size;
   color: $brand;
   margin-bottom: 25px;
 }

--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -177,7 +177,7 @@
 <section class="search-result-sidebar__section">
   <h3 class="search-result-sidebar__subtitle">
     {% trans %} {{title}} {% endtrans %}
-    <span class="search-result-sidebar-title__annotations-count">
+    <span class="search-result-sidebar__subtitle-count">
       {{ users|length }}
     <span>
   </h3>


### PR DESCRIPTION
-Make dark greys the same (grey-6)
-Move copy icon over so it’s padding is equal with the left side of the input text
-Increase size of matching annotations to match sidebar subtitles, move hard coded font into _base defs, and remove extra css subtitle count class

Before:
![image](https://user-images.githubusercontent.com/30059933/36881353-7c168662-1d82-11e8-9e6a-3a224c164501.png)

After:
![image](https://user-images.githubusercontent.com/30059933/36881372-995da57a-1d82-11e8-9061-beac585f1dbf.png)
