### PR TITLE
Index and search annotations in Elasticsearch 6

### DIFF
--- a/h/cli/commands/init.py
+++ b/h/cli/commands/init.py
@@ -19,6 +19,7 @@ def init(ctx):
 
     _init_db(request.registry.settings)
     _init_search(request.registry.settings)
+    _init_search_es6(request.registry.settings)
 
 
 def _init_db(settings):
@@ -39,4 +40,11 @@ def _init_search(settings):
     client = search.get_client(settings)
 
     log.info("initializing search index")
+    search.init(client)
+
+
+def _init_search_es6(settings):
+    client = search.get_es6_client(settings)
+
+    log.info("initializing ES6 search index")
     search.init(client)

--- a/h/cli/commands/search.py
+++ b/h/cli/commands/search.py
@@ -17,13 +17,22 @@ def search():
 @click.pass_context
 def reindex(ctx):
     """
-    Reindex all annotations in all clusters.
+    Reindex all annotations in the old search cluster.
 
     Creates a new search index from the data in PostgreSQL and atomically
     updates the index alias. This requires that the index is aliased already,
     and will raise an error if it is not.
     """
     _reindex_old(ctx)
+
+
+@search.command()
+@click.pass_context
+def reindex_es6(ctx):
+    """
+    Reindex all annotations in the new search cluster.
+    """
+    _reindex_es6(ctx)
 
 
 @search.command('update-settings')
@@ -53,6 +62,17 @@ def _reindex_old(ctx):
     request = ctx.obj['bootstrap']()
 
     indexer.reindex(request.db, request.es, request)
+
+
+def _reindex_es6(ctx):
+    """
+    Reindex all annotations in the new cluster.
+    """
+    os.environ['ELASTICSEARCH_CLIENT_TIMEOUT'] = '30'
+
+    request = ctx.obj['bootstrap']()
+
+    indexer.reindex(request.db, request.es6, request)
 
 
 def _update_settings_old(ctx):

--- a/h/indexer/reindexer.py
+++ b/h/indexer/reindexer.py
@@ -13,6 +13,7 @@ from h.search.index import BatchIndexer
 log = logging.getLogger(__name__)
 
 SETTING_NEW_INDEX = 'reindex.new_index'
+SETTING_NEW_ES6_INDEX = 'reindex.new_es6_index'
 
 
 def reindex(session, es, request):
@@ -24,9 +25,13 @@ def reindex(session, es, request):
     settings = request.find_service(name='settings')
 
     new_index = configure_index(es)
+    if es.using_es6:
+        setting_name = SETTING_NEW_ES6_INDEX
+    else:
+        setting_name = SETTING_NEW_INDEX
 
     try:
-        settings.put(SETTING_NEW_INDEX, new_index)
+        settings.put(setting_name, new_index)
         request.tm.commit()
 
         indexer = BatchIndexer(session, es, request, target_index=new_index, op_type='create')
@@ -44,5 +49,5 @@ def reindex(session, es, request):
         update_aliased_index(es, new_index)
 
     finally:
-        settings.delete(SETTING_NEW_INDEX)
+        settings.delete(setting_name)
         request.tm.commit()

--- a/h/models/feature.py
+++ b/h/models/feature.py
@@ -18,6 +18,9 @@ FEATURES = {
     'overlay_highlighter': "Use the new overlay highlighter?",
     'api_render_user_info': "Return users' extended info in API responses?",
     'client_display_names': "Render display names instead of user names in the client",
+
+    'index_es6': 'Index annotations into Elasticsearch 6 (only takes effect if enabled for everyone)?',
+    'search_es6': 'Search annotations in Elasticsearch 6?',
 }
 
 # Once a feature has been fully deployed, we remove the flag from the codebase.

--- a/h/search/__init__.py
+++ b/h/search/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import unicode_literals
-from h.search.client import get_client
+from h.search.client import get_client, get_es6_client
 from h.search.config import init
 from h.search.connection import connect
 from h.search.core import Search
