### PR TITLE
Establish annotation `moderate` permission; protect API endpoints

### DIFF
--- a/h/models/group.py
+++ b/h/models/group.py
@@ -144,6 +144,8 @@ class Group(Base, mixins.Timestamps):
 
         if self.creator:
             terms.append((security.Allow, self.creator.userid, 'admin'))
+            terms.append((security.Allow, self.creator.userid, 'moderate'))
+
         terms.append(security.DENY_ALL)
 
         return terms

--- a/h/views/api/moderation.py
+++ b/h/views/api/moderation.py
@@ -13,10 +13,8 @@ from h.views.api.config import api_config
             request_method='PUT',
             link_name='annotation.hide',
             description='Hide an annotation as a group moderator.',
-            effective_principals=security.Authenticated)
+            permission='moderate')
 def create(context, request):
-    if not request.has_permission('admin', context.group):
-        raise HTTPNotFound()
 
     svc = request.find_service(name='annotation_moderation')
     svc.hide(context.annotation)

--- a/h/views/api/moderation.py
+++ b/h/views/api/moderation.py
@@ -2,8 +2,7 @@
 
 from __future__ import unicode_literals
 
-from pyramid import security
-from pyramid.httpexceptions import HTTPNoContent, HTTPNotFound
+from pyramid.httpexceptions import HTTPNoContent
 
 from h import events
 from h.views.api.config import api_config
@@ -29,10 +28,8 @@ def create(context, request):
             request_method='DELETE',
             link_name='annotation.unhide',
             description='Unhide an annotation as a group moderator.',
-            effective_principals=security.Authenticated)
+            permission='moderate')
 def delete(context, request):
-    if not request.has_permission('admin', context.group):
-        raise HTTPNotFound()
 
     svc = request.find_service(name='annotation_moderation')
     svc.unhide(context.annotation)

--- a/tests/functional/api/test_moderation.py
+++ b/tests/functional/api/test_moderation.py
@@ -1,0 +1,115 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import pytest
+
+# String type for request/response headers and metadata in WSGI.
+#
+# Per PEP-3333, this is intentionally `str` under both Python 2 and 3, even
+# though it has different meanings.
+#
+# See https://www.python.org/dev/peps/pep-3333/#a-note-on-string-types
+native_str = str
+
+
+@pytest.mark.functional
+class TestPutHide(object):
+
+    def test_it_returns_http_204_for_group_creator(self,
+                                                   app,
+                                                   group_annotation,
+                                                   user_with_token):
+        user, token = user_with_token
+        headers = {'Authorization': str('Bearer {}'.format(token.value))}
+
+        res = app.put('/api/annotations/{id}/hide'.format(id=group_annotation.id),
+                                                          headers=headers)
+
+        # The creator of a group has moderation rights over the annotations in that group
+        assert res.status_code == 204
+
+    def test_it_returns_http_404_if_annotation_is_in_world_group(self,
+                                                                 app,
+                                                                 world_annotation,
+                                                                 user_with_token):
+        user, token = user_with_token
+        headers = {'Authorization': str('Bearer {}'.format(token.value))}
+
+        res = app.put('/api/annotations/{id}/hide'.format(id=world_annotation.id),
+                                                          headers=headers,
+                                                          expect_errors=True)
+        # The current user does not have moderation rights on the world group
+        assert res.status_code == 404
+
+    def test_it_returns_http_404_if_no_authn(self,
+                                             app,
+                                             group_annotation):
+
+        res = app.put('/api/annotations/{id}/hide'.format(id=group_annotation.id),
+                                                          expect_errors=True)
+
+        assert res.status_code == 404
+
+    def test_it_returns_http_404_if_annotation_is_private(self,
+                                                          app,
+                                                          private_group_annotation,
+                                                          user_with_token):
+
+        user, token = user_with_token
+        headers = {'Authorization': str('Bearer {}'.format(token.value))}
+
+        res = app.put('/api/annotations/{id}/hide'.format(id=private_group_annotation.id),
+                                                          headers=headers,
+                                                          expect_errors=True)
+        # private annotations cannot be moderated
+        assert res.status_code == 404
+
+
+@pytest.fixture
+def user(db_session, factories):
+    user = factories.User()
+    db_session.commit()
+    return user
+
+
+@pytest.fixture
+def group(user, db_session, factories):
+    group = factories.Group(creator=user)
+    db_session.commit()
+    return group
+
+
+@pytest.fixture
+def world_annotation(user, db_session, factories):
+    ann = factories.Annotation(userid=user.userid,
+                               groupid='__world__',
+                               shared=True)
+    db_session.commit()
+    return ann
+
+
+@pytest.fixture
+def group_annotation(user, group, db_session, factories):
+    ann = factories.Annotation(userid='acct:someone@example.com',
+                               groupid=group.pubid,
+                               shared=True)
+    db_session.commit()
+    return ann
+
+
+@pytest.fixture
+def private_group_annotation(user, group, db_session, factories):
+    ann = factories.Annotation(userid='acct:someone@example.com',
+                               groupid=group.pubid,
+                               shared=False)
+    db_session.commit()
+    return ann
+
+
+@pytest.fixture
+def user_with_token(user, db_session, factories):
+    token = factories.DeveloperToken(userid=user.userid)
+    db_session.add(token)
+    db_session.commit()
+    return (user, token)

