### PR TITLE
Support specifying query and body schemas in @api_config decorator

### DIFF
--- a/h/schemas/api/group.py
+++ b/h/schemas/api/group.py
@@ -2,6 +2,8 @@
 
 from __future__ import unicode_literals
 
+import colander
+
 from h.schemas.base import JSONSchema
 from h.models.group import (
     GROUP_NAME_MIN_LENGTH,
@@ -29,3 +31,22 @@ class CreateGroupAPISchema(JSONSchema):
             'name'
         ],
     }
+
+
+class GetGroupsAPISchema(colander.Schema):
+    """Query parameter schema for `GET /api/groups`."""
+
+    authority = colander.SchemaNode(colander.String(),
+                                    missing=None,
+                                    description="Domain of authority to fetch groups for")
+
+    document_uri = colander.SchemaNode(colander.String(),
+                                       validator=colander.url,
+                                       missing=None,
+                                       description="Include public groups associated with this URL")
+
+    expand = colander.SchemaNode(colander.Sequence(),
+                                 colander.SchemaNode(colander.String(),
+                                                     validator=colander.OneOf(["organization"])),
+                                 missing=[],
+                                 description="Sub-fields to expand in the response")

--- a/h/views/api/config.py
+++ b/h/views/api/config.py
@@ -1,6 +1,8 @@
 from __future__ import unicode_literals
 import venusian
 
+from h.exceptions import PayloadError
+from h.schemas.base import validate_query_params
 from h.util import cors
 
 
@@ -14,7 +16,8 @@ cors_policy = cors.policy(
 
 
 def add_api_view(config, view, link_name=None, description=None,
-                 enable_preflight=True, **settings):
+                 enable_preflight=True, query_schema=None,
+                 body_schema=None, **settings):
 
     """
     Add a view configuration for an API view.
@@ -24,6 +27,14 @@ def add_api_view(config, view, link_name=None, description=None,
     specified it adds the view to the list of views returned by the `api.index`
     route.
 
+    If `query_schema` is provided, it specifies the schema for query parameters
+    for this request. In the view callable, the parsed and validated parameters
+    are available as `request.validated_params`.
+
+    If `body_schema` is provided, it specifies the schema for the JSON body
+    for this request. In the view callable, the parsed and validated body
+    is available as `request.validated_body`.
+
     :param config: The Pyramid `Configurator`
     :param view: The view callable
     :param link_name: Dotted path of the metadata for this route in the output
@@ -32,6 +43,10 @@ def add_api_view(config, view, link_name=None, description=None,
     :param enable_preflight: If `True` add support for CORS preflight requests
                              for this view. If `True`, a `route_name` must be
                              specified.
+    :param body_schema: JSON body schema for this request
+    :type body_schema: h.schemas.JSONSchema
+    :param query_schema: Query parameter schema for this request
+    :type query_schema: colander.Schema
     :param settings: Arguments to pass on to `config.add_view`
     """
 
@@ -58,7 +73,24 @@ def add_api_view(config, view, link_name=None, description=None,
             registry.api_links = []
         registry.api_links.append(link)
 
-    config.add_view(view=view, **settings)
+    def api_view_wrapper(request, *args, **kwargs):
+        if query_schema:
+            def validate_params(request):
+                return validate_query_params(query_schema, request.GET)
+            request.set_property(validate_params, name='validated_params')
+
+        if body_schema:
+            def validate_body(request):
+                try:
+                    body = request.json_body
+                except ValueError:
+                    raise PayloadError()
+                return body_schema.validate(body)
+            request.set_property(validate_body, name='validated_body')
+
+        return view(request, *args, **kwargs)
+
+    config.add_view(view=api_view_wrapper, **settings)
     if enable_preflight:
         cors.add_preflight_view(config, settings['route_name'], cors_policy)
 

--- a/h/views/api/groups.py
+++ b/h/views/api/groups.py
@@ -8,7 +8,7 @@ from pyramid.httpexceptions import HTTPNoContent, HTTPBadRequest, HTTPNotFound
 from h.auth.util import request_auth_client, validate_auth_client_authority
 from h.exceptions import PayloadError
 from h.presenters import GroupJSONPresenter, GroupsJSONPresenter
-from h.schemas.api.group import CreateGroupAPISchema
+from h.schemas.api.group import CreateGroupAPISchema, GetGroupsAPISchema
 from h.traversal import GroupContext
 from h.views.api.config import api_config
 
@@ -16,11 +16,12 @@ from h.views.api.config import api_config
 @api_config(route_name='api.groups',
             request_method='GET',
             link_name='groups.read',
-            description="Fetch the user's groups")
+            description="Fetch the user's groups",
+            query_schema=GetGroupsAPISchema())
 def groups(request):
