### PR TITLE
Run lint in Python 3 not 2 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ matrix:
     # Lint backend code
     - env: ACTION=backend-lint
       language: python
-      python: '2.7'
+      python: '3.6'
       script:
         make lint
 


### PR DESCRIPTION
Pylint no longer supports running in Python 2 (but it still does support analyzing Python 2 code, for now, although "some checks might not work"): https://github.com/PyCQA/pylint/issues/1763#issuecomment-387697807