### PR TITLE
Split json_error exception view into API and non-API request handlers

### DIFF
--- a/h/views/api/exceptions.py
+++ b/h/views/api/exceptions.py
@@ -47,14 +47,11 @@ def api_validation_error(context, request):
     return {'status': 'failure', 'reason': str(context)}
 
 
-@json_view(context=Exception, decorator=cors_policy)
+@json_view(context=Exception, path_info='/api/', decorator=cors_policy)
 def json_error(request):
-    """Handle an unexpected exception where the request asked for JSON."""
+    """Handle an unexpected exception in an API view."""
     handle_exception(request)
-    message = _("Uh-oh, something went wrong! We're very sorry, our "
-                "application wasn't able to load this page. The team has "
-                "been notified and we'll fix it shortly. If the problem "
-                "persists or you'd like more information please email "
-                "support@hypothes.is with the subject 'Internal Server "
-                "Error'.")
+    message = _("Hypothesis had a problem while handling this request. "
+                "Our team has been notified. Please contact support@hypothes.is"
+                " if the problem persists.")
     return {'status': 'failure', 'reason': message}

--- a/h/views/exceptions.py
+++ b/h/views/exceptions.py
@@ -13,7 +13,8 @@ from pyramid.view import forbidden_view_config
 from pyramid.view import notfound_view_config
 from pyramid.view import view_config
 
-from h.util.view import handle_exception
+from h.i18n import TranslationString as _  # noqa: N813
+from h.util.view import handle_exception, json_view
 
 
 @forbidden_view_config(renderer='h:templates/notfound.html.jinja2')
@@ -32,3 +33,13 @@ def error(request):
     """Handle a request for which the handler threw an exception."""
     handle_exception(request)
     return {}
+
+
+@json_view(context=Exception)
+def json_error(request):
+    """Handle an unexpected exception where the request asked for JSON."""
+    handle_exception(request)
+    message = _("Hypothesis had a problem while handling this request. "
+                "Our team has been notified. Please contact support@hypothes.is"
+                " if the problem persists.")
+    return {'status': 'failure', 'reason': message}

--- a/tests/h/views/exceptions_test.py
+++ b/tests/h/views/exceptions_test.py
@@ -2,7 +2,7 @@
 
 from __future__ import unicode_literals
 
-from h.views.exceptions import notfound, error
+from h.views.exceptions import notfound, error, json_error
 
 
 def test_notfound_view(pyramid_request):
@@ -19,3 +19,13 @@ def test_error_view(patch, pyramid_request):
 
     handle_exception.assert_called_once_with(pyramid_request)
     assert result == {}
+
+
+def test_json_error_view(patch, pyramid_request):
+    handle_exception = patch('h.views.exceptions.handle_exception')
+
+    result = json_error(pyramid_request)
+
+    handle_exception.assert_called_once_with(pyramid_request)
+    assert result['status'] == 'failure'
+    assert result['reason']


### PR DESCRIPTION
We have API and non-API views that return JSON. For consistency handle
unexpected exceptions (aka. Internal Server Errors) for API views in
a view defined in `h/views/api/exceptions.py` and for other views in a
view defined in `h/views/exceptions.py`.

Right now the only difference is that the API view adds CORS headers to
the response.

I have also changed the error message to make it shorter and thus be
easier to read if it gets displayed to the user directly, eg. as the
Hypothesis client will do in a toaster at the top of the sidebar.