### PR TITLE
Redirect users to a not found page when they search for non-existent …

### DIFF
--- a/h/activity/query.py
+++ b/h/activity/query.py
@@ -89,15 +89,19 @@ def check_url(request, query, unparse=parser.unparse):
                                           pubid=group.pubid,
                                           slug=group.slug,
                                           _query={'q': unparse(query)})
+        else:
+            redirect = request.route_path('group_read',
+                                          pubid=pubid,
+                                          slug=None,
+                                          _query={'q': unparse(query)})
 
     elif _single_entry(query, 'user'):
         username = query.pop('user')
         user = request.find_service(name='user').fetch(username,
                                                        request.authority)
-        if user:
-            redirect = request.route_path('activity.user_search',
-                                          username=username,
-                                          _query={'q': unparse(query)})
+        redirect = request.route_path('activity.user_search',
+                                      username=username,
+                                      _query={'q': unparse(query)})
 
     if redirect is not None:
         raise HTTPFound(location=redirect)

--- a/h/templates/activity/groupnotfound.html.jinja2
+++ b/h/templates/activity/groupnotfound.html.jinja2
@@ -1,0 +1,15 @@
+{% extends "h:templates/layouts/base.html.jinja2" %}
+
+{% block title %}Group not Found{% endblock %}
+
+{% block content %}
+  {% include 'h:templates/includes/logo-header.html.jinja2' %}
+  <div class="form-container">
+    <h1 class="form-header">Group "{{ pubid }}" not found</h1>
+    <p>This group does not exist.Please try a different search.</p>
+  </div>
+{% endblock %}
+
+{% block footer %}
+  {% include "h:templates/includes/footer.html.jinja2" %}
+{% endblock %}

--- a/h/templates/activity/usernotfound.html.jinja2
+++ b/h/templates/activity/usernotfound.html.jinja2
@@ -1,0 +1,15 @@
+{% extends "h:templates/layouts/base.html.jinja2" %}
+
+{% block title %}User not Found{% endblock %}
+
+{% block content %}
+  {% include 'h:templates/includes/logo-header.html.jinja2' %}
+  <div class="form-container">
+    <h1 class="form-header">User "{{ username }}" not found</h1>
+    <p>This user does not exist.Please try a different search.</p>
+  </div>
+{% endblock %}
+
+{% block footer %}
+  {% include "h:templates/includes/footer.html.jinja2" %}
+{% endblock %}

--- a/h/views/activity.py
+++ b/h/views/activity.py
@@ -9,7 +9,7 @@ from h._compat import urlparse
 from jinja2 import Markup
 from pyramid import httpexceptions
 from pyramid import security
-from pyramid.view import view_config
+from pyramid.view import view_config, notfound_view_config
 from pyramid.view import view_defaults
 
 from h import util
@@ -97,7 +97,15 @@ class GroupSearchController(SearchController):
     def __init__(self, group, request):
         super(GroupSearchController, self).__init__(request)
         self.group = group
-        self._organization_context = OrganizationContext(group.organization, request)
+
+        if type(group) is not httpexceptions.HTTPNotFound:
+            self._organization_context = OrganizationContext(group.organization, request)
+
+    @notfound_view_config(renderer='h:templates/activity/groupnotfound.html.jinja2')
+    def notfound(self):
+        return {
+            'pubid': self.request.matchdict.get('pubid')
+        }
 
     @view_config(request_method='GET')
     def search(self):
@@ -316,6 +324,12 @@ class UserSearchController(SearchController):
     def __init__(self, user, request):
         super(UserSearchController, self).__init__(request)
         self.user = user
+
+    @notfound_view_config(renderer='h:templates/activity/usernotfound.html.jinja2')
+    def notfound(self):
+        return {
+            'username': self.request.matchdict.get('username')
+        }
 
     @view_config(request_method='GET')
     def search(self):


### PR DESCRIPTION
…users and groups.

Currently, we return all annotations when a user searches for a non-existent
user or group. This can be a very confusing experience for the user.
Change it to be more meaningful.

Fixes https://github.com/hypothesis/product-backlog/issues/462