### PR TITLE
Redux: refactor accounts schemas

### DIFF
--- a/h/accounts/schemas.py
+++ b/h/accounts/schemas.py
@@ -9,10 +9,8 @@ from itsdangerous import BadData, SignatureExpired
 from jinja2 import Markup
 
 from h import i18n, models, validators
-from h.accounts import util
 from h.services.user import UserNotActivated
 from h.models.user import (
-    DISPLAY_NAME_MAX_LENGTH,
     EMAIL_MAX_LENGTH,
     USERNAME_MAX_LENGTH,
     USERNAME_MIN_LENGTH,
@@ -336,59 +334,6 @@ class PasswordChangeSchema(CSRFSchema):
 
         if exc.children:
             raise exc
-
-
-def validate_url(node, cstruct):
-    try:
-        util.validate_url(cstruct)
-    except ValueError as exc:
-        raise colander.Invalid(node, str(exc))
-
-
-def validate_orcid(node, cstruct):
-    try:
-        util.validate_orcid(cstruct)
-    except ValueError as exc:
-        raise colander.Invalid(node, str(exc))
-
-
-class EditProfileSchema(CSRFSchema):
-    display_name = colander.SchemaNode(
-        colander.String(),
-        missing=None,
-        validator=validators.Length(max=DISPLAY_NAME_MAX_LENGTH),
-        title=_('Display name'))
-
-    description = colander.SchemaNode(
-        colander.String(),
-        missing=None,
-        validator=validators.Length(max=250),
-        widget=deform.widget.TextAreaWidget(
-            max_length=250,
-            rows=4,
-        ),
-        title=_('Description'))
-
-    location = colander.SchemaNode(
-        colander.String(),
-        missing=None,
-        validator=validators.Length(max=100),
-        title=_('Location'))
-
-    link = colander.SchemaNode(
-        colander.String(),
-        missing=None,
-        validator=colander.All(
-            validators.Length(max=250),
-            validate_url),
-        title=_('Link'))
-
-    orcid = colander.SchemaNode(
-        colander.String(),
-        missing=None,
-        validator=validate_orcid,
-        title=_('ORCID'),
-        hint=_('ORCID provides a persistent identifier for researchers (see orcid.org).'))
 
 
 class NotificationsSchema(CSRFSchema):

--- a/h/accounts/schemas.py
+++ b/h/accounts/schemas.py
@@ -132,30 +132,6 @@ def _privacy_accepted_message():
     return privacy_msg
 
 
-class ForgotPasswordSchema(CSRFSchema):
-    email = colander.SchemaNode(
-        colander.String(),
-        validator=colander.All(validators.Email()),
-        title=_('Email address'),
-        widget=deform.widget.TextInputWidget(template='emailinput',
-                                             autofocus=True),
-    )
-
-    def validator(self, node, value):
-        super(ForgotPasswordSchema, self).validator(node, value)
-
-        request = node.bindings['request']
-        email = value.get('email')
-        user = models.User.get_by_email(request.db, email, request.authority)
-
-        if user is None:
-            err = colander.Invalid(node)
-            err['email'] = _('Unknown email address.')
-            raise err
-
-        value['user'] = user
-
-
 class RegisterSchema(CSRFSchema):
     username = colander.SchemaNode(
         colander.String(),

--- a/h/accounts/schemas.py
+++ b/h/accounts/schemas.py
@@ -5,7 +5,6 @@ import logging
 
 import colander
 import deform
-from itsdangerous import BadData, SignatureExpired
 from jinja2 import Markup
 
 from h import i18n, models, validators
@@ -165,57 +164,6 @@ class RegisterSchema(CSRFSchema):
             css_class='form-checkbox--inline'
         ),
     )
-
-
-class ResetCode(colander.SchemaType):
-
-    """Schema type transforming a reset code to a user and back."""
-
-    def serialize(self, node, appstruct):
-        if appstruct is colander.null:
-            return colander.null
-        if not isinstance(appstruct, models.User):
-            raise colander.Invalid(node, '%r is not a User' % appstruct)
-        request = node.bindings['request']
-        serializer = request.registry.password_reset_serializer
-        return serializer.dumps(appstruct.username)
-
-    def deserialize(self, node, cstruct):
-        if cstruct is colander.null:
-            return colander.null
-
-        request = node.bindings['request']
-        serializer = request.registry.password_reset_serializer
-
-        try:
-            (username, timestamp) = serializer.loads(cstruct,
-                                                     max_age=72*3600,
-                                                     return_timestamp=True)
-        except SignatureExpired:
-            raise colander.Invalid(node, _('Reset code has expired. Please reset your password again'))
-        except BadData:
-            raise colander.Invalid(node, _('Wrong reset code.'))
-
-        user = models.User.get_by_username(request.db, username, request.authority)
-        if user is None:
-            raise colander.Invalid(node, _('Your reset code is not valid'))
-        if user.password_updated is not None and timestamp < user.password_updated:
-            raise colander.Invalid(node,
-                                   _('This reset code has already been used.'))
-        return user
-
-
-class ResetPasswordSchema(CSRFSchema):
-    # N.B. this is the field into which the user puts their reset code, but we
-    # call it `user` because when validated, it will return a `User` object.
-    user = colander.SchemaNode(
-        ResetCode(),
-        title=_('Reset code'),
-        hint=_('This will be emailed to you.'),
-        widget=deform.widget.TextInputWidget(disable_autocomplete=True))
-    password = new_password_node(
-        title=_('New password'),
-        widget=deform.widget.PasswordWidget(disable_autocomplete=True))
 
 
 class EmailChangeSchema(CSRFSchema):

