### PR TITLE
Update ListGroupsService to account for restricted groups

### DIFF
--- a/h/session.py
+++ b/h/session.py
@@ -76,10 +76,7 @@ def _current_groups(request, authority):
 
     user = request.user
     svc = request.find_service(name='list_groups')
-    if request.feature('filter_groups_by_scope'):
-        groups = svc.request_groups(user=user, authority=authority)
-    else:
-        groups = svc.all_groups(user=user, authority=authority)
+    groups = svc.session_groups(user=user, authority=authority)
 
     return [_group_model(request.route_url, group) for group in groups]
 

--- a/tests/functional/test_api.py
+++ b/tests/functional/test_api.py
@@ -97,7 +97,9 @@ class TestAPI(object):
         assert res.json['userid'] == user.userid
 
         group_ids = [group['id'] for group in res.json['groups']]
-        assert group_ids == [open_group.pubid]
+        # The profile API returns no open groups for third-party accounts.
+        # (The client gets open groups from the groups API instead.)
+        assert group_ids == []
 
     def test_cors_preflight(self, app):
         # Simulate a CORS preflight request made by the browser from a client

--- a/tests/h/services/list_groups_test.py
+++ b/tests/h/services/list_groups_test.py
@@ -1,3 +1,4 @@
+
 # -*- coding: utf-8 -*-
 
 from __future__ import unicode_literals
@@ -101,7 +102,7 @@ class TestListGroupsAllGroups(object):
         assert actual_ids == expected_ids
 
     def test_sorts_groups_by_type(self, svc, user, mixed_groups):
-        expected_sorted_types = ['open', 'open', 'open', 'open', 'private', 'private']
+        expected_sorted_types = ['open', 'restricted', 'open', 'open', 'private', 'private']
         results = svc.all_groups(user=user)
 
         assert [group.type for group in results] == expected_sorted_types
@@ -111,6 +112,69 @@ class TestListGroupsAllGroups(object):
         results = svc.all_groups(user=user)
 
         assert [group.pubid for group in results] == expected_sorted_pubids
+
+
+class TestListGroupsSessionGroups(object):
+
+    def test_it_returns_no_scoped_open_groups_except_world(self, svc, user, default_authority, mixed_groups):
+        results = svc.session_groups(user=user, authority=default_authority)
+
+        non_world_groups = [group for group in results if group.pubid != '__world__']
+
+        for group in non_world_groups:
+            assert group.type != 'open'
+
+    def test_it_returns_no_unscoped_open_groups(self, svc, user, authority, unscoped_open_groups):
+        results = svc.session_groups(user=user, authority=authority)
+
+        assert results == []
+
+    def test_it_returns_scoped_restricted_groups_if_user_member(self, svc, user, scoped_restricted_user_groups, authority):
+        user.groups = scoped_restricted_user_groups
+        results = svc.session_groups(user=user, authority=authority)
+
+        assert results == user.groups
+        for group in results:
+            assert group.type == 'restricted'
+
+    def test_it_excludes_scoped_restricted_groups_if_user_not_member(self, svc, user, scoped_restricted_groups, authority):
+        results = svc.session_groups(user=user, authority=authority)
+
+        assert results == []
+
+    def test_it_returns_the_world_group(self, svc, user, default_authority):
+        results = svc.session_groups(user=user, authority=default_authority)
+
+        assert results[0].pubid == '__world__'
+
+    def test_it_returns_world_group_only_if_no_user(self,
+                                                    svc,
+                                                    default_authority,
+                                                    unscoped_restricted_groups,
+                                                    scoped_restricted_groups,
+                                                    unscoped_open_groups,
+                                                    scoped_open_groups):
+        results = svc.session_groups(user=None, authority=default_authority)
+
+        assert results[0].pubid == '__world__'
+        assert len(results) == 1
+
+    def test_it_returns_private_groups_for_user(self, user, svc, authority, private_groups):
+        user.groups = private_groups
+        results = svc.session_groups(user=user, authority=authority)
+
+        for group in user.groups:
+            assert group in results
+            assert group.type == 'private'
+
+    def test_world_group_is_first(self, user, svc, default_authority, private_groups):
+        user.groups = private_groups
+        results = svc.session_groups(user=user, authority=default_authority)
+
+        world_group = results.pop(0)
+        assert world_group.pubid == '__world__'
+        for group in results:
+            assert group.type == 'private'
 
 
 class TestListGroupsRequestGroups(object):
