### PR TITLE
Replace ? wildcard with _

### DIFF
--- a/docs/_extra/api-reference/hypothesis.yaml
+++ b/docs/_extra/api-reference/hypothesis.yaml
@@ -380,15 +380,15 @@ paths:
             PDF fingerprint.
 
             `*` will match any character sequence (including an empty one), 
-            and a `?` will match any single character. `*`s are only permitted 
-            within the path and query parts of the URI and `?`s are only permitted
+            and a `_` will match any single character. `*`s are only permitted 
+            within the path and query parts of the URI and `_`s are only permitted
             within the domain, path, and query parts of the URI.
 
             Escaping wildcards is not supported.
 
-            Examples of valid uris: `http://foo.com/*` `urn:x-pdf:*` `file://localhost/?bc.pdf`
+            Examples of valid uris: `http://foo.com/*` `urn:x-pdf:*` `file://localhost/_bc.pdf`
 
-            Examples of invalid uris: `*foo.com` `u?n:*` `file://*` `http://foo.com*`
+            Examples of invalid uris: `*foo.com` `u_n:*` `file://*` `http://foo.com*`
             
             <mark>This feature is experimental and the API may change.</mark>
           required: false

--- a/h/schemas/annotation.py
+++ b/h/schemas/annotation.py
@@ -439,14 +439,14 @@ class SearchParamsSchema(colander.Schema):
             PDF fingerprint.
 
             `*` will match any character sequence (including an empty one),
-            and a `?` will match any single character. `*`s are only permitted
-            within the path and query parts of the URI and `?`s are only permitted
+            and a `_` will match any single character. `*`s are only permitted
+            within the path and query parts of the URI and `_`s are only permitted
             within the domain, path, and query parts of the URI.
 
             Escaping wildcards is not supported.
 
-            Examples of valid uris":" `http://foo.com/*` `urn:x-pdf:*` `file://localhost/?bc.pdf`
-            Examples of invalid uris":" `*foo.com` `u?n:*` `file://*` `http://foo.com*`
+            Examples of valid uris":" `http://foo.com/*` `urn:x-pdf:*` `file://localhost/_bc.pdf`
+            Examples of invalid uris":" `*foo.com` `u_n:*` `file://*` `http://foo.com*`
             """,
     )
     any = colander.SchemaNode(


### PR DESCRIPTION
Since ?'s are reserved characters in URL's, using ? causes a lot of
headaches in the URL normalization as /?'s get converted to ? and
? with no text following it gets stripped entirely, etc. Rather than
fighting with url normalization simply use a different character and
replace it with ? after url normalization.