### PR TITLE
Add flag to parallelize search reindexing task

### DIFF
--- a/h/celery.py
+++ b/h/celery.py
@@ -28,7 +28,7 @@ __all__ = (
 
 log = logging.getLogger(__name__)
 
-celery = Celery('h')
+celery = Celery('h', backend='rpc://')
 celery.conf.update(
     broker_url=os.environ.get('CELERY_BROKER_URL',
                               os.environ.get('BROKER_URL', 'amqp://guest:guest@localhost:5672//')),
@@ -70,6 +70,7 @@ celery.conf.update(
     task_routes={
         'h.tasks.indexer.add_annotation': 'indexer',
         'h.tasks.indexer.delete_annotation': 'indexer',
+        'h.tasks.indexer.reindex_annotations': 'indexer',
         'h.tasks.indexer.reindex_user_annotations': 'indexer',
     },
     task_serializer='json',

--- a/h/cli/commands/search.py
+++ b/h/cli/commands/search.py
@@ -15,8 +15,10 @@ def search():
 
 @search.command()
 @click.option('--es6', is_flag=True, help='Reindex into the Elasticsearch 6 cluster')
+@click.option('--parallel/--no-parallel', default=False,
+              help='Use Celery tasks to reindex annotations in parallel.')
 @click.pass_context
-def reindex(ctx, es6):
+def reindex(ctx, es6, parallel):
     """
     Reindex all annotations.
 
@@ -39,7 +41,7 @@ def reindex(ctx, es6):
     es_server_version = es_client.conn.info()['version']['number']
     click.echo('reindexing into Elasticsearch {} cluster'.format(es_server_version))
 
-    indexer.reindex(request.db, es_client, request)
+    indexer.reindex(request.db, es_client, request, parallel=parallel)
 
 
 @search.command('update-settings')

--- a/h/indexer/reindexer.py
+++ b/h/indexer/reindexer.py
@@ -3,6 +3,9 @@
 from __future__ import unicode_literals
 import logging
 
+from celery.result import ResultSet
+
+from h.models import Annotation
 from h.search.config import (
     configure_index,
     delete_index,
@@ -10,22 +13,24 @@ from h.search.config import (
     update_aliased_index,
 )
 from h.search.index import BatchIndexer
+from h.tasks.indexer import reindex_annotations
 
 log = logging.getLogger(__name__)
 
 
-def reindex(session, es, request):
-    """Reindex all annotations into a new index, and update the alias."""
+def reindex(session, es, request, parallel=False):
+    """
+    Reindex all annotations into a new index, and update the alias.
+
+    :param parallel: If `True`, reindex annotations into the new index in batches
+                     using Celery tasks.
+    """
 
     current_index = get_aliased_index(es)
     if current_index is None:
         raise RuntimeError('cannot reindex if current index is not aliased')
 
     settings = request.find_service(name='settings')
-
-    # Preload userids of shadowbanned users.
-    nipsa_svc = request.find_service(name='nipsa')
-    nipsa_svc.fetch_all_flagged_userids()
 
     new_index = configure_index(es)
     log.info('configured new index {}'.format(new_index))
@@ -37,18 +42,22 @@ def reindex(session, es, request):
         settings.put(setting_name, new_index)
         request.tm.commit()
 
-        log.info('reindexing annotations into new index {}'.format(new_index))
-        indexer = BatchIndexer(session, es, request, target_index=new_index, op_type='create')
+        if parallel:
+            log.info('reindexing annotations into new index {}'.format(new_index))
+            _parallel_reindex(request.db, batch_size=2000, max_active_tasks=10, timeout=60)
+        else:
+            log.info('reindexing annotations into new index {}'.format(new_index))
+            indexer = BatchIndexer(session, es, request, target_index=new_index, op_type='create')
 
-        errored = indexer.index()
-        if errored:
-            log.debug('failed to index {} annotations, retrying...'.format(
-                len(errored)))
-            errored = indexer.index(errored)
+            errored = indexer.index()
             if errored:
-                log.warn('failed to index {} annotations: {!r}'.format(
-                    len(errored),
-                    errored))
+                log.debug('failed to index {} annotations, retrying...'.format(
+                    len(errored)))
+                errored = indexer.index(errored)
+                if errored:
+                    log.warn('failed to index {} annotations: {!r}'.format(
+                        len(errored),
+                        errored))
 
         log.info('making new index {} current'.format(new_index))
         update_aliased_index(es, new_index)
@@ -59,3 +68,55 @@ def reindex(session, es, request):
     finally:
         settings.delete(setting_name)
         request.tm.commit()
+
+
+def _parallel_reindex(session, batch_size, max_active_tasks, timeout=None):
+    """
+    Use Celery to reindex batches of annotations in parallel.
+
+    :param batch_size: Number of annotations to index per Celery task.
+    :param max_active_tasks: Maximum number of tasks to create before waiting
+                             for active tasks to complete.
+    :param timeout: Max delay in seconds to wait for a batch of tasks to finish.
+    """
+
+    rs = ResultSet([])
+    completed_tasks = 0
+
+    for batch_ids in _annotation_ids_batched_by_date(session, batch_size):
+
+        task_result = reindex_annotations.delay(batch_ids)
+        rs.add(task_result)
+
+        if len(rs.results) >= max_active_tasks:
+            # Block until at least one active task has finished.
+            next(rs.iter_native())
+            completed_tasks += rs.completed_count()
+
+            # Remove completed tasks from tracked set.
+            for result in rs.results:
+                if result.ready():
+                    rs.remove(result)
+
+            log.info('indexed {} annotations'.format(completed_tasks * batch_size))
+
+    log.info('waiting for remaining reindexing tasks')
+    rs.join(timeout=timeout)
+
+
+def _annotation_ids_batched_by_date(session, batch_size=100):
+    """Yield batches of annotation IDs to reindex."""
+
+    ann_ids = (session.query(Annotation.id)
+                      .filter_by(deleted=False)
+                      .order_by(Annotation.updated)
+                      .yield_per(batch_size))
+
+    batch = []
+    for (ann_id,) in ann_ids:
+        batch.append(ann_id)
+        if len(batch) == batch_size:
+            yield batch
+            batch = []
+    if batch:
+        yield batch

--- a/h/search/index.py
+++ b/h/search/index.py
@@ -132,6 +132,10 @@ class BatchIndexer(object):
             annotations = _filtered_annotations(session=self.session,
                                                 ids=annotation_ids)
 
+        # Preload userids of shadowbanned users.
+        nipsa_svc = self.request.find_service(name='nipsa')
+        nipsa_svc.fetch_all_flagged_userids()
+
         # Report indexing status as we go
         annotations = _log_status(annotations, log_every=windowsize)
 

--- a/h/tasks/indexer.py
+++ b/h/tasks/indexer.py
@@ -54,7 +54,13 @@ def delete_annotation(id_):
 @celery.task
 def reindex_user_annotations(userid):
     ids = [a.id for a in celery.request.db.query(models.Annotation.id).filter_by(userid=userid)]
+    reindex_annotations(ids)
 
+
+# Results are enabled for this task because the `search reindex` command awaits
+# completion.
+@celery.task(ignore_result=False)
+def reindex_annotations(ids):
     indexer = BatchIndexer(celery.request.db, celery.request.es, celery.request)
     errored = indexer.index(ids)
     if errored:

--- a/tests/h/cli/commands/search_test.py
+++ b/tests/h/cli/commands/search_test.py
@@ -20,7 +20,17 @@ class TestReindexCommand(object):
         assert result.exit_code == 0
         reindex.assert_called_once_with(pyramid_request.db,
                                         pyramid_request.es,
-                                        pyramid_request)
+                                        pyramid_request,
+                                        parallel=False)
+
+    def test_calls_reindex_with_parallel_option(self, cli, cliconfig, pyramid_request, reindex):
+        result = cli.invoke(search.reindex, ['--parallel'], obj=cliconfig)
+
+        assert result.exit_code == 0
+        reindex.assert_called_once_with(pyramid_request.db,
+                                        pyramid_request.es,
+                                        pyramid_request,
+                                        parallel=True)
 
     def test_calls_reindex_with_es6_client(self, cli, cliconfig, pyramid_request, reindex):
         result = cli.invoke(search.reindex, ['--es6'], obj=cliconfig)
@@ -28,7 +38,8 @@ class TestReindexCommand(object):
         assert result.exit_code == 0
         reindex.assert_called_once_with(pyramid_request.db,
                                         pyramid_request.es6,
-                                        pyramid_request)
+                                        pyramid_request,
+                                        parallel=False)
 
     @pytest.fixture
     def reindex(self, patch):

--- a/tests/h/indexer/reindexer_test.py
+++ b/tests/h/indexer/reindexer_test.py
@@ -6,13 +6,11 @@ import pytest
 
 from h.indexer.reindexer import reindex
 from h.search import client
-from h.services.nipsa import NipsaService
 
 
 @pytest.mark.usefixtures('BatchIndexer',
                          'configure_index',
                          'delete_index',
-                         'nipsa_service',
                          'get_aliased_index',
                          'update_aliased_index',
                          'settings_service')
@@ -120,9 +118,17 @@ class TestReindex(object):
 
         delete_index.assert_called_once_with(es, 'original_index')
 
-    def test_populates_nipsa_cache(self, pyramid_request, es, nipsa_service):
-        reindex(mock.sentinel.session, es, pyramid_request)
-        nipsa_service.fetch_all_flagged_userids.assert_called_once_with()
+    def test_parallel_reindex_executes_indexing_tasks(self):
+        # TODO - Test that reindex_annotations tasks are dispatched when `parallel=True`.
+        pass
+
+    def test_parallel_reindex_waits_for_indexing_tasks(self):
+        # TODO - Test that finalization happens only after indexing is completed.
+        pass
+
+    def test_parallel_reindex_limits_max_active_tasks(self):
+        # TODO - Test maximum number of active reindexing tasks.
+        pass
 
     @pytest.fixture
     def BatchIndexer(self, patch):
@@ -164,12 +170,6 @@ class TestReindex(object):
     def settings_service(self, pyramid_config):
         service = mock.Mock()
         pyramid_config.register_service(service, name='settings')
-        return service
-
-    @pytest.fixture
-    def nipsa_service(self, pyramid_config):
-        service = mock.create_autospec(NipsaService, spec_set=True, instance=True)
-        pyramid_config.register_service(service, name='nipsa')
         return service
 
     @pytest.fixture

--- a/tests/h/indexer/reindexer_test.py
+++ b/tests/h/indexer/reindexer_test.py
@@ -83,7 +83,7 @@ class TestReindex(object):
     @pytest.mark.parametrize(
         'esversion,new_index_setting_name',
         (((1, 5, 0), 'reindex.new_index'),
-        ((6, 2, 0), 'reindex.new_es6_index'))
+         ((6, 2, 0), 'reindex.new_es6_index'))
     )
     def test_stores_new_index_name_in_settings(self, pyramid_request, es, settings_service,
                                                configure_index, esversion, new_index_setting_name):
@@ -97,7 +97,7 @@ class TestReindex(object):
     @pytest.mark.parametrize(
         'esversion,new_index_setting_name',
         (((1, 5, 0), 'reindex.new_index'),
-        ((6, 2, 0), 'reindex.new_es6_index'))
+         ((6, 2, 0), 'reindex.new_es6_index'))
     )
     def test_deletes_index_name_setting(self, pyramid_request, es, settings_service, esversion, new_index_setting_name):
         es.version = esversion

--- a/tests/h/search/index_test.py
+++ b/tests/h/search/index_test.py
@@ -12,6 +12,7 @@ import mock
 import pytest
 
 import h.search.index
+from h.services.nipsa import NipsaService
 
 from tests.common.matchers import Matcher
 
@@ -321,6 +322,7 @@ class TestDelete(object):
         assert result.get('_source').get('deleted') is True
 
 
+@pytest.mark.usefixtures('nipsa_service')
 class TestBatchIndexer(object):
     def test_it_indexes_all_annotations(self, batch_indexer, each_es_client, factories):
         es_client = each_es_client
@@ -452,6 +454,12 @@ class TestBatchIndexer(object):
                                               pyramid_request, es_client.index, 'create').index()
 
         assert errored == expected_errored_ids
+
+    @pytest.fixture
+    def nipsa_service(self, pyramid_config):
+        svc = mock.create_autospec(NipsaService, spec_set=True, instance=True)
+        pyramid_config.register_service(svc, name='nipsa')
+        return svc
 
 
 class SearchResponseWithIDs(Matcher):

--- a/tests/h/search/old_index_test.py
+++ b/tests/h/search/old_index_test.py
@@ -14,6 +14,7 @@ import pytest
 from h import presenters
 from h.search import client
 from h.search import index
+from h.services.nipsa import NipsaService
 
 
 @pytest.mark.usefixtures('presenters')
@@ -100,6 +101,7 @@ class TestDeleteAnnotation:
         assert kwargs['index'] == 'custom-index'
 
 
+@pytest.mark.usefixtures('nipsa_service')
 class TestBatchIndexer(object):
     def test_index_indexes_all_annotations_to_es(self, db_session, indexer, matchers, streaming_bulk, factories):
         ann_1, ann_2 = factories.Annotation(), factories.Annotation()
@@ -315,6 +317,13 @@ def es():
                                    index="hypothesis")
     mock_es.mapping_type = "annotation"
     return mock_es
+
+
+@pytest.fixture
+def nipsa_service(pyramid_config):
+    svc = mock.create_autospec(NipsaService, spec_set=True, instance=True)
+    pyramid_config.register_service(svc, name='nipsa')
+    return svc
 
 
 @pytest.fixture

--- a/tests/h/tasks/indexer_test.py
+++ b/tests/h/tasks/indexer_test.py
@@ -148,6 +148,8 @@ class TestDeleteAnnotation(object):
         return patch('h.tasks.indexer.delete')
 
 
+# TODO - Add test for reindexing of a batch of annotations and modify test for
+# `ReindexUserAnnotations` to work in terms of this one.
 @pytest.mark.usefixtures('celery')
 class TestReindexUserAnnotations(object):
     def test_it_creates_batch_indexer(self, batch_indexer, annotation_ids, celery):


### PR DESCRIPTION
Rebuilding the search index after a change to the schema or indexed data currently involves a series of sequential steps which all happen on a single production h instance. The time taken scales linearly with the size of the DB, currently just over a couple of hours for the production DB.

This PR adds an experimental `--parallel` option to the `hypothesis search reindex` command which reduces the total time taken by farming out the core reindexing work (loading annotations from the DB, generating JSON dicts and making indexing requests to Elasticsearch) to a set of Celery tasks which can be executed in parallel by as many worker processes as we have running in production.

There are a couple of parameters, currently just hard-coded values in the code, which affect the amount of parallelization that happens - `batch_size` specifies how many annotations to index per Celery task and `max_active_tasks` controls how many indexing tasks may be in-flight at any time.

See the commit message for a detailed explanation of the changes.

Fixes https://github.com/hypothesis/h/issues/5168