### PR TITLE
Revert pinning to tox 3.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
         postgresql: "9.4"
       before_install:
         - ./scripts/elasticsearch.sh
-      install: pip install tox==3.3.0 tox-pip-extensions
+      install: pip install tox tox-pip-extensions
       before_script: createdb htest
       script: tox
       after_success:
@@ -24,7 +24,7 @@ matrix:
         postgresql: '9.4'
       before_install:
         - ./scripts/elasticsearch.sh
-      install: pip install tox==3.3.0 tox-pip-extensions
+      install: pip install tox tox-pip-extensions
       before_script: createdb htest
       script:
         make test-py3
@@ -50,7 +50,7 @@ matrix:
     - env: ACTION=backend-lint
       language: python
       python: '3.6'
-      install: pip install tox==3.3.0 tox-pip-extensions
+      install: pip install tox tox-pip-extensions
       script:
         make lint
 
@@ -58,7 +58,7 @@ matrix:
     - env: ACTION=check-docs
       language: python
       python: '3.6'
-      install: pip install tox==3.3.0 tox-pip-extensions
+      install: pip install tox tox-pip-extensions
       script:
         make checkdocs
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,7 +30,7 @@ node {
                 // Test dependencies
                 sh 'apk add --no-cache build-base libffi-dev postgresql-dev python-dev'
                 sh 'apk add --no-cache python3 python3-dev'
-                sh 'pip install -q tox==3.3.0 tox-pip-extensions'
+                sh 'pip install -q tox tox-pip-extensions'
 
                 // Unit tests
                 sh 'cd /var/lib/hypothesis && tox'

--- a/docs/developing/install.rst
+++ b/docs/developing/install.rst
@@ -46,23 +46,12 @@ Install node by following the
 (the version of the nodejs package in the standard Ubuntu repositories is too
 old).
 
-Upgrade pip and npm, and install tox 3.3.0 and tox-pip-extensions:
+Upgrade pip and npm, and install tox and tox-pip-extensions:
 
 .. code-block:: bash
 
-    sudo pip install -U pip tox==3.3.0 tox-pip-extensions
+    sudo pip install -U pip tox tox-pip-extensions
     sudo npm install -g npm
-
-.. note::
-
-   Tox version 3.3.0 is required until an incompatibility between
-   tox-pip-extensions and newer versions of tox is resolved:
-
-   https://github.com/tox-dev/tox-pip-extensions/issues/16
-
-   If you see a ``TypeError: 'NoneType' object is not iterable`` error from tox
-   then make sure you have tox 3.3 and not a newer version of tox installed
-   (``sudo pip install -U tox==3.3.0``).
 
 Installing the system dependencies on macOS
 -------------------------------------------
@@ -87,22 +76,12 @@ Install the following packages:
 .. note:: Unfortunately you need to install the ``postgresql`` package, because
           Homebrew does not currently provide a standalone ``libpq`` package.
 
-Upgrade pip and install tox 3.3.0 and tox-pip-extensions:
+Upgrade pip and install tox and tox-pip-extensions:
 
 .. code-block:: bash
 
-    pip install -U pip tox==3.3.0 tox-pip-extensions
+    pip install -U pip tox tox-pip-extensions
 
-.. note::
-
-   Tox version 3.3.0 is required until an incompatibility between
-   tox-pip-extensions and newer versions of tox is resolved:
-
-   https://github.com/tox-dev/tox-pip-extensions/issues/16
-
-   If you see a ``TypeError: 'NoneType' object is not iterable`` error from tox
-   then make sure you have Tox 3.3 and not a newer version of Tox installed
-   (``pip install -U tox==3.3.0``).
 
 Getting the h source code from GitHub
 -------------------------------------


### PR DESCRIPTION
Revert "Specify tox==3.3.0 in the dev install docs" and "Pin to tox 3.3.0".

This reverts commits a74c740628f195c80987ca8366178df1a36b7bae and dd9aa5302220088d492397b8bf9266cb6c2c8062. tox-pip-extensions has now been fixed to work with the latest version of tox, so there's no need to pin to an older version of tox anymore. See:

https://github.com/tox-dev/tox-pip-extensions/issues/16#issuecomment-429585330