### PR TITLE
Fix a broken test

### DIFF
--- a/tests/h/services/delete_user_test.py
+++ b/tests/h/services/delete_user_test.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 
 import pytest
 from mock import Mock, call
+import sqlalchemy
 
 from h.events import AnnotationEvent
 from h.models import Annotation, Document
@@ -60,7 +61,8 @@ class TestDeleteUserService(object):
 
         svc.delete(creator)
 
-        assert group in db_session.deleted
+        db_session.flush()
+        assert sqlalchemy.inspect(group).was_deleted
 
     def test_delete_user_fails_if_groups_have_collaborators(self, db_session, group_with_two_users, pyramid_request, svc):
         pyramid_request.db = db_session


### PR DESCRIPTION
My other branch adds a relationship to the `User` model which causes this test to start failing because the test is sensitive to database flushes:

This test was using `db_session.deleted` to test whether a group had
been deleted. This isn't reliable as this list of deleted objects gets
emptied when the db_session gets flushed, and changes to unrelated parts
of the models code (for example, adding a new relationship) can trigger
sqlalchemy auto flushes to happen where they weren't happening before.

Fix the test to use object state inspection instead:

https://docs.sqlalchemy.org/en/latest/orm/session_state_management.html

Use was_deleted rather than deleted as advised here:

https://docs.sqlalchemy.org/en/latest/orm/internals.html#sqlalchemy.orm.state.InstanceState.deleted

We also flush the db_session before asserting, to ensure that
was_deleted is up to date:

If the db_session has not been flushed by something else, or flushed
automatically, when we get to the assert then:

1. sqlalchemy.inspect(group).deleted and sqlalchemy.inspect(group).was_deleted will both be False
2. group will be found in db_session.deleted

But if db_session _has_ already been flushed by something else outside
of the test since the group was deleted then:

1. sqlalchemy.inspect(group).deleted and sqlalchemy.inspect(group).was_deleted will both be True
2. group will not be found in db_session.deleted

We can't be sure that nothing else has called flush() or triggered an auto flush, so we can't rely on `db_session.deleted`. But by explicitly calling flush() in the test we ensure that was_deleted
will be True if the group was deleted.