### PR TITLE
Add a partial index on the `user.nipsa` column

### DIFF
--- a/h/migrations/versions/7fe5d688edd9_add_index_to_user_nipsa.py
+++ b/h/migrations/versions/7fe5d688edd9_add_index_to_user_nipsa.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+"""Add index to user.nipsa"""
+from __future__ import unicode_literals
+from __future__ import absolute_import
+from __future__ import division
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "7fe5d688edd9"
+down_revision = "792debe852c3"
+
+
+def upgrade():
+    op.execute('COMMIT')
+    op.create_index(op.f('ix__user__nipsa'), 'user', ['nipsa'], unique=False,
+                    postgresql_concurrently=True,
+                    postgresql_where=sa.text('nipsa is true'))
+
+
+def downgrade():
+    op.drop_index(op.f('ix__user__nipsa'), table_name='user')

--- a/h/models/user.py
+++ b/h/models/user.py
@@ -137,6 +137,10 @@ class User(Base):
                      _normalise_username(cls.username),
                      cls.authority,
                      unique=True),
+            # Optimize lookup of shadowbanned users.
+            sa.Index('ix__user__nipsa',
+                     cls.nipsa,
+                     postgresql_where=cls.nipsa.is_(True)),
         )
 
     id = sa.Column(sa.Integer, autoincrement=True, primary_key=True)

--- a/h/services/nipsa.py
+++ b/h/services/nipsa.py
@@ -30,9 +30,8 @@ class NipsaService(object):
         if self._flagged_userids is not None:
             return self._flagged_userids
 
-        # TODO: The `nipsa` field is currently not indexed so this requires a
-        # full table scan.
-        query = self.session.query(User).filter_by(nipsa=True)
+        # Filter using `is_` to match the index predicate for `User.nipsa`.
+        query = self.session.query(User).filter(User.nipsa.is_(True))
         self._flagged_userids = set([u.userid for u in query])
 
         return self._flagged_userids


### PR DESCRIPTION
Add an index for efficient lookup of shadowbanned users. This is
currently used during reindexing operations and on the NIPSA admin page.

Since we are only interested in optimizing lookup of users who _are_
shadowbanned, add a predicate on the index to keep it small.

The DB query in `NipsaService.fetch_flagged_userids` has been modified
slightly to make sure it uses exactly the same predicate that is used
when building the index. Otherwise the index doesn't get used.

See https://www.postgresql.org/docs/9.6/static/indexes-partial.html and
http://docs.sqlalchemy.org/en/latest/dialects/postgresql.html#partial-indexes for info on partial indexes.

See https://stackoverflow.com/questions/9822154/ for difference between
`is` and `=` in SQL.

Since this change doesn't alter the content or definition of the `user.nipsa` field we don't need to do the two-step migration dance and so I've included the model change and migration in the same PR.

----

**Testing notes:**

After running the migration, you can verify that these lookups use the index in psql as follows:

```
set enable_seqscan=False
explain select * from user where nipsa is True
```