### PR TITLE
Rename OrganizationResource to OrganizationContext

### DIFF
--- a/h/presenters/group_json.py
+++ b/h/presenters/group_json.py
@@ -10,7 +10,7 @@ class GroupJSONPresenter(object):
 
     def __init__(self, group_resource):
         self.resource = group_resource
-        self.organization_resource = self.resource.organization
+        self.organization_context = self.resource.organization
         self.group = group_resource.group
 
     def asdict(self, expand=[]):
@@ -22,7 +22,7 @@ class GroupJSONPresenter(object):
     def _expand(self, model, expand=[]):
         if 'organization' in expand:
             model['organization'] = OrganizationJSONPresenter(
-              self.organization_resource
+              self.organization_context
             ).asdict()
         return model
 
@@ -30,7 +30,7 @@ class GroupJSONPresenter(object):
         model = {
           'id': self.resource.id,
           'name': self.group.name,
-          'organization': self.organization_resource.id,
+          'organization': self.organization_context.id,
           'public': self.group.is_public,  # DEPRECATED: TODO: remove from client
           'scoped': True if self.group.scopes else False,
           'type': self.group.type

--- a/h/presenters/organization_json.py
+++ b/h/presenters/organization_json.py
@@ -6,18 +6,18 @@ from __future__ import unicode_literals
 class OrganizationJSONPresenter(object):
     """Present an organization in the JSON format returned by API requests."""
 
-    def __init__(self, organization_resource):
-        self.resource = organization_resource
-        self.organization = organization_resource.organization
+    def __init__(self, organization_context):
+        self.context = organization_context
+        self.organization = organization_context.organization
 
     def asdict(self):
         return self._model()
 
     def _model(self):
         model = {
-          'id': self.resource.id,
-          'default': self.resource.default,
-          'logo': self.resource.logo,
+          'id': self.context.id,
+          'default': self.context.default,
+          'logo': self.context.logo,
           'name': self.organization.name,
         }
         return model

--- a/h/resources.py
+++ b/h/resources.py
@@ -133,7 +133,7 @@ class OrganizationRoot(object):
             raise KeyError()
 
 
-class OrganizationResource(object):
+class OrganizationContext(object):
     def __init__(self, organization, request):
         # TODO Links service
         self.organization = organization
@@ -202,7 +202,7 @@ class GroupResource(object):
 
     @property
     def organization(self):
-        return OrganizationResource(self.group.organization, self.request)
+        return OrganizationContext(self.group.organization, self.request)
 
 
 class UserRoot(object):

--- a/h/views/activity.py
+++ b/h/views/activity.py
@@ -22,7 +22,7 @@ from h.search import parser
 from h.util.user import split_user
 from h.views.groups import check_slug
 from h.util.datetime import utc_us_style_date
-from h.resources import OrganizationResource
+from h.resources import OrganizationContext
 
 
 PAGE_SIZE = 200
@@ -97,7 +97,7 @@ class GroupSearchController(SearchController):
     def __init__(self, group, request):
         super(GroupSearchController, self).__init__(request)
         self.group = group
-        self._org_resource = OrganizationResource(group.organization, request)
+        self._organization_context = OrganizationContext(group.organization, request)
 
     @view_config(request_method='GET')
     def search(self):
@@ -169,7 +169,7 @@ class GroupSearchController(SearchController):
             'share_subtitle': _('Share group'),
             'share_msg': _('Sharing the link lets people view this group:'),
             'organization': {'name': self.group.organization.name,
-                             'logo': self._org_resource.logo}
+                             'logo': self._organization_context.logo}
         }
 
         if self.group.type == 'private':

--- a/tests/h/presenters/organization_json_test.py
+++ b/tests/h/presenters/organization_json_test.py
@@ -6,15 +6,15 @@ import pytest
 
 from h.presenters.organization_json import OrganizationJSONPresenter
 from h.models.organization import Organization
