### PR TITLE
Add default group to factories.Annotation.build()

### DIFF
--- a/tests/common/factories/annotation.py
+++ b/tests/common/factories/annotation.py
@@ -28,6 +28,7 @@ class Annotation(ModelFactory):
     userid = factory.LazyFunction(lambda: "acct:{username}@{authority}".format(
         username=FAKER.user_name(), authority=FAKER.domain_name(levels=1)))
     document = factory.SubFactory(Document)
+    groupid = "__world__"
 
     @factory.lazy_attribute
     def target_selectors(self):


### PR DESCRIPTION
Annotations from factories.Annotation() get the `"__world__"` group by
default, but annotations from factories.Annotation.build() get None:

    >>> factories.Annotation().groupid
    u'__world__'

    >>> factories.Annotation.build().groupid
    None

This is because the default group is implemented by models.Annotation
using a sqlalchemy default and server_default, so it doesn't get set
until the annotation is added to the DB.

This can cause tests to crash because code expects all annotations to
have a group.

Fix factories.Annotation.build() to set groupid to `"__world__"` by
default. You can still pass a custom groupid if you want:

    >>> factories.Annotation.build().groupid
    u'__world__'

    >>> factories.Annotation.build(groupid=u"foo").groupid
    u'foo'