### PR TITLE
Search tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
       python: '2.7'
       addons:
         postgresql: "9.4"
-      before_install:
+      before_install: &install-elastic
         # Install Elasticsearch v1.6.2 and the ICU plugin to match the
         # production environment.
         - curl -O https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-1.6.2.deb && sudo dpkg -i elasticsearch-1.6.2.deb && true
@@ -27,6 +27,7 @@ matrix:
       python: '3.6'
       addons:
         postgresql: '9.4'
+      before_install: *install-elastic
       install: pip install tox
       before_script: createdb htest
       script:

--- a/h/search/index.py
+++ b/h/search/index.py
@@ -68,7 +68,7 @@ def index(es, annotation, request, target_index=None, refresh=False):
     )
 
 
-def delete(es, annotation_id, target_index=None):
+def delete(es, annotation_id, target_index=None, refresh=False):
     """
     Mark an annotation as deleted in the search index.
 
@@ -94,7 +94,9 @@ def delete(es, annotation_id, target_index=None):
         index=target_index,
         doc_type=es.t.annotation,
         body={'deleted': True},
-        id=annotation_id)
+        id=annotation_id,
+        refresh=refresh,
+    )
 
 
 class BatchIndexer(object):

--- a/h/search/query.py
+++ b/h/search/query.py
@@ -93,7 +93,7 @@ def extract_limit(params):
 def extract_sort(params):
     return [{
         params.pop("sort", "updated"): {
-            "ignore_unmapped": True,
+            "unmapped_type": "long",
             "order": params.pop("order", "desc"),
         }
     }]

--- a/tests/h/conftest.py
+++ b/tests/h/conftest.py
@@ -258,7 +258,7 @@ def pyramid_settings():
     }
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture
 def search_client():
     """
     Prepare an empty ElasticSearch index and return a client for it.


### PR DESCRIPTION
In preparation for https://github.com/hypothesis/product-backlog/issues/562, and to prevent search regressions in general, it would be useful to include search tests that use a live elastic instance. This patch builds on earlier work by @robertknight, adding more tests and exercising both indexing and query logic. These tests aren't comprehensive, but they're a start.