### PR TITLE
Add stub test classes for testing each filter, matcher and aggregation class

### DIFF
--- a/h/activity/query.py
+++ b/h/activity/query.py
@@ -15,12 +15,10 @@ from h.activity import bucketing
 from h.models import Annotation, Group
 from h.search import Search
 from h.search import parser
-from h.search.query import (
-    AuthorityFilter,
-    TagsAggregation,
-    UsersAggregation,
-)
 from h.search import TopLevelAnnotationsFilter
+from h.search import AuthorityFilter
+from h.search import TagsAggregation
+from h.search import UsersAggregation
 
 
 class ActivityResults(namedtuple('ActivityResults', [

--- a/h/search/__init__.py
+++ b/h/search/__init__.py
@@ -5,10 +5,16 @@ from h.search.client import get_client
 from h.search.config import init
 from h.search.core import Search
 from h.search.query import TopLevelAnnotationsFilter
+from h.search.query import AuthorityFilter
+from h.search.query import TagsAggregation
+from h.search.query import UsersAggregation
 
 __all__ = (
     'Search',
     'TopLevelAnnotationsFilter',
+    'AuthorityFilter',
+    'TagsAggregation',
+    'UsersAggregation',
     'get_client',
     'init',
 )

--- a/tests/h/search/query_test.py
+++ b/tests/h/search/query_test.py
@@ -3,8 +3,7 @@ from __future__ import unicode_literals
 
 import pytest
 
-from h.search import Search
-from h.search import TopLevelAnnotationsFilter
+from h import search
 
 
 class TestTopLevelAnnotationsFilter(object):
@@ -20,6 +19,125 @@ class TestTopLevelAnnotationsFilter(object):
 
     @pytest.fixture
     def search(self, pyramid_request):
-        search = Search(pyramid_request)
-        search.append_filter(TopLevelAnnotationsFilter())
-        return search
+        search_ = search.Search(pyramid_request)
+        search_.append_filter(search.TopLevelAnnotationsFilter())
+        return search_
+
+
+class TestAuthorityFilter(object):
+
+    @pytest.fixture
+    def search(self, pyramid_request):
+        search_ = search.Search(pyramid_request)
+        search_.append_filter(search.AuthorityFilter())
+        return search_
+
+
+class TestAuthFilter(object):
+
+    @pytest.fixture
+    def search(self, pyramid_request):
+        # We don't need to append AuthFilter to Search because it's one of the filters that
+        # Search appends by default.
+        return search.Search(pyramid_request)
+
+
+class TestGroupFilter(object):
+
+    @pytest.fixture
+    def search(self, pyramid_request):
+        # We don't need to append GroupFilter to Search because it's one of the filters that
+        # Search appends by default.
+        return search.Search(pyramid_request)
+
+
+class TestGroupAuthFilter(object):
+
+    @pytest.fixture
+    def search(self, pyramid_request):
+        # We don't need to append GroupAuthFilter to Search because it's one of the filters that
+        # Search appends by default.
+        return search.Search(pyramid_request)
+
+
+class TestUserFilter(object):
+
+    @pytest.fixture
+    def search(self, pyramid_request):
+        # We don't need to append UserFilter to Search because it's one of the filters that
+        # Search appends by default.
+        return search.Search(pyramid_request)
+
+
+class TestUriFilter(object):
+
+    @pytest.fixture
+    def search(self, pyramid_request):
+        # We don't need to append UriFilter to Search because it's one of the filters that
+        # Search appends by default.
+        return search.Search(pyramid_request)
+
+
+class TestDeletedFilter(object):
+
+    @pytest.fixture
+    def search(self, pyramid_request):
+        # We don't need to append DeletedFilter to Search because it's one of the filters that
+        # Search appends by default.
+        return search.Search(pyramid_request)
+
+
+class TestNipsaFilter(object):
+
+    @pytest.fixture
+    def search(self, pyramid_request):
+        # We don't need to append NipsaFilter to Search because it's one of the filters that
+        # Search appends by default.
+        return search.Search(pyramid_request)
+
+
+class TestAnyMatcher(object):
+
+    @pytest.fixture
+    def search(self, pyramid_request):
+        # We don't need to append AnyMatcher to Search because it's one of the matchers that
+        # Search appends by default.
+        return search.Search(pyramid_request)
+
+
+class TestTagsMatcher(object):
+
+    @pytest.fixture
+    def search(self, pyramid_request):
+        # We don't need to append TagsMatcher to Search because it's one of the matchers that
+        # Search appends by default.
+        return search.Search(pyramid_request)
+
+
+class TestRepliesMatcher(object):
+
+    # Note: tests will have to append a RepliesMatcher object to the search
+    # (search.append_matcher(RepliesMatcher(annotation_ids))) passing to RepliesMatcher the
+    # annotation_ids of the annotations that the test wants to search for replies to.
+
+    @pytest.fixture
+    def search(self, pyramid_request):
+        return search.Search(pyramid_request)
+
+
+class TestTagsAggregation(object):
+
+    @pytest.fixture
+    def search(self, pyramid_request):
+        search_ = search.Search(pyramid_request)
+        search_.append_aggregation(search.TagsAggregation())
+        return search_
+
+
+class TestUsersAggregation(object):
+
+    @pytest.fixture
+    def search(self, pyramid_request):
+        search_ = search.Search(pyramid_request)
+        search_.append_aggregation(search.UsersAggregation())
+        return search_


### PR DESCRIPTION
My plan is to make a sprint card for each one of these test classes, to fill them out with the actual tests.

I don't think we need to or should write all of the tests first and _then_ start the work of making h query Es 6.2 though. I think the cards that I will write will be cards like "Fill out the tests for FooFilter and get FooFilter working with Es 6.2". So we'll be adding Es 6.2 querying functionality one piece at a time and adding tests (that run against both Es 1 and Es 6) as we go.

`TestTopLevelAnnotationsFilter` at the top of the file has already been filled out in a previous PR as an example (only works against Es 1 so far of course) so the other test classes can follow that example.

Each test class has its own `search` fixture with the relevant filter, matcher or aggregation class appended.

In the case of the test classes for the default filters and matchers (see [`_default_querybuilder()`](https://github.com/hypothesis/h/blob/7af1b52e48672ea2f04f470422df94540625bf7d/h/search/core.py#L147-L159)) the tests don't need to append them to the `Search` object because they will already be appended by default. This means that the fact that they're used by default is implicitly being tested as well. There's some duplication in that the `search` fixture for each one of these default filter and matcher test classes is exactly the same. But it's only a one-liner and I wanted somewhere to put a comment that the tests know that each thing is used by default.

These classes don't cover all of the search functionality to test - they don't cover stuff in `core.py` and in `query.py::Builder`. That `core.py` and `query.py::Builder` code _is_ being exercised though when these filter/matcher/aggregator class tests use the real `Search` and `Search.run()`. So it's not clear yet exactly what in  `core.py` and `query.py::Builder` needs to be tested separately.