### PR TITLE
Set up Views and Forms for Deleting Groups in Admin Panel

### DIFF
--- a/h/routes.py
+++ b/h/routes.py
@@ -40,6 +40,7 @@ def includeme(config):
     config.add_route('admin_cohorts_edit', '/admin/features/cohorts/{id}')
     config.add_route('admin_groups', '/admin/groups')
     config.add_route('admin_groups_create', '/admin/groups/new')
+    config.add_route('admin_groups_edit', '/admin/groups/edit/{id}')
     config.add_route('admin_mailer', '/admin/mailer')
     config.add_route('admin_mailer_test', '/admin/mailer/test')
     config.add_route('admin_nipsa', '/admin/nipsa')

--- a/h/static/scripts/admin-site.js
+++ b/h/static/scripts/admin-site.js
@@ -9,6 +9,7 @@ if (settings.raven) {
 window.$ = window.jQuery = require('jquery');
 require('bootstrap');
 
+const AdminGroupsController = require('./controllers/admin-groups-controller');
 const AdminUsersController = require('./controllers/admin-users-controller');
 const ConfirmSubmitController = require('./controllers/confirm-submit-controller');
 const FormController = require('./controllers/form-controller');
@@ -20,8 +21,8 @@ const controllers = {
   '.js-form': FormController,
   '.js-tooltip': TooltipController,
   '.js-users-delete-form': AdminUsersController,
+  '.js-groups-delete-form': AdminGroupsController,
 };
 
 upgradeElements(document.body, controllers);
 window.envFlags.ready();
-

--- a/h/static/scripts/controllers/admin-groups-controller.js
+++ b/h/static/scripts/controllers/admin-groups-controller.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const Controller = require('../base/controller');
+
+class AdminGroupsController extends Controller {
+  constructor(element, options) {
+    super(element, options);
+
+    const window_ = options.window || window;
+    function confirmFormSubmit() {
+      return window_.confirm('This will remove all members from the group, delete all annotations in this group and delete the group permanently. Are you sure?');
+    }
+
+    this.on('submit', (event) => {
+      if (!confirmFormSubmit()) {
+        event.preventDefault();
+      }
+    });
+  }
+}
+
+module.exports = AdminGroupsController;

--- a/h/static/scripts/tests/controllers/admin-groups-controller-test.js
+++ b/h/static/scripts/tests/controllers/admin-groups-controller-test.js
@@ -1,0 +1,43 @@
+'use strict';
+
+const AdminGroupsController = require('../../controllers/admin-groups-controller');
+
+function submitEvent() {
+  return new Event('submit', {bubbles: true, cancelable: true});
+}
+
+describe('AdminGroupsController', () => {
+  let root;
+  let form;
+
+  beforeEach(() => {
+    root = document.createElement('div');
+    root.innerHTML = '<form><input type="submit"></form>';
+    form = root.querySelector('form');
+    document.body.appendChild(root);
+  });
+
+  afterEach(() => {
+    root.remove();
+  });
+
+  it('it submits the form when confirm returns true', () => {
+    const event = submitEvent();
+    const fakeWindow = {confirm: sinon.stub().returns(true)};
+    new AdminGroupsController(root, {window: fakeWindow});
+
+    form.dispatchEvent(event);
+
+    assert.isFalse(event.defaultPrevented);
+  });
+
+  it('it cancels the form submission when confirm returns false', () => {
+    const event = submitEvent();
+    const fakeWindow = {confirm: sinon.stub().returns(false)};
+    new AdminGroupsController(root, {window: fakeWindow});
+
+    form.dispatchEvent(event);
+
+    assert.isTrue(event.defaultPrevented);
+  });
+});

--- a/h/templates/admin/groups.html.jinja2
+++ b/h/templates/admin/groups.html.jinja2
@@ -16,6 +16,8 @@
           <th>URL</th>
           <th>Created by</th>
           <th>Members</th>
+          <th>Type</th>
+          <th>Delete Group</th>
         </tr>
       </thead>
       <tbody>
@@ -36,6 +38,16 @@
               {% endif %}
             </td>
             <td>{{ group.members|length }}</td>
+            <td>{{ group.type|capitalize }}</td>
+            <td>
+            <form method="POST"
+                  action="{{request.route_path('admin_groups_edit', id='group.pubid')}}"
+                  class="form-inline js-groups-delete-form">
+              <input type="hidden" name="csrf_token" value="{{ request.session.get_csrf_token() }}">
+              <input type="hidden" name="delete" value="yes">
+              <input type="hidden" name="groupid" value="{{group.pubid}}">
+              <button class="btn btn-danger" type="submit">Delete Group</button>
+            </form>
           </tr>
         {% endfor %}
       </tbody>

--- a/tests/h/routes_test.py
+++ b/tests/h/routes_test.py
@@ -43,6 +43,7 @@ def test_includeme():
         call('admin_cohorts_edit', '/admin/features/cohorts/{id}'),
         call('admin_groups', '/admin/groups'),
         call('admin_groups_create', '/admin/groups/new'),
+        call('admin_groups_edit', '/admin/groups/edit/{id}'),
         call('admin_mailer', '/admin/mailer'),
         call('admin_mailer_test', '/admin/mailer/test'),
         call('admin_nipsa', '/admin/nipsa'),

--- a/tests/h/views/admin_groups_test.py
+++ b/tests/h/views/admin_groups_test.py
@@ -91,10 +91,12 @@ class TestGroupEditController(object):
     def test_delete_raises_if_group_not_found(self, pyramid_request, group_svc):
         group_svc.find.return_value = None
         pyramid_request.POST['groupid'] = 'foobar'
+        pyramid_request.session.flash = mock.Mock()
         ctrl = GroupEditController(pyramid_request)
 
         with pytest.raises(admin_groups.GroupNotFoundError):
             ctrl.delete()
+            pyramid_request.session.flash.assert_called_once_with(mock.ANY, 'error')
 
 
 @pytest.fixture

--- a/tests/h/views/admin_groups_test.py
+++ b/tests/h/views/admin_groups_test.py
@@ -8,8 +8,9 @@ import pytest
 import mock
 
 # from h.models.auth_client import AuthClient, GrantType, ResponseType
+from h.services.groupfinder import GroupfinderService
 from h.views import admin_groups
-from h.views.admin_groups import GroupCreateController
+from h.views.admin_groups import GroupCreateController, GroupEditController
 
 
 def test_index_lists_groups_sorted_by_created_desc(pyramid_request, routes, factories, authority):
@@ -74,6 +75,28 @@ class TestGroupCreateController(object):
         assert response == matchers.redirect_302_to(expected_location)
 
 
+@pytest.mark.usefixtures('routes')
+class TestGroupEditController(object):
+
+    def test_delete_succeeds_if_group_found(self, pyramid_request, group_svc, factories):
+        group_svc.find.return_value = factories.Group()
+        pyramid_request.session.flash = mock.Mock()
+        pyramid_request.POST['groupid'] = 'foobar'
+        ctrl = GroupEditController(pyramid_request)
+
+        ctrl.delete()
+
+        pyramid_request.session.flash.called_once_with(mock.ANY, 'success')
+
+    def test_delete_raises_if_group_not_found(self, pyramid_request, group_svc):
+        group_svc.find.return_value = None
+        pyramid_request.POST['groupid'] = 'foobar'
+        ctrl = GroupEditController(pyramid_request)
+
+        with pytest.raises(admin_groups.GroupNotFoundError):
+            ctrl.delete()
+
+
 @pytest.fixture
 def authority():
     return 'foo.com'
@@ -100,3 +123,11 @@ def handle_form_submission(patch):
 def routes(pyramid_config):
     pyramid_config.add_route('admin_groups', '/admin/groups')
     pyramid_config.add_route('admin_groups_create', '/admin/groups/new')
+    pyramid_config.add_route('admin_groups_delete', '/admin/groups/delete')
+
+
+@pytest.fixture
+def group_svc(pyramid_config):
+    service = mock.create_autospec(GroupfinderService, spec_set=True, instance=True)
+    pyramid_config.register_service(service, iface='h.interfaces.IGroupService')
+    return service


### PR DESCRIPTION
This interim PR adds a "DELETE" option to the list-groups admin panel, and a placeholder view controller for handling delete operations. It also implements a JS-driven confirm dialog mirroring that of delete-user in the admin section.

I'd like to get a quick sanity check on this approach from the view level while I go ahead and work on the service that will be needed to do the actual deletion.