### PR TITLE
Add basic expansion for `organization` on `GET /api/groups`

### DIFF
--- a/docs/_extra/api-reference/hypothesis.yaml
+++ b/docs/_extra/api-reference/hypothesis.yaml
@@ -9,6 +9,15 @@ info:
     See [the API overview](../api/) for an introduction to the API and information
     on how authorization works.
 
+    ## Expanding Resources
+    Resources often contain links to related resources in their response bodies.
+    Some endpoints support resource expansion, allowing those related resources
+    to be expanded inline in the response.
+
+    To expand resources (where supported), use the `expand` request parameter.
+    Individual endpoint documentation indicates which resources are expandable.
+
+
   termsOfService: https://hypothes.is/terms-of-service
   license:
     name: BSD (2-Clause)
@@ -221,6 +230,15 @@ paths:
           required: false
           type: string
           format: uri
+        - name: expand
+          description: >
+            Array of related resource objects to expand within the response
+          in: query
+          type: array
+          items:
+            type: string
+            enum:
+              - organizations
       responses:
         '200':
           description: Success

--- a/docs/_extra/api-reference/hypothesis.yaml
+++ b/docs/_extra/api-reference/hypothesis.yaml
@@ -423,55 +423,7 @@ definitions:
   GroupResults:
     type: array
     items:
-      $ref: '#/definitions/Group'
-  Group:
-    type: object
-    required:
-      - id
-      - links
-      - name
-      - public
-      - scoped
-      - type
-      - urls
-    properties:
-      id:
-        type: string
-      links:
-        type: object
-        properties:
-          html:
-            type: string
-            format: uri
-            description: URL to the group's main (activity) page
-      name:
-        type: string
-      public:
-        type: boolean
-        deprecated: true
-        description: Indicates whether a group's annotations are world-readable
-      scoped:
-        type: boolean
-        description: Whether or not this group has URL restrictions for documents that may be annotated within it. Non-scoped groups allow annotation to documents at any URL
-      type:
-        type: string
-        enum:
-          - private
-          - open
-          - restricted
-      url:
-        type: string
-        format: uri
-        deprecated: true
-      urls:
-        type: object
-        deprecated: true
-        properties:
-          group:
-            type: string
-            format: uri
-            description: URI to group activity page; use `links.html` instead
-            deprecated: true
+      $ref: './schemas/group.yaml#/Group'
   NewUser:
     $ref: './schemas/new-user-schema.json'
   UpdateUser:

--- a/docs/_extra/api-reference/schemas/group.yaml
+++ b/docs/_extra/api-reference/schemas/group.yaml
@@ -24,7 +24,7 @@ Group:
     organization:
       description: If expanded, an organization object, otherwise a link to the organization resource, if available
       oneOf:
-        - type: object
+        - $ref: './organization.yaml#/Organization'
         - type: string
           format: uri
           description: Link to organization resource

--- a/docs/_extra/api-reference/schemas/group.yaml
+++ b/docs/_extra/api-reference/schemas/group.yaml
@@ -1,0 +1,56 @@
+Group:
+  type: object
+  required:
+    - id
+    - links
+    - name
+    - organization
+    - public
+    - scoped
+    - type
+    - urls
+  properties:
+    id:
+      type: string
+    links:
+      type: object
+      properties:
+        html:
+          type: string
+          format: uri
+          description: URL to the group's main (activity) page
+    name:
+      type: string
+    organization:
+      description: If expanded, an organization object, otherwise a link to the organization resource, if available
+      oneOf:
+        - type: object
+        - type: string
+          format: uri
+          description: Link to organization resource
+    public:
+      type: boolean
+      deprecated: true
+      description: Indicates whether a group's annotations are world-readable
+    scoped:
+      type: boolean
+      description: Whether or not this group has URL restrictions for documents that may be annotated within it. Non-scoped groups allow annotation to documents at any URL
+    type:
+      type: string
+      enum:
+        - private
+        - open
+        - restricted
+    url:
+      type: string
+      format: uri
+      deprecated: true
+    urls:
+      type: object
+      deprecated: true
+      properties:
+        group:
+          type: string
+          format: uri
+          description: URI to group activity page; use `links.html` instead
+          deprecated: true

--- a/docs/_extra/api-reference/schemas/organization.yaml
+++ b/docs/_extra/api-reference/schemas/organization.yaml
@@ -1,0 +1,10 @@
+Organization:
+  type: object
+  required:
+    - id
+    - name
+  properties:
+    id:
+      type: string
+    name:
+      type: string

