### PR TITLE
DB migration to make user.email nullable

### DIFF
--- a/h/migrations/versions/792debe852c3_make_user_email_nullable.py
+++ b/h/migrations/versions/792debe852c3_make_user_email_nullable.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+"""Make user.email nullable."""
+from __future__ import unicode_literals
+from __future__ import absolute_import
+from __future__ import division
+
+from alembic import op
+
+
+revision = "792debe852c3"
+down_revision = "2a414b3393be"
+
+
+def upgrade():
+    op.alter_column("user", "email", nullable=True)
+
+
+def downgrade():
+    op.alter_column("user", "email", nullable=False)


### PR DESCRIPTION
## NULL is not equal to NULL in Postgres

`NULL` is not equal to `NULL` in Postgres, i.e. `NULL = NULL` is false. So:

1. The `"uq__user__email" UNIQUE CONSTRAINT, btree (email, authority)` constraint that we have on our DB prevents the table from containing two rows with the same _non-null_ email and authority, but (once the `NOT NULL` constraint has been removed from `email`) the table is allowed to contain multiple rows with the same authority and `NULL` for the email. This is what we want.

2. You can't use `= NULL` in a query. This will find no results: `SELECT * FROM public.user WHERE email = NULL;`. Instead you have to use `IS`: `SELECT * FROM public.user WHERE email IS NULL;`. `NULL IS NULL` is true.

[Postgres docs about this](https://www.postgresql.org/docs/10/static/functions-comparison.html):

> Ordinary comparison operators yield `null` (signifying “unknown”), not true or false, when either input is null. For example, `7 = NULL` yields `null`, as does `7 <> NULL`
> 
> ...
> 
> To check whether a value is or is not null, use the predicates:
> 
>     expression IS NULL
>     expression IS NOT NULL
> 
> ...
> 
> Do not write `expression = NULL` because `NULL` is not “equal to” `NULL`. (The null value represents an unknown value, and it is not known whether two unknown values are equal.)

Also on the [Postgres docs on constraints](https://www.postgresql.org/docs/10/static/ddl-constraints.html), under **5.3.3. Unique Constraints**:

> In general, a unique constraint is violated if there is more than one row in the table where the values of all of the columns included in the constraint are equal. However, two null values are never considered equal in this comparison. That means even in the presence of a unique constraint it is possible to store duplicate rows that contain a null value in at least one of the constrained columns. This behavior conforms to the SQL standard, but we have heard that other SQL databases might not follow this rule. So be careful when developing applications that are intended to be portable.

## Testing the h DB after this migration

You can add multiple users with no email to the same authority:

```sql
postgres=# INSERT INTO public.user (username, authority) VALUES ('user1', 'hypothes.is');
INSERT 0 1
postgres=# INSERT INTO public.user (username, authority) VALUES ('user2', 'hypothes.is');
INSERT 0 1
```

You still can't add two users with the same non-null email to the same authority:

```sql
postgres=# INSERT INTO public.user (username, authority, email) VALUES ('user3', 'hypothes.is', 'me@me.com');
INSERT 0 1
postgres=# INSERT INTO public.user (username, authority, email) VALUES ('user4', 'hypothes.is', 'me@me.com');
ERROR:  duplicate key value violates unique constraint "uq__user__email"
DETAIL:  Key (email, authority)=(me@me.com, hypothes.is) already exists.
```

End result:

```sql
postgres=# SELECT username, authority, email FROM public.user;
 username |  authority  |   email   
----------+-------------+-----------
 user1    | hypothes.is | 
 user2    | hypothes.is | 
 user3    | hypothes.is | me@me.com
(3 rows)
```

Querying for users with a given email address does not return users without an email address:

```sql
postgres=# SELECT username, authority, email FROM public.user WHERE email = 'me@me.com';
 username |  authority  |   email   
----------+-------------+-----------
 user3    | hypothes.is | me@me.com
(1 row)
```

You can query for all users without an email address using `IS NULL` (`= NULL` would find no results):

```sql
postgres=# SELECT username, authority, email FROM public.user WHERE email IS NULL;
 username |  authority  | email 
----------+-------------+-------
 user2    | hypothes.is | 
 user1    | hypothes.is | 
(2 rows)
```