### PR TITLE
Use default organization in group model tests

### DIFF
--- a/tests/h/models/groups_test.py
+++ b/tests/h/models/groups_test.py
@@ -30,11 +30,12 @@ def test_with_long_name():
         models.Group(name="abcdefghijklmnopqrstuvwxyz")
 
 
-def test_slug(db_session, factories):
+def test_slug(db_session, factories, default_organization):
     name = "My Hypothesis Group"
     user = factories.User()
 
-    group = models.Group(name=name, authority="foobar.com", creator=user)
+    group = models.Group(name=name, authority="foobar.com", creator=user,
+                         organization=default_organization)
     db_session.add(group)
     db_session.flush()
 
@@ -72,11 +73,12 @@ def test_you_cannot_set_type(factories):
         group.type = 'open'
 
 
-def test_repr(db_session, factories):
+def test_repr(db_session, factories, default_organization):
     name = "My Hypothesis Group"
     user = factories.User()
 
-    group = models.Group(name=name, authority='foobar.com', creator=user)
+    group = models.Group(name=name, authority='foobar.com', creator=user,
+                         organization=default_organization)
     db_session.add(group)
     db_session.flush()
 
@@ -98,24 +100,15 @@ def test_group_organization(db_session):
     assert group.organization_id == org.id
 
 
-def test_group_organization_defaults_to_none(db_session):
-    name = "My Hypothesis Group"
-
-    group = models.Group(name=name, authority='foobar.com')
-    db_session.add(group)
-    db_session.flush()
-
-    assert group.organization is None
-    assert group.organization_id is None
-
-
-def test_created_by(db_session, factories):
+def test_created_by(db_session, factories, default_organization):
     name_1 = "My first group"
     name_2 = "My second group"
     user = factories.User()
 
-    group_1 = models.Group(name=name_1, authority='foobar.com', creator=user)
-    group_2 = models.Group(name=name_2, authority='foobar.com', creator=user)
+    group_1 = models.Group(name=name_1, authority='foobar.com', creator=user,
+                           organization=default_organization)
+    group_2 = models.Group(name=name_2, authority='foobar.com', creator=user,
+                           organization=default_organization)
 
     db_session.add_all([group_1, group_2])
     db_session.flush()


### PR DESCRIPTION
Once we've made `group.organization_id` not nullable in the database,
`models.Group` unit tests that try to add a group with no organization
to the DB and flush it will crash.

Fix these tests to add the default organization to the groups.

Tests that don't add the `Group` objects to the DB or flush it don't
need to be updated.

One test, `test_group_organization_defaults_to_none()`, is deleted
because it's no longer possible to add a group with no organization to
the DB and flush it (as this test does) without crashing.
`Group.organization` still defaults to `None` _before_ you flush the DB,
but this is just the standard behaviour of an attribute of a sqlalchemy
ORM class (or any Python class) if you don't set it to a value, so it
doesn't need to be tested.