### PR TITLE
Add authorization functional tests for `/api/annotation[s]` endpoints

### DIFF
--- a/h/views/api/annotations.py
+++ b/h/views/api/annotations.py
@@ -160,6 +160,7 @@ def delete(context, request):
         context.annotation,
         'delete')
 
+    # TODO: Track down why we don't return an HTTP 204 like other DELETEs
     return {'id': context.annotation.id, 'deleted': True}
 
 

--- a/tests/functional/api/test_annotations.py
+++ b/tests/functional/api/test_annotations.py
@@ -14,19 +14,6 @@ native_str = str
 
 
 @pytest.mark.functional
-class TestGetAnnotations(object):
-    def test_api_index(self, app):
-        """
-        Test the API index view.
-
-        This view is tested more thoroughly in the view tests, but this test
-        checks the view doesn't error out and returns appropriate-looking JSON.
-        """
-        res = app.get('/api/')
-        assert 'links' in res.json
-
-
-@pytest.mark.functional
 class TestGetAnnotation(object):
     def test_it_returns_annotation_if_shared(self, app, annotation):
         """Unauthenticated users may view shared annotations assuming they have group access"""

--- a/tests/functional/api/test_annotations.py
+++ b/tests/functional/api/test_annotations.py
@@ -40,7 +40,7 @@ class TestGetAnnotations(object):
         assert data['id'] == 'http://example.com/a/' + annotation.id
 
 
-class TestWriteAnnotation(object):
+class TestPostAnnotation(object):
     def test_it_returns_http_404_if_unauthorized(self, app):
         # FIXME: This should return a 403
 
@@ -66,7 +66,7 @@ class TestWriteAnnotation(object):
 
         assert res.status_code == 403
 
-    def test_annotation_write_unauthorized_group(self, app, user_with_token, non_writeable_group):
+    def test_it_returns_http_400_if_group_forbids_write(self, app, user_with_token, non_writeable_group):
         """
         Write an annotation to a group that doesn't allow writes.
 

--- a/tests/functional/api/test_annotations.py
+++ b/tests/functional/api/test_annotations.py
@@ -185,6 +185,40 @@ class TestPatchAnnotation(object):
         assert res.status_code == 404
 
 
+@pytest.mark.functional
+class TestDeleteAnnotation(object):
+
+    def test_it_deletes_annotation_if_authorized(self, app, user_annotation, user_with_token):
+        """An annotation's creator (user) is blessed with the 'update' permission"""
+        user, token = user_with_token
+
+        headers = {'Authorization': str('Bearer {}'.format(token.value))}
+
+        res = app.delete('/api/annotations/{id}'.format(id=user_annotation.id),
+                                                        headers=headers)
+
+        assert res.status_code == 200
+        assert res.json['id'] == user_annotation.id
+
+    def test_it_returns_http_404_if_unauthenticated(self, app, user_annotation):
+
+        res = app.delete('/api/annotations/{id}'.format(id=user_annotation.id),
+                                                        expect_errors=True)
+
+        assert res.status_code == 404
+
+    def test_it_returns_http_404_if_unauthorized(self, app, annotation, user_with_token):
+        """The user in this request is not the annotation's creator"""
+        user, token = user_with_token
+        headers = {'Authorization': str('Bearer {}'.format(token.value))}
+
+        res = app.delete('/api/annotations/{id}'.format(id=annotation.id),
+                                                        headers=headers,
+                                                        expect_errors=True)
+
+        assert res.status_code == 404
+
+
 @pytest.fixture
 def annotation(db_session, factories):
     ann = factories.Annotation(userid='acct:testuser@example.com',


### PR DESCRIPTION
Need to get some functional tests in place for existing authorization-failure responses so that changes introduced by https://github.com/hypothesis/product-backlog/issues/769 may be testable.

Tracking some of these missing functional authorization-related tests in a spreadsheet here: https://docs.google.com/spreadsheets/d/1TJWLSaf1wjjHzmZxi4OHcaaUYrIZdbxiQAtxU2hnUjc/edit#gid=0

This PR adds functional tests for the authorization on various endpoints for annotation resources (GET, POST, PATCH, DELETE). These functional tests are not complete—they are specifically targeted at verifying authorization. The purpose is to catch any unintended response changes when cleaning up the authorization failure responses later.

While composing these, I noted and commented an oddity: our `DELETE annotation` endpoint returns a 200 with status information in the JSON body on success. That deviates from our other DELETE endpoints (and from convention); typically you'd return an empty 204 response. Noted for later; I'd like to track it down (but we may be stuck until we've got API versioning as it's in our published API at present).