### PR TITLE
Don't send reply notifications to users with no email

### DIFF
--- a/h/notification/reply.py
+++ b/h/notification/reply.py
@@ -75,6 +75,10 @@ def get_notification(request, annotation, action):
     if parent_user is None:
         return
 
+    # If the parent user doesn't have an email address we can't email them.
+    if not parent_user.email:
+        return
+
     # If the reply user doesn't exist (anymore), we can't send an email, but
     # this would be super weird, so log a warning.
     reply_user = user_service.fetch(reply.userid)

--- a/tests/h/notification/reply_test.py
+++ b/tests/h/notification/reply_test.py
@@ -75,6 +75,15 @@ class TestGetNotification(object):
 
         assert result is None
 
+    def test_returns_none_when_parent_user_has_no_email_address(self, factories, pyramid_request, reply, user_service):
+        users = {
+            "acct:giraffe@safari.net": factories.User(email=None),
+            "acct:elephant@safari.net": factories.User(),
+        }
+        user_service.fetch.side_effect = users.get
+
+        assert get_notification(pyramid_request, reply, "create") is None
+
     def test_returns_none_when_reply_user_does_not_exist(self, factories, pyramid_request, reply, user_service):
         """
         Don't send a reply if somehow the replying user ceased to exist.

--- a/tests/h/notification/reply_test.py
+++ b/tests/h/notification/reply_test.py
@@ -8,7 +8,6 @@ import mock
 from h.models import Annotation
 from h.models import Document, DocumentMeta
 from h.models import Subscriptions
-from h.models import User
 from h.notification.reply import Notification
 from h.notification.reply import get_notification
 from h.services.user import UserService
@@ -68,17 +67,15 @@ class TestGetNotification(object):
 
         assert result is None
 
-    def test_returns_none_when_parent_user_does_not_exist(self, pyramid_request, reply, user_service):
-        users = {
-            'acct:elephant@safari.net': User(username='elephant')
-        }
+    def test_returns_none_when_parent_user_does_not_exist(self, factories, pyramid_request, reply, user_service):
+        users = {'acct:elephant@safari.net': factories.User()}
         user_service.fetch.side_effect = users.get
 
         result = get_notification(pyramid_request, reply, 'create')
 
         assert result is None
 
-    def test_returns_none_when_reply_user_does_not_exist(self, pyramid_request, reply, user_service):
+    def test_returns_none_when_reply_user_does_not_exist(self, factories, pyramid_request, reply, user_service):
         """
         Don't send a reply if somehow the replying user ceased to exist.
 
