### PR TITLE
Run `make dev` and `make lint` in tox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,6 @@ mail/
 .eggs/
 *.egg
 *.egg-info
-.pydeps
 .pytest_cache
 
 # development TLS cert/key

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,7 @@ matrix:
     - env: ACTION=backend-lint
       language: python
       python: '3.6'
+      install: pip install tox
       script:
         make lint
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
         postgresql: "9.4"
       before_install:
         - ./scripts/elasticsearch.sh
-      install: pip install tox
+      install: pip install tox tox-pip-extensions
       before_script: createdb htest
       script: tox
       after_success:
@@ -24,7 +24,7 @@ matrix:
         postgresql: '9.4'
       before_install:
         - ./scripts/elasticsearch.sh
-      install: pip install tox
+      install: pip install tox tox-pip-extensions
       before_script: createdb htest
       script:
         make test-py3
@@ -50,7 +50,7 @@ matrix:
     - env: ACTION=backend-lint
       language: python
       python: '3.6'
-      install: pip install tox
+      install: pip install tox tox-pip-extensions
       script:
         make lint
 
@@ -58,7 +58,7 @@ matrix:
     - env: ACTION=check-docs
       language: python
       python: '3.6'
-      install: pip install tox
+      install: pip install tox tox-pip-extensions
       script:
         make checkdocs
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
         postgresql: "9.4"
       before_install:
         - ./scripts/elasticsearch.sh
-      install: pip install tox tox-pip-extensions
+      install: pip install tox==3.3.0 tox-pip-extensions
       before_script: createdb htest
       script: tox
       after_success:
@@ -24,7 +24,7 @@ matrix:
         postgresql: '9.4'
       before_install:
         - ./scripts/elasticsearch.sh
-      install: pip install tox tox-pip-extensions
+      install: pip install tox==3.3.0 tox-pip-extensions
       before_script: createdb htest
       script:
         make test-py3
@@ -50,7 +50,7 @@ matrix:
     - env: ACTION=backend-lint
       language: python
       python: '3.6'
-      install: pip install tox tox-pip-extensions
+      install: pip install tox==3.3.0 tox-pip-extensions
       script:
         make lint
 
@@ -58,7 +58,7 @@ matrix:
     - env: ACTION=check-docs
       language: python
       python: '3.6'
