### PR TITLE
Tidy up makefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
       install: pip install tox tox-pip-extensions
       before_script: createdb htest
       script:
-        make test-py3
+        tox -e py36-tests
 
     # Test web application frontend
     - env: ACTION=gulp

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,5 @@
-DOCKER_TAG = dev
-
-GULP := node_modules/.bin/gulp
-
 .PHONY: default
 default: test
-
-build/manifest.json: node_modules/.uptodate
-	$(GULP) build
 
 ## Clean up runtime artifacts (needed after a version update)
 .PHONY: clean
@@ -98,11 +91,6 @@ checkdocstrings:
 
 ################################################################################
 
-node_modules/.uptodate: package.json
-	@echo installing javascript dependencies
-	@node_modules/.bin/check-dependencies 2>/dev/null || npm install
-	@touch $@
-
 # Self documenting Makefile
 .PHONY: help
 help:
@@ -111,3 +99,15 @@ help:
 	@echo " dev        Run the development H server locally"
 	@echo " docker     Build hypothesis/hypothesis docker image"
 	@echo " test       Run the test suite (default)"
+
+DOCKER_TAG = dev
+
+GULP := node_modules/.bin/gulp
+
+build/manifest.json: node_modules/.uptodate
+	$(GULP) build
+
+node_modules/.uptodate: package.json
+	@echo installing javascript dependencies
+	@node_modules/.bin/check-dependencies 2>/dev/null || npm install
+	@touch $@

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,6 @@ checkdocstrings:
 
 ################################################################################
 
-# Self documenting Makefile
 .PHONY: help
 help:
 	@echo "make help              Show this help message"

--- a/Makefile
+++ b/Makefile
@@ -80,8 +80,6 @@ docstrings:
 checkdocstrings:
 	tox -e py27-checkdocstrings
 
-################################################################################
-
 .PHONY: help
 help:
 	@echo "make help              Show this help message"

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: default
-default: test
+default: help
 
 .PHONY: help
 help:

--- a/Makefile
+++ b/Makefile
@@ -48,10 +48,6 @@ test: node_modules/.uptodate
 functests: build/manifest.json
 	tox -e py27-functests
 
-.PHONY: test-py3
-test-py3: node_modules/.uptodate
-	tox -e py36-tests
-
 .PHONY: coverage
 coverage:
 	tox -e py27-coverage

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ dev: build/manifest.json
 
 .PHONY: shell
 shell:
-	tox -q -e py28-dev -- sh bin/hypothesis --dev shell
+	tox -q -e py27-dev -- sh bin/hypothesis --dev shell
 
 .PHONY: sql
 sql:

--- a/Makefile
+++ b/Makefile
@@ -1,81 +1,6 @@
 .PHONY: default
 default: test
 
-.PHONY: clean
-clean:
-	find . -type f -name "*.py[co]" -delete
-	find . -type d -name "__pycache__" -delete
-	rm -f node_modules/.uptodate
-	rm -rf build
-
-.PHONY: dev
-dev: build/manifest.json
-	tox -e py27-dev
-
-.PHONY: shell
-shell:
-	tox -q -e py28-dev -- sh bin/hypothesis --dev shell
-
-.PHONY: sql
-sql:
-	docker-compose exec postgres psql -U postgres
-
-.PHONY: docker
-docker:
-	git archive --format=tar.gz HEAD | docker build -t hypothesis/hypothesis:$(DOCKER_TAG) -
-
-.PHONY: run-docker
-run-docker:
-	docker run \
-		--net h_default \
-		-e "APP_URL=http://localhost:5000" \
-		-e "AUTHORITY=localhost" \
-		-e "BROKER_URL=amqp://guest:guest@rabbit:5672//" \
-		-e "DATABASE_URL=postgresql://postgres@postgres/postgres" \
-		-e "ELASTICSEARCH_URL=http://elasticsearch:9200" \
-		-e "NEW_RELIC_APP_NAME=h (dev)" \
-		-e "NEW_RELIC_LICENSE_KEY" \
-		-e "SECRET_KEY=notasecret" \
-		-p 5000:5000 \
-		hypothesis/hypothesis:$(DOCKER_TAG)
-
-.PHONY: test
-test: node_modules/.uptodate
-	tox
-	$(GULP) test
-
-.PHONY: functests
-functests: build/manifest.json
-	tox -e py27-functests
-
-.PHONY: coverage
-coverage:
-	tox -e py27-coverage
-
-.PHONY: codecov
-codecov:
-	tox -e py27-codecov
-
-.PHONY: lint
-lint:
-	tox -e py27-lint
-
-.PHONY: docs
-docs:
-	tox -e py27-docs
-
-.PHONY: checkdocs
-checkdocs:
-	tox -e py27-checkdocs
-
-.PHONY: docstrings
-docstrings:
-	tox -e py27-docstrings
-
-.PHONY: checkdocstrings
-checkdocstrings:
-	tox -e py27-checkdocstrings
-
 .PHONY: help
 help:
 	@echo "make help              Show this help message"
@@ -99,6 +24,81 @@ help:
 	@echo "                       docker-compose in the 'h_default' network."
 	@echo "make clean             Delete development artefacts (cached files, "
 	@echo "                       dependencies, etc)"
