### PR TITLE
Decrease min group name to 3 characters

### DIFF
--- a/docs/_extra/api-reference/schemas/new-group.yaml
+++ b/docs/_extra/api-reference/schemas/new-group.yaml
@@ -4,7 +4,7 @@ Group:
     name:
       type: string
       description: The name of the new group
-      minLength: 4
+      minLength: 3
       maxLength: 25
     description:
       type: string

--- a/h/models/group.py
+++ b/h/models/group.py
@@ -13,7 +13,7 @@ from h.db import mixins
 from h import pubid
 
 
-GROUP_NAME_MIN_LENGTH = 4
+GROUP_NAME_MIN_LENGTH = 3
 GROUP_NAME_MAX_LENGTH = 25
 GROUP_DESCRIPTION_MAX_LENGTH = 250
 

--- a/tests/h/models/groups_test.py
+++ b/tests/h/models/groups_test.py
@@ -19,9 +19,9 @@ def test_init_sets_given_attributes():
 
 
 def test_with_short_name():
-    """Should raise ValueError if name shorter than 4 characters."""
+    """Should raise ValueError if name shorter than 3 characters."""
     with pytest.raises(ValueError):
-        models.Group(name="abc")
+        models.Group(name="ab")
 
 
 def test_with_long_name():


### PR DESCRIPTION
CNN and other user groups of H have 3 character acronyms and would like to use their acronym as their group name. This enables them to do that by changing the minimum character limit of group names from 4 to 3. 