### PR TITLE
Change `request.authority` -> `request.default_authority`

### DIFF
--- a/h/accounts/schemas.py
+++ b/h/accounts/schemas.py
@@ -42,7 +42,7 @@ def get_blacklist():
 def unique_email(node, value):
     '''Colander validator that ensures no user with this email exists.'''
     request = node.bindings['request']
-    user = models.User.get_by_email(request.db, value, request.authority)
+    user = models.User.get_by_email(request.db, value, request.default_authority)
     if user and user.userid != request.authenticated_userid:
         msg = _("Sorry, an account with this email address already exists.")
         raise colander.Invalid(node, msg)
@@ -51,7 +51,7 @@ def unique_email(node, value):
 def unique_username(node, value):
     '''Colander validator that ensures the username does not exist.'''
     request = node.bindings['request']
-    user = models.User.get_by_username(request.db, value, request.authority)
+    user = models.User.get_by_username(request.db, value, request.default_authority)
     if user:
         msg = _("This username is already taken.")
         raise colander.Invalid(node, msg)

--- a/h/activity/query.py
+++ b/h/activity/query.py
@@ -92,7 +92,7 @@ def check_url(request, query, unparse=parser.unparse):
     elif _single_entry(query, 'user'):
         username = query.get('user')
         user = request.find_service(name='user').fetch(username,
-                                                       request.authority)
+                                                       request.default_authority)
         if user:
             query.pop('user')
             redirect = request.route_path('activity.user_search',
@@ -165,7 +165,7 @@ def fetch_annotations(session, ids):
 @newrelic.agent.function_trace()
 def _execute_search(request, query, page_size):
     search = Search(request, stats=request.stats)
-    search.append_modifier(AuthorityFilter(authority=request.authority))
+    search.append_modifier(AuthorityFilter(authority=request.default_authority))
     search.append_modifier(TopLevelAnnotationsFilter())
     for agg in aggregations_for(query):
         search.append_aggregation(agg)

--- a/h/auth/__init__.py
+++ b/h/auth/__init__.py
@@ -12,7 +12,7 @@ from h.auth.policy import AuthenticationPolicy
 from h.auth.policy import APIAuthenticationPolicy
 from h.auth.policy import AuthClientPolicy
 from h.auth.policy import TokenAuthenticationPolicy
-from h.auth.util import authority, groupfinder
+from h.auth.util import default_authority, groupfinder
 from h.security import derive_key
 
 __all__ = (
@@ -67,7 +67,7 @@ def includeme(config):
     config.set_authentication_policy(DEFAULT_POLICY)
 
     # Allow retrieval of the authority from the request object.
-    config.add_request_method(authority, name='authority', reify=True)
+    config.add_request_method(default_authority, name='default_authority', reify=True)
 
     # Allow retrieval of the auth token (if present) from the request object.
     config.add_request_method('.tokens.auth_token', reify=True)

--- a/h/auth/util.py
+++ b/h/auth/util.py
@@ -108,7 +108,7 @@ def translate_annotation_principals(principals):
     return list(result)
 
 
-def authority(request):
+def default_authority(request):
     """
     Return the value of the h.authority config settings.
 

--- a/h/auth/util.py
+++ b/h/auth/util.py
@@ -227,7 +227,7 @@ def request_auth_client(request):
 
 def validate_auth_client_authority(client, authority):
     """
-    Validate that the auth client authority matches the request authority.
+    Validate that the auth client authority matches the provided ``authority``.
     """
     if client.authority != authority:
         raise ValidationError("'authority' does not match authenticated client")

--- a/h/cli/commands/user.py
+++ b/h/cli/commands/user.py
@@ -61,7 +61,7 @@ def admin(ctx, username, authority, on):
     request = ctx.obj['bootstrap']()
 
     if not authority:
-        authority = request.authority
+        authority = request.default_authority
 
     user = models.User.get_by_username(request.db, username, authority)
     if user is None:
@@ -93,7 +93,7 @@ def password(ctx, username, authority, password):
     password_service = request.find_service(name='user_password')
 
     if not authority:
-        authority = request.authority
+        authority = request.default_authority
 
     user = models.User.get_by_username(request.db, username, authority)
     if user is None:
@@ -119,7 +119,7 @@ def delete(ctx, username, authority):
     request = ctx.obj['bootstrap']()
 
     if not authority:
-        authority = request.authority
+        authority = request.default_authority
 
     user = models.User.get_by_username(request.db, username, authority)
     if user is None:

--- a/h/emails/reply_notification.py
+++ b/h/emails/reply_notification.py
@@ -39,10 +39,10 @@ def generate(request, notification):
     unsubscribe_token = _unsubscribe_token(request, parent_user)
     unsubscribe_url = request.route_url('unsubscribe', token=unsubscribe_token)
 
-    if notification.reply_user.authority != request.authority:
+    if notification.reply_user.authority != request.default_authority:
         reply_user_url = None
 
-    if notification.parent_user.authority != request.authority:
+    if notification.parent_user.authority != request.default_authority:
         parent_user_url = None
 
     context = {

--- a/h/links.py
+++ b/h/links.py
@@ -27,7 +27,7 @@ def pretty_link(url):
 
 def html_link(request, annotation):
     """Return a link to an HTML representation of the given annotation, or None."""
-    is_third_party_annotation = annotation.authority != request.authority
+    is_third_party_annotation = annotation.authority != request.default_authority
     if is_third_party_annotation:
         # We don't currently support HTML representations of third party
         # annotations.

--- a/h/schemas/forms/accounts/forgot_password.py
+++ b/h/schemas/forms/accounts/forgot_password.py
@@ -24,7 +24,7 @@ class ForgotPasswordSchema(CSRFSchema):
 
         request = node.bindings['request']
         email = value.get('email')
-        user = models.User.get_by_email(request.db, email, request.authority)
+        user = models.User.get_by_email(request.db, email, request.default_authority)
 
         if user is None:
             err = colander.Invalid(node)

--- a/h/schemas/forms/accounts/reset_password.py
+++ b/h/schemas/forms/accounts/reset_password.py
@@ -41,7 +41,7 @@ class ResetCode(colander.SchemaType):
         except BadData:
             raise colander.Invalid(node, _('Wrong reset code.'))
 
-        user = models.User.get_by_username(request.db, username, request.authority)
+        user = models.User.get_by_username(request.db, username, request.default_authority)
         if user is None:
             raise colander.Invalid(node, _('Your reset code is not valid'))
         if user.password_updated is not None and timestamp < user.password_updated:

--- a/h/schemas/forms/admin/group.py
+++ b/h/schemas/forms/admin/group.py
@@ -69,7 +69,7 @@ def group_creator_validator(node, kw):
 
 def member_exists_validator(node, val):
     user_svc = node.bindings["request"].find_service(name='user')
-    authority = node.bindings["request"].authority
+    authority = node.bindings["request"].default_authority
     if user_svc.fetch(val, authority) is None:
         raise colander.Invalid(node, _("Username not found"))
 

--- a/h/services/group_links.py
+++ b/h/services/group_links.py
@@ -34,5 +34,5 @@ class GroupLinksService(object):
 
 def group_links_factory(context, request):
     """Return a GroupLinksService instance for the passed context and request."""
-    return GroupLinksService(default_authority=request.authority,
+    return GroupLinksService(default_authority=request.default_authority,
                              route_url=request.route_url)

--- a/h/services/groupfinder.py
+++ b/h/services/groupfinder.py
@@ -30,4 +30,4 @@ class GroupfinderService(object):
 
 
 def groupfinder_service_factory(context, request):
-    return GroupfinderService(request.db, request.authority)
+    return GroupfinderService(request.db, request.default_authority)

--- a/h/services/links.py
+++ b/h/services/links.py
@@ -6,7 +6,7 @@ from __future__ import unicode_literals
 
 from pyramid.request import Request
 
-from h.auth import authority
+from h.auth import default_authority
 
 LINK_GENERATORS_KEY = 'h.links.link_generators'
 
@@ -50,7 +50,7 @@ class LinksService(object):
 
         # Allow retrieval of the authority from the fake request object, the
         # same as we do for real requests.
-        self._request.set_property(authority, name='authority', reify=True)
+        self._request.set_property(default_authority, name='default_authority', reify=True)
 
     def get(self, annotation, name):
         """Get the link named `name` for the passed `annotation`."""

--- a/h/services/list_groups.py
+++ b/h/services/list_groups.py
@@ -32,7 +32,7 @@ class ListGroupsService(object):
 
            Determine the appropriate authority to use for querying groups.
            User's authority will always supersede if present; otherwise provide
-           default value—request.authority—if no authority specified.
+           default value—request.default_authority—if no authority specified.
         """
 
         if user is not None:
@@ -198,4 +198,4 @@ class ListGroupsService(object):
 def list_groups_factory(context, request):
     """Return a ListGroupsService instance for the passed context and request."""
     return ListGroupsService(session=request.db,
-                             request_authority=request.authority)
+                             request_authority=request.default_authority)

--- a/h/services/list_groups.py
+++ b/h/services/list_groups.py
@@ -17,15 +17,15 @@ class ListGroupsService(object):
     ALl public methods return a list of relevant group model objects.
     """
 
-    def __init__(self, session, request_authority):
+    def __init__(self, session, default_authority):
         """
         Create a new list_groups service.
 
-        :param _session: the SQLAlchemy session object
-        :param _request_authority: the authority to use as a default
+        :param session: the SQLAlchemy session object
+        :param default_authority: the authority to use as a default
         """
         self._session = session
-        self.request_authority = request_authority
+        self.default_authority = default_authority
 
     def _authority(self, user=None, authority=None):
         """Determine which authority to use.
@@ -37,7 +37,7 @@ class ListGroupsService(object):
 
         if user is not None:
             return user.authority
-        return authority or self.request_authority
+        return authority or self.default_authority
 
     def all_groups(self, user=None, authority=None, document_uri=None):
         """
@@ -198,4 +198,4 @@ class ListGroupsService(object):
 def list_groups_factory(context, request):
     """Return a ListGroupsService instance for the passed context and request."""
     return ListGroupsService(session=request.db,
-                             request_authority=request.default_authority)
+                             default_authority=request.default_authority)

--- a/h/services/user.py
+++ b/h/services/user.py
@@ -176,5 +176,5 @@ class UserService(object):
 
 def user_service_factory(context, request):
     """Return a UserService instance for the passed context and request."""
-    return UserService(default_authority=request.authority,
+    return UserService(default_authority=request.default_authority,
                        session=request.db)

--- a/h/services/user_signup.py
+++ b/h/services/user_signup.py
@@ -110,7 +110,7 @@ class UserSignupService(object):
 
 def user_signup_service_factory(context, request):
     """Return a UserSignupService instance for the passed context and request."""
-    return UserSignupService(default_authority=request.authority,
+    return UserSignupService(default_authority=request.default_authority,
                              mailer=mailer,
                              session=request.db,
                              signup_email=partial(signup.generate, request),

--- a/h/session.py
+++ b/h/session.py
@@ -10,7 +10,7 @@ def model(request):
     session = {}
     session['csrf'] = request.session.get_csrf_token()
     session['userid'] = request.authenticated_userid
-    session['groups'] = _current_groups(request, request.authority)
+    session['groups'] = _current_groups(request, request.default_authority)
     session['features'] = request.feature.all()
     session['preferences'] = _user_preferences(request.user)
     return session
@@ -31,7 +31,7 @@ def profile(request, authority=None):
     if user is not None:
         authority = user.authority
     else:
-        authority = authority or request.authority
+        authority = authority or request.default_authority
 
     profile = {}
     profile['userid'] = request.authenticated_userid

--- a/h/traversal/roots.py
+++ b/h/traversal/roots.py
@@ -216,7 +216,8 @@ class UserRoot(object):
         self.user_svc = self.request.find_service(name='user')
 
     def __getitem__(self, username):
-        user = self.user_svc.fetch(username, self.request.authority)
+        # FIXME: At present, this fetch would never work for third-party users
+        user = self.user_svc.fetch(username, self.request.default_authority)
 
         if not user:
             raise KeyError()

--- a/h/views/admin/admins.py
+++ b/h/views/admin/admins.py
@@ -17,7 +17,7 @@ def admins_index(request):
     admins = request.db.query(models.User).filter(models.User.admin)
     return {
         "admin_users": [u.userid for u in admins],
-        "default_authority": request.authority,
+        "default_authority": request.default_authority,
     }
 
 

--- a/h/views/admin/features.py
+++ b/h/views/admin/features.py
@@ -85,7 +85,7 @@ def cohorts_edit(context, request):
     return {
         'cohort': cohort,
         'members': cohort.members,
-        'default_authority': request.authority
+        'default_authority': request.default_authority
     }
 
 

--- a/h/views/admin/nipsa.py
+++ b/h/views/admin/nipsa.py
@@ -20,7 +20,7 @@ def nipsa_index(request):
     nipsa_service = request.find_service(name='nipsa')
     return {
         "userids": sorted(nipsa_service.fetch_all_flagged_userids()),
-        "default_authority": request.authority,
+        "default_authority": request.default_authority,
     }
 
 

--- a/h/views/admin/oauthclients.py
+++ b/h/views/admin/oauthclients.py
@@ -47,7 +47,7 @@ class AuthClientCreateController(object):
     def get(self):
         # Set useful defaults for new clients.
         self.form.set_appstruct({
-            'authority': self.request.authority,
+            'authority': self.request.default_authority,
             'grant_type': GrantType.authorization_code,
             'response_type': ResponseType.code,
             'trusted': False,

--- a/h/views/admin/organizations.py
+++ b/h/views/admin/organizations.py
@@ -48,7 +48,7 @@ class OrganizationCreateController(object):
     @view_config(request_method='GET')
     def get(self):
         self.form.set_appstruct({
-            'authority': self.request.authority,
+            'authority': self.request.default_authority,
         })
         return self._template_context()
 

--- a/h/views/admin/staff.py
+++ b/h/views/admin/staff.py
@@ -17,7 +17,7 @@ def staff_index(request):
     staff = request.db.query(models.User).filter(models.User.staff)
     return {
         "staff": [u.userid for u in staff],
-        "default_authority": request.authority,
+        "default_authority": request.default_authority,
     }
 
 

--- a/h/views/admin/users.py
+++ b/h/views/admin/users.py
@@ -41,7 +41,7 @@ def users_index(request):
         user_meta['annotations_count'] = counts['total']
 
     return {
-        'default_authority': request.authority,
+        'default_authority': request.default_authority,
         'username': username,
         'authority': authority,
         'user': user,

--- a/h/views/api/groups.py
+++ b/h/views/api/groups.py
@@ -28,7 +28,7 @@ def groups(request):
     if request.user is not None:
         authority = request.user.authority
     else:
-        authority = authority or request.authority
+        authority = authority or request.default_authority
     all_groups = list_svc.request_groups(user=request.user,
                                          authority=authority,
                                          document_uri=document_uri)

--- a/h/views/client.py
+++ b/h/views/client.py
@@ -50,7 +50,7 @@ def sidebar_app(request, extra=None):
 
     app_config = {
         'apiUrl': request.route_url('api.index'),
-        'authDomain': request.authority,
+        'authDomain': request.default_authority,
         'oauthClientId': settings.get('h.client_oauth_id'),
         'release': __version__,
         'serviceUrl': request.route_url('index'),

--- a/tests/h/accounts/schemas_test.py
+++ b/tests/h/accounts/schemas_test.py
@@ -44,7 +44,7 @@ class TestUniqueEmail(object):
 
         user_model.get_by_email.assert_called_with(pyramid_request.db,
                                                    "foo@bar.com",
-                                                   pyramid_request.authority)
+                                                   pyramid_request.default_authority)
 
     def test_it_is_invalid_when_user_exists(self, dummy_node):
         pytest.raises(colander.Invalid,

--- a/tests/h/activity/query_test.py
+++ b/tests/h/activity/query_test.py
@@ -220,7 +220,8 @@ class TestCheckURL(object):
                          'Search',
                          'TagsAggregation',
                          'TopLevelAnnotationsFilter',
-                         'UsersAggregation')
+                         'UsersAggregation',
+                         'links')
 class TestExecute(object):
 
     PAGE_SIZE = 23
@@ -241,13 +242,13 @@ class TestExecute(object):
         TopLevelAnnotationsFilter.assert_called_once_with()
         search.append_modifier.assert_any_call(TopLevelAnnotationsFilter.return_value)
 
-    def test_it_only_shows_annotations_from_current_authority(self,
+    def test_it_only_shows_annotations_from_default_authority(self,
                                                               pyramid_request,
                                                               search,
                                                               AuthorityFilter):
         execute(pyramid_request, MultiDict(), self.PAGE_SIZE)
 
-        AuthorityFilter.assert_called_once_with(pyramid_request.authority)
+        AuthorityFilter.assert_called_once_with(pyramid_request.default_authority)
         search.append_modifier.assert_any_call(AuthorityFilter.return_value)
 
     def test_it_adds_a_tags_aggregation_to_the_search_query(self,
@@ -499,11 +500,6 @@ class TestExecute(object):
         return patch('h.activity.query.fetch_annotations')
 
     @pytest.fixture
-    def links(self, patch):
-        links = patch('h.activity.query.links')
-        return links
-
-    @pytest.fixture
     def _fetch_groups(self, group_pubids, patch):
         _fetch_groups = patch('h.activity.query._fetch_groups')
         _fetch_groups.return_value = [mock.Mock(pubid=pubid)
@@ -631,6 +627,10 @@ class TestExecute(object):
     @pytest.fixture
     def UsersAggregation(self, patch):
         return patch('h.activity.query.UsersAggregation')
+
+    @pytest.fixture
+    def links(self, patch):
+        return patch('h.activity.query.links')
 
     @pytest.fixture
     def pyramid_request(self, pyramid_request):

--- a/tests/h/auth/util_test.py
+++ b/tests/h/auth/util_test.py
@@ -177,15 +177,15 @@ class TestAuthDomain(object):
         # Make sure h.authority isn't set.
         pyramid_request.registry.settings.pop('h.authority', None)
 
-        assert util.authority(pyramid_request) == pyramid_request.domain
+        assert util.default_authority(pyramid_request) == pyramid_request.domain
 
     def test_it_allows_overriding_request_domain(self, pyramid_request):
         pyramid_request.registry.settings['h.authority'] = 'foo.org'
-        assert util.authority(pyramid_request) == 'foo.org'
+        assert util.default_authority(pyramid_request) == 'foo.org'
 
     def test_it_returns_text_type(self, pyramid_request):
         pyramid_request.domain = str(pyramid_request.domain)
-        assert type(util.authority(pyramid_request)) == text_type
+        assert type(util.default_authority(pyramid_request)) == text_type
 
 
 class TestValidateAuthClientAuthority(object):

--- a/tests/h/conftest.py
+++ b/tests/h/conftest.py
@@ -237,7 +237,7 @@ def pyramid_config(pyramid_settings, pyramid_request):
 def pyramid_request(db_session, fake_feature, pyramid_settings):
     """Dummy Pyramid request object."""
     request = testing.DummyRequest(db=db_session, feature=fake_feature)
-    request.authority = text_type(TEST_AUTHORITY)
+    request.default_authority = text_type(TEST_AUTHORITY)
     request.create_form = mock.Mock()
     request.matched_route = mock.Mock()
     request.registry.settings = pyramid_settings

--- a/tests/h/emails/reply_notification_test.py
+++ b/tests/h/emails/reply_notification_test.py
@@ -184,7 +184,7 @@ class TestGenerate(object):
                                                 pyramid_request,
                                                 html_renderer,
                                                 text_renderer):
-        pyramid_request.authority = 'foo.org'
+        pyramid_request.default_authority = 'foo.org'
         expected_context = {
             'parent_user_url': None,
             'reply_user_url': None,

--- a/tests/h/links_test.py
+++ b/tests/h/links_test.py
@@ -32,7 +32,7 @@ class TestHTMLLink(object):
     def test_html_link_returns_links_for_first_party_annotations(
             self, annotation, pyramid_request):
         # Specify the authority so that it's a first-party annotation.
-        annotation.authority = pyramid_request.authority
+        annotation.authority = pyramid_request.default_authority
 
         link = links.html_link(pyramid_request, annotation)
 

--- a/tests/h/services/group_links_test.py
+++ b/tests/h/services/group_links_test.py
@@ -31,7 +31,7 @@ class TestGroupLinksFactory(object):
 
         assert isinstance(svc, GroupLinksService)
 
-    def test_uses_request_authority(self, pyramid_request):
+    def test_uses_request_default_authority(self, pyramid_request):
         pyramid_request.default_authority = 'bar.com'
 
         svc = group_links_factory(None, pyramid_request)

--- a/tests/h/services/group_links_test.py
+++ b/tests/h/services/group_links_test.py
@@ -12,7 +12,7 @@ from h.services.group_links import group_links_factory
 class TestGroupLinks(object):
 
     def test_it_returns_activity_link_for_default_authority_group(self, pyramid_request, factories, svc):
-        group = factories.OpenGroup(authority=pyramid_request.authority)
+        group = factories.OpenGroup(authority=pyramid_request.default_authority)
         links = svc.get_all(group)
 
         assert 'html' in links
@@ -32,7 +32,7 @@ class TestGroupLinksFactory(object):
         assert isinstance(svc, GroupLinksService)
 
     def test_uses_request_authority(self, pyramid_request):
-        pyramid_request.authority = 'bar.com'
+        pyramid_request.default_authority = 'bar.com'
 
         svc = group_links_factory(None, pyramid_request)
 
@@ -47,6 +47,6 @@ def routes(pyramid_config):
 @pytest.fixture
 def svc(pyramid_request, db_session):
     return GroupLinksService(
-        default_authority=pyramid_request.authority,
+        default_authority=pyramid_request.default_authority,
         route_url=pyramid_request.route_url
     )

--- a/tests/h/services/group_test.py
+++ b/tests/h/services/group_test.py
@@ -29,10 +29,10 @@ class TestGroupServiceCreatePrivateGroup(object):
     def test_it_sets_group_authority(self, svc, creator, pyramid_request):
         group = svc.create_private_group('Anteater fans', creator.userid)
 
-        assert group.authority == pyramid_request.authority
+        assert group.authority == pyramid_request.default_authority
 
     def test_it_sets_group_authority_as_creator_authority(self, svc, creator, pyramid_request):
-        pyramid_request.authority = 'some_other_authority'
+        pyramid_request.default_authority = 'some_other_authority'
         group = svc.create_private_group('Anteater fans', creator.userid)
 
         assert group.authority == creator.authority
@@ -114,7 +114,7 @@ class TestGroupServiceCreateOpenGroup(object):
         assert getattr(group, group_attr) == expected_value
 
     def test_it_sets_group_authority_as_creator_authority(self, svc, creator, pyramid_request):
-        pyramid_request.authority = 'some_other_authority'
+        pyramid_request.default_authority = 'some_other_authority'
         group = svc.create_private_group('Anteater fans', creator.userid)
 
         assert group.authority == creator.authority
@@ -204,7 +204,7 @@ class TestGroupServiceCreateRestrictedGroup(object):
         assert getattr(group, group_attr) == expected_value
 
     def test_it_sets_group_authority_as_creator_authority(self, svc, creator, pyramid_request):
-        pyramid_request.authority = 'some_other_authority'
+        pyramid_request.default_authority = 'some_other_authority'
         group = svc.create_private_group('Anteater fans', creator.userid)
 
         assert group.authority == creator.authority

--- a/tests/h/services/groupfinder_test.py
+++ b/tests/h/services/groupfinder_test.py
@@ -43,4 +43,4 @@ class TestGroupfinderServiceFactory(object):
     def test_provides_authority(self, pyramid_request):
         svc = groupfinder_service_factory(None, pyramid_request)
 
-        assert svc.authority == pyramid_request.authority
+        assert svc.authority == pyramid_request.default_authority

--- a/tests/h/services/list_groups_test.py
+++ b/tests/h/services/list_groups_test.py
@@ -289,7 +289,7 @@ class TestListGroupsFactory(object):
 
         svc = list_groups_factory(None, pyramid_request)
 
-        assert svc.request_authority == 'bar.com'
+        assert svc.default_authority == 'bar.com'
 
 
 @pytest.fixture
@@ -437,5 +437,5 @@ def mixed_groups(factories, user, authority, origin):
 def svc(pyramid_request, db_session):
     return ListGroupsService(
         session=db_session,
-        request_authority=pyramid_request.default_authority
+        default_authority=pyramid_request.default_authority
     )

--- a/tests/h/services/list_groups_test.py
+++ b/tests/h/services/list_groups_test.py
@@ -284,7 +284,7 @@ class TestListGroupsFactory(object):
 
         assert isinstance(svc, ListGroupsService)
 
-    def test_uses_request_authority(self, pyramid_request):
+    def test_uses_request_default_authority(self, pyramid_request):
         pyramid_request.default_authority = 'bar.com'
 
         svc = list_groups_factory(None, pyramid_request)

--- a/tests/h/services/list_groups_test.py
+++ b/tests/h/services/list_groups_test.py
@@ -285,7 +285,7 @@ class TestListGroupsFactory(object):
         assert isinstance(svc, ListGroupsService)
 
     def test_uses_request_authority(self, pyramid_request):
-        pyramid_request.authority = 'bar.com'
+        pyramid_request.default_authority = 'bar.com'
 
         svc = list_groups_factory(None, pyramid_request)
 
@@ -305,7 +305,7 @@ def default_authority(pyramid_request):
 
     Return the default authority—this automatically has a `__world__` group
     """
-    return pyramid_request.authority
+    return pyramid_request.default_authority
 
 
 @pytest.fixture
@@ -437,5 +437,5 @@ def mixed_groups(factories, user, authority, origin):
 def svc(pyramid_request, db_session):
     return ListGroupsService(
         session=db_session,
-        request_authority=pyramid_request.authority
+        request_authority=pyramid_request.default_authority
     )

--- a/tests/h/services/list_organizations_test.py
+++ b/tests/h/services/list_organizations_test.py
@@ -52,7 +52,7 @@ class TestListOrganizationsFactory(object):
 
 @pytest.fixture
 def authority(pyramid_request):
-    return pyramid_request.authority
+    return pyramid_request.default_authority
 
 
 @pytest.fixture

--- a/tests/h/services/user_signup_test.py
+++ b/tests/h/services/user_signup_test.py
@@ -169,7 +169,7 @@ class TestUserSignupServiceFactory(object):
 
         assert isinstance(svc, UserSignupService)
 
-    def test_provides_request_authority_as_default_authority(self, pyramid_request):
+    def test_provides_request_default_authority_as_default_authority(self, pyramid_request):
         svc = user_signup_service_factory(None, pyramid_request)
 
         assert svc.default_authority == pyramid_request.default_authority

--- a/tests/h/services/user_signup_test.py
+++ b/tests/h/services/user_signup_test.py
@@ -172,7 +172,7 @@ class TestUserSignupServiceFactory(object):
     def test_provides_request_authority_as_default_authority(self, pyramid_request):
         svc = user_signup_service_factory(None, pyramid_request)
 
-        assert svc.default_authority == pyramid_request.authority
+        assert svc.default_authority == pyramid_request.default_authority
 
     def test_provides_request_db_as_session(self, pyramid_request):
         svc = user_signup_service_factory(None, pyramid_request)

--- a/tests/h/services/user_test.py
+++ b/tests/h/services/user_test.py
@@ -170,7 +170,7 @@ class TestUserServiceFactory(object):
     def test_provides_request_authority_as_default_authority(self, pyramid_request):
         svc = user_service_factory(None, pyramid_request)
 
-        assert svc.default_authority == pyramid_request.authority
+        assert svc.default_authority == pyramid_request.default_authority
 
     def test_provides_request_db_as_session(self, pyramid_request):
         svc = user_service_factory(None, pyramid_request)

--- a/tests/h/services/user_test.py
+++ b/tests/h/services/user_test.py
@@ -167,7 +167,7 @@ class TestUserServiceFactory(object):
 
         assert isinstance(svc, UserService)
 
-    def test_provides_request_authority_as_default_authority(self, pyramid_request):
+    def test_provides_request_default_authority_as_default_authority(self, pyramid_request):
         svc = user_service_factory(None, pyramid_request)
 
         assert svc.default_authority == pyramid_request.default_authority

--- a/tests/h/session_test.py
+++ b/tests/h/session_test.py
@@ -13,14 +13,14 @@ class TestModel(object):
         session.model(authenticated_request)
 
         svc.session_groups.assert_called_once_with(user=authenticated_request.user,
-                                                   authority=authenticated_request.authority)
+                                                   authority=authenticated_request.default_authority)
 
     def test_proxies_group_lookup_to_service_for_unauth(self, unauthenticated_request):
         svc = unauthenticated_request.find_service(name='list_groups')
 
         session.model(unauthenticated_request)
 
