### PR TITLE
Replace Env & DeprecatedSetting w/ SettingsManager

### DIFF
--- a/h/config.py
+++ b/h/config.py
@@ -107,6 +107,8 @@ def configure(environ=None, settings=None):
         settings_manager.set('mail.host', 'MANDRILL_HOST', default='smtp.mandrillapp.com')
         settings_manager.set('mail.port', 'MANDRILL_PORT', default=587)
         settings_manager.set('mail.tls', 'MANDRILL_TLS', default=True)
+
+    # Get resolved settings.
     settings = settings_manager.settings
 
     if 'secret_key' not in settings:

--- a/h/config.py
+++ b/h/config.py
@@ -11,11 +11,10 @@ from pyramid.config import Configurator
 from pyramid.settings import asbool, aslist
 
 from h.settings import (
-    DeprecatedSetting,
-    EnvSetting,
     SettingError,
     database_url,
     mandrill_settings,
+    SettingsManager
 )
 from h.util.logging_filters import ExceptionFilter
 
@@ -35,73 +34,6 @@ DEFAULT_SALT = (b"\xbc\x9ck!k\x81(\xb6I\xaa\x90\x0f'}\x07\xa1P\xd9\xb7\xcb"
 SETTINGS = [
     # Mailer configuration for Mandrill
     mandrill_settings,
-
-    # Configuration for external components
-    EnvSetting('broker_url', 'BROKER_URL'),
-    EnvSetting('es.client_poolsize', 'ELASTICSEARCH_CLIENT_POOLSIZE',
-               type=int),
-    EnvSetting('es.client.max_retries', 'ELASTICSEARCH_CLIENT_MAX_RETRIES', type=int),
-    EnvSetting('es.client.retry_on_timeout', 'ELASTICSEARCH_CLIENT_RETRY_ON_TIMEOUT', type=asbool),
-    EnvSetting('es.client.timeout', 'ELASTICSEARCH_CLIENT_TIMEOUT', type=float),
-    EnvSetting('es.host', 'ELASTICSEARCH_HOST'),
-    EnvSetting('es.url', 'ELASTICSEARCH_URL'),
-    EnvSetting('es.index', 'ELASTICSEARCH_INDEX'),
-    EnvSetting('es.aws.access_key_id', 'ELASTICSEARCH_AWS_ACCESS_KEY_ID'),
-    EnvSetting('es.aws.region', 'ELASTICSEARCH_AWS_REGION'),
-    EnvSetting('es.aws.secret_access_key', 'ELASTICSEARCH_AWS_SECRET_ACCESS_KEY'),
-    EnvSetting('mail.default_sender', 'MAIL_DEFAULT_SENDER'),
-    EnvSetting('mail.host', 'MAIL_HOST'),
-    EnvSetting('mail.port', 'MAIL_PORT', type=int),
-    EnvSetting('sqlalchemy.url', 'DATABASE_URL', type=database_url),
-    EnvSetting('statsd.host', 'STATSD_HOST'),
-    EnvSetting('statsd.port', 'STATSD_PORT', type=int),
-    EnvSetting('statsd.prefix', 'STATSD_PREFIX'),
-
-    # Configuration for Pyramid
-    EnvSetting('secret_key', 'SECRET_KEY', type=bytes),
-    EnvSetting('secret_salt', 'SECRET_SALT', type=bytes),
-
-    # Configuration for h
-    EnvSetting('csp.enabled', 'CSP_ENABLED', type=asbool),
-    EnvSetting('csp.report_uri', 'CSP_REPORT_URI'),
-    EnvSetting('csp.report_only', 'CSP_REPORT_ONLY'),
-    EnvSetting('ga_tracking_id', 'GOOGLE_ANALYTICS_TRACKING_ID'),
-    EnvSetting('ga_client_tracking_id', 'GOOGLE_ANALYTICS_CLIENT_TRACKING_ID'),
-    EnvSetting('h.app_url', 'APP_URL'),
-    DeprecatedSetting(EnvSetting('h.authority', 'AUTH_DOMAIN'),
-                      message='use the AUTHORITY environment variable instead'),
-    EnvSetting('h.authority', 'AUTHORITY'),
-    EnvSetting('h.bouncer_url', 'BOUNCER_URL'),
-
-    EnvSetting('h.client_url', 'CLIENT_URL'),
-
-    # ID for the OAuth authclient that the embedded client should use when
-    # making requests to OAuth endpoints. As a public client, it does not have a
-    # secret.
-    EnvSetting('h.client_oauth_id', 'CLIENT_OAUTH_ID'),
-
-    # The list of origins that the client will respond to cross-origin RPC
-    # requests from.
-    EnvSetting('h.client_rpc_allowed_origins',
-               'CLIENT_RPC_ALLOWED_ORIGINS', type=aslist),
-
-    EnvSetting('h.db_session_checks', 'DB_SESSION_CHECKS', type=asbool),
-
-    # Environment name, provided by the deployment environment. Please do
-    # *not* toggle functionality based on this value. It is intended as a
-    # label only.
-    EnvSetting('h.env', 'ENV'),
-    # Where should logged-out users visiting the homepage be redirected?
-    EnvSetting('h.homepage_redirect_url', 'HOMEPAGE_REDIRECT_URL'),
-    EnvSetting('h.proxy_auth', 'PROXY_AUTH', type=asbool),
-    # Sentry DSNs for frontend code should be of the public kind, lacking the
-    # password component in the DSN URI.
-    EnvSetting('h.sentry_dsn_client', 'SENTRY_DSN_CLIENT'),
-    EnvSetting('h.sentry_dsn_frontend', 'SENTRY_DSN_FRONTEND'),
-    EnvSetting('h.websocket_url', 'WEBSOCKET_URL'),
-
-    # Debug/development settings
-    EnvSetting('debug_query', 'DEBUG_QUERY'),
 ]
 
 
@@ -110,6 +42,75 @@ def configure(environ=None, settings=None):
         environ = os.environ
     if settings is None:
         settings = {}
+    settings_manager = SettingsManager(settings, environ)
+    # Configuration for external components
+    settings_manager.set('broker_url', 'BROKER_URL')
+    settings_manager.set('es.client_poolsize', 'ELASTICSEARCH_CLIENT_POOLSIZE',
+                         type_=int)
+    settings_manager.set('es.client.max_retries', 'ELASTICSEARCH_CLIENT_MAX_RETRIES', type_=int)
+    settings_manager.set('es.client.retry_on_timeout', 'ELASTICSEARCH_CLIENT_RETRY_ON_TIMEOUT', type_=asbool)
+    settings_manager.set('es.client.timeout', 'ELASTICSEARCH_CLIENT_TIMEOUT', type_=float)
+    settings_manager.set('es.host', 'ELASTICSEARCH_HOST')
+    settings_manager.set('es.url', 'ELASTICSEARCH_URL'),
+    settings_manager.set('es.index', 'ELASTICSEARCH_INDEX')
+    settings_manager.set('es.aws.access_key_id', 'ELASTICSEARCH_AWS_ACCESS_KEY_ID')
+    settings_manager.set('es.aws.region', 'ELASTICSEARCH_AWS_REGION')
+    settings_manager.set('es.aws.secret_access_key', 'ELASTICSEARCH_AWS_SECRET_ACCESS_KEY')
+    settings_manager.set('mail.default_sender', 'MAIL_DEFAULT_SENDER')
+    settings_manager.set('mail.host', 'MAIL_HOST')
+    settings_manager.set('mail.port', 'MAIL_PORT', type_=int)
+    settings_manager.set('sqlalchemy.url', 'DATABASE_URL', type_=database_url)
+    settings_manager.set('statsd.host', 'STATSD_HOST')
+    settings_manager.set('statsd.port', 'STATSD_PORT', type_=int)
+    settings_manager.set('statsd.prefix', 'STATSD_PREFIX')
+
+    # Configuration for Pyramid
+    settings_manager.set('secret_key', 'SECRET_KEY', type_=bytes)
+    settings_manager.set('secret_salt', 'SECRET_SALT', type_=bytes)
+
+    # Configuration for h
+    settings_manager.set('csp.enabled', 'CSP_ENABLED', type_=asbool)
+    settings_manager.set('csp.report_uri', 'CSP_REPORT_URI')
+    settings_manager.set('csp.report_only', 'CSP_REPORT_ONLY')
+    settings_manager.set('ga_tracking_id', 'GOOGLE_ANALYTICS_TRACKING_ID')
+    settings_manager.set('ga_client_tracking_id', 'GOOGLE_ANALYTICS_CLIENT_TRACKING_ID')
+    settings_manager.set('h.app_url', 'APP_URL')
+    settings_manager.set('h.authority', 'AUTH_DOMAIN',
+                         deprecated_msg='use the AUTHORITY environment variable instead')
+    settings_manager.set('h.authority', 'AUTHORITY')
+    settings_manager.set('h.bouncer_url', 'BOUNCER_URL')
+
+    settings_manager.set('h.client_url', 'CLIENT_URL')
+
+    # ID for the OAuth authclient that the embedded client should use when
+    # making requests to OAuth endpoints. As a public client, it does not have a
+    # secret.
+    settings_manager.set('h.client_oauth_id', 'CLIENT_OAUTH_ID')
+
+    # The list of origins that the client will respond to cross-origin RPC
+    # requests from.
+    settings_manager.set('h.client_rpc_allowed_origins',
+                         'CLIENT_RPC_ALLOWED_ORIGINS', type_=aslist)
+
+    settings_manager.set('h.db_session_checks', 'DB_SESSION_CHECKS', type_=asbool)
+
+    # Environment name, provided by the deployment environment. Please do
+    # *not* toggle functionality based on this value. It is intended as a
+    # label only.
+    settings_manager.set('h.env', 'ENV')
+    # Where should logged-out users visiting the homepage be redirected?
+    settings_manager.set('h.homepage_redirect_url', 'HOMEPAGE_REDIRECT_URL')
+    settings_manager.set('h.proxy_auth', 'PROXY_AUTH', type_=asbool)
+    # Sentry DSNs for frontend code should be of the public kind, lacking the
+    # password component in the DSN URI.
+    settings_manager.set('h.sentry_dsn_client', 'SENTRY_DSN_CLIENT')
+    settings_manager.set('h.sentry_dsn_frontend', 'SENTRY_DSN_FRONTEND')
+    settings_manager.set('h.websocket_url', 'WEBSOCKET_URL')
+
+    # Debug/development settings
+    settings_manager.set('debug_query', 'DEBUG_QUERY')
+
+    settings = settings_manager.settings
 
     for s in SETTINGS:
         try:

--- a/h/config.py
+++ b/h/config.py
@@ -66,7 +66,7 @@ def configure(environ=None, settings=None):
 
     # Configuration for Pyramid
     settings_manager.set('secret_key', 'SECRET_KEY', type_=bytes)
-    settings_manager.set('secret_salt', 'SECRET_SALT', type_=bytes)
+    settings_manager.set('secret_salt', 'SECRET_SALT', type_=bytes, default=DEFAULT_SALT)
 
     # Configuration for h
     settings_manager.set('csp.enabled', 'CSP_ENABLED', type_=asbool)
@@ -126,10 +126,6 @@ def configure(environ=None, settings=None):
                  'configure the secret_key setting or the SECRET_KEY '
                  'environment variable!')
         settings['secret_key'] = os.urandom(64)
