### PR TITLE
Use popall in es search query modifiers

### DIFF
--- a/h/search/core.py
+++ b/h/search/core.py
@@ -3,9 +3,9 @@ from __future__ import unicode_literals
 import logging
 from collections import namedtuple
 from contextlib import contextmanager
-
 from elasticsearch.exceptions import ConnectionTimeout
 import elasticsearch_dsl
+from webob.multidict import MultiDict
 
 from h.search import query
 
@@ -130,7 +130,7 @@ class Search(object):
         response = self._search(
             [query.RepliesMatcher(annotation_ids)] + self._modifiers,
             [],  # Aggregations aren't used in replies.
-            {'limit': self._replies_limit},
+            MultiDict({'limit': self._replies_limit}),
         )
 
         if len(response['hits']['hits']) < response['hits']['total']:

--- a/h/search/core.py
+++ b/h/search/core.py
@@ -58,13 +58,12 @@ class Search(object):
         """
         Execute the search query
 
-        :param params: the search parameters
+        :param params: the search parameters that will be popped by each of the filters.
         :type params: webob.multidict.MultiDict
 
         :returns: The search results
         :rtype: SearchResult
         """
-        params = params.copy()  # Avoid mutating input dict.
         total, annotation_ids, aggregations = self._search_annotations(params)
         reply_ids = self._search_replies(annotation_ids)
 

--- a/h/search/core.py
+++ b/h/search/core.py
@@ -59,7 +59,7 @@ class Search(object):
         Execute the search query
 
         :param params: the search parameters
-        :type params: dict-like
+        :type params: webob.multidict.MultiDict
 
         :returns: The search results
         :rtype: SearchResult

--- a/h/search/query.py
+++ b/h/search/query.py
@@ -44,11 +44,11 @@ def wildcard_uri_is_valid(wildcard_uri):
     return False
 
 
-def _pop_param_values(params, key):
-    """ Pops and returns all values of the key in params"""
-    values = params.getall(key)
+def popall(multidict, key):
+    """ Pops and returns all values of the key in multidict"""
+    values = multidict.getall(key)
     if values:
-        del params[key]
+        del multidict[key]
     return values
 
 
@@ -263,7 +263,7 @@ class UriFilter(object):
     def __call__(self, search, params):
         if 'uri' not in params and 'url' not in params:
             return search
-        query_uris = _pop_param_values(params, 'uri') + _pop_param_values(params, 'url')
+        query_uris = popall(params, 'uri') + popall(params, 'url')
 
         uris = set()
         for query_uri in query_uris:
@@ -310,10 +310,10 @@ class UriCombinedWildcardFilter(object):
             return search
 
         if self.separate_keys:
-            uris = _pop_param_values(params, 'uri') + _pop_param_values(params, 'url')
-            wildcard_uris = _pop_param_values(params, 'wildcard_uri')
+            uris = popall(params, 'uri') + popall(params, 'url')
+            wildcard_uris = popall(params, 'wildcard_uri')
         else:
-            uris = _pop_param_values(params, 'uri') + _pop_param_values(params, 'url')
+            uris = popall(params, 'uri') + popall(params, 'url')
             # Split into wildcard uris and non wildcard uris.
             wildcard_uris = [u for u in uris if "*" in u or "?" in u]
             uris = [u for u in uris if "*" not in u and "?" not in u]
@@ -374,7 +374,7 @@ class UserFilter(object):
         if 'user' not in params:
             return search
 
-        users = [v.lower() for v in _pop_param_values(params, 'user')]
+        users = [v.lower() for v in popall(params, 'user')]
 
         return search.filter("terms", user=users)
 
@@ -427,7 +427,7 @@ class AnyMatcher(object):
     def __call__(self, search, params):
         if "any" not in params:
             return search
