### PR TITLE
WIP: Re-introduce `request.authority` as per-request authority

### DIFF
--- a/h/auth/__init__.py
+++ b/h/auth/__init__.py
@@ -12,7 +12,7 @@ from h.auth.policy import AuthenticationPolicy
 from h.auth.policy import APIAuthenticationPolicy
 from h.auth.policy import AuthClientPolicy
 from h.auth.policy import TokenAuthenticationPolicy
-from h.auth.util import default_authority, groupfinder
+from h.auth.util import authority, default_authority, groupfinder
 from h.security import derive_key
 
 __all__ = (
@@ -66,8 +66,11 @@ def includeme(config):
     # that include this one.
     config.set_authentication_policy(DEFAULT_POLICY)
 
-    # Allow retrieval of the authority from the request object.
+    # Allow retrieval of the default authority from the request object
     config.add_request_method(default_authority, name='default_authority', reify=True)
+
+    # All retrieval of the active authority from the request object
+    config.add_request_method(authority, name='authority', reify=True)
 
     # Allow retrieval of the auth token (if present) from the request object.
     config.add_request_method('.tokens.auth_token', reify=True)

--- a/h/auth/util.py
+++ b/h/auth/util.py
@@ -138,6 +138,22 @@ def client_authority(request):
     return None
 
 
+def authority(request):
+    """
+    Return active authority for the current request.
+
+    Return the client_authority, if there is one, or the default authority
+
+    :rtype: str
+    """
+
+    active_authority = client_authority(request)
+    if active_authority is not None:
+        return active_authority
+
+    return default_authority(request)
+
+
 def verify_auth_client(client_id, client_secret, db_session):
     """
     Return matching AuthClient or None

--- a/h/auth/util.py
+++ b/h/auth/util.py
@@ -2,6 +2,7 @@
 
 from __future__ import unicode_literals
 import base64
+import re
 
 import hmac
 
@@ -115,6 +116,26 @@ def default_authority(request):
     Falls back on returning request.domain if h.authority isn't set.
     """
     return text_type(request.registry.settings.get('h.authority', request.domain))
+
+
+def client_authority(request):
+    """
+    Return the authority associated with an authenticated auth_client or None
+
+    Once a request with an auth_client is authenticated, a principal is set
+    indicating the auth_client's verified authority
+
+    see :func:`~h.auth.util.principals_for_auth_client` for more details on
+    principals applied when auth_clients are authenticated
+
+    :rtype: str or None
+    """
+    for principal in request.effective_principals:
+        match = re.match(r"^authority:(.+)$", principal)
+        if match and match.group(1):
+            return match.group(1)
+
+    return None
 
 
 def verify_auth_client(client_id, client_secret, db_session):

--- a/tests/h/auth/util_test.py
+++ b/tests/h/auth/util_test.py
@@ -171,6 +171,35 @@ def test_translate_annotation_principals(p_in, p_out):
     assert set(result) == set(p_out)
 
 
+class TestClientAuthority(object):
+
+    @pytest.mark.parametrize('principals', [
+        ['foo', 'bar', 'baz'],
+        ['authority', 'foo'],
+        [],
+        ['authority:'],
+        [' authority:biz.biz', 'foo'],
+        ['authority :biz.biz', 'foo'],
+    ])
+    def test_it_returns_None_if_no_authority_principal_match(self, principals):
+        class FakePrincipalsRequest(object):
+            """With a real request, you cannot set the ``effective_principals`` property"""
+            effective_principals = principals
+
+        assert util.client_authority(FakePrincipalsRequest()) is None
+
+    @pytest.mark.parametrize('principals,authority', [
+        (['foo', 'bar', 'baz', 'authority:felicitous.com'], 'felicitous.com'),
+        (['authority:somebody.likes.me', 'foo'], 'somebody.likes.me'),
+    ])
+    def test_it_returns_authority_if_authority_principal_match(self, principals, authority):
+        class FakePrincipalsRequest(object):
+            """With a real request, you cannot set the ``effective_principals`` property"""
+            effective_principals = principals
+
+        assert util.client_authority(FakePrincipalsRequest()) == authority
+
+
 class TestAuthDomain(object):
     def test_it_returns_the_request_domain_if_authority_isnt_set(
             self, pyramid_request):

--- a/tests/h/auth/util_test.py
+++ b/tests/h/auth/util_test.py
@@ -200,6 +200,24 @@ class TestClientAuthority(object):
         assert util.client_authority(FakePrincipalsRequest()) == authority
 
 
+class TestAuthority(object):
+
+    def test_it_proxies_to_client_authority(self, pyramid_request, client_authority):
+        util.authority(pyramid_request)
+
+        client_authority.assert_called_once_with(pyramid_request)
+
+    def test_it_returns_client_authority_if_any_set(self, pyramid_request, client_authority):
+        client_authority.return_value = 'something.biz'
+
+        assert util.authority(pyramid_request) == 'something.biz'
+
+    def test_it_returns_default_authority_if_no_client_authority(self, pyramid_request, client_authority):
+        client_authority.return_value = None
+
+        assert util.authority(pyramid_request) == pyramid_request.default_authority
+
+
 class TestAuthDomain(object):
     def test_it_returns_the_request_domain_if_authority_isnt_set(
             self, pyramid_request):
@@ -441,6 +459,11 @@ def basic_auth_creds(patch):
 @pytest.fixture
 def valid_auth(basic_auth_creds, auth_client):
     basic_auth_creds.return_value = (auth_client.id, auth_client.secret)
+
+
+@pytest.fixture
+def client_authority(patch):
+    return patch('h.auth.util.client_authority')
 
 
 @pytest.fixture


### PR DESCRIPTION
A previously-merged PR (#5254 ) changed the naming of what was previously `request.authority` to `request.default_authority` to more clearly indicate what it really was (a static setting, not request-based at all).

This PR re-introduces `request.authority`, and it _can_ vary per request (though, at this time, only in certain API contexts—when there is a set `authority:*` principal from our recently-minted `AuthClientPolicy` auth policy).