### PR TITLE
AuthClientRoot tidy ups

### DIFF
--- a/h/traversal/roots.py
+++ b/h/traversal/roots.py
@@ -123,8 +123,7 @@ class AuthClientRoot(object):
 
     def __getitem__(self, client_id):
         try:
-            client = self.request.db.query(AuthClient) \
-                                    .filter_by(id=client_id).one()
+            client = self.request.db.query(AuthClient).filter_by(id=client_id).one()
 
             # Add the default root factory to this resource's lineage so that the
             # default ACL is applied. This is needed so that permissions required by

--- a/h/traversal/roots.py
+++ b/h/traversal/roots.py
@@ -68,7 +68,7 @@ from pyramid.security import (
     DENY_ALL,
     Allow,
 )
-from sqlalchemy.orm import exc
+import sqlalchemy.orm.exc
 
 from h import storage
 from h.models import AuthClient
@@ -159,7 +159,7 @@ class OrganizationRoot(object):
             org.__parent__ = Root(self.request)
 
             return org
-        except exc.NoResultFound:
+        except sqlalchemy.orm.exc.NoResultFound:
             raise KeyError()
 
 
@@ -198,7 +198,7 @@ class GroupRoot(object):
     def __getitem__(self, pubid):
         try:
             return self.request.db.query(Group).filter_by(pubid=pubid).one()
-        except exc.NoResultFound:
+        except sqlalchemy.orm.exc.NoResultFound:
             raise KeyError()
 
 

--- a/h/traversal/roots.py
+++ b/h/traversal/roots.py
@@ -126,11 +126,14 @@ class AuthClientRoot(object):
             client = self.request.db.query(AuthClient) \
                                     .filter_by(id=client_id).one()
 
-            # Inherit global ACL.
-            # See `pyramid.authorization.ACLAuthorizationPolicy` docs.
+            # Add the default root factory to this resource's lineage so that the
+            # default ACL is applied. This is needed so that permissions required by
+            # auth client admin views (e.g. the "admin_oauthclients" permission) are
+            # granted to admin users.
             #
-            # Other roots do not currently do this, but we rely on it for
-            # this root because it is used within the /admin pages.
+            # For details on how ACLs work see the docs for Pyramid's
+            # ACLAuthorizationPolicy:
+            # https://docs.pylonsproject.org/projects/pyramid/en/latest/api/authorization.html
             client.__parent__ = Root(self.request)
 
             return client

--- a/h/traversal/roots.py
+++ b/h/traversal/roots.py
@@ -68,6 +68,7 @@ from pyramid.security import (
     DENY_ALL,
     Allow,
 )
+import sqlalchemy.exc
 import sqlalchemy.orm.exc
 
 from h import storage
@@ -124,8 +125,9 @@ class AuthClientRoot(object):
     def __getitem__(self, client_id):
         try:
             client = self.request.db.query(AuthClient).filter_by(id=client_id).one()
-        except:  # noqa: E722
-            # No such client found or not a valid UUID.
+        except sqlalchemy.orm.exc.NoResultFound:
+            raise KeyError()
+        except sqlalchemy.exc.DataError:  # Happens when client_id is not a valid UUID.
             raise KeyError()
 
         # Add the default root factory to this resource's lineage so that the default

--- a/h/traversal/roots.py
+++ b/h/traversal/roots.py
@@ -77,7 +77,7 @@ from h.models import Group
 from h.models import Organization
 from h.auth import role
 from h.interfaces import IGroupService
-from h.traversal.contexts import AnnotationContext
+from h.traversal import contexts
 
 
 class Root(object):
@@ -108,7 +108,7 @@ class AnnotationRoot(object):
 
         group_service = self.request.find_service(IGroupService)
         links_service = self.request.find_service(name='links')
-        return AnnotationContext(annotation, group_service, links_service)
+        return contexts.AnnotationContext(annotation, group_service, links_service)
 
 
 class AuthClientRoot(object):

--- a/h/traversal/roots.py
+++ b/h/traversal/roots.py
@@ -124,21 +124,20 @@ class AuthClientRoot(object):
     def __getitem__(self, client_id):
         try:
             client = self.request.db.query(AuthClient).filter_by(id=client_id).one()
