### PR TITLE
Add HiddenFilter to eventually replace the NipsaFilter.

### DIFF
--- a/h/models/feature.py
+++ b/h/models/feature.py
@@ -19,6 +19,7 @@ FEATURES = {
     'api_render_user_info': "Return users' extended info in API responses?",
     'client_display_names': "Render display names instead of user names in the client",
     'wildcard_search_on_activity_pages': "Enable wildcard search via url facet on activity pages.",
+    'replace_nipsa_with_hidden_filter': "Filter annotations which are marked as hidden or belong to a nipsaed user.",
 }
 
 # Once a feature has been fully deployed, we remove the flag from the codebase.

--- a/h/nipsa/subscribers.py
+++ b/h/nipsa/subscribers.py
@@ -9,7 +9,8 @@ def transform_annotation(event):
     payload = event.annotation_dict
 
     nipsa = _user_nipsa(event.request, payload)
-    nipsa = nipsa or _annotation_moderated(event.request, annotation)
+    if not event.request.feature('replace_nipsa_with_hidden_filter'):
+        nipsa = nipsa or _annotation_moderated(event.request, annotation)
 
     if nipsa:
         payload['nipsa'] = True

--- a/h/search/core.py
+++ b/h/search/core.py
@@ -41,17 +41,30 @@ class Search(object):
         self._replies_limit = _replies_limit
         # Order matters! The KeyValueMatcher must be run last,
         # after all other modifiers have popped off the params.
-        self._modifiers = [query.Sorter(),
-                           query.Limiter(),
-                           query.DeletedFilter(),
-                           query.AuthFilter(request),
-                           query.GroupFilter(),
-                           query.GroupAuthFilter(request),
-                           query.UserFilter(),
-                           query.NipsaFilter(request),
-                           query.AnyMatcher(),
-                           query.TagsMatcher(),
-                           query.KeyValueMatcher()]
+        if request.feature('replace_nipsa_with_hidden_filter'):
+            self._modifiers = [query.Sorter(),
+                               query.Limiter(),
+                               query.DeletedFilter(),
+                               query.AuthFilter(request),
+                               query.GroupFilter(),
+                               query.GroupAuthFilter(request),
+                               query.UserFilter(),
+                               query.HiddenFilter(request),
+                               query.AnyMatcher(),
+                               query.TagsMatcher(),
+                               query.KeyValueMatcher()]
+        else:
+            self._modifiers = [query.Sorter(),
+                               query.Limiter(),
+                               query.DeletedFilter(),
+                               query.AuthFilter(request),
+                               query.GroupFilter(),
+                               query.GroupAuthFilter(request),
+                               query.UserFilter(),
+                               query.NipsaFilter(request),
+                               query.AnyMatcher(),
+                               query.TagsMatcher(),
+                               query.KeyValueMatcher()]
         self._aggregations = []
 
     def run(self, params):

--- a/h/search/query.py
+++ b/h/search/query.py
@@ -386,6 +386,31 @@ class DeletedFilter(object):
         return search.exclude("exists", field="deleted")
 
 
+class HiddenFilter(object):
+    """Return an Elasticsearch filter for filtering out moderated or NIPSA'd annotations."""
+
+    def __init__(self, request):
+        self.group_service = request.find_service(name='group')
+        self.user = request.user
+
+    def __call__(self, search, _):
+        """Filter out all hidden and NIPSA'd annotations except the current user's."""
+        # If any one of these "should" clauses is true then the annotation will
+        # get through the filter.
+        should_clauses = [Q("bool", must_not=[Q("term", nipsa=True), Q("term", hidden=True)])]
+
+        if self.user is not None:
+            # Always show the logged-in user's annotations even if they have nipsa.
+            should_clauses.append(Q("term", user=self.user.userid.lower()))
+
+            # Also include nipsa'd annotations for groups that the user created.
+            created_groups = self.group_service.groupids_created_by(self.user)
+            if created_groups:
+                should_clauses.append(Q("terms", group=created_groups))
+
+        return search.filter(Q("bool", should=should_clauses))
+
+
 class NipsaFilter(object):
     """Return an Elasticsearch filter for filtering out NIPSA'd annotations."""
 

--- a/tests/h/nipsa/subscribers_test.py
+++ b/tests/h/nipsa/subscribers_test.py
@@ -40,22 +40,36 @@ class TestTransformAnnotation(object):
         else:
             assert 'nipsa' not in ann.data
 
