### PR TITLE
Replace HKDF implementation from cryptography

### DIFF
--- a/h/security.py
+++ b/h/security.py
@@ -3,16 +3,13 @@
 from __future__ import unicode_literals
 
 import base64
+import hashlib
 import os
 
-from cryptography.hazmat.primitives import hashes
-from cryptography.hazmat.primitives.kdf.hkdf import HKDF
-from cryptography.hazmat.backends import default_backend
+from hkdf import hkdf_expand, hkdf_extract
 from passlib.context import CryptContext
 
 DEFAULT_ENTROPY = 32
-
-backend = default_backend()
 
 # We use a passlib CryptContext to define acceptable hashing algorithms for
 # passwords. This allows us to easily
@@ -34,7 +31,8 @@ def derive_key(key_material, salt, info):
     """
     Derive a fixed-size (64-byte) key for use in cryptographic operations.
 
-    See https://cryptography.io/en/latest/hazmat/primitives/key-derivation-functions/
+    The key is derived using HKDF with the SHA-512 hash function. See
+    https://tools.ietf.org/html/rfc5869.
 
     :type key_material: str or bytes
     :type salt: bytes
@@ -42,10 +40,9 @@ def derive_key(key_material, salt, info):
     """
     if not isinstance(key_material, bytes):
         key_material = key_material.encode()
-    algorithm = hashes.SHA512()
-    length = algorithm.digest_size
-    hkdf = HKDF(algorithm, length, salt, info, backend)
-    return hkdf.derive(key_material)
+
+    pseudorandom_key = hkdf_extract(salt, key_material, hash=hashlib.sha512)
+    return hkdf_expand(pseudorandom_key, info, length=64, hash=hashlib.sha512)
 
 
 # Implementation modeled on `secrets.token_urlsafe`, new in Python 3.6.

--- a/requirements.in
+++ b/requirements.in
@@ -8,7 +8,6 @@ celery >= 4.1
 certifi
 cffi
 click
-cryptography
 deform < 1.0
 deform-jinja2
 elasticsearch==6.2.0
@@ -18,6 +17,7 @@ enum34
 functools32; python_version < "3.0" # Required by jsonschema, listed here to add environment marker
 gevent
 gunicorn
+hkdf
 itsdangerous
 jsonpointer == 1.0
 jsonschema

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@
 #
 alembic==0.9.7
 amqp==2.2.2               # via kombu
-asn1crypto==0.22.0        # via cryptography
 backports.functools-lru-cache==1.2.1
 bcrypt==3.1.3
 billiard==3.5.0.3         # via celery
@@ -18,7 +17,6 @@ chameleon==2.24           # via deform
 click==6.6
 colander==1.3.1           # via deform
 contextlib2==0.5.4        # via raven
-cryptography==2.1.4
 deform-jinja2==0.5
 deform==0.9.9
 elasticsearch-dsl==6.1.0
@@ -29,9 +27,9 @@ functools32==3.2.3.post2 ; python_version < "3.0"
 gevent==1.2.1
 greenlet==0.4.10          # via gevent
 gunicorn==19.6.0
+hkdf==0.0.3
 html5lib==0.999999999     # via bleach
-idna==2.5                 # via cryptography
-ipaddress==1.0.18         # via cryptography, elasticsearch-dsl
+ipaddress==1.0.18         # via elasticsearch-dsl
 iso8601==0.1.11           # via colander
 itsdangerous==0.24
 jinja2==2.8               # via deform-jinja2, pyramid-jinja2
@@ -67,7 +65,7 @@ repoze.lru==0.6           # via pyramid
 repoze.sendmail==4.3      # via pyramid-mailer
 requests-aws4auth==0.9
 requests==2.13.0          # via requests-aws4auth
-six==1.10.0               # via bcrypt, bleach, cryptography, elasticsearch-dsl, html5lib, python-dateutil
+six==1.10.0               # via bcrypt, bleach, elasticsearch-dsl, html5lib, python-dateutil
 sqlalchemy==1.1.4
 statsd==3.2.1
 transaction==2.1.2

--- a/tests/h/security_test.py
+++ b/tests/h/security_test.py
@@ -2,9 +2,11 @@
 
 from __future__ import unicode_literals
 
+from binascii import hexlify, unhexlify
 import string
 
 from passlib.context import CryptContext
+import pytest
 from hypothesis import assume
 from hypothesis import strategies as st
 from hypothesis import given
@@ -94,6 +96,38 @@ class TestDeriveKey(object):
     def test_it_encodes_str_key_material(self):
         derived = derive_key('akey', b'somesalt', b'some-info')
         assert len(derived) == 64
+
+    # Test vectors adapted from the HKDF RFC by https://www.kullo.net/blog/hkdf-sha-512-test-vectors/
+    @pytest.mark.parametrize('info,key,salt,expected', [
+        ('f0f1f2f3f4f5f6f7f8f9', '0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b',
+         '000102030405060708090a0b0c', '832390086cda71fb47625bb5ceb168e4c8e26a1a16ed34d9fc7fe92c1481579338da362cb8d9f925d7cb'),
+
+        ('b0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d'
+         '2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff',
+
+         '000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20212'
+         '2232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f',
+
+         '606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f80818'
+         '2838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7a8a9aaabacadaeaf',
+
+         'ce6c97192805b346e6161e821ed165673b84f400a2b514b2fe23d84cd189ddf1b695b'
+         '48cbd1c8388441137b3ce28f16aa64ba33ba466b24df6cfcb021ecff235f6a2056ce3af1de44d572097a8505d9e7a93'),
+
+        ('f0f1f2f3f4f5f6f7f8f9', '0b0b0b0b0b0b0b0b0b0b0b',
+         '000102030405060708090a0b0c', '7413e8997e020610fbf6823f2ce14bff01875db1ca55f68cfcf3954dc8aff53559bd5e3028b080f7c068'),
+    ])
+    def test_it_produces_correct_result(self, info, key, salt, expected):
+        info_bytes = unhexlify(info)
+        salt_bytes = unhexlify(salt)
+        key_bytes = unhexlify(key)
+
+        derived = derive_key(key_bytes, salt_bytes, info_bytes)
+
+        # The test vectors have key lengths above and below the fixed-sized
+        # output of `derive_key`. Only compare the corresponding prefixes.
+        compare_len = min(len(expected), 64 * 2)
+        assert hexlify(derived)[:compare_len] == expected[:compare_len].encode()
 
 
 def test_password_context():


### PR DESCRIPTION
The `cryptography` Python library currently fails to build against the
latest version of `libressl-dev` in the Alpine release (3.7) that we are using.
`libressl-dev` is in turn a dependency of `postgresql-dev`.

Fortunately we only use `cryptography` for the well-known HKDF key
derivation function. This commit replaces the `cryptography` package
with the very small `hkdf` package which only depends on `hashlib` and
`hmac` from the Python standard library (which do use OpenSSL / LibreSSL
under the hood).

Add tests for the output of `derive_key` based on the vectors from the
HKDF RFC to verify that the outputs are the same as with the previous
implementation.