### PR TITLE
Add `authority_provided_id`, `groupid` to Group model

### DIFF
--- a/h/models/group.py
+++ b/h/models/group.py
@@ -90,6 +90,14 @@ class Group(Base, mixins.Timestamps):
     writeable_by = sa.Column(sa.Enum(WriteableBy, name='group_writeable_by'),
                              nullable=True)
 
+    @property
+    def groupid(self):
+        if self.authority_provided_id is None:
+            return None
+        return 'group:{authority_provided_id}@{authority}'.format(
+            authority_provided_id=self.authority_provided_id,
+            authority=self.authority)
+
     # Group membership
     members = sa.orm.relationship(
         'User', secondary='user_group', backref=sa.orm.backref(

--- a/h/models/group.py
+++ b/h/models/group.py
@@ -35,6 +35,22 @@ class WriteableBy(enum.Enum):
 class Group(Base, mixins.Timestamps):
     __tablename__ = 'group'
 
+    __table_args__ = (
+        # Add a composite index of the (authority, authority_provided_id)
+        # columns. Also impose uniqueness such that no two records may share
+        # the same (authority, authority_provided_id) composite
+        #
+        # See:
+        #
+        # * http://docs.sqlalchemy.org/en/latest/core/constraints.html#indexes
+        sa.Index(
+            "ix__group__groupid",
+            "authority",
+            "authority_provided_id",
+            unique=True,
+        ),
+    )
+
     id = sa.Column(sa.Integer, autoincrement=True, primary_key=True)
     # We don't expose the integer PK to the world, so we generate a short
     # random string to use as the publicly visible ID.
@@ -50,6 +66,11 @@ class Group(Base, mixins.Timestamps):
     creator = sa.orm.relationship('User')
 
     description = sa.Column(sa.UnicodeText())
+
+    #: Allow authorities to define their own unique identifier for a group
+    #: (versus the pubid). This identifier is owned by the authority/client
+    #: versus ``pubid``, which is owned and controlled by the service.
+    authority_provided_id = sa.Column(sa.UnicodeText(), nullable=True)
 
     #: Which type of user is allowed to join this group, possible values are:
     #: authority, None

--- a/h/util/group.py
+++ b/h/util/group.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+"""Some shared utility functions for manipulating group data."""
+from __future__ import unicode_literals
+
+import re
+
+
+def split_groupid(groupid):
+    """Return the ``authority_provided_id`` and ``authority`` from a ``groupid``
+
+    For example if groupid is u'group:339ae9f33c@myauth.org' then return
+    {'authority_provided_id': u'339ae9f33c', 'authority': u'myauth.org'}'
+
+    :raises ValueError: if the given groupid isn't a valid groupid
+
+    """
+    match = re.match(r'^group:([^@]+)@(.*)$', groupid)
+    if match:
+        return {
+            'authority_provided_id': match.groups()[0],
+            'authority': match.groups()[1]
+        }
+    raise ValueError("{groupid} isn't a valid groupid".format(groupid=groupid))

--- a/tests/h/models/groups_test.py
+++ b/tests/h/models/groups_test.py
@@ -8,7 +8,12 @@ from pyramid import security
 from pyramid.authorization import ACLAuthorizationPolicy
 
 from h import models
-from h.models.group import JoinableBy, ReadableBy, WriteableBy
+from h.models.group import (
+    JoinableBy,
+    ReadableBy,
+    WriteableBy,
+    AUTHORITY_PROVIDED_ID_MAX_LENGTH,
+)
 
 
 def test_init_sets_given_attributes():
@@ -58,6 +63,32 @@ def test_it_returns_None_by_default_for_authority_provided_id():
     group = models.Group(name="abcdefg")
 
     assert group.authority_provided_id is None
+
+
+@pytest.mark.parametrize('authority_provided_id', [
+    '%%&whatever',
+    '^flop',
+    '#---',
+    'ßeta',
+])
+def test_it_raises_ValueError_if_invalid_authority_provided_id(authority_provided_id):
+    group = models.Group(name="abcdefg")
+
+    with pytest.raises(ValueError, match="authority_provided_id must only contain"):
+        group.authority_provided_id = authority_provided_id
+
+
+def test_it_raises_ValueError_if_authority_provided_id_too_long():
+    group = models.Group(name="abcdefg")
+
+    with pytest.raises(ValueError, match="characters or fewer"):
+        group.authority_provided_id = ('a' * (AUTHORITY_PROVIDED_ID_MAX_LENGTH + 1))
+
+
+def test_it_allows_authority_provided_id_to_be_None():
+    group = models.Group(name="abcdefg")
+
+    group.authority_provided_id = None
 
 
 def test_type_raises_for_unknown_type_of_group(factories):

--- a/tests/h/models/groups_test.py
+++ b/tests/h/models/groups_test.py
@@ -65,6 +65,19 @@ def test_it_returns_None_by_default_for_authority_provided_id():
     assert group.authority_provided_id is None
 
 
+def test_it_returns_None_for_groupid_if_authority_provided_id_is_None(factories):
+    group = factories.Group()
+
+    assert group.groupid is None
+
+
+def test_it_returns_formatted_groupid_if_authority_provided_id(factories):
+    group = factories.Group()
+    group.authority_provided_id = 'hithere'
+
+    assert group.groupid == 'group:hithere@{authority}'.format(authority=group.authority)
+
+
 @pytest.mark.parametrize('authority_provided_id', [
     '%%&whatever',
     '^flop',

--- a/tests/h/models/groups_test.py
+++ b/tests/h/models/groups_test.py
@@ -54,6 +54,12 @@ def test_type_returns_restricted_for_restricted_groups(factories):
     assert factories.RestrictedGroup().type == 'restricted'
 
 
+def test_it_returns_None_by_default_for_authority_provided_id():
+    group = models.Group(name="abcdefg")
+
+    assert group.authority_provided_id is None
+
+
 def test_type_raises_for_unknown_type_of_group(factories):
     group = factories.Group()
     # Set the group's access flags to an invalid / unused combination.

--- a/tests/h/util/group_test.py
+++ b/tests/h/util/group_test.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import pytest
+
+from h.util import group as group_util
+
+
+class TestSplitGroupID(object):
+    @pytest.mark.parametrize('groupid,authority_provided_id,authority', [
+        ('group:flashbang@dingdong.com', 'flashbang', 'dingdong.com'),
+        ('group::ffff@dingdong.com', ':ffff', 'dingdong.com'),
+        ('group:\\f!orklift@sprongle.co', '\\f!orklift', 'sprongle.co'),
+        ('group:.@dingdong.com', '.', 'dingdong.com'),
+        ('group:group:@yep.nope', 'group:', 'yep.nope'),
+        ('group:()@hi.co', '()', 'hi.co'),
+        ("group:!.~--_*'@hi.co", "!.~--_*'", 'hi.co'),
+        ])
+    def test_it_splits_valid_groupids(self, groupid, authority_provided_id, authority):
+        splitgroup = group_util.split_groupid(groupid)
+
+        assert splitgroup['authority_provided_id'] == authority_provided_id
+        assert splitgroup['authority'] == authority
+
+    @pytest.mark.parametrize('groupid', [
+        'groupp:whatnot@dingdong.co',
+        'grou:whatnot@dingdong.co',
+        'group:@dingdog.com',
+        'group:@',
+        'whatnot@dingdong.co',
+        'group:@@dingdong.com',
+    ])
+    def test_it_raises_ValueError_on_invalid_groupids(self, groupid):
+        with pytest.raises(ValueError, match='valid groupid'):
+            group_util.split_groupid(groupid)


### PR DESCRIPTION
This PR adds a new property, `authority_provided_id` to the group model, as well as a hybrid property `groupid` that is loosely based off of `h.models.user.User.userid`. There is also a utility module with a function to parse formatted `groupid`s.

`authority_provided_id` values are restricted to those that are allowed by `EncodeURIComponent`. That way they shouldn't pose any issues when used as URL params to API endpoints. There is a liberal maxlength validation of 1024.

The `groupid` format is `group:<authority_provided_id>@<authority>`. A few notable differences from `User.userid`:

1. `authority_provided_id` is a NULLABLE field (whereas `User.username` is not). That means that if there is no value present for `authority_provided_id`, `groupid` will be `None`. Put another way: you're not always guaranteed to have a value for `group.groupid`, unlike `user`, which always has a `userid`.
2. Somewhat in response to item 1 here, `groupid` doesn't get a fancy Comparator the way that `userid` has. You can't (SA) filter directly on `groupid`. But I think that's OK. I'll leave the querying up to a (forthcoming) group-fetch service.

p.s. Some of the tests for the util parsing could benefit from a property-testing library like (python) `hypothesis` if we ever get down to how we want to handle those types of tests.