--- a/h/schemas/forms/accounts/__init__.py
+++ b/h/schemas/forms/accounts/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals

--- a/h/schemas/forms/accounts/__init__.py
+++ b/h/schemas/forms/accounts/__init__.py
@@ -1,3 +1,10 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import unicode_literals
+
+from h.schemas.forms.accounts.edit_profile import EditProfileSchema
+
+
+__all__ = (
+    'EditProfileSchema',
+)

--- a/h/schemas/forms/accounts/__init__.py
+++ b/h/schemas/forms/accounts/__init__.py
@@ -3,8 +3,10 @@
 from __future__ import unicode_literals
 
 from h.schemas.forms.accounts.edit_profile import EditProfileSchema
+from h.schemas.forms.accounts.login import LoginSchema
 
 
 __all__ = (
     'EditProfileSchema',
+    'LoginSchema',
 )

--- a/h/schemas/forms/accounts/__init__.py
+++ b/h/schemas/forms/accounts/__init__.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 from h.schemas.forms.accounts.edit_profile import EditProfileSchema
 from h.schemas.forms.accounts.forgot_password import ForgotPasswordSchema
 from h.schemas.forms.accounts.login import LoginSchema
+from h.schemas.forms.accounts.reset_password import ResetCode
 from h.schemas.forms.accounts.reset_password import ResetPasswordSchema
 
 
@@ -12,5 +13,6 @@ __all__ = (
     'EditProfileSchema',
     'ForgotPasswordSchema',
     'LoginSchema',
+    'ResetCode',
     'ResetPasswordSchema',
 )

--- a/h/schemas/forms/accounts/__init__.py
+++ b/h/schemas/forms/accounts/__init__.py
@@ -5,10 +5,12 @@ from __future__ import unicode_literals
 from h.schemas.forms.accounts.edit_profile import EditProfileSchema
 from h.schemas.forms.accounts.forgot_password import ForgotPasswordSchema
 from h.schemas.forms.accounts.login import LoginSchema
+from h.schemas.forms.accounts.reset_password import ResetPasswordSchema
 
 
 __all__ = (
     'EditProfileSchema',
     'ForgotPasswordSchema',
     'LoginSchema',
+    'ResetPasswordSchema',
 )

--- a/h/schemas/forms/accounts/__init__.py
+++ b/h/schemas/forms/accounts/__init__.py
@@ -3,10 +3,12 @@
 from __future__ import unicode_literals
 
 from h.schemas.forms.accounts.edit_profile import EditProfileSchema
+from h.schemas.forms.accounts.forgot_password import ForgotPasswordSchema
 from h.schemas.forms.accounts.login import LoginSchema
 
 
 __all__ = (
     'EditProfileSchema',
+    'ForgotPasswordSchema',
     'LoginSchema',
 )

--- a/h/schemas/forms/accounts/edit_profile.py
+++ b/h/schemas/forms/accounts/edit_profile.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import colander
+import deform
+
+from h import i18n, validators
+from h.accounts import util
+from h.models.user import (
+    DISPLAY_NAME_MAX_LENGTH,
+)
+from h.schemas.base import CSRFSchema
+
+_ = i18n.TranslationString
+
+
+def validate_url(node, cstruct):
+    try:
+        util.validate_url(cstruct)
+    except ValueError as exc:
+        raise colander.Invalid(node, str(exc))
+
+
+def validate_orcid(node, cstruct):
+    try:
+        util.validate_orcid(cstruct)
+    except ValueError as exc:
+        raise colander.Invalid(node, str(exc))
+
+
+class EditProfileSchema(CSRFSchema):
+    display_name = colander.SchemaNode(
+        colander.String(),
+        missing=None,
+        validator=validators.Length(max=DISPLAY_NAME_MAX_LENGTH),
+        title=_('Display name'))
+
+    description = colander.SchemaNode(
+        colander.String(),
+        missing=None,
+        validator=validators.Length(max=250),
+        widget=deform.widget.TextAreaWidget(
+            max_length=250,
+            rows=4,
+        ),
+        title=_('Description'))
+
+    location = colander.SchemaNode(
+        colander.String(),
+        missing=None,
+        validator=validators.Length(max=100),
+        title=_('Location'))
+
+    link = colander.SchemaNode(
+        colander.String(),
+        missing=None,
+        validator=colander.All(
+            validators.Length(max=250),
+            validate_url),
+        title=_('Link'))
+
+    orcid = colander.SchemaNode(
+        colander.String(),
+        missing=None,
+        validator=validate_orcid,
+        title=_('ORCID'),
+        hint=_('ORCID provides a persistent identifier for researchers (see orcid.org).'))

--- a/h/schemas/forms/accounts/forgot_password.py
+++ b/h/schemas/forms/accounts/forgot_password.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import colander
+import deform
+
+from h import i18n, models, validators
+from h.schemas.base import CSRFSchema
+
+_ = i18n.TranslationString
+
+
+class ForgotPasswordSchema(CSRFSchema):
+    email = colander.SchemaNode(
+        colander.String(),
+        validator=colander.All(validators.Email()),
+        title=_('Email address'),
+        widget=deform.widget.TextInputWidget(template='emailinput',
+                                             autofocus=True),
+    )
+
+    def validator(self, node, value):
+        super(ForgotPasswordSchema, self).validator(node, value)
+
+        request = node.bindings['request']
+        email = value.get('email')
+        user = models.User.get_by_email(request.db, email, request.authority)
+
+        if user is None:
+            err = colander.Invalid(node)
+            err['email'] = _('Unknown email address.')
+            raise err
+
+        value['user'] = user

