### PR TITLE
Rename AnnotationResource -> AnnotationContext

### DIFF
--- a/h/formatters/interfaces.py
+++ b/h/formatters/interfaces.py
@@ -39,7 +39,7 @@ class IAnnotationFormatter(Interface):
         Presents additional annotation data that will be served to API clients.
 
         :param annotation_resource: The annotation that needs presenting.
-        :type annotation_resource: h.resources.AnnotationResource
+        :type annotation_resource: :py:class`h.resources.AnnotationContext`
 
         :returns: A formatted dictionary.
         :rtype: dict

--- a/h/resources.py
+++ b/h/resources.py
@@ -45,10 +45,10 @@ class AnnotationRoot(object):
 
         group_service = self.request.find_service(IGroupService)
         links_service = self.request.find_service(name='links')
-        return AnnotationResource(annotation, group_service, links_service)
+        return AnnotationContext(annotation, group_service, links_service)
 
 
-class AnnotationResource(object):
+class AnnotationContext(object):
     def __init__(self, annotation, group_service, links_service):
         self.group_service = group_service
         self.links_service = links_service

--- a/h/services/annotation_json_presentation.py
+++ b/h/services/annotation_json_presentation.py
@@ -48,7 +48,7 @@ class AnnotationJSONPresentationService(object):
             formatter.preload(annotation_ids)
 
         return [self.present(
-                    resources.AnnotationResource(ann, self.group_svc, self.links_svc))
+                    resources.AnnotationContext(ann, self.group_svc, self.links_svc))
                 for ann in annotations]
 
     def _get_presenter(self, annotation_resource):

--- a/h/streamer/messages.py
+++ b/h/streamer/messages.py
@@ -10,7 +10,7 @@ from h import presenters
 from h import realtime
 from h import storage
 from h.realtime import Consumer
-from h.resources import AnnotationResource
+from h.resources import AnnotationContext
 from h.auth.util import translate_annotation_principals
 from h.services.links import LinksService
 from h.services.nipsa import NipsaService
