### PR TITLE
Update getfuncargvalue -> getfixturevalue

### DIFF
--- a/tests/h/views/activity_test.py
+++ b/tests/h/views/activity_test.py
@@ -1113,7 +1113,7 @@ class TestGroupAndUserSearchController(object):
         UserSearchController instance as the controller argument, and once with
         a GroupSearchController.
         """
-        return request.getfuncargvalue(request.param)
+        return request.getfixturevalue(request.param)
 
     @pytest.fixture
     def group_search_controller(self, group, pyramid_request):


### PR DESCRIPTION
getfuncargvalue was deprecated in pytest 3.0.0:

* https://docs.pytest.org/en/latest/changelog.html?highlight=getfuncargvalue#id329
* https://github.com/pytest-dev/pytest/pull/1626

The latest, which we use, is pytest 3.5.0.