### PR TITLE
Extend Auth Client policy to another endpoint via role, permission

### DIFF
--- a/h/auth/policy.py
+++ b/h/auth/policy.py
@@ -14,8 +14,8 @@ from h.auth import util
 
 # As we roll out the new API Auth Policy with Auth Token Policy, we
 # want to keep it restricted to certain endpoints
-# Currently restricted to `POST /api/groups` only
-AUTH_TOKEN_PATH_PATTERN = '^\/api\/groups(\/?)$'
+# Currently restricted to groups API endpoints only
+AUTH_TOKEN_PATH_PATTERN = '^\/api\/groups'
 
 
 @interface.implementer(interfaces.IAuthenticationPolicy)

--- a/h/auth/role.py
+++ b/h/auth/role.py
@@ -6,3 +6,6 @@ Admin = 'group:__admin__'
 
 #: Hypothesis staff. These users have limited access to admin functionality.
 Staff = 'group:__staff__'
+
+#: Auth Clients. Applied to requests authenticated with an auth_client
+Authclient = 'group:__authclient__'

--- a/h/auth/util.py
+++ b/h/auth/util.py
@@ -162,6 +162,7 @@ def principals_for_auth_client(client):
 
     principals = set([])
 
+    principals.add(role.Authclient)
     principals.add('client:{client_id}@{authority}'.format(client_id=client.id, authority=client.authority))
     principals.add('authority:{authority}'.format(authority=client.authority))
 

--- a/h/models/group.py
+++ b/h/models/group.py
@@ -8,6 +8,7 @@ import sqlalchemy as sa
 from pyramid import security
 import slugify
 
+from h.auth import role
 from h.db import Base
 from h.db import mixins
 from h import pubid
@@ -119,7 +120,24 @@ class Group(Base, mixins.Timestamps):
         return self.readable_by == ReadableBy.world
 
     def __acl__(self):
+        """
+        Build an appropriate ACL for this model instance.
+
+        FIXME: We should get ACL/auth'z logic out of model classes in the
+        future and fix up :py:module:`h.traversal.roots` and to appropriately
+        return contexts instead of models; then fix up `h.traversal.contexts`
+        to handle ACLs. See :py:class:`h.traversal.roots.AnnotationRoot` and
+        :py:class:`h.traversal.contexts.AnnotationContext` for the correct
+        way to do this.
+
+        .. note::
+
+            :py:attr:`h.auth.role.Authclient` is applied during authentication
+            for auth_client requests. See :py:func:`h.auth.util.principals_for_auth_client`
+        """
+
         terms = []
+        terms.append((security.Allow, role.Authclient, 'member_add'))
 
         join_principal = _join_principal(self)
         if join_principal is not None:

--- a/h/views/api/groups.py
+++ b/h/views/api/groups.py
@@ -5,7 +5,6 @@ from __future__ import unicode_literals
 from pyramid import security
 from pyramid.httpexceptions import HTTPNoContent, HTTPBadRequest, HTTPNotFound
 
-from h.auth.util import request_auth_client, validate_auth_client_authority
 from h.exceptions import PayloadError
 from h.presenters import GroupJSONPresenter, GroupsJSONPresenter
 from h.schemas.api.group import CreateGroupAPISchema
@@ -89,14 +88,13 @@ def remove_member(group, request):
 @api_config(route_name='api.group_member',
             request_method='POST',
             link_name='group.member.add',
+            permission='member_add',
             description='Add the user in the request params to a group.')
 def add_member(group, request):
     """Add a member to a given group.
 
-    :raises HTTPNotFound: if the user is not found or if the use and group
-      authorities don't match.
+    :raises HTTPNotFound: if the user is not found
     """
-    client = request_auth_client(request)
 
     user_svc = request.find_service(name='user')
     group_svc = request.find_service(name='group')
@@ -105,8 +103,6 @@ def add_member(group, request):
 
     if user is None:
         raise HTTPNotFound()
-
-    validate_auth_client_authority(client, user.authority)
 
     if user.authority != group.authority:
         raise HTTPNotFound()

--- a/tests/functional/api/test_groups.py
+++ b/tests/functional/api/test_groups.py
@@ -81,9 +81,10 @@ class TestAddMember(object):
 
         assert user in group.members
 
