### PR TITLE
WIP: Update docs for `POST users/`

### DIFF
--- a/docs/_extra/api-reference/hypothesis.yaml
+++ b/docs/_extra/api-reference/hypothesis.yaml
@@ -363,6 +363,9 @@ paths:
         designated authority to create users within their authority. Optional
         identity information may be provided to maintain provider-specific
         metadata about users.
+
+        This endpoint will return an HTTP 409 (Conflict) if the request represents
+        a duplicate of an existing user—email, username or identity collision.
       operationId: createUser
       parameters:
         - name: user
@@ -380,6 +383,10 @@ paths:
           description: Could not create user from your request
           schema:
             $ref: '#/definitions/Error'
+        '409':
+          description: Conflict
+          schema:
+            $ref: '#/definitions/ConflictError'
       security:
         - authClientCredentials: []
   /users/{username}:
@@ -459,6 +466,19 @@ definitions:
       reason:
         type: string
         description: A human-readable description of the reason(s) for failure.
+  ConflictError:
+    description: An error indicating a resource conflict, typically because a duplicate resource already exists.
+    type: object
+    required:
+      - status
+    properties:
+      status:
+        type: string
+        enum:
+          - failure
+      reason:
+        type: string
+        description: One or more human-readable errors describing the conflict.
   SearchResults:
     type: object
     required:

--- a/docs/_extra/api-reference/hypothesis.yaml
+++ b/docs/_extra/api-reference/hypothesis.yaml
@@ -360,7 +360,9 @@ paths:
       summary: Create a new user
       description: |
         Only for specific auth clients, this API call allows clients with a
-        designated authority to create users within their authority.
+        designated authority to create users within their authority. Optional
+        identity information may be provided to maintain provider-specific
+        metadata about users.
       operationId: createUser
       parameters:
         - name: user

--- a/docs/_extra/api-reference/schemas/new-user-schema.json
+++ b/docs/_extra/api-reference/schemas/new-user-schema.json
@@ -19,7 +19,25 @@
     "display_name": {
       "type": "string",
       "maxLength": 30
-    }
+    },
+    "identities": {
+      "type": "array",
+      "items": {
+          "type": "object",
+          "properties": {
+              "provider": {
+                  "type": "string",
+              },
+              "provider_unique_id": {
+                  "type": "string",
+              },
+          },
+          "required": [
+              "provider",
+              "provider_unique_id",
+          ]
+      },
+  },
   },
   "required": [
     "authority",


### PR DESCRIPTION
This PR  contains changes to the documentation for the `POST users/` endpoint, which will continue to evolve as the endpoint evolves during this cycle of work.

At this starting point, the docs look like this:

![image](https://user-images.githubusercontent.com/439947/42596392-7b995e54-8523-11e8-821e-0af390057b2e.png)

As things get added and changed, I'll push to this branch/PR.