### PR TITLE
Add `group_update` service

### DIFF
--- a/h/services/__init__.py
+++ b/h/services/__init__.py
@@ -21,6 +21,7 @@ def includeme(config):
     config.register_service_factory('.flag_count.flag_count_service_factory', name='flag_count')
     config.register_service_factory('.group.groups_factory', name='group')
     config.register_service_factory('.group_create.group_create_factory', name='group_create')
+    config.register_service_factory('.group_update.group_update_factory', name='group_update')
     config.register_service_factory('.group_links.group_links_factory', name='group_links')
     config.register_service_factory('.group_members.group_members_factory', name='group_members')
     config.register_service_factory('.groupfinder.groupfinder_service_factory', iface='h.interfaces.IGroupService')

--- a/h/services/exceptions.py
+++ b/h/services/exceptions.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+
+"""Exceptions raised by h services."""
+
+from __future__ import unicode_literals
+
+
+class ServiceError(Exception):
+
+    """Base exception for problems in services."""
+
+    pass
+
+
+class ValidationError(ServiceError):
+
+    """Exception class for handling validation problems in models"""
+
+    pass
+
+
+class ConflictError(ServiceError):
+
+    """Exception class for handling integrity problems with database operations"""
+
+    pass

--- a/h/services/exceptions.py
+++ b/h/services/exceptions.py
@@ -1,26 +1,17 @@
 # -*- coding: utf-8 -*-
 
-"""Exceptions raised by h services."""
+"""Exceptions raised by :mod:`h.services`."""
 
 from __future__ import unicode_literals
 
 
 class ServiceError(Exception):
-
-    """Base exception for problems in services."""
-
-    pass
+    """Base class for all :mod:`h.services` exception classes."""
 
 
 class ValidationError(ServiceError):
-
-    """Exception class for handling validation problems in models"""
-
-    pass
+    """A validation problem with a database model."""
 
 
 class ConflictError(ServiceError):
-
-    """Exception class for handling integrity problems with database operations"""
-
-    pass
+    """An integrity problem with a database operation."""

--- a/h/services/group_update.py
+++ b/h/services/group_update.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import sys
+
+from sqlalchemy.exc import SQLAlchemyError
+
+from h.services.exceptions import ValidationError, ConflictError
+
+
+class GroupUpdateService(object):
+
+    def __init__(self, session):
+        """
+        Create a new GroupUpdateService
+
+        :param session: the SQLAlchemy session object
+        """
+        self.session = session
+
+    def update(self, group, **kwargs):
+        """
+        Update a group model with the args provided.
+
+        :type group:`~h.models.group.Group`
+
+        :raises ValidationError: if setting an attribute on the model raises a ValueError
+        :raises ConflictError: if the ``authority_provided_id`` is already in use
+        :raises SQLAlchemyError: if any unexpected SQL/DB Exception is encountered
+
+        :rtype:`~h.models.group.Group`
+        """
+
+        for key, value in kwargs.items():
+            try:
+                setattr(group, key, value)
+            except ValueError as err:
+                raise ValidationError(err), None, sys.exc_info()[2]
+
+        try:
+            self.session.flush()
+
+        except SQLAlchemyError as err:
+            # Handle DB integrity issues with duplicate ``authority_provided_id``
+            if 'duplicate key value violates unique constraint "ix__group__groupid"' in repr(err):
+                raise ConflictError(
+                    "authority_provided_id '{id}' is already in use".format(id=kwargs['authority_provided_id']))
+            else:
+                # Re-raise as this is an unexpected problem
+                raise
+
+        return group
+
+
+def group_update_factory(context, request):
+    """Return a GroupUpdateService instance for the passed context and request."""
+    return GroupUpdateService(session=request.db)

