### PR TITLE
Add Validation elements of add-group Admin Panel

### DIFF
--- a/h/schemas/admin_group.py
+++ b/h/schemas/admin_group.py
@@ -28,7 +28,8 @@ class CreateAdminGroupSchema(CSRFSchema):
     group_type = colander.SchemaNode(
         colander.String(),
         title=_('Group Type'),
-        widget=SelectWidget(values=(('', _('Select')),) + VALID_GROUP_TYPES)
+        widget=SelectWidget(values=(('', _('Select')),) + VALID_GROUP_TYPES),
+        validator=colander.OneOf([key for key, title in VALID_GROUP_TYPES])
     )
 
     name = colander.SchemaNode(

--- a/h/schemas/admin_group.py
+++ b/h/schemas/admin_group.py
@@ -23,6 +23,19 @@ VALID_GROUP_TYPES = (
 )
 
 
+def user_exists_validator_factory(user_svc):
+    def user_exists_validator(form, value):
+        user = user_svc.fetch(value['creator'], value['authority'])
+        if user is None:
+            exc = colander.Invalid(form, _('User not found'))
+            exc['creator'] = 'User {creator} not found at authority {authority}'.format(
+                creator=value['creator'],
+                authority=value['authority']
+            )
+            raise exc
+    return user_exists_validator
+
+
 class CreateAdminGroupSchema(CSRFSchema):
 
     group_type = colander.SchemaNode(

--- a/h/schemas/admin_group.py
+++ b/h/schemas/admin_group.py
@@ -3,7 +3,7 @@
 from __future__ import unicode_literals
 
 import colander
-from deform.widget import SelectWidget, TextInputWidget
+from deform.widget import SelectWidget, TextAreaWidget
 
 from h import i18n
 from h import validators
@@ -17,10 +17,15 @@ from h.schemas.base import CSRFSchema
 _ = i18n.TranslationString
 
 VALID_GROUP_TYPES = (
-    ('private', _('Private')),
     ('restricted', _('Restricted')),
     ('open', _('Open')),
 )
+
+
+def _split_origins(value):
+    if value != colander.null:
+        return [origin.strip() for origin in value.splitlines()]
+    return value
 
 
 def user_exists_validator_factory(user_svc):
@@ -41,7 +46,9 @@ class CreateAdminGroupSchema(CSRFSchema):
     group_type = colander.SchemaNode(
         colander.String(),
         title=_('Group Type'),
-        widget=SelectWidget(values=(('', _('Select')),) + VALID_GROUP_TYPES),
+        widget=SelectWidget(
+          values=(('', _('Select')),) + VALID_GROUP_TYPES
+        ),
         validator=colander.OneOf([key for key, title in VALID_GROUP_TYPES])
     )
 
@@ -75,6 +82,15 @@ class CreateAdminGroupSchema(CSRFSchema):
         title=_('Description'),
         description=_('Optional group description'),
         validator=colander.Length(max=GROUP_DESCRIPTION_MAX_LENGTH),
-        widget=TextInputWidget(rows=3),
+        widget=TextAreaWidget(rows=3),
+        missing=None
+    )
+
+    origins = colander.SchemaNode(
+        colander.String(),
+        title=_('Scope Origins'),
+        widget=TextAreaWidget(rows=5),
+        hint=_('Enter scope origins (e.g. "http://www.foo.com"), one per line'),
+        preparer=_split_origins,
         missing=None
     )

--- a/h/views/admin_groups.py
+++ b/h/views/admin_groups.py
@@ -8,7 +8,7 @@ from h import form  # noqa F401
 from h import i18n
 from h import models
 from h import paginator
-from h.schemas.admin_group import CreateAdminGroupSchema
+from h.schemas.admin_group import CreateAdminGroupSchema, user_exists_validator_factory
 
 _ = i18n.TranslationString
 
@@ -28,8 +28,9 @@ def groups_index(context, request):
 class GroupCreateController(object):
 
     def __init__(self, request):
+        user_validator = user_exists_validator_factory(request.find_service(name='user'))
+        self.schema = CreateAdminGroupSchema(validator=user_validator).bind(request=request)
         self.request = request
-        self.schema = CreateAdminGroupSchema().bind(request=request)
         self.form = request.create_form(self.schema,
                                         buttons=(_('Create New Group'),))
 

--- a/h/views/admin_groups.py
+++ b/h/views/admin_groups.py
@@ -47,11 +47,13 @@ class GroupCreateController(object):
         def on_success(appstruct):
             read_url = self.request.route_url('admin_groups')
             self.request.session.flash('TODO: I will add a {gtype} group called "{name}"'
-                                       ' for authority {authority}, created by {creator}'.format(
+                                       ' for authority {authority}, created by {creator}'
+                                       ' and origins {origins}'.format(
                                             gtype=appstruct['group_type'],
                                             name=appstruct['name'],
                                             authority=appstruct['authority'],
-                                            creator=appstruct['creator']
+                                            creator=appstruct['creator'],
+                                            origins=', '.join(appstruct['origins'])
                                        ), queue='success')
             response = HTTPFound(location=read_url)
             return response

--- a/tests/h/schemas/admin_group_test.py
+++ b/tests/h/schemas/admin_group_test.py
@@ -38,6 +38,12 @@ class TestCreateGroupSchema(object):
         with pytest.raises(colander.Invalid, match='.*description.*'):
             bound_schema.deserialize(group_data)
 
+    def test_it_raises_if_group_type_invalid(self, group_data, bound_schema):
+        group_data['group_type'] = 'foobarbazding'
+
+        with pytest.raises(colander.Invalid, match='.*group_type.*'):
+            bound_schema.deserialize(group_data)
+
     @pytest.mark.parametrize('required_field', (
         'name',
         'authority',

--- a/tests/h/views/admin_groups_test.py
+++ b/tests/h/views/admin_groups_test.py
@@ -10,6 +10,7 @@ import mock
 # from h.models.auth_client import AuthClient, GrantType, ResponseType
 from h.views import admin_groups
 from h.views.admin_groups import GroupCreateController
+from h.services.user import UserService
 
 
 def test_index_lists_groups_sorted_by_created_desc(pyramid_request, routes, factories, authority):
@@ -36,6 +37,7 @@ def test_index_paginates_results(pyramid_request, routes, paginate):
     paginate.assert_called_once_with(pyramid_request, mock.ANY, mock.ANY)
 
 
+@pytest.mark.usefixtures('user_svc')
 class TestGroupCreateController(object):
 
     def test_get_sets_form(self, pyramid_request):
@@ -100,3 +102,10 @@ def handle_form_submission(patch):
 def routes(pyramid_config):
     pyramid_config.add_route('admin_groups', '/admin/groups')
     pyramid_config.add_route('admin_groups_create', '/admin/groups/new')
+
+
+@pytest.fixture
+def user_svc(pyramid_config):
+    svc = mock.create_autospec(UserService, spec_set=True, instance=True)
+    pyramid_config.register_service(svc, name='user')
+    return svc

--- a/tests/h/views/admin_groups_test.py
+++ b/tests/h/views/admin_groups_test.py
@@ -65,7 +65,8 @@ class TestGroupCreateController(object):
                 'name': 'My New Group',
                 'group_type': 'restricted',
                 'creator': pyramid_request.user.username,
-                'authority': pyramid_request.authority
+                'authority': pyramid_request.authority,
+                'origins': []
             })
         handle_form_submission.side_effect = call_on_success
         ctrl = GroupCreateController(pyramid_request)


### PR DESCRIPTION
This small PR is part of https://github.com/hypothesis/product-backlog/issues/421

This PR adds some validation and an additional field, `origins`. I'm not happy with the design of the `origins` field but after banging my head on forms for a long while I'm going to submit what I've got that actually works at the moment. Bears a larger discussion about how best to use forms and schema, but that can be postponed for the moment.