### PR TITLE
Add SVGRenderer

### DIFF
--- a/h/renderers.py
+++ b/h/renderers.py
@@ -8,5 +8,31 @@ import pyramid.renderers
 json_sorted_factory = pyramid.renderers.JSON(sort_keys=True)
 
 
+class SVGRenderer(object):
+    """
+    A renderer for SVG image files.
+
+    A view callable can use this renderer and just return a string of SVG
+    (u"<svg> ... </svg>") for the body of the response:
+
+        @view_config(renderer="svg", ...)
+        def my_svg_image_view(request):
+            ...
+            return u"<svg> ... </svg>"
+
+    The response will be rendered as an SVG image response with the correct
+    Content-Type etc so that browsers will render the image.
+
+    """
+    def __init__(self, info):
+        pass
+
+    def __call__(self, value, system):
+        response = system['request'].response
+        response.content_type = 'image/svg+xml'
+        return value
+
+
 def includeme(config):
     config.add_renderer(name='json_sorted', factory=json_sorted_factory)
+    config.add_renderer(name='svg', factory=SVGRenderer)

--- a/h/renderers.py
+++ b/h/renderers.py
@@ -30,6 +30,16 @@ class SVGRenderer(object):
     def __call__(self, value, system):
         response = system['request'].response
         response.content_type = 'image/svg+xml'
+
+        # Add a Vary: Accept-Encoding header.
+        # This prevents caches from serving a cached, compressed version of the
+        # file to user agents that don't support compression, or vice-versa.
+        if response.vary:
+            if 'Accept-Encoding' not in response.vary:
+                response.vary = response.vary + ('Accept-Encoding',)
+        else:
+            response.vary = ('Accept-Encoding',)
+
         return value
 
 

--- a/tests/h/renderers_test.py
+++ b/tests/h/renderers_test.py
@@ -4,7 +4,11 @@ from __future__ import unicode_literals
 
 from collections import OrderedDict
 
+import mock
+import pytest
+
 from h.renderers import json_sorted_factory
+from h.renderers import SVGRenderer
 
 
 class TestSortedJSONRenderer(object):
@@ -17,3 +21,34 @@ class TestSortedJSONRenderer(object):
         result = renderer(data, system={})
 
         assert result == '{"bar": 1, "baz": 5, "foo": "bang"}'
+
+
+class TestSVGRenderer(object):
+    def test_it_sets_the_content_type(self, pyramid_request, system, svg_renderer):
+        svg_renderer(mock.sentinel.svg_content, system)
+
+        assert pyramid_request.response.content_type == 'image/svg+xml'
+
+    def test_it_returns_the_svg_content(self, system, svg_renderer):
+        # It returns the actual SVG content (u"<svg> ... </svg>") (actually
+        # just whatever the view callable that's using the renderer returned)
+        # as the body of the response for Pyramid to render.
+        assert svg_renderer(mock.sentinel.svg_content, system) == mock.sentinel.svg_content
+
+    @pytest.fixture
+    def system(self, pyramid_request):
+        """
+        Return a fake Pyramid `system` dict.
+
+        Returns a fake of the `system` dict that Pyramid passes to renderers
+        when it calls them. It's a dict containing a bunch of Pyramid stuff,
+        for example the current request.
+
+        """
+        return {
+            'request': pyramid_request,
+        }
+
+    @pytest.fixture
+    def svg_renderer(self):
+        return SVGRenderer(mock.sentinel.info)

--- a/tests/h/renderers_test.py
+++ b/tests/h/renderers_test.py
@@ -35,6 +35,32 @@ class TestSVGRenderer(object):
         # as the body of the response for Pyramid to render.
         assert svg_renderer(mock.sentinel.svg_content, system) == mock.sentinel.svg_content
 
+    def test_it_adds_a_vary_accept_encoding_header(self, pyramid_request, system, svg_renderer):
+        svg_renderer(mock.sentinel.svg_content, system)
+
+        assert pyramid_request.response.headers.get('Vary') == 'Accept-Encoding'
+
+    def test_it_appends_accept_encoding_to_an_existing_vary_header(self, pyramid_request, system, svg_renderer):
+        # If something earlier in request processing has already added a Vary
+        # header it should append Accept-Encoding to the existing Vary header,
+        # and not for example replace the existing header with just
+        # Accept-Encoding.
+        pyramid_request.response.vary = ('User-Agent',)
+
+        svg_renderer(mock.sentinel.svg_content, system)
+
+        assert pyramid_request.response.headers.get('Vary') == 'User-Agent, Accept-Encoding'
+
+    def test_it_doesnt_add_duplicate_accept_encoding_values(self, pyramid_request, system, svg_renderer):
+        # If something earlier in request processing has already added
+        # Accept-Encoding to the Vary header then it shouldn't add a second
+        # Accept-Encoding to the header.
+        pyramid_request.response.vary = ('User-Agent', 'Accept-Encoding')
+
+        svg_renderer(mock.sentinel.svg_content, system)
+
+        assert pyramid_request.response.headers.get('Vary') == 'User-Agent, Accept-Encoding'
+
     @pytest.fixture
     def system(self, pyramid_request):
         """


### PR DESCRIPTION
Add `SVGRenderer`, a custom Pyramid renderer. See: https://docs.pylonsproject.org/projects/pyramid//en/latest/narr/renderers.html

This is a renderer that can be used by any view that wants to return an SVG image. The view only needs to return the SVG file content as a string, and the renderer will handle setting the appropriate HTTP headers for an SVG file.

This pr just adds the renderer and tests. No production code actually uses the renderer yet. For how this can be used in a view see https://github.com/hypothesis/h/pull/4896