### PR TITLE
Set timestamps of build() and stub() annotations

### DIFF
--- a/tests/common/factories/annotation.py
+++ b/tests/common/factories/annotation.py
@@ -2,6 +2,7 @@
 
 from __future__ import unicode_literals
 
+import datetime
 import random
 import uuid
 
@@ -131,3 +132,20 @@ class Annotation(ModelFactory):
             return
 
         self.id = uuid.uuid1().hex
+
+    @factory.post_generation
+    def timestamps(self, create, extracted, **kwargs):
+        # If using the create strategy let sqlalchemy set the created and
+        # updated times when saving to the DB.
+        if create:
+            return
+
+        # When using the build or stub strategy sqlalchemy won't set created or updated
+        # times for us, so do it ourselves instead.
+        #
+        # We're generating created and updated separately (calling now() twice
+        # instead of just once) so created and updated won't be exactly the
+        # same. This is consistent with how models.Annotation does it when
+        # saving to the DB.
+        self.created = datetime.datetime.now()
+        self.updated = datetime.datetime.now()


### PR DESCRIPTION
Set the created and updated timestamps of test annotations created using
factories.Annotation.build() or factories.Annotation.stub().

When creating an annotation and saving it to the test database using
factories.Annotation() created and updated times will be generated for
the annotation:

    >>> factories.Annotation().created
    datetime.datetime(2018, 5, 18, 15, 39, 41, 677109)

But these created and updated values are implemented using default and
server_default arguments to the sqlalchemy column on the
models.Annotation class, so they're only created when the annotation is
added to the DB. This means that if you create test annotations using
build() or stub() they don't have created or updated times:

    >>> print(factories.Annotation.build().created)
    None

Add created and updated generators to factories.Annotation so that if
build() or stub() is being used the dates do now get generated:

    >>> factories.Annotation.build().created
    datetime.datetime(2018, 5, 18, 16, 44, 20, 857628)