### PR TITLE
Optionally skip elastic plugin check.

### DIFF
--- a/h/cli/commands/init.py
+++ b/h/cli/commands/init.py
@@ -45,4 +45,4 @@ def _init_search(settings):
     client = search.get_client(settings)
 
     log.info("initializing ES6 search index")
-    search.init(client, settings)
+    search.init(client, check_icu_plugin=settings.get('es.check_icu_plugin', True))

--- a/h/cli/commands/init.py
+++ b/h/cli/commands/init.py
@@ -45,4 +45,4 @@ def _init_search(settings):
     client = search.get_client(settings)
 
     log.info("initializing ES6 search index")
-    search.init(client)
+    search.init(client, settings)

--- a/h/config.py
+++ b/h/config.py
@@ -43,6 +43,7 @@ def configure(environ=None, settings=None):
     settings_manager.set('es.client.timeout', 'ELASTICSEARCH_CLIENT_TIMEOUT', type_=float)
     settings_manager.set('es.url', 'ELASTICSEARCH_URL', required=True),
     settings_manager.set('es.index', 'ELASTICSEARCH_INDEX')
+    settings_manager.set('es.skip_plugin_check', 'ELASTICSEARCH_SKIP_PLUGIN_CHECK', type_=asbool)
     settings_manager.set('mail.default_sender', 'MAIL_DEFAULT_SENDER')
     settings_manager.set('mail.host', 'MAIL_HOST')
     settings_manager.set('mail.port', 'MAIL_PORT', type_=int)

--- a/h/config.py
+++ b/h/config.py
@@ -43,7 +43,7 @@ def configure(environ=None, settings=None):
     settings_manager.set('es.client.timeout', 'ELASTICSEARCH_CLIENT_TIMEOUT', type_=float)
     settings_manager.set('es.url', 'ELASTICSEARCH_URL', required=True),
     settings_manager.set('es.index', 'ELASTICSEARCH_INDEX')
-    settings_manager.set('es.skip_plugin_check', 'ELASTICSEARCH_SKIP_PLUGIN_CHECK', type_=asbool)
+    settings_manager.set('es.check_icu_plugin', 'ELASTICSEARCH_CHECK_ICU_PLUGIN', type_=asbool, default=True)
     settings_manager.set('mail.default_sender', 'MAIL_DEFAULT_SENDER')
     settings_manager.set('mail.host', 'MAIL_HOST')
     settings_manager.set('mail.port', 'MAIL_PORT', type_=int)

--- a/h/search/config.py
+++ b/h/search/config.py
@@ -143,7 +143,7 @@ ANALYSIS_SETTINGS = {
 def init(client, settings):
     """Initialise Elasticsearch, creating necessary indices and aliases."""
     # Ensure the ICU analysis plugin is installed
-    if not settings.get('es.skip_plugin_check', False):
+    if settings.get('es.check_icu_plugin', True):
         _ensure_icu_plugin(client.conn)
 
     # If the index already exists (perhaps as an alias), we're done...

--- a/h/search/config.py
+++ b/h/search/config.py
@@ -140,10 +140,10 @@ ANALYSIS_SETTINGS = {
 }
 
 
-def init(client, settings):
+def init(client, check_icu_plugin=True):
     """Initialise Elasticsearch, creating necessary indices and aliases."""
     # Ensure the ICU analysis plugin is installed
-    if settings.get('es.check_icu_plugin', True):
+    if check_icu_plugin:
         _ensure_icu_plugin(client.conn)
 
     # If the index already exists (perhaps as an alias), we're done...

--- a/h/search/config.py
+++ b/h/search/config.py
@@ -140,10 +140,11 @@ ANALYSIS_SETTINGS = {
 }
 
 
-def init(client):
+def init(client, settings):
     """Initialise Elasticsearch, creating necessary indices and aliases."""
     # Ensure the ICU analysis plugin is installed
-    _ensure_icu_plugin(client.conn)
+    if not settings.get('es.skip_plugin_check', False):
+        _ensure_icu_plugin(client.conn)
 
     # If the index already exists (perhaps as an alias), we're done...
     if client.conn.indices.exists(index=client.index):

--- a/tests/common/fixtures/elasticsearch.py
+++ b/tests/common/fixtures/elasticsearch.py
@@ -56,7 +56,7 @@ def init_elasticsearch(request):
     maybe_delete_index()
 
     # Initialize the test search index.
-    search.init(es_client)
+    search.init(es_client, {})
 
 
 def _es_client():

--- a/tests/common/fixtures/elasticsearch.py
+++ b/tests/common/fixtures/elasticsearch.py
@@ -56,7 +56,7 @@ def init_elasticsearch(request):
     maybe_delete_index()
 
     # Initialize the test search index.
-    search.init(es_client, {})
+    search.init(es_client)
 
 
 def _es_client():

--- a/tests/h/cli/commands/init_test.py
+++ b/tests/h/cli/commands/init_test.py
@@ -49,12 +49,12 @@ class TestInitCommand(object):
                                 cliconfig,
                                 search,
                                 pyramid_settings):
