### PR TITLE
Upgrade newrelic to >= 4.2.0.100

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -39,7 +39,7 @@ kombu==4.2.1
 mako==1.0.4               # via alembic
 markupsafe==0.23          # via jinja2, mako, pyramid-jinja2
 mistune==0.8.3
-newrelic==2.106.1.88
+newrelic==4.2.0.100
 oauthlib==2.0.2
 passlib==1.7.1
 pastedeploy==1.5.2        # via pyramid


### PR DESCRIPTION
There was a new release of newrelic which has fixes for pyramid
tweens tracing and adds a new feature called distributed tracing that
lets you track the request throughout the system.

To enable distributed tracing the following env var must be set:
NEW_RELIC_DISTRIBUTED_TRACING_ENABLED=true.

Note all parts of our system must be on the lastest NR version to 
use distributed tracing.

See release notes for details:
https://docs.newrelic.com/docs/release-notes/agent-release-notes/python-release-notes.