### PR TITLE
Use API Policy; Restrict AuthClientPolicy to `POST /api/groups`

### DIFF
--- a/h/auth/__init__.py
+++ b/h/auth/__init__.py
@@ -8,7 +8,10 @@ import logging
 from pyramid.authentication import RemoteUserAuthenticationPolicy
 import pyramid_authsanity
 
-from h.auth.policy import AuthenticationPolicy, TokenAuthenticationPolicy
+from h.auth.policy import AuthenticationPolicy
+from h.auth.policy import APIAuthenticationPolicy
+from h.auth.policy import AuthClientPolicy
+from h.auth.policy import TokenAuthenticationPolicy
 from h.auth.util import authority, groupfinder
 from h.security import derive_key
 
@@ -22,9 +25,14 @@ log = logging.getLogger(__name__)
 PROXY_POLICY = RemoteUserAuthenticationPolicy(environ_key='HTTP_X_FORWARDED_USER',
                                               callback=groupfinder)
 TICKET_POLICY = pyramid_authsanity.AuthServicePolicy()
-TOKEN_POLICY = TokenAuthenticationPolicy(callback=groupfinder)
 
-DEFAULT_POLICY = AuthenticationPolicy(api_policy=TOKEN_POLICY,
+TOKEN_POLICY = TokenAuthenticationPolicy(callback=groupfinder)
+AUTH_CLIENT_POLICY = AuthClientPolicy()
+
+API_POLICY = APIAuthenticationPolicy(user_policy=TOKEN_POLICY,
+                                     client_policy=AUTH_CLIENT_POLICY)
+
+DEFAULT_POLICY = AuthenticationPolicy(api_policy=API_POLICY,
                                       fallback_policy=TICKET_POLICY)
 WEBSOCKET_POLICY = TOKEN_POLICY
 
@@ -50,7 +58,7 @@ def includeme(config):
                  'warning will result in ALL DATA stored by this service '
                  'being available to ANYONE!')
 
