### PR TITLE
Show users a no annotations message when they search for non-existent…

### DIFF
--- a/h/activity/query.py
+++ b/h/activity/query.py
@@ -82,19 +82,21 @@ def check_url(request, query, unparse=parser.unparse):
     redirect = None
 
     if _single_entry(query, 'group'):
-        pubid = query.pop('group')
+        pubid = query.get('group')
         group = request.db.query(Group).filter_by(pubid=pubid).one_or_none()
         if group:
+            query.pop('group')
             redirect = request.route_path('group_read',
                                           pubid=group.pubid,
                                           slug=group.slug,
                                           _query={'q': unparse(query)})
 
     elif _single_entry(query, 'user'):
-        username = query.pop('user')
+        username = query.get('user')
         user = request.find_service(name='user').fetch(username,
                                                        request.authority)
         if user:
+            query.pop('user')
             redirect = request.route_path('activity.user_search',
                                           username=username,
                                           _query={'q': unparse(query)})

--- a/tests/h/activity/query_test.py
+++ b/tests/h/activity/query_test.py
@@ -97,6 +97,16 @@ class TestCheckURL(object):
 
         assert check_url(pyramid_request, query, unparse=unparse) is None
 
+    def test_does_not_remove_group_term_from_query_if_group_does_not_exist(self,
+                                                                           pyramid_request,
+                                                                           unparse):
+        query = MultiDict({'group': 'does_not_exist'})
+
+        check_url(pyramid_request, query, unparse=unparse)
+
+        assert query.get('group') == 'does_not_exist'
+        assert not unparse.called
+
     def test_removes_group_term_from_query(self, group, pyramid_request, unparse):
         query = MultiDict({'group': group.pubid})
 
@@ -142,6 +152,18 @@ class TestCheckURL(object):
         user_service.fetch.return_value = None
 
         assert check_url(pyramid_request, query) is None
+
+    def test_does_not_remove_user_term_from_query_if_user_does_not_exist(self,
+                                                                         pyramid_request,
+                                                                         unparse,
+                                                                         user_service):
+        query = MultiDict({'user': 'jose'})
+        user_service.fetch.return_value = None
+
+        check_url(pyramid_request, query, unparse=unparse)
+
+        assert query.get('user') == 'jose'
+        assert not unparse.called
 
     def test_removes_user_term_from_query(self, pyramid_request, unparse):
         query = MultiDict({'user': 'jose'})


### PR DESCRIPTION
… users and groups.

Currently, we return all annotations when a user searches for a non-existent
user or group. This can be a very confusing experience for the user.
Change it to be more meaningful.

Fixes hypothesis/product-backlog#462