### PR TITLE
Make `h.views.api.groups` handle userid ValueError from user service

### DIFF
--- a/h/views/api/groups.py
+++ b/h/views/api/groups.py
@@ -101,7 +101,10 @@ def add_member(group, request):
     user_svc = request.find_service(name='user')
     group_svc = request.find_service(name='group')
 
-    user = user_svc.fetch(request.matchdict['userid'])
+    try:
+        user = user_svc.fetch(request.matchdict['userid'])
+    except ValueError:
+        raise HTTPNotFound()
 
     if user is None:
         raise HTTPNotFound()

--- a/tests/functional/api/test_groups.py
+++ b/tests/functional/api/test_groups.py
@@ -111,6 +111,13 @@ class TestAddMember(object):
 
         assert res.status_code == 404
 
+    def test_it_returns_404_if_malformed_userid(self, app, factories, group, auth_client_header):
+        res = app.post_json("/api/groups/{pubid}/members/{userid}".format(pubid=group.pubid, userid='foo@bar.com'),
+                            headers=auth_client_header,
+                            expect_errors=True)
+
+        assert res.status_code == 404
+
     def test_it_returns_404_if_authority_mismatch_on_group(self, app, factories, user, auth_client_header):
         group = factories.Group(authority="somewhere-else.org")
         res = app.post_json("/api/groups/{pubid}/members/{userid}".format(pubid=group.pubid, userid=user.userid),

--- a/tests/h/views/api/groups_test.py
+++ b/tests/h/views/api/groups_test.py
@@ -237,6 +237,18 @@ class TestAddMember(object):
         with pytest.raises(HTTPNotFound):
             views.add_member(group, pyramid_request)
 
+    def test_it_raises_HTTPNotFound_if_userid_malformed(self,
+                                                        group,
+                                                        pyramid_request,
+                                                        user_service,):
+
+        user_service.fetch.side_effect = ValueError('nope')
+
+        pyramid_request.matchdict['userid'] = "invalidformat@wherever"
+
+        with pytest.raises(HTTPNotFound):  # view handles ValueError and raises NotFound
+            views.add_member(group, pyramid_request)
+
     def test_it_fetches_user_from_the_request_params(self,
                                                      group,
                                                      user,


### PR DESCRIPTION
`POST /api/groups/{pubid}/members/{userid}` has been returning a 500 if you use a malformed `{userid}` in the path. This is because there is an uncaught `ValueError` that arises from invoking `h.services.user_service.fetch` with a faulty `userid`.

This PR handles the exception and raises a `HTTPNotFound` (404) instead.

There may be a way to do this with a little more nuance—possibly an HTTP 422 (Unprocessable Entity). I want to get a quick fix in place for now, with the understanding that this view is _imminently_ going to be refactored (within the sprint, for other reasons beyond this error handling).

This should get a stable response in place, and 404 may well be where we end up for the long term as it doesn't leak any information about our users.

Fixes https://github.com/hypothesis/h/issues/5266