### PR TITLE
Add user unique(ness) service

### DIFF
--- a/h/services/__init__.py
+++ b/h/services/__init__.py
@@ -32,6 +32,7 @@ def includeme(config):
     config.register_service_factory('.rename_user.rename_user_factory', name='rename_user')
     config.register_service_factory('.settings.settings_factory', name='settings')
     config.register_service_factory('.user.user_service_factory', name='user')
+    config.register_service_factory('.user_unique.user_unique_factory', name='user_unique')
     config.register_service_factory('.user_password.user_password_service_factory', name='user_password')
     config.register_service_factory('.user_signup.user_signup_service_factory', name='user_signup')
 

--- a/h/services/user_unique.py
+++ b/h/services/user_unique.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from h.i18n import TranslationString as _  # noqa: N813
+from h import models
+
+
+class DuplicateUserError(Exception):
+    """Indicates that data violates user uniqueness constraints"""
+
+    def __init__(self, message):
+        super(DuplicateUserError, self).__init__(message)
+
+
+class UserUniqueService(object):
+
+    """
+    A service for ensuring that data represents a unique user and will
+    not constitute a duplicate user.
+    """
+
+    def __init__(self, session, request_authority):
+        """
+        Create a new user_unique service.
+
+        :param _session: the SQLAlchemy session object
+        """
+        self._session = session
+        self.request_authority = request_authority
+
+    def ensure_unique(self, data, authority=None):
+        """
+        Ensure the provided `data` would constitute a new, non-duplicate
+        user. Check for conflicts in email, username, identity.
+
+        :param data: dictionary of new-user data. Will check `email`, `username`
+                     and any `identities` dictionaries provided
+        :raises ConflictError: if the data violate any uniqueness constraints
+        """
+        authority = authority or self.request_authority
+        errors = []
+
+        if data.get('email', None) and (
+            models.User.get_by_email(self._session, data['email'], authority)
+        ):
+            errors.append(_('user with email address %s already exists' % data['email']))
+
+        if data.get('username', None) and (
+            models.User.get_by_username(self._session, data['username'], authority)
+        ):
+            errors.append(_('user with username %s already exists' % data['username']))
+
+        if errors:
+            raise DuplicateUserError(', '.join(errors))
+
+
+def user_unique_factory(context, request):
+    return UserUniqueService(session=request.db,
+                             request_authority=request.authority)

--- a/tests/h/services/user_unique_test.py
+++ b/tests/h/services/user_unique_test.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import pytest
+
+from h.services.user_unique import UserUniqueService, user_unique_factory
+from h.services.user_unique import DuplicateUserError
+
+
+class TestUserUniqueEnsureUnique(object):
+    def test_it_raises_if_email_uniqueness_violated(self, svc, user, pyramid_request):
+        dupe_email = user.email
+        with pytest.raises(DuplicateUserError,
+                           match=(".*user with email address {} already exists".format(dupe_email))):
+            svc.ensure_unique({'email': dupe_email},
+                              authority=pyramid_request.authority)
+
+    def test_it_allows_duplicate_email_at_different_authority(self, svc, user, pyramid_request):
+        svc.ensure_unique({'email': user.email}, authority='foo.com')
+
+    def test_it_raises_if_username_uniqueness_violated(self, svc, user, pyramid_request):
+        dupe_username = user.username
+        with pytest.raises(DuplicateUserError,
+                           match=(".*user with username {} already exists".format(dupe_username))):
+            svc.ensure_unique({'username': dupe_username},
+                              authority=pyramid_request.authority)
+
+    def test_it_allows_duplicate_username_at_different_authority(self, svc, user, pyramid_request):
+        svc.ensure_unique({'username': user.username}, authority='foo.com')
+
+
+class TestUserUniqueFactory(object):
+
+    def test_user_unique_factory(self, pyramid_request):
+        svc = user_unique_factory(None, pyramid_request)
+
+        assert isinstance(svc, UserUniqueService)
+
+    def test_uses_request_authority(self, pyramid_request):
+        pyramid_request.authority = 'bar.com'
+
+        svc = user_unique_factory(None, pyramid_request)
+
+        assert svc.request_authority == 'bar.com'
+
+
+@pytest.fixture
+def user(factories, pyramid_request):
+    return factories.User(
+        username="fernando",
+        email="foo@example.com",
+        authority=pyramid_request.authority
+    )
+
+
+@pytest.fixture
+def svc(pyramid_request, db_session):
+    return UserUniqueService(
+        session=db_session,
+        request_authority=pyramid_request.authority
+    )

