### PR TITLE
Dont instantiate h.search.client.Client in tests

### DIFF
--- a/h/search/client.py
+++ b/h/search/client.py
@@ -25,13 +25,21 @@ class Client(object):
         annotation = 'annotation'
 
     def __init__(self, host, index, **kwargs):
-        self.index = index
-        self.conn = Elasticsearch([host],
-                                  verify_certs=True,
-                                  # N.B. this won't be necessary if we upgrade
-                                  # to elasticsearch>=5.0.0.
-                                  ca_certs=certifi.where(),
-                                  **kwargs)
+        self._index = index
+        self._conn = Elasticsearch([host],
+                                   verify_certs=True,
+                                   # N.B. this won't be necessary if we upgrade
+                                   # to elasticsearch>=5.0.0.
+                                   ca_certs=certifi.where(),
+                                   **kwargs)
+
+    @property
+    def index(self):
+        return self._index
+
+    @property
+    def conn(self):
+        return self._conn
 
 
 def get_client(settings):

--- a/tests/h/indexer/reindexer_test.py
+++ b/tests/h/indexer/reindexer_test.py
@@ -123,8 +123,8 @@ class TestReindex(object):
 
     @pytest.fixture
     def es(self):
-        mock_es = mock.Mock(spec=client.Client('localhost', 'hypothesis'))
-        mock_es.index = 'hypothesis'
+        mock_es = mock.create_autospec(client.Client, instance=True,
+                                       spec_set=True, index="hypothesis")
         mock_es.t.annotation = 'annotation'
         return mock_es
 

--- a/tests/h/search/client_test.py
+++ b/tests/h/search/client_test.py
@@ -7,10 +7,28 @@ import pytest
 from elasticsearch import RequestsHttpConnection
 
 from h.search.client import get_client
+from h.search.client import Client
 
 
 class TestClient(object):
-    pass
+
+    def test_it_sets_the_index_and_conn_properties(self):
+        client = Client(host="http://localhost:9200", index="hypothesis")
+
+        assert client.index == "hypothesis"
+        assert client.conn
+
+    def test_index_is_read_only(self):
+        client = Client(host="http://localhost:9200", index="hypothesis")
+
+        with pytest.raises(AttributeError, match="can't set attribute"):
+            client.index = "changed"
+
+    def test_conn_is_read_only(self):
+        client = Client(host="http://localhost:9200", index="hypothesis")
+
+        with pytest.raises(AttributeError, match="can't set attribute"):
+            client.conn = "changed"
 
 
 class TestGetClient(object):

--- a/tests/h/search/index_test.py
+++ b/tests/h/search/index_test.py
@@ -303,8 +303,8 @@ class TestBatchIndexer(object):
 
 @pytest.fixture
 def es():
-    mock_es = mock.Mock(spec=client.Client('localhost', 'hypothesis'))
-    mock_es.index = 'hypothesis'
+    mock_es = mock.create_autospec(client.Client, instance=True, spec_set=True,
+                                   index="hypothesis")
     mock_es.t.annotation = 'annotation'
     return mock_es
 


### PR DESCRIPTION
reindexer_test.py and index_test.py were instantiating
h.search.client.Client instances in order to mock them. This confused
me, and seems a little dodgy since instantiating a Client will
instantiate a real elasticsearch.Elasticsearch object (although we were
getting away with it).

Change the tests to use create_autospec() instead, which creates mock
instances of classes without instantiating them.

Now Client is only ever instantiated by client_test.py.

In order to get create_autospec() to work with Client I had to change Client's conn and index attributes to `@property`'s.

While this is a bit more verbose, it means that index and conn are now
visible to the mock library's create_autospec() function (mock Client
instances created using create_autospec() now have index and conn
attributes, which they wouldn't before).

See:

https://docs.python.org/3/library/unittest.mock.html#autospeccing

the paragraph beginning `"A more serious problem is that it is common for
instance attributes to be created in the __init__() method and not to
exist on the class..."`

This change also clarifies the API of the class: makes it explicit that
index and conn are read-only.