### PR TITLE
Add Group, Organization Resources

### DIFF
--- a/h/presenters/group_json.py
+++ b/h/presenters/group_json.py
@@ -6,9 +6,9 @@ from __future__ import unicode_literals
 class GroupJSONPresenter(object):
     """Present a group in the JSON format returned by API requests."""
 
-    def __init__(self, group, links_svc=None):
-        self.group = group
-        self._links_svc = links_svc
+    def __init__(self, group_resource):
+        self.resource = group_resource
+        self.group = group_resource.group
 
     def asdict(self, expand=[]):
         model = self._model()
@@ -40,12 +40,7 @@ class GroupJSONPresenter(object):
         return model
 
     def _inject_urls(self, model):
-        model['links'] = {}
-        model['urls'] = {}  # DEPRECATED TODO: remove from client
-        if not self._links_svc:
-            return model
-
-        model['links'] = self._links_svc.get_all(self.group)
+        model['links'] = self.resource.links or {}
         model['urls'] = model['links']  # DEPRECATED TODO: remove from client
         if 'html' in model['links']:
             # DEPRECATED TODO: remove from client
@@ -56,9 +51,8 @@ class GroupJSONPresenter(object):
 class GroupsJSONPresenter(object):
     """Present a list of groups as JSON"""
 
-    def __init__(self, groups, links_svc=None):
-        self.groups = groups
-        self._links_svc = links_svc
+    def __init__(self, group_resources):
+        self.resources = group_resources
 
     def asdicts(self, expand=[]):
-        return [GroupJSONPresenter(group, self._links_svc).asdict(expand=expand) for group in self.groups]
+        return [GroupJSONPresenter(group_resource).asdict(expand=expand) for group_resource in self.resources]

--- a/h/resources.py
+++ b/h/resources.py
@@ -151,6 +151,25 @@ class GroupResource(object):
         return self.links_service.get_all(self.group)
 
 
+class OrganizationResource(object):
+    def __init__(self, organization, request):
+        # TODO Links service
+        self.organization = organization
+        self.request = request
+
+    @property
+    def links(self):
+        # TODO
+        return {}
+
+    @property
+    def logo(self):
+        if self.organization.logo:
+            return self.request.route_url('organization_logo',
+                                          pubid=self.organization.pubid)
+        return None
+
+
 def _group_principals(group):
     if group is None:
         return []

--- a/h/resources.py
+++ b/h/resources.py
@@ -140,6 +140,17 @@ class OrganizationLogoFactory(object):
         return organization.logo
 
 
+class GroupResource(object):
+    def __init__(self, group, request):
+        self.request = request
+        self.group = group
+        self.links_service = self.request.find_service(name='group_links')
+
+    @property
+    def links(self):
+        return self.links_service.get_all(self.group)
+
+
 def _group_principals(group):
     if group is None:
         return []

--- a/h/resources.py
+++ b/h/resources.py
@@ -150,6 +150,12 @@ class GroupResource(object):
     def links(self):
         return self.links_service.get_all(self.group)
 
+    @property
+    def organization(self):
+        if self.group.organization:
+            return OrganizationResource(self.group.organization, self.request)
+        return None
+
 
 class OrganizationResource(object):
     def __init__(self, organization, request):

--- a/h/views/api_groups.py
+++ b/h/views/api_groups.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 
 from pyramid import security
 from pyramid.httpexceptions import HTTPNoContent, HTTPBadRequest
+from h.resources import GroupResource
 from h.presenters import GroupsJSONPresenter
 from h.views.api import api_config
 
@@ -18,7 +19,6 @@ def groups(request):
     expand = request.GET.getall('expand') or []
 
     list_svc = request.find_service(name='list_groups')
-    links_svc = request.find_service(name='group_links')
 
     if request.user is not None:
         authority = request.user.authority
@@ -27,8 +27,8 @@ def groups(request):
     all_groups = list_svc.request_groups(user=request.user,
                                          authority=authority,
                                          document_uri=document_uri)
-
-    all_groups = GroupsJSONPresenter(all_groups, links_svc).asdicts(expand=expand)
+    all_groups = [GroupResource(group, request) for group in all_groups]
+    all_groups = GroupsJSONPresenter(all_groups).asdicts(expand=expand)
     return all_groups
 
 

