### PR TITLE
Fix invalid string escapes

### DIFF
--- a/h/accounts/util.py
+++ b/h/accounts/util.py
@@ -45,7 +45,7 @@ def validate_orcid(orcid):
     Returns the normalized ORCID if successfully parsed or raises a ValueError
     otherwise.
     """
-    orcid_regex = '\A[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{3}[0-9X]\Z'
+    orcid_regex = r'\A[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{3}[0-9X]\Z'
 
     if not re.match(orcid_regex, orcid):
         raise ValueError('The format of this ORCID is incorrect'.format(orcid))

--- a/h/auth/policy.py
+++ b/h/auth/policy.py
@@ -15,7 +15,7 @@ from h.auth import util
 # As we roll out the new API Auth Policy with Auth Token Policy, we
 # want to keep it restricted to certain endpoints
 # Currently restricted to `POST /api/groups*` only
-AUTH_TOKEN_PATH_PATTERN = '^\/api\/groups'
+AUTH_TOKEN_PATH_PATTERN = r"^/api/groups"
 
 
 @interface.implementer(interfaces.IAuthenticationPolicy)

--- a/h/auth/tokens.py
+++ b/h/auth/tokens.py
@@ -11,7 +11,7 @@ from h.auth.interfaces import IAuthenticationToken
 
 @implementer(IAuthenticationToken)
 class Token(object):
-    """
+    r"""
     A long-lived API token for a user.
 
     This is a wrapper class that wraps an ``h.models.Token`` and provides an

--- a/h/util/document_claims.py
+++ b/h/util/document_claims.py
@@ -25,7 +25,7 @@ import re
 #
 # This also accepts DOIs represented as URLs (eg.
 # "https://doi.org/10.1000/123456").
-DOI_PATTERN = re.compile('(https?://(dx\.)?doi\.org/)?10\.[0-9]{4,}[.0-9]*/.*')
+DOI_PATTERN = re.compile(r'(https?://(dx\.)?doi\.org/)?10\.[0-9]{4,}[.0-9]*/.*')
 
 
 def document_uris_from_data(document_data, claimant):

--- a/tests/h/util/markdown_test.py
+++ b/tests/h/util/markdown_test.py
@@ -17,8 +17,8 @@ class TestRender(object):
         assert '<p>$$1 + 1 = 2$$</p>\n' == actual
 
     def test_it_ignores_inline_match(self):
-        actual = markdown.render('Foobar \(1 + 1 = 2\)')
-        assert '<p>Foobar \(1 + 1 = 2\)</p>\n' == actual
+        actual = markdown.render(r'Foobar \(1 + 1 = 2\)')
+        assert '<p>Foobar \\(1 + 1 = 2\\)</p>\n' == actual
 
     def test_it_sanitizes_the_output(self, markdown_render, sanitize):
         markdown.render('foobar')


### PR DESCRIPTION
[`\` is the escape character in Python string literals]( https://docs.python.org/3/reference/lexical_analysis.html#string-and-bytes-literals).

For example if you want to put a tab character in a string you would do:

    >>> print("foo \t bar")
    foo 	 bar
    
If you want to put a literal `\` in a string you have to use `\\`:

    >>> print("foo \\ bar")
    foo \ bar

Or use a "raw string":

    >>> print(r"foo \ bar")
    foo \ bar

You can't just go putting backslashes in string literals whenever you want one. A backslash isn't valid when not followed by one of the valid escape sequences, and [newer versions of Python print a deprecation warning](https://bugs.python.org/issue27364). For example `\A` isn't an escape sequence:

    $ python3.6 -Wd -c '"\A"'
    <string>:1: DeprecationWarning: invalid escape sequence \A

If your backslash sequence does accidentally match one of Python's escape sequences, but you didn't mean it to, that's even worse.

So you should always use raw strings or `\\`.

It's important to remember that a string literal is still a string literal even if that string is intended to be used as a regular expression. [Python's regular expression syntax](https://docs.python.org/3/library/re.html) supports lots of special sequences that begin with `\`. For example `\A` matches the start of a string. But `\A` is not valid in a Python string literal! This is invalid:

    my_regex = "\Afoo"

Instead you should do this:

    my_regex = r"\Afoo"

Docstrings are another one to remember: docstrings are string literals too, and invalid `\` sequences are invalid in docstrings too! Use raw strings (`r"""..."""`) for docstrings if they contain `\`'s.