### PR TITLE
Allow none in validate logo

### DIFF
--- a/h/models/organization.py
+++ b/h/models/organization.py
@@ -47,6 +47,9 @@ class Organization(Base, mixins.Timestamps):
 
     @sa.orm.validates('logo')
     def validate_logo(self, key, logo):
+        # If the logo is None return early.
+        if logo is None:
+            return logo
         if not (len(logo) <= ORGANIZATION_LOGO_MAX_CHARS):
             raise ValueError(
                 'logo must be less than {max} characters long'

--- a/tests/h/models/organization_test.py
+++ b/tests/h/models/organization_test.py
@@ -38,6 +38,11 @@ def test_too_long_name_raises_value_error():
         models.Organization(name="abcdefghijklmnopqrstuvwxyz")
 
 
+def test_none_logo_is_valid():
+    org = models.Organization(name="My Organization", logo=None)
+    assert org.logo is None
+
+
 def test_too_long_logo_raises_value_error():
     with pytest.raises(ValueError):
         models.Organization(logo='<svg>{}</svg>'.format("abcdefghijklmnopqrstuvwxyz" * 400))


### PR DESCRIPTION
The validate logo does not handle None right now as a valid input option and it should. This fixes that.