### PR TITLE
Establish connection to v6 Elasticsearch in `h.search.connection`

### DIFF
--- a/h/search/__init__.py
+++ b/h/search/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import unicode_literals
 from h.search.client import get_client
 from h.search.config import init
+from h.search.connection import connect
 from h.search.core import Search
 from h.search.query import TopLevelAnnotationsFilter
 from h.search.query import AuthorityFilter
@@ -17,6 +18,7 @@ __all__ = (
     'UsersAggregation',
     'get_client',
     'init',
+    'connect'
 )
 
 

--- a/h/search/connection.py
+++ b/h/search/connection.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import os
+
+from elasticsearch_dsl import connections
+
+# TODO: Temporary hard-coding of ELASTICSEARCH_URL: this should come from settings
+ELASTICSEARCH_URL = os.environ.get("ELASTICSEARCH_URL", "http://localhost:9201")
+
+
+# TODO: Make `hosts` a required argument
+def connect(hosts=[ELASTICSEARCH_URL], **kwargs):
+    """
+    Establish a 'default` connection to Elasticsearch
+
+    This establishes a connection to newer (v6.x) Elasticsearch which is
+    available as the 'default' connection henceforth via `elasticsearch_dsl`
+
+    e.g. `elasticsearch_dsl.get_connection()`
+    """
+    connections.create_connection(hosts=hosts, **kwargs)

--- a/h/search/connection.py
+++ b/h/search/connection.py
@@ -17,6 +17,10 @@ def connect(alias='default', hosts=[ELASTICSEARCH_URL], **kwargs):
     This establishes a connection to newer (v6.x) Elasticsearch which is
     available as the 'default' connection henceforth via `elasticsearch_dsl`
 
-    e.g. `elasticsearch_dsl.get_connection()`
+    e.g. `elasticsearch_dsl.connections.get_connection()`
     """
+    # TODO invoke this during request bootstrapping
+    # TODO settings munging if/as needed
+    # TODO AWS auth
+    # TODO certs
     connections.create_connection(alias, hosts=hosts, **kwargs)

--- a/h/search/connection.py
+++ b/h/search/connection.py
@@ -10,7 +10,7 @@ ELASTICSEARCH_URL = os.environ.get("ELASTICSEARCH_URL", "http://localhost:9201")
 
 
 # TODO: Make `hosts` a required argument
-def connect(hosts=[ELASTICSEARCH_URL], **kwargs):
+def connect(alias='default', hosts=[ELASTICSEARCH_URL], **kwargs):
     """
     Establish a 'default` connection to Elasticsearch
 
@@ -19,4 +19,4 @@ def connect(hosts=[ELASTICSEARCH_URL], **kwargs):
 
     e.g. `elasticsearch_dsl.get_connection()`
     """
-    connections.create_connection(hosts=hosts, **kwargs)
+    connections.create_connection(alias, hosts=hosts, **kwargs)

--- a/tests/common/fixtures/elasticsearch.py
+++ b/tests/common/fixtures/elasticsearch.py
@@ -9,6 +9,7 @@ from h import search
 
 ELASTICSEARCH_HOST = os.environ.get("ELASTICSEARCH_HOST", "http://localhost:9200")
 ELASTICSEARCH_INDEX = "hypothesis-test"
+ELASTICSEARCH_URL = os.environ.get("ELASTICSEARCH_URL", "http://localhost:9201")
 
 
 @pytest.fixture
@@ -17,10 +18,19 @@ def es_client(delete_all_elasticsearch_documents):
     return _es_client()
 
 
+@pytest.fixture
+def es_connect():
+    # TODO handle deleting things out of this connection's index as
+    # the `es_client` fixture does
+    search.connect(hosts=[ELASTICSEARCH_URL])
+
+
 @pytest.fixture(scope="session", autouse=True)
 def init_elasticsearch(request):
-    """Initialize the test Elasticsearch index once per test session."""
+    """Initialize the test (old) Elasticsearch index once per test session."""
     client = _es_client()
+    """Connect to the newer v6.x instance of Elasticsearch once per test session"""
+    es_connect()
 
     def maybe_delete_index():
         """Delete the test index if it exists."""

--- a/tests/h/search/connection_test.py
+++ b/tests/h/search/connection_test.py
@@ -11,6 +11,7 @@ from h.search.connection import connect
 
 
 def remove_connection():
+    """Remove elasticsearch connection made in test"""
     connections.remove_connection('foobar')
 
 

--- a/tests/h/search/connection_test.py
+++ b/tests/h/search/connection_test.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from elasticsearch_dsl.connections import connections
+from h import search
+from h.search.connection import connect
+
+
+class TestConnection(object):
+    def test_connect_is_available_in_search_api(self):
+        assert connect == search.connect
+
+    def test_connect_creates_default_connection(self):
+        # search.connect is invoked as part of test bootstrapping
+        # so the connection should already be established
+        assert connections.get_connection()
+        assert connections.get_connection('default')
+        assert connections.get_connection() == connections.get_connection('default')

--- a/tests/h/search/connection_test.py
+++ b/tests/h/search/connection_test.py
@@ -6,6 +6,10 @@ from h import search
 from h.search.connection import connect
 
 
+def remove_connection():
+    connections.remove_connection('foobar')
+
+
 class TestConnection(object):
     def test_connect_is_available_in_search_api(self):
         assert connect == search.connect
@@ -16,3 +20,10 @@ class TestConnection(object):
         assert connections.get_connection()
         assert connections.get_connection('default')
         assert connections.get_connection() == connections.get_connection('default')
+
+    def test_connect_allows_additional_aliases(self, request):
+        request.addfinalizer(remove_connection)
+
+        connections.create_connection(alias='foobar')
+
+        assert connections.get_connection('foobar')

--- a/tests/h/search/connection_test.py
+++ b/tests/h/search/connection_test.py
@@ -5,6 +5,7 @@ import pytest
 
 from elasticsearch_dsl.connections import connections
 from elasticsearch_dsl import Index
+from elasticsearch.exceptions import ConnectionError
 
 from h import search
 from h.search.connection import connect
@@ -44,7 +45,6 @@ class TestConnection(object):
         request.addfinalizer(remove_connection)
 
         connections.create_connection(alias='foobar', hosts=['localhost:2323'])
-        with pytest.raises(Exception) as e:
-            Index('whatever', using='foobar').exists()
 
-        assert e.typename == 'ConnectionError'
+        with pytest.raises(ConnectionError):
+            Index('whatever', using='foobar').exists()


### PR DESCRIPTION
This WIP PR outlines a proposed approach to connecting to the newer version of ES. It is likely that the discussion on this PR could get chattery, which is just fine—I'll close this PR and open a subsequent one when/if things get to a "might actually wanna merge this" state.

My approach involves not trying to solve too many unknowns at once. While I like the simplicity of creating a connection using `elasticsearch_dsl`'s wrapping of `Elasticsearch`, we may need more bells and whistles down the road. But why jump to conclusions? "Seems OK for now!" Optimize later :).

The current code comes with a long list of TODOs, many dependent on the currently-in-flight refactoring of settings. As it stands, the connection to the new ES has been added to search bootstrapping but has not been added to the actual app request lifecycle/bootstrapping. All in good time as we get this more sorted out.

See (forthcoming) code comments for more details.