-    def test_it_ignores_forwarded_user_header(self, app, user, factories, group, auth_client_header):
+    def test_it_ignores_forwarded_user_header(self, app, user, factories, group, auth_client_header, db_session):
         headers = auth_client_header
         user2 = factories.User()
+        db_session.commit()
         headers[native_str('X-Forwarded-User')] = native_str(user2.userid)
 
         res = app.post_json("/api/groups/{pubid}/members/{userid}".format(pubid=group.pubid, userid=user.userid),
@@ -119,18 +120,18 @@ class TestAddMember(object):
 
         assert res.status_code == 404
 
-    def test_it_returns_403_if_missing_auth(self, app, user, group):
+    def test_it_returns_404_if_missing_auth(self, app, user, group):
         res = app.post_json("/api/groups/{pubid}/members/{userid}".format(pubid=group.pubid, userid=user.userid),
                             expect_errors=True)
 
-        assert res.status_code == 403
+        assert res.status_code == 404
 
-    def test_it_returns_403_with_token_auth(self, app, token_auth_header, user, group):
+    def test_it_returns_404_with_token_auth(self, app, token_auth_header, user, group):
         res = app.post_json("/api/groups/{pubid}/members/{userid}".format(pubid=group.pubid, userid=user.userid),
                             headers=token_auth_header,
                             expect_errors=True)
 
-        assert res.status_code == 403
+        assert res.status_code == 404
 
 
 @pytest.mark.functional

--- a/tests/h/auth/policy_test.py
+++ b/tests/h/auth/policy_test.py
@@ -37,8 +37,7 @@ AUTH_CLIENT_PATHS = (
 )
 
 NON_AUTH_CLIENT_PATHS = (
-    '/api/groups//',
-    '/api/groups/33333',
+    '/api/gro',
     '/api/badge',
     '/api',
     '/groups/'

--- a/tests/h/auth/util_test.py
+++ b/tests/h/auth/util_test.py
@@ -205,6 +205,11 @@ class TestValidateAuthClientAuthority(object):
 
 class TestPrincipalsForAuthClient(object):
 
+    def test_it_sets_auth_client_role_principal(self, auth_client):
+        principals = util.principals_for_auth_client(auth_client)
+
+        assert role.Authclient in principals
+
     def test_it_sets_auth_client_principal(self, auth_client):
         principals = util.principals_for_auth_client(auth_client)
 

--- a/tests/h/models/groups_test.py
+++ b/tests/h/models/groups_test.py
@@ -8,6 +8,7 @@ from pyramid import security
 from pyramid.authorization import ACLAuthorizationPolicy
 
 from h import models
+from h.auth import role
 from h.models.group import JoinableBy, ReadableBy, WriteableBy
 
 
@@ -129,6 +130,9 @@ def test_non_public_group():
 
 
 class TestGroupACL(object):
+    def test_auth_clients_can_add_members(self, group, authz_policy):
+        assert authz_policy.permits(group, role.Authclient, 'member_add')
+
     def test_authority_joinable(self, group, authz_policy):
         group.joinable_by = JoinableBy.authority
 


### PR DESCRIPTION
This PR applies the new `AuthClientPolicy` to the add-member-to-group endpoint. To accomplish this, a new role has been added to `h.auth.role` (`group:__Authclient__`) and that role (principal) is assigned when an auth_client authenticates successfully.

A new permission has been added to the `__acl__` method of `h.models.group` blessing all who have the `Authclient` role with a permission `add_member`. `h.views.api.groups` adds a `permission` predicate to the view config for the `group.member.add` route handler.

This has several nice effects—it thins out the `group.member.add` view function and allows tests to be simplified and redundant code to be removed; there is more red than green in this diff.

It does highlight the need, however, to get our authorization house in order; it felt icky adding more stuff to the `__acl__` method of `h.models.group`. It also raised the issue that we've set up the `@forbidden_view_config` for `/api` paths to munge all `403`s into `404`s, something that should be reconsidered. I'll open issues for each of those.

Next step is to apply this policy to the other auth-client-only endpoint (create user) and—yay!—remove a bunch of code from `h.auth.util` once it's not needed anymore.