### PR TITLE
Don't call pytest fixtures directly

### DIFF
--- a/tests/h/oauth/jwt_grant_test.py
+++ b/tests/h/oauth/jwt_grant_test.py
@@ -132,10 +132,10 @@ class TestJWTAuthorizationGrantValidateTokenRequest(object):
 
     def test_raises_when_user_authority_does_not_match_client_authority(self, grant, authclient, user):
         user.authority = 'bogus.org'
-        request = oauth_request(authclient, user)
+        oauth_request = _oauth_request(authclient, user)
 
         with pytest.raises(errors.InvalidGrantError) as exc:
-            grant.validate_token_request(request)
+            grant.validate_token_request(oauth_request)
 
         assert exc.value.description == 'Grant token subject (sub) does not match issuer (iss).'
 
@@ -147,8 +147,7 @@ def grant(pyramid_request, request_validator):
     return JWTAuthorizationGrant(request_validator, user_svc, 'domain.test')
 
 
-@pytest.fixture
-def oauth_request(authclient, user):
+def _oauth_request(authclient, user):
     exp = datetime.utcnow() + timedelta(minutes=5)
     nbf = datetime.utcnow() - timedelta(seconds=2)
     claims = {
@@ -162,6 +161,11 @@ def oauth_request(authclient, user):
 
     return OAuthRequest('/', body={'assertion': jwttok,
                                    'client': Client(authclient)})
+
+
+@pytest.fixture
+def oauth_request(authclient, user):
+    return _oauth_request(authclient, user)
 
 
 @pytest.fixture

--- a/tests/h/services/annotation_json_presentation_test.py
+++ b/tests/h/services/annotation_json_presentation_test.py
@@ -12,46 +12,48 @@ from h.services.annotation_json_presentation import annotation_json_presentation
 
 @pytest.mark.usefixtures('presenters', 'formatters')
 class TestAnnotationJSONPresentationService(object):
-    def test_initializes_flag_formatter(self, services, formatters):
-        self.svc(services)
+    def test_initializes_flag_formatter(self, services, formatters, svc):
         formatters.AnnotationFlagFormatter.assert_called_once_with(services['flag'],
                                                                    mock.sentinel.user)
 
-    def test_it_configures_flag_formatter(self, services, formatters):
-        svc = self.svc(services)
+    def test_it_configures_flag_formatter(self, services, formatters, svc):
         assert formatters.AnnotationFlagFormatter.return_value in svc.formatters
 
-    def test_initializes_hidden_formatter(self, matchers, services, formatters):
-        self.svc(services)
+    def test_initializes_hidden_formatter(self, matchers, services, formatters, svc):
         formatters.AnnotationHiddenFormatter.assert_called_once_with(services['annotation_moderation'],
                                                                      matchers.AnyCallable(),
                                                                      mock.sentinel.user)
 
-    def test_it_configures_hidden_formatter(self, services, formatters):
-        svc = self.svc(services)
+    def test_it_configures_hidden_formatter(self, services, formatters, svc):
         assert formatters.AnnotationHiddenFormatter.return_value in svc.formatters
 
-    def test_initializes_moderation_formatter(self, services, formatters):
-        self.svc(services)
+    def test_initializes_moderation_formatter(self, services, formatters, svc):
         formatters.AnnotationModerationFormatter.assert_called_once_with(services['flag_count'],
                                                                          mock.sentinel.user,
                                                                          mock.sentinel.has_permission)
 
-    def test_it_configures_moderation_formatter(self, services, formatters):
-        svc = self.svc(services)
+    def test_it_configures_moderation_formatter(self, services, formatters, svc):
         assert formatters.AnnotationModerationFormatter.return_value in svc.formatters
 
-    def test_initializes_user_info_formatter(self, services, formatters):
-        self.svc(services)
+    def test_initializes_user_info_formatter(self, services, formatters, svc):
         formatters.AnnotationUserInfoFormatter.assert_called_once_with(mock.sentinel.db_session,
                                                                        services['user'])
 
-    def test_it_configures_user_info_formatter(self, services, formatters):
-        svc = self.svc(services)
+    def test_it_configures_user_info_formatter(self, services, formatters, svc):
         assert formatters.AnnotationUserInfoFormatter.return_value in svc.formatters
 
     def test_it_skips_configuring_user_info_formatter_when_told_to(self, services, formatters):
-        svc = self.svc(services, render_user_info=False)
+        svc = AnnotationJSONPresentationService(session=mock.sentinel.db_session,
+                                                user=mock.sentinel.user,
+                                                group_svc=services['group'],
+                                                links_svc=services['links'],
+                                                flag_svc=services['flag'],
+                                                flag_count_svc=services['flag_count'],
+                                                moderation_svc=services['annotation_moderation'],
+                                                user_svc=services['user'],
+                                                has_permission=mock.sentinel.has_permission,
+                                                render_user_info=False)
+
         assert formatters.AnnotationUserInfoFormatter.return_value not in svc.formatters
 
     def test_present_inits_presenter(self, svc, presenters, annotation_resource):
@@ -110,7 +112,7 @@ class TestAnnotationJSONPresentationService(object):
         assert result == [present.return_value]
 
     @pytest.fixture
-    def svc(self, services, render_user_info=True):
+    def svc(self, services):
         return AnnotationJSONPresentationService(session=mock.sentinel.db_session,
                                                  user=mock.sentinel.user,
                                                  group_svc=services['group'],
@@ -120,7 +122,7 @@ class TestAnnotationJSONPresentationService(object):
                                                  moderation_svc=services['annotation_moderation'],
                                                  user_svc=services['user'],
                                                  has_permission=mock.sentinel.has_permission,
-                                                 render_user_info=render_user_info)
+                                                 render_user_info=True)
 
     @pytest.fixture
     def annotation_resource(self):


### PR DESCRIPTION
Several tests were triggering "fixtures are not meant to be called directly" warnings from pytest, and in a future version of pytest it won't even be _possible_ to call fixtures directly. Fix the code to no longer call fixtures directly.