### PR TITLE
Unicode literals

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,7 @@ test-py3: node_modules/.uptodate
 lint: .pydeps
 	flake8 h
 	flake8 tests
+	flake8 --select FI14 --exclude 'h/cli/*,tests/h/cli/*,h/migrations/versions/*' h tests
 
 ################################################################################
 

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ test-py3: node_modules/.uptodate
 lint: .pydeps
 	flake8 h
 	flake8 tests
-	flake8 --select FI14 --exclude 'h/cli/*,tests/h/cli/*,h/migrations/versions/*' h tests
+	flake8 --select FI14 --exclude 'h/cli/*,tests/h/cli/*,h/util/uri.py,h/migrations/versions/*' h tests
 
 ################################################################################
 

--- a/h/__init__.py
+++ b/h/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 from h._version import get_version
 
 __all__ = ('__version__',)

--- a/h/__main__.py
+++ b/h/__main__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 from h.cli import main
 
 if __name__ == '__main__':

--- a/h/_compat.py
+++ b/h/_compat.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Helpers for the Python 2 to Python 3 transition."""
+from __future__ import unicode_literals
 
 import sys
 

--- a/h/_compat.py
+++ b/h/_compat.py
@@ -57,3 +57,43 @@ try:
     from StringIO import StringIO
 except ImportError:
     from io import StringIO
+
+
+# native() function adapted from Pyramid:
+# https://github.com/Pylons/pyramid/blob/a851d05f76edc6bc6bf65269c20eeba7fe726ade/pyramid/compat.py#L78-L95
+if PY2:
+    def native(s, encoding='latin-1', errors='strict'):
+        """
+        Return the given string as a Python 2 native string (a byte string).
+
+        If the given string is a unicode string then return it as a byte
+        string (Latin 1 encoded by default).
+
+        If the given string is already a byte string (in any encoding) just
+        return it unmodified.
+
+        Latin 1 encoding is used by default because that's the encoding used
+        for "native" strings in PEP-3333 (the WSGI spec).
+
+        """
+        if isinstance(s, unicode):
+            return s.encode(encoding, errors)
+        return s
+else:
+    def native(s, encoding='latin-1', errors='strict'):
+        """
+        Return the given string as a Python 3 native string (a unicode string).
+
+        If the given string is a byte string then return it decoded to unicode
+        (using Latin 1 by default).
+
+        If the given string is already a unicode string then just return it
+        unmodified.
+
+        Latin 1 encoding is used by default because that's the encoding used
+        for "native" strings in PEP-3333 (the WSGI spec).
+
+        """
+        if isinstance(s, str):
+            return s
+        return str(s, encoding, errors)

--- a/h/_version.py
+++ b/h/_version.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 import datetime
 import subprocess
 

--- a/h/accounts/__init__.py
+++ b/h/accounts/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals
 from itsdangerous import URLSafeTimedSerializer
 
 from h.security import derive_key

--- a/h/accounts/events.py
+++ b/h/accounts/events.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+
 class ActivationEvent(object):
     def __init__(self, request, user):
         self.request = request

--- a/h/accounts/schemas.py
+++ b/h/accounts/schemas.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals
 from codecs import open
 import logging
 

--- a/h/accounts/util.py
+++ b/h/accounts/util.py
@@ -1,6 +1,7 @@
 """
 Helpers for account forms
 """
+from __future__ import unicode_literals
 
 import re
 

--- a/h/activity/__init__.py
+++ b/h/activity/__init__.py
@@ -1,1 +1,2 @@
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals

--- a/h/app.py
+++ b/h/app.py
@@ -56,6 +56,7 @@ def includeme(config):
     config.add_tween('h.tweens.invalid_path_tween_factory')
     config.add_tween('h.tweens.security_header_tween_factory')
     config.add_tween('h.tweens.cache_header_tween_factory')
+    config.add_tween('h.tweens.encode_headers_tween_factory')
 
     config.add_request_method(in_debug_mode, 'debug', reify=True)
 

--- a/h/assets.py
+++ b/h/assets.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals
 import os
 
 import json

--- a/h/auth/__init__.py
+++ b/h/auth/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 """Authentication configuration."""
+from __future__ import unicode_literals
 
 import logging
 

--- a/h/auth/policy.py
+++ b/h/auth/policy.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 from pyramid import interfaces
 from pyramid.authentication import CallbackAuthenticationPolicy
 from zope import interface

--- a/h/auth/role.py
+++ b/h/auth/role.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 #: Administrators. These users have super cow powers.
+from __future__ import unicode_literals
 Admin = 'group:__admin__'
 
 #: Hypothesis staff. These users have limited access to admin functionality.

--- a/h/auth/tokens.py
+++ b/h/auth/tokens.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 import datetime
 
 from zope.interface import implementer

--- a/h/auth/util.py
+++ b/h/auth/util.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 import base64
 
 from pyramid import security

--- a/h/authz.py
+++ b/h/authz.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 """Authorization configuration."""
+from __future__ import unicode_literals
 
 from pyramid.authorization import ACLAuthorizationPolicy
 

--- a/h/celery.py
+++ b/h/celery.py
@@ -9,6 +9,7 @@ integrates it with the Pyramid application by attaching a bootstrapped fake
 """
 
 from __future__ import absolute_import
+from __future__ import unicode_literals
 
 from datetime import timedelta
 import logging

--- a/h/db/__init__.py
+++ b/h/db/__init__.py
@@ -12,6 +12,7 @@ application startup.
 Most application code should access the database session using the request
 property `request.db` which is provided by this module.
 """
+from __future__ import unicode_literals
 
 import logging
 

--- a/h/db/__init__.py
+++ b/h/db/__init__.py
@@ -131,7 +131,7 @@ def _maybe_create_default_organization(engine, authority):
         default_org = None
 
     if default_org is None:
-        default_org = models.Organization(name=u'Hypothesis',
+        default_org = models.Organization(name='Hypothesis',
                                           authority=authority,
                                           pubid='__default__',
                                           )
@@ -151,7 +151,7 @@ def _maybe_create_world_group(engine, authority, default_org):
     session = Session(bind=engine)
     world_group = session.query(models.Group).filter_by(pubid='__world__').one_or_none()
     if world_group is None:
-        world_group = models.Group(name=u'Public',
+        world_group = models.Group(name='Public',
                                    authority=authority,
                                    joinable_by=None,
                                    readable_by=ReadableBy.world,

--- a/h/db/types.py
+++ b/h/db/types.py
@@ -195,11 +195,11 @@ def _escape_null_byte(s):
     if s is None:
         return s
 
-    return s.replace(u"\u0000", u"\\u0000")
+    return s.replace("\u0000", "\\u0000")
 
 
 def _unescape_null_byte(s):
     if s is None:
         return s
 
-    return s.replace(u"\\u0000", u"\u0000")
+    return s.replace("\\u0000", "\u0000")

--- a/h/db/types.py
+++ b/h/db/types.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 """Custom SQLAlchemy types for use with the Annotations API database."""
+from __future__ import unicode_literals
 
 from h._compat import string_types
 import binascii

--- a/h/emails/__init__.py
+++ b/h/emails/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 from h.emails import reply_notification, reset_password, signup
 
 __all__ = (

--- a/h/eventqueue.py
+++ b/h/eventqueue.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 import collections
 import logging
 

--- a/h/events.py
+++ b/h/events.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals
 
 
 class AnnotationEvent(object):

--- a/h/feeds/atom.py
+++ b/h/feeds/atom.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Functions for generating Atom feeds."""
+from __future__ import unicode_literals
 from pyramid import i18n
 
 from h import presenters