--- a/h/schemas/forms/accounts/login.py
+++ b/h/schemas/forms/accounts/login.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import colander
+import deform
+
+from h import i18n
+from h.services.user import UserNotActivated
+from h.schemas.base import CSRFSchema
+
+_ = i18n.TranslationString
+
+
+class LoginSchema(CSRFSchema):
+    username = colander.SchemaNode(
+        colander.String(),
+        title=_('Username / email'),
+        widget=deform.widget.TextInputWidget(autofocus=True),
+    )
+    password = colander.SchemaNode(
+        colander.String(),
+        title=_('Password'),
+        widget=deform.widget.PasswordWidget()
+    )
+
+    def validator(self, node, value):
+        super(LoginSchema, self).validator(node, value)
+
+        request = node.bindings['request']
+        username = value.get('username')
+        password = value.get('password')
+
+        user_service = request.find_service(name='user')
+        user_password_service = request.find_service(name='user_password')
+
+        try:
+            user = user_service.fetch_for_login(username_or_email=username)
+        except UserNotActivated:
+            err = colander.Invalid(node)
+            err['username'] = _("Please check your email and open the link "
+                                "to activate your account.")
+            raise err
+
+        if user is None:
+            err = colander.Invalid(node)
+            err['username'] = _('User does not exist.')
+            raise err
+
+        if not user_password_service.check_password(user, password):
+            err = colander.Invalid(node)
+            err['password'] = _('Wrong password.')
+            raise err
+
+        value['user'] = user

--- a/h/schemas/forms/accounts/reset_password.py
+++ b/h/schemas/forms/accounts/reset_password.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import colander
+import deform
+from itsdangerous import BadData, SignatureExpired
+
+from h import i18n, models
+from h.schemas.base import CSRFSchema
+from h.schemas.forms.accounts import util
+
+_ = i18n.TranslationString
+
+
+class ResetCode(colander.SchemaType):
+
+    """Schema type transforming a reset code to a user and back."""
+
+    def serialize(self, node, appstruct):
+        if appstruct is colander.null:
+            return colander.null
+        if not isinstance(appstruct, models.User):
+            raise colander.Invalid(node, '%r is not a User' % appstruct)
+        request = node.bindings['request']
+        serializer = request.registry.password_reset_serializer
+        return serializer.dumps(appstruct.username)
+
+    def deserialize(self, node, cstruct):
+        if cstruct is colander.null:
+            return colander.null
+
+        request = node.bindings['request']
+        serializer = request.registry.password_reset_serializer
+
+        try:
+            (username, timestamp) = serializer.loads(cstruct,
+                                                     max_age=72*3600,
+                                                     return_timestamp=True)
+        except SignatureExpired:
+            raise colander.Invalid(node, _('Reset code has expired. Please reset your password again'))
+        except BadData:
+            raise colander.Invalid(node, _('Wrong reset code.'))
+
+        user = models.User.get_by_username(request.db, username, request.authority)
+        if user is None:
+            raise colander.Invalid(node, _('Your reset code is not valid'))
+        if user.password_updated is not None and timestamp < user.password_updated:
+            raise colander.Invalid(node,
+                                   _('This reset code has already been used.'))
+        return user
+
+
+class ResetPasswordSchema(CSRFSchema):
+    # N.B. this is the field into which the user puts their reset code, but we
+    # call it `user` because when validated, it will return a `User` object.
+    user = colander.SchemaNode(
+        ResetCode(),
+        title=_('Reset code'),
+        hint=_('This will be emailed to you.'),
+        widget=deform.widget.TextInputWidget(disable_autocomplete=True))
+    password = util.new_password_node(
+        title=_('New password'),
+        widget=deform.widget.PasswordWidget(disable_autocomplete=True))

--- a/h/schemas/forms/accounts/util.py
+++ b/h/schemas/forms/accounts/util.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import colander
+import deform
+
+from h import validators
+
+
+PASSWORD_MIN_LENGTH = 2  # FIXME: this is ridiculous
+
+
+def new_password_node(**kwargs):
+    """Return a Colander schema node for a new user password."""
+    kwargs.setdefault('widget', deform.widget.PasswordWidget())
+    return colander.SchemaNode(
+        colander.String(),
+        validator=validators.Length(min=PASSWORD_MIN_LENGTH),
+        **kwargs)

--- a/h/views/accounts.py
+++ b/h/views/accounts.py
@@ -18,6 +18,7 @@ from h import i18n
 from h import models
 from h import session
 from h.accounts import schemas
+from h.schemas.forms.accounts import EditProfileSchema
 from h.accounts.events import ActivationEvent
 from h.accounts.events import PasswordResetEvent
 from h.accounts.events import LogoutEvent
@@ -451,7 +452,7 @@ class EditProfileController(object):
 
     def __init__(self, request):
         self.request = request
-        self.schema = schemas.EditProfileSchema().bind(request=self.request)
+        self.schema = EditProfileSchema().bind(request=self.request)
         self.form = request.create_form(self.schema,
                                         buttons=(_('Save'),),
                                         use_inline_editing=True)

--- a/h/views/accounts.py
+++ b/h/views/accounts.py
@@ -19,6 +19,7 @@ from h import models
 from h import session
 from h.accounts import schemas
 from h.schemas.forms.accounts import EditProfileSchema
+from h.schemas.forms.accounts import LoginSchema
 from h.accounts.events import ActivationEvent
 from h.accounts.events import PasswordResetEvent
 from h.accounts.events import LogoutEvent
