### PR TITLE
Remove organization slugs

### DIFF
--- a/h/models/organization.py
+++ b/h/models/organization.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 import sqlalchemy as sa
-import slugify
 from xml.etree import ElementTree
 
 from h.db import Base
@@ -31,11 +30,6 @@ class Organization(Base, mixins.Timestamps):
 
     authority = sa.Column(sa.UnicodeText(), nullable=False)
 
-    @property
-    def slug(self):
-        """A version of this organization's name suitable for use in a URL."""
-        return slugify.slugify(self.name)
-
     @sa.orm.validates('name')
     def validate_name(self, key, name):
         if not (ORGANIZATION_NAME_MIN_CHARS <= len(name) <= ORGANIZATION_NAME_MAX_CHARS):
@@ -60,4 +54,4 @@ class Organization(Base, mixins.Timestamps):
         return logo
 
     def __repr__(self):
-        return '<Organization: %s>' % self.slug
+        return '<Organization: %s>' % self.pubid

--- a/tests/h/models/organization_test.py
+++ b/tests/h/models/organization_test.py
@@ -28,12 +28,6 @@ def test_null_logo():
     assert organization.logo is None
 
 
-def test_slug():
-    organization = models.Organization(name="My Organization")
-
-    assert organization.slug == 'my-organization'
-
-
 def test_too_short_name_raises_value_error():
     with pytest.raises(ValueError):
         models.Organization(name="")
@@ -60,10 +54,7 @@ def test_non_svg_logo_raises_value_error():
 
 
 def test_repr(db_session, factories):
-    organization = models.Organization(name='My Organization', authority='example.com')
-    db_session.add(organization)
-    db_session.flush()
+    organization = models.Organization(
+        name='My Organization', authority='example.com', pubid='test_pubid')
 
-    assert organization.id is not None
-    assert organization.pubid is not None
-    assert repr(organization) == "<Organization: my-organization>"
+    assert repr(organization) == "<Organization: test_pubid>"


### PR DESCRIPTION
These aren't used currently. They would be used at the ends of URLs
(like we do for groups: https://hypothes.is/groups/<PUBID>/hypothesis-reading)
but I don't think we know yet whether organizations will have web pages
or what we'll want the URLs of those pages to look like (and whether
they'll include slugs).

We can easily add this back later if we decide we want it.