### PR TITLE
Use group_service fixture in all search tests automatically

### DIFF
--- a/tests/h/search/conftest.py
+++ b/tests/h/search/conftest.py
@@ -1,9 +1,19 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+import mock
 import pytest
 
 import h.search.index
+from h.services.group import GroupService
+
+
+@pytest.fixture(autouse=True)
+def group_service(pyramid_config):
+    group_service = mock.create_autospec(GroupService, instance=True, spec_set=True)
+    group_service.groupids_readable_by.return_value = ["__world__"]
+    pyramid_config.register_service(group_service, name="group")
+    return group_service
 
 
 @pytest.fixture

--- a/tests/h/search/core_test.py
+++ b/tests/h/search/core_test.py
@@ -3,14 +3,11 @@ from __future__ import unicode_literals
 
 import datetime
 
-import mock
 import pytest
 
 from h import search
-from h.services.group import GroupService
 
 
-@pytest.mark.usefixtures("group_service")
 class TestSearch(object):
     """Unit tests for search.Search when no separate_replies argument is given."""
 
@@ -120,7 +117,6 @@ class TestSearch(object):
         assert result.reply_ids == []
 
 
-@pytest.mark.usefixtures("group_service")
 class TestSearchWithSeparateReplies(object):
     """Unit tests for search.Search when separate_replies=True is given."""
 
@@ -248,11 +244,3 @@ def Annotation(factories, index):
 def pyramid_request(es_client, pyramid_request):
     pyramid_request.es = es_client
     return pyramid_request
-
-
-@pytest.fixture
-def group_service(pyramid_config):
-    group_service = mock.create_autospec(GroupService, instance=True, spec_set=True)
-    group_service.groupids_readable_by.return_value = ["__world__"]
-    pyramid_config.register_service(group_service, name="group")
-    return group_service

--- a/tests/h/search/old_core_test.py
+++ b/tests/h/search/old_core_test.py
@@ -3,7 +3,6 @@ import mock
 import pytest
 
 from h.search import core
-from h.services.group import GroupService
 
 
 class FakeStatsdClient(object):
@@ -30,7 +29,6 @@ class FakeStatsdTimer(object):
         pass
 
 
-@pytest.mark.usefixtures("group_service")
 class TestSearch(object):
     def test_run_searches_annotations(self, pyramid_request, _search_annotations):
         params = mock.Mock()
@@ -261,7 +259,6 @@ class TestSearch(object):
 #     assert not log.warn.called
 
 
-@pytest.mark.usefixtures("group_service")
 @pytest.mark.parametrize('filter_type', [
     'DeletedFilter',
     'AuthFilter',
@@ -277,7 +274,6 @@ def test_default_querybuilder_includes_default_filters(filter_type, matchers, py
     assert matchers.InstanceOf(type_) in builder.filters
 
 
-@pytest.mark.usefixtures("group_service")
 def test_default_querybuilder_includes_registered_filters(pyramid_request):
     filter_factory = mock.Mock(return_value=mock.sentinel.MY_FILTER,
                                spec_set=[])
@@ -289,7 +285,6 @@ def test_default_querybuilder_includes_registered_filters(pyramid_request):
     assert mock.sentinel.MY_FILTER in builder.filters
 
 
-@pytest.mark.usefixtures("group_service")
 @pytest.mark.parametrize('matcher_type', [
     'AnyMatcher',
     'TagsMatcher',
@@ -327,11 +322,3 @@ def pyramid_request(pyramid_request):
 @pytest.fixture
 def log(patch):
     return patch('h.search.core.log')
-
-
-@pytest.fixture
-def group_service(pyramid_config):
-    group_service = mock.create_autospec(GroupService, instance=True, spec_set=True)
-    group_service.groupids_readable_by.return_value = ["__world__"]
-    pyramid_config.register_service(group_service, name="group")
-    return group_service

--- a/tests/h/search/old_query_test.py
+++ b/tests/h/search/old_query_test.py
@@ -295,7 +295,6 @@ class TestGroupFilter(object):
         assert groupfilter({}) is None
 
 
-@pytest.mark.usefixtures('group_service')
 class TestGroupAuthFilter(object):
     def test_fetches_readable_groups(self, pyramid_request, group_service):
         pyramid_request.user = mock.sentinel.user
@@ -312,12 +311,6 @@ class TestGroupAuthFilter(object):
         result = filter_({})
 
         assert result == {'terms': {'group': ['group-a', 'group-b']}}
-
-    @pytest.fixture
-    def group_service(self, patch, pyramid_config):
-        svc = patch('h.services.group.GroupService')
-        pyramid_config.register_service(svc, name='group')
-        return svc
 
 
 class TestUriFilter(object):


### PR DESCRIPTION
Enable the group_service fixture automatically for all search tests. A lot of search tests need this fixture, so avoid them all having to enable it one by one.