### PR TITLE
Validate query parameters in search feed views

### DIFF
--- a/h/views/feeds.py
+++ b/h/views/feeds.py
@@ -7,6 +7,8 @@ from pyramid import i18n
 
 from h import search
 from h.feeds import render_atom, render_rss
+from h.schemas.annotation import SearchParamsSchema
+from h.schemas.util import validate_query_params
 from h.storage import fetch_ordered_annotations
 
 
@@ -15,7 +17,9 @@ _ = i18n.TranslationStringFactory(__package__)
 
 def _annotations(request):
     """Return the annotations from the search API."""
-    result = search.Search(request, stats=request.stats).run(request.params)
+    schema = SearchParamsSchema()
+    params = validate_query_params(schema, request.params)
+    result = search.Search(request, stats=request.stats).run(params)
     return fetch_ordered_annotations(request.db, result.annotation_ids)
 
 

--- a/tests/functional/test_feeds.py
+++ b/tests/functional/test_feeds.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import pytest
+
+
+@pytest.mark.functional
+def test_atom_feed(app):
+    app.get('/stream.atom')
+
+
+@pytest.mark.functional
+def test_rss_feed(app):
+    app.get('/stream.rss')

--- a/tests/h/views/feeds_test.py
+++ b/tests/h/views/feeds_test.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 import mock
 import pytest
 
+from h.schemas.annotation import SearchParamsSchema
 from h.views.feeds import stream_atom, stream_rss
 
 
@@ -50,6 +51,16 @@ class TestStreamRSS(object):
         result = stream_rss(pyramid_request)
 
         assert result == render_rss.return_value
+
+    def test_it_validates_query_params(self, matchers, pyramid_request, render_rss, patch, search):
+        validate_query_params = patch('h.views.feeds.validate_query_params')
+        searcher = search.Search.return_value
+
+        stream_rss(pyramid_request)
+
+        schema_matcher = matchers.InstanceOf(SearchParamsSchema)
+        validate_query_params.assert_called_with(schema_matcher, pyramid_request.params)
+        searcher.run.assert_called_with(validate_query_params.return_value)
 
 
 @pytest.fixture


### PR DESCRIPTION
Enforce that only recognized arguments are passed from query parameters
to `Search.run`, the same as we do for the search API.

Also add minimal functional tests for the RSS feed views.

See also: https://github.com/hypothesis/h/pull/5262