### PR TITLE
Add single functional test for creating a private group

### DIFF
--- a/tests/functional/api/__init__.py
+++ b/tests/functional/api/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals

--- a/tests/functional/api/test_groups.py
+++ b/tests/functional/api/test_groups.py
@@ -8,6 +8,21 @@ import pytest
 @pytest.mark.functional
 class TestGroupAPI(object):
 
+    def test_create_group(self, app, user_with_token):
+        """Test a request to create a private group through the API"""
+
+        user, token = user_with_token
+        headers = {'Authorization': str('Bearer {}'.format(token.value))}
+
+        group = {
+            'name': 'My Group'
+        }
+
+        res = app.post_json('/api/groups', group, headers=headers)
+
+        assert res.status_code == 200
+        assert res.json['name'] == 'My Group'
+
     def test_leave_group(self, app, group, group_member_with_token):
         """Test a request to leave a group through the API."""
 
@@ -44,3 +59,12 @@ def group_member_with_token(group_member, db_session, factories):
     db_session.add(token)
     db_session.commit()
     return (group_member, token)
+
+
+@pytest.fixture
+def user_with_token(db_session, factories):
+    user = factories.User()
+    token = factories.DeveloperToken(userid=user.userid)
+    db_session.add(token)
+    db_session.commit()
+    return (user, token)


### PR DESCRIPTION
We need more functional tests for our API endpoints. This PR represents the first step in this; it adds a single, simple functional test (a success-path test) for the recently-added create-group endpoint. It also moves groups-API tests under a subdirectory, `api`, as a starting point for a light reorg of these test modules.

It is my hope that having increased functional tests for our API endpoints will make our services more reliable and let us rest a little easier.

This is relevant to LMS because we are adding a number of API endpoints to support the project and extending how `auth_client` authentication works.

Basically:

* Does this look generally OK?
* Am I okay to add a bunch of functional tests? I know there has been some notion of "they run slow" in the past, but the entire suite runs in 11 seconds for me locally; I'll see how long they take to run on CI

We currently have zero tests for any `auth_client`-auth'd endpoint; that's probably my next step here.