--- a/h/services/group_update.py
+++ b/h/services/group_update.py
@@ -21,12 +21,13 @@ class GroupUpdateService(object):
         """
         Update a group model with the args provided.
 
-        :type group:`~h.models.group.Group`
+        :arg group: the group to update
+        :type group: ~h.models.Group
 
-        :raises ValidationError: if setting an attribute on the model raises a ValueError
-        :raises ConflictError: if the ``authority_provided_id`` is already in use
+        :raise ValidationError: if setting an attribute on the model raises :exc:`ValueError`
+        :raise ConflictError: if the ``authority_provided_id`` is already in use
 
-        :rtype:`~h.models.group.Group`
+        :rtype: ~h.models.Group
         """
 
         for key, value in kwargs.items():

--- a/h/services/group_update.py
+++ b/h/services/group_update.py
@@ -2,11 +2,8 @@
 
 from __future__ import unicode_literals
 
-import sys
-
 from sqlalchemy.exc import SQLAlchemyError
 
-from h._compat import PY2
 from h.services.exceptions import ValidationError, ConflictError
 
 
@@ -37,10 +34,7 @@ class GroupUpdateService(object):
             try:
                 setattr(group, key, value)
             except ValueError as err:
-                if PY2:
-                    raise ValidationError(err), None, sys.exc_info()[2]
-                else:
-                    raise ValidationError(err)
+                raise ValidationError(err)
 
         try:
             self.session.flush()

--- a/h/services/group_update.py
+++ b/h/services/group_update.py
@@ -6,6 +6,7 @@ import sys
 
 from sqlalchemy.exc import SQLAlchemyError
 
+from h._compat import PY2
 from h.services.exceptions import ValidationError, ConflictError
 
 
@@ -36,7 +37,10 @@ class GroupUpdateService(object):
             try:
                 setattr(group, key, value)
             except ValueError as err:
-                raise ValidationError(err), None, sys.exc_info()[2]
+                if PY2:
+                    raise ValidationError(err), None, sys.exc_info()[2]
+                else:
+                    raise ValidationError(err)
 
         try:
             self.session.flush()

--- a/h/services/group_update.py
+++ b/h/services/group_update.py
@@ -25,7 +25,6 @@ class GroupUpdateService(object):
 
         :raises ValidationError: if setting an attribute on the model raises a ValueError
         :raises ConflictError: if the ``authority_provided_id`` is already in use
-        :raises SQLAlchemyError: if any unexpected SQL/DB Exception is encountered
 
         :rtype:`~h.models.group.Group`
         """

--- a/h/services/group_update.py
+++ b/h/services/group_update.py
@@ -8,7 +8,6 @@ from h.services.exceptions import ValidationError, ConflictError
 
 
 class GroupUpdateService(object):
-
     def __init__(self, session):
         """
         Create a new GroupUpdateService
@@ -41,9 +40,15 @@ class GroupUpdateService(object):
 
         except SQLAlchemyError as err:
             # Handle DB integrity issues with duplicate ``authority_provided_id``
-            if 'duplicate key value violates unique constraint "ix__group__groupid"' in repr(err):
+            if (
+                'duplicate key value violates unique constraint "ix__group__groupid"'
+                in repr(err)
+            ):
                 raise ConflictError(
-                    "authority_provided_id '{id}' is already in use".format(id=kwargs['authority_provided_id']))
+                    "authority_provided_id '{id}' is already in use".format(
+                        id=kwargs["authority_provided_id"]
+                    )
+                )
             else:
                 # Re-raise as this is an unexpected problem
                 raise