-        qs = ' '.join(_pop_param_values(params, "any"))
+        qs = ' '.join(popall(params, "any"))
         return search.query(
             SimpleQueryString(
                 query=qs,
@@ -442,7 +442,7 @@ class TagsMatcher(object):
     """Matches the tags field against 'tag' or 'tags' parameters."""
 
     def __call__(self, search, params):
-        tags = set(_pop_param_values(params, 'tag') + _pop_param_values(params, 'tags'))
+        tags = set(popall(params, 'tag') + popall(params, 'tags'))
         matchers = [Q("match", tags={"query": t, "operator": "and"})
                     for t in tags]
         if matchers:

--- a/h/search/query.py
+++ b/h/search/query.py
@@ -263,11 +263,7 @@ class UriFilter(object):
     def __call__(self, search, params):
         if 'uri' not in params and 'url' not in params:
             return search
-        query_uris = [v for k, v in params.items() if k in ['uri', 'url']]
-        if 'uri' in params:
-            del params['uri']
-        if 'url' in params:
-            del params['url']
+        query_uris = _pop_param_values(params, 'uri') + _pop_param_values(params, 'url')
 
         uris = set()
         for query_uri in query_uris:
@@ -378,8 +374,7 @@ class UserFilter(object):
         if 'user' not in params:
             return search
 
-        users = [v.lower() for k, v in params.items() if k == 'user']
-        del params['user']
+        users = [v.lower() for v in _pop_param_values(params, 'user')]
 
         return search.filter("terms", user=users)
 
@@ -432,8 +427,7 @@ class AnyMatcher(object):
     def __call__(self, search, params):
         if "any" not in params:
             return search
-        qs = ' '.join([v for k, v in params.items() if k == "any"])
-        del params["any"]
+        qs = ' '.join(_pop_param_values(params, "any"))
         return search.query(
             SimpleQueryString(
                 query=qs,
@@ -448,12 +442,7 @@ class TagsMatcher(object):
     """Matches the tags field against 'tag' or 'tags' parameters."""
 
     def __call__(self, search, params):
-        tags = set(v for k, v in params.items() if k in ['tag', 'tags'])
-        try:
-            del params['tag']
-            del params['tags']
-        except KeyError:
-            pass
+        tags = set(_pop_param_values(params, 'tag') + _pop_param_values(params, 'tags'))
         matchers = [Q("match", tags={"query": t, "operator": "and"})
                     for t in tags]
         if matchers:

--- a/h/views/badge.py
+++ b/h/views/badge.py
@@ -3,6 +3,7 @@
 from __future__ import unicode_literals
 
 from pyramid import httpexceptions
+from webob.multidict import MultiDict
 
 from h import models, search
 from h.util.view import json_view
@@ -47,7 +48,7 @@ def badge(request):
     elif models.Blocklist.is_blocked(request.db, uri):
         count = 0
     else:
-        query = {'uri': uri, 'limit': 0}
+        query = MultiDict({'uri': uri, 'limit': 0})
         s = search.Search(request, stats=request.stats)
         s.append_modifier(search.UriFilter(request))
         result = s.run(query)

--- a/h/views/feeds.py
+++ b/h/views/feeds.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 
 from pyramid.view import view_config
 from pyramid import i18n
+from webob.multidict import MultiDict
 
 from h import search
 from h.feeds import render_atom, render_rss
@@ -17,7 +18,7 @@ def _annotations(request):
     """Return the annotations from the search API."""
     s = search.Search(request, stats=request.stats)
     s.append_modifier(search.UriFilter(request))
-    result = s.run(request.params)
+    result = s.run(MultiDict(request.params))
     return fetch_ordered_annotations(request.db, result.annotation_ids)
 
 

--- a/tests/h/search/core_test.py
+++ b/tests/h/search/core_test.py
@@ -123,14 +123,6 @@ class TestSearch(object):
 
         assert result.reply_ids == []
 
-    def test_it_does_not_modify_param_dict(self, pyramid_request):
-        params = MultiDict({"sort": "updated"})
-        original_params = params.copy()
-
-        search.Search(pyramid_request).run(params)
-
-        assert params == original_params
-
 
 class TestSearchWithSeparateReplies(object):
     """Unit tests for search.Search when separate_replies=True is given."""

--- a/tests/h/search/query_test.py
+++ b/tests/h/search/query_test.py
@@ -51,9 +51,9 @@ class TestLimiter(object):
     def test_offset(self, es_dsl_search, pyramid_request, offset, from_):
         limiter = query.Limiter()
 
-        params = {"offset": offset}
+        params = webob.multidict.MultiDict({"offset": offset})
         if offset is MISSING:
-            params = {}
+            params = webob.multidict.MultiDict({})
 
         q = limiter(es_dsl_search, params).to_dict()
 
@@ -65,7 +65,7 @@ class TestLimiter(object):
         """Given any string input, output should be in the allowed range."""
         limiter = query.Limiter()
 
-        q = limiter(es_dsl_search, {"limit": text}).to_dict()
+        q = limiter(es_dsl_search, webob.multidict.MultiDict({"limit": text})).to_dict()
 
         assert isinstance(q["size"], int)
         assert 0 <= q["size"] <= LIMIT_MAX
@@ -76,7 +76,7 @@ class TestLimiter(object):
         """Given any integer input, output should be in the allowed range."""
         limiter = query.Limiter()
 
-        q = limiter(es_dsl_search, {"limit": str(lim)}).to_dict()
+        q = limiter(es_dsl_search, webob.multidict.MultiDict({"limit": str(lim)})).to_dict()
 
         assert isinstance(q["size"], int)
         assert 0 <= q["size"] <= LIMIT_MAX
@@ -87,14 +87,14 @@ class TestLimiter(object):
         """Given an integer in the allowed range, it should be passed through."""
         limiter = query.Limiter()
 
-        q = limiter(es_dsl_search, {"limit": str(lim)}).to_dict()
+        q = limiter(es_dsl_search, webob.multidict.MultiDict({"limit": str(lim)})).to_dict()
 
         assert q["size"] == lim
 
     def test_limit_set_to_default_when_missing(self, es_dsl_search, pyramid_request):
         limiter = query.Limiter()
 
-        q = limiter(es_dsl_search, {}).to_dict()
+        q = limiter(es_dsl_search, webob.multidict.MultiDict({})).to_dict()
 
         assert q["size"] == LIMIT_DEFAULT
 
@@ -164,7 +164,7 @@ class TestSorter(object):
                     id="2",
                     created=dt(2018, 1, 1)).id]
 
-        params = {}
+        params = webob.multidict.MultiDict({})
         if sort_key:
             params["sort"] = sort_key
         if order:
@@ -188,7 +188,7 @@ class TestSorter(object):
         assert q["search_after"] == [1514764800000.0]
 
     def test_it_ignores_unknown_sort_fields(self, search):
-        search.run({"sort": "no_such_field"})
+        search.run(webob.multidict.MultiDict({"sort": "no_such_field"}))
 
     @pytest.mark.parametrize("date,expected",
         [("1514773561300", [2]),
@@ -209,7 +209,7 @@ class TestSorter(object):
                    Annotation(updated=dt(2018, 1, 1, 2, 26, 1, 500000), created=dt(2016, 1, 1)).id,
                    Annotation(updated=dt(2016, 1, 1), created=dt(2018, 1, 1)).id]
 
-        result = search.run({"search_after": date, "order": "asc"})
+        result = search.run(webob.multidict.MultiDict({"search_after": date, "order": "asc"}))
 
         assert sorted(result.annotation_ids) == sorted([ann_ids[idx] for idx in expected])
 
@@ -218,7 +218,7 @@ class TestSorter(object):
                           str(Annotation(id="11").id),
                           str(Annotation(id="02").id)])
 
-        result = search.run({"search_after": ann_ids[1], "sort": "id", "order": "asc"})
+        result = search.run(webob.multidict.MultiDict({"search_after": ann_ids[1], "sort": "id", "order": "asc"}))
 
         assert result.annotation_ids == [ann_ids[2]]
 
@@ -229,7 +229,7 @@ class TestSorter(object):
                    Annotation(updated=dt(2017, 1, 1), created=dt(2017, 1, 1)).id,
                    Annotation(updated=dt(2018, 1, 1, 2, 26, 1), created=dt(2016, 1, 1)).id]
 
