### PR TITLE
Use default organization in test factories

### DIFF
--- a/tests/common/factories/group.py
+++ b/tests/common/factories/group.py
@@ -12,6 +12,11 @@ from .group_scope import GroupScope
 from .user import User
 
 
+def default_organization():
+    from tests.common.factories.base import SESSION
+    return models.Organization.default(SESSION)
+
+
 class Group(ModelFactory):
 
     class Meta:
@@ -25,6 +30,7 @@ class Group(ModelFactory):
     readable_by = ReadableBy.members
     writeable_by = WriteableBy.members
     members = factory.LazyAttribute(lambda obj: [obj.creator])
+    organization = factory.LazyFunction(default_organization)
 
     @factory.post_generation
     def scopes(self, create, scopes=0, **kwargs):

--- a/tests/h/presenters/group_json_test.py
+++ b/tests/h/presenters/group_json_test.py
@@ -100,7 +100,7 @@ class TestGroupJSONPresenter(object):
 
         model = presenter.asdict(expand=['organization'])
 
-        assert model['organization'] == {}  # empty organization
+        assert model['organization'] == {'id': '__default__', 'name': 'Hypothesis'}
 
     def test_it_populates_expanded_organizations(self, factories):
         group = factories.OpenGroup(name='My Group',

--- a/tests/h/services/delete_group_test.py
+++ b/tests/h/services/delete_group_test.py
@@ -48,17 +48,6 @@ class TestDeleteGroupService(object):
         assert (expected_event.request, expected_event.annotation_id, expected_event.action) == \
                (actual_event.request, actual_event.annotation_id, actual_event.action)
 
-    def test_delete_deletes_user_relationships(self, svc, db_session, factories):
-        user = factories.User()
-        group = factories.Group(creator=user)
-
-        svc.delete(group)
-
-        # note that user.groups retains deleted group through the request
-        # until db is committed/flushed but the group is marked as deleted
-        assert user.groups[0] in db_session.deleted
-        assert user not in db_session.deleted
-
     def test_delete_group_factory(self, pyramid_request):
         svc = delete_group_service_factory(None, pyramid_request)
 


### PR DESCRIPTION
Tests that use these factories will be crashing once `Group.organization` is not nullable. Fix the factories to use the default organization.