### PR TITLE
Add metric unAuthUserGotZero & BadgeNotZero

### DIFF
--- a/tests/h/views/badge_test.py
+++ b/tests/h/views/badge_test.py
@@ -4,13 +4,68 @@ from __future__ import unicode_literals
 
 import pytest
 import mock
+from mock import call
 
 from pyramid import httpexceptions
 
 from h.views.badge import badge
+from h.views.badge import record_metrics
 
 
 badge_fixtures = pytest.mark.usefixtures('models', 'search_lib')
+
+
+def test_record_metrics_records_badgenotzero_with_auth_user():
+    request = mock.Mock(params={'uri': 'test_uri'})
+    request.user.username = 'foopy'
+    record_metric = mock.Mock()
+    record_event = mock.Mock()
+    record_metrics(1, request,
+                   record_metric=record_metric,
+                   record_event=record_event)
+
+    record_event.assert_called_once_with('BadgeNotZero', {'user': request.user.username})
+    record_metric.assert_called_once_with('Custom/Badge/badgeCountIsZero', 0)
+
+
+def test_record_metrics_records_badgenotzero_with_unauth_user():
+    request = mock.Mock(params={'uri': 'test_uri'})
+    request.user = None
+    record_metric = mock.Mock()
+    record_event = mock.Mock()
+    record_metrics(1, request,
+                   record_metric=record_metric,
+                   record_event=record_event)
+
+    record_event.assert_called_once_with('BadgeNotZero', {'user': 'None'})
+    record_metric.assert_called_once_with('Custom/Badge/badgeCountIsZero', 0)
+
+
+def test_record_metrics_records_badgecountiszero_with_auth_user():
+    request = mock.Mock(params={'uri': 'test_uri'})
+    record_metric = mock.Mock()
+    record_event = mock.Mock()
+    record_metrics(0, request,
+                   record_metric=record_metric,
+                   record_event=record_event)
+
+    record_metric.assert_has_calls([call('Custom/Badge/unAuthUserGotZero', 0),
+                                    call('Custom/Badge/badgeCountIsZero', 1),
+                                    ])
+
+
+def test_record_metrics_records_badgecountiszero_with_unauth_user():
+    request = mock.Mock(params={'uri': 'test_uri'})
+    request.user = None
+    record_metric = mock.Mock()
+    record_event = mock.Mock()
+    record_metrics(0, request,
+                   record_metric=record_metric,
+                   record_event=record_event)
+
+    record_metric.assert_has_calls([call('Custom/Badge/unAuthUserGotZero', 1),
+                                    call('Custom/Badge/badgeCountIsZero', 1),
+                                    ])
 
 
 @badge_fixtures


### PR DESCRIPTION
unAuthUserGotZero is, out of all the requests that were zero,
the percentage of them where the user was None/unauthenticated.
This will tell us if a large portion of the badge returning
zero requests are due to unauthenticated users.
![image](https://user-images.githubusercontent.com/30059933/37791223-e9431234-2dc5-11e8-81eb-55a4c8d00575.png)


BadgeNotZero is an event for any request that is not 
zero. It contains the email.authority. This will tell us
if there are a small portion of users for which the badge count
is consistently reporting non zero.
![image](https://user-images.githubusercontent.com/30059933/38333384-4de4e072-380d-11e8-8527-1a742b842ab5.png)