--- a/h/presenters/group_json.py
+++ b/h/presenters/group_json.py
@@ -17,6 +17,7 @@ class GroupJSONPresenter(object):
         model = {
           'name': group.name,
           'id': group.pubid,
+          'organization': '',  # unexexpanded org; no link available yet, so empty string by default
           'public': group.is_public,  # DEPRECATED: TODO: remove from client
           'scoped': True if group.scopes else False,
           'type': group.type

--- a/h/presenters/group_json.py
+++ b/h/presenters/group_json.py
@@ -18,7 +18,14 @@ class GroupJSONPresenter(object):
 
     def _expand(self, model, expand=[]):
         if 'organizations' in expand:
-            model['organization'] = {}
+            org_model = {}
+            org = self.group.organization
+            if org is not None:
+                org_model = {
+                    'id': org.pubid,
+                    'name': org.name,
+                }
+            model['organization'] = org_model
         return model
 
     def _model(self):

--- a/h/presenters/group_json.py
+++ b/h/presenters/group_json.py
@@ -10,28 +10,29 @@ class GroupJSONPresenter(object):
         self.group = group
         self._links_svc = links_svc
 
-    def asdict(self):
-        return self._model(self.group)
-
-    def _model(self, group):
-        model = {
-          'name': group.name,
-          'id': group.pubid,
-          'organization': '',  # unexexpanded org; no link available yet, so empty string by default
-          'public': group.is_public,  # DEPRECATED: TODO: remove from client
-          'scoped': True if group.scopes else False,
-          'type': group.type
-        }
-        model = self._inject_urls(group, model)
+    def asdict(self, expand=[]):
+        model = self._model()
+        self._inject_urls(model)
         return model
 
-    def _inject_urls(self, group, model):
+    def _model(self):
+        model = {
+          'name': self.group.name,
+          'id': self.group.pubid,
+          'organization': '',  # unexexpanded org; no link available yet, so empty string by default
+          'public': self.group.is_public,  # DEPRECATED: TODO: remove from client
+          'scoped': True if self.group.scopes else False,
+          'type': self.group.type
+        }
+        return model
+
+    def _inject_urls(self, model):
         model['links'] = {}
         model['urls'] = {}  # DEPRECATED TODO: remove from client
         if not self._links_svc:
             return model
 
-        model['links'] = self._links_svc.get_all(group)
+        model['links'] = self._links_svc.get_all(self.group)
         model['urls'] = model['links']  # DEPRECATED TODO: remove from client
         if 'html' in model['links']:
             # DEPRECATED TODO: remove from client
@@ -46,5 +47,5 @@ class GroupsJSONPresenter(object):
         self.groups = groups
         self._links_svc = links_svc
 
-    def asdicts(self):
-        return [GroupJSONPresenter(group, self._links_svc).asdict() for group in self.groups]
+    def asdicts(self, expand=[]):
+        return [GroupJSONPresenter(group, self._links_svc).asdict(expand=expand) for group in self.groups]

--- a/h/presenters/group_json.py
+++ b/h/presenters/group_json.py
@@ -12,7 +12,13 @@ class GroupJSONPresenter(object):
 
     def asdict(self, expand=[]):
         model = self._model()
+        self._expand(model, expand)
         self._inject_urls(model)
+        return model
+
+    def _expand(self, model, expand=[]):
+        if 'organizations' in expand:
+            model['organization'] = {}
         return model
 
     def _model(self):

--- a/h/views/api_groups.py
+++ b/h/views/api_groups.py
@@ -15,6 +15,8 @@ from h.views.api import api_config
 def groups(request):
     authority = request.params.get('authority')
     document_uri = request.params.get('document_uri')
+    expand = request.GET.getall('expand') or []
+
     list_svc = request.find_service(name='list_groups')
     links_svc = request.find_service(name='group_links')
 
@@ -26,7 +28,7 @@ def groups(request):
                                          authority=authority,
                                          document_uri=document_uri)
 
-    all_groups = GroupsJSONPresenter(all_groups, links_svc).asdicts()
+    all_groups = GroupsJSONPresenter(all_groups, links_svc).asdicts(expand=expand)
     return all_groups
 
 

--- a/tests/h/presenters/group_json_test.py
+++ b/tests/h/presenters/group_json_test.py
@@ -84,6 +84,33 @@ class TestGroupJSONPresenter(object):
 
         links_svc.get_all.assert_called_once_with(group)
 
