### PR TITLE
Initial implementation of a form control for editing lists

### DIFF
--- a/h/jinja_extensions.py
+++ b/h/jinja_extensions.py
@@ -12,6 +12,8 @@ except ImportError:
 from jinja2 import Markup
 from jinja2.ext import Extension
 
+from h._compat import url_unquote
+
 SVG_NAMESPACE_URI = 'http://www.w3.org/2000/svg'
 
 
@@ -27,6 +29,7 @@ class Filters(Extension):
         environment.filters['to_json'] = to_json
         environment.filters['human_timestamp'] = human_timestamp
         environment.filters['format_number'] = format_number
+        environment.filters['url_unquote'] = url_unquote
 
 
 def human_timestamp(timestamp, now=datetime.datetime.utcnow):

--- a/h/static/scripts/admin-site.js
+++ b/h/static/scripts/admin-site.js
@@ -13,6 +13,7 @@ const AdminUsersController = require('./controllers/admin-users-controller');
 const ConfirmSubmitController = require('./controllers/confirm-submit-controller');
 const FormController = require('./controllers/form-controller');
 const FormInputController = require('./controllers/form-input-controller');
+const ListInputController = require('./controllers/list-input-controller');
 const TooltipController = require('./controllers/tooltip-controller');
 const upgradeElements = require('./base/upgrade-elements');
 
@@ -20,6 +21,7 @@ const controllers = {
   '.js-confirm-submit': ConfirmSubmitController,
   '.js-form': FormController,
   '.js-form-input': FormInputController,
+  '.js-list-input': ListInputController,
   '.js-tooltip': TooltipController,
   '.js-users-delete-form': AdminUsersController,
 };

