### PR TITLE
Add search_es6 feature flag and run search tests against es6

### DIFF
--- a/h/models/feature.py
+++ b/h/models/feature.py
@@ -20,8 +20,7 @@ FEATURES = {
     'client_display_names': "Render display names instead of user names in the client",
     'index_es6': ("Index annotations into Elasticsearch 6 "
                   "(only takes effect if enabled for everyone)?"),
-    'search_es6': ("Search annotations in Elasticsearch 6 "
-                   "(only takes effect if enabled for everyone)?"),
+    'search_es6': "Search annotations in Elasticsearch 6",
 }
 
 # Once a feature has been fully deployed, we remove the flag from the codebase.

--- a/h/models/feature.py
+++ b/h/models/feature.py
@@ -20,6 +20,8 @@ FEATURES = {
     'client_display_names': "Render display names instead of user names in the client",
     'index_es6': ("Index annotations into Elasticsearch 6 "
                   "(only takes effect if enabled for everyone)?"),
+    'search_es6': ("Search annotations in Elasticsearch 6 "
+                   "(only takes effect if enabled for everyone)?"),
 }
 
 # Once a feature has been fully deployed, we remove the flag from the codebase.

--- a/h/search/core.py
+++ b/h/search/core.py
@@ -24,7 +24,7 @@ class Search(object):
     :param request: the request object
     :type request: pyramid.request.Request
 
-    :param separate_replies: Wheter or not to return all replies to the
+    :param separate_replies: Whether or not to return all replies to the
         annotations returned by this search. If this is True then the
         resulting annotations will only include top-level annotations, not replies.
     :type separate_replies: bool
@@ -35,7 +35,10 @@ class Search(object):
     """
     def __init__(self, request, separate_replies=False, stats=None, _replies_limit=200):
         self.request = request
-        self.es = request.es
+        if self.request.feature('search_es6'):
+            self.es = request.es6
+        else:
+            self.es = request.es
         self.separate_replies = separate_replies
         self.stats = stats
         self._replies_limit = _replies_limit

--- a/tests/h/search/core_test.py
+++ b/tests/h/search/core_test.py
@@ -10,7 +10,6 @@ Tests for filtering/matching/aggregating on specific annotation fields are in
 from __future__ import unicode_literals
 
 import datetime
-
 import pytest
 
 from h import search
@@ -126,6 +125,8 @@ class TestSearch(object):
 
     def test_it_passes_es_version_to_builder(self, pyramid_request, Builder):
         client = pyramid_request.es
+        if pyramid_request.feature('search_es6'):
+            client = pyramid_request.es6
 
         search.Search(pyramid_request)
 
@@ -243,3 +244,11 @@ class TestSearchWithSeparateReplies(object):
 
         assert len(result.reply_ids) == 3
         assert oldest_reply.id not in result.reply_ids
+
+
+@pytest.fixture(params=['es1', 'es6'])
+def pyramid_request(request, pyramid_request, es_client, es6_client):
+    pyramid_request.es = es_client
+    pyramid_request.es6 = es6_client
+    pyramid_request.feature.flags["search_es6"] = request.param == 'es6'
+    return pyramid_request

--- a/tests/h/search/query_test.py
+++ b/tests/h/search/query_test.py
@@ -2,7 +2,6 @@
 from __future__ import unicode_literals
 
 import datetime
-
 import pytest
 import webob
 
@@ -50,13 +49,13 @@ class TestBuilder(object):
         # TODO - Remove this test once ES 1 support is dropped.
 
         builder = Builder(es_version=(1, 7, 0))
-        filter = AuthorityFilter("default")
+        filter_ = AuthorityFilter("default")
         params = {}
-        builder.append_filter(filter)
+        builder.append_filter(filter_)
 
         query = builder.build(params)["query"]
 
-        assert query == {"filtered": {"filter": {"and": [filter(params)]},
+        assert query == {"filtered": {"filter": {"and": [filter_(params)]},
                                       "query": {"match_all": {}}}}
 
     def test_it_uses_new_filter_syntax_for_es6(self):
@@ -64,13 +63,13 @@ class TestBuilder(object):
         # searches against Elasticsearch are running against ES 6.
 
         builder = Builder(es_version=(6, 2, 0))
-        filter = AuthorityFilter("default")
+        filter_ = AuthorityFilter("default")
         params = {}
-        builder.append_filter(filter)
+        builder.append_filter(filter_)
 
         query = builder.build(params)["query"]
 
-        assert query == {"bool": {"filter": [filter(params)],
+        assert query == {"bool": {"filter": [filter_(params)],
                                   "must": []}}
 
 
@@ -177,7 +176,7 @@ class TestGroupFilter(object):
 
 class TestGroupAuthFilter(object):
     def test_does_not_return_annotations_if_group_not_readable_by_user(
-        self, search, Annotation, group_service
+        self, search, Annotation, group_service,
     ):
         group_service.groupids_readable_by.return_value = []
         Annotation(groupid="group2").id
@@ -189,7 +188,7 @@ class TestGroupAuthFilter(object):
         assert not result.annotation_ids
 
     def test_returns_annotations_if_group_readable_by_user(
-        self, search, Annotation, group_service
+        self, search, Annotation, group_service,
     ):
         group_service.groupids_readable_by.return_value = ["group1"]
         Annotation(groupid="group2", shared=True).id
@@ -651,6 +650,14 @@ class TestUsersAggregation(object):
         assert len(users_results) == bucket_limit
         assert count_pb == 3
         assert count_pc == 2
+
+
+@pytest.fixture(params=['es1', 'es6'])
+def pyramid_request(request, pyramid_request, es_client, es6_client):
+    pyramid_request.es = es_client
+    pyramid_request.es6 = es6_client
+    pyramid_request.feature.flags['search_es6'] = request.param == 'es6'
+    return pyramid_request
 
 
 @pytest.fixture


### PR DESCRIPTION
1. Add a feature flag called search_es6 that will search the elasticsearch6 cluster instead of the elasticsearch1 cluster.
1. If the search_es6 feature flag is set search the es6 cluster instead of es1.
1. Update the search tests to verify both es6 searching and es1 search behave the same.
1. Update query tests (filters, aggregators, matchers) to verify both es6 and es1 behave the same.

This is a partial fix for https://github.com/hypothesis/product-backlog/issues/601.