### PR TITLE
Add `AuthClient` role-principal and assign it to authClient requests

### DIFF
--- a/h/auth/role.py
+++ b/h/auth/role.py
@@ -6,3 +6,6 @@ Admin = 'group:__admin__'
 
 #: Hypothesis staff. These users have limited access to admin functionality.
 Staff = 'group:__staff__'
+
+#: A request with client-credentials authentication
+AuthClient = 'group:__authclient__'

--- a/h/auth/util.py
+++ b/h/auth/util.py
@@ -185,6 +185,7 @@ def principals_for_auth_client(client):
 
     principals.add('client:{client_id}@{authority}'.format(client_id=client.id, authority=client.authority))
     principals.add('client_authority:{authority}'.format(authority=client.authority))
+    principals.add(role.AuthClient)
 
     return list(principals)
 

--- a/tests/h/auth/util_test.py
+++ b/tests/h/auth/util_test.py
@@ -251,6 +251,11 @@ class TestPrincipalsForAuthClient(object):
 
         assert "client_authority:{authority}".format(authority=auth_client.authority) in principals
 
+    def test_it_sets_authclient_role(self, auth_client):
+        principals = util.principals_for_auth_client(auth_client)
+
+        assert role.AuthClient in principals
+
     def test_it_returns_principals_as_list(self, auth_client):
         principals = util.principals_for_auth_client(auth_client)
 
@@ -281,6 +286,7 @@ class TestPrincipalsForAuthClientUser(object):
         assert 'client:{client_id}@{authority}'.format(client_id=auth_client.id,
                                                        authority=auth_client.authority) in principals
         assert 'authority:{authority}'.format(authority=auth_client.authority)
+        assert role.AuthClient in principals
 
 
 class TestVerifyAuthClient(object):


### PR DESCRIPTION
This PR adds a new "role" (principal) for auth clients and assigns its associated principal to requests authenticated in that manner.

This will allow the ability to assign a permission to "any validated auth client" for API endpoint view handlers (we'll need it for the create-group endpoint).