### PR TITLE
Migration to create group `authority_provided_id` field, index

### DIFF
--- a/h/migrations/versions/5ed9c8c105f6_add_authority_provided_id_field_to_group.py
+++ b/h/migrations/versions/5ed9c8c105f6_add_authority_provided_id_field_to_group.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+"""
+Add authority_provided_id field, index to group
+
+This will allow clients of the API, in certain circumstances, to set a
+unique-to-authority identifier on a group, versus having to use the
+service-generated ``pubid``. This ``authority_provided_id`` can be used
+to perform certain actions on the group without having to know the
+``pubid`` beforehand.
+
+Whereas the ``pubid`` is service-owned and globally unique, this
+``authority_provided_id`` is unique per authority and owned by the
+caller/client. i.e. authority-bound clients may set their own unique
+IDs.
+
+``authority_provided_id`` must be unique per authority; ergo the
+unique-enforced index
+"""
+from __future__ import unicode_literals
+from __future__ import absolute_import
+from __future__ import division
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "5ed9c8c105f6"
+down_revision = "5d256923d642"
+
+
+def upgrade():
+    op.add_column('group', sa.Column('authority_provided_id', sa.UnicodeText(), nullable=True))
+    op.execute('COMMIT')
+    op.create_index(op.f('ix__group__groupid'),
+                    'group',
+                    ['authority_provided_id', 'authority'],
+                    postgresql_concurrently=True,
+                    unique=True)
+
+
+def downgrade():
+    op.drop_index(op.f('ix__group__groupid'))
+    op.drop_column('group', 'authority_provided_id')


### PR DESCRIPTION
Part of https://github.com/hypothesis/lms/issues/287

To better support LMS and potential future consumers of our API services, we've been [discussing the need for a client-defined identifier for group resources](https://gist.github.com/lyzadanger/2f63b4e3e00b0073cda113cd9ee38599) (WARNING: LOTS OF DETAILS THERE). In summary, we need a way for authority-bound clients to be able to set their own identifiers on groups instead of being bound to the service-generated `pubid`.

This will allow us to, ultimately:

* not to have to store group metadata in the LMS database, which is leading to data integrity problems
* reduce the number of API requests necessary on LMS app launch

This sounds somewhat technical and detail-y, but it's the source of a lot of dev heartache right now!

This migration adds a new column to the `group` table and creates a unique index for the combination of (`authority_provided_id`, `authority`). Whereas `pubid`s are globally unique, `authority_provided_id`s are authority-unique.