### PR TITLE
Fix serialization of custom OAuth errors to JSON

### DIFF
--- a/h/oauth/errors.py
+++ b/h/oauth/errors.py
@@ -8,17 +8,19 @@ from oauthlib.oauth2 import InvalidGrantError, InvalidRequestFatalError
 class MissingJWTGrantTokenClaimError(InvalidGrantError):
     def __init__(self, claim, claim_description=None):
         if claim_description:
-            self.description = "Missing claim '{}' ({}) from grant token.".format(claim, claim_description)
+            description = "Missing claim '{}' ({}) from grant token.".format(claim, claim_description)
         else:
-            self.description = "Missing claim '{}' from grant token.".format(claim)
+            description = "Missing claim '{}' from grant token.".format(claim)
+        super(MissingJWTGrantTokenClaimError, self).__init__(description=description)
 
 
 class InvalidJWTGrantTokenClaimError(InvalidGrantError):
     def __init__(self, claim, claim_description=None):
         if claim_description:
-            self.description = "Invalid claim '{}' ({}) in grant token.".format(claim, claim_description)
+            description = "Invalid claim '{}' ({}) in grant token.".format(claim, claim_description)
         else:
-            self.description = "Invalid claim '{}' in grant token.".format(claim)
+            description = "Invalid claim '{}' in grant token.".format(claim)
+        super(InvalidJWTGrantTokenClaimError, self).__init__(description=description)
 
 
 class InvalidRefreshTokenError(InvalidRequestFatalError):

--- a/tests/h/oauth/errors_test.py
+++ b/tests/h/oauth/errors_test.py
@@ -2,6 +2,8 @@
 
 from __future__ import unicode_literals
 
+from json import loads
+
 from h.oauth.errors import (
     InvalidJWTGrantTokenClaimError,
     MissingJWTGrantTokenClaimError,
@@ -17,6 +19,11 @@ class TestMissingJWTGrantTokenClaimError(object):
         exc = MissingJWTGrantTokenClaimError('iss')
         assert exc.description == "Missing claim 'iss' from grant token."
 
+    def test_serializes_to_json(self):
+        exc = MissingJWTGrantTokenClaimError('iss')
+        assert loads(exc.json) == {'error': 'invalid_grant',
+                                   'error_description': "Missing claim 'iss' from grant token."}
+
 
 class TestInvalidJWTGrantTokenClaimError(object):
     def test_sets_correct_description_with_claim_description(self):
@@ -26,3 +33,8 @@ class TestInvalidJWTGrantTokenClaimError(object):
     def test_sets_correct_description_without_claim_description(self):
         exc = InvalidJWTGrantTokenClaimError('iss')
         assert exc.description == "Invalid claim 'iss' in grant token."
+
+    def test_serializes_to_json(self):
+        exc = InvalidJWTGrantTokenClaimError('iss')
+        assert loads(exc.json) == {'error': 'invalid_grant',
+                                   'error_description': "Invalid claim 'iss' in grant token."}


### PR DESCRIPTION
The custom error classes overrode `__init__` but did not call the
base-class implementation, causing the instances not to be completely
initialized. This later caused an exception when attempting to serialize
the error to JSON.

Fixes #4957