### PR TITLE
Make any-term search narrow instead of broadening

### DIFF
--- a/h/search/query.py
+++ b/h/search/query.py
@@ -426,7 +426,7 @@ class AnyMatcher(object):
             SimpleQueryString(
                 query=qs,
                 fields=["quote", "tags", "text", "uri.parts"],
-                # default_operator='or',
+                default_operator='and',
             )
         )
 

--- a/tests/h/search/query_test.py
+++ b/tests/h/search/query_test.py
@@ -707,21 +707,19 @@ class TestAnyMatcher(object):
 
         assert sorted(result.annotation_ids) == sorted(matched_ids)
 
-    def test_ors_any_matches(self, search, Annotation):
+    def test_ands_any_matches(self, search, Annotation):
         """
-        Any is expected to match any of the following fields;
+        Any is expected to match all of the following fields;
         quote, text, uri.parts, and tags
         that contain any of the passed keywords.
         """
-        Annotation(target_selectors=[{'exact': 'selected baz text'}])
-        Annotation(tags=["baz"])
-        Annotation(target_uri="baz.com")
-        Annotation(text="baz is best")
+        Annotation(text="bar is best").id
+        Annotation(tags=["foo"]).id
 
         matched_ids = [Annotation(target_uri="foo/bar/baz.com").id,
-                       Annotation(target_selectors=[{'exact': 'selected foo text'}]).id,
-                       Annotation(text="bar is best").id,
-                       Annotation(tags=["foo"]).id]
+                       Annotation(target_selectors=[{'exact': 'selected foo bar text'}]).id,
+                       Annotation(text="bar foo is best").id,
+                       Annotation(tags=["foo bar"]).id]
 
         params = webob.multidict.MultiDict()
         params.add("any", "foo")


### PR DESCRIPTION
Change default behavior of AnyMatcher to AND instead of OR search terms together so that as more terms are added the search narrows in scope/results rather than broadening.

Fixes https://github.com/hypothesis/h/issues/5338