### PR TITLE
Remove remaining references to elasticsearch1 and elasticsearch1-dsl from config files

### DIFF
--- a/conf/app.ini
+++ b/conf/app.ini
@@ -69,35 +69,3 @@ formatter = generic
 
 [formatter_generic]
 format = %(asctime)s [%(process)d] [%(name)s:%(levelname)s] %(message)s
-
-# Add temporary newrelic hooks for elasticsearch1
-[import-hook:elasticsearch1.client]
-enabled = true
-execute = newrelic.hooks.datastore_elasticsearch:instrument_elasticsearch_client
-[import-hook:elasticsearch1.client.cat]
-enabled = true
-execute = newrelic.hooks.datastore_elasticsearch:instrument_elasticsearch_client_cat
-[import-hook:elasticsearch1.client.cluster]
-enabled = true
-execute = newrelic.hooks.datastore_elasticsearch:instrument_elasticsearch_client_cluster
-[import-hook:elasticsearch1.client.indices]
-enabled = true
-execute = newrelic.hooks.datastore_elasticsearch:instrument_elasticsearch_client_indices
-[import-hook:elasticsearch1.client.nodes]
-enabled = true
-execute = newrelic.hooks.datastore_elasticsearch:instrument_elasticsearch_client_nodes
-[import-hook:elasticsearch1.client.snapshot]
-enabled = true
-execute = newrelic.hooks.datastore_elasticsearch:instrument_elasticsearch_client_snapshot
-[import-hook:elasticsearch1.client.tasks]
-enabled = true
-execute = newrelic.hooks.datastore_elasticsearch:instrument_elasticsearch_client_tasks
-[import-hook:elasticsearch1.client.ingest]
-enabled = true
-execute = newrelic.hooks.datastore_elasticsearch:instrument_elasticsearch_client_ingest
-[import-hook:elasticsearch1.connection.base]
-enabled = true
-execute = newrelic.hooks.datastore_elasticsearch:instrument_elasticsearch_connection_base
-[import-hook:elasticsearch1.transport]
-enabled = true
-execute = newrelic.hooks.datastore_elasticsearch:instrument_elasticsearch_transport

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,6 @@ deps =
     pytest
     hypothesis
     factory-boy
-    elasticsearch1-dsl
     -rrequirements.txt
 passenv =
     TEST_DATABASE_URL


### PR DESCRIPTION
These two commits remove the last couple of references to the elasticsearch1 (New Relic config) and elasticsearch1-dsl (tox config) Python libraries.