### PR TITLE
Fix bug causing group creator to be removed as group member

### DIFF
--- a/h/services/group.py
+++ b/h/services/group.py
@@ -96,6 +96,15 @@ class GroupService(object):
                             organization=organization,
                             )
 
+    def add_members(self, group, userids):
+        """
+        Add the users indicated by userids to this group's members.
+
+        Any pre-existing members will not be affected.
+        """
+        for userid in userids:
+            self.member_join(group, userid)
+
     def update_members(self, group, userids):
         """
         Update this group's membership to be the list of users indicated by

--- a/h/services/group.py
+++ b/h/services/group.py
@@ -118,10 +118,8 @@ class GroupService(object):
         :param userids: the list of userids corresponding to users who should
                         be the members of this group
         """
-        current_member_userids = [member.userid for member in group.members]
-        userids_for_removal = list(
-            filter(lambda mem_id: mem_id not in userids, current_member_userids)
-        )
+        current_mem_ids = [member.userid for member in group.members]
+        userids_for_removal = [mem_id for mem_id in current_mem_ids if mem_id not in userids]
 
         for userid in userids:
             self.member_join(group, userid)

--- a/h/services/group.py
+++ b/h/services/group.py
@@ -96,19 +96,29 @@ class GroupService(object):
                             organization=organization,
                             )
 
-    def update_membership(self, group, usernames):
-        group_member_usernames = [member.username for member in group.members]
+    def update_members(self, group, userids):
+        """
+        Update this group's membership to be the list of users indicated by
+        userids.
 
-        usernames_to_add = list(set(usernames) - set(group_member_usernames))
-        usernames_to_remove = list(set(group_member_usernames) - set(usernames))
+        The users indicated by userids will *replace* the members of this group.
+        Any pre-existing member whose userid is not present in userids will
+        be removed as a member.
 
-        for ua in usernames_to_add:
-            uid = User(username=ua, authority=group.authority).userid
-            self.member_join(group, uid)
+        :param group:   group model
+        :param userids: the list of userids corresponding to users who should
+                        be the members of this group
+        """
+        current_member_userids = [member.userid for member in group.members]
+        userids_for_removal = list(
+            filter(lambda mem_id: mem_id not in userids, current_member_userids)
+        )
 
-        for ur in usernames_to_remove:
-            uid = User(username=ur, authority=group.authority).userid
-            self.member_leave(group, uid)
+        for userid in userids:
+            self.member_join(group, userid)
+
+        for userid in userids_for_removal:
+            self.member_leave(group, userid)
 
     def member_join(self, group, userid):
         """Add `userid` to the member list of `group`."""

--- a/h/views/admin_groups.py
+++ b/h/views/admin_groups.py
@@ -86,9 +86,9 @@ class GroupCreateController(object):
             else:
                 raise Exception('Unsupported group type {}'.format(type_))
 
-            # Update group memberships
+            # Add members to the group
             member_userids = [_userid(username, organization.authority) for username in appstruct['members']]
-            svc.update_members(group, member_userids)
+            svc.add_members(group, member_userids)
 
             # Flush changes to allocate group a pubid
             self.request.db.flush(objects=[group])

--- a/h/views/admin_groups.py
+++ b/h/views/admin_groups.py
@@ -73,7 +73,7 @@ class GroupCreateController(object):
             origins = appstruct['origins']
             type_ = appstruct['group_type']
 
-            userid = models.User(username=creator, authority=organization.authority).userid
+            userid = _userid(creator, organization.authority)
 
             if type_ == 'open':
                 group = svc.create_open_group(name=name, userid=userid,
@@ -87,7 +87,8 @@ class GroupCreateController(object):
                 raise Exception('Unsupported group type {}'.format(type_))
 
             # Update group memberships
-            svc.update_membership(group, appstruct['members'])
+            member_userids = [_userid(username, organization.authority) for username in appstruct['members']]
+            svc.update_members(group, member_userids)
 
             # Flush changes to allocate group a pubid
             self.request.db.flush(objects=[group])
@@ -164,7 +165,8 @@ class GroupEditController(object):
             group.scopes = [GroupScope(origin=o) for o in appstruct['origins']]
             group.organization = self.organizations[appstruct['organization']]
 
-            group_svc.update_membership(group, appstruct['members'])
+            memberids = [_userid(username, group.authority) for username in appstruct['members']]
+            group_svc.update_members(group, memberids)
 
             self.form = _create_form(self.request, self.schema, (_('Save'),))
             self._update_appstruct()
@@ -199,6 +201,10 @@ class GroupEditController(object):
             'annotation_count': num_annotations,
             'member_count': len(self.group.members),
         }
