### PR TITLE
Improve design of form list inputs (Part 1)

### DIFF
--- a/h/schemas/admin_group.py
+++ b/h/schemas/admin_group.py
@@ -87,6 +87,6 @@ class CreateAdminGroupSchema(CSRFSchema):
                             validator=colander.url),
         title=_('Scope Origins'),
         hint=_('Origins where this group appears (e.g. "https://example.com")'),
-        widget=SequenceWidget(add_subitem_text_template=_('Add origin')),
+        widget=SequenceWidget(add_subitem_text_template=_('Add origin'), min_len=1),
         validator=colander.Length(min=1, min_err=_('At least one origin must be specified'))
     )

--- a/h/static/scripts/controllers/list-input-controller.js
+++ b/h/static/scripts/controllers/list-input-controller.js
@@ -23,7 +23,8 @@ class ListInputController extends Controller {
 
     // Handle 'Remove' button.
     element.addEventListener('click', (event) => {
-      if (event.target.getAttribute('data-ref') === 'removeItemButton') {
+      const btn = event.target.closest('button');
+      if (btn.getAttribute('data-ref') === 'removeItemButton') {
         const parentItem = event.target.closest('li');
         parentItem.remove();
       }

--- a/h/static/styles/partials/_form-input.scss
+++ b/h/static/styles/partials/_form-input.scss
@@ -8,8 +8,11 @@
   // Padding between top border of input and input text. This includes space
   // for the field label
   $top-padding: 35px;
+  $top-padding-no-label: 5px;
+
   // Padding between bottom border of input and input text.
   $bottom-padding: 15px;
+  $bottom-padding-no-label: 5px;
 
   // Extra vertical padding added above input content for form fields displaying
   // inline hints
@@ -135,10 +138,8 @@
 
   // The actual <input> element for the field
   .form-input__input {
-    padding-top: $top-padding;
     padding-left: $h-padding;
     padding-right: $h-padding;
-    padding-bottom: $bottom-padding;
     width: 100%;
 
     background: none;
@@ -147,6 +148,24 @@
     outline: none;
     border: 1px solid $grey-3;
     border-radius: 3px;
+  }
+
+  // Set the padding depending on whether or not this field has an associated
+  // label. The `<label>` lives outside the input in the DOM but is positioned
+  // _inside_ the `<input>`'s border visually.
+  //
+  // We do this rather than use a separate element for the field's border so
+  // that clicking anywhere inside the visual border focuses the input.
+  .form-input__input.has-label {
+    padding-top: $top-padding;
+    padding-bottom: $bottom-padding;
+    --bottom-padding: $bottom-padding;
+  }
+
+  .form-input__input:not(.has-label) {
+    padding-top: $top-padding-no-label;
+    padding-bottom: $bottom-padding-no-label;
+    --bottom-padding: $bottom-padding-no-label;
   }
 
   select.form-input__input {
@@ -173,7 +192,11 @@
     position: relative;
     left: -1px;
     top: -1px;
+
+    // Assume largest possible padding if CSS vars are not supported.
     padding-bottom: $bottom-padding - 2px;
+    padding-bottom: calc(var(--bottom-padding) - 2px);
+
     border-width: 2px;
   }
 

--- a/h/static/styles/partials/_list-input.scss
+++ b/h/static/styles/partials/_list-input.scss
@@ -14,10 +14,34 @@
   list-style-type: none;
   display: flex;
   flex-direction: column;
+  margin-bottom: 10px;
+}
+
+.list-input__item-inner {
+  display: flex;
+  flex-direction: row;
 }
 
 .list-input__remove-btn {
+  background: none;
+  border: none;
+  color: $grey-4;
+  margin-left: 5px;
   margin-top: 5px;
   margin-bottom: 5px;
   align-self: flex-end;
+}
+
+.list-input__remove-btn:hover {
+  color: $grey-6;
+}
+
+.list-input__error-list {
+  list-style-type: none;
+  margin-bottom: 10px;
+  padding-left: 10px;
+}
+
+.list-input__error-item {
+  color: $brand;
 }

--- a/h/templates/deform/includes/common_attrs.jinja2
+++ b/h/templates/deform/includes/common_attrs.jinja2
@@ -9,7 +9,11 @@ data-ref="{{ ref }} formInput"
 class="form-input__input
       {% if field.widget.css_class %} {{ field.widget.css_class }} {% endif %}
       {% if field.widget.autofocus %} js-select-onfocus{% endif %}
-      {% if field.schema.hint %} has-hint {% endif %}"
+      {% if field.schema.hint %} has-hint {% endif %}
+
+      {# `has_label` is a flag provided by the containing widget's template (eg.
+         `mapping_item`) which is rendering this field. #}
+      {% if has_label %} has-label {% endif %}"
 {%- if field.widget.size -%}
 size="{{ field.widget.size }}"
 {% endif -%}

--- a/h/templates/deform/mapping_item.jinja2
+++ b/h/templates/deform/mapping_item.jinja2
@@ -1,5 +1,7 @@
 {% set show_char_counter = field.widget.template in ('textinput', 'textarea') and
                            field.widget.max_length %}
+{% set has_label = not (field.widget.hidden or field.widget.omit_label or
+                        field.widget.category == 'structural') %}
 {%- if not field.widget.hidden -%}
 <div class="form-input
             js-form-input
@@ -19,7 +21,7 @@
      id="item-{{ field.oid }}">
 {% endif -%}
 
-{%- if not (field.widget.hidden or field.widget.omit_label or field.widget.category == 'structural') -%}
+{%- if has_label -%}
   <label class="form-input__label {% if field.widget.label_css_class %} {{ field.widget.label_css_class }}{% endif %}
                 {%- if field.schema.hint -%}js-tooltip{% endif %}"
          {%- if field.schema.hint %}aria-label="{{ field.schema.hint }}"{% endif %}
@@ -40,7 +42,7 @@
   </label>
 {% endif -%}
 
-{{ field.serialize(cstruct) }}
+{{ field.serialize(cstruct, has_label=has_label) }}
 
 {%- if field.error and not field.widget.hidden -%}
   <ul class="form-input__error-list">

--- a/h/templates/deform/sequence.jinja2
+++ b/h/templates/deform/sequence.jinja2
@@ -9,7 +9,8 @@
 
   <ul class="list-input__list" data-ref="itemList">
     {% for (cstruct, subfield) in subfields %}
-    {{ subfield.render_template(field.widget.item_template, parent=field) | safe }}
+    {% set can_delete = (not field.widget.min_len) or loop.index > field.widget.min_len %}
+    {{ subfield.render_template(field.widget.item_template, parent=field, can_delete=can_delete) | safe }}
     {% endfor %}
   </ul>
 

--- a/h/templates/deform/sequence_item.jinja2
+++ b/h/templates/deform/sequence_item.jinja2
@@ -1,15 +1,25 @@
 {% if not field.widget.hidden %}
 <li class="list-input__item" title="{{ field.description }}">
 
-  {{ field.serialize(cstruct=cstruct) | safe }}
+  <div class="list-input__item-inner">
+    {{ field.serialize(cstruct=cstruct) | safe }}
 
-  <button class="btn btn--danger list-input__remove-btn" type="button"
-          data-ref="removeItemButton">Remove</button>
+    <button class="list-input__remove-btn"
+            title="{% trans %}Remove item{% endtrans %}"
+            type="button"
+            data-ref="removeItemButton">
+    {{ svg_icon('lozenge-close') }}
+    </button>
+  </div>
 
-  {% if field.error %}
-  {% for msg in field.error.messages() %}
-  <p class="{{ field.widget.error_class }}">{{ msg }}</p>
-  {% endfor %}
-  {% endif %}
+  {%- if field.error and not field.widget.hidden -%}
+  <ul class="list-input__error-list">
+    {% for msg in field.error.messages() -%}
+      {%- set errstr = 'error-%s' % field.oid -%}
+      {%- set pid = (loop.index0==0 and errstr) or ('%s-%s' % (errstr, loop.index0)) -%}
+      <li class="list-input__error-item" id="{{ pid }}">{{ _(msg) }}</li>
+    {% endfor -%}
+  </ul>
+  {% endif -%}
 </li>
 {% endif %}

--- a/h/templates/deform/sequence_item.jinja2
+++ b/h/templates/deform/sequence_item.jinja2
@@ -4,12 +4,14 @@
   <div class="list-input__item-inner">
     {{ field.serialize(cstruct=cstruct) | safe }}
 
+    {% if (can_delete is not defined) or can_delete %}
     <button class="list-input__remove-btn"
             title="{% trans %}Remove item{% endtrans %}"
             type="button"
             data-ref="removeItemButton">
     {{ svg_icon('lozenge-close') }}
     </button>
+    {% endif %}
   </div>
 
   {%- if field.error and not field.widget.hidden -%}


### PR DESCRIPTION
~~**Depends on https://github.com/hypothesis/h/pull/4879**~~

These are the initial batch of improvements to the design of form list input. The changes in this PR are to:

- Reduce the height of input fields without labels
- Make the "Remove item" button more subtle
- Display validation error messages closer to the input field and in red

Notably missing from this first batch of changes is to make the outline of list items with validation errors bold + red as they are for other input fields. That will come in follow-up work.

**Master:**

<img width="435" alt="screenshot 2018-03-15 13 53 04" src="https://user-images.githubusercontent.com/2458/37467609-a194f9c4-2858-11e8-8110-9381eb615a43.png">

<img width="432" alt="screenshot 2018-03-15 13 52 45" src="https://user-images.githubusercontent.com/2458/37467615-a9f425e0-2858-11e8-9a02-5b95a2c6c251.png">

**This branch:**

<img width="426" alt="screenshot 2018-03-15 13 52 01" src="https://user-images.githubusercontent.com/2458/37467641-bc37f68c-2858-11e8-883f-c32bec0a33f8.png">

<img width="426" alt="screenshot 2018-03-15 13 52 17" src="https://user-images.githubusercontent.com/2458/37467630-b62bd52e-2858-11e8-84be-05fe808a817c.png">