-    authority = request.params.get('authority')
-    document_uri = request.params.get('document_uri')
-    expand = request.GET.getall('expand') or []
+    authority = request.validated_params['authority']
+    document_uri = request.validated_params['document_uri']
+    expand = request.validated_params['expand']
 
     list_svc = request.find_service(name='list_groups')
 

--- a/tests/h/views/api/config_test.py
+++ b/tests/h/views/api/config_test.py
@@ -1,9 +1,12 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import unicode_literals
+
 import mock
 import pytest
+from webob.multidict import MultiDict
 
+from h.schemas.base import JSONSchema, ValidationError
 from h.views.api import config as api_config
 
 
@@ -76,6 +79,55 @@ class TestAddApiView(object):
             'method': expected_method,
             'route_name': route_name,
         }]
+
+    def test_api_view_validates_query(self, pyramid_config, pyramid_request, patch):
+        validate_query_params = patch('h.views.api.config.validate_query_params')
+
+        def view(request):
+            assert request.validated_params == {"foo": 42}
+
+        query_schema = mock.Mock()
+        api_config.add_api_view(pyramid_config, view, route_name='thing.read',
+                                query_schema=query_schema)
+        (_, kwargs) = pyramid_config.add_view.call_args
+        wrapped_view = kwargs['view']
+
+        # Calling with an invalid query should raise.
+        validate_query_params.side_effect = ValidationError()
+        pyramid_request.GET = MultiDict({})
+        with pytest.raises(ValidationError):
+            wrapped_view(pyramid_request)
+
+        # Calling with a valid query should not raise.
+        validate_query_params.side_effect = None
+        validate_query_params.return_value = {"foo": 42}
+        pyramid_request.GET = MultiDict({"foo": "42"})
+        wrapped_view(pyramid_request)
+
+    def test_api_view_validates_body(self, pyramid_config, pyramid_request):
+        def validate(data):
+            if data.get("foo", None) != "bar":
+                raise ValidationError()
+            return data
+
+        def view(request):
+            assert request.validated_body == {"foo": "bar"}
+
+        body_schema = mock.create_autospec(JSONSchema, spec_set=True, instance=True)
+        body_schema.validate.side_effect = validate
+        api_config.add_api_view(pyramid_config, view, route_name='thing.update',
+                                body_schema=body_schema)
+        (_, kwargs) = pyramid_config.add_view.call_args
+        wrapped_view = kwargs['view']
+
+        # Calling with an invalid body should raise.
+        pyramid_request.json_body = {"foo": "wibble"}
+        with pytest.raises(ValidationError):
+            wrapped_view(pyramid_request)
+
+        # Calling with a valid body should not raise.
+        pyramid_request.json_body = {"foo": "bar"}
+        wrapped_view(pyramid_request)
 
     @pytest.fixture
     def pyramid_config(self, pyramid_config):

--- a/tests/h/views/api/groups_test.py
+++ b/tests/h/views/api/groups_test.py
@@ -107,35 +107,21 @@ class TestGetGroups(object):
         pyramid_request.user = factories.User()
         return pyramid_request
 
+    @pytest.fixture
+    def pyramid_request(self, pyramid_request):
+        pyramid_request.validated_params = {'authority': None, 'document_uri': None, 'expand': []}
+        return pyramid_request
 