-        result = search.run({"search_after": "invalid_date", "order": "asc"})
+        result = search.run(webob.multidict.MultiDict({"search_after": "invalid_date", "order": "asc"}))
 
         assert result.annotation_ids == ann_ids
 
@@ -240,7 +240,7 @@ class TestTopLevelAnnotationsFilter(object):
         annotation = Annotation()
         Annotation(references=[annotation.id])
 
-        result = search.run({})
+        result = search.run(webob.multidict.MultiDict({}))
 
         assert [annotation.id] == result.annotation_ids
 
@@ -258,7 +258,7 @@ class TestAuthorityFilter(object):
         Annotation(userid="acct:bat@auth2")
         Annotation(userid="acct:bar@auth3")
 
-        result = search.run({})
+        result = search.run(webob.multidict.MultiDict({}))
 
         assert sorted(result.annotation_ids) == sorted(annotations_auth1)
 
@@ -273,7 +273,7 @@ class TestAuthFilter(object):
         Annotation()
         Annotation()
 
-        result = search.run({})
+        result = search.run(webob.multidict.MultiDict({}))
 
         assert not result.annotation_ids
 
@@ -281,7 +281,7 @@ class TestAuthFilter(object):
         shared_ids = [Annotation(shared=True).id,
                       Annotation(shared=True).id]
 
