### PR TITLE
Make docker instance quantification more vague

### DIFF
--- a/docs/developing/install.rst
+++ b/docs/developing/install.rst
@@ -131,7 +131,7 @@ can be installed on:
 
       docker-compose up
 
-   You'll now have three Docker containers running the PostgreSQL, RabbitMQ, and
+   You'll now have some Docker containers running the PostgreSQL, RabbitMQ, and
    Elasticsearch services. You should be able to see them by running ``docker
    ps``. You should also be able to visit your Elasticsearch service by opening
    http://localhost:9200/ in a browser, and connect to your PostgreSQL by


### PR DESCRIPTION
This most trivial of PRs changes a specific counting of docker containers (_three_) to a more vague _some_ in our documentation so that a) we don't have to update the docs frequently as we munge with docker containers and b) installing users aren't confused if they see four containers instead of three for the moment.