### PR TITLE
Don't apply default search filters, aggregators or matchers in search tests

### DIFF
--- a/h/search/core.py
+++ b/h/search/core.py
@@ -58,6 +58,11 @@ class Search(object):
 
         return SearchResult(total, annotation_ids, reply_ids, aggregations)
 
+    def clear(self):
+        """Clear search filters, aggregators, and matchers."""
+        self.builder = query.Builder()
+        self.reply_builder = query.Builder()
+
     def append_filter(self, filter_):
         """Append a search filter to the annotation and reply query."""
         self.builder.append_filter(filter_)

--- a/tests/h/search/query_test.py
+++ b/tests/h/search/query_test.py
@@ -3,64 +3,63 @@ from __future__ import unicode_literals
 
 import pytest
 
-from h import search
+from h.search import Search, query
 
 
 class TestTopLevelAnnotationsFilter(object):
 
-    def test_it_filters_out_replies_but_leaves_annotations_in(self, Annotation, search):
+    def test_it_filters_out_replies_but_leaves_annotations_in(self, Annotation, filtered_search):
         annotation = Annotation(shared=True)
         reply = Annotation(references=[annotation.id], shared=True)
 
-        result = search.run({})
+        result = filtered_search.run({})
 
         assert annotation.id in result.annotation_ids
         assert reply.id not in result.annotation_ids
 
     @pytest.fixture
-    def search(self, pyramid_request):
-        search_ = search.Search(pyramid_request)
-        search_.append_filter(search.TopLevelAnnotationsFilter())
-        return search_
+    def filtered_search(self, search):
+        search.append_filter(query.TopLevelAnnotationsFilter())
+        return search
 
 
 class TestAuthorityFilter(object):
-    def test_it_filters_out_non_matching_authorities(self, Annotation, search):
+    def test_it_filters_out_non_matching_authorities(self, Annotation, filtered_search):
         annotations_auth1 = [Annotation(userid="acct:foo@auth1", shared=True).id,
                              Annotation(userid="acct:bar@auth1", shared=True).id]
         # Make some other annotations that are of different authority.
         Annotation(userid="acct:bat@auth2", shared=True)
         Annotation(userid="acct:bar@auth3", shared=True)
 
-        result = search.run({})
+        result = filtered_search.run({})
 
         assert set(result.annotation_ids) == set(annotations_auth1)
 
     @pytest.fixture
-    def search(self, pyramid_request):
-        search_ = search.Search(pyramid_request)
-        search_.append_filter(search.AuthorityFilter("auth1"))
-        return search_
+    def filtered_search(self, search):
+        search.append_filter(query.AuthorityFilter("auth1"))
+        return search
 
 
 class TestAuthFilter(object):
-    def test_logged_out_user_can_not_see_private_annotations(self, search, Annotation):
+    def test_logged_out_user_can_not_see_private_annotations(self, filtered_search, Annotation):
         Annotation()
         Annotation()
 
-        result = search.run({})
+        result = filtered_search.run({})
 
         assert not result.annotation_ids
 
-    def test_logged_out_user_can_see_shared_annotations(self, search, Annotation):
+    def test_logged_out_user_can_see_shared_annotations(self, filtered_search, Annotation):
         shared_ids = [Annotation(shared=True).id,
                       Annotation(shared=True).id]
 
-        result = search.run({})
+        result = filtered_search.run({})
 
         assert set(result.annotation_ids) == set(shared_ids)
 
-    def test_logged_in_user_can_only_see_their_private_annotations(self, search, pyramid_config, Annotation):
+    def test_logged_in_user_can_only_see_their_private_annotations(self,
+            filtered_search, pyramid_config, Annotation):
         userid = "acct:bar@auth2"
         pyramid_config.testing_securitypolicy(userid)
         # Make a private annotation from a different user.
@@ -68,97 +67,89 @@ class TestAuthFilter(object):
         users_private_ids = [Annotation(userid=userid).id,
                              Annotation(userid=userid).id]
 
-        result = search.run({})
+        result = filtered_search.run({})
 
         assert set(result.annotation_ids) == set(users_private_ids)
 
-    def test_logged_in_user_can_see_shared_annotations(self, search, pyramid_config, Annotation):
+    def test_logged_in_user_can_see_shared_annotations(self,
+            filtered_search, pyramid_config, Annotation):
         userid = "acct:bar@auth2"
         pyramid_config.testing_securitypolicy(userid)
         shared_ids = [Annotation(userid="acct:foo@auth2", shared=True).id,
                       Annotation(userid=userid, shared=True).id]
 
