### PR TITLE
Enable retrying AMQP message publication in `h.realtime._publish`

### DIFF
--- a/h/realtime.py
+++ b/h/realtime.py
@@ -118,13 +118,18 @@ class Publisher(object):
 
     def _publish(self, routing_key, payload):
         headers = {'timestamp': datetime.utcnow().isoformat() + 'Z'}
+        retry_policy = {'max_retries': 5,
+                        'interval_start': 0.2,
+                        'interval_step': 0.3}
 
         with producer_pool[self.connection].acquire(block=True) as producer:
             producer.publish(payload,
                              exchange=self.exchange,
                              declare=[self.exchange],
                              routing_key=routing_key,
-                             headers=headers)
+                             headers=headers,
+                             retry=True,
+                             retry_policy=retry_policy)
 
 
 def get_exchange():

--- a/tests/h/realtime_test.py
+++ b/tests/h/realtime_test.py
@@ -99,7 +99,8 @@ class TestConsumer(object):
 
 
 class TestPublisher(object):
-    def test_publish_annotation(self, matchers, producer_pool, pyramid_request):
+    def test_publish_annotation(self, matchers, producer_pool, pyramid_request,
+                                retry_policy):
         payload = {'action': 'create', 'annotation': {'id': 'foobar'}}
         producer = producer_pool['foobar'].acquire().__enter__()
         exchange = realtime.get_exchange()
@@ -112,9 +113,12 @@ class TestPublisher(object):
                                                  exchange=exchange,
                                                  declare=[exchange],
                                                  routing_key='annotation',
-                                                 headers=expected_headers)
+                                                 headers=expected_headers,
+                                                 retry=True,
+                                                 retry_policy=retry_policy)
 
-    def test_publish_user(self, matchers, producer_pool, pyramid_request):
+    def test_publish_user(self, matchers, producer_pool, pyramid_request,
+                          retry_policy):
         payload = {'action': 'create', 'user': {'id': 'foobar'}}
         producer = producer_pool['foobar'].acquire().__enter__()
         exchange = realtime.get_exchange()
@@ -127,7 +131,15 @@ class TestPublisher(object):
                                                  exchange=exchange,
                                                  declare=[exchange],
                                                  routing_key='user',
-                                                 headers=expected_headers)
+                                                 headers=expected_headers,
+                                                 retry=True,
+                                                 retry_policy=retry_policy)
+
+    @pytest.fixture
+    def retry_policy(self):
+        return {'max_retries': 5,
+                'interval_start': 0.2,
+                'interval_step': 0.3}
 
     @pytest.fixture
     def producer_pool(self, patch):


### PR DESCRIPTION
We are seeing calls to `h.realtime.publish_annotation` periodically
failing with `socket.error` ("[Errno 110] Operation timed out")
exceptions in production at a rate of 30-150 events/day [1].

Enable Kombu's built-in retry mechanism for recovering from these
failures by retrying after a short delay [2].

The retry interval has been explicitly specified here because the
default (1 second) is quite long in the context of a web request.

This should hopefully resolve the most frequent source of https://github.com/hypothesis/h/issues/5311

[1] https://sentry.io/hypothesis/h/issues/499114248
[2] https://kombu.readthedocs.io/en/latest/reference/kombu.pools.html#kombu.pools.ProducerPool.Producer.publish

----

**Testing**: Locally make sure that realtime notifications still work on this branch. Once deployed to prod for a day or so, we should check the Sentry issues mentioned in the comments to see if they stop occurring.