### PR TITLE
Change page title and button text for create group page.

### DIFF
--- a/h/templates/groups/create.html.jinja2
+++ b/h/templates/groups/create.html.jinja2
@@ -1,9 +1,9 @@
 {% extends "h:templates/layouts/group.html.jinja2" %}
 
-{% set page_title = 'Create a new group' %}
+{% set page_title = 'Create a new private group' %}
 
 {% block page_content %}
-  <h1 class="form-header">Create a new group</h1>
+  <h1 class="form-header">Create a new private group</h1>
   {{ form }}
 
   <footer class="form-footer">

--- a/h/views/groups.py
+++ b/h/views/groups.py
@@ -23,7 +23,7 @@ class GroupCreateController(object):
         self.schema = schemas.group_schema(autofocus_name=True).bind(
             request=self.request)
 
-        submit = deform.Button(title=_('Create a new group'),
+        submit = deform.Button(title=_('Create group'),
                                css_class='primary-action-btn '
                                          'group-form__submit-btn '
                                          'js-create-group-create-btn')


### PR DESCRIPTION
Since we have different types of groups, and previously
we didn't explicitly say what type of group is created with
this form, we're updating the page title to be more clear.
Fixes https://github.com/hypothesis/h/issues/5290