### PR TITLE
Remove tox-pip-extensions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
         postgresql: "9.4"
       before_install:
         - ./scripts/elasticsearch.sh
-      install: pip install tox==3.3.0 tox-pip-extensions
+      install: pip install tox
       before_script: createdb htest
       script: tox
       after_success:
@@ -24,7 +24,7 @@ matrix:
         postgresql: '9.4'
       before_install:
         - ./scripts/elasticsearch.sh
-      install: pip install tox==3.3.0 tox-pip-extensions
+      install: pip install tox
       before_script: createdb htest
       script:
         make test-py3
@@ -50,7 +50,7 @@ matrix:
     - env: ACTION=backend-lint
       language: python
       python: '3.6'
-      install: pip install tox==3.3.0 tox-pip-extensions
+      install: pip install tox
       script:
         make lint
 
@@ -58,7 +58,7 @@ matrix:
     - env: ACTION=check-docs
       language: python
       python: '3.6'
-      install: pip install tox==3.3.0 tox-pip-extensions
+      install: pip install tox
       script:
         make checkdocs
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,7 +30,7 @@ node {
                 // Test dependencies
                 sh 'apk add --no-cache build-base libffi-dev postgresql-dev python-dev'
                 sh 'apk add --no-cache python3 python3-dev'
-                sh 'pip install -q tox==3.3.0 tox-pip-extensions'
+                sh 'pip install -q tox'
 
                 // Unit tests
                 sh 'cd /var/lib/hypothesis && tox'

--- a/docs/developing/install.rst
+++ b/docs/developing/install.rst
@@ -46,12 +46,13 @@ Install node by following the
 (the version of the nodejs package in the standard Ubuntu repositories is too
 old).
 
-Upgrade pip and npm, and install tox and tox-pip-extensions:
+Upgrade pip and npm, and install tox:
 
 .. code-block:: bash
 
-    sudo pip install -U pip tox tox-pip-extensions
+    sudo pip install -U pip tox
     sudo npm install -g npm
+
 
 Installing the system dependencies on macOS
 -------------------------------------------
@@ -76,11 +77,11 @@ Install the following packages:
 .. note:: Unfortunately you need to install the ``postgresql`` package, because
           Homebrew does not currently provide a standalone ``libpq`` package.
 
-Upgrade pip and install tox and tox-pip-extensions:
+Upgrade pip and install tox:
 
 .. code-block:: bash
 
-    pip install -U pip tox tox-pip-extensions
+    pip install -U pip tox
 
 
 Getting the h source code from GitHub

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,6 @@
 [tox]
 envlist = py27
 skipsdist = true
-requires =
-    tox-pip-extensions
-tox_pip_extensions_ext_venv_update = true
 
 [pytest]
 minversion = 2.8


### PR DESCRIPTION
Revert three commits in order to remove tox-pip-extensions from the project:

1. Revert "Pin to tox 3.3.0". This reverts commit dd9aa5302220088d492397b8bf9266cb6c2c8062.

2. Revert "tox: Crash if tox-pip-extensions not installed". This reverts commit acff0bc6220fa19fa098276260a4c8a9200e57fe.

3. Revert "Use venv_update to auto update virtualenvs". This reverts commit ebaf18690e2d24cd1db466caf8d362638abf2ea6.

We've been having a couple of different tox problems that seem to be caused, directly or indirectly, by tox-pip-extensions. Removing it for now to get the build working again. May add tox-pip-extensions back later when we can get it working, or replace it with something else.