### PR TITLE
Add missing CORS headers to API error responses

### DIFF
--- a/h/views/api/config.py
+++ b/h/views/api/config.py
@@ -4,6 +4,17 @@ import venusian
 from h.util import cors
 
 
+#: Decorator that adds CORS headers to API responses.
+#:
+#: This decorator enables web applications not running on the same domain as h
+#: to make API requests and read the responses.
+#:
+#: For standard API views the decorator is automatically applied by the
+#: ``api_config`` decorator.
+#:
+#: Exception views need to independently apply this policy because any response
+#: headers set during standard request processing are discarded if an exception
+#: occurs and an exception view is invoked to generate the response instead.
 cors_policy = cors.policy(
     allow_headers=(
         'Authorization',

--- a/h/views/api/exceptions.py
+++ b/h/views/api/exceptions.py
@@ -16,11 +16,12 @@ from h.i18n import TranslationString as _  # noqa: N813
 from h.exceptions import APIError
 from h.schemas import ValidationError
 from h.util.view import handle_exception, json_view
+from h.views.api.config import cors_policy
 
 
 # Within the API, render a JSON 403/404 message.
-@forbidden_view_config(path_info='/api/', renderer='json')
-@notfound_view_config(path_info='/api/', renderer='json')
+@forbidden_view_config(path_info='/api/', renderer='json', decorator=cors_policy)
+@notfound_view_config(path_info='/api/', renderer='json', decorator=cors_policy)
 def api_notfound(request):
     """Handle a request for an unknown/forbidden resource within the API."""
     request.response.status_code = 404
@@ -29,14 +30,14 @@ def api_notfound(request):
     return {'status': 'failure', 'reason': message}
 
 
-@json_view(context=APIError)
+@json_view(context=APIError, decorator=cors_policy)
 def api_error(context, request):
     """Handle an expected/deliberately thrown API exception."""
     request.response.status_code = context.status_code
     return {'status': 'failure', 'reason': str(context)}
 
 
-@json_view(context=ValidationError, path_info='/api/')
+@json_view(context=ValidationError, path_info='/api/', decorator=cors_policy)
 def api_validation_error(context, request):
     request.response.status_code = 400
     return {'status': 'failure', 'reason': str(context)}

--- a/h/views/api/exceptions.py
+++ b/h/views/api/exceptions.py
@@ -18,6 +18,10 @@ from h.schemas import ValidationError
 from h.util.view import handle_exception, json_view
 from h.views.api.config import cors_policy
 
+# All exception views below need to apply the `cors_policy` decorator for the
+# responses to be readable by web applications other than those on the same
+# origin as h itself.
+
 
 # Within the API, render a JSON 403/404 message.
 @forbidden_view_config(path_info='/api/', renderer='json', decorator=cors_policy)

--- a/h/views/api/exceptions.py
+++ b/h/views/api/exceptions.py
@@ -47,7 +47,7 @@ def api_validation_error(context, request):
     return {'status': 'failure', 'reason': str(context)}
 
 
-@json_view(context=Exception)
+@json_view(context=Exception, decorator=cors_policy)
 def json_error(request):
     """Handle an unexpected exception where the request asked for JSON."""
     handle_exception(request)

--- a/tests/functional/api/test_api.py
+++ b/tests/functional/api/test_api.py
@@ -45,3 +45,19 @@ class TestCorsPreflight(object):
         assert 'POST' in res.headers['Access-Control-Allow-Methods']
         for header in ['Authorization', 'Content-Type', 'X-Client-Id']:
             assert header in res.headers['Access-Control-Allow-Headers']
+
+
+class TestCorsHeaders(object):
+    @pytest.mark.parametrize('url, expect_errors', [
+        # A request that succeeds.
+        ('/api/search', False),
+
+        # A request that triggers a validation error.
+        ('/api/search?sort=raise_an_error', True),
+
+        # A request that fails due to a missing resource.
+        ('/api/annotations/does_not_exist', True),
+    ])
+    def test_responses_have_cors_headers(self, app, url, expect_errors):
+        res = app.get(url, expect_errors=expect_errors)
+        assert res.headers.get('Access-Control-Allow-Origin', None) == '*'


### PR DESCRIPTION
Fixes https://github.com/hypothesis/h/issues/5264 by adding applying the same CORS headers to API error responses that we apply to standard API views. See first commit for a detailed explanation.

The upshot is that failing API requests will result in much less confusing messages for developers in browser dev tools.