@@ -98,7 +99,7 @@ class AuthController(object):
             text=_('Forgot your password?'))
 
         self.request = request
-        self.schema = schemas.LoginSchema().bind(request=self.request)
+        self.schema = LoginSchema().bind(request=self.request)
 
         show_cancel_button = bool(request.params.get('for_oauth', False))
         self.form = request.create_form(self.schema,

--- a/h/views/accounts.py
+++ b/h/views/accounts.py
@@ -21,6 +21,7 @@ from h.accounts import schemas
 from h.schemas.forms.accounts import EditProfileSchema
 from h.schemas.forms.accounts import ForgotPasswordSchema
 from h.schemas.forms.accounts import LoginSchema
+from h.schemas.forms.accounts import ResetPasswordSchema
 from h.accounts.events import ActivationEvent
 from h.accounts.events import PasswordResetEvent
 from h.accounts.events import LogoutEvent
@@ -226,7 +227,7 @@ class ResetController(object):
 
     def __init__(self, request):
         self.request = request
-        self.schema = schemas.ResetPasswordSchema().bind(request=self.request)
+        self.schema = ResetPasswordSchema().bind(request=self.request)
         self.form = request.create_form(
             schema=self.schema,
             action=self.request.route_path('account_reset'),
@@ -251,7 +252,7 @@ class ResetController(object):
             raise httpexceptions.HTTPNotFound()
         else:
             # N.B. the form field for the reset code is called 'user'. See the
-            # comment in `schemas.ResetPasswordSchema` for details.
+            # comment in `~h.schemas.forms.accounts.ResetPasswordSchema` for details.
             self.form.set_appstruct({'user': user})
             self.form.set_widgets({'user': deform.widget.HiddenWidget()})
 

--- a/h/views/accounts.py
+++ b/h/views/accounts.py
@@ -21,6 +21,7 @@ from h.accounts import schemas
 from h.schemas.forms.accounts import EditProfileSchema
 from h.schemas.forms.accounts import ForgotPasswordSchema
 from h.schemas.forms.accounts import LoginSchema
+from h.schemas.forms.accounts import ResetCode
 from h.schemas.forms.accounts import ResetPasswordSchema
 from h.accounts.events import ActivationEvent
 from h.accounts.events import PasswordResetEvent
@@ -247,7 +248,7 @@ class ResetController(object):
         # If valid, we inject the supplied it into the form as a hidden field.
         # Otherwise, we 404.
         try:
-            user = schemas.ResetCode().deserialize(self.schema, code)
+            user = ResetCode().deserialize(self.schema, code)
         except colander.Invalid:
             raise httpexceptions.HTTPNotFound()
         else:

--- a/h/views/accounts.py
+++ b/h/views/accounts.py
@@ -19,6 +19,7 @@ from h import models
 from h import session
 from h.accounts import schemas
 from h.schemas.forms.accounts import EditProfileSchema
+from h.schemas.forms.accounts import ForgotPasswordSchema
 from h.schemas.forms.accounts import LoginSchema
 from h.accounts.events import ActivationEvent
 from h.accounts.events import PasswordResetEvent
@@ -175,7 +176,7 @@ class ForgotPasswordController(object):
 
     def __init__(self, request):
         self.request = request
-        self.schema = schemas.ForgotPasswordSchema().bind(request=self.request)
+        self.schema = ForgotPasswordSchema().bind(request=self.request)
         self.form = request.create_form(self.schema, buttons=(_('Reset'),))
 
     @view_config(request_method='GET')

--- a/tests/h/accounts/schemas_test.py
+++ b/tests/h/accounts/schemas_test.py
@@ -7,7 +7,7 @@ from pyramid.exceptions import BadCSRFToken
 from itsdangerous import BadData, SignatureExpired
 
 from h.accounts import schemas
-from h.services.user import UserNotActivated, UserService
+from h.services.user import UserService
 from h.services.user_password import UserPasswordService
 
 
@@ -153,117 +153,6 @@ class TestRegisterSchema(object):
             "password": "sdlkfjlk3j3iuei",
             "privacy_accepted": "true",
         })
