### PR TITLE
Redirect to entity not found page when a user or group search fails.

### DIFF
--- a/h/activity/query.py
+++ b/h/activity/query.py
@@ -89,6 +89,9 @@ def check_url(request, query, unparse=parser.unparse):
                                           pubid=group.pubid,
                                           slug=group.slug,
                                           _query={'q': unparse(query)})
+        else:
+            redirect = request.route_path('activity.entity_not_found',
+                                          entityid=pubid)
 
     elif _single_entry(query, 'user'):
         username = query.pop('user')
@@ -98,6 +101,9 @@ def check_url(request, query, unparse=parser.unparse):
             redirect = request.route_path('activity.user_search',
                                           username=username,
                                           _query={'q': unparse(query)})
+        else:
+            redirect = request.route_path('activity.entity_not_found',
+                                          entityid=username)
 
     if redirect is not None:
         raise HTTPFound(location=redirect)

--- a/h/routes.py
+++ b/h/routes.py
@@ -26,6 +26,8 @@ def includeme(config):
 
     # Activity
     config.add_route('activity.search', '/search')
+    config.add_route('activity.entity_not_found',
+                     '/entity_not_found/{entityid}')
     config.add_route('activity.user_search',
                      '/users/{username}',
                      factory='h.resources:UserRoot',

--- a/h/templates/activity/entity_not_found.html.jinja2
+++ b/h/templates/activity/entity_not_found.html.jinja2
@@ -1,0 +1,15 @@
+{% extends "h:templates/layouts/base.html.jinja2" %}
+
+{% block title %}{{ entityid }} Not Found{% endblock %}
+
+{% block content %}
+  {% include 'h:templates/includes/logo-header.html.jinja2' %}
+  <div class="form-container">
+    <h1 class="form-header">Entity "{{ entityid }}" not found</h1>
+    <p>This entity does not exist, please try a different search.</p>
+  </div>
+{% endblock %}
+
+{% block footer %}
+  {% include "h:templates/includes/footer.html.jinja2" %}
+{% endblock %}

--- a/h/views/activity.py
+++ b/h/views/activity.py
@@ -308,6 +308,17 @@ class GroupSearchController(SearchController):
             raise httpexceptions.HTTPNotFound()
 
 
+@view_defaults(route_name='activity.entity_not_found',
+               renderer='h:templates/activity/entity_not_found.html.jinja2')
+class EntityNotFoundController(SearchController):
+    def __init__(self, request):
+        self.request = request
+
+    @view_config(request_method='GET')
+    def get(self):
+        return {'entityid': self.request.matchdict.get('entityid')}
+
+
 @view_defaults(route_name='activity.user_search',
                renderer='h:templates/activity/search.html.jinja2')
 class UserSearchController(SearchController):

--- a/tests/h/routes_test.py
+++ b/tests/h/routes_test.py
@@ -34,6 +34,7 @@ def test_includeme():
         call('claim_account_legacy', '/claim_account/{token}'),
         call('dismiss_sidebar_tutorial', '/app/dismiss_sidebar_tutorial'),
         call('activity.search', '/search'),
+        call('activity.entity_not_found', '/entity_not_found/{entityid}'),
         call('activity.user_search', '/users/{username}', factory='h.resources:UserRoot', traverse='/{username}'),
         call('admin_index', '/admin/'),
         call('admin_admins', '/admin/admins'),


### PR DESCRIPTION
Currently, for a search where the user or group does not exist, all
annotations are returned even though they don't satisfy the search
criteria.

Correct that by redirecting to an `entity_not_found` page which displays
an appropriate `entity not found` message.

Fixes https://github.com/hypothesis/product-backlog/issues/462