### PR TITLE
Use sequence schema for "origins" field of group creation schema

### DIFF
--- a/h/schemas/admin_group.py
+++ b/h/schemas/admin_group.py
@@ -3,7 +3,7 @@
 from __future__ import unicode_literals
 
 import colander
-from deform.widget import SelectWidget, TextAreaWidget
+from deform.widget import SelectWidget, SequenceWidget, TextAreaWidget
 
 from h import i18n
 from h import validators
@@ -86,11 +86,13 @@ class CreateAdminGroupSchema(CSRFSchema):
         missing=None
     )
 
-    origins = colander.SchemaNode(
-        colander.String(),
+    origins = colander.SequenceSchema(
+        colander.Sequence(),
+        colander.SchemaNode(colander.String(),
+                            name='origin',
+                            validator=colander.url),
         title=_('Scope Origins'),
-        widget=TextAreaWidget(rows=5),
-        hint=_('Enter scope origins (e.g. "http://www.foo.com"), one per line'),
-        preparer=_split_origins,
-        missing=None
+        hint=_('Origins where this group appears (e.g. "https://example.com")'),
+        missing=None,
+        widget=SequenceWidget(add_subitem_text_template=_('Add origin')),
     )


### PR DESCRIPTION
Now that we have support for rendering list inputs in forms (albeit in
an unpolished way), use colander's standard method of representing list
fields in schemas for group origins.

This enables validation of the content of each list item using a
validator plus whatever UI affordances we have in our forms for editing
lists of things.

----

In user-facing terms, these changes mean that the "Scope origins" field in the form for creating groups has changed from a text box to our current (not yet polished) UI for editing a list of things, and that invalid URLs fail validation (note that the scheme is not checked and the validation error is not presented nicely but at least it is there):

<img width="419" alt="screenshot 2018-03-12 16 10 37" src="https://user-images.githubusercontent.com/2458/37299587-9f59e294-261b-11e8-82c8-233548683b01.png">
