### PR TITLE
Ignore `ELASTICSEARCH_CLIENT_TIMEOUT` env var in `hypothesis init` command

### DIFF
--- a/h/cli/commands/init.py
+++ b/h/cli/commands/init.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import logging
+import os
 
 import click
 import sqlalchemy
@@ -15,6 +16,11 @@ log = logging.getLogger(__name__)
 @click.command()
 @click.pass_context
 def init(ctx):
+    # In production environments a short ES request timeout is typically set.
+    # Commands to initialize the index may take longer than this, so override
+    # any custom timeout with a high value.
+    os.environ['ELASTICSEARCH_CLIENT_TIMEOUT'] = '30'
+
     request = ctx.obj['bootstrap']()
 
     _init_db(request.registry.settings)


### PR DESCRIPTION
The request timeout is typically set to a short value (<1s) in
production environments to prevent long-running search/indexing
commands.

The process of initializing the search index can take longer than this
though, so override the default timeout using the same method that is
used for the `hypothesis search reindex` command.

----

I ran into this issue when running `hypothesis init` in production earlier today to initialize the ES 6 cluster. There are plenty of other ways that this could be fixed, but I've opted to use the same approach as the `reindex` command for now.