### PR TITLE
Remove use of elasticseach6 feature flags

### DIFF
--- a/h/search/core.py
+++ b/h/search/core.py
@@ -35,10 +35,7 @@ class Search(object):
     """
     def __init__(self, request, separate_replies=False, stats=None, _replies_limit=200):
         self.request = request
-        if self.request.feature('search_es6'):
-            self.es = request.es6
-        else:
-            self.es = request.es
+        self.es = request.es6
         self.separate_replies = separate_replies
         self.stats = stats
         self._replies_limit = _replies_limit

--- a/h/services/rename_user.py
+++ b/h/services/rename_user.py
@@ -91,10 +91,7 @@ def make_indexer(request):
             return
 
         request.tm.commit()
-        if request.feature("index_es6"):
-            indexer = index.BatchIndexer(request.db, request.es6, request)
-            indexer.index(ids)
-        indexer = index.BatchIndexer(request.db, request.es, request)
+        indexer = index.BatchIndexer(request.db, request.es6, request)
         indexer.index(ids)
     return _reindex
 

--- a/h/tasks/indexer.py
+++ b/h/tasks/indexer.py
@@ -12,18 +12,10 @@ log = get_task_logger(__name__)
 def add_annotation(id_):
     annotation = storage.fetch_annotation(celery.request.db, id_)
     if annotation:
-        index(celery.request.es, annotation, celery.request)
-
-        if celery.request.feature('index_es6'):
-            index(celery.request.es6, annotation, celery.request)
+        index(celery.request.es6, annotation, celery.request)
 
         # If a reindex is running at the moment, add annotation to the new index
         # as well.
-        future_index = _current_reindex_new_name(celery.request, 'reindex.new_index')
-        if future_index is not None:
-            index(celery.request.es, annotation, celery.request,
-                  target_index=future_index)
-
         future_es6_index = _current_reindex_new_name(celery.request, 'reindex.new_es6_index')
         if future_es6_index is not None:
             index(celery.request.es6, annotation, celery.request,
@@ -35,17 +27,10 @@ def add_annotation(id_):
 
 @celery.task
 def delete_annotation(id_):
-    delete(celery.request.es, id_)
-
-    if celery.request.feature('index_es6'):
-        delete(celery.request.es6, id_)
+    delete(celery.request.es6, id_)
 
     # If a reindex is running at the moment, delete annotation from the
     # new index as well.
-    future_index = _current_reindex_new_name(celery.request, 'reindex.new_index')
-    if future_index is not None:
-        delete(celery.request.es, id_, target_index=future_index)
-
     future_es6_index = _current_reindex_new_name(celery.request, 'reindex.new_es6_index')
     if future_es6_index is not None:
         delete(celery.request.es6, id_, target_index=future_es6_index)
@@ -55,16 +40,10 @@ def delete_annotation(id_):
 def reindex_user_annotations(userid):
     ids = [a.id for a in celery.request.db.query(models.Annotation.id).filter_by(userid=userid)]
 
-    indexer = BatchIndexer(celery.request.db, celery.request.es, celery.request)
+    indexer = BatchIndexer(celery.request.db, celery.request.es6, celery.request)
     errored = indexer.index(ids)
     if errored:
-        log.warning('Failed to re-index annotations %s', errored)
-
-    if celery.request.feature('index_es6'):
-        indexer = BatchIndexer(celery.request.db, celery.request.es6, celery.request)
-        errored = indexer.index(ids)
-        if errored:
-            log.warning('Failed to re-index annotations into ES6 %s', errored)
+        log.warning('Failed to re-index annotations into ES6 %s', errored)
 
 
 def _current_reindex_new_name(request, new_index_setting_name):

--- a/tests/h/search/core_test.py
+++ b/tests/h/search/core_test.py
@@ -124,9 +124,7 @@ class TestSearch(object):
         assert result.reply_ids == []
 
     def test_it_passes_es_version_to_builder(self, pyramid_request, Builder):
-        client = pyramid_request.es
-        if pyramid_request.feature('search_es6'):
-            client = pyramid_request.es6
+        client = pyramid_request.es6
 
         search.Search(pyramid_request)
 
@@ -246,9 +244,7 @@ class TestSearchWithSeparateReplies(object):
         assert oldest_reply.id not in result.reply_ids
 
 
-@pytest.fixture(params=['es1', 'es6'])
-def pyramid_request(request, pyramid_request, es_client, es6_client):
-    pyramid_request.es = es_client
+@pytest.fixture
+def pyramid_request(request, pyramid_request, es6_client):
     pyramid_request.es6 = es6_client
-    pyramid_request.feature.flags["search_es6"] = request.param == 'es6'
     return pyramid_request

--- a/tests/h/search/query_test.py
+++ b/tests/h/search/query_test.py
@@ -652,11 +652,9 @@ class TestUsersAggregation(object):
         assert count_pc == 2
 
 
-@pytest.fixture(params=['es1', 'es6'])
-def pyramid_request(request, pyramid_request, es_client, es6_client):
-    pyramid_request.es = es_client
+@pytest.fixture
+def pyramid_request(request, pyramid_request, es6_client):
     pyramid_request.es6 = es6_client
-    pyramid_request.feature.flags['search_es6'] = request.param == 'es6'
     return pyramid_request
 
 

--- a/tests/h/services/rename_user_test.py
+++ b/tests/h/services/rename_user_test.py
@@ -123,9 +123,7 @@ class TestMakeIndexer(object):
         indexer([1, 2, 3])
 
         batch_indexer = index.BatchIndexer.return_value
-        assert batch_indexer.index.call_count == 2
-        batch_indexer.index.assert_any_call([1, 2, 3])
-        index.BatchIndexer.assert_any_call(req.db, req.es, req)
+        batch_indexer.index.assert_called_once_with([1, 2, 3])
         index.BatchIndexer.assert_any_call(req.db, req.es6, req)
 
     def test_it_skips_indexing_when_no_ids_given(self, req, index):
@@ -138,7 +136,6 @@ class TestMakeIndexer(object):
     @pytest.fixture
     def req(self, pyramid_request):
         pyramid_request.tm = mock.MagicMock()
-        pyramid_request.es = mock.MagicMock()
         pyramid_request.es6 = mock.MagicMock()
         return pyramid_request
 

--- a/tests/h/tasks/indexer_test.py
+++ b/tests/h/tasks/indexer_test.py
@@ -36,7 +36,6 @@ class TestAddAnnotation(object):
 
         indexer.add_annotation(id_)
 
-        index.assert_any_call(celery.request.es, annotation, celery.request)
         index.assert_any_call(celery.request.es6, annotation, celery.request)
 
     def test_it_skips_indexing_when_annotation_cannot_be_loaded(self, fetch_annotation, index, celery):
@@ -47,32 +46,22 @@ class TestAddAnnotation(object):
         assert index.called is False
 
     def test_during_reindex_adds_to_current_index(self, fetch_annotation, annotation, index, celery, settings_service):
-        settings_service.put('reindex.new_index', 'hypothesis-abcdef123')
         settings_service.put('reindex.new_es6_index', 'hypothesis-xyz123')
         fetch_annotation.return_value = annotation
 
         indexer.add_annotation('test-annotation-id')
 
-        index.assert_any_call(celery.request.es,
-                              annotation,
-                              celery.request,
-                              target_index='hypothesis-abcdef123')
         index.assert_any_call(celery.request.es6,
                               annotation,
                               celery.request,
                               target_index='hypothesis-xyz123')
 
     def test_during_reindex_adds_to_new_index(self, fetch_annotation, annotation, index, celery, settings_service):
-        settings_service.put('reindex.new_index', 'hypothesis-abcdef123')
         settings_service.put('reindex.new_es6_index', 'hypothesis-xyz123')
         fetch_annotation.return_value = annotation
 
         indexer.add_annotation('test-annotation-id')
 
-        index.assert_any_call(celery.request.es,
-                              annotation,
-                              celery.request,
-                              target_index='hypothesis-abcdef123')
         index.assert_any_call(celery.request.es6,
                               annotation,
                               celery.request,
@@ -115,18 +104,13 @@ class TestDeleteAnnotation(object):
         id_ = 'test-annotation-id'
         indexer.delete_annotation(id_)
 
-        delete.assert_any_call(celery.request.es, id_)
         delete.assert_any_call(celery.request.es6, id_)
 
     def test_during_reindex_deletes_from_current_index(self, delete, celery, settings_service):
-        settings_service.put('reindex.new_index', 'hypothesis-abcdef123')
         settings_service.put('reindex.new_es6_index', 'hypothesis-xyz123')
 
         indexer.delete_annotation('test-annotation-id')
 
-        delete.assert_any_call(celery.request.es,
-                               'test-annotation-id',
-                               target_index='hypothesis-abcdef123')
         delete.assert_any_call(celery.request.es6, 'test-annotation-id',
                                target_index='hypothesis-xyz123')
 
@@ -136,9 +120,6 @@ class TestDeleteAnnotation(object):
 
         indexer.delete_annotation('test-annotation-id')
 
-        delete.assert_any_call(celery.request.es,
-                               'test-annotation-id',
-                               target_index='hypothesis-abcdef123')
         delete.assert_any_call(celery.request.es6,
                                'test-annotation-id',
                                target_index='hypothesis-xyz123')
@@ -155,7 +136,6 @@ class TestReindexUserAnnotations(object):
 
         indexer.reindex_user_annotations(userid)
 
-        batch_indexer.assert_any_call(celery.request.db, celery.request.es, celery.request)
         batch_indexer.assert_any_call(celery.request.db, celery.request.es6, celery.request)
 
     def test_it_reindexes_users_annotations(self, batch_indexer, annotation_ids):
@@ -192,7 +172,6 @@ def celery(patch, pyramid_request):
 
 @pytest.fixture
 def pyramid_request(pyramid_request):
-    pyramid_request.es = mock.Mock()
     pyramid_request.es6 = mock.Mock()
     return pyramid_request
 


### PR DESCRIPTION
This is part of es6 transition cleanup https://github.com/hypothesis/product-backlog/issues/608.  This will remove using elasticsearch6 only when feature flags are enabled and make the switch permanent.