### PR TITLE
Remove unnecessary urls and deprecated url properties from the groups

### DIFF
--- a/docs/_extra/api-reference/schemas/group.yaml
+++ b/docs/_extra/api-reference/schemas/group.yaml
@@ -8,7 +8,6 @@ Group:
     - public
     - scoped
     - type
-    - urls
   properties:
     id:
       type: string
@@ -40,16 +39,3 @@ Group:
         - private
         - open
         - restricted
-    url:
-      type: string
-      format: uri
-      deprecated: true
-    urls:
-      type: object
-      deprecated: true
-      properties:
-        group:
-          type: string
-          format: uri
-          description: URI to group activity page; use `links.html` instead
-          deprecated: true

--- a/h/presenters/group_json.py
+++ b/h/presenters/group_json.py
@@ -16,7 +16,7 @@ class GroupJSONPresenter(object):
     def asdict(self, expand=[]):
         model = self._model()
         self._expand(model, expand)
-        self._inject_urls(model)
+        model['links'] = self.resource.links or {}
         return model
 
     def _expand(self, model, expand=[]):
@@ -35,14 +35,6 @@ class GroupJSONPresenter(object):
           'scoped': True if self.group.scopes else False,
           'type': self.group.type
         }
-        return model
-
-    def _inject_urls(self, model):
-        model['links'] = self.resource.links or {}
-        model['urls'] = model['links']  # DEPRECATED TODO: remove from client
-        if 'html' in model['links']:
-            # DEPRECATED TODO: remove from client
-            model['url'] = model['urls']['html']
         return model
 
 

--- a/tests/h/presenters/group_json_test.py
+++ b/tests/h/presenters/group_json_test.py
@@ -24,7 +24,6 @@ class TestGroupJSONPresenter(object):
             'type': 'private',
             'public': False,
             'scoped': False,
-            'urls': links_svc.get_all.return_value,
             'links': links_svc.get_all.return_value,
         }
 
@@ -41,7 +40,6 @@ class TestGroupJSONPresenter(object):
             'type': 'open',
             'public': True,
             'scoped': False,
-            'urls': links_svc.get_all.return_value,
             'links': links_svc.get_all.return_value,
         }
 
@@ -59,11 +57,10 @@ class TestGroupJSONPresenter(object):
             'organization': group_resource.organization.id,
             'public': True,
             'scoped': True,
-            'urls': links_svc.get_all.return_value,
             'links': links_svc.get_all.return_value,
         }
 
-    def test_it_contains_deprecated_url_if_html_link_present(self, factories, GroupResource_, links_svc):  # noqa: N803
+    def test_it_doesn_not_contain_deprecated_url(self, factories, GroupResource_, links_svc):  # noqa: N803
         links_svc.get_all.return_value = {
             'html': 'foobar'
         }
@@ -71,7 +68,7 @@ class TestGroupJSONPresenter(object):
         group_resource = GroupResource_(group)
         presenter = GroupJSONPresenter(group_resource)
 
-        assert presenter.asdict()['url'] == 'foobar'
+        assert 'url' not in presenter.asdict()
 
     def test_it_does_not_expand_by_default(self, factories, GroupResource_):  # noqa: N803
         group = factories.OpenGroup(name='My Group',
@@ -125,7 +122,7 @@ class TestGroupsJSONPresenter(object):
 
         assert [group['name'] for group in result] == [u'filbert', u'delbert']
 
-    def test_asdicts_injects_urls(self, factories, links_svc, GroupResources):  # noqa: N803
+    def test_asdicts_injects_links(self, factories, links_svc, GroupResources):  # noqa: N803
         groups = [factories.Group(), factories.OpenGroup()]
         group_resources = GroupResources(groups)
         presenter = GroupsJSONPresenter(group_resources)
@@ -133,7 +130,6 @@ class TestGroupsJSONPresenter(object):
         result = presenter.asdicts()
 
         for group_model in result:
-            assert 'urls' in group_model
             assert 'links' in group_model
 
 


### PR DESCRIPTION
Remove unnecessary urls and deprecated url properties from the groups response object.

Fixes https://github.com/hypothesis/product-backlog/issues/486