### PR TITLE
Add organization logo view

### DIFF
--- a/h/routes.py
+++ b/h/routes.py
@@ -118,6 +118,12 @@ def includeme(config):
     config.add_route('stream_atom', '/stream.atom')
     config.add_route('stream_rss', '/stream.rss')
 
+    # Organizations
+    config.add_route('organization_logo',
+                     '/organizations/{pubid}/logo',
+                     factory='h.resources.OrganizationLogoFactory',
+                     traverse='/{pubid}')
+
     # Groups
     config.add_route('api.groups', '/api/groups')
     config.add_route('group_create', '/groups/new')

--- a/h/views/organizations.py
+++ b/h/views/organizations.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from pyramid.view import view_config
+
+
+@view_config(route_name='organization_logo', request_method='GET', renderer='svg', http_cache=600)
+def organization_logo(logo, request):
+    return logo

--- a/tests/h/routes_test.py
+++ b/tests/h/routes_test.py
@@ -93,6 +93,8 @@ def test_includeme():
         call('embed', '/embed.js'),
         call('stream_atom', '/stream.atom'),
         call('stream_rss', '/stream.rss'),
+        call('organization_logo', '/organizations/{pubid}/logo',
+             factory='h.resources.OrganizationLogoFactory', traverse='/{pubid}'),
         call('api.groups', '/api/groups'),
         call('group_create', '/groups/new'),
         call('group_edit', '/groups/{pubid}/edit', factory='h.models.group:GroupFactory', traverse='/{pubid}'),

--- a/tests/h/views/organizations_test.py
+++ b/tests/h/views/organizations_test.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from h.views import organizations
+
+import mock
+
+
+class TestOrganizationLogo(object):
+
+    def test_it_returns_the_given_logo_unmodified(self):
+        logo = organizations.organization_logo(
+            mock.sentinel.logo, mock.sentinel.request)
+
+        assert logo == mock.sentinel.logo


### PR DESCRIPTION
This pull request follows on from https://github.com/hypothesis/h/pull/4902 and https://github.com/hypothesis/h/pull/4903 and adds the actual view that renders the SVG files, along with:

* Deciding what the URLs for these views will look like
* Caching

Response headers from <http://localhost:5000/organizations/RRAYqEVX/logo> on my machine:

![screenshot from 2018-03-26 11-41-49](https://user-images.githubusercontent.com/22498/37901955-cb355efa-30ea-11e8-8c16-a1bd87a1724f.png)

This is with caching disabled in browser. Without caching disabled you can see that the response is normally a 304.

If you change the pubid to one that does't exist, or to the pubid of an organization that doesn't have a logo, you get a nice 404 page (with h logo and footer etc).

To generate URLs for these organization logo views you would do:

```
url = request.route_url("organization_logo", pubid=some_organization.pubid)
```

But note that will return a URL regardless of whether the organization actually has a logo - so the returned URL may 404. If you want a URL only if it's not going to 404 then you would do:

```
url = request.route_url("organization_logo", pubid=some_organization.pubid) or some_organization.logo else None
```

(It will even return a URL for an organization that doesn't exist if you do `request.route_url("organization_logo", pubid="foo")`).