### PR TITLE
Rename `NipsaService.flagged_userids`

### DIFF
--- a/h/services/nipsa.py
+++ b/h/services/nipsa.py
@@ -15,10 +15,9 @@ class NipsaService(object):
     def __init__(self, session):
         self.session = session
 
-    @property
-    def flagged_userids(self):
+    def fetch_all_flagged_userids(self):
         """
-        A list of all the NIPSA'd userids.
+        Fetch the userids of all shadowbanned / NIPSA'd users.
 
         :rtype: set of unicode strings
         """

--- a/h/views/admin_nipsa.py
+++ b/h/views/admin_nipsa.py
@@ -19,7 +19,7 @@ class UserNotFoundError(Exception):
 def nipsa_index(request):
     nipsa_service = request.find_service(name='nipsa')
     return {
-        "userids": sorted(nipsa_service.flagged_userids),
+        "userids": sorted(nipsa_service.fetch_all_flagged_userids()),
         "default_authority": request.authority,
     }
 

--- a/tests/h/services/nipsa_test.py
+++ b/tests/h/services/nipsa_test.py
@@ -10,11 +10,11 @@ from h.services.nipsa import nipsa_factory
 
 @pytest.mark.usefixtures('users', 'reindex_user_annotations')
 class TestNipsaService(object):
-    def test_flagged_userids_returns_set_of_userids(self, db_session):
+    def test_fetch_all_flagged_userids_returns_set_of_userids(self, db_session):
         svc = NipsaService(db_session)
 
-        assert svc.flagged_userids == set(['acct:renata@example.com',
-                                           'acct:cecilia@example.com'])
+        assert svc.fetch_all_flagged_userids() == set(['acct:renata@example.com',
+                                                       'acct:cecilia@example.com'])
 
     def test_is_flagged_returns_true_for_flagged_users(self, db_session, users):
         svc = NipsaService(db_session)

--- a/tests/h/views/admin_nipsa_test.py
+++ b/tests/h/views/admin_nipsa_test.py
@@ -90,8 +90,7 @@ class FakeNipsaService(object):
     def __init__(self, users):
         self.flagged = set([u for u in users if u.nipsa])
 
-    @property
-    def flagged_userids(self):
+    def fetch_all_flagged_userids(self):
         return set([u.userid for u in self.flagged])
 
     def flag(self, user):


### PR DESCRIPTION
Change `flagged_userids` from a property to a method and add a
`fetch_all_` prefix to make it more explicit that this code does a
potentially expensive database query, depending on the number of users
in the system. This is also more consistent with the API of eg. `UserService`.

The property => method change will also make it a little easier to mock
in an upcoming PR.