### PR TITLE
Add wildcard_uri parameter to /api/search

### DIFF
--- a/docs/_extra/api-reference/hypothesis.yaml
+++ b/docs/_extra/api-reference/hypothesis.yaml
@@ -361,6 +361,8 @@ paths:
             Examples of valid uris: `http://foo.com/*` `urn:x-pdf:*` `file://localhost/?bc.pdf`
 
             Examples of invalid uris: `*foo.com` `u?n:*` `file://*` `http://foo.com*`
+            
+            <mark>This feature is experimental and the API may change.</mark>
           required: false
           type: string
         - name: user

--- a/docs/_extra/api-reference/hypothesis.yaml
+++ b/docs/_extra/api-reference/hypothesis.yaml
@@ -353,13 +353,14 @@ paths:
             PDF fingerprint.
 
             `*` will match any character sequence (including an empty one), 
-            and a `?` will match any single character. `*`'s and `?`'s are not
-            permitted within the domain of the URI.
+            and a `?` will match any single character. Wildcards are only permitted 
+            within the path and query parts of the URI.
 
             Escaping wildcards is not supported.
 
-            Examples of valid uris; `http://foo.com/*` `urn:x-pdf:*` `file://localhost/?bc.pdf`
-            Examples of invalid uris; `*foo.com`  `http://?bc.com`  `urn:*`  `file://*`
+            Examples of valid uris: `http://foo.com/*` `urn:x-pdf:*` `file://localhost/?bc.pdf`
+
+            Examples of invalid uris: `*foo.com` `u?n:*` `file://*` `http://foo.com*`
           required: false
           type: string
         - name: user

--- a/docs/_extra/api-reference/hypothesis.yaml
+++ b/docs/_extra/api-reference/hypothesis.yaml
@@ -344,6 +344,24 @@ paths:
             Alias of `uri`.
           required: false
           type: string
+        - name: wildcard_uri
+          in: query
+          description: |
+            Limit the results to annotations matching the wildcard URI. 
+            URI can be a URL (a web page address) or a URN representing another 
+            kind of resource such as DOI (Digital Object Identifier) or a 
+            PDF fingerprint.
+
+            `*` will match any character sequence (including an empty one), 
+            and a `?` will match any single character. `*`'s and `?`'s are not
+            permitted within the domain of the URI.
+
+            Escaping wildcards is not supported.
+
+            Examples of valid uris; `http://foo.com/*` `urn:x-pdf:*` `file://localhost/?bc.pdf`
+            Examples of invalid uris; `*foo.com`  `http://?bc.com`  `urn:*`  `file://*`
+          required: false
+          type: string
         - name: user
           in: query
           description: Limit the results to annotations made by the specified user.

--- a/h/schemas/annotation.py
+++ b/h/schemas/annotation.py
@@ -8,10 +8,20 @@ from dateutil.parser import parse
 from pyramid import i18n
 
 from h.schemas.base import JSONSchema, ValidationError
-from h.search.query import LIMIT_DEFAULT, LIMIT_MAX, OFFSET_MAX
+from h.search.query import LIMIT_DEFAULT, LIMIT_MAX, OFFSET_MAX, wildcard_uri_is_valid
 from h.util import document_claims
 
 _ = i18n.TranslationStringFactory(__package__)
+
+
+def _validate_wildcard_uri(node, value):
+    """Raise if wildcards are within the domain of the uri."""
+    for val in value:
+        if not wildcard_uri_is_valid(val):
+            raise colander.Invalid(
+                node,
+                """Wildcards (? and *) are not permitted within the
+                domain of wildcard_uri""")
 
 
 class AnnotationSchema(JSONSchema):
@@ -416,6 +426,27 @@ class SearchParamsSchema(colander.Schema):
         colander.SchemaNode(colander.String()),
         missing=colander.drop,
         description="Alias of uri.",
