### PR TITLE
Re-enable venv-update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
         postgresql: "9.4"
       before_install:
         - ./scripts/elasticsearch.sh
-      install: pip install tox
+      install: pip install tox==3.3.0 tox-pip-extensions
       before_script: createdb htest
       script: tox
       after_success:
@@ -24,7 +24,7 @@ matrix:
         postgresql: '9.4'
       before_install:
         - ./scripts/elasticsearch.sh
-      install: pip install tox
+      install: pip install tox==3.3.0 tox-pip-extensions
       before_script: createdb htest
       script:
         make test-py3
@@ -50,7 +50,7 @@ matrix:
     - env: ACTION=backend-lint
       language: python
       python: '3.6'
-      install: pip install tox
+      install: pip install tox==3.3.0 tox-pip-extensions
       script:
         make lint
 
@@ -58,7 +58,7 @@ matrix:
     - env: ACTION=check-docs
       language: python
       python: '3.6'
-      install: pip install tox
+      install: pip install tox==3.3.0 tox-pip-extensions
       script:
         make checkdocs
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,7 +30,7 @@ node {
                 // Test dependencies
                 sh 'apk add --no-cache build-base libffi-dev postgresql-dev python-dev'
                 sh 'apk add --no-cache python3 python3-dev'
-                sh 'pip install -q tox'
+                sh 'pip install -q tox==3.3.0 tox-pip-extensions'
 
                 // Unit tests
                 sh 'cd /var/lib/hypothesis && tox'

--- a/docs/developing/install.rst
+++ b/docs/developing/install.rst
@@ -46,12 +46,23 @@ Install node by following the
 (the version of the nodejs package in the standard Ubuntu repositories is too
 old).
 
-Upgrade pip and npm, and install tox and tox-pip-extensions:
+Upgrade pip and npm, and install tox 3.3.0 and tox-pip-extensions:
 
 .. code-block:: bash
 
-    sudo pip install -U pip tox tox-pip-extensions
+    sudo pip install -U pip tox==3.3.0 tox-pip-extensions
     sudo npm install -g npm
+
+.. note::
+
+   Tox version 3.3.0 is required until an incompatibility between
+   tox-pip-extensions and newer versions of tox is resolved:
+
+   https://github.com/tox-dev/tox-pip-extensions/issues/16
+
+   If you see a ``TypeError: 'NoneType' object is not iterable`` error from tox
+   then make sure you have tox 3.3 and not a newer version of tox installed
+   (``sudo pip install -U tox==3.3.0``).
 
 Installing the system dependencies on macOS
 -------------------------------------------
@@ -76,12 +87,22 @@ Install the following packages:
 .. note:: Unfortunately you need to install the ``postgresql`` package, because
           Homebrew does not currently provide a standalone ``libpq`` package.
 
-Upgrade pip and install tox and tox-pip-extensions:
+Upgrade pip and install tox 3.3.0 and tox-pip-extensions:
 
 .. code-block:: bash
 
-    pip install -U pip tox tox-pip-extensions
+    pip install -U pip tox==3.3.0 tox-pip-extensions
 
+.. note::
+
+   Tox version 3.3.0 is required until an incompatibility between
+   tox-pip-extensions and newer versions of tox is resolved:
+
+   https://github.com/tox-dev/tox-pip-extensions/issues/16
+
+   If you see a ``TypeError: 'NoneType' object is not iterable`` error from tox
+   then make sure you have Tox 3.3 and not a newer version of Tox installed
+   (``pip install -U tox==3.3.0``).
 
 Getting the h source code from GitHub
 -------------------------------------

--- a/docs/developing/install.rst
+++ b/docs/developing/install.rst
@@ -46,13 +46,12 @@ Install node by following the
 (the version of the nodejs package in the standard Ubuntu repositories is too
 old).
 
-Upgrade pip and npm, and install tox:
+Upgrade pip and npm, and install tox and tox-pip-extensions:
 
 .. code-block:: bash
 
-    sudo pip install -U pip tox
+    sudo pip install -U pip tox tox-pip-extensions
     sudo npm install -g npm
-
 
 Installing the system dependencies on macOS
 -------------------------------------------
@@ -77,11 +76,11 @@ Install the following packages:
 .. note:: Unfortunately you need to install the ``postgresql`` package, because
           Homebrew does not currently provide a standalone ``libpq`` package.
 
-Upgrade pip and install tox:
+Upgrade pip and install tox and tox-pip-extensions:
 
 .. code-block:: bash
 
-    pip install -U pip tox
+    pip install -U pip tox tox-pip-extensions
 
 
 Getting the h source code from GitHub

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,9 @@
 [tox]
 envlist = py27
 skipsdist = true
+requires =
+    tox-pip-extensions
+tox_pip_extensions_ext_venv_update = true
 
 [pytest]
 minversion = 2.8


### PR DESCRIPTION
Now that [venv-update has been fixed](https://github.com/Yelp/venv-update/issues/214) we can use it (via tox-pip-extensions) again. Re-enable venv-update by reverting "Remove tox-pip-extensions". This reverts commit 73b50ad55d343fbe1aa85b9580408148e6d1cdc8.