### PR TITLE
Default search_after date to 1/1/1970 00:00:00 0ms

### DIFF
--- a/h/search/query.py
+++ b/h/search/query.py
@@ -15,6 +15,7 @@ LIMIT_DEFAULT = 20
 # Elasticsearch requires offset + limit must be <= 10,000.
 LIMIT_MAX = 200
 OFFSET_MAX = 9800
+DEFAULT_DATE = dt(1970, 1, 1, 0, 0, 0, 0).replace(tzinfo=tz.tzutc())
 
 
 def wildcard_uri_is_valid(wildcard_uri):
@@ -160,7 +161,7 @@ class Sorter(object):
             return date
         except ValueError:
             try:
-                date = parse(str_value)
+                date = parse(str_value, default=DEFAULT_DATE)
                 # If timezone isn't specified assume it's utc.
                 if not date.tzinfo:
                     date = date.replace(tzinfo=tz.tzutc())

--- a/tests/h/search/query_test.py
+++ b/tests/h/search/query_test.py
@@ -189,6 +189,22 @@ class TestSorter(object):
         actual_order = [ann_ids.index(id_) for id_ in result.annotation_ids]
         assert actual_order == expected_order
 
+    def test_incomplete_date_defaults_to_min_datetime_values(self, pyramid_request):
+        """
+        The default date should be:
+            1970, 1st month, 1st day, 0 hrs, 0 min, 0 sec, 0 ms
+        """
+        sorter = query.Sorter()
+        search = elasticsearch_dsl.Search(
+            using="default", index=pyramid_request.es.index
+        )
+
+        params = {"search_after": "2018"}
+
+        q = sorter(search, params).to_dict()
+
+        assert q["search_after"] == [1514764800000.0]
+
     def test_it_ignores_unknown_sort_fields(self, search):
         search.run({"sort": "no_such_field"})
 

--- a/tests/h/search/query_test.py
+++ b/tests/h/search/query_test.py
@@ -48,68 +48,53 @@ class TestLimiter(object):
         ("32.7", OFFSET_DEFAULT),
         ("9801", OFFSET_MAX),
     ])
-    def test_offset(self, pyramid_request, offset, from_):
+    def test_offset(self, es_dsl_search, pyramid_request, offset, from_):
         limiter = query.Limiter()
-        search = elasticsearch_dsl.Search(
-            using=pyramid_request.es.conn,
-        )
 
         params = {"offset": offset}
         if offset is MISSING:
             params = {}
 
-        q = limiter(search, params).to_dict()
+        q = limiter(es_dsl_search, params).to_dict()
 
         assert q["from"] == from_
 
     @given(st.text())
     @pytest.mark.fuzz
-    def test_limit_output_within_bounds(self, pyramid_request, text):
+    def test_limit_output_within_bounds(self, es_dsl_search, pyramid_request, text):
         """Given any string input, output should be in the allowed range."""
         limiter = query.Limiter()
-        search = elasticsearch_dsl.Search(
-            using=pyramid_request.es.conn,
-        )
 
-        q = limiter(search, {"limit": text}).to_dict()
+        q = limiter(es_dsl_search, {"limit": text}).to_dict()
 
         assert isinstance(q["size"], int)
         assert 0 <= q["size"] <= LIMIT_MAX
 
     @given(st.integers())
     @pytest.mark.fuzz
-    def test_limit_output_within_bounds_int_input(self, pyramid_request, lim):
+    def test_limit_output_within_bounds_int_input(self, es_dsl_search, pyramid_request, lim):
         """Given any integer input, output should be in the allowed range."""
         limiter = query.Limiter()
-        search = elasticsearch_dsl.Search(
-            using=pyramid_request.es.conn,
-        )
 
-        q = limiter(search, {"limit": str(lim)}).to_dict()
+        q = limiter(es_dsl_search, {"limit": str(lim)}).to_dict()
 
         assert isinstance(q["size"], int)
         assert 0 <= q["size"] <= LIMIT_MAX
 
     @given(st.integers(min_value=0, max_value=LIMIT_MAX))
     @pytest.mark.fuzz
