### PR TITLE
Add create user permission and update `POST /api/users` authz

### DIFF
--- a/h/auth/policy.py
+++ b/h/auth/policy.py
@@ -2,8 +2,6 @@
 
 from __future__ import unicode_literals
 
-import re
-
 import pyramid.compat
 from pyramid import interfaces
 from pyramid.authentication import BasicAuthAuthenticationPolicy
@@ -13,10 +11,13 @@ from zope import interface
 
 from h.auth import util
 
-# As we roll out the new API Auth Policy with Auth Token Policy, we
-# want to keep it restricted to certain endpoints
-# Currently restricted to `POST /api/groups*` only
-AUTH_TOKEN_PATH_PATTERN = r"^/api/groups"
+#: List of route name-method combinations that should
+#: allow AuthClient authentication
+AUTH_CLIENT_API_WHITELIST = [
+    ('api.groups', 'POST'),
+    ('api.group_member', 'POST'),
+    ('api.users', 'POST'),
+]
 
 
 @interface.implementer(interfaces.IAuthenticationPolicy)
@@ -359,14 +360,17 @@ def _is_client_request(request):
     """
     Is client_auth authentication valid for the given request?
 
-    For initial rollout, authentication should be performed by
+    Uuthentication should be performed by
     :py:class:`~h.auth.policy.AuthClientPolicy` only for requests
-    to the `POST /api/groups` endpoint.
+    that match the whitelist.
 
-    This is intended to be temporary.
+    The whitelist will likely evolve.
+
+    :rtype: bool
     """
-    return (re.match(AUTH_TOKEN_PATH_PATTERN, request.path) and
-            request.method == 'POST')
+    if request.matched_route:
+        return (request.matched_route.name, request.method) in AUTH_CLIENT_API_WHITELIST
+    return False
 
 
 def _is_ws_request(request):

--- a/h/routes.py
+++ b/h/routes.py
@@ -115,7 +115,9 @@ def includeme(config):
                      factory='h.traversal.GroupRoot',
                      traverse='/{pubid}')
     config.add_route('api.search', '/api/search')
-    config.add_route('api.users', '/api/users')
+    config.add_route('api.users',
+                     '/api/users',
+                     factory='h.traversal.UserRoot')
     config.add_route('api.user', '/api/users/{username}')
     config.add_route('badge', '/api/badge')
     config.add_route('token', '/api/token')

