### PR TITLE
Rename GroupResource -> GroupContext

### DIFF
--- a/h/presenters/group_json.py
+++ b/h/presenters/group_json.py
@@ -8,15 +8,15 @@ from h.presenters.organization_json import OrganizationJSONPresenter
 class GroupJSONPresenter(object):
     """Present a group in the JSON format returned by API requests."""
 
-    def __init__(self, group_resource):
-        self.resource = group_resource
-        self.organization_context = self.resource.organization
-        self.group = group_resource.group
+    def __init__(self, group_context):
+        self.context = group_context
+        self.organization_context = self.context.organization
+        self.group = group_context.group
 
     def asdict(self, expand=[]):
         model = self._model()
         self._expand(model, expand)
-        model['links'] = self.resource.links or {}
+        model['links'] = self.context.links or {}
         return model
 
     def _expand(self, model, expand=[]):
@@ -28,7 +28,7 @@ class GroupJSONPresenter(object):
 
     def _model(self):
         model = {
-          'id': self.resource.id,
+          'id': self.context.id,
           'name': self.group.name,
           'organization': self.organization_context.id,
           'public': self.group.is_public,  # DEPRECATED: TODO: remove from client
@@ -41,8 +41,8 @@ class GroupJSONPresenter(object):
 class GroupsJSONPresenter(object):
     """Present a list of groups as JSON"""
 
-    def __init__(self, group_resources):
-        self.resources = group_resources
+    def __init__(self, group_contexts):
+        self.contexts = group_contexts
 
     def asdicts(self, expand=[]):
-        return [GroupJSONPresenter(group_resource).asdict(expand=expand) for group_resource in self.resources]
+        return [GroupJSONPresenter(group_context).asdict(expand=expand) for group_context in self.contexts]

--- a/h/resources.py
+++ b/h/resources.py
@@ -186,7 +186,7 @@ class GroupRoot(object):
             raise KeyError()
 
 
-class GroupResource(object):
+class GroupContext(object):
     def __init__(self, group, request):
         self.request = request
         self.group = group

--- a/h/views/api_groups.py
+++ b/h/views/api_groups.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 
 from pyramid import security
 from pyramid.httpexceptions import HTTPNoContent, HTTPBadRequest
-from h.resources import GroupResource
+from h.resources import GroupContext
 from h.presenters import GroupsJSONPresenter
 from h.views.api import api_config
 
@@ -27,7 +27,7 @@ def groups(request):
     all_groups = list_svc.request_groups(user=request.user,
                                          authority=authority,
                                          document_uri=document_uri)
-    all_groups = [GroupResource(group, request) for group in all_groups]
+    all_groups = [GroupContext(group, request) for group in all_groups]
     all_groups = GroupsJSONPresenter(all_groups).asdicts(expand=expand)
     return all_groups
 

--- a/tests/h/resources_test.py
+++ b/tests/h/resources_test.py
@@ -16,7 +16,7 @@ from h.resources import AuthClientRoot
 from h.resources import OrganizationRoot
 from h.resources import OrganizationLogoRoot
 from h.resources import GroupRoot
-from h.resources import GroupResource
+from h.resources import GroupContext
 from h.resources import OrganizationContext
 from h.resources import UserRoot
 from h.services.user import UserService
@@ -291,35 +291,35 @@ class TestGroupRoot(object):
 
 
 @pytest.mark.usefixtures('links_svc')
-class TestGroupResource(object):
+class TestGroupContext(object):
 
     def test_it_returns_group_model_as_property(self, factories, pyramid_request):
         group = factories.Group()
 
-        group_resource = GroupResource(group, pyramid_request)
+        group_context = GroupContext(group, pyramid_request)
 
-        assert group_resource.group == group
+        assert group_context.group == group
 
     def test_it_proxies_links_to_svc(self, factories, links_svc, pyramid_request):
         group = factories.Group()
 
-        group_resource = GroupResource(group, pyramid_request)
+        group_context = GroupContext(group, pyramid_request)
 
-        assert group_resource.links == links_svc.get_all.return_value
+        assert group_context.links == links_svc.get_all.return_value
 
     def test_it_returns_pubid_as_id(self, factories, pyramid_request):
         group = factories.Group()
 
-        group_resource = GroupResource(group, pyramid_request)
+        group_context = GroupContext(group, pyramid_request)
 
-        assert group_resource.id == group.pubid  # NOT the group.id
+        assert group_context.id == group.pubid  # NOT the group.id
 
     def test_it_expands_organization(self, factories, pyramid_request):
         group = factories.Group()
 
-        group_resource = GroupResource(group, pyramid_request)
+        group_context = GroupContext(group, pyramid_request)
 
-        assert isinstance(group_resource.organization, OrganizationContext)
+        assert isinstance(group_context.organization, OrganizationContext)
 
 
 @pytest.mark.usefixtures('organization_routes')

--- a/tests/h/views/api_groups_test.py
+++ b/tests/h/views/api_groups_test.py
@@ -49,12 +49,12 @@ class TestGetGroups(object):
             document_uri=None
         )
 
-    def test_converts_groups_to_resources(self, GroupResource, anonymous_request, open_groups, list_groups_service):  # noqa: N803
+    def test_converts_groups_to_resources(self, GroupContext, anonymous_request, open_groups, list_groups_service):  # noqa: N803
         list_groups_service.request_groups.return_value = open_groups
 
         views.groups(anonymous_request)
 
-        GroupResource.assert_has_calls([
+        GroupContext.assert_has_calls([
             mock.call(open_groups[0], anonymous_request),
             mock.call(open_groups[1], anonymous_request),
         ])
@@ -162,8 +162,8 @@ def GroupsJSONPresenter(patch):  # noqa: N802
 
 
 @pytest.fixture
-def GroupResource(patch):  # noqa: N802
-    return patch('h.views.api_groups.GroupResource')
+def GroupContext(patch):  # noqa: N802
+    return patch('h.views.api_groups.GroupContext')
 
 
 @pytest.fixture


### PR DESCRIPTION
Part of the refactoring described in this Slack post:

https://hypothes-is.slack.com/files/U074DEU66/FA511033L/h_traversal__resources__refactoring

This is part of renaming all the `*Resource` classes to `*Context`. In
practice these classes are always used as "context resources" in Pyramid -
they're always the resource at the end of traversal, and passed to the
view as the context. They're never used as intermediate resources in
traversal. As discussed in the Slack post, "context" much better
describes what we're using these classes for than "resource".