### PR TITLE
Revert "Add organization to group model"

### DIFF
--- a/h/models/group.py
+++ b/h/models/group.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from collections import namedtuple
+
 import enum
 import sqlalchemy as sa
 from pyramid import security
@@ -82,9 +83,6 @@ class Group(Base, mixins.Timestamps):
             'groups', order_by='Group.name'))
 
     scopes = sa.orm.relationship('GroupScope', backref='group', cascade='all, delete-orphan')
-
-    organization_id = sa.Column(sa.Integer, sa.ForeignKey('organization.id'))
-    organization = sa.orm.relationship('Organization')
 
     def __init__(self, **kwargs):
         super(Group, self).__init__(**kwargs)

--- a/tests/h/models/groups_test.py
+++ b/tests/h/models/groups_test.py
@@ -83,32 +83,6 @@ def test_repr(db_session, factories):
     assert repr(group) == "<Group: my-hypothesis-group>"
 
 
-def test_group_organization(db_session):
-    name = "My Hypothesis Group"
-
-    org = models.Organization(name='My Organization', authority='foobar.com')
-    db_session.add(org)
-    db_session.flush()
-
-    group = models.Group(name=name, authority='foobar.com', organization=org)
-    db_session.add(group)
-    db_session.flush()
-
-    assert group.organization == org
-    assert group.organization_id == org.id
-
-
-def test_group_organization_defaults_to_none(db_session):
-    name = "My Hypothesis Group"
-
-    group = models.Group(name=name, authority='foobar.com')
-    db_session.add(group)
-    db_session.flush()
-
-    assert group.organization is None
-    assert group.organization_id is None
-
-
 def test_created_by(db_session, factories):
     name_1 = "My first group"
     name_2 = "My second group"


### PR DESCRIPTION
This commit was merged before the necessary database migration had been
created and run in production.

This reverts commit 51534e6e8f9178e732b8fe08bce77b6572b0e78b.