### PR TITLE
Make default_querybuilder() a private method

### DIFF
--- a/h/search/core.py
+++ b/h/search/core.py
@@ -41,8 +41,8 @@ class Search(object):
         self.separate_replies = separate_replies
         self.stats = stats
 
-        self.builder = default_querybuilder(request)
-        self.reply_builder = default_querybuilder(request)
+        self.builder = self._default_querybuilder(request)
+        self.reply_builder = self._default_querybuilder(request)
 
     def run(self, params):
         """
@@ -144,16 +144,16 @@ class Search(object):
             timer.stop()
             s.send()
 
-
-def default_querybuilder(request):
-    builder = query.Builder()
-    builder.append_filter(query.DeletedFilter())
-    builder.append_filter(query.AuthFilter(request))
-    builder.append_filter(query.UriFilter(request))
-    builder.append_filter(query.GroupFilter())
-    builder.append_filter(query.UserFilter())
-    builder.append_matcher(query.AnyMatcher())
-    builder.append_matcher(query.TagsMatcher())
-    for factory in request.registry.get(FILTERS_KEY, []):
-        builder.append_filter(factory(request))
-    return builder
+    @staticmethod
+    def _default_querybuilder(request):
+        builder = query.Builder()
+        builder.append_filter(query.DeletedFilter())
+        builder.append_filter(query.AuthFilter(request))
+        builder.append_filter(query.UriFilter(request))
+        builder.append_filter(query.GroupFilter())
+        builder.append_filter(query.UserFilter())
+        builder.append_matcher(query.AnyMatcher())
+        builder.append_matcher(query.TagsMatcher())
+        for factory in request.registry.get(FILTERS_KEY, []):
+            builder.append_filter(factory(request))
+        return builder

--- a/tests/h/search/core_test.py
+++ b/tests/h/search/core_test.py
@@ -268,7 +268,7 @@ class TestSearch(object):
 ])
 def test_default_querybuilder_includes_default_filters(filter_type, matchers, pyramid_request):
     from h.search import query
-    builder = core.default_querybuilder(pyramid_request)
+    builder = core.Search._default_querybuilder(pyramid_request)
     type_ = getattr(query, filter_type)
 
     assert matchers.instance_of(type_) in builder.filters
@@ -279,7 +279,7 @@ def test_default_querybuilder_includes_registered_filters(pyramid_request):
                                spec_set=[])
     pyramid_request.registry[core.FILTERS_KEY] = [filter_factory]
 
-    builder = core.default_querybuilder(pyramid_request)
+    builder = core.Search._default_querybuilder(pyramid_request)
 
     filter_factory.assert_called_once_with(pyramid_request)
     assert mock.sentinel.MY_FILTER in builder.filters
@@ -291,7 +291,7 @@ def test_default_querybuilder_includes_registered_filters(pyramid_request):
 ])
 def test_default_querybuilder_includes_default_matchers(matchers, matcher_type, pyramid_request):
     from h.search import query
-    builder = core.default_querybuilder(pyramid_request)
+    builder = core.Search._default_querybuilder(pyramid_request)
     type_ = getattr(query, matcher_type)
 
     assert matchers.instance_of(type_) in builder.matchers


### PR DESCRIPTION
default_querybuilder() is a private method of the Search class: it's
called only by methods of Search and never called from anywhere else.

Clarify this by renaming it to _default_querybuilder(). Also make it a
@staticmethod within the class itself, just to clarify that it belongs
to this class.

This requires updating some tests that're calling default_querybuilder()
directly. I think this just reveals an existing problem with the code
design and tests.