### PR TITLE
Add `description` param and document `POST /groups` API

### DIFF
--- a/docs/_extra/api-reference/hypothesis.yaml
+++ b/docs/_extra/api-reference/hypothesis.yaml
@@ -263,7 +263,7 @@ paths:
       parameters:
         - name: group
           in: body
-          description: Group to be create
+          description: Group to be created
           required: true
           schema:
             $ref: '#/definitions/NewGroup'

--- a/docs/_extra/api-reference/hypothesis.yaml
+++ b/docs/_extra/api-reference/hypothesis.yaml
@@ -253,6 +253,29 @@ paths:
           description: Success
           schema:
             $ref: '#/definitions/GroupResults'
+    post:
+      tags:
+        - groups
+      summary: Create a new group
+      operationId: createGroup
+      description: >
+        Create a new, private group for the currently-authenticated user.
+      parameters:
+        - name: group
+          in: body
+          description: Group to be create
+          required: true
+          schema:
+            $ref: '#/definitions/NewGroup'
+      responses:
+        '200':
+          description: Group successfully created
+          schema:
+            $ref: '#/definitions/GroupResult'
+        '400':
+          description: Could not create group from your request
+          schema:
+            $ref: '#/definitions/Error'
   /search:
     get:
       tags:
@@ -447,6 +470,10 @@ definitions:
       total:
         description: Total number of results matching query.
         type: integer
+  NewGroup:
+    $ref: './schemas/new-group.yaml#/Group'
+  GroupResult:
+    $ref: './schemas/group.yaml#/Group'
   GroupResults:
     type: array
     items:

--- a/docs/_extra/api-reference/schemas/new-group.yaml
+++ b/docs/_extra/api-reference/schemas/new-group.yaml
@@ -4,11 +4,11 @@ Group:
     name:
       type: string
       description: The name of the new group
-      minLength: 3
-      maxLength: 250
+      minLength: 4
+      maxLength: 25
     description:
       type: string
-      description: An optional description for the new group
+      description: group description
       maxLength: 250
   required:
     - name

--- a/docs/_extra/api-reference/schemas/new-group.yaml
+++ b/docs/_extra/api-reference/schemas/new-group.yaml
@@ -1,0 +1,14 @@
+Group:
+  type: object
+  properties:
+    name:
+      type: string
+      description: The name of the new group
+      minLength: 3
+      maxLength: 250
+    description:
+      type: string
+      description: An optional description for the new group
+      maxLength: 250
+  required:
+    - name

--- a/h/schemas/group.py
+++ b/h/schemas/group.py
@@ -6,6 +6,7 @@ from h.schemas.base import JSONSchema
 from h.models.group import (
     GROUP_NAME_MIN_LENGTH,
     GROUP_NAME_MAX_LENGTH,
+    GROUP_DESCRIPTION_MAX_LENGTH,
 )
 
 
@@ -18,6 +19,10 @@ class CreateGroupAPISchema(JSONSchema):
                 'type': 'string',
                 'minLength': GROUP_NAME_MIN_LENGTH,
                 'maxLength': GROUP_NAME_MAX_LENGTH,
+            },
+            'description': {
+                'type': 'string',
+                'maxLength': GROUP_DESCRIPTION_MAX_LENGTH,
             },
         },
         'required': [

--- a/h/views/api_groups.py
+++ b/h/views/api_groups.py
@@ -49,11 +49,17 @@ def create(request):
     schema = CreateGroupAPISchema()
 
     appstruct = schema.validate(_json_payload(request))
+    group_properties = {
+        'name': appstruct['name'],
+        'description': appstruct.get('description', None),
+    }
 
     group_service = request.find_service(name='group')
+
     group = group_service.create_private_group(
-        appstruct['name'],
-        request.user.userid
+        group_properties['name'],
+        request.user.userid,
+        description=group_properties['description'],
     )
     group_context = GroupContext(group, request)
     return GroupJSONPresenter(group_context).asdict(expand=['organization'])

--- a/h/views/api_groups.py
+++ b/h/views/api_groups.py
@@ -56,7 +56,7 @@ def create(request):
         request.user.userid
     )
     group_context = GroupContext(group, request)
-    return GroupJSONPresenter(group_context).asdict()
+    return GroupJSONPresenter(group_context).asdict(expand=['organization'])
 
 
 @api_config(route_name='api.group_member',

--- a/tests/h/schemas/group_test.py
+++ b/tests/h/schemas/group_test.py
@@ -6,6 +6,7 @@ import pytest
 from h.models.group import (
     GROUP_NAME_MIN_LENGTH,
     GROUP_NAME_MAX_LENGTH,
+    GROUP_DESCRIPTION_MAX_LENGTH,
 )
 
 from h.schemas.group import CreateGroupAPISchema
@@ -45,3 +46,23 @@ class TestCreateGroupSchema(object):
         })
 
         assert 'name' in appstruct
