### PR TITLE
Make existing queries compatible with Elasticsearch 6

### DIFF
--- a/tests/h/search/old_query_test.py
+++ b/tests/h/search/old_query_test.py
@@ -92,21 +92,13 @@ class TestBuilder(object):
         assert len(sort) == 1
         assert list(sort[0].keys()) == ["updated"]
 
-    def test_sort_includes_ignore_unmapped(self):
-        """'ignore_unmapped': True is used in the sort clause."""
-        builder = query.Builder()
-
-        q = builder.build({})
-
-        assert q["sort"][0]["updated"]["ignore_unmapped"] is True
-
     def test_with_custom_sort(self):
         """Custom sorts are returned in the query dict."""
         builder = query.Builder()
 
         q = builder.build({"sort": "title"})
 
-        assert q["sort"] == [{'title': {'ignore_unmapped': True, 'order': 'desc'}}]
+        assert q["sort"] == [{'title': {'unmapped_type': 'boolean', 'order': 'desc'}}]
 
     def test_order_defaults_to_desc(self):
         """'order': "desc" is returned in the q dict by default."""
@@ -268,10 +260,12 @@ class TestAuthFilter(object):
         authfilter = query.AuthFilter(request)
 
         assert authfilter({}) == {
-            'or': [
-                {'term': {'shared': True}},
-                {'term': {'user_raw': 'acct:doe@example.org'}},
-            ]
+            'bool': {
+                'should': [
+                    {'term': {'shared': True}},
+                    {'term': {'user_raw': 'acct:doe@example.org'}},
+                ],
+            }
         }
 
 
@@ -609,7 +603,7 @@ def test_nipsa_filter_filters_out_nipsad_annotations(group_service):
     assert query.nipsa_filter(group_service) == {
         "bool": {
             "should": [
-                {'not': {'term': {'nipsa': True}}},
+                {'bool': {'must_not': {'term': {'nipsa': True}}}},
                 {'exists': {'field': 'thread_ids'}},
             ]
         }

--- a/tests/h/search/query_test.py
+++ b/tests/h/search/query_test.py
@@ -97,8 +97,8 @@ class TestAuthFilter(object):
 
         assert sorted(result.annotation_ids) == sorted(shared_ids)
 
-    def test_logged_in_user_can_only_see_their_private_annotations(self,
-            search, pyramid_config, Annotation):
+    def test_logged_in_user_can_only_see_their_private_annotations(self, search, pyramid_config,
+                                                                   Annotation):
         userid = "acct:bar@auth2"
         pyramid_config.testing_securitypolicy(userid)
         # Make a private annotation from a different user.
@@ -110,8 +110,7 @@ class TestAuthFilter(object):
 
         assert sorted(result.annotation_ids) == sorted(users_private_ids)
 
-    def test_logged_in_user_can_see_shared_annotations(self,
-            search, pyramid_config, Annotation):
+    def test_logged_in_user_can_see_shared_annotations(self, search, pyramid_config, Annotation):
         userid = "acct:bar@auth2"
         pyramid_config.testing_securitypolicy(userid)
         shared_ids = [Annotation(userid="acct:foo@auth2", shared=True).id,


### PR DESCRIPTION
This PR makes a few changes to the existing query JSON to make it compatible with both Elasticsearch 1 and Elasticsearch 6. See the commit message for links to relevant parts of the ES documentation. The only remaining piece of query JSON which is not ES1/ES6 compatible is a change to the way [filters are specified](https://www.elastic.co/guide/en/elasticsearch/reference/6.2/query-dsl-filtered-query.html) which will require a branch based on the ES version.

----

- [x] Add test for NIPSA filter (https://github.com/hypothesis/h/pull/5120)
- [x] Add test for sorting of search results, including behaviour when an unknown sort field is specified (https://github.com/hypothesis/h/pull/5136)