### PR TITLE
Replace deprecated `log.warn` with `log.warning`

### DIFF
--- a/h/auth/__init__.py
+++ b/h/auth/__init__.py
@@ -52,11 +52,11 @@ def includeme(config):
     config.include('pyramid_authsanity')
 
     if config.registry.settings.get('h.proxy_auth'):
-        log.warn('Enabling proxy authentication mode: you MUST ensure that '
-                 'the X-Forwarded-User request header can ONLY be set by '
-                 'trusted downstream reverse proxies! Failure to heed this '
-                 'warning will result in ALL DATA stored by this service '
-                 'being available to ANYONE!')
+        log.warning('Enabling proxy authentication mode: you MUST ensure that '
+                    'the X-Forwarded-User request header can ONLY be set by '
+                    'trusted downstream reverse proxies! Failure to heed this '
+                    'warning will result in ALL DATA stored by this service '
+                    'being available to ANYONE!')
 
         DEFAULT_POLICY = AuthenticationPolicy(api_policy=API_POLICY,
                                               fallback_policy=PROXY_POLICY)

--- a/h/db/__init__.py
+++ b/h/db/__init__.py
@@ -112,7 +112,7 @@ def _session(request):
         changes = tracker.uncommitted_changes() if tracker else []
         if changes:
             msg = 'closing a session with uncommitted changes %s'
-            log.warn(msg, changes, extra={
+            log.warning(msg, changes, extra={
                 'stack': True,
                 'changes': changes,
             })

--- a/h/indexer/reindexer.py
+++ b/h/indexer/reindexer.py
@@ -44,7 +44,7 @@ def reindex(session, es, request):
                 len(errored)))
             errored = indexer.index(errored)
             if errored:
-                log.warn('failed to index {} annotations: {!r}'.format(
+                log.warning('failed to index {} annotations: {!r}'.format(
                     len(errored),
                     errored))
 

--- a/h/models/document.py
+++ b/h/models/document.py
@@ -305,9 +305,9 @@ def create_or_update_document_uri(session,
                              updated=updated)
         session.add(docuri)
     elif not docuri.document == document:
-        log.warn("Found DocumentURI (id: %d)'s document_id (%d) doesn't match "
-                 "given Document's id (%d)",
-                 docuri.id, docuri.document_id, document.id)
+        log.warning("Found DocumentURI (id: %d)'s document_id (%d) doesn't match "
+                    "given Document's id (%d)",
+                    docuri.id, docuri.document_id, document.id)
 
     docuri.updated = updated
 
@@ -381,9 +381,9 @@ def create_or_update_document_meta(session,
         existing_dm.value = value
         existing_dm.updated = updated
         if not existing_dm.document == document:
-            log.warn("Found DocumentMeta (id: %d)'s document_id (%d) doesn't "
-                     "match given Document's id (%d)",
-                     existing_dm.id, existing_dm.document_id, document.id)
+            log.warning("Found DocumentMeta (id: %d)'s document_id (%d) doesn't "
+                        "match given Document's id (%d)",
+                        existing_dm.id, existing_dm.document_id, document.id)
 
     if type == 'title' and value and not document.title:
         document.title = value[0]

--- a/h/notification/reply.py
+++ b/h/notification/reply.py
@@ -83,7 +83,7 @@ def get_notification(request, annotation, action):
     # this would be super weird, so log a warning.
     reply_user = user_service.fetch(reply.userid)
     if reply_user is None:
-        log.warn('user who just replied no longer exists: %s', reply.userid)
+        log.warning('user who just replied no longer exists: %s', reply.userid)
         return
 
     # Do not notify users about their own replies

--- a/h/search/core.py
+++ b/h/search/core.py
@@ -135,10 +135,10 @@ class Search(object):
         )
 
         if len(response['hits']['hits']) < response['hits']['total']:
-            log.warn("The number of reply annotations exceeded the page size "
-                     "of the Elasticsearch query. We currently don't handle "
-                     "this, our search API doesn't support pagination of the "
-                     "reply set.")
+            log.warning("The number of reply annotations exceeded the page size "
+                        "of the Elasticsearch query. We currently don't handle "
+                        "this, our search API doesn't support pagination of the "
+                        "reply set.")
 
         return [hit['_id'] for hit in response['hits']['hits']]
 

--- a/h/settings.py
+++ b/h/settings.py
@@ -78,9 +78,9 @@ class SettingsManager(object):
         cast_message = None
         if envvar in self._environ:
             if deprecated_msg:
-                log.warn('use of envvar %s is deprecated: %s',
-                         envvar,
-                         deprecated_msg)
+                log.warning('use of envvar %s is deprecated: %s',
+                            envvar,
+                            deprecated_msg)
             val = self._environ[envvar]
             cast_message = "environment variable {}={!r}".format(envvar, val)
         elif default and name not in self.settings:

--- a/h/streamer/messages.py
+++ b/h/streamer/messages.py
@@ -43,8 +43,8 @@ def process_messages(settings, routing_key, work_queue, raise_error=True):
             message = Message(topic=routing_key, payload=payload)
             work_queue.put(message, timeout=0.1)
         except Full:
-            log.warn('Streamer work queue full! Unable to queue message from '
-                     'h.realtime having waited 0.1s: giving up.')
+            log.warning('Streamer work queue full! Unable to queue message from '
+                        'h.realtime having waited 0.1s: giving up.')
 
     conn = realtime.get_connection(settings)
     sentry_client = h.sentry.get_client(settings)
@@ -89,7 +89,7 @@ def handle_annotation_event(message, sockets, settings, session):
     annotation = storage.fetch_annotation(session, id_)
 
     if annotation is None:
-        log.warn('received annotation event for missing annotation: %s', id_)
+        log.warning('received annotation event for missing annotation: %s', id_)
         return
 
     nipsa_service = NipsaService(session)

--- a/h/streamer/websocket.py
+++ b/h/streamer/websocket.py
@@ -80,8 +80,8 @@ class WebSocket(_WebSocket):
             self._work_queue.put(Message(socket=self, payload=payload),
                                  timeout=0.1)
         except Full:
-            log.warn('Streamer work queue full! Unable to queue message from '
-                     'WebSocket client having waited 0.1s: giving up.')
+            log.warning('Streamer work queue full! Unable to queue message from '
+                        'WebSocket client having waited 0.1s: giving up.')
 
     def closed(self, code, reason=None):
         try:

--- a/tests/h/models/document_test.py
+++ b/tests/h/models/document_test.py
@@ -408,7 +408,7 @@ class TestCreateOrUpdateDocumentURI(object):
             created=now(),
             updated=now())
 
-        assert log.warn.call_count == 1
+        assert log.warning.call_count == 1
 
     def test_raises_retryable_error_when_flush_fails(self, db_session, monkeypatch):
         document_ = document.Document()
@@ -598,7 +598,7 @@ class TestCreateOrUpdateDocumentMeta(object):
             updated=now(),
         )
 
-        assert log.warn.call_count == 1
+        assert log.warning.call_count == 1
 
     def test_raises_retryable_error_when_flush_fails(self, db_session, monkeypatch):
         document_ = document.Document()


### PR DESCRIPTION
See deprecation notice in https://docs.python.org/3/library/logging.html#logging.Logger.warning