-      install: pip install tox tox-pip-extensions
+      install: pip install tox==3.3.0 tox-pip-extensions
       script:
         make checkdocs
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,7 +30,7 @@ node {
                 // Test dependencies
                 sh 'apk add --no-cache build-base libffi-dev postgresql-dev python-dev'
                 sh 'apk add --no-cache python3 python3-dev'
-                sh 'pip install -q tox'
+                sh 'pip install -q tox tox-pip-extensions'
 
                 // Unit tests
                 sh 'cd /var/lib/hypothesis && tox'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,7 +30,7 @@ node {
                 // Test dependencies
                 sh 'apk add --no-cache build-base libffi-dev postgresql-dev python-dev'
                 sh 'apk add --no-cache python3 python3-dev'
-                sh 'pip install -q tox tox-pip-extensions'
+                sh 'pip install -q tox==3.3.0 tox-pip-extensions'
 
                 // Unit tests
                 sh 'cd /var/lib/hypothesis && tox'

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ clean:
 ## Run the development H server locally
 .PHONY: dev
 dev: build/manifest.json
-	tox -e dev
+	tox -e py27-dev
 
 ## Build hypothesis/hypothesis docker image
 .PHONY: docker

--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,6 @@ DOCKER_TAG = dev
 
 GULP := node_modules/.bin/gulp
 
-# Unless the user has specified otherwise in their environment, it's probably a
-# good idea to refuse to install unless we're in an activated virtualenv.
-ifndef PIP_REQUIRE_VIRTUALENV
-PIP_REQUIRE_VIRTUALENV = 1
-endif
-export PIP_REQUIRE_VIRTUALENV
-
 .PHONY: default
 default: test
 
@@ -20,14 +13,13 @@ build/manifest.json: node_modules/.uptodate
 clean:
 	find . -type f -name "*.py[co]" -delete
 	find . -type d -name "__pycache__" -delete
-	rm -f node_modules/.uptodate .pydeps
+	rm -f node_modules/.uptodate
 	rm -rf build
 
 ## Run the development H server locally
 .PHONY: dev
-dev: build/manifest.json .pydeps
-	@bin/hypothesis --dev init
-	@bin/hypothesis devserver
+dev: build/manifest.json
+	tox -e dev
 
 ## Build hypothesis/hypothesis docker image
 .PHONY: docker
@@ -57,7 +49,6 @@ run-docker:
 ## Run test suite
 .PHONY: test
 test: node_modules/.uptodate
-	@pip install -q tox
 	tox
 	$(GULP) test
 
@@ -71,31 +62,21 @@ lint:
 
 .PHONY: docs
 docs:
-	@pip install -q tox
 	tox -e docs
 
 .PHONY: checkdocs
 checkdocs:
-	@pip install -q tox
 	tox -e checkdocs
 
 .PHONY: docstrings
 docstrings:
-	@pip install -q tox
 	tox -e docstrings
 
 .PHONY: checkdocstrings
 checkdocstrings:
-	@pip install -q tox
 	tox -e checkdocstrings
 
 ################################################################################
-
-# Fake targets to aid with deps installation
-.pydeps: requirements.txt requirements-dev.in
-	@echo installing python dependencies
-	@pip install -r requirements-dev.in tox
-	@touch $@
 
 node_modules/.uptodate: package.json
 	@echo installing javascript dependencies

--- a/Makefile
+++ b/Makefile
@@ -66,10 +66,8 @@ test-py3: node_modules/.uptodate
 	tox -e py36 -- tests/h/
 
 .PHONY: lint
-lint: .pydeps
-	flake8 h
-	flake8 tests
-	flake8 --select FI14 --exclude 'h/cli/*,tests/h/cli/*,h/util/uri.py,h/migrations/versions/*' h tests
+lint:
+	tox -e lint
 
 .PHONY: docs
 docs:

--- a/docs/developing/install.rst
+++ b/docs/developing/install.rst
@@ -46,7 +46,7 @@ Install node by following the
 (the version of the nodejs package in the standard Ubuntu repositories is too
 old).
 
-Upgrade pip and npm, and install tox-pip-extensions:
+Upgrade pip and npm, and install tox and tox-pip-extensions:
 
 .. code-block:: bash
 
@@ -76,7 +76,7 @@ Install the following packages:
 .. note:: Unfortunately you need to install the ``postgresql`` package, because
           Homebrew does not currently provide a standalone ``libpq`` package.
 
-Upgrade pip and install tox-pip-extensions:
+Upgrade pip and install tox and tox-pip-extensions:
 
 .. code-block:: bash
 

--- a/docs/developing/install.rst
+++ b/docs/developing/install.rst
@@ -33,7 +33,6 @@ Install the following packages:
     sudo apt-get install -y --no-install-recommends \
         build-essential \
         git \
-        tox \
         libevent-dev \
         libffi-dev \
         libfontconfig \
@@ -51,7 +50,7 @@ Upgrade pip and npm, and install tox-pip-extensions:
 
 .. code-block:: bash
 
-    sudo pip install -U pip tox-pip-extensions
+    sudo pip install -U pip tox tox-pip-extensions
     sudo npm install -g npm
 
 Installing the system dependencies on macOS
@@ -72,8 +71,7 @@ Install the following packages:
         libffi \
         node \
         postgresql \
-        python \
-        tox
+        python
 
 .. note:: Unfortunately you need to install the ``postgresql`` package, because
           Homebrew does not currently provide a standalone ``libpq`` package.
@@ -82,7 +80,7 @@ Upgrade pip and install tox-pip-extensions:
 
 .. code-block:: bash
 
-    pip install -U pip tox-pip-extensions
+    pip install -U pip tox tox-pip-extensions
 
 
 Getting the h source code from GitHub

--- a/docs/developing/install.rst
+++ b/docs/developing/install.rst
@@ -47,13 +47,12 @@ Install node by following the
 (the version of the nodejs package in the standard Ubuntu repositories is too
 old).
 
-Upgrade pip and npm:
+Upgrade pip and npm, and install tox-pip-extensions:
 
 .. code-block:: bash
 
-    sudo pip install -U pip
+    sudo pip install -U pip tox-pip-extensions
     sudo npm install -g npm
-
 
 Installing the system dependencies on macOS
 -------------------------------------------
@@ -79,11 +78,12 @@ Install the following packages:
 .. note:: Unfortunately you need to install the ``postgresql`` package, because
           Homebrew does not currently provide a standalone ``libpq`` package.
 
-Upgrade pip:
+Upgrade pip and install tox-pip-extensions:
 
 .. code-block:: bash
 
-    pip install -U pip
+    pip install -U pip tox-pip-extensions
+
 
 Getting the h source code from GitHub
 -------------------------------------

--- a/docs/developing/install.rst
+++ b/docs/developing/install.rst
@@ -33,25 +33,25 @@ Install the following packages:
     sudo apt-get install -y --no-install-recommends \
         build-essential \
         git \
+        tox \
         libevent-dev \
         libffi-dev \
         libfontconfig \
         libpq-dev \
         libssl-dev \
         python-dev \
-        python-pip \
-        python-virtualenv
+        python-pip
 
 Install node by following the
 `instructions on nodejs.org <https://nodejs.org/en/download/package-manager/>`_
 (the version of the nodejs package in the standard Ubuntu repositories is too
 old).
 
-Upgrade pip, virtualenv and npm:
+Upgrade pip and npm:
 
 .. code-block:: bash
 
-    sudo pip install -U pip virtualenv
+    sudo pip install -U pip
     sudo npm install -g npm
 
 
@@ -73,16 +73,17 @@ Install the following packages:
         libffi \
         node \
         postgresql \
-        python
+        python \
+        tox
 
 .. note:: Unfortunately you need to install the ``postgresql`` package, because
           Homebrew does not currently provide a standalone ``libpq`` package.
 
-Upgrade pip and virtualenv:
+Upgrade pip:
 
 .. code-block:: bash
 
-    pip install -U pip virtualenv
+    pip install -U pip
 
 Getting the h source code from GitHub
 -------------------------------------
@@ -184,39 +185,6 @@ Install ``gulp-cli`` to get the ``gulp`` command:
 .. code-block:: bash
 
     sudo npm install -g gulp-cli
-
-
-Creating a Python virtual environment
--------------------------------------
-
-Create a Python virtual environment to install and run the h Python code and
-Python dependencies in:
-
-.. code-block:: bash
-
-   virtualenv .venv
-
-
-.. _activating_your_virtual_environment:
-
-Activating your virtual environment
------------------------------------
-
-Activate the virtual environment that you've created:
-
-.. code-block:: bash
-
-   source .venv/bin/activate
-
-.. tip::
-
-   You'll need to re-activate this virtualenv with the
-   ``source .venv/bin/activate`` command each time you open a new terminal,
-   before running h.
-   See the `Virtual Environments`_ section in the Hitchhiker's guide to
-   Python for an introduction to Python virtual environments.
-
-.. _Virtual Environments: http://docs.python-guide.org/en/latest/dev/virtualenvs/
 
 
 Running h

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -1,8 +1,4 @@
 -r requirements.txt
 
-flake8
-flake8-future-import
 honcho
-pep257
-prospector[with_pyroma]
 pyramid_debugtoolbar

--- a/tox.ini
+++ b/tox.ini
@@ -45,7 +45,7 @@ passenv =
 whitelist_externals = sh
 commands =
     sh bin/hypothesis --dev init
-    sh bin/hypothesis devserver
+    {posargs:sh bin/hypothesis devserver}
 
 [testenv:py27-dev]
 deps = {[dev]deps}

--- a/tox.ini
+++ b/tox.ini
@@ -106,3 +106,13 @@ deps = {[docstrings]deps}
 commands =
     {[docstrings]commands}
     sphinx-build -qTn -b dirhtml {envtmpdir}/rst {envtmpdir}/dirhtml
+
+[testenv:lint]
+basepython = python3.6
+deps =
+    flake8
+    flake8-future-import
+commands =
+    flake8 h
+    flake8 tests
+    flake8 --select FI14 --exclude 'h/cli/*,tests/h/cli/*,h/util/uri.py,h/migrations/versions/*' h tests

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,8 @@
 [tox]
 envlist = py27
 skipsdist = true
+requires =
+    tox-pip-extensions
 tox_pip_extensions_ext_venv_update = true
 
 [pytest]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 envlist = py27
 skipsdist = true
+tox_pip_extensions_ext_venv_update = true
 
 [pytest]
 minversion = 2.8

--- a/tox.ini
+++ b/tox.ini
@@ -107,7 +107,6 @@ passenv = CI TRAVIS*
 commands = codecov
 
 [docs]
-basepython = python3.6
 changedir = docs
 deps =
     sphinx
@@ -115,40 +114,34 @@ deps =
     sphinx-autobuild
 
 [testenv:docs]
-basepython = {[docs]basepython}
 changedir = {[docs]changedir}
 deps = {[docs]deps}
 commands = sphinx-autobuild -BqT -b dirhtml -d {envtmpdir}/doctrees . {envtmpdir}/html
 
 [testenv:checkdocs]
-basepython = {[docs]basepython}
 changedir = {[docs]changedir}
 deps = {[docs]deps}
 commands = sphinx-build -qTWn -b dirhtml -d {envtmpdir}/doctrees . {envtmpdir}/html
 
 [docstrings]
-basepython = {[docs]basepython}
 commands = sphinx-apidoc -ePMF -a -H "Dooccsstrinngs!!" --ext-intersphinx --ext-todo --ext-viewcode -o {envtmpdir}/rst .
 deps =
     {[docs]deps}
     {[testenv]deps}
 
 [testenv:docstrings]
-basepython = {[docstrings]basepython}
 deps = {[docstrings]deps}
 commands =
     {[docstrings]commands}
     sphinx-autobuild -BqT -z h -z tests -b dirhtml {envtmpdir}/rst {envtmpdir}/dirhtml
 
 [testenv:checkdocstrings]
-basepython = {[docstrings]basepython}
 deps = {[docstrings]deps}
 commands =
     {[docstrings]commands}
     sphinx-build -qTn -b dirhtml {envtmpdir}/rst {envtmpdir}/dirhtml
 
 [testenv:lint]
-basepython = python3.6
 deps =
     flake8
     flake8-future-import

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ passenv =
 commands =
     coverage run --parallel --source h,tests/h -m pytest -Werror {posargs:tests/h/}
 
-[testenv:py27-dev]
+[dev]
 deps = -rrequirements-dev.in
 passenv =
     ALLOWED_ORIGINS
@@ -46,6 +46,24 @@ whitelist_externals = sh
 commands =
     sh bin/hypothesis --dev init
     sh bin/hypothesis devserver
+
+[testenv:py27-dev]
+deps = {[dev]deps}
+passenv = {[dev]passenv}
+whitelist_externals = {[dev]whitelist_externals}
+commands = {[dev]commands}
+
+[testenv:py36-dev]
+deps = {[dev]deps}
+passenv = {[dev]passenv}
+whitelist_externals = {[dev]whitelist_externals}
+commands = {[dev]commands}
+
+[testenv:py37-dev]
+deps = {[dev]deps}
+passenv = {[dev]passenv}
+whitelist_externals = {[dev]whitelist_externals}
+commands = {[dev]commands}
 
 [functional]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ passenv =
 commands =
     coverage run --parallel --source h,tests/h -m pytest -Werror {posargs:tests/h/}
 
-[testenv:dev]
+[testenv:py27-dev]
 deps = -rrequirements-dev.in
 passenv =
     ALLOWED_ORIGINS

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,25 @@ passenv =
 commands =
     coverage run --parallel --source h,tests/h -m pytest -Werror {posargs:tests/h/}
 
+[testenv:dev]
+deps = -rrequirements-dev.in
+passenv =
+    ALLOWED_ORIGINS
+    AUTHORITY
+    BOUNCER_URL
+    CLIENT_OAUTH_ID
+    CLIENT_RPC_ALLOWED_ORIGINS
+    CLIENT_URL
+    CONFIG_URI
+    MODEL_CREATE_ALL
+    SEARCH_AUTOCONFIG
+    USE_HTTPS
+    WEBSOCKET_URL
+whitelist_externals = sh
+commands =
+    sh bin/hypothesis --dev init
+    sh bin/hypothesis devserver
+
 [functional]
 deps =
     pytest


### PR DESCRIPTION
`make test test-py3 docs checkdocs docstrings` and `checkdocstrings` each run in their own tox-managed venvs already. This PR changes `make dev` and `lint` to run in tox venvs too (two venvs: one for `make dev` and one for `make lint`). This means that everything in `Makefile` now runs in tox, except `make clean docker` and `run-docker` which wouldn't make sense in tox.

This means that developers no longer need to create and activate a virtualenv. You just install tox (system-wide: `sudo apt-get|brew install tox`) and then run `make dev`, without having created or activated a venv, and it works.

If some developers _do_ still want to use their own venv, and manager it with virtualenvwrapper or virtualfish, they can do so. All the dependencies are still specified in `requirements` files. You just have to run `bin/hypothesis devserver` instead of `make dev`.

The advantages of running `make dev` and `lint` inside tox are:

* Makes onboarding easier for developers (venv management is one thing that trips up new developers, until they start using virtualenvwrapper or virtualfish and get the hang of it)
* Make our dev install docs shorter and simpler
* Reduces "Something isn't working in my particular dev env" problems
* Reduces difference between different developers envs, CI and prod
* By using a separate venv for each command only the deps needed for the particular command need to be installed in the particular venv, rather than installing everything in one big development venv, so that chance of dependency collisions or incompatibilties is reduced, and we gain some freedom as the venvs for different make commands can use different versions of Python, or different versions of the same Python package

## Future plans

* Do the same change for bouncer and lms so that all our projects are consistent

* Maybe move `docker-compose` into a venv.

  Since docker-compose is just a Python package we could install docker-compose into its own tox-managed docker-compose venv and then provide a command that's just an alias for the docker-compose in the venv. `tox -e docker-compose -- <ARGS>` would certainly work. Maybe `make docker-compose [args]`. You want to be able to pass your own args to it anyway, so you can pass `up`, or `up -d`, or `stop`, etc depending on what you want to do now.

  The advantage of doing this is that we could remove the "install docker-compose" step from our install docs - tox can install it for us, which is one less thing for devs to worry about, and no more problems with installing docker-compose on one dev's system because of problems unique to their environment, it's installed automatically into its very own venv.

* Add some new tox-based make commands: `make shell` to run a Python shell, `make sql` to connect to the DB with SQL

## See also

* Work-in-progress `make sql` command: https://github.com/hypothesis/h/pull/5231