### PR TITLE
Update gevent and gunicorn

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -17,7 +17,7 @@ enum34
 functools32; python_version < "3.0" # Required by jsonschema, listed here to add environment marker
 gevent >= 1.3.5  # TODO: Update to gevent 1.3.6 when released, then remove `greenlet`.
 greenlet==0.4.13  # Pinned dependency of gevent. See https://git.io/fN8Wf
-gunicorn
+gunicorn >= 19.9.0
 hkdf
 itsdangerous
 jsonpointer == 1.0

--- a/requirements.in
+++ b/requirements.in
@@ -15,7 +15,8 @@ elasticsearch1==1.10.0
 elasticsearch-dsl==6.1.0
 enum34
 functools32; python_version < "3.0" # Required by jsonschema, listed here to add environment marker
-gevent
+gevent >= 1.3.5  # TODO: Update to gevent 1.3.6 when released, then remove `greenlet`.
+greenlet==0.4.13  # Pinned dependency of gevent. See https://git.io/fN8Wf
 gunicorn
 hkdf
 itsdangerous

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ enum34==1.1.6
 functools32==3.2.3.post2 ; python_version < "3.0"
 gevent==1.3.5
 greenlet==0.4.13
-gunicorn==19.6.0
+gunicorn==19.9.0
 hkdf==0.0.3
 html5lib==0.999999999     # via bleach
 ipaddress==1.0.18         # via elasticsearch-dsl

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,8 +24,8 @@ elasticsearch1==1.10.0
 elasticsearch==6.2.0
 enum34==1.1.6
 functools32==3.2.3.post2 ; python_version < "3.0"
-gevent==1.2.1
-greenlet==0.4.10          # via gevent
+gevent==1.3.5
+greenlet==0.4.13
 gunicorn==19.6.0
 hkdf==0.0.3
 html5lib==0.999999999     # via bleach


### PR DESCRIPTION
Update gevent and gunicorn for compatibility with Python 3.7.

In the case of gevent, there was an additional need to pin its greenlet dependency until gevent 1.3.6 is released.

With this PR, dependency installation succeeds on Python 3.7. The app does not actually run however because of issues with other packages.