### PR TITLE
Remove obsolete comment in Celery config

### DIFF
--- a/h/celery.py
+++ b/h/celery.py
@@ -30,8 +30,6 @@ log = logging.getLogger(__name__)
 
 celery = Celery('h')
 celery.conf.update(
-    # Default to using database number 10 so we don't conflict with the session
-    # store.
     broker_url=os.environ.get('CELERY_BROKER_URL',
                               os.environ.get('BROKER_URL', 'amqp://guest:guest@localhost:5672//')),
     beat_schedule={


### PR DESCRIPTION
The comment about "using database number 10" referred to the default
value of `BROKER_URL` in an earlier version of the code (see d48cb9cb6176).