### PR TITLE
Change elasticsearch port from 9201 to 9200

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ matrix:
       addons:
         postgresql: "9.4"
       before_install:
-        - ./scripts/elasticsearch-old.sh
         - ./scripts/elasticsearch.sh
       install: pip install tox
       before_script: createdb htest
@@ -24,7 +23,6 @@ matrix:
       addons:
         postgresql: '9.4'
       before_install:
-        - ./scripts/elasticsearch-old.sh
         - ./scripts/elasticsearch.sh
       install: pip install tox
       before_script: createdb htest

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,9 +16,6 @@ node {
         postgres = docker.image('postgres:9.4').run('-P -e POSTGRES_DB=htest')
         databaseUrl = "postgresql://postgres@${hostIp}:${containerPort(postgres, 5432)}/htest"
 
-        elasticsearch_old = docker.image('nickstenning/elasticsearch-icu').run('-P', "-Des.cluster.name=${currentBuild.displayName}")
-        elasticsearchHost_old = "http://${hostIp}:${containerPort(elasticsearch_old, 9200)}"
-
         elasticsearch = docker.image('hypothesis/elasticsearch').run('-P -e "discovery.type=single-node"')
         elasticsearchHost = "http://${hostIp}:${containerPort(elasticsearch, 9200)}"
 
@@ -44,7 +41,6 @@ node {
         } finally {
             rabbit.stop()
             elasticsearch.stop()
-            elasticsearch_old.stop()
             postgres.stop()
         }
     }

--- a/conf/development-app.ini
+++ b/conf/development-app.ini
@@ -4,7 +4,7 @@ pipeline: h
 [app:h]
 use: call:h.app:create_app
 
-es.url: http://localhost:9201
+es.url: http://localhost:9200
 
 pyramid.debug_all: True
 pyramid.reload_templates: True

--- a/conf/development-websocket.ini
+++ b/conf/development-websocket.ini
@@ -3,7 +3,7 @@ use: call:h.websocket:create_app
 
 # Elasticsearch configuration. The WebSocket does not actually use ES but
 # it does use the same config loading code which checks for these settings.
-es.url: http://localhost:9201
+es.url: http://localhost:9200
 
 # Use gevent-compatible transport for the Sentry client
 raven.transport: gevent

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
   elasticsearch:
     image: hypothesis/elasticsearch:latest
     ports:
-      - '127.0.0.1:9201:9200'
+      - '127.0.0.1:9200:9200'
     environment:
       - discovery.type=single-node
   rabbit:

--- a/scripts/elasticsearch-old.sh
+++ b/scripts/elasticsearch-old.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-# Install the old version of Elasticsearch in /tmp and run it.
-set -ev
-mkdir /tmp/elasticsearch-old
-wget -O - https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.6.2.tar.gz | tar xz --directory=/tmp/elasticsearch-old --strip-components=1
-/tmp/elasticsearch-old/bin/plugin install elasticsearch/elasticsearch-analysis-icu/2.6.0/
-/tmp/elasticsearch-old/bin/elasticsearch -Des.http.port=9200 -d --path.data /tmp/elasticsearch-old_data

--- a/scripts/elasticsearch.sh
+++ b/scripts/elasticsearch.sh
@@ -4,4 +4,4 @@ set -ev
 mkdir /tmp/elasticsearch
 wget -O - https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.2.4.tar.gz | tar xz --directory=/tmp/elasticsearch --strip-components=1
 /tmp/elasticsearch/bin/elasticsearch-plugin install analysis-icu
-/tmp/elasticsearch/bin/elasticsearch -E http.port=9201 -E path.data=/tmp/elasticsearch_data -d
+/tmp/elasticsearch/bin/elasticsearch -E http.port=9200 -E path.data=/tmp/elasticsearch_data -d

--- a/tests/common/fixtures/elasticsearch.py
+++ b/tests/common/fixtures/elasticsearch.py
@@ -8,7 +8,7 @@ import pytest
 from h import search
 
 ELASTICSEARCH_INDEX = "hypothesis-test"
-ELASTICSEARCH_URL = os.environ.get("ELASTICSEARCH_URL", "http://localhost:9201")
+ELASTICSEARCH_URL = os.environ.get("ELASTICSEARCH_URL", "http://localhost:9200")
 
 
 @pytest.fixture


### PR DESCRIPTION
Change the elasticsearch 6 cluster port to 9200 (this is the default es port) since we are no longer running two clusters.

This is a partial fix for https://github.com/hypothesis/product-backlog/issues/608.

----
_(Edited by @robertknight)_

After this branch is merged, the Elasticsearch container will need to be rebuilt and repopulated as follows:

1. Stop h if it is currently running.
2. Stop the docker-compose services if they are running (eg. with `docker-compose stop` or Ctrl+C in the terminal where you are running `docker-compose up`)
3. Recreate the Elasticsearch container by running `docker-compose up`.
4. Re-initialize the search index using:
   ```
   ./bin/hypothesis --dev init
   ./bin/hypothesis search reindex
   ```
