### PR TITLE
Add fetch by identity

### DIFF
--- a/h/services/user.py
+++ b/h/services/user.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 
 import sqlalchemy as sa
 
-from h.models import User
+from h.models import User, UserIdentity
 from h.util.user import split_user
 from h.util.db import on_transaction_end
 
@@ -114,6 +114,22 @@ class UserService(object):
                 self._cache[cache_key] = user
 
         return [v for k, v in self._cache.items() if k in cache_keys.keys()]
+
+    def fetch_by_identity(self, provider, provider_unique_id):
+        """
+        Fetch a user by associated identity.
+
+        :returns: a user instance, if found
+        :rtype: h.models.User or None
+        """
+
+        identity = (self.session.query(UserIdentity)
+                                .filter_by(provider=provider,
+                                           provider_unique_id=provider_unique_id)
+                                .one_or_none())
+        if identity:
+            return identity.user
+        return None
 
     def fetch_for_login(self, username_or_email):
         """

--- a/tests/common/factories/__init__.py
+++ b/tests/common/factories/__init__.py
@@ -20,6 +20,7 @@ from .organization import Organization
 from .setting import Setting
 from .token import DeveloperToken, OAuth2Token
 from .user import User
+from .user_identity import UserIdentity
 
 __all__ = (
     'Activation',
@@ -43,5 +44,6 @@ __all__ = (
     'RestrictedGroup',
     'Setting',
     'User',
+    'UserIdentity',
     'set_session',
 )

--- a/tests/common/factories/user_identity.py
+++ b/tests/common/factories/user_identity.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import factory
+
+from h import models
+
+from .base import ModelFactory
+
+
+class UserIdentity(ModelFactory):
+
+    class Meta:
+        model = models.UserIdentity
+        sqlalchemy_session_persistence = 'flush'
+
+    provider = factory.Sequence(lambda n: 'test_provider_{n}'.format(n=str(n)))
+    provider_unique_id = factory.Sequence(lambda n: 'test_id_{n}'.format(n=str(n)))


### PR DESCRIPTION
Add method to fetch a user by associated identity to `UserService`. We'll need this to extend the uniqueness validation in the create-user API endpoint and also later to retrieve a user by identity.

This is the first module to use `UserIdentity`, so it's the right time to add a `UserIdentity` factory for tests, which is done in this PR as well.