### PR TITLE
Refactor group service tests

### DIFF
--- a/tests/h/services/group_test.py
+++ b/tests/h/services/group_test.py
@@ -14,37 +14,37 @@ from tests.common.matchers import Matcher
 
 
 class TestGroupServiceCreatePrivateGroup(object):
-    def test_create_private_group_returns_group_model(self, creator, svc):
+    def test_it_returns_group_model(self, creator, svc):
         group = svc.create_private_group('Anteater fans', creator.userid)
 
         assert isinstance(group, Group)
 
-    def test_create_private_group_sets_group_name(self, creator, svc):
+    def test_it_sets_group_name(self, creator, svc):
         group = svc.create_private_group('Anteater fans', creator.userid)
 
         assert group.name == 'Anteater fans'
 
-    def test_create_private_group_sets_group_authority(self, svc, creator, pyramid_request):
+    def test_it_sets_group_authority(self, svc, creator, pyramid_request):
         group = svc.create_private_group('Anteater fans', creator.userid)
 
         assert group.authority == pyramid_request.authority
 
-    def test_create_private_group_sets_group_creator(self, svc, creator):
+    def test_it_sets_group_creator(self, svc, creator):
         group = svc.create_private_group('Anteater fans', creator.userid)
 
         assert group.creator == creator
 
-    def test_create_private_group_sets_description_when_present(self, svc, creator):
+    def test_it_sets_description_when_present(self, svc, creator):
         group = svc.create_private_group('Anteater fans', creator.userid, 'all about ant eaters')
 
         assert group.description == 'all about ant eaters'
 
-    def test_create_private_group_skips_setting_description_when_missing(self, svc, creator):
+    def test_it_skips_setting_description_when_missing(self, svc, creator):
         group = svc.create_private_group('Anteater fans', creator.userid)
 
         assert group.description is None
 
-    def test_create_private_group_adds_group_creator_to_members(self, svc, creator):
+    def test_it_adds_group_creator_to_members(self, svc, creator):
         group = svc.create_private_group('Anteater fans', creator.userid)
 
         assert creator in group.members
@@ -53,36 +53,36 @@ class TestGroupServiceCreatePrivateGroup(object):
         ('joinable_by', JoinableBy.authority),
         ('readable_by', ReadableBy.members),
         ('writeable_by', WriteableBy.members)])
-    def test_create_private_group_sets_access_flags(self, svc, creator, flag, expected_value):
+    def test_it_sets_access_flags(self, svc, creator, flag, expected_value):
         group = svc.create_private_group('Anteater fans', creator.userid)
 
         assert getattr(group, flag) == expected_value
 
-    def test_create_private_group_creates_group_with_default_organization(
+    def test_it_creates_group_with_default_organization(
             self, default_organization, creator, svc):
         group = svc.create_private_group('Anteater fans', creator.userid)
 
         assert group.organization == default_organization
 
-    def test_create_private_group_creates_group_with_specified_organization(self, factories, creator, svc):
+    def test_it_creates_group_with_specified_organization(self, factories, creator, svc):
         org = factories.Organization()
 
         group = svc.create_private_group('Anteater fans', creator.userid, organization=org)
 
         assert group.organization == org
 
-    def test_create_private_group_adds_group_to_session(self, db_session, creator, svc):
+    def test_it_adds_group_to_session(self, db_session, creator, svc):
         group = svc.create_private_group('Anteater fans', creator.userid)
 
         assert group in db_session
 
-    def test_create_private_group_sets_group_ids(self, creator, svc):
+    def test_it_sets_group_ids(self, creator, svc):
         group = svc.create_private_group('Anteater fans', creator.userid)
 
         assert group.id
         assert group.pubid
 
-    def test_create_private_group_publishes_join_event(self, svc, creator, publish):
+    def test_it_publishes_join_event(self, svc, creator, publish):
         group = svc.create_private_group('Dishwasher disassemblers', creator.userid)
 
         publish.assert_called_once_with('group-join', group.pubid, creator.userid)
@@ -90,7 +90,7 @@ class TestGroupServiceCreatePrivateGroup(object):
 
 class TestGroupServiceCreateOpenGroup(object):
 
-    def test_create_open_group_returns_group_model(self, creator, svc, origins):
+    def test_it_returns_group_model(self, creator, svc, origins):
         group = svc.create_open_group('Anteater fans', creator.userid, origins=origins)
 
         assert isinstance(group, Group)
@@ -100,22 +100,22 @@ class TestGroupServiceCreateOpenGroup(object):
         ('description', 'test description'),
         ('authority', 'example.com')
     ])
-    def test_create_open_group_creates_group_attrs(self, creator, svc, origins, group_attr, expected_value):
+    def test_it_creates_group_attrs(self, creator, svc, origins, group_attr, expected_value):
         group = svc.create_open_group('test group', creator.userid, origins=origins, description='test description')
 
         assert getattr(group, group_attr) == expected_value
 
-    def test_create_open_group_skips_setting_description_when_missing(self, svc, creator, origins):
+    def test_it_skips_setting_description_when_missing(self, svc, creator, origins):
         group = svc.create_open_group('Anteater fans', creator.userid, origins=origins)
 
         assert group.description is None
 
-    def test_create_open_group_sets_group_creator(self, svc, creator, origins):
+    def test_it_sets_group_creator(self, svc, creator, origins):
         group = svc.create_open_group('Anteater fans', creator.userid, origins=origins)
 
         assert group.creator == creator
 
-    def test_create_open_group_does_not_add_group_creator_to_members(self, svc, creator, origins):
+    def test_it_does_not_add_group_creator_to_members(self, svc, creator, origins):
         group = svc.create_open_group('Anteater fans', creator.userid, origins=origins)
 
         assert creator not in group.members
@@ -124,35 +124,35 @@ class TestGroupServiceCreateOpenGroup(object):
         ('joinable_by', None),
         ('readable_by', ReadableBy.world),
         ('writeable_by', WriteableBy.authority)])
-    def test_create_open_group_sets_access_flags(self, svc, creator, origins, flag, expected_value):
+    def test_it_sets_access_flags(self, svc, creator, origins, flag, expected_value):
         group = svc.create_open_group('Anteater fans', creator.userid, origins=origins)
 
         assert getattr(group, flag) == expected_value
 
