### PR TITLE
Add `clientid` property to `AuthClient` model

### DIFF
--- a/h/util/auth_client.py
+++ b/h/util/auth_client.py
@@ -20,12 +20,9 @@ def split_client(clientid):
     uuid_match = r'[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
     match = re.match(r'^client:(' + uuid_match + r')@(.*)$', clientid)
     if match:
-        client = {
+        return {
             'id': match.groups()[0],
             'authority': match.groups()[1]
         }
-
-        if uuid_match:
-            return client
 
     raise ValueError("{clientid} isn't a valid clientid".format(clientid=clientid))

--- a/h/util/auth_client.py
+++ b/h/util/auth_client.py
@@ -10,13 +10,22 @@ def split_client(clientid):
     For example if userid is u'client:04465aaa-8f73-11e8-91ca-8ba11742b240@hypothes.is' then return
     {'id': u'04465aaa-8f73-11e8-91ca-8ba11742b240', 'authority': u'hypothes.is'}'
 
-    :raises ValueError: if the given clientid isn't a valid clientid
+    :py:attr:`~h.models.user.AuthClient.id` must be a valid Python UUID
+
+    :raises ValueError: if the given clientid isn't a valid clientid or if the
+                        supplied AuthClient.id isn't a valid UUID
 
     """
-    match = re.match(r'^client:([^@]+)@(.*)$', clientid)
+    # Validates substring is a valid python UUID
+    uuid_match = r'[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
+    match = re.match(r'^client:(' + uuid_match + r')@(.*)$', clientid)
     if match:
-        return {
+        client = {
             'id': match.groups()[0],
             'authority': match.groups()[1]
         }
+
+        if uuid_match:
+            return client
+
     raise ValueError("{clientid} isn't a valid clientid".format(clientid=clientid))

--- a/h/util/auth_client.py
+++ b/h/util/auth_client.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+"""Some shared utility functions for manipulating auth_client data."""
+from __future__ import unicode_literals
+import re
+
+
+def split_client(clientid):
+    """Return the ID and authority parts from the given clientid as a dict.
+
+    For example if userid is u'client:04465aaa-8f73-11e8-91ca-8ba11742b240@hypothes.is' then return
+    {'id': u'04465aaa-8f73-11e8-91ca-8ba11742b240', 'authority': u'hypothes.is'}'
+
+    :raises ValueError: if the given clientid isn't a valid clientid
+
+    """
+    match = re.match(r'^client:([^@]+)@(.*)$', clientid)
+    if match:
+        return {
+            'id': match.groups()[0],
+            'authority': match.groups()[1]
+        }
+    raise ValueError("{clientid} isn't a valid clientid".format(clientid=clientid))

--- a/tests/h/models/auth_client_test.py
+++ b/tests/h/models/auth_client_test.py
@@ -27,6 +27,88 @@ class TestAuthClient(object):
         db_session.add(client)
         db_session.flush()
 
+    def test_clientid_filter_by_returns_auth_client(self, factories, db_session):
+        client = AuthClient(grant_type=GrantType.client_credentials, authority="foobar.baz")
+        db_session.add(client)
+        db_session.flush()
+
+        clientid = "client:{id}@{authority}".format(id=client.id, authority=client.authority)
+
+        result = db_session.query(AuthClient).filter_by(clientid=clientid).one()
+
+        assert result.authority == "foobar.baz"
+        assert result.id == client.id
+        assert result.clientid == clientid
+
+    def test_clientid_equals_query_with_invalid_clientid(self, db_session):
+        # This is to ensure that we don't expose the ValueError that could
+        # potentially be thrown by split_clientid.
+
+        result = (db_session.query(AuthClient)
+                  .filter_by(clientid='foobles.org')
+                  .all())
+
+        assert result == []
+
+    def test_clientid_in_query(self, factories, db_session):
+        fred = AuthClient(authority='example.net')
+        alice = AuthClient(authority='foobar.com')
+
+        db_session.add_all([fred, alice])  # not bob
+        db_session.flush()
+
+        result = (db_session.query(AuthClient)
+                  .filter(AuthClient.clientid.in_([fred.clientid,
+                                                   alice.clientid,
+                                                   'client:04465aaa-8f73-11e8-91ca-8ba11742b240@nonexistent.foo']))
+                  .all())
+
+        assert len(result) == 2
+        assert fred in result
+        assert alice in result
+
+    def test_it_does_not_raise_when_invalid_clientid_format_in_in_query(self, db_session):
+        # This is to ensure that we don't expose the ValueError that could
+        # potentially be thrown by split_client.
+
+        fred = AuthClient(authority='example.net')
+        db_session.add(fred)
+        db_session.flush()
+
+        result = (db_session.query(AuthClient)
+                  .filter(AuthClient.clientid.in_([fred.clientid,
+                                                  'invalid']))
+                  .all())
+
+        assert len(result) == 1
+        assert fred in result
+
+    def test_it_does_not_raise_when_invalid_uuid_in_in_query(self, db_session):
+        # This is to ensure that we don't expose the ValueError that could
+        # potentially be thrown by split_client.
+
+        fred = AuthClient(authority='example.net')
+        db_session.add(fred)
+        db_session.flush()
+
+        result = (db_session.query(AuthClient)
+                  .filter(AuthClient.clientid.in_([fred.clientid,
+                                                  'client:foo@bar.com']))
+                  .all())
+
+        assert len(result) == 1
+        assert fred in result
+
+    def test_it_doest_not_raise_when_in_query_only_contains_invalid_clientid(self, db_session):
+        # This is to ensure that we don't expose the ValueError that could
+        # potentially be thrown by split_user.
+
+        result = (db_session.query(AuthClient)
+                  .filter(AuthClient.clientid.in_(['client:foobles@baz']))
+                  .all())
+
+        assert result == []
+
     @pytest.fixture
     def client(self, db_session):
         client = AuthClient(authority='example.com')

--- a/tests/h/util/auth_client_test.py
+++ b/tests/h/util/auth_client_test.py
@@ -6,11 +6,16 @@ import pytest
 from h.util import auth_client as client_util
 
 
-def test_split_client():
-    parts = client_util.split_client("client:04465aaa-8f73-11e8-91ca-8ba11742b240@hypothes.is")
-    assert parts == {'id': '04465aaa-8f73-11e8-91ca-8ba11742b240', 'authority': 'hypothes.is'}
+class TestSplitClient(object):
 
+    def test_it_splits_valid_client_id(self):
+        parts = client_util.split_client("client:04465aaa-8f73-11e8-91ca-8ba11742b240@hypothes.is")
+        assert parts == {'id': '04465aaa-8f73-11e8-91ca-8ba11742b240', 'authority': 'hypothes.is'}
 
-def test_split_client_no_match():
-    with pytest.raises(ValueError):
-        client_util.split_client("donkeys")
+    def test_it_raises_if_clientid_format_invalid(self):
+        with pytest.raises(ValueError):
+            client_util.split_client("donkeys")
+
+    def test_it_raises_if_client_id_is_invalid_uuid(self):
+        with pytest.raises(ValueError):
+            client_util.split_client("client:foobar@whatever.baz")

--- a/tests/h/util/auth_client_test.py
+++ b/tests/h/util/auth_client_test.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+import pytest
+
+from h.util import auth_client as client_util
+
+
+def test_split_client():
+    parts = client_util.split_client("client:04465aaa-8f73-11e8-91ca-8ba11742b240@hypothes.is")
+    assert parts == {'id': '04465aaa-8f73-11e8-91ca-8ba11742b240', 'authority': 'hypothes.is'}
+
+
+def test_split_client_no_match():
+    with pytest.raises(ValueError):
+        client_util.split_client("donkeys")


### PR DESCRIPTION
As we expand Authentication, and by that token (heh), have needs for additional principals and `unauthenticated_userid`s and the like, it becomes more ideal to have a normalized and consistent way of representing an `AuthClient` as an entity similar to a user. Ergo, the notion of having a principal and/or an `unauthenticated_userid` be something like `client:{uuid}@{authority}`. (Note that `authenticated_userid`s would _always_ be real system userids, however).

This PR adds a new hybrid property, `clientid` to the `AuthClient` model based very strongly on the `h.models.user.User.userid` property. It also adds `h.util.auth_client` with a `split_client` function (again, very strongly modeled on `h.util.user.split_user` but also tests for a valid UUID).

This will make it easier to manage the more full-fledged Authentication/Authorization for auth_clients that we're moving toward.