### PR TITLE
Remove use of request.es and es_client fixture

### DIFF
--- a/h/cli/commands/init.py
+++ b/h/cli/commands/init.py
@@ -25,7 +25,6 @@ def init(ctx):
 
     _init_db(request.registry.settings)
     _init_search(request.registry.settings)
-    _init_search_es6(request.registry.settings)
 
 
 def _init_db(settings):
@@ -43,13 +42,6 @@ def _init_db(settings):
 
 
 def _init_search(settings):
-    client = search.get_client(settings)
-
-    log.info("initializing search index")
-    search.init(client)
-
-
-def _init_search_es6(settings):
     client = search.get_es6_client(settings)
 
     log.info("initializing ES6 search index")

--- a/h/cli/commands/move_uri.py
+++ b/h/cli/commands/move_uri.py
@@ -54,7 +54,7 @@ def move_uri(ctx, old, new):
         docuri.uri = new
 
     if annotations:
-        indexer = BatchIndexer(request.db, request.es, request)
+        indexer = BatchIndexer(request.db, request.es6, request)
         ids = [a.id for a in annotations]
         indexer.index(ids)
 

--- a/h/cli/commands/normalize_uris.py
+++ b/h/cli/commands/normalize_uris.py
@@ -125,7 +125,7 @@ def _normalize_annotations_window(session, window):
 
 
 def _reindex_annotations(request, ids):
-    indexer = index.BatchIndexer(request.db, request.es, request)
+    indexer = index.BatchIndexer(request.db, request.es6, request)
 
     for _ in range(2):
         ids = indexer.index(ids)

--- a/h/config.py
+++ b/h/config.py
@@ -119,7 +119,7 @@ def configure(environ=None, settings=None):
         logging.getLogger('sqlalchemy.engine').setLevel(level)
 
     # Add ES logging filter to filter out ReadTimeout warnings
-    es_logger = logging.getLogger('elasticsearch1')
+    es_logger = logging.getLogger('elasticsearch')
     es_logger.addFilter(ExceptionFilter((("ReadTimeout", "WARNING"),)))
 
     return Configurator(settings=settings)

--- a/h/search/__init__.py
+++ b/h/search/__init__.py
@@ -17,6 +17,7 @@ __all__ = (
     'TagsAggregation',
     'UsersAggregation',
     'get_client',
+    'get_es6_client',
     'init',
     'connect'
 )

--- a/h/search/client.py
+++ b/h/search/client.py
@@ -17,10 +17,10 @@ class Client(object):
 
     :param host: Elasticsearch host URL
     :param index: index name
