### PR TITLE
Change AuthClientRoot to return AuthClientContext

### DIFF
--- a/h/traversal/__init__.py
+++ b/h/traversal/__init__.py
@@ -10,6 +10,7 @@ from h.traversal.roots import GroupRoot
 from h.traversal.roots import UserRoot
 from h.traversal.contexts import AnnotationContext
 from h.traversal.contexts import AuthClientContext
+from h.traversal.contexts import AuthClientIndexContext
 from h.traversal.contexts import OrganizationContext
 from h.traversal.contexts import GroupContext
 
@@ -24,6 +25,7 @@ __all__ = (
     "UserRoot",
     "AnnotationContext",
     "AuthClientContext",
+    "AuthClientIndexContext",
     "OrganizationContext",
     "GroupContext",
 )

--- a/h/traversal/__init__.py
+++ b/h/traversal/__init__.py
@@ -9,6 +9,7 @@ from h.traversal.roots import OrganizationLogoRoot
 from h.traversal.roots import GroupRoot
 from h.traversal.roots import UserRoot
 from h.traversal.contexts import AnnotationContext
+from h.traversal.contexts import AuthClientContext
 from h.traversal.contexts import OrganizationContext
 from h.traversal.contexts import GroupContext
 
@@ -22,6 +23,7 @@ __all__ = (
     "GroupRoot",
     "UserRoot",
     "AnnotationContext",
+    "AuthClientContext",
     "OrganizationContext",
     "GroupContext",
 )

--- a/h/traversal/contexts.py
+++ b/h/traversal/contexts.py
@@ -76,6 +76,13 @@ class AnnotationContext(object):
         return principals_allowed_by_permission(group, 'read')
 
 
+class AuthClientContext(object):
+    """Context for AuthClient-based views."""
+
+    def __init__(self, auth_client):
+        self.auth_client = auth_client
+
+
 class OrganizationContext(object):
     """Context for organization-based views."""
 

--- a/h/traversal/contexts.py
+++ b/h/traversal/contexts.py
@@ -83,6 +83,12 @@ class AuthClientContext(object):
         self.auth_client = auth_client
 
 
+class AuthClientIndexContext(object):
+    """Context for views based on a list of AuthClients."""
+    def __init__(self, auth_clients):
+        self.auth_clients = auth_clients
+
+
 class OrganizationContext(object):
     """Context for organization-based views."""
 

--- a/h/traversal/roots.py
+++ b/h/traversal/roots.py
@@ -112,13 +112,7 @@ class AnnotationRoot(object):
 
 
 class AuthClientRoot(object):
-    """
-    Root factory for routes whose context is an :py:class:`h.traversal.AuthClientContext`.
-
-    FIXME: This class should return AuthClientContext objects, not AuthClient
-    objects.
-
-    """
+    """Root factory for :py:class:`h.traversal.AuthClientContext`-based routes."""
     def __init__(self, request):
         self.request = request
 

--- a/h/traversal/roots.py
+++ b/h/traversal/roots.py
@@ -130,6 +130,8 @@ class AuthClientRoot(object):
         except sqlalchemy.exc.DataError:  # Happens when client_id is not a valid UUID.
             raise KeyError()
 
+        context = contexts.AuthClientContext(client)
+
         # Add the default root factory to this resource's lineage so that the default
         # ACL is applied. This is needed so that permissions required by auth client
         # admin views (e.g. the "admin_oauthclients" permission) are granted to admin
@@ -137,9 +139,9 @@ class AuthClientRoot(object):
         #
         # For details on how ACLs work see the docs for Pyramid's ACLAuthorizationPolicy:
         # https://docs.pylonsproject.org/projects/pyramid/en/latest/api/authorization.html
-        client.__parent__ = Root(self.request)
+        context.__parent__ = Root(self.request)
 
-        return client
+        return context
 
 
 class OrganizationRoot(object):

--- a/h/traversal/roots.py
+++ b/h/traversal/roots.py
@@ -138,6 +138,18 @@ class AuthClientRoot(object):
         return context
 
 