-
-    # Use a fixed default salt if none provided
-    if 'secret_salt' not in settings:
-        settings['secret_salt'] = DEFAULT_SALT
 
     # Set up SQLAlchemy debug logging
     if 'debug_query' in settings:

--- a/h/settings.py
+++ b/h/settings.py
@@ -51,33 +51,21 @@ class SettingsManager(object):
             default=None,
             deprecated_msg=None):
         """
-        Set settings[name] to envvar or default.
+        Resolve a typed value for a setting.
 
-        Environment variables override config file settings and
-        defaults: if the named envvar is in the environment then set
-        settings[name] to the value of the envvar.
+        Sets the setting `name` to the value from the highest priority source
+        and coerces the result to a typed value using `type_`. The sources
+        in priority order are: 1) Environment variables (`envvar`), 2)
+        Configuration files (passed to the constructor), 3) Defaults (`default`).
 
-        Config file settings override defauits: if the envvar isn't
-        in the environment, and the named setting is already present
-        in settings, then leave settings[name] unchanged.
-
-        Defaults are used if the setting isn't in the environment or
-        the config file: if envvar isn't in the environment and name
-        isn't in settings then set settings[name] to the given default
-        value.
-
-        If envvar isn't in the environment and name isn't in settings
-        and no default is given then leave settings[name] unset. If
-        this happens and required=True then raise SettingError.
-
-        If deprecation_msg is not None and the envvar is in the
-        environment then log a warning envvar deprecation message.
+        If `required` is `True` then an error is raised if no source specifies
+        a value for this setting.
 
         :param name: the name of the pyramid config setting
         :type name: str
         :param envvar: the environment variable name
         :type envvar: str
-        :param type_: the type to type cast the envvar or default value
+        :param type_: callable that casts a string to the desired type
         :param required: True if the the pyramid config setting is required
         :type required: bool
         :param default: a default value to use if the envvar isn't set

--- a/h/settings.py
+++ b/h/settings.py
@@ -137,6 +137,9 @@ class EnvSetting(object):
                                        value=environ[self.varname]))
             return {self.setting: value}
 
+    def __str__(self):
+        return 'environment variable {name}'.format(name=self.varname)
+
 
 def database_url(url):
     """Parse a string as a Heroku-style database URL."""

--- a/h/settings.py
+++ b/h/settings.py
@@ -91,56 +91,6 @@ class SettingsManager(object):
                                        type_.__name__))
 
 
-class DeprecatedSetting(object):
-    """A wrapper for deprecated settings which emits appropriate warnings."""
-
-    def __init__(self, setting, message):
-        self.setting = setting
-        self.message = message
-
-        # Test seam
-        self.warn = log.warn
-
-    def __call__(self, environ):
-        result = self.setting(environ)
-        if result is not None:
-            self.warn(self.warning)
-        return result
-
-    @property
-    def warning(self):
-        return 'use of {s} is deprecated: {m}'.format(s=self.setting,
-                                                      m=self.message)
-
-
-class EnvSetting(object):
-
-    """An (optionally typed) setting read from an environment variable."""
-
-    def __init__(self, setting, varname, type=None):
-        self.setting = setting
-        self.varname = varname
-        if type is not None:
-            self.type = type
-        else:
-            self.type = str
-
-    def __call__(self, environ):
-        if self.varname in environ:
-            try:
-                value = self.type(environ[self.varname])
-            except ValueError:
-                raise SettingError('error parsing environment variable '
-                                   '{varname}={value!r} as {typename}'.format(
-                                       varname=self.varname,
-                                       typename=self.type.__name__,
-                                       value=environ[self.varname]))
-            return {self.setting: value}
-
-    def __str__(self):
-        return 'environment variable {name}'.format(name=self.varname)
-
-
 def database_url(url):
     """Parse a string as a Heroku-style database URL."""
     # Heroku database URLs start with postgres://, which is an old and
@@ -149,14 +99,3 @@ def database_url(url):
     if url.startswith('postgres://'):
         url = 'postgresql+psycopg2://' + url[len('postgres://'):]
     return url
-
-
-def mandrill_settings(environ):
-    if 'MANDRILL_USERNAME' in environ and 'MANDRILL_APIKEY' in environ:
-        return {
-            'mail.username': environ['MANDRILL_USERNAME'],
-            'mail.password': environ['MANDRILL_APIKEY'],
-            'mail.host': 'smtp.mandrillapp.com',
-            'mail.port': 587,
-            'mail.tls': True,
-        }

--- a/h/settings.py
+++ b/h/settings.py
@@ -11,6 +11,8 @@ log = logging.getLogger(__name__)
 
 
 class SettingError(Exception):
+    """Exception thrown when a setting cannot be resolved."""
+
     pass
 
 
@@ -25,22 +27,20 @@ class SettingsManager(object):
     The resolved settings are available via the `settings` attribute.
     """
 
