### PR TITLE
Add utility method to determine current auth client authority

### DIFF
--- a/h/auth/util.py
+++ b/h/auth/util.py
@@ -2,6 +2,7 @@
 
 from __future__ import unicode_literals
 import base64
+import re
 
 import hmac
 
@@ -115,6 +116,26 @@ def default_authority(request):
     Falls back on returning request.domain if h.authority isn't set.
     """
     return text_type(request.registry.settings.get('h.authority', request.domain))
+
+
+def client_authority(request):
+    """
+    Return the authority associated with an authenticated auth_client or None
+
+    Once a request with an auth_client is authenticated, a principal is set
+    indicating the auth_client's verified authority
+
+    see :func:`~h.auth.util.principals_for_auth_client` for more details on
+    principals applied when auth_clients are authenticated
+
+    :rtype: str or None
+    """
+    for principal in request.effective_principals:
+        match = re.match(r"^authority:(.+)$", principal)
+        if match and match.group(1):
+            return match.group(1)
+
+    return None
 
 
 def verify_auth_client(client_id, client_secret, db_session):

--- a/tests/h/auth/util_test.py
+++ b/tests/h/auth/util_test.py
@@ -171,6 +171,41 @@ def test_translate_annotation_principals(p_in, p_out):
     assert set(result) == set(p_out)
 
 
+class TestClientAuthority(object):
+
+    @pytest.mark.parametrize(
+        "principals",
+        [
+            ["foo", "bar", "baz"],
+            ["authority", "foo"],
+            [],
+            ["authority:"],
+            [" authority:biz.biz", "foo"],
+            ["authority :biz.biz", "foo"],
+        ],
+    )
+    def test_it_returns_None_if_no_authority_principal_match(
+        self, principals, pyramid_request, pyramid_config
+    ):
+        pyramid_config.testing_securitypolicy("LYZADOODLE", groupids=principals)
+
+        assert util.client_authority(pyramid_request) is None
+
+    @pytest.mark.parametrize(
+        "principals,authority",
+        [
+            (["foo", "bar", "baz", "authority:felicitous.com"], "felicitous.com"),
+            (["authority:somebody.likes.me", "foo"], "somebody.likes.me"),
+        ],
+    )
+    def test_it_returns_authority_if_authority_principal_matchpyramid_requesi(
+        self, principals, authority, pyramid_request, pyramid_config
+    ):
+        pyramid_config.testing_securitypolicy("LYZADOODLE", groupids=principals)
+
+        assert util.client_authority(pyramid_request) == authority
+
+
 class TestAuthDomain(object):
     def test_it_returns_the_request_domain_if_authority_isnt_set(
             self, pyramid_request):


### PR DESCRIPTION
This supersedes https://github.com/hypothesis/h/pull/5272 for now.

This PR introduces a fairly basic auth utility function as a small step toward cleaning up our auth'n and auth'z for auth clients.

This differs from https://github.com/hypothesis/h/pull/5272 in that it just adds a utility function for now, and does not set `request.authority` until we've had more chance to be thoughtful about that (@robertknight raised some really good questions about its meaning).

I believe we will likely end up somewhere more elegant, but this will allow me to move forward for the time being and exorcise some crufty view-level code.