### PR TITLE
Add optional many->one User->UserIdentity relation

### DIFF
--- a/h/models/user.py
+++ b/h/models/user.py
@@ -194,6 +194,8 @@ class User(Base):
     #: A NULL value in this column indicates the user has never accepted a privacy policy.
     privacy_accepted = sa.Column(sa.DateTime, nullable=True)
 
+    identities = sa.orm.relationship("UserIdentity", backref="user", cascade="all, delete-orphan")
+
     @hybrid_property
     def username(self):
         return self._username

--- a/h/models/user_identity.py
+++ b/h/models/user_identity.py
@@ -13,6 +13,9 @@ class UserIdentity(Base):
     id = sa.Column(sa.Integer(), autoincrement=True, primary_key=True)
     provider = sa.Column(sa.UnicodeText(), nullable=False)
     provider_unique_id = sa.Column(sa.UnicodeText(), nullable=False)
+    user_id = sa.Column(
+        sa.Integer(), sa.ForeignKey("user.id", ondelete="cascade"), nullable=False
+    )
 
     def __repr__(self):
         return "{}(provider={!r}, provider_unique_id={!r})".format(

--- a/tests/h/models/user_identity_test.py
+++ b/tests/h/models/user_identity_test.py
@@ -9,15 +9,17 @@ from h._compat import PY2
 
 
 class TestUserIdentity(object):
-    def test_you_can_save_and_then_retrieve_field_values(self, db_session, matchers):
+    def test_you_can_save_and_then_retrieve_field_values(
+        self, db_session, matchers, user
+    ):
         user_identity_1 = models.UserIdentity(
-            provider="provider_1", provider_unique_id="1"
+            provider="provider_1", provider_unique_id="1", user=user
         )
         user_identity_2 = models.UserIdentity(
-            provider="provider_1", provider_unique_id="2"
+            provider="provider_1", provider_unique_id="2", user=user
         )
         user_identity_3 = models.UserIdentity(
-            provider="provider_2", provider_unique_id="3"
+            provider="provider_2", provider_unique_id="3", user=user
         )
 
         db_session.add_all([user_identity_1, user_identity_2, user_identity_3])
@@ -44,8 +46,8 @@ class TestUserIdentity(object):
         assert user_identities[1].provider_unique_id == "2"
         assert user_identities[2].provider_unique_id == "3"
 
-    def test_provider_cant_be_null(self, db_session):
-        db_session.add(models.UserIdentity(provider_unique_id="1"))
+    def test_provider_cant_be_null(self, db_session, user):
+        db_session.add(models.UserIdentity(provider_unique_id="1", user=user))
 
         with pytest.raises(
             sqlalchemy.exc.IntegrityError,
@@ -53,8 +55,8 @@ class TestUserIdentity(object):
         ):
             db_session.flush()
 
-    def test_provider_id_cant_be_null(self, db_session):
-        db_session.add(models.UserIdentity(provider="provider"))
+    def test_provider_id_cant_be_null(self, db_session, user):
+        db_session.add(models.UserIdentity(provider="provider", user=user))
 
         with pytest.raises(
             sqlalchemy.exc.IntegrityError,
@@ -62,11 +64,26 @@ class TestUserIdentity(object):
         ):
             db_session.flush()
 
-    def test_two_cant_have_the_same_provider_and_provider_id(self, db_session):
+    def test_user_cant_be_null(self, db_session):
+        db_session.add(models.UserIdentity(provider="provider", provider_unique_id="1"))
+
+        with pytest.raises(
+            sqlalchemy.exc.IntegrityError,
+            match='null value in column "user_id" violates not-null constraint',
+        ):
+            db_session.flush()
+
+    def test_two_cant_have_the_same_provider_and_provider_id(
+        self, db_session, factories
+    ):
         db_session.add_all(
             [
-                models.UserIdentity(provider="provider", provider_unique_id="id"),
-                models.UserIdentity(provider="provider", provider_unique_id="id"),
+                models.UserIdentity(
+                    provider="provider", provider_unique_id="id", user=factories.User()
+                ),
+                models.UserIdentity(
+                    provider="provider", provider_unique_id="id", user=factories.User()
+                ),
             ]
         )
 
@@ -76,17 +93,82 @@ class TestUserIdentity(object):
         ):
             db_session.flush()
 
