### PR TITLE
Remove unused requests-aws4auth and certifi dependencies

### DIFF
--- a/h/config.py
+++ b/h/config.py
@@ -117,7 +117,7 @@ def configure(environ=None, settings=None):
 
     # Add ES logging filter to filter out ReadTimeout warnings
     es_logger = logging.getLogger('elasticsearch')
-    es_logger.addFilter(ExceptionFilter((("ReadTimeout", "WARNING"),)))
+    es_logger.addFilter(ExceptionFilter((("ReadTimeoutError", "WARNING"),)))
 
     return Configurator(settings=settings)
 

--- a/requirements.in
+++ b/requirements.in
@@ -5,7 +5,6 @@ backports.functools_lru_cache
 bcrypt
 bleach >= 2.0
 celery >= 4.2.1
-certifi
 cffi
 click
 deform < 1.0
@@ -39,7 +38,6 @@ pyramid_tm
 python-dateutil
 python-slugify < 1.2.0
 raven
-requests-aws4auth >= 0.9
 statsd
 transaction
 venusian

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,6 @@ bcrypt==3.1.3
 billiard==3.5.0.3         # via celery
 bleach==2.1.3
 celery==4.2.1
-certifi==2016.2.28
 cffi==1.7.0
 chameleon==2.24           # via deform
 click==6.6
@@ -62,9 +61,7 @@ pytz==2016.6.1            # via celery
 raven==6.0.0
 repoze.lru==0.6           # via pyramid
 repoze.sendmail==4.3      # via pyramid-mailer
-requests-aws4auth==0.9
-requests==2.13.0          # via requests-aws4auth
-six==1.10.0               # via bcrypt, bleach, elasticsearch-dsl, python-dateutil
+six==1.10.0               # via bcrypt, bleach, elasticsearch-dsl, html5lib, python-dateutil
 sqlalchemy==1.1.4
 statsd==3.2.1
 transaction==2.1.2
@@ -73,6 +70,7 @@ unidecode==0.4.19         # via python-slugify
 urllib3==1.22             # via elasticsearch
 venusian==1.0
 vine==1.1.4               # via amqp
+webencodings==0.5.1       # via html5lib
 webob==1.6.1              # via pyramid
 ws4py==0.4.2
 wsaccel==0.6.2


### PR DESCRIPTION
The last usages were removed in b8588ddc80.

These were previously used when making requests to Elasticsearch 1, but
are no longer necessary since the new Elasticsearch 6 cluster lives
inside our Amazon VPC and access is controlled via security groups.

In making this change, I discovered that the exception filtering that had been added in `h/config.py` was no longer filtering out the correct exception type following the ES migration. I fixed this and the associated tests. See commit message for details.