### PR TITLE
Add Organization.default() class method

### DIFF
--- a/h/models/organization.py
+++ b/h/models/organization.py
@@ -65,3 +65,7 @@ class Organization(Base, mixins.Timestamps):
 
     def __repr__(self):
         return '<Organization: %s>' % self.pubid
+
+    @classmethod
+    def default(cls, session):
+        return session.query(cls).filter_by(pubid='__default__').one()

--- a/tests/h/models/organization_test.py
+++ b/tests/h/models/organization_test.py
@@ -63,3 +63,7 @@ def test_repr(db_session, factories):
         name='My Organization', authority='example.com', pubid='test_pubid')
 
     assert repr(organization) == "<Organization: test_pubid>"
+
+
+def test_default_returns_the_default_organization(db_session):
+    assert models.Organization.default(db_session).pubid == '__default__'


### PR DESCRIPTION
Various parts of the code are going to need to get access to the `__default__` organization, so add a class method to `models.Organization` for it.