### PR TITLE
Specify index to search in `search` fixture

### DIFF
--- a/tests/h/search/index_test.py
+++ b/tests/h/search/index_test.py
@@ -308,4 +308,5 @@ class SearchResponseWithIDs(Matcher):
 
 @pytest.fixture
 def search(es_client):
-    return elasticsearch1_dsl.Search(using=es_client.conn).fields([])
+    return elasticsearch1_dsl.Search(using=es_client.conn,
+                                     index=es_client.index).fields([])


### PR DESCRIPTION
If no index is specified, `search` will find annotations across all
indexes, not just the "hypothesis-test" index which is cleaned after
each test run.