### PR TITLE
Update create-user API schema to require email OR valid identities

### DIFF
--- a/docs/_extra/api-reference/schemas/new-user-schema.json
+++ b/docs/_extra/api-reference/schemas/new-user-schema.json
@@ -22,6 +22,7 @@
     },
     "identities": {
       "type": "array",
+      "minItems": 1,
       "items": {
           "type": "object",
           "properties": {
@@ -39,9 +40,20 @@
       },
   },
   },
-  "required": [
-    "authority",
-    "username",
-    "email"
+  "anyOf": [
+    {
+      "required": [
+        "authority",
+        "username",
+        "email"
+      ]
+    },
+    {
+      "required": [
+        "authority",
+        "username",
+        "identities"
+      ]
+    },
   ]
 }

--- a/h/schemas/api/user.py
+++ b/h/schemas/api/user.py
@@ -38,6 +38,7 @@ class CreateUserAPISchema(JSONSchema):
             },
             'identities': {
                 'type': 'array',
+                'minItems': 1,
                 'items': {
                     'type': 'object',
                     'properties': {
@@ -55,12 +56,27 @@ class CreateUserAPISchema(JSONSchema):
                 }
             },
         },
-        'required': [
-            'authority',
-            'username',
-            'email',
-        ],
+        'anyOf': [  # email may be empty if identities are present
+            {
+                'required': [
+                    'authority',
+                    'username',
+                    'email',
+                ],
+            },
+            {
+                'required': [
+                    'authority',
+                    'username',
+                    'identities',
+                ],
+            }
+        ]
     }
+
+    def validate(self, data):
+        appstruct = super(CreateUserAPISchema, self).validate(data)
+        return appstruct
 
 
 class UpdateUserAPISchema(JSONSchema):

--- a/tests/h/schemas/api/user_test.py
+++ b/tests/h/schemas/api/user_test.py
@@ -56,13 +56,13 @@ class TestCreateUserAPISchema(object):
         with pytest.raises(ValidationError):
             schema.validate(payload)
 
-    def test_it_raises_when_email_missing(self, schema, payload):
+    def test_it_raises_when_email_and_identities_missing(self, schema, payload):
         del payload['email']
 
         with pytest.raises(ValidationError):
             schema.validate(payload)
 
-    def test_it_raises_when_email_empty(self, schema, payload):
+    def test_it_raises_when_email_empty_and_identities_missing(self, schema, payload):
         payload['email'] = ''
 
         with pytest.raises(ValidationError):
@@ -102,12 +102,25 @@ class TestCreateUserAPISchema(object):
         with pytest.raises(ValidationError):
             schema.validate(payload)
 
+    def test_it_allows_missing_email_if_identities_present(self, schema, payload):
+        payload['identities'] = [{'provider': 'foo', 'provider_unique_id': 'bar'}]
+        del payload['email']
+
+        schema.validate(payload)
+
     def test_it_allows_valid_identities(self, schema, payload):
         payload['identities'] = [{'provider': 'foo', 'provider_unique_id': 'bar'}]
 
         appstruct = schema.validate(payload)
 
         assert 'identities' in appstruct
+
+    def test_it_raises_when_email_missing_and_identities_empty(self, schema, payload):
+        del payload['email']
+        payload['identities'] = []
+
+        with pytest.raises(ValidationError, match=".*identities.*too short.*"):
+            schema.validate(payload)
 
     def test_it_raises_when_identities_not_an_array(self, schema, payload):
         payload['identities'] = 'dragnabit'


### PR DESCRIPTION
This PR updates the CreateUserAPISchema (and API documentation) to conditionally allow a missing email address if there are one or more valid identities present in the request body.

This will allow the creation of LMS users with identities but no email.

Fixes https://github.com/hypothesis/product-backlog/issues/700

I was pleased to find that this was possible entirely through JSONSchema, and no extra logic was required. Woot!