### PR TITLE
Make Group.organization nullable and create new private groups with no organization

### DIFF
--- a/h/migrations/versions/5d256923d642_make_organization_relation_nullable_on_.py
+++ b/h/migrations/versions/5d256923d642_make_organization_relation_nullable_on_.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+"""Make organization relation nullable on group"""
+from __future__ import unicode_literals
+from __future__ import absolute_import
+from __future__ import division
+
+from alembic import op
+
+
+revision = "5d256923d642"
+down_revision = "7fe5d688edd9"
+
+
+def upgrade():
+    op.alter_column('group', 'organization_id', nullable=True)
+
+
+def downgrade():
+    op.alter_column('group', 'organization_id', nullable=False)

--- a/h/models/group.py
+++ b/h/models/group.py
@@ -73,7 +73,7 @@ class Group(Base, mixins.Timestamps):
 
     scopes = sa.orm.relationship('GroupScope', backref='group', cascade='all, delete-orphan')
 
-    organization_id = sa.Column(sa.Integer, sa.ForeignKey('organization.id'), nullable=False)
+    organization_id = sa.Column(sa.Integer, sa.ForeignKey('organization.id'), nullable=True)
     organization = sa.orm.relationship('Organization')
 
     def __init__(self, **kwargs):

--- a/h/presenters/group_json.py
+++ b/h/presenters/group_json.py
@@ -21,16 +21,20 @@ class GroupJSONPresenter(object):
 
     def _expand(self, model, expand=[]):
         if 'organization' in expand:
-            model['organization'] = OrganizationJSONPresenter(
-              self.organization_context
-            ).asdict()
+            if self.organization_context:
+                model['organization'] = OrganizationJSONPresenter(
+                  self.organization_context
+                ).asdict()
         return model
 
     def _model(self):
