### PR TITLE
Actually create group when submitting form

### DIFF
--- a/h/views/admin_groups.py
+++ b/h/views/admin_groups.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+from jinja2 import Markup
 from pyramid.view import view_config, view_defaults
 from pyramid.httpexceptions import HTTPFound
 
@@ -70,8 +71,8 @@ class GroupCreateController(object):
             self.request.db.flush(objects=[group])
 
             group_url = self.request.route_url('group_read', pubid=group.pubid, slug=group.slug)
-            self.request.session.flash('Created new group {name} at {url}'.format(
-                                        name=name, url=group_url), queue='success')
+            self.request.session.flash(Markup('Created new group <a href="{url}">{name}</a>'.format(
+                                        name=name, url=group_url)), queue='success')
 
             # Direct the user back to the admin page.
             return HTTPFound(location=self.request.route_url('admin_groups'))

--- a/h/views/admin_groups.py
+++ b/h/views/admin_groups.py
@@ -56,7 +56,7 @@ class GroupCreateController(object):
             origins = appstruct['origins']
             type_ = appstruct['group_type']
 
-            userid = 'acct:{}@{}'.format(creator, authority)
+            userid = models.User(username=creator, authority=authority).userid
 
             if type_ == 'open':
                 group = svc.create_open_group(name=name, userid=userid,

--- a/tests/h/views/admin_groups_test.py
+++ b/tests/h/views/admin_groups_test.py
@@ -11,6 +11,7 @@ import mock
 from h.views import admin_groups
 from h.views.admin_groups import GroupCreateController
 from h.services.user import UserService
+from h.services.group import GroupService
 
 
 def test_index_lists_groups_sorted_by_created_desc(pyramid_request, routes, factories, authority):
@@ -37,7 +38,7 @@ def test_index_paginates_results(pyramid_request, routes, paginate):
     paginate.assert_called_once_with(pyramid_request, mock.ANY, mock.ANY)
 
 
-@pytest.mark.usefixtures('user_svc')
+@pytest.mark.usefixtures('group_svc', 'routes', 'user_svc')
 class TestGroupCreateController(object):
 
     def test_get_sets_form(self, pyramid_request):
@@ -65,6 +66,7 @@ class TestGroupCreateController(object):
                 'name': 'My New Group',
                 'group_type': 'restricted',
                 'creator': pyramid_request.user.username,
+                'description': None,
                 'authority': pyramid_request.authority,
                 'origins': []
             })
@@ -75,6 +77,39 @@ class TestGroupCreateController(object):
 
         expected_location = pyramid_request.route_url('admin_groups')
         assert response == matchers.redirect_302_to(expected_location)
+
+    @pytest.mark.parametrize('type_', [
+        'open',
+        'restricted',
+    ])
+    def test_post_creates_group_on_success(self, pyramid_request, group_svc, handle_form_submission, type_):
+        name = 'My new group'
+        creator = pyramid_request.user.username
+        description = 'Purpose of new group'
+        origins = ['https://example.com']
+
+        def call_on_success(request, form, on_success, on_failure):
+            return on_success({
+                'authority': pyramid_request.authority,
+                'creator': creator,
+                'description': description,
+                'group_type': type_,
+                'name': name,
+                'origins': origins,
+            })
+        handle_form_submission.side_effect = call_on_success
+        ctrl = GroupCreateController(pyramid_request)
+
+        ctrl.post()
+
+        if type_ == 'open':
+            create_method = group_svc.create_open_group
+        else:
+            create_method = group_svc.create_restricted_group
+        expected_userid = 'acct:{}@{}'.format(creator, pyramid_request.authority)
+
+        create_method.assert_called_with(name=name, userid=expected_userid, description=description,
+                                         origins=origins)
 
 
 @pytest.fixture
@@ -103,10 +138,18 @@ def handle_form_submission(patch):
 def routes(pyramid_config):
     pyramid_config.add_route('admin_groups', '/admin/groups')
     pyramid_config.add_route('admin_groups_create', '/admin/groups/new')
+    pyramid_config.add_route('group_read', '/groups/{pubid}/{slug}')
 
 
 @pytest.fixture
 def user_svc(pyramid_config):
     svc = mock.create_autospec(UserService, spec_set=True, instance=True)
     pyramid_config.register_service(svc, name='user')
+    return svc
+
+
+@pytest.fixture
+def group_svc(pyramid_config):
+    svc = mock.create_autospec(GroupService, spec_set=True, instance=True)
+    pyramid_config.register_service(svc, name='group')
     return svc

--- a/tests/h/views/admin_groups_test.py
+++ b/tests/h/views/admin_groups_test.py
@@ -7,7 +7,7 @@ import datetime
 import pytest
 import mock
 
-# from h.models.auth_client import AuthClient, GrantType, ResponseType
+from h.models import User
 from h.views import admin_groups
 from h.views.admin_groups import GroupCreateController
 from h.services.user import UserService
@@ -106,7 +106,7 @@ class TestGroupCreateController(object):
             create_method = group_svc.create_open_group
         else:
             create_method = group_svc.create_restricted_group
-        expected_userid = 'acct:{}@{}'.format(creator, pyramid_request.authority)
+        expected_userid = User(username=creator, authority=pyramid_request.authority).userid
 
         create_method.assert_called_with(name=name, userid=expected_userid, description=description,
                                          origins=origins)


### PR DESCRIPTION
Actually create the group using the appropriate group service method
when submitting the "Create a group" form in the admin panel.