### PR TITLE
Make Group.organization not nullable

### DIFF
--- a/h/migrations/versions/f052da9df33b_make_group_organization_id_not_nullable.py
+++ b/h/migrations/versions/f052da9df33b_make_group_organization_id_not_nullable.py
@@ -1,0 +1,16 @@
+"""Make group.organization_id not nullable."""
+from __future__ import unicode_literals
+
+from alembic import op
+
+
+revision = 'f052da9df33b'
+down_revision = '615358b6c428'
+
+
+def upgrade():
+    op.alter_column('group', 'organization_id', nullable=False)
+
+
+def downgrade():
+    op.alter_column('group', 'organization_id', nullable=True)

--- a/h/models/group.py
+++ b/h/models/group.py
@@ -84,7 +84,7 @@ class Group(Base, mixins.Timestamps):
 
     scopes = sa.orm.relationship('GroupScope', backref='group', cascade='all, delete-orphan')
 
-    organization_id = sa.Column(sa.Integer, sa.ForeignKey('organization.id'))
+    organization_id = sa.Column(sa.Integer, sa.ForeignKey('organization.id'), nullable=False)
     organization = sa.orm.relationship('Organization')
 
     def __init__(self, **kwargs):


### PR DESCRIPTION
This is marked as WIP for now just because there are several other open prs that should be merged before this is, plus one db migration that should be run, to prevent this from breaking things.

I _think_ it's okay to deploy the model change and migration script at the same time and then run the migration script. Safest to deploy the code all the way out to production before running the migration.