+    )
+    wildcard_uri = colander.SchemaNode(
+        colander.Sequence(),
+        colander.SchemaNode(colander.String()),
+        validator=_validate_wildcard_uri,
+        missing=colander.drop,
+        description="""
+            Limit the results to annotations matching the wildcard URI.
+            URI can be a URL (a web page address) or a URN representing another
+            kind of resource such as DOI (Digital Object Identifier) or a
+            PDF fingerprint.
+
+            `*` will match any character sequence (including an empty one),
+            and a `?` will match any single character. `*`'s and `?`'s are not
+            permitted within the domain of the URI.
+
+            Escaping wildcards is not supported.
+
+            Examples of valid uris; `http://foo.com/*` `urn:x-pdf:*` `file://localhost/?bc.pdf`
+            Examples of invalid uris; `*foo.com`  `http://?bc.com`  `urn:*`  `file://*`
+            """,
     )
     any = colander.SchemaNode(
         colander.Sequence(),

--- a/h/schemas/annotation.py
+++ b/h/schemas/annotation.py
@@ -439,13 +439,13 @@ class SearchParamsSchema(colander.Schema):
             PDF fingerprint.
 
             `*` will match any character sequence (including an empty one),
-            and a `?` will match any single character. `*`'s and `?`'s are not
-            permitted within the domain of the URI.
+            and a `?` will match any single character. Wildcards are only permitted
+            within the path and query parts of the URI.
 
             Escaping wildcards is not supported.
 
-            Examples of valid uris; `http://foo.com/*` `urn:x-pdf:*` `file://localhost/?bc.pdf`
-            Examples of invalid uris; `*foo.com`  `http://?bc.com`  `urn:*`  `file://*`
+            Examples of valid uris":" `http://foo.com/*` `urn:x-pdf:*` `file://localhost/?bc.pdf`
+            Examples of invalid uris":" `*foo.com` `u?n:*` `file://*` `http://foo.com*`
             """,
     )
     any = colander.SchemaNode(

--- a/h/search/query.py
+++ b/h/search/query.py
@@ -26,7 +26,7 @@ def wildcard_uri_is_valid(wildcard_uri):
     if "*" not in wildcard_uri and "?" not in wildcard_uri:
         return False
     try:
-        normalized_uri = urlparse.urlparse(wildcard_uri)
+        normalized_uri = urlparse.urlparse(wildcard_uri.replace("*", "").replace("?", ""))
 
         # Remove all parts of the url except the scheme, netloc, and provide a substitute
         # path value "p" so that uri's that only have a scheme and path are still valid.

--- a/h/views/api/annotations.py
+++ b/h/views/api/annotations.py
@@ -22,7 +22,7 @@ from pyramid import security
 import newrelic.agent
 
 from h import search as search_lib
-from h.search import UriFilter
+from h.search import UriCombinedWildcardFilter
 from h import storage
 from h.exceptions import PayloadError
 from h.events import AnnotationEvent
@@ -113,7 +113,7 @@ def search(request):
     search = search_lib.Search(request,
                                separate_replies=separate_replies,
                                stats=stats)
-    search.append_modifier(UriFilter(request))
+    search.append_modifier(UriCombinedWildcardFilter(request, separate_keys=True))
     result = search.run(params)
 
     svc = request.find_service(name='annotation_json_presentation')

--- a/tests/h/schemas/annotation_test.py
+++ b/tests/h/schemas/annotation_test.py
@@ -628,6 +628,7 @@ class TestSearchParamsSchema(object):
             'text': "text me",
             'uri': "foobar.com",
             'uri.parts': "bbc",
+            'wildcard_uri': "http://foo.com/*",
             'url': "https://foobar.com",
             'any': "foo",
             'user': "pooky",
@@ -647,6 +648,7 @@ class TestSearchParamsSchema(object):
             'text': "text me",
             'uri': "foobar.com",
             'uri.parts': "bbc",
+            'wildcard_uri': "http://foo.com/*",
             'url': "https://foobar.com",
             'any': "foo",
             'user': "pooky",
@@ -757,6 +759,16 @@ class TestSearchParamsSchema(object):
 
         assert params["offset"] == 0
         assert params["search_after"] == "2009-02-16"
+
+    @pytest.mark.parametrize('wildcard_uri', (
+        "https://localhost:3000*",
+        "file://localhost*/foo.pdf",
+    ))
+    def test_raises_if_wildcards_are_in_domain(self, schema, wildcard_uri):
+        input_params = NestedMultiDict(MultiDict({"wildcard_uri": wildcard_uri}))
+
+        with pytest.raises(ValidationError):
+            validate_query_params(schema, input_params)
 
     @pytest.fixture
     def schema(self):

--- a/tests/h/search/query_test.py
+++ b/tests/h/search/query_test.py
@@ -602,7 +602,9 @@ class TestUriCombinedWildcardFilter():
     ("urn:*", True),
     ("urn:x-pdf:*", True),
     ("http://foo.com/*", True),
-    ("doi:10.101?", True)
+    ("doi:10.101?", True),
+    ("http://*.org/*", False),
+    ("http://example.*", False),
 ])
 def test_identifies_wildcard_uri_is_valid(wildcard_uri, expected):
     assert query.wildcard_uri_is_valid(wildcard_uri) == expected


### PR DESCRIPTION
This will allow searching for uri's containing wildcards via the
wildcard_uri parameter.

Add the wildcard_uri parameter to the schema and raise a validation
error if the uri value is invalid (aka contains wildcards in the
domain of the uri).

Update the docs to reflect the additional wildcard_uri parameter.

This is a partial fix for https://github.com/hypothesis/product-backlog/issues/30.