### PR TITLE
Remove old Elasticsearch index after reindexing annotations

### DIFF
--- a/h/indexer/reindexer.py
+++ b/h/indexer/reindexer.py
@@ -5,6 +5,7 @@ import logging
 
 from h.search.config import (
     configure_index,
+    delete_index,
     get_aliased_index,
     update_aliased_index,
 )
@@ -18,7 +19,8 @@ SETTING_NEW_INDEX = 'reindex.new_index'
 def reindex(session, es, request):
     """Reindex all annotations into a new index, and update the alias."""
 
-    if get_aliased_index(es) is None:
+    current_index = get_aliased_index(es)
+    if current_index is None:
         raise RuntimeError('cannot reindex if current index is not aliased')
 
     settings = request.find_service(name='settings')
@@ -42,6 +44,8 @@ def reindex(session, es, request):
                     errored))
 
         update_aliased_index(es, new_index)
+
+        delete_index(es, current_index)
 
     finally:
         settings.delete(SETTING_NEW_INDEX)

--- a/h/search/config.py
+++ b/h/search/config.py
@@ -227,6 +227,22 @@ def update_aliased_index(client, new_target):
     })
 
 
+def delete_index(client, index_name):
+    """
+    Delete an unused index.
+
+    This must be an actual index and not an alias.
+    """
+
+    try:
+        client.conn.indices.delete(index=index_name)
+    except NotFoundError:
+        # In production using AWS Elasticsearch 1.5, `IndexMissingException`
+        # responses have been seen in response to index deletion requests which
+        # did actually succeed. We are just ignoring them here.
+        log.warn("NotFoundError reported when deleting index {}".format(index_name))
+
+
 def update_index_settings(client):
     """
     Update the index settings (analysis and mappings) to their current state.

--- a/tests/h/indexer/reindexer_test.py
+++ b/tests/h/indexer/reindexer_test.py
@@ -10,6 +10,7 @@ from h.search import client
 
 @pytest.mark.usefixtures('BatchIndexer',
                          'configure_index',
+                         'delete_index',
                          'get_aliased_index',
                          'update_aliased_index',
                          'settings_service')
@@ -97,6 +98,13 @@ class TestReindex(object):
 
         settings_service.delete.assert_called_once_with(SETTING_NEW_INDEX)
 
+    def test_deletes_old_index(self, pyramid_request, es, delete_index, get_aliased_index):
+        get_aliased_index.return_value = 'original_index'
+
+        reindex(mock.sentinel.session, es, pyramid_request)
+
+        delete_index.assert_called_once_with(es, 'original_index')
+
     @pytest.fixture
     def BatchIndexer(self, patch):
         return patch('h.indexer.reindexer.BatchIndexer')
@@ -110,6 +118,10 @@ class TestReindex(object):
         func = patch('h.indexer.reindexer.get_aliased_index')
         func.return_value = 'foobar'
         return func
+
+    @pytest.fixture
+    def delete_index(self, patch):
+        return patch('h.indexer.reindexer.delete_index')
 
     @pytest.fixture
     def update_aliased_index(self, patch):

--- a/tests/h/search/config_test.py
+++ b/tests/h/search/config_test.py
@@ -15,6 +15,7 @@ from h.search.config import (
     ANALYSIS_SETTINGS,
     init,
     configure_index,
+    delete_index,
     get_aliased_index,
     update_aliased_index,
 )
@@ -181,6 +182,18 @@ class TestUpdateAliasedIndex(object):
 
         with pytest.raises(RuntimeError):
             update_aliased_index(client, 'new-target')
+
+
+class TestDeleteIndex(object):
+    def test_deletes_index(self, client):
+        delete_index(client, 'unused-index')
+
+        client.conn.indices.delete.assert_called_once_with(index='unused-index')
+
+    def test_ignores_NotFound_error(self, client):
+        client.conn.indices.delete.side_effect = NotFoundError('IndexMissingException', '')
+
+        delete_index(client, 'unused-index')
 
 
 def captures(patterns, text):


### PR DESCRIPTION
After reindexing annotations into a new index, the previous index never got deleted. This was wasting ~10GB or so of disk space in our production ES cluster, as well as cluttering up the dashboards in various monitoring tools.

All Elasticsearch queries are made to an alias which points at the current index, which is updated before the old index is deleted. Therefore it should be safe to delete the old index immediately at the end of the reindexing task.

I saw an issue in production which I haven't reproduced locally where deleting old indexes using the same method, but from the Hypothesis shell, succeeded despite returning a `NotFoundError`. I've opted to ignore that particular error but just log a warning.

The second commit adds some more log output to make it easier to see what the reindexing task is doing when we run it from Jenkins.