+
+    def test_it_validates_with_valid_description(self):
+        schema = CreateGroupAPISchema()
+
+        appstruct = schema.validate({
+            'name': 'This Seems Fine',
+            'description': 'This description seems adequate'
+        })
+
+        assert 'description' in appstruct
+
+    def test_it_raises_if_description_too_long(self):
+        schema = CreateGroupAPISchema()
+        with pytest.raises(ValidationError) as exc:
+            schema.validate({
+                'name': 'Name not the Problem',
+                'description': 'o' * (GROUP_DESCRIPTION_MAX_LENGTH + 1)
+            })
+        assert "description:" in str(exc.value)
+        assert "is too long" in str(exc.value)

--- a/tests/h/views/api_groups_test.py
+++ b/tests/h/views/api_groups_test.py
@@ -49,7 +49,7 @@ class TestGetGroups(object):
             document_uri=None
         )
 
-    def test_converts_groups_to_resources(self, GroupContext, anonymous_request, open_groups, list_groups_service):  # noqa: N803
+    def test_converts_groups_to_resources(self, GroupContext, anonymous_request, open_groups, list_groups_service):
         list_groups_service.request_groups.return_value = open_groups
 
         views.groups(anonymous_request)
@@ -59,7 +59,7 @@ class TestGetGroups(object):
             mock.call(open_groups[1], anonymous_request),
         ])
 
-    def test_uses_presenter_for_formatting(self,  # noqa: N803
+    def test_uses_presenter_for_formatting(self,
                                            group_links_service,
                                            open_groups,
                                            list_groups_service,
@@ -71,14 +71,14 @@ class TestGetGroups(object):
 
         GroupsJSONPresenter.assert_called_once()
 
-    def test_returns_dicts_from_presenter(self, anonymous_request, open_groups, list_groups_service, GroupsJSONPresenter):  # noqa: N803
+    def test_returns_dicts_from_presenter(self, anonymous_request, open_groups, list_groups_service, GroupsJSONPresenter):
         list_groups_service.request_groups.return_value = open_groups
 
         result = views.groups(anonymous_request)
 
         assert result == GroupsJSONPresenter(open_groups).asdicts.return_value
 
-    def test_proxies_expand_to_presenter(self, anonymous_request, open_groups, list_groups_service, GroupsJSONPresenter):  # noqa: N803
+    def test_proxies_expand_to_presenter(self, anonymous_request, open_groups, list_groups_service, GroupsJSONPresenter):
         anonymous_request.params['expand'] = 'organization'
         list_groups_service.request_groups.return_value = open_groups
 
@@ -86,7 +86,7 @@ class TestGetGroups(object):
 
         GroupsJSONPresenter(open_groups).asdicts.assert_called_once_with(expand=['organization'])
 
-    def test_passes_multiple_expand_to_presenter(self, anonymous_request, open_groups, list_groups_service, GroupsJSONPresenter):  # noqa: N803
+    def test_passes_multiple_expand_to_presenter(self, anonymous_request, open_groups, list_groups_service, GroupsJSONPresenter):
         anonymous_request.GET.add('expand', 'organization')
         anonymous_request.GET.add('expand', 'foobars')
         list_groups_service.request_groups.return_value = open_groups
@@ -111,7 +111,7 @@ class TestGetGroups(object):
                          'GroupJSONPresenter')
 class TestCreateGroup(object):
 
-    def test_it_inits_group_create_schema(self, pyramid_request, CreateGroupAPISchema):  # noqa: N803
+    def test_it_inits_group_create_schema(self, pyramid_request, CreateGroupAPISchema):
         views.create(pyramid_request)
 
         CreateGroupAPISchema.assert_called_once_with()
@@ -134,7 +134,7 @@ class TestCreateGroup(object):
         with pytest.raises(HTTPBadRequest):
             views.create(pyramid_request)
 
-    def test_it_passes_request_params_to_group_create_service(self,  # noqa: N803
+    def test_it_passes_request_params_to_group_create_service(self,
                                                               pyramid_request,
                                                               CreateGroupAPISchema,
                                                               group_service):
@@ -148,10 +148,10 @@ class TestCreateGroup(object):
                                                                    pyramid_request.user.userid,
                                                                    description='How about that?')
 
-    def test_it_sets_description_to_none_if_not_present(self,  # noqa: N803
-                                                           pyramid_request,
-                                                           CreateGroupAPISchema,
-                                                           group_service):
+    def test_it_sets_description_to_none_if_not_present(self,
+                                                        pyramid_request,
+                                                        CreateGroupAPISchema,
+                                                        group_service):
         CreateGroupAPISchema.return_value.validate.return_value = {
           'name': 'My Group',
          }
@@ -161,7 +161,7 @@ class TestCreateGroup(object):
                                                                    pyramid_request.user.userid,
                                                                    description=None)
 
