### PR TITLE
Add missing collectd plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ MAINTAINER Hypothes.is Project and contributors
 RUN apk add --no-cache \
     ca-certificates \
     collectd \
+    collectd-disk \
     collectd-nginx \
     libffi \
     libpq \


### PR DESCRIPTION
collectd-disk used to be part of the collectd package in Alpine 3.4 but
moved to a separate package in Alpine 3.7.