-
-
-@pytest.mark.usefixtures('user_service', 'user_password_service')
-class TestLoginSchema(object):
-
-    def test_passes_username_to_user_service(self,
-                                             factories,
-                                             pyramid_csrf_request,
-                                             user_service):
-        user = factories.User.build(username='jeannie')
-        user_service.fetch_for_login.return_value = user
-        schema = schemas.LoginSchema().bind(request=pyramid_csrf_request)
-
-        schema.deserialize({
-            'username': 'jeannie',
-            'password': 'cake',
-        })
-
-        user_service.fetch_for_login.assert_called_once_with(username_or_email='jeannie')
-
-    def test_passes_password_to_user_password_service(self,
-                                                      factories,
-                                                      pyramid_csrf_request,
-                                                      user_service,
-                                                      user_password_service):
-        user = factories.User.build(username='jeannie')
-        user_service.fetch_for_login.return_value = user
-        schema = schemas.LoginSchema().bind(request=pyramid_csrf_request)
-
-        schema.deserialize({
-            'username': 'jeannie',
-            'password': 'cake',
-        })
-
-        user_password_service.check_password.assert_called_once_with(user, 'cake')
-
-    def test_it_returns_user_when_valid(self,
-                                        factories,
-                                        pyramid_csrf_request,
-                                        user_service):
-        user = factories.User.build(username='jeannie')
-        user_service.fetch_for_login.return_value = user
-        schema = schemas.LoginSchema().bind(request=pyramid_csrf_request)
-
-        result = schema.deserialize({
-            'username': 'jeannie',
-            'password': 'cake',
-        })
-
-        assert result['user'] is user
-
-    def test_invalid_with_bad_csrf(self, pyramid_request, user_service):
-        schema = schemas.LoginSchema().bind(request=pyramid_request)
-
-        with pytest.raises(BadCSRFToken):
-            schema.deserialize({
-                'username': 'jeannie',
-                'password': 'cake',
-            })
-
-    def test_invalid_with_inactive_user(self,
-                                        pyramid_csrf_request,
-                                        user_service):
-        schema = schemas.LoginSchema().bind(request=pyramid_csrf_request)
-        user_service.fetch_for_login.side_effect = UserNotActivated()
-
-        with pytest.raises(colander.Invalid) as exc:
-            schema.deserialize({
-                'username': 'jeannie',
-                'password': 'cake',
-            })
-        errors = exc.value.asdict()
-
-        assert 'username' in errors
-        assert 'activate your account' in errors['username']
-
-    def test_invalid_with_unknown_user(self,
-                                       pyramid_csrf_request,
-                                       user_service):
-        schema = schemas.LoginSchema().bind(request=pyramid_csrf_request)
-        user_service.fetch_for_login.return_value = None
-
-        with pytest.raises(colander.Invalid) as exc:
-            schema.deserialize({
-                'username': 'jeannie',
-                'password': 'cake',
-            })
-        errors = exc.value.asdict()
-
-        assert 'username' in errors
-        assert 'does not exist' in errors['username']
-
-    def test_invalid_with_bad_password(self,
-                                       factories,
-                                       pyramid_csrf_request,
-                                       user_service,
-                                       user_password_service):
-        user = factories.User.build(username='jeannie')
-        user_service.fetch_for_login.return_value = user
-        user_password_service.check_password.return_value = False
-        schema = schemas.LoginSchema().bind(request=pyramid_csrf_request)
-
-        with pytest.raises(colander.Invalid) as exc:
-            schema.deserialize({
-                'username': 'jeannie',
-                'password': 'cake',
-            })
-        errors = exc.value.asdict()
-
-        assert 'password' in errors
-        assert 'Wrong password' in errors['password']
 
 
 @pytest.mark.usefixtures('user_model')

--- a/tests/h/accounts/schemas_test.py
+++ b/tests/h/accounts/schemas_test.py
@@ -156,34 +156,6 @@ class TestRegisterSchema(object):
 
 
 @pytest.mark.usefixtures('user_model')
-class TestForgotPasswordSchema(object):
-
-    def test_it_is_invalid_with_no_user(self,
-                                        pyramid_csrf_request,
-                                        user_model):
-        schema = schemas.ForgotPasswordSchema().bind(
-            request=pyramid_csrf_request)
-        user_model.get_by_email.return_value = None
-
-        with pytest.raises(colander.Invalid) as exc:
-            schema.deserialize({'email': 'rapha@example.com'})
-
-        assert 'email' in exc.value.asdict()
-        assert exc.value.asdict()['email'] == 'Unknown email address.'
-
-    def test_it_returns_user_when_valid(self,
-                                        pyramid_csrf_request,
-                                        user_model):
-        schema = schemas.ForgotPasswordSchema().bind(
-            request=pyramid_csrf_request)
-        user = user_model.get_by_email.return_value
-
-        appstruct = schema.deserialize({'email': 'rapha@example.com'})
-
-        assert appstruct['user'] == user
-
-
-@pytest.mark.usefixtures('user_model')
 class TestResetPasswordSchema(object):
 
     def test_it_is_invalid_with_password_too_short(self, pyramid_csrf_request):

--- a/tests/h/accounts/schemas_test.py
+++ b/tests/h/accounts/schemas_test.py
@@ -559,42 +559,6 @@ class TestPasswordChangeSchema(object):
         assert 'password' in exc.value.asdict()
 
 
-class TestEditProfileSchema(object):
-    def test_accepts_valid_input(self, pyramid_csrf_request):
-        schema = schemas.EditProfileSchema().bind(request=pyramid_csrf_request)
-        schema.deserialize({
-            'display_name': 'Michael Granitzer',
-            'description': 'Professor at University of Passau',
-            'link': 'http://mgrani.github.io/',
-            'location': 'Bavaria, Germany',
-            'orcid': '0000-0003-3566-5507',
-        })
-
-    def test_rejects_invalid_orcid(self, pyramid_csrf_request, validate_orcid):
-        validate_orcid.side_effect = ValueError('Invalid ORCID')
-        schema = schemas.EditProfileSchema().bind(request=pyramid_csrf_request)
-        with pytest.raises(colander.Invalid) as exc:
-            schema.deserialize({'orcid': 'abcdef'})
-        assert exc.value.asdict()['orcid'] == 'Invalid ORCID'
-
-    def test_rejects_invalid_url(self, pyramid_csrf_request, validate_url):
-        validate_url.side_effect = ValueError('Invalid URL')
-        schema = schemas.EditProfileSchema().bind(request=pyramid_csrf_request)
-        with pytest.raises(colander.Invalid) as exc:
-            schema.deserialize({'link': '"invalid URL"'})
-        assert exc.value.asdict()['link'] == 'Invalid URL'
-
-
-@pytest.fixture
-def validate_url(patch):
-    return patch('h.accounts.schemas.util.validate_url')
-
-
-@pytest.fixture
-def validate_orcid(patch):
-    return patch('h.accounts.schemas.util.validate_orcid')
-
-
 @pytest.fixture
 def dummy_node(pyramid_request):
     class DummyNode(object):

