### PR TITLE
Remove Sphinx deps

### DIFF
--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -6,5 +6,3 @@ honcho
 pep257
 prospector[with_pyroma]
 pyramid_debugtoolbar
-sphinx
-sphinx_rtd_theme


### PR DESCRIPTION
`make docs` and other docs-related Makefile commands run in tox-managed
venvs, so it's no longer necessary to install docs stuff in yout
development venv.

@robertknight This is just a bit of cleanup following on from a `make docs` etc PR that you merged recently.