### PR TITLE
Add `identities` to `h.schemas.api.user`

### DIFF
--- a/h/schemas/api/user.py
+++ b/h/schemas/api/user.py
@@ -36,6 +36,24 @@ class CreateUserAPISchema(JSONSchema):
                 'type': 'string',
                 'maxLength': DISPLAY_NAME_MAX_LENGTH,
             },
+            'identities': {
+                'type': 'array',
+                'items': {
+                    'type': 'object',
+                    'properties': {
+                        'provider': {
+                            'type': 'string',
+                        },
+                        'provider_unique_id': {
+                            'type': 'string',
+                        },
+                    },
+                    'required': [
+                        'provider',
+                        'provider_unique_id',
+                    ]
+                }
+            },
         },
         'required': [
             'authority',

--- a/tests/h/schemas/api/user_test.py
+++ b/tests/h/schemas/api/user_test.py
@@ -102,6 +102,49 @@ class TestCreateUserAPISchema(object):
         with pytest.raises(ValidationError):
             schema.validate(payload)
 
+    def test_it_allows_valid_identities(self, schema, payload):
+        payload['identities'] = [{'provider': 'foo', 'provider_unique_id': 'bar'}]
+
+        appstruct = schema.validate(payload)
+
+        assert 'identities' in appstruct
+
+    def test_it_raises_when_identities_not_an_array(self, schema, payload):
+        payload['identities'] = 'dragnabit'
+
+        with pytest.raises(ValidationError, match=".*identities.*is not of type.*"):
+            schema.validate(payload)
+
+    def test_it_raises_when_identities_items_not_objects(self, schema, payload):
+        payload['identities'] = ['flerp', 'flop']
+
+        with pytest.raises(ValidationError, match=".*identities.*is not of type.*"):
+            schema.validate(payload)
+
+    def test_it_raises_when_provider_missing_in_identity(self, schema, payload):
+        payload['identities'] = [{'foo': 'bar', 'provider_unique_id': 'flop'}]
+
+        with pytest.raises(ValidationError, match=".*provider'.*is a required property.*"):
+            schema.validate(payload)
+
+    def test_it_raises_when_provider_unique_id_missing_in_identity(self, schema, payload):
+        payload['identities'] = [{'foo': 'bar', 'provider': 'flop'}]
+
+        with pytest.raises(ValidationError, match=".*provider_unique_id'.*is a required property.*"):
+            schema.validate(payload)
+
+    def test_it_raises_if_identity_provider_is_not_a_string(self, schema, payload):
+        payload['identities'] = [{'provider_unique_id': 'bar', 'provider': 75}]
+
+        with pytest.raises(ValidationError, match=".*provider:.*is not of type.*string.*"):
+            schema.validate(payload)
+
+    def test_it_raises_if_identity_provider_unique_id_is_not_a_string(self, schema, payload):
+        payload['identities'] = [{'provider_unique_id': [], 'provider': 'hithere'}]
+
+        with pytest.raises(ValidationError, match=".*provider_unique_id:.*is not of type.*string.*"):
+            schema.validate(payload)
+
     @pytest.fixture
     def payload(self):
         return {


### PR DESCRIPTION
Part of https://github.com/hypothesis/product-backlog/issues/700

This PR updates the user API schema to accept an Array of identity Objects. This will be needed by the API shortly.