### PR TITLE
Remove unnecessary lint comments

### DIFF
--- a/tests/h/models/user_test.py
+++ b/tests/h/models/user_test.py
@@ -179,7 +179,7 @@ class TestUserModelUserId(object):
 
 class TestUserModel(object):
 
-    def test_User_activate_activates_user(self, db_session):  # noqa: N802
+    def test_User_activate_activates_user(self, db_session):
         user = models.User(authority='example.com',
                            username='kiki',
                            email='kiki@kiki.com')
@@ -193,7 +193,7 @@ class TestUserModel(object):
 
         assert user.is_activated
 
-    def test_privacy_accepted_defaults_to_None(self, db_session):  # noqa: N802
+    def test_privacy_accepted_defaults_to_None(self, db_session):
         # nullable
         assert getattr(models.User(), "privacy_accepted") is None
 

--- a/tests/h/presenters/group_json_test.py
+++ b/tests/h/presenters/group_json_test.py
@@ -11,7 +11,7 @@ from h import traversal
 
 
 class TestGroupJSONPresenter(object):
-    def test_private_group_asdict(self, factories, GroupContext, links_svc):  # noqa: N803
+    def test_private_group_asdict(self, factories, GroupContext, links_svc):
         group = factories.Group(name='My Group',
                                 pubid='mygroup')
         group_context = GroupContext(group)
@@ -27,7 +27,7 @@ class TestGroupJSONPresenter(object):
             'links': links_svc.get_all.return_value,
         }
 
-    def test_open_group_asdict(self, factories, GroupContext, links_svc):  # noqa: N803
+    def test_open_group_asdict(self, factories, GroupContext, links_svc):
         group = factories.OpenGroup(name='My Group',
                                     pubid='mygroup')
         group_context = GroupContext(group)
@@ -43,7 +43,7 @@ class TestGroupJSONPresenter(object):
             'links': links_svc.get_all.return_value,
         }
 
-    def test_open_scoped_group_asdict(self, factories, GroupContext, links_svc):  # noqa: N803
+    def test_open_scoped_group_asdict(self, factories, GroupContext, links_svc):
         group = factories.OpenGroup(name='My Group',
                                     pubid='groupy',
                                     scopes=[factories.GroupScope(origin='http://foo.com')])
@@ -60,7 +60,7 @@ class TestGroupJSONPresenter(object):
             'links': links_svc.get_all.return_value,
         }
 
-    def test_it_does_not_contain_deprecated_url(self, factories, GroupContext, links_svc):  # noqa: N803
+    def test_it_does_not_contain_deprecated_url(self, factories, GroupContext, links_svc):
         links_svc.get_all.return_value = {
             'html': 'foobar'
         }
@@ -70,7 +70,7 @@ class TestGroupJSONPresenter(object):
 
         assert 'url' not in presenter.asdict()
 
-    def test_it_does_not_expand_by_default(self, factories, GroupContext):  # noqa: N803
+    def test_it_does_not_expand_by_default(self, factories, GroupContext):
         group = factories.OpenGroup(name='My Group',
                                     pubid='mygroup')
         group_context = GroupContext(group)
@@ -80,7 +80,7 @@ class TestGroupJSONPresenter(object):
 
         assert model['organization'] == group_context.organization.id
 
-    def test_it_expands_organizations(self, factories, GroupContext, OrganizationJSONPresenter):  # noqa: N803
+    def test_it_expands_organizations(self, factories, GroupContext, OrganizationJSONPresenter):
         group = factories.OpenGroup(name='My Group',
                                     pubid='mygroup')
         group_context = GroupContext(group)
@@ -90,7 +90,7 @@ class TestGroupJSONPresenter(object):
 
         assert model['organization'] == OrganizationJSONPresenter(group_context.organization).asdict.return_value
 
-    def test_it_ignores_unrecognized_expands(self, factories, GroupContext):  # noqa: N803
+    def test_it_ignores_unrecognized_expands(self, factories, GroupContext):
         group = factories.OpenGroup(name='My Group',
                                     pubid='mygroup')
         group_context = GroupContext(group)
@@ -103,7 +103,7 @@ class TestGroupJSONPresenter(object):
 
 class TestGroupsJSONPresenter(object):
 
-    def test_proxies_to_GroupJSONPresenter(self, factories, GroupJSONPresenter_, GroupContexts):  # noqa: [N802, N803]
+    def test_proxies_to_GroupJSONPresenter(self, factories, GroupJSONPresenter_, GroupContexts):  # noqa: N802
         groups = [factories.Group(), factories.OpenGroup()]
         group_contexts = GroupContexts(groups)
         presenter = GroupsJSONPresenter(group_contexts)
@@ -113,7 +113,7 @@ class TestGroupsJSONPresenter(object):
 
         assert GroupJSONPresenter_.call_args_list == expected_call_args
 
