### PR TITLE
Fix broken factories.Feature

### DIFF
--- a/tests/common/factories/feature.py
+++ b/tests/common/factories/feature.py
@@ -2,6 +2,8 @@
 
 from __future__ import unicode_literals
 
+import factory
+
 from h import models
 
 from .base import ModelFactory
@@ -11,3 +13,5 @@ class Feature(ModelFactory):
 
     class Meta:
         model = models.Feature
+
+    name = factory.Sequence(lambda n: 'feature_%d' % n)


### PR DESCRIPTION
Fixes https://github.com/hypothesis/h/issues/4860

factories.Feature isn't flakey as the issue says, it's just broken.
Whenever you call factories.Feature() it creates and adds to the DB a
Feature that, when the DB is flushed, will cause an IntegrityError
because it has None for the not-nullable name field. You have to do
factories.Feature(name="something"), which it so happens all our tests
always do (so there are no broken or flakey tests related to this
issue).

Generally when a factory exists I think you should be able to rely on,
without looking at the code of the factory or the model class, that
calling the factory without any args will produce a valid object that
won't crash the DB.

So fix this by adding auto-generated feature names to factories.Feature.

Before:

    > factories.Feature()
    > request.tm.commit()
    IntegrityError

After:

    > factories.Feature()
    Returns a feature named "feature_1". The next call will be
    "feature_2" etc.