-from h.resources import OrganizationResource
+from h.resources import OrganizationContext
 
 
 class TestOrganizationJSONPresenter(object):
     def test_organization_asdict_no_logo(self, factories, pyramid_request):
         organization = factories.Organization(name='My Org', logo=None)
-        organization_resource = OrganizationResource(organization, pyramid_request)
+        organization_context = OrganizationContext(organization, pyramid_request)
 
-        presenter = OrganizationJSONPresenter(organization_resource)
+        presenter = OrganizationJSONPresenter(organization_context)
 
         assert presenter.asdict() == {
             'name': 'My Org',
@@ -25,22 +25,22 @@ class TestOrganizationJSONPresenter(object):
 
     def test_organization_asdict_with_logo(self, factories, routes, pyramid_request):
         organization = factories.Organization(name='My Org', logo='<svg>H</svg>')
-        organization_resource = OrganizationResource(organization, pyramid_request)
+        organization_context = OrganizationContext(organization, pyramid_request)
 
-        presenter = OrganizationJSONPresenter(organization_resource)
+        presenter = OrganizationJSONPresenter(organization_context)
 
         assert presenter.asdict() == {
             'name': 'My Org',
-            'id': organization_resource.id,
+            'id': organization_context.id,
             'default': False,
             'logo': pyramid_request.route_url('organization_logo', pubid=organization.pubid)
         }
 
     def test_default_organization(self, db_session, routes, pyramid_request):
         organization = Organization.default(db_session)
-        organization_resource = OrganizationResource(organization, pyramid_request)
+        organization_context = OrganizationContext(organization, pyramid_request)
 
-        presenter = OrganizationJSONPresenter(organization_resource)
+        presenter = OrganizationJSONPresenter(organization_context)
         presented = presenter.asdict()
 
         assert presented['default'] is True

--- a/tests/h/resources_test.py
+++ b/tests/h/resources_test.py
@@ -17,7 +17,7 @@ from h.resources import OrganizationRoot
 from h.resources import OrganizationLogoRoot
 from h.resources import GroupRoot
 from h.resources import GroupResource
-from h.resources import OrganizationResource
+from h.resources import OrganizationContext
 from h.resources import UserRoot
 from h.services.user import UserService
 
@@ -319,33 +319,33 @@ class TestGroupResource(object):
 
         group_resource = GroupResource(group, pyramid_request)
 
-        assert isinstance(group_resource.organization, OrganizationResource)
+        assert isinstance(group_resource.organization, OrganizationContext)
 
 
 @pytest.mark.usefixtures('organization_routes')
-class TestOrganizationResource(object):
+class TestOrganizationContext(object):
 
     def test_it_returns_organization_model_as_property(self, factories, pyramid_request):
         organization = factories.Organization()
 
-        organization_resource = OrganizationResource(organization, pyramid_request)
+        organization_context = OrganizationContext(organization, pyramid_request)
 
-        assert organization_resource.organization == organization
+        assert organization_context.organization == organization
 
     def test_it_returns_pubid_as_id(self, factories, pyramid_request):
         organization = factories.Organization()
 
-        organization_resource = OrganizationResource(organization, pyramid_request)
+        organization_context = OrganizationContext(organization, pyramid_request)
 
-        assert organization_resource.id != organization.id
-        assert organization_resource.id == organization.pubid
+        assert organization_context.id != organization.id
+        assert organization_context.id == organization.pubid
 
     def test_it_returns_links_property(self, factories, pyramid_request):
         organization = factories.Organization()
 
-        organization_resource = OrganizationResource(organization, pyramid_request)
+        organization_context = OrganizationContext(organization, pyramid_request)
 
-        assert organization_resource.links == {}
+        assert organization_context.links == {}
 
     def test_it_returns_logo_property_as_route_url(self, factories, pyramid_request):
         fake_logo = '<svg>H</svg>'
@@ -353,8 +353,8 @@ class TestOrganizationResource(object):
 
         organization = factories.Organization(logo=fake_logo)
 
-        organization_resource = OrganizationResource(organization, pyramid_request)
-        logo = organization_resource.logo
+        organization_context = OrganizationContext(organization, pyramid_request)
+        logo = organization_context.logo
 
         pyramid_request.route_url.assert_called_with('organization_logo', pubid=organization.pubid)
         assert logo is not None
@@ -364,8 +364,8 @@ class TestOrganizationResource(object):
 
         organization = factories.Organization(logo=None)
 
-        organization_resource = OrganizationResource(organization, pyramid_request)
-        logo = organization_resource.logo
+        organization_context = OrganizationContext(organization, pyramid_request)
+        logo = organization_context.logo
 
         pyramid_request.route_url.assert_not_called
         assert logo is None
@@ -373,16 +373,16 @@ class TestOrganizationResource(object):
     def test_default_property_if_not_default_organization(self, factories, pyramid_request):
         organization = factories.Organization()
 
-        organization_resource = OrganizationResource(organization, pyramid_request)
+        organization_context = OrganizationContext(organization, pyramid_request)
 
-        assert organization_resource.default is False
+        assert organization_context.default is False
 
     def test_default_property_if_default_organization(self, factories, pyramid_request):
         organization = Organization.default(pyramid_request.db)
 
-        organization_resource = OrganizationResource(organization, pyramid_request)
+        organization_context = OrganizationContext(organization, pyramid_request)
 
-        assert organization_resource.default is True
+        assert organization_context.default is True
 
 
 @pytest.mark.usefixtures('user_service')

--- a/tests/h/views/activity_test.py
+++ b/tests/h/views/activity_test.py
@@ -238,7 +238,7 @@ class TestGroupSearchController(object):
             test_group,
             test_user,
             default_org,
-            OrganizationResource,
+            OrganizationContext,
             pyramid_request):
         group_info = controller.search()['group']
 
