### PR TITLE
Add Identities, 409 errors to `POST users/` endpoint

### DIFF
--- a/docs/_extra/api-reference/hypothesis.yaml
+++ b/docs/_extra/api-reference/hypothesis.yaml
@@ -363,6 +363,9 @@ paths:
         designated authority to create users within their authority. Optional
         identity information may be provided to maintain provider-specific
         metadata about users.
+
+        This endpoint will return an HTTP 409 (Conflict) if the request represents
+        a duplicate of an existing user—email, username or identity collision.
       operationId: createUser
       parameters:
         - name: user
@@ -380,6 +383,10 @@ paths:
           description: Could not create user from your request
           schema:
             $ref: '#/definitions/Error'
+        '409':
+          description: Conflict
+          schema:
+            $ref: '#/definitions/ConflictError'
       security:
         - authClientCredentials: []
   /users/{username}:
@@ -459,6 +466,19 @@ definitions:
       reason:
         type: string
         description: A human-readable description of the reason(s) for failure.
+  ConflictError:
+    description: An error indicating a resource conflict, typically because a duplicate resource already exists.
+    type: object
+    required:
+      - status
+    properties:
+      status:
+        type: string
+        enum:
+          - failure
+      reason:
+        type: string
+        description: One or more human-readable errors describing the conflict.
   SearchResults:
     type: object
     required:

--- a/docs/_extra/api-reference/hypothesis.yaml
+++ b/docs/_extra/api-reference/hypothesis.yaml
@@ -360,7 +360,9 @@ paths:
       summary: Create a new user
       description: |
         Only for specific auth clients, this API call allows clients with a
-        designated authority to create users within their authority.
+        designated authority to create users within their authority. Optional
+        identity information may be provided to maintain provider-specific
+        metadata about users.
       operationId: createUser
       parameters:
         - name: user

--- a/docs/_extra/api-reference/schemas/new-user-schema.json
+++ b/docs/_extra/api-reference/schemas/new-user-schema.json
@@ -19,7 +19,25 @@
     "display_name": {
       "type": "string",
       "maxLength": 30
-    }
+    },
+    "identities": {
+      "type": "array",
+      "items": {
+          "type": "object",
+          "properties": {
+              "provider": {
+                  "type": "string",
+              },
+              "provider_unique_id": {
+                  "type": "string",
+              },
+          },
+          "required": [
+              "provider",
+              "provider_unique_id",
+          ]
+      },
+  },
   },
   "required": [
     "authority",

--- a/h/schemas/api/user.py
+++ b/h/schemas/api/user.py
@@ -36,6 +36,24 @@ class CreateUserAPISchema(JSONSchema):
                 'type': 'string',
                 'maxLength': DISPLAY_NAME_MAX_LENGTH,
             },
