### PR TITLE
Add admin view for editing groups

### DIFF
--- a/h/routes.py
+++ b/h/routes.py
@@ -40,6 +40,7 @@ def includeme(config):
     config.add_route('admin_cohorts_edit', '/admin/features/cohorts/{id}')
     config.add_route('admin_groups', '/admin/groups')
     config.add_route('admin_groups_create', '/admin/groups/new')
+    config.add_route('admin_groups_edit', '/admin/groups/{pubid}')
     config.add_route('admin_mailer', '/admin/mailer')
     config.add_route('admin_mailer_test', '/admin/mailer/test')
     config.add_route('admin_nipsa', '/admin/nipsa')

--- a/h/schemas/admin_group.py
+++ b/h/schemas/admin_group.py
@@ -35,6 +35,18 @@ def user_exists_validator_factory(user_svc):
     return user_exists_validator
 
 
+@colander.deferred
+def group_type_validator(node, kw):
+    group = kw.get('group')
+    if not group:
+        return colander.OneOf([key for key, title in VALID_GROUP_TYPES])
+
+    def validate(node, value):
+        if group.type != value:
+            raise colander.Invalid(node, _('Changing group type is currently not supported'))
+    return validate
+
+
 class CreateAdminGroupSchema(CSRFSchema):
 
     group_type = colander.SchemaNode(
@@ -43,7 +55,7 @@ class CreateAdminGroupSchema(CSRFSchema):
         widget=SelectWidget(
           values=(('', _('Select')),) + VALID_GROUP_TYPES
         ),
-        validator=colander.OneOf([key for key, title in VALID_GROUP_TYPES])
+        validator=group_type_validator,
     )
 
     name = colander.SchemaNode(

--- a/h/templates/admin/groups.html.jinja2
+++ b/h/templates/admin/groups.html.jinja2
@@ -22,8 +22,13 @@
         {% for group in results %}
           <tr>
             <td>
+              {% if group.type in ('open', 'restricted') %}
               {% set edit_url = request.route_url('admin_groups_edit', pubid=group.pubid) %}
               <a href="{{ edit_url }}">{{ group.name }}</a>
+              {% else %}
+              {# The group edit view does not currently support editing private groups. #}
+              {{ group.name }}
+              {% endif %}
             </td>
             <td>
               {% set group_url = request.route_url('group_read', pubid=group.pubid, slug=group.slug) %}

--- a/h/templates/admin/groups.html.jinja2
+++ b/h/templates/admin/groups.html.jinja2
@@ -21,7 +21,10 @@
       <tbody>
         {% for group in results %}
           <tr>
-            <td>{{ group.name }}</td>
+            <td>
+              {% set edit_url = request.route_url('admin_groups_edit', pubid=group.pubid) %}
+              <a href="{{ edit_url }}">{{ group.name }}</a>
+            </td>
             <td>
               {% set group_url = request.route_url('group_read', pubid=group.pubid, slug=group.slug) %}
               <a href="{{ group_url }}">

--- a/h/templates/admin/groups_edit.html.jinja2
+++ b/h/templates/admin/groups_edit.html.jinja2
@@ -1,0 +1,8 @@
+{% extends "h:templates/layouts/admin.html.jinja2" %}
+
+{% set page_id = 'groups_edit' %}
+{% set page_title = 'Edit group' %}
+
+{% block content %}
+  {{ form }}
+{% endblock %}

--- a/h/views/admin_groups.py
+++ b/h/views/admin_groups.py
@@ -3,11 +3,13 @@ from __future__ import unicode_literals
 
 from jinja2 import Markup
 from pyramid.view import view_config, view_defaults
-from pyramid.httpexceptions import HTTPFound
+from pyramid.httpexceptions import HTTPFound, HTTPNotFound
 
 from h import form  # noqa F401
 from h import i18n
 from h import models
+from h.models.group import GroupFactory, OPEN_GROUP_TYPE_FLAGS, RESTRICTED_GROUP_TYPE_FLAGS
+from h.models.group_scope import GroupScope
 from h import paginator
 from h.schemas.admin_group import CreateAdminGroupSchema, user_exists_validator_factory
 
@@ -80,6 +82,73 @@ class GroupCreateController(object):
         return form.handle_form_submission(self.request, self.form,
                                            on_success=on_success,
                                            on_failure=self._template_context)
+
+    def _template_context(self):
+        return {'form': self.form.render()}
+
+
+@view_defaults(route_name='admin_groups_edit',
+               permission='admin_groups',
+               renderer='h:templates/admin/groups_edit.html.jinja2')
+class GroupEditController(object):
+
+    def __init__(self, request):
+        # Look up the group here rather than using traversal in the route
+        # definition as that would apply `Group.__acl__` which will not match if
+        # the current (admin) user is not the creator of the group.
+        try:
+            pubid = request.matchdict.get('pubid')
+            self.group = GroupFactory(request)[pubid]
+        except KeyError:
+            raise HTTPNotFound()
+
+        self.request = request
+        self.schema = CreateAdminGroupSchema().bind(request=request)
+        self.form = request.create_form(self.schema,
+                                        buttons=(_('Save'),))
+
+    @view_config(request_method='GET')
+    def read(self):
+        self._update_appstruct()
+        return self._template_context()
+
+    @view_config(request_method='POST')
+    def update(self):
+        group = self.group
+
+        def on_success(appstruct):
+            user_svc = self.request.find_service(name='user')
+
+            group.creator = user_svc.fetch(appstruct['creator'], group.authority)
+            group.description = appstruct['description']
+            group.name = appstruct['name']
+            group.scopes = [GroupScope(origin=o) for o in appstruct['origins']]
+
+            type_flags = {'open': OPEN_GROUP_TYPE_FLAGS,
+                          'restricted': RESTRICTED_GROUP_TYPE_FLAGS}
+            permissions = type_flags[appstruct['group_type']]
+            group.joinable_by = permissions.joinable_by
+            group.readable_by = permissions.readable_by
+            group.writeable_by = permissions.writeable_by
+
+            self._update_appstruct()
+
+            return self._template_context()
+
+        return form.handle_form_submission(self.request, self.form,
+                                           on_success=on_success,
+                                           on_failure=self._template_context)
+
+    def _update_appstruct(self):
+        group = self.group
+        self.form.set_appstruct({
+            'authority': group.authority,
+            'creator': group.creator.username,
+            'description': group.description or '',
+            'group_type': group.type,
+            'name': group.name,
+            'origins': [s.origin for s in group.scopes],
+        })
 
     def _template_context(self):
         return {'form': self.form.render()}

--- a/h/views/admin_groups.py
+++ b/h/views/admin_groups.py
@@ -8,7 +8,7 @@ from pyramid.httpexceptions import HTTPFound, HTTPNotFound
 from h import form  # noqa F401
 from h import i18n
 from h import models
-from h.models.group import GroupFactory, OPEN_GROUP_TYPE_FLAGS, RESTRICTED_GROUP_TYPE_FLAGS
+from h.models.group import GroupFactory
 from h.models.group_scope import GroupScope
 from h import paginator
 from h.schemas.admin_group import CreateAdminGroupSchema, user_exists_validator_factory
@@ -103,7 +103,7 @@ class GroupEditController(object):
             raise HTTPNotFound()
 
         self.request = request
-        self.schema = CreateAdminGroupSchema().bind(request=request)
+        self.schema = CreateAdminGroupSchema().bind(request=request, group=self.group)
         self.form = request.create_form(self.schema,
                                         buttons=(_('Save'),))
 
@@ -123,13 +123,6 @@ class GroupEditController(object):
             group.description = appstruct['description']
             group.name = appstruct['name']
             group.scopes = [GroupScope(origin=o) for o in appstruct['origins']]
-
-            type_flags = {'open': OPEN_GROUP_TYPE_FLAGS,
-                          'restricted': RESTRICTED_GROUP_TYPE_FLAGS}
-            permissions = type_flags[appstruct['group_type']]
-            group.joinable_by = permissions.joinable_by
-            group.readable_by = permissions.readable_by
-            group.writeable_by = permissions.writeable_by
 
             self._update_appstruct()
 

--- a/h/views/admin_groups.py
+++ b/h/views/admin_groups.py
@@ -143,7 +143,11 @@ class GroupEditController(object):
         group = self.group
         self.form.set_appstruct({
             'authority': group.authority,
-            'creator': group.creator.username,
+
+            # `group.creator` is nullable but "Creator" is currently a required
+            # field, so the user will have to pick one when editing the group.
+            'creator': group.creator.username if group.creator else '',
+
             'description': group.description or '',
             'group_type': group.type,
             'name': group.name,

--- a/tests/h/routes_test.py
+++ b/tests/h/routes_test.py
@@ -43,6 +43,7 @@ def test_includeme():
         call('admin_cohorts_edit', '/admin/features/cohorts/{id}'),
         call('admin_groups', '/admin/groups'),
         call('admin_groups_create', '/admin/groups/new'),
+        call('admin_groups_edit', '/admin/groups/{pubid}'),
         call('admin_mailer', '/admin/mailer'),
         call('admin_mailer_test', '/admin/mailer/test'),
         call('admin_nipsa', '/admin/nipsa'),

--- a/tests/h/schemas/admin_group_test.py
+++ b/tests/h/schemas/admin_group_test.py
@@ -79,6 +79,21 @@ class TestCreateGroupSchema(object):
         with pytest.raises(colander.Invalid, match='At least one origin'):
             bound_schema.deserialize(group_data)
 
+    def test_it_raises_if_group_type_changed(self, group_data, pyramid_csrf_request):
+        group = mock.Mock(type='open')
+        group_data['group_type'] = 'restricted'
+        schema = CreateAdminGroupSchema().bind(request=pyramid_csrf_request, group=group)
+
+        with pytest.raises(colander.Invalid, match='Changing group type'):
+            schema.deserialize(group_data)
+
+    def test_it_does_not_raise_if_group_type_is_same(self, group_data, pyramid_csrf_request):
+        group = mock.Mock(type='open')
+        group_data['group_type'] = 'open'
+        schema = CreateAdminGroupSchema().bind(request=pyramid_csrf_request, group=group)
+
+        schema.deserialize(group_data)
+
 
 class TestCreateSchemaWithValidator(object):
 

--- a/tests/h/views/admin_groups_test.py
+++ b/tests/h/views/admin_groups_test.py
@@ -138,6 +138,15 @@ class TestGroupEditController(object):
 
         assert ctx['form'] == self._expected_form(group)
 
+    def test_read_renders_form_if_group_has_no_creator(self, pyramid_request, group):
+        pyramid_request.matchdict = {'pubid': group.pubid}
+        group.creator = None
+        ctrl = GroupEditController(pyramid_request)
+
+        ctx = ctrl.read()
+
+        assert ctx['form'] == self._expected_form(group)
+
     def test_update_updates_group_on_success(self, factories, pyramid_request, group, group_svc, user_svc, handle_form_submission):
         pyramid_request.matchdict = {'pubid': group.pubid}
 
@@ -225,7 +234,7 @@ class TestGroupEditController(object):
 
     def _expected_form(self, group):
         return {'authority': group.authority,
-                'creator': group.creator.username,
+                'creator': group.creator.username if group.creator else '',
                 'description': group.description or '',
                 'group_type': group.type,
                 'name': group.name,


### PR DESCRIPTION
Add an admin view at `/admin/groups/{pubid}` for editing groups. Once we have a service for deleting users, the button for deleting the group will appear on this page as well.

The view does not allow changing the authority, since all the annotations and users associated with the group have to belong to that authority as well. All the other parameters of the group, including the type, can be changed.

There are some limitations of this first iteration:
- Editing members is not yet supported, that will be a follow-up piece of work.
- Editing private groups is not yet supported. Adding support for "Private" to the list of types is trivial, but we also need to allow groups without scopes, since most existing private groups do not have them.