--- a/h/feeds/render.py
+++ b/h/feeds/render.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from pyramid import renderers
 
 from h.feeds import atom

--- a/h/feeds/rss.py
+++ b/h/feeds/rss.py
@@ -1,4 +1,5 @@
 """Functions for generating RSS feeds."""
+from __future__ import unicode_literals
 
 from calendar import timegm
 from email.utils import formatdate

--- a/h/feeds/util.py
+++ b/h/feeds/util.py
@@ -1,4 +1,5 @@
 """Utility functions for feed-generating code."""
+from __future__ import unicode_literals
 from h._compat import urlparse
 
 # See RFC4151 for details of the use and format of the tag date:

--- a/h/feeds/util.py
+++ b/h/feeds/util.py
@@ -19,6 +19,6 @@ def tag_uri_for_annotation(annotation, annotation_url):
 
     """
     domain = urlparse.urlparse(annotation_url(annotation)).hostname
-    return u"tag:{domain},{date}:{id_}".format(domain=domain,
-                                               date=FEED_TAG_DATE,
-                                               id_=annotation.id)
+    return "tag:{domain},{date}:{id_}".format(domain=domain,
+                                              date=FEED_TAG_DATE,
+                                              id_=annotation.id)

--- a/h/form.py
+++ b/h/form.py
@@ -7,6 +7,7 @@ form templates in preference to the defaults. Uses `deform_jinja2` to provide
 the fallback templates in Jinja2 format, which we can then extend and modify as
 necessary.
 """
+from __future__ import unicode_literals
 import deform
 import jinja2
 from pyramid import httpexceptions

--- a/h/groups/__init__.py
+++ b/h/groups/__init__.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
+
 
 def includeme(config):
     config.add_search_filter('h.groups.search.GroupAuthFilter')

--- a/h/groups/schemas.py
+++ b/h/groups/schemas.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 import colander
 import deform
 

--- a/h/i18n.py
+++ b/h/i18n.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals
 from pyramid.i18n import TranslationStringFactory
 
 TranslationString = TranslationStringFactory('hypothesis')

