### PR TITLE
Capitalise all matcher class names

### DIFF
--- a/tests/common/matchers.py
+++ b/tests/common/matchers.py
@@ -15,9 +15,9 @@ would have to do something like:
     assert foo.set_value.call_count == 1
     assert isinstance(foo.set_value.call_args[0][0], int)
 
-By using the `instance_of` matcher you can simply write:
+By using the `InstanceOf` matcher you can simply write:
 
-    foo.set_value.assert_called_once_with(matchers.instance_of(int))
+    foo.set_value.assert_called_once_with(matchers.InstanceOf(int))
 
 As a bonus, the second test will print substantially more useful debugging
 output if it fails, e.g.
@@ -42,7 +42,7 @@ class Matcher(object):
         return not self.__eq__(other)
 
 
-class any_callable(Matcher):  # noqa: N801
+class AnyCallable(Matcher):
     """An object __eq__ to any callable object."""
 
     def __eq__(self, other):
@@ -50,7 +50,7 @@ class any_callable(Matcher):  # noqa: N801
         return callable(other)
 
 
-class native_string(Matcher):  # noqa: N801
+class NativeString(Matcher):
     """
     Matches any native string with the given characters.
 
@@ -79,10 +79,10 @@ class native_string(Matcher):  # noqa: N801
         return '<native string matching "{string}">'.format(string=self.string)
 
     def lower(self):
-        return native_string(self.string.lower())
+        return NativeString(self.string.lower())
 
 
-class instance_of(Matcher):  # noqa: N801
+class InstanceOf(Matcher):
     """An object __eq__ to any object which is an instance of `type_`."""
 
     def __init__(self, type_):
@@ -95,7 +95,7 @@ class instance_of(Matcher):  # noqa: N801
         return '<instance of {!r}>'.format(self.type)
 
 
-class iterable_with(Matcher):  # noqa: N801
+class IterableWith(Matcher):
     """An object __eq__ to any iterable which yields `items`."""
 
     def __init__(self, items):
@@ -108,7 +108,7 @@ class iterable_with(Matcher):  # noqa: N801
         return '<iterable with {!r}>'.format(self.items)
 
 
-class mapping_containing(Matcher):  # noqa: N801
+class MappingContaining(Matcher):
     """An object __eq__ to any mapping with the passed `key`."""
 
     def __init__(self, key):
@@ -126,7 +126,7 @@ class mapping_containing(Matcher):  # noqa: N801
         return '<mapping containing {!r}>'.format(self.key)
 
 
-class redirect_302_to(Matcher):  # noqa: N801
+class Redirect302To(Matcher):
     """Matches any HTTPFound redirect to the given URL."""
 
     def __init__(self, location):
@@ -138,7 +138,7 @@ class redirect_302_to(Matcher):  # noqa: N801
         return other.location == self.location
 
 
-class redirect_303_to(Matcher):  # noqa: N801
+class Redirect303To(Matcher):
     """Matches any HTTPSeeOther redirect to the given URL."""
 
     def __init__(self, location):
@@ -150,7 +150,7 @@ class redirect_303_to(Matcher):  # noqa: N801
         return other.location == self.location
 
 
-class regex(Matcher):  # noqa: N801
+class Regex(Matcher):
     """Matches any string matching the passed regex."""
 
     def __init__(self, patt):
@@ -163,7 +163,7 @@ class regex(Matcher):  # noqa: N801
         return '<string matching re {!r}>'.format(self.patt.pattern)
 
 
-class unordered_list(Matcher):  # noqa: N801
+class UnorderedList(Matcher):
     """
     Matches a list with the same items in any order.
 