@@ -148,7 +148,7 @@ def _generate_annotation_event(message, socket, annotation, user_nipsad, group_s
     base_url = socket.registry.settings.get('h.app_url',
                                             'http://localhost:5000')
     links_service = LinksService(base_url, socket.registry)
-    resource = AnnotationResource(annotation, group_service, links_service)
+    resource = AnnotationContext(annotation, group_service, links_service)
     serialized = presenters.AnnotationJSONPresenter(resource).asdict()
 
     permissions = serialized.get('permissions')

--- a/h/views/api.py
+++ b/h/views/api.py
@@ -26,7 +26,7 @@ from h.exceptions import PayloadError
 from h.events import AnnotationEvent
 from h.interfaces import IGroupService
 from h.presenters import AnnotationJSONLDPresenter
-from h.resources import AnnotationResource
+from h.resources import AnnotationContext
 from h.schemas.annotation import CreateAnnotationSchema, UpdateAnnotationSchema
 from h.views.api_config import api_config, AngularRouteTemplater
 
@@ -249,4 +249,4 @@ def _set_at_path(dict_, path, value):
 def _annotation_resource(request, annotation):
     group_service = request.find_service(IGroupService)
     links_service = request.find_service(name='links')
-    return AnnotationResource(annotation, group_service, links_service)
+    return AnnotationContext(annotation, group_service, links_service)

--- a/tests/h/formatters/annotation_flag_test.py
+++ b/tests/h/formatters/annotation_flag_test.py
@@ -9,7 +9,7 @@ import pytest
 from h.formatters.annotation_flag import AnnotationFlagFormatter
 from h.services.flag import FlagService
 
-FakeAnnotationResource = namedtuple('FakeAnnotationResource', ['annotation'])
+FakeAnnotationContext = namedtuple('FakeAnnotationContext', ['annotation'])
 
 
 class TestAnnotationFlagFormatter(object):
@@ -27,18 +27,18 @@ class TestAnnotationFlagFormatter(object):
 
     def test_format_for_existing_flag(self, formatter, factories, current_user):
         flag = factories.Flag(user=current_user)
-        annotation_resource = FakeAnnotationResource(flag.annotation)
+        annotation_resource = FakeAnnotationContext(flag.annotation)
         assert formatter.format(annotation_resource) == {'flagged': True}
 
     def test_format_for_missing_flag(self, formatter, factories):
         annotation = factories.Annotation()
-        annotation_resource = FakeAnnotationResource(annotation)
+        annotation_resource = FakeAnnotationContext(annotation)
 
         assert formatter.format(annotation_resource) == {'flagged': False}
 
     def test_format_for_unauthenticated_user(self, flag_service, factories):
         annotation = factories.Annotation()
-        annotation_resource = FakeAnnotationResource(annotation)
+        annotation_resource = FakeAnnotationContext(annotation)
         formatter = AnnotationFlagFormatter(flag_service,
                                             user=None)
 

--- a/tests/h/formatters/annotation_hidden_test.py
+++ b/tests/h/formatters/annotation_hidden_test.py
@@ -9,7 +9,7 @@ import pytest
 from h.formatters.annotation_hidden import AnnotationHiddenFormatter
 from h.services.annotation_moderation import AnnotationModerationService
 
-FakeAnnotationResource = namedtuple('FakeAnnotationResource', ['annotation', 'group'])
+FakeAnnotationContext = namedtuple('FakeAnnotationContext', ['annotation', 'group'])
 
 
 class TestAnnotationHiddenFormatter(object):
@@ -36,11 +36,11 @@ class TestAnonymousUserHiding(object):
     """An anonymous user will see redacted annotations when they're hidden."""
 
     def test_format_for_unhidden_annotation(self, formatter, annotation, group):
-        resource = FakeAnnotationResource(annotation, group)
+        resource = FakeAnnotationContext(annotation, group)
         assert formatter.format(resource) == {'hidden': False}
 
     def test_format_for_hidden_annotation(self, formatter, hidden_annotation, group):
-        resource = FakeAnnotationResource(hidden_annotation, group)
+        resource = FakeAnnotationContext(hidden_annotation, group)
 
         censored = {'hidden': True, 'text': '', 'tags': []}
         assert formatter.format(resource) == censored
@@ -54,17 +54,17 @@ class TestNonAuthorHiding(object):
     """Regular users see redacted annotations, unless they are a moderator."""
 
     def test_format_for_unhidden_annotation(self, formatter, annotation, group):
-        resource = FakeAnnotationResource(annotation, group)
+        resource = FakeAnnotationContext(annotation, group)
         assert formatter.format(resource) == {'hidden': False}
 
     def test_format_for_non_moderator(self, formatter, hidden_annotation, group):
-        resource = FakeAnnotationResource(hidden_annotation, group)
+        resource = FakeAnnotationContext(hidden_annotation, group)
 
         censored = {'hidden': True, 'text': '', 'tags': []}
         assert formatter.format(resource) == censored
 
     def test_format_for_moderator(self, formatter, hidden_annotation, moderated_group):
-        resource = FakeAnnotationResource(hidden_annotation, moderated_group)
+        resource = FakeAnnotationContext(hidden_annotation, moderated_group)
         assert formatter.format(resource) == {'hidden': True}
 
 
@@ -75,15 +75,15 @@ class TestAuthorHiding(object):
     """
 
     def test_format_for_public_annotation(self, formatter, annotation, group):
-        resource = FakeAnnotationResource(annotation, group)
+        resource = FakeAnnotationContext(annotation, group)
         assert formatter.format(resource) == {'hidden': False}
 
     def test_format_for_non_moderator(self, formatter, hidden_annotation, group):
-        resource = FakeAnnotationResource(hidden_annotation, group)
+        resource = FakeAnnotationContext(hidden_annotation, group)
         assert formatter.format(resource) == {'hidden': False}
 
     def test_format_for_moderator(self, formatter, hidden_annotation, moderated_group):
-        resource = FakeAnnotationResource(hidden_annotation, moderated_group)
+        resource = FakeAnnotationContext(hidden_annotation, moderated_group)
         assert formatter.format(resource) == {'hidden': True}
 
     @pytest.fixture

--- a/tests/h/formatters/annotation_moderation_test.py
+++ b/tests/h/formatters/annotation_moderation_test.py
@@ -9,8 +9,7 @@ import pytest
 from h.formatters.annotation_moderation import AnnotationModerationFormatter
 from h.services.flag_count import FlagCountService
 
-FakeAnnotationResource = namedtuple('FakeAnnotationResource',
-                                    ['annotation', 'group'])
+FakeAnnotationContext = namedtuple('FakeAnnotationContext', ['annotation', 'group'])
 
 
 class FakePermissionCheck(object):
@@ -44,24 +43,24 @@ class TestAnnotationModerationFormatter(object):
         formatter = AnnotationModerationFormatter(flag_count_svc,
                                                   user,
                                                   permission_denied)
-        annotation_resource = FakeAnnotationResource(flagged, group)
+        annotation_resource = FakeAnnotationContext(flagged, group)
 
         assert formatter.format(annotation_resource) == {}
 
     def test_format_returns_flag_count_for_moderator(self, formatter, group, flagged):
-        annotation_resource = FakeAnnotationResource(flagged, group)
+        annotation_resource = FakeAnnotationContext(flagged, group)
 
         output = formatter.format(annotation_resource)
         assert output == {'moderation': {'flagCount': 2}}
 
     def test_format_returns_zero_flag_count(self, formatter, group, unflagged):
-        annotation_resource = FakeAnnotationResource(unflagged, group)
+        annotation_resource = FakeAnnotationContext(unflagged, group)
 
         output = formatter.format(annotation_resource)
         assert output == {'moderation': {'flagCount': 0}}
 
     def test_format_for_preloaded_annotation(self, formatter, group, flagged):
-        annotation_resource = FakeAnnotationResource(flagged, group)
+        annotation_resource = FakeAnnotationContext(flagged, group)
 
         formatter.preload([flagged.id])
         output = formatter.format(annotation_resource)

--- a/tests/h/formatters/annotation_user_info_test.py
+++ b/tests/h/formatters/annotation_user_info_test.py
@@ -9,7 +9,7 @@ import pytest
 
 from h.formatters.annotation_user_info import AnnotationUserInfoFormatter
 
-FakeAnnotationResource = namedtuple('FakeAnnotationResource', ['annotation'])
+FakeAnnotationContext = namedtuple('FakeAnnotationContext', ['annotation'])
 
 
 class TestAnnotationUserInfoFormatter(object):
@@ -28,7 +28,7 @@ class TestAnnotationUserInfoFormatter(object):
 
     def test_format_fetches_user_by_id(self, formatter, factories, user_svc):
         annotation = factories.Annotation.build()
-        resource = FakeAnnotationResource(annotation)
+        resource = FakeAnnotationContext(annotation)
 
         formatter.format(resource)
 
@@ -38,12 +38,12 @@ class TestAnnotationUserInfoFormatter(object):
         user = mock.Mock(display_name='Jane Doe')
         user_svc.fetch.return_value = user
 
-        formatter.format(FakeAnnotationResource(mock.Mock()))
+        formatter.format(FakeAnnotationContext(mock.Mock()))
 
         user_info.assert_called_once_with(user)
 
     def test_format_returns_formatted_user_info(self, formatter, user_info):
-        result = formatter.format(FakeAnnotationResource(mock.Mock()))
+        result = formatter.format(FakeAnnotationContext(mock.Mock()))
 
         assert result == user_info.return_value
 

--- a/tests/h/presenters/annotation_json_test.py
+++ b/tests/h/presenters/annotation_json_test.py
@@ -13,7 +13,7 @@ from zope.interface import implementer
 
 from h.formatters.interfaces import IAnnotationFormatter
 from h.presenters.annotation_json import AnnotationJSONPresenter
-from h.resources import AnnotationResource
+from h.resources import AnnotationContext
 
 
 @implementer(IAnnotationFormatter)
@@ -33,7 +33,7 @@ class IDDuplicatingFormatter(object):
     """This formatter take the annotation's ID and adds it in another key.
 
     The main purpose of it is to confirm that the presenter is passing in the
-    AnnotationResource object.
+    AnnotationContext object.
     """
 
     def preload(self, ids):
@@ -57,7 +57,7 @@ class TestAnnotationJSONPresenter(object):
                         target_selectors=[{'TestSelector': 'foobar'}],
                         references=['referenced-id-1', 'referenced-id-2'],
                         extra={'extra-1': 'foo', 'extra-2': 'bar'})
-        resource = AnnotationResource(ann, group_service, fake_links_service)
+        resource = AnnotationContext(ann, group_service, fake_links_service)
 
         document_asdict.return_value = {'foo': 'bar'}
 
@@ -88,7 +88,7 @@ class TestAnnotationJSONPresenter(object):
 
     def test_asdict_extra_cannot_override_other_data(self, document_asdict, group_service, fake_links_service):
         ann = mock.Mock(id='the-real-id', extra={'id': 'the-extra-id'})
-        resource = AnnotationResource(ann, group_service, fake_links_service)
+        resource = AnnotationContext(ann, group_service, fake_links_service)
         document_asdict.return_value = {}
 
         presented = AnnotationJSONPresenter(resource).asdict()
@@ -97,7 +97,7 @@ class TestAnnotationJSONPresenter(object):
     def test_asdict_extra_uses_copy_of_extra(self, document_asdict, group_service, fake_links_service):
         extra = {'foo': 'bar'}
         ann = mock.Mock(id='my-id', extra=extra)
-        resource = AnnotationResource(ann, group_service, fake_links_service)
+        resource = AnnotationContext(ann, group_service, fake_links_service)
         document_asdict.return_value = {}
 
         AnnotationJSONPresenter(resource).asdict()
@@ -107,7 +107,7 @@ class TestAnnotationJSONPresenter(object):
 
     def test_asdict_merges_formatters(self, group_service, fake_links_service):
         ann = mock.Mock(id='the-real-id', extra={})
-        resource = AnnotationResource(ann, group_service, fake_links_service)
+        resource = AnnotationContext(ann, group_service, fake_links_service)
 
         formatters = [
             FakeFormatter({'flagged': 'nope'}),
@@ -128,7 +128,7 @@ class TestAnnotationJSONPresenter(object):
 
         """
         ann = mock.Mock(id='the-real-id', extra={})
-        resource = AnnotationResource(ann, group_service, fake_links_service)
+        resource = AnnotationContext(ann, group_service, fake_links_service)
 
         formatters = [FakeFormatter({'flagged': 'nope'})]
         presenter = AnnotationJSONPresenter(resource, formatters)
@@ -139,7 +139,7 @@ class TestAnnotationJSONPresenter(object):
 
     def test_formatter_uses_annotation_resource(self, group_service, fake_links_service):
         annotation = mock.Mock(id='the-id', extra={})
-        resource = AnnotationResource(annotation, group_service, fake_links_service)
+        resource = AnnotationContext(annotation, group_service, fake_links_service)
 
         formatters = [IDDuplicatingFormatter()]
         presenter = AnnotationJSONPresenter(resource, formatters)
@@ -171,7 +171,7 @@ class TestAnnotationJSONPresenter(object):
         group.__acl__.return_value = [group_principals[group_readable]]
         group_service.find.return_value = group
 
-        resource = AnnotationResource(annotation, group_service, fake_links_service)
+        resource = AnnotationContext(annotation, group_service, fake_links_service)
         presenter = AnnotationJSONPresenter(resource)
         assert expected == presenter.permissions[action]
 

--- a/tests/h/presenters/annotation_jsonld_test.py
+++ b/tests/h/presenters/annotation_jsonld_test.py
@@ -7,7 +7,7 @@ import datetime
 import mock
 
 from h.presenters.annotation_jsonld import AnnotationJSONLDPresenter
-from h.resources import AnnotationResource
+from h.resources import AnnotationContext
 
 
 class TestAnnotationJSONLDPresenter(object):
@@ -40,14 +40,14 @@ class TestAnnotationJSONLDPresenter(object):
                                       'test': 'foobar'}]}]
         }
 