--- a/h/indexer/__init__.py
+++ b/h/indexer/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 from h.indexer.reindexer import reindex
 
 __all__ = (

--- a/h/indexer/reindexer.py
+++ b/h/indexer/reindexer.py
@@ -12,7 +12,7 @@ from h.search.index import BatchIndexer
 
 log = logging.getLogger(__name__)
 
-SETTING_NEW_INDEX = u'reindex.new_index'
+SETTING_NEW_INDEX = 'reindex.new_index'
 
 
 def reindex(session, es, request):

--- a/h/indexer/reindexer.py
+++ b/h/indexer/reindexer.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 import logging
 
 from h.search.config import (

--- a/h/indexer/subscribers.py
+++ b/h/indexer/subscribers.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 from h.tasks.indexer import add_annotation, delete_annotation
 
 

--- a/h/jinja_extensions.py
+++ b/h/jinja_extensions.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 import datetime
 from functools import partial
 import json

--- a/h/jinja_extensions.py
+++ b/h/jinja_extensions.py
@@ -59,10 +59,10 @@ def to_json(value):
 
     # Adapted from Flask's htmlsafe_dumps() function / tojson filter.
     result = json.dumps(value) \
-                 .replace(u'<', u'\\u003c') \
-                 .replace(u'>', u'\\u003e') \
-                 .replace(u'&', u'\\u0026') \
-                 .replace(u"'", u'\\u0027')
+                 .replace('<', '\\u003c') \
+                 .replace('>', '\\u003e') \
+                 .replace('&', '\\u0026') \
+                 .replace("'", '\\u0027')
 
     return Markup(result)
 

--- a/h/links.py
+++ b/h/links.py
@@ -3,6 +3,7 @@
 """
 Provides links to different representations of annotations.
 """
+from __future__ import unicode_literals
 
 
 from h._compat import urlparse, url_unquote

--- a/h/migrations/env.py
+++ b/h/migrations/env.py
@@ -1,4 +1,5 @@
 from __future__ import with_statement
+from __future__ import unicode_literals
 
 import logging
 import os

--- a/h/models/__init__.py
+++ b/h/models/__init__.py
@@ -17,6 +17,7 @@ key to. So for convenience the test module can instead just do
 ``from h import models`` and have all ORM classes be defined.
 
 """
+from __future__ import unicode_literals
 
 from h.models.activation import Activation
 from h.models.annotation import Annotation

--- a/h/models/activation.py
+++ b/h/models/activation.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 import hashlib
 import random
 import string

--- a/h/models/blocklist.py
+++ b/h/models/blocklist.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals
 import sqlalchemy as sa
 from sqlalchemy.sql import expression
 

--- a/h/models/group.py
+++ b/h/models/group.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 from collections import namedtuple
 
 import enum

--- a/h/models/organization.py
+++ b/h/models/organization.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 import sqlalchemy as sa
 from xml.etree import ElementTree
 

--- a/h/models/subscriptions.py
+++ b/h/models/subscriptions.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals
 import sqlalchemy as sa
 from sqlalchemy import func
 

--- a/h/models/user.py
+++ b/h/models/user.py
@@ -204,8 +204,8 @@ class User(Base):
 
     @hybrid_property
     def userid(self):
-        return u'acct:{username}@{authority}'.format(username=self.username,
-                                                     authority=self.authority)
+        return 'acct:{username}@{authority}'.format(username=self.username,
+                                                    authority=self.authority)
 
     @userid.comparator
     def userid(cls):  # noqa: N805

--- a/h/models/user.py
+++ b/h/models/user.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 import datetime
 import re
 

--- a/h/nipsa/__init__.py
+++ b/h/nipsa/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals
 
 
 def includeme(config):

--- a/h/nipsa/search.py
+++ b/h/nipsa/search.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals
 
 
 class Filter(object):

--- a/h/notification/__init__.py
+++ b/h/notification/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals
 from webob.cookies import SignedSerializer
 
 from ..security import derive_key

--- a/h/notification/reply.py
+++ b/h/notification/reply.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 from collections import namedtuple
 import logging
 

--- a/h/paginator.py
+++ b/h/paginator.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import division
+from __future__ import unicode_literals
 
 import functools
 import math

--- a/h/panels/__init__.py
+++ b/h/panels/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals
 
 
 def includeme(config):

--- a/h/realtime.py
+++ b/h/realtime.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 import base64
 import random
 import struct

--- a/h/schemas/__init__.py
+++ b/h/schemas/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 """Classes for validating data supplied to the application."""
+from __future__ import unicode_literals
 
 from h.schemas.base import ValidationError
 

--- a/h/schemas/annotation.py
+++ b/h/schemas/annotation.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Classes for validating data passed to the annotations API."""
+from __future__ import unicode_literals
 
 import copy
 from pyramid import i18n

--- a/h/schemas/annotation.py
+++ b/h/schemas/annotation.py
@@ -145,14 +145,14 @@ class CreateAnnotationSchema(object):
 
         new_appstruct['userid'] = self.request.authenticated_userid
 
-        uri = appstruct.pop('uri', u'').strip()
+        uri = appstruct.pop('uri', '').strip()
         if not uri:
             raise ValidationError('uri: ' + _("'uri' is a required property"))
         new_appstruct['target_uri'] = uri
 
-        new_appstruct['text'] = appstruct.pop('text', u'')
+        new_appstruct['text'] = appstruct.pop('text', '')
         new_appstruct['tags'] = appstruct.pop('tags', [])
-        new_appstruct['groupid'] = appstruct.pop('group', u'__world__')
+        new_appstruct['groupid'] = appstruct.pop('group', '__world__')
         new_appstruct['references'] = appstruct.pop('references', [])
 
         if 'permissions' in appstruct:

--- a/h/search/__init__.py
+++ b/h/search/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 from h.search.client import get_client
 from h.search.config import init
 from h.search.core import Search

--- a/h/search/client.py
+++ b/h/search/client.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 import certifi
 from elasticsearch import Elasticsearch, RequestsHttpConnection
 from requests_aws4auth import AWS4Auth

--- a/h/search/core.py
+++ b/h/search/core.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals
 import logging
 from collections import namedtuple
 from contextlib import contextmanager

--- a/h/search/query.py
+++ b/h/search/query.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 from h import storage
 from h.util import uri
 

--- a/h/sentry.py
+++ b/h/sentry.py
@@ -7,6 +7,7 @@ context, as a request property, `request.sentry`. This allows us to more easily
 log exceptions from within the application with a useful complement of
 diagnostic data.
 """
+from __future__ import unicode_literals
 
 import raven
 from raven.transport import GeventedHTTPTransport

--- a/h/services/group.py
+++ b/h/services/group.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 from functools import partial
 
 import sqlalchemy as sa

--- a/h/services/list_groups.py
+++ b/h/services/list_groups.py
@@ -191,7 +191,7 @@ class ListGroupsService(object):
         return (self._session.query(models.Group)
                     .filter_by(authority=authority,
                                readable_by=group.ReadableBy.world,
-                               pubid=u'__world__')
+                               pubid='__world__')
                     .one_or_none())
 
 

--- a/h/services/nipsa.py
+++ b/h/services/nipsa.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 from h.models import User
 from h.tasks.indexer import reindex_user_annotations
 

--- a/h/services/organization.py
+++ b/h/services/organization.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 from h.models import Organization
 
 

--- a/h/session.py
+++ b/h/session.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 from pyramid.session import SignedCookieSessionFactory
 
 from h.security import derive_key

--- a/h/stats.py
+++ b/h/stats.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals
 import statsd
 
 __all__ = ('get_client',)

--- a/h/storage.py
+++ b/h/storage.py
@@ -6,6 +6,7 @@ This module provides the core API with access to basic persistence functions
 for storing and retrieving annotations. Data passed to these functions is
 assumed to be validated.
 """
+from __future__ import unicode_literals
 
 # FIXME: This module was originally written to be a single point of
 #        indirection through which the storage backend could be swapped out on

--- a/h/streamer/__init__.py
+++ b/h/streamer/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals
 
 
 def includeme(config):

--- a/h/streamer/filter.py
+++ b/h/streamer/filter.py
@@ -209,4 +209,4 @@ def uni_fold(text):
 
     text = text.lower()
     text = unicodedata.normalize('NFKD', text)
-    return u"".join([c for c in text if not unicodedata.combining(c)])
+    return "".join([c for c in text if not unicodedata.combining(c)])

--- a/h/streamer/filter.py
+++ b/h/streamer/filter.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 import copy
 import operator
 import unicodedata

--- a/h/streamer/messages.py
+++ b/h/streamer/messages.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 from collections import namedtuple
 import logging
 

--- a/h/streamer/streamer.py
+++ b/h/streamer/streamer.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 import logging
 import sys
 

--- a/h/streamer/views.py
+++ b/h/streamer/views.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 from pyramid.view import forbidden_view_config
 from pyramid.view import notfound_view_config
 from pyramid.view import view_config

--- a/h/streamer/websocket.py
+++ b/h/streamer/websocket.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 from collections import namedtuple
 import copy
 import json

--- a/h/subscribers.py
+++ b/h/subscribers.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 
+from __future__ import unicode_literals
 from h import __version__
 from h import emails
 from h import storage

--- a/h/tasks/__init__.py
+++ b/h/tasks/__init__.py
@@ -1,3 +1,4 @@
 # -*- coding: utf-8 -*-
 
 """Background worker task definitions for the h application."""
+from __future__ import unicode_literals

--- a/h/tasks/indexer.py
+++ b/h/tasks/indexer.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 from h import models, storage
 from h.celery import celery, get_task_logger
 from h.indexer.reindexer import SETTING_NEW_INDEX

--- a/h/tasks/mailer.py
+++ b/h/tasks/mailer.py
@@ -4,6 +4,7 @@ A module for sending email.
 
 This module defines a Celery task for sending emails in a worker process.
 """
+from __future__ import unicode_literals
 
 import smtplib
 

--- a/h/tweens.py
+++ b/h/tweens.py
@@ -8,6 +8,7 @@ from codecs import open
 from pyramid import httpexceptions
 from pyramid.util import DottedNameResolver
 
+from h._compat import native
 from h.util.redirects import parse as parse_redirects
 from h.util.redirects import lookup as lookup_redirects
 
@@ -143,3 +144,40 @@ def cache_header_tween_factory(handler, registry):
         return resp
 
     return cache_header_tween
+
+
+def encode_headers_tween_factory(handler, registry):
+    """
+    Convert HTTP response headers to native strings.
+
+    The WSGI spec (https://www.python.org/dev/peps/pep-3333/) requires all
+    HTTP response header names and values to be "native" strings:
+
+    * Byte strings in Python 2
+    * Unicode strings in Python 3
+
+    Since string literals are byte strings in Python 2 and are unicode strings
+    in Python 3, using string literals for header values (as in
+    ``response.headers["Access-Control-Allow-Origin"] = "*"``) works fine in
+    either Python 2 or 3.
+
+    But once you add ``from __future__ import unicode_literals`` to a source
+    code file the string literals become unicode strings in Python 2, and
+    violate PEP-3333. This violation causes ``AssertionError``s from WebTest,
+    and may cause problems with WSGI servers.
+
+    This tween fixes that by converting all header names and values to native
+    strings.
+
+    TODO: Remove this tween once we no longer support Python 2.
+
+    """
+    def encode_headers_tween(request):
+        resp = handler(request)
+        for key in list(resp.headers.keys()):
+            values = resp.headers.getall(key)
+            del resp.headers[key]
+            for value in values:
+                resp.headers.add(native(key), native(value))
+        return resp
+    return encode_headers_tween

--- a/h/tweens.py
+++ b/h/tweens.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 import collections
 import logging
 from codecs import open

--- a/h/tweens.py
+++ b/h/tweens.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 from __future__ import unicode_literals
 import collections
 import logging

--- a/h/util/__init__.py
+++ b/h/util/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 from h.util import db
 from h.util import user
 from h.util import view

--- a/h/util/cors.py
+++ b/h/util/cors.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals
 from pyramid.httpexceptions import HTTPBadRequest
 from pyramid.response import Response
 

--- a/h/util/datetime.py
+++ b/h/util/datetime.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 """Shared utility functions for manipulating dates and times."""
+from __future__ import unicode_literals
 
 
 def utc_iso8601(datetime):

--- a/h/util/document_claims.py
+++ b/h/util/document_claims.py
@@ -265,7 +265,7 @@ def document_uri_self_claim(claimant):
     return {
         'claimant': claimant,
         'uri': claimant,
-        'type': u'self-claim',
+        'type': 'self-claim',
         'content_type': '',
     }
 

--- a/h/util/logging_filters.py
+++ b/h/util/logging_filters.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Logging Filters."""
+from __future__ import unicode_literals
 
 import logging
 

--- a/h/util/query.py
+++ b/h/util/query.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 """Database query utilities."""
+from __future__ import unicode_literals
 
 import sqlalchemy as sa
 

--- a/h/util/redirects.py
+++ b/h/util/redirects.py
@@ -23,6 +23,7 @@ The redirect type can be one of the following:
 Lines that contain only whitespace, or which start with a '#' character, will
 be ignored.
 """
+from __future__ import unicode_literals
 
 from collections import namedtuple
 

--- a/h/util/session_tracker.py
+++ b/h/util/session_tracker.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from copy import copy
 from enum import Enum
 

--- a/h/util/uri.py
+++ b/h/util/uri.py
@@ -62,6 +62,7 @@ This package is responsible for defining URI normalization routines for use
 elsewhere in the Hypothesis application. URI expansion is handled by
 :py:function:`h.storage.expand_uri`.
 """
+from __future__ import unicode_literals
 
 import re
 

--- a/h/util/uri.py
+++ b/h/util/uri.py
@@ -62,8 +62,6 @@ This package is responsible for defining URI normalization routines for use
 elsewhere in the Hypothesis application. URI expansion is handled by
 :py:function:`h.storage.expand_uri`.
 """
-from __future__ import unicode_literals
-
 import re
 
 from h._compat import (

--- a/h/util/user.py
+++ b/h/util/user.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Some shared utility functions for manipulating user data."""
+from __future__ import unicode_literals
 import re
 
 

--- a/h/viewpredicates.py
+++ b/h/viewpredicates.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 """Custom Pyramid view predicates."""
+from __future__ import unicode_literals
 
 
 class FeaturePredicate(object):

--- a/h/views/__init__.py
+++ b/h/views/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals
 
 
 def includeme(config):

--- a/h/views/accounts.py
+++ b/h/views/accounts.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 import datetime
 import itertools
 

--- a/h/views/admin_admins.py
+++ b/h/views/admin_admins.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 from pyramid import httpexceptions
 from pyramid.view import view_config
 

--- a/h/views/admin_badge.py
+++ b/h/views/admin_badge.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 from pyramid import httpexceptions
 from pyramid.view import view_config
 from sqlalchemy.exc import IntegrityError

--- a/h/views/admin_features.py
+++ b/h/views/admin_features.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 from pyramid import httpexceptions
 from pyramid.view import view_config
 

--- a/h/views/admin_index.py
+++ b/h/views/admin_index.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 import platform
 
 from pyramid.view import view_config

--- a/h/views/admin_nipsa.py
+++ b/h/views/admin_nipsa.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 from pyramid import httpexceptions
 from pyramid.view import view_config
 

--- a/h/views/admin_oauthclients.py
+++ b/h/views/admin_oauthclients.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 from pyramid.httpexceptions import HTTPFound
 from pyramid.view import view_config, view_defaults
 

--- a/h/views/admin_staff.py
+++ b/h/views/admin_staff.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 from pyramid import httpexceptions
 from pyramid.view import view_config
 

--- a/h/views/api.py
+++ b/h/views/api.py
@@ -16,6 +16,7 @@ particular, requests to the CRUD API endpoints are protected by the Pyramid
 authorization system. You can find the mapping between annotation "permissions"
 objects and Pyramid ACLs in :mod:`h.resources`.
 """
+from __future__ import unicode_literals
 from pyramid import i18n
 from pyramid import security
 

--- a/h/views/api_config.py
+++ b/h/views/api_config.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import venusian
 
 from h.util import cors

--- a/h/views/groups.py
+++ b/h/views/groups.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 import deform
 from pyramid import httpexceptions
 from pyramid import security

--- a/h/views/notification.py
+++ b/h/views/notification.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 from pyramid.httpexceptions import HTTPNotFound
 from pyramid.view import view_config
 

--- a/h/websocket.py
+++ b/h/websocket.py
@@ -35,6 +35,7 @@ N.B. Portions of the ws4py code are used here under the terms of the MIT
 license distributed with the ws4py project. Such code remains copyright (c)
 2011-2015, Sylvain Hellegouarch.
 """
+from __future__ import unicode_literals
 
 import logging
 

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -1,6 +1,7 @@
 -r requirements.txt
 
 flake8
+flake8-future-import
 honcho
 pep257
 prospector[with_pyroma]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,18 @@
 [flake8]
 exclude = h/migrations/versions/*
 max-line-length = 160
+ignore = \
+    # Rules that flake8 ignores by default (we have to put these in our `ignore`
+    # setting otherwise they would be un-ignored).
+    E121,E123,E126,E226,E24,E704,W503,W504 \
+
+    # flake8-future-import's "__future__ import “*” missing' rules. We run a
+    # separate flake8 command to run these rules because we want them to ignore
+    # certain files, so disable them for our general flake8 command.
+    #
+    # This also disables flake8-future-import's '__future__ import “*” present'
+    # rules. These will become useful once we've moved to Python 3.
+    FI
 
 [isort]
 include_trailing_comma = True

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals

--- a/tests/common/__init__.py
+++ b/tests/common/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals

--- a/tests/common/factories/__init__.py
+++ b/tests/common/factories/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 """Factory classes for easily generating test objects."""
+from __future__ import unicode_literals
 
 from .base import set_session
 

--- a/tests/common/factories/activation.py
+++ b/tests/common/factories/activation.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 from h import models
 
 from .base import ModelFactory

--- a/tests/common/factories/annotation_moderation.py
+++ b/tests/common/factories/annotation_moderation.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 import factory
 
 from h import models

--- a/tests/common/factories/base.py
+++ b/tests/common/factories/base.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 import factory
 import faker
 

--- a/tests/common/matchers.py
+++ b/tests/common/matchers.py
@@ -171,7 +171,6 @@ class unordered_list(Matcher):  # noqa: N801
     (and no more), regardless of order.
 
     """
-
     def __init__(self, items):
         self.items = items
 

--- a/tests/common/matchers.py
+++ b/tests/common/matchers.py
@@ -26,6 +26,7 @@ output if it fails, e.g.
     E       Actual call: set_value('a string')
 
 """
+from __future__ import unicode_literals
 
 import re
 

--- a/tests/common/matchers.py
+++ b/tests/common/matchers.py
@@ -50,6 +50,38 @@ class any_callable(Matcher):  # noqa: N801
         return callable(other)
 
 
+class native_string(Matcher):  # noqa: N801
+    """
+    Matches any native string with the given characters.
+
+    "Native string" means the ``str`` type which is a byte string in Python 2
+    and a unicode string in Python 3. Does not match unicode strings (type
+    ``unicode``) in Python 2, or byte strings (type ``bytes``) in Python 3,
+    even if they contain the same characters.
+
+    In Python 3 a ``bytes`` is never ``==`` to a ``str`` anyway, even if they
+    contain the same characters. But in Python 2 a ``str`` is equal to a
+    ``unicode`` if they contain the same characters, and that's why this
+    matcher is needed.
+
+    TODO: Delete this matcher once we no longer support Python 2.
+
+    """
+    def __init__(self, string):
+        self.string = str(string)
+
+    def __eq__(self, other):
+        if not isinstance(other, str):
+            return False
+        return other == self.string
+
+    def __repr__(self):
+        return '<native string matching "{string}">'.format(string=self.string)
+
+    def lower(self):
+        return native_string(self.string.lower())
+
+
 class instance_of(Matcher):  # noqa: N801
     """An object __eq__ to any object which is an instance of `type_`."""
 

--- a/tests/common/matchers.py
+++ b/tests/common/matchers.py
@@ -181,3 +181,6 @@ class unordered_list(Matcher):  # noqa: N801
             if item not in other:
                 return False
         return True
+
+    def __repr__(self):
+        return "<unordered list containing {items}".format(items=self.items)

--- a/tests/functional/__init__.py
+++ b/tests/functional/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 import contextlib
 import os
 

--- a/tests/h/__init__.py
+++ b/tests/h/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals

--- a/tests/h/accounts/__init__.py
+++ b/tests/h/accounts/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals

--- a/tests/h/accounts/__init___test.py
+++ b/tests/h/accounts/__init___test.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals
 import mock
 import pytest
 

--- a/tests/h/accounts/schemas_test.py
+++ b/tests/h/accounts/schemas_test.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals
 import colander
 import pytest
 from mock import Mock

--- a/tests/h/accounts/util_test.py
+++ b/tests/h/accounts/util_test.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import pytest
 
 from h.accounts.util import validate_orcid, validate_url

--- a/tests/h/admin/__init__.py
+++ b/tests/h/admin/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals

--- a/tests/h/assets_test.py
+++ b/tests/h/assets_test.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 from sys import version_info
 from h._compat import StringIO
 

--- a/tests/h/auth/__init__.py
+++ b/tests/h/auth/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals

--- a/tests/h/auth/policy_test.py
+++ b/tests/h/auth/policy_test.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 import mock
 import pytest
 

--- a/tests/h/auth/tokens_test.py
+++ b/tests/h/auth/tokens_test.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 import datetime
 
 import jwt

--- a/tests/h/auth/util_test.py
+++ b/tests/h/auth/util_test.py
@@ -176,7 +176,7 @@ class TestAuthDomain(object):
 
     def test_it_allows_overriding_request_domain(self, pyramid_request):
         pyramid_request.registry.settings['h.authority'] = 'foo.org'
-        assert util.authority(pyramid_request) == u'foo.org'
+        assert util.authority(pyramid_request) == 'foo.org'
 
     def test_it_returns_text_type(self, pyramid_request):
         pyramid_request.domain = str(pyramid_request.domain)

--- a/tests/h/badge/__init__.py
+++ b/tests/h/badge/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals

--- a/tests/h/celery_test.py
+++ b/tests/h/celery_test.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 import logging
 
 import mock

--- a/tests/h/cli/__init__.py
+++ b/tests/h/cli/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals

--- a/tests/h/cli/commands/__init__.py
+++ b/tests/h/cli/commands/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals

--- a/tests/h/config_test.py
+++ b/tests/h/config_test.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 import pytest
 
 from h.config import configure

--- a/tests/h/conftest.py
+++ b/tests/h/conftest.py
@@ -25,7 +25,7 @@ from h import models
 from h.settings import database_url
 from h._compat import text_type
 
-TEST_AUTHORITY = u'example.com'
+TEST_AUTHORITY = 'example.com'
 TEST_DATABASE_URL = database_url(os.environ.get('TEST_DATABASE_URL',
                                                 'postgresql://postgres@localhost/htest'))
 

--- a/tests/h/conftest.py
+++ b/tests/h/conftest.py
@@ -4,6 +4,7 @@
 The `conftest` module is automatically loaded by pytest and serves as a place
 to put fixture functions that are useful application-wide.
 """
+from __future__ import unicode_literals
 
 import functools
 import os

--- a/tests/h/db/__init__.py
+++ b/tests/h/db/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals

--- a/tests/h/db/types_test.py
+++ b/tests/h/db/types_test.py
@@ -62,13 +62,13 @@ def test_annotation_selector_serialize():
     t = types.AnnotationSelectorJSONB()
     selectors = [{
         'type': 'TextQuoteSelector',
-        'prefix': u'\u0000Lorem ipsum ',
-        'exact': u'dolor sit amet,\u0000 ',
-        'suffix': u'consectetur\u0000 adipiscing elit.'
+        'prefix': '\u0000Lorem ipsum ',
+        'exact': 'dolor sit amet,\u0000 ',
+        'suffix': 'consectetur\u0000 adipiscing elit.'
     }]
 
     value = t.process_bind_param(selectors, dialect)
-    assert value[0]['prefix'] == u'\\u0000Lorem ipsum '
+    assert value[0]['prefix'] == '\\u0000Lorem ipsum '
     assert value[0]['exact'] == 'dolor sit amet,\\u0000 '
     assert value[0]['suffix'] == 'consectetur\\u0000 adipiscing elit.'
 
@@ -89,15 +89,15 @@ def test_annotation_selector_deserialize():
     t = types.AnnotationSelectorJSONB()
     selectors = [{
         'type': 'TextQuoteSelector',
-        'prefix': u'\\u0000Lorem ipsum ',
-        'exact': u'dolor sit amet,\\u0000 ',
-        'suffix': u'consectetur\\u0000 adipiscing elit.'
+        'prefix': '\\u0000Lorem ipsum ',
+        'exact': 'dolor sit amet,\\u0000 ',
+        'suffix': 'consectetur\\u0000 adipiscing elit.'
     }]
 
     value = t.process_result_value(selectors, dialect)
-    assert value[0]['prefix'] == u'\u0000Lorem ipsum '
-    assert value[0]['exact'] == u'dolor sit amet,\u0000 '
-    assert value[0]['suffix'] == u'consectetur\u0000 adipiscing elit.'
+    assert value[0]['prefix'] == '\u0000Lorem ipsum '
+    assert value[0]['exact'] == 'dolor sit amet,\u0000 '
+    assert value[0]['suffix'] == 'consectetur\u0000 adipiscing elit.'
 
 
 def test_annotation_selector_deserialize_missing_text_quote_selector():

--- a/tests/h/db/types_test.py
+++ b/tests/h/db/types_test.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 import pytest
 
 from sqlalchemy.dialects.postgresql import dialect

--- a/tests/h/emails/__init__.py
+++ b/tests/h/emails/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals

--- a/tests/h/emails/reply_notification_test.py
+++ b/tests/h/emails/reply_notification_test.py
@@ -212,7 +212,7 @@ class TestGenerate(object):
 
     @pytest.fixture
     def document(self, db_session):
-        doc = Document(title=u'My fascinating page')
+        doc = Document(title='My fascinating page')
         db_session.add(doc)
         db_session.flush()
         return doc
@@ -245,7 +245,7 @@ class TestGenerate(object):
 
     @pytest.fixture
     def parent_user(self, factories):
-        return factories.User(username=u'patricia', email=u'pat@ric.ia',
+        return factories.User(username='patricia', email='pat@ric.ia',
                               display_name='Patricia Demylus')
 
     @pytest.fixture
@@ -260,7 +260,7 @@ class TestGenerate(object):
 
     @pytest.fixture
     def reply_user(self, factories):
-        return factories.User(username=u'ron', email=u'ron@thesmiths.com',
+        return factories.User(username='ron', email='ron@thesmiths.com',
                               display_name='Ron Burgundy')
 
     @pytest.fixture

--- a/tests/h/eventqueue_test.py
+++ b/tests/h/eventqueue_test.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 import mock
 import pytest
 

--- a/tests/h/feeds/__init__.py
+++ b/tests/h/feeds/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals

--- a/tests/h/feeds/atom_test.py
+++ b/tests/h/feeds/atom_test.py
@@ -102,7 +102,7 @@ def test_entry_id(util, factories):
 
 def test_entry_author(factories):
     """The authors of entries should come from the annotation usernames."""
-    annotation = factories.Annotation(userid=u'acct:nobu@hypothes.is')
+    annotation = factories.Annotation(userid='acct:nobu@hypothes.is')
 
     feed = atom.feed_from_annotations(
         [annotation], "atom_url", lambda annotation: "annotation url")

--- a/tests/h/feeds/atom_test.py
+++ b/tests/h/feeds/atom_test.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=protected-access
 """Unit tests for h/atom.py."""
+from __future__ import unicode_literals
 from datetime import datetime
 import mock
 

--- a/tests/h/feeds/rss_test.py
+++ b/tests/h/feeds/rss_test.py
@@ -62,7 +62,7 @@ def test_feed_from_annotations_html_links(factories):
 
 def test_feed_from_annotations_item_titles(factories):
     """Feed items should include the annotation's document's title."""
-    document = factories.Document(title=u'Hello, World')
+    document = factories.Document(title='Hello, World')
     annotation = factories.Annotation(document=document)
 
     feed = rss.feed_from_annotations(

--- a/tests/h/feeds/rss_test.py
+++ b/tests/h/feeds/rss_test.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import datetime
 
 import mock

--- a/tests/h/feeds/util_test.py
+++ b/tests/h/feeds/util_test.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import datetime
 
 import mock

--- a/tests/h/form_test.py
+++ b/tests/h/form_test.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 import mock
 import pytest
 

--- a/tests/h/groups/__init__.py
+++ b/tests/h/groups/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals

--- a/tests/h/groups/__init___test.py
+++ b/tests/h/groups/__init___test.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 import pytest
 
 from h.groups import includeme

--- a/tests/h/groups/schemas_test.py
+++ b/tests/h/groups/schemas_test.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 import pytest
 
 import colander

--- a/tests/h/indexer/__init__.py
+++ b/tests/h/indexer/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals

--- a/tests/h/indexer/reindexer_test.py
+++ b/tests/h/indexer/reindexer_test.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 import mock
 import pytest
 

--- a/tests/h/indexer/subscribers_test.py
+++ b/tests/h/indexer/subscribers_test.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 import pytest
 
 from h import events

--- a/tests/h/jinja_extension_test.py
+++ b/tests/h/jinja_extension_test.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 import datetime
 
 from jinja2 import Markup

--- a/tests/h/links_test.py
+++ b/tests/h/links_test.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 import mock
 import pytest
 

--- a/tests/h/models/feature_test.py
+++ b/tests/h/models/feature_test.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 import mock
 import pytest
 

--- a/tests/h/nipsa/__init__.py
+++ b/tests/h/nipsa/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals

--- a/tests/h/nipsa/search_test.py
+++ b/tests/h/nipsa/search_test.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 import mock
 import pytest
 

--- a/tests/h/nipsa/subscribers_test.py
+++ b/tests/h/nipsa/subscribers_test.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 from collections import namedtuple
 
 import mock

--- a/tests/h/notification/__init__.py
+++ b/tests/h/notification/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals

--- a/tests/h/paginator_test.py
+++ b/tests/h/paginator_test.py
@@ -263,6 +263,17 @@ class TestPaginateQuery(object):
             spec_set=['__call__', '__name__'],
         )
         view_callable.__name__ = 'mock_view_callable'
+
+        # functools.wraps(wrapped) expects wrapped.__name__ to be a unicode
+        # string in Python 3, but to be a byte string in Python 2, otherwise
+        # it raises TypeError: __name__ must be set to a string object.
+        #
+        # str is the unicode type in Python 3 but is the byte string type in
+        # Python 2, so it does what we need either way.
+        #
+        # TODO: Remove this once we no longer need to support Python 2.
+        view_callable.__name__ = str(view_callable.__name__)
+
         return view_callable
 
     @pytest.fixture

--- a/tests/h/paginator_test.py
+++ b/tests/h/paginator_test.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 import mock
 import pytest
 from webob.multidict import NestedMultiDict

--- a/tests/h/paginator_test.py
+++ b/tests/h/paginator_test.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import unicode_literals
+
 import mock
 import pytest
 from webob.multidict import NestedMultiDict

--- a/tests/h/panels/__init__.py
+++ b/tests/h/panels/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals

--- a/tests/h/presenters/__init__.py
+++ b/tests/h/presenters/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals

--- a/tests/h/presenters/annotation_html_test.py
+++ b/tests/h/presenters/annotation_html_test.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 import datetime
 
 import pytest

--- a/tests/h/presenters/document_html_test.py
+++ b/tests/h/presenters/document_html_test.py
@@ -46,12 +46,12 @@ class TestDocumentHTMLPresenter(object):
     def test_filename_with_no_uri(self):
         # self.uri should always be unicode, the worst it should ever be is an
         # empty string.
-        presenter = self.presenter(document_uris=[mock.Mock(uri=u"")])
+        presenter = self.presenter(document_uris=[mock.Mock(uri="")])
 
         assert presenter.filename == ""
 
     def test_filename_with_nonsense_uri(self):
-        presenter = self.presenter(document_uris=[mock.Mock(uri=u"foobar")])
+        presenter = self.presenter(document_uris=[mock.Mock(uri="foobar")])
 
         assert presenter.filename == ""
 
@@ -153,7 +153,7 @@ class TestDocumentHTMLPresenter(object):
                                                             uri,
                                                             filename):
         filename.return_value = ""
-        uri.return_value = u""
+        uri.return_value = ""
 
         assert isinstance(self.presenter().hostname_or_filename, text_type)
 
@@ -163,7 +163,7 @@ class TestDocumentHTMLPresenter(object):
 
         # urlparse.urlparse(u"foobar").hostname is None, make sure this doesn't
         # trip up .hostname_or_filename.
-        uri.return_value = u"foobar"
+        uri.return_value = "foobar"
 
         assert isinstance(self.presenter().hostname_or_filename, text_type)
 
@@ -234,7 +234,7 @@ class TestDocumentHTMLPresenter(object):
                                                        filename,
                                                        title):
         """If title is None it should use the uri instead."""
-        uri.return_value = u"http://example.com/example.html"
+        uri.return_value = "http://example.com/example.html"
         filename.return_value = ""  # This is not a file:// URI.
 
         assert isinstance(self.presenter(title=title).title, text_type)

--- a/tests/h/presenters/document_html_test.py
+++ b/tests/h/presenters/document_html_test.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 from h._compat import text_type
 
 import pytest

--- a/tests/h/presenters/group_json_test.py
+++ b/tests/h/presenters/group_json_test.py
@@ -117,13 +117,13 @@ class TestGroupsJSONPresenter(object):
         assert GroupJSONPresenter_.call_args_list == expected_call_args
 
     def test_asdicts_returns_list_of_dicts(self, factories, GroupResources):  # noqa: N803
-        groups = [factories.Group(name=u'filbert'), factories.OpenGroup(name=u'delbert')]
+        groups = [factories.Group(name='filbert'), factories.OpenGroup(name='delbert')]
         group_resources = GroupResources(groups)
         presenter = GroupsJSONPresenter(group_resources)
 
         result = presenter.asdicts()
 
-        assert [group['name'] for group in result] == [u'filbert', u'delbert']
+        assert [group['name'] for group in result] == ['filbert', 'delbert']
 
     def test_asdicts_injects_urls(self, factories, links_svc, GroupResources):  # noqa: N803
         groups = [factories.Group(), factories.OpenGroup()]

--- a/tests/h/realtime_test.py
+++ b/tests/h/realtime_test.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 from datetime import datetime
 
 import pytest

--- a/tests/h/routes_test.py
+++ b/tests/h/routes_test.py
@@ -34,7 +34,7 @@ def test_includeme():
         call('claim_account_legacy', '/claim_account/{token}'),
         call('dismiss_sidebar_tutorial', '/app/dismiss_sidebar_tutorial'),
         call('activity.search', '/search'),
-        call('activity.user_search', '/users/{username}', factory=u'h.resources:UserFactory', traverse=u'/{username}'),
+        call('activity.user_search', '/users/{username}', factory='h.resources:UserFactory', traverse='/{username}'),
         call('admin_index', '/admin/'),
         call('admin_admins', '/admin/admins'),
         call('admin_badge', '/admin/badge'),

--- a/tests/h/schemas/__init__.py
+++ b/tests/h/schemas/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals

--- a/tests/h/search/__init__.py
+++ b/tests/h/search/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals

--- a/tests/h/search/config_test.py
+++ b/tests/h/search/config_test.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 from h._compat import url_quote_plus
 
 import itertools

--- a/tests/h/search/core_test.py
+++ b/tests/h/search/core_test.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import mock
 import pytest
 

--- a/tests/h/search/query_test.py
+++ b/tests/h/search/query_test.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 import mock
 import pytest
 from hypothesis import strategies as st

--- a/tests/h/services/__init__.py
+++ b/tests/h/services/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals

--- a/tests/h/services/list_groups_test.py
+++ b/tests/h/services/list_groups_test.py
@@ -13,7 +13,7 @@ class TestListGroupsAllGroups(object):
     def test_returns_world_group_if_no_user(self, svc):
         results = svc.all_groups()
 
-        assert u'__world__' in [group.pubid for group in results]
+        assert '__world__' in [group.pubid for group in results]
 
     def test_returns_scoped_open_groups_if_no_user(self, svc, authority, scoped_open_groups):
         results = svc.all_groups(authority=authority)
@@ -42,7 +42,7 @@ class TestListGroupsAllGroups(object):
     def test_returns_world_group_if_user(self, svc, default_user):
         results = svc.all_groups(user=default_user)
 
-        assert u'__world__' in [group.pubid for group in results]
+        assert '__world__' in [group.pubid for group in results]
 
     def test_returns_scoped_open_groups_if_user(self, svc, user, scoped_open_groups):
         results = svc.all_groups(user=user)
@@ -209,7 +209,7 @@ class TestListGroupsRequestGroups(object):
     def test_it_returns_world_group(self, svc, default_authority):
         results = svc.request_groups(authority=default_authority)
 
-        assert results[0].pubid == u'__world__'
+        assert results[0].pubid == '__world__'
 
     def test_it_returns_matching_scoped_open_groups(self, svc, authority, document_uri, scoped_open_groups):
         results = svc.request_groups(authority=authority, document_uri=document_uri)

--- a/tests/h/session_test.py
+++ b/tests/h/session_test.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import pytest
 import mock
 

--- a/tests/h/session_test.py
+++ b/tests/h/session_test.py
@@ -89,7 +89,7 @@ class TestProfile(object):
 
     def test_userid_authenticated(self, authenticated_request):
         profile = session.profile(authenticated_request)
-        assert profile['userid'] == u'acct:user@example.com'
+        assert profile['userid'] == 'acct:user@example.com'
 
     def test_proxies_group_lookup_to_service(self, authenticated_request):
         svc = authenticated_request.find_service(name='list_groups')
@@ -206,12 +206,12 @@ class TestProfile(object):
 
     @pytest.fixture
     def third_party_domain(self):
-        return u'thirdparty.example.org'
+        return 'thirdparty.example.org'
 
     @pytest.fixture
     def third_party_request(self, authority, third_party_domain, fake_feature):
         return FakeRequest(authority,
-                           u'acct:user@{}'.format(third_party_domain),
+                           'acct:user@{}'.format(third_party_domain),
                            third_party_domain,
                            fake_feature)
 
@@ -304,7 +304,7 @@ class FakeRequest(object):
 
 @pytest.fixture
 def authority():
-    return u'example.com'
+    return 'example.com'
 
 
 @pytest.fixture
@@ -316,11 +316,11 @@ def unauthenticated_request(authority, fake_feature):
 @pytest.fixture
 def authenticated_request(authority, fake_feature):
     return FakeRequest(authority,
-                       u'acct:user@{}'.format(authority),
+                       'acct:user@{}'.format(authority),
                        authority,
                        fake_feature)
 
 
 @pytest.fixture
 def world_group(factories):
-    return factories.OpenGroup(name=u'Public', pubid='__worldish__')
+    return factories.OpenGroup(name='Public', pubid='__worldish__')

--- a/tests/h/storage_test.py
+++ b/tests/h/storage_test.py
@@ -450,7 +450,7 @@ class TestUpdateAnnotation(object):
         assert str(exc.value).startswith('group: ')
 
     def test_it_allows_when_group_scope_matches(self, annotation_data, pyramid_request, group_service, scoped_open_group, models):
-        annotation_data['target_uri'] = u'http://www.foo.com/baz/ding.html'
+        annotation_data['target_uri'] = 'http://www.foo.com/baz/ding.html'
 
         # this should not raise
         annotation = storage.update_annotation(pyramid_request, 'test_annotation_id', annotation_data, group_service)
@@ -458,7 +458,7 @@ class TestUpdateAnnotation(object):
         assert annotation == pyramid_request.db.query.return_value.get.return_value
 
     def test_it_raises_when_group_scope_mismatch(self, annotation_data, pyramid_request, group_service, scoped_open_group):
-        annotation_data['target_uri'] = u'http://www.bar.com/baz/ding.html'
+        annotation_data['target_uri'] = 'http://www.bar.com/baz/ding.html'
         group_service.find.return_value = scoped_open_group
 
         with pytest.raises(ValidationError) as exc:

--- a/tests/h/streamer/__init__.py
+++ b/tests/h/streamer/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals

--- a/tests/h/streamer/messages_test.py
+++ b/tests/h/streamer/messages_test.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 import mock
 import pytest
 from gevent.queue import Queue

--- a/tests/h/streamer/streamer_test.py
+++ b/tests/h/streamer/streamer_test.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 import mock
 from mock import call
 import pytest

--- a/tests/h/streamer/views_test.py
+++ b/tests/h/streamer/views_test.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 import pytest
 
 from h.streamer import views

--- a/tests/h/streamer/websocket_test.py
+++ b/tests/h/streamer/websocket_test.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 from collections import namedtuple
 
 import mock

--- a/tests/h/tasks/__init__.py
+++ b/tests/h/tasks/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals

--- a/tests/h/tasks/mailer_test.py
+++ b/tests/h/tasks/mailer_test.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 from smtplib import SMTPServerDisconnected
 
 import mock

--- a/tests/h/tweens_test.py
+++ b/tests/h/tweens_test.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 import pytest
 
 from h import tweens

--- a/tests/h/tweens_test.py
+++ b/tests/h/tweens_test.py
@@ -6,79 +6,87 @@ from h import tweens
 from h.util.redirects import Redirect
 
 
-def test_tween_redirect_loads_redirects(patch):
-    open_ = patch('h.tweens.open')
-    parse_redirects = patch('h.tweens.parse_redirects')
+class TestRedirectTween(object):
 
-    tweens.redirect_tween_factory(handler=None, registry=None)
+    def test_it_loads_redirects(self, patch):
+        open_ = patch('h.tweens.open')
+        parse_redirects = patch('h.tweens.parse_redirects')
 
-    open_.assert_called_once_with('h/redirects', encoding='utf-8')
-    # Parse redirects is called with the value returned by the context manager
-    parse_redirects.assert_called_once_with(open_.return_value.__enter__.return_value)
+        tweens.redirect_tween_factory(handler=None, registry=None)
 
+        open_.assert_called_once_with('h/redirects', encoding='utf-8')
+        # Parse redirects is called with the value returned by the context manager
+        parse_redirects.assert_called_once_with(open_.return_value.__enter__.return_value)
 
-def test_tween_redirect_non_redirected_route(pyramid_request):
-    redirects = [
-        Redirect(src='/foo', dst='http://bar', internal=False, prefix=False)
-    ]
+    def test_it_does_not_redirect_for_non_redirected_routes(self, pyramid_request):
+        redirects = [
+            Redirect(src='/foo', dst='http://bar', internal=False, prefix=False)
+        ]
 
-    pyramid_request.path = '/quux'
+        pyramid_request.path = '/quux'
 
-    tween = tweens.redirect_tween_factory(
-        lambda req: req.response,
-        pyramid_request.registry,
-        redirects)
+        tween = tweens.redirect_tween_factory(
+            lambda req: req.response,
+            pyramid_request.registry,
+            redirects)
 
-    response = tween(pyramid_request)
+        response = tween(pyramid_request)
 
-    assert response.status_code == 200
+        assert response.status_code == 200
 
+    def test_it_redirects_for_redirected_routes(self, pyramid_request, pyramid_config):
+        redirects = [
+            Redirect(src='/foo', dst='http://bar', internal=False, prefix=False)
+        ]
 
-def test_tween_redirect_redirected_route(pyramid_request, pyramid_config):
-    redirects = [
-        Redirect(src='/foo', dst='http://bar', internal=False, prefix=False)
-    ]
+        pyramid_request.path = '/foo'
 
-    pyramid_request.path = '/foo'
+        tween = tweens.redirect_tween_factory(
+            lambda req: req.response,
+            pyramid_request.registry,
+            redirects)
 
-    tween = tweens.redirect_tween_factory(
-        lambda req: req.response,
-        pyramid_request.registry,
-        redirects)
+        response = tween(pyramid_request)
 
-    response = tween(pyramid_request)
-
-    assert response.status_code == 301
-    assert response.location == 'http://bar'
-
-
-def test_tween_security_header_adds_headers(pyramid_request):
-    tween = tweens.security_header_tween_factory(lambda req: req.response,
-                                                 pyramid_request.registry)
-
-    response = tween(pyramid_request)
-
-    assert response.headers['Referrer-Policy'] == 'origin-when-cross-origin, strict-origin-when-cross-origin'
-    assert response.headers['X-XSS-Protection'] == '1; mode=block'
+        assert response.status_code == 301
+        assert response.location == 'http://bar'
 
 
-@pytest.mark.parametrize('content_type, expected_cc_header', [
-    # Web pages.
-    ('text/html', None),
+class TestSecurityHeaderTween(object):
 
-    # An API or XHR response.
-    ('application/json', 'no-cache'),
+    def test_it_adds_security_headers_to_the_response(self, pyramid_request):
+        tween = tweens.security_header_tween_factory(lambda req: req.response,
+                                                    pyramid_request.registry)
 
-    # A response with no content (eg. 204 response to a `DELETE` request).
-    (None, None),
-])
-def test_tween_cache_header_adds_headers(pyramid_request, content_type, expected_cc_header):
-    tween = tweens.cache_header_tween_factory(lambda req: req.response,
-                                              pyramid_request.registry)
+        response = tween(pyramid_request)
 
-    if content_type is not None:
-        pyramid_request.response.headers['Content-Type'] = content_type
+        assert response.headers['Referrer-Policy'] == 'origin-when-cross-origin, strict-origin-when-cross-origin'
+        assert response.headers['X-XSS-Protection'] == '1; mode=block'
 
-    response = tween(pyramid_request)
 
-    assert response.headers.get('Cache-Control') == expected_cc_header
+class TestCacheHeaderTween(object):
+
+    @pytest.mark.parametrize('content_type, expected_cc_header', [
+        # It doesn't add any headers for HTML pages.
+        ('text/html', None),
+
+        # It adds Cache-Control: no-cache for JSON responses.
+        ('application/json', 'no-cache'),
+
+        # It doesn't add any headers for responses with no content (eg. 204
+        # response to a `DELETE` request).
+        (None, None),
+    ])
+    def test_it_adds_caching_headers_to_the_response(self,
+                                                     pyramid_request,
+                                                     content_type,
+                                                     expected_cc_header):
+        tween = tweens.cache_header_tween_factory(lambda req: req.response,
+                                                  pyramid_request.registry)
+
+        if content_type is not None:
+            pyramid_request.response.headers['Content-Type'] = content_type
+
+        response = tween(pyramid_request)
+
+        assert response.headers.get('Cache-Control') == expected_cc_header

--- a/tests/h/tweens_test.py
+++ b/tests/h/tweens_test.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-
 from __future__ import unicode_literals
+
 import pytest
 
 from h import tweens

--- a/tests/h/util/__init__.py
+++ b/tests/h/util/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals

--- a/tests/h/util/cors_test.py
+++ b/tests/h/util/cors_test.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals
 import mock
 import pytest
 

--- a/tests/h/util/redirects_test.py
+++ b/tests/h/util/redirects_test.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 import pytest
 from hypothesis import strategies as st
 from hypothesis import given

--- a/tests/h/util/user_test.py
+++ b/tests/h/util/user_test.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 import pytest
 
 from h.util import user as user_util

--- a/tests/h/viewpredicates_test.py
+++ b/tests/h/viewpredicates_test.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 import mock
 
 from h.viewpredicates import FeaturePredicate

--- a/tests/h/views/__init__.py
+++ b/tests/h/views/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals

--- a/tests/h/views/accounts_test.py
+++ b/tests/h/views/accounts_test.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=no-self-use
 
+from __future__ import unicode_literals
 import mock
 import pytest
 

--- a/tests/h/views/admin_index_test.py
+++ b/tests/h/views/admin_index_test.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 
+from __future__ import unicode_literals
 from h.views.admin_index import index
 
 

--- a/tests/h/views/api_config_test.py
+++ b/tests/h/views/api_config_test.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 import mock
 import pytest
 

--- a/tests/h/views/api_test.py
+++ b/tests/h/views/api_test.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 import mock
 import pytest
 

--- a/tests/h/views/groups_test.py
+++ b/tests/h/views/groups_test.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 import deform
 import mock
 import pytest

--- a/tests/setup.cfg
+++ b/tests/setup.cfg
@@ -21,3 +21,10 @@ ignore = \
     #   E128 - continuation line under-intended for visual indent
     E121, E122, E123, E126, E127, E128,
 
+    # flake8-future-import's "__future__ import “*” missing' rules. We run a
+    # separate flake8 command to run these rules because we want them to ignore
+    # certain files, so disable them for our general flake8 command.
+    #
+    # This also disables flake8-future-import's '__future__ import “*” present'
+    # rules. These will become useful once we've moved to Python 3.
+    FI


### PR DESCRIPTION
* Add `unicode_literals` to all Python files
  
  Add `from __future__ import unicode_literals` to all Python files that don't have it yet.
  
  See: https://www.python.org/dev/peps/pep-3112/
  
  This makes our Python 2.7 environment a little more similar to what a Python 3 one will look like: string literals are unicode by default. By doing this as a separate step now we reduce the size of the change that we'll be applying when we move from Python 2 to 3.
  
  This was done using `futurize --unicode-literals -wn1 h tests`.
  
  I did not add `unicode_literals` to:
  
  - `h/cli/*` and its tests, because the click library complains about `unicode_literals` (see: http://click.pocoo.org/5/python3/)
  
  - `h/migrations/versions/*`, because I don't want to make changes to old migration scripts.

* Remove now unnecessary `u`-prefixes from string literals

* Use `make lint` to enforce `unicode_literals`

  Add an additional flake8 command to `make lint` that complains if `from __future__ import unicode_literals` is missing from any files. To make sure that no new files are added without it.