### PR TITLE
Remove es1 connections, library, container & rename es6 names

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,6 @@ node {
         try {
             testApp(image: img, runArgs: "-u root " +
                                          "-e BROKER_URL=${brokerUrl} " +
-                                         "-e ELASTICSEARCH_HOST=${elasticsearchHost_old} " +
                                          "-e ELASTICSEARCH_URL=${elasticsearchHost} " +
                                          "-e TEST_DATABASE_URL=${databaseUrl}") {
                 // Test dependencies

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,6 @@ run-docker:
 		-e "AUTHORITY=localhost" \
 		-e "BROKER_URL=amqp://guest:guest@rabbit:5672//" \
 		-e "DATABASE_URL=postgresql://postgres@postgres/postgres" \
-		-e "ELASTICSEARCH_HOST=http://elasticsearchold:9200" \
 		-e "ELASTICSEARCH_URL=http://elasticsearch:9201" \
 		-e "SECRET_KEY=notasecret" \
 		-p 5000:5000 \

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ run-docker:
 		-e "AUTHORITY=localhost" \
 		-e "BROKER_URL=amqp://guest:guest@rabbit:5672//" \
 		-e "DATABASE_URL=postgresql://postgres@postgres/postgres" \
-		-e "ELASTICSEARCH_URL=http://elasticsearch:9201" \
+		-e "ELASTICSEARCH_URL=http://elasticsearch:9200" \
 		-e "SECRET_KEY=notasecret" \
 		-p 5000:5000 \
 		hypothesis/hypothesis:$(DOCKER_TAG)

--- a/conf/development-app.ini
+++ b/conf/development-app.ini
@@ -4,7 +4,6 @@ pipeline: h
 [app:h]
 use: call:h.app:create_app
 
-es.host: http://localhost:9200
 es.url: http://localhost:9201
 
 pyramid.debug_all: True

--- a/conf/development-websocket.ini
+++ b/conf/development-websocket.ini
@@ -3,7 +3,6 @@ use: call:h.websocket:create_app
 
 # Elasticsearch configuration. The WebSocket does not actually use ES but
 # it does use the same config loading code which checks for these settings.
-es.host: http://localhost:9200
 es.url: http://localhost:9201
 
 # Use gevent-compatible transport for the Sentry client

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,10 +10,6 @@ services:
       - '127.0.0.1:9201:9200'
     environment:
       - discovery.type=single-node
-  elasticsearchold:
-    image: nickstenning/elasticsearch-icu
-    ports:
-      - '127.0.0.1:9200:9200'
   rabbit:
     image: rabbitmq:3.6-management-alpine
     ports:

--- a/h/cli/commands/init.py
+++ b/h/cli/commands/init.py
@@ -42,7 +42,7 @@ def _init_db(settings):
 
 
 def _init_search(settings):
-    client = search.get_es6_client(settings)
+    client = search.get_client(settings)
 
     log.info("initializing ES6 search index")
     search.init(client)

--- a/h/cli/commands/move_uri.py
+++ b/h/cli/commands/move_uri.py
@@ -54,7 +54,7 @@ def move_uri(ctx, old, new):
         docuri.uri = new
 
     if annotations:
-        indexer = BatchIndexer(request.db, request.es6, request)
+        indexer = BatchIndexer(request.db, request.es, request)
         ids = [a.id for a in annotations]
         indexer.index(ids)
 

--- a/h/cli/commands/normalize_uris.py
+++ b/h/cli/commands/normalize_uris.py
@@ -125,7 +125,7 @@ def _normalize_annotations_window(session, window):
 
 
 def _reindex_annotations(request, ids):
-    indexer = index.BatchIndexer(request.db, request.es6, request)
+    indexer = index.BatchIndexer(request.db, request.es, request)
 
     for _ in range(2):
         ids = indexer.index(ids)

--- a/h/cli/commands/search.py
+++ b/h/cli/commands/search.py
@@ -27,7 +27,7 @@ def reindex(ctx):
 
     request = ctx.obj['bootstrap']()
 
-    es_client = request.es6
+    es_client = request.es
 
     es_server_version = es_client.conn.info()['version']['number']
     click.echo('reindexing into Elasticsearch {} cluster'.format(es_server_version))
@@ -48,6 +48,6 @@ def update_settings(ctx):
     request = ctx.obj['bootstrap']()
 
     try:
-        config.update_index_settings(request.es6)
+        config.update_index_settings(request.es)
     except RuntimeError as e:
         raise click.ClickException(str(e))

--- a/h/config.py
+++ b/h/config.py
@@ -41,12 +41,8 @@ def configure(environ=None, settings=None):
     settings_manager.set('es.client.max_retries', 'ELASTICSEARCH_CLIENT_MAX_RETRIES', type_=int)
     settings_manager.set('es.client.retry_on_timeout', 'ELASTICSEARCH_CLIENT_RETRY_ON_TIMEOUT', type_=asbool)
     settings_manager.set('es.client.timeout', 'ELASTICSEARCH_CLIENT_TIMEOUT', type_=float)
-    settings_manager.set('es.host', 'ELASTICSEARCH_HOST', required=True)
     settings_manager.set('es.url', 'ELASTICSEARCH_URL', required=True),
     settings_manager.set('es.index', 'ELASTICSEARCH_INDEX')
-    settings_manager.set('es.aws.access_key_id', 'ELASTICSEARCH_AWS_ACCESS_KEY_ID')
-    settings_manager.set('es.aws.region', 'ELASTICSEARCH_AWS_REGION')
-    settings_manager.set('es.aws.secret_access_key', 'ELASTICSEARCH_AWS_SECRET_ACCESS_KEY')
     settings_manager.set('mail.default_sender', 'MAIL_DEFAULT_SENDER')
     settings_manager.set('mail.host', 'MAIL_HOST')
     settings_manager.set('mail.port', 'MAIL_PORT', type_=int)

--- a/h/indexer/reindexer.py
+++ b/h/indexer/reindexer.py
@@ -29,7 +29,7 @@ def reindex(session, es, request):
 
     new_index = configure_index(es)
     log.info('configured new index {}'.format(new_index))
-    setting_name = 'reindex.new_es6_index'
+    setting_name = 'reindex.new_index'
     if es.version < (2,):
         setting_name = 'reindex.new_index'
 

--- a/h/search/__init__.py
+++ b/h/search/__init__.py
@@ -16,7 +16,6 @@ __all__ = (
     'AuthorityFilter',
     'TagsAggregation',
     'UsersAggregation',
-    'get_client',
     'get_es6_client',
     'init',
     'connect'

--- a/h/search/__init__.py
+++ b/h/search/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import unicode_literals
-from h.search.client import get_es6_client
+from h.search.client import get_client
 from h.search.config import init
 from h.search.connection import connect
 from h.search.core import Search
@@ -16,7 +16,7 @@ __all__ = (
     'AuthorityFilter',
     'TagsAggregation',
     'UsersAggregation',
-    'get_es6_client',
+    'get_client',
     'init',
     'connect'
 )
@@ -40,7 +40,7 @@ def includeme(config):
     # Add a property to all requests for easy access to the elasticsearch 6.x
     # client. This can be used for direct or bulk access without having to
     # reread the settings.
-    config.registry['es.client'] = get_es6_client(settings)
+    config.registry['es.client'] = get_client(settings)
     config.add_request_method(
         lambda r: r.registry['es.client'],
         name='es',

--- a/h/search/__init__.py
+++ b/h/search/__init__.py
@@ -40,8 +40,8 @@ def includeme(config):
     # Add a property to all requests for easy access to the elasticsearch 6.x
     # client. This can be used for direct or bulk access without having to
     # reread the settings.
-    config.registry['es6.client'] = get_es6_client(settings)
+    config.registry['es.client'] = get_es6_client(settings)
     config.add_request_method(
-        lambda r: r.registry['es6.client'],
-        name='es6',
+        lambda r: r.registry['es.client'],
+        name='es',
         reify=True)

--- a/h/search/__init__.py
+++ b/h/search/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import unicode_literals
-from h.search.client import get_client, get_es6_client
+from h.search.client import get_es6_client
 from h.search.config import init
 from h.search.connection import connect
 from h.search.core import Search
@@ -26,8 +26,6 @@ __all__ = (
 def includeme(config):
     settings = config.registry.settings
 
-    # Connection to version 6.x of ES follows
-    # TODO The munging of these settings may change when settings refactoring complete
     kwargs = {}
     kwargs['max_retries'] = settings.get('es.client.max_retries', 3)
     kwargs['retry_on_timeout'] = settings.get('es.client.retry_on_timeout', False)
@@ -38,18 +36,7 @@ def includeme(config):
 
     connect(hosts=[settings['es.url']], **kwargs)
 
-    # Connection to old (ES1.5) follows
-    settings.setdefault('es.host', 'http://localhost:9200')
     settings.setdefault('es.index', 'hypothesis')
-
-    # Add a property to all requests for easy access to the elasticsearch 1.x
-    # client. This can be used for direct or bulk access without having to
-    # reread the settings.
-    config.registry['es.client'] = get_client(settings)
-    config.add_request_method(
-        lambda r: r.registry['es.client'],
-        name='es',
-        reify=True)
 
     # Add a property to all requests for easy access to the elasticsearch 6.x
     # client. This can be used for direct or bulk access without having to

--- a/h/search/client.py
+++ b/h/search/client.py
@@ -68,7 +68,7 @@ def _get_client_settings(settings):
     return kwargs
 
 
-def get_es6_client(settings):
+def get_client(settings):
     """Return a client for the Elasticsearch index."""
     host = settings['es.url']
     index = settings['es.index']

--- a/h/search/client.py
+++ b/h/search/client.py
@@ -1,10 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import unicode_literals
-import certifi
-import elasticsearch1
 import elasticsearch
-from requests_aws4auth import AWS4Auth
 
 
 class Client(object):
@@ -71,29 +68,8 @@ def _get_client_settings(settings):
     return kwargs
 
 
-def get_client(settings):
-    """Return a client for the Elasticsearch index."""
-    host = settings['es.host']
-    index = settings['es.index']
-    kwargs = _get_client_settings(settings)
-    # N.B. this won't be necessary if we upgrade
-    # to elasticsearch>=5.0.0.
-    kwargs['ca_certs'] = certifi.where()
-    have_aws_creds = ('es.aws.access_key_id' in settings and
-                      'es.aws.region' in settings and
-                      'es.aws.secret_access_key' in settings)
-    if have_aws_creds:
-        auth = AWS4Auth(settings['es.aws.access_key_id'],
-                        settings['es.aws.secret_access_key'],
-                        settings['es.aws.region'],
-                        'es')
-        kwargs['http_auth'] = auth
-        kwargs['connection_class'] = elasticsearch1.RequestsHttpConnection
-    return Client(host, index, elasticsearch=elasticsearch1, **kwargs)
-
-
 def get_es6_client(settings):
-    """Return a client for the Elasticsearch 6 index."""
+    """Return a client for the Elasticsearch index."""
     host = settings['es.url']
     index = settings['es.index']
     kwargs = _get_client_settings(settings)

--- a/h/search/core.py
+++ b/h/search/core.py
@@ -35,7 +35,7 @@ class Search(object):
     """
     def __init__(self, request, separate_replies=False, stats=None, _replies_limit=200):
         self.request = request
-        self.es = request.es6
+        self.es = request.es
         self.separate_replies = separate_replies
         self.stats = stats
         self._replies_limit = _replies_limit

--- a/h/search/query.py
+++ b/h/search/query.py
@@ -54,28 +54,13 @@ class Builder(object):
         for key, value in params.items():
             matchers.append({"match": {key: value}})
 
-        # Use appropriate filter syntax depending on ES version.
         # See https://www.elastic.co/guide/en/elasticsearch/reference/6.2/query-dsl-filtered-query.html
-        if self._es_version >= (2,):
-            query = {
-                "bool": {
-                    "filter": filters,
-                    "must": matchers,
-                },
-            }
-        else:
-            query = {"match_all": {}}
-
-            if matchers:
-                query = {"bool": {"must": matchers}}
-
-            if filters:
-                query = {
-                    "filtered": {
-                        "filter": {"and": filters},
-                        "query": query,
-                    }
-                }
+        query = {
+            "bool": {
+                "filter": filters,
+                "must": matchers,
+            },
+        }
 
         return {
             "from": p_from,

--- a/h/services/rename_user.py
+++ b/h/services/rename_user.py
@@ -91,7 +91,7 @@ def make_indexer(request):
             return
 
         request.tm.commit()
-        indexer = index.BatchIndexer(request.db, request.es6, request)
+        indexer = index.BatchIndexer(request.db, request.es, request)
         indexer.index(ids)
     return _reindex
 

--- a/h/tasks/indexer.py
+++ b/h/tasks/indexer.py
@@ -16,10 +16,10 @@ def add_annotation(id_):
 
         # If a reindex is running at the moment, add annotation to the new index
         # as well.
-        future_es6_index = _current_reindex_new_name(celery.request, 'reindex.new_es6_index')
-        if future_es6_index is not None:
+        future_index = _current_reindex_new_name(celery.request, 'reindex.new_index')
+        if future_index is not None:
             index(celery.request.es, annotation, celery.request,
-                  target_index=future_es6_index)
+                  target_index=future_index)
 
         if annotation.is_reply:
             add_annotation.delay(annotation.thread_root_id)
@@ -31,9 +31,9 @@ def delete_annotation(id_):
 
     # If a reindex is running at the moment, delete annotation from the
     # new index as well.
-    future_es6_index = _current_reindex_new_name(celery.request, 'reindex.new_es6_index')
-    if future_es6_index is not None:
-        delete(celery.request.es, id_, target_index=future_es6_index)
+    future_index = _current_reindex_new_name(celery.request, 'reindex.new_index')
+    if future_index is not None:
+        delete(celery.request.es, id_, target_index=future_index)
 
 
 @celery.task

--- a/requirements.in
+++ b/requirements.in
@@ -11,7 +11,6 @@ click
 deform < 1.0
 deform-jinja2
 elasticsearch==6.2.0
-elasticsearch1==1.10.0
 elasticsearch-dsl==6.1.0
 enum34
 functools32; python_version < "3.0" # Required by jsonschema, listed here to add environment marker

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,6 @@ contextlib2==0.5.4        # via raven
 deform-jinja2==0.5
 deform==0.9.9
 elasticsearch-dsl==6.1.0
-elasticsearch1==1.10.0
 elasticsearch==6.2.0
 enum34==1.1.6
 functools32==3.2.3.post2 ; python_version < "3.0"
@@ -71,7 +70,7 @@ statsd==3.2.1
 transaction==2.1.2
 translationstring==1.3    # via colander, deform, pyramid
 unidecode==0.4.19         # via python-slugify
-urllib3==1.22             # via elasticsearch, elasticsearch1
+urllib3==1.22             # via elasticsearch
 venusian==1.0
 vine==1.1.4               # via amqp
 webencodings==0.5.1       # via html5lib

--- a/tests/common/fixtures/__init__.py
+++ b/tests/common/fixtures/__init__.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from tests.common.fixtures.elasticsearch import es6_client, es_connect
+from tests.common.fixtures.elasticsearch import es_client, es_connect
 from tests.common.fixtures.elasticsearch import init_elasticsearch
 
 
 __all__ = (
-    "es6_client",
+    "es_client",
     "es_connect",
     "init_elasticsearch",
 )

--- a/tests/common/fixtures/elasticsearch.py
+++ b/tests/common/fixtures/elasticsearch.py
@@ -12,8 +12,8 @@ ELASTICSEARCH_URL = os.environ.get("ELASTICSEARCH_URL", "http://localhost:9201")
 
 
 @pytest.fixture
-def es6_client():
-    client = _es6_client()
+def es_client():
+    client = _es_client()
     yield client
     client.conn.delete_by_query(index=client.index, body={"query": {"match_all": {}}},
                                 # This query occassionally fails with a version conflict.
@@ -37,16 +37,16 @@ def init_elasticsearch(request):
     Connect to the instance of Elasticsearch and initialize the index
     once per test session and delete the index after the test is completed.
     """
-    es6_client = _es6_client()
+    es_client = _es_client()
 
     def maybe_delete_index():
         """Delete the test index if it exists."""
-        if es6_client.conn.indices.exists(index=ELASTICSEARCH_INDEX):
+        if es_client.conn.indices.exists(index=ELASTICSEARCH_INDEX):
             # The delete operation must be done on a concrete index, not an alias
             # in ES6. See https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-delete-index.html
-            concrete_indexes = es6_client.conn.indices.get(index=ELASTICSEARCH_INDEX)
+            concrete_indexes = es_client.conn.indices.get(index=ELASTICSEARCH_INDEX)
             for index in concrete_indexes:
-                es6_client.conn.indices.delete(index=index)
+                es_client.conn.indices.delete(index=index)
 
     # Delete the test search index at the end of the test run.
     request.addfinalizer(maybe_delete_index)
@@ -56,8 +56,8 @@ def init_elasticsearch(request):
     maybe_delete_index()
 
     # Initialize the test search index.
-    search.init(es6_client)
+    search.init(es_client)
 
 
-def _es6_client():
-    return search.get_es6_client({'es.url': ELASTICSEARCH_URL, 'es.index': ELASTICSEARCH_INDEX})
+def _es_client():
+    return search.get_client({'es.url': ELASTICSEARCH_URL, 'es.index': ELASTICSEARCH_INDEX})

--- a/tests/common/fixtures/elasticsearch.py
+++ b/tests/common/fixtures/elasticsearch.py
@@ -7,7 +7,6 @@ import pytest
 
 from h import search
 
-ELASTICSEARCH_HOST = os.environ.get("ELASTICSEARCH_HOST", "http://localhost:9200")
 ELASTICSEARCH_INDEX = "hypothesis-test"
 ELASTICSEARCH_URL = os.environ.get("ELASTICSEARCH_URL", "http://localhost:9201")
 

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -10,13 +10,11 @@ from webtest import TestApp
 from h._compat import text_type
 from tests.common.fixtures import es6_client  # noqa: F401
 from tests.common.fixtures import init_elasticsearch  # noqa: F401
-from tests.common.fixtures.elasticsearch import ELASTICSEARCH_HOST
 from tests.common.fixtures.elasticsearch import ELASTICSEARCH_URL
 from tests.common.fixtures.elasticsearch import ELASTICSEARCH_INDEX
 
 
 TEST_SETTINGS = {
-    'es.host': ELASTICSEARCH_HOST,
     'es.url': ELASTICSEARCH_URL,
     'es.index': ELASTICSEARCH_INDEX,
     'h.app_url': 'http://example.com',

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -8,7 +8,7 @@ import pytest
 from webtest import TestApp
 
 from h._compat import text_type
-from tests.common.fixtures import es6_client  # noqa: F401
+from tests.common.fixtures import es_client  # noqa: F401
 from tests.common.fixtures import init_elasticsearch  # noqa: F401
 from tests.common.fixtures.elasticsearch import ELASTICSEARCH_URL
 from tests.common.fixtures.elasticsearch import ELASTICSEARCH_INDEX
@@ -77,7 +77,7 @@ def pyramid_app():
 # Always unconditionally wipe the Elasticsearch index after every functional
 # test.
 @pytest.fixture(autouse=True)  # noqa: F811
-def always_delete_all_elasticsearch_documents(es6_client):
+def always_delete_all_elasticsearch_documents(es_client):
     pass
 
 

--- a/tests/h/cli/commands/init_test.py
+++ b/tests/h/cli/commands/init_test.py
@@ -49,12 +49,12 @@ class TestInitCommand(object):
                                 cliconfig,
                                 search,
                                 pyramid_settings):
-        es6_client = search.get_es6_client.return_value
+        es_client = search.get_client.return_value
 
         result = cli.invoke(init_cli.init, obj=cliconfig)
 
-        search.get_es6_client.assert_called_once_with(pyramid_settings)
-        search.init.assert_any_call(es6_client)
+        search.get_client.assert_called_once_with(pyramid_settings)
+        search.init.assert_any_call(es_client)
         assert result.exit_code == 0
 
 

--- a/tests/h/cli/commands/normalize_uris_test.py
+++ b/tests/h/cli/commands/normalize_uris_test.py
@@ -179,7 +179,7 @@ def test_it_skips_reindexing_unaltered_annotations(req, index, factories, db_ses
 @pytest.fixture
 def req(pyramid_request):
     pyramid_request.tm = mock.MagicMock()
-    pyramid_request.es6 = mock.MagicMock()
+    pyramid_request.es = mock.MagicMock()
     return pyramid_request
 
 

--- a/tests/h/cli/commands/search_test.py
+++ b/tests/h/cli/commands/search_test.py
@@ -19,7 +19,7 @@ class TestReindexCommand(object):
 
         assert result.exit_code == 0
         reindex.assert_called_once_with(pyramid_request.db,
-                                        pyramid_request.es6,
+                                        pyramid_request.es,
                                         pyramid_request)
 
     @pytest.fixture
@@ -33,7 +33,7 @@ class TestUpdateSettingsCommand(object):
         result = cli.invoke(search.update_settings, [], obj=cliconfig)
 
         assert result.exit_code == 0
-        update_index_settings.assert_called_once_with(pyramid_request.es6)
+        update_index_settings.assert_called_once_with(pyramid_request.es)
 
     def test_handles_runtimeerror(self, cli, cliconfig, update_index_settings):
         update_index_settings.side_effect = RuntimeError("asplode!")
@@ -50,5 +50,5 @@ class TestUpdateSettingsCommand(object):
 
 @pytest.fixture
 def cliconfig(pyramid_request):
-    pyramid_request.es6 = mock.create_autospec(Client, spec_set=True, instance=True)
+    pyramid_request.es = mock.create_autospec(Client, spec_set=True, instance=True)
     return {'bootstrap': mock.Mock(return_value=pyramid_request)}

--- a/tests/h/config_test.py
+++ b/tests/h/config_test.py
@@ -20,7 +20,6 @@ def test_configure_updates_settings_from_env_vars(env_var, env_val, setting_name
     settings_from_conf = {'h.db_session_checks': True,
 
                           # Required settings
-                          'es.host': 'https://es1-search-cluster',
                           'es.url': 'https://es6-search-cluster',
                           'secret_key': 'notasecret',
                           'sqlalchemy.url': 'postgres://user@dbhost/dbname',

--- a/tests/h/conftest.py
+++ b/tests/h/conftest.py
@@ -24,7 +24,7 @@ from h import db
 from h import models
 from h.settings import database_url
 from h._compat import text_type
-from tests.common.fixtures import es6_client, es_connect  # noqa: F401
+from tests.common.fixtures import es_client, es_connect  # noqa: F401
 from tests.common.fixtures import init_elasticsearch  # noqa: F401
 
 TEST_AUTHORITY = 'example.com'

--- a/tests/h/indexer/reindexer_test.py
+++ b/tests/h/indexer/reindexer_test.py
@@ -80,30 +80,18 @@ class TestReindex(object):
         with pytest.raises(RuntimeError):
             reindex(mock.sentinel.session, es, mock.sentinel.request)
 
-    @pytest.mark.parametrize(
-        'esversion,new_index_setting_name',
-        (((1, 5, 0), 'reindex.new_index'),
-        ((6, 2, 0), 'reindex.new_es6_index'))
-    )
-    def test_stores_new_index_name_in_settings(self, pyramid_request, es, settings_service,
-                                               configure_index, esversion, new_index_setting_name):
-        es.version = esversion
+    def test_stores_new_index_name_in_settings(self, pyramid_request, es, settings_service, configure_index):
         configure_index.return_value = 'hypothesis-abcd1234'
 
         reindex(mock.sentinel.session, es, pyramid_request)
 
-        settings_service.put.assert_called_once_with(new_index_setting_name, 'hypothesis-abcd1234')
+        settings_service.put.assert_called_once_with('reindex.new_index', 'hypothesis-abcd1234')
 
-    @pytest.mark.parametrize(
-        'esversion,new_index_setting_name',
-        (((1, 5, 0), 'reindex.new_index'),
-        ((6, 2, 0), 'reindex.new_es6_index'))
-    )
-    def test_deletes_index_name_setting(self, pyramid_request, es, settings_service, esversion, new_index_setting_name):
-        es.version = esversion
+
+    def test_deletes_index_name_setting(self, pyramid_request, es, settings_service):
         reindex(mock.sentinel.session, es, pyramid_request)
 
-        settings_service.delete.assert_called_once_with(new_index_setting_name)
+        settings_service.delete.assert_called_once_with('reindex.new_index')
 
     def test_deletes_index_name_setting_when_exception_raised(self, pyramid_request, es, settings_service, batchindexer):
         batchindexer.index.side_effect = RuntimeError('boom!')

--- a/tests/h/indexer/reindexer_test.py
+++ b/tests/h/indexer/reindexer_test.py
@@ -87,7 +87,6 @@ class TestReindex(object):
 
         settings_service.put.assert_called_once_with('reindex.new_index', 'hypothesis-abcd1234')
 
-
     def test_deletes_index_name_setting(self, pyramid_request, es, settings_service):
         reindex(mock.sentinel.session, es, pyramid_request)
 

--- a/tests/h/search/client_test.py
+++ b/tests/h/search/client_test.py
@@ -6,7 +6,7 @@ import pytest
 
 import elasticsearch
 
-from h.search.client import get_es6_client
+from h.search.client import get_client
 from h.search.client import Client
 
 
@@ -42,12 +42,12 @@ class TestClient(object):
 
 class TestGetClient(object):
     def test_initializes_client_with_host(self, settings, patched_client):
-        get_es6_client(settings)
+        get_client(settings)
         args, _ = patched_client.call_args
         assert args[0] == 'search.svc'
 
     def test_initializes_client_with_index(self, settings, patched_client):
-        get_es6_client(settings)
+        get_client(settings)
         args, _ = patched_client.call_args
         assert args[1] == 'my-index'
 
@@ -63,7 +63,7 @@ class TestGetClient(object):
     ])
     def test_client_configuration(self, settings, patched_client, key, value, settingkey):
         settings[settingkey] = value
-        get_es6_client(settings)
+        get_client(settings)
 
         _, kwargs = patched_client.call_args
         assert kwargs[key] == value

--- a/tests/h/search/client_test.py
+++ b/tests/h/search/client_test.py
@@ -71,7 +71,6 @@ class TestGetClient(object):
     @pytest.fixture
     def settings(self):
         return {
-            'es.host': 'search.svc',
             'es.url': 'search.svc',
             'es.index': 'my-index',
         }

--- a/tests/h/search/conftest.py
+++ b/tests/h/search/conftest.py
@@ -44,5 +44,5 @@ def index(es6_client, pyramid_request):
 
 @pytest.fixture
 def pyramid_request(es6_client, pyramid_request):
-    pyramid_request.es6 = es6_client
+    pyramid_request.es = es6_client
     return pyramid_request

--- a/tests/h/search/conftest.py
+++ b/tests/h/search/conftest.py
@@ -32,17 +32,17 @@ def Annotation(factories, index):
 
 
 @pytest.fixture
-def index(es6_client, pyramid_request):
+def index(es_client, pyramid_request):
     def _index(*annotations):
         """Index the given annotation(s) into Elasticsearch."""
         for annotation in annotations:
-            h.search.index.index(es6_client, annotation, pyramid_request)
-        es6_client.conn.indices.refresh(index=es6_client.index)
+            h.search.index.index(es_client, annotation, pyramid_request)
+        es_client.conn.indices.refresh(index=es_client.index)
 
     return _index
 
 
 @pytest.fixture
-def pyramid_request(es6_client, pyramid_request):
-    pyramid_request.es = es6_client
+def pyramid_request(es_client, pyramid_request):
+    pyramid_request.es = es_client
     return pyramid_request

--- a/tests/h/search/core_test.py
+++ b/tests/h/search/core_test.py
@@ -124,7 +124,7 @@ class TestSearch(object):
         assert result.reply_ids == []
 
     def test_it_passes_es_version_to_builder(self, pyramid_request, Builder):
-        client = pyramid_request.es6
+        client = pyramid_request.es
 
         search.Search(pyramid_request)
 
@@ -246,5 +246,5 @@ class TestSearchWithSeparateReplies(object):
 
 @pytest.fixture
 def pyramid_request(request, pyramid_request, es6_client):
-    pyramid_request.es6 = es6_client
+    pyramid_request.es = es6_client
     return pyramid_request

--- a/tests/h/search/core_test.py
+++ b/tests/h/search/core_test.py
@@ -245,6 +245,6 @@ class TestSearchWithSeparateReplies(object):
 
 
 @pytest.fixture
-def pyramid_request(request, pyramid_request, es6_client):
-    pyramid_request.es = es6_client
+def pyramid_request(request, pyramid_request, es_client):
+    pyramid_request.es = es_client
     return pyramid_request

--- a/tests/h/search/old_query_test.py
+++ b/tests/h/search/old_query_test.py
@@ -125,7 +125,7 @@ class TestBuilder(object):
 
         q = builder.build({})
 
-        assert q["query"] == {"match_all": {}}
+        assert q["query"] == {'bool': {'filter': [], 'must': []}}
 
     def test_default_param_action(self):
         """Other params are added as "match" clauses."""
@@ -133,7 +133,10 @@ class TestBuilder(object):
 
         q = builder.build({"foo": "bar"})
 
-        assert q["query"] == {"bool": {"must": [{"match": {"foo": "bar"}}]}}
+        assert q["query"] == {
+            'bool': {'filter': [],
+                     'must': [{'match': {'foo': 'bar'}}]},
+        }
 
     def test_default_params_multidict(self):
         """Multiple params go into multiple "match" dicts."""
@@ -145,12 +148,9 @@ class TestBuilder(object):
         q = builder.build(params)
 
         assert q["query"] == {
-            "bool": {
-                "must": [
-                    {"match": {"user": "fred"}},
-                    {"match": {"user": "bob"}}
-                ]
-            }
+            'bool': {'filter': [],
+                     'must': [{'match': {'user': 'fred'}},
+                              {'match': {'user': 'bob'}}]},
         }
 
     def test_with_evil_arguments(self):
@@ -164,7 +164,7 @@ class TestBuilder(object):
 
         assert q["from"] == 0
         assert q["size"] == 20
-        assert q["query"] == {'match_all': {}}
+        assert q["query"] == {'bool': {'filter': [], 'must': []}}
 
     def test_passes_params_to_filters(self):
         testfilter = mock.Mock()
@@ -183,7 +183,7 @@ class TestBuilder(object):
 
         q = builder.build({})
 
-        assert q["query"] == {"match_all": {}}
+        assert q["query"] == {'bool': {'filter': [], 'must': []}}
 
     def test_filters_query_by_filter_results(self):
         testfilter = mock.Mock()
@@ -192,12 +192,9 @@ class TestBuilder(object):
         builder.append_filter(testfilter)
 
         q = builder.build({})
-
         assert q["query"] == {
-            "filtered": {
-                "filter": {"and": [{"term": {"giraffe": "nose"}}]},
-                "query": {"match_all": {}},
-            },
+            'bool': {'filter': [{'term': {'giraffe': 'nose'}}],
+                     'must': []},
         }
 
     def test_passes_params_to_matchers(self):
@@ -218,7 +215,8 @@ class TestBuilder(object):
         q = builder.build({})
 
         assert q["query"] == {
-            "bool": {"must": [{"match": {"giraffe": "nose"}}]},
+            'bool': {'filter': [],
+                     'must': [{'match': {'giraffe': 'nose'}}]},
         }
 
     def test_passes_params_to_aggregations(self):

--- a/tests/h/search/query_test.py
+++ b/tests/h/search/query_test.py
@@ -45,34 +45,6 @@ class TestBuilder(object):
     def test_it_ignores_unknown_sort_fields(self, search):
         search.run({"sort": "no_such_field"})
 
-    def test_it_uses_old_filter_syntax_for_es1(self):
-        # TODO - Remove this test once ES 1 support is dropped.
-
-        builder = Builder(es_version=(1, 7, 0))
-        filter_ = AuthorityFilter("default")
-        params = {}
-        builder.append_filter(filter_)
-
-        query = builder.build(params)["query"]
-
-        assert query == {"filtered": {"filter": {"and": [filter_(params)]},
-                                      "query": {"match_all": {}}}}
-
-    def test_it_uses_new_filter_syntax_for_es6(self):
-        # TODO - This test will be obsolete once the tests which execute
-        # searches against Elasticsearch are running against ES 6.
-
-        builder = Builder(es_version=(6, 2, 0))
-        filter_ = AuthorityFilter("default")
-        params = {}
-        builder.append_filter(filter_)
-
-        query = builder.build(params)["query"]
-
-        assert query == {"bool": {"filter": [filter_(params)],
-                                  "must": []}}
-
-
 class TestTopLevelAnnotationsFilter(object):
 
     def test_it_filters_out_replies_but_leaves_annotations_in(self, Annotation, search):

--- a/tests/h/search/query_test.py
+++ b/tests/h/search/query_test.py
@@ -6,7 +6,6 @@ import pytest
 import webob
 
 from h.search import Search, index, query
-from h.search.query import AuthorityFilter, Builder
 
 
 class TestBuilder(object):
@@ -44,6 +43,7 @@ class TestBuilder(object):
 
     def test_it_ignores_unknown_sort_fields(self, search):
         search.run({"sort": "no_such_field"})
+
 
 class TestTopLevelAnnotationsFilter(object):
 

--- a/tests/h/search/query_test.py
+++ b/tests/h/search/query_test.py
@@ -653,8 +653,8 @@ class TestUsersAggregation(object):
 
 
 @pytest.fixture
-def pyramid_request(request, pyramid_request, es6_client):
-    pyramid_request.es = es6_client
+def pyramid_request(request, pyramid_request, es_client):
+    pyramid_request.es = es_client
     return pyramid_request
 
 

--- a/tests/h/search/query_test.py
+++ b/tests/h/search/query_test.py
@@ -654,7 +654,7 @@ class TestUsersAggregation(object):
 
 @pytest.fixture
 def pyramid_request(request, pyramid_request, es6_client):
-    pyramid_request.es6 = es6_client
+    pyramid_request.es = es6_client
     return pyramid_request
 
 

--- a/tests/h/services/rename_user_test.py
+++ b/tests/h/services/rename_user_test.py
@@ -124,7 +124,7 @@ class TestMakeIndexer(object):
 
         batch_indexer = index.BatchIndexer.return_value
         batch_indexer.index.assert_called_once_with([1, 2, 3])
-        index.BatchIndexer.assert_any_call(req.db, req.es6, req)
+        index.BatchIndexer.assert_any_call(req.db, req.es, req)
 
     def test_it_skips_indexing_when_no_ids_given(self, req, index):
         indexer = make_indexer(req)
@@ -136,7 +136,7 @@ class TestMakeIndexer(object):
     @pytest.fixture
     def req(self, pyramid_request):
         pyramid_request.tm = mock.MagicMock()
-        pyramid_request.es6 = mock.MagicMock()
+        pyramid_request.es = mock.MagicMock()
         return pyramid_request
 
     @pytest.fixture

--- a/tests/h/tasks/indexer_test.py
+++ b/tests/h/tasks/indexer_test.py
@@ -36,7 +36,7 @@ class TestAddAnnotation(object):
 
         indexer.add_annotation(id_)
 
-        index.assert_any_call(celery.request.es6, annotation, celery.request)
+        index.assert_any_call(celery.request.es, annotation, celery.request)
 
     def test_it_skips_indexing_when_annotation_cannot_be_loaded(self, fetch_annotation, index, celery):
         fetch_annotation.return_value = None
@@ -51,7 +51,7 @@ class TestAddAnnotation(object):
 
         indexer.add_annotation('test-annotation-id')
 
-        index.assert_any_call(celery.request.es6,
+        index.assert_any_call(celery.request.es,
                               annotation,
                               celery.request,
                               target_index='hypothesis-xyz123')
@@ -62,7 +62,7 @@ class TestAddAnnotation(object):
 
         indexer.add_annotation('test-annotation-id')
 
-        index.assert_any_call(celery.request.es6,
+        index.assert_any_call(celery.request.es,
                               annotation,
                               celery.request,
                               target_index='hypothesis-xyz123')
@@ -104,14 +104,14 @@ class TestDeleteAnnotation(object):
         id_ = 'test-annotation-id'
         indexer.delete_annotation(id_)
 
-        delete.assert_any_call(celery.request.es6, id_)
+        delete.assert_any_call(celery.request.es, id_)
 
     def test_during_reindex_deletes_from_current_index(self, delete, celery, settings_service):
         settings_service.put('reindex.new_es6_index', 'hypothesis-xyz123')
 
         indexer.delete_annotation('test-annotation-id')
 
-        delete.assert_any_call(celery.request.es6, 'test-annotation-id',
+        delete.assert_any_call(celery.request.es, 'test-annotation-id',
                                target_index='hypothesis-xyz123')
 
     def test_during_reindex_deletes_from_new_index(self, delete, celery, settings_service):
@@ -120,7 +120,7 @@ class TestDeleteAnnotation(object):
 
         indexer.delete_annotation('test-annotation-id')
 
-        delete.assert_any_call(celery.request.es6,
+        delete.assert_any_call(celery.request.es,
                                'test-annotation-id',
                                target_index='hypothesis-xyz123')
 
@@ -136,7 +136,7 @@ class TestReindexUserAnnotations(object):
 
         indexer.reindex_user_annotations(userid)
 
-        batch_indexer.assert_any_call(celery.request.db, celery.request.es6, celery.request)
+        batch_indexer.assert_any_call(celery.request.db, celery.request.es, celery.request)
 
     def test_it_reindexes_users_annotations(self, batch_indexer, annotation_ids):
         userid = list(annotation_ids.keys())[0]
@@ -172,7 +172,7 @@ def celery(patch, pyramid_request):
 
 @pytest.fixture
 def pyramid_request(pyramid_request):
-    pyramid_request.es6 = mock.Mock()
+    pyramid_request.es = mock.Mock()
     return pyramid_request
 
 

--- a/tests/h/tasks/indexer_test.py
+++ b/tests/h/tasks/indexer_test.py
@@ -46,7 +46,7 @@ class TestAddAnnotation(object):
         assert index.called is False
 
     def test_during_reindex_adds_to_current_index(self, fetch_annotation, annotation, index, celery, settings_service):
-        settings_service.put('reindex.new_es6_index', 'hypothesis-xyz123')
+        settings_service.put('reindex.new_index', 'hypothesis-xyz123')
         fetch_annotation.return_value = annotation
 
         indexer.add_annotation('test-annotation-id')
@@ -57,7 +57,7 @@ class TestAddAnnotation(object):
                               target_index='hypothesis-xyz123')
 
     def test_during_reindex_adds_to_new_index(self, fetch_annotation, annotation, index, celery, settings_service):
-        settings_service.put('reindex.new_es6_index', 'hypothesis-xyz123')
+        settings_service.put('reindex.new_index', 'hypothesis-xyz123')
         fetch_annotation.return_value = annotation
 
         indexer.add_annotation('test-annotation-id')
@@ -107,7 +107,7 @@ class TestDeleteAnnotation(object):
         delete.assert_any_call(celery.request.es, id_)
 
     def test_during_reindex_deletes_from_current_index(self, delete, celery, settings_service):
-        settings_service.put('reindex.new_es6_index', 'hypothesis-xyz123')
+        settings_service.put('reindex.new_index', 'hypothesis-xyz123')
 
         indexer.delete_annotation('test-annotation-id')
 
@@ -115,8 +115,7 @@ class TestDeleteAnnotation(object):
                                target_index='hypothesis-xyz123')
 
     def test_during_reindex_deletes_from_new_index(self, delete, celery, settings_service):
-        settings_service.put('reindex.new_index', 'hypothesis-abcdef123')
-        settings_service.put('reindex.new_es6_index', 'hypothesis-xyz123')
+        settings_service.put('reindex.new_index', 'hypothesis-xyz123')
 
         indexer.delete_annotation('test-annotation-id')
 

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,6 @@ deps =
     -rrequirements.txt
 passenv =
     TEST_DATABASE_URL
-    ELASTICSEARCH_HOST
     ELASTICSEARCH_URL
     PYTEST_ADDOPTS
 commands =
@@ -37,7 +36,6 @@ deps =
     -rrequirements.txt
 passenv =
     BROKER_URL
-    ELASTICSEARCH_HOST
     ELASTICSEARCH_URL
     TEST_DATABASE_URL
     PYTEST_ADDOPTS
@@ -53,7 +51,6 @@ deps =
     -rrequirements.txt
 passenv =
     BROKER_URL
-    ELASTICSEARCH_HOST
     ELASTICSEARCH_URL
     TEST_DATABASE_URL
     PYTEST_ADDOPTS


### PR DESCRIPTION
- [x]  Remove unused ELASTICSEARCH_HOST & _AWS* settings
- [x]  Remove unused get_client for es1
- [x]  Remove elasticsearchold from docker-compose
- [x]  Remove elasticsearch1 as a dependency 
- [x]  Rename request.es6 to request.es
- [x]  Rename es6_client fixture & search.get_es6_client
- [x]  Replace new_es6_index w/ new_index
- [x]  Remove es filter syntax for es1

This is a partial fix for https://github.com/hypothesis/product-backlog/issues/608.

The change to the docker-compose is simply to remove the old elasticsearch container. This can be achieved without re-running docker-compose and destroying the data in the Postgres container by just killing the old elasticsearch container:
```
docker kill h_elasticsearchold_1
```
