### PR TITLE
Pipe compressed archive to `docker build`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ dev: build/manifest.json .pydeps
 ## Build hypothesis/hypothesis docker image
 .PHONY: docker
 docker:
-	git archive HEAD | docker build -t hypothesis/hypothesis:$(DOCKER_TAG) -
+	git archive --format=tar.gz HEAD | docker build -t hypothesis/hypothesis:$(DOCKER_TAG) -
 
 # Run docker container.
 #


### PR DESCRIPTION
On my system (git 2.18.0 from Homebrew, docker 18.06.0-ce, macOS),
the "make docker" task was failing with the error:

```
git archive HEAD | docker build -t hypothesis/hypothesis:dev -
Sending build context to Docker daemon  4.487MB
Error response from daemon: Syntax error - can't find = in "paster.bootstrap(config,". Must be of the form: name=value
make: *** [docker] Error 1
```

The "docker build" documentation [1] states that the context should be
compressed, and sure enough configuring `git archive` to generate a
compressed archive resolves the issue.

[1] https://docs.docker.com/engine/reference/commandline/build/#build-with--