### PR TITLE
Fix a flakey test

### DIFF
--- a/tests/h/models/document_test.py
+++ b/tests/h/models/document_test.py
@@ -356,7 +356,7 @@ class TestCreateOrUpdateDocumentURI(object):
             updated=now(),
         )
 
-        document_uri = db_session.query(document.DocumentURI).all()[-1]
+        document_uri = db_session.query(document.DocumentURI).order_by(document.DocumentURI.created.desc()).first()
         assert document_uri.claimant == claimant
         assert document_uri.uri == uri
         assert document_uri.type == type_


### PR DESCRIPTION
Fixes <https://github.com/hypothesis/h/issues/4852>. This test was
making an unordered DB request, while implicitly assuming the order.
Very occassionally the two documents come out in the opposite order and
the test fails.