--- a/tests/h/accounts/schemas_test.py
+++ b/tests/h/accounts/schemas_test.py
@@ -4,7 +4,6 @@ import colander
 import pytest
 from mock import Mock
 from pyramid.exceptions import BadCSRFToken
-from itsdangerous import BadData, SignatureExpired
 
 from h.accounts import schemas
 from h.services.user import UserService
@@ -153,101 +152,6 @@ class TestRegisterSchema(object):
             "password": "sdlkfjlk3j3iuei",
             "privacy_accepted": "true",
         })
-
-
-@pytest.mark.usefixtures('user_model')
-class TestResetPasswordSchema(object):
-
-    def test_it_is_invalid_with_password_too_short(self, pyramid_csrf_request):
-        schema = schemas.ResetPasswordSchema().bind(
-            request=pyramid_csrf_request)
-
-        with pytest.raises(colander.Invalid) as exc:
-            schema.deserialize({"password": "a"})
-        assert "password" in exc.value.asdict()
-
-    def test_it_is_invalid_with_invalid_user_token(self, pyramid_csrf_request):
-        pyramid_csrf_request.registry.password_reset_serializer = (
-            self.FakeInvalidSerializer())
-        schema = schemas.ResetPasswordSchema().bind(
-            request=pyramid_csrf_request)
-
-        with pytest.raises(colander.Invalid) as exc:
-            schema.deserialize({
-                'user': 'abc123',
-                'password': 'secret',
-            })
-
-        assert 'user' in exc.value.asdict()
-        assert 'Wrong reset code.' in exc.value.asdict()['user']
-
-    def test_it_is_invalid_with_expired_token(self, pyramid_csrf_request):
-        pyramid_csrf_request.registry.password_reset_serializer = (
-            self.FakeExpiredSerializer())
-        schema = schemas.ResetPasswordSchema().bind(
-            request=pyramid_csrf_request)
-
-        with pytest.raises(colander.Invalid) as exc:
-            schema.deserialize({
-                'user': 'abc123',
-                'password': 'secret',
-            })
-
-        assert 'user' in exc.value.asdict()
-        assert 'Reset code has expired.' in exc.value.asdict()['user']
-
-    def test_it_is_invalid_if_user_has_already_reset_their_password(
-            self, pyramid_csrf_request, user_model):
-        pyramid_csrf_request.registry.password_reset_serializer = (
-            self.FakeSerializer())
-        schema = schemas.ResetPasswordSchema().bind(
-            request=pyramid_csrf_request)
-        user = user_model.get_by_username.return_value
-        user.password_updated = 2
-
-        with pytest.raises(colander.Invalid) as exc:
-            schema.deserialize({
-                'user': 'abc123',
-                'password': 'secret',
-            })
-
-        assert 'user' in exc.value.asdict()
-        assert 'This reset code has already been used.' in exc.value.asdict()['user']
-
-    def test_it_returns_user_when_valid(self,
-                                        pyramid_csrf_request,
-                                        user_model):
-        pyramid_csrf_request.registry.password_reset_serializer = (
-            self.FakeSerializer())
-        schema = schemas.ResetPasswordSchema().bind(
-            request=pyramid_csrf_request)
-        user = user_model.get_by_username.return_value
-        user.password_updated = 0
-
-        appstruct = schema.deserialize({
-            'user': 'abc123',
-            'password': 'secret',
-        })
-
-        assert appstruct['user'] == user
-
-    class FakeSerializer(object):
-        def dumps(self, obj):
-            return 'faketoken'
-
-        def loads(self, token, max_age=0, return_timestamp=False):
-            payload = {'username': 'foo@bar.com'}
-            if return_timestamp:
-                return payload, 1
-            return payload
-
-    class FakeExpiredSerializer(FakeSerializer):
-        def loads(self, token, max_age=0, return_timestamp=False):
-            raise SignatureExpired("Token has expired")
-
-    class FakeInvalidSerializer(FakeSerializer):
-        def loads(self, token, max_age=0, return_timestamp=False):
-            raise BadData("Invalid token")
 
 
 @pytest.mark.usefixtures('models', 'user_password_service')

--- a/tests/h/schemas/forms/accounts/__init__.py
+++ b/tests/h/schemas/forms/accounts/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals

--- a/tests/h/schemas/forms/accounts/edit_profile_test.py
+++ b/tests/h/schemas/forms/accounts/edit_profile_test.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+import colander
+import pytest
+
+from h.schemas.forms.accounts import EditProfileSchema
+
+
+class TestEditProfileSchema(object):
+    def test_accepts_valid_input(self, pyramid_csrf_request):
+        schema = EditProfileSchema().bind(request=pyramid_csrf_request)
+        schema.deserialize({
+            'display_name': 'Michael Granitzer',
+            'description': 'Professor at University of Passau',
+            'link': 'http://mgrani.github.io/',
+            'location': 'Bavaria, Germany',
+            'orcid': '0000-0003-3566-5507',
+        })
+
+    def test_rejects_invalid_orcid(self, pyramid_csrf_request, validate_orcid):
+        validate_orcid.side_effect = ValueError('Invalid ORCID')
+        schema = EditProfileSchema().bind(request=pyramid_csrf_request)
+        with pytest.raises(colander.Invalid) as exc:
+            schema.deserialize({'orcid': 'abcdef'})
+        assert exc.value.asdict()['orcid'] == 'Invalid ORCID'
+
+    def test_rejects_invalid_url(self, pyramid_csrf_request, validate_url):
+        validate_url.side_effect = ValueError('Invalid URL')
+        schema = EditProfileSchema().bind(request=pyramid_csrf_request)
+        with pytest.raises(colander.Invalid) as exc:
+            schema.deserialize({'link': '"invalid URL"'})
+        assert exc.value.asdict()['link'] == 'Invalid URL'
+
+
+@pytest.fixture
+def validate_url(patch):
+    return patch('h.accounts.util.validate_url')
+
+
+@pytest.fixture
+def validate_orcid(patch):
+    return patch('h.accounts.util.validate_orcid')