-        resource = AnnotationResource(annotation, group_service, fake_links_service)
+        resource = AnnotationContext(annotation, group_service, fake_links_service)
         result = AnnotationJSONLDPresenter(resource).asdict()
 
         assert result == expected
 
     def test_id_returns_jsonld_id_link(self, group_service, fake_links_service):
         annotation = mock.Mock(id='foobar')
-        resource = AnnotationResource(annotation, group_service, fake_links_service)
+        resource = AnnotationContext(annotation, group_service, fake_links_service)
 
         presenter = AnnotationJSONLDPresenter(resource)
 
@@ -55,7 +55,7 @@ class TestAnnotationJSONLDPresenter(object):
 
     def test_id_passes_annotation_to_link_service(self, group_service, fake_links_service):
         annotation = mock.Mock(id='foobar')
-        resource = AnnotationResource(annotation, group_service, fake_links_service)
+        resource = AnnotationContext(annotation, group_service, fake_links_service)
 
         presenter = AnnotationJSONLDPresenter(resource)
         presenter.id
@@ -64,7 +64,7 @@ class TestAnnotationJSONLDPresenter(object):
 
     def test_bodies_returns_textual_body(self, group_service, fake_links_service):
         annotation = mock.Mock(text='Flib flob flab', tags=None)
