### PR TITLE
Add update-user permission; use AuthClient auth'n for `PATCH /api/user/{username}`

### DIFF
--- a/h/auth/policy.py
+++ b/h/auth/policy.py
@@ -17,6 +17,7 @@ AUTH_CLIENT_API_WHITELIST = [
     ('api.groups', 'POST'),
     ('api.group_member', 'POST'),
     ('api.users', 'POST'),
+    ('api.user', 'PATCH'),
 ]
 
 

--- a/h/models/user.py
+++ b/h/models/user.py
@@ -7,6 +7,7 @@ import re
 import sqlalchemy as sa
 from sqlalchemy.ext.hybrid import Comparator, hybrid_property
 from sqlalchemy.ext.declarative import declared_attr
+from pyramid import security
 
 from h._compat import string_types
 from h.db import Base
@@ -313,6 +314,18 @@ class User(Base):
             cls.username == username,
             cls.authority == authority,
         ).first()
+
+    def __acl__(self):
+        terms = []
+
+        # auth_clients that have the same authority as the user
+        # may update the user
+        user_update_principal = "client_authority:{}".format(self.authority)
+        terms.append((security.Allow, user_update_principal, 'update'))
+
+        terms.append(security.DENY_ALL)
+
+        return terms
 
     def __repr__(self):
         return '<User: %s>' % self.username

--- a/h/routes.py
+++ b/h/routes.py
@@ -118,7 +118,10 @@ def includeme(config):
     config.add_route('api.users',
                      '/api/users',
                      factory='h.traversal.UserRoot')
-    config.add_route('api.user', '/api/users/{username}')
+    config.add_route('api.user',
+                     '/api/users/{username}',
+                     factory='h.traversal.UserRoot',
+                     traverse='/{username}')
     config.add_route('badge', '/api/badge')
     config.add_route('token', '/api/token')
     config.add_route('oauth_authorize', '/oauth/authorize')

--- a/h/traversal/roots.py
+++ b/h/traversal/roots.py
@@ -76,6 +76,7 @@ from h.models import AuthClient
 from h.models import Group
 from h.models import Organization
 from h.auth import role
+from h.auth.util import client_authority
 from h.interfaces import IGroupService
 from h.traversal import contexts
 
@@ -220,8 +221,8 @@ class UserRoot(object):
         self.user_svc = self.request.find_service(name='user')
 
     def __getitem__(self, username):
-        # FIXME: At present, this fetch would never work for third-party users
-        user = self.user_svc.fetch(username, self.request.default_authority)
+        authority = client_authority(self.request) or self.request.default_authority
+        user = self.user_svc.fetch(username, authority)
 
         if not user:
             raise KeyError()

--- a/h/views/api/users.py
+++ b/h/views/api/users.py
@@ -2,7 +2,7 @@
 
 from __future__ import unicode_literals
 
-from h.auth.util import request_auth_client, client_authority
+from h.auth.util import client_authority
 from h.exceptions import PayloadError, ConflictError
 from h.presenters import UserJSONPresenter
 from h.schemas.api.user import CreateUserAPISchema, UpdateUserAPISchema
@@ -56,7 +56,9 @@ def create(request):
     return presenter.asdict()
 
 
-@json_view(route_name='api.user', request_method='PATCH')
+@json_view(route_name='api.user',
+           request_method='PATCH',
+           permission='update')
 def update(user, request):
     """
     Update a user.
@@ -64,8 +66,6 @@ def update(user, request):
     This API endpoint allows authorised clients (those able to provide a valid
     Client ID and Client Secret) to update users in their authority.
     """
-    request_auth_client(request)
-
     schema = UpdateUserAPISchema()
     appstruct = schema.validate(_json_payload(request))
 

--- a/h/views/api/users.py
+++ b/h/views/api/users.py
@@ -2,8 +2,6 @@
 
 from __future__ import unicode_literals
 
-from pyramid.exceptions import HTTPNotFound
-
 from h.auth.util import request_auth_client, client_authority
 from h.exceptions import PayloadError, ConflictError
 from h.presenters import UserJSONPresenter
@@ -59,20 +57,14 @@ def create(request):
 
 
 @json_view(route_name='api.user', request_method='PATCH')
-def update(request):
+def update(user, request):
     """
     Update a user.
 
     This API endpoint allows authorised clients (those able to provide a valid
     Client ID and Client Secret) to update users in their authority.
     """
-    client = request_auth_client(request)
-
-    user_svc = request.find_service(name='user')
-    user = user_svc.fetch(request.matchdict['username'],
-                          client.authority)
-    if user is None:
-        raise HTTPNotFound()
+    request_auth_client(request)
 
     schema = UpdateUserAPISchema()
     appstruct = schema.validate(_json_payload(request))

