### PR TITLE
Add documentation for hide/unhide-annotation (moderate) API Endpoint

### DIFF
--- a/docs/_extra/api-reference/hypothesis.yaml
+++ b/docs/_extra/api-reference/hypothesis.yaml
@@ -231,6 +231,47 @@ paths:
           description: Annotation not found or no permission to flag
           schema:
             $ref: '#/definitions/Error'
+  /annotations/{id}/hide:
+    put:
+      tags:
+        - annotations
+      summary: Hide an annotation
+      operationId: hideAnnotation
+      description: >
+        Hide an annotation. The authenticated user needs to have the `moderate` permission for the group that contains the annotation—this permission is granted to the user who created the group.
+      parameters:
+        - name: id
+          in: path
+          description: ID of annotation to hide (moderate)
+          required: true
+          type: string
+      responses:
+        '204':
+          description: Success
+        '404':
+          description: Annotation not found or no permission to moderate
+          schema:
+            $ref: '#/definitions/Error'
+    delete:
+      tags:
+        - annotations
+      summary: Show an annotation
+      operationId: unhideAnnotation
+      description: >
+        Show/"un-hide" an annotation. The authenticated user needs to have the `moderate` permission for the group that contains the annotation—this permission is granted to the user who created the group.
+      parameters:
+        - name: id
+          in: path
+          description: ID of annotation to show/un-hide
+          required: true
+          type: string
+      responses:
+        '204':
+          description: Success
+        '404':
+          description: Annotation not found or no permission to moderate
+          schema:
+            $ref: '#/definitions/Error'
 
   /profile:
     get:


### PR DESCRIPTION
While we wait for GitHub to calm down a bit, here's a PR unrelated to anything: it adds documentation for the `/api/annotations/{id}/hide` endpoint (PUT and DELETE).

<img width="1338" alt="screen shot 2018-10-22 at 10 19 43 am" src="https://user-images.githubusercontent.com/439947/47309396-4fafcc80-d602-11e8-9cfd-f80c0f301333.png">

and

<img width="1341" alt="screen shot 2018-10-22 at 10 19 49 am" src="https://user-images.githubusercontent.com/439947/47309404-52122680-d602-11e8-818c-309df6fab243.png">

After this, the only undocumented API endpoint is the slightly-odd PATCH-user-profile one...