### PR TITLE
Add New Relic env vars to `run-docker` make task

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,8 @@ run-docker:
 		-e "BROKER_URL=amqp://guest:guest@rabbit:5672//" \
 		-e "DATABASE_URL=postgresql://postgres@postgres/postgres" \
 		-e "ELASTICSEARCH_URL=http://elasticsearch:9200" \
+		-e "NEW_RELIC_APP_NAME=h (dev)" \
+		-e "NEW_RELIC_LICENSE_KEY" \
 		-e "SECRET_KEY=notasecret" \
 		-p 5000:5000 \
 		hypothesis/hypothesis:$(DOCKER_TAG)


### PR DESCRIPTION
This makes it easier to run h with New Relic reporting enabled locally
for performance analysis etc.

To use it:

 1. Set the `NEW_RELIC_LICENSE_KEY` env var to the key from your NR
    Account Settings page.
 2. Run `make docker` to build the docker image from git's HEAD commit
 3. Run `make run-docker` and execute web requests against http://localhost:5000

Metrics will now appear under the "h (dev)" application in your NR
account.

If you need more flexibility, see Hannah's answer at
https://stackoverflow.com/c/hypothesis/questions/98