### PR TITLE
Speed up reindexing by re-adding NIPSA flag cache

### DIFF
--- a/h/indexer/reindexer.py
+++ b/h/indexer/reindexer.py
@@ -25,9 +25,9 @@ def reindex(session, es, request):
 
     settings = request.find_service(name='settings')
 
-    # Preload flagged userids.
+    # Preload userids of shadowbanned users.
     nipsa_svc = request.find_service(name='nipsa')
-    nipsa_svc.flagged_userids
+    nipsa_svc.fetch_all_flagged_userids()
 
     new_index = configure_index(es)
     log.info('configured new index {}'.format(new_index))

--- a/h/indexer/reindexer.py
+++ b/h/indexer/reindexer.py
@@ -25,6 +25,10 @@ def reindex(session, es, request):
 
     settings = request.find_service(name='settings')
 
+    # Preload flagged userids.
+    nipsa_svc = request.find_service(name='nipsa')
+    nipsa_svc.flagged_userids
+
     new_index = configure_index(es)
     log.info('configured new index {}'.format(new_index))
 

--- a/tests/h/services/nipsa_test.py
+++ b/tests/h/services/nipsa_test.py
@@ -78,6 +78,7 @@ class TestNipsaService(object):
 
         svc.fetch_all_flagged_userids()
         svc.flag(users['dominic'])
+        users['dominic'].nipsa = False  # Make sure result below comes from cache.
 
         assert svc.is_flagged(users['dominic'].userid)
 
@@ -86,6 +87,7 @@ class TestNipsaService(object):
 
         svc.fetch_all_flagged_userids()
         svc.unflag(users['renata'])
+        users['renata'].nipsa = True  # Make sure result below comes from cache.
 
         assert not svc.is_flagged(users['renata'].userid)
 


### PR DESCRIPTION
**Depends on https://github.com/hypothesis/h/pull/5153**

This PR should resolve a reindexing performance regression (~500 anns/sec => ~200 anns/sec in production) caused by the removal of the NIPSA cache in https://github.com/hypothesis/h/pull/5129.

The removal of the cache speeded up WebSocket message processing and indexing single annotations by removing an expensive scan of the `User` table and replacing it with an indexed lookup of a single user. However it regressed reindexing of all annotations because the one-at-a-time lookup of users by userid was less efficient than the previous bulk-loading of flagged userids into a set, in that context.

To optimize for both uses I reintroduced the cache, but it is only populated when `fetch_all_flagged_userids` is called explicitly, which the `hypothesis search reindex` CLI command now does.

On my laptop this improves reindexing speed with a small database of ~2.5K annotations from ~300/sec to ~2000/sec. In production I'm only hoping to get reindexing performance back to where it was previously.

Hopefully fixes https://github.com/hypothesis/h/issues/5151 