### PR TITLE
Add unique constraint on `annotation_moderation.annotation_id`

### DIFF
--- a/h/models/annotation_moderation.py
+++ b/h/models/annotation_moderation.py
@@ -22,7 +22,8 @@ class AnnotationModeration(Base, Timestamps):
 
     annotation_id = sa.Column(types.URLSafeUUID,
                               sa.ForeignKey('annotation.id', ondelete='cascade'),
-                              nullable=False)
+                              nullable=False,
+                              unique=True)
 
     #: The annotation which has been flagged.
     annotation = sa.orm.relationship('Annotation',


### PR DESCRIPTION
This constraint is present in the database migration (see e5f7aa602)
and thus present in the production DB, but missing from the model
definition and therefore missing from newly-created databases.