### PR TITLE
Ignore unknown es query params

### DIFF
--- a/h/search/query.py
+++ b/h/search/query.py
@@ -95,8 +95,12 @@ def extract_limit(params):
 
 
 def extract_sort(params):
+    sort_by = params.pop("sort", "updated")
+    # Sorting must be done on non-analyzed fields.
+    if sort_by == "user":
+        sort_by = "user_raw"
     return [{
-        params.pop("sort", "updated"): {
+        sort_by: {
             "order": params.pop("order", "desc"),
 
             # `unmapped_type` causes unknown fields specified as arguments to

--- a/tests/h/search/query_test.py
+++ b/tests/h/search/query_test.py
@@ -209,6 +209,9 @@ class TestBuilder(object):
         ("updated", "asc", [2, 0, 1]),
         ("created", "desc", [2, 0, 1]),
         ("created", "asc", [1, 0, 2]),
+        ("group", "asc", [2, 0, 1]),
+        ("id", "asc", [0, 2, 1]),
+        ("user", "asc", [2, 0, 1]),
 
         # Default sort order should be descending.
         ("updated", None, [1, 0, 2]),
@@ -221,9 +224,24 @@ class TestBuilder(object):
 
         # nb. Test annotations have a different ordering for updated vs created
         # and creation order is different than updated/created asc/desc.
-        ann_ids = [Annotation(updated=dt(2017, 1, 1), created=dt(2017, 1, 1)).id,
-                   Annotation(updated=dt(2018, 1, 1), created=dt(2016, 1, 1)).id,
-                   Annotation(updated=dt(2016, 1, 1), created=dt(2018, 1, 1)).id]
+        ann_ids = [Annotation(
+                    updated=dt(2017, 1, 1),
+                    groupid="12345",
+                    userid="acct:foo@auth1",
+                    id="1",
+                    created=dt(2017, 1, 1)).id,
+                   Annotation(
+                    updated=dt(2018, 1, 1),
+                    groupid="12347",
+                    userid="acct:foo@auth2",
+                    id="9",
+                    created=dt(2016, 1, 1)).id,
+                   Annotation(
+                    updated=dt(2016, 1, 1),
+                    groupid="12342",
+                    userid="acct:boo@auth1",
+                    id="2",
+                    created=dt(2018, 1, 1)).id]
 
         params = {}
         if sort_key:


### PR DESCRIPTION
Add a schema to ignore and remove all unknown search query params when running a GET /api/search request. This is a fix for https://github.com/hypothesis/product-backlog/issues/741.