### PR TITLE
Remove WebSocket server dependency on `h.search`

### DIFF
--- a/conf/development-websocket.ini
+++ b/conf/development-websocket.ini
@@ -1,7 +1,8 @@
 [app:main]
 use: call:h.websocket:create_app
 
-# Elasticsearch configuration
+# Elasticsearch configuration. The WebSocket does not actually use ES but
+# it does use the same config loading code which checks for these settings.
 es.host: http://localhost:9200
 es.url: http://localhost:9201
 

--- a/h/websocket.py
+++ b/h/websocket.py
@@ -157,7 +157,6 @@ def create_app(global_config, **settings):
     config.include('h.authz')
     config.include('h.db')
     config.include('h.session')
-    config.include('h.search')
     config.include('h.sentry')
     config.include('h.services')
     config.include('h.stats')


### PR DESCRIPTION
I cannot see any references to functionality from `h.search` in
`h.websocket`, `h.realtime` or `h.streamer`. I can imagine there would
have been a dependency back when Elasticsearch was our primary data
store but not any longer.

Removing this dependency may make it slightly easier to run the
WebSocket server in a separate container / Elastic Beanstalk application
in future, something we may want to do for scaling reasons.

----

Since our integrated test coverage of the WebSocket server is not great, I would suggest testing this manually as follows:

1. Run the dev server, verify that there are no errors from the WS process
2. Open up a couple of browser tabs to the same page with the dev client loaded and verify that basic WS functionality still works:
   - Annotating in one tab should result in a red "update available" notification in the other tab
   - Creating a group on the h web pages should auto-update the groups list in open tabs
   - Leaving a group via the h web pages should auto-update the groups list in open tabs