-    def test_limit_matches_input(self, pyramid_request, lim):
+    def test_limit_matches_input(self, es_dsl_search, pyramid_request, lim):
         """Given an integer in the allowed range, it should be passed through."""
         limiter = query.Limiter()
-        search = elasticsearch_dsl.Search(
-            using=pyramid_request.es.conn,
-        )
 
-        q = limiter(search, {"limit": str(lim)}).to_dict()
+        q = limiter(es_dsl_search, {"limit": str(lim)}).to_dict()
 
         assert q["size"] == lim
 
-    def test_limit_set_to_default_when_missing(self, pyramid_request):
+    def test_limit_set_to_default_when_missing(self, es_dsl_search, pyramid_request):
         limiter = query.Limiter()
-        search = elasticsearch_dsl.Search(
-            using=pyramid_request.es.conn,
-        )
 
-        q = limiter(search, {}).to_dict()
+        q = limiter(es_dsl_search, {}).to_dict()
 
         assert q["size"] == LIMIT_DEFAULT
 
@@ -189,19 +174,16 @@ class TestSorter(object):
         actual_order = [ann_ids.index(id_) for id_ in result.annotation_ids]
         assert actual_order == expected_order
 
-    def test_incomplete_date_defaults_to_min_datetime_values(self, pyramid_request):
+    def test_incomplete_date_defaults_to_min_datetime_values(self, es_dsl_search, pyramid_request):
         """
         The default date should be:
             1970, 1st month, 1st day, 0 hrs, 0 min, 0 sec, 0 ms
         """
         sorter = query.Sorter()
-        search = elasticsearch_dsl.Search(
-            using="default", index=pyramid_request.es.index
-        )
 
         params = {"search_after": "2018"}
 
-        q = sorter(search, params).to_dict()
+        q = sorter(es_dsl_search, params).to_dict()
 
         assert q["search_after"] == [1514764800000.0]
 
@@ -570,13 +552,10 @@ class TestUriCombinedWildcardFilter():
         (webob.multidict.MultiDict([("wildcard_uri", "http?://bar.com")]), True),
         (webob.multidict.MultiDict([("url", "ur*n:x-pdf:*")]), False),
     ])
-    def test_ignores_urls_with_wildcards_in_the_domain(self, pyramid_request, params, separate_keys):
+    def test_ignores_urls_with_wildcards_in_the_domain(self, es_dsl_search, pyramid_request, params, separate_keys):
         urifilter = query.UriCombinedWildcardFilter(pyramid_request, separate_keys)
-        search = elasticsearch_dsl.Search(
-            using="default", index=pyramid_request.es.index
-        )
 
-        q = urifilter(search, params).to_dict()
+        q = urifilter(es_dsl_search, params).to_dict()
 
         assert "should" not in q['query']['bool']
 
@@ -587,13 +566,10 @@ class TestUriCombinedWildcardFilter():
         (webob.multidict.MultiDict([("uri", "http?://bar.com"),
                                     ("url", "http://baz.com")]), False),
     ])
-    def test_pops_params(self, pyramid_request, params, separate_keys):
+    def test_pops_params(self, es_dsl_search, pyramid_request, params, separate_keys):
         urifilter = query.UriCombinedWildcardFilter(pyramid_request, separate_keys)
-        search = elasticsearch_dsl.Search(
-            using="default", index=pyramid_request.es.index
-        )
 
-        urifilter(search, params).to_dict()
+        urifilter(es_dsl_search, params).to_dict()
 
         assert "uri" not in params
         assert "url" not in params
@@ -952,3 +928,11 @@ def search(pyramid_request):
     # Remove all default modifiers and aggregators except Sorter.
     search.clear()
     return search
+
+
+@pytest.fixture
+def es_dsl_search(pyramid_request):
+    return elasticsearch_dsl.Search(
+        using=pyramid_request.es.conn,
+        index=pyramid_request.es.index,
+    )


### PR DESCRIPTION
Datetimes default the date to be the current date for fields that
aren't specified. This behavior is unintuitive and undesireable.
Dates should be defaulted to the first month, first day, 00:00:00 0ms.

This is a fix for the issue raised here: https://github.com/hypothesis/h/pull/5235#discussion_r215905599.