### PR TITLE
Revert "Add Identities, 409 errors to `POST users/` endpoint (#5162)"

### DIFF
--- a/docs/_extra/api-reference/hypothesis.yaml
+++ b/docs/_extra/api-reference/hypothesis.yaml
@@ -360,12 +360,7 @@ paths:
       summary: Create a new user
       description: |
         Only for specific auth clients, this API call allows clients with a
-        designated authority to create users within their authority. Optional
-        identity information may be provided to maintain provider-specific
-        metadata about users.
-
-        This endpoint will return an HTTP 409 (Conflict) if the request represents
-        a duplicate of an existing user—email, username or identity collision.
+        designated authority to create users within their authority.
       operationId: createUser
       parameters:
         - name: user
@@ -383,10 +378,6 @@ paths:
           description: Could not create user from your request
           schema:
             $ref: '#/definitions/Error'
-        '409':
-          description: Conflict
-          schema:
-            $ref: '#/definitions/ConflictError'
       security:
         - authClientCredentials: []
   /users/{username}:
@@ -466,19 +457,6 @@ definitions:
       reason:
         type: string
         description: A human-readable description of the reason(s) for failure.
-  ConflictError:
-    description: An error indicating a resource conflict, typically because a duplicate resource already exists.
-    type: object
-    required:
-      - status
-    properties:
-      status:
-        type: string
-        enum:
-          - failure
-      reason:
-        type: string
-        description: One or more human-readable errors describing the conflict.
   SearchResults:
     type: object
     required:

--- a/docs/_extra/api-reference/schemas/new-user-schema.json
+++ b/docs/_extra/api-reference/schemas/new-user-schema.json
@@ -19,25 +19,7 @@
     "display_name": {
       "type": "string",
       "maxLength": 30
-    },
-    "identities": {
-      "type": "array",
-      "items": {
-          "type": "object",
-          "properties": {
-              "provider": {
-                  "type": "string",
-              },
-              "provider_unique_id": {
-                  "type": "string",
-              },
-          },
-          "required": [
-              "provider",
-              "provider_unique_id",
-          ]
-      },
-  },
+    }
   },
   "required": [
     "authority",

--- a/h/schemas/api/user.py
+++ b/h/schemas/api/user.py
@@ -36,24 +36,6 @@ class CreateUserAPISchema(JSONSchema):
                 'type': 'string',
                 'maxLength': DISPLAY_NAME_MAX_LENGTH,
             },
-            'identities': {
-                'type': 'array',
-                'items': {
-                    'type': 'object',
-                    'properties': {
-                        'provider': {
-                            'type': 'string',
-                        },
-                        'provider_unique_id': {
-                            'type': 'string',
-                        },
-                    },
-                    'required': [
-                        'provider',
-                        'provider_unique_id',
-                    ]
-                }
-            },
         },
         'required': [
             'authority',

--- a/h/views/api/users.py
+++ b/h/views/api/users.py
@@ -9,12 +9,11 @@ from pyramid.exceptions import HTTPNotFound
 
 from h import models
 from h.auth.util import basic_auth_creds
-from h.exceptions import ClientUnauthorized, PayloadError, ConflictError
+from h.exceptions import ClientUnauthorized, PayloadError
 from h.models.auth_client import GrantType
 from h.presenters import UserJSONPresenter
 from h.schemas import ValidationError
 from h.schemas.api.user import CreateUserAPISchema, UpdateUserAPISchema
-from h.services.user_unique import DuplicateUserError
 from h.util.view import json_view
 
 
@@ -36,12 +35,7 @@ def create(request):
     _check_authority(client, appstruct)
     appstruct['authority'] = client.authority
 
-    user_unique_service = request.find_service(name='user_unique')
-
-    try:
-        user_unique_service.ensure_unique(appstruct)
-    except DuplicateUserError as err:
-        raise ConflictError(err)
+    _check_existing_user(request.db, appstruct)
 
     user_signup_service = request.find_service(name='user_signup')
     user = user_signup_service.signup(require_activation=False, **appstruct)
@@ -79,6 +73,25 @@ def _check_authority(client, data):
     if client.authority != authority:
         msg = "'authority' does not match authenticated client"
         raise ValidationError(msg)
+
+
+def _check_existing_user(session, data):
+    errors = []
+
+    existing_user = models.User.get_by_email(session,
+                                             data['email'],
+                                             data['authority'])
+    if existing_user:
+        errors.append("user with email address %s already exists" % data['email'])
+
+    existing_user = models.User.get_by_username(session,
+                                                data['username'],
+                                                data['authority'])
+    if existing_user:
+        errors.append("user with username %s already exists" % data['username'])
+
+    if errors:
+        raise ValidationError(', '.join(errors))
 
 
 def _request_client(request):

--- a/tests/h/schemas/api/user_test.py
+++ b/tests/h/schemas/api/user_test.py
@@ -102,49 +102,6 @@ class TestCreateUserAPISchema(object):
         with pytest.raises(ValidationError):
             schema.validate(payload)
 
-    def test_it_allows_valid_identities(self, schema, payload):
-        payload['identities'] = [{'provider': 'foo', 'provider_unique_id': 'bar'}]
-
-        appstruct = schema.validate(payload)
-
-        assert 'identities' in appstruct
-
-    def test_it_raises_when_identities_not_an_array(self, schema, payload):
-        payload['identities'] = 'dragnabit'
-
-        with pytest.raises(ValidationError, match=".*identities.*is not of type.*"):
-            schema.validate(payload)
-
-    def test_it_raises_when_identities_items_not_objects(self, schema, payload):
-        payload['identities'] = ['flerp', 'flop']
-
-        with pytest.raises(ValidationError, match=".*identities.*is not of type.*"):
-            schema.validate(payload)
-
-    def test_it_raises_when_provider_missing_in_identity(self, schema, payload):
-        payload['identities'] = [{'foo': 'bar', 'provider_unique_id': 'flop'}]
-
-        with pytest.raises(ValidationError, match=".*provider'.*is a required property.*"):
-            schema.validate(payload)
-
-    def test_it_raises_when_provider_unique_id_missing_in_identity(self, schema, payload):
-        payload['identities'] = [{'foo': 'bar', 'provider': 'flop'}]
-
-        with pytest.raises(ValidationError, match=".*provider_unique_id'.*is a required property.*"):
-            schema.validate(payload)
-
-    def test_it_raises_if_identity_provider_is_not_a_string(self, schema, payload):
-        payload['identities'] = [{'provider_unique_id': 'bar', 'provider': 75}]
-
-        with pytest.raises(ValidationError, match=".*provider:.*is not of type.*string.*"):
-            schema.validate(payload)
-
-    def test_it_raises_if_identity_provider_unique_id_is_not_a_string(self, schema, payload):
-        payload['identities'] = [{'provider_unique_id': [], 'provider': 'hithere'}]
-
-        with pytest.raises(ValidationError, match=".*provider_unique_id:.*is not of type.*string.*"):
-            schema.validate(payload)
-
     @pytest.fixture
     def payload(self):
         return {


### PR DESCRIPTION
This PR reverts #5162 which is causing unexpected `500` responses on duplicate user creations.