### PR TITLE
Remove redundant comments from migration script template

### DIFF
--- a/h/migrations/script.py.mako
+++ b/h/migrations/script.py.mako
@@ -1,9 +1,5 @@
 """
 ${message}
-
-Revision ID: ${up_revision}
-Revises: ${down_revision}
-Create Date: ${create_date}
 """
 
 from __future__ import unicode_literals


### PR DESCRIPTION
The `Revises` and `Revision ID` comments duplicate the `revision` and
`down_revision` declarations below and the `Create Date` duplicates info
in the git commit.

Removing these duplicated comments avoids them getting out of sync,
which has happened in a few PRs following rebasing.