-    def test_two_can_have_the_same_provider_id_but_different_providers(
-        self, db_session
+    def test_one_user_can_have_the_same_provider_id_from_different_providers(
+        self, db_session, user
     ):
         db_session.add_all(
             [
-                models.UserIdentity(provider="provider_1", provider_unique_id="id"),
-                models.UserIdentity(provider="provider_2", provider_unique_id="id"),
+                models.UserIdentity(
+                    provider="provider_1", provider_unique_id="id", user=user
+                ),
+                models.UserIdentity(
+                    provider="provider_2", provider_unique_id="id", user=user
+                ),
             ]
         )
 
         db_session.flush()
+
+    def test_different_users_can_have_the_same_provider_id_from_different_providers(
+        self, db_session, factories
+    ):
+        db_session.add_all(
+            [
+                models.UserIdentity(
+                    provider="provider_1",
+                    provider_unique_id="id",
+                    user=factories.User(),
+                ),
+                models.UserIdentity(
+                    provider="provider_2",
+                    provider_unique_id="id",
+                    user=factories.User(),
+                ),
+            ]
+        )
+
+        db_session.flush()
+
+    def test_removing_a_user_identity_from_a_user_deletes_the_user_identity_from_the_db(
+        self, db_session, user
+    ):
+        # Add a couple of noise UserIdentity's. These should not be removed
+        # from the DB.
+        models.UserIdentity(provider="provider", provider_unique_id="1", user=user)
+        models.UserIdentity(provider="provider", provider_unique_id="2", user=user)
+        # The UserIdentity that we are going to remove.
+        user_identity = models.UserIdentity(
+            provider="provider", provider_unique_id="3", user=user
+        )
+
+        user.identities.remove(user_identity)
+
+        assert user_identity not in db_session.query(models.UserIdentity).all()
+
+    def test_deleting_a_user_identity_removes_it_from_its_user(self, db_session, user):
+        # Add a couple of noise UserIdentity's. These should not be removed
+        # from user.identities.
+        models.UserIdentity(provider="provider", provider_unique_id="1", user=user)
+        models.UserIdentity(provider="provider", provider_unique_id="2", user=user)
+        # The UserIdentity that we are going to remove.
+        user_identity = models.UserIdentity(
+            provider="provider", provider_unique_id="3", user=user
+        )
+        db_session.commit()
+
+        db_session.delete(user_identity)
+
+        db_session.refresh(user)  # Make sure user.identities is up to date.
+        assert user_identity not in user.identities
+
+    def test_deleting_a_user_deletes_all_its_user_identities(self, db_session, user):
+        models.UserIdentity(provider="provider", provider_unique_id="1", user=user)
+        models.UserIdentity(provider="provider", provider_unique_id="2", user=user)
+        db_session.commit()
+
+        db_session.delete(user)
+
+        assert db_session.query(models.UserIdentity).count() == 0
 
     def test_repr(self):
         user_identity = models.UserIdentity(
@@ -101,3 +183,7 @@ class TestUserIdentity(object):
             )
 
         assert repr(user_identity) == expected_repr
+
+    @pytest.fixture
+    def user(self, factories):
+        return factories.User()


### PR DESCRIPTION
Depends on <https://github.com/hypothesis/h/pull/5096> and <https://github.com/hypothesis/h/pull/5098/>.

Each `UserIdentity` must belong to exactly one user.

Each `User` can have zero or more `UserIdentity`'s.

Usage:

```python
>>> from __future__ import unicode_literals
>>>
>>> user = models.User(username="user1", authority="hypothes.is", email="user1@hypothes.is")
>>>
>>> # The `user` field here is required (IntegrityError on DB flush if it's not present).
>>> user_identity = models.UserIdentity(provider="lms", provider_unique_id="1", user=user)
>>>
>>> user.identities
[<h.models.user_identity.UserIdentity at 0x7f9841265910>]
>>> user_identity.user
<User: user1>
>>>
>>> # Associate a second UserIdentity with the same User.
>>> user_identity_2 = models.UserIdentity(provider="another", provider_unique_id="1", user=user)
>>> user.identities
[<h.models.user_identity.UserIdentity at 0x7f9841265910>,
<h.models.user_identity.UserIdentity at 0x7f9840a3e610>]
>>>
>>> # UserIdentity is optional.
>>> user2 = models.User(username="user2", authority="hypothes.is", email="user2@hypothes.is")
>>>
>>> request.db.add_all((user, user2))
>>> request.db.flush()
>>> request.tm.commit()
```