### PR TITLE
Only show one error message per field while submiting a form.

### DIFF
--- a/h/templates/deform/mapping_item.jinja2
+++ b/h/templates/deform/mapping_item.jinja2
@@ -46,7 +46,9 @@
 
 {%- if field.error and not field.widget.hidden -%}
   <ul class="form-input__error-list">
-  {% for msg in field.error.messages() -%}
+  {# Only show the first error message for each field. #}
+  {# https://github.com/hypothesis/product-backlog/issues/581 #}
+  {% for msg in field.error.messages()[0:1] -%}
     {%- set errstr = 'error-%s' % field.oid -%}
     {%- set pid = (loop.index0==0 and errstr) or ('%s-%s' % (errstr, loop.index0)) -%}
     <li class="form-input__error-item" id="{{ pid }}">{{ _(msg) }}</li>


### PR DESCRIPTION
At the moment we show every error message applicable to a form field
causing them to overlap, making it impossible to read them.
Show the user just one error message at a time.

Fixes: https://github.com/hypothesis/product-backlog/issues/581