@@ -125,7 +189,12 @@ class TestListGroupsRequestGroups(object):
 
         assert results == scoped_open_groups
 
-    def test_it_returns_no_scoped_groups_if_uri_missing(self, svc, authority, scoped_open_groups):
+    def test_it_returns_matching_scoped_restricted_groups(self, svc, authority, document_uri, scoped_restricted_groups):
+        results = svc.request_groups(authority=authority, document_uri=document_uri)
+
+        assert results == scoped_restricted_groups
+
+    def test_it_returns_no_scoped_groups_if_uri_missing(self, svc, authority, scoped_open_groups, scoped_restricted_groups):
         results = svc.request_groups(authority=authority)
 
         assert results == []
@@ -135,25 +204,47 @@ class TestListGroupsRequestGroups(object):
 
         assert results == []
 
+    def test_it_returns_no_unscoped_restricted_groups(self, svc, authority, unscoped_restricted_groups):
+        results = svc.request_groups(authority=authority)
+
+        assert results == []
+
+    def test_it_returns_no_unscoped_restricted_user_groups(self, svc, authority, user, unscoped_restricted_groups):
+        user.groups = unscoped_restricted_groups
+        results = svc.request_groups(user=user, authority=authority)
+
+        assert results == []
+
     def test_it_returns_private_groups_if_user(self, svc, user, authority, private_groups):
         user.groups = private_groups
         results = svc.request_groups(user=user, authority=authority)
 
         assert results == private_groups
 
+    def test_it_returns_no_group_dupes(self, svc, user, authority, private_groups, document_uri, scoped_restricted_user_groups):
+        user.groups = private_groups + scoped_restricted_user_groups
+        results = svc.request_groups(user=user, authority=authority, document_uri=document_uri)
+
+        assert results == scoped_restricted_user_groups + private_groups
+
     def test_returned_open_groups_must_match_authority(self, svc, alternate_authority, unscoped_open_groups, scoped_open_groups):
         results = svc.request_groups(authority=alternate_authority)
 
         assert results == []
 
+    def test_returned_restricted_groups_must_match_authority(self, svc, alternate_authority, scoped_restricted_groups):
+        results = svc.request_groups(authority=alternate_authority)
+
+        assert results == []
+
     def test_groups_are_sorted_by_type(self, svc, user, mixed_groups, authority, document_uri):
-        expected_sorted_types = ['open', 'open', 'private', 'private']
+        expected_sorted_types = ['open', 'restricted', 'open', 'private', 'private']
         results = svc.request_groups(user=user, authority=authority, document_uri=document_uri)
 
         assert [group.type for group in results] == expected_sorted_types
 
     def test_groups_are_sorted_alphabetically(self, svc, user, mixed_groups, authority, document_uri):
-        expected_sorted_pubids = ['wadsworth', 'yaks', 'spectacle', 'yams']
+        expected_sorted_pubids = ['wadsworth', 'xander', 'yaks', 'spectacle', 'yams']
         results = svc.request_groups(user=user, authority=authority, document_uri=document_uri)
 
         assert [group.pubid for group in results] == expected_sorted_pubids
@@ -231,6 +322,39 @@ def scoped_open_groups(factories, authority, origin):
 
 
 @pytest.fixture
