### PR TITLE
Test that `user:{username}` searches are case-insensitive

### DIFF
--- a/tests/h/search/query_test.py
+++ b/tests/h/search/query_test.py
@@ -149,6 +149,13 @@ class TestUserFilter(object):
 
         assert sorted(result.annotation_ids) == sorted(expected_ids)
 
+    def test_filter_is_case_insensitive(self, search, Annotation):
+        ann_id = Annotation(userid="acct:bob@example", shared=True).id
+
+        result = search.run({"user": "BOB"})
+
+        assert result.annotation_ids == [ann_id]
+
     def test_filters_annotations_by_multiple_users(self, search, Annotation):
         Annotation(userid="acct:foo@auth2", shared=True)
         expected_ids = [Annotation(userid="acct:bar@auth2", shared=True).id,


### PR DESCRIPTION
I noticed looking over `old_query_test.py` that the new `UserFilter` tests were missing a case.

A search for `user:BOB` should match annotations by `bob`. Usernames are
lower-cased at indexing time as a result of the mapping configuration.
Since `UserFilter` uses a term query [1] it has to explicitly lowercase
the value itself at search time.

[1] https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-term-query.html