### PR TITLE
Index annotations into Elasticsearch 6 when feature flag enabled

### DIFF
--- a/h/indexer/reindexer.py
+++ b/h/indexer/reindexer.py
@@ -25,9 +25,12 @@ def reindex(session, es, request):
 
     new_index = configure_index(es)
     log.info('configured new index {}'.format(new_index))
+    setting_name = 'reindex.new_es6_index'
+    if es.version < (2,):
+        setting_name = 'reindex.new_index'
 
     try:
-        settings.put('reindex.new_index', new_index)
+        settings.put(setting_name, new_index)
         request.tm.commit()
 
         log.info('reindexing annotations into new index {}'.format(new_index))
@@ -50,5 +53,5 @@ def reindex(session, es, request):
         delete_index(es, current_index)
 
     finally:
-        settings.delete('reindex.new_index')
+        settings.delete(setting_name)
         request.tm.commit()

--- a/h/indexer/reindexer.py
+++ b/h/indexer/reindexer.py
@@ -13,8 +13,6 @@ from h.search.index import BatchIndexer
 
 log = logging.getLogger(__name__)
 
-SETTING_NEW_INDEX = 'reindex.new_index'
-
 
 def reindex(session, es, request):
     """Reindex all annotations into a new index, and update the alias."""
@@ -29,7 +27,7 @@ def reindex(session, es, request):
     log.info('configured new index {}'.format(new_index))
 
     try:
-        settings.put(SETTING_NEW_INDEX, new_index)
+        settings.put('reindex.new_index', new_index)
         request.tm.commit()
 
         log.info('reindexing annotations into new index {}'.format(new_index))
@@ -52,5 +50,5 @@ def reindex(session, es, request):
         delete_index(es, current_index)
 
     finally:
-        settings.delete(SETTING_NEW_INDEX)
+        settings.delete('reindex.new_index')
         request.tm.commit()

--- a/h/tasks/indexer.py
+++ b/h/tasks/indexer.py
@@ -3,7 +3,6 @@
 from __future__ import unicode_literals
 from h import models, storage
 from h.celery import celery, get_task_logger
-from h.indexer.reindexer import SETTING_NEW_INDEX
 from h.search.index import BatchIndexer, delete, index
 
 log = get_task_logger(__name__)
@@ -49,6 +48,6 @@ def reindex_user_annotations(userid):
 
 def _current_reindex_new_name(request):
     settings = celery.request.find_service(name='settings')
-    new_index = settings.get(SETTING_NEW_INDEX)
+    new_index = settings.get('reindex.new_index')
 
     return new_index

--- a/h/tasks/indexer.py
+++ b/h/tasks/indexer.py
@@ -14,12 +14,20 @@ def add_annotation(id_):
     if annotation:
         index(celery.request.es, annotation, celery.request)
 
+        if celery.request.feature('index_es6'):
+            index(celery.request.es6, annotation, celery.request)
+
         # If a reindex is running at the moment, add annotation to the new index
         # as well.
-        future_index = _current_reindex_new_name(celery.request)
+        future_index = _current_reindex_new_name(celery.request, 'reindex.new_index')
         if future_index is not None:
             index(celery.request.es, annotation, celery.request,
                   target_index=future_index)
+
+        future_es6_index = _current_reindex_new_name(celery.request, 'reindex.new_es6_index')
+        if future_es6_index is not None:
+            index(celery.request.es6, annotation, celery.request,
+                  target_index=future_es6_index)
 
         if annotation.is_reply:
             add_annotation.delay(annotation.thread_root_id)
@@ -29,11 +37,18 @@ def add_annotation(id_):
 def delete_annotation(id_):
     delete(celery.request.es, id_)
 
+    if celery.request.feature('index_es6'):
+        delete(celery.request.es6, id_)
+
     # If a reindex is running at the moment, delete annotation from the
     # new index as well.
-    future_index = _current_reindex_new_name(celery.request)
+    future_index = _current_reindex_new_name(celery.request, 'reindex.new_index')
     if future_index is not None:
         delete(celery.request.es, id_, target_index=future_index)
+
+    future_es6_index = _current_reindex_new_name(celery.request, 'reindex.new_es6_index')
+    if future_es6_index is not None:
+        delete(celery.request.es6, id_, target_index=future_es6_index)
 
 
 @celery.task
