### PR TITLE
Set group info display strings for open, private and restricted groups for display in activity pages.

### DIFF
--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -205,7 +205,7 @@
           {% endif %}
         </button>
       </li>
-      {% endfor %}
+    {% endfor %}
     </ul>
   </form>
 </section>
@@ -256,8 +256,8 @@
           </a>
         </p>
       {% endif %}
-      {# only show ability to leave group if group has concept of members #}
-      {% if group.members %}
+      {# only show ability to leave group if the logged in user is a member of that group #}
+      {% if show_leave_button %}
         <button class="link--btn js-confirm-submit"
                 type="submit"
                 form="search-bar"
@@ -273,38 +273,25 @@
 
     {{ tags_section() }}
 
-    {# if the group has a concept of members display members and join text #}
-    {% if group.members %} 
-      {{ group_users("Members", group.members, group.creator) }}
-      <section class="search-result-sidebar__section">
-        <h3 class="search-result-sidebar__subtitle">
-          {% trans %}Invite new members{% endtrans %}
-        </h3>
-        <p class="search-result-sidebar__share-link">
-          {% trans %}Sharing the link lets people join this group:{% endtrans %}
-        </p>
-    {# if the group has no concept of members display moderators and share text #}
-    {% else %}
-      {{ group_users("Moderators", group.moderators, group.creator) }}
-      <section class="search-result-sidebar__section">
-        <h3 class="search-result-sidebar__subtitle">
-          {% trans %}Share group{% endtrans %}
-        </h3>
-        <p class="search-result-sidebar__share-link">
-          {% trans %}Sharing the link lets people view this group:{% endtrans %}
-        </p>
-    {% endif %}
-    <div class="group-invite__container js-copy-button">
-      <input class="group-invite__input js-select-onfocus"
-             data-ref="input"
-             value="{{ group.url }}">
-      <button class="group-invite__clipboard-button"
-              data-ref="button"
-              title="Copy to clipboard">
-        {{ svg_icon('copy_to_clipboard', 'group-invite__clipboard-image') }}
-      </button>
-    </div>
-  </section>
+    {{ group_users(*group_users_args) }}
+    <section class="search-result-sidebar__section">
+      <h3 class="search-result-sidebar__subtitle">
+        {{ group.share_subtitle }}
+      </h3>
+      <p class="search-result-sidebar__share-link">
+        {{ group.share_msg }}
+      </p>
+      <div class="group-invite__container js-copy-button">
+        <input class="group-invite__input js-select-onfocus"
+               data-ref="input"
+               value="{{ group.url }}">
+        <button class="group-invite__clipboard-button"
+                data-ref="button"
+                title="Copy to clipboard">
+          {{ svg_icon('copy_to_clipboard', 'group-invite__clipboard-image') }}
+        </button>
+      </div>
+    </section>
   {% endcall %}
 {% endmacro %}
 

--- a/h/views/activity.py
+++ b/h/views/activity.py
@@ -15,6 +15,7 @@ from h import util
 from h.activity import query
 from h.i18n import TranslationString as _  # noqa: N813
 from h.links import pretty_link
+from h.models.group import ReadableBy
 from h.paginator import paginate
 from h.search import parser
 from h.util.user import split_user
@@ -107,9 +108,9 @@ class GroupSearchController(SearchController):
 
         result['opts'] = {'search_groupname': self.group.name}
 
-        # If the group has a concept of members (aka joinable_by is not None)
-        # and the user is not in the list of members, return without extra info.
-        if self.group.joinable_by and (self.request.user not in self.group.members):
+        # If the group has read access only for members  and the user is not in that list
+        # return without extra info.
+        if self.group.readable_by == ReadableBy.members and (self.request.user not in self.group.members):
             return result
 
         def user_annotation_count(aggregation, userid):
@@ -119,12 +120,12 @@ class GroupSearchController(SearchController):
             return 0
 
         q = query.extract(self.request)
-        members = None
-        moderators = None
+        members = []
+        moderators = []
         users_aggregation = result['search_results'].aggregations.get('users', [])
-        # If the group has a concept of members provide a list of member info,
+        # If the group has members provide a list of member info,
         # otherwise provide a list of moderator info instead.
-        if self.group.joinable_by:
+        if self.group.members:
             members = [{'username': u.username,
                         'userid': u.userid,
                         'count': user_annotation_count(users_aggregation,
@@ -154,6 +155,7 @@ class GroupSearchController(SearchController):
         result['stats'] = {
             'annotation_count': group_annotation_count,
         }
+
         result['group'] = {
             'created': utc_us_style_date(self.group.created),
             'description': self.group.description,
@@ -163,9 +165,21 @@ class GroupSearchController(SearchController):
                                           pubid=self.group.pubid,
                                           slug=self.group.slug),
             'members': members,
-            'moderators': moderators,
             'creator': self.group.creator.userid if self.group.creator else None,
+            'share_subtitle': _('Share group'),
+            'share_msg': _('Sharing the link lets people view this group:'),
         }
+
+        if self.group.type == 'private':
+            result['group']['share_subtitle'] = _('Invite new members')
+            result['group']['share_msg'] = _('Sharing the link lets people join this group:')
+
+        result['group_users_args'] = [
+            _('Members'),
+            moderators if self.group.type == 'open' else members,
+            result['group']['creator'],
+        ]
+
         if self.request.has_permission('admin', self.group):
             result['group_edit_url'] = self.request.route_url(
                 'group_edit', pubid=self.group.pubid)
@@ -176,6 +190,8 @@ class GroupSearchController(SearchController):
             result['zero_message'] = Markup(_(
                 'The group “{name}” has not made any annotations yet.').format(
                     name=Markup.escape(self.group.name)))
+
+        result['show_leave_button'] = self.request.user in self.group.members
 
         return result
 


### PR DESCRIPTION
See https://github.com/hypothesis/product-backlog/issues/495