### PR TITLE
DO NOT MERGE: Proposed API surface for `groups`

### DIFF
--- a/docs/_extra/api-reference/hypothesis.yaml
+++ b/docs/_extra/api-reference/hypothesis.yaml
@@ -9,6 +9,12 @@ info:
     See [the API overview](../api/) for an introduction to the API and information
     on how authorization works.
 
+    ## Expanding Resources
+
+    Resources often contain links to related resources in their response bodies. Some endpoints support resource expansion, allowing those related resources to be expanded inline in the response.
+
+    To expand resources (where supported), use the `expand` request parameter. Individual endpoint documentation indicates which resources are expandable.
+
   termsOfService: https://hypothes.is/terms-of-service
   license:
     name: BSD (2-Clause)
@@ -216,11 +222,21 @@ paths:
         - name: document_uri
           in: query
           description: >
-            The URI of the document currently being annotated.
-            Used to filter appropriate groups
+            The URI of the resource targeted for annotation.
+            Used to filter valid groups
           required: false
           type: string
           format: uri
+        - name: expand
+          description: >
+            Array of related resource objects to expand within the response
+          in: query
+          type: array
+          items:
+            type: string
+            enum:
+              - organizations
+
       responses:
         '200':
           description: Success
@@ -430,6 +446,7 @@ definitions:
       - id
       - links
       - name
+      - organization
       - public
       - scoped
       - type
@@ -446,6 +463,13 @@ definitions:
             description: URL to the group's main (activity) page
       name:
         type: string
+      organization:
+        description: Representation of this group's owning organization. If request `expand` parameter value contains `organizations`, a full object representation is returned, otherwise the value is a URI to the organization resource.
+        oneOf:
+          - type: string
+            format: uri
+            description: Link to related organization resource
+          - $ref: '#/definitions/Organization'
       public:
         type: boolean
         deprecated: true
@@ -472,6 +496,24 @@ definitions:
             format: uri
             description: URI to group activity page; use `links.html` instead
             deprecated: true
+  Organization:
+    type: object
+    required:
+      - id
+      - links
+      - name
+    properties:
+      id:
+        type: string
+      links:
+        type: object
+      logo:
+        type: string
+        format: uri
+        description: URI to logo image for this organization
+      name:
+        type: string
+
   NewUser:
     $ref: './schemas/new-user-schema.json'
   UpdateUser:


### PR DESCRIPTION
The `expanded-group-api` branch contains updated documentation reflecting proposed adaptations to the `GET /api/groups` endpoint. It adds the ability to `expand` the response to contain qualified `organization` objects within group objects. Don't merge this as this API spec doesn't match reality (yet).

The nature of `redoc` (API specification renderer, JavaScript) makes it irritatingly hard to share static files that show documentation; instead after a few false starts trying to build a zippable set of HTML files, I figure it's easier to pull this branch and build locally [using the instructions here](http://h.readthedocs.io/en/latest/developing/documentation/). I'll endeavor to attach a few screenshots of some of the pieces here.

A general section on expandable resources has been added:

![image](https://user-images.githubusercontent.com/439947/37978998-72570db2-31b5-11e8-97da-b21104752e13.png)

`groups` takes an `expand` parameter:

![image](https://user-images.githubusercontent.com/439947/37979035-8a974ffe-31b5-11e8-8844-5c2f8c55e01f.png)

The response properties include `organization`:

![image](https://user-images.githubusercontent.com/439947/37979062-9ade8fee-31b5-11e8-861e-38c4bf24011c.png)

What's _in_ `organization` is dependent on the presence/value of `expand` in the query.

When not expanded, it is:

![image](https://user-images.githubusercontent.com/439947/37979093-ae9a65ee-31b5-11e8-800a-ae51cf9f36ec.png)

When `expands` contains `organizations`, it is:

![image](https://user-images.githubusercontent.com/439947/37979101-b878a1ac-31b5-11e8-8337-b39fae8a9349.png)


redoc provides support for _some_ of this without too much effort; true support of linking is in OpenAPI 3.0 but not supported (yet) by redoc.

