### PR TITLE
Re-add certifi dependency

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -5,6 +5,7 @@ backports.functools_lru_cache
 bcrypt
 bleach >= 2.0
 celery >= 4.2.1
+certifi  # Required to connect to Elasticsearch over SSL.
 cffi
 click
 deform < 1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ bcrypt==3.1.3
 billiard==3.5.0.3         # via celery
 bleach==2.1.3
 celery==4.2.1
+certifi==2018.8.24
 cffi==1.7.0
 chameleon==2.24           # via deform
 click==6.6


### PR DESCRIPTION
This is an optional dependency of Elasticsearch which is required for h
to be able to connect to our Elasticsearch cluster in production over
HTTPS, something we didn't realize when removing it previously.