### PR TITLE
Factor out `links` module in `h.views.api`

### DIFF
--- a/h/views/api/annotations.py
+++ b/h/views/api/annotations.py
@@ -34,36 +34,9 @@ from h.schemas.annotation import (
     CreateAnnotationSchema,
     SearchParamsSchema,
     UpdateAnnotationSchema)
-from h.views.api.config import api_config, AngularRouteTemplater
+from h.views.api.config import api_config
 
 _ = i18n.TranslationStringFactory(__package__)
-
-
-@api_config(route_name='api.links',
-            link_name='links',
-            renderer='json_sorted',
-            description='URL templates for generating URLs for HTML pages')
-def links(context, request):
-    templater = AngularRouteTemplater(request.route_url, params=['user'])
-
-    tag_search_url = request.route_url('activity.search',
-                                       _query={'q': '_query_'})
-    tag_search_url = tag_search_url.replace('_query_', 'tag:":tag"')
-
-    oauth_authorize_url = request.route_url('oauth_authorize')
-    oauth_revoke_url = request.route_url('oauth_revoke')
-
-    return {
-        'account.settings': request.route_url('account'),
-        'forgot-password': request.route_url('forgot_password'),
-        'groups.new': request.route_url('group_create'),
-        'help': request.route_url('help'),
-        'oauth.authorize': oauth_authorize_url,
-        'oauth.revoke': oauth_revoke_url,
-        'search.tag': tag_search_url,
-        'signup': request.route_url('signup'),
-        'user': templater.route_template('stream.user_query'),
-    }
 
 
 @api_config(route_name='api.search',

--- a/h/views/api/links.py
+++ b/h/views/api/links.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from h.views.api.config import api_config, AngularRouteTemplater
+
+
+@api_config(route_name='api.links',
+            link_name='links',
+            renderer='json_sorted',
+            description='URL templates for generating URLs for HTML pages')
+def links(context, request):
+    templater = AngularRouteTemplater(request.route_url, params=['user'])
+
+    tag_search_url = request.route_url('activity.search',
+                                       _query={'q': '_query_'})
+    tag_search_url = tag_search_url.replace('_query_', 'tag:":tag"')
+
+    oauth_authorize_url = request.route_url('oauth_authorize')
+    oauth_revoke_url = request.route_url('oauth_revoke')
+
+    return {
+        'account.settings': request.route_url('account'),
+        'forgot-password': request.route_url('forgot_password'),
+        'groups.new': request.route_url('group_create'),
+        'help': request.route_url('help'),
+        'oauth.authorize': oauth_authorize_url,
+        'oauth.revoke': oauth_revoke_url,
+        'search.tag': tag_search_url,
+        'signup': request.route_url('signup'),
+        'user': templater.route_template('stream.user_query'),
+    }

--- a/tests/h/views/api/annotations_test.py
+++ b/tests/h/views/api/annotations_test.py
@@ -5,40 +5,9 @@ import mock
 import pytest
 from webob.multidict import NestedMultiDict, MultiDict
 
-from pyramid import testing
-
 from h.schemas import ValidationError
 from h.search.core import SearchResult
 from h.views.api import annotations as views
-
-
-class TestLinks(object):
-
-    def test_it_returns_the_right_links(self, pyramid_config, pyramid_request):
-        pyramid_config.add_route('account', '/account/settings')
-        pyramid_config.add_route('forgot_password', '/forgot-password')
-        pyramid_config.add_route('group_create', '/groups/new')
-        pyramid_config.add_route('help', '/docs/help')
-        pyramid_config.add_route('oauth_authorize', '/oauth/authorize')
-        pyramid_config.add_route('oauth_revoke', '/oauth/revoke')
-        pyramid_config.add_route('activity.search', '/search')
-        pyramid_config.add_route('signup', '/signup')
-        pyramid_config.add_route('stream.user_query', '/u/{user}')
-
-        links = views.links(testing.DummyResource(), pyramid_request)
-
-        host = 'http://example.com'  # Pyramid's default host URL.
-        assert links == {
-            'account.settings': host + '/account/settings',
-            'forgot-password': host + '/forgot-password',
-            'groups.new': host + '/groups/new',
-            'help': host + '/docs/help',
-            'oauth.authorize': host + '/oauth/authorize',
-            'oauth.revoke': host + '/oauth/revoke',
-            'search.tag': host + '/search?q=tag:":tag"',
-            'signup': host + '/signup',
-            'user': host + '/u/:user',
-        }
 
 
 @pytest.mark.usefixtures('presentation_service', 'search_lib')

--- a/tests/h/views/api/links_test.py
+++ b/tests/h/views/api/links_test.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from pyramid import testing
+
+from h.views.api import links as views
+
+
+class TestLinks(object):
+
+    def test_it_returns_the_right_links(self, pyramid_config, pyramid_request):
+        pyramid_config.add_route('account', '/account/settings')
+        pyramid_config.add_route('forgot_password', '/forgot-password')
+        pyramid_config.add_route('group_create', '/groups/new')
+        pyramid_config.add_route('help', '/docs/help')
+        pyramid_config.add_route('oauth_authorize', '/oauth/authorize')
+        pyramid_config.add_route('oauth_revoke', '/oauth/revoke')
+        pyramid_config.add_route('activity.search', '/search')
+        pyramid_config.add_route('signup', '/signup')
+        pyramid_config.add_route('stream.user_query', '/u/{user}')
+
+        links = views.links(testing.DummyResource(), pyramid_request)
+
+        host = 'http://example.com'  # Pyramid's default host URL.
+        assert links == {
+            'account.settings': host + '/account/settings',
+            'forgot-password': host + '/forgot-password',
+            'groups.new': host + '/groups/new',
+            'help': host + '/docs/help',
+            'oauth.authorize': host + '/oauth/authorize',
+            'oauth.revoke': host + '/oauth/revoke',
+            'search.tag': host + '/search?q=tag:":tag"',
+            'signup': host + '/signup',
+            'user': host + '/u/:user',
+        }


### PR DESCRIPTION
Today's quick refactor: this PR factors out a `links` module in `h.views.api`, separating it out of the large `annotations` module.