### PR TITLE
Privacy opt in checkbox

### DIFF
--- a/h/schemas/auth_client.py
+++ b/h/schemas/auth_client.py
@@ -35,6 +35,7 @@ class CreateAuthClientSchema(CSRFSchema):
 
     trusted = colander.SchemaNode(
                 colander.Boolean(),
+                missing=False,
                 widget=deform.widget.CheckboxWidget(
                     omit_label=False,
                     css_class='form-checkbox--inline'

--- a/h/schemas/auth_client.py
+++ b/h/schemas/auth_client.py
@@ -3,6 +3,7 @@
 from __future__ import unicode_literals
 
 import colander
+import deform
 
 from h import i18n
 from h.models.auth_client import GrantType
@@ -34,6 +35,10 @@ class CreateAuthClientSchema(CSRFSchema):
 
     trusted = colander.SchemaNode(
                 colander.Boolean(),
+                widget=deform.widget.CheckboxWidget(
+                    omit_label=False,
+                    css_class='form-checkbox--inline'
+                ),
                 title=_('Trusted ⚠️'),
                 hint=_('Trusted clients do not require user approval. '
                        '⚠️ Only enable this for official Hypothesis clients.'))

--- a/h/static/styles/partials/_form-checkbox.scss
+++ b/h/static/styles/partials/_form-checkbox.scss
@@ -9,6 +9,12 @@
   margin-right: auto;
 }
 
+.form-checkbox--inline {
+  color: $grey-4;
+  border: none;
+  display: flex;
+}
+
 .form-checkbox__input {
   margin-right: 15px;
 }

--- a/h/templates/deform/checkbox.jinja2
+++ b/h/templates/deform/checkbox.jinja2
@@ -1,9 +1,19 @@
-<div class="form-checkbox">
+<div class="form-checkbox {% if field.widget.css_class %}{{ field.widget.css_class }}{% endif %}">
   <input type="checkbox"
+         class="form-checkbox__input"
          name="{{ field.name }}"
          id="{{ field.oid }}"
          value="{{ field.widget.true_val }}"
          {%- if cstruct == field.widget.true_val %}
          checked=""
-         {% endif -%}>
+         {% endif -%}
+         {% if field.required %}
+         required
+         {% endif %}
+  >
+  {% if field.description %}
+    <label for="{{ field.oid }}">
+      {{ field.description }}
+    </label>
+  {% endif %}
 </div>

--- a/h/templates/deform/mapping_item.jinja2
+++ b/h/templates/deform/mapping_item.jinja2
@@ -8,8 +8,8 @@
             {% if field.error %}is-error{% endif %}
             {% if show_char_counter %} js-character-limit {%- endif %}
             {% if field.schema.hide_until_form_active %} is-hidden-when-loading {%- endif %}"
-     {%- if field.description -%}
-     title="{{ _(field.description) }}"
+     {%- if field.description-%}
+     title="{{ _(field.description) | striptags }}"
      {% endif %}
      {%- if field.schema.hide_until_form_active -%}
      data-hide-until-active="true"

--- a/h/views/account_signup.py
+++ b/h/views/account_signup.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import unicode_literals
+import datetime
 
 import deform
 import jinja2
@@ -23,23 +24,13 @@ def _login_redirect_url(request):
 class SignupController(object):
 
     def __init__(self, request):
-        tos_link = ('<a class="link" href="/terms-of-service">' +
-                    _('Terms of Service') +
-                    '</a>')
-        cg_link = ('<a class="link" href="/community-guidelines">' +
-                   _('Community Guidelines') +
-                   '</a>')
-        form_footer = _(
-            'You are agreeing to our {tos_link} and '
-            '{cg_link}.').format(tos_link=tos_link, cg_link=cg_link)
 
         self.request = request
         self.schema = schemas.RegisterSchema().bind(request=self.request)
         self.form = request.create_form(self.schema,
                                         buttons=(deform.Button(title=_('Sign up'),
                                                                css_class='js-signup-btn'),),
-                                        css_class='js-signup-form',
-                                        footer=form_footer)
+                                        css_class='js-signup-form')
 
     @view_config(request_method='GET')
     def get(self):
