### PR TITLE
Add note about supported Python versions

### DIFF
--- a/docs/developing/install.rst
+++ b/docs/developing/install.rst
@@ -189,6 +189,9 @@ Install ``gulp-cli`` to get the ``gulp`` command:
 Creating a Python virtual environment
 -------------------------------------
 
+h requires either Python 2.7 or Python 3.6. Python >= 3.7 is not yet supported
+by some of h's dependencies.
+
 Create a Python virtual environment to install and run the h Python code and
 Python dependencies in:
 


### PR DESCRIPTION
Very recent distributions and homebrew on macOS will have Python 3.7
which is not yet supported. Advise readers about this issue.

If we switch to using tox by default, removing the need to create and manage a virtualenv, I think we should still have a general note about the Python environment.