### PR TITLE
Remove use of using="default" for es connection

### DIFF
--- a/tests/h/search/query_test.py
+++ b/tests/h/search/query_test.py
@@ -51,7 +51,7 @@ class TestLimiter(object):
     def test_offset(self, pyramid_request, offset, from_):
         limiter = query.Limiter()
         search = elasticsearch_dsl.Search(
-            using="default", index=pyramid_request.es.index
+            using=pyramid_request.es.conn,
         )
 
         params = {"offset": offset}
@@ -68,7 +68,7 @@ class TestLimiter(object):
         """Given any string input, output should be in the allowed range."""
         limiter = query.Limiter()
         search = elasticsearch_dsl.Search(
-            using="default", index=pyramid_request.es.index
+            using=pyramid_request.es.conn,
         )
 
         q = limiter(search, {"limit": text}).to_dict()
@@ -82,7 +82,7 @@ class TestLimiter(object):
         """Given any integer input, output should be in the allowed range."""
         limiter = query.Limiter()
         search = elasticsearch_dsl.Search(
-            using="default", index=pyramid_request.es.index
+            using=pyramid_request.es.conn,
         )
 
         q = limiter(search, {"limit": str(lim)}).to_dict()
@@ -96,7 +96,7 @@ class TestLimiter(object):
         """Given an integer in the allowed range, it should be passed through."""
         limiter = query.Limiter()
         search = elasticsearch_dsl.Search(
-            using="default", index=pyramid_request.es.index
+            using=pyramid_request.es.conn,
         )
 
         q = limiter(search, {"limit": str(lim)}).to_dict()
@@ -106,7 +106,7 @@ class TestLimiter(object):
     def test_limit_set_to_default_when_missing(self, pyramid_request):
         limiter = query.Limiter()
         search = elasticsearch_dsl.Search(
-            using="default", index=pyramid_request.es.index
+            using=pyramid_request.es.conn,
         )
 
         q = limiter(search, {}).to_dict()


### PR DESCRIPTION
Since we chose not to go forward with using elasticsearch-dsl to
generate an elasticsearch connection, using "default" doesn't make
sense so simply pass the elasticsearch-dsl search the request.es.conn
in the tests instead.
This keeps the tests consistent with the rest of the code.

This addresses the issue raised [here](https://github.com/hypothesis/h/pull/5219#discussion_r215212479).