### PR TITLE
Add character limit indicators to group create/edit view

### DIFF
--- a/h/schemas/admin_group.py
+++ b/h/schemas/admin_group.py
@@ -3,7 +3,7 @@
 from __future__ import unicode_literals
 
 import colander
-from deform.widget import SelectWidget, SequenceWidget, TextAreaWidget
+from deform.widget import SelectWidget, SequenceWidget, TextAreaWidget, TextInputWidget
 
 from h import i18n
 from h import validators
@@ -63,6 +63,7 @@ class CreateAdminGroupSchema(CSRFSchema):
         title=_('Group Name'),
         validator=validators.Length(min=GROUP_NAME_MIN_LENGTH,
                                     max=GROUP_NAME_MAX_LENGTH),
+        widget=TextInputWidget(max_length=GROUP_NAME_MAX_LENGTH),
     )
 
     authority = colander.SchemaNode(
@@ -88,7 +89,7 @@ class CreateAdminGroupSchema(CSRFSchema):
         title=_('Description'),
         description=_('Optional group description'),
         validator=colander.Length(max=GROUP_DESCRIPTION_MAX_LENGTH),
-        widget=TextAreaWidget(rows=3),
+        widget=TextAreaWidget(rows=3, max_length=GROUP_DESCRIPTION_MAX_LENGTH),
         missing=None
     )
 

--- a/h/static/scripts/admin-site.js
+++ b/h/static/scripts/admin-site.js
@@ -10,6 +10,7 @@ window.$ = window.jQuery = require('jquery');
 require('bootstrap');
 
 const AdminUsersController = require('./controllers/admin-users-controller');
+const CharacterLimitController = require('./controllers/character-limit-controller');
 const ConfirmSubmitController = require('./controllers/confirm-submit-controller');
 const FormController = require('./controllers/form-controller');
 const FormInputController = require('./controllers/form-input-controller');
@@ -18,6 +19,7 @@ const TooltipController = require('./controllers/tooltip-controller');
 const upgradeElements = require('./base/upgrade-elements');
 
 const controllers = {
+  '.js-character-limit': CharacterLimitController,
   '.js-confirm-submit': ConfirmSubmitController,
   '.js-form': FormController,
   '.js-form-input': FormInputController,


### PR DESCRIPTION
Add the same character limit indicators to the admin group creation view
as already exists for the user-facing group create/edit views.

In future it might make sense to unify the two sets of schemas but for now it was easier to just add the relevant extra bits to the admin groups schemas.

----

<img width="739" alt="screenshot 2018-03-26 15 54 19" src="https://user-images.githubusercontent.com/2458/37914209-931cc124-310e-11e8-8ef8-3eaaf1bcdfcf.png">
