### PR TITLE
Fix security documentation for POST api/groups/{id}/members/{user}

### DIFF
--- a/docs/_extra/api-reference/hypothesis.yaml
+++ b/docs/_extra/api-reference/hypothesis.yaml
@@ -320,7 +320,7 @@ paths:
           description: |
             Limit the results to annotations matching the specific URI or equivalent URIs.
 
-            URI can be a URL (a web page address) or a URN representing another kind of 
+            URI can be a URL (a web page address) or a URN representing another kind of
             resource such as DOI (Digital Object Identifier) or a PDF fingerprint.
           required: false
           type: string
@@ -352,8 +352,8 @@ paths:
           type: string
         - name: any
           in: query
-          description: Limit the results to annotations whose quote, tags, text or url 
-            fields contain this keyword.  
+          description: Limit the results to annotations whose quote, tags, text or url
+            fields contain this keyword.
           required: false
           type: string
         - name: group
@@ -374,7 +374,7 @@ paths:
           type: string
         - name: text
           in: query
-          description: Limit the results to annotations that contain this text in their 
+          description: Limit the results to annotations that contain this text in their
             textual body.
           required: false
           type: string
@@ -498,6 +498,8 @@ paths:
           description: User or Group not found
           schema:
             $ref: '#/definitions/Error'
+      security:
+        - authClientCredentials: []
 definitions:
   NewAnnotation:
     $ref: './schemas/annotation-schema.json'


### PR DESCRIPTION
This quick PR corrects API documentation to show (accurately) that one needs authClientCredentials to add members to groups:

![image](https://user-images.githubusercontent.com/439947/45113764-379af100-b119-11e8-8086-0941d345178f.png)

(Apparently it also fixes some trailing spaces! We shouldn't have those!)