### PR TITLE
Update the database migration template

### DIFF
--- a/h/migrations/script.py.mako
+++ b/h/migrations/script.py.mako
@@ -1,14 +1,14 @@
-"""
-${message}
-"""
-
+<%text># -*- coding: utf-8 -*-</%text>
+"""${message}"""
 from __future__ import unicode_literals
+from __future__ import absolute_import
+from __future__ import division
 
 from alembic import op
 ${imports if imports else ""}
 
-revision = ${repr(str(up_revision))}
-down_revision = ${repr(str(down_revision))}
+revision = "${str(up_revision)}"
+down_revision = "${str(down_revision)}"
 
 
 def upgrade():


### PR DESCRIPTION
* Add a `-*- coding: utf-8` comment
* Add all the `__future__` imports for Python 3 compat
* Format the code using Black

Example output:

    # -*- coding: utf-8 -*-
    """Add the new table."""
    from __future__ import unicode_literals
    from __future__ import absolute_import
    from __future__ import division
    from __future__ import print_function

    from alembic import op

    revision = "71c7c16e3a16"
    down_revision = "5dd2dd5547a2"

    def upgrade():
        pass

    def downgrade():
        pass