-    @pytest.mark.parametrize('ann,moderated', [
-        (FakeAnnotation({'id': 'normal'}), False),
-        (FakeAnnotation({'id': 'moderated'}), True)
+    @pytest.mark.parametrize('ann,moderated,enable_hidden_filter', [
+        (FakeAnnotation({'id': 'normal'}), False, True),
+        (FakeAnnotation({'id': 'moderated'}), True, True),
+        (FakeAnnotation({'id': 'normal'}), False, False),
+        (FakeAnnotation({'id': 'moderated'}), True, False)
     ])
-    def test_with_moderated_annotation(self, ann, moderated, moderation_service, pyramid_request):
+    def test_with_moderated_annotation(self,
+                                       ann,
+                                       moderated,
+                                       enable_hidden_filter, 
+                                       moderation_service,
+                                       pyramid_request):
         moderation_service.hidden.return_value = moderated
         event = FakeEvent(request=pyramid_request,
                           annotation=ann,
                           annotation_dict=ann.data)
+        pyramid_request.feature.flags['replace_nipsa_with_hidden_filter'] = enable_hidden_filter
 
         subscribers.transform_annotation(event)
 
-        if moderated:
-            assert ann.data['nipsa'] is True
+        if enable_hidden_filter:
+            if moderated:
+                assert 'nipsa' not in ann.data
+            else:
+                assert 'nipsa' not in ann.data
         else:
-            assert 'nipsa' not in ann.data
+            if moderated:
+                assert ann.data['nipsa'] is True
+            else:
+                assert 'nipsa' not in ann.data
 
     @pytest.fixture
     def nipsa_service(self, pyramid_config):

--- a/tests/h/search/query_test.py
+++ b/tests/h/search/query_test.py
@@ -670,6 +670,102 @@ class TestNipsaFilter(object):
         return group_service
 
 
+@pytest.mark.usefixtures('pyramid_config')
+class TestHiddenFilter(object):
+
+    @pytest.mark.parametrize('nipsa,hidden,should_show_annotation', [
+        # both nipsa and hidden fields are set, so don't show the annotation
+        (True, True, False),
+        # nipsa field is set, so don't show the annotation
+        (True, False, False),
+        # hidden field is set, so don't show the annotation
+        (False, True, False),
+        # neither field is set, show the annotation
+        (False, False, True),
+    ])
+    def test_visibility_of_moderated_and_nipsaed_annotations(
+        self, index, Annotation, pyramid_request, search, user,
+        AnnotationSearchIndexPresenter, nipsa, hidden, should_show_annotation
+    ):
+        pyramid_request.user = user
+        search.append_modifier(query.HiddenFilter(pyramid_request))
+        presenter = AnnotationSearchIndexPresenter.return_value
+        presenter.asdict.return_value = {'id': 'ann1',
+                                         'hidden': hidden,
+                                         'nipsa': nipsa}
+        Annotation(id='ann1')
+        presenter.asdict.return_value = {'id': 'ann2',
+                                         'hidden': False,
+                                         'nipsa': False}
+        Annotation(id='ann2', userid=user.userid)
+        expected_ids = ['ann2']
+        if should_show_annotation:
+           expected_ids.append('ann1')
+        result = search.run({})
+        assert sorted(result.annotation_ids) == sorted(expected_ids)
+
+    def test_hides_banned_users_annotations_from_other_users(
+        self, pyramid_request, search, banned_user, user, Annotation
+    ):
+        pyramid_request.user = user
+        search.append_modifier(query.HiddenFilter(pyramid_request))
+        Annotation(userid=banned_user.userid)
+        expected_ids = [Annotation(userid=user.userid).id]
+
+        result = search.run(webob.multidict.MultiDict({}))
+
+        assert sorted(result.annotation_ids) == sorted(expected_ids)
+
+    def test_shows_banned_users_annotations_to_banned_user(
+        self, pyramid_request, search, banned_user, user, Annotation
+    ):
+        pyramid_request.user = banned_user
+        search.append_modifier(query.HiddenFilter(pyramid_request))
+        expected_ids = [Annotation(userid=banned_user.userid).id]
+
+        result = search.run(webob.multidict.MultiDict({}))
+
+        assert sorted(result.annotation_ids) == sorted(expected_ids)
+
+    def test_shows_banned_users_annotations_in_groups_they_created(
+        self, pyramid_request, search, banned_user, user, Annotation,
+        group_service,
+    ):
+        pyramid_request.user = user
+        group_service.groupids_created_by.return_value = ["created_by_banneduser"]
+        search.append_modifier(query.HiddenFilter(pyramid_request))
+        expected_ids = [Annotation(groupid="created_by_banneduser",
+                                   userid=banned_user.userid).id]
+
+        result = search.run(webob.multidict.MultiDict({}))
+
+        assert sorted(result.annotation_ids) == sorted(expected_ids)
+
+    @pytest.fixture
+    def banned_user(self, factories):
+        return factories.User(username="banned", nipsa=True)
+
+    @pytest.fixture
+    def user(self, factories):
+        return factories.User(username="notbanned", nipsa=False)
+
+    @pytest.fixture
+    def pyramid_config(self, pyramid_config, banned_user):
+        # Fake implementation of the `AnnotationTransformEvent` subscriber
+        # which adds the "nipsa" flag to annotations during indexing.
+        def add_nipsa_flag(event):
+            if event.annotation.userid == banned_user.userid:
+                event.annotation_dict['nipsa'] = True
+        pyramid_config.add_subscriber(add_nipsa_flag, 'h.events.AnnotationTransformEvent')
+
+        return pyramid_config
+
+    @pytest.fixture
+    def group_service(self, group_service):
+        group_service.groupids_created_by.return_value = []
+        return group_service
+
+
 class TestAnyMatcher(object):
     def test_matches_uriparts(self, search, Annotation):
         Annotation(target_uri="http://bar.com")
@@ -919,3 +1015,10 @@ def es_dsl_search(pyramid_request):
         using=pyramid_request.es.conn,
         index=pyramid_request.es.index,
     )
+
+
+@pytest.fixture
+def AnnotationSearchIndexPresenter(patch):
+    AnnotationSearchIndexPresenter = patch('h.search.index.presenters.AnnotationSearchIndexPresenter')
+    AnnotationSearchIndexPresenter.return_value.asdict.return_value = {'test': 'val'}
+    return AnnotationSearchIndexPresenter


### PR DESCRIPTION
The hidden filter combines the logic for filtering annotations
which are moderated or belong to a nipsaed user when the
'replace_nipsa_with_hidden_filter' feature flag is turned on.

See hypothesis/product-backlog#583