### PR TITLE
Allow custom timestamps in Annotation.build()

### DIFF
--- a/tests/common/factories/annotation.py
+++ b/tests/common/factories/annotation.py
@@ -147,5 +147,5 @@ class Annotation(ModelFactory):
         # instead of just once) so created and updated won't be exactly the
         # same. This is consistent with how models.Annotation does it when
         # saving to the DB.
-        self.created = datetime.datetime.now()
-        self.updated = datetime.datetime.now()
+        self.created = self.created or datetime.datetime.now()
+        self.updated = self.updated or datetime.datetime.now()


### PR DESCRIPTION
factories.Annotation.build() was setting created and updated itself,
even if the calling code passed them in. In this example created and
updated would be ignored and different times used:

    factories.Annotation.build(
        created=some_datetime,
        updated=another_datetime)

Fix factories.Annotation.build() to only write created and updated if
they aren't passed in.