### PR TITLE
Move auth_client logic to a common and more reusable place.

### DIFF
--- a/h/auth/util.py
+++ b/h/auth/util.py
@@ -3,10 +3,16 @@
 from __future__ import unicode_literals
 import base64
 
+import hmac
+
+import sqlalchemy as sa
 from pyramid import security
 
 from h.auth import role
 from h._compat import text_type
+from h.exceptions import ClientUnauthorized
+from h.models.auth_client import GrantType, AuthClient
+from h.schemas import ValidationError
 
 
 def basic_auth_creds(request):
@@ -109,3 +115,51 @@ def authority(request):
     Falls back on returning request.domain if h.authority isn't set.
     """
     return text_type(request.registry.settings.get('h.authority', request.domain))
+
+
+def request_auth_client(request):
+    """
+    Locate a matching AuthClient record in the database.
+
+    :param request: the request object
+    :type request: pyramid.request.Request
+
+    :returns: an auth client
+    :rtype: an AuthClient model
+
+    :raises ClientUnauthorized: if the client does not have a valid Client ID
+    and Client Secret or is not allowed to create users in their authority.
+    """
+    creds = basic_auth_creds(request)
+    if creds is None:
+        raise ClientUnauthorized()
+
+    # We fetch the client by its ID and then do a constant-time comparison of
+    # the secret with that provided in the request.
+    #
+    # It is important not to include the secret as part of the SQL query
+    # because the resulting code may be subject to a timing attack.
+    client_id, client_secret = creds
+    try:
+        client = request.db.query(AuthClient).get(client_id)
+    except sa.exc.StatementError:  # client_id is malformed
+        raise ClientUnauthorized()
+    if client is None:
+        raise ClientUnauthorized()
+    if client.secret is None:  # client is not confidential
+        raise ClientUnauthorized()
+    if client.grant_type != GrantType.client_credentials:  # client not allowed to create users
+        raise ClientUnauthorized()
+
+    if not hmac.compare_digest(client.secret, client_secret):
+        raise ClientUnauthorized()
+
+    return client
+
+
+def validate_auth_client_authority(client, data):
+    """
+    Validate that the auth client authority matches the request authority.
+    """
+    if client.authority != data.get('authority'):
+        raise ValidationError("'authority' does not match authenticated client")


### PR DESCRIPTION
Refactor auth_client logic out of h.views.api.users and into h.auth.util so that it is reusable from other places.
This is the first step towards implementing a new `POST /groups/{id}/members/{user_id}` API endpoint which will be an auth_client endpoint i.e only "blessed" auth clients should be able to use it, and operate on users and groups within their authority.
See https://github.com/hypothesis/product-backlog/issues/707