--- a/h/static/scripts/controllers/form-input-controller.js
+++ b/h/static/scripts/controllers/form-input-controller.js
@@ -20,7 +20,7 @@ class FormInputController extends Controller {
     const hasError = element.classList.contains('is-error');
     this.setState({ hasError });
 
-    this.refs.formInput.addEventListener('input', () => {
+    element.addEventListener('input', () => {
       this.setState({ hasError: false });
     });
   }

--- a/h/static/scripts/controllers/list-input-controller.js
+++ b/h/static/scripts/controllers/list-input-controller.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const Controller = require('../base/controller');
+const { cloneTemplate } = require('../util/dom');
+
+/**
+ * Controller for list inputs.
+ *
+ * The default deform widget for editing sequences,
+ * `deform.widget.SequenceWidget` has support for various options such as a
+ * minimum and maximum number of items and drag-and-drop re-ordering, which are
+ * not yet implemented here.
+ */
+class ListInputController extends Controller {
+  constructor(element) {
+    super(element);
+
+    // Handle 'Add {item type}' button.
+    this.refs.addItemButton.addEventListener('click', () => {
+      const newItemEl = cloneTemplate(this.refs.itemTemplate);
+      this.refs.itemList.appendChild(newItemEl);
+    });
+
+    // Handle 'Remove' button.
+    element.addEventListener('click', (event) => {
+      if (event.target.getAttribute('data-ref') === 'removeItemButton') {
+        const parentItem = event.target.closest('li');
+        parentItem.remove();
+      }
+    });
+  }
+}
+
+module.exports = ListInputController;

--- a/h/static/scripts/site.js
+++ b/h/static/scripts/site.js
@@ -20,6 +20,7 @@ const FormCancelController = require('./controllers/form-cancel-controller');
 const FormInputController = require('./controllers/form-input-controller');
 const FormSelectOnFocusController = require('./controllers/form-select-onfocus-controller');
 const InputAutofocusController = require('./controllers/input-autofocus-controller');
+const ListInputController = require('./controllers/list-input-controller');
 const SearchBarController = require('./controllers/search-bar-controller');
 const SearchBucketController = require('./controllers/search-bucket-controller');
 const ShareWidgetController = require('./controllers/share-widget-controller');
@@ -38,6 +39,7 @@ const controllers = {
   '.js-form-cancel': FormCancelController,
   '.js-form-input': FormInputController,
   '.js-input-autofocus': InputAutofocusController,
+  '.js-list-input': ListInputController,
   '.js-select-onfocus': FormSelectOnFocusController,
   '.js-search-bar': SearchBarController,
   '.js-search-bucket': SearchBucketController,

--- a/h/static/scripts/tests/controllers/form-input-controller-test.js
+++ b/h/static/scripts/tests/controllers/form-input-controller-test.js
@@ -8,7 +8,7 @@ describe('FormInputController', () => {
   const template = `
     <div class="js-form-input">
       <label>Some label</label>
-      <input type="text" data-ref="formInput">
+      <input type="text" name="some-text-input">
     </div>
   `.trim();
 
@@ -21,6 +21,16 @@ describe('FormInputController', () => {
     const errorTemplate = template.replace('js-form-input', 'js-form-input is-error');
     const ctrl = setupComponent(document, errorTemplate, FormInputController);
     assert.equal(ctrl.state.hasError, true);
+  });
+
+  it('resets `hasError` state when an input event occurs', () => {
+    const ctrl = setupComponent(document, template, FormInputController);
+    const input = ctrl.element.querySelector('input');
+    ctrl.setState({ hasError: true });
+
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+
+    assert.equal(ctrl.state.hasError, false);
   });
 
   it('toggles "is-error" class when setting `hasError` state', () => {

--- a/h/static/scripts/tests/controllers/list-input-controller-test.js
+++ b/h/static/scripts/tests/controllers/list-input-controller-test.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const ListInputController = require('../../controllers/list-input-controller');
+const { setupComponent } = require('./util');
+
+describe('ListInputController', () => {
+  const template = `
+  <div class="js-list-input">
+    <template data-ref="itemTemplate">
+      <li>
+        <input name="an-input-field">
+        <button data-ref="removeItemButton">Remove</button>
+      </li>
+    </template>
+
+    <ul data-ref="itemList">
+    </ul>
+
+    <button data-ref="addItemButton">Add item</button>
+  </div>
+  `.trim();
+
+  function itemCount(ctrl) {
+    return ctrl.refs.itemList.querySelectorAll('li').length;
+  }
+
+  it('adds a new blank item when clicking "Add item" button', () => {
+    const ctrl = setupComponent(document, template, ListInputController);
+    ctrl.refs.addItemButton.click();
+    assert.equal(itemCount(ctrl), 1);
+
+    ctrl.refs.addItemButton.click();
+    assert.equal(itemCount(ctrl), 2);
+  });
+
+  it('removes the item when clicking "Remove item" button', () => {
+    const ctrl = setupComponent(document, template, ListInputController);
+    ctrl.refs.addItemButton.click();
+
+    const removeBtn = ctrl.element.querySelector('li > button');
+    removeBtn.click();
+
+    assert.equal(itemCount(ctrl), 1);
+  });
+});

--- a/h/static/styles/admin.scss
+++ b/h/static/styles/admin.scss
@@ -8,6 +8,7 @@
 @import 'partials/form-container';
 @import 'partials/form-input';
 @import 'partials/form';
+@import 'partials/list-input';
 @import 'partials/svg-icon';
 @import 'partials/tooltip';
 

--- a/h/static/styles/partials/_list-input.scss
+++ b/h/static/styles/partials/_list-input.scss
@@ -1,0 +1,23 @@
+.list-input {
+  /**
+   * Add padding to position list items below the absolutely-positioned field
+   * label.
+   */
+  padding-top: 30px;
+}
+
+.list-input__list {
+  padding-left: 0;
+}
+
+.list-input__item {
+  list-style-type: none;
+  display: flex;
+  flex-direction: column;
+}
+
+.list-input__remove-btn {
+  margin-top: 5px;
+  margin-bottom: 5px;
+  align-self: flex-end;
+}

--- a/h/static/styles/site.scss
+++ b/h/static/styles/site.scss
@@ -18,6 +18,7 @@
 @import 'partials/group-invite';
 @import 'partials/join-group-form';
 @import 'partials/link';
+@import 'partials/list-input';
 @import 'partials/lozenge';
 @import 'partials/masthead';
 @import 'partials/nav-bar';

--- a/h/templates/deform/sequence.jinja2
+++ b/h/templates/deform/sequence.jinja2
@@ -1,53 +1,19 @@
-<div tal:define="prototype field.widget.prototype(field)"
-     class="deformSeq"
-     id="{{ field.oid }}">
+<div class="list-input js-list-input" id="{{ field.oid }}">
+  <template data-ref="itemTemplate">
+  {# `field.widget.prototype(field)` returns the `sequence_item` template
+     rendered by deform as HTML and then URL-encoded. #}
+  {{ field.widget.prototype(field) | url_unquote | safe }}
+  </template>
 
-  <!-- sequence -->
+  <input type="hidden" name="__start__" value="{{ field.name }}:sequence">
 
-  <input type="hidden" name="__start__" value="{{ field.name }}:sequence"
-         class="deformProto"
-         tal:attributes="prototype prototype"/>
-
-  <ul id="{{ field.oid }}-orderable">
-
-    <!--! subfields is a tuple for bw compat with 3rdparty templates;
-          we ignore the first element (the cstruct) because it's already
-          attached to the field -->
-    {% for (_, subfield) in subfields %}
+  <ul class="list-input__list" data-ref="itemList">
+    {% for (cstruct, subfield) in subfields %}
     {{ subfield.render_template(field.widget.item_template, parent=field) | safe }}
     {% endfor %}
-
-    <li class="deformInsertBefore"
-          tal:attributes="min_len min_len;
-                          max_len max_len;
-                          now_len now_len;
-                          orderable orderable;"></li>
-
   </ul>
 
-  <a href="#"
-     class="deformSeqAdd"
-     id="{{ field.oid }}-seqAdd"
-     onclick="javascript: return deform.appendSequenceItem(this);">
-    <small id="{{ field.oid }}-addtext">{{ add_subitem_text }}</small>
-  </a>
-
-  <script type="text/javascript">
-     deform.addCallback(
-       '{{ field.oid }}',
-       function(oid) {
-         oid_node = $('#'+ oid);
-         deform.processSequenceButtons(oid_node, {{ field.widget.min_len }},
-                                       {{ field.widget.max_len }}, {{ subfields | length }}, {{ orderable }});
-       }
-     )
-     {% if field.widget.orderable %}
-     $( "#{{oid}}-orderable" ).sortable({handle: "span.deformOrderbutton"});
-     {% endif %}
-  </script>
+  <button class="btn" type="button" data-ref="addItemButton">{{ add_subitem_text }}</button>
 
   <input type="hidden" name="__end__" value="{{ field.name }}:sequence"/>
-
-  <!-- /sequence -->
-
 </div>

--- a/h/templates/deform/sequence.jinja2
+++ b/h/templates/deform/sequence.jinja2
@@ -1,0 +1,53 @@
+<div tal:define="prototype field.widget.prototype(field)"
+     class="deformSeq"
+     id="{{ field.oid }}">
+
+  <!-- sequence -->
+
+  <input type="hidden" name="__start__" value="{{ field.name }}:sequence"
+         class="deformProto"
+         tal:attributes="prototype prototype"/>
+
+  <ul id="{{ field.oid }}-orderable">
+
+    <!--! subfields is a tuple for bw compat with 3rdparty templates;
+          we ignore the first element (the cstruct) because it's already
+          attached to the field -->
+    {% for (_, subfield) in subfields %}
+    {{ subfield.render_template(field.widget.item_template, parent=field) | safe }}
+    {% endfor %}
+
+    <li class="deformInsertBefore"
+          tal:attributes="min_len min_len;
+                          max_len max_len;
+                          now_len now_len;
+                          orderable orderable;"></li>
+
+  </ul>
+
+  <a href="#"
+     class="deformSeqAdd"
+     id="{{ field.oid }}-seqAdd"
+     onclick="javascript: return deform.appendSequenceItem(this);">
+    <small id="{{ field.oid }}-addtext">{{ add_subitem_text }}</small>
+  </a>
+
+  <script type="text/javascript">
+     deform.addCallback(
+       '{{ field.oid }}',
+       function(oid) {
+         oid_node = $('#'+ oid);
+         deform.processSequenceButtons(oid_node, {{ field.widget.min_len }},
+                                       {{ field.widget.max_len }}, {{ subfields | length }}, {{ orderable }});
+       }
+     )
+     {% if field.widget.orderable %}
+     $( "#{{oid}}-orderable" ).sortable({handle: "span.deformOrderbutton"});
+     {% endif %}
+  </script>
+
+  <input type="hidden" name="__end__" value="{{ field.name }}:sequence"/>
+
+  <!-- /sequence -->
+
+</div>

--- a/h/templates/deform/sequence.jinja2
+++ b/h/templates/deform/sequence.jinja2
@@ -13,6 +13,9 @@
     {% endfor %}
   </ul>
 
+  {# New item button. The label must be supplied by setting the `add_subitem_text_template`
+     argument to the `SequenceWidget` constructor when declaring the widget used
+     by the field. #}
   <button class="btn" type="button" data-ref="addItemButton">{{ add_subitem_text }}</button>
 
   <input type="hidden" name="__end__" value="{{ field.name }}:sequence"/>

--- a/h/templates/deform/sequence_item.jinja2
+++ b/h/templates/deform/sequence_item.jinja2
@@ -1,30 +1,15 @@
 {% if not field.widget.hidden %}
-<li class="{{ field.widget.item_css_class or ''}} {{ field.error and error_class or '' }}"
-    title="{{ field.description }}" i18n:domain="deform">
-
-  <!-- sequence_item -->
-
-  <span class="deformClosebutton"
-        id="{{ oid }}-close"
-        tal:condition="not hidden"
-        title="Remove"
-        i18n:attributes="title"
-        onclick="javascript:deform.removeSequenceItem(this);"></span>
-
-  <span class="deformOrderbutton"
-        id="{{ field.oid }}-order"
-        tal:condition="not hidden"
-        title="Reorder (via drag and drop)"
-        i18n:attributes="title"></span>
+<li class="list-input__item" title="{{ field.description }}">
 
   {{ field.serialize(cstruct=cstruct) | safe }}
+
+  <button class="btn btn--danger list-input__remove-btn" type="button"
+          data-ref="removeItemButton">Remove</button>
 
   {% if field.error %}
   {% for msg in field.error.messages() %}
   <p class="{{ field.widget.error_class }}">{{ msg }}</p>
   {% endfor %}
   {% endif %}
-
-  <!-- /sequence_item -->
 </li>
 {% endif %}

--- a/h/templates/deform/sequence_item.jinja2
+++ b/h/templates/deform/sequence_item.jinja2
@@ -1,0 +1,30 @@
+{% if not field.widget.hidden %}
+<li class="{{ field.widget.item_css_class or ''}} {{ field.error and error_class or '' }}"
+    title="{{ field.description }}" i18n:domain="deform">
+
+  <!-- sequence_item -->
+
+  <span class="deformClosebutton"
+        id="{{ oid }}-close"
+        tal:condition="not hidden"
+        title="Remove"
+        i18n:attributes="title"
+        onclick="javascript:deform.removeSequenceItem(this);"></span>
+
+  <span class="deformOrderbutton"
+        id="{{ field.oid }}-order"
+        tal:condition="not hidden"
+        title="Reorder (via drag and drop)"
+        i18n:attributes="title"></span>
+
+  {{ field.serialize(cstruct=cstruct) | safe }}
+
+  {% if field.error %}
+  {% for msg in field.error.messages() %}
+  <p class="{{ field.widget.error_class }}">{{ msg }}</p>
+  {% endfor %}
+  {% endif %}
+
+  <!-- /sequence_item -->
+</li>
+{% endif %}


### PR DESCRIPTION
Implement a form control for editing form fields that have a list type.
These fields use the `SequenceSchema` colander schema and deform's `SequenceWidget`.

I started with deform's bundled templates for `SequenceWidget` and
rewrote them to conform to our conventions for form controls:

 - BEM-style CSS
 - `<template>` elements for item templates that need to be "stamped
   out" on the client side
 - Use of correct semantic elements for things (eg. `<button>` for
   buttons)
 - Removal of inline JavaScript (which our CSP policy disallows) and
   logic added to the HTML via a `Controller` subclass.

The other form controls were designed to work without JavaScript. I have
intentionally not done that here as I don't think we have a need.

This initial implementation is not pretty and it doesn't implement some
of the features of the original sequence widget, such as item
re-ordering, but it does provide a basic scaffold that we can build on
in future.