### PR TITLE
Add Basics of Index for Annotation Documents for ES 6.x

### DIFF
--- a/h/search/index.py
+++ b/h/search/index.py
@@ -26,7 +26,7 @@ class Window(namedtuple('Window', ['start', 'end'])):
     pass
 
 
-def index(es, annotation, request, target_index=None):
+def index_old(es, annotation, request, target_index=None):
     """
     Index an annotation into the search index.
 

--- a/h/search/persistence.py
+++ b/h/search/persistence.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+"""Code for persisting (indexing) Annotations in ElasticSearch"""
+
+from __future__ import unicode_literals
+
+import elasticsearch_dsl
+
+
+class Annotation(elasticsearch_dsl.DocType):
+    """Defines an ElasticSearch annotation document via elasticsearch_dsl"""
+
+    class Meta:
+        """
+        Define the default index to use for this DocType
+
+        N.B. This index name can be overridden (e.g. in tests)
+        via ``Annotation._doc_type.index = "something_else"``
+        """
+        index = "hypothesis"
+
+    authority = elasticsearch_dsl.Keyword()
+    """
+    An annotation's authority can be used to filter out annotations by
+    authority — e.g. retrieve annotations only applicable to a certain
+    user's authority
+    """
+
+    @staticmethod
+    def create(annotation_model):
+        """
+        Return a new search.Annotation (DocType)
+
+        Return a search.Annotation instance built from the provided, populated
+        annotation model
+        """
+        return Annotation(meta={
+            "id": annotation_model.id
+        })

--- a/h/tasks/indexer.py
+++ b/h/tasks/indexer.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 from h import models, storage
 from h.celery import celery, get_task_logger
 from h.indexer.reindexer import SETTING_NEW_INDEX
-from h.search.index import BatchIndexer, delete, index
+from h.search.index import BatchIndexer, delete, index_old
 
 log = get_task_logger(__name__)
 
@@ -13,14 +13,14 @@ log = get_task_logger(__name__)
 def add_annotation(id_):
     annotation = storage.fetch_annotation(celery.request.db, id_)
     if annotation:
-        index(celery.request.es, annotation, celery.request)
+        index_old(celery.request.es, annotation, celery.request)
 
         # If a reindex is running at the moment, add annotation to the new index
         # as well.
         future_index = _current_reindex_new_name(celery.request)
         if future_index is not None:
-            index(celery.request.es, annotation, celery.request,
-                  target_index=future_index)
+            index_old(celery.request.es, annotation, celery.request,
+                      target_index=future_index)
 
         if annotation.is_reply:
             add_annotation.delay(annotation.thread_root_id)

--- a/tests/h/search/conftest.py
+++ b/tests/h/search/conftest.py
@@ -4,6 +4,8 @@ from __future__ import unicode_literals
 import mock
 import pytest
 
+import elasticsearch_dsl
+
 import h.search.index
 from h.services.group import GroupService
 
@@ -34,10 +36,20 @@ def Annotation(factories, index):
 @pytest.fixture
 def index(es_client, pyramid_request):
     def _index(*annotations):
-        """Index the given annotation(s) into Elasticsearch."""
+        """Index the given annotation(s) into Elasticsearch (v1.x)."""
         for annotation in annotations:
             h.search.index.index_old(es_client, annotation, pyramid_request)
         es_client.conn.indices.refresh(index=es_client.index)
+    return _index
+
+
+@pytest.fixture
+def index_new(pyramid_request):
+    def _index(*annotations):
+        """Index the given annotation(s) into Elasticsearch (v6.x)."""
+        for annotation in annotations:
+            h.search.index.index(annotation, pyramid_request)
+        elasticsearch_dsl.connections.get_connection().indices.refresh()
     return _index
 
 

--- a/tests/h/search/conftest.py
+++ b/tests/h/search/conftest.py
@@ -36,7 +36,7 @@ def index(es_client, pyramid_request):
     def _index(*annotations):
         """Index the given annotation(s) into Elasticsearch."""
         for annotation in annotations:
-            h.search.index.index(es_client, annotation, pyramid_request)
+            h.search.index.index_old(es_client, annotation, pyramid_request)
         es_client.conn.indices.refresh(index=es_client.index)
     return _index
 

--- a/tests/h/search/index_test.py
+++ b/tests/h/search/index_test.py
@@ -8,12 +8,25 @@ import mock
 import pytest
 
 import h.search.index
+from h.search import persistence
 
 from tests.common.matchers import Matcher
 
 
-@pytest.mark.usefixtures("annotations")
 class TestIndex(object):
+    """Test indexing of ES v6.x+"""
+    def test_annotation_ids_are_used_as_elasticsearch_ids(self, factories, index_new):
+        annotation = factories.Annotation.build()
+
+        index_new(annotation)
+
+        result = persistence.Annotation.get(id=annotation.id)
+        assert result.meta.id == annotation.id
+
+
+@pytest.mark.usefixtures("annotations")
+class TestIndexOld(object):
+    """Test indexing of ES v1.x (deprecated)"""
     def test_annotation_ids_are_used_as_elasticsearch_ids(self, es_client,
                                                           factories,
                                                           index):

--- a/tests/h/search/old_index_test.py
+++ b/tests/h/search/old_index_test.py
@@ -22,7 +22,7 @@ class TestIndexAnnotation:
     def test_it_presents_the_annotation(self, es, presenters, pyramid_request):
         annotation = mock.Mock()
 
-        index.index(es, annotation, pyramid_request)
+        index.index_old(es, annotation, pyramid_request)
 
         presenters.AnnotationSearchIndexPresenter.assert_called_once_with(annotation)
 
@@ -34,7 +34,7 @@ class TestIndexAnnotation:
         annotation = mock.Mock()
         presented = presenters.AnnotationSearchIndexPresenter.return_value.asdict()
 
-        index.index(es, annotation, pyramid_request)
+        index.index_old(es, annotation, pyramid_request)
 
         AnnotationTransformEvent.assert_called_once_with(pyramid_request, annotation, presented)
 
@@ -44,13 +44,13 @@ class TestIndexAnnotation:
                                            notify,
                                            presenters,
                                            pyramid_request):
-        index.index(es, mock.Mock(), pyramid_request)
+        index.index_old(es, mock.Mock(), pyramid_request)
 
         event = AnnotationTransformEvent.return_value
         notify.assert_called_once_with(event)
 
     def test_it_indexes_the_annotation(self, es, presenters, pyramid_request):
-        index.index(es, mock.Mock(), pyramid_request)
+        index.index_old(es, mock.Mock(), pyramid_request)
 
         es.conn.index.assert_called_once_with(
             index='hypothesis',
@@ -60,7 +60,7 @@ class TestIndexAnnotation:
         )
 
     def test_it_allows_to_override_target_index(self, es, presenters, pyramid_request):
-        index.index(es, mock.Mock(), pyramid_request, target_index='custom-index')
+        index.index_old(es, mock.Mock(), pyramid_request, target_index='custom-index')
 
         _, kwargs = es.conn.index.call_args
         assert kwargs['index'] == 'custom-index'


### PR DESCRIPTION
This PR supersedes and is heavily based on https://github.com/hypothesis/h/pull/5051 Like that PR, it adds a `elasticsearch_dsl`-compatible `Annotation` Document class (the `h.search.persistence` module) and updates elements of `h.search.index` to be able to work with both the old (v1.x) index and the new (v6.x) one.

The tests are updated to initialize and delete the test ES index. This adds about 2% to the test suite run time (a couple of seconds for the whole suite on my local). It may be possible to find a more efficient way to do this.
