### PR TITLE
Add documentation for `PUT /api/annotations/{id}/flag`

### DIFF
--- a/docs/_extra/api-reference/hypothesis.yaml
+++ b/docs/_extra/api-reference/hypothesis.yaml
@@ -209,6 +209,29 @@ paths:
           description: Annotation not found or no permission to delete
           schema:
             $ref: '#/definitions/Error'
+  /annotations/{id}/flag:
+    put:
+      tags:
+        - annotations
+      summary: Flag an annotation
+      operationId: flagAnnotation
+      description: >
+        Flag an annotation for moderation. The administrator (moderator) of the
+        group containing the annotation will be notified by email.
+      parameters:
+        - name: id
+          in: path
+          description: ID of annotation to flag for moderation
+          required: true
+          type: string
+      responses:
+        '204':
+          description: Success
+        '404':
+          description: Annotation not found or no permission to flag
+          schema:
+            $ref: '#/definitions/Error'
+
   /profile:
     get:
       tags:


### PR DESCRIPTION
The flag-for-moderation API is not currently documented. This PR adds documentation for it:

![image](https://user-images.githubusercontent.com/439947/46829044-a861a880-cd6a-11e8-88a7-fbe81370cff8.png)

I was going with the assumption that the lack of documentation was an oversight. If there's a good reason not to document this endpoint, let's chat!