### PR TITLE
Add wildcard uri filter

### DIFF
--- a/h/activity/query.py
+++ b/h/activity/query.py
@@ -15,10 +15,11 @@ from h.activity import bucketing
 from h.models import Annotation, Group
 from h.search import Search
 from h.search import parser
-from h.search import TopLevelAnnotationsFilter
-from h.search import AuthorityFilter
-from h.search import TagsAggregation
-from h.search import UsersAggregation
+from h.search import (TopLevelAnnotationsFilter,
+                      AuthorityFilter,
+                      TagsAggregation,
+                      UsersAggregation,
+                      UriFilter)
 
 
 class ActivityResults(namedtuple('ActivityResults', [
@@ -167,6 +168,7 @@ def _execute_search(request, query, page_size):
     search = Search(request, stats=request.stats)
     search.append_modifier(AuthorityFilter(authority=request.default_authority))
     search.append_modifier(TopLevelAnnotationsFilter())
+    search.append_modifier(UriFilter(request=request))
     for agg in aggregations_for(query):
         search.append_aggregation(agg)
 

--- a/h/search/__init__.py
+++ b/h/search/__init__.py
@@ -4,10 +4,12 @@ from __future__ import unicode_literals
 from h.search.client import get_client
 from h.search.config import init
 from h.search.core import Search
-from h.search.query import TopLevelAnnotationsFilter
-from h.search.query import AuthorityFilter
-from h.search.query import TagsAggregation
-from h.search.query import UsersAggregation
+from h.search.query import (TopLevelAnnotationsFilter,
+                            AuthorityFilter,
+                            TagsAggregation,
+                            UsersAggregation,
+                            UriCombinedWildcardFilter,
+                            UriFilter)
 
 __all__ = (
     'Search',
@@ -15,6 +17,8 @@ __all__ = (
     'AuthorityFilter',
     'TagsAggregation',
     'UsersAggregation',
+    'UriCombinedWildcardFilter',
+    'UriFilter',
     'get_client',
     'init',
 )

--- a/h/search/core.py
+++ b/h/search/core.py
@@ -106,7 +106,7 @@ class Search(object):
         return response
 
     def _search_annotations(self, params):
-        # If seperate_replies is True, don't return any replies to annotations.
+        # If separate_replies is True, don't return any replies to annotations.
         modifiers = self._modifiers
         if self.separate_replies:
             modifiers = [query.TopLevelAnnotationsFilter()] + modifiers

--- a/h/search/core.py
+++ b/h/search/core.py
@@ -45,7 +45,6 @@ class Search(object):
                            query.Limiter(),
                            query.DeletedFilter(),
                            query.AuthFilter(request),
-                           query.UriFilter(request),
                            query.GroupFilter(),
                            query.GroupAuthFilter(request),
                            query.UserFilter(),

--- a/h/search/query.py
+++ b/h/search/query.py
@@ -288,7 +288,7 @@ class UriCombinedWildcardFilter(object):
         are performed on uri/url parameters.
     If separate_keys is False:
         uri/url parameters are expected to contain exact matches and wildcard matches.
-        Values containing wildcards are intrepted as wildcard searches.
+        Values containing wildcards are interpreted as wildcard searches.
 
     If specifying a uri with wildcards:
     * will match any character sequence (including an empty one), and a ? will match
@@ -299,7 +299,7 @@ class UriCombinedWildcardFilter(object):
         """Initialize a new UriFilter.
 
         :param request: the pyramid.request object
-        :param separate_keys: if True will treate wildcard_uri as wildcards and uri/url
+        :param separate_keys: if True will treat wildcard_uri as wildcards and uri/url
             as exact match. If False will treat any values in uri/url containing wildcards
             ("?" or "*") as wildcard searches.
 

--- a/h/search/query.py
+++ b/h/search/query.py
@@ -25,29 +25,21 @@ def wildcard_uri_is_valid(wildcard_uri):
     """
     if "*" not in wildcard_uri and "?" not in wildcard_uri:
         return False
-    # Accept all uri's without an authority (empty netloc).
-    normalized_uri = urlparse.urlparse(wildcard_uri)
-    if normalized_uri.scheme and not normalized_uri.netloc:
-        return True
-    # Let urlparse get what it thinks is the scheme+netloc from the wildcard_uri and then
-    # strip any remaining "*"s. "?"s will be stripped by urlparse. If this matches the
-    # start of the original uri and the scheme+netloc aren't empty then the uri is valid.
-    normalized_uri = urlparse.urlparse(wildcard_uri)
-    scheme = normalized_uri.scheme.replace("*", "")
-    netloc = normalized_uri.netloc.replace("?", "")
+    try:
+        normalized_uri = urlparse.urlparse(wildcard_uri)
 
-    # Both scheme and netloc must be specified.
-    if scheme == "" or netloc in ["", ""]:
-        return False
+        # Remove all parts of the url except the scheme, netloc, and provide a substitute
+        # path value "p" so that uri's that only have a scheme and path are still valid.
+        uri_parts = (normalized_uri.scheme, normalized_uri.netloc, "p", "", "", "")
 
-    domain = '{0}://{1}/'.format(scheme, netloc)
-    if wildcard_uri.startswith(domain):
-        # Make a final verification effort before returning.
-        try:
-            uri.normalize(wildcard_uri)
+        # Remove the "p" standing for path from the end of the uri.
+        begining_of_uri = urlparse.urlunparse(uri_parts)[:-1]
+
+        # If a wildcard was in the scheme the uri may come back as "" (a falsey value).
+        if begining_of_uri and wildcard_uri.startswith(begining_of_uri):
             return True
-        except Exception:
-            pass
+    except ValueError:
+        pass
     return False
 
 

--- a/h/search/query.py
+++ b/h/search/query.py
@@ -117,7 +117,7 @@ class Sorter(object):
             sort_by = "user_raw"
 
         # Since search_after depends on the field that the annotations are
-        # being sorted by, it is set here rather than in a seperate class.
+        # being sorted by, it is set here rather than in a separate class.
         search_after = params.pop("search_after", None)
         if search_after:
             if sort_by in ["updated", "created"]:

--- a/h/views/api/annotations.py
+++ b/h/views/api/annotations.py
@@ -22,6 +22,7 @@ from pyramid import security
 import newrelic.agent
 
 from h import search as search_lib
+from h.search import UriFilter
 from h import storage
 from h.exceptions import PayloadError
 from h.events import AnnotationEvent
@@ -108,9 +109,12 @@ def search(request):
     separate_replies = params.pop('_separate_replies', False)
 
     stats = getattr(request, 'stats', None)
-    result = search_lib.Search(request,
+
+    search = search_lib.Search(request,
                                separate_replies=separate_replies,
-                               stats=stats).run(params)
+                               stats=stats)
+    search.append_modifier(UriFilter(request))
+    result = search.run(params)
 
     svc = request.find_service(name='annotation_json_presentation')
 

--- a/h/views/badge.py
+++ b/h/views/badge.py
@@ -48,7 +48,9 @@ def badge(request):
         count = 0
     else:
         query = {'uri': uri, 'limit': 0}
-        result = search.Search(request, stats=request.stats).run(query)
+        s = search.Search(request, stats=request.stats)
+        s.append_modifier(search.UriFilter(request))
+        result = s.run(query)
         count = result.total
 
     return {'total': count}

--- a/h/views/feeds.py
+++ b/h/views/feeds.py
@@ -15,7 +15,9 @@ _ = i18n.TranslationStringFactory(__package__)
 
 def _annotations(request):
     """Return the annotations from the search API."""
-    result = search.Search(request, stats=request.stats).run(request.params)
+    s = search.Search(request, stats=request.stats)
+    s.append_modifier(search.UriFilter(request))
+    result = s.run(request.params)
     return fetch_ordered_annotations(request.db, result.annotation_ids)
 
 

--- a/tests/h/search/query_test.py
+++ b/tests/h/search/query_test.py
@@ -498,7 +498,7 @@ class TestUriFilter(object):
 
 class TestUriCombinedWildcardFilter():
 
-    @pytest.mark.parametrize('params,expected_ann_idxs,separate_keys', [
+    @pytest.mark.parametrize('params,expected_ann_indexes,separate_keys', [
 
     # Test with separate_keys = True (aka uri/url are exact match & wildcard_uri is wildcard match.)
     (webob.multidict.MultiDict([("wildcard_uri", "http://bar.com/baz?45")]),
@@ -531,7 +531,7 @@ class TestUriCombinedWildcardFilter():
         pyramid_request,
         Annotation,
         params,
-        expected_ann_idxs,
+        expected_ann_indexes,
         separate_keys,
     ):
         """
@@ -548,7 +548,7 @@ class TestUriCombinedWildcardFilter():
 
         result = search.run(params)
 
-        assert sorted(result.annotation_ids) == sorted([ann_ids[ann] for ann in expected_ann_idxs])
+        assert sorted(result.annotation_ids) == sorted([ann_ids[ann] for ann in expected_ann_indexes])
 
     @pytest.mark.parametrize('params,separate_keys', [
         (webob.multidict.MultiDict([("wildcard_uri", "http?://bar.com")]), True),

--- a/tests/h/search/query_test.py
+++ b/tests/h/search/query_test.py
@@ -496,6 +496,146 @@ class TestUriFilter(object):
         return patch('h.search.query.storage')
 
 
+class TestUriCombinedWildcardFilter():
+
+    @pytest.mark.parametrize('params,expected,separate_keys', [
+    # Test with separate_keys = True (aka uri/url are exact match & wildcard_uri is wildcard match.)
+    (webob.multidict.MultiDict([("wildcard_uri", "http://bar.com/*-*")]),
+     [3, 4, 5, 9],
+     True),
+    (webob.multidict.MultiDict([("wildcard_uri", "http://bar.com/baz?45")]),
+     [5, 6],
+     True),
+    (webob.multidict.MultiDict([("wildcard_uri", "file://localhost/*foo*bar.pdf")]),
+     [11, 12],
+     True),
+    (webob.multidict.MultiDict([("wildcard_uri", "urn:x-pdf:*")]),
+     [10],
+     True),
+    (webob.multidict.MultiDict([("wildcard_uri", "http://bar.com/*-*"), ("wildcard_uri", "http://baz.com/*-*")]),
+     [0, 3, 4, 5, 9],
+     True),
+    (webob.multidict.MultiDict([("wildcard_uri", "http://bar.com/baz?45"), ("uri", "http://bar.com/baz-45")]),
+     [5, 6],
+     True),
+    (webob.multidict.MultiDict([("uri", "https://www.foo.com"), ("wildcard_uri", "http://bar.com/baz*45")]),
+     [2, 5, 6, 7, 8],
+     True),
+    (webob.multidict.MultiDict([("uri", "https://www.foo.com"), ("url", "http://bar.com/foo")]),
+     [1, 2],
+     True),
+    # Test with separate_keys = False (aka uri/url contain both exact &  wildcard matches.)
+    (webob.multidict.MultiDict([("uri", "http://bar.com/*-*")]),
+     [3, 4, 5, 9],
+     False),
+    (webob.multidict.MultiDict([("uri", "http://bar.com/baz?45")]),
+     [5, 6],
+     False),
+    (webob.multidict.MultiDict([("uri", "file://localhost/*foo*bar.pdf")]),
+     [11, 12],
+     False),
+    (webob.multidict.MultiDict([("uri", "urn:x-pdf:*")]),
+     [10],
+     False),
+    (webob.multidict.MultiDict([("uri", "http://bar.com/*-*"), ("uri", "http://baz.com/*-*")]),
+     [0, 3, 4, 5, 9],
+     False),
+    (webob.multidict.MultiDict([("url", "http://bar.com/baz?45"), ("uri", "http://bar.com/baz-45")]),
+     [5, 6],
+     False),
+    (webob.multidict.MultiDict([("uri", "https://www.foo.com"), ("uri", "http://bar.com/baz*45")]),
+     [2, 5, 6, 7, 8],
+     False),
+    (webob.multidict.MultiDict([("uri", "https://www.foo.com"), ("url", "http://bar.com/foo")]),
+     [1, 2],
+     False),
+    ])
+    def test_matches(
+        self,
+        search,
+        pyramid_request,
+        Annotation,
+        params,
+        expected,
+        separate_keys,
+    ):
+        """
+        All uri matches (wildcard and exact) are OR'd.
+        """
+        search = self._get_search(search, pyramid_request, separate_keys)
+
+        ann_ids = [Annotation(target_uri="http://baz.com/foo-450").id,
+                        Annotation(target_uri="http://bar.com/foo").id,
+                        Annotation(target_uri="https://www.foo.com").id,
+                        Annotation(target_uri="https://bar.com/foo-43").id,
+                        Annotation(target_uri="http://bar.com/foo-457").id,
+                        Annotation(target_uri="http://bar.com/baz-45").id,
+                        Annotation(target_uri="http://bar.com/baz*45").id,
+                        Annotation(target_uri="http://bar.com/baz/*/45").id,
+                        Annotation(target_uri="https://bar.com/baz?=45").id,
+                        Annotation(target_uri="http://bar.com/baz-47").id,
+                        Annotation(target_uri="urn:x-pdf:a34480f5dbed8c4482a3a921e0196d2a").id,
+                        Annotation(target_uri="file://localhost/baz,%20foo%20bar.pdf").id,
+                        Annotation(target_uri="file://localhost/foobar.pdf").id]
+
+        result = search.run(params)
+
+        assert sorted(result.annotation_ids) == sorted([ann_ids[ann] for ann in expected])
+
+    @pytest.mark.parametrize('params,separate_keys', [
+        (webob.multidict.MultiDict([("wildcard_uri", "http?://bar.com")]), True),
+        (webob.multidict.MultiDict([("url", "urn:*")]), False),
+    ])
+    def test_ignores_urls_with_wildcards_in_the_domain(self, pyramid_request, params, separate_keys):
+        urifilter = query.UriCombinedWildcardFilter(pyramid_request, separate_keys)
+        search = elasticsearch_dsl.Search(
+            using="default", index=pyramid_request.es.index
+        )
+
+        q = urifilter(search, params).to_dict()
+
+        assert "should" not in q['query']['bool']
+
+    @pytest.mark.parametrize('params,separate_keys', [
+        (webob.multidict.MultiDict([("wildcard_uri", "http?://bar.com"),
+                                    ("uri", "http://bar.com"),
+                                    ("url", "http://baz.com")]), True),
+        (webob.multidict.MultiDict([("uri", "http?://bar.com"),
+                                    ("url", "http://baz.com")]), False),
+    ])
+    def test_pops_params(self, pyramid_request, params, separate_keys):
+        urifilter = query.UriCombinedWildcardFilter(pyramid_request, separate_keys)
+        search = elasticsearch_dsl.Search(
+            using="default", index=pyramid_request.es.index
+        )
+
+        urifilter(search, params).to_dict()
+
+        assert "uri" not in params
+        assert "url" not in params
+        assert "wildcard_uri" not in params
+
+    def _get_search(self, search, pyramid_request, separate_keys):
+        search.append_modifier(query.UriCombinedWildcardFilter(
+            pyramid_request, separate_keys))
+        return search
+
+
+@pytest.mark.parametrize('wildcard_uri,expected', [
+    ("http?://bar.com", False),
+    ("http://localhost:3000*", False),
+    ("http://bar*.com", False),
+    ("*?http://bar.com", False),
+    ("file://*", False),
+    ("urn:*", False),
+    ("urn:x-pdf:*", True),
+    ("file://localhost/*", True),
+    ("http://foo.com/*", True),
+])
+def test_identifies_wildcard_uri_is_valid(wildcard_uri, expected):
+    assert query.wildcard_uri_is_valid(wildcard_uri) == expected
+
+
 class TestDeletedFilter(object):
 
     def test_excludes_deleted_annotations(self, search, es_client, Annotation):

--- a/tests/h/search/query_test.py
+++ b/tests/h/search/query_test.py
@@ -498,7 +498,7 @@ class TestUriFilter(object):
 
 class TestUriCombinedWildcardFilter():
 
-    @pytest.mark.parametrize('params,expected,separate_keys', [
+    @pytest.mark.parametrize('params,expected_ann_idxs,separate_keys', [
 
     # Test with separate_keys = True (aka uri/url are exact match & wildcard_uri is wildcard match.)
     (webob.multidict.MultiDict([("wildcard_uri", "http://bar.com/baz?45")]),
@@ -531,7 +531,7 @@ class TestUriCombinedWildcardFilter():
         pyramid_request,
         Annotation,
         params,
-        expected,
+        expected_ann_idxs,
         separate_keys,
     ):
         """
@@ -548,11 +548,11 @@ class TestUriCombinedWildcardFilter():
 
         result = search.run(params)
 
-        assert sorted(result.annotation_ids) == sorted([ann_ids[ann] for ann in expected])
+        assert sorted(result.annotation_ids) == sorted([ann_ids[ann] for ann in expected_ann_idxs])
 
     @pytest.mark.parametrize('params,separate_keys', [
         (webob.multidict.MultiDict([("wildcard_uri", "http?://bar.com")]), True),
-        (webob.multidict.MultiDict([("url", "urn:*")]), False),
+        (webob.multidict.MultiDict([("url", "ur*n:x-pdf:*")]), False),
     ])
     def test_ignores_urls_with_wildcards_in_the_domain(self, pyramid_request, params, separate_keys):
         urifilter = query.UriCombinedWildcardFilter(pyramid_request, separate_keys)
@@ -598,10 +598,11 @@ class TestUriCombinedWildcardFilter():
     ("*?http://bar.com", False),
     ("file://*", False),
     ("https://foo.com", False),
-    ("urn:*", False),
     ("http://foo.com*", False),
+    ("urn:*", True),
     ("urn:x-pdf:*", True),
     ("http://foo.com/*", True),
+    ("doi:10.101?", True)
 ])
 def test_identifies_wildcard_uri_is_valid(wildcard_uri, expected):
     assert query.wildcard_uri_is_valid(wildcard_uri) == expected


### PR DESCRIPTION
Searching for a partial url is a common use case. It is particularly
useful for publishers who want to know who has been making annotations
on all their articles. It is also useful for users who simply can't
remember the entire url of an article they have annotated.
This is a partial fix for https://github.com/hypothesis/product-backlog/issues/30.

Add UriCombinedWildcardFilter has two configurations:
 1. seperate_keys=True
    Wildcards are only present in wildcard_uri param values and exact
    matches are present in uri/url param values.
 1. seperate_keys=False
    Wildcards and exact matches are present in uri/url param values.

UriCombinedWildcardFilter igores all wildcard uri's that have wildcards
in the domain.

Remove UriFilter from default modifier list in Search class since
the UriCombinedWildcardFilter will need to replace it in certain
cases and there is no way to selectively remove modifiers. The
current design pattern is if the modifier is used by all searches,
then it is in the default list, since it will not be, drop it from
the default list.

Add both UriFilter and UriCombinedWildcardFilter's to the search `__init__`
module as they will be appended to the Search class modifier list as needed.

Modify all existing code that runs Search to append the UriFilter to the list
of modifiers before running a search.