### PR TITLE
Move UserFactory into h/resources.py

### DIFF
--- a/h/models/user.py
+++ b/h/models/user.py
@@ -122,22 +122,6 @@ class UserIDComparator(Comparator):
         return self.__clause_element__().in_(others)
 
 
-class UserFactory(object):
-    """Root resource for routes that look up User objects by traversal."""
-
-    def __init__(self, request):
-        self.request = request
-
-    def __getitem__(self, username):
-        user = self.request.find_service(name='user').fetch(
-            username, self.request.authority)
-
-        if not user:
-            raise KeyError()
-
-        return user
-
-
 class User(Base):
     __tablename__ = 'user'
 

--- a/h/resources.py
+++ b/h/resources.py
@@ -187,6 +187,22 @@ class OrganizationResource(object):
         return None
 
 
+class UserFactory(object):
+    """Root resource for routes that look up User objects by traversal."""
+
+    def __init__(self, request):
+        self.request = request
+
+    def __getitem__(self, username):
+        user = self.request.find_service(name='user').fetch(
+            username, self.request.authority)
+
+        if not user:
+            raise KeyError()
+
+        return user
+
+
 def _group_principals(group):
     if group is None:
         return []

--- a/h/resources.py
+++ b/h/resources.py
@@ -192,10 +192,10 @@ class UserFactory(object):
 
     def __init__(self, request):
         self.request = request
+        self.user_svc = self.request.find_service(name='user')
 
     def __getitem__(self, username):
-        user = self.request.find_service(name='user').fetch(
-            username, self.request.authority)
+        user = self.user_svc.fetch(username, self.request.authority)
 
         if not user:
             raise KeyError()

--- a/h/routes.py
+++ b/h/routes.py
@@ -28,7 +28,7 @@ def includeme(config):
     config.add_route('activity.search', '/search')
     config.add_route('activity.user_search',
                      '/users/{username}',
-                     factory='h.models.user:UserFactory',
+                     factory='h.resources:UserFactory',
                      traverse='/{username}')
 
     # Admin

--- a/tests/h/models/user_test.py
+++ b/tests/h/models/user_test.py
@@ -1,41 +1,10 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-import mock
 import pytest
 from sqlalchemy import exc
 
 from h import models
-from h.services.user import user_service_factory
-from h.models.user import UserFactory
-
-
-@pytest.mark.usefixtures('user_service')
-class TestUserFactory(object):
-
-    def test_it_raises_KeyError_if_the_user_does_not_exist(self,
-                                                           user_factory,
-                                                           user_service):
-        user_service.fetch.return_value = None
-
-        with pytest.raises(KeyError):
-            user_factory["does_not_exist"]
-
-    def test_it_returns_users(self, factories, user_factory, user_service):
-        user_service.fetch.return_value = user = factories.User.build()
-
-        assert user_factory[user.username] == user
-
-    @pytest.fixture
-    def user_factory(self, pyramid_request):
-        return UserFactory(pyramid_request)
-
-    @pytest.fixture
-    def user_service(self, pyramid_config, pyramid_request):
-        user_service = mock.Mock(spec_set=user_service_factory(
-            None, pyramid_request))
-        pyramid_config.register_service(user_service, name='user')
-        return user_service
 
 
 def test_cannot_create_dot_variant_of_user(db_session):

--- a/tests/h/resources_test.py
+++ b/tests/h/resources_test.py
@@ -363,6 +363,11 @@ class TestOrganizationResource(object):
 @pytest.mark.usefixtures('user_service')
 class TestUserFactory(object):
 
+    def test_it_fetches_the_requested_user(self, pyramid_request, user_factory, user_service):
+        user_factory["bob"]
+
+        user_service.fetch.assert_called_once_with("bob", pyramid_request.authority)
+
     def test_it_raises_KeyError_if_the_user_does_not_exist(self,
                                                            user_factory,
                                                            user_service):

--- a/tests/h/resources_test.py
+++ b/tests/h/resources_test.py
@@ -17,6 +17,8 @@ from h.resources import OrganizationFactory
 from h.resources import OrganizationLogoFactory
 from h.resources import GroupResource
 from h.resources import OrganizationResource
+from h.resources import UserFactory
+from h.services.user import user_service_factory
 
 
 @pytest.mark.usefixtures('group_service', 'links_service')
@@ -356,6 +358,34 @@ class TestOrganizationResource(object):
         organization_resource = OrganizationResource(organization, pyramid_request)
 
         assert organization_resource.default is True
+
+
+@pytest.mark.usefixtures('user_service')
+class TestUserFactory(object):
+
+    def test_it_raises_KeyError_if_the_user_does_not_exist(self,
+                                                           user_factory,
+                                                           user_service):
+        user_service.fetch.return_value = None
+
+        with pytest.raises(KeyError):
+            user_factory["does_not_exist"]
+
+    def test_it_returns_users(self, factories, user_factory, user_service):
+        user_service.fetch.return_value = user = factories.User.build()
+
+        assert user_factory[user.username] == user
+
+    @pytest.fixture
+    def user_factory(self, pyramid_request):
+        return UserFactory(pyramid_request)
+
+    @pytest.fixture
+    def user_service(self, pyramid_config, pyramid_request):
+        user_service = mock.Mock(spec_set=user_service_factory(
+            None, pyramid_request))
+        pyramid_config.register_service(user_service, name='user')
+        return user_service
 
 
 @pytest.fixture

--- a/tests/h/resources_test.py
+++ b/tests/h/resources_test.py
@@ -18,7 +18,7 @@ from h.resources import OrganizationLogoFactory
 from h.resources import GroupResource
 from h.resources import OrganizationResource
 from h.resources import UserFactory
-from h.services.user import user_service_factory
+from h.services.user import UserService
 
 
 @pytest.mark.usefixtures('group_service', 'links_service')
@@ -381,9 +381,8 @@ class TestUserFactory(object):
         return UserFactory(pyramid_request)
 
     @pytest.fixture
-    def user_service(self, pyramid_config, pyramid_request):
-        user_service = mock.Mock(spec_set=user_service_factory(
-            None, pyramid_request))
+    def user_service(self, pyramid_config):
+        user_service = mock.create_autospec(UserService, spec_set=True, instance=True)
         pyramid_config.register_service(user_service, name='user')
         return user_service
 

--- a/tests/h/routes_test.py
+++ b/tests/h/routes_test.py
@@ -34,7 +34,7 @@ def test_includeme():
         call('claim_account_legacy', '/claim_account/{token}'),
         call('dismiss_sidebar_tutorial', '/app/dismiss_sidebar_tutorial'),
         call('activity.search', '/search'),
-        call('activity.user_search', '/users/{username}', factory=u'h.models.user:UserFactory', traverse=u'/{username}'),
+        call('activity.user_search', '/users/{username}', factory=u'h.resources:UserFactory', traverse=u'/{username}'),
         call('admin_index', '/admin/'),
         call('admin_admins', '/admin/admins'),
         call('admin_badge', '/admin/badge'),


### PR DESCRIPTION
Part of the refactoring [described here](https://hypothes-is.slack.com/files/U074DEU66/FA511033L/h_traversal__resources__refactoring). Beginning by moving all the factories and resources into one place.

Also tagged on a little refactoring of `UserFactory` and its tests - see separate commits,