### PR TITLE
Move _group_principals helper into class

### DIFF
--- a/h/resources.py
+++ b/h/resources.py
@@ -73,7 +73,7 @@ class AnnotationResource(object):
 
         acl = []
         if self.annotation.shared:
-            for principal in _group_principals(self.group):
+            for principal in self._group_principals(self.group):
                 acl.append((Allow, principal, 'read'))
         else:
             acl.append((Allow, self.annotation.userid, 'read'))
@@ -85,6 +85,12 @@ class AnnotationResource(object):
         acl.append(DENY_ALL)
 
         return acl
+
+    @staticmethod
+    def _group_principals(group):
+        if group is None:
+            return []
+        return principals_allowed_by_permission(group, 'read')
 
 
 class AuthClientFactory(object):
@@ -201,9 +207,3 @@ class UserFactory(object):
             raise KeyError()
 
         return user
-
-
-def _group_principals(group):
-    if group is None:
-        return []
-    return principals_allowed_by_permission(group, 'read')


### PR DESCRIPTION
Move the private helper function `_group_principals` into the
`AnnotationResource` class, making it a `staticmethod` since it doesn't need
access either `self` or `cls`.

This is just a teeny bit of code organization / cleanup: since this
function is only used in this class, define it in the class where it is
used, rather than far away at the bottom of the module.

I'm not a big fan of the long disorganised list of helper functions at
the bottom of the file design pattern, I don't think it helps code
organisation or readability.