-@pytest.mark.usefixtures('CreateGroupAPISchema',
-                         'group_service',
+
+@pytest.mark.usefixtures('group_service',
                          'GroupContext',
                          'GroupJSONPresenter')
 class TestCreateGroup(object):
 
-    def test_it_inits_group_create_schema(self, pyramid_request, CreateGroupAPISchema):
-        views.create(pyramid_request)
-
-        CreateGroupAPISchema.assert_called_once_with()
-
-    # @TODO Move this test once _json_payload() has been moved to a reusable util module
-    def test_it_raises_if_json_parsing_fails(self, pyramid_request):
-        """It raises PayloadError if parsing of the request body fails."""
-        # Make accessing the request.json_body property raise ValueError.
-        type(pyramid_request).json_body = {}
-        with mock.patch.object(type(pyramid_request),
-                               'json_body',
-                               new_callable=mock.PropertyMock) as json_body:
-            json_body.side_effect = ValueError()
-            with pytest.raises(views.PayloadError):
-                views.create(pyramid_request)
-
     def test_it_passes_request_params_to_group_create_service(self,
                                                               pyramid_request,
-                                                              CreateGroupAPISchema,
                                                               group_service):
-        CreateGroupAPISchema.return_value.validate.return_value = {
+        pyramid_request.validated_body = {
           'name': 'My Group',
           'description': 'How about that?',
          }
@@ -147,9 +133,8 @@ class TestCreateGroup(object):
 
     def test_it_sets_description_to_none_if_not_present(self,
                                                         pyramid_request,
-                                                        CreateGroupAPISchema,
                                                         group_service):
-        CreateGroupAPISchema.return_value.validate.return_value = {
+        pyramid_request.validated_body = {
           'name': 'My Group',
          }
         views.create(pyramid_request)
@@ -180,9 +165,7 @@ class TestCreateGroup(object):
 
     @pytest.fixture
     def pyramid_request(self, pyramid_request, factories):
-        # Add a nominal json_body so that _json_payload() parsing of
-        # it doesn't raise
-        pyramid_request.json_body = {}
+        pyramid_request.validated_body = {'name': 'A group', 'description': 'About this group'}
         pyramid_request.user = factories.User()
         return pyramid_request
 
@@ -380,11 +363,6 @@ def GroupsJSONPresenter(patch):
 @pytest.fixture
 def GroupContext(patch):
     return patch('h.views.api.groups.GroupContext')
-
-
-@pytest.fixture
-def CreateGroupAPISchema(patch):
-    return patch('h.views.api.groups.CreateGroupAPISchema')
 
 
 @pytest.fixture

--- a/tests/h/views/api/groups_test.py
+++ b/tests/h/views/api/groups_test.py
@@ -32,8 +32,8 @@ class TestGetGroups(object):
         )
 
     def test_proxies_request_params(self, anonymous_request, list_groups_service):
-        anonymous_request.params['document_uri'] = 'http://example.com/thisthing.html'
-        anonymous_request.params['authority'] = 'foo.com'
+        anonymous_request.validated_params['document_uri'] = 'http://example.com/thisthing.html'
+        anonymous_request.validated_params['authority'] = 'foo.com'
         views.groups(anonymous_request)
 
         list_groups_service.request_groups.assert_called_once_with(
@@ -43,7 +43,7 @@ class TestGetGroups(object):
         )
 
     def test_overrides_authority_with_user_authority(self, authenticated_request, list_groups_service):
-        authenticated_request.params['authority'] = 'foo.com'
+        authenticated_request.validated_params['authority'] = 'foo.com'
 
         views.groups(authenticated_request)
 
@@ -83,7 +83,7 @@ class TestGetGroups(object):
         assert result == GroupsJSONPresenter(open_groups).asdicts.return_value
 
     def test_proxies_expand_to_presenter(self, anonymous_request, open_groups, list_groups_service, GroupsJSONPresenter):
-        anonymous_request.params['expand'] = 'organization'
+        anonymous_request.validated_params['expand'] = ['organization']
         list_groups_service.request_groups.return_value = open_groups
 
         views.groups(anonymous_request)
@@ -91,8 +91,7 @@ class TestGetGroups(object):
         GroupsJSONPresenter(open_groups).asdicts.assert_called_once_with(expand=['organization'])
 
     def test_passes_multiple_expand_to_presenter(self, anonymous_request, open_groups, list_groups_service, GroupsJSONPresenter):
-        anonymous_request.GET.add('expand', 'organization')
-        anonymous_request.GET.add('expand', 'foobars')
+        anonymous_request.validated_params['expand'] = ['organization', 'foobars']
         list_groups_service.request_groups.return_value = open_groups
 
         views.groups(anonymous_request)


### PR DESCRIPTION
We don't currently have a standard way to validate query string parameters in the API and consistently return error messages if required params are missing, or of the wrong type, or out of range. This is also a little bit of boilerplate required to use JSON schema validation in API requests.

This PR addresses this by providing a way to declare the query and body schemas as part of the metadata for an API request in the `@api_config` decorator. Body schemas are `h.schema.JSONSchema` instances. Query schemas are `colander.Schema` instances, since they are more like form data than JSON documents.

My immediate goal is to provide better validation for a number of existing API endpoints but in future we should also be able to leverage schema metadata on API views for other purposes.

----

The first commit adds support for `query_schema` and `body_schema` parameters in the `@api_config` view decorator used to register API view callables.

The second commit shows how to use `query_schema` using the `GET /api/groups` method to provide validation for the `expand` and `document_uri` parameters.

The third commit shows how to use `body_schema` using the `POST /api/groups` method and simplifies the code and tests for that method in the process.