--- a/tests/h/schemas/forms/accounts/forgot_password_test.py
+++ b/tests/h/schemas/forms/accounts/forgot_password_test.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+import colander
+import pytest
+
+from h.schemas.forms.accounts import ForgotPasswordSchema
+
+
+@pytest.mark.usefixtures('user_model')
+class TestForgotPasswordSchema(object):
+
+    def test_it_is_invalid_with_no_user(self,
+                                        pyramid_csrf_request,
+                                        user_model):
+        schema = ForgotPasswordSchema().bind(
+            request=pyramid_csrf_request)
+        user_model.get_by_email.return_value = None
+
+        with pytest.raises(colander.Invalid) as exc:
+            schema.deserialize({'email': 'rapha@example.com'})
+
+        assert 'email' in exc.value.asdict()
+        assert exc.value.asdict()['email'] == 'Unknown email address.'
+
+    def test_it_returns_user_when_valid(self,
+                                        pyramid_csrf_request,
+                                        user_model):
+        schema = ForgotPasswordSchema().bind(
+            request=pyramid_csrf_request)
+        user = user_model.get_by_email.return_value
+
+        appstruct = schema.deserialize({'email': 'rapha@example.com'})
+
+        assert appstruct['user'] == user
+
+
+@pytest.fixture
+def user_model(patch):
+    return patch('h.accounts.schemas.models.User')

--- a/tests/h/schemas/forms/accounts/login_test.py
+++ b/tests/h/schemas/forms/accounts/login_test.py
@@ -1,0 +1,138 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+import colander
+import pytest
+from mock import Mock
+from pyramid.exceptions import BadCSRFToken
+
+from h.schemas.forms.accounts import LoginSchema
+from h.services.user import UserNotActivated, UserService
+from h.services.user_password import UserPasswordService
+
+
+@pytest.mark.usefixtures('user_service', 'user_password_service')
+class TestLoginSchema(object):
+
+    def test_passes_username_to_user_service(self,
+                                             factories,
+                                             pyramid_csrf_request,
+                                             user_service):
+        user = factories.User.build(username='jeannie')
+        user_service.fetch_for_login.return_value = user
+        schema = LoginSchema().bind(request=pyramid_csrf_request)
+
+        schema.deserialize({
+            'username': 'jeannie',
+            'password': 'cake',
+        })
+
+        user_service.fetch_for_login.assert_called_once_with(username_or_email='jeannie')
+
+    def test_passes_password_to_user_password_service(self,
+                                                      factories,
+                                                      pyramid_csrf_request,
+                                                      user_service,
+                                                      user_password_service):
+        user = factories.User.build(username='jeannie')
+        user_service.fetch_for_login.return_value = user
+        schema = LoginSchema().bind(request=pyramid_csrf_request)
+
+        schema.deserialize({
+            'username': 'jeannie',
+            'password': 'cake',
+        })
+
+        user_password_service.check_password.assert_called_once_with(user, 'cake')
+
+    def test_it_returns_user_when_valid(self,
+                                        factories,
+                                        pyramid_csrf_request,
+                                        user_service):
+        user = factories.User.build(username='jeannie')
+        user_service.fetch_for_login.return_value = user
+        schema = LoginSchema().bind(request=pyramid_csrf_request)
+
+        result = schema.deserialize({
+            'username': 'jeannie',
+            'password': 'cake',
+        })
+
+        assert result['user'] is user
+
+    def test_invalid_with_bad_csrf(self, pyramid_request, user_service):
+        schema = LoginSchema().bind(request=pyramid_request)
+
+        with pytest.raises(BadCSRFToken):
+            schema.deserialize({
+                'username': 'jeannie',
+                'password': 'cake',
+            })
+
+    def test_invalid_with_inactive_user(self,
+                                        pyramid_csrf_request,
+                                        user_service):
+        schema = LoginSchema().bind(request=pyramid_csrf_request)
+        user_service.fetch_for_login.side_effect = UserNotActivated()
+
+        with pytest.raises(colander.Invalid) as exc:
+            schema.deserialize({
+                'username': 'jeannie',
+                'password': 'cake',
+            })
+        errors = exc.value.asdict()
+
+        assert 'username' in errors
+        assert 'activate your account' in errors['username']
+
+    def test_invalid_with_unknown_user(self,
+                                       pyramid_csrf_request,
+                                       user_service):
+        schema = LoginSchema().bind(request=pyramid_csrf_request)
+        user_service.fetch_for_login.return_value = None
+
+        with pytest.raises(colander.Invalid) as exc:
+            schema.deserialize({
+                'username': 'jeannie',
+                'password': 'cake',
+            })
+        errors = exc.value.asdict()
+
+        assert 'username' in errors
+        assert 'does not exist' in errors['username']
+
+    def test_invalid_with_bad_password(self,
+                                       factories,
+                                       pyramid_csrf_request,
+                                       user_service,
+                                       user_password_service):
+        user = factories.User.build(username='jeannie')
+        user_service.fetch_for_login.return_value = user
+        user_password_service.check_password.return_value = False
+        schema = LoginSchema().bind(request=pyramid_csrf_request)
+
+        with pytest.raises(colander.Invalid) as exc:
+            schema.deserialize({
+                'username': 'jeannie',
+                'password': 'cake',
+            })
+        errors = exc.value.asdict()
+
+        assert 'password' in errors
+        assert 'Wrong password' in errors['password']
+
+
+@pytest.fixture
+def user_service(db_session, pyramid_config):
+    service = Mock(spec_set=UserService(default_authority='example.com',
+                                        session=db_session))
+    service.fetch_for_login.return_value = None
+    pyramid_config.register_service(service, name='user')
+    return service
+
+
+@pytest.fixture
+def user_password_service(pyramid_config):
+    service = Mock(spec_set=UserPasswordService())
+    service.check_password.return_value = True
+    pyramid_config.register_service(service, name='user_password')
+    return service