-    def __init__(self, settings={}, environ=None):
+    def __init__(self, settings=None, environ=None):
         """
-        Initialize SettingsManager with initial setting values from config files
-        and the environment.
+        Initialize with initial setting values from config files and environment.
 
         :param settings: Initial configuration settings read from config files
         :type settings: Dict[str,str]
         :param environ: Environment variable mappings
         :type environ: Dict[str, str]
         """
-
         if environ is None:
             environ = os.environ
 
         self.settings = {}
-        self.settings.update(settings)
+        self.settings.update(settings or {})
 
         self._environ = environ
 

--- a/h/settings.py
+++ b/h/settings.py
@@ -5,12 +5,90 @@
 from __future__ import unicode_literals
 
 import logging
+import os
 
 log = logging.getLogger(__name__)
 
 
 class SettingError(Exception):
     pass
+
+
+class SettingsManager(object):
+    def __init__(self, settings=None, environ=None):
+        if settings is None:
+            settings = {}
+        if environ is None:
+            environ = os.environ
+        self.settings = settings
+        self._environ = environ
+
+    def set(self,  # pylint: disable=too-many-arguments
+            name,
+            envvar,
+            type_=str,
+            required=False,
+            default=None,
+            deprecated_msg=None):
+        """
+        Set settings[name] to envvar or default.
+
+        Environment variables override config file settings and
+        defaults: if the named envvar is in the environment then set
+        settings[name] to the value of the envvar.
+
+        Config file settings override defauits: if the envvar isn't
+        in the environment, and the named setting is already present
+        in settings, then leave settings[name] unchanged.
+
+        Defaults are used if the setting isn't in the environment or
+        the config file: if envvar isn't in the environment and name
+        isn't in settings then set settings[name] to the given default
+        value.
+
+        If envvar isn't in the environment and name isn't in settings
+        and no default is given then leave settings[name] unset. If
+        this happens and required=True then raise SettingError.
+
+        If deprecation_msg is not None and the envvar is in the
+        environment then log a warning envvar deprecation message.
+
+        :param name: the name of the pyramid config setting
+        :type name: str
+        :param envvar: the environment variable name
+        :type envvar: str
+        :param type_: the type to type cast the envvar or default value
+        :param required: True if the the pyramid config setting is required
+        :type required: bool
+        :param default: a default value to use if the envvar isn't set
+        :param deprecated_msg: a deprecated envvar setting message to display
+        :type deprecated_msg: str
+        :raises SettingsError: if required and not set
+        :raises SettingsError: if type casting fails
+        """
+        val = None
+        cast_message = None
+        if envvar in self._environ:
+            if deprecated_msg:
+                log.warn('use of envvar %s is deprecated: %s',
+                         envvar,
+                         deprecated_msg)
+            val = self._environ[envvar]
+            cast_message = "environment variable {}={!r}".format(envvar, val)
+        elif default and name not in self.settings:
+            val = default
+            cast_message = "{}'s default {!r}".format(name, val)
+        elif required and name not in self.settings:
+            raise SettingError(
+                'error parsing environment variable '
+                '{varname} not found'.format(varname=envvar))
+        if val:
+            try:
+                self.settings[name] = type_(val)
+            except ValueError:
+                raise SettingError('error casting {} as {}'.format(
+                                       cast_message,
+                                       type_.__name__))
 
 
 class DeprecatedSetting(object):
