### PR TITLE
Replace deprecated readfp()

### DIFF
--- a/h/assets.py
+++ b/h/assets.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 import os
+import sys
 
 import json
 from pyramid.settings import asbool, aslist
@@ -131,7 +132,14 @@ def _add_cors_header(wrapped):
 def _load_bundles(fp):
     """Read an asset bundle config from a file object."""
     parser = configparser.ConfigParser()
-    parser.readfp(fp)
+
+    # readfp() changed to read_file() in Python 3.2.
+    # FIXME: Remove this once we no longer support Python 2.
+    if sys.version_info.major == 3 and sys.version_info.minor >= 2:
+        parser.read_file(fp)
+    else:
+        parser.readfp(fp)
+
     return {k: aslist(v) for k, v in parser.items('bundles')}
 
 


### PR DESCRIPTION
Calling readfp() prints a warning in Python 3:

> DeprecationWarning: This method will be removed in future versions.  Use 'parser.read_file()' instead.

Fix this by calling read_file() instead. But read_file() isn't available in Python < 3.2, so still use readfp() in older versions.

Here's the docs for the old, deprecated readfp():

https://docs.python.org/2/library/configparser.html?highlight=readfp#ConfigParser.RawConfigParser.readfp

Here's the docs for the new read_file():

https://docs.python.org/3/library/configparser.html?highlight=read_file#configparser.ConfigParser.read_file