### PR TITLE
Remove unused add_search_matcher

### DIFF
--- a/h/search/__init__.py
+++ b/h/search/__init__.py
@@ -5,7 +5,6 @@ from h.search.client import get_client
 from h.search.config import init
 from h.search.core import Search
 from h.search.core import FILTERS_KEY
-from h.search.core import MATCHERS_KEY
 
 __all__ = (
     'Search',
@@ -22,15 +21,10 @@ def includeme(config):
     # Allow users of this module to register additional search filter and
     # search matcher factories.
     config.registry[FILTERS_KEY] = []
-    config.registry[MATCHERS_KEY] = []
     config.add_directive('add_search_filter',
                          lambda c, f: c.registry[FILTERS_KEY].append(config.maybe_dotted(f)))
     config.add_directive('get_search_filters',
                          lambda c: c.registry[FILTERS_KEY])
-    config.add_directive('add_search_matcher',
-                         lambda c, m: c.registry[MATCHERS_KEY].append(config.maybe_dotted(m)))
-    config.add_directive('get_search_matchers',
-                         lambda c: c.registry[MATCHERS_KEY])
 
     # Add a property to all requests for easy access to the elasticsearch
     # client. This can be used for direct or bulk access without having to

--- a/h/search/core.py
+++ b/h/search/core.py
@@ -9,7 +9,6 @@ from elasticsearch.exceptions import ConnectionTimeout
 from h.search import query
 
 FILTERS_KEY = 'h.search.filters'
-MATCHERS_KEY = 'h.search.matchers'
 
 log = logging.getLogger(__name__)
 
@@ -157,6 +156,4 @@ def default_querybuilder(request):
     builder.append_matcher(query.TagsMatcher())
     for factory in request.registry.get(FILTERS_KEY, []):
         builder.append_filter(factory(request))
-    for factory in request.registry.get(MATCHERS_KEY, []):
-        builder.append_matcher(factory(request))
     return builder

--- a/tests/h/search/core_test.py
+++ b/tests/h/search/core_test.py
@@ -297,17 +297,6 @@ def test_default_querybuilder_includes_default_matchers(matchers, matcher_type, 
     assert matchers.instance_of(type_) in builder.matchers
 
 
-def test_default_querybuilder_includes_registered_matchers(pyramid_request):
-    matcher_factory = mock.Mock(return_value=mock.sentinel.MY_MATCHER,
-                                spec_set=[])
-    pyramid_request.registry[core.MATCHERS_KEY] = [matcher_factory]
-
-    builder = core.default_querybuilder(pyramid_request)
-
-    matcher_factory.assert_called_once_with(pyramid_request)
-    assert mock.sentinel.MY_MATCHER in builder.matchers
-
-
 def dummy_search_results(start=1, count=0, name='annotation'):
     """Generate some dummy search results."""
     out = {'hits': {'total': 0, 'hits': []}}


### PR DESCRIPTION
Remove the unused add_search_matcher() and get_search_matchers() config
directives.