### PR TITLE
Extend AuthPolicy, add Authorization to API add-group-member endpoint

### DIFF
--- a/h/auth/policy.py
+++ b/h/auth/policy.py
@@ -14,8 +14,8 @@ from h.auth import util
 
 # As we roll out the new API Auth Policy with Auth Token Policy, we
 # want to keep it restricted to certain endpoints
-# Currently restricted to `POST /api/groups` only
-AUTH_TOKEN_PATH_PATTERN = '^\/api\/groups(\/?)$'
+# Currently restricted to `POST /api/groups*` only
+AUTH_TOKEN_PATH_PATTERN = '^\/api\/groups'
 
 
 @interface.implementer(interfaces.IAuthenticationPolicy)

--- a/h/models/group.py
+++ b/h/models/group.py
@@ -121,6 +121,11 @@ class Group(Base, mixins.Timestamps):
     def __acl__(self):
         terms = []
 
+        # auth_clients that have the same authority as the target group
+        # may add members to it
+        member_add_principal = "client_authority:{}".format(self.authority)
+        terms.append((security.Allow, member_add_principal, 'member_add'))
+
         join_principal = _join_principal(self)
         if join_principal is not None:
             terms.append((security.Allow, join_principal, 'join'))

--- a/h/views/api/groups.py
+++ b/h/views/api/groups.py
@@ -5,7 +5,6 @@ from __future__ import unicode_literals
 from pyramid import security
 from pyramid.httpexceptions import HTTPNoContent, HTTPBadRequest, HTTPNotFound
 
-from h.auth.util import request_auth_client, validate_auth_client_authority
 from h.exceptions import PayloadError
 from h.presenters import GroupJSONPresenter, GroupsJSONPresenter
 from h.schemas.api.group import CreateGroupAPISchema
@@ -73,7 +72,6 @@ def create(request):
             effective_principals=security.Authenticated)
 def remove_member(group, request):
     """Remove a member from the given group."""
-
     # Currently, we only support removing the requesting user
     if request.matchdict.get('userid') == 'me':
         userid = request.authenticated_userid
@@ -89,6 +87,7 @@ def remove_member(group, request):
 @api_config(route_name='api.group_member',
             request_method='POST',
             link_name='group.member.add',
+            permission='member_add',
             description='Add the user in the request params to a group.')
 def add_member(group, request):
     """Add a member to a given group.
@@ -96,8 +95,6 @@ def add_member(group, request):
     :raises HTTPNotFound: if the user is not found or if the use and group
       authorities don't match.
     """
-    client = request_auth_client(request)
-
     user_svc = request.find_service(name='user')
     group_svc = request.find_service(name='group')
 
@@ -108,8 +105,6 @@ def add_member(group, request):
 
     if user is None:
         raise HTTPNotFound()
-
-    validate_auth_client_authority(client, user.authority)
 
     if user.authority != group.authority:
         raise HTTPNotFound()

--- a/tests/functional/api/test_groups.py
+++ b/tests/functional/api/test_groups.py
@@ -81,9 +81,11 @@ class TestAddMember(object):
 
         assert user in group.members
 
-    def test_it_ignores_forwarded_user_header(self, app, user, factories, group, auth_client_header):
+    def test_it_ignores_forwarded_user_header(self, app, user, factories, group, db_session, auth_client_header):
         headers = auth_client_header
         user2 = factories.User()