--- a/tests/h/services/user_unique_test.py
+++ b/tests/h/services/user_unique_test.py
@@ -3,33 +3,103 @@
 from __future__ import unicode_literals
 
 import pytest
+import mock
 
 from h.services.user_unique import UserUniqueService, user_unique_factory
 from h.services.user_unique import DuplicateUserError
+from h.services.user import UserService
 
 
 class TestUserUniqueEnsureUnique(object):
     def test_it_raises_if_email_uniqueness_violated(self, svc, user, pyramid_request):
         dupe_email = user.email
+
         with pytest.raises(DuplicateUserError,
-                           match=(".*user with email address {} already exists".format(dupe_email))):
+                           match=(".*user with email address '{}' already exists".format(dupe_email))):
             svc.ensure_unique({'email': dupe_email},
                               authority=pyramid_request.authority)
 
-    def test_it_allows_duplicate_email_at_different_authority(self, svc, user, pyramid_request):
+    def test_it_allows_duplicate_email_at_different_authority(self, svc, user):
         svc.ensure_unique({'email': user.email}, authority='foo.com')
 
     def test_it_raises_if_username_uniqueness_violated(self, svc, user, pyramid_request):
         dupe_username = user.username
+
         with pytest.raises(DuplicateUserError,
-                           match=(".*user with username {} already exists".format(dupe_username))):
+                           match=(".*user with username '{}' already exists".format(dupe_username))):
             svc.ensure_unique({'username': dupe_username},
                               authority=pyramid_request.authority)
 
-    def test_it_allows_duplicate_username_at_different_authority(self, svc, user, pyramid_request):
+    def test_it_allows_duplicate_username_at_different_authority(self, svc, user):
         svc.ensure_unique({'username': user.username}, authority='foo.com')
 
+    def test_it_raises_if_identities_uniqueness_violated(self, svc, user, pyramid_request):
+        dupe_identity = {'provider': 'provider_a', 'provider_unique_id': '123'}
 