-        result = search.run({})
+        result = search.run(webob.multidict.MultiDict({}))
 
         assert sorted(result.annotation_ids) == sorted(shared_ids)
 
@@ -294,7 +294,7 @@ class TestAuthFilter(object):
         users_private_ids = [Annotation(userid=userid).id,
                              Annotation(userid=userid).id]
 
-        result = search.run({})
+        result = search.run(webob.multidict.MultiDict({}))
 
         assert sorted(result.annotation_ids) == sorted(users_private_ids)
 
@@ -304,7 +304,7 @@ class TestAuthFilter(object):
         shared_ids = [Annotation(userid="acct:foo@auth2", shared=True).id,
                       Annotation(userid=userid, shared=True).id]
 
-        result = search.run({})
+        result = search.run(webob.multidict.MultiDict({}))
 
         assert sorted(result.annotation_ids) == sorted(shared_ids)
 
@@ -321,7 +321,7 @@ class TestGroupFilter(object):
         group1_annotations = [Annotation(groupid=group.pubid).id,
                               Annotation(groupid=group.pubid).id]
 
-        result = search.run({'group': group.pubid})
+        result = search.run(webob.multidict.MultiDict({'group': group.pubid}))
 
         assert sorted(result.annotation_ids) == sorted(group1_annotations)
 
@@ -344,7 +344,7 @@ class TestGroupAuthFilter(object):
         Annotation(groupid="group1").id
         Annotation(groupid="group1").id
 
-        result = search.run({})
+        result = search.run(webob.multidict.MultiDict({}))
 
         assert not result.annotation_ids
 
@@ -356,7 +356,7 @@ class TestGroupAuthFilter(object):
         expected_ids = [Annotation(groupid="group1").id,
                         Annotation(groupid="group1").id]
 
-        result = search.run({})
+        result = search.run(webob.multidict.MultiDict({}))
 
         assert sorted(result.annotation_ids) == sorted(expected_ids)
 
@@ -371,14 +371,14 @@ class TestUserFilter(object):
         Annotation(userid="acct:foo@auth2", shared=True)
         expected_ids = [Annotation(userid="acct:bar@auth2", shared=True).id]
 
-        result = search.run({'user': "bar"})
+        result = search.run(webob.multidict.MultiDict({'user': "bar"}))
 
         assert sorted(result.annotation_ids) == sorted(expected_ids)
 
     def test_filter_is_case_insensitive(self, search, Annotation):
         ann_id = Annotation(userid="acct:bob@example", shared=True).id
 
-        result = search.run({"user": "BOB"})
+        result = search.run(webob.multidict.MultiDict({"user": "BOB"}))
 
         assert result.annotation_ids == [ann_id]
 
@@ -398,7 +398,7 @@ class TestUserFilter(object):
         Annotation(userid="acct:foo@auth2", shared=True)
         expected_ids = [Annotation(userid="acct:foo@auth3", shared=True).id]
 
-        result = search.run({"user": "foo@auth3"})
+        result = search.run(webob.multidict.MultiDict({"user": "foo@auth3"}))
 
         assert sorted(result.annotation_ids) == sorted(expected_ids)
 
@@ -414,7 +414,7 @@ class TestUriFilter(object):
         Annotation(target_uri="https://foo.com")
         expected_ids = [Annotation(target_uri="https://bar.com").id]
 
-        result = search.run({field: "https://bar.com"})
+        result = search.run(webob.multidict.MultiDict({field: "https://bar.com"}))
 
         assert sorted(result.annotation_ids) == sorted(expected_ids)
 
@@ -423,7 +423,7 @@ class TestUriFilter(object):
         expected_ids = [Annotation(target_uri="http://bar.com").id,
                         Annotation(target_uri="http://bar.com/").id]
 
-        result = search.run({"url": "http://bar.com"})
+        result = search.run(webob.multidict.MultiDict({"url": "http://bar.com"}))
 
         assert sorted(result.annotation_ids) == sorted(expected_ids)
 
