### PR TITLE
Fix Sentry reporting in `h.util.view.handle_exception`

### DIFF
--- a/h/util/view.py
+++ b/h/util/view.py
@@ -2,7 +2,14 @@
 
 from __future__ import unicode_literals
 
+import sys
+
 from pyramid.view import view_config
+
+
+# Test seam. Patching `sys.exc_info` directly causes problems with pytest.
+def _exc_info():
+    return sys.exc_info()
 
 
 def handle_exception(request, exception):
@@ -13,7 +20,20 @@ def handle_exception(request, exception):
     :param exception: The exception passed as context to the exception-handling view.
     """
     request.response.status_int = 500
-    request.sentry.captureException(exception)
+
+    # There are two code paths here depending on whether this is the most recent
+    # exception in the current thread. If it is, we can let Raven capture
+    # the details under Python 2 + 3. If not, we need to construct the
+    # exc_info tuple manually and the stacktrace is only available in Python 3.
+    last_exc_info = _exc_info()
+    if exception is last_exc_info[1]:
+        request.sentry.captureException()
+    else:
+        # `__traceback__` is a Python 3-only property.
+        traceback = getattr(exception, '__traceback__', None)
+        exc_info = (type(exception), exception, traceback)
+        request.sentry.captureException(exc_info)
+
     # In debug mode we should just reraise, so that the exception is caught by
     # the debug toolbar.
     if request.debug:

--- a/tox.ini
+++ b/tox.ini
@@ -40,6 +40,7 @@ passenv =
     CONFIG_URI
     MODEL_CREATE_ALL
     SEARCH_AUTOCONFIG
+    SENTRY_DSN
     USE_HTTPS
     WEBSOCKET_URL
 whitelist_externals = sh


### PR DESCRIPTION
I didn't read the `raven.captureException()` documentation properly 🤦‍♂️ when authoring https://github.com/hypothesis/h/pull/5373. The
first argument is an `exc_info` 3-tuple, not an exception instance.

If the exception passed to `handle_exception` is the most recent
exception in the current thread, we can just call `captureException`
without arguments. If it is an older exception, we must construct the
`exc_info` tuple manually. In that case the traceback is only available
in Python 3 via the `exc.__traceback__` property.

**Caveat** - The above limitation means that in some rare cases, Sentry reports may be missing exception stacktraces as long as we are using Python 2. At least they will report the right exception,
unlike before.

This relates to the Sentry issue https://sentry.io/hypothesis/h/issues/730479519/.

**Testing** - I have tested this locally with the real Sentry service under Python 2 + 3 by using my personal Sentry account, setting the `SENTRY_DSN` environment variable and modifying a view to raise an exception.