### PR TITLE
Deprecate wildcard_search_on_activity_pages feature flag

### DIFF
--- a/h/activity/query.py
+++ b/h/activity/query.py
@@ -19,7 +19,6 @@ from h.search import (TopLevelAnnotationsFilter,
                       AuthorityFilter,
                       TagsAggregation,
                       UsersAggregation,
-                      UriFilter,
                       UriCombinedWildcardFilter)
 
 
@@ -169,10 +168,7 @@ def _execute_search(request, query, page_size):
     search = Search(request, stats=request.stats)
     search.append_modifier(AuthorityFilter(authority=request.default_authority))
     search.append_modifier(TopLevelAnnotationsFilter())
-    if request.feature("wildcard_search_on_activity_pages"):
-        search.append_modifier(UriCombinedWildcardFilter(request=request))
-    else:
-        search.append_modifier(UriFilter(request=request))
+    search.append_modifier(UriCombinedWildcardFilter(request=request))
     for agg in aggregations_for(query):
         search.append_aggregation(agg)
 

--- a/h/models/feature.py
+++ b/h/models/feature.py
@@ -18,7 +18,6 @@ FEATURES = {
     'overlay_highlighter': "Use the new overlay highlighter?",
     'api_render_user_info': "Return users' extended info in API responses?",
     'client_display_names': "Render display names instead of user names in the client",
-    'wildcard_search_on_activity_pages': "Enable wildcard search via url facet on activity pages.",
 }
 
 # Once a feature has been fully deployed, we remove the flag from the codebase.
@@ -40,6 +39,7 @@ FEATURES = {
 # 4. Finally, remove the feature from FEATURES_PENDING_REMOVAL.
 #
 FEATURES_PENDING_REMOVAL = {
+    'wildcard_search_on_activity_pages': "Enable wildcard search via url facet on activity pages.",
 }
 
 

--- a/tests/h/activity/query_test.py
+++ b/tests/h/activity/query_test.py
@@ -252,24 +252,15 @@ class TestExecute(object):
         AuthorityFilter.assert_called_once_with(pyramid_request.default_authority)
         search.append_modifier.assert_any_call(AuthorityFilter.return_value)
 
-    @pytest.mark.parametrize('enable_flag', (True, False))
     def test_it_recognizes_wildcards_in_uri_url(self,
                                                 pyramid_request,
                                                 search,
-                                                UriFilter,
-                                                UriCombinedWildcardFilter,
-                                                enable_flag):
-
-        pyramid_request.feature.flags['wildcard_search_on_activity_pages'] = enable_flag
+                                                UriCombinedWildcardFilter):
 
         execute(pyramid_request, MultiDict(), self.PAGE_SIZE)
 
-        if enable_flag:
-            UriCombinedWildcardFilter.assert_called_once_with(pyramid_request)
-            search.append_modifier.assert_any_call(UriCombinedWildcardFilter.return_value)
-        else:
-            UriFilter.assert_called_once_with(pyramid_request)
-            search.append_modifier.assert_any_call(UriFilter.return_value)
+        UriCombinedWildcardFilter.assert_called_once_with(pyramid_request)
+        search.append_modifier.assert_any_call(UriCombinedWildcardFilter.return_value)
 
     def test_it_adds_a_tags_aggregation_to_the_search_query(self,
                                                             pyramid_request,
@@ -639,10 +630,6 @@ class TestExecute(object):
     @pytest.fixture
     def AuthorityFilter(self, patch):
         return patch('h.activity.query.AuthorityFilter')
-
-    @pytest.fixture
-    def UriFilter(self, patch):
-        return patch('h.activity.query.UriFilter')
 
     @pytest.fixture
     def UriCombinedWildcardFilter(self, patch):


### PR DESCRIPTION
Deprecate wildcard_search_on_activity_pages feature flag and make the switch to wildcards being allowed in the URL facet on activity pages permanent. 