### PR TITLE
Add Es-integrated tests for separate_replies

### DIFF
--- a/tests/h/search/conftest.py
+++ b/tests/h/search/conftest.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import pytest
+
+import h.search.index
+
+
+@pytest.fixture
+def index(es_client, pyramid_request):
+    def _index(*annotations):
+        """Index the given annotation(s) into Elasticsearch."""
+        for annotation in annotations:
+            h.search.index.index(es_client, annotation, pyramid_request)
+        es_client.conn.indices.refresh(index=es_client.index)
+    return _index

--- a/tests/h/search/core_test.py
+++ b/tests/h/search/core_test.py
@@ -213,14 +213,19 @@ class TestWithSeparateReplies(object):
         annotation_ids) that can be included in reply_ids.
         """
         annotation = Annotation(shared=True)
-        first_reply = Annotation(references=[annotation.id], shared=True)
-        for _ in range(200):
+        oldest_reply = Annotation(references=[annotation.id], shared=True)
+
+        # Create three more replies so that the oldest reply will be pushed out
+        # of reply_ids. (We only need 3, not 200, because we're going to use
+        # the _replies_limit test seam to limit it to 3 replies instead of 200.
+        # This is just to make the test faster.
+        for _ in range(3):
             Annotation(references=[annotation.id], shared=True)
 
-        result = search.Search(pyramid_request, separate_replies=True).run({})
+        result = search.Search(pyramid_request, separate_replies=True, _replies_limit=3).run({})
 
-        assert len(result.reply_ids) == 200
-        assert first_reply.id not in result.reply_ids
+        assert len(result.reply_ids) == 3
+        assert oldest_reply.id not in result.reply_ids
 
 
 @pytest.fixture

--- a/tests/h/search/core_test.py
+++ b/tests/h/search/core_test.py
@@ -1,0 +1,243 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import datetime
+
+import pytest
+
+from h import search
+
+
+class TestWithoutSeparateReplies(object):
+    """Tests for what happens when no separate_replies argument is given."""
+
+    def test_it_returns_replies_in_annotations_ids(self, matchers, pyramid_request, Annotation):
+        """Without separate_replies it returns replies in annotation_ids.
+
+        Test that if no separate_replies argument is given then it returns the
+        ids of replies mixed in with the top-level annotations in
+        annotation_ids.
+        """
+        annotation = Annotation(shared=True)
+        reply_1 = Annotation(shared=True, references=[annotation.id])
+        reply_2 = Annotation(shared=True, references=[annotation.id])
+
+        result = search.Search(pyramid_request).run({})
+
+        assert result.annotation_ids == matchers.UnorderedList([annotation.id, reply_1.id,
+                                                                reply_2.id])
+
+    def test_replies_that_dont_match_the_search_arent_included(self, factories, pyramid_request,
+                                                               Annotation):
+        """Replies that don't match the search query aren't included.
+
+        Not even if the top-level annotations that they're replies to _are_
+        included.
+        """
+        user = factories.User()
+        reply_user = factories.User()
+        annotation = Annotation(userid=user.userid, shared=True)
+        reply = Annotation(userid=reply_user.userid, references=[annotation.id], shared=True)
+
+        result = search.Search(pyramid_request).run(
+            # Search for annotations from ``user``, so that ``reply_user``'s
+            # reply doesn't match.
+            params={"user": user.userid},
+        )
+
+        assert reply.id not in result.annotation_ids
+
+    def test_replies_from_different_pages_arent_included(self, pyramid_request, Annotation):
+        """Replies may not be on the same page of results as their annotations."""
+        # First create an annotation and a reply.
+        annotation = Annotation(shared=True)
+        reply = Annotation(references=[annotation.id], shared=True)
+
+        # Now create 19 more annotations so that the original annotation is
+        # pushed onto the second page of the search results, but the reply is
+        # still on the first page.
+        for _ in range(19):
+            Annotation(shared=True)
+
+        # The reply is one the first page of search results, but the original annotation isn't.
+        result = search.Search(pyramid_request).run(params={"offset": 0, "limit": 20})
+        assert reply.id in result.annotation_ids
+        assert annotation.id not in result.annotation_ids
+
+        # The original annotation is on the second page of search results, but the reply isn't.
+        result = search.Search(pyramid_request).run(params={"offset": 20})
+        assert reply.id not in result.annotation_ids
+        assert annotation.id in result.annotation_ids
+
+    def test_replies_can_come_before_annotations(self, pyramid_request, Annotation):
+        """A reply may appear before its annotation in the search results.
+
+        Things are returned in updated order so normally a reply would appear
+        before the annotation that it is a reply to in the search results.
+        """
+        annotation = Annotation(shared=True)
+        reply = Annotation(references=[annotation.id], shared=True)
+
+        result = search.Search(pyramid_request).run({})
+
+        # The reply appears _before_ the annotation in the search results.
+        assert result.annotation_ids == [reply.id, annotation.id]
+
+    def test_replies_can_come_after_annotations(self, index, pyramid_request, Annotation):
+        """A reply may appear after its annotation in the search results.
+
+        Things are returned in updated order so if the original author has
+        updated the top-level annotation since the reply was created, then the
+        annotation would come before the reply in the search results.
+        """
+        annotation = Annotation(shared=True)
+        reply = Annotation(references=[annotation.id], shared=True)
+
+        # Simulate updating the original annotation.
+        annotation.updated = datetime.datetime.now()
+        index(annotation)
+
+        result = search.Search(pyramid_request).run({})
+
+        # The reply appears _after_ the annotation in the search results.
+        assert result.annotation_ids == [annotation.id, reply.id]
+
+    def test_it_returns_an_empty_replies_list(self, pyramid_request, Annotation):
+        """Test that without separate_replies it returns an empty reply_ids.
+
+        If no separate_replies argument is given then it still returns a
+        reply_ids list but the list is always empty.
+        """
+        annotation = Annotation(shared=True)
+        Annotation(references=[annotation.id], shared=True)
+        Annotation(references=[annotation.id], shared=True)
+
+        result = search.Search(pyramid_request).run({})
+
+        assert result.reply_ids == []
+
+
+class TestWithSeparateReplies(object):
+    """Tests for what happens when separate_replies=True is given."""
+
+    def test_it_returns_replies_separately_from_annotations(self, matchers, pyramid_request,
+                                                            Annotation):
+        """If separate_replies=True replies and annotations are returned separately."""
+        annotation = Annotation(shared=True)
+        reply_1 = Annotation(references=[annotation.id], shared=True)
+        reply_2 = Annotation(references=[annotation.id], shared=True)
+
+        result = search.Search(pyramid_request, separate_replies=True).run({})
+
+        assert result.annotation_ids == [annotation.id]
+        assert result.reply_ids == matchers.UnorderedList([reply_1.id, reply_2.id])
+
+    def test_replies_are_ordered_most_recently_updated_first(self, Annotation, index,
+                                                             pyramid_request):
+        annotation = Annotation(shared=True)
+        reply_1 = Annotation(references=[annotation.id], shared=True)
+        reply_2 = Annotation(references=[annotation.id], shared=True)
+        reply_3 = Annotation(references=[annotation.id], shared=True)
+
+        # Simulate updating one of the replies.
+        reply_1.updated = datetime.datetime.now()
+        index(reply_1)
+
+        result = search.Search(pyramid_request, separate_replies=True).run({})
+
+        assert result.reply_ids == [reply_1.id, reply_3.id, reply_2.id]
+
+    def test_replies_ignore_the_sort_param(self, Annotation, pyramid_request):
+        annotation = Annotation(shared=True)
+        reply_1 = Annotation(id="3", references=[annotation.id], shared=True)
+        reply_2 = Annotation(id="1", references=[annotation.id], shared=True)
+        reply_3 = Annotation(id="2", references=[annotation.id], shared=True)
+
+        result = search.Search(pyramid_request, separate_replies=True).run({
+            "sort": "id", "order": "asc",
+        })
+
+        assert result.reply_ids == [reply_3.id, reply_2.id, reply_1.id]
+
+    def test_separate_replies_that_dont_match_the_search_are_still_included(self, factories,
+                                                                            pyramid_request,
+                                                                            Annotation):
+        """All replies to the matching annotations are included.
+
+        Even if the replies don't match the search query. As long as the
+        top-level annotation matches the search query, its replies will be
+        included in reply_ids.
+        """
+        user = factories.User()
+        reply_user = factories.User()
+        annotation = Annotation(userid=user.userid, shared=True)
+        reply = Annotation(userid=reply_user.userid, references=[annotation.id], shared=True)
+
+        result = search.Search(pyramid_request, separate_replies=True).run(
+            # The reply would not match this search query because it's from
+            # ``reply_user`` not ``user``.
+            params={"user": user.userid},
+        )
+
+        assert result.reply_ids == [reply.id]
+
+    def test_replies_from_different_pages_are_included(self, index, pyramid_request, Annotation):
+        """Replies that would not be on the same page are included."""
+        # First create an annotation and a reply.
+        annotation = Annotation(shared=True)
+        reply = Annotation(references=[annotation.id], shared=True)
+
+        # Update the annotation so that it would appear before the reply in the
+        # search results (if no separate_replies was given).
+        annotation.updated = datetime.datetime.now()
+        index(annotation)
+
+        # Now create 19 more annotations. Without separate_replies the
+        # annotation would be the 20th item in the search results (last item on
+        # the first page) and the reply would be pushed onto the second page.
+        for _ in range(19):
+            Annotation(shared=True)
+
+        result = search.Search(pyramid_request, separate_replies=True).run(params={"limit": 20})
+
+        # Even though the reply would have been on the second page of the
+        # search results, it is still included in reply_ids if
+        # separate_replies=True.
+        assert result.reply_ids == [reply.id]
+
+    def test_only_200_replies_are_included(self, pyramid_request, Annotation):
+        """No more than 200 replies can be included in reply_ids.
+
+        200 is the total maximum number of replies (to all annotations in
+        annotation_ids) that can be included in reply_ids.
+        """
+        annotation = Annotation(shared=True)
+        first_reply = Annotation(references=[annotation.id], shared=True)
+        for _ in range(200):
+            Annotation(references=[annotation.id], shared=True)
+
+        result = search.Search(pyramid_request, separate_replies=True).run({})
+
+        assert len(result.reply_ids) == 200
+        assert first_reply.id not in result.reply_ids
+
+
+@pytest.fixture
+def Annotation(factories, index):
+    """Create and index an annotation.
+
+    Looks like factories.Annotation() but automatically uses the build()
+    strategy and automatically indexes the annotation into the test
+    Elasticsearch index.
+    """
+    def _Annotation(**kwargs):
+        annotation = factories.Annotation.build(**kwargs)
+        index(annotation)
+        return annotation
+    return _Annotation
+
+
+@pytest.fixture
+def pyramid_request(es_client, pyramid_request):
+    pyramid_request.es = es_client
+    return pyramid_request

--- a/tests/h/search/core_test.py
+++ b/tests/h/search/core_test.py
@@ -215,7 +215,7 @@ class TestSearchWithSeparateReplies(object):
         # Create three more replies so that the oldest reply will be pushed out
         # of reply_ids. (We only need 3, not 200, because we're going to use
         # the _replies_limit test seam to limit it to 3 replies instead of 200.
-        # This is just to make the test faster.
+        # This is just to make the test faster.)
         for _ in range(3):
             Annotation(references=[annotation.id], shared=True)
 

--- a/tests/h/search/core_test.py
+++ b/tests/h/search/core_test.py
@@ -182,16 +182,13 @@ class TestSearchWithSeparateReplies(object):
 
         assert result.reply_ids == [reply.id]
 
-    def test_replies_from_different_pages_are_included(self, index, pyramid_request, Annotation):
+    def test_replies_from_different_pages_are_included(self, pyramid_request, Annotation):
         """Replies that would not be on the same page are included."""
         # First create an annotation and a reply.
-        annotation = Annotation(shared=True)
-        reply = Annotation(references=[annotation.id], shared=True)
-
-        # Update the annotation so that it would appear before the reply in the
-        # search results (if no separate_replies was given).
-        annotation.updated = datetime.datetime.now()
-        index(annotation)
+        now = datetime.datetime.now()
+        five_mins = datetime.timedelta(minutes=5)
+        annotation = Annotation(updated=now + five_mins, shared=True)
+        reply = Annotation(updated=now, references=[annotation.id], shared=True)
 
         # Now create 19 more annotations. Without separate_replies the
         # annotation would be the 20th item in the search results (last item on

--- a/tests/h/search/core_test.py
+++ b/tests/h/search/core_test.py
@@ -59,7 +59,7 @@ class TestWithoutSeparateReplies(object):
         for _ in range(19):
             Annotation(shared=True)
 
-        # The reply is one the first page of search results, but the original annotation isn't.
+        # The reply is on the first page of search results, but the original annotation isn't.
         result = search.Search(pyramid_request).run(params={"offset": 0, "limit": 20})
         assert reply.id in result.annotation_ids
         assert annotation.id not in result.annotation_ids

--- a/tests/h/search/core_test.py
+++ b/tests/h/search/core_test.py
@@ -8,8 +8,8 @@ import pytest
 from h import search
 
 
-class TestWithoutSeparateReplies(object):
-    """Tests for what happens when no separate_replies argument is given."""
+class TestSearch(object):
+    """Unit tests for search.Search when no separate_replies argument is given."""
 
     def test_it_returns_replies_in_annotations_ids(self, matchers, pyramid_request, Annotation):
         """Without separate_replies it returns replies in annotation_ids.
