### PR TITLE
Use test factories to create test groups

### DIFF
--- a/tests/h/services/delete_user_test.py
+++ b/tests/h/services/delete_user_test.py
@@ -6,7 +6,7 @@ import pytest
 from mock import Mock, call
 
 from h.events import AnnotationEvent
-from h.models import Annotation, Document, Group
+from h.models import Annotation, Document
 from h.services.delete_user import (
     UserDeleteError,
     delete_user_service_factory,
@@ -102,9 +102,8 @@ def group_with_two_users(db_session, factories):
     creator = factories.User()
     member = factories.User()
 
-    group = Group(authority=creator.authority, creator=creator, members=[creator, member],
-                  name='test', pubid='group_with_two_users')
-    db_session.add(group)
+    group = factories.Group(authority=creator.authority, creator=creator,
+                            members=[creator, member])
 
     doc = Document(web_uri='https://example.org')
     creator_ann = Annotation(userid=creator.userid, groupid=group.pubid, document=doc)


### PR DESCRIPTION
This test would crash once `Group.organization` becomes not nullable. If
the test uses `factories.Group()` to create its test group, rather than
calling `models.Group()` directly, then (as long as `factories.Group()`
has been updated) the test won't break when `Group` changes.

This also means the test doesn't need to add the group to the DB
session, as the factory does that.