### PR TITLE
Use Python 3 in h Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN apk add --no-cache \
     libffi \
     libpq \
     nginx \
-    python2 \
+    python3 \
     py2-pip \
     git
 
@@ -37,9 +37,11 @@ RUN apk add --no-cache --virtual build-deps \
     build-base \
     libffi-dev \
     postgresql-dev \
-    python-dev \
-  && pip install --no-cache-dir -U pip supervisor \
-  && pip install --no-cache-dir -r requirements.txt \
+    python3-dev \
+  && python3 -m ensurepip \
+  && pip3 install --no-cache-dir -U pip \
+  && pip2.7 install --no-cache-dir -U supervisor \
+  && pip3 install --no-cache-dir -r requirements.txt \
   && apk del build-deps
 
 # Copy nginx config
@@ -66,6 +68,7 @@ EXPOSE 5000
 ENV PATH /var/lib/hypothesis/bin:$PATH
 ENV PYTHONIOENCODING utf_8
 ENV PYTHONPATH /var/lib/hypothesis:$PYTHONPATH
+RUN ln -sf /usr/bin/python3 /usr/bin/python
 
 # Start the web server by default
 USER hypothesis

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,6 @@ RUN apk add --no-cache \
     libpq \
     nginx \
     python3 \
-    py2-pip \
     git
 
 # Create the hypothesis user, group, home directory and package directory.
@@ -32,6 +31,9 @@ RUN chown -R hypothesis:hypothesis /var/log/nginx /var/lib/nginx /var/tmp/nginx
 # Copy minimal data to allow installation of dependencies.
 COPY requirements.txt ./
 
+# Install Golang implementation of supervisord
+COPY --from=ochinchina/supervisord:latest /usr/local/bin/supervisord /usr/local/bin/supervisord
+
 # Install build deps, build, and then clean up.
 RUN apk add --no-cache --virtual build-deps \
     build-base \
@@ -40,7 +42,6 @@ RUN apk add --no-cache --virtual build-deps \
     python3-dev \
   && python3 -m ensurepip \
   && pip3 install --no-cache-dir -U pip \
-  && pip2.7 install --no-cache-dir -U supervisor \
   && pip3 install --no-cache-dir -r requirements.txt \
   && apk del build-deps
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,9 +31,9 @@ node {
                                          "-e ELASTICSEARCH_URL=${elasticsearchHost} " +
                                          "-e TEST_DATABASE_URL=${databaseUrl}") {
                 // Test dependencies
-                sh 'apk add --no-cache build-base libffi-dev postgresql-dev python-dev'
-                sh 'apk add --no-cache python3 python3-dev'
-                sh 'pip install -q tox'
+                sh 'apk add --no-cache build-base libffi-dev postgresql-dev python3-dev'
+                sh 'apk add --no-cache python-dev' // while we continue to run tests under Python 2.7
+                sh 'pip3 install -q tox'
 
                 // Unit tests
                 sh 'cd /var/lib/hypothesis && tox'


### PR DESCRIPTION
Transition the QA/production Docker image to use Python 3 to run the h web app and workers.

supervisord still requires Python 2, so to avoid having to install Python 2 alongside Python 3, I have replaced it with a [Golang implementation](https://github.com/ochinchina/supervisord) which has all the features we need.

After this hits QA we should do some sanity testing of important parts of the site and check memory/CPU usage. After this hits production we should keep an eye on memory and CPU usage stats.

If we need to roll back for any reason, we can revert these commits and redeploy, or even just re-deploy the previous Docker image from the [deployment build page](https://jenkins.hypothes.is/job/deployment/build?delay=0sec).

**Image size stats**

Sizes reported by `docker inspect hypothesis/hypothesis:dev`:

Image size (master): 154MB
Image size (this branch): 167MB

**Testing**

1. Build the dev docker image using `make docker`
2. Run the image in a new container using `make run-docker`
3. Inspect the container and verify that processes are using the expected version of Python

```sh
[I] (h-py3)  ~/h/r/h > docker exec -it <ID of container> /bin/sh
~ $ ps aux 
PID   USER     TIME   COMMAND
    1 hypothes   0:00 {supervisord} /usr/bin/python2 /usr/bin/supervisord -c co
   11 hypothes   0:00 python /var/lib/hypothesis/bin/logger
   12 hypothes   0:00 {gunicorn} /usr/bin/python3.6 /usr/bin/gunicorn --name we
   13 hypothes   0:00 {gunicorn} /usr/bin/python3.6 /usr/bin/gunicorn --paste c
   14 hypothes   0:02 python -m h celery worker
   16 hypothes   0:00 nginx: master process nginx
   17 hypothes   0:00 nginx: worker process
   18 hypothes   0:00 nginx: worker process
   24 hypothes   0:01 {gunicorn} /usr/bin/python3.6 /usr/bin/gunicorn --paste c
   29 hypothes   0:02 {gunicorn} /usr/bin/python3.6 /usr/bin/gunicorn --name we
   35 hypothes   0:00 python -m h celery worker
   36 hypothes   0:00 python -m h celery worker
   44 hypothes   0:00 /bin/sh
   48 hypothes   0:00 ps aux
~ $ stat /proc/11/exe # check that "python" is Python 3
  File: '/proc/11/exe' -> '/usr/bin/python3.6'
  Size: 0         	Blocks: 0          IO Block: 1024   symbolic link
Device: a0h/160d	Inode: 1034058     Links: 1
Access: (0777/lrwxrwxrwx)  Uid: (  102/hypothesis)   Gid: (  103/hypothesis)
Access: 2018-03-21 08:56:10.000000000
Modify: 2018-03-21 08:56:10.000000000
Change: 2018-03-21 08:56:10.000000000

~ $ 
```