### PR TITLE
Add `make coverage` and `make codecov`

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -5,10 +5,7 @@ source =
     h
     tests/h
 omit =
-    # development
     h/debug.py
-
-    # migrations
     h/migrations/*
 
 [report]

--- a/.coveragerc
+++ b/.coveragerc
@@ -6,8 +6,3 @@ omit =
 
     # migrations
     h/migrations/*
-
-[paths]
-source =
-   src/memex
-   .tox/*/lib/python*/site-packages/memex

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,8 +1,15 @@
 [run]
 branch = True
+parallel = True
+source =
+    h
+    tests/h
 omit =
     # development
     h/debug.py
 
     # migrations
     h/migrations/*
+
+[report]
+show_missing = True

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,8 @@ matrix:
       before_script: createdb htest
       script: tox
       after_success:
-        tox -e py27-coverage
-        tox -e py27-codecov
+        make coverage
+        tox -e py28-codecov
 
     - env: ACTION=tox-py3
       language: python

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,7 @@ matrix:
       before_script: createdb htest
       script: tox
       after_success:
-        make coverage
-        tox -e py28-codecov
+        make coverage codecov
 
     - env: ACTION=tox-py3
       language: python

--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,10 @@ test: node_modules/.uptodate
 test-py3: node_modules/.uptodate
 	tox -e py36-tests
 
+.PHONY: coverage
+coverage:
+	tox -e py27-coverage
+
 .PHONY: lint
 lint:
 	tox -e py27-lint

--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,10 @@ test-py3: node_modules/.uptodate
 coverage:
 	tox -e py27-coverage
 
+.PHONY: codecov
+codecov:
+	tox -e py27-codecov
+
 .PHONY: lint
 lint:
 	tox -e py27-lint

--- a/tox.ini
+++ b/tox.ini
@@ -56,5 +56,5 @@ commands =
     docstrings: sphinx-autobuild -BqT -z h -z tests -b dirhtml {envtmpdir}/rst {envtmpdir}/dirhtml
     checkdocstrings: sphinx-build -qTn -b dirhtml {envtmpdir}/rst {envtmpdir}/dirhtml
     coverage: -coverage combine
-    coverage: coverage report
+    coverage: coverage report -m
     codecov: codecov

--- a/tox.ini
+++ b/tox.ini
@@ -48,7 +48,7 @@ commands =
     lint: flake8 h
     lint: flake8 tests
     lint: flake8 --select FI14 --exclude 'h/cli/*,tests/h/cli/*,h/util/uri.py,h/migrations/versions/*' h tests
-    tests: coverage run --parallel --source h,tests/h -m pytest -Werror {posargs:tests/h/}
+    tests: coverage run -m pytest -Werror {posargs:tests/h/}
     functests: pytest -Werror {posargs:tests/functional/}
     docs: sphinx-autobuild -BqT -b dirhtml -d {envtmpdir}/doctrees . {envtmpdir}/html
     checkdocs: sphinx-build -qTWn -b dirhtml -d {envtmpdir}/doctrees . {envtmpdir}/html
@@ -56,5 +56,5 @@ commands =
     docstrings: sphinx-autobuild -BqT -z h -z tests -b dirhtml {envtmpdir}/rst {envtmpdir}/dirhtml
     checkdocstrings: sphinx-build -qTn -b dirhtml {envtmpdir}/rst {envtmpdir}/dirhtml
     coverage: -coverage combine
-    coverage: coverage report -m
+    coverage: coverage report
     codecov: codecov

--- a/tox.ini
+++ b/tox.ini
@@ -55,6 +55,6 @@ commands =
     {docstrings,checkdocstrings}: sphinx-apidoc -ePMF -a -H "Dooccsstrinngs!!" --ext-intersphinx --ext-todo --ext-viewcode -o {envtmpdir}/rst .
     docstrings: sphinx-autobuild -BqT -z h -z tests -b dirhtml {envtmpdir}/rst {envtmpdir}/dirhtml
     checkdocstrings: sphinx-build -qTn -b dirhtml {envtmpdir}/rst {envtmpdir}/dirhtml
-    coverage: coverage combine
+    coverage: -coverage combine
     coverage: coverage report
     codecov: codecov


### PR DESCRIPTION
Just two `tox` commands that were lacking `Makefile` shortcuts. Also cleaned up our `coverage.py` config and improved the terminal reporting.