### PR TITLE
Enable searching for wildcard url's on activity pages

### DIFF
--- a/h/activity/query.py
+++ b/h/activity/query.py
@@ -19,7 +19,7 @@ from h.search import (TopLevelAnnotationsFilter,
                       AuthorityFilter,
                       TagsAggregation,
                       UsersAggregation,
-                      UriFilter)
+                      UriCombinedWildcardFilter)
 
 
 class ActivityResults(namedtuple('ActivityResults', [
@@ -168,7 +168,7 @@ def _execute_search(request, query, page_size):
     search = Search(request, stats=request.stats)
     search.append_modifier(AuthorityFilter(authority=request.default_authority))
     search.append_modifier(TopLevelAnnotationsFilter())
-    search.append_modifier(UriFilter(request=request))
+    search.append_modifier(UriCombinedWildcardFilter(request=request))
     for agg in aggregations_for(query):
         search.append_aggregation(agg)
 

--- a/h/activity/query.py
+++ b/h/activity/query.py
@@ -19,6 +19,7 @@ from h.search import (TopLevelAnnotationsFilter,
                       AuthorityFilter,
                       TagsAggregation,
                       UsersAggregation,
+                      UriFilter,
                       UriCombinedWildcardFilter)
 
 
@@ -168,7 +169,10 @@ def _execute_search(request, query, page_size):
     search = Search(request, stats=request.stats)
     search.append_modifier(AuthorityFilter(authority=request.default_authority))
     search.append_modifier(TopLevelAnnotationsFilter())
-    search.append_modifier(UriCombinedWildcardFilter(request=request))
+    if request.feature("wildcard_search_on_activity_pages"):
+        search.append_modifier(UriCombinedWildcardFilter(request=request))
+    else:
+        search.append_modifier(UriFilter(request=request))
     for agg in aggregations_for(query):
         search.append_aggregation(agg)
 

--- a/h/models/feature.py
+++ b/h/models/feature.py
@@ -18,6 +18,7 @@ FEATURES = {
     'overlay_highlighter': "Use the new overlay highlighter?",
     'api_render_user_info': "Return users' extended info in API responses?",
     'client_display_names': "Render display names instead of user names in the client",
+    'wildcard_search_on_activity_pages': "Enable wildcard search via url facet on activity pages.",
 }
 
 # Once a feature has been fully deployed, we remove the flag from the codebase.

--- a/h/static/scripts/controllers/search-bar-controller.js
+++ b/h/static/scripts/controllers/search-bar-controller.js
@@ -59,7 +59,7 @@ class SearchBarController extends Controller {
         {
           matchOn: 'url',
           title: 'url:',
-          explanation: `see all annotations on page(s) * matches any number 
+          explanation: `see all annotations on a document URL. * matches any number 
             of characters and ? matches any single character`,
         },
         {

--- a/h/static/scripts/controllers/search-bar-controller.js
+++ b/h/static/scripts/controllers/search-bar-controller.js
@@ -59,7 +59,8 @@ class SearchBarController extends Controller {
         {
           matchOn: 'url',
           title: 'url:',
-          explanation: 'see all annotations on a page',
+          explanation: `see all annotations on page(s) * matches any number 
+            of characters and ? matches any single character`,
         },
         {
           matchOn: 'group',

--- a/h/static/scripts/tests/controllers/autosuggest-dropdown-controller-test.js
+++ b/h/static/scripts/tests/controllers/autosuggest-dropdown-controller-test.js
@@ -60,7 +60,7 @@ describe('AutosuggestDropdownController', () => {
         },
         {
           title: 'url:',
-          explanation: `see all annotations on page(s) * matches any number 
+          explanation: `see all annotations on a document URL. * matches any number 
             of characters and ? matches any single character`,
         },
         {

--- a/h/static/scripts/tests/controllers/autosuggest-dropdown-controller-test.js
+++ b/h/static/scripts/tests/controllers/autosuggest-dropdown-controller-test.js
@@ -60,7 +60,8 @@ describe('AutosuggestDropdownController', () => {
         },
         {
           title: 'url:',
-          explanation: 'see all annotations on a page',
+          explanation: `see all annotations on page(s) * matches any number 
+            of characters and ? matches any single character`,
         },
         {
           title: 'group:',

--- a/tests/h/activity/query_test.py
+++ b/tests/h/activity/query_test.py
@@ -252,14 +252,24 @@ class TestExecute(object):
         AuthorityFilter.assert_called_once_with(pyramid_request.default_authority)
         search.append_modifier.assert_any_call(AuthorityFilter.return_value)
 
+    @pytest.mark.parametrize('enable_flag', (True, False))
     def test_it_recognizes_wildcards_in_uri_url(self,
                                                 pyramid_request,
                                                 search,
-                                                UriCombinedWildcardFilter):
+                                                UriFilter,
+                                                UriCombinedWildcardFilter,
+                                                enable_flag):
+
+        pyramid_request.feature.flags['wildcard_search_on_activity_pages'] = enable_flag
+
         execute(pyramid_request, MultiDict(), self.PAGE_SIZE)
 
-        UriCombinedWildcardFilter.assert_called_once_with(pyramid_request)
-        search.append_modifier.assert_any_call(UriCombinedWildcardFilter.return_value)
+        if enable_flag:
+            UriCombinedWildcardFilter.assert_called_once_with(pyramid_request)
+            search.append_modifier.assert_any_call(UriCombinedWildcardFilter.return_value)
+        else:
+            UriFilter.assert_called_once_with(pyramid_request)
+            search.append_modifier.assert_any_call(UriFilter.return_value)
 
     def test_it_adds_a_tags_aggregation_to_the_search_query(self,
                                                             pyramid_request,
@@ -629,6 +639,10 @@ class TestExecute(object):
     @pytest.fixture
     def AuthorityFilter(self, patch):
         return patch('h.activity.query.AuthorityFilter')
+
+    @pytest.fixture
+    def UriFilter(self, patch):
+        return patch('h.activity.query.UriFilter')
 
     @pytest.fixture
     def UriCombinedWildcardFilter(self, patch):

--- a/tests/h/activity/query_test.py
+++ b/tests/h/activity/query_test.py
@@ -217,6 +217,7 @@ class TestCheckURL(object):
                          'bucketing',
                          'presenters',
                          'AuthorityFilter',
+                         'UriCombinedWildcardFilter',
                          'Search',
                          'TagsAggregation',
                          'TopLevelAnnotationsFilter',
@@ -250,6 +251,15 @@ class TestExecute(object):
 
         AuthorityFilter.assert_called_once_with(pyramid_request.default_authority)
         search.append_modifier.assert_any_call(AuthorityFilter.return_value)
+
+    def test_it_recognizes_wildcards_in_uri_url(self,
+                                                pyramid_request,
+                                                search,
+                                                UriCombinedWildcardFilter):
+        execute(pyramid_request, MultiDict(), self.PAGE_SIZE)
+
+        UriCombinedWildcardFilter.assert_called_once_with(pyramid_request)
+        search.append_modifier.assert_any_call(UriCombinedWildcardFilter.return_value)
 
     def test_it_adds_a_tags_aggregation_to_the_search_query(self,
                                                             pyramid_request,
@@ -619,6 +629,10 @@ class TestExecute(object):
     @pytest.fixture
     def AuthorityFilter(self, patch):
         return patch('h.activity.query.AuthorityFilter')
+
+    @pytest.fixture
+    def UriCombinedWildcardFilter(self, patch):
+        return patch('h.activity.query.UriCombinedWildcardFilter')
 
     @pytest.fixture
     def TopLevelAnnotationsFilter(self, patch):


### PR DESCRIPTION
 1. Replace UriFilter with UriCombinedWildcardFilter
 1. Update url facet description to explain how to use wildcards

This is a partial fix for https://github.com/hypothesis/product-backlog/issues/30.