@@ -66,7 +57,8 @@ class SignupController(object):
         signup_service = self.request.find_service(name='user_signup')
         signup_service.signup(username=appstruct['username'],
                               email=appstruct['email'],
-                              password=appstruct['password'])
+                              password=appstruct['password'],
+                              privacy_accepted=datetime.datetime.utcnow())
 
         self.request.session.flash(jinja2.Markup(_(
             "Please check your email and open the link to activate your "

--- a/tests/h/accounts/schemas_test.py
+++ b/tests/h/accounts/schemas_test.py
@@ -126,12 +126,11 @@ class TestRegisterSchema(object):
                                                   "numbers, periods, and "
                                                   "underscores.")
 
-    def test_it_is_invalid_with_false_privacy_accepted(self,
-                                                            pyramid_request):
+    def test_it_is_invalid_with_false_privacy_accepted(self, pyramid_request):
         schema = schemas.RegisterSchema().bind(request=pyramid_request)
 
         with pytest.raises(colander.Invalid) as exc:
-            schema.deserialize({"privacy_accepted": False})
+            schema.deserialize({"privacy_accepted": 'false'})
 
         assert exc.value.asdict()['privacy_accepted'] == "Acceptance of the privacy policy is required"
 
@@ -415,7 +414,7 @@ class TestEmailChangeSchema(object):
 
         """
         models.User.get_by_email.return_value = Mock(spec_set=['userid'],
-                                                      userid=user.userid)
+                                                     userid=user.userid)
         pyramid_config.testing_securitypolicy(user.userid)
 
         schema.deserialize({'email': user.email, 'password': 'flibble'})

--- a/tests/h/accounts/schemas_test.py
+++ b/tests/h/accounts/schemas_test.py
@@ -126,6 +126,36 @@ class TestRegisterSchema(object):
                                                   "numbers, periods, and "
                                                   "underscores.")
 
+    def test_it_is_invalid_with_false_privacy_accepted(self,
+                                                            pyramid_request):
+        schema = schemas.RegisterSchema().bind(request=pyramid_request)
+
+        with pytest.raises(colander.Invalid) as exc:
+            schema.deserialize({"privacy_accepted": False})
+
+        assert exc.value.asdict()['privacy_accepted'] == "Acceptance of the privacy policy is required"
+
+    def test_it_is_invalid_when_privacy_accepted_missing(self,
+                                                         pyramid_request):
+        schema = schemas.RegisterSchema().bind(request=pyramid_request)
+
+        with pytest.raises(colander.Invalid) as exc:
+            schema.deserialize({})
+
+        assert exc.value.asdict()['privacy_accepted'] == "Required"
+
+    def test_it_validates_with_valid_payload(self, pyramid_csrf_request, user_model):
+        user_model.get_by_username.return_value = None
+        user_model.get_by_email.return_value = None
+
+        schema = schemas.RegisterSchema().bind(request=pyramid_csrf_request)
+        schema.deserialize({
+            "username": "filbert",
+            "email": "foo@bar.com",
+            "password": "sdlkfjlk3j3iuei",
+            "privacy_accepted": "true",
+        })
+
 
 @pytest.mark.usefixtures('user_service', 'user_password_service')
 class TestLoginSchema(object):

--- a/tests/h/services/user_signup_test.py
+++ b/tests/h/services/user_signup_test.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import unicode_literals
+import datetime
 
 import mock
 import pytest
@@ -52,6 +53,14 @@ class TestUserSignupService(object):
                           authority='bar-client.com')
 
         assert user.authority == 'bar-client.com'
+
+    def test_signup_passes_through_privacy_acceptance(self, svc):
+        now = datetime.datetime.utcnow()
+        user = svc.signup(username='foo',
+                          email='foo@bar.com',
+                          privacy_accepted=now)
+
+        assert user.privacy_accepted == now
 
     def test_signup_sets_password_using_password_service(self, svc, user_password_service):
         user = svc.signup(username='foo',

--- a/tests/h/views/account_signup_test.py
+++ b/tests/h/views/account_signup_test.py
@@ -30,7 +30,8 @@ class TestSignupController(object):
     def test_post_creates_user_from_form_data(self,
                                               form_validating_to,
                                               pyramid_request,
-                                              user_signup_service):
+                                              user_signup_service,
+                                              datetime):
         controller = views.SignupController(pyramid_request)
         controller.form = form_validating_to({
             "username": "bob",
@@ -43,7 +44,8 @@ class TestSignupController(object):
 
         user_signup_service.signup.assert_called_with(username="bob",
                                                       email="bob@example.com",
-                                                      password="s3crets")
+                                                      password="s3crets",
+                                                      privacy_accepted=datetime.datetime.utcnow.return_value)
 
     def test_post_does_not_create_user_when_validation_fails(self,
                                                              invalid_form,
@@ -96,3 +98,8 @@ def user_signup_service(pyramid_config):
     service = mock.create_autospec(UserSignupService, spec_set=True, instance=True)
     pyramid_config.register_service(service, name='user_signup')
     return service
+
+
+@pytest.fixture
+def datetime(patch):
+    return patch('h.views.account_signup.datetime')


### PR DESCRIPTION
I'd love to get extra eyes and attention on reviewing this new feature PR.

This PR introduces:

* A required checkbox on the signup form that must be checked, indicating the user is agreeing to privacy policy and other terms.
* Updates to the signup view (`h.views.account_signup`) to populate the `privacy_accepted` field on the new User with a current timestamp.
* A bunch of futzing to get a single checkbox field working per deform and templates.

Current form appearance in Chrome:

![image](https://user-images.githubusercontent.com/439947/39372674-08a25c0c-4a13-11e8-94e8-80729f27642c.png)


A few things to work through yet:

1. I’m not confident on the CSS. I tried to add just the minimal amount of new CSS to style close to the mockups, but I’m not strong in flexbox and I’m not certain my changes are BEM-savvy enough. I’d like someone with some CSS chops to review this work. In addition, the description for checkbox wraps to two lines. If we care.
2. I’m uncertain as to whether we should take the step of trying to customise the browser messaging for not checking the checkbox. The markup makes use of the `required` attribute on the checkbox `input`. What shows up if you don’t check the box differs between browsers (Chrome’s behavior is shown below as an example). It’s strictly _possible_ to override this messaging by using the [constraint validation API](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#the-constraint-validation-api) but generally I shy away from trying to mess with browser-level behavior so I wanted to get some feedback on that.
3. I’ve done my best with tests but I’m not feeling 100% confident. Feedback appreciated.

Browser behavior when required checkbox not checked (Chrome):
![image](https://user-images.githubusercontent.com/439947/39372635-e6fe612c-4a12-11e8-9a51-2e8087619682.png)


Fixes https://github.com/hypothesis/product-backlog/issues/591
Fixes https://github.com/hypothesis/product-backlog/issues/611