### PR TITLE
Convert `POST /api/annotations` to use a permission for authz

### DIFF
--- a/h/routes.py
+++ b/h/routes.py
@@ -90,7 +90,9 @@ def includeme(config):
     # template generator in `h/views/api.py`
     config.add_route('api.index', '/api/')
     config.add_route('api.links', '/api/links')
-    config.add_route('api.annotations', '/api/annotations')
+    config.add_route('api.annotations',
+                     '/api/annotations',
+                     factory='h.traversal:AnnotationRoot')
     config.add_route('api.annotation',
                      '/api/annotations/{id:[A-Za-z0-9_-]{20,22}}',
                      factory='h.traversal:AnnotationRoot',

--- a/h/traversal/roots.py
+++ b/h/traversal/roots.py
@@ -67,6 +67,7 @@ from pyramid.security import (
     ALL_PERMISSIONS,
     DENY_ALL,
     Allow,
+    Authenticated
 )
 import sqlalchemy.exc
 import sqlalchemy.orm.exc
@@ -99,6 +100,11 @@ class Root(object):
 
 class AnnotationRoot(object):
     """Root factory for routes whose context is an :py:class:`h.traversal.AnnotationContext`."""
+
+    __acl__ = [
+        (Allow, Authenticated, 'create'),
+    ]
+
     def __init__(self, request):
         self.request = request
 

--- a/h/views/api/annotations.py
+++ b/h/views/api/annotations.py
@@ -18,7 +18,6 @@ objects and Pyramid ACLs in :mod:`h.traversal`.
 """
 from __future__ import unicode_literals
 from pyramid import i18n
-from pyramid import security
 import newrelic.agent
 
 from h import search as search_lib
@@ -74,7 +73,7 @@ def search(request):
 
 @api_config(route_name='api.annotations',
             request_method='POST',
-            effective_principals=security.Authenticated,
+            permission='create',
             link_name='annotation.create',
             description='Create an annotation')
 def create(request):

--- a/tests/functional/api/test_annotations.py
+++ b/tests/functional/api/test_annotations.py
@@ -41,6 +41,31 @@ class TestGetAnnotations(object):
 
 
 class TestWriteAnnotation(object):
+    def test_it_returns_http_404_if_unauthorized(self, app):
+        # FIXME: This should return a 403
+
+        # This isn't a valid payload, but it won't get validated because the
+        # authorization will fail first
+        annotation = {
+            'text': 'My annotation',
+            'uri': 'http://example.com',
+        }
+
+        res = app.post_json('/api/annotations', annotation, expect_errors=True)
+
+        assert res.status_code == 404
+
+    @pytest.mark.xfail
+    def test_it_returns_http_403_if_unauthorized(self, app):
+        annotation = {
+            'text': 'My annotation',
+            'uri': 'http://example.com',
+        }
+
+        res = app.post_json('/api/annotations', annotation, expect_errors=True)
+
+        assert res.status_code == 403
+
     def test_annotation_write_unauthorized_group(self, app, user_with_token, non_writeable_group):
         """
         Write an annotation to a group that doesn't allow writes.

--- a/tests/h/routes_test.py
+++ b/tests/h/routes_test.py
@@ -73,7 +73,7 @@ def test_includeme():
         call('assets', '/assets/*subpath'),
         call('api.index', '/api/'),
         call('api.links', '/api/links'),
-        call('api.annotations', '/api/annotations'),
+        call('api.annotations', '/api/annotations', factory='h.traversal:AnnotationRoot'),
         call('api.annotation',
              '/api/annotations/{id:[A-Za-z0-9_-]{20,22}}',
              factory='h.traversal:AnnotationRoot',

--- a/tests/h/traversal/roots_test.py
+++ b/tests/h/traversal/roots_test.py
@@ -72,6 +72,25 @@ class TestRoot(object):
 
 @pytest.mark.usefixtures('group_service', 'links_service')
 class TestAnnotationRoot(object):
+    def test_it_does_not_assign_create_permission_without_authenticated_user(self, pyramid_config, pyramid_request):
+        policy = pyramid.authorization.ACLAuthorizationPolicy()
+        pyramid_config.testing_securitypolicy(None, groupids=[pyramid.security.Everyone])
+        pyramid_config.set_authorization_policy(policy)
+
+        context = AnnotationRoot(pyramid_request)
+
+        assert not pyramid_request.has_permission('create', context)
+
+    def test_it_assigns_create_permission_to_authenticated_request(self, pyramid_config, pyramid_request):
+        policy = pyramid.authorization.ACLAuthorizationPolicy()
+        pyramid_config.testing_securitypolicy('acct:adminuser@foo',
+                                              groupids=[pyramid.security.Authenticated])
+        pyramid_config.set_authorization_policy(policy)
+
+        context = AnnotationRoot(pyramid_request)
+
+        assert pyramid_request.has_permission('create', context)
+
     def test_get_item_fetches_annotation(self, pyramid_request, storage):
         factory = AnnotationRoot(pyramid_request)
 


### PR DESCRIPTION
This is part of the many-step process to satisfy https://github.com/hypothesis/product-backlog/issues/769

Similar in vein to what we're now doing in `h.traversal.roots.UserRoot` and associated `user` API endpoints, this PR converts the `POST /api/annotations` endpoint away from a view predicate (`effective_principals=security.Authenticated`) to an authorization/permission of `create`.

Also adds a few functional tests.

This will allow us to wrangle the HTTP response codes better as otherwise the view would always raise a 404 instead of a 403.

There are no functional changes resulting here (this endpoint still incorrectly returns a 404 when unauthorized).