### PR TITLE
Add AuthClientUser role

### DIFF
--- a/h/auth/role.py
+++ b/h/auth/role.py
@@ -14,3 +14,9 @@ AuthClient = 'group:__authclient__'
 #: c.f. ``AuthClient``, which can exist on an authenticated request but
 #: there is no user
 User = 'group:__user__'
+
+
+#: This role represents an authenticated authclient request that also has a
+#: verified forwarded user. This kind of request would also qualify for
+#: ``AuthClient`` and ``User`` roles.
+AuthClientUser = 'group:__authclientuser__'

--- a/h/auth/util.py
+++ b/h/auth/util.py
@@ -162,8 +162,9 @@ def principals_for_auth_client_user(user, client):
     """
     user_principals = principals_for_user(user)
     client_principals = principals_for_auth_client(client)
+    auth_client_principals = [role.AuthClientUser]
 
-    all_principals = user_principals + client_principals
+    all_principals = user_principals + client_principals + auth_client_principals
     distinct_principals = list(set(all_principals))
 
     return distinct_principals

--- a/tests/h/auth/util_test.py
+++ b/tests/h/auth/util_test.py
@@ -183,6 +183,13 @@ class TestPrincipalsForAuthClientUser(object):
 
         principals_for_auth_client.assert_called_once_with(auth_client)
 
+    def test_it_adds_the_authclientuser_role(self, factories, auth_client):
+        user = factories.User(authority=auth_client.authority)
+
+        principals = util.principals_for_auth_client_user(user, auth_client)
+
+        assert role.AuthClientUser in principals
+
     def test_it_returns_combined_principals(self, factories, auth_client):
         user = factories.User(authority=auth_client.authority)
         group = factories.Group()


### PR DESCRIPTION
I foresee some cases coming up in which we will want to assign a permission for certain actions on resources only to requests that have an auth_client _AND_ a forwarded user.

This PR adds a role that gets assigned to such requests to differentiate them from requests with any sort of authenticated user (`role.User`, which gets assigned regardless of the authentication mechanism).