### PR TITLE
Add tests to check creation of groups at non-default authorities.

### DIFF
--- a/h/views/api/groups.py
+++ b/h/views/api/groups.py
@@ -6,7 +6,6 @@ from pyramid import security
 from pyramid.httpexceptions import HTTPNoContent, HTTPBadRequest
 
 from h.exceptions import PayloadError
-from h.i18n import TranslationString as _  # noqa: N813
 from h.presenters import GroupJSONPresenter, GroupsJSONPresenter
 from h.schemas.api.group import CreateGroupAPISchema
 from h.traversal import GroupContext
@@ -42,10 +41,6 @@ def groups(request):
             description='Create a new group')
 def create(request):
     """Create a group from the POST payload."""
-    # @TODO Temporary: Remove this check once private groups supported at other authorities
-    if request.authority != request.user.authority:
-        raise HTTPBadRequest(_('Group creation currently only supported for default authority'))
-
     schema = CreateGroupAPISchema()
 
     appstruct = schema.validate(_json_payload(request))
@@ -61,6 +56,7 @@ def create(request):
         request.user.userid,
         description=group_properties['description'],
     )
+
     group_context = GroupContext(group, request)
     return GroupJSONPresenter(group_context).asdict(expand=['organization'])
 

--- a/tests/h/services/group_test.py
+++ b/tests/h/services/group_test.py
@@ -31,6 +31,12 @@ class TestGroupServiceCreatePrivateGroup(object):
 
         assert group.authority == pyramid_request.authority
 
+    def test_it_sets_group_authority_as_creator_authority(self, svc, creator, pyramid_request):
+        pyramid_request.authority = 'some_other_authority'
+        group = svc.create_private_group('Anteater fans', creator.userid)
+
+        assert group.authority == creator.authority
+
     def test_it_sets_group_creator(self, svc, creator):
         group = svc.create_private_group('Anteater fans', creator.userid)
 
@@ -100,13 +106,18 @@ class TestGroupServiceCreateOpenGroup(object):
 
     @pytest.mark.parametrize('group_attr,expected_value', [
         ('name', 'test group'),
-        ('description', 'test description'),
-        ('authority', 'example.com')
+        ('description', 'test description')
     ])
     def test_it_creates_group_attrs(self, creator, svc, origins, group_attr, expected_value):
         group = svc.create_open_group('test group', creator.userid, origins=origins, description='test description')
 
         assert getattr(group, group_attr) == expected_value
+
+    def test_it_sets_group_authority_as_creator_authority(self, svc, creator, pyramid_request):
+        pyramid_request.authority = 'some_other_authority'
+        group = svc.create_private_group('Anteater fans', creator.userid)
+
+        assert group.authority == creator.authority
 
     def test_it_skips_setting_description_when_missing(self, svc, creator, origins):
         group = svc.create_open_group('Anteater fans', creator.userid, origins=origins)
@@ -185,13 +196,18 @@ class TestGroupServiceCreateRestrictedGroup(object):
 
     @pytest.mark.parametrize('group_attr,expected_value', [
         ('name', 'test group'),
-        ('description', 'test description'),
-        ('authority', 'example.com')
+        ('description', 'test description')
     ])
     def test_it_creates_group_attrs(self, creator, svc, origins, group_attr, expected_value):
         group = svc.create_restricted_group('test group', creator.userid, origins=origins, description='test description')
 
         assert getattr(group, group_attr) == expected_value
+
+    def test_it_sets_group_authority_as_creator_authority(self, svc, creator, pyramid_request):
+        pyramid_request.authority = 'some_other_authority'
+        group = svc.create_private_group('Anteater fans', creator.userid)
+
+        assert group.authority == creator.authority
 
     def test_it_skips_setting_description_when_missing(self, svc, creator, origins):
         group = svc.create_restricted_group('Anteater fans', creator.userid, origins=origins)

--- a/tests/h/views/api/groups_test.py
+++ b/tests/h/views/api/groups_test.py
@@ -128,12 +128,6 @@ class TestCreateGroup(object):
             with pytest.raises(views.PayloadError):
                 views.create(pyramid_request)
 
-    def test_it_returns_400_if_user_has_non_default_authority(self, pyramid_request, factories):
-        pyramid_request.user = factories.User(authority='other.com')
-
-        with pytest.raises(HTTPBadRequest):
-            views.create(pyramid_request)
-
     def test_it_passes_request_params_to_group_create_service(self,
                                                               pyramid_request,
                                                               CreateGroupAPISchema,


### PR DESCRIPTION
See https://github.com/hypothesis/product-backlog/issues/684

Note: Creating private, public and restricted groups all use the same private method which assigns creator authority as the group authority. Hence the additional tests.