+        organization = None
+        if self.organization_context:
+            organization = self.organization_context.id
         model = {
           'id': self.context.id,
           'name': self.group.name,
-          'organization': self.organization_context.id,
+          'organization': organization,
           'public': self.group.is_public,  # DEPRECATED: TODO: remove from client
           'scoped': True if self.group.scopes else False,
           'type': self.group.type

--- a/h/services/group.py
+++ b/h/services/group.py
@@ -6,7 +6,7 @@ from functools import partial
 import sqlalchemy as sa
 
 from h import session
-from h.models import Group, GroupScope, Organization, User
+from h.models import Group, GroupScope, User
 from h.models.group import ReadableBy, OPEN_GROUP_TYPE_FLAGS, PRIVATE_GROUP_TYPE_FLAGS, RESTRICTED_GROUP_TYPE_FLAGS
 
 
@@ -192,9 +192,8 @@ class GroupService(object):
         """
         creator = self.user_fetcher(userid)
         scopes = [GroupScope(origin=o) for o in origins]
-        if organization is None:
-            organization = Organization.default(self.session)
-        self._validate_authorities_match(creator.authority, organization.authority)
+        if organization is not None:
+            self._validate_authorities_match(creator.authority, organization.authority)
         group = Group(name=name,
                       authority=creator.authority,
                       creator=creator,

--- a/h/templates/admin/groups.html.jinja2
+++ b/h/templates/admin/groups.html.jinja2
@@ -42,8 +42,10 @@
               </a>
             </td>
             <td>
+            {% if group.organization %}
               {% set org_url = request.route_url('admin.organizations_edit', pubid=group.organization.pubid) %}
               <a href="{{ org_url }}">{{ group.organization.name }}</a>
+            {% endif %}
             </td>
             <td>
               {% if group.creator %}

--- a/h/traversal/contexts.py
+++ b/h/traversal/contexts.py
@@ -123,4 +123,6 @@ class GroupContext(object):
 
     @property
     def organization(self):
-        return OrganizationContext(self.group.organization, self.request)
+        if self.group.organization is not None:
+            return OrganizationContext(self.group.organization, self.request)
+        return None

--- a/h/views/activity.py
+++ b/h/views/activity.py
@@ -97,7 +97,10 @@ class GroupSearchController(SearchController):
     def __init__(self, group, request):
         super(GroupSearchController, self).__init__(request)
         self.group = group
-        self._organization_context = OrganizationContext(group.organization, request)
+        if group.organization:
+            self._organization_context = OrganizationContext(group.organization, request)
+        else:
+            self._organization_context = None
 
     @view_config(request_method='GET')
     def search(self):
@@ -167,10 +170,15 @@ class GroupSearchController(SearchController):
                                           pubid=self.group.pubid,
                                           slug=self.group.slug),
             'share_subtitle': _('Share group'),
-            'share_msg': _('Sharing the link lets people view this group:'),
-            'organization': {'name': self.group.organization.name,
-                             'logo': self._organization_context.logo}
+            'share_msg': _('Sharing the link lets people view this group:')
         }
+        if self.group.organization:
+            result['group']['organization'] = {
+                'name': self.group.organization.name,
+                'logo': self._organization_context.logo
+            }
+        else:
+            result['group']['organization'] = None
 
         if self.group.type == 'private':
             result['group']['share_subtitle'] = _('Invite new members')

--- a/tests/h/presenters/group_json_test.py
+++ b/tests/h/presenters/group_json_test.py
@@ -70,6 +70,17 @@ class TestGroupJSONPresenter(object):
 
         assert 'url' not in presenter.asdict()
 
+    def test_it_sets_organization_None_if_group_has_no_organization(self, factories, GroupContext):
+        group = factories.OpenGroup(name='My Group',
+                                    pubid='mygroup')
+        group.organization = None
+        group_context = GroupContext(group)
+        presenter = GroupJSONPresenter(group_context)
+
+        model = presenter.asdict()
+
+        assert model['organization'] is None
+
     def test_it_does_not_expand_by_default(self, factories, GroupContext):
         group = factories.OpenGroup(name='My Group',
                                     pubid='mygroup')
@@ -89,6 +100,17 @@ class TestGroupJSONPresenter(object):
         model = presenter.asdict(expand=['organization'])
 
         assert model['organization'] == OrganizationJSONPresenter(group_context.organization).asdict.return_value
+
+    def test_expanded_organizations_None_if_missing(self, factories, GroupContext, OrganizationJSONPresenter):
+        group = factories.OpenGroup(name='My Group',
+                                    pubid='mygroup')
+        group.organization = None
+        group_context = GroupContext(group)
+        presenter = GroupJSONPresenter(group_context)
+
+        model = presenter.asdict(expand=['organization'])
+
+        assert model['organization'] is None
 
     def test_it_ignores_unrecognized_expands(self, factories, GroupContext):
         group = factories.OpenGroup(name='My Group',

--- a/tests/h/services/group_test.py
+++ b/tests/h/services/group_test.py
@@ -66,11 +66,11 @@ class TestGroupServiceCreatePrivateGroup(object):
 
         assert getattr(group, flag) == expected_value
 
-    def test_it_creates_group_with_default_organization(
+    def test_it_creates_group_with_no_organization_by_default(
             self, default_organization, creator, svc):
         group = svc.create_private_group('Anteater fans', creator.userid)
 
-        assert group.organization == default_organization
+        assert group.organization is None
 
     def test_it_creates_group_with_specified_organization(self, factories, creator, svc):
         org = factories.Organization()
@@ -143,11 +143,11 @@ class TestGroupServiceCreateOpenGroup(object):
 
         assert getattr(group, flag) == expected_value
 
-    def test_it_creates_group_with_default_organization(
+    def test_it_creates_group_with_no_organization_by_default(
             self, default_organization, creator, svc, origins):
         group = svc.create_open_group('Anteater fans', creator.userid, origins=origins)
 
-        assert group.organization == default_organization
+        assert group.organization is None
 
     def test_it_creates_group_with_specified_organization(self, factories, creator, svc, origins):
         org = factories.Organization()
@@ -233,11 +233,11 @@ class TestGroupServiceCreateRestrictedGroup(object):
 
         assert getattr(group, flag) == expected_value
 
-    def test_it_creates_group_with_default_organization(
+    def test_it_creates_group_with_no_organization_by_default(
             self, default_organization, creator, svc, origins):
         group = svc.create_restricted_group('Anteater fans', creator.userid, origins=origins)
 
-        assert group.organization == default_organization
+        assert group.organization is None
 
     def test_it_creates_group_with_specified_organization(self, factories, creator, svc, origins):
         org = factories.Organization()

--- a/tests/h/traversal/contexts_test.py
+++ b/tests/h/traversal/contexts_test.py
@@ -169,6 +169,14 @@ class TestGroupContext(object):
 
         assert isinstance(group_context.organization, OrganizationContext)
 
+    def test_it_returns_None_for_missing_organization_relation(self, factories, pyramid_request):
+        group = factories.Group()
+        group.organization = None
+
+        group_context = GroupContext(group, pyramid_request)
+
+        assert group_context.organization is None
+
 
 @pytest.mark.usefixtures('organization_routes')
 class TestOrganizationContext(object):

--- a/tests/h/views/activity_test.py
+++ b/tests/h/views/activity_test.py
@@ -250,6 +250,26 @@ class TestGroupSearchController(object):
         assert group_info['organization']['name'] == default_org.name
 
     @pytest.mark.parametrize('test_group,test_user',
+                             [('no_organization_group', 'member')],
+                             indirect=['test_group', 'test_user'])
+    def test_search_does_not_return_organization_info_if_missing(
+            self,
+            controller,
+            factories,
+            test_group,
+            test_user,
+            default_org,
+            OrganizationContext,
+            pyramid_request):
+        group_info = controller.search()['group']
+
+        assert group_info['created'] == "{d:%B} {d.day}, {d:%Y}".format(d=test_group.created)
+        assert group_info['description'] == test_group.description
+        assert group_info['name'] == test_group.name
+        assert group_info['pubid'] == test_group.pubid
+        assert group_info['organization'] is None
+
+    @pytest.mark.parametrize('test_group,test_user',
                              [('no_creator_group', 'member'), ('no_creator_open_group', 'user')],
                              indirect=['test_group', 'test_user'])
     def test_search_does_not_show_the_edit_link_to_non_admin_users(self,
@@ -1179,6 +1199,13 @@ def no_creator_group(factories):
 
 
 @pytest.fixture
+def no_organization_group(factories):
+    group = factories.Group(organization=None)
+    group.members.extend([factories.User(), factories.User()])
+    return group
+
+
+@pytest.fixture
 def open_group(factories):
     open_group = factories.OpenGroup()
     return open_group
@@ -1199,10 +1226,11 @@ def no_creator_open_group(factories):
 
 
 @pytest.fixture
-def groups(group, open_group, no_creator_group, no_creator_open_group, restricted_group):
+def groups(group, open_group, no_creator_group, no_creator_open_group, no_organization_group, restricted_group):
     return {"open_group": open_group,
             "group": group,
             "no_creator_open_group": no_creator_open_group,
+            "no_organization_group": no_organization_group,
             "no_creator_group": no_creator_group,
             "restricted_group": restricted_group}
 


### PR DESCRIPTION
This PR contains all of the places I believe need to be touched in `h` to make `group.organization_id` (the organization relation on group) nullable/optional.

Things that are not here:

* Updates to API documentation, which we should do to denote what `organization` looks like on returned `group` objects when the relation is missing (I want to decide what it _should_ look like, first)
* Possible update to group factory in tests to _not_ assign an `organization` by default (should we do this?)

Each change is separated out in a commit, if it's easier to review that way...