### PR TITLE
Refresh correct index in ES6 tests

### DIFF
--- a/tests/h/search/conftest.py
+++ b/tests/h/search/conftest.py
@@ -48,7 +48,7 @@ def index(es_client, es6_client, pyramid_request):
         # Index annotations into new Elasticsearch cluster.
         for annotation in annotations:
             h.search.index.index(es6_client, annotation, pyramid_request)
-        es6_client.conn.indices.refresh(index=es_client.index)
+        es6_client.conn.indices.refresh(index=es6_client.index)
 
     return _index
 


### PR DESCRIPTION
`es_client.index` and `es6_client.index` have the same value
`hypothesis-test` so this change should be a no-op, but I thought I'd
fix it anyway.