### PR TITLE
Add security warning on admin/create-oauth-client form

### DIFF
--- a/h/static/styles/admin.scss
+++ b/h/static/styles/admin.scss
@@ -13,6 +13,7 @@
 @import 'partials/search-form';
 @import 'partials/svg-icon';
 @import 'partials/tooltip';
+@import 'partials/warning-box';
 
 .flashbar {
   margin-top: 20px;

--- a/h/static/styles/partials/_warning-box.scss
+++ b/h/static/styles/partials/_warning-box.scss
@@ -1,0 +1,9 @@
+.warning-box {
+  background-color: #fff4aa;
+  border: 1px solid orange;
+  border-radius: 3px;
+  margin-bottom: 20px;
+  padding-left: 10px;
+  padding-right: 10px;
+}
+

--- a/h/templates/admin/oauthclients_create.html.jinja2
+++ b/h/templates/admin/oauthclients_create.html.jinja2
@@ -4,18 +4,20 @@
 {% set page_title = 'Create OAuth client' %}
 
 {% block content %}
-<h3>Security Warning</h3>
+<div class="warning-box">
+  <h3>Security Warning</h3>
 
-<p>Be especially careful and thoughtful when creating OAuth clients with grant type of
-<code>client_credentials</code> (a.k.a. "auth_client" credentials), as these grant
-significant powers:</p>
+  <p>Be especially careful and thoughtful when creating OAuth clients with grant type of
+  <code>client_credentials</code> (a.k.a. "auth_client" credentials), as these grant
+  significant powers:</p>
 
-<ul>
-  <li>Do not store this type of credentials in unencrypted form; share them securely only with their intended users.</li>
-  <li>These credentials grant the ability to create and manipulate all users and other resources (groups, e.g.) within <strong>an entire authority</strong>.</li>
-  <li>These credentials are intended for third parties. Creating <code>client_credentials</code>
-      for the "hypothes.is" authority would grant keys to the entire kingdom of first-party users.</li>
-</ul>
+  <ul>
+    <li>Do not store this type of credentials in unencrypted form; share them securely only with their intended users.</li>
+    <li>These credentials grant the ability to create and manipulate all users and other resources (groups, e.g.) within <strong>an entire authority</strong>.</li>
+    <li>These credentials are intended for third parties. Creating <code>client_credentials</code>
+        for the "hypothes.is" authority would grant keys to the entire kingdom of first-party users.</li>
+  </ul>
+</div>
 
   {{ form }}
 {% endblock content %}

--- a/h/templates/admin/oauthclients_create.html.jinja2
+++ b/h/templates/admin/oauthclients_create.html.jinja2
@@ -4,5 +4,18 @@
 {% set page_title = 'Create OAuth client' %}
 
 {% block content %}
+<h3>Security Warning</h3>
+
+<p>Be especially careful and thoughtful when creating OAuth clients with grant type of
+<code>client_credentials</code> (a.k.a. "auth_client" credentials), as these grant
+significant powers:</p>
+
+<ul>
+  <li>Do not store this type of credentials in unencrypted form; share them securely only with their intended users.</li>
+  <li>These credentials grant the ability to create and manipulate all users and other resources (groups, e.g.) within <strong>an entire authority</strong>.</li>
+  <li>These credentials are intended for third parties. Creating <code>client_credentials</code>
+      for the "hypothes.is" authority would grant keys to the entire kingdom of first-party users.</li>
+</ul>
+
   {{ form }}
 {% endblock content %}


### PR DESCRIPTION
This PR adds some warning text to the admin page for creating OAuth clients. We're a little hamstrung by colander and our current form templates (I'd like to have put this explanation as part of the description/text for the client_credentials field but that's not very easy at present). Anyway! I hope this suffices—here's a screenshot of the relevant part of the form:

<img width="1217" alt="screen shot 2018-09-26 at 10 41 09 am" src="https://user-images.githubusercontent.com/439947/46087617-b6170b80-c178-11e8-8952-1246d1c32f02.png">


Fixes https://github.com/hypothesis/product-backlog/issues/794