### PR TITLE
Install tox when running docs-related make commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,18 +71,22 @@ lint: .pydeps
 
 .PHONY: docs
 docs:
+	@pip install -q tox
 	tox -e docs
 
 .PHONY: checkdocs
 checkdocs:
+	@pip install -q tox
 	tox -e checkdocs
 
 .PHONY: docstrings
 docstrings:
+	@pip install -q tox
 	tox -e docstrings
 
 .PHONY: checkdocstrings
 checkdocstrings:
+	@pip install -q tox
 	tox -e checkdocstrings
 
 ################################################################################


### PR DESCRIPTION
Automatically install `tox` in the developer's virtualenv when running any of the various docs-related `Makefile` commands (`make docs` etc).

This fixes an issue that, if the developer didn't already have `tox` available on their system, the various docs-related `Makefile` commands would fail.

Having the `Makefile` explicitly install `tox` is consistent with how `make test` already does it.

The use of `PIP_REQUIRE_VIRTUALENV` in the `Makefile` prevents `tox` from being installed if the developer hasn't created and activated a virtualenv for h - it won't try to install `tox` globally.