-
-            # Add the default root factory to this resource's lineage so that the
-            # default ACL is applied. This is needed so that permissions required by
-            # auth client admin views (e.g. the "admin_oauthclients" permission) are
-            # granted to admin users.
-            #
-            # For details on how ACLs work see the docs for Pyramid's
-            # ACLAuthorizationPolicy:
-            # https://docs.pylonsproject.org/projects/pyramid/en/latest/api/authorization.html
-            client.__parent__ = Root(self.request)
-
-            return client
         except:  # noqa: E722
             # No such client found or not a valid UUID.
             raise KeyError()
+
+        # Add the default root factory to this resource's lineage so that the default
+        # ACL is applied. This is needed so that permissions required by auth client
+        # admin views (e.g. the "admin_oauthclients" permission) are granted to admin
+        # users.
+        #
+        # For details on how ACLs work see the docs for Pyramid's ACLAuthorizationPolicy:
+        # https://docs.pylonsproject.org/projects/pyramid/en/latest/api/authorization.html
+        client.__parent__ = Root(self.request)
+
+        return client
 
 
 class OrganizationRoot(object):

--- a/tests/h/traversal/roots_test.py
+++ b/tests/h/traversal/roots_test.py
@@ -77,7 +77,7 @@ class TestAnnotationRoot(object):
 
 
 class TestAuthClientRoot(object):
-    def test_get_item_returns_an_authclient(self, pyramid_request):
+    def test_getitem_returns_an_authclient(self, pyramid_request):
         authclient = AuthClient(name='test', authority='example.com')
         pyramid_request.db.add(authclient)
         pyramid_request.db.flush()
@@ -85,12 +85,12 @@ class TestAuthClientRoot(object):
         factory = AuthClientRoot(pyramid_request)
         assert factory[authclient.id] == authclient
 
-    def test_get_item_returns_keyerror_if_not_found(self, pyramid_request):
+    def test_getitem_returns_keyerror_if_not_found(self, pyramid_request):
         factory = AuthClientRoot(pyramid_request)
         with pytest.raises(KeyError):
             factory['E19D247D-1F07-4E91-B40D-00DF22E693E4']
 
-    def test_get_item_returns_keyerror_if_invalid(self, pyramid_request):
+    def test_getitem_returns_keyerror_if_invalid(self, pyramid_request):
         factory = AuthClientRoot(pyramid_request)
         with pytest.raises(KeyError):
             factory['not-a-uuid']

--- a/tests/h/traversal/roots_test.py
+++ b/tests/h/traversal/roots_test.py
@@ -76,7 +76,7 @@ class TestAnnotationRoot(object):
         return service
 
 
-class TestAuthClientResourceFactory(object):
+class TestAuthClientRoot(object):
     def test_get_item_returns_an_authclient(self, pyramid_request):
         authclient = AuthClient(name='test', authority='example.com')
         pyramid_request.db.add(authclient)

--- a/tests/h/traversal/roots_test.py
+++ b/tests/h/traversal/roots_test.py
@@ -2,9 +2,12 @@
 
 from __future__ import unicode_literals
 
+import pyramid.authorization
+import pyramid.security
 import pytest
 import mock
 
+import h.auth
 from h.models import AuthClient
 from h.services.user import UserService
 from h.traversal.roots import AnnotationRoot
@@ -77,23 +80,84 @@ class TestAnnotationRoot(object):
 
 
 class TestAuthClientRoot(object):
-    def test_getitem_returns_an_authclient(self, pyramid_request):
-        authclient = AuthClient(name='test', authority='example.com')
-        pyramid_request.db.add(authclient)
-        pyramid_request.db.flush()
+    def test_getitem_returns_the_right_AuthClient(self, db_session, pyramid_request):
+        # Add a couple of noise AuthClients to the DB. It should not return these.
+        db_session.add(AuthClient(authority="elifesciences.org"))
+        db_session.add(AuthClient(authority="localhost"))
 
-        factory = AuthClientRoot(pyramid_request)
-        assert factory[authclient.id] == authclient
+        # The AuthClient that we do expect it to return.
+        expected_auth_client = AuthClient(authority="hypothes.is")
+        db_session.add(expected_auth_client)
 
-    def test_getitem_returns_keyerror_if_not_found(self, pyramid_request):
-        factory = AuthClientRoot(pyramid_request)
+        db_session.flush()
+
+        auth_client = AuthClientRoot(pyramid_request)[expected_auth_client.id]
+
+        assert auth_client == expected_auth_client
+
+    def test_getitem_returns_KeyError_if_no_AuthClients_in_DB(self, pyramid_request):
+        auth_client_root = AuthClientRoot(pyramid_request)
+
         with pytest.raises(KeyError):
