### PR TITLE
Add Conflict Exception (HTTP 409)

### DIFF
--- a/h/exceptions.py
+++ b/h/exceptions.py
@@ -33,7 +33,7 @@ class ConflictError(APIError):
     Exception raised if client request represents a duplicate of an
     existing resource.
     """
-    def __init__(self, message='Conflict'):
+    def __init__(self, message=_('Conflict')):
         super(ConflictError, self).__init__(message, status_code=409)
 
 

--- a/h/exceptions.py
+++ b/h/exceptions.py
@@ -28,6 +28,15 @@ class ClientUnauthorized(APIError):
         super(ClientUnauthorized, self).__init__(message, status_code=403)
 
 
+class ConflictError(APIError):
+    """
+    Exception raised if client request represents a duplicate of an
+    existing resource.
+    """
+    def __init__(self, message='Conflict'):
+        super(ConflictError, self).__init__(message, status_code=409)
+
+
 class OAuthTokenError(APIError):
 
     """

--- a/tests/h/exceptions_test.py
+++ b/tests/h/exceptions_test.py
@@ -2,7 +2,7 @@
 
 from __future__ import unicode_literals
 
-from h.exceptions import APIError, ClientUnauthorized
+from h.exceptions import APIError, ClientUnauthorized, ConflictError
 
 
 class TestAPIError(object):
@@ -32,3 +32,20 @@ class TestClientUnauthorized(object):
         exc = ClientUnauthorized()
 
         assert exc.status_code == 403
+
+
+class TestConflictError(object):
+    def test_it_returns_the_correct_http_status(self):
+        exc = ConflictError()
+
+        assert exc.status_code == 409
+
+    def test_it_sets_default_message_if_none_provided(self):
+        exc = ConflictError()
+
+        assert exc.message == "Conflict"
+
+    def test_it_sets_provided_message(self):
+        exc = ConflictError("nah, that's no good")
+
+        assert exc.message == "nah, that's no good"

--- a/tests/h/exceptions_test.py
+++ b/tests/h/exceptions_test.py
@@ -43,12 +43,12 @@ class TestConflictError(object):
     def test_it_sets_default_message_if_none_provided(self):
         exc = exceptions.ConflictError()
 
-        assert exc.message == "Conflict"
+        assert str(exc) == "Conflict"
 
     def test_it_sets_provided_message(self):
         exc = exceptions.ConflictError("nah, that's no good")
 
-        assert exc.message == "nah, that's no good"
+        assert str(exc) == "nah, that's no good"
 
 
 class TestOAuthTokenError(object):
@@ -56,7 +56,7 @@ class TestOAuthTokenError(object):
         exc = exceptions.OAuthTokenError('boom', 'mytype')
 
         assert exc.type == 'mytype'
-        assert exc.message == 'boom'
+        assert str(exc) == 'boom'
 
     def test_it_sets_default_response_code(self):
         exc = exceptions.OAuthTokenError('boom', 'mytype')
@@ -74,4 +74,4 @@ class TestPayloadError(object):
         exc = exceptions.PayloadError()
 
         assert exc.status_code == 400
-        assert exc.message == 'Expected a valid JSON payload, but none was found!'
+        assert str(exc) == 'Expected a valid JSON payload, but none was found!'

--- a/tests/h/exceptions_test.py
+++ b/tests/h/exceptions_test.py
@@ -2,50 +2,76 @@
 
 from __future__ import unicode_literals
 
-from h.exceptions import APIError, ClientUnauthorized, ConflictError
+from h import exceptions
 
 
 class TestAPIError(object):
     def test_message(self):
-        exc = APIError('some message')
+        exc = exceptions.APIError('some message')
 
         assert str(exc) == 'some message'
 
     def test_default_status_code(self):
-        exc = APIError('some message')
+        exc = exceptions.APIError('some message')
 
         assert exc.status_code == 500
 
     def test_custom_status_code(self):
-        exc = APIError('some message', status_code=418)
+        exc = exceptions.APIError('some message', status_code=418)
 
         assert exc.status_code == 418
 
 
 class TestClientUnauthorized(object):
     def test_message(self):
-        exc = ClientUnauthorized()
+        exc = exceptions.ClientUnauthorized()
 
         assert 'credentials are invalid' in str(exc)
 
     def test_status_code(self):
-        exc = ClientUnauthorized()
+        exc = exceptions.ClientUnauthorized()
 
         assert exc.status_code == 403
 
 
 class TestConflictError(object):
     def test_it_returns_the_correct_http_status(self):
-        exc = ConflictError()
+        exc = exceptions.ConflictError()
 
         assert exc.status_code == 409
 
     def test_it_sets_default_message_if_none_provided(self):
-        exc = ConflictError()
+        exc = exceptions.ConflictError()
 
         assert exc.message == "Conflict"
 
     def test_it_sets_provided_message(self):
-        exc = ConflictError("nah, that's no good")
+        exc = exceptions.ConflictError("nah, that's no good")
 
         assert exc.message == "nah, that's no good"
+
+
+class TestOAuthTokenError(object):
+    def test_it_sets_type_and_message(self):
+        exc = exceptions.OAuthTokenError('boom', 'mytype')
+
+        assert exc.type == 'mytype'
+        assert exc.message == 'boom'
+
+    def test_it_sets_default_response_code(self):
+        exc = exceptions.OAuthTokenError('boom', 'mytype')
+
+        assert exc.status_code == 400
+
+    def test_it_sets_custom_response_code(self):
+        exc = exceptions.OAuthTokenError('boom', 'mytype', 500)
+
+        assert exc.status_code == 500
+
+
+class TestPayloadError(object):
+    def test_it_sets_default_message_and_status(self):
+        exc = exceptions.PayloadError()
+
+        assert exc.status_code == 400
+        assert exc.message == 'Expected a valid JSON payload, but none was found!'


### PR DESCRIPTION
This PR adds a new Exception class to `h.exceptions`: `ConflictError`. This will raise a 409 (HTTP Conflict). Nothing makes use of this exception yet.

While in there, I took the opportunity to add tests for other Exceptions in this module which were missing tests.