### PR TITLE
Add metric for badge count

### DIFF
--- a/h/views/badge.py
+++ b/h/views/badge.py
@@ -3,6 +3,7 @@
 from __future__ import unicode_literals
 
 from pyramid import httpexceptions
+import newrelic.agent
 
 from h import models, search
 from h.util.view import json_view
@@ -25,9 +26,11 @@ def badge(request):
         raise httpexceptions.HTTPBadRequest()
 
     if models.Blocklist.is_blocked(request.db, uri):
+        newrelic.agent.record_custom_metric('Custom/Badge/badgeCountIsZero', 1)
         return {'total': 0}
 
     query = {'uri': uri, 'limit': 0}
     result = search.Search(request, stats=request.stats).run(query)
 
+    newrelic.agent.record_custom_metric('Custom/Badge/badgeCountIsZero', int(result.total == 0))
     return {'total': result.total}


### PR DESCRIPTION
This adds a new relic custom metric to record when the badge count is zero. Since it's recorded every time (1 when it is zero, 0 when it is not zero), the average value will give us the percentage of times the badge count is zero. 
![image](https://user-images.githubusercontent.com/30059933/37572348-d6e43750-2ac6-11e8-8556-21b2ba29db55.png)

