### PR TITLE
Update API functional tests

### DIFF
--- a/tests/functional/api/test_annotations.py
+++ b/tests/functional/api/test_annotations.py
@@ -14,7 +14,7 @@ native_str = str
 
 
 @pytest.mark.functional
-class TestAPI(object):
+class TestGetAnnotations(object):
     def test_api_index(self, app):
         """
         Test the API index view.
@@ -39,6 +39,8 @@ class TestAPI(object):
         assert data['@context'] == 'http://www.w3.org/ns/anno.jsonld'
         assert data['id'] == 'http://example.com/a/' + annotation.id
 
+
+class TestWriteAnnotation(object):
     def test_annotation_write_unauthorized_group(self, app, user_with_token, non_writeable_group):
         """
         Write an annotation to a group that doesn't allow writes.
@@ -66,24 +68,6 @@ class TestAPI(object):
 
         assert res.status_code == 400
         assert res.json['reason'].startswith('group:')
-
-    def test_cors_preflight(self, app):
-        # Simulate a CORS preflight request made by the browser from a client
-        # hosted on a domain other than the one the service is running on.
-        #
-        # Note that no `Authorization` header is set.
-        origin = 'https://custom-client.herokuapp.com'
-        headers = {'Access-Control-Request-Headers': str('authorization,content-type'),
-                   'Access-Control-Request-Method': str('POST'),
-                   'Origin': str(origin)}
-
-        res = app.options('/api/annotations', headers=headers)
-
-        assert res.status_code == 200
-        assert res.headers['Access-Control-Allow-Origin'] == str(origin)
-        assert 'POST' in res.headers['Access-Control-Allow-Methods']
-        for header in ['Authorization', 'Content-Type', 'X-Client-Id']:
-            assert header in res.headers['Access-Control-Allow-Headers']
 
 
 @pytest.fixture
@@ -115,13 +99,6 @@ def auth_client(db_session, factories):
     auth_client = factories.AuthClient(authority='thirdparty.example.org')
     db_session.commit()
     return auth_client
-
-
-@pytest.fixture
-def open_group(auth_client, db_session, factories):
-    group = factories.OpenGroup(authority=auth_client.authority)
-    db_session.commit()
-    return group
 
 
 @pytest.fixture

--- a/tests/functional/api/test_api.py
+++ b/tests/functional/api/test_api.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import pytest
+
+# String type for request/response headers and metadata in WSGI.
+#
+# Per PEP-3333, this is intentionally `str` under both Python 2 and 3, even
+# though it has different meanings.
+#
+# See https://www.python.org/dev/peps/pep-3333/#a-note-on-string-types
+native_str = str
+
+
+@pytest.mark.functional
+class TestGetIndex(object):
+    def test_api_index(self, app):
+        """
+        Test the API index view.
+
+        This view is tested more thoroughly in the view tests, but this test
+        checks the view doesn't error out and returns appropriate-looking JSON.
+        """
+        res = app.get('/api/')
+        assert 'links' in res.json
+
+
+class TestCorsPreflight(object):
+
+    def test_cors_preflight(self, app):
+        # Simulate a CORS preflight request made by the browser from a client
+        # hosted on a domain other than the one the service is running on.
+        #
+        # Note that no `Authorization` header is set.
+        origin = 'https://custom-client.herokuapp.com'
+        headers = {'Access-Control-Request-Headers': str('authorization,content-type'),
+                   'Access-Control-Request-Method': str('POST'),
+                   'Origin': str(origin)}
+
+        res = app.options('/api/annotations', headers=headers)
+
+        assert res.status_code == 200
+        assert res.headers['Access-Control-Allow-Origin'] == str(origin)
+        assert 'POST' in res.headers['Access-Control-Allow-Methods']
+        for header in ['Authorization', 'Content-Type', 'X-Client-Id']:
+            assert header in res.headers['Access-Control-Allow-Headers']

--- a/tests/functional/api/test_profile.py
+++ b/tests/functional/api/test_profile.py
@@ -1,0 +1,104 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import pytest
+
+# String type for request/response headers and metadata in WSGI.
+#
+# Per PEP-3333, this is intentionally `str` under both Python 2 and 3, even
+# though it has different meanings.
+#
+# See https://www.python.org/dev/peps/pep-3333/#a-note-on-string-types
+native_str = str
+
+
+@pytest.mark.functional
+class TestGetProfile(object):
+    def test_it_returns_profile_with_single_group_when_not_authd(self, app):
+        """
+        Fetch an anonymous "profile".
+
+        With no authentication and no authority parameter, this should default
+        to the site's `authority` and show only the global group.
+        """
+
+        res = app.get('/api/profile')
+
+        assert res.json['userid'] is None
+        assert res.json['authority'] == 'example.com'
+        assert [group['id'] for group in res.json['groups']] == ['__world__']
+
+    def test_it_returns_profile_for_authenticated_user(self, app, user_with_token):
+        """Fetch a profile through the API for an authenticated user."""
+
+        user, token = user_with_token
+
+        headers = {'Authorization': str('Bearer {}'.format(token.value))}
+
+        res = app.get('/api/profile', headers=headers)
+
+        assert res.json['userid'] == user.userid
+        assert [group['id'] for group in res.json['groups']] == ['__world__']
+
+    def test_it_returns_profile_for_third_party_authd_user(self,
+                                                           app,
+                                                           open_group,
+                                                           third_party_user_with_token):
+        """Fetch a profile for a third-party account."""
+
+        user, token = third_party_user_with_token
+
+        headers = {'Authorization': str('Bearer {}'.format(token.value))}
+
+        res = app.get('/api/profile', headers=headers)
+
+        assert res.json['userid'] == user.userid
+
+        group_ids = [group['id'] for group in res.json['groups']]
+        # The profile API returns no open groups for third-party accounts.
+        # (The client gets open groups from the groups API instead.)
+        assert group_ids == []
+
+
+@pytest.fixture
+def user(db_session, factories):
+    user = factories.User()
+    db_session.commit()
+    return user
+
+
+@pytest.fixture
+def user_with_token(user, db_session, factories):
+    token = factories.DeveloperToken(userid=user.userid)
+    db_session.add(token)
+    db_session.commit()
+    return (user, token)
+
+
+@pytest.fixture
+def auth_client(db_session, factories):
+    auth_client = factories.AuthClient(authority='thirdparty.example.org')
+    db_session.commit()
+    return auth_client
+
+
+@pytest.fixture
+def third_party_user(auth_client, db_session, factories):
+    user = factories.User(authority=auth_client.authority)
+    db_session.commit()
+    return user
+
+
+@pytest.fixture
+def open_group(auth_client, db_session, factories):
+    group = factories.OpenGroup(authority=auth_client.authority)
+    db_session.commit()
+    return group
+
+
+@pytest.fixture
+def third_party_user_with_token(third_party_user, db_session, factories):
+    token = factories.DeveloperToken(userid=third_party_user.userid)
+    db_session.commit()
+    return (third_party_user, token)


### PR DESCRIPTION
This PR does some reorganization of functional tests for API endpoints, moving all them within the `api` sub-directory and breaking them into appropriate modules (`annotations`, `groups`, `profile` and `api`—the latter being for endpoints that don't "fit" into other resources).

No tests were changed or added in this work, just reorganized. This will make it easier to add missing functional tests (e.g. `users`) as it will be easier to see what in the API is already tested, and the fixtures for given test modules will be easier/simpler to manage.