### PR TITLE
Add a get_es6_client and re-use the`Client`class

### DIFF
--- a/h/search/__init__.py
+++ b/h/search/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import unicode_literals
-from h.search.client import get_client
+from h.search.client import get_client, get_es6_client
 from h.search.config import init
 from h.search.connection import connect
 from h.search.core import Search
@@ -41,11 +41,20 @@ def includeme(config):
     settings.setdefault('es.host', 'http://localhost:9200')
     settings.setdefault('es.index', 'hypothesis')
 
-    # Add a property to all requests for easy access to the elasticsearch
+    # Add a property to all requests for easy access to the elasticsearch 1.x
     # client. This can be used for direct or bulk access without having to
     # reread the settings.
     config.registry['es.client'] = get_client(settings)
     config.add_request_method(
         lambda r: r.registry['es.client'],
         name='es',
+        reify=True)
+
+    # Add a property to all requests for easy access to the elasticsearch 6.x
+    # client. This can be used for direct or bulk access without having to
+    # reread the settings.
+    config.registry['es6.client'] = get_es6_client(settings)
+    config.add_request_method(
+        lambda r: r.registry['es6.client'],
+        name='es6',
         reify=True)

--- a/h/search/client.py
+++ b/h/search/client.py
@@ -2,10 +2,9 @@
 
 from __future__ import unicode_literals
 import certifi
-from elasticsearch1 import Elasticsearch, RequestsHttpConnection
+import elasticsearch1
+import elasticsearch
 from requests_aws4auth import AWS4Auth
-
-__all__ = ('Client',)
 
 
 class Client(object):
@@ -17,16 +16,13 @@ class Client(object):
 
     :param host: Elasticsearch host URL
     :param index: index name
+    :param elasticsearch: Elasticsearch library defaulted to elasticsearch1
     """
 
-    def __init__(self, host, index, **kwargs):
+    def __init__(self, host, index, elasticsearch=elasticsearch1, **kwargs):
         self._index = index
-        self._conn = Elasticsearch([host],
-                                   verify_certs=True,
-                                   # N.B. this won't be necessary if we upgrade
-                                   # to elasticsearch>=5.0.0.
-                                   ca_certs=certifi.where(),
-                                   **kwargs)
+        self._conn = elasticsearch.Elasticsearch([host],
+                                                 **kwargs)
 
         # Our existing Elasticsearch 1.x indexes have a single mapping type
         # "annotation". For ES 6 we should change this to the preferred name
@@ -55,10 +51,7 @@ class Client(object):
         return self._mapping_type
 
 
-def get_client(settings):
-    """Return a client for the Elasticsearch index."""
-    host = settings['es.host']
-    index = settings['es.index']
+def _get_client_settings(settings):
     kwargs = {}
     kwargs['max_retries'] = settings.get('es.client.max_retries', 3)
     kwargs['retry_on_timeout'] = settings.get('es.client.retry_on_timeout', False)
@@ -67,16 +60,36 @@ def get_client(settings):
     if 'es.client_poolsize' in settings:
         kwargs['maxsize'] = settings['es.client_poolsize']
 
+    kwargs['verify_certs'] = True
+    return kwargs
+
+
+def get_client(settings):
+    """Return a client for the Elasticsearch index."""
+    host = settings['es.host']
+    index = settings['es.index']
+    kwargs = _get_client_settings(settings)
+    # N.B. this won't be necessary if we upgrade
+    # to elasticsearch>=5.0.0.
+    kwargs['ca_certs'] = certifi.where()
     have_aws_creds = ('es.aws.access_key_id' in settings and
                       'es.aws.region' in settings and
                       'es.aws.secret_access_key' in settings)
-
     if have_aws_creds:
         auth = AWS4Auth(settings['es.aws.access_key_id'],
                         settings['es.aws.secret_access_key'],
                         settings['es.aws.region'],
                         'es')
         kwargs['http_auth'] = auth
-        kwargs['connection_class'] = RequestsHttpConnection
-
+        kwargs['connection_class'] = elasticsearch1.RequestsHttpConnection
     return Client(host, index, **kwargs)
+
+
+def get_es6_client(settings):
+    """Return a client for the Elasticsearch 6 index."""
+    host = settings['es.url']
+    index = settings['es.index']
+    kwargs = _get_client_settings(settings)
+    # nb. No AWS credentials here because we assume that if using AWS-managed
+    # ES, the cluster lives inside a VPC.
+    return Client(host, index, elasticsearch=elasticsearch, **kwargs)


### PR DESCRIPTION
Add a parameter called elasticsearch which is the elasticsearch library to use to
create the elastic search connection in the Client class

Move all shared kwargs from inside the Client class and from inside the get_client
method into a seperate method specificially for generating the shared connection
settings.

Add a get_es6_client method that gets the Elasticsearch 6 connection and expose it
on the request as `request.es6`.

This will enable existing code for setting up the Elasticsearch index
and reindexing annotations to be used with the ES6 cluster.