### PR TITLE
Isolate event subscriber failures when calling `request.notify_after_commit`

### DIFF
--- a/h/eventqueue.py
+++ b/h/eventqueue.py
@@ -4,8 +4,17 @@ from __future__ import unicode_literals
 import collections
 import logging
 
+from zope.interface import providedBy
+
 
 log = logging.getLogger(__name__)
+
+
+def _get_subscribers(registry, event):
+    # This code is adapted from the `subscribers` method in
+    # `zope.interface.adapter` which is what Pyramid's `request.registry.notify`
+    # is a very thin wrapper around.
+    return registry.adapters.subscriptions(map(providedBy, [event]), None)
 
 
 class EventQueue(object):
@@ -25,23 +34,26 @@ class EventQueue(object):
             except IndexError:
                 break
 
-            try:
-                # Notify all subscribers to this particular event. Note that the
-                # order in which subcribers run is not guaranteed [1] and if one
-                # fails, remaining subscribers to the same event which have not
-                # yet run will be skipped.
-                #
-                # [1] See https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/events.html
-                self.request.registry.notify(event)
-            except Exception:
-                sentry = getattr(event.request, 'sentry', None)
-                if sentry is not None:
-                    sentry.captureException()
-                else:
-                    log.exception('Queued event subscriber failed')
+            # Get subscribers to event and invoke them. The normal way to do
+            # this in Pyramid is to invoke `registry.notify`, but that provides
+            # no guarantee about the order of execution and any failure causes
+            # later subscribers not to run.
+            #
+            # Here we wrap each subscriber call in an exception handler to
+            # make failure independent in non-debug environments.
+            subscribers = _get_subscribers(self.request.registry, event)
+            for subscriber in subscribers:
+                try:
+                    subscriber(event)
+                except Exception:
+                    sentry = getattr(event.request, 'sentry', None)
+                    if sentry is not None:
+                        sentry.captureException()
+                    else:
+                        log.exception('Queued event subscriber failed')
 
-                if event.request.debug:
-                    raise
+                    if event.request.debug:
+                        raise
 
     def response_callback(self, request, response):
         if request.exception is not None:

--- a/h/eventqueue.py
+++ b/h/eventqueue.py
@@ -18,6 +18,18 @@ def _get_subscribers(registry, event):
 
 
 class EventQueue(object):
+    """
+    EventQueue enables dispatching Pyramid events at the end of a request.
+
+    An instance of this class is exposed on the request object via the
+    `notify_after_commit` method. The `_after_commit` part refers to the
+    database transaction associated with the request. Unlike calling
+    `request.registry.notify` during a request, failures will not cause a
+    database transaction rollback.
+
+    Events are dispatched in the order they are queued. Failure of one
+    event subscriber does not affect execution of other subscribers.
+    """
     def __init__(self, request):
         self.request = request
         self.queue = collections.deque()

--- a/tests/h/eventqueue_test.py
+++ b/tests/h/eventqueue_test.py
@@ -13,51 +13,38 @@ class DummyEvent(object):
         self.request = request
 
 
-@pytest.mark.usefixtures('pyramid_config')
 class TestEventQueue(object):
-    def test_init_adds_response_callback(self, pyramid_request):
-        request = mock.Mock()
-        queue = eventqueue.EventQueue(request)
+    def test_init_adds_response_callback(self, queue, pyramid_request):
+        pyramid_request.add_response_callback = mock.Mock(autospec=pyramid_request.add_response_callback)
+        queue = eventqueue.EventQueue(pyramid_request)
+        pyramid_request.add_response_callback.assert_called_once_with(queue.response_callback)
 
-        request.add_response_callback.assert_called_once_with(queue.response_callback)
-
-    def test_call_appends_event_to_queue(self):
-        queue = eventqueue.EventQueue(mock.Mock())
-
+    def test_call_appends_event_to_queue(self, queue, event):
         assert len(queue.queue) == 0
-        event = mock.Mock()
+
         queue(event)
         assert list(queue.queue) == [event]
 
