### PR TITLE
Remove deprecated and redundant pip `--use-wheel` argument

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ lint: .pydeps
 # Fake targets to aid with deps installation
 .pydeps: requirements.txt
 	@echo installing python dependencies
-	@pip install --use-wheel -r requirements-dev.in tox
+	@pip install -r requirements-dev.in tox
 	@touch $@
 
 node_modules/.uptodate: package.json


### PR DESCRIPTION
As noted at https://pip.pypa.io/en/stable/user_guide/, pip automatically
installs wheels when they are available, so `--use-wheel` is a no-op
which existed because of the counterpart `--no-use-wheel`. That was in
turn removed in favor of `--no-binary` in pip 10.0.

This fixes Python dependency installation with the latest pip release.