--- a/h/traversal/roots.py
+++ b/h/traversal/roots.py
@@ -211,6 +211,10 @@ class UserRoot(object):
     FIXME: This class should return UserContext objects, not User objects.
 
     """
+    __acl__ = [
+        (Allow, role.AuthClient, 'create'),
+    ]
+
     def __init__(self, request):
         self.request = request
         self.user_svc = self.request.find_service(name='user')

--- a/tests/functional/api/test_users.py
+++ b/tests/functional/api/test_users.py
@@ -25,6 +25,13 @@ class TestCreateUser(object):
 
         assert res.status_code == 200
 
+    def test_it_returns_404_if_missing_auth_client(self, app, user_payload):
+        # FIXME: This should return a 403; our exception views squash it into a 404
+        res = app.post_json("/api/users", user_payload, expect_errors=True)
+
+        assert res.status_code == 404
+
+    @pytest.mark.xfail
     def test_it_returns_403_if_missing_auth_client(self, app, user_payload):
         res = app.post_json("/api/users", user_payload, expect_errors=True)
 

--- a/tests/functional/api/test_users.py
+++ b/tests/functional/api/test_users.py
@@ -44,6 +44,21 @@ class TestCreateUser(object):
 
         assert res.status_code == 400
 
+    def test_it_returns_400_if_authority_param_missing(self, app, user_payload, auth_client_header):
+        del user_payload["authority"]
+
+        res = app.post_json("/api/users", user_payload, headers=auth_client_header, expect_errors=True)
+
+        assert res.status_code == 400
+
+    def test_it_returns_400_if_authority_mismatch(self, app, user_payload, auth_client_header):
+        user_payload["authority"] = "mismatch.com"
+
+        res = app.post_json("/api/users", user_payload, headers=auth_client_header, expect_errors=True)
+
+        assert res.status_code == 400
+        assert res.json_body['reason'] == "authority 'mismatch.com' does not match client authority"
+
     def test_it_returns_409_if_user_conflict(self, app, user_payload, auth_client_header, user):
         # user fixture creates user with conflicting username/authority combo
         res = app.post_json("/api/users", user_payload, headers=auth_client_header, expect_errors=True)

--- a/tests/h/routes_test.py
+++ b/tests/h/routes_test.py
@@ -95,7 +95,7 @@ def test_includeme():
         call('api.debug_token', '/api/debug-token'),
         call('api.group_member', '/api/groups/{pubid}/members/{userid}', factory='h.traversal.GroupRoot', traverse='/{pubid}'),
         call('api.search', '/api/search'),
-        call('api.users', '/api/users'),
+        call('api.users', '/api/users', factory='h.traversal.UserRoot'),
         call('api.user', '/api/users/{username}'),
         call('badge', '/api/badge'),
         call('token', '/api/token'),

--- a/tests/h/traversal/roots_test.py
+++ b/tests/h/traversal/roots_test.py
@@ -277,6 +277,24 @@ class TestGroupRoot(object):
 @pytest.mark.usefixtures('user_service')
 class TestUserRoot(object):
 
+    def test_it_does_not_assign_create_permission_without_auth_client_role(self, pyramid_config, pyramid_request):
+        policy = pyramid.authorization.ACLAuthorizationPolicy()
+        pyramid_config.testing_securitypolicy('acct:adminuser@foo')
+        pyramid_config.set_authorization_policy(policy)
+
+        context = UserRoot(pyramid_request)
+
+        assert not pyramid_request.has_permission('create', context)
+
+    def test_it_assigns_create_permission_to_auth_client_role(self, pyramid_config, pyramid_request):
+        policy = pyramid.authorization.ACLAuthorizationPolicy()
+        pyramid_config.testing_securitypolicy('acct:adminuser@foo', groupids=[role.AuthClient])
+        pyramid_config.set_authorization_policy(policy)
+
+        context = UserRoot(pyramid_request)
+
+        assert pyramid_request.has_permission('create', context)
+
     def test_it_fetches_the_requested_user(self, pyramid_request, user_factory, user_service):
         user_factory["bob"]
 

--- a/tests/h/views/api/users_test.py
+++ b/tests/h/views/api/users_test.py
@@ -15,9 +15,7 @@ from h.services.user_unique import UserUniqueService, DuplicateUserError
 from h.views.api.users import create, update
 
 
-@pytest.mark.usefixtures('auth_client',
-                         'request_auth_client',
-                         'validate_auth_client_authority',
+@pytest.mark.usefixtures('client_authority',
                          'user_signup_service',
                          'user_unique_svc')
 class TestCreate(object):
@@ -89,6 +87,12 @@ class TestCreate(object):
 
         with pytest.raises(PayloadError):
             create(pyramid_request)
+
+    @pytest.fixture
+    def client_authority(self, patch):
+        client_authority = patch('h.views.api.users.client_authority')
+        client_authority.return_value = 'weylandindustries.com'
+        return client_authority
 
     @pytest.fixture
     def valid_payload(self):

--- a/tests/h/views/api/users_test.py
+++ b/tests/h/views/api/users_test.py
@@ -65,6 +65,13 @@ class TestCreate(object):
         with pytest.raises(ValidationError):
             create(pyramid_request)
 
+    def test_raises_ValidationError_when_authority_mismatch(self, pyramid_request, valid_payload):
+        valid_payload['authority'] = 'invalid.com'
+        pyramid_request.json_body = valid_payload
+
+        with pytest.raises(ValidationError, match="does not match client authority"):
+            create(pyramid_request)
+
     def test_it_proxies_uniqueness_check_to_service(self, valid_payload, pyramid_request, user_unique_svc, CreateUserAPISchema, auth_client):
         pyramid_request.json_body = valid_payload
         CreateUserAPISchema().validate.return_value = valid_payload


### PR DESCRIPTION
This PR removes the view-level auth* logic for authClients on the `POST /api/users` endpoint and replaces it with a `permission` view config. To accomplish this, a new permission (`'create'`) has been added to `h.traversal.roots.UserRoot` and `UserRoot` has been set as the route factory for that endpoint. The permission is assigned to authenticated AuthClients.

Also in this PR, the route whitelisting for AuthClients is updated and, I think, better. This is in its own commit; if it's too much for this PR I can break it out, though it'd be convenient to ship it together.

Note: After this is merged, `POST /api/users` will temporarily return a 404 instead of a 403 on auth fail. This is because of our squashing of all 403s to 404s in our view exceptions. 403s happened before because of the custom/legacy view-level logic that was doing the auth before it was normalized. Now that we're using "real" Pyramid authn and authz, the error views are getting used and  re-coding all 403s to 404s. [Fixing this is very much on my list](https://github.com/hypothesis/product-backlog/issues/769)