### PR TITLE
Work around a WebOb UnicodeDecodeError

### DIFF
--- a/h/app.py
+++ b/h/app.py
@@ -53,6 +53,7 @@ def includeme(config):
     config.add_tween('h.tweens.conditional_http_tween_factory', under=EXCVIEW)
     config.add_tween('h.tweens.redirect_tween_factory')
     config.add_tween('h.tweens.csrf_tween_factory')
+    config.add_tween('h.tweens.invalid_path_tween_factory')
     config.add_tween('h.tweens.security_header_tween_factory')
     config.add_tween('h.tweens.cache_header_tween_factory')
 

--- a/tests/functional/test_tweens.py
+++ b/tests/functional/test_tweens.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+
+class TestInvalidPathTweenFactory(object):
+    def test_it_400s_if_the_requested_path_isnt_utf8(self, app):
+        app.get('/%c5', status=400)


### PR DESCRIPTION
Due to a bug in WebOb accessing request.path (or request.path_info etc) will raise UnicodeDecodeError if the requested path doesn't decode with UTF-8, and this will result in a 500 Server Error from our app.

Add a tween to detect this situation and send a 400 Bad Request instead.

See https://github.com/Pylons/webob/issues/115

Fixes https://github.com/hypothesis/h/issues/4915