### PR TITLE
Fix reading of `SECRET_KEY` and `SECRET_SALT` env vars in Python 3

### DIFF
--- a/h/config.py
+++ b/h/config.py
@@ -56,8 +56,8 @@ def configure(environ=None, settings=None):
     settings_manager.set('statsd.prefix', 'STATSD_PREFIX')
 
     # Configuration for Pyramid
-    settings_manager.set('secret_key', 'SECRET_KEY', type_=bytes, required=True)
-    settings_manager.set('secret_salt', 'SECRET_SALT', type_=bytes, default=DEFAULT_SALT)
+    settings_manager.set('secret_key', 'SECRET_KEY', type_=_to_utf8, required=True)
+    settings_manager.set('secret_salt', 'SECRET_SALT', type_=_to_utf8, default=DEFAULT_SALT)
 
     # Configuration for h
     settings_manager.set('csp.enabled', 'CSP_ENABLED', type_=asbool)
@@ -123,3 +123,9 @@ def configure(environ=None, settings=None):
     es_logger.addFilter(ExceptionFilter((("ReadTimeout", "WARNING"),)))
 
     return Configurator(settings=settings)
+
+
+def _to_utf8(str_or_bytes):
+    if isinstance(str_or_bytes, bytes):
+        return str_or_bytes
+    return str_or_bytes.encode('utf-8')

--- a/tests/h/config_test.py
+++ b/tests/h/config_test.py
@@ -9,6 +9,8 @@ from h.config import configure
 @pytest.mark.parametrize('env_var,env_val,setting_name,setting_val', [
     (None, None, 'h.db_session_checks', True),
     ('DB_SESSION_CHECKS', "False", 'h.db_session_checks', False),
+    ('SECRET_KEY', 'dont_tell_anyone', 'secret_key', b'dont_tell_anyone'),
+    ('SECRET_SALT', 'best_with_pepper', 'secret_salt', b'best_with_pepper'),
 
     # There are many other settings that can be updated from env vars.
     # These are not currently tested.


### PR DESCRIPTION
If these env vars are set, they are read as strings. Calling
`bytes(str_value)` to cast them to byte strings fails in Python 3.
Instead `str.encode` has to be used, which defaults to UTF-8.

This fixes an issue that got overlooked during the recent settings refactoring.