### PR TITLE
Mark `SECRET_KEY` as a required setting

### DIFF
--- a/h/config.py
+++ b/h/config.py
@@ -56,7 +56,7 @@ def configure(environ=None, settings=None):
     settings_manager.set('statsd.prefix', 'STATSD_PREFIX')
 
     # Configuration for Pyramid
-    settings_manager.set('secret_key', 'SECRET_KEY', type_=bytes)
+    settings_manager.set('secret_key', 'SECRET_KEY', type_=bytes, required=True)
     settings_manager.set('secret_salt', 'SECRET_SALT', type_=bytes, default=DEFAULT_SALT)
 
     # Configuration for h
@@ -110,12 +110,6 @@ def configure(environ=None, settings=None):
 
     # Get resolved settings.
     settings = settings_manager.settings
-
-    if 'secret_key' not in settings:
-        log.warn('No secret key provided: using transient key. Please '
-                 'configure the secret_key setting or the SECRET_KEY '
-                 'environment variable!')
-        settings['secret_key'] = os.urandom(64)
 
     # Set up SQLAlchemy debug logging
     if 'debug_query' in settings:

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -21,6 +21,7 @@ TEST_SETTINGS = {
     'h.app_url': 'http://example.com',
     'h.authority': 'example.com',
     'pyramid.debug_all': True,
+    'secret_key': 'notasecret',
     'sqlalchemy.url': os.environ.get('TEST_DATABASE_URL',
                                      'postgresql://postgres@localhost/htest')
 }

--- a/tests/h/config_test.py
+++ b/tests/h/config_test.py
@@ -6,18 +6,6 @@ import pytest
 from h.config import configure
 
 
-def test_configure_generates_secret_key_if_missing():
-    config = configure(environ={}, settings={})
-
-    assert 'secret_key' in config.registry.settings
-
-
-def test_configure_doesnt_override_secret_key():
-    config = configure(environ={}, settings={'secret_key': 'foobar'})
-
-    assert config.registry.settings['secret_key'] == 'foobar'
-
-
 @pytest.mark.parametrize('env_var,env_val,setting_name,setting_val', [
     (None, None, 'h.db_session_checks', True),
     ('DB_SESSION_CHECKS', "False", 'h.db_session_checks', False),
@@ -27,7 +15,11 @@ def test_configure_doesnt_override_secret_key():
 ])
 def test_configure_updates_settings_from_env_vars(env_var, env_val, setting_name, setting_val):
     environ = {env_var: env_val} if env_var else {}
-    settings_from_conf = {'h.db_session_checks': True}
+    settings_from_conf = {'h.db_session_checks': True,
+
+                          # Required settings
+                          'secret_key': 'notasecret',
+                          }
 
     config = configure(environ=environ, settings=settings_from_conf)
 


### PR DESCRIPTION
This PR leverages the functionality added in #5033 to be able to mark settings as required in production environments to fix an issue I ran into setting up a new h deployment for load-testing last week.

The `SECRET_KEY` value is used to derive the key for signing cookie
sessions. The previous behavior of generating a random value if this is
not set is not useful in a production environment because each web
process generates a different value and therefore cookies signed by one
process fail to validate when submitted to a different web process. Not
setting a `SECRET_KEY` also means that existing cookies become invalid
after a server restart.