### PR TITLE
2to3: Replace im_self with __self__

### DIFF
--- a/h/websocket.py
+++ b/h/websocket.py
@@ -111,7 +111,7 @@ class GEventWebSocketPool(Pool):
         log.info("terminating server and all connected websockets")
         for greenlet in list(self):
             try:
-                websocket = greenlet._run.im_self
+                websocket = greenlet._run.__self__
                 if websocket:
                     websocket.close(1001, 'Server is shutting down')
             except:  # noqa: E722


### PR DESCRIPTION
`im_self` has been renamed to `__self__` in Python 3, and `__self__` has been backported to 2.