### PR TITLE
Add a string representation to UserIdentity

### DIFF
--- a/h/models/user_identity.py
+++ b/h/models/user_identity.py
@@ -13,3 +13,8 @@ class UserIdentity(Base):
     id = sa.Column(sa.Integer(), autoincrement=True, primary_key=True)
     provider = sa.Column(sa.UnicodeText(), nullable=False)
     provider_unique_id = sa.Column(sa.UnicodeText(), nullable=False)
+
+    def __repr__(self):
+        return "{}(provider={!r}, provider_unique_id={!r})".format(
+            self.__class__.__name__, self.provider, self.provider_unique_id
+        )

--- a/tests/h/models/user_identity_test.py
+++ b/tests/h/models/user_identity_test.py
@@ -5,6 +5,7 @@ import pytest
 import sqlalchemy.exc
 
 from h import models
+from h._compat import PY2
 
 
 class TestUserIdentity(object):
@@ -86,3 +87,17 @@ class TestUserIdentity(object):
         )
 
         db_session.flush()
+
+    def test_repr(self):
+        user_identity = models.UserIdentity(
+            provider="provider_1", provider_unique_id="1"
+        )
+
+        expected_repr = "UserIdentity(provider='provider_1', provider_unique_id='1')"
+
+        if PY2:
+            expected_repr = (
+                "UserIdentity(provider=u'provider_1', " "provider_unique_id=u'1')"
+            )
+
+        assert repr(user_identity) == expected_repr


### PR DESCRIPTION
This is used for example by the Python shell when it renders a
UserIdentity:

    >>> UserIdentity(provider=u"lms", provider_unique_id=u"abc123")
    UserIdentity(provider=u'lms', provider_unique_id=u'abc123')

Instead of what it currently does on master:

    >>> UserIdentity(provider=u"lms", provider_unique_id=u"abc123")
    <h.models.user_identity.UserIdentity at 0x7f104c3ec450>

I've designed the repr string so that if you were to copy-paste it then
it would be valid Python for constructing a new UserIdentity the same as
this one. I think this is a good general approach to repr strings (when
it can be done easily).