### PR TITLE
Add support for identities to user_signup service

### DIFF
--- a/h/services/user_signup.py
+++ b/h/services/user_signup.py
@@ -5,7 +5,7 @@ from __future__ import unicode_literals
 from functools import partial
 
 from h.emails import signup
-from h.models import Activation, Subscriptions, User
+from h.models import Activation, Subscriptions, User, UserIdentity
 from h.tasks import mailer
 
 
@@ -47,6 +47,10 @@ class UserSignupService(object):
         :param require_activation: The name to use.
         :type require_activation: bool.
 
+        :param identities: A list of dictionaries representing identities to
+        add to the new user. Each dictionary will be passed as keyword args
+        to :py:class:`h.models.UserIdentity`.
+
         Remaining keyword arguments are used to construct a new
         :py:class:`h.models.User` object.
 
@@ -59,7 +63,14 @@ class UserSignupService(object):
         # user's password.
         password = kwargs.pop('password', None)
 
+        # Extract any passed identities for this new user
+        identities = kwargs.pop('identities', [])
+
         user = User(**kwargs)
+
+        # Add identity relations to this new user, if provided
+        user.identities = [UserIdentity(user=user, **i_args) for i_args in identities]
+
         self.session.add(user)
 
         if password is not None:

--- a/tests/h/services/user_signup_test.py
+++ b/tests/h/services/user_signup_test.py
@@ -88,7 +88,7 @@ class TestUserSignupService(object):
 
     def test_signup_raises_with_invalid_identities(self, svc, db_session):
         dupe_identity = {'provider': 'a', 'provider_unique_id': 1}
-        with pytest.raises(IntegrityError):
+        with pytest.raises(IntegrityError, match="violates unique constraint.*identity"):
             svc.signup(username='foo',
                        email='foo@bar.com',
                        identities=[dupe_identity, dupe_identity])

--- a/tests/h/services/user_signup_test.py
+++ b/tests/h/services/user_signup_test.py
@@ -6,6 +6,8 @@ import datetime
 import mock
 import pytest
 
+from sqlalchemy.exc import IntegrityError
+
 from h.models import Activation, Subscriptions, User
 from h.services.user_password import UserPasswordService
 from h.services.user_signup import (
@@ -54,6 +56,13 @@ class TestUserSignupService(object):
 
         assert user.authority == 'bar-client.com'
 
+    def test_signup_allows_user_with_empty_identities(self, svc):
+        user = svc.signup(require_activation=False,
+                          username='foo',
+                          identities=[])
+
+        assert user.identities == []
+
     def test_signup_passes_through_privacy_acceptance(self, svc):
         now = datetime.datetime.utcnow()
         user = svc.signup(username='foo',
@@ -61,6 +70,28 @@ class TestUserSignupService(object):
                           privacy_accepted=now)
 
         assert user.privacy_accepted == now
+
+    def test_signup_sets_provided_user_identities(self, svc):
+        identity_data = [{
+            'provider': 'someprovider',
+            'provider_unique_id': 1
+        }, {
+            'provider': 'someotherprovider',
+            'provider_unique_id': '394ffa3'
+        }]
+
+        user = svc.signup(username='foo',
+                          email='foo@bar.com',
+                          identities=identity_data)
+
+        assert len(user.identities) == 2
+
+    def test_signup_raises_with_invalid_identities(self, svc, db_session):
+        dupe_identity = {'provider': 'a', 'provider_unique_id': 1}
+        with pytest.raises(IntegrityError):
+            svc.signup(username='foo',
+                       email='foo@bar.com',
+                       identities=[dupe_identity, dupe_identity])
 
     def test_signup_sets_password_using_password_service(self, svc, user_password_service):
         user = svc.signup(username='foo',


### PR DESCRIPTION
Part of https://github.com/hypothesis/product-backlog/issues/700

This PR adds the support for `user_identities` to the `user_signup` service. The `user_signup` service will now optionally take an `identities` keyword param; this should be a list of dictionaries (see code comments) if present.

I've kept this PR very, very concise; it has minimal tests because the real heavy lifting is being done by the models. That is, further testing would not be unit testing (one of tests I added is already arguably technically testing the functionality of an underlying model more than the service itself). But let me know if I erred too far on the light-testing side.

I will say that it was refreshing how few lines of code were needed here.