### PR TITLE
Adjust URL facet description to be more clear

### DIFF
--- a/h/static/scripts/controllers/search-bar-controller.js
+++ b/h/static/scripts/controllers/search-bar-controller.js
@@ -59,8 +59,8 @@ class SearchBarController extends Controller {
         {
           matchOn: 'url',
           title: 'url:',
-          explanation: `see all annotations on a document URL. * matches any number 
-            of characters and ? matches any single character`,
+          explanation: `search by URL<br>for domain level search 
+            add trailing /* eg. https://example.com/*`,
         },
         {
           matchOn: 'group',

--- a/h/static/scripts/tests/controllers/autosuggest-dropdown-controller-test.js
+++ b/h/static/scripts/tests/controllers/autosuggest-dropdown-controller-test.js
@@ -60,8 +60,8 @@ describe('AutosuggestDropdownController', () => {
         },
         {
           title: 'url:',
-          explanation: `see all annotations on a document URL. * matches any number 
-            of characters and ? matches any single character`,
+          explanation: `search by URL<br>for domain level search 
+            add trailing /* eg. https://example.com/*`,
         },
         {
           title: 'group:',


### PR DESCRIPTION
Based on feedback from @heatherstaines and @jeremydean, I have adjusted the URL facet description to, 

> search by URL
> for domain level search add trailing /* eg. https://example.com/*

Jeremy pointed out customers have been describing this feature as "domain level search" and that the ? is more of an advanced feature and is TMI. Also both indicated an example would be helpful.