### PR TITLE
Implement new admin navbar design

### DIFF
--- a/h/static/styles/admin.scss
+++ b/h/static/styles/admin.scss
@@ -2,6 +2,7 @@
 @import 'partials/util';
 
 // Components
+@import 'partials/admin-navbar';
 @import 'partials/btn';
 @import 'partials/form-actions';
 @import 'partials/form-checkbox';
@@ -12,10 +13,6 @@
 @import 'partials/search-form';
 @import 'partials/svg-icon';
 @import 'partials/tooltip';
-
-body {
-  padding-top: 50px;
-}
 
 .flashbar {
   margin-top: 20px;

--- a/h/static/styles/partials/_admin-navbar.scss
+++ b/h/static/styles/partials/_admin-navbar.scss
@@ -7,7 +7,7 @@
   color: white;
   display: flex;
   flex-direction: row;
-  font-size: $normal-font-size;
+  font-size: $subtitle-font-size;
   justify-content: center;
   min-height: 50px;
 }

--- a/h/static/styles/partials/_admin-navbar.scss
+++ b/h/static/styles/partials/_admin-navbar.scss
@@ -1,0 +1,96 @@
+/**
+ * The dark navbar shown at the top of `/admin` pages.
+ */
+
+.admin-navbar {
+  background-color: $grey-7;
+  color: white;
+  display: flex;
+  flex-direction: row;
+  font-size: $normal-font-size;
+  justify-content: center;
+  min-height: 50px;
+}
+
+.admin-navbar__container {
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
+  padding-left: 15px;
+  padding-right: 15px;
+  flex-grow: 1;
+
+  // Width chosen to match Bootstrap's "container" class,
+  // which is used for the main content of the page.
+  max-width: 970px;
+}
+
+.admin-navbar__logo-link {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.admin-navbar__logo {
+  color: $brand;
+}
+
+.admin-navbar__tab-list {
+  list-style-type: none;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  padding-left: 20px;
+
+  // Override bootstrap defaults.
+  margin: 0;
+}
+
+.admin-navbar__tab-item {
+  flex-shrink: 0;
+  color: white;
+  padding-left: 10px;
+  padding-right: 10px;
+  text-align: center;
+
+  // Give tabs reasonable padding above and below text, even when wrapped onto
+  // multiple lines.
+  min-height: 2em;
+
+  // Color for the tab's link.
+  --link-color: $grey-3;
+
+  // The `open` class here is applied by Bootstrap's dropdown menu.
+  // `is-active` is applied statically when the page is rendered.
+  &.is-active, &.open {
+    background-color: $grey-5;
+    --link-color: white;
+  }
+
+  &:hover {
+    --link-color: white;
+  }
+}
+
+.admin-navbar__tab-link {
+  color: var(--link-color);
+
+  // Make link expand to fill the area of the tab.
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  height: 100%;
+
+  // Override Bootstrap's styling for the link that opens dropdown menus.
+  &:hover, &:focus {
+    color: var(--link-color);
+    text-decoration: none;
+  }
+}
+
+@media (min-width: 1200px) {
+  // Width chosen to match Bootstrap's "container" class.
+  .admin-navbar__container {
+    max-width: 1170px;
+  }
+}

--- a/h/static/styles/partials/_base.scss
+++ b/h/static/styles/partials/_base.scss
@@ -35,12 +35,10 @@ $small-font-size: 11px;
 $small-line-height: 12px;
 
 $title-font-size: 19px;
+$subtitle-font-size: 15px;
 
 // Font sizes for specific categories of control
 $input-font-size: 15px;
-
-// Font size for search results sidebar subtitles
-$search-results-subtitle-font-size: 15px;
 
 // Minimum font size for <input> fields on iOS. If the font size is smaller than
 // this, iOS will zoom into the field when focused.

--- a/h/static/styles/partials/_search-result-sidebar.scss
+++ b/h/static/styles/partials/_search-result-sidebar.scss
@@ -12,7 +12,7 @@
 
 .search-result-sidebar__subtitle {
   margin-bottom: 9px;
-  font-size: $search-results-subtitle-font-size;
+  font-size: $subtitle-font-size;
 }
 
 .search-result-sidebar__title,

--- a/h/templates/layouts/admin.html.jinja2
+++ b/h/templates/layouts/admin.html.jinja2
@@ -11,13 +11,13 @@
       ('groups', 'admin_groups', 'List Groups'),
       ('groups_create', 'admin_groups_create', 'Create a Group'),
     ]),
+    ('mailer', 'admin_mailer', 'Mailer', []),
+    ('nipsa', 'admin_nipsa', 'NIPSA', []),
+    ('oauth', 'admin_oauthclients', 'OAuth clients', []),
     ('organizations', 'admin_organizations', 'Organizations', [
       ('organizations', 'admin_organizations', 'List organizations'),
       ('organizations_create', 'admin_organizations_create', 'Create an organization'),
     ]),
