### PR TITLE
Remove Groups Filter Feature Flag: Part I

### DIFF
--- a/h/models/feature.py
+++ b/h/models/feature.py
@@ -15,8 +15,6 @@ FEATURES = {
                           "using a cached version?"),
     'filter_highlights': ("Filter highlights in document based on visible"
                           " annotations in sidebar?"),
-    'filter_groups_by_scope': ("Only show open groups that match current authority and"
-                               " 'document_uri'? Non-scoped groups won't be returned"),
     'overlay_highlighter': "Use the new overlay highlighter?",
     'api_render_user_info': "Return users' extended info in API responses?",
     'client_display_names': "Render display names instead of user names in the client",
@@ -48,6 +46,8 @@ FEATURES_PENDING_REMOVAL = {
                                " updates to annotations in the client?"),
     'flag_action': ("Enable user to flag inappropriate annotations in the "
                     "client?"),
+    'filter_groups_by_scope': ("Only show open groups that match current authority and"
+                               " 'document_uri'? Non-scoped groups won't be returned"),
     'homepage_redirects': "Enable homepage redirects (for WordPress migration)?",
     'orphans_tab': "Show the orphans tab to separate anchored and unanchored annotations?",
     'search_for_doi': "Use DOI metadata when searching for annotations on the current page?",

--- a/h/storage.py
+++ b/h/storage.py
@@ -132,8 +132,7 @@ def create_annotation(request, data, group_service):
                                       _('You may not create annotations '
                                         'in the specified group!'))
 
-    if request.feature('filter_groups_by_scope'):
-        _validate_group_scope(group, data['target_uri'])
+    _validate_group_scope(group, data['target_uri'])
 
     annotation = models.Annotation(**data)
     annotation.created = created
@@ -189,7 +188,7 @@ def update_annotation(request, id_, data, group_service):
     if group is None:
         raise schemas.ValidationError('group: ' +
                                       _('Invalid group specified for annotation'))
-    if request.feature('filter_groups_by_scope') and data.get('target_uri', None):
+    if data.get('target_uri', None):
         _validate_group_scope(group, data['target_uri'])
 
     annotation.extra.update(data.pop('extra', {}))

--- a/h/views/api_groups.py
+++ b/h/views/api_groups.py
@@ -18,22 +18,14 @@ def groups(request):
     list_svc = request.find_service(name='list_groups')
     links_svc = request.find_service(name='group_links')
 
-    if request.feature('filter_groups_by_scope'):
-        # Filter open groups by scope against the ``document_uri`` param.
-        # The different handling of authority here is part of this
-        # feature — authority "babysitting" is going to be moving
-        # out of the service and back to the view's...purview.
-        if request.user is not None:
-            authority = request.user.authority
-        else:
-            authority = authority or request.authority
-        all_groups = list_svc.request_groups(user=request.user,
-                                             authority=authority,
-                                             document_uri=document_uri)
+    if request.user is not None:
+        authority = request.user.authority
     else:
