### PR TITLE
Update API docs to indicate group.organization may be `null`

### DIFF
--- a/docs/_extra/api-reference/schemas/group.yaml
+++ b/docs/_extra/api-reference/schemas/group.yaml
@@ -21,11 +21,13 @@ Group:
     name:
       type: string
     organization:
-      description: "**EXPANDABLE** The organization to which this group belongs"
+      description: "**EXPANDABLE** The organization to which this group belongs. May be `null`, even if expanded, as not all groups belong to an organization"
       oneOf:
-        - $ref: './organization.yaml#/Organization'
-        - type: string
-          description: The unique ID for the organization (when not expanded)
+          - type: null
+            description: Not all groups have an organization
+          - type: string
+            description: The unique ID for the organization (when not expanded)
+          - $ref: './organization.yaml#/Organization'
     public:
       type: boolean
       deprecated: true


### PR DESCRIPTION
This PR is independent, but it doesn't make sense to merge it until after #5223 

This updates API docs for the value of `organization` in `GET /api/groups` response `group` objects. There are now _three_ possible types that `organization` could have:

* `object`, if organization has been expanded _and_ the group has an organization relationship
* `string`, if organization has _not_ been expanded _and_ the group has an organization relationship
* `null`, if group has no organization, regardless of whether expanded or not

Some screenshots to save time:

<img width="767" alt="screen shot 2018-08-17 at 11 42 24 am" src="https://user-images.githubusercontent.com/439947/44283405-2db95880-a213-11e8-9a86-e9a850c22684.png">

<img width="745" alt="screen shot 2018-08-17 at 11 42 30 am" src="https://user-images.githubusercontent.com/439947/44283411-30b44900-a213-11e8-87ed-b51d8b6d629c.png">

<img width="789" alt="screen shot 2018-08-17 at 11 42 41 am" src="https://user-images.githubusercontent.com/439947/44283416-3316a300-a213-11e8-8eea-10dcd3fde2ec.png">
