### PR TITLE
Use elasticsearch to get group annotation count

### DIFF
--- a/h/services/annotation_stats.py
+++ b/h/services/annotation_stats.py
@@ -3,20 +3,23 @@
 from __future__ import unicode_literals
 
 import sqlalchemy as sa
+from webob.multidict import MultiDict
 
 from h.models import Annotation
+from h.search import Search
+from h.search import TopLevelAnnotationsFilter
 
 
 class AnnotationStatsService(object):
     """A service for retrieving annotation stats for users and groups."""
 
-    def __init__(self, session):
-        self.session = session
+    def __init__(self, request):
+        self.request = request
 
     def user_annotation_counts(self, userid):
         """Return the count of annotations for this user."""
 
-        annotations = self.session.query(Annotation). \
+        annotations = self.request.db.query(Annotation). \
             filter_by(userid=userid, deleted=False). \
             options(sa.orm.load_only('groupid', 'shared')).subquery()
         grouping = sa.case([
@@ -24,7 +27,7 @@ class AnnotationStatsService(object):
             (annotations.c.groupid == '__world__', 'public'),
         ], else_='group')
 
-        result = dict(self.session.query(grouping, sa.func.count(annotations.c.id)).group_by(grouping).all())
+        result = dict(self.request.db.query(grouping, sa.func.count(annotations.c.id)).group_by(grouping).all())
         for key in ['public', 'group', 'private']:
             result.setdefault(key, 0)
 
@@ -36,15 +39,17 @@ class AnnotationStatsService(object):
 
     def group_annotation_count(self, pubid):
         """
-        Return the count of shared annotations for this group.
+        Return the count of searchable top level annotations for this group.
         """
+        search = Search(self.request, stats=self.request.stats)
+        search.append_modifier(TopLevelAnnotationsFilter())
 
-        return (
-            self.session.query(Annotation)
-            .filter_by(groupid=pubid, shared=True, deleted=False)
-            .count())
+        params = MultiDict({'limit': 0, 'group': pubid})
+
+        search_result = search.run(params)
+        return search_result.total
 
 
 def annotation_stats_factory(context, request):
     """Return an AnnotationStatsService instance for the passed context and request."""
-    return AnnotationStatsService(session=request.db)
+    return AnnotationStatsService(request)

--- a/h/views/activity.py
+++ b/h/views/activity.py
@@ -156,7 +156,7 @@ class GroupSearchController(SearchController):
                               for u in [self.group.creator]]
                 moderators = sorted(moderators, key=lambda k: k['username'].lower())
 
-        group_annotation_count = self.request.find_service(name='annotation_stats').group_annotation_count(self.group.pubid)
+        group_annotation_count = self._get_total_annotations_in_group(result, q, self.request)
 
         result['stats'] = {
             'annotation_count': group_annotation_count,
@@ -204,6 +204,19 @@ class GroupSearchController(SearchController):
         result['show_leave_button'] = self.request.user in self.group.members
 
         return result
+
+    def _get_total_annotations_in_group(self, result, q, request):
+        """
+        Get number of annotations in group.
+
+        If the search result already has this number don't run a query, just re-use it.
+        """
+        group_annotation_count = result['search_results'].total
+        if len(q) > 1:
+            group_annotation_count = (self.request
+                                      .find_service(name='annotation_stats')
+                                      .group_annotation_count(self.group.pubid))
+        return group_annotation_count
 
     @view_config(request_method='POST',
                  request_param='group_join')

--- a/tests/h/views/admin/users_test.py
+++ b/tests/h/views/admin/users_test.py
@@ -240,8 +240,8 @@ def user_service(pyramid_config, db_session):
 
 
 @pytest.fixture
-def annotation_stats_service(pyramid_config, db_session):
-    service = Mock(spec_set=AnnotationStatsService(session=db_session))
+def annotation_stats_service(pyramid_config, pyramid_request):
+    service = Mock(spec_set=AnnotationStatsService(request=pyramid_request))
     service.user_annotation_counts.return_value = {'total': 0}
     pyramid_config.register_service(service, name='annotation_stats')
     return service

--- a/tests/h/views/admin/users_test.py
+++ b/tests/h/views/admin/users_test.py
@@ -2,7 +2,7 @@
 
 from __future__ import unicode_literals
 
-from mock import Mock
+import mock
 from mock import MagicMock
 from pyramid import httpexceptions
 import pytest
@@ -233,15 +233,24 @@ def models(patch):
 
 @pytest.fixture
 def user_service(pyramid_config, db_session):
-    service = Mock(spec_set=UserService(default_authority='example.com',
-                                        session=db_session))
+    service = mock.create_autospec(
+        UserService,
+        instance=True,
+        spec_set=True)
+    service.return_value.default_authority = 'example.com'
+    service.return_value.session = db_session
+
     pyramid_config.register_service(service, name='user')
     return service
 
 
 @pytest.fixture
 def annotation_stats_service(pyramid_config, pyramid_request):
-    service = Mock(spec_set=AnnotationStatsService(request=pyramid_request))
+    service = mock.create_autospec(
+        AnnotationStatsService,
+        instance=True,
+        spec_set=True)
+    service.return_value.request = pyramid_request
     service.user_annotation_counts.return_value = {'total': 0}
     pyramid_config.register_service(service, name='annotation_stats')
     return service
@@ -249,6 +258,10 @@ def annotation_stats_service(pyramid_config, pyramid_request):
 
 @pytest.fixture
 def delete_user_service(pyramid_config, pyramid_request):
-    service = Mock(spec_set=DeleteUserService(request=pyramid_request))
+    service = mock.create_autospec(
+        DeleteUserService,
+        instance=True,
+        spec_set=True)
+    service.return_value.request = pyramid_request
     pyramid_config.register_service(service, name='delete_user')
     return service


### PR DESCRIPTION
Previously the count was obtained from a db query. The problem with
this was two fold:
 1. Shared was being queried on even though it wasn't indexed
 2. When searching for groups such as Public, where the group has a
    large portion of the annotation in the table, the db was optimizing
    to search the table directly rather than use the index due to the
    overhead of indexing lookup being larger than a full table scan.

Elasticsearch performs much better for aggregation queries with 
complex where clauses and it also has built in caching. Although
looking at the Public group on activity pages doesn't happen that 
often, when it does, it takes ~3.5 s on average of query time to perform 
this lookup. ES ends up taking ~.01 s.

This is a partial fix for https://github.com/hypothesis/product-backlog/issues/812.

Since the count is now coming from elasticsearch with the default query
filters, this count now takes into account other things such as; nipsa,
permissions, moderation, etc. While the count previously considered
"annotations" to include replies, since this is used on activity pages
only, it was agreed by the team that it makes more sense for this to
not include replies and exactly match the "Matching Annotations" count.

This decision of not including replies also has the advantage that if
the query run in the search box doesn't include any other search
criteria we can re-use that total and we don't have to run this query
at all.