### PR TITLE
Fix RSS stream

### DIFF
--- a/h/search/core.py
+++ b/h/search/core.py
@@ -65,6 +65,7 @@ class Search(object):
         :returns: The search results
         :rtype: SearchResult
         """
+        params = params.copy()  # Avoid mutating input dict.
         total, annotation_ids, aggregations = self._search_annotations(params)
         reply_ids = self._search_replies(annotation_ids)
 

--- a/tests/h/search/core_test.py
+++ b/tests/h/search/core_test.py
@@ -122,6 +122,14 @@ class TestSearch(object):
 
         assert result.reply_ids == []
 
+    def test_it_does_not_modify_param_dict(self, pyramid_request):
+        params = {"sort": "updated"}
+        original_params = params.copy()
+
+        search.Search(pyramid_request).run(params)
+
+        assert params == original_params
+
 
 class TestSearchWithSeparateReplies(object):
     """Unit tests for search.Search when separate_replies=True is given."""


### PR DESCRIPTION
The `/stream.rss` and `/stream.atom` views were broken by
6c342c7cbffaa6efafd883df37237886d2ead706 because the `params.copy()`
call in `h.search.query.Builder.build` was removed. As a result
`Search.run` tried to modify its input `params` dict which crashed in
views where that argument is the read-only `request.params`.

It seems less surprising for `Search.run` not to mutate its input dict,
so restore that behavior.