+def scoped_restricted_groups(factories, authority, origin):
+    return [
+        factories.RestrictedGroup(authority=authority,
+                                  scopes=[factories.GroupScope(origin=origin)]),
+        factories.RestrictedGroup(authority=authority,
+                                  scopes=[factories.GroupScope(origin=origin)])
+    ]
+
+
+@pytest.fixture
+def unscoped_restricted_groups(factories, authority):
+    return [
+        factories.RestrictedGroup(authority=authority),
+        factories.RestrictedGroup(authority=authority)
+    ]
+
+
+@pytest.fixture
+def scoped_restricted_user_groups(factories, authority, user, origin):
+    return [
+        factories.RestrictedGroup(name='Alpha',
+                                  authority=authority,
+                                  creator=user,
+                                  scopes=[factories.GroupScope(origin=origin)]),
+        factories.RestrictedGroup(
+                                  name='Beta',
+                                  authority=authority,
+                                  creator=user,
+                                  scopes=[factories.GroupScope(origin=origin)])
+    ]
+
+
+@pytest.fixture
 def unscoped_open_groups(factories, authority):
     return [
         factories.OpenGroup(authority=authority),
@@ -269,9 +393,10 @@ def mixed_groups(factories, user, authority, origin):
                             pubid='yaks',
                             authority=authority,
                             scopes=[factories.GroupScope(origin=origin)]),
