### PR TITLE
Replace finalizers with yield in test fixtures

### DIFF
--- a/tests/common/fixtures/__init__.py
+++ b/tests/common/fixtures/__init__.py
@@ -3,11 +3,9 @@ from __future__ import unicode_literals
 
 from tests.common.fixtures.elasticsearch import es_client
 from tests.common.fixtures.elasticsearch import init_elasticsearch
-from tests.common.fixtures.elasticsearch import delete_all_elasticsearch_documents
 
 
 __all__ = (
     "es_client",
     "init_elasticsearch",
-    "delete_all_elasticsearch_documents",
 )

--- a/tests/common/fixtures/elasticsearch.py
+++ b/tests/common/fixtures/elasticsearch.py
@@ -29,23 +29,18 @@ def es_connect():
 def init_elasticsearch(request):
     """Initialize the test (old) Elasticsearch index once per test session."""
     client = _es_client()
+    # Initialize the test search index.
+    search.init(es_client)
     """Connect to the newer v6.x instance of Elasticsearch once per test session"""
     es_connect()
 
-    def maybe_delete_index():
-        """Delete the test index if it exists."""
-        if client.conn.indices.exists(index=ELASTICSEARCH_INDEX):
-            client.conn.indices.delete(index=ELASTICSEARCH_INDEX)
+
+    yield es_client
 
     # Delete the test search index at the end of the test run.
-    request.addfinalizer(maybe_delete_index)
-
-    # Delete the test search index at the start of the run, just in case it
-    # was somehow left behind by a previous test run.
-    maybe_delete_index()
-
-    # Initialize the test search index.
-    search.init(client)
+    if es_client.conn.indices.exists(index=ELASTICSEARCH_INDEX):
+        es_client.conn.indices.delete(index=ELASTICSEARCH_INDEX)
+    # Todo: call es_disconnect to disconnect from v6.x es.
 
 
 @pytest.fixture

--- a/tests/common/fixtures/elasticsearch.py
+++ b/tests/common/fixtures/elasticsearch.py
@@ -48,17 +48,6 @@ def init_elasticsearch(request):
     # Todo: call es_disconnect to disconnect from v6.x es.
 
 
-@pytest.fixture
-def delete_all_elasticsearch_documents(request):
-    """Delete everything from the test search index after each test."""
-    client = _es_client()
-
-    def delete_everything():
-        client.conn.delete_by_query(index=client.index, body={"query": {"match_all": {}}})
-
-    request.addfinalizer(delete_everything)
-
-
 def _es_client():
     """Return a :py:class:`h.search.client.Client` for the test search index."""
     return search.get_client({"es.host": ELASTICSEARCH_HOST, "es.index": ELASTICSEARCH_INDEX})

--- a/tests/common/fixtures/elasticsearch.py
+++ b/tests/common/fixtures/elasticsearch.py
@@ -13,9 +13,14 @@ ELASTICSEARCH_URL = os.environ.get("ELASTICSEARCH_URL", "http://localhost:9201")
 
 
 @pytest.fixture
-def es_client(delete_all_elasticsearch_documents):
+def es_client():
     """A :py:class:`h.search.client.Client` for the test search index."""
-    return _es_client()
+    client = _es_client()
+
+    yield client
+
+    # Delete everything from the test search index after each test.
+    client.conn.delete_by_query(index=client.index, body={"query": {"match_all": {}}})
 
 
 @pytest.fixture

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -10,7 +10,6 @@ from webtest import TestApp
 from h._compat import text_type
 from tests.common.fixtures import es_client  # noqa: F401
 from tests.common.fixtures import init_elasticsearch  # noqa: F401
-from tests.common.fixtures import delete_all_elasticsearch_documents  # noqa: F401
 from tests.common.fixtures.elasticsearch import ELASTICSEARCH_HOST
 from tests.common.fixtures.elasticsearch import ELASTICSEARCH_INDEX
 
@@ -78,7 +77,7 @@ def pyramid_app():
 # Always unconditionally wipe the Elasticsearch index after every functional
 # test.
 @pytest.fixture(autouse=True)  # noqa: F811
-def always_delete_all_elasticsearch_documents(delete_all_elasticsearch_documents):
+def always_delete_all_elasticsearch_documents(es_client):
     pass
 
 

--- a/tests/h/conftest.py
+++ b/tests/h/conftest.py
@@ -26,7 +26,6 @@ from h.settings import database_url
 from h._compat import text_type
 from tests.common.fixtures import es_client  # noqa: F401
 from tests.common.fixtures import init_elasticsearch  # noqa: F401
-from tests.common.fixtures import delete_all_elasticsearch_documents  # noqa: F401
 
 TEST_AUTHORITY = 'example.com'
 TEST_DATABASE_URL = database_url(os.environ.get('TEST_DATABASE_URL',

--- a/tests/h/streamer/websocket_test.py
+++ b/tests/h/streamer/websocket_test.py
@@ -240,8 +240,8 @@ class TestHandleMessage(object):
             None: unknown_handler,
         }, clear=True)
         handlers = patcher.start()
-        request.addfinalizer(patcher.stop)
-        return handlers
+        yield handlers
+        patcher.stop()
 
 
 class TestHandleClientIDMessage(object):


### PR DESCRIPTION
See https://docs.pytest.org/en/latest/fixture.html#fixture-finalization-executing-teardown-code for details. Instead of using finalizer callbacks which are a bit indirect use yield which explicitly implements setup, return value, and teardown behavior for a fixture.