### PR TITLE
Default to groups with no organization in test factories

### DIFF
--- a/tests/common/factories/group.py
+++ b/tests/common/factories/group.py
@@ -12,11 +12,6 @@ from .group_scope import GroupScope
 from .user import User
 
 
-def default_organization():
-    from tests.common.factories.base import SESSION
-    return models.Organization.default(SESSION)
-
-
 class Group(ModelFactory):
 
     class Meta:
@@ -30,7 +25,6 @@ class Group(ModelFactory):
     readable_by = ReadableBy.members
     writeable_by = WriteableBy.members
     members = factory.LazyAttribute(lambda obj: [obj.creator])
-    organization = factory.LazyFunction(default_organization)
 
     @factory.post_generation
     def scopes(self, create, scopes=0, **kwargs):

--- a/tests/h/presenters/group_json_test.py
+++ b/tests/h/presenters/group_json_test.py
@@ -13,7 +13,8 @@ from h import traversal
 class TestGroupJSONPresenter(object):
     def test_private_group_asdict(self, factories, GroupContext, links_svc):
         group = factories.Group(name='My Group',
-                                pubid='mygroup')
+                                pubid='mygroup',
+                                organization=factories.Organization())
         group_context = GroupContext(group)
         presenter = GroupJSONPresenter(group_context)
 
@@ -29,7 +30,8 @@ class TestGroupJSONPresenter(object):
 
     def test_open_group_asdict(self, factories, GroupContext, links_svc):
         group = factories.OpenGroup(name='My Group',
-                                    pubid='mygroup')
+                                    pubid='mygroup',
+                                    organization=factories.Organization())
         group_context = GroupContext(group)
         presenter = GroupJSONPresenter(group_context)
 
@@ -46,7 +48,8 @@ class TestGroupJSONPresenter(object):
     def test_open_scoped_group_asdict(self, factories, GroupContext, links_svc):
         group = factories.OpenGroup(name='My Group',
                                     pubid='groupy',
-                                    scopes=[factories.GroupScope(origin='http://foo.com')])
+                                    scopes=[factories.GroupScope(origin='http://foo.com')],
+                                    organization=factories.Organization())
         group_context = GroupContext(group)
         presenter = GroupJSONPresenter(group_context)
 
@@ -83,7 +86,8 @@ class TestGroupJSONPresenter(object):
 
     def test_it_does_not_expand_by_default(self, factories, GroupContext):
         group = factories.OpenGroup(name='My Group',
-                                    pubid='mygroup')
+                                    pubid='mygroup',
+                                    organization=factories.Organization())
         group_context = GroupContext(group)
         presenter = GroupJSONPresenter(group_context)
 
@@ -93,7 +97,8 @@ class TestGroupJSONPresenter(object):
 
     def test_it_expands_organizations(self, factories, GroupContext, OrganizationJSONPresenter):
         group = factories.OpenGroup(name='My Group',
-                                    pubid='mygroup')
+                                    pubid='mygroup',
+                                    organization=factories.Organization())
         group_context = GroupContext(group)
         presenter = GroupJSONPresenter(group_context)
 
@@ -114,7 +119,8 @@ class TestGroupJSONPresenter(object):
 
     def test_it_ignores_unrecognized_expands(self, factories, GroupContext):
         group = factories.OpenGroup(name='My Group',
-                                    pubid='mygroup')
+                                    pubid='mygroup',
+                                    organization=factories.Organization())
         group_context = GroupContext(group)
         presenter = GroupJSONPresenter(group_context)
 

--- a/tests/h/traversal/contexts_test.py
+++ b/tests/h/traversal/contexts_test.py
@@ -162,12 +162,20 @@ class TestGroupContext(object):
 
         assert group_context.id == group.pubid  # NOT the group.id
 
-    def test_it_expands_organization(self, factories, pyramid_request):
+    def test_organization_is_None_if_the_group_has_no_organization(self, factories, pyramid_request):
         group = factories.Group()
 
         group_context = GroupContext(group, pyramid_request)
 
-        assert isinstance(group_context.organization, OrganizationContext)
+        assert group_context.organization is None
+
+    def test_it_expands_organization_if_the_group_has_one(self, factories, pyramid_request):
+        organization = factories.Organization()
+        group = factories.Group(organization=organization)
+
+        group_context = GroupContext(group, pyramid_request)
+
+        assert group_context.organization.organization == organization
 
     def test_it_returns_None_for_missing_organization_relation(self, factories, pyramid_request):
         group = factories.Group()

--- a/tests/h/views/activity_test.py
+++ b/tests/h/views/activity_test.py
@@ -246,8 +246,7 @@ class TestGroupSearchController(object):
         assert group_info['description'] == test_group.description
         assert group_info['name'] == test_group.name
         assert group_info['pubid'] == test_group.pubid
-        assert group_info['organization']['logo'] == OrganizationContext(None, None).logo
-        assert group_info['organization']['name'] == default_org.name
+        assert group_info['organization'] is None
 
     @pytest.mark.parametrize('test_group,test_user',
                              [('no_organization_group', 'member')],

--- a/tests/h/views/admin/groups_test.py
+++ b/tests/h/views/admin/groups_test.py
@@ -256,8 +256,12 @@ class TestGroupEditController(object):
         assert [s.origin for s in group.scopes] == updated_origins
         assert ctx['form'] == self._expected_form(group)
 
-    def test_update_updates_group_members_on_success(self, factories, pyramid_request, group_svc, user_svc, handle_form_submission):
-        group = factories.RestrictedGroup(pubid='testgroup')
+    def test_update_updates_group_members_on_success(self, factories, pyramid_request, group_svc, user_svc, handle_form_submission, list_orgs_svc):
+        group = factories.RestrictedGroup(
+            pubid='testgroup',
+            organization=factories.Organization(),
+        )
+        list_orgs_svc.organizations.return_value = [group.organization]
 
         pyramid_request.matchdict = {'pubid': group.pubid}
 
@@ -296,7 +300,10 @@ class TestGroupEditController(object):
 
     @pytest.fixture
     def group(self, factories):
-        return factories.OpenGroup(pubid='testgroup')
+        return factories.OpenGroup(
+            pubid='testgroup',
+            organization=factories.Organization(),
+        )
 
     def _expected_form(self, group):
         return {'creator': group.creator.username if group.creator else '',


### PR DESCRIPTION
Depends on <https://github.com/hypothesis/h/pull/5223>.

Change the `factories.Group` test factory to create groups with no organization (`group.organization` is `None`) by default as this is now the default behaviour when creating a group in production.

If you do want to create a test group with an organization you can do so explicitly with something like:

    group = factories.Group(organization=factories.Organization())