### PR TITLE
Stamp new databases with alembic version

### DIFF
--- a/docs/developing/making-changes-to-model-code.rst
+++ b/docs/developing/making-changes-to-model-code.rst
@@ -64,21 +64,7 @@ steps to create a new migration script for h are:
       downgrade that adds the constraint back may not work with data created
       using the updated schema.
 
-3. Stamp your database.
-
-   Before running any upgrades or downgrades you need to stamp the database
-   with its current revision, so Alembic knows which migration scripts to run:
-
-   .. code-block:: bash
-
-      tox -e py27-dev -- sh bin/hypothesis migrate stamp <revision_id>
-
-   ``<revision_id>`` should be the revision corresponding to the version of the
-   code that was present when the current database was created. The will
-   usually be the ``down_revision`` from the migration script that you've just
-   generated.
-
-4. Test your ``upgrade()`` function by upgrading your database to the most
+3. Test your ``upgrade()`` function by upgrading your database to the most
    recent revision. This will run all migration scripts newer than the revision
    that your db is currently stamped with, which usually means just your new
    revision script:
@@ -96,7 +82,7 @@ steps to create a new migration script for h are:
       columns of the database before testing upgrading and downgrading it.
       Some migration script crashes will only happen when there's data present.
 
-5. Test your ``downgrade()`` function:
+4. Test your ``downgrade()`` function:
 
    .. code-block:: bash
 

--- a/h/cli/commands/init.py
+++ b/h/cli/commands/init.py
@@ -3,6 +3,8 @@
 import logging
 import os
 
+import alembic.config
+import alembic.command
 import click
 import sqlalchemy
 
@@ -37,6 +39,11 @@ def _init_db(settings):
     except sqlalchemy.exc.ProgrammingError:
         log.info("initializing database")
         db.init(engine, should_create=True, authority=text_type(settings['h.authority']))
+
+        # Stamp the database with the current schema version so that future
+        # migrations start from the correct point.
+        alembic_cfg = alembic.config.Config('conf/alembic.ini')
+        alembic.command.stamp(alembic_cfg, 'head')
     else:
         log.info("detected alembic_version table, skipping db initialization")
 


### PR DESCRIPTION
When initializing a new database, stamp the database with the current
schema revision (aka. populate the "alembic_version" table) so that
future uses of `hypothesis migrate upgrade` start from the correct
revision instead of trying to apply _all_ past revisions, unless the
developer remembered to run `hypothesis migrate stamp` manually.

Test with an existing DB as follows:

 1. Execute `DROP TABLE alembic_version;` using psql
 2. Run `bin/hypothesis --dev init`
 3. Check that `alembic_version` table has been recreated and populated
    with the correct version string.

This issue caught out both me and Sheetal when we recreated our databases not long ago for various reasons.

The code used here is adapted from the [alembic cookbook](https://alembic.zzzcomputing.com/en/latest/cookbook.html#building-an-up-to-date-database-from-scratch).