+class AuthClientIndexRoot(object):
+    """Root factory for :py:class:`h.traversal.AuthClientContext`-based index routes."""
+    def __init__(self, request):
+        self.request = request
+
+    def __getitem__(self):
+        auth_clients = self.request.db.query(AuthClient).order_by(AuthClient.name.asc()).all()
+        context = contexts.AuthClientIndexContext(auth_clients)
+        context.__parent__ = Root(self.request)
+        return context
+
+
 class OrganizationRoot(object):
     """
     Root factory for routes whose context is an :py:class:`h.traversal.OrganizationContext`.

--- a/h/views/admin_oauthclients.py
+++ b/h/views/admin_oauthclients.py
@@ -24,11 +24,8 @@ def _response_type_for_grant_type(grant_type):
 @view_config(route_name='admin_oauthclients',
              renderer='h:templates/admin/oauthclients.html.jinja2',
              permission='admin_oauthclients')
-def index(request):
-    clients = request.db.query(AuthClient) \
-                        .order_by(AuthClient.name.asc()) \
-                        .all()
-    return {'clients': clients}
+def index(auth_client_context, request):
+    return {"clients": auth_client_context.auth_clients}
 
 
 @view_defaults(route_name='admin_oauthclients_create',

--- a/h/views/admin_oauthclients.py
+++ b/h/views/admin_oauthclients.py
@@ -91,9 +91,9 @@ class AuthClientCreateController(object):
                renderer='h:templates/admin/oauthclients_edit.html.jinja2')
 class AuthClientEditController(object):
 
-    def __init__(self, client, request):
+    def __init__(self, auth_client_context, request):
         self.request = request
-        self.client = client
+        self.client = auth_client_context.auth_client
         self.schema = EditAuthClientSchema().bind(request=request)
         self.form = request.create_form(self.schema,
                                         buttons=(_('Save'),))

--- a/tests/h/traversal/roots_test.py
+++ b/tests/h/traversal/roots_test.py
@@ -91,9 +91,9 @@ class TestAuthClientRoot(object):
 
         db_session.flush()
 
-        auth_client = AuthClientRoot(pyramid_request)[expected_auth_client.id]
+        auth_client_context = AuthClientRoot(pyramid_request)[expected_auth_client.id]
 
-        assert auth_client == expected_auth_client
+        assert auth_client_context.auth_client == expected_auth_client
 
     def test_getitem_returns_KeyError_if_no_AuthClients_in_DB(self, pyramid_request):
         auth_client_root = AuthClientRoot(pyramid_request)

--- a/tests/h/views/admin_oauthclients_test.py
+++ b/tests/h/views/admin_oauthclients_test.py
@@ -6,7 +6,7 @@ from mock import create_autospec, Mock
 import pytest
 
 from h.models.auth_client import AuthClient, GrantType, ResponseType
-from h.traversal import AuthClientContext
+from h import traversal
 from h.views.admin_oauthclients import index, AuthClientCreateController, AuthClientEditController
 
 
@@ -32,15 +32,16 @@ class FakeForm(object):
 
 
 def test_index_lists_authclients_sorted_by_name(pyramid_request, routes):
-    clients = [AuthClient(authority='foo.org', name='foo'),
-               AuthClient(authority='foo.org', name='bar')]
-    for client in clients:
-        pyramid_request.db.add(client)
+    auth_clients = [
+        AuthClient(authority='foo.org', name='foo'),
+        AuthClient(authority='foo.org', name='bar'),
+    ]
+    auth_client_context = create_autospec(
+        traversal.AuthClientIndexContext, instance=True, auth_clients=auth_clients)
 
-    ctx = index(pyramid_request)
+    template_context = index(auth_client_context, pyramid_request)
 
-    expected_clients = [clients[1], clients[0]]
-    assert ctx == {'clients': expected_clients}
+    assert template_context == {"clients": auth_clients}
 
 
 @pytest.mark.usefixtures('routes')
@@ -219,7 +220,7 @@ class TestAuthClientEditController(object):
 
     @pytest.fixture
     def auth_client_context(self, authclient):
-        return AuthClientContext(authclient)
+        return traversal.AuthClientContext(authclient)
 
 
 @pytest.fixture

--- a/tests/h/views/admin_oauthclients_test.py
+++ b/tests/h/views/admin_oauthclients_test.py
@@ -6,6 +6,7 @@ from mock import create_autospec, Mock
 import pytest
 
 from h.models.auth_client import AuthClient, GrantType, ResponseType
+from h.traversal import AuthClientContext
 from h.views.admin_oauthclients import index, AuthClientCreateController, AuthClientEditController
 
 
@@ -128,18 +129,18 @@ class TestAuthClientCreateController(object):
 @pytest.mark.usefixtures('routes')
 class TestAuthClientEditController(object):
 
-    def test_read_renders_form(self, authclient, pyramid_request):
-        ctrl = AuthClientEditController(authclient, pyramid_request)
+    def test_read_renders_form(self, authclient, auth_client_context, pyramid_request):
+        ctrl = AuthClientEditController(auth_client_context, pyramid_request)
 
         ctx = ctrl.read()
 
         assert ctx['form'] == self._expected_form(authclient)
 
-    def test_update_updates_authclient(self, authclient, form_post, pyramid_request):
+    def test_update_updates_authclient(self, authclient, auth_client_context, form_post, pyramid_request):
         form_post['client_id'] = authclient.id
         form_post['client_secret'] = authclient.secret
         pyramid_request.POST = form_post
-        ctrl = AuthClientEditController(authclient, pyramid_request)
+        ctrl = AuthClientEditController(auth_client_context, pyramid_request)
 
         ctx = ctrl.update()
 
@@ -150,24 +151,25 @@ class TestAuthClientEditController(object):
         ('authorization_code', ResponseType.code),
         ('jwt_bearer', None),
     ])
-    def test_update_sets_response_type(self, authclient, form_post, pyramid_request,
-                                       grant_type, expected_response_type):
+    def test_update_sets_response_type(self, authclient, auth_client_context, form_post,
+                                       pyramid_request, grant_type,
+                                       expected_response_type):
         pyramid_request.POST = form_post
         pyramid_request.POST['grant_type'] = grant_type
-        ctrl = AuthClientEditController(authclient, pyramid_request)
+        ctrl = AuthClientEditController(auth_client_context, pyramid_request)
 
         ctrl.update()
 
         assert authclient.response_type == expected_response_type
 
-    def test_update_does_not_update_read_only_fields(self, authclient, form_post, pyramid_request):
+    def test_update_does_not_update_read_only_fields(self, authclient, auth_client_context, form_post, pyramid_request):
         # Attempt to modify read-only ID and secret fields.
         old_id = authclient.id
         old_secret = authclient.secret
         form_post['client_id'] = 'new-id'
         form_post['client_secret'] = 'new-secret'
         pyramid_request.POST = form_post
-        ctrl = AuthClientEditController(authclient, pyramid_request)
+        ctrl = AuthClientEditController(auth_client_context, pyramid_request)
 
         ctx = ctrl.update()
 
@@ -175,17 +177,17 @@ class TestAuthClientEditController(object):
         assert authclient.secret == old_secret
         assert ctx['form'] == self._expected_form(authclient)
 
-    def test_delete_removes_authclient(self, authclient, matchers, pyramid_request):
+    def test_delete_removes_authclient(self, authclient, auth_client_context, matchers, pyramid_request):
         pyramid_request.db.delete = create_autospec(pyramid_request.db.delete, return_value=None)
-        ctrl = AuthClientEditController(authclient, pyramid_request)
+        ctrl = AuthClientEditController(auth_client_context, pyramid_request)
 
         ctrl.delete()
 
         pyramid_request.db.delete.assert_called_with(authclient)
 
-    def test_delete_redirects_to_index(self, authclient, matchers, pyramid_request):
+    def test_delete_redirects_to_index(self, authclient, auth_client_context, matchers, pyramid_request):
         pyramid_request.db.delete = create_autospec(pyramid_request.db.delete, return_value=None)
-        ctrl = AuthClientEditController(authclient, pyramid_request)
+        ctrl = AuthClientEditController(auth_client_context, pyramid_request)
 
         response = ctrl.delete()
 
@@ -214,6 +216,10 @@ class TestAuthClientEditController(object):
         pyramid_request.db.add(client)
 
         return client
+
+    @pytest.fixture
+    def auth_client_context(self, authclient):
+        return AuthClientContext(authclient)
 
 
 @pytest.fixture


### PR DESCRIPTION
This is part of the resources refactoring here: <https://github.com/hypothesis/h/issues/5015>.

Change `AuthClientRoot` to return `AuthClientContext`'s that wrap `models.AuthClient` objects, rather than returning `AuthClient` models directly. The reason for doing this is that context objects are more generally useful objects for views than model objects used as contexts - context objects can have properties and methods  that do things based on the `request`.

In the case of `AuthClient` though there _isn't_ anything that the views need `AuthClientContext` to do (yet) that a `models.AuthClient` doesn't already do. So this doesn't give us anything, other than putting it in place for potential use, and consistency with how other `*Root` classes are going to behave (but most other `*Root` classes haven't been refactored to return contexts rather than models yet, so there's nothing to be consistent with yet). For this reason I'm closing this PR now and may return to it later.

P.S. This PR also adds an `AuthClientIndexContext` for the page that lists all the `AuthClient`'s to use. This moves the sqlalchemy query out of the view and into the resources, which I like (and is one of the aims of #5015.