### PR TITLE
Prepare for change to a single mapping type per index in Elasticsearch 6

### DIFF
--- a/h/search/client.py
+++ b/h/search/client.py
@@ -13,16 +13,11 @@ class Client(object):
     """
     A convenience wrapper around a connection to Elasticsearch.
 
-    Holds a connection object, an index name, and an enumeration of document
-    types stored in the index.
+    Holds a connection object, an index name, and the name of the mapping type.
 
     :param host: Elasticsearch host URL
     :param index: index name
     """
-
-    class t(object):  # noqa
-        """Document types"""
-        annotation = 'annotation'
 
     def __init__(self, host, index, **kwargs):
         self._index = index
@@ -33,6 +28,12 @@ class Client(object):
                                    ca_certs=certifi.where(),
                                    **kwargs)
 
+        # Our existing Elasticsearch 1.x indexes have a single mapping type
+        # "annotation". For ES 6 we should change this to the preferred name
+        # of "_doc".
+        # See https://www.elastic.co/guide/en/elasticsearch/reference/6.x/removal-of-types.html
+        self._mapping_type = "annotation"
+
     @property
     def index(self):
         return self._index
@@ -40,6 +41,18 @@ class Client(object):
     @property
     def conn(self):
         return self._conn
+
+    @property
+    def mapping_type(self):
+        """
+        Return the name of the index's mapping type (aka. document type).
+
+        The concept of mapping types is being removed from Elasticsearch and in
+        ES >= 6 an index only has a single mapping type.
+
+        See https://www.elastic.co/guide/en/elasticsearch/reference/6.x/removal-of-types.html
+        """
+        return self._mapping_type
 
 
 def get_client(settings):