--- a/tests/h/activity/query_test.py
+++ b/tests/h/activity/query_test.py
@@ -401,7 +401,7 @@ class TestExecute(object):
         execute(pyramid_request, MultiDict(), self.PAGE_SIZE)
 
         _fetch_groups.assert_called_once_with(
-            pyramid_request.db, matchers.unordered_list(group_pubids))
+            pyramid_request.db, matchers.UnorderedList(group_pubids))
 
     def test_it_returns_each_annotation_presented(self,
                                                   annotations,

--- a/tests/h/emails/test_test.py
+++ b/tests/h/emails/test_test.py
@@ -20,9 +20,9 @@ class TestGenerate(object):
         generate(pyramid_request, 'meerkat@example.com')
 
         expected_context = {
-            'time': matchers.instance_of(string_types),
-            'hostname': matchers.instance_of(string_types),
-            'python_version': matchers.instance_of(string_types),
+            'time': matchers.InstanceOf(string_types),
+            'hostname': matchers.InstanceOf(string_types),
+            'python_version': matchers.InstanceOf(string_types),
             'version': __version__,
         }
         html_renderer.assert_(**expected_context)

--- a/tests/h/form_test.py
+++ b/tests/h/form_test.py
@@ -89,7 +89,7 @@ class TestCreateForm(object):
 
         Form.assert_called_once_with(mock.sentinel.schema,
                                      foo='bar',
-                                     renderer=matchers.instance_of(form.Jinja2Renderer))
+                                     renderer=matchers.InstanceOf(form.Jinja2Renderer))
 
     def test_adds_feature_client_to_system_context(self,
                                                    Form,
@@ -173,7 +173,7 @@ class TestHandleFormSubmission(object):
                                     mock_callable(),
                                     mock.sentinel.on_failure)
 