-    def test_publish_all_notifies_events_in_fifo_order(self, pyramid_request, subscriber):
-        queue = eventqueue.EventQueue(pyramid_request)
-        firstevent = DummyEvent(pyramid_request)
+    def test_publish_all_notifies_events_in_fifo_order(self, queue, subscriber, event_factory, pyramid_config):
+        pyramid_config.add_subscriber(subscriber, DummyEvent)
+        firstevent = event_factory.get()
+        secondevent = event_factory.get()
+
         queue(firstevent)
-        secondevent = DummyEvent(pyramid_request)
         queue(secondevent)
 
         queue.publish_all()
 
-        assert subscriber.call_args_list == [
-            mock.call(firstevent),
-            mock.call(secondevent)
-        ]
+        subscriber.assert_has_calls([mock.call(firstevent), mock.call(secondevent)])
 
-    def test_publish_all_sandboxes_each_subscriber(self, pyramid_request, pyramid_config):
-        queue = eventqueue.EventQueue(pyramid_request)
+    def test_publish_all_sandboxes_each_subscriber(self, event, subscriber_factory, failing_subscriber, pyramid_config, queue):
+        subscribers = [
+            subscriber_factory.get(),
+            failing_subscriber,
+            subscriber_factory.get()]
 
-        def failing_subscriber(event):
-            raise Exception('failing_subscriber failed')
-        first_subscriber = mock.Mock()
-        second_subscriber = mock.Mock()
-        second_subscriber.side_effect = failing_subscriber
-        third_subscriber = mock.Mock()
-
-        subscribers = [first_subscriber, second_subscriber, third_subscriber]
         for sub in subscribers:
             pyramid_config.add_subscriber(sub, DummyEvent)
-
-        event = DummyEvent(pyramid_request)
 
         queue(event)
         queue.publish_all()
@@ -67,65 +54,83 @@ class TestEventQueue(object):
         for sub in subscribers:
             sub.assert_called_once_with(event)
 
-    def test_publish_all_reraises_in_debug_mode(self, subscriber, pyramid_request):
-        queue = eventqueue.EventQueue(pyramid_request)
+    def test_publish_all_reraises_in_debug_mode(self, failing_subscriber, event, queue, pyramid_request, pyramid_config):
+        pyramid_config.add_subscriber(failing_subscriber, DummyEvent)
         pyramid_request.debug = True
-        subscriber.side_effect = Exception('boom!')
 
         with pytest.raises(Exception) as excinfo:
-            queue(DummyEvent(pyramid_request))
+            queue(event)
             queue.publish_all()
         assert str(excinfo.value) == 'boom!'
 
-    def test_publish_all_sends_exception_to_sentry(self, subscriber, pyramid_request):
-        pyramid_request.sentry = mock.Mock()
-        subscriber.side_effect = ValueError('exploded!')
-        queue = eventqueue.EventQueue(pyramid_request)
-        event = DummyEvent(pyramid_request)
+    def test_publish_all_sends_exception_to_sentry(self, failing_subscriber, event, queue, pyramid_request, pyramid_config):
+        pyramid_config.add_subscriber(failing_subscriber, DummyEvent)
+        pyramid_request.sentry = mock.Mock(spec_set=['captureException'])
         queue(event)
 
         queue.publish_all()
 
         assert pyramid_request.sentry.captureException.called
 
-    def test_publish_all_logs_exception_when_sentry_is_not_available(self, log, subscriber, pyramid_request):
-        subscriber.side_effect = ValueError('exploded!')
-        queue = eventqueue.EventQueue(pyramid_request)
-        event = DummyEvent(pyramid_request)
+    def test_publish_all_logs_exception_when_sentry_is_not_available(self, log, failing_subscriber, event, queue, pyramid_config):
+        pyramid_config.add_subscriber(failing_subscriber, DummyEvent)
         queue(event)
 
         queue.publish_all()
 
         assert log.exception.called
 
-    def test_response_callback_skips_publishing_events_on_exception(self, publish_all, pyramid_request):
+    def test_response_callback_skips_publishing_events_on_exception(self, publish_all, queue, pyramid_request):
         pyramid_request.exception = ValueError('exploded!')