+
+.PHONY: dev
+dev: build/manifest.json
+	tox -e py27-dev
+
+.PHONY: shell
+shell:
+	tox -q -e py28-dev -- sh bin/hypothesis --dev shell
+
+.PHONY: sql
+sql:
+	docker-compose exec postgres psql -U postgres
+
+.PHONY: lint
+lint:
+	tox -e py27-lint
+
+.PHONY: test
+test: node_modules/.uptodate
+	tox
+	$(GULP) test
+
+.PHONY: coverage
+coverage:
+	tox -e py27-coverage
+
+.PHONY: codecov
+codecov:
+	tox -e py27-codecov
+
+.PHONY: functests
+functests: build/manifest.json
+	tox -e py27-functests
+
+.PHONY: docs
+docs:
+	tox -e py27-docs
+
+.PHONY: checkdocs
+checkdocs:
+	tox -e py27-checkdocs
+
+.PHONY: docstrings
+docstrings:
+	tox -e py27-docstrings
+
+.PHONY: checkdocstrings
+checkdocstrings:
+	tox -e py27-checkdocstrings
+
+.PHONY: docker
+docker:
+	git archive --format=tar.gz HEAD | docker build -t hypothesis/hypothesis:$(DOCKER_TAG) -
+
+.PHONY: run-docker
+run-docker:
+	docker run \
+		--net h_default \
+		-e "APP_URL=http://localhost:5000" \
+		-e "AUTHORITY=localhost" \
+		-e "BROKER_URL=amqp://guest:guest@rabbit:5672//" \
+		-e "DATABASE_URL=postgresql://postgres@postgres/postgres" \
+		-e "ELASTICSEARCH_URL=http://elasticsearch:9200" \
+		-e "NEW_RELIC_APP_NAME=h (dev)" \
+		-e "NEW_RELIC_LICENSE_KEY" \
+		-e "SECRET_KEY=notasecret" \
+		-p 5000:5000 \
+		hypothesis/hypothesis:$(DOCKER_TAG)
+
+.PHONY: clean
+clean:
+	find . -type f -name "*.py[co]" -delete
+	find . -type d -name "__pycache__" -delete
+	rm -f node_modules/.uptodate
+	rm -rf build
 
 DOCKER_TAG = dev
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 .PHONY: default
 default: test
 
-## Clean up runtime artifacts (needed after a version update)
 .PHONY: clean
 clean:
 	find . -type f -name "*.py[co]" -delete
@@ -9,7 +8,6 @@ clean:
 	rm -f node_modules/.uptodate
 	rm -rf build
 
-## Run the development H server locally
 .PHONY: dev
 dev: build/manifest.json
 	tox -e py27-dev
@@ -22,16 +20,10 @@ shell:
 sql:
 	docker-compose exec postgres psql -U postgres
 
-## Build hypothesis/hypothesis docker image
 .PHONY: docker
 docker:
 	git archive --format=tar.gz HEAD | docker build -t hypothesis/hypothesis:$(DOCKER_TAG) -
 
-# Run docker container.
-#
-# This command exists for conveniently testing the Docker image locally in
-# production mode. It assumes the services are being run using docker-compose
-# in the `h_default` network.
 .PHONY: run-docker
 run-docker:
 	docker run \
@@ -47,7 +39,6 @@ run-docker:
 		-p 5000:5000 \
 		hypothesis/hypothesis:$(DOCKER_TAG)
 
-## Run test suite
 .PHONY: test
 test: node_modules/.uptodate
 	tox
@@ -94,11 +85,27 @@ checkdocstrings:
 # Self documenting Makefile
 .PHONY: help
 help:
-	@echo "The following targets are available:"
-	@echo " clean      Clean up runtime artifacts (needed after a version update)"
-	@echo " dev        Run the development H server locally"
-	@echo " docker     Build hypothesis/hypothesis docker image"
-	@echo " test       Run the test suite (default)"
+	@echo "make help              Show this help message"
+	@echo "make dev               Run the app in the development server"
+	@echo "make shell             Launch a Python shell in the dev environment"
+	@echo "make sql               Connect to the dev database with a psql shell"
+	@echo "make lint              Run the code linter(s) and print any warnings"
+	@echo "make test              Run the unit tests"
+	@echo "make coverage          Print the unit test coverage report"
+	@echo "make codecov           Upload the coverage report to codecov.io"
+	@echo "make functests         Run the functional tests"
+	@echo "make docs              Build docs website and serve it locally"
+	@echo "make checkdocs         Crash if building the docs website fails"
+	@echo "make docstrings        View all the docstrings locally as HTML"
+	@echo "make checkdocstrings   Crash if building the docstrings fails"
+	@echo "make docker            Make the app's Docker image"
+	@echo "make run-docker        Run the app's Docker image locally. "
+	@echo "                       This command exists for conveniently testing "
+	@echo "                       the Docker image locally in production mode. "
+	@echo "                       It assumes the services are being run using "
+	@echo "                       docker-compose in the 'h_default' network."
+	@echo "make clean             Delete development artefacts (cached files, "
+	@echo "                       dependencies, etc)"
 
 DOCKER_TAG = dev
 


### PR DESCRIPTION
See the individual commits for details of what and why.

```shellsession
$ make
make help              Show this help message
make dev               Run the app in the development server
make shell             Launch a Python shell in the dev environment
make sql               Connect to the dev database with a psql shell
make lint              Run the code linter(s) and print any warnings
make test              Run the unit tests
make coverage          Print the unit test coverage report
make codecov           Upload the coverage report to codecov.io
make functests         Run the functional tests
make docs              Build docs website and serve it locally
make checkdocs         Crash if building the docs website fails
make docstrings        View all the docstrings locally as HTML
make checkdocstrings   Crash if building the docstrings fails
make docker            Make the app's Docker image
make run-docker        Run the app's Docker image locally. 
                       This command exists for conveniently testing 
                       the Docker image locally in production mode. 
                       It assumes the services are being run using 
                       docker-compose in the 'h_default' network.
make clean             Delete development artefacts (cached files, 
                       dependencies, etc)
```

The source code of the `Makefile` itself is a lot tidier and easier to follow now too.