-    def test_create_open_group_creates_group_with_default_organization(
+    def test_it_creates_group_with_default_organization(
             self, default_organization, creator, svc, origins):
         group = svc.create_open_group('Anteater fans', creator.userid, origins=origins)
 
         assert group.organization == default_organization
 
-    def test_create_open_group_creates_group_with_specified_organization(self, factories, creator, svc, origins):
+    def test_it_creates_group_with_specified_organization(self, factories, creator, svc, origins):
         org = factories.Organization()
 
         group = svc.create_open_group('Anteater fans', creator.userid, origins=origins, organization=org)
 
         assert group.organization == org
 
-    def test_create_open_group_adds_group_to_session(self, db_session, creator, svc, origins):
+    def test_it_adds_group_to_session(self, db_session, creator, svc, origins):
         group = svc.create_open_group('Anteater fans', creator.userid, origins=origins)
 
         assert group in db_session
 
-    def test_create_open_group_does_not_publish_join_event(self, svc, creator, publish, origins):
+    def test_it_does_not_publish_join_event(self, svc, creator, publish, origins):
         svc.create_open_group('Dishwasher disassemblers', creator.userid, origins=origins)
 
         publish.assert_not_called()
 
-    def test_create_open_group_sets_scopes(self, svc, matchers, creator):
+    def test_it_sets_scopes(self, svc, matchers, creator):
         origins = ['https://biopub.org', 'http://example.com', 'https://wikipedia.com']
 
         group = svc.create_open_group(name='test_group', userid=creator.userid, origins=origins)
@@ -160,7 +160,7 @@ class TestGroupServiceCreateOpenGroup(object):
         assert group.scopes == matchers.unordered_list([
             GroupScopeWithOrigin(h) for h in origins])
 
-    def test_create_open_group_always_creates_new_scopes(self, db_session, factories, svc, creator, matchers):
+    def test_it_always_creates_new_scopes(self, db_session, factories, svc, creator, matchers):
         # It always creates a new scope, even if a scope with the given origin
         # already exists (this is because a single scope can only belong to
         # one group, so the existing scope can't be reused with the new group).
@@ -174,7 +174,7 @@ class TestGroupServiceCreateOpenGroup(object):
 
 class TestGroupServiceCreateRestrictedGroup(object):
 
-    def test_create_restricted_group_returns_group_model(self, creator, svc, origins):
+    def test_it_returns_group_model(self, creator, svc, origins):
         group = svc.create_restricted_group('Anteater fans', creator.userid, origins=origins)
 
         assert isinstance(group, Group)
@@ -184,22 +184,22 @@ class TestGroupServiceCreateRestrictedGroup(object):
         ('description', 'test description'),
         ('authority', 'example.com')
     ])
-    def test_create_restricted_group_creates_group_attrs(self, creator, svc, origins, group_attr, expected_value):
+    def test_it_creates_group_attrs(self, creator, svc, origins, group_attr, expected_value):
         group = svc.create_restricted_group('test group', creator.userid, origins=origins, description='test description')
 
         assert getattr(group, group_attr) == expected_value
 
-    def test_create_restricted_group_skips_setting_description_when_missing(self, svc, creator, origins):
+    def test_it_skips_setting_description_when_missing(self, svc, creator, origins):
         group = svc.create_restricted_group('Anteater fans', creator.userid, origins=origins)
 
         assert group.description is None
 
-    def test_create_restricted_group_sets_group_creator(self, svc, creator, origins):
+    def test_it_sets_group_creator(self, svc, creator, origins):
         group = svc.create_restricted_group('Anteater fans', creator.userid, origins=origins)
 
         assert group.creator == creator
 
-    def test_create_restricted_group_adds_group_creator_to_members(self, svc, creator, origins):
+    def test_it_adds_group_creator_to_members(self, svc, creator, origins):
         group = svc.create_restricted_group('Anteater fans', creator.userid, origins=origins)
 
         assert creator in group.members
@@ -208,35 +208,35 @@ class TestGroupServiceCreateRestrictedGroup(object):
         ('joinable_by', None),
         ('readable_by', ReadableBy.world),
         ('writeable_by', WriteableBy.members)])
-    def test_create_restricted_group_sets_access_flags(self, svc, creator, origins, flag, expected_value):
+    def test_it_sets_access_flags(self, svc, creator, origins, flag, expected_value):
         group = svc.create_restricted_group('Anteater fans', creator.userid, origins=origins)
 
         assert getattr(group, flag) == expected_value
 