-    def test_it_creates_group_context_from_created_group(self,   # noqa: N803
+    def test_it_creates_group_context_from_created_group(self,
                                                          pyramid_request,
                                                          GroupContext,
                                                          group_service):
@@ -172,7 +172,7 @@ class TestCreateGroup(object):
 
         GroupContext.assert_called_with(my_group, pyramid_request)
 
-    def test_it_returns_new_group_formatted_with_presenter(self,   # noqa: N803
+    def test_it_returns_new_group_formatted_with_presenter(self,
                                                            pyramid_request,
                                                            GroupContext,
                                                            GroupJSONPresenter):
@@ -237,22 +237,22 @@ def anonymous_request(pyramid_request):
 
 
 @pytest.fixture
-def GroupJSONPresenter(patch):  # noqa: N802
+def GroupJSONPresenter(patch):
     return patch('h.views.api_groups.GroupJSONPresenter')
 
 
 @pytest.fixture
-def GroupsJSONPresenter(patch):  # noqa: N802
+def GroupsJSONPresenter(patch):
     return patch('h.views.api_groups.GroupsJSONPresenter')
 
 
 @pytest.fixture
-def GroupContext(patch):  # noqa: N802
+def GroupContext(patch):
     return patch('h.views.api_groups.GroupContext')
 
 
 @pytest.fixture
-def CreateGroupAPISchema(patch):  # noqa: N802
+def CreateGroupAPISchema(patch):
     return patch('h.views.api_groups.CreateGroupAPISchema')
 
 

--- a/tests/h/views/api_groups_test.py
+++ b/tests/h/views/api_groups_test.py
@@ -161,7 +161,7 @@ class TestCreateGroup(object):
         views.create(pyramid_request)
 
         GroupJSONPresenter.assert_called_once_with(GroupContext.return_value)
-        GroupJSONPresenter.return_value.asdict.assert_called_once_with()
+        GroupJSONPresenter.return_value.asdict.assert_called_once_with(expand=['organization'])
 
     @pytest.fixture
     def pyramid_request(self, pyramid_request, factories):

--- a/tests/h/views/api_groups_test.py
+++ b/tests/h/views/api_groups_test.py
@@ -138,10 +138,28 @@ class TestCreateGroup(object):
                                                               pyramid_request,
                                                               CreateGroupAPISchema,
                                                               group_service):
-        CreateGroupAPISchema.return_value.validate.return_value = {'name': 'My Group'}
+        CreateGroupAPISchema.return_value.validate.return_value = {
+          'name': 'My Group',
+          'description': 'How about that?',
+         }
         views.create(pyramid_request)
 
-        group_service.create_private_group.assert_called_once_with('My Group', pyramid_request.user.userid)
+        group_service.create_private_group.assert_called_once_with('My Group',
+                                                                   pyramid_request.user.userid,
+                                                                   description='How about that?')
+
+    def test_it_sets_description_to_none_if_not_present(self,  # noqa: N803
+                                                           pyramid_request,
+                                                           CreateGroupAPISchema,
+                                                           group_service):
+        CreateGroupAPISchema.return_value.validate.return_value = {
+          'name': 'My Group',
+         }
+        views.create(pyramid_request)
+
+        group_service.create_private_group.assert_called_once_with('My Group',
+                                                                   pyramid_request.user.userid,
+                                                                   description=None)
 
     def test_it_creates_group_context_from_created_group(self,   # noqa: N803
                                                          pyramid_request,


### PR DESCRIPTION
This PR continues work on https://github.com/hypothesis/product-backlog/issues/681

It adds support for a `description` parameter to the `POST /groups` API endpoint. It also adds documentation (see screenshot).

![image](https://user-images.githubusercontent.com/439947/41680308-157d222a-749f-11e8-92e8-20b959f049ff.png)

`description` is not a required parameter.

*Note*: I noticed that we don't return a `description` field for our Group resource (responses). Perhaps we should?