### PR TITLE
Implement the  API endpoint for adding members to (private) groups.

### DIFF
--- a/docs/_extra/api-reference/hypothesis.yaml
+++ b/docs/_extra/api-reference/hypothesis.yaml
@@ -428,10 +428,10 @@ paths:
           description: Public ID of the group
           required: true
           type: string
-        - name: user
+        - name: userid
           in: path
           description: |
-            The user to remove from the group. For now, only the value `me` is
+            The userid of the user to remove from the group. For now, only the value `me` is
             supported, representing the currently-authenticated user.
           required: true
           type: string
@@ -441,6 +441,31 @@ paths:
           description: Success
         '404':
           description: Group not found
+          schema:
+            $ref: '#/definitions/Error'
+    post:
+      tags:
+        - groups
+      summary: Add a member to a group
+      operationId: addGroupMember
+      parameters:
+        - name: id
+          in: path
+          description: Public ID of the group
+          required: true
+          type: string
+        - name: userid
+          in: path
+          description: |
+            User ID of the user to add to the group.
+            The userID should be of the format `acct:<username>@<authority>`
+          required: true
+          type: string
+      responses:
+        '204':
+          description: Success
+        '404':
+          description: User or Group not found
           schema:
             $ref: '#/definitions/Error'
 definitions:

--- a/h/routes.py
+++ b/h/routes.py
@@ -111,7 +111,7 @@ def includeme(config):
     config.add_route('api.profile', '/api/profile')
     config.add_route('api.debug_token', '/api/debug-token')
     config.add_route('api.group_member',
-                     '/api/groups/{pubid}/members/{user}',
+                     '/api/groups/{pubid}/members/{userid}',
                      factory='h.traversal.GroupRoot',
                      traverse='/{pubid}')
     config.add_route('api.search', '/api/search')

--- a/h/views/api/annotations.py
+++ b/h/views/api/annotations.py
@@ -47,7 +47,7 @@ def index(context, request):
     # parameter names are added, we'll need to add them here, or this view will
     # break (and get caught by the `test_api_index` functional test).
     templater = AngularRouteTemplater(request.route_url,
-                                      params=['id', 'pubid', 'user'])
+                                      params=['id', 'pubid', 'user', 'userid'])
 
     links = {}
     for link in api_links:

--- a/tests/h/routes_test.py
+++ b/tests/h/routes_test.py
@@ -93,7 +93,7 @@ def test_includeme():
         call('api.groups', '/api/groups'),
         call('api.profile', '/api/profile'),
         call('api.debug_token', '/api/debug-token'),
-        call('api.group_member', '/api/groups/{pubid}/members/{user}', factory='h.traversal.GroupRoot', traverse='/{pubid}'),
+        call('api.group_member', '/api/groups/{pubid}/members/{userid}', factory='h.traversal.GroupRoot', traverse='/{pubid}'),
         call('api.search', '/api/search'),
         call('api.users', '/api/users'),
         call('api.user', '/api/users/{username}'),


### PR DESCRIPTION
This is so that the LMS app can auto-join LMS users to the correct
course-related group.

See https://github.com/hypothesis/product-backlog/issues/707

To test:
1. `git checkout group-members`
2. `make dev`
3. In your virtualenv:
`import requests`
`import json`
`requests.post("http://localhost:5000/api/groups/<pubid>/members/<userid>", auth=("<client_id>", "<client_secret>")).__dict__`

Results on my local:
1. 204 when the user and group both exist and the user authority, group authority and auth_client authority all match.
2. 400 when the user, group and auth_client authorities don't match.
3. 404 when the user and/or the group are not found.

For more see: https://stackoverflow.com/c/hypothesis/questions/90/91#91
