### PR TITLE
Add `default` property to org resource and API response

### DIFF
--- a/docs/_extra/api-reference/schemas/organization.yaml
+++ b/docs/_extra/api-reference/schemas/organization.yaml
@@ -2,13 +2,13 @@ Organization:
   type: object
   required:
     - id
-    - isDefault
+    - default
     - logo
     - name
   properties:
     id:
       type: string
-    isDefault:
+    default:
       type: boolean
       description: true if this organization is the default organization for the current authority
     logo:

--- a/docs/_extra/api-reference/schemas/organization.yaml
+++ b/docs/_extra/api-reference/schemas/organization.yaml
@@ -2,11 +2,15 @@ Organization:
   type: object
   required:
     - id
+    - isDefault
     - logo
     - name
   properties:
     id:
       type: string
+    isDefault:
+      type: boolean
+      description: true if this organization is the default organization for the current authority
     logo:
       oneOf:
         - type: string

--- a/h/models/organization.py
+++ b/h/models/organization.py
@@ -10,6 +10,7 @@ from h import pubid
 ORGANIZATION_NAME_MIN_CHARS = 1
 ORGANIZATION_NAME_MAX_CHARS = 25
 ORGANIZATION_LOGO_MAX_CHARS = 10000
+ORGANIZATION_DEFAULT_PUBID = '__default__'
 
 
 def _strip_xmlns(tag):
@@ -68,4 +69,4 @@ class Organization(Base, mixins.Timestamps):
 
     @classmethod
     def default(cls, session):
-        return session.query(cls).filter_by(pubid='__default__').one()
+        return session.query(cls).filter_by(pubid=ORGANIZATION_DEFAULT_PUBID).one()

--- a/h/presenters/organization_json.py
+++ b/h/presenters/organization_json.py
@@ -16,6 +16,7 @@ class OrganizationJSONPresenter(object):
     def _model(self):
         model = {
           'id': self.resource.id,
+          'isDefault': self.resource.is_default,
           'logo': self.resource.logo,
           'name': self.organization.name,
         }

--- a/h/presenters/organization_json.py
+++ b/h/presenters/organization_json.py
@@ -16,7 +16,7 @@ class OrganizationJSONPresenter(object):
     def _model(self):
         model = {
           'id': self.resource.id,
-          'isDefault': self.resource.is_default,
+          'default': self.resource.default,
           'logo': self.resource.logo,
           'name': self.organization.name,
         }

--- a/h/resources.py
+++ b/h/resources.py
@@ -170,6 +170,10 @@ class OrganizationResource(object):
         return self.organization.pubid  # Web-facing unique ID for this resource
 
     @property
+    def is_default(self):
+        return self.organization == Organization.default(self.request.db)
+
+    @property
     def links(self):
         # TODO
         return {}

--- a/h/resources.py
+++ b/h/resources.py
@@ -13,6 +13,7 @@ from sqlalchemy.orm import exc
 from h import storage
 from h.models import AuthClient
 from h.models import Organization
+from h.models.organization import ORGANIZATION_DEFAULT_PUBID
 from h.auth import role
 from h.interfaces import IGroupService
 
@@ -171,7 +172,7 @@ class OrganizationResource(object):
 
     @property
     def default(self):
-        return self.organization == Organization.default(self.request.db)
+        return self.id == ORGANIZATION_DEFAULT_PUBID
 
     @property
     def links(self):

--- a/h/resources.py
+++ b/h/resources.py
@@ -170,7 +170,7 @@ class OrganizationResource(object):
         return self.organization.pubid  # Web-facing unique ID for this resource
 
     @property
-    def is_default(self):
+    def default(self):
         return self.organization == Organization.default(self.request.db)
 
     @property

--- a/tests/h/presenters/organization_json_test.py
+++ b/tests/h/presenters/organization_json_test.py
@@ -19,7 +19,7 @@ class TestOrganizationJSONPresenter(object):
         assert presenter.asdict() == {
             'name': 'My Org',
             'id': organization.pubid,
-            'isDefault': False,
+            'default': False,
             'logo': None,
         }
 