-    :param elasticsearch: Elasticsearch library defaulted to elasticsearch1
+    :param elasticsearch: Elasticsearch library defaulted to elasticsearch
     """
 
-    def __init__(self, host, index, elasticsearch=elasticsearch1, **kwargs):
+    def __init__(self, host, index, elasticsearch=elasticsearch, **kwargs):
         self._version = elasticsearch.__version__
         self._index = index
         self._conn = elasticsearch.Elasticsearch([host],
@@ -89,7 +89,7 @@ def get_client(settings):
                         'es')
         kwargs['http_auth'] = auth
         kwargs['connection_class'] = elasticsearch1.RequestsHttpConnection
-    return Client(host, index, **kwargs)
+    return Client(host, index, elasticsearch=elasticsearch1, **kwargs)
 
 
 def get_es6_client(settings):
@@ -99,4 +99,4 @@ def get_es6_client(settings):
     kwargs = _get_client_settings(settings)
     # nb. No AWS credentials here because we assume that if using AWS-managed
     # ES, the cluster lives inside a VPC.
-    return Client(host, index, elasticsearch=elasticsearch, **kwargs)
+    return Client(host, index, **kwargs)

--- a/h/search/core.py
+++ b/h/search/core.py
@@ -4,7 +4,7 @@ import logging
 from collections import namedtuple
 from contextlib import contextmanager
 
-from elasticsearch1.exceptions import ConnectionTimeout
+from elasticsearch.exceptions import ConnectionTimeout
 
 from h.search import query
 

--- a/h/search/index.py
+++ b/h/search/index.py
@@ -8,7 +8,7 @@ import time
 from collections import namedtuple
 
 import sqlalchemy as sa
-from elasticsearch1 import helpers as es_helpers
+from elasticsearch import helpers as es_helpers
 from sqlalchemy.orm import subqueryload
 
 from h import models

--- a/tests/common/fixtures/__init__.py
+++ b/tests/common/fixtures/__init__.py
@@ -1,15 +1,12 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from tests.common.fixtures.elasticsearch import es_client, es6_client, es_connect
+from tests.common.fixtures.elasticsearch import es6_client, es_connect
 from tests.common.fixtures.elasticsearch import init_elasticsearch
-from tests.common.fixtures.elasticsearch import delete_all_elasticsearch_documents
 
 
 __all__ = (
-    "es_client",
     "es6_client",
     "es_connect",
     "init_elasticsearch",
-    "delete_all_elasticsearch_documents",
 )

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -8,15 +8,16 @@ import pytest
 from webtest import TestApp
 
 from h._compat import text_type
-from tests.common.fixtures import es_client  # noqa: F401
+from tests.common.fixtures import es6_client  # noqa: F401
 from tests.common.fixtures import init_elasticsearch  # noqa: F401
-from tests.common.fixtures import delete_all_elasticsearch_documents  # noqa: F401
 from tests.common.fixtures.elasticsearch import ELASTICSEARCH_HOST
+from tests.common.fixtures.elasticsearch import ELASTICSEARCH_URL
 from tests.common.fixtures.elasticsearch import ELASTICSEARCH_INDEX
 
 
 TEST_SETTINGS = {
     'es.host': ELASTICSEARCH_HOST,
+    'es.url': ELASTICSEARCH_URL,
     'es.index': ELASTICSEARCH_INDEX,
     'h.app_url': 'http://example.com',
     'h.authority': 'example.com',
@@ -78,7 +79,7 @@ def pyramid_app():
 # Always unconditionally wipe the Elasticsearch index after every functional
 # test.
 @pytest.fixture(autouse=True)  # noqa: F811
-def always_delete_all_elasticsearch_documents(delete_all_elasticsearch_documents):
+def always_delete_all_elasticsearch_documents(es6_client):
     pass
 
 

--- a/tests/h/cli/commands/init_test.py
+++ b/tests/h/cli/commands/init_test.py
@@ -49,13 +49,11 @@ class TestInitCommand(object):
                                 cliconfig,
                                 search,
                                 pyramid_settings):
-        client = search.get_client.return_value
         es6_client = search.get_es6_client.return_value
 
         result = cli.invoke(init_cli.init, obj=cliconfig)
 
-        search.get_client.assert_called_once_with(pyramid_settings)
-        search.init.assert_any_call(client)
+        search.get_es6_client.assert_called_once_with(pyramid_settings)
         search.init.assert_any_call(es6_client)
         assert result.exit_code == 0
 

--- a/tests/h/cli/commands/normalize_uris_test.py
+++ b/tests/h/cli/commands/normalize_uris_test.py
@@ -179,7 +179,7 @@ def test_it_skips_reindexing_unaltered_annotations(req, index, factories, db_ses
 @pytest.fixture
 def req(pyramid_request):
     pyramid_request.tm = mock.MagicMock()
-    pyramid_request.es = mock.MagicMock()
+    pyramid_request.es6 = mock.MagicMock()
     return pyramid_request
 
 

--- a/tests/h/conftest.py
+++ b/tests/h/conftest.py
@@ -24,9 +24,8 @@ from h import db
 from h import models
 from h.settings import database_url
 from h._compat import text_type
-from tests.common.fixtures import es_client, es6_client, es_connect  # noqa: F401
+from tests.common.fixtures import es6_client, es_connect  # noqa: F401
 from tests.common.fixtures import init_elasticsearch  # noqa: F401
-from tests.common.fixtures import delete_all_elasticsearch_documents  # noqa: F401
 
 TEST_AUTHORITY = 'example.com'
 TEST_DATABASE_URL = database_url(os.environ.get('TEST_DATABASE_URL',

--- a/tests/h/search/client_test.py
+++ b/tests/h/search/client_test.py
@@ -4,23 +4,30 @@ from __future__ import unicode_literals
 
 import pytest
 
-import elasticsearch1
 import elasticsearch
 
-from h.search.client import get_client, get_es6_client
+from h.search.client import get_es6_client
 from h.search.client import Client
-
-
-GET_CLIENTS = (get_client, get_es6_client)
 
 
 class TestClient(object):
 
-    def test_it_sets_the_index_and_conn_properties(self):
+    def test_it_sets_the_index_property(self):
         client = Client(host="http://localhost:9200", index="hypothesis")
 
         assert client.index == "hypothesis"
-        assert client.conn
+        assert client.version == (6, 2, 0)
+        assert isinstance(client.conn, elasticsearch.Elasticsearch)
+
+    def test_it_sets_the_version_property(self):
+        client = Client(host="http://localhost:9200", index="hypothesis")
+
+        assert client.version == (6, 2, 0)
+
+    def test_it_sets_the_conn_property(self):
+        client = Client(host="http://localhost:9200", index="hypothesis")
+
+        assert isinstance(client.conn, elasticsearch.Elasticsearch)
 
     def test_index_is_read_only(self):
         client = Client(host="http://localhost:9200", index="hypothesis")
@@ -34,86 +41,34 @@ class TestClient(object):
         with pytest.raises(AttributeError, match="can't set attribute"):
             client.conn = "changed"
 
-    def test_defaults_to_es1(self):
-        client = Client(host="http://localhost:9200", index="hypothesis")
-
-        assert client.version == (1, 10, 0)
-        assert isinstance(client.conn, elasticsearch1.Elasticsearch)
-
-    def test_uses_es6_when_specified(self):
-        client = Client(
-            host="http://localhost:9200",
-            index="hypothesis",
-            elasticsearch=elasticsearch)
-
-        assert client.version == (6, 2, 0)
-        assert isinstance(client.conn, elasticsearch.Elasticsearch)
-
 
 class TestGetClient(object):
-    @pytest.mark.parametrize('get_client', GET_CLIENTS)
-    def test_initializes_client_with_host(self, settings, get_client, patched_client):
-        get_client(settings)
+    def test_initializes_client_with_host(self, settings, patched_client):
+        get_es6_client(settings)
         args, _ = patched_client.call_args
         assert args[0] == 'search.svc'
 
-    @pytest.mark.parametrize('get_client', GET_CLIENTS)
-    def test_initializes_client_with_index(self, settings, get_client, patched_client):
-        get_client(settings)
+    def test_initializes_client_with_index(self, settings, patched_client):
+        get_es6_client(settings)
         args, _ = patched_client.call_args
         assert args[1] == 'my-index'
 
-    @pytest.mark.parametrize('key,value,settingkey,get_client', [
-        ('max_retries', 7, 'es.client.max_retries', get_client),
-        ('retry_on_timeout', True, 'es.client.retry_on_timeout', get_client),
-        ('timeout', 15, 'es.client.timeout', get_client),
-        ('maxsize', 4, 'es.client_poolsize', get_client),
-        ('max_retries', 7, 'es.client.max_retries', get_es6_client),
-        ('retry_on_timeout', True, 'es.client.retry_on_timeout', get_es6_client),
-        ('timeout', 15, 'es.client.timeout', get_es6_client),
-        ('maxsize', 4, 'es.client_poolsize', get_es6_client),
+    @pytest.mark.parametrize('key,value,settingkey', [
+        ('max_retries', 7, 'es.client.max_retries'),
+        ('retry_on_timeout', True, 'es.client.retry_on_timeout'),
+        ('timeout', 15, 'es.client.timeout'),
+        ('maxsize', 4, 'es.client_poolsize'),
+        ('max_retries', 7, 'es.client.max_retries'),
+        ('retry_on_timeout', True, 'es.client.retry_on_timeout'),
+        ('timeout', 15, 'es.client.timeout'),
+        ('maxsize', 4, 'es.client_poolsize'),
     ])
-    def test_client_configuration(self, settings, get_client, patched_client, key, value, settingkey):
+    def test_client_configuration(self, settings, patched_client, key, value, settingkey):
         settings[settingkey] = value
-        get_client(settings)
+        get_es6_client(settings)
 
         _, kwargs = patched_client.call_args
         assert kwargs[key] == value
-
-    def test_initialises_aws_auth(self, settings, patched_aws_auth):
-        settings.update({'es.aws.access_key_id': 'foo', 'es.aws.secret_access_key': 'bar', 'es.aws.region': 'baz'})
-        get_client(settings)
-
-        patched_aws_auth.assert_called_once_with('foo', 'bar', 'baz', 'es')
-
-    def test_sets_aws_auth(self, settings, patched_client, patched_aws_auth):
-        settings.update({'es.aws.access_key_id': 'foo', 'es.aws.secret_access_key': 'bar', 'es.aws.region': 'baz'})
-        get_client(settings)
-
-        _, kwargs = patched_client.call_args
-        assert kwargs['http_auth'] == patched_aws_auth.return_value
-
-    def test_sets_connection_class_for_aws_auth(self, settings, patched_client):
-        settings.update({'es.aws.access_key_id': 'foo', 'es.aws.secret_access_key': 'bar', 'es.aws.region': 'baz'})
-        get_client(settings)
-
-        _, kwargs = patched_client.call_args
-        assert kwargs['connection_class'] == elasticsearch1.RequestsHttpConnection
-
-    @pytest.mark.parametrize('aws_settings', [
-        {'es.aws.access_key_id': 'foo'},
-        {'es.aws.secret_access_key': 'foo'},
-        {'es.aws.region': 'foo'},
-        {'es.aws.access_key_id': 'foo', 'es.aws.secret_access_key': 'bar'},
-        {'es.aws.access_key_id': 'foo', 'es.aws.region': 'bar'},
-        {'es.aws.secret_access_key': 'foo', 'es.aws.region': 'bar'},
-    ])
-    def test_ignores_aws_auth_when_settings_missing(self, settings, patched_client, aws_settings):
-        settings.update(aws_settings)
-        get_client(settings)
-
-        _, kwargs = patched_client.call_args
-        assert 'auth' not in kwargs
 
     @pytest.fixture
     def settings(self):
@@ -126,7 +81,3 @@ class TestGetClient(object):
     @pytest.fixture
     def patched_client(self, patch):
         return patch('h.search.client.Client')
-
-    @pytest.fixture
-    def patched_aws_auth(self, patch):
-        return patch('h.search.client.AWS4Auth')

--- a/tests/h/search/client_test.py
+++ b/tests/h/search/client_test.py
@@ -16,8 +16,6 @@ class TestClient(object):
         client = Client(host="http://localhost:9200", index="hypothesis")
 
         assert client.index == "hypothesis"
-        assert client.version == (6, 2, 0)
-        assert isinstance(client.conn, elasticsearch.Elasticsearch)
 
     def test_it_sets_the_version_property(self):
         client = Client(host="http://localhost:9200", index="hypothesis")

--- a/tests/h/search/config_test.py
+++ b/tests/h/search/config_test.py
@@ -8,14 +8,12 @@ import re
 
 import mock
 import pytest
-import elasticsearch1
 import elasticsearch
 
 from h.search.client import Client
 from h.search.config import (
     ANNOTATION_MAPPING,
     ANALYSIS_SETTINGS,
-    ES6_ANNOTATION_MAPPING,
     init,
     configure_index,
     delete_index,
@@ -127,19 +125,13 @@ class TestConfigureIndex(object):
 
         assert name == matchers.Regex('foo-[0-9a-f]{8}')
 
-    @pytest.mark.parametrize(
-        'esversion,mapping',
-        (((1, 5, 0), ANNOTATION_MAPPING),
-         ((6, 2, 0), ES6_ANNOTATION_MAPPING))
-    )
-    def test_sets_correct_mappings_and_settings(self, client, esversion, mapping):
-        client.version = esversion
+    def test_sets_correct_mappings_and_settings(self, client):
         configure_index(client)
 
         client.conn.indices.create.assert_called_once_with(
             mock.ANY,
             body={
-                'mappings': {'annotation': mapping},
+                'mappings': {'annotation': ANNOTATION_MAPPING},
                 'settings': {'analysis': ANALYSIS_SETTINGS},
             })
 
@@ -153,14 +145,11 @@ class TestGetAliasedIndex(object):
 
         assert get_aliased_index(client) == 'target-index'
 
-    @pytest.mark.parametrize(
-        'error',
-        ((elasticsearch1.exceptions.NotFoundError),
-         (elasticsearch.exceptions.NotFoundError))
-    )
-    def test_returns_none_when_no_alias(self, client, error):
+    def test_returns_none_when_no_alias(self, client):
         """If ``index`` is a concrete index, return None."""
-        client.conn.indices.get_alias.side_effect = error('test', 'test desc')
+        client.conn.indices.get_alias.side_effect = (
+            elasticsearch.exceptions.NotFoundError('test', 'test desc')
+        )
 
         assert get_aliased_index(client) is None
 
@@ -193,7 +182,7 @@ class TestUpdateAliasedIndex(object):
     def test_raises_if_called_for_concrete_index(self, client):
         """Raise if called for a concrete index."""
         client.conn.indices.get_alias.side_effect = (
-            elasticsearch1.exceptions.NotFoundError('test', 'test desc'))
+            elasticsearch.exceptions.NotFoundError('test', 'test desc'))
 
         with pytest.raises(RuntimeError):
             update_aliased_index(client, 'new-target')
@@ -205,20 +194,9 @@ class TestDeleteIndex(object):
 
         client.conn.indices.delete.assert_called_once_with(index='unused-index')
 
-    def test_ignores_NotFound_error(self, client):
-        client.conn.indices.delete.side_effect = elasticsearch1.exceptions.NotFoundError('IndexMissingException', '')
-
-        delete_index(client, 'unused-index')
-
 
 class TestUpdateIndexSettings(object):
-    @pytest.mark.parametrize(
-        'esversion,mapping',
-        (((1, 5, 0), ANNOTATION_MAPPING),
-         ((6, 2, 0), ES6_ANNOTATION_MAPPING))
-    )
-    def test_succesfully_updates_the_index_settings(self, client, esversion, mapping):
-        client.version = esversion
+    def test_succesfully_updates_the_index_settings(self, client):
         client.conn.indices.get_alias.return_value = {
             'old-target': {'aliases': {'foo': {}}},
         }
@@ -245,33 +223,26 @@ class TestUpdateIndexSettings(object):
         client.conn.indices.put_mapping.assert_called_once_with(
             index="old-target",
             doc_type=client.mapping_type,
-            body=mapping,
+            body=ANNOTATION_MAPPING,
         )
 
-    @pytest.mark.parametrize(
-        'error',
-        ((elasticsearch1.exceptions.RequestError),
-         (elasticsearch.exceptions.RequestError))
-    )
-    def test_raises_original_exception_if_not_merge_mapping_exception(self, client, error):
+    def test_raises_original_exception_if_not_merge_mapping_exception(self, client):
         client.conn.indices.get_alias.return_value = {
             'old-target': {'aliases': {'foo': {}}},
         }
+        error = elasticsearch.exceptions.RequestError
         client.conn.indices.put_mapping.side_effect = error('test', 'test desc')
 
         with pytest.raises(error):
             update_index_settings(client)
 
-    @pytest.mark.parametrize(
-        'error',
-        ((elasticsearch1.exceptions.RequestError),
-         (elasticsearch.exceptions.RequestError))
-    )
-    def test_raises_runtime_exception_if_merge_mapping_exception(self, client, error):
+    def test_raises_runtime_exception_if_merge_mapping_exception(self, client):
         client.conn.indices.get_alias.return_value = {
             'old-target': {'aliases': {'foo': {}}},
         }
-        client.conn.indices.put_mapping.side_effect = error('test', 'MergeMappingException')
+        client.conn.indices.put_mapping.side_effect = (
+            elasticsearch.exceptions.RequestError('test', 'MergeMappingException')
+        )
 
         with pytest.raises(RuntimeError):
             update_index_settings(client)
@@ -287,7 +258,7 @@ def groups(pattern, text):
 
 @pytest.fixture
 def client():
-    client = mock.create_autospec(Client, spec_set=True, instance=True, version=elasticsearch1.__version__)
+    client = mock.create_autospec(Client, spec_set=True, instance=True, version=elasticsearch.__version__)
     client.index = 'foo'
     client.mapping_type = 'annotation'
     return client

--- a/tests/h/search/conftest.py
+++ b/tests/h/search/conftest.py
@@ -32,20 +32,9 @@ def Annotation(factories, index):
 
 
 @pytest.fixture
-def index(es_client, es6_client, pyramid_request):
+def index(es6_client, pyramid_request):
     def _index(*annotations):
         """Index the given annotation(s) into Elasticsearch."""
-
-        # Here we index the document into both clusters. Most tests will only
-        # check the result in a single cluster. This is inefficient, but we
-        # don't intend the dual cluster usage to live long.
-
-        # Index annotations into old Elasticsearch cluster.
-        for annotation in annotations:
-            h.search.index.index(es_client, annotation, pyramid_request)
-        es_client.conn.indices.refresh(index=es_client.index)
-
-        # Index annotations into new Elasticsearch cluster.
         for annotation in annotations:
             h.search.index.index(es6_client, annotation, pyramid_request)
         es6_client.conn.indices.refresh(index=es6_client.index)
@@ -54,7 +43,6 @@ def index(es_client, es6_client, pyramid_request):
 
 
 @pytest.fixture
-def pyramid_request(es_client, es6_client, pyramid_request):
-    pyramid_request.es = es_client
+def pyramid_request(es6_client, pyramid_request):
     pyramid_request.es6 = es6_client
     return pyramid_request


### PR DESCRIPTION
Only use elastic search 6 in code and remove all references to elastic search 1.

*Note this does not include removing get_client or the actual request.es object those will come in a follow up PR.