### PR TITLE
Ignore unknown es query params

### DIFF
--- a/docs/_extra/api-reference/hypothesis.yaml
+++ b/docs/_extra/api-reference/hypothesis.yaml
@@ -294,17 +294,19 @@ paths:
         - name: offset
           in: query
           description: >
-            The minimum number of initial annotations to skip. This is
+            The number of initial annotations to skip. This is
             used for pagination.
           required: false
           type: integer
           default: 0
           minimum: 0
+          maximum: 9800
         - name: sort
           in: query
           description: The field by which annotations should be sorted.
           required: false
           type: string
+          enum: [created, updated, group, id, user]
           default: updated
         - name: order
           in: query
@@ -318,7 +320,8 @@ paths:
           description: |
             Limit the results to annotations matching the specific URI or equivalent URIs.
 
-            URI can be a URL (a web page address) or a URN representing another kind of resource such as DOI (Digital Object Identifier) or a PDF fingerprint.
+            URI can be a URL (a web page address) or a URN representing another kind of 
+            resource such as DOI (Digital Object Identifier) or a PDF fingerprint.
           required: false
           type: string
         - name: url
@@ -342,10 +345,37 @@ paths:
           description: Limit the results to annotations tagged with the specified value.
           required: false
           type: string
+        - name: tags
+          in: query
+          description: Alias of `tag`.
+          required: false
+          type: string
         - name: any
           in: query
-          description: |
-            Limit the results to annotations in which one of a number of common fields contain the passed value.
+          description: Limit the results to annotations whose quote, tags, text or url 
+            fields contain this keyword.  
+          required: false
+          type: string
+        - name: group
+          in: query
+          description: Limit the results to this group of annotations.
+          required: false
+          type: string
+        - name: quote
+          in: query
+          description: Limit the results to annotations that contain this text inside
+            the text that was annotated.
+          required: false
+          type: string
+        - name: references
+          in: query
+          description: Returns annotations that are replies to this parent annotation id.
+          required: false
+          type: string
+        - name: text
+          in: query
+          description: Limit the results to annotations that contain this text in their 
+            textual body.
           required: false
           type: string
       responses:

--- a/h/schemas/annotation.py
+++ b/h/schemas/annotation.py
@@ -2,10 +2,12 @@
 """Classes for validating data passed to the annotations API."""
 from __future__ import unicode_literals
 
+import colander
 import copy
 from pyramid import i18n
 
 from h.schemas.base import JSONSchema, ValidationError
+from h.search.query import LIMIT_DEFAULT, LIMIT_MAX, OFFSET_MAX
 from h.util import document_claims
 
 _ = i18n.TranslationStringFactory(__package__)
@@ -311,3 +313,99 @@ def _target_selectors(targets):
         return targets[0]['selector']
     else:
         return []
+
+
+class SearchParamsSchema(colander.Schema):
+    _separate_replies = colander.SchemaNode(
+        colander.Boolean(),
+        missing=False,
+        description="Return a separate set of annotations and their replies.",
+    )
+    sort = colander.SchemaNode(
+        colander.String(),
+        validator=colander.OneOf(["created", "updated", "group", "id", "user"]),
+        missing="updated",
+        description="The field by which annotations should be sorted.",
+    )
+    limit = colander.SchemaNode(
+        colander.Integer(),
+        validator=colander.Range(min=0, max=LIMIT_MAX),
+        missing=LIMIT_DEFAULT,
+        description="The maximum number of annotations to return.",
+    )
+    order = colander.SchemaNode(
+        colander.String(),
+        validator=colander.OneOf(["asc", "desc"]),
+        missing="desc",
+        description="The direction of sort.",
+    )
+    offset = colander.SchemaNode(
+        colander.Integer(),
+        validator=colander.Range(min=0, max=OFFSET_MAX),
+        missing=0,
+        description="""The number of initial annotations to skip. This is
+                       used for pagination.""",
+    )
+    group = colander.SchemaNode(
+        colander.String(),
+        missing=colander.drop,
+        description="Limit the results to this group of annotations.",
+    )
+    quote = colander.SchemaNode(
+        colander.Sequence(),
+        colander.SchemaNode(colander.String()),
+        missing=colander.drop,
+        description="""Limit the results to annotations that contain this text inside
+                        the text that was annotated.""",
+    )
+    references = colander.SchemaNode(
+        colander.Sequence(),
+        colander.SchemaNode(colander.String()),
+        missing=colander.drop,
+        description="""Returns annotations that are replies to this parent annotation id.""",
+    )
+    tag = colander.SchemaNode(
+        colander.Sequence(),
+        colander.SchemaNode(colander.String()),
+        missing=colander.drop,
+        description="Limit the results to annotations tagged with the specified value.",
+    )
+    tags = colander.SchemaNode(
+        colander.Sequence(),
+        colander.SchemaNode(colander.String()),
+        missing=colander.drop,
+        description="Alias of tag.",
+    )
+    text = colander.SchemaNode(
+        colander.Sequence(),
+        colander.SchemaNode(colander.String()),
+        missing=colander.drop,
+        description="Limit the results to annotations that contain this text in their textual body.",
+    )
+    uri = colander.SchemaNode(
+        colander.Sequence(),
+        colander.SchemaNode(colander.String()),
+        missing=colander.drop,
+        description="""Limit the results to annotations matching the specific URI
+                       or equivalent URIs. URI can be a URL (a web page address) or
+                       a URN representing another kind of resource such as DOI
+                       (Digital Object Identifier) or a PDF fingerprint.""",
+    )
+    url = colander.SchemaNode(
+        colander.Sequence(),
+        colander.SchemaNode(colander.String()),
+        missing=colander.drop,
+        description="Alias of uri.",
+    )
+    any = colander.SchemaNode(
+        colander.Sequence(),
+        colander.SchemaNode(colander.String()),
+        missing=colander.drop,
+        description="""Limit the results to annotations whose quote, tags,
+                       text or url fields contain this keyword.""",
+    )
+    user = colander.SchemaNode(
+        colander.String(),
+        missing=colander.drop,
+        description="Limit the results to annotations made by the specified user.",
+    )

