### PR TITLE
Use uuid4 instead of uuid1 for test annotation ids

### DIFF
--- a/tests/common/factories/annotation.py
+++ b/tests/common/factories/annotation.py
@@ -131,7 +131,7 @@ class Annotation(ModelFactory):
         if getattr(self, "id", None):
             return
 
-        self.id = uuid.uuid1().hex
+        self.id = uuid.uuid4().hex
 
     @factory.post_generation
     def timestamps(self, create, extracted, **kwargs):


### PR DESCRIPTION
uuid1 seems to produce very similar ids:

    >>> for _ in range(10):
    ...     print uuid.uuid1()
    ...
    204447c0-5d1a-11e8-a9f7-2c4d5499f8bd
    204447c1-5d1a-11e8-a9f7-2c4d5499f8bd
    204447c2-5d1a-11e8-a9f7-2c4d5499f8bd
    204447c3-5d1a-11e8-a9f7-2c4d5499f8bd
    204447c4-5d1a-11e8-a9f7-2c4d5499f8bd
    204447c5-5d1a-11e8-a9f7-2c4d5499f8bd
    204447c6-5d1a-11e8-a9f7-2c4d5499f8bd
    204447c7-5d1a-11e8-a9f7-2c4d5499f8bd
    204447c8-5d1a-11e8-a9f7-2c4d5499f8bd
    204447c9-5d1a-11e8-a9f7-2c4d5499f8bd

This is pretty unhelpful for debugging. uuid4 is better:

    >>> for _ in range(10):
    ...     uuid.uuid4()
    ...
    UUID('1c0c0664-459f-4ef0-a70f-cee407ab9929')
    UUID('d2b75f08-3caa-46c5-bb36-0067366bebff')
    UUID('2f7e1bec-9e50-4504-a0bb-6d14be6471bc')
    UUID('4115f24e-10d5-4d09-949d-cb9b715ecac1')
    UUID('711386e8-66b2-4224-a081-5a7a174c1fc4')
    UUID('7602311c-27ea-4afa-b986-84e1000eb0d4')
    UUID('11ba7cd5-ef86-4bb4-aea7-8487c0914126')
    UUID('6ab325b3-a818-42fa-9188-65d885468b91')
    UUID('1998e8a4-29cb-4151-8d57-5f19c1883625')
    UUID('5c6cb279-1c35-4952-897b-7b7e6606bd7c')

The Python docs say "If all you want is a unique ID, you should probably
call uuid1() or uuid4()":

https://docs.python.org/2/library/uuid.html