### PR TITLE
Search indexing test cleanups

### DIFF
--- a/tests/h/search/index_test.py
+++ b/tests/h/search/index_test.py
@@ -88,11 +88,8 @@ class TestIndex(object):
 
         event = AnnotationTransformEvent.return_value
 
-        AnnotationTransformEvent.assert_called_with(pyramid_request, annotation, mock.ANY)
-
-        # `notify` will be called twice. Once when indexing with ES1, once when
-        # indexing with ES6.
-        notify.assert_called_with(event)
+        AnnotationTransformEvent.assert_called_once_with(pyramid_request, annotation, mock.ANY)
+        notify.assert_called_once_with(event)
 
     def test_you_can_filter_annotations_by_authority(self, factories, index, search):
         annotation = factories.Annotation.build(userid="acct:someone@example.com")

--- a/tests/h/search/index_test.py
+++ b/tests/h/search/index_test.py
@@ -28,6 +28,19 @@ class TestIndex(object):
                                     id=annotation.id)
         assert result["_id"] == annotation.id
 
+    def test_it_indexes_presented_annotation(self, factories, get, index,
+                                             AnnotationSearchIndexPresenter):
+        annotation = factories.Annotation.build()
+        presenter = AnnotationSearchIndexPresenter.return_value
+        presenter.asdict.return_value = {'id': annotation.id,
+                                         'some_other_field': 'a_value'}
+
+        index(annotation)
+        indexed_doc = get(annotation.id)
+
+        AnnotationSearchIndexPresenter.assert_called_once_with(annotation)
+        assert indexed_doc == presenter.asdict.return_value
+
     def test_it_can_index_an_annotation_with_no_document(self, factories,
                                                          index, get):
         annotation = factories.Annotation.build(document=None)


### PR DESCRIPTION
These three commits address a few pieces of cleanup for the new search indexing tests:

- The first commit removes a comment that only applied when we were indexing into two clusters at the same time
- The second commit ports a test over from old_index_test.py which I don't think was adequately covered by the new tests
- The third commit replaces some duplicated code for fetching annotations from ES with the existing `get` fixture which I renamed to `get_indexed_ann` for clarity.

I put these in the same PR since they build on one another. Happy to split them out if that's a problem.