+            'identities': {
+                'type': 'array',
+                'items': {
+                    'type': 'object',
+                    'properties': {
+                        'provider': {
+                            'type': 'string',
+                        },
+                        'provider_unique_id': {
+                            'type': 'string',
+                        },
+                    },
+                    'required': [
+                        'provider',
+                        'provider_unique_id',
+                    ]
+                }
+            },
         },
         'required': [
             'authority',

--- a/tests/h/schemas/api/user_test.py
+++ b/tests/h/schemas/api/user_test.py
@@ -102,6 +102,49 @@ class TestCreateUserAPISchema(object):
         with pytest.raises(ValidationError):
             schema.validate(payload)
 
+    def test_it_allows_valid_identities(self, schema, payload):
+        payload['identities'] = [{'provider': 'foo', 'provider_unique_id': 'bar'}]
+
+        appstruct = schema.validate(payload)
+
+        assert 'identities' in appstruct
+
+    def test_it_raises_when_identities_not_an_array(self, schema, payload):
+        payload['identities'] = 'dragnabit'
+
+        with pytest.raises(ValidationError, match=".*identities.*is not of type.*"):
+            schema.validate(payload)
+
+    def test_it_raises_when_identities_items_not_objects(self, schema, payload):
+        payload['identities'] = ['flerp', 'flop']
+
+        with pytest.raises(ValidationError, match=".*identities.*is not of type.*"):
+            schema.validate(payload)
+
+    def test_it_raises_when_provider_missing_in_identity(self, schema, payload):
+        payload['identities'] = [{'foo': 'bar', 'provider_unique_id': 'flop'}]
+
+        with pytest.raises(ValidationError, match=".*provider'.*is a required property.*"):
+            schema.validate(payload)
+
+    def test_it_raises_when_provider_unique_id_missing_in_identity(self, schema, payload):
+        payload['identities'] = [{'foo': 'bar', 'provider': 'flop'}]
+
+        with pytest.raises(ValidationError, match=".*provider_unique_id'.*is a required property.*"):
+            schema.validate(payload)
+
+    def test_it_raises_if_identity_provider_is_not_a_string(self, schema, payload):
+        payload['identities'] = [{'provider_unique_id': 'bar', 'provider': 75}]
+
+        with pytest.raises(ValidationError, match=".*provider:.*is not of type.*string.*"):
+            schema.validate(payload)
+
+    def test_it_raises_if_identity_provider_unique_id_is_not_a_string(self, schema, payload):
+        payload['identities'] = [{'provider_unique_id': [], 'provider': 'hithere'}]
+
+        with pytest.raises(ValidationError, match=".*provider_unique_id:.*is not of type.*string.*"):
+            schema.validate(payload)
+
     @pytest.fixture
     def payload(self):
         return {

--- a/tests/h/views/api/users_test.py
+++ b/tests/h/views/api/users_test.py
@@ -3,14 +3,15 @@
 from __future__ import unicode_literals
 
 import pytest
-from mock import Mock, PropertyMock
+import mock
 
 from pyramid.exceptions import HTTPNotFound
 
-from h.exceptions import ClientUnauthorized, PayloadError
+from h.exceptions import ClientUnauthorized, PayloadError, ConflictError
 from h.models.auth_client import GrantType
 from h.schemas import ValidationError
 from h.services.user_signup import UserSignupService
+from h.services.user_unique import UserUniqueService, DuplicateUserError
 from h.views.api.users import create, update
 
 
@@ -101,7 +102,8 @@ class TestCreateAndUpdateAuth(object):
 
 @pytest.mark.usefixtures('auth_client',
                          'basic_auth_creds',
-                         'user_signup_service')
+                         'user_signup_service',
+                         'user_unique_svc')
 class TestCreate(object):
     @pytest.mark.usefixtures('valid_auth')
     def test_signs_up_user(self,
@@ -110,7 +112,6 @@ class TestCreate(object):
                            user_signup_service,
                            valid_payload):
         pyramid_request.json_body = valid_payload
-        user_signup_service.signup.return_value = factories.User.build(**valid_payload)
 
         create(pyramid_request)
 
@@ -119,7 +120,8 @@ class TestCreate(object):
             authority='weylandindustries.com',
             username='jeremy',
             email='jeremy@weylandtech.com',
-            display_name='Jeremy Weyland')
+            display_name='Jeremy Weyland',
+            identities=[{'provider': 'provider_a', 'provider_unique_id': 'abc123'}])
 
     @pytest.mark.usefixtures('valid_auth')
     def test_it_presents_user(self, pyramid_request, valid_payload, user, presenter):
@@ -167,67 +169,27 @@ class TestCreate(object):
         assert "'authority' does not match authenticated client" in str(exc.value)
 
     @pytest.mark.usefixtures('valid_auth')
-    def test_raises_when_username_taken(self,
-                                        pyramid_request,
-                                        valid_payload,
-                                        db_session,
-                                        factories,
-                                        auth_client):
-        existing_user = factories.User(authority=auth_client.authority)
-        db_session.flush()
+    def test_it_proxies_uniqueness_check_to_service(self, valid_payload, pyramid_request, user_unique_svc, CreateUserAPISchema):
+        pyramid_request.json_body = valid_payload
+        CreateUserAPISchema().validate.return_value = valid_payload
 
-        payload = valid_payload
-        payload['username'] = existing_user.username
-        pyramid_request.json_body = payload
+        create(pyramid_request)
 
-        with pytest.raises(ValidationError) as exc:
-            create(pyramid_request)
-
-        assert ('username %s already exists' % existing_user.username) in str(exc.value)
+        user_unique_svc.ensure_unique.assert_called_with(valid_payload)
 
     @pytest.mark.usefixtures('valid_auth')
-    def test_raises_when_email_taken(self,
-                                     pyramid_request,
-                                     valid_payload,
-                                     db_session,
-                                     factories,
-                                     auth_client):
-        existing_user = factories.User(authority=auth_client.authority)
-        db_session.flush()
+    def test_raises_conflict_error_from_duplicate_user_error(self, valid_payload, pyramid_request, user_unique_svc):
+        pyramid_request.json_body = valid_payload
+        user_unique_svc.ensure_unique.side_effect = DuplicateUserError('nope')
 
