### PR TITLE
Fix an SQLAlchemy unicode warning

### DIFF
--- a/h/auth/policy.py
+++ b/h/auth/policy.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 
 import re
 
+import pyramid.compat
 from pyramid import interfaces
 from pyramid.authentication import BasicAuthAuthenticationPolicy
 from pyramid.authentication import CallbackAuthenticationPolicy
@@ -283,7 +284,13 @@ class AuthClientPolicy(object):
     @staticmethod
     def _forwarded_userid(request):
         """Return forwarded userid or None"""
-        return request.headers.get('X-Forwarded-User', None)
+        userid = request.headers.get('X-Forwarded-User', None)
+        if userid is not None:
+            # In Python 2 request header values are byte strings, so we need to
+            # decode them to get unicode.
+            # FIXME: Remove this once we've moved to Python 3.
+            userid = pyramid.compat.text_(userid)
+        return userid
 
 
 @interface.implementer(interfaces.IAuthenticationPolicy)


### PR DESCRIPTION
We're reading the value of the X-Forwarded-User header, which in Python 2 is a byte string, and then using it in an SQLAlchemy query which is triggering a unicode warning from SQLAlchemy:

    Unicode type received non-unicode bind param value

This is because we're passing SQLAlchemy a byte string and asking it to match it against a unicode column.

Fix this by decoding the byte string to unicode first.

Once we've moved to Python 3 we can remove this decoding: request header values are unicode already in Python 3.