### PR TITLE
Allow tests to be run against Python 3.7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ test: node_modules/.uptodate
 
 .PHONY: test-py3
 test-py3: node_modules/.uptodate
-	tox -e py36 -- tests/h/
+	tox -e py3 -- tests/h/
 
 .PHONY: lint
 lint: .pydeps

--- a/tox.ini
+++ b/tox.ini
@@ -44,7 +44,7 @@ passenv =
 commands = pytest {posargs:tests/functional/}
 
 [testenv:functional-py3]
-basepython = python3.6
+basepython = python3
 skip_install = true
 deps =
     pytest


### PR DESCRIPTION
Make unit and functional tests use the default version of Python 3 in
the current environment rather than requiring Python 3.6 specifically.
On Travis and Jenkins this will still be Python 3.6. For local
development this may be Python 3.7 or newer, if that is what is
installed.