-    def test_create_restricted_group_creates_group_with_default_organization(
+    def test_it_creates_group_with_default_organization(
             self, default_organization, creator, svc, origins):
         group = svc.create_restricted_group('Anteater fans', creator.userid, origins=origins)
 
         assert group.organization == default_organization
 
-    def test_create_restricted_group_creates_group_with_specified_organization(self, factories, creator, svc, origins):
+    def test_it_creates_group_with_specified_organization(self, factories, creator, svc, origins):
         org = factories.Organization()
 
         group = svc.create_restricted_group('Anteater fans', creator.userid, origins=origins, organization=org)
 
         assert group.organization == org
 
-    def test_create_restricted_group_adds_group_to_session(self, db_session, creator, svc, origins):
+    def test_it_adds_group_to_session(self, db_session, creator, svc, origins):
         group = svc.create_restricted_group('Anteater fans', creator.userid, origins=origins)
 
         assert group in db_session
 
-    def test_create_restricted_group_publishes_join_event(self, svc, creator, publish, origins):
+    def test_it_publishes_join_event(self, svc, creator, publish, origins):
         group = svc.create_restricted_group('Dishwasher disassemblers', creator.userid, origins=origins)
 
         publish.assert_called_once_with('group-join', group.pubid, creator.userid)
 
-    def test_create_restricted_group_sets_scopes(self, svc, matchers, creator):
+    def test_it_sets_scopes(self, svc, matchers, creator):
         origins = ['https://biopub.org', 'http://example.com', 'https://wikipedia.com']
 
         group = svc.create_restricted_group(name='test_group', userid=creator.userid, origins=origins)
@@ -244,7 +244,7 @@ class TestGroupServiceCreateRestrictedGroup(object):
         assert group.scopes == matchers.unordered_list([
             GroupScopeWithOrigin(h) for h in origins])
 
-    def test_create_restricted_group_with_mismatched_authorities_raises_value_error(
+    def test_it_with_mismatched_authorities_raises_value_error(
             self, db_session, svc, origins, creator, factories):
         org = factories.Organization(
             name='My organization',
@@ -257,7 +257,7 @@ class TestGroupServiceCreateRestrictedGroup(object):
                                         description='test_description',
                                         organization=org)
 
-    def test_create_restricted_group_always_creates_new_scopes(self, db_session, factories, svc, creator, matchers):
+    def test_it_always_creates_new_scopes(self, db_session, factories, svc, creator, matchers):
         # It always creates a new scope, even if a scope with the given origin
         # already exists (this is because a single scope can only belong to
         # one group, so the existing scope can't be reused with the new group).
@@ -274,14 +274,14 @@ class TestGroupServiceCreateRestrictedGroup(object):
 
 class TestGroupServiceMemberJoin(object):
 
-    def test_member_join_adds_user_to_group(self, svc, factories):
+    def test_it_adds_user_to_group(self, svc, factories):
         user = factories.User()
         group = factories.Group()
         svc.member_join(group, user.userid)
 
         assert user in group.members
 
-    def test_member_join_is_idempotent(self, svc, factories):
+    def test_it_is_idempotent(self, svc, factories):
         user = factories.User()
         group = factories.Group()
         svc.member_join(group, user.userid)
@@ -289,7 +289,7 @@ class TestGroupServiceMemberJoin(object):
 
         assert group.members.count(user) == 1
 
-    def test_member_join_publishes_join_event(self, svc, factories, publish):
+    def test_it_publishes_join_event(self, svc, factories, publish):
         group = factories.Group()
         user = factories.User()
 
@@ -300,7 +300,7 @@ class TestGroupServiceMemberJoin(object):
 
 class TestGroupServiceMemberLeave(object):
 
-    def test_member_leave_removes_user_from_group(self, svc, factories, creator):
+    def test_it_removes_user_from_group(self, svc, factories, creator):
         group = factories.Group(creator=creator)
         new_member = factories.User()
         group.members.append(new_member)
@@ -309,7 +309,7 @@ class TestGroupServiceMemberLeave(object):
 
         assert new_member not in group.members
 
-    def test_member_leave_is_idempotent(self, svc, factories, creator):
+    def test_it_is_idempotent(self, svc, factories, creator):
         group = factories.Group(creator=creator)
         new_member = factories.User()
         group.members.append(new_member)
@@ -319,7 +319,7 @@ class TestGroupServiceMemberLeave(object):
 
         assert new_member not in group.members
 
-    def test_member_leave_publishes_leave_event(self, svc, factories, publish):
+    def test_it_publishes_leave_event(self, svc, factories, publish):
         group = factories.Group()
         new_member = factories.User()
         group.members.append(new_member)
@@ -331,7 +331,7 @@ class TestGroupServiceMemberLeave(object):
 
 class TestGroupServiceUpdateMembership(object):
 
-    def test_update_membership_adds_users_in_usernames(self, factories, svc):
+    def test_it_adds_users_in_usernames(self, factories, svc):
         group = factories.OpenGroup()  # no members at outset
         new_members = [
             factories.User(),
@@ -349,7 +349,7 @@ class TestGroupServiceUpdateMembership(object):
         for member in new_members:
             assert member in group.members
 
-    def test_update_membership_removes_members_not_present_in_usernames(self, factories, svc, creator):
+    def test_it_removes_members_not_present_in_usernames(self, factories, svc, creator):
         group = factories.Group(creator=creator)  # creator will be a member
         new_members = [
             factories.User(),
@@ -362,7 +362,7 @@ class TestGroupServiceUpdateMembership(object):
 
         assert not group.members  # including the creator
 
-    def test_update_membership_does_not_remove_members_present_in_usernames(self, factories, svc, publish):
+    def test_it_does_not_remove_members_present_in_usernames(self, factories, svc, publish):
         group = factories.OpenGroup()  # no members at outset
         new_members = [
             factories.User(),
@@ -377,7 +377,7 @@ class TestGroupServiceUpdateMembership(object):
         assert new_members[1] in group.members
         publish.assert_not_called()
 
-    def test_update_membership_proxies_to_member_join_and_leave(self, factories, svc):
+    def test_it_proxies_to_member_join_and_leave(self, factories, svc):
         svc.member_join = mock.Mock()
         svc.member_leave = mock.Mock()
 
@@ -397,7 +397,7 @@ class TestGroupServiceUpdateMembership(object):
 class TestGroupServiceGroupIds(object):
 
     @pytest.mark.parametrize('with_user', [True, False])
-    def test_groupids_readable_by_includes_world(self, with_user, svc, db_session, factories):
+    def test_readable_by_includes_world(self, with_user, svc, db_session, factories):
         user = None
         if with_user:
             user = factories.User()
@@ -406,7 +406,7 @@ class TestGroupServiceGroupIds(object):
         assert '__world__' in svc.groupids_readable_by(user)
 
     @pytest.mark.parametrize('with_user', [True, False])
-    def test_groupids_readable_by_includes_world_readable_groups(self, with_user, svc, db_session, factories):
+    def test_readable_by_includes_world_readable_groups(self, with_user, svc, db_session, factories):
         # group readable by members
         factories.Group(readable_by=ReadableBy.members)
         # group readable by everyone
@@ -419,7 +419,7 @@ class TestGroupServiceGroupIds(object):
 
         assert group.pubid in svc.groupids_readable_by(user)
 
-    def test_groupids_readable_by_includes_memberships(self, svc, db_session, factories):
+    def test_readable_by_includes_memberships(self, svc, db_session, factories):
         user = factories.User()
 
         group = factories.Group(readable_by=ReadableBy.members)
@@ -429,13 +429,13 @@ class TestGroupServiceGroupIds(object):
 
         assert group.pubid in svc.groupids_readable_by(user)
 
-    def test_groupids_created_by_includes_created_groups(self, svc, factories):
+    def test_created_by_includes_created_groups(self, svc, factories):
         user = factories.User()
         group = factories.Group(creator=user)
 
         assert group.pubid in svc.groupids_created_by(user)
 
-    def test_groupids_created_by_excludes_other_groups(self, svc, db_session, factories):
+    def test_created_by_excludes_other_groups(self, svc, db_session, factories):
         user = factories.User()
         private_group = factories.Group()
         private_group.members.append(user)
@@ -444,7 +444,7 @@ class TestGroupServiceGroupIds(object):
 
         assert svc.groupids_created_by(user) == []
 
-    def test_groupids_created_by_returns_empty_list_for_missing_user(self, svc):
+    def test_created_by_returns_empty_list_for_missing_user(self, svc):
         assert svc.groupids_created_by(None) == []
 
 

--- a/tests/h/services/group_test.py
+++ b/tests/h/services/group_test.py
@@ -14,6 +14,8 @@ from tests.common.matchers import Matcher
 
 
 class TestGroupServiceCreatePrivateGroup(object):
+    """Unit tests for :py:meth:`GroupService.create_private_group`"""
+
     def test_it_returns_group_model(self, creator, svc):
         group = svc.create_private_group('Anteater fans', creator.userid)
 
@@ -89,6 +91,7 @@ class TestGroupServiceCreatePrivateGroup(object):
 
 
 class TestGroupServiceCreateOpenGroup(object):
+    """Unit tests for :py:meth:`GroupService.create_open_group`"""
 
     def test_it_returns_group_model(self, creator, svc, origins):
         group = svc.create_open_group('Anteater fans', creator.userid, origins=origins)
@@ -173,6 +176,7 @@ class TestGroupServiceCreateOpenGroup(object):
 
 
 class TestGroupServiceCreateRestrictedGroup(object):
+    """Unit tests for :py:meth:`GroupService.create_restricted_group`"""
 
     def test_it_returns_group_model(self, creator, svc, origins):
         group = svc.create_restricted_group('Anteater fans', creator.userid, origins=origins)
@@ -273,6 +277,7 @@ class TestGroupServiceCreateRestrictedGroup(object):
 
 
 class TestGroupServiceMemberJoin(object):
+    """Unit tests for :py:meth:`GroupService.member_join`"""
 
     def test_it_adds_user_to_group(self, svc, factories):
         user = factories.User()
@@ -299,6 +304,7 @@ class TestGroupServiceMemberJoin(object):
 
 
 class TestGroupServiceMemberLeave(object):
+    """Unit tests for :py:meth:`GroupService.member_leave`"""
 
     def test_it_removes_user_from_group(self, svc, factories, creator):
         group = factories.Group(creator=creator)
@@ -330,6 +336,7 @@ class TestGroupServiceMemberLeave(object):
 
 
 class TestGroupServiceUpdateMembership(object):
+    """Unit tests for :py:meth:`GroupService.update_membership`"""
 
     def test_it_adds_users_in_usernames(self, factories, svc):
         group = factories.OpenGroup()  # no members at outset
@@ -395,6 +402,10 @@ class TestGroupServiceUpdateMembership(object):
 
 
 class TestGroupServiceGroupIds(object):
+    """Unit tests for methods related to group IDs:
+        - :py:meth:`GroupService.groupids_readable_by`
+        - :py:meth:`GroupService.groupids_created_by`
+    """
 
     @pytest.mark.parametrize('with_user', [True, False])
     def test_readable_by_includes_world(self, with_user, svc, db_session, factories):

--- a/tests/h/services/group_test.py
+++ b/tests/h/services/group_test.py
@@ -5,344 +5,409 @@ from __future__ import unicode_literals
 import mock
 import pytest
 
-from h.models import Group, GroupScope
+from h.models import Group, User, GroupScope
 from h.models.group import JoinableBy, ReadableBy, WriteableBy
 from h.services.group import GroupService
 from h.services.group import groups_factory
-from h.services.organization import OrganizationService
-
+from h.services.user import UserService
 from tests.common.matchers import Matcher
 
 
-class TestGroupService(object):
-    def test_create_private_group_returns_group(self, service):
-        group = service.create_private_group('Anteater fans', 'cazimir')
+class TestGroupServiceCreatePrivateGroup(object):
+    def test_create_private_group_returns_group_model(self, creator, svc):
+        group = svc.create_private_group('Anteater fans', creator.userid)
 
         assert isinstance(group, Group)
 
-    def test_create_private_group_sets_group_name(self, service):
-        group = service.create_private_group('Anteater fans', 'cazimir')
+    def test_create_private_group_sets_group_name(self, creator, svc):
+        group = svc.create_private_group('Anteater fans', creator.userid)
 
         assert group.name == 'Anteater fans'
 
-    def test_create_private_group_sets_group_authority(self, service):
-        group = service.create_private_group('Anteater fans', 'cazimir')
+    def test_create_private_group_sets_group_authority(self, svc, creator, pyramid_request):
+        group = svc.create_private_group('Anteater fans', creator.userid)
 
-        assert group.authority == 'example.com'
+        assert group.authority == pyramid_request.authority
 
-    def test_create_private_group_sets_group_creator(self, service, users):
-        group = service.create_private_group('Anteater fans', 'cazimir')
+    def test_create_private_group_sets_group_creator(self, svc, creator):
+        group = svc.create_private_group('Anteater fans', creator.userid)
 
-        assert group.creator == users['cazimir']
+        assert group.creator == creator
 
-    def test_create_private_group_sets_description_when_present(self, service):
-        group = service.create_private_group('Anteater fans', 'cazimir', 'all about ant eaters')
+    def test_create_private_group_sets_description_when_present(self, svc, creator):
+        group = svc.create_private_group('Anteater fans', creator.userid, 'all about ant eaters')
 
         assert group.description == 'all about ant eaters'
 
-    def test_create_private_group_skips_setting_description_when_missing(self, service):
-        group = service.create_private_group('Anteater fans', 'cazimir')
+    def test_create_private_group_skips_setting_description_when_missing(self, svc, creator):
+        group = svc.create_private_group('Anteater fans', creator.userid)
 
         assert group.description is None
 
-    def test_create_private_group_adds_group_creator_to_members(self, service, users):
-        group = service.create_private_group('Anteater fans', 'cazimir')
+    def test_create_private_group_adds_group_creator_to_members(self, svc, creator):
+        group = svc.create_private_group('Anteater fans', creator.userid)
 
-        assert users['cazimir'] in group.members
+        assert creator in group.members
 
     @pytest.mark.parametrize('flag,expected_value', [
         ('joinable_by', JoinableBy.authority),
         ('readable_by', ReadableBy.members),
         ('writeable_by', WriteableBy.members)])
-    def test_create_private_group_sets_access_flags(self, service, flag, expected_value):
-        group = service.create_private_group('Anteater fans', 'cazimir')
+    def test_create_private_group_sets_access_flags(self, svc, creator, flag, expected_value):
+        group = svc.create_private_group('Anteater fans', creator.userid)
 
         assert getattr(group, flag) == expected_value
 
     def test_create_private_group_creates_group_with_default_organization(
-            self, default_organization, service):
-        group = service.create_private_group('Anteater fans', 'cazimir')
+            self, default_organization, creator, svc):
+        group = svc.create_private_group('Anteater fans', creator.userid)
 
         assert group.organization == default_organization
 
-    def test_create_private_group_creates_group_with_specified_organization(
-            self, db_session, service):
-        org = OrganizationService(db_session).create(
-            name='My organization',
-            authority='example.com',
-            )
+    def test_create_private_group_creates_group_with_specified_organization(self, factories, creator, svc):
+        org = factories.Organization()
 
-        group = service.create_private_group('Anteater fans', 'cazimir', organization=org)
+        group = svc.create_private_group('Anteater fans', creator.userid, organization=org)
 
         assert group.organization == org
 
-    def test_create_private_group_adds_group_to_session(self, db_session, service):
-        group = service.create_private_group('Anteater fans', 'cazimir')
+    def test_create_private_group_adds_group_to_session(self, db_session, creator, svc):
+        group = svc.create_private_group('Anteater fans', creator.userid)
 
         assert group in db_session
 
-    def test_create_private_group_sets_group_ids(self, service):
-        group = service.create_private_group('Anteater fans', 'cazimir')
+    def test_create_private_group_sets_group_ids(self, creator, svc):
+        group = svc.create_private_group('Anteater fans', creator.userid)
 
         assert group.id
         assert group.pubid
 
-    def test_create_private_group_publishes_join_event(self, service, publish):
-        group = service.create_private_group('Dishwasher disassemblers', 'theresa')
+    def test_create_private_group_publishes_join_event(self, svc, creator, publish):
+        group = svc.create_private_group('Dishwasher disassemblers', creator.userid)
 
-        publish.assert_called_once_with('group-join', group.pubid, 'acct:theresa@example.com')
+        publish.assert_called_once_with('group-join', group.pubid, creator.userid)
 
-    def test_create_open_group_returns_group(self, default_organization, service, users):
-        creator = users['cazimir']
 
-        group = service.create_open_group(name='test_group',
-                                          userid=creator.username,
-                                          origins=['https://biopub.org'],
-                                          description='test_description')
+class TestGroupServiceCreateOpenGroup(object):
 
-        assert group.name == 'test_group'
-        assert group.authority == 'example.com'
+    def test_create_open_group_returns_group_model(self, creator, svc, origins):
+        group = svc.create_open_group('Anteater fans', creator.userid, origins=origins)
+
+        assert isinstance(group, Group)
+
+    @pytest.mark.parametrize('group_attr,expected_value', [
+        ('name', 'test group'),
+        ('description', 'test description'),
+        ('authority', 'example.com')
+    ])
+    def test_create_open_group_creates_group_attrs(self, creator, svc, origins, group_attr, expected_value):
+        group = svc.create_open_group('test group', creator.userid, origins=origins, description='test description')
+
+        assert getattr(group, group_attr) == expected_value
+
+    def test_create_open_group_skips_setting_description_when_missing(self, svc, creator, origins):
+        group = svc.create_open_group('Anteater fans', creator.userid, origins=origins)
+
+        assert group.description is None
+
+    def test_create_open_group_sets_group_creator(self, svc, creator, origins):
+        group = svc.create_open_group('Anteater fans', creator.userid, origins=origins)
+
         assert group.creator == creator
-        assert group.description == 'test_description'
-        assert group.joinable_by is None
-        assert group.readable_by == ReadableBy.world
-        assert group.writeable_by == WriteableBy.authority
+
+    def test_create_open_group_does_not_add_group_creator_to_members(self, svc, creator, origins):
+        group = svc.create_open_group('Anteater fans', creator.userid, origins=origins)
+
+        assert creator not in group.members
+
+    @pytest.mark.parametrize('flag,expected_value', [
+        ('joinable_by', None),
+        ('readable_by', ReadableBy.world),
+        ('writeable_by', WriteableBy.authority)])
+    def test_create_open_group_sets_access_flags(self, svc, creator, origins, flag, expected_value):
+        group = svc.create_open_group('Anteater fans', creator.userid, origins=origins)
+
+        assert getattr(group, flag) == expected_value
+
+    def test_create_open_group_creates_group_with_default_organization(
+            self, default_organization, creator, svc, origins):
+        group = svc.create_open_group('Anteater fans', creator.userid, origins=origins)
+
         assert group.organization == default_organization
 
-    def test_create_open_group_creates_group_with_specified_organization(
-            self, db_session, service, users):
-        creator = users['cazimir']
-        org = OrganizationService(db_session).create(
-            name='My organization',
-            authority='example.com',
-            )
+    def test_create_open_group_creates_group_with_specified_organization(self, factories, creator, svc, origins):
+        org = factories.Organization()
 
-        group = service.create_open_group(name='test_group',
-                                          userid=creator.username,
-                                          origins=['https://biopub.org'],
-                                          description='test_description',
-                                          organization=org)
+        group = svc.create_open_group('Anteater fans', creator.userid, origins=origins, organization=org)
 
         assert group.organization == org
 
-    def test_create_open_group_sets_scopes(self, service, matchers, users):
+    def test_create_open_group_adds_group_to_session(self, db_session, creator, svc, origins):
+        group = svc.create_open_group('Anteater fans', creator.userid, origins=origins)
+
+        assert group in db_session
+
+    def test_create_open_group_does_not_publish_join_event(self, svc, creator, publish, origins):
+        svc.create_open_group('Dishwasher disassemblers', creator.userid, origins=origins)
+
+        publish.assert_not_called()
+
+    def test_create_open_group_sets_scopes(self, svc, matchers, creator):
         origins = ['https://biopub.org', 'http://example.com', 'https://wikipedia.com']
 
-        group = service.create_open_group(name='test_group',
-                                          userid=users['cazimir'].username,
-                                          origins=origins,
-                                          description='test_description')
+        group = svc.create_open_group(name='test_group', userid=creator.userid, origins=origins)
 
         assert group.scopes == matchers.unordered_list([
             GroupScopeWithOrigin(h) for h in origins])
 
-    def test_create_open_group_always_creates_new_scopes(self, db_session, factories, service, users, matchers):
+    def test_create_open_group_always_creates_new_scopes(self, db_session, factories, svc, creator, matchers):
         # It always creates a new scope, even if a scope with the given origin
         # already exists (this is because a single scope can only belong to
         # one group, so the existing scope can't be reused with the new group).
         origins = ['https://biopub.org', 'http://example.com']
         scopes = [factories.GroupScope(origin=h) for h in origins]
 
-        group = service.create_open_group(name='test_group',
-                                          userid=users['cazimir'].username,
-                                          origins=origins,
-                                          description='test_description')
-
+        group = svc.create_open_group(name='test_group', userid=creator.userid, origins=origins)
         for scope in scopes:
             assert scope not in group.scopes
 
-    def test_create_open_group_description_defaults_to_None(self, service):  # noqa: N802
-        # Create a group with no `description` argument.
-        group = service.create_open_group(name='test_group',
-                                          userid='cazimir',
-                                          origins=['https://biopub.org'])
+
+class TestGroupServiceCreateRestrictedGroup(object):
+
+    def test_create_restricted_group_returns_group_model(self, creator, svc, origins):
+        group = svc.create_restricted_group('Anteater fans', creator.userid, origins=origins)
+
+        assert isinstance(group, Group)
+
+    @pytest.mark.parametrize('group_attr,expected_value', [
+        ('name', 'test group'),
+        ('description', 'test description'),
+        ('authority', 'example.com')
+    ])
+    def test_create_restricted_group_creates_group_attrs(self, creator, svc, origins, group_attr, expected_value):
+        group = svc.create_restricted_group('test group', creator.userid, origins=origins, description='test description')
+
+        assert getattr(group, group_attr) == expected_value
+
+    def test_create_restricted_group_skips_setting_description_when_missing(self, svc, creator, origins):
+        group = svc.create_restricted_group('Anteater fans', creator.userid, origins=origins)
 
         assert group.description is None
 
-    def test_create_restricted_group_returns_group(self, default_organization, service, users):
-        creator = users['cazimir']
+    def test_create_restricted_group_sets_group_creator(self, svc, creator, origins):
+        group = svc.create_restricted_group('Anteater fans', creator.userid, origins=origins)
 
-        group = service.create_restricted_group(name='test_group',
-                                                userid=creator.username,
-                                                origins=['https://biopub.org'],
-                                                description='test_description')
-
-        assert group.name == 'test_group'
-        assert group.authority == 'example.com'
         assert group.creator == creator
-        assert group.description == 'test_description'
-        assert group.joinable_by is None
-        assert group.readable_by == ReadableBy.world
-        assert group.writeable_by == WriteableBy.members
-        assert group.organization == default_organization
+
+    def test_create_restricted_group_adds_group_creator_to_members(self, svc, creator, origins):
+        group = svc.create_restricted_group('Anteater fans', creator.userid, origins=origins)
+
         assert creator in group.members
 
-    def test_create_restricted_group_creates_group_with_specified_organization(
-            self, db_session, service, users):
-        creator = users['cazimir']
-        org = OrganizationService(db_session).create(
-            name='My organization',
-            authority='example.com',
-            )
+    @pytest.mark.parametrize('flag,expected_value', [
+        ('joinable_by', None),
+        ('readable_by', ReadableBy.world),
+        ('writeable_by', WriteableBy.members)])
+    def test_create_restricted_group_sets_access_flags(self, svc, creator, origins, flag, expected_value):
+        group = svc.create_restricted_group('Anteater fans', creator.userid, origins=origins)
 
-        group = service.create_restricted_group(name='test_group',
-                                                userid=creator.username,
-                                                origins=['https://biopub.org'],
-                                                description='test_description',
-                                                organization=org)
+        assert getattr(group, flag) == expected_value
+
+    def test_create_restricted_group_creates_group_with_default_organization(
+            self, default_organization, creator, svc, origins):
+        group = svc.create_restricted_group('Anteater fans', creator.userid, origins=origins)
+
+        assert group.organization == default_organization
+
+    def test_create_restricted_group_creates_group_with_specified_organization(self, factories, creator, svc, origins):
+        org = factories.Organization()
+
+        group = svc.create_restricted_group('Anteater fans', creator.userid, origins=origins, organization=org)
 
         assert group.organization == org
 
+    def test_create_restricted_group_adds_group_to_session(self, db_session, creator, svc, origins):
+        group = svc.create_restricted_group('Anteater fans', creator.userid, origins=origins)
+
+        assert group in db_session
+
+    def test_create_restricted_group_publishes_join_event(self, svc, creator, publish, origins):
+        group = svc.create_restricted_group('Dishwasher disassemblers', creator.userid, origins=origins)
+
+        publish.assert_called_once_with('group-join', group.pubid, creator.userid)
+
+    def test_create_restricted_group_sets_scopes(self, svc, matchers, creator):
+        origins = ['https://biopub.org', 'http://example.com', 'https://wikipedia.com']
+
+        group = svc.create_restricted_group(name='test_group', userid=creator.userid, origins=origins)
+
+        assert group.scopes == matchers.unordered_list([
+            GroupScopeWithOrigin(h) for h in origins])
+
     def test_create_restricted_group_with_mismatched_authorities_raises_value_error(
-            self, db_session, service, users):
-        creator = users['cazimir']
-        org = OrganizationService(db_session).create(
+            self, db_session, svc, origins, creator, factories):
+        org = factories.Organization(
             name='My organization',
             authority='bar.com',
             )
         with pytest.raises(ValueError):
-            service.create_restricted_group(name='test_group',
-                                            userid=creator.username,
-                                            origins=['https://biopub.org'],
-                                            description='test_description',
-                                            organization=org)
+            svc.create_restricted_group(name='test_group',
+                                        userid=creator.userid,
+                                        origins=origins,
+                                        description='test_description',
+                                        organization=org)
 
-    def test_create_restricted_group_adds_group_creator_to_members(self, service, users):
-        creator = users['cazimir']
-
-        group = service.create_restricted_group(name='test_group',
-                                                userid=creator.username,
-                                                origins=['https://biopub.org'],
-                                                description='test_description')
-
-        assert creator in group.members
-
-    def test_create_restricted_group_publishes_join_event(self, publish, service, users):
-        creator = users['cazimir']
-
-        group = service.create_restricted_group(name='test_group',
-                                                userid=creator.username,
-                                                origins=['https://biopub.org'],
-                                                description='test_description')
-
-        publish.assert_called_once_with('group-join', group.pubid, 'acct:cazimir@example.com')
-
-    def test_create_restricted_group_sets_scopes(self, service, matchers, users):
-        origins = ['https://biopub.org', 'http://example.com', 'https://wikipedia.com']
-
-        group = service.create_restricted_group(name='test_group',
-                                                userid=users['cazimir'].username,
-                                                origins=origins,
-                                                description='test_description')
-
-        assert group.scopes == matchers.unordered_list([
-            GroupScopeWithOrigin(h) for h in origins])
-
-    def test_create_restricted_group_always_creates_new_scopes(self, db_session, factories, service, users, matchers):
+    def test_create_restricted_group_always_creates_new_scopes(self, db_session, factories, svc, creator, matchers):
         # It always creates a new scope, even if a scope with the given origin
         # already exists (this is because a single scope can only belong to
         # one group, so the existing scope can't be reused with the new group).
         origins = ['https://biopub.org', 'http://example.com']
         scopes = [factories.GroupScope(origin=h) for h in origins]
 
-        group = service.create_restricted_group(name='test_group',
-                                                userid=users['cazimir'].username,
-                                                origins=origins,
-                                                description='test_description')
+        group = svc.create_restricted_group(name='test_group',
+                                            userid=creator.userid,
+                                            origins=origins)
 
         for scope in scopes:
             assert scope not in group.scopes
 
-    def test_create_restricted_group_description_defaults_to_None(self, service):  # noqa: N802
-        # Create a restricted group with no `description` argument.
-        group = service.create_restricted_group(name='test_group',
-                                                userid='cazimir',
-                                                origins=['https://biopub.org'])
 
-        assert group.description is None
+class TestGroupServiceMemberJoin(object):
 
-    def test_member_join_adds_user_to_group(self, service, group, users):
-        service.member_join(group, 'theresa')
+    def test_member_join_adds_user_to_group(self, svc, factories):
+        user = factories.User()
+        group = factories.Group()
+        svc.member_join(group, user.userid)
 
-        assert users['theresa'] in group.members
+        assert user in group.members
 
-    def test_member_join_is_idempotent(self, service, group, users):
-        service.member_join(group, 'theresa')
-        service.member_join(group, 'theresa')
+    def test_member_join_is_idempotent(self, svc, factories):
+        user = factories.User()
+        group = factories.Group()
+        svc.member_join(group, user.userid)
+        svc.member_join(group, user.userid)
 
-        assert group.members.count(users['theresa']) == 1
+        assert group.members.count(user) == 1
 
-    def test_member_join_publishes_join_event(self, service, publish, group):
-        group.pubid = 'abc123'
+    def test_member_join_publishes_join_event(self, svc, factories, publish):
+        group = factories.Group()
+        user = factories.User()
 
-        service.member_join(group, 'theresa')
+        svc.member_join(group, user.userid)
 
-        publish.assert_called_once_with('group-join', 'abc123', 'theresa')
+        publish.assert_called_once_with('group-join', group.pubid, user.userid)
 
-    def test_member_leave_removes_user_from_group(self, service, users):
-        group = Group(name='Theresa and her buddies',
-                      authority='foobar.com',
-                      creator=users['theresa'])
-        group.members.append(users['cazimir'])
 
-        service.member_leave(group, 'cazimir')
+class TestGroupServiceMemberLeave(object):
 
-        assert users['cazimir'] not in group.members
+    def test_member_leave_removes_user_from_group(self, svc, factories, creator):
+        group = factories.Group(creator=creator)
+        new_member = factories.User()
+        group.members.append(new_member)
 
-    def test_member_leave_is_idempotent(self, service, users):
-        group = Group(name='Theresa and her buddies',
-                      authority='foobar.com',
-                      creator=users['theresa'])
-        group.members.append(users['cazimir'])
+        svc.member_leave(group, new_member.userid)
 
-        service.member_leave(group, 'cazimir')
-        service.member_leave(group, 'cazimir')
+        assert new_member not in group.members
 
-        assert users['cazimir'] not in group.members
+    def test_member_leave_is_idempotent(self, svc, factories, creator):
+        group = factories.Group(creator=creator)
+        new_member = factories.User()
+        group.members.append(new_member)
 
-    def test_member_leave_publishes_leave_event(self, service, users, publish):
-        group = Group(name='Donkey Trust',
-                      authority='foobari.com',
-                      creator=users['theresa'])
-        group.members.append(users['cazimir'])
-        group.pubid = 'abc123'
+        svc.member_leave(group, new_member.userid)
+        svc.member_leave(group, new_member.userid)
 
-        service.member_leave(group, 'cazimir')
+        assert new_member not in group.members
 
-        publish.assert_called_once_with('group-leave', 'abc123', 'cazimir')
+    def test_member_leave_publishes_leave_event(self, svc, factories, publish):
+        group = factories.Group()
+        new_member = factories.User()
+        group.members.append(new_member)
 
-    def test_update_memberships_adds_and_remove_members(self, factories, publish, service, users):
-        group = Group(name='Donkey Trust',
-                      authority='example.com',
-                      creator=users['theresa'])
-        group.pubid = 'abc123'
-        service.member_join = mock.Mock()
-        service.member_leave = mock.Mock()
+        svc.member_leave(group, new_member.userid)
 
-        group.members.append(users['cazimir'])
-        group.members.append(users['theresa'])
-        group.members.append(users['ali'])
+        assert publish.called_once_with('group-leave', group.pubid, new_member.userid)
 
-        service.update_membership(group, [users['henry'].username, users['poppy'].username, users['theresa'].username])
 
-        assert len(service.member_leave.call_args_list) == 2
-        service.member_leave.assert_any_call(group, users['cazimir'].userid)
-        service.member_leave.assert_any_call(group, users['ali'].userid)
-        assert len(service.member_join.call_args_list) == 2
-        service.member_join.assert_any_call(group, users['henry'].userid)
-        service.member_join.assert_any_call(group, users['poppy'].userid)
+class TestGroupServiceUpdateMembership(object):
+
+    def test_update_membership_adds_users_in_usernames(self, factories, svc):
+        group = factories.OpenGroup()  # no members at outset
+        new_members = [
+            factories.User(),
+            factories.User()
+        ]
+
+        svc.update_membership(group, [user.username for user in new_members])
+
+        # The following is the desired end state but the ordering is currently non-deterministic
+        # TODO refactor method such that ordering is deterministic
+        # assert group.members == new_members
+
+        for member in group.members:
+            assert member in new_members
+        for member in new_members:
+            assert member in group.members
+
+    def test_update_membership_removes_members_not_present_in_usernames(self, factories, svc, creator):
+        group = factories.Group(creator=creator)  # creator will be a member
+        new_members = [
+            factories.User(),
+            factories.User()
+        ]
+        group.members.append(new_members[0])
+        group.members.append(new_members[1])
+
+        svc.update_membership(group, [])
+
+        assert not group.members  # including the creator
+
+    def test_update_membership_does_not_remove_members_present_in_usernames(self, factories, svc, publish):
+        group = factories.OpenGroup()  # no members at outset
+        new_members = [
+            factories.User(),
+            factories.User()
+        ]
+        group.members.append(new_members[0])
+        group.members.append(new_members[1])
+
+        svc.update_membership(group, [user.username for user in group.members])
+
+        assert new_members[0] in group.members
+        assert new_members[1] in group.members
+        publish.assert_not_called()
+
+    def test_update_membership_proxies_to_member_join_and_leave(self, factories, svc):
+        svc.member_join = mock.Mock()
+        svc.member_leave = mock.Mock()
+
+        group = factories.OpenGroup()  # no members at outset
+        new_members = [
+            factories.User(),
+            factories.User()
+        ]
+        group.members.append(new_members[0])
+        print group.members
+
+        svc.update_membership(group, [new_members[1].username])
+
+        svc.member_join.assert_called_once_with(group, new_members[1].userid)
+        svc.member_leave.assert_called_once_with(group, new_members[0].userid)
+
+
+class TestGroupServiceGroupIds(object):
 
     @pytest.mark.parametrize('with_user', [True, False])
-    def test_groupids_readable_by_includes_world(self, with_user, service, db_session, factories):
+    def test_groupids_readable_by_includes_world(self, with_user, svc, db_session, factories):
         user = None
         if with_user:
             user = factories.User()
             db_session.flush()
 
-        assert '__world__' in service.groupids_readable_by(user)
+        assert '__world__' in svc.groupids_readable_by(user)
 
     @pytest.mark.parametrize('with_user', [True, False])
-    def test_groupids_readable_by_includes_world_readable_groups(self, with_user, service, db_session, factories):
+    def test_groupids_readable_by_includes_world_readable_groups(self, with_user, svc, db_session, factories):
         # group readable by members
         factories.Group(readable_by=ReadableBy.members)
         # group readable by everyone
@@ -353,9 +418,9 @@ class TestGroupService(object):
             user = factories.User()
             db_session.flush()
 
-        assert group.pubid in service.groupids_readable_by(user)
+        assert group.pubid in svc.groupids_readable_by(user)
 
-    def test_groupids_readable_by_includes_memberships(self, service, db_session, factories):
+    def test_groupids_readable_by_includes_memberships(self, svc, db_session, factories):
         user = factories.User()
 
         group = factories.Group(readable_by=ReadableBy.members)
@@ -363,39 +428,25 @@ class TestGroupService(object):
 
         db_session.flush()
 
-        assert group.pubid in service.groupids_readable_by(user)
+        assert group.pubid in svc.groupids_readable_by(user)
 
-    def test_groupids_created_by_includes_created_groups(self, service, factories):
+    def test_groupids_created_by_includes_created_groups(self, svc, factories):
         user = factories.User()
         group = factories.Group(creator=user)
 
-        assert group.pubid in service.groupids_created_by(user)
+        assert group.pubid in svc.groupids_created_by(user)
 
-    def test_groupids_created_by_excludes_other_groups(self, service, db_session, factories):
+    def test_groupids_created_by_excludes_other_groups(self, svc, db_session, factories):
         user = factories.User()
         private_group = factories.Group()
         private_group.members.append(user)
         factories.Group(readable_by=ReadableBy.world)
         db_session.flush()
 
-        assert service.groupids_created_by(user) == []
+        assert svc.groupids_created_by(user) == []
 
-    def test_groupids_created_by_returns_empty_list_for_missing_user(self, service):
-        assert service.groupids_created_by(None) == []
-
-    @pytest.fixture
-    def group(self, users):
-        return Group(name='Donkey Trust',
-                     authority='foobar.com',
-                     creator=users['cazimir'])
-
-    @pytest.fixture
-    def publish(self):
-        return mock.Mock(spec_set=[])
-
-    @pytest.fixture
-    def service(self, db_session, users, publish):
-        return GroupService(db_session, users.get, publish=publish)
+    def test_groupids_created_by_returns_empty_list_for_missing_user(self, svc):
+        assert svc.groupids_created_by(None) == []
 
 
 @pytest.mark.usefixtures('user_service')
@@ -433,6 +484,43 @@ class TestGroupsFactory(object):
         })
 
 
+@pytest.fixture
+def usr_svc(pyramid_request, db_session):
+    def fetch(userid):
+        # One doesn't want to couple to the user fetching service but
+        # we do want to be able to fetch user models for internal
+        # module behavior tests
+        return db_session.query(User).filter_by(userid=userid).one_or_none()
+    return fetch
+
+
+@pytest.fixture
+def origins():
+    return ['http://example.com']
+
+
+@pytest.fixture
+def publish():
+    return mock.Mock()
+
+
+@pytest.fixture
+def svc(db_session, usr_svc, publish):
+    return GroupService(db_session, usr_svc, publish=publish)
+
+
+@pytest.fixture
+def creator(factories):
+    return factories.User(username='group_creator')
+
+
+@pytest.fixture
+def user_service(pyramid_config):
+    service = mock.create_autospec(UserService, spec_set=True, instance=True)
+    pyramid_config.register_service(service, name='user')
+    return service
+
+
 class GroupScopeWithOrigin(Matcher):
     """Matches any GroupScope with the given origin."""
 
@@ -443,22 +531,3 @@ class GroupScopeWithOrigin(Matcher):
         if not isinstance(group_scope, GroupScope):
             return False
         return group_scope.origin == self.origin
-
-
-@pytest.fixture
-def user_service(pyramid_config):
-    service = mock.Mock(spec_set=['fetch'])
-    service.fetch.return_value = None
-    pyramid_config.register_service(service, name='user')
-    return service
-
-
-@pytest.fixture
-def users(factories):
-    return {
-        'cazimir': factories.User(username='cazimir'),
-        'theresa': factories.User(username='theresa'),
-        'henry': factories.User(username='henry'),
-        'poppy': factories.User(username='poppy'),
-        'ali': factories.User(username='ali'),
-    }

--- a/tests/h/services/group_test.py
+++ b/tests/h/services/group_test.py
@@ -332,7 +332,7 @@ class TestGroupServiceMemberLeave(object):
 
         svc.member_leave(group, new_member.userid)
 
-        assert publish.called_once_with('group-leave', group.pubid, new_member.userid)
+        publish.assert_called_once_with('group-leave', group.pubid, new_member.userid)
 
 
 class TestGroupServiceUpdateMembership(object):
@@ -511,7 +511,7 @@ def origins():
 
 @pytest.fixture
 def publish():
-    return mock.Mock()
+    return mock.Mock(spec_set=[])
 
 
 @pytest.fixture

--- a/tests/h/services/group_test.py
+++ b/tests/h/services/group_test.py
@@ -387,7 +387,6 @@ class TestGroupServiceUpdateMembership(object):
             factories.User()
         ]
         group.members.append(new_members[0])
-        print group.members
 
         svc.update_membership(group, [new_members[1].username])
 


### PR DESCRIPTION
Pursuant to https://github.com/hypothesis/product-backlog/issues/578, these service tests need refactoring so that they are stable and reliable. In refactoring, I ended up with one flaky test that exposes some non-deterministic behavior in a method; I made the test pass for now and will refactor the method in question as part of the bug fix in https://github.com/hypothesis/product-backlog/issues/578

This was rather necessary–the service method calls as they were in the tests would actually raise exceptions if they were used that way in a real non-test runtime. 

Sorry this is a big (and kind of useless) diff—pretty much had to touch everything in the module.

Some tasks accomplished:

- Do not mock user fetcher (instead use one-liner as a sub)
- Use userids instead of usernames as method params expect
- Make tests more consistent across functions
- Use autospecs and cleaner mocks
- Break tests into classes for organization
- Make consistent use of factories
- Consolidate fixtures