@@ -45,9 +60,15 @@ def reindex_user_annotations(userid):
     if errored:
         log.warning('Failed to re-index annotations %s', errored)
 
+    if celery.request.feature('index_es6'):
+        indexer = BatchIndexer(celery.request.db, celery.request.es6, celery.request)
+        errored = indexer.index(ids)
+        if errored:
+            log.warning('Failed to re-index annotations into ES6 %s', errored)
 
-def _current_reindex_new_name(request):
+
+def _current_reindex_new_name(request, new_index_setting_name):
     settings = celery.request.find_service(name='settings')
-    new_index = settings.get('reindex.new_index')
+    new_index = settings.get(new_index_setting_name)
 
     return new_index

--- a/tests/h/indexer/reindexer_test.py
+++ b/tests/h/indexer/reindexer_test.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 import mock
 import pytest
 
-from h.indexer.reindexer import reindex, SETTING_NEW_INDEX
+from h.indexer.reindexer import reindex
 from h.search import client
 
 
@@ -83,12 +83,12 @@ class TestReindex(object):
 
         reindex(mock.sentinel.session, es, pyramid_request)
 
-        settings_service.put.assert_called_once_with(SETTING_NEW_INDEX, 'hypothesis-abcd1234')
+        settings_service.put.assert_called_once_with('reindex.new_index', 'hypothesis-abcd1234')
 
     def test_deletes_index_name_setting(self, pyramid_request, es, settings_service):
         reindex(mock.sentinel.session, es, pyramid_request)
 
-        settings_service.delete.assert_called_once_with(SETTING_NEW_INDEX)
+        settings_service.delete.assert_called_once_with('reindex.new_index')
 
     def test_deletes_index_name_setting_when_exception_raised(self, pyramid_request, es, settings_service, batchindexer):
         batchindexer.index.side_effect = RuntimeError('boom!')
@@ -96,7 +96,7 @@ class TestReindex(object):
         with pytest.raises(RuntimeError):
             reindex(mock.sentinel.session, es, pyramid_request)
 
-        settings_service.delete.assert_called_once_with(SETTING_NEW_INDEX)
+        settings_service.delete.assert_called_once_with('reindex.new_index')
 
     def test_deletes_old_index(self, pyramid_request, es, delete_index, get_aliased_index):
         get_aliased_index.return_value = 'original_index'

--- a/tests/h/indexer/reindexer_test.py
+++ b/tests/h/indexer/reindexer_test.py
@@ -78,17 +78,30 @@ class TestReindex(object):
         with pytest.raises(RuntimeError):
             reindex(mock.sentinel.session, es, mock.sentinel.request)
 
-    def test_stores_new_index_name_in_settings(self, pyramid_request, es, settings_service, configure_index):
+    @pytest.mark.parametrize(
+        'esversion,new_index_setting_name',
+        (((1, 5, 0), 'reindex.new_index'),
+        ((6, 2, 0), 'reindex.new_es6_index'))
+    )
+    def test_stores_new_index_name_in_settings(self, pyramid_request, es, settings_service,
+                                               configure_index, esversion, new_index_setting_name):
+        es.version = esversion
         configure_index.return_value = 'hypothesis-abcd1234'
 
         reindex(mock.sentinel.session, es, pyramid_request)
 
-        settings_service.put.assert_called_once_with('reindex.new_index', 'hypothesis-abcd1234')
+        settings_service.put.assert_called_once_with(new_index_setting_name, 'hypothesis-abcd1234')
 
-    def test_deletes_index_name_setting(self, pyramid_request, es, settings_service):
+    @pytest.mark.parametrize(
+        'esversion,new_index_setting_name',
+        (((1, 5, 0), 'reindex.new_index'),
+        ((6, 2, 0), 'reindex.new_es6_index'))
+    )
+    def test_deletes_index_name_setting(self, pyramid_request, es, settings_service, esversion, new_index_setting_name):
+        es.version = esversion
         reindex(mock.sentinel.session, es, pyramid_request)
 
-        settings_service.delete.assert_called_once_with('reindex.new_index')
+        settings_service.delete.assert_called_once_with(new_index_setting_name)
 
     def test_deletes_index_name_setting_when_exception_raised(self, pyramid_request, es, settings_service, batchindexer):
         batchindexer.index.side_effect = RuntimeError('boom!')
