### PR TITLE
Reduce duplication of selector/controller mappings

### DIFF
--- a/h/static/scripts/admin-site.js
+++ b/h/static/scripts/admin-site.js
@@ -9,25 +9,15 @@ if (settings.raven) {
 window.$ = window.jQuery = require('jquery');
 require('bootstrap');
 
-const AdminUsersController = require('./controllers/admin-users-controller');
-const CharacterLimitController = require('./controllers/character-limit-controller');
-const ConfirmSubmitController = require('./controllers/confirm-submit-controller');
-const FormController = require('./controllers/form-controller');
-const FormInputController = require('./controllers/form-input-controller');
-const ListInputController = require('./controllers/list-input-controller');
-const TooltipController = require('./controllers/tooltip-controller');
+const sharedControllers = require('./controllers');
 const upgradeElements = require('./base/upgrade-elements');
 
-const controllers = {
-  '.js-character-limit': CharacterLimitController,
-  '.js-confirm-submit': ConfirmSubmitController,
-  '.js-form': FormController,
-  '.js-form-input': FormInputController,
-  '.js-list-input': ListInputController,
-  '.js-tooltip': TooltipController,
-  '.js-users-delete-form': AdminUsersController,
-};
+// Additional controllers for admin site.
+const AdminUsersController = require('./controllers/admin-users-controller');
 
+const controllers = Object.assign({}, {
+  '.js-users-delete-form': AdminUsersController,
+}, sharedControllers);
 upgradeElements(document.body, controllers);
 window.envFlags.ready();
 

--- a/h/static/scripts/controllers/index.js
+++ b/h/static/scripts/controllers/index.js
@@ -1,0 +1,38 @@
+'use strict';
+
+/**
+ * Controllers provide client-side logic for server-rendered HTML.
+ *
+ * HTML elements declare their associated controller(s) using `js-`-prefixed
+ * class names.
+ *
+ * This file exports a mapping between CSS selectors and controller
+ * classes for "common" controls that are useful on both the admin and
+ * user-facing sites.
+ */
+
+const CharacterLimitController = require('./character-limit-controller');
+const CopyButtonController = require('./copy-button-controller');
+const ConfirmSubmitController = require('./confirm-submit-controller');
+const DropdownMenuController = require('./dropdown-menu-controller');
+const FormController = require('./form-controller');
+const FormCancelController = require('./form-cancel-controller');
+const FormInputController = require('./form-input-controller');
+const FormSelectOnFocusController = require('./form-select-onfocus-controller');
+const InputAutofocusController = require('./input-autofocus-controller');
+const ListInputController = require('./list-input-controller');
+const TooltipController = require('./tooltip-controller');
+
+module.exports = {
+  '.js-character-limit': CharacterLimitController,
+  '.js-copy-button': CopyButtonController,
+  '.js-confirm-submit': ConfirmSubmitController,
+  '.js-dropdown-menu': DropdownMenuController,
+  '.js-form': FormController,
+  '.js-form-cancel': FormCancelController,
+  '.js-form-input': FormInputController,
+  '.js-input-autofocus': InputAutofocusController,
+  '.js-list-input': ListInputController,
+  '.js-select-onfocus': FormSelectOnFocusController,
+  '.js-tooltip': TooltipController,
+};

--- a/h/static/scripts/site.js
+++ b/h/static/scripts/site.js
@@ -9,44 +9,25 @@ if (settings.raven) {
 
 require('./polyfills');
 
+const sharedControllers = require('./controllers');
+const upgradeElements = require('./base/upgrade-elements');
+
+// Additional controllers for user-facing site.
 const AuthorizeFormController = require('./controllers/authorize-form-controller');
-const CharacterLimitController = require('./controllers/character-limit-controller');
-const CopyButtonController = require('./controllers/copy-button-controller');
-const ConfirmSubmitController = require('./controllers/confirm-submit-controller');
 const CreateGroupFormController = require('./controllers/create-group-form-controller');
-const DropdownMenuController = require('./controllers/dropdown-menu-controller');
-const FormController = require('./controllers/form-controller');
-const FormCancelController = require('./controllers/form-cancel-controller');
-const FormInputController = require('./controllers/form-input-controller');
-const FormSelectOnFocusController = require('./controllers/form-select-onfocus-controller');
-const InputAutofocusController = require('./controllers/input-autofocus-controller');
-const ListInputController = require('./controllers/list-input-controller');
 const SearchBarController = require('./controllers/search-bar-controller');
 const SearchBucketController = require('./controllers/search-bucket-controller');
 const ShareWidgetController = require('./controllers/share-widget-controller');
 const SignupFormController = require('./controllers/signup-form-controller');
-const TooltipController = require('./controllers/tooltip-controller');
-const upgradeElements = require('./base/upgrade-elements');
 
-const controllers = {
+const controllers = Object.assign({
   '.js-authorize-form': AuthorizeFormController,
-  '.js-character-limit': CharacterLimitController,
-  '.js-copy-button': CopyButtonController,
-  '.js-confirm-submit': ConfirmSubmitController,
   '.js-create-group-form': CreateGroupFormController,
-  '.js-dropdown-menu': DropdownMenuController,
-  '.js-form': FormController,
-  '.js-form-cancel': FormCancelController,
-  '.js-form-input': FormInputController,
-  '.js-input-autofocus': InputAutofocusController,
-  '.js-list-input': ListInputController,
-  '.js-select-onfocus': FormSelectOnFocusController,
   '.js-search-bar': SearchBarController,
   '.js-search-bucket': SearchBucketController,
   '.js-share-widget': ShareWidgetController,
   '.js-signup-form': SignupFormController,
-  '.js-tooltip': TooltipController,
-};
+}, sharedControllers);
 
 if (window.envFlags && window.envFlags.get('js-capable')) {
   upgradeElements(document.body, controllers);


### PR DESCRIPTION
Avoid duplicating selector/controller mappings for controllers used by
both the admin site and the user-facing site by centralizing them in
`controllers/index.js`.

This removes a bit of duplication between `scripts/site.js` and `scripts/admin-site.js`.