--- a/tests/h/services/exceptions_test.py
+++ b/tests/h/services/exceptions_test.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from h.services import exceptions
+
+
+class TestServiceError(object):
+
+    def test_it_is_an_exception(self):
+        exc = exceptions.ServiceError('a message')
+
+        assert isinstance(exc, Exception)
+        assert isinstance(exc, exceptions.ServiceError)
+
+    def test_it_can_set_message(self):
+        exc = exceptions.ServiceError('a message')
+
+        assert 'a message' in repr(exc)
+
+
+class TestValidationError(object):
+
+    def test_it_extends_ServiceError(self):
+        exc = exceptions.ValidationError('some message')
+
+        assert isinstance(exc, exceptions.ValidationError)
+        assert isinstance(exc, exceptions.ServiceError)
+
+    def test_it_can_set_message(self):
+        exc = exceptions.ValidationError('a message')
+
+        assert 'a message' in repr(exc)
+
+
+class TestConflictError(object):
+
+    def test_it_extends_ServiceError(self):
+        exc = exceptions.ConflictError('some message')
+
+        assert isinstance(exc, exceptions.ConflictError)
+        assert isinstance(exc, exceptions.ServiceError)
+
+    def test_it_can_set_message(self):
+        exc = exceptions.ConflictError('a message')
+
+        assert 'a message' in repr(exc)

--- a/tests/h/services/group_update_test.py
+++ b/tests/h/services/group_update_test.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import pytest
+import mock
+
+from sqlalchemy.exc import SQLAlchemyError
+
+from h.services.exceptions import ConflictError, ValidationError
+from h.services.group_update import GroupUpdateService
+from h.services.group_update import group_update_factory
+
+
+class TestGroupUpdate(object):
+
+    def test_it_updates_valid_group_attrs(self, factories, svc):
+        group = factories.Group()
+        data = {
+            'name': 'foobar',
+            'description': 'I am foobar',
+        }
+
+        svc.update(group, **data)
+
+        assert group.name == 'foobar'
+        assert group.description == 'I am foobar'
+
+    def test_it_returns_updated_group_model(self, factories, svc):
+        group = factories.Group()
+        data = {'name': 'whatnot'}
+
+        updated_group = svc.update(group, **data)
+
+        assert updated_group == group
+
+    def test_it_does_not_protect_against_undefined_properties(self, factories, svc):
+        group = factories.Group()
+        data = {'some_random_field': 'whatever'}
+
+        updated_group = svc.update(group, **data)
+
+        # This won't be persisted in the DB, of course, but the model instance
+        # doesn't have a problem with it
+        assert updated_group.some_random_field == 'whatever'
+
+    def test_it_raises_ValidationError_if_name_fails_model_validation(self, factories, svc, db_session):
+        group = factories.Group()
+
+        with pytest.raises(ValidationError, match='name must be between'):
+            svc.update(group, name='ye')
+
+    def test_it_raises_ValidationError_if_authority_provided_id_fails_model_validation(self, factories, svc, db_session):
+        group = factories.Group()
+
+        with pytest.raises(ValidationError, match='must only contain characters allowed in encoded URIs'):
+            svc.update(group, authority_provided_id='%%^&#*')
+
+    def test_it_raises_ConflictError_on_provided_id_uniqueness_violation(self, factories, svc, db_session):
+        factories.Group(authority_provided_id='foo', authority='foo.com')
+        group2 = factories.Group(authority_provided_id='bar', authority='foo.com')
+
+        with pytest.raises(ConflictError, match='authority_provided_id'):
+            svc.update(group2, authority_provided_id='foo')
+
+    def test_it_raises_on_any_other_SQLAlchemy_exception(self, factories):
+        fake_session = mock.Mock()
+        fake_session.flush.side_effect = SQLAlchemyError('foo')
+
+        update_svc = GroupUpdateService(session=fake_session)
+        group = factories.Group(authority_provided_id='foo', authority='foo.com')
+
+        with pytest.raises(SQLAlchemyError):
+            update_svc.update(group, name='fingers')
+
+
+class TestFactory(object):
+    def test_returns_group_update_service(self, pyramid_request):
+        group_update_service = group_update_factory(None, pyramid_request)
+
+        assert isinstance(group_update_service, GroupUpdateService)
+
+
+@pytest.fixture
+def svc(db_session):
+    return GroupUpdateService(session=db_session)


### PR DESCRIPTION
This PR adds a `group_update` service, which can be used by upcoming API services to update a group model. Once such a service is in place, we should also update `h.views.admin.groups` to make use of it (for the core group properties if not the relationships).

This is not presently "hooked up" to anything.