-        result = search.run({})
+        result = filtered_search.run({})
 
         assert set(result.annotation_ids) == set(shared_ids)
 
     @pytest.fixture
-    def search(self, pyramid_request):
-        # We don't need to append AuthFilter to Search because it's one of the filters that
-        # Search appends by default.
-        return search.Search(pyramid_request)
+    def filtered_search(self, search, pyramid_request):
+        search.append_filter(query.AuthFilter(pyramid_request))
+        return search
 
 
 class TestGroupFilter(object):
 
     @pytest.fixture
-    def search(self, pyramid_request):
-        # We don't need to append GroupFilter to Search because it's one of the filters that
-        # Search appends by default.
-        return search.Search(pyramid_request)
+    def filtered_search(self, search):
+        search.append_filter(query.GroupFilter())
+        return search
 
 
 class TestGroupAuthFilter(object):
 
     @pytest.fixture
-    def search(self, pyramid_request):
-        # We don't need to append GroupAuthFilter to Search because it's one of the filters that
-        # Search appends by default.
-        return search.Search(pyramid_request)
+    def filtered_search(self, search, pyramid_request):
+        search.append_filter(query.GroupAuthFilter(pyramid_request))
+        return search
 
 
 class TestUserFilter(object):
 
     @pytest.fixture
-    def search(self, pyramid_request):
-        # We don't need to append UserFilter to Search because it's one of the filters that
-        # Search appends by default.
-        return search.Search(pyramid_request)
+    def filtered_search(self, search):
+        search.append_filter(query.UserFilter())
+        return search
 
 
 class TestUriFilter(object):
 
     @pytest.fixture
-    def search(self, pyramid_request):
-        # We don't need to append UriFilter to Search because it's one of the filters that
-        # Search appends by default.
-        return search.Search(pyramid_request)
+    def filtered_search(self, search, pyramid_request):
+        search.append_filter(query.UriFilter(pyramid_request))
+        return search
 
 
 class TestDeletedFilter(object):
 
     @pytest.fixture
-    def search(self, pyramid_request):
-        # We don't need to append DeletedFilter to Search because it's one of the filters that
-        # Search appends by default.
-        return search.Search(pyramid_request)
+    def filtered_search(self, search):
+        search.append_filter(query.DeletedFilter())
+        return search
 
 
 class TestNipsaFilter(object):
 
     @pytest.fixture
-    def search(self, pyramid_request):
-        # We don't need to append NipsaFilter to Search because it's one of the filters that
-        # Search appends by default.
-        return search.Search(pyramid_request)
+    def filtered_search(self, search, pyramid_request):
+        search.append_filter(query.NipsaFilter(pyramid_request))
+        return search
 
 
 class TestAnyMatcher(object):
 
     @pytest.fixture
-    def search(self, pyramid_request):
-        # We don't need to append AnyMatcher to Search because it's one of the matchers that
-        # Search appends by default.
-        return search.Search(pyramid_request)
+    def filtered_search(self, search):
+        search.append_filter(query.AnyMatcher())
+        return search
 
 
 class TestTagsMatcher(object):
 
     @pytest.fixture
-    def search(self, pyramid_request):
-        # We don't need to append TagsMatcher to Search because it's one of the matchers that
-        # Search appends by default.
-        return search.Search(pyramid_request)
+    def filtered_search(self, search):
+        search.append_filter(query.TagsMatcher())
+        return search
 
 
 class TestRepliesMatcher(object):
@@ -166,25 +157,28 @@ class TestRepliesMatcher(object):
     # Note: tests will have to append a RepliesMatcher object to the search
     # (search.append_matcher(RepliesMatcher(annotation_ids))) passing to RepliesMatcher the
     # annotation_ids of the annotations that the test wants to search for replies to.
-
-    @pytest.fixture
-    def search(self, pyramid_request):
-        return search.Search(pyramid_request)
+    pass
 
 
 class TestTagsAggregation(object):
 
     @pytest.fixture
-    def search(self, pyramid_request):
-        search_ = search.Search(pyramid_request)
-        search_.append_aggregation(search.TagsAggregation())
-        return search_
+    def filtered_search(self, search):
+        search.append_aggregation(query.TagsAggregation())
+        return search
 
 
 class TestUsersAggregation(object):
 
     @pytest.fixture
