### PR TITLE
Add OrganizationLogoFactory

### DIFF
--- a/h/resources.py
+++ b/h/resources.py
@@ -8,9 +8,11 @@ from pyramid.security import (
     Allow,
     principals_allowed_by_permission,
 )
+from sqlalchemy.orm import exc
 
 from h import storage
 from h.models import AuthClient
+from h.models import Organization
 from h.auth import role
 from h.interfaces import IGroupService
 
@@ -103,6 +105,17 @@ class AuthClientFactory(object):
             return client
         except:  # noqa: E722
             # No such client found or not a valid UUID.
+            raise KeyError()
+
+
+class OrganizationFactory(object):
+    def __init__(self, request):
+        self.request = request
+
+    def __getitem__(self, pubid):
+        try:
+            return self.request.db.query(Organization).filter_by(pubid=pubid).one()
+        except exc.NoResultFound:
             raise KeyError()
 
 

--- a/h/resources.py
+++ b/h/resources.py
@@ -119,6 +119,21 @@ class OrganizationFactory(object):
             raise KeyError()
 
 
+class OrganizationLogoFactory(object):
+    def __init__(self, request):
+        self.request = request
+        self.organization_factory = OrganizationFactory(self.request)
+
+    def __getitem__(self, pubid):
+        # This will raise KeyError if the organization doesn't exist.
+        organization = self.organization_factory[pubid]
+
+        if not organization.logo:
+            raise KeyError()
+
+        return organization.logo
+
+
 def _group_principals(group):
     if group is None:
         return []

--- a/tests/common/factories/__init__.py
+++ b/tests/common/factories/__init__.py
@@ -15,6 +15,7 @@ from .feature import Feature
 from .flag import Flag
 from .group import Group, OpenGroup, RestrictedGroup
 from .group_scope import GroupScope
+from .organization import Organization
 from .setting import Setting
 from .token import DeveloperToken, OAuth2Token
 from .user import User
@@ -37,6 +38,7 @@ __all__ = (
     'GroupScope',
     'OAuth2Token',
     'OpenGroup',
+    'Organization',
     'RestrictedGroup',
     'Setting',
     'User',

--- a/tests/common/factories/organization.py
+++ b/tests/common/factories/organization.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import factory
+
+from h import models
+
+from .base import ModelFactory
+
+
+class Organization(ModelFactory):
+
+    class Meta:
+        model = models.Organization
+        sqlalchemy_session_persistence = 'flush'
+
+    name = factory.Sequence(lambda n: 'Test Organization {n}'.format(n=str(n)))
+    authority = 'example.com'

--- a/tests/h/resources_test.py
+++ b/tests/h/resources_test.py
@@ -13,6 +13,7 @@ from h.resources import AnnotationResource
 from h.resources import AnnotationResourceFactory
 from h.resources import AuthClientFactory
 from h.resources import OrganizationFactory
+from h.resources import OrganizationLogoFactory
 
 
 @pytest.mark.usefixtures('group_service', 'links_service')
@@ -236,10 +237,33 @@ class TestOrganizationFactory(object):
     def organization_factory(self, pyramid_request):
         return OrganizationFactory(pyramid_request)
 
+
+@pytest.mark.usefixtures('organizations')
+class TestOrganizationLogoFactory(object):
+
+    def test_it_returns_the_requested_organizations_logo(self, organizations, organization_logo_factory):
+        organization = organizations[1]
+        organization.logo = '<svg>blah</svg>'
+
+        assert organization_logo_factory[organization.pubid] == '<svg>blah</svg>'
+
+    def test_it_404s_if_the_organization_doesnt_exist(self, organization_logo_factory):
+        with pytest.raises(KeyError):
+            organization_logo_factory['does_not_exist']
+
+    def test_it_404s_if_the_organization_has_no_logo(self, organizations, organization_logo_factory):
+        with pytest.raises(KeyError):
+            assert organization_logo_factory[organizations[0].pubid]
+
     @pytest.fixture
-    def organizations(self, factories):
-        # Add a handful of organizations to the DB to make the test realistic.
-        return [factories.Organization() for _ in range(3)]
+    def organization_logo_factory(self, pyramid_request):
+        return OrganizationLogoFactory(pyramid_request)
+
+
+@pytest.fixture
+def organizations(factories):
+    # Add a handful of organizations to the DB to make the test realistic.
+    return [factories.Organization() for _ in range(3)]
 
 
 class FakeGroup(object):

--- a/tests/h/resources_test.py
+++ b/tests/h/resources_test.py
@@ -9,7 +9,9 @@ from pyramid import security
 from pyramid.authorization import ACLAuthorizationPolicy
 
 from h.models import AuthClient
-from h.resources import AnnotationResource, AnnotationResourceFactory, AuthClientFactory
+from h.resources import AnnotationResource
+from h.resources import AnnotationResourceFactory
+from h.resources import AuthClientFactory
 
 
 @pytest.mark.usefixtures('group_service', 'links_service')

--- a/tests/h/resources_test.py
+++ b/tests/h/resources_test.py
@@ -12,6 +12,7 @@ from h.models import AuthClient
 from h.resources import AnnotationResource
 from h.resources import AnnotationResourceFactory
 from h.resources import AuthClientFactory
+from h.resources import OrganizationFactory
 
 
 @pytest.mark.usefixtures('group_service', 'links_service')
@@ -217,6 +218,28 @@ class TestAuthClientResourceFactory(object):
         factory = AuthClientFactory(pyramid_request)
         with pytest.raises(KeyError):
             factory['not-a-uuid']
+
+
+@pytest.mark.usefixtures('organizations')
+class TestOrganizationFactory(object):
+
+    def test_it_returns_the_requested_organization(self, organizations, organization_factory):
+        organization = organizations[1]
+
+        assert organization_factory[organization.pubid] == organization
+
+    def test_it_404s_if_the_organization_doesnt_exist(self, organization_factory):
+        with pytest.raises(KeyError):
+            organization_factory['does_not_exist']
+
+    @pytest.fixture
+    def organization_factory(self, pyramid_request):
+        return OrganizationFactory(pyramid_request)
+
+    @pytest.fixture
+    def organizations(self, factories):
+        # Add a handful of organizations to the DB to make the test realistic.
+        return [factories.Organization() for _ in range(3)]
 
 
 class FakeGroup(object):


### PR DESCRIPTION
This is a piece of Pyramid "traversal" machinery that we can use to create views for organizations and for organization logos. For the full picture of how this gets fitted together with a view see https://github.com/hypothesis/h/pull/4896

This pr just adds the traversal machinery and tests, there's no production code that actually calls the new classes yet.

I haven't added much in the way of docstrings or code comments here. Just followed the style of our existing traversal factories. In follow up prs I'd like to reorganise our traversal code a little, rename classes, and add docstrings, and it should all be clearer then.