### PR TITLE
Auto-generate test annotation ids in factories.Annotation.build() and factories.Annotation.stub()

### DIFF
--- a/tests/common/factories/annotation.py
+++ b/tests/common/factories/annotation.py
@@ -3,6 +3,7 @@
 from __future__ import unicode_literals
 
 import random
+import uuid
 
 import factory
 from sqlalchemy import orm
@@ -115,3 +116,18 @@ class Annotation(ModelFactory):
             created=self.created,
             updated=self.updated,
         )
+
+    @factory.post_generation
+    def make_id(self, create, extracted, **kwargs):
+        """Add a randomly ID if the annotation doesn't have one yet."""
+        # If using the create strategy don't generate an id.
+        # models.Annotation.id's server_default function will generate one
+        # when the annotation is saved to the DB.
+        if create:
+            return
+
+        # Don't generate an id if the user passed in one of their own.
+        if getattr(self, "id", None):
+            return
+
+        self.id = uuid.uuid1().hex

--- a/tests/h/search/index_test.py
+++ b/tests/h/search/index_test.py
@@ -92,7 +92,7 @@ class TestIndex(object):
 
     def test_you_can_filter_annotations_by_creation_time(self, factories, index, search):
         before = datetime.datetime.now()
-        annotation = factories.Annotation.build(id="test_annotation_id", created=datetime.datetime.now())
+        annotation = factories.Annotation.build(created=datetime.datetime.now())
 
         index(annotation)
 
@@ -102,15 +102,14 @@ class TestIndex(object):
     @pytest.fixture
     def make_annotation(self, factories):
         """A helper function for making test annotations."""
-        def _make_annotation(id_=None, **kwargs):
+        def _make_annotation(**kwargs):
             now = datetime.datetime.now()
             # We call .build() so that the annotation doesn't get added to the
             # DB (so the tests run faster) but then we have to pass in our own
-            # id, created, updated etc because our tests need these and they
+            # created and updated etc because our tests need these and they
             # wouldn't normally be created until the annotation actually gets
             # added to the DB.
             return factories.Annotation.build(
-                id=id_ or "test_annotation_id",
                 created=now,
                 updated=now,
                 **kwargs)
@@ -128,9 +127,9 @@ class TestIndex(object):
 
         """
         index(
-            factories.Annotation.build(id="noise_annotation_1"),
-            factories.Annotation.build(id="noise_annotation_2"),
-            factories.Annotation.build(id="noise_annotation_3"),
+            factories.Annotation.build(),
+            factories.Annotation.build(),
+            factories.Annotation.build(),
         )
 
     @pytest.fixture


### PR DESCRIPTION
Annotations created with factories.Annotation() do have ids but
unsaved and stub annotations created by factories.Annotion.build() or
factories.Annotation.stub() without passing an id argument don't have
ids:

    >>> a = factories.Annotation.build()
    >>> a.id
    None

This is because the ids are generated by models.Annotation using a
server_default function, so an id isn't generated until the annotation
is actually saved to the DB.

This creates noise in tests that have to pass an id argument to build()
or stub() because, for example, the test is going to add the annotation
to the test Elasticsearch index and doing so requires a non-null id,

Add code to factories.Annotation to auto-generate an id when build() or
stub() is called without passing an id.

Annotations created without using build() or stub() are not affected,
they still get an id from the server_default function:

    >>> factories.Annotation()
    <Annotation 3nemKFqbEeirh6fGyzgKag>

Annotations created with build() or stub() now also get a UUID id.
You'll notice that these look slightly different to the server_default
ids because the code for creating the ids isn't exactly the same. But
it's good enough for the tests:

    >>> factories.Annotation.build()
    <Annotation MTVhOTNiZDQtNWE5Yy0xMW>

    >>> factories.Annotation.stub().id
    'MjFlOTMwZmMtNWE5Yy0xMW'

You can still pass an id argument to create an annotation with a
particular id:

    >>> factories.Annotation.build(id="foo")
    <Annotation foo>

    >>> factories.Annotation.stub(id="bar").id
    'bar'