### PR TITLE
Add tests for TopLevelAnnotationsFilter

### DIFF
--- a/h/activity/query.py
+++ b/h/activity/query.py
@@ -18,9 +18,9 @@ from h.search import parser
 from h.search.query import (
     AuthorityFilter,
     TagsAggregation,
-    TopLevelAnnotationsFilter,
     UsersAggregation,
 )
+from h.search import TopLevelAnnotationsFilter
 
 
 class ActivityResults(namedtuple('ActivityResults', [

--- a/h/search/__init__.py
+++ b/h/search/__init__.py
@@ -4,9 +4,11 @@ from __future__ import unicode_literals
 from h.search.client import get_client
 from h.search.config import init
 from h.search.core import Search
+from h.search.query import TopLevelAnnotationsFilter
 
 __all__ = (
     'Search',
+    'TopLevelAnnotationsFilter',
     'get_client',
     'init',
 )

--- a/tests/h/search/conftest.py
+++ b/tests/h/search/conftest.py
@@ -17,6 +17,21 @@ def group_service(pyramid_config):
 
 
 @pytest.fixture
+def Annotation(factories, index):
+    """Create and index an annotation.
+
+    Looks like factories.Annotation() but automatically uses the build()
+    strategy and automatically indexes the annotation into the test
+    Elasticsearch index.
+    """
+    def _Annotation(**kwargs):
+        annotation = factories.Annotation.build(**kwargs)
+        index(annotation)
+        return annotation
+    return _Annotation
+
+
+@pytest.fixture
 def index(es_client, pyramid_request):
     def _index(*annotations):
         """Index the given annotation(s) into Elasticsearch."""
@@ -24,3 +39,9 @@ def index(es_client, pyramid_request):
             h.search.index.index(es_client, annotation, pyramid_request)
         es_client.conn.indices.refresh(index=es_client.index)
     return _index
+
+
+@pytest.fixture
+def pyramid_request(es_client, pyramid_request):
+    pyramid_request.es = es_client
+    return pyramid_request

--- a/tests/h/search/core_test.py
+++ b/tests/h/search/core_test.py
@@ -3,8 +3,6 @@ from __future__ import unicode_literals
 
 import datetime
 
-import pytest
-
 from h import search
 
 
@@ -223,24 +221,3 @@ class TestSearchWithSeparateReplies(object):
 
         assert len(result.reply_ids) == 3
         assert oldest_reply.id not in result.reply_ids
-
-
-@pytest.fixture
-def Annotation(factories, index):
-    """Create and index an annotation.
-
-    Looks like factories.Annotation() but automatically uses the build()
-    strategy and automatically indexes the annotation into the test
-    Elasticsearch index.
-    """
-    def _Annotation(**kwargs):
-        annotation = factories.Annotation.build(**kwargs)
-        index(annotation)
-        return annotation
-    return _Annotation
-
-
-@pytest.fixture
-def pyramid_request(es_client, pyramid_request):
-    pyramid_request.es = es_client
-    return pyramid_request

--- a/tests/h/search/query_test.py
+++ b/tests/h/search/query_test.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import pytest
+
+from h.search import Search
+from h.search import TopLevelAnnotationsFilter
+
+
+class TestTopLevelAnnotationsFilter(object):
+
+    def test_it_filters_out_replies_but_leaves_annotations_in(self, Annotation, search):
+        annotation = Annotation(shared=True)
+        reply = Annotation(references=[annotation.id], shared=True)
+
+        result = search.run({})
+
+        assert annotation.id in result.annotation_ids
+        assert reply.id not in result.annotation_ids
+
+    @pytest.fixture
+    def search(self, pyramid_request):
+        search = Search(pyramid_request)
+        search.append_filter(TopLevelAnnotationsFilter())
+        return search


### PR DESCRIPTION
Depends on https://github.com/hypothesis/h/pull/5045

These tests are kind of duplicative of the existing [tests for `separate_replies`](https://github.com/hypothesis/h/blob/49fd4cb4e415ac79e8144715bb2f677f3926f678/tests/h/search/core_test.py#L124). The `separate_replies` tests also test that replies are filtered out of `annotation_ids` but annotations are left in. But those are tests for the `separate_replies` argument, which is partly implemented by `TopLevelAnnotationsFilter`, partly by `RepliesMatcher`, and partly by code in `Search` itself. The fact that `TopLevelAnnotationsFilter` and `RepliesMatcher` are used to implement `separate_replies` is an internal implementation detail (`separate_replies` could be refactored to no longer use `TopLevelAnnotationsFilter` and its tests would still pass).

The tests in this PR are tests for `TopLevelAnnotationsFilter` when used directly (without `separate_replies`) as is [done by activity pages](https://github.com/hypothesis/h/blob/362143c17d7cd090255d9d36d6fecfbbb750218e/h/activity/query.py#L171).

Also, `TopLevelAnnotationsFilter` has to have a `TestTopLevelAnnotationsFilter` where you would expect one to be, otherwise it would look like there were no tests for it. Meanwhile, the filtering out of replies (while leaving annotations in) kind of has to be tested by the `separate_replies` tests otherwise `separate_replies` isn't fully tested. (Because of the way the code is written you can't really write a "Test that it uses `TopLevelAnnotationsFilter`" test for `separate_replies` that uses a mock `TopLevelAnnotationsFilter`, you would have to mock out `Builder` or something.)