### PR TITLE
Run new search indexing tests against es1 and es6

### DIFF
--- a/tests/common/fixtures/__init__.py
+++ b/tests/common/fixtures/__init__.py
@@ -1,13 +1,15 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from tests.common.fixtures.elasticsearch import es_client
+from tests.common.fixtures.elasticsearch import es_client, es6_client, es_connect
 from tests.common.fixtures.elasticsearch import init_elasticsearch
 from tests.common.fixtures.elasticsearch import delete_all_elasticsearch_documents
 
 
 __all__ = (
     "es_client",
+    "es6_client",
+    "es_connect",
     "init_elasticsearch",
     "delete_all_elasticsearch_documents",
 )

--- a/tests/h/conftest.py
+++ b/tests/h/conftest.py
@@ -24,7 +24,7 @@ from h import db
 from h import models
 from h.settings import database_url
 from h._compat import text_type
-from tests.common.fixtures import es_client  # noqa: F401
+from tests.common.fixtures import es_client, es6_client, es_connect  # noqa: F401
 from tests.common.fixtures import init_elasticsearch  # noqa: F401
 from tests.common.fixtures import delete_all_elasticsearch_documents  # noqa: F401
 

--- a/tests/h/search/connection_test.py
+++ b/tests/h/search/connection_test.py
@@ -21,8 +21,8 @@ class TestConnection(object):
     def test_connect_is_available_in_search_api(self):
         assert connect == search.connect
 
-    def test_connect_creates_default_connection(self):
-        # search.connect is invoked as part of test bootstrapping
+    def test_connect_creates_default_connection(self, es_connect):
+        # search.connect is invoked by the `es_connect` fixture
         # so the connection should already be established
         assert connections.get_connection()
         assert connections.get_connection('default')


### PR DESCRIPTION
Use parametrized pytest fixtures to run the new indexing tests against
both ES 1 and ES 6.

 - Define an `es6_client` fixture that can be used in place of
   `es_client` in order to run code against Elasticsearch 6 instead of
   Elasticsearch 1. This fixture unlike its predecesor es_client does not
   depend on `delete_all_elasticsearch_documents` fixture but rather uses
   yield to delete the documents in the index.

 - Modify the existing `index` fixture to index annotations into both
   ES1 and ES6 clusters. This makes it easier to write tests that run
   against both clusters. Once we are done with the migration, we can
   just remove the code that writes to ES1 here.