### PR TITLE
Remove unused `JSONError` from app

### DIFF
--- a/h/accounts/__init__.py
+++ b/h/accounts/__init__.py
@@ -5,25 +5,6 @@ from itsdangerous import URLSafeTimedSerializer
 from h.security import derive_key
 
 
-class Error(Exception):
-
-    """Base class for this package's custom exception classes."""
-
-    pass
-
-
-class JSONError(Error):
-
-    """Exception raised when there's a problem with a request's JSON body.
-
-    This is for pre-validation problems such as no JSON body, body cannot
-    be parsed as JSON, or top-level keys missing from the JSON.
-
-    """
-
-    pass
-
-
 def get_user(request):
     """Return the user for the request or None.
 

--- a/h/views/accounts.py
+++ b/h/views/accounts.py
@@ -70,15 +70,6 @@ def bad_csrf_token_json(context, request):
     }
 
 
-@json_view(context=accounts.JSONError)
-def error_json(error, request):
-    request.response.status_code = 400
-    return {
-        'status': 'failure',
-        'reason': str(error),
-    }
-
-
 @json_view(context=deform.ValidationFailure)
 def error_validation(error, request):
     request.response.status_code = 400


### PR DESCRIPTION
This tiny PR removes the custom `JSONError` from `h.accounts`. It appears to be unused. I need a sanity check on that, however, as I may be missing something Pyramid-y here.

Goal: remove small bits of unused code from app; be more explicitly consistent about error-handling.