### PR TITLE
Add motivations to annotation table, model

### DIFF
--- a/h/migrations/versions/ec178dfd2098_add_motivations_field_to_annotation_.py
+++ b/h/migrations/versions/ec178dfd2098_add_motivations_field_to_annotation_.py
@@ -1,0 +1,45 @@
+"""
+Add motivations field to annotation table
+"""
+
+from __future__ import unicode_literals
+
+import enum
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "ec178dfd2098"
+down_revision = "178270e3ee58"
+
+
+class Motivation(enum.Enum):
+    assessing = "assessing"
+    bookmarking = "bookmarking"
+    classifying = "classifying"
+    commenting = "commenting"
+    describing = "describing"
+    editing = "editing"
+    highlighting = "highlighting"
+    identifying = "identifying"
+    linking = "linking"
+    moderating = "moderating"
+    questioning = "questioning"
+    replying = "replying"
+    tagging = "tagging"
+
+motivation_type = sa.Enum(Motivation, name="annotation_motivation")
+
+def upgrade():
+    # Create the motivation_type type in db
+    motivation_type.create(op.get_bind())
+    # Add an Array column whose elements must be a motivation_type
+    op.add_column("annotation", sa.Column('motivations',
+                    postgresql.ARRAY(motivation_type),
+                    server_default=sa.text('ARRAY[]::annotation_motivation[]')
+                  ))
+
+def downgrade():
+    op.drop_column("annotation", "motivations")
+    motivation_type.drop(op.get_bind())

--- a/h/migrations/versions/ec178dfd2098_add_motivations_field_to_annotation_.py
+++ b/h/migrations/versions/ec178dfd2098_add_motivations_field_to_annotation_.py
@@ -13,33 +13,13 @@ from sqlalchemy.dialects import postgresql
 revision = "ec178dfd2098"
 down_revision = "178270e3ee58"
 
-
-class Motivation(enum.Enum):
-    assessing = "assessing"
-    bookmarking = "bookmarking"
-    classifying = "classifying"
-    commenting = "commenting"
-    describing = "describing"
-    editing = "editing"
-    highlighting = "highlighting"
-    identifying = "identifying"
-    linking = "linking"
-    moderating = "moderating"
-    questioning = "questioning"
-    replying = "replying"
-    tagging = "tagging"
-
-motivation_type = sa.Enum(Motivation, name="annotation_motivation")
-
 def upgrade():
-    # Create the motivation_type type in db
-    motivation_type.create(op.get_bind())
-    # Add an Array column whose elements must be a motivation_type
+    # Add an Array column
+    # Ideally, the items should be enum'd, but SQLAlchemy does not support
+    # ARRAY with ENUM; validation is at model level
     op.add_column("annotation", sa.Column('motivations',
-                    postgresql.ARRAY(motivation_type),
-                    server_default=sa.text('ARRAY[]::annotation_motivation[]')
+                    postgresql.ARRAY(sa.UnicodeText, zero_indexes=True)
                   ))
 
 def downgrade():
     op.drop_column("annotation", "motivations")
-    motivation_type.drop(op.get_bind())

--- a/h/models/annotation.py
+++ b/h/models/annotation.py
@@ -3,15 +3,32 @@
 from __future__ import unicode_literals
 
 import datetime
+import enum
 
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql as pg
 from sqlalchemy.ext.hybrid import hybrid_property
-from sqlalchemy.ext.mutable import MutableDict, MutableList
+from sqlalchemy.ext.mutable import MutableDict, MutableList, MutableSet
 
 from h.db import Base, types
 from h.util import markdown, uri
 from h.util.user import split_user
+
+
+class Motivation(enum.Enum):
+    assessing = "assessing"
+    bookmarking = "bookmarking"
+    classifying = "classifying"
+    commenting = "commenting"
+    describing = "describing"
+    editing = "editing"
+    highlighting = "highlighting"
+    identifying = "identifying"
+    linking = "linking"
+    moderating = "moderating"
+    questioning = "questioning"
+    replying = "replying"
+    tagging = "tagging"
 
 
 class Annotation(Base):
@@ -113,6 +130,12 @@ class Annotation(Base):
     document_id = sa.Column(sa.Integer,
                             sa.ForeignKey('document.id'),
                             nullable=False)
+
+    # motivations are a Set of enumerated motivation_types (Motivation)
+    motivation_type = sa.Enum(Motivation, name="annotation_motivation")
+    motivations = sa.Column(MutableSet.as_mutable(pg.ARRAY(motivation_type)),
+                            default=set,
+                            server_default=sa.text('ARRAY[]::annotation_motivation[]'))
 
     document = sa.orm.relationship('Document', backref='annotations')
 

--- a/h/models/annotation.py
+++ b/h/models/annotation.py
@@ -148,8 +148,10 @@ class Annotation(Base):
     def validate_motivations(self, key, motivations):
         # We can't use enum in an array field because SQLAlchemy doesn't
         # support it, so we have to do validation here