--- a/tests/functional/api/test_users.py
+++ b/tests/functional/api/test_users.py
@@ -84,12 +84,12 @@ class TestUpdateUser(object):
         assert res.json_body['email'] == patch_user_payload['email']
         assert res.json_body['display_name'] == patch_user_payload['display_name']
 
-    def test_it_returns_http_403_if_auth_client_missing(self, app, user, patch_user_payload):
+    def test_it_returns_http_404_if_auth_client_missing(self, app, user, patch_user_payload):
         url = "/api/users/{username}".format(username=user.username)
 
         res = app.patch_json(url, patch_user_payload, expect_errors=True)
 
-        assert res.status_code == 403
+        assert res.status_code == 404
 
     def test_it_returns_http_404_if_user_not_in_client_authority(self,
                                                                  app,

--- a/tests/functional/api/test_users.py
+++ b/tests/functional/api/test_users.py
@@ -66,12 +66,60 @@ class TestCreateUser(object):
         assert res.status_code == 409
 
 
+@pytest.mark.functional
+class TestUpdateUser(object):
+
+    def test_it_returns_http_200_when_successful(self, app, auth_client_header, user, patch_user_payload):
+        url = "/api/users/{username}".format(username=user.username)
+
+        res = app.patch_json(url, patch_user_payload, headers=auth_client_header)
+
+        assert res.status_code == 200
+
+    def test_it_returns_updated_user_when_successful(self, app, auth_client_header, user, patch_user_payload):
+        url = "/api/users/{username}".format(username=user.username)
+
+        res = app.patch_json(url, patch_user_payload, headers=auth_client_header)
+
+        assert res.json_body['email'] == patch_user_payload['email']
+        assert res.json_body['display_name'] == patch_user_payload['display_name']
+
+    def test_it_returns_http_403_if_auth_client_missing(self, app, user, patch_user_payload):
+        url = "/api/users/{username}".format(username=user.username)
+
+        res = app.patch_json(url, patch_user_payload, expect_errors=True)
+
+        assert res.status_code == 403
+
+    def test_it_returns_http_404_if_user_not_in_client_authority(self,
+                                                                 app,
+                                                                 auth_client_header,
+                                                                 user,
+                                                                 patch_user_payload,
+                                                                 db_session):
+        user.authority = 'somewhere.com'
+        db_session.commit()
+        url = "/api/users/{username}".format(username=user.username)
+
+        res = app.patch_json(url, patch_user_payload, headers=auth_client_header, expect_errors=True)
+
+        assert res.status_code == 404
+
+
 @pytest.fixture
 def user_payload():
     return {
         "username": "filip",
         "email": "filip@example.com",
         "authority": "example.com"
+    }
+
+
+@pytest.fixture
+def patch_user_payload():
+    return {
+        "email": "filip@example2.com",
+        "display_name": "Filip Pilip",
     }
 
 

--- a/tests/h/routes_test.py
+++ b/tests/h/routes_test.py
@@ -96,7 +96,7 @@ def test_includeme():
         call('api.group_member', '/api/groups/{pubid}/members/{userid}', factory='h.traversal.GroupRoot', traverse='/{pubid}'),
         call('api.search', '/api/search'),
         call('api.users', '/api/users', factory='h.traversal.UserRoot'),
-        call('api.user', '/api/users/{username}'),
+        call('api.user', '/api/users/{username}', factory='h.traversal.UserRoot', traverse='/{username}'),
         call('badge', '/api/badge'),
         call('token', '/api/token'),
         call('oauth_authorize', '/oauth/authorize'),

--- a/tests/h/views/api/users_test.py
+++ b/tests/h/views/api/users_test.py
@@ -114,7 +114,6 @@ class TestCreate(object):
 
 
 @pytest.mark.usefixtures('auth_client',
-                         'request_auth_client',
                          'user_svc',
                          'user')
 class TestUpdate(object):
@@ -223,13 +222,6 @@ class TestUpdate(object):
 def auth_client(factories):
     return factories.ConfidentialAuthClient(authority='weylandindustries.com',
                                             grant_type=GrantType.client_credentials)
-
-
-@pytest.fixture
-def request_auth_client(patch, auth_client):
-    request_auth_client = patch('h.views.api.users.request_auth_client')
-    request_auth_client.return_value = auth_client
-    return request_auth_client
 
 
 @pytest.fixture

--- a/tests/h/views/api/users_test.py
+++ b/tests/h/views/api/users_test.py
@@ -5,8 +5,6 @@ from __future__ import unicode_literals
 import pytest
 import mock
 
-from pyramid.exceptions import HTTPNotFound
-
 from h.exceptions import PayloadError, ConflictError
 from h.models.auth_client import GrantType
 from h.schemas import ValidationError
@@ -122,13 +120,13 @@ class TestCreate(object):
 class TestUpdate(object):
     def test_it_updates_display_name(self, pyramid_request, valid_payload, user):
         pyramid_request.json_body = valid_payload
-        update(pyramid_request)
+        update(user, pyramid_request)
 
         assert user.display_name == 'Jeremy Weyland'
 
     def test_it_updates_email(self, pyramid_request, valid_payload, user):
         pyramid_request.json_body = valid_payload
-        update(pyramid_request)
+        update(user, pyramid_request)
 
         assert user.email == 'jeremy@weylandtech.com'
 
@@ -141,7 +139,7 @@ class TestUpdate(object):
         valid_payload['display_name'] = 'new_display_name'
         pyramid_request.json_body = valid_payload
 
-        update(pyramid_request)
+        update(user, pyramid_request)
 
         assert user.display_name == 'new_display_name'
         assert user.email is None
@@ -155,51 +153,45 @@ class TestUpdate(object):
         valid_payload['email'] = 'new@new.com'
         pyramid_request.json_body = valid_payload
 
-        update(pyramid_request)
+        update(user, pyramid_request)
 
         assert user.email == 'new@new.com'
 
     def test_it_presents_user(self, pyramid_request, valid_payload, user, presenter):
         pyramid_request.json_body = valid_payload
-        update(pyramid_request)
+        update(user, pyramid_request)
 
         presenter.assert_called_once_with(user)
 
     def test_it_returns_presented_user(self, pyramid_request, valid_payload, presenter):
         pyramid_request.json_body = valid_payload
-        result = update(pyramid_request)
+        result = update(user, pyramid_request)
 
         assert result == presenter.return_value.asdict()
 
-    def test_raises_404_when_user_not_found(self, pyramid_request, valid_payload):
-        pyramid_request.matchdict['username'] = 'missing'
-
-        with pytest.raises(HTTPNotFound):
-            update(pyramid_request)
-
-    def test_it_validates_the_input(self, pyramid_request, valid_payload, UpdateUserAPISchema):
+    def test_it_validates_the_input(self, user, pyramid_request, valid_payload, UpdateUserAPISchema):
         update_schema = UpdateUserAPISchema.return_value
         update_schema.validate.return_value = valid_payload
         pyramid_request.json_body = valid_payload
 
-        update(pyramid_request)
+        update(user, pyramid_request)
 
         update_schema.validate.assert_called_once_with(valid_payload)
 
-    def test_raises_when_schema_validation_fails(self, pyramid_request, valid_payload, UpdateUserAPISchema):
+    def test_raises_when_schema_validation_fails(self, user, pyramid_request, valid_payload, UpdateUserAPISchema):
         update_schema = UpdateUserAPISchema.return_value
         update_schema.validate.side_effect = ValidationError('validation failed')
 
         pyramid_request.json_body = valid_payload
 
         with pytest.raises(ValidationError):
-            update(pyramid_request)
+            update(user, pyramid_request)
 
-    def test_raises_for_invalid_json_body(self, pyramid_request, patch):
+    def test_raises_for_invalid_json_body(self, user, pyramid_request, patch):
         type(pyramid_request).json_body = mock.PropertyMock(side_effect=ValueError())
 
         with pytest.raises(PayloadError):
-            update(pyramid_request)
+            update(user, pyramid_request)
 
     @pytest.fixture
     def pyramid_request(self, pyramid_request, user):


### PR DESCRIPTION
This is the last chunky PR (hooray!) for moving auth-client endpoints behind Pyramid authn and authz instead of view-level logic. In summary, these changes remove the view-level logic from the `PATCH /api/user/{username}` view handler and use a `permission` (`update`) that is set on appropriate auth_clients from `h.models.User`'s ACL. The PATCH-user route now also uses Pyramid traversal.

In this PR:

* PATCH-user had no functional tests. Remedied.
* A change to `UserRoot`'s `__getitem__` such that it will search for a user against a `client_authority` if one is active instead of always using the default authority. `UserRoot` is used for traversal in one other place in the code: user activity view. As `client_authority` is only ever set for a specific subset of whitelisted API endpoints, I believe this a "safe" change to make.
* An addition of an `__acl__` to `h.models.User`. While not ideal—I would think we'd like to get ACL stuff out of the model level—it's necessary for the interim until we can clean up the traversal/context stuff (which may well be blocked until we untangle activity pages). This ACL assigns an `update` permission to auth_clients with an authority that matches that of the user. This permission will only ever get assigned for requests that route to the whitelisted AuthClient API routes.
* Addition of `UserRoot` and traversal to the PATCH-user route
* Removal of view-level auth logic from PATCH-user view handler
* Updates to tests (in large part to account for the `user` context now provided to the view because of traversal

----

Expected behavior:

* 404 if bad client auth credentials or a mismatch of authorities with the `username` param, or a non-existent user overall
* 400 if bad or missing payload
* 200 with JSON body of resulting user record on success
