### PR TITLE
Add test for `DeletedFilter`

### DIFF
--- a/h/search/index.py
+++ b/h/search/index.py
@@ -60,7 +60,7 @@ def index(es, annotation, request, target_index=None):
     )
 
 
-def delete(es, annotation_id, target_index=None):
+def delete(es, annotation_id, target_index=None, refresh=False):
     """
     Mark an annotation as deleted in the search index.
 
@@ -77,6 +77,10 @@ def delete(es, annotation_id, target_index=None):
 
     :param target_index: the index name, uses default index if not given
     :type target_index: unicode
+
+    :param refresh: Force this deletion to be immediately visible to search operations
+    :type refresh: bool
+
     """
 
     if target_index is None:
@@ -86,7 +90,8 @@ def delete(es, annotation_id, target_index=None):
         index=target_index,
         doc_type=es.t.annotation,
         body={'deleted': True},
-        id=annotation_id)
+        id=annotation_id,
+        refresh=refresh)
 
 
 class BatchIndexer(object):

--- a/tests/h/search/old_index_test.py
+++ b/tests/h/search/old_index_test.py
@@ -89,7 +89,8 @@ class TestDeleteAnnotation:
             index='hypothesis',
             doc_type='annotation',
             body={'deleted': True},
-            id='test_annotation_id'
+            id='test_annotation_id',
+            refresh=False,
         )
 
     def test_it_allows_to_override_target_index(self, es):

--- a/tests/h/search/query_test.py
+++ b/tests/h/search/query_test.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 import pytest
 import webob
 
-from h.search import Search, query
+from h.search import Search, index, query
 
 
 class TestTopLevelAnnotationsFilter(object):
@@ -259,6 +259,18 @@ class TestUriFilter(object):
 
 
 class TestDeletedFilter(object):
+
+    def test_excludes_deleted_annotations(self, search, Annotation):
+        deleted_ids = [Annotation(deleted=True).id]
+        not_deleted_ids = [Annotation(deleted=False).id]
+
+        # Deleted annotations need to be marked in the index using `h.search.index.delete`.
+        for id_ in deleted_ids:
+            index.delete(search.es, id_, refresh=True)
+
+        result = search.run({})
+
+        assert sorted(result.annotation_ids) == sorted(not_deleted_ids)
 
     @pytest.fixture
     def search(self, search):


### PR DESCRIPTION
Unlike the rest of the fields which are set by AnnotationSearchIndexPresenter
when the annotation is indexed, the `deleted` field is set in the app by
`h.search.index.delete` which replaces the annotation's entire body in
the index. To ensure the delete operation/deleted filter match up, I've re-used
`h.search.index.delete` in the tests.

Add an optional `refresh` kwarg to `delete` to force a refresh so that
the change is immediately visible in search. Otherwise there will be a
brief delay until searches reflect the deletion.