-        svc.session_groups.assert_called_once_with(authority=unauthenticated_request.authority,
+        svc.session_groups.assert_called_once_with(authority=unauthenticated_request.default_authority,
                                                    user=None)
 
     def test_open_group_is_public(self, unauthenticated_request, world_group):
@@ -97,14 +97,14 @@ class TestProfile(object):
         session.profile(authenticated_request)
 
         svc.session_groups.assert_called_once_with(user=authenticated_request.user,
-                                                   authority=authenticated_request.authority)
+                                                   authority=authenticated_request.default_authority)
 
     def test_proxies_group_lookup_to_service_for_unauth(self, unauthenticated_request):
         svc = unauthenticated_request.find_service(name='list_groups')
 
         session.profile(unauthenticated_request)
 
-        svc.session_groups.assert_called_once_with(authority=unauthenticated_request.authority,
+        svc.session_groups.assert_called_once_with(authority=unauthenticated_request.default_authority,
                                                    user=None)
 
     def test_open_group_is_public(self, unauthenticated_request, world_group):
@@ -224,14 +224,14 @@ class TestProfileWithScopedGroups(object):
         session.profile(authenticated_request)
 
         svc.session_groups.assert_called_once_with(user=authenticated_request.user,
-                                                   authority=authenticated_request.authority)
+                                                   authority=authenticated_request.default_authority)
 
     def test_proxies_group_lookup_to_service_for_unauth(self, unauthenticated_request):
         svc = unauthenticated_request.find_service(name='list_groups')
 
         session.profile(unauthenticated_request)
 
