### PR TITLE
Add `make sql`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,10 @@ clean:
 dev: build/manifest.json
 	tox -e py27-dev
 
+.PHONY: sql
+sql:
+	docker-compose exec postgres psql -U postgres
+
 ## Build hypothesis/hypothesis docker image
 .PHONY: docker
 docker:

--- a/docs/developing/install.rst
+++ b/docs/developing/install.rst
@@ -154,11 +154,12 @@ can be installed on:
 .. tip::
 
    You can use Docker Compose image to open a psql shell in your Dockerized
-   database container without having to install psql on your host machine. Do:
+   database container without having to install psql on your host machine.
+   We've provided a shortcut for this in our ``Makefile``, so just run:
 
    .. code-block:: bash
 
-      docker-compose exec postgres psql -U postgres
+      make sql
 
 .. tip::
 


### PR DESCRIPTION
Add a convenient `make sql` command for launching a `psql` shell
connected to the h dev DB.

This uses the copy of `docker-compose` that the developer _should_
already have on their path, if they've followed our dev instructions
which tell you to install Docker Compose.

Docker Compose is a Python thing so we _could_ have tox install it into
one of its virtualenvs (e.g. its dev venv, or a new venv just for Docker
Compose). However if we do that we should probably change all Docker
Compose usage (e.g. having to run `docker-compose up -d` manually before
`make dev` will work) to be done via tox. The advantage would be simplifying
the dev install instructions by no longer having to manually install Docker Compose
(but you'd still have to install Docker).

For now, just add a `make sql` the quick way.