### PR TITLE
Update Celery and Kombu

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -4,7 +4,7 @@ alembic
 backports.functools_lru_cache
 bcrypt
 bleach >= 2.0
-celery >= 4.1
+celery >= 4.2.1
 certifi
 cffi
 click
@@ -21,7 +21,7 @@ hkdf
 itsdangerous
 jsonpointer == 1.0
 jsonschema
-kombu
+kombu >= 4.2.1
 mistune
 newrelic
 oauthlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ backports.functools-lru-cache==1.2.1
 bcrypt==3.1.3
 billiard==3.5.0.3         # via celery
 bleach==2.1.3
-celery==4.1.0
+celery==4.2.1
 certifi==2016.2.28
 cffi==1.7.0
 chameleon==2.24           # via deform
@@ -35,7 +35,7 @@ itsdangerous==0.24
 jinja2==2.8               # via deform-jinja2, pyramid-jinja2
 jsonpointer==1.0
 jsonschema==2.5.1
-kombu==4.1.0
+kombu==4.2.1
 mako==1.0.4               # via alembic
 markupsafe==0.23          # via jinja2, mako, pyramid-jinja2
 mistune==0.8.3


### PR DESCRIPTION
This update partially resolves compatibility issues with Python 3.7.
In the case of Celery there is still ongoing work upstream to fully
support Python 3.7, currently expected for the 4.3 release.