-            factory['E19D247D-1F07-4E91-B40D-00DF22E693E4']
+            auth_client_root["1d5937d6-73be-11e8-9125-871084ad92cf"]
 
-    def test_getitem_returns_keyerror_if_invalid(self, pyramid_request):
-        factory = AuthClientRoot(pyramid_request)
+    def test_getitem_returns_KeyError_if_no_matching_AuthClient_in_DB(self, db_session, pyramid_request):
+        # Add a couple of noise AuthClients to the DB. It should not return these.
+        db_session.add(AuthClient(authority="elifesciences.org", id="c396be08-73bd-11e8-a791-e76551a909f6"))
+        db_session.add(AuthClient(authority="localhost", id="cf482552-73bd-11e8-a791-c37e5c2510d8"))
+
+        auth_client_root = AuthClientRoot(pyramid_request)
+
         with pytest.raises(KeyError):
-            factory['not-a-uuid']
+            auth_client_root["1d5937d6-73be-11e8-9125-871084ad92cf"]
+
+    def test_getitem_returns_KeyError_if_client_id_is_invalid(self, pyramid_request):
+        auth_client_root = AuthClientRoot(pyramid_request)
+
+        with pytest.raises(KeyError):
+            auth_client_root["this_is_not_a_valid_UUID"]
+
+    @pytest.mark.parametrize("permission", ("foo", "bar", "admin_oauthclients"))
+    def test_getitem_grants_admins_all_permissions_on_the_AuthClient(
+            self, db_session, permission, pyramid_request):
+        auth_client = AuthClient(authority="hypothes.is")
+        db_session.add(auth_client)
+        db_session.flush()
+        auth_policy = pyramid.authorization.ACLAuthorizationPolicy()
+
+        auth_client = AuthClientRoot(pyramid_request)[auth_client.id]
+
+        assert auth_policy.permits(
+            context=auth_client,
+            principals=(h.auth.role.Admin,),
+            permission=permission,
+        )
+
+    @pytest.mark.parametrize("permission", ("foo", "bar", "admin_oauthclients"))
+    def test_getitem_doesnt_grant_non_admins_all_permissions_on_the_AuthClient(
+            self, db_session, factories, permission, pyramid_request):
+        user = factories.User()
+        auth_client = AuthClient(authority="hypothes.is")
+        db_session.add(auth_client)
+        db_session.flush()
+        auth_policy = pyramid.authorization.ACLAuthorizationPolicy()
+
+        auth_client = AuthClientRoot(pyramid_request)[auth_client.id]
+
+        assert not auth_policy.permits(
+            context=auth_client,
+            # Simulate the principals that a real non-admin request would have: lots of
+            # principals but not h.auth.role.Admin.
+            principals=(
+                pyramid.security.Everyone,
+                pyramid.security.Authenticated,
+                h.auth.role.Staff,
+                "group:__world__",
+                "authority:example.com",
+                user.userid,
+            ),
+            permission=permission,
+        )
 
 
 @pytest.mark.usefixtures('organizations')

--- a/tests/h/views/admin_oauthclients_test.py
+++ b/tests/h/views/admin_oauthclients_test.py
@@ -202,19 +202,18 @@ class TestAuthClientEditController(object):
                 'grant_type': authclient.grant_type,
                 'response_type': authclient.response_type}
 
+    @pytest.fixture
+    def authclient(self, pyramid_request):
+        client = AuthClient(name='testclient',
+                            authority='annotator.org',
+                            secret='not_a_secret',
+                            trusted=False,
+                            grant_type=GrantType.authorization_code,
+                            response_type=ResponseType.code)
 
-@pytest.fixture
-def authclient(pyramid_request):
-    client = AuthClient(name='testclient',
-                        authority='annotator.org',
-                        secret='not_a_secret',
-                        trusted=False,
-                        grant_type=GrantType.authorization_code,
-                        response_type=ResponseType.code)
+        pyramid_request.db.add(client)
 
-    pyramid_request.db.add(client)
-
-    return client
+        return client
 
 
 @pytest.fixture


### PR DESCRIPTION
Various tidy ups that I did while I was poking at the the `AuthClientRoot` code yesterday: code comments and formatting, remove oversized `try` block, remove bare `except`, improve tests, fix out-of-date test class name, etc.