### PR TITLE
Add minimal functional tests for RSS feeds

### DIFF
--- a/tests/functional/test_feeds.py
+++ b/tests/functional/test_feeds.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import pytest
+
+
+@pytest.mark.functional
+def test_atom_feed(app):
+    app.get('/stream.atom')
+
+
+@pytest.mark.functional
+def test_rss_feed(app):
+    app.get('/stream.rss')


### PR DESCRIPTION
We inadvertently broke the RSS feeds in production. This was resolved in
https://github.com/hypothesis/h/pull/5262 but I think it would be useful to have a couple of minimal functional tests as extra security. All they check is that the views don't crash.

This was extracted from https://github.com/hypothesis/h/pull/5263