@@ -246,7 +246,7 @@ class TestGroupSearchController(object):
         assert group_info['description'] == test_group.description
         assert group_info['name'] == test_group.name
         assert group_info['pubid'] == test_group.pubid
-        assert group_info['organization']['logo'] == OrganizationResource(None, None).logo
+        assert group_info['organization']['logo'] == OrganizationContext(None, None).logo
         assert group_info['organization']['name'] == default_org.name
 
     @pytest.mark.parametrize('test_group,test_user',
@@ -768,14 +768,14 @@ class TestGroupSearchController(object):
                 "user": factories.User()}
 
     @pytest.fixture
-    def OrganizationResource(self, patch):
-        OrganizationResource = patch("h.views.activity.OrganizationResource")
-        organization_resource = OrganizationResource.return_value
-        organization_resource.logo = "http://example.com/organizations/pubid/logo"
-        return OrganizationResource
+    def OrganizationContext(self, patch):
+        OrganizationContext = patch("h.views.activity.OrganizationContext")
+        organization_context = OrganizationContext.return_value
+        organization_context.logo = "http://example.com/organizations/pubid/logo"
+        return OrganizationContext
 
     @pytest.fixture
-    def controller(self, request, group, pyramid_request, OrganizationResource):
+    def controller(self, request, group, pyramid_request, OrganizationContext):
         test_group = group
         if 'test_group' in request.fixturenames:
             test_group = request.getfixturevalue('test_group')


### PR DESCRIPTION
Part of the refactoring described in this Slack post:

https://hypothes-is.slack.com/files/U074DEU66/FA511033L/h_traversal__resources__refactoring

This is part of renaming all the `*Resource` classes to `*Context`. In
practice these classes are always used as "context resources" in Pyramid -
they're always the resource at the end of traversal, and passed to the
view as the context. They're never used as intermediate resources in
traversal. As discussed in the Slack post, "context" much better
describes what we're using these classes for than "resource".