### PR TITLE
Speed up building the docs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -50,11 +50,11 @@ commands =
     lint: flake8 --select FI14 --exclude 'h/cli/*,tests/h/cli/*,h/util/uri.py,h/migrations/versions/*' h tests
     tests: coverage run -m pytest -Werror {posargs:tests/h/}
     functests: pytest -Werror {posargs:tests/functional/}
-    docs: sphinx-autobuild -BqT -b dirhtml -d {envtmpdir}/doctrees . {envtmpdir}/html
-    checkdocs: sphinx-build -qTWn -b dirhtml -d {envtmpdir}/doctrees . {envtmpdir}/html
-    {docstrings,checkdocstrings}: sphinx-apidoc -ePMF -a -H "Dooccsstrinngs!!" --ext-intersphinx --ext-todo --ext-viewcode -o {envtmpdir}/rst .
-    docstrings: sphinx-autobuild -BqT -z h -z tests -b dirhtml {envtmpdir}/rst {envtmpdir}/dirhtml
-    checkdocstrings: sphinx-build -qTn -b dirhtml {envtmpdir}/rst {envtmpdir}/dirhtml
+    docs: sphinx-autobuild -BqT -b dirhtml -d {envdir}/doctrees . {envdir}/html
+    checkdocs: sphinx-build -qTWn -b dirhtml -d {envdir}/doctrees . {envdir}/html
+    {docstrings,checkdocstrings}: sphinx-apidoc -ePMF -a -H "Dooccsstrinngs!!" --ext-intersphinx --ext-todo --ext-viewcode -o {envdir}/rst .
+    docstrings: sphinx-autobuild -BqT -z h -z tests -b dirhtml {envdir}/rst {envdir}/dirhtml
+    checkdocstrings: sphinx-build -qTn -b dirhtml {envdir}/rst {envdir}/dirhtml
     coverage: -coverage combine
     coverage: coverage report
     codecov: codecov


### PR DESCRIPTION
Speed up building the docs by reusing generated files between runs. The first run will still be slow but subsequent runs will be much faster. Only the rst and html files that need to be recreated (because their corresponding source files have changed) will be recreated.

`tox -r ...` will rebuild from scratch with a clean slate.