### PR TITLE
Remove model-level validation of SVGs

### DIFF
--- a/h/models/organization.py
+++ b/h/models/organization.py
@@ -2,7 +2,6 @@
 
 import sqlalchemy as sa
 import slugify
-from xml.etree import ElementTree
 
 from h.db import Base
 from h.db import mixins
@@ -10,7 +9,6 @@ from h import pubid
 
 ORGANIZATION_NAME_MIN_CHARS = 1
 ORGANIZATION_NAME_MAX_CHARS = 25
-ORGANIZATION_LOGO_MAX_CHARS = 10000
 
 
 class Organization(Base, mixins.Timestamps):
@@ -44,20 +42,6 @@ class Organization(Base, mixins.Timestamps):
                 .format(min=ORGANIZATION_NAME_MIN_CHARS,
                         max=ORGANIZATION_NAME_MAX_CHARS))
         return name
-
-    @sa.orm.validates('logo')
-    def validate_logo(self, key, logo):
-        if not (len(logo) <= ORGANIZATION_LOGO_MAX_CHARS):
-            raise ValueError(
-                'logo must be less than {max} characters long'
-                .format(max=ORGANIZATION_NAME_MAX_CHARS))
-        try:
-            root = ElementTree.fromstring(logo)
-        except ElementTree.ParseError:
-            raise ValueError('logo is not a valid SVG (could not parse XML)')
-        if root.tag != 'svg':
-            raise ValueError('logo is not a valid SVG (does not start with an <svg> tag')
-        return logo
 
     def __repr__(self):
         return '<Organization: %s>' % self.slug

--- a/tests/h/models/organization_test.py
+++ b/tests/h/models/organization_test.py
@@ -44,21 +44,6 @@ def test_too_long_name_raises_value_error():
         models.Organization(name="abcdefghijklmnopqrstuvwxyz")
 
 
-def test_too_long_logo_raises_value_error():
-    with pytest.raises(ValueError):
-        models.Organization(logo='<svg>{}</svg>'.format("abcdefghijklmnopqrstuvwxyz" * 400))
-
-
-def test_malformed_logo_raises_value_error():
-    with pytest.raises(ValueError):
-        models.Organization(logo='<svg>/svg>')
-
-
-def test_non_svg_logo_raises_value_error():
-    with pytest.raises(ValueError):
-        models.Organization(logo='<h>This is not a svg</h>')
-
-
 def test_repr(db_session, factories):
     organization = models.Organization(name='My Organization', authority='example.com')
     db_session.add(organization)


### PR DESCRIPTION
Since organizations and their logos can only be created by developers
currently I don't think this is needed, and this validation currently
prevents valid SVG values from being set: many SVG files start with an
`<?xml>` tag not an `<svg>` tag.

If we do have a form for uploading SVGs in the future I'm not sure that
the model will be the right place to validate them. For example we might
want to have a separate validation function that's called by the view
before the SVG is ever passed on to the service or model layers.