### PR TITLE
Add migration for privacy agreement column on user

### DIFF
--- a/h/migrations/versions/178270e3ee58_add_user_privacy_agreement_column.py
+++ b/h/migrations/versions/178270e3ee58_add_user_privacy_agreement_column.py
@@ -1,0 +1,22 @@
+"""
+Add user privacy agreement column
+
+Add a column to track user's most recent acceptance of privacy policy
+"""
+
+from __future__ import unicode_literals
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '178270e3ee58'
+down_revision = 'f052da9df33b'
+
+
+def upgrade():
+    op.add_column('user', sa.Column('privacy_accepted', sa.DateTime, nullable=True))
+
+
+def downgrade():
+    op.drop_column('user', 'privacy_accepted')


### PR DESCRIPTION
Part of https://github.com/hypothesis/product-backlog/issues/591

This PR adds an additive migration to add a column on the `user` table for tracking privacy opt-in agreements. This is a DateTime field to give us more flexibility in how we use it in the future. This column is nullable and shouldn't make a big impact.

This is my first `h` migration, so I tried to do things carefully: I tested the migration, connected to postgres to make sure it looked right, added some data manually to the column, and tested my downgrade and upgrade scripts once again. But of course, I'd love an extra set of eyes!

Next stop: add property to User model.