--- a/h/search/query.py
+++ b/h/search/query.py
@@ -5,7 +5,9 @@ from h import storage
 from h.util import uri
 
 LIMIT_DEFAULT = 20
+# Elasticsearch requires offset + limit must be <= 10,000.
 LIMIT_MAX = 200
+OFFSET_MAX = 9800
 
 
 class Builder(object):
@@ -74,6 +76,7 @@ class Builder(object):
 def extract_offset(params):
     try:
         val = int(params.pop("offset"))
+        val = min(val, OFFSET_MAX)
         if val < 0:
             raise ValueError
     except (ValueError, KeyError):

--- a/h/search/query.py
+++ b/h/search/query.py
@@ -98,8 +98,12 @@ def extract_limit(params):
 
 
 def extract_sort(params):
+    sort_by = params.pop("sort", "updated")
+    # Sorting must be done on non-analyzed fields.
+    if sort_by == "user":
+        sort_by = "user_raw"
     return [{
-        params.pop("sort", "updated"): {
+        sort_by: {
             "order": params.pop("order", "desc"),
 
             # `unmapped_type` causes unknown fields specified as arguments to

--- a/h/views/api/annotations.py
+++ b/h/views/api/annotations.py
@@ -28,6 +28,7 @@ from h.events import AnnotationEvent
 from h.interfaces import IGroupService
 from h.presenters import AnnotationJSONLDPresenter
 from h.traversal import AnnotationContext
+from h.schemas.util import validate_query_params
 from h.schemas.annotation import (
     CreateAnnotationSchema,
     SearchParamsSchema,
@@ -100,8 +101,8 @@ def links(context, request):
 def search(request):
     """Search the database for annotations matching with the given query."""
     schema = SearchParamsSchema()
+    params = validate_query_params(schema, request.params)
 
-    params = schema.validate(request.params.copy())
     _record_search_api_usage_metrics(params)
 
     separate_replies = params.pop('_separate_replies', False)

--- a/h/views/api/annotations.py
+++ b/h/views/api/annotations.py
@@ -28,7 +28,10 @@ from h.events import AnnotationEvent
 from h.interfaces import IGroupService
 from h.presenters import AnnotationJSONLDPresenter
 from h.traversal import AnnotationContext
-from h.schemas.annotation import CreateAnnotationSchema, UpdateAnnotationSchema
+from h.schemas.annotation import (
+    CreateAnnotationSchema,
+    SearchParamsSchema,
+    UpdateAnnotationSchema)
 from h.views.api.config import api_config, AngularRouteTemplater
 
 _ = i18n.TranslationStringFactory(__package__)
@@ -96,7 +99,9 @@ def links(context, request):
             description='Search for annotations')
 def search(request):
     """Search the database for annotations matching with the given query."""
-    params = request.params.copy()
+    schema = SearchParamsSchema()
+
+    params = schema.validate(request.params.copy())
     _record_search_api_usage_metrics(params)
 
     separate_replies = params.pop('_separate_replies', False)

--- a/tests/h/schemas/util_test.py
+++ b/tests/h/schemas/util_test.py
@@ -56,6 +56,15 @@ class TestValidateQueryParams(object):
 
         assert parsed.getall("list_field") == ["first", "second"]
 
+    def test_a_list_field_can_have_a_single_value(self):
+        schema = QueryParamSchema()
+        params = MultiDict()
+        params.add("list_field", "first")
+
+        parsed = validate_query_params(schema, params)
+
+        assert parsed.getall("list_field") == ["first"]
+
     def test_it_keeps_only_last_value_for_non_sequence_fields(self):
         schema = QueryParamSchema()
         params = MultiDict()

--- a/tests/h/search/query_test.py
+++ b/tests/h/search/query_test.py
@@ -10,12 +10,12 @@ from h.search import Search, index, query
 from hypothesis import strategies as st
 from hypothesis import given
 
-
 MISSING = object()
 ES_VERSION = (1, 7, 0)
 OFFSET_DEFAULT = 0
-LIMIT_DEFAULT = 20
-LIMIT_MAX = 200
+LIMIT_DEFAULT = query.LIMIT_DEFAULT
+LIMIT_MAX = query.LIMIT_MAX
+OFFSET_MAX = query.OFFSET_MAX
 
 
 class TestBuilder(object):
@@ -34,6 +34,7 @@ class TestBuilder(object):
         ("   ",  OFFSET_DEFAULT),
         ("-23",  OFFSET_DEFAULT),
         ("32.7", OFFSET_DEFAULT),
+        ("9801", OFFSET_MAX),
     ])
     def test_offset(self, offset, from_):
         builder = query.Builder(ES_VERSION)

--- a/tests/h/search/query_test.py
+++ b/tests/h/search/query_test.py
@@ -210,6 +210,9 @@ class TestBuilder(object):
         ("updated", "asc", [2, 0, 1]),
         ("created", "desc", [2, 0, 1]),
         ("created", "asc", [1, 0, 2]),
+        ("group", "asc", [2, 0, 1]),
+        ("id", "asc", [0, 2, 1]),
+        ("user", "asc", [2, 0, 1]),
 
         # Default sort order should be descending.
         ("updated", None, [1, 0, 2]),
@@ -222,9 +225,24 @@ class TestBuilder(object):
 
         # nb. Test annotations have a different ordering for updated vs created
         # and creation order is different than updated/created asc/desc.
-        ann_ids = [Annotation(updated=dt(2017, 1, 1), created=dt(2017, 1, 1)).id,
-                   Annotation(updated=dt(2018, 1, 1), created=dt(2016, 1, 1)).id,
-                   Annotation(updated=dt(2016, 1, 1), created=dt(2018, 1, 1)).id]
+        ann_ids = [Annotation(
+                    updated=dt(2017, 1, 1),
+                    groupid="12345",
+                    userid="acct:foo@auth1",
+                    id="1",
+                    created=dt(2017, 1, 1)).id,
+                   Annotation(
+                    updated=dt(2018, 1, 1),
+                    groupid="12347",
+                    userid="acct:foo@auth2",
+                    id="9",
+                    created=dt(2016, 1, 1)).id,
+                   Annotation(
+                    updated=dt(2016, 1, 1),
+                    groupid="12342",
+                    userid="acct:boo@auth1",
+                    id="2",
+                    created=dt(2018, 1, 1)).id]
 
         params = {}
         if sort_key:

--- a/tests/h/views/api/annotations_test.py
+++ b/tests/h/views/api/annotations_test.py
@@ -3,6 +3,7 @@
 from __future__ import unicode_literals
 import mock
 import pytest
+from webob.multidict import NestedMultiDict, MultiDict
 
 from pyramid import testing
 from pyramid.config import Configurator
@@ -88,7 +89,13 @@ class TestSearch(object):
         search_lib.Search.assert_called_with(pyramid_request,
                                              separate_replies=False,
                                              stats=pyramid_request.stats)
-        search.run.assert_called_once_with(pyramid_request.params)
+
+        expected_params = MultiDict([
+            ('sort', 'updated'),
+            ('limit', 20),
+            ('order', 'desc'),
+            ('offset', 0)])
+        search.run.assert_called_once_with(expected_params)
 
     def test_it_presents_search_results(self, pyramid_request, search_run, presentation_service):
         search_run.return_value = SearchResult(2, ['row-1', 'row-2'], [], {})
@@ -108,7 +115,7 @@ class TestSearch(object):
         assert views.search(pyramid_request) == expected
 
     def test_it_presents_replies(self, pyramid_request, search_run, presentation_service):
-        pyramid_request.params = {'_separate_replies': '1'}
+        pyramid_request.params = NestedMultiDict(MultiDict({'_separate_replies': '1'}))
         search_run.return_value = SearchResult(1, ['row-1'], ['reply-1', 'reply-2'], {})
 
         views.search(pyramid_request)
@@ -116,7 +123,7 @@ class TestSearch(object):
         presentation_service.present_all.assert_called_with(['reply-1', 'reply-2'])
 
     def test_it_returns_replies(self, pyramid_request, search_run, presentation_service):
-        pyramid_request.params = {'_separate_replies': '1'}
+        pyramid_request.params = NestedMultiDict(MultiDict({'_separate_replies': '1'}))
         search_run.return_value = SearchResult(1, ['row-1'], ['reply-1', 'reply-2'], {})
 
         expected = {


### PR DESCRIPTION
Add a schema to ignore and remove all unknown search query params when running a GET /api/search request. This is a fix for https://github.com/hypothesis/product-backlog/issues/741.