### PR TITLE
Substitute elasticsearch1 for elasticsearch

### DIFF
--- a/h/config.py
+++ b/h/config.py
@@ -137,7 +137,7 @@ def configure(environ=None, settings=None):
         logging.getLogger('sqlalchemy.engine').setLevel(level)
 
     # Add ES logging filter to filter out ReadTimeout warnings
-    es_logger = logging.getLogger('elasticsearch')
+    es_logger = logging.getLogger('elasticsearch1')
     es_logger.addFilter(ExceptionFilter((("ReadTimeout", "WARNING"),)))
 
     return Configurator(settings=settings)

--- a/h/search/client.py
+++ b/h/search/client.py
@@ -2,7 +2,7 @@
 
 from __future__ import unicode_literals
 import certifi
-from elasticsearch import Elasticsearch, RequestsHttpConnection
+from elasticsearch1 import Elasticsearch, RequestsHttpConnection
 from requests_aws4auth import AWS4Auth
 
 __all__ = ('Client',)

--- a/h/search/config.py
+++ b/h/search/config.py
@@ -14,7 +14,7 @@ import binascii
 import logging
 import os
 
-from elasticsearch.exceptions import NotFoundError, RequestError
+from elasticsearch1.exceptions import NotFoundError, RequestError
 
 log = logging.getLogger(__name__)
 

--- a/h/search/core.py
+++ b/h/search/core.py
@@ -4,7 +4,7 @@ import logging
 from collections import namedtuple
 from contextlib import contextmanager
 
-from elasticsearch.exceptions import ConnectionTimeout
+from elasticsearch1.exceptions import ConnectionTimeout
 
 from h.search import query
 

--- a/h/search/index.py
+++ b/h/search/index.py
@@ -8,7 +8,7 @@ import time
 from collections import namedtuple
 
 import sqlalchemy as sa
-from elasticsearch import helpers as es_helpers
+from elasticsearch1 import helpers as es_helpers
 from sqlalchemy.orm import subqueryload
 
 from h import models

--- a/requirements.in
+++ b/requirements.in
@@ -11,7 +11,7 @@ click
 cryptography
 deform < 1.0
 deform-jinja2
-elasticsearch < 2.0.0
+elasticsearch1==1.10.0
 enum34
 functools32; python_version < "3.0" # Required by jsonschema, listed here to add environment marker
 gevent

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ contextlib2==0.5.4        # via raven
 cryptography==2.1.4
 deform-jinja2==0.5
 deform==0.9.9
-elasticsearch==1.9.0
+elasticsearch1==1.10.0
 enum34==1.1.6
 functools32==3.2.3.post2 ; python_version < "3.0"
 gevent==1.2.1
@@ -71,7 +71,7 @@ statsd==3.2.1
 transaction==2.1.2
 translationstring==1.3    # via colander, deform, pyramid
 unidecode==0.4.19         # via python-slugify
-urllib3==1.16             # via elasticsearch
+urllib3==1.16             # via elasticsearch1
 venusian==1.0
 vine==1.1.4               # via amqp
 webencodings==0.5.1       # via html5lib

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -90,7 +90,7 @@ def _clean_database(engine):
 
 
 def _clean_elasticsearch(settings):
-    import elasticsearch
+    import elasticsearch1
 
     conn = elasticsearch.Elasticsearch([settings['es.host']])
     conn.delete_by_query(index=settings['es.index'],
@@ -98,7 +98,7 @@ def _clean_elasticsearch(settings):
 
 
 def _drop_indices(settings):
-    import elasticsearch
+    import elasticsearch1
 
     conn = elasticsearch.Elasticsearch([settings['es.host']])
 

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -92,7 +92,7 @@ def _clean_database(engine):
 def _clean_elasticsearch(settings):
     import elasticsearch1
 
-    conn = elasticsearch.Elasticsearch([settings['es.host']])
+    conn = elasticsearch1.Elasticsearch([settings['es.host']])
     conn.delete_by_query(index=settings['es.index'],
                          body={"query": {"match_all": {}}})
 
@@ -100,7 +100,7 @@ def _clean_elasticsearch(settings):
 def _drop_indices(settings):
     import elasticsearch1
 
-    conn = elasticsearch.Elasticsearch([settings['es.host']])
+    conn = elasticsearch1.Elasticsearch([settings['es.host']])
 
     name = settings['es.index']
     if conn.indices.exists(index=name):

--- a/tests/h/search/client_test.py
+++ b/tests/h/search/client_test.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 
 import pytest
 
-from elasticsearch import RequestsHttpConnection
+from elasticsearch1 import RequestsHttpConnection
 
 from h.search.client import get_client
 from h.search.client import Client

--- a/tests/h/search/config_test.py
+++ b/tests/h/search/config_test.py
@@ -8,7 +8,7 @@ import re
 
 import mock
 import pytest
-from elasticsearch.exceptions import NotFoundError
+from elasticsearch1.exceptions import NotFoundError
 
 from h.search.config import (
     ANNOTATION_MAPPING,


### PR DESCRIPTION
Replace the elasticsearch library with elasticsearch1 in prep for using two different elasticsearch library versions at the same time. This is a fix for https://github.com/hypothesis/product-backlog/issues/633. This doesn't include any test changes as mentioned in the linked issue.