### PR TITLE
Make badge requests cheaper for URIs that have never been annotated

### DIFF
--- a/h/views/badge.py
+++ b/h/views/badge.py
@@ -7,6 +7,7 @@ import newrelic.agent
 
 from h import models, search
 from h.util.view import json_view
+from h.util.uri import normalize
 
 
 def record_metrics(count,
@@ -20,6 +21,18 @@ def record_metrics(count,
     else:
         record_metric('Custom/Badge/unAuthUserGotZero', int(request.user is None))
     record_metric('Custom/Badge/badgeCountIsZero', int(count == 0))
+
+
+def _has_uri_ever_been_annotated(db, uri):
+    """Return `True` if a given URI has ever been annotated."""
+
+    # This check is written with SQL directly to guarantee an efficient query
+    # and minimize SQLAlchemy overhead. We query `document_uri.uri_normalized`
+    # instead of `annotation.target_uri_normalized` because there is an existing
+    # index on `uri_normalized`.
+    query = 'SELECT EXISTS(SELECT 1 FROM document_uri WHERE uri_normalized = :uri)'
+    result = db.execute(query, {'uri': normalize(uri)}).first()
+    return result[0] is True
 
 
 @json_view(route_name='badge')
@@ -38,7 +51,14 @@ def badge(request):
     if not uri:
         raise httpexceptions.HTTPBadRequest()
 
-    if models.Blocklist.is_blocked(request.db, uri):
+    # Do a cheap check to see if this URI has ever been annotated. If not,
+    # and most haven't, then we can skip the costs of a blocklist lookup or
+    # search request. In addition to the Elasticsearch query, the search request
+    # involves several DB queries to expand URIs and enumerate group IDs
+    # readable by the current user.
+    if not _has_uri_ever_been_annotated(request.db, uri):
+        count = 0
+    elif models.Blocklist.is_blocked(request.db, uri):
         count = 0
     else:
         query = {'uri': uri, 'limit': 0}

--- a/tests/h/views/badge_test.py
+++ b/tests/h/views/badge_test.py
@@ -69,25 +69,42 @@ def test_record_metrics_records_badgecountiszero_with_unauth_user():
 
 
 @badge_fixtures
-def test_badge_returns_number_from_search(models, search_run):
-    request = mock.Mock(params={'uri': 'test_uri'})
+def test_badge_returns_number_from_search(models, pyramid_request, search_run, mark_uri_as_annotated):
+    mark_uri_as_annotated('http://example.com')
+
+    pyramid_request.params['uri'] = 'http://example.com'
     models.Blocklist.is_blocked.return_value = False
     search_run.return_value = mock.Mock(total=29)
 
-    result = badge(request)
+    result = badge(pyramid_request)
 
-    search_run.assert_called_once_with({'uri': 'test_uri', 'limit': 0})
+    search_run.assert_called_once_with({'uri': 'http://example.com', 'limit': 0})
     assert result == {'total': 29}
 
 
 @badge_fixtures
-def test_badge_returns_0_if_blocked(models, search_run):
-    request = mock.Mock(params={'uri': 'test_uri'})
+def test_badge_does_not_search_if_uri_never_annotated(models, pyramid_request, search_run):
+    pyramid_request.params['uri'] = 'http://example.com'
+    models.Blocklist.is_blocked.return_value = False
+
+    result = badge(pyramid_request)
+
+    assert result == {'total': 0}
+    models.Blocklist.is_blocked.assert_not_called()
+    search_run.assert_not_called()
+
+
+@badge_fixtures
+def test_badge_returns_0_if_blocked(models, pyramid_request, search_run, mark_uri_as_annotated):
+    mark_uri_as_annotated('http://blocked-domain.com')
+
+    pyramid_request.params['uri'] = 'http://blocked-domain.com'
     models.Blocklist.is_blocked.return_value = True
     search_run.return_value = {'total': 29}
 
-    result = badge(request)
+    result = badge(pyramid_request)
 
+    models.Blocklist.is_blocked.assert_called_with(mock.ANY, 'http://blocked-domain.com')
     assert not search_run.called
     assert result == {'total': 0}
 
@@ -111,3 +128,17 @@ def search_lib(patch):
 @pytest.fixture
 def search_run(search_lib):
     return search_lib.Search.return_value.run
+
+
+@pytest.fixture
+def mark_uri_as_annotated(factories, pyramid_request):
+    def mark(uri):
+        factories.DocumentURI(uri=uri)
+        pyramid_request.db.flush()
+    return mark
+
+
+@pytest.fixture
+def pyramid_request(pyramid_request):
+    pyramid_request.stats = mock.Mock()
+    return pyramid_request


### PR DESCRIPTION
For each request to the badge endpoint, the view function:

 1. Looks up the URI in a blocklist in the DB
 2. Performs a search for annotations against a given URI which involves:
    1. Expanding the URI into all "equivalent" URIs via a DB query
    2. Enumerating groups that the user has read access to
    3. Issuing a query to ES with the complete query

(See [this trace](https://rpm.newrelic.com/accounts/1385283/applications/22688631/profiles/3017047) for a more detailed breakdown of where the badge endpoint spends its time).

Data suggests that the majority of URIs passed in queries to the badge
endpoint have never been annotated. Therefore perform a cheap index-only
DB query against the `document_uri.uri_normalized` field to check if the
URI has ever been annotated and skip the rest of the request if this
returns false.

There is still a fair amount of per-request overhead not eliminated by
this approach, but it could be a significant win that doesn't involve adding additional
infrastructure. In particular I'm interested to see whether we can significantly reduce the traffic to the Elasticsearch cluster this way.