@@ -58,9 +136,6 @@ class EnvSetting(object):
                                        typename=self.type.__name__,
                                        value=environ[self.varname]))
             return {self.setting: value}
-
-    def __str__(self):
-        return 'environment variable {name}'.format(name=self.varname)
 
 
 def database_url(url):

--- a/h/settings.py
+++ b/h/settings.py
@@ -52,21 +52,20 @@ class SettingsManager(object):
             default=None,
             deprecated_msg=None):
         """
-        Resolve a typed value for a setting.
+        Update `setting[name]`.
 
-        Sets the setting `name` to the value from the highest priority source
-        and coerces the result to a typed value using `type_`. The sources
-        in priority order are: 1) Environment variables (`envvar`), 2)
-        Configuration files (passed to the constructor), 3) Defaults (`default`).
+        Update `setting[name]` using the value from the environment variable
+        `envvar`. If there is no such environment variable and `setting[name]`
+        is not already set, `setting[name]` is set to `default`.
 
-        If `required` is `True` then an error is raised if no source specifies
-        a value for this setting.
+        Raises `SettingsError` if a required setting is missing and has no default,
+        or coercing the setting using `type_` fails.
 
         :param name: the name of the pyramid config setting
         :type name: str
         :param envvar: the environment variable name
         :type envvar: str
-        :param type_: callable that casts a string to the desired type
+        :param type_: callable that casts the setting value to the desired type
         :param required: True if the the pyramid config setting is required
         :type required: bool
         :param default: a default value to use if the envvar isn't set

--- a/h/settings.py
+++ b/h/settings.py
@@ -15,7 +15,27 @@ class SettingError(Exception):
 
 
 class SettingsManager(object):
+    """
+    Configuration setting resolver.
+
+    SettingsManager resolves settings from various sources into the final typed
+    values used when the app runs. It also provides a way to check for missing
+    required settings or use of deprecated settings.
+
+    The resolved settings are available via the `settings` attribute.
+    """
+
     def __init__(self, settings=None, environ=None):
+        """
+        Initialize SettingsManager with initial setting values from config files
+        and the environment.
+
+        :param settings: Initial configuration settings read from config files
+        :type settings: Dict[str,str]
+        :param environ: Environment variable mappings
+        :type environ: Dict[str, str]
+        """
+
         if settings is None:
             settings = {}
         if environ is None:

--- a/h/settings.py
+++ b/h/settings.py
@@ -25,7 +25,7 @@ class SettingsManager(object):
     The resolved settings are available via the `settings` attribute.
     """
 
