### PR TITLE
Fix a tox warning and remove some duplication

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,7 +36,7 @@ node {
                 sh 'cd /var/lib/hypothesis && tox'
                 // Functional tests
                 sh 'cd /var/lib/hypothesis && tox -e functional'
-                sh 'cd /var/lib/hypothesis && tox -e functional-py3'
+                sh 'cd /var/lib/hypothesis && tox -e functional-py36'
             }
         } finally {
             rabbit.stop()

--- a/tox.ini
+++ b/tox.ini
@@ -25,9 +25,7 @@ passenv =
 commands =
     coverage run --parallel --source h,tests/h -m pytest {posargs:tests/h/}
 
-[testenv:functional]
-basepython = python2.7
-skip_install = true
+[functional]
 deps =
     pytest
     webtest
@@ -40,20 +38,15 @@ passenv =
     PYTEST_ADDOPTS
 commands = pytest {posargs:tests/functional/}
 
-[testenv:functional-py3]
-basepython = python3.6
-skip_install = true
-deps =
-    pytest
-    webtest
-    factory-boy
-    -rrequirements.txt
-passenv =
-    BROKER_URL
-    ELASTICSEARCH_URL
-    TEST_DATABASE_URL
-    PYTEST_ADDOPTS
-commands = pytest {posargs:tests/functional/}
+[testenv:functional]
+deps = {[functional]deps}
+passenv = {[functional]passenv}
+commands = {[functional]commands}
+
+[testenv:functional-py36]
+deps = {[functional]deps}
+passenv = {[functional]passenv}
+commands = {[functional]commands}
 
 [testenv:clean]
 deps = coverage


### PR DESCRIPTION
Fix a "Conflicting basepython for environment 'functional-py3'" warning
that tox was printing out, and also remove some duplication from the
tox.ini file.

The problem was that tox testenv names, such as "py27", "functional",
"functional-py3", "coverage", etc in our tox.ini file, are actually
hyphen-separated lists of what tox calls "factors":

https://tox.readthedocs.io/en/latest/config.html?highlight=factors#factors-and-factor-conditional-settings

Tox sees the testenv name "functional-py3" as two factors "functional"
and "py3". And "py3" is the name of one of tox's builtin factors.
The testenv name "functional-py3" activates the builtin "py3" factor
which sets `basepython = python3`. This conflicts with the
`basepython = python3.6` within the testenv definition
(py3 != python3.6).

Fix this by:

1. Renaming the functional-py3 testenv to functional-py36, so that it
   triggers the builtin py36 factor (basepython = python3.6) instead of
   the py3 one.

2. Removing the `basepython = python3.6` from the testenv definition
   body. It's not needed as the "-py36" in the testenv name has already
   set that basepython.

Also remove the `basepython = python2.7` from `[testenv:functional]` as
it's not needed - testenvs inherit the `basepython` from the default
testenv which, in our tox.ini file, is tox's builtin py27 testenv.

Also remove the `skip_install = true` from `[testenv:functional]` - it
already inherits this from `[testenv]`.

Also remove some duplication by adding a `tox.ini`-file section
`[functional]` and having both `[testenv:functional]` and
`[testenv:functional-py36]` use values from it.