### PR TITLE
Always pass correct exception object to Sentry in exception view

### DIFF
--- a/h/util/view.py
+++ b/h/util/view.py
@@ -5,10 +5,15 @@ from __future__ import unicode_literals
 from pyramid.view import view_config
 
 
-def handle_exception(request):
-    """Handle an uncaught exception for the passed request."""
+def handle_exception(request, exception):
+    """
+    Handle an uncaught exception for the passed request.
+
+    :param request: The Pyramid request which caused the exception.
+    :param exception: The exception passed as context to the exception-handling view.
+    """
     request.response.status_int = 500
-    request.sentry.captureException()
+    request.sentry.captureException(exception)
     # In debug mode we should just reraise, so that the exception is caught by
     # the debug toolbar.
     if request.debug:

--- a/h/views/api/exceptions.py
+++ b/h/views/api/exceptions.py
@@ -48,9 +48,9 @@ def api_validation_error(context, request):
 
 
 @json_view(context=Exception, path_info='/api/', decorator=cors_policy)
-def json_error(request):
+def json_error(context, request):
     """Handle an unexpected exception in an API view."""
-    handle_exception(request)
+    handle_exception(request, exception=context)
     message = _("Hypothesis had a problem while handling this request. "
                 "Our team has been notified. Please contact support@hypothes.is"
                 " if the problem persists.")

--- a/h/views/exceptions.py
+++ b/h/views/exceptions.py
@@ -29,16 +29,16 @@ def notfound(request):
 @view_config(context=Exception,
              accept='text/html',
              renderer='h:templates/5xx.html.jinja2')
-def error(request):
+def error(context, request):
     """Handle a request for which the handler threw an exception."""
-    handle_exception(request)
+    handle_exception(request, exception=context)
     return {}
 
 
 @json_view(context=Exception)
-def json_error(request):
+def json_error(context, request):
     """Handle an unexpected exception where the request asked for JSON."""
-    handle_exception(request)
+    handle_exception(request, exception=context)
     message = _("Hypothesis had a problem while handling this request. "
                 "Our team has been notified. Please contact support@hypothes.is"
                 " if the problem persists.")

--- a/tests/h/util/view_test.py
+++ b/tests/h/util/view_test.py
@@ -10,14 +10,15 @@ from h.util.view import handle_exception, json_view
 
 class TestHandleException(object):
     def test_sets_response_status_500(self, pyramid_request):
-        handle_exception(pyramid_request)
+        handle_exception(pyramid_request, Mock())
 
         assert pyramid_request.response.status_int == 500
 
     def test_triggers_sentry_capture(self, pyramid_request):
-        handle_exception(pyramid_request)
+        exception = Mock()
+        handle_exception(pyramid_request, exception)
 
-        pyramid_request.sentry.captureException.assert_called_once_with()
+        pyramid_request.sentry.captureException.assert_called_once_with(exception)
 
     def test_reraises_in_debug_mode(self, pyramid_request):
         pyramid_request.debug = True
@@ -27,7 +28,7 @@ class TestHandleException(object):
             raise dummy_exc
         except:
             with pytest.raises(ValueError) as exc:
-                handle_exception(pyramid_request)
+                handle_exception(pyramid_request, Mock())
             assert exc.value == dummy_exc
 
     @pytest.fixture

--- a/tests/h/views/api/exceptions_test.py
+++ b/tests/h/views/api/exceptions_test.py
@@ -2,6 +2,8 @@
 
 from __future__ import unicode_literals
 
+from mock import Mock
+
 from h.exceptions import APIError
 from h.schemas import ValidationError
 from h.views.api import exceptions as views
@@ -38,8 +40,9 @@ def test_api_validation_error(pyramid_request):
 def test_json_error_view(patch, pyramid_request):
     handle_exception = patch('h.views.api.exceptions.handle_exception')
 
-    result = views.json_error(pyramid_request)
+    exception = Mock()
+    result = views.json_error(exception, pyramid_request)
 
-    handle_exception.assert_called_once_with(pyramid_request)
+    handle_exception.assert_called_once_with(pyramid_request, exception)
     assert result['status'] == 'failure'
     assert result['reason']

--- a/tests/h/views/exceptions_test.py
+++ b/tests/h/views/exceptions_test.py
@@ -2,6 +2,8 @@
 
 from __future__ import unicode_literals
 
+from mock import Mock
+
 from h.views.exceptions import notfound, error, json_error
 
 
@@ -14,18 +16,20 @@ def test_notfound_view(pyramid_request):
 
 def test_error_view(patch, pyramid_request):
     handle_exception = patch('h.views.exceptions.handle_exception')
+    exception = Mock()
 
-    result = error(pyramid_request)
+    result = error(exception, pyramid_request)
 
-    handle_exception.assert_called_once_with(pyramid_request)
+    handle_exception.assert_called_once_with(pyramid_request, exception)
     assert result == {}
 
 
 def test_json_error_view(patch, pyramid_request):
     handle_exception = patch('h.views.exceptions.handle_exception')
+    exception = Mock()
 
-    result = json_error(pyramid_request)
+    result = json_error(exception, pyramid_request)
 
-    handle_exception.assert_called_once_with(pyramid_request)
+    handle_exception.assert_called_once_with(pyramid_request, exception)
     assert result['status'] == 'failure'
     assert result['reason']


### PR DESCRIPTION
Exception views call `h.util.view.handle_exception` to report the exception to
Sentry. This function calls `request.sentry.captureException()` without
specifying an argument, which means that the Sentry client defaults to capturing
the _last_ exception that was raised. In rare circumstances this is not the
exception that caused the request to fail. Pyramid internally raises, and
catches, exceptions (eg. `PredicateMismatch`) during the routine course of
resolving and invoking the exception view.

The scenario where the `PredicateMismatch` exception is reported to Sentry
instead of the real exception happens only sometimes when running h.
Perhaps there may be non-determinism in the order in which Pyramid
matches requests against candidate view callables?

Resolve the problem by always passing the exception view's context object to
`request.sentry.captureException`. The context object is the exception which
actually caused the request to fail.

This should hopefully resolve https://sentry.io/hypothesis/h/issues/709085496.