### PR TITLE
Change auth_client `authority` principal to `client_authority`

### DIFF
--- a/h/auth/util.py
+++ b/h/auth/util.py
@@ -131,7 +131,7 @@ def client_authority(request):
     :rtype: str or None
     """
     for principal in request.effective_principals:
-        match = re.match(r"^authority:(.+)$", principal)
+        match = re.match(r"^client_authority:(.+)$", principal)
         if match and match.group(1):
             return match.group(1)
 
@@ -184,7 +184,7 @@ def principals_for_auth_client(client):
     principals = set([])
 
     principals.add('client:{client_id}@{authority}'.format(client_id=client.id, authority=client.authority))
-    principals.add('authority:{authority}'.format(authority=client.authority))
+    principals.add('client_authority:{authority}'.format(authority=client.authority))
 
     return list(principals)
 

--- a/tests/h/auth/util_test.py
+++ b/tests/h/auth/util_test.py
@@ -179,12 +179,12 @@ class TestClientAuthority(object):
             ["foo", "bar", "baz"],
             ["authority", "foo"],
             [],
-            ["authority:"],
-            [" authority:biz.biz", "foo"],
-            ["authority :biz.biz", "foo"],
+            ["client_authority:"],
+            [" client_authority:biz.biz", "foo"],
+            ["client_authority :biz.biz", "foo"],
         ],
     )
-    def test_it_returns_None_if_no_authority_principal_match(
+    def test_it_returns_None_if_no_client_authority_principal_match(
         self, principals, pyramid_request, pyramid_config
     ):
         pyramid_config.testing_securitypolicy("LYZADOODLE", groupids=principals)
@@ -194,8 +194,8 @@ class TestClientAuthority(object):
     @pytest.mark.parametrize(
         "principals,authority",
         [
-            (["foo", "bar", "baz", "authority:felicitous.com"], "felicitous.com"),
-            (["authority:somebody.likes.me", "foo"], "somebody.likes.me"),
+            (["foo", "bar", "baz", "client_authority:felicitous.com"], "felicitous.com"),
+            (["client_authority:somebody.likes.me", "foo"], "somebody.likes.me"),
         ],
     )
     def test_it_returns_authority_if_authority_principal_matchpyramid_requesi(
@@ -246,10 +246,10 @@ class TestPrincipalsForAuthClient(object):
         assert "client:{client_id}@{authority}".format(client_id=auth_client.id,
                                                        authority=auth_client.authority) in principals
 
-    def test_it_sets_authority_principal(self, auth_client):
+    def test_it_sets_client_authority_principal(self, auth_client):
         principals = util.principals_for_auth_client(auth_client)
 
-        assert "authority:{authority}".format(authority=auth_client.authority) in principals
+        assert "client_authority:{authority}".format(authority=auth_client.authority) in principals
 
     def test_it_returns_principals_as_list(self, auth_client):
         principals = util.principals_for_auth_client(auth_client)


### PR DESCRIPTION
Long story short, I can't do the refactor I'd like on `h.traversal.GroupRoot` and `h.traversal.GroupContext` to get `__acl__` in the `Context` instead of in the model until after we untangle the activity/groups modules and views—it's just too hairy in there to adjust the way that groups work right now.

Until we can do the full cleanup that I greatly hope we will, I'd feel safer if authenticated `auth_client`s get a _distinctly-named_ principal for their associated authority. Until this PR, `auth_client`s get assigned an `authority` principal, which is sensible. OK, but _so do "normal" users_, so it's not immediately discernible from looking at that principal alone, out of context, whether the authenticated "user" is a user indeed or an `auth_client`. This matters because I can't move the ACL for groups out of the model, and inside of the model we don't have access to request (nor should we, egads) meaning that to handle assigning a particular permission to an auth client based on its authority, I need to be able to isolate a single principal that an authenticated user would _not_ have.

This has no functional implications at present as nothing is actually _using_ any of these principals yet, logically (except for the `client_authority` util function, which is also updated herein).