-        svc.session_groups.assert_called_once_with(authority=unauthenticated_request.authority,
+        svc.session_groups.assert_called_once_with(authority=unauthenticated_request.default_authority,
                                                    user=None)
 
     def test_private_group_is_not_public(self, authenticated_request, factories):
@@ -274,7 +274,7 @@ class FakeRequest(object):
 
     def __init__(self, authority, userid, user_authority,
                  fake_feature):
-        self.authority = authority
+        self.default_authority = authority
         self.authenticated_userid = userid
 
         if userid is None:

--- a/tests/h/traversal/roots_test.py
+++ b/tests/h/traversal/roots_test.py
@@ -229,7 +229,7 @@ class TestUserRoot(object):
     def test_it_fetches_the_requested_user(self, pyramid_request, user_factory, user_service):
         user_factory["bob"]
 
-        user_service.fetch.assert_called_once_with("bob", pyramid_request.authority)
+        user_service.fetch.assert_called_once_with("bob", pyramid_request.default_authority)
 
     def test_it_raises_KeyError_if_the_user_does_not_exist(self,
                                                            user_factory,

--- a/tests/h/views/admin/admins_test.py
+++ b/tests/h/views/admin/admins_test.py
@@ -44,7 +44,7 @@ class TestAdminsAddRemove(object):
     def test_add_is_idempotent(self, pyramid_request, users):
         pyramid_request.params = {
             "add": "agnos",
-            "authority": pyramid_request.authority,
+            "authority": pyramid_request.default_authority,
         }
 
         admins_add(pyramid_request)
@@ -61,7 +61,7 @@ class TestAdminsAddRemove(object):
     def test_add_redirects_to_index(self, pyramid_request):
         pyramid_request.params = {
             "add": "eva",
-            "authority": pyramid_request.authority,
+            "authority": pyramid_request.default_authority,
         }
 
         result = admins_add(pyramid_request)
@@ -72,7 +72,7 @@ class TestAdminsAddRemove(object):
     def test_add_redirects_to_index_when_user_not_found(self, pyramid_request):
         pyramid_request.params = {
             "add": "florp",
-            "authority": pyramid_request.authority,
+            "authority": pyramid_request.default_authority,
         }
 
         result = admins_add(pyramid_request)
@@ -83,7 +83,7 @@ class TestAdminsAddRemove(object):
     def test_add_flashes_when_user_not_found(self, pyramid_request):
         pyramid_request.params = {
             "add": "florp",
-            "authority": pyramid_request.authority,
+            "authority": pyramid_request.default_authority,
         }
         pyramid_request.session.flash = mock.Mock()
 

--- a/tests/h/views/admin/groups_test.py
+++ b/tests/h/views/admin/groups_test.py
@@ -156,7 +156,7 @@ class TestGroupCreateController(object):
         create_method.return_value = factories.RestrictedGroup(pubid='testgroup')
         ctrl.post()
 
-        expected_userid = User(username=creator, authority=pyramid_request.authority).userid
+        expected_userid = User(username=creator, authority=pyramid_request.default_authority).userid
 
         create_method.assert_called_with(name=name, userid=expected_userid, description=description,
                                          origins=origins, organization=default_org)
@@ -269,7 +269,7 @@ class TestGroupEditController(object):
 
         def call_on_success(request, form, on_success, on_failure):
             return on_success({
-                'authority': pyramid_request.authority,
+                'authority': pyramid_request.default_authority,
                 'creator': updated_creator.username,
                 'description': 'a desc',
                 'group_type': 'restricted',

--- a/tests/h/views/admin/organizations_test.py
+++ b/tests/h/views/admin/organizations_test.py
@@ -46,7 +46,7 @@ class TestOrganizationCreateController(object):
 
         ctx = ctrl.get()
 
-        assert ctx['form'] == {'authority': pyramid_request.authority}
+        assert ctx['form'] == {'authority': pyramid_request.default_authority}
 
     def test_post_creates_org(self, pyramid_request, handle_form_submission):
         def call_on_success(request, form, on_success, on_failure):

--- a/tests/h/views/admin/staff_test.py
+++ b/tests/h/views/admin/staff_test.py
@@ -43,7 +43,7 @@ class TestStaffAddRemove(object):
     def test_add_is_idempotent(self, pyramid_request, users):
         pyramid_request.params = {
             "add": "agnos",
-            "authority": pyramid_request.authority
+            "authority": pyramid_request.default_authority
         }
 
         staff_add(pyramid_request)
@@ -63,7 +63,7 @@ class TestStaffAddRemove(object):
     def test_add_redirects_to_index(self, pyramid_request):
         pyramid_request.params = {
             "add": "eva",
-            "authority": pyramid_request.authority
+            "authority": pyramid_request.default_authority
         }
 
         result = staff_add(pyramid_request)
@@ -74,7 +74,7 @@ class TestStaffAddRemove(object):
     def test_add_redirects_to_index_when_user_not_found(self, pyramid_request):
         pyramid_request.params = {
             "add": "florp",
-            "authority": pyramid_request.authority
+            "authority": pyramid_request.default_authority
         }
 
         result = staff_add(pyramid_request)
@@ -85,7 +85,7 @@ class TestStaffAddRemove(object):
     def test_add_flashes_when_user_not_found(self, pyramid_request):
         pyramid_request.params = {
             "add": "florp",
-            "authority": pyramid_request.authority
+            "authority": pyramid_request.default_authority
         }
         pyramid_request.session.flash = mock.Mock()
 

--- a/tests/h/views/admin/users_test.py
+++ b/tests/h/views/admin/users_test.py
@@ -26,7 +26,7 @@ def test_users_index(pyramid_request):
     result = users_index(pyramid_request)
 
     assert result == {
-        'default_authority': pyramid_request.authority,
+        'default_authority': pyramid_request.default_authority,
         'username': None,
         'authority': None,
         'user': None,

--- a/tests/h/views/api/groups_test.py
+++ b/tests/h/views/api/groups_test.py
@@ -27,7 +27,7 @@ class TestGetGroups(object):
 
         list_groups_service.request_groups.assert_called_once_with(
             user=None,
-            authority=anonymous_request.authority,
+            authority=anonymous_request.default_authority,
             document_uri=None
         )
 


### PR DESCRIPTION
Part of https://github.com/hypothesis/product-backlog/issues/775

This PR changes the name of `request.authority` to `request.default_authority`. This has a few purposes, as discussed in https://github.com/hypothesis/product-backlog/issues/775

There should be no change in functionality from these changes. I've been careful and methodical to grep for every variant I can think of and was excruciatingly organized with the commits on this branch. Note that these commits should be squashed if/when this merges as the commits are not independently functional (the app would crash, presumably).

In summary:

* `h.auth.__init__` now registers `default_authority` instead of `authority` on the request and the `h.auth.util` function that this invokes is renamed as well
* 21 `h` modules directly used `request.authority`; all of these references have been updated to `request.default_authority`
* In most cases, changes to each of the 21 affected modules caused their tests to fail (good). Changes to `activity` code did not cause a unit test failure (hrm), but at least the simple functional search test did. In a few cases—a few admin views—I think it's OK that tests did not break. In one or two cases, these changes exposed some incomplete mocking in tests and I fixed that where I saw it.
* There was one scarier reference I found because of a breaking test—one of the form schemas had a reference that looked like `node.bindings["request"].authority` which escaped my initial greps; this is fixed in https://github.com/hypothesis/h/commit/6cdfa64d0b49edf39cea643ef28f100660d4c5b7
After finding that I really grepped the hell out of things.
* A handful of tests failed even though their respective modules didn't directly reference `request.authority`. I fixed those (obviously).

This was an illuminating exercise! In a bunch of modules, the naming `default_authority` was already in play (especially in services), showing that in many cases, we already think of it this way. But in other modules, it's more ambiguous. It looks like it could be dynamic, which it is not.

This paves the way for the "real" `request.authority`, which will take auth_clients into account...