@@ -136,7 +149,8 @@ class TestReindex(object):
     @pytest.fixture
     def es(self):
         mock_es = mock.create_autospec(client.Client, instance=True,
-                                       spec_set=True, index="hypothesis")
+                                       spec_set=True, index="hypothesis",
+                                       version=(1, 5, 0))
         mock_es.mapping_type = 'annotation'
         return mock_es
 

--- a/tests/h/tasks/indexer_test.py
+++ b/tests/h/tasks/indexer_test.py
@@ -5,7 +5,6 @@ from __future__ import unicode_literals
 import mock
 import pytest
 
-from h.indexer.reindexer import SETTING_NEW_INDEX
 from h.tasks import indexer
 
 
@@ -47,7 +46,7 @@ class TestAddAnnotation(object):
         assert index.called is False
 
     def test_during_reindex_adds_to_current_index(self, fetch_annotation, annotation, index, celery, settings_service):
-        settings_service.put(SETTING_NEW_INDEX, 'hypothesis-abcdef123')
+        settings_service.put('reindex.new_index', 'hypothesis-abcdef123')
         fetch_annotation.return_value = annotation
 
         indexer.add_annotation('test-annotation-id')
@@ -57,7 +56,7 @@ class TestAddAnnotation(object):
                               celery.request)
 
     def test_during_reindex_adds_to_new_index(self, fetch_annotation, annotation, index, celery, settings_service):
-        settings_service.put(SETTING_NEW_INDEX, 'hypothesis-abcdef123')
+        settings_service.put('reindex.new_index', 'hypothesis-abcdef123')
         fetch_annotation.return_value = annotation
 
         indexer.add_annotation('test-annotation-id')
@@ -107,7 +106,7 @@ class TestDeleteAnnotation(object):
         delete.assert_called_once_with(celery.request.es, id_)
 
     def test_during_reindex_deletes_from_current_index(self, delete, celery, settings_service):
-        settings_service.put(SETTING_NEW_INDEX, 'hypothesis-abcdef123')
+        settings_service.put('reindex.new_index', 'hypothesis-abcdef123')
 
         indexer.delete_annotation('test-annotation-id')
 
@@ -115,7 +114,7 @@ class TestDeleteAnnotation(object):
                                'test-annotation-id')
 
     def test_during_reindex_deletes_from_new_index(self, delete, celery, settings_service):
-        settings_service.put(SETTING_NEW_INDEX, 'hypothesis-abcdef123')
+        settings_service.put('reindex.new_index', 'hypothesis-abcdef123')
 
         indexer.delete_annotation('test-annotation-id')
 

--- a/tests/h/tasks/indexer_test.py
+++ b/tests/h/tasks/indexer_test.py
@@ -36,7 +36,8 @@ class TestAddAnnotation(object):
 
         indexer.add_annotation(id_)
 
-        index.assert_called_once_with(celery.request.es, annotation, celery.request)
+        index.assert_any_call(celery.request.es, annotation, celery.request)
+        index.assert_any_call(celery.request.es6, annotation, celery.request)
 
     def test_it_skips_indexing_when_annotation_cannot_be_loaded(self, fetch_annotation, index, celery):
         fetch_annotation.return_value = None
@@ -47,16 +48,7 @@ class TestAddAnnotation(object):
 
     def test_during_reindex_adds_to_current_index(self, fetch_annotation, annotation, index, celery, settings_service):
         settings_service.put('reindex.new_index', 'hypothesis-abcdef123')
-        fetch_annotation.return_value = annotation
-
-        indexer.add_annotation('test-annotation-id')
-
-        index.assert_any_call(celery.request.es,
-                              annotation,
-                              celery.request)
-
-    def test_during_reindex_adds_to_new_index(self, fetch_annotation, annotation, index, celery, settings_service):
-        settings_service.put('reindex.new_index', 'hypothesis-abcdef123')
+        settings_service.put('reindex.new_es6_index', 'hypothesis-xyz123')
         fetch_annotation.return_value = annotation
 
         indexer.add_annotation('test-annotation-id')
