### PR TITLE
Small fixes and cleanup.

### DIFF
--- a/tests/h/search/index_test.py
+++ b/tests/h/search/index_test.py
@@ -142,16 +142,17 @@ class TestIndex(object):
         annotation_1 = factories.Annotation.build(userid="acct:someone@example.com")
         annotation_2 = factories.Annotation.build(userid="acct:Someone@example.com")
 
-        index(annotation_1)
-        index(annotation_2)
+        index(annotation_1, annotation_2)
 
-        a = elasticsearch1_dsl.A('terms', field='user_raw')
-        search.aggs.bucket('user_raw_terms', a)
+        user_aggregation = elasticsearch1_dsl.A('terms', field='user_raw')
+        search.aggs.bucket('user_raw_terms', user_aggregation)
 
         response = search.execute()
 
-        user_bucket_1 = next(bucket for bucket in response.aggregations.user_raw_terms.buckets if bucket["key"] == "acct:someone@example.com")
-        user_bucket_2 = next(bucket for bucket in response.aggregations.user_raw_terms.buckets if bucket["key"] == "acct:Someone@example.com")
+        user_bucket_1 = next(bucket for bucket in response.aggregations.user_raw_terms.buckets
+                             if bucket["key"] == "acct:someone@example.com")
+        user_bucket_2 = next(bucket for bucket in response.aggregations.user_raw_terms.buckets
+                             if bucket["key"] == "acct:Someone@example.com")
 
         assert user_bucket_1["doc_count"] == 1
         assert user_bucket_2["doc_count"] == 1
@@ -171,11 +172,10 @@ class TestIndex(object):
         annotation_1 = factories.Annotation.build(id="test_annotation_id_1", tags=["Hello"])
         annotation_2 = factories.Annotation.build(id="test_annotation_id_2", tags=["hello"])
 
-        index(annotation_1)
-        index(annotation_2)
+        index(annotation_1, annotation_2)
 
-        a = elasticsearch1_dsl.A('terms', field='tags_raw')
-        search.aggs.bucket('tags_raw_terms', a)
+        tags_aggregation = elasticsearch1_dsl.A('terms', field='tags_raw')
+        search.aggs.bucket('tags_raw_terms', tags_aggregation)
 
         response = search.execute()
 
@@ -237,9 +237,9 @@ class TestIndex(object):
 
         index(annotation1, annotation2)
 
-        response1 = search.filter("term", thread_ids=[annotation1.id]).execute()
+        response = search.filter("term", thread_ids=[annotation1.id]).execute()
 
-        assert SearchResponseWithIDs([annotation2.id]) == response1
+        assert SearchResponseWithIDs([annotation2.id]) == response
 
     @pytest.fixture
     def annotations(self, factories, index):


### PR DESCRIPTION
Address comments in feedback on #5037 : 
- renamed `response1` to `response` in one of the tests since there is really just one response. 
- renamed very short variable name `a` to `user_aggregation` and `tags_aggregation` to make more sense
- broke a vey long line to increase readability
- pass multiple annotations to `index` instead of calling `index` once per annotation.  It is slightly more efficient to do this because each call to index triggers a "refresh" of the search index in order to make the changes visible in search results. Indexing several annotations in one call means that only one refresh operation is needed. (See: https://github.com/hypothesis/h/pull/5037#discussion_r191740462)