### PR TITLE
Initialize the Elasticsearch 6 cluster in the `init` CLI command

### DIFF
--- a/h/cli/commands/init.py
+++ b/h/cli/commands/init.py
@@ -19,6 +19,7 @@ def init(ctx):
 
     _init_db(request.registry.settings)
     _init_search(request.registry.settings)
+    _init_search_es6(request.registry.settings)
 
 
 def _init_db(settings):
@@ -39,4 +40,11 @@ def _init_search(settings):
     client = search.get_client(settings)
 
     log.info("initializing search index")
+    search.init(client)
+
+
+def _init_search_es6(settings):
+    client = search.get_es6_client(settings)
+
+    log.info("initializing ES6 search index")
     search.init(client)

--- a/tests/h/cli/commands/init_test.py
+++ b/tests/h/cli/commands/init_test.py
@@ -50,11 +50,13 @@ class TestInitCommand(object):
                                 search,
                                 pyramid_settings):
         client = search.get_client.return_value
+        es6_client = search.get_es6_client.return_value
 
         result = cli.invoke(init_cli.init, obj=cliconfig)
 
         search.get_client.assert_called_once_with(pyramid_settings)
-        search.init.assert_called_once_with(client)
+        search.init.assert_any_call(client)
+        search.init.assert_any_call(es6_client)
         assert result.exit_code == 0
 
 


### PR DESCRIPTION
Initialize the ES 6 cluster with the ES 6 mappings when the `init` CLI
command is invoked.