-    def test_asdicts_returns_list_of_dicts(self, factories, GroupContexts):  # noqa: N803
+    def test_asdicts_returns_list_of_dicts(self, factories, GroupContexts):
         groups = [factories.Group(name='filbert'), factories.OpenGroup(name='delbert')]
         group_contexts = GroupContexts(groups)
         presenter = GroupsJSONPresenter(group_contexts)
@@ -122,7 +122,7 @@ class TestGroupsJSONPresenter(object):
 
         assert [group['name'] for group in result] == ['filbert', 'delbert']
 
-    def test_asdicts_injects_links(self, factories, links_svc, GroupContexts):  # noqa: N803
+    def test_asdicts_injects_links(self, factories, links_svc, GroupContexts):
         groups = [factories.Group(), factories.OpenGroup()]
         group_contexts = GroupContexts(groups)
         presenter = GroupsJSONPresenter(group_contexts)

--- a/tests/h/presenters/group_json_test.py
+++ b/tests/h/presenters/group_json_test.py
@@ -103,7 +103,7 @@ class TestGroupJSONPresenter(object):
 
 class TestGroupsJSONPresenter(object):
 
-    def test_proxies_to_GroupJSONPresenter(self, factories, GroupJSONPresenter_, GroupContexts):  # noqa: N802
+    def test_proxies_to_GroupJSONPresenter(self, factories, GroupJSONPresenter_, GroupContexts):
         groups = [factories.Group(), factories.OpenGroup()]
         group_contexts = GroupContexts(groups)
         presenter = GroupsJSONPresenter(group_contexts)
@@ -141,24 +141,24 @@ def links_svc(pyramid_config):
 
 
 @pytest.fixture
-def GroupContext(pyramid_request, links_svc):  # noqa: N802
+def GroupContext(pyramid_request, links_svc):
     def resource_factory(group):
         return traversal.GroupContext(group, pyramid_request)
     return resource_factory
 
 
 @pytest.fixture
-def GroupContexts(pyramid_request, links_svc):  # noqa: N802
+def GroupContexts(pyramid_request, links_svc):
     def resource_factory(groups):
         return [traversal.GroupContext(group, pyramid_request) for group in groups]
     return resource_factory
 
 
 @pytest.fixture
-def GroupJSONPresenter_(patch):  # noqa: N802
+def GroupJSONPresenter_(patch):
     return patch('h.presenters.group_json.GroupJSONPresenter')
 
 
 @pytest.fixture
-def OrganizationJSONPresenter(patch):  # noqa: N802
+def OrganizationJSONPresenter(patch):
     return patch('h.presenters.group_json.OrganizationJSONPresenter')

--- a/tests/h/views/accounts_test.py
+++ b/tests/h/views/accounts_test.py
@@ -489,7 +489,7 @@ class TestActivateController(object):
         assert success_flash
         assert success_flash[0].startswith("Your account has been activated")
 