--- a/h/search/config.py
+++ b/h/search/config.py
@@ -181,7 +181,7 @@ def configure_index(client):
 
     client.conn.indices.create(index_name, body={
         'mappings': {
-            client.t.annotation: ANNOTATION_MAPPING,
+            client.mapping_type: ANNOTATION_MAPPING,
         },
         'settings': {
             'analysis': ANALYSIS_SETTINGS,
@@ -237,7 +237,7 @@ def update_index_settings(client):
     index = get_aliased_index(client)
     _update_index_analysis(client.conn, index, ANALYSIS_SETTINGS)
     _update_index_mappings(client.conn, index,
-                           {client.t.annotation: ANNOTATION_MAPPING})
+                           {client.mapping_type: ANNOTATION_MAPPING})
 
 
 def _ensure_icu_plugin(conn):

--- a/h/search/core.py
+++ b/h/search/core.py
@@ -83,7 +83,7 @@ class Search(object):
         response = None
         with self._instrument():
             response = self.es.conn.search(index=self.es.index,
-                                           doc_type=self.es.t.annotation,
+                                           doc_type=self.es.mapping_type,
                                            _source=False,
                                            body=self.builder.build(params))
         total = response['hits']['total']
@@ -101,7 +101,7 @@ class Search(object):
         with self._instrument():
             response = self.es.conn.search(
                 index=self.es.index,
-                doc_type=self.es.t.annotation,
+                doc_type=self.es.mapping_type,
                 _source=False,
                 body=self.reply_builder.build({'limit': self._replies_limit}))
 

--- a/h/search/index.py
+++ b/h/search/index.py
@@ -54,7 +54,7 @@ def index(es, annotation, request, target_index=None):
 
     es.conn.index(
         index=target_index,
-        doc_type=es.t.annotation,
+        doc_type=es.mapping_type,
         body=annotation_dict,
         id=annotation_dict["id"],
     )
@@ -84,7 +84,7 @@ def delete(es, annotation_id, target_index=None):
 
     es.conn.index(
         index=target_index,
-        doc_type=es.t.annotation,
+        doc_type=es.mapping_type,
         body={'deleted': True},
         id=annotation_id)
 
@@ -148,7 +148,7 @@ class BatchIndexer(object):
 
     def _prepare(self, annotation):
         action = {self.op_type: {'_index': self._target_index,
-                                 '_type': self.es_client.t.annotation,
+                                 '_type': self.es_client.mapping_type,
                                  '_id': annotation.id}}
         data = presenters.AnnotationSearchIndexPresenter(annotation).asdict()
 

--- a/tests/h/indexer/reindexer_test.py
+++ b/tests/h/indexer/reindexer_test.py
@@ -125,7 +125,7 @@ class TestReindex(object):
     def es(self):
         mock_es = mock.create_autospec(client.Client, instance=True,
                                        spec_set=True, index="hypothesis")
-        mock_es.t.annotation = 'annotation'
+        mock_es.mapping_type = 'annotation'
         return mock_es
 
     @pytest.fixture

--- a/tests/h/search/config_test.py
+++ b/tests/h/search/config_test.py
@@ -10,6 +10,7 @@ import mock
 import pytest
 from elasticsearch1.exceptions import NotFoundError
 
+from h.search.client import Client
 from h.search.config import (
     ANNOTATION_MAPPING,
     ANALYSIS_SETTINGS,
@@ -193,7 +194,7 @@ def groups(pattern, text):
 
 @pytest.fixture
 def client():
-    client = mock.Mock(spec_set=['conn', 'index', 't'])
+    client = mock.create_autospec(Client, spec_set=True, instance=True)
     client.index = 'foo'
-    client.t.annotation = 'annotation'
+    client.mapping_type = 'annotation'
     return client

--- a/tests/h/search/index_test.py
+++ b/tests/h/search/index_test.py
@@ -24,7 +24,7 @@ class TestIndex(object):
         index(annotation)
 
         result = es_client.conn.get(index=es_client.index,
-                                    doc_type="annotation",
+                                    doc_type=es_client.mapping_type,
                                     id=annotation.id)
         assert result["_id"] == annotation.id
 
@@ -286,7 +286,7 @@ class TestIndex(object):
         def _get(annotation_id):
             """Return the annotation with the given ID from Elasticsearch."""
             return es_client.conn.get(
-                index=es_client.index, doc_type="annotation",
+                index=es_client.index, doc_type=es_client.mapping_type,
                 id=annotation_id)["_source"]
         return _get
 
@@ -297,13 +297,13 @@ class TestDelete(object):
 
         index(annotation)
         result = es_client.conn.get(index=es_client.index,
-                                    doc_type="annotation",
+                                    doc_type=es_client.mapping_type,
                                     id=annotation.id)
         assert 'deleted' not in result.get('_source')
 
         h.search.index.delete(es_client, annotation.id)
         result = es_client.conn.get(index=es_client.index,
-                                    doc_type="annotation",
+                                    doc_type=es_client.mapping_type,
                                     id=annotation.id)
         assert result.get('_source').get('deleted') is True
 
@@ -317,7 +317,7 @@ class TestBatchIndexer(object):
 
         for _id in ids:
             result = es_client.conn.get(index=es_client.index,
-                                        doc_type="annotation",
+                                        doc_type=es_client.mapping_type,
                                         id=_id)
             assert result["_id"] == _id
 
@@ -331,14 +331,14 @@ class TestBatchIndexer(object):
 
         for _id in ids_to_index:
             result = es_client.conn.get(index=es_client.index,
-                                        doc_type="annotation",
+                                        doc_type=es_client.mapping_type,
                                         id=_id)
             assert result["_id"] == _id
 
         for _id in ids_not_to_index:
             with pytest.raises(elasticsearch1.exceptions.NotFoundError):
                 es_client.conn.get(index=es_client.index,
-                                   doc_type="annotation",
+                                   doc_type=es_client.mapping_type,
                                    id=_id)
 
     def test_it_does_not_index_deleted_annotations(self, batch_indexer, es_client, factories):
@@ -349,13 +349,13 @@ class TestBatchIndexer(object):
         batch_indexer.index()
 
         result_indexed = es_client.conn.get(index=es_client.index,
-                                            doc_type="annotation",
+                                            doc_type=es_client.mapping_type,
                                             id=ann.id)
         assert result_indexed["_id"] == ann.id
 
         with pytest.raises(elasticsearch1.exceptions.NotFoundError):
             es_client.conn.get(index=es_client.index,
-                               doc_type="annotation",
+                               doc_type=es_client.mapping_type,
                                id=ann_del.id)
 
     def test_it_notifies(self, AnnotationSearchIndexPresenter, AnnotationTransformEvent, batch_indexer, factories, pyramid_request,
@@ -396,7 +396,7 @@ class TestBatchIndexer(object):
 
         for ann in annotations:
             result = es_client.conn.get(index=es_client.index,
-                                        doc_type="annotation",
+                                        doc_type=es_client.mapping_type,
                                         id=ann.id)
             assert result.get("_source").get("group") == ann.groupid
             assert result.get("_source").get("authority") == ann.authority

--- a/tests/h/search/old_core_test.py
+++ b/tests/h/search/old_core_test.py
@@ -3,6 +3,7 @@ import mock
 import pytest
 
 from h.search import core
+from h.search.client import Client
 
 
 class FakeStatsdClient(object):
@@ -303,7 +304,8 @@ def dummy_search_results(start=1, count=0, name='annotation'):
 @pytest.fixture
 def pyramid_request(pyramid_request):
     """Return a mock request with a faked out Elasticsearch connection."""
-    pyramid_request.es = mock.Mock(spec_set=['conn', 'index', 't'])
+    pyramid_request.es = mock.create_autospec(Client, spec_set=True, instance=True)
+    pyramid_request.es.mapping_type = "annotation"
     pyramid_request.es.conn.search.return_value = dummy_search_results(0)
     return pyramid_request
 

--- a/tests/h/search/old_index_test.py
+++ b/tests/h/search/old_index_test.py
@@ -167,7 +167,7 @@ class TestBatchIndexer(object):
         rendered = presenters.AnnotationSearchIndexPresenter(annotation).asdict()
         rendered['target'][0]['scope'] = [annotation.target_uri_normalized]
         assert results[0] == (
-            {'index': {'_type': indexer.es_client.t.annotation,
+            {'index': {'_type': indexer.es_client.mapping_type,
                        '_index': 'hypothesis',
                        '_id': annotation.id}},
             rendered
@@ -194,7 +194,7 @@ class TestBatchIndexer(object):
         rendered = presenters.AnnotationSearchIndexPresenter(annotation).asdict()
         rendered['target'][0]['scope'] = [annotation.target_uri_normalized]
         assert results[0] == (
-            {'create': {'_type': indexer.es_client.t.annotation,
+            {'create': {'_type': indexer.es_client.mapping_type,
                         '_index': 'hypothesis',
                         '_id': annotation.id}},
             rendered
@@ -233,7 +233,7 @@ class TestBatchIndexer(object):
         rendered['target'][0]['scope'] = [annotation.target_uri_normalized]
 
         assert results[0] == (
-            {'index': {'_type': indexer.es_client.t.annotation,
+            {'index': {'_type': indexer.es_client.mapping_type,
                        '_index': 'hypothesis',
                        '_id': annotation.id}},
             rendered
@@ -312,7 +312,7 @@ class TestBatchIndexer(object):
 def es():
     mock_es = mock.create_autospec(client.Client, instance=True, spec_set=True,
                                    index="hypothesis")
-    mock_es.t.annotation = 'annotation'
+    mock_es.mapping_type = "annotation"
     return mock_es
 
 


### PR DESCRIPTION
While working on tests for `DeletedFilter` I noticed that we were hard-coding the document/mapping type name to "annotation" in many tests. It is likely that we'll want to change the mapping type name in ES 6 to the preferred value of "_doc" for forwards compatibility with ES 7 (see [1]).

This PR refactors `h.search.client.Client` to better reflect the way that mapping types behave in ES 6, allowing a single type per index, and replaces hard-coded references to the ES 1 mapping type name in tests.

[1] https://www.elastic.co/guide/en/elasticsearch/reference/6.x/removal-of-types.html