### PR TITLE
Add the first Elasticsearch-integrated unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ matrix:
       python: '2.7'
       addons:
         postgresql: "9.4"
+      before_install:
+        - ./scripts/elasticsearch-old.sh
+        - ./scripts/elasticsearch.sh
       install: pip install tox
       before_script: createdb htest
       script: tox
@@ -20,6 +23,9 @@ matrix:
       python: '3.6'
       addons:
         postgresql: '9.4'
+      before_install:
+        - ./scripts/elasticsearch-old.sh
+        - ./scripts/elasticsearch.sh
       install: pip install tox
       before_script: createdb htest
       script:

--- a/scripts/elasticsearch-old.sh
+++ b/scripts/elasticsearch-old.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Install the old version of Elasticsearch in /tmp and run it.
+set -ev
+mkdir /tmp/elasticsearch-old
+wget -O - https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.6.2.tar.gz | tar xz --directory=/tmp/elasticsearch-old --strip-components=1
+/tmp/elasticsearch-old/bin/plugin install elasticsearch/elasticsearch-analysis-icu/2.6.0/
+/tmp/elasticsearch-old/bin/elasticsearch -Des.http.port=9200 -d --path.data /tmp/elasticsearch-old_data

--- a/scripts/elasticsearch.sh
+++ b/scripts/elasticsearch.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Install Elasticsearch in /tmp and run it.
+set -ev
+mkdir /tmp/elasticsearch
+wget -O - https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.2.4.tar.gz | tar xz --directory=/tmp/elasticsearch --strip-components=1
+/tmp/elasticsearch/bin/elasticsearch-plugin install analysis-icu
+/tmp/elasticsearch/bin/elasticsearch -E http.port=9201 -E path.data=/tmp/elasticsearch_data -d

--- a/tests/common/fixtures/__init__.py
+++ b/tests/common/fixtures/__init__.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from tests.common.fixtures.elasticsearch import es_client
+from tests.common.fixtures.elasticsearch import init_elasticsearch
+from tests.common.fixtures.elasticsearch import delete_all_elasticsearch_documents
+
+
+__all__ = (
+    "es_client",
+    "init_elasticsearch",
+    "delete_all_elasticsearch_documents",
+)

--- a/tests/common/fixtures/elasticsearch.py
+++ b/tests/common/fixtures/elasticsearch.py
@@ -38,7 +38,7 @@ def init_elasticsearch(request):
     search.init(client)
 
 
-@pytest.fixture()
+@pytest.fixture
 def delete_all_elasticsearch_documents(request):
     """Delete everything from the test search index after each test."""
     client = _es_client()

--- a/tests/common/fixtures/elasticsearch.py
+++ b/tests/common/fixtures/elasticsearch.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import os
+
+import pytest
+
+from h import search
+
+ELASTICSEARCH_HOST = os.environ.get("ELASTICSEARCH_HOST", "http://localhost:9200")
+ELASTICSEARCH_INDEX = "hypothesis-test"
+
+
+@pytest.fixture
+def es_client():
+    """A :py:class:`h.search.client.Client` for the test search index."""
+    return _es_client()
+
+
+@pytest.fixture(scope="session", autouse=True)
+def init_elasticsearch(request):
+    """Initialize the test Elasticsearch index once per test session."""
+    client = _es_client()
+
+    def maybe_delete_index():
+        """Delete the test index if it exists."""
+        if client.conn.indices.exists(index=ELASTICSEARCH_INDEX):
+            client.conn.indices.delete(index=ELASTICSEARCH_INDEX)
+
+    # Delete the test search index at the end of the test run.
+    request.addfinalizer(maybe_delete_index)
+
+    # Delete the test search index at the start of the run, just in case it
+    # was somehow left behind by a previous test run.
+    maybe_delete_index()
+
+    # Initialize the test search index.
+    search.init(client)
+
+
+@pytest.fixture(autouse=True)
+def delete_all_elasticsearch_documents(request):
+    """Delete everything from the test search index after each test."""
+    client = _es_client()
+
+    def delete_everything():
+        client.conn.delete_by_query(index=client.index, body={"query": {"match_all": {}}})
+
+    request.addfinalizer(delete_everything)
+
+
+def _es_client():
+    """Return a :py:class:`h.search.client.Client` for the test search index."""
+    return search.get_client({"es.host": ELASTICSEARCH_HOST, "es.index": ELASTICSEARCH_INDEX})

--- a/tests/common/fixtures/elasticsearch.py
+++ b/tests/common/fixtures/elasticsearch.py
@@ -12,7 +12,7 @@ ELASTICSEARCH_INDEX = "hypothesis-test"
 
 
 @pytest.fixture
-def es_client():
+def es_client(delete_all_elasticsearch_documents):
     """A :py:class:`h.search.client.Client` for the test search index."""
     return _es_client()
 
@@ -38,7 +38,7 @@ def init_elasticsearch(request):
     search.init(client)
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture()
 def delete_all_elasticsearch_documents(request):
     """Delete everything from the test search index after each test."""
     client = _es_client()

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -74,6 +74,13 @@ def pyramid_app():
     return create_app(None, **TEST_SETTINGS)
 
 
