### PR TITLE
Add Creator label to My group facet

### DIFF
--- a/h/panels/navbar.py
+++ b/h/panels/navbar.py
@@ -35,7 +35,16 @@ def navbar(context, request, search=None, opts=None):
     # Make all groups associated with the user visible in the search auto complete.
     list_group_service = request.find_service(name='list_groups')
     groups = list_group_service.associated_groups(request.user)
-    groups_suggestions = [{'name': group.name, 'pubid': group.pubid} for group in groups]
+
+    def _relationship(group, username):
+        if group.creator == username:
+            return 'Creator'
+        return None
+
+    groups_suggestions = [{'name': group.name,
+                           'pubid': group.pubid,
+                           'relationship': _relationship(group, request.user)}
+                          for group in groups]
 
     route = request.matched_route
 

--- a/h/panels/navbar.py
+++ b/h/panels/navbar.py
@@ -24,11 +24,6 @@ def navbar(context, request, search=None, opts=None):
     username = None
 
     if request.user:
-        for group in request.user.groups:
-            groups_menu_items.append({
-                'title': group.name,
-                'link': request.route_url('group_read', pubid=group.pubid, slug=group.slug)
-            })
         user_activity_url = request.route_url('activity.user_search',
                                               username=request.user.username)
         username = request.user.username
@@ -41,6 +36,10 @@ def navbar(context, request, search=None, opts=None):
             return 'Creator'
         return None
 
+    groups_menu_items = [{
+        'title': group.name,
+        'link': request.route_url('group_read', pubid=group.pubid, slug=group.slug),
+        } for group in groups]
     groups_suggestions = [{'name': group.name,
                            'pubid': group.pubid,
                            'relationship': _relationship(group, request.user)}

--- a/h/static/scripts/controllers/search-bar-controller.js
+++ b/h/static/scripts/controllers/search-bar-controller.js
@@ -64,7 +64,7 @@ class SearchBarController extends Controller {
         {
           matchOn: 'group',
           title: 'group:',
-          explanation: 'show annotations created in a group you are a member of',
+          explanation: 'show annotations associated with a group',
         },
       ].map((item) => { return Object.assign(item, { type: FACET_TYPE}); });
 
@@ -444,7 +444,7 @@ class SearchBarController extends Controller {
       if (newState.suggestionsType === TAG_TYPE) {
         this._suggestionsHandler.setHeader('Popular tags:');
       } else if (newState.suggestionsType === GROUP_TYPE) {
-        this._suggestionsHandler.setHeader('My groups:');
+        this._suggestionsHandler.setHeader('Your groups:');
       } else {
         this._suggestionsHandler.setHeader('Narrow your search:');
       }

--- a/h/static/scripts/controllers/search-bar-controller.js
+++ b/h/static/scripts/controllers/search-bar-controller.js
@@ -110,6 +110,7 @@ class SearchBarController extends Controller {
           matchOn: normalizeStr(item.name),
           pubid: item.pubid,
           name: item.name,
+          relationship: item.relationship,
         });
       });
 
@@ -322,9 +323,11 @@ class SearchBarController extends Controller {
       },
 
       renderListItem: (listItem) => {
-
         let itemContents = `<span class="search-bar__dropdown-menu-title"> ${escapeHtml(listItem.title)} </span>`;
-
+        if (listItem.type === GROUP_TYPE && listItem.relationship) {
+          itemContents += `<span class="search-bar__dropdown-menu-relationship"> ${escapeHtml(listItem.relationship)} </span>`;
+        }
+        
         if (listItem.explanation) {
           itemContents += `<span class="search-bar__dropdown-menu-explanation"> ${listItem.explanation} </span>`;
         }
@@ -441,7 +444,7 @@ class SearchBarController extends Controller {
       if (newState.suggestionsType === TAG_TYPE) {
         this._suggestionsHandler.setHeader('Popular tags:');
       } else if (newState.suggestionsType === GROUP_TYPE) {
-        this._suggestionsHandler.setHeader('Your groups:');
+        this._suggestionsHandler.setHeader('My groups:');
       } else {
         this._suggestionsHandler.setHeader('Narrow your search:');
       }

--- a/h/static/styles/partials/_search-bar.scss
+++ b/h/static/styles/partials/_search-bar.scss
@@ -101,6 +101,7 @@
 }
 
 .search-bar__dropdown-menu-relationship {
+  margin-left: 5px;
   color: $grey-4;
   font-weight: bold;
 }

--- a/h/static/styles/partials/_search-bar.scss
+++ b/h/static/styles/partials/_search-bar.scss
@@ -100,6 +100,11 @@
   font-weight: bold;
 }
 
+.search-bar__dropdown-menu-relationship {
+  color: $grey-4;
+  font-weight: bold;
+}
+
 .search-bar__dropdown-menu-explanation {
   font-style: italic;
 }

--- a/tests/h/panels/navbar_test.py
+++ b/tests/h/panels/navbar_test.py
@@ -34,7 +34,9 @@ class TestNavbar(object):
     def test_includes_groups_suggestions_when_logged_in(self, req, user, open_group):
         req.user = user
         result = navbar({}, req)
-        assert result['groups_suggestions'] == [{'name': g.name, 'pubid': g.pubid}
+        assert result['groups_suggestions'] == [{'name': g.name,
+                                                 'pubid': g.pubid,
+                                                 'relationship': 'Creator' if g.creator == user else None}
                                                 for g in user.groups]
 
     def test_username_url_when_logged_in(self, req, user):

--- a/tests/h/panels/navbar_test.py
+++ b/tests/h/panels/navbar_test.py
@@ -93,7 +93,7 @@ class TestNavbar(object):
     @pytest.fixture
     def user(self, factories):
         user = factories.User(username='vannevar')
-        user.groups = [factories.Group(), factories.Group()]
+        user.groups = [factories.Group(creator=user), factories.Group()]
         return user
 
     @pytest.fixture


### PR DESCRIPTION
Add a relationship label after the title of the group on the search
autocomplete group facet drop down. Currently the only relationship
so far is 'Creator' but there may be more relationships defined
later. A styling class for the new relationship label was added. The 
navbar tests were also updated to reflect the relationship addition in 
the suggested_groups. 
This is a UX fix for https://github.com/hypothesis/product-backlog/issues/510.

![image](https://user-images.githubusercontent.com/30059933/37671101-36f31cee-2c28-11e8-9985-e9ed6a488e3d.png)

Change the description of the group facet to 'show 
annotations associated with a group'. 
![image](https://user-images.githubusercontent.com/30059933/37670978-e446c4aa-2c27-11e8-84ae-815fd8f0cb06.png)

Change the Groups to return associated groups.
![image](https://user-images.githubusercontent.com/30059933/37672767-e36317ce-2c2b-11e8-8352-bb2a90887cc8.png)
