### PR TITLE
Remove unused pytest fixtures

### DIFF
--- a/tests/h/accounts/schemas_test.py
+++ b/tests/h/accounts/schemas_test.py
@@ -6,7 +6,6 @@ from mock import Mock
 from pyramid.exceptions import BadCSRFToken
 
 from h.accounts import schemas
-from h.services.user import UserService
 from h.services.user_password import UserPasswordService
 
 

--- a/tests/h/accounts/schemas_test.py
+++ b/tests/h/accounts/schemas_test.py
@@ -340,15 +340,6 @@ def user_model(patch):
 
 
 @pytest.fixture
-def user_service(db_session, pyramid_config):
-    service = Mock(spec_set=UserService(default_authority='example.com',
-                                        session=db_session))
-    service.fetch_for_login.return_value = None
-    pyramid_config.register_service(service, name='user')
-    return service
-
-
-@pytest.fixture
 def user_password_service(pyramid_config):
     service = Mock(spec_set=UserPasswordService())
     service.check_password.return_value = True

--- a/tests/h/auth/util_test.py
+++ b/tests/h/auth/util_test.py
@@ -293,18 +293,6 @@ def auth_client(factories):
 
 
 @pytest.fixture
-def basic_auth_creds(patch):
-    basic_auth_creds = patch('h.auth.util.basic_auth_creds')
-    basic_auth_creds.return_value = None
-    return basic_auth_creds
-
-
-@pytest.fixture
-def valid_auth(basic_auth_creds, auth_client):
-    basic_auth_creds.return_value = (auth_client.id, auth_client.secret)
-
-
-@pytest.fixture
 def principals_for_user(patch):
     return patch('h.auth.util.principals_for_user')
 

--- a/tests/h/conftest.py
+++ b/tests/h/conftest.py
@@ -195,15 +195,6 @@ def invalid_form():
 
 
 @pytest.fixture
-def mailer(pyramid_config):
-    from pyramid_mailer.interfaces import IMailer
-    from pyramid_mailer.testing import DummyMailer
-    mailer = DummyMailer()
-    pyramid_config.registry.registerUtility(mailer, IMailer)
-    return mailer
-
-
-@pytest.fixture
 def matchers():
     from ..common import matchers
     return matchers

--- a/tests/h/services/list_groups_test.py
+++ b/tests/h/services/list_groups_test.py
@@ -324,11 +324,6 @@ def user(factories, authority):
 
 
 @pytest.fixture
-def alternate_user(factories, alternate_authority):
-    return factories.User(authority=alternate_authority)
-
-
-@pytest.fixture
 def origin():
     return 'http://foo.com'
 

--- a/tests/h/services/oauth_validator_test.py
+++ b/tests/h/services/oauth_validator_test.py
@@ -211,10 +211,6 @@ class TestInvalidateAuthorizationCode(object):
 
         assert db_session.query(models.AuthzCode).get(keep_code.id) is not None
 
-    @pytest.fixture
-    def authz_code(self, factories):
-        return factories.AuthzCode()
-
 
 class TestInvalidateRefreshToken(object):
     def test_it_shortens_refresh_token_expires(self, svc, oauth_request, token, utcnow):

--- a/tests/h/views/accounts_test.py
+++ b/tests/h/views/accounts_test.py
@@ -910,11 +910,6 @@ class TestDeveloperController(object):
 
 
 @pytest.fixture
-def session(patch):
-    return patch('h.views.accounts.session')
-
-
-@pytest.fixture
 def subscriptions_model(patch):
     return patch('h.models.Subscriptions')
 
@@ -940,19 +935,7 @@ def mailer(patch):
 
 
 @pytest.fixture
-def models(patch):
-    return patch('h.views.accounts.models')
-
-
-@pytest.fixture
 def user_password_service(pyramid_config):
     service = mock.Mock(spec_set=UserPasswordService())
     pyramid_config.register_service(service, name='user_password')
-    return service
-
-
-@pytest.fixture
-def user_signup_service(pyramid_config):
-    service = mock.Mock(spec_set=['signup'])
-    pyramid_config.register_service(service, name='user_signup')
     return service

--- a/tests/h/views/api/annotations_test.py
+++ b/tests/h/views/api/annotations_test.py
@@ -75,10 +75,6 @@ class TestSearch(object):
     def search_run(self, search_lib):
         return search_lib.Search.return_value.run
 
-    @pytest.fixture
-    def storage(self, patch):
-        return patch('h.views.api.annotations.storage')
-
 
 @pytest.mark.usefixtures('AnnotationEvent',
                          'create_schema',
@@ -445,11 +441,6 @@ def group_service(pyramid_config):
 def pyramid_request(pyramid_request):
     pyramid_request.notify_after_commit = mock.Mock(spec_set=[])
     return pyramid_request
-
-
-@pytest.fixture
-def search_lib(patch):
-    return patch('h.views.api.annotations.search_lib')
 
 
 @pytest.fixture


### PR DESCRIPTION
Remove unused fixtures found using https://github.com/jllorencetti/pytest-deadfixtures

Of the unused fixtures it reported, only a couple that really were used
were marked as unused because they were retrieved via
`request.getfixturevalue`.