### PR TITLE
Add es6.2 docker container to docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,12 @@ services:
     ports:
       - '127.0.0.1:5432:5432'
   elasticsearch:
+    image: hypothesis/elasticsearch:latest
+    ports:
+      - '127.0.0.1:9201:9200'
+    environment:
+      - discovery.type=single-node
+  elasticsearchold:
     image: nickstenning/elasticsearch-icu
     ports:
       - '127.0.0.1:9200:9200'


### PR DESCRIPTION
This is a fix for https://github.com/hypothesis/product-backlog/issues/598.
- [x] Rename the old elastic search docker container to elasticsearchold and leave it running on port 9200. 
- [x] Add a new elasticsearch container named elasticsearch and set it to run on port 9201. 
