### PR TITLE
Upgrade dependencies for compatibility with Python 3.7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ test: node_modules/.uptodate
 
 .PHONY: test-py3
 test-py3: node_modules/.uptodate
-	tox -e py36 -- tests/h/
+	tox -e py3 -- tests/h/
 
 .PHONY: lint
 lint: .pydeps

--- a/requirements.in
+++ b/requirements.in
@@ -17,7 +17,7 @@ enum34
 functools32; python_version < "3.0" # Required by jsonschema, listed here to add environment marker
 gevent >= 1.3.5  # TODO: Update to gevent 1.3.6 when released, then remove `greenlet`.
 greenlet==0.4.13  # Pinned dependency of gevent. See https://git.io/fN8Wf
-gunicorn
+gunicorn >= 19.9.0
 hkdf
 itsdangerous
 jsonpointer == 1.0

--- a/requirements.in
+++ b/requirements.in
@@ -22,7 +22,7 @@ hkdf
 itsdangerous
 jsonpointer == 1.0
 jsonschema
-kombu
+kombu >= 4.2.1
 mistune
 newrelic
 oauthlib

--- a/requirements.in
+++ b/requirements.in
@@ -15,7 +15,8 @@ elasticsearch1==1.10.0
 elasticsearch-dsl==6.1.0
 enum34
 functools32; python_version < "3.0" # Required by jsonschema, listed here to add environment marker
-gevent
+gevent >= 1.3.5  # TODO: Update to gevent 1.3.6 when released, then remove `greenlet`.
+greenlet==0.4.13  # Pinned dependency of gevent. See https://git.io/fN8Wf
 gunicorn
 hkdf
 itsdangerous

--- a/requirements.in
+++ b/requirements.in
@@ -4,7 +4,7 @@ alembic
 backports.functools_lru_cache
 bcrypt
 bleach >= 2.0
-celery >= 4.1
+celery >= 4.2.1
 certifi
 cffi
 click

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,7 @@ itsdangerous==0.24
 jinja2==2.8               # via deform-jinja2, pyramid-jinja2
 jsonpointer==1.0
 jsonschema==2.5.1
-kombu==4.1.0
+kombu==4.2.1
 mako==1.0.4               # via alembic
 markupsafe==0.23          # via jinja2, mako, pyramid-jinja2
 mistune==0.8.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ backports.functools-lru-cache==1.2.1
 bcrypt==3.1.3
 billiard==3.5.0.3         # via celery
 bleach==2.1.3
-celery==4.1.0
+celery==4.2.1
 certifi==2016.2.28
 cffi==1.7.0
 chameleon==2.24           # via deform

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ enum34==1.1.6
 functools32==3.2.3.post2 ; python_version < "3.0"
 gevent==1.3.5
 greenlet==0.4.13
-gunicorn==19.6.0
+gunicorn==19.9.0
 hkdf==0.0.3
 html5lib==0.999999999     # via bleach
 ipaddress==1.0.18         # via elasticsearch-dsl

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,8 +24,8 @@ elasticsearch1==1.10.0
 elasticsearch==6.2.0
 enum34==1.1.6
 functools32==3.2.3.post2 ; python_version < "3.0"
-gevent==1.2.1
-greenlet==0.4.10          # via gevent
+gevent==1.3.5
+greenlet==0.4.13
 gunicorn==19.6.0
 hkdf==0.0.3
 html5lib==0.999999999     # via bleach

--- a/tox.ini
+++ b/tox.ini
@@ -44,7 +44,7 @@ passenv =
 commands = pytest {posargs:tests/functional/}
 
 [testenv:functional-py3]
-basepython = python3.6
+basepython = python3
 skip_install = true
 deps =
     pytest


### PR DESCRIPTION
Update gevent, kombu, gunicorn and celery dependencies for compatibility with Python 3.7 and run tox tests for Python 3 against 3.7. See commit messages for links to upstream issues.

Note that some changes have been merged into Celery recently containing additional Python 3.7 fixes which have not yet been included in a stable release.

Since these are updates of core libraries we might want to look at extracting out the individual updates and deploying them separately. I've integrated all the changes together in this branch to facilitate testing the whole application against Python 3.7.