### PR TITLE
Add `make sql` to connect to dev DB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,11 @@ docstrings:
 checkdocstrings:
 	tox -e checkdocstrings
 
+.PHONY: sql
+sql:
+	@pip install -q tox
+	tox -e sql
+
 ################################################################################
 
 # Fake targets to aid with deps installation

--- a/tox.ini
+++ b/tox.ini
@@ -114,3 +114,10 @@ deps = {[docstrings]deps}
 commands =
     {[docstrings]commands}
     sphinx-build -qTn -b dirhtml {envtmpdir}/rst {envtmpdir}/dirhtml
+
+[testenv:sql]
+basepython = python3.6
+deps =
+    docker-compose
+commands =
+    docker-compose exec postgres psql -U postgres


### PR DESCRIPTION
Add a convenient `make sql` command to connect to your development database with `psql`.

`make sql` will:

- Bail out if no virtualenv is activated
- Install `tox` in the activated virtualenv, if it isn't isntalled already
- Call `tox`, which will:
- Create a separate virtualenv for the `make sql` command
- Install `docker-compose` in that virtualenv
- Call `docker-compose` to run `psql` in the h dev env's main postgres docker container (running the copy of psql from the postgres docker container)

The developer doesn't need to install `docker-compose` or `psql` themselves.