+        pyramid_settings['es.check_icu_plugin'] = False
         es_client = search.get_client.return_value
-
         result = cli.invoke(init_cli.init, obj=cliconfig)
 
         search.get_client.assert_called_once_with(pyramid_settings)
-        search.init.assert_any_call(es_client, pyramid_settings)
+        search.init.assert_any_call(es_client, pyramid_settings['es.check_icu_plugin'])
         assert result.exit_code == 0
 
 

--- a/tests/h/cli/commands/init_test.py
+++ b/tests/h/cli/commands/init_test.py
@@ -54,7 +54,7 @@ class TestInitCommand(object):
         result = cli.invoke(init_cli.init, obj=cliconfig)
 
         search.get_client.assert_called_once_with(pyramid_settings)
-        search.init.assert_any_call(es_client)
+        search.init.assert_any_call(es_client, pyramid_settings)
         assert result.exit_code == 0
 
 

--- a/tests/h/search/config_test.py
+++ b/tests/h/search/config_test.py
@@ -100,7 +100,7 @@ class TestInit(object):
     def test_skips_plugin_check(self, client, configure_index):
         client.conn.cat.plugins.return_value = ''
 
-        init(client, {'es.skip_plugin_check': True})
+        init(client, {'es.check_icu_plugin': False})
 
         configure_index.assert_called_once_with(client)
 

--- a/tests/h/search/config_test.py
+++ b/tests/h/search/config_test.py
@@ -71,13 +71,13 @@ def test_uri_part_tokenizer():
 class TestInit(object):
     def test_configures_index_when_index_missing(self, client, configure_index):
         """Calls configure_index when one doesn't exist."""
-        init(client, {})
+        init(client)
 
         configure_index.assert_called_once_with(client)
 
     def test_configures_alias(self, client):
         """Adds an alias to the newly-created index."""
-        init(client, {})
+        init(client)
 
         client.conn.indices.put_alias.assert_called_once_with(index='foo-abcd1234', name='foo')
 
@@ -85,7 +85,7 @@ class TestInit(object):
         """Exits early if the index (or an alias) already exists."""
         client.conn.indices.exists.return_value = True
 
-        init(client, {})
+        init(client)
 
         assert not configure_index.called
 
@@ -93,14 +93,14 @@ class TestInit(object):
         client.conn.cat.plugins.return_value = ''
 
         with pytest.raises(RuntimeError) as e:
-            init(client, {})
+            init(client)
 
         assert 'plugin is not installed' in str(e.value)
 
     def test_skips_plugin_check(self, client, configure_index):
         client.conn.cat.plugins.return_value = ''
 
-        init(client, {'es.check_icu_plugin': False})
+        init(client, check_icu_plugin=False)
 
         configure_index.assert_called_once_with(client)
 

--- a/tests/h/search/config_test.py
+++ b/tests/h/search/config_test.py
@@ -71,13 +71,13 @@ def test_uri_part_tokenizer():
 class TestInit(object):
     def test_configures_index_when_index_missing(self, client, configure_index):
         """Calls configure_index when one doesn't exist."""
-        init(client)
+        init(client, {})
 
         configure_index.assert_called_once_with(client)
 
     def test_configures_alias(self, client):
         """Adds an alias to the newly-created index."""
-        init(client)
+        init(client, {})
 
         client.conn.indices.put_alias.assert_called_once_with(index='foo-abcd1234', name='foo')
 
@@ -85,7 +85,7 @@ class TestInit(object):
         """Exits early if the index (or an alias) already exists."""
         client.conn.indices.exists.return_value = True
 
-        init(client)
+        init(client, {})
 
         assert not configure_index.called
 
@@ -93,9 +93,16 @@ class TestInit(object):
         client.conn.cat.plugins.return_value = ''
 
         with pytest.raises(RuntimeError) as e:
-            init(client)
+            init(client, {})
 
         assert 'plugin is not installed' in str(e.value)
+
+    def test_skips_plugin_check(self, client, configure_index):
+        client.conn.cat.plugins.return_value = ''
+
+        init(client, {'es.skip_plugin_check': True})
+
+        configure_index.assert_called_once_with(client)
 
     @pytest.fixture
     def client(self, client):


### PR DESCRIPTION
Some managed elastic providers, like Bonsai, disable access to
administrative endpoints like `/_cat/plugins`. In these cases, we have
to skip the check on the icu plugin.

For context, I'm deploying `h` via heroku.