-        resource = AnnotationResource(annotation, group_service, fake_links_service)
+        resource = AnnotationContext(annotation, group_service, fake_links_service)
 
         bodies = AnnotationJSONLDPresenter(resource).bodies
 
@@ -76,7 +76,7 @@ class TestAnnotationJSONLDPresenter(object):
 
     def test_bodies_appends_tag_bodies(self, group_service, fake_links_service):
         annotation = mock.Mock(text='Flib flob flab', tags=['giraffe', 'lion'])
-        resource = AnnotationResource(annotation, group_service, fake_links_service)
+        resource = AnnotationContext(annotation, group_service, fake_links_service)
 
         bodies = AnnotationJSONLDPresenter(resource).bodies
 
@@ -97,7 +97,7 @@ class TestAnnotationJSONLDPresenter(object):
             {'type': 'TestSelector', 'test': 'foobar'},
             {'something': 'else'},
         ]
-        resource = AnnotationResource(annotation, group_service, fake_links_service)
+        resource = AnnotationContext(annotation, group_service, fake_links_service)
 
         selectors = AnnotationJSONLDPresenter(resource).target[0]['selector']
 
@@ -122,7 +122,7 @@ class TestAnnotationJSONLDPresenter(object):
                 'endOffset': 43,
             }
         ]
