### PR TITLE
Remove error state of form inputs after editing them

### DIFF
--- a/h/static/scripts/admin-site.js
+++ b/h/static/scripts/admin-site.js
@@ -12,12 +12,14 @@ require('bootstrap');
 const AdminUsersController = require('./controllers/admin-users-controller');
 const ConfirmSubmitController = require('./controllers/confirm-submit-controller');
 const FormController = require('./controllers/form-controller');
+const FormInputController = require('./controllers/form-input-controller');
 const TooltipController = require('./controllers/tooltip-controller');
 const upgradeElements = require('./base/upgrade-elements');
 
 const controllers = {
   '.js-confirm-submit': ConfirmSubmitController,
   '.js-form': FormController,
+  '.js-form-input': FormInputController,
   '.js-tooltip': TooltipController,
   '.js-users-delete-form': AdminUsersController,
 };

--- a/h/static/scripts/controllers/form-input-controller.js
+++ b/h/static/scripts/controllers/form-input-controller.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const Controller = require('../base/controller');
+const { setElementState } = require('../util/dom');
+
+/**
+ * Controller for individual form input fields.
+ *
+ * This is used for both forms with inline editing (ie. those which show "Save"
+ * and "Cancel" buttons beneath individual form fields, see `FormController`)
+ * and those without.
+ *
+ * Note that for forms using inline editing much of the logic lives in the
+ * form-level controller rather than here.
+ */
+class FormInputController extends Controller {
+  constructor(element) {
+    super(element);
+
+    const hasError = element.classList.contains('is-error');
+    this.setState({ hasError });
+
+    this.refs.formInput.addEventListener('input', () => {
+      this.setState({ hasError: false });
+    });
+  }
+
+  update() {
+    setElementState(this.element, { error: this.state.hasError });
+  }
+}
+
+module.exports = FormInputController;

--- a/h/static/scripts/site.js
+++ b/h/static/scripts/site.js
@@ -17,6 +17,7 @@ const CreateGroupFormController = require('./controllers/create-group-form-contr
 const DropdownMenuController = require('./controllers/dropdown-menu-controller');
 const FormController = require('./controllers/form-controller');
 const FormCancelController = require('./controllers/form-cancel-controller');
+const FormInputController = require('./controllers/form-input-controller');
 const FormSelectOnFocusController = require('./controllers/form-select-onfocus-controller');
 const InputAutofocusController = require('./controllers/input-autofocus-controller');
 const SearchBarController = require('./controllers/search-bar-controller');
@@ -35,6 +36,7 @@ const controllers = {
   '.js-dropdown-menu': DropdownMenuController,
   '.js-form': FormController,
   '.js-form-cancel': FormCancelController,
+  '.js-form-input': FormInputController,
   '.js-input-autofocus': InputAutofocusController,
   '.js-select-onfocus': FormSelectOnFocusController,
   '.js-search-bar': SearchBarController,

--- a/h/static/scripts/tests/controllers/form-input-controller-test.js
+++ b/h/static/scripts/tests/controllers/form-input-controller-test.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const FormInputController = require('../../controllers/form-input-controller');
+
+const { setupComponent } = require('./util');
+
+describe('FormInputController', () => {
+  const template = `
+    <div class="js-form-input">
+      <label>Some label</label>
+      <input type="text" data-ref="formInput">
+    </div>
+  `.trim();
+
+  it('does not set `hasError` state of controller if rendered without "is-error" class', () => {
+    const ctrl = setupComponent(document, template, FormInputController);
+    assert.equal(ctrl.state.hasError, false);
+  });
+
+  it('sets `hasError` state of controller if rendered with "is-error" class', () => {
+    const errorTemplate = template.replace('js-form-input', 'js-form-input is-error');
+    const ctrl = setupComponent(document, errorTemplate, FormInputController);
+    assert.equal(ctrl.state.hasError, true);
+  });
+
+  it('toggles "is-error" class when setting `hasError` state', () => {
+    const ctrl = setupComponent(document, template, FormInputController);
+
+    ctrl.setState({ hasError: true });
+    assert.equal(ctrl.element.classList.contains('is-error'), true);
+
+    ctrl.setState({ hasError: false });
+    assert.equal(ctrl.element.classList.contains('is-error'), false);
+  });
+});


### PR DESCRIPTION
Remove the bold red border and validation error messages after editing a
form input, since the validation error message is no longer applicable
at that point.

Form inputs were already being rendered with a `js-form-input` class.
Add a controller for those elements which removes the "is-error" class
after the child `<input>` is edited.

Note that the `is-error` class controls both the border style and
visibility of validation error messages.

----

On master, if you submit a form and there is an error with a field, the field is rendered with a bold outline and error message:

<img width="539" alt="screenshot 2018-03-08 11 16 20" src="https://user-images.githubusercontent.com/2458/37148466-75b2d3d0-22c2-11e8-8d90-e06c3dac759e.png">

If you then edit the field, the error message remains even though it no longer applies:

<img width="532" alt="screenshot 2018-03-08 11 16 58" src="https://user-images.githubusercontent.com/2458/37148483-7eb7489e-22c2-11e8-804f-14702c6417af.png">

On this branch, the error message goes away after editing the field:

<img width="528" alt="screenshot 2018-03-08 11 16 36" src="https://user-images.githubusercontent.com/2458/37148494-886f8b62-22c2-11e8-90a0-e0fb19343132.png">
