### PR TITLE
Revert "fixup: tests"

### DIFF
--- a/tests/h/eventqueue_test.py
+++ b/tests/h/eventqueue_test.py
@@ -13,38 +13,51 @@ class DummyEvent(object):
         self.request = request
 
 
+@pytest.mark.usefixtures('pyramid_config')
 class TestEventQueue(object):
-    def test_init_adds_response_callback(self, queue, pyramid_request):
-        pyramid_request.add_response_callback = mock.Mock(autospec=pyramid_request.add_response_callback)
-        queue = eventqueue.EventQueue(pyramid_request)
-        pyramid_request.add_response_callback.assert_called_once_with(queue.response_callback)
+    def test_init_adds_response_callback(self, pyramid_request):
+        request = mock.Mock()
+        queue = eventqueue.EventQueue(request)
 
-    def test_call_appends_event_to_queue(self, queue, event):
+        request.add_response_callback.assert_called_once_with(queue.response_callback)
+
+    def test_call_appends_event_to_queue(self):
+        queue = eventqueue.EventQueue(mock.Mock())
+
         assert len(queue.queue) == 0
-
+        event = mock.Mock()
         queue(event)
         assert list(queue.queue) == [event]
 
-    def test_publish_all_notifies_events_in_fifo_order(self, queue, subscriber, event_factory, pyramid_config):
-        pyramid_config.add_subscriber(subscriber, DummyEvent)
-        firstevent = event_factory.get()
-        secondevent = event_factory.get()
-
+    def test_publish_all_notifies_events_in_fifo_order(self, pyramid_request, subscriber):
+        queue = eventqueue.EventQueue(pyramid_request)
+        firstevent = DummyEvent(pyramid_request)
         queue(firstevent)
+        secondevent = DummyEvent(pyramid_request)
         queue(secondevent)
 
         queue.publish_all()
 
-        subscriber.assert_has_calls([mock.call(firstevent), mock.call(secondevent)])
+        assert subscriber.call_args_list == [
+            mock.call(firstevent),
+            mock.call(secondevent)
+        ]
 
-    def test_publish_all_sandboxes_each_subscriber(self, event, subscriber_factory, failing_subscriber, pyramid_config, queue):
-        subscribers = [
-            subscriber_factory.get(),
-            failing_subscriber,
-            subscriber_factory.get()]
+    def test_publish_all_sandboxes_each_subscriber(self, pyramid_request, pyramid_config):
+        queue = eventqueue.EventQueue(pyramid_request)
 
+        def failing_subscriber(event):
+            raise Exception('failing_subscriber failed')
+        first_subscriber = mock.Mock()
+        second_subscriber = mock.Mock()
+        second_subscriber.side_effect = failing_subscriber
+        third_subscriber = mock.Mock()
+
+        subscribers = [first_subscriber, second_subscriber, third_subscriber]
         for sub in subscribers:
             pyramid_config.add_subscriber(sub, DummyEvent)
+
+        event = DummyEvent(pyramid_request)
 
         queue(event)
         queue.publish_all()
@@ -54,83 +67,65 @@ class TestEventQueue(object):
         for sub in subscribers:
             sub.assert_called_once_with(event)
 
-    def test_publish_all_reraises_in_debug_mode(self, failing_subscriber, event, queue, pyramid_request, pyramid_config):
-        pyramid_config.add_subscriber(failing_subscriber, DummyEvent)
+    def test_publish_all_reraises_in_debug_mode(self, subscriber, pyramid_request):
+        queue = eventqueue.EventQueue(pyramid_request)
         pyramid_request.debug = True
+        subscriber.side_effect = Exception('boom!')
 
         with pytest.raises(Exception) as excinfo:
-            queue(event)
+            queue(DummyEvent(pyramid_request))
             queue.publish_all()
         assert str(excinfo.value) == 'boom!'
 
-    def test_publish_all_sends_exception_to_sentry(self, failing_subscriber, event, queue, pyramid_request, pyramid_config):
-        pyramid_config.add_subscriber(failing_subscriber, DummyEvent)
-        pyramid_request.sentry = mock.Mock(spec_set=['captureException'])
+    def test_publish_all_sends_exception_to_sentry(self, subscriber, pyramid_request):
+        pyramid_request.sentry = mock.Mock()
+        subscriber.side_effect = ValueError('exploded!')
+        queue = eventqueue.EventQueue(pyramid_request)
+        event = DummyEvent(pyramid_request)
         queue(event)
 
         queue.publish_all()
 
         assert pyramid_request.sentry.captureException.called
 
-    def test_publish_all_logs_exception_when_sentry_is_not_available(self, log, failing_subscriber, event, queue, pyramid_config):
-        pyramid_config.add_subscriber(failing_subscriber, DummyEvent)
+    def test_publish_all_logs_exception_when_sentry_is_not_available(self, log, subscriber, pyramid_request):
+        subscriber.side_effect = ValueError('exploded!')
+        queue = eventqueue.EventQueue(pyramid_request)
+        event = DummyEvent(pyramid_request)
         queue(event)
 
         queue.publish_all()
 
         assert log.exception.called
 
-    def test_response_callback_skips_publishing_events_on_exception(self, publish_all, queue, pyramid_request):
+    def test_response_callback_skips_publishing_events_on_exception(self, publish_all, pyramid_request):
         pyramid_request.exception = ValueError('exploded!')
+        queue = eventqueue.EventQueue(pyramid_request)
         queue.response_callback(pyramid_request, None)
         assert not publish_all.called
 
-    def test_response_callback_publishes_events(self, publish_all, event, queue, pyramid_request):
-        queue(event)
+    def test_response_callback_publishes_events(self, publish_all, pyramid_request):
+        queue = eventqueue.EventQueue(pyramid_request)
+        queue(mock.Mock())
         queue.response_callback(pyramid_request, None)
         assert publish_all.called
 
     @pytest.fixture
     def log(self, patch):
-        return patch('h.eventqueue.log', autospec=True)
+        return patch('h.eventqueue.log')
 
     @pytest.fixture
     def publish_all(self, patch):
-        return patch('h.eventqueue.EventQueue.publish_all', autospec=True)
+        return patch('h.eventqueue.EventQueue.publish_all')
 
     @pytest.fixture
-    def event(self, event_factory):
-        return event_factory.get()
+    def subscriber(self):
+        return mock.Mock()
 
     @pytest.fixture
-    def event_factory(self, pyramid_request):
-
-        class EventFactory():
-            def get(self):
-                return DummyEvent(pyramid_request)
-
-        return EventFactory()
-
-    @pytest.fixture
-    def subscriber(self, subscriber_factory):
-        return subscriber_factory.get()
-
-    @pytest.fixture
-    def failing_subscriber(self, subscriber_factory):
-        sub = subscriber_factory.get()
-        sub.side_effect = Exception("boom!")
-        return sub
-
-    @pytest.fixture
-    def subscriber_factory(self):
-        class SubscriberFactory():
-            def get(self):
-                return mock.Mock()
-        return SubscriberFactory()
-
-    @pytest.fixture
-    def queue(self, pyramid_request):
-        return eventqueue.EventQueue(pyramid_request)
+    def pyramid_config(self, pyramid_config, subscriber):
+        pyramid_config.add_subscriber(subscriber, DummyEvent)
+        return pyramid_config
 
     @pytest.fixture
     def pyramid_request(self, pyramid_request):


### PR DESCRIPTION
This was included by mistake when merging https://github.com/hypothesis/h/pull/5337

This reverts commit 02959990e6d68ca1bcb21263e4ea8a3eba2c4316.