### PR TITLE
Add annotation mapping for Elasticsearch 6

### DIFF
--- a/h/search/config.py
+++ b/h/search/config.py
@@ -11,13 +11,27 @@ these settings in an Elasticsearch instance.
 from __future__ import unicode_literals
 
 import binascii
+import elasticsearch1
+import elasticsearch
 import logging
 import os
 
-from elasticsearch1.exceptions import NotFoundError, RequestError
 
 log = logging.getLogger(__name__)
 
+ES_NOTFOUND_ERRORS = (
+    elasticsearch1.exceptions.NotFoundError,
+    elasticsearch.exceptions.NotFoundError,
+)
+ES_REQUEST_ERRORS = (
+    elasticsearch1.exceptions.RequestError,
+    elasticsearch.exceptions.RequestError,
+)
+
+# Elasticsearch mapping type for annotations for ES 1.x.
+#
+# These definition includes a number of legacy fields which don't need to be
+# indexed for historical reasons.
 ANNOTATION_MAPPING = {
     '_id': {'path': 'id'},
     '_source': {'excludes': ['id']},
@@ -105,6 +119,72 @@ ANNOTATION_MAPPING = {
     }
 }
 
+# Elasticsearch type mapping for annotations for ES 6.x and later.
+# This mapping does not include the legacy fields from the ES 1.x mapping.
+ES6_ANNOTATION_MAPPING = {
+    # Ignore unknown fields and do not add them to the mapping.
+    # This ensures that only fields included in the "properties" section
+    # here can be searched against.
+    'dynamic': False,
+
+    # Indexed (searchable) fields.
+    'properties': {
+        'authority': {'type': 'keyword'},
+        'created': {'type': 'date'},
+        'deleted': {'type': 'boolean'},
+        'document': {
+            'enabled': False,  # not indexed
+        },
+        'group': {'type': 'keyword'},
+        'id': {'type': 'keyword'},
+        'quote': {'type': 'text', 'analyzer': 'uni_normalizer'},
+        'references': {'type': 'keyword'},
+        'shared': {'type': 'boolean'},
+        'tags': {'type': 'text', 'analyzer': 'uni_normalizer'},
+        'tags_raw': {'type': 'keyword'},
+        'text': {'type': 'text', 'analyzer': 'uni_normalizer'},
+        'target': {
+            'properties': {
+                'source': {
+                    'type': 'text',
+                    'analyzer': 'uri',
+                    'copy_to': ['uri'],
+                },
+                # We store the 'scope' unanalyzed and only do term filters
+                # against this field.
+                'scope': {
+                    'type': 'keyword',
+                },
+                'selector': {
+                    'properties': {
+                        # Open Annotation TextQuoteSelector
+                        'exact': {
+                            'copy_to': 'quote',
+                            'type': 'text',
+                            'index': False,
+                        },
+                    }
+                }
+            }
+        },
+        'thread_ids': {'type': 'keyword'},
+        'updated': {'type': 'date'},
+        'uri': {
+            'type': 'text',
+            'analyzer': 'uri',
+            'fields': {
+                'parts': {
+                    'type': 'text',
+                    'analyzer': 'uri_parts',
+                },
+            },
+        },
+        'user': {'type': 'text', 'analyzer': 'user'},
+        'user_raw': {'type': 'keyword'},
+    }
+}
+
+# Filter and tokenizer definitions shared by ES 1.x and ES 6.x mappings.
 ANALYSIS_SETTINGS = {
     'char_filter': {
         'strip_scheme': {
@@ -178,10 +258,10 @@ def init(client):
 def configure_index(client):
     """Create a new randomly-named index and return its name."""
     index_name = client.index + '-' + _random_id()
-
+    mapping = _get_mapping(client)
     client.conn.indices.create(index_name, body={
         'mappings': {
-            client.mapping_type: ANNOTATION_MAPPING,
+            client.mapping_type: mapping,
         },
         'settings': {
             'analysis': ANALYSIS_SETTINGS,
@@ -199,7 +279,7 @@ def get_aliased_index(client):
     """
     try:
         result = client.conn.indices.get_alias(name=client.index)
-    except NotFoundError:  # no alias with that name
+    except ES_NOTFOUND_ERRORS:  # no alias with that name
         return None
     if len(result) > 1:
         raise RuntimeError("We don't support managing aliases that "
@@ -236,7 +316,7 @@ def delete_index(client, index_name):
 
     try:
         client.conn.indices.delete(index=index_name)
-    except NotFoundError:
+    except elasticsearch1.exceptions.NotFoundError:
         # In production using AWS Elasticsearch 1.5, `IndexMissingException`
         # responses have been seen in response to index deletion requests which
         # did actually succeed. We are just ignoring them here.
@@ -251,9 +331,11 @@ def update_index_settings(client):
     the index cannot be updated without reindexing.
     """
     index = get_aliased_index(client)
+    mapping = _get_mapping(client)
+
     _update_index_analysis(client.conn, index, ANALYSIS_SETTINGS)
     _update_index_mappings(client.conn, index,
-                           {client.mapping_type: ANNOTATION_MAPPING})
+                           {client.mapping_type: mapping})
 
 
 def _ensure_icu_plugin(conn):
@@ -291,7 +373,7 @@ def _update_index_mappings(conn, name, mappings):
             conn.indices.put_mapping(index=name,
                                      doc_type=doc_type,
                                      body=body)
-    except RequestError as e:
+    except ES_REQUEST_ERRORS as e:
         if not e.error.startswith('MergeMappingException'):
             raise
 
@@ -305,3 +387,10 @@ def _update_index_mappings(conn, name, mappings):
 def _random_id():
     """Generate a short random hex string."""
     return binascii.hexlify(os.urandom(4)).decode()
+
+
+def _get_mapping(client):
+    mapping = ES6_ANNOTATION_MAPPING
+    if client.version < (2,):
+        mapping = ANNOTATION_MAPPING
+    return mapping

--- a/h/search/config.py
+++ b/h/search/config.py
@@ -137,6 +137,7 @@ ES6_ANNOTATION_MAPPING = {
         },
         'group': {'type': 'keyword'},
         'id': {'type': 'keyword'},
+        'nipsa': {'type': 'boolean'},
         'quote': {'type': 'text', 'analyzer': 'uni_normalizer'},
         'references': {'type': 'keyword'},
         'shared': {'type': 'boolean'},

--- a/h/search/config.py
+++ b/h/search/config.py
@@ -335,7 +335,7 @@ def update_index_settings(client):
 
     _update_index_analysis(client.conn, index, ANALYSIS_SETTINGS)
     _update_index_mappings(client.conn, index,
-                           {client.mapping_type: mapping})
+                           client.mapping_type, mapping)
 
 
 def _ensure_icu_plugin(conn):
@@ -366,13 +366,12 @@ def _update_index_analysis(conn, name, analysis):
             conn.indices.open(index=name)
 
 
-def _update_index_mappings(conn, name, mappings):
+def _update_index_mappings(conn, name, doc_type, mapping):
     """Attempt to update the index mappings."""
     try:
-        for doc_type, body in mappings.items():
-            conn.indices.put_mapping(index=name,
-                                     doc_type=doc_type,
-                                     body=body)
+        conn.indices.put_mapping(index=name,
+                                 doc_type=doc_type,
+                                 body=mapping)
     except ES_REQUEST_ERRORS as e:
         if not e.error.startswith('MergeMappingException'):
             raise

--- a/tests/h/cli/commands/search_test.py
+++ b/tests/h/cli/commands/search_test.py
@@ -5,6 +5,7 @@ import os
 import pytest
 
 from h.cli.commands import search
+from h.search.config import ANNOTATION_MAPPING
 
 
 class TestReindexCommand(object):
@@ -32,7 +33,7 @@ class TestUpdateSettingsCommand(object):
         result = cli.invoke(search.update_settings, [], obj=cliconfig)
 
         assert result.exit_code == 0
-        update_index_settings.assert_called_once_with(pyramid_request.es)
+        update_index_settings.assert_called_once_with(pyramid_request.es, ANNOTATION_MAPPING)
 
     def test_handles_runtimeerror(self, cli, cliconfig, update_index_settings):
         update_index_settings.side_effect = RuntimeError("asplode!")
@@ -44,8 +45,7 @@ class TestUpdateSettingsCommand(object):
 
     @pytest.fixture
     def update_index_settings(self, patch):
-        config = patch('h.cli.commands.search.config')
-        return config.update_index_settings
+        return patch('h.cli.commands.search.config.update_index_settings')
 
 
 @pytest.fixture

--- a/tests/h/cli/commands/search_test.py
+++ b/tests/h/cli/commands/search_test.py
@@ -5,7 +5,6 @@ import os
 import pytest
 
 from h.cli.commands import search
-from h.search.config import ANNOTATION_MAPPING
 
 
 class TestReindexCommand(object):
@@ -33,7 +32,7 @@ class TestUpdateSettingsCommand(object):
         result = cli.invoke(search.update_settings, [], obj=cliconfig)
 
         assert result.exit_code == 0
-        update_index_settings.assert_called_once_with(pyramid_request.es, ANNOTATION_MAPPING)
+        update_index_settings.assert_called_once_with(pyramid_request.es)
 
     def test_handles_runtimeerror(self, cli, cliconfig, update_index_settings):
         update_index_settings.side_effect = RuntimeError("asplode!")


### PR DESCRIPTION
Add mappings that define the schema of indexed annotations for
Elasticsearch 6. Compared to the existing `ANNOTATION_MAPPING`, the
following changes have been made:

 - The indexed fields are sorted alphabetically
 - "string" fields have been changed to use either "text" or "keyword"
   types depending on whether we need to support search within those
   fields ("text") or only on the whole content of the field ("keyword")
 - Fields which we have no need to search or sort on have been removed.
   This includes:

    - `annotator_schema_version`
    - `target.selector` fields other than `exact` (the annotation's
      quote)
 - The "id" field has been explicitly added since the document's `_id`
   field is not configurable in ES6.
 - The `dynamic` option has been set to `false` to disable indexing of
   any fields which are not explicitly listed in the mapping. This
   avoids anyone relying on being able to search fields which happen to
   get written to the index but are not explicitly listed as searchable.

The analysis settings have not been changed since the existing settings
work with ES6.

Since the mapping depends on which es client is passed in (es1 or es6)
the mapping was exposed as a parameter to the higher level code as the
higher level code knows which version of the client it's passing.