-        resource = AnnotationResource(annotation, group_service, fake_links_service)
+        resource = AnnotationContext(annotation, group_service, fake_links_service)
 
         selectors = AnnotationJSONLDPresenter(resource).target[0]['selector']
 
@@ -152,7 +152,7 @@ class TestAnnotationJSONLDPresenter(object):
                 'endOffset': 72,
             }
         ]
-        resource = AnnotationResource(annotation, group_service, fake_links_service)
+        resource = AnnotationContext(annotation, group_service, fake_links_service)
 
         selectors = AnnotationJSONLDPresenter(resource).target[0]['selector']
 
@@ -188,7 +188,7 @@ class TestAnnotationJSONLDPresenter(object):
                 'endContainer': '/div[1]/main[1]/article[1]/div[2]/p[339]',
             }
         ]
-        resource = AnnotationResource(annotation, group_service, fake_links_service)
+        resource = AnnotationContext(annotation, group_service, fake_links_service)
 
         target = AnnotationJSONLDPresenter(resource).target[0]
 

--- a/tests/h/resources_test.py
+++ b/tests/h/resources_test.py
@@ -10,7 +10,7 @@ from pyramid.authorization import ACLAuthorizationPolicy
 
 from h.models import AuthClient, Organization
 from h.services.group_links import GroupLinksService
-from h.resources import AnnotationResource
+from h.resources import AnnotationContext
 from h.resources import AnnotationRoot
 from h.resources import AuthClientRoot
 from h.resources import OrganizationRoot
@@ -35,7 +35,7 @@ class TestAnnotationRoot(object):
         storage.fetch_annotation.return_value = mock.Mock()
 
         resource = factory['123']
-        assert isinstance(resource, AnnotationResource)
+        assert isinstance(resource, AnnotationContext)
 
     def test_get_item_resource_has_right_annotation(self, pyramid_request, storage):
         factory = AnnotationRoot(pyramid_request)
@@ -83,10 +83,10 @@ class TestAnnotationRoot(object):
 
 
 @pytest.mark.usefixtures('group_service', 'links_service')
-class TestAnnotationResource(object):
+class TestAnnotationContext(object):
     def test_links(self, group_service, links_service):
         ann = mock.Mock()
-        res = AnnotationResource(ann, group_service, links_service)
+        res = AnnotationContext(ann, group_service, links_service)
 
         result = res.links
 
@@ -95,7 +95,7 @@ class TestAnnotationResource(object):
 
     def test_link(self, group_service, links_service):
         ann = mock.Mock()
-        res = AnnotationResource(ann, group_service, links_service)
+        res = AnnotationContext(ann, group_service, links_service)
 
         result = res.link('json')
 
@@ -104,7 +104,7 @@ class TestAnnotationResource(object):
 
     def test_acl_private(self, factories, group_service, links_service):
         ann = factories.Annotation(shared=False, userid='saoirse')