+        with pytest.raises(DuplicateUserError, match=".*provider 'provider_a' and unique id '123' already exists"):
+            svc.ensure_unique({'identities': [dupe_identity]}, authority=pyramid_request.authority)
+
+    def test_it_raises_if_identities_uniqueness_violated_at_different_authority(self, svc, user):
+        # note that this is different from email and username behavior
+        dupe_identity = {'provider': 'provider_a', 'provider_unique_id': '123'}
+        with pytest.raises(DuplicateUserError, match=".*provider 'provider_a' and unique id '123' already exists"):
+            svc.ensure_unique({'identities': [dupe_identity]}, authority='foo.com')
+
+    def test_it_proxies_email_lookup_to_model(self, svc, user_model, db_session, pyramid_request):
+        svc.ensure_unique({'email': 'foo@bar.com'}, pyramid_request.authority)
+
+        user_model.get_by_email.assert_called_once_with(db_session, 'foo@bar.com', pyramid_request.authority)
+
+    def test_it_proxies_username_lookup_to_model(self, svc, user_model, db_session, pyramid_request):
+        svc.ensure_unique({'username': 'fernando'}, pyramid_request.authority)
+
+        user_model.get_by_username.assert_called_once_with(db_session, 'fernando', pyramid_request.authority)
+
+    def test_it_proxies_identity_fetching_to_user_service(self, svc, user_service):
+        identity_data = [{'provider': 'provider_a', 'provider_unique_id': '123'},
+                         {'provider': 'provider_a', 'provider_unique_id': '123'}]
+        user_service.fetch_by_identity.return_value = None
+
+        svc.ensure_unique({'identities': identity_data})
+
+        user_service.fetch_by_identity.assert_has_calls([
+            mock.call(identity_data[0]['provider'], identity_data[0]['provider_unique_id']),
+            mock.call(identity_data[1]['provider'], identity_data[1]['provider_unique_id'])
+        ])
+
+    def test_it_does_not_fetch_by_username_if_not_present(self, svc, user_model, db_session, pyramid_request):
+        svc.ensure_unique({'email': 'foo@bar.com'}, pyramid_request.authority)
+
+        user_model.get_by_username.assert_not_called()
+
+    def test_it_does_not_fetch_by_email_if_not_present(self, svc, user_model, db_session, pyramid_request):
+        svc.ensure_unique({'username': 'doodle'}, pyramid_request.authority)
+
+        user_model.get_by_email.assert_not_called()
+
+    def test_it_allows_empty_data(self, svc, pyramid_request):
+        svc.ensure_unique({})
+        # does not raise
+
+    def test_it_combines_error_messages(self, svc, user, pyramid_request):
+        dupe_identity = {'provider': user.identities[0].provider,
+                          'provider_unique_id': user.identities[0].provider_unique_id}
+        with pytest.raises(DuplicateUserError, match=".*email.*username.*provider"):
+            svc.ensure_unique({'email': user.email,
+                               'username': user.username,
+                               'identities': [dupe_identity]})
+
+    def test_it_defaults_to_request_authority(self, svc, pyramid_request, db_session, user_model):
+        svc.ensure_unique({'email': 'somebody@example.com'})
+
+        user_model.get_by_email.assert_called_once_with(
+            db_session,
+            'somebody@example.com',
+            pyramid_request.authority
+        )
+
+
+@pytest.mark.usefixtures('user_service')
 class TestUserUniqueFactory(object):
 
     def test_user_unique_factory(self, pyramid_request):
@@ -47,16 +117,37 @@ class TestUserUniqueFactory(object):
 
 @pytest.fixture
 def user(factories, pyramid_request):
-    return factories.User(
+    user = factories.User(
         username="fernando",
         email="foo@example.com",
         authority=pyramid_request.authority
     )
+    user.identities = [
+        factories.UserIdentity(provider='provider_a', provider_unique_id='123', user=user)
+    ]
+    return user
 
 
 @pytest.fixture
-def svc(pyramid_request, db_session):
+def user_model(patch):
+    patched = patch('h.services.user_unique.models.User')
+    # By default, a mocked method will return another Mock
+    patched.get_by_email.return_value = None
+    patched.get_by_username.return_value = None
+    return patched
+
+
+@pytest.fixture
+def svc(pyramid_request, db_session, user_service):
     return UserUniqueService(
         session=db_session,
+        user_service=user_service,
         request_authority=pyramid_request.authority
     )
+
+
+@pytest.fixture
+def user_service(pyramid_config):
+    service = mock.create_autospec(UserService, spec_set=True, instance=True)
+    pyramid_config.register_service(service, name='user')
+    return service


### PR DESCRIPTION
**Depends on https://github.com/hypothesis/h/pull/5148**

This PR adds a new service for user data uniqueness verification. It checks provided data against a number of checks and will raise its own `DuplicateUserError` if any uniqueness checks fail. It will perform all checks before raising, meaning that there will be an aggregate set of error-state messages available in the Exception.

This is needed for LMS so that we can assure that no two users get created with the same identity information.

The idea is that a view can use this service, catch any raised `DuplicateUserError`s and raise an appropriate HTTP error (hint: ConflictError in this case).

This duplicates behavior (and intends to replace it) in `h.views.api.users` and makes it more robust (more thorough testing) and adds identity uniqueness checking.