### PR TITLE
Make functional tests pass under Python 3

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,12 +29,14 @@ node {
                                          "-e TEST_DATABASE_URL=${databaseUrl}") {
                 // Test dependencies
                 sh 'apk add --no-cache build-base libffi-dev postgresql-dev python-dev'
+                sh 'apk add --no-cache python3 python3-dev'
                 sh 'pip install -q tox'
 
                 // Unit tests
                 sh 'cd /var/lib/hypothesis && tox'
                 // Functional tests
                 sh 'cd /var/lib/hypothesis && tox -e functional'
+                sh 'cd /var/lib/hypothesis && tox -e functional-py3'
             }
         } finally {
             rabbit.stop()

--- a/h/views/api.py
+++ b/h/views/api.py
@@ -151,6 +151,7 @@ def read(context, request):
 def read_jsonld(context, request):
     request.response.content_type = 'application/ld+json'
     request.response.content_type_params = {
+        'charset': 'UTF-8',
         'profile': str(AnnotationJSONLDPresenter.CONTEXT_URL)}
     presenter = AnnotationJSONLDPresenter(context)
     return presenter.asdict()

--- a/tests/functional/test_api.py
+++ b/tests/functional/test_api.py
@@ -4,6 +4,14 @@ from __future__ import unicode_literals
 
 import pytest
 
+# String type for request/response headers and metadata in WSGI.
+#
+# Per PEP-3333, this is intentionally `str` under both Python 2 and 3, even
+# though it has different meanings.
+#
+# See https://www.python.org/dev/peps/pep-3333/#a-note-on-string-types
+native_str = str
+
 
 @pytest.mark.functional
 class TestAPI(object):
@@ -20,7 +28,7 @@ class TestAPI(object):
     def test_annotation_read(self, app, annotation):
         """Fetch an annotation by ID."""
         res = app.get('/api/annotations/' + annotation.id,
-                      headers={b'accept': b'application/json'})
+                      headers={native_str('accept'): native_str('application/json')})
         data = res.json
         assert data['id'] == annotation.id
 

--- a/tests/functional/test_groups.py
+++ b/tests/functional/test_groups.py
@@ -48,7 +48,7 @@ def test_submit_create_group_form_with_xhr_returns_partial_html_snippet(app):
 
     res = group_form.submit(xhr=True)
 
-    assert res.body.strip('\n').startswith('<form')
+    assert res.body.strip(b'\n').startswith(b'<form')
 
 
 @pytest.mark.functional

--- a/tests/h/views/api_test.py
+++ b/tests/h/views/api_test.py
@@ -280,6 +280,7 @@ class TestReadJSONLD(object):
 
         assert pyramid_request.response.content_type == 'application/ld+json'
         assert pyramid_request.response.content_type_params == {
+            'charset': 'UTF-8',
             'profile': 'http://foo.com/context.jsonld'
         }
 

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,22 @@ commands =
     coverage run --parallel --source h,tests/h -m pytest {posargs:tests/h/}
 
 [testenv:functional]
+basepython = python2.7
+skip_install = true
+deps =
+    pytest
+    webtest
+    factory-boy
+    -rrequirements.txt
+passenv =
+    BROKER_URL
+    ELASTICSEARCH_HOST
+    TEST_DATABASE_URL
+    PYTEST_ADDOPTS
+commands = py.test {posargs:tests/functional/}
+
+[testenv:functional-py3]
+basepython = python3.6
 skip_install = true
 deps =
     pytest


### PR DESCRIPTION
This PR resolves a couple of issues with the functional tests under Python 3 and makes them all pass. See commit messages for details. To ensure they stay fixed, it also adds a step to the Jenkinsfile to run the functional tests under Python 3.

To test it out locally run `tox -e functional-py3` in this branch. Note that `tox -e functional` now always uses Python 2.7 in this branch.