+
+
+def _userid(username, authority):
+    return models.User(username=username, authority=authority).userid
 
 
 def _create_form(request, schema, buttons):

--- a/tests/h/services/group_test.py
+++ b/tests/h/services/group_test.py
@@ -335,6 +335,30 @@ class TestGroupServiceMemberLeave(object):
         publish.assert_called_once_with('group-leave', group.pubid, new_member.userid)
 
 
+class TestGroupServiceAddMembers(object):
+    """Unit tests for :py:meth:`GroupService.add_members`"""
+
+    def test_it_adds_users_in_userids(self, factories, svc):
+        group = factories.OpenGroup()
+        users = [factories.User(), factories.User()]
+        userids = [user.userid for user in users]
+
+        svc.add_members(group, userids)
+
+        assert group.members == users
+
+    def test_it_does_not_remove_existing_members(self, factories, svc):
+        creator = factories.User()
+        group = factories.Group(creator=creator)
+        users = [factories.User(), factories.User()]
+        userids = [user.userid for user in users]
+
+        svc.add_members(group, userids)
+
+        assert len(group.members) == len(users) + 1  # account for creator user
+        assert creator in group.members
+
+
 class TestGroupServiceUpdateMembers(object):
     """Unit tests for :py:meth:`GroupService.update_members`"""
 

--- a/tests/h/views/admin_groups_test.py
+++ b/tests/h/views/admin_groups_test.py
@@ -131,7 +131,7 @@ class TestGroupCreateController(object):
                                            type_, default_org):
         name = 'My new group'
         creator = pyramid_request.user.username
-        member_to_add = 'member_to_add'
+        member_to_add = factories.User()
         description = 'Purpose of new group'
         origins = ['https://example.com']
 
@@ -143,7 +143,7 @@ class TestGroupCreateController(object):
                 'group_type': type_,
                 'name': name,
                 'origins': origins,
-                'members': [member_to_add]
+                'members': [member_to_add.username]
             })
         handle_form_submission.side_effect = call_on_success
         ctrl = GroupCreateController(pyramid_request)
@@ -160,7 +160,7 @@ class TestGroupCreateController(object):
 
         create_method.assert_called_with(name=name, userid=expected_userid, description=description,
                                          origins=origins, organization=default_org)
-        group_svc.update_membership.assert_called_once_with(create_method.return_value, [member_to_add])
+        group_svc.update_members.assert_called_once_with(create_method.return_value, [member_to_add.userid])
 
 
 @pytest.mark.usefixtures('routes', 'user_svc', 'group_svc', 'list_orgs_svc')
@@ -256,7 +256,7 @@ class TestGroupEditController(object):
         assert [s.origin for s in group.scopes] == updated_origins
         assert ctx['form'] == self._expected_form(group)
 
-    def test_update_updates_group_membership_on_success(self, factories, pyramid_request, group_svc, user_svc, handle_form_submission):
+    def test_update_updates_group_members_on_success(self, factories, pyramid_request, group_svc, user_svc, handle_form_submission):
         group = factories.RestrictedGroup(pubid='testgroup')
 
         pyramid_request.matchdict = {'pubid': group.pubid}
@@ -283,7 +283,7 @@ class TestGroupEditController(object):
 
         ctrl.update()
 
-        group_svc.update_membership.assert_any_call(group, [member_a.username, member_b.username])
+        group_svc.update_members.assert_any_call(group, [member_a.userid, member_b.userid])
 
     def test_delete_deletes_group(self, group, delete_group_svc, pyramid_request, routes):
         pyramid_request.matchdict = {"pubid": group.pubid}

--- a/tests/h/views/admin_groups_test.py
+++ b/tests/h/views/admin_groups_test.py
@@ -160,7 +160,7 @@ class TestGroupCreateController(object):
 
         create_method.assert_called_with(name=name, userid=expected_userid, description=description,
                                          origins=origins, organization=default_org)
-        group_svc.update_members.assert_called_once_with(create_method.return_value, [member_to_add.userid])
+        group_svc.add_members.assert_called_once_with(create_method.return_value, [member_to_add.userid])
 
 
 @pytest.mark.usefixtures('routes', 'user_svc', 'group_svc', 'list_orgs_svc')


### PR DESCRIPTION
This PR fixes the bug in which a restricted group's creator is effectively not added as a member when a restricted group is created through the admin interface.

It clarifies the difference between adding members (non-destructive) and updating members (potentially destructive) in the related `group` service. The `update_members` method has also been changed to accept a list of `userids`, which is more in line with the other methods in the service; the view now converts usernames into userids.

Fixes https://github.com/hypothesis/product-backlog/issues/578