@@ -86,9 +83,7 @@ class TestGetNotification(object):
         construct the reply email without the user who replied existing. We log
         a warning if this happens.
         """
-        users = {
-            'acct:giraffe@safari.net': User(username='giraffe')
-        }
+        users = {'acct:giraffe@safari.net': factories.User()}
         user_service.fetch.side_effect = users.get
 
         result = get_notification(pyramid_request, reply, 'create')
@@ -176,12 +171,12 @@ class TestGetNotification(object):
         return sub
 
     @pytest.fixture
-    def user_service(self, pyramid_config):
+    def user_service(self, factories, pyramid_config):
         user_service = mock.create_autospec(UserService, spec_set=True, instance=True)
 
         users = {
-            'acct:giraffe@safari.net': User(username='giraffe', email='giraffe@giraffe.com'),
-            'acct:elephant@safari.net': User(username='elephant', email='elephant@elephant.com'),
+            'acct:giraffe@safari.net': factories.User(),
+            'acct:elephant@safari.net': factories.User(),
         }
         user_service.fetch.side_effect = users.get
 

--- a/tests/h/notification/reply_test.py
+++ b/tests/h/notification/reply_test.py
@@ -177,8 +177,8 @@ class TestGetNotification(object):
     @pytest.fixture
     def user_service(self, pyramid_config):
         users = {
-            'acct:giraffe@safari.net': User(username='giraffe'),
-            'acct:elephant@safari.net': User(username='elephant'),
+            'acct:giraffe@safari.net': User(username='giraffe', email='giraffe@giraffe.com'),
+            'acct:elephant@safari.net': User(username='elephant', email='elephant@elephant.com'),
         }
         service = mock.Mock(spec_set=['fetch'])
         service.fetch.side_effect = users.get

--- a/tests/h/notification/reply_test.py
+++ b/tests/h/notification/reply_test.py
@@ -11,6 +11,7 @@ from h.models import Subscriptions
 from h.models import User
 from h.notification.reply import Notification
 from h.notification.reply import get_notification
+from h.services.user import UserService
 
 FIXTURE_DATA = {
     'reply': {
@@ -176,11 +177,13 @@ class TestGetNotification(object):
 
     @pytest.fixture
     def user_service(self, pyramid_config):
+        user_service = mock.create_autospec(UserService, spec_set=True, instance=True)
+
         users = {
             'acct:giraffe@safari.net': User(username='giraffe', email='giraffe@giraffe.com'),
             'acct:elephant@safari.net': User(username='elephant', email='elephant@elephant.com'),
         }
-        service = mock.Mock(spec_set=['fetch'])
-        service.fetch.side_effect = users.get
-        pyramid_config.register_service(service, name='user')
-        return service
+        user_service.fetch.side_effect = users.get
+
+        pyramid_config.register_service(user_service, name='user')
+        return user_service


### PR DESCRIPTION
Needs a test, but looks like the tests (mocking) for this function will need some refactoring in order to make writing a test nicely possible.

Currently if the author of an annotation has no email address, and someone replies to that annotation, you get a celery worker crash:

```
17:24:12 worker | [2018-07-02 17:24:12,272: ERROR/ForkPoolWorker-3] task failure: h.tasks.mailer.send (9dcfdeae-f15d-45bb-a52d-fb3b1f4f766e) called with args=[[None], u'admin has replied to your annotation', u'admin has replied to your annotation on "Hypothesis":\n\nOn 02 July at 16:23 user commented:\n\n> Annotation\n\nOn 02 July at 16:24 admin replied:\n\n> REPLY\n\nView the thread and respond: http://localhost:8000/Qnsrmn4UEei4lndaOzmVDg/localhost:5000/docs/help\n\nIf you\'d rather not receive these notifications you can unsubscribe: http://localhost:5000/notification/unsubscribe/DxpCC7Gehzs9evl9SW1aZkhnBHtqLo-aGtEsqi861_GeEVnQJ2cXIbbYfIwk_V-sylsr_JGnR0mIGmE7xpbLGHsidHlwZSI6ICJyZXBseSIsICJ1cmkiOiAiYWNjdDp1c2VyQGh5cG90aGVzLmlzIn0', u'<p>\n  \n    <a href="http://localhost:5000/u/admin">admin</a>\n  \n  has\n  <a href="http://localhost:8000/Qnsrmn4UEei4lndaOzmVDg/localhost:5000/docs/help">replied to your annotation</a>\n  on\n  <a href="http://localhost:5000/docs/help">&ldquo;Hypothesis&rdquo;</a>:\n</p>\n\n<p>\n  On\n  02 July at 16:23\n  \n    <a href="http://localhost:5000/u/user">user</a>\n  \n  commented:\n</p>\n\n<blockquote>Annotation</blockquote>\n\n<p>\n  On\n  02 July at 16:24\n  \n    <a href="http://localhost:5000/u/admin">admin</a>\n  \n  replied:\n</p>\n\n<blockquote>REPLY</blockquote>\n\n<p><a href="http://localhost:8000/Qnsrmn4UEei4lndaOzmVDg/localhost:5000/docs/help">View the thread and respond</a>.</p>\n\n<p><small>If you\'d rather not receive these notifications you can\n<a href="http://localhost:5000/notification/unsubscribe/DxpCC7Gehzs9evl9SW1aZkhnBHtqLo-aGtEsqi861_GeEVnQJ2cXIbbYfIwk_V-sylsr_JGnR0mIGmE7xpbLGHsidHlwZSI6ICJyZXBseSIsICJ1cmkiOiAiYWNjdDp1c2VyQGh5cG90aGVzLmlzIn0">unsubscribe now</a>.</small></p>'], kwargs={}
17:24:12 worker | Traceback (most recent call last):
17:24:12 worker |   File "/home/seanh/.virtualenvs/h/local/lib/python2.7/site-packages/celery/app/trace.py", line 374, in trace_task
17:24:12 worker |     R = retval = fun(*args, **kwargs)
17:24:12 worker |   File "/home/seanh/.virtualenvs/h/local/lib/python2.7/site-packages/celery/app/trace.py", line 629, in __protected_call__
17:24:12 worker |     return self.run(*args, **kwargs)
17:24:12 worker |   File "h/tasks/mailer.py", line 43, in send
17:24:12 worker |     mailer.send_immediately(email)
17:24:12 worker |   File "/home/seanh/.virtualenvs/h/local/lib/python2.7/site-packages/pyramid_mailer/mailer.py", line 82, in _send
17:24:12 worker |     fd.write(str(message.to_message()))
17:24:12 worker |   File "/home/seanh/.virtualenvs/h/local/lib/python2.7/site-packages/pyramid_mailer/message.py", line 199, in to_message
17:24:12 worker |     self.validate()
17:24:12 worker |   File "/home/seanh/.virtualenvs/h/local/lib/python2.7/site-packages/pyramid_mailer/message.py", line 307, in validate
17:24:12 worker |     if self.is_bad_headers():
17:24:12 worker |   File "/home/seanh/.virtualenvs/h/local/lib/python2.7/site-packages/pyramid_mailer/message.py", line 289, in is_bad_headers
17:24:12 worker |     if c in val:
17:24:12 worker | TypeError: argument of type 'NoneType' is not iterable
```

This PR changes it to silently not try to send reply notification emails to users without email addresses, instead.