### PR TITLE
Revert "Add new HiddenFilter to filter annotations which are moderated or belong to a nipsaed user."

### DIFF
--- a/h/presenters/annotation_searchindex.py
+++ b/h/presenters/annotation_searchindex.py
@@ -44,14 +44,13 @@ class AnnotationSearchIndexPresenter(AnnotationBasePresenter):
         # Mark an annotation as hidden if it and all of it's children have been
         # moderated and hidden.
         result['hidden'] = False
-
-        ann_mod_svc = self.request.find_service(name='annotation_moderation')
-        result['hidden'] = ann_mod_svc.hidden(self.annotation)
-
         if self.annotation.thread_ids:
-            are_all_replies_hidden = len(ann_mod_svc.all_hidden(self.annotation.thread_ids)) == len(self.annotation.thread_ids)
+            ann_mod_svc = self.request.find_service(name='annotation_moderation')
+            annotation_hidden = ann_mod_svc.hidden(self.annotation)
+            thread_ids_hidden = len(ann_mod_svc.all_hidden(self.annotation.thread_ids)) == len(self.annotation.thread_ids)
 
-            result['hidden'] = result['hidden'] and are_all_replies_hidden
+            if annotation_hidden and thread_ids_hidden:
+                result['hidden'] = True
 
         return result
 

--- a/h/search/core.py
+++ b/h/search/core.py
@@ -48,7 +48,7 @@ class Search(object):
                            query.GroupFilter(),
                            query.GroupAuthFilter(request),
                            query.UserFilter(),
-                           query.HiddenFilter(request),
+                           query.NipsaFilter(request),
                            query.AnyMatcher(),
                            query.TagsMatcher(),
                            query.KeyValueMatcher()]

--- a/h/search/query.py
+++ b/h/search/query.py
@@ -392,18 +392,19 @@ class DeletedFilter(object):
         return search.exclude("exists", field="deleted")
 
 
-class HiddenFilter(object):
-    """Return an Elasticsearch filter for filtering out moderated or NIPSA'd annotations."""
+class NipsaFilter(object):
+    """Return an Elasticsearch filter for filtering out NIPSA'd annotations."""
 
     def __init__(self, request):
         self.group_service = request.find_service(name='group')
         self.user = request.user
 
     def __call__(self, search, _):
-        """Filter out all hidden and NIPSA'd annotations except the current user's."""
-        # If any one of the "should" clauses is true then the annotation will
-        # get through these filter.
-        should_clauses = [Q("bool", must_not=Q("term", nipsa=True), must=Q("term", hidden=False))]
+        """Filter out all NIPSA'd annotations except the current user's."""
+        # If any one of these "should" clauses is true then the annotation will
+        # get through the filter.
+        should_clauses = [Q("bool", must_not=Q("term", nipsa=True)),
+                          Q("exists", field="thread_ids")]
 
         if self.user is not None:
             # Always show the logged-in user's annotations even if they have nipsa.

--- a/tests/h/presenters/annotation_searchindex_test.py
+++ b/tests/h/presenters/annotation_searchindex_test.py
@@ -123,9 +123,7 @@ class TestAnnotationSearchIndexPresenter(object):
         assert annotation_dict['hidden'] is False
 
     def test_it_marks_annotation_hidden_when_moderated_and_no_replies(self, pyramid_request, moderation_service):
-        thread_ids = []
-        annotation = mock.MagicMock(userid='acct:luke@hypothes.is',
-                                    thread_ids=thread_ids)
+        annotation = mock.MagicMock(userid='acct:luke@hypothes.is')
 
         moderation_service.hidden.return_value = True
 

--- a/tests/h/search/conftest.py
+++ b/tests/h/search/conftest.py
@@ -6,7 +6,6 @@ import pytest
 
 import h.search.index
 from h.services.group import GroupService
-from h.services.annotation_moderation import AnnotationModerationService
 
 
 @pytest.fixture(autouse=True)
@@ -15,15 +14,6 @@ def group_service(pyramid_config):
     group_service.groupids_readable_by.return_value = ["__world__"]
     pyramid_config.register_service(group_service, name="group")
     return group_service
-
-
-@pytest.fixture(autouse=True)
-def moderation_service(pyramid_config):
-    svc = mock.create_autospec(AnnotationModerationService, spec_set=True, instance=True)
-    svc.all_hidden.return_value = []
-    svc.hidden.return_value = False
-    pyramid_config.register_service(svc, name='annotation_moderation')
-    return svc
 
 
 @pytest.fixture

--- a/tests/h/search/index_test.py
+++ b/tests/h/search/index_test.py
@@ -10,11 +10,12 @@ import mock
 import pytest
 
 import h.search.index
+from h.services.annotation_moderation import AnnotationModerationService
 
 from tests.common.matchers import Matcher
 
 
-@pytest.mark.usefixtures("annotations")
+@pytest.mark.usefixtures("annotations", "moderation_service")
 class TestIndex(object):
     def test_annotation_ids_are_used_as_elasticsearch_ids(self, es_client,
                                                           factories,
@@ -494,3 +495,12 @@ def get_indexed_ann(es_client):
             index=es_client.index, doc_type=es_client.mapping_type,
             id=annotation_id)["_source"]
     return _get
+
+
+@pytest.fixture
+def moderation_service(pyramid_config):
+    svc = mock.create_autospec(AnnotationModerationService, spec_set=True, instance=True)
+    svc.all_hidden.return_value = []
+    svc.hidden.return_value = False
+    pyramid_config.register_service(svc, name='annotation_moderation')
+    return svc


### PR DESCRIPTION
Reverts hypothesis/h#5309

Testing on QA surfaced the problem that even though annotations were getting marked as hidden at the time of indexing, the act of moderating an annotation did not update the value hidden field. `h\nipsa\subscribers.py` has logic which updates the `nipsa` field, we should be updating the `hidden` field there as well.
Will submit a PR for that change so that we can rebase and merge this branch after that branch has been merged.