### PR TITLE
Index hidden field into ES such that if an annotation and all of its replies are hidden it is set to True otherwise False.

### DIFF
--- a/h/presenters/annotation_searchindex.py
+++ b/h/presenters/annotation_searchindex.py
@@ -43,14 +43,10 @@ class AnnotationSearchIndexPresenter(AnnotationBasePresenter):
 
         # Mark an annotation as hidden if it and all of it's children have been
         # moderated and hidden.
-        result['hidden'] = False
-        if self.annotation.thread_ids:
-            ann_mod_svc = self.request.find_service(name='annotation_moderation')
-            annotation_hidden = ann_mod_svc.hidden(self.annotation)
-            thread_ids_hidden = len(ann_mod_svc.all_hidden(self.annotation.thread_ids)) == len(self.annotation.thread_ids)
+        parents_and_replies = [self.annotation.id] + self.annotation.thread_ids
 
-            if annotation_hidden and thread_ids_hidden:
-                result['hidden'] = True
+        ann_mod_svc = self.request.find_service(name='annotation_moderation')
+        result['hidden'] = len(ann_mod_svc.all_hidden(parents_and_replies)) == len(parents_and_replies)
 
         return result
 

--- a/tests/h/presenters/annotation_searchindex_test.py
+++ b/tests/h/presenters/annotation_searchindex_test.py
@@ -76,8 +76,7 @@ class TestAnnotationSearchIndexPresenter(object):
             userid='acct:luke@hypothes.is',
             thread_ids=thread_ids)
 
-        moderation_service.hidden.return_value = True
-        moderation_service.all_hidden.return_value = thread_ids
+        moderation_service.all_hidden.return_value = [annotation.id] + thread_ids
 
         annotation_dict = AnnotationSearchIndexPresenter(annotation, pyramid_request).asdict()
 
@@ -105,8 +104,7 @@ class TestAnnotationSearchIndexPresenter(object):
             userid='acct:luke@hypothes.is',
             thread_ids=thread_ids)
 
-        moderation_service.all_hidden.return_value = thread_ids[1:]
-        moderation_service.hidden.return_value = True
+        moderation_service.all_hidden.return_value = [annotation.id] + thread_ids[1:]
 
         annotation_dict = AnnotationSearchIndexPresenter(annotation, pyramid_request).asdict()
 
@@ -123,9 +121,11 @@ class TestAnnotationSearchIndexPresenter(object):
         assert annotation_dict['hidden'] is False
 
     def test_it_marks_annotation_hidden_when_moderated_and_no_replies(self, pyramid_request, moderation_service):
-        annotation = mock.MagicMock(userid='acct:luke@hypothes.is')
+        thread_ids = []
+        annotation = mock.MagicMock(userid='acct:luke@hypothes.is',
+                                    thread_ids=thread_ids)
 
-        moderation_service.hidden.return_value = True
+        moderation_service.all_hidden.return_value = [annotation.id] + thread_ids
 
         annotation_dict = AnnotationSearchIndexPresenter(annotation, pyramid_request).asdict()
 
@@ -142,7 +142,6 @@ class TestAnnotationSearchIndexPresenter(object):
 def moderation_service(pyramid_config):
     svc = mock.create_autospec(AnnotationModerationService, spec_set=True, instance=True)
     svc.all_hidden.return_value = []
-    svc.hidden.return_value = False
     pyramid_config.register_service(svc, name='annotation_moderation')
     return svc
 

--- a/tests/h/search/conftest.py
+++ b/tests/h/search/conftest.py
@@ -6,6 +6,7 @@ import pytest
 
 import h.search.index
 from h.services.group import GroupService
+from h.services.annotation_moderation import AnnotationModerationService
 
 
 @pytest.fixture(autouse=True)
@@ -14,6 +15,14 @@ def group_service(pyramid_config):
     group_service.groupids_readable_by.return_value = ["__world__"]
     pyramid_config.register_service(group_service, name="group")
     return group_service
+
+
+@pytest.fixture(autouse=True)
+def moderation_service(pyramid_config):
+    svc = mock.create_autospec(AnnotationModerationService, spec_set=True, instance=True)
+    svc.all_hidden.return_value = []
+    pyramid_config.register_service(svc, name='annotation_moderation')
+    return svc
 
 
 @pytest.fixture

--- a/tests/h/search/index_test.py
+++ b/tests/h/search/index_test.py
@@ -10,12 +10,11 @@ import mock
 import pytest
 
 import h.search.index
-from h.services.annotation_moderation import AnnotationModerationService
 
 from tests.common.matchers import Matcher
 
 
-@pytest.mark.usefixtures("annotations", "moderation_service")
+@pytest.mark.usefixtures("annotations")
 class TestIndex(object):
     def test_annotation_ids_are_used_as_elasticsearch_ids(self, es_client,
                                                           factories,
@@ -495,12 +494,3 @@ def get_indexed_ann(es_client):
             index=es_client.index, doc_type=es_client.mapping_type,
             id=annotation_id)["_source"]
     return _get
-
-
-@pytest.fixture
-def moderation_service(pyramid_config):
-    svc = mock.create_autospec(AnnotationModerationService, spec_set=True, instance=True)
-    svc.all_hidden.return_value = []
-    svc.hidden.return_value = False
-    pyramid_config.register_service(svc, name='annotation_moderation')
-    return svc


### PR DESCRIPTION
There was a bug with how the hidden field was set in an earlier commit. It would only be set to True if the annotation
had replies, otherwise False.

See https://github.com/hypothesis/product-backlog/issues/583