### PR TITLE
Remove New Relic badge metrics

### DIFF
--- a/h/views/badge.py
+++ b/h/views/badge.py
@@ -3,24 +3,10 @@
 from __future__ import unicode_literals
 
 from pyramid import httpexceptions
-import newrelic.agent
 
 from h import models, search
 from h.util.view import json_view
 from h.util.uri import normalize
-
-
-def record_metrics(count,
-                   request,
-                   record_metric=newrelic.agent.record_custom_metric,
-                   record_event=newrelic.agent.record_custom_event):
-    if count > 0:
-        record_event(
-            'BadgeNotZero',
-            {'user': "None" if request.user is None else request.user.username})
-    else:
-        record_metric('Custom/Badge/unAuthUserGotZero', int(request.user is None))
-    record_metric('Custom/Badge/badgeCountIsZero', int(count == 0))
 
 
 def _has_uri_ever_been_annotated(db, uri):
@@ -64,7 +50,5 @@ def badge(request):
         query = {'uri': uri, 'limit': 0}
         result = search.Search(request, stats=request.stats).run(query)
         count = result.total
-
-    record_metrics(count, request)
 
     return {'total': count}

--- a/tests/h/views/badge_test.py
+++ b/tests/h/views/badge_test.py
@@ -4,68 +4,13 @@ from __future__ import unicode_literals
 
 import pytest
 import mock
-from mock import call
 
 from pyramid import httpexceptions
 
 from h.views.badge import badge
-from h.views.badge import record_metrics
 
 
 badge_fixtures = pytest.mark.usefixtures('models', 'search_lib')
-
-
-def test_record_metrics_records_badgenotzero_with_auth_user():
-    request = mock.Mock(params={'uri': 'test_uri'})
-    request.user.username = 'foopy'
-    record_metric = mock.Mock()
-    record_event = mock.Mock()
-    record_metrics(1, request,
-                   record_metric=record_metric,
-                   record_event=record_event)
-
-    record_event.assert_called_once_with('BadgeNotZero', {'user': request.user.username})
-    record_metric.assert_called_once_with('Custom/Badge/badgeCountIsZero', 0)
-
-
-def test_record_metrics_records_badgenotzero_with_unauth_user():
-    request = mock.Mock(params={'uri': 'test_uri'})
-    request.user = None
-    record_metric = mock.Mock()
-    record_event = mock.Mock()
-    record_metrics(1, request,
-                   record_metric=record_metric,
-                   record_event=record_event)
-
-    record_event.assert_called_once_with('BadgeNotZero', {'user': 'None'})
-    record_metric.assert_called_once_with('Custom/Badge/badgeCountIsZero', 0)
-
-
-def test_record_metrics_records_badgecountiszero_with_auth_user():
-    request = mock.Mock(params={'uri': 'test_uri'})
-    record_metric = mock.Mock()
-    record_event = mock.Mock()
-    record_metrics(0, request,
-                   record_metric=record_metric,
-                   record_event=record_event)
-
-    record_metric.assert_has_calls([call('Custom/Badge/unAuthUserGotZero', 0),
-                                    call('Custom/Badge/badgeCountIsZero', 1),
-                                    ])
-
-
-def test_record_metrics_records_badgecountiszero_with_unauth_user():
-    request = mock.Mock(params={'uri': 'test_uri'})
-    request.user = None
-    record_metric = mock.Mock()
-    record_event = mock.Mock()
-    record_metrics(0, request,
-                   record_metric=record_metric,
-                   record_event=record_event)
-
-    record_metric.assert_has_calls([call('Custom/Badge/unAuthUserGotZero', 1),
-                                    call('Custom/Badge/badgeCountIsZero', 1),
-                                    ])
 
 
 @badge_fixtures


### PR DESCRIPTION
`record_metrics` accounted for about 20% of the time spent in the badge
endpoint (see [this profile](https://rpm.newrelic.com/accounts/1385283/applications/22688631/profiles/3017089)), most of this in resolving the user's authentication status and fetching
the corresponding `h.models.User` object from the DB.

Since we've now learned what we needed to about the results of badge
lookups, that the vast majority of requests return 0, I think we can
safely remove this. We can always get the code back from the history if
we need it again in future.