### PR TITLE
Optimize redirect lookup

### DIFF
--- a/h/util/redirects.py
+++ b/h/util/redirects.py
@@ -48,11 +48,16 @@ def lookup(redirects, request):
     Returns None if the request does not match, and the URL to redirect to
     otherwise.
     """
+
+    # Compute and cache `request.path` once, rather than recomputing for each
+    # redirect rule that the path is matched against.
+    path = request.path
+
     for r in redirects:
-        if r.prefix and request.path.startswith(r.src):
-            suffix = request.path.replace(r.src, '', 1)
+        if r.prefix and path.startswith(r.src):
+            suffix = path.replace(r.src, '', 1)
             return _dst_root(request, r) + suffix
-        elif not r.prefix and request.path == r.src:
+        elif not r.prefix and path == r.src:
             return _dst_root(request, r)
     return None
 


### PR DESCRIPTION
Computing the `request.path` property in `webob/request.py` involves
reading values from the environment, then decoding, URL-quoting and
concatenating the results. This has enough overhead that it is worth
doing once rather than for each of the 214 redirect rules that we have,
on each request to h. Thread profiling via New Relic suggests this
accounts for ~8% of active request processing time.

A better but slightly more complex optimization would be to use a more
efficient data structure for matching the request path against the
redirect rules.