-    def search(self, pyramid_request):
-        search_ = search.Search(pyramid_request)
-        search_.append_aggregation(search.UsersAggregation())
-        return search_
+    def filtered_search(self, search):
+        search.append_aggregation(query.UsersAggregation())
+        return search
+
+
+@pytest.fixture
+def search(pyramid_request):
+    search = Search(pyramid_request)
+    # Remove all default filters, aggregators, and matchers.
+    search.clear()
+    return search

--- a/tests/h/search/query_test.py
+++ b/tests/h/search/query_test.py
@@ -9,8 +9,8 @@ from h.search import Search, query
 class TestTopLevelAnnotationsFilter(object):
 
     def test_it_filters_out_replies_but_leaves_annotations_in(self, Annotation, filtered_search):
-        annotation = Annotation(shared=True)
-        reply = Annotation(references=[annotation.id], shared=True)
+        annotation = Annotation()
+        reply = Annotation(references=[annotation.id])
 
         result = filtered_search.run({})
 
@@ -25,11 +25,11 @@ class TestTopLevelAnnotationsFilter(object):
 
 class TestAuthorityFilter(object):
     def test_it_filters_out_non_matching_authorities(self, Annotation, filtered_search):
-        annotations_auth1 = [Annotation(userid="acct:foo@auth1", shared=True).id,
-                             Annotation(userid="acct:bar@auth1", shared=True).id]
+        annotations_auth1 = [Annotation(userid="acct:foo@auth1").id,
+                             Annotation(userid="acct:bar@auth1").id]
         # Make some other annotations that are of different authority.
-        Annotation(userid="acct:bat@auth2", shared=True)
-        Annotation(userid="acct:bar@auth3", shared=True)
+        Annotation(userid="acct:bat@auth2")
+        Annotation(userid="acct:bar@auth3")
 
         result = filtered_search.run({})
 
@@ -140,7 +140,7 @@ class TestAnyMatcher(object):
 
     @pytest.fixture
     def filtered_search(self, search):
-        search.append_filter(query.AnyMatcher())
+        search.append_matcher(query.AnyMatcher())
         return search
 
 
@@ -148,7 +148,7 @@ class TestTagsMatcher(object):
 
     @pytest.fixture
     def filtered_search(self, search):
-        search.append_filter(query.TagsMatcher())
+        search.append_matcher(query.TagsMatcher())
         return search
 
 

--- a/tests/h/search/query_test.py
+++ b/tests/h/search/query_test.py
@@ -8,58 +8,58 @@ from h.search import Search, query
 
 class TestTopLevelAnnotationsFilter(object):
 
-    def test_it_filters_out_replies_but_leaves_annotations_in(self, Annotation, filtered_search):
+    def test_it_filters_out_replies_but_leaves_annotations_in(self, Annotation, search):
         annotation = Annotation()
         reply = Annotation(references=[annotation.id])
 
-        result = filtered_search.run({})
+        result = search.run({})
 
         assert annotation.id in result.annotation_ids
         assert reply.id not in result.annotation_ids
 
     @pytest.fixture
-    def filtered_search(self, search):
+    def search(self, search):
         search.append_filter(query.TopLevelAnnotationsFilter())
         return search
 
 
 class TestAuthorityFilter(object):
-    def test_it_filters_out_non_matching_authorities(self, Annotation, filtered_search):
+    def test_it_filters_out_non_matching_authorities(self, Annotation, search):
         annotations_auth1 = [Annotation(userid="acct:foo@auth1").id,
                              Annotation(userid="acct:bar@auth1").id]
         # Make some other annotations that are of different authority.
         Annotation(userid="acct:bat@auth2")
         Annotation(userid="acct:bar@auth3")
 
-        result = filtered_search.run({})
+        result = search.run({})
 
         assert set(result.annotation_ids) == set(annotations_auth1)
 
     @pytest.fixture
-    def filtered_search(self, search):
+    def search(self, search):
         search.append_filter(query.AuthorityFilter("auth1"))
         return search
 
 
 class TestAuthFilter(object):
-    def test_logged_out_user_can_not_see_private_annotations(self, filtered_search, Annotation):
+    def test_logged_out_user_can_not_see_private_annotations(self, search, Annotation):
         Annotation()
         Annotation()
 
-        result = filtered_search.run({})
+        result = search.run({})
 
         assert not result.annotation_ids
 
-    def test_logged_out_user_can_see_shared_annotations(self, filtered_search, Annotation):
+    def test_logged_out_user_can_see_shared_annotations(self, search, Annotation):
         shared_ids = [Annotation(shared=True).id,
                       Annotation(shared=True).id]
 
