### PR TITLE
Connect to new elasticsearch cluster

### DIFF
--- a/h/cli/commands/init.py
+++ b/h/cli/commands/init.py
@@ -16,9 +16,9 @@ log = logging.getLogger(__name__)
 @click.pass_context
 def init(ctx):
     request = ctx.obj['bootstrap']()
-
-    _init_db(request.registry.settings)
-    _init_search(request.registry.settings)
+    settings = request.registry.settings
+    _init_db(settings)
+    _init_search(settings)
 
 
 def _init_db(settings):

--- a/h/cli/commands/init.py
+++ b/h/cli/commands/init.py
@@ -3,6 +3,7 @@
 import logging
 
 import click
+from elasticsearch_dsl import connections
 import sqlalchemy
 
 from h import db
@@ -18,6 +19,7 @@ def init(ctx):
     request = ctx.obj['bootstrap']()
     settings = request.registry.settings
     _init_db(settings)
+    _init_search_old(settings)
     _init_search(settings)
 
 
@@ -35,8 +37,13 @@ def _init_db(settings):
         log.info("detected alembic_version table, skipping db initialization")
 
 
-def _init_search(settings):
-    client = search.get_client(settings)
+def _init_search_old(settings):
+    client = search.get_client_old(settings)
 
     log.info("initializing search index")
     search.init(client)
+
+
+def _init_search(settings):
+    # Set the elasticsearch client connection as the default connection.
+    connections.add_connection('default', search.get_client(settings))

--- a/h/search/__init__.py
+++ b/h/search/__init__.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import unicode_literals
-from h.search.client import get_client
+from elasticsearch_dsl import connections
+from h.search.client import get_client, get_client_old
 from h.search.config import init
 from h.search.core import Search
 from h.search.core import FILTERS_KEY