--- a/tests/functional/api/test_moderation.py
+++ b/tests/functional/api/test_moderation.py
@@ -66,6 +66,59 @@ class TestPutHide(object):
         assert res.status_code == 404
 
 
+@pytest.mark.functional
+class TestDeleteHide(object):
+
+    def test_it_returns_http_204_for_group_creator(self,
+                                                   app,
+                                                   group_annotation,
+                                                   user_with_token):
+        user, token = user_with_token
+        headers = {'Authorization': str('Bearer {}'.format(token.value))}
+
+        res = app.delete('/api/annotations/{id}/hide'.format(id=group_annotation.id),
+                                                             headers=headers)
+
+        # The creator of a group has moderation rights over the annotations in that group
+        assert res.status_code == 204
+
+    def test_it_returns_http_404_if_annotation_is_in_world_group(self,
+                                                                 app,
+                                                                 world_annotation,
+                                                                 user_with_token):
+        user, token = user_with_token
+        headers = {'Authorization': str('Bearer {}'.format(token.value))}
+
+        res = app.delete('/api/annotations/{id}/hide'.format(id=world_annotation.id),
+                                                             headers=headers,
+                                                             expect_errors=True)
+        # The current user does not have moderation rights on the world group
+        assert res.status_code == 404
+
+    def test_it_returns_http_404_if_no_authn(self,
+                                             app,
+                                             group_annotation):
+
+        res = app.delete('/api/annotations/{id}/hide'.format(id=group_annotation.id),
+                                                             expect_errors=True)
+
+        assert res.status_code == 404
+
+    def test_it_returns_http_404_if_annotation_is_private(self,
+                                                          app,
+                                                          private_group_annotation,
+                                                          user_with_token):
+
+        user, token = user_with_token
+        headers = {'Authorization': str('Bearer {}'.format(token.value))}
+
+        res = app.delete('/api/annotations/{id}/hide'.format(id=private_group_annotation.id),
+                                                             headers=headers,
+                                                             expect_errors=True)
+        # private annotations cannot be moderated
+        assert res.status_code == 404
+
+
 @pytest.fixture
 def user(db_session, factories):
     user = factories.User()

--- a/tests/h/models/groups_test.py
+++ b/tests/h/models/groups_test.py
@@ -157,10 +157,15 @@ class TestGroupACL(object):
         group.readable_by = ReadableBy.world
         assert authz_policy.permits(group, [security.Everyone], 'read')
 
-    def test_world_flaggable(self, group, authz_policy):
+    def test_world_readable_grants_flag_permissions(self, group, authz_policy):
         group.readable_by = ReadableBy.world
         assert authz_policy.permits(group, [security.Authenticated], 'flag')
         assert not authz_policy.permits(group, [security.Everyone], 'flag')
