### PR TITLE
Replace deprecated warn()

### DIFF
--- a/tests/h/util/test_logging_filters.py
+++ b/tests/h/util/test_logging_filters.py
@@ -20,7 +20,7 @@ class TestExceptionFilter(object):
         try:
             raise ReadTimeout("this is a test read timeout error")
         except ReadTimeout:
-            logger.warn("warning", exc_info=True)
+            logger.warning("warning", exc_info=True)
         assert not logger.handlers[0].handler_called, "Didn't filter out log message when it should have!!"
 
     def test_does_log_if_log_level_mismatch(self, logger):
@@ -34,14 +34,14 @@ class TestExceptionFilter(object):
         try:
             raise Exception("this is a test read timeout error")
         except Exception:
-            logger.warn("warning", exc_info=True)
+            logger.warning("warning", exc_info=True)
         assert logger.handlers[0].handler_called, "Filtered out log message when it shouldn't have!!"
 
     def test_does_log_if_no_exc_info_is_recorded(self, logger):
         try:
             raise ReadTimeout("this is a test read timeout error")
         except ReadTimeout:
-            logger.warn("warning")
+            logger.warning("warning")
         assert logger.handlers[0].handler_called, "Filtered out log message when it shouldn't have!!"
 
 


### PR DESCRIPTION
warn() is deprecated and prints a warning in newer versions of Python. Use warning() instead.