### PR TITLE
Support Amazon SQS as the message transport for Celery

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,7 @@ COPY requirements.txt ./
 # Install build deps, build, and then clean up.
 RUN apk add --no-cache --virtual build-deps \
     build-base \
+    curl-dev \
     libffi-dev \
     postgresql-dev \
     python-dev \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,7 +32,7 @@ node {
                                          "-e ELASTICSEARCH_URL=${elasticsearchHost} " +
                                          "-e TEST_DATABASE_URL=${databaseUrl}") {
                 // Test dependencies
-                sh 'apk add --no-cache build-base libffi-dev postgresql-dev python-dev'
+                sh 'apk add --no-cache build-base curl-dev libffi-dev postgresql-dev python-dev'
                 sh 'apk add --no-cache python3 python3-dev'
                 sh 'pip install -q tox'
 

--- a/h/celery.py
+++ b/h/celery.py
@@ -18,8 +18,25 @@ import os
 from celery import Celery
 from celery import signals
 from celery.utils.log import get_task_logger
+
+# This package can be imported on any system but properties and methods will
+# only work in an actual EC2 instance.
+from ec2_metadata import ec2_metadata
+
 from kombu import Exchange, Queue
 from raven.contrib.celery import register_signal, register_logger_signal
+
+
+def _broker_transport_options(broker_url):
+    """
+    Return backend-specific configuration options for the message broker.
+    """
+    if not broker_url.startswith('sqs://'):
+        return {}
+
+    # Use SQS in the same region as the EC2 instance on which 'h' is running.
+    return {'region': ec2_metadata.region}
+
 
 __all__ = (
     'celery',
@@ -27,11 +44,13 @@ __all__ = (
 )
 
 log = logging.getLogger(__name__)
+broker_url = os.environ.get('CELERY_BROKER_URL',
+                            os.environ.get('BROKER_URL', 'amqp://guest:guest@localhost:5672//'))
 
 celery = Celery('h')
 celery.conf.update(
-    broker_url=os.environ.get('CELERY_BROKER_URL',
-                              os.environ.get('BROKER_URL', 'amqp://guest:guest@localhost:5672//')),
+    broker_url=broker_url,
+    broker_transport_options=_broker_transport_options(broker_url),
     beat_schedule={
         'purge-deleted-annotations': {
             'task': 'h.tasks.cleanup.purge_deleted_annotations',

--- a/h/celery.py
+++ b/h/celery.py
@@ -34,10 +34,16 @@ def _broker_transport_options(broker_url):
     if not broker_url.startswith('sqs://'):
         return {}
 
+    # Prefix for SQS queue names to make it clearer which service the queues
+    # are associated with.
+    #
+    # This is configurable to support different h instances in the same AWS
+    # account.
+    queue_name_prefix = os.getenv('SQS_QUEUE_NAME_PREFIX', 'hypothesis-h-')
+
     return {
-        # Prefix SQS queue names to make it clearer which service the queues
-        # are associated with.
-        'queue_name_prefix': 'hypothesis-h-',
+        'queue_name_prefix': queue_name_prefix,
+
         # Use SQS in the same region as the EC2 instance on which 'h' is running.
         'region': ec2_metadata.region,
     }

--- a/h/celery.py
+++ b/h/celery.py
@@ -34,8 +34,13 @@ def _broker_transport_options(broker_url):
     if not broker_url.startswith('sqs://'):
         return {}
 
-    # Use SQS in the same region as the EC2 instance on which 'h' is running.
-    return {'region': ec2_metadata.region}
+    return {
+        # Prefix SQS queue names to make it clearer which service the queues
+        # are associated with.
+        'queue_name_prefix': 'hypothesis-h-',
+        # Use SQS in the same region as the EC2 instance on which 'h' is running.
+        'region': ec2_metadata.region,
+    }
 
 
 __all__ = (

--- a/requirements.in
+++ b/requirements.in
@@ -4,6 +4,7 @@ alembic
 backports.functools_lru_cache
 bcrypt
 bleach >= 2.0
+boto3
 celery >= 4.1
 certifi
 cffi
@@ -28,6 +29,7 @@ oauthlib
 passlib
 psycogreen
 psycopg2
+pycurl
 pyparsing >= 2.1.5
 pyramid
 pyramid_authsanity >= 1.0.0  # 1.0.0 fixes an IE bug: https://git.io/vH3mi

--- a/requirements.in
+++ b/requirements.in
@@ -11,6 +11,7 @@ cffi
 click
 deform < 1.0
 deform-jinja2
+ec2-metadata
 elasticsearch==6.2.0
 elasticsearch1==1.10.0
 elasticsearch-dsl==6.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,8 @@ backports.functools-lru-cache==1.2.1
 bcrypt==3.1.3
 billiard==3.5.0.3         # via celery
 bleach==2.1.3
+boto3==1.7.30
+botocore==1.10.30         # via boto3, s3transfer
 celery==4.1.0
 certifi==2016.2.28
 cffi==1.7.0
@@ -19,6 +21,7 @@ colander==1.3.1           # via deform
 contextlib2==0.5.4        # via raven
 deform-jinja2==0.5
 deform==0.9.9
+docutils==0.14            # via botocore
 elasticsearch-dsl==6.1.0
 elasticsearch1==1.10.0
 elasticsearch==6.2.0
@@ -33,6 +36,7 @@ ipaddress==1.0.18         # via elasticsearch-dsl
 iso8601==0.1.11           # via colander
 itsdangerous==0.24
 jinja2==2.8               # via deform-jinja2, pyramid-jinja2
+jmespath==0.9.3           # via boto3, botocore
 jsonpointer==1.0
 jsonschema==2.5.1
 kombu==4.1.0
@@ -47,6 +51,7 @@ peppercorn==0.5           # via deform
 psycogreen==1.0
 psycopg2==2.7.3.2
 pycparser==2.14           # via cffi
+pycurl==7.43.0.1
 pyjwt==1.5.3
 pyparsing==2.1.10
 pyramid-authsanity==1.0.0
@@ -65,6 +70,7 @@ repoze.lru==0.6           # via pyramid
 repoze.sendmail==4.3      # via pyramid-mailer
 requests-aws4auth==0.9
 requests==2.13.0          # via requests-aws4auth
+s3transfer==0.1.13        # via boto3
 six==1.10.0               # via bcrypt, bleach, elasticsearch-dsl, html5lib, python-dateutil
 sqlalchemy==1.1.4
 statsd==3.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ billiard==3.5.0.3         # via celery
 bleach==2.1.3
 boto3==1.7.30
 botocore==1.10.30         # via boto3, s3transfer
+cached-property==1.4.2    # via ec2-metadata
 celery==4.1.0
 certifi==2016.2.28
 cffi==1.7.0
@@ -22,6 +23,7 @@ contextlib2==0.5.4        # via raven
 deform-jinja2==0.5
 deform==0.9.9
 docutils==0.14            # via botocore
+ec2-metadata==1.6.0
 elasticsearch-dsl==6.1.0
 elasticsearch1==1.10.0
 elasticsearch==6.2.0
@@ -69,7 +71,7 @@ raven==6.0.0
 repoze.lru==0.6           # via pyramid
 repoze.sendmail==4.3      # via pyramid-mailer
 requests-aws4auth==0.9
-requests==2.13.0          # via requests-aws4auth
+requests==2.13.0          # via ec2-metadata, requests-aws4auth
 s3transfer==0.1.13        # via boto3
 six==1.10.0               # via bcrypt, bleach, elasticsearch-dsl, html5lib, python-dateutil
 sqlalchemy==1.1.4


### PR DESCRIPTION
We have partners interested in using Amazon SQS rather than RabbitMQ as the [message broker for Celery](http://docs.celeryproject.org/en/latest/getting-started/brokers/index.html). This will save them the operational hassle of managing additional infrastructure (either self-hosted or using eg. CloudAMQP) since they already use SQS.

Amazon SQS has a more limited set of features than RabbitMQ. Fortunately what it does support is enough for executing h's background and periodic tasks. It [won't be able to support](https://github.com/hypothesis/product-backlog/issues/652#issuecomment-390642479) the current implementation of the realtime API.

This PR adds support for SQS as follows:

- Add the boto3 and pycurl libraries required by Kombu's SQS support. Celery provides a `celery[sqs]` convenience bundle that _should_ include these but we can't use that because it ships the wrong version of boto (boto 2 instead of 3) in Celery 4.1.x (this is fixed in the next Celery release)
- Configure Celery to use SQS from the same region as the current EC2 instance when using SQS
- Disable the realtime API when using SQS as a message broker by replacing `request.realtime` with a dummy implementation. In future we'll probably want to rearchitect the websocket server [for performance reasons](https://github.com/hypothesis/h/issues/5030) and could consider how to make it possible to use alternative backends (eg. Amazon SNS) at that point.

Supporting use of SQS for periodic tasks executed by Celery beat will require changes to [h-periodic](https://github.com/hypothesis/h-periodic) as well.

A limitation of SQS is that it can't be tested entirely on a local system since SQS isn't open source, although you can configure your local dev instance to use SQS if you provide it with appropriate credentials in the `BROKER_URL`. I've been testing this out by deploying Docker images to the `load-testing` ECS cluster in our AWS account.