@@ -41,11 +41,20 @@ def includeme(config):
     settings.setdefault('es.host', 'http://localhost:9200')
     settings.setdefault('es.index', 'hypothesis')
 
-    # Add a property to all requests for easy access to the elasticsearch
+    # Add a property to all requests for easy access to the elasticsearch 1.x
     # client. This can be used for direct or bulk access without having to
     # reread the settings.
     config.registry['es.client'] = get_client(settings)
     config.add_request_method(
         lambda r: r.registry['es.client'],
         name='es',
+        reify=True)
+
+    # Add a property to all requests for easy access to the elasticsearch 6.x
+    # client. This can be used for direct or bulk access without having to
+    # reread the settings.
+    config.registry['es6.client'] = get_es6_client(settings)
+    config.add_request_method(
+        lambda r: r.registry['es6.client'],
+        name='es6',
         reify=True)

--- a/h/search/client.py
+++ b/h/search/client.py
@@ -3,15 +3,17 @@
 from __future__ import unicode_literals
 import certifi
 from elasticsearch1 import Elasticsearch, RequestsHttpConnection
+from elasticsearch import Elasticsearch as Elasticsearch6
 from requests_aws4auth import AWS4Auth
 
+# TODO - Can we remove this?
 __all__ = ('Client',)
 
 
 class Client(object):
 
     """
-    A convenience wrapper around a connection to Elasticsearch.
+    A convenience wrapper around a connection to Elasticsearch 1.x.
 
     Holds a connection object, an index name, and an enumeration of document
     types stored in the index.
@@ -41,6 +43,51 @@ class Client(object):
     def conn(self):
         return self._conn
 
+    @property
+    def using_es6(self):
+        return False
+
+
+class Elasticsearch6Client(object):
+    """
+    A convenience wrapper around a connection to Elasticsearch 6.x.
+
+    Holds a connection object, an index name, and an enumeration of document
+    types stored in the index.
+
+    :param host: Elasticsearch host URL
+    :param index: index name
+    """
+
+    # Document ("mapping") types are deprecated in Elasticsearch.
+    # ES 6 only allows one mapping type per index. Fortunately that is all we
+    # need. If we want to index other types of object in future, we will either
+    # need to use separate indexes or a custom `type` flag per document.
+    #
+    # See https://www.elastic.co/guide/en/elasticsearch/reference/6.x/removal-of-types.html
+    class t(object):  # noqa
+        """Document types"""
+
+        # The mapping type name `_doc` is the preferred value in ES 6 for
+        # forward compatibility with ES 7.
+        annotation = '_doc'
+
+    def __init__(self, host, index, **kwargs):
+        self._index = index
+        self._conn = Elasticsearch6([host], **kwargs)
+
+    @property
+    def index(self):
+        return self._index
+
+    @property
+    def conn(self):
+        return self._conn
+
+    @property
+    def using_es6(self):
+        return True
+
 
 def get_client(settings):
     """Return a client for the Elasticsearch index."""
@@ -67,3 +114,20 @@ def get_client(settings):
         kwargs['connection_class'] = RequestsHttpConnection
 
     return Client(host, index, **kwargs)
+
+
+def get_es6_client(settings):
+    """Return a client for the Elasticsearch 6 index."""
+    host = settings['es.url']
+    index = settings['es.index']
+    kwargs = {}
+    kwargs['max_retries'] = settings.get('es.client.max_retries', 3)
+    kwargs['retry_on_timeout'] = settings.get('es.client.retry_on_timeout', False)
+    kwargs['timeout'] = settings.get('es.client.timeout', 10)
+
+    if 'es.client_poolsize' in settings:
+        kwargs['maxsize'] = settings['es.client_poolsize']
+
+    # nb. No AWS credentials here because we assume that if using AWS-managed
+    # ES, the cluster lives inside a VPC.
+    return Elasticsearch6Client(host, index, **kwargs)

--- a/h/search/core.py
+++ b/h/search/core.py
@@ -35,7 +35,12 @@ class Search(object):
     """
     def __init__(self, request, separate_replies=False, stats=None, _replies_limit=200):
         self.request = request