+        if len(set(motivations)) != len(motivations):
+            raise ValueError(_('motivations must not contain duplicates'))
         if len(set(motivations) - set(MOTIVATIONS)) != 0:
-            raise ValueError(_('motivation must be valid motivation'))
+            raise ValueError(_('motivations must contain valid motivations {}'.format(MOTIVATIONS)))
         return motivations
 
     @hybrid_property

--- a/tests/h/models/annotation_test.py
+++ b/tests/h/models/annotation_test.py
@@ -3,8 +3,15 @@
 from __future__ import unicode_literals
 
 import pytest
+import sqlalchemy
 
 from h.models.annotation import Annotation
+
+
+def test_motivations_can_be_set():
+    ann = Annotation(motivations=set(["tagging"]))
+
+    assert ann.motivations == set(['tagging'])
 
 
 def test_parent_id_of_direct_reply():
@@ -87,6 +94,17 @@ def test_authority(factories, userid, authority):
 
 def test_authority_when_annotation_has_no_userid():
     assert Annotation().authority is None
+
+
+def test_default_motivations_is_empty_set(factories):
+    annotation = factories.Annotation()
+
+    assert annotation.motivations == set([])
+
+
+def test_raises_when_invalid_motivation(db_session, factories):
+    with pytest.raises(sqlalchemy.exc.ProgrammingError):
+        factories.Annotation(motivations=set(["invalid"]))
 
 
 def test_setting_extras_inline_is_persisted(db_session, factories):

--- a/tests/h/models/annotation_test.py
+++ b/tests/h/models/annotation_test.py
@@ -3,15 +3,20 @@
 from __future__ import unicode_literals
 
 import pytest
-import sqlalchemy
 
 from h.models.annotation import Annotation
 
 
 def test_motivations_can_be_set():
-    ann = Annotation(motivations=set(["tagging"]))
+    ann = Annotation(motivations=["tagging"])
 
-    assert ann.motivations == set(['tagging'])
+    assert ann.motivations == ["tagging"]
+
+
+def test_multiple_motivations_can_be_set():
+    ann = Annotation(motivations=["tagging", "linking"])
+
+    assert ann.motivations == ["tagging", "linking"]
 
 
 def test_parent_id_of_direct_reply():
@@ -96,15 +101,25 @@ def test_authority_when_annotation_has_no_userid():
     assert Annotation().authority is None
 
 
-def test_default_motivations_is_empty_set(factories):
+def test_default_motivations_is_empty(factories):
     annotation = factories.Annotation()
 
-    assert annotation.motivations == set([])
+    assert annotation.motivations == []
 
 
 def test_raises_when_invalid_motivation(db_session, factories):
-    with pytest.raises(sqlalchemy.exc.ProgrammingError):
-        factories.Annotation(motivations=set(["invalid"]))
+    with pytest.raises(ValueError):
+        factories.Annotation(motivations=["invalid"])
+
+
+def test_raises_when_any_invalid_motivation(db_session, factories):
+    with pytest.raises(ValueError):
+        factories.Annotation(motivations=["highlighting", "invalid"])
+
+
+def test_raises_when_wrong_motivation_type(db_session, factories):
+    with pytest.raises(ValueError):
+        factories.Annotation(motivations="tagging")
 
 
 def test_setting_extras_inline_is_persisted(db_session, factories):

--- a/tests/h/models/annotation_test.py
+++ b/tests/h/models/annotation_test.py
@@ -113,6 +113,11 @@ def test_allows_empty_motivations_list(db_session, factories):
     assert annotation.motivations == []
 
 
+def test_raises_when_motivations_contains_duplicates(db_session, factories):
+    with pytest.raises(ValueError):
+        factories.Annotation(motivations=["tagging", "highlighting", "tagging"])
+
+
 def test_raises_when_invalid_motivation(db_session, factories):
     with pytest.raises(ValueError):
         factories.Annotation(motivations=["invalid"])

--- a/tests/h/models/annotation_test.py
+++ b/tests/h/models/annotation_test.py
@@ -107,6 +107,12 @@ def test_default_motivations_is_empty(factories):
     assert annotation.motivations == []
 
 
+def test_allows_empty_motivations_list(db_session, factories):
+    annotation = factories.Annotation(motivations=[])
+
+    assert annotation.motivations == []
+
+
 def test_raises_when_invalid_motivation(db_session, factories):
     with pytest.raises(ValueError):
         factories.Annotation(motivations=["invalid"])


### PR DESCRIPTION
Motivations are a field on the Annotation model and describe the "motivation" for creating an annotation. There may be 0 or more motivations according to the w3 annotation spec. Currently there are a list of accepted motivation types based on those provided in the spec. These include:
assessing, bookmarking, classifying, commenting, describing, editing, highlighting, identifying, linking, moderating, questioning, replying, tagging.

See https://www.w3.org/TR/annotation-model/#motivation-and-purpose.