-        result = filtered_search.run({})
+        result = search.run({})
 
         assert set(result.annotation_ids) == set(shared_ids)
 
     def test_logged_in_user_can_only_see_their_private_annotations(self,
-            filtered_search, pyramid_config, Annotation):
+            search, pyramid_config, Annotation):
         userid = "acct:bar@auth2"
         pyramid_config.testing_securitypolicy(userid)
         # Make a private annotation from a different user.
@@ -67,23 +67,23 @@ class TestAuthFilter(object):
         users_private_ids = [Annotation(userid=userid).id,
                              Annotation(userid=userid).id]
 
-        result = filtered_search.run({})
+        result = search.run({})
 
         assert set(result.annotation_ids) == set(users_private_ids)
 
     def test_logged_in_user_can_see_shared_annotations(self,
-            filtered_search, pyramid_config, Annotation):
+            search, pyramid_config, Annotation):
         userid = "acct:bar@auth2"
         pyramid_config.testing_securitypolicy(userid)
         shared_ids = [Annotation(userid="acct:foo@auth2", shared=True).id,
                       Annotation(userid=userid, shared=True).id]
 
-        result = filtered_search.run({})
+        result = search.run({})
 
         assert set(result.annotation_ids) == set(shared_ids)
 
     @pytest.fixture
-    def filtered_search(self, search, pyramid_request):
+    def search(self, search, pyramid_request):
         search.append_filter(query.AuthFilter(pyramid_request))
         return search
 
@@ -91,7 +91,7 @@ class TestAuthFilter(object):
 class TestGroupFilter(object):
 
     @pytest.fixture
-    def filtered_search(self, search):
+    def search(self, search):
         search.append_filter(query.GroupFilter())
         return search
 
@@ -99,7 +99,7 @@ class TestGroupFilter(object):
 class TestGroupAuthFilter(object):
 
     @pytest.fixture
-    def filtered_search(self, search, pyramid_request):
+    def search(self, search, pyramid_request):
         search.append_filter(query.GroupAuthFilter(pyramid_request))
         return search
 
@@ -107,7 +107,7 @@ class TestGroupAuthFilter(object):
 class TestUserFilter(object):
 
     @pytest.fixture
-    def filtered_search(self, search):
+    def search(self, search):
         search.append_filter(query.UserFilter())
         return search
 
@@ -115,7 +115,7 @@ class TestUserFilter(object):
 class TestUriFilter(object):
 
     @pytest.fixture
-    def filtered_search(self, search, pyramid_request):
+    def search(self, search, pyramid_request):
         search.append_filter(query.UriFilter(pyramid_request))
         return search
 
@@ -123,7 +123,7 @@ class TestUriFilter(object):
 class TestDeletedFilter(object):
 
     @pytest.fixture
-    def filtered_search(self, search):
+    def search(self, search):
         search.append_filter(query.DeletedFilter())
         return search
 
@@ -131,7 +131,7 @@ class TestDeletedFilter(object):
 class TestNipsaFilter(object):
 
     @pytest.fixture
-    def filtered_search(self, search, pyramid_request):
+    def search(self, search, pyramid_request):
         search.append_filter(query.NipsaFilter(pyramid_request))
         return search
 
@@ -139,7 +139,7 @@ class TestNipsaFilter(object):
 class TestAnyMatcher(object):
 
     @pytest.fixture
-    def filtered_search(self, search):
+    def search(self, search):
         search.append_matcher(query.AnyMatcher())
         return search
 
@@ -147,7 +147,7 @@ class TestAnyMatcher(object):
 class TestTagsMatcher(object):
 
     @pytest.fixture
-    def filtered_search(self, search):
+    def search(self, search):
         search.append_matcher(query.TagsMatcher())
         return search
 
@@ -163,7 +163,7 @@ class TestRepliesMatcher(object):
 class TestTagsAggregation(object):
 
     @pytest.fixture
-    def filtered_search(self, search):
+    def search(self, search):
         search.append_aggregation(query.TagsAggregation())
         return search
 
@@ -171,7 +171,7 @@ class TestTagsAggregation(object):
 class TestUsersAggregation(object):
 
     @pytest.fixture
-    def filtered_search(self, search):
+    def search(self, search):
         search.append_aggregation(query.UsersAggregation())
         return search
 


### PR DESCRIPTION
Make the default search filters, aggregators, and matchers clearable so that we can remove them when unit testing so as to only test one filter at a time.