### PR TITLE
Change search cli to only talk to es6

### DIFF
--- a/h/cli/commands/search.py
+++ b/h/cli/commands/search.py
@@ -14,27 +14,20 @@ def search():
 
 
 @search.command()
-@click.option('--es6', is_flag=True, help='Reindex into the Elasticsearch 6 cluster')
 @click.pass_context
-def reindex(ctx, es6):
+def reindex(ctx):
     """
     Reindex all annotations.
 
     Creates a new search index from the data in PostgreSQL and atomically
     updates the index alias. This requires that the index is aliased already,
     and will raise an error if it is not.
-
-    Reindex into the Elasticsearch 1 cluster by default, unless the `--es6`
-    flag is set.
     """
     os.environ['ELASTICSEARCH_CLIENT_TIMEOUT'] = '30'
 
     request = ctx.obj['bootstrap']()
 
-    if es6:
-        es_client = request.es6
-    else:
-        es_client = request.es
+    es_client = request.es6
 
     es_server_version = es_client.conn.info()['version']['number']
     click.echo('reindexing into Elasticsearch {} cluster'.format(es_server_version))
@@ -67,6 +60,6 @@ def _update_settings_old(ctx):
     request = ctx.obj['bootstrap']()
 
     try:
-        config.update_index_settings(request.es)
+        config.update_index_settings(request.es6)
     except RuntimeError as e:
         raise click.ClickException(str(e))

--- a/h/cli/commands/search.py
+++ b/h/cli/commands/search.py
@@ -39,24 +39,12 @@ def reindex(ctx):
 @click.pass_context
 def update_settings(ctx):
     """
-    Attempt to update mappings and settings in all clusters.
+    Attempt to update mappings and settings in elasticsearch.
 
     Attempts to update mappings and index settings. This may fail if the
     pending changes to mappings are not compatible with the current index. In
     this case you will likely need to reindex.
     """
-    _update_settings_old(ctx)
-
-
-def _update_settings_old(ctx):
-    """
-    Attempt to update mappings and settings in the old cluster.
-
-    Attempts to update mappings and index settings. This may fail if the
-    pending changes to mappings are not compatible with the current index. In
-    this case you will likely need to reindex.
-    """
-
     request = ctx.obj['bootstrap']()
 
     try:

--- a/tests/h/cli/commands/search_test.py
+++ b/tests/h/cli/commands/search_test.py
@@ -19,14 +19,6 @@ class TestReindexCommand(object):
 
         assert result.exit_code == 0
         reindex.assert_called_once_with(pyramid_request.db,
-                                        pyramid_request.es,
-                                        pyramid_request)
-
-    def test_calls_reindex_with_es6_client(self, cli, cliconfig, pyramid_request, reindex):
-        result = cli.invoke(search.reindex, ['--es6'], obj=cliconfig)
-
-        assert result.exit_code == 0
-        reindex.assert_called_once_with(pyramid_request.db,
                                         pyramid_request.es6,
                                         pyramid_request)
 
@@ -41,7 +33,7 @@ class TestUpdateSettingsCommand(object):
         result = cli.invoke(search.update_settings, [], obj=cliconfig)
 
         assert result.exit_code == 0
-        update_index_settings.assert_called_once_with(pyramid_request.es)
+        update_index_settings.assert_called_once_with(pyramid_request.es6)
 
     def test_handles_runtimeerror(self, cli, cliconfig, update_index_settings):
         update_index_settings.side_effect = RuntimeError("asplode!")
@@ -58,6 +50,5 @@ class TestUpdateSettingsCommand(object):
 
 @pytest.fixture
 def cliconfig(pyramid_request):
-    pyramid_request.es = mock.create_autospec(Client, spec_set=True, instance=True)
     pyramid_request.es6 = mock.create_autospec(Client, spec_set=True, instance=True)
     return {'bootstrap': mock.Mock(return_value=pyramid_request)}


### PR DESCRIPTION
Remove es6 flag from reindex command & corresponding test.

Replace any remaining refferences of es with es6 so that all search
commands now talk only to elasticsearch6.