### PR TITLE
Add `flag` permission to Annotation resource (context)

### DIFF
--- a/h/views/api/flags.py
+++ b/h/views/api/flags.py
@@ -2,7 +2,6 @@
 
 from __future__ import unicode_literals
 
-from pyramid import security
 from pyramid.httpexceptions import HTTPNoContent
 
 from h.views.api.config import api_config
@@ -16,8 +15,7 @@ from h.tasks import mailer
             request_method='PUT',
             link_name='annotation.flag',
             description='Flag an annotation for review.',
-            effective_principals=security.Authenticated,
-            permission='read')
+            permission='flag')
 def create(context, request):
     svc = request.find_service(name='flag')
     svc.create(request.user, context.annotation)

--- a/tests/functional/api/test_flags.py
+++ b/tests/functional/api/test_flags.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import pytest
+
+# String type for request/response headers and metadata in WSGI.
+#
+# Per PEP-3333, this is intentionally `str` under both Python 2 and 3, even
+# though it has different meanings.
+#
+# See https://www.python.org/dev/peps/pep-3333/#a-note-on-string-types
+native_str = str
+
+
+@pytest.mark.functional
+class TestPutFlag(object):
+    def test_it_returns_http_204_if_user_allowed_to_flag_shared_annotation(self,
+                                                                           app,
+                                                                           annotation,
+                                                                           user_with_token):
+        user, token = user_with_token
+        headers = {'Authorization': str('Bearer {}'.format(token.value))}
+
+        res = app.put('/api/annotations/{id}/flag'.format(id=annotation.id), headers=headers)
+
+        # This annotation was not created by this user but it is a shared annotation
+        assert res.status_code == 204
+
+    def test_it_returns_http_204_if_user_allowed_to_flag_private_annotation(self,
+                                                                            app,
+                                                                            private_annotation,
+                                                                            user_with_token):
+
+        user, token = user_with_token
+        headers = {'Authorization': str('Bearer {}'.format(token.value))}
+
+        res = app.put('/api/annotations/{id}/flag'.format(id=private_annotation.id), headers=headers)
+
+        # This annotation was created by this user
+        assert res.status_code == 204
+
+    def test_it_returns_http_404_if_user_not_allowed_to_flag_private_annotation(self,
+                                                                                app,
+                                                                                unreadable_annotation,
+                                                                                user_with_token):
+
+        user, token = user_with_token
+        headers = {'Authorization': str('Bearer {}'.format(token.value))}
+
+        res = app.put('/api/annotations/{id}/flag'.format(id=unreadable_annotation.id),
+                                                          headers=headers,
+                                                          expect_errors=True)
+
+        # This private annotation was not created by this user
+        assert res.status_code == 404
+
+    def test_it_returns_http_404_if_unauthenticated(self,
+                                                    app,
+                                                    annotation):
+
+        res = app.put('/api/annotations/{id}/flag'.format(id=annotation.id), expect_errors=True)
+
+        assert res.status_code == 404
+
+
+@pytest.fixture
+def annotation(db_session, factories):
+    ann = factories.Annotation(userid='acct:testuser@example.com',
+                               groupid='__world__',
+                               shared=True)
+    db_session.commit()
+    return ann
+
+
+@pytest.fixture
+def private_annotation(db_session, factories, user):
+    ann = factories.Annotation(userid=user.userid,
+                               groupid='__world__',
+                               shared=False)
+    db_session.commit()
+    return ann
+
+
+@pytest.fixture
+def unreadable_annotation(db_session, factories):
+    user = factories.User()
+    ann = factories.Annotation(userid=user.userid,
+                               groupid='__world__',
+                               shared=False)
+    db_session.commit()
+    return ann
+
+
+@pytest.fixture
+def user(db_session, factories):
+    user = factories.User()
+    db_session.commit()
+    return user
+
+
+@pytest.fixture
+def user_with_token(user, db_session, factories):
+    token = factories.DeveloperToken(userid=user.userid)
+    db_session.add(token)
+    db_session.commit()
+    return (user, token)


### PR DESCRIPTION
This PR adds a new `flag` permission to the `AnnotationContext`'s ACL and uses it to protect the `PUT /api/annotation/{id}/flag` endpoint.

This permission gets assigned to anyone who can read the annotation (complex logic already in place that takes group permissions into account), with a slight twist: if the annotation is readable by `security.Everyone` (literally everyone, any request), the permission is instead assigned to `security.Authenticated` (everyone, but you gotta be logged in). Scrutiny is due on that logic;  there may be a more kosher way of accomplishing this. Glad to discuss.<sup>[1](#footnote1)</sup>

This endpoint also did not have functional tests yet. Rectified.

<a name="footnote1">1</a>: My first variant had the permission being assigned to `security.Everyone` (if that was a valid read principal) and had the view checking both on the permission (`flag`) _and_ `effective_principal=security.Authenticated`, but  I don't like the idea of the `flag` permission getting assigned to the wrong principal at any point during the request cycle; seems rife with potential for bugs or scary security things later on, and relies on the views to handle the logic combination, ewww. That's actually the current setup: a combination of the overused `read` permission and the `Authenticated` principal.