-    def __init__(self, settings=None, environ=None):
+    def __init__(self, settings={}, environ=None):
         """
         Initialize SettingsManager with initial setting values from config files
         and the environment.
@@ -36,11 +36,12 @@ class SettingsManager(object):
         :type environ: Dict[str, str]
         """
 
-        if settings is None:
-            settings = {}
         if environ is None:
             environ = os.environ
-        self.settings = settings
+
+        self.settings = {}
+        self.settings.update(settings)
+
         self._environ = environ
 
     def set(self,  # pylint: disable=too-many-arguments

--- a/tests/h/settings_test.py
+++ b/tests/h/settings_test.py
@@ -3,9 +3,11 @@
 from __future__ import unicode_literals
 
 import pytest
-import mock
+import logging
 
-from h import settings
+from h.settings import (SettingsManager,
+                        SettingError,
+                        database_url)
 
 
 class FakeSetting(object):
@@ -42,8 +44,8 @@ class TestDeprecatedSetting(object):
         assert not func.warn.called
 
 
-def asutf8(str):
-    return str.encode()
+def asutf8(string):
+    return string.encode()
 
 
 @pytest.mark.parametrize('setting,varname,type,environ,expected', (
@@ -77,7 +79,7 @@ def test_database_url():
     url = 'postgres://postgres:1234/database'
     expected = 'postgresql+psycopg2://postgres:1234/database'
 
-    assert settings.database_url(url) == expected
+    assert database_url(url) == expected
 
 
 def test_mandrill_settings():
@@ -98,3 +100,90 @@ def test_mandrill_settings():
 
 def test_mandrill_settings_unset():
     assert settings.mandrill_settings({}) is None
+
+
+class TestSettingsManager(object):
+    def test_does_not_warn_when_deprecated_setting_is_not_used(self, caplog):
+        with caplog.at_level(logging.WARN):
+            settings_manager = SettingsManager({}, {})
+            settings_manager.set('foo', 'FOO', deprecated_msg='what to do instead')
+        assert not caplog.records
+
+    def test_sets_value_when_deprecated_setting_is_used(self):
+        settings_manager = SettingsManager(environ={'FOO': 'bar'})
+        settings_manager.set('foo', 'FOO', deprecated_msg='what to do instead')
+
+        result = settings_manager.settings['foo']
+
+        assert result == 'bar'
+
+    def test_warns_when_deprecated_setting_is_used(self, caplog):
+        with caplog.at_level(logging.WARN):
+            settings_manager = SettingsManager({}, {'FOO': 'bar'})
+            settings_manager.set('foo', 'FOO', deprecated_msg='what to do instead')
+        assert 'what to do instead' in caplog.text
+
+    @pytest.mark.parametrize('settings,name,envvar,type_,environ,required,default,expected', (
+        # Should leave value at None when the env var in question isn't set
+        ({'foo': None}, 'foo', 'FOO', str, {}, False, None, None),
+
+        # Should return the setting as a string when the env var is set
+        ({}, 'foo', 'FOO', str, {'FOO': 'bar'}, False, None, 'bar'),
+        ({'foo.bar': 'foo.bar'}, 'foo.bar', 'FOO', str, {'FOO': 'baz'}, False, None, 'baz'),
+
+        # Should coerce the result using the passed type
+        ({}, 'foo', 'FOO', asutf8, {'FOO': 'bar'}, False, None, asutf8('bar')),
+        ({}, 'app_port', 'PORT', int, {'PORT': '123'}, False, None, 123),
+
+        # Should overide the value when a default is provided
+        ({}, 'bar', 'BAR', str, {}, True, 'bar', 'bar'),
+
+        # Should not overide the value when a default is provided and the envvar is set
+        ({}, 'foo', 'FOO', str, {'FOO': 'bar'}, True, 'boo', 'bar'),
+
+        # Should not error when required and a default is already set
+        ({'foo': 'foo'}, 'foo', 'FOO', str, {}, True, None, 'foo'),
+
+        # Should not overide default if default is already set
+        ({'boo': 'boo'}, 'boo', 'BOO', str, {}, True, 'foo', 'boo'),
+
+    ))
+    def test_env_setting(self, settings, name, envvar, type_, environ, required, default, expected):
+        settings_manager = SettingsManager(settings, environ)
+        settings_manager.set(name, envvar, type_, required, default)
+
+        result = settings[name]
+
+        assert result == expected
+
+    @pytest.mark.parametrize('name,envvar,type_,environ,default', (
+        # Should raise because default isn't an int
+        ('foo', 'FOO', int, {}, 'notanint'),
+        # Should raise because environment variable isn't an int
+        ('foo', 'FOO', int, {'FOO': 'notanint'}, None),
+        ))
+    def test_raises_when_unable_to_type_cast(self, name, envvar, type_, environ, default):
+        settings_manager = SettingsManager(environ=environ)
+        with pytest.raises(SettingError):
+            settings_manager.set(name, envvar, type_=type_, default=default)
+
+    def test_raises_when_not_in_env_no_default_and_required(self):
+        settings_manager = SettingsManager({'bar': 'val'}, {'BAR': 'bar'})
+        with pytest.raises(SettingError):
+            settings_manager.set('foo', 'FOO', required=True)
+
+    def test_defaults_settings_to_empty_dict(self):
+        settings_manager = SettingsManager()
+        assert settings_manager.settings == {}
+
+    def test_defaults_environ_to_osenviron(self, environ):
+        settings_manager = SettingsManager()
+        settings_manager.set('foo', 'FOO', default='bar')
+        result = settings_manager.settings['foo']
+        assert result == 'foo'
+
+    @pytest.fixture
+    def environ(self, patch):
+        patched_os = patch('h.settings.os')
+        patched_os.environ = {'FOO': 'foo'}
+        return patched_os

--- a/tests/h/settings_test.py
+++ b/tests/h/settings_test.py
@@ -106,7 +106,8 @@ class TestSettingsManager(object):
         settings_manager = SettingsManager()
         assert settings_manager.settings == {}
 
-    def test_defaults_environ_to_osenviron(self, environ):
+    @pytest.mark.usefixtures('environ')
+    def test_defaults_environ_to_osenviron(self):
         settings_manager = SettingsManager()
         settings_manager.set('foo', 'FOO', default='bar')
         result = settings_manager.settings['foo']

--- a/tests/h/settings_test.py
+++ b/tests/h/settings_test.py
@@ -112,6 +112,10 @@ class TestSettingsManager(object):
         result = settings_manager.settings['foo']
         assert result == 'foo'
 
+    def test_it_preserves_extra_config_settings(self):
+        settings_manager = SettingsManager({'pyramid.setting': True})
+        assert settings_manager.settings['pyramid.setting'] is True
+
     @pytest.fixture
     def environ(self, patch):
         patched_os = patch('h.settings.os')

--- a/tests/h/settings_test.py
+++ b/tests/h/settings_test.py
@@ -10,69 +10,8 @@ from h.settings import (SettingsManager,
                         database_url)
 
 
-class FakeSetting(object):
-    def __init__(self, result):
-        self.result = result
-
-    def __call__(self, environ):
-        return self.result
-
-    def __str__(self):
-        return 'fake setting'
-
-
-class TestDeprecatedSetting(object):
-    def test_emits_warnings_when_child_setting_is_used(self):
-        func = settings.DeprecatedSetting(FakeSetting(result={'foo': 'bar'}),
-                                          message='what to do instead')
-        func.warn = mock.Mock(spec_set=[])
-
-        result = func({})
-
-        assert result == {'foo': 'bar'}
-        func.warn.assert_called_once_with('use of fake setting is '
-                                          'deprecated: what to do instead')
-
-    def test_emits_no_warnings_when_unused(self):
-        func = settings.DeprecatedSetting(FakeSetting(result=None),
-                                          message='what to do instead')
-        func.warn = mock.Mock(spec_set=[])
-
-        result = func({})
-
-        assert result is None
-        assert not func.warn.called
-
-
 def asutf8(string):
     return string.encode()
-
-
-@pytest.mark.parametrize('setting,varname,type,environ,expected', (
-    # Should return None when the env var in question isn't set
-    ('foo', 'FOO', None, {}, None),
-
-    # Should return the setting as a string when the env var is set
-    ('foo', 'FOO', None, {'FOO': 'bar'}, {'foo': 'bar'}),
-    ('foo.bar', 'FOO', None, {'FOO': 'baz'}, {'foo.bar': 'baz'}),
-
-    # Should coerce the result using the passed type
-    ('foo', 'FOO', asutf8, {'FOO': 'bar'}, {'foo': b'bar'}),
-    ('app_port', 'PORT', int, {'PORT': '123'}, {'app_port': 123}),
-))
-def test_env_setting(setting, varname, type, environ, expected):
-    func = settings.EnvSetting(setting, varname, type)
-
-    result = func(environ)
-
-    assert result == expected
-
-
-def test_env_setting_returns_nicer_error_for_type_failure():
-    func = settings.EnvSetting('port', 'PORT', type=int)
-
-    with pytest.raises(settings.SettingError):
-        func({'PORT': 'notanint'})
 
 
 def test_database_url():
@@ -80,26 +19,6 @@ def test_database_url():
     expected = 'postgresql+psycopg2://postgres:1234/database'
 
     assert database_url(url) == expected
-
-
-def test_mandrill_settings():
-    environ = {
-        'MANDRILL_USERNAME': 'foobar',
-        'MANDRILL_APIKEY': 'wibble',
-    }
-    expected = {
-        'mail.username': 'foobar',
-        'mail.password': 'wibble',
-        'mail.host': 'smtp.mandrillapp.com',
-        'mail.port': 587,
-        'mail.tls': True,
-    }
-
-    assert settings.mandrill_settings(environ) == expected
-
-
-def test_mandrill_settings_unset():
-    assert settings.mandrill_settings({}) is None
 
 
 class TestSettingsManager(object):


### PR DESCRIPTION
This is a partial fix for https://github.com/hypothesis/product-backlog/issues/647.
- [x] Add a `required=False` keyword argument to `EnvSetting`. Change any existing required settings should use this.
- [x] Add a `default=None` keyword argument to `EnvSetting`. Change any existing settings that have default values that can be hardcoded in Python should use this.