### PR TITLE
Dissalow   in domain

### DIFF
--- a/docs/_extra/api-reference/hypothesis.yaml
+++ b/docs/_extra/api-reference/hypothesis.yaml
@@ -380,9 +380,8 @@ paths:
             PDF fingerprint.
 
             `*` will match any character sequence (including an empty one), 
-            and a `_` will match any single character. `*`s are only permitted 
-            within the path and query parts of the URI and `_`s are only permitted
-            within the domain, path, and query parts of the URI.
+            and a `_` will match any single character. Wildcards are only permitted 
+            within the path and query parts of the URI.
 
             Escaping wildcards is not supported.
 

--- a/h/schemas/annotation.py
+++ b/h/schemas/annotation.py
@@ -20,7 +20,7 @@ def _validate_wildcard_uri(node, value):
         if not wildcard_uri_is_valid(val):
             raise colander.Invalid(
                 node,
-                """Wildcards (? and *) are not permitted within the
+                """Wildcards (_ and *) are not permitted within the
                 domain of wildcard_uri""")
 
 
@@ -439,9 +439,8 @@ class SearchParamsSchema(colander.Schema):
             PDF fingerprint.
 
             `*` will match any character sequence (including an empty one),
-            and a `_` will match any single character. `*`s are only permitted
-            within the path and query parts of the URI and `_`s are only permitted
-            within the domain, path, and query parts of the URI.
+            and a `_` will match any single character. Wildcards are only permitted
+            within the path and query parts of the URI.
 
             Escaping wildcards is not supported.
 

--- a/h/search/query.py
+++ b/h/search/query.py
@@ -22,21 +22,17 @@ def wildcard_uri_is_valid(wildcard_uri):
     """
     Return True if uri contains wildcards in appropriate places, return False otherwise.
 
-    *'s are not permitted in the scheme or netloc. _'s are not permitted in the scheme.
+    *'s and _'s are not permitted in the scheme or netloc.
     """
     if "*" not in wildcard_uri and "_" not in wildcard_uri:
         return False
 
     normalized_uri = urlparse.urlparse(wildcard_uri)
-    if not normalized_uri.scheme or "*" in normalized_uri.netloc:
+    if (not normalized_uri.scheme or
+            "*" in normalized_uri.netloc or
+            "_" in normalized_uri.netloc):
         return False
 
-    # If a wildcard comes before the port aka: http://localhost:_3000 the request for the
-    # port will fail with a ValueError: invalid literal for int() with base 10: '_3000'.
-    try:
-        normalized_uri.port
-    except ValueError:
-        return False
     return True
 
 

--- a/tests/h/search/query_test.py
+++ b/tests/h/search/query_test.py
@@ -572,15 +572,15 @@ class TestUriCombinedWildcardFilter():
     ("_http://bar.com", False),
     ("http://localhost:3000*", False),
     ("http://localhost:_3000", False),
+    ("http://bar.com_foo=baz", False),
+    ("http://example.com_", False),
     ("http://bar*.com", False),
     ("file://*", False),
     ("https://foo.com", False),
     ("http://foo.com*", False),
     ("http://foo.com/*", True),
     ("urn:*", True),
-    ("http://bar.com_foo=baz", True),
     ("doi:10.101_", True),
-    ("http://example.com_", True),
     ("http://example.com/__/", True),
 ])
 def test_identifies_wildcard_uri_is_valid(wildcard_uri, expected):


### PR DESCRIPTION
Previously when the single character wildcard was a ? we allowed it to be inside the domain because so many url's have queries directly off the domain (since ? is a special character in urls indicating query params). Since _ is being used instead, we no longer need to support the single character wildcard in the domain. (According to the spec _'s are allowed inside the domain and while H currently doesn't have any urls with _'s inside the domain, that may be something we need to support later.)

Fixup an error message that was missed in the previous commit where _ replaced ?.