### PR TITLE
WIP: Spike a new Auth Policy for auth_clients

### DIFF
--- a/h/auth/policy.py
+++ b/h/auth/policy.py
@@ -2,6 +2,7 @@
 
 from __future__ import unicode_literals
 from pyramid import interfaces
+from pyramid.authentication import BasicAuthAuthenticationPolicy
 from pyramid.authentication import CallbackAuthenticationPolicy
 from zope import interface
 
@@ -37,6 +38,23 @@ class AuthenticationPolicy(object):
         if _is_api_request(request):
             return self.api_policy.forget(request)
         return self.fallback_policy.forget(request)
+
+
+@interface.implementer(interfaces.IAuthenticationPolicy)
+class AuthClientPolicy(BasicAuthAuthenticationPolicy):
+
+    """
+    An authentication policy for registered auth_clients.
+    """
+
+    def __init__(self, check, realm='Realm', debug=False):
+        self.check = check
+        self.realm = realm
+        self.debug = debug
+
+    def authenticated_userid(self, request):
+        """Extend me here (carefully) to operate on behalf of user in authority)"""
+        return None
 
 
 @interface.implementer(interfaces.IAuthenticationPolicy)

--- a/h/auth/util.py
+++ b/h/auth/util.py
@@ -117,8 +117,63 @@ def authority(request):
     return text_type(request.registry.settings.get('h.authority', request.domain))
 
 
+def check_auth_client(username, password, request):
+    """
+    Return list of principals for the auth_client matching the username and
+    password or None if no matching auth_client
+
+    Validate the basic auth credentials from the request by matching them to
+    an auth_client record in the DB.
+
+    :param username: username parsed out of Authorization header (Basic)
+    :param password: password parsed out of Authorization header (Basic)
+    :returns: additional principals for the auth_client or None
+    :rtype: list or None
+    """
+    # We fetch the client by its ID and then do a constant-time comparison of
+    # the secret with that provided in the request.
+    #
+    # It is important not to include the secret as part of the SQL query
+    # because the resulting code may be subject to a timing attack.
+    client_id = username
+    client_secret = password
+
+    try:
+        client = request.db.query(AuthClient).get(client_id)
+    except sa.exc.StatementError:  # client_id is malformed
+        return None
+    if client is None:
+        return None
+    if client.secret is None:  # client is not confidential
+        return None
+    if client.grant_type != GrantType.client_credentials:  # client not allowed to create users
+        return None
+
+    if not hmac.compare_digest(client.secret, client_secret):
+        return None
+
+    return principals_for_auth_client(client)
+
+
+def principals_for_auth_client(client):
+    """
+    Return the list of additional principles for an auth client
+
+    :type client: h.models.AuthClient
+    :rtype: list
+    """
+
+    principals = set()
+
+    principals.add('auth_client:{authority}'.format(authority=client.authority))
+    principals.add('authority:{authority}'.format(authority=client.authority))
+
+    return list(principals)
+
+
 def request_auth_client(request):
     """
+    DEPRECATED
     Locate a matching AuthClient record in the database.
 
     :param request: the request object


### PR DESCRIPTION
I wanted to share a partial approach for extending our authentication policies to bring `auth_client` authentication into the fold instead of handling it at the view level.

If I am on this branch, and have generated some `client_credentials` in my local `h` instance (for the `foobar.org` authority), I can get into the shell and run:

```
from h.auth import util
# Import my new policy that extends pyramid's BasicAuthAuthenticationPolicy
from h.auth.policy import AuthClientPolicy

# Base64-encoded CLIENT_ID, CLIENT_SECRET registered with my local `h`
request.headers['Authorization'] = "Basic MDQ0NjVhYWEtOGY3My0xMWU4LTkxY2EtOGJhMTE3NDJiMjQwOlcwaDN1cmtsbE00UjlYcE9GZjQyWUlhQ0Y2cEJLYkZTWDZ0SjcyR0tRYm8="
# `check` callback looks up auth_client in DB
basic = AuthClientPolicy(check=util.check_auth_client)
```

The above sets an `Authorization` header on the request (getting that to work probably represents 50% of the time invested on this!) and instantiates my new auth policy with a callback that reproduces the logic for verifying an auth_client against the database.

Now, I can:

```
>>> basic.effective_principals(request)
['system.Everyone', 'system.Authenticated', '04465aaa-8f73-11e8-91ca-8ba11742b240', 'auth_client:foobar.org', 'authority:foobar.org']
```

Note here that I've added a couple of principals (you can see this in the code), and that the "username" (CLIENT_ID) is in the principals, _and_ the request is considered "authenticated" (`system.Authenticated`), but, ta-da:

```
>>> basic.authenticated_userid(request)
>>>
```

No authenticated user! For now, you can do:

```
>>> basic.unauthenticated_userid(request)
>>> '04465aaa-8f73-11e8-91ca-8ba11742b240'
```

and you'll get the CLIENT_ID. For now I think this is OK.

I tracked things down, and our app won't set `request.user` if `request.authenticated_userid` isn't set. This is also ideal. (Took me a while to track down where this happens: `h.accounts.__init__`.

None of this is hooked up or tested at all, but I wanted to get eyes on it in case I'm doing something daft.

In summary: this auth policy gives us the ability to have an honest-to-god Pyramid Authenticated request, but one with out an `authenticated_userid` or a `user` attached to it. I'm hopeful this will give us the "hooks" we need to build useful things for view_configs to do the right kind of authorization.

Of course, there's work to be done still to integrate this into our existing auth policies and figure out the flow.