### PR TITLE
WIP: Remove auth client logic

### DIFF
--- a/h/auth/util.py
+++ b/h/auth/util.py
@@ -11,7 +11,6 @@ from pyramid import security
 from h.auth import role
 from h._compat import text_type
 from h.models.auth_client import GrantType, AuthClient
-from h.schemas import ValidationError
 
 
 def groupfinder(userid, request):
@@ -167,11 +166,3 @@ def principals_for_auth_client_user(user, client):
     distinct_principals = list(set(all_principals))
 
     return distinct_principals
-
-
-def validate_auth_client_authority(client, authority):
-    """
-    Validate that the auth client authority matches the provided ``authority``.
-    """
-    if client.authority != authority:
-        raise ValidationError("'authority' does not match authenticated client")

--- a/h/auth/util.py
+++ b/h/auth/util.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import unicode_literals
-import base64
 import re
 
 import hmac
@@ -13,42 +12,6 @@ from h.auth import role
 from h._compat import text_type
 from h.models.auth_client import GrantType, AuthClient
 from h.schemas import ValidationError
-
-
-def basic_auth_creds(request):
-    """
-    Extract any HTTP Basic authentication credentials for the request.
-
-    Returns a tuple with the HTTP Basic access authentication credentials
-    ``(username, password)`` if provided, otherwise ``None``.
-
-    :param request: the request object
-    :type request: pyramid.request.Request
-
-    :returns: a tuple of (username, password) or None
-    :rtype: tuple or NoneType
-    """
-    try:
-        authtype, value = request.authorization
-    except TypeError:  # no authorization header
-        return None
-    if authtype.lower() != 'basic':
-        return None
-    try:
-        user_pass_bytes = base64.standard_b64decode(value)
-    except TypeError:  # failed to decode
-        return None
-    try:
-        # See the lengthy comment in the tests about why we assume UTF-8
-        # encoding here.
-        user_pass = user_pass_bytes.decode('utf-8')
-    except UnicodeError:  # not UTF-8
-        return None
-    try:
-        username, password = user_pass.split(':', 1)
-    except ValueError:  # not enough values to unpack
-        return None
-    return (username, password)
 
 
 def groupfinder(userid, request):

--- a/tests/h/auth/util_test.py
+++ b/tests/h/auth/util_test.py
@@ -2,14 +2,10 @@
 
 from __future__ import unicode_literals
 
-import base64
 from collections import namedtuple
-from h._compat import unichr
 
 import pytest
 import mock
-from hypothesis import strategies as st
-from hypothesis import given
 import sqlalchemy as sa
 
 from pyramid import security
@@ -24,82 +20,6 @@ from h.services.user import UserService
 
 FakeUser = namedtuple('FakeUser', ['authority', 'admin', 'staff', 'groups'])
 FakeGroup = namedtuple('FakeGroup', ['pubid'])
