### PR TITLE
Add es.url pyramid config setting for es6.2 cluster

### DIFF
--- a/conf/app.ini
+++ b/conf/app.ini
@@ -10,10 +10,6 @@ pipeline:
 [app:h]
 use: call:h.app:create_app
 
-# Elasticsearch configuration
-#es.host: http://localhost:9200
-#es.index: hypothesis
-
 # SQLAlchemy configuration -- See SQLAlchemy documentation
 sqlalchemy.url: postgresql://postgres@localhost/postgres
 

--- a/conf/development-app.ini
+++ b/conf/development-app.ini
@@ -5,6 +5,7 @@ pipeline: h
 use: call:h.app:create_app
 
 es.host: http://localhost:9200
+es.url: http://localhost:9201
 
 pyramid.debug_all: True
 pyramid.reload_templates: True

--- a/conf/development-websocket.ini
+++ b/conf/development-websocket.ini
@@ -1,6 +1,9 @@
 [app:main]
 use: call:h.websocket:create_app
 
+# Elasticsearch configuration
+es.url: http://localhost:9201
+
 # Use gevent-compatible transport for the Sentry client
 raven.transport: gevent
 

--- a/h/config.py
+++ b/h/config.py
@@ -44,6 +44,7 @@ SETTINGS = [
     EnvSetting('es.client.retry_on_timeout', 'ELASTICSEARCH_CLIENT_RETRY_ON_TIMEOUT', type=asbool),
     EnvSetting('es.client.timeout', 'ELASTICSEARCH_CLIENT_TIMEOUT', type=float),
     EnvSetting('es.host', 'ELASTICSEARCH_HOST'),
+    EnvSetting('es.url', 'ELASTICSEARCH_URL'),
     EnvSetting('es.index', 'ELASTICSEARCH_INDEX'),
     EnvSetting('es.aws.access_key_id', 'ELASTICSEARCH_AWS_ACCESS_KEY_ID'),
     EnvSetting('es.aws.region', 'ELASTICSEARCH_AWS_REGION'),

--- a/h/search/__init__.py
+++ b/h/search/__init__.py
@@ -35,8 +35,7 @@ def includeme(config):
     if 'es.client_poolsize' in settings:
         kwargs['maxsize'] = settings['es.client_poolsize']
 
-    # TODO should pass `hosts` param once that setting (ELASTICSEARCH_URL) is in place
-    connect(**kwargs)
+    connect(hosts=settings['es.url'], **kwargs)
 
     # Connection to old (ES1.5) follows
     settings.setdefault('es.host', 'http://localhost:9200')

--- a/h/search/__init__.py
+++ b/h/search/__init__.py
@@ -35,7 +35,7 @@ def includeme(config):
     if 'es.client_poolsize' in settings:
         kwargs['maxsize'] = settings['es.client_poolsize']
 
-    connect(hosts=settings['es.url'], **kwargs)
+    connect(hosts=[settings['es.url']], **kwargs)
 
     # Connection to old (ES1.5) follows
     settings.setdefault('es.host', 'http://localhost:9200')

--- a/h/search/connection.py
+++ b/h/search/connection.py
@@ -1,16 +1,10 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-import os
-
 from elasticsearch_dsl import connections
 
-# TODO: Temporary hard-coding of ELASTICSEARCH_URL: this should come from settings
-ELASTICSEARCH_URL = os.environ.get("ELASTICSEARCH_URL", "http://localhost:9201")
 
-
-# TODO: Make `hosts` a required argument
-def connect(alias='default', hosts=[ELASTICSEARCH_URL], **kwargs):
+def connect(hosts, alias='default', **kwargs):
     """
     Establish a connection to Elasticsearch through elasticsearch_dsl
 

--- a/tests/h/search/connection_test.py
+++ b/tests/h/search/connection_test.py
@@ -36,20 +36,21 @@ class TestConnection(object):
         assert connections.get_connection('foobar')
 
     def test_connect_defaults_to_default_alias(self, connections_):
-        connect()
+        connect(['http://localhost:9200'])
 
         connections_.create_connection.assert_called_once_with('default',
                                                                hosts=mock.ANY,
                                                                verify_certs=True)
 
-    def test_connect_passes_kwargs_to_create_connection(self, connections_):
+    def test_connect_passes_hosts_and_kwargs_to_create_connection(self, connections_):
+        hosts = ['http://localhost:9200']
         kwargs = {
             'foo': 'bar'
         }
-        connect(**kwargs)
+        connect(hosts, **kwargs)
 
         connections_.create_connection.assert_called_once_with('default',
-                                                               hosts=mock.ANY,
+                                                               hosts=hosts,
                                                                verify_certs=True,
                                                                **kwargs)
 


### PR DESCRIPTION
Note this is a partial fix for https://github.com/hypothesis/product-backlog/issues/646 in that it does the following:
- [x] Configure settings['es.url'] to be the value of the env var ELASTICSEARCH_URL in production/qa.
- [x] Default the value os settings['es.url'] to be localhost:9201 in development envs.

----
(_Added 2018-05-31 by @robertknight_)

- [x] Use the `es.url` setting instead of reading the `ELASTICSEARCH_URL` env var in `h.search.connection`