### PR TITLE
Build static assets in separate stage.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,7 @@ COPY . .
 RUN [ -d .git ] && chown -R hypothesis:hypothesis .git || :
 
 # Copy frontend assets.
-COPY --from=build /build .
+COPY --from=build /build build
 
 # Expose the default port.
 EXPOSE 5000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,11 @@
+FROM node:alpine as build
+
+ENV NODE_ENV production
+
+COPY . .
+
+RUN npm install --production && npm run build
+
 FROM alpine:3.7
 MAINTAINER Hypothes.is Project and contributors
 
@@ -12,7 +20,6 @@ RUN apk add --no-cache \
     nginx \
     python2 \
     py2-pip \
-    nodejs \
     git
 
 # Create the hypothesis user, group, home directory and package directory.
@@ -49,9 +56,8 @@ COPY . .
 # If we're building from a git clone, ensure that .git is writeable
 RUN [ -d .git ] && chown -R hypothesis:hypothesis .git || :
 
-# Build frontend assets
-RUN npm install --production \
-  && NODE_ENV=production node_modules/.bin/gulp build
+# Copy frontend assets.
+COPY --from=build /build .
 
 # Expose the default port.
 EXPOSE 5000

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "version": "0.0.0",
   "description": "The Internet, peer reviewed.",
+  "scripts": {
+    "build": "gulp build"
+  },
   "dependencies": {
     "autoprefixer": "^6.0.3",
     "babel-preset-es2015": "^6.14.0",


### PR DESCRIPTION
This shaves about 120mb off the docker image: ~20mb from dropping the node runtime (which afaict is only used here to build assets, but lmk if not), and ~100mb from dropping `node_modules`.