### PR TITLE
Add a field called hidden to an annotation document at the time of indexing

### DIFF
--- a/h/search/config.py
+++ b/h/search/config.py
@@ -40,6 +40,7 @@ ANNOTATION_MAPPING = {
         'quote': {'type': 'text', 'analyzer': 'uni_normalizer'},
         'references': {'type': 'keyword'},
         'shared': {'type': 'boolean'},
+        'hidden': {'type': 'boolean'},
         'tags': {'type': 'text', 'analyzer': 'uni_normalizer'},
         'tags_raw': {'type': 'keyword'},
         'text': {'type': 'text', 'analyzer': 'uni_normalizer'},

--- a/h/search/index.py
+++ b/h/search/index.py
@@ -43,7 +43,7 @@ def index(es, annotation, request, target_index=None):
     :param target_index: the index name, uses default index if not given
     :type target_index: unicode
     """
-    presenter = presenters.AnnotationSearchIndexPresenter(annotation)
+    presenter = presenters.AnnotationSearchIndexPresenter(annotation, request)
     annotation_dict = presenter.asdict()
 
     event = AnnotationTransformEvent(request, annotation, annotation_dict)
@@ -155,7 +155,7 @@ class BatchIndexer(object):
         action = {self.op_type: {'_index': self._target_index,
                                  '_type': self.es_client.mapping_type,
                                  '_id': annotation.id}}
-        data = presenters.AnnotationSearchIndexPresenter(annotation).asdict()
+        data = presenters.AnnotationSearchIndexPresenter(annotation, self.request).asdict()
 
         event = AnnotationTransformEvent(self.request, annotation, data)
         self.request.registry.notify(event)

--- a/tests/h/presenters/annotation_searchindex_test.py
+++ b/tests/h/presenters/annotation_searchindex_test.py
@@ -8,13 +8,15 @@ import mock
 import pytest
 
 from h.presenters.annotation_searchindex import AnnotationSearchIndexPresenter
+from h.services.annotation_moderation import AnnotationModerationService
 
 
-@pytest.mark.usefixtures('DocumentSearchIndexPresenter')
+@pytest.mark.usefixtures('DocumentSearchIndexPresenter', 'moderation_service', 'thread_ids')
 class TestAnnotationSearchIndexPresenter(object):
 
-    def test_asdict(self, DocumentSearchIndexPresenter):
-        annotation = mock.Mock(
+    def test_asdict(self, DocumentSearchIndexPresenter, pyramid_request, thread_ids):
+
+        annotation = mock.MagicMock(
             id='xyz123',
             created=datetime.datetime(2016, 2, 24, 18, 3, 25, 768),
             updated=datetime.datetime(2016, 2, 29, 10, 24, 5, 564),
@@ -27,11 +29,11 @@ class TestAnnotationSearchIndexPresenter(object):
             shared=True,
             target_selectors=[{'TestSelector': 'foobar'}],
             references=['referenced-id-1', 'referenced-id-2'],
-            thread_ids=['thread-id-1', 'thread-id-2'],
+            thread_ids=thread_ids,
             extra={'extra-1': 'foo', 'extra-2': 'bar'})
         DocumentSearchIndexPresenter.return_value.asdict.return_value = {'foo': 'bar'}
 
-        annotation_dict = AnnotationSearchIndexPresenter(annotation).asdict()
+        annotation_dict = AnnotationSearchIndexPresenter(annotation, pyramid_request).asdict()
 
         assert annotation_dict == {
             'authority': 'hypothes.is',
@@ -51,22 +53,101 @@ class TestAnnotationSearchIndexPresenter(object):
                         'selector': [{'TestSelector': 'foobar'}]}],
             'document': {'foo': 'bar'},
             'references': ['referenced-id-1', 'referenced-id-2'],
-            'thread_ids': ['thread-id-1', 'thread-id-2'],
+            'thread_ids': thread_ids,
+            'hidden': False,
         }
 
-    def test_it_copies_target_uri_normalized_to_target_scope(self):
-        annotation = mock.Mock(
+    def test_it_copies_target_uri_normalized_to_target_scope(self, pyramid_request):
+        annotation = mock.MagicMock(
             userid='acct:luke@hypothes.is',
             target_uri_normalized='http://example.com/normalized',
             extra={})
 
-        annotation_dict = AnnotationSearchIndexPresenter(annotation).asdict()
+        annotation_dict = AnnotationSearchIndexPresenter(annotation, pyramid_request).asdict()
 
         assert annotation_dict['target'][0]['scope'] == [
             'http://example.com/normalized']
+
+    def test_it_marks_annotation_hidden_when_it_and_all_children_are_moderated(self,
+                                                                               pyramid_request,
+                                                                               moderation_service,
+                                                                               thread_ids):
+        annotation = mock.MagicMock(
+            userid='acct:luke@hypothes.is',
+            thread_ids=thread_ids)
+
+        moderation_service.hidden.return_value = True
+        moderation_service.all_hidden.return_value = thread_ids
+
+        annotation_dict = AnnotationSearchIndexPresenter(annotation, pyramid_request).asdict()
+
+        assert annotation_dict['hidden'] is True
+
+    def test_it_does_not_mark_annotation_hidden_when_it_is_not_moderated(self,
+                                                                         pyramid_request,
+                                                                         moderation_service,
+                                                                         thread_ids):
+        annotation = mock.MagicMock(
+            userid='acct:luke@hypothes.is',
+            thread_ids=thread_ids)
+
+        moderation_service.all_hidden.return_value = thread_ids
+
+        annotation_dict = AnnotationSearchIndexPresenter(annotation, pyramid_request).asdict()
+
+        assert annotation_dict['hidden'] is False
+
+    def test_it_does_not_mark_annotation_hidden_when_children_are_not_moderated(self,
+                                                                                pyramid_request,
+                                                                                moderation_service,
+                                                                                thread_ids):
+        annotation = mock.MagicMock(
+            userid='acct:luke@hypothes.is',
+            thread_ids=thread_ids)
+
+        moderation_service.all_hidden.return_value = thread_ids[1:]
+        moderation_service.hidden.return_value = True
+
+        annotation_dict = AnnotationSearchIndexPresenter(annotation, pyramid_request).asdict()
+
+        assert annotation_dict['hidden'] is False
+
+    def test_it_does_not_mark_annotation_hidden_when_not_moderated_and_no_replies(self, pyramid_request):
+        thread_ids = []
+        annotation = mock.MagicMock(
+            userid='acct:luke@hypothes.is',
+            thread_ids=thread_ids)
+
+        annotation_dict = AnnotationSearchIndexPresenter(annotation, pyramid_request).asdict()
+
+        assert annotation_dict['hidden'] is False
+
+    def test_it_marks_annotation_hidden_when_moderated_and_no_replies(self, pyramid_request, moderation_service):
+        annotation = mock.MagicMock(userid='acct:luke@hypothes.is')
+
+        moderation_service.hidden.return_value = True
+
+        annotation_dict = AnnotationSearchIndexPresenter(annotation, pyramid_request).asdict()
+
+        assert annotation_dict['hidden'] is True
 
     @pytest.fixture
     def DocumentSearchIndexPresenter(self, patch):
         class_ = patch('h.presenters.annotation_searchindex.DocumentSearchIndexPresenter')
         class_.return_value.asdict.return_value = {}
         return class_
+
+
+@pytest.fixture
+def moderation_service(pyramid_config):
+    svc = mock.create_autospec(AnnotationModerationService, spec_set=True, instance=True)
+    svc.all_hidden.return_value = []
+    svc.hidden.return_value = False
+    pyramid_config.register_service(svc, name='annotation_moderation')
+    return svc
+
+
+@pytest.fixture
+def thread_ids():
+    # Annotation reply ids are referred to as thread_ids in our code base.
+    return ['thread-id-1', 'thread-id-2']


### PR DESCRIPTION
Fixes a bug which happens when all children of an annotation AND the
annotation itself, have the nipsa field set to true, that annotation
appears in a redacted state instead of being filtered out of the search
results.

See https://github.com/hypothesis/product-backlog/issues/583