+
+    def test_world_readable_does_not_grant_moderate_permissions(self, group, authz_policy):
+        group.readable_by = ReadableBy.world
+        assert not authz_policy.permits(group, [security.Authenticated], 'moderate')
+        assert not authz_policy.permits(group, [security.Everyone], 'moderate')
 
     def test_members_readable(self, group, authz_policy):
         group.readable_by = ReadableBy.members
@@ -169,6 +174,10 @@ class TestGroupACL(object):
     def test_members_flaggable(self, group, authz_policy):
         group.readable_by = ReadableBy.members
         assert authz_policy.permits(group, ['group:test-group'], 'flag')
+
+    def test_non_creator_members_do_not_have_moderate_permission(self, group, authz_policy):
+        group.readable_by = ReadableBy.members
+        assert not authz_policy.permits(group, ['group:test-group'], 'moderate')
 
     def test_not_readable(self, group, authz_policy):
         group.readable_by = None
@@ -190,6 +199,9 @@ class TestGroupACL(object):
         group.writeable_by = None,
         assert not authz_policy.permits(group, ['authority:example.com', 'group:test-group'], 'write')
 
+    def test_creator_has_moderate_permission(self, group, authz_policy):
+        assert authz_policy.permits(group, 'acct:luke@example.com', 'moderate')
+
     def test_creator_has_admin_permissions(self, group, authz_policy):
         assert authz_policy.permits(group, 'acct:luke@example.com', 'admin')
 
@@ -197,6 +209,12 @@ class TestGroupACL(object):
         group.creator = None
 
         principals = authz_policy.principals_allowed_by_permission(group, 'admin')
+        assert len(principals) == 0
+
+    def test_no_moderate_permission_when_no_creator(self, group, authz_policy):
+        group.creator = None
+
+        principals = authz_policy.principals_allowed_by_permission(group, 'moderate')
         assert len(principals) == 0
 
     def test_fallback_is_deny_all(self, group, authz_policy):

--- a/tests/h/models/groups_test.py
+++ b/tests/h/models/groups_test.py
@@ -232,6 +232,3 @@ class TestGroupACL(object):
                              creator=creator)
         group.pubid = 'test-group'
         return group
-
-    def permissions(self, acl):
-        return [term[-1] for term in acl]

--- a/tests/h/traversal/contexts_test.py
+++ b/tests/h/traversal/contexts_test.py
@@ -37,6 +37,7 @@ class TestAnnotationContext(object):
         ann = factories.Annotation(shared=False, userid='saoirse')
         res = AnnotationContext(ann, group_service, links_service)
         actual = res.__acl__()
