### PR TITLE
Add ES 6.x connection to application bootstrapping

### DIFF
--- a/h/search/__init__.py
+++ b/h/search/__init__.py
@@ -24,6 +24,21 @@ __all__ = (
 
 def includeme(config):
     settings = config.registry.settings
+
+    # Connection to version 6.x of ES follows
+    # TODO The munging of these settings may change when settings refactoring complete
+    kwargs = {}
+    kwargs['max_retries'] = settings.get('es.client.max_retries', 3)
+    kwargs['retry_on_timeout'] = settings.get('es.client.retry_on_timeout', False)
+    kwargs['timeout'] = settings.get('es.client.timeout', 10)
+
+    if 'es.client_poolsize' in settings:
+        kwargs['maxsize'] = settings['es.client_poolsize']
+
+    # TODO should pass `hosts` param once that setting (ELASTICSEARCH_URL) is in place
+    connect(**kwargs)
+
+    # Connection to old (ES1.5) follows
     settings.setdefault('es.host', 'http://localhost:9200')
     settings.setdefault('es.index', 'hypothesis')
 

--- a/h/search/connection.py
+++ b/h/search/connection.py
@@ -12,15 +12,25 @@ ELASTICSEARCH_URL = os.environ.get("ELASTICSEARCH_URL", "http://localhost:9201")
 # TODO: Make `hosts` a required argument
 def connect(alias='default', hosts=[ELASTICSEARCH_URL], **kwargs):
     """
-    Establish a 'default` connection to Elasticsearch
+    Establish a connection to Elasticsearch through elasticsearch_dsl
 
-    This establishes a connection to newer (v6.x) Elasticsearch which is
-    available as the 'default' connection henceforth via `elasticsearch_dsl`
+    This establishes a connection to newer (v6.x) Elasticsearch. Unless the
+    `alias` parameter has a value other than "default", this connection will
+    then be available as the 'default' connection for `elasticsearch_dsl`
 
-    e.g. `elasticsearch_dsl.connections.get_connection()`
+    e.g. `elasticsearch_dsl.connections.get_connection()` will return the
+    connection established here
+
+    kwargs get passed on to Elasticsearch
+
+    .. seealso:: https://elasticsearch-py.readthedocs.io/en/master/api.html#elasticsearch
+
+    :param alias: The alias to use for referencing the created connection. Will
+                  create a "default" connection unless this param has a value
+                  other than `default`
+    :param hosts: List of host(s) (e.g. 'http://foo.com:9200') to connect to
     """
-    # TODO invoke this during request bootstrapping
-    # TODO settings munging if/as needed
-    # TODO AWS auth
-    # TODO certs
-    connections.create_connection(alias, hosts=hosts, **kwargs)
+    connections.create_connection(alias,
+                                  hosts=hosts,
+                                  verify_certs=True,
+                                  **kwargs)

--- a/tests/h/search/connection_test.py
+++ b/tests/h/search/connection_test.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 
 import pytest
+import mock
 
 from elasticsearch_dsl.connections import connections
 from elasticsearch_dsl import Index
@@ -34,6 +35,24 @@ class TestConnection(object):
 
         assert connections.get_connection('foobar')
 
+    def test_connect_defaults_to_default_alias(self, connections_):
+        connect()
+
+        connections_.create_connection.assert_called_once_with('default',
+                                                               hosts=mock.ANY,
+                                                               verify_certs=True)
+
+    def test_connect_passes_kwargs_to_create_connection(self, connections_):
+        kwargs = {
+            'foo': 'bar'
+        }
+        connect(**kwargs)
+
+        connections_.create_connection.assert_called_once_with('default',
+                                                               hosts=mock.ANY,
+                                                               verify_certs=True,
+                                                               **kwargs)
+
     def test_connect_does_not_raise_on_invalid_host(self, request):
         request.addfinalizer(remove_connection)
 
@@ -48,3 +67,8 @@ class TestConnection(object):
 
         with pytest.raises(ConnectionError):
             Index('whatever', using='foobar').exists()
+
+
+@pytest.fixture
+def connections_(patch):
+    return patch('h.search.connection.connections')


### PR DESCRIPTION
This PR finishes out some connection settings work and adds a call to `connect()` in the application bootstrapping phase.

The result is that a connection will be made to ES 6 instances, but that connection is not yet accessed or used otherwise.