+    def test_it_does_not_expand_by_default(self, factories):
+        group = factories.OpenGroup(name='My Group',
+                                    pubid='mygroup')
+        presenter = GroupJSONPresenter(group)
+
+        model = presenter.asdict()
+
+        assert model['organization'] == ''
+
+    def test_it_expands_organizations(self, factories):
+        group = factories.OpenGroup(name='My Group',
+                                    pubid='mygroup')
+        presenter = GroupJSONPresenter(group)
+
+        model = presenter.asdict(expand=['organizations'])
+
+        assert model['organization'] == {}
+
+    def test_it_ignores_unrecognized_expands(self, factories):
+        group = factories.OpenGroup(name='My Group',
+                                    pubid='mygroup')
+        presenter = GroupJSONPresenter(group)
+
+        model = presenter.asdict(expand=['foobars', 'dingdong'])
+
+        assert model['organization'] == ''
+
 
 class TestGroupsJSONPresenter(object):
 

--- a/tests/h/presenters/group_json_test.py
+++ b/tests/h/presenters/group_json_test.py
@@ -19,6 +19,7 @@ class TestGroupJSONPresenter(object):
         assert presenter.asdict() == {
             'name': 'My Group',
             'id': 'mygroup',
+            'organization': '',
             'type': 'private',
             'public': False,
             'scoped': False,
@@ -35,6 +36,7 @@ class TestGroupJSONPresenter(object):
         assert presenter.asdict() == {
             'name': 'My Group',
             'id': 'mygroup',
+            'organization': '',
             'type': 'open',
             'public': True,
             'scoped': False,
@@ -53,6 +55,7 @@ class TestGroupJSONPresenter(object):
             'name': 'My Group',
             'id': 'groupy',
             'type': 'open',
+            'organization': '',
             'public': True,
             'scoped': True,
             'urls': {},

--- a/tests/h/presenters/group_json_test.py
+++ b/tests/h/presenters/group_json_test.py
@@ -100,7 +100,20 @@ class TestGroupJSONPresenter(object):
 
         model = presenter.asdict(expand=['organizations'])
 
-        assert model['organization'] == {}
+        assert model['organization'] == {}  # empty organization
+
+    def test_it_populates_expanded_organizations(self, factories):
+        group = factories.OpenGroup(name='My Group',
+                                    pubid='mygroup')
+        group.organization = factories.Organization()
+        presenter = GroupJSONPresenter(group)
+
+        model = presenter.asdict(expand=['organizations'])
+
+        assert model['organization'] == {
+            'name': group.organization.name,
+            'id': group.organization.pubid,
+        }
 
     def test_it_ignores_unrecognized_expands(self, factories):
         group = factories.OpenGroup(name='My Group',

--- a/tests/h/views/api_groups_test.py
+++ b/tests/h/views/api_groups_test.py
@@ -63,6 +63,23 @@ class TestGetGroups(object):
 
         assert result == GroupsJSONPresenter(open_groups, anonymous_request).asdicts.return_value
 
+    def test_proxies_expand_to_presenter(self, anonymous_request, open_groups, list_groups_service, GroupsJSONPresenter):  # noqa: N803
+        anonymous_request.params['expand'] = 'organizations'
+        list_groups_service.request_groups.return_value = open_groups
+
+        views.groups(anonymous_request)
+
+        GroupsJSONPresenter(open_groups, anonymous_request).asdicts.assert_called_once_with(expand=['organizations'])
+
+    def test_passes_multiple_expand_to_presenter(self, anonymous_request, open_groups, list_groups_service, GroupsJSONPresenter):  # noqa: N803
+        anonymous_request.GET.add('expand', 'organizations')
+        anonymous_request.GET.add('expand', 'foobars')
+        list_groups_service.request_groups.return_value = open_groups
+
+        views.groups(anonymous_request)
+
+        GroupsJSONPresenter(open_groups, anonymous_request).asdicts.assert_called_once_with(expand=['organizations', 'foobars'])
+
     @pytest.fixture
     def open_groups(self, factories):
         return [factories.OpenGroup(), factories.OpenGroup()]


### PR DESCRIPTION
This PR adds basic expansion for `organization` resources on the `GET /api/groups` endpoint. `organization` objects will be expanded if the `expands` query parameter contains `organizations` as one of its values (it's an Array).

When expanded, at present, the organization object for a group will contain an `id` (pubid) and `name`. `logo` will come later. When the group in question has no associated `organization`, this will result in an empty object (production groups don't have organizations, yet).

When not expanded (i.e. default), `organization` at present is an empty string—ultimately it should be a link to a representation of the resource.

All of this is reflected in updated documentation.

Next up:

* Adding logo
* Refactor/create an `OrganizationJSONPresenter`