### PR TITLE
Organization Representation in API response: Expanded and not

### DIFF
--- a/docs/_extra/api-reference/schemas/group.yaml
+++ b/docs/_extra/api-reference/schemas/group.yaml
@@ -26,8 +26,7 @@ Group:
       oneOf:
         - $ref: './organization.yaml#/Organization'
         - type: string
-          format: uri
-          description: Link to organization resource
+          description: The unique ID for the organization (when not expanded)
     public:
       type: boolean
       deprecated: true

--- a/docs/_extra/api-reference/schemas/organization.yaml
+++ b/docs/_extra/api-reference/schemas/organization.yaml
@@ -2,9 +2,16 @@ Organization:
   type: object
   required:
     - id
+    - logo
     - name
   properties:
     id:
       type: string
+    logo:
+      oneOf:
+        - type: string
+          format: uri
+          description: URI to logo image
+        - type: null
     name:
       type: string

--- a/h/presenters/group_json.py
+++ b/h/presenters/group_json.py
@@ -2,12 +2,15 @@
 
 from __future__ import unicode_literals
 
+from h.presenters.organization_json import OrganizationJSONPresenter
+
 
 class GroupJSONPresenter(object):
     """Present a group in the JSON format returned by API requests."""
 
     def __init__(self, group_resource):
         self.resource = group_resource
+        self.organization_resource = self.resource.organization
         self.group = group_resource.group
 
     def asdict(self, expand=[]):
@@ -18,21 +21,16 @@ class GroupJSONPresenter(object):
 
     def _expand(self, model, expand=[]):
         if 'organization' in expand:
-            org_model = {}
-            org = self.group.organization
-            if org is not None:
-                org_model = {
-                    'id': org.pubid,
-                    'name': org.name,
-                }
-            model['organization'] = org_model
+            model['organization'] = OrganizationJSONPresenter(
+              self.organization_resource
+            ).asdict()
         return model
 
     def _model(self):
         model = {
+          'id': self.resource.id,
           'name': self.group.name,
-          'id': self.group.pubid,
-          'organization': '',  # unexpanded org; no link available yet, so empty string by default
+          'organization': self.organization_resource.id,
           'public': self.group.is_public,  # DEPRECATED: TODO: remove from client
           'scoped': True if self.group.scopes else False,
           'type': self.group.type

--- a/h/presenters/organization_json.py
+++ b/h/presenters/organization_json.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+
+class OrganizationJSONPresenter(object):
+    """Present an organization in the JSON format returned by API requests."""
+
+    def __init__(self, organization_resource):
+        self.resource = organization_resource
+        self.organization = organization_resource.organization
+
+    def asdict(self):
+        return self._model()
+
+    def _model(self):
+        model = {
+          'id': self.resource.id,
+          'logo': self.resource.logo,
+          'name': self.organization.name,
+        }
+        return model

--- a/h/resources.py
+++ b/h/resources.py
@@ -147,14 +147,16 @@ class GroupResource(object):
         self.links_service = self.request.find_service(name='group_links')
 
     @property
+    def id(self):
+        return self.group.pubid  # Web-facing unique ID for this resource
+
+    @property
     def links(self):
         return self.links_service.get_all(self.group)
 
     @property
     def organization(self):
-        if self.group.organization:
-            return OrganizationResource(self.group.organization, self.request)
-        return None
+        return OrganizationResource(self.group.organization, self.request)
 
 
 class OrganizationResource(object):
@@ -162,6 +164,10 @@ class OrganizationResource(object):
         # TODO Links service
         self.organization = organization
         self.request = request
+
+    @property
+    def id(self):
+        return self.organization.pubid  # Web-facing unique ID for this resource
 
     @property
     def links(self):

--- a/tests/h/presenters/organization_json_test.py
+++ b/tests/h/presenters/organization_json_test.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import pytest
+
+from h.presenters.organization_json import OrganizationJSONPresenter
+from h.resources import OrganizationResource
+
+
+class TestOrganizationJSONPresenter(object):
+    def test_organization_asdict_no_logo(self, factories, pyramid_request):
+        organization = factories.Organization(name='My Org', logo=None)
+        organization_resource = OrganizationResource(organization, pyramid_request)
+
+        presenter = OrganizationJSONPresenter(organization_resource)
+
+        assert presenter.asdict() == {
+            'name': 'My Org',
+            'id': organization.pubid,
+            'logo': None,
+        }
+
+    def test_organization_asdict_with_logo(self, factories, routes, pyramid_request):
+        organization = factories.Organization(name='My Org', logo='<svg>H</svg>')
+        organization_resource = OrganizationResource(organization, pyramid_request)
+
+        presenter = OrganizationJSONPresenter(organization_resource)
+
+        assert presenter.asdict() == {
+            'name': 'My Org',
+            'id': organization_resource.id,
+            'logo': pyramid_request.route_url('organization_logo', pubid=organization.pubid)
+        }
+
+
+@pytest.fixture
+def routes(pyramid_config):
+    pyramid_config.add_route('organization_logo', '/organizations/{pubid}/logo')

--- a/tests/h/resources_test.py
+++ b/tests/h/resources_test.py
@@ -280,6 +280,13 @@ class TestGroupResource(object):
 
         assert group_resource.links == links_svc.get_all.return_value
 
+    def test_it_returns_pubid_as_id(self, factories, pyramid_request):
+        group = factories.Group()
+
+        group_resource = GroupResource(group, pyramid_request)
+
+        assert group_resource.id == group.pubid  # NOT the group.id
+
     def test_it_expands_organization(self, factories, pyramid_request):
         group = factories.Group()
 
@@ -297,6 +304,14 @@ class TestOrganizationResource(object):
         organization_resource = OrganizationResource(organization, pyramid_request)
 
         assert organization_resource.organization == organization
+
+    def test_it_returns_pubid_as_id(self, factories, pyramid_request):
+        organization = factories.Organization()
+
+        organization_resource = OrganizationResource(organization, pyramid_request)
+
+        assert organization_resource.id != organization.id
+        assert organization_resource.id == organization.pubid
 
     def test_it_returns_links_property(self, factories, pyramid_request):
         organization = factories.Organization()


### PR DESCRIPTION
Based on feedback from @robertknight on https://github.com/hypothesis/h/pull/4949 I've done some rework on the API representation of `organization` resources on `group` objects.

The changes this PR introduce are:

* API pieces assume the presence of the non-nullable `organization` relationship on `group` objects instead of testing for its existence in multiple places. If we make changes in the future such that the relationship changes (e.g. is nullable) tests will break and we can fix things then! Over-designing to account for a possible non-extant relationship was polluting the code a bit.
* Adds an `id` property on `GroupResource` and `OrganizationResource` objects. This is the "web-facing ID" and is the `pubid` in both of their cases (the model object itself is a property on resource objects, so you can still get at the original integer ID by referencing, e.g., `group_resource.group.id`, but `group.id` is the group's `pubid`). <-- This seemed like kind of a nice thing to do but feedback is welcome.
* Biggest change: `organization` is now returned as the organization `pubid` when the `organization` is _not_ expanded. This is instead of a weird empty string that was there. The earlier intent was to return a URI (link) to a representation of the `organization` resource—but we don't have a way to do that as there is no exposed service for that. I'd like to _get_ to a link eventually, but in the interim, perhaps returning a pubid is useful? Totes open to feedback as I sort of just added this in and this has implications for API changes/versioning.
* Organization `logo` properties (when organizations are expanded) are now returned as `null` when there is no logo, instead of not returning the property at all.

The above changes are reflected in updated API documentation.

Fixes https://github.com/hypothesis/product-backlog/issues/539