-        res = AnnotationResource(ann, group_service, links_service)
+        res = AnnotationContext(ann, group_service, links_service)
         actual = res.__acl__()
         expect = [(security.Allow, 'saoirse', 'read'),
                   (security.Allow, 'saoirse', 'admin'),
@@ -121,7 +121,7 @@ class TestAnnotationResource(object):
         policy = ACLAuthorizationPolicy()
 
         ann = factories.Annotation(shared=False, userid='saoirse')
-        res = AnnotationResource(ann, group_service, links_service)
+        res = AnnotationContext(ann, group_service, links_service)
 
         for perm in ['admin', 'update', 'delete']:
             assert policy.permits(res, ['saoirse'], perm)
@@ -135,7 +135,7 @@ class TestAnnotationResource(object):
         policy = ACLAuthorizationPolicy()
 
         ann = factories.Annotation(userid='saoirse', deleted=True)
-        res = AnnotationResource(ann, group_service, links_service)
+        res = AnnotationContext(ann, group_service, links_service)
 
         for perm in ['read', 'admin', 'update', 'delete']:
             assert not policy.permits(res, ['saiorse'], perm)
@@ -178,7 +178,7 @@ class TestAnnotationResource(object):
         ann = factories.Annotation(shared=True,
                                    userid='mioara',
                                    groupid=groupid)
-        res = AnnotationResource(ann, group_service, links_service)
+        res = AnnotationContext(ann, group_service, links_service)
 
         if permitted:
             assert pyramid_request.has_permission('read', res)

--- a/tests/h/services/annotation_json_presentation_test.py
+++ b/tests/h/services/annotation_json_presentation_test.py
@@ -86,11 +86,11 @@ class TestAnnotationJSONPresentationService(object):
 
         svc.present_all(['ann-1'])
 
-        resources.AnnotationResource.assert_called_once_with(ann, svc.group_svc, svc.links_svc)
+        resources.AnnotationContext.assert_called_once_with(ann, svc.group_svc, svc.links_svc)
 
     def test_present_all_presents_annotation_resources(self, svc, storage, resources, present):
         storage.fetch_ordered_annotations.return_value = [mock.Mock()]
-        resource = resources.AnnotationResource.return_value
+        resource = resources.AnnotationContext.return_value
 
         svc.present_all(['ann-1'])
         present.assert_called_once_with(svc, resource)

--- a/tests/h/streamer/messages_test.py
+++ b/tests/h/streamer/messages_test.py
@@ -424,7 +424,7 @@ class TestHandleAnnotationEvent(object):
 
     @pytest.fixture
     def annotation_resource(self, patch):
-        return patch('h.streamer.messages.AnnotationResource')
+        return patch('h.streamer.messages.AnnotationContext')
 
 
 class TestHandleUserEvent(object):

--- a/tests/h/views/api_test.py
+++ b/tests/h/views/api_test.py
@@ -477,7 +477,7 @@ def AnnotationEvent(patch):
 
 @pytest.fixture
 def annotation_resource(patch):
-    return patch('h.views.api.AnnotationResource')
+    return patch('h.views.api.AnnotationContext')
 
 
 @pytest.fixture

--- a/tests/h/views/main_test.py
+++ b/tests/h/views/main_test.py
@@ -7,7 +7,7 @@ from pyramid import httpexceptions
 import pytest
 
 from h.models import Annotation
-from h.resources import AnnotationResource
+from h.resources import AnnotationContext
 from h.views import main
 
 
@@ -18,7 +18,7 @@ def _fake_sidebar_app(request, extra):
 @pytest.mark.usefixtures('routes')
 def test_og_document(factories, pyramid_request, group_service, links_service, sidebar_app):
     annotation = factories.Annotation(userid='acct:foo@example.com')
-    context = AnnotationResource(annotation, group_service, links_service)
+    context = AnnotationContext(annotation, group_service, links_service)
     sidebar_app.side_effect = _fake_sidebar_app
 
     ctx = main.annotation_page(context, pyramid_request)
@@ -31,7 +31,7 @@ def test_og_document(factories, pyramid_request, group_service, links_service, s
 @pytest.mark.usefixtures('routes')
 def test_og_no_document(pyramid_request, group_service, links_service, sidebar_app):
     annotation = Annotation(id='123', userid='foo', target_uri='http://example.com')
-    context = AnnotationResource(annotation, group_service, links_service)
+    context = AnnotationContext(annotation, group_service, links_service)
     sidebar_app.side_effect = _fake_sidebar_app
 
     ctx = main.annotation_page(context, pyramid_request)


### PR DESCRIPTION
Part of the refactoring described in this [Slack post](https://hypothes-is.slack.com/files/U074DEU66/FA511033L/h_traversal__resources__refactoring).

This is the beginning of renaming all the `*Resource` classes to `*Context`. In practice these classes are always used "context resources" in Pyramid - they're always the resource at the end of traversal, and passed to the view as the context. They're never used as intermediate resources in traversal. As discussed in the Slack post, "context" much better describes what we're using these classes for than "resource".