### PR TITLE
Add elasticsearch1 monitoring to New Relic.

### DIFF
--- a/conf/app.ini
+++ b/conf/app.ini
@@ -69,3 +69,35 @@ formatter = generic
 
 [formatter_generic]
 format = %(asctime)s [%(process)d] [%(name)s:%(levelname)s] %(message)s
+
+# Add temporary newrelic hooks for elasticsearch1
+[import-hook:elasticsearch1.client]
+enabled = true
+execute = newrelic.hooks.datastore_elasticsearch:instrument_elasticsearch_client
+[import-hook:elasticsearch1.client.cat]
+enabled = true
+execute = newrelic.hooks.datastore_elasticsearch:instrument_elasticsearch_client_cat
+[import-hook:elasticsearch1.client.cluster]
+enabled = true
+execute = newrelic.hooks.datastore_elasticsearch:instrument_elasticsearch_client_cluster
+[import-hook:elasticsearch1.client.indices]
+enabled = true
+execute = newrelic.hooks.datastore_elasticsearch:instrument_elasticsearch_client_indices
+[import-hook:elasticsearch1.client.nodes]
+enabled = true
+execute = newrelic.hooks.datastore_elasticsearch:instrument_elasticsearch_client_nodes
+[import-hook:elasticsearch1.client.snapshot]
+enabled = true
+execute = newrelic.hooks.datastore_elasticsearch:instrument_elasticsearch_client_snapshot
+[import-hook:elasticsearch1.client.tasks]
+enabled = true
+execute = newrelic.hooks.datastore_elasticsearch:instrument_elasticsearch_client_tasks
+[import-hook:elasticsearch1.client.ingest]
+enabled = true
+execute = newrelic.hooks.datastore_elasticsearch:instrument_elasticsearch_client_ingest
+[import-hook:elasticsearch1.connection.base]
+enabled = true
+execute = newrelic.hooks.datastore_elasticsearch:instrument_elasticsearch_connection_base
+[import-hook:elasticsearch1.transport]
+enabled = true
+execute = newrelic.hooks.datastore_elasticsearch:instrument_elasticsearch_transport

--- a/conf/supervisord.conf
+++ b/conf/supervisord.conf
@@ -12,6 +12,7 @@ stdout_events_enabled=true
 stderr_events_enabled=true
 
 [program:web]
+environment=NEW_RELIC_CONFIG_FILE=conf/app.ini
 command=newrelic-admin run-program gunicorn --name web --paste conf/app.ini -b unix:/tmp/gunicorn-web.sock
 stdout_logfile=NONE
 stderr_logfile=NONE


### PR DESCRIPTION
CC: @hmstepanek 

Hi there! I noticed that both the `elasticsearch1` library and New Relic monitoring is in use in this project.  Since `elasticsearch1` isn't a New Relic officially supported library, elasticsearch queries that are made through `elasticsearch1` may fail to appear in the New Relic user interface.

Since `elasticsearch1` appears to be a fork of the `elasticsearch` library, the New Relic agent can be configured to load all of the `elasticsearch` instrumentation when the `elasticsearch1` package is loaded.

Summary of the changes:
* Initializing the agent normally sets up "import hooks" for elasticsearch as defined [here](https://github.com/edmorley/newrelic-python-agent/blob/da8e13e92af5c428cfc0da861bae78e2e149feb6/newrelic/newrelic/config.py#L2420L2449)
* A configuration file may also be used to define import hooks in the form of:
```
[import-hook:%s]
enabled = true
execute = module:function
```
* The builtin instrumentation can be loaded by replacing `elasticsearch` with `elasticsearch1` so that the import-hook fires on import of `elasticsearch1`!

The supervisor config / app config has been updated to load these modules. All existing New Relic environment variables should continue to work!

I hope this change helps the team, please let me know if I can provide further assistance!