### PR TITLE
Fix `hypothesis` commands in docs

### DIFF
--- a/docs/developing/administration.rst
+++ b/docs/developing/administration.rst
@@ -6,13 +6,13 @@ permissions. To grant admin permissions to a user, run the following command:
 
 .. code-block:: bash
 
-  hypothesis user admin <username>
+  tox -e py27-dev -- sh bin/hypothesis user admin <username>
 
 For example, to make the user 'joe' an admin in the development environment:
 
 .. code-block:: bash
 
-  hypothesis --dev user admin joe
+  tox -e py27-dev -- sh bin/hypothesis --dev user admin joe
 
 When this user signs in they can now access the adminstration panel at
 ``/admin``. The administration panel has options for managing users and optional

--- a/docs/developing/making-changes-to-model-code.rst
+++ b/docs/developing/making-changes-to-model-code.rst
@@ -47,7 +47,7 @@ steps to create a new migration script for h are:
 
    .. code-block:: bash
 
-      bin/hypothesis migrate revision -m "Add the foobar table"
+      tox -e py27-dev -- sh bin/hypothesis migrate revision -m "Add the foobar table"
 
    This will create a new script in ``h/migrations/versions/``.
 
@@ -71,7 +71,7 @@ steps to create a new migration script for h are:
 
    .. code-block:: bash
 
-      bin/hypothesis migrate stamp <revision_id>
+      tox -e py27-dev -- sh bin/hypothesis migrate stamp <revision_id>
 
    ``<revision_id>`` should be the revision corresponding to the version of the
    code that was present when the current database was created. The will
@@ -85,7 +85,7 @@ steps to create a new migration script for h are:
 
    .. code-block:: bash
 
-      bin/hypothesis migrate upgrade head
+      tox -e py27-dev -- sh bin/hypothesis migrate upgrade head
 
    After running this command inspect your database's schema to check that it's
    as expected, and run h to check that everything is working.
@@ -100,14 +100,14 @@ steps to create a new migration script for h are:
 
    .. code-block:: bash
 
-      bin/hypothesis migrate downgrade -1
+      tox -e py27-dev -- sh bin/hypothesis migrate downgrade -1
 
    After running this command inspect your database's schema to check that it's
    as expected. You can then upgrade it again:
 
    .. code-block:: bash
 
-      bin/hypothesis migrate upgrade +1
+      tox -e py27-dev -- sh bin/hypothesis migrate upgrade +1
 
 Batch deletes and updates in migration scripts
 ==============================================

--- a/docs/developing/ssl.rst
+++ b/docs/developing/ssl.rst
@@ -18,7 +18,7 @@ To serve your local dev instance of h over HTTPS:
 
 3. Run ``hypothesis devserver`` with the ``--https`` option::
 
-    hypothesis devserver --https
+    tox -e py27-dev -- sh bin/hypothesis devserver --https
 
 4. Since the certificate is self-signed, you will need to instruct your browser to
    trust it explicitly by visiting https://localhost:5000 and selecting the option


### PR DESCRIPTION
Fix various `bin/hypothesis` commands in the docs. Now that we use a tox-managed virtualenv instead of a manually created and activated one (see https://github.com/hypothesis/h/pull/5261) it's necessary for `bin/hypothesis` commands to be run inside tox.

Specifically, this commit changes the docs to run the hypothesis command inside the `py27-dev` virtualenv, which is the virtualenv that `make dev` uses.

Running the commands like this (`tox -e py27-dev -- sh bin/hypothesis ...`) is pretty awkward. I'm open to ideas for how to make it more convenient. For now, though, this gets the commands in the docs working.