-        self.es = request.es
+
+        if request.feature('search_es6'):
+            self.es = request.es6
+        else:
+            self.es = request.es
+
         self.separate_replies = separate_replies
         self.stats = stats
         self._replies_limit = _replies_limit
@@ -146,7 +151,7 @@ class Search(object):
 
     @staticmethod
     def _default_querybuilder(request):
-        builder = query.Builder()
+        builder = query.Builder(using_es6=request.feature('search_es6'))
         builder.append_filter(query.DeletedFilter())
         builder.append_filter(query.AuthFilter(request))
         builder.append_filter(query.UriFilter(request))

--- a/h/search/query.py
+++ b/h/search/query.py
@@ -14,10 +14,11 @@ class Builder(object):
     Build a query for execution in Elasticsearch.
     """
 
-    def __init__(self):
+    def __init__(self, using_es6=False):
         self.filters = []
         self.matchers = []
         self.aggregations = []
+        self.using_es6 = using_es6
 
     def append_filter(self, f):
         self.filters.append(f)
@@ -48,16 +49,24 @@ class Builder(object):
 
         query = {"match_all": {}}
 
-        if matchers:
-            query = {"bool": {"must": matchers}}
+        if self.using_es6:
+            bool_query = {}
+            if matchers:
+                bool_query["must"] = matchers
+            if filters:
+                bool_query["filter"] = filters
+            query = {"bool": bool_query}
+        else:
+            if matchers:
+                query = {"bool": {"must": matchers}}
 
-        if filters:
-            query = {
-                "filtered": {
-                    "filter": {"and": filters},
-                    "query": query,
+            if filters:
+                query = {
+                    "filtered": {
+                        "filter": {"and": filters},
+                        "query": query,
+                    }
                 }
-            }
 
         return {
             "from": p_from,
@@ -94,8 +103,16 @@ def extract_limit(params):
 def extract_sort(params):
     return [{
         params.pop("sort", "updated"): {
-            "ignore_unmapped": True,
             "order": params.pop("order", "desc"),
+
+            # `unmapped_type` causes unknown fields specified as arguments to
+            # `sort` behave as if all documents contained empty values of the
+            # given type. Without this, specifying eg. `sort=foobar` throws
+            # an exception.
+            #
+            # We use the field type `boolean` to assist with migration because
+            # that exists in both ES 1 and ES 6.
+            "unmapped_type": "boolean",
         }
     }]
 
@@ -105,7 +122,7 @@ class TopLevelAnnotationsFilter(object):
     """Matches top-level annotations only, filters out replies."""
 
     def __call__(self, _):
-        return {'missing': {'field': 'references'}}
+        return {'bool': {'must_not': {'exists': {'field': 'references'}}}}
 
 
 class AuthorityFilter(object):
@@ -145,10 +162,9 @@ class AuthFilter(object):
         if userid is None:
             return public_filter
 
-        return {'or': [
-            public_filter,
-            {'term': {'user_raw': userid}},
-        ]}
+        userid_filter = {'term': {'user_raw': userid}}
+
+        return {'bool': {'should': [public_filter, userid_filter]}}
 
 
 class GroupFilter(object):
@@ -271,7 +287,7 @@ def nipsa_filter(group_service, user=None):
     # If any one of these "should" clauses is true then the annotation will
     # get through the filter.
     should_clauses = [
-        {"not": {"term": {"nipsa": True}}},
+        {"bool": {"must_not": {"term": {"nipsa": True}}}},
         {"exists": {"field": "thread_ids"}},
     ]
 

--- a/h/tasks/indexer.py
+++ b/h/tasks/indexer.py
@@ -3,7 +3,7 @@
 from __future__ import unicode_literals
 from h import models, storage
 from h.celery import celery, get_task_logger
-from h.indexer.reindexer import SETTING_NEW_INDEX
+from h.indexer.reindexer import SETTING_NEW_INDEX, SETTING_NEW_ES6_INDEX
 from h.search.index import BatchIndexer, delete, index
 
 log = get_task_logger(__name__)
@@ -15,12 +15,20 @@ def add_annotation(id_):
     if annotation:
         index(celery.request.es, annotation, celery.request)
 
+        if celery.request.feature('index_es6'):
+            index(celery.request.es6, annotation, celery.request)
+
         # If a reindex is running at the moment, add annotation to the new index
         # as well.
         future_index = _current_reindex_new_name(celery.request)
         if future_index is not None:
             index(celery.request.es, annotation, celery.request,
                   target_index=future_index)
+
+        future_es6_index = _current_reindex_new_es6_name(celery.request)
+        if future_es6_index is not None:
+            index(celery.request.es6, annotation, celery.request,
+                  target_index=future_es6_index)
 
         if annotation.is_reply:
             add_annotation.delay(annotation.thread_root_id)
@@ -30,11 +38,18 @@ def add_annotation(id_):
 def delete_annotation(id_):
     delete(celery.request.es, id_)
 
+    if celery.request.feature('index_es6'):
+        delete(celery.request.es6, id_)
+
     # If a reindex is running at the moment, delete annotation from the
     # new index as well.
     future_index = _current_reindex_new_name(celery.request)
     if future_index is not None:
         delete(celery.request.es, id_, target_index=future_index)
+
+    future_es6_index = _current_reindex_new_es6_name(celery.request)
+    if future_es6_index is not None:
+        delete(celery.request.es6, id_, target_index=future_es6_index)
 
 
 @celery.task
@@ -46,9 +61,22 @@ def reindex_user_annotations(userid):
     if errored:
         log.warning('Failed to re-index annotations %s', errored)
 
+    if celery.request.feature('index_es6'):
+        indexer = BatchIndexer(celery.request.db, celery.request.es6, celery.request)
+        errored = indexer.index(ids)
+        if errored:
+            log.warning('Failed to re-index annotations into ES6 %s', errored)
+
 
 def _current_reindex_new_name(request):
     settings = celery.request.find_service(name='settings')
     new_index = settings.get(SETTING_NEW_INDEX)
+
+    return new_index
+
+
+def _current_reindex_new_es6_name(request):
+    settings = celery.request.find_service(name='settings')
+    new_index = settings.get(SETTING_NEW_ES6_INDEX)
 
     return new_index

--- a/tests/common/fixtures/__init__.py
+++ b/tests/common/fixtures/__init__.py
@@ -1,13 +1,17 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from tests.common.fixtures.elasticsearch import es_client
+from tests.common.fixtures.elasticsearch import es_client, es6_client, es_connect
 from tests.common.fixtures.elasticsearch import init_elasticsearch
 from tests.common.fixtures.elasticsearch import delete_all_elasticsearch_documents
+from tests.common.fixtures.elasticsearch import delete_all_elasticsearch6_documents
 
 
 __all__ = (
     "es_client",
+    "es6_client",
+    "es_connect",
     "init_elasticsearch",
     "delete_all_elasticsearch_documents",
+    "delete_all_elasticsearch6_documents",
 )

--- a/tests/common/fixtures/elasticsearch.py
+++ b/tests/common/fixtures/elasticsearch.py
@@ -19,6 +19,11 @@ def es_client(delete_all_elasticsearch_documents):
 
 
 @pytest.fixture
+def es6_client(delete_all_elasticsearch6_documents):
+    return _es6_client()
+
+
+@pytest.fixture
 def es_connect():
     # TODO handle deleting things out of this connection's index as
     # the `es_client` fixture does
@@ -30,12 +35,19 @@ def init_elasticsearch(request):
     """Initialize the test (old) Elasticsearch index once per test session."""
     client = _es_client()
     """Connect to the newer v6.x instance of Elasticsearch once per test session"""
-    es_connect()
+    es6_client = _es6_client()
 
     def maybe_delete_index():
         """Delete the test index if it exists."""
         if client.conn.indices.exists(index=ELASTICSEARCH_INDEX):
             client.conn.indices.delete(index=ELASTICSEARCH_INDEX)
+
+        if es6_client.conn.indices.exists(index=ELASTICSEARCH_INDEX):
+            # The delete operation must be done on a concrete index, not an alias
+            # in ES6. See https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-delete-index.html
+            concrete_indexes = es6_client.conn.indices.get(index=ELASTICSEARCH_INDEX)
+            for index in concrete_indexes:
+                es6_client.conn.indices.delete(index=index)
 
     # Delete the test search index at the end of the test run.
     request.addfinalizer(maybe_delete_index)
@@ -46,6 +58,7 @@ def init_elasticsearch(request):
 
     # Initialize the test search index.
     search.init(client)
+    search.init(es6_client)
 
 
 @pytest.fixture
@@ -59,6 +72,25 @@ def delete_all_elasticsearch_documents(request):
     request.addfinalizer(delete_everything)
 
 
+@pytest.fixture
+def delete_all_elasticsearch6_documents(request):
+    """Delete everything from the test search index after each test."""
+    client = _es6_client()
+
+    def delete_everything():
+        client.conn.delete_by_query(index=client.index, body={"query": {"match_all": {}}},
+                                    # This query occassionally fails with a version conflict.
+                                    # Forcing the deletion resolves the issue, but the exact
+                                    # cause of the version conflict has not been found yet.
+                                    conflicts='proceed')
+
+    request.addfinalizer(delete_everything)
+
+
 def _es_client():
     """Return a :py:class:`h.search.client.Client` for the test search index."""
     return search.get_client({"es.host": ELASTICSEARCH_HOST, "es.index": ELASTICSEARCH_INDEX})
+
+
+def _es6_client():
+    return search.get_es6_client({'es.url': ELASTICSEARCH_URL, 'es.index': ELASTICSEARCH_INDEX})

--- a/tests/h/cli/commands/init_test.py
+++ b/tests/h/cli/commands/init_test.py
@@ -50,11 +50,13 @@ class TestInitCommand(object):
                                 search,
                                 pyramid_settings):
         client = search.get_client.return_value
+        es6_client = search.get_es6_client.return_value
 
         result = cli.invoke(init_cli.init, obj=cliconfig)
 
         search.get_client.assert_called_once_with(pyramid_settings)
-        search.init.assert_called_once_with(client)
+        search.init.assert_any_call(client)
+        search.init.assert_any_call(es6_client)
         assert result.exit_code == 0
 
 

--- a/tests/h/conftest.py
+++ b/tests/h/conftest.py
@@ -24,9 +24,9 @@ from h import db
 from h import models
 from h.settings import database_url
 from h._compat import text_type
-from tests.common.fixtures import es_client  # noqa: F401
+from tests.common.fixtures import es_client, es6_client, es_connect  # noqa: F401
 from tests.common.fixtures import init_elasticsearch  # noqa: F401
-from tests.common.fixtures import delete_all_elasticsearch_documents  # noqa: F401
+from tests.common.fixtures import delete_all_elasticsearch_documents, delete_all_elasticsearch6_documents  # noqa: F401
 
 TEST_AUTHORITY = 'example.com'
 TEST_DATABASE_URL = database_url(os.environ.get('TEST_DATABASE_URL',

--- a/tests/h/search/conftest.py
+++ b/tests/h/search/conftest.py
@@ -32,16 +32,32 @@ def Annotation(factories, index):
 
 
 @pytest.fixture
-def index(es_client, pyramid_request):
+def index(es_client, es6_client, pyramid_request):
     def _index(*annotations):
         """Index the given annotation(s) into Elasticsearch."""
+
+        # Here we index the document into both clusters. Most tests will only
+        # check the result in a single cluster. This is inefficient, but we
+        # don't intend the dual cluster usage to live long.
+
+        # Index annotations into old Elasticsearch cluster.
         for annotation in annotations:
             h.search.index.index(es_client, annotation, pyramid_request)
         es_client.conn.indices.refresh(index=es_client.index)
+
+        # Index annotations into new Elasticsearch cluster.
+        for annotation in annotations:
+            h.search.index.index(es6_client, annotation, pyramid_request)
+        es6_client.conn.indices.refresh(index=es_client.index)
+
     return _index
 
 
 @pytest.fixture
-def pyramid_request(es_client, pyramid_request):
+def pyramid_request(es_client, es6_client, pyramid_request):
+    # Use ES1 by default.
+    pyramid_request.feature.flags['search_es6'] = False
+
     pyramid_request.es = es_client
+    pyramid_request.es6 = es6_client
     return pyramid_request

--- a/tests/h/search/connection_test.py
+++ b/tests/h/search/connection_test.py
@@ -21,8 +21,8 @@ class TestConnection(object):
     def test_connect_is_available_in_search_api(self):
         assert connect == search.connect
 
-    def test_connect_creates_default_connection(self):
-        # search.connect is invoked as part of test bootstrapping
+    def test_connect_creates_default_connection(self, es_connect):
+        # search.connect is invoked by the `es_connect` fixture
         # so the connection should already be established
         assert connections.get_connection()
         assert connections.get_connection('default')

--- a/tests/h/search/query_test.py
+++ b/tests/h/search/query_test.py
@@ -18,7 +18,7 @@ class TestTopLevelAnnotationsFilter(object):
         assert reply.id not in result.annotation_ids
 
     @pytest.fixture
-    def search(self, pyramid_request):
+    def search(self, pyramid_request, use_both_es_versions):
         search_ = search.Search(pyramid_request)
         search_.append_filter(search.TopLevelAnnotationsFilter())
         return search_
@@ -37,7 +37,7 @@ class TestAuthorityFilter(object):
         assert set(result.annotation_ids) == set(annotations_auth1)
 
     @pytest.fixture
-    def search(self, pyramid_request):
+    def search(self, pyramid_request, use_both_es_versions):
         search_ = search.Search(pyramid_request)
         search_.append_filter(search.AuthorityFilter("auth1"))
         return search_
@@ -83,7 +83,7 @@ class TestAuthFilter(object):
         assert set(result.annotation_ids) == set(shared_ids)
 
     @pytest.fixture
-    def search(self, pyramid_request):
+    def search(self, pyramid_request, use_both_es_versions):
         # We don't need to append AuthFilter to Search because it's one of the filters that
         # Search appends by default.
         return search.Search(pyramid_request)
@@ -92,7 +92,7 @@ class TestAuthFilter(object):
 class TestGroupFilter(object):
 
     @pytest.fixture
-    def search(self, pyramid_request):
+    def search(self, pyramid_request, use_both_es_versions):
         # We don't need to append GroupFilter to Search because it's one of the filters that
         # Search appends by default.
         return search.Search(pyramid_request)
@@ -101,7 +101,7 @@ class TestGroupFilter(object):
 class TestGroupAuthFilter(object):
 
     @pytest.fixture
-    def search(self, pyramid_request):
+    def search(self, pyramid_request, use_both_es_versions):
         # We don't need to append GroupAuthFilter to Search because it's one of the filters that
         # Search appends by default.
         return search.Search(pyramid_request)
@@ -110,7 +110,7 @@ class TestGroupAuthFilter(object):
 class TestUserFilter(object):
 
     @pytest.fixture
-    def search(self, pyramid_request):
+    def search(self, pyramid_request, use_both_es_versions):
         # We don't need to append UserFilter to Search because it's one of the filters that
         # Search appends by default.
         return search.Search(pyramid_request)
@@ -119,7 +119,7 @@ class TestUserFilter(object):
 class TestUriFilter(object):
 
     @pytest.fixture
-    def search(self, pyramid_request):
+    def search(self, pyramid_request, use_both_es_versions):
         # We don't need to append UriFilter to Search because it's one of the filters that
         # Search appends by default.
         return search.Search(pyramid_request)
@@ -128,7 +128,7 @@ class TestUriFilter(object):
 class TestDeletedFilter(object):
 
     @pytest.fixture
-    def search(self, pyramid_request):
+    def search(self, pyramid_request, use_both_es_versions):
         # We don't need to append DeletedFilter to Search because it's one of the filters that
         # Search appends by default.
         return search.Search(pyramid_request)
@@ -137,7 +137,7 @@ class TestDeletedFilter(object):
 class TestNipsaFilter(object):
 
     @pytest.fixture
-    def search(self, pyramid_request):
+    def search(self, pyramid_request, use_both_es_versions):
         # We don't need to append NipsaFilter to Search because it's one of the filters that
         # Search appends by default.
         return search.Search(pyramid_request)
@@ -146,7 +146,7 @@ class TestNipsaFilter(object):
 class TestAnyMatcher(object):
 
     @pytest.fixture
-    def search(self, pyramid_request):
+    def search(self, pyramid_request, use_both_es_versions):
         # We don't need to append AnyMatcher to Search because it's one of the matchers that
         # Search appends by default.
         return search.Search(pyramid_request)
@@ -155,7 +155,7 @@ class TestAnyMatcher(object):
 class TestTagsMatcher(object):
 
     @pytest.fixture
-    def search(self, pyramid_request):
+    def search(self, pyramid_request, use_both_es_versions):
         # We don't need to append TagsMatcher to Search because it's one of the matchers that
         # Search appends by default.
         return search.Search(pyramid_request)
@@ -168,14 +168,14 @@ class TestRepliesMatcher(object):
     # annotation_ids of the annotations that the test wants to search for replies to.
 
     @pytest.fixture
-    def search(self, pyramid_request):
+    def search(self, pyramid_request, use_both_es_versions):
         return search.Search(pyramid_request)
 
 
 class TestTagsAggregation(object):
 
     @pytest.fixture
-    def search(self, pyramid_request):
+    def search(self, pyramid_request, use_both_es_versions):
         search_ = search.Search(pyramid_request)
         search_.append_aggregation(search.TagsAggregation())
         return search_
@@ -184,7 +184,12 @@ class TestTagsAggregation(object):
 class TestUsersAggregation(object):
 
     @pytest.fixture
-    def search(self, pyramid_request):
+    def search(self, pyramid_request, use_both_es_versions):
         search_ = search.Search(pyramid_request)
         search_.append_aggregation(search.UsersAggregation())
         return search_
+
+
+@pytest.fixture(params=['es1', 'es6'])
+def use_both_es_versions(pyramid_request, request):
+    pyramid_request.feature.flags['search_es6'] = request.param == 'es6'


### PR DESCRIPTION
This is a rough branch which gets indexing into both ES 1 and ES 6 working, behind a feature flag (`index_es6`), and gets search working with ES 6, behind a separate feature flag (`search_es6`).

I'm not intending to merge this as-is but rather use it to review the basic approach, enable other devs to do some testing, and go over some of the specific changes required. If we're happy then logical chunks can be extracted into smaller PRs and shipped separately.

See also [my notes](https://gist.github.com/robertknight/32e12ddfa38d417b3e8cfc7a9c150705) on the investigation.