-        payload = valid_payload
-        payload['email'] = existing_user.email
-        pyramid_request.json_body = payload
-
-        with pytest.raises(ValidationError) as exc:
+        with pytest.raises(ConflictError) as exc:
             create(pyramid_request)
 
-        assert ('email address %s already exists' % existing_user.email) in str(exc.value)
-
-    @pytest.mark.usefixtures('valid_auth')
-    def test_combines_unique_username_email_errors(self,
-                                                   pyramid_request,
-                                                   valid_payload,
-                                                   db_session,
-                                                   factories,
-                                                   auth_client):
-        existing_user = factories.User(authority=auth_client.authority)
-        db_session.flush()
-
-        payload = valid_payload
-        payload['email'] = existing_user.email
-        payload['username'] = existing_user.username
-        pyramid_request.json_body = payload
-
-        with pytest.raises(ValidationError) as exc:
-            create(pyramid_request)
-
-        assert ('email address %s already exists' % existing_user.email) in str(exc.value)
-        assert ('username %s already exists' % existing_user.username) in str(exc.value)
+        assert 'nope' in str(exc.value)
 
     @pytest.mark.usefixtures('valid_auth')
     def test_raises_for_invalid_json_body(self, pyramid_request, patch):
-        type(pyramid_request).json_body = PropertyMock(side_effect=ValueError())
+        type(pyramid_request).json_body = mock.PropertyMock(side_effect=ValueError())
 
         with pytest.raises(PayloadError):
             create(pyramid_request)
@@ -239,6 +201,10 @@ class TestCreate(object):
             'email': 'jeremy@weylandtech.com',
             'username': 'jeremy',
             'display_name': 'Jeremy Weyland',
+            'identities': [{
+                'provider': 'provider_a',
+                'provider_unique_id': 'abc123'
+            }],
         }
 
 
@@ -333,7 +299,7 @@ class TestUpdate(object):
 
     @pytest.mark.usefixtures('valid_auth')
     def test_raises_for_invalid_json_body(self, pyramid_request, patch):
-        type(pyramid_request).json_body = PropertyMock(side_effect=ValueError())
+        type(pyramid_request).json_body = mock.PropertyMock(side_effect=ValueError())
 
         with pytest.raises(PayloadError):
             update(pyramid_request)
@@ -352,7 +318,7 @@ class TestUpdate(object):
 
     @pytest.fixture
     def user_svc(self, pyramid_config, user):
-        svc = Mock(spec_set=['fetch'])
+        svc = mock.Mock(spec_set=['fetch'])
 
         def fake_fetch(username, authority):
             if (username == user.username and
@@ -384,7 +350,7 @@ def valid_auth(basic_auth_creds, auth_client):
 
 @pytest.fixture
 def user_signup_service(db_session, pyramid_config, user):
-    service = Mock(spec_set=UserSignupService(default_authority='example.com',
+    service = mock.Mock(spec_set=UserSignupService(default_authority='example.com',
                                               mailer=None,
                                               session=None,
                                               password_service=None,
@@ -393,6 +359,13 @@ def user_signup_service(db_session, pyramid_config, user):
     service.signup.return_value = user
     pyramid_config.register_service(service, name='user_signup')
     return service
+
+
+@pytest.fixture
+def user_unique_svc(pyramid_config):
+    svc = mock.create_autospec(UserUniqueService, spec_set=True, instance=True)
+    pyramid_config.register_service(svc, name='user_unique')
+    return svc
 
 
 @pytest.fixture


### PR DESCRIPTION
This PR is a combination of the commits in:

* https://github.com/hypothesis/h/pull/5142
* https://github.com/hypothesis/h/pull/5141
* https://github.com/hypothesis/h/pull/5155

All three of those PRs have been approved. I wanted to package this into one PR for better deployment of the related features.

This PR updates the create-user API schema to allow `identities`. It also replaces duplicate-checking logic with a separate service, and it now returns HTTP `409` instead of HTTP `400` if there is a dupe-check fail. The API docs have been updated as well to reflect these changes.

I have tested this with a local install of `publisher-test-site` to be more extra sure that this change won't disrupt `auth_client` requests to the `POST users/` endpoint.

(a large) part of https://github.com/hypothesis/product-backlog/issues/700