### PR TITLE
Remove final references to removed feature flags

### DIFF
--- a/h/models/feature.py
+++ b/h/models/feature.py
@@ -39,19 +39,6 @@ FEATURES = {
 # 4. Finally, remove the feature from FEATURES_PENDING_REMOVAL.
 #
 FEATURES_PENDING_REMOVAL = {
-    'activity_pages': "Show the new activity pages?",
-    'client_oauth': ("Use OAuth for first party accounts in client? "
-                     "(Only takes effect if enabled for everyone)"),
-    'defer_realtime_updates': ("Require a user action before applying real-time"
-                               " updates to annotations in the client?"),
-    'flag_action': ("Enable user to flag inappropriate annotations in the "
-                    "client?"),
-    'homepage_redirects': "Enable homepage redirects (for WordPress migration)?",
-    'orphans_tab': "Show the orphans tab to separate anchored and unanchored annotations?",
-    'search_for_doi': "Use DOI metadata when searching for annotations on the current page?",
-    'search_page': "Show the activity pages search skeleton page?",
-    'total_shared_annotations': "Show the total number of shared annotations for users and groups?",
-    'use_client_boot_script': "Use the client's boot script?",
 }
 
 


### PR DESCRIPTION
IIRC removal of these was blocked until 3a8bf6ab5565280f553caee8a2c2c7abca3fbef8 made feature flag deletions cascade.