-        post_items = matchers.iterable_with(list(pyramid_request.POST.items()))
+        post_items = matchers.IterableWith(list(pyramid_request.POST.items()))
         form_.validate.assert_called_once_with(post_items)
 
     def test_if_validation_fails_it_calls_on_failure(self,
@@ -262,7 +262,7 @@ class TestHandleFormSubmission(object):
 
         to_xhr_response.assert_called_once_with(
             pyramid_request,
-            matchers.redirect_302_to(pyramid_request.url),
+            matchers.Redirect302To(pyramid_request.url),
             form_)
 
     def test_if_validation_succeeds_it_passes_on_success_result_to_to_xhr_response(

--- a/tests/h/models/group_scope_test.py
+++ b/tests/h/models/group_scope_test.py
@@ -44,7 +44,7 @@ class TestGroupScope(object):
             factories.GroupScope(group=group),
         ]
 
-        assert group.scopes == matchers.unordered_list(scopes)
+        assert group.scopes == matchers.UnorderedList(scopes)
 
     def test_deleting_a_group_deletes_its_groupscopes(self, db_session,
                                                       factories):

--- a/tests/h/realtime_test.py
+++ b/tests/h/realtime_test.py
@@ -65,7 +65,7 @@ class TestConsumer(object):
         consumer.handle_message({}, message)
 
         statsd_client.timing.assert_called_once_with('streamer.msg.queueing',
-                                                     matchers.instance_of(int))
+                                                     matchers.InstanceOf(int))
 
     def test_handle_message_doesnt_explode_if_timestamp_missing(self, handler, statsd_client):
         consumer = realtime.Consumer(mock.sentinel.connection,
@@ -107,7 +107,7 @@ class TestPublisher(object):
         publisher = realtime.Publisher(pyramid_request)
         publisher.publish_annotation(payload)
 
-        expected_headers = matchers.mapping_containing('timestamp')
+        expected_headers = matchers.MappingContaining('timestamp')
         producer.publish.assert_called_once_with(payload,
                                                  exchange=exchange,
                                                  declare=[exchange],
@@ -122,7 +122,7 @@ class TestPublisher(object):
         publisher = realtime.Publisher(pyramid_request)
         publisher.publish_user(payload)
 
-        expected_headers = matchers.mapping_containing('timestamp')
+        expected_headers = matchers.MappingContaining('timestamp')
         producer.publish.assert_called_once_with(payload,
                                                  exchange=exchange,
                                                  declare=[exchange],

--- a/tests/h/search/config_test.py
+++ b/tests/h/search/config_test.py
@@ -114,13 +114,13 @@ class TestConfigureIndex(object):
         configure_index(client)
 
         client.conn.indices.create.assert_called_once_with(
-            matchers.regex('foo-[0-9a-f]{8}'),
+            matchers.Regex('foo-[0-9a-f]{8}'),
             body=mock.ANY)
 
     def test_returns_index_name(self, client, matchers):
         name = configure_index(client)
 
-        assert name == matchers.regex('foo-[0-9a-f]{8}')
+        assert name == matchers.Regex('foo-[0-9a-f]{8}')
 
     def test_sets_correct_mappings_and_settings(self, client):
         configure_index(client)

--- a/tests/h/search/old_core_test.py
+++ b/tests/h/search/old_core_test.py
@@ -271,7 +271,7 @@ def test_default_querybuilder_includes_default_filters(filter_type, matchers, py
     builder = core.Search._default_querybuilder(pyramid_request)
     type_ = getattr(query, filter_type)
 
-    assert matchers.instance_of(type_) in builder.filters
+    assert matchers.InstanceOf(type_) in builder.filters
 
 
 def test_default_querybuilder_includes_registered_filters(pyramid_request):
@@ -294,7 +294,7 @@ def test_default_querybuilder_includes_default_matchers(matchers, matcher_type, 
     builder = core.Search._default_querybuilder(pyramid_request)
     type_ = getattr(query, matcher_type)
 
-    assert matchers.instance_of(type_) in builder.matchers
+    assert matchers.InstanceOf(type_) in builder.matchers
 
 
 def dummy_search_results(start=1, count=0, name='annotation'):

--- a/tests/h/search/old_index_test.py
+++ b/tests/h/search/old_index_test.py
@@ -106,7 +106,7 @@ class TestBatchIndexer(object):
         indexer.index()
 
         streaming_bulk.assert_called_once_with(
-            indexer.es_client.conn, matchers.iterable_with(matchers.unordered_list([ann_1, ann_2])),
+            indexer.es_client.conn, matchers.IterableWith(matchers.UnorderedList([ann_1, ann_2])),
             chunk_size=mock.ANY, raise_on_error=False, expand_action_callback=mock.ANY)
 
     def test_index_skips_deleted_annotations_when_indexing_all(self, db_session, indexer, matchers, streaming_bulk, factories):
@@ -118,7 +118,7 @@ class TestBatchIndexer(object):
         indexer.index()
 
         streaming_bulk.assert_called_once_with(
-            indexer.es_client.conn, matchers.iterable_with(matchers.unordered_list([ann_1, ann_2])),
+            indexer.es_client.conn, matchers.IterableWith(matchers.UnorderedList([ann_1, ann_2])),
             chunk_size=mock.ANY, raise_on_error=False, expand_action_callback=mock.ANY)
 
     def test_index_indexes_filtered_annotations_to_es(self, db_session, indexer, matchers, streaming_bulk, factories):
@@ -127,7 +127,7 @@ class TestBatchIndexer(object):
         indexer.index([ann_2.id])
 
         streaming_bulk.assert_called_once_with(
-            indexer.es_client.conn, matchers.iterable_with([ann_2]),
+            indexer.es_client.conn, matchers.IterableWith([ann_2]),
             chunk_size=mock.ANY, raise_on_error=False, expand_action_callback=mock.ANY)
 
     def test_index_skips_deleted_annotations_when_indexing_filtered(self, db_session, indexer, matchers, streaming_bulk, factories):
@@ -140,7 +140,7 @@ class TestBatchIndexer(object):
         indexer.index([ann_2.id])
 
         streaming_bulk.assert_called_once_with(
-            indexer.es_client.conn, matchers.iterable_with([ann_2]),
+            indexer.es_client.conn, matchers.IterableWith([ann_2]),
             chunk_size=mock.ANY, raise_on_error=False, expand_action_callback=mock.ANY)
 
     def test_index_correctly_presents_bulk_actions(self,

--- a/tests/h/services/annotation_json_presentation_test.py
+++ b/tests/h/services/annotation_json_presentation_test.py
@@ -24,7 +24,7 @@ class TestAnnotationJSONPresentationService(object):
     def test_initializes_hidden_formatter(self, matchers, services, formatters):
         self.svc(services)
         formatters.AnnotationHiddenFormatter.assert_called_once_with(services['annotation_moderation'],
-                                                                     matchers.any_callable(),
+                                                                     matchers.AnyCallable(),
                                                                      mock.sentinel.user)
 
     def test_it_configures_hidden_formatter(self, services, formatters):

--- a/tests/h/services/group_test.py
+++ b/tests/h/services/group_test.py
@@ -160,7 +160,7 @@ class TestGroupServiceCreateOpenGroup(object):
 
         group = svc.create_open_group(name='test_group', userid=creator.userid, origins=origins)
 
-        assert group.scopes == matchers.unordered_list([
+        assert group.scopes == matchers.UnorderedList([
             GroupScopeWithOrigin(h) for h in origins])
 
     def test_it_always_creates_new_scopes(self, db_session, factories, svc, creator, matchers):
@@ -245,7 +245,7 @@ class TestGroupServiceCreateRestrictedGroup(object):
 
         group = svc.create_restricted_group(name='test_group', userid=creator.userid, origins=origins)
 
-        assert group.scopes == matchers.unordered_list([
+        assert group.scopes == matchers.UnorderedList([
             GroupScopeWithOrigin(h) for h in origins])
 
     def test_it_with_mismatched_authorities_raises_value_error(

--- a/tests/h/streamer/websocket_test.py
+++ b/tests/h/streamer/websocket_test.py
@@ -264,7 +264,7 @@ class TestHandleClientIDMessage(object):
         with mock.patch.object(websocket.Message, 'reply') as mock_reply:
             websocket.handle_client_id_message(message)
 
-        mock_reply.assert_called_once_with(matchers.mapping_containing('error'),
+        mock_reply.assert_called_once_with(matchers.MappingContaining('error'),
                                            ok=False)
 
     @pytest.fixture
@@ -347,7 +347,7 @@ class TestHandleFilterMessage(object):
         with mock.patch.object(websocket.Message, 'reply') as mock_reply:
             websocket.handle_filter_message(message)
 
-        mock_reply.assert_called_once_with(matchers.mapping_containing('error'),
+        mock_reply.assert_called_once_with(matchers.MappingContaining('error'),
                                            ok=False)
 
     @mock.patch('h.streamer.websocket.jsonschema.validate')
@@ -361,7 +361,7 @@ class TestHandleFilterMessage(object):
         with mock.patch.object(websocket.Message, 'reply') as mock_reply:
             websocket.handle_filter_message(message)
 
-        mock_reply.assert_called_once_with(matchers.mapping_containing('error'),
+        mock_reply.assert_called_once_with(matchers.MappingContaining('error'),
                                            ok=False)
 
     @pytest.fixture
@@ -417,5 +417,5 @@ class TestUnknownMessage(object):
         with mock.patch.object(websocket.Message, 'reply') as mock_reply:
             websocket.handle_unknown_message(message)
 
-        mock_reply.assert_called_once_with(matchers.mapping_containing('error'),
+        mock_reply.assert_called_once_with(matchers.MappingContaining('error'),
                                            ok=False)

--- a/tests/h/tweens_test.py
+++ b/tests/h/tweens_test.py
@@ -103,7 +103,7 @@ class TestEncodeHeadersTween(object):
 
         response = encode_headers_tween(pyramid_request)
 
-        expected_header = matchers.native_string("Access-Control-Allow-Origin")
+        expected_header = matchers.NativeString("Access-Control-Allow-Origin")
         assert response.headers.getone(expected_header) == str("*")
 
     def test_it_converts_unicode_header_values_to_native_strings(self,
@@ -114,7 +114,7 @@ class TestEncodeHeadersTween(object):
 
         response = encode_headers_tween(pyramid_request)
 
-        expected_value = matchers.native_string("*")
+        expected_value = matchers.NativeString("*")
         assert response.headers.getone(str("Access-Control-Allow-Origin")) == expected_value
 
     def test_multiple_values_for_a_single_header(self,
@@ -127,10 +127,10 @@ class TestEncodeHeadersTween(object):
 
         response = encode_headers_tween(pyramid_request)
 
-        assert response.headers.getall(matchers.native_string("foo")) == matchers.unordered_list([
-            matchers.native_string("bar"),
-            matchers.native_string("gar"),
-            matchers.native_string("zar"),
+        assert response.headers.getall(matchers.NativeString("foo")) == matchers.UnorderedList([
+            matchers.NativeString("bar"),
+            matchers.NativeString("gar"),
+            matchers.NativeString("zar"),
         ])
 
     @pytest.fixture

--- a/tests/h/util/document_claims_test.py
+++ b/tests/h/util/document_claims_test.py
@@ -798,7 +798,7 @@ class TestDocumentURIsFromData(object):
         document_uris = document_claims.document_uris_from_data(
             {}, 'http://example.com/claimant')
 
-        assert document_uris == matchers.unordered_list([
+        assert document_uris == matchers.UnorderedList([
             {'uri': 'from_link_1'},
             {'uri': 'from_link_2'},
             {'uri': 'from_link_3'},

--- a/tests/h/views/admin_groups_test.py
+++ b/tests/h/views/admin_groups_test.py
@@ -99,7 +99,7 @@ class TestGroupCreateController(object):
         handle_form_submission.assert_called_once_with(
             ctrl.request,
             ctrl.form,
-            matchers.any_callable(),
+            matchers.AnyCallable(),
             ctrl._template_context
         )
 
@@ -121,7 +121,7 @@ class TestGroupCreateController(object):
         response = ctrl.post()
 
         expected_location = pyramid_request.route_url('admin_groups')
-        assert response == matchers.redirect_302_to(expected_location)
+        assert response == matchers.Redirect302To(expected_location)
 
     @pytest.mark.parametrize('type_', [
         'open',

--- a/tests/h/views/admin_oauthclients_test.py
+++ b/tests/h/views/admin_oauthclients_test.py
@@ -5,8 +5,6 @@ from __future__ import unicode_literals
 from mock import create_autospec, Mock
 import pytest
 
-from tests.common.matchers import Redirect302To
-
 from h.models.auth_client import AuthClient, GrantType, ResponseType
 from h.views.admin_oauthclients import index, AuthClientCreateController, AuthClientEditController
 
@@ -115,7 +113,7 @@ class TestAuthClientCreateController(object):
         client = pyramid_request.db.query(AuthClient).one()
         assert client.secret is None
 
-    def test_post_redirects_to_edit_view(self, form_post, pyramid_request):
+    def test_post_redirects_to_edit_view(self, form_post, matchers, pyramid_request):
         pyramid_request.POST = form_post
         ctrl = AuthClientCreateController(pyramid_request)
 
@@ -124,7 +122,7 @@ class TestAuthClientCreateController(object):
         client = pyramid_request.db.query(AuthClient).one()
         expected_location = pyramid_request.route_url('admin_oauthclients_edit',
                                                       id=client.id)
-        assert response == Redirect302To(expected_location)
+        assert response == matchers.Redirect302To(expected_location)
 
 
 @pytest.mark.usefixtures('routes')
@@ -177,7 +175,7 @@ class TestAuthClientEditController(object):
         assert authclient.secret == old_secret
         assert ctx['form'] == self._expected_form(authclient)
 
-    def test_delete_removes_authclient(self, authclient, pyramid_request):
+    def test_delete_removes_authclient(self, authclient, matchers, pyramid_request):
         pyramid_request.db.delete = create_autospec(pyramid_request.db.delete, return_value=None)
         ctrl = AuthClientEditController(authclient, pyramid_request)
 
@@ -185,14 +183,14 @@ class TestAuthClientEditController(object):
 
         pyramid_request.db.delete.assert_called_with(authclient)
 
-    def test_delete_redirects_to_index(self, authclient, pyramid_request):
+    def test_delete_redirects_to_index(self, authclient, matchers, pyramid_request):
         pyramid_request.db.delete = create_autospec(pyramid_request.db.delete, return_value=None)
         ctrl = AuthClientEditController(authclient, pyramid_request)
 
         response = ctrl.delete()
 
         expected_location = pyramid_request.route_url('admin_oauthclients')
-        assert response == Redirect302To(expected_location)
+        assert response == matchers.Redirect302To(expected_location)
 
     def _expected_form(self, authclient):
         return {'authority': authclient.authority,

--- a/tests/h/views/admin_oauthclients_test.py
+++ b/tests/h/views/admin_oauthclients_test.py
@@ -5,7 +5,7 @@ from __future__ import unicode_literals
 from mock import create_autospec, Mock
 import pytest
 
-from tests.common.matchers import redirect_302_to
+from tests.common.matchers import Redirect302To
 
 from h.models.auth_client import AuthClient, GrantType, ResponseType
 from h.views.admin_oauthclients import index, AuthClientCreateController, AuthClientEditController
@@ -124,7 +124,7 @@ class TestAuthClientCreateController(object):
         client = pyramid_request.db.query(AuthClient).one()
         expected_location = pyramid_request.route_url('admin_oauthclients_edit',
                                                       id=client.id)
-        assert response == redirect_302_to(expected_location)
+        assert response == Redirect302To(expected_location)
 
 
 @pytest.mark.usefixtures('routes')
@@ -192,7 +192,7 @@ class TestAuthClientEditController(object):
         response = ctrl.delete()
 
         expected_location = pyramid_request.route_url('admin_oauthclients')
-        assert response == redirect_302_to(expected_location)
+        assert response == Redirect302To(expected_location)
 
     def _expected_form(self, authclient):
         return {'authority': authclient.authority,

--- a/tests/h/views/admin_organizations_test.py
+++ b/tests/h/views/admin_organizations_test.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 from mock import Mock
 import pytest
 
-from tests.common.matchers import redirect_302_to, regex
+from tests.common.matchers import Redirect302To, Regex
 
 from h.models import Organization
 from h.views.admin_organizations import index, OrganizationCreateController, OrganizationEditController
@@ -77,7 +77,7 @@ class TestOrganizationCreateController(object):
         response = ctrl.post()
 
         list_url = pyramid_request.route_url('admin_organizations')
-        assert response == redirect_302_to(list_url)
+        assert response == Redirect302To(list_url)
 
 
 @pytest.mark.usefixtures('routes')
@@ -133,7 +133,7 @@ class TestOrganizationEditController(object):
         response = ctrl.delete()
 
         list_url = pyramid_request.route_path('admin_organizations')
-        assert response == redirect_302_to(list_url)
+        assert response == Redirect302To(list_url)
 
     def test_delete_fails_if_org_has_groups(self, factories, org, pyramid_request):
         factories.Group(name='Test', organization=org)
@@ -144,7 +144,7 @@ class TestOrganizationEditController(object):
         assert org not in pyramid_request.db.deleted
         assert pyramid_request.response.status_int == 400
         pyramid_request.session.flash.assert_called_with(
-            regex('.*Cannot delete.*1 groups'), 'error')
+            Regex('.*Cannot delete.*1 groups'), 'error')
         assert ctx['form'] == self._expected_form(org)
 
     def _expected_form(self, org):

--- a/tests/h/views/groups_test.py
+++ b/tests/h/views/groups_test.py
@@ -31,8 +31,8 @@ class TestGroupCreateController(object):
         handle_form_submission.assert_called_once_with(
             controller.request,
             controller.form,
-            matchers.any_callable(),
-            matchers.any_callable(),
+            matchers.AnyCallable(),
+            matchers.AnyCallable(),
         )
 
     def test_post_returns_handle_form_submission(self,
@@ -69,7 +69,7 @@ class TestGroupCreateController(object):
             return on_success({'name': 'my_new_group'})
         handle_form_submission.side_effect = return_on_success
 
-        assert controller.post() == matchers.redirect_303_to(
+        assert controller.post() == matchers.Redirect303To(
             '/g/abc123/fake-group')
 
     def test_post_does_not_create_group_if_form_invalid(self,


### PR DESCRIPTION
Class names should be written in CamelCase in Python, not in snake_case. For an unknown reason all of our matcher classes have always been named in snake_case, necessitating a `# noqa: N801` comment on every class to prevent flake8 from complaining about the style violation.

Just use the correct style for class names, and remove the `noqa`s.

Also fixed a couple of places where the matchers module was being imported. Be consistent and always use them via the matchers fixture.