### PR TITLE
Mark Elasticsearch and Postgres URLs as required settings

### DIFF
--- a/conf/app.ini
+++ b/conf/app.ini
@@ -10,9 +10,6 @@ pipeline:
 [app:h]
 use: call:h.app:create_app
 
-# SQLAlchemy configuration -- See SQLAlchemy documentation
-sqlalchemy.url: postgresql://postgres@localhost/postgres
-
 [filter:proxy-prefix]
 use: egg:PasteDeploy#prefix
 

--- a/conf/development-websocket.ini
+++ b/conf/development-websocket.ini
@@ -2,6 +2,7 @@
 use: call:h.websocket:create_app
 
 # Elasticsearch configuration
+es.host: http://localhost:9200
 es.url: http://localhost:9201
 
 # Use gevent-compatible transport for the Sentry client

--- a/conf/websocket.ini
+++ b/conf/websocket.ini
@@ -4,9 +4,6 @@ use: call:h.websocket:create_app
 # Use gevent-compatible transport for the Sentry client
 raven.transport: gevent
 
-# SQLAlchemy configuration -- See SQLAlchemy documentation
-sqlalchemy.url: postgresql://postgres@localhost/postgres
-
 [server:main]
 use: egg:gunicorn
 host: 0.0.0.0

--- a/h/config.py
+++ b/h/config.py
@@ -56,7 +56,7 @@ def configure(environ=None, settings=None):
     settings_manager.set('statsd.prefix', 'STATSD_PREFIX')
 
     # Configuration for Pyramid
-    settings_manager.set('secret_key', 'SECRET_KEY', type_=bytes)
+    settings_manager.set('secret_key', 'SECRET_KEY', type_=bytes, required=True)
     settings_manager.set('secret_salt', 'SECRET_SALT', type_=bytes, default=DEFAULT_SALT)
 
     # Configuration for h
@@ -110,12 +110,6 @@ def configure(environ=None, settings=None):
 
     # Get resolved settings.
     settings = settings_manager.settings
-
-    if 'secret_key' not in settings:
-        log.warn('No secret key provided: using transient key. Please '
-                 'configure the secret_key setting or the SECRET_KEY '
-                 'environment variable!')
-        settings['secret_key'] = os.urandom(64)
 
     # Set up SQLAlchemy debug logging
     if 'debug_query' in settings:

--- a/h/config.py
+++ b/h/config.py
@@ -41,8 +41,8 @@ def configure(environ=None, settings=None):
     settings_manager.set('es.client.max_retries', 'ELASTICSEARCH_CLIENT_MAX_RETRIES', type_=int)
     settings_manager.set('es.client.retry_on_timeout', 'ELASTICSEARCH_CLIENT_RETRY_ON_TIMEOUT', type_=asbool)
     settings_manager.set('es.client.timeout', 'ELASTICSEARCH_CLIENT_TIMEOUT', type_=float)
-    settings_manager.set('es.host', 'ELASTICSEARCH_HOST')
-    settings_manager.set('es.url', 'ELASTICSEARCH_URL'),
+    settings_manager.set('es.host', 'ELASTICSEARCH_HOST', required=True)
+    settings_manager.set('es.url', 'ELASTICSEARCH_URL', required=True),
     settings_manager.set('es.index', 'ELASTICSEARCH_INDEX')
     settings_manager.set('es.aws.access_key_id', 'ELASTICSEARCH_AWS_ACCESS_KEY_ID')
     settings_manager.set('es.aws.region', 'ELASTICSEARCH_AWS_REGION')
@@ -50,7 +50,7 @@ def configure(environ=None, settings=None):
     settings_manager.set('mail.default_sender', 'MAIL_DEFAULT_SENDER')
     settings_manager.set('mail.host', 'MAIL_HOST')
     settings_manager.set('mail.port', 'MAIL_PORT', type_=int)
-    settings_manager.set('sqlalchemy.url', 'DATABASE_URL', type_=database_url)
+    settings_manager.set('sqlalchemy.url', 'DATABASE_URL', type_=database_url, required=True)
     settings_manager.set('statsd.host', 'STATSD_HOST')
     settings_manager.set('statsd.port', 'STATSD_PORT', type_=int)
     settings_manager.set('statsd.prefix', 'STATSD_PREFIX')

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -21,6 +21,7 @@ TEST_SETTINGS = {
     'h.app_url': 'http://example.com',
     'h.authority': 'example.com',
     'pyramid.debug_all': True,
+    'secret_key': 'notasecret',
     'sqlalchemy.url': os.environ.get('TEST_DATABASE_URL',
                                      'postgresql://postgres@localhost/htest')
 }

--- a/tests/h/config_test.py
+++ b/tests/h/config_test.py
@@ -18,7 +18,10 @@ def test_configure_updates_settings_from_env_vars(env_var, env_val, setting_name
     settings_from_conf = {'h.db_session_checks': True,
 
                           # Required settings
+                          'es.host': 'https://es1-search-cluster',
+                          'es.url': 'https://es6-search-cluster',
                           'secret_key': 'notasecret',
+                          'sqlalchemy.url': 'postgres://user@dbhost/dbname',
                           }
 
     config = configure(environ=environ, settings=settings_from_conf)

--- a/tests/h/config_test.py
+++ b/tests/h/config_test.py
@@ -6,18 +6,6 @@ import pytest
 from h.config import configure
 
 
-def test_configure_generates_secret_key_if_missing():
-    config = configure(environ={}, settings={})
-
-    assert 'secret_key' in config.registry.settings
-
-
-def test_configure_doesnt_override_secret_key():
-    config = configure(environ={}, settings={'secret_key': 'foobar'})
-
-    assert config.registry.settings['secret_key'] == 'foobar'
-
-
 @pytest.mark.parametrize('env_var,env_val,setting_name,setting_val', [
     (None, None, 'h.db_session_checks', True),
     ('DB_SESSION_CHECKS', "False", 'h.db_session_checks', False),
@@ -27,7 +15,11 @@ def test_configure_doesnt_override_secret_key():
 ])
 def test_configure_updates_settings_from_env_vars(env_var, env_val, setting_name, setting_val):
     environ = {env_var: env_val} if env_var else {}
-    settings_from_conf = {'h.db_session_checks': True}
+    settings_from_conf = {'h.db_session_checks': True,
+
+                          # Required settings
+                          'secret_key': 'notasecret',
+                          }
 
     config = configure(environ=environ, settings=settings_from_conf)
 


### PR DESCRIPTION
_Depends on https://github.com/hypothesis/h/pull/5064_

The app can't function without these in production environments, so mark them as required settings.

One open question here is whether we should mark `es.url` as required straight away. The current code in `master` *does* require this setting, but you can't use the app with just ES 6 yet, you also have to have an ES 1 cluster. I think it would be friendlier to anyone running h in the meantime to make `es.url` optional until Hypothesis is fully functional with ES 6. Thoughts?