@@ -431,7 +431,7 @@ class TestUriFilter(object):
         Annotation(target_uri="https://bar.com")
         expected_ids = [Annotation(target_uri="invalid-uri").id]
 
-        result = search.run({"uri": "invalid-uri"})
+        result = search.run(webob.multidict.MultiDict({"uri": "invalid-uri"}))
 
         assert sorted(result.annotation_ids) == sorted(expected_ids)
 
@@ -439,7 +439,7 @@ class TestUriFilter(object):
         expected_ids = [Annotation(target_uri="http://bar.com").id,
                         Annotation(target_uri="https://bar.com").id]
 
-        result = search.run({"url": "http://bar.com"})
+        result = search.run(webob.multidict.MultiDict({"url": "http://bar.com"}))
 
         assert sorted(result.annotation_ids) == sorted(expected_ids)
 
@@ -612,7 +612,7 @@ class TestDeletedFilter(object):
         for id_ in deleted_ids:
             index.delete(es_client, id_, refresh=True)
 
-        result = search.run({})
+        result = search.run(webob.multidict.MultiDict({}))
 
         assert sorted(result.annotation_ids) == sorted(not_deleted_ids)
 
@@ -633,7 +633,7 @@ class TestNipsaFilter(object):
         Annotation(userid=banned_user.userid)
         expected_ids = [Annotation(userid=user.userid).id]
 
-        result = search.run({})
+        result = search.run(webob.multidict.MultiDict({}))
 
         assert sorted(result.annotation_ids) == sorted(expected_ids)
 
@@ -644,7 +644,7 @@ class TestNipsaFilter(object):
         search.append_modifier(query.NipsaFilter(pyramid_request))
         expected_ids = [Annotation(userid=banned_user.userid).id]
 
-        result = search.run({})
+        result = search.run(webob.multidict.MultiDict({}))
 
         assert sorted(result.annotation_ids) == sorted(expected_ids)
 
@@ -658,7 +658,7 @@ class TestNipsaFilter(object):
         expected_ids = [Annotation(groupid="created_by_banneduser",
                                    userid=banned_user.userid).id]
 
-        result = search.run({})
+        result = search.run(webob.multidict.MultiDict({}))
 
         assert sorted(result.annotation_ids) == sorted(expected_ids)
 
@@ -693,7 +693,7 @@ class TestAnyMatcher(object):
         matched_ids = [Annotation(target_uri="http://foo.com").id,
                        Annotation(target_uri="http://foo.com/bar").id]
 
-        result = search.run({"any": "foo"})
+        result = search.run(webob.multidict.MultiDict({"any": "foo"}))
 
         assert sorted(result.annotation_ids) == sorted(matched_ids)
 
@@ -702,7 +702,7 @@ class TestAnyMatcher(object):
         matched_ids = [Annotation(target_selectors=[{'exact': 'selected foo text'}]).id,
                        Annotation(target_selectors=[{'exact': 'selected foo bar text'}]).id]
 
-        result = search.run({"any": "foo"})
+        result = search.run(webob.multidict.MultiDict({"any": "foo"}))
 
         assert sorted(result.annotation_ids) == sorted(matched_ids)
 
@@ -711,7 +711,7 @@ class TestAnyMatcher(object):
         matched_ids = [Annotation(text="foo is fun").id,
                        Annotation(text="foo is bar's friend").id]
 
-        result = search.run({"any": "foo"})
+        result = search.run(webob.multidict.MultiDict({"any": "foo"}))
 
         assert sorted(result.annotation_ids) == sorted(matched_ids)
 
@@ -720,7 +720,7 @@ class TestAnyMatcher(object):
         matched_ids = [Annotation(tags=["foo"]).id,
                        Annotation(tags=["foo", "bar"]).id]
 
-        result = search.run({"any": "foo"})
+        result = search.run(webob.multidict.MultiDict({"any": "foo"}))
 
         assert sorted(result.annotation_ids) == sorted(matched_ids)
 
@@ -774,7 +774,7 @@ class TestTagsMatcher(object):
         matched_ids = [Annotation(shared=True, tags=["foo"]).id,
                        Annotation(shared=True, tags=["foo", "bar"]).id]
 
