### PR TITLE
Make `h.pubid` unicode

### DIFF
--- a/h/pubid.py
+++ b/h/pubid.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
 """
 Generate random strings for use as identifiers in URLs (and other places).
 


### PR DESCRIPTION
Make `h.pubid` import `unicode_literals` so we can avoid problems like:

`Group` model:
```
    pubid = sa.Column(sa.Text(),
                      default=pubid.generate,
                      unique=True,
                      nullable=False)
```

vs.

`Annotation` model:
```
    groupid = sa.Column(sa.UnicodeText,
                        default='__world__',
                        server_default='__world__',
                        nullable=False,
                        index=True)
```

having different opinions of what a string should look like.