### PR TITLE
Fix flakey factories.User

### DIFF
--- a/tests/common/factories/user.py
+++ b/tests/common/factories/user.py
@@ -10,6 +10,32 @@ from .activation import Activation
 from .base import ModelFactory
 
 
+def unique_username(obj):
+    """
+    Return a unique username for a test user.
+
+    Return a randomly generated username that is guaranteed to be unique within
+    a given test run. Uniqueness is necessary because usernames must be unique
+    in the DB and generating random usernames in a not-guaranteed-to-be-unique
+    way would result in intermittent database errors when running the tests.
+
+    """
+    return obj.non_unique_username + '__' + obj.count
+
+
+def unique_email(obj):
+    """
+    Return a unique email for a test user.
+
+    Return a randomly generated email that is guaranteed to be unique within
+    a given test run. Uniqueness is necessary because emails must be unique
+    in the DB and generating random emails in a not-guaranteed-to-be-unique
+    way would result in intermittent database errors when running the tests.
+
+    """
+    return obj.username + '@' + obj.email_domain
+
+
 class User(ModelFactory):
 
     class Meta:
@@ -17,8 +43,14 @@ class User(ModelFactory):
 
     class Params:
         inactive = factory.Trait(activation=factory.SubFactory(Activation))
+        # A count that's appended to non-unique usernames to make them unique.
+        count = factory.Sequence(lambda n: '%d' % n)
+        # The non-unique part of the generated username.
+        non_unique_username = factory.Faker('user_name')
+        # The domain (following ``@``) part of the generated email address.
+        email_domain = factory.Faker('free_email_domain')
 
     authority = 'example.com'
-    username = factory.Faker('user_name')
-    email = factory.Faker('email')
+    username = factory.LazyAttribute(unique_username)
+    email = factory.LazyAttribute(unique_email)
     registered_date = factory.Faker('date_time_this_decade')


### PR DESCRIPTION
factories.User was generating usernames and email addresses that were
not guaranteed to be unique. This meant that any test that called
factories.User more than once would sometimes get two users with the
same username and/or email, which will result in an IntegrityError from
the DB if something adds these users to the DB session then tries to flush it.
The end result is flakey tests that sometimes fail. Tests that use other test
factories that use factories.User as a subfactory (many) were also affected.

The email address now also includes the username in it, instead of a
different random name.

Fixes:

* https://github.com/hypothesis/h/issues/4851
* https://github.com/hypothesis/h/issues/4853
* https://github.com/hypothesis/h/issues/4854
* https://github.com/hypothesis/h/issues/4855
* https://github.com/hypothesis/h/issues/4856
* https://github.com/hypothesis/h/issues/4858
* https://github.com/hypothesis/h/issues/4859

Before:

    > u = factories.User()
    > u.username
    'cbruce'
    > u.email
    'karen@king-mcmahon.biz'

After:

    > u = factories.User()
    > u.username
    'llucas__0'
    > u.email
    'llucas__0@gmail.com'

(The first username generated will end in "0", the next call to
factories.User() will return a user with a username like `"<SOMEONE>__1"`
and so on. The `<SOMEONE>` part is randomly generated and then the number
appended to the end guarantees uniqueness by always counting upwards.)