@@ -117,8 +117,8 @@ class TestWithoutSeparateReplies(object):
         assert result.reply_ids == []
 
 
-class TestWithSeparateReplies(object):
-    """Tests for what happens when separate_replies=True is given."""
+class TestSearchWithSeparateReplies(object):
+    """Unit tests for search.Search when separate_replies=True is given."""
 
     def test_it_returns_replies_separately_from_annotations(self, matchers, pyramid_request,
                                                             Annotation):

--- a/tests/h/search/index_test.py
+++ b/tests/h/search/index_test.py
@@ -6,7 +6,6 @@ import datetime
 import elasticsearch1_dsl
 import pytest
 
-import h.search.index
 from tests.common.matchers import Matcher
 
 
@@ -119,15 +118,6 @@ class TestIndex(object):
                 index=es_client.index, doc_type="annotation",
                 id=annotation_id)["_source"]
         return _get
-
-    @pytest.fixture
-    def index(self, es_client, pyramid_request):
-        def _index(*annotations):
-            """Index the given annotation(s) into Elasticsearch."""
-            for annotation in annotations:
-                h.search.index.index(es_client, annotation, pyramid_request)
-            es_client.conn.indices.refresh(index=es_client.index)
-        return _index
 
     @pytest.fixture
     def search(self, es_client):


### PR DESCRIPTION
Add the first Elasticsearch-integrated tests for the search querying functionality.

These test elements of the search querying functionality related to the separate_replies argument: how search behaves with and without this argument.

I'm not sure that everything to do with separate_replies is covered by these tests yet. For example deleted replies are excluded from reply_ids, and this isn't tested yet. There are several more things like
this still to test.