### PR TITLE
Don't crash when logged out user tries to leave group

### DIFF
--- a/h/views/activity.py
+++ b/h/views/activity.py
@@ -8,6 +8,7 @@ from h._compat import urlparse
 
 from jinja2 import Markup
 from pyramid import httpexceptions
+from pyramid import security
 from pyramid.view import view_config
 from pyramid.view import view_defaults
 
@@ -217,7 +218,8 @@ class GroupSearchController(SearchController):
         return httpexceptions.HTTPSeeOther(location=url)
 
     @view_config(request_method='POST',
-                 request_param='group_leave')
+                 request_param='group_leave',
+                 effective_principals=security.Authenticated)
     def leave(self):
         """
         Leave the given group.


### PR DESCRIPTION
1. Login and create or join a group.
2. Open the group's page in a tab.
3. Open Hypothesis in another tab and log out.
4. Back in the first tab, click the leave group button.
=> You'll see a 500 Server Error page.

The code involved in leaving a group doesn't assume that the user is a
member of the group (if the user isn't a member, e.g. they already left
the group, then clicking the leave group button again is a no-op).

But it does assume that a user is logged in, and if one isn't it ends up
with a TypeError in the groups service.

Fix this by turning it into a 404 page instead.

Fixes https://github.com/hypothesis/h/issues/4917.