### PR TITLE
Add `make functests`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,10 @@ test: node_modules/.uptodate
 	tox
 	$(GULP) test
 
+.PHONY: functests
+functests: build/manifest.json
+	tox -e py27-functests
+
 .PHONY: test-py3
 test-py3: node_modules/.uptodate
 	tox -e py36-tests


### PR DESCRIPTION
I'm not going to add a `Makefile` shortcut for the `tox -e py36-functests` command (which `Jenkinsfile` also runs): my pattern is to add `Makefile` shortcuts for the "defaults" but not for the temporary Python 3 transitional ones.

`make functests` seems worth having as it could also apply to other projects if they have functional tests and it lets you do handy things like `make test functests`. Also handles building the deps that're needed for the functional tests to work.