### PR TITLE
Move `json_body` retrieval to `h.util.view`

### DIFF
--- a/h/util/view.py
+++ b/h/util/view.py
@@ -4,6 +4,8 @@ from __future__ import unicode_literals
 
 from pyramid.view import view_config
 
+from h.exceptions import PayloadError
+
 
 def handle_exception(request):
     """Handle an uncaught exception for the passed request."""
@@ -20,3 +22,15 @@ def json_view(**settings):
     settings.setdefault('accept', 'application/json')
     settings.setdefault('renderer', 'json')
     return view_config(**settings)
+
+
+def json_body(request):
+    """
+    Return a parsed JSON body for the request.
+
+    :raises PayloadError: if the body has no valid JSON body
+    """
+    try:
+        return request.json_body
+    except ValueError:
+        raise PayloadError()

--- a/h/views/api/groups.py
+++ b/h/views/api/groups.py
@@ -5,12 +5,12 @@ from __future__ import unicode_literals
 from pyramid import security
 from pyramid.httpexceptions import HTTPNoContent, HTTPBadRequest
 
-from h.exceptions import PayloadError
 from h.i18n import TranslationString as _  # noqa: N813
 from h.presenters import GroupJSONPresenter, GroupsJSONPresenter
 from h.schemas.group import CreateGroupAPISchema
 from h.traversal import GroupContext
 from h.views.api.config import api_config
+from h.util.view import json_body
 
 
 @api_config(route_name='api.groups',
@@ -48,7 +48,7 @@ def create(request):
 
     schema = CreateGroupAPISchema()
 
-    appstruct = schema.validate(_json_payload(request))
+    appstruct = schema.validate(json_body(request))
     group_properties = {
         'name': appstruct['name'],
         'description': appstruct.get('description', None),
@@ -83,16 +83,3 @@ def remove_member(group, request):
     group_service.member_leave(group, userid)
 
     return HTTPNoContent()
-
-
-# @TODO This is a duplication of code in h.views.api — move to a util module
-def _json_payload(request):
-    """
-    Return a parsed JSON payload for the request.
-
-    :raises PayloadError: if the body has no valid JSON body
-    """
-    try:
-        return request.json_body
-    except ValueError:
-        raise PayloadError()

--- a/h/views/api/users.py
+++ b/h/views/api/users.py
@@ -10,11 +10,11 @@ from pyramid.exceptions import HTTPNotFound
 from h import models
 from h.accounts import schemas
 from h.auth.util import basic_auth_creds
-from h.exceptions import ClientUnauthorized, PayloadError
+from h.exceptions import ClientUnauthorized
 from h.models.auth_client import GrantType
 from h.presenters import UserJSONPresenter
 from h.schemas import ValidationError
-from h.util.view import json_view
+from h.util.view import json_view, json_body
 
 
 @json_view(route_name='api.users', request_method='POST')
@@ -30,7 +30,7 @@ def create(request):
     client = _request_client(request)
 
     schema = schemas.CreateUserAPISchema()
-    appstruct = schema.validate(_json_payload(request))
+    appstruct = schema.validate(json_body(request))
 
     _check_authority(client, appstruct)
     appstruct['authority'] = client.authority
@@ -60,7 +60,7 @@ def update(request):
         raise HTTPNotFound()
 
     schema = schemas.UpdateUserAPISchema()
-    appstruct = schema.validate(_json_payload(request))
+    appstruct = schema.validate(json_body(request))
 
     _update_user(user, appstruct)
 
@@ -127,10 +127,3 @@ def _update_user(user, appstruct):
         user.email = appstruct['email']
     if 'display_name' in appstruct:
         user.display_name = appstruct['display_name']
-
-
-def _json_payload(request):
-    try:
-        return request.json_body
-    except ValueError:
-        raise PayloadError()

--- a/tests/h/views/api/annotations_test.py
+++ b/tests/h/views/api/annotations_test.py
@@ -10,6 +10,7 @@ from pyramid.config import Configurator
 from h.schemas import ValidationError
 from h.search.core import SearchResult
 from h.views.api import annotations as views
+from h.exceptions import PayloadError
 
 
 class TestIndex(object):
@@ -156,7 +157,7 @@ class TestCreate(object):
                                'json_body',
                                new_callable=mock.PropertyMock) as json_body:
             json_body.side_effect = ValueError()
-            with pytest.raises(views.PayloadError):
+            with pytest.raises(PayloadError):
                 views.create(pyramid_request)
 
     def test_it_inits_CreateAnnotationSchema(self, pyramid_request, create_schema):
@@ -328,7 +329,7 @@ class TestUpdate(object):
                                'json_body',
                                new_callable=mock.PropertyMock) as json_body:
             json_body.side_effect = ValueError()
-            with pytest.raises(views.PayloadError):
+            with pytest.raises(PayloadError):
                 views.update(mock.Mock(), pyramid_request)
 
     def test_it_validates_the_posted_data(self, pyramid_request, update_schema):

--- a/tests/h/views/api/groups_test.py
+++ b/tests/h/views/api/groups_test.py
@@ -11,6 +11,7 @@ from h.views.api import groups as views
 from h.services.list_groups import ListGroupsService
 from h.services.group import GroupService
 from h.services.group_links import GroupLinksService
+from h.exceptions import PayloadError
 
 pytestmark = pytest.mark.usefixtures('GroupsJSONPresenter')
 
@@ -116,7 +117,6 @@ class TestCreateGroup(object):
 
         CreateGroupAPISchema.assert_called_once_with()
 
-    # @TODO Move this test once _json_payload() has been moved to a reusable util module
     def test_it_raises_if_json_parsing_fails(self, pyramid_request):
         """It raises PayloadError if parsing of the request body fails."""
         # Make accessing the request.json_body property raise ValueError.
@@ -125,7 +125,7 @@ class TestCreateGroup(object):
                                'json_body',
                                new_callable=mock.PropertyMock) as json_body:
             json_body.side_effect = ValueError()
-            with pytest.raises(views.PayloadError):
+            with pytest.raises(PayloadError):
                 views.create(pyramid_request)
 
     def test_it_returns_400_if_user_has_non_default_authority(self, pyramid_request, factories):
@@ -183,7 +183,7 @@ class TestCreateGroup(object):
 
     @pytest.fixture
     def pyramid_request(self, pyramid_request, factories):
-        # Add a nominal json_body so that _json_payload() parsing of
+        # Add a nominal json_body so that parsing of
         # it doesn't raise
         pyramid_request.json_body = {}
         pyramid_request.user = factories.User()


### PR DESCRIPTION
Several API views had a redundant `_json_payload` method. This PR moves this functionality to the `h.util.view. module so as to DRY things out. It also renames it `json_body` as that is more apropos.