+# Always unconditionally wipe the Elasticsearch index after every functional
+# test.
+@pytest.fixture(autouse=True)
+def always_delete_all_elasticsearch_documents(delete_all_elasticsearch_documents):
+    pass
+
+
 def _clean_database(engine):
     from h import db
     tables = reversed(db.Base.metadata.sorted_tables)

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -76,7 +76,7 @@ def pyramid_app():
 
 # Always unconditionally wipe the Elasticsearch index after every functional
 # test.
-@pytest.fixture(autouse=True)
+@pytest.fixture(autouse=True)  # noqa: F811
 def always_delete_all_elasticsearch_documents(delete_all_elasticsearch_documents):
     pass
 

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -11,9 +11,13 @@ from h._compat import text_type
 from tests.common.fixtures import es_client  # noqa: F401
 from tests.common.fixtures import init_elasticsearch  # noqa: F401
 from tests.common.fixtures import delete_all_elasticsearch_documents  # noqa: F401
+from tests.common.fixtures.elasticsearch import ELASTICSEARCH_HOST
+from tests.common.fixtures.elasticsearch import ELASTICSEARCH_INDEX
 
 
 TEST_SETTINGS = {
+    'es.host': ELASTICSEARCH_HOST,
+    'es.index': ELASTICSEARCH_INDEX,
     'h.app_url': 'http://example.com',
     'h.authority': 'example.com',
     'pyramid.debug_all': True,

--- a/tests/h/conftest.py
+++ b/tests/h/conftest.py
@@ -24,6 +24,9 @@ from h import db
 from h import models
 from h.settings import database_url
 from h._compat import text_type
+from tests.common.fixtures import es_client  # noqa: F401
+from tests.common.fixtures import init_elasticsearch  # noqa: F401
+from tests.common.fixtures import delete_all_elasticsearch_documents  # noqa: F401
 
 TEST_AUTHORITY = 'example.com'
 TEST_DATABASE_URL = database_url(os.environ.get('TEST_DATABASE_URL',

--- a/tests/h/search/index_test.py
+++ b/tests/h/search/index_test.py
@@ -9,6 +9,68 @@ from h.search import client
 from h.search import index
 
 
+class TestIndexAnnotationDocuments(object):
+    """
+    Integrated tests for indexing and retrieving annotations documents.
+
+    Tests that index real annotations into a real Elasticsearch index, and
+    test the saving and retrieval of the ``annotation.document`` field.
+
+    *Searching* for an annotation by ``annotation.document`` (e.g. by document
+    ``title`` or ``web_uri``) isn't enabled.  But you can retrieve an
+    annotation by ID, or by searching on other field(s), and then access
+    its ``document``. Bouncer (https://github.com/hypothesis/bouncer) accesses
+    h's Elasticsearch index directly and uses this ``document`` field.
+
+    """
+    def test_it_can_index_an_annotation_with_no_document(self, factories,
+                                                         index, get):
+        annotation = factories.Annotation.build(id="test_annotation_id",
+                                                document=None)
+
+        index(annotation)
+
+        assert get(annotation.id)["document"] == {}
+
+    def test_it_indexes_the_annotations_document_title(self, factories,
+                                                       index, get):
+        annotation = factories.Annotation.build(
+            id="test_annotation_id",
+            document=factories.Document.build(title="test_document_title"),
+        )
+
+        index(annotation)
+
+        assert get(annotation.id)["document"]["title"] == ["test_document_title"]
+
+    def test_it_can_index_an_annotation_with_a_document_with_no_title(self, factories,
+                                                                      index, get):
+        annotation = factories.Annotation.build(
+            id="test_annotation_id",
+            document=factories.Document.build(title=None),
+        )
+
+        index(annotation)
+
+        assert "title" not in get(annotation.id)["document"]
+
+    @pytest.fixture
+    def index(self, es_client, pyramid_request):
+        def _index(annotation):
+            """Index the given annotation into Elasticsearch."""
+            index.index(es_client, annotation, pyramid_request)
+        return _index
+
+    @pytest.fixture
+    def get(self, es_client):
+        def _get(annotation_id):
+            """Return the annotation with the given ID from Elasticsearch."""
+            return es_client.conn.get(
+                index=es_client.index, doc_type="annotation",
+                id=annotation_id)["_source"]
+        return _get
+
+
 @pytest.mark.usefixtures('presenters')
 class TestIndexAnnotation:
 

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,7 @@ deps =
 passenv =
     TEST_DATABASE_URL
     ELASTICSEARCH_HOST
+    ELASTICSEARCH_URL
     PYTEST_ADDOPTS
 commands =
     coverage run --parallel --source h,tests/h -m pytest {posargs:tests/h/}
@@ -36,6 +37,7 @@ deps =
 passenv =
     BROKER_URL
     ELASTICSEARCH_HOST
+    ELASTICSEARCH_URL
     TEST_DATABASE_URL
     PYTEST_ADDOPTS
 commands = pytest {posargs:tests/functional/}
@@ -51,6 +53,7 @@ deps =
 passenv =
     BROKER_URL
     ELASTICSEARCH_HOST
+    ELASTICSEARCH_URL
     TEST_DATABASE_URL
     PYTEST_ADDOPTS
 commands = pytest {posargs:tests/functional/}

--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,7 @@ deps =
     -rrequirements.txt
 passenv =
     TEST_DATABASE_URL
+    ELASTICSEARCH_HOST
     PYTEST_ADDOPTS
 commands =
     coverage run --parallel --source h,tests/h -m pytest {posargs:tests/h/}


### PR DESCRIPTION
This pull request adds the first unit tests that use a real Elasticsearch service to test against:

* A running Elasticsearch 1.6 service is now available to all tests in dev envs and on Travis and Jenkins. (Previously Es 1.6 was available to functional tests in devs envs and on Jenkins, but not on Travis and not available to unit tests.)

* There are fixtures, shared by the functional and unit tests, that initialize a test Es 1.6 index at the start of a test run, and clean out the index after every test.

* There is a new `es_client` fixture for tests to have access to the actual Es 1.6 client object.

* There is also now an Es 6.2 service running on both Travis and Jenkins in addition to Es 1.6. Es 6.2 was already running in dev envs. The tests and test fixtures don't use Es 6.2 yet, but it's available.

* Finally, a couple of example Es-integrated tests are added. (For Es 1,6)

Comments on the tests:

* These tests would fail if `AnnotationSearchIndexPresenter` was wrong (not calling `DocumentSearchIndexPresenter` and inserting its result in the right place. But `AnnotationSearchIndexPresenter` unit tests that don't touch the real Es could test that.

* These tests would fail if `DocumentSearchIndexPresenter` was wrong. E.g. if it named them document "names" instead of "titles". But `DocumentSearchIndexPresenter` unit tests that don't touch the real Es could test that.

* These tests would fail if there was a disagreement between `AnnotationSearchIndexPresenter` / `DocumentSearchIndexPresenter` and `ANNOTATION_MAPPING`. If you try to index something that doesn't fit with the mapping, Es will crash. Testing `AnnotationSearchIndexPresenter` and `DocumentSearchIndexPresenter` in isolation would not catch this.

  Since `annotation.document` is not indexed though, Es is a lot more permissive about what it will allow to be indexed without crashing, than it otherwise would be.

* I think tests for other fields, that actually test querying, will be more valuable.

Limitations:

* These unit tests test the index and retrieving of annotation documents from Elasticsearch. Annotation documents are a little bit special in that they aren't indexed, so you can't do search queries by them, but they _are_ written to Elasticsearch and can be retrieved (e.g. by directly retrieving the entire Elasticsearch document by ID). Bouncer does this. So that's what these tests test. For indexing other fields that _are_ supposed to be queryable the tests should probably do actual queries. This pull request hasn't figured out how that should work yet. (Also you need to refresh the search index before a query will work.)

* These are just the first few tests. They don't test everything to do with the document field. E.g. web_uri not tested yet.

Details:

* Elasticsearch is now running on Travis CI. It's running two Es's: 1.6 and 6.2, though nothing uses the 6.2 yet.

   We can't use Docker on Travis because that would kick us over to Travis's slower, VM-based infrastructure instead of their faster container-based stuff. Nor can we use Travis's built-in Elasticsearch service because it gives us just one Es 5 but we need both 1.6 and 6.2 running (plus we need the ICU plugin, which I don't think we could install on Travis's built-in Es without using sudo and getting kicked over to the VM infra). See commit message for details https://github.com/hypothesis/h/pull/5002/commits/22ab765d681c4fd921d6a56e1a2b7c6d683c2c3e

* Elasticsearch 6.2 is now running on Jenkins. Es 1.6 was already running on Jenkins (for the functional tests, which run on Jenkins only not Travis). Again, nothing uses the Es 6.2 yet, only the 1.6 is used. On Jenkins we can use Docker, so we use the same Docker images as we use in dev envs. https://github.com/hypothesis/h/pull/5002/commits/190effc9f37e7ea62fb50bffa2a73c78a773eb9a

* Add the `ELASTICSEARCH_HOST` env var (URL of the old Es 1.6 service) to the unit test tox environment. Previously `tox.ini` made this available to functional tests but not to unit tests.

* Add a new environment variable, `ELASTICSEARCH_URL`, intended to hold the URL of the new Es 6.2 service. In dev envs and in Travis this will be able to be hard-coded into the test files like the old `ELASTICSEARCH_HOST` is currently, because the URL is predictable. On Jenkins the Es URL is not predictable, the port is randomised, so have Jenkins and tox pass the new `ELASTICSEARCH_URL` env var through to the code as they already do for `ELASTICSEARCH_HOST`.

  All we're doing with `ELASTICSEARCH_URL` is having Jenkins and tox pass it through, the tests and code don't use it yet.

* Move the pre-existing Elasticsearch fixtures (for initializing an Es index and cleaning it out after each test) from `tests/functional` into `tests/common` and have both the unit and functional tests import and use them. Also tidied up these fixtures and added a new `es_client` fixture for tests to have access to the actual client. All of these fixtures are for Es 1.6, Es 6.2 is available but not used by tests or test fixtures yet.