### PR TITLE
Replace Builder class with elasticsearch_dsl

### DIFF
--- a/h/activity/query.py
+++ b/h/activity/query.py
@@ -165,8 +165,8 @@ def fetch_annotations(session, ids):
 @newrelic.agent.function_trace()
 def _execute_search(request, query, page_size):
     search = Search(request, stats=request.stats)
-    search.append_filter(AuthorityFilter(authority=request.authority))
-    search.append_filter(TopLevelAnnotationsFilter())
+    search.append_modifier(AuthorityFilter(authority=request.authority))
+    search.append_modifier(TopLevelAnnotationsFilter())
     for agg in aggregations_for(query):
         search.append_aggregation(agg)
 

--- a/tests/common/fixtures/elasticsearch.py
+++ b/tests/common/fixtures/elasticsearch.py
@@ -22,7 +22,7 @@ def es_client():
                                 conflicts='proceed')
 
 
-@pytest.fixture
+@pytest.fixture(scope="session", autouse=True)
 def es_connect():
     # TODO handle deleting things out of this connection's index as
     # the `es_client` fixture does

--- a/tests/h/activity/query_test.py
+++ b/tests/h/activity/query_test.py
@@ -239,7 +239,7 @@ class TestExecute(object):
         execute(pyramid_request, MultiDict(), self.PAGE_SIZE)
 
         TopLevelAnnotationsFilter.assert_called_once_with()
-        search.append_filter.assert_any_call(TopLevelAnnotationsFilter.return_value)
+        search.append_modifier.assert_any_call(TopLevelAnnotationsFilter.return_value)
 
     def test_it_only_shows_annotations_from_current_authority(self,
                                                               pyramid_request,
@@ -248,7 +248,7 @@ class TestExecute(object):
         execute(pyramid_request, MultiDict(), self.PAGE_SIZE)
 
         AuthorityFilter.assert_called_once_with(pyramid_request.authority)
-        search.append_filter.assert_any_call(AuthorityFilter.return_value)
+        search.append_modifier.assert_any_call(AuthorityFilter.return_value)
 
     def test_it_adds_a_tags_aggregation_to_the_search_query(self,
                                                             pyramid_request,
@@ -603,7 +603,7 @@ class TestExecute(object):
     @pytest.fixture
     def search(self, annotations):
         search = mock.Mock(
-            spec_set=['append_filter', 'append_aggregation', 'run'])
+            spec_set=['append_modifier', 'append_aggregation', 'run'])
         search.run.return_value = mock.Mock(
             spec_set=['total', 'aggregations', 'annotation_ids'])
         search.run.return_value.total = 20

--- a/tests/h/search/core_test.py
+++ b/tests/h/search/core_test.py
@@ -10,7 +10,6 @@ Tests for filtering/matching/aggregating on specific annotation fields are in
 from __future__ import unicode_literals
 
 import datetime
-import pytest
 
 from h import search
 
@@ -123,18 +122,6 @@ class TestSearch(object):
 
         assert result.reply_ids == []
 
-    def test_it_passes_es_version_to_builder(self, pyramid_request, Builder):
-        client = pyramid_request.es
-
-        search.Search(pyramid_request)
-
-        assert Builder.call_count == 2
-        Builder.assert_any_call(es_version=client.version)
-
-    @pytest.fixture
-    def Builder(self, patch):
-        return patch('h.search.core.query.Builder', autospec=True)
-
 
 class TestSearchWithSeparateReplies(object):
     """Unit tests for search.Search when separate_replies=True is given."""
@@ -242,9 +229,3 @@ class TestSearchWithSeparateReplies(object):
 
         assert len(result.reply_ids) == 3
         assert oldest_reply.id not in result.reply_ids
-
-
-@pytest.fixture
-def pyramid_request(request, pyramid_request, es_client):
-    pyramid_request.es = es_client
-    return pyramid_request


### PR DESCRIPTION
The Builder class is a customized version of elasticsearch-dsl. It is a legacy class that was made back when there was no solution for building elasticsearch queries. Replacing the Builder class with elasticsearch-dsl reduces hidden complexity that previously existed inside the Builder class (for example making the sorters and limiters into their own qualifier classes) and makes the building of the query more explicit and readable. It also shifts us off of an internally maintained wrapper class to an externally maintained library which means less time that devs have to dedicate to maintaining our internal solution.

