### PR TITLE
Fix flakey factories.Setting()

### DIFF
--- a/tests/common/factories/setting.py
+++ b/tests/common/factories/setting.py
@@ -15,5 +15,5 @@ class Setting(ModelFactory):
         model = models.Setting
         sqlalchemy_session_persistence = 'flush'
 
-    key = factory.LazyAttribute(lambda _: FAKER.domain_word())
+    key = factory.Sequence(lambda n: 'setting_%d' % n)
     value = factory.LazyAttribute(lambda _: FAKER.catch_phrase())


### PR DESCRIPTION
`FAKER.domain_word()` produces random but not guaranteed unique strings.
Ocassionally it'll return the same string twice and then you'll get an
`IntegrityError` since `Setting.key` must be unique in the DB.

* Fixes https://github.com/hypothesis/h/issues/4857
* Fixes https://github.com/hypothesis/h/issues/4850