-    def test_get_when_not_logged_in_successful_creates_ActivationEvent(  # noqa: N802
+    def test_get_when_not_logged_in_successful_creates_ActivationEvent(
             self,
             pyramid_request,
             user_model,
@@ -891,7 +891,7 @@ def activation_model(patch):
 
 
 @pytest.fixture
-def ActivationEvent(patch):  # noqa: N802
+def ActivationEvent(patch):
     return patch('h.views.accounts.ActivationEvent')
 
 

--- a/tests/h/views/accounts_test.py
+++ b/tests/h/views/accounts_test.py
@@ -489,7 +489,7 @@ class TestActivateController(object):
         assert success_flash
         assert success_flash[0].startswith("Your account has been activated")
 
-    def test_get_when_not_logged_in_successful_creates_ActivationEvent(  # noqa: N802, N803
+    def test_get_when_not_logged_in_successful_creates_ActivationEvent(  # noqa: N802
             self,
             pyramid_request,
             user_model,
@@ -502,7 +502,7 @@ class TestActivateController(object):
         ActivationEvent.assert_called_once_with(
             pyramid_request, user_model.get_by_activation.return_value)
 
-    def test_get_when_not_logged_in_successful_notifies(self,  # noqa: N803
+    def test_get_when_not_logged_in_successful_notifies(self,
                                                         notify,
                                                         pyramid_request,
                                                         user_model,

--- a/tests/h/views/admin/groups_test.py
+++ b/tests/h/views/admin/groups_test.py
@@ -82,7 +82,7 @@ class TestGroupCreateController(object):
 
         assert 'form' in ctx
 
-    def test_get_lists_all_organizations(self, pyramid_request, factories, default_org,  # noqa: N803
+    def test_get_lists_all_organizations(self, pyramid_request, factories, default_org,
                                          CreateAdminGroupSchema, list_orgs_svc):
         GroupCreateController(pyramid_request)
 
@@ -166,7 +166,7 @@ class TestGroupCreateController(object):
 @pytest.mark.usefixtures('routes', 'user_svc', 'group_svc', 'list_orgs_svc')
 class TestGroupEditController(object):
 
-    def test_it_binds_schema(self, pyramid_request, group, user_svc,  # noqa: N803
+    def test_it_binds_schema(self, pyramid_request, group, user_svc,
                              default_org, CreateAdminGroupSchema):
         pyramid_request.matchdict = {'pubid': group.pubid}
 
@@ -207,7 +207,7 @@ class TestGroupEditController(object):
 
         assert ctx['form'] == self._expected_form(group)
 
-    def test_read_lists_organizations_in_groups_authority(self, factories, pyramid_request, group,  # noqa: N803
+    def test_read_lists_organizations_in_groups_authority(self, factories, pyramid_request, group,
                                                           default_org, CreateAdminGroupSchema,
                                                           list_orgs_svc):
         pyramid_request.matchdict = {'pubid': group.pubid}

--- a/tests/h/views/admin/groups_test.py
+++ b/tests/h/views/admin/groups_test.py
@@ -370,7 +370,7 @@ def list_orgs_svc(pyramid_config, db_session):
 @pytest.fixture
 def CreateAdminGroupSchema(patch):
     schema = mock.Mock(spec_set=['bind'])
-    CreateAdminGroupSchema = patch('h.views.admin.groups.CreateAdminGroupSchema')  # noqa: N806
+    CreateAdminGroupSchema = patch('h.views.admin.groups.CreateAdminGroupSchema')
     CreateAdminGroupSchema.return_value = schema
     return CreateAdminGroupSchema
 

--- a/tests/h/views/admin/groups_test.py
+++ b/tests/h/views/admin/groups_test.py
@@ -368,7 +368,7 @@ def list_orgs_svc(pyramid_config, db_session):
 
 
 @pytest.fixture
-def CreateAdminGroupSchema(patch):  # noqa: N802
+def CreateAdminGroupSchema(patch):
     schema = mock.Mock(spec_set=['bind'])
     CreateAdminGroupSchema = patch('h.views.admin.groups.CreateAdminGroupSchema')  # noqa: N806
     CreateAdminGroupSchema.return_value = schema

--- a/tests/h/views/admin/users_test.py
+++ b/tests/h/views/admin/users_test.py
@@ -164,7 +164,7 @@ def test_users_activate_inits_ActivationEvent(ActivationEvent, user_service, pyr
 
 
 @users_activate_fixtures
-def test_users_activate_calls_notify(ActivationEvent, notify, pyramid_request): # noqa N802
+def test_users_activate_calls_notify(ActivationEvent, notify, pyramid_request):
     pyramid_request.params = {"userid": "acct:bob@example.com"}
 
     users_activate(pyramid_request)
@@ -220,7 +220,7 @@ def routes(pyramid_config):
 
 
 @pytest.fixture
-def ActivationEvent(patch):  # noqa N802
+def ActivationEvent(patch):
     return patch('h.views.admin.users.ActivationEvent')
 
 

--- a/tests/h/views/admin/users_test.py
+++ b/tests/h/views/admin/users_test.py
@@ -154,7 +154,7 @@ def test_users_activate_flashes_success(pyramid_request):
 
 
 @users_activate_fixtures
-def test_users_activate_inits_ActivationEvent(ActivationEvent, user_service, pyramid_request): # noqa N803
+def test_users_activate_inits_ActivationEvent(ActivationEvent, user_service, pyramid_request):
     pyramid_request.params = {"userid": "acct:bob@example.com"}
 
     users_activate(pyramid_request)


### PR DESCRIPTION
Some lint comments for disabling flake8 rules (`# noqa: N803` etc) that're already disabled globally have slipped into the codebase.

The globally disabled flake8 rules are [here](https://github.com/hypothesis/h/blob/658a05afda15ea9d920cb97c101ceeee4f178708/setup.cfg#L4-L15) and for the test files, [here](https://github.com/hypothesis/h/blob/658a05afda15ea9d920cb97c101ceeee4f178708/tests/setup.cfg#L5-L30).

I'm guessing that some developers' editors' lint integrations are failing to pick up our linter config or perhaps just the tests linter config.

The source of truth for this is `make lint`, though, which does pick them up.

Reasons we disable linter rules globally:

1. Save developers time, not having to line-by-line disable rules that we don't want to follow
2. Avoid littering the code with a whole lot of `noqa` comments
3. Avoid a "crying wolf" effect where developers will get into the habit of ignoring `noqa` comments (instead of taking note of them, being aware of what they mean, questioning whether they're still necessary, ...) because there are just so many of them

Putting a lot of `noqa` comments for rules that're disabled globally defeats all three reasons.