### PR TITLE
Do not qa unicode in h/_compat.py

### DIFF
--- a/h/_compat.py
+++ b/h/_compat.py
@@ -76,7 +76,7 @@ if PY2:
         for "native" strings in PEP-3333 (the WSGI spec).
 
         """
-        if isinstance(s, unicode):
+        if isinstance(s, unicode):  # noqa
             return s.encode(encoding, errors)
         return s
 else:


### PR DESCRIPTION
Add noqa in order to not lint check unicode in h/_compat.py as it produces
the following when running make lint in py3:
h/_compat.py:79:26: F821 undefined name 'unicode'