### PR TITLE
Require prospector[with_pyroma] == 1.0

### DIFF
--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -4,7 +4,7 @@ flake8
 flake8-future-import
 honcho
 pep257
-prospector[with_pyroma]
+prospector[with_pyroma] == 1.0 
 pyramid_debugtoolbar
 sphinx
 sphinx_rtd_theme


### PR DESCRIPTION
Currently prospector[with_pyroma] >= 1.0 requires pylint >= 2.0
and 2.7 fails to find a package that matches that criteria thus
our build fails to install dependencies. pylint as of 2.0 has
dropped support for 2.7.