--- a/tests/h/schemas/forms/accounts/reset_password_test.py
+++ b/tests/h/schemas/forms/accounts/reset_password_test.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+import colander
+import pytest
+from itsdangerous import BadData, SignatureExpired
+
+from h.schemas.forms.accounts import ResetPasswordSchema
+
+
+@pytest.mark.usefixtures('user_model')
+class TestResetPasswordSchema(object):
+
+    def test_it_is_invalid_with_password_too_short(self, pyramid_csrf_request):
+        schema = ResetPasswordSchema().bind(
+            request=pyramid_csrf_request)
+
+        with pytest.raises(colander.Invalid) as exc:
+            schema.deserialize({"password": "a"})
+        assert "password" in exc.value.asdict()
+
+    def test_it_is_invalid_with_invalid_user_token(self, pyramid_csrf_request):
+        pyramid_csrf_request.registry.password_reset_serializer = (
+            self.FakeInvalidSerializer())
+        schema = ResetPasswordSchema().bind(
+            request=pyramid_csrf_request)
+
+        with pytest.raises(colander.Invalid) as exc:
+            schema.deserialize({
+                'user': 'abc123',
+                'password': 'secret',
+            })
+
+        assert 'user' in exc.value.asdict()
+        assert 'Wrong reset code.' in exc.value.asdict()['user']
+
+    def test_it_is_invalid_with_expired_token(self, pyramid_csrf_request):
+        pyramid_csrf_request.registry.password_reset_serializer = (
+            self.FakeExpiredSerializer())
+        schema = ResetPasswordSchema().bind(
+            request=pyramid_csrf_request)
+
+        with pytest.raises(colander.Invalid) as exc:
+            schema.deserialize({
+                'user': 'abc123',
+                'password': 'secret',
+            })
+
+        assert 'user' in exc.value.asdict()
+        assert 'Reset code has expired.' in exc.value.asdict()['user']
+
+    def test_it_is_invalid_if_user_has_already_reset_their_password(
+            self, pyramid_csrf_request, user_model):
+        pyramid_csrf_request.registry.password_reset_serializer = (
+            self.FakeSerializer())
+        schema = ResetPasswordSchema().bind(
+            request=pyramid_csrf_request)
+        user = user_model.get_by_username.return_value
+        user.password_updated = 2
+
+        with pytest.raises(colander.Invalid) as exc:
+            schema.deserialize({
+                'user': 'abc123',
+                'password': 'secret',
+            })
+
+        assert 'user' in exc.value.asdict()
+        assert 'This reset code has already been used.' in exc.value.asdict()['user']
+
+    def test_it_returns_user_when_valid(self,
+                                        pyramid_csrf_request,
+                                        user_model):
+        pyramid_csrf_request.registry.password_reset_serializer = (
+            self.FakeSerializer())
+        schema = ResetPasswordSchema().bind(
+            request=pyramid_csrf_request)
+        user = user_model.get_by_username.return_value
+        user.password_updated = 0
+
+        appstruct = schema.deserialize({
+            'user': 'abc123',
+            'password': 'secret',
+        })
+
+        assert appstruct['user'] == user
+
+    class FakeSerializer(object):
+        def dumps(self, obj):
+            return 'faketoken'
+
+        def loads(self, token, max_age=0, return_timestamp=False):
+            payload = {'username': 'foo@bar.com'}
+            if return_timestamp:
+                return payload, 1
+            return payload
+
+    class FakeExpiredSerializer(FakeSerializer):
+        def loads(self, token, max_age=0, return_timestamp=False):
+            raise SignatureExpired("Token has expired")
+
+    class FakeInvalidSerializer(FakeSerializer):
+        def loads(self, token, max_age=0, return_timestamp=False):
+            raise BadData("Invalid token")
+
+
+@pytest.fixture
+def user_model(patch):
+    return patch('h.accounts.schemas.models.User')


### PR DESCRIPTION
This PR is a do-over of https://github.com/hypothesis/h/pull/5255, which was merged and deployed but broke an untested password reset view. I [reverted it](https://github.com/hypothesis/h/pull/5267) and here is a second attempt that fixes the untested views and the one affected schema reference.

See especially https://github.com/hypothesis/h/commit/170de48a203824878c9840817a9f67291fce476b, which is the commit that "fixes the glitch".

It's my hope that as we _continue_ refactoring things into smaller modules, we won't miss stuff like this (i.e. if `h.views.accounts` were a more constrained module, we might not have overlooked that there were two views that had no tests).