### PR TITLE
Documentation: Add reference to redoc, redoc-CLI

### DIFF
--- a/docs/developing/documentation.rst
+++ b/docs/developing/documentation.rst
@@ -15,3 +15,20 @@ web server in the newly generated ``_build/dirhtml`` directory. For example:
 .. code-block:: bash
 
    cd _build/dirhtml; python -m SimpleHTTPServer; cd -
+
+------------------------------------
+API Documentation
+------------------------------------
+
+The Hypothesis API documentation is rendered using `ReDoc <https://github.com/Rebilly/ReDoc>`_,
+a JavaScript tool for generating OpenAPI/Swagger reference documentation.
+
+The documentation-building process above will regenerate API documentation output without intervention,
+but if you are making changes to the API specification (`hypothesis.yaml`), you may find it
+convenient to use the `ReDoc CLI tool <https://github.com/Rebilly/ReDoc/blob/master/cli/README.md>`_,
+which can watch the spec file for changes:
+
+.. code-block:: bash
+
+  npm install -g redoc-cli
+  redoc-cli serve [path-to-spec] --watch


### PR DESCRIPTION
This little PR updates the `documentation` section of the `h` docs to add reference to `redoc-cli`, which I have found to be a handy tool versus re-building documentation by hand every time I make a small change to the spec file (and, in fact, the `make dirhtml` task tends to not see changes sometimes, requiring me to blow away `_build` first). Anyway, the change looks like this (adds a section on the `documentation` section):

![image](https://user-images.githubusercontent.com/439947/37980574-6b802dbc-31b9-11e8-9400-83305f1b5c93.png)

Thought it might be helpful to others.