@@ -32,7 +32,7 @@ class TestOrganizationJSONPresenter(object):
         assert presenter.asdict() == {
             'name': 'My Org',
             'id': organization_resource.id,
-            'isDefault': False,
+            'default': False,
             'logo': pyramid_request.route_url('organization_logo', pubid=organization.pubid)
         }
 
@@ -43,7 +43,7 @@ class TestOrganizationJSONPresenter(object):
         presenter = OrganizationJSONPresenter(organization_resource)
         presented = presenter.asdict()
 
-        assert presented['isDefault'] is True
+        assert presented['default'] is True
 
 
 @pytest.fixture

--- a/tests/h/presenters/organization_json_test.py
+++ b/tests/h/presenters/organization_json_test.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 import pytest
 
 from h.presenters.organization_json import OrganizationJSONPresenter
+from h.models.organization import Organization
 from h.resources import OrganizationResource
 
 
@@ -18,6 +19,7 @@ class TestOrganizationJSONPresenter(object):
         assert presenter.asdict() == {
             'name': 'My Org',
             'id': organization.pubid,
+            'isDefault': False,
             'logo': None,
         }
 
@@ -30,8 +32,18 @@ class TestOrganizationJSONPresenter(object):
         assert presenter.asdict() == {
             'name': 'My Org',
             'id': organization_resource.id,
+            'isDefault': False,
             'logo': pyramid_request.route_url('organization_logo', pubid=organization.pubid)
         }
+
+    def test_default_organization(self, db_session, routes, pyramid_request):
+        organization = Organization.default(db_session)
+        organization_resource = OrganizationResource(organization, pyramid_request)
+
+        presenter = OrganizationJSONPresenter(organization_resource)
+        presented = presenter.asdict()
+
+        assert presented['isDefault'] is True
 
 
 @pytest.fixture

--- a/tests/h/resources_test.py
+++ b/tests/h/resources_test.py
@@ -8,7 +8,7 @@ import mock
 from pyramid import security
 from pyramid.authorization import ACLAuthorizationPolicy
 
-from h.models import AuthClient
+from h.models import AuthClient, Organization
 from h.services.group_links import GroupLinksService
 from h.resources import AnnotationResource
 from h.resources import AnnotationResourceFactory
@@ -342,6 +342,20 @@ class TestOrganizationResource(object):
 
         pyramid_request.route_url.assert_not_called
         assert logo is None
+
+    def test_is_default_property_if_not_default_organization(self, factories, pyramid_request):
+        organization = factories.Organization()
+
+        organization_resource = OrganizationResource(organization, pyramid_request)
+
+        assert organization_resource.is_default is False
+
+    def test_is_default_property_if_default_organization(self, factories, pyramid_request):
+        organization = Organization.default(pyramid_request.db)
+
+        organization_resource = OrganizationResource(organization, pyramid_request)
+
+        assert organization_resource.is_default is True
 
 
 @pytest.fixture

--- a/tests/h/resources_test.py
+++ b/tests/h/resources_test.py
@@ -343,19 +343,19 @@ class TestOrganizationResource(object):
         pyramid_request.route_url.assert_not_called
         assert logo is None
 
-    def test_is_default_property_if_not_default_organization(self, factories, pyramid_request):
+    def test_default_property_if_not_default_organization(self, factories, pyramid_request):
         organization = factories.Organization()
 
         organization_resource = OrganizationResource(organization, pyramid_request)
 
-        assert organization_resource.is_default is False
+        assert organization_resource.default is False
 
-    def test_is_default_property_if_default_organization(self, factories, pyramid_request):
+    def test_default_property_if_default_organization(self, factories, pyramid_request):
         organization = Organization.default(pyramid_request.db)
 
         organization_resource = OrganizationResource(organization, pyramid_request)
 
-        assert organization_resource.is_default is True
+        assert organization_resource.default is True
 
 
 @pytest.fixture


### PR DESCRIPTION
This PR adds an `isDefault` property to `OrganizationResource` objects and also to the expanded organization response in the API. Its aim is to aid clients in discovery of which organization is the default.

Fixes https://github.com/hypothesis/product-backlog/issues/582