@@ -16,6 +17,7 @@ __all__ = (
 def includeme(config):
     settings = config.registry.settings
     settings.setdefault('es.host', 'http://localhost:9200')
+    settings.setdefault('es.url', 'http://localhost:9201')
     settings.setdefault('es.index', 'hypothesis')
 
     # Allow users of this module to register additional search filter and
@@ -29,8 +31,10 @@ def includeme(config):
     # Add a property to all requests for easy access to the elasticsearch
     # client. This can be used for direct or bulk access without having to
     # reread the settings.
-    config.registry['es.client'] = get_client(settings)
+    config.registry['es.client'] = get_client_old(settings)
     config.add_request_method(
         lambda r: r.registry['es.client'],
         name='es',
         reify=True)
+    # Set the elasticsearch client connection as the default connection.
+    connections.add_connection('default', get_client(settings))

--- a/h/search/client.py
+++ b/h/search/client.py
@@ -2,10 +2,9 @@
 
 from __future__ import unicode_literals
 import certifi
-from elasticsearch1 import Elasticsearch, RequestsHttpConnection
+import elasticsearch
+import elasticsearch1
 from requests_aws4auth import AWS4Auth
-
-__all__ = ('Client',)
 
 
 class Client(object):
@@ -26,12 +25,9 @@ class Client(object):
 
     def __init__(self, host, index, **kwargs):
         self._index = index
-        self._conn = Elasticsearch([host],
-                                   verify_certs=True,
-                                   # N.B. this won't be necessary if we upgrade
-                                   # to elasticsearch>=5.0.0.
-                                   ca_certs=certifi.where(),
-                                   **kwargs)
+        self._conn = elasticsearch1.Elasticsearch(
+            [host],
+            **kwargs)
 
     @property
     def index(self):
@@ -42,14 +38,11 @@ class Client(object):
         return self._conn
 
 
-def get_client(settings):
-    """Return a client for the Elasticsearch index."""
-    host = settings['es.host']
-    index = settings['es.index']
-    kwargs = {}
-    kwargs['max_retries'] = settings.get('es.client.max_retries', 3)
-    kwargs['retry_on_timeout'] = settings.get('es.client.retry_on_timeout', False)
-    kwargs['timeout'] = settings.get('es.client.timeout', 10)
+def _get_settings(settings, elasticsearch=elasticsearch):
+    kwargs = {'verify_certs': True,
+              'max_retries': settings.get('es.client.max_retries', 3),
+              'retry_on_timeout': settings.get('es.client.retry_on_timeout', False),
+              'timeout': settings.get('es.client.timeout', 10)}
 
     if 'es.client_poolsize' in settings:
         kwargs['maxsize'] = settings['es.client_poolsize']
@@ -57,13 +50,23 @@ def get_client(settings):
     have_aws_creds = ('es.aws.access_key_id' in settings and
                       'es.aws.region' in settings and
                       'es.aws.secret_access_key' in settings)
-
     if have_aws_creds:
         auth = AWS4Auth(settings['es.aws.access_key_id'],
                         settings['es.aws.secret_access_key'],
                         settings['es.aws.region'],
                         'es')
         kwargs['http_auth'] = auth
-        kwargs['connection_class'] = RequestsHttpConnection
+        kwargs['connection_class'] = elasticsearch.RequestsHttpConnection
+    return kwargs
 
-    return Client(host, index, **kwargs)
+
+def get_client(settings):
+    return elasticsearch.Elasticsearch([settings['es.url']], **_get_settings(settings))
+
+
+def get_client_old(settings):
+    kwargs = _get_settings(settings, elasticsearch=elasticsearch1)
+    # N.B. this won't be necessary if we upgrade
+    # to elasticsearch>=5.0.0.
+    kwargs['ca_certs'] = certifi.where()
+    return Client(settings['es.host'], settings['es.index'], **kwargs)

--- a/tests/common/fixtures/elasticsearch.py
+++ b/tests/common/fixtures/elasticsearch.py
@@ -51,4 +51,4 @@ def delete_all_elasticsearch_documents(request):
 
 def _es_client():
     """Return a :py:class:`h.search.client.Client` for the test search index."""
-    return search.get_client({"es.host": ELASTICSEARCH_HOST, "es.index": ELASTICSEARCH_INDEX})
+    return search.get_client_old({"es.host": ELASTICSEARCH_HOST, "es.index": ELASTICSEARCH_INDEX})

--- a/tests/h/search/client_test.py
+++ b/tests/h/search/client_test.py
@@ -4,15 +4,28 @@ from __future__ import unicode_literals
 
 import pytest
 
-from elasticsearch1 import RequestsHttpConnection
+import elasticsearch
+import elasticsearch1
+import elasticsearch_dsl
+import elasticsearch1_dsl
 
-from h.search.client import get_client
+from h.search.client import get_client, get_client_old
 from h.search.client import Client
 
 
-class TestClient(object):
+ES1_PATH = 'h.search.client.elasticsearch1.Elasticsearch'
+ES_PATH = 'h.search.client.elasticsearch.Elasticsearch'
 
-    def test_it_sets_the_index_and_conn_properties(self):
+
+# Make the old get client method just return the es client obj
+# as opposed to the custom wrapper class obj.
+def get_client_old_wrap(settings):
+    return get_client_old(settings).conn
+
+
+class TestClient(object):
+    @pytest.mark.parametrize('elasticsearch', [(elasticsearch, elasticsearch1)])
+    def test_it_sets_the_index_and_conn_properties(self, elasticsearch):
         client = Client(host="http://localhost:9200", index="hypothesis")
 
         assert client.index == "hypothesis"
@@ -31,75 +44,139 @@ class TestClient(object):
             client.conn = "changed"
 
 
-class TestGetClient(object):
-    def test_initializes_client_with_host(self, settings, patched_client):
-        get_client(settings)
-        args, _ = patched_client.call_args
-        assert args[0] == 'search.svc'
+class TestClientConnection(object):
 
-    def test_initializes_client_with_index(self, settings, patched_client):
+    @pytest.mark.parametrize('get_client,elasticsearch_dsl',
+        [(get_client, elasticsearch_dsl), (get_client_old_wrap, elasticsearch1_dsl)])
+    def test_client_connection_successful(self, client, index, User, get_client, elasticsearch_dsl):
+        # write
+        user = User(meta={'id': 1}, age=34)
+        user.save(index='user', using='es')
+        # read
+        user = User.get(id=1, index='user', using='es')
+        assert user.age == 34
+
+    @pytest.fixture
+    def User(self, request):
+        elasticsearch_dsl = request.getfixturevalue('elasticsearch_dsl')
+
+        class User(elasticsearch_dsl.DocType):
+            age = elasticsearch_dsl.Integer()
+
+        return User
+
+    @pytest.fixture
+    def client(self, request):
+        get_client = request.getfixturevalue('get_client')
+        elasticsearch_dsl = request.getfixturevalue('elasticsearch_dsl')
+        # create the connection
+        settings = {'es.url': 'http://localhost:9201',
+                    'es.host': 'http://localhost:9200',
+                    'es.index': 'myindex'}
+        client = get_client(settings)
+        elasticsearch_dsl.connections.connections.add_connection('es', client)
+        yield client
+        # delete connection
+        elasticsearch_dsl.connections.connections.remove_connection('es')
+
+    @pytest.fixture
+    def index(self, User, client, request):
+        elasticsearch_dsl = request.getfixturevalue('elasticsearch_dsl')
+        # create the index
+        index = elasticsearch_dsl.Index('user', using='es')
+        index.doc_type(User)
+        index.create()
+        yield index
+        # delete index
+        index.delete()
+
+
+class TestGetClient(object):
+    @pytest.mark.parametrize('get_client,patch_path',
+        [(get_client, ES_PATH),
+         (get_client_old, ES1_PATH)])
+    def test_initializes_client_with_host(self, settings, patch_path, patched_elasticsearch, get_client):
         get_client(settings)
-        args, _ = patched_client.call_args
+        args, _ = patched_elasticsearch.call_args
+        assert args[0] == ['search.svc']
+
+    @pytest.mark.parametrize('patch_path', ['h.search.client.Client'])
+    def test_initializes_client_with_index(self, settings, patch_path, patched_elasticsearch):
+        get_client_old(settings)
+        args, _ = patched_elasticsearch.call_args
         assert args[1] == 'my-index'
 
-    @pytest.mark.parametrize('key,value,settingkey', [
-        ('max_retries', 7, 'es.client.max_retries'),
-        ('retry_on_timeout', True, 'es.client.retry_on_timeout'),
-        ('timeout', 15, 'es.client.timeout'),
-        ('maxsize', 4, 'es.client_poolsize'),
+    @pytest.mark.parametrize('key,value,settingkey,get_client,patch_path', [
+        ('max_retries', 7, 'es.client.max_retries', get_client, ES_PATH),
+        ('retry_on_timeout', True, 'es.client.retry_on_timeout', get_client, ES_PATH),
+        ('timeout', 15, 'es.client.timeout', get_client, ES_PATH),
+        ('maxsize', 4, 'es.client_poolsize', get_client, ES_PATH),
+        ('max_retries', 7, 'es.client.max_retries', get_client_old, ES1_PATH),
+        ('retry_on_timeout', True, 'es.client.retry_on_timeout', get_client_old, ES1_PATH),
+        ('timeout', 15, 'es.client.timeout', get_client_old, ES1_PATH),
+        ('maxsize', 4, 'es.client_poolsize', get_client_old, ES1_PATH),
     ])
-    def test_client_configuration(self, settings, patched_client, key, value, settingkey):
+    def test_client_configuration(self, settings, patch_path, patched_elasticsearch, key, value, settingkey, get_client):
         settings[settingkey] = value
         get_client(settings)
 
-        _, kwargs = patched_client.call_args
+        _, kwargs = patched_elasticsearch.call_args
         assert kwargs[key] == value
 
-    def test_initialises_aws_auth(self, settings, patched_aws_auth):
+    @pytest.mark.parametrize('get_client,patch_path',
+        [(get_client, ES_PATH),
+         (get_client_old, ES1_PATH)])
+    def test_initialises_aws_auth(self, settings, patch_path, patched_aws_auth, get_client):
         settings.update({'es.aws.access_key_id': 'foo', 'es.aws.secret_access_key': 'bar', 'es.aws.region': 'baz'})
         get_client(settings)
 
         patched_aws_auth.assert_called_once_with('foo', 'bar', 'baz', 'es')
 
-    def test_sets_aws_auth(self, settings, patched_client, patched_aws_auth):
+    @pytest.mark.parametrize('get_client,patch_path',
+        [(get_client, ES_PATH),
+         (get_client_old, ES1_PATH)])
+    def test_sets_aws_auth(self, settings, patch_path, patched_elasticsearch, patched_aws_auth, get_client):
         settings.update({'es.aws.access_key_id': 'foo', 'es.aws.secret_access_key': 'bar', 'es.aws.region': 'baz'})
         get_client(settings)
 
-        _, kwargs = patched_client.call_args
+        _, kwargs = patched_elasticsearch.call_args
         assert kwargs['http_auth'] == patched_aws_auth.return_value
 
-    def test_sets_connection_class_for_aws_auth(self, settings, patched_client):
+    @pytest.mark.parametrize('get_client,elasticsearch,patch_path',
+        [(get_client, elasticsearch, ES_PATH), (get_client_old, elasticsearch1, ES1_PATH)])
+    def test_sets_connection_class_for_aws_auth(self, settings, patch_path, patched_elasticsearch, get_client, elasticsearch):
         settings.update({'es.aws.access_key_id': 'foo', 'es.aws.secret_access_key': 'bar', 'es.aws.region': 'baz'})
         get_client(settings)
 
-        _, kwargs = patched_client.call_args
-        assert kwargs['connection_class'] == RequestsHttpConnection
+        _, kwargs = patched_elasticsearch.call_args
+        assert kwargs['connection_class'] == elasticsearch.RequestsHttpConnection
 
-    @pytest.mark.parametrize('aws_settings', [
-        {'es.aws.access_key_id': 'foo'},
-        {'es.aws.secret_access_key': 'foo'},
-        {'es.aws.region': 'foo'},
-        {'es.aws.access_key_id': 'foo', 'es.aws.secret_access_key': 'bar'},
-        {'es.aws.access_key_id': 'foo', 'es.aws.region': 'bar'},
-        {'es.aws.secret_access_key': 'foo', 'es.aws.region': 'bar'},
+    @pytest.mark.parametrize('aws_settings,get_client,patch_path', [
+        ({'es.aws.access_key_id': 'foo'}, get_client, ES_PATH),
+        ({'es.aws.secret_access_key': 'foo'}, get_client, ES_PATH),
+        ({'es.aws.region': 'foo'}, get_client, ES_PATH),
+        ({'es.aws.access_key_id': 'foo', 'es.aws.secret_access_key': 'bar'}, get_client, ES_PATH),
+        ({'es.aws.access_key_id': 'foo', 'es.aws.region': 'bar'}, get_client, ES_PATH),
+        ({'es.aws.secret_access_key': 'foo', 'es.aws.region': 'bar'}, get_client, ES_PATH),
     ])
-    def test_ignores_aws_auth_when_settings_missing(self, settings, patched_client, aws_settings):
+    def test_ignores_aws_auth_when_settings_missing(self, settings, patch_path, patched_elasticsearch, aws_settings, get_client):
         settings.update(aws_settings)
         get_client(settings)
 
-        _, kwargs = patched_client.call_args
+        _, kwargs = patched_elasticsearch.call_args
         assert 'auth' not in kwargs
 
     @pytest.fixture
     def settings(self):
         return {
             'es.host': 'search.svc',
+            'es.url': 'search.svc',
             'es.index': 'my-index',
         }
 
     @pytest.fixture
-    def patched_client(self, patch):
-        return patch('h.search.client.Client')
+    def patched_elasticsearch(self, patch, request):
+        return patch(request.getfixturevalue('patch_path'))
 
     @pytest.fixture
     def patched_aws_auth(self, patch):


### PR DESCRIPTION
Add in connection logic so that the app connects to elasticsearch6.2 cluster on startup. This is a partial fix for https://github.com/hypothesis/product-backlog/issues/648. Note this does not include indexing the cluster it is just the creation of the connection/client obj.