--- a/tests/h/resources_test.py
+++ b/tests/h/resources_test.py
@@ -3,17 +3,19 @@
 from __future__ import unicode_literals
 
 import pytest
-from mock import Mock
+import mock
 
 from pyramid import security
 from pyramid.authorization import ACLAuthorizationPolicy
 
 from h.models import AuthClient
+from h.services.group_links import GroupLinksService
 from h.resources import AnnotationResource
 from h.resources import AnnotationResourceFactory
 from h.resources import AuthClientFactory
 from h.resources import OrganizationFactory
 from h.resources import OrganizationLogoFactory
+from h.resources import GroupResource
 
 
 @pytest.mark.usefixtures('group_service', 'links_service')
@@ -26,14 +28,14 @@ class TestAnnotationResourceFactory(object):
 
     def test_get_item_returns_annotation_resource(self, pyramid_request, storage):
         factory = AnnotationResourceFactory(pyramid_request)
-        storage.fetch_annotation.return_value = Mock()
+        storage.fetch_annotation.return_value = mock.Mock()
 
         resource = factory['123']
         assert isinstance(resource, AnnotationResource)
 
     def test_get_item_resource_has_right_annotation(self, pyramid_request, storage):
         factory = AnnotationResourceFactory(pyramid_request)
-        storage.fetch_annotation.return_value = Mock()
+        storage.fetch_annotation.return_value = mock.Mock()
 
         resource = factory['123']
         assert resource.annotation == storage.fetch_annotation.return_value
@@ -47,14 +49,14 @@ class TestAnnotationResourceFactory(object):
 
     def test_get_item_has_right_group_service(self, pyramid_request, storage, group_service):
         factory = AnnotationResourceFactory(pyramid_request)
-        storage.fetch_annotation.return_value = Mock()
+        storage.fetch_annotation.return_value = mock.Mock()
 
         resource = factory['123']
         assert resource.group_service == group_service
 
     def test_get_item_has_right_links_service(self, pyramid_request, storage, links_service):
         factory = AnnotationResourceFactory(pyramid_request)
-        storage.fetch_annotation.return_value = Mock()
+        storage.fetch_annotation.return_value = mock.Mock()
 
         resource = factory['123']
         assert resource.links_service == links_service
@@ -65,13 +67,13 @@ class TestAnnotationResourceFactory(object):
 
     @pytest.fixture
     def group_service(self, pyramid_config):
-        group_service = Mock(spec_set=['find'])
+        group_service = mock.Mock(spec_set=['find'])
         pyramid_config.register_service(group_service, iface='h.interfaces.IGroupService')
         return group_service
 
     @pytest.fixture
     def links_service(self, pyramid_config):
-        service = Mock()
+        service = mock.Mock()
         pyramid_config.register_service(service, name='links')
         return service
 
@@ -79,7 +81,7 @@ class TestAnnotationResourceFactory(object):
 @pytest.mark.usefixtures('group_service', 'links_service')
 class TestAnnotationResource(object):
     def test_links(self, group_service, links_service):
-        ann = Mock()
+        ann = mock.Mock()
         res = AnnotationResource(ann, group_service, links_service)
 
         result = res.links
@@ -88,7 +90,7 @@ class TestAnnotationResource(object):
         assert result == links_service.get_all.return_value
 
     def test_link(self, group_service, links_service):
-        ann = Mock()
+        ann = mock.Mock()
         res = AnnotationResource(ann, group_service, links_service)
 
         result = res.link('json')
@@ -189,14 +191,14 @@ class TestAnnotationResource(object):
 
     @pytest.fixture
     def group_service(self, pyramid_config, groups):
-        group_service = Mock(spec_set=['find'])
+        group_service = mock.Mock(spec_set=['find'])
         group_service.find.side_effect = lambda groupid: groups.get(groupid)
         pyramid_config.register_service(group_service, iface='h.interfaces.IGroupService')
         return group_service
 
     @pytest.fixture
     def links_service(self, pyramid_config):
-        service = Mock(spec_set=['get', 'get_all'])
+        service = mock.Mock(spec_set=['get', 'get_all'])
         pyramid_config.register_service(service, name='links')
         return service
 
@@ -260,10 +262,35 @@ class TestOrganizationLogoFactory(object):
         return OrganizationLogoFactory(pyramid_request)
 
 
