### PR TITLE
Add a copy icon to annotation url on activity page

### DIFF
--- a/h/templates/activity/search.html.jinja2
+++ b/h/templates/activity/search.html.jinja2
@@ -72,10 +72,16 @@
       {% trans %}URL{% endtrans %}
     </h4>
     <div class="search-bucket-stats__val search-bucket-stats__url">
-        <a class="link--plain"
-           rel="nofollow noopener"
-           href="{{ bucket.uri }}"
-           target="_blank">{{ pretty_link(bucket.uri) }}</a>
+      <div class="group-invite__container js-copy-button">
+        <input class="group-invite__input js-select-onfocus"
+               data-ref="input"
+               value="{{ bucket.uri }}">
+        <button class="group-invite__clipboard-button"
+                data-ref="button"
+                title="Copy to clipboard">
+          {{ svg_icon('copy_to_clipboard', 'group-invite__clipboard-image') }}
+        </button>
+      </div>
     </div>
   {% endif %}
   <div class="u-stretch">


### PR DESCRIPTION
The "pretty url" displayed under the URL heading of an annotation
card on the activity page (https://hypothes.is/users/joe) is confusing to users since it is not
the full url. If the user copies this and pastes it into the url
search facet they expect it to work but in fact it does not because
it is not the full url.

Re-use the copy UI for group join links for the annotation URL so
the user can copy the full link inside the input box or simply
click the copy button to copy the full link to the clipboard.

Before:
![image](https://user-images.githubusercontent.com/30059933/46708852-8f83b680-cbf5-11e8-92e9-f01d0254bc2c.png)

After:
![image](https://user-images.githubusercontent.com/30059933/46708805-6cf19d80-cbf5-11e8-9a2f-8e90d337a318.png)

This is a fix for https://github.com/hypothesis/h/issues/5336 and https://github.com/hypothesis/h/issues/5335.