### PR TITLE
Raise HTTPConflict (409) when email uniqueness constraint violated

### DIFF
--- a/h/cli/commands/user.py
+++ b/h/cli/commands/user.py
@@ -38,7 +38,7 @@ def add(ctx, username, email, password, authority):
         request.tm.commit()
     except sqlalchemy.exc.IntegrityError as err:
         upstream_error = '\n'.join('    ' + line
-                                   for line in err.message.split('\n'))
+                                   for line in str(err).split('\n'))
         message = ('could not create user due to integrity constraint.\n\n{}'
                    .format(upstream_error))
         raise click.ClickException(message)

--- a/h/views/api_exceptions.py
+++ b/h/views/api_exceptions.py
@@ -11,6 +11,7 @@ from __future__ import unicode_literals
 
 from pyramid.view import forbidden_view_config
 from pyramid.view import notfound_view_config
+from pyramid.httpexceptions import HTTPException
 
 from h.i18n import TranslationString as _  # noqa: N813
 from h.exceptions import APIError
@@ -27,6 +28,13 @@ def api_notfound(request):
     message = _("Either the resource you requested doesn't exist, or you are "
                 "not currently authorized to see it.")
     return {'status': 'failure', 'reason': message}
+
+
+@json_view(context=HTTPException)
+def http_error(context, request):
+    """Handle an expected/deliberately thrown API exception."""
+    request.response.status_code = context.code
+    return {'status': 'failure', 'reason': str(context)}
 
 
 @json_view(context=APIError)

--- a/h/views/api_users.py
+++ b/h/views/api_users.py
@@ -6,6 +6,7 @@ import hmac
 
 import sqlalchemy as sa
 from pyramid.exceptions import HTTPNotFound
+from pyramid.httpexceptions import HTTPConflict
 
 from h import models
 from h.accounts import schemas
@@ -63,6 +64,10 @@ def update(request):
     appstruct = schema.validate(_json_payload(request))
 
     _update_user(user, appstruct)
+    try:
+        request.db.flush()
+    except sa.exc.IntegrityError:
+        raise HTTPConflict()
 
     presenter = UserJSONPresenter(user)
     return presenter.asdict()

--- a/tests/h/views/api_exceptions_test.py
+++ b/tests/h/views/api_exceptions_test.py
@@ -2,6 +2,8 @@
 
 from __future__ import unicode_literals
 
+from pyramid.httpexceptions import HTTPException, HTTPConflict
+
 from h.exceptions import APIError
 from h.schemas import ValidationError
 from h.views import api_exceptions as views
@@ -13,6 +15,26 @@ def test_api_notfound_view(pyramid_request):
     assert pyramid_request.response.status_int == 404
     assert result['status'] == 'failure'
     assert result['reason']
+
+
+def test_http_error_view_handles_generic_HTTPException(pyramid_request):  # noqa: N802
+    context = HTTPException()
+
+    result = views.http_error(context, pyramid_request)
+
+    # HTTPException (base class) response code is 520
+    assert pyramid_request.response.status_code == 520
+    assert result['status'] == 'failure'
+
+
+def test_http_error_view_handles_HTTPConflict(pyramid_request):  # noqa: N802
+    context = HTTPConflict()
+
+    result = views.http_error(context, pyramid_request)
+
+    # HTTP Conflict response status code is 409
+    assert pyramid_request.response.status_code == 409
+    assert result['status'] == 'failure'
 
 
 def test_api_error_view(pyramid_request):

--- a/tests/h/views/api_users_test.py
+++ b/tests/h/views/api_users_test.py
@@ -291,7 +291,6 @@ class TestUpdate(object):
         pyramid_request.json_body = {'email': existing.email}
         with pytest.raises(HTTPConflict):
             update(pyramid_request)
-            assert pyramid_request.response.status_code == 409
 
     @pytest.mark.usefixtures('valid_auth')
     def test_it_validates_the_input(self, pyramid_request, valid_payload, schemas):

--- a/tests/h/views/api_users_test.py
+++ b/tests/h/views/api_users_test.py
@@ -6,6 +6,7 @@ import pytest
 from mock import Mock, PropertyMock
 
 from pyramid.exceptions import HTTPNotFound
+from pyramid.httpexceptions import HTTPConflict
 
 from h.exceptions import ClientUnauthorized, PayloadError
 from h.models.auth_client import GrantType
@@ -280,6 +281,15 @@ class TestUpdate(object):
         pyramid_request.matchdict['username'] = 'missing'
 
         with pytest.raises(HTTPNotFound):
+            update(pyramid_request)
+
+    @pytest.mark.usefixtures('valid_auth')
+    def test_raises_409_when_email_exists(self, user, pyramid_request, auth_client, db_session, factories):
+        existing = factories.User(authority=auth_client.authority)
+        db_session.flush()
+
+        pyramid_request.json_body = {'email': existing.email}
+        with pytest.raises(HTTPConflict):
             update(pyramid_request)
 
     @pytest.mark.usefixtures('valid_auth')

--- a/tests/h/views/api_users_test.py
+++ b/tests/h/views/api_users_test.py
@@ -291,6 +291,7 @@ class TestUpdate(object):
         pyramid_request.json_body = {'email': existing.email}
         with pytest.raises(HTTPConflict):
             update(pyramid_request)
+            assert pyramid_request.response.status_code == 409
 
     @pytest.mark.usefixtures('valid_auth')
     def test_it_validates_the_input(self, pyramid_request, valid_payload, schemas):


### PR DESCRIPTION
This PR is based on https://github.com/hypothesis/h/pull/4945 — the only difference is the addition of a few tests and a recent rebase on `master`.

These changes will cause a 409 HTTP response code if one tries to update a user's email address to a value already in use by another record. This situation passes validation but fails DB integrity checking.

Further work to be done on returning consistent HTTP response codes, but this is a nice improvement, I think!

Thanks to @jmcarp for this work!