### PR TITLE
Expand Organization API Response

### DIFF
--- a/docs/_extra/api-reference/schemas/organization.yaml
+++ b/docs/_extra/api-reference/schemas/organization.yaml
@@ -6,5 +6,9 @@ Organization:
   properties:
     id:
       type: string
+    logo:
+      type: string
+      format: uri
+      description: URI to logo image
     name:
       type: string

--- a/h/presenters/group_json.py
+++ b/h/presenters/group_json.py
@@ -2,6 +2,8 @@
 
 from __future__ import unicode_literals
 
+from h.presenters.organization_json import OrganizationJSONPresenter
+
 
 class GroupJSONPresenter(object):
     """Present a group in the JSON format returned by API requests."""
@@ -18,14 +20,11 @@ class GroupJSONPresenter(object):
 
     def _expand(self, model, expand=[]):
         if 'organization' in expand:
-            org_model = {}
-            org = self.group.organization
-            if org is not None:
-                org_model = {
-                    'id': org.pubid,
-                    'name': org.name,
-                }
-            model['organization'] = org_model
+            org_resource = self.resource.organization
+            if org_resource is not None:
+                model['organization'] = OrganizationJSONPresenter(org_resource).asdict()
+            else:
+                model['organization'] = {}
         return model
 
     def _model(self):

--- a/h/presenters/organization_json.py
+++ b/h/presenters/organization_json.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+
+class OrganizationJSONPresenter(object):
+    """Present an organization in the JSON format returned by API requests."""
+
+    def __init__(self, organization_resource):
+        self.resource = organization_resource
+        self.organization = organization_resource.organization
+
+    def asdict(self):
+        model = self._model()
+        self._logo(model)
+        return model
+
+    def _model(self):
+        model = {
+          'name': self.organization.name,
+          'id': self.organization.pubid,
+        }
+        return model
+
+    def _logo(self, model):
+        if self.resource.logo is not None:
+            model['logo'] = self.resource.logo

--- a/tests/h/presenters/group_json_test.py
+++ b/tests/h/presenters/group_json_test.py
@@ -83,7 +83,7 @@ class TestGroupJSONPresenter(object):
 
         assert model['organization'] == ''
 
-    def test_it_expands_organizations(self, factories, GroupResource_):  # noqa: N803
+    def test_it_expands_organizations(self, factories, GroupResource_, OrganizationJSONPresenter):  # noqa: N803
         group = factories.OpenGroup(name='My Group',
                                     pubid='mygroup')
         group_resource = GroupResource_(group)
@@ -91,21 +91,18 @@ class TestGroupJSONPresenter(object):
 
         model = presenter.asdict(expand=['organization'])
 
-        assert model['organization'] == {'id': '__default__', 'name': 'Hypothesis'}
+        assert model['organization'] == OrganizationJSONPresenter(group_resource.organization).asdict.return_value
 
-    def test_it_populates_expanded_organizations(self, factories, GroupResource_):  # noqa: N803
+    def test_it_returns_empty_object_when_organization_is_none(self, factories, GroupResource_):  # noqa: N803
         group = factories.OpenGroup(name='My Group',
                                     pubid='mygroup')
-        group.organization = factories.Organization()
+        group.organization = None
         group_resource = GroupResource_(group)
         presenter = GroupJSONPresenter(group_resource)
 
         model = presenter.asdict(expand=['organization'])
 
-        assert model['organization'] == {
-            'name': group.organization.name,
-            'id': group.organization.pubid,
-        }
+        assert model['organization'] == {}
 
     def test_it_ignores_unrecognized_expands(self, factories, GroupResource_):  # noqa: N803
         group = factories.OpenGroup(name='My Group',
@@ -175,3 +172,8 @@ def GroupResources(pyramid_request, links_svc):  # noqa: N802
 @pytest.fixture
 def GroupJSONPresenter_(patch):  # noqa: N802
     return patch('h.presenters.group_json.GroupJSONPresenter')
+
+
+@pytest.fixture
+def OrganizationJSONPresenter(patch):  # noqa: N802
+    return patch('h.presenters.group_json.OrganizationJSONPresenter')

--- a/tests/h/presenters/organization_json_test.py
+++ b/tests/h/presenters/organization_json_test.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import mock
+
+from h.presenters.organization_json import OrganizationJSONPresenter
+from h.resources import OrganizationResource
+
+
+class TestOrganizationJSONPresenter(object):
+    def test_organization_asdict_no_logo(self, factories, pyramid_request):
+        organization = factories.Organization(name='My Org', logo=None)
+        organization_resource = OrganizationResource(organization, pyramid_request)
+
+        presenter = OrganizationJSONPresenter(organization_resource)
+
+        assert presenter.asdict() == {
+            'name': 'My Org',
+            'id': organization.pubid,
+        }
+
+    def test_organization_asdict_with_logo(self, factories, pyramid_request):
+        pyramid_request.route_url = mock.Mock()
+        organization = factories.Organization(name='My Org', logo='<svg>H</svg>')
+        organization_resource = OrganizationResource(organization, pyramid_request)
+
+        presenter = OrganizationJSONPresenter(organization_resource)
+
+        assert presenter.asdict() == {
+            'name': 'My Org',
+            'id': organization.pubid,
+            'logo': pyramid_request.route_url.return_value
+        }


### PR DESCRIPTION
This PR builds on the Resource refactor to be able to deliver the `logo` property on expanded `organization` objects returned from the `GET /api/groups` endpoint.

It introduces an `OrganizationJSONPresenter` for expanding the `organization` resource objects, as well. It updates the docs accordingly.

Fixes https://github.com/hypothesis/product-backlog/issues/539 

(yay!)