-
-# The most recent standard covering the 'Basic' HTTP Authentication scheme is
-# RFC 7617. It defines the allowable characters in usernames and passwords as
-# follows:
-#
-#     The user-id and password MUST NOT contain any control characters (see
-#     "CTL" in Appendix B.1 of [RFC5234]).
-#
-# RFC5234 defines CTL as:
-#
-#     CTL            =  %x00-1F / %x7F
-#
-CONTROL_CHARS = set(unichr(n) for n in range(0x00, 0x1F + 1)) | set('\x7f')
-
-# We assume user ID and password strings are UTF-8 and surrogates are not
-# allowed in UTF-8.
-SURROGATE_CHARS = set(unichr(n) for n in range(0xD800, 0xDBFF + 1)) | \
-                  set(unichr(n) for n in range(0xDC00, 0xDFFF + 1))
-INVALID_USER_PASS_CHARS = CONTROL_CHARS | SURROGATE_CHARS
-
-# Furthermore, from RFC 7617:
-#
-#     a user-id containing a colon character is invalid
-#
-INVALID_USERNAME_CHARS = INVALID_USER_PASS_CHARS | set(':')
-
-# The character encoding of the user-id and password is *undefined* by
-# specification for historical reasons:
-#
-#     The original definition of this authentication scheme failed to specify
-#     the character encoding scheme used to convert the user-pass into an
-#     octet sequence.  In practice, most implementations chose either a
-#     locale-specific encoding such as ISO-8859-1 ([ISO-8859-1]), or UTF-8
-#     ([RFC3629]).  For backwards compatibility reasons, this specification
-#     continues to leave the default encoding undefined, as long as it is
-#     compatible with US-ASCII (mapping any US-ASCII character to a single
-#     octet matching the US-ASCII character code).
-#
-# In particular, Firefox still does *very* special things if you provide
-# non-BMP characters in a username or password.
-#
-# There's not a lot we can do about this so we are going to assume UTF-8
-# encoding for the user-pass string, and these tests verify that we
-# successfully decode valid Unicode user-pass strings.
-#
-VALID_USERNAME_CHARS = st.characters(blacklist_characters=INVALID_USERNAME_CHARS)
-VALID_PASSWORD_CHARS = st.characters(blacklist_characters=INVALID_USER_PASS_CHARS)
-
-
-class TestBasicAuthCreds(object):
-
-    @given(username=st.text(alphabet=VALID_USERNAME_CHARS),
-           password=st.text(alphabet=VALID_PASSWORD_CHARS))
-    def test_valid(self, username, password, pyramid_request):
-        user_pass = username + ':' + password
-        creds = ('Basic', base64.standard_b64encode(user_pass.encode('utf-8')))
-        pyramid_request.authorization = creds
-
-        assert util.basic_auth_creds(pyramid_request) == (username, password)
-
-    def test_missing(self, pyramid_request):
-        pyramid_request.authorization = None
-
-        assert util.basic_auth_creds(pyramid_request) is None
-
-    def test_no_password(self, pyramid_request):
-        creds = ('Basic', base64.standard_b64encode('foobar'.encode('utf-8')))
-        pyramid_request.authorization = creds
-
-        assert util.basic_auth_creds(pyramid_request) is None
-
-    def test_other_authorization_type(self, pyramid_request):
-        creds = ('Digest', base64.standard_b64encode('foo:bar'.encode('utf-8')))
-        pyramid_request.authorization = creds
-
-        assert util.basic_auth_creds(pyramid_request) is None
 
 
 class TestGroupfinder(object):

--- a/tests/h/auth/util_test.py
+++ b/tests/h/auth/util_test.py
@@ -15,7 +15,6 @@ from h.auth import util
 from h._compat import text_type
 from h.models.auth_client import GrantType
 from h.models import AuthClient
-from h.schemas import ValidationError
 from h.services.user import UserService
 
 FakeUser = namedtuple('FakeUser', ['authority', 'admin', 'staff', 'groups'])
@@ -140,21 +139,6 @@ class TestAuthDomain(object):
     def test_it_returns_text_type(self, pyramid_request):
         pyramid_request.domain = str(pyramid_request.domain)
         assert type(util.default_authority(pyramid_request)) == text_type
-
-
-class TestValidateAuthClientAuthority(object):
-
-    def test_raises_when_authority_doesnt_match(self, pyramid_request, auth_client):
-        authority = 'mismatched_authority'
-
-        with pytest.raises(ValidationError,
-                           match=".*authority.*does not match authenticated client"):
-            util.validate_auth_client_authority(auth_client, authority)
-
-    def test_does_not_raise_when_authority_matches(self, pyramid_request, auth_client):
-        authority = 'weylandindustries.com'
-
-        util.validate_auth_client_authority(auth_client, authority)
 
 
 class TestPrincipalsForAuthClient(object):

--- a/tests/h/views/api/users_test.py
+++ b/tests/h/views/api/users_test.py
@@ -225,11 +225,6 @@ def auth_client(factories):
 
 
 @pytest.fixture
-def validate_auth_client_authority(patch):
-    return patch('h.views.api.users.validate_auth_client_authority')
-
-
-@pytest.fixture
 def user_signup_service(db_session, pyramid_config, user):
     service = mock.Mock(spec_set=UserSignupService(default_authority='example.com',
                                               mailer=None,


### PR DESCRIPTION
(Let's not merge just yet; I want to give #5318 a little bit of breathing room in production; marked WIP).

Oh this is going to feel sooooooo good. I love all-red PRs. This PR removes the now-unused view-level auth-util logic for validating auth client requests.

Fixes https://github.com/hypothesis/product-backlog/issues/722