-        DEFAULT_POLICY = AuthenticationPolicy(api_policy=TOKEN_POLICY,
+        DEFAULT_POLICY = AuthenticationPolicy(api_policy=API_POLICY,
                                               fallback_policy=PROXY_POLICY)
         WEBSOCKET_POLICY = TOKEN_POLICY
 

--- a/h/auth/policy.py
+++ b/h/auth/policy.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import unicode_literals
+
+import re
+
 from pyramid import interfaces
 from pyramid.authentication import BasicAuthAuthenticationPolicy
 from pyramid.authentication import CallbackAuthenticationPolicy
@@ -8,6 +11,11 @@ from pyramid.security import Authenticated
 from zope import interface
 
 from h.auth import util
+
+# As we roll out the new API Auth Policy with Auth Token Policy, we
+# want to keep it restricted to certain endpoints
+# Currently restricted to `POST /api/groups` only
+AUTH_TOKEN_PATH_PATTERN = '^\/api\/groups(\/?)$'
 
 
 @interface.implementer(interfaces.IAuthenticationPolicy)
@@ -350,7 +358,7 @@ def _is_client_request(request):
 
     This is intended to be temporary.
     """
-    return (request.path.startswith('/api/groups') and
+    return (re.match(AUTH_TOKEN_PATH_PATTERN, request.path) and
             request.method == 'POST')
 
 

--- a/h/auth/policy.py
+++ b/h/auth/policy.py
@@ -262,7 +262,10 @@ class AuthClientPolicy(object):
             return util.principals_for_auth_client(client)
 
         user_service = request.find_service(name='user')
-        user = user_service.fetch(forwarded_userid)
+        try:
+            user = user_service.fetch(forwarded_userid)
+        except ValueError:  # raised if userid is invalid format
+            return None  # invalid user, so we are failing here
 
         if user and user.authority == client.authority:
             return util.principals_for_auth_client_user(user, client)

--- a/h/views/api/groups.py
+++ b/h/views/api/groups.py
@@ -9,6 +9,7 @@ from h.auth.util import request_auth_client, validate_auth_client_authority
 from h.exceptions import PayloadError
 from h.presenters import GroupJSONPresenter, GroupsJSONPresenter
 from h.schemas.api.group import CreateGroupAPISchema
+from h.schemas import ValidationError
 from h.traversal import GroupContext
 from h.views.api.config import api_config
 
@@ -42,6 +43,9 @@ def groups(request):
             description='Create a new group')
 def create(request):
     """Create a group from the POST payload."""
+    if request.user is None:
+        raise ValidationError('Request must have an authenticated user')
+
     schema = CreateGroupAPISchema()
 
     appstruct = schema.validate(_json_payload(request))

--- a/tests/functional/api/test_groups.py
+++ b/tests/functional/api/test_groups.py
@@ -81,6 +81,18 @@ class TestAddMember(object):
 
         assert user in group.members
 
+    def test_it_ignores_forwarded_user_header(self, app, user, factories, group, auth_client_header):
+        headers = auth_client_header
+        user2 = factories.User()
+        headers[native_str('X-Forwarded-User')] = native_str(user2.userid)
+
+        res = app.post_json("/api/groups/{pubid}/members/{userid}".format(pubid=group.pubid, userid=user.userid),
+                            headers=auth_client_header)
+
+        assert user in group.members
+        assert user2 not in group.members
+        assert res.status_code == 204
+
     def test_it_is_idempotent(self, app, user, group, auth_client_header):
         app.post_json("/api/groups/{pubid}/members/{userid}".format(pubid=group.pubid, userid=user.userid),
                             headers=auth_client_header)

--- a/tests/functional/api/test_groups.py
+++ b/tests/functional/api/test_groups.py
@@ -55,6 +55,16 @@ class TestCreateGroup(object):
 
         assert res.status_code == 200
 
+    def test_it_returns_http_404_with_invalid_forwarded_user_format(self, app, auth_client_header, user):
+        # FIXME: This should return a 403
+        headers = auth_client_header
+        headers[native_str('X-Forwarded-User')] = native_str('floopflarp')
+        group = {}
+
+        res = app.post_json('/api/groups', group, headers=headers, expect_errors=True)
+
+        assert res.status_code == 404
+
 
 @pytest.mark.functional
 class TestAddMember(object):

--- a/tests/h/auth/policy_test.py
+++ b/tests/h/auth/policy_test.py
@@ -237,6 +237,12 @@ class TestAPIAuthenticationPolicy(object):
         return APIAuthenticationPolicy(user_policy=user_policy,
                                         client_policy=client_policy)
 
+    @pytest.fixture
+    def pyramid_request(self, pyramid_request):
+        pyramid_request.path = '/api/groups'
+        pyramid_request.method = 'POST'
+        return pyramid_request
+
 
 class TestAuthClientAuthenticationPolicy(object):
 

--- a/tests/h/auth/policy_test.py
+++ b/tests/h/auth/policy_test.py
@@ -406,6 +406,18 @@ class TestAuthClientAuthenticationPolicy(object):
 
         user_service.fetch.assert_called_once_with('acct:flop@woebang.baz')
 
+    def test_check_returns_None_if_user_fetch_raises_valueError(self,
+                                                                pyramid_request,
+                                                                verify_auth_client,
+                                                                user_service):
+
+        pyramid_request.headers['X-Forwarded-User'] = 'flop@woebang.baz'
+        user_service.fetch.side_effect = ValueError('whoops')
+
+        principals = AuthClientPolicy.check('someusername', 'somepassword', pyramid_request)
+
+        assert principals is None
+
     def test_check_returns_None_if_fetch_forwarded_user_fails(self,
                                                               pyramid_request,
                                                               verify_auth_client,

--- a/tests/h/views/api/groups_test.py
+++ b/tests/h/views/api/groups_test.py
@@ -179,6 +179,13 @@ class TestCreateGroup(object):
         GroupJSONPresenter.assert_called_once_with(GroupContext.return_value)
         GroupJSONPresenter.return_value.asdict.assert_called_once_with(expand=['organization'])
 
+    def test_it_raises_validation_error_if_missing_request_user(self,
+                                                                pyramid_request):
+        pyramid_request.user = None
+
+        with pytest.raises(ValidationError, match="must have an authenticated user"):
+            views.create(pyramid_request)
+
     @pytest.fixture
     def pyramid_request(self, pyramid_request, factories):
         # Add a nominal json_body so that _json_payload() parsing of


### PR DESCRIPTION
~~~DEPENDS ON #5223~~~ <-- That's been merged and this has been rebased

This PR enables the new `APIAuthenticationPolicy`, which is a no-op for all API endpoints (still uses Token Auth for them) except `POST /api/groups`. Thus, a private group may be created by an auth client with a forwarded user.

At this stage, there is a check in the view itself to validate that there is a `request.user` present (versus an auth_client that passed authentication but doesn't have a forwarded user to work with).