### PR TITLE
Refactor the tox.ini file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,8 @@ matrix:
       before_script: createdb htest
       script: tox
       after_success:
-        tox -e coverage
-        tox -e codecov
+        tox -e py27-coverage
+        tox -e py27-codecov
 
     - env: ACTION=tox-py3
       language: python

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,8 +35,8 @@ node {
                 // Unit tests
                 sh 'cd /var/lib/hypothesis && tox'
                 // Functional tests
-                sh 'cd /var/lib/hypothesis && tox -e functional'
-                sh 'cd /var/lib/hypothesis && tox -e functional-py36'
+                sh 'cd /var/lib/hypothesis && tox -e py27-functests'
+                sh 'cd /var/lib/hypothesis && tox -e py36-functests'
             }
         } finally {
             rabbit.stop()

--- a/Makefile
+++ b/Makefile
@@ -54,27 +54,27 @@ test: node_modules/.uptodate
 
 .PHONY: test-py3
 test-py3: node_modules/.uptodate
-	tox -e py36 -- tests/h/
+	tox -e py36-tests
 
 .PHONY: lint
 lint:
-	tox -e lint
+	tox -e py27-lint
 
 .PHONY: docs
 docs:
-	tox -e docs
+	tox -e py27-docs
 
 .PHONY: checkdocs
 checkdocs:
-	tox -e checkdocs
+	tox -e py27-checkdocs
 
 .PHONY: docstrings
 docstrings:
-	tox -e docstrings
+	tox -e py27-docstrings
 
 .PHONY: checkdocstrings
 checkdocstrings:
-	tox -e checkdocstrings
+	tox -e py27-checkdocstrings
 
 ################################################################################
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,152 +1,62 @@
 [tox]
-envlist = py27
+envlist = py27-tests
 skipsdist = true
-requires =
-    tox-pip-extensions
+requires = tox-pip-extensions
 tox_pip_extensions_ext_venv_update = true
-
-[pytest]
-minversion = 2.8
-addopts = --pyargs
-testpaths = tests
 
 [testenv]
 skip_install = true
-# N.B. "hypothesis" in the list below is the property-based testing library,
-#      not our own code.
-deps =
-    coverage
-    mock
-    pytest
-    hypothesis
-    factory-boy
-    -rrequirements.txt
 passenv =
-    TEST_DATABASE_URL
-    ELASTICSEARCH_URL
-    PYTEST_ADDOPTS
-commands =
-    coverage run --parallel --source h,tests/h -m pytest -Werror {posargs:tests/h/}
-
-[dev]
-deps = -rrequirements-dev.in
-passenv =
-    ALLOWED_ORIGINS
-    AUTHORITY
-    BOUNCER_URL
-    CLIENT_OAUTH_ID
-    CLIENT_RPC_ALLOWED_ORIGINS
-    CLIENT_URL
-    CONFIG_URI
-    MODEL_CREATE_ALL
-    SEARCH_AUTOCONFIG
-    SENTRY_DSN
-    USE_HTTPS
-    WEBSOCKET_URL
-whitelist_externals = sh
-commands =
-    sh bin/hypothesis --dev init
-    {posargs:sh bin/hypothesis devserver}
-
-[testenv:py27-dev]
-deps = {[dev]deps}
-passenv = {[dev]passenv}
-whitelist_externals = {[dev]whitelist_externals}
-commands = {[dev]commands}
-
-[testenv:py36-dev]
-deps = {[dev]deps}
-passenv = {[dev]passenv}
-whitelist_externals = {[dev]whitelist_externals}
-commands = {[dev]commands}
-
-[testenv:py37-dev]
-deps = {[dev]deps}
-passenv = {[dev]passenv}
-whitelist_externals = {[dev]whitelist_externals}
-commands = {[dev]commands}
-
-[functional]
+    dev: ALLOWED_ORIGINS
+    dev: AUTHORITY
+    dev: BOUNCER_URL
+    dev: CLIENT_OAUTH_ID
+    dev: CLIENT_RPC_ALLOWED_ORIGINS
+    dev: CLIENT_URL
+    dev: CONFIG_URI
+    dev: MODEL_CREATE_ALL
+    dev: SEARCH_AUTOCONFIG
+    dev: SENTRY_DSN
+    dev: USE_HTTPS
+    dev: WEBSOCKET_URL
+    {tests,functests}: TEST_DATABASE_URL
+    {tests,functests}: ELASTICSEARCH_URL
+    {tests,functests}: PYTEST_ADDOPTS
+    functests: BROKER_URL
+    codecov: CI TRAVIS*
 deps =
-    pytest
-    webtest
-    factory-boy
-    -rrequirements.txt
-passenv =
-    BROKER_URL
-    ELASTICSEARCH_URL
-    TEST_DATABASE_URL
-    PYTEST_ADDOPTS
-commands = pytest -Werror {posargs:tests/functional/}
-
-[testenv:functional]
-deps = {[functional]deps}
-passenv = {[functional]passenv}
-commands = {[functional]commands}
-
-[testenv:functional-py36]
-deps = {[functional]deps}
-passenv = {[functional]passenv}
-commands = {[functional]commands}
-
-[testenv:clean]
-deps = coverage
-skip_install = true
-commands = coverage erase
-
-[testenv:coverage]
-deps = coverage
-skip_install = true
+    tests: coverage
+    {tests,functests,docstrings,checkdocstrings}: pytest
+    {tests,functests,docstrings,checkdocstrings}: factory-boy
+    {tests,docstrings,checkdocstrings}: mock
+    {tests,docstrings,checkdocstrings}: hypothesis
+    lint: flake8
+    lint: flake8-future-import
+    coverage: coverage
+    codecov: codecov
+    {functests,docstrings,checkdocstrings}: webtest
+    {docs,docstrings}: sphinx-autobuild
+    {docs,checkdocs,docstrings,checkdocstrings}: sphinx
+    {docs,checkdocs,docstrings,checkdocstrings}: sphinx_rtd_theme
+    {tests,functests,docstrings,checkdocstrings}: -r requirements.txt
+    dev: -r requirements-dev.in
+whitelist_externals =
+    dev: sh
+changedir =
+    {docs,checkdocs}: docs
 commands =
-    coverage combine
-    coverage report
-
-[testenv:codecov]
-deps = codecov
-skip_install = true
-passenv = CI TRAVIS*
-commands = codecov
-
-[docs]
-changedir = docs
-deps =
-    sphinx
-    sphinx_rtd_theme
-    sphinx-autobuild
-
-[testenv:docs]
-changedir = {[docs]changedir}
-deps = {[docs]deps}
-commands = sphinx-autobuild -BqT -b dirhtml -d {envtmpdir}/doctrees . {envtmpdir}/html
-
-[testenv:checkdocs]
-changedir = {[docs]changedir}
-deps = {[docs]deps}
-commands = sphinx-build -qTWn -b dirhtml -d {envtmpdir}/doctrees . {envtmpdir}/html
-
-[docstrings]
-commands = sphinx-apidoc -ePMF -a -H "Dooccsstrinngs!!" --ext-intersphinx --ext-todo --ext-viewcode -o {envtmpdir}/rst .
-deps =
-    {[docs]deps}
-    {[testenv]deps}
-
-[testenv:docstrings]
-deps = {[docstrings]deps}
-commands =
-    {[docstrings]commands}
-    sphinx-autobuild -BqT -z h -z tests -b dirhtml {envtmpdir}/rst {envtmpdir}/dirhtml
-
-[testenv:checkdocstrings]
-deps = {[docstrings]deps}
-commands =
-    {[docstrings]commands}
-    sphinx-build -qTn -b dirhtml {envtmpdir}/rst {envtmpdir}/dirhtml
-
-[testenv:lint]
-deps =
-    flake8
-    flake8-future-import
-commands =
-    flake8 h
-    flake8 tests
-    flake8 --select FI14 --exclude 'h/cli/*,tests/h/cli/*,h/util/uri.py,h/migrations/versions/*' h tests
+    dev: sh bin/hypothesis --dev init
+    dev: {posargs:sh bin/hypothesis devserver}
+    lint: flake8 h
+    lint: flake8 tests
+    lint: flake8 --select FI14 --exclude 'h/cli/*,tests/h/cli/*,h/util/uri.py,h/migrations/versions/*' h tests
+    tests: coverage run --parallel --source h,tests/h -m pytest -Werror {posargs:tests/h/}
+    functests: pytest -Werror {posargs:tests/functional/}
+    docs: sphinx-autobuild -BqT -b dirhtml -d {envtmpdir}/doctrees . {envtmpdir}/html
+    checkdocs: sphinx-build -qTWn -b dirhtml -d {envtmpdir}/doctrees . {envtmpdir}/html
+    {docstrings,checkdocstrings}: sphinx-apidoc -ePMF -a -H "Dooccsstrinngs!!" --ext-intersphinx --ext-todo --ext-viewcode -o {envtmpdir}/rst .
+    docstrings: sphinx-autobuild -BqT -z h -z tests -b dirhtml {envtmpdir}/rst {envtmpdir}/dirhtml
+    checkdocstrings: sphinx-build -qTn -b dirhtml {envtmpdir}/rst {envtmpdir}/dirhtml
+    coverage: coverage combine
+    coverage: coverage report
+    codecov: codecov


### PR DESCRIPTION
Rewrite the `tox.ini` file to be:

1. Much shorter and much more regular, and easier to understand and modify
2. Make the tox commands more consistent. They're all of the form `tox -e pyXY-cmd`, e.g. `tox -e py27-dev`, `tox -e py36-tests`, whereas previously the format of commands varied
3. More flexible by allowing any command (tests, functional tests, dev, ...) to be run with any version of Python, without further edits to the `tox.ini` file

This PR does add some additional tox commands that weren't available before (you can now run anything in any version of Python), and it does change some of the existing tox commands (for example `tox -e functional` is now `tox -e py27-functests`, and `tox -e functional-py36` is now `tox -e py36-functests`), but the actual functionality / what happens when you run the new version of the tox command should be the same as on master, and all of the `make` commands should remain the same.

The commands we now have are:

* `make dev`. Runs `tox -e py27-dev`. You can also run the dev server in any other version of Python that you have on your system, e.g. `tox -e py36-dev`, `tox -e py37-dev`.
* `make test`. Runs `tox` which is equivalent to `tox -e py27-tests`.
* `make test-py3`. Runs `tox -e py36-tests`. You could also run `tox -e py37-tests` and so on. It's probably not really necessary to have this in the `Makefile`.
* `make lint`, `docs`, `checkdocs`, `docstrings`, `checkdocstring` should all do what they did before. The `tox` commands for these also allow running them in different Python versions but there's probably little reason to ever do so.
* `tox -e coverage` and `tox -e codecov` should also do what they did before. These aren't in the `Makefile`.

### How this works

To explain what's going on in this new `tox.ini` file:

* When you run a command like `tox -e py27-dev` or `tox -e py36-tests`, the `py36-tests` part is a tox **testenv name**. A "testenv" as tox calls them is basically a description of a virtualenv, including what version of Python to create that virtualenv in, what dependencies to install in it, what envvars to pass through or set in it, what commands to run in it, etc. Whenever you run `tox` you're "running" one or more testenvs.

* A testenv name is actually a dash-separated list of **factors**. For example `py36-tests` names two factors `py36` and `tests`. A factor is a collection of testenv settings and a testenv name like `py36-tests` pulls in all the settings from the `py36` factor and the `tests` factor into a single testenv definition named `py36-tests`.

* Tox comes with builtin factors for all the versions of Python: `py27`, `py36`, `py37`, etc. These are factors that contain just one setting: the Python version to use.

* We can also define our own factors in the `tox.ini` file. So for example we define the `dev` factor, which includes settings for what dependencies to install, what envvars to pass through, and what commands to run. It _does not_ define with version of Python to use though. Our style of writing the `tox.ini` file is to leave that to be defined by another factor. `dev` is always meant to be used with `py27-dev` or `py36-dev` etc. All our factors are like this.

* Whenever you give a list of things in the `tox.ini` file -- for example the list of dependencies to install, or envvars to pass through, or commands to run -- items in the list can be prefixed with `factorname: `. So for example this:

      deps = 
        tests: coverage
        lint: flake8
        ...

  means to install the `coverage` dependency only when the `tests` factor is invoked (e.g. `tox -e py36-tests`) and to install the `flake8` dependency only when the `lint` factor is invoked (e.g. `tox -e py27-lint`).

* This can also be a comma-separated lists of factors. So for example `{functests,docstrings,checkdocstrings}: webtest` in `tox.ini` says to install `webtest` whenever any of the `functests`, `docstrings` or `checkdocstrings` factor is involved. There's more complex conditions possible to: negation, logic, etc. But we don't need those.

So to understand for example with `tox -e py27-dev` does:

* The `py27` means run it with Python 2.7
* For the `dev` read through `tox.ini` and apply each line that either doesn't have any `factor: ` prefix (those lines apply to all testenvs) or that has a `factor: ` prefix including `dev`. So for example all of the dependencies starting with `dev: <package>` will get installed, and all of the commands starting with `dev: <command>` will get run
* Tox moves through the `tox.ini` file from top to bottom. So the matching commands will be run in the order that they appear in.