### PR TITLE
Expand group API Functional Tests

### DIFF
--- a/tests/functional/api/test_groups.py
+++ b/tests/functional/api/test_groups.py
@@ -3,6 +3,10 @@
 from __future__ import unicode_literals
 
 import pytest
+import base64
+
+
+from h.models.auth_client import GrantType
 
 
 @pytest.mark.functional
@@ -24,10 +28,81 @@ class TestCreateGroup(object):
 
         assert res.status_code == 400
 
+
+@pytest.mark.functional
+class TestAddMember(object):
+
+    def test_it_returns_http_204_when_successful(self, app, user, group, auth_client_header):
+        res = app.post_json("/api/groups/{pubid}/members/{userid}".format(pubid=group.pubid, userid=user.userid),
+                            headers=auth_client_header)
+
+        assert res.status_code == 204
+
+    def test_it_adds_member_to_group(self, app, user, group, auth_client_header):
+        app.post_json("/api/groups/{pubid}/members/{userid}".format(pubid=group.pubid, userid=user.userid),
+                            headers=auth_client_header)
+
+        assert user in group.members
+
+    def test_it_is_idempotent(self, app, user, group, auth_client_header):
+        app.post_json("/api/groups/{pubid}/members/{userid}".format(pubid=group.pubid, userid=user.userid),
+                            headers=auth_client_header)
+
+        res = app.post_json("/api/groups/{pubid}/members/{userid}".format(pubid=group.pubid, userid=user.userid),
+                            headers=auth_client_header)
+
+        assert user in group.members
+        assert res.status_code == 204
+
+    def test_it_returns_404_if_authority_mismatch_on_user(self, app, factories, group, auth_client_header):
+        user = factories.User(authority="somewhere-else.org")
+        res = app.post_json("/api/groups/{pubid}/members/{userid}".format(pubid=group.pubid, userid=user.userid),
+                            headers=auth_client_header,
+                            expect_errors=True)
+
+        assert res.status_code == 404
+
+    def test_it_returns_404_if_authority_mismatch_on_group(self, app, factories, user, auth_client_header):
+        group = factories.Group(authority="somewhere-else.org")
+        res = app.post_json("/api/groups/{pubid}/members/{userid}".format(pubid=group.pubid, userid=user.userid),
+                            headers=auth_client_header,
+                            expect_errors=True)
+
+        assert res.status_code == 404
+
+    def test_it_returns_403_if_missing_auth(self, app, user, group):
+        res = app.post_json("/api/groups/{pubid}/members/{userid}".format(pubid=group.pubid, userid=user.userid),
+                            expect_errors=True)
+
+        assert res.status_code == 403
+
+    def test_it_returns_403_with_token_auth(self, app, token_auth_header, user, group):
+        res = app.post_json("/api/groups/{pubid}/members/{userid}".format(pubid=group.pubid, userid=user.userid),
+                            headers=token_auth_header,
+                            expect_errors=True)
+
+        assert res.status_code == 403
+
     @pytest.fixture
-    def token_auth_header(self, user_with_token):
-        user, token = user_with_token
-        return {'Authorization': str('Bearer {}'.format(token.value))}
+    def auth_client(self, db_session, factories):
+        auth_client = factories.ConfidentialAuthClient(authority='example.com',
+                                                       grant_type=GrantType.client_credentials)
+        db_session.add(auth_client)
+        db_session.commit()
+        return auth_client
+
+    @pytest.fixture
+    def auth_client_header(self, auth_client):
+        user_pass = "{client_id}:{secret}".format(client_id=auth_client.id, secret=auth_client.secret)
+        encoded = base64.standard_b64encode(user_pass.encode('utf-8'))
+        return {'Authorization': "Basic {creds}".format(creds=encoded.decode('ascii'))}
+
+    @pytest.fixture
+    def user(self, db_session, factories):
+        user = factories.User()
+        db_session.add(user)
+        db_session.commit()
+        return user
 
 
 @pytest.mark.functional
@@ -77,3 +152,9 @@ def user_with_token(db_session, factories):
     db_session.add(token)
     db_session.commit()
     return (user, token)
+
+
+@pytest.fixture
+def token_auth_header(user_with_token):
+    user, token = user_with_token
+    return {'Authorization': str('Bearer {}'.format(token.value))}

--- a/tests/functional/api/test_groups.py
+++ b/tests/functional/api/test_groups.py
@@ -6,25 +6,34 @@ import pytest
 
 
 @pytest.mark.functional
-class TestGroupAPI(object):
+class TestCreateGroup(object):
 
-    def test_create_group(self, app, user_with_token):
-        """Test a request to create a private group through the API"""
-
-        user, token = user_with_token
-        headers = {'Authorization': str('Bearer {}'.format(token.value))}
-
+    def test_it_returns_http_200_with_valid_payload(self, app, token_auth_header):
         group = {
             'name': 'My Group'
         }
 
-        res = app.post_json('/api/groups', group, headers=headers)
+        res = app.post_json('/api/groups', group, headers=token_auth_header)
 
         assert res.status_code == 200
-        assert res.json['name'] == 'My Group'
 
-    def test_leave_group(self, app, group, group_member_with_token):
-        """Test a request to leave a group through the API."""
+    def test_it_returns_http_400_with_invalid_payload(self, app, token_auth_header):
+        group = {}
+
+        res = app.post_json('/api/groups', group, headers=token_auth_header, expect_errors=True)
+
+        assert res.status_code == 400
+
+    @pytest.fixture
+    def token_auth_header(self, user_with_token):
+        user, token = user_with_token
+        return {'Authorization': str('Bearer {}'.format(token.value))}
+
+
+@pytest.mark.functional
+class TestRemoveMember(object):
+
+    def test_it_removes_authed_user_from_group(self, app, group, group_member_with_token):
 
         group_member, token = group_member_with_token
         headers = {'Authorization': str('Bearer {}'.format(token.value))}


### PR DESCRIPTION
Depends on #5198 

This PR expands the functional tests for groups endpoints to add `auth_client` request tests and a few more checks for expected HTTP responses.