### PR TITLE
Add group service `fetch` method

### DIFF
--- a/h/services/group.py
+++ b/h/services/group.py
@@ -21,6 +21,11 @@ class GroupService(object):
         self.session = session
         self.user_fetcher = user_fetcher
 
+    def fetch(self, pubid):
+        """Fetch a group by ``pubid``"""
+
+        return self.session.query(Group).filter_by(pubid=pubid).one_or_none()
+
     def groupids_readable_by(self, user):
         """
         Return a list of pubids for which the user has read access.

--- a/h/traversal/roots.py
+++ b/h/traversal/roots.py
@@ -74,7 +74,6 @@ import sqlalchemy.orm.exc
 
 from h import storage
 from h.models import AuthClient
-from h.models import Group
 from h.models import Organization
 from h.auth import role
 from h.auth.util import client_authority
@@ -208,12 +207,13 @@ class GroupRoot(object):
 
     def __init__(self, request):
         self.request = request
+        self.group_service = request.find_service(name='group')
 
     def __getitem__(self, pubid):
-        try:
-            return self.request.db.query(Group).filter_by(pubid=pubid).one()
-        except sqlalchemy.orm.exc.NoResultFound:
+        group = self.group_service.fetch(pubid=pubid)
+        if group is None:
             raise KeyError()
+        return group
 
 
 class ProfileRoot(object):

--- a/tests/h/services/group_test.py
+++ b/tests/h/services/group_test.py
@@ -5,12 +5,28 @@ from __future__ import unicode_literals
 import mock
 import pytest
 
-from h.models import User, GroupScope
+from h.models import User, Group, GroupScope
 from h.models.group import ReadableBy
 from h.services.group import GroupService
 from h.services.group import groups_factory
 from h.services.user import UserService
 from tests.common.matchers import Matcher
+
+
+class TestGroupServiceFetch(object):
+
+    def test_it_returns_group_model(self, svc, factories):
+        group = factories.Group()
+
+        fetched_group = svc.fetch(group.pubid)
+
+        assert fetched_group == group
+        assert isinstance(fetched_group, Group)
+
+    def test_it_returns_None_if_no_group_found(self, svc):
+        group = svc.fetch('abcdeff')
+
+        assert group is None
 
 
 class TestGroupServiceGroupIds(object):


### PR DESCRIPTION
This PR adds a rudimentary `fetch` method to the `group` service, akin to `user_svc.fetch`. Purpose: so we can start using `groupid` identifier syntax to traverse and manipulate groups, for LMS.

 It converts the traversal (`GroupRoot`) to make use of this service for `__getitem__`. After chatting with @seanh I didn't elect to implement the simple caching stuff that the `user_svc` does, though we _could_.

The admin-groups view is using the `GroupRoot` directly in its edit controller. `GroupRoot` wasn't mocked in the view's edit tests, so they all broke, necessitating test changes. I'll open another issue when I have a chance: we should refactor the edit controller to use a permission instead of "traversing" within the view. I can explain how in that issue. I didn't want to take the time to fix it now as this is somewhat on the critical path.

Next step: make this group fetcher accept a `groupid` syntax in addition to `pubid`.