### PR TITLE
Add helper for validating query parameters using colander

### DIFF
--- a/h/schemas/util.py
+++ b/h/schemas/util.py
@@ -1,0 +1,73 @@
+from __future__ import unicode_literals
+
+import colander
+from webob.multidict import MultiDict
+
+from h.schemas.base import ValidationError
+
+
+def _colander_exception_msg(exc):
+    """
+    Combine error messages from a :class:`colander.Invalid` exception.
+
+    :type exc: colander.Invalid
+    :rtype: str
+    """
+    msg_dict = exc.asdict()
+    for child in exc.children:
+        msg_dict.update(child.asdict())
+    msg_list = ["{}: {}".format(field, err) for field, err in msg_dict.items()]
+    return "\n".join(msg_list)
+
+
+def _multidict_to_dict(schema, multidict):
+    """
+    Combine or drop repeated fields in a ``MultiDict`` according to a schema.
+
+    Prepare a query param ``MultiDict`` for validation against a schema by
+    converting repeated fields to lists or keeping only the last value.
+    """
+    dict_ = multidict.dict_of_lists()
+    for key, values in dict_.items():
+        node = schema.get(key)
+
+        if not node or not isinstance(node.typ, colander.Sequence):
+            dict_[key] = values[-1]
+    return dict_
+
+
+def _dict_to_multidict(dict_):
+    """Convert a validated query param dict back to a ``MultiDict``."""
+    result = MultiDict()
+    for key, value in dict_.items():
+        if isinstance(value, list):
+            for item in value:
+                result.add(key, item)
+        else:
+            result.add(key, value)
+    return result
+
+
+def validate_query_params(schema, params):
+    """
+    Validate query parameters using a Colander schema.
+
+    Repeated fields in the input are either preserved or discarded except for
+    the last value depending on whether the corresponding schema node is
+    a sequence.
+
+    :param schema: Colander schema to validate data with.
+    :type schema: colander.Schema
+    :param params: Query parameter dict, usually `request.params`.
+    :type params: webob.multidict.MultiDict
+    :rtype: webob.multidict.MultiDict
+    :raises ValidationError:
+    """
+    param_dict = _multidict_to_dict(schema, params)
+
+    try:
+        parsed = schema.deserialize(param_dict)
+    except colander.Invalid as exc:
+        raise ValidationError(_colander_exception_msg(exc))
+
+    return _dict_to_multidict(parsed)

--- a/tests/h/schemas/util_test.py
+++ b/tests/h/schemas/util_test.py
@@ -1,0 +1,77 @@
+from __future__ import unicode_literals
+
+import colander
+from webob.multidict import MultiDict
+import pytest
+
+from h.schemas.base import ValidationError
+from h.schemas.util import validate_query_params
+
+
+class QueryParamSchema(colander.Schema):
+
+    int_field = colander.SchemaNode(colander.Integer(), missing=0)
+
+    string_field = colander.SchemaNode(colander.String(), missing=None)
+
+    list_field = colander.SchemaNode(colander.Sequence(),
+                                     colander.SchemaNode(colander.String()),
+                                     missing=None)
+
+    enum_field = colander.SchemaNode(colander.String(),
+                                     validator=colander.OneOf(["up", "down"]),
+                                     missing="up")
+
+    drop_if_not_set_field = colander.SchemaNode(colander.String(), missing=colander.drop)
+
+
+class TestValidateQueryParams(object):
+
+    def test_it_deserializes_params(self):
+        schema = QueryParamSchema()
+        params = MultiDict()
+        params.add("string_field", "test")
+
+        parsed = validate_query_params(schema, params)
+
+        assert parsed == {"int_field": 0,
+                          "string_field": "test",
+                          "list_field": None,
+                          "enum_field": "up"}
+
+    def test_it_raises_if_params_invalid(self):
+        schema = QueryParamSchema()
+        params = MultiDict({"int_field": "not-an-int"})
+
+        with pytest.raises(ValidationError):
+            validate_query_params(schema, params)
+
+    def test_it_keeps_all_values_for_sequence_fields(self):
+        schema = QueryParamSchema()
+        params = MultiDict()
+        params.add("list_field", "first")
+        params.add("list_field", "second")
+
+        parsed = validate_query_params(schema, params)
+
+        assert parsed.getall("list_field") == ["first", "second"]
+
+    def test_it_keeps_only_last_value_for_non_sequence_fields(self):
+        schema = QueryParamSchema()
+        params = MultiDict()
+        params.add("string_field", "first")
+        params.add("string_field", "second")
+
+        parsed = validate_query_params(schema, params)
+
+        assert parsed.getall("string_field") == ["second"]
+
+    def test_it_does_not_include_unknown_fields(self):
+        schema = QueryParamSchema()
+        params = MultiDict()
+        params.add("string_field", "include_me")
+        params.add("unknown_field", "ignore_me")
+
+        parsed = validate_query_params(schema, params)
+
+        assert "unknown_field" not in parsed


### PR DESCRIPTION
Add a `validate_query_params` helper function for validating query
parameters (`request.GET` or `request.params`) using Colander schemas.

Compared to simply calling `schema.deserialize(request.params)` this
helper handles:

 - Raising a `ValidationError` with a single string error
   message if validation fails.

 - Preserving repeated fields. Ordinarily Colander will only return the
   last occurrence after parsing.

   In our case we want to preserve repeated fields for use in eg.
   requests such as `GET /api/search?tag=foo&tag=bar` to return
   annotations with tags "foo" and "bar".