-        factories.OpenGroup(name='Xander',
-                            pubid='xander',
-                            authority=authority),
+        factories.RestrictedGroup(name='Xander',
+                                  pubid='xander',
+                                  authority=authority,
+                                  scopes=[factories.GroupScope(origin=origin)]),
         factories.OpenGroup(name='wadsworth',
                             pubid='wadsworth',
                             authority=authority,

--- a/tests/h/session_test.py
+++ b/tests/h/session_test.py
@@ -12,20 +12,20 @@ class TestModel(object):
 
         session.model(authenticated_request)
 
-        svc.all_groups.assert_called_once_with(user=authenticated_request.user,
-                                               authority=authenticated_request.authority)
+        svc.session_groups.assert_called_once_with(user=authenticated_request.user,
+                                                   authority=authenticated_request.authority)
 
     def test_proxies_group_lookup_to_service_for_unauth(self, unauthenticated_request):
         svc = unauthenticated_request.find_service(name='list_groups')
 
         session.model(unauthenticated_request)
 
-        svc.all_groups.assert_called_once_with(authority=unauthenticated_request.authority,
-                                               user=None)
+        svc.session_groups.assert_called_once_with(authority=unauthenticated_request.authority,
+                                                   user=None)
 
     def test_open_group_is_public(self, unauthenticated_request, world_group):
         svc = unauthenticated_request.find_service(name='list_groups')
-        svc.all_groups.return_value = [world_group]
+        svc.session_groups.return_value = [world_group]
 
         model = session.model(unauthenticated_request)
 
@@ -34,7 +34,7 @@ class TestModel(object):
     def test_private_group_is_not_public(self, authenticated_request, factories):
         a_group = factories.Group()
         svc = authenticated_request.find_service(name='list_groups')
-        svc.all_groups.return_value = [a_group]
+        svc.session_groups.return_value = [a_group]
 
         model = session.model(authenticated_request)
 
@@ -42,7 +42,7 @@ class TestModel(object):
 
     def test_open_group_has_no_url(self, unauthenticated_request, world_group):
         svc = unauthenticated_request.find_service(name='list_groups')
-        svc.all_groups.return_value = [world_group]
+        svc.session_groups.return_value = [world_group]
 
         model = session.model(unauthenticated_request)
 
@@ -51,7 +51,7 @@ class TestModel(object):
     def test_private_group_has_url(self, authenticated_request, factories):
         a_group = factories.Group()
         svc = authenticated_request.find_service(name='list_groups')
-        svc.all_groups.return_value = [a_group]
+        svc.session_groups.return_value = [a_group]
 
         model = session.model(authenticated_request)
 
@@ -89,13 +89,13 @@ class TestModelWithScopedGroups(object):
 
         session.model(authenticated_request)
 
-        svc.request_groups.assert_called_once_with(user=authenticated_request.user,
+        svc.session_groups.assert_called_once_with(user=authenticated_request.user,
                                                    authority=authenticated_request.authority)
 
     def test_private_group_is_not_public(self, authenticated_request, factories):
         a_group = factories.Group()
         svc = authenticated_request.find_service(name='list_groups')
-        svc.request_groups.return_value = [a_group]
+        svc.session_groups.return_value = [a_group]
 
         model = session.model(authenticated_request)
 
@@ -103,7 +103,7 @@ class TestModelWithScopedGroups(object):
 
     def test_open_group_has_no_url(self, unauthenticated_request, world_group):
         svc = unauthenticated_request.find_service(name='list_groups')
-        svc.request_groups.return_value = [world_group]
+        svc.session_groups.return_value = [world_group]
 
         model = session.model(unauthenticated_request)
 
@@ -112,14 +112,13 @@ class TestModelWithScopedGroups(object):
     def test_private_group_has_url(self, authenticated_request, factories):
         a_group = factories.Group()
         svc = authenticated_request.find_service(name='list_groups')
-        svc.request_groups.return_value = [a_group]
+        svc.session_groups.return_value = [a_group]
 
         model = session.model(authenticated_request)
 
         assert model['groups'][0]['url']
 
 
-@pytest.mark.usefixtures('scope_feature_off')
 class TestProfile(object):
     def test_userid_unauthenticated(self, unauthenticated_request):
         assert session.profile(unauthenticated_request)['userid'] is None
@@ -133,20 +132,20 @@ class TestProfile(object):
 
         session.profile(authenticated_request)
 
-        svc.all_groups.assert_called_once_with(user=authenticated_request.user,
-                                               authority=authenticated_request.authority)
+        svc.session_groups.assert_called_once_with(user=authenticated_request.user,
+                                                   authority=authenticated_request.authority)
 
     def test_proxies_group_lookup_to_service_for_unauth(self, unauthenticated_request):
         svc = unauthenticated_request.find_service(name='list_groups')
 
         session.profile(unauthenticated_request)
 
-        svc.all_groups.assert_called_once_with(authority=unauthenticated_request.authority,
-                                               user=None)
+        svc.session_groups.assert_called_once_with(authority=unauthenticated_request.authority,
+                                                   user=None)
 
     def test_open_group_is_public(self, unauthenticated_request, world_group):
         svc = unauthenticated_request.find_service(name='list_groups')
-        svc.all_groups.return_value = [world_group]
+        svc.session_groups.return_value = [world_group]
 
         profile = session.profile(unauthenticated_request)
 
@@ -155,7 +154,7 @@ class TestProfile(object):
     def test_private_group_is_not_public(self, authenticated_request, factories):
         a_group = factories.Group()
         svc = authenticated_request.find_service(name='list_groups')
-        svc.all_groups.return_value = [a_group]
+        svc.session_groups.return_value = [a_group]
 
         profile = session.profile(authenticated_request)
 
@@ -163,7 +162,7 @@ class TestProfile(object):
 
     def test_open_group_has_no_url(self, unauthenticated_request, world_group):
         svc = unauthenticated_request.find_service(name='list_groups')
-        svc.all_groups.return_value = [world_group]
+        svc.session_groups.return_value = [world_group]
 
         profile = session.profile(unauthenticated_request)
 
@@ -172,7 +171,7 @@ class TestProfile(object):
     def test_private_group_has_url(self, authenticated_request, factories):
         a_group = factories.Group()
         svc = authenticated_request.find_service(name='list_groups')
-        svc.all_groups.return_value = [a_group]
+        svc.session_groups.return_value = [a_group]
 
         profile = session.profile(authenticated_request)
 
@@ -260,7 +259,7 @@ class TestProfileWithScopedGroups(object):
 
         session.profile(authenticated_request)
 
-        svc.request_groups.assert_called_once_with(user=authenticated_request.user,
+        svc.session_groups.assert_called_once_with(user=authenticated_request.user,
                                                    authority=authenticated_request.authority)
 
     def test_proxies_group_lookup_to_service_for_unauth(self, unauthenticated_request):
@@ -268,13 +267,13 @@ class TestProfileWithScopedGroups(object):
 
         session.profile(unauthenticated_request)
 
-        svc.request_groups.assert_called_once_with(authority=unauthenticated_request.authority,
+        svc.session_groups.assert_called_once_with(authority=unauthenticated_request.authority,
                                                    user=None)
 
     def test_private_group_is_not_public(self, authenticated_request, factories):
         a_group = factories.Group()
         svc = authenticated_request.find_service(name='list_groups')
-        svc.request_groups.return_value = [a_group]
+        svc.session_groups.return_value = [a_group]
 
         profile = session.profile(authenticated_request)
 
@@ -283,7 +282,7 @@ class TestProfileWithScopedGroups(object):
     def test_private_group_has_url(self, authenticated_request, factories):
         a_group = factories.Group()
         svc = authenticated_request.find_service(name='list_groups')
-        svc.request_groups.return_value = [a_group]
+        svc.session_groups.return_value = [a_group]
 
         profile = session.profile(authenticated_request)
 


### PR DESCRIPTION
This PR makes needed changes to the `ListGroupsService` and updates how `session` uses the service to account for the introduction of restricted groups.

Net result:  `GET /api/groups` should return appropriate open, restricted and private groups and should not duplicate any groups in the list.

As of this PR, the list of groups returned to the client via the API (via the `request_groups` method on this service) are, in this order:

* Any open **or** restricted groups that match the current scope per `document_uri` parameter. If `document_uri` parameter is missing, or if it doesn't match any groups' scopes, no open or restricted groups are returned. No unscoped open or restricted groups are returned.
* The special "world" group is always returned
* Any _private_ groups that this user is a member of are returned (Note that _private_ groups are now a subset of a user's groups, as _restricted_ groups can be included in a user's groups now if they are a member of said group)

For the session, too, the behavior is now slightly different (through `ListGroupsService.session_groups`). This is the list of groups returned for use in views like activity pages (drop down listing of groups) or other h service pages:

* No open groups are returned (pending future work on which _should_ show up in activity-page-like drop downs)
* The special "world" group is always returned
* The list of groups that the user is a member of are returned—this includes _both_ private and restricted groups, intermingled

(The list of groups returned by `session.profile` or `session.model` via the above is identical to those in `request.user.groups` with the addition of the "world" group)

It is important to note that with this change, the list of groups returned within `GET /api/profile` has the potential for being different than those returned by `GET /api/groups`. That is because `GET /api/groups` uses the `ListGroupsService.request_groups` method (see behavior above) while `GET /api/profile` uses the `ListGroupsService.session_groups` method (see behavior above).

I think this difference is OK (and possibly ideal) because:

1. The use of `GET /api/profile` is deprecated at present for getting groups information
2. Any stale clients out there (if this is even possible at this point) using `GET /api/profile` won't get any open groups, and would only get restricted groups if the user is a member of the group—we shouldn't end up with unexpected stuff happening here
3. This could actually be _useful_ in the future to delineate between the list of groups that is relevant to the user-plus-request-context (i.e. those returned by `GET /api/groups`) versus a list of all the groups that the user is associated with in general (i.e. those returned by `GET /api/profile`). Maybe. We can cross that bridge when we get there!

Fixes https://github.com/hypothesis/product-backlog/issues/514
Fixes https://github.com/hypothesis/product-backlog/issues/509

Next steps: I think it's a good time to kill the scoped groups feature flag to reduce the complexity in some of the tests here and to be able to rip out some unused methods from the service; I've noted these in comments.