@@ -65,6 +57,26 @@ class TestAddAnnotation(object):
                               annotation,
                               celery.request,
                               target_index='hypothesis-abcdef123')
+        index.assert_any_call(celery.request.es6,
+                              annotation,
+                              celery.request,
+                              target_index='hypothesis-xyz123')
+
+    def test_during_reindex_adds_to_new_index(self, fetch_annotation, annotation, index, celery, settings_service):
+        settings_service.put('reindex.new_index', 'hypothesis-abcdef123')
+        settings_service.put('reindex.new_es6_index', 'hypothesis-xyz123')
+        fetch_annotation.return_value = annotation
+
+        indexer.add_annotation('test-annotation-id')
+
+        index.assert_any_call(celery.request.es,
+                              annotation,
+                              celery.request,
+                              target_index='hypothesis-abcdef123')
+        index.assert_any_call(celery.request.es6,
+                              annotation,
+                              celery.request,
+                              target_index='hypothesis-xyz123')
 
     def test_it_indexes_thread_root(self, fetch_annotation, reply, delay):
         fetch_annotation.return_value = reply
@@ -103,24 +115,33 @@ class TestDeleteAnnotation(object):
         id_ = 'test-annotation-id'
         indexer.delete_annotation(id_)
 
-        delete.assert_called_once_with(celery.request.es, id_)
+        delete.assert_any_call(celery.request.es, id_)
+        delete.assert_any_call(celery.request.es6, id_)
 
     def test_during_reindex_deletes_from_current_index(self, delete, celery, settings_service):
         settings_service.put('reindex.new_index', 'hypothesis-abcdef123')
-
-        indexer.delete_annotation('test-annotation-id')
-
-        delete.assert_any_call(celery.request.es,
-                               'test-annotation-id')
-
-    def test_during_reindex_deletes_from_new_index(self, delete, celery, settings_service):
-        settings_service.put('reindex.new_index', 'hypothesis-abcdef123')
+        settings_service.put('reindex.new_es6_index', 'hypothesis-xyz123')
 
         indexer.delete_annotation('test-annotation-id')
 
         delete.assert_any_call(celery.request.es,
                                'test-annotation-id',
                                target_index='hypothesis-abcdef123')
+        delete.assert_any_call(celery.request.es6, 'test-annotation-id',
+                               target_index='hypothesis-xyz123')
+
+    def test_during_reindex_deletes_from_new_index(self, delete, celery, settings_service):
+        settings_service.put('reindex.new_index', 'hypothesis-abcdef123')
+        settings_service.put('reindex.new_es6_index', 'hypothesis-xyz123')
+
+        indexer.delete_annotation('test-annotation-id')
+
+        delete.assert_any_call(celery.request.es,
+                               'test-annotation-id',
+                               target_index='hypothesis-abcdef123')
+        delete.assert_any_call(celery.request.es6,
+                               'test-annotation-id',
+                               target_index='hypothesis-xyz123')
 
     @pytest.fixture
     def delete(self, patch):
@@ -129,6 +150,14 @@ class TestDeleteAnnotation(object):
 
 @pytest.mark.usefixtures('celery')
 class TestReindexUserAnnotations(object):
+    def test_it_creates_batch_indexer(self, batch_indexer, annotation_ids, celery):
+        userid = list(annotation_ids.keys())[0]
+
+        indexer.reindex_user_annotations(userid)
+
+        batch_indexer.assert_any_call(celery.request.db, celery.request.es, celery.request)
+        batch_indexer.assert_any_call(celery.request.db, celery.request.es6, celery.request)
+
     def test_it_reindexes_users_annotations(self, batch_indexer, annotation_ids):
         userid = list(annotation_ids.keys())[0]
 
@@ -164,6 +193,7 @@ def celery(patch, pyramid_request):
 @pytest.fixture
 def pyramid_request(pyramid_request):
     pyramid_request.es = mock.Mock()
+    pyramid_request.es6 = mock.Mock()
     return pyramid_request
 
 


### PR DESCRIPTION
When the `index_es6` feature flag is enabled, index annotations into
both Elasticsearch 1 and Elasticsearch 6.

During reindexing, annotations need to be indexed into the new index.
Since it is possible we may be rebuilding only one of the indexes (ES1
or ES6), a separate setting has been added in the DB to record the name
of the new ES6 index.