+        # Note NOT the ``moderate`` permission
         expect = [(security.Allow, 'saoirse', 'read'),
                   (security.Allow, 'saoirse', 'flag'),
                   (security.Allow, 'saoirse', 'admin'),
@@ -145,6 +146,52 @@ class TestAnnotationContext(object):
         """
         Flag permissions should echo read permissions with the exception that
         `Security.Everyone` does not get the permission
+        """
+        # Set up the test with a dummy authn policy and a real ACL authz
+        # policy:
+        policy = ACLAuthorizationPolicy()
+        pyramid_config.testing_securitypolicy(userid)
+        pyramid_config.set_authorization_policy(policy)
+
+        ann = factories.Annotation(shared=True,
+                                   userid='mioara',
+                                   groupid=groupid)
+        res = AnnotationContext(ann, group_service, links_service)
+
+        if permitted:
+            assert pyramid_request.has_permission('flag', res)
+        else:
+            assert not pyramid_request.has_permission('flag', res)
+
+    @pytest.mark.parametrize('groupid,userid,permitted', [
+        ('freeforall', 'jim', True),
+        ('freeforall', 'saoirse', True),
+        ('freeforall', None, False),
+        ('only-saoirse', 'jim', False),
+        ('only-saoirse', 'saoirse', True),
+        ('only-saoirse', None, False),
+        ('pals', 'jim', True),
+        ('pals', 'saoirse', True),
+        ('pals', 'francis', False),
+        ('pals', None, False),
+        ('unknown-group', 'jim', False),
+        ('unknown-group', 'saoirse', False),
+        ('unknown-group', 'francis', False),
+        ('unknown-group', None, False),
+    ])
+    def test_acl_moderate_shared(self,
+                                 factories,
+                                 pyramid_config,
+                                 pyramid_request,
+                                 groupid,
+                                 userid,
+                                 permitted,
+                                 group_service,
+                                 links_service):
+        """
+        Moderate permissions should only be applied when an annotation
+        is shared—as the annotation here is shared, anyone set as a principal
+        for the given ``FakeGroup`` will receive the ``moderate`` permission.
         """
         # Set up the test with a dummy authn policy and a real ACL authz
         # policy:
@@ -312,6 +359,13 @@ class FakeGroup(object):
                 acl.append((security.Allow, security.Authenticated, 'flag'))
             else:
                 acl.append((security.Allow, p, 'flag'))
+                # Normally, the ``moderate`` permission would only be applied
+                # to the admin (creator) of a group, but this ``FakeGroup``
+                # is indeed fake. Tests in this module are merely around whether
+                # this permission is translated appropriately from a group
+                # to an annotation context (i.e. it should not be applied
+                # to private annotations)
+                acl.append((security.Allow, p, 'moderate'))
         self.__acl__ = acl
 
 

--- a/tests/h/traversal/contexts_test.py
+++ b/tests/h/traversal/contexts_test.py
@@ -205,9 +205,9 @@ class TestAnnotationContext(object):
         res = AnnotationContext(ann, group_service, links_service)
 
         if permitted:
-            assert pyramid_request.has_permission('flag', res)
+            assert pyramid_request.has_permission('moderate', res)
         else:
-            assert not pyramid_request.has_permission('flag', res)
+            assert not pyramid_request.has_permission('moderate', res)
 
     @pytest.fixture
     def groups(self):
@@ -357,6 +357,7 @@ class FakeGroup(object):
             acl.append((security.Allow, p, 'read'))
             if p == security.Everyone:
                 acl.append((security.Allow, security.Authenticated, 'flag'))
+                acl.append((security.Allow, security.Authenticated, 'moderate'))
             else:
                 acl.append((security.Allow, p, 'flag'))
                 # Normally, the ``moderate`` permission would only be applied

--- a/tests/h/traversal/contexts_test.py
+++ b/tests/h/traversal/contexts_test.py
@@ -69,7 +69,7 @@ class TestAnnotationContext(object):
         ann = factories.Annotation(userid='saoirse', deleted=True)
         res = AnnotationContext(ann, group_service, links_service)
 
-        for perm in ['read', 'admin', 'update', 'delete']:
+        for perm in ['read', 'admin', 'update', 'delete', 'moderate']:
             assert not policy.permits(res, ['saiorse'], perm)
 
     @pytest.mark.parametrize('groupid,userid,permitted', [

--- a/tests/h/views/api/moderation_test.py
+++ b/tests/h/views/api/moderation_test.py
@@ -5,12 +5,12 @@ from __future__ import unicode_literals
 import mock
 import pytest
 
-from pyramid.httpexceptions import HTTPNoContent, HTTPNotFound
+from pyramid.httpexceptions import HTTPNoContent
 
 from h.views.api import moderation as views
 
 
-@pytest.mark.usefixtures('moderation_service', 'has_permission')
+@pytest.mark.usefixtures('moderation_service')
 class TestCreate(object):
     def test_it_hides_the_annotation(self, pyramid_request, resource, moderation_service):
         views.create(resource, pyramid_request)
@@ -29,15 +29,6 @@ class TestCreate(object):
     def test_it_renders_no_content(self, pyramid_request, resource):
         response = views.create(resource, pyramid_request)
         assert isinstance(response, HTTPNoContent)
-
-    def test_it_checks_for_group_admin_permission(self, pyramid_request, resource):
-        views.create(resource, pyramid_request)
-        pyramid_request.has_permission.assert_called_once_with('admin', resource.group)
-
-    def test_it_responds_with_not_found_when_no_admin_access_in_group(self, pyramid_request, resource):
-        pyramid_request.has_permission.return_value = False
-        with pytest.raises(HTTPNotFound):
-            views.create(resource, pyramid_request)
 
 
 @pytest.mark.usefixtures('moderation_service', 'has_permission')

--- a/tests/h/views/api/moderation_test.py
+++ b/tests/h/views/api/moderation_test.py
@@ -31,7 +31,7 @@ class TestCreate(object):
         assert isinstance(response, HTTPNoContent)
 
 
-@pytest.mark.usefixtures('moderation_service', 'has_permission')
+@pytest.mark.usefixtures('moderation_service')
 class TestDelete(object):
     def test_it_unhides_the_annotation(self, pyramid_request, resource, moderation_service):
         views.delete(resource, pyramid_request)
@@ -51,15 +51,6 @@ class TestDelete(object):
         response = views.delete(resource, pyramid_request)
         assert isinstance(response, HTTPNoContent)
 
-    def test_it_checks_for_group_admin_permission(self, pyramid_request, resource):
-        views.delete(resource, pyramid_request)
-        pyramid_request.has_permission.assert_called_once_with('admin', resource.group)
-
-    def test_it_responds_with_not_found_when_no_admin_access_in_group(self, pyramid_request, resource):
-        pyramid_request.has_permission.return_value = False
-        with pytest.raises(HTTPNotFound):
-            views.delete(resource, pyramid_request)
-
 
 @pytest.fixture
 def resource():
@@ -71,13 +62,6 @@ def moderation_service(pyramid_config):
     svc = mock.Mock(spec_set=['hide', 'unhide'])
     pyramid_config.register_service(svc, name='annotation_moderation')
     return svc
-
-
-@pytest.fixture
-def has_permission(pyramid_request):
-    func = mock.Mock(return_value=True)
-    pyramid_request.has_permission = func
-    return func
 
 
 @pytest.fixture


### PR DESCRIPTION
Part of getting ready for https://github.com/hypothesis/product-backlog/issues/769

Whether a user should have the rights to moderate (hide/unhide) an annotation is something that has never been codified. Previously, the hide and unhide endpoints had a view predicate for `security.Authenticated`, meaning that any authenticated user could access the views themselves, authz-wise. In the views, an HTTP 404 was manually raised if the current user was not an admin of the annotation's containing _group_.

There were a few holes here:

1. We're trying to move towards authz on endpoints (not `security. Authenticated`, e.g., which is actually authn)
1. Authz for moderation is inferred through a few levels and could use its own permission that can be adapted or extended independently later on
1. There are some situations in which moderation does not make sense—it does not make sense to moderate a private annotation

With that in mind, I've created a new `moderate` permission which is used to protect these endpoints. How this permission is applied depends on the shared state of the annotation, which follows the way several other annotation permissions are applied.

If the annotation is shared, the `moderate` permission is assigned based on the `moderate` permissions on the annotation's containing group (hint: the `moderate` permission on groups gets assigned to the group's creator, similar to `admin` permissions).

If the annotation is private, the `moderate` permission is assigned to the creator of the annotation, again consistent with several other permissions assignments for private annotations.

That means that the creator/owner of a private annotation may _access_ the moderation endpoints (authorization-wise), but as stated earlier, moderating a private annotation is nonsensical. Thus, the endpoints now will raise an HTTP 405 in this situation, with an error message to explain why.

We have never returned 405s before from our API endpoints, so a new error view handler has been added.

Note that these two endpoints (hide/unhide) are completely undocumented! I had no idea. I'd like to add documentation for them, but, since it's not there at all, it won't hurt to do that as a separate PR as this one is big enough.