### PR TITLE
Add ability to filter groups by name in admin form

### DIFF
--- a/h/static/styles/admin.scss
+++ b/h/static/styles/admin.scss
@@ -9,6 +9,7 @@
 @import 'partials/form-input';
 @import 'partials/form';
 @import 'partials/list-input';
+@import 'partials/search-form';
 @import 'partials/svg-icon';
 @import 'partials/tooltip';
 

--- a/h/static/styles/partials/_search-form.scss
+++ b/h/static/styles/partials/_search-form.scss
@@ -1,0 +1,10 @@
+.search-form {
+  display: flex;
+  flex-direction: row;
+  margin-top: 10px;
+  margin-bottom: 20px;
+}
+
+.search-form__submit-btn {
+  margin-left: 10px;
+}

--- a/h/templates/admin/groups.html.jinja2
+++ b/h/templates/admin/groups.html.jinja2
@@ -1,5 +1,7 @@
 {% extends "h:templates/layouts/admin.html.jinja2" %}
 
+{% from '../includes/search_form.html.jinja2' import search_form %}
+
 {% set page_id = 'groups' %}
 {% set page_title = 'Groups' %}
 
@@ -7,6 +9,8 @@
   <p>
     On this page you can see a list of all the groups and their details.
   </p>
+
+  {{ search_form('Search by name…', request.params.get('q')) }}
 
   <div class="table-responsive">
     <table class="table table-striped">

--- a/h/templates/includes/search_form.html.jinja2
+++ b/h/templates/includes/search_form.html.jinja2
@@ -1,0 +1,10 @@
+{% macro search_form(placeholder, value='') -%}
+<form class="search-form">
+  <input type="search"
+         name="q"
+         class="form-input__input"
+         value="{{ value or '' }}"
+         placeholder="{{ placeholder }}">
+  <button class="btn search-form__submit-btn">{% trans %}Search{% endtrans %}</button>
+</form>
+{% endmacro %}

--- a/tests/h/views/admin_groups_test.py
+++ b/tests/h/views/admin_groups_test.py
@@ -48,6 +48,29 @@ def test_index_paginates_results(pyramid_request, routes, paginate):
     paginate.assert_called_once_with(pyramid_request, mock.ANY, mock.ANY)
 
 
+@pytest.mark.parametrize('query,expected_groups', [
+    # All groups should be returned when there is no query.
+    (None, ['BioPub', 'ChemPub', 'Public']),
+
+    # Only matching groups should be returned if there is a query.
+    ('BioPub', ['BioPub']),
+    ('ChemPub', ['ChemPub']),
+
+    # Filtering should be case-insensitive.
+    ('chem', ['ChemPub']),
+])
+def test_index_filters_results(pyramid_request, factories, query, expected_groups):
+    factories.Group(name='BioPub')
+    factories.Group(name='ChemPub')
+
+    if query:
+        pyramid_request.GET['q'] = query
+    ctx = admin_groups.groups_index(None, pyramid_request)
+
+    filtered_group_names = sorted([g.name for g in ctx['results']])
+    assert filtered_group_names == expected_groups
+
+
 @pytest.mark.usefixtures('group_svc', 'routes', 'user_svc')
 class TestGroupCreateController(object):
 


### PR DESCRIPTION
In h instances with a large number of groups it becomes impractical to
find a specific group by paging through the list, so add a facility to
search for groups by name.

The search currently does a naive `LIKE` SQL query which should be OK
for the admin page. If we were to expose this to users we might need to
optimize it using a suitable index.

Fixes https://github.com/hypothesis/product-backlog/issues/553

<img width="1170" alt="screenshot 2018-03-28 16 47 34" src="https://user-images.githubusercontent.com/2458/38040620-cf85e3a8-32a7-11e8-8272-f19e541e9aa0.png">

<img width="1175" alt="screenshot 2018-03-28 16 47 24" src="https://user-images.githubusercontent.com/2458/38040628-d66485bc-32a7-11e8-9496-c371a60849f9.png">
