### PR TITLE
Index user rename in es6 when index_es6 is set

### DIFF
--- a/h/services/rename_user.py
+++ b/h/services/rename_user.py
@@ -91,6 +91,9 @@ def make_indexer(request):
             return
 
         request.tm.commit()
+        if request.feature("index_es6"):
+            indexer = index.BatchIndexer(request.db, request.es6, request)
+            indexer.index(ids)
         indexer = index.BatchIndexer(request.db, request.es, request)
         indexer.index(ids)
     return _reindex

--- a/tests/h/services/rename_user_test.py
+++ b/tests/h/services/rename_user_test.py
@@ -123,7 +123,10 @@ class TestMakeIndexer(object):
         indexer([1, 2, 3])
 
         batch_indexer = index.BatchIndexer.return_value
-        batch_indexer.index.assert_called_once_with([1, 2, 3])
+        assert batch_indexer.index.call_count == 2
+        batch_indexer.index.assert_any_call([1, 2, 3])
+        index.BatchIndexer.assert_any_call(req.db, req.es, req)
+        index.BatchIndexer.assert_any_call(req.db, req.es6, req)
 
     def test_it_skips_indexing_when_no_ids_given(self, req, index):
         indexer = make_indexer(req)
@@ -136,6 +139,7 @@ class TestMakeIndexer(object):
     def req(self, pyramid_request):
         pyramid_request.tm = mock.MagicMock()
         pyramid_request.es = mock.MagicMock()
+        pyramid_request.es6 = mock.MagicMock()
         return pyramid_request
 
     @pytest.fixture


### PR DESCRIPTION
Rename the user in the elasticsearch6 cluster when the index_es6
feature flag is enabled.