### PR TITLE
Reinstall Python deps when requirements-dev.in changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ lint: .pydeps
 ################################################################################
 
 # Fake targets to aid with deps installation
-.pydeps: requirements.txt
+.pydeps: requirements.txt requirements-dev.in
 	@echo installing python dependencies
 	@pip install -r requirements-dev.in tox
 	@touch $@


### PR DESCRIPTION
Previously the Python deps were only installed when the _production_
requirements lockfile in requirements.txt changed. We should also re-run
this rule when the _development_ requirements in requirements-dev.in
change.