-        queue = eventqueue.EventQueue(pyramid_request)
         queue.response_callback(pyramid_request, None)
         assert not publish_all.called
 
-    def test_response_callback_publishes_events(self, publish_all, pyramid_request):
-        queue = eventqueue.EventQueue(pyramid_request)
-        queue(mock.Mock())
+    def test_response_callback_publishes_events(self, publish_all, event, queue, pyramid_request):
+        queue(event)
         queue.response_callback(pyramid_request, None)
         assert publish_all.called
 
     @pytest.fixture
     def log(self, patch):
-        return patch('h.eventqueue.log')
+        return patch('h.eventqueue.log', autospec=True)
 
     @pytest.fixture
     def publish_all(self, patch):
-        return patch('h.eventqueue.EventQueue.publish_all')
+        return patch('h.eventqueue.EventQueue.publish_all', autospec=True)
 
     @pytest.fixture
-    def subscriber(self):
-        return mock.Mock()
+    def event(self, event_factory):
+        return event_factory.get()
 
     @pytest.fixture
-    def pyramid_config(self, pyramid_config, subscriber):
-        pyramid_config.add_subscriber(subscriber, DummyEvent)
-        return pyramid_config
+    def event_factory(self, pyramid_request):
+
+        class EventFactory():
+            def get(self):
+                return DummyEvent(pyramid_request)
+
+        return EventFactory()
+
+    @pytest.fixture
+    def subscriber(self, subscriber_factory):
+        return subscriber_factory.get()
+
+    @pytest.fixture
+    def failing_subscriber(self, subscriber_factory):
+        sub = subscriber_factory.get()
+        sub.side_effect = Exception("boom!")
+        return sub
+
+    @pytest.fixture
+    def subscriber_factory(self):
+        class SubscriberFactory():
+            def get(self):
+                return mock.Mock()
+        return SubscriberFactory()
+
+    @pytest.fixture
+    def queue(self, pyramid_request):
+        return eventqueue.EventQueue(pyramid_request)
 
     @pytest.fixture
     def pyramid_request(self, pyramid_request):

--- a/tests/h/eventqueue_test.py
+++ b/tests/h/eventqueue_test.py
@@ -67,6 +67,16 @@ class TestEventQueue(object):
         for sub in subscribers:
             sub.assert_called_once_with(event)
 
+    def test_publish_all_reraises_in_debug_mode(self, subscriber, pyramid_request):
+        queue = eventqueue.EventQueue(pyramid_request)
+        pyramid_request.debug = True
+        subscriber.side_effect = Exception('boom!')
+
+        with pytest.raises(Exception) as excinfo:
+            queue(DummyEvent(pyramid_request))
+            queue.publish_all()
+        assert str(excinfo.value) == 'boom!'
+
     def test_publish_all_sends_exception_to_sentry(self, subscriber, pyramid_request):
         pyramid_request.sentry = mock.Mock()
         subscriber.side_effect = ValueError('exploded!')


### PR DESCRIPTION
When using `request.notify_after_commit` to trigger an event after the current web request's transaction is committed, an exception in one event subscriber can cause other subscribers not to run. The order in which subscribers are run is not specified. This makes it hard to reason about the eventual state if any one subscriber fails to run.

This relates to a [Sentry issue](https://github.com/hypothesis/h/issues/5311) I'm looking into where failures sending a message to the message broker in order to trigger a websocket notification can also cause other, more important tasks to fail. These tasks include sending reply notification emails and indexing the annotation for search. Fixing the actual cause of the write failure itself is something I also plan to look into, but I think it would be good to reduce the "blast radius" of the problem.
    
This commit replaces `request.registry.notify` with equivalent code using lower-level zope functions, which wraps each subscriber in a catch block. Therefore one subscriber failure won't affect others.

I also added some basic documentation to the `EventQueue` class to explain what it is for.

_This is a partial mitigation for https://github.com/hypothesis/h/issues/5311_.