+        db_session.commit()
+
         headers[native_str('X-Forwarded-User')] = native_str(user2.userid)
 
         res = app.post_json("/api/groups/{pubid}/members/{userid}".format(pubid=group.pubid, userid=user.userid),
@@ -126,18 +128,18 @@ class TestAddMember(object):
 
         assert res.status_code == 404
 
-    def test_it_returns_403_if_missing_auth(self, app, user, group):
+    def test_it_returns_404_if_missing_auth(self, app, user, group):
         res = app.post_json("/api/groups/{pubid}/members/{userid}".format(pubid=group.pubid, userid=user.userid),
                             expect_errors=True)
 
-        assert res.status_code == 403
+        assert res.status_code == 404
 
-    def test_it_returns_403_with_token_auth(self, app, token_auth_header, user, group):
+    def test_it_returns_404_with_token_auth(self, app, token_auth_header, user, group):
         res = app.post_json("/api/groups/{pubid}/members/{userid}".format(pubid=group.pubid, userid=user.userid),
                             headers=token_auth_header,
                             expect_errors=True)
 
-        assert res.status_code == 403
+        assert res.status_code == 404
 
 
 @pytest.mark.functional

--- a/tests/h/auth/policy_test.py
+++ b/tests/h/auth/policy_test.py
@@ -34,11 +34,10 @@ NONAPI_PATHS = (
 AUTH_CLIENT_PATHS = (
     '/api/groups',
     '/api/groups/',
+    '/api/groups/foobar/members/something',
 )
 
 NON_AUTH_CLIENT_PATHS = (
-    '/api/groups//',
-    '/api/groups/33333',
     '/api/badge',
     '/api',
     '/groups/'

--- a/tests/h/models/groups_test.py
+++ b/tests/h/models/groups_test.py
@@ -129,6 +129,21 @@ def test_non_public_group():
 
 
 class TestGroupACL(object):
+    def test_auth_client_with_matching_authority_may_add_members(self, group, authz_policy):
+        group.authority = 'weewhack.com'
+
+        assert authz_policy.permits(group, ['flip', 'client_authority:weewhack.com'], 'member_add')
+
+    def test_auth_client_without_matching_authority_may_not_add_members(self, group, authz_policy):
+        group.authority = 'weewhack.com'
+
+        assert not authz_policy.permits(group, ['flip', 'client_authority:2weewhack.com'], 'member_add')
+
+    def test_user_with_authority_may_not_add_members(self, group, authz_policy):
+        group.authority = 'fabuloso.biz'
+
+        assert not authz_policy.permits(group, ['flip', 'authority:fabuloso.biz'], 'member_add')
+
     def test_authority_joinable(self, group, authz_policy):
         group.joinable_by = JoinableBy.authority
 

--- a/tests/h/views/api/groups_test.py
+++ b/tests/h/views/api/groups_test.py
@@ -7,9 +7,7 @@ import pytest
 
 from pyramid.httpexceptions import HTTPNoContent, HTTPBadRequest, HTTPNotFound
 
-from h.exceptions import ClientUnauthorized
 from h.views.api import groups as views
-from h.models.auth_client import GrantType
 from h.schemas import ValidationError
 from h.services.list_groups import ListGroupsService
 from h.services.group import GroupService
@@ -196,9 +194,7 @@ class TestCreateGroup(object):
 
 
 @pytest.mark.usefixtures('group_service',
-                         'user_service',
-                         'request_auth_client',
-                         'validate_auth_client_authority')
+                         'user_service')
 class TestAddMember(object):
 
     def test_it_adds_user_from_request_params_to_group(self,
@@ -258,52 +254,6 @@ class TestAddMember(object):
 
         user_service.fetch.assert_called_once_with(user.userid)
 
-    def test_it_gets_the_auth_client_from_the_request(self,
-                                                      group,
-                                                      pyramid_request,
-                                                      request_auth_client):
-        views.add_member(group, pyramid_request)
-
-        request_auth_client.assert_called_once_with(pyramid_request)
-
-    def test_it_validates_auth_client_and_user_authorities(self,
-                                                           group,
-                                                           user,
-                                                           pyramid_request,
-                                                           validate_auth_client_authority,
-                                                           auth_client):
-        views.add_member(group, pyramid_request)
-
-        validate_auth_client_authority.assert_called_once_with(auth_client, user.authority)
-
-    def test_it_raises_ClientUnauthorized_with_bad_client_credentials(self,
-                                                                      group,
-                                                                      pyramid_request,
-                                                                      request_auth_client):
-        request_auth_client.side_effect = ClientUnauthorized()
-
-        with pytest.raises(ClientUnauthorized):
-            views.add_member(group, pyramid_request)
-
-    def test_it_raises_ClientUnauthorized_with_bad_auth_client(self,
-                                                               group,
-                                                               pyramid_request,
-                                                               request_auth_client):
-        request_auth_client.side_effect = ClientUnauthorized()
-
-        with pytest.raises(ClientUnauthorized):
-            views.add_member(group, pyramid_request)
-
-    def test_it_raises_ValidationError_with_mismatched_authorities(self,
-                                                                   group,
-                                                                   pyramid_request,
-                                                                   validate_auth_client_authority):
-        msg = "'authority' does not match authenticated client"
-        validate_auth_client_authority.side_effect = ValidationError()
-
-        with pytest.raises(ValidationError, message=msg):
-            views.add_member(group, pyramid_request)
-
     @pytest.fixture
     def group(self, factories):
         return factories.Group(authority='example.com')
@@ -324,21 +274,6 @@ class TestAddMember(object):
         service.fetch.return_value = user
         pyramid_config.register_service(service, name='user')
         return service
-
-    @pytest.fixture
-    def auth_client(self, factories):
-        return factories.ConfidentialAuthClient(authority='example.com',
-                                                grant_type=GrantType.client_credentials)
-
-    @pytest.fixture
-    def request_auth_client(self, patch, auth_client):
-        request_auth_client = patch('h.views.api.groups.request_auth_client')
-        request_auth_client.return_value = auth_client
-        return request_auth_client
-
-    @pytest.fixture
-    def validate_auth_client_authority(self, patch):
-        return patch('h.views.api.groups.validate_auth_client_authority')
 
 
 @pytest.mark.usefixtures('authenticated_userid', 'group_service')


### PR DESCRIPTION
~~~Depends on https://github.com/hypothesis/h/pull/5278~~~

This PR removes the view-level authn/authz from the view handler for `POST /api/groups/{pubid}/members/{userid}` and instead protects the view with a permission assigned to authority-matching auth-clients in `h.models.Group`'s `__acl__`. I had hoped to be able to move group ACL into a Context/Resource and out of the model, but that's not feasible at this time.