+@pytest.mark.usefixtures('links_svc')
+class TestGroupResource(object):
+
+    def test_it_returns_group_model_as_property(self, factories, pyramid_request):
+        group = factories.Group()
+
+        group_resource = GroupResource(group, pyramid_request)
+
+        assert group_resource.group == group
+
+    def test_it_proxies_links_to_svc(self, factories, links_svc, pyramid_request):
+        group = factories.Group()
+
+        group_resource = GroupResource(group, pyramid_request)
+
+        assert group_resource.links == links_svc.get_all.return_value
+
+
 @pytest.fixture
 def organizations(factories):
     # Add a handful of organizations to the DB to make the test realistic.
     return [factories.Organization() for _ in range(3)]
+
+
+@pytest.fixture
+def links_svc(pyramid_config):
+    svc = mock.create_autospec(GroupLinksService, spec_set=True, instance=True)
+    pyramid_config.register_service(svc, name='group_links')
+    return svc
 
 
 class FakeGroup(object):

--- a/tests/h/resources_test.py
+++ b/tests/h/resources_test.py
@@ -280,6 +280,13 @@ class TestGroupResource(object):
 
         assert group_resource.links == links_svc.get_all.return_value
 
+    def test_it_expands_organization(self, factories, pyramid_request):
+        group = factories.Group()
+
+        group_resource = GroupResource(group, pyramid_request)
+
+        assert isinstance(group_resource.organization, OrganizationResource)
+
 
 @pytest.mark.usefixtures('organization_routes')
 class TestOrganizationResource(object):


### PR DESCRIPTION
This PR addresses a large part of https://github.com/hypothesis/product-backlog/issues/567

It adds additional Resource classes in the `h.resources` module: `GroupResource` and `OrganizationResource`.

 `GroupResource` objects contain an `organization` property which allow for expanded representations.

`OrganizationResource` objects contain a `logo` property which is a URL to the organization’s logo, when available.

**Applied Problem Statement**:

Previously, `Group[s]JSONPresenter` took `Group` model objects and decorated them with links by using a links-generating service specific to the model type (thus there is a `groups-links` service and one would project a service for generating `organization` links, too).

This didn't feel like the right separation of concerns: Presenters were thus responsible for generating the correct links for objects, meaning that they had to interact with the `request`.

This became truly painful when the notion of API resource expansion came around, as it would mean that the Group presenter would somehow need to know about the Organization's links service in order to properly render an expanded organization. And the Organization Presenter (future module) would be on the hook for determining the right URL to an organization’s logo. House of cards started to fall.

**Instead…**

Instead, this PR makes the relevant GroupPresenter deal in _Resources_, not model objects. Those resources decorate themselves with links, etc., _before_ they are handed off to the presentation layer.

It gets us to the point where we can feasibly return links for logos for expanded organizations on groups (in the API response).

In order to keep PRs of a sane size, this PR doesn't accomplish all the things:

**TODOs and Next Steps**

The are some bits of imminent, straightforward work to support the applied feature at hand (returning logo information with organizations in the API). This includes creating an Organization JSON Presenter and updating the API response to include a logo. I won’t bother itemizing these here as they’re not terribly relevant to the `Resource`-related refactors here.

There are also some higher-level things @seanh and I discussed, such as:

* Possibly introducing a Context layer between the view at hand (`api-groups`) and the Resources (and having other context modules for other views where it makes sense). The state of the view right now is somewhat tortured and seems to be calling out for a supplied `context`. OTOH, the needed context-generating logic is endpoint specific—it needs to munge the right parameters and produce the correct list of groups (group resources) specific to the request. This makes it inherently different than the other Resource-y, Traversal stuff in that it requires a) a _collection_ of resources, not just a single resource and b) the “factory” for the result is endpoint-specific and likely not reusable.

We discussed the possibility of an endpoint-specific Context that would provide the view a context that is the correct list of groups, while the view would still be responsible for passing on the `expand` param to the presenter (this seemed like a feasible separation of concerns).

Overall, my opinion (just one dev’s opinion!) is that our view logic is somewhat heavy; finding some sort of context abstraction could be interesting. But it might not be the right time to dive into this? Dunno.
* Possibly re-evaluating the way we’re using `Resource` and `ResourceFactory` classes as they aren’t really what they say they are. We’re twisting ourselves around a bunch trying to _sort of_ do Pyramid resource traversal but is it worth it to do it the way we’re doing it?
* Refactoring links generation because, wow, we keep stumbling over it