### PR TITLE
Use elasticsearch to get annotation_user_count

### DIFF
--- a/h/search/__init__.py
+++ b/h/search/__init__.py
@@ -5,6 +5,9 @@ from h.search.client import get_client
 from h.search.config import init
 from h.search.core import Search
 from h.search.query import (TopLevelAnnotationsFilter,
+                            DeletedFilter,
+                            Limiter,
+                            UserFilter,
                             AuthorityFilter,
                             TagsAggregation,
                             UsersAggregation,
@@ -14,6 +17,9 @@ from h.search.query import (TopLevelAnnotationsFilter,
 __all__ = (
     'Search',
     'TopLevelAnnotationsFilter',
+    'DeletedFilter',
+    'Limiter',
+    'UserFilter',
     'AuthorityFilter',
     'TagsAggregation',
     'UsersAggregation',

--- a/h/services/annotation_stats.py
+++ b/h/services/annotation_stats.py
@@ -2,10 +2,8 @@
 
 from __future__ import unicode_literals
 
-import sqlalchemy as sa
 from webob.multidict import MultiDict
 
-from h.models import Annotation
 from h.search import Search
 from h.search import TopLevelAnnotationsFilter
 
@@ -16,35 +14,26 @@ class AnnotationStatsService(object):
     def __init__(self, request):
         self.request = request
 
-    def user_annotation_counts(self, userid):
-        """Return the count of annotations for this user."""
+    def user_annotation_count(self, userid):
+        """
+        Return the count of searchable top level annotations for this user.
 
-        annotations = self.request.db.query(Annotation). \
-            filter_by(userid=userid, deleted=False). \
-            options(sa.orm.load_only('groupid', 'shared')).subquery()
-        grouping = sa.case([
-            (sa.not_(annotations.c.shared), 'private'),
-            (annotations.c.groupid == '__world__', 'public'),
-        ], else_='group')
-
-        result = dict(self.request.db.query(grouping, sa.func.count(annotations.c.id)).group_by(grouping).all())
-        for key in ['public', 'group', 'private']:
-            result.setdefault(key, 0)
-
-        result['total'] = result['public'] + \
-            result['group'] + \
-            result['private']
-
-        return result
+        If the logged in user has this userid, private annotations will be
+        included in this count, otherwise they will not.
+        """
+        params = MultiDict({'limit': 0, 'user': userid})
+        return self._search(params)
 
     def group_annotation_count(self, pubid):
         """
         Return the count of searchable top level annotations for this group.
         """
+        params = MultiDict({'limit': 0, 'group': pubid})
+        return self._search(params)
+
+    def _search(self, params):
         search = Search(self.request, stats=self.request.stats)
         search.append_modifier(TopLevelAnnotationsFilter())
-
-        params = MultiDict({'limit': 0, 'group': pubid})
 
         search_result = search.run(params)
         return search_result.total

--- a/h/views/admin/users.py
+++ b/h/views/admin/users.py
@@ -37,7 +37,7 @@ def users_index(request):
 
     if user is not None:
         svc = request.find_service(name='annotation_stats')
-        user_meta['annotations_count'] = svc.user_annotation_count(user.userid)
+        user_meta['annotations_count'] = svc.total_user_annotation_count(user.userid)
 
     return {
         'default_authority': request.default_authority,

--- a/h/views/admin/users.py
+++ b/h/views/admin/users.py
@@ -37,8 +37,7 @@ def users_index(request):
 
     if user is not None:
         svc = request.find_service(name='annotation_stats')
-        counts = svc.user_annotation_counts(user.userid)
-        user_meta['annotations_count'] = counts['total']
+        user_meta['annotations_count'] = svc.user_annotation_count(user.userid)
 
     return {
         'default_authority': request.default_authority,

--- a/tests/h/views/admin/users_test.py
+++ b/tests/h/views/admin/users_test.py
@@ -72,7 +72,7 @@ def test_users_index_strips_spaces(models, pyramid_request):
 def test_users_index_queries_annotation_count_by_userid(models, factories, pyramid_request, annotation_stats_service):
     user = factories.User.build(username='bob')
     models.User.get_by_username.return_value = user
-    annotation_stats_service.user_annotation_count.return_value = 8
+    annotation_stats_service.total_user_annotation_count.return_value = 8
 
     pyramid_request.params = {"username": "bob", "authority": user.authority}
     result = users_index(pyramid_request)
@@ -251,7 +251,7 @@ def annotation_stats_service(pyramid_config, pyramid_request):
         instance=True,
         spec_set=True)
     service.return_value.request = pyramid_request
-    service.user_annotation_count.return_value = 0
+    service.total_user_annotation_count.return_value = 0
     pyramid_config.register_service(service, name='annotation_stats')
     return service
 

--- a/tests/h/views/admin/users_test.py
+++ b/tests/h/views/admin/users_test.py
@@ -72,7 +72,7 @@ def test_users_index_strips_spaces(models, pyramid_request):
 def test_users_index_queries_annotation_count_by_userid(models, factories, pyramid_request, annotation_stats_service):
     user = factories.User.build(username='bob')
     models.User.get_by_username.return_value = user
-    annotation_stats_service.user_annotation_counts.return_value = {'total': 8}
+    annotation_stats_service.user_annotation_count.return_value = 8
 
     pyramid_request.params = {"username": "bob", "authority": user.authority}
     result = users_index(pyramid_request)
@@ -251,7 +251,7 @@ def annotation_stats_service(pyramid_config, pyramid_request):
         instance=True,
         spec_set=True)
     service.return_value.request = pyramid_request
-    service.user_annotation_counts.return_value = {'total': 0}
+    service.user_annotation_count.return_value = 0
     pyramid_config.register_service(service, name='annotation_stats')
     return service
 


### PR DESCRIPTION
Previously the count was obtained from a db query. The problem with
this was two fold:
 1. Shared was being queried on even though it wasn't indexed
 2. When searching for users such as scibot, where the user has a
    large portion of the annotations in the table, the db was optimizing
    to search the table directly rather than use the index due to the
    overhead of indexing lookup being larger than a full table scan.

Elasticsearch performs much better for aggregation queries with 
complex where clauses and it also has built in caching. Although
looking at the scibot user on activity pages doesn't happen that 
often, when it does, it takes up to 7.5 s of query time to perform 
this lookup. ES ends up taking ~.02 s. 

Rename annotation_user_counts to annotation_user_count and simply
return the total as opposed to the previous implementation that 
returned 3 different values. 

Add a new method total_annotation_user_counts that counts all the user's
annotations regardless of permissions, public/private, and includes replies.

Cache the parsed query params from query.extract so that the parser
doesn't have to be run twice in the group and user controllers.

If able, re-use the total user counts from the search to avoid running
the same query twice. 

This is the final fix for https://github.com/hypothesis/product-backlog/issues/812.