### PR TITLE
Add request.user to pyramid_request fixture

### DIFF
--- a/tests/h/conftest.py
+++ b/tests/h/conftest.py
@@ -246,6 +246,7 @@ def pyramid_request(db_session, fake_feature, pyramid_settings):
     request.params = MultiDict()
     request.GET = request.params
     request.POST = request.params
+    request.user = None
     return request
 
 

--- a/tests/h/groups/search_test.py
+++ b/tests/h/groups/search_test.py
@@ -34,5 +34,4 @@ class TestGroupAuthFilter(object):
 
     @pytest.fixture
     def pyramid_request(self, pyramid_request):
-        pyramid_request.user = None
         return pyramid_request

--- a/tests/h/panels/navbar_test.py
+++ b/tests/h/panels/navbar_test.py
@@ -98,7 +98,6 @@ class TestNavbar(object):
 
     @pytest.fixture
     def req(self, pyramid_request):
-        pyramid_request.user = None
         return pyramid_request
 
     @pytest.fixture


### PR DESCRIPTION
h adds a custom `.user` property to the request but Pyramid's
DummyRequest (which is what we use for our pyramid_request fixture)
doesn't have this property. As a result lots of tests need to add
`pyramid_request.user` so that code doesn't crash.

Add `pyramid_request.user` by default so tests no longer need to do
this.