### PR TITLE
Make email nullable model

### DIFF
--- a/h/models/user.py
+++ b/h/models/user.py
@@ -260,6 +260,9 @@ class User(Base):
 
     @sa.orm.validates('email')
     def validate_email(self, key, email):
+        if email is None:
+            return email
+
         if len(email) > EMAIL_MAX_LENGTH:
             raise ValueError('email must be less than {max} characters '
                              'long'.format(max=EMAIL_MAX_LENGTH))

--- a/h/models/user.py
+++ b/h/models/user.py
@@ -285,6 +285,9 @@ class User(Base):
     @classmethod
     def get_by_email(cls, session, email, authority):
         """Fetch a user by email address."""
+        if email is None:
+            return None
+
         return session.query(cls).filter(
             sa.func.lower(cls.email) == email.lower(),
             cls.authority == authority,

--- a/h/models/user.py
+++ b/h/models/user.py
@@ -217,7 +217,7 @@ class User(Base):
     def userid(cls):  # noqa: N805
         return UserIDComparator(cls.username, cls.authority)
 
-    email = sa.Column(sa.UnicodeText(), nullable=False)
+    email = sa.Column(sa.UnicodeText())
 
     last_login_date = sa.Column(sa.TIMESTAMP(timezone=False),
                                 default=datetime.datetime.utcnow,

--- a/tests/h/models/user_test.py
+++ b/tests/h/models/user_test.py
@@ -224,12 +224,16 @@ class TestUserGetByEmail(object):
         actual = models.User.get_by_email(db_session, user.email, 'example.com')
         assert actual is None
 
+    def test_you_cannot_get_users_with_no_emails(self, db_session):
+        assert not models.User.get_by_email(db_session, None, "example.com")
+
     @pytest.fixture
     def users(self, db_session, factories):
         users = {
             'emily': factories.User(username='emily', email='emily@msn.com', authority='example.com'),
             'norma': factories.User(username='norma', email='norma@foo.org', authority='foo.org'),
             'meredith': factories.User(username='meredith', email='meredith@gmail.com', authority='example.com'),
+            'bob': factories.User(username='bob', email=None, authority='example.com'),
         }
         db_session.flush()
         return users

--- a/tests/h/models/user_test.py
+++ b/tests/h/models/user_test.py
@@ -81,6 +81,27 @@ class TestUserModelDataConstraints(object):
         with pytest.raises(ValueError):
             models.User(email='bob@b' + 'o' * 100 + 'b.com')
 
+    def test_can_create_user_with_null_email(self):
+        models.User(email=None)
+
+    def test_can_change_email_to_null(self):
+        user = models.User(email="bob@bob.com")
+
+        user.email = None
+
+    def test_cannot_create_two_users_with_same_non_null_email_and_authority(self, db_session, factories):
+        factories.User(email="bob@bob.com", authority="hypothes.is")
+        factories.User(email="bob@bob.com", authority="hypothes.is")
+
+        with pytest.raises(exc.IntegrityError, match='duplicate key value violates unique constraint "uq__user__email"'):
+            db_session.flush()
+
+    def test_can_create_two_users_with_same_null_email_and_authority(self, db_session, factories):
+        factories.User(email=None, authority="hypothes.is")
+        factories.User(email=None, authority="hypothes.is")
+
+        db_session.flush()
+
 
 class TestUserModelUserId(object):
 


### PR DESCRIPTION
Depends on <https://github.com/hypothesis/h/pull/5102>.

Usage:

    $ ./bin/hypothesis --dev shell
    >>> from __future__ import unicode_literals
    >>>
    >>> # You can add two users with the same authority and no email.
    >>> session.add(models.User(username="user1", authority="hypothes.is"))
    >>> session.add(models.User(username="user2", authority="hypothes.is"))
    >>> # Commit the transaction, no error:
    >>> request.tm.commit()

    >>> # You still can't add two users with the same authority and the
    >>> # same non-null email.
    >>> session.add(models.User(username="user3", authority="hypothes.is", email="me@me.com"))
    >>> session.add(models.User(username="user4", authority="hypothes.is", email="me@me.com"))
    >>> # You'll get an error when you try to commit the transaction.
    >>> # Note that because of a bug in the transaction library we're
    >>> # actually getting a TypeError here. But the underlying
    >>> # exception, which the transaction library is swallowing, is a
    >>> # database IntegrityError.
    >>> request.tm.commit()
    TypeError: 'unicode' does not have the buffer interface

    >>> # Querying.
    >>> session.query(models.User).all()
    [<User: user1>, <User: user2>, <User: user3>]

    >>> session.query(models.User).filter_by(email="me@me.com").all()
    [<User: user3>]

    >>> # SQLAlchemy handles the Postgres = NULL vs IS NULL stuff
    >>> # (see #5102 for notes)
    >>> # for us, so filter_by(email=None) works fine.
    >>> session.query(models.User).filter_by(email=None).all()
    [<User: user2>, <User: user1>]