### PR TITLE
Remove unused code blocks in tags and users aggregators.

### DIFF
--- a/h/search/query.py
+++ b/h/search/query.py
@@ -350,9 +350,6 @@ class TagsAggregation(object):
         }
 
     def parse_result(self, result):
-        if not result:
-            return {}
-
         return [
             {'tag': b['key'], 'count': b['doc_count']}
             for b in result['buckets']
@@ -373,9 +370,6 @@ class UsersAggregation(object):
         }
 
     def parse_result(self, result):
-        if not result:
-            return {}
-
         return [
             {'user': b['key'], 'count': b['doc_count']}
             for b in result['buckets']

--- a/tests/h/search/old_query_test.py
+++ b/tests/h/search/old_query_test.py
@@ -547,14 +547,6 @@ class TestTagsAggregations(object):
             {'tag': 'tag-2', 'count': 28},
         ]
 
-    def test_parse_result_with_none(self):
-        agg = query.TagsAggregation()
-        assert agg.parse_result(None) == {}
-
-    def test_parse_result_with_empty(self):
-        agg = query.TagsAggregation()
-        assert agg.parse_result({}) == {}
-
 
 class TestUsersAggregation(object):
     def test_key_is_users(self):
@@ -585,14 +577,6 @@ class TestUsersAggregation(object):
             {'user': 'alice', 'count': 42},
             {'user': 'luke', 'count': 28},
         ]
-
-    def test_parse_result_with_none(self):
-        agg = query.UsersAggregation()
-        assert agg.parse_result(None) == {}
-
-    def test_parse_result_with_empty(self):
-        agg = query.UsersAggregation()
-        assert agg.parse_result({}) == {}
 
 
 class TestNipsaFilter(object):


### PR DESCRIPTION
The result from an aggregation is never an None or empty.
This is not a necessary check.

See https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-terms-aggregation.html