### PR TITLE
Change default size limit for number of buckets for aggregations.

### DIFF
--- a/h/search/query.py
+++ b/h/search/query.py
@@ -337,7 +337,7 @@ class RepliesMatcher(object):
 
 
 class TagsAggregation(object):
-    def __init__(self, limit=0):
+    def __init__(self, limit=10):
         self.key = 'tags'
         self.limit = limit
 
@@ -360,7 +360,7 @@ class TagsAggregation(object):
 
 
 class UsersAggregation(object):
-    def __init__(self, limit=0):
+    def __init__(self, limit=10):
         self.key = 'users'
         self.limit = limit
 

--- a/tests/h/search/old_query_test.py
+++ b/tests/h/search/old_query_test.py
@@ -524,7 +524,7 @@ class TestTagsAggregations(object):
     def test_elasticsearch_aggregation(self):
         agg = query.TagsAggregation()
         assert agg({}) == {
-            'terms': {'field': 'tags_raw', 'size': 0}
+            'terms': {'field': 'tags_raw', 'size': 10}
         }
 
     def test_it_allows_to_set_a_limit(self):
@@ -563,7 +563,7 @@ class TestUsersAggregation(object):
     def test_elasticsearch_aggregation(self):
         agg = query.UsersAggregation()
         assert agg({}) == {
-            'terms': {'field': 'user_raw', 'size': 0}
+            'terms': {'field': 'user_raw', 'size': 10}
         }
 
     def test_it_allows_to_set_a_limit(self):


### PR DESCRIPTION
Specifying  for aggregations was used as an alias to get all the
buckets on the aggregation terms. This is deprecated since ES 2.x.
We are now required to specify the number of buckets.
See https://github.com/elastic/elasticsearch/issues/18838