-        result = search.run({"tag": "foo"})
+        result = search.run(webob.multidict.MultiDict({"tag": "foo"}))
 
         assert sorted(result.annotation_ids) == sorted(matched_ids)
 
@@ -784,7 +784,7 @@ class TestTagsMatcher(object):
         matched_ids = [Annotation(shared=True, tags=["foo"]).id,
                        Annotation(shared=True, tags=["foo", "bar"]).id]
 
-        result = search.run({"tags": "foo"})
+        result = search.run(webob.multidict.MultiDict({"tags": "foo"}))
 
         assert sorted(result.annotation_ids) == sorted(matched_ids)
 
@@ -829,7 +829,7 @@ class TestRepliesMatcher(object):
 
         ann_ids = [ann1.id, ann2.id]
         search.append_modifier(query.RepliesMatcher(ann_ids))
-        result = search.run({})
+        result = search.run(webob.multidict.MultiDict({}))
 
         assert sorted(result.annotation_ids) == sorted(expected_reply_ids)
 
@@ -843,7 +843,7 @@ class TestRepliesMatcher(object):
 
         ann_ids = [ann1.id]
         search.append_modifier(query.RepliesMatcher(ann_ids))
-        result = search.run({})
+        result = search.run(webob.multidict.MultiDict({}))
 
         assert sorted(result.annotation_ids) == sorted(expected_reply_ids)
 
@@ -855,7 +855,7 @@ class TestTagsAggregation(object):
         Annotation(tags=["tag_b"])
 
         search.append_aggregation(query.TagsAggregation())
-        result = search.run({})
+        result = search.run(webob.multidict.MultiDict({}))
 
         tag_results = result.aggregations["tags"]
         count_for_tag_a = next(r for r in tag_results if r["tag"] == "tag_a")["count"]
@@ -875,7 +875,7 @@ class TestTagsAggregation(object):
             Annotation(tags=["tag_c"])
 
         search.append_aggregation(query.TagsAggregation(bucket_limit))
-        result = search.run({})
+        result = search.run(webob.multidict.MultiDict({}))
 
         tag_results = result.aggregations["tags"]
         count_for_tag_b = next(r for r in tag_results if r["tag"] == "tag_b")["count"]
@@ -893,7 +893,7 @@ class TestUsersAggregation(object):
         Annotation(userid="acct:pb@example.com")
 
         search.append_aggregation(query.UsersAggregation())
-        result = search.run({})
+        result = search.run(webob.multidict.MultiDict({}))
 
         users_results = result.aggregations["users"]
         count_pa = next(r for r in users_results if r["user"] == "acct:pa@example.com")["count"]
@@ -913,7 +913,7 @@ class TestUsersAggregation(object):
             Annotation(userid="acct:pc@example.com")
 
         search.append_aggregation(query.UsersAggregation(limit=bucket_limit))
-        result = search.run({})
+        result = search.run(webob.multidict.MultiDict({}))
 
         users_results = result.aggregations["users"]
         count_pb = next(r for r in users_results if r["user"] == "acct:pb@example.com")["count"]

--- a/tests/h/views/badge_test.py
+++ b/tests/h/views/badge_test.py
@@ -6,6 +6,7 @@ import pytest
 import mock
 
 from pyramid import httpexceptions
+from webob.multidict import MultiDict
 
 from h.views.badge import badge
 
@@ -23,7 +24,7 @@ def test_badge_returns_number_from_search(models, pyramid_request, search_run, m
 
     result = badge(pyramid_request)
 
-    search_run.assert_called_once_with({'uri': 'http://example.com', 'limit': 0})
+    search_run.assert_called_once_with(MultiDict({'uri': 'http://example.com', 'limit': 0}))
     assert result == {'total': 29}
 
 


### PR DESCRIPTION
Previously each modifier had essentially the same code to extact
all values of the same key from the params multidict, now they just
call popall(key) instead.

Some of the tests were passing in a dict-type value for params instead of
a MultiDict-type. This change forces the params to now be a MultiDict as it
uses a MultiDict-only method called getall().

Previously Search did not mutate the params dict but instead made an initial copy,
now Search modifies the params passed in directly which means the code the calls
Search.run must pass a mutable MultiDict to Search. The description of param in
Search.run was also updated to reflect this change. Coping is expensive and not always
necessary (plus only 1 out of 4 cases where Search was used depended on this behavior) 
so it's better to let the code calling Search decide whether it needs to do this.