### PR TITLE
Fix Pyramid deprecation warning

### DIFF
--- a/h/views/admin/mailer.py
+++ b/h/views/admin/mailer.py
@@ -23,7 +23,7 @@ def mailer_index(request):
 @view_config(route_name='admin.mailer_test',
              request_method='POST',
              permission='admin_mailer',
-             check_csrf=True)
+             require_csrf=True)
 def mailer_test(request):
     """Send a test email."""
     if 'recipient' not in request.params:


### PR DESCRIPTION
`check_csrf` was deprecated in Pyramid 1.7:

https://docs.pylonsproject.org/projects/pyramid/en/latest/whatsnew-1.7.html?highlight=check_csrf#deprecations

The new `require_csrf` view option was added in Pyramid 1.7, to be used instead of `check_csrf`:

https://docs.pylonsproject.org/projects/pyramid/en/latest/whatsnew-1.7.html?highlight=check_csrf#feature-additions

The docs for the old, deprecated `check_csrf` can be found on this page:

https://docs.pylonsproject.org/projects/pyramid/en/1.6-branch/api/config.html?highlight=check_csrf#pyramid.config.Configurator.add_view

And here's the new `require_csrf`:

https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/viewconfig.html?highlight=require_csrf#non-predicate-arguments