-    ('mailer', 'admin_mailer', 'Mailer', []),
-    ('nipsa', 'admin_nipsa', 'NIPSA', []),
-    ('oauth', 'admin_oauthclients', 'OAuth clients', []),
     ('staff', 'admin_staff', 'Staff', []),
     ('users', 'admin_users', 'Users', []),
 ] -%}

--- a/h/templates/layouts/admin.html.jinja2
+++ b/h/templates/layouts/admin.html.jinja2
@@ -47,44 +47,34 @@
     {% include 'h:templates/includes/settings.html.jinja2' %}
   </head>
   <body>
-    <nav class="navbar navbar-inverse navbar-fixed-top">
-      <div class="container">
-        <div class="navbar-header">
-          <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false" aria-controls="navbar">
-            <span class="sr-only">Toggle navigation</span>
-            <span class="icon-bar"></span>
-            <span class="icon-bar"></span>
-            <span class="icon-bar"></span>
-          </button>
-          <a class="navbar-brand" href="{{ request.route_url('admin_index') }}">
-            Hypothesis Admin
-          </a>
-        </div>
-        <div id="navbar" class="navbar-collapse collapse">
-          <ul class="nav navbar-nav">
-            {% for id, permission, title, children in nav_pages %}
-              {% if request.has_permission(permission) %}
-                {% if not children %}
-                  <li{% if id == page_id %} class="active"{% endif %}>
-                    <a href="{{ request.route_url(permission) }}">{{ title }}</a>
-                  </li>
-                {% else %}
-                  <li class="dropdown{% if id in page_id %} active{% endif %}">
-                      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
-                      {{ title }}
-                      <span class="caret"></span>
-                      </a>
-                      <ul class="dropdown-menu">
-                        {% for id, url, title in children %}
-                          <li><a href="{{ request.route_url(url) }}">{{ title }}</a></li>
-                        {% endfor %}
-                      </ul>
-                  </li>
-                {% endif %}
+    <nav class="admin-navbar">
+      <div class="admin-navbar__container">
+        <a class="admin-navbar__logo-link" href="{{ request.route_url('admin_index') }}">
+          {{ svg_icon('logo', 'admin-navbar__logo') }}
+        </a>
+        <ul class="admin-navbar__tab-list">
+          {% for id, permission, title, children in nav_pages %}
+            {% if request.has_permission(permission) %}
+              {% if not children %}
+                <li class="admin-navbar__tab-item{% if id == page_id %} is-active{% endif %}">
+                  <a class="admin-navbar__tab-link" href="{{ request.route_url(permission) }}">{{ title }}</a>
+                </li>
+              {% else %}
+                <li class="admin-navbar__tab-item dropdown{% if id in page_id %} active{% endif %}">
+                    <a href="#" class="admin-navbar__tab-link dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
+                    {{ title }}
+                    <span class="caret"></span>
+                    </a>
+                    <ul class="dropdown-menu">
+                      {% for id, url, title in children %}
+                        <li><a href="{{ request.route_url(url) }}">{{ title }}</a></li>
+                      {% endfor %}
+                    </ul>
+                </li>
               {% endif %}
-            {% endfor %}
-          </ul>
-        </div>
+            {% endif %}
+          {% endfor %}
+        </ul>
       </div>
     </nav>
 


### PR DESCRIPTION
The existing `/admin` navbar covered the main content of the page when it wraps
onto multiple lines, and the wrapping happens even on not-very-narrow
screens. This commit implements a revised look for the navbar in the
admin panel which resolves that problem and generally uses horizontal
space more efficiently.

The new look currently explicitly does away with the switch to a hamburger menu at very small screen sizes. This is simply because it isn't that often that the menu needs to be used on a phone-sized screen, although the new layout will still work in that context.

As a bonus, the layout is implemented with flexbox following our CSS
conventions which should make it easier to adapt in future.

----

**Existing navbar**

(Note that it obscures the top of the content below)

<img width="1178" alt="screenshot 2018-04-03 15 58 55" src="https://user-images.githubusercontent.com/2458/38262698-ece5f164-3765-11e8-90b3-e41023f274ae.png">

**New navbar**

<img width="1060" alt="screenshot 2018-04-03 15 57 03" src="https://user-images.githubusercontent.com/2458/38262725-0765e99a-3766-11e8-8fed-a8ac72e0b602.png">

**New navbar (narrow screen)**

(Note that it pushes content below down)

<img width="817" alt="screenshot 2018-04-03 15 57 35" src="https://user-images.githubusercontent.com/2458/38262768-270d5c1a-3766-11e8-8638-dc0ac8f21b96.png">
