### PR TITLE
Ignore xmlns in svg tag when validating org's logo

### DIFF
--- a/h/models/organization.py
+++ b/h/models/organization.py
@@ -13,6 +13,12 @@ ORGANIZATION_NAME_MAX_CHARS = 25
 ORGANIZATION_LOGO_MAX_CHARS = 10000
 
 
+def _strip_xmlns(tag):
+    if '}' in tag:
+        return tag.split('}', 1)[1]
+    return tag
+
+
 class Organization(Base, mixins.Timestamps):
     __tablename__ = 'organization'
 
@@ -55,7 +61,8 @@ class Organization(Base, mixins.Timestamps):
             root = ElementTree.fromstring(logo)
         except ElementTree.ParseError:
             raise ValueError('logo is not a valid SVG (could not parse XML)')
-        if root.tag != 'svg':
+
+        if _strip_xmlns(root.tag) != 'svg':
             raise ValueError('logo is not a valid SVG (does not start with an <svg> tag')
         return logo
 

--- a/tests/h/models/organization_test.py
+++ b/tests/h/models/organization_test.py
@@ -7,7 +7,7 @@ from h import models
 
 
 def test_init_sets_given_attributes():
-    logo = """<svg width="100" height="100">
+    logo = """<svg width="100" height="100" xmlns="http://www.w3.org/2000/svg">
             <circle cx="50" cy="50" r="40" stroke="green" stroke-width="4" fill="yellow" />
             </svg>"""
     organization = models.Organization(


### PR DESCRIPTION
Xmlns are inserted into the tag like {http://svg.com}svg which
causes the tag == 'svg' compare to fail. A strip_xmlns function
was added to strip the xmlns from the tag before comparing to
mitigate this issue.