### PR TITLE
Add integrated tests for search result ordering

### DIFF
--- a/tests/h/search/query_test.py
+++ b/tests/h/search/query_test.py
@@ -1,10 +1,46 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+import datetime
+
 import pytest
 import webob
 
 from h.search import Search, index, query
+
+
+class TestBuilder(object):
+    @pytest.mark.parametrize("sort_key,order,expected_order", [
+        # Sort supports "updated" and "created" fields.
+        ("updated", "desc", [0, 1, 2]),
+        ("updated", "asc", [2, 1, 0]),
+        ("created", "desc", [2, 1, 0]),
+        ("created", "asc", [0, 1, 2]),
+
+        # Default sort order should be descending.
+        ("updated", None, [0, 1, 2]),
+
+        # Default sort field should be "updated".
+        (None, "asc", [2, 1, 0]),
+    ])
+    def test_it_sorts_annotations(self, Annotation, search, sort_key, order, expected_order):
+        dt = datetime.datetime
+        ann_ids = [Annotation(updated=dt(2018, 1, 1), created=dt(2016, 1, 1)).id,
+                   Annotation(updated=dt(2017, 1, 1), created=dt(2017, 1, 1)).id,
+                   Annotation(updated=dt(2016, 1, 1), created=dt(2018, 1, 1)).id]
+
+        params = {}
+        if sort_key:
+            params["sort"] = sort_key
+        if order:
+            params["order"] = order
+        result = search.run(params)
+
+        actual_order = [ann_ids.index(id_) for id_ in result.annotation_ids]
+        assert actual_order == expected_order
+
+    def test_it_ignores_unknown_sort_fields(self, search):
+        search.run({"sort": "no_such_field"})
 
 
 class TestTopLevelAnnotationsFilter(object):


### PR DESCRIPTION
Test support for:

 - Sorting by "updated" and "created" fields
 - Default sort ordering
 - What happens when an invalid sort field is specified

As far as I can tell we only ever sort annotations in chronological
order of last update in h and the client (ie. sort by updated,
descending). However the search API currently supports sorting by any
field which is indexed in Elasticsearch. We might be able to drop that
flexibility if it is unused.