### PR TITLE
Correct SVG in migration script

### DIFF
--- a/h/migrations/versions/8a7f31c4525d_add___default___organization.py
+++ b/h/migrations/versions/8a7f31c4525d_add___default___organization.py
@@ -26,21 +26,13 @@ Base = declarative_base()
 Session = sessionmaker()
 
 
-H_LOGO = \
-"""
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg width="24px" height="28px" viewBox="0 0 24 28" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 3.8.3 (29802) - http://www.bohemiancoding.com/sketch -->
-    <title>Rectangle 2 Copy 17</title>
-    <desc>Created with Sketch.</desc>
-    <defs></defs>
-    <rect fill="#ffffff" stroke="none" width="17.14407" height="16.046612"
-          x="3.8855932" y="3.9449153" />
+H_LOGO = """<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+  <svg width="24px" height="28px" viewBox="0 0 24 28" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <rect fill="#ffffff" stroke="none" width="17.14407" height="16.046612" x="3.8855932" y="3.9449153" />
     <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
         <path d="M0,2.00494659 C0,0.897645164 0.897026226,0 2.00494659,0 L21.9950534,0 C23.1023548,0 24,0.897026226 24,2.00494659 L24,21.9950534 C24,23.1023548 23.1029738,24 21.9950534,24 L2.00494659,24 C0.897645164,24 0,23.1029738 0,21.9950534 L0,2.00494659 Z M9,24 L12,28 L15,24 L9,24 Z M7.00811294,4 L4,4 L4,20 L7.00811294,20 L7.00811294,15.0028975 C7.00811294,12.004636 8.16824717,12.0097227 9,12 C10,12.0072451 11.0189302,12.0606714 11.0189302,14.003477 L11.0189302,20 L14.0270431,20 L14.0270431,13.1087862 C14.0270433,10 12,9.00309038 10,9.00309064 C8.01081726,9.00309091 8,9.00309086 7.00811294,11.0019317 L7.00811294,4 Z M19,19.9869002 C20.1045695,19.9869002 21,19.0944022 21,17.9934501 C21,16.892498 20.1045695,16 19,16 C17.8954305,16 17,16.892498 17,17.9934501 C17,19.0944022 17.8954305,19.9869002 19,19.9869002 Z" id="Rectangle-2-Copy-17" fill="currentColor"></path>
     </g>
-</svg>
-""".decode('utf-8')
+</svg>"""
 
 
 class Group(Base):


### PR DESCRIPTION
This is a correction to the DB migration in <https://github.com/hypothesis/h/pull/4927>. The migration hasn't been run on production yet (or rather, I did run it, but then I downgraded it again afterwards, and manually removed the `__default__` org from the production db).

The SVG string wasn't valid SVG because it has empty lines at the start and end, and wasn't rendering in browsers, fixed that. It also had a non-sensical `.decode('utf-8')` on it that would crash in Python 3, removed that. It also contained some junk: Sketch comment, silly `<title>`, empty `<defs>`, unnecessary newlines, removed all those.

It renders in Chrome and Firefox now.