-        all_groups = list_svc.all_groups(user=request.user,
+        authority = authority or request.authority
+    all_groups = list_svc.request_groups(user=request.user,
                                          authority=authority,
                                          document_uri=document_uri)
+
     all_groups = GroupsJSONPresenter(all_groups, links_svc).asdicts()
     return all_groups
 

--- a/tests/h/session_test.py
+++ b/tests/h/session_test.py
@@ -82,42 +82,6 @@ class TestModel(object):
             assert preferences['show_sidebar_tutorial'] is True
 
 
-class TestModelWithScopedGroups(object):
-    def test_proxies_group_lookup_to_service(self, authenticated_request):
-        svc = authenticated_request.find_service(name='list_groups')
-
-        session.model(authenticated_request)
-
-        svc.session_groups.assert_called_once_with(user=authenticated_request.user,
-                                                   authority=authenticated_request.authority)
-
-    def test_private_group_is_not_public(self, authenticated_request, factories):
-        a_group = factories.Group()
-        svc = authenticated_request.find_service(name='list_groups')
-        svc.session_groups.return_value = [a_group]
-
-        model = session.model(authenticated_request)
-
-        assert not model['groups'][0]['public']
-
-    def test_open_group_has_no_url(self, unauthenticated_request, world_group):
-        svc = unauthenticated_request.find_service(name='list_groups')
-        svc.session_groups.return_value = [world_group]
-
-        model = session.model(unauthenticated_request)
-
-        assert not model['groups'][0].get('url')
-
-    def test_private_group_has_url(self, authenticated_request, factories):
-        a_group = factories.Group()
-        svc = authenticated_request.find_service(name='list_groups')
-        svc.session_groups.return_value = [a_group]
-
-        model = session.model(authenticated_request)
-
-        assert model['groups'][0]['url']
-
-
 class TestProfile(object):
     def test_userid_unauthenticated(self, unauthenticated_request):
         assert session.profile(unauthenticated_request)['userid'] is None

--- a/tests/h/session_test.py
+++ b/tests/h/session_test.py
@@ -5,7 +5,6 @@ from h import session
 from h.services.list_groups import ListGroupsService
 
 
-@pytest.mark.usefixtures('scope_feature_off')
 class TestModel(object):
     def test_proxies_group_lookup_to_service(self, authenticated_request):
         svc = authenticated_request.find_service(name='list_groups')
@@ -360,8 +359,3 @@ def authenticated_request(authority, fake_feature):
 @pytest.fixture
 def world_group(factories):
     return factories.OpenGroup(name=u'Public', pubid='__worldish__')
-
-
-@pytest.fixture
-def scope_feature_off(pyramid_request):
-    pyramid_request.feature.flags['filter_groups_by_scope'] = False

--- a/tests/h/storage_test.py
+++ b/tests/h/storage_test.py
@@ -244,18 +244,6 @@ class TestCreateAnnotation(object):
 
         assert str(exc.value).startswith('group scope: ')
 
-    @pytest.mark.usefixtures('scope_feature_off')
-    def test_it_allows_mismatched_scope_when_feature_flag_off(self, pyramid_request, pyramid_config, group_service, scoped_open_group, models):
-        group_service.find.return_value = scoped_open_group
-
-        data = self.annotation_data()
-        data['target_uri'] = 'http://www.baz.com/boo/bah.html'
-
-        # this should not raise
-        result = storage.create_annotation(pyramid_request, data, group_service)
-
-        assert result == models.Annotation.return_value
-
     def test_it_raises_when_group_could_not_be_found(self, pyramid_request, pyramid_config, group_service):
         pyramid_config.testing_securitypolicy('userid', permissive=True)
         group_service.find.return_value = None
@@ -487,16 +475,6 @@ class TestUpdateAnnotation(object):
 
         assert annotation == pyramid_request.db.query.return_value.get.return_value
 
-    @pytest.mark.usefixtures('scope_feature_off')
-    def test_it_allows_scope_mismatch_when_feature_off(self, annotation_data, pyramid_request, group_service, scoped_open_group):
-        annotation_data['target_uri'] = u'http://www.bar.com/baz/ding.html'
-        group_service.find.return_value = scoped_open_group
-
-        # this should not raise
-        annotation = storage.update_annotation(pyramid_request, 'test_annotation_id', annotation_data, group_service)
-
-        assert annotation == pyramid_request.db.query.return_value.get.return_value
-
     def test_it_updates_the_document_metadata_from_the_annotation(
             self,
             annotation_data,
@@ -645,8 +623,3 @@ def group_service(pyramid_config, factories):
     group_service.find.return_value = open_group
     pyramid_config.register_service(group_service, iface='h.interfaces.IGroupService')
     return group_service
-
-
-@pytest.fixture
-def scope_feature_off(pyramid_request):
-    pyramid_request.feature.flags['filter_groups_by_scope'] = False


### PR DESCRIPTION
This PR follows step 1 and 2 outlined in `h.models.feature` (https://github.com/hypothesis/h/blob/1620594d3f78d22583523d338cd64ab442b5a87b/h/models/feature.py#L25) to remove feature-flag lookup in the code for filtering-groups-by-scope and move the feature flag into `PENDING_REMOVAL`. Per the instructions, this needs to be deployed before the feature flag can be fully removed.

This is part of https://github.com/hypothesis/product-backlog/issues/488