### PR TITLE
Change annotation body wrapper element from `p` to `div`

### DIFF
--- a/h/templates/includes/annotation_card.html.jinja2
+++ b/h/templates/includes/annotation_card.html.jinja2
@@ -51,9 +51,9 @@
       {{ presented_annotation.annotation.quote }}
     </blockquote>
   {% endif %}
-  <p class="annotation-card__text">
+  <div class="annotation-card__text">
     {{ presented_annotation.annotation.text_rendered }}
-  </p>
+  </div>
   <div title="Tags" class="annotation-card__tags">
     {% for tag in presented_annotation.annotation.tags%}
       <a class="annotation-card__tag" href="{{ tag_link(tag) }}">


### PR DESCRIPTION
The wrapper element applied to annotation body content on activity pages
used a `p` tag. The actual body content itself usually consists of a
series of `p` elements. Since `p` elements cannot be nested, this meant
that the resulting DOM structure looked like this:

```html
<p class="annotation-card__text"></p>
<p><!-- First para of body !--></p>
<p><!-- Second para of body !--></p>
```

Instead of the intended result:

```html
<p class="annotation-card__text">
    <p><!-- First para of body !--></p>
    <p><!-- Second para of body !--></p>
</p>
```

Changing this to an element which can contain `p` children allows
the `annotation-card__text` styling to apply, which makes the rendering
more consistent with annotation bodies in the client, since the client
and h share the `styled-text` mixin which applies most of the styling.

This also fixes an issue where images could overflow annotation bodies
due to the `max-width: 100%` rule for images from `styled-text` not
being applied.

Fixes #4566